### PR TITLE
feat: add update reminder

### DIFF
--- a/cli/app/session_lifecycle.go
+++ b/cli/app/session_lifecycle.go
@@ -27,6 +27,7 @@ func runSessionLifecycle(ctx context.Context, server embeddedServer, interactor 
 	nextSessionInitialInput := ""
 	nextSessionParentID := ""
 	forceNewSession := false
+	showStartupUpdateNotice := true
 	for {
 		plan, err := planner.PlanSession(ctx, sessionLaunchRequest{
 			Mode:              launchModeInteractive,
@@ -63,6 +64,7 @@ func runSessionLifecycle(ctx context.Context, server embeddedServer, interactor 
 		}
 		initialInput := sessionLaunchInitialInputFromServer(ctx, server, plan.SessionID, nextSessionInitialInput)
 
+		startupUpdateNotice := consumeStartupUpdateNoticeFlag(&showStartupUpdateNotice)
 		finalModel, runErr := runUILoopWithInitialPrompt(
 			runtimePlan.Wiring,
 			plan.ActiveSettings,
@@ -74,6 +76,7 @@ func runSessionLifecycle(ctx context.Context, server embeddedServer, interactor 
 			plan.ModelContractLocked,
 			plan.ConfiguredModelName,
 			plan.StatusConfig,
+			startupUpdateNotice,
 		)
 		nextSessionInitialPrompt = ""
 		nextSessionInitialInput = ""
@@ -101,6 +104,14 @@ func runSessionLifecycle(ctx context.Context, server embeddedServer, interactor 
 		nextSessionParentID = resolved.ParentSessionID
 		forceNewSession = resolved.ForceNewSession
 	}
+}
+
+func consumeStartupUpdateNoticeFlag(enabled *bool) bool {
+	if enabled == nil || !*enabled {
+		return false
+	}
+	*enabled = false
+	return true
 }
 
 func shouldCloseReboundServer(original embeddedServer, rebound embeddedServer) bool {

--- a/cli/app/session_lifecycle.go
+++ b/cli/app/session_lifecycle.go
@@ -64,7 +64,6 @@ func runSessionLifecycle(ctx context.Context, server embeddedServer, interactor 
 		}
 		initialInput := sessionLaunchInitialInputFromServer(ctx, server, plan.SessionID, nextSessionInitialInput)
 
-		startupUpdateNotice := consumeStartupUpdateNoticeFlag(&showStartupUpdateNotice)
 		finalModel, runErr := runUILoopWithInitialPrompt(
 			runtimePlan.Wiring,
 			plan.ActiveSettings,
@@ -76,8 +75,9 @@ func runSessionLifecycle(ctx context.Context, server embeddedServer, interactor 
 			plan.ModelContractLocked,
 			plan.ConfiguredModelName,
 			plan.StatusConfig,
-			startupUpdateNotice,
+			showStartupUpdateNotice,
 		)
+		showStartupUpdateNotice = shouldRetryStartupUpdateNotice(finalModel, showStartupUpdateNotice)
 		nextSessionInitialPrompt = ""
 		nextSessionInitialInput = ""
 		if runErr != nil {
@@ -106,12 +106,12 @@ func runSessionLifecycle(ctx context.Context, server embeddedServer, interactor 
 	}
 }
 
-func consumeStartupUpdateNoticeFlag(enabled *bool) bool {
-	if enabled == nil || !*enabled {
+func shouldRetryStartupUpdateNotice(model any, enabled bool) bool {
+	if !enabled {
 		return false
 	}
-	*enabled = false
-	return true
+	ui, ok := model.(*uiModel)
+	return !ok || ui == nil || !ui.startupUpdateShown
 }
 
 func shouldCloseReboundServer(original embeddedServer, rebound embeddedServer) bool {

--- a/cli/app/session_lifecycle_test.go
+++ b/cli/app/session_lifecycle_test.go
@@ -838,15 +838,14 @@ func TestResolveSessionActionOpenSessionUsesTargetID(t *testing.T) {
 	}
 }
 
-func TestConsumeStartupUpdateNoticeFlagOnlyOnce(t *testing.T) {
-	enabled := true
-	if !consumeStartupUpdateNoticeFlag(&enabled) {
-		t.Fatal("expected first session to consume startup update notice")
+func TestShouldRetryStartupUpdateNoticeUntilShown(t *testing.T) {
+	if shouldRetryStartupUpdateNotice(&uiModel{}, true) != true {
+		t.Fatal("expected retry when startup update notice was not shown")
 	}
-	if enabled {
-		t.Fatal("expected startup update notice flag to be disabled after first consume")
+	if shouldRetryStartupUpdateNotice(&uiModel{startupUpdateShown: true}, true) {
+		t.Fatal("did not expect retry after startup update notice was shown")
 	}
-	if consumeStartupUpdateNoticeFlag(&enabled) {
-		t.Fatal("did not expect later sessions to show startup update notice")
+	if shouldRetryStartupUpdateNotice(&uiModel{}, false) {
+		t.Fatal("did not expect retry when startup update notices are disabled")
 	}
 }

--- a/cli/app/session_lifecycle_test.go
+++ b/cli/app/session_lifecycle_test.go
@@ -837,3 +837,16 @@ func TestResolveSessionActionOpenSessionUsesTargetID(t *testing.T) {
 		t.Fatal("did not expect force-new session")
 	}
 }
+
+func TestConsumeStartupUpdateNoticeFlagOnlyOnce(t *testing.T) {
+	enabled := true
+	if !consumeStartupUpdateNoticeFlag(&enabled) {
+		t.Fatal("expected first session to consume startup update notice")
+	}
+	if enabled {
+		t.Fatal("expected startup update notice flag to be disabled after first consume")
+	}
+	if consumeStartupUpdateNoticeFlag(&enabled) {
+		t.Fatal("did not expect later sessions to show startup update notice")
+	}
+}

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -77,6 +77,10 @@ type clearTransientStatusMsg struct {
 	token uint64
 }
 
+type startupUpdateNoticeMsg struct {
+	version string
+}
+
 type nativeResizeReplayMsg struct {
 	token uint64
 }
@@ -220,6 +224,20 @@ const (
 	uiStatusNoticeNeutral uiStatusNoticeKind = iota
 	uiStatusNoticeSuccess
 	uiStatusNoticeError
+	uiStatusNoticeUpdateAvailable
+)
+
+type uiStatusNotice struct {
+	Text     string
+	Kind     uiStatusNoticeKind
+	Duration time.Duration
+}
+
+type uiStatusNoticeDelivery uint8
+
+const (
+	uiStatusNoticeReplace uiStatusNoticeDelivery = iota
+	uiStatusNoticeQueue
 )
 
 type uiLogger interface {
@@ -427,6 +445,12 @@ func WithUIPromptHistory(history []string) UIOption {
 	}
 }
 
+func WithUIStartupUpdateNotice(enabled bool) UIOption {
+	return func(m *uiModel) {
+		m.startupUpdateNotice = enabled
+	}
+}
+
 func WithUIClipboardImagePaster(paster uiClipboardImagePaster) UIOption {
 	return func(m *uiModel) {
 		m.clipboardImagePaster = paster
@@ -559,6 +583,9 @@ type uiModel struct {
 	transientStatus       string
 	transientStatusKind   uiStatusNoticeKind
 	transientStatusToken  uint64
+	transientStatusQueue  []uiStatusNotice
+	startupUpdateNotice   bool
+	startupUpdateShown    bool
 	debugKeys             bool
 	debugMode             bool
 	transcriptDiagnostics bool
@@ -731,6 +758,9 @@ func NewProjectedUIModel(runtimeClient clientui.RuntimeClient, runtimeEvents <-c
 			m.pathReferenceSearch.StartPrewarm(strings.TrimSpace(m.statusConfig.WorkspaceRoot))
 			return nil
 		})
+	}
+	if m.startupUpdateNotice && m.hasRuntimeClient() {
+		m.startupCmds = append(m.startupCmds, m.startupUpdateNoticeCmd(status.Update))
 	}
 	m.syncViewport()
 	return m
@@ -1056,11 +1086,19 @@ func (m *uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, waitPathReferenceSearchEvent(m.pathReferenceEvents)
 	case clearTransientStatusMsg:
 		if msg.token == m.transientStatusToken {
-			m.transientStatus = ""
-			m.transientStatusKind = uiStatusNoticeNeutral
+			return m, m.advanceTransientStatusQueue()
 		}
 		m.syncViewport()
 		return m, nil
+	case startupUpdateNoticeMsg:
+		if m.startupUpdateShown {
+			m.syncViewport()
+			return m, nil
+		}
+		m.startupUpdateShown = true
+		cmd := m.enqueueTransientStatusWithDuration("update available: "+strings.TrimSpace(msg.version), uiStatusNoticeUpdateAvailable, updateNoticeDuration)
+		m.syncViewport()
+		return m, cmd
 	case nativeHistoryFlushMsg:
 		return m, m.handleNativeHistoryFlush(msg)
 	case promptHistoryPersistErrMsg:
@@ -1483,14 +1521,67 @@ func (m *uiModel) setTransientStatus(message string) tea.Cmd {
 }
 
 func (m *uiModel) setTransientStatusWithKind(message string, kind uiStatusNoticeKind) tea.Cmd {
+	return m.sendTransientStatus(message, kind, transientStatusDuration, uiStatusNoticeReplace)
+}
+
+func (m *uiModel) enqueueTransientStatus(message string, kind uiStatusNoticeKind) tea.Cmd {
+	return m.sendTransientStatus(message, kind, transientStatusDuration, uiStatusNoticeQueue)
+}
+
+func (m *uiModel) enqueueTransientStatusWithDuration(message string, kind uiStatusNoticeKind, duration time.Duration) tea.Cmd {
+	return m.sendTransientStatus(message, kind, duration, uiStatusNoticeQueue)
+}
+
+func (m *uiModel) sendTransientStatus(message string, kind uiStatusNoticeKind, duration time.Duration, delivery uiStatusNoticeDelivery) tea.Cmd {
 	if strings.TrimSpace(message) == "" {
 		return nil
 	}
+	notice := uiStatusNotice{Text: strings.TrimSpace(message), Kind: kind, Duration: duration}
+	if delivery == uiStatusNoticeQueue && strings.TrimSpace(m.transientStatus) != "" {
+		if m.transientStatus == notice.Text && m.transientStatusKind == notice.Kind {
+			return nil
+		}
+		if len(m.transientStatusQueue) > 0 {
+			last := m.transientStatusQueue[len(m.transientStatusQueue)-1]
+			if last == notice {
+				return nil
+			}
+		}
+		m.transientStatusQueue = append(m.transientStatusQueue, notice)
+		return nil
+	}
+	return m.showTransientStatusNotice(notice)
+}
+
+func (m *uiModel) showTransientStatusNotice(notice uiStatusNotice) tea.Cmd {
 	m.transientStatusToken++
 	token := m.transientStatusToken
-	m.transientStatus = strings.TrimSpace(message)
-	m.transientStatusKind = kind
-	return scheduleTransientStatusClear(token)
+	m.transientStatus = strings.TrimSpace(notice.Text)
+	m.transientStatusKind = notice.Kind
+	return scheduleTransientStatusClear(notice.Duration, token)
+}
+
+func (m *uiModel) advanceTransientStatusQueue() tea.Cmd {
+	m.transientStatus = ""
+	m.transientStatusKind = uiStatusNoticeNeutral
+	if len(m.transientStatusQueue) == 0 {
+		m.syncViewport()
+		return nil
+	}
+	next := m.transientStatusQueue[0]
+	m.transientStatusQueue = append([]uiStatusNotice(nil), m.transientStatusQueue[1:]...)
+	cmd := m.showTransientStatusNotice(next)
+	m.syncViewport()
+	return cmd
+}
+
+func (m *uiModel) startupUpdateNoticeCmd(status clientui.UpdateStatus) tea.Cmd {
+	if !status.Available || strings.TrimSpace(status.LatestVersion) == "" {
+		return nil
+	}
+	return func() tea.Msg {
+		return startupUpdateNoticeMsg{version: status.LatestVersion}
+	}
 }
 
 func batchCmds(cmds ...tea.Cmd) tea.Cmd {

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -1095,7 +1095,6 @@ func (m *uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.syncViewport()
 			return m, nil
 		}
-		m.startupUpdateShown = true
 		cmd := m.enqueueTransientStatusWithDuration("update available: "+strings.TrimSpace(msg.version), uiStatusNoticeUpdateAvailable, updateNoticeDuration)
 		m.syncViewport()
 		return m, cmd
@@ -1558,6 +1557,9 @@ func (m *uiModel) showTransientStatusNotice(notice uiStatusNotice) tea.Cmd {
 	token := m.transientStatusToken
 	m.transientStatus = strings.TrimSpace(notice.Text)
 	m.transientStatusKind = notice.Kind
+	if notice.Kind == uiStatusNoticeUpdateAvailable {
+		m.startupUpdateShown = true
+	}
 	return scheduleTransientStatusClear(notice.Duration, token)
 }
 

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -1576,11 +1576,24 @@ func (m *uiModel) advanceTransientStatusQueue() tea.Cmd {
 }
 
 func (m *uiModel) startupUpdateNoticeCmd(status clientui.UpdateStatus) tea.Cmd {
-	if !status.Available || strings.TrimSpace(status.LatestVersion) == "" {
+	if status.Available && strings.TrimSpace(status.LatestVersion) != "" {
+		return func() tea.Msg {
+			return startupUpdateNoticeMsg{version: status.LatestVersion}
+		}
+	}
+	if status.Checked {
+		return nil
+	}
+	client := m.runtimeClient()
+	if client == nil {
 		return nil
 	}
 	return func() tea.Msg {
-		return startupUpdateNoticeMsg{version: status.LatestVersion}
+		refreshed, err := client.RefreshMainView()
+		if err != nil || !refreshed.Status.Update.Available || strings.TrimSpace(refreshed.Status.Update.LatestVersion) == "" {
+			return nil
+		}
+		return startupUpdateNoticeMsg{version: refreshed.Status.Update.LatestVersion}
 	}
 }
 

--- a/cli/app/ui_input_controller.go
+++ b/cli/app/ui_input_controller.go
@@ -59,8 +59,12 @@ var pendingToolSpinner = bubblespinner.Spinner{
 }
 var spinnerTickInterval = pendingToolSpinner.FPS
 var transientStatusDuration = 8 * time.Second
-var scheduleTransientStatusClear = func(token uint64) tea.Cmd {
-	return tea.Tick(transientStatusDuration, func(time.Time) tea.Msg {
+var updateNoticeDuration = 5 * time.Second
+var scheduleTransientStatusClear = func(duration time.Duration, token uint64) tea.Cmd {
+	if duration <= 0 {
+		duration = transientStatusDuration
+	}
+	return tea.Tick(duration, func(time.Time) tea.Msg {
 		return clearTransientStatusMsg{token: token}
 	})
 }

--- a/cli/app/ui_layout_rendering_status.go
+++ b/cli/app/ui_layout_rendering_status.go
@@ -190,6 +190,8 @@ func statusNoticeStyle(theme string, kind uiStatusNoticeKind) lipgloss.Style {
 	switch kind {
 	case uiStatusNoticeSuccess:
 		color = palette.secondary
+	case uiStatusNoticeUpdateAvailable:
+		color = statusGreenColor()
 	case uiStatusNoticeError:
 		color = statusRedColor()
 	}

--- a/cli/app/ui_layout_rendering_status_overlay.go
+++ b/cli/app/ui_layout_rendering_status_overlay.go
@@ -119,6 +119,9 @@ func (l uiViewLayout) statusOverlayContentLines(width int) []string {
 	}
 	appendWrapped("CWD: "+statusValueOrFallback(snapshot.Workdir, "<unknown>"), boldStyle)
 	appendANSI(l.renderStatusModelLine(width, snapshot.Model.Summary))
+	if updateLine := l.renderStatusUpdateLine(width, snapshot.Update); updateLine != "" {
+		appendANSI(updateLine)
+	}
 	if sessionName := strings.TrimSpace(snapshot.SessionName); sessionName != "" {
 		appendWrapped(sessionName, boldStyle)
 	}
@@ -197,6 +200,15 @@ func (l uiViewLayout) statusOverlayContentLines(width int) []string {
 		appendWrapped(warning, warningStyle)
 	}
 	return lines
+}
+
+func (l uiViewLayout) renderStatusUpdateLine(width int, update uiStatusUpdateInfo) string {
+	if !update.Available || strings.TrimSpace(update.LatestVersion) == "" {
+		return ""
+	}
+	text := "Update: available " + strings.TrimSpace(update.LatestVersion)
+	style := lipgloss.NewStyle().Foreground(statusGreenColor()).Bold(true)
+	return padANSIRight(style.Render(truncateQueuedMessageLine(text, width)), width)
 }
 
 func (l uiViewLayout) statusSectionLoading(section uiStatusSection) bool {

--- a/cli/app/ui_loop.go
+++ b/cli/app/ui_loop.go
@@ -8,10 +8,10 @@ import (
 )
 
 func runUILoop(wiring *runtimeWiring, active config.Settings, logger *runLogger, commandRegistry *commands.Registry) (tea.Model, error) {
-	return runUILoopWithInitialPrompt(wiring, active, logger, commandRegistry, "", "", "", false, active.Model, uiStatusConfig{})
+	return runUILoopWithInitialPrompt(wiring, active, logger, commandRegistry, "", "", "", false, active.Model, uiStatusConfig{}, false)
 }
 
-func runUILoopWithInitialPrompt(wiring *runtimeWiring, active config.Settings, logger *runLogger, commandRegistry *commands.Registry, initialPrompt string, initialInput string, sessionName string, modelContractLocked bool, configuredModelName string, statusConfig uiStatusConfig) (tea.Model, error) {
+func runUILoopWithInitialPrompt(wiring *runtimeWiring, active config.Settings, logger *runLogger, commandRegistry *commands.Registry, initialPrompt string, initialInput string, sessionName string, modelContractLocked bool, configuredModelName string, statusConfig uiStatusConfig, startupUpdateNotice bool) (tea.Model, error) {
 	options := mainUIProgramOptions(active)
 	runtimeClient := wiring.runtimeClient
 	if runtimeClient == nil {
@@ -60,6 +60,7 @@ func runUILoopWithInitialPrompt(wiring *runtimeWiring, active config.Settings, l
 		WithUISessionName(sessionName),
 		WithUISessionID(sessionID),
 		WithUIStatusConfig(statusConfig),
+		WithUIStartupUpdateNotice(startupUpdateNotice),
 	)
 	if closable, ok := model.(interface{ Close() }); ok {
 		defer closable.Close()

--- a/cli/app/ui_native_scrollback_integration_part2_test.go
+++ b/cli/app/ui_native_scrollback_integration_part2_test.go
@@ -213,6 +213,9 @@ func TestNativeFinalizeDoesNotBlinkDuplicateTailTokens(t *testing.T) {
 		if model.sawAssistantDelta {
 			return false
 		}
+		if strings.Count(model.nativeRenderedSnapshot, "TAIL-ONCE") != 1 {
+			return false
+		}
 		for _, entry := range eng.ChatSnapshot().Entries {
 			if strings.Contains(entry.Text, "NO_OP") {
 				return false
@@ -232,9 +235,11 @@ func TestNativeFinalizeDoesNotBlinkDuplicateTailTokens(t *testing.T) {
 		t.Fatal("program did not terminate")
 	}
 
-	plain := xansi.Strip(out.String())
-	if strings.Contains(plain, "TAIL-ONCETAIL-ONCE") {
-		t.Fatalf("expected no duplicated tail token blink pattern, got %q", plain)
+	if count := strings.Count(model.nativeRenderedSnapshot, "TAIL-ONCE"); count != 1 {
+		t.Fatalf("expected native rendered snapshot to contain tail token once, count=%d snapshot=%q", count, model.nativeRenderedSnapshot)
+	}
+	if strings.Contains(xansi.Strip(out.String()), "TAIL-ONCETAIL-ONCE") {
+		t.Fatalf("expected no adjacent duplicate tail token writes, got %q", normalizedOutput(out.String()))
 	}
 }
 

--- a/cli/app/ui_part3_test.go
+++ b/cli/app/ui_part3_test.go
@@ -6,6 +6,7 @@ import (
 	"builder/server/session"
 	"builder/server/tools"
 	"builder/server/tools/askquestion"
+	"builder/shared/clientui"
 	"bytes"
 	"context"
 	"errors"
@@ -44,6 +45,79 @@ func TestShowErrorStatusSetsErrorNoticeKind(t *testing.T) {
 	}
 	if m.transientStatusKind != uiStatusNoticeError {
 		t.Fatalf("expected error notice kind, got %d", m.transientStatusKind)
+	}
+}
+
+func TestTransientStatusQueuePromotesNextNoticeAfterClear(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	first := m.enqueueTransientStatus("first", uiStatusNoticeSuccess)
+	second := m.enqueueTransientStatus("second", uiStatusNoticeError)
+
+	if first == nil {
+		t.Fatal("expected first notice clear command")
+	}
+	if second != nil {
+		t.Fatalf("expected queued notice to wait for active clear, got %T", second())
+	}
+	if m.transientStatus != "first" {
+		t.Fatalf("active notice = %q, want first", m.transientStatus)
+	}
+
+	next, cmd := m.Update(clearTransientStatusMsg{token: m.transientStatusToken})
+	updated := next.(*uiModel)
+	if updated.transientStatus != "second" {
+		t.Fatalf("promoted notice = %q, want second", updated.transientStatus)
+	}
+	if updated.transientStatusKind != uiStatusNoticeError {
+		t.Fatalf("promoted notice kind = %d, want error", updated.transientStatusKind)
+	}
+	if cmd == nil {
+		t.Fatal("expected promoted notice clear command")
+	}
+}
+
+func TestTransientStatusReplaceUpdatesActiveNoticeImmediately(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	first := m.setTransientStatusWithKind("first", uiStatusNoticeSuccess)
+	second := m.setTransientStatusWithKind("second", uiStatusNoticeError)
+
+	if first == nil || second == nil {
+		t.Fatal("expected replacement notices to schedule clear commands")
+	}
+	if m.transientStatus != "second" {
+		t.Fatalf("active notice = %q, want second", m.transientStatus)
+	}
+	if m.transientStatusKind != uiStatusNoticeError {
+		t.Fatalf("active notice kind = %d, want error", m.transientStatusKind)
+	}
+}
+
+func TestStartupUpdateNoticeShowsAvailableVersionOnce(t *testing.T) {
+	client := &runtimeControlFakeClient{
+		status: clientui.RuntimeStatus{
+			Update: clientui.UpdateStatus{Checked: true, Available: true, LatestVersion: "1.2.3"},
+		},
+		sessionView: clientui.RuntimeSessionView{SessionID: "session-1"},
+	}
+	m := newProjectedTestUIModel(client, nil, nil, WithUIStartupUpdateNotice(true))
+
+	msg := m.startupUpdateNoticeCmd(client.status.Update)()
+	next, cmd := m.Update(msg)
+	updated := next.(*uiModel)
+	if updated.transientStatus != "update available: 1.2.3" {
+		t.Fatalf("startup update notice = %q", updated.transientStatus)
+	}
+	if updated.transientStatusKind != uiStatusNoticeUpdateAvailable {
+		t.Fatalf("startup update notice kind = %d, want update available", updated.transientStatusKind)
+	}
+	if cmd == nil {
+		t.Fatal("expected update notice clear command")
+	}
+
+	next, _ = updated.Update(startupUpdateNoticeMsg{version: "1.2.4"})
+	updated = next.(*uiModel)
+	if updated.transientStatus != "update available: 1.2.3" {
+		t.Fatalf("expected duplicate startup update notice suppressed, got %q", updated.transientStatus)
 	}
 }
 

--- a/cli/app/ui_part3_test.go
+++ b/cli/app/ui_part3_test.go
@@ -121,6 +121,38 @@ func TestStartupUpdateNoticeShowsAvailableVersionOnce(t *testing.T) {
 	}
 }
 
+func TestStartupUpdateNoticeMarksShownOnlyAfterDisplay(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	initialClear := m.setTransientStatusWithKind("busy", uiStatusNoticeNeutral)
+	if initialClear == nil {
+		t.Fatal("expected initial notice clear command")
+	}
+
+	next, cmd := m.Update(startupUpdateNoticeMsg{version: "1.2.3"})
+	updated := next.(*uiModel)
+	if cmd != nil {
+		t.Fatalf("expected queued update notice to wait for active clear, got %T", cmd())
+	}
+	if updated.startupUpdateShown {
+		t.Fatal("did not expect startup update notice marked shown while queued")
+	}
+	if updated.transientStatus != "busy" {
+		t.Fatalf("active notice = %q, want busy", updated.transientStatus)
+	}
+
+	next, cmd = updated.Update(clearTransientStatusMsg{token: updated.transientStatusToken})
+	updated = next.(*uiModel)
+	if updated.transientStatus != "update available: 1.2.3" {
+		t.Fatalf("promoted startup update notice = %q", updated.transientStatus)
+	}
+	if !updated.startupUpdateShown {
+		t.Fatal("expected startup update notice marked shown after promotion")
+	}
+	if cmd == nil {
+		t.Fatal("expected promoted update notice clear command")
+	}
+}
+
 func TestMainInputSupportsInlineCursorEditing(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.input = "hello world"

--- a/cli/app/ui_part7_test.go
+++ b/cli/app/ui_part7_test.go
@@ -669,6 +669,10 @@ func TestSlashFastTogglesAndShowsStatus(t *testing.T) {
 	if !strings.Contains(plain, "Fast mode enabled") {
 		t.Fatalf("expected transcript notice for /fast toggle, got %q", plain)
 	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
 
 	updated.input = "/fast off"
 	next, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -702,6 +706,34 @@ func TestSlashFastTogglesAndShowsStatus(t *testing.T) {
 	}
 	if updated.transientStatus != "Fast mode disabled" {
 		t.Fatalf("did not expect /fast status to overwrite transient status, got %q", updated.transientStatus)
+	}
+}
+
+func TestSlashFastStatusNoticeReplacesWithoutWaitingForClear(t *testing.T) {
+	m := newProjectedStaticUIModel(WithUIFastModeAvailable(true))
+	m.termWidth = 100
+	m.termHeight = 24
+	m.windowSizeKnown = true
+	m.syncViewport()
+	m.input = "/fast on"
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	if !updated.fastModeEnabled {
+		t.Fatal("expected fast mode enabled")
+	}
+	if !strings.Contains(updated.transientStatus, "Fast mode enabled") {
+		t.Fatalf("expected enable status, got %q", updated.transientStatus)
+	}
+
+	updated.input = "/fast off"
+	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = next.(*uiModel)
+	if updated.fastModeEnabled {
+		t.Fatal("expected fast mode disabled")
+	}
+	if !strings.Contains(updated.transientStatus, "Fast mode disabled") {
+		t.Fatalf("expected immediate replacement disable status, got %q", updated.transientStatus)
 	}
 }
 
@@ -794,6 +826,10 @@ func TestSlashSupervisorTogglesReviewerInvocationAndShowsStatus(t *testing.T) {
 	plain := stripANSIAndTrimRight(updated.View())
 	if !strings.Contains(plain, "Supervisor invocation enabled") {
 		t.Fatalf("expected transcript notice for /supervisor toggle, got %q", plain)
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
 	}
 
 	updated.input = "/supervisor off"

--- a/cli/app/ui_part8_test.go
+++ b/cli/app/ui_part8_test.go
@@ -154,6 +154,10 @@ func TestSlashAutoCompactionTogglesAndShowsStatus(t *testing.T) {
 	if !strings.Contains(plain, "Auto-compaction disabled") {
 		t.Fatalf("expected transcript notice for /autocompaction toggle, got %q", plain)
 	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
 
 	updated.input = "/autocompaction on"
 	next, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})

--- a/cli/app/ui_slash_command_picker_test.go
+++ b/cli/app/ui_slash_command_picker_test.go
@@ -456,9 +456,6 @@ func TestRollbackEditRejectsSlashCommandSubmitAndAutocomplete(t *testing.T) {
 	updated.input = "/sta"
 	next, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyTab})
 	updated = next.(*uiModel)
-	if cmd == nil {
-		t.Fatal("expected transient status command for blocked edit-mode slash autocomplete")
-	}
 	if updated.input != "/sta" {
 		t.Fatalf("expected blocked slash autocomplete to preserve input, got %q", updated.input)
 	}

--- a/cli/app/ui_status.go
+++ b/cli/app/ui_status.go
@@ -103,6 +103,7 @@ type uiStatusSnapshot struct {
 	Auth              uiStatusAuthInfo
 	Context           uiStatusContextInfo
 	Model             uiStatusModelInfo
+	Update            uiStatusUpdateInfo
 	Config            uiStatusConfigInfo
 	Subscription      uiStatusSubscriptionInfo
 	Skills            []runtime.SkillInspection
@@ -137,6 +138,12 @@ type uiStatusContextInfo struct {
 
 type uiStatusModelInfo struct {
 	Summary string
+}
+
+type uiStatusUpdateInfo struct {
+	Checked       bool
+	Available     bool
+	LatestVersion string
 }
 
 type uiStatusConfigInfo struct {
@@ -346,6 +353,7 @@ func (defaultUIStatusCollector) CollectBase(req uiStatusRequest) uiStatusSnapsho
 		OwnsServer:      req.OwnsServer,
 		Context:         contextInfo,
 		Model:           uiStatusModelInfo{Summary: statusModelSummary(req)},
+		Update:          statusUpdateInfo(req),
 		Config: uiStatusConfigInfo{
 			SettingsPath:    filepath.ToSlash(strings.TrimSpace(req.Source.SettingsPath)),
 			OverrideSources: statusConfigOverrideSources(req.Source),
@@ -354,6 +362,18 @@ func (defaultUIStatusCollector) CollectBase(req uiStatusRequest) uiStatusSnapsho
 			Debug:           req.Settings.Debug,
 		},
 		CompactionCount: compactionCount,
+	}
+}
+
+func statusUpdateInfo(req uiStatusRequest) uiStatusUpdateInfo {
+	if req.Runtime == nil {
+		return uiStatusUpdateInfo{}
+	}
+	status := req.Runtime.Status().Update
+	return uiStatusUpdateInfo{
+		Checked:       status.Checked,
+		Available:     status.Available,
+		LatestVersion: strings.TrimSpace(status.LatestVersion),
 	}
 }
 

--- a/cli/app/ui_status_test.go
+++ b/cli/app/ui_status_test.go
@@ -81,6 +81,7 @@ func TestStatusCommandOpensDetailOverlayInNativeMode(t *testing.T) {
 		Model: uiStatusModelInfo{
 			Summary: "gpt-5 high fast",
 		},
+		Update: uiStatusUpdateInfo{Checked: true, Available: true, LatestVersion: "1.2.3"},
 		Config: uiStatusConfigInfo{
 			SettingsPath:    "/Users/test/.builder/config.toml",
 			OverrideSources: []string{"ENV", "CLI ARGS"},
@@ -137,7 +138,7 @@ func TestStatusCommandOpensDetailOverlayInNativeMode(t *testing.T) {
 	next, _ = updated.Update(statusRefreshDoneMsg{token: updated.status.refreshToken, snapshot: collector.snapshot})
 	updated = next.(*uiModel)
 	plain := stripANSIAndTrimRight(updated.View())
-	for _, want := range []string{"Pro subscription", "Server: owned by this CLI", "CWD: /tmp/workdir", "Model: gpt-5 high fast", "incident", "Parent session: incident-root <parent-456>", "session-123", "master", "dirty | ahead 2 | behind 1"} {
+	for _, want := range []string{"Pro subscription", "Server: owned by this CLI", "CWD: /tmp/workdir", "Model: gpt-5 high fast", "Update: available 1.2.3", "incident", "Parent session: incident-root <parent-456>", "session-123", "master", "dirty | ahead 2 | behind 1"} {
 		if !strings.Contains(plain, want) {
 			t.Fatalf("expected status overlay to contain %q, got %q", want, plain)
 		}

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -22,7 +22,7 @@ curl -fsSL https://raw.githubusercontent.com/respawn-app/builder/main/scripts/in
 
 Check the installed version with: `builder --version`
 
-Interactive sessions show `update available: <version>` in the status line when a newer release is published. `/status` shows the same update state.
+Interactive sessions show a one-time startup notice, `update available: <version>`, in the first interactive session when a newer release is published. `/status` shows the same update state.
 
 ## First Authentication
 

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -22,6 +22,8 @@ curl -fsSL https://raw.githubusercontent.com/respawn-app/builder/main/scripts/in
 
 Check the installed version with: `builder --version`
 
+Interactive sessions show `update available: <version>` in the status line when a newer release is published. `/status` shows the same update state.
+
 ## First Authentication
 
 Start Builder CLI with: `builder`

--- a/server/core/core.go
+++ b/server/core/core.go
@@ -150,7 +150,6 @@ func New(cfg config.App, authSupport serverbootstrap.AuthSupport, runtimeSupport
 	authBootstrapService := authbootstrap.NewService(authSupport.AuthManager, authSupport.OAuthOptions, protocol.AllowedPreAuthMethods())
 	authStatusService := authstatus.NewService(authSupport.AuthManager)
 	updateStatusService := updatestatus.NewService(buildinfo.Version)
-	updateStatusService.Start()
 	sessionViewService := sessionview.NewService(registry.NewGlobalPersistenceSessionResolver(cfg.PersistenceRoot, storeOptions...), runtimeRegistry, metadataStore).WithCacheWarningMode(cfg.Settings.CacheWarningMode).WithUpdateStatusProvider(updateStatusService)
 	sessionLifecycleService := sessionlifecycle.NewGlobalService(cfg.PersistenceRoot, sessionStoreRegistry, authSupport.AuthManager, storeOptions...).WithControllerLeaseVerifier(sessionRuntimeService)
 	sessionActivityService := sessionactivity.NewService(runtimeRegistry)
@@ -210,6 +209,7 @@ func New(cfg config.App, authSupport serverbootstrap.AuthSupport, runtimeSupport
 			}
 		}
 	}
+	updateStatusService.Start()
 	return core, nil
 }
 

--- a/server/core/core.go
+++ b/server/core/core.go
@@ -36,7 +36,9 @@ import (
 	"builder/server/storagemigration"
 	askquestion "builder/server/tools/askquestion"
 	shelltool "builder/server/tools/shell"
+	"builder/server/updatestatus"
 	"builder/server/worktree"
+	"builder/shared/buildinfo"
 	"builder/shared/client"
 	"builder/shared/clientui"
 	"builder/shared/config"
@@ -78,6 +80,7 @@ type Core struct {
 	sessionActivity  client.SessionActivityClient
 	worktrees        client.WorktreeClient
 	runPrompt        client.RunPromptClient
+	updateStatus     *updatestatus.Service
 }
 
 type unregisteredSessionLaunchClient struct{}
@@ -146,7 +149,9 @@ func New(cfg config.App, authSupport serverbootstrap.AuthSupport, runtimeSupport
 	projectViews := client.NewLoopbackProjectViewClient(projectService)
 	authBootstrapService := authbootstrap.NewService(authSupport.AuthManager, authSupport.OAuthOptions, protocol.AllowedPreAuthMethods())
 	authStatusService := authstatus.NewService(authSupport.AuthManager)
-	sessionViewService := sessionview.NewService(registry.NewGlobalPersistenceSessionResolver(cfg.PersistenceRoot, storeOptions...), runtimeRegistry, metadataStore).WithCacheWarningMode(cfg.Settings.CacheWarningMode)
+	updateStatusService := updatestatus.NewService(buildinfo.Version)
+	updateStatusService.Start()
+	sessionViewService := sessionview.NewService(registry.NewGlobalPersistenceSessionResolver(cfg.PersistenceRoot, storeOptions...), runtimeRegistry, metadataStore).WithCacheWarningMode(cfg.Settings.CacheWarningMode).WithUpdateStatusProvider(updateStatusService)
 	sessionLifecycleService := sessionlifecycle.NewGlobalService(cfg.PersistenceRoot, sessionStoreRegistry, authSupport.AuthManager, storeOptions...).WithControllerLeaseVerifier(sessionRuntimeService)
 	sessionActivityService := sessionactivity.NewService(runtimeRegistry)
 	core := &Core{
@@ -180,6 +185,7 @@ func New(cfg config.App, authSupport serverbootstrap.AuthSupport, runtimeSupport
 		sessionActivity:  client.NewLoopbackSessionActivityClient(sessionActivityService),
 		worktrees:        client.NewLoopbackWorktreeClient(worktreeService),
 		runPrompt:        unregisteredRunPromptClient{},
+		updateStatus:     updateStatusService,
 	}
 	if strings.TrimSpace(cfg.WorkspaceRoot) != "" {
 		binding, err := metadataStore.EnsureWorkspaceBinding(context.Background(), cfg.WorkspaceRoot)

--- a/server/embedded/embedded_test.go
+++ b/server/embedded/embedded_test.go
@@ -21,6 +21,7 @@ import (
 	"builder/server/session"
 	"builder/server/tools"
 	shelltool "builder/server/tools/shell"
+	"builder/shared/clientui"
 	"builder/shared/config"
 	"builder/shared/serverapi"
 	"builder/shared/testopenai"
@@ -744,23 +745,35 @@ func TestProcessOutputClientStreamsBackgroundProcessOutput(t *testing.T) {
 	}
 	defer func() { _ = sub.Close() }()
 
-	first, err := sub.Next(ctx)
-	if err != nil {
-		t.Fatalf("first Next: %v", err)
+	chunks := make([]clientui.ProcessOutputChunk, 0, 2)
+	for {
+		chunk, err := sub.Next(ctx)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		if chunk.ProcessID != result.SessionID {
+			t.Fatalf("unexpected chunk process id: %+v", chunk)
+		}
+		if len(chunks) > 0 {
+			previous := chunks[len(chunks)-1]
+			if chunk.OffsetBytes != previous.NextOffsetBytes || chunk.NextOffsetBytes <= chunk.OffsetBytes {
+				t.Fatalf("unexpected chunk offsets previous=%+v current=%+v", previous, chunk)
+			}
+		}
+		chunks = append(chunks, chunk)
 	}
-	if first.ProcessID != result.SessionID || !strings.Contains(first.Text, "first") {
-		t.Fatalf("unexpected first chunk: %+v", first)
+	combined := strings.Builder{}
+	for _, chunk := range chunks {
+		combined.WriteString(chunk.Text)
 	}
-
-	second, err := sub.Next(ctx)
-	if err != nil {
-		t.Fatalf("second Next: %v", err)
-	}
-	if second.OffsetBytes <= first.OffsetBytes || second.NextOffsetBytes <= second.OffsetBytes || !strings.Contains(second.Text, "second") {
-		t.Fatalf("unexpected second chunk: %+v", second)
-	}
-	if _, err := sub.Next(ctx); !errors.Is(err, io.EOF) {
-		t.Fatalf("expected EOF after process exit, got %v", err)
+	combinedText := combined.String()
+	firstIndex := strings.Index(combinedText, "first")
+	secondIndex := strings.Index(combinedText, "second")
+	if len(chunks) == 0 || firstIndex < 0 || secondIndex < firstIndex {
+		t.Fatalf("expected streamed process output to contain first and second, chunks=%+v", chunks)
 	}
 }
 

--- a/server/sessionview/service.go
+++ b/server/sessionview/service.go
@@ -27,10 +27,15 @@ type ExecutionTargetResolver interface {
 	ResolveSessionExecutionTarget(ctx context.Context, sessionID string) (clientui.SessionExecutionTarget, error)
 }
 
+type UpdateStatusProvider interface {
+	Status(ctx context.Context) clientui.UpdateStatus
+}
+
 type Service struct {
 	sessions         SessionStoreResolver
 	runtimes         RuntimeResolver
 	targets          ExecutionTargetResolver
+	updates          UpdateStatusProvider
 	dormant          *dormantTranscriptCache
 	cacheWarningMu   sync.RWMutex
 	cacheWarningMode config.CacheWarningMode
@@ -59,6 +64,14 @@ func (s *Service) WithCacheWarningMode(mode config.CacheWarningMode) *Service {
 	if changed && s.dormant != nil {
 		s.dormant.clear()
 	}
+	return s
+}
+
+func (s *Service) WithUpdateStatusProvider(provider UpdateStatusProvider) *Service {
+	if s == nil {
+		return nil
+	}
+	s.updates = provider
 	return s
 }
 
@@ -232,6 +245,9 @@ func (s *Service) enrichMainViewWithExecutionTarget(ctx context.Context, view cl
 		return clientui.RuntimeMainView{}, err
 	}
 	view.Session = sessionView
+	if s.updates != nil {
+		view.Status.Update = s.updates.Status(ctx)
+	}
 	return view, nil
 }
 

--- a/server/sessionview/service_test.go
+++ b/server/sessionview/service_test.go
@@ -52,6 +52,14 @@ func (r staticExecutionTargetResolver) ResolveSessionExecutionTarget(context.Con
 	return r.target, nil
 }
 
+type staticUpdateStatusProvider struct {
+	status clientui.UpdateStatus
+}
+
+func (p staticUpdateStatusProvider) Status(context.Context) clientui.UpdateStatus {
+	return p.status
+}
+
 func (serviceBlockingTool) Name() toolspec.ID { return toolspec.ToolExecCommand }
 
 func (t serviceBlockingTool) Call(_ context.Context, c tools.Call) (tools.Result, error) {
@@ -111,6 +119,25 @@ func TestServiceGetSessionMainViewUsesLiveRuntimeWhenAttached(t *testing.T) {
 	close(release)
 	if err := <-done; err != nil {
 		t.Fatalf("submit user message: %v", err)
+	}
+}
+
+func TestServiceGetSessionMainViewIncludesUpdateStatus(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	svc := NewService(NewStaticSessionResolver(store), nil, nil).WithUpdateStatusProvider(staticUpdateStatusProvider{
+		status: clientui.UpdateStatus{Checked: true, Available: true, LatestVersion: "1.2.3"},
+	})
+
+	resp, err := svc.GetSessionMainView(context.Background(), serverapi.SessionMainViewRequest{SessionID: store.Meta().SessionID})
+	if err != nil {
+		t.Fatalf("get session main view: %v", err)
+	}
+	if resp.MainView.Status.Update.LatestVersion != "1.2.3" || !resp.MainView.Status.Update.Available {
+		t.Fatalf("unexpected update status: %+v", resp.MainView.Status.Update)
 	}
 }
 

--- a/server/updatestatus/service.go
+++ b/server/updatestatus/service.go
@@ -1,0 +1,206 @@
+package updatestatus
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"builder/shared/clientui"
+)
+
+const defaultLatestReleaseURL = "https://api.github.com/repos/respawn-app/builder/releases/latest"
+
+type Service struct {
+	currentVersion string
+	latestURL      string
+	client         *http.Client
+
+	mu       sync.Mutex
+	status   clientui.UpdateStatus
+	inflight chan struct{}
+	disabled bool
+}
+
+type Option func(*Service)
+
+func WithHTTPClient(client *http.Client) Option {
+	return func(s *Service) {
+		if client != nil {
+			s.client = client
+		}
+	}
+}
+
+func WithLatestReleaseURL(url string) Option {
+	return func(s *Service) {
+		if strings.TrimSpace(url) != "" {
+			s.latestURL = strings.TrimSpace(url)
+		}
+	}
+}
+
+func NewService(currentVersion string, opts ...Option) *Service {
+	s := &Service{
+		currentVersion: normalizeVersion(currentVersion),
+		latestURL:      defaultLatestReleaseURL,
+		client:         http.DefaultClient,
+		status: clientui.UpdateStatus{
+			CurrentVersion: normalizeVersion(currentVersion),
+		},
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	s.disabled = !isComparableVersion(s.currentVersion)
+	return s
+}
+
+func (s *Service) Status(ctx context.Context) clientui.UpdateStatus {
+	if s == nil {
+		return clientui.UpdateStatus{}
+	}
+	s.mu.Lock()
+	if s.disabled {
+		status := s.status
+		s.mu.Unlock()
+		return status
+	}
+	if s.status.Checked {
+		status := s.status
+		s.mu.Unlock()
+		return status
+	}
+	if s.inflight == nil {
+		s.inflight = make(chan struct{})
+		done := s.inflight
+		go s.refresh(done)
+	}
+	done := s.inflight
+	s.mu.Unlock()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.status
+}
+
+func (s *Service) Start() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.disabled {
+		s.mu.Unlock()
+		return
+	}
+	if s.status.Checked || s.inflight != nil {
+		s.mu.Unlock()
+		return
+	}
+	s.inflight = make(chan struct{})
+	done := s.inflight
+	s.mu.Unlock()
+	go s.refresh(done)
+}
+
+func (s *Service) refresh(done chan struct{}) {
+	defer close(done)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	latest, err := s.fetchLatestVersion(ctx)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer func() { s.inflight = nil }()
+	if err != nil {
+		s.status.Checked = true
+		return
+	}
+	s.status.Checked = true
+	s.status.LatestVersion = latest
+	s.status.Available = compareVersions(latest, s.currentVersion) > 0
+}
+
+func (s *Service) fetchLatestVersion(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.latestURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "builder")
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", errors.New(resp.Status)
+	}
+	var payload struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+	latest := normalizeVersion(payload.TagName)
+	if !isComparableVersion(latest) {
+		return "", errors.New("latest release tag is not semantic")
+	}
+	return latest, nil
+}
+
+func normalizeVersion(version string) string {
+	return strings.TrimPrefix(strings.TrimSpace(version), "v")
+}
+
+func isComparableVersion(version string) bool {
+	parts := versionParts(version)
+	return len(parts) == 3
+}
+
+func compareVersions(left string, right string) int {
+	leftParts := versionParts(left)
+	rightParts := versionParts(right)
+	if len(leftParts) != 3 || len(rightParts) != 3 {
+		return 0
+	}
+	for idx := 0; idx < 3; idx++ {
+		if leftParts[idx] > rightParts[idx] {
+			return 1
+		}
+		if leftParts[idx] < rightParts[idx] {
+			return -1
+		}
+	}
+	return 0
+}
+
+func versionParts(version string) []int {
+	rawParts := strings.Split(normalizeVersion(version), ".")
+	if len(rawParts) != 3 {
+		return nil
+	}
+	parts := make([]int, 0, 3)
+	for _, raw := range rawParts {
+		if raw == "" {
+			return nil
+		}
+		value := 0
+		for _, r := range raw {
+			if r < '0' || r > '9' {
+				return nil
+			}
+			value = value*10 + int(r-'0')
+		}
+		parts = append(parts, value)
+	}
+	return parts
+}

--- a/server/updatestatus/service.go
+++ b/server/updatestatus/service.go
@@ -56,6 +56,9 @@ func NewService(currentVersion string, opts ...Option) *Service {
 		opt(s)
 	}
 	s.disabled = !isComparableVersion(s.currentVersion)
+	if s.disabled {
+		s.status.Checked = true
+	}
 	return s
 }
 

--- a/server/updatestatus/service_test.go
+++ b/server/updatestatus/service_test.go
@@ -1,0 +1,66 @@
+package updatestatus
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStatusReportsAvailableRelease(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.0"}`))
+	}))
+	defer server.Close()
+
+	service := NewService("1.1.0", WithLatestReleaseURL(server.URL), WithHTTPClient(server.Client()))
+	status := service.Status(context.Background())
+
+	if !status.Checked || !status.Available || status.LatestVersion != "1.2.0" || status.CurrentVersion != "1.1.0" {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+}
+
+func TestStatusSkipsDevVersion(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		calls++
+	}))
+	defer server.Close()
+
+	service := NewService("dev", WithLatestReleaseURL(server.URL), WithHTTPClient(server.Client()))
+	status := service.Status(context.Background())
+
+	if status.Checked || status.Available || calls != 0 {
+		t.Fatalf("unexpected dev status=%+v calls=%d", status, calls)
+	}
+}
+
+func TestStatusCachesFailedCheck(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	service := NewService("1.1.0", WithLatestReleaseURL(server.URL), WithHTTPClient(server.Client()))
+	first := service.Status(context.Background())
+	second := service.Status(context.Background())
+
+	if !first.Checked || !second.Checked || first.Available || second.Available || calls != 1 {
+		t.Fatalf("unexpected failed-check cache: first=%+v second=%+v calls=%d", first, second, calls)
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	if compareVersions("1.10.0", "1.9.9") <= 0 {
+		t.Fatal("expected numeric semver ordering")
+	}
+	if compareVersions("1.0.0", "1.0.0") != 0 {
+		t.Fatal("expected equal versions")
+	}
+	if compareVersions("1.0.0", "1.0.1") >= 0 {
+		t.Fatal("expected patch ordering")
+	}
+}

--- a/server/updatestatus/service_test.go
+++ b/server/updatestatus/service_test.go
@@ -31,7 +31,7 @@ func TestStatusSkipsDevVersion(t *testing.T) {
 	service := NewService("dev", WithLatestReleaseURL(server.URL), WithHTTPClient(server.Client()))
 	status := service.Status(context.Background())
 
-	if status.Checked || status.Available || calls != 0 {
+	if !status.Checked || status.Available || calls != 0 {
 		t.Fatalf("unexpected dev status=%+v calls=%d", status, calls)
 	}
 }

--- a/shared/clientui/runtime.go
+++ b/shared/clientui/runtime.go
@@ -36,6 +36,14 @@ type RuntimeStatus struct {
 	CompactionMode                    string
 	ContextUsage                      RuntimeContextUsage
 	CompactionCount                   int
+	Update                            UpdateStatus
+}
+
+type UpdateStatus struct {
+	Checked        bool
+	Available      bool
+	CurrentVersion string
+	LatestVersion  string
 }
 
 type RunStatus string


### PR DESCRIPTION
## Summary
- add a server-cached update status check backed by GitHub releases
- show available updates in /status and once in the first interactive session status line
- add replace/queue statusline notice delivery so direct action feedback stays current

## Verification
- ./scripts/test.sh ./...
- ./scripts/build.sh --output ./bin/builder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic update availability detection that displays "update available: <version>" in the status line when a newer release is available
  * Startup sessions now show an update notice if an update is detected
  * Improved transient notice handling with queuing and deduplication

* **Documentation**
  * Clarified update availability visibility in interactive sessions and `/status` command output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->