### PR TITLE
feat: add configurable system prompt files

### DIFF
--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -48,6 +48,7 @@ Changing `persistence_root` does not move either config file. `persistence_root`
 model = "gpt-5.5"
 thinking_level = "medium" # low, medium, high, xhigh
 model_verbosity = "medium" # or "low"
+# system_prompt_file = "SYSTEM.md" # relative to this config.toml directory
 theme = "auto" # or light / dark
 web_search = "native"
 compaction_mode = "local" # or "native" (if supported)
@@ -107,6 +108,7 @@ verbose_output = false # show in ongoing transcript
 | `model` | string | `gpt-5.5` | `BUILDER_MODEL` | `builder run --model` | Model name. If provider inference from the model name is not enough, set `provider_override` too. |
 | `thinking_level` | string | `medium` | `BUILDER_THINKING_LEVEL` | `builder run --thinking-level` | Provider-specific reasoning effort string. |
 | `model_verbosity` | string | `medium` |  |  | Text verbosity hint for supported models. Allowed: `""`, `low`, `medium`, `high`. Unsupported models ignore it. |
+| `system_prompt_file` | string | `""` |  |  | Main system prompt file. Relative paths resolve from the containing `config.toml` directory. Empty files are skipped. |
 | `theme` | string | `auto` | `BUILDER_THEME` | `builder run --theme` | TUI theme. Allowed: `auto`, `light`, `dark`. `light` and `dark` force Builder's fixed palettes. `auto` or an omitted value falls back to terminal background detection. |
 | `tui_alternate_screen` | string | `auto` | `BUILDER_TUI_ALTERNATE_SCREEN` |  | Alternate-screen policy. Allowed: `auto`, `always`, `never`. |
 | `notification_method` | string | `auto` | `BUILDER_NOTIFICATION_METHOD` |  | Terminal notification backend. Allowed: `auto`, `osc9`, `bel`. `auto` chooses `osc9` on supported terminals and falls back to `bel`. |
@@ -199,6 +201,7 @@ Notes:
 
 `[subagents.<role>]` is a file-only table for named headless subagent roles. Fast is always-present, but you can add custom agents here.
 Subagent roles inherit the main config and then override only the keys set in that role table.
+Set `system_prompt_file` inside a subagent role to use a role-specific main system prompt for `builder run --agent <role>`.
 
 ```toml
 [subagents.fast]

--- a/docs/src/content/docs/prompts.md
+++ b/docs/src/content/docs/prompts.md
@@ -16,18 +16,26 @@ Workspace instructions are included after global instructions. Builder injects t
 
 ## System Prompt
 
-`SYSTEM.md` replaces Builder's built-in main system prompt for new sessions:
+System prompt files replace Builder's built-in main system prompt for new sessions.
 
+Priority, lowest to highest:
+
+- Built-in system prompt
 - `~/.builder/SYSTEM.md`
+- `~/.builder/config.toml` `system_prompt_file`
 - `<workspace-root>/.builder/SYSTEM.md`
+- `<workspace-root>/.builder/config.toml` `system_prompt_file`
+- Selected `[subagents.<role>]` `system_prompt_file`
 
-The workspace file takes priority. If neither file exists, Builder uses the built-in system prompt.
+Only non-empty, non-whitespace prompt files count. Empty files are skipped.
 
-Builder reads and renders `SYSTEM.md` once when the session sends its first model request, stores the fully rendered result in the `system_prompt` session metadata, and reuses that snapshot for later requests. After a session has stored that snapshot, editing `SYSTEM.md` affects new sessions only. Sessions without `system_prompt` capture the current `SYSTEM.md` on their next model request.
+`system_prompt_file` paths are resolved relative to the containing `config.toml` directory unless absolute. If no prompt file has content, Builder uses the built-in system prompt.
+
+Builder reads and renders the selected system prompt file once when the session sends its first model request, stores the fully rendered result in the `system_prompt` session metadata, and reuses that snapshot for later requests. After a session has stored that snapshot, editing prompt files affects new sessions only. Sessions without `system_prompt` capture the current prompt file on their next model request.
 
 ## Placeholders
 
-`SYSTEM.md` uses Go template syntax with these fields:
+System prompt files use Go template syntax with these fields:
 
 | Placeholder | Value |
 | --- | --- |

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,6 +6,18 @@ repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$repo_root"
 
+if [ "${BUILDER_TEST_INHERIT_ENV:-}" != "1" ]; then
+    while IFS= read -r name; do
+        case "$name" in
+            BUILDER_TEST_INHERIT_ENV)
+                ;;
+            BUILDER_*)
+                unset "$name"
+                ;;
+        esac
+    done < <(compgen -e BUILDER_ || true)
+fi
+
 log_file="$(mktemp -t builder-go-test.XXXXXX.log)"
 cleanup() {
     rm -f "$log_file"

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -404,6 +404,36 @@ func TestApplyRunPromptOverridesFastRoleWarnsWhenHeuristicDoesNothing(t *testing
 	}
 }
 
+func TestApplySubagentRoleOverridesAppendsRoleSystemPromptFile(t *testing.T) {
+	mainPrompt := filepath.Join(t.TempDir(), "main-system.md")
+	rolePrompt := filepath.Join(t.TempDir(), "worker-system.md")
+	settings := config.Settings{
+		SystemPromptFiles: []config.SystemPromptFile{{Path: mainPrompt, Scope: config.SystemPromptFileScopeHomeConfig}},
+	}
+	role := config.SubagentRole{
+		Settings: config.Settings{
+			SystemPromptFile:  "worker-system.md",
+			SystemPromptFiles: []config.SystemPromptFile{{Path: rolePrompt, Scope: config.SystemPromptFileScopeSubagent}},
+		},
+		Sources: map[string]string{"system_prompt_file": "file"},
+	}
+	applySubagentRoleOverrides(&settings, role, true)
+
+	if settings.SystemPromptFile != "worker-system.md" {
+		t.Fatalf("system_prompt_file = %q, want worker-system.md", settings.SystemPromptFile)
+	}
+	files := settings.SystemPromptFiles
+	if len(files) != 2 {
+		t.Fatalf("system prompt files = %+v, want base and role entries", files)
+	}
+	if got := files[0]; got.Path != mainPrompt || got.Scope != config.SystemPromptFileScopeHomeConfig {
+		t.Fatalf("base system prompt file = %+v, want %q %s", got, mainPrompt, config.SystemPromptFileScopeHomeConfig)
+	}
+	if got := files[1]; got.Path != rolePrompt || got.Scope != config.SystemPromptFileScopeSubagent {
+		t.Fatalf("role system prompt file = %+v, want %q %s", got, rolePrompt, config.SystemPromptFileScopeSubagent)
+	}
+}
+
 func TestApplyRunPromptOverridesFastRoleAppliesBuiltInHeuristics(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()

--- a/server/launch/subagents.go
+++ b/server/launch/subagents.go
@@ -81,6 +81,9 @@ func applySubagentRoleOverrides(settings *config.Settings, role config.SubagentR
 			settings.ThinkingLevel = role.Settings.ThinkingLevel
 		case "model_verbosity":
 			settings.ModelVerbosity = role.Settings.ModelVerbosity
+		case "system_prompt_file":
+			settings.SystemPromptFile = role.Settings.SystemPromptFile
+			settings.SystemPromptFiles = append(settings.SystemPromptFiles, role.Settings.SystemPromptFiles...)
 		case "model_capabilities.supports_reasoning_effort":
 			settings.ModelCapabilities.SupportsReasoningEffort = role.Settings.ModelCapabilities.SupportsReasoningEffort
 		case "model_capabilities.supports_vision_inputs":
@@ -254,6 +257,7 @@ func applyReviewerInheritance(settings *config.Settings, sources map[string]stri
 
 func cloneSettings(in config.Settings) config.Settings {
 	out := in
+	out.SystemPromptFiles = append([]config.SystemPromptFile(nil), in.SystemPromptFiles...)
 	out.EnabledTools = cloneEnabledToolSet(in.EnabledTools)
 	out.SkillToggles = cloneStringBoolMap(in.SkillToggles)
 	out.Subagents = cloneSubagentRoles(in.Subagents)

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -103,6 +103,7 @@ type Config struct {
 	ProviderCapabilitiesOverride  *llm.ProviderCapabilities
 	EnabledTools                  []toolspec.ID
 	DisabledSkills                map[string]bool
+	SystemPromptFiles             []config.SystemPromptFile
 	AutoCompactTokenLimit         int
 	PreSubmitCompactionLeadTokens int
 	ContextWindowTokens           int

--- a/server/runtime/engine_part2_test.go
+++ b/server/runtime/engine_part2_test.go
@@ -4,11 +4,13 @@ import (
 	"builder/server/llm"
 	"builder/server/session"
 	"builder/server/tools"
+	"builder/shared/config"
 	"builder/shared/toolspec"
 	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -291,7 +293,7 @@ func TestLegacyLockedSessionBackfillsSystemPromptSnapshotOnce(t *testing.T) {
 	}
 }
 
-func TestEmptySystemPromptSnapshotIsReused(t *testing.T) {
+func TestEmptySystemPromptFileIsSkippedAndFallbackSnapshotIsReused(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
@@ -328,11 +330,12 @@ func TestEmptySystemPromptSnapshotIsReused(t *testing.T) {
 	if _, err := eng.SubmitUserMessage(context.Background(), "hello"); err != nil {
 		t.Fatalf("submit: %v", err)
 	}
-	if got := client.calls[0].SystemPrompt; got != "" {
-		t.Fatalf("first system prompt = %q, want empty", got)
+	firstPrompt := client.calls[0].SystemPrompt
+	if strings.TrimSpace(firstPrompt) == "" || firstPrompt == "changed" {
+		t.Fatalf("first system prompt = %q, want built-in fallback", firstPrompt)
 	}
-	if locked := store.Meta().Locked; locked == nil || !locked.HasSystemPrompt || locked.SystemPrompt != "" {
-		t.Fatalf("locked system prompt snapshot = %+v, want empty marked snapshot", locked)
+	if locked := store.Meta().Locked; locked == nil || !locked.HasSystemPrompt || locked.SystemPrompt != firstPrompt {
+		t.Fatalf("locked system prompt snapshot = %+v, want built-in fallback snapshot", locked)
 	}
 	if err := eng.Close(); err != nil {
 		t.Fatalf("close engine: %v", err)
@@ -342,8 +345,8 @@ func TestEmptySystemPromptSnapshotIsReused(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reopen store: %v", err)
 	}
-	if locked := reopened.Meta().Locked; locked == nil || !locked.HasSystemPrompt || locked.SystemPrompt != "" {
-		t.Fatalf("reopened locked system prompt snapshot = %+v, want empty marked snapshot", locked)
+	if locked := reopened.Meta().Locked; locked == nil || !locked.HasSystemPrompt || locked.SystemPrompt != firstPrompt {
+		t.Fatalf("reopened locked system prompt snapshot = %+v, want built-in fallback snapshot", locked)
 	}
 	reopenedClient := &fakeClient{responses: []llm.Response{{
 		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "still ok"},
@@ -361,10 +364,10 @@ func TestEmptySystemPromptSnapshotIsReused(t *testing.T) {
 	if _, err := reopenedEngine.SubmitUserMessage(context.Background(), "again"); err != nil {
 		t.Fatalf("submit again: %v", err)
 	}
-	if got := reopenedClient.calls[0].SystemPrompt; got != "" {
-		t.Fatalf("second system prompt = %q, want empty snapshot", got)
+	if got := reopenedClient.calls[0].SystemPrompt; got != firstPrompt {
+		t.Fatalf("second system prompt = %q, want locked fallback snapshot %q", got, firstPrompt)
 	}
-	if locked := reopened.Meta().Locked; locked == nil || !locked.HasSystemPrompt || locked.SystemPrompt != "" {
+	if locked := reopened.Meta().Locked; locked == nil || !locked.HasSystemPrompt || locked.SystemPrompt != firstPrompt {
 		t.Fatalf("stored system prompt snapshot changed: %+v", locked)
 	}
 }
@@ -855,5 +858,97 @@ func TestSetReviewerEnabledLazyInitializesReviewerClient(t *testing.T) {
 	}
 	if !changed || mode != "edits" {
 		t.Fatalf("expected changed=true mode=edits, got changed=%v mode=%q", changed, mode)
+	}
+}
+
+func TestReadSystemPromptTemplateUsesConfiguredPriorityAndSkipsEmptyFiles(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	for _, dir := range []string{filepath.Join(home, agentsGlobalDirName), filepath.Join(workspace, agentsGlobalDirName)} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	homeConfigPrompt := filepath.Join(home, "home-config-system.md")
+	workspaceConfigPrompt := filepath.Join(workspace, "workspace-config-system.md")
+	writeTestFile(t, filepath.Join(home, agentsGlobalDirName, systemPromptFileName), "home SYSTEM")
+	writeTestFile(t, homeConfigPrompt, "home config")
+	writeTestFile(t, filepath.Join(workspace, agentsGlobalDirName, systemPromptFileName), "workspace SYSTEM")
+	writeTestFile(t, workspaceConfigPrompt, "workspace config")
+
+	opts := systemPromptSnapshotOptions{
+		WorkspaceRoot: workspace,
+		SystemPromptFiles: []config.SystemPromptFile{
+			{Path: homeConfigPrompt, Scope: config.SystemPromptFileScopeHomeConfig},
+			{Path: workspaceConfigPrompt, Scope: config.SystemPromptFileScopeWorkspaceConfig},
+		},
+	}
+	template, sourcePath, ok, err := readSystemPromptTemplate(opts)
+	if err != nil {
+		t.Fatalf("read system prompt template: %v", err)
+	}
+	if !ok || template != "workspace config" || sourcePath != workspaceConfigPrompt {
+		t.Fatalf("template=%q sourcePath=%q ok=%t, want workspace config from %q", template, sourcePath, ok, workspaceConfigPrompt)
+	}
+
+	writeTestFile(t, workspaceConfigPrompt, " \n\t")
+	template, sourcePath, ok, err = readSystemPromptTemplate(opts)
+	if err != nil {
+		t.Fatalf("read system prompt template after empty workspace config: %v", err)
+	}
+	if !ok || template != "workspace SYSTEM" {
+		t.Fatalf("template=%q sourcePath=%q ok=%t, want workspace SYSTEM", template, sourcePath, ok)
+	}
+
+	writeTestFile(t, filepath.Join(workspace, agentsGlobalDirName, systemPromptFileName), "\n")
+	template, sourcePath, ok, err = readSystemPromptTemplate(opts)
+	if err != nil {
+		t.Fatalf("read system prompt template after empty workspace SYSTEM: %v", err)
+	}
+	if !ok || template != "home config" || sourcePath != homeConfigPrompt {
+		t.Fatalf("template=%q sourcePath=%q ok=%t, want home config from %q", template, sourcePath, ok, homeConfigPrompt)
+	}
+
+	writeTestFile(t, homeConfigPrompt, " ")
+	template, sourcePath, ok, err = readSystemPromptTemplate(opts)
+	if err != nil {
+		t.Fatalf("read system prompt template after empty home config: %v", err)
+	}
+	if !ok || template != "home SYSTEM" {
+		t.Fatalf("template=%q sourcePath=%q ok=%t, want home SYSTEM", template, sourcePath, ok)
+	}
+
+	writeTestFile(t, filepath.Join(home, agentsGlobalDirName, systemPromptFileName), "\n")
+	template, sourcePath, ok, err = readSystemPromptTemplate(opts)
+	if err != nil {
+		t.Fatalf("read system prompt template after all files empty: %v", err)
+	}
+	if ok || template != "" || sourcePath != "" {
+		t.Fatalf("template=%q sourcePath=%q ok=%t, want built-in fallback marker", template, sourcePath, ok)
+	}
+}
+
+func TestReadSystemPromptTemplateSubagentConfigOverridesWorkspaceConfig(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	subagentPrompt := filepath.Join(home, "subagent-system.md")
+	workspaceConfigPrompt := filepath.Join(workspace, "workspace-config-system.md")
+	writeTestFile(t, subagentPrompt, "subagent")
+	writeTestFile(t, workspaceConfigPrompt, "workspace config")
+
+	template, sourcePath, ok, err := readSystemPromptTemplate(systemPromptSnapshotOptions{
+		WorkspaceRoot: workspace,
+		SystemPromptFiles: []config.SystemPromptFile{
+			{Path: workspaceConfigPrompt, Scope: config.SystemPromptFileScopeWorkspaceConfig},
+			{Path: subagentPrompt, Scope: config.SystemPromptFileScopeSubagent},
+		},
+	})
+	if err != nil {
+		t.Fatalf("read system prompt template: %v", err)
+	}
+	if !ok || template != "subagent" || sourcePath != subagentPrompt {
+		t.Fatalf("template=%q sourcePath=%q ok=%t, want subagent from %q", template, sourcePath, ok, subagentPrompt)
 	}
 }

--- a/server/runtime/system_prompt_snapshot.go
+++ b/server/runtime/system_prompt_snapshot.go
@@ -9,10 +9,12 @@ import (
 
 	"builder/prompts"
 	"builder/server/session"
+	"builder/shared/config"
 )
 
 type systemPromptSnapshotOptions struct {
-	WorkspaceRoot string
+	WorkspaceRoot     string
+	SystemPromptFiles []config.SystemPromptFile
 }
 
 func (e *Engine) buildSystemPromptSnapshot(locked session.LockedContract) (string, error) {
@@ -27,14 +29,17 @@ func (e *Engine) buildSystemPromptSnapshotForRoot(locked session.LockedContract,
 	args := prompts.SystemPromptTemplateArgs{
 		EstimatedToolCallsForContext: e.estimatedToolCallsForLockedContext(locked),
 	}
-	template, sourcePath, hasCustom, err := readSystemPromptTemplate(systemPromptSnapshotOptions{WorkspaceRoot: workspaceRoot})
+	template, sourcePath, hasCustom, err := readSystemPromptTemplate(systemPromptSnapshotOptions{
+		WorkspaceRoot:     workspaceRoot,
+		SystemPromptFiles: e.cfg.SystemPromptFiles,
+	})
 	if err != nil {
 		return "", err
 	}
 	if hasCustom {
 		rendered, err := prompts.RenderCustomSystemPrompt(template, includeToolPreambles, args)
 		if err != nil {
-			return "", fmt.Errorf("render SYSTEM.md %q: %w", sourcePath, err)
+			return "", fmt.Errorf("render system prompt file %q: %w", sourcePath, err)
 		}
 		return rendered, nil
 	}
@@ -69,38 +74,61 @@ func (e *Engine) systemPromptWorkspaceRootLocked() string {
 }
 
 func readSystemPromptTemplate(opts systemPromptSnapshotOptions) (string, string, bool, error) {
-	paths, err := systemPromptPaths(opts.WorkspaceRoot)
+	paths, err := systemPromptPathsWithConfig(opts)
 	if err != nil {
 		return "", "", false, err
 	}
 	for _, path := range paths {
 		data, readErr := os.ReadFile(path)
 		if readErr == nil {
-			return string(data), path, true, nil
+			template := strings.TrimSpace(string(data))
+			if template == "" {
+				continue
+			}
+			return template, path, true, nil
 		}
 		if errors.Is(readErr, os.ErrNotExist) {
 			continue
 		}
-		return "", "", false, fmt.Errorf("read SYSTEM.md %q: %w", path, readErr)
+		return "", "", false, fmt.Errorf("read system prompt file %q: %w", path, readErr)
 	}
 	return "", "", false, nil
 }
 
 func systemPromptPaths(workspaceRoot string) ([]string, error) {
-	paths := make([]string, 0, 2)
+	return systemPromptPathsWithConfig(systemPromptSnapshotOptions{WorkspaceRoot: workspaceRoot})
+}
+
+func systemPromptPathsWithConfig(opts systemPromptSnapshotOptions) ([]string, error) {
+	paths := make([]string, 0, 2+len(opts.SystemPromptFiles))
 	addPath := func(path string) {
 		trimmed := strings.TrimSpace(path)
 		if trimmed != "" {
 			paths = append(paths, trimmed)
 		}
 	}
-	if trimmed := strings.TrimSpace(workspaceRoot); trimmed != "" {
-		absWorkspace, err := filepath.Abs(trimmed)
+	absWorkspace := ""
+	if trimmed := strings.TrimSpace(opts.WorkspaceRoot); trimmed != "" {
+		var err error
+		absWorkspace, err = filepath.Abs(trimmed)
 		if err != nil {
 			return nil, fmt.Errorf("resolve workspace root: %w", err)
 		}
+	}
+	addConfigPaths := func(scope config.SystemPromptFileScope) {
+		for i := len(opts.SystemPromptFiles) - 1; i >= 0; i-- {
+			candidate := opts.SystemPromptFiles[i]
+			if candidate.Scope == scope {
+				addPath(candidate.Path)
+			}
+		}
+	}
+	addConfigPaths(config.SystemPromptFileScopeSubagent)
+	addConfigPaths(config.SystemPromptFileScopeWorkspaceConfig)
+	if absWorkspace != "" {
 		addPath(filepath.Join(absWorkspace, agentsGlobalDirName, systemPromptFileName))
 	}
+	addConfigPaths(config.SystemPromptFileScopeHomeConfig)
 	if home, err := os.UserHomeDir(); err == nil {
 		addPath(filepath.Join(home, agentsGlobalDirName, systemPromptFileName))
 	}

--- a/server/runtimewire/wiring.go
+++ b/server/runtimewire/wiring.go
@@ -128,6 +128,7 @@ func NewRuntimeWiringWithBackground(store *session.Store, active config.Settings
 		}(),
 		EnabledTools:                  enabledTools,
 		DisabledSkills:                config.DisabledSkillToggles(active),
+		SystemPromptFiles:             active.SystemPromptFiles,
 		AutoCompactTokenLimit:         active.ContextCompactionThresholdTokens,
 		PreSubmitCompactionLeadTokens: active.PreSubmitCompactionLeadTokens,
 		ContextWindowTokens:           active.ModelContextWindow,

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -82,10 +82,25 @@ type SubagentRole struct {
 	Sources  map[string]string
 }
 
+type SystemPromptFileScope string
+
+const (
+	SystemPromptFileScopeHomeConfig      SystemPromptFileScope = "home_config"
+	SystemPromptFileScopeWorkspaceConfig SystemPromptFileScope = "workspace_config"
+	SystemPromptFileScopeSubagent        SystemPromptFileScope = "subagent"
+)
+
+type SystemPromptFile struct {
+	Path  string
+	Scope SystemPromptFileScope
+}
+
 type Settings struct {
 	Model                            string
 	ThinkingLevel                    string
 	ModelVerbosity                   ModelVerbosity
+	SystemPromptFile                 string
+	SystemPromptFiles                []SystemPromptFile
 	ModelCapabilities                ModelCapabilitiesOverride
 	Theme                            string
 	TUIAlternateScreen               TUIAlternateScreenPolicy

--- a/shared/config/config_load.go
+++ b/shared/config/config_load.go
@@ -75,8 +75,14 @@ func load(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions) (A
 	if err := configRegistry.applyFile(homeFileConfig, homeSettingsPath, &state, sources); err != nil {
 		return App{}, err
 	}
+	if err := appendSystemPromptFileFromConfig(homeFileConfig, homeSettingsPath, SystemPromptFileScopeHomeConfig, &state); err != nil {
+		return App{}, err
+	}
 	if includeWorkspaceLayer {
 		if err := configRegistry.applyFile(workspaceFileConfig, workspaceSettingsPath, &state, sources); err != nil {
+			return App{}, err
+		}
+		if err := appendSystemPromptFileFromConfig(workspaceFileConfig, workspaceSettingsPath, SystemPromptFileScopeWorkspaceConfig, &state); err != nil {
 			return App{}, err
 		}
 	}
@@ -127,4 +133,39 @@ func load(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions) (A
 			Sources:                       sources,
 		},
 	}, nil
+}
+
+func appendSystemPromptFileFromConfig(raw settingsFile, settingsPath string, scope SystemPromptFileScope, state *settingsState) error {
+	path, ok, err := lookupFileString(raw, []string{"system_prompt_file"})
+	if err != nil || !ok {
+		return err
+	}
+	resolved, err := resolveConfigRelativePath(path, settingsPath)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(resolved) == "" {
+		return nil
+	}
+	state.Settings.SystemPromptFiles = append(state.Settings.SystemPromptFiles, SystemPromptFile{Path: resolved, Scope: scope})
+	return nil
+}
+
+func resolveConfigRelativePath(path string, settingsPath string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", nil
+	}
+	expanded, err := expandTildePath(trimmed)
+	if err != nil {
+		return "", err
+	}
+	if filepath.IsAbs(expanded) {
+		return filepath.Abs(expanded)
+	}
+	baseDir := strings.TrimSpace(filepath.Dir(settingsPath))
+	if baseDir == "" || baseDir == "." {
+		return filepath.Abs(expanded)
+	}
+	return filepath.Abs(filepath.Join(baseDir, expanded))
 }

--- a/shared/config/config_registry.go
+++ b/shared/config/config_registry.go
@@ -94,6 +94,13 @@ func newSettingsRegistry() settingsRegistry {
 			nil,
 			normalizeModelVerbosity,
 			settingDocOptions{}),
+		newStringSetting("system_prompt_file", "",
+			func(state *settingsState, value string) { state.Settings.SystemPromptFile = value },
+			func(state settingsState) string { return state.Settings.SystemPromptFile },
+			"",
+			nil,
+			nil,
+			settingDocOptions{commented: true}),
 		newBoolSetting("model_capabilities.supports_reasoning_effort", false,
 			func(state *settingsState, value bool) {
 				state.Settings.ModelCapabilities.SupportsReasoningEffort = value
@@ -933,6 +940,15 @@ func parseSubagentRole(raw settingsFile, settingsPath string, roleKey string) (S
 	}
 	if err := validateSubagentRoleState(roleState, explicitSources); err != nil {
 		return SubagentRole{}, fmt.Errorf("invalid subagents.%s: %w", roleKey, err)
+	}
+	if _, ok := explicitSources["system_prompt_file"]; ok {
+		resolved, err := resolveConfigRelativePath(roleState.Settings.SystemPromptFile, settingsPath)
+		if err != nil {
+			return SubagentRole{}, fmt.Errorf("invalid subagents.%s: %w", roleKey, err)
+		}
+		if strings.TrimSpace(resolved) != "" {
+			roleState.Settings.SystemPromptFiles = []SystemPromptFile{{Path: resolved, Scope: SystemPromptFileScopeSubagent}}
+		}
 	}
 	roleState.Settings.Subagents = nil
 	return SubagentRole{Settings: roleState.Settings, Sources: explicitSources}, nil

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -297,6 +297,42 @@ func TestLoadSubagentRoleFromFile(t *testing.T) {
 	}
 }
 
+func TestAppendSystemPromptFileFromConfigResolvesConfigRelativePath(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), ".builder", "config.toml")
+	state := configRegistry.defaultState()
+
+	if err := appendSystemPromptFileFromConfig(
+		settingsFile{"system_prompt_file": "prompts/SYSTEM.md"},
+		configPath,
+		SystemPromptFileScopeWorkspaceConfig,
+		&state,
+	); err != nil {
+		t.Fatalf("append system prompt file: %v", err)
+	}
+
+	want := filepath.Join(filepath.Dir(configPath), "prompts", "SYSTEM.md")
+	if got := state.Settings.SystemPromptFiles; len(got) != 1 || got[0].Path != want || got[0].Scope != SystemPromptFileScopeWorkspaceConfig {
+		t.Fatalf("system prompt files = %+v, want %q %s", got, want, SystemPromptFileScopeWorkspaceConfig)
+	}
+}
+
+func TestParseSubagentRoleSystemPromptFileResolvesConfigRelativePath(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), ".builder", "config.toml")
+
+	role, err := parseSubagentRole(settingsFile{"system_prompt_file": "fast-system.md"}, configPath, "fast")
+	if err != nil {
+		t.Fatalf("parse subagent role: %v", err)
+	}
+
+	want := filepath.Join(filepath.Dir(configPath), "fast-system.md")
+	if got := role.Settings.SystemPromptFiles; len(got) != 1 || got[0].Path != want || got[0].Scope != SystemPromptFileScopeSubagent {
+		t.Fatalf("subagent system prompt files = %+v, want %q %s", got, want, SystemPromptFileScopeSubagent)
+	}
+	if role.Sources["system_prompt_file"] != "file" {
+		t.Fatalf("system_prompt_file source = %q, want file", role.Sources["system_prompt_file"])
+	}
+}
+
 func TestLoadSubagentRoleRejectsNestedSubagentsTable(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()


### PR DESCRIPTION
## Summary
- add system_prompt_file config support for global/workspace config layers
- apply non-empty prompt-file precedence including SYSTEM.md files and subagent overrides
- document prompt precedence and harden scripts/test.sh against inherited BUILDER_* env

## Verification
- ./scripts/test.sh ./shared/config ./server/runtime ./server/launch ./scripts
- BUILDER_PERSISTENCE_ROOT=/__builder_test_must_not_touch__ BUILDER_SERVER_HOST=203.0.113.1 BUILDER_SERVER_PORT=1 ./scripts/test.sh ./shared/config -run TestLoadUsesDefaultsWithoutCreatingConfigOnFirstUse -count=1
- ./scripts/build.sh --output ./bin/builder
- git diff --check

Closes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `system_prompt_file` configuration setting to specify a system prompt file location; can be overridden per subagent role for role-specific prompts.

* **Documentation**
  * Updated configuration documentation with the new `system_prompt_file` setting.
  * Clarified system prompt precedence rules, including handling of empty/whitespace files with fallback to built-in prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->