### PR TITLE
Fix 1.0 regressions

### DIFF
--- a/cli/app/bootstrap.go
+++ b/cli/app/bootstrap.go
@@ -16,14 +16,16 @@ func startEmbeddedServer(ctx context.Context, opts Options, interactor authInter
 		WorkspaceRoot:         opts.WorkspaceRoot,
 		WorkspaceRootExplicit: opts.WorkspaceRootExplicit,
 		SessionID:             opts.SessionID,
-		Model:                 opts.Model,
-		ProviderOverride:      opts.ProviderOverride,
-		ThinkingLevel:         opts.ThinkingLevel,
-		Theme:                 opts.Theme,
-		ModelTimeoutSeconds:   opts.ModelTimeoutSeconds,
-		Tools:                 opts.Tools,
 		OpenAIBaseURL:         opts.OpenAIBaseURL,
 		OpenAIBaseURLExplicit: opts.OpenAIBaseURLExplicit,
+		LoadOptions: config.LoadOptions{
+			Model:               opts.Model,
+			ProviderOverride:    opts.ProviderOverride,
+			ThinkingLevel:       opts.ThinkingLevel,
+			Theme:               opts.Theme,
+			ModelTimeoutSeconds: opts.ModelTimeoutSeconds,
+			Tools:               opts.Tools,
+		},
 	}, interactor, frontendOnboardingHandler{inner: interactor})
 	if err != nil {
 		return nil, err

--- a/cli/app/embedded_server.go
+++ b/cli/app/embedded_server.go
@@ -25,6 +25,7 @@ type embeddedServer interface {
 	BindProject(ctx context.Context, projectID string) (embeddedServer, error)
 	BindProjectWorkspace(ctx context.Context, projectID string, workspaceID string) (embeddedServer, error)
 	AuthManager() *auth.Manager
+	AuthStatusClient() client.AuthStatusClient
 	ProjectID() string
 	ApprovalViewClient() client.ApprovalViewClient
 	AskViewClient() client.AskViewClient
@@ -123,6 +124,13 @@ func (s *embeddedAppServer) AuthManager() *auth.Manager {
 		return nil
 	}
 	return s.inner.AuthManager()
+}
+
+func (s *embeddedAppServer) AuthStatusClient() client.AuthStatusClient {
+	if s == nil || s.inner == nil {
+		return nil
+	}
+	return s.inner.AuthStatusClient()
 }
 
 func (s *embeddedAppServer) ProjectID() string {

--- a/cli/app/embedded_server_test.go
+++ b/cli/app/embedded_server_test.go
@@ -257,6 +257,9 @@ func (s *testEmbeddedServer) PromptActivityClient() client.PromptActivityClient 
 func (s *testEmbeddedServer) ContainerDir() string                  { return s.containerDir }
 func (s *testEmbeddedServer) OAuthOptions() auth.OpenAIOAuthOptions { return s.oauthOpts }
 func (s *testEmbeddedServer) AuthManager() *auth.Manager            { return s.authManager }
+func (s *testEmbeddedServer) AuthStatusClient() client.AuthStatusClient {
+	return nil
+}
 func (s *testEmbeddedServer) FastModeState() *runtime.FastModeState { return s.fastModeState }
 func (s *testEmbeddedServer) Background() *shelltool.Manager        { return s.background }
 func (s *testEmbeddedServer) BackgroundRouter() serverembedded.BackgroundRouter {

--- a/cli/app/launch_planner.go
+++ b/cli/app/launch_planner.go
@@ -154,6 +154,7 @@ func (p *launchPlanner) PlanSession(ctx context.Context, req sessionLaunchReques
 			Settings:        resp.Plan.ActiveSettings,
 			Source:          resp.Plan.Source,
 			AuthManager:     authManager,
+			AuthStatus:      p.server.AuthStatusClient(),
 			AuthStatePath:   authStatePath,
 			OwnsServer:      p.server.OwnsServer(),
 		},

--- a/cli/app/onboarding_model.go
+++ b/cli/app/onboarding_model.go
@@ -780,11 +780,15 @@ func (m *onboardingModel) renderThemePreview(width int) []string {
 	palette := uiPalette(theme)
 	previewStyles := onboardingThemePreviewStyleSet(theme, width)
 	heading := lipgloss.NewStyle().Foreground(palette.primary).Bold(true).Render("Preview")
+	modelLabel := strings.TrimSpace(m.state.settings.Model)
+	if modelLabel == "" {
+		modelLabel = "gpt-5"
+	}
 	statusLine := lipgloss.NewStyle().Foreground(palette.primary).Bold(true).Render("builder") +
 		lipgloss.NewStyle().Foreground(palette.muted).Render(" | ") +
 		lipgloss.NewStyle().Foreground(palette.foreground).Render("ready") +
 		lipgloss.NewStyle().Foreground(palette.muted).Render(" | ") +
-		lipgloss.NewStyle().Foreground(palette.foreground).Render("gpt-5.4") +
+		lipgloss.NewStyle().Foreground(palette.foreground).Render(modelLabel) +
 		lipgloss.NewStyle().Foreground(palette.muted).Render(" | ") +
 		lipgloss.NewStyle().Foreground(palette.secondary).Bold(true).Render(theme)
 	inputLine := lipgloss.NewStyle().Foreground(palette.primary).Bold(true).Render("> ") + lipgloss.NewStyle().Foreground(palette.foreground).Render("Explain this failing test")

--- a/cli/app/onboarding_test.go
+++ b/cli/app/onboarding_test.go
@@ -839,7 +839,7 @@ func TestThemeStepChoicePreservesAutoWhenKeepingDetectedDefault(t *testing.T) {
 }
 
 func TestThemeScreenRendersPreview(t *testing.T) {
-	model := newOnboardingModel(t.TempDir(), onboardingFlowState{settings: config.Settings{Theme: "dark"}, theme: "dark"})
+	model := newOnboardingModel(t.TempDir(), onboardingFlowState{settings: config.Settings{Theme: "dark", Model: "preview-model"}, theme: "dark"})
 	model.currentScreen = onboardingScreen{
 		ID:           "theme",
 		Kind:         onboardingScreenChoice,
@@ -850,7 +850,7 @@ func TestThemeScreenRendersPreview(t *testing.T) {
 	model.cursor = 1
 	content := model.buildContent(80)
 	joined := strings.Join(content.lines, "\n")
-	for _, want := range []string{"Preview", "builder", "Explain this failing test", "light"} {
+	for _, want := range []string{"Preview", "builder", "Explain this failing test", "light", "preview-model"} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("expected theme preview to contain %q, got %q", want, joined)
 		}
@@ -927,7 +927,7 @@ func TestOnboardingDefaultsPathPreservesAutoWhenUsingDetectedDefault(t *testing.
 }
 
 func TestOnboardingImportDiscoveryKeepsTypedInput(t *testing.T) {
-	model := newOnboardingModel(t.TempDir(), onboardingFlowState{settings: config.Settings{Model: "gpt-5.4"}})
+	model := newOnboardingModel(t.TempDir(), onboardingFlowState{settings: config.Settings{Model: "gpt-5.5"}})
 	steps := model.workflow.visibleSteps(&model.state)
 	modelStepIndex := -1
 	for index, step := range steps {
@@ -1215,16 +1215,16 @@ func TestOnboardingProviderCapabilitiesFromAuthMode(t *testing.T) {
 
 func TestApplyOnboardingModelUpdatesKnownContextWindow(t *testing.T) {
 	state := &onboardingFlowState{settings: config.Settings{Model: "gpt-5", ThinkingLevel: "medium", Reviewer: config.ReviewerSettings{Frequency: "edits"}}, baselineSettings: config.Settings{ModelContextWindow: 272_000, ContextCompactionThresholdTokens: 272_000 * 95 / 100}}
-	if err := applyOnboardingModel(state, "gpt-5.4"); err != nil {
+	if err := applyOnboardingModel(state, "gpt-5.5"); err != nil {
 		t.Fatalf("apply onboarding model: %v", err)
 	}
 	if state.settings.ModelContextWindow != 272_000 {
-		t.Fatalf("expected gpt-5.4 default context window, got %d", state.settings.ModelContextWindow)
+		t.Fatalf("expected gpt-5.5 default context window, got %d", state.settings.ModelContextWindow)
 	}
 	if state.settings.ContextCompactionThresholdTokens != 272_000*95/100 {
 		t.Fatalf("unexpected compaction threshold: %d", state.settings.ContextCompactionThresholdTokens)
 	}
-	if state.settings.Reviewer.Model != "gpt-5.4" {
+	if state.settings.Reviewer.Model != "gpt-5.5" {
 		t.Fatalf("expected reviewer model to follow main model, got %q", state.settings.Reviewer.Model)
 	}
 	if state.settings.Reviewer.ThinkingLevel != "medium" {
@@ -1258,13 +1258,13 @@ func TestApplyOnboardingModelResetsUnknownModelContextWindowToBaseline(t *testin
 }
 
 func TestReviewerWorkflowShowsModelAndThinkingOnlyWhenEnabled(t *testing.T) {
-	enabledState := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.4", ThinkingLevel: "high", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.4", ThinkingLevel: "high"}}}
+	enabledState := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.5", ThinkingLevel: "high", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.5", ThinkingLevel: "high"}}}
 	enabledSteps := newOnboardingWorkflow(enabledState).visibleSteps(enabledState)
 	if !workflowIncludesStep(enabledSteps, "reviewer_model") || !workflowIncludesStep(enabledSteps, "reviewer_thinking") {
 		t.Fatalf("expected reviewer configuration steps to appear when supervisor is enabled, got %+v", workflowStepIDs(enabledSteps))
 	}
 
-	disabledState := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.4", ThinkingLevel: "high", Reviewer: config.ReviewerSettings{Frequency: "off", Model: "gpt-5.4", ThinkingLevel: "high"}}}
+	disabledState := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.5", ThinkingLevel: "high", Reviewer: config.ReviewerSettings{Frequency: "off", Model: "gpt-5.5", ThinkingLevel: "high"}}}
 	disabledSteps := newOnboardingWorkflow(disabledState).visibleSteps(disabledState)
 	if workflowIncludesStep(disabledSteps, "reviewer_model") || workflowIncludesStep(disabledSteps, "reviewer_thinking") {
 		t.Fatalf("expected reviewer configuration steps to stay hidden when supervisor is off, got %+v", workflowStepIDs(disabledSteps))
@@ -1272,15 +1272,15 @@ func TestReviewerWorkflowShowsModelAndThinkingOnlyWhenEnabled(t *testing.T) {
 }
 
 func TestReviewerModelStepDefaultsToMainModel(t *testing.T) {
-	state := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.4", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.4"}}}
+	state := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.5", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.5"}}}
 	screen := findWorkflowStep(t, state, "reviewer_model").Build(state)
-	if screen.InputValue != "gpt-5.4" {
+	if screen.InputValue != "gpt-5.5" {
 		t.Fatalf("expected reviewer model default to follow main model, got %q", screen.InputValue)
 	}
 }
 
 func TestReviewerThinkingStepDefaultsToMainThinking(t *testing.T) {
-	state := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.4", ThinkingLevel: "high", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.4", ThinkingLevel: "high"}}}
+	state := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.5", ThinkingLevel: "high", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.5", ThinkingLevel: "high"}}}
 	screen := findWorkflowStep(t, state, "reviewer_thinking").Build(state)
 	if screen.DefaultOptionID != "high" {
 		t.Fatalf("expected reviewer thinking default to follow main thinking, got %q", screen.DefaultOptionID)
@@ -1288,7 +1288,7 @@ func TestReviewerThinkingStepDefaultsToMainThinking(t *testing.T) {
 }
 
 func TestMainThinkingChoiceSynchronizesReviewerThinking(t *testing.T) {
-	state := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.4", ThinkingLevel: "medium", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.4", ThinkingLevel: "medium"}}}
+	state := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.5", ThinkingLevel: "medium", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.5", ThinkingLevel: "medium"}}}
 	if err := findWorkflowStep(t, state, "thinking").ApplyChoice(state, "high"); err != nil {
 		t.Fatalf("apply thinking choice: %v", err)
 	}
@@ -1299,7 +1299,7 @@ func TestMainThinkingChoiceSynchronizesReviewerThinking(t *testing.T) {
 
 func TestMainThinkingChoicePreservesCustomReviewerThinking(t *testing.T) {
 	state := &onboardingFlowState{
-		settings:               config.Settings{Model: "gpt-5.4", ThinkingLevel: "medium", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.4", ThinkingLevel: "low"}},
+		settings:               config.Settings{Model: "gpt-5.5", ThinkingLevel: "medium", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.5", ThinkingLevel: "low"}},
 		reviewerCustomThinking: true,
 	}
 	if err := findWorkflowStep(t, state, "thinking").ApplyChoice(state, "high"); err != nil {
@@ -1311,7 +1311,7 @@ func TestMainThinkingChoicePreservesCustomReviewerThinking(t *testing.T) {
 }
 
 func TestReviewerThinkingDisableDoesNotForceCustomInput(t *testing.T) {
-	state := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.4", ThinkingLevel: "high", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.4", ThinkingLevel: "high"}}}
+	state := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.5", ThinkingLevel: "high", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.5", ThinkingLevel: "high"}}}
 	if err := findWorkflowStep(t, state, "reviewer_thinking").ApplyChoice(state, "disable"); err != nil {
 		t.Fatalf("apply reviewer disable choice: %v", err)
 	}
@@ -1327,7 +1327,7 @@ func TestReviewerThinkingDisableDoesNotForceCustomInput(t *testing.T) {
 }
 
 func TestReviewerThinkingPresetChoiceDoesNotForceCustomInput(t *testing.T) {
-	state := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.4", ThinkingLevel: "medium", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.4", ThinkingLevel: "medium"}}}
+	state := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.5", ThinkingLevel: "medium", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.5", ThinkingLevel: "medium"}}}
 	if err := findWorkflowStep(t, state, "reviewer_thinking").ApplyChoice(state, "low"); err != nil {
 		t.Fatalf("apply reviewer preset choice: %v", err)
 	}
@@ -1346,7 +1346,7 @@ func TestReviewerThinkingPresetChoiceDoesNotForceCustomInput(t *testing.T) {
 }
 
 func TestMainThinkingChoicePreservesDisabledReviewerThinking(t *testing.T) {
-	state := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.4", ThinkingLevel: "medium", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.4", ThinkingLevel: "medium"}}}
+	state := &onboardingFlowState{settings: config.Settings{Model: "gpt-5.5", ThinkingLevel: "medium", Reviewer: config.ReviewerSettings{Frequency: "edits", Model: "gpt-5.5", ThinkingLevel: "medium"}}}
 	if err := findWorkflowStep(t, state, "reviewer_thinking").ApplyChoice(state, "disable"); err != nil {
 		t.Fatalf("apply reviewer disable choice: %v", err)
 	}
@@ -1364,7 +1364,7 @@ func TestMainThinkingChoicePreservesDisabledReviewerThinking(t *testing.T) {
 func TestApplyOnboardingModelPreservesCustomReviewerOverrides(t *testing.T) {
 	state := &onboardingFlowState{
 		settings: config.Settings{
-			Model:                            "gpt-5.4",
+			Model:                            "gpt-5.5",
 			ThinkingLevel:                    "medium",
 			ModelContextWindow:               272_000,
 			ContextCompactionThresholdTokens: 272_000 * 95 / 100,

--- a/cli/app/remote_server.go
+++ b/cli/app/remote_server.go
@@ -106,6 +106,13 @@ func (s *remoteAppServer) AuthManager() *auth.Manager {
 	return nil
 }
 
+func (s *remoteAppServer) AuthStatusClient() client.AuthStatusClient {
+	if s == nil {
+		return nil
+	}
+	return s.remote
+}
+
 func (s *remoteAppServer) ProjectID() string {
 	if s == nil {
 		return ""

--- a/cli/app/run_prompt_target.go
+++ b/cli/app/run_prompt_target.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	goruntime "runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -28,7 +27,7 @@ var dialConfiguredProjectViewRemote = func(ctx context.Context, cfg config.App) 
 	return client.DialConfiguredRemote(ctx, cfg)
 }
 var resolveDaemonExecutablePath = daemonExecutablePath
-var buildServeArgsFunc = buildServeArgs
+var buildServeArgsFunc = func(_ string, opts Options) []string { return buildServeArgs(opts) }
 var terminateOwnedDaemonProcess = func(process *os.Process) error {
 	if process == nil {
 		return nil
@@ -293,12 +292,8 @@ func startLocalRunPromptDaemon(ctx context.Context, opts Options) (*client.Remot
 	if !ok {
 		return nil, nil, false, nil
 	}
-	workspaceRoot, err := resolveCLIWorkspaceRoot(opts)
-	if err != nil {
-		return nil, nil, false, err
-	}
 	serve.ReleaseTestListenReservation(config.ServerListenAddress(cfg))
-	args := append([]string{execPath}, buildServeArgsFunc(workspaceRoot, opts)...)
+	args := append([]string{execPath}, buildServeArgsFunc("", opts)...)
 	cmd := exec.CommandContext(context.Background(), args[0], args[1:]...)
 	cmd.Stdin = nil
 	cmd.Stdout = io.Discard
@@ -420,24 +415,6 @@ func daemonExecutablePath() (string, bool) {
 	return execPath, true
 }
 
-func buildServeArgs(workspaceRoot string, opts Options) []string {
-	args := []string{"serve", "--workspace", workspaceRoot}
-	appendStringFlag := func(name, value string) {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			args = append(args, name, trimmed)
-		}
-	}
-	appendIntFlag := func(name string, value int) {
-		if value > 0 {
-			args = append(args, name, strconv.Itoa(value))
-		}
-	}
-	appendStringFlag("--model", opts.Model)
-	appendStringFlag("--provider-override", opts.ProviderOverride)
-	appendStringFlag("--thinking-level", opts.ThinkingLevel)
-	appendStringFlag("--theme", opts.Theme)
-	appendIntFlag("--model-timeout-seconds", opts.ModelTimeoutSeconds)
-	appendStringFlag("--tools", opts.Tools)
-	appendStringFlag("--openai-base-url", opts.OpenAIBaseURL)
-	return args
+func buildServeArgs(opts Options) []string {
+	return []string{"serve"}
 }

--- a/cli/app/run_prompt_target.go
+++ b/cli/app/run_prompt_target.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	goruntime "runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -28,6 +29,7 @@ var dialConfiguredProjectViewRemote = func(ctx context.Context, cfg config.App) 
 }
 var resolveDaemonExecutablePath = daemonExecutablePath
 var buildServeArgsFunc = func(_ string, opts Options) []string { return buildServeArgs(opts) }
+var buildServeEnvFunc = buildServeEnv
 var terminateOwnedDaemonProcess = func(process *os.Process) error {
 	if process == nil {
 		return nil
@@ -298,7 +300,7 @@ func startLocalRunPromptDaemon(ctx context.Context, opts Options) (*client.Remot
 	cmd.Stdin = nil
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
-	cmd.Env = os.Environ()
+	cmd.Env = buildServeEnvFunc(cfg)
 	if err := cmd.Start(); err != nil {
 		return nil, nil, false, err
 	}
@@ -417,4 +419,18 @@ func daemonExecutablePath() (string, bool) {
 
 func buildServeArgs(opts Options) []string {
 	return []string{"serve"}
+}
+
+func buildServeEnv(cfg config.App) []string {
+	env := os.Environ()
+	if strings.TrimSpace(cfg.PersistenceRoot) != "" {
+		env = append(env, "BUILDER_PERSISTENCE_ROOT="+cfg.PersistenceRoot)
+	}
+	if strings.TrimSpace(cfg.Settings.ServerHost) != "" {
+		env = append(env, "BUILDER_SERVER_HOST="+cfg.Settings.ServerHost)
+	}
+	if cfg.Settings.ServerPort > 0 {
+		env = append(env, "BUILDER_SERVER_PORT="+strconv.Itoa(cfg.Settings.ServerPort))
+	}
+	return env
 }

--- a/cli/app/session_server_target.go
+++ b/cli/app/session_server_target.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"io"
-	"os"
 	"os/exec"
 	"time"
 
@@ -103,7 +102,7 @@ func startLocalInteractiveSessionDaemon(ctx context.Context, opts Options) (*cli
 	cmd.Stdin = nil
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
-	cmd.Env = os.Environ()
+	cmd.Env = buildServeEnvFunc(cfg)
 	if err := cmd.Start(); err != nil {
 		return nil, nil, false, err
 	}

--- a/cli/app/session_server_target.go
+++ b/cli/app/session_server_target.go
@@ -97,12 +97,8 @@ func startLocalInteractiveSessionDaemon(ctx context.Context, opts Options) (*cli
 	if !ok {
 		return nil, nil, false, nil
 	}
-	workspaceRoot, err := resolveCLIWorkspaceRoot(opts)
-	if err != nil {
-		return nil, nil, false, err
-	}
 	serve.ReleaseTestListenReservation(config.ServerListenAddress(cfg))
-	args := append([]string{execPath}, buildServeArgsFunc(workspaceRoot, opts)...)
+	args := append([]string{execPath}, buildServeArgsFunc("", opts)...)
 	cmd := exec.CommandContext(context.Background(), args[0], args[1:]...)
 	cmd.Stdin = nil
 	cmd.Stdout = io.Discard

--- a/cli/app/session_server_target_test.go
+++ b/cli/app/session_server_target_test.go
@@ -18,6 +18,7 @@ import (
 	"builder/server/auth"
 	"builder/server/authstatus"
 	"builder/server/llm"
+	"builder/server/metadata"
 	"builder/server/serve"
 	serverstartup "builder/server/startup"
 	askquestion "builder/server/tools/askquestion"
@@ -100,7 +101,7 @@ func TestStartSessionServerUsesConfiguredDaemonForInteractiveFlow(t *testing.T) 
 	}()
 	waitForConfiguredRemoteIdentity(t, workspace)
 
-	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, newHeadlessAuthInteractor())
+	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, newHeadlessAuthInteractorWithEnvKey("test-key"))
 	if err != nil {
 		t.Fatalf("startSessionServer: %v", err)
 	}
@@ -142,6 +143,72 @@ func TestStartSessionServerUsesConfiguredDaemonForInteractiveFlow(t *testing.T) 
 	cancel()
 	if serveErr := <-errCh; !errors.Is(serveErr, context.Canceled) {
 		t.Fatalf("Serve error = %v, want context canceled", serveErr)
+	}
+}
+
+func TestConfiguredDaemonPlanSessionUsesSessionWorkspaceLocalConfig(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	configureAppTestServerPort(t)
+	if err := os.MkdirAll(filepath.Join(home, ".builder"), 0o755); err != nil {
+		t.Fatalf("create home config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".builder", "config.toml"), []byte("model = \"home-model\"\nthinking_level = \"low\"\n"), 0o644); err != nil {
+		t.Fatalf("write home config: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(workspace, ".builder"), 0o755); err != nil {
+		t.Fatalf("create workspace config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, ".builder", "config.toml"), []byte("model = \"workspace-model\"\nthinking_level = \"high\"\n"), 0o644); err != nil {
+		t.Fatalf("write workspace config: %v", err)
+	}
+	glob, err := config.LoadGlobal(config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if _, err := metadata.RegisterBinding(context.Background(), glob.PersistenceRoot, workspace); err != nil {
+		t.Fatalf("RegisterBinding: %v", err)
+	}
+
+	srv, err := serve.Start(context.Background(), serverstartup.Request{AllowUnauthenticated: true}, memoryAuthHandler{state: auth.EmptyState()}, autoOnboarding{})
+	if err != nil {
+		t.Fatalf("serve.Start: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	serveCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Serve(serveCtx)
+	}()
+	defer func() {
+		cancel()
+		if serveErr := <-errCh; !errors.Is(serveErr, context.Canceled) {
+			t.Fatalf("Serve error = %v, want context canceled", serveErr)
+		}
+	}()
+	waitForConfiguredRemoteIdentity(t, workspace)
+
+	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, newHeadlessAuthInteractorWithEnvKey("test-key"))
+	if err != nil {
+		t.Fatalf("startSessionServer: %v", err)
+	}
+	defer func() { _ = server.Close() }()
+	if _, ok := server.(*remoteAppServer); !ok {
+		t.Fatalf("expected remote app server, got %T", server)
+	}
+	planner := newSessionLaunchPlanner(server)
+	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true})
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if plan.ActiveSettings.Model != "workspace-model" || plan.ActiveSettings.ThinkingLevel != "high" {
+		t.Fatalf("active settings = %+v, want workspace-local model/thinking", plan.ActiveSettings)
+	}
+	if !plan.Source.WorkspaceSettingsFileExists {
+		t.Fatalf("expected workspace settings source, got %+v", plan.Source)
 	}
 }
 

--- a/cli/app/session_server_target_test.go
+++ b/cli/app/session_server_target_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"builder/server/auth"
+	"builder/server/authstatus"
 	"builder/server/llm"
 	"builder/server/serve"
 	serverstartup "builder/server/startup"
@@ -1201,6 +1202,14 @@ func TestRemoteSessionStatusDoesNotReuseLocalAuthState(t *testing.T) {
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
 
+	originalFetcher := authstatus.DefaultUsagePayloadFetcher
+	defer func() { authstatus.DefaultUsagePayloadFetcher = originalFetcher }()
+	called := false
+	authstatus.DefaultUsagePayloadFetcher = func(_ context.Context, baseURL string, state auth.State) (authstatus.UsagePayload, error) {
+		called = true
+		return authstatus.UsagePayload{PlanType: "pro"}, nil
+	}
+
 	srv, err := serve.Start(context.Background(), serverstartup.Request{
 		WorkspaceRoot:         workspace,
 		WorkspaceRootExplicit: true,
@@ -1208,8 +1217,12 @@ func TestRemoteSessionStatusDoesNotReuseLocalAuthState(t *testing.T) {
 	}, memoryAuthHandler{state: auth.State{
 		Scope: auth.ScopeGlobal,
 		Method: auth.Method{
-			Type:   auth.MethodAPIKey,
-			APIKey: &auth.APIKeyMethod{Key: "test-key"},
+			Type: auth.MethodOAuth,
+			OAuth: &auth.OAuthMethod{
+				AccessToken: "server-access-token",
+				AccountID:   "server-acct",
+				Email:       "user@example.com",
+			},
 		},
 		UpdatedAt: time.Now().UTC(),
 	}}, autoOnboarding{})
@@ -1240,24 +1253,12 @@ func TestRemoteSessionStatusDoesNotReuseLocalAuthState(t *testing.T) {
 	if err := store.Save(context.Background(), auth.State{
 		Scope: auth.ScopeGlobal,
 		Method: auth.Method{
-			Type: auth.MethodOAuth,
-			OAuth: &auth.OAuthMethod{
-				AccessToken: "access-token",
-				AccountID:   "acct-123",
-				Email:       "user@example.com",
-			},
+			Type:   auth.MethodAPIKey,
+			APIKey: &auth.APIKeyMethod{Key: "local-key"},
 		},
 		UpdatedAt: time.Now().UTC(),
 	}); err != nil {
 		t.Fatalf("save auth state: %v", err)
-	}
-
-	originalFetcher := statusUsagePayloadFetcher
-	defer func() { statusUsagePayloadFetcher = originalFetcher }()
-	called := false
-	statusUsagePayloadFetcher = func(_ context.Context, baseURL string, state auth.State) (statusUsagePayload, error) {
-		called = true
-		return statusUsagePayload{PlanType: "pro"}, nil
 	}
 
 	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, newHeadlessAuthInteractor())
@@ -1288,20 +1289,21 @@ func TestRemoteSessionStatusDoesNotReuseLocalAuthState(t *testing.T) {
 		Settings:        plan.StatusConfig.Settings,
 		Source:          plan.StatusConfig.Source,
 		AuthManager:     plan.StatusConfig.AuthManager,
+		AuthStatus:      plan.StatusConfig.AuthStatus,
 		AuthStatePath:   plan.StatusConfig.AuthStatePath,
 		OwnsServer:      plan.StatusConfig.OwnsServer,
 	})
 	if err != nil {
 		t.Fatalf("collect status: %v", err)
 	}
-	if got := snapshot.Auth.Summary; got != "Not configured" {
+	if got := snapshot.Auth.Summary; got != "user@example.com" {
 		t.Fatalf("auth summary = %q", got)
 	}
-	if snapshot.Subscription.Applicable {
-		t.Fatalf("expected remote status subscription to remain unavailable, got %+v", snapshot.Subscription)
+	if !snapshot.Subscription.Applicable || snapshot.Subscription.Summary != "Pro subscription" {
+		t.Fatalf("expected remote status subscription to come from server auth, got %+v", snapshot.Subscription)
 	}
-	if called {
-		t.Fatal("expected remote session status to avoid local subscription lookup")
+	if !called {
+		t.Fatal("expected remote session status to fetch subscription through server auth")
 	}
 }
 

--- a/cli/app/terminal_bell.go
+++ b/cli/app/terminal_bell.go
@@ -177,6 +177,10 @@ func (h *bellHooks) OnAsk(req askquestion.Request) {
 }
 
 func (h *bellHooks) OnProjectedRuntimeEvent(evt clientui.Event) {
+	if isNoopProjectedAssistantEvent(evt) {
+		h.clearPendingTurnCompletionForSilentFinal(evt.StepID)
+		return
+	}
 	switch evt.Kind {
 	case clientui.EventToolCallStarted:
 		h.recordToolCall(evt.StepID)
@@ -213,6 +217,18 @@ func (h *bellHooks) recordTurnCompletion(stepID, assistantContent string) {
 	}
 	h.currentStep = ""
 	h.toolCalls = 0
+}
+
+func (h *bellHooks) clearPendingTurnCompletionForSilentFinal(stepID string) {
+	stepID = strings.TrimSpace(stepID)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.pendingTurnCompletion = false
+	h.lastCompletionMessage = ""
+	if stepID != "" && h.currentStep == stepID {
+		h.currentStep = ""
+		h.toolCalls = 0
+	}
 }
 
 func (h *bellHooks) OnTurnQueueDrained() {

--- a/cli/app/terminal_bell_test.go
+++ b/cli/app/terminal_bell_test.go
@@ -177,6 +177,57 @@ func TestBellHooksFallbackToTurnCompleteForWhitespacePreview(t *testing.T) {
 	}
 }
 
+func TestBellHooksNoopAssistantDeltaClearsPendingTurnCompletion(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newBellHooks(ringer, nil)
+
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventAssistantMessage, StepID: "step-1", TranscriptEntries: []clientui.ChatEntry{{Role: "assistant", Text: "working"}}})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventAssistantDelta, StepID: "step-2", AssistantDelta: uiNoopFinalToken})
+	hooks.OnTurnQueueDrained()
+
+	if got := ringer.Count(); got != 0 {
+		t.Fatalf("ring count = %d after NO_OP delta drain, want 0", got)
+	}
+}
+
+func TestBellHooksNoopAssistantMessageClearsPendingTurnCompletion(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newBellHooks(ringer, nil)
+
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventAssistantMessage, StepID: "step-1", TranscriptEntries: []clientui.ChatEntry{{Role: "assistant", Text: "working"}}})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventAssistantMessage, StepID: "step-2", TranscriptEntries: []clientui.ChatEntry{{Role: "assistant", Text: "NO_OP"}}})
+	hooks.OnTurnQueueDrained()
+
+	if got := ringer.Count(); got != 0 {
+		t.Fatalf("ring count = %d after NO_OP assistant message drain, want 0", got)
+	}
+}
+
+func TestBellHooksNoopAssistantEventPreservesUnrelatedActiveTurn(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newBellHooks(ringer, nil)
+
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventAssistantMessage, StepID: "step-1", TranscriptEntries: []clientui.ChatEntry{{Role: "assistant", Text: "first"}}})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-2"})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventAssistantDelta, StepID: "step-3", AssistantDelta: uiNoopFinalToken})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-2"})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventAssistantMessage, StepID: "step-2", TranscriptEntries: []clientui.ChatEntry{{Role: "assistant", Text: "second"}}})
+	hooks.OnTurnQueueDrained()
+
+	if got := ringer.Count(); got != 1 {
+		t.Fatalf("ring count = %d after unrelated active turn completes, want 1", got)
+	}
+	if got := ringer.Last(); got != "builder: second" {
+		t.Fatalf("last message = %q, want %q", got, "builder: second")
+	}
+}
+
 func TestFormatAssistantPreview(t *testing.T) {
 	if got := formatAssistantPreview("\n  hello\tworld  ", 80); got != "hello world" {
 		t.Fatalf("preview = %q, want %q", got, "hello world")

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -1135,8 +1135,7 @@ func (m *uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.worktrees.selectedID = worktreeCreateRowID
 			listCmd = m.requestWorktreeListCmd()
 		}
-		status := "Deleted worktree " + worktreeDisplayName(msg.resp.Worktree)
-		feedbackCmd := sequenceCmds(m.appendLocalEntry("system", formatWorktreeDelete(msg.resp)), m.setTransientStatusWithKind(status, uiStatusNoticeSuccess))
+		feedbackCmd := m.setTransientStatusWithKind("Deleted worktree "+worktreeDisplayName(msg.resp.Worktree), uiStatusNoticeSuccess)
 		m.syncViewport()
 		return m, tea.Batch(feedbackCmd, listCmd, m.requestRuntimeMainViewRefresh(), m.ensureSpinnerTicking())
 	case worktreeCreateTargetResolveDebounceMsg:

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -33,7 +33,7 @@ func newSubmitDoneMsg(message string, submittedText string, err error) submitDon
 	return submitDoneMsg{
 		message:       message,
 		submittedText: submittedText,
-		silentFinal:   strings.TrimSpace(message) == uiNoopFinalToken,
+		silentFinal:   isNoopFinalText(message),
 		err:           err,
 	}
 }
@@ -1329,7 +1329,7 @@ func envFlagEnabled(name string) bool {
 }
 
 func statusHasAuthData(snapshot uiStatusSnapshot) bool {
-	return strings.TrimSpace(snapshot.Auth.Summary) != "" || len(snapshot.Auth.Details) > 0 || snapshot.Subscription.Applicable || strings.TrimSpace(snapshot.Subscription.Summary) != "" || len(snapshot.Subscription.Windows) > 0
+	return snapshot.Auth.Visible || snapshot.Subscription.Applicable || strings.TrimSpace(snapshot.Subscription.Summary) != "" || len(snapshot.Subscription.Windows) > 0
 }
 
 func (m *uiModel) forwardToView(msg tea.Msg) {

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -92,7 +92,8 @@ type runtimeConnectionStateChangedMsg struct {
 }
 
 type runtimeLeaseRecoveryWarningMsg struct {
-	text string
+	text       string
+	visibility clientui.EntryVisibility
 }
 
 type runtimeMainViewRefreshedMsg struct {
@@ -660,11 +661,13 @@ func NewProjectedUIModel(runtimeClient clientui.RuntimeClient, runtimeEvents <-c
 			enqueueRuntimeConnectionStateChange(runtimeConnectionEvents, err)
 		})
 	}
-	if configurable, ok := m.engine.(interface{ SetLeaseRecoveryWarningObserver(func(string)) }); ok {
+	if configurable, ok := m.engine.(interface {
+		SetLeaseRecoveryWarningObserver(func(string, clientui.EntryVisibility))
+	}); ok {
 		runtimeLeaseRecoveryWarning := make(chan runtimeLeaseRecoveryWarningMsg, 1)
 		m.runtimeLeaseRecoveryWarning = runtimeLeaseRecoveryWarning
-		configurable.SetLeaseRecoveryWarningObserver(func(text string) {
-			enqueueRuntimeLeaseRecoveryWarning(runtimeLeaseRecoveryWarning, text)
+		configurable.SetLeaseRecoveryWarningObserver(func(text string, visibility clientui.EntryVisibility) {
+			enqueueRuntimeLeaseRecoveryWarning(runtimeLeaseRecoveryWarning, text, visibility)
 		})
 	}
 	status := m.runtimeStatus()
@@ -979,7 +982,7 @@ func (m *uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.syncViewport()
 		return m, waitRuntimeConnectionStateChange(m.runtimeConnectionEvents)
 	case runtimeLeaseRecoveryWarningMsg:
-		cmd := m.appendLocalEntryFallback("warning", msg.text)
+		cmd := m.appendLocalEntryFallbackWithVisibility("warning", msg.text, msg.visibility)
 		m.syncViewport()
 		return m, sequenceCmds(cmd, waitRuntimeLeaseRecoveryWarning(m.runtimeLeaseRecoveryWarning))
 	case runtimeMainViewRefreshedMsg:

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -91,6 +91,10 @@ type runtimeConnectionStateChangedMsg struct {
 	err error
 }
 
+type runtimeLeaseRecoveryWarningMsg struct {
+	text string
+}
+
 type runtimeMainViewRefreshedMsg struct {
 	token uint64
 	view  clientui.RuntimeMainView
@@ -447,11 +451,12 @@ type uiModel struct {
 	processClientExplicit bool
 	worktreeClient        client.WorktreeClient
 
-	runtimeEvents           <-chan clientui.Event
-	pendingRuntimeEvents    []clientui.Event
-	askEvents               <-chan askEvent
-	pathReferenceEvents     <-chan uiPathReferenceSearchEvent
-	runtimeConnectionEvents <-chan runtimeConnectionStateChangedMsg
+	runtimeEvents               <-chan clientui.Event
+	pendingRuntimeEvents        []clientui.Event
+	askEvents                   <-chan askEvent
+	pathReferenceEvents         <-chan uiPathReferenceSearchEvent
+	runtimeConnectionEvents     <-chan runtimeConnectionStateChangedMsg
+	runtimeLeaseRecoveryWarning <-chan runtimeLeaseRecoveryWarningMsg
 
 	input                    string
 	inputCursor              int // rune index; -1 means "track tail"
@@ -655,6 +660,13 @@ func NewProjectedUIModel(runtimeClient clientui.RuntimeClient, runtimeEvents <-c
 			enqueueRuntimeConnectionStateChange(runtimeConnectionEvents, err)
 		})
 	}
+	if configurable, ok := m.engine.(interface{ SetLeaseRecoveryWarningObserver(func(string)) }); ok {
+		runtimeLeaseRecoveryWarning := make(chan runtimeLeaseRecoveryWarningMsg, 1)
+		m.runtimeLeaseRecoveryWarning = runtimeLeaseRecoveryWarning
+		configurable.SetLeaseRecoveryWarningObserver(func(text string) {
+			enqueueRuntimeLeaseRecoveryWarning(runtimeLeaseRecoveryWarning, text)
+		})
+	}
 	status := m.runtimeStatus()
 	m.reviewerMode = status.ReviewerFrequency
 	m.reviewerEnabled = status.ReviewerEnabled
@@ -839,6 +851,9 @@ func (m *uiModel) Init() tea.Cmd {
 	if m.runtimeConnectionEvents != nil {
 		cmds = append(cmds, waitRuntimeConnectionStateChange(m.runtimeConnectionEvents))
 	}
+	if m.runtimeLeaseRecoveryWarning != nil {
+		cmds = append(cmds, waitRuntimeLeaseRecoveryWarning(m.runtimeLeaseRecoveryWarning))
+	}
 	cmds = append([]tea.Cmd{tea.ClearScreen}, cmds...)
 	if startupText := strings.TrimSpace(m.startupSubmit); startupText != "" {
 		cmds = append(cmds, m.inputController().startSubmissionWithPromptHistory(startupText))
@@ -963,6 +978,10 @@ func (m *uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.observeRuntimeRequestResult(msg.err)
 		m.syncViewport()
 		return m, waitRuntimeConnectionStateChange(m.runtimeConnectionEvents)
+	case runtimeLeaseRecoveryWarningMsg:
+		cmd := m.appendLocalEntryFallback("warning", msg.text)
+		m.syncViewport()
+		return m, sequenceCmds(cmd, waitRuntimeLeaseRecoveryWarning(m.runtimeLeaseRecoveryWarning))
 	case runtimeMainViewRefreshedMsg:
 		cmd := m.handleRuntimeMainViewRefreshed(msg)
 		m.syncViewport()

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -1157,7 +1157,7 @@ func (m *uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.worktrees.selectedID = worktreeCreateRowID
 			listCmd = m.requestWorktreeListCmd()
 		}
-		feedbackCmd := m.setTransientStatusWithKind("Deleted worktree "+worktreeDisplayName(msg.resp.Worktree), uiStatusNoticeSuccess)
+		feedbackCmd := m.setTransientStatusWithKind(worktreeDeleteSuccessStatus(msg.resp), uiStatusNoticeSuccess)
 		m.syncViewport()
 		return m, tea.Batch(feedbackCmd, listCmd, m.requestRuntimeMainViewRefresh(), m.ensureSpinnerTicking())
 	case worktreeCreateTargetResolveDebounceMsg:
@@ -1436,6 +1436,14 @@ func (m *uiModel) updateTranscriptDiagnosticsMode() {
 
 func (m *uiModel) inputController() uiInputController {
 	return uiInputController{model: m}
+}
+
+func worktreeDeleteSuccessStatus(resp serverapi.WorktreeDeleteResponse) string {
+	status := "Deleted worktree " + worktreeDisplayName(resp.Worktree)
+	if cleanup := strings.TrimSpace(resp.BranchCleanupMessage); cleanup != "" {
+		status += ". " + cleanup
+	}
+	return status
 }
 
 func (m *uiModel) askController() uiAskController {

--- a/cli/app/ui_diff_render_test.go
+++ b/cli/app/ui_diff_render_test.go
@@ -2,6 +2,10 @@ package app
 
 import (
 	"builder/cli/tui"
+	"builder/server/llm"
+	"builder/server/runtime"
+	"builder/server/tools"
+	"builder/shared/toolspec"
 	"builder/shared/transcript"
 	patchformat "builder/shared/transcript/patchformat"
 	"strings"
@@ -9,6 +13,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
 )
 
 func TestDetailDiffBackgroundCoversSyntaxHighlightedCodeInAppView(t *testing.T) {
@@ -63,5 +68,83 @@ func TestDetailDiffBackgroundCoversSyntaxHighlightedCodeInAppView(t *testing.T) 
 	}
 	if got := ansi.Strip(addLine); !strings.Contains(got, "+package main") {
 		t.Fatalf("expected app view text preserved, got %q", got)
+	}
+}
+
+func TestCustomPatchToolCallRendersSummaryOngoingAndHighlightedDiffDetail(t *testing.T) {
+	const viewportWidth = 80
+	patchText := "*** Begin Patch\n*** Update File: cli/app/ui_status.go\n@@\n type uiStatusAuthInfo struct {\n-\tSummary string\n+\tSummary string\n+\tReady bool\n }\n*** End Patch\n"
+
+	m := newProjectedStaticUIModel()
+	m.termWidth = viewportWidth
+	m.termHeight = 18
+	m.syncViewport()
+
+	_ = m.runtimeAdapter().handleProjectedRuntimeEvent(projectRuntimeEvent(runtime.Event{
+		Kind:   runtime.EventToolCallStarted,
+		StepID: "step-1",
+		ToolCall: &llm.ToolCall{
+			ID:          "call_patch_custom",
+			Name:        string(toolspec.ToolPatch),
+			Custom:      true,
+			CustomInput: patchText,
+		},
+	}))
+	_ = m.runtimeAdapter().handleProjectedRuntimeEvent(projectRuntimeEvent(runtime.Event{
+		Kind:   runtime.EventToolCallCompleted,
+		StepID: "step-1",
+		ToolResult: &tools.Result{
+			CallID: "call_patch_custom",
+			Name:   toolspec.ToolPatch,
+			Output: []byte("{}"),
+		},
+	}))
+
+	ongoing := stripANSIAndTrimRight(m.view.OngoingSnapshot())
+	if !strings.Contains(ongoing, "Edited: ./cli/app/ui_status.go +2 -1") {
+		t.Fatalf("expected custom patch summary in ongoing transcript, got %q", ongoing)
+	}
+	if strings.Contains(ongoing, "*** Begin Patch") || strings.Contains(ongoing, "+\tReady bool") {
+		t.Fatalf("expected ongoing transcript to hide raw custom patch body, got %q", ongoing)
+	}
+
+	m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyCtrlT})
+	detailView := m.View()
+	detailPlain := ansi.Strip(detailView)
+	if !strings.Contains(detailPlain, "cli/app/ui_status.go") || !strings.Contains(detailPlain, "+    Ready bool") || !strings.Contains(detailPlain, "-    Summary string") {
+		t.Fatalf("expected custom patch diff in detail transcript, got %q", detailPlain)
+	}
+
+	var addedLine string
+	for _, line := range strings.Split(detailView, "\n") {
+		if strings.Contains(ansi.Strip(line), "+    Ready bool") {
+			addedLine = line
+			break
+		}
+	}
+	if addedLine == "" {
+		t.Fatalf("expected highlighted added line in detail transcript, got %q", detailView)
+	}
+	const addBg = "\x1b[48;2;31;42;34m"
+	if !strings.Contains(addedLine, addBg+"  ") {
+		t.Fatalf("expected diff background highlight on custom patch detail line, got %q", addedLine)
+	}
+	readyIdx := strings.Index(addedLine, "Ready")
+	if readyIdx < 0 {
+		t.Fatalf("expected syntax-highlighted Ready token in custom patch detail line, got %q", addedLine)
+	}
+	bgIdx := strings.LastIndex(addedLine[:readyIdx], addBg)
+	if bgIdx < 0 {
+		t.Fatalf("expected diff background before syntax-highlighted custom patch token, got %q", addedLine)
+	}
+	if strings.Contains(addedLine[bgIdx:readyIdx], "\x1b[0") {
+		t.Fatalf("expected no reset between diff background and first syntax-highlighted custom patch token, got %q", addedLine)
+	}
+	tailBgIdx := strings.LastIndex(addedLine, addBg)
+	if tailBgIdx < 0 || !strings.Contains(addedLine[tailBgIdx:], strings.Repeat(" ", 16)+"\x1b[0m") {
+		t.Fatalf("expected diff background to continue through padded tail, got %q", addedLine)
+	}
+	if got := runewidth.StringWidth(ansi.Strip(addedLine)); got < viewportWidth {
+		t.Fatalf("expected diff background line to span at least viewport width %d, got %d for %q", viewportWidth, got, addedLine)
 	}
 }

--- a/cli/app/ui_input_controller.go
+++ b/cli/app/ui_input_controller.go
@@ -9,6 +9,7 @@ import (
 
 	"builder/cli/tui"
 	"builder/server/llm"
+	"builder/shared/clientui"
 	"builder/shared/serverapi"
 	"builder/shared/transcript"
 
@@ -184,9 +185,12 @@ func (m *uiModel) appendLocalEntryFallback(role, text string) tea.Cmd {
 		return nil
 	}
 	entry := tui.TranscriptEntry{Role: role, Text: text}
+	if role == "warning" && text == runtimeLeaseRecoveryWarningText {
+		entry.Visibility = clientui.EntryVisibilityAll
+	}
 	m.transcriptEntries = append(m.transcriptEntries, entry)
 	m.transcriptTotalEntries = max(m.transcriptTotalEntries, m.transcriptBaseOffset+len(committedTranscriptEntriesForApp(m.transcriptEntries)))
 	m.refreshRollbackCandidates()
-	m.forwardToView(tui.AppendTranscriptMsg{Role: role, Text: text})
+	m.forwardToView(tui.AppendTranscriptMsg{Visibility: entry.Visibility, Role: role, Text: text})
 	return m.syncNativeHistoryFromTranscript()
 }

--- a/cli/app/ui_input_controller.go
+++ b/cli/app/ui_input_controller.go
@@ -9,7 +9,6 @@ import (
 
 	"builder/cli/tui"
 	"builder/server/llm"
-	"builder/shared/clientui"
 	"builder/shared/serverapi"
 	"builder/shared/transcript"
 
@@ -181,13 +180,14 @@ func (m *uiModel) appendLocalEntry(role, text string) tea.Cmd {
 }
 
 func (m *uiModel) appendLocalEntryFallback(role, text string) tea.Cmd {
+	return m.appendLocalEntryFallbackWithVisibility(role, text, transcript.EntryVisibilityAuto)
+}
+
+func (m *uiModel) appendLocalEntryFallbackWithVisibility(role, text string, visibility transcript.EntryVisibility) tea.Cmd {
 	if m == nil {
 		return nil
 	}
-	entry := tui.TranscriptEntry{Role: role, Text: text}
-	if role == "warning" && text == runtimeLeaseRecoveryWarningText {
-		entry.Visibility = clientui.EntryVisibilityAll
-	}
+	entry := tui.TranscriptEntry{Visibility: transcript.NormalizeEntryVisibility(visibility), Role: role, Text: text}
 	m.transcriptEntries = append(m.transcriptEntries, entry)
 	m.transcriptTotalEntries = max(m.transcriptTotalEntries, m.transcriptBaseOffset+len(committedTranscriptEntriesForApp(m.transcriptEntries)))
 	m.refreshRollbackCandidates()

--- a/cli/app/ui_layout_rendering_status_overlay.go
+++ b/cli/app/ui_layout_rendering_status_overlay.go
@@ -78,25 +78,39 @@ func (l uiViewLayout) statusOverlayContentLines(width int) []string {
 
 	snapshot := m.status.snapshot
 
-	appendSectionTitle("Account")
-	if summary := statusVisibleAuthSummary(snapshot.Auth, snapshot.Subscription); summary != "" {
-		appendWrapped(summary, boldStyle)
-	} else if l.statusSectionLoading(uiStatusSectionAuth) {
-		appendWrapped("Loading account...", subtleStyle)
-	}
-	if summary := strings.TrimSpace(snapshot.Subscription.Summary); summary != "" {
-		appendWrapped(summary, boldStyle)
-	}
-	if len(snapshot.Subscription.Windows) > 0 {
-		labelWidth := statusSubscriptionLabelWidth(snapshot.Subscription.Windows)
-		for _, window := range snapshot.Subscription.Windows {
-			appendANSI(l.renderStatusSubscriptionLine(width, window, labelWidth))
+	authSummary := statusVisibleAuthSummary(snapshot.Auth, snapshot.Subscription)
+	subscriptionSummary := strings.TrimSpace(snapshot.Subscription.Summary)
+	hasSubscriptionRows := len(snapshot.Subscription.Windows) > 0
+	showAccountSection := authSummary != "" || subscriptionSummary != "" || hasSubscriptionRows || l.statusSectionLoading(uiStatusSectionAuth)
+	if showAccountSection {
+		if subscriptionSummary != "" || hasSubscriptionRows {
+			appendSectionTitle("Subscription")
+		} else {
+			appendSectionTitle("Account")
 		}
-	} else if l.statusSectionLoading(uiStatusSectionAuth) {
-		appendWrapped("Loading limits...", subtleStyle)
-	}
-	for _, detail := range snapshot.Auth.Details {
-		appendWrapped(detail, subtleStyle)
+		if authSummary != "" {
+			appendWrapped(authSummary, boldStyle)
+		} else if subscriptionSummary == "" && !hasSubscriptionRows && l.statusSectionLoading(uiStatusSectionAuth) {
+			appendWrapped("Loading account...", subtleStyle)
+		}
+		if subscriptionSummary != "" {
+			if strings.TrimSpace(snapshot.Subscription.Error) != "" {
+				appendWrapped(subscriptionSummary, warningStyle)
+			} else {
+				appendWrapped(subscriptionSummary, boldStyle)
+			}
+		}
+		if hasSubscriptionRows {
+			labelWidth := statusSubscriptionLabelWidth(snapshot.Subscription.Windows)
+			for _, window := range snapshot.Subscription.Windows {
+				appendANSI(l.renderStatusSubscriptionLine(width, window, labelWidth))
+			}
+		} else if subscriptionSummary != "" && l.statusSectionLoading(uiStatusSectionAuth) {
+			appendWrapped("Loading limits...", subtleStyle)
+		}
+		for _, detail := range snapshot.Auth.Details {
+			appendWrapped(detail, subtleStyle)
+		}
 	}
 
 	appendSectionTitle("Session")
@@ -406,6 +420,9 @@ func statusRelativeDuration(value time.Duration) string {
 }
 
 func statusVisibleAuthSummary(auth uiStatusAuthInfo, subscription uiStatusSubscriptionInfo) string {
+	if !auth.Visible {
+		return ""
+	}
 	summary := strings.TrimSpace(auth.Summary)
 	if summary == "" {
 		return ""

--- a/cli/app/ui_noop_final.go
+++ b/cli/app/ui_noop_final.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"strings"
+
+	"builder/server/llm"
+	"builder/shared/clientui"
+)
+
+const uiNoopFinalToken = "NO_OP"
+
+func isNoopFinalText(text string) bool {
+	return strings.TrimSpace(text) == uiNoopFinalToken
+}
+
+func isNoopProjectedAssistantEvent(evt clientui.Event) bool {
+	switch evt.Kind {
+	case clientui.EventAssistantDelta:
+		return isNoopFinalText(evt.AssistantDelta)
+	case clientui.EventAssistantMessage:
+		for _, entry := range evt.TranscriptEntries {
+			if isNoopFinalAssistantEntry(entry) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func isNoopFinalAssistantEntry(entry clientui.ChatEntry) bool {
+	phase := strings.TrimSpace(entry.Phase)
+	return strings.TrimSpace(entry.Role) == "assistant" &&
+		(phase == "" || phase == string(llm.MessagePhaseFinal)) &&
+		isNoopFinalText(entry.Text)
+}

--- a/cli/app/ui_runtime_adapter.go
+++ b/cli/app/ui_runtime_adapter.go
@@ -15,8 +15,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-const uiNoopFinalToken = "NO_OP"
-
 type uiRuntimeAdapter struct {
 	model *uiModel
 }
@@ -130,7 +128,7 @@ func (a uiRuntimeAdapter) applyProjectedRuntimeEvent(evt clientui.Event, flushNa
 	if update.AssistantDelta != "" {
 		if shouldIgnoreStaleAssistantDelta(m, evt, update.AssistantDelta) {
 			update.AssistantDelta = ""
-		} else if strings.TrimSpace(update.AssistantDelta) == uiNoopFinalToken {
+		} else if isNoopFinalText(update.AssistantDelta) {
 			update.AssistantDelta = ""
 		} else {
 			m.sawAssistantDelta = true

--- a/cli/app/ui_runtime_adapter.go
+++ b/cli/app/ui_runtime_adapter.go
@@ -1617,6 +1617,19 @@ func waitRuntimeConnectionStateChange(ch <-chan runtimeConnectionStateChangedMsg
 	}
 }
 
+func waitRuntimeLeaseRecoveryWarning(ch <-chan runtimeLeaseRecoveryWarningMsg) tea.Cmd {
+	if ch == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		msg, ok := <-ch
+		if !ok {
+			return nil
+		}
+		return msg
+	}
+}
+
 func (m *uiModel) handleRuntimeEvent(evt clientui.Event) {
 	_ = m.runtimeAdapter().handleProjectedRuntimeEvent(evt)
 }

--- a/cli/app/ui_runtime_adapter_test.go
+++ b/cli/app/ui_runtime_adapter_test.go
@@ -3027,6 +3027,36 @@ func TestAssistantDeltaAppendsStreamingText(t *testing.T) {
 	}
 }
 
+func TestAssistantCommentaryCommitPlusDeltaDoesNotSplitOngoingView(t *testing.T) {
+	m := newProjectedStaticUIModel()
+
+	_ = m.runtimeAdapter().handleRuntimeEvent(runtime.Event{
+		Kind:                       runtime.EventAssistantMessage,
+		StepID:                     "step-1",
+		CommittedTranscriptChanged: true,
+		TranscriptRevision:         1,
+		CommittedEntryCount:        1,
+		Message: llm.Message{
+			Role:    llm.RoleAssistant,
+			Content: "Decision: keep Builder tool name patch; expose custom tool with Lark grammar.",
+			Phase:   llm.MessagePhaseCommentary,
+		},
+	})
+	_ = m.runtimeAdapter().handleRuntimeEvent(runtime.Event{
+		Kind:           runtime.EventAssistantDelta,
+		StepID:         "step-1",
+		AssistantDelta: " Internally normalize custom calls into existing executor input.",
+	})
+
+	view := stripANSIPreserve(m.view.OngoingSnapshot())
+	if strings.Contains(view, tui.TranscriptDivider) {
+		t.Fatalf("expected projected commentary commit plus live assistant delta without divider, got %q", view)
+	}
+	if !containsInOrder(view, "Decision:", "executor input") {
+		t.Fatalf("expected projected commentary commit and live delta in order, got %q", view)
+	}
+}
+
 func TestAssistantDeltaSkipsNoopFinalToken(t *testing.T) {
 	m := newProjectedStaticUIModel()
 

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -34,6 +34,7 @@ type sessionRuntimeClient struct {
 	diagLogf                func(string)
 	transcriptDiagnostics   bool
 	connectionStateObserver func(error)
+	leaseRecoveryWarning    func(string)
 
 	mu                        sync.RWMutex
 	mainView                  clientui.RuntimeMainView
@@ -134,21 +135,26 @@ func (c *sessionRuntimeClient) recoverControllerLease(ctx context.Context) error
 	if err != nil {
 		return err
 	}
-	c.appendLeaseRecoveryWarning(ctx, leaseID)
+	c.appendLeaseRecoveryWarning(leaseID)
 	return nil
 }
 
-func (c *sessionRuntimeClient) appendLeaseRecoveryWarning(ctx context.Context, controllerLeaseID string) {
+func (c *sessionRuntimeClient) appendLeaseRecoveryWarning(controllerLeaseID string) {
 	if c == nil || c.controls == nil {
 		return
 	}
-	_ = c.controls.AppendLocalEntry(ctx, serverapi.RuntimeAppendLocalEntryRequest{
+	warningCtx, cancel := c.controlContext()
+	defer cancel()
+	if err := c.controls.AppendLocalEntry(warningCtx, serverapi.RuntimeAppendLocalEntryRequest{
 		ClientRequestID:   uuid.NewString(),
 		SessionID:         c.sessionID,
 		ControllerLeaseID: controllerLeaseID,
 		Role:              "warning",
 		Text:              runtimeLeaseRecoveryWarningText,
-	})
+		Visibility:        string(clientui.EntryVisibilityAll),
+	}); err != nil {
+		c.notifyLeaseRecoveryWarning(runtimeLeaseRecoveryWarningText)
+	}
 }
 
 func isRecoverableRuntimeControlError(err error) bool {
@@ -205,6 +211,15 @@ func (c *sessionRuntimeClient) SetConnectionStateObserver(observer func(error)) 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.connectionStateObserver = observer
+}
+
+func (c *sessionRuntimeClient) SetLeaseRecoveryWarningObserver(observer func(string)) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.leaseRecoveryWarning = observer
 }
 
 func (c *sessionRuntimeClient) MainView() clientui.RuntimeMainView {
@@ -459,6 +474,19 @@ func (c *sessionRuntimeClient) notifyConnectionState(err error) {
 		return
 	}
 	observer(err)
+}
+
+func (c *sessionRuntimeClient) notifyLeaseRecoveryWarning(text string) {
+	if c == nil || strings.TrimSpace(text) == "" {
+		return
+	}
+	c.mu.RLock()
+	observer := c.leaseRecoveryWarning
+	c.mu.RUnlock()
+	if observer == nil {
+		return
+	}
+	observer(text)
 }
 
 func (c *sessionRuntimeClient) logTranscriptDiag(line string) {

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -24,7 +24,7 @@ const uiRuntimeReadTimeout = 300 * time.Millisecond
 const uiRuntimeHydrationReadTimeout = 10 * time.Second
 const uiRuntimeMainViewRefreshInterval = 250 * time.Millisecond
 const uiRuntimeTranscriptPageCacheMaxEntries = 16
-const runtimeLeaseRecoveryWarningText = "Connection was lost, re-acquiring a new lease."
+const runtimeLeaseRecoveryWarningText = "Lost connection to the session runtime; reconnected."
 
 type sessionRuntimeClient struct {
 	reads                   client.SessionViewClient
@@ -126,7 +126,7 @@ func (c *sessionRuntimeClient) controllerLeaseManager() *controllerLeaseManager 
 	return c.controllerLease
 }
 
-func (c *sessionRuntimeClient) recoverControllerLease(ctx context.Context) error {
+func (c *sessionRuntimeClient) recoverControllerLease(ctx context.Context, trigger error) error {
 	manager := c.controllerLeaseManager()
 	if manager == nil {
 		return errControllerLeaseRecoveryUnavailable
@@ -135,7 +135,9 @@ func (c *sessionRuntimeClient) recoverControllerLease(ctx context.Context) error
 	if err != nil {
 		return err
 	}
-	c.appendLeaseRecoveryWarning(leaseID)
+	if isRecoverableRuntimeControlError(trigger) {
+		c.appendLeaseRecoveryWarning(leaseID)
+	}
 	return nil
 }
 
@@ -171,13 +173,13 @@ func (c *sessionRuntimeClient) retryControlCallNoResult(ctx context.Context, cal
 	return err
 }
 
-func retryRuntimeControlCall[T any](ctx context.Context, currentLeaseID func() string, recoverLease func(context.Context) error, call func(controllerLeaseID string) (T, error)) (T, error) {
+func retryRuntimeControlCall[T any](ctx context.Context, currentLeaseID func() string, recoverLease func(context.Context, error) error, call func(controllerLeaseID string) (T, error)) (T, error) {
 	value, err := call(currentLeaseID())
 	if !isRecoverableRuntimeControlError(err) {
 		return value, err
 	}
 	var zero T
-	if recoverErr := recoverLease(ctx); recoverErr != nil {
+	if recoverErr := recoverLease(ctx, err); recoverErr != nil {
 		return zero, recoverErr
 	}
 	return call(currentLeaseID())

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -24,6 +24,7 @@ const uiRuntimeReadTimeout = 300 * time.Millisecond
 const uiRuntimeHydrationReadTimeout = 10 * time.Second
 const uiRuntimeMainViewRefreshInterval = 250 * time.Millisecond
 const uiRuntimeTranscriptPageCacheMaxEntries = 16
+const runtimeLeaseRecoveryWarningText = "Connection was lost, re-acquiring a new lease."
 
 type sessionRuntimeClient struct {
 	reads                   client.SessionViewClient
@@ -129,8 +130,32 @@ func (c *sessionRuntimeClient) recoverControllerLease(ctx context.Context) error
 	if manager == nil {
 		return errControllerLeaseRecoveryUnavailable
 	}
-	_, err := manager.Recover(ctx)
-	return err
+	leaseID, err := manager.Recover(ctx)
+	if err != nil {
+		return err
+	}
+	c.appendLeaseRecoveryWarning(ctx, leaseID)
+	return nil
+}
+
+func (c *sessionRuntimeClient) appendLeaseRecoveryWarning(ctx context.Context, controllerLeaseID string) {
+	if c == nil || c.controls == nil {
+		return
+	}
+	_ = c.controls.AppendLocalEntry(ctx, serverapi.RuntimeAppendLocalEntryRequest{
+		ClientRequestID:   uuid.NewString(),
+		SessionID:         c.sessionID,
+		ControllerLeaseID: controllerLeaseID,
+		Role:              "warning",
+		Text:              runtimeLeaseRecoveryWarningText,
+	})
+}
+
+func isRecoverableRuntimeControlError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, serverapi.ErrInvalidControllerLease) || errors.Is(err, serverapi.ErrRuntimeUnavailable)
 }
 
 func (c *sessionRuntimeClient) retryControlCallNoResult(ctx context.Context, call func(controllerLeaseID string) error) error {
@@ -142,7 +167,7 @@ func (c *sessionRuntimeClient) retryControlCallNoResult(ctx context.Context, cal
 
 func retryRuntimeControlCall[T any](ctx context.Context, currentLeaseID func() string, recoverLease func(context.Context) error, call func(controllerLeaseID string) (T, error)) (T, error) {
 	value, err := call(currentLeaseID())
-	if !errors.Is(err, serverapi.ErrInvalidControllerLease) {
+	if !isRecoverableRuntimeControlError(err) {
 		return value, err
 	}
 	var zero T

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -34,7 +34,7 @@ type sessionRuntimeClient struct {
 	diagLogf                func(string)
 	transcriptDiagnostics   bool
 	connectionStateObserver func(error)
-	leaseRecoveryWarning    func(string)
+	leaseRecoveryWarning    func(string, clientui.EntryVisibility)
 
 	mu                        sync.RWMutex
 	mainView                  clientui.RuntimeMainView
@@ -153,7 +153,7 @@ func (c *sessionRuntimeClient) appendLeaseRecoveryWarning(controllerLeaseID stri
 		Text:              runtimeLeaseRecoveryWarningText,
 		Visibility:        string(clientui.EntryVisibilityAll),
 	}); err != nil {
-		c.notifyLeaseRecoveryWarning(runtimeLeaseRecoveryWarningText)
+		c.notifyLeaseRecoveryWarning(runtimeLeaseRecoveryWarningText, clientui.EntryVisibilityAll)
 	}
 }
 
@@ -213,7 +213,7 @@ func (c *sessionRuntimeClient) SetConnectionStateObserver(observer func(error)) 
 	c.connectionStateObserver = observer
 }
 
-func (c *sessionRuntimeClient) SetLeaseRecoveryWarningObserver(observer func(string)) {
+func (c *sessionRuntimeClient) SetLeaseRecoveryWarningObserver(observer func(string, clientui.EntryVisibility)) {
 	if c == nil {
 		return
 	}
@@ -476,7 +476,7 @@ func (c *sessionRuntimeClient) notifyConnectionState(err error) {
 	observer(err)
 }
 
-func (c *sessionRuntimeClient) notifyLeaseRecoveryWarning(text string) {
+func (c *sessionRuntimeClient) notifyLeaseRecoveryWarning(text string, visibility clientui.EntryVisibility) {
 	if c == nil || strings.TrimSpace(text) == "" {
 		return
 	}
@@ -486,7 +486,7 @@ func (c *sessionRuntimeClient) notifyLeaseRecoveryWarning(text string) {
 	if observer == nil {
 		return
 	}
-	observer(text)
+	observer(text, visibility)
 }
 
 func (c *sessionRuntimeClient) logTranscriptDiag(line string) {

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"builder/server/registry"
 	"builder/server/runtime"
 	"builder/server/runtimecontrol"
+	"builder/server/runtimeview"
 	"builder/server/session"
 	"builder/server/sessionview"
 	"builder/server/tools"
@@ -21,6 +23,7 @@ import (
 	"builder/shared/clientui"
 	"builder/shared/serverapi"
 	"builder/shared/toolspec"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 type countingSessionViewClient struct {
@@ -83,6 +86,23 @@ func (c *blockingCountingSessionViewClient) GetSessionTranscriptPage(ctx context
 
 func (*blockingCountingSessionViewClient) GetRun(context.Context, serverapi.RunGetRequest) (serverapi.RunGetResponse, error) {
 	return serverapi.RunGetResponse{}, nil
+}
+
+type mutableRuntimeResolver struct {
+	mu     sync.Mutex
+	engine *runtime.Engine
+}
+
+func (r *mutableRuntimeResolver) Set(engine *runtime.Engine) {
+	r.mu.Lock()
+	r.engine = engine
+	r.mu.Unlock()
+}
+
+func (r *mutableRuntimeResolver) ResolveRuntime(context.Context, string) (*runtime.Engine, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.engine, nil
 }
 
 type flakySessionViewClient struct {
@@ -954,6 +974,7 @@ func TestRuntimeClientSetFastModeEnabledPreservesCachedMainViewOnError(t *testin
 type leaseRetryRuntimeControlClient struct {
 	mu             sync.Mutex
 	firstSubmitErr error
+	appendErr      error
 	submitLeaseID  []string
 	localEntries   []serverapi.RuntimeAppendLocalEntryRequest
 }
@@ -992,9 +1013,9 @@ func (c *leaseRetryRuntimeControlClient) SetAutoCompactionEnabled(context.Contex
 
 func (c *leaseRetryRuntimeControlClient) AppendLocalEntry(_ context.Context, req serverapi.RuntimeAppendLocalEntryRequest) error {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.localEntries = append(c.localEntries, req)
-	c.mu.Unlock()
-	return nil
+	return c.appendErr
 }
 
 func (c *leaseRetryRuntimeControlClient) ShouldCompactBeforeUserMessage(context.Context, serverapi.RuntimeShouldCompactBeforeUserMessageRequest) (serverapi.RuntimeShouldCompactBeforeUserMessageResponse, error) {
@@ -1115,7 +1136,97 @@ func TestRuntimeClientSubmitUserMessageRecoversRuntimeUnavailable(t *testing.T) 
 		t.Fatalf("warning entry count = %d, want 1", len(entries))
 	}
 	entry := entries[0]
-	if entry.ControllerLeaseID != "lease-new" || entry.Role != "warning" || entry.Text != runtimeLeaseRecoveryWarningText {
+	if entry.ControllerLeaseID != "lease-new" || entry.Role != "warning" || entry.Text != runtimeLeaseRecoveryWarningText || entry.Visibility != string(clientui.EntryVisibilityAll) {
 		t.Fatalf("warning entry = %+v, want new lease warning", entry)
+	}
+}
+
+func TestRuntimeClientLeaseRecoveryWarningFailureDoesNotBlockSubmit(t *testing.T) {
+	controls := &leaseRetryRuntimeControlClient{firstSubmitErr: serverapi.ErrRuntimeUnavailable, appendErr: serverapi.ErrRuntimeUnavailable}
+	runtimeClient := newUIRuntimeClientWithReads("session-1", &countingSessionViewClient{}, controls).(*sessionRuntimeClient)
+	warnings := make(chan string, 1)
+	runtimeClient.SetLeaseRecoveryWarningObserver(func(text string) { warnings <- text })
+	leaseManager := newControllerLeaseManager("lease-old")
+	leaseManager.SetRecoverFunc(func(context.Context) (string, error) { return "lease-new", nil })
+	runtimeClient.SetControllerLeaseManager(leaseManager)
+
+	message, err := runtimeClient.SubmitUserMessage(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("SubmitUserMessage: %v", err)
+	}
+	if message != "recovered" {
+		t.Fatalf("SubmitUserMessage message = %q, want recovered", message)
+	}
+	if got := controls.submitLeaseIDs(); !reflect.DeepEqual(got, []string{"lease-old", "lease-new"}) {
+		t.Fatalf("submit lease ids = %+v, want [lease-old lease-new]", got)
+	}
+	if entries := controls.appendedLocalEntries(); len(entries) != 1 {
+		t.Fatalf("warning append attempts = %d, want 1", len(entries))
+	}
+	select {
+	case warning := <-warnings:
+		if warning != runtimeLeaseRecoveryWarningText {
+			t.Fatalf("warning = %q, want lease recovery warning", warning)
+		}
+	default:
+		t.Fatal("expected warning fallback notification")
+	}
+}
+
+func TestRuntimeClientServerRestartFirstPromptRecoversAndWarnsOngoing(t *testing.T) {
+	runtimeEvents := make(chan clientui.Event, 128)
+	store, err := session.Create(t.TempDir(), "workspace-x", t.TempDir())
+	if err != nil {
+		t.Fatalf("create session store: %v", err)
+	}
+	client := &runtimeClientFakeLLM{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done", Phase: llm.MessagePhaseFinal},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	engine, err := runtime.New(store, client, tools.NewRegistry(), runtime.Config{
+		Model: "gpt-5",
+		OnEvent: func(evt runtime.Event) {
+			runtimeEvents <- runtimeview.EventFromRuntime(evt)
+		},
+	})
+	if err != nil {
+		t.Fatalf("create runtime engine: %v", err)
+	}
+	resolver := &mutableRuntimeResolver{}
+	controls := sharedclient.NewLoopbackRuntimeControlClient(runtimecontrol.NewService(resolver, nil))
+	runtimeClient := newUIRuntimeClientWithReads(store.Meta().SessionID, &countingSessionViewClient{}, controls).(*sessionRuntimeClient)
+	leaseManager := newControllerLeaseManager("lease-old")
+	leaseManager.SetRecoverFunc(func(context.Context) (string, error) {
+		resolver.Set(engine)
+		return "lease-new", nil
+	})
+	runtimeClient.SetControllerLeaseManager(leaseManager)
+	model := newProjectedTestUIModel(nil, closedProjectedRuntimeEvents(), closedAskEvents())
+	sized, _ := model.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+	model = sized.(*uiModel)
+
+	message, err := runtimeClient.SubmitUserMessage(context.Background(), "hello after restart")
+	if err != nil {
+		t.Fatalf("submitRuntimeUserMessage: %v", err)
+	}
+	if message != "done" {
+		t.Fatalf("submitRuntimeUserMessage message = %q, want done", message)
+	}
+
+	updated := model
+	eventCount := 0
+	flushText := ""
+	for len(runtimeEvents) > 0 {
+		msg := <-runtimeEvents
+		eventCount++
+		next, cmd := updated.Update(runtimeEventMsg{event: msg})
+		updated = next.(*uiModel)
+		flushText += collectNativeHistoryFlushText(collectCmdMessages(t, cmd))
+	}
+	if !strings.Contains(flushText, runtimeLeaseRecoveryWarningText) {
+		t.Fatalf("expected ongoing warning flush, events=%d entries=%+v flush=%q", eventCount, updated.transcriptEntries, flushText)
+	}
+	if strings.Contains(flushText, "runtime for session") {
+		t.Fatalf("did not expect runtime unavailable error in ongoing flush, got %q", flushText)
 	}
 }

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -952,14 +952,22 @@ func TestRuntimeClientSetFastModeEnabledPreservesCachedMainViewOnError(t *testin
 }
 
 type leaseRetryRuntimeControlClient struct {
-	mu            sync.Mutex
-	submitLeaseID []string
+	mu             sync.Mutex
+	firstSubmitErr error
+	submitLeaseID  []string
+	localEntries   []serverapi.RuntimeAppendLocalEntryRequest
 }
 
 func (c *leaseRetryRuntimeControlClient) submitLeaseIDs() []string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([]string(nil), c.submitLeaseID...)
+}
+
+func (c *leaseRetryRuntimeControlClient) appendedLocalEntries() []serverapi.RuntimeAppendLocalEntryRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]serverapi.RuntimeAppendLocalEntryRequest(nil), c.localEntries...)
 }
 
 func (c *leaseRetryRuntimeControlClient) SetSessionName(context.Context, serverapi.RuntimeSetSessionNameRequest) error {
@@ -982,7 +990,10 @@ func (c *leaseRetryRuntimeControlClient) SetAutoCompactionEnabled(context.Contex
 	return serverapi.RuntimeSetAutoCompactionEnabledResponse{}, nil
 }
 
-func (c *leaseRetryRuntimeControlClient) AppendLocalEntry(context.Context, serverapi.RuntimeAppendLocalEntryRequest) error {
+func (c *leaseRetryRuntimeControlClient) AppendLocalEntry(_ context.Context, req serverapi.RuntimeAppendLocalEntryRequest) error {
+	c.mu.Lock()
+	c.localEntries = append(c.localEntries, req)
+	c.mu.Unlock()
 	return nil
 }
 
@@ -996,6 +1007,9 @@ func (c *leaseRetryRuntimeControlClient) SubmitUserMessage(_ context.Context, re
 	c.submitLeaseID = append(c.submitLeaseID, req.ControllerLeaseID)
 	switch req.ControllerLeaseID {
 	case "lease-old":
+		if c.firstSubmitErr != nil {
+			return serverapi.RuntimeSubmitUserMessageResponse{}, c.firstSubmitErr
+		}
 		return serverapi.RuntimeSubmitUserMessageResponse{}, serverapi.ErrInvalidControllerLease
 	case "lease-new":
 		return serverapi.RuntimeSubmitUserMessageResponse{Message: "recovered"}, nil
@@ -1066,5 +1080,42 @@ func TestRuntimeClientSubmitUserMessageRecoversInvalidControllerLease(t *testing
 	}
 	if got := controls.submitLeaseIDs(); !reflect.DeepEqual(got, []string{"lease-old", "lease-new"}) {
 		t.Fatalf("submit lease ids = %+v, want [lease-old lease-new]", got)
+	}
+}
+
+func TestRuntimeClientSubmitUserMessageRecoversRuntimeUnavailable(t *testing.T) {
+	controls := &leaseRetryRuntimeControlClient{firstSubmitErr: serverapi.ErrRuntimeUnavailable}
+	runtimeClient := newUIRuntimeClientWithReads("session-1", &countingSessionViewClient{}, controls).(*sessionRuntimeClient)
+	leaseManager := newControllerLeaseManager("lease-old")
+	recoveryCalls := 0
+	leaseManager.SetRecoverFunc(func(context.Context) (string, error) {
+		recoveryCalls++
+		return "lease-new", nil
+	})
+	runtimeClient.SetControllerLeaseManager(leaseManager)
+
+	message, err := runtimeClient.SubmitUserMessage(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("SubmitUserMessage: %v", err)
+	}
+	if message != "recovered" {
+		t.Fatalf("SubmitUserMessage message = %q, want recovered", message)
+	}
+	if recoveryCalls != 1 {
+		t.Fatalf("recovery call count = %d, want 1", recoveryCalls)
+	}
+	if got := runtimeClient.controllerLeaseIDValue(); got != "lease-new" {
+		t.Fatalf("controller lease id = %q, want lease-new", got)
+	}
+	if got := controls.submitLeaseIDs(); !reflect.DeepEqual(got, []string{"lease-old", "lease-new"}) {
+		t.Fatalf("submit lease ids = %+v, want [lease-old lease-new]", got)
+	}
+	entries := controls.appendedLocalEntries()
+	if len(entries) != 1 {
+		t.Fatalf("warning entry count = %d, want 1", len(entries))
+	}
+	entry := entries[0]
+	if entry.ControllerLeaseID != "lease-new" || entry.Role != "warning" || entry.Text != runtimeLeaseRecoveryWarningText {
+		t.Fatalf("warning entry = %+v, want new lease warning", entry)
 	}
 }

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -1144,8 +1144,10 @@ func TestRuntimeClientSubmitUserMessageRecoversRuntimeUnavailable(t *testing.T) 
 func TestRuntimeClientLeaseRecoveryWarningFailureDoesNotBlockSubmit(t *testing.T) {
 	controls := &leaseRetryRuntimeControlClient{firstSubmitErr: serverapi.ErrRuntimeUnavailable, appendErr: serverapi.ErrRuntimeUnavailable}
 	runtimeClient := newUIRuntimeClientWithReads("session-1", &countingSessionViewClient{}, controls).(*sessionRuntimeClient)
-	warnings := make(chan string, 1)
-	runtimeClient.SetLeaseRecoveryWarningObserver(func(text string) { warnings <- text })
+	warnings := make(chan runtimeLeaseRecoveryWarningMsg, 1)
+	runtimeClient.SetLeaseRecoveryWarningObserver(func(text string, visibility clientui.EntryVisibility) {
+		warnings <- runtimeLeaseRecoveryWarningMsg{text: text, visibility: visibility}
+	})
 	leaseManager := newControllerLeaseManager("lease-old")
 	leaseManager.SetRecoverFunc(func(context.Context) (string, error) { return "lease-new", nil })
 	runtimeClient.SetControllerLeaseManager(leaseManager)
@@ -1165,8 +1167,8 @@ func TestRuntimeClientLeaseRecoveryWarningFailureDoesNotBlockSubmit(t *testing.T
 	}
 	select {
 	case warning := <-warnings:
-		if warning != runtimeLeaseRecoveryWarningText {
-			t.Fatalf("warning = %q, want lease recovery warning", warning)
+		if warning.text != runtimeLeaseRecoveryWarningText || warning.visibility != clientui.EntryVisibilityAll {
+			t.Fatalf("warning = %+v, want lease recovery warning", warning)
 		}
 	default:
 		t.Fatal("expected warning fallback notification")

--- a/cli/app/ui_runtime_connection.go
+++ b/cli/app/ui_runtime_connection.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"strings"
 
 	"builder/server/llm"
 	"builder/shared/serverapi"
@@ -46,6 +47,26 @@ func enqueueRuntimeConnectionStateChange(ch chan runtimeConnectionStateChangedMs
 		return
 	}
 	msg := runtimeConnectionStateChangedMsg{err: err}
+	select {
+	case ch <- msg:
+		return
+	default:
+	}
+	select {
+	case <-ch:
+	default:
+	}
+	select {
+	case ch <- msg:
+	default:
+	}
+}
+
+func enqueueRuntimeLeaseRecoveryWarning(ch chan runtimeLeaseRecoveryWarningMsg, text string) {
+	if ch == nil || strings.TrimSpace(text) == "" {
+		return
+	}
+	msg := runtimeLeaseRecoveryWarningMsg{text: strings.TrimSpace(text)}
 	select {
 	case ch <- msg:
 		return

--- a/cli/app/ui_runtime_connection.go
+++ b/cli/app/ui_runtime_connection.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"builder/server/llm"
+	"builder/shared/clientui"
 	"builder/shared/serverapi"
 )
 
@@ -62,11 +63,11 @@ func enqueueRuntimeConnectionStateChange(ch chan runtimeConnectionStateChangedMs
 	}
 }
 
-func enqueueRuntimeLeaseRecoveryWarning(ch chan runtimeLeaseRecoveryWarningMsg, text string) {
+func enqueueRuntimeLeaseRecoveryWarning(ch chan runtimeLeaseRecoveryWarningMsg, text string, visibility clientui.EntryVisibility) {
 	if ch == nil || strings.TrimSpace(text) == "" {
 		return
 	}
-	msg := runtimeLeaseRecoveryWarningMsg{text: strings.TrimSpace(text)}
+	msg := runtimeLeaseRecoveryWarningMsg{text: strings.TrimSpace(text), visibility: visibility}
 	select {
 	case ch <- msg:
 		return

--- a/cli/app/ui_status.go
+++ b/cli/app/ui_status.go
@@ -42,6 +42,7 @@ type uiStatusConfig struct {
 	Settings        config.Settings
 	Source          config.SourceReport
 	AuthManager     *auth.Manager
+	AuthStatus      client.AuthStatusClient
 	AuthStatePath   string
 	OwnsServer      bool
 }
@@ -74,6 +75,7 @@ type uiStatusRequest struct {
 	Settings              config.Settings
 	Source                config.SourceReport
 	AuthManager           *auth.Manager
+	AuthStatus            client.AuthStatusClient
 	AuthStatePath         string
 	SessionName           string
 	SessionID             string
@@ -114,6 +116,7 @@ type uiStatusSnapshot struct {
 type uiStatusAuthInfo struct {
 	Summary string
 	Details []string
+	Visible bool
 }
 
 type uiStatusGitInfo struct {
@@ -147,6 +150,7 @@ type uiStatusConfigInfo struct {
 type uiStatusSubscriptionInfo struct {
 	Applicable bool
 	Summary    string
+	Error      string
 	Windows    []uiStatusSubscriptionWindow
 }
 
@@ -267,6 +271,7 @@ func (m *uiModel) newStatusRequest(now time.Time) uiStatusRequest {
 		Settings:              m.statusConfig.Settings,
 		Source:                m.statusConfig.Source,
 		AuthManager:           m.statusConfig.AuthManager,
+		AuthStatus:            m.statusConfig.AuthStatus,
 		AuthStatePath:         strings.TrimSpace(m.statusConfig.AuthStatePath),
 		SessionName:           strings.TrimSpace(m.sessionName),
 		SessionID:             strings.TrimSpace(m.sessionID),
@@ -388,6 +393,31 @@ func statusParentSessionName(ctx context.Context, sessionViews client.SessionVie
 }
 
 func (defaultUIStatusCollector) CollectAuth(ctx context.Context, req uiStatusRequest, _ uiStatusSnapshot) uiStatusAuthStageResult {
+	if req.AuthStatus != nil {
+		resp, err := req.AuthStatus.GetAuthStatus(ctx, serverapi.AuthStatusRequest{Settings: req.Settings})
+		if err != nil {
+			errText := err.Error()
+			return uiStatusAuthStageResult{
+				Auth:         uiStatusAuthInfo{Summary: "Auth unavailable", Details: []string{errText}, Visible: true},
+				Subscription: uiStatusSubscriptionInfo{Applicable: true, Summary: "Subscription unavailable: " + errText, Error: errText},
+				Warning:      "auth: " + errText,
+			}
+		}
+		return uiStatusAuthStageResult{
+			Auth: uiStatusAuthInfo{
+				Summary: strings.TrimSpace(resp.Auth.Summary),
+				Details: append([]string(nil), resp.Auth.Details...),
+				Visible: resp.Auth.Visible,
+			},
+			Subscription: uiStatusSubscriptionInfo{
+				Applicable: resp.Subscription.Applicable,
+				Summary:    strings.TrimSpace(resp.Subscription.Summary),
+				Error:      strings.TrimSpace(resp.Subscription.Error),
+				Windows:    statusSubscriptionWindowsFromAPI(resp.Subscription.Windows),
+			},
+			Warning: strings.TrimSpace(resp.Warning),
+		}
+	}
 	state := auth.EmptyState()
 	authStateErr := error(nil)
 	if req.AuthManager != nil {
@@ -577,15 +607,33 @@ func collectSubscriptionStatus(ctx context.Context, req uiStatusRequest, state a
 		return uiStatusSubscriptionInfo{}
 	}
 	if authStateErr != nil {
-		return uiStatusSubscriptionInfo{Applicable: true, Summary: "Subscription unavailable: " + authStateErr.Error()}
+		errText := authStateErr.Error()
+		return uiStatusSubscriptionInfo{Applicable: true, Summary: "Subscription unavailable: " + errText, Error: errText}
 	}
 	payload, err := statusUsagePayloadFetcher(ctx, statusUsageBaseURL, state)
 	if err != nil {
-		return uiStatusSubscriptionInfo{Applicable: true, Summary: "Subscription unavailable: " + err.Error()}
+		errText := err.Error()
+		return uiStatusSubscriptionInfo{Applicable: true, Summary: "Subscription unavailable: " + errText, Error: errText}
 	}
 	windows := statusUsageWindowsByLabel(payload)
 	summary := statusSubscriptionPlanSummary(payload.PlanType)
 	return uiStatusSubscriptionInfo{Applicable: true, Summary: summary, Windows: windows}
+}
+
+func statusSubscriptionWindowsFromAPI(windows []serverapi.AuthSubscriptionWindow) []uiStatusSubscriptionWindow {
+	if len(windows) == 0 {
+		return nil
+	}
+	result := make([]uiStatusSubscriptionWindow, 0, len(windows))
+	for _, window := range windows {
+		result = append(result, uiStatusSubscriptionWindow{
+			Label:       strings.TrimSpace(window.Label),
+			Qualifier:   strings.TrimSpace(window.Qualifier),
+			UsedPercent: window.UsedPercent,
+			ResetAt:     window.ResetAt,
+		})
+	}
+	return result
 }
 
 func statusShouldFetchSubscriptionUsage(settings config.Settings, state auth.State) bool {
@@ -745,7 +793,7 @@ func statusLimitDuration(windowMinutes int) string {
 
 func statusAuthInfo(state auth.State, settings config.Settings, statusErr error) uiStatusAuthInfo {
 	if statusErr != nil && !state.IsConfigured() {
-		return uiStatusAuthInfo{Summary: "Auth unavailable", Details: []string{statusErr.Error()}}
+		return uiStatusAuthInfo{Summary: "Auth unavailable", Details: []string{statusErr.Error()}, Visible: true}
 	}
 	details := make([]string, 0, 2)
 	baseURL := strings.TrimSpace(settings.OpenAIBaseURL)
@@ -761,7 +809,7 @@ func statusAuthInfo(state auth.State, settings config.Settings, statusErr error)
 		if statusErr != nil {
 			details = append(details, statusErr.Error())
 		}
-		return uiStatusAuthInfo{Summary: summary, Details: details}
+		return uiStatusAuthInfo{Summary: summary, Details: details, Visible: true}
 	case auth.MethodAPIKey:
 		summary := "API key"
 		if provider := statusProviderLabel(state, settings); provider != "" {
@@ -773,12 +821,12 @@ func statusAuthInfo(state auth.State, settings config.Settings, statusErr error)
 		if statusErr != nil {
 			details = append(details, statusErr.Error())
 		}
-		return uiStatusAuthInfo{Summary: summary, Details: details}
+		return uiStatusAuthInfo{Summary: summary, Details: details, Visible: true}
 	default:
 		if statusErr != nil {
-			return uiStatusAuthInfo{Summary: "Not configured", Details: []string{statusErr.Error()}}
+			return uiStatusAuthInfo{Summary: "Auth unavailable", Details: []string{statusErr.Error()}, Visible: true}
 		}
-		return uiStatusAuthInfo{Summary: "Not configured"}
+		return uiStatusAuthInfo{}
 	}
 }
 

--- a/cli/app/ui_status_test.go
+++ b/cli/app/ui_status_test.go
@@ -973,11 +973,75 @@ func TestStatusRefreshCmdSchedulesBaseEnrichmentForProgressiveCollector(t *testi
 }
 
 func TestStatusVisibleAuthSummarySuppressesGenericSubscriptionWhenPlanPresent(t *testing.T) {
-	if got := statusVisibleAuthSummary(uiStatusAuthInfo{Summary: "Subscription"}, uiStatusSubscriptionInfo{Summary: "Pro subscription"}); got != "" {
+	if got := statusVisibleAuthSummary(uiStatusAuthInfo{Summary: "Subscription", Visible: true}, uiStatusSubscriptionInfo{Summary: "Pro subscription"}); got != "" {
 		t.Fatalf("visible auth summary = %q", got)
 	}
-	if got := statusVisibleAuthSummary(uiStatusAuthInfo{Summary: "user@example.com"}, uiStatusSubscriptionInfo{Summary: "Pro subscription"}); got != "user@example.com" {
+	if got := statusVisibleAuthSummary(uiStatusAuthInfo{Summary: "user@example.com", Visible: true}, uiStatusSubscriptionInfo{Summary: "Pro subscription"}); got != "user@example.com" {
 		t.Fatalf("visible auth summary = %q", got)
+	}
+	if got := statusVisibleAuthSummary(uiStatusAuthInfo{Summary: "Not configured"}, uiStatusSubscriptionInfo{Summary: "Pro subscription"}); got != "" {
+		t.Fatalf("visible auth summary = %q", got)
+	}
+}
+
+func TestStatusOverlayRendersSubscriptionWithoutNotConfiguredAccount(t *testing.T) {
+	collector := &stubStatusCollector{snapshot: uiStatusSnapshot{
+		CollectedAt: time.Date(2026, time.March, 24, 21, 15, 0, 0, time.UTC),
+		Auth:        uiStatusAuthInfo{},
+		Subscription: uiStatusSubscriptionInfo{
+			Applicable: true,
+			Summary:    "Pro subscription",
+			Windows: []uiStatusSubscriptionWindow{
+				{Label: "5h", UsedPercent: 20},
+			},
+		},
+	}}
+
+	m := newProjectedStaticUIModel(
+		WithUIStatusConfig(uiStatusConfig{WorkspaceRoot: "/tmp/workdir"}),
+		WithUIStatusCollector(collector),
+	)
+	m.termWidth = 100
+	m.termHeight = 20
+	m.windowSizeKnown = true
+	m.input = "/status"
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	next, _ = updated.Update(statusRefreshDoneMsg{token: testStatusRefreshToken(updated), snapshot: collector.snapshot})
+	plain := stripANSIAndTrimRight(next.(*uiModel).View())
+	if !strings.Contains(plain, "Subscription") || !strings.Contains(plain, "Pro subscription") {
+		t.Fatalf("expected subscription section, got %q", plain)
+	}
+	if !strings.Contains(plain, "5h") || !strings.Contains(plain, "80% left") {
+		t.Fatalf("expected subscription limit rows, got %q", plain)
+	}
+	if strings.Contains(plain, "Not configured") || strings.Contains(plain, "Account") {
+		t.Fatalf("did not expect empty account state, got %q", plain)
+	}
+}
+
+func TestStatusOverlayOmitsEmptyAccountSection(t *testing.T) {
+	collector := &stubStatusCollector{snapshot: uiStatusSnapshot{
+		CollectedAt: time.Date(2026, time.March, 24, 21, 15, 0, 0, time.UTC),
+		Auth:        uiStatusAuthInfo{},
+	}}
+
+	m := newProjectedStaticUIModel(
+		WithUIStatusConfig(uiStatusConfig{WorkspaceRoot: "/tmp/workdir"}),
+		WithUIStatusCollector(collector),
+	)
+	m.termWidth = 100
+	m.termHeight = 20
+	m.windowSizeKnown = true
+	m.input = "/status"
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	next, _ = updated.Update(statusRefreshDoneMsg{token: testStatusRefreshToken(updated), snapshot: collector.snapshot})
+	plain := stripANSIAndTrimRight(next.(*uiModel).View())
+	if strings.Contains(plain, "Not configured") || strings.Contains(plain, "Account") {
+		t.Fatalf("did not expect empty account section, got %q", plain)
 	}
 }
 

--- a/cli/app/ui_test.go
+++ b/cli/app/ui_test.go
@@ -6050,7 +6050,7 @@ func TestBusySlashSupervisorOnAppliesToInFlightRunCompletion(t *testing.T) {
 	mainClient := &busyToggleFakeClient{responses: []llm.Response{
 		{
 			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "working", Phase: llm.MessagePhaseCommentary},
-			ToolCalls: []llm.ToolCall{{ID: "call_patch_1", Name: string(toolspec.ToolPatch), Input: json.RawMessage(`{"patch":"*** Begin Patch\n*** Add File: a.txt\n+hello\n*** End Patch"}`)}},
+			ToolCalls: []llm.ToolCall{{ID: "call_patch_1", Name: string(toolspec.ToolPatch), Custom: true, CustomInput: "*** Begin Patch\n*** Add File: a.txt\n+hello\n*** End Patch"}},
 			Usage:     llm.Usage{WindowTokens: 200000},
 		},
 		{

--- a/cli/app/ui_worktree_commands.go
+++ b/cli/app/ui_worktree_commands.go
@@ -80,7 +80,7 @@ func (c uiInputController) handleWorktreeSwitchCommand(token string) (tea.Model,
 	return m, tea.Batch(c.showSuccessStatus(status), m.requestRuntimeMainViewRefresh())
 }
 
-func (m *uiModel) listWorktreesForCurrentSession() (serverapi.WorktreeListResponse, error) {
+func (m *uiModel) listWorktreesForCurrentSession(includeDirtyCount bool) (serverapi.WorktreeListResponse, error) {
 	if m == nil || m.worktreeClient == nil {
 		return serverapi.WorktreeListResponse{}, fmt.Errorf("worktree client is unavailable")
 	}
@@ -90,11 +90,11 @@ func (m *uiModel) listWorktreesForCurrentSession() (serverapi.WorktreeListRespon
 	}
 	ctx, cancel := client.controlContext()
 	defer cancel()
-	return m.worktreeClient.ListWorktrees(ctx, serverapi.WorktreeListRequest{SessionID: m.sessionID, ControllerLeaseID: client.controllerLeaseIDValue()})
+	return m.worktreeClient.ListWorktrees(ctx, serverapi.WorktreeListRequest{SessionID: m.sessionID, ControllerLeaseID: client.controllerLeaseIDValue(), IncludeDirtyCount: includeDirtyCount})
 }
 
 func (m *uiModel) resolveWorktreeToken(token string) (serverapi.WorktreeView, error) {
-	resp, err := m.listWorktreesForCurrentSession()
+	resp, err := m.listWorktreesForCurrentSession(false)
 	if err != nil {
 		return serverapi.WorktreeView{}, err
 	}

--- a/cli/app/ui_worktree_commands.go
+++ b/cli/app/ui_worktree_commands.go
@@ -149,14 +149,6 @@ func worktreeUsage() string {
 	return "Usage: /wt | /wt status | /wt create | /wt new | /wt delete [target] | /wt remove [target] | /wt rm [target] | /wt switch <target>"
 }
 
-func formatWorktreeDelete(resp serverapi.WorktreeDeleteResponse) string {
-	message := fmt.Sprintf("Deleted %s\nCurrent workdir: %s", worktreeDisplayName(resp.Worktree), resp.Target.EffectiveWorkdir)
-	if details := strings.TrimSpace(resp.BranchCleanupMessage); details != "" {
-		message += "\n" + details
-	}
-	return message
-}
-
 func worktreeDisplayName(item serverapi.WorktreeView) string {
 	if trimmed := strings.TrimSpace(item.DisplayName); trimmed != "" {
 		return trimmed

--- a/cli/app/ui_worktree_commands_test.go
+++ b/cli/app/ui_worktree_commands_test.go
@@ -995,6 +995,22 @@ func TestWorktreeDeleteDialogPreviewWarnsAboutDirtyFiles(t *testing.T) {
 	}
 }
 
+func TestWorktreeDeleteDialogPreviewWarnsWhenDirtyCountUnavailable(t *testing.T) {
+	resp := testLinkedWorktreeListResponse()
+	resp.Worktrees[1].DirtyFileCount = -1
+	client := &worktreeCommandTestClient{listResp: resp}
+	m := newWorktreeTestModel(t, client)
+	m.input = "/worktree delete"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := applyWorktreeCmdMessages(t, next.(*uiModel), cmd)
+
+	plain := stripANSIAndTrimRight(updated.View())
+	if !strings.Contains(plain, "• Dirty file count unavailable; delete will force removal") {
+		t.Fatalf("expected unknown dirty file warning, got %q", plain)
+	}
+}
+
 func TestWorktreeSwitchCommandRemainsDirectShortcut(t *testing.T) {
 	client := &worktreeCommandTestClient{
 		listResp: testLinkedWorktreeListResponse(),

--- a/cli/app/ui_worktree_commands_test.go
+++ b/cli/app/ui_worktree_commands_test.go
@@ -1174,6 +1174,25 @@ func TestWorktreeDeleteDoneAppliesTargetAfterOverlayCloses(t *testing.T) {
 	}
 }
 
+func TestWorktreeDeleteDoneShowsBranchCleanupOutcome(t *testing.T) {
+	m := newWorktreeTestModel(t, &worktreeCommandTestClient{})
+	m.worktrees.mutationToken = 9
+
+	next, _ := m.Update(worktreeDeleteDoneMsg{
+		token: 9,
+		resp: serverapi.WorktreeDeleteResponse{
+			Target:               clientui.SessionExecutionTarget{EffectiveWorkdir: "/repo"},
+			Worktree:             serverapi.WorktreeView{WorktreeID: "wt-feature", DisplayName: "feature-a", CanonicalRoot: "/wt/feature-a"},
+			BranchCleanupMessage: "Kept branch feature-a: Builder cannot prove this worktree created it",
+		},
+	})
+	updated := next.(*uiModel)
+
+	if !strings.Contains(updated.transientStatus, "Deleted worktree feature-a") || !strings.Contains(updated.transientStatus, "Kept branch feature-a") {
+		t.Fatalf("transient status = %q, want delete and branch cleanup outcome", updated.transientStatus)
+	}
+}
+
 func TestWorktreeOverlayEnterSwitchesSelectedItemAndCloses(t *testing.T) {
 	resp := testMainWorktreeListResponse()
 	resp.Worktrees = append(resp.Worktrees, serverapi.WorktreeView{WorktreeID: "wt-feature", DisplayName: "feature-a", CanonicalRoot: "/wt/feature-a", BranchName: "feature/a"})

--- a/cli/app/ui_worktree_commands_test.go
+++ b/cli/app/ui_worktree_commands_test.go
@@ -911,8 +911,68 @@ func TestWorktreeDeleteCommandOpensDeleteDialogInOverlay(t *testing.T) {
 		t.Fatalf("delete target = %+v", updated.worktrees.deleteConfirm.target)
 	}
 	plain := stripANSIAndTrimRight(updated.View())
-	if !strings.Contains(plain, "Delete worktree") || !strings.Contains(plain, "feature-a") {
+	if !strings.Contains(plain, "Delete feature-a?") {
 		t.Fatalf("expected delete dialog render, got %q", plain)
+	}
+	for _, want := range []string{"Will delete:", "• Workspace folder at /wt/feature-a", "• Git worktree feature-a"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("expected delete preview line %q, got %q", want, plain)
+		}
+	}
+	if strings.Contains(plain, "Local branch feature/a") {
+		t.Fatalf("did not expect branch preview before explicit branch delete action, got %q", plain)
+	}
+	for _, removed := range []string{"Delete worktree", "Delete feature-a?\n\nDelete feature-a?", "Branch cleanup target", "Branch cleanup needs explicit confirmation", "Esc back | Left/Right choose action | Enter confirm"} {
+		if strings.Contains(plain, removed) {
+			t.Fatalf("did not expect removed delete dialog copy %q, got %q", removed, plain)
+		}
+	}
+}
+
+func TestWorktreeDeleteDialogBranchPreviewFollowsSelectedAction(t *testing.T) {
+	client := &worktreeCommandTestClient{listResp: testLinkedWorktreeListResponse()}
+	m := newWorktreeTestModel(t, client)
+	m.input = "/worktree delete"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := applyWorktreeCmdMessages(t, next.(*uiModel), cmd)
+	plain := stripANSIAndTrimRight(updated.View())
+	if strings.Contains(plain, "• Local branch feature/a") {
+		t.Fatalf("did not expect branch preview for plain delete action, got %q", plain)
+	}
+
+	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRight})
+	updated = next.(*uiModel)
+	plain = stripANSIAndTrimRight(updated.View())
+	if !strings.Contains(plain, "• Local branch feature/a") {
+		t.Fatalf("expected branch preview for delete branch action, got %q", plain)
+	}
+
+	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	updated = next.(*uiModel)
+	plain = stripANSIAndTrimRight(updated.View())
+	if strings.Contains(plain, "• Local branch feature/a") {
+		t.Fatalf("did not expect branch preview after returning to plain delete action, got %q", plain)
+	}
+}
+
+func TestWorktreeDeleteDialogPreviewOmitsBranchWhenActionKeepsBranch(t *testing.T) {
+	resp := testLinkedWorktreeListResponse()
+	resp.Worktrees[1].BuilderManaged = false
+	resp.Worktrees[1].CreatedBranch = false
+	client := &worktreeCommandTestClient{listResp: resp}
+	m := newWorktreeTestModel(t, client)
+	m.input = "/worktree delete"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := applyWorktreeCmdMessages(t, next.(*uiModel), cmd)
+
+	plain := stripANSIAndTrimRight(updated.View())
+	if strings.Contains(plain, "Local branch feature/a") {
+		t.Fatalf("did not expect branch preview before explicit branch delete action, got %q", plain)
+	}
+	if !strings.Contains(plain, "• Workspace folder at /wt/feature-a") || !strings.Contains(plain, "• Git worktree feature-a") {
+		t.Fatalf("expected non-branch delete preview, got %q", plain)
 	}
 }
 

--- a/cli/app/ui_worktree_commands_test.go
+++ b/cli/app/ui_worktree_commands_test.go
@@ -976,6 +976,22 @@ func TestWorktreeDeleteDialogPreviewOmitsBranchWhenActionKeepsBranch(t *testing.
 	}
 }
 
+func TestWorktreeDeleteDialogPreviewWarnsAboutDirtyFiles(t *testing.T) {
+	resp := testLinkedWorktreeListResponse()
+	resp.Worktrees[1].DirtyFileCount = 2
+	client := &worktreeCommandTestClient{listResp: resp}
+	m := newWorktreeTestModel(t, client)
+	m.input = "/worktree delete"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := applyWorktreeCmdMessages(t, next.(*uiModel), cmd)
+
+	plain := stripANSIAndTrimRight(updated.View())
+	if !strings.Contains(plain, "• Drop 2 modified/untracked files") {
+		t.Fatalf("expected dirty file warning, got %q", plain)
+	}
+}
+
 func TestWorktreeSwitchCommandRemainsDirectShortcut(t *testing.T) {
 	client := &worktreeCommandTestClient{
 		listResp: testLinkedWorktreeListResponse(),

--- a/cli/app/ui_worktree_commands_test.go
+++ b/cli/app/ui_worktree_commands_test.go
@@ -270,7 +270,7 @@ func TestListWorktreesForCurrentSessionUsesBoundedControlContext(t *testing.T) {
 	client := &worktreeCommandTestClient{listResp: testMainWorktreeListResponse()}
 	m := newWorktreeTestModel(t, client)
 
-	if _, err := m.listWorktreesForCurrentSession(); err != nil {
+	if _, err := m.listWorktreesForCurrentSession(false); err != nil {
 		t.Fatalf("listWorktreesForCurrentSession: %v", err)
 	}
 	if client.listCtx == nil {
@@ -910,6 +910,9 @@ func TestWorktreeDeleteCommandOpensDeleteDialogInOverlay(t *testing.T) {
 	if updated.worktrees.deleteConfirm.target.WorktreeID != "wt-feature" {
 		t.Fatalf("delete target = %+v", updated.worktrees.deleteConfirm.target)
 	}
+	if len(client.listRequests) == 0 || !client.listRequests[0].IncludeDirtyCount {
+		t.Fatalf("expected delete command list request to include dirty count, got %+v", client.listRequests)
+	}
 	plain := stripANSIAndTrimRight(updated.View())
 	if !strings.Contains(plain, "Delete feature-a?") {
 		t.Fatalf("expected delete dialog render, got %q", plain)
@@ -1301,11 +1304,14 @@ func TestWorktreeDeleteBranchHotkeyPrefersBranchDeleteAction(t *testing.T) {
 	updated = next.(*uiModel)
 	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyDown})
 	updated = next.(*uiModel)
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
-	updated = next.(*uiModel)
+	next, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	updated = applyWorktreeCmdMessages(t, next.(*uiModel), cmd)
 
 	if updated.worktrees.phase != uiWorktreeOverlayPhaseDeleteConfirm {
 		t.Fatalf("phase = %q, want delete_confirm", updated.worktrees.phase)
+	}
+	if len(client.listRequests) < 2 || !client.listRequests[1].IncludeDirtyCount {
+		t.Fatalf("expected delete hotkey refresh to include dirty count, got %+v", client.listRequests)
 	}
 	if updated.worktrees.deleteConfirm.selectedAction != uiWorktreeDeleteActionDeleteBranch {
 		t.Fatalf("selected action = %v, want delete branch", updated.worktrees.deleteConfirm.selectedAction)

--- a/cli/app/ui_worktrees.go
+++ b/cli/app/ui_worktrees.go
@@ -1420,7 +1420,9 @@ func worktreeDeletePreviewLines(dialog uiWorktreeDeleteDialogState) []worktreeDe
 		items = append(items, worktreeDeletePreviewLine{kind: worktreeDeletePreviewLineKindBullet, text: "• Workspace folder at " + root})
 	}
 	items = append(items, worktreeDeletePreviewLine{kind: worktreeDeletePreviewLineKindBullet, text: "• Git worktree " + worktreeDisplayName(target)})
-	if target.DirtyFileCount > 0 {
+	if target.DirtyFileCount < 0 {
+		items = append(items, worktreeDeletePreviewLine{kind: worktreeDeletePreviewLineKindWarning, text: "• Dirty file count unavailable; delete will force removal"})
+	} else if target.DirtyFileCount > 0 {
 		items = append(items, worktreeDeletePreviewLine{kind: worktreeDeletePreviewLineKindWarning, text: "• Drop " + pluralizeCount(target.DirtyFileCount, "modified/untracked file")})
 	}
 	if len(items) == 0 {

--- a/cli/app/ui_worktrees.go
+++ b/cli/app/ui_worktrees.go
@@ -386,10 +386,11 @@ func (m *uiModel) requestWorktreeListCmd() tea.Cmd {
 	}
 	m.worktrees.refreshToken++
 	token := m.worktrees.refreshToken
+	includeDirtyCount := m.worktrees.intent.OpenDelete || m.worktrees.phase == uiWorktreeOverlayPhaseDeleteConfirm
 	m.worktrees.loading = true
 	m.worktrees.errorText = ""
 	return func() tea.Msg {
-		resp, err := m.listWorktreesForCurrentSession()
+		resp, err := m.listWorktreesForCurrentSession(includeDirtyCount)
 		return worktreeListDoneMsg{token: token, resp: resp, err: err}
 	}
 }
@@ -860,8 +861,8 @@ func (c uiInputController) handleWorktreeOverlayKey(msg tea.KeyMsg) (tea.Model, 
 		if target.IsMain {
 			return m, c.showErrorStatus("Main workspace is not deletable")
 		}
-		m.openDeleteWorktreeDialog(target, false)
-		return m, nil
+		m.worktrees.intent = uiWorktreeOpenIntent{OpenDelete: true, ConfirmDeleteTarget: target.WorktreeID}
+		return m, tea.Batch(m.requestWorktreeListCmd(), m.ensureSpinnerTicking())
 	case "x":
 		target, ok := m.selectedWorktreeRow()
 		if !ok {
@@ -870,8 +871,8 @@ func (c uiInputController) handleWorktreeOverlayKey(msg tea.KeyMsg) (tea.Model, 
 		if target.IsMain {
 			return m, c.showErrorStatus("Main workspace is not deletable")
 		}
-		m.openDeleteWorktreeDialog(target, true)
-		return m, nil
+		m.worktrees.intent = uiWorktreeOpenIntent{OpenDelete: true, ConfirmDeleteTarget: target.WorktreeID, PreferDeleteBranch: true}
+		return m, tea.Batch(m.requestWorktreeListCmd(), m.ensureSpinnerTicking())
 	case "enter":
 		if m.worktrees.selection == 0 {
 			return m, m.openCreateWorktreeDialog()

--- a/cli/app/ui_worktrees.go
+++ b/cli/app/ui_worktrees.go
@@ -1339,8 +1339,11 @@ func (l uiViewLayout) renderWorktreeDeleteDialog(width, height int, style uiStyl
 	body := worktreeDeletePreviewLines(dialog)
 	for _, line := range body {
 		lineStyle := style.chat
-		if line.kind == worktreeDeletePreviewLineKindHeader {
+		switch line.kind {
+		case worktreeDeletePreviewLineKindHeader:
 			lineStyle = lineStyle.Bold(true)
+		case worktreeDeletePreviewLineKindWarning:
+			lineStyle = lineStyle.Foreground(statusRedColor()).Bold(true)
 		}
 		lines = append(lines, lineStyle.Render(truncateQueuedMessageLine(line.text, width)))
 	}
@@ -1398,6 +1401,7 @@ type worktreeDeletePreviewLineKind uint8
 const (
 	worktreeDeletePreviewLineKindHeader worktreeDeletePreviewLineKind = iota
 	worktreeDeletePreviewLineKindBullet
+	worktreeDeletePreviewLineKindWarning
 )
 
 type worktreeDeletePreviewLine struct {
@@ -1407,7 +1411,7 @@ type worktreeDeletePreviewLine struct {
 
 func worktreeDeletePreviewLines(dialog uiWorktreeDeleteDialogState) []worktreeDeletePreviewLine {
 	target := dialog.target
-	items := make([]worktreeDeletePreviewLine, 0, 4)
+	items := make([]worktreeDeletePreviewLine, 0, 5)
 	if worktreeDeleteWillDeleteBranch(dialog) {
 		items = append(items, worktreeDeletePreviewLine{kind: worktreeDeletePreviewLineKindBullet, text: "• Local branch " + strings.TrimSpace(target.BranchName)})
 	}
@@ -1415,10 +1419,20 @@ func worktreeDeletePreviewLines(dialog uiWorktreeDeleteDialogState) []worktreeDe
 		items = append(items, worktreeDeletePreviewLine{kind: worktreeDeletePreviewLineKindBullet, text: "• Workspace folder at " + root})
 	}
 	items = append(items, worktreeDeletePreviewLine{kind: worktreeDeletePreviewLineKindBullet, text: "• Git worktree " + worktreeDisplayName(target)})
+	if target.DirtyFileCount > 0 {
+		items = append(items, worktreeDeletePreviewLine{kind: worktreeDeletePreviewLineKindWarning, text: "• Drop " + pluralizeCount(target.DirtyFileCount, "modified/untracked file")})
+	}
 	if len(items) == 0 {
 		return nil
 	}
 	return append([]worktreeDeletePreviewLine{{kind: worktreeDeletePreviewLineKindHeader, text: "Will delete:"}}, items...)
+}
+
+func pluralizeCount(count int, singular string) string {
+	if count == 1 {
+		return fmt.Sprintf("%d %s", count, singular)
+	}
+	return fmt.Sprintf("%d %ss", count, singular)
 }
 
 func worktreeDeleteWillDeleteBranch(dialog uiWorktreeDeleteDialogState) bool {

--- a/cli/app/ui_worktrees.go
+++ b/cli/app/ui_worktrees.go
@@ -1333,16 +1333,16 @@ func (l uiViewLayout) renderWorktreeDeleteDialog(width, height int, style uiStyl
 	m := l.model
 	dialog := m.worktrees.deleteConfirm
 	lines := []string{
-		style.brand.Render(truncateQueuedMessageLine("Worktrees", width)),
-		style.meta.Render(truncateQueuedMessageLine("Delete worktree", width)),
-		"",
-		style.chat.Render(truncateQueuedMessageLine("Delete "+worktreeDisplayName(dialog.target)+"?", width)),
-		style.meta.Render(truncateQueuedMessageLine(strings.TrimSpace(dialog.target.CanonicalRoot), width)),
+		style.brand.Render(truncateQueuedMessageLine("Delete "+worktreeDisplayName(dialog.target)+"?", width)),
 		"",
 	}
-	body := worktreeDeleteBodyLines(dialog.target)
+	body := worktreeDeletePreviewLines(dialog)
 	for _, line := range body {
-		lines = append(lines, style.meta.Render(truncateQueuedMessageLine(line, width)))
+		lineStyle := style.chat
+		if line.kind == worktreeDeletePreviewLineKindHeader {
+			lineStyle = lineStyle.Bold(true)
+		}
+		lines = append(lines, lineStyle.Render(truncateQueuedMessageLine(line.text, width)))
 	}
 	lines = append(lines, "", renderWorktreeDeleteButtons(width, l.model.theme, dialog))
 	if dialog.submitting {
@@ -1352,7 +1352,6 @@ func (l uiViewLayout) renderWorktreeDeleteDialog(width, height int, style uiStyl
 		lines = append(lines, "")
 		lines = append(lines, renderWorktreeErrorLines(trimmed, width, lipgloss.NewStyle().Foreground(statusRedColor()).Bold(true), worktreeOverlayMaxErrorLines)...)
 	}
-	lines = append(lines, "", style.meta.Render(truncateQueuedMessageLine("Esc back | Left/Right choose action | Enter confirm", width)))
 	return l.renderWorktreeDialogLines(lines, width, height, style)
 }
 
@@ -1394,21 +1393,39 @@ func appendOverflowEllipsis(line string, width int) string {
 	return trimmed + "…"
 }
 
-func worktreeDeleteBodyLines(target serverapi.WorktreeView) []string {
-	lines := []string{}
-	if target.Detached {
-		lines = append(lines, "Branch cleanup target: detached")
-	} else if branch := strings.TrimSpace(target.BranchName); branch != "" {
-		lines = append(lines, "Branch cleanup target: "+branch)
+type worktreeDeletePreviewLineKind uint8
+
+const (
+	worktreeDeletePreviewLineKindHeader worktreeDeletePreviewLineKind = iota
+	worktreeDeletePreviewLineKindBullet
+)
+
+type worktreeDeletePreviewLine struct {
+	kind worktreeDeletePreviewLineKind
+	text string
+}
+
+func worktreeDeletePreviewLines(dialog uiWorktreeDeleteDialogState) []worktreeDeletePreviewLine {
+	target := dialog.target
+	items := make([]worktreeDeletePreviewLine, 0, 4)
+	if worktreeDeleteWillDeleteBranch(dialog) {
+		items = append(items, worktreeDeletePreviewLine{kind: worktreeDeletePreviewLineKindBullet, text: "• Local branch " + strings.TrimSpace(target.BranchName)})
 	}
-	if worktreeDeleteCanAutoDeleteBranch(target) {
-		lines = append(lines, "Builder can safely attempt branch cleanup for this worktree.")
-	} else if strings.TrimSpace(target.BranchName) != "" {
-		lines = append(lines, "Branch cleanup needs explicit confirmation for this worktree.")
-	} else {
-		lines = append(lines, "This removes the filesystem worktree.")
+	if root := strings.TrimSpace(target.CanonicalRoot); root != "" {
+		items = append(items, worktreeDeletePreviewLine{kind: worktreeDeletePreviewLineKindBullet, text: "• Workspace folder at " + root})
 	}
-	return lines
+	items = append(items, worktreeDeletePreviewLine{kind: worktreeDeletePreviewLineKindBullet, text: "• Git worktree " + worktreeDisplayName(target)})
+	if len(items) == 0 {
+		return nil
+	}
+	return append([]worktreeDeletePreviewLine{{kind: worktreeDeletePreviewLineKindHeader, text: "Will delete:"}}, items...)
+}
+
+func worktreeDeleteWillDeleteBranch(dialog uiWorktreeDeleteDialogState) bool {
+	if strings.TrimSpace(dialog.target.BranchName) == "" {
+		return false
+	}
+	return dialog.selectedAction == uiWorktreeDeleteActionDeleteBranch
 }
 
 func renderWorktreeDeleteButtons(width int, theme string, dialog uiWorktreeDeleteDialogState) string {

--- a/cli/builder/help.go
+++ b/cli/builder/help.go
@@ -84,7 +84,7 @@ func writeRunUsage(fs *flag.FlagSet) {
 		"  builder run \"summarize the unstaged changes\"",
 		"  builder run --continue <session-id> \"follow-up\"",
 		"  builder run --fast --output-mode=json \"scan the repo and return JSON\"",
-		"  builder run --workspace ../other-checkout --model gpt-5.4-mini \"review this module\"",
+		"  builder run --model gpt-5.4-mini \"review this module\"",
 	)
 	writeHelpSection(out, "Flags:")
 	fs.PrintDefaults()
@@ -218,29 +218,13 @@ func writeServeUsage(fs *flag.FlagSet) {
 		"  This is for daemon/server mode, not for running one prompt interactively.",
 	)
 	writeHelpSection(out, "Notes:",
-		"  `builder serve` does not accept `--session` or `--continue`.",
-		"  Use `--workspace` to choose the startup workspace root for config resolution.",
+		"  `builder serve` is workspace-agnostic at startup.",
+		"  Session config is resolved from each session workspace: defaults, ~/.builder, env, <workspace>/.builder.",
 	)
 	writeHelpSection(out, "Examples:",
 		"  builder serve",
-		"  builder serve --workspace /srv/repos/app --model gpt-5.4-mini",
+		"  builder project create --path /srv/repos/app --name app",
 	)
-	writeHelpSection(out, "Flags:",
-		"  -workspace string",
-		"    	workspace root (default \".\")",
-		"  -model string",
-		"    	model name override",
-		"  -provider-override string",
-		"    	provider override for custom/alias model names",
-		"  -thinking-level string",
-		"    	thinking level override (low|medium|high|xhigh)",
-		"  -theme string",
-		"    	theme override (light|dark)",
-		"  -model-timeout-seconds int",
-		"    	model request timeout override in seconds",
-		"  -tools string",
-		"    	enabled tools override as csv (e.g. shell,patch)",
-		"  -openai-base-url string",
-		"    	OpenAI-compatible base URL override",
-	)
+	writeHelpSection(out, "Flags:")
+	fs.PrintDefaults()
 }

--- a/cli/builder/main.go
+++ b/cli/builder/main.go
@@ -106,7 +106,7 @@ func rootCommand(args []string, stdin io.Reader, stdout io.Writer, stderr io.Wri
 	rootFS.Usage = func() { writeRootUsage(rootFS) }
 	showVersion := rootFS.Bool("version", false, "print version and exit")
 	forceInteractive := rootFS.Bool("force-interactive", false, "run interactive UI even when stdin/stdout are not terminals")
-	flags := registerCommonFlags(rootFS, true)
+	flags := registerSessionFlags(rootFS)
 	if err := rootFS.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -134,17 +134,8 @@ func rootCommand(args []string, stdin io.Reader, stdout io.Writer, stderr io.Wri
 	}
 
 	opts := app.Options{
-		WorkspaceRoot:         flags.WorkspaceRoot,
-		WorkspaceRootExplicit: flags.WorkspaceExplicit,
-		SessionID:             sessionID,
-		Model:                 flags.Model,
-		ProviderOverride:      flags.ProviderOverride,
-		ThinkingLevel:         flags.ThinkingLevel,
-		Theme:                 flags.Theme,
-		ModelTimeoutSeconds:   flags.ModelTimeoutSeconds,
-		Tools:                 flags.Tools,
-		OpenAIBaseURL:         flags.OpenAIBaseURL,
-		OpenAIBaseURLExplicit: flags.OpenAIBaseURLExplicit,
+		WorkspaceRoot: ".",
+		SessionID:     sessionID,
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -319,8 +310,7 @@ func registerCommonFlags(fs *flag.FlagSet, includeSession bool) *commonFlags {
 	flags := &commonFlags{}
 	fs.StringVar(&flags.WorkspaceRoot, "workspace", ".", "workspace root")
 	if includeSession {
-		fs.StringVar(&flags.SessionID, "session", "", "session id to resume")
-		fs.StringVar(&flags.ContinueID, "continue", "", "session id to continue")
+		registerSessionFlagVars(fs, flags)
 	}
 	fs.StringVar(&flags.Model, "model", "", "model name override")
 	fs.StringVar(&flags.ProviderOverride, "provider-override", "", "provider override for custom/alias model names")
@@ -330,6 +320,17 @@ func registerCommonFlags(fs *flag.FlagSet, includeSession bool) *commonFlags {
 	fs.StringVar(&flags.Tools, "tools", "", "enabled tools override as csv (e.g. shell,patch)")
 	fs.StringVar(&flags.OpenAIBaseURL, "openai-base-url", "", "OpenAI-compatible base URL override")
 	return flags
+}
+
+func registerSessionFlags(fs *flag.FlagSet) *commonFlags {
+	flags := &commonFlags{}
+	registerSessionFlagVars(fs, flags)
+	return flags
+}
+
+func registerSessionFlagVars(fs *flag.FlagSet, flags *commonFlags) {
+	fs.StringVar(&flags.SessionID, "session", "", "session id to resume")
+	fs.StringVar(&flags.ContinueID, "continue", "", "session id to continue")
 }
 
 func effectiveSessionID(flags commonFlags) (string, error) {

--- a/cli/builder/main_test.go
+++ b/cli/builder/main_test.go
@@ -150,7 +150,7 @@ func TestRootCommandForceInteractiveBypassesTerminalCheck(t *testing.T) {
 	}
 }
 
-func TestRootCommandMapsCommonFlagsToInteractiveApp(t *testing.T) {
+func TestRootCommandMapsSessionFlagsToInteractiveApp(t *testing.T) {
 	original := runInteractiveApp
 	t.Cleanup(func() {
 		runInteractiveApp = original
@@ -165,36 +165,30 @@ func TestRootCommandMapsCommonFlagsToInteractiveApp(t *testing.T) {
 	var stderr bytes.Buffer
 	args := []string{
 		"--force-interactive",
-		"--workspace", "/tmp/workspace",
 		"--session", "session-123",
-		"--model", "gpt-5",
-		"--provider-override", "openai",
-		"--thinking-level", "high",
-		"--theme", "dark",
-		"--model-timeout-seconds", "45",
-		"--tools", "shell,patch",
-		"--openai-base-url", "http://example.test/v1",
 	}
 	if code := rootCommand(args, strings.NewReader(""), &stdout, &stderr); code != 0 {
 		t.Fatalf("exit code = %d, want 0", code)
 	}
-	if got.WorkspaceRoot != "/tmp/workspace" || !got.WorkspaceRootExplicit {
+	if got.WorkspaceRoot != "." || got.WorkspaceRootExplicit {
 		t.Fatalf("unexpected workspace mapping: %+v", got)
 	}
-	if got.SessionID != "session-123" || got.Model != "gpt-5" || got.ProviderOverride != "openai" || got.ThinkingLevel != "high" || got.Theme != "dark" {
+	if got.SessionID != "session-123" {
 		t.Fatalf("unexpected interactive option mapping: %+v", got)
-	}
-	if got.ModelTimeoutSeconds != 45 {
-		t.Fatalf("unexpected timeout mapping: %+v", got)
-	}
-	if got.Tools != "shell,patch" {
-		t.Fatalf("tools = %q, want shell,patch", got.Tools)
-	}
-	if got.OpenAIBaseURL != "http://example.test/v1" || !got.OpenAIBaseURLExplicit {
-		t.Fatalf("unexpected base url mapping: %+v", got)
 	}
 	if stdout.Len() != 0 || stderr.Len() != 0 {
 		t.Fatalf("unexpected output stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestRootCommandRejectsRemovedStartupConfigFlags(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := rootCommand([]string{"--force-interactive", "--model", "gpt-5"}, strings.NewReader(""), &stdout, &stderr); code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "flag provided but not defined: -model") {
+		t.Fatalf("stderr = %q, want undefined model flag rejection", stderr.String())
 	}
 }
 
@@ -237,20 +231,14 @@ func TestRootCommandServeUsesStandaloneServerPath(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	if code := rootCommand([]string{"serve", "--workspace", "/tmp/work", "--model", "gpt-5", "--openai-base-url", "http://example.test/v1"}, strings.NewReader(""), &stdout, &stderr); code != 130 {
+	if code := rootCommand([]string{"serve"}, strings.NewReader(""), &stdout, &stderr); code != 130 {
 		t.Fatalf("exit code = %d, want 130", code)
 	}
 	if !called {
 		t.Fatal("expected serve startup path to run")
 	}
-	if got.WorkspaceRoot != "/tmp/work" || !got.WorkspaceRootExplicit {
+	if got.WorkspaceRoot != "" || got.WorkspaceRootExplicit {
 		t.Fatalf("unexpected workspace mapping: %+v", got)
-	}
-	if got.Model != "gpt-5" {
-		t.Fatalf("model = %q, want gpt-5", got.Model)
-	}
-	if got.OpenAIBaseURL != "http://example.test/v1" || !got.OpenAIBaseURLExplicit {
-		t.Fatalf("unexpected base url mapping: %+v", got)
 	}
 	if !strings.Contains(stderr.String(), "Server started, Ctrl+C to stop") {
 		t.Fatalf("stderr = %q, want serve startup message", stderr.String())
@@ -260,6 +248,17 @@ func TestRootCommandServeUsesStandaloneServerPath(t *testing.T) {
 	}
 	if got.SessionID != "" {
 		t.Fatalf("expected empty session id for serve request, got %q", got.SessionID)
+	}
+}
+
+func TestServeSubcommandRejectsRemovedStartupConfigFlags(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := rootCommand([]string{"serve", "--workspace", "/tmp/work"}, strings.NewReader(""), &stdout, &stderr); code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "flag provided but not defined: -workspace") {
+		t.Fatalf("stderr = %q, want undefined workspace flag rejection", stderr.String())
 	}
 }
 
@@ -290,7 +289,7 @@ func TestServeSubcommandHelpExplainsDaemonUsage(t *testing.T) {
 	got := stderr.String()
 	if !strings.Contains(got, "Usage of builder serve:") ||
 		!strings.Contains(got, "Start the Builder app server") ||
-		!strings.Contains(got, "does not accept `--session` or `--continue`") ||
+		!strings.Contains(got, "workspace-agnostic at startup") ||
 		!strings.Contains(got, "Flags:") {
 		t.Fatalf("stderr = %q, want expanded serve help", got)
 	}

--- a/cli/builder/serve.go
+++ b/cli/builder/serve.go
@@ -37,14 +37,12 @@ func serveSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 	serveFS := flag.NewFlagSet("builder serve", flag.ContinueOnError)
 	serveFS.SetOutput(stderr)
 	serveFS.Usage = func() { writeServeUsage(serveFS) }
-	flags := registerCommonFlags(serveFS, false)
 	if err := serveFS.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
 		}
 		return 2
 	}
-	markExplicitCommonFlags(serveFS, flags)
 	if remaining := serveFS.Args(); len(remaining) > 0 {
 		fmt.Fprintf(stderr, "unexpected arguments: %s\n", strings.Join(remaining, " "))
 		serveFS.Usage()
@@ -54,17 +52,7 @@ func serveSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 	defer stop()
 	authHandler, onboardingHandler := newServeStartupHandlers()
 	server, err := startServeServer(ctx, serverstartup.Request{
-		WorkspaceRoot:         flags.WorkspaceRoot,
-		WorkspaceRootExplicit: flags.WorkspaceExplicit,
-		AllowUnauthenticated:  true,
-		Model:                 flags.Model,
-		ProviderOverride:      flags.ProviderOverride,
-		ThinkingLevel:         flags.ThinkingLevel,
-		Theme:                 flags.Theme,
-		ModelTimeoutSeconds:   flags.ModelTimeoutSeconds,
-		Tools:                 flags.Tools,
-		OpenAIBaseURL:         flags.OpenAIBaseURL,
-		OpenAIBaseURLExplicit: flags.OpenAIBaseURLExplicit,
+		AllowUnauthenticated: true,
 	}, authHandler, onboardingHandler)
 	if err != nil {
 		fmt.Fprintln(stderr, err)

--- a/cli/tui/ansi_style_transform_test.go
+++ b/cli/tui/ansi_style_transform_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"builder/shared/transcript"
 	"strings"
 	"testing"
 
@@ -62,6 +63,44 @@ func TestMuteANSIOutputPrefixesPreviewForegroundAndFaint(t *testing.T) {
 	}
 	if !strings.HasSuffix(muted, "\x1b[0m") {
 		t.Fatalf("expected muted output to terminate style state, got %q", muted)
+	}
+}
+
+func TestApplyANSIStyleIntentsFaintUsesForegroundAndRestoresAfterReset(t *testing.T) {
+	m := NewModel(WithTheme("dark"))
+	base := m.palette().foregroundColor
+	out := applyANSIStyleIntents("echo \x1b[0mhello", m.ansiIntentPalette(), ThemeForeground|Faint)
+
+	prefix := "\x1b[" + strings.Join(styleParams(ansiStyleTransform{
+		DefaultForeground: &base,
+		ForceFaint:        true,
+	}, false), ";") + "m"
+	if !strings.HasPrefix(out, prefix) {
+		t.Fatalf("expected faint foreground output to start with app foreground+faint style, got %q", out)
+	}
+	reset := "\x1b[" + strings.Join(styleParams(ansiStyleTransform{
+		DefaultForeground: &base,
+		ForceFaint:        true,
+	}, true), ";") + "m"
+	if !strings.Contains(out, reset+"hello") {
+		t.Fatalf("expected reset to restore app foreground+faint style, got %q", out)
+	}
+	if got := xansi.Strip(out); got != "echo hello" {
+		t.Fatalf("expected text preserved after faint foreground styling, got %q", got)
+	}
+}
+
+func TestOrdinaryMutedShellPreviewStillUsesPreviewForeground(t *testing.T) {
+	m := NewModel(WithTheme("dark"))
+	line := strings.Join(m.flattenEntryWithMeta("tool_shell_success", "plain shell summary", true, &transcript.ToolCallMeta{
+		IsShell: true,
+	}), "\n")
+
+	if !containsColor(extractForegroundTrueColors(line), m.palette().previewColor) {
+		t.Fatalf("expected ordinary muted shell preview to keep preview foreground, got %q", line)
+	}
+	if containsColor(extractForegroundTrueColors(line), m.palette().foregroundColor) {
+		t.Fatalf("did not expect ordinary muted shell preview to switch to app foreground, got %q", line)
 	}
 }
 

--- a/cli/tui/model_rendering_entries.go
+++ b/cli/tui/model_rendering_entries.go
@@ -284,7 +284,7 @@ func (m Model) decorateEntryLayoutBodyStage(role string, lines []transcriptLayou
 		if !strings.Contains(display, "\x1b[") {
 			display = applyANSIStyleIntents(display, m.ansiIntentPalette(), line.Intents)
 		}
-		if muteText && strings.TrimSpace(display) != "" && !isEditedBlock && !line.Intents.Has(Subdued) {
+		if muteText && strings.TrimSpace(display) != "" && !isEditedBlock && !line.Intents.Has(Subdued) && !line.Intents.Has(Faint) {
 			display = m.palette().preview.Faint(true).Render(display)
 		} else if isStyledMetaRole(role) {
 			display = styleForRole(role, m.palette()).Render(display)
@@ -520,6 +520,9 @@ func (m Model) renderEntryTextStage(role, text string, width int, toolMeta *tran
 	if rendered, intents, ok := m.renderToolTextWithHighlight(role, text, toolMeta, muteText); ok {
 		return rendered, intents, transcriptRenderWrapModeViewport
 	}
+	if shouldUseMutedToolForeground(role, toolMeta, muteText) {
+		return text, ThemeForeground | Faint, transcriptRenderWrapModeViewport
+	}
 	if !isMarkdownRole(role) {
 		intents := m.defaultEntryStyleIntents(role, muteText)
 		if isToolHeadlineRole(role) && strings.Contains(text, "\n") {
@@ -539,6 +542,14 @@ func (m Model) renderEntryTextStage(role, text string, width int, toolMeta *tran
 
 func (m Model) wrapRenderedEntryContent(text string, width int) string {
 	return wrapTextForViewport(text, width)
+}
+
+func shouldUseMutedToolForeground(role string, toolMeta *transcript.ToolCallMeta, muteText bool) bool {
+	return muteText &&
+		isShellPreviewRole(role) &&
+		toolMeta != nil &&
+		toolMeta.HasRenderHint() &&
+		toolMeta.RenderHint.Kind == transcript.ToolRenderKindPlain
 }
 
 func (m Model) defaultEntryStyleIntents(role string, muteText bool) StyleIntent {
@@ -628,6 +639,9 @@ func resolveToolRenderHint(role, text string, toolMeta *transcript.ToolCallMeta)
 	}
 	hint := toolMeta.RenderHint
 	if hint == nil {
+		return nil, false
+	}
+	if hint.Kind == transcript.ToolRenderKindPlain {
 		return nil, false
 	}
 	if shouldFallbackToShellPreviewHint(role, text, toolMeta, hint) {

--- a/cli/tui/model_rendering_tools.go
+++ b/cli/tui/model_rendering_tools.go
@@ -15,11 +15,19 @@ func detailDivider() string {
 }
 
 func ongoingDividerGroup(role string) string {
-	trimmed := strings.TrimSpace(role)
-	if isToolHeadlineRole(trimmed) {
+	normalized := normalizeOngoingDividerRole(role)
+	if isToolHeadlineRole(normalized) {
 		return "tool"
 	}
-	return strings.ToLower(trimmed)
+	return normalized
+}
+
+func normalizeOngoingDividerRole(role string) string {
+	normalized := strings.ToLower(strings.TrimSpace(role))
+	if normalized == "assistant_commentary" {
+		return "assistant"
+	}
+	return normalized
 }
 
 func skipInOngoing(entry TranscriptEntry) bool {

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -401,6 +401,24 @@ func TestOngoingShowsCommittedAssistantAfterCommit(t *testing.T) {
 	}
 }
 
+func TestOngoingDoesNotInsertDividerBetweenCommentaryAndLiveAssistantTail(t *testing.T) {
+	m := NewModel(WithPreviewLines(20))
+	m = updateModel(t, m, AppendTranscriptMsg{
+		Role:  "assistant",
+		Text:  "Decision: keep custom tool grammar {\"patch\": ...",
+		Phase: llm.MessagePhaseCommentary,
+	})
+	m = updateModel(t, m, StreamAssistantMsg{Delta: "  } executor input so runtime/UI stays compatible."})
+
+	view := plainTranscript(m.View())
+	if strings.Contains(view, TranscriptDivider) {
+		t.Fatalf("ongoing commentary continuation should not be split by divider, got %q", view)
+	}
+	if !containsInOrder(view, "Decision:", "executor input") {
+		t.Fatalf("expected committed commentary and live tail in one assistant group, got %q", view)
+	}
+}
+
 func TestOngoingAutoFollowsWhenUserIsAtBottom(t *testing.T) {
 	m := NewModel(WithPreviewLines(2))
 	m = updateModel(t, m, AppendTranscriptMsg{Role: "assistant", Text: "a1"})

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -1325,6 +1325,7 @@ func TestOngoingWriteStdinPollSummaryUsesMutedForeground(t *testing.T) {
 	m := NewModel(WithTheme("dark"))
 	m.viewportWidth = 16
 	line := strings.Join(m.flattenEntryWithMeta("tool_shell_success", "Polled session 1149 for 2s", true, &transcript.ToolCallMeta{
+		ToolName:   "write_stdin",
 		IsShell:    true,
 		Command:    "Polled session 1149 for 2s",
 		RenderHint: &transcript.ToolRenderHint{Kind: transcript.ToolRenderKindPlain},

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -1321,6 +1321,35 @@ func TestRenderEntryTextDoesNotShellHighlightWriteStdinPollSummary(t *testing.T)
 	}
 }
 
+func TestOngoingWriteStdinPollSummaryUsesMutedForeground(t *testing.T) {
+	m := NewModel(WithTheme("dark"))
+	m.viewportWidth = 16
+	line := strings.Join(m.flattenEntryWithMeta("tool_shell_success", "Polled session 1149 for 2s", true, &transcript.ToolCallMeta{
+		IsShell:    true,
+		Command:    "Polled session 1149 for 2s",
+		RenderHint: &transcript.ToolRenderHint{Kind: transcript.ToolRenderKindPlain},
+	}), "\n")
+
+	if !strings.Contains(line, ";2m") {
+		t.Fatalf("expected ongoing write_stdin poll summary to stay faint, got %q", line)
+	}
+	foreground := m.palette().foregroundColor
+	expectedContentPrefix := m.roleSymbol("tool_shell_success") + " " + "\x1b[" + strings.Join(styleParams(ansiStyleTransform{
+		DefaultForeground: &foreground,
+		ForceFaint:        true,
+	}, false), ";") + "m"
+	if !strings.HasPrefix(line, expectedContentPrefix) {
+		t.Fatalf("expected truncated poll summary to start with exact foreground+faint style, got %q want prefix %q", line, expectedContentPrefix)
+	}
+	colors := extractForegroundTrueColors(line)
+	if !containsColor(colors, m.palette().foregroundColor) {
+		t.Fatalf("expected ongoing write_stdin poll summary to use app foreground, got %q", line)
+	}
+	if containsColor(colors, m.palette().previewColor) {
+		t.Fatalf("expected ongoing write_stdin poll summary to avoid extra-muted preview color, got %q", line)
+	}
+}
+
 func TestWriteStdinPollFormattingShowsSubSecondDurationInOngoingAndDetail(t *testing.T) {
 	m := NewModel()
 	m = updateModel(t, m, SetViewportSizeMsg{Lines: 20, Width: 80})

--- a/cli/tui/render_style_intents.go
+++ b/cli/tui/render_style_intents.go
@@ -8,6 +8,7 @@ const (
 	SuccessForeground
 	WarningForeground
 	ErrorForeground
+	Faint
 	ShellPreview
 	SyntaxHighlighted
 	DiffAdded
@@ -68,7 +69,12 @@ func applyANSIStyleIntents(text string, palette ansiIntentPalette, intents Style
 	case intents.Has(ThemeForeground):
 		transform.DefaultForeground = &palette.ThemeForeground
 	default:
-		return text
+		if !intents.Has(Faint) {
+			return text
+		}
+	}
+	if intents.Has(Subdued) || intents.Has(Faint) {
+		transform.ForceFaint = true
 	}
 	return applyANSIStyleTransform(text, transform)
 }

--- a/cli/tui/transcript_projection_test.go
+++ b/cli/tui/transcript_projection_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"builder/server/llm"
 	"builder/shared/transcript"
 )
 
@@ -23,6 +24,25 @@ func TestCommittedOngoingProjectionRenderAppendDeltaFromAppendedEntry(t *testing
 	}
 	if strings.Contains(delta, "seed") {
 		t.Fatalf("expected delta to exclude already committed prefix, got %q", delta)
+	}
+}
+
+func TestCommittedOngoingProjectionRenderAppendDeltaFromAssistantCommentaryContinuation(t *testing.T) {
+	m := NewModel(WithPreviewLines(20))
+	m = updateModel(t, m, AppendTranscriptMsg{Role: "assistant", Text: "Decision: keep", Phase: llm.MessagePhaseCommentary})
+	previous := m.CommittedOngoingProjection()
+
+	m = updateModel(t, m, AppendTranscriptMsg{Role: "assistant", Text: "going"})
+	current := m.CommittedOngoingProjection()
+	delta, ok := current.RenderAppendDeltaFrom(previous, TranscriptDivider)
+	if !ok {
+		t.Fatal("expected append-only committed projection delta")
+	}
+	if strings.Contains(delta, TranscriptDivider) {
+		t.Fatalf("expected assistant commentary continuation delta without divider, got %q", delta)
+	}
+	if !strings.Contains(delta, "going") {
+		t.Fatalf("expected delta to include appended assistant continuation, got %q", delta)
 	}
 }
 

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -9,8 +9,8 @@ Builder resolves settings in this order (higher no. = higher priority):
 
 1. Built-in defaults
 2. `~/.builder/config.toml`
-3. Environment variables
-4. `<workspace-root>/.builder/config.toml`
+3. `<workspace-root>/.builder/config.toml`
+4. Environment variables
 5. `builder run` CLI flags
 
 Interactive session flows resolve workspace-local config from the session workspace root. `builder serve` starts without a workspace root and applies workspace config only when a project/session selects a workspace. `builder run` is the only entrypoint that accepts config override flags.

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -38,7 +38,7 @@ Changing `persistence_root` does not move `config.toml`. `persistence_root` cont
 ## Example
 
 ```toml
-model = "gpt-5.4"
+model = "gpt-5.5"
 thinking_level = "medium" # low, medium, high, xhigh
 model_verbosity = "medium" # or "low"
 theme = "auto" # or light / dark
@@ -99,7 +99,7 @@ These flags overlay settings at startup.
 
 | Key | Type | Default | Env | CLI | Description |
 | --- | --- | --- | --- | --- | --- |
-| `model` | string | `gpt-5.4` | `BUILDER_MODEL` | `--model` | Model name. If provider inference from the model name is not enough, set `provider_override` too. |
+| `model` | string | `gpt-5.5` | `BUILDER_MODEL` | `--model` | Model name. If provider inference from the model name is not enough, set `provider_override` too. |
 | `thinking_level` | string | `medium` | `BUILDER_THINKING_LEVEL` | `--thinking-level` | Provider-specific reasoning effort string. |
 | `model_verbosity` | string | `medium` |  |  | Text verbosity hint for supported models. Allowed: `""`, `low`, `medium`, `high`. Unsupported models ignore it. |
 | `theme` | string | `auto` | `BUILDER_THEME` | `--theme` | TUI theme. Allowed: `auto`, `light`, `dark`. `light` and `dark` force Builder's fixed palettes. `auto` or an omitted value falls back to terminal background detection. |

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -10,18 +10,25 @@ Builder resolves settings in this order (higher no. = higher priority):
 1. Built-in defaults
 2. `~/.builder/config.toml`
 3. Environment variables
-4. CLI flags
+4. `<workspace-root>/.builder/config.toml`
+5. `builder run` CLI flags
 
-When you `continue` a session, Builder reuses the saved workspace root and saved continuation `openai_base_url` unless you explicitly pass `--workspace` or `--openai-base-url`.
+Interactive session flows resolve workspace-local config from the session workspace root. `builder serve` starts without a workspace root and applies workspace config only when a project/session selects a workspace. `builder run` is the only entrypoint that accepts config override flags.
 
 ## Locations
 
 ### Persistence root
 
-The settings file is always:
+Global settings live at:
 
 ```text
 ~/.builder/config.toml
+```
+
+Workspace settings live at:
+
+```text
+<workspace-root>/.builder/config.toml
 ```
 
 Builder also installs a user-editable ripgrep config at:
@@ -32,7 +39,7 @@ Builder also installs a user-editable ripgrep config at:
 
 Builder creates `~/.builder/rg.conf` when missing and exports it to shell tools via `RIPGREP_CONFIG_PATH` only when you have not already set `RIPGREP_CONFIG_PATH` yourself.
 
-Changing `persistence_root` does not move `config.toml`. `persistence_root` controls where Builder stores its database & auth state. The default is `~/.builder`.
+Changing `persistence_root` does not move either config file. `persistence_root` controls where Builder stores its database & auth state. The default is `~/.builder`.
 
 
 ## Example
@@ -78,17 +85,15 @@ verbose_output = false # show in ongoing transcript
 
 ## CLI Overrides
 
-These flags overlay settings at startup.
-
 | Flag | Overrides | Notes |
 | --- | --- | --- |
-| `--model` | `model` | |
-| `--provider-override` | `provider_override` | |
-| `--thinking-level` | `thinking_level` | |
-| `--theme` | `theme` | |
-| `--model-timeout-seconds` | `timeouts.model_request_seconds` | |
-| `--tools` | entire tool set | CSV replacement, not a merge |
-| `--openai-base-url` | `openai_base_url` | Also affects continuation behavior |
+| `builder run --model` | `model` | |
+| `builder run --provider-override` | `provider_override` | |
+| `builder run --thinking-level` | `thinking_level` | |
+| `builder run --theme` | `theme` | |
+| `builder run --model-timeout-seconds` | `timeouts.model_request_seconds` | |
+| `builder run --tools` | entire tool set | CSV replacement, not a merge |
+| `builder run --openai-base-url` | `openai_base_url` | Also affects continuation behavior |
 
 
 `builder run` also accepts the headless-only selectors `--agent <role>` and `--fast`, which choose a subagent role rather than directly overriding one config key.
@@ -99,10 +104,10 @@ These flags overlay settings at startup.
 
 | Key | Type | Default | Env | CLI | Description |
 | --- | --- | --- | --- | --- | --- |
-| `model` | string | `gpt-5.5` | `BUILDER_MODEL` | `--model` | Model name. If provider inference from the model name is not enough, set `provider_override` too. |
-| `thinking_level` | string | `medium` | `BUILDER_THINKING_LEVEL` | `--thinking-level` | Provider-specific reasoning effort string. |
+| `model` | string | `gpt-5.5` | `BUILDER_MODEL` | `builder run --model` | Model name. If provider inference from the model name is not enough, set `provider_override` too. |
+| `thinking_level` | string | `medium` | `BUILDER_THINKING_LEVEL` | `builder run --thinking-level` | Provider-specific reasoning effort string. |
 | `model_verbosity` | string | `medium` |  |  | Text verbosity hint for supported models. Allowed: `""`, `low`, `medium`, `high`. Unsupported models ignore it. |
-| `theme` | string | `auto` | `BUILDER_THEME` | `--theme` | TUI theme. Allowed: `auto`, `light`, `dark`. `light` and `dark` force Builder's fixed palettes. `auto` or an omitted value falls back to terminal background detection. |
+| `theme` | string | `auto` | `BUILDER_THEME` | `builder run --theme` | TUI theme. Allowed: `auto`, `light`, `dark`. `light` and `dark` force Builder's fixed palettes. `auto` or an omitted value falls back to terminal background detection. |
 | `tui_alternate_screen` | string | `auto` | `BUILDER_TUI_ALTERNATE_SCREEN` |  | Alternate-screen policy. Allowed: `auto`, `always`, `never`. |
 | `notification_method` | string | `auto` | `BUILDER_NOTIFICATION_METHOD` |  | Terminal notification backend. Allowed: `auto`, `osc9`, `bel`. `auto` chooses `osc9` on supported terminals and falls back to `bel`. |
 | `tool_preambles` | bool | `true` | `BUILDER_TOOL_PREAMBLES` |  | Includes tool-usage preambles in the main system prompt for interactive runs. Headless `builder run` still suppresses them. |
@@ -111,8 +116,8 @@ These flags overlay settings at startup.
 | `server_host` | string | `127.0.0.1` | `BUILDER_SERVER_HOST` |  | Exact TCP app-server host Builder will dial or listen on. Builder does not use discovery files or silent port rebinding. Same-machine Unix socket optimization, when supported, is derived automatically and does not override an explicit TCP target. |
 | `server_port` | int | `53082` | `BUILDER_SERVER_PORT` |  | Exact TCP app-server port Builder will dial or listen on. Must match across clients attached to the same persistence root. Same-machine Unix socket optimization, when supported, is additive only and does not override an explicit TCP target. |
 | `web_search` | string | `native` | `BUILDER_WEB_SEARCH` |  | Web search backend. Allowed: `off`, `native`. `custom` (e.g. Brave Search) is not implemented yet, on the roadmap. |
-| `provider_override` | string | `""` | `BUILDER_PROVIDER_OVERRIDE` | `--provider-override` | Forces provider family for custom or alias model names. Allowed: `openai`, `anthropic`. Requires an explicit `model` override. |
-| `openai_base_url` | string | `""` | `BUILDER_OPENAI_BASE_URL` | `--openai-base-url` | OpenAI-compatible base URL. Must be used with `provider_override=openai` or with no explicit provider override. Cannot be changed mid-session. |
+| `provider_override` | string | `""` | `BUILDER_PROVIDER_OVERRIDE` | `builder run --provider-override` | Forces provider family for custom or alias model names. Allowed: `openai`, `anthropic`. Requires an explicit `model` override. |
+| `openai_base_url` | string | `""` | `BUILDER_OPENAI_BASE_URL` | `builder run --openai-base-url` | OpenAI-compatible base URL. Must be used with `provider_override=openai` or with no explicit provider override. Cannot be changed mid-session. |
 | `store` | bool | `false` | `BUILDER_STORE` |  | Sets OpenAI Responses `store=true` for main model requests. |
 | `allow_non_cwd_edits` | bool | `false` | `BUILDER_ALLOW_NON_CWD_EDITS` |  | Lets the `patch` tool edit files outside the workspace root. This is not sandboxing - model can still bypass this easily. |
 | `model_context_window` | int | `272000` | `BUILDER_MODEL_CONTEXT_WINDOW` |  | Explicit context-window size used for compaction and token accounting. Must be `> 0`. |
@@ -131,7 +136,7 @@ These flags overlay settings at startup.
 
 | Key | Type | Default | Env | CLI | Description |
 | --- | --- | --- | --- | --- | --- |
-| `timeouts.model_request_seconds` | int | `400` | `BUILDER_TIMEOUTS_MODEL_REQUEST_SECONDS` | `--model-timeout-seconds` | HTTP timeout for model requests. Must be `> 0`. |
+| `timeouts.model_request_seconds` | int | `400` | `BUILDER_TIMEOUTS_MODEL_REQUEST_SECONDS` | `builder run --model-timeout-seconds` | HTTP timeout for model requests. Must be `> 0`. |
 
 
 ### Supervisor
@@ -173,7 +178,7 @@ Use these only for custom providers or models.
 ### Tools
 
 `[tools]` is a per-tool boolean table in `config.toml`.
-File-based tool toggles merge with defaults. `BUILDER_TOOLS` and `--tools` behave differently: they replace the entire tool set with the CSV you provide.
+File-based tool toggles merge with defaults. `BUILDER_TOOLS` and `builder run --tools` behave differently: they replace the entire tool set with the CSV you provide.
 
 
 | Key | Default | What enabling it exposes |

--- a/docs/src/content/docs/worktrees.md
+++ b/docs/src/content/docs/worktrees.md
@@ -19,7 +19,7 @@ Builder manages git worktrees for the current session. Creating or switching a w
 
 If `target` is omitted, Builder opens delete confirmation for the current worktree. The main workspace worktree cannot be deleted.
 
-`Delete + Branch` is available when the worktree has a branch name. Builder preselects this option for Builder-managed worktrees it created from a new branch.
+The confirmation page previews what the selected action deletes. `Delete + Branch` is available when the worktree has a branch name and adds the local branch to that preview.
 
 Deletion is blocked when another session targets that worktree or when background processes are running inside it.
 

--- a/docs/src/content/docs/worktrees.md
+++ b/docs/src/content/docs/worktrees.md
@@ -19,7 +19,7 @@ Builder manages git worktrees for the current session. Creating or switching a w
 
 If `target` is omitted, Builder opens delete confirmation for the current worktree. The main workspace worktree cannot be deleted.
 
-The confirmation page previews what the selected action deletes. `Delete + Branch` is available when the worktree has a branch name and adds the local branch to that preview.
+The confirmation page previews what the selected action deletes. If the worktree contains modified or untracked files, Builder shows that count and force-removes the worktree after confirmation. `Delete + Branch` is available when the worktree has a branch name and adds the local branch to that preview.
 
 Deletion is blocked when another session targets that worktree or when background processes are running inside it.
 

--- a/prompts/embed.go
+++ b/prompts/embed.go
@@ -1,19 +1,21 @@
 package prompts
 
 import (
+	"bytes"
 	_ "embed"
-	"strconv"
+	"fmt"
 	"strings"
+	"text/template"
 
 	"builder/cli/selfcmd"
 )
 
-const (
-	runCommandPlaceholder                = "{{builder_run_command}}"
-	estimatedToolCallsContextPlaceholder = "{{estimated_tool_calls_for_context}}"
-)
-
 type SystemPromptTemplateArgs struct {
+	EstimatedToolCallsForContext int
+}
+
+type systemPromptTemplateData struct {
+	BuilderRunCommand            string
 	EstimatedToolCallsForContext int
 }
 
@@ -103,16 +105,23 @@ func RenderWorktreeModeExitPrompt(branch, cwd, worktreePath, workspaceRoot strin
 	})
 }
 
-func renderRunCommand(text string) string {
-	return renderRunCommandWithPrefix(text, selfcmd.RunCommandPrefix())
-}
-
 func renderSystemPromptTemplate(text string, args SystemPromptTemplateArgs) string {
-	if strings.TrimSpace(text) == "" {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
 		return ""
 	}
-	rendered := renderRunCommand(text)
-	return strings.ReplaceAll(rendered, estimatedToolCallsContextPlaceholder, strconv.Itoa(args.EstimatedToolCallsForContext))
+	tmpl, err := template.New("system_prompt").Option("missingkey=error").Parse(trimmed)
+	if err != nil {
+		panic(fmt.Errorf("parse system prompt template: %w", err))
+	}
+	var out bytes.Buffer
+	if err := tmpl.Execute(&out, systemPromptTemplateData{
+		BuilderRunCommand:            selfcmd.RunCommandPrefix(),
+		EstimatedToolCallsForContext: args.EstimatedToolCallsForContext,
+	}); err != nil {
+		panic(fmt.Errorf("render system prompt template: %w", err))
+	}
+	return out.String()
 }
 
 func renderWorktreePrompt(template string, replacements map[string]string) string {
@@ -124,11 +133,4 @@ func renderWorktreePrompt(template string, replacements map[string]string) strin
 		text = strings.ReplaceAll(text, placeholder, value)
 	}
 	return text
-}
-
-func renderRunCommandWithPrefix(text, prefix string) string {
-	if strings.TrimSpace(text) == "" {
-		return ""
-	}
-	return strings.ReplaceAll(text, runCommandPlaceholder, prefix)
 }

--- a/prompts/embed.go
+++ b/prompts/embed.go
@@ -2,12 +2,20 @@ package prompts
 
 import (
 	_ "embed"
+	"strconv"
 	"strings"
 
 	"builder/cli/selfcmd"
 )
 
-const runCommandPlaceholder = "{{builder_run_command}}"
+const (
+	runCommandPlaceholder                = "{{builder_run_command}}"
+	estimatedToolCallsContextPlaceholder = "{{estimated_tool_calls_for_context}}"
+)
+
+type SystemPromptTemplateArgs struct {
+	EstimatedToolCallsForContext int
+}
 
 //go:embed system_prompt.md
 var SystemPrompt string
@@ -51,8 +59,8 @@ var WorktreeModePrompt string
 //go:embed worktree_mode_exit_prompt.md
 var WorktreeModeExitPrompt string
 
-func MainSystemPrompt(includeToolPreambles bool) string {
-	base := renderRunCommand(strings.TrimSpace(SystemPrompt))
+func MainSystemPrompt(includeToolPreambles bool, args SystemPromptTemplateArgs) string {
+	base := renderSystemPromptTemplate(strings.TrimSpace(SystemPrompt), args)
 	if !includeToolPreambles {
 		return base
 	}
@@ -66,8 +74,8 @@ func MainSystemPrompt(includeToolPreambles bool) string {
 	return base + "\n\n" + preambles
 }
 
-func BaseSystemPrompt() string {
-	return renderRunCommand(strings.TrimSpace(SystemPrompt))
+func BaseSystemPrompt(args SystemPromptTemplateArgs) string {
+	return renderSystemPromptTemplate(strings.TrimSpace(SystemPrompt), args)
 }
 
 func RenderCompactionSoonReminderPrompt(triggerHandoffEnabled bool) string {
@@ -97,6 +105,14 @@ func RenderWorktreeModeExitPrompt(branch, cwd, worktreePath, workspaceRoot strin
 
 func renderRunCommand(text string) string {
 	return renderRunCommandWithPrefix(text, selfcmd.RunCommandPrefix())
+}
+
+func renderSystemPromptTemplate(text string, args SystemPromptTemplateArgs) string {
+	if strings.TrimSpace(text) == "" {
+		return ""
+	}
+	rendered := renderRunCommand(text)
+	return strings.ReplaceAll(rendered, estimatedToolCallsContextPlaceholder, strconv.Itoa(args.EstimatedToolCallsForContext))
 }
 
 func renderWorktreePrompt(template string, replacements map[string]string) string {

--- a/prompts/embed_test.go
+++ b/prompts/embed_test.go
@@ -1,0 +1,18 @@
+package prompts
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderSystemPromptTemplateUsesTypedFields(t *testing.T) {
+	rendered := renderSystemPromptTemplate("calls={{.EstimatedToolCallsForContext}} cmd={{.BuilderRunCommand}}", SystemPromptTemplateArgs{
+		EstimatedToolCallsForContext: 123,
+	})
+	if !strings.Contains(rendered, "calls=123") {
+		t.Fatalf("expected estimated tool calls rendered, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "cmd=") || strings.Contains(rendered, "{{") {
+		t.Fatalf("expected builder run command rendered, got %q", rendered)
+	}
+}

--- a/prompts/embed_test.go
+++ b/prompts/embed_test.go
@@ -3,6 +3,8 @@ package prompts
 import (
 	"strings"
 	"testing"
+
+	"builder/cli/selfcmd"
 )
 
 func TestRenderSystemPromptTemplateUsesTypedFields(t *testing.T) {
@@ -12,7 +14,8 @@ func TestRenderSystemPromptTemplateUsesTypedFields(t *testing.T) {
 	if !strings.Contains(rendered, "calls=123") {
 		t.Fatalf("expected estimated tool calls rendered, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "cmd=") || strings.Contains(rendered, "{{") {
-		t.Fatalf("expected builder run command rendered, got %q", rendered)
+	expectedCmd := "cmd=" + selfcmd.RunCommandPrefix()
+	if !strings.Contains(rendered, expectedCmd) || strings.Contains(rendered, "{{") {
+		t.Fatalf("expected %q in rendered output, got %q", expectedCmd, rendered)
 	}
 }

--- a/prompts/system_prompt.md
+++ b/prompts/system_prompt.md
@@ -13,7 +13,7 @@ As an expert coding agent, your primary focus is writing code, answering questio
 Your agentic environment has specific traits & tools that were created to help you. Use these capabilities proactively.
 
 - Your memory is structured as a "conversation" that spans an unlimited amount of time. Tool calls you make are messages in this conversation and stay there forever.
-- Like humans, you have limited available working memory. After ~{{estimated_tool_calls_for_context}} function calls, you will have to hand off your work to another agent because the conversation will have become too long. So work efficiently: use terse commands like `git status --short`, efficiently search with `sg` or `rg`, delegate, write scripts/docs, and improve tooling for repeated commands. Use files as durable memory. Do not worry, handoffs are normal, and you will be notified when your memory becomes full, so do not cut corners or sacrifice quality in the name of efficiency. 
+- Like humans, you have limited available working memory. After ~{{.EstimatedToolCallsForContext}} function calls, you will have to hand off your work to another agent because the conversation will have become too long. So work efficiently: use terse commands like `git status --short`, efficiently search with `sg` or `rg`, delegate, write scripts/docs, and improve tooling for repeated commands. Use files as durable memory. Do not worry, handoffs are normal, and you will be notified when your memory becomes full, so do not cut corners or sacrifice quality in the name of efficiency.
 - In this environment, after you submit a `final_answer`, you "go to sleep" and pause indefinitely until something else happens, mainly a user's message or a background shell completion event. Some time may pass between your last answer and next event that wakes you up. So use final answers strategically where you are okay with stopping potentially indefinitely. For temporary pauses, prefer starting background shells that will issue notifications later and let you resume, preventing "getting stuck on pause".
 - For large tasks, multiple handoffs are essentially inevitable, which will cause forgetfulness and drift. In that case, you will need a durable store of logs, notes, and plans as markdown files in this repository that future agents will be able to read to gather context. Consider creating plan documents that will split the work into chunks manageable to complete within one-two handoffs, then follow the larger plan across many handoffs, or utilize subagents that will do the work without inflating the conversation size.
 - You and the user share the same workspace and collaborate to achieve the user's goals.
@@ -36,7 +36,8 @@ These best practices are here to make your life better; follow them unless the u
   * If the changes are in files you've touched recently, you should read carefully and understand how you can work with the changes rather than reverting them.
   * If the changes are in unrelated files, just ignore them. If they directly conflict with your current task, stop and ask the user how they would like to proceed. Otherwise, focus on the task at hand.
 - Do not amend a commit unless explicitly requested to do so.
-- Do not re-read the files that you just edited to confirm changes. If patch succeeded, assume the file is in the state you expect it to be. You will be notified about errors separately.
+- Avoid redundant re-reads of files you just edited.
+- Re-read a file when exact post-edit state matters for correctness, nearby concurrent edits are possible, or you need to verify that a delicate/manual patch landed as intended.
 - Poll background shells for 5-15 mins at a time; avoid short polls.
 - Parallelize tool calls whenever possible - especially file reads, such as `cat`, `rg`, `sed`, `ls`, `git show`, `nl`, `wc`. Prefer emitting multiple tool calls in a single assistant turn so the runtime executes them in parallel. Avoid parallelizing `git` operations due to locking/races.
 
@@ -95,7 +96,7 @@ Requirements for your final answer:
 - Don’t use emojis or em dashes unless explicitly instructed.
 
 # Delegating work
-You can delegate work to agents by executing `{{builder_run_command}} "<prompt>"` in a **background shell**. When the agent completes, you will be notified. While they work, you can do something else or pause. Subagents usually take 15-45 minutes and only produce output when done. You should give them enough time to complete.
+You can delegate work to agents by executing `{{.BuilderRunCommand}} "<prompt>"` in a **background shell**. When the agent completes, you will be notified. While they work, you can do something else or pause. Subagents usually take 15-45 minutes and only produce output when done. You should give them enough time to complete.
 
 You should consider delegating parts of work to the agents to:
 
@@ -112,7 +113,7 @@ To accomplish large tasks - take on a manager role, communicating with agents (v
 
 - If you want to delegate implementations, identify during the planning phase if and which parts of your task can be delegated that are not on the critical path. Do this planning step before delegating to agents so you do not hand off the immediate blocking task to an agent and then waste time waiting on it.
 - Prefer subagents when a subtask can run in parallel with your local work. Prefer delegating concrete, bounded sidecar tasks that materially advance the main task without blocking your immediate next local step.
-- For fast, simple task like exploration and context gathering, prefer fast mode subagents with `{{builder_run_command}} --fast "..."`. Prefer fast subagents to manual broad file searches.
+- For fast, simple task like exploration and context gathering, prefer fast mode subagents with `{{.BuilderRunCommand}} --fast "..."`. Prefer fast subagents to manual broad file searches.
 - Keep work local when the subtask is too difficult to delegate well, when it is tightly coupled, urgent, or likely to block your immediate next step.
 
 ### Designing delegated subtasks
@@ -135,7 +136,7 @@ To accomplish large tasks - take on a manager role, communicating with agents (v
 - Split implementation into disjoint codebase slices and spawn multiple agents for them in parallel when the write scopes do not overlap.
 
 ## Example workflows
-- `$ {{builder_run_command}} --fast "Explore logs via Axiom and find mentions of 'BILLING_FAILURE'", then report timestamps, context, and narrow search queries for me to look through failure paths`. This command relies on repo knowledge about axiom to start a sidecar subagent, gives specific instructions, and asks to sift through huge log queries to find relevant info while you explore the code to debug an issue.
+- `$ {{.BuilderRunCommand}} --fast "Explore logs via Axiom and find mentions of 'BILLING_FAILURE'", then report timestamps, context, and narrow search queries for me to look through failure paths`. This command relies on repo knowledge about axiom to start a sidecar subagent, gives specific instructions, and asks to sift through huge log queries to find relevant info while you explore the code to debug an issue.
 - "We're working on ./docs/feature_plan.md. Your task is implementation of module 2. Implement module #2 and give back a report of changed files." This is one of several agents completing parts of a plan you, the main agent, created. The plan you wrote is descriptive and work is disjoint with other modules, so you acted as a manager in that session.
 - `--fast "Explore this monorepo, find all modules that use BGTaskScheduler (declared in <...>), list all usages with concrete paths."`. While doing a larger refactor, you delegated information search of a widely used utility. This wasn't your immediate task and not on the critical path - perfect to save context from `rg` noise.
 

--- a/prompts/system_prompt.md
+++ b/prompts/system_prompt.md
@@ -1,27 +1,59 @@
-You are an autonomous coding agent named Builder - a deeply pragmatic, effective software engineer. You take engineering quality seriously, and collaboration comes through as direct, factual statements.
+You are an autonomous coding agent named Builder - a deeply pragmatic, effective product engineer. You take engineering quality seriously, and collaboration comes through as direct, factual statements.
 
 You are guided by these core values:
 - Clarity: You communicate reasoning explicitly and concretely, so decisions and tradeoffs are easy to evaluate upfront.
 - Pragmatism: You keep the end goal and momentum in mind, focusing on what will actually work and move things forward to achieve the user's goal.
 - Rigor: You expect technical arguments to be coherent and defensible, and you surface gaps or weak assumptions politely with emphasis on creating clarity and moving the task forward.
 
-You communicate concisely and respectfully, focusing on the task at hand. You always prioritize actionable guidance, clearly stating assumptions, environment prerequisites, and next steps. Unless explicitly asked, you avoid excessively verbose explanations about your work.
-
 You challenge the user to raise their technical bar, but you never patronize or dismiss their concerns. When presenting an alternative approach or solution to the user, you explain the reasoning behind the approach, so your thoughts are demonstrably correct. You maintain a pragmatic mindset when discussing these tradeoffs, and so are willing to work with the user after concerns have been noted. You know that both you and the user may not have the full context, so you challenge incorrect assumptions from the user and back them with concrete evidence.
 
-As an expert coding agent, your primary focus is writing code, answering questions, and helping the user complete their task in the current environment. You build context by examining the codebase first without making assumptions or jumping to conclusions. You think through the nuances of the code you encounter, and embody the mentality of a skilled senior software engineer.
+As an expert coding agent, your primary focus is writing code, answering questions, and helping the user complete their task in the current environment. You build context by examining the codebase first without making assumptions or jumping to conclusions. You think through the nuances of the code you encounter, and embody the mentality of a skilled senior product engineer.
+
+# Your environment
+Your agentic environment has specific traits & tools that were created to help you. Use these capabilities proactively.
+
+- Your memory is structured as a "conversation" that spans an unlimited amount of time. Tool calls you make are messages in this conversation and stay there forever.
+- Like humans, you have limited available working memory. After ~{{estimated_tool_calls_for_context}} function calls, you will have to hand off your work to another agent because the conversation will have become too long. So work efficiently: use terse commands like `git status --short`, efficiently search with `sg` or `rg`, delegate, write scripts/docs, and improve tooling for repeated commands. Use files as durable memory. Do not worry, handoffs are normal, and you will be notified when your memory becomes full, so do not cut corners or sacrifice quality in the name of efficiency. 
+- In this environment, after you submit a `final_answer`, you "go to sleep" and pause indefinitely until something else happens, mainly a user's message or a background shell completion event. Some time may pass between your last answer and next event that wakes you up. So use final answers strategically where you are okay with stopping potentially indefinitely. For temporary pauses, prefer starting background shells that will issue notifications later and let you resume, preventing "getting stuck on pause".
+- For large tasks, multiple handoffs are essentially inevitable, which will cause forgetfulness and drift. In that case, you will need a durable store of logs, notes, and plans as markdown files in this repository that future agents will be able to read to gather context. Consider creating plan documents that will split the work into chunks manageable to complete within one-two handoffs, then follow the larger plan across many handoffs, or utilize subagents that will do the work without inflating the conversation size.
+- You and the user share the same workspace and collaborate to achieve the user's goals.
+- In responses, you are producing plain text that will later be styled as Markdown for the user.
+- If you intentionally want to pause silently with no user-visible effect, send exactly `NO_OP` as the entire `final_answer` content. Do not add any extra text around it.
+- If you started an asynchronous process (subagent or shell), the harness will notify you whenever it ends and you will be able to resume your work. Combine async processes and the `NO_OP` token messages to "go to sleep" and then continue upon notification.
+- When you are notified by your supervisor or shells waking you up or interrupting you, don't repeat or restate user-facing answers because of that - assume every message you send is seen by the user.
+- If a function (tool) is not available to you despite being mentioned in these instructions, it was intentionally disabled by the user.
+
+## Workflow guidance
+These best practices are here to make your life better; follow them unless the user explicitly overrides them.
+
+- **NEVER** use destructive commands like `git reset --hard` or `git checkout --` unless specifically requested by the user.
+- Default to ASCII when editing or creating files. Only introduce non-ASCII or other Unicode characters when there is a clear justification and the file already uses them.
+- Use `patch` for manual code edits. Do not use cat or any other commands when creating or editing files. Formatting commands or bulk edits don't need to be done with the patch tool.
+- Do not use Python to read/write files when a simple shell command or patch would suffice.
+- You may be in a dirty git worktree.
+  * Do not revert existing changes you did not make unless explicitly requested, since these changes were made by the user.
+  * If asked to make a commit or code edits and there are unrelated changes to your work or changes that you didn't make in those files, don't revert those changes.
+  * If the changes are in files you've touched recently, you should read carefully and understand how you can work with the changes rather than reverting them.
+  * If the changes are in unrelated files, just ignore them. If they directly conflict with your current task, stop and ask the user how they would like to proceed. Otherwise, focus on the task at hand.
+- Do not amend a commit unless explicitly requested to do so.
+- Do not re-read the files that you just edited to confirm changes. If patch succeeded, assume the file is in the state you expect it to be. You will be notified about errors separately.
+- Poll background shells for 5-15 mins at a time; avoid short polls.
+- Parallelize tool calls whenever possible - especially file reads, such as `cat`, `rg`, `sed`, `ls`, `git show`, `nl`, `wc`. Prefer emitting multiple tool calls in a single assistant turn so the runtime executes them in parallel. Avoid parallelizing `git` operations due to locking/races.
 
 ## Autonomy and persistence
-Sometimes you will be working on large tasks. Your working memory has limited capacity, but the available scope of the work you can do is unlimited. When appropriate, you will be asked to hand off your work to another agent because your working memory is full. They will automatically continue. Consequently, do NOT use `final_answer` to stop mid-task because you "worked for a while", because "you want a checkpoint" or to "report progress". You will be given rest when appropriate by this environment, you do not need it right now. Use `ask_question` function for clarification and discussion. Only issue `final_answer` when the task is complete in full & E2E. Do not reduce the task scope in any way without confirming with the user. Keep long-term plans & checklists in temporary markdown files as needed.
+Sometimes you will be working on large tasks. Do not use `final_answer` to stop mid-task because you "worked for a while", because "you want a checkpoint" or to "report progress". You will be given rest when appropriate by this environment, you do not need it right now. Only issue `final_answer` when the task is complete in full & E2E. Do not reduce the task scope in any way without confirming with the user. Keep long-term plans & checklists in temporary markdown files as needed.
 
-Persist until the task is fully handled end-to-end within the current turn whenever feasible: do not stop at analysis, partial or temporary fixes; carry changes through implementation, verification, and a clear explanation of outcomes unless the user explicitly pauses or redirects you. You can still ask questions via `ask_question` tool - that will not interrupt your turn.
+Be agentic by default: when implementation details are clear and user intent is stable, proceed without asking. Do not stop at analysis, partial or temporary fixes; carry changes through implementation, verification, and a clear explanation of outcomes unless the user explicitly pauses or redirects you. You can still ask questions via `ask_question` tool - that will not interrupt your flow.
 
 Sometimes you will encounter the need for large-scale refactors or significant changes to existing code to implement a root-cause fix or correctly design a new feature. In such cases, ask the user whether they want to expand or reduce the scope, and make proposals with different scope breadth as part of planning. Code quality is ongoing work, and sometimes changes can introduce regressions. During planning/discovery, carefully balance together with the user incremental improvements and avoiding regressions in existing logic.
 
-Unless the user explicitly asks for a plan, asks a question about the code, is brainstorming potential solutions, or some other intent that makes it clear that code should not be written, assume the user wants you to make code changes or run tools to solve the user's problem. In these cases, it's bad to output your proposed solution in a message, you should go ahead and actually implement the change. Consider proactively using `ask_question` during the planning phase to align with the user on product decisions or architectural approaches.
+Unless the user explicitly asks for a plan, a simple question, or is brainstorming potential solutions, or some other intent that makes it clear that code should not be written, assume the user wants you to start working on the user's problem. In these cases, it's bad to output your proposed solution in a `final_answer`, you should go ahead and start planning your work, collaborating, then implementing the change. Consider proactively using `ask_question` during the planning phase to align with the user on product decisions, architectural approaches, ambiguities or UX decisions.
 
-## Code quality
-Unless specified otherwise, by default and in case of ambiguity, always implement the most correct, robust, extensible, performant, architecturally sound possible solution. Avoid adding hacks, maintaining backward compatibility, or defensive code. Avoid "surgical fixes", "minimal changes", "quick patches" or similar, even if the situation calls for those. 
+## Product Ambiguity And Planning
+Sometimes users will talk to you in product terms, describing what they want on a higher level. The user may not have full context of the codebase, such as pre-existing limitations, missing features or infra, past decisions, technical constraints, interactions between subsystems, etc. As you work and especially as you plan, consider asking the user about their potential assumptions that materially affect the outcome to clarify intended design. Do not argue or push your own narrative at all costs, rather, confirm with the user what they truly want and if they are aware of certain aspects of the task, give them options, and offer recommendations through neutral questions. Avoid asking obvious or repeating questions like "Do you want tests?" that do not clarify the task or that you can answer yourself.
+
+## Output quality
+Unless specified otherwise, by default and in case of ambiguity, implement root-cause, robust, extensible, performant, architecturally sound solutions. Avoid adding hacks, compatibility shims unless preserving existing user/API behavior is an explicit product requirement, or blanket defensive programming that hides errors. Avoid "surgical fixes", "minimal solutions", "quick patches" or similar, even if the situation calls for those.
 
 Never cut corners or reduce work scope to save "time" or "tokens", or introduce least-effort solutions in the face of ambiguity. Approach each problem from first principles and implement the best solution regardless of potential scope. Here is non-conclusive list of examples of what to AVOID:
 
@@ -42,9 +74,7 @@ Add succinct code comments that explain what is going on if code is not self-exp
 When working, you are allowed **and expected** to keep the code clean and do the necessary work to keep maintaining and improving the codebase quality, unless the user explicitly instructs you to resort to hacks or simpler solutions. Architectural work, cleanup, or refactoring never justifies unapproved UX or product behavior changes. Consult with the user for each such change that wasn't approved yet.
 
 ## Final answer instructions
-Always favor conciseness in your final answer - you should usually avoid long-winded explanations and focus only on the most important details. For casual chit-chat, just chat. For simple or single-file tasks, prefer 1-2 short paragraphs plus an optional short verification line. Do not default to bullets. On simple tasks, prose is usually better than a list, and if there are only one or two concrete changes you should almost always keep the close-out fully in prose.
-
-On larger tasks, use at most 2-4 high-level sections when helpful. Each section can be a short paragraph or a few flat bullets. Prefer grouping by major change area or user-facing outcome, not by file or edit inventory.
+By default, favor conciseness in your final answer - you should avoid filler, narration, poetic verbosity, or basic explanations and focus on the important details. Don't omit important info like test/build/tooling failures, caveats, blockers, verification status or other user-relevant context in the name of conciseness. For casual chit-chat, just chat. For simple or single-file tasks, prefer 1-2 short paragraphs plus an optional short verification line. Do not default to bullets. On simple tasks, prose is usually better than a list, and if there are only one or two concrete changes you should keep the close-out fully in prose. On larger tasks, use 2-4 high-level sections when helpful. Each section can be a short paragraph or a few flat bullets. Prefer grouping by major change area or user-facing outcome, not by file or edit inventory.
 
 Requirements for your final answer:
 - Use lists only when the content is inherently list-shaped: enumerating distinct items, steps, options, categories, comparisons, ideas. Do not use lists for opinions or straightforward explanations that would read more naturally as prose.
@@ -53,36 +83,7 @@ Requirements for your final answer:
 - Never tell the user to "save/copy this file", the user is on the same machine and has access to the same files as you have.
 - If the user asks for a code explanation, include code references as appropriate.
 - If you weren't able to do something, for example run tests, tell the user.
-
-# Your environment
-Your harness has specific traits & tools that were created to help you. Use these capabilities proactively.
-
-- You and the user share the same workspace and collaborate to achieve the user's goals.
-- To interact with the outside world, you should call tools (functions) available to you.
-- You are producing plain text that will later be styled as Markdown.
-- Always use `patch` for manual code edits. Do not use cat or any other commands when creating or editing files. Formatting commands or bulk edits don't need to be done with the patch tool.
-- Do not use Python to read/write files when a simple shell command or patch would suffice.
-- If you intentionally want the turn to end silently with no transcript entry or other visible effect, send exactly `NO_OP` as the entire `final_answer` content. Do not add any extra text around it. 
-- If you started an asynchronous process (subagent or shell), the harness will notify you whenever it ends and you will be able to resume your work. Combine async processes and the `NO_OP` token turns to "go to sleep" and then continue upon notification.
-- Sometimes you will be notified by your supervisor or shells, waking you up or interrupting you. Don't repeat or restate your answers because of that - assume every message you send is seen by the user unless stated otherwise.
-- Parallelize tool calls whenever possible - especially file reads, such as `cat`, `rg`, `sed`, `ls`, `git show`, `nl`, `wc`. Prefer emitting multiple tool calls in a single assistant turn so the runtime executes them in parallel. Avoid parallelizing `git` operations due to locking/races.
-- Do not re-read the files that you just edited to confirm changes. If patch succeeded, assume the file is in the state you expect it to be. You will be notified about errors separately.
-- Poll background shells for 5-15 mins at a time; avoid short polls.
-
-Like humans, you have limited available working memory. After roughly ~100-200 function calls, you will have to hand off your work to another agent because the conversation will have become long. So work efficiently: use terse commands like `git status --short`, efficiently search with `sg` or `rg`, write scripts, docs, and improve tooling for repeated commands. Handoffs are normal, and you will be notified when your memory becomes full, so do not cut corners, worry, or sacrifice quality in the name of efficiency.
-
-## Workflow guidance
-These best practices are here to make your life better; follow them unless the user explicitly overrides them.
-
-- **NEVER** use destructive commands like `git reset --hard` or `git checkout --` unless specifically requested by the user.
-- Default to ASCII when editing or creating files. Only introduce non-ASCII or other Unicode characters when there is a clear justification and the file already uses them.
-- You struggle using the git interactive console. Do not attempt to use interactive git commands.
-- You may be in a dirty git worktree.
-  * Do not revert existing changes you did not make unless explicitly requested, since these changes were made by the user.
-  * If asked to make a commit or code edits and there are unrelated changes to your work or changes that you didn't make in those files, don't revert those changes.
-  * If the changes are in files you've touched recently, you should read carefully and understand how you can work with the changes rather than reverting them.
-  * If the changes are in unrelated files, just ignore them. If they directly conflict with your current task, stop and ask the user how they would like to proceed. Otherwise, focus on the task at hand.
-- Do not amend a commit unless explicitly requested to do so.
+- If you made a product or other important decision on your own during work, make the user aware of the expanded scope or that ambiguity.
 
 ## Formatting rules
 - Structure your answer if necessary, the complexity of the answer should match the task. If the task is simple, your answer should be a one-liner. Order sections from general to specific to supporting.
@@ -94,17 +95,17 @@ These best practices are here to make your life better; follow them unless the u
 - Don’t use emojis or em dashes unless explicitly instructed.
 
 # Delegating work
-You should delegate work to agents by executing `{{builder_run_command}} "<prompt>"` in a **background shell**. When the agent completes, you will be notified. While they work, you can do something else or end your turn. Subagents usually take 15-45 minutes and only produce output when done. You should give them enough time to complete.
+You can delegate work to agents by executing `{{builder_run_command}} "<prompt>"` in a **background shell**. When the agent completes, you will be notified. While they work, you can do something else or pause. Subagents usually take 15-45 minutes and only produce output when done. You should give them enough time to complete.
 
-You should delegate parts of work to the agents to:
+You should consider delegating parts of work to the agents to:
 
 1. Reduce amount of noise/text in your conversation log (e.g. logs, shell outputs, build steps, code searches, and results). For that, a subagent can run the command for you, wait for it, filter output, and give you a summary. This should be used where you can't reduce the output more easily e.g. grepping or `quiet` flags.
-2. Explore large codebases. A subagent can read and search files to give you relevant, narrowed-down paths to look through, help you plan or debug. Use this approach sparingly only where you know that the codebase is large, or you're looking through a lot of files. Never delegate tiny tasks like reading files or "summarizing file content". Delegate noisy, expansive searches.
+2. Explore large codebases. A subagent can read and search files to give you relevant, narrowed-down paths to look through, help you plan or debug. Use this approach where you know that the codebase/task are large. Never delegate tiny tasks like reading files or "summarizing file content". Delegate noisy, expansive searches.
 3. Split and delegate parts of your real work, described in next sections.
 
 IMPORTANT: Do NOT delegate the entirety of user's request or task. It is bad to receive a task and immediately fully delegate all of it to one agent. Instead, delegate _parts_ of your task when they do not constitute the entirety of the assigned work, or manage multiple subagents that will work for you.
 
-Every subagent is a fresh `builder` instance, with NO prior context about the current conversation. Due to that, your prompts to agents must include **all task-specific information** needed for completion. Subagents already have their own system prompt, repo instructions, and standard engineering workflow, so do **not** pad delegated prompts with baseline rules they already know (for example: "use patch", "avoid unrelated files", "do not revert user changes"). Only restate those when you are overriding them, tightening scope for this subtask, or there is a real risk of ambiguity. Subagents cannot ask questions unless they stop, so preemptively include task context and reduce ambiguity. When orchestrating multiple subagents or task context is large, create temp files with context and for cross-communication if needed. 
+Every subagent is a fresh `builder` instance, with no prior context about your current conversation. Due to that, your prompts to agents must include **all task-specific information** needed for completion. Subagents already have the same system and repo instructions as you, so do **not** pad delegated prompts with baseline rules they already know (for example: "use patch", "avoid unrelated files", "do not revert user changes"). Only restate those when you are overriding them, tightening scope for this subtask, or there is a real risk of ambiguity. Subagents cannot ask questions unless they stop, so preemptively include task context and reduce ambiguity. When orchestrating multiple subagents or task context is large, create temp files with context and for cross-communication if needed.
 
 ## How to split work
 To accomplish large tasks - take on a manager role, communicating with agents (via `--continue` or stdin), clearly breaking down tasks, writing plan documents for agents to follow, responding to subagent run outputs (shell completion notifications), verifying their work, treating other instances as your subordinates, and reviewing completed work. Subagents are aware of this repo's context (AGENTS.md).
@@ -134,11 +135,11 @@ To accomplish large tasks - take on a manager role, communicating with agents (v
 - Split implementation into disjoint codebase slices and spawn multiple agents for them in parallel when the write scopes do not overlap.
 
 ## Example workflows
-- `$ {{builder_run_command}} --fast "Explore logs via Axiom and find mentions of 'REQUEST_CODE_BILLING_FAILURE'", then report timestamps, context, and narrow search queries for me to look through failure paths`. This command relies on AGENTS.md knowledge about axiom to start a sidecar subagent, gives specific instructions, and asks to sift through huge log queries to find relevant info while you explore the code to debug an issue.
+- `$ {{builder_run_command}} --fast "Explore logs via Axiom and find mentions of 'BILLING_FAILURE'", then report timestamps, context, and narrow search queries for me to look through failure paths`. This command relies on repo knowledge about axiom to start a sidecar subagent, gives specific instructions, and asks to sift through huge log queries to find relevant info while you explore the code to debug an issue.
 - "We're working on ./docs/feature_plan.md. Your task is implementation of module 2. Implement module #2 and give back a report of changed files." This is one of several agents completing parts of a plan you, the main agent, created. The plan you wrote is descriptive and work is disjoint with other modules, so you acted as a manager in that session.
-- `--fast "Explore this monorepo, find all modules which use BGTaskScheduler (declared in <...>), list all usages with concrete paths."`. While doing a larger refactor, you delegated information search of a widely used utility. This wasn't your immediate task and not on the critical path - perfect to save context from `rg` noise.
+- `--fast "Explore this monorepo, find all modules that use BGTaskScheduler (declared in <...>), list all usages with concrete paths."`. While doing a larger refactor, you delegated information search of a widely used utility. This wasn't your immediate task and not on the critical path - perfect to save context from `rg` noise.
 
 ### Examples of how NOT to delegate
 - ❌ "Read this file and edit line 147 to include error handling" - the scope is too narrow to delegate. Just do the work yourself.
 - ❌ "Implement <...feature the user just requested...>" - do not delegate the entirety of your work.
-- ❌ "Build the error handling for my code so that we don't crash" - this task is not specific and bounded in scope, blocks your work, the description lacks context, and will result in bad quality implementation.
+- ❌ "Build the error handling for my code so that we don't crash" - this task is not specific and bounded in scope, blocks your work, the description lacks context, and will result in low quality implementation.

--- a/scripts/sandbox-serve.sh
+++ b/scripts/sandbox-serve.sh
@@ -53,7 +53,7 @@ Options:
 
 Examples:
   scripts/sandbox-serve.sh up
-  scripts/sandbox-serve.sh up --host-port 53100 --project-name builder -- --model gpt-5.4
+  scripts/sandbox-serve.sh up --host-port 53100 --project-name builder -- --model gpt-5.5
   scripts/sandbox-serve.sh env --host-port 53100
   scripts/sandbox-serve.sh down --reset
 USAGE

--- a/server/authstatus/service.go
+++ b/server/authstatus/service.go
@@ -223,14 +223,16 @@ func fetchUsagePayload(ctx context.Context, baseURL string, state auth.State) (u
 	}
 	request.Header.Set("Authorization", authorization)
 	request.Header.Set("User-Agent", "builder/dev")
-	if accountID := strings.TrimSpace(state.Method.OAuth.AccountID); accountID != "" {
-		request.Header.Set("ChatGPT-Account-Id", accountID)
+	if state.Method.OAuth != nil {
+		if accountID := strings.TrimSpace(state.Method.OAuth.AccountID); accountID != "" {
+			request.Header.Set("ChatGPT-Account-Id", accountID)
+		}
 	}
 	response, err := (&http.Client{Timeout: 10 * time.Second}).Do(request)
 	if err != nil {
 		return usagePayload{}, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		return usagePayload{}, fmt.Errorf("usage request failed: %s", response.Status)
 	}

--- a/server/authstatus/service.go
+++ b/server/authstatus/service.go
@@ -1,0 +1,344 @@
+package authstatus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"builder/server/auth"
+	"builder/shared/config"
+	"builder/shared/serverapi"
+)
+
+const usageBaseURL = "https://chatgpt.com/backend-api"
+
+type UsagePayloadFetcher func(ctx context.Context, baseURL string, state auth.State) (usagePayload, error)
+
+var DefaultUsagePayloadFetcher UsagePayloadFetcher = fetchUsagePayload
+
+type Service struct {
+	manager *auth.Manager
+	fetcher UsagePayloadFetcher
+}
+
+func NewService(manager *auth.Manager) *Service {
+	return &Service{manager: manager, fetcher: DefaultUsagePayloadFetcher}
+}
+
+func (s *Service) WithUsagePayloadFetcher(fetcher UsagePayloadFetcher) *Service {
+	if s != nil && fetcher != nil {
+		s.fetcher = fetcher
+	}
+	return s
+}
+
+func (s *Service) GetAuthStatus(ctx context.Context, req serverapi.AuthStatusRequest) (serverapi.AuthStatusResponse, error) {
+	state := auth.EmptyState()
+	authStateErr := error(nil)
+	if s != nil && s.manager != nil {
+		loaded, loadErr := s.manager.Load(ctx)
+		if loadErr != nil {
+			authStateErr = loadErr
+		} else {
+			state = loaded
+			resolved, resolveErr := s.manager.CurrentState(ctx)
+			if resolveErr == nil {
+				state = resolved
+			} else {
+				authStateErr = resolveErr
+			}
+		}
+	}
+	resp := serverapi.AuthStatusResponse{
+		Auth:         authInfo(state, req.Settings, authStateErr),
+		Subscription: s.subscriptionStatus(ctx, req.Settings, state, authStateErr),
+	}
+	if authStateErr != nil {
+		resp.Warning = "auth: " + authStateErr.Error()
+	}
+	return resp, nil
+}
+
+func authInfo(state auth.State, settings config.Settings, statusErr error) serverapi.AuthStatusInfo {
+	if statusErr != nil && !state.IsConfigured() {
+		return serverapi.AuthStatusInfo{Summary: "Auth unavailable", Details: []string{statusErr.Error()}, Visible: true}
+	}
+	details := make([]string, 0, 2)
+	baseURL := strings.TrimSpace(settings.OpenAIBaseURL)
+	if baseURL != "" && !isOfficialChatGPTBaseURL(baseURL) {
+		details = append(details, filepath.ToSlash(baseURL))
+	}
+	switch state.Method.Type {
+	case auth.MethodOAuth:
+		summary := "Subscription"
+		if state.Method.OAuth != nil && strings.TrimSpace(state.Method.OAuth.Email) != "" {
+			summary = strings.TrimSpace(state.Method.OAuth.Email)
+		}
+		if statusErr != nil {
+			details = append(details, statusErr.Error())
+		}
+		return serverapi.AuthStatusInfo{Summary: summary, Details: details, Visible: true}
+	case auth.MethodAPIKey:
+		summary := "API key"
+		if provider := providerLabel(state, settings); provider != "" {
+			details = append(details, provider)
+		}
+		if pref := envPreferenceLabel(state.EnvAPIKeyPreference); pref != "" {
+			details = append(details, pref)
+		}
+		if statusErr != nil {
+			details = append(details, statusErr.Error())
+		}
+		return serverapi.AuthStatusInfo{Summary: summary, Details: details, Visible: true}
+	default:
+		if statusErr != nil {
+			return serverapi.AuthStatusInfo{Summary: "Auth unavailable", Details: []string{statusErr.Error()}, Visible: true}
+		}
+		return serverapi.AuthStatusInfo{}
+	}
+}
+
+func (s *Service) subscriptionStatus(ctx context.Context, settings config.Settings, state auth.State, authStateErr error) serverapi.AuthSubscriptionInfo {
+	if !shouldFetchSubscriptionUsage(settings, state) {
+		return serverapi.AuthSubscriptionInfo{}
+	}
+	if authStateErr != nil {
+		errText := authStateErr.Error()
+		return serverapi.AuthSubscriptionInfo{Applicable: true, Summary: "Subscription unavailable: " + errText, Error: errText}
+	}
+	fetcher := fetchUsagePayload
+	if s != nil && s.fetcher != nil {
+		fetcher = s.fetcher
+	}
+	payload, err := fetcher(ctx, usageBaseURL, state)
+	if err != nil {
+		errText := err.Error()
+		return serverapi.AuthSubscriptionInfo{Applicable: true, Summary: "Subscription unavailable: " + errText, Error: errText}
+	}
+	return serverapi.AuthSubscriptionInfo{
+		Applicable: true,
+		Summary:    subscriptionPlanSummary(payload.PlanType),
+		Windows:    usageWindowsByLabel(payload),
+	}
+}
+
+func shouldFetchSubscriptionUsage(settings config.Settings, state auth.State) bool {
+	if state.Method.Type != auth.MethodOAuth || state.Method.OAuth == nil {
+		return false
+	}
+	if strings.TrimSpace(settings.ProviderOverride) != "" {
+		return false
+	}
+	if baseURL := strings.TrimSpace(settings.OpenAIBaseURL); baseURL != "" && !isOfficialChatGPTBaseURL(baseURL) {
+		return false
+	}
+	return true
+}
+
+func isOfficialChatGPTBaseURL(raw string) bool {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return true
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	return host == "chatgpt.com" || host == "chat.openai.com"
+}
+
+func providerLabel(state auth.State, settings config.Settings) string {
+	if provider := strings.TrimSpace(settings.ProviderOverride); provider != "" {
+		return provider
+	}
+	if baseURL := strings.TrimSpace(settings.OpenAIBaseURL); baseURL != "" {
+		return filepath.ToSlash(baseURL)
+	}
+	if state.Method.Type == auth.MethodAPIKey {
+		return "OpenAI"
+	}
+	return ""
+}
+
+func envPreferenceLabel(pref auth.EnvAPIKeyPreference) string {
+	switch pref {
+	case auth.EnvAPIKeyPreferencePreferSaved:
+		return "saved auth preferred"
+	case auth.EnvAPIKeyPreferencePreferEnv:
+		return "OPENAI_API_KEY preferred"
+	default:
+		return ""
+	}
+}
+
+func subscriptionPlanSummary(plan string) string {
+	trimmed := strings.TrimSpace(plan)
+	if trimmed == "" {
+		return "Subscription"
+	}
+	normalized := strings.ToLower(trimmed)
+	return strings.ToUpper(normalized[:1]) + normalized[1:] + " subscription"
+}
+
+type usagePayload struct {
+	PlanType             string             `json:"plan_type"`
+	RateLimit            *usageRateLimit    `json:"rate_limit"`
+	AdditionalRateLimits []usageExtraBucket `json:"additional_rate_limits"`
+}
+
+type UsagePayload = usagePayload
+
+type usageExtraBucket struct {
+	MeteredFeature string          `json:"metered_feature"`
+	LimitName      string          `json:"limit_name"`
+	RateLimit      *usageRateLimit `json:"rate_limit"`
+}
+
+type usageRateLimit struct {
+	PrimaryWindow   *usageWindow `json:"primary_window"`
+	SecondaryWindow *usageWindow `json:"secondary_window"`
+}
+
+type usageWindow struct {
+	UsedPercent        float64 `json:"used_percent"`
+	LimitWindowSeconds int     `json:"limit_window_seconds"`
+	ResetAt            int64   `json:"reset_at"`
+}
+
+func fetchUsagePayload(ctx context.Context, baseURL string, state auth.State) (usagePayload, error) {
+	authorization, err := state.Method.AuthHeaderValue()
+	if err != nil {
+		return usagePayload{}, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/wham/usage", nil)
+	if err != nil {
+		return usagePayload{}, err
+	}
+	request.Header.Set("Authorization", authorization)
+	request.Header.Set("User-Agent", "builder/dev")
+	if accountID := strings.TrimSpace(state.Method.OAuth.AccountID); accountID != "" {
+		request.Header.Set("ChatGPT-Account-Id", accountID)
+	}
+	response, err := (&http.Client{Timeout: 10 * time.Second}).Do(request)
+	if err != nil {
+		return usagePayload{}, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return usagePayload{}, fmt.Errorf("usage request failed: %s", response.Status)
+	}
+	var payload usagePayload
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		return usagePayload{}, fmt.Errorf("decode usage response: %w", err)
+	}
+	return payload, nil
+}
+
+func usageWindowsByLabel(payload usagePayload) []serverapi.AuthSubscriptionWindow {
+	type orderedWindow struct {
+		window        serverapi.AuthSubscriptionWindow
+		durationSecs  int
+		discoveryRank int
+	}
+	qualifierCounts := map[string]int{}
+	ordered := make([]orderedWindow, 0, 2+len(payload.AdditionalRateLimits)*2)
+	discoveryRank := 0
+	addWindow := func(window *usageWindow, qualifier string) {
+		if window == nil {
+			return
+		}
+		label := limitDuration(window.LimitWindowSeconds / 60)
+		if label == "" {
+			return
+		}
+		snapshot := serverapi.AuthSubscriptionWindow{
+			Label:       label,
+			Qualifier:   qualifier,
+			UsedPercent: window.UsedPercent,
+		}
+		if window.ResetAt > 0 {
+			snapshot.ResetAt = time.Unix(window.ResetAt, 0).UTC()
+		}
+		ordered = append(ordered, orderedWindow{window: snapshot, durationSecs: window.LimitWindowSeconds, discoveryRank: discoveryRank})
+		discoveryRank++
+	}
+	if payload.RateLimit != nil {
+		addWindow(payload.RateLimit.PrimaryWindow, "")
+		addWindow(payload.RateLimit.SecondaryWindow, "")
+	}
+	for _, extra := range payload.AdditionalRateLimits {
+		if extra.RateLimit == nil {
+			continue
+		}
+		qualifier := usageWindowQualifier(extra, qualifierCounts)
+		addWindow(extra.RateLimit.PrimaryWindow, qualifier)
+		addWindow(extra.RateLimit.SecondaryWindow, qualifier)
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].durationSecs != ordered[j].durationSecs {
+			return ordered[i].durationSecs < ordered[j].durationSecs
+		}
+		return ordered[i].discoveryRank < ordered[j].discoveryRank
+	})
+	windows := make([]serverapi.AuthSubscriptionWindow, 0, len(ordered))
+	for _, window := range ordered {
+		windows = append(windows, window.window)
+	}
+	return windows
+}
+
+func usageWindowQualifier(bucket usageExtraBucket, counts map[string]int) string {
+	limitName := strings.TrimSpace(bucket.LimitName)
+	feature := strings.TrimSpace(bucket.MeteredFeature)
+	base := ""
+	switch {
+	case limitName == "" && feature == "":
+		base = "extra"
+	case limitName == "":
+		base = feature
+	case feature == "" || strings.EqualFold(limitName, feature):
+		base = limitName
+	default:
+		base = limitName + " / " + feature
+	}
+	counts[base]++
+	if counts[base] == 1 {
+		return base
+	}
+	return fmt.Sprintf("%s #%d", base, counts[base])
+}
+
+func limitDuration(windowMinutes int) string {
+	const minutesPerHour = 60
+	const minutesPerDay = 24 * minutesPerHour
+	const minutesPerWeek = 7 * minutesPerDay
+	const minutesPerMonth = 30 * minutesPerDay
+	const roundingBiasMinutes = 3
+
+	if windowMinutes < 0 {
+		windowMinutes = 0
+	}
+	if windowMinutes <= minutesPerDay+roundingBiasMinutes {
+		hours := (windowMinutes + roundingBiasMinutes) / minutesPerHour
+		if hours < 1 {
+			hours = 1
+		}
+		return fmt.Sprintf("%dh", hours)
+	}
+	if windowMinutes <= minutesPerWeek+roundingBiasMinutes {
+		return "weekly"
+	}
+	if windowMinutes <= minutesPerMonth+roundingBiasMinutes {
+		return "monthly"
+	}
+	return "annual"
+}
+
+var _ serverapi.AuthStatusService = (*Service)(nil)

--- a/server/authstatus/service.go
+++ b/server/authstatus/service.go
@@ -322,6 +322,7 @@ func limitDuration(windowMinutes int) string {
 	const minutesPerDay = 24 * minutesPerHour
 	const minutesPerWeek = 7 * minutesPerDay
 	const minutesPerMonth = 30 * minutesPerDay
+	const minutesPerYear = 365 * minutesPerDay
 	const roundingBiasMinutes = 3
 
 	if windowMinutes < 0 {
@@ -339,6 +340,13 @@ func limitDuration(windowMinutes int) string {
 	}
 	if windowMinutes <= minutesPerMonth+roundingBiasMinutes {
 		return "monthly"
+	}
+	if windowMinutes < minutesPerYear-roundingBiasMinutes {
+		days := (windowMinutes + minutesPerDay/2) / minutesPerDay
+		if days < 31 {
+			days = 31
+		}
+		return fmt.Sprintf("%dd", days)
 	}
 	return "annual"
 }

--- a/server/authstatus/service_test.go
+++ b/server/authstatus/service_test.go
@@ -28,3 +28,24 @@ func TestFetchUsagePayloadHandlesNonOAuthState(t *testing.T) {
 		t.Fatalf("ChatGPT-Account-Id = %q, want empty for API key auth", accountHeader)
 	}
 }
+
+func TestLimitDuration(t *testing.T) {
+	tests := []struct {
+		name          string
+		windowMinutes int
+		want          string
+	}{
+		{name: "daily", windowMinutes: 24 * 60, want: "24h"},
+		{name: "weekly", windowMinutes: 7 * 24 * 60, want: "weekly"},
+		{name: "monthly", windowMinutes: 30 * 24 * 60, want: "monthly"},
+		{name: "ninety days", windowMinutes: 90 * 24 * 60, want: "90d"},
+		{name: "annual", windowMinutes: 365 * 24 * 60, want: "annual"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := limitDuration(tt.windowMinutes); got != tt.want {
+				t.Fatalf("limitDuration(%d) = %q, want %q", tt.windowMinutes, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/authstatus/service_test.go
+++ b/server/authstatus/service_test.go
@@ -1,0 +1,30 @@
+package authstatus
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"builder/server/auth"
+)
+
+func TestFetchUsagePayloadHandlesNonOAuthState(t *testing.T) {
+	var accountHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		accountHeader = r.Header.Get("ChatGPT-Account-Id")
+		_ = json.NewEncoder(w).Encode(usagePayload{
+			PlanType: "pro",
+		})
+	}))
+	defer server.Close()
+
+	_, err := fetchUsagePayload(context.Background(), server.URL, auth.State{Method: auth.Method{Type: auth.MethodAPIKey, APIKey: &auth.APIKeyMethod{Key: "test-key"}}})
+	if err != nil {
+		t.Fatalf("fetchUsagePayload: %v", err)
+	}
+	if accountHeader != "" {
+		t.Fatalf("ChatGPT-Account-Id = %q, want empty for API key auth", accountHeader)
+	}
+}

--- a/server/bootstrap/embedded.go
+++ b/server/bootstrap/embedded.go
@@ -51,7 +51,7 @@ func ResolveConfig(req Request) (ConfigPlan, error) {
 		now = time.Now
 	}
 	bootstrapPlan := launch.BootstrapPlan{
-		WorkspaceRoot:    requestedWorkspaceRoot(req.WorkspaceRoot),
+		WorkspaceRoot:    strings.TrimSpace(req.WorkspaceRoot),
 		OpenAIBaseURL:    strings.TrimSpace(req.OpenAIBaseURL),
 		UseOpenAIBaseURL: req.OpenAIBaseURLExplicit,
 	}
@@ -63,7 +63,7 @@ func ResolveConfig(req Request) (ConfigPlan, error) {
 		return ConfigPlan{}, err
 	}
 	bootstrapPlan, err = launch.ResolveBootstrapPlan(cfg.PersistenceRoot, launch.BootstrapRequest{
-		WorkspaceRoot:         requestedWorkspaceRoot(req.WorkspaceRoot),
+		WorkspaceRoot:         strings.TrimSpace(req.WorkspaceRoot),
 		WorkspaceRootExplicit: req.WorkspaceRootExplicit,
 		SessionID:             strings.TrimSpace(req.SessionID),
 		OpenAIBaseURL:         strings.TrimSpace(req.OpenAIBaseURL),
@@ -76,9 +76,13 @@ func ResolveConfig(req Request) (ConfigPlan, error) {
 	if err != nil {
 		return ConfigPlan{}, err
 	}
-	_, containerDir, err := config.ResolveWorkspaceContainer(cfg)
-	if err != nil {
-		return ConfigPlan{}, err
+	containerDir := ""
+	if strings.TrimSpace(cfg.WorkspaceRoot) != "" {
+		_, resolvedContainerDir, err := config.ResolveWorkspaceContainer(cfg)
+		if err != nil {
+			return ConfigPlan{}, err
+		}
+		containerDir = resolvedContainerDir
 	}
 	return ConfigPlan{Config: cfg, ContainerDir: containerDir}, nil
 }
@@ -131,12 +135,8 @@ func loadConfig(loadOpts config.LoadOptions, workspaceRoot, openAIBaseURL string
 	} else {
 		loadOpts.OpenAIBaseURL = ""
 	}
-	return config.Load(workspaceRoot, loadOpts)
-}
-
-func requestedWorkspaceRoot(workspaceRoot string) string {
 	if strings.TrimSpace(workspaceRoot) == "" {
-		return "."
+		return config.LoadGlobal(loadOpts)
 	}
-	return workspaceRoot
+	return config.Load(workspaceRoot, loadOpts)
 }

--- a/server/core/core.go
+++ b/server/core/core.go
@@ -11,6 +11,7 @@ import (
 	"builder/server/askview"
 	"builder/server/auth"
 	"builder/server/authbootstrap"
+	"builder/server/authstatus"
 	serverbootstrap "builder/server/bootstrap"
 	"builder/server/launch"
 	"builder/server/metadata"
@@ -61,6 +62,7 @@ type Core struct {
 	projectID        string
 	projectViews     client.ProjectViewClient
 	authBootstrap    client.AuthBootstrapClient
+	authStatus       client.AuthStatusClient
 	askViews         client.AskViewClient
 	approvalViews    client.ApprovalViewClient
 	processControls  client.ProcessControlClient
@@ -139,6 +141,7 @@ func New(cfg config.App, authSupport serverbootstrap.AuthSupport, runtimeSupport
 	worktreeService := worktree.NewService(metadataStore, nil, runtimeRegistry, sessionRuntimeService, runtimeSupport.Background, runtimeControlService, worktree.ServiceOptions{BaseDir: cfg.Settings.Worktrees.BaseDir, SetupScript: cfg.Settings.Worktrees.SetupScript})
 	projectViews := client.NewLoopbackProjectViewClient(projectService)
 	authBootstrapService := authbootstrap.NewService(authSupport.AuthManager, authSupport.OAuthOptions, protocol.AllowedPreAuthMethods())
+	authStatusService := authstatus.NewService(authSupport.AuthManager)
 	sessionViewService := sessionview.NewService(registry.NewGlobalPersistenceSessionResolver(cfg.PersistenceRoot, storeOptions...), runtimeRegistry, metadataStore).WithCacheWarningMode(cfg.Settings.CacheWarningMode)
 	sessionLifecycleService := sessionlifecycle.NewGlobalService(cfg.PersistenceRoot, sessionStoreRegistry, authSupport.AuthManager, storeOptions...).WithControllerLeaseVerifier(sessionRuntimeService)
 	sessionActivityService := sessionactivity.NewService(runtimeRegistry)
@@ -157,6 +160,7 @@ func New(cfg config.App, authSupport serverbootstrap.AuthSupport, runtimeSupport
 		runPromptMap:     make(map[string]client.RunPromptClient),
 		projectViews:     projectViews,
 		authBootstrap:    client.NewLoopbackAuthBootstrapClient(authBootstrapService),
+		authStatus:       client.NewLoopbackAuthStatusClient(authStatusService),
 		askViews:         client.NewLoopbackAskViewClient(askService),
 		approvalViews:    client.NewLoopbackApprovalViewClient(approvalService),
 		processControls:  client.NewLoopbackProcessControlClient(processService),
@@ -503,6 +507,13 @@ func (s *Core) AuthBootstrapClient() client.AuthBootstrapClient {
 		return nil
 	}
 	return s.authBootstrap
+}
+
+func (s *Core) AuthStatusClient() client.AuthStatusClient {
+	if s == nil {
+		return nil
+	}
+	return s.authStatus
 }
 
 func (s *Core) AskViewClient() client.AskViewClient {

--- a/server/core/core.go
+++ b/server/core/core.go
@@ -101,10 +101,14 @@ func New(cfg config.App, authSupport serverbootstrap.AuthSupport, runtimeSupport
 		_ = rootLease.Close()
 		return nil, err
 	}
-	_, containerDir, err := config.ResolveWorkspaceContainer(cfg)
-	if err != nil {
-		_ = rootLease.Close()
-		return nil, err
+	containerDir := ""
+	if strings.TrimSpace(cfg.WorkspaceRoot) != "" {
+		_, resolvedContainerDir, err := config.ResolveWorkspaceContainer(cfg)
+		if err != nil {
+			_ = rootLease.Close()
+			return nil, err
+		}
+		containerDir = resolvedContainerDir
 	}
 	metadataStore, err := metadata.Open(cfg.PersistenceRoot)
 	if err != nil {
@@ -177,25 +181,27 @@ func New(cfg config.App, authSupport serverbootstrap.AuthSupport, runtimeSupport
 		worktrees:        client.NewLoopbackWorktreeClient(worktreeService),
 		runPrompt:        unregisteredRunPromptClient{},
 	}
-	binding, err := metadataStore.EnsureWorkspaceBinding(context.Background(), cfg.WorkspaceRoot)
-	if err != nil && !errors.Is(err, serverapi.ErrWorkspaceNotRegistered) {
-		_ = rootLease.Close()
-		_ = metadataStore.Close()
-		return nil, err
-	}
-	if err == nil {
-		core.projectID = binding.ProjectID
-		core.sessionLaunch, err = core.SessionLaunchClientForProjectWorkspace(context.Background(), binding.ProjectID, cfg.WorkspaceRoot)
-		if err != nil {
+	if strings.TrimSpace(cfg.WorkspaceRoot) != "" {
+		binding, err := metadataStore.EnsureWorkspaceBinding(context.Background(), cfg.WorkspaceRoot)
+		if err != nil && !errors.Is(err, serverapi.ErrWorkspaceNotRegistered) {
 			_ = rootLease.Close()
 			_ = metadataStore.Close()
 			return nil, err
 		}
-		core.runPrompt, err = core.RunPromptClientForProjectWorkspace(context.Background(), binding.ProjectID, cfg.WorkspaceRoot)
-		if err != nil {
-			_ = rootLease.Close()
-			_ = metadataStore.Close()
-			return nil, err
+		if err == nil {
+			core.projectID = binding.ProjectID
+			core.sessionLaunch, err = core.SessionLaunchClientForProjectWorkspace(context.Background(), binding.ProjectID, cfg.WorkspaceRoot)
+			if err != nil {
+				_ = rootLease.Close()
+				_ = metadataStore.Close()
+				return nil, err
+			}
+			core.runPrompt, err = core.RunPromptClientForProjectWorkspace(context.Background(), binding.ProjectID, cfg.WorkspaceRoot)
+			if err != nil {
+				_ = rootLease.Close()
+				_ = metadataStore.Close()
+				return nil, err
+			}
 		}
 	}
 	return core, nil
@@ -304,8 +310,10 @@ func (s *Core) resolveProjectContext(ctx context.Context, projectID string, work
 				Availability: availability,
 			}
 		}
-		projectCfg := s.cfg
-		projectCfg.WorkspaceRoot = binding.CanonicalRoot
+		projectCfg, err := s.configForWorkspace(binding.CanonicalRoot)
+		if err != nil {
+			return projectContext{}, err
+		}
 		return projectContext{
 			config:         projectCfg,
 			projectID:      trimmedProjectID,
@@ -320,8 +328,10 @@ func (s *Core) resolveProjectContext(ctx context.Context, projectID string, work
 			if strings.TrimSpace(binding.ProjectID) != trimmedProjectID {
 				return projectContext{}, fmt.Errorf("workspace %q is not bound to project %q", binding.CanonicalRoot, trimmedProjectID)
 			}
-			projectCfg := s.cfg
-			projectCfg.WorkspaceRoot = binding.CanonicalRoot
+			projectCfg, err := s.configForWorkspace(binding.CanonicalRoot)
+			if err != nil {
+				return projectContext{}, err
+			}
 			return projectContext{
 				config:         projectCfg,
 				projectID:      trimmedProjectID,
@@ -348,14 +358,37 @@ func (s *Core) resolveProjectContext(ctx context.Context, projectID string, work
 			Availability: overview.Project.Availability,
 		}
 	}
-	projectCfg := s.cfg
-	projectCfg.WorkspaceRoot = overview.Project.RootPath
+	projectCfg, err := s.configForWorkspace(overview.Project.RootPath)
+	if err != nil {
+		return projectContext{}, err
+	}
 	return projectContext{
 		config:         projectCfg,
 		projectID:      trimmedProjectID,
 		projectRoot:    overview.Project.RootPath,
 		projectSession: config.ProjectSessionsRoot(projectCfg, trimmedProjectID),
 	}, nil
+}
+
+func (s *Core) configForWorkspace(workspaceRoot string) (config.App, error) {
+	if s == nil {
+		return config.App{}, errors.New("core is required")
+	}
+	if strings.TrimSpace(s.cfg.WorkspaceRoot) != "" {
+		currentRoot, currentErr := config.CanonicalWorkspaceRoot(s.cfg.WorkspaceRoot)
+		requestedRoot, requestedErr := config.CanonicalWorkspaceRoot(workspaceRoot)
+		if currentErr == nil && requestedErr == nil && currentRoot == requestedRoot {
+			projectCfg := s.cfg
+			projectCfg.WorkspaceRoot = requestedRoot
+			return projectCfg, nil
+		}
+	}
+	projectCfg, err := config.Load(workspaceRoot, config.LoadOptions{})
+	if err != nil {
+		return config.App{}, err
+	}
+	projectCfg.PersistenceRoot = s.cfg.PersistenceRoot
+	return projectCfg, nil
 }
 
 func (s *Core) sessionLaunchClientForProjectContext(projectCtx projectContext) client.SessionLaunchClient {
@@ -374,6 +407,9 @@ func (s *Core) sessionLaunchClientForProjectContext(projectCtx projectContext) c
 		ProjectID:    projectCtx.projectID,
 		ProjectViews: s.projectViews,
 		StoreOptions: s.metadataStore.AuthoritativeSessionStoreOptions(),
+		ReloadConfig: func() (config.App, error) {
+			return s.configForWorkspace(projectCtx.projectRoot)
+		},
 	}, s.sessionStores)
 	client := client.NewLoopbackSessionLaunchClient(service)
 	s.sessionLaunchMap[scopeKey] = client

--- a/server/core/core_test.go
+++ b/server/core/core_test.go
@@ -293,6 +293,59 @@ func TestSessionLaunchClientForProjectWorkspaceReplaysForceNewSessionAcrossClien
 	}
 }
 
+func TestSessionLaunchClientForProjectWorkspaceUsesWorkspaceLocalConfig(t *testing.T) {
+	home := t.TempDir()
+	workspaceA := t.TempDir()
+	workspaceB := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(workspaceB, ".builder"), 0o755); err != nil {
+		t.Fatalf("create workspace config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspaceB, ".builder", "config.toml"), []byte("model = \"workspace-b-model\"\nthinking_level = \"high\"\n"), 0o644); err != nil {
+		t.Fatalf("write workspace config: %v", err)
+	}
+
+	resolvedA, err := serverbootstrap.ResolveConfig(serverbootstrap.Request{WorkspaceRoot: workspaceA})
+	if err != nil {
+		t.Fatalf("ResolveConfig A: %v", err)
+	}
+	resolvedB, err := serverbootstrap.ResolveConfig(serverbootstrap.Request{WorkspaceRoot: workspaceB})
+	if err != nil {
+		t.Fatalf("ResolveConfig B: %v", err)
+	}
+	bindingB, err := metadata.RegisterBinding(context.Background(), resolvedB.Config.PersistenceRoot, resolvedB.Config.WorkspaceRoot)
+	if err != nil {
+		t.Fatalf("RegisterBinding B: %v", err)
+	}
+	authSupport, err := serverbootstrap.BuildAuthSupport(auth.NewMemoryStore(auth.EmptyState()), nil, nil)
+	if err != nil {
+		t.Fatalf("BuildAuthSupport: %v", err)
+	}
+	runtimeSupport, err := serverbootstrap.BuildRuntimeSupport(resolvedA.Config)
+	if err != nil {
+		t.Fatalf("BuildRuntimeSupport: %v", err)
+	}
+	t.Cleanup(func() { _ = runtimeSupport.Background.Close() })
+
+	appCore, err := New(resolvedA.Config, authSupport, runtimeSupport)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = appCore.Close() })
+
+	client, err := appCore.SessionLaunchClientForProjectWorkspace(context.Background(), bindingB.ProjectID, workspaceB)
+	if err != nil {
+		t.Fatalf("SessionLaunchClientForProjectWorkspace: %v", err)
+	}
+	plan, err := client.PlanSession(context.Background(), serverapi.SessionPlanRequest{ClientRequestID: "req-1", Mode: serverapi.SessionLaunchModeInteractive, ForceNewSession: true})
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if plan.Plan.ActiveSettings.Model != "workspace-b-model" || plan.Plan.ActiveSettings.ThinkingLevel != "high" {
+		t.Fatalf("unexpected active settings: %+v", plan.Plan.ActiveSettings)
+	}
+}
+
 func TestRunPromptClientForProjectWorkspaceReplaysHeadlessRunAcrossClientInstances(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()

--- a/server/launch/bootstrap.go
+++ b/server/launch/bootstrap.go
@@ -29,9 +29,6 @@ func ResolveBootstrapPlan(persistenceRoot string, req BootstrapRequest) (Bootstr
 		OpenAIBaseURL:    strings.TrimSpace(req.OpenAIBaseURL),
 		UseOpenAIBaseURL: req.OpenAIBaseURLExplicit,
 	}
-	if plan.WorkspaceRoot == "" {
-		plan.WorkspaceRoot = "."
-	}
 	if strings.TrimSpace(req.SessionID) == "" {
 		return plan, nil
 	}

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -34,6 +34,7 @@ type Planner struct {
 	ProjectViews client.ProjectViewClient
 	PickSession  SessionPicker
 	StoreOptions []session.StoreOption
+	ReloadConfig func() (config.App, error)
 }
 
 type SessionPicker func([]session.Summary) (SessionSelection, error)
@@ -63,6 +64,13 @@ type SessionPlan struct {
 }
 
 func (p Planner) PlanSession(req SessionRequest) (SessionPlan, error) {
+	if p.ReloadConfig != nil {
+		cfg, err := p.ReloadConfig()
+		if err != nil {
+			return SessionPlan{}, err
+		}
+		p.Config = cfg
+	}
 	store, err := p.openStore(req)
 	if err != nil {
 		return SessionPlan{}, err

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"builder/server/auth"
+	"builder/server/llm"
 	"builder/server/session"
 	"builder/shared/client"
 	"builder/shared/clientui"
@@ -51,6 +52,39 @@ func TestPlannerHeadlessCreatesNewSessionAndAppliesContinuationContext(t *testin
 	}
 	if plan.WorkspaceRoot != "/tmp/workspace-a" {
 		t.Fatalf("expected workspace root passthrough, got %q", plan.WorkspaceRoot)
+	}
+}
+
+func TestPlannerHeadlessUsesDefaultGPT55ModelAndOpenAIProviderInference(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg, err := config.Load(workspace, config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	planner := Planner{
+		Config:       cfg,
+		ContainerDir: filepath.Join(cfg.PersistenceRoot, "sessions", "workspace-a"),
+	}
+
+	plan, err := planner.PlanSession(SessionRequest{Mode: ModeHeadless})
+	if err != nil {
+		t.Fatalf("plan session: %v", err)
+	}
+	if plan.ActiveSettings.Model != "gpt-5.5" {
+		t.Fatalf("active model = %q, want gpt-5.5", plan.ActiveSettings.Model)
+	}
+	if plan.ConfiguredModelName != "gpt-5.5" {
+		t.Fatalf("configured model = %q, want gpt-5.5", plan.ConfiguredModelName)
+	}
+	provider, err := llm.InferProviderFromModel(plan.ActiveSettings.Model)
+	if err != nil {
+		t.Fatalf("InferProviderFromModel: %v", err)
+	}
+	if provider != llm.ProviderOpenAI {
+		t.Fatalf("provider = %q, want %q", provider, llm.ProviderOpenAI)
 	}
 }
 

--- a/server/llm/openai_http_input.go
+++ b/server/llm/openai_http_input.go
@@ -33,6 +33,18 @@ func buildResponsesInput(canonical []ResponseItem) []responses.ResponseInputItem
 				continue
 			}
 			items = append(items, functionCallOutputInputItems(callID, item.Name, item.Output)...)
+		case ResponseItemTypeCustomToolCall:
+			callID := textutil.FirstNonEmpty(strings.TrimSpace(item.CallID), strings.TrimSpace(item.ID))
+			if callID == "" {
+				continue
+			}
+			items = append(items, responses.ResponseInputItemParamOfCustomToolCall(callID, item.CustomInput, strings.TrimSpace(item.Name)))
+		case ResponseItemTypeCustomToolOutput:
+			callID := strings.TrimSpace(item.CallID)
+			if callID == "" {
+				continue
+			}
+			items = append(items, responses.ResponseInputItemParamOfCustomToolCallOutput(callID, outputStringFromRaw(item.Output)))
 		case ResponseItemTypeReasoning:
 			id := strings.TrimSpace(item.ID)
 			if id == "" {

--- a/server/llm/openai_http_output_parser.go
+++ b/server/llm/openai_http_output_parser.go
@@ -39,6 +39,7 @@ func defaultResponseOutputItemParsers() responseOutputItemParsers {
 	return newResponseOutputItemParsers(
 		messageOutputItemParser{},
 		functionCallOutputItemParser{},
+		customToolCallOutputItemParser{},
 		reasoningOutputItemParser{},
 		compactionOutputItemParser{},
 	)
@@ -151,6 +152,37 @@ func (functionCallOutputItemParser) Parse(item responses.ResponseOutputItemUnion
 }
 
 type reasoningOutputItemParser struct{}
+
+type customToolCallOutputItemParser struct{}
+
+func (customToolCallOutputItemParser) ItemType() string { return "custom_tool_call" }
+
+func (customToolCallOutputItemParser) Parse(item responses.ResponseOutputItemUnion) parsedResponseOutputItem {
+	call := item.AsCustomToolCall()
+	callID := textutil.FirstNonEmpty(strings.TrimSpace(call.CallID), strings.TrimSpace(call.ID))
+	name := strings.TrimSpace(call.Name)
+	if callID == "" && name == "" {
+		return parsedResponseOutputItem{}
+	}
+	raw := json.RawMessage(item.RawJSON())
+	return parsedResponseOutputItem{
+		CanonicalItems: []ResponseItem{{
+			Type:        ResponseItemTypeCustomToolCall,
+			ID:          strings.TrimSpace(call.ID),
+			CallID:      callID,
+			Name:        call.Name,
+			CustomInput: call.Input,
+			Raw:         raw,
+		}},
+		ToolCalls: []ToolCall{{
+			ID:          callID,
+			Name:        call.Name,
+			Input:       normalizeToolInput(call.Input),
+			Custom:      true,
+			CustomInput: call.Input,
+		}},
+	}
+}
 
 func (reasoningOutputItemParser) ItemType() string { return "reasoning" }
 

--- a/server/llm/openai_http_payloads.go
+++ b/server/llm/openai_http_payloads.go
@@ -142,12 +142,16 @@ func (b openAIRequestPayloadBuilder) buildTools(requestTools []Tool, enableNativ
 
 func buildFunctionToolParam(tool Tool) (responses.ToolUnionParam, error) {
 	if tool.Custom != nil {
+		name := strings.TrimSpace(tool.Name)
+		if name == "" {
+			return responses.ToolUnionParam{}, fmt.Errorf("custom tool name is required")
+		}
 		format := shared.CustomToolInputFormatUnionParam{}
 		switch strings.TrimSpace(tool.Custom.Type) {
 		case "grammar":
 			definition := tool.Custom.Definition
 			if strings.TrimSpace(definition) == "" {
-				return responses.ToolUnionParam{}, fmt.Errorf("custom tool grammar definition is required for %s", tool.Name)
+				return responses.ToolUnionParam{}, fmt.Errorf("custom tool grammar definition is required for %s", name)
 			}
 			syntax := strings.TrimSpace(tool.Custom.Syntax)
 			if syntax == "" {
@@ -158,9 +162,9 @@ func buildFunctionToolParam(tool Tool) (responses.ToolUnionParam, error) {
 			text := shared.NewCustomToolInputFormatTextParam()
 			format = shared.CustomToolInputFormatUnionParam{OfText: &text}
 		default:
-			return responses.ToolUnionParam{}, fmt.Errorf("unsupported custom tool format %q for %s", tool.Custom.Type, tool.Name)
+			return responses.ToolUnionParam{}, fmt.Errorf("unsupported custom tool format %q for %s", tool.Custom.Type, name)
 		}
-		custom := responses.CustomToolParam{Name: strings.TrimSpace(tool.Name), Format: format}
+		custom := responses.CustomToolParam{Name: name, Format: format}
 		if description := strings.TrimSpace(tool.Description); description != "" {
 			custom.Description = openai.String(description)
 		}

--- a/server/llm/openai_http_payloads.go
+++ b/server/llm/openai_http_payloads.go
@@ -141,6 +141,31 @@ func (b openAIRequestPayloadBuilder) buildTools(requestTools []Tool, enableNativ
 }
 
 func buildFunctionToolParam(tool Tool) (responses.ToolUnionParam, error) {
+	if tool.Custom != nil {
+		format := shared.CustomToolInputFormatUnionParam{}
+		switch strings.TrimSpace(tool.Custom.Type) {
+		case "grammar":
+			definition := tool.Custom.Definition
+			if strings.TrimSpace(definition) == "" {
+				return responses.ToolUnionParam{}, fmt.Errorf("custom tool grammar definition is required for %s", tool.Name)
+			}
+			syntax := strings.TrimSpace(tool.Custom.Syntax)
+			if syntax == "" {
+				syntax = "lark"
+			}
+			format = shared.CustomToolInputFormatParamOfGrammar(definition, syntax)
+		case "", "text":
+			text := shared.NewCustomToolInputFormatTextParam()
+			format = shared.CustomToolInputFormatUnionParam{OfText: &text}
+		default:
+			return responses.ToolUnionParam{}, fmt.Errorf("unsupported custom tool format %q for %s", tool.Custom.Type, tool.Name)
+		}
+		custom := responses.CustomToolParam{Name: strings.TrimSpace(tool.Name), Format: format}
+		if description := strings.TrimSpace(tool.Description); description != "" {
+			custom.Description = openai.String(description)
+		}
+		return responses.ToolUnionParam{OfCustom: &custom}, nil
+	}
 	if len(tool.Schema) > 0 && !json.Valid(tool.Schema) {
 		return responses.ToolUnionParam{}, fmt.Errorf("invalid tool schema for %s", tool.Name)
 	}

--- a/server/llm/openai_http_stream.go
+++ b/server/llm/openai_http_stream.go
@@ -50,6 +50,10 @@ func (a *responseStreamAccumulator) Consume(evt responses.ResponseStreamEventUni
 		a.toolCalls.AppendArguments(evt.ItemID, evt.Delta)
 	case "response.function_call_arguments.done":
 		a.toolCalls.SetArguments(evt.ItemID, evt.Arguments)
+	case "response.custom_tool_call_input.delta":
+		a.toolCalls.AppendCustomInput(evt.ItemID, evt.Delta)
+	case "response.custom_tool_call_input.done":
+		a.toolCalls.SetCustomInput(evt.ItemID, evt.Input)
 	case "response.reasoning_summary_text.delta":
 		key := reasoningEventKey(evt.ItemID, evt.OutputIndex, evt.SummaryIndex)
 		a.reasoning.Append(reasoningRoleSummary, key, evt.Delta)
@@ -410,9 +414,11 @@ type toolCallAccumulator struct {
 }
 
 type toolCallState struct {
-	CallID string
-	Name   string
-	Args   strings.Builder
+	CallID   string
+	Name     string
+	Args     strings.Builder
+	Custom   strings.Builder
+	IsCustom bool
 }
 
 func newToolCallAccumulator() *toolCallAccumulator {
@@ -437,11 +443,28 @@ func (a *toolCallAccumulator) ensure(key string) *toolCallState {
 }
 
 func (a *toolCallAccumulator) UpsertFromOutput(item responses.ResponseOutputItemUnion) {
-	if item.Type != "function_call" {
+	if item.Type != "function_call" && item.Type != "custom_tool_call" {
 		return
 	}
-	call := item.AsFunctionCall()
-	key := textutil.FirstNonEmpty(strings.TrimSpace(call.CallID), strings.TrimSpace(call.ID))
+	callID := ""
+	id := ""
+	name := ""
+	args := ""
+	isCustom := item.Type == "custom_tool_call"
+	if isCustom {
+		call := item.AsCustomToolCall()
+		callID = call.CallID
+		id = call.ID
+		name = call.Name
+		args = call.Input
+	} else {
+		call := item.AsFunctionCall()
+		callID = call.CallID
+		id = call.ID
+		name = call.Name
+		args = call.Arguments
+	}
+	key := textutil.FirstNonEmpty(strings.TrimSpace(callID), strings.TrimSpace(id))
 	if key == "" {
 		return
 	}
@@ -449,16 +472,22 @@ func (a *toolCallAccumulator) UpsertFromOutput(item responses.ResponseOutputItem
 	if state == nil {
 		return
 	}
-	if v := strings.TrimSpace(call.CallID); v != "" {
+	if v := strings.TrimSpace(callID); v != "" {
 		state.CallID = v
 	}
-	if v := strings.TrimSpace(call.Name); v != "" {
+	if v := strings.TrimSpace(name); v != "" {
 		state.Name = v
 	}
-	if call.ID != "" {
-		a.itemToKey[call.ID] = key
+	if id != "" {
+		a.itemToKey[id] = key
 	}
-	if args := strings.TrimSpace(call.Arguments); args != "" {
+	if isCustom {
+		state.IsCustom = true
+		if strings.TrimSpace(args) != "" {
+			state.Custom.Reset()
+			state.Custom.WriteString(args)
+		}
+	} else if strings.TrimSpace(args) != "" {
 		state.Args.Reset()
 		state.Args.WriteString(args)
 	}
@@ -483,6 +512,27 @@ func (a *toolCallAccumulator) SetArguments(itemID, arguments string) {
 	state.Args.WriteString(arguments)
 }
 
+func (a *toolCallAccumulator) AppendCustomInput(itemID, delta string) {
+	key := textutil.FirstNonEmpty(strings.TrimSpace(a.itemToKey[itemID]), strings.TrimSpace(itemID))
+	state := a.ensure(key)
+	if state == nil || delta == "" {
+		return
+	}
+	state.IsCustom = true
+	state.Custom.WriteString(delta)
+}
+
+func (a *toolCallAccumulator) SetCustomInput(itemID, input string) {
+	key := textutil.FirstNonEmpty(strings.TrimSpace(a.itemToKey[itemID]), strings.TrimSpace(itemID))
+	state := a.ensure(key)
+	if state == nil {
+		return
+	}
+	state.IsCustom = true
+	state.Custom.Reset()
+	state.Custom.WriteString(input)
+}
+
 func (a *toolCallAccumulator) Merge(calls []ToolCall) {
 	for _, call := range calls {
 		key := textutil.FirstNonEmpty(strings.TrimSpace(call.ID), strings.TrimSpace(call.Name))
@@ -497,8 +547,14 @@ func (a *toolCallAccumulator) Merge(calls []ToolCall) {
 			state.Name = v
 		}
 		if len(call.Input) > 0 {
-			state.Args.Reset()
-			state.Args.WriteString(normalizeToolArguments(string(call.Input)))
+			if call.Custom {
+				state.IsCustom = true
+				state.Custom.Reset()
+				state.Custom.WriteString(call.CustomInput)
+			} else {
+				state.Args.Reset()
+				state.Args.WriteString(normalizeToolArguments(string(call.Input)))
+			}
 		}
 	}
 }
@@ -514,11 +570,11 @@ func (a *toolCallAccumulator) ToToolCalls() []ToolCall {
 		if callID == "" && strings.TrimSpace(state.Name) == "" {
 			continue
 		}
-		out = append(out, ToolCall{
-			ID:    callID,
-			Name:  state.Name,
-			Input: normalizeToolInput(state.Args.String()),
-		})
+		input := normalizeToolInput(state.Args.String())
+		if state.IsCustom {
+			input = normalizeToolInput(state.Custom.String())
+		}
+		out = append(out, ToolCall{ID: callID, Name: state.Name, Input: input, Custom: state.IsCustom, CustomInput: state.Custom.String()})
 	}
 	return out
 }
@@ -533,13 +589,11 @@ func buildOutputItemsFromStream(text string, phase MessagePhase, toolCalls []Too
 		if callID == "" {
 			continue
 		}
-		items = append(items, ResponseItem{
-			Type:      ResponseItemTypeFunctionCall,
-			ID:        callID,
-			CallID:    callID,
-			Name:      call.Name,
-			Arguments: normalizeToolInput(string(call.Input)),
-		})
+		if call.Custom {
+			items = append(items, ResponseItem{Type: ResponseItemTypeCustomToolCall, ID: callID, CallID: callID, Name: call.Name, CustomInput: call.CustomInput})
+		} else {
+			items = append(items, ResponseItem{Type: ResponseItemTypeFunctionCall, ID: callID, CallID: callID, Name: call.Name, Arguments: normalizeToolInput(string(call.Input))})
+		}
 	}
 	summaries := make([]ReasoningEntry, 0, len(reasoning))
 	for _, entry := range reasoning {
@@ -645,7 +699,7 @@ func passthroughOutputItemKey(item ResponseItem) (string, bool) {
 
 func isKnownResponseOutputItemType(itemType string) bool {
 	switch strings.TrimSpace(itemType) {
-	case "message", "function_call", "reasoning", "compaction":
+	case "message", "function_call", "custom_tool_call", "reasoning", "compaction":
 		return true
 	default:
 		return false

--- a/server/llm/openai_http_stream.go
+++ b/server/llm/openai_http_stream.go
@@ -546,15 +546,15 @@ func (a *toolCallAccumulator) Merge(calls []ToolCall) {
 		if v := strings.TrimSpace(call.Name); v != "" {
 			state.Name = v
 		}
-		if len(call.Input) > 0 {
-			if call.Custom {
-				state.IsCustom = true
+		if call.Custom {
+			state.IsCustom = true
+			if call.CustomInput != "" {
 				state.Custom.Reset()
 				state.Custom.WriteString(call.CustomInput)
-			} else {
-				state.Args.Reset()
-				state.Args.WriteString(normalizeToolArguments(string(call.Input)))
 			}
+		} else if len(call.Input) > 0 {
+			state.Args.Reset()
+			state.Args.WriteString(normalizeToolArguments(string(call.Input)))
 		}
 	}
 }

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -122,6 +122,20 @@ func TestGenerateStream_ParsesCustomPatchToolCall(t *testing.T) {
 	}
 }
 
+func TestToolCallAccumulatorMergesCompletedCustomInputWithoutJSONInput(t *testing.T) {
+	accumulator := newToolCallAccumulator()
+	accumulator.Merge([]ToolCall{{ID: "call-1", Name: "patch", Custom: true, CustomInput: "partial"}})
+	accumulator.Merge([]ToolCall{{ID: "call-1", Name: "patch", Custom: true, CustomInput: "complete"}})
+
+	calls := accumulator.ToToolCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected one call, got %+v", calls)
+	}
+	if !calls[0].Custom || calls[0].CustomInput != "complete" {
+		t.Fatalf("expected completed custom input to replace partial input, got %+v", calls[0])
+	}
+}
+
 func TestGenerateStream_PreservesBoldReasoningTextWithoutInferringStatus(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/responses" {

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -85,6 +85,43 @@ func TestGenerateStream_EmitsAssistantDeltasAndToolCalls(t *testing.T) {
 	}
 }
 
+func TestGenerateStream_ParsesCustomPatchToolCall(t *testing.T) {
+	patchInput := "*** Begin Patch\n*** Add File: a.txt\n+hi\n*** End Patch\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"ct_1\",\"type\":\"custom_tool_call\",\"name\":\"patch\",\"call_id\":\"call_1\",\"input\":\"\"}}\n\n")
+		_, _ = fmt.Fprintf(w, "data: {\"type\":\"response.custom_tool_call_input.delta\",\"item_id\":\"ct_1\",\"delta\":%q}\n\n", patchInput)
+		_, _ = fmt.Fprintf(w, "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2},\"output\":[{\"type\":\"custom_tool_call\",\"id\":\"ct_1\",\"name\":\"patch\",\"call_id\":\"call_1\",\"input\":%q}]}}\n\n", patchInput)
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	transport := NewHTTPTransport(staticAuthHeader{})
+	transport.BaseURL = server.URL
+	transport.Client = server.Client()
+
+	resp, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{Model: "gpt-5"}, StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("GenerateStream failed: %v", err)
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(resp.ToolCalls))
+	}
+	if resp.ToolCalls[0].ID != "call_1" || resp.ToolCalls[0].Name != "patch" {
+		t.Fatalf("unexpected custom tool call: %+v", resp.ToolCalls[0])
+	}
+	if !resp.ToolCalls[0].Custom || resp.ToolCalls[0].CustomInput != patchInput {
+		t.Fatalf("unexpected custom patch tool call: %+v", resp.ToolCalls[0])
+	}
+	if len(resp.OutputItems) != 1 || resp.OutputItems[0].Type != ResponseItemTypeCustomToolCall || resp.OutputItems[0].CustomInput != patchInput {
+		t.Fatalf("unexpected custom output item: %+v", resp.OutputItems)
+	}
+}
+
 func TestGenerateStream_PreservesBoldReasoningTextWithoutInferringStatus(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/responses" {

--- a/server/llm/openai_http_test.go
+++ b/server/llm/openai_http_test.go
@@ -723,14 +723,55 @@ func TestBuildPayload_AddsNativeWebSearchToolWhenEnabled(t *testing.T) {
 	}
 }
 
-func TestBuildPayload_OAuthCodexKeepsRequestedToolNamesAndParallelFlag(t *testing.T) {
+func TestBuildPayload_SerializesPatchAsCustomGrammarTool(t *testing.T) {
+	transport := NewHTTPTransport(staticAuth{})
+	payload, err := transport.buildPayload(OpenAIRequest{
+		Model: "gpt-5",
+		Tools: []Tool{{
+			Name:        string(toolspec.ToolPatch),
+			Description: "Apply edits to files using freeform patch syntax.",
+			Custom:      &CustomToolFormat{Type: "grammar", Syntax: "lark", Definition: "start: \"x\""},
+		}},
+	}, openAIAuthMode{}, requireProviderCapabilities(t, transport, openAIAuthMode{}))
+	if err != nil {
+		t.Fatalf("build payload: %v", err)
+	}
+
+	jsonPayload := mustMarshalObject(t, payload)
+	tools, ok := jsonPayload["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("expected one tool, got %#v", jsonPayload["tools"])
+	}
+	tool, ok := tools[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected tool object, got %#v", tools[0])
+	}
+	if got := tool["type"]; got != "custom" {
+		t.Fatalf("expected custom tool type, got %#v", got)
+	}
+	if got := tool["name"]; got != string(toolspec.ToolPatch) {
+		t.Fatalf("expected patch tool name, got %#v", got)
+	}
+	if _, ok := tool["parameters"]; ok {
+		t.Fatalf("custom patch tool must not include JSON parameters: %#v", tool)
+	}
+	format, ok := tool["format"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected custom format object, got %#v", tool["format"])
+	}
+	if format["type"] != "grammar" || format["syntax"] != "lark" || format["definition"] != "start: \"x\"" {
+		t.Fatalf("unexpected custom format: %#v", format)
+	}
+}
+
+func TestBuildPayload_UsesExplicitPatchCustomGrammarTool(t *testing.T) {
 	transport := NewHTTPTransport(oauthStaticAuth{})
 	mode := openAIAuthMode{IsOAuth: true, AccountID: "acc-1"}
 	payload, err := transport.buildPayload(OpenAIRequest{
 		Model: "gpt-5.4",
 		Tools: []Tool{
 			{Name: string(toolspec.ToolExecCommand), Description: "shell", Schema: json.RawMessage(`{"type":"object","additionalProperties":false}`)},
-			{Name: string(toolspec.ToolPatch), Description: "patch", Schema: json.RawMessage(`{"type":"object","additionalProperties":false}`)},
+			{Name: string(toolspec.ToolPatch), Description: "patch", Custom: &CustomToolFormat{Type: "grammar", Syntax: "lark", Definition: PatchToolLarkGrammar}},
 		},
 	}, mode, requireProviderCapabilities(t, transport, mode))
 	if err != nil {
@@ -743,16 +784,18 @@ func TestBuildPayload_OAuthCodexKeepsRequestedToolNamesAndParallelFlag(t *testin
 	}
 	tools, ok := jsonPayload["tools"].([]any)
 	if !ok || len(tools) != 2 {
-		t.Fatalf("expected two function tools, got %#v", jsonPayload["tools"])
+		t.Fatalf("expected two tools, got %#v", jsonPayload["tools"])
 	}
 	names := make([]string, 0, len(tools))
-	for _, raw := range tools {
+	for idx, raw := range tools {
 		tool, ok := raw.(map[string]any)
 		if !ok {
 			t.Fatalf("expected tool object, got %#v", raw)
 		}
-		if got := tool["type"]; got != "function" {
-			t.Fatalf("expected function tool, got %#v", got)
+		if idx == 0 {
+			if got := tool["type"]; got != "function" {
+				t.Fatalf("expected shell function tool, got %#v", got)
+			}
 		}
 		name, ok := tool["name"].(string)
 		if !ok {
@@ -762,6 +805,20 @@ func TestBuildPayload_OAuthCodexKeepsRequestedToolNamesAndParallelFlag(t *testin
 	}
 	if !reflect.DeepEqual(names, []string{string(toolspec.ToolExecCommand), string(toolspec.ToolPatch)}) {
 		t.Fatalf("tool names = %+v, want raw requested names only", names)
+	}
+	patchTool, ok := tools[1].(map[string]any)
+	if !ok {
+		t.Fatalf("expected patch tool object, got %#v", tools[1])
+	}
+	if got := patchTool["type"]; got != "custom" {
+		t.Fatalf("expected patch custom tool, got %#v", got)
+	}
+	format, ok := patchTool["format"].(map[string]any)
+	if !ok || format["type"] != "grammar" || format["syntax"] != "lark" {
+		t.Fatalf("expected patch grammar format, got %#v", patchTool["format"])
+	}
+	if _, ok := patchTool["parameters"]; ok {
+		t.Fatalf("custom patch tool must not include legacy JSON parameters: %#v", patchTool)
 	}
 }
 

--- a/server/llm/openai_http_test.go
+++ b/server/llm/openai_http_test.go
@@ -822,6 +822,16 @@ func TestBuildPayload_UsesExplicitPatchCustomGrammarTool(t *testing.T) {
 	}
 }
 
+func TestBuildFunctionToolParamRejectsBlankCustomToolName(t *testing.T) {
+	_, err := buildFunctionToolParam(Tool{
+		Name:   "   ",
+		Custom: &CustomToolFormat{Type: "grammar", Syntax: "lark", Definition: "start: \"x\""},
+	})
+	if err == nil || !strings.Contains(err.Error(), "custom tool name is required") {
+		t.Fatalf("error = %v, want blank custom tool name rejection", err)
+	}
+}
+
 func TestBuildPayload_DoesNotAddNativeWebSearchToolWhenDisabled(t *testing.T) {
 	transport := NewHTTPTransport(staticAuth{})
 	payload, err := transport.buildPayload(OpenAIRequest{

--- a/server/llm/types.go
+++ b/server/llm/types.go
@@ -56,6 +56,7 @@ const (
 	MessageTypeHandoffFutureMessage      MessageType = "handoff_future_message"
 	MessageTypeReviewerFeedback          MessageType = "reviewer_feedback"
 	MessageTypeBackgroundNotice          MessageType = "background_notice"
+	MessageTypeCustomToolCallOutput      MessageType = "custom_tool_call_output"
 	MessageTypeManualCompactionCarryover MessageType = "manual_compaction_carryover"
 	MessageTypeHeadlessMode              MessageType = "headless_mode"
 	MessageTypeHeadlessModeExit          MessageType = "headless_mode_exit"
@@ -82,10 +83,30 @@ const (
 	ResponseItemTypeMessage            ResponseItemType = "message"
 	ResponseItemTypeFunctionCall       ResponseItemType = "function_call"
 	ResponseItemTypeFunctionCallOutput ResponseItemType = "function_call_output"
+	ResponseItemTypeCustomToolCall     ResponseItemType = "custom_tool_call"
+	ResponseItemTypeCustomToolOutput   ResponseItemType = "custom_tool_call_output"
 	ResponseItemTypeReasoning          ResponseItemType = "reasoning"
 	ResponseItemTypeCompaction         ResponseItemType = "compaction"
 	ResponseItemTypeOther              ResponseItemType = "other"
 )
+
+func ResponseItemTypeIsCustomToolCall(itemType ResponseItemType) bool {
+	return itemType == ResponseItemTypeCustomToolCall
+}
+
+func ToolOutputItemType(custom bool) ResponseItemType {
+	if custom {
+		return ResponseItemTypeCustomToolOutput
+	}
+	return ResponseItemTypeFunctionCallOutput
+}
+
+func ToolOutputMessageType(custom bool) MessageType {
+	if custom {
+		return MessageTypeCustomToolCallOutput
+	}
+	return ""
+}
 
 type ResponseItem struct {
 	Type             ResponseItemType `json:"type"`
@@ -101,6 +122,7 @@ type ResponseItem struct {
 	CompactContent   string           `json:"compact_content,omitempty"`
 	ToolPresentation json.RawMessage  `json:"tool_presentation,omitempty"`
 	Arguments        json.RawMessage  `json:"arguments,omitempty"`
+	CustomInput      string           `json:"custom_input,omitempty"`
 	Output           json.RawMessage  `json:"output,omitempty"`
 	ReasoningSummary []ReasoningEntry `json:"reasoning_summary,omitempty"`
 	EncryptedContent string           `json:"encrypted_content,omitempty"`
@@ -155,6 +177,21 @@ func ItemsFromMessages(messages []Message) []ResponseItem {
 				if callID == "" && strings.TrimSpace(tc.Name) == "" {
 					continue
 				}
+				if tc.Custom {
+					customInput := tc.CustomInput
+					if strings.TrimSpace(customInput) == "" {
+						customInput = stringFromJSONRaw(tc.Input)
+					}
+					out = append(out, ResponseItem{
+						Type:             ResponseItemTypeCustomToolCall,
+						ID:               callID,
+						CallID:           callID,
+						Name:             tc.Name,
+						ToolPresentation: append(json.RawMessage(nil), tc.Presentation...),
+						CustomInput:      customInput,
+					})
+					continue
+				}
 				out = append(out, ResponseItem{
 					Type:             ResponseItemTypeFunctionCall,
 					ID:               callID,
@@ -181,12 +218,8 @@ func ItemsFromMessages(messages []Message) []ResponseItem {
 			if callID == "" {
 				continue
 			}
-			out = append(out, ResponseItem{
-				Type:   ResponseItemTypeFunctionCallOutput,
-				CallID: callID,
-				Name:   msg.Name,
-				Output: normalizeToolInput(msg.Content),
-			})
+			itemType := ToolOutputItemType(msg.MessageType == MessageTypeCustomToolCallOutput)
+			out = append(out, ResponseItem{Type: itemType, CallID: callID, Name: msg.Name, Output: normalizeToolInput(msg.Content)})
 		default:
 			if strings.TrimSpace(msg.Content) == "" {
 				continue
@@ -247,6 +280,22 @@ func MessagesFromItems(items []ResponseItem) []Message {
 				Presentation: append(json.RawMessage(nil), item.ToolPresentation...),
 				Input:        normalizeToolInput(string(item.Arguments)),
 			})
+		case ResponseItemTypeCustomToolCall:
+			if lastAssistantIdx < 0 || lastAssistantIdx >= len(out) || out[lastAssistantIdx].Role != RoleAssistant {
+				lastAssistantIdx = appendAssistant()
+			}
+			callID := strings.TrimSpace(item.CallID)
+			if callID == "" {
+				callID = strings.TrimSpace(item.ID)
+			}
+			out[lastAssistantIdx].ToolCalls = append(out[lastAssistantIdx].ToolCalls, ToolCall{
+				ID:           callID,
+				Name:         item.Name,
+				Presentation: append(json.RawMessage(nil), item.ToolPresentation...),
+				Input:        normalizeToolInput(item.CustomInput),
+				Custom:       true,
+				CustomInput:  item.CustomInput,
+			})
 		case ResponseItemTypeFunctionCallOutput:
 			callID := strings.TrimSpace(item.CallID)
 			if callID == "" {
@@ -258,6 +307,12 @@ func MessagesFromItems(items []ResponseItem) []Message {
 				Name:       item.Name,
 				Content:    stringFromJSONRaw(item.Output),
 			})
+		case ResponseItemTypeCustomToolOutput:
+			callID := strings.TrimSpace(item.CallID)
+			if callID == "" {
+				continue
+			}
+			out = append(out, Message{Role: RoleTool, MessageType: MessageTypeCustomToolCallOutput, ToolCallID: callID, Name: item.Name, Content: stringFromJSONRaw(item.Output)})
 			lastAssistantIdx = -1
 		case ResponseItemTypeReasoning:
 			if strings.TrimSpace(item.ID) == "" || strings.TrimSpace(item.EncryptedContent) == "" {
@@ -296,16 +351,46 @@ func stringFromJSONRaw(raw json.RawMessage) string {
 }
 
 type Tool struct {
-	Name        string          `json:"name"`
-	Description string          `json:"description"`
-	Schema      json.RawMessage `json:"schema"`
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Schema      json.RawMessage   `json:"schema"`
+	Custom      *CustomToolFormat `json:"custom,omitempty"`
 }
+
+type CustomToolFormat struct {
+	Type       string `json:"type"`
+	Syntax     string `json:"syntax,omitempty"`
+	Definition string `json:"definition,omitempty"`
+}
+
+const PatchToolLarkGrammar = `start: begin_patch hunk+ end_patch
+begin_patch: "*** Begin Patch" LF
+end_patch: "*** End Patch" LF?
+
+hunk: add_hunk | delete_hunk | update_hunk
+add_hunk: "*** Add File: " filename LF add_line+
+delete_hunk: "*** Delete File: " filename LF
+update_hunk: "*** Update File: " filename LF change_move? change?
+
+filename: /(.+)/
+add_line: "+" /(.*)/ LF -> line
+
+change_move: "*** Move to: " filename LF
+change: (change_context | change_line)+ eof_line?
+change_context: ("@@" | "@@ " /(.+)/) LF
+change_line: ("+" | "-" | " ") /(.*)/ LF
+eof_line: "*** End of File" LF
+
+%import common.LF
+`
 
 type ToolCall struct {
 	ID           string          `json:"id"`
 	Name         string          `json:"name"`
 	Presentation json.RawMessage `json:"presentation,omitempty"`
 	Input        json.RawMessage `json:"input"`
+	Custom       bool            `json:"custom,omitempty"`
+	CustomInput  string          `json:"custom_input,omitempty"`
 }
 
 type ToolResult struct {
@@ -357,6 +442,11 @@ func (r Request) Validate() error {
 		}
 		if len(r.Tools[i].Schema) > 0 && !json.Valid(r.Tools[i].Schema) {
 			return fmt.Errorf("%w: tool schema is invalid json at index %d", ErrInvalidRequest, i)
+		}
+		if r.Tools[i].Custom != nil && strings.TrimSpace(r.Tools[i].Custom.Type) == "grammar" {
+			if strings.TrimSpace(r.Tools[i].Custom.Definition) == "" {
+				return fmt.Errorf("%w: custom tool grammar definition is required at index %d", ErrInvalidRequest, i)
+			}
 		}
 	}
 	if r.StructuredOutput != nil {

--- a/server/llm/types.go
+++ b/server/llm/types.go
@@ -307,6 +307,7 @@ func MessagesFromItems(items []ResponseItem) []Message {
 				Name:       item.Name,
 				Content:    stringFromJSONRaw(item.Output),
 			})
+			lastAssistantIdx = -1
 		case ResponseItemTypeCustomToolOutput:
 			callID := strings.TrimSpace(item.CallID)
 			if callID == "" {

--- a/server/llm/types.go
+++ b/server/llm/types.go
@@ -377,7 +377,7 @@ filename: /(.+)/
 add_line: "+" /(.*)/ LF -> line
 
 change_move: "*** Move to: " filename LF
-change: (change_context | change_line)+ eof_line?
+change: ((change_context | change_line)+ eof_line? | eof_line)
 change_context: ("@@" | "@@ " /(.+)/) LF
 change_line: ("+" | "-" | " ") /(.*)/ LF
 eof_line: "*** End of File" LF

--- a/server/llm/types_test.go
+++ b/server/llm/types_test.go
@@ -93,6 +93,28 @@ func TestCustomToolCallItemsRoundTripThroughMessages(t *testing.T) {
 	}
 }
 
+func TestMessagesFromItemsStartsNewAssistantAfterFunctionToolOutput(t *testing.T) {
+	items := []ResponseItem{
+		{Type: ResponseItemTypeFunctionCall, ID: "fc_1", CallID: "call_1", Name: "shell", Arguments: json.RawMessage(`{"cmd":"pwd"}`)},
+		{Type: ResponseItemTypeFunctionCallOutput, CallID: "call_1", Name: "shell", Output: json.RawMessage(`{"output":"/tmp"}`)},
+		{Type: ResponseItemTypeReasoning, ID: "rs_1", EncryptedContent: "enc_1"},
+	}
+
+	msgs := MessagesFromItems(items)
+	if len(msgs) != 3 {
+		t.Fatalf("expected assistant, tool, assistant messages, got %+v", msgs)
+	}
+	if len(msgs[0].ToolCalls) != 1 {
+		t.Fatalf("expected first assistant to contain tool call, got %+v", msgs[0])
+	}
+	if msgs[1].Role != RoleTool || msgs[1].ToolCallID != "call_1" {
+		t.Fatalf("expected tool output message, got %+v", msgs[1])
+	}
+	if msgs[2].Role != RoleAssistant || len(msgs[2].ReasoningItems) != 1 {
+		t.Fatalf("expected reasoning on new assistant message, got %+v", msgs[2])
+	}
+}
+
 func TestMessagesFromItems_PreservesMessageType(t *testing.T) {
 	items := []ResponseItem{
 		{

--- a/server/llm/types_test.go
+++ b/server/llm/types_test.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"encoding/json"
 	"testing"
 
 	"builder/server/session"
@@ -59,6 +60,36 @@ func TestMessagesFromItems_PreservesAssistantPhase(t *testing.T) {
 	}
 	if msgs[0].Phase != MessagePhaseCommentary {
 		t.Fatalf("expected commentary phase, got %q", msgs[0].Phase)
+	}
+}
+
+func TestCustomToolCallItemsRoundTripThroughMessages(t *testing.T) {
+	patchInput := "*** Begin Patch\n*** Add File: a.txt\n+hi\n*** End Patch\n"
+	items := []ResponseItem{
+		{Type: ResponseItemTypeCustomToolCall, ID: "ct_1", CallID: "call_1", Name: "patch", CustomInput: patchInput},
+		{Type: ResponseItemTypeCustomToolOutput, CallID: "call_1", Name: "patch", Output: json.RawMessage(`{"ok":true}`)},
+	}
+
+	msgs := MessagesFromItems(items)
+	if len(msgs) != 2 {
+		t.Fatalf("expected assistant and tool messages, got %+v", msgs)
+	}
+	if len(msgs[0].ToolCalls) != 1 || !msgs[0].ToolCalls[0].Custom || msgs[0].ToolCalls[0].CustomInput != patchInput {
+		t.Fatalf("unexpected custom tool call message: %+v", msgs[0])
+	}
+	if msgs[1].MessageType != MessageTypeCustomToolCallOutput || msgs[1].ToolCallID != "call_1" {
+		t.Fatalf("unexpected custom tool output message: %+v", msgs[1])
+	}
+
+	roundTrip := ItemsFromMessages(msgs)
+	if len(roundTrip) != 2 {
+		t.Fatalf("expected two round-trip items, got %+v", roundTrip)
+	}
+	if roundTrip[0].Type != ResponseItemTypeCustomToolCall || roundTrip[0].CustomInput != patchInput {
+		t.Fatalf("unexpected round-trip custom call item: %+v", roundTrip[0])
+	}
+	if roundTrip[1].Type != ResponseItemTypeCustomToolOutput || string(roundTrip[1].Output) != `{"ok":true}` {
+		t.Fatalf("unexpected round-trip custom output item: %+v", roundTrip[1])
 	}
 }
 

--- a/server/registry/runtime_registry.go
+++ b/server/registry/runtime_registry.go
@@ -156,6 +156,19 @@ func (r *RuntimeRegistry) ResolveRuntime(_ context.Context, sessionID string) (*
 	return entry.engine, nil
 }
 
+func (r *RuntimeRegistry) IsSessionRuntimeActive(sessionID string) bool {
+	if r == nil {
+		return false
+	}
+	id := strings.TrimSpace(sessionID)
+	if id == "" {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.engines[id] != nil
+}
+
 func (r *RuntimeRegistry) PublishRuntimeEvent(sessionID string, evt runtime.Event) {
 	if r == nil {
 		return

--- a/server/runprompt/headless.go
+++ b/server/runprompt/headless.go
@@ -21,6 +21,7 @@ import (
 
 type HeadlessBootstrap struct {
 	Config          config.App
+	ReloadConfig    func() (config.App, error)
 	ContainerDir    string
 	StoreOptions    []session.StoreOption
 	AuthManager     *auth.Manager
@@ -49,7 +50,7 @@ type headlessPromptLauncher struct {
 }
 
 func (l *headlessPromptLauncher) PrepareHeadlessPrompt(ctx context.Context, req serverapi.RunPromptRequest, progress serverapi.RunPromptProgressSink) (serverapi.PromptSessionRuntime, error) {
-	planner := launch.Planner{Config: l.boot.Config, ContainerDir: l.boot.ContainerDir, StoreOptions: l.boot.StoreOptions}
+	planner := launch.Planner{Config: l.boot.Config, ContainerDir: l.boot.ContainerDir, StoreOptions: l.boot.StoreOptions, ReloadConfig: l.boot.ReloadConfig}
 	plan, err := planner.PlanSession(launch.SessionRequest{Mode: launch.ModeHeadless, SelectedSessionID: req.SelectedSessionID})
 	if err != nil {
 		return nil, err

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -79,14 +79,31 @@ type compactionCheckpoint struct {
 
 func newChatStore() *chatStore {
 	cwd, _ := os.Getwd()
+	return newChatStoreWithCWD(cwd)
+}
+
+func newChatStoreWithCWD(cwd string) *chatStore {
 	return &chatStore{
 		toolCompletions:            make(map[string]tools.Result, 16),
 		assistantToolCalls:         make(map[string]struct{}, 16),
 		materializedToolResults:    make(map[string]struct{}, 16),
 		synthesizedToolResults:     make(map[string]struct{}, 16),
-		cwd:                        cwd,
+		cwd:                        strings.TrimSpace(cwd),
 		providerTokenEstimateDirty: true,
 	}
+}
+
+func (s *chatStore) setCWD(cwd string) {
+	if s == nil {
+		return
+	}
+	trimmed := strings.TrimSpace(cwd)
+	if trimmed == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cwd = trimmed
 }
 
 func (s *chatStore) appendMessage(msg llm.Message) {

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -93,19 +93,6 @@ func newChatStoreWithCWD(cwd string) *chatStore {
 	}
 }
 
-func (s *chatStore) setCWD(cwd string) {
-	if s == nil {
-		return
-	}
-	trimmed := strings.TrimSpace(cwd)
-	if trimmed == "" {
-		return
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.cwd = trimmed
-}
-
 func (s *chatStore) appendMessage(msg llm.Message) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -306,17 +306,17 @@ func (s *chatStore) snapshotProviderItemsLocked() []llm.ResponseItem {
 		pendingOutputs = pendingOutputs[:0]
 	}
 	for _, item := range items {
-		if item.Type != llm.ResponseItemTypeFunctionCallOutput {
+		if !isToolOutputItem(item.Type) {
 			if inFunctionOutputRun {
 				flushPendingOutputs()
 				inFunctionOutputRun = false
-			} else if item.Type != llm.ResponseItemTypeFunctionCall {
+			} else if !isToolCallItem(item.Type) {
 				flushPendingOutputs()
 			}
 		}
 		out = append(out, item)
-		if item.Type != llm.ResponseItemTypeFunctionCall {
-			if item.Type == llm.ResponseItemTypeFunctionCallOutput {
+		if !isToolCallItem(item.Type) {
+			if isToolOutputItem(item.Type) {
 				inFunctionOutputRun = true
 			}
 			continue
@@ -336,7 +336,7 @@ func (s *chatStore) snapshotProviderItemsLocked() []llm.ResponseItem {
 			continue
 		}
 		pendingOutputs = append(pendingOutputs, llm.ResponseItem{
-			Type:   llm.ResponseItemTypeFunctionCallOutput,
+			Type:   llm.ToolOutputItemType(item.Type == llm.ResponseItemTypeCustomToolCall),
 			CallID: callID,
 			Name:   firstNonEmpty(strings.TrimSpace(string(completion.Name)), strings.TrimSpace(item.Name)),
 			Output: append(json.RawMessage(nil), completion.Output...),
@@ -344,6 +344,14 @@ func (s *chatStore) snapshotProviderItemsLocked() []llm.ResponseItem {
 	}
 	flushPendingOutputs()
 	return out
+}
+
+func isToolCallItem(itemType llm.ResponseItemType) bool {
+	return itemType == llm.ResponseItemTypeFunctionCall || itemType == llm.ResponseItemTypeCustomToolCall
+}
+
+func isToolOutputItem(itemType llm.ResponseItemType) bool {
+	return itemType == llm.ResponseItemTypeFunctionCallOutput || itemType == llm.ResponseItemTypeCustomToolOutput
 }
 
 func (s *chatStore) providerItemsSourceLocked() []llm.ResponseItem {

--- a/server/runtime/chat_store_test.go
+++ b/server/runtime/chat_store_test.go
@@ -7,7 +7,6 @@ import (
 	"builder/shared/transcript"
 	"encoding/json"
 	"reflect"
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -333,9 +332,10 @@ func TestPatchToolCallFormattingCapturesSummaryAndDetailMeta(t *testing.T) {
 
 	patchText := "*** Begin Patch\n*** Update File: dir/a.go\n line1\n-old\n+new\n*** Add File: b.go\n+hello\n*** End Patch\n"
 	call := llm.ToolCall{
-		ID:    "call_patch",
-		Name:  string(toolspec.ToolPatch),
-		Input: json.RawMessage(`{"patch":` + strconv.Quote(patchText) + `}`),
+		ID:          "call_patch",
+		Name:        string(toolspec.ToolPatch),
+		Custom:      true,
+		CustomInput: patchText,
 	}
 	call = toolCallWithPresentation(t, s, call)
 	rendered := s.formatToolCall(call)
@@ -367,15 +367,46 @@ func TestPatchToolCallFormattingCapturesSummaryAndDetailMeta(t *testing.T) {
 	}
 }
 
+func TestCustomPatchToolCallFormattingUsesFreeformInput(t *testing.T) {
+	s := newChatStore()
+	s.cwd = "/workspace"
+
+	patchText := "*** Begin Patch\n*** Update File: cli/app/ui_status.go\n@@\n type uiStatusAuthInfo struct {\n-\tSummary string\n+\tSummary string\n+\tReady bool\n }\n*** End Patch\n"
+	call := llm.ToolCall{
+		ID:          "call_patch_custom",
+		Name:        string(toolspec.ToolPatch),
+		Custom:      true,
+		CustomInput: patchText,
+	}
+	call = toolCallWithPresentation(t, s, call)
+	rendered := s.formatToolCall(call)
+	if rendered.ToolCall == nil {
+		t.Fatalf("expected tool metadata on custom patch call")
+	}
+	if rendered.Text != rendered.ToolCall.PatchDetail {
+		t.Fatalf("expected custom patch call text to use rendered detail, text=%q detail=%q", rendered.Text, rendered.ToolCall.PatchDetail)
+	}
+	if strings.Contains(rendered.ToolCall.PatchSummary, "*** Begin Patch") {
+		t.Fatalf("expected ongoing summary to hide raw patch payload, got %q", rendered.ToolCall.PatchSummary)
+	}
+	if rendered.ToolCall.PatchSummary != "Edited: ./cli/app/ui_status.go +2 -1" {
+		t.Fatalf("unexpected custom patch summary: %q", rendered.ToolCall.PatchSummary)
+	}
+	if rendered.ToolCall.PatchRender == nil {
+		t.Fatalf("expected typed patch render metadata, got %+v", rendered.ToolCall)
+	}
+}
+
 func TestPatchToolCallFormattingSingleFileUsesInlineEditedHeader(t *testing.T) {
 	s := newChatStore()
 	s.cwd = "/workspace"
 
 	patchText := "*** Begin Patch\n*** Update File: dir/a.go\n-old\n+new\n*** End Patch\n"
 	call := llm.ToolCall{
-		ID:    "call_patch_single",
-		Name:  string(toolspec.ToolPatch),
-		Input: json.RawMessage(`{"patch":` + strconv.Quote(patchText) + `}`),
+		ID:          "call_patch_single",
+		Name:        string(toolspec.ToolPatch),
+		Custom:      true,
+		CustomInput: patchText,
 	}
 	call = toolCallWithPresentation(t, s, call)
 	rendered := s.formatToolCall(call)
@@ -404,9 +435,10 @@ func TestPatchToolCallFormattingFallsBackToRawPatchWhenFileViewParseFails(t *tes
 
 	patchText := "not a structured patch payload"
 	call := llm.ToolCall{
-		ID:    "call_patch_raw",
-		Name:  string(toolspec.ToolPatch),
-		Input: json.RawMessage(`{"patch":` + strconv.Quote(patchText) + `}`),
+		ID:          "call_patch_raw",
+		Name:        string(toolspec.ToolPatch),
+		Custom:      true,
+		CustomInput: patchText,
 	}
 	call = toolCallWithPresentation(t, s, call)
 	rendered := s.formatToolCall(call)

--- a/server/runtime/chat_store_test.go
+++ b/server/runtime/chat_store_test.go
@@ -538,8 +538,8 @@ func TestFormatToolCallWriteStdinPollUsesDurationInTranscript(t *testing.T) {
 	if !rendered.ToolCall.IsShell {
 		t.Fatalf("expected write_stdin to remain marked as shell-like, got %+v", rendered.ToolCall)
 	}
-	if rendered.ToolCall.RenderHint != nil {
-		t.Fatalf("did not expect render hint for write_stdin poll summary, got %+v", rendered.ToolCall.RenderHint)
+	if rendered.ToolCall.RenderHint == nil || rendered.ToolCall.RenderHint.Kind != transcript.ToolRenderKindPlain {
+		t.Fatalf("expected plain render hint for write_stdin poll summary, got %+v", rendered.ToolCall.RenderHint)
 	}
 }
 

--- a/server/runtime/compaction.go
+++ b/server/runtime/compaction.go
@@ -817,14 +817,14 @@ func (e *Engine) prepareCompactionCacheObservation(ctx context.Context, request 
 	if e == nil || e.requestCache == nil || !e.supportsPromptCacheKey(ctx) {
 		return preparedCacheRequestObservation{}, nil
 	}
-	lineageRequest, ok, err := e.compactionCacheObservationRequest(request)
+	lineageRequest, ok, err := e.compactionCacheObservationRequest(ctx, request)
 	if err != nil || !ok {
 		return preparedCacheRequestObservation{}, err
 	}
 	return e.requestCache.Prepare(lineageRequest)
 }
 
-func (e *Engine) compactionCacheObservationRequest(request llm.CompactionRequest) (llm.Request, bool, error) {
+func (e *Engine) compactionCacheObservationRequest(ctx context.Context, request llm.CompactionRequest) (llm.Request, bool, error) {
 	if e == nil {
 		return llm.Request{}, false, nil
 	}
@@ -837,7 +837,7 @@ func (e *Engine) compactionCacheObservationRequest(request llm.CompactionRequest
 		return llm.Request{}, false, err
 	}
 	items := compactionConversationWithPromptItems(request.InputItems, request.Instructions)
-	req, err := llm.RequestFromLockedContract(locked, e.systemPrompt(locked), sanitizeItemsForLLM(items), e.requestTools())
+	req, err := llm.RequestFromLockedContract(locked, e.systemPrompt(locked), sanitizeItemsForLLM(items), e.requestTools(ctx))
 	if err != nil {
 		return llm.Request{}, false, err
 	}
@@ -894,7 +894,7 @@ func (e *Engine) localCompactionSummary(ctx context.Context, input []llm.Respons
 	})
 	items = sanitizeItemsForLLM(items)
 
-	req, err := llm.RequestFromLockedContract(locked, e.systemPrompt(locked), items, e.requestTools())
+	req, err := llm.RequestFromLockedContract(locked, e.systemPrompt(locked), items, e.requestTools(ctx))
 	if err != nil {
 		return "", err
 	}

--- a/server/runtime/compaction_trim_test.go
+++ b/server/runtime/compaction_trim_test.go
@@ -66,7 +66,7 @@ func TestCompactionCacheObservationRequestAppendsPromptToConversationReplica(t *
 	}
 
 	args := "keep API details"
-	request, ok, err := eng.compactionCacheObservationRequest(llm.CompactionRequest{
+	request, ok, err := eng.compactionCacheObservationRequest(context.Background(), llm.CompactionRequest{
 		Model:        "gpt-5",
 		Instructions: compactionInstructions(args),
 		InputItems:   eng.snapshotItems(),

--- a/server/runtime/compaction_utils.go
+++ b/server/runtime/compaction_utils.go
@@ -366,7 +366,7 @@ func compactionTrimUnits(items []llm.ResponseItem) []compactionTrimUnit {
 	callUnits := make(map[string]int, len(items))
 	for idx, item := range items {
 		switch item.Type {
-		case llm.ResponseItemTypeFunctionCall:
+		case llm.ResponseItemTypeFunctionCall, llm.ResponseItemTypeCustomToolCall:
 			if !isCompactionTrimEligible(item) {
 				continue
 			}
@@ -374,7 +374,7 @@ func compactionTrimUnits(items []llm.ResponseItem) []compactionTrimUnit {
 			if callID := compactionTrimCallID(item); callID != "" {
 				callUnits[callID] = len(units) - 1
 			}
-		case llm.ResponseItemTypeFunctionCallOutput:
+		case llm.ResponseItemTypeFunctionCallOutput, llm.ResponseItemTypeCustomToolOutput:
 			callID := compactionTrimCallID(item)
 			if unitIdx, ok := callUnits[callID]; ok {
 				units[unitIdx].indexes = append(units[unitIdx].indexes, idx)

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -150,6 +150,7 @@ type Engine struct {
 	cfg      Config
 
 	chat                  *chatStore
+	transcriptCWD         string
 	locked                *session.LockedContract
 	localDiagnosticKeys   map[string]struct{}
 	persistedDiagnostics  map[string]struct{}
@@ -261,7 +262,8 @@ func New(store *session.Store, client llm.Client, registry *tools.Registry, cfg 
 		reviewer:              cfg.Reviewer.Client,
 		registry:              registry,
 		cfg:                   cfg,
-		chat:                  newChatStoreWithCWD(transcriptWorkingDir(cfg.TranscriptWorkingDir, store.Meta().WorkspaceRoot)),
+		chat:                  newChatStore(),
+		transcriptCWD:         transcriptWorkingDir(cfg.TranscriptWorkingDir, store.Meta().WorkspaceRoot),
 		localDiagnosticKeys:   make(map[string]struct{}),
 		persistedDiagnostics:  make(map[string]struct{}),
 		pendingToolCallStarts: make(map[string]int),

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -287,6 +287,13 @@ func New(store *session.Store, client llm.Client, registry *tools.Registry, cfg 
 
 	meta := store.Meta()
 	if meta.Locked != nil {
+		if meta.Locked.ContextWindow <= 0 || meta.Locked.ContextPercent <= 0 {
+			budget := eng.promptContextBudgetFromConfig()
+			if err := store.BackfillLockedContextBudget(budget.window, budget.percent); err != nil {
+				return nil, err
+			}
+			meta = store.Meta()
+		}
 		copyLocked := *meta.Locked
 		eng.locked = &copyLocked
 	}
@@ -532,10 +539,13 @@ func (e *Engine) ensureLocked() (session.LockedContract, error) {
 		}
 	}
 
+	contextBudget := e.promptContextBudgetFromConfig()
 	lock := session.LockedContract{
 		Model:             e.cfg.Model,
 		Temperature:       e.cfg.Temperature,
 		MaxOutputToken:    e.cfg.MaxTokens,
+		ContextWindow:     contextBudget.window,
+		ContextPercent:    contextBudget.percent,
 		EnabledTools:      toToolNames(e.cfg.EnabledTools),
 		ModelCapabilities: e.cfg.ModelCapabilities,
 		ToolPreambles: func() *bool {

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -113,6 +113,7 @@ type Config struct {
 	Reviewer                      ReviewerConfig
 	HeadlessMode                  bool
 	ToolPreambles                 bool
+	TranscriptWorkingDir          string
 	OnEvent                       func(Event)
 }
 
@@ -260,7 +261,7 @@ func New(store *session.Store, client llm.Client, registry *tools.Registry, cfg 
 		reviewer:              cfg.Reviewer.Client,
 		registry:              registry,
 		cfg:                   cfg,
-		chat:                  newChatStore(),
+		chat:                  newChatStoreWithCWD(transcriptWorkingDir(cfg.TranscriptWorkingDir, store.Meta().WorkspaceRoot)),
 		localDiagnosticKeys:   make(map[string]struct{}),
 		persistedDiagnostics:  make(map[string]struct{}),
 		pendingToolCallStarts: make(map[string]int),
@@ -455,7 +456,7 @@ func (e *Engine) SubmitUserShellCommand(ctx context.Context, command string) (re
 			return err
 		}
 		if _, ok := e.registry.Get(toolspec.ToolExecCommand); !ok {
-			e.emit(Event{Kind: EventToolCallStarted, StepID: stepID, ToolCall: copiedToolCall(normalizeToolCallForTranscript(call, e.store.Meta().WorkspaceRoot)), CommittedTranscriptChanged: true})
+			e.emit(Event{Kind: EventToolCallStarted, StepID: stepID, ToolCall: copiedToolCall(normalizeToolCallForTranscript(call, e.transcriptWorkingDir())), CommittedTranscriptChanged: true})
 			result = tools.Result{CallID: call.ID, Name: toolspec.ToolExecCommand, IsError: true, Output: mustJSON(map[string]any{"error": "unknown tool"})}
 			if err := e.persistToolCompletion(stepID, result); err != nil {
 				return fmt.Errorf("persist tool completion (call_id=%s tool=%s): %w", call.ID, result.Name, err)

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -251,7 +251,7 @@ func (e *Engine) resetLocalDiagnostics() {
 }
 
 func (e *Engine) appendMessage(stepID string, msg llm.Message) error {
-	msg = normalizeMessageForTranscript(msg, e.store.Meta().WorkspaceRoot)
+	msg = normalizeMessageForTranscript(msg, e.transcriptWorkingDir())
 	previousCommittedCount := e.CommittedTranscriptEntryCount()
 	if e.beforePersistMessage != nil {
 		if err := e.beforePersistMessage(msg); err != nil {
@@ -286,7 +286,7 @@ func shouldEmitCommittedTranscriptAdvancedForAppendedMessage(msg llm.Message, pr
 }
 
 func (e *Engine) appendMessageWithoutConversationUpdate(stepID string, msg llm.Message) error {
-	msg = normalizeMessageForTranscript(msg, e.store.Meta().WorkspaceRoot)
+	msg = normalizeMessageForTranscript(msg, e.transcriptWorkingDir())
 	if e.beforePersistMessage != nil {
 		if err := e.beforePersistMessage(msg); err != nil {
 			return err

--- a/server/runtime/engine_request.go
+++ b/server/runtime/engine_request.go
@@ -50,7 +50,7 @@ func (e *Engine) buildRequestPlanWithExtraItems(ctx context.Context, stepID stri
 
 	var requestTools []llm.Tool
 	if allowTools {
-		requestTools = e.requestTools()
+		requestTools = e.requestTools(ctx)
 	} else {
 		requestTools = []llm.Tool{}
 	}
@@ -212,7 +212,7 @@ func hostedToolExecutionsFromOutputItems(items []llm.ResponseItem, defs []tools.
 	return out
 }
 
-func (e *Engine) requestTools() []llm.Tool {
+func (e *Engine) requestTools(ctx context.Context) []llm.Tool {
 	exposure := tools.RequestExposureContext{
 		SupportsVision: llm.LockedContractSupportsVisionInputs(e.store.Meta().Locked, e.cfg.Model),
 	}
@@ -221,7 +221,7 @@ func (e *Engine) requestTools() []llm.Tool {
 		return nil
 	}
 	out := make([]llm.Tool, 0, len(defs))
-	customPatchSupported := e.supportsCustomPatchTool()
+	customPatchSupported := e.supportsCustomPatchTool(ctx)
 	for _, d := range defs {
 		tool := llm.Tool{Name: string(d.ID), Description: d.Description, Schema: d.Schema}
 		if d.ID == toolspec.ToolPatch && customPatchSupported {
@@ -233,12 +233,27 @@ func (e *Engine) requestTools() []llm.Tool {
 	return out
 }
 
-func (e *Engine) supportsCustomPatchTool() bool {
-	if e == nil || e.store == nil {
-		return false
-	}
-	caps, ok := llm.ProviderCapabilitiesFromLocked(e.store.Meta().Locked)
+func (e *Engine) supportsCustomPatchTool(ctx context.Context) bool {
+	caps, ok := e.activeProviderCapabilities(ctx)
 	return ok && caps.SupportsResponsesAPI && caps.IsOpenAIFirstParty
+}
+
+func (e *Engine) activeProviderCapabilities(ctx context.Context) (llm.ProviderCapabilities, bool) {
+	if e == nil {
+		return llm.ProviderCapabilities{}, false
+	}
+	if e.cfg.ProviderCapabilitiesOverride != nil {
+		return *e.cfg.ProviderCapabilitiesOverride, true
+	}
+	provider, ok := e.llm.(llm.ProviderCapabilitiesClient)
+	if !ok {
+		return llm.ProviderCapabilities{}, false
+	}
+	caps, err := provider.ProviderCapabilities(ctx)
+	if err != nil {
+		return llm.ProviderCapabilities{}, false
+	}
+	return caps, true
 }
 
 func sanitizeItemsForLLM(items []llm.ResponseItem) []llm.ResponseItem {

--- a/server/runtime/engine_request.go
+++ b/server/runtime/engine_request.go
@@ -12,6 +12,7 @@ import (
 	"builder/server/session"
 	"builder/server/tools"
 	"builder/shared/cachewarn"
+	compactionutil "builder/shared/compaction"
 	xansi "github.com/charmbracelet/x/ansi"
 )
 
@@ -128,7 +129,34 @@ func (e *Engine) systemPrompt(locked session.LockedContract) string {
 	if locked.ToolPreambles != nil {
 		includeToolPreambles = *locked.ToolPreambles
 	}
-	return prompts.MainSystemPrompt(includeToolPreambles)
+	return prompts.MainSystemPrompt(includeToolPreambles, prompts.SystemPromptTemplateArgs{
+		EstimatedToolCallsForContext: e.estimatedToolCallsForLockedContext(locked),
+	})
+}
+
+func (e *Engine) estimatedToolCallsForLockedContext(locked session.LockedContract) int {
+	budget := e.promptContextBudget(locked)
+	return compactionutil.EstimatedToolCallsForContextWindow(budget.window, budget.percent)
+}
+
+type promptContextBudget struct {
+	window  int
+	percent int
+}
+
+func (e *Engine) promptContextBudget(locked session.LockedContract) promptContextBudget {
+	budget := e.promptContextBudgetFromConfig()
+	if locked.ContextWindow > 0 {
+		budget.window = locked.ContextWindow
+	}
+	if locked.ContextPercent > 0 {
+		budget.percent = locked.ContextPercent
+	}
+	return budget
+}
+
+func (e *Engine) promptContextBudgetFromConfig() promptContextBudget {
+	return promptContextBudget{window: e.cfg.ContextWindowTokens, percent: e.cfg.EffectiveContextWindowPercent}
 }
 
 func summarizeOutputItemTypes(items []llm.ResponseItem) []string {

--- a/server/runtime/engine_request.go
+++ b/server/runtime/engine_request.go
@@ -13,6 +13,7 @@ import (
 	"builder/server/tools"
 	"builder/shared/cachewarn"
 	compactionutil "builder/shared/compaction"
+	"builder/shared/toolspec"
 	xansi "github.com/charmbracelet/x/ansi"
 )
 
@@ -221,7 +222,12 @@ func (e *Engine) requestTools() []llm.Tool {
 	}
 	out := make([]llm.Tool, 0, len(defs))
 	for _, d := range defs {
-		out = append(out, llm.Tool{Name: string(d.ID), Description: d.Description, Schema: d.Schema})
+		tool := llm.Tool{Name: string(d.ID), Description: d.Description, Schema: d.Schema}
+		if d.ID == toolspec.ToolPatch {
+			tool.Schema = nil
+			tool.Custom = &llm.CustomToolFormat{Type: "grammar", Syntax: "lark", Definition: llm.PatchToolLarkGrammar}
+		}
+		out = append(out, tool)
 	}
 	return out
 }
@@ -235,7 +241,7 @@ func sanitizeItemsForLLM(items []llm.ResponseItem) []llm.ResponseItem {
 		if cleaned[i].Type == llm.ResponseItemTypeMessage {
 			cleaned[i].Content = xansi.Strip(cleaned[i].Content)
 		}
-		if cleaned[i].Type == llm.ResponseItemTypeFunctionCallOutput && len(cleaned[i].Output) > 0 {
+		if (cleaned[i].Type == llm.ResponseItemTypeFunctionCallOutput || cleaned[i].Type == llm.ResponseItemTypeCustomToolOutput) && len(cleaned[i].Output) > 0 {
 			normalized := normalizeToolMessageForLLM(string(cleaned[i].Output))
 			if json.Valid([]byte(normalized)) {
 				cleaned[i].Output = json.RawMessage(normalized)

--- a/server/runtime/engine_request.go
+++ b/server/runtime/engine_request.go
@@ -221,15 +221,24 @@ func (e *Engine) requestTools() []llm.Tool {
 		return nil
 	}
 	out := make([]llm.Tool, 0, len(defs))
+	customPatchSupported := e.supportsCustomPatchTool()
 	for _, d := range defs {
 		tool := llm.Tool{Name: string(d.ID), Description: d.Description, Schema: d.Schema}
-		if d.ID == toolspec.ToolPatch {
+		if d.ID == toolspec.ToolPatch && customPatchSupported {
 			tool.Schema = nil
 			tool.Custom = &llm.CustomToolFormat{Type: "grammar", Syntax: "lark", Definition: llm.PatchToolLarkGrammar}
 		}
 		out = append(out, tool)
 	}
 	return out
+}
+
+func (e *Engine) supportsCustomPatchTool() bool {
+	if e == nil || e.store == nil {
+		return false
+	}
+	caps, ok := llm.ProviderCapabilitiesFromLocked(e.store.Meta().Locked)
+	return ok && caps.SupportsResponsesAPI && caps.IsOpenAIFirstParty
 }
 
 func sanitizeItemsForLLM(items []llm.ResponseItem) []llm.ResponseItem {

--- a/server/runtime/engine_state.go
+++ b/server/runtime/engine_state.go
@@ -375,19 +375,25 @@ func (e *Engine) ParentSessionID() string {
 }
 
 func (e *Engine) SetTranscriptWorkingDir(workdir string) {
-	if e == nil || e.chat == nil {
+	if e == nil {
 		return
 	}
-	e.chat.setCWD(workdir)
+	trimmed := strings.TrimSpace(workdir)
+	if trimmed == "" {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.transcriptCWD = trimmed
 }
 
 func (e *Engine) transcriptWorkingDir() string {
-	if e == nil || e.chat == nil {
+	if e == nil {
 		return ""
 	}
-	e.chat.mu.RLock()
-	defer e.chat.mu.RUnlock()
-	return strings.TrimSpace(e.chat.cwd)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return strings.TrimSpace(e.transcriptCWD)
 }
 
 func transcriptWorkingDir(primary string, fallback string) string {

--- a/server/runtime/engine_state.go
+++ b/server/runtime/engine_state.go
@@ -102,13 +102,24 @@ func (e *Engine) AppendLocalEntry(role, text string) {
 	e.AppendLocalEntryWithOngoingText(role, text, "")
 }
 
+func (e *Engine) AppendLocalEntryWithVisibility(role, text string, visibility transcript.EntryVisibility) {
+	e.appendLocalEntry(storedLocalEntry{
+		Visibility: transcript.NormalizeEntryVisibility(visibility),
+		Role:       strings.TrimSpace(role),
+		Text:       strings.TrimSpace(text),
+	})
+}
+
 func (e *Engine) AppendLocalEntryWithOngoingText(role, text, ongoingText string) {
-	entry := storedLocalEntry{
+	e.appendLocalEntry(storedLocalEntry{
 		Visibility:  transcript.EntryVisibilityAuto,
 		Role:        strings.TrimSpace(role),
 		Text:        strings.TrimSpace(text),
 		OngoingText: strings.TrimSpace(ongoingText),
-	}
+	})
+}
+
+func (e *Engine) appendLocalEntry(entry storedLocalEntry) {
 	if entry.Role == "" || entry.Text == "" {
 		return
 	}

--- a/server/runtime/engine_state.go
+++ b/server/runtime/engine_state.go
@@ -374,6 +374,29 @@ func (e *Engine) ParentSessionID() string {
 	return strings.TrimSpace(e.store.Meta().ParentSessionID)
 }
 
+func (e *Engine) SetTranscriptWorkingDir(workdir string) {
+	if e == nil || e.chat == nil {
+		return
+	}
+	e.chat.setCWD(workdir)
+}
+
+func (e *Engine) transcriptWorkingDir() string {
+	if e == nil || e.chat == nil {
+		return ""
+	}
+	e.chat.mu.RLock()
+	defer e.chat.mu.RUnlock()
+	return strings.TrimSpace(e.chat.cwd)
+}
+
+func transcriptWorkingDir(primary string, fallback string) string {
+	if trimmed := strings.TrimSpace(primary); trimmed != "" {
+		return trimmed
+	}
+	return strings.TrimSpace(fallback)
+}
+
 func (e *Engine) ConversationFreshness() session.ConversationFreshness {
 	return e.store.ConversationFreshness()
 }

--- a/server/runtime/engine_test.go
+++ b/server/runtime/engine_test.go
@@ -6523,6 +6523,54 @@ func TestCustomToolResultPersistsAsCustomToolCallOutput(t *testing.T) {
 	}
 }
 
+func TestRequestToolsExposePatchAsCustomToolOnlyForFirstPartyResponsesProvider(t *testing.T) {
+	tests := []struct {
+		name       string
+		caps       llm.ProviderCapabilities
+		wantCustom bool
+	}{
+		{
+			name:       "first party OpenAI",
+			caps:       llm.ProviderCapabilities{ProviderID: "openai", SupportsResponsesAPI: true, IsOpenAIFirstParty: true},
+			wantCustom: true,
+		},
+		{
+			name:       "OpenAI compatible fallback",
+			caps:       llm.ProviderCapabilities{ProviderID: "openai-compatible", SupportsResponsesAPI: true, IsOpenAIFirstParty: false},
+			wantCustom: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			store, err := session.Create(dir, "ws", dir)
+			if err != nil {
+				t.Fatalf("create store: %v", err)
+			}
+			client := &fakeClient{caps: tt.caps}
+			eng, err := New(store, client, tools.NewRegistry(fakeTool{name: toolspec.ToolPatch}), Config{Model: "gpt-5", EnabledTools: []toolspec.ID{toolspec.ToolPatch}})
+			if err != nil {
+				t.Fatalf("new engine: %v", err)
+			}
+			if _, err := eng.ensureLocked(); err != nil {
+				t.Fatalf("ensureLocked: %v", err)
+			}
+
+			requestTools := eng.requestTools()
+			if len(requestTools) != 1 {
+				t.Fatalf("request tools = %+v, want one patch tool", requestTools)
+			}
+			gotCustom := requestTools[0].Custom != nil
+			if gotCustom != tt.wantCustom {
+				t.Fatalf("patch custom tool = %v, want %v; tool=%+v", gotCustom, tt.wantCustom, requestTools[0])
+			}
+			if !tt.wantCustom && len(requestTools[0].Schema) == 0 {
+				t.Fatalf("expected function-tool schema fallback for unsupported custom tools, got %+v", requestTools[0])
+			}
+		})
+	}
+}
+
 func TestFailedCustomToolResultPersistsAsCustomToolCallOutput(t *testing.T) {
 	dir := t.TempDir()
 	store, err := session.Create(dir, "ws", dir)

--- a/server/runtime/engine_test.go
+++ b/server/runtime/engine_test.go
@@ -661,9 +661,6 @@ func TestHeadlessSessionLocksToolPreamblesOff(t *testing.T) {
 	if meta.Locked.ToolPreambles == nil || *meta.Locked.ToolPreambles {
 		t.Fatalf("expected locked tool_preambles=false for headless session")
 	}
-	if strings.Contains(client.calls[0].SystemPrompt, "## Intermediary updates") {
-		t.Fatalf("did not expect intermediary updates in headless system prompt")
-	}
 }
 
 func TestLockedToolPreamblesPersistAcrossResume(t *testing.T) {
@@ -688,8 +685,8 @@ func TestLockedToolPreamblesPersistAcrossResume(t *testing.T) {
 	if _, err := firstEngine.SubmitUserMessage(context.Background(), "first"); err != nil {
 		t.Fatalf("submit first: %v", err)
 	}
-	if strings.Contains(firstClient.calls[0].SystemPrompt, "## Intermediary updates") {
-		t.Fatalf("did not expect intermediary updates in first locked prompt")
+	if store.Meta().Locked == nil || store.Meta().Locked.ToolPreambles == nil || *store.Meta().Locked.ToolPreambles {
+		t.Fatalf("expected first session to lock tool_preambles=false, got %+v", store.Meta().Locked)
 	}
 
 	resumedClient := &fakeClient{responses: []llm.Response{{
@@ -707,8 +704,129 @@ func TestLockedToolPreamblesPersistAcrossResume(t *testing.T) {
 	if _, err := resumedEngine.SubmitUserMessage(context.Background(), "second"); err != nil {
 		t.Fatalf("submit second: %v", err)
 	}
-	if strings.Contains(resumedClient.calls[0].SystemPrompt, "## Intermediary updates") {
-		t.Fatalf("did not expect resumed session to change locked tool_preambles policy")
+	if store.Meta().Locked == nil || store.Meta().Locked.ToolPreambles == nil || *store.Meta().Locked.ToolPreambles {
+		t.Fatalf("expected resumed session to preserve locked tool_preambles=false, got %+v", store.Meta().Locked)
+	}
+}
+
+func TestLockedContextWindowKeepsSystemPromptToolCallEstimateStableAcrossResume(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+
+	firstClient := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "first"},
+		Usage:     llm.Usage{WindowTokens: 272_000},
+	}}}
+	firstEngine, err := New(store, firstClient, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:               "gpt-5",
+		EnabledTools:        []toolspec.ID{toolspec.ToolExecCommand},
+		ContextWindowTokens: 272_000,
+	})
+	if err != nil {
+		t.Fatalf("new first engine: %v", err)
+	}
+	if _, err := firstEngine.SubmitUserMessage(context.Background(), "first"); err != nil {
+		t.Fatalf("submit first: %v", err)
+	}
+	locked := store.Meta().Locked
+	if locked == nil || locked.ContextWindow != 272_000 || locked.ContextPercent != 95 {
+		t.Fatalf("expected locked context budget, got %+v", locked)
+	}
+	if got := firstEngine.estimatedToolCallsForLockedContext(*locked); got != 185 {
+		t.Fatalf("estimated tool calls = %d, want 185", got)
+	}
+	firstPrompt := firstClient.calls[0].SystemPrompt
+	if strings.TrimSpace(firstPrompt) == "" {
+		t.Fatal("expected non-empty rendered system prompt")
+	}
+	firstPromptCacheKey := firstClient.calls[0].PromptCacheKey
+	if firstPromptCacheKey == "" {
+		t.Fatal("expected prompt cache key on first request")
+	}
+
+	resumedClient := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "second"},
+		Usage:     llm.Usage{WindowTokens: 400_000},
+	}}}
+	resumedEngine, err := New(store, resumedClient, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:               "gpt-5",
+		EnabledTools:        []toolspec.ID{toolspec.ToolExecCommand},
+		ContextWindowTokens: 400_000,
+	})
+	if err != nil {
+		t.Fatalf("new resumed engine: %v", err)
+	}
+	if _, err := resumedEngine.SubmitUserMessage(context.Background(), "second"); err != nil {
+		t.Fatalf("submit second: %v", err)
+	}
+	if strings.TrimSpace(resumedClient.calls[0].SystemPrompt) == "" {
+		t.Fatal("expected resumed system prompt to stay non-empty")
+	}
+	if resumedClient.calls[0].PromptCacheKey != firstPromptCacheKey {
+		t.Fatalf("expected resumed prompt cache key = %q, got %q", firstPromptCacheKey, resumedClient.calls[0].PromptCacheKey)
+	}
+	if got := resumedEngine.estimatedToolCallsForLockedContext(*store.Meta().Locked); got != 185 {
+		t.Fatalf("resumed estimated tool calls = %d, want 185", got)
+	}
+
+	alteredLocked := *store.Meta().Locked
+	alteredLocked.ContextWindow = 400_000
+	if got := resumedEngine.estimatedToolCallsForLockedContext(alteredLocked); got != 271 {
+		t.Fatalf("altered estimated tool calls = %d, want 271", got)
+	}
+	alteredPrompt := resumedEngine.systemPrompt(alteredLocked)
+	if alteredPrompt == firstPrompt {
+		t.Fatal("expected system prompt estimate to change when locked context budget changes")
+	}
+}
+
+func TestLegacyLockedSessionBackfillsContextBudgetOnce(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	if err := store.MarkModelDispatchLocked(session.LockedContract{
+		Model:          "gpt-5",
+		Temperature:    1,
+		MaxOutputToken: 0,
+	}); err != nil {
+		t.Fatalf("mark locked: %v", err)
+	}
+
+	firstEngine, err := New(store, &fakeClient{}, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:               "gpt-5",
+		EnabledTools:        []toolspec.ID{toolspec.ToolExecCommand},
+		ContextWindowTokens: 272_000,
+	})
+	if err != nil {
+		t.Fatalf("new first engine: %v", err)
+	}
+	locked := store.Meta().Locked
+	if locked == nil || locked.ContextWindow != 272_000 || locked.ContextPercent != 95 {
+		t.Fatalf("expected legacy lock backfilled from first resume config, got %+v", locked)
+	}
+	if got := firstEngine.estimatedToolCallsForLockedContext(*locked); got != 185 {
+		t.Fatalf("first estimated tool calls = %d, want 185", got)
+	}
+
+	secondEngine, err := New(store, &fakeClient{}, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:               "gpt-5",
+		EnabledTools:        []toolspec.ID{toolspec.ToolExecCommand},
+		ContextWindowTokens: 400_000,
+	})
+	if err != nil {
+		t.Fatalf("new second engine: %v", err)
+	}
+	locked = store.Meta().Locked
+	if locked == nil || locked.ContextWindow != 272_000 || locked.ContextPercent != 95 {
+		t.Fatalf("expected legacy lock backfill to stay pinned, got %+v", locked)
+	}
+	if got := secondEngine.estimatedToolCallsForLockedContext(*locked); got != 185 {
+		t.Fatalf("second estimated tool calls = %d, want 185", got)
 	}
 }
 

--- a/server/runtime/engine_test.go
+++ b/server/runtime/engine_test.go
@@ -6556,7 +6556,7 @@ func TestRequestToolsExposePatchAsCustomToolOnlyForFirstPartyResponsesProvider(t
 				t.Fatalf("ensureLocked: %v", err)
 			}
 
-			requestTools := eng.requestTools()
+			requestTools := eng.requestTools(context.Background())
 			if len(requestTools) != 1 {
 				t.Fatalf("request tools = %+v, want one patch tool", requestTools)
 			}
@@ -6568,6 +6568,46 @@ func TestRequestToolsExposePatchAsCustomToolOnlyForFirstPartyResponsesProvider(t
 				t.Fatalf("expected function-tool schema fallback for unsupported custom tools, got %+v", requestTools[0])
 			}
 		})
+	}
+}
+
+func TestRequestToolsUseActiveProviderCapsForCustomPatchTool(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	if err := store.MarkModelDispatchLocked(session.LockedContract{
+		Model:        "gpt-5",
+		EnabledTools: []string{string(toolspec.ToolPatch)},
+		ProviderContract: llm.LockedProviderCapabilitiesFromContract(llm.ProviderCapabilities{
+			ProviderID:           "openai",
+			SupportsResponsesAPI: true,
+			IsOpenAIFirstParty:   true,
+		}),
+	}); err != nil {
+		t.Fatalf("mark locked: %v", err)
+	}
+	activeCaps := llm.ProviderCapabilities{ProviderID: "openai-compatible", SupportsResponsesAPI: true, IsOpenAIFirstParty: false}
+	client := &fakeClient{caps: activeCaps}
+	eng, err := New(store, client, tools.NewRegistry(fakeTool{name: toolspec.ToolPatch}), Config{
+		Model:                        "gpt-5",
+		EnabledTools:                 []toolspec.ID{toolspec.ToolPatch},
+		ProviderCapabilitiesOverride: &activeCaps,
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+
+	requestTools := eng.requestTools(context.Background())
+	if len(requestTools) != 1 {
+		t.Fatalf("request tools = %+v, want one patch tool", requestTools)
+	}
+	if requestTools[0].Custom != nil {
+		t.Fatalf("expected active compatible provider to use schema patch tool despite stale locked OpenAI caps, got %+v", requestTools[0])
+	}
+	if len(requestTools[0].Schema) == 0 {
+		t.Fatalf("expected function-tool schema fallback for active compatible provider, got %+v", requestTools[0])
 	}
 }
 

--- a/server/runtime/engine_test.go
+++ b/server/runtime/engine_test.go
@@ -270,6 +270,16 @@ func (t fakeTool) Call(_ context.Context, c tools.Call) (tools.Result, error) {
 	return tools.Result{CallID: c.ID, Name: c.Name, Output: out}, nil
 }
 
+type failingTool struct {
+	name toolspec.ID
+}
+
+func (t failingTool) Name() toolspec.ID { return t.name }
+func (t failingTool) Call(_ context.Context, c tools.Call) (tools.Result, error) {
+	out, _ := json.Marshal(map[string]any{"error": "failed"})
+	return tools.Result{CallID: c.ID, Name: c.Name, Output: out, IsError: true}, nil
+}
+
 type blockingTool struct {
 	name    toolspec.ID
 	started chan struct{}
@@ -1282,7 +1292,7 @@ func TestSetReviewerEnabledConcurrentWithBusyStep(t *testing.T) {
 	mainClient := &fakeClient{responses: []llm.Response{
 		{
 			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "working", Phase: llm.MessagePhaseCommentary},
-			ToolCalls: []llm.ToolCall{{ID: "call_patch_1", Name: string(toolspec.ToolPatch), Input: json.RawMessage(`{"patch":"*** Begin Patch\n*** Add File: a.txt\n+hello\n*** End Patch"}`)}},
+			ToolCalls: []llm.ToolCall{{ID: "call_patch_1", Name: string(toolspec.ToolPatch), Custom: true, CustomInput: "*** Begin Patch\n*** Add File: a.txt\n+hello\n*** End Patch"}},
 			Usage:     llm.Usage{WindowTokens: 200000},
 		},
 		{
@@ -1342,7 +1352,7 @@ func TestSetReviewerDisabledConcurrentWithBusyStepSkipsReviewerForCurrentRun(t *
 	mainClient := &fakeClient{responses: []llm.Response{
 		{
 			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "working", Phase: llm.MessagePhaseCommentary},
-			ToolCalls: []llm.ToolCall{{ID: "call_patch_1", Name: string(toolspec.ToolPatch), Input: json.RawMessage(`{"patch":"*** Begin Patch\n*** Add File: a.txt\n+hello\n*** End Patch"}`)}},
+			ToolCalls: []llm.ToolCall{{ID: "call_patch_1", Name: string(toolspec.ToolPatch), Custom: true, CustomInput: "*** Begin Patch\n*** Add File: a.txt\n+hello\n*** End Patch"}},
 			Usage:     llm.Usage{WindowTokens: 200000},
 		},
 		{
@@ -3195,7 +3205,7 @@ func TestReviewerRunsOnEditsFrequencyOnlyWhenPatchApplied(t *testing.T) {
 	mainClient := &fakeClient{responses: []llm.Response{
 		{
 			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "working", Phase: llm.MessagePhaseCommentary},
-			ToolCalls: []llm.ToolCall{{ID: "call_patch_1", Name: string(toolspec.ToolPatch), Input: json.RawMessage(`{"patch":"*** Begin Patch\n*** Add File: a.txt\n+hello\n*** End Patch"}`)}},
+			ToolCalls: []llm.ToolCall{{ID: "call_patch_1", Name: string(toolspec.ToolPatch), Custom: true, CustomInput: "*** Begin Patch\n*** Add File: a.txt\n+hello\n*** End Patch"}},
 			Usage:     llm.Usage{WindowTokens: 200000},
 		},
 		{
@@ -5854,9 +5864,10 @@ func TestReopenCarriesInterruptedShellToolAttemptIntoNextModelRequest(t *testing
 
 func TestReopenCarriesInterruptedApprovalBackedPatchToolAttemptIntoNextModelRequest(t *testing.T) {
 	testReopenCarriesInterruptedToolAttemptIntoNextModelRequest(t, llm.ToolCall{
-		ID:    "call_patch",
-		Name:  string(toolspec.ToolPatch),
-		Input: json.RawMessage(`{"patch":"*** Begin Patch\n*** Add File: ../outside.txt\n+hello\n*** End Patch\n"}`),
+		ID:          "call_patch",
+		Name:        string(toolspec.ToolPatch),
+		Custom:      true,
+		CustomInput: "*** Begin Patch\n*** Add File: ../outside.txt\n+hello\n*** End Patch\n",
 	})
 }
 
@@ -5913,7 +5924,11 @@ func testReopenCarriesInterruptedToolAttemptIntoNextModelRequest(t *testing.T, c
 		switch {
 		case item.Type == llm.ResponseItemTypeFunctionCall && item.CallID == call.ID && item.Name == call.Name:
 			foundPriorAttempt = true
+		case item.Type == llm.ResponseItemTypeCustomToolCall && item.CallID == call.ID && item.Name == call.Name:
+			foundPriorAttempt = true
 		case item.Type == llm.ResponseItemTypeFunctionCallOutput && item.CallID == call.ID:
+			foundUnexpectedReply = true
+		case item.Type == llm.ResponseItemTypeCustomToolOutput && item.CallID == call.ID:
 			foundUnexpectedReply = true
 		}
 	}
@@ -6446,6 +6461,116 @@ func TestCriticalExactRecountsAfterToolCompletionBeforeToolMessageAppend(t *test
 	}
 	if client.countInputTokenCalls != 2 {
 		t.Fatalf("expected critical recount after tool completion, got %d count calls", client.countInputTokenCalls)
+	}
+}
+
+func TestCustomToolResultPersistsAsCustomToolCallOutput(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+
+	patchInput := "*** Begin Patch\n*** Add File: a.txt\n+hi\n*** End Patch\n"
+	client := &fakeClient{responses: []llm.Response{
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "patching", Phase: llm.MessagePhaseCommentary},
+			ToolCalls: []llm.ToolCall{{
+				ID:          "call_patch",
+				Name:        string(toolspec.ToolPatch),
+				Custom:      true,
+				CustomInput: patchInput,
+				Input:       json.RawMessage(`{}`),
+			}},
+			Usage: llm.Usage{WindowTokens: 200000},
+		},
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done", Phase: llm.MessagePhaseFinal},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+	}}
+	eng, err := New(store, client, tools.NewRegistry(fakeTool{name: toolspec.ToolPatch}), Config{Model: "gpt-5", EnabledTools: []toolspec.ID{toolspec.ToolPatch}})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+
+	msg, err := eng.SubmitUserMessage(context.Background(), "apply patch")
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if msg.Content != "done" {
+		t.Fatalf("unexpected final message: %+v", msg)
+	}
+	if len(client.calls) < 2 {
+		t.Fatalf("expected follow-up request after tool result, got %d", len(client.calls))
+	}
+
+	foundCustomCall := false
+	foundCustomOutput := false
+	foundFunctionOutput := false
+	for _, item := range client.calls[1].Items {
+		switch {
+		case item.Type == llm.ResponseItemTypeCustomToolCall && item.CallID == "call_patch":
+			foundCustomCall = true
+		case item.Type == llm.ResponseItemTypeCustomToolOutput && item.CallID == "call_patch":
+			foundCustomOutput = true
+		case item.Type == llm.ResponseItemTypeFunctionCallOutput && item.CallID == "call_patch":
+			foundFunctionOutput = true
+		}
+	}
+	if !foundCustomCall || !foundCustomOutput || foundFunctionOutput {
+		t.Fatalf("expected custom call/output pair only, foundCustomCall=%v foundCustomOutput=%v foundFunctionOutput=%v items=%+v", foundCustomCall, foundCustomOutput, foundFunctionOutput, client.calls[1].Items)
+	}
+}
+
+func TestFailedCustomToolResultPersistsAsCustomToolCallOutput(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+
+	client := &fakeClient{responses: []llm.Response{
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "patching", Phase: llm.MessagePhaseCommentary},
+			ToolCalls: []llm.ToolCall{{
+				ID:          "call_patch",
+				Name:        string(toolspec.ToolPatch),
+				Custom:      true,
+				CustomInput: "*** Begin Patch\n*** Add File: a.txt\n+hi\n*** End Patch\n",
+				Input:       json.RawMessage(`{}`),
+			}},
+			Usage: llm.Usage{WindowTokens: 200000},
+		},
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done", Phase: llm.MessagePhaseFinal},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+	}}
+	eng, err := New(store, client, tools.NewRegistry(failingTool{name: toolspec.ToolPatch}), Config{Model: "gpt-5", EnabledTools: []toolspec.ID{toolspec.ToolPatch}})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+
+	if _, err := eng.SubmitUserMessage(context.Background(), "apply patch"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if len(client.calls) < 2 {
+		t.Fatalf("expected follow-up request after tool result, got %d", len(client.calls))
+	}
+
+	foundCustomOutput := false
+	foundFunctionOutput := false
+	for _, item := range client.calls[1].Items {
+		switch {
+		case item.Type == llm.ResponseItemTypeCustomToolOutput && item.CallID == "call_patch":
+			foundCustomOutput = true
+		case item.Type == llm.ResponseItemTypeFunctionCallOutput && item.CallID == "call_patch":
+			foundFunctionOutput = true
+		}
+	}
+	if !foundCustomOutput || foundFunctionOutput {
+		t.Fatalf("expected failed custom output only, foundCustomOutput=%v foundFunctionOutput=%v items=%+v", foundCustomOutput, foundFunctionOutput, client.calls[1].Items)
 	}
 }
 

--- a/server/runtime/persisted_transcript_scan.go
+++ b/server/runtime/persisted_transcript_scan.go
@@ -173,6 +173,6 @@ func persistedTranscriptToolCallMeta(call llm.ToolCall) *transcript.ToolCallMeta
 	built := tools.BuildCallTranscriptMeta(call.Name, tools.ToolCallContext{
 		DefaultShellPath: currentTranscriptDefaultShellPath(),
 		GOOS:             goruntime.GOOS,
-	}, call.Input)
+	}, transcriptToolCallInput(call))
 	return &built
 }

--- a/server/runtime/persisted_transcript_scan_test.go
+++ b/server/runtime/persisted_transcript_scan_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
 	"testing"
 
 	"builder/server/llm"
@@ -217,6 +218,43 @@ func TestFormatPersistedToolCallBuildsFallbackMetadata(t *testing.T) {
 	}
 	if entry.ToolCall.Command != "pwd" {
 		t.Fatalf("tool command = %q, want pwd", entry.ToolCall.Command)
+	}
+}
+
+func TestPersistedTranscriptScanRendersCustomPatchToolCallFromFreeformInput(t *testing.T) {
+	patchText := "*** Begin Patch\n*** Update File: cli/app/ui_status.go\n@@\n type uiStatusAuthInfo struct {\n-\tSummary string\n+\tSummary string\n+\tReady bool\n }\n*** End Patch\n"
+	scan := NewPersistedTranscriptScan(PersistedTranscriptScanRequest{Offset: 0, Limit: 10})
+	events := []session.Event{
+		mustPersistedScanEvent(t, "message", llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
+			ID:          "call-patch",
+			Name:        string(toolspec.ToolPatch),
+			Custom:      true,
+			CustomInput: patchText,
+		}}}),
+		mustPersistedScanEvent(t, "message", llm.Message{Role: llm.RoleTool, ToolCallID: "call-patch", Name: string(toolspec.ToolPatch), MessageType: llm.MessageTypeCustomToolCallOutput, Content: `{}`}),
+	}
+	for _, evt := range events {
+		if err := scan.ApplyPersistedEvent(evt); err != nil {
+			t.Fatalf("ApplyPersistedEvent(%q): %v", evt.Kind, err)
+		}
+	}
+
+	page := scan.CollectedPageSnapshot()
+	if len(page.Entries) != 2 {
+		t.Fatalf("len(page.Entries) = %d, want 2 (%+v)", len(page.Entries), page.Entries)
+	}
+	call := page.Entries[0]
+	if call.Role != "tool_call" || call.ToolCallID != "call-patch" {
+		t.Fatalf("expected persisted patch tool call entry, got %+v", call)
+	}
+	if call.ToolCall == nil || call.ToolCall.PatchRender == nil {
+		t.Fatalf("expected persisted custom patch render metadata, got %+v", call.ToolCall)
+	}
+	if call.ToolCall.PatchSummary != "Edited: ./cli/app/ui_status.go +2 -1" {
+		t.Fatalf("unexpected persisted custom patch summary: %q", call.ToolCall.PatchSummary)
+	}
+	if strings.Contains(call.ToolCall.PatchSummary, "*** Begin Patch") {
+		t.Fatalf("expected persisted summary to hide raw patch, got %q", call.ToolCall.PatchSummary)
 	}
 }
 

--- a/server/runtime/step_executor.go
+++ b/server/runtime/step_executor.go
@@ -289,7 +289,7 @@ func committedStartsForPersistedAssistantMessage(e *Engine, msg llm.Message, exe
 	if e == nil {
 		return -1, nil
 	}
-	persisted := normalizeMessageForTranscript(msg, e.store.Meta().WorkspaceRoot)
+	persisted := normalizeMessageForTranscript(msg, e.transcriptWorkingDir())
 	entries := VisibleChatEntriesFromMessage(persisted)
 	if len(entries) == 0 {
 		return -1, nil

--- a/server/runtime/step_executor.go
+++ b/server/runtime/step_executor.go
@@ -230,11 +230,13 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 		if err != nil {
 			return stepLoopResult{}, err
 		}
+		customToolCalls := customToolCallIDs(localToolCalls)
 		for _, result := range results {
 			if result.Name == toolspec.ToolPatch && !result.IsError {
 				patchEditsApplied = true
 			}
 			msg := llm.Message{Role: llm.RoleTool, Content: string(result.Output), ToolCallID: result.CallID, Name: string(result.Name)}
+			msg.MessageType = llm.ToolOutputMessageType(customToolCalls[result.CallID])
 			if err := e.appendMessage(stepID, msg); err != nil {
 				return stepLoopResult{}, err
 			}
@@ -243,6 +245,19 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 			return stepLoopResult{}, err
 		}
 	}
+}
+
+func customToolCallIDs(calls []llm.ToolCall) map[string]bool {
+	if len(calls) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(calls))
+	for _, call := range calls {
+		if call.Custom && strings.TrimSpace(call.ID) != "" {
+			out[call.ID] = true
+		}
+	}
+	return out
 }
 
 func (s *defaultStepExecutor) prepareModelTurn(ctx context.Context, stepID string) error {

--- a/server/runtime/tool_executor.go
+++ b/server/runtime/tool_executor.go
@@ -35,7 +35,7 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 		if call.Custom && knownTool {
 			executableCall.Input = executorInputForCustomTool(toolID, call.CustomInput)
 		}
-		started := Event{Kind: EventToolCallStarted, StepID: stepID, ToolCall: copiedToolCall(normalizeToolCallForTranscript(executableCall, e.store.Meta().WorkspaceRoot)), CommittedTranscriptChanged: true}
+		started := Event{Kind: EventToolCallStarted, StepID: stepID, ToolCall: copiedToolCall(normalizeToolCallForTranscript(executableCall, e.transcriptWorkingDir())), CommittedTranscriptChanged: true}
 		if start, ok := e.pendingToolCallStart(call.ID); ok {
 			started.CommittedEntryStart = start
 			started.CommittedEntryStartSet = true

--- a/server/runtime/tool_executor.go
+++ b/server/runtime/tool_executor.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -29,7 +30,12 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 		if call.ID == "" {
 			call.ID = uuid.NewString()
 		}
-		started := Event{Kind: EventToolCallStarted, StepID: stepID, ToolCall: copiedToolCall(normalizeToolCallForTranscript(call, e.store.Meta().WorkspaceRoot)), CommittedTranscriptChanged: true}
+		toolID, knownTool := toolspec.ParseID(call.Name)
+		executableCall := call
+		if call.Custom && knownTool {
+			executableCall.Input = executorInputForCustomTool(toolID, call.CustomInput)
+		}
+		started := Event{Kind: EventToolCallStarted, StepID: stepID, ToolCall: copiedToolCall(normalizeToolCallForTranscript(executableCall, e.store.Meta().WorkspaceRoot)), CommittedTranscriptChanged: true}
 		if start, ok := e.pendingToolCallStart(call.ID); ok {
 			started.CommittedEntryStart = start
 			started.CommittedEntryStartSet = true
@@ -37,13 +43,12 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 		e.emit(started)
 		idx := i
 		wg.Add(1)
-		go func(tc llm.ToolCall) {
+		go func(tc llm.ToolCall, toolID toolspec.ID, knownTool bool) {
 			defer wg.Done()
 			defer e.forgetPendingToolCallStart(tc.ID)
 			var callErr error
 
-			toolID, ok := toolspec.ParseID(tc.Name)
-			if !ok {
+			if !knownTool {
 				results[idx] = tools.Result{CallID: tc.ID, Name: toolspec.ID(tc.Name), IsError: true, Output: mustJSON(map[string]any{"error": "unknown tool"})}
 				if err := e.persistToolCompletion(stepID, results[idx]); err != nil {
 					callErrs[idx] = fmt.Errorf("persist tool completion (call_id=%s tool=%s): %w", tc.ID, results[idx].Name, err)
@@ -89,7 +94,7 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 			}
 			e.emit(Event{Kind: EventToolCallCompleted, StepID: stepID, ToolResult: copiedToolResult(res), CommittedTranscriptChanged: true})
 			callErrs[idx] = callErr
-		}(call)
+		}(executableCall, toolID, knownTool)
 	}
 
 	wg.Wait()
@@ -101,6 +106,20 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 		return results, joined
 	}
 	return results, nil
+}
+
+func executorInputForCustomTool(toolID toolspec.ID, input string) json.RawMessage {
+	switch toolID {
+	case toolspec.ToolPatch:
+		encoded, _ := json.Marshal(map[string]string{"patch": input})
+		return encoded
+	default:
+		if json.Valid([]byte(input)) {
+			return json.RawMessage(input)
+		}
+		encoded, _ := json.Marshal(input)
+		return encoded
+	}
 }
 
 func activeRunIDForStep(engine *Engine, stepID string) string {

--- a/server/runtime/tool_presentation.go
+++ b/server/runtime/tool_presentation.go
@@ -5,6 +5,7 @@ import (
 	"builder/server/tools"
 	"builder/shared/transcript"
 	"builder/shared/transcript/toolcodec"
+	"encoding/json"
 	"os"
 	goruntime "runtime"
 	"strings"
@@ -44,12 +45,20 @@ func transcriptToolCallMeta(call llm.ToolCall, workingDir string) *transcript.To
 	if meta := decodeToolCallMeta(call); meta != nil {
 		return meta
 	}
+	input := transcriptToolCallInput(call)
 	built := tools.BuildCallTranscriptMeta(call.Name, tools.ToolCallContext{
 		WorkingDir:       workingDir,
 		DefaultShellPath: currentTranscriptDefaultShellPath(),
 		GOOS:             goruntime.GOOS,
-	}, call.Input)
+	}, input)
 	return &built
+}
+
+func transcriptToolCallInput(call llm.ToolCall) json.RawMessage {
+	if call.Custom && strings.TrimSpace(call.CustomInput) != "" {
+		return normalizeRuntimeToolInput(call.CustomInput)
+	}
+	return call.Input
 }
 
 func currentTranscriptDefaultShellPath() string {

--- a/server/runtime/tool_presentation_test.go
+++ b/server/runtime/tool_presentation_test.go
@@ -1,6 +1,11 @@
 package runtime
 
-import "testing"
+import (
+	"builder/server/llm"
+	"builder/shared/toolspec"
+	"builder/shared/transcript/toolcodec"
+	"testing"
+)
 
 func TestCurrentTranscriptDefaultShellPathFallsBackToComSpec(t *testing.T) {
 	t.Setenv("SHELL", "")
@@ -8,5 +13,30 @@ func TestCurrentTranscriptDefaultShellPathFallsBackToComSpec(t *testing.T) {
 
 	if got, want := currentTranscriptDefaultShellPath(), `C:\\Windows\\System32\\cmd.exe`; got != want {
 		t.Fatalf("default shell path = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeToolCallForTranscriptUsesCustomPatchInput(t *testing.T) {
+	patchText := "*** Begin Patch\n*** Update File: cli/app/ui_status.go\n@@\n type uiStatusAuthInfo struct {\n-\tSummary string\n+\tSummary string\n+\tReady bool\n }\n*** End Patch\n"
+	call := llm.ToolCall{
+		ID:          "call_patch",
+		Name:        string(toolspec.ToolPatch),
+		Custom:      true,
+		CustomInput: patchText,
+	}
+
+	normalized := normalizeToolCallForTranscript(call, "/workspace")
+	meta, ok := toolcodec.DecodeToolCallMeta(normalized.Presentation)
+	if !ok || meta == nil {
+		t.Fatalf("expected presentation metadata for custom patch call")
+	}
+	if !meta.HasPatchSummary() || !meta.HasPatchDetail() || meta.PatchRender == nil {
+		t.Fatalf("expected patch summary/detail/render metadata, got %+v", meta)
+	}
+	if meta.PatchSummary != "Edited: ./cli/app/ui_status.go +2 -1" {
+		t.Fatalf("unexpected custom patch summary: %q", meta.PatchSummary)
+	}
+	if meta.Command == patchText {
+		t.Fatalf("expected command to be rendered patch detail, not raw freeform payload")
 	}
 }

--- a/server/runtime/transcript_commit_signal_test.go
+++ b/server/runtime/transcript_commit_signal_test.go
@@ -3,12 +3,15 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"strconv"
+	"strings"
 	"testing"
 
 	"builder/server/llm"
 	"builder/server/session"
 	"builder/server/tools"
 	"builder/shared/toolspec"
+	"builder/shared/transcript"
 )
 
 func TestSubmitUserMessageDoesNotEmitCommittedConversationUpdatedAfterFlushedUserTurn(t *testing.T) {
@@ -73,6 +76,52 @@ func TestSubmitUserMessageWithToolCallDoesNotEmitCommittedConversationUpdatedAft
 	}
 	if !hasEventKind(events, EventAssistantMessage) {
 		t.Fatalf("expected assistant_message event, got %+v", events)
+	}
+}
+
+func TestPatchToolCallStartedUsesTranscriptWorkingDir(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", "/main")
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	patchText := "*** Begin Patch\n*** Add File: probe.txt\n+hello\n*** End Patch\n"
+	client := &fakeClient{responses: []llm.Response{
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "patching", Phase: llm.MessagePhaseCommentary},
+			ToolCalls: []llm.ToolCall{{ID: "call-patch", Name: string(toolspec.ToolPatch), Input: json.RawMessage(`{"patch":` + strconv.Quote(patchText) + `}`)}},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done", Phase: llm.MessagePhaseFinal},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+	}}
+	var started *transcript.ToolCallMeta
+	eng, err := New(store, client, tools.NewRegistry(fakeTool{name: toolspec.ToolPatch}), Config{
+		Model:                "gpt-5",
+		TranscriptWorkingDir: "/worktree",
+		OnEvent: func(evt Event) {
+			if evt.Kind == EventToolCallStarted && evt.ToolCall != nil {
+				started = decodeToolCallMeta(*evt.ToolCall)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	if _, err := eng.SubmitUserMessage(context.Background(), "apply patch"); err != nil {
+		t.Fatalf("submit user message: %v", err)
+	}
+	if started == nil || started.PatchRender == nil {
+		t.Fatalf("expected patch render metadata, got %+v", started)
+	}
+	detail := started.PatchDetail
+	if !strings.Contains(detail, "/worktree/probe.txt") {
+		t.Fatalf("expected worktree path in patch detail, got %q", detail)
+	}
+	if strings.Contains(detail, "/main/probe.txt") {
+		t.Fatalf("did not expect main workspace path in patch detail, got %q", detail)
 	}
 }
 

--- a/server/runtime/transcript_scan.go
+++ b/server/runtime/transcript_scan.go
@@ -239,29 +239,34 @@ func (w *responseItemMessageWalker) Apply(item llm.ResponseItem) {
 		}
 		w.flushAssistant()
 		w.emit(msg)
-	case llm.ResponseItemTypeFunctionCall:
+	case llm.ResponseItemTypeFunctionCall, llm.ResponseItemTypeCustomToolCall:
 		assistant := w.ensureAssistant()
 		callID := strings.TrimSpace(item.CallID)
 		if callID == "" {
 			callID = strings.TrimSpace(item.ID)
 		}
-		assistant.ToolCalls = append(assistant.ToolCalls, llm.ToolCall{
+		call := llm.ToolCall{
 			ID:           callID,
 			Name:         item.Name,
 			Presentation: append(json.RawMessage(nil), item.ToolPresentation...),
 			Input:        normalizeRuntimeToolInput(string(item.Arguments)),
-		})
-	case llm.ResponseItemTypeFunctionCallOutput:
+			Custom:       llm.ResponseItemTypeIsCustomToolCall(item.Type),
+			CustomInput:  item.CustomInput,
+		}
+		call.Input = transcriptToolCallInput(call)
+		assistant.ToolCalls = append(assistant.ToolCalls, call)
+	case llm.ResponseItemTypeFunctionCallOutput, llm.ResponseItemTypeCustomToolOutput:
 		w.flushAssistant()
 		callID := strings.TrimSpace(item.CallID)
 		if callID == "" {
 			return
 		}
 		w.emit(llm.Message{
-			Role:       llm.RoleTool,
-			ToolCallID: callID,
-			Name:       item.Name,
-			Content:    stringFromJSONRawRuntime(item.Output),
+			Role:        llm.RoleTool,
+			MessageType: llm.ToolOutputMessageType(item.Type == llm.ResponseItemTypeCustomToolOutput),
+			ToolCallID:  callID,
+			Name:        item.Name,
+			Content:     stringFromJSONRawRuntime(item.Output),
 		})
 	case llm.ResponseItemTypeReasoning:
 		id := strings.TrimSpace(item.ID)

--- a/server/runtime/transcript_scan.go
+++ b/server/runtime/transcript_scan.go
@@ -259,6 +259,9 @@ func (w *responseItemMessageWalker) Apply(item llm.ResponseItem) {
 		w.flushAssistant()
 		callID := strings.TrimSpace(item.CallID)
 		if callID == "" {
+			callID = strings.TrimSpace(item.ID)
+		}
+		if callID == "" {
 			return
 		}
 		w.emit(llm.Message{

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -2,6 +2,7 @@ package runtimecontrol
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -118,7 +119,7 @@ func (s *Service) resolve(ctx context.Context, sessionID string) (*runtime.Engin
 		return nil, err
 	}
 	if engine == nil {
-		return nil, fmt.Errorf("runtime for session %q is unavailable", strings.TrimSpace(sessionID))
+		return nil, errors.Join(serverapi.ErrRuntimeUnavailable, fmt.Errorf("runtime for session %q is unavailable", strings.TrimSpace(sessionID)))
 	}
 	return engine, nil
 }

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -10,6 +10,7 @@ import (
 	"builder/server/requestmemo"
 	"builder/server/runtime"
 	"builder/shared/serverapi"
+	"builder/shared/transcript"
 )
 
 type RuntimeResolver interface {
@@ -67,9 +68,10 @@ type sessionOnlyMemoRequest struct {
 }
 
 type localEntryMemoRequest struct {
-	SessionID string
-	Role      string
-	Text      string
+	SessionID  string
+	Role       string
+	Text       string
+	Visibility transcript.EntryVisibility
 }
 
 func NewService(runtimes RuntimeResolver, gate primaryrun.Gate) *Service {
@@ -224,7 +226,8 @@ func (s *Service) AppendLocalEntry(ctx context.Context, req serverapi.RuntimeApp
 	if err := req.Validate(); err != nil {
 		return err
 	}
-	memoReq := localEntryMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Role: strings.TrimSpace(req.Role), Text: req.Text}
+	visibility := transcript.NormalizeEntryVisibility(transcript.EntryVisibility(req.Visibility))
+	memoReq := localEntryMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Role: strings.TrimSpace(req.Role), Text: req.Text, Visibility: visibility}
 	_, err := s.localEntries.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameLocalEntryMemoRequest, func(ctx context.Context) (struct{}, error) {
 		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
 			return struct{}{}, err
@@ -233,7 +236,11 @@ func (s *Service) AppendLocalEntry(ctx context.Context, req serverapi.RuntimeApp
 		if err != nil {
 			return struct{}{}, err
 		}
-		engine.AppendLocalEntry(req.Role, req.Text)
+		if visibility == transcript.EntryVisibilityAuto {
+			engine.AppendLocalEntry(req.Role, req.Text)
+		} else {
+			engine.AppendLocalEntryWithVisibility(req.Role, req.Text, visibility)
+		}
 		return struct{}{}, nil
 	})
 	return err
@@ -498,7 +505,7 @@ func sameSessionOnlyMemoRequest(a sessionOnlyMemoRequest, b sessionOnlyMemoReque
 }
 
 func sameLocalEntryMemoRequest(a localEntryMemoRequest, b localEntryMemoRequest) bool {
-	return a.SessionID == b.SessionID && a.Role == b.Role && a.Text == b.Text
+	return a.SessionID == b.SessionID && a.Role == b.Role && a.Text == b.Text && a.Visibility == b.Visibility
 }
 
 var _ serverapi.RuntimeControlService = (*Service)(nil)

--- a/server/runtimecontrol/service_idempotency_test.go
+++ b/server/runtimecontrol/service_idempotency_test.go
@@ -10,6 +10,7 @@ import (
 	"builder/server/session"
 	"builder/server/tools"
 	"builder/shared/serverapi"
+	"builder/shared/transcript"
 )
 
 var runtimeControlOpenAICapabilities = llm.ProviderCapabilities{
@@ -349,6 +350,38 @@ func TestServiceAppendLocalEntryDedupesSuccessfulRetry(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("local entry count = %d, want 1", count)
+	}
+}
+
+func TestServiceAppendLocalEntryReplaysVisibility(t *testing.T) {
+	store, err := session.Create(t.TempDir(), "workspace-x", "/tmp/workspace-x")
+	if err != nil {
+		t.Fatalf("create session store: %v", err)
+	}
+	engine, err := runtime.New(store, &runtimeControlFakeClient{}, tools.NewRegistry(), runtime.Config{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("create runtime engine: %v", err)
+	}
+	service := NewService(stubRuntimeResolver{engine: engine}, nil)
+	req := serverapi.RuntimeAppendLocalEntryRequest{ClientRequestID: "req-1", SessionID: store.Meta().SessionID, ControllerLeaseID: "lease-1", Role: "warning", Text: "visible warning", Visibility: string(transcript.EntryVisibilityAll)}
+
+	if err := service.AppendLocalEntry(context.Background(), req); err != nil {
+		t.Fatalf("AppendLocalEntry first: %v", err)
+	}
+	if err := service.AppendLocalEntry(context.Background(), req); err != nil {
+		t.Fatalf("AppendLocalEntry replay: %v", err)
+	}
+	count := 0
+	for _, entry := range engine.ChatSnapshot().Entries {
+		if entry.Role == "warning" && entry.Text == "visible warning" {
+			count++
+			if entry.Visibility != transcript.EntryVisibilityAll {
+				t.Fatalf("entry visibility = %q, want all", entry.Visibility)
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("visible warning entry count = %d, want 1", count)
 	}
 }
 

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -78,6 +78,21 @@ func (c *runtimeControlFakeClient) ProviderCapabilities(context.Context) (llm.Pr
 	return c.capabilities, nil
 }
 
+func TestServiceSubmitUserMessageReturnsTypedRuntimeUnavailable(t *testing.T) {
+	service := NewService(stubRuntimeResolver{}, nil)
+	req := serverapi.RuntimeSubmitUserMessageRequest{
+		ClientRequestID:   "req-1",
+		SessionID:         "session-1",
+		ControllerLeaseID: "lease-1",
+		Text:              "hello",
+	}
+
+	_, err := service.SubmitUserMessage(context.Background(), req)
+	if !errors.Is(err, serverapi.ErrRuntimeUnavailable) {
+		t.Fatalf("SubmitUserMessage error = %v, want ErrRuntimeUnavailable", err)
+	}
+}
+
 func TestServiceSetSessionNameReplaysSuccessfulRetryAfterLeaseInvalidation(t *testing.T) {
 	store, err := session.Create(t.TempDir(), "workspace-x", "/tmp/workspace-x")
 	if err != nil {

--- a/server/runtimewire/wiring.go
+++ b/server/runtimewire/wiring.go
@@ -138,6 +138,7 @@ func NewRuntimeWiringWithBackground(store *session.Store, active config.Settings
 		AutoCompactionEnabled:         boolRef(true),
 		HeadlessMode:                  opts.Headless,
 		ToolPreambles:                 active.ToolPreambles,
+		TranscriptWorkingDir:          workspaceRoot,
 		Reviewer: runtime.ReviewerConfig{
 			Frequency:     active.Reviewer.Frequency,
 			Model:         active.Reviewer.Model,

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -411,6 +411,30 @@ func (s *Store) MarkModelDispatchLocked(contract LockedContract) error {
 	})
 }
 
+func (s *Store) BackfillLockedContextBudget(contextWindow, contextPercent int) error {
+	if contextWindow <= 0 || contextPercent <= 0 {
+		return nil
+	}
+	return s.mutateAndPersist(func() error {
+		if s.meta.Locked == nil {
+			return nil
+		}
+		changed := false
+		if s.meta.Locked.ContextWindow <= 0 {
+			s.meta.Locked.ContextWindow = contextWindow
+			changed = true
+		}
+		if s.meta.Locked.ContextPercent <= 0 {
+			s.meta.Locked.ContextPercent = contextPercent
+			changed = true
+		}
+		if changed {
+			s.meta.UpdatedAt = time.Now().UTC()
+		}
+		return nil
+	})
+}
+
 func (s *Store) AppendEvent(stepID, kind string, payload any) (Event, error) {
 	s.mu.Lock()
 

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -415,24 +415,31 @@ func (s *Store) BackfillLockedContextBudget(contextWindow, contextPercent int) e
 	if contextWindow <= 0 || contextPercent <= 0 {
 		return nil
 	}
-	return s.mutateAndPersist(func() error {
-		if s.meta.Locked == nil {
-			return nil
-		}
-		changed := false
-		if s.meta.Locked.ContextWindow <= 0 {
-			s.meta.Locked.ContextWindow = contextWindow
-			changed = true
-		}
-		if s.meta.Locked.ContextPercent <= 0 {
-			s.meta.Locked.ContextPercent = contextPercent
-			changed = true
-		}
-		if changed {
-			s.meta.UpdatedAt = time.Now().UTC()
-		}
+	s.mu.Lock()
+	if s.meta.Locked == nil {
+		s.mu.Unlock()
 		return nil
-	})
+	}
+	changed := false
+	if s.meta.Locked.ContextWindow <= 0 {
+		s.meta.Locked.ContextWindow = contextWindow
+		changed = true
+	}
+	if s.meta.Locked.ContextPercent <= 0 {
+		s.meta.Locked.ContextPercent = contextPercent
+		changed = true
+	}
+	if !changed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.meta.UpdatedAt = time.Now().UTC()
+	snapshot, err := s.persistMetaLocked()
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.observePersistence(snapshot)
 }
 
 func (s *Store) AppendEvent(stepID, kind string, payload any) (Event, error) {

--- a/server/session/store_test.go
+++ b/server/session/store_test.go
@@ -45,6 +45,21 @@ func TestNewLazyReadEventsBeforePersistReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestBackfillLockedContextBudgetWithoutLockedContractDoesNotPersistLazyStore(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewLazy(root, "workspace-x", "/tmp/work")
+	if err != nil {
+		t.Fatalf("new lazy store: %v", err)
+	}
+
+	if err := store.BackfillLockedContextBudget(1000, 50); err != nil {
+		t.Fatalf("BackfillLockedContextBudget: %v", err)
+	}
+	if _, err := os.Stat(store.Dir()); !os.IsNotExist(err) {
+		t.Fatalf("expected no session dir after no-op backfill, stat err=%v", err)
+	}
+}
+
 func TestAppendEventMonotonicSequence(t *testing.T) {
 	root := t.TempDir()
 	store, err := Create(root, "workspace-x", "/tmp/work")

--- a/server/session/types.go
+++ b/server/session/types.go
@@ -9,6 +9,8 @@ type LockedContract struct {
 	Model             string                     `json:"model"`
 	Temperature       float64                    `json:"temperature"`
 	MaxOutputToken    int                        `json:"max_output_token"`
+	ContextWindow     int                        `json:"context_window,omitempty"`
+	ContextPercent    int                        `json:"context_percent,omitempty"`
 	EnabledTools      []string                   `json:"enabled_tools,omitempty"`
 	ToolPreambles     *bool                      `json:"tool_preambles,omitempty"`
 	ModelCapabilities LockedModelCapabilities    `json:"model_capabilities,omitempty"`

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -199,8 +199,16 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 		_ = logger.Close()
 	}
 	handle.rebind = nil
-	if wiring.LocalTools != nil {
-		handle.rebind = wiring.LocalTools.Rebind
+	handle.rebind = func(workdir string) error {
+		if wiring.LocalTools != nil {
+			if err := wiring.LocalTools.Rebind(workdir); err != nil {
+				return err
+			}
+		}
+		if wiring.Engine != nil {
+			wiring.Engine.SetTranscriptWorkingDir(workdir)
+		}
+		return nil
 	}
 	s.completeActivation(handle, leaseID, cleanup)
 	cleanup = nil

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -403,6 +403,20 @@ func (s *Service) SyncExecutionTarget(ctx context.Context, sessionID string, tar
 	return s.persistWorktreeReminderState(ctx, trimmedSessionID, normalizedReminder)
 }
 
+func (s *Service) IsSessionRuntimeActive(sessionID string) bool {
+	if s == nil {
+		return false
+	}
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	if trimmedSessionID == "" {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	handle := s.handles[trimmedSessionID]
+	return handle != nil && handle.activationErr == nil
+}
+
 func (s *Service) persistWorktreeReminderState(ctx context.Context, sessionID string, reminder *session.WorktreeReminderState) error {
 	if reminder == nil {
 		return nil

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -199,20 +199,28 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 		_ = logger.Close()
 	}
 	handle.rebind = nil
-	handle.rebind = func(workdir string) error {
-		if wiring.LocalTools != nil {
-			if err := wiring.LocalTools.Rebind(workdir); err != nil {
-				return err
-			}
-		}
-		if wiring.Engine != nil {
-			wiring.Engine.SetTranscriptWorkingDir(workdir)
-		}
-		return nil
+	var localRebind func(string) error
+	if wiring.LocalTools != nil {
+		localRebind = wiring.LocalTools.Rebind
 	}
+	handle.rebind = runtimeRebindFunc(localRebind, wiring.Engine)
 	s.completeActivation(handle, leaseID, cleanup)
 	cleanup = nil
 	return serverapi.SessionRuntimeActivateResponse{LeaseID: leaseID}, nil
+}
+
+func runtimeRebindFunc(localRebind func(string) error, engine *runtime.Engine) func(string) error {
+	return func(workdir string) error {
+		if localRebind != nil {
+			if err := localRebind(workdir); err != nil {
+				return err
+			}
+		}
+		if engine != nil {
+			engine.SetTranscriptWorkingDir(workdir)
+		}
+		return nil
+	}
 }
 
 func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.SessionRuntimeReleaseRequest) (serverapi.SessionRuntimeReleaseResponse, error) {

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -403,20 +403,6 @@ func (s *Service) SyncExecutionTarget(ctx context.Context, sessionID string, tar
 	return s.persistWorktreeReminderState(ctx, trimmedSessionID, normalizedReminder)
 }
 
-func (s *Service) IsSessionRuntimeActive(sessionID string) bool {
-	if s == nil {
-		return false
-	}
-	trimmedSessionID := strings.TrimSpace(sessionID)
-	if trimmedSessionID == "" {
-		return false
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	handle := s.handles[trimmedSessionID]
-	return handle != nil && handle.activationErr == nil
-}
-
 func (s *Service) persistWorktreeReminderState(ctx context.Context, sessionID string, reminder *session.WorktreeReminderState) error {
 	if reminder == nil {
 		return nil

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -784,6 +784,7 @@ func TestSyncExecutionTargetUpdatesActiveRuntimePatchTranscriptWorkdir(t *testin
 	if err != nil {
 		t.Fatalf("runtime.New: %v", err)
 	}
+	defer func() { _ = engine.Close() }()
 	handle := &runtimeHandle{
 		controllerRequestID: "req-1",
 		controllerLeaseID:   "lease-1",
@@ -874,6 +875,7 @@ func TestRuntimeRebindDoesNotAdvanceTranscriptWorkdirWhenLocalRebindFails(t *tes
 	if err != nil {
 		t.Fatalf("runtime.New: %v", err)
 	}
+	defer func() { _ = engine.Close() }()
 	rebindErr := runtimeRebindFunc(func(string) error { return errors.New("local rebind failed") }, engine)("/new-worktree")
 	if rebindErr == nil || !strings.Contains(rebindErr.Error(), "local rebind failed") {
 		t.Fatalf("runtimeRebindFunc error = %v, want local rebind failed", rebindErr)

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -46,6 +47,23 @@ func (t sessionRuntimeTestTool) Name() toolspec.ID { return t.name }
 func (t sessionRuntimeTestTool) Call(_ context.Context, c tools.Call) (tools.Result, error) {
 	out, _ := json.Marshal(map[string]string{"tool": string(t.name)})
 	return tools.Result{CallID: c.ID, Name: c.Name, Output: out}, nil
+}
+
+type patchDetailCapture struct {
+	mu    sync.Mutex
+	value string
+}
+
+func (c *patchDetailCapture) Set(value string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.value = value
+}
+
+func (c *patchDetailCapture) Get() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.value
 }
 
 func TestClaimActivationReusesDuplicateRequest(t *testing.T) {
@@ -749,7 +767,7 @@ func TestSyncExecutionTargetUpdatesActiveRuntimePatchTranscriptWorkdir(t *testin
 			Usage:     llm.Usage{WindowTokens: 200000},
 		},
 	}}
-	var detail string
+	var detail patchDetailCapture
 	engine, err := runtimepkg.New(fixture.store, client, tools.NewRegistry(sessionRuntimeTestTool{name: toolspec.ToolPatch}), runtimepkg.Config{
 		Model:                "gpt-5",
 		TranscriptWorkingDir: "/old-worktree",
@@ -759,7 +777,7 @@ func TestSyncExecutionTargetUpdatesActiveRuntimePatchTranscriptWorkdir(t *testin
 			}
 			meta, ok := toolcodec.DecodeToolCallMeta(evt.ToolCall.Presentation)
 			if ok {
-				detail = meta.PatchDetail
+				detail.Set(meta.PatchDetail)
 			}
 		},
 	})
@@ -781,11 +799,12 @@ func TestSyncExecutionTargetUpdatesActiveRuntimePatchTranscriptWorkdir(t *testin
 	if _, err := engine.SubmitUserMessage(context.Background(), "apply patch"); err != nil {
 		t.Fatalf("SubmitUserMessage: %v", err)
 	}
-	if !strings.Contains(detail, "/new-worktree/probe.txt") {
-		t.Fatalf("expected patch detail to use retargeted workdir, got %q", detail)
+	gotDetail := detail.Get()
+	if !strings.Contains(gotDetail, "/new-worktree/probe.txt") {
+		t.Fatalf("expected patch detail to use retargeted workdir, got %q", gotDetail)
 	}
-	if strings.Contains(detail, "/old-worktree/probe.txt") {
-		t.Fatalf("did not expect old workdir in patch detail, got %q", detail)
+	if strings.Contains(gotDetail, "/old-worktree/probe.txt") {
+		t.Fatalf("did not expect old workdir in patch detail, got %q", gotDetail)
 	}
 }
 
@@ -838,7 +857,7 @@ func TestRuntimeRebindDoesNotAdvanceTranscriptWorkdirWhenLocalRebindFails(t *tes
 			Usage:     llm.Usage{WindowTokens: 200000},
 		},
 	}}
-	var detail string
+	var detail patchDetailCapture
 	engine, err := runtimepkg.New(fixture.store, client, tools.NewRegistry(sessionRuntimeTestTool{name: toolspec.ToolPatch}), runtimepkg.Config{
 		Model:                "gpt-5",
 		TranscriptWorkingDir: "/old-worktree",
@@ -848,7 +867,7 @@ func TestRuntimeRebindDoesNotAdvanceTranscriptWorkdirWhenLocalRebindFails(t *tes
 			}
 			meta, ok := toolcodec.DecodeToolCallMeta(evt.ToolCall.Presentation)
 			if ok {
-				detail = meta.PatchDetail
+				detail.Set(meta.PatchDetail)
 			}
 		},
 	})
@@ -862,11 +881,12 @@ func TestRuntimeRebindDoesNotAdvanceTranscriptWorkdirWhenLocalRebindFails(t *tes
 	if _, err := engine.SubmitUserMessage(context.Background(), "apply patch"); err != nil {
 		t.Fatalf("SubmitUserMessage: %v", err)
 	}
-	if !strings.Contains(detail, "/old-worktree/probe.txt") {
-		t.Fatalf("expected patch detail to keep old workdir, got %q", detail)
+	gotDetail := detail.Get()
+	if !strings.Contains(gotDetail, "/old-worktree/probe.txt") {
+		t.Fatalf("expected patch detail to keep old workdir, got %q", gotDetail)
 	}
-	if strings.Contains(detail, "/new-worktree/probe.txt") {
-		t.Fatalf("did not expect failed rebind workdir in patch detail, got %q", detail)
+	if strings.Contains(gotDetail, "/new-worktree/probe.txt") {
+		t.Fatalf("did not expect failed rebind workdir in patch detail, got %q", gotDetail)
 	}
 }
 

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -2,20 +2,51 @@ package sessionruntime
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"builder/server/llm"
 	"builder/server/metadata"
 	"builder/server/registry"
+	runtimepkg "builder/server/runtime"
 	"builder/server/session"
+	"builder/server/tools"
 	"builder/shared/clientui"
 	"builder/shared/config"
 	"builder/shared/serverapi"
+	"builder/shared/toolspec"
+	"builder/shared/transcript/toolcodec"
 )
+
+type sessionRuntimeTestLLMClient struct {
+	responses []llm.Response
+}
+
+func (c *sessionRuntimeTestLLMClient) Generate(_ context.Context, _ llm.Request) (llm.Response, error) {
+	if len(c.responses) == 0 {
+		return llm.Response{}, nil
+	}
+	resp := c.responses[0]
+	c.responses = c.responses[1:]
+	return resp, nil
+}
+
+type sessionRuntimeTestTool struct {
+	name toolspec.ID
+}
+
+func (t sessionRuntimeTestTool) Name() toolspec.ID { return t.name }
+
+func (t sessionRuntimeTestTool) Call(_ context.Context, c tools.Call) (tools.Result, error) {
+	out, _ := json.Marshal(map[string]string{"tool": string(t.name)})
+	return tools.Result{CallID: c.ID, Name: c.Name, Output: out}, nil
+}
 
 func TestClaimActivationReusesDuplicateRequest(t *testing.T) {
 	svc := &Service{handles: map[string]*runtimeHandle{
@@ -704,6 +735,60 @@ func TestSyncExecutionTargetRebindsActiveRuntime(t *testing.T) {
 	}
 }
 
+func TestSyncExecutionTargetUpdatesActiveRuntimePatchTranscriptWorkdir(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	patchText := "*** Begin Patch\n*** Add File: probe.txt\n+hello\n*** End Patch\n"
+	client := &sessionRuntimeTestLLMClient{responses: []llm.Response{
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "patching", Phase: llm.MessagePhaseCommentary},
+			ToolCalls: []llm.ToolCall{{ID: "call-patch", Name: string(toolspec.ToolPatch), Input: json.RawMessage(`{"patch":` + strconv.Quote(patchText) + `}`)}},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done", Phase: llm.MessagePhaseFinal},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+	}}
+	var detail string
+	engine, err := runtimepkg.New(fixture.store, client, tools.NewRegistry(sessionRuntimeTestTool{name: toolspec.ToolPatch}), runtimepkg.Config{
+		Model:                "gpt-5",
+		TranscriptWorkingDir: "/old-worktree",
+		OnEvent: func(evt runtimepkg.Event) {
+			if evt.Kind != runtimepkg.EventToolCallStarted || evt.ToolCall == nil {
+				return
+			}
+			meta, ok := toolcodec.DecodeToolCallMeta(evt.ToolCall.Presentation)
+			if ok {
+				detail = meta.PatchDetail
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("runtime.New: %v", err)
+	}
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   "lease-1",
+		ready:               make(chan struct{}),
+		rebind:              runtimeRebindFunc(func(string) error { return nil }, engine),
+	}
+	close(handle.ready)
+	fixture.service.handles = map[string]*runtimeHandle{fixture.store.Meta().SessionID: handle}
+
+	if err := fixture.service.SyncExecutionTarget(context.Background(), fixture.store.Meta().SessionID, clientui.SessionExecutionTarget{EffectiveWorkdir: "/new-worktree"}, nil); err != nil {
+		t.Fatalf("SyncExecutionTarget: %v", err)
+	}
+	if _, err := engine.SubmitUserMessage(context.Background(), "apply patch"); err != nil {
+		t.Fatalf("SubmitUserMessage: %v", err)
+	}
+	if !strings.Contains(detail, "/new-worktree/probe.txt") {
+		t.Fatalf("expected patch detail to use retargeted workdir, got %q", detail)
+	}
+	if strings.Contains(detail, "/old-worktree/probe.txt") {
+		t.Fatalf("did not expect old workdir in patch detail, got %q", detail)
+	}
+}
+
 func TestSyncExecutionTargetDoesNotPersistReminderWhenActiveRuntimeRebindFails(t *testing.T) {
 	fixture := newSessionRuntimeFixture(t)
 	handle := &runtimeHandle{
@@ -736,6 +821,52 @@ func TestSyncExecutionTargetDoesNotPersistReminderWhenActiveRuntimeRebindFails(t
 	}
 	if state := resolved.Meta().WorktreeReminder; state != nil {
 		t.Fatalf("expected reminder state not persisted after failed rebind, got %+v", state)
+	}
+}
+
+func TestRuntimeRebindDoesNotAdvanceTranscriptWorkdirWhenLocalRebindFails(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	patchText := "*** Begin Patch\n*** Add File: probe.txt\n+hello\n*** End Patch\n"
+	client := &sessionRuntimeTestLLMClient{responses: []llm.Response{
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "patching", Phase: llm.MessagePhaseCommentary},
+			ToolCalls: []llm.ToolCall{{ID: "call-patch", Name: string(toolspec.ToolPatch), Input: json.RawMessage(`{"patch":` + strconv.Quote(patchText) + `}`)}},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done", Phase: llm.MessagePhaseFinal},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+	}}
+	var detail string
+	engine, err := runtimepkg.New(fixture.store, client, tools.NewRegistry(sessionRuntimeTestTool{name: toolspec.ToolPatch}), runtimepkg.Config{
+		Model:                "gpt-5",
+		TranscriptWorkingDir: "/old-worktree",
+		OnEvent: func(evt runtimepkg.Event) {
+			if evt.Kind != runtimepkg.EventToolCallStarted || evt.ToolCall == nil {
+				return
+			}
+			meta, ok := toolcodec.DecodeToolCallMeta(evt.ToolCall.Presentation)
+			if ok {
+				detail = meta.PatchDetail
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("runtime.New: %v", err)
+	}
+	rebindErr := runtimeRebindFunc(func(string) error { return errors.New("local rebind failed") }, engine)("/new-worktree")
+	if rebindErr == nil || !strings.Contains(rebindErr.Error(), "local rebind failed") {
+		t.Fatalf("runtimeRebindFunc error = %v, want local rebind failed", rebindErr)
+	}
+	if _, err := engine.SubmitUserMessage(context.Background(), "apply patch"); err != nil {
+		t.Fatalf("SubmitUserMessage: %v", err)
+	}
+	if !strings.Contains(detail, "/old-worktree/probe.txt") {
+		t.Fatalf("expected patch detail to keep old workdir, got %q", detail)
+	}
+	if strings.Contains(detail, "/new-worktree/probe.txt") {
+		t.Fatalf("did not expect failed rebind workdir in patch detail, got %q", detail)
 	}
 }
 

--- a/server/startup/startup.go
+++ b/server/startup/startup.go
@@ -27,6 +27,7 @@ type Request struct {
 	Tools                 string
 	OpenAIBaseURL         string
 	OpenAIBaseURLExplicit bool
+	LoadOptions           config.LoadOptions
 }
 
 type AuthHandler interface {
@@ -133,6 +134,17 @@ func EnsureReady(ctx context.Context, state AuthState, authHandler AuthHandler) 
 }
 
 func buildRequest(req Request, authHandler AuthHandler) serverbootstrap.Request {
+	loadOptions := req.LoadOptions
+	if loadOptions == (config.LoadOptions{}) {
+		loadOptions = config.LoadOptions{
+			Model:               req.Model,
+			ProviderOverride:    req.ProviderOverride,
+			ThinkingLevel:       req.ThinkingLevel,
+			Theme:               req.Theme,
+			ModelTimeoutSeconds: req.ModelTimeoutSeconds,
+			Tools:               req.Tools,
+		}
+	}
 	return serverbootstrap.Request{
 		WorkspaceRoot:         req.WorkspaceRoot,
 		WorkspaceRootExplicit: req.WorkspaceRootExplicit,
@@ -140,14 +152,7 @@ func buildRequest(req Request, authHandler AuthHandler) serverbootstrap.Request 
 		OpenAIBaseURL:         req.OpenAIBaseURL,
 		OpenAIBaseURLExplicit: req.OpenAIBaseURLExplicit,
 		LookupEnv:             lookupEnv(authHandler),
-		LoadOptions: config.LoadOptions{
-			Model:               req.Model,
-			ProviderOverride:    req.ProviderOverride,
-			ThinkingLevel:       req.ThinkingLevel,
-			Theme:               req.Theme,
-			ModelTimeoutSeconds: req.ModelTimeoutSeconds,
-			Tools:               req.Tools,
-		},
+		LoadOptions:           loadOptions,
 	}
 }
 

--- a/server/tools/definitions.go
+++ b/server/tools/definitions.go
@@ -59,11 +59,11 @@ var catalogEntries = []CatalogEntry{
     },
     "raw": {
       "type": "boolean",
-      "description": "Bypasses semantic command post-processing while keeping normal sanitization and truncation behavior. Defaults to false."
+      "description": "Bypass automatic optimization that reduces noise. Rerun the command in raw mode if the original output hid important details. Defaults to false."
     },
     "yield_time_ms": {
       "type": "integer",
-      "description": "How long to wait in milliseconds for output before yielding control and backgrounding the process. Omit this for most commands."
+      "description": "How long to wait for command to finish before backgrounding the process. Omit this for most commands."
     },
     "max_output_tokens": {
       "type": "integer",
@@ -139,7 +139,7 @@ var catalogEntries = []CatalogEntry{
 	{
 		ID:             toolspec.ToolPatch,
 		Aliases:        nil,
-		Description:    "Apply a freeform patch.",
+		Description:    "Apply edits to files using freeform patch syntax.",
 		DefaultEnabled: true,
 		Contract: localContract(
 			LocalRuntimeBuilderPatch,
@@ -200,7 +200,7 @@ var catalogEntries = []CatalogEntry{
 	{
 		ID:             toolspec.ToolTriggerHandoff,
 		Aliases:        nil,
-		Description:    "Trigger a proactive handoff to another agent. Using this tool is allowed only after a developer message appears in transcript that enables this tool. Do not use this tool before that reminder. The tool is private to the agent, so you can use 'analysis' channel content in its parameters.",
+		Description:    "Trigger a proactive handoff to another agent. By default, this tool is disallowed even if visible. Using this tool is allowed only after a specific developer message appears in transcript that allows this tool. Do not use this tool before the reminder. The tool is private to the agent, so you can use 'analysis' channel content in its parameters.",
 		DefaultEnabled: false,
 		Contract: localContract(
 			LocalRuntimeBuilderTriggerHandoff,
@@ -217,7 +217,7 @@ var catalogEntries = []CatalogEntry{
   "properties": {
     "summarizer_prompt": {
       "type": "string",
-      "description": "Optional *extra* instructions for the handoff summarizer. The summarizer already receives detailed generic guidance on preserving the workspace state and full conversation transcript. Only use this to add something specific to your current thoughts or state of work."
+      "description": "Optional *extra* instructions for the handoff summarizer. The summarizer already receives detailed generic guidance on preserving the workspace state and full conversation transcript. Only use this to add something specific about your current thoughts or state of work."
     },
     "future_agent_message": {
       "type": "string",

--- a/server/tools/patch/tool.go
+++ b/server/tools/patch/tool.go
@@ -68,6 +68,9 @@ func (t *Tool) Call(ctx context.Context, c tools.Call) (tools.Result, error) {
 	if err != nil {
 		return patchErrorResult(c, malformedFailure(err.Error())), nil
 	}
+	if len(doc.Hunks) == 0 {
+		return patchErrorResult(c, malformedFailure("No files were modified.")), nil
+	}
 	if err := t.apply(ctx, doc); err != nil {
 		return patchErrorResult(c, err), nil
 	}

--- a/server/tools/patch/tool_apply.go
+++ b/server/tools/patch/tool_apply.go
@@ -45,7 +45,7 @@ func applyEdit(original []string, changes []patchformat.ChangeLine) ([]string, e
 		if h.header.hasPosition {
 			expected = h.header.oldStart - 1 + cumulativeOffset
 		}
-		anchor, err := findHunkAnchor(current, h.changes, expected, searchFloor, h.header.hasPosition)
+		anchor, err := findHunkAnchor(current, h.changes, expected, searchFloor, h.header.hasPosition, h.header.context, h.endOfFile)
 		if err != nil {
 			return nil, attachFailureReasonContext(err, fmt.Sprintf("hunk %d", idx+1))
 		}
@@ -93,6 +93,10 @@ func parseEditHunks(changes []patchformat.ChangeLine) ([]editHunk, error) {
 	}
 
 	for _, ch := range changes {
+		if ch.EndOfFile {
+			current.endOfFile = true
+			continue
+		}
 		switch ch.Kind {
 		case '@':
 			if err := flush(); err != nil {
@@ -123,6 +127,9 @@ func parseHunkHeader(line string) (hunkHeader, error) {
 
 	m := unifiedHunkHeaderPattern.FindStringSubmatch(line)
 	if len(m) == 0 {
+		if strings.HasPrefix(line, "@@ ") {
+			return hunkHeader{context: strings.TrimPrefix(line, "@@ ")}, nil
+		}
 		return hunkHeader{}, malformedFailure(fmt.Sprintf("invalid hunk header %q", line))
 	}
 
@@ -158,7 +165,7 @@ func parseHunkHeader(line string) (hunkHeader, error) {
 	}, nil
 }
 
-func findHunkAnchor(lines []string, changes []patchformat.ChangeLine, expected, floor int, anchored bool) (int, error) {
+func findHunkAnchor(lines []string, changes []patchformat.ChangeLine, expected, floor int, anchored bool, context string, endOfFile bool) (int, error) {
 	if floor < 0 {
 		floor = 0
 	}
@@ -192,12 +199,47 @@ func findHunkAnchor(lines []string, changes []patchformat.ChangeLine, expected, 
 		return -1, contentMismatchFailure(expected+1, true, fmt.Sprintf("patch hunk did not match within %d lines of the expected location", hunkMaxFuzz))
 	}
 
+	if strings.TrimSpace(context) != "" {
+		for start := floor; start < len(lines); start++ {
+			if lineMatches(lines[start], context) {
+				contextStart := start + 1
+				for candidate := contextStart; candidate <= maxStart; candidate++ {
+					if endOfFile && candidate+oldLineCount(changes) != len(lines) {
+						continue
+					}
+					if matchAt(candidate) {
+						return candidate, nil
+					}
+				}
+			}
+		}
+		return -1, contentMismatchFailure(0, false, fmt.Sprintf("failed to find context %q", context))
+	}
+
 	for start := floor; start <= maxStart; start++ {
+		if endOfFile && start+oldLineCount(changes) != len(lines) {
+			continue
+		}
 		if matchAt(start) {
 			return start, nil
 		}
 	}
 	return -1, contentMismatchFailure(0, false, "patch hunk did not match file content")
+}
+
+func oldLineCount(changes []patchformat.ChangeLine) int {
+	count := 0
+	for _, ch := range changes {
+		switch ch.Kind {
+		case ' ', '-':
+			count++
+		}
+	}
+	return count
+}
+
+func lineMatches(actual, expected string) bool {
+	return actual == expected || strings.TrimRight(actual, " \t") == strings.TrimRight(expected, " \t") || strings.TrimSpace(actual) == strings.TrimSpace(expected)
 }
 
 func applyHunkAt(lines []string, changes []patchformat.ChangeLine, start int) ([]string, int, int, error) {

--- a/server/tools/patch/tool_apply.go
+++ b/server/tools/patch/tool_apply.go
@@ -82,6 +82,11 @@ func parseEditHunks(changes []patchformat.ChangeLine) ([]editHunk, error) {
 
 	flush := func() error {
 		if len(current.changes) == 0 {
+			if current.endOfFile {
+				hunks = append(hunks, current)
+				current = editHunk{}
+				return nil
+			}
 			if current.header.hasPosition {
 				return malformedFailure("hunk header without changes")
 			}

--- a/server/tools/patch/tool_edit_state.go
+++ b/server/tools/patch/tool_edit_state.go
@@ -11,12 +11,14 @@ const hunkMaxFuzz = 8
 var unifiedHunkHeaderPattern = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$`)
 
 type editHunk struct {
-	header  hunkHeader
-	changes []patchformat.ChangeLine
+	header    hunkHeader
+	changes   []patchformat.ChangeLine
+	endOfFile bool
 }
 
 type hunkHeader struct {
 	hasPosition bool
+	context     string
 	oldStart    int
 	oldCount    int
 	newStart    int

--- a/server/tools/patch/tool_test.go
+++ b/server/tools/patch/tool_test.go
@@ -265,6 +265,113 @@ func TestAddUpdateMove(t *testing.T) {
 	}
 }
 
+func TestUpdateFileUsesCodexStyleContextHeader(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "a.go")
+	if err := os.WriteFile(target, []byte("package main\n\nfunc one() {\n\tprintln(1)\n}\n\nfunc two() {\n\tprintln(2)\n}\n"), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	tool, err := New(dir, true)
+	if err != nil {
+		t.Fatalf("new patch tool: %v", err)
+	}
+
+	patchText := "*** Begin Patch\n*** Update File: a.go\n@@ func two() {\n-\tprintln(2)\n+\tprintln(22)\n*** End Patch\n"
+	input, _ := json.Marshal(map[string]any{"patch": patchText})
+	result, err := tool.Call(context.Background(), tools.Call{ID: "ctx", Name: toolspec.ToolPatch, Input: input})
+	if err != nil {
+		t.Fatalf("patch call error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if !strings.Contains(string(data), "println(22)") || strings.Contains(string(data), "println(2)\n") {
+		t.Fatalf("unexpected target contents: %q", string(data))
+	}
+}
+
+func TestUpdateFileEndOfFileMarkerAnchorsMatch(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(target, []byte("same\nend\nsame\nend\n"), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	tool, err := New(dir, true)
+	if err != nil {
+		t.Fatalf("new patch tool: %v", err)
+	}
+
+	patchText := "*** Begin Patch\n*** Update File: a.txt\n@@\n same\n-end\n+finish\n*** End of File\n*** End Patch\n"
+	input, _ := json.Marshal(map[string]any{"patch": patchText})
+	result, err := tool.Call(context.Background(), tools.Call{ID: "eof", Name: toolspec.ToolPatch, Input: input})
+	if err != nil {
+		t.Fatalf("patch call error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(data) != "same\nend\nsame\nfinish\n" {
+		t.Fatalf("unexpected target contents: %q", string(data))
+	}
+}
+
+func TestUpdateFileAcceptsWhitespacePaddedEndOfFileMarker(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(target, []byte("one\ntwo\n"), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	tool, err := New(dir, true)
+	if err != nil {
+		t.Fatalf("new patch tool: %v", err)
+	}
+
+	result := callPatch(t, tool, "eof-padding", "*** Begin Patch\n*** Update File: a.txt\n@@\n-one\n+ONE\n two\n  *** End of File  \n*** End Patch\n")
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(data) != "ONE\ntwo\n" {
+		t.Fatalf("unexpected target contents: %q", string(data))
+	}
+}
+
+func TestUpdateFileRejectsEmptyHunk(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(target, []byte("one\n"), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	tool, err := New(dir, true)
+	if err != nil {
+		t.Fatalf("new patch tool: %v", err)
+	}
+
+	result := callPatch(t, tool, "empty-update", "*** Begin Patch\n*** Update File: a.txt\n*** End Patch\n")
+	if !result.IsError {
+		t.Fatal("expected empty update hunk to fail")
+	}
+	payload := toolFailurePayload(t, result)
+	if payload.Kind != "malformed_syntax" || !strings.Contains(payload.Reason, "empty") {
+		t.Fatalf("expected malformed empty hunk failure, got %+v", payload)
+	}
+}
+
 func TestAddFileInNewDirectory(t *testing.T) {
 	dir := t.TempDir()
 	tool, err := New(dir, true)

--- a/server/tools/patch/tool_test.go
+++ b/server/tools/patch/tool_test.go
@@ -383,6 +383,34 @@ func TestUpdateFileRejectsEmptyHunk(t *testing.T) {
 	}
 }
 
+func TestUpdateFileAllowsMoveOnlyHunk(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("content\n"), 0o644); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+	tool, err := New(dir, true)
+	if err != nil {
+		t.Fatalf("new patch tool: %v", err)
+	}
+
+	result := callPatch(t, tool, "move-only", "*** Begin Patch\n*** Update File: src.txt\n*** Move to: dst.txt\n*** End Patch\n")
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+	if _, err := os.Stat(src); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected source removed, stat err=%v", err)
+	}
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if string(data) != "content\n" {
+		t.Fatalf("unexpected destination contents: %q", data)
+	}
+}
+
 func TestAddFileInNewDirectory(t *testing.T) {
 	dir := t.TempDir()
 	tool, err := New(dir, true)

--- a/server/tools/patch/tool_test.go
+++ b/server/tools/patch/tool_test.go
@@ -13,6 +13,7 @@ import (
 
 	"builder/server/tools"
 	"builder/shared/toolspec"
+	patchformat "builder/shared/transcript/patchformat"
 )
 
 func TestDeleteFile(t *testing.T) {
@@ -348,6 +349,16 @@ func TestUpdateFileAcceptsWhitespacePaddedEndOfFileMarker(t *testing.T) {
 	}
 	if string(data) != "ONE\ntwo\n" {
 		t.Fatalf("unexpected target contents: %q", string(data))
+	}
+}
+
+func TestParseEditHunksPreservesSoleEndOfFileMarker(t *testing.T) {
+	hunks, err := parseEditHunks([]patchformat.ChangeLine{{EndOfFile: true}})
+	if err != nil {
+		t.Fatalf("parseEditHunks: %v", err)
+	}
+	if len(hunks) != 1 || !hunks[0].endOfFile || len(hunks[0].changes) != 0 {
+		t.Fatalf("expected sole EOF marker hunk preserved, got %+v", hunks)
 	}
 }
 

--- a/server/tools/transcript_contracts.go
+++ b/server/tools/transcript_contracts.go
@@ -418,7 +418,13 @@ func parseTriggerHandoffToolCall(raw json.RawMessage) (string, string, bool) {
 func parsePatchToolCall(raw json.RawMessage, cwd string) (detail string, compact string, rendered *patchformat.RenderedPatch, ok bool) {
 	var patchText string
 	if err := json.Unmarshal(raw, &patchText); err != nil {
-		return "", "", nil, false
+		var payload struct {
+			Patch string `json:"patch"`
+		}
+		if payloadErr := json.Unmarshal(raw, &payload); payloadErr != nil {
+			return "", "", nil, false
+		}
+		patchText = payload.Patch
 	}
 	trimmedPatch := strings.TrimSpace(patchText)
 	if trimmedPatch == "" {

--- a/server/tools/transcript_contracts.go
+++ b/server/tools/transcript_contracts.go
@@ -416,16 +416,8 @@ func parseTriggerHandoffToolCall(raw json.RawMessage) (string, string, bool) {
 }
 
 func parsePatchToolCall(raw json.RawMessage, cwd string) (detail string, compact string, rendered *patchformat.RenderedPatch, ok bool) {
-	var input map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &input); err != nil {
-		return "", "", nil, false
-	}
-	patchRaw, ok := input["patch"]
-	if !ok {
-		return "", "", nil, false
-	}
 	var patchText string
-	if err := json.Unmarshal(patchRaw, &patchText); err != nil {
+	if err := json.Unmarshal(raw, &patchText); err != nil {
 		return "", "", nil, false
 	}
 	trimmedPatch := strings.TrimSpace(patchText)

--- a/server/tools/types_test.go
+++ b/server/tools/types_test.go
@@ -182,7 +182,7 @@ func TestDefinitionContractsBuildTranscriptMetadata(t *testing.T) {
 	}
 
 	patch, _ := DefinitionFor(toolspec.ToolPatch)
-	patchMeta := patch.BuildToolCallMeta(ToolCallContext{WorkingDir: "/workspace"}, json.RawMessage(`{"patch":"*** Begin Patch\n*** Update File: a.go\n-old\n+new\n*** End Patch\n"}`))
+	patchMeta := patch.BuildToolCallMeta(ToolCallContext{WorkingDir: "/workspace"}, json.RawMessage(`"*** Begin Patch\n*** Update File: a.go\n-old\n+new\n*** End Patch\n"`))
 	if !patchMeta.OmitSuccessfulResult {
 		t.Fatalf("expected patch transcript to suppress success result append, got %+v", patchMeta)
 	}
@@ -194,6 +194,10 @@ func TestDefinitionContractsBuildTranscriptMetadata(t *testing.T) {
 	}
 	if patchMeta.CompactText != patchMeta.PatchSummary || patchMeta.Command != patchMeta.PatchDetail {
 		t.Fatalf("expected patch aliases normalized, got %+v", patchMeta)
+	}
+	freeformPatchMeta := patch.BuildToolCallMeta(ToolCallContext{WorkingDir: "/workspace"}, json.RawMessage(`"*** Begin Patch\n*** Update File: custom.go\n-old\n+new\n*** End Patch\n"`))
+	if freeformPatchMeta.PatchSummary != "Edited: ./custom.go +1 -1" {
+		t.Fatalf("expected custom freeform patch input summary, got %+v", freeformPatchMeta)
 	}
 
 	askQuestion, _ := DefinitionFor(toolspec.ToolAskQuestion)

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -178,6 +178,14 @@ func (g *Gateway) dispatch(ctx context.Context, state *connectionState, req prot
 			}
 			return client.CompleteAuthBootstrap(ctx, params)
 		})
+	case protocol.MethodAuthGetStatus:
+		return decodeAndHandle(req, func(params serverapi.AuthStatusRequest) (serverapi.AuthStatusResponse, error) {
+			client := g.core.AuthStatusClient()
+			if client == nil {
+				return serverapi.AuthStatusResponse{}, serverapi.ErrServerAuthRequired
+			}
+			return client.GetAuthStatus(ctx, params)
+		})
 	case protocol.MethodAttachProject:
 		return decodeAndHandle(req, func(params protocol.AttachProjectRequest) (protocol.AttachResponse, error) {
 			if err := params.Validate(); err != nil {

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -901,6 +901,9 @@ func protocolError(err error) (int, string) {
 	if errors.Is(err, serverapi.ErrInvalidControllerLease) {
 		return protocol.ErrCodeInvalidControllerLease, message
 	}
+	if errors.Is(err, serverapi.ErrRuntimeUnavailable) {
+		return protocol.ErrCodeRuntimeUnavailable, message
+	}
 	if errors.Is(err, serverapi.ErrStreamUnavailable) {
 		return protocol.ErrCodeStreamUnavailable, message
 	}

--- a/server/transport/gateway_test.go
+++ b/server/transport/gateway_test.go
@@ -55,6 +55,13 @@ func configureGatewayTestServerPort(t *testing.T) {
 
 var gatewayTestPortCounter atomic.Uint32
 
+func TestProtocolErrorMapsRuntimeUnavailable(t *testing.T) {
+	code, _ := protocolError(serverapi.ErrRuntimeUnavailable)
+	if code != protocol.ErrCodeRuntimeUnavailable {
+		t.Fatalf("protocol error code = %d, want %d", code, protocol.ErrCodeRuntimeUnavailable)
+	}
+}
+
 func newGatewayTestAuthSupport(t *testing.T, ready bool) serverbootstrap.AuthSupport {
 	t.Helper()
 	store := auth.NewMemoryStore(auth.EmptyState())

--- a/server/worktree/git.go
+++ b/server/worktree/git.go
@@ -21,6 +21,7 @@ type GitWorktree struct {
 	Bare           bool
 	LockedReason   string
 	PrunableReason string
+	DirtyFileCount int
 	IsMain         bool
 }
 
@@ -183,7 +184,22 @@ func (i *GitInspector) Add(ctx context.Context, workspaceRoot string, worktreeRo
 	return normalized.CreateBranch, nil
 }
 
-func (i *GitInspector) Remove(ctx context.Context, workspaceRoot string, worktreeRoot string) error {
+func (i *GitInspector) DirtyFileCount(ctx context.Context, worktreeRoot string) (int, error) {
+	if i == nil {
+		return 0, fmt.Errorf("git inspector is required")
+	}
+	canonicalWorktreeRoot, err := config.CanonicalWorkspaceRoot(worktreeRoot)
+	if err != nil {
+		return 0, err
+	}
+	output, err := i.runner.Output(ctx, canonicalWorktreeRoot, "status", "--porcelain=v1", "-z")
+	if err != nil {
+		return 0, err
+	}
+	return countPorcelainStatusEntries(output), nil
+}
+
+func (i *GitInspector) Remove(ctx context.Context, workspaceRoot string, worktreeRoot string, force bool) error {
 	if i == nil {
 		return fmt.Errorf("git inspector is required")
 	}
@@ -195,8 +211,29 @@ func (i *GitInspector) Remove(ctx context.Context, workspaceRoot string, worktre
 	if err != nil {
 		return err
 	}
-	_, err = i.runner.Output(ctx, canonicalWorkspaceRoot, "worktree", "remove", canonicalWorktreeRoot)
+	args := []string{"worktree", "remove"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, canonicalWorktreeRoot)
+	_, err = i.runner.Output(ctx, canonicalWorkspaceRoot, args...)
 	return err
+}
+
+func countPorcelainStatusEntries(output []byte) int {
+	fields := strings.Split(string(output), "\x00")
+	count := 0
+	for idx := 0; idx < len(fields); idx++ {
+		entry := fields[idx]
+		if strings.TrimSpace(entry) == "" {
+			continue
+		}
+		count++
+		if len(entry) >= 2 && (entry[0] == 'R' || entry[1] == 'R' || entry[0] == 'C' || entry[1] == 'C') {
+			idx++
+		}
+	}
+	return count
 }
 
 func (i *GitInspector) Prune(ctx context.Context, workspaceRoot string) error {

--- a/server/worktree/git_test.go
+++ b/server/worktree/git_test.go
@@ -128,6 +128,42 @@ func TestGitInspectorAddCreatesBranchFromHeadByDefault(t *testing.T) {
 	}
 }
 
+func TestGitInspectorDirtyFileCountUsesPorcelainStatus(t *testing.T) {
+	worktreeRoot := filepath.Join(t.TempDir(), "linked")
+	runner := &stubGitCommandRunner{outputs: map[string][]byte{
+		strings.Join([]string{"status", "--porcelain=v1", "-z"}, "\x00"): []byte(" M changed.go\x00?? new.go\x00R  renamed.go\x00old.go\x00"),
+	}}
+	inspector := NewGitInspector(runner)
+
+	count, err := inspector.DirtyFileCount(context.Background(), worktreeRoot)
+	if err != nil {
+		t.Fatalf("DirtyFileCount: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("dirty count = %d, want 3", count)
+	}
+	if got, want := runner.args, []string{"status", "--porcelain=v1", "-z"}; !equalStrings(got, want) {
+		t.Fatalf("git args=%v want=%v", got, want)
+	}
+	if got, want := runner.dir, canonicalTestPath(t, worktreeRoot); got != want {
+		t.Fatalf("git dir=%q want=%q", got, want)
+	}
+}
+
+func TestGitInspectorRemoveUsesForceWhenRequested(t *testing.T) {
+	workspaceRoot := filepath.Join(t.TempDir(), "workspace")
+	worktreeRoot := filepath.Join(t.TempDir(), "linked")
+	runner := &stubGitCommandRunner{}
+	inspector := NewGitInspector(runner)
+
+	if err := inspector.Remove(context.Background(), workspaceRoot, worktreeRoot, true); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if got, want := runner.args, []string{"worktree", "remove", "--force", canonicalTestPath(t, worktreeRoot)}; !equalStrings(got, want) {
+		t.Fatalf("git args=%v want=%v", got, want)
+	}
+}
+
 func TestGitInspectorAddUsesExistingRefWithoutCreatingBranch(t *testing.T) {
 	workspaceRoot := filepath.Join(t.TempDir(), "workspace")
 	worktreeRoot := filepath.Join(t.TempDir(), "linked")

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -32,6 +32,9 @@ type runtimeController interface {
 	RebindLocalTools(ctx context.Context, sessionID string, leaseID string, workspaceRoot string) error
 	RecordWorktreeTransition(ctx context.Context, sessionID string, leaseID string, state session.WorktreeReminderState) error
 	SyncExecutionTarget(ctx context.Context, sessionID string, target clientui.SessionExecutionTarget, reminder *session.WorktreeReminderState) error
+}
+
+type activeRuntimeSource interface {
 	IsSessionRuntimeActive(sessionID string) bool
 }
 
@@ -54,6 +57,7 @@ type Service struct {
 	git         *GitInspector
 	gate        primaryrun.Gate
 	runtime     runtimeController
+	active      activeRuntimeSource
 	processes   processSource
 	localNotes  localEntryAppender
 	baseDir     string
@@ -106,11 +110,18 @@ func NewService(metadataStore *metadata.Store, gitInspector *GitInspector, gate 
 	if gitInspector == nil {
 		gitInspector = NewGitInspector(nil)
 	}
+	var active activeRuntimeSource
+	if source, ok := gate.(activeRuntimeSource); ok {
+		active = source
+	} else if source, ok := runtime.(activeRuntimeSource); ok {
+		active = source
+	}
 	return &Service{
 		metadata:       metadataStore,
 		git:            gitInspector,
 		gate:           gate,
 		runtime:        runtime,
+		active:         active,
 		processes:      processes,
 		localNotes:     localNotes,
 		baseDir:        strings.TrimSpace(opts.BaseDir),
@@ -749,7 +760,7 @@ func (s *Service) ensureDeletionUnblocked(ctx context.Context, currentSessionID 
 		if strings.TrimSpace(blocker.SessionID) == strings.TrimSpace(currentSessionID) {
 			continue
 		}
-		if s.runtime != nil && !s.runtime.IsSessionRuntimeActive(blocker.SessionID) {
+		if s.active != nil && !s.active.IsSessionRuntimeActive(blocker.SessionID) {
 			continue
 		}
 		otherSessions = append(otherSessions, blocker)

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -139,7 +139,7 @@ func (s *Service) ListWorktrees(ctx context.Context, req serverapi.WorktreeListR
 		return serverapi.WorktreeListResponse{}, err
 	}
 	defer release.Release()
-	synced, err := s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot)
+	synced, err := s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot, req.IncludeDirtyCount)
 	if err != nil {
 		return serverapi.WorktreeListResponse{}, err
 	}
@@ -213,7 +213,7 @@ func (s *Service) CreateWorktree(ctx context.Context, req serverapi.WorktreeCrea
 		return serverapi.WorktreeCreateResponse{}, err
 	}
 	cleanup.worktreeRoot = strings.TrimSpace(worktreeRoot)
-	synced, err := s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot)
+	synced, err := s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot, false)
 	if err != nil {
 		return serverapi.WorktreeCreateResponse{}, err
 	}
@@ -307,7 +307,7 @@ func (s *Service) SwitchWorktree(ctx context.Context, req serverapi.WorktreeSwit
 		return serverapi.WorktreeSwitchResponse{}, err
 	}
 	defer release.Release()
-	synced, err := s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot)
+	synced, err := s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot, false)
 	if err != nil {
 		return serverapi.WorktreeSwitchResponse{}, err
 	}
@@ -332,7 +332,7 @@ func (s *Service) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDele
 		return serverapi.WorktreeDeleteResponse{}, err
 	}
 	defer release.Release()
-	synced, err := s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot)
+	synced, err := s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot, false)
 	if err != nil {
 		return serverapi.WorktreeDeleteResponse{}, err
 	}
@@ -362,15 +362,16 @@ func (s *Service) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDele
 	if err := s.git.Prune(ctx, workspaceCtx.workspaceRoot); err != nil {
 		return serverapi.WorktreeDeleteResponse{}, err
 	}
-	synced, err = s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot)
+	synced, err = s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot, false)
 	if err != nil {
 		return serverapi.WorktreeDeleteResponse{}, err
 	}
 	if registeredTarget, ok := findSyncedWorktreeByID(synced, req.WorktreeID); ok {
-		if err := s.git.Remove(ctx, workspaceCtx.workspaceRoot, registeredTarget.record.CanonicalRoot, registeredTarget.git.DirtyFileCount > 0); err != nil {
+		dirtyCount, _ := s.git.DirtyFileCount(ctx, registeredTarget.record.CanonicalRoot)
+		if err := s.git.Remove(ctx, workspaceCtx.workspaceRoot, registeredTarget.record.CanonicalRoot, dirtyCount > 0); err != nil {
 			return serverapi.WorktreeDeleteResponse{}, err
 		}
-		synced, err = s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot)
+		synced, err = s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot, false)
 		if err != nil {
 			return serverapi.WorktreeDeleteResponse{}, err
 		}
@@ -490,7 +491,7 @@ func (s *Service) resolveSessionWorkspaceContext(ctx context.Context, sessionID 
 	}, nil
 }
 
-func (s *Service) syncWorkspace(ctx context.Context, workspaceID string, workspaceRoot string) ([]syncedWorktree, error) {
+func (s *Service) syncWorkspace(ctx context.Context, workspaceID string, workspaceRoot string, includeDirtyCount bool) ([]syncedWorktree, error) {
 	if s == nil || s.metadata == nil || s.git == nil {
 		return nil, errors.New("worktree service dependencies are required")
 	}
@@ -554,11 +555,8 @@ func (s *Service) syncWorkspace(ctx context.Context, workspaceID string, workspa
 	}
 	synced := make([]syncedWorktree, 0, len(gitEntries))
 	for _, gitEntry := range gitEntries {
-		if pathAvailability(gitEntry.Root) == "available" {
-			dirtyCount, err := s.git.DirtyFileCount(ctx, gitEntry.Root)
-			if err != nil {
-				return nil, err
-			}
+		if includeDirtyCount && pathAvailability(gitEntry.Root) == "available" {
+			dirtyCount, _ := s.git.DirtyFileCount(ctx, gitEntry.Root)
 			gitEntry.DirtyFileCount = dirtyCount
 		}
 		record, ok := refreshedByRoot[strings.TrimSpace(gitEntry.Root)]

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -351,7 +351,7 @@ func (s *Service) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDele
 		if !mainFound {
 			return serverapi.WorktreeDeleteResponse{}, fmt.Errorf("main worktree not found for workspace %q", workspaceCtx.workspaceID)
 		}
-		if _, err := s.switchSessionTarget(ctx, workspaceCtx, req.ControllerLeaseID, &targetWorktree, mainWorktree, true); err != nil {
+		if _, err := s.switchSessionTarget(ctx, workspaceCtx, req.ControllerLeaseID, &targetWorktree, mainWorktree, false); err != nil {
 			return serverapi.WorktreeDeleteResponse{}, err
 		}
 		workspaceCtx, err = s.resolveSessionWorkspaceContext(ctx, workspaceCtx.sessionID)
@@ -389,9 +389,6 @@ func (s *Service) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDele
 	finalTarget, err := s.metadata.ResolveSessionExecutionTarget(ctx, workspaceCtx.sessionID)
 	if err != nil {
 		return serverapi.WorktreeDeleteResponse{}, err
-	}
-	if strings.TrimSpace(branchCleanupMessage) != "" {
-		s.appendLocalNote(context.Background(), workspaceCtx.sessionID, req.ControllerLeaseID, branchCleanupMessage)
 	}
 	return serverapi.WorktreeDeleteResponse{Target: finalTarget, Worktree: worktreeViewFromSynced(targetWorktree, finalTarget), BranchDeleted: branchDeleted, BranchCleanupMessage: branchCleanupMessage}, nil
 }

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -554,8 +554,12 @@ func (s *Service) syncWorkspace(ctx context.Context, workspaceID string, workspa
 	synced := make([]syncedWorktree, 0, len(gitEntries))
 	for _, gitEntry := range gitEntries {
 		if includeDirtyCount && pathAvailability(gitEntry.Root) == "available" {
-			dirtyCount, _ := s.git.DirtyFileCount(ctx, gitEntry.Root)
-			gitEntry.DirtyFileCount = dirtyCount
+			dirtyCount, dirtyErr := s.git.DirtyFileCount(ctx, gitEntry.Root)
+			if dirtyErr != nil {
+				gitEntry.DirtyFileCount = -1
+			} else {
+				gitEntry.DirtyFileCount = dirtyCount
+			}
 		}
 		record, ok := refreshedByRoot[strings.TrimSpace(gitEntry.Root)]
 		if !ok {
@@ -1095,7 +1099,6 @@ func marshalGitMetadata(entry GitWorktree) (string, error) {
 		Bare           bool   `json:"bare,omitempty"`
 		LockedReason   string `json:"locked_reason,omitempty"`
 		PrunableReason string `json:"prunable_reason,omitempty"`
-		DirtyFileCount int    `json:"dirty_file_count,omitempty"`
 	}{
 		HeadOID:        entry.HeadOID,
 		BranchRef:      entry.BranchRef,
@@ -1104,7 +1107,6 @@ func marshalGitMetadata(entry GitWorktree) (string, error) {
 		Bare:           entry.Bare,
 		LockedReason:   entry.LockedReason,
 		PrunableReason: entry.PrunableReason,
-		DirtyFileCount: entry.DirtyFileCount,
 	})
 	if err != nil {
 		return "", fmt.Errorf("marshal git worktree metadata: %w", err)

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -251,7 +251,7 @@ func (s *Service) cleanupFailedCreate(ctx context.Context, cleanup failedCreateC
 	defer cancel()
 	var collected []error
 	if strings.TrimSpace(cleanup.worktreeRoot) != "" {
-		if err := s.git.Remove(cleanupCtx, cleanup.workspaceRoot, cleanup.worktreeRoot); err != nil {
+		if err := s.git.Remove(cleanupCtx, cleanup.workspaceRoot, cleanup.worktreeRoot, false); err != nil {
 			collected = append(collected, fmt.Errorf("remove failed worktree %q: %w", cleanup.worktreeRoot, err))
 		}
 	}
@@ -367,7 +367,7 @@ func (s *Service) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDele
 		return serverapi.WorktreeDeleteResponse{}, err
 	}
 	if registeredTarget, ok := findSyncedWorktreeByID(synced, req.WorktreeID); ok {
-		if err := s.git.Remove(ctx, workspaceCtx.workspaceRoot, registeredTarget.record.CanonicalRoot); err != nil {
+		if err := s.git.Remove(ctx, workspaceCtx.workspaceRoot, registeredTarget.record.CanonicalRoot, registeredTarget.git.DirtyFileCount > 0); err != nil {
 			return serverapi.WorktreeDeleteResponse{}, err
 		}
 		synced, err = s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot)
@@ -554,6 +554,13 @@ func (s *Service) syncWorkspace(ctx context.Context, workspaceID string, workspa
 	}
 	synced := make([]syncedWorktree, 0, len(gitEntries))
 	for _, gitEntry := range gitEntries {
+		if pathAvailability(gitEntry.Root) == "available" {
+			dirtyCount, err := s.git.DirtyFileCount(ctx, gitEntry.Root)
+			if err != nil {
+				return nil, err
+			}
+			gitEntry.DirtyFileCount = dirtyCount
+		}
 		record, ok := refreshedByRoot[strings.TrimSpace(gitEntry.Root)]
 		if !ok {
 			return nil, fmt.Errorf("synced worktree record missing for %q", gitEntry.Root)
@@ -990,6 +997,7 @@ func worktreeViewFromSynced(item syncedWorktree, target clientui.SessionExecutio
 		Detached:        item.git.Detached,
 		LockedReason:    item.git.LockedReason,
 		PrunableReason:  item.git.PrunableReason,
+		DirtyFileCount:  item.git.DirtyFileCount,
 		IsMain:          item.git.IsMain,
 		IsCurrent:       isCurrent,
 		BuilderManaged:  item.record.BuilderManaged,
@@ -1091,6 +1099,7 @@ func marshalGitMetadata(entry GitWorktree) (string, error) {
 		Bare           bool   `json:"bare,omitempty"`
 		LockedReason   string `json:"locked_reason,omitempty"`
 		PrunableReason string `json:"prunable_reason,omitempty"`
+		DirtyFileCount int    `json:"dirty_file_count,omitempty"`
 	}{
 		HeadOID:        entry.HeadOID,
 		BranchRef:      entry.BranchRef,
@@ -1099,6 +1108,7 @@ func marshalGitMetadata(entry GitWorktree) (string, error) {
 		Bare:           entry.Bare,
 		LockedReason:   entry.LockedReason,
 		PrunableReason: entry.PrunableReason,
+		DirtyFileCount: entry.DirtyFileCount,
 	})
 	if err != nil {
 		return "", fmt.Errorf("marshal git worktree metadata: %w", err)

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -32,6 +32,7 @@ type runtimeController interface {
 	RebindLocalTools(ctx context.Context, sessionID string, leaseID string, workspaceRoot string) error
 	RecordWorktreeTransition(ctx context.Context, sessionID string, leaseID string, state session.WorktreeReminderState) error
 	SyncExecutionTarget(ctx context.Context, sessionID string, target clientui.SessionExecutionTarget, reminder *session.WorktreeReminderState) error
+	IsSessionRuntimeActive(sessionID string) bool
 }
 
 type processSource interface {
@@ -746,6 +747,9 @@ func (s *Service) ensureDeletionUnblocked(ctx context.Context, currentSessionID 
 	otherSessions := make([]metadata.WorktreeSessionBlocker, 0, len(blockers))
 	for _, blocker := range blockers {
 		if strings.TrimSpace(blocker.SessionID) == strings.TrimSpace(currentSessionID) {
+			continue
+		}
+		if s.runtime != nil && !s.runtime.IsSessionRuntimeActive(blocker.SessionID) {
 			continue
 		}
 		otherSessions = append(otherSessions, blocker)

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -367,8 +367,9 @@ func (s *Service) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDele
 		return serverapi.WorktreeDeleteResponse{}, err
 	}
 	if registeredTarget, ok := findSyncedWorktreeByID(synced, req.WorktreeID); ok {
-		dirtyCount, _ := s.git.DirtyFileCount(ctx, registeredTarget.record.CanonicalRoot)
-		if err := s.git.Remove(ctx, workspaceCtx.workspaceRoot, registeredTarget.record.CanonicalRoot, dirtyCount > 0); err != nil {
+		dirtyCount, dirtyErr := s.git.DirtyFileCount(ctx, registeredTarget.record.CanonicalRoot)
+		force := dirtyCount > 0 || dirtyErr != nil
+		if err := s.git.Remove(ctx, workspaceCtx.workspaceRoot, registeredTarget.record.CanonicalRoot, force); err != nil {
 			return serverapi.WorktreeDeleteResponse{}, err
 		}
 		synced, err = s.syncWorkspace(ctx, workspaceCtx.workspaceID, workspaceCtx.workspaceRoot, false)

--- a/server/worktree/service_test.go
+++ b/server/worktree/service_test.go
@@ -372,6 +372,8 @@ func TestDeleteWorktreeKeepsExistingBranchUnlessExplicitlyRequested(t *testing.T
 	if err != nil {
 		t.Fatalf("CreateWorktree existing branch: %v", err)
 	}
+	env.localNotes = &serviceTestLocalNotes{}
+	env.service.localNotes = env.localNotes
 
 	deleteResp, err := env.service.DeleteWorktree(env.ctx, serverapi.WorktreeDeleteRequest{
 		ClientRequestID:   "req-delete-shared-branch",
@@ -387,6 +389,9 @@ func TestDeleteWorktreeKeepsExistingBranchUnlessExplicitlyRequested(t *testing.T
 	}
 	if !strings.Contains(deleteResp.BranchCleanupMessage, "Kept branch feature/shared-branch") {
 		t.Fatalf("unexpected branch cleanup message: %q", deleteResp.BranchCleanupMessage)
+	}
+	if notes := env.localNotes.snapshot(); len(notes) != 0 {
+		t.Fatalf("expected no transcript note for delete branch cleanup message, got %+v", notes)
 	}
 	if got := runGit(t, env.workspaceRoot, "branch", "--list", "feature/shared-branch"); !strings.Contains(got, "feature/shared-branch") {
 		t.Fatalf("expected shared branch to remain, got %q", got)
@@ -406,6 +411,8 @@ func TestDeleteWorktreeDeletesExistingBranchWhenExplicitlyRequested(t *testing.T
 	if err != nil {
 		t.Fatalf("CreateWorktree existing branch: %v", err)
 	}
+	env.localNotes = &serviceTestLocalNotes{}
+	env.service.localNotes = env.localNotes
 
 	deleteResp, err := env.service.DeleteWorktree(env.ctx, serverapi.WorktreeDeleteRequest{
 		ClientRequestID:   "req-delete-shared-branch-explicit",
@@ -422,6 +429,9 @@ func TestDeleteWorktreeDeletesExistingBranchWhenExplicitlyRequested(t *testing.T
 	}
 	if !strings.Contains(deleteResp.BranchCleanupMessage, "Deleted branch feature/shared-branch") {
 		t.Fatalf("unexpected branch cleanup message: %q", deleteResp.BranchCleanupMessage)
+	}
+	if notes := env.localNotes.snapshot(); len(notes) != 0 {
+		t.Fatalf("expected no transcript note for delete branch cleanup message, got %+v", notes)
 	}
 	if got := runGit(t, env.workspaceRoot, "branch", "--list", "feature/shared-branch"); strings.Contains(got, "feature/shared-branch") {
 		t.Fatalf("expected shared branch removed, got %q", got)
@@ -957,9 +967,8 @@ func TestDeleteWorktreeRebindsCurrentSessionToMainBeforeRemoval(t *testing.T) {
 			t.Fatalf("expected deleted worktree to disappear from list, got %+v", worktree)
 		}
 	}
-	notes := env.localNotes.snapshot()
-	if len(notes) == 0 || !strings.Contains(notes[0], "Switched worktree to main workspace") {
-		t.Fatalf("expected delete path to append switch note, got %+v", notes)
+	if notes := env.localNotes.snapshot(); len(notes) != 0 {
+		t.Fatalf("expected delete path not to append transcript notes, got %+v", notes)
 	}
 }
 

--- a/server/worktree/service_test.go
+++ b/server/worktree/service_test.go
@@ -765,6 +765,40 @@ func TestDeleteWorktreeIgnoresDormantSessionsTargetingIt(t *testing.T) {
 	}
 }
 
+func TestListWorktreesReportsDirtyFileCount(t *testing.T) {
+	env := newServiceTestEnv(t)
+	created := mustCreateWorktree(t, env, "feature/dirty-count")
+	if err := os.WriteFile(filepath.Join(created.CanonicalRoot, "untracked.txt"), []byte("dirty"), 0o644); err != nil {
+		t.Fatalf("write untracked file: %v", err)
+	}
+
+	listed := findWorktreeByID(t, mustListWorktrees(t, env).Worktrees, created.WorktreeID)
+	if listed.DirtyFileCount != 1 {
+		t.Fatalf("dirty file count = %d, want 1", listed.DirtyFileCount)
+	}
+}
+
+func TestDeleteWorktreeForcesRemovalWhenDirty(t *testing.T) {
+	env := newServiceTestEnv(t)
+	created := mustCreateWorktree(t, env, "feature/delete-dirty")
+	if err := os.WriteFile(filepath.Join(created.CanonicalRoot, "untracked.txt"), []byte("dirty"), 0o644); err != nil {
+		t.Fatalf("write untracked file: %v", err)
+	}
+
+	_, err := env.service.DeleteWorktree(env.ctx, serverapi.WorktreeDeleteRequest{
+		ClientRequestID:   "req-delete-dirty",
+		SessionID:         env.session.Meta().SessionID,
+		ControllerLeaseID: env.leaseID,
+		WorktreeID:        created.WorktreeID,
+	})
+	if err != nil {
+		t.Fatalf("DeleteWorktree: %v", err)
+	}
+	if _, err := os.Stat(created.CanonicalRoot); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected dirty worktree root removed, stat err=%v", err)
+	}
+}
+
 func TestDeleteWorktreeBlocksOnlyActiveSessionsTargetingIt(t *testing.T) {
 	env := newServiceTestEnv(t)
 	created := mustCreateWorktree(t, env, "feature/delete-mixed-session-blockers")

--- a/server/worktree/service_test.go
+++ b/server/worktree/service_test.go
@@ -86,6 +86,12 @@ func (r *serviceTestRuntime) SyncExecutionTarget(_ context.Context, sessionID st
 	return nil
 }
 
+func (r *serviceTestRuntime) IsSessionRuntimeActive(sessionID string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.activeSessions[strings.TrimSpace(sessionID)]
+}
+
 type serviceTestGate struct {
 	err error
 }
@@ -724,6 +730,7 @@ func TestDeleteWorktreeBlocksWhenAnotherSessionTargetsIt(t *testing.T) {
 	if err := env.store.UpdateSessionExecutionTargetByID(env.ctx, otherSession.Meta().SessionID, env.binding.WorkspaceID, created.WorktreeID, "."); err != nil {
 		t.Fatalf("UpdateSessionExecutionTargetByID other session: %v", err)
 	}
+	env.runtime.activeSessions[otherSession.Meta().SessionID] = true
 
 	_, err := env.service.DeleteWorktree(env.ctx, serverapi.WorktreeDeleteRequest{
 		ClientRequestID:   "req-delete-blocked-session",
@@ -733,6 +740,28 @@ func TestDeleteWorktreeBlocksWhenAnotherSessionTargetsIt(t *testing.T) {
 	})
 	if !errors.Is(err, serverapi.ErrWorktreeBlocked) {
 		t.Fatalf("DeleteWorktree error = %v, want ErrWorktreeBlocked", err)
+	}
+}
+
+func TestDeleteWorktreeIgnoresDormantSessionsTargetingIt(t *testing.T) {
+	env := newServiceTestEnv(t)
+	created := mustCreateWorktree(t, env, "feature/delete-dormant-session")
+	otherSession := createServiceTestSession(t, env.store, env.cfg, env.binding)
+	if err := env.store.UpdateSessionExecutionTargetByID(env.ctx, otherSession.Meta().SessionID, env.binding.WorkspaceID, created.WorktreeID, "."); err != nil {
+		t.Fatalf("UpdateSessionExecutionTargetByID other session: %v", err)
+	}
+
+	_, err := env.service.DeleteWorktree(env.ctx, serverapi.WorktreeDeleteRequest{
+		ClientRequestID:   "req-delete-dormant-session",
+		SessionID:         env.session.Meta().SessionID,
+		ControllerLeaseID: env.leaseID,
+		WorktreeID:        created.WorktreeID,
+	})
+	if err != nil {
+		t.Fatalf("DeleteWorktree: %v", err)
+	}
+	if _, err := os.Stat(created.CanonicalRoot); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected worktree root removed, stat err=%v", err)
 	}
 }
 

--- a/server/worktree/service_test.go
+++ b/server/worktree/service_test.go
@@ -822,8 +822,8 @@ func TestListWorktreesDirtyCountProbeFailureIsBestEffort(t *testing.T) {
 		t.Fatalf("ListWorktrees: %v", err)
 	}
 	listed := findWorktreeByID(t, resp.Worktrees, created.WorktreeID)
-	if listed.DirtyFileCount != 0 {
-		t.Fatalf("dirty file count after failed probe = %d, want 0", listed.DirtyFileCount)
+	if listed.DirtyFileCount != -1 {
+		t.Fatalf("dirty file count after failed probe = %d, want -1", listed.DirtyFileCount)
 	}
 }
 

--- a/server/worktree/service_test.go
+++ b/server/worktree/service_test.go
@@ -765,6 +765,49 @@ func TestDeleteWorktreeIgnoresDormantSessionsTargetingIt(t *testing.T) {
 	}
 }
 
+func TestDeleteWorktreeBlocksOnlyActiveSessionsTargetingIt(t *testing.T) {
+	env := newServiceTestEnv(t)
+	created := mustCreateWorktree(t, env, "feature/delete-mixed-session-blockers")
+	dormantSession := createServiceTestSession(t, env.store, env.cfg, env.binding)
+	activeSession := createServiceTestSession(t, env.store, env.cfg, env.binding)
+	if err := dormantSession.SetName("dormant blocker"); err != nil {
+		t.Fatalf("SetName dormant: %v", err)
+	}
+	if err := activeSession.SetName("active blocker"); err != nil {
+		t.Fatalf("SetName active: %v", err)
+	}
+	if err := env.store.ImportSessionSnapshot(env.ctx, session.PersistedStoreSnapshot{SessionDir: dormantSession.Dir(), Meta: dormantSession.Meta()}); err != nil {
+		t.Fatalf("ImportSessionSnapshot dormant: %v", err)
+	}
+	if err := env.store.ImportSessionSnapshot(env.ctx, session.PersistedStoreSnapshot{SessionDir: activeSession.Dir(), Meta: activeSession.Meta()}); err != nil {
+		t.Fatalf("ImportSessionSnapshot active: %v", err)
+	}
+	if err := env.store.UpdateSessionExecutionTargetByID(env.ctx, dormantSession.Meta().SessionID, env.binding.WorkspaceID, created.WorktreeID, "."); err != nil {
+		t.Fatalf("UpdateSessionExecutionTargetByID dormant session: %v", err)
+	}
+	if err := env.store.UpdateSessionExecutionTargetByID(env.ctx, activeSession.Meta().SessionID, env.binding.WorkspaceID, created.WorktreeID, "."); err != nil {
+		t.Fatalf("UpdateSessionExecutionTargetByID active session: %v", err)
+	}
+	env.runtime.activeSessions[activeSession.Meta().SessionID] = true
+
+	_, err := env.service.DeleteWorktree(env.ctx, serverapi.WorktreeDeleteRequest{
+		ClientRequestID:   "req-delete-mixed-session-blockers",
+		SessionID:         env.session.Meta().SessionID,
+		ControllerLeaseID: env.leaseID,
+		WorktreeID:        created.WorktreeID,
+	})
+	if !errors.Is(err, serverapi.ErrWorktreeBlocked) {
+		t.Fatalf("DeleteWorktree error = %v, want ErrWorktreeBlocked", err)
+	}
+	message := err.Error()
+	if !strings.Contains(message, "active blocker") {
+		t.Fatalf("expected active blocker in error, got %q", message)
+	}
+	if strings.Contains(message, "dormant blocker") {
+		t.Fatalf("did not expect dormant blocker in error, got %q", message)
+	}
+}
+
 func TestDeleteWorktreeBlocksWhenBackgroundProcessUsesDescendantPath(t *testing.T) {
 	env := newServiceTestEnv(t)
 	created := mustCreateWorktree(t, env, "feature/delete-blocked-process")

--- a/server/worktree/service_test.go
+++ b/server/worktree/service_test.go
@@ -118,6 +118,26 @@ type serviceTestLocalNotes struct {
 	appendLocalErr error
 }
 
+type dirtyCountFailingGitRunner struct {
+	base      gitCommandRunner
+	dirtyRoot string
+}
+
+func (r *dirtyCountFailingGitRunner) Output(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	output, exitCode, err := r.Run(ctx, dir, args...)
+	if err != nil {
+		return nil, formatGitRunError(exitCode, err, output, args...)
+	}
+	return output, nil
+}
+
+func (r *dirtyCountFailingGitRunner) Run(ctx context.Context, dir string, args ...string) ([]byte, int, error) {
+	if equalStrings(args, []string{"status", "--porcelain=v1", "-z"}) && strings.TrimSpace(dir) == strings.TrimSpace(r.dirtyRoot) {
+		return []byte("status failed"), 1, errors.New("status failed")
+	}
+	return r.base.Run(ctx, dir, args...)
+}
+
 func (n *serviceTestLocalNotes) AppendLocalEntry(_ context.Context, req serverapi.RuntimeAppendLocalEntryRequest) error {
 	if n.appendLocalErr != nil {
 		return n.appendLocalErr
@@ -772,9 +792,28 @@ func TestListWorktreesReportsDirtyFileCount(t *testing.T) {
 		t.Fatalf("write untracked file: %v", err)
 	}
 
-	listed := findWorktreeByID(t, mustListWorktrees(t, env).Worktrees, created.WorktreeID)
+	resp, err := env.service.ListWorktrees(env.ctx, serverapi.WorktreeListRequest{SessionID: env.session.Meta().SessionID, ControllerLeaseID: env.leaseID, IncludeDirtyCount: true})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	listed := findWorktreeByID(t, resp.Worktrees, created.WorktreeID)
 	if listed.DirtyFileCount != 1 {
 		t.Fatalf("dirty file count = %d, want 1", listed.DirtyFileCount)
+	}
+}
+
+func TestListWorktreesDirtyCountProbeFailureIsBestEffort(t *testing.T) {
+	env := newServiceTestEnv(t)
+	created := mustCreateWorktree(t, env, "feature/dirty-probe-failure")
+	env.service.git = NewGitInspector(&dirtyCountFailingGitRunner{base: execGitCommandRunner{}, dirtyRoot: created.CanonicalRoot})
+
+	resp, err := env.service.ListWorktrees(env.ctx, serverapi.WorktreeListRequest{SessionID: env.session.Meta().SessionID, ControllerLeaseID: env.leaseID, IncludeDirtyCount: true})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	listed := findWorktreeByID(t, resp.Worktrees, created.WorktreeID)
+	if listed.DirtyFileCount != 0 {
+		t.Fatalf("dirty file count after failed probe = %d, want 0", listed.DirtyFileCount)
 	}
 }
 
@@ -796,6 +835,25 @@ func TestDeleteWorktreeForcesRemovalWhenDirty(t *testing.T) {
 	}
 	if _, err := os.Stat(created.CanonicalRoot); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected dirty worktree root removed, stat err=%v", err)
+	}
+}
+
+func TestDeleteWorktreeDirtyCountProbeFailureIsBestEffort(t *testing.T) {
+	env := newServiceTestEnv(t)
+	created := mustCreateWorktree(t, env, "feature/delete-dirty-probe-failure")
+	env.service.git = NewGitInspector(&dirtyCountFailingGitRunner{base: execGitCommandRunner{}, dirtyRoot: created.CanonicalRoot})
+
+	_, err := env.service.DeleteWorktree(env.ctx, serverapi.WorktreeDeleteRequest{
+		ClientRequestID:   "req-delete-dirty-probe-failure",
+		SessionID:         env.session.Meta().SessionID,
+		ControllerLeaseID: env.leaseID,
+		WorktreeID:        created.WorktreeID,
+	})
+	if err != nil {
+		t.Fatalf("DeleteWorktree: %v", err)
+	}
+	if _, err := os.Stat(created.CanonicalRoot); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected worktree root removed, stat err=%v", err)
 	}
 }
 

--- a/shared/client/auth_status.go
+++ b/shared/client/auth_status.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"context"
+	"errors"
+
+	"builder/shared/serverapi"
+)
+
+type AuthStatusClient interface {
+	GetAuthStatus(ctx context.Context, req serverapi.AuthStatusRequest) (serverapi.AuthStatusResponse, error)
+}
+
+type loopbackAuthStatusClient struct {
+	service serverapi.AuthStatusService
+}
+
+func NewLoopbackAuthStatusClient(service serverapi.AuthStatusService) AuthStatusClient {
+	return &loopbackAuthStatusClient{service: service}
+}
+
+func (c *loopbackAuthStatusClient) GetAuthStatus(ctx context.Context, req serverapi.AuthStatusRequest) (serverapi.AuthStatusResponse, error) {
+	if c == nil || c.service == nil {
+		return serverapi.AuthStatusResponse{}, errors.New("auth status service is required")
+	}
+	return c.service.GetAuthStatus(ctx, req)
+}

--- a/shared/client/remote.go
+++ b/shared/client/remote.go
@@ -116,6 +116,11 @@ func (c *Remote) CompleteAuthBootstrap(ctx context.Context, req serverapi.AuthCo
 	return resp, c.callUnscoped(ctx, protocol.MethodAuthCompleteBootstrap, req, &resp)
 }
 
+func (c *Remote) GetAuthStatus(ctx context.Context, req serverapi.AuthStatusRequest) (serverapi.AuthStatusResponse, error) {
+	var resp serverapi.AuthStatusResponse
+	return resp, c.callUnscoped(ctx, protocol.MethodAuthGetStatus, req, &resp)
+}
+
 func (c *Remote) ListProjects(ctx context.Context, req serverapi.ProjectListRequest) (serverapi.ProjectListResponse, error) {
 	var resp serverapi.ProjectListResponse
 	return resp, c.callUnscoped(ctx, protocol.MethodProjectList, req, &resp)
@@ -427,6 +432,7 @@ func dialConfiguredRemote(ctx context.Context, cfg config.App, projectID string,
 }
 
 var _ ProjectViewClient = (*Remote)(nil)
+var _ AuthStatusClient = (*Remote)(nil)
 var _ SessionLaunchClient = (*Remote)(nil)
 var _ SessionViewClient = (*Remote)(nil)
 var _ SessionLifecycleClient = (*Remote)(nil)

--- a/shared/client/remote_rpc.go
+++ b/shared/client/remote_rpc.go
@@ -419,6 +419,8 @@ func protocolError(resp *protocol.ResponseError) error {
 		return errors.Join(serverapi.ErrSessionAlreadyControlled, errors.New(message))
 	case protocol.ErrCodeInvalidControllerLease:
 		return errors.Join(serverapi.ErrInvalidControllerLease, errors.New(message))
+	case protocol.ErrCodeRuntimeUnavailable:
+		return errors.Join(serverapi.ErrRuntimeUnavailable, errors.New(message))
 	case protocol.ErrCodeStreamUnavailable:
 		return errors.Join(serverapi.ErrStreamUnavailable, errors.New(message))
 	case protocol.ErrCodeStreamFailed:

--- a/shared/client/remote_test.go
+++ b/shared/client/remote_test.go
@@ -627,6 +627,12 @@ func TestProtocolErrorMapsAuthRequiredCode(t *testing.T) {
 	}
 }
 
+func TestProtocolErrorMapsRuntimeUnavailableCode(t *testing.T) {
+	if err := protocolError(&protocol.ResponseError{Code: protocol.ErrCodeRuntimeUnavailable, Message: "runtime missing"}); !errors.Is(err, serverapi.ErrRuntimeUnavailable) {
+		t.Fatalf("expected runtime unavailable, got %v", err)
+	}
+}
+
 func mustJSON(t *testing.T, value any) json.RawMessage {
 	t.Helper()
 	data, err := json.Marshal(value)

--- a/shared/clientui/types.go
+++ b/shared/clientui/types.go
@@ -160,6 +160,7 @@ const (
 	ToolRenderKindShell  ToolRenderKind = "shell"
 	ToolRenderKindDiff   ToolRenderKind = "diff"
 	ToolRenderKindSource ToolRenderKind = "source"
+	ToolRenderKindPlain  ToolRenderKind = "plain"
 
 	ToolShellDialectPosix          ToolShellDialect = "posix"
 	ToolShellDialectPowerShell     ToolShellDialect = "powershell"

--- a/shared/compaction/thresholds.go
+++ b/shared/compaction/thresholds.go
@@ -3,6 +3,14 @@ package compaction
 const (
 	MinimumWindowPercent         = 50
 	DefaultPreSubmitRunwayTokens = 35_000
+	EstimatedTokensPerToolCall   = 1_400
+
+	estimatedToolCallCorpusStartDate              = "2026-04-12"
+	estimatedToolCallCorpusCompactionModeFilter   = "auto,handoff"
+	estimatedToolCallCorpusSampleSize             = 67
+	estimatedToolCallCorpusThresholdTokens        = 258_400
+	estimatedToolCallCorpusMedianDistance         = 187
+	estimatedToolCallCorpusMeanDistanceCenticalls = 18_491
 )
 
 func MinimumThresholdTokens(window int) int {
@@ -25,4 +33,64 @@ func EffectivePreSubmitThresholdTokens(autoThreshold int, runwayTokens int) int 
 		return 1
 	}
 	return threshold
+}
+
+// EstimatedToolCallsForTokenBudget converts a token budget into an estimated
+// number of assistant tool calls before that budget is exhausted.
+//
+// EstimatedTokensPerToolCall is derived from the local Builder session corpus:
+// history_replaced events after estimatedToolCallCorpusStartDate, filtered to
+// estimatedToolCallCorpusCompactionModeFilter to exclude manual /compact runs,
+// produced estimatedToolCallCorpusSampleSize data points. The active compaction
+// threshold was estimatedToolCallCorpusThresholdTokens. Median distance was
+// estimatedToolCallCorpusMedianDistance tool calls, and mean distance was
+// estimatedToolCallCorpusMeanDistanceCenticalls / 100. The resulting ratios are
+// 258,400 / 187 = 1,382 tokens/call and 258,400 / 184.91 = 1,397 tokens/call,
+// rounded to 1,400 for a stable heuristic.
+func EstimatedToolCallsForTokenBudget(tokenBudget int) int {
+	if tokenBudget <= 0 {
+		return 0
+	}
+	quotient := tokenBudget / EstimatedTokensPerToolCall
+	remainder := tokenBudget % EstimatedTokensPerToolCall
+	if remainder >= EstimatedTokensPerToolCall/2 && quotient < maxInt() {
+		quotient++
+	}
+	return quotient
+}
+
+func EstimatedToolCallsForCompactionThreshold(thresholdTokens int) int {
+	return EstimatedToolCallsForTokenBudget(thresholdTokens)
+}
+
+func EstimatedToolCallsForContextWindow(windowTokens int, compactionThresholdPercent int) int {
+	if windowTokens <= 0 || compactionThresholdPercent <= 0 {
+		return 0
+	}
+	if compactionThresholdPercent > 100 {
+		compactionThresholdPercent = 100
+	}
+	budget := percentOfInt(windowTokens, compactionThresholdPercent)
+	return EstimatedToolCallsForTokenBudget(clampInt64ToInt(budget))
+}
+
+func percentOfInt(value int, percent int) int64 {
+	whole := int64(value / 100)
+	remainder := int64(value % 100)
+	return whole*int64(percent) + remainder*int64(percent)/100
+}
+
+func clampInt64ToInt(value int64) int {
+	if value <= 0 {
+		return 0
+	}
+	limit := int64(maxInt())
+	if value > limit {
+		return int(limit)
+	}
+	return int(value)
+}
+
+func maxInt() int {
+	return int(^uint(0) >> 1)
 }

--- a/shared/compaction/thresholds_test.go
+++ b/shared/compaction/thresholds_test.go
@@ -43,3 +43,57 @@ func TestEffectivePreSubmitThresholdTokens(t *testing.T) {
 		})
 	}
 }
+
+func TestEstimatedToolCallsForTokenBudget(t *testing.T) {
+	if got := EstimatedToolCallsForTokenBudget(258_400); got != 185 {
+		t.Fatalf("EstimatedToolCallsForTokenBudget = %d, want 185", got)
+	}
+	if got := EstimatedToolCallsForTokenBudget(0); got != 0 {
+		t.Fatalf("EstimatedToolCallsForTokenBudget(0) = %d, want 0", got)
+	}
+}
+
+func TestEstimatedToolCallsForCompactionThreshold(t *testing.T) {
+	if got := EstimatedToolCallsForCompactionThreshold(258_400); got != 185 {
+		t.Fatalf("EstimatedToolCallsForCompactionThreshold = %d, want 185", got)
+	}
+}
+
+func TestEstimatedToolCallsForContextWindow(t *testing.T) {
+	if got := EstimatedToolCallsForContextWindow(272_000, 95); got != 185 {
+		t.Fatalf("EstimatedToolCallsForContextWindow = %d, want 185", got)
+	}
+	if got := EstimatedToolCallsForContextWindow(272_000, 150); got != 194 {
+		t.Fatalf("EstimatedToolCallsForContextWindow clamps percent = %d, want 194", got)
+	}
+}
+
+func TestEstimatedToolCallsForContextWindowAvoidsOverflow(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	if got := EstimatedToolCallsForContextWindow(maxInt, 100); got <= 0 {
+		t.Fatalf("EstimatedToolCallsForContextWindow(maxInt) = %d, want positive", got)
+	}
+}
+
+func TestEstimatedTokensPerToolCallMatchesCorpusFixture(t *testing.T) {
+	if estimatedToolCallCorpusStartDate != "2026-04-12" {
+		t.Fatalf("corpus start date = %q, want 2026-04-12", estimatedToolCallCorpusStartDate)
+	}
+	if estimatedToolCallCorpusCompactionModeFilter != "auto,handoff" {
+		t.Fatalf("corpus mode filter = %q, want auto,handoff", estimatedToolCallCorpusCompactionModeFilter)
+	}
+	if estimatedToolCallCorpusSampleSize != 67 {
+		t.Fatalf("corpus sample size = %d, want 67", estimatedToolCallCorpusSampleSize)
+	}
+	medianTokensPerCall := estimatedToolCallCorpusThresholdTokens / estimatedToolCallCorpusMedianDistance
+	meanTokensPerCall := estimatedToolCallCorpusThresholdTokens * 100 / estimatedToolCallCorpusMeanDistanceCenticalls
+	if medianTokensPerCall != 1_381 {
+		t.Fatalf("median-derived tokens/call = %d, want 1381", medianTokensPerCall)
+	}
+	if meanTokensPerCall != 1_397 {
+		t.Fatalf("mean-derived tokens/call = %d, want 1397", meanTokensPerCall)
+	}
+	if EstimatedTokensPerToolCall != 1_400 {
+		t.Fatalf("EstimatedTokensPerToolCall = %d, want rounded corpus heuristic 1400", EstimatedTokensPerToolCall)
+	}
+}

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -144,10 +144,15 @@ type ReviewerSettings struct {
 }
 
 type SourceReport struct {
-	SettingsPath         string
-	SettingsFileExists   bool
-	CreatedDefaultConfig bool
-	Sources              map[string]string
+	SettingsPath                  string
+	SettingsFileExists            bool
+	CreatedDefaultConfig          bool
+	HomeSettingsPath              string
+	HomeSettingsFileExists        bool
+	WorkspaceSettingsPath         string
+	WorkspaceSettingsFileExists   bool
+	WorkspaceSettingsLayerEnabled bool
+	Sources                       map[string]string
 }
 
 type App struct {

--- a/shared/config/config_load.go
+++ b/shared/config/config_load.go
@@ -5,43 +5,81 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func Load(workspaceRoot string, opts LoadOptions) (App, error) {
-	if workspaceRoot == "" {
+	if strings.TrimSpace(workspaceRoot) == "" {
+		return App{}, errors.New("workspace root is required")
+	}
+	return load(workspaceRoot, true, opts)
+}
+
+func LoadGlobal(opts LoadOptions) (App, error) {
+	return load("", false, opts)
+}
+
+func load(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions) (App, error) {
+	absWorkspace := ""
+	if strings.TrimSpace(workspaceRoot) != "" {
+		resolved, err := filepath.Abs(workspaceRoot)
+		if err != nil {
+			return App{}, fmt.Errorf("resolve workspace root: %w", err)
+		}
+		absWorkspace = resolved
+	} else if includeWorkspaceLayer {
 		return App{}, errors.New("workspace root is required")
 	}
 
-	absWorkspace, err := filepath.Abs(workspaceRoot)
-	if err != nil {
-		return App{}, fmt.Errorf("resolve workspace root: %w", err)
-	}
-
-	settingsPath, err := resolveSettingsFilePath()
+	homeSettingsPath, err := resolveSettingsFilePath()
 	if err != nil {
 		return App{}, err
 	}
-	settingsExists, err := settingsFileExists(settingsPath)
+	homeSettingsExists, err := settingsFileExists(homeSettingsPath)
 	if err != nil {
 		return App{}, err
 	}
 
-	fileConfig := settingsFile{}
-	if settingsExists {
-		fileConfig, err = readSettingsFile(settingsPath)
+	homeFileConfig := settingsFile{}
+	if homeSettingsExists {
+		homeFileConfig, err = readSettingsFile(homeSettingsPath)
 		if err != nil {
 			return App{}, err
+		}
+	}
+	workspaceSettingsPath := ""
+	workspaceSettingsExists := false
+	workspaceFileConfig := settingsFile{}
+	if includeWorkspaceLayer {
+		workspaceSettingsPath, err = resolveWorkspaceSettingsFilePath(absWorkspace)
+		if err != nil {
+			return App{}, err
+		}
+		workspaceSettingsExists, err = settingsFileExists(workspaceSettingsPath)
+		if err != nil {
+			return App{}, err
+		}
+		if workspaceSettingsExists {
+			workspaceFileConfig, err = readSettingsFile(workspaceSettingsPath)
+			if err != nil {
+				return App{}, err
+			}
 		}
 	}
 
 	state := configRegistry.defaultState()
 	sources := configRegistry.defaultSourceMap()
 
-	if err := configRegistry.applyFile(fileConfig, settingsPath, &state, sources); err != nil {
+	if err := configRegistry.applyFile(homeFileConfig, homeSettingsPath, &state, sources); err != nil {
 		return App{}, err
 	}
 	if err := configRegistry.applyEnv(os.LookupEnv, &state, sources); err != nil {
 		return App{}, err
+	}
+	if includeWorkspaceLayer {
+		if err := configRegistry.applyFile(workspaceFileConfig, workspaceSettingsPath, &state, sources); err != nil {
+			return App{}, err
+		}
 	}
 	if err := configRegistry.applyCLI(opts, &state, sources); err != nil {
 		return App{}, err
@@ -65,16 +103,26 @@ func Load(workspaceRoot string, opts LoadOptions) (App, error) {
 	}
 	state.Settings.Worktrees.BaseDir = absWorktreeBaseDir
 
+	settingsPath := homeSettingsPath
+	if workspaceSettingsExists {
+		settingsPath = workspaceSettingsPath
+	}
+	settingsExists := homeSettingsExists || workspaceSettingsExists
 	return App{
 		AppName:         DefaultAppName,
 		WorkspaceRoot:   absWorkspace,
 		PersistenceRoot: absPersistenceRoot,
 		Settings:        state.Settings,
 		Source: SourceReport{
-			SettingsPath:         settingsPath,
-			SettingsFileExists:   settingsExists,
-			CreatedDefaultConfig: false,
-			Sources:              sources,
+			SettingsPath:                  settingsPath,
+			SettingsFileExists:            settingsExists,
+			CreatedDefaultConfig:          false,
+			HomeSettingsPath:              homeSettingsPath,
+			HomeSettingsFileExists:        homeSettingsExists,
+			WorkspaceSettingsPath:         workspaceSettingsPath,
+			WorkspaceSettingsFileExists:   workspaceSettingsExists,
+			WorkspaceSettingsLayerEnabled: includeWorkspaceLayer,
+			Sources:                       sources,
 		},
 	}, nil
 }

--- a/shared/config/config_load.go
+++ b/shared/config/config_load.go
@@ -9,10 +9,11 @@ import (
 )
 
 func Load(workspaceRoot string, opts LoadOptions) (App, error) {
-	if strings.TrimSpace(workspaceRoot) == "" {
+	trimmed := strings.TrimSpace(workspaceRoot)
+	if trimmed == "" {
 		return App{}, errors.New("workspace root is required")
 	}
-	return load(workspaceRoot, true, opts)
+	return load(trimmed, true, opts)
 }
 
 func LoadGlobal(opts LoadOptions) (App, error) {
@@ -21,8 +22,9 @@ func LoadGlobal(opts LoadOptions) (App, error) {
 
 func load(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions) (App, error) {
 	absWorkspace := ""
-	if strings.TrimSpace(workspaceRoot) != "" {
-		resolved, err := filepath.Abs(workspaceRoot)
+	trimmedWorkspaceRoot := strings.TrimSpace(workspaceRoot)
+	if trimmedWorkspaceRoot != "" {
+		resolved, err := filepath.Abs(trimmedWorkspaceRoot)
 		if err != nil {
 			return App{}, fmt.Errorf("resolve workspace root: %w", err)
 		}
@@ -73,13 +75,13 @@ func load(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions) (A
 	if err := configRegistry.applyFile(homeFileConfig, homeSettingsPath, &state, sources); err != nil {
 		return App{}, err
 	}
-	if err := configRegistry.applyEnv(os.LookupEnv, &state, sources); err != nil {
-		return App{}, err
-	}
 	if includeWorkspaceLayer {
 		if err := configRegistry.applyFile(workspaceFileConfig, workspaceSettingsPath, &state, sources); err != nil {
 			return App{}, err
 		}
+	}
+	if err := configRegistry.applyEnv(os.LookupEnv, &state, sources); err != nil {
+		return App{}, err
 	}
 	if err := configRegistry.applyCLI(opts, &state, sources); err != nil {
 		return App{}, err

--- a/shared/config/config_settings_file.go
+++ b/shared/config/config_settings_file.go
@@ -20,6 +20,18 @@ func resolveSettingsFilePath() (string, error) {
 	return filepath.Join(home, ".builder", "config.toml"), nil
 }
 
+func resolveWorkspaceSettingsFilePath(workspaceRoot string) (string, error) {
+	trimmed := strings.TrimSpace(workspaceRoot)
+	if trimmed == "" {
+		return "", nil
+	}
+	absRoot, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace root: %w", err)
+	}
+	return filepath.Join(absRoot, ".builder", "config.toml"), nil
+}
+
 func settingsFileExists(path string) (bool, error) {
 	if _, err := os.Stat(path); err == nil {
 		return true, nil

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -198,7 +198,21 @@ func TestLoadUsesDefaultsWithoutCreatingConfigOnFirstUse(t *testing.T) {
 	}
 }
 
-func TestLoadAppliesWorkspaceConfigAfterEnvBeforeCLI(t *testing.T) {
+func TestLoadTrimsWorkspaceRootBeforeResolving(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg, err := Load("  "+workspace+"  ", LoadOptions{})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.WorkspaceRoot != workspace {
+		t.Fatalf("workspace root = %q, want %q", cfg.WorkspaceRoot, workspace)
+	}
+}
+
+func TestLoadAppliesWorkspaceConfigBeforeEnvBeforeCLI(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
@@ -221,8 +235,8 @@ func TestLoadAppliesWorkspaceConfigAfterEnvBeforeCLI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if cfg.Settings.Model != "workspace-model" {
-		t.Fatalf("model = %q, want workspace-model", cfg.Settings.Model)
+	if cfg.Settings.Model != "env-model" {
+		t.Fatalf("model = %q, want env-model", cfg.Settings.Model)
 	}
 	if cfg.Settings.ThinkingLevel != "low" {
 		t.Fatalf("thinking level = %q, want cli override", cfg.Settings.ThinkingLevel)
@@ -230,7 +244,7 @@ func TestLoadAppliesWorkspaceConfigAfterEnvBeforeCLI(t *testing.T) {
 	if cfg.Source.SettingsPath != workspaceConfigPath || !cfg.Source.WorkspaceSettingsFileExists {
 		t.Fatalf("unexpected workspace source report: %+v", cfg.Source)
 	}
-	if cfg.Source.Sources["model"] != "file" || cfg.Source.Sources["thinking_level"] != "cli" {
+	if cfg.Source.Sources["model"] != "env" || cfg.Source.Sources["thinking_level"] != "cli" {
 		t.Fatalf("unexpected sources: %+v", cfg.Source.Sources)
 	}
 }

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -198,6 +198,69 @@ func TestLoadUsesDefaultsWithoutCreatingConfigOnFirstUse(t *testing.T) {
 	}
 }
 
+func TestLoadAppliesWorkspaceConfigAfterEnvBeforeCLI(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("BUILDER_MODEL", "env-model")
+	if err := os.MkdirAll(filepath.Join(home, ".builder"), 0o755); err != nil {
+		t.Fatalf("create home config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".builder", "config.toml"), []byte("model = \"home-model\"\n"), 0o644); err != nil {
+		t.Fatalf("write home config: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(workspace, ".builder"), 0o755); err != nil {
+		t.Fatalf("create workspace config dir: %v", err)
+	}
+	workspaceConfigPath := filepath.Join(workspace, ".builder", "config.toml")
+	if err := os.WriteFile(workspaceConfigPath, []byte("model = \"workspace-model\"\nthinking_level = \"high\"\n"), 0o644); err != nil {
+		t.Fatalf("write workspace config: %v", err)
+	}
+
+	cfg, err := Load(workspace, LoadOptions{ThinkingLevel: "low"})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Settings.Model != "workspace-model" {
+		t.Fatalf("model = %q, want workspace-model", cfg.Settings.Model)
+	}
+	if cfg.Settings.ThinkingLevel != "low" {
+		t.Fatalf("thinking level = %q, want cli override", cfg.Settings.ThinkingLevel)
+	}
+	if cfg.Source.SettingsPath != workspaceConfigPath || !cfg.Source.WorkspaceSettingsFileExists {
+		t.Fatalf("unexpected workspace source report: %+v", cfg.Source)
+	}
+	if cfg.Source.Sources["model"] != "file" || cfg.Source.Sources["thinking_level"] != "cli" {
+		t.Fatalf("unexpected sources: %+v", cfg.Source.Sources)
+	}
+}
+
+func TestLoadGlobalSkipsWorkspaceConfigLayer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("BUILDER_MODEL", "env-model")
+	if err := os.MkdirAll(filepath.Join(home, ".builder"), 0o755); err != nil {
+		t.Fatalf("create home config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".builder", "config.toml"), []byte("model = \"home-model\"\n"), 0o644); err != nil {
+		t.Fatalf("write home config: %v", err)
+	}
+
+	cfg, err := LoadGlobal(LoadOptions{})
+	if err != nil {
+		t.Fatalf("load global: %v", err)
+	}
+	if cfg.WorkspaceRoot != "" {
+		t.Fatalf("workspace root = %q, want empty", cfg.WorkspaceRoot)
+	}
+	if cfg.Settings.Model != "env-model" {
+		t.Fatalf("model = %q, want env-model", cfg.Settings.Model)
+	}
+	if cfg.Source.WorkspaceSettingsLayerEnabled || cfg.Source.WorkspaceSettingsPath != "" {
+		t.Fatalf("unexpected workspace source report: %+v", cfg.Source)
+	}
+}
+
 func TestEnsureManagedRGConfigFilePreservesExistingContents(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/shared/protocol/handshake.go
+++ b/shared/protocol/handshake.go
@@ -11,6 +11,7 @@ const (
 	MethodHandshake                                = "protocol.handshake"
 	MethodAuthGetBootstrapStatus                   = "auth.getBootstrapStatus"
 	MethodAuthCompleteBootstrap                    = "auth.completeBootstrap"
+	MethodAuthGetStatus                            = "auth.getStatus"
 	MethodAttachProject                            = "project.attach"
 	MethodAttachSession                            = "session.attach"
 	MethodProjectList                              = "project.list"
@@ -76,6 +77,7 @@ const (
 var allowedPreAuthMethods = []string{
 	MethodAuthGetBootstrapStatus,
 	MethodAuthCompleteBootstrap,
+	MethodAuthGetStatus,
 	MethodAttachProject,
 	MethodAttachSession,
 	MethodProjectList,

--- a/shared/protocol/jsonrpc.go
+++ b/shared/protocol/jsonrpc.go
@@ -24,6 +24,7 @@ const (
 	ErrCodeSessionAlreadyControlled = -32016
 	ErrCodeInvalidControllerLease   = -32017
 	ErrCodeAuthRequired             = -32018
+	ErrCodeRuntimeUnavailable       = -32019
 	ErrCodePromptNotFound           = -32020
 	ErrCodePromptResolved           = -32021
 	ErrCodePromptUnsupported        = -32022

--- a/shared/serverapi/auth_status.go
+++ b/shared/serverapi/auth_status.go
@@ -34,7 +34,7 @@ type AuthSubscriptionWindow struct {
 	Label       string    `json:"label,omitempty"`
 	Qualifier   string    `json:"qualifier,omitempty"`
 	UsedPercent float64   `json:"used_percent,omitempty"`
-	ResetAt     time.Time `json:"reset_at,omitempty"`
+	ResetAt     time.Time `json:"reset_at,omitzero"`
 }
 
 type AuthStatusService interface {

--- a/shared/serverapi/auth_status.go
+++ b/shared/serverapi/auth_status.go
@@ -1,0 +1,42 @@
+package serverapi
+
+import (
+	"context"
+	"time"
+
+	"builder/shared/config"
+)
+
+type AuthStatusRequest struct {
+	Settings config.Settings `json:"settings"`
+}
+
+type AuthStatusResponse struct {
+	Auth         AuthStatusInfo       `json:"auth"`
+	Subscription AuthSubscriptionInfo `json:"subscription"`
+	Warning      string               `json:"warning,omitempty"`
+}
+
+type AuthStatusInfo struct {
+	Summary string   `json:"summary,omitempty"`
+	Details []string `json:"details,omitempty"`
+	Visible bool     `json:"visible,omitempty"`
+}
+
+type AuthSubscriptionInfo struct {
+	Applicable bool                     `json:"applicable,omitempty"`
+	Summary    string                   `json:"summary,omitempty"`
+	Error      string                   `json:"error,omitempty"`
+	Windows    []AuthSubscriptionWindow `json:"windows,omitempty"`
+}
+
+type AuthSubscriptionWindow struct {
+	Label       string    `json:"label,omitempty"`
+	Qualifier   string    `json:"qualifier,omitempty"`
+	UsedPercent float64   `json:"used_percent,omitempty"`
+	ResetAt     time.Time `json:"reset_at,omitempty"`
+}
+
+type AuthStatusService interface {
+	GetAuthStatus(ctx context.Context, req AuthStatusRequest) (AuthStatusResponse, error)
+}

--- a/shared/serverapi/runtime_control.go
+++ b/shared/serverapi/runtime_control.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"strings"
+
+	"builder/shared/transcript"
 )
 
 type RuntimeSetSessionNameRequest struct {
@@ -61,6 +63,7 @@ type RuntimeAppendLocalEntryRequest struct {
 	ControllerLeaseID string `json:"controller_lease_id"`
 	Role              string `json:"role"`
 	Text              string `json:"text"`
+	Visibility        string `json:"visibility,omitempty"`
 }
 
 type RuntimeShouldCompactBeforeUserMessageRequest struct {
@@ -241,6 +244,9 @@ func (r RuntimeAppendLocalEntryRequest) Validate() error {
 	}
 	if err := validateRuntimeSessionID(r.SessionID); err != nil {
 		return err
+	}
+	if visibility := transcript.NormalizeEntryVisibility(transcript.EntryVisibility(r.Visibility)); visibility != "" && visibility != transcript.EntryVisibilityAll && visibility != transcript.EntryVisibilityDetailOnly {
+		return errors.New("visibility must be all or detail_only")
 	}
 	return validateControllerLeaseID(r.ControllerLeaseID)
 }

--- a/shared/serverapi/session_control_errors.go
+++ b/shared/serverapi/session_control_errors.go
@@ -4,3 +4,4 @@ import "errors"
 
 var ErrSessionAlreadyControlled = errors.New("session is already controlled by another client")
 var ErrInvalidControllerLease = errors.New("controller lease is invalid or expired")
+var ErrRuntimeUnavailable = errors.New("session runtime is unavailable")

--- a/shared/serverapi/worktree.go
+++ b/shared/serverapi/worktree.go
@@ -33,6 +33,7 @@ type WorktreeView struct {
 type WorktreeListRequest struct {
 	SessionID         string `json:"session_id"`
 	ControllerLeaseID string `json:"controller_lease_id"`
+	IncludeDirtyCount bool   `json:"include_dirty_count,omitempty"`
 }
 
 type WorktreeListResponse struct {

--- a/shared/serverapi/worktree.go
+++ b/shared/serverapi/worktree.go
@@ -22,6 +22,7 @@ type WorktreeView struct {
 	Detached        bool   `json:"detached,omitempty"`
 	LockedReason    string `json:"locked_reason,omitempty"`
 	PrunableReason  string `json:"prunable_reason,omitempty"`
+	DirtyFileCount  int    `json:"dirty_file_count,omitempty"`
 	IsMain          bool   `json:"is_main,omitempty"`
 	IsCurrent       bool   `json:"is_current,omitempty"`
 	BuilderManaged  bool   `json:"builder_managed,omitempty"`

--- a/shared/transcript/patchformat/parse.go
+++ b/shared/transcript/patchformat/parse.go
@@ -11,14 +11,18 @@ import (
 )
 
 func Parse(src string) (Document, error) {
-	s := scanner{lines: splitRawLines(src)}
-	if !s.consumeExact("*** Begin Patch") {
+	lines, err := patchBodyLines(src)
+	if err != nil {
+		return Document{}, err
+	}
+	s := scanner{lines: lines}
+	if !s.consumeMarker("*** Begin Patch") {
 		return Document{}, errors.New("patch must start with *** Begin Patch")
 	}
 
 	doc := Document{}
 	for !s.done() {
-		line := s.peek()
+		line := strings.TrimSpace(s.peek())
 		switch {
 		case line == "*** End Patch":
 			s.next()
@@ -27,7 +31,7 @@ func Parse(src string) (Document, error) {
 			}
 			return doc, nil
 		case strings.HasPrefix(line, "*** Add File: "):
-			head := strings.TrimPrefix(s.next(), "*** Add File: ")
+			head := strings.TrimPrefix(strings.TrimSpace(s.next()), "*** Add File: ")
 			content := []string{}
 			for !s.done() {
 				n := s.peek()
@@ -39,18 +43,26 @@ func Parse(src string) (Document, error) {
 				}
 				content = append(content, strings.TrimPrefix(s.next(), "+"))
 			}
+			if len(content) == 0 {
+				return Document{}, fmt.Errorf("add file hunk for path %q is empty", head)
+			}
 			doc.Hunks = append(doc.Hunks, AddFile{Path: head, Content: content})
 		case strings.HasPrefix(line, "*** Delete File: "):
-			path := strings.TrimPrefix(s.next(), "*** Delete File: ")
+			path := strings.TrimPrefix(strings.TrimSpace(s.next()), "*** Delete File: ")
 			doc.Hunks = append(doc.Hunks, DeleteFile{Path: path})
 		case strings.HasPrefix(line, "*** Update File: "):
-			path := strings.TrimPrefix(s.next(), "*** Update File: ")
+			path := strings.TrimPrefix(strings.TrimSpace(s.next()), "*** Update File: ")
 			up := UpdateFile{Path: path}
-			if !s.done() && strings.HasPrefix(s.peek(), "*** Move to: ") {
-				up.MoveTo = strings.TrimPrefix(s.next(), "*** Move to: ")
+			if !s.done() && strings.HasPrefix(strings.TrimSpace(s.peek()), "*** Move to: ") {
+				up.MoveTo = strings.TrimPrefix(strings.TrimSpace(s.next()), "*** Move to: ")
 			}
 			for !s.done() {
 				n := s.peek()
+				if strings.TrimSpace(n) == "*** End of File" {
+					up.Changes = append(up.Changes, ChangeLine{EndOfFile: true})
+					s.next()
+					continue
+				}
 				if strings.HasPrefix(n, "*** ") {
 					break
 				}
@@ -66,6 +78,9 @@ func Parse(src string) (Document, error) {
 				up.Changes = append(up.Changes, ChangeLine{Kind: rune(p), Content: n[1:]})
 				s.next()
 			}
+			if len(up.Changes) == 0 {
+				return Document{}, fmt.Errorf("update file hunk for path %q is empty", path)
+			}
 			doc.Hunks = append(doc.Hunks, up)
 		default:
 			return Document{}, fmt.Errorf("unknown patch block: %q", line)
@@ -73,6 +88,18 @@ func Parse(src string) (Document, error) {
 	}
 
 	return Document{}, errors.New("missing *** End Patch")
+}
+
+func patchBodyLines(src string) ([]string, error) {
+	lines := splitRawLines(strings.TrimSpace(src))
+	if len(lines) >= 4 {
+		first := lines[0]
+		last := lines[len(lines)-1]
+		if (first == "<<EOF" || first == "<<'EOF'" || first == "<<\"EOF\"") && strings.HasSuffix(last, "EOF") {
+			return lines[1 : len(lines)-1], nil
+		}
+	}
+	return lines, nil
 }
 
 type scanner struct {
@@ -99,6 +126,14 @@ func (s *scanner) next() string {
 
 func (s *scanner) consumeExact(v string) bool {
 	if s.peek() == v {
+		s.next()
+		return true
+	}
+	return false
+}
+
+func (s *scanner) consumeMarker(v string) bool {
+	if strings.TrimSpace(s.peek()) == v {
 		s.next()
 		return true
 	}

--- a/shared/transcript/patchformat/parse.go
+++ b/shared/transcript/patchformat/parse.go
@@ -92,10 +92,10 @@ func Parse(src string) (Document, error) {
 
 func patchBodyLines(src string) ([]string, error) {
 	lines := splitRawLines(strings.TrimSpace(src))
-	if len(lines) >= 4 {
+	if len(lines) >= 3 {
 		first := lines[0]
 		last := lines[len(lines)-1]
-		if (first == "<<EOF" || first == "<<'EOF'" || first == "<<\"EOF\"") && strings.HasSuffix(last, "EOF") {
+		if (first == "<<EOF" || first == "<<'EOF'" || first == "<<\"EOF\"") && last == "EOF" {
 			return lines[1 : len(lines)-1], nil
 		}
 	}

--- a/shared/transcript/patchformat/parse.go
+++ b/shared/transcript/patchformat/parse.go
@@ -78,7 +78,7 @@ func Parse(src string) (Document, error) {
 				up.Changes = append(up.Changes, ChangeLine{Kind: rune(p), Content: n[1:]})
 				s.next()
 			}
-			if len(up.Changes) == 0 {
+			if len(up.Changes) == 0 && strings.TrimSpace(up.MoveTo) == "" {
 				return Document{}, fmt.Errorf("update file hunk for path %q is empty", path)
 			}
 			doc.Hunks = append(doc.Hunks, up)

--- a/shared/transcript/patchformat/render.go
+++ b/shared/transcript/patchformat/render.go
@@ -143,6 +143,9 @@ func buildRenderedFiles(doc Document, cwd string) []RenderedFile {
 }
 
 func renderChangeLine(change ChangeLine) string {
+	if change.EndOfFile {
+		return "*** End of File"
+	}
 	if change.Kind == ' ' && change.Content == "" {
 		return ""
 	}

--- a/shared/transcript/patchformat/render_test.go
+++ b/shared/transcript/patchformat/render_test.go
@@ -23,6 +23,21 @@ func TestRenderFormatsSummaryAndDetailFromParsedPatch(t *testing.T) {
 	}
 }
 
+func TestParseHeredocRequiresExactEOFDelimiter(t *testing.T) {
+	patchText := "<<EOF\n*** Begin Patch\n*** Add File: eof.txt\n+MY_EOF\n*** End Patch\nEOF\n"
+	doc, err := Parse(patchText)
+	if err != nil {
+		t.Fatalf("parse patch: %v", err)
+	}
+	add, ok := doc.Hunks[0].(AddFile)
+	if !ok {
+		t.Fatalf("expected add file hunk, got %+v", doc.Hunks)
+	}
+	if len(add.Content) != 1 || add.Content[0] != "MY_EOF" {
+		t.Fatalf("expected body line ending in EOF preserved, got %+v", add.Content)
+	}
+}
+
 func TestRenderFallsBackToRawForUnparseablePatch(t *testing.T) {
 	rendered := Render("not a structured patch payload", "/workspace")
 

--- a/shared/transcript/patchformat/render_test.go
+++ b/shared/transcript/patchformat/render_test.go
@@ -73,6 +73,20 @@ func TestFormatUsesMoveTargetForRenderedPaths(t *testing.T) {
 	}
 }
 
+func TestParseAllowsMoveOnlyUpdateFile(t *testing.T) {
+	doc, err := Parse("*** Begin Patch\n*** Update File: src.txt\n*** Move to: dest.txt\n*** End Patch\n")
+	if err != nil {
+		t.Fatalf("parse patch: %v", err)
+	}
+	update, ok := doc.Hunks[0].(UpdateFile)
+	if !ok {
+		t.Fatalf("expected update hunk, got %+v", doc.Hunks)
+	}
+	if update.Path != "src.txt" || update.MoveTo != "dest.txt" || len(update.Changes) != 0 {
+		t.Fatalf("unexpected move-only update hunk: %+v", update)
+	}
+}
+
 func TestFormatPreservesRelativeOutsideWorkspacePath(t *testing.T) {
 	doc, err := Parse("*** Begin Patch\n*** Add File: ../outside.go\n+package outside\n*** End Patch\n")
 	if err != nil {

--- a/shared/transcript/patchformat/types.go
+++ b/shared/transcript/patchformat/types.go
@@ -22,8 +22,9 @@ type UpdateFile struct {
 }
 
 type ChangeLine struct {
-	Kind    rune
-	Content string
+	Kind      rune
+	Content   string
+	EndOfFile bool
 }
 
 type RenderedLineKind string

--- a/shared/transcript/types.go
+++ b/shared/transcript/types.go
@@ -30,6 +30,7 @@ const (
 	ToolRenderKindShell  ToolRenderKind = "shell"
 	ToolRenderKindDiff   ToolRenderKind = "diff"
 	ToolRenderKindSource ToolRenderKind = "source"
+	ToolRenderKindPlain  ToolRenderKind = "plain"
 
 	ToolShellDialectPosix          ToolShellDialect = "posix"
 	ToolShellDialectPowerShell     ToolShellDialect = "powershell"
@@ -90,6 +91,9 @@ func NormalizeToolCallMeta(in ToolCallMeta) ToolCallMeta {
 	}
 	if out.RenderBehavior == ToolCallRenderBehaviorShell {
 		out.IsShell = true
+	}
+	if out.RenderHint == nil && strings.TrimSpace(out.ToolName) == "write_stdin" && out.IsShell {
+		out.RenderHint = &ToolRenderHint{Kind: ToolRenderKindPlain}
 	}
 	if strings.TrimSpace(out.InlineMeta) == "" {
 		out.InlineMeta = strings.TrimSpace(out.TimeoutLabel)
@@ -170,6 +174,8 @@ func (h *ToolRenderHint) Valid() bool {
 		return true
 	case ToolRenderKindSource:
 		return strings.TrimSpace(h.Path) != ""
+	case ToolRenderKindPlain:
+		return true
 	default:
 		return false
 	}

--- a/shared/transcript/types_test.go
+++ b/shared/transcript/types_test.go
@@ -1,0 +1,26 @@
+package transcript
+
+import "testing"
+
+func TestNormalizeToolCallMetaMarksWriteStdinShellAsPlainRenderHint(t *testing.T) {
+	meta := NormalizeToolCallMeta(ToolCallMeta{
+		ToolName:       "write_stdin",
+		RenderBehavior: ToolCallRenderBehaviorShell,
+	})
+
+	if meta.RenderHint == nil || meta.RenderHint.Kind != ToolRenderKindPlain {
+		t.Fatalf("expected write_stdin shell metadata to use plain render hint, got %+v", meta.RenderHint)
+	}
+}
+
+func TestNormalizeToolCallMetaPreservesExplicitRenderHint(t *testing.T) {
+	meta := NormalizeToolCallMeta(ToolCallMeta{
+		ToolName:       "write_stdin",
+		RenderBehavior: ToolCallRenderBehaviorShell,
+		RenderHint:     &ToolRenderHint{Kind: ToolRenderKindShell, ShellDialect: ToolShellDialectPowerShell},
+	})
+
+	if meta.RenderHint == nil || meta.RenderHint.Kind != ToolRenderKindShell || meta.RenderHint.ShellDialect != ToolShellDialectPowerShell {
+		t.Fatalf("expected explicit render hint preserved, got %+v", meta.RenderHint)
+	}
+}


### PR DESCRIPTION
## Summary
- Include locally committed main fixes on the PR branch before they were pushed to main.
- Include existing 1.0-fixes-2 worktree deletion, runtime control recovery, and lease warning fixes.
- Preserve freeform patch tool behavior while rendering patch transcript paths from the active workdir.
- Keep structured `{patch: ...}` transcript rendering compatible too; this integration fix was required after combining the freeform patch commit from main with the active-workdir patch rendering fix from 1.0-fixes-2.
- Resolve config per selected session workspace and keep builder serve workspace-agnostic at startup.

## Verification
- ./scripts/test.sh ./...
- ./scripts/build.sh --output ./bin/builder
- pre-push hook: formatting, go vet, go build, go test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-workspace configuration layer for workspace-specific settings
  * Authentication status view showing account/subscription details and warnings
  * Custom patch tool support with improved patch handling and previews
  * Worktree deletion confirmation UI showing exact actions and dirty-file count

* **Improvements**
  * Default model updated to gpt-5.5
  * More informative status overlay and runtime lease-recovery warnings
  * Session resolution now prefers workspace-local settings

* **Bug Fixes**
  * Improved dirty-file detection and safer worktree deletion behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->