### PR TITLE
fix: add agent shell environment overrides

### DIFF
--- a/server/tools/shell/postprocess/hook.go
+++ b/server/tools/shell/postprocess/hook.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
 
+	"builder/server/tools/shell/shellenv"
 	"builder/shared/toolspec"
 )
 
@@ -61,6 +63,7 @@ func (r *Runner) applyHook(ctx context.Context, req Request, originalOutput stri
 	defer cancel()
 
 	cmd := exec.CommandContext(timeoutCtx, hookPath)
+	cmd.Env = shellenv.Enrich(os.Environ())
 	cmd.Stdin = bytes.NewReader(payload)
 	stdout := newLimitedBuffer(maxHookOutputBytes)
 	stderr := newLimitedBuffer(maxHookOutputBytes)

--- a/server/tools/shell/shellenv/env.go
+++ b/server/tools/shell/shellenv/env.go
@@ -1,0 +1,91 @@
+package shellenv
+
+import (
+	"os"
+	"strings"
+
+	"builder/shared/config"
+)
+
+var overrides = []string{
+	"AGENT=builder",
+	"TERM=dumb",
+	"COLORTERM=",
+	"CI=1",
+	"NO_COLOR=1",
+	"CLICOLOR=0",
+	"CLICOLOR_FORCE=0",
+	"FORCE_COLOR=0",
+	"PAGER=cat",
+	"GIT_PAGER=cat",
+	"GH_PAGER=cat",
+	"MANPAGER=cat",
+	"SYSTEMD_PAGER=",
+	"BAT_PAGER=cat",
+	"GIT_EDITOR=:",
+	"EDITOR=:",
+	"VISUAL=:",
+	"GIT_TERMINAL_PROMPT=0",
+	"GCM_INTERACTIVE=Never",
+	"DEBIAN_FRONTEND=noninteractive",
+	"PY_COLORS=0",
+	"CARGO_TERM_COLOR=never",
+	"NPM_CONFIG_COLOR=false",
+	"npm_config_progress=false",
+	"YARN_ENABLE_PROGRESS_BARS=false",
+	"DOCKER_CLI_HINTS=false",
+	"BUILDKIT_PROGRESS=plain",
+	"COMPOSE_PROGRESS=plain",
+	"COMPOSE_ANSI=never",
+}
+
+func Enrich(base []string) []string {
+	env := make(map[string]string, len(base)+len(overrides))
+	order := make([]string, 0, len(base)+len(overrides))
+
+	for _, entry := range base {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || key == "" {
+			continue
+		}
+		if _, exists := env[key]; !exists {
+			order = append(order, key)
+		}
+		env[key] = value
+	}
+
+	for _, entry := range overrides {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || key == "" {
+			continue
+		}
+		if _, exists := env[key]; !exists {
+			order = append(order, key)
+		}
+		env[key] = value
+	}
+
+	if _, exists := env["RIPGREP_CONFIG_PATH"]; !exists {
+		if path, ok := managedRGConfigEnvValue(); ok {
+			order = append(order, "RIPGREP_CONFIG_PATH")
+			env["RIPGREP_CONFIG_PATH"] = path
+		}
+	}
+
+	out := make([]string, 0, len(order))
+	for _, key := range order {
+		out = append(out, key+"="+env[key])
+	}
+	return out
+}
+
+func managedRGConfigEnvValue() (string, bool) {
+	path, err := config.ResolveManagedRGConfigPath()
+	if err != nil || strings.TrimSpace(path) == "" {
+		return "", false
+	}
+	if _, err := os.Stat(path); err != nil {
+		return "", false
+	}
+	return path, true
+}

--- a/server/tools/shell/shellenv/env_test.go
+++ b/server/tools/shell/shellenv/env_test.go
@@ -1,0 +1,56 @@
+package shellenv
+
+import (
+	"strings"
+	"testing"
+)
+
+func envMap(t *testing.T, in []string) map[string]string {
+	t.Helper()
+	out := make(map[string]string, len(in))
+	for _, entry := range in {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || key == "" {
+			t.Fatalf("invalid env entry: %q", entry)
+		}
+		if _, exists := out[key]; exists {
+			t.Fatalf("duplicate env key: %s", key)
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func TestEnrichAppliesAgentShellDefaults(t *testing.T) {
+	env := envMap(t, Enrich([]string{
+		"AGENT=other",
+		"TERM=xterm-256color",
+		"DOCKER_CLI_HINTS=true",
+		"BUILDKIT_PROGRESS=auto",
+		"COMPOSE_PROGRESS=auto",
+		"COMPOSE_ANSI=always",
+		"npm_config_progress=true",
+		"YARN_ENABLE_PROGRESS_BARS=true",
+		"KEEP=1",
+	}))
+
+	want := map[string]string{
+		"AGENT":                     "builder",
+		"TERM":                      "dumb",
+		"CI":                        "1",
+		"NO_COLOR":                  "1",
+		"GIT_TERMINAL_PROMPT":       "0",
+		"DOCKER_CLI_HINTS":          "false",
+		"BUILDKIT_PROGRESS":         "plain",
+		"COMPOSE_PROGRESS":          "plain",
+		"COMPOSE_ANSI":              "never",
+		"npm_config_progress":       "false",
+		"YARN_ENABLE_PROGRESS_BARS": "false",
+		"KEEP":                      "1",
+	}
+	for key, wantValue := range want {
+		if env[key] != wantValue {
+			t.Fatalf("%s = %q, want %q", key, env[key], wantValue)
+		}
+	}
+}

--- a/server/tools/shell/tool.go
+++ b/server/tools/shell/tool.go
@@ -4,11 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"unicode"
 
-	"builder/shared/config"
+	"builder/server/tools/shell/shellenv"
 
 	xansi "github.com/charmbracelet/x/ansi"
 )
@@ -19,31 +18,6 @@ const (
 	truncationBannerTemplate           = "\n\n...[Output is very large, omitted %d bytes. Consider using more targeted commands to reduce output size]...\n\n"
 	backgroundTruncationBannerTemplate = "\n\n...[Omitted %d bytes, read log file for details]...\n\n"
 )
-
-var shellEnvOverrides = []string{
-	"TERM=dumb",
-	"COLORTERM=",
-	"CI=1",
-	"NO_COLOR=1",
-	"CLICOLOR=0",
-	"CLICOLOR_FORCE=0",
-	"FORCE_COLOR=0",
-	"PAGER=cat",
-	"GIT_PAGER=cat",
-	"GH_PAGER=cat",
-	"MANPAGER=cat",
-	"SYSTEMD_PAGER=",
-	"BAT_PAGER=cat",
-	"GIT_EDITOR=:",
-	"EDITOR=:",
-	"VISUAL=:",
-	"GIT_TERMINAL_PROMPT=0",
-	"GCM_INTERACTIVE=Never",
-	"DEBIAN_FRONTEND=noninteractive",
-	"PY_COLORS=0",
-	"CARGO_TERM_COLOR=never",
-	"NPM_CONFIG_COLOR=false",
-}
 
 func marshalNoHTMLEscape(v any) (json.RawMessage, error) {
 	var buf bytes.Buffer
@@ -56,54 +30,7 @@ func marshalNoHTMLEscape(v any) (json.RawMessage, error) {
 }
 
 func enrichEnv(base []string) []string {
-	env := make(map[string]string, len(base)+len(shellEnvOverrides))
-	order := make([]string, 0, len(base)+len(shellEnvOverrides))
-
-	for _, entry := range base {
-		key, value, ok := strings.Cut(entry, "=")
-		if !ok || key == "" {
-			continue
-		}
-		if _, exists := env[key]; !exists {
-			order = append(order, key)
-		}
-		env[key] = value
-	}
-
-	for _, entry := range shellEnvOverrides {
-		key, value, ok := strings.Cut(entry, "=")
-		if !ok || key == "" {
-			continue
-		}
-		if _, exists := env[key]; !exists {
-			order = append(order, key)
-		}
-		env[key] = value
-	}
-
-	if _, exists := env["RIPGREP_CONFIG_PATH"]; !exists {
-		if path, ok := managedRGConfigEnvValue(); ok {
-			order = append(order, "RIPGREP_CONFIG_PATH")
-			env["RIPGREP_CONFIG_PATH"] = path
-		}
-	}
-
-	out := make([]string, 0, len(order))
-	for _, key := range order {
-		out = append(out, key+"="+env[key])
-	}
-	return out
-}
-
-func managedRGConfigEnvValue() (string, bool) {
-	path, err := config.ResolveManagedRGConfigPath()
-	if err != nil || strings.TrimSpace(path) == "" {
-		return "", false
-	}
-	if _, err := os.Stat(path); err != nil {
-		return "", false
-	}
-	return path, true
+	return shellenv.Enrich(base)
 }
 
 func sanitizeOutput(s string) string {

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -107,14 +107,24 @@ func envSliceToMap(t *testing.T, in []string) map[string]string {
 func TestEnrichEnvOverridesNonInteractiveDefaults(t *testing.T) {
 	env := envSliceToMap(t, enrichEnv([]string{
 		"TERM=xterm-256color",
+		"AGENT=other",
 		"GIT_EDITOR=vim",
 		"PAGER=less",
 		"NO_COLOR=0",
+		"DOCKER_CLI_HINTS=true",
+		"BUILDKIT_PROGRESS=auto",
+		"COMPOSE_PROGRESS=auto",
+		"COMPOSE_ANSI=always",
+		"npm_config_progress=true",
+		"YARN_ENABLE_PROGRESS_BARS=true",
 		"KEEP=1",
 	}))
 
 	if env["TERM"] != "dumb" {
 		t.Fatalf("TERM = %q, want dumb", env["TERM"])
+	}
+	if env["AGENT"] != "builder" {
+		t.Fatalf("AGENT = %q, want builder", env["AGENT"])
 	}
 	if env["GIT_EDITOR"] != ":" {
 		t.Fatalf("GIT_EDITOR = %q, want :", env["GIT_EDITOR"])
@@ -127,6 +137,24 @@ func TestEnrichEnvOverridesNonInteractiveDefaults(t *testing.T) {
 	}
 	if env["GIT_TERMINAL_PROMPT"] != "0" {
 		t.Fatalf("GIT_TERMINAL_PROMPT = %q, want 0", env["GIT_TERMINAL_PROMPT"])
+	}
+	if env["DOCKER_CLI_HINTS"] != "false" {
+		t.Fatalf("DOCKER_CLI_HINTS = %q, want false", env["DOCKER_CLI_HINTS"])
+	}
+	if env["BUILDKIT_PROGRESS"] != "plain" {
+		t.Fatalf("BUILDKIT_PROGRESS = %q, want plain", env["BUILDKIT_PROGRESS"])
+	}
+	if env["COMPOSE_PROGRESS"] != "plain" {
+		t.Fatalf("COMPOSE_PROGRESS = %q, want plain", env["COMPOSE_PROGRESS"])
+	}
+	if env["COMPOSE_ANSI"] != "never" {
+		t.Fatalf("COMPOSE_ANSI = %q, want never", env["COMPOSE_ANSI"])
+	}
+	if env["npm_config_progress"] != "false" {
+		t.Fatalf("npm_config_progress = %q, want false", env["npm_config_progress"])
+	}
+	if env["YARN_ENABLE_PROGRESS_BARS"] != "false" {
+		t.Fatalf("YARN_ENABLE_PROGRESS_BARS = %q, want false", env["YARN_ENABLE_PROGRESS_BARS"])
 	}
 	if env["KEEP"] != "1" {
 		t.Fatalf("KEEP = %q, want 1", env["KEEP"])
@@ -399,9 +427,71 @@ func TestExecCommandMovesToBackgroundAndPollsToCompletion(t *testing.T) {
 	waitForManagerCount(t, manager, 0, time.Second)
 }
 
+func TestExecCommandExportsAgentEnv(t *testing.T) {
+	workspace := t.TempDir()
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+
+	execInput, _ := json.Marshal(map[string]any{
+		"cmd":           "printf '%s' \"$AGENT\"",
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 1_000,
+	})
+	result, err := execTool.Call(context.Background(), tools.Call{ID: "agent-env", Name: toolspec.ToolExecCommand, Input: execInput})
+	if err != nil {
+		t.Fatalf("exec_command call error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected exec_command error: %s", string(result.Output))
+	}
+	if got := decodeStringToolOutput(t, result); !strings.Contains(got, "builder") {
+		t.Fatalf("expected AGENT=builder in shell output, got %q", got)
+	}
+}
+
+func TestExecCommandBackgroundProcessExportsAgentEnv(t *testing.T) {
+	workspace := t.TempDir()
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+	pollTool := NewWriteStdinTool(16_000, manager)
+
+	execInput, _ := json.Marshal(map[string]any{
+		"cmd":           "sleep 0.35; printf '%s' \"$AGENT\"",
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 250,
+	})
+	result, err := execTool.Call(context.Background(), tools.Call{ID: "agent-env-bg-start", Name: toolspec.ToolExecCommand, Input: execInput})
+	if err != nil {
+		t.Fatalf("exec_command call error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected exec_command error: %s", string(result.Output))
+	}
+	if got := decodeStringToolOutput(t, result); !strings.Contains(got, "Process moved to background with ID 1000.") {
+		t.Fatalf("expected background transition, got %q", got)
+	}
+
+	pollInput, _ := json.Marshal(map[string]any{
+		"session_id":    1000,
+		"yield_time_ms": 800,
+	})
+	pollResult, err := pollTool.Call(context.Background(), tools.Call{ID: "agent-env-bg-poll", Name: toolspec.ToolWriteStdin, Input: pollInput})
+	if err != nil {
+		t.Fatalf("write_stdin call error: %v", err)
+	}
+	if pollResult.IsError {
+		t.Fatalf("unexpected write_stdin error: %s", string(pollResult.Output))
+	}
+	if got := decodeStringToolOutput(t, pollResult); !strings.Contains(got, "builder") {
+		t.Fatalf("expected AGENT=builder in background shell output, got %q", got)
+	}
+}
+
 func TestExecCommandAppliesUserHookOutput(t *testing.T) {
 	workspace := t.TempDir()
-	hookPath := writeExecutableScript(t, "#!/bin/sh\nprintf '{\"processed\":true,\"replaced_output\":\"HOOKED\"}\n'")
+	hookPath := writeExecutableScript(t, "#!/bin/sh\nif [ \"$AGENT\" != builder ]; then printf '{\"processed\":true,\"replaced_output\":\"MISSING_AGENT\"}'; exit 0; fi\nprintf '{\"processed\":true,\"replaced_output\":\"HOOKED\"}\n'")
 	manager, err := NewManager(
 		WithMinimumExecToBgTime(250*time.Millisecond),
 		WithCloseTimeouts(20*time.Millisecond, 200*time.Millisecond),


### PR DESCRIPTION
## Summary
- Set `AGENT=builder` for shell-tool subprocesses.
- Centralize shell env enrichment and apply it to command execution plus shell postprocess hooks.
- Add Docker, Compose, npm, and Yarn non-interactive/progress env defaults.

Closes #114

## Verification
- `./scripts/test.sh ./server/tools/shell/shellenv ./server/tools/shell`
- `./scripts/build.sh --output ./bin/builder`
- pre-push hook: formatting, go vet, go build, go test