### PR TITLE
feat!: make ongoing delivery SSOT-backed

### DIFF
--- a/cli/app/auth_gate.go
+++ b/cli/app/auth_gate.go
@@ -273,9 +273,8 @@ func (i *interactiveAuthInteractor) showAuthSuccess(ctx context.Context, req aut
 		return fmt.Errorf("load auth state for success screen: %w", err)
 	}
 	return run(authSuccessScreenData{
-		Theme:           req.Theme,
-		AlternateScreen: req.AlternateScreen,
-		Method:          state.Method,
+		Theme:  req.Theme,
+		Method: state.Method,
 	})
 }
 

--- a/cli/app/auth_gate_test.go
+++ b/cli/app/auth_gate_test.go
@@ -55,7 +55,7 @@ func (s *stubAuthInteractor) Interactive() bool {
 func TestEnsureAuthReadyHeadlessReturnsStartupErrorWithoutCredentials(t *testing.T) {
 	mgr := auth.NewManager(auth.NewMemoryStore(auth.EmptyState()), nil, time.Now)
 
-	err := ensureAuthReady(context.Background(), mgr, auth.OpenAIOAuthOptions{}, config.Settings{Model: "gpt-5", Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenAuto}, &headlessAuthInteractor{
+	err := ensureAuthReady(context.Background(), mgr, auth.OpenAIOAuthOptions{}, config.Settings{Model: "gpt-5", Theme: "dark"}, &headlessAuthInteractor{
 		lookupEnv: func(string) string { return "" },
 	})
 	if !errors.Is(err, auth.ErrAuthNotConfigured) {

--- a/cli/app/auth_picker.go
+++ b/cli/app/auth_picker.go
@@ -7,7 +7,6 @@ import (
 
 	"builder/cli/tui"
 	"builder/server/auth"
-	"builder/shared/config"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
@@ -315,12 +314,8 @@ func newStartupPickerStyles(theme string) startupPickerStyles {
 	}
 }
 
-func runStartupPicker(model *startupPickerModel, alternateScreen config.TUIAlternateScreenPolicy) (startupPickerResult, error) {
-	options := []tea.ProgramOption{}
-	if shouldUseStartupPickerAltScreen(alternateScreen) {
-		options = append(options, tea.WithAltScreen())
-	}
-	program := tea.NewProgram(model, options...)
+func runStartupPicker(model *startupPickerModel) (startupPickerResult, error) {
+	program := tea.NewProgram(model, tea.WithAltScreen())
 	finalModel, err := program.Run()
 	if err != nil {
 		return startupPickerResult{}, err
@@ -412,7 +407,7 @@ func authMethodDisplayTitle(choice authMethodChoice) string {
 
 func runAuthMethodPicker(req authInteraction) (authMethodPickerResult, error) {
 	model := newAuthMethodPickerModel(req.Theme, authMethodPickerNoticeForRequest(req), req.HasEnvAPIKey, !req.AuthRequired)
-	picked, err := runStartupPicker(model, req.AlternateScreen)
+	picked, err := runStartupPicker(model)
 	if err != nil {
 		return authMethodPickerResult{}, err
 	}
@@ -452,7 +447,7 @@ func runAuthConflictPicker(req authInteraction) (authConflictPickerResult, error
 		startupPickerNotice{Text: "Builder found both saved subscription auth and OPENAI_API_KEY. Choose which auth source should win from now on.", Kind: startupPickerNoticeNeutral},
 		authConflictOptions(),
 	)
-	picked, err := runStartupPicker(model, req.AlternateScreen)
+	picked, err := runStartupPicker(model)
 	if err != nil {
 		return authConflictPickerResult{}, err
 	}

--- a/cli/app/auth_picker_test.go
+++ b/cli/app/auth_picker_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"builder/server/auth"
-	"builder/shared/config"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -145,12 +144,11 @@ func TestInteractiveAuthInteractorOffersEnvAPIKeyChoiceWhenAvailable(t *testing.
 	}
 
 	_, err := interactor.Interact(ctx, authInteraction{
-		Manager:         mgr,
-		State:           auth.EmptyState(),
-		Gate:            auth.StartupGate{Reason: auth.ErrAuthNotConfigured.Error()},
-		Theme:           "dark",
-		AlternateScreen: config.TUIAlternateScreenAuto,
-		HasEnvAPIKey:    true,
+		Manager:      mgr,
+		State:        auth.EmptyState(),
+		Gate:         auth.StartupGate{Reason: auth.ErrAuthNotConfigured.Error()},
+		Theme:        "dark",
+		HasEnvAPIKey: true,
 	})
 	if err != nil {
 		t.Fatalf("interact: %v", err)
@@ -178,12 +176,11 @@ func TestInteractiveAuthInteractorRejectsEnvAPIKeyChoiceWithoutAvailableKey(t *t
 	}
 
 	_, err := interactor.Interact(context.Background(), authInteraction{
-		Manager:         auth.NewManager(auth.NewMemoryStore(auth.EmptyState()), nil, time.Now),
-		State:           auth.EmptyState(),
-		Gate:            auth.StartupGate{Reason: auth.ErrAuthNotConfigured.Error()},
-		Theme:           "dark",
-		AlternateScreen: config.TUIAlternateScreenAuto,
-		HasEnvAPIKey:    false,
+		Manager:      auth.NewManager(auth.NewMemoryStore(auth.EmptyState()), nil, time.Now),
+		State:        auth.EmptyState(),
+		Gate:         auth.StartupGate{Reason: auth.ErrAuthNotConfigured.Error()},
+		Theme:        "dark",
+		HasEnvAPIKey: false,
 	})
 	if err == nil || err.Error() != "OPENAI_API_KEY is not available" {
 		t.Fatalf("expected missing OPENAI_API_KEY error, got %v", err)
@@ -198,11 +195,10 @@ func TestInteractiveAuthInteractorRejectsUnknownAuthMethodChoice(t *testing.T) {
 	}
 
 	_, err := interactor.Interact(context.Background(), authInteraction{
-		Manager:         auth.NewManager(auth.NewMemoryStore(auth.EmptyState()), nil, time.Now),
-		State:           auth.EmptyState(),
-		Gate:            auth.StartupGate{Reason: auth.ErrAuthNotConfigured.Error()},
-		Theme:           "dark",
-		AlternateScreen: config.TUIAlternateScreenAuto,
+		Manager: auth.NewManager(auth.NewMemoryStore(auth.EmptyState()), nil, time.Now),
+		State:   auth.EmptyState(),
+		Gate:    auth.StartupGate{Reason: auth.ErrAuthNotConfigured.Error()},
+		Theme:   "dark",
 	})
 	if err == nil || err.Error() != "unknown auth method \"bogus\"" {
 		t.Fatalf("expected unknown auth method error, got %v", err)
@@ -240,13 +236,12 @@ func TestInteractiveAuthInteractorResolvesEnvConflictAndRemembersPreference(t *t
 	}
 
 	_, err := interactor.Interact(ctx, authInteraction{
-		Manager:         mgr,
-		State:           auth.State{Scope: auth.ScopeGlobal, Method: auth.Method{Type: auth.MethodOAuth, OAuth: &auth.OAuthMethod{AccessToken: "oauth-token"}}},
-		StoredState:     auth.State{Scope: auth.ScopeGlobal, Method: auth.Method{Type: auth.MethodOAuth, OAuth: &auth.OAuthMethod{AccessToken: "oauth-token"}}},
-		Gate:            auth.StartupGate{Ready: true},
-		Theme:           "dark",
-		AlternateScreen: config.TUIAlternateScreenAuto,
-		HasEnvAPIKey:    true,
+		Manager:      mgr,
+		State:        auth.State{Scope: auth.ScopeGlobal, Method: auth.Method{Type: auth.MethodOAuth, OAuth: &auth.OAuthMethod{AccessToken: "oauth-token"}}},
+		StoredState:  auth.State{Scope: auth.ScopeGlobal, Method: auth.Method{Type: auth.MethodOAuth, OAuth: &auth.OAuthMethod{AccessToken: "oauth-token"}}},
+		Gate:         auth.StartupGate{Ready: true},
+		Theme:        "dark",
+		HasEnvAPIKey: true,
 	})
 	if err != nil {
 		t.Fatalf("interact: %v", err)
@@ -293,12 +288,11 @@ func TestInteractiveAuthInteractorChoosingOAuthWithEnvRemembersSavedPreference(t
 	}
 
 	_, err := interactor.Interact(ctx, authInteraction{
-		Manager:         mgr,
-		State:           auth.EmptyState(),
-		Gate:            auth.StartupGate{Reason: auth.ErrAuthNotConfigured.Error()},
-		Theme:           "dark",
-		AlternateScreen: config.TUIAlternateScreenAuto,
-		HasEnvAPIKey:    true,
+		Manager:      mgr,
+		State:        auth.EmptyState(),
+		Gate:         auth.StartupGate{Reason: auth.ErrAuthNotConfigured.Error()},
+		Theme:        "dark",
+		HasEnvAPIKey: true,
 	})
 	if err != nil {
 		t.Fatalf("interact: %v", err)
@@ -366,11 +360,10 @@ func TestInteractiveAuthInteractorRetriesWithFlowErrorAndClearsOnSuccess(t *test
 	}
 
 	_, err := interactor.Interact(ctx, authInteraction{
-		Manager:         mgr,
-		State:           auth.EmptyState(),
-		Gate:            auth.StartupGate{Reason: auth.ErrAuthNotConfigured.Error()},
-		Theme:           "dark",
-		AlternateScreen: config.TUIAlternateScreenAuto,
+		Manager: mgr,
+		State:   auth.EmptyState(),
+		Gate:    auth.StartupGate{Reason: auth.ErrAuthNotConfigured.Error()},
+		Theme:   "dark",
 	})
 	if err != nil {
 		t.Fatalf("interact: %v", err)

--- a/cli/app/auth_success_screen.go
+++ b/cli/app/auth_success_screen.go
@@ -5,15 +5,13 @@ import (
 	"strings"
 
 	"builder/server/auth"
-	"builder/shared/config"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
 
 type authSuccessScreenData struct {
-	Theme           string
-	AlternateScreen config.TUIAlternateScreenPolicy
-	Method          auth.Method
+	Theme  string
+	Method auth.Method
 }
 
 type authSuccessScreenModel struct {
@@ -93,11 +91,7 @@ func authSuccessScreenTitle(method auth.Method) string {
 
 var runAuthSuccessScreen = func(data authSuccessScreenData) error {
 	model := newAuthSuccessScreenModel(data)
-	options := []tea.ProgramOption{}
-	if shouldUseStartupPickerAltScreen(data.AlternateScreen) {
-		options = append(options, tea.WithAltScreen())
-	}
-	program := tea.NewProgram(model, options...)
+	program := tea.NewProgram(model, tea.WithAltScreen())
 	_, err := program.Run()
 	return err
 }

--- a/cli/app/launch_planner.go
+++ b/cli/app/launch_planner.go
@@ -81,7 +81,7 @@ func (p *runtimeLaunchPlan) CurrentControllerLeaseID() string {
 	return strings.TrimSpace(p.ControllerLeaseID)
 }
 
-type sessionPickerRunner func([]clientui.SessionSummary, string, config.TUIAlternateScreenPolicy) (sessionPickerResult, error)
+type sessionPickerRunner func([]clientui.SessionSummary, string) (sessionPickerResult, error)
 
 type sessionViewReader interface {
 	GetSessionMainView(ctx context.Context, req serverapi.SessionMainViewRequest) (serverapi.SessionMainViewResponse, error)
@@ -95,8 +95,8 @@ type launchPlanner struct {
 func newSessionLaunchPlanner(server embeddedServer) *launchPlanner {
 	return &launchPlanner{
 		server: server,
-		pickSession: func(summaries []clientui.SessionSummary, theme string, alternateScreenPolicy config.TUIAlternateScreenPolicy) (sessionPickerResult, error) {
-			return runSessionPickerFlow(summaries, theme, alternateScreenPolicy)
+		pickSession: func(summaries []clientui.SessionSummary, theme string) (sessionPickerResult, error) {
+			return runSessionPickerFlow(summaries, theme)
 		},
 	}
 }
@@ -211,7 +211,7 @@ func (p *launchPlanner) resolvePlanRequest(ctx context.Context, req sessionLaunc
 		return resolvedSessionPlanRequest{}, errors.New("session picker is required")
 	}
 	cfg := p.server.Config()
-	picked, err := p.pickSession(summaries, cfg.Settings.Theme, cfg.Settings.TUIAlternateScreen)
+	picked, err := p.pickSession(summaries, cfg.Settings.Theme)
 	if err != nil {
 		return resolvedSessionPlanRequest{}, err
 	}
@@ -348,9 +348,6 @@ func cloneEnabledToolSet(in map[toolspec.ID]bool) map[toolspec.ID]bool {
 
 func logLaunchPlanStart(logger *runLogger, plan sessionLaunchPlan, startLogLine string) {
 	logger.Logf("%s", startLogLine)
-	if plan.Mode == launchModeInteractive && plan.ActiveSettings.TUIAlternateScreen == config.TUIAlternateScreenAlways {
-		logger.Logf("ui.scrollback.native keeps main UI startup in normal buffer even with tui_alternate_screen=always")
-	}
 	logger.Logf("config.settings path=%s created=%t", plan.Source.SettingsPath, plan.Source.CreatedDefaultConfig)
 	for _, line := range configSourceLines(plan.Source) {
 		logger.Logf("config.source %s", line)

--- a/cli/app/launch_planner_test.go
+++ b/cli/app/launch_planner_test.go
@@ -120,14 +120,14 @@ func TestSessionLaunchPlannerInteractiveUsesPickerSelection(t *testing.T) {
 			cfg: config.App{
 				WorkspaceRoot:   cfg.WorkspaceRoot,
 				PersistenceRoot: cfg.PersistenceRoot,
-				Settings:        config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenAuto},
+				Settings:        config.Settings{Theme: "dark"},
 			},
 			containerDir: containerDir,
 			sessionViewClient: stubSessionViewClient{getSessionMainView: func(context.Context, serverapi.SessionMainViewRequest) (serverapi.SessionMainViewResponse, error) {
 				return serverapi.SessionMainViewResponse{MainView: clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{ExecutionTarget: clientui.SessionExecutionTarget{WorkspaceRoot: cfg.WorkspaceRoot}}}}, nil
 			}},
 		},
-		pickSession: func(summaries []clientui.SessionSummary, theme string, alternateScreenPolicy config.TUIAlternateScreenPolicy) (sessionPickerResult, error) {
+		pickSession: func(summaries []clientui.SessionSummary, theme string) (sessionPickerResult, error) {
 			if len(summaries) != 2 {
 				t.Fatalf("expected two summaries, got %d", len(summaries))
 			}
@@ -183,7 +183,7 @@ func TestSessionLaunchPlannerMarksNoOtherSessionsForDirectSingleSessionResume(t 
 		cfg: config.App{
 			WorkspaceRoot:   cfg.WorkspaceRoot,
 			PersistenceRoot: cfg.PersistenceRoot,
-			Settings:        config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenAuto},
+			Settings:        config.Settings{Theme: "dark"},
 		},
 		containerDir: containerDir,
 	})
@@ -209,7 +209,7 @@ func TestSessionLaunchPlannerPickerSelectionMissingMetadataMarksRecoveryInsteadO
 			cfg: config.App{
 				WorkspaceRoot:   workspaceRoot,
 				PersistenceRoot: root,
-				Settings:        config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenAuto},
+				Settings:        config.Settings{Theme: "dark"},
 			},
 			projectID: binding.ProjectID,
 			projectViewClient: client.NewLoopbackProjectViewClient(projectBindingFlowStubProjectViewService{
@@ -219,10 +219,10 @@ func TestSessionLaunchPlannerPickerSelectionMissingMetadataMarksRecoveryInsteadO
 				return serverapi.SessionMainViewResponse{}, errors.New("missing selected session")
 			}},
 			sessionLaunch: stubSessionLaunchClient{planSession: func(context.Context, serverapi.SessionPlanRequest) (serverapi.SessionPlanResponse, error) {
-				return serverapi.SessionPlanResponse{Plan: serverapi.SessionPlan{SessionID: "missing-session", WorkspaceRoot: workspaceRoot, ActiveSettings: config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenAuto}}}, nil
+				return serverapi.SessionPlanResponse{Plan: serverapi.SessionPlan{SessionID: "missing-session", WorkspaceRoot: workspaceRoot, ActiveSettings: config.Settings{Theme: "dark"}}}, nil
 			}},
 		},
-		pickSession: func(summaries []clientui.SessionSummary, theme string, alternateScreenPolicy config.TUIAlternateScreenPolicy) (sessionPickerResult, error) {
+		pickSession: func(summaries []clientui.SessionSummary, theme string) (sessionPickerResult, error) {
 			picked := summaries[0]
 			return sessionPickerResult{Session: &picked}, nil
 		},
@@ -294,11 +294,11 @@ func TestSessionLaunchPlannerInteractiveUsesMigratedLegacySession(t *testing.T) 
 			cfg: config.App{
 				WorkspaceRoot:   cfg.WorkspaceRoot,
 				PersistenceRoot: cfg.PersistenceRoot,
-				Settings:        config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenAuto},
+				Settings:        config.Settings{Theme: "dark"},
 			},
 			containerDir: containerDir,
 		},
-		pickSession: func(summaries []clientui.SessionSummary, theme string, alternateScreenPolicy config.TUIAlternateScreenPolicy) (sessionPickerResult, error) {
+		pickSession: func(summaries []clientui.SessionSummary, theme string) (sessionPickerResult, error) {
 			if len(summaries) != 1 {
 				t.Fatalf("expected one legacy summary, got %d", len(summaries))
 			}
@@ -335,7 +335,7 @@ func TestSessionLaunchPlannerPropagatesServerOwnershipToStatusConfig(t *testing.
 					cfg: config.App{
 						WorkspaceRoot:   "/tmp/workspace-a",
 						PersistenceRoot: root,
-						Settings:        config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenAuto},
+						Settings:        config.Settings{Theme: "dark"},
 					},
 					containerDir: containerDir,
 				},
@@ -370,7 +370,7 @@ func TestSessionLaunchPlannerSelectedSessionIDBypassesPicker(t *testing.T) {
 			cfg: config.App{
 				WorkspaceRoot:   "/tmp/workspace-a",
 				PersistenceRoot: root,
-				Settings:        config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenAuto, OpenAIBaseURL: "http://config.local/v1"},
+				Settings:        config.Settings{Theme: "dark", OpenAIBaseURL: "http://config.local/v1"},
 			},
 			containerDir: containerDir,
 			sessionViewClient: stubSessionViewClient{getSessionMainView: func(context.Context, serverapi.SessionMainViewRequest) (serverapi.SessionMainViewResponse, error) {
@@ -378,7 +378,7 @@ func TestSessionLaunchPlannerSelectedSessionIDBypassesPicker(t *testing.T) {
 				return serverapi.SessionMainViewResponse{}, nil
 			}},
 		},
-		pickSession: func([]clientui.SessionSummary, string, config.TUIAlternateScreenPolicy) (sessionPickerResult, error) {
+		pickSession: func([]clientui.SessionSummary, string) (sessionPickerResult, error) {
 			t.Fatal("did not expect picker for explicit session id")
 			return sessionPickerResult{}, nil
 		},

--- a/cli/app/onboarding_flow.go
+++ b/cli/app/onboarding_flow.go
@@ -73,7 +73,6 @@ type onboardingFlowState struct {
 	settings                    config.Settings
 	baselineSettings            config.Settings
 	theme                       string
-	alternateScreen             config.TUIAlternateScreenPolicy
 	authState                   auth.State
 	providerCapabilities        llm.ProviderCapabilities
 	pendingAction               onboardingPendingAction

--- a/cli/app/onboarding_run.go
+++ b/cli/app/onboarding_run.go
@@ -41,18 +41,13 @@ func runOnboardingFlow(cfg config.App, authState auth.State) (onboardingResult, 
 		settings:             cfg.Settings,
 		baselineSettings:     cfg.Settings,
 		theme:                cfg.Settings.Theme,
-		alternateScreen:      cfg.Settings.TUIAlternateScreen,
 		authState:            authState,
 		providerCapabilities: providerCaps,
 		skillImport:          onboardingImportSelection{Mode: onboardingImportModeNone},
 		commandImport:        onboardingImportSelection{Mode: onboardingImportModeNone},
 	}
 	model := newOnboardingModel(cfg.PersistenceRoot, state)
-	options := []tea.ProgramOption{}
-	if shouldUseStartupPickerAltScreen(cfg.Settings.TUIAlternateScreen) {
-		options = append(options, tea.WithAltScreen())
-	}
-	program := tea.NewProgram(model, options...)
+	program := tea.NewProgram(model, tea.WithAltScreen())
 	finalModel, err := program.Run()
 	if err != nil {
 		return onboardingResult{}, err

--- a/cli/app/project_binding_flow.go
+++ b/cli/app/project_binding_flow.go
@@ -11,7 +11,6 @@ import (
 
 	"builder/cli/tui"
 	"builder/shared/clientui"
-	"builder/shared/config"
 	"builder/shared/serverapi"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
@@ -390,8 +389,8 @@ func projectBindingPreviewPath(rootPath string) string {
 	return trimmedRoot
 }
 
-func runProjectBindingPicker(projects []clientui.ProjectSummary, theme string, alternateScreen config.TUIAlternateScreenPolicy) (projectBindingPickerResult, error) {
-	return runConfiguredProjectPicker(projects, theme, alternateScreen, projectPickerOptions{
+func runProjectBindingPicker(projects []clientui.ProjectSummary, theme string) (projectBindingPickerResult, error) {
+	return runConfiguredProjectPicker(projects, theme, projectPickerOptions{
 		AllowCreate:    true,
 		HeaderMarkdown: projectBindingPickerHeaderMarkdown,
 		HeaderFallback: projectBindingPickerHeaderFallback,
@@ -400,8 +399,8 @@ func runProjectBindingPicker(projects []clientui.ProjectSummary, theme string, a
 	})
 }
 
-func runServerProjectPicker(projects []clientui.ProjectSummary, theme string, alternateScreen config.TUIAlternateScreenPolicy) (projectBindingPickerResult, error) {
-	return runConfiguredProjectPicker(projects, theme, alternateScreen, projectPickerOptions{
+func runServerProjectPicker(projects []clientui.ProjectSummary, theme string) (projectBindingPickerResult, error) {
+	return runConfiguredProjectPicker(projects, theme, projectPickerOptions{
 		AllowCreate:    false,
 		HeaderMarkdown: serverProjectPickerHeaderMarkdown,
 		HeaderFallback: serverProjectPickerHeaderFallback,
@@ -410,13 +409,9 @@ func runServerProjectPicker(projects []clientui.ProjectSummary, theme string, al
 	})
 }
 
-func runConfiguredProjectPicker(projects []clientui.ProjectSummary, theme string, alternateScreen config.TUIAlternateScreenPolicy, options projectPickerOptions) (projectBindingPickerResult, error) {
+func runConfiguredProjectPicker(projects []clientui.ProjectSummary, theme string, options projectPickerOptions) (projectBindingPickerResult, error) {
 	model := newProjectBindingPickerModel(projects, theme, options)
-	programOptions := []tea.ProgramOption{}
-	if shouldUseStartupPickerAltScreen(alternateScreen) {
-		programOptions = append(programOptions, tea.WithAltScreen())
-	}
-	program := tea.NewProgram(model, programOptions...)
+	program := tea.NewProgram(model, tea.WithAltScreen())
 	finalModel, err := program.Run()
 	if err != nil {
 		return projectBindingPickerResult{}, err
@@ -669,13 +664,9 @@ func (m *projectWorkspacePickerModel) hasPreview(index int) bool {
 	return strings.TrimSpace(m.workspaces[index].RootPath) != ""
 }
 
-func runProjectWorkspacePicker(workspaces []clientui.ProjectWorkspaceSummary, theme string, alternateScreen config.TUIAlternateScreenPolicy) (projectWorkspacePickerResult, error) {
+func runProjectWorkspacePicker(workspaces []clientui.ProjectWorkspaceSummary, theme string) (projectWorkspacePickerResult, error) {
 	model := newProjectWorkspacePickerModel(workspaces, theme)
-	programOptions := []tea.ProgramOption{}
-	if shouldUseStartupPickerAltScreen(alternateScreen) {
-		programOptions = append(programOptions, tea.WithAltScreen())
-	}
-	program := tea.NewProgram(model, programOptions...)
+	program := tea.NewProgram(model, tea.WithAltScreen())
 	finalModel, err := program.Run()
 	if err != nil {
 		return projectWorkspacePickerResult{}, err
@@ -764,13 +755,9 @@ func (m *projectNamePromptModel) renderHeader() string {
 	return lipgloss.NewStyle().Foreground(uiPalette(m.theme).primary).Bold(true).Render(projectNamePromptHeaderFallback)
 }
 
-func runProjectNamePrompt(defaultName string, theme string, alternateScreen config.TUIAlternateScreenPolicy) (string, error) {
+func runProjectNamePrompt(defaultName string, theme string) (string, error) {
 	model := newProjectNamePromptModel(defaultName, theme)
-	options := []tea.ProgramOption{}
-	if shouldUseStartupPickerAltScreen(alternateScreen) {
-		options = append(options, tea.WithAltScreen())
-	}
-	program := tea.NewProgram(model, options...)
+	program := tea.NewProgram(model, tea.WithAltScreen())
 	finalModel, err := program.Run()
 	if err != nil {
 		return "", err
@@ -820,7 +807,7 @@ func ensureInteractiveLocalPathBinding(ctx context.Context, server embeddedServe
 		return nil, err
 	}
 	cfg := server.Config()
-	picked, err := runProjectBindingPickerFlow(projects.Projects, cfg.Settings.Theme, cfg.Settings.TUIAlternateScreen)
+	picked, err := runProjectBindingPickerFlow(projects.Projects, cfg.Settings.Theme)
 	if err != nil {
 		return nil, err
 	}
@@ -828,7 +815,7 @@ func ensureInteractiveLocalPathBinding(ctx context.Context, server embeddedServe
 		return nil, errors.New("startup canceled by user")
 	}
 	if picked.CreateNew {
-		projectName, err := runProjectNamePromptFlow(filepath.Base(filepath.Clean(workspaceRoot)), cfg.Settings.Theme, cfg.Settings.TUIAlternateScreen)
+		projectName, err := runProjectNamePromptFlow(filepath.Base(filepath.Clean(workspaceRoot)), cfg.Settings.Theme)
 		if err != nil {
 			return nil, err
 		}
@@ -865,7 +852,7 @@ func ensureInteractiveServerBrowsingBinding(ctx context.Context, server embedded
 		return nil, errors.New("server has no registered projects. Create one with `builder project create --path <server-path> --name <project-name>` or attach an existing workspace with `builder attach --project <project-id> <server-path>`")
 	}
 	cfg := server.Config()
-	picked, err := runServerProjectPickerFlow(projects.Projects, cfg.Settings.Theme, cfg.Settings.TUIAlternateScreen)
+	picked, err := runServerProjectPickerFlow(projects.Projects, cfg.Settings.Theme)
 	if err != nil {
 		return nil, err
 	}
@@ -897,7 +884,7 @@ func selectProjectWorkspaceForStartup(ctx context.Context, server embeddedServer
 	if len(overview.Overview.Workspaces) == 1 {
 		return overview.Overview.Workspaces[0], nil
 	}
-	picked, err := runProjectWorkspacePickerFlow(overview.Overview.Workspaces, server.Config().Settings.Theme, server.Config().Settings.TUIAlternateScreen)
+	picked, err := runProjectWorkspacePickerFlow(overview.Overview.Workspaces, server.Config().Settings.Theme)
 	if err != nil {
 		return clientui.ProjectWorkspaceSummary{}, err
 	}

--- a/cli/app/project_binding_flow_test.go
+++ b/cli/app/project_binding_flow_test.go
@@ -47,11 +47,11 @@ func TestEnsureInteractiveProjectBindingBindsRegisteredWorkspaceWithoutPrompt(t 
 		runProjectBindingPickerFlow = originalPicker
 		runProjectNamePromptFlow = originalPrompt
 	})
-	runProjectBindingPickerFlow = func([]clientui.ProjectSummary, string, config.TUIAlternateScreenPolicy) (projectBindingPickerResult, error) {
+	runProjectBindingPickerFlow = func([]clientui.ProjectSummary, string) (projectBindingPickerResult, error) {
 		t.Fatal("did not expect binding picker for registered workspace")
 		return projectBindingPickerResult{}, nil
 	}
-	runProjectNamePromptFlow = func(string, string, config.TUIAlternateScreenPolicy) (string, error) {
+	runProjectNamePromptFlow = func(string, string) (string, error) {
 		t.Fatal("did not expect project name prompt for registered workspace")
 		return "", nil
 	}
@@ -108,13 +108,13 @@ func TestEnsureInteractiveProjectBindingTreatsNestedDirectoryAsUnknownWorkspace(
 		runProjectBindingPickerFlow = originalPicker
 		runProjectNamePromptFlow = originalPrompt
 	})
-	runProjectBindingPickerFlow = func(projects []clientui.ProjectSummary, theme string, policy config.TUIAlternateScreenPolicy) (projectBindingPickerResult, error) {
+	runProjectBindingPickerFlow = func(projects []clientui.ProjectSummary, theme string) (projectBindingPickerResult, error) {
 		if len(projects) != 1 {
 			t.Fatalf("expected parent project to appear in picker, got %+v", projects)
 		}
 		return projectBindingPickerResult{CreateNew: true}, nil
 	}
-	runProjectNamePromptFlow = func(defaultName string, theme string, policy config.TUIAlternateScreenPolicy) (string, error) {
+	runProjectNamePromptFlow = func(defaultName string, theme string) (string, error) {
 		if want := filepath.Base(nested); defaultName != want {
 			t.Fatalf("default project name = %q, want %q", defaultName, want)
 		}
@@ -172,13 +172,13 @@ func TestEnsureInteractiveProjectBindingCreatesProjectForUnknownWorkspace(t *tes
 		runProjectBindingPickerFlow = originalPicker
 		runProjectNamePromptFlow = originalPrompt
 	})
-	runProjectBindingPickerFlow = func(projects []clientui.ProjectSummary, theme string, policy config.TUIAlternateScreenPolicy) (projectBindingPickerResult, error) {
+	runProjectBindingPickerFlow = func(projects []clientui.ProjectSummary, theme string) (projectBindingPickerResult, error) {
 		if len(projects) != 0 {
 			t.Fatalf("expected no projects, got %+v", projects)
 		}
 		return projectBindingPickerResult{CreateNew: true}, nil
 	}
-	runProjectNamePromptFlow = func(defaultName string, theme string, policy config.TUIAlternateScreenPolicy) (string, error) {
+	runProjectNamePromptFlow = func(defaultName string, theme string) (string, error) {
 		if want := filepath.Base(workspace); defaultName != want {
 			t.Fatalf("default project name = %q, want %q", defaultName, want)
 		}
@@ -247,18 +247,18 @@ func TestEnsureInteractiveProjectBindingUsesServerBrowsingForMissingServerPath(t
 		runServerProjectPickerFlow = originalRemotePicker
 		runProjectWorkspacePickerFlow = originalWorkspacePicker
 	})
-	runProjectBindingPickerFlow = func([]clientui.ProjectSummary, string, config.TUIAlternateScreenPolicy) (projectBindingPickerResult, error) {
+	runProjectBindingPickerFlow = func([]clientui.ProjectSummary, string) (projectBindingPickerResult, error) {
 		t.Fatal("did not expect local binding picker in server-browsing mode")
 		return projectBindingPickerResult{}, nil
 	}
-	runServerProjectPickerFlow = func(projects []clientui.ProjectSummary, theme string, policy config.TUIAlternateScreenPolicy) (projectBindingPickerResult, error) {
+	runServerProjectPickerFlow = func(projects []clientui.ProjectSummary, theme string) (projectBindingPickerResult, error) {
 		if len(projects) != 1 || projects[0].ProjectID != "project-1" {
 			t.Fatalf("unexpected server projects: %+v", projects)
 		}
 		picked := projects[0]
 		return projectBindingPickerResult{Project: &picked}, nil
 	}
-	runProjectWorkspacePickerFlow = func([]clientui.ProjectWorkspaceSummary, string, config.TUIAlternateScreenPolicy) (projectWorkspacePickerResult, error) {
+	runProjectWorkspacePickerFlow = func([]clientui.ProjectWorkspaceSummary, string) (projectWorkspacePickerResult, error) {
 		t.Fatal("did not expect workspace picker for single workspace project")
 		return projectWorkspacePickerResult{}, nil
 	}
@@ -364,14 +364,14 @@ func TestEnsureInteractiveProjectBindingAttachesUnknownWorkspaceToExistingProjec
 		runProjectBindingPickerFlow = originalPicker
 		runProjectNamePromptFlow = originalPrompt
 	})
-	runProjectBindingPickerFlow = func(projects []clientui.ProjectSummary, theme string, policy config.TUIAlternateScreenPolicy) (projectBindingPickerResult, error) {
+	runProjectBindingPickerFlow = func(projects []clientui.ProjectSummary, theme string) (projectBindingPickerResult, error) {
 		if len(projects) != 1 || projects[0].ProjectID != bindingA.ProjectID {
 			t.Fatalf("unexpected projects: %+v", projects)
 		}
 		picked := projects[0]
 		return projectBindingPickerResult{Project: &picked}, nil
 	}
-	runProjectNamePromptFlow = func(string, string, config.TUIAlternateScreenPolicy) (string, error) {
+	runProjectNamePromptFlow = func(string, string) (string, error) {
 		t.Fatal("did not expect project name prompt when attaching to existing project")
 		return "", nil
 	}
@@ -423,11 +423,11 @@ func TestEnsureInteractiveProjectBindingFormatsMissingSelectedProjectError(t *te
 		runProjectBindingPickerFlow = originalPicker
 		runProjectNamePromptFlow = originalPrompt
 	})
-	runProjectBindingPickerFlow = func([]clientui.ProjectSummary, string, config.TUIAlternateScreenPolicy) (projectBindingPickerResult, error) {
+	runProjectBindingPickerFlow = func([]clientui.ProjectSummary, string) (projectBindingPickerResult, error) {
 		picked := clientui.ProjectSummary{ProjectID: "project-missing", DisplayName: "Missing Project"}
 		return projectBindingPickerResult{Project: &picked}, nil
 	}
-	runProjectNamePromptFlow = func(string, string, config.TUIAlternateScreenPolicy) (string, error) {
+	runProjectNamePromptFlow = func(string, string) (string, error) {
 		t.Fatal("did not expect project name prompt when attaching to existing project")
 		return "", nil
 	}
@@ -472,10 +472,10 @@ func TestEnsureInteractiveProjectBindingReturnsCancelWhenPickerAborts(t *testing
 		runProjectBindingPickerFlow = originalPicker
 		runProjectNamePromptFlow = originalPrompt
 	})
-	runProjectBindingPickerFlow = func([]clientui.ProjectSummary, string, config.TUIAlternateScreenPolicy) (projectBindingPickerResult, error) {
+	runProjectBindingPickerFlow = func([]clientui.ProjectSummary, string) (projectBindingPickerResult, error) {
 		return projectBindingPickerResult{Canceled: true}, nil
 	}
-	runProjectNamePromptFlow = func(string, string, config.TUIAlternateScreenPolicy) (string, error) {
+	runProjectNamePromptFlow = func(string, string) (string, error) {
 		t.Fatal("did not expect project name prompt after picker cancel")
 		return "", nil
 	}
@@ -519,10 +519,10 @@ func TestEnsureInteractiveProjectBindingReturnsCancelWhenProjectNamingAborts(t *
 		runProjectBindingPickerFlow = originalPicker
 		runProjectNamePromptFlow = originalPrompt
 	})
-	runProjectBindingPickerFlow = func([]clientui.ProjectSummary, string, config.TUIAlternateScreenPolicy) (projectBindingPickerResult, error) {
+	runProjectBindingPickerFlow = func([]clientui.ProjectSummary, string) (projectBindingPickerResult, error) {
 		return projectBindingPickerResult{CreateNew: true}, nil
 	}
-	runProjectNamePromptFlow = func(string, string, config.TUIAlternateScreenPolicy) (string, error) {
+	runProjectNamePromptFlow = func(string, string) (string, error) {
 		return "", context.Canceled
 	}
 
@@ -571,7 +571,7 @@ func TestEnsureInteractiveServerBrowsingBindingUsesConfiguredServerPickerNotice(
 		runServerProjectPickerFlow = originalRemotePicker
 		runProjectWorkspacePickerFlow = originalWorkspacePicker
 	})
-	runServerProjectPickerFlow = func(projects []clientui.ProjectSummary, theme string, policy config.TUIAlternateScreenPolicy) (projectBindingPickerResult, error) {
+	runServerProjectPickerFlow = func(projects []clientui.ProjectSummary, theme string) (projectBindingPickerResult, error) {
 		model := newProjectBindingPickerModel(projects, theme, projectPickerOptions{
 			AllowCreate:    false,
 			HeaderMarkdown: serverProjectPickerHeaderMarkdown,
@@ -587,7 +587,7 @@ func TestEnsureInteractiveServerBrowsingBindingUsesConfiguredServerPickerNotice(
 		picked := projects[0]
 		return projectBindingPickerResult{Project: &picked}, nil
 	}
-	runProjectWorkspacePickerFlow = func([]clientui.ProjectWorkspaceSummary, string, config.TUIAlternateScreenPolicy) (projectWorkspacePickerResult, error) {
+	runProjectWorkspacePickerFlow = func([]clientui.ProjectWorkspaceSummary, string) (projectWorkspacePickerResult, error) {
 		t.Fatal("did not expect workspace picker for single workspace project")
 		return projectWorkspacePickerResult{}, nil
 	}

--- a/cli/app/session_lifecycle_test.go
+++ b/cli/app/session_lifecycle_test.go
@@ -30,7 +30,7 @@ func TestRunSessionLifecycleMissingWorkspacePrepareRuntimeSuggestsRebind(t *test
 		cfg: config.App{
 			WorkspaceRoot:   missingWorkspace,
 			PersistenceRoot: t.TempDir(),
-			Settings:        config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenAuto},
+			Settings:        config.Settings{Theme: "dark"},
 		},
 		containerDir: containerDir,
 		projectID:    "project-1",
@@ -82,12 +82,12 @@ func TestMaybeHandlePickedSessionWorkspaceChangeSkipsPromptWhenWorkspaceUnchange
 	originalPrompt := runWorkspaceChangePromptFlow
 	defer func() { runWorkspaceChangePromptFlow = originalPrompt }()
 	promptCalls := 0
-	runWorkspaceChangePromptFlow = func(string, string, string, config.TUIAlternateScreenPolicy) (workspaceChangePromptResult, error) {
+	runWorkspaceChangePromptFlow = func(string, string, string) (workspaceChangePromptResult, error) {
 		promptCalls++
 		return workspaceChangePromptResult{Rebind: true}, nil
 	}
 
-	action, err := maybeHandlePickedSessionWorkspaceChange(context.Background(), &testEmbeddedServer{cfg: config.App{WorkspaceRoot: "/tmp/workspace", Settings: config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenNever}}}, sessionLaunchPlan{
+	action, err := maybeHandlePickedSessionWorkspaceChange(context.Background(), &testEmbeddedServer{cfg: config.App{WorkspaceRoot: "/tmp/workspace", Settings: config.Settings{Theme: "dark"}}}, sessionLaunchPlan{
 		SessionID:                    "session-1",
 		SelectedViaPicker:            true,
 		SelectedSessionWorkspaceRoot: "/tmp/workspace",
@@ -112,12 +112,12 @@ func TestMaybeHandlePickedSessionWorkspaceChangeCanonicalizesAliases(t *testing.
 	originalPrompt := runWorkspaceChangePromptFlow
 	defer func() { runWorkspaceChangePromptFlow = originalPrompt }()
 	promptCalls := 0
-	runWorkspaceChangePromptFlow = func(string, string, string, config.TUIAlternateScreenPolicy) (workspaceChangePromptResult, error) {
+	runWorkspaceChangePromptFlow = func(string, string, string) (workspaceChangePromptResult, error) {
 		promptCalls++
 		return workspaceChangePromptResult{Rebind: true}, nil
 	}
 
-	action, err := maybeHandlePickedSessionWorkspaceChange(context.Background(), &testEmbeddedServer{cfg: config.App{WorkspaceRoot: aliasRoot, Settings: config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenNever}}}, sessionLaunchPlan{
+	action, err := maybeHandlePickedSessionWorkspaceChange(context.Background(), &testEmbeddedServer{cfg: config.App{WorkspaceRoot: aliasRoot, Settings: config.Settings{Theme: "dark"}}}, sessionLaunchPlan{
 		SessionID:                    "session-1",
 		SelectedViaPicker:            true,
 		SelectedSessionWorkspaceRoot: realRoot,
@@ -137,12 +137,12 @@ func TestMaybeHandlePickedSessionWorkspaceChangeLookupFailureReturnsPicker(t *te
 	originalPrompt := runWorkspaceChangePromptFlow
 	defer func() { runWorkspaceChangePromptFlow = originalPrompt }()
 	promptCalls := 0
-	runWorkspaceChangePromptFlow = func(string, string, string, config.TUIAlternateScreenPolicy) (workspaceChangePromptResult, error) {
+	runWorkspaceChangePromptFlow = func(string, string, string) (workspaceChangePromptResult, error) {
 		promptCalls++
 		return workspaceChangePromptResult{Rebind: true}, nil
 	}
 
-	action, err := maybeHandlePickedSessionWorkspaceChange(context.Background(), &testEmbeddedServer{cfg: config.App{WorkspaceRoot: "/tmp/workspace", Settings: config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenNever}}}, sessionLaunchPlan{
+	action, err := maybeHandlePickedSessionWorkspaceChange(context.Background(), &testEmbeddedServer{cfg: config.App{WorkspaceRoot: "/tmp/workspace", Settings: config.Settings{Theme: "dark"}}}, sessionLaunchPlan{
 		SessionID:                            "session-1",
 		SelectedViaPicker:                    true,
 		SelectedSessionWorkspaceLookupFailed: true,
@@ -180,7 +180,7 @@ func TestRunSessionLifecyclePickerWorkspaceChangeYesRetargetsSessionAndReplans(t
 	}()
 
 	pickerCalls := 0
-	runSessionPickerFlow = func(summaries []clientui.SessionSummary, theme string, policy config.TUIAlternateScreenPolicy) (sessionPickerResult, error) {
+	runSessionPickerFlow = func(summaries []clientui.SessionSummary, theme string) (sessionPickerResult, error) {
 		pickerCalls++
 		for _, summary := range summaries {
 			if summary.SessionID == store.Meta().SessionID {
@@ -192,7 +192,7 @@ func TestRunSessionLifecyclePickerWorkspaceChangeYesRetargetsSessionAndReplans(t
 		return sessionPickerResult{}, nil
 	}
 	promptCalls := 0
-	runWorkspaceChangePromptFlow = func(selectedRoot string, currentRoot string, theme string, policy config.TUIAlternateScreenPolicy) (workspaceChangePromptResult, error) {
+	runWorkspaceChangePromptFlow = func(selectedRoot string, currentRoot string, theme string) (workspaceChangePromptResult, error) {
 		promptCalls++
 		if comparableWorkspaceChangeRoot(selectedRoot) != mustCanonicalPath(t, previousWorkspace) {
 			t.Fatalf("selected root = %q, want %q", selectedRoot, mustCanonicalPath(t, previousWorkspace))
@@ -210,7 +210,7 @@ func TestRunSessionLifecyclePickerWorkspaceChangeYesRetargetsSessionAndReplans(t
 		cfg: config.App{
 			WorkspaceRoot:   cfg.WorkspaceRoot,
 			PersistenceRoot: cfg.PersistenceRoot,
-			Settings:        config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenNever},
+			Settings:        config.Settings{Theme: "dark"},
 		},
 		projectID:         binding.ProjectID,
 		projectViewClient: projectViews,
@@ -228,7 +228,7 @@ func TestRunSessionLifecyclePickerWorkspaceChangeYesRetargetsSessionAndReplans(t
 			return serverapi.SessionPlanResponse{Plan: serverapi.SessionPlan{
 				SessionID:      store.Meta().SessionID,
 				WorkspaceRoot:  cfg.WorkspaceRoot,
-				ActiveSettings: config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenNever},
+				ActiveSettings: config.Settings{Theme: "dark"},
 			}}, nil
 		}},
 		prepareRuntime: func(_ context.Context, plan sessionLaunchPlan, _ io.Writer, _ string) (*runtimeLaunchPlan, error) {
@@ -290,7 +290,7 @@ func TestRunSessionLifecyclePickerWorkspaceChangeNoReturnsToPicker(t *testing.T)
 	}()
 
 	pickerCalls := 0
-	runSessionPickerFlow = func(summaries []clientui.SessionSummary, theme string, policy config.TUIAlternateScreenPolicy) (sessionPickerResult, error) {
+	runSessionPickerFlow = func(summaries []clientui.SessionSummary, theme string) (sessionPickerResult, error) {
 		pickerCalls++
 		if pickerCalls == 1 {
 			for _, summary := range summaries {
@@ -304,7 +304,7 @@ func TestRunSessionLifecyclePickerWorkspaceChangeNoReturnsToPicker(t *testing.T)
 		return sessionPickerResult{Canceled: true}, nil
 	}
 	promptCalls := 0
-	runWorkspaceChangePromptFlow = func(string, string, string, config.TUIAlternateScreenPolicy) (workspaceChangePromptResult, error) {
+	runWorkspaceChangePromptFlow = func(string, string, string) (workspaceChangePromptResult, error) {
 		promptCalls++
 		return workspaceChangePromptResult{}, nil
 	}
@@ -314,7 +314,7 @@ func TestRunSessionLifecyclePickerWorkspaceChangeNoReturnsToPicker(t *testing.T)
 		cfg: config.App{
 			WorkspaceRoot:   cfg.WorkspaceRoot,
 			PersistenceRoot: cfg.PersistenceRoot,
-			Settings:        config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenNever},
+			Settings:        config.Settings{Theme: "dark"},
 		},
 		projectID:         binding.ProjectID,
 		projectViewClient: projectViews,
@@ -332,7 +332,7 @@ func TestRunSessionLifecyclePickerWorkspaceChangeNoReturnsToPicker(t *testing.T)
 			return serverapi.SessionPlanResponse{Plan: serverapi.SessionPlan{
 				SessionID:      store.Meta().SessionID,
 				WorkspaceRoot:  cfg.WorkspaceRoot,
-				ActiveSettings: config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenNever},
+				ActiveSettings: config.Settings{Theme: "dark"},
 			}}, nil
 		}},
 	}
@@ -374,7 +374,7 @@ func TestRunSessionLifecycleStalePickedSessionReturnsToPickerAndOpensAnother(t *
 	}()
 
 	pickerCalls := 0
-	runSessionPickerFlow = func(summaries []clientui.SessionSummary, theme string, policy config.TUIAlternateScreenPolicy) (sessionPickerResult, error) {
+	runSessionPickerFlow = func(summaries []clientui.SessionSummary, theme string) (sessionPickerResult, error) {
 		pickerCalls++
 		for _, summary := range summaries {
 			if pickerCalls == 1 && summary.SessionID == staleSessionID {
@@ -390,7 +390,7 @@ func TestRunSessionLifecycleStalePickedSessionReturnsToPickerAndOpensAnother(t *
 		return sessionPickerResult{}, nil
 	}
 	promptCalls := 0
-	runWorkspaceChangePromptFlow = func(string, string, string, config.TUIAlternateScreenPolicy) (workspaceChangePromptResult, error) {
+	runWorkspaceChangePromptFlow = func(string, string, string) (workspaceChangePromptResult, error) {
 		promptCalls++
 		return workspaceChangePromptResult{Rebind: true}, nil
 	}
@@ -402,7 +402,7 @@ func TestRunSessionLifecycleStalePickedSessionReturnsToPickerAndOpensAnother(t *
 		cfg: config.App{
 			WorkspaceRoot:   cfg.WorkspaceRoot,
 			PersistenceRoot: cfg.PersistenceRoot,
-			Settings:        config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenNever},
+			Settings:        config.Settings{Theme: "dark"},
 		},
 		projectID:         binding.ProjectID,
 		projectViewClient: projectViews,
@@ -421,7 +421,7 @@ func TestRunSessionLifecycleStalePickedSessionReturnsToPickerAndOpensAnother(t *
 			return serverapi.SessionPlanResponse{Plan: serverapi.SessionPlan{
 				SessionID:      req.SelectedSessionID,
 				WorkspaceRoot:  cfg.WorkspaceRoot,
-				ActiveSettings: config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenNever},
+				ActiveSettings: config.Settings{Theme: "dark"},
 			}}, nil
 		}},
 		prepareRuntime: func(_ context.Context, plan sessionLaunchPlan, _ io.Writer, _ string) (*runtimeLaunchPlan, error) {
@@ -468,7 +468,7 @@ func TestRunSessionLifecycleExplicitSessionIDBypassesWorkspaceChangePrompt(t *te
 	originalPrompt := runWorkspaceChangePromptFlow
 	defer func() { runWorkspaceChangePromptFlow = originalPrompt }()
 	promptCalls := 0
-	runWorkspaceChangePromptFlow = func(string, string, string, config.TUIAlternateScreenPolicy) (workspaceChangePromptResult, error) {
+	runWorkspaceChangePromptFlow = func(string, string, string) (workspaceChangePromptResult, error) {
 		promptCalls++
 		return workspaceChangePromptResult{Rebind: true}, nil
 	}
@@ -479,7 +479,7 @@ func TestRunSessionLifecycleExplicitSessionIDBypassesWorkspaceChangePrompt(t *te
 		cfg: config.App{
 			WorkspaceRoot:   cfg.WorkspaceRoot,
 			PersistenceRoot: cfg.PersistenceRoot,
-			Settings:        config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenNever},
+			Settings:        config.Settings{Theme: "dark"},
 		},
 		projectID:         binding.ProjectID,
 		projectViewClient: projectViews,
@@ -491,7 +491,7 @@ func TestRunSessionLifecycleExplicitSessionIDBypassesWorkspaceChangePrompt(t *te
 			return serverapi.SessionPlanResponse{Plan: serverapi.SessionPlan{
 				SessionID:      store.Meta().SessionID,
 				WorkspaceRoot:  cfg.WorkspaceRoot,
-				ActiveSettings: config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenNever},
+				ActiveSettings: config.Settings{Theme: "dark"},
 			}}, nil
 		}},
 		prepareRuntime: func(_ context.Context, plan sessionLaunchPlan, _ io.Writer, _ string) (*runtimeLaunchPlan, error) {
@@ -683,7 +683,7 @@ func TestNewSessionTransitionKeepsBackgroundProcessesAlive(t *testing.T) {
 		cfg: config.App{
 			WorkspaceRoot:   workdir,
 			PersistenceRoot: root,
-			Settings:        config.Settings{Theme: "dark", TUIAlternateScreen: config.TUIAlternateScreenAuto},
+			Settings:        config.Settings{Theme: "dark"},
 		},
 		containerDir: root,
 	}

--- a/cli/app/session_picker.go
+++ b/cli/app/session_picker.go
@@ -8,7 +8,6 @@ import (
 
 	"builder/cli/tui"
 	"builder/shared/clientui"
-	"builder/shared/config"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	glamouransi "github.com/charmbracelet/glamour/ansi"
@@ -347,13 +346,9 @@ func humanTime(ts time.Time) string {
 	return ts.Local().Format("2006-01-02 15:04")
 }
 
-func runSessionPicker(summaries []clientui.SessionSummary, theme string, alternateScreen config.TUIAlternateScreenPolicy) (sessionPickerResult, error) {
+func runSessionPicker(summaries []clientui.SessionSummary, theme string) (sessionPickerResult, error) {
 	model := newSessionPickerModel(summaries, theme)
-	options := []tea.ProgramOption{}
-	if shouldUseStartupPickerAltScreen(alternateScreen) {
-		options = append(options, tea.WithAltScreen())
-	}
-	program := tea.NewProgram(model, options...)
+	program := tea.NewProgram(model, tea.WithAltScreen())
 	finalModel, err := program.Run()
 	if err != nil {
 		return sessionPickerResult{}, err

--- a/cli/app/session_server_target_part2_test.go
+++ b/cli/app/session_server_target_part2_test.go
@@ -48,13 +48,13 @@ func TestStartEmbeddedServerUnknownWorkspaceCreateProjectFlowCanPlanSession(t *t
 		runProjectBindingPickerFlow = originalPicker
 		runProjectNamePromptFlow = originalPrompt
 	})
-	runProjectBindingPickerFlow = func(projects []clientui.ProjectSummary, theme string, policy config.TUIAlternateScreenPolicy) (projectBindingPickerResult, error) {
+	runProjectBindingPickerFlow = func(projects []clientui.ProjectSummary, theme string) (projectBindingPickerResult, error) {
 		if len(projects) != 0 {
 			t.Fatalf("expected no existing projects, got %+v", projects)
 		}
 		return projectBindingPickerResult{CreateNew: true}, nil
 	}
-	runProjectNamePromptFlow = func(defaultName string, theme string, policy config.TUIAlternateScreenPolicy) (string, error) {
+	runProjectNamePromptFlow = func(defaultName string, theme string) (string, error) {
 		if want := filepath.Base(workspace); defaultName != want {
 			t.Fatalf("default project name = %q, want %q", defaultName, want)
 		}

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -14,7 +14,6 @@ import (
 	shelltool "builder/server/tools/shell"
 	"builder/shared/client"
 	"builder/shared/clientui"
-	"builder/shared/config"
 	"builder/shared/serverapi"
 	"builder/shared/theme"
 	"builder/shared/transcriptdiag"
@@ -122,6 +121,19 @@ type runtimeTranscriptRefreshedMsg struct {
 	transcript    clientui.TranscriptPage
 	recoveryCause clientui.TranscriptRecoveryCause
 	err           error
+}
+
+type runtimeCommittedTranscriptSuffixRefreshedMsg struct {
+	token  uint64
+	req    clientui.CommittedTranscriptSuffixRequest
+	suffix clientui.CommittedTranscriptSuffix
+	err    error
+}
+
+type nativeResizeTranscriptSuffixRefreshedMsg struct {
+	token  uint64
+	suffix clientui.CommittedTranscriptSuffix
+	err    error
 }
 
 type runtimeTranscriptRetryMsg struct {
@@ -362,13 +374,6 @@ func WithUITheme(theme string) UIOption {
 	}
 }
 
-func WithUIAlternateScreenPolicy(policy config.TUIAlternateScreenPolicy) UIOption {
-	return func(m *uiModel) {
-		m.tuiAlternateScreen = policy
-		m.altScreenActive = policy == config.TUIAlternateScreenAlways
-	}
-}
-
 func WithUIInitialTranscript(entries []UITranscriptEntry) UIOption {
 	return func(m *uiModel) {
 		m.initialTranscript = append([]UITranscriptEntry(nil), entries...)
@@ -539,8 +544,7 @@ func newUIInputFeatureState() uiInputFeatureState {
 
 func newUIPresentationFeatureState() uiPresentationFeatureState {
 	return uiPresentationFeatureState{
-		theme:              theme.Auto,
-		tuiAlternateScreen: config.TUIAlternateScreenAuto,
+		theme: theme.Auto,
 	}
 }
 
@@ -733,13 +737,16 @@ func (m *uiModel) handleRuntimeEventBatch(events []clientui.Event) (*uiModel, te
 		m.waitRuntimeEventAfterHydration = true
 	}
 	if m.nativeFlushSequence != flushSequenceBefore {
-		m.waitRuntimeEventAfterFlushSequence = m.nativeFlushSequence
 		m.logTranscriptDiag(transcriptdiag.FormatLine("transcript.diag.client.runtime_batch_wait_flush", map[string]string{
 			"session_id":             strings.TrimSpace(m.sessionID),
 			"mode":                   string(m.view.Mode()),
 			"pending_runtime_events": strconv.Itoa(len(m.pendingRuntimeEvents)),
 			"native_flush_sequence":  strconv.FormatUint(m.nativeFlushSequence, 10),
 		}))
+		m.waitRuntimeEventAfterFlushSequence = m.nativeFlushSequence
+		if result.awaitsHydration {
+			return m, cmd
+		}
 		return m, cmd
 	}
 	if result.awaitsHydration {

--- a/cli/app/ui_alt_screen.go
+++ b/cli/app/ui_alt_screen.go
@@ -2,24 +2,11 @@ package app
 
 import (
 	"builder/cli/tui"
-	"builder/shared/config"
 	"os"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
-
-func shouldStartMainUIInAltScreen(policy config.TUIAlternateScreenPolicy) bool {
-	return policy == config.TUIAlternateScreenAlways
-}
-
-func shouldUseDetailAltScreen(policy config.TUIAlternateScreenPolicy) bool {
-	return policy != config.TUIAlternateScreenNever
-}
-
-func shouldUseStartupPickerAltScreen(policy config.TUIAlternateScreenPolicy) bool {
-	return policy != config.TUIAlternateScreenNever
-}
 
 var writeTerminalSequence = func(sequence string) {
 	_, _ = os.Stdout.WriteString(sequence)
@@ -97,10 +84,7 @@ func (m *uiModel) clearCmdForModeTransition(prev, next tui.Mode) tea.Cmd {
 	if next != tui.ModeDetail {
 		return nil
 	}
-	if shouldUseDetailAltScreen(m.tuiAlternateScreen) {
-		return nil
-	}
-	return tea.ClearScreen
+	return nil
 }
 
 func (m *uiModel) detailLoadCmdForModeTransition(prev, next tui.Mode) tea.Cmd {
@@ -166,9 +150,6 @@ func (m *uiModel) altScreenCmdForModeTransition(prev, next tui.Mode, enableAlter
 	if prev == next {
 		return nil
 	}
-	if !shouldUseDetailAltScreen(m.tuiAlternateScreen) {
-		return nil
-	}
 	if next == tui.ModeDetail && !m.altScreenActive {
 		m.altScreenActive = true
 		if !enableAlternateScroll {
@@ -182,12 +163,9 @@ func (m *uiModel) altScreenCmdForModeTransition(prev, next tui.Mode, enableAlter
 		}
 		return enableAlternateScrollCmd()
 	}
-	if prev == tui.ModeDetail && m.altScreenActive && m.tuiAlternateScreen != config.TUIAlternateScreenAlways {
+	if prev == tui.ModeDetail && m.altScreenActive {
 		m.altScreenActive = false
 		return tea.Sequence(disableAlternateScrollCmd(), tea.ExitAltScreen)
-	}
-	if prev == tui.ModeDetail && m.altScreenActive {
-		return disableAlternateScrollCmd()
 	}
 	return nil
 }

--- a/cli/app/ui_alt_screen_test.go
+++ b/cli/app/ui_alt_screen_test.go
@@ -4,34 +4,10 @@ import (
 	"testing"
 
 	"builder/cli/tui"
-	"builder/shared/config"
 )
 
-func TestAltScreenPolicyHelpers(t *testing.T) {
-	if !shouldStartMainUIInAltScreen(config.TUIAlternateScreenAlways) {
-		t.Fatal("expected always policy to start main UI in alt-screen")
-	}
-	if shouldStartMainUIInAltScreen(config.TUIAlternateScreenAuto) {
-		t.Fatal("expected auto policy to start main UI in normal screen")
-	}
-	if !shouldUseDetailAltScreen(config.TUIAlternateScreenAuto) {
-		t.Fatal("expected auto policy to use detail alt-screen")
-	}
-	if shouldUseDetailAltScreen(config.TUIAlternateScreenNever) {
-		t.Fatal("expected never policy to keep detail in normal screen")
-	}
-	if !shouldUseStartupPickerAltScreen(config.TUIAlternateScreenAuto) {
-		t.Fatal("expected auto policy to use picker alt-screen")
-	}
-	if shouldUseStartupPickerAltScreen(config.TUIAlternateScreenNever) {
-		t.Fatal("expected never policy to disable picker alt-screen")
-	}
-}
-
-func TestToggleTranscriptModeAutoUsesDetailAltScreen(t *testing.T) {
-	m := newProjectedStaticUIModel(
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenAuto),
-	)
+func TestToggleTranscriptModeUsesFixedDetailAltScreen(t *testing.T) {
+	m := newProjectedStaticUIModel()
 
 	if m.view.Mode() != tui.ModeOngoing {
 		t.Fatalf("mode=%q want ongoing", m.view.Mode())
@@ -59,55 +35,7 @@ func TestToggleTranscriptModeAutoUsesDetailAltScreen(t *testing.T) {
 		t.Fatalf("mode=%q want ongoing", m.view.Mode())
 	}
 	if m.altScreenActive {
-		t.Fatal("expected alt-screen inactive after leaving detail in auto policy")
-	}
-}
-
-func TestToggleTranscriptModeNeverDoesNotEnterAltScreen(t *testing.T) {
-	m := newProjectedStaticUIModel(
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenNever),
-	)
-
-	cmd := m.toggleTranscriptMode()
-	if cmd == nil {
-		t.Fatal("expected command for detail mode")
-	}
-	if m.view.Mode() != tui.ModeDetail {
-		t.Fatalf("mode=%q want detail", m.view.Mode())
-	}
-	if m.altScreenActive {
-		t.Fatal("expected alt-screen inactive in detail mode")
-	}
-}
-
-func TestToggleTranscriptModeAlwaysKeepsAltScreenWithoutDetailTransition(t *testing.T) {
-	m := newProjectedStaticUIModel(
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenAlways),
-	)
-	if !m.altScreenActive {
-		t.Fatal("expected alt-screen active at startup for always policy")
-	}
-
-	cmd := m.toggleTranscriptMode()
-	if cmd == nil {
-		t.Fatal("expected command when entering detail")
-	}
-	if m.view.Mode() != tui.ModeDetail {
-		t.Fatalf("mode=%q want detail", m.view.Mode())
-	}
-	if !m.altScreenActive {
-		t.Fatal("expected alt-screen to stay active")
-	}
-
-	cmd = m.toggleTranscriptMode()
-	if cmd == nil {
-		t.Fatal("expected command when leaving detail")
-	}
-	if m.view.Mode() != tui.ModeOngoing {
-		t.Fatalf("mode=%q want ongoing", m.view.Mode())
-	}
-	if !m.altScreenActive {
-		t.Fatal("expected alt-screen to remain active for always policy")
+		t.Fatal("expected alt-screen inactive after leaving detail")
 	}
 }
 

--- a/cli/app/ui_clipboard_test.go
+++ b/cli/app/ui_clipboard_test.go
@@ -119,7 +119,7 @@ func TestCopySlashCommandCopiesLatestAssistantFinalAnswerAfterReviewerFeedback(t
 	}
 }
 
-func TestCopySlashCommandFallsBackToVisibleCommittedFinalWhenRuntimeStatusIsStale(t *testing.T) {
+func TestCopySlashCommandDoesNotUseVisibleProjectionWhenRuntimeStatusIsStale(t *testing.T) {
 	copier := &stubClipboardTextCopier{}
 	client := &runtimeControlFakeClient{sessionView: clientui.RuntimeSessionView{SessionID: "session-1"}}
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUIClipboardTextCopier(copier))
@@ -147,14 +147,13 @@ func TestCopySlashCommandFallsBackToVisibleCommittedFinalWhenRuntimeStatusIsStal
 	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
 	if cmd == nil {
-		t.Fatal("expected clipboard copy command")
+		t.Fatal("expected transient-status command")
 	}
-	msgs := collectCmdMessages(t, cmd)
-	if copier.calls != 1 {
-		t.Fatalf("expected one clipboard copy, got %d msgs=%+v", copier.calls, msgs)
+	if copier.calls != 0 {
+		t.Fatalf("did not expect clipboard copy from visible projection, got %d", copier.calls)
 	}
-	if copier.text != "visible final" {
-		t.Fatalf("copied text = %q, want %q", copier.text, "visible final")
+	if updated.transientStatus != "No final answer available to copy" {
+		t.Fatalf("expected no-answer status, got %q", updated.transientStatus)
 	}
 }
 

--- a/cli/app/ui_committed_suffix_delivery.go
+++ b/cli/app/ui_committed_suffix_delivery.go
@@ -134,28 +134,44 @@ func (m *uiModel) applyCommittedTranscriptSuffixAppend(suffix clientui.Committed
 	}
 	beforeSequence := m.nativeFlushSequence
 	cmd := m.syncNativeHistoryFromTranscript()
-	m.trackOngoingCommittedSuffixFlush(suffix, beforeSequence)
-	return cmd
+	return sequenceCmds(cmd, m.trackOngoingCommittedSuffixFlush(suffix, beforeSequence))
 }
 
-func (m *uiModel) trackOngoingCommittedSuffixFlush(suffix clientui.CommittedTranscriptSuffix, beforeSequence uint64) {
+func (m *uiModel) trackOngoingCommittedSuffixFlush(suffix clientui.CommittedTranscriptSuffix, beforeSequence uint64) tea.Cmd {
 	if m == nil || !m.ongoingCommittedDelivery.initialized || suffix.NextEntryCount <= suffix.StartEntryCount {
-		return
+		return nil
 	}
 	emittedEnd := committedOngoingLocalFrontierEnd(m)
 	if emittedEnd <= m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount {
-		return
+		return nil
 	}
 	if !m.shouldEmitNativeHistory() {
 		m.ongoingCommittedDelivery.recordCommittedAdvance(emittedEnd, suffix.Revision)
-		return
+		return nil
 	}
 	if m.nativeFlushSequence <= beforeSequence {
 		m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount = emittedEnd
 		m.ongoingCommittedDelivery.lastEmittedTranscriptRevision = suffix.Revision
-		return
+		return nil
 	}
 	emittedSuffix := suffix
 	emittedSuffix.NextEntryCount = emittedEnd
-	_ = m.ongoingCommittedDelivery.beginNativeFlush(emittedSuffix, m.nativeFlushSequence)
+	if err := m.ongoingCommittedDelivery.beginNativeFlush(emittedSuffix, m.nativeFlushSequence); err != nil {
+		m.logf(
+			"ui.runtime.committed_suffix.begin_flush_failed err=%q sequence=%d start=%d next=%d revision=%d cursor=%d",
+			err.Error(),
+			m.nativeFlushSequence,
+			emittedSuffix.StartEntryCount,
+			emittedSuffix.NextEntryCount,
+			emittedSuffix.Revision,
+			m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount,
+		)
+		m.ongoingCommittedDelivery.recordPendingRange(
+			m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount,
+			emittedEnd,
+			suffix.Revision,
+		)
+		return m.requestRuntimeCommittedGapSync()
+	}
+	return nil
 }

--- a/cli/app/ui_committed_suffix_delivery.go
+++ b/cli/app/ui_committed_suffix_delivery.go
@@ -1,0 +1,161 @@
+package app
+
+import (
+	"builder/cli/tui"
+	"builder/shared/clientui"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func shouldDeliverCommittedRuntimeEventFromSuffix(m *uiModel, evt clientui.Event) bool {
+	if m == nil || !evt.CommittedTranscriptChanged || len(evt.TranscriptEntries) == 0 {
+		return false
+	}
+	if evt.Kind == clientui.EventUserMessageFlushed {
+		return false
+	}
+	if _, ok := m.runtimeClient().(interface {
+		RefreshCommittedTranscriptSuffix(clientui.CommittedTranscriptSuffixRequest) (clientui.CommittedTranscriptSuffix, error)
+	}); !ok {
+		return false
+	}
+	return true
+}
+
+func committedTranscriptSuffixRequestForEvent(m *uiModel, evt clientui.Event) clientui.CommittedTranscriptSuffixRequest {
+	after := committedTranscriptTailEnd(m)
+	limit := clientui.DefaultCommittedTranscriptSuffixLimit
+	if evt.CommittedEntryCount > after {
+		limit = evt.CommittedEntryCount - after
+	}
+	return clientui.NormalizeCommittedTranscriptSuffixRequest(clientui.CommittedTranscriptSuffixRequest{
+		AfterEntryCount: after,
+		Limit:           limit,
+	})
+}
+
+func committedTranscriptTailEnd(m *uiModel) int {
+	if m == nil {
+		return 0
+	}
+	if m.ongoingCommittedDelivery.initialized {
+		return m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount
+	}
+	return committedTranscriptLocalFrontierEnd(m)
+}
+
+func committedTranscriptLocalFrontierEnd(m *uiModel) int {
+	if m == nil {
+		return 0
+	}
+	committedCount := 0
+	for _, entry := range m.transcriptEntries {
+		if transcriptEntryCommittedForApp(entry) {
+			committedCount++
+		}
+	}
+	end := m.transcriptBaseOffset + committedCount
+	if end < 0 {
+		return 0
+	}
+	return end
+}
+
+func committedOngoingLocalFrontierEnd(m *uiModel) int {
+	if m == nil {
+		return 0
+	}
+	return m.transcriptBaseOffset + len(committedTranscriptEntriesForApp(m.transcriptEntries))
+}
+
+func (m *uiModel) truncatePendingOngoingTailBeforeSuffix(startEntryCount int) {
+	if m == nil {
+		return
+	}
+	localIndex := startEntryCount - m.transcriptBaseOffset
+	if localIndex < 0 || localIndex > len(m.transcriptEntries) {
+		return
+	}
+	if localIndex == len(m.transcriptEntries) {
+		return
+	}
+	m.transcriptEntries = append([]tui.TranscriptEntry(nil), m.transcriptEntries[:localIndex]...)
+	if m.view.Mode() == tui.ModeOngoing {
+		m.forwardToView(tui.SetConversationMsg{
+			BaseOffset:   m.transcriptBaseOffset,
+			TotalEntries: m.transcriptTotalEntries,
+			Entries:      append([]tui.TranscriptEntry(nil), m.transcriptEntries...),
+			Ongoing:      m.view.OngoingStreamingText(),
+			OngoingError: m.view.OngoingErrorText(),
+		})
+	}
+}
+
+func (m *uiModel) applyCommittedTranscriptSuffixAppend(suffix clientui.CommittedTranscriptSuffix) tea.Cmd {
+	if m == nil {
+		return nil
+	}
+	if !m.ongoingCommittedDelivery.initialized {
+		m.ongoingCommittedDelivery = newOngoingCommittedDeliveryCursor(committedTranscriptTailEnd(m), m.transcriptRevision)
+	}
+	page := transcriptPageFromCommittedTranscriptSuffix(suffix)
+	entries := transcriptEntriesFromPage(page)
+	expectedStart := committedTranscriptTailEnd(m)
+	if page.Offset != expectedStart {
+		m.runtimeAdapter().applyAuthoritativeOngoingTailPage(page, entries, false)
+		if m.view.Mode() == tui.ModeOngoing {
+			m.forwardToView(tui.SetConversationMsg{
+				BaseOffset:   page.Offset,
+				TotalEntries: page.TotalEntries,
+				Entries:      entries,
+				Ongoing:      page.Ongoing,
+				OngoingError: page.OngoingError,
+			})
+		}
+		return m.syncNativeHistoryFromTranscript()
+	}
+	m.truncatePendingOngoingTailBeforeSuffix(expectedStart)
+	for _, entry := range entries {
+		m.transcriptEntries = append(m.transcriptEntries, entry)
+		if m.view.Mode() == tui.ModeOngoing {
+			m.forwardToView(appendTranscriptMsgFromEntry(entry))
+		}
+	}
+	m.transcriptRevision = max(m.transcriptRevision, suffix.Revision)
+	m.transcriptTotalEntries = max(m.transcriptTotalEntries, suffix.CommittedEntryCount)
+	m.transcriptLiveDirty = true
+	m.refreshRollbackCandidates()
+	if m.view.Mode() == tui.ModeDetail {
+		m.detailTranscript.apply(page)
+	}
+	if suffix.NextEntryCount > suffix.StartEntryCount {
+		m.sawAssistantDelta = false
+		m.forwardToView(tui.ClearOngoingAssistantMsg{})
+	}
+	beforeSequence := m.nativeFlushSequence
+	cmd := m.syncNativeHistoryFromTranscript()
+	m.trackOngoingCommittedSuffixFlush(suffix, beforeSequence)
+	return cmd
+}
+
+func (m *uiModel) trackOngoingCommittedSuffixFlush(suffix clientui.CommittedTranscriptSuffix, beforeSequence uint64) {
+	if m == nil || !m.ongoingCommittedDelivery.initialized || suffix.NextEntryCount <= suffix.StartEntryCount {
+		return
+	}
+	emittedEnd := committedOngoingLocalFrontierEnd(m)
+	if emittedEnd <= m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount {
+		return
+	}
+	if !m.shouldEmitNativeHistory() {
+		m.ongoingCommittedDelivery.recordCommittedAdvance(emittedEnd, suffix.Revision)
+		return
+	}
+	if m.nativeFlushSequence <= beforeSequence {
+		m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount = emittedEnd
+		m.ongoingCommittedDelivery.lastEmittedTranscriptRevision = suffix.Revision
+		return
+	}
+	emittedSuffix := suffix
+	emittedSuffix.NextEntryCount = emittedEnd
+	_ = m.ongoingCommittedDelivery.beginNativeFlush(emittedSuffix, m.nativeFlushSequence)
+}

--- a/cli/app/ui_input_controller_commands.go
+++ b/cli/app/ui_input_controller_commands.go
@@ -118,8 +118,19 @@ func (m *uiModel) backTeleportInput() string {
 }
 
 func (m *uiModel) latestAssistantFinalAnswer() string {
+	return m.latestAssistantFinalAnswerFromStatus(true)
+}
+
+func (m *uiModel) cachedLatestAssistantFinalAnswer() string {
+	return m.latestAssistantFinalAnswerFromStatus(false)
+}
+
+func (m *uiModel) latestAssistantFinalAnswerFromStatus(refresh bool) string {
 	if m.hasRuntimeClient() {
-		status := m.refreshRuntimeStatus()
+		status := m.cachedRuntimeStatus()
+		if refresh {
+			status = m.refreshRuntimeStatus()
+		}
 		if answer := strings.TrimSpace(status.LastCommittedAssistantFinalAnswer); answer != "" {
 			return status.LastCommittedAssistantFinalAnswer
 		}
@@ -129,7 +140,7 @@ func (m *uiModel) latestAssistantFinalAnswer() string {
 }
 
 func (m *uiModel) hasAssistantFinalAnswerToCopy() bool {
-	return strings.TrimSpace(m.latestAssistantFinalAnswer()) != ""
+	return strings.TrimSpace(m.cachedLatestAssistantFinalAnswer()) != ""
 }
 
 func (c uiInputController) handleCopyCommand() (tea.Model, tea.Cmd) {

--- a/cli/app/ui_input_controller_commands.go
+++ b/cli/app/ui_input_controller_commands.go
@@ -118,8 +118,12 @@ func (m *uiModel) backTeleportInput() string {
 }
 
 func (m *uiModel) latestAssistantFinalAnswer() string {
-	if answer := strings.TrimSpace(m.runtimeStatus().LastCommittedAssistantFinalAnswer); answer != "" {
-		return m.runtimeStatus().LastCommittedAssistantFinalAnswer
+	if m.hasRuntimeClient() {
+		status := m.refreshRuntimeStatus()
+		if answer := strings.TrimSpace(status.LastCommittedAssistantFinalAnswer); answer != "" {
+			return status.LastCommittedAssistantFinalAnswer
+		}
+		return ""
 	}
 	return localLastCommittedAssistantFinalAnswer(m.transcriptEntries)
 }

--- a/cli/app/ui_input_controller_keys.go
+++ b/cli/app/ui_input_controller_keys.go
@@ -272,11 +272,7 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.moveCursorDownLine()
 		return m, nil
-	case tea.KeyPgUp:
-		m.forwardToView(tea.KeyMsg{Type: tea.KeyPgUp})
-		return m, nil
-	case tea.KeyPgDown:
-		m.forwardToView(tea.KeyMsg{Type: tea.KeyPgDown})
+	case tea.KeyPgUp, tea.KeyPgDown:
 		return m, nil
 	default:
 		if isShiftEnterKey(msg) {

--- a/cli/app/ui_loop.go
+++ b/cli/app/ui_loop.go
@@ -50,7 +50,6 @@ func runUILoopWithInitialPrompt(wiring *runtimeWiring, active config.Settings, l
 		WithUIModelContractLocked(modelContractLocked),
 		WithUITheme(active.Theme),
 		WithUIDebug(active.Debug),
-		WithUIAlternateScreenPolicy(active.TUIAlternateScreen),
 		WithUICommandRegistry(commandRegistry),
 		WithUIHasOtherSessions(wiring.hasOtherSessionsKnown, wiring.hasOtherSessions),
 		WithUIBackgroundManager(wiring.background),

--- a/cli/app/ui_mode_flow_test.go
+++ b/cli/app/ui_mode_flow_test.go
@@ -13,7 +13,6 @@ import (
 	"builder/server/tools"
 	"builder/shared/cachewarn"
 	"builder/shared/clientui"
-	"builder/shared/config"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -189,7 +188,6 @@ func TestCtrlTDeferredDetailLoadSkipsDuplicateSeededPageRequest(t *testing.T) {
 		client,
 		closedProjectedRuntimeEvents(),
 		closedAskEvents(),
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenNever),
 	)
 	m.termWidth = 100
 	m.termHeight = 12
@@ -240,7 +238,6 @@ func TestCtrlTDeferredDetailLoadSkippedDoesNotRebuildDetailEndToEnd(t *testing.T
 		client,
 		closedProjectedRuntimeEvents(),
 		closedAskEvents(),
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenNever),
 	)
 	m.termWidth = 100
 	m.termHeight = 12
@@ -279,7 +276,6 @@ func TestDeferredDetailLoadRefreshesWhenTranscriptDirty(t *testing.T) {
 		client,
 		closedProjectedRuntimeEvents(),
 		closedAskEvents(),
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenNever),
 	)
 	m.termWidth = 100
 	m.termHeight = 12
@@ -332,7 +328,6 @@ func TestCtrlTDeferredDetailLoadDoesNotMutateNativeHistoryState(t *testing.T) {
 		client,
 		closedProjectedRuntimeEvents(),
 		closedAskEvents(),
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenNever),
 	)
 	m.termWidth = 100
 	m.termHeight = 12
@@ -558,8 +553,8 @@ func TestScenarioScrollAttemptsAcrossModesAfterLongDetailStay(t *testing.T) {
 	}
 
 	updated := updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyPgUp})
-	if got := updated.view.OngoingScroll(); got >= start {
-		t.Fatalf("expected pgup to scroll ongoing up, got %d from %d", got, start)
+	if got := updated.view.OngoingScroll(); got != start {
+		t.Fatalf("expected pgup not to mutate ongoing scroll, got %d from %d", got, start)
 	}
 
 	detail := updateUIModel(t, updated, tea.KeyMsg{Type: tea.KeyShiftTab})
@@ -578,20 +573,17 @@ func TestScenarioScrollAttemptsAcrossModesAfterLongDetailStay(t *testing.T) {
 		t.Fatalf("expected latest line visible after returning from detail, got %q", plain)
 	}
 
-	ongoing = updateUIModel(t, ongoing, tea.KeyMsg{Type: tea.KeyUp})
 	afterUp := ongoing.view.OngoingScroll()
 	ongoing = updateUIModel(t, ongoing, tea.KeyMsg{Type: tea.KeyPgDown})
-	if ongoing.view.OngoingScroll() < afterUp {
-		t.Fatalf("expected pgdown to move toward latest tail, got %d from %d", ongoing.view.OngoingScroll(), afterUp)
+	if ongoing.view.OngoingScroll() != afterUp {
+		t.Fatalf("expected pgdown not to mutate ongoing scroll, got %d from %d", ongoing.view.OngoingScroll(), afterUp)
 	}
 }
 
-func TestAlwaysAltScreenPolicyStartsInAltScreen(t *testing.T) {
-	m := newProjectedStaticUIModel(
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenAlways),
-	)
-	if !m.altScreenActive {
-		t.Fatal("expected alt-screen active in always policy")
+func TestMainUIStartsInNormalBuffer(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	if m.altScreenActive {
+		t.Fatal("expected main UI to start in normal buffer")
 	}
 }
 

--- a/cli/app/ui_mode_transition_output_test.go
+++ b/cli/app/ui_mode_transition_output_test.go
@@ -113,9 +113,9 @@ func TestModeTogglesUseDetailAltScreenAltMode(t *testing.T) {
 	}
 }
 
-func TestNativeAlwaysPolicyDisablesAltScreenAndShowsReplayAfterWindowSize(t *testing.T) {
+func TestMainUIStartsInNormalBufferAndShowsReplayAfterWindowSize(t *testing.T) {
 	out := &bytes.Buffer{}
-	settings := config.Settings{TUIAlternateScreen: config.TUIAlternateScreenAlways}
+	settings := config.Settings{}
 	model := newProjectedStaticUIModel(
 		WithUIInitialTranscript([]UITranscriptEntry{{Role: "assistant", Text: "startup replay marker"}}),
 	)

--- a/cli/app/ui_native_history.go
+++ b/cli/app/ui_native_history.go
@@ -9,8 +9,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-const nativeHistoryDivergenceStatusMessage = "Transcript sync bug: ongoing scrollback may be stale until reconnect"
-
 func (m *uiModel) syncNativeHistoryFromTranscript() tea.Cmd {
 	if !m.windowSizeKnown {
 		return nil
@@ -75,7 +73,7 @@ func (m *uiModel) syncNativeHistoryFromTranscript() tea.Cmd {
 		}
 		if replayPermit == nativeHistoryReplayPermitAuthoritativeHydrate {
 			m.acceptNativeProjectionWithoutReplay(projection)
-			return m.sequenceNativeStreamingScrollback(m.setTransientStatusWithKind(nativeHistoryDivergenceStatusMessage, uiStatusNoticeError))
+			return m.sequenceNativeStreamingScrollback(nil)
 		}
 		m.acceptNativeProjectionWithoutReplay(projection)
 		return m.sequenceNativeStreamingScrollback(m.reportNativeProjectionDivergence(projection, previousProjection))
@@ -366,7 +364,7 @@ func (m *uiModel) reportNativeProjectionDivergence(current tui.TranscriptProject
 		panic(fmt.Sprintf("same-session committed transcript divergence requires root-cause fix: rendered_blocks=%d current_blocks=%d", len(rendered.Blocks), len(current.Blocks)))
 	}
 	m.logf("ui.native_history.divergence_detected rendered_blocks=%d current_blocks=%d", len(rendered.Blocks), len(current.Blocks))
-	return m.setTransientStatusWithKind(nativeHistoryDivergenceStatusMessage, uiStatusNoticeError)
+	return nil
 }
 
 func (m *uiModel) rebaseNativeProjection(projection tui.TranscriptProjection, baseOffset int, committedCount int) {
@@ -455,7 +453,7 @@ func (m *uiModel) emitCurrentNativeHistorySnapshot(forceFull bool, replayPermit 
 			}
 			if replayPermit == nativeHistoryReplayPermitAuthoritativeHydrate {
 				m.acceptNativeProjectionWithoutReplay(m.nativeProjection)
-				return m.setTransientStatusWithKind(nativeHistoryDivergenceStatusMessage, uiStatusNoticeError)
+				return nil
 			}
 			m.acceptNativeProjectionWithoutReplay(m.nativeProjection)
 			return m.reportNativeProjectionDivergence(m.nativeProjection, m.nativeRenderedProjection)
@@ -703,6 +701,11 @@ func (m *uiModel) discardPendingNativeHistoryFlushes() {
 }
 
 func (m *uiModel) handleNativeHistoryFlush(msg nativeHistoryFlushMsg) tea.Cmd {
+	defer func() {
+		if m.ongoingCommittedDelivery.initialized {
+			m.ongoingCommittedDelivery.ackNativeFlush(m.nativeFlushedSequence)
+		}
+	}()
 	if msg.Sequence == 0 {
 		if !msg.AllowBlank && strings.TrimSpace(msg.Text) == "" {
 			if m.waitRuntimeEventAfterFlushSequence != 0 && m.nativeFlushedSequence >= m.waitRuntimeEventAfterFlushSequence {

--- a/cli/app/ui_native_history_part3_test.go
+++ b/cli/app/ui_native_history_part3_test.go
@@ -5,7 +5,6 @@ import (
 	"builder/server/llm"
 	"builder/server/runtime"
 	"builder/shared/clientui"
-	"builder/shared/config"
 	"fmt"
 	tea "github.com/charmbracelet/bubbletea"
 	"strings"
@@ -370,6 +369,109 @@ func TestNativeHistoryFlushWaitsForTargetSequenceBeforeRearmingRuntimeEvents(t *
 	}
 }
 
+func TestRuntimeBatchNativeFlushArmsFlushFenceBeforeRearmingRuntimeEvents(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.windowSizeKnown = true
+	m.termWidth = 100
+	m.termHeight = 20
+	m.pendingRuntimeEvents = []clientui.Event{{Kind: clientui.EventConversationUpdated}}
+
+	next, cmd := m.handleRuntimeEventBatch([]clientui.Event{{
+		Kind:                       clientui.EventUserMessageFlushed,
+		UserMessage:                "prompt",
+		CommittedTranscriptChanged: true,
+		CommittedEntryCount:        1,
+		CommittedEntryStart:        0,
+		CommittedEntryStartSet:     true,
+		TranscriptEntries:          []clientui.ChatEntry{{Role: "user", Text: "prompt"}},
+	}})
+	m = next
+
+	if m.waitRuntimeEventAfterFlushSequence == 0 {
+		t.Fatal("expected runtime-event wait to be fenced behind native flush sequence")
+	}
+	if m.waitRuntimeEventAfterFlushSequence != m.nativeFlushSequence {
+		t.Fatalf("wait flush sequence = %d, want native sequence %d", m.waitRuntimeEventAfterFlushSequence, m.nativeFlushSequence)
+	}
+	foundFlush := false
+	for _, msg := range collectCmdMessages(t, cmd) {
+		switch msg.(type) {
+		case nativeHistoryFlushMsg:
+			foundFlush = true
+		case runtimeEventBatchMsg:
+			t.Fatalf("runtime event rearmed before native flush ack: %+v", msg)
+		}
+	}
+	if !foundFlush {
+		t.Fatal("expected runtime batch to emit native history flush")
+	}
+	if got := len(m.pendingRuntimeEvents); got != 1 {
+		t.Fatalf("pending runtime events drained before flush ack: %d", got)
+	}
+}
+
+func TestRuntimeBatchHydrationWithNativeFlushWaitsForFlushAndHydration(t *testing.T) {
+	client := &refreshingRuntimeClient{transcripts: []clientui.TranscriptPage{{
+		SessionID:    "session-1",
+		Revision:     2,
+		TotalEntries: 1,
+		Entries:      []clientui.ChatEntry{{Role: "user", Text: "prompt"}},
+	}}}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.windowSizeKnown = true
+	m.termWidth = 100
+	m.termHeight = 20
+	m.pendingRuntimeEvents = []clientui.Event{{Kind: clientui.EventLocalEntryAdded}}
+
+	next, cmd := m.handleRuntimeEventBatch([]clientui.Event{
+		{
+			Kind:                       clientui.EventUserMessageFlushed,
+			UserMessage:                "prompt",
+			CommittedTranscriptChanged: true,
+			TranscriptRevision:         1,
+			CommittedEntryCount:        1,
+			CommittedEntryStart:        0,
+			CommittedEntryStartSet:     true,
+			TranscriptEntries:          []clientui.ChatEntry{{Role: "user", Text: "prompt"}},
+		},
+		{
+			Kind:                       clientui.EventConversationUpdated,
+			CommittedTranscriptChanged: true,
+			TranscriptRevision:         2,
+			CommittedEntryCount:        2,
+		},
+	})
+	m = next
+
+	if !m.waitRuntimeEventAfterHydration {
+		t.Fatal("expected hydration fence to remain armed")
+	}
+	if m.waitRuntimeEventAfterFlushSequence == 0 {
+		t.Fatal("expected native flush fence to remain armed")
+	}
+	foundFlush := false
+	foundHydration := false
+	for _, msg := range collectCmdMessages(t, cmd) {
+		switch msg.(type) {
+		case nativeHistoryFlushMsg:
+			foundFlush = true
+		case runtimeTranscriptRefreshedMsg:
+			foundHydration = true
+		case runtimeEventBatchMsg:
+			t.Fatalf("runtime event rearmed before flush+hydration completed: %+v", msg)
+		}
+	}
+	if !foundFlush {
+		t.Fatal("expected native flush command")
+	}
+	if !foundHydration {
+		t.Fatal("expected hydration command")
+	}
+	if got := len(m.pendingRuntimeEvents); got != 1 {
+		t.Fatalf("pending runtime events drained before fences cleared: %d", got)
+	}
+}
+
 func TestNativeHistoryReplayDefersWhileDetailAndFlushesOnReturn(t *testing.T) {
 	m := newProjectedStaticUIModel(
 		WithUIInitialTranscript([]UITranscriptEntry{{Role: "assistant", Text: "seed"}}),
@@ -436,9 +538,6 @@ func TestNativeHistorySnapshotDoesNotReplaySameSessionRewriteInOngoingMode(t *te
 	}}
 
 	cmd := m.emitCurrentNativeHistorySnapshot(false, nativeHistoryReplayPermitNone)
-	if cmd == nil {
-		t.Fatal("expected same-session rewrite to surface a transient error notice")
-	}
 	for _, msg := range collectCmdMessages(t, cmd) {
 		if _, ok := msg.(nativeHistoryFlushMsg); ok {
 			t.Fatalf("did not expect same-session rewrite to replay committed scrollback, got %+v", msg)
@@ -500,9 +599,6 @@ func TestNativeHistorySnapshotDoesNotAppendSuffixWhenVisibleRewriteTouchesRender
 	m.nativeRenderedSnapshot = previous.Render(tui.TranscriptDivider)
 
 	cmd := m.emitCurrentNativeHistorySnapshot(false, nativeHistoryReplayPermitNone)
-	if cmd == nil {
-		t.Fatal("expected same-session visible rewrite to surface a transient error notice")
-	}
 	for _, msg := range collectCmdMessages(t, cmd) {
 		if _, ok := msg.(nativeHistoryFlushMsg); ok {
 			t.Fatalf("did not expect visible rewrite to append stale suffix after divergence, got %+v", msg)
@@ -522,9 +618,6 @@ func TestNativeScrollbackResumesAssistantFlushesAfterSameSessionRebase(t *testin
 	m.transcriptEntries[1].Text = "after"
 	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries})
 	recoveryCmd := m.syncNativeHistoryFromTranscript()
-	if recoveryCmd == nil {
-		t.Fatal("expected same-session rewrite to surface a transient error notice")
-	}
 	for _, msg := range collectCmdMessages(t, recoveryCmd) {
 		if _, ok := msg.(nativeHistoryFlushMsg); ok {
 			t.Fatalf("did not expect same-session rewrite to replay committed history, got %+v", msg)
@@ -555,7 +648,6 @@ func TestNativeScrollbackResumesAssistantFlushesAfterSameSessionRebase(t *testin
 
 func TestNativeDetailExitRebasesCommittedTranscriptWhenDetailChangedState(t *testing.T) {
 	m := newProjectedStaticUIModel(
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenNever),
 		WithUIInitialTranscript([]UITranscriptEntry{{Role: "assistant", Text: "seed"}}),
 	)
 	_, startupCmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 20})
@@ -581,8 +673,10 @@ func TestNativeDetailExitRebasesCommittedTranscriptWhenDetailChangedState(t *tes
 	if m.view.Mode() != tui.ModeOngoing {
 		t.Fatalf("expected ongoing mode, got %q", m.view.Mode())
 	}
-	if leaveCmd != nil {
-		t.Fatalf("expected detail exit to rebase committed normal-buffer history without replay, got %T", leaveCmd())
+	for _, msg := range collectCmdMessages(t, leaveCmd) {
+		if _, ok := msg.(nativeHistoryFlushMsg); ok {
+			t.Fatalf("expected detail exit to avoid native replay, got %+v", msg)
+		}
 	}
 	plain := stripANSIText(m.nativeRenderedSnapshot)
 	if !strings.Contains(plain, "fresh root") || !strings.Contains(plain, "rewritten tail") {
@@ -613,7 +707,6 @@ func TestNativeDetailExitRebasesCommittedTranscriptWhenDetailChangedState(t *tes
 
 func TestDefaultDetailTranscriptHydrationSyncsNativeProjectionWithoutTailReplacement(t *testing.T) {
 	m := newProjectedStaticUIModel(
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenNever),
 		WithUIInitialTranscript([]UITranscriptEntry{{Role: "assistant", Text: "seed"}}),
 	)
 	_, startupCmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 20})
@@ -657,7 +750,6 @@ func TestDefaultDetailTranscriptHydrationSyncsNativeProjectionWithoutTailReplace
 
 func TestNativeDetailRepeatedTogglesDoNotPoisonNextAppend(t *testing.T) {
 	m := newProjectedStaticUIModel(
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenNever),
 		WithUIInitialTranscript([]UITranscriptEntry{{Role: "assistant", Text: "seed"}}),
 	)
 	_, startupCmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 20})
@@ -674,13 +766,21 @@ func TestNativeDetailRepeatedTogglesDoNotPoisonNextAppend(t *testing.T) {
 		t.Fatalf("expected detail-mode hydrate repair to stay deferred, got %T", cmd())
 	}
 	if leaveCmd := m.toggleTranscriptModeWithNativeReplay(true); leaveCmd != nil {
-		t.Fatalf("expected first detail exit to rebase without replay, got %T", leaveCmd())
+		for _, msg := range collectCmdMessages(t, leaveCmd) {
+			if _, ok := msg.(nativeHistoryFlushMsg); ok {
+				t.Fatalf("expected first detail exit to avoid native replay, got %+v", msg)
+			}
+		}
 	}
 
 	for i := 0; i < 2; i++ {
 		_ = collectCmdMessages(t, m.toggleTranscriptModeWithNativeReplay(false))
 		if leaveCmd := m.toggleTranscriptModeWithNativeReplay(true); leaveCmd != nil {
-			t.Fatalf("expected repeated detail exit %d to avoid replay, got %T", i, leaveCmd())
+			for _, msg := range collectCmdMessages(t, leaveCmd) {
+				if _, ok := msg.(nativeHistoryFlushMsg); ok {
+					t.Fatalf("expected repeated detail exit %d to avoid native replay, got %+v", i, msg)
+				}
+			}
 		}
 	}
 
@@ -701,7 +801,7 @@ func TestNativeDetailRepeatedTogglesDoNotPoisonNextAppend(t *testing.T) {
 	if strings.Contains(appendPlain, "fresh root") || strings.Contains(appendPlain, "rewritten tail") || strings.Contains(appendPlain, "seed") {
 		t.Fatalf("expected repeated detail toggles to keep prior transcript rebased, got %q", appendPlain)
 	}
-	if m.transientStatus == nativeHistoryDivergenceStatusMessage {
+	if m.transientStatus != "" {
 		t.Fatalf("did not expect repeated detail toggles to poison the next append, got status=%q", m.transientStatus)
 	}
 }
@@ -783,18 +883,11 @@ func TestNativeHistorySnapshotRebasesDuringAuthoritativeHydrateWithoutReplay(t *
 	}}
 
 	cmd := m.emitCurrentNativeHistorySnapshot(false, nativeHistoryReplayPermitAuthoritativeHydrate)
-	if cmd == nil {
-		t.Fatal("expected authoritative hydrate divergence to surface status without replay")
-	}
 	msgs := collectCmdMessages(t, cmd)
-	if len(msgs) != 1 {
-		t.Fatalf("expected authoritative hydrate divergence to emit status only, got %d message(s)", len(msgs))
-	}
-	if _, ok := msgs[0].(nativeHistoryFlushMsg); ok {
-		t.Fatalf("did not expect authoritative hydrate divergence to replay normal-buffer history, got %+v", msgs)
-	}
-	if m.transientStatus != nativeHistoryDivergenceStatusMessage || m.transientStatusKind != uiStatusNoticeError {
-		t.Fatalf("expected authoritative hydrate divergence to surface status, got status=%q kind=%v", m.transientStatus, m.transientStatusKind)
+	for _, msg := range msgs {
+		if _, ok := msg.(nativeHistoryFlushMsg); ok {
+			t.Fatalf("did not expect authoritative hydrate divergence to replay normal-buffer history, got %+v", msgs)
+		}
 	}
 	if got := stripANSIPreserve(m.nativeRenderedSnapshot); !strings.Contains(got, "commit/push") || !strings.Contains(got, "after") || strings.Contains(got, "before") {
 		t.Fatalf("expected authoritative hydrate divergence to rebase internal rendered snapshot, got %q", got)
@@ -818,18 +911,11 @@ func TestNativeHistorySnapshotAuthoritativeHydrateDoesNotReplayInDebugMode(t *te
 	}}
 
 	cmd := m.emitCurrentNativeHistorySnapshot(false, nativeHistoryReplayPermitAuthoritativeHydrate)
-	if cmd == nil {
-		t.Fatal("expected authoritative hydrate divergence status in debug mode")
-	}
 	msgs := collectCmdMessages(t, cmd)
-	if len(msgs) != 1 {
-		t.Fatalf("expected debug authoritative hydrate divergence to emit status only, got %d message(s)", len(msgs))
-	}
-	if m.transientStatus != nativeHistoryDivergenceStatusMessage || m.transientStatusKind != uiStatusNoticeError {
-		t.Fatalf("expected debug authoritative hydrate divergence to surface status, got status=%q kind=%v", m.transientStatus, m.transientStatusKind)
-	}
-	if _, ok := msgs[0].(nativeHistoryFlushMsg); ok {
-		t.Fatalf("did not expect debug authoritative hydrate divergence to replay normal-buffer history, got %+v", msgs)
+	for _, msg := range msgs {
+		if _, ok := msg.(nativeHistoryFlushMsg); ok {
+			t.Fatalf("did not expect debug authoritative hydrate divergence to replay normal-buffer history, got %+v", msgs)
+		}
 	}
 	if got := stripANSIPreserve(m.nativeRenderedSnapshot); !strings.Contains(got, "commit/push") || !strings.Contains(got, "after") || strings.Contains(got, "before") {
 		t.Fatalf("expected debug authoritative hydrate divergence to rebase internal rendered snapshot, got %q", got)
@@ -875,7 +961,6 @@ func TestNativeHistorySnapshotAppendsAcrossSlidingTailWindowWithoutReplay(t *tes
 
 func TestModeRestorePermitOverridesEarlierAuthoritativeHydratePermitWithoutReplay(t *testing.T) {
 	m := newProjectedStaticUIModel(
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenNever),
 		WithUIInitialTranscript([]UITranscriptEntry{{Role: "assistant", Text: "seed"}}),
 	)
 	_, startupCmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 20})
@@ -905,14 +990,16 @@ func TestModeRestorePermitOverridesEarlierAuthoritativeHydratePermitWithoutRepla
 	if m.view.Mode() != tui.ModeOngoing {
 		t.Fatalf("expected ongoing mode, got %q", m.view.Mode())
 	}
-	if leaveCmd != nil {
-		t.Fatalf("expected mode-restore to rebase without replay, got %T", leaveCmd())
+	for _, msg := range collectCmdMessages(t, leaveCmd) {
+		if _, ok := msg.(nativeHistoryFlushMsg); ok {
+			t.Fatalf("expected mode-restore to avoid native replay, got %+v", msg)
+		}
 	}
 	plain := stripANSIText(m.nativeRenderedSnapshot)
 	if !strings.Contains(plain, "fresh root") || !strings.Contains(plain, "rewritten tail") || strings.Contains(plain, "seed") {
 		t.Fatalf("expected mode-restore to update rendered baseline, got %q", plain)
 	}
-	if m.transientStatus == nativeHistoryDivergenceStatusMessage {
+	if m.transientStatus != "" {
 		t.Fatalf("did not expect authoritative-hydrate warning to win after mode-restore rebase, got status=%q", m.transientStatus)
 	}
 }

--- a/cli/app/ui_native_history_test.go
+++ b/cli/app/ui_native_history_test.go
@@ -27,7 +27,7 @@ func pendingSpinnerFrameText(frame int) string {
 }
 
 func pendingSpinnerLine(frame int, text string) string {
-	return pendingSpinnerFrameText(frame) + text
+	return pendingSpinnerFrameText(frame) + " " + text
 }
 
 func collectNativeHistoryFlushText(msgs []tea.Msg) string {
@@ -378,16 +378,10 @@ func TestNativeScrollbackDoesNotReplaySameSessionNonAppendMutation(t *testing.T)
 	m.transcriptEntries[1].Text = "mutated line"
 	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries})
 	cmd := m.syncNativeHistoryFromTranscript()
-	if cmd == nil {
-		t.Fatal("expected same-session divergence to surface a transient error notice")
-	}
 	for _, msg := range collectCmdMessages(t, cmd) {
 		if _, ok := msg.(nativeHistoryFlushMsg); ok {
 			t.Fatalf("did not expect same-session divergence to replay normal-buffer history, got %+v", msg)
 		}
-	}
-	if m.transientStatus != nativeHistoryDivergenceStatusMessage || m.transientStatusKind != uiStatusNoticeError {
-		t.Fatalf("expected divergence status surfaced to user, got status=%q kind=%v", m.transientStatus, m.transientStatusKind)
 	}
 	if got := stripANSIText(m.nativeRenderedSnapshot); !strings.Contains(got, "mutated line") || strings.Contains(got, "old line") {
 		t.Fatalf("expected rendered baseline rebased without replay, got %q", got)
@@ -406,9 +400,6 @@ func TestNativeScrollbackRebasesWhenNoSharedPrefixExists(t *testing.T) {
 	m.transcriptEntries = []tui.TranscriptEntry{{Role: "user", Text: "fresh root"}, {Role: "assistant", Text: "rewritten tail"}}
 	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries})
 	cmd := m.syncNativeHistoryFromTranscript()
-	if cmd == nil {
-		t.Fatal("expected same-session zero-prefix divergence to surface a transient error notice")
-	}
 	for _, msg := range collectCmdMessages(t, cmd) {
 		if _, ok := msg.(nativeHistoryFlushMsg); ok {
 			t.Fatalf("did not expect same-session zero-prefix divergence to replay scrollback, got %+v", msg)
@@ -786,8 +777,8 @@ func TestNativeScrollbackFlowIntegration(t *testing.T) {
 
 	start := m.view.OngoingScroll()
 	m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyPgUp})
-	if got := m.view.OngoingScroll(); got >= start {
-		t.Fatalf("expected pgup to scroll ongoing transcript state, got %d from %d", got, start)
+	if got := m.view.OngoingScroll(); got != start {
+		t.Fatalf("expected pgup not to mutate ongoing transcript state, got %d from %d", got, start)
 	}
 
 	m.forwardToView(tui.AppendTranscriptMsg{Role: "assistant", Text: "message 121"})

--- a/cli/app/ui_native_scrollback_integration_part2_test.go
+++ b/cli/app/ui_native_scrollback_integration_part2_test.go
@@ -7,7 +7,6 @@ import (
 	"builder/server/session"
 	"builder/server/tools"
 	sharedclient "builder/shared/client"
-	"builder/shared/config"
 	"bytes"
 	"context"
 	"errors"
@@ -33,7 +32,6 @@ func TestNativePSOverlayEscBalancesAltScreenAndAlternateScroll(t *testing.T) {
 		nil,
 		closedProjectedRuntimeEvents(),
 		closedAskEvents(),
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenAuto),
 	)
 	model.input = "/ps"
 
@@ -96,7 +94,7 @@ func TestNativePSOverlayEscBalancesAltScreenAndAlternateScroll(t *testing.T) {
 	}
 }
 
-func TestNativePSOverlayUsesClearScreenWhenAltScreenNever(t *testing.T) {
+func TestNativePSOverlayUsesFixedAltScreen(t *testing.T) {
 	var terminalSequences []string
 	originalWriteTerminalSequence := writeTerminalSequence
 	writeTerminalSequence = func(sequence string) {
@@ -111,7 +109,6 @@ func TestNativePSOverlayUsesClearScreenWhenAltScreenNever(t *testing.T) {
 		nil,
 		closedProjectedRuntimeEvents(),
 		closedAskEvents(),
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenNever),
 	)
 	model.input = "/ps"
 
@@ -147,15 +144,16 @@ func TestNativePSOverlayUsesClearScreenWhenAltScreenNever(t *testing.T) {
 	}
 
 	raw := out.String()
-	if strings.Contains(raw, "\x1b[?1049h") || strings.Contains(raw, "\x1b[?1049l") {
-		t.Fatalf("did not expect /ps overlay to use alt-screen when detail alt-screen is disabled, got %q", raw)
+	enterAlt := strings.Count(raw, "\x1b[?1049h")
+	exitAlt := strings.Count(raw, "\x1b[?1049l")
+	if enterAlt == 0 || enterAlt != exitAlt {
+		t.Fatalf("expected balanced /ps alt-screen enter/exit sequences, enter=%d exit=%d raw=%q", enterAlt, exitAlt, raw)
 	}
 	sequenceLog := strings.Join(terminalSequences, "")
-	if strings.Contains(sequenceLog, "\x1b[?1007h") || strings.Contains(sequenceLog, "\x1b[?1007l") {
-		t.Fatalf("did not expect /ps overlay to toggle alternate scroll when detail alt-screen is disabled, got %q", sequenceLog)
-	}
-	if clearCount := strings.Count(raw, "\x1b[2J"); clearCount < 2 {
-		t.Fatalf("expected startup + /ps open clear-screen sequences, got %d in %q", clearCount, raw)
+	enableAltScroll := strings.Count(sequenceLog, "\x1b[?1007h")
+	disableAltScroll := strings.Count(sequenceLog, "\x1b[?1007l")
+	if enableAltScroll == 0 || enableAltScroll != disableAltScroll {
+		t.Fatalf("expected balanced /ps alternate-scroll enable/disable sequences, enable=%d disable=%d log=%q", enableAltScroll, disableAltScroll, sequenceLog)
 	}
 	if !strings.Contains(normalizedOutput(raw), "Background Processes") {
 		t.Fatalf("expected /ps overlay content in output, got %q", normalizedOutput(raw))

--- a/cli/app/ui_native_scrollback_integration_part4_test.go
+++ b/cli/app/ui_native_scrollback_integration_part4_test.go
@@ -842,8 +842,9 @@ func TestRuntimeAuthoritativeHydrateRepairsOngoingScrollbackWithoutContinuityLos
 		},
 	}})
 	baselineLen := out.Len()
-	waitForTestCondition(t, 2*time.Second, "authoritative hydrate divergence status visible", func() bool {
-		return strings.Contains(stripANSIAndTrimRight(model.View()), nativeHistoryDivergenceStatusMessage)
+	waitForTestCondition(t, 2*time.Second, "authoritative hydrate divergence rebased", func() bool {
+		got := stripANSIAndTrimRight(model.nativeRenderedSnapshot)
+		return strings.Contains(got, "after") && !strings.Contains(got, "before")
 	})
 
 	program.Quit()
@@ -864,8 +865,5 @@ func TestRuntimeAuthoritativeHydrateRepairsOngoingScrollbackWithoutContinuityLos
 	}
 	if normalized := normalizedOutput(out.String()); !strings.Contains(normalized, "before") {
 		t.Fatalf("expected previously emitted ongoing scrollback to remain intact, got %q", normalized)
-	}
-	if !strings.Contains(stripANSIAndTrimRight(model.View()), nativeHistoryDivergenceStatusMessage) {
-		t.Fatalf("expected authoritative hydrate divergence to surface status, got %q", stripANSIAndTrimRight(model.View()))
 	}
 }

--- a/cli/app/ui_native_scrollback_integration_test.go
+++ b/cli/app/ui_native_scrollback_integration_test.go
@@ -5,7 +5,6 @@ import (
 	"builder/server/llm"
 	"builder/server/tools"
 	"builder/shared/clientui"
-	"builder/shared/config"
 	"builder/shared/protocol"
 	"builder/shared/rpcwire"
 	"builder/shared/serverapi"
@@ -798,7 +797,6 @@ func TestNativeRollbackOverlayCtrlCBalancesAltScreenAndAlternateScroll(t *testin
 		nil,
 		closedProjectedRuntimeEvents(),
 		closedAskEvents(),
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenAuto),
 		WithUIInitialTranscript([]UITranscriptEntry{
 			{Role: "user", Text: "u1"},
 			{Role: "assistant", Text: "a1"},

--- a/cli/app/ui_ongoing_delivery_cursor.go
+++ b/cli/app/ui_ongoing_delivery_cursor.go
@@ -1,0 +1,166 @@
+package app
+
+import (
+	"errors"
+
+	"builder/shared/clientui"
+)
+
+type ongoingCommittedRange struct {
+	startEntryCount int
+	endEntryCount   int
+	revision        int64
+}
+
+type ongoingCommittedDeliveryCursor struct {
+	initialized                    bool
+	lastEmittedCommittedEntryCount int
+	lastEmittedTranscriptRevision  int64
+	nativeFlushInFlight            bool
+	emissionEnabledByMode          bool
+	pendingCommittedRanges         []ongoingCommittedRange
+
+	flushSequence       uint64
+	flushNextEntryCount int
+	flushRevision       int64
+}
+
+func newOngoingCommittedDeliveryCursor(lastCommittedEntryCount int, revision int64) ongoingCommittedDeliveryCursor {
+	if lastCommittedEntryCount < 0 {
+		lastCommittedEntryCount = 0
+	}
+	return ongoingCommittedDeliveryCursor{
+		initialized:                    true,
+		lastEmittedCommittedEntryCount: lastCommittedEntryCount,
+		lastEmittedTranscriptRevision:  revision,
+		emissionEnabledByMode:          true,
+	}
+}
+
+func (c *ongoingCommittedDeliveryCursor) setEmissionEnabled(enabled bool) {
+	if c == nil {
+		return
+	}
+	c.emissionEnabledByMode = enabled
+}
+
+func (c *ongoingCommittedDeliveryCursor) recordCommittedAdvance(committedEntryCount int, revision int64) {
+	if c == nil || committedEntryCount <= c.lastEmittedCommittedEntryCount {
+		return
+	}
+	if c.emissionEnabledByMode && !c.nativeFlushInFlight {
+		return
+	}
+	c.recordPendingRange(c.lastEmittedCommittedEntryCount, committedEntryCount, revision)
+}
+
+func (c *ongoingCommittedDeliveryCursor) beginNativeFlush(suffix clientui.CommittedTranscriptSuffix, sequence uint64) error {
+	if c == nil {
+		return errors.New("ongoing delivery cursor is required")
+	}
+	if c.nativeFlushInFlight {
+		return errors.New("native flush already in flight")
+	}
+	if suffix.StartEntryCount != c.lastEmittedCommittedEntryCount {
+		return errors.New("suffix start does not match delivery cursor")
+	}
+	if suffix.NextEntryCount < suffix.StartEntryCount {
+		return errors.New("suffix next cursor is before suffix start")
+	}
+	if suffix.NextEntryCount == suffix.StartEntryCount {
+		return nil
+	}
+	c.nativeFlushInFlight = true
+	c.flushSequence = sequence
+	c.flushNextEntryCount = suffix.NextEntryCount
+	c.flushRevision = suffix.Revision
+	return nil
+}
+
+func (c *ongoingCommittedDeliveryCursor) ackNativeFlush(sequence uint64) bool {
+	if c == nil || !c.nativeFlushInFlight || sequence < c.flushSequence {
+		return false
+	}
+	c.lastEmittedCommittedEntryCount = c.flushNextEntryCount
+	c.lastEmittedTranscriptRevision = c.flushRevision
+	c.nativeFlushInFlight = false
+	c.flushSequence = 0
+	c.flushNextEntryCount = 0
+	c.flushRevision = 0
+	c.discardPendingThrough(c.lastEmittedCommittedEntryCount)
+	return true
+}
+
+func (c *ongoingCommittedDeliveryCursor) failNativeFlush(sequence uint64) {
+	if c == nil || !c.nativeFlushInFlight || sequence < c.flushSequence {
+		return
+	}
+	failedNextEntryCount := c.flushNextEntryCount
+	failedRevision := c.flushRevision
+	c.nativeFlushInFlight = false
+	c.flushSequence = 0
+	c.flushNextEntryCount = 0
+	c.flushRevision = 0
+	if failedNextEntryCount > c.lastEmittedCommittedEntryCount {
+		c.recordPendingRange(c.lastEmittedCommittedEntryCount, failedNextEntryCount, failedRevision)
+	}
+}
+
+func (c *ongoingCommittedDeliveryCursor) nextSuffixRequest() (clientui.CommittedTranscriptSuffixRequest, bool) {
+	if c == nil || c.nativeFlushInFlight {
+		return clientui.CommittedTranscriptSuffixRequest{}, false
+	}
+	if len(c.pendingCommittedRanges) == 0 {
+		return clientui.CommittedTranscriptSuffixRequest{
+			AfterEntryCount: c.lastEmittedCommittedEntryCount,
+			Limit:           clientui.DefaultCommittedTranscriptSuffixLimit,
+		}, true
+	}
+	next := c.pendingCommittedRanges[0]
+	limit := next.endEntryCount - c.lastEmittedCommittedEntryCount
+	if limit <= 0 {
+		limit = clientui.DefaultCommittedTranscriptSuffixLimit
+	}
+	return clientui.CommittedTranscriptSuffixRequest{
+		AfterEntryCount: c.lastEmittedCommittedEntryCount,
+		Limit:           limit,
+	}, true
+}
+
+func (c *ongoingCommittedDeliveryCursor) recordPendingRange(startEntryCount int, endEntryCount int, revision int64) {
+	if c == nil || endEntryCount <= startEntryCount {
+		return
+	}
+	if len(c.pendingCommittedRanges) == 0 {
+		c.pendingCommittedRanges = append(c.pendingCommittedRanges, ongoingCommittedRange{startEntryCount: startEntryCount, endEntryCount: endEntryCount, revision: revision})
+		return
+	}
+	last := &c.pendingCommittedRanges[len(c.pendingCommittedRanges)-1]
+	if startEntryCount <= last.endEntryCount {
+		if endEntryCount > last.endEntryCount {
+			last.endEntryCount = endEntryCount
+		}
+		if revision > last.revision {
+			last.revision = revision
+		}
+		return
+	}
+	c.pendingCommittedRanges = append(c.pendingCommittedRanges, ongoingCommittedRange{startEntryCount: startEntryCount, endEntryCount: endEntryCount, revision: revision})
+}
+
+func (c *ongoingCommittedDeliveryCursor) discardPendingThrough(entryCount int) {
+	if c == nil || len(c.pendingCommittedRanges) == 0 {
+		return
+	}
+	ranges := c.pendingCommittedRanges[:0]
+	for _, pending := range c.pendingCommittedRanges {
+		if pending.endEntryCount <= entryCount {
+			continue
+		}
+		if pending.startEntryCount < entryCount {
+			pending.startEntryCount = entryCount
+		}
+		ranges = append(ranges, pending)
+	}
+	c.pendingCommittedRanges = ranges
+}

--- a/cli/app/ui_ongoing_delivery_cursor.go
+++ b/cli/app/ui_ongoing_delivery_cursor.go
@@ -78,7 +78,7 @@ func (c *ongoingCommittedDeliveryCursor) beginNativeFlush(suffix clientui.Commit
 }
 
 func (c *ongoingCommittedDeliveryCursor) ackNativeFlush(sequence uint64) bool {
-	if c == nil || !c.nativeFlushInFlight || sequence < c.flushSequence {
+	if c == nil || !c.nativeFlushInFlight || sequence != c.flushSequence {
 		return false
 	}
 	c.lastEmittedCommittedEntryCount = c.flushNextEntryCount
@@ -92,7 +92,7 @@ func (c *ongoingCommittedDeliveryCursor) ackNativeFlush(sequence uint64) bool {
 }
 
 func (c *ongoingCommittedDeliveryCursor) failNativeFlush(sequence uint64) {
-	if c == nil || !c.nativeFlushInFlight || sequence < c.flushSequence {
+	if c == nil || !c.nativeFlushInFlight || sequence != c.flushSequence {
 		return
 	}
 	failedNextEntryCount := c.flushNextEntryCount

--- a/cli/app/ui_ongoing_delivery_cursor_test.go
+++ b/cli/app/ui_ongoing_delivery_cursor_test.go
@@ -27,6 +27,12 @@ func TestOngoingDeliveryCursorAdvancesOnlyAfterNativeFlushAck(t *testing.T) {
 	if cursor.lastEmittedCommittedEntryCount != 2 {
 		t.Fatalf("cursor advanced after stale ack: %+v", cursor)
 	}
+	if advanced := cursor.ackNativeFlush(8); advanced {
+		t.Fatalf("ack for a different newer flush advanced cursor: %+v", cursor)
+	}
+	if cursor.lastEmittedCommittedEntryCount != 2 {
+		t.Fatalf("cursor advanced after mismatched ack: %+v", cursor)
+	}
 	if advanced := cursor.ackNativeFlush(7); !advanced {
 		t.Fatalf("expected target ack to advance cursor: %+v", cursor)
 	}
@@ -81,6 +87,10 @@ func TestOngoingDeliveryCursorRetryKeepsCursorWhenFlushFails(t *testing.T) {
 
 	if err := cursor.beginNativeFlush(suffix, 9); err != nil {
 		t.Fatalf("begin native flush: %v", err)
+	}
+	cursor.failNativeFlush(10)
+	if !cursor.nativeFlushInFlight {
+		t.Fatalf("mismatched failure cleared flush: %+v", cursor)
 	}
 	cursor.failNativeFlush(9)
 

--- a/cli/app/ui_ongoing_delivery_cursor_test.go
+++ b/cli/app/ui_ongoing_delivery_cursor_test.go
@@ -1,0 +1,100 @@
+package app
+
+import (
+	"testing"
+
+	"builder/shared/clientui"
+)
+
+func TestOngoingDeliveryCursorAdvancesOnlyAfterNativeFlushAck(t *testing.T) {
+	cursor := newOngoingCommittedDeliveryCursor(2, 10)
+	suffix := clientui.CommittedTranscriptSuffix{
+		Revision:        11,
+		StartEntryCount: 2,
+		NextEntryCount:  4,
+		Entries:         []clientui.ChatEntry{{Role: "assistant", Text: "a"}, {Role: "assistant", Text: "b"}},
+	}
+
+	if err := cursor.beginNativeFlush(suffix, 7); err != nil {
+		t.Fatalf("begin native flush: %v", err)
+	}
+	if cursor.lastEmittedCommittedEntryCount != 2 {
+		t.Fatalf("cursor advanced before ack: %+v", cursor)
+	}
+	if advanced := cursor.ackNativeFlush(6); advanced {
+		t.Fatalf("ack before target advanced cursor: %+v", cursor)
+	}
+	if cursor.lastEmittedCommittedEntryCount != 2 {
+		t.Fatalf("cursor advanced after stale ack: %+v", cursor)
+	}
+	if advanced := cursor.ackNativeFlush(7); !advanced {
+		t.Fatalf("expected target ack to advance cursor: %+v", cursor)
+	}
+	if cursor.lastEmittedCommittedEntryCount != 4 {
+		t.Fatalf("last emitted count = %d, want 4", cursor.lastEmittedCommittedEntryCount)
+	}
+	if cursor.lastEmittedTranscriptRevision != 11 {
+		t.Fatalf("last revision = %d, want 11", cursor.lastEmittedTranscriptRevision)
+	}
+	if cursor.nativeFlushInFlight {
+		t.Fatalf("flush still in flight after ack: %+v", cursor)
+	}
+}
+
+func TestOngoingDeliveryCursorRecordsPendingRangeWhileEmissionDisabled(t *testing.T) {
+	cursor := newOngoingCommittedDeliveryCursor(2, 10)
+	cursor.setEmissionEnabled(false)
+
+	cursor.recordCommittedAdvance(5, 12)
+	cursor.recordCommittedAdvance(7, 13)
+
+	if cursor.lastEmittedCommittedEntryCount != 2 {
+		t.Fatalf("cursor advanced while emission disabled: %+v", cursor)
+	}
+	if len(cursor.pendingCommittedRanges) != 1 {
+		t.Fatalf("pending ranges = %+v, want one compact range", cursor.pendingCommittedRanges)
+	}
+	pending := cursor.pendingCommittedRanges[0]
+	if pending.startEntryCount != 2 || pending.endEntryCount != 7 || pending.revision != 13 {
+		t.Fatalf("unexpected pending range: %+v", pending)
+	}
+	req, ok := cursor.nextSuffixRequest()
+	if !ok {
+		t.Fatal("expected suffix request for pending range")
+	}
+	if req.AfterEntryCount != 2 {
+		t.Fatalf("after entry count = %d, want 2", req.AfterEntryCount)
+	}
+	if req.Limit != 5 {
+		t.Fatalf("limit = %d, want 5", req.Limit)
+	}
+}
+
+func TestOngoingDeliveryCursorRetryKeepsCursorWhenFlushFails(t *testing.T) {
+	cursor := newOngoingCommittedDeliveryCursor(3, 10)
+	suffix := clientui.CommittedTranscriptSuffix{
+		Revision:        11,
+		StartEntryCount: 3,
+		NextEntryCount:  6,
+		Entries:         []clientui.ChatEntry{{Role: "assistant", Text: "a"}},
+	}
+
+	if err := cursor.beginNativeFlush(suffix, 9); err != nil {
+		t.Fatalf("begin native flush: %v", err)
+	}
+	cursor.failNativeFlush(9)
+
+	if cursor.nativeFlushInFlight {
+		t.Fatalf("flush still in flight after failure: %+v", cursor)
+	}
+	if cursor.lastEmittedCommittedEntryCount != 3 || cursor.lastEmittedTranscriptRevision != 10 {
+		t.Fatalf("cursor changed after failed flush: %+v", cursor)
+	}
+	req, ok := cursor.nextSuffixRequest()
+	if !ok {
+		t.Fatal("expected retry request after failed flush")
+	}
+	if req.AfterEntryCount != 3 {
+		t.Fatalf("retry after entry count = %d, want 3", req.AfterEntryCount)
+	}
+}

--- a/cli/app/ui_part2_test.go
+++ b/cli/app/ui_part2_test.go
@@ -7,7 +7,6 @@ import (
 	"builder/server/session"
 	"builder/server/tools"
 	"builder/server/tools/askquestion"
-	"builder/shared/config"
 	"errors"
 	"fmt"
 	tea "github.com/charmbracelet/bubbletea"
@@ -210,7 +209,6 @@ func TestRollbackTransitionsUseDetailOverlayInNativeMode(t *testing.T) {
 
 func TestNativeRollbackOverlayUsesClearScreenWhenAltScreenNever(t *testing.T) {
 	m := newProjectedStaticUIModel(
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenNever),
 		WithUIInitialTranscript([]UITranscriptEntry{{Role: "user", Text: "u1"}, {Role: "assistant", Text: "a1"}, {Role: "user", Text: "u2"}}),
 	)
 
@@ -497,7 +495,6 @@ func TestNativeRollbackEditCommandSequenceClearsBeforeAnchoredReplay(t *testing.
 		)
 	}
 	m := newProjectedStaticUIModel(
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenNever),
 		WithUIInitialTranscript(entries),
 	)
 	next, startupCmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 14})
@@ -565,7 +562,6 @@ func TestNativeRollbackEditCommandSequenceClearsBeforeAnchoredReplay(t *testing.
 
 func TestRollbackTransitionsDoNotClearScreenWhenNotInAltScreen(t *testing.T) {
 	m := newProjectedStaticUIModel(
-		WithUIAlternateScreenPolicy(config.TUIAlternateScreenAuto),
 		WithUIInitialTranscript([]UITranscriptEntry{{Role: "user", Text: "u1"}, {Role: "assistant", Text: "a1"}, {Role: "user", Text: "u2"}}),
 	)
 

--- a/cli/app/ui_rollback.go
+++ b/cli/app/ui_rollback.go
@@ -191,7 +191,7 @@ func (m *uiModel) suppressRollbackAlternateScrollIfNeeded() tea.Cmd {
 	if m == nil || m.rollback.suppressedAlternateScroll {
 		return nil
 	}
-	if m.view.Mode() != tui.ModeDetail || !m.altScreenActive || !shouldUseDetailAltScreen(m.tuiAlternateScreen) {
+	if m.view.Mode() != tui.ModeDetail || !m.altScreenActive {
 		return nil
 	}
 	m.rollback.suppressedAlternateScroll = true
@@ -203,7 +203,7 @@ func (m *uiModel) restoreRollbackAlternateScrollIfNeeded() tea.Cmd {
 		return nil
 	}
 	m.rollback.suppressedAlternateScroll = false
-	if m.view.Mode() != tui.ModeDetail || !m.altScreenActive || !shouldUseDetailAltScreen(m.tuiAlternateScreen) {
+	if m.view.Mode() != tui.ModeDetail || !m.altScreenActive {
 		return nil
 	}
 	return enableAlternateScrollCmd()

--- a/cli/app/ui_runtime_adapter.go
+++ b/cli/app/ui_runtime_adapter.go
@@ -87,16 +87,27 @@ func (a uiRuntimeAdapter) applyProjectedRuntimeEvent(evt clientui.Event, flushNa
 		m.invalidateTransientTranscriptState()
 	}
 	if len(evt.TranscriptEntries) > 0 {
-		cmd, mutated, needsHydration := a.applyProjectedTranscriptEntries(evt, flushNativeHistory)
-		cmds = append(cmds, cmd)
-		transcriptMutated = transcriptMutated || mutated
-		awaitsHydration = awaitsHydration || needsHydration
-		if shouldClearAssistantStreamForCommittedAssistantEvent(evt) && (mutated || skippedAssistantCommitMatchesActiveLiveStream(m, evt)) {
-			if stepID := strings.TrimSpace(evt.StepID); stepID != "" {
-				m.lastCommittedAssistantStepID = stepID
+		if shouldDeliverCommittedRuntimeEventFromSuffix(m, evt) {
+			cmds = append(cmds, m.requestRuntimeCommittedTranscriptSuffix(committedTranscriptSuffixRequestForEvent(m, evt)))
+			if shouldClearAssistantStreamForCommittedAssistantEvent(evt) || skippedAssistantCommitMatchesActiveLiveStream(m, evt) {
+				if stepID := strings.TrimSpace(evt.StepID); stepID != "" {
+					m.lastCommittedAssistantStepID = stepID
+				}
+				m.sawAssistantDelta = false
+				m.forwardToView(tui.ClearOngoingAssistantMsg{})
 			}
-			m.sawAssistantDelta = false
-			m.forwardToView(tui.ClearOngoingAssistantMsg{})
+		} else {
+			cmd, mutated, needsHydration := a.applyProjectedTranscriptEntries(evt, flushNativeHistory)
+			cmds = append(cmds, cmd)
+			transcriptMutated = transcriptMutated || mutated
+			awaitsHydration = awaitsHydration || needsHydration
+			if shouldClearAssistantStreamForCommittedAssistantEvent(evt) && (mutated || skippedAssistantCommitMatchesActiveLiveStream(m, evt)) {
+				if stepID := strings.TrimSpace(evt.StepID); stepID != "" {
+					m.lastCommittedAssistantStepID = stepID
+				}
+				m.sawAssistantDelta = false
+				m.forwardToView(tui.ClearOngoingAssistantMsg{})
+			}
 		}
 	}
 	for _, streamCommand := range reduction.Transcript.AssistantStream {

--- a/cli/app/ui_runtime_adapter_part4_test.go
+++ b/cli/app/ui_runtime_adapter_part4_test.go
@@ -221,7 +221,7 @@ func TestRuntimeAuthoritativeHydrateDoesNotRepairCommittedToolPathWhenLiveProjec
 		_ = collectCmdMessages(t, cmd)
 	}
 
-	if m.transientStatus == nativeHistoryDivergenceStatusMessage {
+	if m.transientStatus != "" {
 		t.Fatalf("did not expect authoritative hydrate warning when live committed tool path already matches, got status=%q", m.transientStatus)
 	}
 	if got, want := len(m.transcriptEntries), 3; got != want {
@@ -281,7 +281,7 @@ func TestRuntimeAuthoritativeHydrateDoesNotRepairCommittedReviewerStatusPathWhen
 		_ = collectCmdMessages(t, cmd)
 	}
 
-	if m.transientStatus == nativeHistoryDivergenceStatusMessage {
+	if m.transientStatus != "" {
 		t.Fatalf("did not expect authoritative hydrate warning when reviewer status path already matches, got status=%q", m.transientStatus)
 	}
 	if got, want := len(m.transcriptEntries), 2; got != want {

--- a/cli/app/ui_runtime_adapter_part5_test.go
+++ b/cli/app/ui_runtime_adapter_part5_test.go
@@ -176,8 +176,8 @@ func TestApplyChatSnapshotShowsMixedParallelPendingStatesInLiveView(t *testing.T
 	if !strings.Contains(view, pendingSpinnerLine(0, "echo a")) {
 		t.Fatalf("expected unresolved tool to keep spinner in live view, got %q", view)
 	}
-	if !strings.Contains(view, "$ echo b") {
-		t.Fatalf("expected completed sibling to use final shell symbol in live view, got %q", view)
+	if !strings.Contains(view, "$  echo b") {
+		t.Fatalf("expected completed live shell command to align with two spaces after symbol, got %q", view)
 	}
 	if strings.Contains(view, pendingSpinnerLine(0, "echo b")) {
 		t.Fatalf("did not expect completed sibling to keep spinner in live view, got %q", view)

--- a/cli/app/ui_runtime_adapter_part6_test.go
+++ b/cli/app/ui_runtime_adapter_part6_test.go
@@ -5,7 +5,6 @@ import (
 	"builder/server/llm"
 	"builder/server/runtime"
 	"builder/shared/clientui"
-	"builder/shared/config"
 	"builder/shared/transcript"
 	tea "github.com/charmbracelet/bubbletea"
 	"strings"
@@ -293,14 +292,10 @@ func TestProjectedUserMessageFlushedDoesNotDeferWhenUIIsIdleDespiteStaleLiveAssi
 }
 
 func TestDeferredNativeReplayFlushesAutomaticallyOnDetailExit(t *testing.T) {
-	policies := []config.TUIAlternateScreenPolicy{
-		config.TUIAlternateScreenNever,
-		config.TUIAlternateScreenAuto,
-	}
+	policies := []string{"fixed-detail-alt-screen"}
 	for _, policy := range policies {
-		t.Run(string(policy), func(t *testing.T) {
+		t.Run(policy, func(t *testing.T) {
 			m := newProjectedStaticUIModel(
-				WithUIAlternateScreenPolicy(policy),
 				WithUIInitialTranscript([]UITranscriptEntry{{Role: "assistant", Text: "seed"}}),
 			)
 
@@ -428,14 +423,10 @@ func TestBackgroundUpdatedWithSuppressedNoticeSkipsTransientStatus(t *testing.T)
 }
 
 func TestDeferredNativeReplayFlushesBackgroundNoticeOnDetailExit(t *testing.T) {
-	policies := []config.TUIAlternateScreenPolicy{
-		config.TUIAlternateScreenNever,
-		config.TUIAlternateScreenAuto,
-	}
+	policies := []string{"fixed-detail-alt-screen"}
 	for _, policy := range policies {
-		t.Run(string(policy), func(t *testing.T) {
+		t.Run(policy, func(t *testing.T) {
 			m := newProjectedStaticUIModel(
-				WithUIAlternateScreenPolicy(policy),
 				WithUIInitialTranscript([]UITranscriptEntry{{Role: "assistant", Text: "seed"}}),
 			)
 

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -235,6 +235,10 @@ func (c *sessionRuntimeClient) LoadTranscriptPage(req clientui.TranscriptPageReq
 	return c.refreshTranscriptPageSync(req, uiRuntimeHydrationReadTimeout)
 }
 
+func (c *sessionRuntimeClient) RefreshCommittedTranscriptSuffix(req clientui.CommittedTranscriptSuffixRequest) (clientui.CommittedTranscriptSuffix, error) {
+	return c.refreshCommittedTranscriptSuffixSync(req, uiRuntimeHydrationReadTimeout)
+}
+
 func (c *sessionRuntimeClient) Status() clientui.RuntimeStatus {
 	return c.MainView().Status
 }
@@ -366,6 +370,40 @@ func (c *sessionRuntimeClient) refreshTranscriptPageSync(req clientui.Transcript
 	return page, nil
 }
 
+func (c *sessionRuntimeClient) refreshCommittedTranscriptSuffixSync(req clientui.CommittedTranscriptSuffixRequest, timeout time.Duration) (clientui.CommittedTranscriptSuffix, error) {
+	req = clientui.NormalizeCommittedTranscriptSuffixRequest(req)
+	suffixClient, ok := c.reads.(client.SessionCommittedTranscriptSuffixClient)
+	if !ok {
+		page, err := c.refreshTranscriptPageSync(clientui.TranscriptPageRequest{Offset: req.AfterEntryCount, Limit: req.Limit}, timeout)
+		if err != nil {
+			return clientui.CommittedTranscriptSuffix{SessionID: c.sessionID}, err
+		}
+		return committedTranscriptSuffixFromPage(page), nil
+	}
+	ctx, cancel := c.readContext(timeout)
+	defer cancel()
+	resp, err := suffixClient.GetSessionCommittedTranscriptSuffix(ctx, serverapi.SessionCommittedTranscriptSuffixRequest{
+		SessionID:       c.sessionID,
+		AfterEntryCount: req.AfterEntryCount,
+		Limit:           req.Limit,
+	})
+	c.notifyConnectionState(err)
+	if err != nil {
+		return clientui.CommittedTranscriptSuffix{SessionID: c.sessionID}, err
+	}
+	suffix := resp.Suffix
+	if suffix.SessionID == "" {
+		suffix.SessionID = c.sessionID
+	}
+	c.patchMainView(func(view *clientui.RuntimeMainView) {
+		view.Session.Transcript = clientui.TranscriptMetadata{
+			Revision:            suffix.Revision,
+			CommittedEntryCount: suffix.CommittedEntryCount,
+		}
+	})
+	return suffix, nil
+}
+
 func (c *sessionRuntimeClient) transcriptDiagnosticsEnabled() bool {
 	if c == nil {
 		return false
@@ -438,6 +476,38 @@ func transcriptPageFromSessionView(view clientui.RuntimeSessionView) clientui.Tr
 		NextOffset:            nextOffset,
 		HasMore:               hasMore,
 		Entries:               cloneTranscriptEntries(view.Chat.Entries),
+	}
+}
+
+func transcriptPageFromCommittedTranscriptSuffix(suffix clientui.CommittedTranscriptSuffix) clientui.TranscriptPage {
+	nextOffset := 0
+	if suffix.HasMore {
+		nextOffset = suffix.NextEntryCount
+	}
+	return clientui.TranscriptPage{
+		SessionID:             suffix.SessionID,
+		SessionName:           suffix.SessionName,
+		ConversationFreshness: suffix.ConversationFreshness,
+		Revision:              suffix.Revision,
+		TotalEntries:          suffix.CommittedEntryCount,
+		Offset:                suffix.StartEntryCount,
+		NextOffset:            nextOffset,
+		HasMore:               suffix.HasMore,
+		Entries:               cloneTranscriptEntries(suffix.Entries),
+	}
+}
+
+func committedTranscriptSuffixFromPage(page clientui.TranscriptPage) clientui.CommittedTranscriptSuffix {
+	return clientui.CommittedTranscriptSuffix{
+		SessionID:             page.SessionID,
+		SessionName:           page.SessionName,
+		ConversationFreshness: page.ConversationFreshness,
+		Revision:              page.Revision,
+		CommittedEntryCount:   page.TotalEntries,
+		StartEntryCount:       page.Offset,
+		NextEntryCount:        page.Offset + len(page.Entries),
+		HasMore:               page.HasMore,
+		Entries:               cloneTranscriptEntries(page.Entries),
 	}
 }
 

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -33,9 +33,10 @@ type sessionRuntimeClient struct {
 	connectionStateObserver func(error)
 	leaseRecoveryWarning    func(string, clientui.EntryVisibility)
 
-	mu          sync.RWMutex
-	mainView    clientui.RuntimeMainView
-	hasMainView bool
+	mu                   sync.RWMutex
+	mainView             clientui.RuntimeMainView
+	hasMainView          bool
+	suffixRPCUnsupported bool
 }
 
 func newRuntimeClient(sessionID string, reads client.SessionViewClient, controls client.RuntimeControlClient) clientui.RuntimeClient {
@@ -268,6 +269,13 @@ func (c *sessionRuntimeClient) cachedMainView() (clientui.RuntimeMainView, bool)
 	return view, true
 }
 
+func (c *sessionRuntimeClient) CachedMainView() (clientui.RuntimeMainView, bool) {
+	if c == nil {
+		return clientui.RuntimeMainView{}, false
+	}
+	return c.cachedMainView()
+}
+
 func (c *sessionRuntimeClient) storeMainView(view clientui.RuntimeMainView) clientui.RuntimeMainView {
 	if view.Session.SessionID == "" {
 		view.Session.SessionID = c.sessionID
@@ -372,13 +380,19 @@ func (c *sessionRuntimeClient) refreshTranscriptPageSync(req clientui.Transcript
 
 func (c *sessionRuntimeClient) refreshCommittedTranscriptSuffixSync(req clientui.CommittedTranscriptSuffixRequest, timeout time.Duration) (clientui.CommittedTranscriptSuffix, error) {
 	req = clientui.NormalizeCommittedTranscriptSuffixRequest(req)
-	suffixClient, ok := c.reads.(client.SessionCommittedTranscriptSuffixClient)
-	if !ok {
+	fallbackToPage := func() (clientui.CommittedTranscriptSuffix, error) {
 		page, err := c.refreshTranscriptPageSync(clientui.TranscriptPageRequest{Offset: req.AfterEntryCount, Limit: req.Limit}, timeout)
 		if err != nil {
 			return clientui.CommittedTranscriptSuffix{SessionID: c.sessionID}, err
 		}
 		return committedTranscriptSuffixFromPage(page), nil
+	}
+	suffixClient, ok := c.reads.(client.SessionCommittedTranscriptSuffixClient)
+	if !ok {
+		return fallbackToPage()
+	}
+	if c.committedSuffixRPCUnsupported() {
+		return fallbackToPage()
 	}
 	ctx, cancel := c.readContext(timeout)
 	defer cancel()
@@ -389,6 +403,10 @@ func (c *sessionRuntimeClient) refreshCommittedTranscriptSuffixSync(req clientui
 	})
 	c.notifyConnectionState(err)
 	if err != nil {
+		if errors.Is(err, serverapi.ErrMethodNotFound) {
+			c.setCommittedSuffixRPCUnsupported()
+			return fallbackToPage()
+		}
 		return clientui.CommittedTranscriptSuffix{SessionID: c.sessionID}, err
 	}
 	suffix := resp.Suffix
@@ -402,6 +420,18 @@ func (c *sessionRuntimeClient) refreshCommittedTranscriptSuffixSync(req clientui
 		}
 	})
 	return suffix, nil
+}
+
+func (c *sessionRuntimeClient) committedSuffixRPCUnsupported() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.suffixRPCUnsupported
+}
+
+func (c *sessionRuntimeClient) setCommittedSuffixRPCUnsupported() {
+	c.mu.Lock()
+	c.suffixRPCUnsupported = true
+	c.mu.Unlock()
 }
 
 func (c *sessionRuntimeClient) transcriptDiagnosticsEnabled() bool {

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -28,8 +28,11 @@ type countingSessionViewClient struct {
 	view              clientui.RuntimeMainView
 	page              clientui.TranscriptPage
 	suffix            clientui.CommittedTranscriptSuffix
+	suffixErr         error
 	pageForRequest    func(serverapi.SessionTranscriptPageRequest) clientui.TranscriptPage
 	count             atomic.Int32
+	pageCount         atomic.Int32
+	suffixCount       atomic.Int32
 	lastTranscriptReq serverapi.SessionTranscriptPageRequest
 	lastSuffixReq     serverapi.SessionCommittedTranscriptSuffixRequest
 }
@@ -43,6 +46,7 @@ func (c *countingSessionViewClient) GetSessionTranscriptPage(ctx context.Context
 	_ = ctx
 	c.lastTranscriptReq = req
 	c.count.Add(1)
+	c.pageCount.Add(1)
 	if c.pageForRequest != nil {
 		return serverapi.SessionTranscriptPageResponse{Transcript: c.pageForRequest(req)}, nil
 	}
@@ -53,6 +57,10 @@ func (c *countingSessionViewClient) GetSessionCommittedTranscriptSuffix(ctx cont
 	_ = ctx
 	c.lastSuffixReq = req
 	c.count.Add(1)
+	c.suffixCount.Add(1)
+	if c.suffixErr != nil {
+		return serverapi.SessionCommittedTranscriptSuffixResponse{}, c.suffixErr
+	}
 	return serverapi.SessionCommittedTranscriptSuffixResponse{Suffix: c.suffix}, nil
 }
 
@@ -261,6 +269,52 @@ func TestRuntimeClientRefreshCommittedTranscriptSuffixUsesSessionViewSuffixAPI(t
 	cached := runtimeClient.SessionView()
 	if cached.Transcript.Revision != 12 || cached.Transcript.CommittedEntryCount != 5 {
 		t.Fatalf("cached transcript metadata = %+v, want revision 12 count 5", cached.Transcript)
+	}
+}
+
+func TestRuntimeClientCommittedSuffixDisablesUnsupportedRPC(t *testing.T) {
+	reads := &countingSessionViewClient{
+		page: clientui.TranscriptPage{
+			SessionID:    "session-1",
+			Revision:     7,
+			TotalEntries: 4,
+			Offset:       2,
+			Entries:      []clientui.ChatEntry{{Role: "assistant", Text: "page fallback"}},
+		},
+		suffixErr: serverapi.ErrMethodNotFound,
+	}
+	controls := sharedclient.NewLoopbackRuntimeControlClient(runtimecontrol.NewService(nil, nil))
+	runtimeClient := newUIRuntimeClientWithReads("session-1", reads, controls).(*sessionRuntimeClient)
+	req := clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 2, Limit: 1}
+
+	suffix, err := runtimeClient.RefreshCommittedTranscriptSuffix(req)
+	if err != nil {
+		t.Fatalf("refresh committed transcript suffix fallback: %v", err)
+	}
+	if suffix.StartEntryCount != 2 || suffix.NextEntryCount != 3 || suffix.Entries[0].Text != "page fallback" {
+		t.Fatalf("unexpected fallback suffix: %+v", suffix)
+	}
+	if reads.suffixCount.Load() != 1 || reads.pageCount.Load() != 1 {
+		t.Fatalf("first refresh counts suffix=%d page=%d, want 1/1", reads.suffixCount.Load(), reads.pageCount.Load())
+	}
+
+	reads.suffixErr = nil
+	reads.suffix = clientui.CommittedTranscriptSuffix{
+		SessionID:           "session-1",
+		CommittedEntryCount: 4,
+		StartEntryCount:     2,
+		NextEntryCount:      3,
+		Entries:             []clientui.ChatEntry{{Role: "assistant", Text: "rpc should stay disabled"}},
+	}
+	suffix, err = runtimeClient.RefreshCommittedTranscriptSuffix(req)
+	if err != nil {
+		t.Fatalf("second refresh committed transcript suffix fallback: %v", err)
+	}
+	if suffix.Entries[0].Text != "page fallback" {
+		t.Fatalf("expected cached unsupported capability to keep page fallback, got %+v", suffix)
+	}
+	if reads.suffixCount.Load() != 1 || reads.pageCount.Load() != 2 {
+		t.Fatalf("second refresh counts suffix=%d page=%d, want 1/2", reads.suffixCount.Load(), reads.pageCount.Load())
 	}
 }
 

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"builder/cli/tui"
 	"builder/server/llm"
 	"builder/server/registry"
 	"builder/server/runtime"
@@ -14,18 +15,23 @@ import (
 	"builder/shared/toolspec"
 	"context"
 	"encoding/json"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 type countingSessionViewClient struct {
 	view              clientui.RuntimeMainView
 	page              clientui.TranscriptPage
+	suffix            clientui.CommittedTranscriptSuffix
 	pageForRequest    func(serverapi.SessionTranscriptPageRequest) clientui.TranscriptPage
 	count             atomic.Int32
 	lastTranscriptReq serverapi.SessionTranscriptPageRequest
+	lastSuffixReq     serverapi.SessionCommittedTranscriptSuffixRequest
 }
 
 func (c *countingSessionViewClient) GetSessionMainView(context.Context, serverapi.SessionMainViewRequest) (serverapi.SessionMainViewResponse, error) {
@@ -41,6 +47,13 @@ func (c *countingSessionViewClient) GetSessionTranscriptPage(ctx context.Context
 		return serverapi.SessionTranscriptPageResponse{Transcript: c.pageForRequest(req)}, nil
 	}
 	return serverapi.SessionTranscriptPageResponse{Transcript: c.page}, nil
+}
+
+func (c *countingSessionViewClient) GetSessionCommittedTranscriptSuffix(ctx context.Context, req serverapi.SessionCommittedTranscriptSuffixRequest) (serverapi.SessionCommittedTranscriptSuffixResponse, error) {
+	_ = ctx
+	c.lastSuffixReq = req
+	c.count.Add(1)
+	return serverapi.SessionCommittedTranscriptSuffixResponse{Suffix: c.suffix}, nil
 }
 
 func (*countingSessionViewClient) GetRun(context.Context, serverapi.RunGetRequest) (serverapi.RunGetResponse, error) {
@@ -213,6 +226,575 @@ func TestRuntimeClientLoadTranscriptPageLetsServerApplyDefaultWindow(t *testing.
 	}
 	if reads.lastTranscriptReq.Window != "" {
 		t.Fatalf("window = %q, want empty server-default request", reads.lastTranscriptReq.Window)
+	}
+}
+
+func TestRuntimeClientRefreshCommittedTranscriptSuffixUsesSessionViewSuffixAPI(t *testing.T) {
+	reads := &countingSessionViewClient{
+		suffix: clientui.CommittedTranscriptSuffix{
+			SessionID:             "session-1",
+			Revision:              12,
+			CommittedEntryCount:   5,
+			StartEntryCount:       2,
+			NextEntryCount:        4,
+			HasMore:               true,
+			Entries:               []clientui.ChatEntry{{Role: "assistant", Text: "reply-002"}, {Role: "assistant", Text: "reply-003"}},
+			ConversationFreshness: clientui.ConversationFreshnessEstablished,
+		},
+	}
+	controls := sharedclient.NewLoopbackRuntimeControlClient(runtimecontrol.NewService(nil, nil))
+	runtimeClient := newUIRuntimeClientWithReads("session-1", reads, controls).(*sessionRuntimeClient)
+
+	suffix, err := runtimeClient.RefreshCommittedTranscriptSuffix(clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 2, Limit: 2})
+	if err != nil {
+		t.Fatalf("refresh committed transcript suffix: %v", err)
+	}
+	if reads.lastSuffixReq.SessionID != "session-1" || reads.lastSuffixReq.AfterEntryCount != 2 || reads.lastSuffixReq.Limit != 2 {
+		t.Fatalf("unexpected suffix request: %+v", reads.lastSuffixReq)
+	}
+	if reads.lastTranscriptReq != (serverapi.SessionTranscriptPageRequest{}) {
+		t.Fatalf("did not expect transcript page request, got %+v", reads.lastTranscriptReq)
+	}
+	if suffix.StartEntryCount != 2 || suffix.NextEntryCount != 4 || len(suffix.Entries) != 2 {
+		t.Fatalf("unexpected suffix response: %+v", suffix)
+	}
+	cached := runtimeClient.SessionView()
+	if cached.Transcript.Revision != 12 || cached.Transcript.CommittedEntryCount != 5 {
+		t.Fatalf("cached transcript metadata = %+v, want revision 12 count 5", cached.Transcript)
+	}
+}
+
+func TestStartupRuntimeTranscriptUsesCommittedSuffixBounding(t *testing.T) {
+	reads := &countingSessionViewClient{
+		view: clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{
+			SessionID: "session-1",
+			Transcript: clientui.TranscriptMetadata{
+				Revision:            10,
+				CommittedEntryCount: 600,
+			},
+		}},
+		suffix: clientui.CommittedTranscriptSuffix{
+			SessionID:           "session-1",
+			Revision:            10,
+			CommittedEntryCount: 600,
+			StartEntryCount:     100,
+			NextEntryCount:      101,
+			HasMore:             true,
+			Entries:             []clientui.ChatEntry{{Role: "assistant", Text: "reply-100"}},
+		},
+	}
+	controls := sharedclient.NewLoopbackRuntimeControlClient(runtimecontrol.NewService(nil, nil))
+	runtimeClient := newUIRuntimeClientWithReads("session-1", reads, controls)
+
+	model := NewProjectedUIModel(runtimeClient, closedProjectedRuntimeEvents(), closedAskEvents()).(*uiModel)
+
+	if reads.lastSuffixReq.AfterEntryCount != 100 {
+		t.Fatalf("startup suffix after_entry_count = %d, want 100", reads.lastSuffixReq.AfterEntryCount)
+	}
+	if reads.lastSuffixReq.Limit != clientui.MaxCommittedTranscriptSuffixLimit {
+		t.Fatalf("startup suffix limit = %d, want %d", reads.lastSuffixReq.Limit, clientui.MaxCommittedTranscriptSuffixLimit)
+	}
+	if reads.lastTranscriptReq != (serverapi.SessionTranscriptPageRequest{}) {
+		t.Fatalf("did not expect startup seed to use transcript page request, got %+v", reads.lastTranscriptReq)
+	}
+	if model.transcriptBaseOffset != 100 || model.transcriptTotalEntries != 600 {
+		t.Fatalf("startup transcript metadata base=%d total=%d, want base 100 total 600", model.transcriptBaseOffset, model.transcriptTotalEntries)
+	}
+	if got := len(model.transcriptEntries); got != 1 {
+		t.Fatalf("startup transcript entries = %d, want 1", got)
+	}
+	if model.transcriptEntries[0].Text != "reply-100" {
+		t.Fatalf("startup transcript entry = %+v, want reply-100", model.transcriptEntries[0])
+	}
+}
+
+func TestWidthResizeReplayFetchesCommittedSuffixBeforeFullReplay(t *testing.T) {
+	reads := &countingSessionViewClient{
+		view: clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{
+			SessionID: "session-1",
+			Transcript: clientui.TranscriptMetadata{
+				Revision:            10,
+				CommittedEntryCount: 3,
+			},
+		}},
+		suffix: clientui.CommittedTranscriptSuffix{
+			SessionID:           "session-1",
+			Revision:            10,
+			CommittedEntryCount: 3,
+			StartEntryCount:     0,
+			NextEntryCount:      1,
+			HasMore:             true,
+			Entries:             []clientui.ChatEntry{{Role: "assistant", Text: "startup"}},
+		},
+	}
+	controls := sharedclient.NewLoopbackRuntimeControlClient(runtimecontrol.NewService(nil, nil))
+	runtimeClient := newUIRuntimeClientWithReads("session-1", reads, controls)
+	model := NewProjectedUIModel(runtimeClient, closedProjectedRuntimeEvents(), closedAskEvents()).(*uiModel)
+
+	next, startupCmd := model.Update(tea.WindowSizeMsg{Width: 100, Height: 20})
+	model = next.(*uiModel)
+	if startupCmd != nil {
+		if flush, ok := startupCmd().(nativeHistoryFlushMsg); ok {
+			next, _ = model.Update(flush)
+			model = next.(*uiModel)
+		}
+	}
+	reads.suffix = clientui.CommittedTranscriptSuffix{
+		SessionID:           "session-1",
+		Revision:            11,
+		CommittedEntryCount: 3,
+		StartEntryCount:     0,
+		NextEntryCount:      3,
+		Entries:             []clientui.ChatEntry{{Role: "assistant", Text: "fresh-0"}, {Role: "assistant", Text: "fresh-1"}, {Role: "assistant", Text: "fresh-2"}},
+	}
+
+	next, resizeCmd := model.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
+	model = next.(*uiModel)
+	if resizeCmd == nil {
+		t.Fatal("expected resize debounce command")
+	}
+	model.nativeResizeReplayAt = time.Time{}
+	next, fetchCmd := model.Update(nativeResizeReplayMsg{token: model.nativeResizeReplayToken})
+	model = next.(*uiModel)
+	if fetchCmd == nil {
+		t.Fatal("expected resize replay to fetch committed suffix")
+	}
+	refresh, ok := fetchCmd().(nativeResizeTranscriptSuffixRefreshedMsg)
+	if !ok {
+		t.Fatalf("expected nativeResizeTranscriptSuffixRefreshedMsg, got %T", fetchCmd())
+	}
+	if reads.lastSuffixReq.AfterEntryCount != 0 || reads.lastSuffixReq.Limit != clientui.MaxCommittedTranscriptSuffixLimit {
+		t.Fatalf("unexpected resize suffix request: %+v", reads.lastSuffixReq)
+	}
+	next, replayCmd := model.Update(refresh)
+	model = next.(*uiModel)
+	msgs := collectCmdMessages(t, replayCmd)
+	foundFreshReplay := false
+	for _, msg := range msgs {
+		flush, ok := msg.(nativeHistoryFlushMsg)
+		if ok && strings.Contains(flush.Text, "fresh-0") && strings.Contains(flush.Text, "fresh-2") {
+			foundFreshReplay = true
+		}
+	}
+	if !foundFreshReplay {
+		t.Fatalf("expected full replay from refreshed suffix, got msgs=%+v", msgs)
+	}
+	if model.transcriptRevision != 11 || model.transcriptTotalEntries != 3 {
+		t.Fatalf("model transcript metadata revision=%d total=%d, want revision 11 total 3", model.transcriptRevision, model.transcriptTotalEntries)
+	}
+}
+
+func TestCommittedRuntimeEventPermanentOutputUsesCommittedSuffix(t *testing.T) {
+	reads := &countingSessionViewClient{
+		view: clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{
+			SessionID: "session-1",
+			Transcript: clientui.TranscriptMetadata{
+				Revision:            1,
+				CommittedEntryCount: 1,
+			},
+		}},
+		suffix: clientui.CommittedTranscriptSuffix{
+			SessionID:           "session-1",
+			Revision:            1,
+			CommittedEntryCount: 1,
+			StartEntryCount:     0,
+			NextEntryCount:      1,
+			Entries:             []clientui.ChatEntry{{Role: "assistant", Text: "seed"}},
+		},
+	}
+	controls := sharedclient.NewLoopbackRuntimeControlClient(runtimecontrol.NewService(nil, nil))
+	runtimeClient := newUIRuntimeClientWithReads("session-1", reads, controls)
+	model := NewProjectedUIModel(runtimeClient, closedProjectedRuntimeEvents(), closedAskEvents()).(*uiModel)
+	model.termWidth = 100
+	model.termHeight = 20
+	model.windowSizeKnown = true
+	reads.suffix = clientui.CommittedTranscriptSuffix{
+		SessionID:           "session-1",
+		Revision:            2,
+		CommittedEntryCount: 2,
+		StartEntryCount:     1,
+		NextEntryCount:      2,
+		Entries:             []clientui.ChatEntry{{Role: "assistant", Text: "authoritative suffix"}},
+	}
+
+	cmd := model.runtimeAdapter().handleProjectedRuntimeEvent(clientui.Event{
+		Kind:                       clientui.EventAssistantMessage,
+		StepID:                     "step-1",
+		CommittedTranscriptChanged: true,
+		TranscriptRevision:         2,
+		CommittedEntryCount:        2,
+		CommittedEntryStart:        1,
+		CommittedEntryStartSet:     true,
+		TranscriptEntries:          []clientui.ChatEntry{{Role: "assistant", Text: "stale event payload", Phase: string(llm.MessagePhaseFinal)}},
+	})
+	msgs := collectCmdMessages(t, cmd)
+	var refresh runtimeCommittedTranscriptSuffixRefreshedMsg
+	for _, msg := range msgs {
+		if typed, ok := msg.(runtimeCommittedTranscriptSuffixRefreshedMsg); ok {
+			refresh = typed
+		}
+	}
+	if refresh.token == 0 {
+		t.Fatalf("expected committed suffix refresh, got %+v", msgs)
+	}
+	if reads.lastSuffixReq.AfterEntryCount != 1 || reads.lastSuffixReq.Limit != 1 {
+		t.Fatalf("unexpected committed suffix request: %+v", reads.lastSuffixReq)
+	}
+	if strings.Contains(stripANSIAndTrimRight(model.view.OngoingSnapshot()), "stale event payload") {
+		t.Fatalf("event payload rendered before suffix response: %q", stripANSIAndTrimRight(model.view.OngoingSnapshot()))
+	}
+
+	next, applyCmd := model.Update(refresh)
+	model = next.(*uiModel)
+	_ = collectCmdMessages(t, applyCmd)
+	ongoing := stripANSIAndTrimRight(model.view.OngoingSnapshot())
+	if !strings.Contains(ongoing, "authoritative suffix") {
+		t.Fatalf("expected authoritative suffix rendered, got %q", ongoing)
+	}
+	if strings.Contains(ongoing, "stale event payload") {
+		t.Fatalf("event payload leaked into permanent output: %q", ongoing)
+	}
+}
+
+func TestCommittedSuffixRequestUsesDeliveryCursorNotLocalProjection(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.ongoingCommittedDelivery = newOngoingCommittedDeliveryCursor(2, 10)
+	for i := 0; i < 8; i++ {
+		m.transcriptEntries = append(m.transcriptEntries, tui.TranscriptEntry{Role: tui.TranscriptRoleAssistant, Text: "stale"})
+	}
+
+	req := committedTranscriptSuffixRequestForEvent(m, clientui.Event{
+		CommittedTranscriptChanged: true,
+		CommittedEntryCount:        5,
+		TranscriptEntries:          []clientui.ChatEntry{{Role: "assistant", Text: "committed"}},
+	})
+
+	if req.AfterEntryCount != 2 {
+		t.Fatalf("suffix request after_entry_count = %d, want delivery cursor 2", req.AfterEntryCount)
+	}
+	if req.Limit != 3 {
+		t.Fatalf("suffix request limit = %d, want committed gap 3", req.Limit)
+	}
+}
+
+func TestUserMessageFlushedAdvancesDeliveryCursorBeforeFollowingSuffix(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.ongoingCommittedDelivery = newOngoingCommittedDeliveryCursor(0, 1)
+
+	cmd := m.runtimeAdapter().handleProjectedRuntimeEvent(clientui.Event{
+		Kind:                       clientui.EventUserMessageFlushed,
+		CommittedTranscriptChanged: true,
+		CommittedEntryCount:        1,
+		TranscriptRevision:         2,
+		CommittedEntryStart:        0,
+		CommittedEntryStartSet:     true,
+		TranscriptEntries:          []clientui.ChatEntry{{Role: "user", Text: "prompt"}},
+	})
+	_ = collectCmdMessages(t, cmd)
+
+	if m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount != 1 {
+		t.Fatalf("user echo did not advance delivery cursor: %+v", m.ongoingCommittedDelivery)
+	}
+	req := committedTranscriptSuffixRequestForEvent(m, clientui.Event{
+		CommittedTranscriptChanged: true,
+		CommittedEntryCount:        2,
+		TranscriptRevision:         3,
+		TranscriptEntries:          []clientui.ChatEntry{{Role: "assistant", Text: "answer"}},
+	})
+	if req.AfterEntryCount != 1 {
+		t.Fatalf("following suffix after_entry_count = %d, want user echo cursor 1", req.AfterEntryCount)
+	}
+	if req.Limit != 1 {
+		t.Fatalf("following suffix limit = %d, want 1", req.Limit)
+	}
+}
+
+func TestCommittedSuffixAppendCursorAdvancesAfterNativeFlushAck(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.windowSizeKnown = true
+	m.termWidth = 100
+	m.termHeight = 20
+	m.ongoingCommittedDelivery = newOngoingCommittedDeliveryCursor(0, 1)
+
+	cmd := m.applyCommittedTranscriptSuffixAppend(clientui.CommittedTranscriptSuffix{
+		Revision:            2,
+		CommittedEntryCount: 1,
+		StartEntryCount:     0,
+		NextEntryCount:      1,
+		Entries:             []clientui.ChatEntry{{Role: "assistant", Text: "answer"}},
+	})
+	if cmd == nil {
+		t.Fatal("expected native flush command")
+	}
+	if m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount != 0 {
+		t.Fatalf("cursor advanced before native flush ack: %+v", m.ongoingCommittedDelivery)
+	}
+	msg, ok := cmd().(nativeHistoryFlushMsg)
+	if !ok {
+		t.Fatalf("expected nativeHistoryFlushMsg, got %T", cmd())
+	}
+	_ = m.handleNativeHistoryFlush(msg)
+	if m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount != 1 {
+		t.Fatalf("cursor did not advance after native flush ack: %+v", m.ongoingCommittedDelivery)
+	}
+}
+
+func TestCommittedSuffixDeliveryDoesNotAdvancePastUnresolvedToolTail(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.windowSizeKnown = true
+	m.termWidth = 100
+	m.termHeight = 20
+	m.transcriptEntries = []tui.TranscriptEntry{{Role: tui.TranscriptRoleUser, Text: "prompt"}}
+	m.transcriptTotalEntries = 1
+	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries, TotalEntries: 1})
+	m.rebaseNativeProjection(m.nativeCommittedProjection(m.transcriptEntries), 0, 1)
+	m.acceptNativeProjectionWithoutReplay(m.nativeProjection)
+	m.ongoingCommittedDelivery = newOngoingCommittedDeliveryCursor(1, 1)
+
+	cmd := m.applyCommittedTranscriptSuffixAppend(clientui.CommittedTranscriptSuffix{
+		Revision:            2,
+		CommittedEntryCount: 3,
+		StartEntryCount:     1,
+		NextEntryCount:      3,
+		Entries: []clientui.ChatEntry{
+			{Role: "tool_call", Text: "echo a", ToolCallID: "call_a", ToolCall: &clientui.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo a"}},
+			{Role: "tool_call", Text: "echo b", ToolCallID: "call_b", ToolCall: &clientui.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo b"}},
+		},
+	})
+	if cmd != nil {
+		for _, msg := range collectCmdMessages(t, cmd) {
+			if _, ok := msg.(nativeHistoryFlushMsg); ok {
+				t.Fatalf("did not expect unresolved tool calls to flush committed history, got %+v", msg)
+			}
+		}
+	}
+	if got := m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount; got != 1 {
+		t.Fatalf("cursor advanced past unresolved tools: got %d want 1", got)
+	}
+	if got := len(m.transcriptEntries); got != 3 {
+		t.Fatalf("transcript entries after unresolved suffix = %d, want 3", got)
+	}
+
+	cmd = m.applyCommittedTranscriptSuffixAppend(clientui.CommittedTranscriptSuffix{
+		Revision:            3,
+		CommittedEntryCount: 4,
+		StartEntryCount:     1,
+		NextEntryCount:      4,
+		Entries: []clientui.ChatEntry{
+			{Role: "tool_call", Text: "echo a", ToolCallID: "call_a", ToolCall: &clientui.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo a"}},
+			{Role: "tool_result_ok", Text: "out-a", ToolCallID: "call_a"},
+			{Role: "tool_call", Text: "echo b", ToolCallID: "call_b", ToolCall: &clientui.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo b"}},
+		},
+	})
+	if cmd == nil {
+		t.Fatal("expected completed tool prefix to flush")
+	}
+	flushes := collectCmdMessages(t, cmd)
+	foundFlush := false
+	for _, msg := range flushes {
+		flush, ok := msg.(nativeHistoryFlushMsg)
+		if !ok {
+			continue
+		}
+		foundFlush = true
+		if strings.Contains(stripANSIText(flush.Text), "echo b") {
+			t.Fatalf("unresolved sibling flushed as committed history: %q", stripANSIText(flush.Text))
+		}
+		_ = m.handleNativeHistoryFlush(flush)
+	}
+	if !foundFlush {
+		t.Fatalf("expected native flush for resolved tool prefix, got %+v", flushes)
+	}
+	if got := m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount; got != 3 {
+		t.Fatalf("cursor after resolved prefix flush = %d, want 3", got)
+	}
+	if got := len(m.transcriptEntries); got != 4 {
+		t.Fatalf("transcript entries after replacing pending tail = %d, want 4 (%+v)", got, m.transcriptEntries)
+	}
+	if m.transcriptEntries[1].ToolCallID != "call_a" || m.transcriptEntries[2].ToolCallID != "call_a" || m.transcriptEntries[3].ToolCallID != "call_b" {
+		t.Fatalf("pending tail replacement duplicated or reordered entries: %+v", m.transcriptEntries)
+	}
+
+	cmd = m.applyCommittedTranscriptSuffixAppend(clientui.CommittedTranscriptSuffix{
+		Revision:            4,
+		CommittedEntryCount: 5,
+		StartEntryCount:     3,
+		NextEntryCount:      5,
+		Entries: []clientui.ChatEntry{
+			{Role: "tool_call", Text: "echo b", ToolCallID: "call_b", ToolCall: &clientui.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo b"}},
+			{Role: "tool_result_ok", Text: "out-b", ToolCallID: "call_b"},
+		},
+	})
+	for _, msg := range collectCmdMessages(t, cmd) {
+		if flush, ok := msg.(nativeHistoryFlushMsg); ok {
+			_ = m.handleNativeHistoryFlush(flush)
+		}
+	}
+	if got := m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount; got != 5 {
+		t.Fatalf("cursor after final tool flush = %d, want 5", got)
+	}
+	if pending := tui.PendingOngoingEntries(m.transcriptEntries); len(pending) != 0 {
+		t.Fatalf("expected no pending live tool entries after all results, got %+v", pending)
+	}
+}
+
+func TestCommittedSuffixMultiToolDetailRoundTripLeavesNoLiveSpinnerAfterFinalResults(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.windowSizeKnown = true
+	m.termWidth = 100
+	m.termHeight = 20
+	m.transcriptEntries = []tui.TranscriptEntry{{Role: tui.TranscriptRoleUser, Text: "prompt"}}
+	m.transcriptTotalEntries = 1
+	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries, TotalEntries: 1})
+	m.rebaseNativeProjection(m.nativeCommittedProjection(m.transcriptEntries), 0, 1)
+	m.acceptNativeProjectionWithoutReplay(m.nativeProjection)
+	m.ongoingCommittedDelivery = newOngoingCommittedDeliveryCursor(1, 1)
+
+	_ = collectCmdMessages(t, m.applyCommittedTranscriptSuffixAppend(clientui.CommittedTranscriptSuffix{
+		Revision:            2,
+		CommittedEntryCount: 3,
+		StartEntryCount:     1,
+		NextEntryCount:      3,
+		Entries: []clientui.ChatEntry{
+			{Role: "tool_call", Text: "echo a", ToolCallID: "call_a", ToolCall: &clientui.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo a"}},
+			{Role: "tool_call", Text: "echo b", ToolCallID: "call_b", ToolCall: &clientui.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo b"}},
+		},
+	}))
+	if pending := tui.PendingOngoingEntries(m.transcriptEntries); len(pending) != 2 {
+		t.Fatalf("expected two pending tool calls after starts, got %+v", pending)
+	}
+
+	_ = collectCmdMessages(t, m.toggleTranscriptModeWithNativeReplay(false))
+	if m.view.Mode() != tui.ModeDetail {
+		t.Fatalf("mode = %q, want detail", m.view.Mode())
+	}
+
+	_ = collectCmdMessages(t, m.applyCommittedTranscriptSuffixAppend(clientui.CommittedTranscriptSuffix{
+		Revision:            3,
+		CommittedEntryCount: 4,
+		StartEntryCount:     1,
+		NextEntryCount:      4,
+		Entries: []clientui.ChatEntry{
+			{Role: "tool_call", Text: "echo a", ToolCallID: "call_a", ToolCall: &clientui.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo a"}},
+			{Role: "tool_result_ok", Text: "out-a", ToolCallID: "call_a"},
+			{Role: "tool_call", Text: "echo b", ToolCallID: "call_b", ToolCall: &clientui.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo b"}},
+		},
+	}))
+
+	for _, msg := range collectCmdMessages(t, m.toggleTranscriptModeWithNativeReplay(true)) {
+		if flush, ok := msg.(nativeHistoryFlushMsg); ok {
+			_ = m.handleNativeHistoryFlush(flush)
+		}
+	}
+	if m.view.Mode() != tui.ModeOngoing {
+		t.Fatalf("mode = %q, want ongoing", m.view.Mode())
+	}
+
+	for _, msg := range collectCmdMessages(t, m.applyCommittedTranscriptSuffixAppend(clientui.CommittedTranscriptSuffix{
+		Revision:            4,
+		CommittedEntryCount: 5,
+		StartEntryCount:     committedTranscriptTailEnd(m),
+		NextEntryCount:      5,
+		Entries: []clientui.ChatEntry{
+			{Role: "tool_call", Text: "echo a", ToolCallID: "call_a", ToolCall: &clientui.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo a"}},
+			{Role: "tool_result_ok", Text: "out-a", ToolCallID: "call_a"},
+			{Role: "tool_call", Text: "echo b", ToolCallID: "call_b", ToolCall: &clientui.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo b"}},
+			{Role: "tool_result_ok", Text: "out-b", ToolCallID: "call_b"},
+		},
+	})) {
+		if flush, ok := msg.(nativeHistoryFlushMsg); ok {
+			_ = m.handleNativeHistoryFlush(flush)
+		}
+	}
+
+	if pending := tui.PendingOngoingEntries(m.transcriptEntries); len(pending) != 0 {
+		t.Fatalf("expected no pending live tool entries after all results, got %+v", pending)
+	}
+	if view := stripANSIPreserve(m.View()); strings.Contains(view, pendingSpinnerFrameText(0)+" echo") || strings.Contains(view, pendingSpinnerFrameText(1)+" echo") {
+		t.Fatalf("did not expect live spinner after final tool results, got %q", view)
+	}
+	counts := map[string]int{}
+	for _, entry := range committedTranscriptEntriesForApp(m.transcriptEntries) {
+		if strings.TrimSpace(entry.ToolCallID) != "" {
+			counts[string(entry.Role)+":"+entry.ToolCallID]++
+		}
+	}
+	for _, key := range []string{"tool_call:call_a", "tool_result_ok:call_a", "tool_call:call_b", "tool_result_ok:call_b"} {
+		if counts[key] != 1 {
+			t.Fatalf("committed transcript row count %s = %d, want 1; entries=%+v", key, counts[key], m.transcriptEntries)
+		}
+	}
+}
+
+func TestCommittedSuffixRefreshedRequestsNextPageWhenCapped(t *testing.T) {
+	reads := &countingSessionViewClient{
+		suffix: clientui.CommittedTranscriptSuffix{
+			SessionID:           "session-1",
+			Revision:            3,
+			CommittedEntryCount: 900,
+			StartEntryCount:     500,
+			NextEntryCount:      750,
+			HasMore:             false,
+			Entries:             []clientui.ChatEntry{{Role: "assistant", Text: "next capped page"}},
+		},
+	}
+	runtimeClient := newUIRuntimeClientWithReads(
+		"session-1",
+		reads,
+		sharedclient.NewLoopbackRuntimeControlClient(runtimecontrol.NewService(nil, nil)),
+	)
+	m := newProjectedTestUIModel(runtimeClient, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.runtimeCommittedSuffixToken = 7
+
+	cmd := m.handleRuntimeCommittedTranscriptSuffixRefreshed(runtimeCommittedTranscriptSuffixRefreshedMsg{
+		token: 7,
+		req:   clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 0, Limit: clientui.MaxCommittedTranscriptSuffixLimit},
+		suffix: clientui.CommittedTranscriptSuffix{
+			SessionID:           "session-1",
+			Revision:            2,
+			CommittedEntryCount: 900,
+			StartEntryCount:     0,
+			NextEntryCount:      500,
+			HasMore:             true,
+			Entries:             []clientui.ChatEntry{{Role: "assistant", Text: "first capped page"}},
+		},
+	})
+	if cmd == nil {
+		t.Fatal("expected follow-up suffix request command")
+	}
+
+	var followUp runtimeCommittedTranscriptSuffixRefreshedMsg
+	found := false
+	for _, msg := range collectCmdMessages(t, cmd) {
+		typed, ok := msg.(runtimeCommittedTranscriptSuffixRefreshedMsg)
+		if !ok {
+			continue
+		}
+		followUp = typed
+		found = true
+	}
+	if !found {
+		t.Fatal("expected capped suffix to schedule a follow-up committed suffix request")
+	}
+	if followUp.req.AfterEntryCount != 500 {
+		t.Fatalf("follow-up after_entry_count = %d, want 500", followUp.req.AfterEntryCount)
+	}
+	if followUp.req.Limit != clientui.MaxCommittedTranscriptSuffixLimit {
+		t.Fatalf("follow-up limit = %d, want max %d", followUp.req.Limit, clientui.MaxCommittedTranscriptSuffixLimit)
+	}
+	if reads.lastSuffixReq.AfterEntryCount != 500 {
+		t.Fatalf("server follow-up after_entry_count = %d, want 500", reads.lastSuffixReq.AfterEntryCount)
+	}
+
+	nextCount := reads.count.Load()
+	stopCmd := m.handleRuntimeCommittedTranscriptSuffixRefreshed(followUp)
+	for _, msg := range collectCmdMessages(t, stopCmd) {
+		if _, ok := msg.(runtimeCommittedTranscriptSuffixRefreshedMsg); ok {
+			t.Fatalf("did not expect another suffix request after HasMore=false follow-up, got %+v", msg)
+		}
+	}
+	if got := reads.count.Load(); got != nextCount {
+		t.Fatalf("unexpected extra suffix request after HasMore=false follow-up: count=%d want %d", got, nextCount)
 	}
 }
 

--- a/cli/app/ui_runtime_control_test.go
+++ b/cli/app/ui_runtime_control_test.go
@@ -41,6 +41,7 @@ type runtimeControlFakeClient struct {
 	discardQueuedText      string
 	discardQueuedCount     int
 	recordedPromptHistory  string
+	refreshMainViewCalls   int
 	err                    error
 	appendErr              error
 	shouldCompactErr       error
@@ -66,6 +67,7 @@ func (f *runtimeControlFakeClient) MainView() clientui.RuntimeMainView {
 	return clientui.RuntimeMainView{Status: f.status, Session: f.sessionView}
 }
 func (f *runtimeControlFakeClient) RefreshMainView() (clientui.RuntimeMainView, error) {
+	f.refreshMainViewCalls++
 	return f.MainView(), f.err
 }
 func (f *runtimeControlFakeClient) Transcript() clientui.TranscriptPage {

--- a/cli/app/ui_runtime_reducer.go
+++ b/cli/app/ui_runtime_reducer.go
@@ -52,6 +52,10 @@ func (r uiRuntimeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		cmd := m.handleRuntimeTranscriptRefreshed(msg)
 		m.syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
+	case runtimeCommittedTranscriptSuffixRefreshedMsg:
+		cmd := m.handleRuntimeCommittedTranscriptSuffixRefreshed(msg)
+		m.syncViewport()
+		return handledUIFeatureUpdate(m, cmd)
 	case runtimeTranscriptRetryMsg:
 		if msg.token != m.runtimeTranscriptRetry {
 			m.syncViewport()

--- a/cli/app/ui_runtime_status.go
+++ b/cli/app/ui_runtime_status.go
@@ -43,6 +43,30 @@ func (m *uiModel) runtimeStatus() clientui.RuntimeStatus {
 	return status
 }
 
+func (m *uiModel) cachedRuntimeStatus() clientui.RuntimeStatus {
+	client := m.runtimeClient()
+	view := clientui.RuntimeMainView{}
+	if cached, ok := client.(interface {
+		CachedMainView() (clientui.RuntimeMainView, bool)
+	}); ok {
+		if cachedView, hasCached := cached.CachedMainView(); hasCached {
+			view = cachedView
+		}
+	} else if client != nil {
+		view = client.MainView()
+	} else {
+		view = clientui.RuntimeMainView{
+			Status:  m.localRuntimeStatus(),
+			Session: m.localRuntimeSessionView(),
+		}
+	}
+	status := view.Status
+	if m.runtimeContextUsageAppliesTo(view.Session.SessionID) {
+		status.ContextUsage = m.runtimeContextUsage
+	}
+	return status
+}
+
 func (m *uiModel) refreshRuntimeStatus() clientui.RuntimeStatus {
 	view := m.refreshRuntimeMainView()
 	status := view.Status

--- a/cli/app/ui_runtime_status.go
+++ b/cli/app/ui_runtime_status.go
@@ -125,11 +125,35 @@ func (m *uiModel) runtimeTranscript() clientui.TranscriptPage {
 
 func (m *uiModel) startupRuntimeTranscript() clientui.TranscriptPage {
 	if client := m.runtimeClient(); client != nil {
+		if suffixClient, ok := client.(interface {
+			RefreshCommittedTranscriptSuffix(clientui.CommittedTranscriptSuffixRequest) (clientui.CommittedTranscriptSuffix, error)
+		}); ok {
+			suffix, err := suffixClient.RefreshCommittedTranscriptSuffix(m.startupCommittedTranscriptSuffixRequest())
+			if err == nil {
+				m.observeRuntimeRequestResult(nil)
+				return transcriptPageFromCommittedTranscriptSuffix(suffix)
+			}
+			m.observeRuntimeRequestResult(err)
+			return m.localRuntimeTranscript()
+		}
 		if _, ok := client.(*sessionRuntimeClient); ok {
 			return m.refreshRuntimeTranscript()
 		}
 	}
 	return m.runtimeTranscript()
+}
+
+func (m *uiModel) startupCommittedTranscriptSuffixRequest() clientui.CommittedTranscriptSuffixRequest {
+	committedCount := 0
+	if m != nil {
+		committedCount = m.runtimeMainView().Session.Transcript.CommittedEntryCount
+	}
+	limit := clientui.MaxCommittedTranscriptSuffixLimit
+	after := committedCount - limit
+	if after < 0 {
+		after = 0
+	}
+	return clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: after, Limit: limit}
 }
 
 func (m *uiModel) refreshRuntimeTranscript() clientui.TranscriptPage {

--- a/cli/app/ui_runtime_sync.go
+++ b/cli/app/ui_runtime_sync.go
@@ -44,6 +44,25 @@ func (m *uiModel) requestRuntimeCommittedConversationSync() tea.Cmd {
 	return m.startRuntimeTranscriptPageRequest(m.transcriptRequestForCurrentMode(), false, runtimeTranscriptSyncCauseCommittedConversation, clientui.TranscriptRecoveryCauseNone)
 }
 
+func (m *uiModel) requestRuntimeCommittedTranscriptSuffix(req clientui.CommittedTranscriptSuffixRequest) tea.Cmd {
+	if !m.hasRuntimeClient() {
+		return nil
+	}
+	client, ok := m.runtimeClient().(interface {
+		RefreshCommittedTranscriptSuffix(clientui.CommittedTranscriptSuffixRequest) (clientui.CommittedTranscriptSuffix, error)
+	})
+	if !ok {
+		return nil
+	}
+	req = clientui.NormalizeCommittedTranscriptSuffixRequest(req)
+	m.runtimeCommittedSuffixToken++
+	token := m.runtimeCommittedSuffixToken
+	return func() tea.Msg {
+		suffix, err := client.RefreshCommittedTranscriptSuffix(req)
+		return runtimeCommittedTranscriptSuffixRefreshedMsg{token: token, req: req, suffix: suffix, err: err}
+	}
+}
+
 func (m *uiModel) requestRuntimeCommittedGapSync() tea.Cmd {
 	if !m.hasRuntimeClient() {
 		return nil
@@ -228,6 +247,27 @@ func (m *uiModel) handleRuntimeTranscriptRefreshed(msg runtimeTranscriptRefreshe
 	m.logf("ui.runtime.transcript.repeat_after_dirty token=%d sync_cause=%s", msg.token, runtimeTranscriptSyncCauseDirtyFollowUp)
 	followUpRecoveryCause := m.runtimeTranscriptDirtyRecoveryCause
 	return sequenceCmds(applyCmd, m.requestRuntimeDirtyFollowUpTranscriptSync(followUpRecoveryCause))
+}
+
+func (m *uiModel) handleRuntimeCommittedTranscriptSuffixRefreshed(msg runtimeCommittedTranscriptSuffixRefreshedMsg) tea.Cmd {
+	if msg.token != m.runtimeCommittedSuffixToken {
+		return nil
+	}
+	if msg.err != nil {
+		m.observeRuntimeRequestResult(msg.err)
+		m.logf("ui.runtime.committed_suffix err=%q after_entry_count=%d limit=%d", msg.err.Error(), msg.req.AfterEntryCount, msg.req.Limit)
+		return m.requestRuntimeCommittedConversationSync()
+	}
+	m.observeRuntimeRequestResult(nil)
+	applyCmd := m.applyCommittedTranscriptSuffixAppend(msg.suffix)
+	if !msg.suffix.HasMore {
+		return applyCmd
+	}
+	nextReq := clientui.NormalizeCommittedTranscriptSuffixRequest(clientui.CommittedTranscriptSuffixRequest{
+		AfterEntryCount: msg.suffix.NextEntryCount,
+		Limit:           msg.req.Limit,
+	})
+	return sequenceCmds(applyCmd, m.requestRuntimeCommittedTranscriptSuffix(nextReq))
 }
 
 func (m *uiModel) flushQueuedInputsAfterHydration() tea.Cmd {

--- a/cli/app/ui_scroll_keys_test.go
+++ b/cli/app/ui_scroll_keys_test.go
@@ -9,7 +9,6 @@ import (
 	"builder/cli/tui"
 	"builder/server/runtime"
 	"builder/shared/clientui"
-	"builder/shared/config"
 	"builder/shared/transcript"
 	"builder/shared/uiglyphs"
 
@@ -616,110 +615,99 @@ func TestRollbackForkSubmissionUsesPagedDetailAbsoluteIndex(t *testing.T) {
 	}
 }
 
-func TestRollbackTransitionsByAltScreenPolicy(t *testing.T) {
-	tests := []struct {
-		name       string
-		policy     config.TUIAlternateScreenPolicy
-		altOnEntry bool
-	}{
-		{name: "auto", policy: config.TUIAlternateScreenAuto, altOnEntry: true},
-		{name: "never", policy: config.TUIAlternateScreenNever, altOnEntry: false},
-	}
+func TestRollbackTransitionsUseFixedDetailAltScreen(t *testing.T) {
+	altOnEntry := true
 
-	for _, tt := range tests {
-		t.Run(tt.name+"/ongoing_to_picker_to_edit_to_picker", func(t *testing.T) {
-			m := newProjectedStaticUIModel(
-				WithUIAlternateScreenPolicy(tt.policy),
-				WithUIInitialTranscript([]UITranscriptEntry{
-					{Role: "user", Text: "u1"},
-					{Role: "assistant", Text: "a1"},
-					{Role: "user", Text: "u2"},
-				}),
-			)
-			m.termWidth = 80
-			m.termHeight = 10
-			m.syncViewport()
+	t.Run("ongoing_to_picker_to_edit_to_picker", func(t *testing.T) {
+		m := newProjectedStaticUIModel(
+			WithUIInitialTranscript([]UITranscriptEntry{
+				{Role: "user", Text: "u1"},
+				{Role: "assistant", Text: "a1"},
+				{Role: "user", Text: "u2"},
+			}),
+		)
+		m.termWidth = 80
+		m.termHeight = 10
+		m.syncViewport()
 
-			m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyEsc})
-			next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-			m = next.(*uiModel)
-			if cmd == nil {
-				t.Fatal("expected picker entry transition command")
-			}
-			if !testRollbackSelecting(m) || m.view.Mode() != tui.ModeDetail || m.altScreenActive != tt.altOnEntry {
-				t.Fatalf("unexpected picker entry state: selecting=%t mode=%q alt=%t", testRollbackSelecting(m), m.view.Mode(), m.altScreenActive)
-			}
-			m = updateUIModel(t, m, tea.MouseMsg{Button: tea.MouseButtonWheelUp})
-			if testRollbackSelection(m) != 1 {
-				t.Fatalf("expected mouse wheel ignored while selecting, got selection %d", testRollbackSelection(m))
-			}
+		m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+		next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		m = next.(*uiModel)
+		if cmd == nil {
+			t.Fatal("expected picker entry transition command")
+		}
+		if !testRollbackSelecting(m) || m.view.Mode() != tui.ModeDetail || m.altScreenActive != altOnEntry {
+			t.Fatalf("unexpected picker entry state: selecting=%t mode=%q alt=%t", testRollbackSelecting(m), m.view.Mode(), m.altScreenActive)
+		}
+		m = updateUIModel(t, m, tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+		if testRollbackSelection(m) != 1 {
+			t.Fatalf("expected mouse wheel ignored while selecting, got selection %d", testRollbackSelection(m))
+		}
 
-			next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-			m = next.(*uiModel)
-			if cmd == nil {
-				t.Fatal("expected edit transition command")
-			}
-			if !testRollbackEditing(m) || m.view.Mode() != tui.ModeOngoing {
-				t.Fatalf("unexpected edit state: editing=%t mode=%q", testRollbackEditing(m), m.view.Mode())
-			}
-			beforeScroll := m.view.OngoingScroll()
-			m = updateUIModel(t, m, tea.MouseMsg{Button: tea.MouseButtonWheelUp})
-			if got := m.view.OngoingScroll(); got != beforeScroll {
-				t.Fatalf("expected mouse wheel ignored while editing, got scroll %d want %d", got, beforeScroll)
-			}
+		next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		m = next.(*uiModel)
+		if cmd == nil {
+			t.Fatal("expected edit transition command")
+		}
+		if !testRollbackEditing(m) || m.view.Mode() != tui.ModeOngoing {
+			t.Fatalf("unexpected edit state: editing=%t mode=%q", testRollbackEditing(m), m.view.Mode())
+		}
+		beforeScroll := m.view.OngoingScroll()
+		m = updateUIModel(t, m, tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+		if got := m.view.OngoingScroll(); got != beforeScroll {
+			t.Fatalf("expected mouse wheel ignored while editing, got scroll %d want %d", got, beforeScroll)
+		}
 
-			next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-			m = next.(*uiModel)
-			if cmd == nil {
-				t.Fatal("expected edit cancel transition command")
-			}
-			if !testRollbackSelecting(m) || m.view.Mode() != tui.ModeDetail || m.altScreenActive != tt.altOnEntry {
-				t.Fatalf("unexpected picker restore state: selecting=%t mode=%q alt=%t", testRollbackSelecting(m), m.view.Mode(), m.altScreenActive)
-			}
-		})
+		next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		m = next.(*uiModel)
+		if cmd == nil {
+			t.Fatal("expected edit cancel transition command")
+		}
+		if !testRollbackSelecting(m) || m.view.Mode() != tui.ModeDetail || m.altScreenActive != altOnEntry {
+			t.Fatalf("unexpected picker restore state: selecting=%t mode=%q alt=%t", testRollbackSelecting(m), m.view.Mode(), m.altScreenActive)
+		}
+	})
 
-		t.Run(tt.name+"/detail_to_picker_to_edit_to_picker", func(t *testing.T) {
-			m := newProjectedStaticUIModel(
-				WithUIAlternateScreenPolicy(tt.policy),
-				WithUIInitialTranscript([]UITranscriptEntry{
-					{Role: "user", Text: "u1"},
-					{Role: "assistant", Text: "a1"},
-					{Role: "user", Text: "u2"},
-				}),
-			)
-			m.termWidth = 80
-			m.termHeight = 10
-			m.syncViewport()
-			m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyShiftTab})
-			if m.view.Mode() != tui.ModeDetail || m.altScreenActive != tt.altOnEntry {
-				t.Fatalf("unexpected detail state before picker: mode=%q alt=%t", m.view.Mode(), m.altScreenActive)
-			}
+	t.Run("detail_to_picker_to_edit_to_picker", func(t *testing.T) {
+		m := newProjectedStaticUIModel(
+			WithUIInitialTranscript([]UITranscriptEntry{
+				{Role: "user", Text: "u1"},
+				{Role: "assistant", Text: "a1"},
+				{Role: "user", Text: "u2"},
+			}),
+		)
+		m.termWidth = 80
+		m.termHeight = 10
+		m.syncViewport()
+		m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyShiftTab})
+		if m.view.Mode() != tui.ModeDetail || m.altScreenActive != altOnEntry {
+			t.Fatalf("unexpected detail state before picker: mode=%q alt=%t", m.view.Mode(), m.altScreenActive)
+		}
 
-			m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyEsc})
-			next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-			m = next.(*uiModel)
-			if !testRollbackSelecting(m) || m.view.Mode() != tui.ModeDetail || m.altScreenActive != tt.altOnEntry {
-				t.Fatalf("unexpected detail picker state: selecting=%t mode=%q alt=%t", testRollbackSelecting(m), m.view.Mode(), m.altScreenActive)
-			}
+		m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		m = next.(*uiModel)
+		if !testRollbackSelecting(m) || m.view.Mode() != tui.ModeDetail || m.altScreenActive != altOnEntry {
+			t.Fatalf("unexpected detail picker state: selecting=%t mode=%q alt=%t", testRollbackSelecting(m), m.view.Mode(), m.altScreenActive)
+		}
 
-			next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-			m = next.(*uiModel)
-			if !testRollbackEditing(m) || m.view.Mode() != tui.ModeDetail {
-				t.Fatalf("unexpected detail edit state: editing=%t mode=%q", testRollbackEditing(m), m.view.Mode())
-			}
-			beforeScroll := m.view.DetailScroll()
-			m = updateUIModel(t, m, tea.MouseMsg{Button: tea.MouseButtonWheelUp})
-			if got := m.view.DetailScroll(); got != beforeScroll {
-				t.Fatalf("expected mouse wheel ignored while detail edit active, got scroll %d want %d", got, beforeScroll)
-			}
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		m = next.(*uiModel)
+		if !testRollbackEditing(m) || m.view.Mode() != tui.ModeDetail {
+			t.Fatalf("unexpected detail edit state: editing=%t mode=%q", testRollbackEditing(m), m.view.Mode())
+		}
+		beforeScroll := m.view.DetailScroll()
+		m = updateUIModel(t, m, tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+		if got := m.view.DetailScroll(); got != beforeScroll {
+			t.Fatalf("expected mouse wheel ignored while detail edit active, got scroll %d want %d", got, beforeScroll)
+		}
 
-			next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-			m = next.(*uiModel)
-			if !testRollbackSelecting(m) || m.view.Mode() != tui.ModeDetail || m.altScreenActive != tt.altOnEntry {
-				t.Fatalf("unexpected detail picker restore state: selecting=%t mode=%q alt=%t", testRollbackSelecting(m), m.view.Mode(), m.altScreenActive)
-			}
-		})
-	}
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		m = next.(*uiModel)
+		if !testRollbackSelecting(m) || m.view.Mode() != tui.ModeDetail || m.altScreenActive != altOnEntry {
+			t.Fatalf("unexpected detail picker restore state: selecting=%t mode=%q alt=%t", testRollbackSelecting(m), m.view.Mode(), m.altScreenActive)
+		}
+	})
 }
 
 func TestUpDownRouteByTranscriptMode(t *testing.T) {

--- a/cli/app/ui_slash_command_picker_test.go
+++ b/cli/app/ui_slash_command_picker_test.go
@@ -10,6 +10,7 @@ import (
 	"builder/cli/tui"
 	"builder/server/auth"
 	"builder/server/llm"
+	"builder/shared/clientui"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -415,6 +416,23 @@ func TestSlashCommandPickerShowsCopyOnlyWhenFinalAnswerIsAvailable(t *testing.T)
 	}
 	if !slashPickerContainsCommand(state, "copy") {
 		t.Fatalf("expected /copy in slash picker, got %+v", slashPickerCommandNames(state))
+	}
+}
+
+func TestSlashCommandPickerUsesCachedRuntimeStatusForCopy(t *testing.T) {
+	client := &runtimeControlFakeClient{
+		status: clientui.RuntimeStatus{LastCommittedAssistantFinalAnswer: "done"},
+	}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.input = "/co"
+	m.refreshSlashCommandFilterFromInput()
+
+	state := m.slashCommandPicker()
+	if !slashPickerContainsCommand(state, "copy") {
+		t.Fatalf("expected /copy from cached runtime status, got %+v", slashPickerCommandNames(state))
+	}
+	if client.refreshMainViewCalls != 0 {
+		t.Fatalf("slash picker refreshed runtime status %d times, want 0", client.refreshMainViewCalls)
 	}
 }
 

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -7,7 +7,6 @@ import (
 	"builder/cli/tui"
 	"builder/shared/client"
 	"builder/shared/clientui"
-	"builder/shared/config"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -99,15 +98,14 @@ type uiInputFeatureState struct {
 }
 
 type uiPresentationFeatureState struct {
-	theme              string
-	tuiAlternateScreen config.TUIAlternateScreenPolicy
-	altScreenActive    bool
-	terminalCursor     *uiTerminalCursorState
-	termWidth          int
-	termHeight         int
-	windowSizeKnown    bool
-	helpVisible        bool
-	startupCmds        []tea.Cmd
+	theme           string
+	altScreenActive bool
+	terminalCursor  *uiTerminalCursorState
+	termWidth       int
+	termHeight      int
+	windowSizeKnown bool
+	helpVisible     bool
+	startupCmds     []tea.Cmd
 }
 
 type uiConversationFeatureState struct {
@@ -159,6 +157,7 @@ type uiTranscriptFeatureState struct {
 	transcriptBaseOffset                int
 	transcriptTotalEntries              int
 	transcriptRevision                  int64
+	ongoingCommittedDelivery            ongoingCommittedDeliveryCursor
 	deferredCommittedTail               []deferredProjectedTranscriptTail
 	runtimeDisconnected                 bool
 	transcriptLiveDirty                 bool
@@ -166,6 +165,7 @@ type uiTranscriptFeatureState struct {
 	detailTranscript                    uiDetailTranscriptWindow
 	runtimeMainViewToken                uint64
 	runtimeTranscriptToken              uint64
+	runtimeCommittedSuffixToken         uint64
 	runtimeTranscriptRetry              uint64
 	runtimeTranscriptBusy               bool
 	runtimeTranscriptDirty              bool

--- a/cli/app/ui_transcript_event_apply.go
+++ b/cli/app/ui_transcript_event_apply.go
@@ -87,6 +87,7 @@ func (a uiRuntimeAdapter) applyProjectedTranscriptEntries(evt clientui.Event, fl
 	}
 	m.transcriptRevision = max(m.transcriptRevision, evt.TranscriptRevision)
 	m.transcriptTotalEntries = max(m.transcriptTotalEntries, max(evt.CommittedEntryCount, m.transcriptBaseOffset+len(m.transcriptEntries)))
+	m.observeDirectCommittedEventDelivery(evt)
 	m.refreshRollbackCandidates()
 	if plan.mode == projectedTranscriptEntryPlanAppend && replaceLoadedSyntheticEntries {
 		m.forwardToView(tui.SetConversationMsg{
@@ -135,4 +136,26 @@ func (a uiRuntimeAdapter) applyProjectedTranscriptEntries(evt clientui.Event, fl
 	}
 	m.logProjectedTranscriptAppliedDiag(evt, plan, incomingCount, len(entries), startOffset, entries, true)
 	return m.syncNativeHistoryFromTranscript(), true, false
+}
+
+func (m *uiModel) observeDirectCommittedEventDelivery(evt clientui.Event) {
+	if m == nil || !evt.CommittedTranscriptChanged || evt.CommittedEntryCount <= 0 {
+		return
+	}
+	// User echoes still use the direct event path to preserve prompt responsiveness.
+	// Keep the SSOT delivery cursor in step so the following committed suffix starts
+	// after that already-emitted user row instead of duplicating it from SSOT.
+	if evt.Kind != clientui.EventUserMessageFlushed {
+		return
+	}
+	if !m.ongoingCommittedDelivery.initialized {
+		m.ongoingCommittedDelivery = newOngoingCommittedDeliveryCursor(evt.CommittedEntryCount, evt.TranscriptRevision)
+		return
+	}
+	if evt.CommittedEntryCount > m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount {
+		m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount = evt.CommittedEntryCount
+	}
+	if evt.TranscriptRevision > m.ongoingCommittedDelivery.lastEmittedTranscriptRevision {
+		m.ongoingCommittedDelivery.lastEmittedTranscriptRevision = evt.TranscriptRevision
+	}
 }

--- a/cli/app/ui_transcript_page_apply.go
+++ b/cli/app/ui_transcript_page_apply.go
@@ -182,6 +182,7 @@ func (a uiRuntimeAdapter) applyAuthoritativeOngoingTailPage(page clientui.Transc
 	m.transcriptEntries = append(m.transcriptEntries[:0], entries...)
 	m.transcriptTotalEntries = max(page.TotalEntries, page.Offset+len(entries))
 	m.transcriptRevision = max(m.transcriptRevision, page.Revision)
+	m.ongoingCommittedDelivery = newOngoingCommittedDeliveryCursor(page.Offset+len(committedTranscriptEntriesForApp(entries)), m.transcriptRevision)
 	m.transcriptLiveDirty = false
 	if !preserveLiveReasoning {
 		m.reasoningLiveDirty = false

--- a/cli/app/ui_transcript_sync_recovery_test.go
+++ b/cli/app/ui_transcript_sync_recovery_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"builder/cli/tui"
+	"builder/server/llm"
 	"builder/shared/clientui"
 	"builder/shared/serverapi"
 
@@ -120,6 +121,202 @@ func TestSessionActivityGapRecoveryEventuallyHydratesCommittedTranscriptInBothMo
 	if client.calls != 2 {
 		t.Fatalf("refresh call count = %d, want 2", client.calls)
 	}
+}
+
+func TestSupervisorTerminalEventsReachOngoingBeforeDetail(t *testing.T) {
+	m, ongoing := newSupervisorTerminalFenceRepro(t)
+
+	if !strings.Contains(ongoing, "updated final after supervisor") || !strings.Contains(ongoing, "Supervisor ran: 1 suggestion, applied.") {
+		t.Fatalf("expected ongoing to receive final assistant and supervisor rows before detail, got %q", ongoing)
+	}
+	if m.waitRuntimeEventAfterHydration {
+		t.Fatal("expected hydration fence to clear after stale authoritative response")
+	}
+	if got := len(m.runtimeEvents); got != 0 {
+		t.Fatalf("expected terminal row events consumed before detail, got %d queued events", got)
+	}
+}
+
+func TestDetailHydrationStillReadsSupervisorTerminalRowsFromSSOT(t *testing.T) {
+	m, ongoing := newSupervisorTerminalFenceRepro(t)
+	if !strings.Contains(ongoing, "updated final after supervisor") || !strings.Contains(ongoing, "Supervisor ran: 1 suggestion, applied.") {
+		t.Fatalf("expected ongoing delivered before detail, got %q", ongoing)
+	}
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	m = next.(*uiModel)
+	_ = collectCmdMessages(t, cmd)
+	if m.view.Mode() != tui.ModeDetail {
+		t.Fatalf("mode = %q, want detail", m.view.Mode())
+	}
+
+	// The real workaround is an authoritative detail hydration. The dirty flag
+	// avoids the duplicate-page short-circuit because this repro intentionally
+	// starts from an already-primed detail tail.
+	m.runtimeTranscriptDirty = true
+	next, cmd = m.Update(detailTranscriptLoadMsg{})
+	m = next.(*uiModel)
+	msgs := collectCmdMessages(t, cmd)
+	var detailRefresh runtimeTranscriptRefreshedMsg
+	for _, msg := range msgs {
+		if typed, ok := msg.(runtimeTranscriptRefreshedMsg); ok {
+			detailRefresh = typed
+		}
+	}
+	if detailRefresh.token == 0 {
+		t.Fatalf("expected detail hydration after ongoing miss, got %+v", msgs)
+	}
+
+	next, cmd = m.Update(detailRefresh)
+	m = next.(*uiModel)
+	_ = collectCmdMessages(t, cmd)
+	detailAfterHydration := stripANSIAndTrimRight(m.view.View())
+	if !strings.Contains(detailAfterHydration, "updated final after supervisor") || !strings.Contains(detailAfterHydration, "Supervisor ran: 1 suggestion, applied.") {
+		t.Fatalf("expected detail hydration to repair missing terminal rows, got %q", detailAfterHydration)
+	}
+}
+
+func newSupervisorTerminalFenceRepro(t *testing.T) (*uiModel, string) {
+	t.Helper()
+	client := &refreshingRuntimeClient{
+		transcripts: []clientui.TranscriptPage{
+			{
+				SessionID:    "session-1",
+				Revision:     12,
+				TotalEntries: 2,
+				Entries: []clientui.ChatEntry{
+					{Role: "assistant", Text: "seed", Phase: string(llm.MessagePhaseFinal)},
+					{Role: "user", Text: "supervisor feedback"},
+				},
+			},
+			{
+				SessionID:    "session-1",
+				Revision:     13,
+				TotalEntries: 4,
+				Entries: []clientui.ChatEntry{
+					{Role: "assistant", Text: "seed", Phase: string(llm.MessagePhaseFinal)},
+					{Role: "user", Text: "supervisor feedback"},
+					{Role: "assistant", Text: "updated final after supervisor", Phase: string(llm.MessagePhaseFinal)},
+					{Role: "reviewer_status", Text: "Supervisor ran: 1 suggestion, applied."},
+				},
+			},
+		},
+	}
+	runtimeEvents := make(chan clientui.Event, 2)
+	runtimeEvents <- clientui.Event{
+		Kind:                       clientui.EventAssistantMessage,
+		StepID:                     "step-1",
+		CommittedTranscriptChanged: true,
+		TranscriptRevision:         13,
+		CommittedEntryCount:        4,
+		CommittedEntryStart:        2,
+		CommittedEntryStartSet:     true,
+		TranscriptEntries: []clientui.ChatEntry{{
+			Role:  "assistant",
+			Text:  "updated final after supervisor",
+			Phase: string(llm.MessagePhaseFinal),
+		}},
+	}
+	runtimeEvents <- clientui.Event{
+		Kind:                       clientui.EventLocalEntryAdded,
+		StepID:                     "step-1",
+		CommittedTranscriptChanged: true,
+		TranscriptRevision:         13,
+		CommittedEntryCount:        4,
+		CommittedEntryStart:        3,
+		CommittedEntryStartSet:     true,
+		TranscriptEntries:          []clientui.ChatEntry{{Role: "reviewer_status", Text: "Supervisor ran: 1 suggestion, applied."}},
+	}
+	close(runtimeEvents)
+
+	m := newProjectedTestUIModel(client, runtimeEvents, closedAskEvents())
+	m.startupCmds = nil
+	m.termWidth = 100
+	m.termHeight = 20
+	m.windowSizeKnown = true
+	m.activity = uiActivityRunning
+	m.forwardToView(tui.SetViewportSizeMsg{Lines: 20, Width: 100})
+	if cmd := m.runtimeAdapter().applyRuntimeTranscriptPage(clientui.TranscriptPageRequest{Window: clientui.TranscriptWindowOngoingTail}, clientui.TranscriptPage{
+		SessionID:    "session-1",
+		Revision:     11,
+		TotalEntries: 1,
+		Entries:      []clientui.ChatEntry{{Role: "assistant", Text: "seed", Phase: string(llm.MessagePhaseFinal)}},
+	}); cmd != nil {
+		m = applyRuntimeEventBatchMessagesFromCommand(t, m, cmd)
+	}
+
+	next, cmd := m.Update(runtimeEventBatchMsg{events: []clientui.Event{
+		{
+			Kind:                       clientui.EventUserMessageFlushed,
+			StepID:                     "step-1",
+			CommittedTranscriptChanged: true,
+			TranscriptRevision:         12,
+			CommittedEntryCount:        2,
+			CommittedEntryStart:        1,
+			CommittedEntryStartSet:     true,
+			UserMessage:                "supervisor feedback",
+			TranscriptEntries:          []clientui.ChatEntry{{Role: "user", Text: "supervisor feedback"}},
+		},
+		{
+			Kind:                       clientui.EventConversationUpdated,
+			StepID:                     "step-1",
+			CommittedTranscriptChanged: true,
+			TranscriptRevision:         13,
+			CommittedEntryCount:        4,
+		},
+	}})
+	m = next.(*uiModel)
+	msgs := collectCmdMessages(t, cmd)
+	var refresh runtimeTranscriptRefreshedMsg
+	nativeFlushSeen := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(runtimeTranscriptRefreshedMsg); ok {
+			refresh = typed
+		}
+		if flush, ok := msg.(nativeHistoryFlushMsg); ok {
+			nativeFlushSeen = true
+			if next, flushCmd := m.Update(flush); flushCmd != nil {
+				m = next.(*uiModel)
+				m = applyRuntimeEventBatchMessagesFromCommand(t, m, flushCmd)
+			} else {
+				m = next.(*uiModel)
+			}
+		}
+	}
+	if refresh.token == 0 {
+		t.Fatalf("expected committed-advance hydration command, got %+v", msgs)
+	}
+	if !nativeFlushSeen {
+		t.Fatalf("expected committed user flush to arm native flush fence, got %+v", msgs)
+	}
+
+	next, cmd = m.Update(refresh)
+	m = next.(*uiModel)
+	m = applyRuntimeEventBatchMessagesFromCommand(t, m, cmd)
+	return m, stripANSIAndTrimRight(m.view.OngoingSnapshot())
+}
+
+func applyRuntimeEventBatchMessagesFromCommand(t *testing.T, m *uiModel, cmd tea.Cmd) *uiModel {
+	t.Helper()
+	msgs := collectCmdMessages(t, cmd)
+	for guard := 0; len(msgs) > 0 && guard < 20; guard++ {
+		msg := msgs[0]
+		msgs = msgs[1:]
+		if flush, ok := msg.(nativeHistoryFlushMsg); ok {
+			next, nextCmd := m.Update(flush)
+			m = next.(*uiModel)
+			msgs = append(msgs, collectCmdMessages(t, nextCmd)...)
+			continue
+		}
+		batch, ok := msg.(runtimeEventBatchMsg)
+		if !ok {
+			continue
+		}
+		next, nextCmd := m.Update(batch)
+		m = next.(*uiModel)
+		msgs = append(msgs, collectCmdMessages(t, nextCmd)...)
+	}
+	return m
 }
 
 func TestDeferredContinuityRefreshPreservesRecoveryCauseAcrossBusyHydration(t *testing.T) {

--- a/cli/app/ui_window_reducer.go
+++ b/cli/app/ui_window_reducer.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"builder/cli/tui"
+	"builder/shared/clientui"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -68,6 +69,9 @@ func (r uiWindowFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			}
 		}
 		m.nativeResizeReplayAt = time.Time{}
+		if refresh := m.requestNativeResizeCommittedTranscriptSuffix(msg.token); refresh != nil {
+			return handledUIFeatureUpdate(m, refresh)
+		}
 		if replay := m.emitCurrentNativeScrollbackState(true); replay != nil {
 			return handledUIFeatureUpdate(m, replay)
 		}
@@ -75,6 +79,68 @@ func (r uiWindowFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			return handledUIFeatureUpdate(m, nil)
 		}
 		return handledUIFeatureUpdate(m, tea.ClearScreen)
+	case nativeResizeTranscriptSuffixRefreshedMsg:
+		if msg.token != m.nativeResizeReplayToken || m.view.Mode() != tui.ModeOngoing {
+			return handledUIFeatureUpdate(m, nil)
+		}
+		if msg.err != nil {
+			m.observeRuntimeRequestResult(msg.err)
+			if replay := m.emitCurrentNativeScrollbackState(true); replay != nil {
+				return handledUIFeatureUpdate(m, replay)
+			}
+			return handledUIFeatureUpdate(m, tea.ClearScreen)
+		}
+		m.observeRuntimeRequestResult(nil)
+		cmd := m.applyCommittedTranscriptSuffixForNativeReplay(msg.suffix)
+		return handledUIFeatureUpdate(m, cmd)
 	}
 	return uiFeatureUpdateResult{}
+}
+
+func (m *uiModel) requestNativeResizeCommittedTranscriptSuffix(token uint64) tea.Cmd {
+	if m == nil || !m.hasRuntimeClient() {
+		return nil
+	}
+	client, ok := m.runtimeClient().(interface {
+		RefreshCommittedTranscriptSuffix(clientui.CommittedTranscriptSuffixRequest) (clientui.CommittedTranscriptSuffix, error)
+	})
+	if !ok {
+		return nil
+	}
+	req := m.startupCommittedTranscriptSuffixRequest()
+	return func() tea.Msg {
+		suffix, err := client.RefreshCommittedTranscriptSuffix(req)
+		return nativeResizeTranscriptSuffixRefreshedMsg{token: token, suffix: suffix, err: err}
+	}
+}
+
+func (m *uiModel) applyCommittedTranscriptSuffixForNativeReplay(suffix clientui.CommittedTranscriptSuffix) tea.Cmd {
+	if m == nil {
+		return nil
+	}
+	page := transcriptPageFromCommittedTranscriptSuffix(suffix)
+	entries := transcriptEntriesFromPage(page)
+	m.runtimeAdapter().applyAuthoritativeOngoingTailPage(page, entries, false)
+	m.detailTranscript.syncTail(page)
+	m.forwardToView(tui.SetConversationMsg{
+		BaseOffset:   page.Offset,
+		TotalEntries: page.TotalEntries,
+		Entries:      entries,
+		Ongoing:      page.Ongoing,
+		OngoingError: page.OngoingError,
+	})
+	committedEntries := committedTranscriptEntriesForApp(m.transcriptEntries)
+	if len(committedEntries) == 0 {
+		m.resetNativeHistoryState()
+		m.nativeHistoryReplayed = true
+		if spacer := m.emitEmptyNativeScrollbackSpacer(true); spacer != nil {
+			return spacer
+		}
+		return tea.ClearScreen
+	}
+	m.rebaseNativeProjection(m.nativeCommittedProjection(committedEntries), m.transcriptBaseOffset, len(committedEntries))
+	if replay := m.emitCurrentNativeScrollbackState(true); replay != nil {
+		return replay
+	}
+	return tea.ClearScreen
 }

--- a/cli/app/workspace_change_prompt.go
+++ b/cli/app/workspace_change_prompt.go
@@ -1,16 +1,14 @@
 package app
 
 import (
+	"builder/shared/serverapi"
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
-	"strings"
-
-	"builder/shared/config"
-	"builder/shared/serverapi"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/google/uuid"
+	"path/filepath"
+	"strings"
 )
 
 const (
@@ -56,7 +54,7 @@ func maybeHandlePickedSessionWorkspaceChange(ctx context.Context, server embedde
 	if comparableWorkspaceChangeRoot(currentRoot) == "" || comparableWorkspaceChangeRoot(selectedRoot) == "" || comparableWorkspaceChangeRoot(currentRoot) == comparableWorkspaceChangeRoot(selectedRoot) {
 		return sessionWorkspaceChangeProceed, nil
 	}
-	result, err := runWorkspaceChangePromptFlow(selectedRoot, currentRoot, server.Config().Settings.Theme, server.Config().Settings.TUIAlternateScreen)
+	result, err := runWorkspaceChangePromptFlow(selectedRoot, currentRoot, server.Config().Settings.Theme)
 	if err != nil {
 		return sessionWorkspaceChangeProceed, err
 	}
@@ -213,13 +211,9 @@ func (m *workspaceChangePromptModel) optionLine(index int, label string) string 
 	return fmt.Sprintf("%d. %s", index+1, label)
 }
 
-func runWorkspaceChangePrompt(selectedRoot string, currentRoot string, theme string, alternateScreen config.TUIAlternateScreenPolicy) (workspaceChangePromptResult, error) {
+func runWorkspaceChangePrompt(selectedRoot string, currentRoot string, theme string) (workspaceChangePromptResult, error) {
 	model := newWorkspaceChangePromptModel(selectedRoot, currentRoot, theme)
-	options := []tea.ProgramOption{}
-	if shouldUseStartupPickerAltScreen(alternateScreen) {
-		options = append(options, tea.WithAltScreen())
-	}
-	program := tea.NewProgram(model, options...)
+	program := tea.NewProgram(model, tea.WithAltScreen())
 	finalModel, err := program.Run()
 	if err != nil {
 		return workspaceChangePromptResult{}, err

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -192,6 +192,7 @@ type Model struct {
 	ongoingScroll               int
 	detailScroll                int
 	snapOngoingOnViewportResize bool
+	toolSymbolGap               int
 
 	transcript             []TranscriptEntry
 	transcriptBaseOffset   int
@@ -365,6 +366,7 @@ func NewModel(opts ...Option) Model {
 		mode:             ModeOngoing,
 		viewportLines:    DefaultPreviewLines,
 		viewportWidth:    120,
+		toolSymbolGap:    1,
 		theme:            normalizeTheme(""),
 		ongoingBaseDirty: true,
 		ongoingDirty:     true,

--- a/cli/tui/model_reducer.go
+++ b/cli/tui/model_reducer.go
@@ -116,10 +116,6 @@ func (m *Model) reduceOngoingKeyMsg(msg tea.KeyMsg) {
 		*m = m.scrollOngoing(-1)
 	case tea.KeyDown:
 		*m = m.scrollOngoing(1)
-	case tea.KeyPgUp:
-		*m = m.scrollOngoing(-max(1, m.viewportLines-1))
-	case tea.KeyPgDown:
-		*m = m.scrollOngoing(max(1, m.viewportLines-1))
 	}
 }
 

--- a/cli/tui/model_rendering_entries.go
+++ b/cli/tui/model_rendering_entries.go
@@ -29,6 +29,9 @@ func (m Model) entryPrefix(role RenderIntent, symbolOverride string) string {
 	if symbol == "" {
 		return ""
 	}
+	if isToolHeadlineRole(role) && m.toolSymbolGap > 1 {
+		return symbol + strings.Repeat(" ", m.toolSymbolGap)
+	}
 	return symbol + " "
 }
 

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -427,7 +427,7 @@ func TestMouseWheelScrollsDetailView(t *testing.T) {
 	}
 }
 
-func TestPageKeysScrollActiveView(t *testing.T) {
+func TestPageKeysDoNotScrollOngoingView(t *testing.T) {
 	m := NewModel(WithPreviewLines(2))
 	m = updateModel(t, m, AppendTranscriptMsg{Role: "assistant", Text: "a1"})
 	m = updateModel(t, m, AppendTranscriptMsg{Role: "assistant", Text: "a2"})
@@ -437,13 +437,20 @@ func TestPageKeysScrollActiveView(t *testing.T) {
 
 	start := m.OngoingScroll()
 	m = updateModel(t, m, tea.KeyMsg{Type: tea.KeyPgUp})
-	if got := m.OngoingScroll(); got >= start {
-		t.Fatalf("expected pgup to scroll up ongoing view, got %d from %d", got, start)
+	if got := m.OngoingScroll(); got != start {
+		t.Fatalf("expected pgup not to mutate ongoing scroll, got %d from %d", got, start)
 	}
 
 	m = updateModel(t, m, tea.KeyMsg{Type: tea.KeyPgDown})
-	if got, want := m.OngoingScroll(), m.maxOngoingScroll(); got != want {
-		t.Fatalf("expected pgdown to return to bottom, got %d want %d", got, want)
+	if got := m.OngoingScroll(); got != start {
+		t.Fatalf("expected pgdown not to mutate ongoing scroll, got %d from %d", got, start)
+	}
+
+	m = updateModel(t, m, ToggleModeMsg{})
+	detailStart := m.DetailScroll()
+	m = updateModel(t, m, tea.KeyMsg{Type: tea.KeyPgUp})
+	if got := m.DetailScroll(); got == detailStart {
+		t.Fatalf("expected pgup to keep scrolling detail view, got %d", got)
 	}
 }
 

--- a/cli/tui/pending_snapshot.go
+++ b/cli/tui/pending_snapshot.go
@@ -36,6 +36,7 @@ func renderPendingOngoingSnapshotProjection(entries []TranscriptEntry, theme str
 		width = 120
 	}
 	model := transcriptProjectionRenderer(theme, width, 0)
+	model.toolSymbolGap = 2
 	model.transcript = append([]TranscriptEntry(nil), entries...)
 	blocks := model.buildOngoingBlocks(false)
 	blocks = model.applyPendingSpinner(blocks, entries, spinner)
@@ -57,7 +58,7 @@ func (m Model) applyPendingSpinner(blocks []ongoingBlock, entries []TranscriptEn
 			out = append(out, block)
 			continue
 		}
-		spinnerSymbol := styleForRole(block.role, m.palette()).Render(spinner)
+		spinnerSymbol := styleForRole(block.role, m.palette()).Render(spinner) + " "
 		rebuilt, ok := m.renderPendingSpinnerBlock(block, entries, spinnerSymbol)
 		if !ok {
 			out = append(out, block)

--- a/cli/tui/transcript_projection_test.go
+++ b/cli/tui/transcript_projection_test.go
@@ -6,6 +6,8 @@ import (
 
 	"builder/server/llm"
 	"builder/shared/transcript"
+
+	xansi "github.com/charmbracelet/x/ansi"
 )
 
 func TestCommittedOngoingProjectionRenderAppendDeltaFromAppendedEntry(t *testing.T) {
@@ -126,6 +128,39 @@ func TestCommittedOngoingProjectionCommitFrontierWaitsForToolResult(t *testing.T
 	}
 	if strings.Contains(delta, "prompt") {
 		t.Fatalf("expected committed delta to exclude previously emitted prompt, got %q", delta)
+	}
+}
+
+func TestPendingToolSpacingDoesNotChangeCommittedOrDetailSpacing(t *testing.T) {
+	entries := []TranscriptEntry{
+		{Role: "tool_call", Text: "echo done", ToolCallID: "done", ToolCall: &transcript.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo done"}},
+		{Role: "tool_result_ok", Text: "done", ToolCallID: "done"},
+	}
+	m := NewModel(WithPreviewLines(20), WithTheme("dark"))
+	m = updateModel(t, m, SetViewportSizeMsg{Lines: 20, Width: 80})
+	m = updateModel(t, m, SetConversationMsg{Entries: entries})
+
+	committed := xansi.Strip(m.View())
+	if !strings.Contains(committed, "$ echo done") || strings.Contains(committed, "$  echo done") {
+		t.Fatalf("expected committed tool spacing unchanged, got %q", committed)
+	}
+
+	detail := updateModel(t, m, ToggleModeMsg{})
+	detailView := xansi.Strip(detail.View())
+	if !strings.Contains(detailView, "$ echo done") || strings.Contains(detailView, "$  echo done") {
+		t.Fatalf("expected detail tool spacing unchanged, got %q", detailView)
+	}
+
+	pending := xansi.Strip(RenderPendingOngoingSnapshot([]TranscriptEntry{
+		{Role: "tool_call", Text: "echo pending", ToolCallID: "pending", ToolCall: &transcript.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo pending"}},
+		{Role: "tool_call", Text: "echo done", ToolCallID: "done", ToolCall: &transcript.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "echo done"}},
+		{Role: "tool_result_ok", Text: "done", ToolCallID: "done"},
+	}, "dark", 80, "⢎"))
+	if !strings.Contains(pending, "⢎ echo pending") {
+		t.Fatalf("expected pending spinner spacing, got %q", pending)
+	}
+	if !strings.Contains(pending, "$  echo done") {
+		t.Fatalf("expected live completed tool spacing with two spaces, got %q", pending)
 	}
 }
 

--- a/docs/dev/decisions.md
+++ b/docs/dev/decisions.md
@@ -247,7 +247,6 @@
 - Responses API `store` is configurable via `store` / `BUILDER_STORE`, default `false`.
 - Compaction routing is configurable by `compaction_mode` (`native|local|none`, default `local`).
 - Terminal notification backend is configurable by `notification_method` (`auto|osc9|bel`, default `auto`).
-- TUI alternate-screen policy is configurable by `tui_alternate_screen` (`auto|always|never`, default `auto`).
 - `tools.web_search` is enabled by default; `web_search` controls whether provider-native web search is activated (`native`) or disabled (`off`).
 - `tools.view_image` is enabled by default; runtime only advertises it to models that support multimodal inputs.
 
@@ -359,12 +358,12 @@
 - Snapshot scope is full session transcript up to latest completed step.
 - Detail transcript rendering is flat continuous stream (no grouped sections).
 - Step-end markers appear in detail only.
-- Switching detail -> ongoing restores prior ongoing scroll position.
+- Ongoing does not own a transcript viewport or restore app-managed ongoing scroll. Native terminal scrollback owns committed ongoing history navigation.
 - Mode-toggle events are UI-ephemeral and not persisted.
 - App interaction/overlay control is modeled as explicit typed states with allowed transitions. `ask`, `rollback`, `process list`, and `status` own isolated controller state; overlapping boolean precedence is forbidden.
 - Detail is a fullscreen pager-style transcript overlay (input/queued/picker hidden).
-- Ongoing mode uses native terminal scrollback by replaying committed transcript history into the normal buffer and appending only new committed transcript deltas.
-- Main UI startup stays in the normal buffer even when `tui_alternate_screen=always`, because ongoing-mode replay must remain visible in terminal scrollback.
+- Ongoing mode uses native terminal scrollback backed by backend/runtime committed transcript SSOT. Runtime events are delivery triggers and live-overlay updates; permanent ongoing rows come from committed suffix/range reads.
+- Main UI startup stays in the normal buffer because ongoing-mode replay must remain visible in terminal scrollback. The former `tui_alternate_screen` config is removed; legacy config keys are rejected.
 - Main UI startup clears the visible terminal viewport once before rendering (including `native` mode), so each session (including `/new`) starts from a clean visible slate.
 - During continuous attachment, ongoing-mode normal-buffer history is append-only. Once a transcript line is emitted into scrollback, it is immutable: no retroactive restyling, no in-place rewrites, no clear-and-replay, and no full-buffer re-emission to paper over same-session logical divergence.
 - For frontend transcript-sync semantics, compaction is same-session committed transcript progression, not a same-session transcript rewrite.
@@ -377,22 +376,22 @@
 - If connectivity or subscription continuity is lost, the transient ongoing live viewport is discarded immediately. Recovery happens by hydrating authoritative committed transcript state and resubscribing.
 - Transcript-affecting transport failures must not be swallowed or converted into fake empty/idle UI state. Correctness wins over continuity: the affected live view may stop, but it must not continue from stale transcript data.
 - For external continuity-loss recovery only, re-issuing the TUI ongoing buffer from authoritative committed state is acceptable.
-- Client-side transcript divergence caused by deduplication, ordering, overlap, or pagination bugs is not an acceptable redraw case; it must be fixed at the root cause. Global debug mode may hard-fail instead.
+- Client-side transcript divergence caused by deduplication, ordering, overlap, or pagination bugs is not an acceptable redraw case; it must be fixed at the root cause. Production reconciles/rebases silently without user-visible same-session divergence warnings; global debug mode may hard-fail instead.
 - Pending tool-call activity in ongoing mode lives only in the volatile live region, not in committed normal-buffer scrollback.
 - Ongoing-mode glyphs reserve `@` for web search tool calls; reviewer status/suggestion entries use `§`.
 - Pending tool-call previews in the live region use the same rendering/layout as normal committed `tool_call` previews, with no pending-only labels, keywords, or extra markers.
 - Tool completion in ongoing mode appends exactly one final committed line for that tool, already rendered in its terminal state. Ongoing mode must never recolor or otherwise mutate an earlier emitted tool line.
 - Parallel tool calls in ongoing mode commit through a stable frontier: later completed calls remain in the live region until all earlier pending calls are ready, but they render in their final tool state immediately; only still-running calls show the spinner. Newly committable final lines append once in transcript order.
-- In ongoing main-input mode, `Up`/`Down` are reserved for prompt-history recall at whole-buffer boundaries and for normal multiline cursor movement otherwise; they do not scroll the ongoing transcript.
+- In ongoing main-input mode, `Up`/`Down` are reserved for prompt-history recall at whole-buffer boundaries and for normal multiline cursor movement otherwise; they do not scroll the ongoing transcript. `PgUp`/`PgDn` also do not scroll ongoing transcript state; terminal/native scrollback owns that behavior.
 - Builder input fields use one shared editor implementation with a real terminal cursor by default across ongoing and alt-screen surfaces. The editor owns text semantics and rendering computes exact physical cursor coordinates; the terminal owns cursor shape, color, and blink so emulator configuration is respected. Soft/reverse-video cursor rendering is fallback-only for inactive/locked inputs or verified integration failures, not a parallel primary implementation.
 - Real-cursor input rendering must be width-safe inside a closed input component. `InputField.Render(width)` owns both rendered input lines and cursor coordinates; callers must not splice arbitrary unwrapped content into those lines. Any line that can physically hard-wrap in the terminal must be pre-wrapped/truncated and counted by `InputField` before cursor placement; untracked hard wraps are correctness bugs because they shift the terminal cursor and can corrupt Bubble Tea diff rendering. Fallback to soft cursor is allowed only for verified cursor drift, wrap mismatch, or alt-screen corruption that cannot be solved in the renderer adapter.
 - Startup/onboarding/project/worktree input fields use Builder's shared input path rather than Bubble `textinput.Model`; future input surfaces must use the same shared editor/field implementation instead of adding separate cursor/rendering behavior.
-- Ongoing transcript scrolling remains on `PgUp`/`PgDn`; failed prompt-history navigation attempts emit a plain terminal BEL with no transient UI notification.
+- Failed prompt-history navigation attempts emit a plain terminal BEL with no transient UI notification.
 - Main-input `@` path autocomplete uses a cached repo-relative path corpus built asynchronously from `rg --no-config --files -0 --hidden -g '!.git'`; corpus prewarming starts eagerly in the background when the UI model is created for a workspace, but it must be scheduled through Bubble Tea startup commands (`startupCmds` / `Init`) rather than unmanaged constructor goroutines. Live matching never shells out per keystroke and runs only against the in-memory cache. Query tracking is cursor-local and accepts path-safe runes inside the tracked token: Unicode letters/digits plus `/`, `.`, `_`, and `-`, so nested and hidden path references can be continued after accepting a directory completion. Hidden paths are included, `.git` is explicitly excluded, and normal ignore-file handling remains enabled so `.gitignore` junk such as `node_modules`, `.gradle`, and `build` stays out by default. Non-empty directory candidates are derived from file paths, so empty directories are intentionally excluded in v1. Corpus-build failures are retryable on later queries in the same workspace; they do not permanently disable path autocomplete for the session.
 - Rationale: terminal normal-buffer scrollback cannot be safely rewritten portably; committed replay is the single source of truth for persistent formatted history.
 - Ongoing mode keeps mouse capture disabled to preserve native text selection behavior.
 - Ongoing mode never enables terminal alternate-scroll (`?1007`).
-- Detail transcript overlay uses terminal alt-screen (`?1049`) when `tui_alternate_screen != never`.
+- Detail transcript overlay always uses terminal alt-screen (`?1049`).
 - Detail does not enable terminal mouse capture because it blocks native text selection in common terminals. Detail may enable terminal alternate-scroll (`?1007`) while active, and must disable it again on leaving detail.
 - Rollback/edit message picker uses detail rendering inside alt-screen but does not enable terminal alternate-scroll (`?1007`) and ignores mouse events; `Up`/`Down` are the only picker navigation path.
 - Rationale: ongoing must preserve long-lived normal-buffer scrollback; detail still needs smooth native selection/copy, so selection wins over app-level pointer capture. Wheel navigation is best-effort through terminal alternate-scroll and any mouse events the terminal can deliver without capture.

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -111,7 +111,6 @@ verbose_output = false # show in ongoing transcript
 | `model_verbosity` | string | `medium` |  |  | Text verbosity hint for supported models. Allowed: `""`, `low`, `medium`, `high`. Unsupported models ignore it. |
 | `system_prompt_file` | string | `""` |  |  | Main system prompt file. Relative paths resolve from the containing `config.toml` directory. Empty files are skipped. |
 | `theme` | string | `auto` | `BUILDER_THEME` | `builder run --theme` | TUI theme. Allowed: `auto`, `light`, `dark`. `light` and `dark` force Builder's fixed palettes. `auto` or an omitted value falls back to terminal background detection. |
-| `tui_alternate_screen` | string | `auto` | `BUILDER_TUI_ALTERNATE_SCREEN` |  | Alternate-screen policy. Allowed: `auto`, `always`, `never`. |
 | `notification_method` | string | `auto` | `BUILDER_NOTIFICATION_METHOD` |  | Terminal notification backend. Allowed: `auto`, `osc9`, `bel`. `auto` chooses `osc9` on supported terminals and falls back to `bel`. |
 | `tool_preambles` | bool | `true` | `BUILDER_TOOL_PREAMBLES` |  | Includes tool-usage preambles in the main system prompt for interactive runs. Headless `builder run` still suppresses them. |
 | `priority_request_mode` | bool | `false` |  |  | Enables fast-mode requests where the provider supports them. |

--- a/server/authflow/authflow.go
+++ b/server/authflow/authflow.go
@@ -7,22 +7,20 @@ import (
 	"strings"
 
 	"builder/server/auth"
-	"builder/shared/config"
 )
 
 type InteractionRequest struct {
-	Manager         *auth.Manager
-	State           auth.State
-	StoredState     auth.State
-	Gate            auth.StartupGate
-	AuthRequired    bool
-	PromptOptional  bool
-	StartupErr      error
-	FlowErr         error
-	OAuthOptions    auth.OpenAIOAuthOptions
-	Theme           string
-	AlternateScreen config.TUIAlternateScreenPolicy
-	HasEnvAPIKey    bool
+	Manager        *auth.Manager
+	State          auth.State
+	StoredState    auth.State
+	Gate           auth.StartupGate
+	AuthRequired   bool
+	PromptOptional bool
+	StartupErr     error
+	FlowErr        error
+	OAuthOptions   auth.OpenAIOAuthOptions
+	Theme          string
+	HasEnvAPIKey   bool
 }
 
 type InteractionOutcome struct {
@@ -44,7 +42,7 @@ func WrapStoreWithEnvAPIKeyOverride(base auth.Store, lookupEnv func(string) stri
 	})
 }
 
-func EnsureReady(ctx context.Context, mgr *auth.Manager, oauthOpts auth.OpenAIOAuthOptions, theme string, alternateScreen config.TUIAlternateScreenPolicy, lookupEnv func(string) string, authRequired bool, promptOptional bool, handler Handler) error {
+func EnsureReady(ctx context.Context, mgr *auth.Manager, oauthOpts auth.OpenAIOAuthOptions, theme string, lookupEnv func(string) string, authRequired bool, promptOptional bool, handler Handler) error {
 	if mgr == nil {
 		return errors.New("auth manager is required")
 	}
@@ -69,17 +67,16 @@ func EnsureReady(ctx context.Context, mgr *auth.Manager, oauthOpts auth.OpenAIOA
 			startupErr = auth.EnsureStartupReady(state)
 		}
 		req := InteractionRequest{
-			Manager:         mgr,
-			State:           state,
-			StoredState:     storedState,
-			Gate:            gate,
-			AuthRequired:    authRequired,
-			PromptOptional:  promptOptional,
-			StartupErr:      startupErr,
-			OAuthOptions:    oauthOpts,
-			Theme:           theme,
-			AlternateScreen: alternateScreen,
-			HasEnvAPIKey:    strings.TrimSpace(lookupEnv("OPENAI_API_KEY")) != "",
+			Manager:        mgr,
+			State:          state,
+			StoredState:    storedState,
+			Gate:           gate,
+			AuthRequired:   authRequired,
+			PromptOptional: promptOptional,
+			StartupErr:     startupErr,
+			OAuthOptions:   oauthOpts,
+			Theme:          theme,
+			HasEnvAPIKey:   strings.TrimSpace(lookupEnv("OPENAI_API_KEY")) != "",
 		}
 		if !handler.NeedsInteraction(req) {
 			if startupErr != nil {

--- a/server/authflow/authflow_test.go
+++ b/server/authflow/authflow_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"builder/server/auth"
-	"builder/shared/config"
 )
 
 type stubHandler struct {
@@ -31,7 +30,7 @@ func (h stubHandler) Interact(ctx context.Context, req InteractionRequest) (Inte
 
 func TestEnsureReadyReturnsStartupErrorWithoutInteractiveHandler(t *testing.T) {
 	mgr := auth.NewManager(auth.NewMemoryStore(auth.EmptyState()), nil, time.Now)
-	err := EnsureReady(context.Background(), mgr, auth.OpenAIOAuthOptions{}, "dark", config.TUIAlternateScreenAuto, func(string) string { return "" }, true, false, stubHandler{
+	err := EnsureReady(context.Background(), mgr, auth.OpenAIOAuthOptions{}, "dark", func(string) string { return "" }, true, false, stubHandler{
 		needs: func(InteractionRequest) bool { return false },
 	})
 	if !errors.Is(err, auth.ErrAuthNotConfigured) {
@@ -42,7 +41,7 @@ func TestEnsureReadyReturnsStartupErrorWithoutInteractiveHandler(t *testing.T) {
 func TestEnsureReadyLoopsAfterInteractionUntilAuthConfigured(t *testing.T) {
 	mgr := auth.NewManager(auth.NewMemoryStore(auth.EmptyState()), nil, time.Now)
 	callCount := 0
-	err := EnsureReady(context.Background(), mgr, auth.OpenAIOAuthOptions{}, "dark", config.TUIAlternateScreenAuto, func(key string) string {
+	err := EnsureReady(context.Background(), mgr, auth.OpenAIOAuthOptions{}, "dark", func(key string) string {
 		if key == "OPENAI_API_KEY" {
 			return "sk-env"
 		}
@@ -79,7 +78,7 @@ func TestEnsureReadyLoopsAfterInteractionUntilAuthConfigured(t *testing.T) {
 func TestEnsureReadyAllowsOptionalStartupWithoutConfiguredAuth(t *testing.T) {
 	mgr := auth.NewManager(auth.NewMemoryStore(auth.EmptyState()), nil, time.Now)
 	interacted := false
-	err := EnsureReady(context.Background(), mgr, auth.OpenAIOAuthOptions{}, "dark", config.TUIAlternateScreenAuto, func(string) string { return "" }, false, false, stubHandler{
+	err := EnsureReady(context.Background(), mgr, auth.OpenAIOAuthOptions{}, "dark", func(string) string { return "" }, false, false, stubHandler{
 		needs: func(InteractionRequest) bool { return false },
 		interact: func(context.Context, InteractionRequest) (InteractionOutcome, error) {
 			interacted = true

--- a/server/embedded/embedded.go
+++ b/server/embedded/embedded.go
@@ -59,7 +59,7 @@ func Start(ctx context.Context, req Request, hooks StartHooks) (*Server, error) 
 	if err != nil {
 		return nil, err
 	}
-	if err := authflow.EnsureReady(ctx, authSupport.AuthManager, authSupport.OAuthOptions, cfg.Settings.Theme, cfg.Settings.TUIAlternateScreen, req.LookupEnv, authpolicy.RequiresStartupAuth(cfg.Settings), false, hooks.Auth); err != nil {
+	if err := authflow.EnsureReady(ctx, authSupport.AuthManager, authSupport.OAuthOptions, cfg.Settings.Theme, req.LookupEnv, authpolicy.RequiresStartupAuth(cfg.Settings), false, hooks.Auth); err != nil {
 		return nil, err
 	}
 	if hooks.Onboarding != nil {

--- a/server/launch/subagents.go
+++ b/server/launch/subagents.go
@@ -90,8 +90,6 @@ func applySubagentRoleOverrides(settings *config.Settings, role config.SubagentR
 			settings.ModelCapabilities.SupportsVisionInputs = role.Settings.ModelCapabilities.SupportsVisionInputs
 		case "theme":
 			settings.Theme = role.Settings.Theme
-		case "tui_alternate_screen":
-			settings.TUIAlternateScreen = role.Settings.TUIAlternateScreen
 		case "notification_method":
 			settings.NotificationMethod = role.Settings.NotificationMethod
 		case "tool_preambles":

--- a/server/runtimeview/transcript.go
+++ b/server/runtimeview/transcript.go
@@ -37,6 +37,24 @@ func TranscriptPageFromRuntime(engine *runtime.Engine, req clientui.TranscriptPa
 	)
 }
 
+func CommittedTranscriptSuffixFromRuntime(engine *runtime.Engine, req clientui.CommittedTranscriptSuffixRequest) clientui.CommittedTranscriptSuffix {
+	if engine == nil {
+		return clientui.CommittedTranscriptSuffix{}
+	}
+	req = clientui.NormalizeCommittedTranscriptSuffixRequest(req)
+	page := engine.TranscriptPageSnapshot(req.AfterEntryCount, req.Limit)
+	return CommittedTranscriptSuffixFromCollectedChat(
+		engine.SessionID(),
+		engine.SessionName(),
+		ConversationFreshnessFromSession(engine.ConversationFreshness()),
+		engine.TranscriptRevision(),
+		ChatSnapshotFromRuntime(page.Snapshot),
+		page.TotalEntries,
+		page.Offset,
+		req,
+	)
+}
+
 func TranscriptPageFromOngoingTailWindow(sessionID, sessionName string, freshness clientui.ConversationFreshness, revision int64, window runtime.TranscriptWindowSnapshot, req clientui.TranscriptPageRequest) clientui.TranscriptPage {
 	req = NormalizeDefaultTranscriptRequest(req)
 	pageReq := ongoingTailTranscriptRequest(req, revision, window)
@@ -134,6 +152,48 @@ func TranscriptPageFromCollectedChat(sessionID, sessionName string, freshness cl
 	page.Ongoing = snapshot.Ongoing
 	page.OngoingError = snapshot.OngoingError
 	return page
+}
+
+func CommittedTranscriptSuffixFromCollectedChat(sessionID, sessionName string, freshness clientui.ConversationFreshness, revision int64, snapshot clientui.ChatSnapshot, totalEntries, baseOffset int, req clientui.CommittedTranscriptSuffixRequest) clientui.CommittedTranscriptSuffix {
+	req = clientui.NormalizeCommittedTranscriptSuffixRequest(req)
+	if totalEntries < 0 {
+		totalEntries = 0
+	}
+	startEntryCount := req.AfterEntryCount
+	if startEntryCount > totalEntries {
+		startEntryCount = totalEntries
+	}
+	if startEntryCount < baseOffset {
+		startEntryCount = baseOffset
+	}
+	total := len(snapshot.Entries)
+	start := startEntryCount - baseOffset
+	if start < 0 {
+		start = 0
+	}
+	if start > total {
+		start = total
+	}
+	end := start
+	if req.Limit > 0 {
+		end = start + req.Limit
+		if end > total {
+			end = total
+		}
+	}
+	entries := cloneChatEntries(snapshot.Entries[start:end])
+	nextEntryCount := startEntryCount + len(entries)
+	return clientui.CommittedTranscriptSuffix{
+		SessionID:             sessionID,
+		SessionName:           sessionName,
+		ConversationFreshness: freshness,
+		Revision:              revision,
+		CommittedEntryCount:   totalEntries,
+		StartEntryCount:       startEntryCount,
+		NextEntryCount:        nextEntryCount,
+		HasMore:               nextEntryCount < totalEntries,
+		Entries:               entries,
+	}
 }
 
 func TranscriptPageFromChat(sessionID, sessionName string, freshness clientui.ConversationFreshness, revision int64, snapshot clientui.ChatSnapshot, req clientui.TranscriptPageRequest) clientui.TranscriptPage {

--- a/server/runtimeview/transcript.go
+++ b/server/runtimeview/transcript.go
@@ -166,9 +166,14 @@ func CommittedTranscriptSuffixFromCollectedChat(sessionID, sessionName string, f
 	if startEntryCount < baseOffset {
 		startEntryCount = baseOffset
 	}
+	if startEntryCount > totalEntries {
+		startEntryCount = totalEntries
+	}
 	total := len(snapshot.Entries)
 	start := startEntryCount - baseOffset
-	if start < 0 {
+	if startEntryCount >= totalEntries {
+		start = total
+	} else if start < 0 {
 		start = 0
 	}
 	if start > total {
@@ -183,6 +188,9 @@ func CommittedTranscriptSuffixFromCollectedChat(sessionID, sessionName string, f
 	}
 	entries := cloneChatEntries(snapshot.Entries[start:end])
 	nextEntryCount := startEntryCount + len(entries)
+	if nextEntryCount > totalEntries {
+		nextEntryCount = totalEntries
+	}
 	return clientui.CommittedTranscriptSuffix{
 		SessionID:             sessionID,
 		SessionName:           sessionName,

--- a/server/runtimeview/transcript_suffix_test.go
+++ b/server/runtimeview/transcript_suffix_test.go
@@ -1,0 +1,126 @@
+package runtimeview
+
+import (
+	"fmt"
+	"testing"
+
+	"builder/server/llm"
+	"builder/server/runtime"
+	"builder/server/session"
+	"builder/server/tools"
+	"builder/shared/clientui"
+	"builder/shared/transcript"
+)
+
+func TestCommittedTranscriptSuffixReturnsRowsAfterCursor(t *testing.T) {
+	eng := newRuntimeViewTranscriptSuffixEngine(t, 5)
+
+	suffix := CommittedTranscriptSuffixFromRuntime(eng, clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 2, Limit: 2})
+
+	if suffix.SessionID != eng.SessionID() || suffix.SessionName != eng.SessionName() {
+		t.Fatalf("unexpected session metadata: %+v", suffix)
+	}
+	if suffix.StartEntryCount != 2 {
+		t.Fatalf("start entry count = %d, want 2", suffix.StartEntryCount)
+	}
+	if suffix.NextEntryCount != 4 {
+		t.Fatalf("next entry count = %d, want 4", suffix.NextEntryCount)
+	}
+	if suffix.CommittedEntryCount != 5 {
+		t.Fatalf("committed entry count = %d, want 5", suffix.CommittedEntryCount)
+	}
+	if !suffix.HasMore {
+		t.Fatalf("expected has_more for bounded suffix, got %+v", suffix)
+	}
+	if got := len(suffix.Entries); got != 2 {
+		t.Fatalf("entries = %d, want 2", got)
+	}
+	if suffix.Entries[0].Text != "reply-002" || suffix.Entries[1].Text != "reply-003" {
+		t.Fatalf("unexpected suffix entries: %+v", suffix.Entries)
+	}
+}
+
+func TestCommittedTranscriptSuffixReturnsEmptyAtTail(t *testing.T) {
+	eng := newRuntimeViewTranscriptSuffixEngine(t, 3)
+
+	suffix := CommittedTranscriptSuffixFromRuntime(eng, clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 3, Limit: 10})
+
+	if suffix.StartEntryCount != 3 || suffix.NextEntryCount != 3 {
+		t.Fatalf("unexpected empty cursor metadata: %+v", suffix)
+	}
+	if suffix.CommittedEntryCount != 3 {
+		t.Fatalf("committed entry count = %d, want 3", suffix.CommittedEntryCount)
+	}
+	if suffix.HasMore {
+		t.Fatalf("did not expect has_more at tail: %+v", suffix)
+	}
+	if len(suffix.Entries) != 0 {
+		t.Fatalf("entries = %d, want 0", len(suffix.Entries))
+	}
+}
+
+func TestCommittedTranscriptSuffixHonorsLimit(t *testing.T) {
+	eng := newRuntimeViewTranscriptSuffixEngine(t, 8)
+
+	suffix := CommittedTranscriptSuffixFromRuntime(eng, clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 1, Limit: 3})
+
+	if got := len(suffix.Entries); got != 3 {
+		t.Fatalf("entries = %d, want 3", got)
+	}
+	if suffix.NextEntryCount != 4 {
+		t.Fatalf("next entry count = %d, want 4", suffix.NextEntryCount)
+	}
+	if !suffix.HasMore {
+		t.Fatalf("expected has_more when limit cuts suffix: %+v", suffix)
+	}
+}
+
+func TestCommittedTranscriptSuffixPreservesEntryMetadata(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	eng, err := runtime.New(store, projectionFastClient{}, tools.NewRegistry(), runtime.Config{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	eng.AppendLocalEntryWithVisibility("developer_context", "internal note", transcript.EntryVisibilityDetailOnly)
+
+	suffix := CommittedTranscriptSuffixFromRuntime(eng, clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 0, Limit: 1})
+
+	if got := len(suffix.Entries); got != 1 {
+		t.Fatalf("entries = %d, want 1", got)
+	}
+	entry := suffix.Entries[0]
+	if entry.Role != "developer_context" || entry.Text != "internal note" {
+		t.Fatalf("unexpected entry: %+v", entry)
+	}
+	if entry.Visibility != clientui.EntryVisibilityDetailOnly {
+		t.Fatalf("visibility = %q, want %q", entry.Visibility, clientui.EntryVisibilityDetailOnly)
+	}
+	entry.Text = "mutated"
+	second := CommittedTranscriptSuffixFromRuntime(eng, clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 0, Limit: 1})
+	if second.Entries[0].Text != "internal note" {
+		t.Fatalf("suffix entries were not cloned: %+v", second.Entries[0])
+	}
+}
+
+func newRuntimeViewTranscriptSuffixEngine(t *testing.T, count int) *runtime.Engine {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	for i := 0; i < count; i++ {
+		if _, err := store.AppendEvent("step-1", "message", llm.Message{Role: llm.RoleAssistant, Content: fmt.Sprintf("reply-%03d", i), Phase: llm.MessagePhaseFinal}); err != nil {
+			t.Fatalf("append message %d: %v", i, err)
+		}
+	}
+	eng, err := runtime.New(store, projectionFastClient{}, tools.NewRegistry(), runtime.Config{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	return eng
+}

--- a/server/runtimeview/transcript_suffix_test.go
+++ b/server/runtimeview/transcript_suffix_test.go
@@ -75,6 +75,29 @@ func TestCommittedTranscriptSuffixHonorsLimit(t *testing.T) {
 	}
 }
 
+func TestCommittedTranscriptSuffixClampsInconsistentBaseOffset(t *testing.T) {
+	suffix := CommittedTranscriptSuffixFromCollectedChat(
+		"session-1",
+		"session",
+		clientui.ConversationFreshnessEstablished,
+		12,
+		clientui.ChatSnapshot{Entries: []clientui.ChatEntry{{Role: "assistant", Text: "stale row"}}},
+		1,
+		3,
+		clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 0, Limit: 10},
+	)
+
+	if suffix.StartEntryCount != 1 || suffix.NextEntryCount != 1 {
+		t.Fatalf("expected clamped cursor at committed total, got %+v", suffix)
+	}
+	if suffix.HasMore {
+		t.Fatalf("did not expect has_more after clamping inconsistent cursor: %+v", suffix)
+	}
+	if len(suffix.Entries) != 0 {
+		t.Fatalf("expected no entries beyond committed total, got %+v", suffix.Entries)
+	}
+}
+
 func TestCommittedTranscriptSuffixPreservesEntryMetadata(t *testing.T) {
 	dir := t.TempDir()
 	store, err := session.Create(dir, "ws", dir)

--- a/server/sessioncontrol/controller.go
+++ b/server/sessioncontrol/controller.go
@@ -12,7 +12,7 @@ import (
 	"builder/shared/config"
 )
 
-type SessionPicker func([]session.Summary, string, config.TUIAlternateScreenPolicy) (launch.SessionSelection, error)
+type SessionPicker func([]session.Summary, string) (launch.SessionSelection, error)
 
 type Controller struct {
 	Config       config.App
@@ -33,7 +33,7 @@ func (c Controller) PlanSession(ctx context.Context, req launch.SessionRequest) 
 	}
 	if c.PickSession != nil {
 		planner.PickSession = func(summaries []session.Summary) (launch.SessionSelection, error) {
-			return c.PickSession(summaries, c.Config.Settings.Theme, c.Config.Settings.TUIAlternateScreen)
+			return c.PickSession(summaries, c.Config.Settings.Theme)
 		}
 	}
 	return planner.PlanSession(ctx, req)

--- a/server/sessioncontrol/controller_test.go
+++ b/server/sessioncontrol/controller_test.go
@@ -17,7 +17,7 @@ import (
 	"builder/shared/serverapi"
 )
 
-func TestControllerPlanSessionForwardsPickerThemeAndPolicy(t *testing.T) {
+func TestControllerPlanSessionForwardsPickerTheme(t *testing.T) {
 	root := t.TempDir()
 	containerDir := filepath.Join(root, "sessions", "workspace-a")
 	first, err := session.Create(containerDir, "workspace-a", "/tmp/workspace-a")
@@ -36,15 +36,13 @@ func TestControllerPlanSessionForwardsPickerThemeAndPolicy(t *testing.T) {
 	}
 
 	var gotTheme string
-	var gotPolicy config.TUIAlternateScreenPolicy
 	pickedCalled := false
 	controller := Controller{
 		Config: config.App{
 			WorkspaceRoot:   "/tmp/workspace-a",
 			PersistenceRoot: root,
 			Settings: config.Settings{
-				Theme:              "dark",
-				TUIAlternateScreen: config.TUIAlternateScreenAlways,
+				Theme: "dark",
 			},
 		},
 		ContainerDir: containerDir,
@@ -56,10 +54,9 @@ func TestControllerPlanSessionForwardsPickerThemeAndPolicy(t *testing.T) {
 				{SessionID: store.Meta().SessionID, Name: "second", UpdatedAt: store.Meta().UpdatedAt},
 			},
 		}}}),
-		PickSession: func(summaries []session.Summary, theme string, alternateScreenPolicy config.TUIAlternateScreenPolicy) (launch.SessionSelection, error) {
+		PickSession: func(summaries []session.Summary, theme string) (launch.SessionSelection, error) {
 			pickedCalled = true
 			gotTheme = theme
-			gotPolicy = alternateScreenPolicy
 			if len(summaries) != 2 {
 				t.Fatalf("expected two summaries, got %d", len(summaries))
 			}
@@ -83,9 +80,6 @@ func TestControllerPlanSessionForwardsPickerThemeAndPolicy(t *testing.T) {
 	}
 	if gotTheme != "dark" {
 		t.Fatalf("theme = %q, want dark", gotTheme)
-	}
-	if gotPolicy != config.TUIAlternateScreenAlways {
-		t.Fatalf("alternate screen policy = %q, want always", gotPolicy)
 	}
 	if plan.Store.Meta().SessionID != store.Meta().SessionID {
 		t.Fatalf("planned session = %q, want %q", plan.Store.Meta().SessionID, store.Meta().SessionID)

--- a/server/sessionview/service.go
+++ b/server/sessionview/service.go
@@ -199,6 +199,31 @@ func (s *Service) GetSessionTranscriptPage(ctx context.Context, req serverapi.Se
 	return serverapi.SessionTranscriptPageResponse{}, errors.New("session store resolver is required")
 }
 
+func (s *Service) GetSessionCommittedTranscriptSuffix(ctx context.Context, req serverapi.SessionCommittedTranscriptSuffixRequest) (serverapi.SessionCommittedTranscriptSuffixResponse, error) {
+	if err := req.Validate(); err != nil {
+		return serverapi.SessionCommittedTranscriptSuffixResponse{}, err
+	}
+	suffixReq := clientui.NormalizeCommittedTranscriptSuffixRequest(clientui.CommittedTranscriptSuffixRequest{
+		AfterEntryCount: req.AfterEntryCount,
+		Limit:           req.Limit,
+	})
+	if runtimeEngine, err := s.resolveRuntime(ctx, req.SessionID); err != nil {
+		return serverapi.SessionCommittedTranscriptSuffixResponse{}, err
+	} else if runtimeEngine != nil {
+		return serverapi.SessionCommittedTranscriptSuffixResponse{Suffix: runtimeview.CommittedTranscriptSuffixFromRuntime(runtimeEngine, suffixReq)}, nil
+	}
+	if store, err := s.resolveSessionStore(ctx, req.SessionID); err != nil {
+		return serverapi.SessionCommittedTranscriptSuffixResponse{}, err
+	} else if store != nil {
+		suffix, err := s.dormantCommittedTranscriptSuffixFromStore(ctx, store, suffixReq)
+		if err != nil {
+			return serverapi.SessionCommittedTranscriptSuffixResponse{}, err
+		}
+		return serverapi.SessionCommittedTranscriptSuffixResponse{Suffix: suffix}, nil
+	}
+	return serverapi.SessionCommittedTranscriptSuffixResponse{}, errors.New("session store resolver is required")
+}
+
 func (s *Service) GetRun(ctx context.Context, req serverapi.RunGetRequest) (serverapi.RunGetResponse, error) {
 	if err := req.Validate(); err != nil {
 		return serverapi.RunGetResponse{}, err
@@ -327,6 +352,38 @@ func (s *Service) dormantTranscriptPageFromStore(ctx context.Context, store *ses
 			clientui.TranscriptPageRequest{Offset: pageOffset, Limit: limit},
 		), nil
 	})
+}
+
+func (s *Service) dormantCommittedTranscriptSuffixFromStore(ctx context.Context, store *session.Store, req clientui.CommittedTranscriptSuffixRequest) (clientui.CommittedTranscriptSuffix, error) {
+	if store == nil {
+		return clientui.CommittedTranscriptSuffix{}, errors.New("session store is required")
+	}
+	req = clientui.NormalizeCommittedTranscriptSuffixRequest(req)
+	meta := store.Meta()
+	freshness := runtimeview.ConversationFreshnessFromSession(store.ConversationFreshness())
+	cacheWarningMode := s.cacheWarningModeValue()
+	scan, err := scanDormantTranscript(ctx, store, runtime.PersistedTranscriptScanRequest{
+		Offset:           req.AfterEntryCount,
+		Limit:            req.Limit,
+		CacheWarningMode: cacheWarningMode,
+	})
+	if err != nil {
+		return clientui.CommittedTranscriptSuffix{}, err
+	}
+	startEntryCount := req.AfterEntryCount
+	if total := scan.TotalEntries(); startEntryCount > total {
+		startEntryCount = total
+	}
+	return runtimeview.CommittedTranscriptSuffixFromCollectedChat(
+		meta.SessionID,
+		meta.Name,
+		freshness,
+		meta.LastSequence,
+		runtimeview.ChatSnapshotFromRuntime(scan.CollectedPageSnapshot()),
+		scan.TotalEntries(),
+		startEntryCount,
+		req,
+	), nil
 }
 
 func scanDormantTranscript(ctx context.Context, store *session.Store, req runtime.PersistedTranscriptScanRequest) (*runtime.PersistedTranscriptScan, error) {

--- a/server/sessionview/transcript_suffix_test.go
+++ b/server/sessionview/transcript_suffix_test.go
@@ -1,0 +1,95 @@
+package sessionview
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"builder/server/llm"
+	"builder/server/runtime"
+	"builder/server/session"
+	"builder/server/tools"
+	"builder/shared/serverapi"
+)
+
+func TestGetSessionCommittedTranscriptSuffixReturnsRuntimeViewSuffix(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	for i := 0; i < 4; i++ {
+		if _, err := store.AppendEvent("step-1", "message", llm.Message{Role: llm.RoleAssistant, Content: fmt.Sprintf("reply-%03d", i), Phase: llm.MessagePhaseFinal}); err != nil {
+			t.Fatalf("append message %d: %v", i, err)
+		}
+	}
+	eng, err := runtime.New(store, &serviceFakeLLM{}, tools.NewRegistry(), runtime.Config{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	svc := NewService(NewStaticSessionResolver(store), NewStaticRuntimeResolver(eng), nil)
+
+	resp, err := svc.GetSessionCommittedTranscriptSuffix(context.Background(), serverapi.SessionCommittedTranscriptSuffixRequest{
+		SessionID:       store.Meta().SessionID,
+		AfterEntryCount: 1,
+		Limit:           2,
+	})
+	if err != nil {
+		t.Fatalf("get committed transcript suffix: %v", err)
+	}
+	if resp.Suffix.StartEntryCount != 1 || resp.Suffix.NextEntryCount != 3 {
+		t.Fatalf("unexpected cursor metadata: %+v", resp.Suffix)
+	}
+	if got := len(resp.Suffix.Entries); got != 2 {
+		t.Fatalf("entries = %d, want 2", got)
+	}
+	if resp.Suffix.Entries[0].Text != "reply-001" || resp.Suffix.Entries[1].Text != "reply-002" {
+		t.Fatalf("unexpected entries: %+v", resp.Suffix.Entries)
+	}
+}
+
+func TestGetSessionCommittedTranscriptSuffixReturnsDormantSuffix(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	for i := 0; i < 4; i++ {
+		if _, err := store.AppendEvent("step-1", "message", llm.Message{Role: llm.RoleAssistant, Content: fmt.Sprintf("reply-%03d", i), Phase: llm.MessagePhaseFinal}); err != nil {
+			t.Fatalf("append message %d: %v", i, err)
+		}
+	}
+	svc := NewService(NewStaticSessionResolver(store), nil, nil)
+
+	resp, err := svc.GetSessionCommittedTranscriptSuffix(context.Background(), serverapi.SessionCommittedTranscriptSuffixRequest{
+		SessionID:       store.Meta().SessionID,
+		AfterEntryCount: 2,
+		Limit:           10,
+	})
+	if err != nil {
+		t.Fatalf("get dormant committed transcript suffix: %v", err)
+	}
+	if resp.Suffix.StartEntryCount != 2 || resp.Suffix.NextEntryCount != 4 {
+		t.Fatalf("unexpected cursor metadata: %+v", resp.Suffix)
+	}
+	if got := len(resp.Suffix.Entries); got != 2 {
+		t.Fatalf("entries = %d, want 2", got)
+	}
+	if resp.Suffix.Entries[0].Text != "reply-002" || resp.Suffix.Entries[1].Text != "reply-003" {
+		t.Fatalf("unexpected entries: %+v", resp.Suffix.Entries)
+	}
+}
+
+func TestGetSessionCommittedTranscriptSuffixRejectsInvalidLimit(t *testing.T) {
+	svc := NewService(nil, nil, nil)
+
+	_, err := svc.GetSessionCommittedTranscriptSuffix(context.Background(), serverapi.SessionCommittedTranscriptSuffixRequest{
+		SessionID:       "session-1",
+		AfterEntryCount: 0,
+		Limit:           -1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "limit must be >= 0") {
+		t.Fatalf("expected invalid limit error, got %v", err)
+	}
+}

--- a/server/startup/startup.go
+++ b/server/startup/startup.go
@@ -77,7 +77,7 @@ func StartCore(ctx context.Context, req Request, authHandler AuthHandler, onboar
 		return nil, err
 	}
 	if !req.AllowUnauthenticated {
-		if err := authflow.EnsureReady(ctx, authSupport.AuthManager, authSupport.OAuthOptions, cfg.Settings.Theme, cfg.Settings.TUIAlternateScreen, bootstrapReq.LookupEnv, authpolicy.RequiresStartupAuth(cfg.Settings), false, authHandler); err != nil {
+		if err := authflow.EnsureReady(ctx, authSupport.AuthManager, authSupport.OAuthOptions, cfg.Settings.Theme, bootstrapReq.LookupEnv, authpolicy.RequiresStartupAuth(cfg.Settings), false, authHandler); err != nil {
 			return nil, err
 		}
 	}
@@ -125,7 +125,6 @@ func EnsureReady(ctx context.Context, state AuthState, authHandler AuthHandler) 
 		state.AuthManager(),
 		state.OAuthOptions(),
 		cfg.Settings.Theme,
-		cfg.Settings.TUIAlternateScreen,
 		lookupEnv(authHandler),
 		authpolicy.RequiresStartupAuth(cfg.Settings),
 		true,

--- a/server/startup/startup_test.go
+++ b/server/startup/startup_test.go
@@ -73,8 +73,7 @@ func TestEnsureReadyUsesAuthHandlerLookupEnv(t *testing.T) {
 	sawInteraction := false
 	err := EnsureReady(context.Background(), stubAuthState{
 		cfg: config.App{Settings: config.Settings{
-			Theme:              "dark",
-			TUIAlternateScreen: config.TUIAlternateScreenAuto,
+			Theme: "dark",
 		}},
 		oauthOpts: auth.OpenAIOAuthOptions{ClientID: "client-test"},
 		mgr:       mgr,
@@ -92,9 +91,6 @@ func TestEnsureReadyUsesAuthHandlerLookupEnv(t *testing.T) {
 			}
 			if req.Theme != "dark" {
 				t.Fatalf("theme = %q, want dark", req.Theme)
-			}
-			if req.AlternateScreen != config.TUIAlternateScreenAuto {
-				t.Fatalf("alternate screen policy = %q, want auto", req.AlternateScreen)
 			}
 			return true
 		},
@@ -115,9 +111,8 @@ func TestEnsureReadyPromptsDuringExplicitReauthWhenStartupAuthIsOptional(t *test
 	called := false
 	err := EnsureReady(context.Background(), stubAuthState{
 		cfg: config.App{Settings: config.Settings{
-			Theme:              "dark",
-			TUIAlternateScreen: config.TUIAlternateScreenAuto,
-			OpenAIBaseURL:      "http://127.0.0.1:8080/v1",
+			Theme:         "dark",
+			OpenAIBaseURL: "http://127.0.0.1:8080/v1",
 		}},
 		mgr: mgr,
 	}, stubAuthHandler{

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -12,6 +12,7 @@ import (
 
 	"builder/server/auth"
 	"builder/server/core"
+	"builder/shared/client"
 	"builder/shared/clientui"
 	"builder/shared/protocol"
 	"builder/shared/rpcwire"
@@ -266,6 +267,17 @@ func (g *Gateway) dispatch(ctx context.Context, state *connectionState, req prot
 				return serverapi.SessionTranscriptPageResponse{}, err
 			}
 			return g.core.SessionViewClient().GetSessionTranscriptPage(ctx, params)
+		})
+	case protocol.MethodSessionGetCommittedTranscriptSuffix:
+		return decodeAndHandle(req, func(params serverapi.SessionCommittedTranscriptSuffixRequest) (serverapi.SessionCommittedTranscriptSuffixResponse, error) {
+			if err := g.requireSessionInActiveProject(ctx, state, params.SessionID); err != nil {
+				return serverapi.SessionCommittedTranscriptSuffixResponse{}, err
+			}
+			suffixClient, ok := g.core.SessionViewClient().(client.SessionCommittedTranscriptSuffixClient)
+			if !ok {
+				return serverapi.SessionCommittedTranscriptSuffixResponse{}, errors.New("session committed transcript suffix client is required")
+			}
+			return suffixClient.GetSessionCommittedTranscriptSuffix(ctx, params)
 		})
 	case protocol.MethodSessionGetInitialInput:
 		return decodeAndHandle(req, func(params serverapi.SessionInitialInputRequest) (serverapi.SessionInitialInputResponse, error) {

--- a/shared/client/remote.go
+++ b/shared/client/remote.go
@@ -171,6 +171,11 @@ func (c *Remote) GetSessionTranscriptPage(ctx context.Context, req serverapi.Ses
 	return resp, c.call(ctx, protocol.MethodSessionGetTranscriptPage, req, &resp)
 }
 
+func (c *Remote) GetSessionCommittedTranscriptSuffix(ctx context.Context, req serverapi.SessionCommittedTranscriptSuffixRequest) (serverapi.SessionCommittedTranscriptSuffixResponse, error) {
+	var resp serverapi.SessionCommittedTranscriptSuffixResponse
+	return resp, c.call(ctx, protocol.MethodSessionGetCommittedTranscriptSuffix, req, &resp)
+}
+
 func (c *Remote) GetInitialInput(ctx context.Context, req serverapi.SessionInitialInputRequest) (serverapi.SessionInitialInputResponse, error) {
 	var resp serverapi.SessionInitialInputResponse
 	return resp, c.call(ctx, protocol.MethodSessionGetInitialInput, req, &resp)

--- a/shared/client/session_view.go
+++ b/shared/client/session_view.go
@@ -13,6 +13,10 @@ type SessionViewClient interface {
 	GetRun(ctx context.Context, req serverapi.RunGetRequest) (serverapi.RunGetResponse, error)
 }
 
+type SessionCommittedTranscriptSuffixClient interface {
+	GetSessionCommittedTranscriptSuffix(ctx context.Context, req serverapi.SessionCommittedTranscriptSuffixRequest) (serverapi.SessionCommittedTranscriptSuffixResponse, error)
+}
+
 type loopbackSessionViewClient struct {
 	service serverapi.SessionViewService
 }
@@ -33,6 +37,13 @@ func (c *loopbackSessionViewClient) GetSessionTranscriptPage(ctx context.Context
 		return serverapi.SessionTranscriptPageResponse{}, errors.New("session view service is required")
 	}
 	return c.service.GetSessionTranscriptPage(ctx, req)
+}
+
+func (c *loopbackSessionViewClient) GetSessionCommittedTranscriptSuffix(ctx context.Context, req serverapi.SessionCommittedTranscriptSuffixRequest) (serverapi.SessionCommittedTranscriptSuffixResponse, error) {
+	if c == nil || c.service == nil {
+		return serverapi.SessionCommittedTranscriptSuffixResponse{}, errors.New("session view service is required")
+	}
+	return c.service.GetSessionCommittedTranscriptSuffix(ctx, req)
 }
 
 func (c *loopbackSessionViewClient) GetRun(ctx context.Context, req serverapi.RunGetRequest) (serverapi.RunGetResponse, error) {

--- a/shared/clientui/transcript_suffix_test.go
+++ b/shared/clientui/transcript_suffix_test.go
@@ -1,0 +1,21 @@
+package clientui
+
+import "testing"
+
+func TestCommittedTranscriptSuffixRequestDefaultsAndValidation(t *testing.T) {
+	defaulted := NormalizeCommittedTranscriptSuffixRequest(CommittedTranscriptSuffixRequest{})
+	if defaulted.AfterEntryCount != 0 {
+		t.Fatalf("default after entry count = %d, want 0", defaulted.AfterEntryCount)
+	}
+	if defaulted.Limit != DefaultCommittedTranscriptSuffixLimit {
+		t.Fatalf("default limit = %d, want %d", defaulted.Limit, DefaultCommittedTranscriptSuffixLimit)
+	}
+
+	clamped := NormalizeCommittedTranscriptSuffixRequest(CommittedTranscriptSuffixRequest{AfterEntryCount: -10, Limit: MaxCommittedTranscriptSuffixLimit + 1})
+	if clamped.AfterEntryCount != 0 {
+		t.Fatalf("clamped after entry count = %d, want 0", clamped.AfterEntryCount)
+	}
+	if clamped.Limit != MaxCommittedTranscriptSuffixLimit {
+		t.Fatalf("clamped limit = %d, want %d", clamped.Limit, MaxCommittedTranscriptSuffixLimit)
+	}
+}

--- a/shared/clientui/types.go
+++ b/shared/clientui/types.go
@@ -150,6 +150,41 @@ type TranscriptPage struct {
 	OngoingError          string
 }
 
+const (
+	DefaultCommittedTranscriptSuffixLimit = 250
+	MaxCommittedTranscriptSuffixLimit     = 500
+)
+
+type CommittedTranscriptSuffixRequest struct {
+	AfterEntryCount int
+	Limit           int
+}
+
+type CommittedTranscriptSuffix struct {
+	SessionID             string
+	SessionName           string
+	ConversationFreshness ConversationFreshness
+	Revision              int64
+	CommittedEntryCount   int
+	StartEntryCount       int
+	NextEntryCount        int
+	HasMore               bool
+	Entries               []ChatEntry
+}
+
+func NormalizeCommittedTranscriptSuffixRequest(req CommittedTranscriptSuffixRequest) CommittedTranscriptSuffixRequest {
+	if req.AfterEntryCount < 0 {
+		req.AfterEntryCount = 0
+	}
+	if req.Limit <= 0 {
+		req.Limit = DefaultCommittedTranscriptSuffixLimit
+	}
+	if req.Limit > MaxCommittedTranscriptSuffixLimit {
+		req.Limit = MaxCommittedTranscriptSuffixLimit
+	}
+	return req
+}
+
 type ToolPresentationKind string
 type ToolCallRenderBehavior string
 type ToolRenderKind string

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -18,8 +18,6 @@ const (
 	globalAuthConfigName = "auth.json"
 )
 
-type TUIAlternateScreenPolicy string
-
 type CompactionMode string
 type BGShellsOutputMode string
 type CacheWarningMode string
@@ -32,10 +30,6 @@ type WorktreeSettings struct {
 }
 
 const (
-	TUIAlternateScreenAuto   TUIAlternateScreenPolicy = "auto"
-	TUIAlternateScreenAlways TUIAlternateScreenPolicy = "always"
-	TUIAlternateScreenNever  TUIAlternateScreenPolicy = "never"
-
 	CompactionModeNative CompactionMode = "native"
 	CompactionModeLocal  CompactionMode = "local"
 	CompactionModeNone   CompactionMode = "none"
@@ -103,7 +97,6 @@ type Settings struct {
 	SystemPromptFiles                []SystemPromptFile
 	ModelCapabilities                ModelCapabilitiesOverride
 	Theme                            string
-	TUIAlternateScreen               TUIAlternateScreenPolicy
 	NotificationMethod               string
 	ToolPreambles                    bool
 	PriorityRequestMode              bool

--- a/shared/config/config_defaults.go
+++ b/shared/config/config_defaults.go
@@ -26,7 +26,6 @@ const (
 	defaultPreSubmitCompactionLeadTokens = compaction.DefaultPreSubmitRunwayTokens
 	defaultReviewerFrequency             = "edits"
 	defaultReviewerTimeoutSec            = 60
-	defaultTUIAlternateScreen            = "auto"
 	defaultCompactionMode                = "local"
 	defaultServerHost                    = "127.0.0.1"
 	defaultServerPort                    = 53082

--- a/shared/config/config_part2_test.go
+++ b/shared/config/config_part2_test.go
@@ -818,7 +818,7 @@ func TestLoadToolPreamblesPrecedence(t *testing.T) {
 	}
 }
 
-func TestLoadTUIAlternateScreenPrecedenceAndValidation(t *testing.T) {
+func TestLoadRejectsRemovedTUIAlternateScreenSetting(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
@@ -831,52 +831,8 @@ func TestLoadTUIAlternateScreenPrecedenceAndValidation(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	cfg, err := Load(workspace, LoadOptions{})
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	if cfg.Settings.TUIAlternateScreen != TUIAlternateScreenAlways {
-		t.Fatalf("expected file tui_alternate_screen=always, got %q", cfg.Settings.TUIAlternateScreen)
-	}
-	if got := cfg.Source.Sources["tui_alternate_screen"]; got != "file" {
-		t.Fatalf("expected tui_alternate_screen source file, got %q", got)
-	}
-
-	if err := os.WriteFile(configPath, []byte("tui_alternate_screen = \"Always\"\n"), 0o644); err != nil {
-		t.Fatalf("write config mixed case: %v", err)
-	}
-	cfg, err = Load(workspace, LoadOptions{})
-	if err != nil {
-		t.Fatalf("load mixed-case file value: %v", err)
-	}
-	if cfg.Settings.TUIAlternateScreen != TUIAlternateScreenAlways {
-		t.Fatalf("expected mixed-case file value normalized to always, got %q", cfg.Settings.TUIAlternateScreen)
-	}
-
-	t.Setenv("BUILDER_TUI_ALTERNATE_SCREEN", "never")
-	cfg, err = Load(workspace, LoadOptions{})
-	if err != nil {
-		t.Fatalf("load with env: %v", err)
-	}
-	if cfg.Settings.TUIAlternateScreen != TUIAlternateScreenNever {
-		t.Fatalf("expected env tui_alternate_screen=never, got %q", cfg.Settings.TUIAlternateScreen)
-	}
-	if got := cfg.Source.Sources["tui_alternate_screen"]; got != "env" {
-		t.Fatalf("expected tui_alternate_screen source env, got %q", got)
-	}
-
-	t.Setenv("BUILDER_TUI_ALTERNATE_SCREEN", "NEVER")
-	cfg, err = Load(workspace, LoadOptions{})
-	if err != nil {
-		t.Fatalf("load mixed-case env value: %v", err)
-	}
-	if cfg.Settings.TUIAlternateScreen != TUIAlternateScreenNever {
-		t.Fatalf("expected mixed-case env value normalized to never, got %q", cfg.Settings.TUIAlternateScreen)
-	}
-
-	t.Setenv("BUILDER_TUI_ALTERNATE_SCREEN", "broken")
-	if _, err := Load(workspace, LoadOptions{}); err == nil {
-		t.Fatal("expected invalid tui_alternate_screen validation error")
+	if _, err := Load(workspace, LoadOptions{}); err == nil || !strings.Contains(err.Error(), "tui_alternate_screen") {
+		t.Fatalf("expected removed tui_alternate_screen setting error, got %v", err)
 	}
 }
 

--- a/shared/config/config_registry.go
+++ b/shared/config/config_registry.go
@@ -122,13 +122,6 @@ func newSettingsRegistry() settingsRegistry {
 			func(opts LoadOptions) (string, bool, error) { return trimmedCLIString(opts.Theme) },
 			theme.Normalize,
 			settingDocOptions{}),
-		newStringSetting("tui_alternate_screen", TUIAlternateScreenPolicy(defaultTUIAlternateScreen),
-			func(state *settingsState, value TUIAlternateScreenPolicy) { state.Settings.TUIAlternateScreen = value },
-			func(state settingsState) TUIAlternateScreenPolicy { return state.Settings.TUIAlternateScreen },
-			"BUILDER_TUI_ALTERNATE_SCREEN",
-			nil,
-			normalizeTUIAlternateScreenPolicy,
-			settingDocOptions{}),
 		newStringSetting("notification_method", "auto",
 			func(state *settingsState, value string) { state.Settings.NotificationMethod = value },
 			func(state settingsState) string { return state.Settings.NotificationMethod },
@@ -425,7 +418,6 @@ func newSettingsRegistry() settingsRegistry {
 			validateThinkingLevel,
 			validateModelVerbosity,
 			validateTheme,
-			validateTUIAlternateScreen,
 			validateNotificationMethod,
 			validateServerHost,
 			validateServerPort,
@@ -1247,8 +1239,6 @@ func renderTOMLValue(value any) string {
 		return strconv.Itoa(v)
 	case fmt.Stringer:
 		return strconv.Quote(v.String())
-	case TUIAlternateScreenPolicy:
-		return strconv.Quote(string(v))
 	case ModelVerbosity:
 		return strconv.Quote(string(v))
 	case CompactionMode:

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -61,9 +61,6 @@ func TestLoadUsesDefaultsWithoutCreatingConfigOnFirstUse(t *testing.T) {
 	if cfg.Settings.Debug {
 		t.Fatalf("expected default debug=false")
 	}
-	if cfg.Settings.TUIAlternateScreen != TUIAlternateScreenAuto {
-		t.Fatalf("default tui_alternate_screen mismatch: %q", cfg.Settings.TUIAlternateScreen)
-	}
 	if got := cfg.PersistenceRoot; got != filepath.Join(home, ".builder") {
 		t.Fatalf("default persistence root mismatch: %q", got)
 	}

--- a/shared/config/config_validation.go
+++ b/shared/config/config_validation.go
@@ -30,7 +30,6 @@ func validateSubagentRoleState(state settingsState, sources map[string]string) e
 		{enabled: hasExplicitPrefix(sources, "provider_capabilities."), check: validateProviderCapabilitiesProviderID},
 		{enabled: hasExplicitSource(sources, "model_verbosity"), check: validateModelVerbosity},
 		{enabled: hasExplicitSource(sources, "theme"), check: validateTheme},
-		{enabled: hasExplicitSource(sources, "tui_alternate_screen"), check: validateTUIAlternateScreen},
 		{enabled: hasExplicitSource(sources, "notification_method"), check: validateNotificationMethod},
 		{enabled: hasExplicitSource(sources, "server_host"), check: validateServerHost},
 		{enabled: hasExplicitSource(sources, "server_port"), check: validateServerPort},
@@ -194,15 +193,6 @@ func validateTheme(state settingsState, _ map[string]string) error {
 	}
 }
 
-func validateTUIAlternateScreen(state settingsState, _ map[string]string) error {
-	switch strings.ToLower(strings.TrimSpace(string(state.Settings.TUIAlternateScreen))) {
-	case "auto", "always", "never":
-		return nil
-	default:
-		return fmt.Errorf("invalid tui_alternate_screen %q (expected auto|always|never)", state.Settings.TUIAlternateScreen)
-	}
-}
-
 func validateNotificationMethod(state settingsState, _ map[string]string) error {
 	switch strings.ToLower(strings.TrimSpace(state.Settings.NotificationMethod)) {
 	case "auto", "osc9", "bel":
@@ -346,19 +336,6 @@ func validateReviewer(state settingsState, _ map[string]string) error {
 		return fmt.Errorf("reviewer.timeout_seconds must be > 0")
 	}
 	return nil
-}
-
-func normalizeTUIAlternateScreenPolicy(raw string) TUIAlternateScreenPolicy {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "auto":
-		return TUIAlternateScreenAuto
-	case "always":
-		return TUIAlternateScreenAlways
-	case "never":
-		return TUIAlternateScreenNever
-	default:
-		return TUIAlternateScreenPolicy(strings.TrimSpace(raw))
-	}
 }
 
 func normalizeCompactionMode(raw string) CompactionMode {

--- a/shared/protocol/handshake.go
+++ b/shared/protocol/handshake.go
@@ -24,6 +24,7 @@ const (
 	MethodSessionPlan                              = "session.plan"
 	MethodSessionGetMainView                       = "session.getMainView"
 	MethodSessionGetTranscriptPage                 = "session.getTranscriptPage"
+	MethodSessionGetCommittedTranscriptSuffix      = "session.getCommittedTranscriptSuffix"
 	MethodSessionGetInitialInput                   = "session.getInitialInput"
 	MethodSessionPersistInputDraft                 = "session.persistInputDraft"
 	MethodSessionRetargetWorkspace                 = "session.retargetWorkspace"
@@ -86,6 +87,7 @@ var allowedPreAuthMethods = []string{
 	MethodSessionListByProject,
 	MethodSessionGetMainView,
 	MethodSessionGetTranscriptPage,
+	MethodSessionGetCommittedTranscriptSuffix,
 	MethodSessionGetInitialInput,
 	MethodProcessList,
 	MethodProcessGet,

--- a/shared/serverapi/session_view.go
+++ b/shared/serverapi/session_view.go
@@ -31,6 +31,16 @@ type SessionTranscriptPageResponse struct {
 	Transcript clientui.TranscriptPage `json:"transcript"`
 }
 
+type SessionCommittedTranscriptSuffixRequest struct {
+	SessionID       string `json:"session_id"`
+	AfterEntryCount int    `json:"after_entry_count,omitempty"`
+	Limit           int    `json:"limit,omitempty"`
+}
+
+type SessionCommittedTranscriptSuffixResponse struct {
+	Suffix clientui.CommittedTranscriptSuffix `json:"suffix"`
+}
+
 type RunGetRequest struct {
 	SessionID string
 	RunID     string
@@ -43,6 +53,7 @@ type RunGetResponse struct {
 type SessionViewService interface {
 	GetSessionMainView(ctx context.Context, req SessionMainViewRequest) (SessionMainViewResponse, error)
 	GetSessionTranscriptPage(ctx context.Context, req SessionTranscriptPageRequest) (SessionTranscriptPageResponse, error)
+	GetSessionCommittedTranscriptSuffix(ctx context.Context, req SessionCommittedTranscriptSuffixRequest) (SessionCommittedTranscriptSuffixResponse, error)
 	GetRun(ctx context.Context, req RunGetRequest) (RunGetResponse, error)
 }
 
@@ -78,6 +89,22 @@ func (r SessionTranscriptPageRequest) Validate() error {
 	}
 	if r.KnownCommittedEntryCount < 0 {
 		return errors.New("known_committed_entry_count must be >= 0")
+	}
+	return nil
+}
+
+func (r SessionCommittedTranscriptSuffixRequest) Validate() error {
+	if err := validateRequiredSessionID(r.SessionID); err != nil {
+		return err
+	}
+	if r.AfterEntryCount < 0 {
+		return errors.New("after_entry_count must be >= 0")
+	}
+	if r.Limit < 0 {
+		return errors.New("limit must be >= 0")
+	}
+	if r.Limit > clientui.MaxCommittedTranscriptSuffixLimit {
+		return errors.New("limit exceeds maximum committed transcript suffix limit")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- add committed transcript suffix RPC/API and route ongoing permanent scrollback through SSOT suffix reads
- add delivery cursor/flush-ack handling so unresolved pending tools stay live-only until committed final rows arrive
- remove app-owned ongoing PgUp/PgDn scrolling and delete stale `tui_alternate_screen` config end-to-end
- update docs/tests for native-scrollback ongoing semantics, detail alt-screen behavior, and pending tool live spacing

## Verification
- `./scripts/test.sh ./cli/tui ./cli/app -count=1`
- `./scripts/test.sh ./...`
- `./scripts/build.sh --output ./bin/builder`
- push hook: formatting, `go vet`, `go build`, `go test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Removed the `tui_alternate_screen` setting; the UI now always uses terminal alternate screen mode.

* **UI Behavior Changes**
  * Page Up/Down keys no longer scroll the ongoing transcript view; they now only affect the detail view.
  * Detail mode overlay now consistently uses terminal alternate screen.

* **Performance Improvements**
  * Optimized transcript suffix delivery for more efficient data synchronization and reduced latency during transcript updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->