### PR TITLE
fix: use session root for statusline git branch

### DIFF
--- a/cli/app/ui_status.go
+++ b/cli/app/ui_status.go
@@ -445,8 +445,8 @@ func (defaultUIStatusCollector) CollectAuth(ctx context.Context, req uiStatusReq
 	return result
 }
 
-func (defaultUIStatusCollector) CollectGit(ctx context.Context, _ uiStatusRequest, base uiStatusSnapshot) uiStatusGitStageResult {
-	return uiStatusGitStageResult{Git: collectGitStatus(ctx, base.Workdir)}
+func (defaultUIStatusCollector) CollectGit(ctx context.Context, req uiStatusRequest, _ uiStatusSnapshot) uiStatusGitStageResult {
+	return uiStatusGitStageResult{Git: collectGitStatus(ctx, statusGitRoot(req))}
 }
 
 func (defaultUIStatusCollector) CollectEnvironment(_ context.Context, req uiStatusRequest, _ uiStatusSnapshot) uiStatusEnvironmentStageResult {
@@ -498,6 +498,20 @@ func statusWorkdir(workspaceRoot string, target clientui.SessionExecutionTarget)
 	}
 	if cwd, err := os.Getwd(); err == nil {
 		return strings.TrimSpace(cwd)
+	}
+	return ""
+}
+
+func statusGitRoot(req uiStatusRequest) string {
+	target := statusExecutionTarget(req)
+	if worktreeRoot := strings.TrimSpace(target.WorktreeRoot); worktreeRoot != "" {
+		return worktreeRoot
+	}
+	if workspaceRoot := strings.TrimSpace(req.WorkspaceRoot); workspaceRoot != "" {
+		return workspaceRoot
+	}
+	if workspaceRoot := strings.TrimSpace(target.WorkspaceRoot); workspaceRoot != "" {
+		return workspaceRoot
 	}
 	return ""
 }
@@ -1112,7 +1126,7 @@ func (m *uiModel) statusRefreshCmd() tea.Cmd {
 			case uiStatusSectionAuth:
 				cmds = append(cmds, m.statusAuthRefreshCmd(token, statusAuthCacheKey(request), request, progressive, base))
 			case uiStatusSectionGit:
-				cmds = append(cmds, m.statusGitRefreshCmd(token, statusGitCacheKey(base.Workdir), request, progressive, base))
+				cmds = append(cmds, m.statusGitRefreshCmd(token, statusGitCacheKey(statusGitRoot(request)), request, progressive, base))
 			case uiStatusSectionEnvironment:
 				cmds = append(cmds, m.statusEnvironmentRefreshCmd(token, statusEnvironmentCacheKey(request), request, progressive, base))
 			}
@@ -1134,14 +1148,6 @@ func (m *uiModel) statusRefreshCmd() tea.Cmd {
 
 func (m *uiModel) statusLineGitStartupCmd() tea.Cmd {
 	request := m.newStatusRequest(time.Now())
-	workdir := statusWorkdir(request.WorkspaceRoot, statusExecutionTarget(request))
-	trimmedWorkdir := strings.TrimSpace(workdir)
-	if trimmedWorkdir == "" {
-		return nil
-	}
-	if info, err := os.Stat(trimmedWorkdir); err != nil || !info.IsDir() {
-		return nil
-	}
 	token := m.status.refreshToken
 	request.CurrentTime = time.Now()
 	collector := m.statusCollector
@@ -1153,7 +1159,13 @@ func (m *uiModel) statusLineGitStartupCmd() tea.Cmd {
 		progressive = defaultUIStatusCollector{}
 	}
 	base := progressive.CollectBase(request)
-	cacheKey := statusGitCacheKey(base.Workdir)
+	gitRoot := statusGitRoot(request)
+	if trimmedGitRoot := strings.TrimSpace(gitRoot); trimmedGitRoot == "" {
+		return nil
+	} else if info, err := os.Stat(trimmedGitRoot); err != nil || !info.IsDir() {
+		return nil
+	}
+	cacheKey := statusGitCacheKey(gitRoot)
 	return m.statusGitRefreshCmd(token, cacheKey, request, progressive, base, true)
 }
 

--- a/cli/app/ui_status_part2_test.go
+++ b/cli/app/ui_status_part2_test.go
@@ -4,6 +4,7 @@ import (
 	"builder/server/auth"
 	"builder/server/sessionview"
 	"builder/shared/client"
+	"builder/shared/clientui"
 	"builder/shared/config"
 	"context"
 	tea "github.com/charmbracelet/bubbletea"
@@ -32,6 +33,41 @@ func TestStatusLineGitStartupRefreshCachesBranch(t *testing.T) {
 	status := stripANSIAndTrimRight(updated.renderStatusLine(120, uiThemeStyles("dark")))
 	if !strings.Contains(status, "statusline-branch") {
 		t.Fatalf("expected startup git branch in status line, got %q", status)
+	}
+}
+
+func TestStatusLineGitStartupUsesRuntimeWorktreeRootBranch(t *testing.T) {
+	processRoot := initStatusLineGitRepo(t, "main")
+	workspaceRoot := initStatusLineGitRepo(t, "workspace-branch")
+	worktreeRoot := initStatusLineGitRepo(t, "worktree-branch")
+	t.Chdir(processRoot)
+
+	runtimeClient := &runtimeControlFakeClient{sessionView: clientui.RuntimeSessionView{
+		ExecutionTarget: clientui.SessionExecutionTarget{
+			WorkspaceRoot:    workspaceRoot,
+			WorktreeRoot:     worktreeRoot,
+			EffectiveWorkdir: processRoot,
+		},
+	}}
+	search := newStubUIPathReferenceSearch()
+	close(search.events)
+	m := newProjectedTestUIModel(
+		runtimeClient,
+		closedProjectedRuntimeEvents(),
+		closedAskEvents(),
+		WithUIPathReferenceSearch(search),
+		WithUIStatusConfig(uiStatusConfig{WorkspaceRoot: workspaceRoot}),
+	)
+
+	updated := drainStatusLineStartupCommands(t, m, m.Init())
+	status := stripANSIAndTrimRight(updated.renderStatusLine(120, uiThemeStyles("dark")))
+	if !strings.Contains(status, "worktree-branch") {
+		t.Fatalf("expected worktree git branch in status line, got %q", status)
+	}
+	for _, unexpected := range []string{"main", "workspace-branch"} {
+		if strings.Contains(status, unexpected) {
+			t.Fatalf("did not expect %q branch in status line, got %q", unexpected, status)
+		}
 	}
 }
 

--- a/cli/app/ui_status_repository.go
+++ b/cli/app/ui_status_repository.go
@@ -80,7 +80,7 @@ func (r *memoryUIStatusRepository) SeedSnapshot(req uiStatusRequest, base uiStat
 		seed.PendingSections = append(seed.PendingSections, uiStatusSectionAuth)
 	}
 
-	gitEntry, gitCached := r.gitByKey[statusGitCacheKey(base.Workdir)]
+	gitEntry, gitCached := r.gitByKey[statusGitCacheKey(statusGitRoot(req))]
 	if gitCached {
 		seed.Snapshot.Git = gitEntry.result.Git
 	}

--- a/cli/app/ui_status_test.go
+++ b/cli/app/ui_status_test.go
@@ -6,6 +6,7 @@ import (
 	"builder/server/runtime"
 	"builder/server/session"
 	"builder/server/tools"
+	"builder/shared/clientui"
 	"builder/shared/config"
 	"context"
 	tea "github.com/charmbracelet/bubbletea"
@@ -504,6 +505,57 @@ func TestCollectGitStatusSurfacesUnexpectedErrors(t *testing.T) {
 	}
 	if !strings.Contains(git.Error, context.Canceled.Error()) {
 		t.Fatalf("expected git error to include underlying failure, got %+v", git)
+	}
+}
+
+func TestStatusCollectorUsesRuntimeWorkspaceRootForGitBranch(t *testing.T) {
+	processRoot := initStatusLineGitRepo(t, "main")
+	sessionRoot := initStatusLineGitRepo(t, "session-branch")
+	t.Chdir(processRoot)
+	collector := defaultUIStatusCollector{}
+
+	snapshot, err := collector.Collect(context.Background(), uiStatusRequest{
+		Runtime: &runtimeControlFakeClient{sessionView: clientui.RuntimeSessionView{
+			ExecutionTarget: clientui.SessionExecutionTarget{
+				EffectiveWorkdir: processRoot,
+			},
+		}},
+		WorkspaceRoot: sessionRoot,
+	})
+	if err != nil {
+		t.Fatalf("collect status: %v", err)
+	}
+	if !snapshot.Git.Visible {
+		t.Fatalf("expected git section visible for session root, got %+v", snapshot.Git)
+	}
+	if snapshot.Git.Branch != "session-branch" {
+		t.Fatalf("git branch = %q, want session-branch", snapshot.Git.Branch)
+	}
+}
+
+func TestStatusCollectorPrefersWorktreeRootForGitBranch(t *testing.T) {
+	workspaceRoot := initStatusLineGitRepo(t, "main")
+	worktreeRoot := initStatusLineGitRepo(t, "worktree-branch")
+	collector := defaultUIStatusCollector{}
+
+	snapshot, err := collector.Collect(context.Background(), uiStatusRequest{
+		Runtime: &runtimeControlFakeClient{sessionView: clientui.RuntimeSessionView{
+			ExecutionTarget: clientui.SessionExecutionTarget{
+				WorkspaceRoot:    workspaceRoot,
+				WorktreeRoot:     worktreeRoot,
+				EffectiveWorkdir: filepath.Join(worktreeRoot, "pkg"),
+			},
+		}},
+		WorkspaceRoot: workspaceRoot,
+	})
+	if err != nil {
+		t.Fatalf("collect status: %v", err)
+	}
+	if !snapshot.Git.Visible {
+		t.Fatalf("expected git section visible for worktree root, got %+v", snapshot.Git)
+	}
+	if snapshot.Git.Branch != "worktree-branch" {
+		t.Fatalf("git branch = %q, want worktree-branch", snapshot.Git.Branch)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Resolve statusline git branch from the current session/worktree root instead of the CLI process cwd.
- Keep git status cache keyed by the same session git root.
- Add collector and rendered statusline regressions for process-cwd/workspace/worktree mismatches.

## Verification
- ./scripts/test.sh ./cli/app -run 'Test(StatusLineGitStartupUsesRuntimeWorktreeRootBranch|StatusCollectorUsesRuntimeWorkspaceRootForGitBranch|StatusCollectorPrefersWorktreeRootForGitBranch|StatusLineGitStartupRefreshCachesBranch|StatusRepositoryNormalizesGitCacheKeysAcrossSlashStyles|CollectGitStatus)'
- ./scripts/build.sh --output ./bin/builder
- git push hook: formatting, go vet, go build, go test