### PR TITLE
feat: support SYSTEM.md prompt snapshots

### DIFF
--- a/cli/app/ui_runtime_adapter_test.go
+++ b/cli/app/ui_runtime_adapter_test.go
@@ -211,6 +211,90 @@ func TestProjectRuntimeEventIncludesBackgroundSystemTranscriptEntry(t *testing.T
 	}
 }
 
+func TestOngoingReviewerEntriesAfterCommittedFinalKeepFinalVisibleWithoutHydration(t *testing.T) {
+	client := &runtimeControlFakeClient{transcript: clientui.TranscriptPage{SessionID: "session-1"}}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.forwardToView(tui.SetViewportSizeMsg{Lines: 20, Width: 100})
+
+	finalText := "final answer"
+	_ = m.runtimeAdapter().handleProjectedRuntimeEvent(clientui.Event{
+		Kind:           clientui.EventAssistantDelta,
+		StepID:         "step-1",
+		AssistantDelta: finalText,
+	})
+	if got := stripANSIPreserve(m.view.OngoingSnapshot()); !strings.Contains(got, finalText) {
+		t.Fatalf("expected streaming final answer visible before commit, got %q", got)
+	}
+
+	events := []clientui.Event{
+		{
+			Kind:                       clientui.EventAssistantMessage,
+			StepID:                     "step-1",
+			CommittedTranscriptChanged: true,
+			TranscriptRevision:         1,
+			CommittedEntryCount:        1,
+			CommittedEntryStart:        0,
+			CommittedEntryStartSet:     true,
+			TranscriptEntries: []clientui.ChatEntry{{
+				Role:  "assistant",
+				Text:  finalText,
+				Phase: string(llm.MessagePhaseFinal),
+			}},
+		},
+		{
+			Kind:                       clientui.EventLocalEntryAdded,
+			StepID:                     "step-1",
+			CommittedTranscriptChanged: true,
+			TranscriptRevision:         2,
+			CommittedEntryCount:        2,
+			CommittedEntryStart:        1,
+			CommittedEntryStartSet:     true,
+			TranscriptEntries: []clientui.ChatEntry{{
+				Role:        "reviewer_suggestions",
+				Text:        "Supervisor suggested:\n1. Check final answer.",
+				OngoingText: "Supervisor suggested:\n1. Check final answer.",
+			}},
+		},
+		{
+			Kind:                       clientui.EventLocalEntryAdded,
+			StepID:                     "step-1",
+			CommittedTranscriptChanged: true,
+			TranscriptRevision:         3,
+			CommittedEntryCount:        3,
+			CommittedEntryStart:        2,
+			CommittedEntryStartSet:     true,
+			TranscriptEntries: []clientui.ChatEntry{{
+				Role: "reviewer_status",
+				Text: "Supervisor ran: 1 suggestion, no changes applied.",
+			}},
+		},
+		{
+			Kind:   clientui.EventReviewerCompleted,
+			StepID: "step-1",
+		},
+	}
+
+	for _, evt := range events {
+		msgs := collectCmdMessages(t, m.runtimeAdapter().handleProjectedRuntimeEvent(evt))
+		for _, msg := range msgs {
+			if _, ok := msg.(runtimeTranscriptRefreshedMsg); ok {
+				t.Fatalf("did not expect reviewer sequence to trigger transcript hydration, event=%s msg=%+v", evt.Kind, msg)
+			}
+		}
+		if m.runtimeTranscriptBusy {
+			t.Fatalf("did not expect reviewer sequence to start transcript sync after event=%s", evt.Kind)
+		}
+	}
+
+	view := stripANSIPreserve(m.view.OngoingSnapshot())
+	if !containsInOrder(view, finalText, "Supervisor suggested:", "Supervisor ran: 1 suggestion") {
+		t.Fatalf("expected final answer and reviewer entries visible immediately in ongoing mode, got %q", view)
+	}
+	if got := m.view.OngoingStreamingText(); got != "" {
+		t.Fatalf("expected committed final to clear streaming text, got %q", got)
+	}
+}
+
 func TestHandleProjectedRuntimeEventAppendsTranscriptEntriesImmediately(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.forwardToView(tui.SetViewportSizeMsg{Lines: 20, Width: 80})

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -45,6 +45,10 @@ export default defineConfig({
           link: '/worktrees/',
         },
         {
+          label: 'Prompts',
+          link: '/prompts/',
+        },
+        {
           label: 'Subagents / Headless',
           link: '/headless/',
         },

--- a/docs/src/content/docs/prompts.md
+++ b/docs/src/content/docs/prompts.md
@@ -23,7 +23,7 @@ Workspace instructions are included after global instructions. Builder injects t
 
 The workspace file takes priority. If neither file exists, Builder uses the built-in system prompt.
 
-Builder reads and renders `SYSTEM.md` once when the session sends its first model request, stores the fully rendered result in the session metadata, and reuses that snapshot for later requests. Editing `SYSTEM.md` during a session affects new sessions only.
+Builder reads and renders `SYSTEM.md` once when the session sends its first model request, stores the fully rendered result in the `system_prompt` session metadata, and reuses that snapshot for later requests. After a session has stored that snapshot, editing `SYSTEM.md` affects new sessions only. Sessions without `system_prompt` capture the current `SYSTEM.md` on their next model request.
 
 ## Placeholders
 

--- a/docs/src/content/docs/prompts.md
+++ b/docs/src/content/docs/prompts.md
@@ -1,0 +1,48 @@
+---
+title: Prompts
+description: Prompt customization files, precedence, placeholders, and session snapshot behavior.
+---
+
+Builder reads prompt context from global and workspace files.
+
+## Instruction Files
+
+`AGENTS.md` files add developer-context instructions to each session:
+
+- `~/.builder/AGENTS.md`
+- `<workspace-root>/AGENTS.md`
+
+Workspace instructions are included after global instructions. Builder injects these files into the conversation as developer context, not as the main system prompt.
+
+## System Prompt
+
+`SYSTEM.md` replaces Builder's built-in main system prompt for new sessions:
+
+- `~/.builder/SYSTEM.md`
+- `<workspace-root>/.builder/SYSTEM.md`
+
+The workspace file takes priority. If neither file exists, Builder uses the built-in system prompt.
+
+Builder reads and renders `SYSTEM.md` once when the session sends its first model request, stores the fully rendered result in the session metadata, and reuses that snapshot for later requests. Editing `SYSTEM.md` during a session affects new sessions only.
+
+## Placeholders
+
+`SYSTEM.md` uses Go template syntax with these fields:
+
+| Placeholder | Value |
+| --- | --- |
+| `{{.BuilderRunCommand}}` | The command prefix for launching a Builder subagent from shell. |
+| `{{.EstimatedToolCallsForContext}}` | Approximate tool-call count that fits in the locked context budget. |
+| `{{.DefaultSystemPrompt}}` | Builder's rendered built-in system prompt, without tool preambles. |
+
+Example:
+
+```md
+{{.DefaultSystemPrompt}}
+
+# Team Rules
+
+Prefer small, reviewable commits.
+```
+
+Tool preambles are appended after the rendered `SYSTEM.md` when `tool_preambles = true` for the locked session.

--- a/prompts/embed.go
+++ b/prompts/embed.go
@@ -17,6 +17,7 @@ type SystemPromptTemplateArgs struct {
 type systemPromptTemplateData struct {
 	BuilderRunCommand            string
 	EstimatedToolCallsForContext int
+	DefaultSystemPrompt          string
 }
 
 //go:embed system_prompt.md
@@ -62,7 +63,27 @@ var WorktreeModePrompt string
 var WorktreeModeExitPrompt string
 
 func MainSystemPrompt(includeToolPreambles bool, args SystemPromptTemplateArgs) string {
-	base := renderSystemPromptTemplate(strings.TrimSpace(SystemPrompt), args)
+	return WithToolPreambles(BaseSystemPrompt(args), includeToolPreambles)
+}
+
+func CustomSystemPrompt(text string, includeToolPreambles bool, args SystemPromptTemplateArgs) string {
+	rendered, err := RenderCustomSystemPrompt(text, includeToolPreambles, args)
+	if err != nil {
+		panic(err)
+	}
+	return rendered
+}
+
+func RenderCustomSystemPrompt(text string, includeToolPreambles bool, args SystemPromptTemplateArgs) (string, error) {
+	rendered, err := renderSystemPromptTemplateErr(strings.TrimSpace(text), args, BaseSystemPrompt(args))
+	if err != nil {
+		return "", err
+	}
+	return WithToolPreambles(rendered, includeToolPreambles), nil
+}
+
+func WithToolPreambles(base string, includeToolPreambles bool) string {
+	base = strings.TrimSpace(base)
 	if !includeToolPreambles {
 		return base
 	}
@@ -77,7 +98,7 @@ func MainSystemPrompt(includeToolPreambles bool, args SystemPromptTemplateArgs) 
 }
 
 func BaseSystemPrompt(args SystemPromptTemplateArgs) string {
-	return renderSystemPromptTemplate(strings.TrimSpace(SystemPrompt), args)
+	return renderSystemPromptTemplate(strings.TrimSpace(SystemPrompt), args, "")
 }
 
 func RenderCompactionSoonReminderPrompt(triggerHandoffEnabled bool) string {
@@ -105,23 +126,32 @@ func RenderWorktreeModeExitPrompt(branch, cwd, worktreePath, workspaceRoot strin
 	})
 }
 
-func renderSystemPromptTemplate(text string, args SystemPromptTemplateArgs) string {
+func renderSystemPromptTemplate(text string, args SystemPromptTemplateArgs, defaultSystemPrompt string) string {
+	rendered, err := renderSystemPromptTemplateErr(text, args, defaultSystemPrompt)
+	if err != nil {
+		panic(err)
+	}
+	return rendered
+}
+
+func renderSystemPromptTemplateErr(text string, args SystemPromptTemplateArgs, defaultSystemPrompt string) (string, error) {
 	trimmed := strings.TrimSpace(text)
 	if trimmed == "" {
-		return ""
+		return "", nil
 	}
 	tmpl, err := template.New("system_prompt").Option("missingkey=error").Parse(trimmed)
 	if err != nil {
-		panic(fmt.Errorf("parse system prompt template: %w", err))
+		return "", fmt.Errorf("parse system prompt template: %w", err)
 	}
 	var out bytes.Buffer
 	if err := tmpl.Execute(&out, systemPromptTemplateData{
 		BuilderRunCommand:            selfcmd.RunCommandPrefix(),
 		EstimatedToolCallsForContext: args.EstimatedToolCallsForContext,
+		DefaultSystemPrompt:          strings.TrimSpace(defaultSystemPrompt),
 	}); err != nil {
-		panic(fmt.Errorf("render system prompt template: %w", err))
+		return "", fmt.Errorf("render system prompt template: %w", err)
 	}
-	return out.String()
+	return out.String(), nil
 }
 
 func renderWorktreePrompt(template string, replacements map[string]string) string {

--- a/prompts/embed.go
+++ b/prompts/embed.go
@@ -66,14 +66,6 @@ func MainSystemPrompt(includeToolPreambles bool, args SystemPromptTemplateArgs) 
 	return WithToolPreambles(BaseSystemPrompt(args), includeToolPreambles)
 }
 
-func CustomSystemPrompt(text string, includeToolPreambles bool, args SystemPromptTemplateArgs) string {
-	rendered, err := RenderCustomSystemPrompt(text, includeToolPreambles, args)
-	if err != nil {
-		panic(err)
-	}
-	return rendered
-}
-
 func RenderCustomSystemPrompt(text string, includeToolPreambles bool, args SystemPromptTemplateArgs) (string, error) {
 	rendered, err := renderSystemPromptTemplateErr(strings.TrimSpace(text), args, BaseSystemPrompt(args))
 	if err != nil {

--- a/prompts/embed_test.go
+++ b/prompts/embed_test.go
@@ -24,9 +24,12 @@ func TestCustomSystemPromptResolvesDefaultSystemPromptPlaceholder(t *testing.T) 
 	defaultPrompt := BaseSystemPrompt(SystemPromptTemplateArgs{
 		EstimatedToolCallsForContext: 123,
 	})
-	rendered := CustomSystemPrompt("custom\n{{.DefaultSystemPrompt}}", false, SystemPromptTemplateArgs{
+	rendered, err := RenderCustomSystemPrompt("custom\n{{.DefaultSystemPrompt}}", false, SystemPromptTemplateArgs{
 		EstimatedToolCallsForContext: 123,
 	})
+	if err != nil {
+		t.Fatalf("RenderCustomSystemPrompt: %v", err)
+	}
 	if !strings.Contains(rendered, "custom\n") {
 		t.Fatalf("expected custom prefix, got %q", rendered)
 	}

--- a/prompts/embed_test.go
+++ b/prompts/embed_test.go
@@ -10,12 +10,27 @@ import (
 func TestRenderSystemPromptTemplateUsesTypedFields(t *testing.T) {
 	rendered := renderSystemPromptTemplate("calls={{.EstimatedToolCallsForContext}} cmd={{.BuilderRunCommand}}", SystemPromptTemplateArgs{
 		EstimatedToolCallsForContext: 123,
-	})
+	}, "")
 	if !strings.Contains(rendered, "calls=123") {
 		t.Fatalf("expected estimated tool calls rendered, got %q", rendered)
 	}
 	expectedCmd := "cmd=" + selfcmd.RunCommandPrefix()
 	if !strings.Contains(rendered, expectedCmd) || strings.Contains(rendered, "{{") {
 		t.Fatalf("expected %q in rendered output, got %q", expectedCmd, rendered)
+	}
+}
+
+func TestCustomSystemPromptResolvesDefaultSystemPromptPlaceholder(t *testing.T) {
+	defaultPrompt := BaseSystemPrompt(SystemPromptTemplateArgs{
+		EstimatedToolCallsForContext: 123,
+	})
+	rendered := CustomSystemPrompt("custom\n{{.DefaultSystemPrompt}}", false, SystemPromptTemplateArgs{
+		EstimatedToolCallsForContext: 123,
+	})
+	if !strings.Contains(rendered, "custom\n") {
+		t.Fatalf("expected custom prefix, got %q", rendered)
+	}
+	if !strings.Contains(rendered, defaultPrompt) || strings.Contains(rendered, "{{") {
+		t.Fatalf("expected default prompt placeholder rendered, got %q", rendered)
 	}
 }

--- a/server/runtime/compaction.go
+++ b/server/runtime/compaction.go
@@ -837,7 +837,11 @@ func (e *Engine) compactionCacheObservationRequest(ctx context.Context, request 
 		return llm.Request{}, false, err
 	}
 	items := compactionConversationWithPromptItems(request.InputItems, request.Instructions)
-	req, err := llm.RequestFromLockedContract(locked, e.systemPrompt(locked), sanitizeItemsForLLM(items), e.requestTools(ctx))
+	systemPrompt, err := e.systemPrompt(locked)
+	if err != nil {
+		return llm.Request{}, false, err
+	}
+	req, err := llm.RequestFromLockedContract(locked, systemPrompt, sanitizeItemsForLLM(items), e.requestTools(ctx))
 	if err != nil {
 		return llm.Request{}, false, err
 	}
@@ -894,7 +898,11 @@ func (e *Engine) localCompactionSummary(ctx context.Context, input []llm.Respons
 	})
 	items = sanitizeItemsForLLM(items)
 
-	req, err := llm.RequestFromLockedContract(locked, e.systemPrompt(locked), items, e.requestTools(ctx))
+	systemPrompt, err := e.systemPrompt(locked)
+	if err != nil {
+		return "", err
+	}
+	req, err := llm.RequestFromLockedContract(locked, systemPrompt, items, e.requestTools(ctx))
 	if err != nil {
 		return "", err
 	}

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -565,6 +565,7 @@ func (e *Engine) ensureLocked() (session.LockedContract, error) {
 		return session.LockedContract{}, err
 	}
 	lock.SystemPrompt = systemPrompt
+	lock.HasSystemPrompt = true
 	if err := e.store.MarkModelDispatchLocked(lock); err != nil {
 		return session.LockedContract{}, err
 	}

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -22,6 +22,7 @@ const (
 	interruptMessage                  = "User interrupted you"
 	agentsFileName                    = "AGENTS.md"
 	agentsGlobalDirName               = ".builder"
+	systemPromptFileName              = "SYSTEM.md"
 	agentsInjectedHeader              = "# Project context and authoritative instructions from the ./AGENTS.md file:"
 	agentsInjectedFenceLabel          = "md"
 	environmentInjectedHeader         = "# Info about environment:"
@@ -559,6 +560,11 @@ func (e *Engine) ensureLocked() (session.LockedContract, error) {
 	if hasProviderContract {
 		lock.ProviderContract = llm.LockedProviderCapabilitiesFromContract(providerContract)
 	}
+	systemPrompt, err := e.buildSystemPromptSnapshotForRoot(lock, e.systemPromptWorkspaceRootLocked())
+	if err != nil {
+		return session.LockedContract{}, err
+	}
+	lock.SystemPrompt = systemPrompt
 	if err := e.store.MarkModelDispatchLocked(lock); err != nil {
 		return session.LockedContract{}, err
 	}

--- a/server/runtime/engine_request.go
+++ b/server/runtime/engine_request.go
@@ -129,6 +129,9 @@ func (e *Engine) enableNativeWebSearch(ctx context.Context) (bool, error) {
 }
 
 func (e *Engine) systemPrompt(locked session.LockedContract) (string, error) {
+	if locked.HasSystemPrompt {
+		return strings.TrimSpace(locked.SystemPrompt), nil
+	}
 	if prompt := strings.TrimSpace(locked.SystemPrompt); prompt != "" {
 		return prompt, nil
 	}
@@ -139,13 +142,14 @@ func (e *Engine) systemPrompt(locked session.LockedContract) (string, error) {
 	if err := e.store.BackfillLockedSystemPrompt(prompt); err != nil {
 		return "", err
 	}
-	if meta := e.store.Meta(); meta.Locked != nil && strings.TrimSpace(meta.Locked.SystemPrompt) != "" {
+	if meta := e.store.Meta(); meta.Locked != nil && meta.Locked.HasSystemPrompt {
 		persisted := strings.TrimSpace(meta.Locked.SystemPrompt)
 		prompt = persisted
 	}
 	e.mu.Lock()
-	if e.locked != nil && strings.TrimSpace(e.locked.SystemPrompt) == "" {
+	if e.locked != nil && !e.locked.HasSystemPrompt {
 		e.locked.SystemPrompt = prompt
+		e.locked.HasSystemPrompt = true
 	}
 	e.mu.Unlock()
 	return prompt, nil

--- a/server/runtime/engine_request.go
+++ b/server/runtime/engine_request.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"builder/prompts"
 	"builder/server/llm"
 	"builder/server/session"
 	"builder/server/tools"
@@ -68,7 +67,11 @@ func (e *Engine) buildRequestPlanWithExtraItems(ctx context.Context, stepID stri
 	}
 	items = sanitizeItemsForLLM(items)
 
-	req, err := llm.RequestFromLockedContract(locked, e.systemPrompt(locked), items, requestTools)
+	systemPrompt, err := e.systemPrompt(locked)
+	if err != nil {
+		return requestBuildPlan{}, err
+	}
+	req, err := llm.RequestFromLockedContract(locked, systemPrompt, items, requestTools)
 	if err != nil {
 		return requestBuildPlan{}, err
 	}
@@ -125,14 +128,27 @@ func (e *Engine) enableNativeWebSearch(ctx context.Context) (bool, error) {
 	return caps.SupportsNativeWebSearch, nil
 }
 
-func (e *Engine) systemPrompt(locked session.LockedContract) string {
-	includeToolPreambles := true
-	if locked.ToolPreambles != nil {
-		includeToolPreambles = *locked.ToolPreambles
+func (e *Engine) systemPrompt(locked session.LockedContract) (string, error) {
+	if prompt := strings.TrimSpace(locked.SystemPrompt); prompt != "" {
+		return prompt, nil
 	}
-	return prompts.MainSystemPrompt(includeToolPreambles, prompts.SystemPromptTemplateArgs{
-		EstimatedToolCallsForContext: e.estimatedToolCallsForLockedContext(locked),
-	})
+	prompt, err := e.buildSystemPromptSnapshot(locked)
+	if err != nil {
+		return "", err
+	}
+	if err := e.store.BackfillLockedSystemPrompt(prompt); err != nil {
+		return "", err
+	}
+	if meta := e.store.Meta(); meta.Locked != nil && strings.TrimSpace(meta.Locked.SystemPrompt) != "" {
+		persisted := strings.TrimSpace(meta.Locked.SystemPrompt)
+		prompt = persisted
+	}
+	e.mu.Lock()
+	if e.locked != nil && strings.TrimSpace(e.locked.SystemPrompt) == "" {
+		e.locked.SystemPrompt = prompt
+	}
+	e.mu.Unlock()
+	return prompt, nil
 }
 
 func (e *Engine) estimatedToolCallsForLockedContext(locked session.LockedContract) int {

--- a/server/runtime/engine_test.go
+++ b/server/runtime/engine_test.go
@@ -3284,8 +3284,17 @@ func TestReviewerSuggestionsTriggerFollowUpAndNoopKeepsOriginalAnswer(t *testing
 		Usage:     llm.Usage{WindowTokens: 200000},
 	}}}
 
+	var (
+		eventsMu sync.Mutex
+		events   []Event
+	)
 	eng, err := New(store, mainClient, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
 		Model: "gpt-5",
+		OnEvent: func(evt Event) {
+			eventsMu.Lock()
+			defer eventsMu.Unlock()
+			events = append(events, evt)
+		},
 		Reviewer: ReviewerConfig{
 			Frequency:     "all",
 			Model:         "gpt-5",
@@ -3428,6 +3437,36 @@ func TestReviewerSuggestionsTriggerFollowUpAndNoopKeepsOriginalAnswer(t *testing
 	}
 	if !foundReviewerStatus {
 		t.Fatalf("expected reviewer status entry in snapshot, got %+v", snapshot.Entries)
+	}
+
+	eventsMu.Lock()
+	recordedEvents := append([]Event(nil), events...)
+	eventsMu.Unlock()
+	originalFinalEventIdx := -1
+	reviewerSuggestionsEventIdx := -1
+	reviewerStatusEventIdx := -1
+	for idx, evt := range recordedEvents {
+		if evt.Kind == EventAssistantMessage && evt.Message.Content == "original final" {
+			originalFinalEventIdx = idx
+		}
+		if evt.Kind == EventLocalEntryAdded && evt.LocalEntry != nil && evt.LocalEntry.Role == "reviewer_suggestions" {
+			reviewerSuggestionsEventIdx = idx
+		}
+		if evt.Kind == EventLocalEntryAdded && evt.LocalEntry != nil && evt.LocalEntry.Role == "reviewer_status" {
+			reviewerStatusEventIdx = idx
+		}
+	}
+	if originalFinalEventIdx < 0 {
+		t.Fatalf("expected original final assistant event before reviewer events, got %+v", recordedEvents)
+	}
+	if reviewerSuggestionsEventIdx < 0 {
+		t.Fatalf("expected reviewer suggestions local entry event, got %+v", recordedEvents)
+	}
+	if reviewerStatusEventIdx < 0 {
+		t.Fatalf("expected reviewer status local entry event, got %+v", recordedEvents)
+	}
+	if originalFinalEventIdx > reviewerSuggestionsEventIdx || reviewerSuggestionsEventIdx > reviewerStatusEventIdx {
+		t.Fatalf("expected original final -> reviewer suggestions -> reviewer status event order, got %+v", recordedEvents)
 	}
 }
 
@@ -3708,10 +3747,18 @@ func TestReviewerAppliedFollowUpRemainsVisibleInTranscript(t *testing.T) {
 	eventsMu.Lock()
 	deferredEvents := append([]Event(nil), events...)
 	eventsMu.Unlock()
+	originalFinalEventIdx := -1
+	reviewerSuggestionsEventIdx := -1
 	assistantEventIdx := -1
 	reviewerStatusIdx := -1
 	reviewerEventIdx := -1
 	for idx, evt := range deferredEvents {
+		if evt.Kind == EventAssistantMessage && evt.Message.Content == "original final" {
+			originalFinalEventIdx = idx
+		}
+		if evt.Kind == EventLocalEntryAdded && evt.LocalEntry != nil && evt.LocalEntry.Role == "reviewer_suggestions" {
+			reviewerSuggestionsEventIdx = idx
+		}
 		if evt.Kind == EventAssistantMessage && evt.Message.Content == "updated final after review" {
 			assistantEventIdx = idx
 		}
@@ -3728,14 +3775,20 @@ func TestReviewerAppliedFollowUpRemainsVisibleInTranscript(t *testing.T) {
 	if assistantEventIdx < 0 {
 		t.Fatalf("expected follow-up assistant event, got %+v", deferredEvents)
 	}
+	if originalFinalEventIdx < 0 {
+		t.Fatalf("expected original final assistant event before reviewer follow-up, got %+v", deferredEvents)
+	}
+	if reviewerSuggestionsEventIdx < 0 {
+		t.Fatalf("expected reviewer suggestions local entry event before reviewer follow-up, got %+v", deferredEvents)
+	}
 	if reviewerStatusIdx < 0 {
 		t.Fatalf("expected reviewer status local entry event, got %+v", deferredEvents)
 	}
 	if reviewerEventIdx < 0 {
 		t.Fatalf("expected reviewer completed event, got %+v", deferredEvents)
 	}
-	if assistantEventIdx > reviewerStatusIdx || reviewerStatusIdx > reviewerEventIdx {
-		t.Fatalf("expected assistant -> reviewer_status -> reviewer_completed event order, got %+v", deferredEvents)
+	if originalFinalEventIdx > reviewerSuggestionsEventIdx || reviewerSuggestionsEventIdx > assistantEventIdx || assistantEventIdx > reviewerStatusIdx || reviewerStatusIdx > reviewerEventIdx {
+		t.Fatalf("expected original final -> reviewer suggestions -> updated final -> reviewer_status -> reviewer_completed event order, got %+v", deferredEvents)
 	}
 
 	restored, err := New(store, &fakeClient{}, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{Model: "gpt-5"})

--- a/server/runtime/engine_test.go
+++ b/server/runtime/engine_test.go
@@ -787,9 +787,312 @@ func TestLockedContextWindowKeepsSystemPromptToolCallEstimateStableAcrossResume(
 	if got := resumedEngine.estimatedToolCallsForLockedContext(alteredLocked); got != 271 {
 		t.Fatalf("altered estimated tool calls = %d, want 271", got)
 	}
-	alteredPrompt := resumedEngine.systemPrompt(alteredLocked)
-	if alteredPrompt == firstPrompt {
-		t.Fatal("expected system prompt estimate to change when locked context budget changes")
+	alteredPrompt, err := resumedEngine.systemPrompt(alteredLocked)
+	if err != nil {
+		t.Fatalf("altered system prompt: %v", err)
+	}
+	if alteredPrompt != firstPrompt {
+		t.Fatal("expected locked system prompt snapshot to stay stable when locked context budget changes")
+	}
+}
+
+func TestSystemPromptSnapshotUsesLocalFileAndSurvivesMidSessionFileChanges(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	for _, dir := range []string{filepath.Join(home, agentsGlobalDirName), filepath.Join(workspace, agentsGlobalDirName)} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	writeTestFile(t, filepath.Join(home, agentsGlobalDirName, systemPromptFileName), "global system")
+	localPath := filepath.Join(workspace, agentsGlobalDirName, systemPromptFileName)
+	writeTestFile(t, localPath, "local {{.EstimatedToolCallsForContext}} {{.BuilderRunCommand}}")
+
+	store, err := session.Create(t.TempDir(), "ws", workspace)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	client := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "first"},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	eng, err := New(store, client, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:                "gpt-5",
+		EnabledTools:         []toolspec.ID{toolspec.ToolExecCommand},
+		ContextWindowTokens:  272_000,
+		TranscriptWorkingDir: workspace,
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	if _, err := eng.SubmitUserMessage(context.Background(), "first"); err != nil {
+		t.Fatalf("submit first: %v", err)
+	}
+	firstPrompt := client.calls[0].SystemPrompt
+	if !strings.Contains(firstPrompt, "local 185 ") || strings.Contains(firstPrompt, "global system") || strings.Contains(firstPrompt, "{{") {
+		t.Fatalf("unexpected first system prompt: %q", firstPrompt)
+	}
+	firstCacheKey := client.calls[0].PromptCacheKey
+	if firstCacheKey == "" {
+		t.Fatal("expected prompt cache key")
+	}
+	writeTestFile(t, localPath, "changed local system")
+	if err := eng.Close(); err != nil {
+		t.Fatalf("close first engine: %v", err)
+	}
+
+	reopened, err := session.Open(store.Dir())
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	reopenedClient := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "second"},
+		Usage:     llm.Usage{WindowTokens: 400000},
+	}}}
+	reopenedEngine, err := New(reopened, reopenedClient, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:                "gpt-5",
+		EnabledTools:         []toolspec.ID{toolspec.ToolExecCommand},
+		ContextWindowTokens:  400_000,
+		TranscriptWorkingDir: workspace,
+	})
+	if err != nil {
+		t.Fatalf("new reopened engine: %v", err)
+	}
+	if _, err := reopenedEngine.SubmitUserMessage(context.Background(), "second"); err != nil {
+		t.Fatalf("submit second: %v", err)
+	}
+	if got := reopenedClient.calls[0].SystemPrompt; got != firstPrompt {
+		t.Fatalf("system prompt changed after SYSTEM.md edit\ngot: %q\nwant: %q", got, firstPrompt)
+	}
+	if got := reopenedClient.calls[0].PromptCacheKey; got != firstCacheKey {
+		t.Fatalf("prompt cache key changed after SYSTEM.md edit: got %q want %q", got, firstCacheKey)
+	}
+	if got := reopened.Meta().Locked.SystemPrompt; got != firstPrompt {
+		t.Fatalf("locked system prompt mismatch\ngot: %q\nwant: %q", got, firstPrompt)
+	}
+}
+
+func TestReadSystemPromptTemplateUsesGlobalFileWhenLocalMissing(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	globalDir := filepath.Join(home, agentsGlobalDirName)
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatalf("mkdir global dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(globalDir, systemPromptFileName), "global system")
+
+	template, sourcePath, ok, err := readSystemPromptTemplate(systemPromptSnapshotOptions{WorkspaceRoot: workspace})
+	if err != nil {
+		t.Fatalf("read system prompt template: %v", err)
+	}
+	if !ok || template != "global system" {
+		t.Fatalf("template = %q ok=%t, want global system true", template, ok)
+	}
+	if want := filepath.Join(globalDir, systemPromptFileName); sourcePath != want {
+		t.Fatalf("source path = %q, want %q", sourcePath, want)
+	}
+}
+
+func TestEnsureLockedWithSystemPromptAndTranscriptWorkingDirDoesNotDeadlock(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	systemDir := filepath.Join(workspace, agentsGlobalDirName)
+	if err := os.MkdirAll(systemDir, 0o755); err != nil {
+		t.Fatalf("mkdir system dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(systemDir, systemPromptFileName), "deadlock guard")
+
+	store, err := session.Create(t.TempDir(), "ws", workspace)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	eng, err := New(store, &fakeClient{}, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:                "gpt-5",
+		EnabledTools:         []toolspec.ID{toolspec.ToolExecCommand},
+		TranscriptWorkingDir: workspace,
+		ToolPreambles:        false,
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	done := make(chan struct {
+		locked session.LockedContract
+		err    error
+	}, 1)
+	go func() {
+		locked, err := eng.ensureLocked()
+		done <- struct {
+			locked session.LockedContract
+			err    error
+		}{locked: locked, err: err}
+	}()
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("ensureLocked: %v", got.err)
+		}
+		if got.locked.SystemPrompt != "deadlock guard" {
+			t.Fatalf("system prompt = %q, want deadlock guard", got.locked.SystemPrompt)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ensureLocked deadlocked while resolving SYSTEM.md from TranscriptWorkingDir")
+	}
+}
+
+func TestBuildSystemPromptSnapshotForRootDoesNotUseMutexTakingWorkspaceAccessor(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	systemDir := filepath.Join(workspace, agentsGlobalDirName)
+	if err := os.MkdirAll(systemDir, 0o755); err != nil {
+		t.Fatalf("mkdir system dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(systemDir, systemPromptFileName), "locked helper guard")
+
+	store, err := session.Create(t.TempDir(), "ws", t.TempDir())
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	eng, err := New(store, &fakeClient{}, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:         "gpt-5",
+		EnabledTools:  []toolspec.ID{toolspec.ToolExecCommand},
+		ToolPreambles: false,
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	done := make(chan struct {
+		prompt string
+		err    error
+	}, 1)
+	eng.mu.Lock()
+	go func() {
+		prompt, err := eng.buildSystemPromptSnapshotForRoot(session.LockedContract{
+			Model:          "gpt-5",
+			Temperature:    1,
+			ContextWindow:  272_000,
+			ContextPercent: 95,
+			ToolPreambles: func() *bool {
+				enabled := false
+				return &enabled
+			}(),
+		}, workspace)
+		done <- struct {
+			prompt string
+			err    error
+		}{prompt: prompt, err: err}
+	}()
+	select {
+	case got := <-done:
+		eng.mu.Unlock()
+		if got.err != nil {
+			t.Fatalf("buildSystemPromptSnapshotForRoot: %v", got.err)
+		}
+		if got.prompt != "locked helper guard" {
+			t.Fatalf("prompt = %q, want locked helper guard", got.prompt)
+		}
+	case <-time.After(2 * time.Second):
+		eng.mu.Unlock()
+		t.Fatal("buildSystemPromptSnapshotForRoot called a mutex-taking workspace accessor")
+	}
+}
+
+func TestSystemPromptSnapshotUsesTranscriptWorkingDirForRetargetedSession(t *testing.T) {
+	home := t.TempDir()
+	canonical := t.TempDir()
+	worktree := t.TempDir()
+	t.Setenv("HOME", home)
+	for _, dir := range []string{filepath.Join(canonical, agentsGlobalDirName), filepath.Join(worktree, agentsGlobalDirName)} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	writeTestFile(t, filepath.Join(canonical, agentsGlobalDirName, systemPromptFileName), "canonical system")
+	writeTestFile(t, filepath.Join(worktree, agentsGlobalDirName, systemPromptFileName), "worktree system")
+
+	store, err := session.Create(t.TempDir(), "ws", canonical)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	client := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "ok"},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	eng, err := New(store, client, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:                "gpt-5",
+		EnabledTools:         []toolspec.ID{toolspec.ToolExecCommand},
+		TranscriptWorkingDir: canonical,
+		ToolPreambles:        false,
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	eng.SetTranscriptWorkingDir(worktree)
+	if _, err := eng.SubmitUserMessage(context.Background(), "hello"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if got := client.calls[0].SystemPrompt; got != "worktree system" {
+		t.Fatalf("system prompt = %q, want worktree system", got)
+	}
+}
+
+func TestLegacyLockedSessionBackfillsSystemPromptSnapshotOnce(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	systemDir := filepath.Join(workspace, agentsGlobalDirName)
+	if err := os.MkdirAll(systemDir, 0o755); err != nil {
+		t.Fatalf("mkdir system dir: %v", err)
+	}
+	systemPath := filepath.Join(systemDir, systemPromptFileName)
+	writeTestFile(t, systemPath, "stale legacy {{.EstimatedToolCallsForContext}}")
+
+	store, err := session.Create(t.TempDir(), "ws", workspace)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	if err := store.MarkModelDispatchLocked(session.LockedContract{
+		Model:          "gpt-5",
+		Temperature:    1,
+		MaxOutputToken: 0,
+		ContextWindow:  272_000,
+		ContextPercent: 95,
+		ToolPreambles: func() *bool {
+			enabled := false
+			return &enabled
+		}(),
+	}); err != nil {
+		t.Fatalf("mark locked: %v", err)
+	}
+	client := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "ok"},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	eng, err := New(store, client, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:                "gpt-5",
+		EnabledTools:         []toolspec.ID{toolspec.ToolExecCommand},
+		TranscriptWorkingDir: workspace,
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	if snapshot := store.Meta().Locked.SystemPrompt; snapshot != "" {
+		t.Fatalf("system prompt snapshot before first dispatch = %q, want empty", snapshot)
+	}
+	writeTestFile(t, systemPath, "legacy {{.EstimatedToolCallsForContext}}")
+	if _, err := eng.SubmitUserMessage(context.Background(), "hello"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	snapshot := store.Meta().Locked.SystemPrompt
+	if snapshot != "legacy 185" {
+		t.Fatalf("system prompt snapshot = %q, want legacy 185", snapshot)
+	}
+	writeTestFile(t, systemPath, "changed legacy")
+	if got := client.calls[0].SystemPrompt; got != snapshot {
+		t.Fatalf("request used changed system prompt\ngot: %q\nwant: %q", got, snapshot)
 	}
 }
 

--- a/server/runtime/engine_test.go
+++ b/server/runtime/engine_test.go
@@ -895,6 +895,72 @@ func TestReadSystemPromptTemplateUsesGlobalFileWhenLocalMissing(t *testing.T) {
 	}
 }
 
+func TestSystemPromptSnapshotUsesStoredWorkspaceRootWhenTranscriptWorkdirIsNested(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	nested := filepath.Join(workspace, "pkg")
+	t.Setenv("HOME", home)
+	systemDir := filepath.Join(workspace, agentsGlobalDirName)
+	if err := os.MkdirAll(systemDir, 0o755); err != nil {
+		t.Fatalf("mkdir system dir: %v", err)
+	}
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(systemDir, systemPromptFileName), "workspace root system")
+
+	store, err := session.Create(t.TempDir(), "ws", workspace)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	client := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "ok"},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	eng, err := New(store, client, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:                "gpt-5",
+		EnabledTools:         []toolspec.ID{toolspec.ToolExecCommand},
+		TranscriptWorkingDir: nested,
+		ToolPreambles:        false,
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	if _, err := eng.SubmitUserMessage(context.Background(), "hello"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if got := client.calls[0].SystemPrompt; got != "workspace root system" {
+		t.Fatalf("system prompt = %q, want workspace root system", got)
+	}
+}
+
+func TestSystemPromptSnapshotFallsBackWhenHomeDirUnavailable(t *testing.T) {
+	workspace := t.TempDir()
+	t.Setenv("HOME", "")
+	if err := os.MkdirAll(filepath.Join(workspace, agentsGlobalDirName), 0o755); err != nil {
+		t.Fatalf("mkdir system dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(workspace, agentsGlobalDirName, systemPromptFileName), "local without home")
+
+	template, sourcePath, ok, err := readSystemPromptTemplate(systemPromptSnapshotOptions{WorkspaceRoot: workspace})
+	if err != nil {
+		t.Fatalf("read system prompt template: %v", err)
+	}
+	if !ok || template != "local without home" {
+		t.Fatalf("template = %q ok=%t, want local without home true", template, ok)
+	}
+	if want := filepath.Join(workspace, agentsGlobalDirName, systemPromptFileName); sourcePath != want {
+		t.Fatalf("source path = %q, want %q", sourcePath, want)
+	}
+	template, sourcePath, ok, err = readSystemPromptTemplate(systemPromptSnapshotOptions{})
+	if err != nil {
+		t.Fatalf("read system prompt template without local prompt: %v", err)
+	}
+	if ok || template != "" || sourcePath != "" {
+		t.Fatalf("template = %q sourcePath=%q ok=%t, want empty fallback", template, sourcePath, ok)
+	}
+}
+
 func TestEnsureLockedWithSystemPromptAndTranscriptWorkingDirDoesNotDeadlock(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
@@ -1067,10 +1133,16 @@ func TestLegacyLockedSessionBackfillsSystemPromptSnapshotOnce(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("mark locked: %v", err)
 	}
-	client := &fakeClient{responses: []llm.Response{{
-		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "ok"},
-		Usage:     llm.Usage{WindowTokens: 200000},
-	}}}
+	client := &fakeClient{responses: []llm.Response{
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "ok"},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "still ok"},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+	}}
 	eng, err := New(store, client, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
 		Model:                "gpt-5",
 		EnabledTools:         []toolspec.ID{toolspec.ToolExecCommand},
@@ -1093,6 +1165,15 @@ func TestLegacyLockedSessionBackfillsSystemPromptSnapshotOnce(t *testing.T) {
 	writeTestFile(t, systemPath, "changed legacy")
 	if got := client.calls[0].SystemPrompt; got != snapshot {
 		t.Fatalf("request used changed system prompt\ngot: %q\nwant: %q", got, snapshot)
+	}
+	if _, err := eng.SubmitUserMessage(context.Background(), "again"); err != nil {
+		t.Fatalf("submit again: %v", err)
+	}
+	if got := client.calls[1].SystemPrompt; got != snapshot {
+		t.Fatalf("second request used changed system prompt\ngot: %q\nwant: %q", got, snapshot)
+	}
+	if got := store.Meta().Locked.SystemPrompt; got != snapshot {
+		t.Fatalf("stored system prompt changed\ngot: %q\nwant: %q", got, snapshot)
 	}
 }
 

--- a/server/runtime/engine_test.go
+++ b/server/runtime/engine_test.go
@@ -1138,10 +1138,6 @@ func TestLegacyLockedSessionBackfillsSystemPromptSnapshotOnce(t *testing.T) {
 			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "ok"},
 			Usage:     llm.Usage{WindowTokens: 200000},
 		},
-		{
-			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "still ok"},
-			Usage:     llm.Usage{WindowTokens: 200000},
-		},
 	}}
 	eng, err := New(store, client, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
 		Model:                "gpt-5",
@@ -1220,22 +1216,37 @@ func TestEmptySystemPromptSnapshotIsReused(t *testing.T) {
 	if locked := store.Meta().Locked; locked == nil || !locked.HasSystemPrompt || locked.SystemPrompt != "" {
 		t.Fatalf("locked system prompt snapshot = %+v, want empty marked snapshot", locked)
 	}
-	data, err := os.ReadFile(filepath.Join(store.Dir(), "session.json"))
-	if err != nil {
-		t.Fatalf("read session metadata: %v", err)
-	}
-	text := string(data)
-	if !strings.Contains(text, `"system_prompt": ""`) || !strings.Contains(text, `"has_system_prompt": true`) {
-		t.Fatalf("session metadata must persist empty system prompt snapshot marker: %s", text)
+	if err := eng.Close(); err != nil {
+		t.Fatalf("close engine: %v", err)
 	}
 	writeTestFile(t, systemPath, "changed")
-	if _, err := eng.SubmitUserMessage(context.Background(), "again"); err != nil {
+	reopened, err := session.Open(store.Dir())
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	if locked := reopened.Meta().Locked; locked == nil || !locked.HasSystemPrompt || locked.SystemPrompt != "" {
+		t.Fatalf("reopened locked system prompt snapshot = %+v, want empty marked snapshot", locked)
+	}
+	reopenedClient := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "still ok"},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	reopenedEngine, err := New(reopened, reopenedClient, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:                "gpt-5",
+		EnabledTools:         []toolspec.ID{toolspec.ToolExecCommand},
+		TranscriptWorkingDir: workspace,
+		ToolPreambles:        false,
+	})
+	if err != nil {
+		t.Fatalf("new reopened engine: %v", err)
+	}
+	if _, err := reopenedEngine.SubmitUserMessage(context.Background(), "again"); err != nil {
 		t.Fatalf("submit again: %v", err)
 	}
-	if got := client.calls[1].SystemPrompt; got != "" {
+	if got := reopenedClient.calls[0].SystemPrompt; got != "" {
 		t.Fatalf("second system prompt = %q, want empty snapshot", got)
 	}
-	if locked := store.Meta().Locked; locked == nil || !locked.HasSystemPrompt || locked.SystemPrompt != "" {
+	if locked := reopened.Meta().Locked; locked == nil || !locked.HasSystemPrompt || locked.SystemPrompt != "" {
 		t.Fatalf("stored system prompt snapshot changed: %+v", locked)
 	}
 }

--- a/server/runtime/engine_test.go
+++ b/server/runtime/engine_test.go
@@ -1177,6 +1177,69 @@ func TestLegacyLockedSessionBackfillsSystemPromptSnapshotOnce(t *testing.T) {
 	}
 }
 
+func TestEmptySystemPromptSnapshotIsReused(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	systemDir := filepath.Join(workspace, agentsGlobalDirName)
+	if err := os.MkdirAll(systemDir, 0o755); err != nil {
+		t.Fatalf("mkdir system dir: %v", err)
+	}
+	systemPath := filepath.Join(systemDir, systemPromptFileName)
+	writeTestFile(t, systemPath, "   \n")
+
+	store, err := session.Create(t.TempDir(), "ws", workspace)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	client := &fakeClient{responses: []llm.Response{
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "ok"},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "still ok"},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+	}}
+	eng, err := New(store, client, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:                "gpt-5",
+		EnabledTools:         []toolspec.ID{toolspec.ToolExecCommand},
+		TranscriptWorkingDir: workspace,
+		ToolPreambles:        false,
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	if _, err := eng.SubmitUserMessage(context.Background(), "hello"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if got := client.calls[0].SystemPrompt; got != "" {
+		t.Fatalf("first system prompt = %q, want empty", got)
+	}
+	if locked := store.Meta().Locked; locked == nil || !locked.HasSystemPrompt || locked.SystemPrompt != "" {
+		t.Fatalf("locked system prompt snapshot = %+v, want empty marked snapshot", locked)
+	}
+	data, err := os.ReadFile(filepath.Join(store.Dir(), "session.json"))
+	if err != nil {
+		t.Fatalf("read session metadata: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `"system_prompt": ""`) || !strings.Contains(text, `"has_system_prompt": true`) {
+		t.Fatalf("session metadata must persist empty system prompt snapshot marker: %s", text)
+	}
+	writeTestFile(t, systemPath, "changed")
+	if _, err := eng.SubmitUserMessage(context.Background(), "again"); err != nil {
+		t.Fatalf("submit again: %v", err)
+	}
+	if got := client.calls[1].SystemPrompt; got != "" {
+		t.Fatalf("second system prompt = %q, want empty snapshot", got)
+	}
+	if locked := store.Meta().Locked; locked == nil || !locked.HasSystemPrompt || locked.SystemPrompt != "" {
+		t.Fatalf("stored system prompt snapshot changed: %+v", locked)
+	}
+}
+
 func TestLegacyLockedSessionBackfillsContextBudgetOnce(t *testing.T) {
 	dir := t.TempDir()
 	store, err := session.Create(dir, "ws", dir)

--- a/server/runtime/request_cache_lineage_test.go
+++ b/server/runtime/request_cache_lineage_test.go
@@ -347,7 +347,11 @@ func TestLocalCompactionSummary_UsesMainConversationRequestIdentityAndPrompt(t *
 	if got, want := req.PromptCacheScope, cachewarn.ScopeConversation; got != want {
 		t.Fatalf("PromptCacheScope = %q, want %q", got, want)
 	}
-	if got, want := req.SystemPrompt, eng.systemPrompt(locked); got != want {
+	want, err := eng.systemPrompt(locked)
+	if err != nil {
+		t.Fatalf("systemPrompt: %v", err)
+	}
+	if got := req.SystemPrompt; got != want {
 		t.Fatalf("SystemPrompt mismatch\ngot: %q\nwant: %q", got, want)
 	}
 	if got, want := req.ReasoningEffort, eng.ThinkingLevel(); got != want {

--- a/server/runtime/step_executor.go
+++ b/server/runtime/step_executor.go
@@ -205,7 +205,16 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 			if options.RefreshReviewerConfigOnResolve {
 				effectiveReviewerFrequency, effectiveReviewerClient = e.reviewerTurnConfigSnapshot()
 			}
+			assistantEventEmitted := false
 			if s.reviewer.ShouldRunTurn(effectiveReviewerFrequency, effectiveReviewerClient, patchEditsApplied) {
+				if options.EmitAssistantEvent {
+					// The answer is already committed before supervisor entries are appended.
+					// Publish it first so live clients never see supervisor entries as a gap
+					// after an unannounced committed assistant message.
+					e.emit(Event{Kind: EventAssistantMessage, StepID: stepID, Message: resolved, CommittedTranscriptChanged: true, CommittedEntryStart: resolvedCommittedStart, CommittedEntryStartSet: resolvedCommittedStartSet})
+					assistantEventEmitted = true
+				}
+				preReviewMessage := resolved
 				reviewed, err := s.reviewer.RunFollowUp(ctx, stepID, resolved, resolvedCommittedStart, resolvedCommittedStartSet, effectiveReviewerClient)
 				if err == nil {
 					resolved = reviewed.Message
@@ -213,8 +222,9 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 					resolvedCommittedStart = reviewed.AssistantCommittedStart
 					resolvedCommittedStartSet = reviewed.AssistantCommittedStartSet
 				}
+				assistantEventEmitted = assistantEventEmitted && sameVisibleAssistantMessage(preReviewMessage, resolved)
 			}
-			if options.EmitAssistantEvent {
+			if options.EmitAssistantEvent && !assistantEventEmitted {
 				e.emit(Event{Kind: EventAssistantMessage, StepID: stepID, Message: resolved, CommittedTranscriptChanged: true, CommittedEntryStart: resolvedCommittedStart, CommittedEntryStartSet: resolvedCommittedStartSet})
 			}
 			if reviewerCompletion != nil {
@@ -283,6 +293,29 @@ func liveCommittedAssistantEventMessage(msg llm.Message) (llm.Message, bool) {
 		Content: msg.Content,
 		Phase:   msg.Phase,
 	}, true
+}
+
+func sameVisibleAssistantMessage(a, b llm.Message) bool {
+	aEntries := VisibleChatEntriesFromMessage(a)
+	bEntries := VisibleChatEntriesFromMessage(b)
+	if len(aEntries) != len(bEntries) {
+		return false
+	}
+	for idx := range aEntries {
+		if !sameVisibleChatEntryContent(aEntries[idx], bEntries[idx]) {
+			return false
+		}
+	}
+	return true
+}
+
+func sameVisibleChatEntryContent(a, b ChatEntry) bool {
+	return a.Visibility == b.Visibility &&
+		a.Role == b.Role &&
+		a.Text == b.Text &&
+		a.OngoingText == b.OngoingText &&
+		a.Phase == b.Phase &&
+		strings.TrimSpace(a.ToolCallID) == strings.TrimSpace(b.ToolCallID)
 }
 
 func committedStartsForPersistedAssistantMessage(e *Engine, msg llm.Message, executableCallIDs map[string]struct{}) (int, map[string]int) {

--- a/server/runtime/system_prompt_snapshot.go
+++ b/server/runtime/system_prompt_snapshot.go
@@ -51,13 +51,21 @@ func (e *Engine) systemPromptWorkspaceRoot() string {
 }
 
 func (e *Engine) systemPromptWorkspaceRootLocked() string {
-	if trimmed := strings.TrimSpace(e.transcriptCWD); trimmed != "" {
-		return trimmed
+	activeRoot := strings.TrimSpace(e.transcriptCWD)
+	if activeRoot == "" {
+		activeRoot = strings.TrimSpace(e.cfg.TranscriptWorkingDir)
 	}
-	if trimmed := strings.TrimSpace(e.cfg.TranscriptWorkingDir); trimmed != "" {
-		return trimmed
+	persistedRoot := strings.TrimSpace(e.store.Meta().WorkspaceRoot)
+	if activeRoot == "" {
+		return persistedRoot
 	}
-	return strings.TrimSpace(e.store.Meta().WorkspaceRoot)
+	if persistedRoot == "" {
+		return activeRoot
+	}
+	if pathWithinRoot(activeRoot, persistedRoot) {
+		return persistedRoot
+	}
+	return activeRoot
 }
 
 func readSystemPromptTemplate(opts systemPromptSnapshotOptions) (string, string, bool, error) {
@@ -93,10 +101,21 @@ func systemPromptPaths(workspaceRoot string) ([]string, error) {
 		}
 		addPath(filepath.Join(absWorkspace, agentsGlobalDirName, systemPromptFileName))
 	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("resolve home dir: %w", err)
+	if home, err := os.UserHomeDir(); err == nil {
+		addPath(filepath.Join(home, agentsGlobalDirName, systemPromptFileName))
 	}
-	addPath(filepath.Join(home, agentsGlobalDirName, systemPromptFileName))
 	return paths, nil
+}
+
+func pathWithinRoot(path string, root string) bool {
+	absPath, pathErr := filepath.Abs(strings.TrimSpace(path))
+	absRoot, rootErr := filepath.Abs(strings.TrimSpace(root))
+	if pathErr != nil || rootErr != nil {
+		return false
+	}
+	rel, err := filepath.Rel(absRoot, absPath)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }

--- a/server/runtime/system_prompt_snapshot.go
+++ b/server/runtime/system_prompt_snapshot.go
@@ -1,0 +1,102 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"builder/prompts"
+	"builder/server/session"
+)
+
+type systemPromptSnapshotOptions struct {
+	WorkspaceRoot string
+}
+
+func (e *Engine) buildSystemPromptSnapshot(locked session.LockedContract) (string, error) {
+	return e.buildSystemPromptSnapshotForRoot(locked, e.systemPromptWorkspaceRoot())
+}
+
+func (e *Engine) buildSystemPromptSnapshotForRoot(locked session.LockedContract, workspaceRoot string) (string, error) {
+	includeToolPreambles := true
+	if locked.ToolPreambles != nil {
+		includeToolPreambles = *locked.ToolPreambles
+	}
+	args := prompts.SystemPromptTemplateArgs{
+		EstimatedToolCallsForContext: e.estimatedToolCallsForLockedContext(locked),
+	}
+	template, sourcePath, hasCustom, err := readSystemPromptTemplate(systemPromptSnapshotOptions{WorkspaceRoot: workspaceRoot})
+	if err != nil {
+		return "", err
+	}
+	if hasCustom {
+		rendered, err := prompts.RenderCustomSystemPrompt(template, includeToolPreambles, args)
+		if err != nil {
+			return "", fmt.Errorf("render SYSTEM.md %q: %w", sourcePath, err)
+		}
+		return rendered, nil
+	}
+	return prompts.MainSystemPrompt(includeToolPreambles, args), nil
+}
+
+func (e *Engine) systemPromptWorkspaceRoot() string {
+	if e == nil {
+		return ""
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.systemPromptWorkspaceRootLocked()
+}
+
+func (e *Engine) systemPromptWorkspaceRootLocked() string {
+	if trimmed := strings.TrimSpace(e.transcriptCWD); trimmed != "" {
+		return trimmed
+	}
+	if trimmed := strings.TrimSpace(e.cfg.TranscriptWorkingDir); trimmed != "" {
+		return trimmed
+	}
+	return strings.TrimSpace(e.store.Meta().WorkspaceRoot)
+}
+
+func readSystemPromptTemplate(opts systemPromptSnapshotOptions) (string, string, bool, error) {
+	paths, err := systemPromptPaths(opts.WorkspaceRoot)
+	if err != nil {
+		return "", "", false, err
+	}
+	for _, path := range paths {
+		data, readErr := os.ReadFile(path)
+		if readErr == nil {
+			return string(data), path, true, nil
+		}
+		if errors.Is(readErr, os.ErrNotExist) {
+			continue
+		}
+		return "", "", false, fmt.Errorf("read SYSTEM.md %q: %w", path, readErr)
+	}
+	return "", "", false, nil
+}
+
+func systemPromptPaths(workspaceRoot string) ([]string, error) {
+	paths := make([]string, 0, 2)
+	addPath := func(path string) {
+		trimmed := strings.TrimSpace(path)
+		if trimmed != "" {
+			paths = append(paths, trimmed)
+		}
+	}
+	if trimmed := strings.TrimSpace(workspaceRoot); trimmed != "" {
+		absWorkspace, err := filepath.Abs(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("resolve workspace root: %w", err)
+		}
+		addPath(filepath.Join(absWorkspace, agentsGlobalDirName, systemPromptFileName))
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve home dir: %w", err)
+	}
+	addPath(filepath.Join(home, agentsGlobalDirName, systemPromptFileName))
+	return paths, nil
+}

--- a/server/session/fork.go
+++ b/server/session/fork.go
@@ -76,6 +76,7 @@ func cloneLockedContract(in *LockedContract) *LockedContract {
 	if len(in.EnabledTools) > 0 {
 		copyLocked.EnabledTools = append([]string(nil), in.EnabledTools...)
 	}
+	copyLocked.SystemPrompt = strings.TrimSpace(in.SystemPrompt)
 	return &copyLocked
 }
 

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -444,15 +444,13 @@ func (s *Store) BackfillLockedContextBudget(contextWindow, contextPercent int) e
 
 func (s *Store) BackfillLockedSystemPrompt(systemPrompt string) error {
 	trimmed := strings.TrimSpace(systemPrompt)
-	if trimmed == "" {
-		return nil
-	}
 	s.mu.Lock()
-	if s.meta.Locked == nil || strings.TrimSpace(s.meta.Locked.SystemPrompt) != "" {
+	if s.meta.Locked == nil || s.meta.Locked.HasSystemPrompt {
 		s.mu.Unlock()
 		return nil
 	}
 	s.meta.Locked.SystemPrompt = trimmed
+	s.meta.Locked.HasSystemPrompt = true
 	s.meta.UpdatedAt = time.Now().UTC()
 	snapshot, err := s.persistMetaLocked()
 	s.mu.Unlock()

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -442,6 +442,26 @@ func (s *Store) BackfillLockedContextBudget(contextWindow, contextPercent int) e
 	return s.observePersistence(snapshot)
 }
 
+func (s *Store) BackfillLockedSystemPrompt(systemPrompt string) error {
+	trimmed := strings.TrimSpace(systemPrompt)
+	if trimmed == "" {
+		return nil
+	}
+	s.mu.Lock()
+	if s.meta.Locked == nil || strings.TrimSpace(s.meta.Locked.SystemPrompt) != "" {
+		s.mu.Unlock()
+		return nil
+	}
+	s.meta.Locked.SystemPrompt = trimmed
+	s.meta.UpdatedAt = time.Now().UTC()
+	snapshot, err := s.persistMetaLocked()
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.observePersistence(snapshot)
+}
+
 func (s *Store) AppendEvent(stepID, kind string, payload any) (Event, error) {
 	s.mu.Lock()
 

--- a/server/session/store_test.go
+++ b/server/session/store_test.go
@@ -309,10 +309,11 @@ func TestLockedContractPersistenceIncludesSystemPromptButNotToolSchema(t *testin
 		t.Fatalf("create store: %v", err)
 	}
 	if err := store.MarkModelDispatchLocked(LockedContract{
-		Model:          "gpt-5",
-		Temperature:    1,
-		MaxOutputToken: 0,
-		SystemPrompt:   "locked system prompt",
+		Model:           "gpt-5",
+		Temperature:     1,
+		MaxOutputToken:  0,
+		SystemPrompt:    "locked system prompt",
+		HasSystemPrompt: true,
 	}); err != nil {
 		t.Fatalf("mark model dispatch locked: %v", err)
 	}
@@ -327,6 +328,9 @@ func TestLockedContractPersistenceIncludesSystemPromptButNotToolSchema(t *testin
 	}
 	if !strings.Contains(text, `"system_prompt": "locked system prompt"`) {
 		t.Fatalf("session metadata must persist system_prompt snapshot: %s", text)
+	}
+	if !strings.Contains(text, `"has_system_prompt": true`) {
+		t.Fatalf("session metadata must persist system_prompt marker: %s", text)
 	}
 }
 

--- a/server/session/store_test.go
+++ b/server/session/store_test.go
@@ -302,7 +302,7 @@ func TestListSessionsSortedByUpdatedAt(t *testing.T) {
 	}
 }
 
-func TestLockedContractPersistenceDoesNotIncludePromptOrToolSchema(t *testing.T) {
+func TestLockedContractPersistenceIncludesSystemPromptButNotToolSchema(t *testing.T) {
 	root := t.TempDir()
 	store, err := Create(root, "workspace-x", "/tmp/work")
 	if err != nil {
@@ -312,6 +312,7 @@ func TestLockedContractPersistenceDoesNotIncludePromptOrToolSchema(t *testing.T)
 		Model:          "gpt-5",
 		Temperature:    1,
 		MaxOutputToken: 0,
+		SystemPrompt:   "locked system prompt",
 	}); err != nil {
 		t.Fatalf("mark model dispatch locked: %v", err)
 	}
@@ -324,8 +325,8 @@ func TestLockedContractPersistenceDoesNotIncludePromptOrToolSchema(t *testing.T)
 	if strings.Contains(text, "tools_json") {
 		t.Fatalf("session metadata must not persist tools_json: %s", text)
 	}
-	if strings.Contains(text, "system_prompt") {
-		t.Fatalf("session metadata must not persist system_prompt: %s", text)
+	if !strings.Contains(text, `"system_prompt": "locked system prompt"`) {
+		t.Fatalf("session metadata must persist system_prompt snapshot: %s", text)
 	}
 }
 

--- a/server/session/store_test.go
+++ b/server/session/store_test.go
@@ -326,11 +326,13 @@ func TestLockedContractPersistenceIncludesSystemPromptButNotToolSchema(t *testin
 	if strings.Contains(text, "tools_json") {
 		t.Fatalf("session metadata must not persist tools_json: %s", text)
 	}
-	if !strings.Contains(text, `"system_prompt": "locked system prompt"`) {
-		t.Fatalf("session metadata must persist system_prompt snapshot: %s", text)
+	opened, err := Open(store.Dir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
 	}
-	if !strings.Contains(text, `"has_system_prompt": true`) {
-		t.Fatalf("session metadata must persist system_prompt marker: %s", text)
+	locked := opened.Meta().Locked
+	if locked == nil || locked.SystemPrompt != "locked system prompt" || !locked.HasSystemPrompt {
+		t.Fatalf("locked system prompt = %+v, want persisted snapshot marker", locked)
 	}
 }
 

--- a/server/session/types.go
+++ b/server/session/types.go
@@ -9,6 +9,7 @@ type LockedContract struct {
 	Model             string                     `json:"model"`
 	Temperature       float64                    `json:"temperature"`
 	MaxOutputToken    int                        `json:"max_output_token"`
+	SystemPrompt      string                     `json:"system_prompt,omitempty"`
 	ContextWindow     int                        `json:"context_window,omitempty"`
 	ContextPercent    int                        `json:"context_percent,omitempty"`
 	EnabledTools      []string                   `json:"enabled_tools,omitempty"`

--- a/server/session/types.go
+++ b/server/session/types.go
@@ -9,7 +9,8 @@ type LockedContract struct {
 	Model             string                     `json:"model"`
 	Temperature       float64                    `json:"temperature"`
 	MaxOutputToken    int                        `json:"max_output_token"`
-	SystemPrompt      string                     `json:"system_prompt,omitempty"`
+	SystemPrompt      string                     `json:"system_prompt"`
+	HasSystemPrompt   bool                       `json:"has_system_prompt,omitempty"`
 	ContextWindow     int                        `json:"context_window,omitempty"`
 	ContextPercent    int                        `json:"context_percent,omitempty"`
 	EnabledTools      []string                   `json:"enabled_tools,omitempty"`


### PR DESCRIPTION
## Summary
- add global and workspace `SYSTEM.md` support with workspace precedence
- snapshot the fully rendered system prompt into the locked session contract on first model dispatch
- keep resumed, legacy, and retargeted sessions on the stored/active-workdir prompt snapshot to avoid cache invalidations
- document prompt files and supported placeholders

Closes #116

## Verification
- `./scripts/test.sh ./server/runtime -run 'TestEnsureLockedWithSystemPromptAndTranscriptWorkingDirDoesNotDeadlock|TestBuildSystemPromptSnapshotForRootDoesNotUseMutexTakingWorkspaceAccessor|TestSystemPromptSnapshotUsesTranscriptWorkingDirForRetargetedSession'`\n- `./scripts/test.sh ./prompts ./server/runtime ./server/sessionruntime`\n- `./scripts/test.sh ./...`\n- `./scripts/build.sh --output ./bin/builder`\n- `cd docs && pnpm test && pnpm build`\n- real manual QA with isolated repo/home/persistence/server port confirmed edited `SYSTEM.md` does not affect a continued session snapshot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system prompt customization support with workspace and home directory discovery
  * System prompts are now captured and persisted as snapshots in locked sessions
  * Improved handling of reviewer suggestions and status events to prevent duplicate messaging

* **Documentation**
  * Added guide covering system prompt customization and configuration with template placeholders

* **Tests**
  * Enhanced test coverage for system prompt snapshot behavior, persistence stability, and reviewer event ordering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->