### PR TITLE
fix: show auth slash command by state

### DIFF
--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -497,6 +497,8 @@ type uiModel struct {
 	commandRegistry       *commands.Registry
 	hasOtherSessions      bool
 	hasOtherSessionsKnown bool
+	authSlashCommandName  string
+	authSlashCommandErr   string
 	slashCommandFilter    string
 	slashCommandFilterSet bool
 	slashCommandSelection int
@@ -677,6 +679,7 @@ func NewProjectedUIModel(runtimeClient clientui.RuntimeClient, runtimeEvents <-c
 	m.fastModeAvailable = status.FastModeAvailable
 	m.fastModeEnabled = status.FastModeEnabled
 	m.conversationFreshness = status.ConversationFreshness
+	m.refreshAuthSlashCommandState()
 	if !m.hasRuntimeClient() {
 		m.reviewerEnabled = strings.TrimSpace(m.reviewerMode) != "" && strings.TrimSpace(m.reviewerMode) != "off"
 	}

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -499,6 +499,7 @@ type uiModel struct {
 	hasOtherSessionsKnown bool
 	authSlashCommandName  string
 	authSlashCommandErr   string
+	authSlashSessionOpen  bool
 	slashCommandFilter    string
 	slashCommandFilterSet bool
 	slashCommandSelection int

--- a/cli/app/ui_slash_command_picker.go
+++ b/cli/app/ui_slash_command_picker.go
@@ -1,10 +1,12 @@
 package app
 
 import (
+	"context"
 	"strings"
 	"unicode"
 
 	"builder/cli/app/commands"
+	"builder/server/auth"
 )
 
 const slashCommandPickerLines = 7
@@ -63,6 +65,7 @@ func (m *uiModel) refreshSlashCommandFilterFromInput() {
 		m.slashCommandSelection = 0
 		return
 	}
+	m.refreshAuthSlashCommandState()
 	normalized := normalizeSlashCommandToken(parsed.token)
 	if !m.slashCommandFilterSet || m.slashCommandFilter != normalized {
 		m.slashCommandSelection = 0
@@ -115,9 +118,45 @@ func (m *uiModel) filterSlashCommandMatches(matches []commands.Command) []comman
 		if command.Name == "copy" && !m.hasAssistantFinalAnswerToCopy() {
 			continue
 		}
+		if isAuthSlashCommand(command.Name) && command.Name != m.authSlashCommandName {
+			continue
+		}
 		filtered = append(filtered, command)
 	}
 	return filtered
+}
+
+func isAuthSlashCommand(name string) bool {
+	switch strings.TrimSpace(name) {
+	case "login", "logout":
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *uiModel) refreshAuthSlashCommandState() {
+	name, err := m.resolveAuthSlashCommandName()
+	m.authSlashCommandName = name
+	if err != nil {
+		m.authSlashCommandErr = err.Error()
+		return
+	}
+	m.authSlashCommandErr = ""
+}
+
+func (m *uiModel) resolveAuthSlashCommandName() (string, error) {
+	if m == nil || m.statusConfig.AuthManager == nil {
+		return "login", nil
+	}
+	state, err := m.statusConfig.AuthManager.Load(context.Background())
+	if err != nil {
+		return "", err
+	}
+	if state.Method.Type == auth.MethodOAuth {
+		return "logout", nil
+	}
+	return "login", nil
 }
 
 func (m *uiModel) resumeCommandAvailable() bool {

--- a/cli/app/ui_slash_command_picker.go
+++ b/cli/app/ui_slash_command_picker.go
@@ -60,12 +60,16 @@ func normalizeSlashCommandToken(token string) string {
 func (m *uiModel) refreshSlashCommandFilterFromInput() {
 	parsed := parseSlashCommandInput(m.input)
 	if !parsed.active || parsed.argumentMode {
+		m.authSlashSessionOpen = false
 		m.slashCommandFilter = ""
 		m.slashCommandFilterSet = false
 		m.slashCommandSelection = 0
 		return
 	}
-	m.refreshAuthSlashCommandState()
+	if !m.authSlashSessionOpen {
+		m.refreshAuthSlashCommandState()
+		m.authSlashSessionOpen = true
+	}
 	normalized := normalizeSlashCommandToken(parsed.token)
 	if !m.slashCommandFilterSet || m.slashCommandFilter != normalized {
 		m.slashCommandSelection = 0

--- a/cli/app/ui_slash_command_picker_test.go
+++ b/cli/app/ui_slash_command_picker_test.go
@@ -338,6 +338,38 @@ func TestSlashCommandPickerRefreshesAuthStateAfterModelInit(t *testing.T) {
 	}
 }
 
+func TestSlashCommandPickerLoadsAuthStateOncePerSlashSession(t *testing.T) {
+	store := &countingAuthStore{state: auth.State{
+		Scope: auth.ScopeGlobal,
+		Method: auth.Method{
+			Type: auth.MethodOAuth,
+			OAuth: &auth.OAuthMethod{
+				AccessToken: "access-token",
+				TokenType:   "Bearer",
+			},
+		},
+	}}
+	manager := auth.NewManager(store, nil, nil)
+	m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{AuthManager: manager}))
+	loadsAfterInit := store.loads
+
+	for _, input := range []string{"/", "/l", "/lo"} {
+		m.input = input
+		m.refreshSlashCommandFilterFromInput()
+	}
+	if got := store.loads - loadsAfterInit; got != 1 {
+		t.Fatalf("expected one auth load while editing one slash session, got %d", got)
+	}
+
+	m.input = "ordinary prompt"
+	m.refreshSlashCommandFilterFromInput()
+	m.input = "/"
+	m.refreshSlashCommandFilterFromInput()
+	if got := store.loads - loadsAfterInit; got != 2 {
+		t.Fatalf("expected auth load after starting a new slash session, got %d", got)
+	}
+}
+
 type errorAuthStore struct {
 	err error
 }
@@ -347,6 +379,21 @@ func (s errorAuthStore) Load(context.Context) (auth.State, error) {
 }
 
 func (s errorAuthStore) Save(context.Context, auth.State) error {
+	return nil
+}
+
+type countingAuthStore struct {
+	state auth.State
+	loads int
+}
+
+func (s *countingAuthStore) Load(context.Context) (auth.State, error) {
+	s.loads++
+	return s.state, nil
+}
+
+func (s *countingAuthStore) Save(_ context.Context, state auth.State) error {
+	s.state = state
 	return nil
 }
 

--- a/cli/app/ui_slash_command_picker_test.go
+++ b/cli/app/ui_slash_command_picker_test.go
@@ -1,11 +1,14 @@
 package app
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"builder/cli/app/commands"
 	"builder/cli/tui"
+	"builder/server/auth"
 	"builder/server/llm"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -176,6 +179,175 @@ func TestResumeSlashCommandAllowsUnknownOtherSessionAvailability(t *testing.T) {
 	if updated.Action() != UIActionResume {
 		t.Fatalf("expected UIActionResume, got %q", updated.Action())
 	}
+}
+
+func TestSlashCommandPickerShowsLoginWhenAuthIsMissingOrAPIKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		manager *auth.Manager
+	}{
+		{name: "missing auth"},
+		{
+			name: "api key",
+			manager: auth.NewManager(auth.NewMemoryStore(auth.State{
+				Scope: auth.ScopeGlobal,
+				Method: auth.Method{
+					Type:   auth.MethodAPIKey,
+					APIKey: &auth.APIKeyMethod{Key: "sk-test"},
+				},
+			}), nil, nil),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{AuthManager: tc.manager}))
+			m.input = "/"
+			m.refreshSlashCommandFilterFromInput()
+
+			state := m.slashCommandPicker()
+			if !slashPickerContainsCommand(state, "login") {
+				t.Fatalf("expected /login in slash picker, got %+v", slashPickerCommandNames(state))
+			}
+			if slashPickerContainsCommand(state, "logout") {
+				t.Fatalf("did not expect /logout in slash picker, got %+v", slashPickerCommandNames(state))
+			}
+		})
+	}
+}
+
+func TestExactHiddenAuthSlashCommandsStillExecute(t *testing.T) {
+	cases := []struct {
+		name    string
+		manager *auth.Manager
+		input   string
+	}{
+		{
+			name: "login while oauth shows logout",
+			manager: auth.NewManager(auth.NewMemoryStore(auth.State{
+				Scope: auth.ScopeGlobal,
+				Method: auth.Method{
+					Type: auth.MethodOAuth,
+					OAuth: &auth.OAuthMethod{
+						AccessToken: "access-token",
+						TokenType:   "Bearer",
+					},
+				},
+			}), nil, nil),
+			input: "/login",
+		},
+		{
+			name: "logout while api key shows login",
+			manager: auth.NewManager(auth.NewMemoryStore(auth.State{
+				Scope: auth.ScopeGlobal,
+				Method: auth.Method{
+					Type:   auth.MethodAPIKey,
+					APIKey: &auth.APIKeyMethod{Key: "sk-test"},
+				},
+			}), nil, nil),
+			input: "/logout",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{AuthManager: tc.manager}))
+			m.input = tc.input
+
+			next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			updated := next.(*uiModel)
+			if cmd == nil {
+				t.Fatalf("expected %s to execute", tc.input)
+			}
+			if updated.Action() != UIActionLogout {
+				t.Fatalf("expected %s to execute logout/login transition, got %q", tc.input, updated.Action())
+			}
+		})
+	}
+}
+
+func TestSlashCommandPickerShowsLogoutForOAuthAuth(t *testing.T) {
+	manager := auth.NewManager(auth.NewMemoryStore(auth.State{
+		Scope: auth.ScopeGlobal,
+		Method: auth.Method{
+			Type: auth.MethodOAuth,
+			OAuth: &auth.OAuthMethod{
+				AccessToken: "access-token",
+				TokenType:   "Bearer",
+			},
+		},
+	}), nil, nil)
+	m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{AuthManager: manager}))
+	m.input = "/"
+	m.refreshSlashCommandFilterFromInput()
+
+	state := m.slashCommandPicker()
+	if !slashPickerContainsCommand(state, "logout") {
+		t.Fatalf("expected /logout in slash picker, got %+v", slashPickerCommandNames(state))
+	}
+	if slashPickerContainsCommand(state, "login") {
+		t.Fatalf("did not expect /login in slash picker, got %+v", slashPickerCommandNames(state))
+	}
+}
+
+func TestSlashCommandPickerHidesAuthCommandsWhenAuthStateCannotLoad(t *testing.T) {
+	manager := auth.NewManager(errorAuthStore{err: errors.New("permission denied")}, nil, nil)
+	m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{AuthManager: manager}))
+	m.input = "/"
+	m.refreshSlashCommandFilterFromInput()
+
+	state := m.slashCommandPicker()
+	if slashPickerContainsCommand(state, "login") || slashPickerContainsCommand(state, "logout") {
+		t.Fatalf("did not expect auth commands when auth state cannot load, got %+v", slashPickerCommandNames(state))
+	}
+	if m.authSlashCommandErr == "" {
+		t.Fatal("expected auth slash command error to be recorded")
+	}
+}
+
+func TestSlashCommandPickerRefreshesAuthStateAfterModelInit(t *testing.T) {
+	store := auth.NewMemoryStore(auth.State{
+		Scope: auth.ScopeGlobal,
+		Method: auth.Method{
+			Type:   auth.MethodAPIKey,
+			APIKey: &auth.APIKeyMethod{Key: "sk-test"},
+		},
+	})
+	manager := auth.NewManager(store, nil, nil)
+	m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{AuthManager: manager}))
+
+	if err := store.Save(context.Background(), auth.State{
+		Scope: auth.ScopeGlobal,
+		Method: auth.Method{
+			Type: auth.MethodOAuth,
+			OAuth: &auth.OAuthMethod{
+				AccessToken: "access-token",
+				TokenType:   "Bearer",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("update auth store: %v", err)
+	}
+
+	m.input = "/"
+	m.refreshSlashCommandFilterFromInput()
+	state := m.slashCommandPicker()
+	if !slashPickerContainsCommand(state, "logout") {
+		t.Fatalf("expected refreshed /logout in slash picker, got %+v", slashPickerCommandNames(state))
+	}
+	if slashPickerContainsCommand(state, "login") {
+		t.Fatalf("did not expect stale /login after auth refresh, got %+v", slashPickerCommandNames(state))
+	}
+}
+
+type errorAuthStore struct {
+	err error
+}
+
+func (s errorAuthStore) Load(context.Context) (auth.State, error) {
+	return auth.State{}, s.err
+}
+
+func (s errorAuthStore) Save(context.Context, auth.State) error {
+	return nil
 }
 
 func TestSlashCommandPickerShowsCopyOnlyWhenFinalAnswerIsAvailable(t *testing.T) {


### PR DESCRIPTION
## Summary
- Show `/logout` in the slash picker only for OAuth/saved Builder auth.
- Show `/login` for API-key auth or unauthenticated state.
- Keep exact `/login` and `/logout` execution working even when hidden from picker, and refresh picker auth state as auth changes.

Closes #107

## Verification
- `./scripts/test.sh ./cli/app -run 'TestSlashCommandPickerShowsLoginWhenAuthIsMissingOrAPIKey|TestSlashCommandPickerShowsLogoutForOAuthAuth|TestExactHiddenAuthSlashCommandsStillExecute|TestSlashCommandPickerHidesAuthCommandsWhenAuthStateCannotLoad|TestSlashCommandPickerRefreshesAuthStateAfterModelInit' -count=1`\n- `./scripts/test.sh ./cli/app`\n- `./scripts/test.sh ./cli/app/commands`\n- `./scripts/build.sh --output ./bin/builder`\n- pre-push hook: formatting, go vet, go build, go test