### PR TITLE
feat: add Builder background service

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Builder is a highly opinionated terminal coding agent for professional Agentic E
 
 ## Get started 
 
-Everything you need is in the [Quicktart Guide](https://opensource.respawn.pro/builder/quickstart) - start there.
+Everything you need is in the [Quickstart Guide](https://opensource.respawn.pro/builder/quickstart) - start there.
 
 ### Features:
 
@@ -38,20 +38,19 @@ Everything you need is in the [Quicktart Guide](https://opensource.respawn.pro/b
 
 ### What will likely never be implemented
 
-These features are controversial or questionable for model performance, and usually have a better replacement.
-Here is where this project has to be highly opinionated:
+These features are controversial or questionable for model performance, and usually have a better replacement. Here is where this project has to be opinionated:
 
 - Native subagent orchestration inside one process; use separate headless Builder instances instead.
   - Supported path: `builder run "..."` for tmux/background subagent workflows. Agent already does this on its own.
 - Plan mode - the model has native plan capabilities and can always ask questions, rest is just eye candy.
-- MCPs - mcps are net negative on model performance, pollute context, and can be replaced with CLI scripts
+- MCPs - mcps are net negative on model performance, pollute context, and can be replaced with CLI scripts. MCPs can be turned into CLIs easily with tools like [MCPorter](https://github.com/steipete/mcporter)
 - Extra UI candy tool calls. Less tools, less burden on the model.
-- On the fly changing of toolsets or models. Changing models at runtime hurts model performance and invalidates caches.
+- On the fly changing of toolsets or models. Changing models at runtime hurts model performance and invalidates caches, which can cost up to 10x more per invalidation.
 - Microcompaction - this invalidates caches and drives costs up with marginal benefits
-- Sandboxing - Codex's sandbox is annoying, doesn't work with many tools (gradle, java etc), junie's sandbox can be bypassed, claude code's sandbox is brittle and can also be bypassed. Frontier models are not so stupid anymore and are trained not to destroy your PC.
+- Sandboxing - Codex's sandbox is annoying, doesn't work with many tools (gradle, java etc), junie's sandbox can be bypassed, claude code's sandbox is brittle and can also be bypassed. Builder can be easily sandboxed in a true, fully isolated Docker container with remote connection (no ssh hacks).
 - WebFetch tool or similar. Just use [jina.ai](https://r.jina.ai) to fetch urls.
-- Fancy summaries, UI, minimal mode, features for "vibe coding". The philosophy is to build something for professionals (agentic engineers)
-- Anthropic, Gemini, Antigravity subscription usage. Not until that becomes legal.
+- Fancy summaries, UI, minimal mode, features for "vibe coding". The philosophy is to build something for professionals (agentic engineers).
+- Anthropic, Gemini, Antigravity subscription usage. Not until that becomes legal according to those companies' ToS.
 
 ## License
 

--- a/cli/builder/help.go
+++ b/cli/builder/help.go
@@ -28,6 +28,7 @@ func writeRootUsage(fs *flag.FlagSet) {
 		"  builder [flags]",
 		"  builder run [flags] <prompt>",
 		"  builder serve [flags]",
+		"  builder service <status|install|uninstall|start|stop|restart>",
 		"  builder project [path]",
 		"  builder project list",
 		"  builder project create --path <server-path> --name <project-name>",
@@ -38,11 +39,13 @@ func writeRootUsage(fs *flag.FlagSet) {
 		"  `builder` without a subcommand starts the interactive TUI.",
 		"  `builder run` executes one headless prompt and exits.",
 		"  `builder serve` starts the app server in daemon mode.",
+		"  `builder service` manages the Builder server background service.",
 		"  `builder project` / `attach` / `rebind` inspect or repair workspace bindings.",
 	)
 	writeHelpSection(out, "Commands:",
 		"  run      Execute a headless prompt against a workspace and print the final result.",
 		"  serve    Start the Builder app server and keep serving until interrupted.",
+		"  service  Install, inspect, or restart the Builder server background service.",
 		"  project  Inspect project bindings, list projects, or create a project.",
 		"  attach   Attach another workspace path to an existing project.",
 		"  rebind   Retarget one session to a different workspace root.",
@@ -50,6 +53,8 @@ func writeRootUsage(fs *flag.FlagSet) {
 	writeHelpSection(out, "Examples:",
 		"  builder",
 		"  builder run --fast \"summarize the repo\"",
+		"  builder service status",
+		"  builder service install",
 		"  builder project",
 		"  builder attach ../other-checkout",
 		"  builder rebind <session-id> ../moved-workspace",
@@ -224,6 +229,93 @@ func writeServeUsage(fs *flag.FlagSet) {
 	writeHelpSection(out, "Examples:",
 		"  builder serve",
 		"  builder project create --path /srv/repos/app --name app",
+	)
+	writeHelpSection(out, "Flags:")
+	fs.PrintDefaults()
+}
+
+func writeServiceUsage(fs *flag.FlagSet) {
+	if fs == nil {
+		return
+	}
+	out := fs.Output()
+	writeHelpSection(out, "Usage of builder service:",
+		"  builder service status [--json]",
+		"  builder service install [--force] [--no-start]",
+		"  builder service uninstall [--keep-running]",
+		"  builder service start",
+		"  builder service stop",
+		"  builder service restart [--if-installed]",
+	)
+	writeHelpSection(out, "What This Does:",
+		"  Manage the Builder server background service for one shared local `builder serve`.",
+		"  The service starts at login and is supervised by the OS.",
+	)
+	writeHelpSection(out, "Backends:",
+		"  macOS: launchd LaunchAgent.",
+		"  Linux/WSL2: systemd --user unit.",
+		"  Windows: Scheduled Task, with Startup folder fallback when needed.",
+	)
+	writeHelpSection(out, "Examples:",
+		"  builder service status",
+		"  builder service install",
+		"  builder service restart",
+	)
+}
+
+func writeServiceStatusUsage(fs *flag.FlagSet) {
+	if fs == nil {
+		return
+	}
+	out := fs.Output()
+	writeHelpSection(out, "Usage of builder service status:",
+		"  builder service status [--json]",
+	)
+	writeHelpSection(out, "Flags:")
+	fs.PrintDefaults()
+}
+
+func writeServiceInstallUsage(fs *flag.FlagSet) {
+	if fs == nil {
+		return
+	}
+	out := fs.Output()
+	writeHelpSection(out, "Usage of builder service install:",
+		"  builder service install [--force] [--no-start]",
+	)
+	writeHelpSection(out, "Flags:")
+	fs.PrintDefaults()
+}
+
+func writeServiceUninstallUsage(fs *flag.FlagSet) {
+	if fs == nil {
+		return
+	}
+	out := fs.Output()
+	writeHelpSection(out, "Usage of builder service uninstall:",
+		"  builder service uninstall [--keep-running]",
+	)
+	writeHelpSection(out, "Flags:")
+	fs.PrintDefaults()
+}
+
+func writeServiceLifecycleUsage(fs *flag.FlagSet, action serviceAction) {
+	if fs == nil {
+		return
+	}
+	out := fs.Output()
+	writeHelpSection(out, "Usage of builder service "+string(action)+":",
+		"  builder service "+string(action),
+	)
+}
+
+func writeServiceRestartUsage(fs *flag.FlagSet) {
+	if fs == nil {
+		return
+	}
+	out := fs.Output()
+	writeHelpSection(out, "Usage of builder service restart:",
+		"  builder service restart [--if-installed]",
 	)
 	writeHelpSection(out, "Flags:")
 	fs.PrintDefaults()

--- a/cli/builder/main.go
+++ b/cli/builder/main.go
@@ -100,6 +100,9 @@ func rootCommand(args []string, stdin io.Reader, stdout io.Writer, stderr io.Wri
 	if len(args) > 0 && args[0] == "serve" {
 		return serveSubcommand(args[1:], stdout, stderr)
 	}
+	if len(args) > 0 && args[0] == "service" {
+		return serviceSubcommand(args[1:], stdout, stderr)
+	}
 
 	rootFS := flag.NewFlagSet("builder", flag.ContinueOnError)
 	rootFS.SetOutput(stderr)

--- a/cli/builder/service_backend_darwin.go
+++ b/cli/builder/service_backend_darwin.go
@@ -1,0 +1,265 @@
+//go:build darwin
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type launchdServiceBackend struct{}
+
+func currentServiceBackend() serviceBackend {
+	return launchdServiceBackend{}
+}
+
+func (launchdServiceBackend) Name() string {
+	return "launchd"
+}
+
+func (launchdServiceBackend) Install(ctx context.Context, spec serviceSpec, force bool, start bool) error {
+	if err := ensureServiceLogDir(spec); err != nil {
+		return err
+	}
+	path, err := launchdPlistPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create LaunchAgents dir: %w", err)
+	}
+	if !force {
+		if existing, err := os.ReadFile(path); err == nil && !bytes.Equal(existing, []byte(renderLaunchdPlist(spec))) {
+			return fmt.Errorf("Builder background service is already installed at %s; use --force to rewrite it", path)
+		}
+	}
+	if err := os.WriteFile(path, []byte(renderLaunchdPlist(spec)), 0o644); err != nil {
+		return fmt.Errorf("write launchd plist: %w", err)
+	}
+	if start {
+		if loaded, _ := launchdLoaded(ctx); loaded {
+			_, _ = runServiceCommand(ctx, "launchctl", "bootout", launchdDomain()+"/"+serviceLaunchdLabel)
+		}
+		if _, err := runServiceCommand(ctx, "launchctl", "bootstrap", launchdDomain(), path); err != nil {
+			return err
+		}
+		if _, err := runServiceCommand(ctx, "launchctl", "kickstart", "-k", launchdDomain()+"/"+serviceLaunchdLabel); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (launchdServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop bool) error {
+	if stop {
+		_ = launchdServiceBackend{}.Stop(ctx, spec)
+	}
+	path, err := launchdPlistPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove launchd plist: %w", err)
+	}
+	return nil
+}
+
+func (launchdServiceBackend) Start(ctx context.Context, spec serviceSpec) error {
+	path, err := launchdPlistPath()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return errors.New("Builder background service is not installed; run `builder service install`")
+		}
+		return fmt.Errorf("stat launchd plist: %w", err)
+	}
+	if loaded, _ := launchdLoaded(ctx); !loaded {
+		if _, err := runServiceCommand(ctx, "launchctl", "bootstrap", launchdDomain(), path); err != nil {
+			return err
+		}
+	}
+	_, err = runServiceCommand(ctx, "launchctl", "kickstart", "-k", launchdDomain()+"/"+serviceLaunchdLabel)
+	return err
+}
+
+func (launchdServiceBackend) Stop(ctx context.Context, spec serviceSpec) error {
+	if loaded, _ := launchdLoaded(ctx); !loaded {
+		return nil
+	}
+	_, err := runServiceCommand(ctx, "launchctl", "bootout", launchdDomain()+"/"+serviceLaunchdLabel)
+	return err
+}
+
+func (launchdServiceBackend) Restart(ctx context.Context, spec serviceSpec) error {
+	if loaded, _ := launchdLoaded(ctx); !loaded {
+		return launchdServiceBackend{}.Start(ctx, spec)
+	}
+	_, err := runServiceCommand(ctx, "launchctl", "kickstart", "-k", launchdDomain()+"/"+serviceLaunchdLabel)
+	return err
+}
+
+func (launchdServiceBackend) Status(ctx context.Context, spec serviceSpec) (serviceStatus, error) {
+	path, err := launchdPlistPath()
+	if err != nil {
+		return serviceStatus{}, err
+	}
+	installed := false
+	if _, err := os.Stat(path); err == nil {
+		installed = true
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return serviceStatus{}, fmt.Errorf("stat launchd plist: %w", err)
+	}
+	loaded, output := launchdLoaded(ctx)
+	pid := launchdPID(output)
+	return serviceStatus{
+		Backend:     "launchd",
+		Installed:   installed,
+		Loaded:      loaded,
+		Running:     pid > 0,
+		PID:         pid,
+		Command:     readLaunchdRegisteredCommand(path),
+		Endpoint:    spec.Endpoint,
+		Logs:        []string{spec.StdoutLogPath, spec.StderrLogPath},
+		InstallPath: path,
+	}, nil
+}
+
+func readLaunchdRegisteredCommand(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	return parseLaunchdProgramArguments(data)
+}
+
+func parseLaunchdProgramArguments(data []byte) []string {
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	lastKey := ""
+	inProgramArguments := false
+	args := []string{}
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return args
+		}
+		switch typed := token.(type) {
+		case xml.StartElement:
+			switch typed.Name.Local {
+			case "key":
+				lastKey = strings.TrimSpace(readXMLText(decoder, "key"))
+			case "array":
+				if lastKey == "ProgramArguments" {
+					inProgramArguments = true
+				}
+			case "string":
+				text := readXMLText(decoder, "string")
+				if inProgramArguments {
+					args = append(args, text)
+				}
+			}
+		case xml.EndElement:
+			if typed.Name.Local == "array" && inProgramArguments {
+				return args
+			}
+		}
+	}
+}
+
+func readXMLText(decoder *xml.Decoder, endElement string) string {
+	var builder strings.Builder
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return builder.String()
+		}
+		switch typed := token.(type) {
+		case xml.CharData:
+			builder.Write([]byte(typed))
+		case xml.EndElement:
+			if typed.Name.Local == endElement {
+				return builder.String()
+			}
+		}
+	}
+}
+
+func launchdPlistPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", serviceLaunchdLabel+".plist"), nil
+}
+
+func launchdDomain() string {
+	return fmt.Sprintf("gui/%d", os.Getuid())
+}
+
+func launchdLoaded(ctx context.Context) (bool, string) {
+	result, err := runServiceCommand(ctx, "launchctl", "print", launchdDomain()+"/"+serviceLaunchdLabel)
+	if err != nil {
+		return false, result.Text()
+	}
+	return true, result.Text()
+}
+
+func launchdPID(output string) int {
+	for _, line := range strings.Split(output, "\n") {
+		parts := strings.SplitN(strings.TrimSpace(line), "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if strings.TrimSpace(parts[0]) == "pid" {
+			return parsePositiveInt(parts[1])
+		}
+	}
+	return 0
+}
+
+func renderLaunchdPlist(spec serviceSpec) string {
+	var builder strings.Builder
+	builder.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	builder.WriteString(`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">` + "\n")
+	builder.WriteString("<plist version=\"1.0\">\n<dict>\n")
+	writeLaunchdString(&builder, "Label", serviceLaunchdLabel)
+	builder.WriteString("\t<key>ProgramArguments</key>\n\t<array>\n")
+	for _, arg := range serviceCommand(spec) {
+		builder.WriteString("\t\t<string>")
+		_ = xml.EscapeText(&builder, []byte(arg))
+		builder.WriteString("</string>\n")
+	}
+	builder.WriteString("\t</array>\n")
+	writeLaunchdBool(&builder, "RunAtLoad", true)
+	writeLaunchdBool(&builder, "KeepAlive", true)
+	writeLaunchdString(&builder, "StandardOutPath", spec.StdoutLogPath)
+	writeLaunchdString(&builder, "StandardErrorPath", spec.StderrLogPath)
+	builder.WriteString("</dict>\n</plist>\n")
+	return builder.String()
+}
+
+func writeLaunchdString(builder *strings.Builder, key string, value string) {
+	builder.WriteString("\t<key>")
+	_ = xml.EscapeText(builder, []byte(key))
+	builder.WriteString("</key>\n\t<string>")
+	_ = xml.EscapeText(builder, []byte(value))
+	builder.WriteString("</string>\n")
+}
+
+func writeLaunchdBool(builder *strings.Builder, key string, value bool) {
+	builder.WriteString("\t<key>")
+	_ = xml.EscapeText(builder, []byte(key))
+	builder.WriteString("</key>\n")
+	if value {
+		builder.WriteString("\t<true/>\n")
+	} else {
+		builder.WriteString("\t<false/>\n")
+	}
+}

--- a/cli/builder/service_backend_linux.go
+++ b/cli/builder/service_backend_linux.go
@@ -1,0 +1,255 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type systemdServiceBackend struct{}
+
+func currentServiceBackend() serviceBackend {
+	return systemdServiceBackend{}
+}
+
+func (systemdServiceBackend) Name() string {
+	return "systemd"
+}
+
+func (systemdServiceBackend) Install(ctx context.Context, spec serviceSpec, force bool, start bool) error {
+	if err := ensureServiceLogDir(spec); err != nil {
+		return err
+	}
+	path, err := systemdUnitPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create systemd user dir: %w", err)
+	}
+	if !force {
+		if existing, err := os.ReadFile(path); err == nil && strings.TrimSpace(string(existing)) != strings.TrimSpace(renderSystemdUnit(spec)) {
+			return fmt.Errorf("Builder background service is already installed at %s; use --force to rewrite it", path)
+		}
+	}
+	if err := os.WriteFile(path, []byte(renderSystemdUnit(spec)), 0o644); err != nil {
+		return fmt.Errorf("write systemd unit: %w", err)
+	}
+	if _, err := runServiceCommand(ctx, "systemctl", "--user", "daemon-reload"); err != nil {
+		return err
+	}
+	if _, err := runServiceCommand(ctx, "systemctl", "--user", "enable", serviceSystemdUnitName); err != nil {
+		return err
+	}
+	if start {
+		if _, err := runServiceCommand(ctx, "systemctl", "--user", "restart", serviceSystemdUnitName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (systemdServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop bool) error {
+	if stop {
+		_ = systemdServiceBackend{}.Stop(ctx, spec)
+	}
+	_, _ = runServiceCommand(ctx, "systemctl", "--user", "disable", serviceSystemdUnitName)
+	path, err := systemdUnitPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove systemd unit: %w", err)
+	}
+	_, _ = runServiceCommand(ctx, "systemctl", "--user", "daemon-reload")
+	return nil
+}
+
+func (systemdServiceBackend) Start(ctx context.Context, spec serviceSpec) error {
+	if _, err := os.Stat(mustSystemdUnitPath()); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return errors.New("Builder background service is not installed; run `builder service install`")
+		}
+		return fmt.Errorf("stat systemd unit: %w", err)
+	}
+	_, err := runServiceCommand(ctx, "systemctl", "--user", "start", serviceSystemdUnitName)
+	return err
+}
+
+func (systemdServiceBackend) Stop(ctx context.Context, spec serviceSpec) error {
+	_, err := runServiceCommand(ctx, "systemctl", "--user", "stop", serviceSystemdUnitName)
+	if err != nil && strings.Contains(err.Error(), "not loaded") {
+		return nil
+	}
+	return err
+}
+
+func (systemdServiceBackend) Restart(ctx context.Context, spec serviceSpec) error {
+	_, err := runServiceCommand(ctx, "systemctl", "--user", "restart", serviceSystemdUnitName)
+	return err
+}
+
+func (systemdServiceBackend) Status(ctx context.Context, spec serviceSpec) (serviceStatus, error) {
+	path, err := systemdUnitPath()
+	if err != nil {
+		return serviceStatus{}, err
+	}
+	installed := false
+	if _, err := os.Stat(path); err == nil {
+		installed = true
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return serviceStatus{}, fmt.Errorf("stat systemd unit: %w", err)
+	}
+	activeResult, activeErr := runServiceCommand(ctx, "systemctl", "--user", "is-active", serviceSystemdUnitName)
+	loaded := activeErr == nil || strings.TrimSpace(activeResult.Stdout) == "active"
+	running := strings.TrimSpace(activeResult.Stdout) == "active"
+	showResult, _ := runServiceCommand(ctx, "systemctl", "--user", "show", serviceSystemdUnitName, "--property=MainPID", "--value")
+	pid := parsePositiveInt(showResult.Stdout)
+	return serviceStatus{
+		Backend:     "systemd",
+		Installed:   installed,
+		Loaded:      loaded,
+		Running:     running,
+		PID:         pid,
+		Command:     readSystemdRegisteredCommand(path),
+		Endpoint:    spec.Endpoint,
+		Logs:        []string{spec.StdoutLogPath, spec.StderrLogPath},
+		InstallPath: path,
+		Hints: []string{
+			"On headless Linux, run `loginctl enable-linger $USER` if the service should survive logout.",
+		},
+	}, nil
+}
+
+func readSystemdRegisteredCommand(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	for _, rawLine := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if value, ok := strings.CutPrefix(line, "ExecStart="); ok {
+			return parseSystemdCommand(value)
+		}
+	}
+	return nil
+}
+
+func parseSystemdCommand(value string) []string {
+	args := []string{}
+	var builder strings.Builder
+	inQuote := false
+	escaped := false
+	flush := func() {
+		if builder.Len() == 0 {
+			return
+		}
+		args = append(args, builder.String())
+		builder.Reset()
+	}
+	for _, r := range value {
+		if escaped {
+			switch r {
+			case 'n':
+				builder.WriteByte('\n')
+			default:
+				builder.WriteRune(r)
+			}
+			escaped = false
+			continue
+		}
+		switch r {
+		case '\\':
+			escaped = true
+		case '"':
+			inQuote = !inQuote
+		case ' ', '\t':
+			if inQuote {
+				builder.WriteRune(r)
+			} else {
+				flush()
+			}
+		default:
+			builder.WriteRune(r)
+		}
+	}
+	if escaped {
+		builder.WriteByte('\\')
+	}
+	flush()
+	return args
+}
+
+func systemdUnitPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".config", "systemd", "user", serviceSystemdUnitName), nil
+}
+
+func mustSystemdUnitPath() string {
+	path, err := systemdUnitPath()
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
+func renderSystemdUnit(spec serviceSpec) string {
+	lines := []string{
+		"[Unit]",
+		"Description=Builder server background service",
+		"After=network-online.target",
+		"",
+		"[Service]",
+		"Type=simple",
+		"ExecStart=" + systemdCommand(serviceCommand(spec)),
+		"Restart=always",
+		"RestartSec=2",
+		"StandardOutput=append:" + spec.StdoutLogPath,
+		"StandardError=append:" + spec.StderrLogPath,
+		"",
+		"[Install]",
+		"WantedBy=default.target",
+		"",
+	}
+	return strings.Join(lines, "\n")
+}
+
+func systemdCommand(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, systemdQuote(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func systemdQuote(value string) string {
+	if value == "" {
+		return `""`
+	}
+	if !strings.ContainsAny(value, " \t\n\"\\$`") {
+		return value
+	}
+	var builder strings.Builder
+	builder.WriteByte('"')
+	for _, r := range value {
+		switch r {
+		case '"', '\\', '$', '`':
+			builder.WriteByte('\\')
+			builder.WriteRune(r)
+		case '\n':
+			builder.WriteString(`\n`)
+		default:
+			builder.WriteRune(r)
+		}
+	}
+	builder.WriteByte('"')
+	return builder.String()
+}

--- a/cli/builder/service_backend_linux.go
+++ b/cli/builder/service_backend_linux.go
@@ -40,6 +40,14 @@ func (systemdServiceBackend) Install(ctx context.Context, spec serviceSpec, forc
 	if err := os.WriteFile(path, []byte(renderSystemdUnit(spec)), 0o644); err != nil {
 		return fmt.Errorf("write systemd unit: %w", err)
 	}
+	installed := false
+	defer func() {
+		if installed {
+			return
+		}
+		_ = os.Remove(path)
+		_, _ = runServiceCommand(ctx, "systemctl", "--user", "daemon-reload")
+	}()
 	if _, err := runServiceCommand(ctx, "systemctl", "--user", "daemon-reload"); err != nil {
 		return err
 	}
@@ -51,6 +59,7 @@ func (systemdServiceBackend) Install(ctx context.Context, spec serviceSpec, forc
 			return err
 		}
 	}
+	installed = true
 	return nil
 }
 
@@ -71,25 +80,26 @@ func (systemdServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, st
 }
 
 func (systemdServiceBackend) Start(ctx context.Context, spec serviceSpec) error {
-	if _, err := os.Stat(mustSystemdUnitPath()); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return errors.New("Builder background service is not installed; run `builder service install`")
-		}
-		return fmt.Errorf("stat systemd unit: %w", err)
+	if err := requireSystemdUnitInstalled(); err != nil {
+		return err
 	}
 	_, err := runServiceCommand(ctx, "systemctl", "--user", "start", serviceSystemdUnitName)
 	return err
 }
 
 func (systemdServiceBackend) Stop(ctx context.Context, spec serviceSpec) error {
-	_, err := runServiceCommand(ctx, "systemctl", "--user", "stop", serviceSystemdUnitName)
-	if err != nil && strings.Contains(err.Error(), "not loaded") {
+	loadState, err := systemdLoadState(ctx)
+	if err != nil || loadState != "loaded" {
 		return nil
 	}
+	_, err = runServiceCommand(ctx, "systemctl", "--user", "stop", serviceSystemdUnitName)
 	return err
 }
 
 func (systemdServiceBackend) Restart(ctx context.Context, spec serviceSpec) error {
+	if err := requireSystemdUnitInstalled(); err != nil {
+		return err
+	}
 	_, err := runServiceCommand(ctx, "systemctl", "--user", "restart", serviceSystemdUnitName)
 	return err
 }
@@ -105,9 +115,10 @@ func (systemdServiceBackend) Status(ctx context.Context, spec serviceSpec) (serv
 	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return serviceStatus{}, fmt.Errorf("stat systemd unit: %w", err)
 	}
-	activeResult, activeErr := runServiceCommand(ctx, "systemctl", "--user", "is-active", serviceSystemdUnitName)
-	loaded := activeErr == nil || strings.TrimSpace(activeResult.Stdout) == "active"
+	activeResult, _ := runServiceCommand(ctx, "systemctl", "--user", "is-active", serviceSystemdUnitName)
 	running := strings.TrimSpace(activeResult.Stdout) == "active"
+	loadState, _ := systemdLoadState(ctx)
+	loaded := loadState == "loaded"
 	showResult, _ := runServiceCommand(ctx, "systemctl", "--user", "show", serviceSystemdUnitName, "--property=MainPID", "--value")
 	pid := parsePositiveInt(showResult.Stdout)
 	return serviceStatus{
@@ -124,6 +135,28 @@ func (systemdServiceBackend) Status(ctx context.Context, spec serviceSpec) (serv
 			"On headless Linux, run `loginctl enable-linger $USER` if the service should survive logout.",
 		},
 	}, nil
+}
+
+func requireSystemdUnitInstalled() error {
+	path, err := systemdUnitPath()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return errors.New("Builder background service is not installed; run `builder service install`")
+		}
+		return fmt.Errorf("stat systemd unit: %w", err)
+	}
+	return nil
+}
+
+func systemdLoadState(ctx context.Context) (string, error) {
+	result, err := runServiceCommand(ctx, "systemctl", "--user", "show", serviceSystemdUnitName, "--property=LoadState", "--value")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result.Stdout), nil
 }
 
 func readSystemdRegisteredCommand(path string) []string {
@@ -191,14 +224,6 @@ func systemdUnitPath() (string, error) {
 		return "", fmt.Errorf("resolve home dir: %w", err)
 	}
 	return filepath.Join(home, ".config", "systemd", "user", serviceSystemdUnitName), nil
-}
-
-func mustSystemdUnitPath() string {
-	path, err := systemdUnitPath()
-	if err != nil {
-		return ""
-	}
-	return path
 }
 
 func renderSystemdUnit(spec serviceSpec) string {

--- a/cli/builder/service_backend_linux.go
+++ b/cli/builder/service_backend_linux.go
@@ -37,6 +37,8 @@ func (systemdServiceBackend) Install(ctx context.Context, spec serviceSpec, forc
 			return fmt.Errorf("Builder background service is already installed at %s; use --force to rewrite it", path)
 		}
 	}
+	previousUnit, previousErr := os.ReadFile(path)
+	previousExists := previousErr == nil
 	if err := os.WriteFile(path, []byte(renderSystemdUnit(spec)), 0o644); err != nil {
 		return fmt.Errorf("write systemd unit: %w", err)
 	}
@@ -45,7 +47,11 @@ func (systemdServiceBackend) Install(ctx context.Context, spec serviceSpec, forc
 		if installed {
 			return
 		}
-		_ = os.Remove(path)
+		if previousExists {
+			_ = os.WriteFile(path, previousUnit, 0o644)
+		} else {
+			_ = os.Remove(path)
+		}
 		_, _ = runServiceCommand(ctx, "systemctl", "--user", "daemon-reload")
 	}()
 	if _, err := runServiceCommand(ctx, "systemctl", "--user", "daemon-reload"); err != nil {

--- a/cli/builder/service_backend_other.go
+++ b/cli/builder/service_backend_other.go
@@ -1,0 +1,46 @@
+//go:build !darwin && !linux && !windows
+
+package main
+
+import (
+	"context"
+	"runtime"
+)
+
+type unsupportedServiceBackend struct{}
+
+func currentServiceBackend() serviceBackend {
+	return unsupportedServiceBackend{}
+}
+
+func (unsupportedServiceBackend) Name() string {
+	return runtime.GOOS
+}
+
+func (unsupportedServiceBackend) Install(context.Context, serviceSpec, bool, bool) error {
+	return errUnsupportedServiceBackend()
+}
+
+func (unsupportedServiceBackend) Uninstall(context.Context, serviceSpec, bool) error {
+	return errUnsupportedServiceBackend()
+}
+
+func (unsupportedServiceBackend) Start(context.Context, serviceSpec) error {
+	return errUnsupportedServiceBackend()
+}
+
+func (unsupportedServiceBackend) Stop(context.Context, serviceSpec) error {
+	return errUnsupportedServiceBackend()
+}
+
+func (unsupportedServiceBackend) Restart(context.Context, serviceSpec) error {
+	return errUnsupportedServiceBackend()
+}
+
+func (unsupportedServiceBackend) Status(context.Context, serviceSpec) (serviceStatus, error) {
+	return serviceStatus{Backend: runtime.GOOS}, nil
+}
+
+func errUnsupportedServiceBackend() error {
+	return serviceCommandError{Name: "builder service", Args: []string{runtime.GOOS}, Result: serviceCommandResult{Code: 1, Stderr: "background service management is not supported on this OS"}}
+}

--- a/cli/builder/service_backend_windows.go
+++ b/cli/builder/service_backend_windows.go
@@ -57,6 +57,9 @@ func (scheduledTaskServiceBackend) Install(ctx context.Context, spec serviceSpec
 		}
 		return nil
 	}
+	if err := os.Remove(windowsStartupItemPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove Startup folder fallback after scheduled task registration: %w", err)
+	}
 	if start {
 		if _, err := runServiceCommand(ctx, "schtasks", "/Run", "/TN", serviceWindowsTaskName); err != nil {
 			return err

--- a/cli/builder/service_backend_windows.go
+++ b/cli/builder/service_backend_windows.go
@@ -272,14 +272,14 @@ func windowsProcessPIDsMatchingAll(ctx context.Context, needles []string) []int 
 		return nil
 	}
 	var script strings.Builder
-	script.WriteString("$needles = @(")
+	script.WriteString("$self = $PID; $needles = @(")
 	for i, needle := range filteredNeedles {
 		if i > 0 {
 			script.WriteString(", ")
 		}
 		script.WriteString(windowsPowerShellSingleQuote(needle))
 	}
-	script.WriteString("); Get-CimInstance Win32_Process | Where-Object { $cmd = ($_.CommandLine -replace '/', '\\'); $ok = $true; foreach ($needle in $needles) { if ($cmd.IndexOf($needle, [StringComparison]::OrdinalIgnoreCase) -lt 0) { $ok = $false; break } }; $ok } | ForEach-Object { $_.ProcessId }")
+	script.WriteString("); Get-CimInstance Win32_Process | Where-Object { $_.ProcessId -ne $self -and $_.CommandLine } | Where-Object { $cmd = ($_.CommandLine -replace '/', '\\'); $ok = $true; foreach ($needle in $needles) { if ($cmd.IndexOf($needle, [StringComparison]::OrdinalIgnoreCase) -lt 0) { $ok = $false; break } }; $ok } | ForEach-Object { $_.ProcessId }")
 	result, err := runServiceCommand(ctx, "powershell", "-NoProfile", "-Command", script.String())
 	if err != nil {
 		return nil

--- a/cli/builder/service_backend_windows.go
+++ b/cli/builder/service_backend_windows.go
@@ -53,7 +53,7 @@ func (scheduledTaskServiceBackend) Install(ctx context.Context, spec serviceSpec
 	createArgs = append(createArgs, "/SC", "ONLOGON", "/RL", "LIMITED", "/TN", serviceWindowsTaskName, "/TR", scriptPath)
 	if _, err := runServiceCommand(ctx, "schtasks", createArgs...); err != nil {
 		if fallbackErr := installWindowsStartupItem(ctx, spec, start); fallbackErr != nil {
-			return fmt.Errorf("%w; startup fallback failed: %v", err, fallbackErr)
+			return errors.Join(err, fmt.Errorf("startup fallback failed: %w", fallbackErr))
 		}
 		return nil
 	}
@@ -116,7 +116,7 @@ func (scheduledTaskServiceBackend) Status(ctx context.Context, spec serviceSpec)
 	}
 	taskScriptPIDs := windowsTaskScriptPIDs(ctx, spec)
 	serverPIDs := windowsRegisteredCommandPIDs(ctx, spec)
-	running := strings.Contains(strings.ToLower(taskOutput), "running") || len(taskScriptPIDs) > 0 || len(serverPIDs) > 0
+	running := len(taskScriptPIDs) > 0 || len(serverPIDs) > 0
 	pid := 0
 	if len(serverPIDs) > 0 {
 		pid = serverPIDs[0]
@@ -279,7 +279,7 @@ func windowsProcessPIDsMatchingAll(ctx context.Context, needles []string) []int 
 		}
 		script.WriteString(windowsPowerShellSingleQuote(needle))
 	}
-	script.WriteString("); Get-CimInstance Win32_Process | Where-Object { $cmd = ($_.CommandLine -replace '/', '\\'); $ok = $true; foreach ($needle in $needles) { if ($cmd -notlike \"*$needle*\") { $ok = $false; break } }; $ok } | ForEach-Object { $_.ProcessId }")
+	script.WriteString("); Get-CimInstance Win32_Process | Where-Object { $cmd = ($_.CommandLine -replace '/', '\\'); $ok = $true; foreach ($needle in $needles) { if ($cmd.IndexOf($needle, [StringComparison]::OrdinalIgnoreCase) -lt 0) { $ok = $false; break } }; $ok } | ForEach-Object { $_.ProcessId }")
 	result, err := runServiceCommand(ctx, "powershell", "-NoProfile", "-Command", script.String())
 	if err != nil {
 		return nil

--- a/cli/builder/service_backend_windows.go
+++ b/cli/builder/service_backend_windows.go
@@ -1,0 +1,301 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type scheduledTaskServiceBackend struct{}
+
+func currentServiceBackend() serviceBackend {
+	return scheduledTaskServiceBackend{}
+}
+
+func (scheduledTaskServiceBackend) Name() string {
+	return "schtasks"
+}
+
+func (scheduledTaskServiceBackend) Install(ctx context.Context, spec serviceSpec, force bool, start bool) error {
+	if err := ensureServiceLogDir(spec); err != nil {
+		return err
+	}
+	scriptPath := windowsTaskScriptPath(spec)
+	nextScript := renderWindowsTaskScript(spec)
+	installed, _ := windowsScheduledTaskInstalled(ctx)
+	startupInstalled := windowsStartupItemInstalled()
+	existingScript, scriptErr := os.ReadFile(scriptPath)
+	scriptExists := scriptErr == nil
+	if !force && (installed || startupInstalled || scriptExists) {
+		if !scriptExists || string(existingScript) != nextScript {
+			return fmt.Errorf("Builder background service is already installed; use --force to rewrite it")
+		}
+		if start {
+			return scheduledTaskServiceBackend{}.Start(ctx, spec)
+		}
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		return fmt.Errorf("create task script dir: %w", err)
+	}
+	if err := os.WriteFile(scriptPath, []byte(nextScript), 0o644); err != nil {
+		return fmt.Errorf("write task script: %w", err)
+	}
+	createArgs := []string{"/Create"}
+	if force {
+		createArgs = append(createArgs, "/F")
+	}
+	createArgs = append(createArgs, "/SC", "ONLOGON", "/RL", "LIMITED", "/TN", serviceWindowsTaskName, "/TR", scriptPath)
+	if _, err := runServiceCommand(ctx, "schtasks", createArgs...); err != nil {
+		if fallbackErr := installWindowsStartupItem(ctx, spec, start); fallbackErr != nil {
+			return fmt.Errorf("%w; startup fallback failed: %v", err, fallbackErr)
+		}
+		return nil
+	}
+	if start {
+		if _, err := runServiceCommand(ctx, "schtasks", "/Run", "/TN", serviceWindowsTaskName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (scheduledTaskServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop bool) error {
+	if stop {
+		_ = scheduledTaskServiceBackend{}.Stop(ctx, spec)
+	}
+	_, _ = runServiceCommand(ctx, "schtasks", "/Delete", "/F", "/TN", serviceWindowsTaskName)
+	if err := os.Remove(windowsStartupItemPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove Startup folder item: %w", err)
+	}
+	if err := os.Remove(windowsTaskScriptPath(spec)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove task script: %w", err)
+	}
+	return nil
+}
+
+func (scheduledTaskServiceBackend) Start(ctx context.Context, spec serviceSpec) error {
+	if installed, _ := windowsScheduledTaskInstalled(ctx); installed {
+		_, err := runServiceCommand(ctx, "schtasks", "/Run", "/TN", serviceWindowsTaskName)
+		return err
+	}
+	if _, err := os.Stat(windowsStartupItemPath()); err == nil {
+		return launchWindowsTaskScript(ctx, spec)
+	}
+	return errors.New("Builder background service is not installed; run `builder service install`")
+}
+
+func (scheduledTaskServiceBackend) Stop(ctx context.Context, spec serviceSpec) error {
+	if installed, _ := windowsScheduledTaskInstalled(ctx); installed {
+		_, _ = runServiceCommand(ctx, "schtasks", "/End", "/TN", serviceWindowsTaskName)
+		_ = stopWindowsTaskScriptProcess(ctx, spec)
+		return nil
+	}
+	if windowsStartupItemInstalled() {
+		return stopWindowsTaskScriptProcess(ctx, spec)
+	}
+	_ = stopWindowsTaskScriptProcess(ctx, spec)
+	return nil
+}
+
+func (scheduledTaskServiceBackend) Restart(ctx context.Context, spec serviceSpec) error {
+	_ = scheduledTaskServiceBackend{}.Stop(ctx, spec)
+	return scheduledTaskServiceBackend{}.Start(ctx, spec)
+}
+
+func (scheduledTaskServiceBackend) Status(ctx context.Context, spec serviceSpec) (serviceStatus, error) {
+	taskInstalled, taskOutput := windowsScheduledTaskInstalled(ctx)
+	startupInstalled, err := windowsStartupItemInstalledChecked()
+	if err != nil {
+		return serviceStatus{}, fmt.Errorf("stat Startup folder item: %w", err)
+	}
+	taskScriptPIDs := windowsTaskScriptPIDs(ctx, spec)
+	running := strings.Contains(strings.ToLower(taskOutput), "running") || len(taskScriptPIDs) > 0
+	pid := 0
+	if len(taskScriptPIDs) > 0 {
+		pid = taskScriptPIDs[0]
+	}
+	return serviceStatus{
+		Backend:     "schtasks",
+		Installed:   taskInstalled || startupInstalled,
+		Loaded:      taskInstalled || startupInstalled,
+		Running:     running,
+		PID:         pid,
+		Command:     readWindowsRegisteredCommand(spec),
+		Endpoint:    spec.Endpoint,
+		Logs:        []string{spec.StdoutLogPath, spec.StderrLogPath},
+		InstallPath: windowsTaskScriptPath(spec),
+		Detail:      strings.TrimSpace(taskOutput),
+	}, nil
+}
+
+func readWindowsRegisteredCommand(spec serviceSpec) []string {
+	data, err := os.ReadFile(windowsTaskScriptPath(spec))
+	if err != nil {
+		return nil
+	}
+	for _, rawLine := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(rawLine)
+		lower := strings.ToLower(line)
+		if line == "" || strings.HasPrefix(lower, "@echo") || strings.HasPrefix(lower, "rem ") || strings.HasPrefix(lower, "cd /d ") {
+			continue
+		}
+		if before, _, ok := strings.Cut(line, " 1>>"); ok {
+			line = before
+		}
+		return parseWindowsCommandLine(line)
+	}
+	return nil
+}
+
+func parseWindowsCommandLine(value string) []string {
+	args := []string{}
+	var builder strings.Builder
+	inQuote := false
+	escaped := false
+	flush := func() {
+		if builder.Len() == 0 {
+			return
+		}
+		args = append(args, builder.String())
+		builder.Reset()
+	}
+	for _, r := range value {
+		if escaped {
+			builder.WriteRune(r)
+			escaped = false
+			continue
+		}
+		switch r {
+		case '\\':
+			escaped = true
+		case '"':
+			inQuote = !inQuote
+		case ' ', '\t':
+			if inQuote {
+				builder.WriteRune(r)
+			} else {
+				flush()
+			}
+		default:
+			builder.WriteRune(r)
+		}
+	}
+	if escaped {
+		builder.WriteByte('\\')
+	}
+	flush()
+	return args
+}
+
+func windowsScheduledTaskInstalled(ctx context.Context) (bool, string) {
+	result, err := runServiceCommand(ctx, "schtasks", "/Query", "/TN", serviceWindowsTaskName, "/V", "/FO", "LIST")
+	if err != nil {
+		return false, result.Text()
+	}
+	return true, result.Text()
+}
+
+func windowsStartupItemInstalled() bool {
+	installed, _ := windowsStartupItemInstalledChecked()
+	return installed
+}
+
+func windowsStartupItemInstalledChecked() (bool, error) {
+	if _, err := os.Stat(windowsStartupItemPath()); err == nil {
+		return true, nil
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	return false, nil
+}
+
+func windowsTaskScriptPath(spec serviceSpec) string {
+	return filepath.Join(spec.Config.PersistenceRoot, "service", "server.cmd")
+}
+
+func windowsStartupItemPath() string {
+	base := strings.TrimSpace(os.Getenv("APPDATA"))
+	if base == "" {
+		base = filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Roaming")
+	}
+	return filepath.Join(base, "Microsoft", "Windows", "Start Menu", "Programs", "Startup", serviceWindowsTaskName+".cmd")
+}
+
+func installWindowsStartupItem(ctx context.Context, spec serviceSpec, start bool) error {
+	path := windowsStartupItemPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create Startup folder: %w", err)
+	}
+	contents := "@echo off\r\nstart \"\" /min cmd.exe /d /c " + windowsCmdQuote(windowsTaskScriptPath(spec)) + "\r\n"
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		return fmt.Errorf("write Startup folder item: %w", err)
+	}
+	if start {
+		return launchWindowsTaskScript(ctx, spec)
+	}
+	return nil
+}
+
+func launchWindowsTaskScript(ctx context.Context, spec serviceSpec) error {
+	_, err := runServiceCommand(ctx, "cmd.exe", "/d", "/c", "start", "", "/min", "cmd.exe", "/d", "/c", windowsTaskScriptPath(spec))
+	return err
+}
+
+func stopWindowsTaskScriptProcess(ctx context.Context, spec serviceSpec) error {
+	for _, pid := range windowsTaskScriptPIDs(ctx, spec) {
+		if pid <= 0 {
+			continue
+		}
+		_, _ = runServiceCommand(ctx, "taskkill", "/T", "/F", "/PID", fmt.Sprintf("%d", pid))
+	}
+	return nil
+}
+
+func windowsTaskScriptPIDs(ctx context.Context, spec serviceSpec) []int {
+	needle := strings.ReplaceAll(windowsTaskScriptPath(spec), "/", "\\")
+	script := "$needle = " + windowsPowerShellSingleQuote(needle) + "; Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like \"*$needle*\" } | ForEach-Object { $_.ProcessId }"
+	result, err := runServiceCommand(ctx, "powershell", "-NoProfile", "-Command", script)
+	if err != nil {
+		return nil
+	}
+	pids := []int{}
+	for _, line := range strings.Split(result.Stdout, "\n") {
+		if pid := parsePositiveInt(line); pid > 0 {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
+}
+
+func windowsPowerShellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func renderWindowsTaskScript(spec serviceSpec) string {
+	lines := []string{"@echo off"}
+	lines = append(lines, "cd /d "+windowsCmdQuote(spec.Config.PersistenceRoot))
+	lines = append(lines, serviceCommandLineWindows(serviceCommand(spec))+" 1>>"+windowsCmdQuote(spec.StdoutLogPath)+" 2>>"+windowsCmdQuote(spec.StderrLogPath))
+	return strings.Join(lines, "\r\n") + "\r\n"
+}
+
+func serviceCommandLineWindows(args []string) string {
+	parts := make([]string, 0, len(args))
+	for _, arg := range args {
+		parts = append(parts, windowsCmdQuote(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func windowsCmdQuote(value string) string {
+	escaped := strings.ReplaceAll(value, `"`, `\"`)
+	if escaped == "" || strings.ContainsAny(escaped, " \t&()[]{}^=;!'+,`~") {
+		return `"` + escaped + `"`
+	}
+	return escaped
+}

--- a/cli/builder/service_backend_windows.go
+++ b/cli/builder/service_backend_windows.go
@@ -115,10 +115,11 @@ func (scheduledTaskServiceBackend) Status(ctx context.Context, spec serviceSpec)
 		return serviceStatus{}, fmt.Errorf("stat Startup folder item: %w", err)
 	}
 	taskScriptPIDs := windowsTaskScriptPIDs(ctx, spec)
-	running := strings.Contains(strings.ToLower(taskOutput), "running") || len(taskScriptPIDs) > 0
+	serverPIDs := windowsRegisteredCommandPIDs(ctx, spec)
+	running := strings.Contains(strings.ToLower(taskOutput), "running") || len(taskScriptPIDs) > 0 || len(serverPIDs) > 0
 	pid := 0
-	if len(taskScriptPIDs) > 0 {
-		pid = taskScriptPIDs[0]
+	if len(serverPIDs) > 0 {
+		pid = serverPIDs[0]
 	}
 	return serviceStatus{
 		Backend:     "schtasks",
@@ -248,8 +249,38 @@ func stopWindowsTaskScriptProcess(ctx context.Context, spec serviceSpec) error {
 
 func windowsTaskScriptPIDs(ctx context.Context, spec serviceSpec) []int {
 	needle := strings.ReplaceAll(windowsTaskScriptPath(spec), "/", "\\")
-	script := "$needle = " + windowsPowerShellSingleQuote(needle) + "; Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like \"*$needle*\" } | ForEach-Object { $_.ProcessId }"
-	result, err := runServiceCommand(ctx, "powershell", "-NoProfile", "-Command", script)
+	return windowsProcessPIDsMatchingAll(ctx, []string{needle})
+}
+
+func windowsRegisteredCommandPIDs(ctx context.Context, spec serviceSpec) []int {
+	command := readWindowsRegisteredCommand(spec)
+	if len(command) == 0 {
+		return nil
+	}
+	return windowsProcessPIDsMatchingAll(ctx, command)
+}
+
+func windowsProcessPIDsMatchingAll(ctx context.Context, needles []string) []int {
+	filteredNeedles := make([]string, 0, len(needles))
+	for _, needle := range needles {
+		trimmed := strings.TrimSpace(strings.ReplaceAll(needle, "/", "\\"))
+		if trimmed != "" {
+			filteredNeedles = append(filteredNeedles, trimmed)
+		}
+	}
+	if len(filteredNeedles) == 0 {
+		return nil
+	}
+	var script strings.Builder
+	script.WriteString("$needles = @(")
+	for i, needle := range filteredNeedles {
+		if i > 0 {
+			script.WriteString(", ")
+		}
+		script.WriteString(windowsPowerShellSingleQuote(needle))
+	}
+	script.WriteString("); Get-CimInstance Win32_Process | Where-Object { $cmd = ($_.CommandLine -replace '/', '\\'); $ok = $true; foreach ($needle in $needles) { if ($cmd -notlike \"*$needle*\") { $ok = $false; break } }; $ok } | ForEach-Object { $_.ProcessId }")
+	result, err := runServiceCommand(ctx, "powershell", "-NoProfile", "-Command", script.String())
 	if err != nil {
 		return nil
 	}

--- a/cli/builder/service_backend_windows.go
+++ b/cli/builder/service_backend_windows.go
@@ -31,7 +31,7 @@ func (scheduledTaskServiceBackend) Install(ctx context.Context, spec serviceSpec
 	startupInstalled := windowsStartupItemInstalled()
 	existingScript, scriptErr := os.ReadFile(scriptPath)
 	scriptExists := scriptErr == nil
-	if !force && (installed || startupInstalled || scriptExists) {
+	if !force && (installed || startupInstalled) {
 		if !scriptExists || string(existingScript) != nextScript {
 			return fmt.Errorf("Builder background service is already installed; use --force to rewrite it")
 		}
@@ -116,9 +116,9 @@ func (scheduledTaskServiceBackend) Status(ctx context.Context, spec serviceSpec)
 	}
 	taskScriptPIDs := windowsTaskScriptPIDs(ctx, spec)
 	serverPIDs := windowsRegisteredCommandPIDs(ctx, spec)
-	running := len(taskScriptPIDs) > 0 || len(serverPIDs) > 0
+	running := len(taskScriptPIDs) > 0
 	pid := 0
-	if len(serverPIDs) > 0 {
+	if running && len(serverPIDs) > 0 {
 		pid = serverPIDs[0]
 	}
 	return serviceStatus{

--- a/cli/builder/service_backend_windows.go
+++ b/cli/builder/service_backend_windows.go
@@ -157,7 +157,6 @@ func parseWindowsCommandLine(value string) []string {
 	args := []string{}
 	var builder strings.Builder
 	inQuote := false
-	escaped := false
 	flush := func() {
 		if builder.Len() == 0 {
 			return
@@ -166,14 +165,7 @@ func parseWindowsCommandLine(value string) []string {
 		builder.Reset()
 	}
 	for _, r := range value {
-		if escaped {
-			builder.WriteRune(r)
-			escaped = false
-			continue
-		}
 		switch r {
-		case '\\':
-			escaped = true
 		case '"':
 			inQuote = !inQuote
 		case ' ', '\t':
@@ -185,9 +177,6 @@ func parseWindowsCommandLine(value string) []string {
 		default:
 			builder.WriteRune(r)
 		}
-	}
-	if escaped {
-		builder.WriteByte('\\')
 	}
 	flush()
 	return args

--- a/cli/builder/service_backend_windows_test.go
+++ b/cli/builder/service_backend_windows_test.go
@@ -69,6 +69,37 @@ func TestWindowsInstallWithoutForceReRegistersOrphanScript(t *testing.T) {
 	}
 }
 
+func TestWindowsInstallRemovesStartupFallbackAfterScheduledTaskRegistration(t *testing.T) {
+	spec := windowsServiceTestSpec(t)
+	if err := os.MkdirAll(filepath.Dir(windowsStartupItemPath()), 0o755); err != nil {
+		t.Fatalf("mkdir startup dir: %v", err)
+	}
+	if err := os.WriteFile(windowsStartupItemPath(), []byte("fallback"), 0o644); err != nil {
+		t.Fatalf("write startup item: %v", err)
+	}
+	calls := captureWindowsServiceCommands(t, func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch name {
+		case "schtasks":
+			if len(args) > 0 && args[0] == "/Query" {
+				return serviceCommandResult{}, errors.New("task missing")
+			}
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	if err := (scheduledTaskServiceBackend{}).Install(context.Background(), spec, true, false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := os.Stat(windowsStartupItemPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("startup fallback stat err = %v, want not exist", err)
+	}
+	if len(*calls) != 2 || (*calls)[1][0] != "schtasks" || (*calls)[1][1] != "/Create" {
+		t.Fatalf("calls = %+v, want query then create", *calls)
+	}
+}
+
 func TestWindowsStopStartupFallbackKillsTaskScriptProcess(t *testing.T) {
 	spec := windowsServiceTestSpec(t)
 	if err := os.MkdirAll(filepath.Dir(windowsStartupItemPath()), 0o755); err != nil {

--- a/cli/builder/service_backend_windows_test.go
+++ b/cli/builder/service_backend_windows_test.go
@@ -38,6 +38,37 @@ func TestWindowsInstallWithoutForceRejectsExistingDifferentScript(t *testing.T) 
 	}
 }
 
+func TestWindowsInstallWithoutForceReRegistersOrphanScript(t *testing.T) {
+	spec := windowsServiceTestSpec(t)
+	if err := os.MkdirAll(filepath.Dir(windowsTaskScriptPath(spec)), 0o755); err != nil {
+		t.Fatalf("mkdir task script dir: %v", err)
+	}
+	if err := os.WriteFile(windowsTaskScriptPath(spec), []byte("old script"), 0o644); err != nil {
+		t.Fatalf("write existing task script: %v", err)
+	}
+	calls := captureWindowsServiceCommands(t, func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch name {
+		case "schtasks":
+			if len(args) > 0 && args[0] == "/Query" {
+				return serviceCommandResult{}, errors.New("task missing")
+			}
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	if err := (scheduledTaskServiceBackend{}).Install(context.Background(), spec, false, false); err != nil {
+		t.Fatalf("install with orphan script: %v", err)
+	}
+	if string(mustReadFile(t, windowsTaskScriptPath(spec))) == "old script" {
+		t.Fatal("expected orphan script to be rewritten")
+	}
+	if len(*calls) != 2 || (*calls)[1][0] != "schtasks" || (*calls)[1][1] != "/Create" {
+		t.Fatalf("calls = %+v, want query then create", *calls)
+	}
+}
+
 func TestWindowsStopStartupFallbackKillsTaskScriptProcess(t *testing.T) {
 	spec := windowsServiceTestSpec(t)
 	if err := os.MkdirAll(filepath.Dir(windowsStartupItemPath()), 0o755); err != nil {
@@ -100,6 +131,41 @@ func TestWindowsStatusReportsRegisteredServerPID(t *testing.T) {
 	}
 	if status.PID != 222 {
 		t.Fatalf("status PID = %d, want registered server PID 222", status.PID)
+	}
+}
+
+func TestWindowsStatusDoesNotTreatBareServerProcessAsServiceRunning(t *testing.T) {
+	spec := windowsServiceTestSpec(t)
+	if err := os.MkdirAll(filepath.Dir(windowsTaskScriptPath(spec)), 0o755); err != nil {
+		t.Fatalf("mkdir task script dir: %v", err)
+	}
+	if err := os.WriteFile(windowsTaskScriptPath(spec), []byte(renderWindowsTaskScript(spec)), 0o644); err != nil {
+		t.Fatalf("write task script: %v", err)
+	}
+	captureWindowsServiceCommands(t, func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch name {
+		case "schtasks":
+			return serviceCommandResult{Stdout: "Status: Ready\r\n"}, nil
+		case "powershell":
+			script := strings.Join(args, " ")
+			if strings.Contains(script, windowsTaskScriptPath(spec)) {
+				return serviceCommandResult{}, nil
+			}
+			if strings.Contains(script, spec.Executable) {
+				return serviceCommandResult{Stdout: "222\r\n"}, nil
+			}
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	status, err := (scheduledTaskServiceBackend{}).Status(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Running || status.PID != 0 {
+		t.Fatalf("status running=%v pid=%d, want stopped with no service PID", status.Running, status.PID)
 	}
 }
 

--- a/cli/builder/service_backend_windows_test.go
+++ b/cli/builder/service_backend_windows_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"builder/shared/config"
@@ -64,6 +65,41 @@ func TestWindowsStopStartupFallbackKillsTaskScriptProcess(t *testing.T) {
 	want := []string{"taskkill", "/T", "/F", "/PID", "123"}
 	if len(*calls) != 3 || !reflect.DeepEqual((*calls)[2], want) {
 		t.Fatalf("calls = %+v, want final %v", *calls, want)
+	}
+}
+
+func TestWindowsStatusReportsRegisteredServerPID(t *testing.T) {
+	spec := windowsServiceTestSpec(t)
+	if err := os.MkdirAll(filepath.Dir(windowsTaskScriptPath(spec)), 0o755); err != nil {
+		t.Fatalf("mkdir task script dir: %v", err)
+	}
+	if err := os.WriteFile(windowsTaskScriptPath(spec), []byte(renderWindowsTaskScript(spec)), 0o644); err != nil {
+		t.Fatalf("write task script: %v", err)
+	}
+	captureWindowsServiceCommands(t, func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch name {
+		case "schtasks":
+			return serviceCommandResult{Stdout: "Status: Running\r\n"}, nil
+		case "powershell":
+			script := strings.Join(args, " ")
+			if strings.Contains(script, windowsTaskScriptPath(spec)) {
+				return serviceCommandResult{Stdout: "111\r\n"}, nil
+			}
+			if strings.Contains(script, spec.Executable) {
+				return serviceCommandResult{Stdout: "222\r\n"}, nil
+			}
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	status, err := (scheduledTaskServiceBackend{}).Status(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.PID != 222 {
+		t.Fatalf("status PID = %d, want registered server PID 222", status.PID)
 	}
 }
 

--- a/cli/builder/service_backend_windows_test.go
+++ b/cli/builder/service_backend_windows_test.go
@@ -1,0 +1,104 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"builder/shared/config"
+)
+
+func TestWindowsInstallWithoutForceRejectsExistingDifferentScript(t *testing.T) {
+	spec := windowsServiceTestSpec(t)
+	if err := os.MkdirAll(filepath.Dir(windowsTaskScriptPath(spec)), 0o755); err != nil {
+		t.Fatalf("mkdir task script dir: %v", err)
+	}
+	if err := os.WriteFile(windowsTaskScriptPath(spec), []byte("old script"), 0o644); err != nil {
+		t.Fatalf("write existing task script: %v", err)
+	}
+	calls := captureWindowsServiceCommands(t, func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
+		return serviceCommandResult{}, errors.New("unexpected command")
+	})
+
+	err := (scheduledTaskServiceBackend{}).Install(context.Background(), spec, false, false)
+	if err == nil {
+		t.Fatal("expected existing script rejection")
+	}
+	if string(mustReadFile(t, windowsTaskScriptPath(spec))) != "old script" {
+		t.Fatal("expected existing script to remain unchanged")
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("commands = %+v, want none", *calls)
+	}
+}
+
+func TestWindowsStopStartupFallbackKillsTaskScriptProcess(t *testing.T) {
+	spec := windowsServiceTestSpec(t)
+	if err := os.MkdirAll(filepath.Dir(windowsStartupItemPath()), 0o755); err != nil {
+		t.Fatalf("mkdir startup dir: %v", err)
+	}
+	if err := os.WriteFile(windowsStartupItemPath(), []byte("launcher"), 0o644); err != nil {
+		t.Fatalf("write startup item: %v", err)
+	}
+	calls := captureWindowsServiceCommands(t, func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch name {
+		case "schtasks":
+			return serviceCommandResult{}, errors.New("task missing")
+		case "powershell":
+			return serviceCommandResult{Stdout: "123\r\n"}, nil
+		case "taskkill":
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	if err := (scheduledTaskServiceBackend{}).Stop(context.Background(), spec); err != nil {
+		t.Fatalf("stop fallback: %v", err)
+	}
+	want := []string{"taskkill", "/T", "/F", "/PID", "123"}
+	if len(*calls) != 3 || !reflect.DeepEqual((*calls)[2], want) {
+		t.Fatalf("calls = %+v, want final %v", *calls, want)
+	}
+}
+
+func windowsServiceTestSpec(t *testing.T) serviceSpec {
+	t.Helper()
+	temp := t.TempDir()
+	t.Setenv("APPDATA", filepath.Join(temp, "AppData", "Roaming"))
+	return serviceSpec{
+		Config:        config.App{PersistenceRoot: filepath.Join(temp, ".builder")},
+		Executable:    filepath.Join(temp, "builder.exe"),
+		Arguments:     []string{"serve"},
+		LogDir:        filepath.Join(temp, ".builder", "logs"),
+		StdoutLogPath: filepath.Join(temp, ".builder", "logs", "server.log"),
+		StderrLogPath: filepath.Join(temp, ".builder", "logs", "server.err.log"),
+		Endpoint:      "http://127.0.0.1:53082",
+	}
+}
+
+func captureWindowsServiceCommands(t *testing.T, fn func(context.Context, string, ...string) (serviceCommandResult, error)) *[][]string {
+	t.Helper()
+	original := runServiceCommand
+	calls := [][]string{}
+	runServiceCommand = func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
+		calls = append(calls, append([]string{name}, args...))
+		return fn(ctx, name, args...)
+	}
+	t.Cleanup(func() { runServiceCommand = original })
+	return &calls
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file %s: %v", path, err)
+	}
+	return data
+}

--- a/cli/builder/service_backend_windows_test.go
+++ b/cli/builder/service_backend_windows_test.go
@@ -67,6 +67,14 @@ func TestWindowsStopStartupFallbackKillsTaskScriptProcess(t *testing.T) {
 	}
 }
 
+func TestParseWindowsCommandLinePreservesPathBackslashes(t *testing.T) {
+	got := parseWindowsCommandLine(`"C:\Users\Nek\AppData\Local\Builder\builder.exe" serve`)
+	want := []string{`C:\Users\Nek\AppData\Local\Builder\builder.exe`, "serve"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseWindowsCommandLine = %#v, want %#v", got, want)
+	}
+}
+
 func windowsServiceTestSpec(t *testing.T) serviceSpec {
 	t.Helper()
 	temp := t.TempDir()

--- a/cli/builder/service_command.go
+++ b/cli/builder/service_command.go
@@ -287,6 +287,9 @@ func ensureNoUnmanagedServerConflict(ctx context.Context, backend serviceBackend
 		return fmt.Errorf("Builder server is already running on %s, but the background service is not loaded. Stop the manual server or run `builder service restart` after fixing service state", spec.Endpoint)
 	}
 	if !healthRunning {
+		if status.Installed && status.Loaded && status.Running {
+			return nil
+		}
 		dialer := net.Dialer{Timeout: 500 * time.Millisecond}
 		conn, err := dialer.DialContext(ctx, "tcp", config.ServerListenAddress(spec.Config))
 		if err == nil {

--- a/cli/builder/service_command.go
+++ b/cli/builder/service_command.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"builder/shared/config"
+	"builder/shared/protocol"
 )
 
 type serviceAction string
@@ -271,7 +272,7 @@ func ensureNoUnmanagedServerConflict(ctx context.Context, backend serviceBackend
 		return err
 	}
 	healthStatus, healthPID := probeServiceHealth(ctx, spec)
-	healthRunning := healthStatus == "ok"
+	healthRunning := healthStatus == protocol.HealthStatusOK
 	pidProof := status.PID > 0 && healthPID > 0 && status.PID == healthPID
 	commandProof := len(status.Command) > 0 && commandArgsEqual(status.Command, serviceCommand(spec))
 	backendOwnsHealthyServer := healthRunning && status.Running && status.Loaded && (pidProof || commandProof)

--- a/cli/builder/service_command.go
+++ b/cli/builder/service_command.go
@@ -1,0 +1,340 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"builder/shared/config"
+)
+
+type serviceAction string
+
+const (
+	serviceActionStatus    serviceAction = "status"
+	serviceActionInstall   serviceAction = "install"
+	serviceActionUninstall serviceAction = "uninstall"
+	serviceActionStart     serviceAction = "start"
+	serviceActionStop      serviceAction = "stop"
+	serviceActionRestart   serviceAction = "restart"
+)
+
+type serviceCommandOptions struct {
+	JSON        bool
+	Force       bool
+	NoStart     bool
+	KeepRunning bool
+	IfInstalled bool
+}
+
+func serviceSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		fs := flag.NewFlagSet("builder service", flag.ContinueOnError)
+		fs.SetOutput(stderr)
+		fs.Usage = func() { writeServiceUsage(fs) }
+		fs.Usage()
+		if len(args) == 0 {
+			return 2
+		}
+		return 0
+	}
+	action := serviceAction(strings.TrimSpace(args[0]))
+	switch action {
+	case serviceActionStatus:
+		return serviceStatusSubcommand(args[1:], stdout, stderr)
+	case serviceActionInstall:
+		return serviceInstallSubcommand(args[1:], stdout, stderr)
+	case serviceActionUninstall:
+		return serviceUninstallSubcommand(args[1:], stdout, stderr)
+	case serviceActionStart:
+		return serviceLifecycleSubcommand(action, args[1:], stdout, stderr)
+	case serviceActionStop:
+		return serviceLifecycleSubcommand(action, args[1:], stdout, stderr)
+	case serviceActionRestart:
+		return serviceRestartSubcommand(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown service command: %s\n\n", args[0])
+		fs := flag.NewFlagSet("builder service", flag.ContinueOnError)
+		fs.SetOutput(stderr)
+		writeServiceUsage(fs)
+		return 2
+	}
+}
+
+func serviceStatusSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
+	fs := flag.NewFlagSet("builder service status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { writeServiceStatusUsage(fs) }
+	jsonOut := fs.Bool("json", false, "print machine-readable JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if len(fs.Args()) != 0 {
+		fmt.Fprintln(stderr, "service status does not accept positional arguments")
+		return 2
+	}
+	return runServiceCommandAction(context.Background(), serviceActionStatus, serviceCommandOptions{JSON: *jsonOut}, stdout, stderr)
+}
+
+func serviceInstallSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
+	fs := flag.NewFlagSet("builder service install", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { writeServiceInstallUsage(fs) }
+	force := fs.Bool("force", false, "rewrite existing service registration")
+	noStart := fs.Bool("no-start", false, "install service without starting it")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if len(fs.Args()) != 0 {
+		fmt.Fprintln(stderr, "service install does not accept positional arguments")
+		return 2
+	}
+	return runServiceCommandAction(context.Background(), serviceActionInstall, serviceCommandOptions{Force: *force, NoStart: *noStart}, stdout, stderr)
+}
+
+func serviceUninstallSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
+	fs := flag.NewFlagSet("builder service uninstall", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { writeServiceUninstallUsage(fs) }
+	keepRunning := fs.Bool("keep-running", false, "remove service registration without stopping current server process")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if len(fs.Args()) != 0 {
+		fmt.Fprintln(stderr, "service uninstall does not accept positional arguments")
+		return 2
+	}
+	return runServiceCommandAction(context.Background(), serviceActionUninstall, serviceCommandOptions{KeepRunning: *keepRunning}, stdout, stderr)
+}
+
+func serviceLifecycleSubcommand(action serviceAction, args []string, stdout io.Writer, stderr io.Writer) int {
+	fs := flag.NewFlagSet("builder service "+string(action), flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { writeServiceLifecycleUsage(fs, action) }
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if len(fs.Args()) != 0 {
+		fmt.Fprintf(stderr, "service %s does not accept positional arguments\n", action)
+		return 2
+	}
+	return runServiceCommandAction(context.Background(), action, serviceCommandOptions{}, stdout, stderr)
+}
+
+func serviceRestartSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
+	fs := flag.NewFlagSet("builder service restart", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { writeServiceRestartUsage(fs) }
+	ifInstalled := fs.Bool("if-installed", false, "exit successfully without action when service is not installed")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if len(fs.Args()) != 0 {
+		fmt.Fprintln(stderr, "service restart does not accept positional arguments")
+		return 2
+	}
+	return runServiceCommandAction(context.Background(), serviceActionRestart, serviceCommandOptions{IfInstalled: *ifInstalled}, stdout, stderr)
+}
+
+func runServiceCommandAction(ctx context.Context, action serviceAction, opts serviceCommandOptions, stdout io.Writer, stderr io.Writer) int {
+	spec, err := loadServiceSpec()
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	backend := serviceBackendFactory()
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	switch action {
+	case serviceActionStatus:
+		status, err := readServiceStatus(ctx, backend, spec)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if opts.JSON {
+			encoder := json.NewEncoder(stdout)
+			encoder.SetIndent("", "  ")
+			if err := encoder.Encode(status); err != nil {
+				fmt.Fprintln(stderr, err)
+				return 1
+			}
+			return 0
+		}
+		writeServiceStatus(stdout, status)
+		return 0
+	case serviceActionInstall:
+		if err := ensureNoUnmanagedServerConflict(ctx, backend, spec); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if err := backend.Install(ctx, spec, opts.Force, !opts.NoStart); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "Installed %s.\n", serviceDisplayName)
+		if !opts.NoStart {
+			fmt.Fprintln(stdout, "Started: yes")
+		} else {
+			fmt.Fprintln(stdout, "Started: no")
+		}
+	case serviceActionUninstall:
+		if err := backend.Uninstall(ctx, spec, !opts.KeepRunning); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "Uninstalled %s.\n", serviceDisplayName)
+	case serviceActionStart:
+		if err := ensureNoUnmanagedServerConflict(ctx, backend, spec); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if err := backend.Start(ctx, spec); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "Started %s.\n", serviceDisplayName)
+	case serviceActionStop:
+		if err := backend.Stop(ctx, spec); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "Stopped %s.\n", serviceDisplayName)
+	case serviceActionRestart:
+		if !opts.IfInstalled {
+			if err := ensureNoUnmanagedServerConflict(ctx, backend, spec); err != nil {
+				fmt.Fprintln(stderr, err)
+				return 1
+			}
+		}
+		if opts.IfInstalled {
+			status, err := backend.Status(ctx, spec)
+			if err != nil {
+				fmt.Fprintln(stderr, err)
+				return 1
+			}
+			if !status.Installed {
+				return 0
+			}
+			if err := ensureNoUnmanagedServerConflict(ctx, backend, spec); err != nil {
+				fmt.Fprintln(stderr, err)
+				return 1
+			}
+			fmt.Fprintln(stdout, "Builder background service is installed. Restarting it after update; sessions may fail briefly.")
+			if err := backend.Install(ctx, spec, true, true); err != nil {
+				fmt.Fprintln(stderr, err)
+				return 1
+			}
+			fmt.Fprintf(stdout, "Restarted %s.\n", serviceDisplayName)
+			return 0
+		}
+		if err := backend.Restart(ctx, spec); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "Restarted %s.\n", serviceDisplayName)
+	}
+	return 0
+}
+
+func ensureNoUnmanagedServerConflict(ctx context.Context, backend serviceBackend, spec serviceSpec) error {
+	status, err := backend.Status(ctx, spec)
+	if err != nil {
+		return err
+	}
+	healthStatus, healthPID := probeServiceHealth(ctx, spec)
+	healthRunning := healthStatus == "ok"
+	pidProof := status.PID > 0 && healthPID > 0 && status.PID == healthPID
+	commandProof := len(status.Command) > 0 && commandArgsEqual(status.Command, serviceCommand(spec))
+	backendOwnsHealthyServer := healthRunning && status.Running && status.Loaded && (pidProof || commandProof)
+	if healthRunning && !backendOwnsHealthyServer {
+		pidText := ""
+		if healthPID > 0 {
+			pidText = fmt.Sprintf(" (pid %d)", healthPID)
+		}
+		return fmt.Errorf("Builder server is already running outside the background service on %s%s. Stop it before changing the service", spec.Endpoint, pidText)
+	}
+	if status.Running && status.Installed && !status.Loaded {
+		return fmt.Errorf("Builder server is already running on %s, but the background service is not loaded. Stop the manual server or run `builder service restart` after fixing service state", spec.Endpoint)
+	}
+	if !healthRunning {
+		dialer := net.Dialer{Timeout: 500 * time.Millisecond}
+		conn, err := dialer.DialContext(ctx, "tcp", config.ServerListenAddress(spec.Config))
+		if err == nil {
+			_ = conn.Close()
+			return fmt.Errorf("server port %s is already in use, but it is not responding as Builder. Stop the process using that port before installing the background service", config.ServerListenAddress(spec.Config))
+		}
+	}
+	return nil
+}
+
+func readServiceStatus(ctx context.Context, backend serviceBackend, spec serviceSpec) (serviceStatus, error) {
+	status, err := backend.Status(ctx, spec)
+	if err != nil {
+		return serviceStatus{}, err
+	}
+	status.Backend = backend.Name()
+	status.Endpoint = spec.Endpoint
+	status.Logs = []string{spec.StdoutLogPath, spec.StderrLogPath}
+	if len(status.Command) == 0 {
+		status.Command = serviceCommand(spec)
+	}
+	return applyHealthProbe(ctx, status, spec), nil
+}
+
+func writeServiceStatus(stdout io.Writer, status serviceStatus) {
+	state := "not installed"
+	if status.Installed && status.Running {
+		state = "running"
+	} else if status.Installed {
+		state = "stopped"
+	} else if status.Running {
+		state = "not installed (server running manually)"
+	}
+	fmt.Fprintf(stdout, "Builder background service: %s\n", state)
+	fmt.Fprintf(stdout, "Backend: %s\n", status.Backend)
+	if status.PID > 0 {
+		fmt.Fprintf(stdout, "PID: %d\n", status.PID)
+	}
+	if len(status.Command) > 0 {
+		fmt.Fprintf(stdout, "Command: %s\n", commandString(status.Command))
+	}
+	fmt.Fprintf(stdout, "Endpoint: %s\n", status.Endpoint)
+	if len(status.Logs) > 0 {
+		fmt.Fprintf(stdout, "Logs: %s\n", strings.Join(status.Logs, ", "))
+	}
+	for _, hint := range status.Hints {
+		fmt.Fprintf(stdout, "Hint: %s\n", hint)
+	}
+	if strings.TrimSpace(status.Detail) != "" {
+		fmt.Fprintf(stdout, "Detail: %s\n", status.Detail)
+	}
+}

--- a/cli/builder/service_command.go
+++ b/cli/builder/service_command.go
@@ -317,13 +317,15 @@ func writeServiceStatus(stdout io.Writer, status serviceStatus) {
 		state = "running"
 	} else if status.Installed {
 		state = "stopped"
-	} else if status.Running {
+	} else if status.HealthStatus == protocol.HealthStatusOK {
 		state = "not installed (server running manually)"
 	}
 	fmt.Fprintf(stdout, "Builder background service: %s\n", state)
 	fmt.Fprintf(stdout, "Backend: %s\n", status.Backend)
 	if status.PID > 0 {
 		fmt.Fprintf(stdout, "PID: %d\n", status.PID)
+	} else if status.HealthPID > 0 {
+		fmt.Fprintf(stdout, "PID: %d\n", status.HealthPID)
 	}
 	if len(status.Command) > 0 {
 		fmt.Fprintf(stdout, "Command: %s\n", commandString(status.Command))

--- a/cli/builder/service_command_test.go
+++ b/cli/builder/service_command_test.go
@@ -1,0 +1,337 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"builder/shared/config"
+)
+
+type stubServiceBackend struct {
+	status        serviceStatus
+	installStart  bool
+	installForce  bool
+	uninstallStop bool
+	calls         []serviceAction
+	err           error
+}
+
+func (s *stubServiceBackend) Name() string { return "stub" }
+
+func (s *stubServiceBackend) Install(_ context.Context, _ serviceSpec, force bool, start bool) error {
+	s.calls = append(s.calls, serviceActionInstall)
+	s.installForce = force
+	s.installStart = start
+	return s.err
+}
+
+func (s *stubServiceBackend) Uninstall(_ context.Context, _ serviceSpec, stop bool) error {
+	s.calls = append(s.calls, serviceActionUninstall)
+	s.uninstallStop = stop
+	return s.err
+}
+
+func (s *stubServiceBackend) Start(context.Context, serviceSpec) error {
+	s.calls = append(s.calls, serviceActionStart)
+	return s.err
+}
+
+func (s *stubServiceBackend) Stop(context.Context, serviceSpec) error {
+	s.calls = append(s.calls, serviceActionStop)
+	return s.err
+}
+
+func (s *stubServiceBackend) Restart(context.Context, serviceSpec) error {
+	s.calls = append(s.calls, serviceActionRestart)
+	return s.err
+}
+
+func (s *stubServiceBackend) Status(context.Context, serviceSpec) (serviceStatus, error) {
+	s.calls = append(s.calls, serviceActionStatus)
+	return s.status, s.err
+}
+
+func withServiceCommandTestBackend(t *testing.T, backend *stubServiceBackend) {
+	withServiceCommandTestBackendEndpoint(t, backend, "http://127.0.0.1:1")
+}
+
+func withServiceCommandTestBackendEndpoint(t *testing.T, backend *stubServiceBackend, endpoint string) {
+	t.Helper()
+	originalLoadSpec := loadServiceSpec
+	originalBackendFactory := serviceBackendFactory
+	t.Cleanup(func() {
+		loadServiceSpec = originalLoadSpec
+		serviceBackendFactory = originalBackendFactory
+	})
+	loadServiceSpec = func() (serviceSpec, error) {
+		host, portText, _ := net.SplitHostPort(strings.TrimPrefix(endpoint, "http://"))
+		port := parsePositiveInt(portText)
+		return serviceSpec{
+			Config:        config.App{PersistenceRoot: t.TempDir(), Settings: config.Settings{ServerHost: host, ServerPort: port}},
+			Executable:    "/usr/local/bin/builder",
+			Arguments:     []string{"serve"},
+			LogDir:        "/tmp/builder/logs",
+			StdoutLogPath: "/tmp/builder/logs/server.log",
+			StderrLogPath: "/tmp/builder/logs/server.err.log",
+			Endpoint:      endpoint,
+		}, nil
+	}
+	serviceBackendFactory = func() serviceBackend {
+		return backend
+	}
+}
+
+func TestServiceInstallNoStartAndForce(t *testing.T) {
+	backend := &stubServiceBackend{}
+	withServiceCommandTestBackend(t, backend)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"install", "--force", "--no-start"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if !backend.installForce || backend.installStart {
+		t.Fatalf("install flags force=%v start=%v, want force true start false", backend.installForce, backend.installStart)
+	}
+	if !strings.Contains(stdout.String(), "Started: no") {
+		t.Fatalf("stdout = %q, want Started: no", stdout.String())
+	}
+}
+
+func TestServiceUninstallKeepRunning(t *testing.T) {
+	backend := &stubServiceBackend{}
+	withServiceCommandTestBackend(t, backend)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"uninstall", "--keep-running"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if backend.uninstallStop {
+		t.Fatal("expected --keep-running to skip stop")
+	}
+}
+
+func TestServiceRestartIfInstalledSkipsMissingService(t *testing.T) {
+	backend := &stubServiceBackend{status: serviceStatus{Installed: false}}
+	withServiceCommandTestBackend(t, backend)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"restart", "--if-installed"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if len(backend.calls) != 1 || backend.calls[0] != serviceActionStatus {
+		t.Fatalf("calls = %+v, want status only", backend.calls)
+	}
+	if strings.TrimSpace(stdout.String()) != "" {
+		t.Fatalf("stdout = %q, want quiet no-op", stdout.String())
+	}
+}
+
+func TestServiceRestartIfInstalledRefreshesRegistrationBeforeRestart(t *testing.T) {
+	backend := &stubServiceBackend{status: serviceStatus{Installed: true, Loaded: false, Running: false}}
+	withServiceCommandTestBackend(t, backend)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"restart", "--if-installed"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	want := []serviceAction{serviceActionStatus, serviceActionStatus, serviceActionInstall}
+	if strings.Join(actionsToStrings(backend.calls), ",") != strings.Join(actionsToStrings(want), ",") {
+		t.Fatalf("calls = %+v, want %+v", backend.calls, want)
+	}
+	if !backend.installForce || !backend.installStart {
+		t.Fatalf("refresh flags force=%v start=%v, want force true start true", backend.installForce, backend.installStart)
+	}
+	if !strings.Contains(stdout.String(), "sessions may fail briefly") {
+		t.Fatalf("stdout = %q, want restart warning", stdout.String())
+	}
+}
+
+func TestServiceStatusJSON(t *testing.T) {
+	backend := &stubServiceBackend{status: serviceStatus{Installed: true, Loaded: true, Running: true, PID: 123}}
+	withServiceCommandTestBackend(t, backend)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"status", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	var decoded serviceStatus
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode status json: %v; raw=%q", err, stdout.String())
+	}
+	if !decoded.Installed || !decoded.Running || decoded.PID != 123 || decoded.Backend != "stub" {
+		t.Fatalf("decoded status = %+v", decoded)
+	}
+}
+
+func actionsToStrings(actions []serviceAction) []string {
+	out := make([]string, 0, len(actions))
+	for _, action := range actions {
+		out = append(out, string(action))
+	}
+	return out
+}
+
+func TestServiceInstallRejectsUnmanagedRunningServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"status":"ok","pid":123}`)
+	}))
+	t.Cleanup(server.Close)
+	backend := &stubServiceBackend{status: serviceStatus{Installed: false, Loaded: false, Running: false}}
+	withServiceCommandTestBackendEndpoint(t, backend, server.URL)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"install"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if len(backend.calls) != 1 || backend.calls[0] != serviceActionStatus {
+		t.Fatalf("calls = %+v, want status only", backend.calls)
+	}
+	if !strings.Contains(stderr.String(), "outside the background service") {
+		t.Fatalf("stderr = %q, want unmanaged conflict", stderr.String())
+	}
+}
+
+func TestServiceInstallAllowsHealthyServerOwnedByLoadedService(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"status":"ok","pid":123}`)
+	}))
+	t.Cleanup(server.Close)
+	backend := &stubServiceBackend{status: serviceStatus{Installed: true, Loaded: true, Running: true, PID: 123}}
+	withServiceCommandTestBackendEndpoint(t, backend, server.URL)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"install", "--force"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if len(backend.calls) != 2 || backend.calls[0] != serviceActionStatus || backend.calls[1] != serviceActionInstall {
+		t.Fatalf("calls = %+v, want status then install", backend.calls)
+	}
+}
+
+func TestServiceStartRejectsUnmanagedRunningServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"status":"ok","pid":123}`)
+	}))
+	t.Cleanup(server.Close)
+	backend := &stubServiceBackend{status: serviceStatus{Installed: true, Loaded: false, Running: false}}
+	withServiceCommandTestBackendEndpoint(t, backend, server.URL)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"start"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if len(backend.calls) != 1 || backend.calls[0] != serviceActionStatus {
+		t.Fatalf("calls = %+v, want status only", backend.calls)
+	}
+}
+
+func TestServiceRestartRejectsRunningServerWhenServicePIDMismatches(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"status":"ok","pid":123}`)
+	}))
+	t.Cleanup(server.Close)
+	backend := &stubServiceBackend{status: serviceStatus{
+		Installed: true,
+		Loaded:    true,
+		Running:   true,
+		PID:       456,
+		Command:   []string{"/other/builder", "serve"},
+	}}
+	withServiceCommandTestBackendEndpoint(t, backend, server.URL)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"restart"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if len(backend.calls) != 1 || backend.calls[0] != serviceActionStatus {
+		t.Fatalf("calls = %+v, want status only", backend.calls)
+	}
+	if !strings.Contains(stderr.String(), "outside the background service") {
+		t.Fatalf("stderr = %q, want unmanaged conflict", stderr.String())
+	}
+}
+
+func TestServiceRestartRejectsRunningServerWhenOwnershipPIDMissingAndCommandDiffers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"status":"ok"}`)
+	}))
+	t.Cleanup(server.Close)
+	backend := &stubServiceBackend{status: serviceStatus{
+		Installed: true,
+		Loaded:    true,
+		Running:   true,
+		Command:   []string{"/other/builder", "serve"},
+	}}
+	withServiceCommandTestBackendEndpoint(t, backend, server.URL)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"restart"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if len(backend.calls) != 1 || backend.calls[0] != serviceActionStatus {
+		t.Fatalf("calls = %+v, want status only", backend.calls)
+	}
+}
+
+func TestServiceActionErrorReturnsOne(t *testing.T) {
+	backend := &stubServiceBackend{err: errors.New("boom")}
+	withServiceCommandTestBackend(t, backend)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"start"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "boom") {
+		t.Fatalf("stderr = %q, want boom", stderr.String())
+	}
+}

--- a/cli/builder/service_command_test.go
+++ b/cli/builder/service_command_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"builder/shared/config"
+	"builder/shared/protocol"
 )
 
 type stubServiceBackend struct {
@@ -178,6 +179,36 @@ func TestServiceStatusJSON(t *testing.T) {
 	}
 	if !decoded.Installed || !decoded.Running || decoded.PID != 123 || decoded.Backend != "stub" {
 		t.Fatalf("decoded status = %+v", decoded)
+	}
+}
+
+func TestServiceStatusKeepsManualHealthSeparateFromServiceRunningState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"status":"ok","pid":123}`)
+	}))
+	t.Cleanup(server.Close)
+	backend := &stubServiceBackend{status: serviceStatus{Installed: true, Loaded: false, Running: false}}
+	withServiceCommandTestBackendEndpoint(t, backend, server.URL)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"status", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	var decoded serviceStatus
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode status json: %v; raw=%q", err, stdout.String())
+	}
+	if decoded.Running {
+		t.Fatalf("running = true, want false for backend stopped status: %+v", decoded)
+	}
+	if decoded.HealthStatus != protocol.HealthStatusOK || decoded.HealthPID != 123 {
+		t.Fatalf("health status = %q pid=%d, want ok/123", decoded.HealthStatus, decoded.HealthPID)
 	}
 }
 

--- a/cli/builder/service_command_test.go
+++ b/cli/builder/service_command_test.go
@@ -352,6 +352,30 @@ func TestServiceRestartRejectsRunningServerWhenOwnershipPIDMissingAndCommandDiff
 	}
 }
 
+func TestServiceRestartAllowsUnhealthyListenerWhenServiceRunning(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		http.Error(w, `{"status":"starting","pid":123}`, http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+	backend := &stubServiceBackend{status: serviceStatus{Installed: true, Loaded: true, Running: true, PID: 123}}
+	withServiceCommandTestBackendEndpoint(t, backend, server.URL)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"restart"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	want := []serviceAction{serviceActionStatus, serviceActionRestart}
+	if strings.Join(actionsToStrings(backend.calls), ",") != strings.Join(actionsToStrings(want), ",") {
+		t.Fatalf("calls = %+v, want %+v", backend.calls, want)
+	}
+}
+
 func TestServiceActionErrorReturnsOne(t *testing.T) {
 	backend := &stubServiceBackend{err: errors.New("boom")}
 	withServiceCommandTestBackend(t, backend)

--- a/cli/builder/service_types.go
+++ b/cli/builder/service_types.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"builder/shared/config"
+	"builder/shared/protocol"
+)
+
+const (
+	serviceDisplayName     = "Builder background service"
+	serviceLaunchdLabel    = "pro.respawn.builder.server"
+	serviceSystemdUnitName = "builder.service"
+	serviceWindowsTaskName = "Builder Server"
+	serviceLogDirName      = "logs"
+	serviceStdoutLogName   = "server.log"
+	serviceStderrLogName   = "server.err.log"
+)
+
+type serviceSpec struct {
+	Config        config.App
+	Executable    string
+	Arguments     []string
+	LogDir        string
+	StdoutLogPath string
+	StderrLogPath string
+	Endpoint      string
+}
+
+type serviceStatus struct {
+	Backend      string   `json:"backend"`
+	Installed    bool     `json:"installed"`
+	Loaded       bool     `json:"loaded"`
+	Running      bool     `json:"running"`
+	PID          int      `json:"pid,omitempty"`
+	Command      []string `json:"command,omitempty"`
+	Endpoint     string   `json:"endpoint"`
+	Logs         []string `json:"logs"`
+	InstallPath  string   `json:"install_path,omitempty"`
+	Detail       string   `json:"detail,omitempty"`
+	Hints        []string `json:"hints,omitempty"`
+	HealthStatus string   `json:"health_status,omitempty"`
+}
+
+type serviceBackend interface {
+	Name() string
+	Install(ctx context.Context, spec serviceSpec, force bool, start bool) error
+	Uninstall(ctx context.Context, spec serviceSpec, stop bool) error
+	Start(ctx context.Context, spec serviceSpec) error
+	Stop(ctx context.Context, spec serviceSpec) error
+	Restart(ctx context.Context, spec serviceSpec) error
+	Status(ctx context.Context, spec serviceSpec) (serviceStatus, error)
+}
+
+type serviceCommandResult struct {
+	Stdout string
+	Stderr string
+	Code   int
+}
+
+func (r serviceCommandResult) Text() string {
+	return strings.TrimSpace(strings.Join([]string{r.Stdout, r.Stderr}, "\n"))
+}
+
+type serviceCommandError struct {
+	Name   string
+	Args   []string
+	Result serviceCommandResult
+}
+
+func (e serviceCommandError) Error() string {
+	detail := e.Result.Text()
+	if detail == "" {
+		detail = fmt.Sprintf("exit code %d", e.Result.Code)
+	}
+	return fmt.Sprintf("%s %s failed: %s", e.Name, strings.Join(e.Args, " "), detail)
+}
+
+var runServiceCommand = func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	stdout, err := cmd.Output()
+	result := serviceCommandResult{Stdout: string(stdout)}
+	if err == nil {
+		return result, nil
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		result.Stderr = string(exitErr.Stderr)
+		result.Code = exitErr.ExitCode()
+		return result, serviceCommandError{Name: name, Args: args, Result: result}
+	}
+	result.Stderr = err.Error()
+	result.Code = 1
+	return result, serviceCommandError{Name: name, Args: args, Result: result}
+}
+
+var serviceHTTPClient = &http.Client{Timeout: 500 * time.Millisecond}
+var resolveServiceExecutablePath = defaultServiceExecutablePath
+var loadServiceSpec = defaultLoadServiceSpec
+var serviceBackendFactory = currentServiceBackend
+
+func defaultLoadServiceSpec() (serviceSpec, error) {
+	cfg, err := config.LoadGlobal(config.LoadOptions{})
+	if err != nil {
+		return serviceSpec{}, err
+	}
+	executable, err := resolveServiceExecutablePath()
+	if err != nil {
+		return serviceSpec{}, err
+	}
+	logDir := filepath.Join(cfg.PersistenceRoot, serviceLogDirName)
+	return serviceSpec{
+		Config:        cfg,
+		Executable:    executable,
+		Arguments:     []string{"serve"},
+		LogDir:        logDir,
+		StdoutLogPath: filepath.Join(logDir, serviceStdoutLogName),
+		StderrLogPath: filepath.Join(logDir, serviceStderrLogName),
+		Endpoint:      config.ServerHTTPBaseURL(cfg),
+	}, nil
+}
+
+func defaultServiceExecutablePath() (string, error) {
+	raw := strings.TrimSpace(os.Args[0])
+	if raw == "" {
+		return "", errors.New("resolve executable path: argv[0] is empty")
+	}
+	if strings.ContainsAny(raw, `/\`) {
+		abs, err := filepath.Abs(raw)
+		if err != nil {
+			return "", fmt.Errorf("resolve executable path: %w", err)
+		}
+		return abs, nil
+	}
+	path, err := exec.LookPath(raw)
+	if err != nil {
+		return "", fmt.Errorf("resolve executable path: %w", err)
+	}
+	return path, nil
+}
+
+func ensureServiceLogDir(spec serviceSpec) error {
+	if err := os.MkdirAll(spec.LogDir, 0o755); err != nil {
+		return fmt.Errorf("create service log dir: %w", err)
+	}
+	return nil
+}
+
+func serviceCommand(spec serviceSpec) []string {
+	cmd := make([]string, 0, 1+len(spec.Arguments))
+	cmd = append(cmd, spec.Executable)
+	cmd = append(cmd, spec.Arguments...)
+	return cmd
+}
+
+func commandString(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(args))
+	for _, arg := range args {
+		parts = append(parts, shellQuote(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func commandArgsEqual(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if !strings.ContainsAny(value, " \t\n'\"\\$`!*?[]{}();&|<>") {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+func applyHealthProbe(ctx context.Context, status serviceStatus, spec serviceSpec) serviceStatus {
+	healthStatus, pid := probeServiceHealth(ctx, spec)
+	if strings.TrimSpace(healthStatus) == "" {
+		return status
+	}
+	status.HealthStatus = healthStatus
+	if status.HealthStatus == "ok" {
+		status.Running = true
+	}
+	if pid > 0 {
+		status.PID = pid
+	}
+	return status
+}
+
+func probeServiceHealth(ctx context.Context, spec serviceSpec) (string, int) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, spec.Endpoint+protocol.HealthPath, nil)
+	if err != nil {
+		return "", 0
+	}
+	resp, err := serviceHTTPClient.Do(req)
+	if err != nil {
+		return "", 0
+	}
+	defer func() { _ = resp.Body.Close() }()
+	type healthResponse struct {
+		Status string `json:"status"`
+		PID    int    `json:"pid"`
+	}
+	var health healthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		return "", 0
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return strings.TrimSpace(health.Status), health.PID
+	}
+	return strings.TrimSpace(health.Status), health.PID
+}
+
+func appendStatusDetail(existing string, detail string) string {
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return existing
+	}
+	if strings.TrimSpace(existing) == "" {
+		return detail
+	}
+	return existing + "; " + detail
+}
+
+func parsePositiveInt(value string) int {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0
+	}
+	parsed, err := strconv.Atoi(trimmed)
+	if err != nil || parsed <= 0 {
+		return 0
+	}
+	return parsed
+}

--- a/cli/builder/service_types.go
+++ b/cli/builder/service_types.go
@@ -201,7 +201,7 @@ func applyHealthProbe(ctx context.Context, status serviceStatus, spec serviceSpe
 		return status
 	}
 	status.HealthStatus = healthStatus
-	if status.HealthStatus == "ok" {
+	if status.HealthStatus == protocol.HealthStatusOK {
 		status.Running = true
 	}
 	if pid > 0 {
@@ -229,7 +229,7 @@ func probeServiceHealth(ctx context.Context, spec serviceSpec) (string, int) {
 		return "", 0
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return strings.TrimSpace(health.Status), health.PID
+		return "", 0
 	}
 	return strings.TrimSpace(health.Status), health.PID
 }

--- a/cli/builder/service_types.go
+++ b/cli/builder/service_types.go
@@ -50,6 +50,7 @@ type serviceStatus struct {
 	Detail       string   `json:"detail,omitempty"`
 	Hints        []string `json:"hints,omitempty"`
 	HealthStatus string   `json:"health_status,omitempty"`
+	HealthPID    int      `json:"health_pid,omitempty"`
 }
 
 type serviceBackend interface {
@@ -201,11 +202,8 @@ func applyHealthProbe(ctx context.Context, status serviceStatus, spec serviceSpe
 		return status
 	}
 	status.HealthStatus = healthStatus
-	if status.HealthStatus == protocol.HealthStatusOK {
-		status.Running = true
-	}
 	if pid > 0 {
-		status.PID = pid
+		status.HealthPID = pid
 	}
 	return status
 }

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -53,6 +53,10 @@ export default defineConfig({
           link: '/headless/',
         },
         {
+          label: 'Builder Server',
+          link: '/server/',
+        },
+        {
           label: 'Configuration',
           link: '/config/',
         },

--- a/docs/src/content/docs/headless.md
+++ b/docs/src/content/docs/headless.md
@@ -7,6 +7,8 @@ Builder supports a headless, non-interactive run mode via `builder run`.
 When the interactive Builder session uses subagents, it does so by launching separate headless Builder runs. In other words:
 This keeps the subagent path transparent and scriptable: the feature Builder uses internally is also directly available to human users.
 
+For a shared local server that starts at login, use [`builder service`](../server/).
+
 Run a single prompt:
 
 ```bash

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -22,6 +22,17 @@ curl -fsSL https://raw.githubusercontent.com/respawn-app/builder/main/scripts/in
 
 Check the installed version with: `builder --version`
 
+## Optional: Install the Background Service
+
+Run this if you want one shared Builder server to start at login:
+
+```bash
+builder service install
+```
+
+It uses about 70 MB of RAM, lets unlimited frontends stay lightweight by connecting to one local orchestrator, and makes background shells reliable when a terminal frontend exits.
+See [Builder Server](../server/) for details and service management commands.
+
 ## First Authentication
 
 Start Builder CLI with: `builder`

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -22,8 +22,6 @@ curl -fsSL https://raw.githubusercontent.com/respawn-app/builder/main/scripts/in
 
 Check the installed version with: `builder --version`
 
-Interactive sessions show a one-time startup notice, `update available: <version>`, in the first interactive session when a newer release is published. `/status` shows the same update state.
-
 ## Optional: Install the Background Service
 
 Run this if you want one shared Builder server to start at login:
@@ -47,8 +45,7 @@ Supported auth options:
 You can switch later with `/login`.
 
 :::note
-Anthropic or Gemini subscriptions will not be supported until that becomes legal.
-Non-OpenAI model support is limited.
+Anthropic or Gemini subscriptions/models will not be supported until they allow third-party harnesses in their ToS.
 :::
 
 ## Main Workflows
@@ -73,7 +70,7 @@ Builder reads settings from `~/.builder/config.toml` and will auto-create it thr
 
 ## Skills and Slash Commands
 
-On first launch, the setup wizard can optionally symlink existing skills and slash-command directories from `~/.claude`, `~/.codex`, or `~/.agents` into Builder's `~/.builder` layout. Runtime discovery still reads Builder directories only.
+On first launch, the setup wizard can optionally symlink existing skills and slash-command directories from `~/.claude`, `~/.codex`, or `~/.agents` into Builder's `~/.builder` layout.
 
 Builder discovers skills from:
 
@@ -95,11 +92,9 @@ Builder discovers custom slash commands from Markdown files in:
 - `~/.builder/prompts`
 - `~/.builder/commands`
 
-Each top-level `.md` file becomes a `/prompt:<name>` command.
-
 ## Supervisor
 
-- Use `/supervisor` to toggle its invocation for the current session. Initial value is config's `reviewer.frequency`, and default is after code edits. Supervisor is a feature that will automatically review the edits made by the model. It increases costs by ~20% but improves results.
+- Use `/supervisor` to toggle its invocation for the current session. Initial value is config's `reviewer.frequency`, and default is after code edits. Supervisor is a feature that will automatically review the edits made by the model. It increases costs by ~15% (if using the main model) but improves results.
 
 By default supervisor uses the same model as the main one. That may be too much / too slow for you. [Configuration](../config/) page contains instructions on how to change supervisor model.
 Running OSS models or smaller models like `gpt-5.4-mini` seems to give almost the same results while keeping costs low.

--- a/docs/src/content/docs/server.md
+++ b/docs/src/content/docs/server.md
@@ -1,0 +1,79 @@
+---
+title: Builder Server
+description: Builder's local client-server architecture and background service management.
+---
+
+Builder runs work through a local server process.
+Frontends are clients: the terminal UI, headless runs, future apps, and other local integrations connect to the same server API instead of each owning separate orchestration state.
+
+The server owns long-running work: sessions, project bindings, runtime orchestration, background shells, tool execution, and server-side storage under Builder's persistence root.
+Keeping one shared server running lets frontends stay lightweight and reconnect without taking ownership of in-flight work.
+
+## Background Service
+
+`builder service` installs and manages a supervised background `builder serve` process.
+The service starts at login and keeps the local server available before any frontend opens.
+
+```bash
+builder service install
+```
+
+The background server uses about 70 MB of RAM while idle.
+That cost buys one shared orchestrator for all Builder frontends and makes long-running background shells less dependent on the lifetime of a single terminal frontend.
+
+Homebrew does not install the background service automatically.
+
+## Commands
+
+```bash
+builder service status
+builder service status --json
+builder service install
+builder service install --no-start
+builder service install --force
+builder service restart
+builder service restart --if-installed
+builder service stop
+builder service start
+builder service uninstall
+builder service uninstall --keep-running
+```
+
+`install` starts the service after registration. `--no-start` only writes the service registration.
+`uninstall` stops the service before removing registration. `--keep-running` removes registration without stopping an already-running process.
+`restart --if-installed` is used by package updates: it exits successfully without output when no service is installed.
+
+## Backends
+
+| OS | Supervisor |
+| --- | --- |
+| macOS | LaunchAgent |
+| Linux / WSL2 | `systemd --user` |
+| Windows | Scheduled Task at logon, with Startup folder fallback |
+
+Linux headless machines may need lingering enabled so the server survives logout:
+
+```bash
+loginctl enable-linger "$USER"
+```
+
+## Status
+
+Human status output includes install state, backend, PID when known, command, endpoint, and log paths.
+
+```bash
+builder service status
+```
+
+JSON output is stable for scripts:
+
+```bash
+builder service status --json
+```
+
+## Port Conflicts
+
+Service lifecycle commands refuse to change the service when Builder's configured server endpoint is already owned by a manual `builder serve` process or by a non-Builder listener.
+If you started `builder serve` manually, stop that process before installing, starting, or restarting the background service.
+
+Running another server on a different configured port is fine. Builder only checks the endpoint resolved from `server_host` and `server_port`.

--- a/docs/src/content/docs/service.md
+++ b/docs/src/content/docs/service.md
@@ -1,0 +1,6 @@
+---
+title: Background Service
+description: Compatibility page for Builder server service docs.
+---
+
+Builder server service docs moved to [Builder Server](../server/).

--- a/scripts/sandbox-serve.sh
+++ b/scripts/sandbox-serve.sh
@@ -162,6 +162,15 @@ container_exists() {
 	docker container inspect "$container_name" >/dev/null 2>&1
 }
 
+require_host_port_available() {
+	if [ "$dry_run" = "true" ]; then
+		return 0
+	fi
+	if (echo >/dev/tcp/127.0.0.1/"$host_port") >/dev/null 2>&1; then
+		die "host port ${host_port} is already in use. Stop the owner or pass --host-port <free-port>."
+	fi
+}
+
 wait_for_ready() {
 	if [ "$dry_run" = "true" ]; then
 		printf '[dry-run] poll http://127.0.0.1:%s/healthz until transport is ready\n' "$host_port"
@@ -226,13 +235,14 @@ run_up() {
 	home_volume="${home_volume:-${container_name}-home}"
 	serve_args=("${passthrough_args[@]}")
 	ensure_docker
-	build_image
-	collect_container_env
-	collect_seed_mounts
 	if container_exists; then
 		log "replace existing container ${container_name}"
 		run docker container rm -f "$container_name"
 	fi
+	require_host_port_available
+	build_image
+	collect_container_env
+	collect_seed_mounts
 	run docker volume create "$workspace_volume"
 	run docker volume create "$home_volume"
 	log "start sandbox container ${container_name}"

--- a/scripts/sandbox/builder-sandbox-entrypoint.sh
+++ b/scripts/sandbox/builder-sandbox-entrypoint.sh
@@ -11,27 +11,13 @@ server_port="${BUILDER_SERVER_PORT:-53082}"
 sandbox_home="${SANDBOX_HOME:-/home/builder}"
 builder_bin="${BUILDER_SANDBOX_BUILDER_BIN:-/usr/local/bin/builder}"
 
-require_commands() {
-	local missing=()
-	local cmd
-	for cmd in "$@"; do
-		if ! command -v "$cmd" >/dev/null 2>&1; then
-			missing+=("$cmd")
-		fi
-	done
-	if [ ${#missing[@]} -gt 0 ]; then
-		echo "sandbox image is missing required dev tools: ${missing[*]}" >&2
-		return 1
-	fi
-}
-
-require_project_create_cli() {
-	if HOME="$sandbox_home" "$builder_bin" project create --help >/dev/null 2>&1; then
-		return 0
-	fi
-	echo "sandbox bootstrap requires project registration support. Upgrade Builder so \`builder project create --path <server-path> --name <project-name>\` is available." >&2
-	return 1
-}
+if [ "$(id -u)" -eq 0 ]; then
+	mkdir -p "$(dirname -- "$workspace_root")"
+	mkdir -p "$workspace_root"
+	mkdir -p "$sandbox_home/.builder"
+	chown -R builder:builder "$workspace_root" "$sandbox_home"
+	exec runuser -u builder -- "$0" "$@"
+fi
 
 copy_seed_file_if_missing() {
 	local target_path="${1:-}"
@@ -65,13 +51,9 @@ cleanup() {
 
 trap cleanup EXIT INT TERM
 
-require_commands git jq yq rg fd fzf sqlite3 strace lsof ip dig nc tree rsync zip python3 python pip uv
-
 mkdir -p "$(dirname -- "$workspace_root")"
 mkdir -p "$workspace_root"
 mkdir -p "$sandbox_home/.builder"
-
-require_project_create_cli
 
 copy_seed_file_if_missing "$sandbox_home/.builder/config.toml" "$config_seed_path"
 copy_seed_file_if_missing "$sandbox_home/.builder/auth.json" "$auth_seed_path"
@@ -82,7 +64,7 @@ fi
 
 cd "$workspace_root"
 
-HOME="$sandbox_home" "$builder_bin" serve --workspace "$workspace_root" "$@" &
+HOME="$sandbox_home" "$builder_bin" serve "$@" &
 server_pid=$!
 
 ready_status=0

--- a/scripts/sandbox/builder-sandbox.Dockerfile
+++ b/scripts/sandbox/builder-sandbox.Dockerfile
@@ -80,6 +80,4 @@ RUN chmod +x /usr/local/bin/builder /usr/local/bin/builder-sandbox-entrypoint \
 	&& git -C /opt/builder-sandbox-seed commit -qm "chore: sandbox seed ${SANDBOX_SNAPSHOT_REF}" \
 	&& chown -R builder:builder /go /home/builder /opt/builder-sandbox-seed /workspace
 
-USER builder
-
 ENTRYPOINT ["tini", "--", "/usr/local/bin/builder-sandbox-entrypoint"]

--- a/scripts/scripts_test.go
+++ b/scripts/scripts_test.go
@@ -1,10 +1,12 @@
 package scripts_test
 
 import (
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -96,6 +98,38 @@ func TestUpdateDepsUnknownArgument(t *testing.T) {
 	}
 	if !strings.Contains(text, "Usage: scripts/update-deps.sh") {
 		t.Fatalf("expected usage output, got %q", text)
+	}
+}
+
+func TestSandboxServeUpReportsHostPortInUse(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on local port: %v", err)
+	}
+	defer listener.Close()
+
+	root := repoRoot(t)
+	script := filepath.Join(root, "scripts", "sandbox-serve.sh")
+	port := listener.Addr().(*net.TCPAddr).Port
+	binDir := t.TempDir()
+	fakeDocker := filepath.Join(binDir, "docker")
+	if err := os.WriteFile(fakeDocker, []byte("#!/usr/bin/env bash\nif [ \"${1:-}\" = info ]; then exit 0; fi\nif [ \"${1:-}\" = container ] && [ \"${2:-}\" = inspect ]; then exit 1; fi\necho unexpected docker \"$@\" >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+	cmd := exec.Command("bash", script, "up", "--host-port", strconv.Itoa(port))
+	cmd.Dir = root
+	cmd.Env = append(sanitizedScriptTestEnv(os.Environ()), "PATH="+binDir+string(os.PathListSeparator)+mustLookupEnv(t, "PATH"))
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected occupied host port failure")
+	}
+	text := string(output)
+	expected := "host port " + strconv.Itoa(port) + " is already in use"
+	if !strings.Contains(text, expected) {
+		t.Fatalf("expected %q in output, got %q", expected, text)
+	}
+	if strings.Contains(text, "build sandbox image") {
+		t.Fatalf("expected port preflight before image build, got %q", text)
 	}
 }
 

--- a/scripts/update-brew-tap.sh
+++ b/scripts/update-brew-tap.sh
@@ -188,6 +188,22 @@ class ${formula_class} < Formula
     system "bash", "scripts/build.sh", "--output", bin/"builder"
   end
 
+  def post_install
+    output = Utils.safe_popen_read(bin/"builder", "service", "restart", "--if-installed").strip
+    ohai output unless output.empty?
+  rescue => e
+    opoo "Builder background service restart failed after update: #{e.message}"
+  end
+
+  def caveats
+    <<~EOS
+      Homebrew does not install the Builder server background service.
+
+      If you want one shared background server for all Builder frontends (~70 MB RAM), run:
+        builder service install
+    EOS
+  end
+
   test do
     assert_match "Usage of builder:", shell_output("#{bin}/builder --help 2>&1")
   end

--- a/server/serve/serve.go
+++ b/server/serve/serve.go
@@ -145,7 +145,7 @@ func (s *Server) Serve(ctx context.Context) error {
 	mux.HandleFunc(protocol.HealthPath, func(w http.ResponseWriter, r *http.Request) {
 		authReady := serverAuthReady(r.Context(), s.Core)
 		writeStatusJSON(w, http.StatusOK, map[string]any{
-			"status":     "ok",
+			"status":     protocol.HealthStatusOK,
 			"server_id":  identity.ServerID,
 			"pid":        identity.PID,
 			"auth_ready": authReady,

--- a/shared/protocol/protocol.go
+++ b/shared/protocol/protocol.go
@@ -6,6 +6,7 @@ const (
 	Version           = "1"
 	RPCPath           = "/rpc"
 	HealthPath        = "/healthz"
+	HealthStatusOK    = "ok"
 	ReadinessPath     = "/readyz"
 	DiscoveryFilename = "app-server.json"
 )


### PR DESCRIPTION
## Summary
- add `builder service` lifecycle commands for the Builder server background service
- implement macOS launchd, Linux systemd user, and Windows scheduled-task/startup fallback backends
- add Homebrew service caveat/restart hook and Builder Server docs

## Verification
- `go test ./...`
- `GOOS=linux GOARCH=arm64 go test -c ./cli/builder -o /tmp/builder-cli-linux.test`
- `GOOS=windows GOARCH=amd64 go test -c ./cli/builder -o /tmp/builder-cli-windows.test.exe`
- `./scripts/test.sh ./...`
- `./scripts/build.sh --output ./bin/builder`
- `pnpm --dir docs test`
- `pnpm --dir docs build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `builder service` command for installing, starting, stopping, and managing a shared Builder background server.
  * Background service auto-starts at login with per-platform supervisor support (macOS, Linux, Windows).
  * Service status available in human-readable or JSON format.

* **Documentation**
  * New Builder Server documentation with setup and management guidance.
  * Updated Quickstart with optional service installation instructions.
  * Added post-install hook to Homebrew formula for service restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->