### PR TITLE
Allow supervisor system prompt override

### DIFF
--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -76,6 +76,7 @@ postprocessing_mode = "all" # shell output token optimizations by Builder, or "a
 frequency = "edits"
 timeout_seconds = 60
 verbose_output = false # show in ongoing transcript
+# system_prompt_file = "~/.builder/reviewer_system_prompt.md"
 
 # custom subagent roles config, fast is the default one, always provided
 [subagents.fast]
@@ -147,6 +148,7 @@ Configure the supervisor agent that oversees model changes.
 | `reviewer.frequency` | string | `edits` | `BUILDER_REVIEWER_FREQUENCY` | Allowed: `off`, `all`, `edits`. `all` runs the reviewer after every completed assistant turn. `edits` runs it only after successful `patch` edits. |
 | `reviewer.model` | string | inherits `model` | `BUILDER_REVIEWER_MODEL` | Separate model for the reviewer pass. If unset, Builder uses main `model`. |
 | `reviewer.thinking_level` | string | inherits `thinking_level` | `BUILDER_REVIEWER_THINKING_LEVEL` | Allowed: `low`, `medium`, `high`, `xhigh`. |
+| `reviewer.system_prompt_file` | string | `""` |  | Path to a custom supervisor system prompt file. Workspace config overrides global config; no CLI or environment override is provided. |
 | `reviewer.timeout_seconds` | int | `60` | `BUILDER_REVIEWER_TIMEOUT_SECONDS` | Reviewer HTTP timeout. Must be `> 0`. |
 | `reviewer.verbose_output` | bool | `false` | `BUILDER_REVIEWER_VERBOSE_OUTPUT` | Controls whether reviewer suggestion text is shown at all. When `false`, Builder only shows the concise reviewer result/status line. When `true`, Builder shows the full suggestion list at the moment the reviewer issues it, and the later reviewer status stays concise after the follow-up is applied or ignored. |
 

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -148,7 +148,7 @@ Configure the supervisor agent that oversees model changes.
 | `reviewer.frequency` | string | `edits` | `BUILDER_REVIEWER_FREQUENCY` | Allowed: `off`, `all`, `edits`. `all` runs the reviewer after every completed assistant turn. `edits` runs it only after successful `patch` edits. |
 | `reviewer.model` | string | inherits `model` | `BUILDER_REVIEWER_MODEL` | Separate model for the reviewer pass. If unset, Builder uses main `model`. |
 | `reviewer.thinking_level` | string | inherits `thinking_level` | `BUILDER_REVIEWER_THINKING_LEVEL` | Allowed: `low`, `medium`, `high`, `xhigh`. |
-| `reviewer.system_prompt_file` | string | `""` |  | Path to a custom supervisor system prompt file. Workspace config overrides global config; no CLI or environment override is provided. |
+| `reviewer.system_prompt_file` | string | `""` |  | Path to a custom supervisor system prompt file. Relative paths resolve from the config file directory. Workspace config overrides global config; no CLI or environment override is provided. |
 | `reviewer.timeout_seconds` | int | `60` | `BUILDER_REVIEWER_TIMEOUT_SECONDS` | Reviewer HTTP timeout. Must be `> 0`. |
 | `reviewer.verbose_output` | bool | `false` | `BUILDER_REVIEWER_VERBOSE_OUTPUT` | Controls whether reviewer suggestion text is shown at all. When `false`, Builder only shows the concise reviewer result/status line. When `true`, Builder shows the full suggestion list at the moment the reviewer issues it, and the later reviewer status stays concise after the follow-up is applied or ignored. |
 

--- a/docs/src/content/docs/prompts.md
+++ b/docs/src/content/docs/prompts.md
@@ -46,3 +46,12 @@ Prefer small, reviewable commits.
 ```
 
 Tool preambles are appended after the rendered `SYSTEM.md` when `tool_preambles = true` for the locked session.
+
+## Supervisor System Prompt
+
+`reviewer.system_prompt_file` replaces Builder's built-in supervisor system prompt:
+
+- `~/.builder/config.toml`
+- `<workspace-root>/.builder/config.toml`
+
+The workspace config value takes priority. Builder reads the referenced file when the supervisor first runs for a session, stores the prompt with the session, and reuses that snapshot for later supervisor requests. Editing the file affects only sessions that have not run the supervisor with that override.

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -551,6 +551,55 @@ func TestApplyRunPromptOverridesSubagentProviderOverrideCanInheritBaseModel(t *t
 	}
 }
 
+func TestApplyRunPromptOverridesSubagentReviewerSystemPromptFile(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	configPath := filepath.Join(home, ".builder", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	contents := strings.Join([]string{
+		"model = \"gpt-5.5\"",
+		"",
+		"[reviewer]",
+		"system_prompt_file = \"base-reviewer.md\"",
+		"",
+		"[subagents.worker.reviewer]",
+		"system_prompt_file = \"worker-reviewer.md\"",
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	loaded, err := config.Load(workspace, config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	store, err := session.Create(filepath.Join(t.TempDir(), "sessions", "workspace-a"), "workspace-a", workspace)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	plan := SessionPlan{
+		Store:               store,
+		ActiveSettings:      loaded.Settings,
+		EnabledTools:        []toolspec.ID{toolspec.ToolExecCommand},
+		ConfiguredModelName: loaded.Settings.Model,
+		WorkspaceRoot:       workspace,
+		Source:              loaded.Source,
+	}
+
+	updated, warnings, err := ApplyRunPromptOverrides(plan, serverapi.RunPromptOverrides{AgentRole: "worker"}, auth.EmptyState())
+	if err != nil {
+		t.Fatalf("ApplyRunPromptOverrides: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %+v", warnings)
+	}
+	if want := filepath.Join(home, ".builder", "worker-reviewer.md"); updated.ActiveSettings.Reviewer.SystemPromptFile != want {
+		t.Fatalf("reviewer system prompt file = %q, want %q", updated.ActiveSettings.Reviewer.SystemPromptFile, want)
+	}
+}
+
 func TestApplyRunPromptOverridesRoleModelOverrideRecomputesContextBudget(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()

--- a/server/launch/subagents.go
+++ b/server/launch/subagents.go
@@ -157,6 +157,8 @@ func applySubagentRoleOverrides(settings *config.Settings, role config.SubagentR
 			settings.Reviewer.Model = role.Settings.Reviewer.Model
 		case "reviewer.thinking_level":
 			settings.Reviewer.ThinkingLevel = role.Settings.Reviewer.ThinkingLevel
+		case "reviewer.system_prompt_file":
+			settings.Reviewer.SystemPromptFile = role.Settings.Reviewer.SystemPromptFile
 		case "reviewer.timeout_seconds":
 			settings.Reviewer.TimeoutSeconds = role.Settings.Reviewer.TimeoutSeconds
 		case "reviewer.verbose_output":

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -119,12 +119,13 @@ type Config struct {
 }
 
 type ReviewerConfig struct {
-	Frequency     string
-	Model         string
-	ThinkingLevel string
-	VerboseOutput bool
-	Client        llm.Client
-	ClientFactory func() (llm.Client, error)
+	Frequency        string
+	Model            string
+	ThinkingLevel    string
+	SystemPromptFile string
+	VerboseOutput    bool
+	Client           llm.Client
+	ClientFactory    func() (llm.Client, error)
 }
 
 type ContextUsage struct {

--- a/server/runtime/engine_part5_test.go
+++ b/server/runtime/engine_part5_test.go
@@ -57,6 +57,178 @@ func TestReviewerRunsOnAllFrequencyWithoutToolCalls(t *testing.T) {
 	}
 }
 
+func TestReviewerSystemPromptFileIsLazyLockedAndReused(t *testing.T) {
+	dir := t.TempDir()
+	reviewerPromptPath := filepath.Join(dir, "reviewer-prompt.md")
+	writeTestFile(t, reviewerPromptPath, "custom reviewer prompt")
+
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	mainClient := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done", Phase: llm.MessagePhaseFinal},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	reviewerClient := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: `{"suggestions":[]}`},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	eng, err := New(store, mainClient, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model: "gpt-5",
+		Reviewer: ReviewerConfig{
+			Frequency:        "all",
+			Model:            "gpt-5",
+			SystemPromptFile: reviewerPromptPath,
+			Client:           reviewerClient,
+		},
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	if _, err := eng.SubmitUserMessage(context.Background(), "hello"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if got := reviewerClient.calls[0].SystemPrompt; got != "custom reviewer prompt" {
+		t.Fatalf("reviewer system prompt = %q, want custom reviewer prompt", got)
+	}
+	if locked := store.Meta().Locked; locked == nil || !locked.HasReviewerPrompt || locked.ReviewerPrompt != "custom reviewer prompt" {
+		t.Fatalf("locked reviewer prompt = %+v, want custom reviewer prompt snapshot", locked)
+	}
+
+	writeTestFile(t, reviewerPromptPath, "changed reviewer prompt")
+	if err := eng.Close(); err != nil {
+		t.Fatalf("close engine: %v", err)
+	}
+	reopened, err := session.Open(store.Dir())
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	reopenedReviewer := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: `{"suggestions":[]}`},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	reopenedEngine, err := New(reopened, mainClient, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model: "gpt-5",
+		Reviewer: ReviewerConfig{
+			Model:            "gpt-5",
+			SystemPromptFile: reviewerPromptPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("new reopened engine: %v", err)
+	}
+	if _, err := reopenedEngine.runReviewerSuggestions(context.Background(), "step-2", reopenedReviewer); err != nil {
+		t.Fatalf("run reviewer suggestions: %v", err)
+	}
+	if got := reopenedReviewer.calls[0].SystemPrompt; got != "custom reviewer prompt" {
+		t.Fatalf("reopened reviewer system prompt = %q, want locked custom reviewer prompt", got)
+	}
+}
+
+func TestReviewerSystemPromptFileResolvesTilde(t *testing.T) {
+	home := t.TempDir()
+	dir := t.TempDir()
+	t.Setenv("HOME", home)
+	reviewerPromptPath := filepath.Join(home, "reviewer-prompt.md")
+	writeTestFile(t, reviewerPromptPath, "tilde reviewer prompt")
+
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	reviewerClient := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: `{"suggestions":[]}`},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	eng, err := New(store, &fakeClient{}, tools.NewRegistry(), Config{
+		Model: "gpt-5",
+		Reviewer: ReviewerConfig{
+			Model:            "gpt-5",
+			SystemPromptFile: "~/reviewer-prompt.md",
+		},
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	if _, err := eng.runReviewerSuggestions(context.Background(), "step-1", reviewerClient); err != nil {
+		t.Fatalf("run reviewer suggestions: %v", err)
+	}
+	if got := reviewerClient.calls[0].SystemPrompt; got != "tilde reviewer prompt" {
+		t.Fatalf("reviewer system prompt = %q, want tilde reviewer prompt", got)
+	}
+}
+
+func TestReviewerSystemPromptFileMissingFailsWithoutSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	missingPromptPath := filepath.Join(dir, "missing-reviewer-prompt.md")
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	eng, err := New(store, &fakeClient{}, tools.NewRegistry(), Config{
+		Model: "gpt-5",
+		Reviewer: ReviewerConfig{
+			Model:            "gpt-5",
+			SystemPromptFile: missingPromptPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	if _, err := eng.ensureLocked(); err != nil {
+		t.Fatalf("ensure locked: %v", err)
+	}
+	_, err = eng.runReviewerSuggestions(context.Background(), "step-1", &fakeClient{})
+	if err == nil {
+		t.Fatal("expected missing reviewer system prompt file error")
+	}
+	if !strings.Contains(err.Error(), "read reviewer.system_prompt_file") {
+		t.Fatalf("expected reviewer prompt read error, got %v", err)
+	}
+	if locked := store.Meta().Locked; locked == nil || locked.HasReviewerPrompt || locked.ReviewerPrompt != "" {
+		t.Fatalf("locked reviewer prompt = %+v, want no reviewer prompt snapshot", locked)
+	}
+}
+
+func TestReviewerFrequencyOffDoesNotReadSystemPromptFile(t *testing.T) {
+	dir := t.TempDir()
+	missingPromptPath := filepath.Join(dir, "missing-reviewer-prompt.md")
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	mainClient := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done", Phase: llm.MessagePhaseFinal},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	reviewerClient := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: `{"suggestions":[]}`},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	eng, err := New(store, mainClient, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model: "gpt-5",
+		Reviewer: ReviewerConfig{
+			Frequency:        "off",
+			Model:            "gpt-5",
+			SystemPromptFile: missingPromptPath,
+			Client:           reviewerClient,
+		},
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	if _, err := eng.SubmitUserMessage(context.Background(), "hello"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if len(reviewerClient.calls) != 0 {
+		t.Fatalf("expected reviewer not to run, got %d calls", len(reviewerClient.calls))
+	}
+	if locked := store.Meta().Locked; locked == nil || locked.HasReviewerPrompt || locked.ReviewerPrompt != "" {
+		t.Fatalf("locked reviewer prompt = %+v, want no reviewer prompt snapshot", locked)
+	}
+}
+
 func TestReviewerSuggestionsRequestInheritsFastMode(t *testing.T) {
 	dir := t.TempDir()
 	store, err := session.Create(dir, "ws", dir)

--- a/server/runtime/reviewer_request_builder.go
+++ b/server/runtime/reviewer_request_builder.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"context"
 
-	"builder/prompts"
 	"builder/server/llm"
 	"builder/shared/cachewarn"
 )
@@ -35,6 +34,10 @@ func (e *Engine) buildReviewerRequest(ctx context.Context, reviewerClient llm.Cl
 	if err != nil {
 		return llm.Request{}, err
 	}
+	systemPrompt, err := e.reviewerSystemPrompt()
+	if err != nil {
+		return llm.Request{}, err
+	}
 	reviewerItems := sanitizeItemsForLLM(llm.ItemsFromMessages(reviewerMessages))
 	req := llm.Request{
 		Model:            reviewerCfg.Model,
@@ -42,7 +45,7 @@ func (e *Engine) buildReviewerRequest(ctx context.Context, reviewerClient llm.Cl
 		MaxTokens:        0,
 		FastMode:         e.FastModeEnabled(),
 		ReasoningEffort:  reviewerCfg.ThinkingLevel,
-		SystemPrompt:     prompts.ReviewerSystemPrompt,
+		SystemPrompt:     systemPrompt,
 		SessionID:        reviewerSessionID(e.store.Meta().SessionID),
 		Items:            reviewerItems,
 		Tools:            []llm.Tool{},

--- a/server/runtime/system_prompt_snapshot.go
+++ b/server/runtime/system_prompt_snapshot.go
@@ -119,3 +119,100 @@ func pathWithinRoot(path string, root string) bool {
 	}
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
+
+func (e *Engine) reviewerSystemPrompt() (string, error) {
+	if prompt, ok := e.lockedReviewerPromptSnapshot(); ok {
+		return prompt, nil
+	}
+	prompt, err := e.buildReviewerPromptSnapshot()
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(e.cfg.Reviewer.SystemPromptFile) == "" {
+		return prompt, nil
+	}
+	if err := e.store.BackfillLockedReviewerPrompt(prompt); err != nil {
+		return "", err
+	}
+	if prompt, ok := e.lockedReviewerPromptSnapshot(); ok {
+		return prompt, nil
+	}
+	e.mu.Lock()
+	if e.locked != nil && !e.locked.HasReviewerPrompt {
+		e.locked.ReviewerPrompt = prompt
+		e.locked.HasReviewerPrompt = true
+	}
+	e.mu.Unlock()
+	return prompt, nil
+}
+
+func (e *Engine) lockedReviewerPromptSnapshot() (string, bool) {
+	if e == nil {
+		return "", false
+	}
+	if meta := e.store.Meta(); meta.Locked != nil {
+		if meta.Locked.HasReviewerPrompt {
+			return strings.TrimSpace(meta.Locked.ReviewerPrompt), true
+		}
+		if prompt := strings.TrimSpace(meta.Locked.ReviewerPrompt); prompt != "" {
+			return prompt, true
+		}
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.locked == nil {
+		return "", false
+	}
+	if e.locked.HasReviewerPrompt {
+		return strings.TrimSpace(e.locked.ReviewerPrompt), true
+	}
+	if prompt := strings.TrimSpace(e.locked.ReviewerPrompt); prompt != "" {
+		return prompt, true
+	}
+	return "", false
+}
+
+func (e *Engine) buildReviewerPromptSnapshot() (string, error) {
+	path := strings.TrimSpace(e.cfg.Reviewer.SystemPromptFile)
+	if path == "" {
+		return prompts.ReviewerSystemPrompt, nil
+	}
+	resolved, err := resolveConfiguredPromptFile(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve reviewer.system_prompt_file %q: %w", path, err)
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return "", fmt.Errorf("read reviewer.system_prompt_file %q: %w", resolved, err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func resolveConfiguredPromptFile(path string) (string, error) {
+	expanded, err := expandTildePromptPath(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(expanded)
+}
+
+func expandTildePromptPath(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" || !strings.HasPrefix(trimmed, "~") {
+		return trimmed, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	if trimmed == "~" {
+		return home, nil
+	}
+	if strings.HasPrefix(trimmed, "~/") {
+		return filepath.Join(home, strings.TrimPrefix(trimmed, "~/")), nil
+	}
+	if strings.HasPrefix(trimmed, "~\\") {
+		return filepath.Join(home, strings.TrimPrefix(trimmed, "~\\")), nil
+	}
+	return trimmed, nil
+}

--- a/server/runtimewire/wiring.go
+++ b/server/runtimewire/wiring.go
@@ -140,12 +140,13 @@ func NewRuntimeWiringWithBackground(store *session.Store, active config.Settings
 		ToolPreambles:                 active.ToolPreambles,
 		TranscriptWorkingDir:          workspaceRoot,
 		Reviewer: runtime.ReviewerConfig{
-			Frequency:     active.Reviewer.Frequency,
-			Model:         active.Reviewer.Model,
-			ThinkingLevel: active.Reviewer.ThinkingLevel,
-			VerboseOutput: active.Reviewer.VerboseOutput,
-			Client:        reviewerClient,
-			ClientFactory: newReviewerClient,
+			Frequency:        active.Reviewer.Frequency,
+			Model:            active.Reviewer.Model,
+			ThinkingLevel:    active.Reviewer.ThinkingLevel,
+			SystemPromptFile: active.Reviewer.SystemPromptFile,
+			VerboseOutput:    active.Reviewer.VerboseOutput,
+			Client:           reviewerClient,
+			ClientFactory:    newReviewerClient,
 		},
 		OnEvent: func(evt runtime.Event) {
 			if opts.OnEvent != nil {

--- a/server/session/fork.go
+++ b/server/session/fork.go
@@ -77,6 +77,7 @@ func cloneLockedContract(in *LockedContract) *LockedContract {
 		copyLocked.EnabledTools = append([]string(nil), in.EnabledTools...)
 	}
 	copyLocked.SystemPrompt = strings.TrimSpace(in.SystemPrompt)
+	copyLocked.ReviewerPrompt = strings.TrimSpace(in.ReviewerPrompt)
 	return &copyLocked
 }
 

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -479,6 +479,24 @@ func (s *Store) BackfillLockedSystemPrompt(systemPrompt string) error {
 	return s.observePersistence(snapshot)
 }
 
+func (s *Store) BackfillLockedReviewerPrompt(reviewerPrompt string) error {
+	trimmed := strings.TrimSpace(reviewerPrompt)
+	s.mu.Lock()
+	if s.meta.Locked == nil || s.meta.Locked.HasReviewerPrompt {
+		s.mu.Unlock()
+		return nil
+	}
+	s.meta.Locked.ReviewerPrompt = trimmed
+	s.meta.Locked.HasReviewerPrompt = true
+	s.meta.UpdatedAt = time.Now().UTC()
+	snapshot, err := s.persistMetaLocked()
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.observePersistence(snapshot)
+}
+
 func (s *Store) AppendEvent(stepID, kind string, payload any) (Event, error) {
 	s.mu.Lock()
 

--- a/server/session/store_test.go
+++ b/server/session/store_test.go
@@ -308,11 +308,13 @@ func TestLockedContractPersistenceIncludesSystemPromptButNotToolSchema(t *testin
 		t.Fatalf("create store: %v", err)
 	}
 	if err := store.MarkModelDispatchLocked(LockedContract{
-		Model:           "gpt-5",
-		Temperature:     1,
-		MaxOutputToken:  0,
-		SystemPrompt:    "locked system prompt",
-		HasSystemPrompt: true,
+		Model:             "gpt-5",
+		Temperature:       1,
+		MaxOutputToken:    0,
+		SystemPrompt:      "locked system prompt",
+		HasSystemPrompt:   true,
+		ReviewerPrompt:    "locked reviewer prompt",
+		HasReviewerPrompt: true,
 	}); err != nil {
 		t.Fatalf("mark model dispatch locked: %v", err)
 	}
@@ -332,6 +334,9 @@ func TestLockedContractPersistenceIncludesSystemPromptButNotToolSchema(t *testin
 	locked := opened.Meta().Locked
 	if locked == nil || locked.SystemPrompt != "locked system prompt" || !locked.HasSystemPrompt {
 		t.Fatalf("locked system prompt = %+v, want persisted snapshot marker", locked)
+	}
+	if locked.ReviewerPrompt != "locked reviewer prompt" || !locked.HasReviewerPrompt {
+		t.Fatalf("locked reviewer prompt = %+v, want persisted snapshot marker", locked)
 	}
 }
 

--- a/server/session/types.go
+++ b/server/session/types.go
@@ -11,6 +11,8 @@ type LockedContract struct {
 	MaxOutputToken    int                        `json:"max_output_token"`
 	SystemPrompt      string                     `json:"system_prompt"`
 	HasSystemPrompt   bool                       `json:"has_system_prompt,omitempty"`
+	ReviewerPrompt    string                     `json:"reviewer_prompt,omitempty"`
+	HasReviewerPrompt bool                       `json:"has_reviewer_prompt,omitempty"`
 	ContextWindow     int                        `json:"context_window,omitempty"`
 	ContextPercent    int                        `json:"context_percent,omitempty"`
 	EnabledTools      []string                   `json:"enabled_tools,omitempty"`

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -136,11 +136,12 @@ type ProviderCapabilitiesOverride struct {
 }
 
 type ReviewerSettings struct {
-	Frequency      string
-	Model          string
-	ThinkingLevel  string
-	TimeoutSeconds int
-	VerboseOutput  bool
+	Frequency        string
+	Model            string
+	ThinkingLevel    string
+	SystemPromptFile string
+	TimeoutSeconds   int
+	VerboseOutput    bool
 }
 
 type SourceReport struct {

--- a/shared/config/config_part2_test.go
+++ b/shared/config/config_part2_test.go
@@ -475,7 +475,7 @@ func TestLoadReviewerPrecedenceAndValidation(t *testing.T) {
 frequency = "all"
 model = "gpt-file-reviewer"
 thinking_level = "medium"
-system_prompt_file = "~/reviewer-global.md"
+system_prompt_file = "reviewer-global.md"
 timeout_seconds = 45
 verbose_output = true
 `), 0o644); err != nil {
@@ -501,8 +501,8 @@ verbose_output = true
 	if !cfg.Settings.Reviewer.VerboseOutput {
 		t.Fatalf("expected file reviewer.verbose_output=true")
 	}
-	if cfg.Settings.Reviewer.SystemPromptFile != "~/reviewer-global.md" {
-		t.Fatalf("expected file reviewer.system_prompt_file, got %q", cfg.Settings.Reviewer.SystemPromptFile)
+	if want := filepath.Join(home, ".builder", "reviewer-global.md"); cfg.Settings.Reviewer.SystemPromptFile != want {
+		t.Fatalf("expected file reviewer.system_prompt_file=%q, got %q", want, cfg.Settings.Reviewer.SystemPromptFile)
 	}
 	if got := cfg.Source.Sources["reviewer.verbose_output"]; got != "file" {
 		t.Fatalf("expected reviewer.verbose_output source file, got %q", got)
@@ -522,8 +522,8 @@ verbose_output = true
 	if err != nil {
 		t.Fatalf("load with workspace config: %v", err)
 	}
-	if cfg.Settings.Reviewer.SystemPromptFile != "workspace-reviewer.md" {
-		t.Fatalf("expected workspace reviewer.system_prompt_file override, got %q", cfg.Settings.Reviewer.SystemPromptFile)
+	if want := filepath.Join(workspace, ".builder", "workspace-reviewer.md"); cfg.Settings.Reviewer.SystemPromptFile != want {
+		t.Fatalf("expected workspace reviewer.system_prompt_file=%q, got %q", want, cfg.Settings.Reviewer.SystemPromptFile)
 	}
 
 	t.Setenv("BUILDER_REVIEWER_FREQUENCY", "off")

--- a/shared/config/config_part2_test.go
+++ b/shared/config/config_part2_test.go
@@ -475,6 +475,7 @@ func TestLoadReviewerPrecedenceAndValidation(t *testing.T) {
 frequency = "all"
 model = "gpt-file-reviewer"
 thinking_level = "medium"
+system_prompt_file = "~/reviewer-global.md"
 timeout_seconds = 45
 verbose_output = true
 `), 0o644); err != nil {
@@ -500,8 +501,29 @@ verbose_output = true
 	if !cfg.Settings.Reviewer.VerboseOutput {
 		t.Fatalf("expected file reviewer.verbose_output=true")
 	}
+	if cfg.Settings.Reviewer.SystemPromptFile != "~/reviewer-global.md" {
+		t.Fatalf("expected file reviewer.system_prompt_file, got %q", cfg.Settings.Reviewer.SystemPromptFile)
+	}
 	if got := cfg.Source.Sources["reviewer.verbose_output"]; got != "file" {
 		t.Fatalf("expected reviewer.verbose_output source file, got %q", got)
+	}
+	if got := cfg.Source.Sources["reviewer.system_prompt_file"]; got != "file" {
+		t.Fatalf("expected reviewer.system_prompt_file source file, got %q", got)
+	}
+
+	workspaceConfigPath := filepath.Join(workspace, ".builder", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(workspaceConfigPath), 0o755); err != nil {
+		t.Fatalf("mkdir workspace config dir: %v", err)
+	}
+	if err := os.WriteFile(workspaceConfigPath, []byte("[reviewer]\nsystem_prompt_file = \"workspace-reviewer.md\"\n"), 0o644); err != nil {
+		t.Fatalf("write workspace config: %v", err)
+	}
+	cfg, err = Load(workspace, LoadOptions{})
+	if err != nil {
+		t.Fatalf("load with workspace config: %v", err)
+	}
+	if cfg.Settings.Reviewer.SystemPromptFile != "workspace-reviewer.md" {
+		t.Fatalf("expected workspace reviewer.system_prompt_file override, got %q", cfg.Settings.Reviewer.SystemPromptFile)
 	}
 
 	t.Setenv("BUILDER_REVIEWER_FREQUENCY", "off")

--- a/shared/config/config_registry.go
+++ b/shared/config/config_registry.go
@@ -377,6 +377,13 @@ func newSettingsRegistry() settingsRegistry {
 					return "<inherits thinking_level when unset>"
 				},
 			}),
+		newStringSetting("reviewer.system_prompt_file", "",
+			func(state *settingsState, value string) { state.Settings.Reviewer.SystemPromptFile = value },
+			func(state settingsState) string { return state.Settings.Reviewer.SystemPromptFile },
+			"",
+			nil,
+			nil,
+			settingDocOptions{}),
 		newIntSetting("reviewer.timeout_seconds", defaultReviewerTimeoutSec,
 			func(state *settingsState, value int) { state.Settings.Reviewer.TimeoutSeconds = value },
 			func(state settingsState) int { return state.Settings.Reviewer.TimeoutSeconds },

--- a/shared/config/config_registry.go
+++ b/shared/config/config_registry.go
@@ -48,21 +48,23 @@ type settingsRegistry struct {
 }
 
 type settingDocOptions struct {
-	commented    bool
-	omitInTOML   bool
-	defaultValue func(settingsState) any
+	commented                    bool
+	omitInTOML                   bool
+	resolveRelativeToSettingsDir bool
+	defaultValue                 func(settingsState) any
 }
 
 type scalarSetting[T any] struct {
-	key          string
-	defaultValue T
-	apply        func(*settingsState, T)
-	get          func(settingsState) T
-	decodeFile   func(settingsFile, []string) (T, bool, error)
-	envName      string
-	decodeEnv    func(string, string) (T, error)
-	decodeCLI    func(LoadOptions) (T, bool, error)
-	doc          settingDocOptions
+	key                string
+	defaultValue       T
+	apply              func(*settingsState, T)
+	get                func(settingsState) T
+	decodeFile         func(settingsFile, []string) (T, bool, error)
+	transformFileValue func(T, string) (T, error)
+	envName            string
+	decodeEnv          func(string, string) (T, error)
+	decodeCLI          func(LoadOptions) (T, bool, error)
+	doc                settingDocOptions
 }
 
 type toolsSetting struct{}
@@ -383,7 +385,7 @@ func newSettingsRegistry() settingsRegistry {
 			"",
 			nil,
 			nil,
-			settingDocOptions{}),
+			settingDocOptions{resolveRelativeToSettingsDir: true}),
 		newIntSetting("reviewer.timeout_seconds", defaultReviewerTimeoutSec,
 			func(state *settingsState, value int) { state.Settings.Reviewer.TimeoutSeconds = value },
 			func(state settingsState) int { return state.Settings.Reviewer.TimeoutSeconds },
@@ -522,11 +524,19 @@ func newStringSetting[T ~string](
 	normalize func(string) T,
 	doc settingDocOptions,
 ) scalarSetting[T] {
+	var transformFileValue func(T, string) (T, error)
+	if doc.resolveRelativeToSettingsDir {
+		transformFileValue = func(value T, settingsPath string) (T, error) {
+			resolved, err := resolveFileSettingRelativeToSettingsPath(string(value), settingsPath)
+			return T(resolved), err
+		}
+	}
 	return scalarSetting[T]{
-		key:          key,
-		defaultValue: defaultValue,
-		apply:        apply,
-		get:          get,
+		key:                key,
+		defaultValue:       defaultValue,
+		apply:              apply,
+		get:                get,
+		transformFileValue: transformFileValue,
 		decodeFile: func(raw settingsFile, path []string) (T, bool, error) {
 			value, ok, err := lookupFileString(raw, path)
 			if err != nil || !ok {
@@ -623,7 +633,7 @@ func (s scalarSetting[T]) initSources(sources map[string]string) {
 	sources[s.key] = "default"
 }
 
-func (s scalarSetting[T]) applyFile(raw settingsFile, _ string, state *settingsState, sources map[string]string) error {
+func (s scalarSetting[T]) applyFile(raw settingsFile, settingsPath string, state *settingsState, sources map[string]string) error {
 	value, ok, err := s.decodeFile(raw, splitSettingKey(s.key))
 	if err != nil {
 		return err
@@ -631,9 +641,34 @@ func (s scalarSetting[T]) applyFile(raw settingsFile, _ string, state *settingsS
 	if !ok {
 		return nil
 	}
+	if s.transformFileValue != nil {
+		value, err = s.transformFileValue(value, settingsPath)
+		if err != nil {
+			return err
+		}
+	}
 	s.apply(state, value)
 	sources[s.key] = "file"
 	return nil
+}
+
+func resolveFileSettingRelativeToSettingsPath(value string, settingsPath string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", nil
+	}
+	expanded, err := expandTildePath(trimmed)
+	if err != nil {
+		return "", err
+	}
+	if filepath.IsAbs(expanded) {
+		return filepath.Abs(expanded)
+	}
+	baseDir := strings.TrimSpace(filepath.Dir(settingsPath))
+	if baseDir == "" || baseDir == "." {
+		return filepath.Abs(expanded)
+	}
+	return filepath.Abs(filepath.Join(baseDir, expanded))
 }
 
 func (s scalarSetting[T]) applyEnv(lookup envLookup, state *settingsState, sources map[string]string) error {

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -265,6 +265,9 @@ func TestLoadSubagentRoleFromFile(t *testing.T) {
 		"model = \"gpt-5.4-mini\"",
 		"thinking_level = \"low\"",
 		"",
+		"[subagents.fast.reviewer]",
+		"system_prompt_file = \"fast-reviewer.md\"",
+		"",
 		"[subagents.fast.tools]",
 		"patch = false",
 	}, "\n")
@@ -289,7 +292,10 @@ func TestLoadSubagentRoleFromFile(t *testing.T) {
 	if role.Settings.EnabledTools[toolspec.ToolPatch] {
 		t.Fatalf("expected fast role patch tool disabled, got %+v", role.Settings.EnabledTools)
 	}
-	if role.Sources["model"] != "file" || role.Sources["thinking_level"] != "file" || role.Sources["tools.patch"] != "file" {
+	if want := filepath.Join(home, ".builder", "fast-reviewer.md"); role.Settings.Reviewer.SystemPromptFile != want {
+		t.Fatalf("role reviewer system prompt file = %q, want %q", role.Settings.Reviewer.SystemPromptFile, want)
+	}
+	if role.Sources["model"] != "file" || role.Sources["thinking_level"] != "file" || role.Sources["tools.patch"] != "file" || role.Sources["reviewer.system_prompt_file"] != "file" {
 		t.Fatalf("unexpected role sources: %+v", role.Sources)
 	}
 	if _, exists := role.Sources["reviewer.model"]; exists {


### PR DESCRIPTION
## Summary
- add reviewer.system_prompt_file config override from global/workspace config
- lazy-load and lock custom supervisor prompts per session
- document supervisor prompt override behavior

Closes #157

## Tests
- ./scripts/test.sh ./server/runtime ./server/runtimewire ./shared/config ./server/session
- ./scripts/build.sh --output ./bin/builder