### PR TITLE
Fix shell UX edge cases

### DIFF
--- a/cli/app/embedded_server.go
+++ b/cli/app/embedded_server.go
@@ -360,6 +360,7 @@ func prepareSharedRuntime(ctx context.Context, server embeddedServer, plan sessi
 	}, func(ctx context.Context) (map[string]struct{}, error) {
 		return listPendingPromptIDs(ctx, plan.SessionID, server.AskViewClient(), server.ApprovalViewClient())
 	}, server.PromptControlClient(), leaseManager)
+	terminalFocus := newTerminalFocusState()
 	turnQueueHook := newBellHooks(defaultTerminalNotifier(plan.ActiveSettings.NotificationMethod), func() string {
 		if runtimeClient != nil {
 			if sessionName := strings.TrimSpace(runtimeClient.MainView().Session.SessionName); sessionName != "" {
@@ -367,12 +368,13 @@ func prepareSharedRuntime(ctx context.Context, server embeddedServer, plan sessi
 			}
 		}
 		return strings.TrimSpace(plan.SessionName)
-	})
+	}, terminalFocus.FocusedForAttention)
 	wiring := &runtimeWiring{
 		runtimeEvents:         runtimeEvents,
 		askEvents:             askEvents,
 		background:            nil,
 		turnQueueHook:         turnQueueHook,
+		terminalFocus:         terminalFocus,
 		runtimeClient:         runtimeClient,
 		promptControl:         server.PromptControlClient(),
 		runtimeControls:       server.RuntimeControlClient(),

--- a/cli/app/runtime_factory.go
+++ b/cli/app/runtime_factory.go
@@ -27,6 +27,7 @@ type runtimeWiring struct {
 	askBridge             *askBridge
 	eventBridge           *runtimeEventBridge
 	turnQueueHook         turnQueueHook
+	terminalFocus         *terminalFocusState
 	runtimeEvents         <-chan clientui.Event
 	askEvents             <-chan askEvent
 	background            *shelltool.Manager
@@ -104,9 +105,10 @@ func newRuntimeWiring(store *session.Store, active config.Settings, enabledTools
 }
 
 func newRuntimeWiringWithBackground(store *session.Store, active config.Settings, enabledTools []toolspec.ID, workspaceRoot string, mgr *auth.Manager, logger *runLogger, background *shelltool.Manager, opts runtimeWiringOptions) (*runtimeWiring, error) {
+	terminalFocus := newTerminalFocusState()
 	bells := newBellHooks(defaultTerminalNotifier(active.NotificationMethod), func() string {
 		return store.Meta().Name
-	})
+	}, terminalFocus.FocusedForAttention)
 
 	wiring, err := runtimewire.NewRuntimeWiringWithBackground(store, active, enabledTools, workspaceRoot, mgr, logger, background, runtimewire.RuntimeWiringOptions{
 		Headless: opts.Headless,
@@ -145,6 +147,7 @@ func newRuntimeWiringWithBackground(store *session.Store, active config.Settings
 		askBridge:     askBridge,
 		eventBridge:   wiring.EventBridge,
 		turnQueueHook: bells,
+		terminalFocus: terminalFocus,
 		background:    wiring.Background,
 		promptHistory: append([]string(nil), wiring.PromptHistory...),
 	}, nil

--- a/cli/app/terminal_bell.go
+++ b/cli/app/terminal_bell.go
@@ -144,20 +144,26 @@ type bellHooks struct {
 	mu                    sync.Mutex
 	notifier              terminalNotifier
 	title                 func() string
+	focused               func() bool
 	currentStep           string
 	toolCalls             int
 	pendingTurnCompletion bool
+	pendingCompaction     bool
 	lastCompletionMessage string
 }
 
-func newBellHooks(notifier terminalNotifier, title func() string) *bellHooks {
+func newBellHooks(notifier terminalNotifier, title func() string, focused ...func() bool) *bellHooks {
 	if notifier == nil {
 		notifier = newBELTerminalNotifier(io.Discard)
 	}
 	if title == nil {
 		title = func() string { return defaultSessionTitle }
 	}
-	return &bellHooks{notifier: notifier, title: title}
+	focusedProvider := func() bool { return false }
+	if len(focused) > 0 && focused[0] != nil {
+		focusedProvider = focused[0]
+	}
+	return &bellHooks{notifier: notifier, title: title, focused: focusedProvider}
 }
 
 func (h *bellHooks) OnAsk(req askquestion.Request) {
@@ -236,6 +242,14 @@ func (h *bellHooks) OnTurnQueueDrained() {
 		return
 	}
 	h.mu.Lock()
+	if h.pendingCompaction {
+		h.pendingCompaction = false
+		h.pendingTurnCompletion = false
+		h.lastCompletionMessage = ""
+		h.mu.Unlock()
+		h.notifyIfUnfocused(compactionCompletionNotificationMessage)
+		return
+	}
 	if !h.pendingTurnCompletion {
 		h.mu.Unlock()
 		return
@@ -244,7 +258,7 @@ func (h *bellHooks) OnTurnQueueDrained() {
 	h.pendingTurnCompletion = false
 	h.lastCompletionMessage = ""
 	h.mu.Unlock()
-	h.notifier.Notify(h.formatMessage(message))
+	h.notifyIfUnfocused(message)
 }
 
 func (h *bellHooks) OnTurnQueueAborted() {
@@ -255,8 +269,28 @@ func (h *bellHooks) OnTurnQueueAborted() {
 	h.currentStep = ""
 	h.toolCalls = 0
 	h.pendingTurnCompletion = false
+	h.pendingCompaction = false
 	h.lastCompletionMessage = ""
 	h.mu.Unlock()
+}
+
+const compactionCompletionNotificationMessage = "Compaction finished"
+
+func (h *bellHooks) OnUserCompactionCompleted(queueDrained bool) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	if !queueDrained {
+		h.pendingCompaction = true
+		h.mu.Unlock()
+		return
+	}
+	h.pendingCompaction = false
+	h.pendingTurnCompletion = false
+	h.lastCompletionMessage = ""
+	h.mu.Unlock()
+	h.notifyIfUnfocused(compactionCompletionNotificationMessage)
 }
 
 func turnCompletionNotificationMessage(assistantContent string) string {
@@ -282,4 +316,20 @@ func (h *bellHooks) formatMessage(message string) string {
 		title = sessionTitle(h.title())
 	}
 	return title + ": " + sanitizeTerminalNotificationMessage(message)
+}
+
+func (h *bellHooks) notifyIfUnfocused(message string) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	focused := false
+	if h.focused != nil {
+		focused = h.focused()
+	}
+	h.mu.Unlock()
+	if focused {
+		return
+	}
+	h.notifier.Notify(h.formatMessage(message))
 }

--- a/cli/app/terminal_bell_test.go
+++ b/cli/app/terminal_bell_test.go
@@ -35,6 +35,10 @@ func (r *countRinger) Last() string {
 	return r.last
 }
 
+func newUnfocusedBellHooks(ringer *countRinger) *bellHooks {
+	return newBellHooks(ringer, nil, func() bool { return false })
+}
+
 func TestTerminalBellRingerWritesBellCharacter(t *testing.T) {
 	var out bytes.Buffer
 	notifier := newTerminalNotifier(notificationMethodBEL, &out, nil)
@@ -95,7 +99,7 @@ func TestAutoNotifierFallsBackToBELForWindowsTerminal(t *testing.T) {
 
 func TestBellHooksRingOnAskRequests(t *testing.T) {
 	ringer := &countRinger{}
-	hooks := newBellHooks(ringer, nil)
+	hooks := newUnfocusedBellHooks(ringer)
 
 	hooks.OnAsk(askquestion.Request{Question: "question"})
 	hooks.OnAsk(askquestion.Request{Question: "approval", Approval: true})
@@ -121,7 +125,7 @@ func TestBellHooksUseSessionNameAndQuestionTextForAskNotifications(t *testing.T)
 
 func TestBellHooksRingOnToolHeavyTurnEnd(t *testing.T) {
 	ringer := &countRinger{}
-	hooks := newBellHooks(ringer, nil)
+	hooks := newUnfocusedBellHooks(ringer)
 
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventAssistantMessage, StepID: "step-1"})
@@ -149,9 +153,38 @@ func TestBellHooksRingOnToolHeavyTurnEnd(t *testing.T) {
 	}
 }
 
+func TestBellHooksSuppressTurnCompletionWhileFocused(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newBellHooks(ringer, nil, func() bool { return true })
+
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventAssistantMessage, StepID: "step-1", TranscriptEntries: []clientui.ChatEntry{{Role: "assistant", Text: "done"}}})
+	hooks.OnTurnQueueDrained()
+
+	if got := ringer.Count(); got != 0 {
+		t.Fatalf("ring count while focused = %d, want 0", got)
+	}
+}
+
+func TestBellHooksRingOnToolHeavyTurnEndWithUnknownFocus(t *testing.T) {
+	ringer := &countRinger{}
+	focus := newTerminalFocusState()
+	hooks := newBellHooks(ringer, nil, focus.FocusedForAttention)
+
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
+	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventAssistantMessage, StepID: "step-1", TranscriptEntries: []clientui.ChatEntry{{Role: "assistant", Text: "done"}}})
+	hooks.OnTurnQueueDrained()
+
+	if got := ringer.Count(); got != 1 {
+		t.Fatalf("ring count with unknown focus = %d, want 1", got)
+	}
+}
+
 func TestBellHooksIncludeAssistantPreviewInTurnCompleteNotification(t *testing.T) {
 	ringer := &countRinger{}
-	hooks := newBellHooks(ringer, nil)
+	hooks := newUnfocusedBellHooks(ringer)
 
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
@@ -165,7 +198,7 @@ func TestBellHooksIncludeAssistantPreviewInTurnCompleteNotification(t *testing.T
 
 func TestBellHooksFallbackToTurnCompleteForWhitespacePreview(t *testing.T) {
 	ringer := &countRinger{}
-	hooks := newBellHooks(ringer, nil)
+	hooks := newUnfocusedBellHooks(ringer)
 
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
@@ -179,7 +212,7 @@ func TestBellHooksFallbackToTurnCompleteForWhitespacePreview(t *testing.T) {
 
 func TestBellHooksNoopAssistantDeltaClearsPendingTurnCompletion(t *testing.T) {
 	ringer := &countRinger{}
-	hooks := newBellHooks(ringer, nil)
+	hooks := newUnfocusedBellHooks(ringer)
 
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
@@ -194,7 +227,7 @@ func TestBellHooksNoopAssistantDeltaClearsPendingTurnCompletion(t *testing.T) {
 
 func TestBellHooksNoopAssistantMessageClearsPendingTurnCompletion(t *testing.T) {
 	ringer := &countRinger{}
-	hooks := newBellHooks(ringer, nil)
+	hooks := newUnfocusedBellHooks(ringer)
 
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
@@ -209,7 +242,7 @@ func TestBellHooksNoopAssistantMessageClearsPendingTurnCompletion(t *testing.T) 
 
 func TestBellHooksNoopAssistantEventPreservesUnrelatedActiveTurn(t *testing.T) {
 	ringer := &countRinger{}
-	hooks := newBellHooks(ringer, nil)
+	hooks := newUnfocusedBellHooks(ringer)
 
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
@@ -254,7 +287,7 @@ func TestFormatAssistantPreview(t *testing.T) {
 
 func TestBellHooksIgnoresMismatchedTurnEndStep(t *testing.T) {
 	ringer := &countRinger{}
-	hooks := newBellHooks(ringer, nil)
+	hooks := newUnfocusedBellHooks(ringer)
 
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
@@ -268,7 +301,7 @@ func TestBellHooksIgnoresMismatchedTurnEndStep(t *testing.T) {
 
 func TestBellHooksRingOnceAfterQueuedTurnsDrain(t *testing.T) {
 	ringer := &countRinger{}
-	hooks := newBellHooks(ringer, nil)
+	hooks := newUnfocusedBellHooks(ringer)
 
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
@@ -291,7 +324,7 @@ func TestBellHooksRingOnceAfterQueuedTurnsDrain(t *testing.T) {
 
 func TestBellHooksClearPendingTurnCompletionAfterAbort(t *testing.T) {
 	ringer := &countRinger{}
-	hooks := newBellHooks(ringer, nil)
+	hooks := newUnfocusedBellHooks(ringer)
 
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
 	hooks.OnProjectedRuntimeEvent(clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"})
@@ -301,5 +334,48 @@ func TestBellHooksClearPendingTurnCompletionAfterAbort(t *testing.T) {
 
 	if got := ringer.Count(); got != 0 {
 		t.Fatalf("ring count = %d after aborted queue, want 0", got)
+	}
+}
+
+func TestBellHooksRingOnUserCompactionCompletion(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newUnfocusedBellHooks(ringer)
+
+	hooks.OnUserCompactionCompleted(true)
+
+	if got := ringer.Count(); got != 1 {
+		t.Fatalf("ring count = %d after user compaction completion, want 1", got)
+	}
+	if got := ringer.Last(); got != "builder: Compaction finished" {
+		t.Fatalf("last message = %q, want %q", got, "builder: Compaction finished")
+	}
+}
+
+func TestBellHooksSuppressUserCompactionCompletionWhileFocused(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newBellHooks(ringer, nil, func() bool { return true })
+
+	hooks.OnUserCompactionCompleted(true)
+
+	if got := ringer.Count(); got != 0 {
+		t.Fatalf("ring count while focused = %d, want 0", got)
+	}
+}
+
+func TestBellHooksDeferUserCompactionCompletionUntilQueueDrains(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newUnfocusedBellHooks(ringer)
+
+	hooks.OnUserCompactionCompleted(false)
+	if got := ringer.Count(); got != 0 {
+		t.Fatalf("ring count before queue drain = %d, want 0", got)
+	}
+	hooks.OnTurnQueueDrained()
+
+	if got := ringer.Count(); got != 1 {
+		t.Fatalf("ring count after queue drain = %d, want 1", got)
+	}
+	if got := ringer.Last(); got != "builder: Compaction finished" {
+		t.Fatalf("last message = %q, want %q", got, "builder: Compaction finished")
 	}
 }

--- a/cli/app/terminal_focus.go
+++ b/cli/app/terminal_focus.go
@@ -1,0 +1,51 @@
+package app
+
+import "sync"
+
+type terminalFocusState struct {
+	mu      sync.RWMutex
+	known   bool
+	focused bool
+}
+
+func newTerminalFocusState() *terminalFocusState {
+	return &terminalFocusState{}
+}
+
+func (s *terminalFocusState) MarkFocused() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.known = true
+	s.focused = true
+	s.mu.Unlock()
+}
+
+func (s *terminalFocusState) MarkBlurred() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.known = true
+	s.focused = false
+	s.mu.Unlock()
+}
+
+func (s *terminalFocusState) FocusedForAttention() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.known && s.focused
+}
+
+func (s *terminalFocusState) Known() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.known
+}

--- a/cli/app/turn_queue_hooks.go
+++ b/cli/app/turn_queue_hooks.go
@@ -8,4 +8,5 @@ type turnQueueHook interface {
 	OnProjectedRuntimeEvent(evt clientui.Event)
 	OnTurnQueueDrained()
 	OnTurnQueueAborted()
+	OnUserCompactionCompleted(queueDrained bool)
 }

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -454,6 +454,14 @@ func WithUITurnQueueHook(hook turnQueueHook) UIOption {
 	}
 }
 
+func WithUITerminalFocusState(state *terminalFocusState) UIOption {
+	return func(m *uiModel) {
+		if state != nil {
+			m.terminalFocus = state
+		}
+	}
+}
+
 func WithUIPromptHistory(history []string) UIOption {
 	return func(m *uiModel) {
 		m.loadPromptHistory(history)
@@ -548,7 +556,8 @@ func newUIInputFeatureState() uiInputFeatureState {
 
 func newUIPresentationFeatureState() uiPresentationFeatureState {
 	return uiPresentationFeatureState{
-		theme: theme.Auto,
+		theme:         theme.Auto,
+		terminalFocus: newTerminalFocusState(),
 	}
 }
 
@@ -820,6 +829,14 @@ func (m *uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		probe.probeUIModel(m)
 		return m, nil
 	}
+	switch msg.(type) {
+	case tea.FocusMsg:
+		m.terminalFocus.MarkFocused()
+		return m, nil
+	case tea.BlurMsg:
+		m.terminalFocus.MarkBlurred()
+		return m, nil
+	}
 	if result := m.reduceFeatureMessage(msg); result.handled {
 		return result.bubbleTea()
 	}
@@ -831,6 +848,20 @@ func (m *uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.forwardToView(msg)
 	m.syncViewport()
 	return m, m.maybeRequestDetailTranscriptPage()
+}
+
+func (m *uiModel) TerminalFocused() bool {
+	if m == nil {
+		return false
+	}
+	return m.terminalFocus.FocusedForAttention()
+}
+
+func (m *uiModel) TerminalFocusKnown() bool {
+	if m == nil {
+		return false
+	}
+	return m.terminalFocus.Known()
 }
 
 func (m *uiModel) setDebugKeyTransientStatus(raw tea.Msg, normalized tea.KeyMsg, source string) {

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -726,6 +726,7 @@ func (m *uiModel) handleRuntimeEventBatch(events []clientui.Event) (*uiModel, te
 	cmd = tea.Batch(cmd, m.rearmSpinnerTicking())
 	if !result.awaitsHydration {
 		cmd = sequenceCmds(cmd, m.flushQueuedInputsAfterHydration())
+		cmd = sequenceCmds(cmd, m.inputController().resumeQueuedInputsAfterIdleRuntime())
 	}
 	m.syncViewport()
 	if !result.transcriptMutated {

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -99,6 +99,10 @@ type runtimeEventBatchMsg struct {
 	carry  *clientui.Event
 }
 
+type uiModelProbeMessage interface {
+	probeUIModel(*uiModel)
+}
+
 type runtimeConnectionStateChangedMsg struct {
 	err error
 }
@@ -811,6 +815,10 @@ func (m *uiModel) Init() tea.Cmd {
 }
 
 func (m *uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if probe, ok := msg.(uiModelProbeMessage); ok {
+		probe.probeUIModel(m)
+		return m, nil
+	}
 	if result := m.reduceFeatureMessage(msg); result.handled {
 		return result.bubbleTea()
 	}

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -345,7 +345,7 @@ func (c uiAskController) renderPromptLines() []askPromptLine {
 			{Kind: askPromptLineKindInput, InputPrefix: m.askInputPrefix(), InputText: m.ask.input, InputCursor: m.ask.inputCursor, ShowsCursor: true},
 		}
 	}
-	lines := []askPromptLine{{Text: strings.TrimSpace(req.Question), Kind: askPromptLineKindQuestion}}
+	lines := askQuestionPromptTextLines(req.Question)
 	if askOptionCount(req) > 0 && !m.ask.freeform {
 		visibleOptions := askVisibleOptions(req)
 		for i, s := range visibleOptions {
@@ -399,6 +399,19 @@ func (c uiAskController) renderPromptLines() []askPromptLine {
 		hint = "Tab to return to picker • Enter to submit"
 	}
 	lines = append(lines, askPromptLine{Text: hint, Kind: askPromptLineKindHint})
+	return lines
+}
+
+func askQuestionPromptTextLines(question string) []askPromptLine {
+	normalized := strings.ReplaceAll(strings.ReplaceAll(question, "\r\n", "\n"), "\r", "\n")
+	if strings.TrimSpace(normalized) == "" {
+		return []askPromptLine{{Text: "", Kind: askPromptLineKindQuestion}}
+	}
+	parts := strings.Split(normalized, "\n")
+	lines := make([]askPromptLine, 0, len(parts))
+	for _, part := range parts {
+		lines = append(lines, askPromptLine{Text: part, Kind: askPromptLineKindQuestion})
+	}
 	return lines
 }
 

--- a/cli/app/ui_focus_test.go
+++ b/cli/app/ui_focus_test.go
@@ -1,0 +1,32 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestUIModelTracksTerminalFocus(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	if m.TerminalFocusKnown() {
+		t.Fatal("expected terminal focus to start unknown")
+	}
+	if m.TerminalFocused() {
+		t.Fatal("expected unknown terminal focus to require attention")
+	}
+
+	next, _ := m.Update(tea.BlurMsg{})
+	updated := next.(*uiModel)
+	if !updated.TerminalFocusKnown() {
+		t.Fatal("expected terminal blur to mark focus known")
+	}
+	if updated.TerminalFocused() {
+		t.Fatal("expected terminal blur to mark model unfocused")
+	}
+
+	next, _ = updated.Update(tea.FocusMsg{})
+	updated = next.(*uiModel)
+	if !updated.TerminalFocused() {
+		t.Fatal("expected terminal focus to mark model focused")
+	}
+}

--- a/cli/app/ui_input_controller_commands.go
+++ b/cli/app/ui_input_controller_commands.go
@@ -12,6 +12,14 @@ import (
 )
 
 func (c uiInputController) applyCommandResult(commandResult commands.Result) (tea.Model, tea.Cmd) {
+	return c.applyCommandResultWithPreSubmitQueuePosition(commandResult, preSubmitQueueBack)
+}
+
+func (c uiInputController) applyQueuedCommandResult(commandResult commands.Result) (tea.Model, tea.Cmd) {
+	return c.applyCommandResultWithPreSubmitQueuePosition(commandResult, preSubmitQueueFront)
+}
+
+func (c uiInputController) applyCommandResultWithPreSubmitQueuePosition(commandResult commands.Result, queuePosition preSubmitQueuePosition) (tea.Model, tea.Cmd) {
 	m := c.model
 	if commandResult.SubmitUser {
 		if blocked, disconnectCmd := c.blockDisconnectedSubmission(true, commandResult.User); blocked {
@@ -25,7 +33,7 @@ func (c uiInputController) applyCommandResult(commandResult commands.Result) (te
 		return m, tea.Quit
 	}
 	if commandResult.SubmitUser {
-		return m, c.startSubmission(commandResult.User)
+		return m, c.startSubmissionWithPreSubmitQueuePosition(commandResult.User, queuePosition)
 	}
 	prefixCmd := tea.Cmd(nil)
 	if commandResult.Text != "" {

--- a/cli/app/ui_input_controller_keys.go
+++ b/cli/app/ui_input_controller_keys.go
@@ -176,8 +176,10 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if inputState.Mode == uiInputModeRollbackEdit && !inputState.Busy {
 			return c.startRollbackFork(text)
 		}
-		if handled, next, cmd := c.handleEnteredSlashCommandInput(text); handled {
-			return next, cmd
+		if m.busy {
+			if handled, next, cmd := c.handleEnteredSlashCommandInput(text); handled {
+				return next, cmd
+			}
 		}
 		if blocked, disconnectCmd := c.blockDisconnectedSubmission(false, ""); blocked {
 			return m, disconnectCmd
@@ -193,6 +195,14 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.queueInjectedInput(text)
 			m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
 			return m, nil
+		}
+		if len(m.queued) > 0 {
+			m.queueInput(text)
+			m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
+			return c.flushQueuedInputs(queueDrainOne)
+		}
+		if handled, next, cmd := c.handleEnteredSlashCommandInput(text); handled {
+			return next, cmd
 		}
 		if commandResult := m.commandRegistry.Execute(text); commandResult.Handled {
 			recordCmd := m.recordPromptHistory(text)

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -3,6 +3,8 @@ package app
 import (
 	"strings"
 
+	"builder/cli/app/commands"
+
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -205,6 +207,9 @@ func (c uiInputController) dispatchQueuedInput(text string) tea.Cmd {
 	if m.commandRegistry != nil {
 		if _, knownCommand := m.commandRegistry.Command(text); knownCommand {
 			if commandResult := m.commandRegistry.Execute(text); commandResult.Handled {
+				if commandResult.Action == commands.ActionCompact {
+					return finalizeSlashCommandCmd(commandResult.Action, c.startQueuedCompaction(commandResult.Args), m.recordPromptHistory(text))
+				}
 				_, cmd := c.applyCommandResult(commandResult)
 				return finalizeSlashCommandCmd(commandResult.Action, cmd, m.recordPromptHistory(text))
 			}

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -184,6 +184,22 @@ func (c uiInputController) flushQueuedInputs(mode queueDrainMode) (tea.Model, te
 	return m, tea.Batch(cmds...)
 }
 
+func (c uiInputController) resumeQueuedInputsAfterIdleRuntime() tea.Cmd {
+	m := c.model
+	if m == nil || m.busy || m.ask.hasCurrent() || len(m.queued) == 0 || m.isInputLocked() || m.pendingQueuedDrainAfterHydration {
+		return nil
+	}
+	if m.hasRuntimeClient() && c.queuedDrainRequiresHydration() {
+		m.pendingQueuedDrainAfterHydration = true
+		m.queuedDrainReadyAfterHydration = false
+		m.syncViewport()
+		return m.requestRuntimeQueuedDrainTranscriptSync()
+	}
+	_, cmd := c.flushQueuedInputs(queueDrainAuto)
+	c.notifyTurnQueueDrainedIfIdle()
+	return cmd
+}
+
 func (c uiInputController) dispatchQueuedInput(text string) tea.Cmd {
 	m := c.model
 	if m.commandRegistry != nil {

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -210,12 +210,12 @@ func (c uiInputController) dispatchQueuedInput(text string) tea.Cmd {
 				if commandResult.Action == commands.ActionCompact {
 					return finalizeSlashCommandCmd(commandResult.Action, c.startQueuedCompaction(commandResult.Args), m.recordPromptHistory(text))
 				}
-				_, cmd := c.applyCommandResult(commandResult)
+				_, cmd := c.applyQueuedCommandResult(commandResult)
 				return finalizeSlashCommandCmd(commandResult.Action, cmd, m.recordPromptHistory(text))
 			}
 		}
 	}
-	return c.startSubmissionWithPromptHistory(text)
+	return c.startQueuedSubmissionWithPromptHistory(text)
 }
 
 func (m *uiModel) shouldContinueQueuedInputAutoDrain() bool {

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -40,7 +40,7 @@ func (c uiInputController) startSubmission(text string) tea.Cmd {
 		m.preSubmitCheckToken++
 		token := m.preSubmitCheckToken
 		m.pendingPreSubmitText = text
-		m.queued = append(m.queued, text)
+		m.queued = append([]string{text}, m.queued...)
 		return tea.Batch(c.preSubmitCompactionCheckCmd(token, text), m.ensureSpinnerTicking())
 	}
 	return tea.Batch(c.submitCmd(text), m.ensureSpinnerTicking())

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -12,7 +12,18 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+type preSubmitQueuePosition uint8
+
+const (
+	preSubmitQueueBack preSubmitQueuePosition = iota
+	preSubmitQueueFront
+)
+
 func (c uiInputController) startSubmission(text string) tea.Cmd {
+	return c.startSubmissionWithPreSubmitQueuePosition(text, preSubmitQueueBack)
+}
+
+func (c uiInputController) startSubmissionWithPreSubmitQueuePosition(text string, queuePosition preSubmitQueuePosition) tea.Cmd {
 	m := c.model
 	if blocked, disconnectCmd := c.blockDisconnectedSubmission(true, text); blocked {
 		return disconnectCmd
@@ -40,22 +51,34 @@ func (c uiInputController) startSubmission(text string) tea.Cmd {
 		m.preSubmitCheckToken++
 		token := m.preSubmitCheckToken
 		m.pendingPreSubmitText = text
-		m.queued = append([]string{text}, m.queued...)
+		if queuePosition == preSubmitQueueFront {
+			m.queued = append([]string{text}, m.queued...)
+		} else {
+			m.queued = append(m.queued, text)
+		}
 		return tea.Batch(c.preSubmitCompactionCheckCmd(token, text), m.ensureSpinnerTicking())
 	}
 	return tea.Batch(c.submitCmd(text), m.ensureSpinnerTicking())
 }
 
 func (c uiInputController) startSubmissionWithPromptHistory(text string) tea.Cmd {
+	return c.startSubmissionWithPromptHistoryAndQueuePosition(text, preSubmitQueueBack)
+}
+
+func (c uiInputController) startQueuedSubmissionWithPromptHistory(text string) tea.Cmd {
+	return c.startSubmissionWithPromptHistoryAndQueuePosition(text, preSubmitQueueFront)
+}
+
+func (c uiInputController) startSubmissionWithPromptHistoryAndQueuePosition(text string, queuePosition preSubmitQueuePosition) tea.Cmd {
 	m := c.model
 	if blocked, disconnectCmd := c.blockDisconnectedSubmission(true, text); blocked {
 		return disconnectCmd
 	}
 	_, isUserShell := parseUserShellCommand(text)
 	if m.hasRuntimeClient() && !isUserShell {
-		return c.startSubmission(text)
+		return c.startSubmissionWithPreSubmitQueuePosition(text, queuePosition)
 	}
-	return sequenceCmds(m.recordPromptHistory(text), c.startSubmission(text))
+	return sequenceCmds(m.recordPromptHistory(text), c.startSubmissionWithPreSubmitQueuePosition(text, queuePosition))
 }
 
 func (c uiInputController) preSubmitCompactionCheckCmd(token uint64, text string) tea.Cmd {

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -157,9 +157,27 @@ func (m *uiModel) markActiveSubmitUserMessageFlushed(evt clientui.Event) {
 	}
 }
 
+type uiCompactionOrigin uint8
+
+const (
+	uiCompactionOriginNone uiCompactionOrigin = iota
+	uiCompactionOriginManual
+	uiCompactionOriginQueued
+	uiCompactionOriginPreSubmit
+)
+
 func (c uiInputController) startCompaction(args string) tea.Cmd {
+	return c.startCompactionWithOrigin(args, uiCompactionOriginManual)
+}
+
+func (c uiInputController) startQueuedCompaction(args string) tea.Cmd {
+	return c.startCompactionWithOrigin(args, uiCompactionOriginQueued)
+}
+
+func (c uiInputController) startCompactionWithOrigin(args string, origin uiCompactionOrigin) tea.Cmd {
 	m := c.model
 	c.startBusyActivity(true)
+	m.compactionOrigin = origin
 	m.logf("compaction.start args_chars=%d", len(strings.TrimSpace(args)))
 	m.syncViewport()
 	return tea.Batch(c.compactCmd(args), m.ensureSpinnerTicking())
@@ -168,6 +186,7 @@ func (c uiInputController) startCompaction(args string) tea.Cmd {
 func (c uiInputController) startPreSubmitCompaction() tea.Cmd {
 	m := c.model
 	c.startBusyActivity(true)
+	m.compactionOrigin = uiCompactionOriginPreSubmit
 	m.logf("compaction.pre_submit.start")
 	m.syncViewport()
 	return tea.Batch(c.preSubmitCompactCmd(), m.ensureSpinnerTicking())
@@ -382,6 +401,8 @@ func (c uiInputController) handleSpinnerTick(msg spinnerTickMsg) (tea.Model, tea
 
 func (c uiInputController) handleCompactDone(msg compactDoneMsg) (tea.Model, tea.Cmd) {
 	m := c.model
+	compactionOrigin := m.compactionOrigin
+	m.compactionOrigin = uiCompactionOriginNone
 	c.finishBusyActivity(true)
 	c.releaseLockedInjectedInput(true)
 	if msg.err != nil {
@@ -406,6 +427,7 @@ func (c uiInputController) handleCompactDone(msg compactDoneMsg) (tea.Model, tea
 	m.activity = uiActivityIdle
 	m.logf("compaction.done")
 	if len(m.queued) > 0 {
+		c.notifyUserCompactionCompleted(compactionOrigin, false)
 		return c.flushQueuedInputs(queueDrainAuto)
 	}
 	queuedRuntimeWork, err := m.hasQueuedRuntimeUserWork()
@@ -425,8 +447,21 @@ func (c uiInputController) handleCompactDone(msg compactDoneMsg) (tea.Model, tea
 		return m, appendCmd
 	}
 	if queuedRuntimeWork {
+		c.notifyUserCompactionCompleted(compactionOrigin, false)
 		return m, c.startQueuedInjectionSubmission()
 	}
+	c.notifyUserCompactionCompleted(compactionOrigin, !m.pendingQueuedDrainAfterHydration)
 	m.syncViewport()
 	return m, nil
+}
+
+func (c uiInputController) notifyUserCompactionCompleted(origin uiCompactionOrigin, queueDrained bool) {
+	m := c.model
+	if m == nil || m.turnQueueHook == nil {
+		return
+	}
+	switch origin {
+	case uiCompactionOriginManual, uiCompactionOriginQueued:
+		m.turnQueueHook.OnUserCompactionCompleted(queueDrained)
+	}
 }

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -451,7 +451,9 @@ func (c uiInputController) handleCompactDone(msg compactDoneMsg) (tea.Model, tea
 	m.logf("compaction.done")
 	if len(m.queued) > 0 {
 		c.notifyUserCompactionCompleted(compactionOrigin, false)
-		return c.flushQueuedInputs(queueDrainAuto)
+		next, cmd := c.flushQueuedInputs(queueDrainAuto)
+		c.notifyTurnQueueDrainedIfIdle()
+		return next, cmd
 	}
 	queuedRuntimeWork, err := m.hasQueuedRuntimeUserWork()
 	if err != nil {

--- a/cli/app/ui_loop.go
+++ b/cli/app/ui_loop.go
@@ -64,6 +64,7 @@ func runUILoopWithInitialPrompt(wiring *runtimeWiring, active config.Settings, l
 		WithUIStatusConfig(statusConfig),
 		WithUIStartupUpdateNotice(startupUpdateNotice),
 		WithUITerminalCursorState(terminalCursor),
+		WithUITerminalFocusState(wiring.terminalFocus),
 	)
 	if closable, ok := model.(interface{ Close() }); ok {
 		defer closable.Close()
@@ -89,7 +90,7 @@ func mainUIProgramOptions(active config.Settings, terminalCursor *uiTerminalCurs
 }
 
 func mainUIProgramOptionsWithOutput(active config.Settings, terminalCursor *uiTerminalCursorState, output io.Writer) []tea.ProgramOption {
-	options := []tea.ProgramOption{tea.WithFilter(terminalCursorProgramFilter(terminalCursor))}
+	options := []tea.ProgramOption{tea.WithFilter(terminalCursorProgramFilter(terminalCursor)), tea.WithReportFocus()}
 	if terminalCursor != nil {
 		options = append(options, tea.WithOutput(mainUIProgramOutputWriter(terminalCursor, output)))
 	}

--- a/cli/app/ui_part4_test.go
+++ b/cli/app/ui_part4_test.go
@@ -347,6 +347,7 @@ type countingTurnQueueHook struct {
 func (h *countingTurnQueueHook) OnProjectedRuntimeEvent(clientui.Event) { h.projected++ }
 func (h *countingTurnQueueHook) OnTurnQueueDrained()                    { h.drained++ }
 func (h *countingTurnQueueHook) OnTurnQueueAborted()                    { h.aborted++ }
+func (h *countingTurnQueueHook) OnUserCompactionCompleted(bool)         {}
 
 func TestRuntimeIdleQueuedDrainNotifiesTurnQueueHookOnce(t *testing.T) {
 	client := &runtimeControlFakeClient{}

--- a/cli/app/ui_part4_test.go
+++ b/cli/app/ui_part4_test.go
@@ -170,6 +170,263 @@ func TestBusySteeringBatchFlushPreservesPostTurnQueueOrder(t *testing.T) {
 	}
 }
 
+func TestPreSubmitCompactionKeepsActiveQueuedMessageAheadOfLaterQueueItems(t *testing.T) {
+	client := &runtimeControlFakeClient{shouldCompactResult: true}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.queued = []string{"first queued", "second queued", "third queued"}
+
+	next, cmd := m.inputController().flushQueuedInputs(queueDrainAuto)
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected first queued message to start pre-submit check")
+	}
+	msgs := collectCmdMessages(t, cmd)
+	var preSubmit preSubmitCompactionCheckDoneMsg
+	foundPreSubmit := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(preSubmitCompactionCheckDoneMsg); ok {
+			preSubmit = typed
+			foundPreSubmit = true
+		}
+	}
+	if !foundPreSubmit {
+		t.Fatalf("expected pre-submit check completion, got %+v", msgs)
+	}
+	if preSubmit.text != "first queued" || !preSubmit.shouldCompact {
+		t.Fatalf("pre-submit check = (%q, %t), want first queued requiring compaction", preSubmit.text, preSubmit.shouldCompact)
+	}
+
+	next, cmd = updated.Update(preSubmit)
+	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected pre-submit compaction command")
+	}
+	_ = collectCmdMessages(t, cmd)
+	if updated.pendingPreSubmitText != "first queued" {
+		t.Fatalf("pending pre-submit text = %q, want first queued", updated.pendingPreSubmitText)
+	}
+
+	client.shouldCompactResult = false
+	next, cmd = updated.Update(compactDoneMsg{})
+	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected original queued message to resume pre-submit after compaction")
+	}
+	msgs = collectCmdMessages(t, cmd)
+	foundPreSubmit = false
+	for _, msg := range msgs {
+		if typed, ok := msg.(preSubmitCompactionCheckDoneMsg); ok {
+			preSubmit = typed
+			foundPreSubmit = true
+		}
+	}
+	if !foundPreSubmit {
+		t.Fatalf("expected pre-submit completion for original queued message, got %+v", msgs)
+	}
+	if preSubmit.text != "first queued" || preSubmit.shouldCompact {
+		t.Fatalf("resumed pre-submit check = (%q, %t), want first queued without compaction", preSubmit.text, preSubmit.shouldCompact)
+	}
+
+	next, cmd = updated.Update(preSubmit)
+	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected original queued message to submit after resumed pre-submit")
+	}
+	msgs = collectCmdMessages(t, cmd)
+	var done submitDoneMsg
+	foundDone := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(submitDoneMsg); ok {
+			done = typed
+			foundDone = true
+		}
+	}
+	if !foundDone {
+		t.Fatalf("expected submit completion for original queued message, got %+v", msgs)
+	}
+	if done.submittedText != "first queued" || client.submitText != "first queued" {
+		t.Fatalf("submitted text = (%q, %q), want first queued before later queued items", done.submittedText, client.submitText)
+	}
+	if len(updated.queued) != 2 || updated.queued[0] != "second queued" || updated.queued[1] != "third queued" {
+		t.Fatalf("expected later queued messages preserved in order, got %+v", updated.queued)
+	}
+}
+
+func TestRuntimeIdleEventResumesVisibleQueuedMessagesWithoutBlankEnter(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.busy = true
+	m.activity = uiActivityRunning
+	m.queued = []string{"first queued", "second queued"}
+	client.transcript = clientui.TranscriptPage{
+		SessionID:    "session-1",
+		Revision:     4,
+		Offset:       0,
+		TotalEntries: 1,
+		Entries:      []clientui.ChatEntry{{Role: "assistant", Text: "done"}},
+	}
+
+	next, cmd := m.Update(runtimeEventMsg{event: clientui.Event{
+		Kind:     clientui.EventRunStateChanged,
+		RunState: &clientui.RunState{Busy: false},
+	}})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected runtime idle event to start queued drain hydration")
+	}
+	if !updated.pendingQueuedDrainAfterHydration {
+		t.Fatal("expected queued drain armed after runtime idle event")
+	}
+	msgs := collectCmdMessages(t, cmd)
+	var refresh runtimeTranscriptRefreshedMsg
+	foundRefresh := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(runtimeTranscriptRefreshedMsg); ok {
+			refresh = typed
+			foundRefresh = true
+		}
+	}
+	if !foundRefresh {
+		t.Fatalf("expected queued drain transcript refresh, got %+v", msgs)
+	}
+
+	next, cmd = updated.Update(refresh)
+	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected queued message to enter pre-submit after hydration")
+	}
+	_ = collectCmdMessages(t, cmd)
+	if updated.pendingPreSubmitText != "first queued" {
+		t.Fatalf("pending pre-submit text = %q, want first queued without blank Enter", updated.pendingPreSubmitText)
+	}
+	if len(updated.queued) != 2 || updated.queued[0] != "first queued" || updated.queued[1] != "second queued" {
+		t.Fatalf("expected runtime pre-submit to own first queued while preserving visible queue order, got %+v", updated.queued)
+	}
+}
+
+func TestRuntimeIdleEventDoesNotDuplicatePendingQueuedDrainHydration(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.busy = true
+	m.activity = uiActivityRunning
+	m.queued = []string{"first queued", "second queued"}
+	m.pendingQueuedDrainAfterHydration = true
+	m.queuedDrainReadyAfterHydration = false
+
+	next, cmd := m.Update(runtimeEventMsg{event: clientui.Event{
+		Kind:     clientui.EventRunStateChanged,
+		RunState: &clientui.RunState{Busy: false},
+	}})
+	updated := next.(*uiModel)
+	if !updated.pendingQueuedDrainAfterHydration {
+		t.Fatal("expected existing queued drain hydration to stay armed")
+	}
+	if len(updated.queued) != 2 || updated.queued[0] != "first queued" || updated.queued[1] != "second queued" {
+		t.Fatalf("expected queued messages preserved without duplicate drain, got %+v", updated.queued)
+	}
+	msgs := collectCmdMessages(t, cmd)
+	for _, msg := range msgs {
+		if _, ok := msg.(runtimeTranscriptRefreshedMsg); ok {
+			t.Fatalf("did not expect duplicate queued drain transcript refresh, got %+v", msgs)
+		}
+		if _, ok := msg.(preSubmitCompactionCheckDoneMsg); ok {
+			t.Fatalf("did not expect duplicate queued drain pre-submit, got %+v", msgs)
+		}
+	}
+}
+
+type countingTurnQueueHook struct {
+	projected int
+	drained   int
+	aborted   int
+}
+
+func (h *countingTurnQueueHook) OnProjectedRuntimeEvent(clientui.Event) { h.projected++ }
+func (h *countingTurnQueueHook) OnTurnQueueDrained()                    { h.drained++ }
+func (h *countingTurnQueueHook) OnTurnQueueAborted()                    { h.aborted++ }
+
+func TestRuntimeIdleQueuedDrainNotifiesTurnQueueHookOnce(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	hook := &countingTurnQueueHook{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUITurnQueueHook(hook))
+	m.startupCmds = nil
+	m.busy = true
+	m.activity = uiActivityRunning
+	m.queued = []string{"follow up"}
+	client.transcript = clientui.TranscriptPage{
+		SessionID:    "session-1",
+		Revision:     4,
+		Offset:       0,
+		TotalEntries: 1,
+		Entries:      []clientui.ChatEntry{{Role: "assistant", Text: "done"}},
+	}
+
+	next, cmd := m.Update(runtimeEventMsg{event: clientui.Event{
+		Kind:     clientui.EventRunStateChanged,
+		RunState: &clientui.RunState{Busy: false},
+	}})
+	updated := next.(*uiModel)
+	msgs := collectCmdMessages(t, cmd)
+	var refresh runtimeTranscriptRefreshedMsg
+	foundRefresh := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(runtimeTranscriptRefreshedMsg); ok {
+			refresh = typed
+			foundRefresh = true
+		}
+	}
+	if !foundRefresh {
+		t.Fatalf("expected queued drain transcript refresh, got %+v", msgs)
+	}
+	if hook.drained != 0 || hook.aborted != 0 {
+		t.Fatalf("hook counts before queued turn starts: drained=%d aborted=%d", hook.drained, hook.aborted)
+	}
+
+	next, cmd = updated.Update(refresh)
+	updated = next.(*uiModel)
+	msgs = collectCmdMessages(t, cmd)
+	var preSubmit preSubmitCompactionCheckDoneMsg
+	foundPreSubmit := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(preSubmitCompactionCheckDoneMsg); ok {
+			preSubmit = typed
+			foundPreSubmit = true
+		}
+	}
+	if !foundPreSubmit {
+		t.Fatalf("expected queued follow-up pre-submit, got %+v", msgs)
+	}
+	if hook.drained != 0 || hook.aborted != 0 {
+		t.Fatalf("hook counts while queued turn is running: drained=%d aborted=%d", hook.drained, hook.aborted)
+	}
+
+	next, cmd = updated.Update(preSubmit)
+	updated = next.(*uiModel)
+	msgs = collectCmdMessages(t, cmd)
+	var done submitDoneMsg
+	foundDone := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(submitDoneMsg); ok {
+			done = typed
+			foundDone = true
+		}
+	}
+	if !foundDone {
+		t.Fatalf("expected queued follow-up submit completion, got %+v", msgs)
+	}
+	next, _ = updated.Update(done)
+	updated = next.(*uiModel)
+	if hook.drained != 1 || hook.aborted != 0 {
+		t.Fatalf("hook counts after queued drain: drained=%d aborted=%d", hook.drained, hook.aborted)
+	}
+	if updated.busy || len(updated.queued) != 0 {
+		t.Fatalf("expected queue drained and idle, busy=%t queued=%+v", updated.busy, updated.queued)
+	}
+}
+
 func TestBusyEnterWithUserShellPrefixQueuesInsteadOfInjecting(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.busy = true

--- a/cli/app/ui_part4_test.go
+++ b/cli/app/ui_part4_test.go
@@ -253,6 +253,39 @@ func TestPreSubmitCompactionKeepsActiveQueuedMessageAheadOfLaterQueueItems(t *te
 	}
 }
 
+func TestDirectSubmitQueuesBehindExistingVisibleMessages(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.queued = []string{"first queued"}
+	m.input = "direct submit"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected existing queued message to start before direct submit")
+	}
+	msgs := collectCmdMessages(t, cmd)
+	foundPreSubmit := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(preSubmitCompactionCheckDoneMsg); ok {
+			foundPreSubmit = true
+			if typed.text != "first queued" {
+				t.Fatalf("pre-submit text = %q, want first queued", typed.text)
+			}
+		}
+	}
+	if !foundPreSubmit {
+		t.Fatalf("expected pre-submit check for existing queued message, got %+v", msgs)
+	}
+	if updated.pendingPreSubmitText != "first queued" {
+		t.Fatalf("pending pre-submit text = %q, want first queued", updated.pendingPreSubmitText)
+	}
+	if len(updated.queued) != 2 || updated.queued[0] != "first queued" || updated.queued[1] != "direct submit" {
+		t.Fatalf("expected direct submit queued behind existing message, got %+v", updated.queued)
+	}
+}
+
 func TestRuntimeIdleEventResumesVisibleQueuedMessagesWithoutBlankEnter(t *testing.T) {
 	client := &runtimeControlFakeClient{}
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -64,6 +64,9 @@ type uiInputFeatureState struct {
 	autoCompactionEnabled    bool
 	conversationFreshness    clientui.ConversationFreshness
 
+	// UI-side post-turn input queue. It may contain slash commands, shell
+	// commands, and other client-only actions; server queues only runtime
+	// injected user work.
 	queued               []string
 	preSubmitCheckToken  uint64
 	pendingPreSubmitText string

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -70,6 +70,7 @@ type uiInputFeatureState struct {
 	queued               []string
 	preSubmitCheckToken  uint64
 	pendingPreSubmitText string
+	compactionOrigin     uiCompactionOrigin
 	submitToken          uint64
 	activeSubmit         activeSubmitState
 
@@ -104,6 +105,7 @@ type uiInputFeatureState struct {
 type uiPresentationFeatureState struct {
 	theme           string
 	altScreenActive bool
+	terminalFocus   *terminalFocusState
 	terminalCursor  *uiTerminalCursorState
 	termWidth       int
 	termHeight      int

--- a/cli/app/ui_terminal_cursor_test.go
+++ b/cli/app/ui_terminal_cursor_test.go
@@ -111,8 +111,8 @@ func TestMainUIProgramOptionsPreservesTerminalFileOutput(t *testing.T) {
 	state := newUITerminalCursorState()
 	file := &fakeTerminalCursorFile{fd: 42}
 	options := mainUIProgramOptionsWithOutput(config.Settings{}, state, file)
-	if len(options) != 2 {
-		t.Fatalf("main options length = %d, want filter and output options", len(options))
+	if len(options) != 3 {
+		t.Fatalf("main options length = %d, want filter, focus reporting, and output options", len(options))
 	}
 
 	output := mainUIProgramOutputWriter(state, file)

--- a/cli/app/ui_test.go
+++ b/cli/app/ui_test.go
@@ -682,6 +682,56 @@ func TestDetailModeStatusLineOmitsModeLabel(t *testing.T) {
 	}
 }
 
+func TestAskQuestionLargeMarkdownPromptPreservesLogicalLines(t *testing.T) {
+	question := strings.Join([]string{
+		"    val preserved = true",
+		"Please review this plan before I continue:",
+		"",
+		"```kotlin",
+		"fun main() {",
+		"    println(\"hi\")",
+		"}",
+		"```",
+		"",
+		"- Keep the four leading spaces in the code block.",
+		"- Do not collapse blank lines.",
+	}, "\n")
+	m := newProjectedStaticUIModel()
+	m.termWidth = 72
+	m.termHeight = 24
+	m.windowSizeKnown = true
+	m.syncViewport()
+	testSetActiveAsk(m, &askEvent{req: askquestion.Request{Question: question}, reply: make(chan askReply, 1)})
+
+	wrapped, _ := m.layout().wrappedAskPromptLines(64)
+	gotLines := make([]string, 0, len(wrapped))
+	for _, line := range wrapped {
+		if strings.Contains(line.Text, "\n") {
+			t.Fatalf("ask prompt line contains embedded newline: %+v", line)
+		}
+		gotLines = append(gotLines, strings.TrimRight(line.Text, " "))
+	}
+	got := strings.Join(gotLines, "\n")
+	want := strings.Join([]string{
+		"    val preserved = true",
+		"Please review this plan before I continue:",
+		"",
+		"```kotlin",
+		"fun main() {",
+		"    println(\"hi\")",
+		"}",
+		"```",
+		"",
+		"- Keep the four leading spaces in the code block.",
+		"- Do not collapse blank lines.",
+		"›",
+		"Enter to submit",
+	}, "\n")
+	if got != want {
+		t.Fatalf("ask prompt snapshot mismatch:\n--- got ---\n%q\n--- want ---\n%q", got, want)
+	}
+}
+
 func TestDoubleEscEntersRollbackSelectionAndEnterStartsEditing(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUIInitialTranscript([]UITranscriptEntry{
 		{Role: "user", Text: "u1"},

--- a/cli/app/ui_turn_completion_bell_test.go
+++ b/cli/app/ui_turn_completion_bell_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -14,7 +15,7 @@ import (
 
 func TestSubmitDoneDefersTurnCompletionBellUntilQueuedTurnsFinish(t *testing.T) {
 	ringer := &countRinger{}
-	bells := newBellHooks(ringer, nil)
+	bells := newUnfocusedBellHooks(ringer)
 	m := newProjectedStaticUIModel(WithUITurnQueueHook(bells))
 	m.busy = true
 	m.queued = []string{"follow up"}
@@ -70,7 +71,7 @@ func TestPreSubmitCheckErrorAbortsPendingTurnCompletionBell(t *testing.T) {
 	}
 
 	ringer := &countRinger{}
-	bells := newBellHooks(ringer, nil)
+	bells := newUnfocusedBellHooks(ringer)
 	m := newProjectedEngineUIModel(eng, WithUITurnQueueHook(bells))
 
 	next, _ := m.Update(runtimeEventMsg{event: clientui.Event{Kind: clientui.EventToolCallStarted, StepID: "step-1"}})
@@ -102,7 +103,7 @@ func TestPreSubmitCheckErrorAbortsPendingTurnCompletionBell(t *testing.T) {
 
 func TestNoopFinalAbortsPendingTurnCompletionBell(t *testing.T) {
 	ringer := &countRinger{}
-	bells := newBellHooks(ringer, nil)
+	bells := newUnfocusedBellHooks(ringer)
 	m := newProjectedStaticUIModel(WithUITurnQueueHook(bells))
 	m.busy = true
 
@@ -129,7 +130,7 @@ func TestNoopFinalAbortsPendingTurnCompletionBell(t *testing.T) {
 
 func TestQueuedFollowUpAfterNoopFinalDoesNotLeakTurnCompletionBell(t *testing.T) {
 	ringer := &countRinger{}
-	bells := newBellHooks(ringer, nil)
+	bells := newUnfocusedBellHooks(ringer)
 	m := newProjectedStaticUIModel(WithUITurnQueueHook(bells))
 	m.busy = true
 	m.queued = []string{"follow up"}
@@ -155,5 +156,350 @@ func TestQueuedFollowUpAfterNoopFinalDoesNotLeakTurnCompletionBell(t *testing.T)
 	bells.OnTurnQueueDrained()
 	if got := ringer.Count(); got != 0 {
 		t.Fatalf("ring count = %d after forced drain following queued NO_OP final, want 0", got)
+	}
+}
+
+func TestManualCompactRingsWhenIdleAfterCompaction(t *testing.T) {
+	ringer := &countRinger{}
+	bells := newUnfocusedBellHooks(ringer)
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUITurnQueueHook(bells))
+	m.startupCmds = nil
+	m.input = "/compact keep API details"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected manual compaction command")
+	}
+	if !updated.busy || !updated.compacting {
+		t.Fatalf("expected manual compaction to set busy/compacting, busy=%t compacting=%t", updated.busy, updated.compacting)
+	}
+	msgs := collectCmdMessages(t, cmd)
+	var done compactDoneMsg
+	foundDone := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(compactDoneMsg); ok {
+			done = typed
+			foundDone = true
+		}
+	}
+	if !foundDone {
+		t.Fatalf("expected compactDoneMsg, got %+v", msgs)
+	}
+
+	next, _ = updated.Update(done)
+	updated = next.(*uiModel)
+	if updated.busy || updated.compacting {
+		t.Fatalf("expected idle after manual compaction, busy=%t compacting=%t", updated.busy, updated.compacting)
+	}
+	if got := ringer.Count(); got != 1 {
+		t.Fatalf("ring count = %d after idle manual compaction, want 1", got)
+	}
+	if got := ringer.Last(); got != "builder: Compaction finished" {
+		t.Fatalf("last ring = %q, want compaction completion", got)
+	}
+}
+
+func TestQueuedCompactRingsAfterCompactionWhenQueueIsDrained(t *testing.T) {
+	ringer := &countRinger{}
+	bells := newUnfocusedBellHooks(ringer)
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUITurnQueueHook(bells))
+	m.startupCmds = nil
+	m.busy = true
+	m.activity = uiActivityRunning
+	m.input = "/compact queued"
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	updated := next.(*uiModel)
+	if len(updated.queued) != 1 {
+		t.Fatalf("expected queued compact command, got %+v", updated.queued)
+	}
+	next, cmd := updated.Update(submitDoneMsg{message: "done"})
+	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected queued compact to start after turn done")
+	}
+	msgs := collectCmdMessages(t, cmd)
+	var done compactDoneMsg
+	foundDone := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(compactDoneMsg); ok {
+			done = typed
+			foundDone = true
+		}
+	}
+	if !foundDone {
+		t.Fatalf("expected compactDoneMsg from queued compact, got %+v", msgs)
+	}
+
+	next, _ = updated.Update(done)
+	updated = next.(*uiModel)
+	if updated.busy || updated.compacting {
+		t.Fatalf("expected idle after queued compaction, busy=%t compacting=%t", updated.busy, updated.compacting)
+	}
+	if got := ringer.Count(); got != 1 {
+		t.Fatalf("ring count = %d after queued compact, want 1", got)
+	}
+	if got := ringer.Last(); got != "builder: Compaction finished" {
+		t.Fatalf("last ring = %q, want compaction completion", got)
+	}
+}
+
+func TestQueuedCompactDefersBellUntilFollowingQueuedMessageDrains(t *testing.T) {
+	ringer := &countRinger{}
+	bells := newUnfocusedBellHooks(ringer)
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUITurnQueueHook(bells))
+	m.startupCmds = nil
+	m.busy = true
+	m.activity = uiActivityRunning
+	m.input = "/compact queued"
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	updated := next.(*uiModel)
+	updated.input = "follow up"
+	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyTab})
+	updated = next.(*uiModel)
+	if len(updated.queued) != 2 {
+		t.Fatalf("expected queued compact plus follow-up, got %+v", updated.queued)
+	}
+
+	next, cmd := updated.Update(submitDoneMsg{message: "done"})
+	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected queued drain hydration after turn done")
+	}
+	msgs := collectCmdMessages(t, cmd)
+	var refresh runtimeTranscriptRefreshedMsg
+	foundRefresh := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(runtimeTranscriptRefreshedMsg); ok {
+			refresh = typed
+			foundRefresh = true
+		}
+	}
+	if !foundRefresh {
+		t.Fatalf("expected queued drain transcript refresh, got %+v", msgs)
+	}
+
+	next, cmd = updated.Update(refresh)
+	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected queued compact to start after hydration")
+	}
+	msgs = collectCmdMessages(t, cmd)
+	var compactDone compactDoneMsg
+	foundCompactDone := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(compactDoneMsg); ok {
+			compactDone = typed
+			foundCompactDone = true
+		}
+	}
+	if !foundCompactDone {
+		t.Fatalf("expected compactDoneMsg from queued compact, got %+v", msgs)
+	}
+
+	next, cmd = updated.Update(compactDone)
+	updated = next.(*uiModel)
+	if got := ringer.Count(); got != 0 {
+		t.Fatalf("ring count after compact before following queued message = %d, want 0", got)
+	}
+	if cmd == nil {
+		t.Fatal("expected following queued message to start after compact")
+	}
+	msgs = collectCmdMessages(t, cmd)
+	var preSubmit preSubmitCompactionCheckDoneMsg
+	foundPreSubmit := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(preSubmitCompactionCheckDoneMsg); ok {
+			preSubmit = typed
+			foundPreSubmit = true
+		}
+	}
+	if !foundPreSubmit {
+		t.Fatalf("expected following queued pre-submit check, got %+v", msgs)
+	}
+
+	next, cmd = updated.Update(preSubmit)
+	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected following queued message to submit after pre-submit")
+	}
+	msgs = collectCmdMessages(t, cmd)
+	var submitDone submitDoneMsg
+	foundSubmitDone := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(submitDoneMsg); ok {
+			submitDone = typed
+			foundSubmitDone = true
+		}
+	}
+	if !foundSubmitDone {
+		t.Fatalf("expected following queued submitDoneMsg, got %+v", msgs)
+	}
+
+	next, _ = updated.Update(submitDone)
+	if got := ringer.Count(); got != 1 {
+		t.Fatalf("ring count after following queued message drained = %d, want 1", got)
+	}
+	if got := ringer.Last(); got != "builder: Compaction finished" {
+		t.Fatalf("last ring = %q, want compaction completion", got)
+	}
+}
+
+func TestPreSubmitCompactionDoesNotRing(t *testing.T) {
+	ringer := &countRinger{}
+	bells := newUnfocusedBellHooks(ringer)
+	client := &runtimeControlFakeClient{shouldCompactResult: true}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUITurnQueueHook(bells))
+	m.startupCmds = nil
+	m.input = "follow up"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	msgs := collectCmdMessages(t, cmd)
+	var preSubmit preSubmitCompactionCheckDoneMsg
+	foundPreSubmit := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(preSubmitCompactionCheckDoneMsg); ok {
+			preSubmit = typed
+			foundPreSubmit = true
+		}
+	}
+	if !foundPreSubmit {
+		t.Fatalf("expected pre-submit compaction check, got %+v", msgs)
+	}
+
+	next, cmd = updated.Update(preSubmit)
+	updated = next.(*uiModel)
+	msgs = collectCmdMessages(t, cmd)
+	var done compactDoneMsg
+	foundDone := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(compactDoneMsg); ok {
+			done = typed
+			foundDone = true
+		}
+	}
+	if !foundDone {
+		t.Fatalf("expected pre-submit compactDoneMsg, got %+v", msgs)
+	}
+
+	next, _ = updated.Update(done)
+	if got := ringer.Count(); got != 0 {
+		t.Fatalf("ring count = %d after pre-submit compaction, want 0", got)
+	}
+}
+
+func TestManualCompactWithQueuedSteeringDoesNotRing(t *testing.T) {
+	ringer := &countRinger{}
+	bells := newUnfocusedBellHooks(ringer)
+	client := &runtimeControlFakeClient{hasQueuedUserWork: true, submitQueuedResult: "resumed"}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUITurnQueueHook(bells))
+	m.startupCmds = nil
+	m.busy = true
+	m.compacting = true
+	m.activity = uiActivityRunning
+	m.compactionOrigin = uiCompactionOriginManual
+	m.input = "steer after compact"
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	if len(updated.pendingInjected) != 1 {
+		t.Fatalf("expected queued steering, got %+v", updated.pendingInjected)
+	}
+	next, cmd := updated.Update(compactDoneMsg{})
+	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected queued steering to resume after compact")
+	}
+	if got := ringer.Count(); got != 0 {
+		t.Fatalf("ring count = %d after compact resumed steering, want 0", got)
+	}
+
+	msgs := collectCmdMessages(t, cmd)
+	var done submitDoneMsg
+	foundDone := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(submitDoneMsg); ok {
+			done = typed
+			foundDone = true
+		}
+	}
+	if !foundDone {
+		t.Fatalf("expected resumed steering submitDoneMsg, got %+v", msgs)
+	}
+	next, _ = updated.Update(done)
+	if got := ringer.Count(); got != 1 {
+		t.Fatalf("ring count = %d after queued steering drain, want 1", got)
+	}
+	if got := ringer.Last(); got != "builder: Compaction finished" {
+		t.Fatalf("last ring = %q, want compaction completion", got)
+	}
+}
+
+func TestFailedManualCompactClearsCompactionBell(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "failure", err: errors.New("compact failed")},
+		{name: "canceled", err: context.Canceled},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ringer := &countRinger{}
+			bells := newUnfocusedBellHooks(ringer)
+			m := newProjectedStaticUIModel(WithUITurnQueueHook(bells))
+			m.busy = true
+			m.compacting = true
+			m.activity = uiActivityRunning
+			m.compactionOrigin = uiCompactionOriginManual
+
+			next, _ := m.Update(compactDoneMsg{err: tt.err})
+			updated := next.(*uiModel)
+			if updated.compactionOrigin != uiCompactionOriginNone {
+				t.Fatalf("expected compaction origin cleared after %s, got %v", tt.name, updated.compactionOrigin)
+			}
+			if got := ringer.Count(); got != 0 {
+				t.Fatalf("ring count after %s = %d, want 0", tt.name, got)
+			}
+
+			next, _ = updated.Update(compactDoneMsg{})
+			if got := ringer.Count(); got != 0 {
+				t.Fatalf("delayed ring count after %s = %d, want 0", tt.name, got)
+			}
+		})
+	}
+}
+
+func TestManualCompactWithPendingQueuedDrainHydrationDoesNotRing(t *testing.T) {
+	ringer := &countRinger{}
+	bells := newUnfocusedBellHooks(ringer)
+	m := newProjectedStaticUIModel(WithUITurnQueueHook(bells))
+	m.busy = true
+	m.compacting = true
+	m.activity = uiActivityRunning
+	m.compactionOrigin = uiCompactionOriginManual
+	m.pendingQueuedDrainAfterHydration = true
+
+	next, _ := m.Update(compactDoneMsg{})
+	updated := next.(*uiModel)
+	if updated.compactionOrigin != uiCompactionOriginNone {
+		t.Fatalf("expected compaction origin cleared, got %v", updated.compactionOrigin)
+	}
+	if got := ringer.Count(); got != 0 {
+		t.Fatalf("ring count after compact with queued drain hydration = %d, want 0", got)
+	}
+
+	updated.inputController().notifyTurnQueueDrainedIfIdle()
+	if got := ringer.Count(); got != 1 {
+		t.Fatalf("ring count after later queued drain = %d, want 1", got)
+	}
+	if got := ringer.Last(); got != "builder: Compaction finished" {
+		t.Fatalf("last ring = %q, want compaction completion", got)
 	}
 }

--- a/cli/app/ui_turn_completion_bell_test.go
+++ b/cli/app/ui_turn_completion_bell_test.go
@@ -441,6 +441,32 @@ func TestManualCompactWithQueuedSteeringDoesNotRing(t *testing.T) {
 	}
 }
 
+func TestManualCompactRingsAfterQueuedLocalCommandDrains(t *testing.T) {
+	ringer := &countRinger{}
+	bells := newUnfocusedBellHooks(ringer)
+	m := newProjectedStaticUIModel(WithUITurnQueueHook(bells))
+	m.busy = true
+	m.compacting = true
+	m.activity = uiActivityRunning
+	m.compactionOrigin = uiCompactionOriginManual
+	m.queued = []string{"/status"}
+
+	next, cmd := m.Update(compactDoneMsg{})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected queued local command to run after compaction")
+	}
+	if updated.busy || len(updated.queued) != 0 {
+		t.Fatalf("expected queued local command to drain to idle, busy=%t queued=%+v", updated.busy, updated.queued)
+	}
+	if got := ringer.Count(); got != 1 {
+		t.Fatalf("ring count after queued local command drain = %d, want 1", got)
+	}
+	if got := ringer.Last(); got != "builder: Compaction finished" {
+		t.Fatalf("last ring = %q, want compaction completion", got)
+	}
+}
+
 func TestFailedManualCompactClearsCompactionBell(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cli/builder/service_backend_darwin.go
+++ b/cli/builder/service_backend_darwin.go
@@ -142,7 +142,7 @@ func bootstrapLaunchdService(ctx context.Context, spec serviceSpec, path string)
 		if !isTransientLaunchdBootstrapError(err) {
 			return err
 		}
-		return kickstartMatchingLoadedLaunchdService(ctx, spec, err)
+		return replaceStaleLaunchdService(ctx, path, err)
 	}
 	return nil
 }
@@ -155,12 +155,12 @@ func isTransientLaunchdBootstrapError(err error) bool {
 	return commandErr.Name == "launchctl" && commandErr.Result.Code == 5
 }
 
-func kickstartMatchingLoadedLaunchdService(ctx context.Context, spec serviceSpec, cause error) error {
-	loaded, output := launchdLoaded(ctx)
-	if !loaded || !commandArgsEqual(parseLaunchdPrintProgramArguments(output), serviceCommand(spec)) {
-		return cause
+func replaceStaleLaunchdService(ctx context.Context, path string, cause error) error {
+	target := launchdDomain() + "/" + serviceLaunchdLabel
+	if _, err := runServiceCommand(ctx, "launchctl", "bootout", target); err != nil {
+		return errors.Join(cause, err)
 	}
-	if _, err := runServiceCommand(ctx, "launchctl", "kickstart", "-k", launchdDomain()+"/"+serviceLaunchdLabel); err != nil {
+	if _, err := runServiceCommand(ctx, "launchctl", "bootstrap", launchdDomain(), path); err != nil {
 		return errors.Join(cause, err)
 	}
 	return nil

--- a/cli/builder/service_backend_darwin.go
+++ b/cli/builder/service_backend_darwin.go
@@ -11,9 +11,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type launchdServiceBackend struct{}
+
+var launchdServiceShutdownTimeout = 5 * time.Second
+var launchdServiceShutdownPollInterval = 100 * time.Millisecond
 
 func currentServiceBackend() serviceBackend {
 	return launchdServiceBackend{}
@@ -133,8 +137,47 @@ func reloadLaunchdService(ctx context.Context, spec serviceSpec, path string) er
 		if _, err := runServiceCommand(ctx, "launchctl", "bootout", launchdDomain()+"/"+serviceLaunchdLabel); err != nil {
 			return err
 		}
+		if err := waitForLaunchdServiceShutdown(ctx, spec); err != nil {
+			return err
+		}
 	}
 	return bootstrapLaunchdService(ctx, spec, path)
+}
+
+func waitForLaunchdServiceShutdown(ctx context.Context, spec serviceSpec) error {
+	timeout := launchdServiceShutdownTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	interval := launchdServiceShutdownPollInterval
+	if interval <= 0 {
+		interval = 100 * time.Millisecond
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		healthStatus, healthPID := probeServiceHealth(ctx, spec)
+		if healthStatus != "ok" {
+			return nil
+		}
+		loaded, _ := launchdLoaded(ctx)
+		if time.Now().After(deadline) {
+			detail := "Builder server still responds on " + spec.Endpoint
+			if healthPID > 0 {
+				detail = fmt.Sprintf("%s (pid %d)", detail, healthPID)
+			}
+			if loaded {
+				detail += "; launchd still reports the service as loaded"
+			}
+			return fmt.Errorf("stopped launchd job, but the old Builder server did not exit before restart: %s. Not bootstrapping a second server because it would fail with launchctl Bootstrap error 5. Re-running with sudo will not fix this; stop the stale builder process or wait for it to exit, then run `builder service restart` again", detail)
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
 }
 
 func bootstrapLaunchdService(ctx context.Context, spec serviceSpec, path string) error {
@@ -142,7 +185,7 @@ func bootstrapLaunchdService(ctx context.Context, spec serviceSpec, path string)
 		if !isTransientLaunchdBootstrapError(err) {
 			return err
 		}
-		return replaceStaleLaunchdService(ctx, path, err)
+		return replaceStaleLaunchdService(ctx, spec, path, err)
 	}
 	return nil
 }
@@ -155,9 +198,12 @@ func isTransientLaunchdBootstrapError(err error) bool {
 	return commandErr.Name == "launchctl" && commandErr.Result.Code == 5
 }
 
-func replaceStaleLaunchdService(ctx context.Context, path string, cause error) error {
+func replaceStaleLaunchdService(ctx context.Context, spec serviceSpec, path string, cause error) error {
 	target := launchdDomain() + "/" + serviceLaunchdLabel
 	if _, err := runServiceCommand(ctx, "launchctl", "bootout", target); err != nil {
+		return errors.Join(cause, err)
+	}
+	if err := waitForLaunchdServiceShutdown(ctx, spec); err != nil {
 		return errors.Join(cause, err)
 	}
 	if _, err := runServiceCommand(ctx, "launchctl", "bootstrap", launchdDomain(), path); err != nil {

--- a/cli/builder/service_backend_darwin_test.go
+++ b/cli/builder/service_backend_darwin_test.go
@@ -162,8 +162,100 @@ func TestLaunchdRestartIfInstalledReplacesStaleLoadedServiceAfterTransientBootst
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("calls = %#v, want %#v", *calls, want)
 	}
-	if !strings.Contains(stdout.String(), "Restarted Builder background service.") {
-		t.Fatalf("stdout = %q, want restart confirmation", stdout.String())
+	wantStdout := "Builder background service is installed. Restarting it after update; sessions may fail briefly.\nRestarted Builder background service.\n"
+	if stdout.String() != wantStdout {
+		t.Fatalf("stdout = %q, want %q", stdout.String(), wantStdout)
+	}
+}
+
+func TestLaunchdRestartIfInstalledBootstrapRecoveryFailsWhenBootoutFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	spec := testLaunchdServiceSpec(t)
+	withLaunchdServiceCommandSpec(t, spec)
+	path := mustLaunchdPlistPath(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(renderLaunchdPlist(spec)), 0o644); err != nil {
+		t.Fatalf("write plist: %v", err)
+	}
+	printCalls := 0
+	var calls *[][]string
+	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch strings.Join(append([]string{name}, args...), "\x00") {
+		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			printCalls++
+			if printCalls <= 2 {
+				return serviceCommandResult{Stdout: "state = running\npid = 42\narguments = {\n\t/old/builder\n\tserve\n}\n"}, nil
+			}
+			return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
+		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
+			return serviceCommandResult{Stderr: "Bootstrap failed: 5: Input/output error", Code: 5}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "Bootstrap failed: 5: Input/output error", Code: 5}}
+		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			return serviceCommandResult{Stderr: "bootout failed", Code: 5}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "bootout failed", Code: 5}}
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	code := serviceSubcommand([]string{"restart", "--if-installed"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if countLaunchdCommand(*calls, "bootstrap") != 1 || countLaunchdCommand(*calls, "bootout") != 1 {
+		t.Fatalf("calls = %#v, want one bootstrap then failed bootout", *calls)
+	}
+	if !strings.Contains(stderr.String(), "bootout failed") {
+		t.Fatalf("stderr = %q, want bootout failure", stderr.String())
+	}
+}
+
+func TestLaunchdRestartIfInstalledBootstrapRecoveryFailsWhenRetryBootstrapFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	spec := testLaunchdServiceSpec(t)
+	withLaunchdServiceCommandSpec(t, spec)
+	path := mustLaunchdPlistPath(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(renderLaunchdPlist(spec)), 0o644); err != nil {
+		t.Fatalf("write plist: %v", err)
+	}
+	printCalls := 0
+	var calls *[][]string
+	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch strings.Join(append([]string{name}, args...), "\x00") {
+		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			printCalls++
+			if printCalls <= 2 {
+				return serviceCommandResult{Stdout: "state = running\npid = 42\narguments = {\n\t/old/builder\n\tserve\n}\n"}, nil
+			}
+			return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
+		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
+			if countLaunchdCommand(*calls, "bootstrap") == 1 {
+				return serviceCommandResult{Stderr: "Bootstrap failed: 5: Input/output error", Code: 5}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "Bootstrap failed: 5: Input/output error", Code: 5}}
+			}
+			return serviceCommandResult{Stderr: "retry bootstrap failed", Code: 5}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "retry bootstrap failed", Code: 5}}
+		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	code := serviceSubcommand([]string{"restart", "--if-installed"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if countLaunchdCommand(*calls, "bootstrap") != 2 || countLaunchdCommand(*calls, "bootout") != 1 {
+		t.Fatalf("calls = %#v, want failed bootstrap, bootout, failed retry bootstrap", *calls)
+	}
+	if !strings.Contains(stderr.String(), "retry bootstrap failed") {
+		t.Fatalf("stderr = %q, want retry bootstrap failure", stderr.String())
 	}
 }
 

--- a/cli/builder/service_backend_darwin_test.go
+++ b/cli/builder/service_backend_darwin_test.go
@@ -4,11 +4,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -258,6 +261,72 @@ func TestLaunchdReloadExplainsOldServerStillRunningInsteadOfBootstrapCodeFive(t 
 	}
 }
 
+func TestLaunchdRestartIfInstalledRepeatedIntegration(t *testing.T) {
+	if os.Getenv("BUILDER_LAUNCHD_INTEGRATION") != "1" {
+		t.Skip("set BUILDER_LAUNCHD_INTEGRATION=1 to run real launchd service restart integration")
+	}
+	builderPath := strings.TrimSpace(os.Getenv("BUILDER_LAUNCHD_INTEGRATION_BUILDER"))
+	if builderPath == "" {
+		var err error
+		builderPath, err = exec.LookPath("builder")
+		if err != nil {
+			t.Fatalf("find builder binary: %v", err)
+		}
+	}
+	freePort := reserveFreeLocalPort(t)
+	root := t.TempDir()
+	wrapperPath := filepath.Join(root, "builder")
+	wrapper := fmt.Sprintf("#!/bin/sh\nexport BUILDER_SERVER_PORT=%d\nexport BUILDER_PERSISTENCE_ROOT=%s\nexec -a \"$0\" %s \"$@\"\n", freePort, shellQuote(filepath.Join(root, "persist")), shellQuote(builderPath))
+	if err := os.WriteFile(wrapperPath, []byte(wrapper), 0o755); err != nil {
+		t.Fatalf("write builder wrapper: %v", err)
+	}
+	home := filepath.Join(root, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	env := append(os.Environ(),
+		"HOME="+home,
+		fmt.Sprintf("BUILDER_SERVER_PORT=%d", freePort),
+		"BUILDER_PERSISTENCE_ROOT="+filepath.Join(root, "persist"),
+	)
+	runBuilder := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(wrapperPath, args...)
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s %s failed: %v\n%s", wrapperPath, strings.Join(args, " "), err, out)
+		}
+		return string(out)
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command(wrapperPath, "service", "uninstall")
+		cmd.Env = env
+		_ = cmd.Run()
+	})
+
+	runBuilder("service", "install", "--force")
+	lastPID := 0
+	for i := 0; i < 3; i++ {
+		output := runBuilder("service", "restart", "--if-installed")
+		if !strings.Contains(output, "Restarted Builder background service.") {
+			t.Fatalf("restart output = %q, want restart confirmation", output)
+		}
+		status := runBuilder("service", "status", "--json")
+		var decoded serviceStatus
+		if err := json.Unmarshal([]byte(status), &decoded); err != nil {
+			t.Fatalf("decode status JSON: %v; raw=%q", err, status)
+		}
+		if !decoded.Installed || !decoded.Loaded || !decoded.Running || decoded.PID <= 0 {
+			t.Fatalf("status after restart %d = %+v, want installed/loaded/running with pid", i+1, decoded)
+		}
+		if lastPID > 0 && decoded.PID == lastPID {
+			t.Fatalf("pid did not change after restart %d: %d", i+1, decoded.PID)
+		}
+		lastPID = decoded.PID
+	}
+}
+
 func TestLaunchdStartReplacesStaleLoadedServiceAfterTransientBootstrapError(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	spec := testLaunchdServiceSpec(t)
@@ -422,4 +491,14 @@ func countLaunchdCommand(calls [][]string, name string) int {
 		}
 	}
 	return count
+}
+
+func reserveFreeLocalPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve local port: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	return listener.Addr().(*net.TCPAddr).Port
 }

--- a/cli/builder/service_backend_darwin_test.go
+++ b/cli/builder/service_backend_darwin_test.go
@@ -104,7 +104,63 @@ func TestLaunchdRestartKickstartsLoadedServiceWithoutBootstrap(t *testing.T) {
 	}
 }
 
-func TestLaunchdStartFallsBackToKickstartWhenBootstrapFindsMatchingLoadedService(t *testing.T) {
+func TestLaunchdRestartIfInstalledReplacesStaleLoadedServiceAfterTransientBootstrapError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	spec := testLaunchdServiceSpec(t)
+	withLaunchdServiceCommandSpec(t, spec)
+	path := mustLaunchdPlistPath(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(renderLaunchdPlist(spec)), 0o644); err != nil {
+		t.Fatalf("write plist: %v", err)
+	}
+	printCalls := 0
+	var calls *[][]string
+	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch strings.Join(append([]string{name}, args...), "\x00") {
+		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			printCalls++
+			if printCalls <= 2 {
+				return serviceCommandResult{Stdout: "state = running\npid = 42\narguments = {\n\t/old/builder\n\tserve\n}\n"}, nil
+			}
+			return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
+		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
+			if countLaunchdCommand(*calls, "bootstrap") == 1 {
+				return serviceCommandResult{Stderr: "Bootstrap failed: 5: Input/output error", Code: 5}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "Bootstrap failed: 5: Input/output error", Code: 5}}
+			}
+			return serviceCommandResult{}, nil
+		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	code := serviceSubcommand([]string{"restart", "--if-installed"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+
+	want := [][]string{
+		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
+		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
+		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
+		{"launchctl", "bootstrap", "gui/" + currentUIDText(), path},
+		{"launchctl", "bootout", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
+		{"launchctl", "bootstrap", "gui/" + currentUIDText(), path},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("calls = %#v, want %#v", *calls, want)
+	}
+	if !strings.Contains(stdout.String(), "Restarted Builder background service.") {
+		t.Fatalf("stdout = %q, want restart confirmation", stdout.String())
+	}
+}
+
+func TestLaunchdStartReplacesStaleLoadedServiceAfterTransientBootstrapError(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	spec := testLaunchdServiceSpec(t)
 	path := mustLaunchdPlistPath(t)
@@ -114,19 +170,17 @@ func TestLaunchdStartFallsBackToKickstartWhenBootstrapFindsMatchingLoadedService
 	if err := os.WriteFile(path, []byte(renderLaunchdPlist(spec)), 0o644); err != nil {
 		t.Fatalf("write plist: %v", err)
 	}
-	loadedPrint := "state = running\narguments = {\n\t/usr/local/bin/builder\n\tserve\n}\n"
-	printCalls := 0
-	calls := captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
+	var calls *[][]string
+	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
 		switch strings.Join(append([]string{name}, args...), "\x00") {
 		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
-			printCalls++
-			if printCalls == 1 {
-				return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
-			}
-			return serviceCommandResult{Stdout: loadedPrint}, nil
+			return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
 		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
-			return serviceCommandResult{Stderr: "Bootstrap failed: 5: Input/output error", Code: 5}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "Bootstrap failed: 5: Input/output error", Code: 5}}
-		case "launchctl\x00kickstart\x00-k\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			if countLaunchdCommand(*calls, "bootstrap") == 1 {
+				return serviceCommandResult{Stderr: "Bootstrap failed: 5: Input/output error", Code: 5}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "Bootstrap failed: 5: Input/output error", Code: 5}}
+			}
+			return serviceCommandResult{}, nil
+		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
 			return serviceCommandResult{}, nil
 		default:
 			return serviceCommandResult{}, errors.New("unexpected command")
@@ -140,8 +194,8 @@ func TestLaunchdStartFallsBackToKickstartWhenBootstrapFindsMatchingLoadedService
 	want := [][]string{
 		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 		{"launchctl", "bootstrap", "gui/" + currentUIDText(), path},
-		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
-		{"launchctl", "kickstart", "-k", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
+		{"launchctl", "bootout", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
+		{"launchctl", "bootstrap", "gui/" + currentUIDText(), path},
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("calls = %#v, want %#v", *calls, want)
@@ -237,6 +291,18 @@ func captureLaunchdServiceCommands(t *testing.T, fn func(context.Context, string
 	return &calls
 }
 
+func withLaunchdServiceCommandSpec(t *testing.T, spec serviceSpec) {
+	t.Helper()
+	originalLoadSpec := loadServiceSpec
+	originalBackendFactory := serviceBackendFactory
+	loadServiceSpec = func() (serviceSpec, error) { return spec, nil }
+	serviceBackendFactory = func() serviceBackend { return launchdServiceBackend{} }
+	t.Cleanup(func() {
+		loadServiceSpec = originalLoadSpec
+		serviceBackendFactory = originalBackendFactory
+	})
+}
+
 func currentUIDText() string {
 	return strconv.Itoa(os.Getuid())
 }
@@ -248,4 +314,14 @@ func mustLaunchdPlistPath(t *testing.T) string {
 		t.Fatalf("launchd plist path: %v", err)
 	}
 	return path
+}
+
+func countLaunchdCommand(calls [][]string, name string) int {
+	count := 0
+	for _, call := range calls {
+		if len(call) >= 2 && call[0] == "launchctl" && call[1] == name {
+			count++
+		}
+	}
+	return count
 }

--- a/cli/builder/service_backend_darwin_test.go
+++ b/cli/builder/service_backend_darwin_test.go
@@ -5,12 +5,16 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestLaunchdInstallReloadsLoadedServiceBeforeBootstrap(t *testing.T) {
@@ -157,6 +161,100 @@ func TestLaunchdRestartIfInstalledReplacesStaleLoadedServiceAfterTransientBootst
 	}
 	if !strings.Contains(stdout.String(), "Restarted Builder background service.") {
 		t.Fatalf("stdout = %q, want restart confirmation", stdout.String())
+	}
+}
+
+func TestLaunchdReloadWaitsForOldServerBeforeBootstrap(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	serverRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		serverRequests++
+		if serverRequests == 1 {
+			_, _ = fmt.Fprint(w, `{"status":"ok","pid":42}`)
+			return
+		}
+		http.Error(w, "stopped", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+	spec := testLaunchdServiceSpec(t)
+	spec.Endpoint = server.URL
+	path := mustLaunchdPlistPath(t)
+	calls := captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch strings.Join(append([]string{name}, args...), "\x00") {
+		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			return serviceCommandResult{Stdout: "state = running\npid = 42\n"}, nil
+		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			return serviceCommandResult{}, nil
+		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
+			if serverRequests < 2 {
+				t.Fatalf("bootstrap happened before old server health went down")
+			}
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	if err := reloadLaunchdService(context.Background(), spec, path); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	want := [][]string{
+		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
+		{"launchctl", "bootout", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
+		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
+		{"launchctl", "bootstrap", "gui/" + currentUIDText(), path},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("calls = %#v, want %#v", *calls, want)
+	}
+}
+
+func TestLaunchdReloadExplainsOldServerStillRunningInsteadOfBootstrapCodeFive(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	originalTimeout := launchdServiceShutdownTimeout
+	originalInterval := launchdServiceShutdownPollInterval
+	launchdServiceShutdownTimeout = time.Millisecond
+	launchdServiceShutdownPollInterval = time.Millisecond
+	t.Cleanup(func() {
+		launchdServiceShutdownTimeout = originalTimeout
+		launchdServiceShutdownPollInterval = originalInterval
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"status":"ok","pid":42}`)
+	}))
+	t.Cleanup(server.Close)
+	spec := testLaunchdServiceSpec(t)
+	spec.Endpoint = server.URL
+	path := mustLaunchdPlistPath(t)
+	calls := captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch strings.Join(append([]string{name}, args...), "\x00") {
+		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			return serviceCommandResult{Stdout: "state = running\npid = 42\n"}, nil
+		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	err := reloadLaunchdService(context.Background(), spec, path)
+	if err == nil {
+		t.Fatal("expected reload to fail while old server is still healthy")
+	}
+	if !strings.Contains(err.Error(), "old Builder server did not exit") || !strings.Contains(err.Error(), "sudo will not fix this") || !strings.Contains(err.Error(), "Bootstrap error 5") {
+		t.Fatalf("error = %v, want actionable old-server message", err)
+	}
+	if countLaunchdCommand(*calls, "bootstrap") != 0 {
+		t.Fatalf("bootstrap should not run while old server still owns port, calls=%#v", *calls)
 	}
 }
 

--- a/cli/builder/service_command.go
+++ b/cli/builder/service_command.go
@@ -245,17 +245,6 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 			if !status.Installed {
 				return 0
 			}
-			healthStatus, healthPID := probeServiceHealth(ctx, spec)
-			if healthStatus == protocol.HealthStatusOK && !serviceOwnsHealthyServer(status, healthPID, spec) {
-				fmt.Fprintln(stdout, "Builder background service is installed, but a Builder server is already running outside the background service.")
-				fmt.Fprintln(stdout, "Refreshing service registration without starting it; restart skipped to avoid disrupting the running session.")
-				if err := backend.Install(ctx, spec, true, false); err != nil {
-					fmt.Fprintln(stderr, err)
-					return 1
-				}
-				fmt.Fprintf(stdout, "Updated %s registration.\n", serviceDisplayName)
-				return 0
-			}
 			if err := ensureNoUnmanagedServerConflict(ctx, backend, spec); err != nil {
 				fmt.Fprintln(stderr, err)
 				return 1
@@ -277,15 +266,6 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 	return 0
 }
 
-func serviceOwnsHealthyServer(status serviceStatus, healthPID int, spec serviceSpec) bool {
-	if !status.Running || !status.Loaded {
-		return false
-	}
-	pidProof := status.PID > 0 && healthPID > 0 && status.PID == healthPID
-	commandProof := len(status.Command) > 0 && commandArgsEqual(status.Command, serviceCommand(spec))
-	return pidProof || commandProof
-}
-
 func ensureNoUnmanagedServerConflict(ctx context.Context, backend serviceBackend, spec serviceSpec) error {
 	status, err := backend.Status(ctx, spec)
 	if err != nil {
@@ -293,7 +273,9 @@ func ensureNoUnmanagedServerConflict(ctx context.Context, backend serviceBackend
 	}
 	healthStatus, healthPID := probeServiceHealth(ctx, spec)
 	healthRunning := healthStatus == protocol.HealthStatusOK
-	backendOwnsHealthyServer := healthRunning && serviceOwnsHealthyServer(status, healthPID, spec)
+	pidProof := status.PID > 0 && healthPID > 0 && status.PID == healthPID
+	commandProof := len(status.Command) > 0 && commandArgsEqual(status.Command, serviceCommand(spec))
+	backendOwnsHealthyServer := healthRunning && status.Running && status.Loaded && (pidProof || commandProof)
 	if healthRunning && !backendOwnsHealthyServer {
 		pidText := ""
 		if healthPID > 0 {

--- a/cli/builder/service_command.go
+++ b/cli/builder/service_command.go
@@ -245,6 +245,17 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 			if !status.Installed {
 				return 0
 			}
+			healthStatus, healthPID := probeServiceHealth(ctx, spec)
+			if healthStatus == protocol.HealthStatusOK && !serviceOwnsHealthyServer(status, healthPID, spec) {
+				fmt.Fprintln(stdout, "Builder background service is installed, but a Builder server is already running outside the background service.")
+				fmt.Fprintln(stdout, "Refreshing service registration without starting it; restart skipped to avoid disrupting the running session.")
+				if err := backend.Install(ctx, spec, true, false); err != nil {
+					fmt.Fprintln(stderr, err)
+					return 1
+				}
+				fmt.Fprintf(stdout, "Updated %s registration.\n", serviceDisplayName)
+				return 0
+			}
 			if err := ensureNoUnmanagedServerConflict(ctx, backend, spec); err != nil {
 				fmt.Fprintln(stderr, err)
 				return 1
@@ -266,6 +277,15 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 	return 0
 }
 
+func serviceOwnsHealthyServer(status serviceStatus, healthPID int, spec serviceSpec) bool {
+	if !status.Running || !status.Loaded {
+		return false
+	}
+	pidProof := status.PID > 0 && healthPID > 0 && status.PID == healthPID
+	commandProof := len(status.Command) > 0 && commandArgsEqual(status.Command, serviceCommand(spec))
+	return pidProof || commandProof
+}
+
 func ensureNoUnmanagedServerConflict(ctx context.Context, backend serviceBackend, spec serviceSpec) error {
 	status, err := backend.Status(ctx, spec)
 	if err != nil {
@@ -273,9 +293,7 @@ func ensureNoUnmanagedServerConflict(ctx context.Context, backend serviceBackend
 	}
 	healthStatus, healthPID := probeServiceHealth(ctx, spec)
 	healthRunning := healthStatus == protocol.HealthStatusOK
-	pidProof := status.PID > 0 && healthPID > 0 && status.PID == healthPID
-	commandProof := len(status.Command) > 0 && commandArgsEqual(status.Command, serviceCommand(spec))
-	backendOwnsHealthyServer := healthRunning && status.Running && status.Loaded && (pidProof || commandProof)
+	backendOwnsHealthyServer := healthRunning && serviceOwnsHealthyServer(status, healthPID, spec)
 	if healthRunning && !backendOwnsHealthyServer {
 		pidText := ""
 		if healthPID > 0 {

--- a/cli/builder/service_command_test.go
+++ b/cli/builder/service_command_test.go
@@ -197,39 +197,6 @@ func TestServiceRestartIfInstalledStopsWhenRefreshFails(t *testing.T) {
 	}
 }
 
-func TestServiceRestartIfInstalledRefreshesRegistrationWithoutStartingWhenManualServerRuns(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/healthz" {
-			http.NotFound(w, r)
-			return
-		}
-		_, _ = fmt.Fprint(w, `{"status":"ok","pid":123}`)
-	}))
-	t.Cleanup(server.Close)
-	backend := &stubServiceBackend{status: serviceStatus{Installed: true, Loaded: false, Running: false}}
-	withServiceCommandTestBackendEndpoint(t, backend, server.URL)
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	code := serviceSubcommand([]string{"restart", "--if-installed"}, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
-	}
-	want := []serviceAction{serviceActionStatus, serviceActionInstall}
-	if strings.Join(actionsToStrings(backend.calls), ",") != strings.Join(actionsToStrings(want), ",") {
-		t.Fatalf("calls = %+v, want %+v", backend.calls, want)
-	}
-	if !backend.installForce || backend.installStart {
-		t.Fatalf("refresh flags force=%v start=%v, want force true start false", backend.installForce, backend.installStart)
-	}
-	if !strings.Contains(stdout.String(), "restart skipped") || !strings.Contains(stdout.String(), "Updated Builder background service registration") {
-		t.Fatalf("stdout = %q, want skipped restart and registration update", stdout.String())
-	}
-	if strings.TrimSpace(stderr.String()) != "" {
-		t.Fatalf("stderr = %q, want empty", stderr.String())
-	}
-}
-
 func TestServiceStatusJSON(t *testing.T) {
 	backend := &stubServiceBackend{status: serviceStatus{Installed: true, Loaded: true, Running: true, PID: 123}}
 	withServiceCommandTestBackend(t, backend)

--- a/cli/builder/service_command_test.go
+++ b/cli/builder/service_command_test.go
@@ -197,6 +197,39 @@ func TestServiceRestartIfInstalledStopsWhenRefreshFails(t *testing.T) {
 	}
 }
 
+func TestServiceRestartIfInstalledRefreshesRegistrationWithoutStartingWhenManualServerRuns(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"status":"ok","pid":123}`)
+	}))
+	t.Cleanup(server.Close)
+	backend := &stubServiceBackend{status: serviceStatus{Installed: true, Loaded: false, Running: false}}
+	withServiceCommandTestBackendEndpoint(t, backend, server.URL)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"restart", "--if-installed"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	want := []serviceAction{serviceActionStatus, serviceActionInstall}
+	if strings.Join(actionsToStrings(backend.calls), ",") != strings.Join(actionsToStrings(want), ",") {
+		t.Fatalf("calls = %+v, want %+v", backend.calls, want)
+	}
+	if !backend.installForce || backend.installStart {
+		t.Fatalf("refresh flags force=%v start=%v, want force true start false", backend.installForce, backend.installStart)
+	}
+	if !strings.Contains(stdout.String(), "restart skipped") || !strings.Contains(stdout.String(), "Updated Builder background service registration") {
+		t.Fatalf("stdout = %q, want skipped restart and registration update", stdout.String())
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
 func TestServiceStatusJSON(t *testing.T) {
 	backend := &stubServiceBackend{status: serviceStatus{Installed: true, Loaded: true, Running: true, PID: 123}}
 	withServiceCommandTestBackend(t, backend)

--- a/cli/tui/markdown_renderer.go
+++ b/cli/tui/markdown_renderer.go
@@ -97,7 +97,7 @@ func (r *markdownRenderer) styleConfig() glamouransi.StyleConfig {
 
 func isMarkdownRole(role RenderIntent) bool {
 	switch role {
-	case RenderIntentUser, RenderIntentAssistant, RenderIntentAssistantCommentary:
+	case RenderIntentUser, RenderIntentAssistant, RenderIntentAssistantCommentary, RenderIntentToolQuestion, RenderIntentToolQuestionError:
 		return true
 	default:
 		return false

--- a/cli/tui/model_rendering_tools.go
+++ b/cli/tui/model_rendering_tools.go
@@ -136,7 +136,7 @@ func (m Model) flattenAskQuestionEntryWithSymbol(role RenderIntent, question str
 	if question == "" {
 		question = "ask question"
 	}
-	for _, line := range splitLines(wrapTextForViewport(question, renderWidth)) {
+	for _, line := range m.renderAskQuestionMarkdownLines(role, question, renderWidth) {
 		lines = append(lines, askQuestionLine{text: line, kind: "question"})
 	}
 	if includeSuggestions {
@@ -205,6 +205,25 @@ func (m Model) flattenAskQuestionEntryWithSymbol(role RenderIntent, question str
 		out = append(out, continuationPrefix+display)
 	}
 	return out
+}
+
+func (m Model) renderAskQuestionMarkdownLines(role RenderIntent, question string, renderWidth int) []string {
+	if renderWidth < 1 {
+		renderWidth = 1
+	}
+	if m.md != nil {
+		if rendered, err := m.md.render(role, question, renderWidth); err == nil {
+			lines := splitLines(rendered)
+			if len(lines) > 0 {
+				return lines
+			}
+		}
+	}
+	lines := splitLines(wrapTextForViewport(question, renderWidth))
+	if len(lines) == 0 {
+		return []string{""}
+	}
+	return lines
 }
 
 func toolCallDisplayText(meta *transcript.ToolCallMeta, text string) string {

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -683,6 +683,48 @@ func TestDetailAskQuestionRendersQuestionSuggestionsAndAnswer(t *testing.T) {
 	}
 }
 
+func TestDetailAskQuestionRendersLargeMarkdownQuestionSnapshot(t *testing.T) {
+	question := strings.Join([]string{
+		"Please review **this plan** before I continue:",
+		"",
+		"```kotlin",
+		"fun main() {",
+		"    println(\"hi\")",
+		"}",
+		"```",
+		"",
+		"- Keep the four leading spaces in the code block.",
+		"- Do not collapse blank lines.",
+	}, "\n")
+	m := NewModel(WithPreviewLines(40), WithTheme("dark"))
+	m = updateModel(t, m, SetViewportSizeMsg{Lines: 40, Width: 80})
+	m = updateModel(t, m, AppendTranscriptMsg{
+		Role: "tool_call",
+		Text: question,
+		ToolCall: &transcript.ToolCallMeta{
+			ToolName: "ask_question",
+			Question: question,
+		},
+	})
+	m = updateModel(t, m, ToggleModeMsg{})
+
+	plain := plainTranscript(m.View())
+	if strings.Contains(plain, "**this plan**") || strings.Contains(plain, "```") {
+		t.Fatalf("expected rendered markdown markers, got %q", plain)
+	}
+	if !containsInOrder(plain,
+		"?",
+		"Please review this plan before I continue:",
+		"fun main() {",
+		"    println(\"hi\")",
+		"}",
+		"Keep the four leading spaces in the code block.",
+		"Do not collapse blank lines.",
+	) {
+		t.Fatalf("ask_question markdown snapshot missing expected content, got %q", plain)
+	}
+}
+
 func TestOngoingAskQuestionRendersSelectedOptionText(t *testing.T) {
 	m := NewModel(WithPreviewLines(20))
 	m = updateModel(t, m, AppendTranscriptMsg{

--- a/docs/src/content/docs/command-postprocessing.md
+++ b/docs/src/content/docs/command-postprocessing.md
@@ -48,7 +48,7 @@ Direct partial file reads add one context line before output:
 [Total line count: 742]
 ```
 
-Builder applies that marker to simple `sed`, `head`, `tail`, `awk` line reads, and simple PowerShell `Get-Content` partial reads. It skips composed commands such as pipelines, whole-file reads, binary files, and files larger than 1 MB.
+Builder applies that marker to simple `sed`, `head`, `tail`, and PowerShell `Get-Content` partial reads. It skips composed commands such as pipelines, whole-file reads, binary files, and files larger than 1 MB.
 
 ## Hook Protocol
 

--- a/docs/src/content/docs/command-postprocessing.md
+++ b/docs/src/content/docs/command-postprocessing.md
@@ -6,7 +6,7 @@ description: Configure Builder's shell command post-processing and ship your own
 ## Overview
 
 Builder can post-process shell command output before it is shown to the model.
-This is meant to reduce command noise and improve usefulness.
+It reduces command noise and adds useful execution context.
 Builder keeps this separate from command execution itself:
 
 - command runs normally
@@ -37,6 +37,18 @@ When `postprocessing_mode = "all"`:
 
 1. Builder built-in processors run first.
 2. Your hook runs second.
+
+## Built-ins
+
+Successful direct `go test ...` commands collapse to `PASS` when output has no benchmarks, coverage, or JSON data.
+
+Direct partial file reads add one context line before output:
+
+```text
+[Total line count: 742]
+```
+
+Builder applies that marker to simple `sed`, `head`, `tail`, `awk` line reads, and simple PowerShell `Get-Content` partial reads. It skips composed commands such as pipelines, whole-file reads, binary files, and files larger than 1 MB.
 
 ## Hook Protocol
 

--- a/docs/src/content/docs/server.md
+++ b/docs/src/content/docs/server.md
@@ -41,7 +41,7 @@ builder service uninstall --keep-running
 
 `install` starts the service after registration. `--no-start` only writes the service registration.
 `uninstall` stops the service before removing registration. `--keep-running` removes registration without stopping an already-running process.
-`restart --if-installed` is used by package updates: it exits successfully without output when no service is installed.
+`restart --if-installed` is used by package updates: it exits successfully without output when no service is installed. If a manual Builder server is already running, it refreshes the service registration without starting the service.
 On macOS, restart rewrites the LaunchAgent, unloads the loaded job, and bootstraps it again. Starting an unloaded LaunchAgent relies on launchd `RunAtLoad`; no separate kickstart is needed.
 
 ## Backends
@@ -74,7 +74,7 @@ builder service status --json
 
 ## Port Conflicts
 
-Service lifecycle commands refuse to change the service when Builder's configured server endpoint is already owned by a manual `builder serve` process or by a non-Builder listener.
+Service lifecycle commands refuse to change the service when Builder's configured server endpoint is already owned by a manual `builder serve` process or by a non-Builder listener. Package-update restarts with `restart --if-installed` are the exception: they refresh registration and skip starting the service while a manual Builder server is running.
 If you started `builder serve` manually, stop that process before installing, starting, or restarting the background service.
 
 Running another server on a different configured port is fine. Builder only checks the endpoint resolved from `server_host` and `server_port`.

--- a/docs/src/content/docs/server.md
+++ b/docs/src/content/docs/server.md
@@ -41,8 +41,8 @@ builder service uninstall --keep-running
 
 `install` starts the service after registration. `--no-start` only writes the service registration.
 `uninstall` stops the service before removing registration. `--keep-running` removes registration without stopping an already-running process.
-`restart --if-installed` is used by package updates: it exits successfully without output when no service is installed. If a manual Builder server is already running, it refreshes the service registration without starting the service.
-On macOS, restart rewrites the LaunchAgent, unloads the loaded job, and bootstraps it again. Starting an unloaded LaunchAgent relies on launchd `RunAtLoad`; no separate kickstart is needed.
+`restart --if-installed` is used by package updates: it exits successfully without output when no service is installed.
+On macOS, restart rewrites the LaunchAgent, unloads the loaded job, waits for the old server to stop, and bootstraps it again. Starting an unloaded LaunchAgent relies on launchd `RunAtLoad`; no separate kickstart is needed.
 
 ## Backends
 
@@ -74,7 +74,7 @@ builder service status --json
 
 ## Port Conflicts
 
-Service lifecycle commands refuse to change the service when Builder's configured server endpoint is already owned by a manual `builder serve` process or by a non-Builder listener. Package-update restarts with `restart --if-installed` are the exception: they refresh registration and skip starting the service while a manual Builder server is running.
+Service lifecycle commands refuse to change the service when Builder's configured server endpoint is already owned by a manual `builder serve` process or by a non-Builder listener.
 If you started `builder serve` manually, stop that process before installing, starting, or restarting the background service.
 
 Running another server on a different configured port is fine. Builder only checks the endpoint resolved from `server_host` and `server_port`.

--- a/prompts/skills/skill-creator/SKILL.md
+++ b/prompts/skills/skill-creator/SKILL.md
@@ -58,7 +58,7 @@ Follow these rules for authoring skill docs (especially SKILL.md).
   - Bad: "introduced Decompose on April 29th in commit `abcdef`".
   - Bad: <User complains about wrong TDD approach>, you write "Encoding correct TDD patterns, not shallow assertions" (in an attempt to appease the user, but as a result encoding irrelevant emotional statement in docs)
 
-- Do not include global H1 header like `# My Skill`. Do not add spaces after headers.
+- Do not include a global H1 header like `# My Skill`. Do not add extra blank lines immediately after header lines.
 - Do not use eye-candy formatting, fancy diagrams that contain a lot of symbols, or emoji. Skills are read by AI, not humans.
 - Do not include large code examples, or API docs in SKILL.md. Generated, third-party, or optional content like templates / API docs lives either as a reference to SSOT, or in adjacent directories.
 - Keep SKILL.md under ~300 lines of markdown text. If docs don't fit, reference remaining guidance by topic in SKILL.md and use paths relative to the SKILL.md-containing directory (aka "skill dir"), turning SKILL.md into a summary + doc index. It's fine for skills to contain large amounts of text, only SKILL.md needs to stay under 300 lines.

--- a/prompts/skills/skill-creator/SKILL.md
+++ b/prompts/skills/skill-creator/SKILL.md
@@ -1,26 +1,19 @@
 ---
 name: skill-creator
-description: Create or improve Builder skills. Use when the user wants to add a new skill, update an existing skill, choose a skill scope, structure skill files, write skill frontmatter, or decide what belongs in a skill versus existing docs or source-of-truth files.
+description: Create or improve agent skills. Use when the user wants to add a new skill or update an existing skill.
 ---
 
-# Skill Creator
-
-Use this skill to create and improve Builder skills without duplicating existing source-of-truth documentation.
-
-## Placement
+Skills is a specialized technical documentation standard intended for AI Agents to read on-demand, and designed to teach them a specific technology, tool, or approach that is **outside of their training data** (aka "memory"). Agents learn about skills when they see injected frontmatter description, just like you did in this session for this skill. When agents need the skill, they read SKILL.md and change their behavior to follow skill instructions, just like you are doing right now.
 
 Builder discovers skills from these roots:
 
 - `<workspace>/.builder/skills`
 - `~/.builder/skills`
 
-Use workspace skills for project-specific workflows, repository conventions, local tools, or instructions that should travel with a codebase.
+Skills in ~/.builder/.generated/ are ephemeral, do not attempt to edit them.
+Use workspace skills for project-specific workflows, repository conventions, local tools, or instructions that should travel with a codebase. When the user asks to create a skill and it's not evident if it's global or local, use `ask_question` to ask for scope.
 
 Use global skills for reusable personal workflows that apply across projects.
-
-Do not edit `~/.builder/.generated`. Builder manages that directory and overwrites it on startup. To customize a generated skill, copy it to `<workspace>/.builder/skills/<skill-name>` or `~/.builder/skills/<skill-name>` and edit the copy.
-
-## Folder Structure
 
 A skill is a directory with a required `SKILL.md` file:
 
@@ -41,7 +34,6 @@ Use optional directories only when they reduce context or make repeatable work d
 Keep `SKILL.md` as the entry point. Put trigger guidance in frontmatter, core workflow in the body, and large variant-specific detail in referenced files.
 
 ## Frontmatter
-
 `SKILL.md` starts with YAML frontmatter:
 
 ```markdown
@@ -53,33 +45,36 @@ description: Do a specific workflow. Use when the user asks for concrete trigger
 
 `name` and `description` are required.
 
-Use a stable, lowercase, kebab-case `name` unless there is an existing compatibility reason not to.
+- Use a stable, lowercase, unique, kebab-case `name`.
+- Write `description` as trigger metadata. Include what the skill does and when to use it. Mention concrete user phrases, task types, tools, files, or domains that should activate the skill. Do not include trigger rules in the body; Builder gives the agent the name, description, and path until the model opens `SKILL.md`.
 
-Write `description` as trigger metadata. Include what the skill does and when to use it. Mention concrete user phrases, task types, tools, files, or domains that should activate the skill. Do not bury trigger rules only in the body; Builder injects only the name, description, and path until the model opens `SKILL.md`.
+## Skill content
+Follow these rules for authoring skill docs (especially SKILL.md).
 
-## Body
+- Important: Do not document anything that you as a model already know - generic APIs of widely known tools you already remember, basic coding guidelines, widespread tools (like git, docker, jetpack compose, java). If the user asks for a skill for a thing you already know / widespread / too generic, assume they are mistaken and explain that you already know the tool. If they insist, proceed with minimal content that does not duplicate known info, like maybe repo-specific patterns observed in real code, specific user preferences, niche tooling stack, repo-scoped architecture guidelines, or similar. Ask yourself a question when designing a skill: "If an AI Agent like me saw this repository/workflow/task, what would they need to know to accomplish it effectively and to user's satisfaction?"
+- Important: Do not include in skills anything that can quickly become outdated or info that isn't practically useful for completion of task and only documents events. Assume skills are updated once a year or more rarely. Do not include temporal data, taken decisions, or explainers of your behavior anywhere in the skill. Avoid mentioning user requests that pertain to this conversation or other guidance/feedback you received.
+  - Bad: "Per user instruction, corrected this skill to explain Decompose Components".
+  - Bad: "Deleted section about committing as requested".
+  - Bad: "introduced Decompose on April 29th in commit `abcdef`".
+  - Bad: <User complains about wrong TDD approach>, you write "Encoding correct TDD patterns, not shallow assertions" (in an attempt to appease the user, but as a result encoding irrelevant emotional statement in docs)
 
-Write the body as operational guidance for the model:
-
-- Start with the goal in one short paragraph.
-- Explain the decision flow and required checks.
-- Point to `scripts/`, `references/`, or `assets/` only when needed.
-- Prefer reusable rules over one-off examples.
+- Do not include global H1 header like `# My Skill`. Do not add spaces after headers.
+- Do not use eye-candy formatting, fancy diagrams that contain a lot of symbols, or emoji. Skills are read by AI, not humans.
+- Do not include large code examples, or API docs in SKILL.md. Generated, third-party, or optional content like templates / API docs lives either as a reference to SSOT, or in adjacent directories.
+- Keep SKILL.md under ~300 lines of markdown text. If docs don't fit, reference remaining guidance by topic in SKILL.md and use paths relative to the SKILL.md-containing directory (aka "skill dir"), turning SKILL.md into a summary + doc index. It's fine for skills to contain large amounts of text, only SKILL.md needs to stay under 300 lines.
 - Keep source-of-truth details in their owning docs or commands; link or delegate instead of copying long references.
-- Include output format only when the skill must produce a specific structure.
-
-Avoid documenting CLI help text, public docs, API docs, or web content verbatim when the model can read the source of truth directly.
+- Avoid repeating CLI help text, public docs, API docs, or web content verbatim when the model can read the source of truth directly, but do point to those documents for discovery.
+- For workspace skills, only point to files in the skill directory and the repository (workspace). For global skills, avoid pointing to any machine-local files outside the skill dir. Bad: "Example query at ~/Desktop/sample.sql" (this is local user file that might be gone, or not shared if User decides to give skill to someone else). Good: "FlowMVI docs index https://opensource.respawn.pro/FlowMVI/llms.txt, use curl -S to retrieve".
+- Assume skills are shared across developers, used on different machines, and public on the internet. Avoid PII, credentials, local references.
+- Don't create scripts or write code in skills "just in case" or for "what might be useful". Scripts are needed for something actually meaningfully codifying/automating a task, or meaningfully reducing the **amount of input/output** to be manually processed by the skill user. For example, for a merge request review/respond skill, you might include a self-contained, one-shot, flexible script to retrieve all existing inline review comments, that will eliminate verbose GraphQL calls. For a docs writing skill, if the doc follows a strict template, you can include a validator script, or a script that sets up a skeleton.
+- Do not apply any oververbosity parameters or other verbosity instructions you received when writing skill doc files. Do not omit info to be able to one-shot the entire skill; write the file in chunks instead.
 
 ## Creation Workflow
-
-When creating a skill:
-
 1. Identify the scope: workspace or global.
 2. Check existing skills so the new one does not duplicate or conflict with them.
 3. Choose a stable directory name and frontmatter `name`.
 4. Draft a trigger-focused `description`.
 5. Write the smallest useful `SKILL.md` body.
-6. Add optional files only when they are needed for progressive disclosure or deterministic execution.
-7. Validate that the skill can be discovered and that referenced files exist.
-
-When scope is ambiguous, recommend workspace scope for repository-specific tooling or conventions, and global scope for reusable personal workflows.
+6. If SKILL.md did not encompass the entire topic, write adjacent files.
+7. If skill needs reusable scripts, create and manually test them.
+8. Double-check that SKILL.md does not exceed 300 lines, no temporal references or fluff were left, and each file in the skill folder is mentioned at least in one place.

--- a/prompts/worktree_mode_prompt.md
+++ b/prompts/worktree_mode_prompt.md
@@ -1,5 +1,4 @@
-The user has moved this established conversation into a git worktree. The previous environment has now been changed:
+The user has moved this conversation into a git worktree. The previous environment has now been changed. Uncommitted changes from the previous workspace were not brought over:
 - Branch: {{branch}}
-- New cwd: {{cwd}}
-- Worktree path: {{worktree_path}}
+- New cwd / worktree path: {{cwd}}
 - Main workspace root: {{workspace_root}}

--- a/server/tools/shell/exec_command_tool.go
+++ b/server/tools/shell/exec_command_tool.go
@@ -106,7 +106,7 @@ func (t *ExecCommandTool) Call(ctx context.Context, c tools.Call) (tools.Result,
 		Raw:            in.Raw,
 	})
 	if err != nil {
-		return tools.ErrorResultWith(c, fmt.Sprintf("exec_command failed: %v", err), marshalNoHTMLEscape), nil
+		return tools.ErrorResultWith(c, formatToolCallError("exec_command", err), marshalNoHTMLEscape), nil
 	}
 	body, marshalErr := marshalNoHTMLEscape(formatExecResponse(result))
 	if marshalErr != nil {

--- a/server/tools/shell/manager.go
+++ b/server/tools/shell/manager.go
@@ -267,6 +267,9 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (ExecResult,
 	start := time.Now()
 	output, err := m.collectUntil(ctx, entry, time.Now().Add(yieldTime))
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return ExecResult{}, &PollingCanceledError{SessionID: id, Active: entry.snapshot().Running}
+		}
 		return ExecResult{}, err
 	}
 	snapshot := entry.snapshot()

--- a/server/tools/shell/manager_types.go
+++ b/server/tools/shell/manager_types.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -127,6 +128,26 @@ type WriteRequest struct {
 	Input          string
 	YieldTime      time.Duration
 	MaxOutputChars int
+}
+
+type PollingCanceledError struct {
+	SessionID string
+	Active    bool
+}
+
+func (e *PollingCanceledError) Error() string {
+	state := "process finished"
+	if e.Active {
+		state = "process active"
+	}
+	if strings.TrimSpace(e.SessionID) == "" {
+		return fmt.Sprintf("Canceled polling by user, %s", state)
+	}
+	return fmt.Sprintf("Canceled polling by user, %s (session_id %s)", state, strings.TrimSpace(e.SessionID))
+}
+
+func (e *PollingCanceledError) Unwrap() error {
+	return context.Canceled
 }
 
 type processEntry struct {

--- a/server/tools/shell/postprocess/file_read_context.go
+++ b/server/tools/shell/postprocess/file_read_context.go
@@ -283,6 +283,10 @@ func parseHeadTailLineLimit(isTail bool, value string) (int, bool, bool) {
 		}
 		return 0, startLine <= 1, true
 	}
+	if isTail && strings.HasPrefix(trimmed, "-") {
+		lineLimit, ok := parsePositiveLineLimit(strings.TrimPrefix(trimmed, "-"))
+		return lineLimit, false, ok
+	}
 	lineLimit, ok := parsePositiveLineLimit(trimmed)
 	return lineLimit, false, ok
 }

--- a/server/tools/shell/postprocess/file_read_context.go
+++ b/server/tools/shell/postprocess/file_read_context.go
@@ -1,0 +1,554 @@
+package postprocess
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"builder/shared/toolspec"
+)
+
+const maxFileReadContextFileBytes int64 = 1024 * 1024
+const unknownSedScript = "\x00unknown-sed-script"
+
+type fileReadContextProcessor struct{}
+
+type fileReadCandidate struct {
+	path                      string
+	certainlyFull             bool
+	fullWhenLineCountAtMost   int
+	canInferFullFromLineCount bool
+}
+
+func (fileReadContextProcessor) ID() string {
+	return "builtin/file-read-context"
+}
+
+func (fileReadContextProcessor) Process(_ context.Context, req Request) (Result, error) {
+	if req.ToolName != toolspec.ToolExecCommand {
+		return Result{Output: req.Output}, nil
+	}
+	if req.ExitCode == nil || *req.ExitCode != 0 {
+		return Result{Output: req.Output}, nil
+	}
+	if len(req.ParsedArgs) < 2 || strings.HasPrefix(req.Output, "[Total line count: ") {
+		return Result{Output: req.Output}, nil
+	}
+
+	candidate, ok := classifyFileRead(req.CommandName, req.ParsedArgs)
+	if !ok {
+		return Result{Output: req.Output}, nil
+	}
+	if candidate.certainlyFull {
+		return Result{Output: req.Output}, nil
+	}
+	path, ok := resolveReadPath(req.Workdir, candidate.path)
+	if !ok {
+		return Result{Output: req.Output}, nil
+	}
+	lineCount, ok := countSmallRegularFileLines(path)
+	if !ok {
+		return Result{Output: req.Output}, nil
+	}
+	if candidate.canInferFullFromLineCount && lineCount <= candidate.fullWhenLineCountAtMost {
+		return Result{Output: req.Output}, nil
+	}
+
+	return Result{
+		Output:      fmt.Sprintf("[Total line count: %d]\n%s", lineCount, req.Output),
+		Processed:   true,
+		ProcessorID: "builtin/file-read-context",
+	}, nil
+}
+
+func classifyFileRead(commandName string, args []string) (fileReadCandidate, bool) {
+	switch strings.ToLower(strings.TrimSpace(commandName)) {
+	case "sed":
+		return classifySedFileRead(args[1:])
+	case "head":
+		return classifyHeadTailFileRead(args[1:])
+	case "tail":
+		return classifyHeadTailFileRead(args[1:])
+	case "awk", "gawk", "mawk", "nawk":
+		return classifyAwkFileRead(args[1:])
+	case "get-content", "gc":
+		return classifyPowerShellGetContent(args[1:])
+	default:
+		return fileReadCandidate{}, false
+	}
+}
+
+func resolveReadPath(workdir string, rawPath string) (string, bool) {
+	path := strings.TrimSpace(rawPath)
+	if path == "" || strings.ContainsAny(path, "*?[") {
+		return "", false
+	}
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil || strings.TrimSpace(home) == "" {
+			return "", false
+		}
+		if path == "~" {
+			path = home
+		} else {
+			path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+		}
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), true
+	}
+	base := strings.TrimSpace(workdir)
+	if base == "" {
+		return "", false
+	}
+	return filepath.Clean(filepath.Join(base, path)), true
+}
+
+func countSmallRegularFileLines(path string) (int, bool) {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Size() > maxFileReadContextFileBytes {
+		return 0, false
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, false
+	}
+	defer func() { _ = file.Close() }()
+
+	reader := bufio.NewReader(file)
+	lines := 0
+	seenBytes := false
+	endedWithNewline := false
+	buf := make([]byte, 32*1024)
+	for {
+		n, readErr := reader.Read(buf)
+		if n > 0 {
+			seenBytes = true
+			chunk := buf[:n]
+			endedWithNewline = chunk[len(chunk)-1] == '\n'
+			for _, b := range chunk {
+				if b == 0 {
+					return 0, false
+				}
+				if b == '\n' {
+					lines++
+				}
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return 0, false
+		}
+	}
+	if seenBytes && !endedWithNewline {
+		lines++
+	}
+	return lines, true
+}
+
+func classifyHeadTailFileRead(args []string) (fileReadCandidate, bool) {
+	lineLimit := 10
+	limitKnown := true
+	paths := make([]string, 0, 1)
+
+	for i := 0; i < len(args); i++ {
+		arg := strings.TrimSpace(args[i])
+		switch {
+		case arg == "":
+			return fileReadCandidate{}, false
+		case arg == "--":
+			paths = append(paths, args[i+1:]...)
+			i = len(args)
+		case arg == "-n" || arg == "--lines":
+			if i+1 >= len(args) {
+				return fileReadCandidate{}, false
+			}
+			nextLimit, ok := parsePositiveLineLimit(args[i+1])
+			if !ok {
+				limitKnown = false
+			} else {
+				lineLimit = nextLimit
+			}
+			i++
+		case strings.HasPrefix(arg, "--lines="):
+			nextLimit, ok := parsePositiveLineLimit(strings.TrimPrefix(arg, "--lines="))
+			if !ok {
+				limitKnown = false
+			} else {
+				lineLimit = nextLimit
+			}
+		case arg == "-c" || arg == "--bytes":
+			return fileReadCandidate{}, false
+		case strings.HasPrefix(arg, "--bytes="), strings.HasPrefix(arg, "-c"):
+			return fileReadCandidate{}, false
+		case isHeadTailCompactLineOption(arg):
+			nextLimit, ok := parsePositiveLineLimit(strings.TrimPrefix(arg, "-"))
+			if !ok {
+				limitKnown = false
+			} else {
+				lineLimit = nextLimit
+			}
+		case strings.HasPrefix(arg, "-n"):
+			nextLimit, ok := parsePositiveLineLimit(strings.TrimPrefix(arg, "-n"))
+			if !ok {
+				limitKnown = false
+			} else {
+				lineLimit = nextLimit
+			}
+		case arg == "-q" || arg == "-v" || arg == "-z" || arg == "--quiet" || arg == "--silent" || arg == "--verbose" || arg == "--zero-terminated":
+		case strings.HasPrefix(arg, "-"):
+			return fileReadCandidate{}, false
+		default:
+			paths = append(paths, arg)
+		}
+	}
+
+	path, ok := singlePath(paths)
+	if !ok {
+		return fileReadCandidate{}, false
+	}
+	candidate := fileReadCandidate{path: path}
+	if limitKnown {
+		candidate.fullWhenLineCountAtMost = lineLimit
+		candidate.canInferFullFromLineCount = true
+	}
+	return candidate, true
+}
+
+func isHeadTailCompactLineOption(arg string) bool {
+	if len(arg) < 2 || arg[0] != '-' || arg[1] == '-' || arg[1] == 'n' || arg[1] == 'c' {
+		return false
+	}
+	for _, r := range arg[1:] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func parsePositiveLineLimit(value string) (int, bool) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, false
+	}
+	for _, r := range trimmed {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+	}
+	parsed, err := strconv.Atoi(trimmed)
+	if err != nil || parsed < 0 {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func classifySedFileRead(args []string) (fileReadCandidate, bool) {
+	scripts := make([]string, 0, 1)
+	files := make([]string, 0, 1)
+	suppressDefault := false
+	scriptFromOperand := false
+
+	for i := 0; i < len(args); i++ {
+		arg := strings.TrimSpace(args[i])
+		switch {
+		case arg == "":
+			return fileReadCandidate{}, false
+		case arg == "--":
+			if !scriptFromOperand && len(scripts) == 0 && i+1 < len(args) {
+				scripts = append(scripts, args[i+1])
+				scriptFromOperand = true
+				files = append(files, args[i+2:]...)
+			} else {
+				files = append(files, args[i+1:]...)
+			}
+			i = len(args)
+		case arg == "-n" || arg == "--quiet" || arg == "--silent":
+			suppressDefault = true
+		case arg == "-e" || arg == "--expression":
+			if i+1 >= len(args) {
+				return fileReadCandidate{}, false
+			}
+			scripts = append(scripts, args[i+1])
+			i++
+		case strings.HasPrefix(arg, "-e") && len(arg) > 2:
+			scripts = append(scripts, strings.TrimPrefix(arg, "-e"))
+		case strings.HasPrefix(arg, "--expression="):
+			scripts = append(scripts, strings.TrimPrefix(arg, "--expression="))
+		case arg == "-f" || arg == "--file":
+			if i+1 >= len(args) {
+				return fileReadCandidate{}, false
+			}
+			scripts = append(scripts, unknownSedScript)
+			i++
+		case strings.HasPrefix(arg, "--file="):
+			scripts = append(scripts, unknownSedScript)
+		case strings.HasPrefix(arg, "-") && !scriptFromOperand:
+			return fileReadCandidate{}, false
+		case !scriptFromOperand && len(scripts) == 0:
+			scripts = append(scripts, arg)
+			scriptFromOperand = true
+		default:
+			files = append(files, arg)
+		}
+	}
+
+	path, ok := singlePath(files)
+	if !ok || len(scripts) == 0 {
+		return fileReadCandidate{}, false
+	}
+	readOnly, certainlyFull := classifySedScripts(scripts, suppressDefault)
+	if !readOnly {
+		return fileReadCandidate{}, false
+	}
+	return fileReadCandidate{path: path, certainlyFull: certainlyFull}, true
+}
+
+func classifySedScripts(scripts []string, suppressDefault bool) (bool, bool) {
+	anyPartial := false
+	for _, script := range scripts {
+		classified, full := classifySedScript(script, suppressDefault)
+		if !classified {
+			return false, false
+		}
+		if !full {
+			anyPartial = true
+		}
+	}
+	return true, !anyPartial
+}
+
+func classifySedScript(script string, suppressDefault bool) (bool, bool) {
+	if script == unknownSedScript {
+		return true, false
+	}
+	trimmed := strings.TrimSpace(script)
+	if trimmed == "" {
+		return true, !suppressDefault
+	}
+	command, hasAddress, ok := sedSingleCommand(trimmed)
+	if !ok {
+		return false, false
+	}
+	if command == 'p' && suppressDefault {
+		return true, !hasAddress
+	}
+	if command == 'd' && !suppressDefault {
+		return true, false
+	}
+	return false, false
+}
+
+func sedSingleCommand(script string) (byte, bool, bool) {
+	trimmed := strings.TrimSpace(script)
+	i, hasAddress, ok := consumeSedAddress(trimmed, 0)
+	if !ok {
+		return 0, false, false
+	}
+	rest := strings.TrimSpace(trimmed[i:])
+	if hasAddress && strings.HasPrefix(rest, ",") {
+		rangeTail := strings.TrimSpace(strings.TrimPrefix(rest, ","))
+		next, secondAddress, ok := consumeSedAddress(rangeTail, 0)
+		if !ok || !secondAddress {
+			return 0, false, false
+		}
+		rest = strings.TrimSpace(rangeTail[next:])
+	}
+	if hasAddress && strings.HasPrefix(rest, "!") {
+		rest = strings.TrimSpace(strings.TrimPrefix(rest, "!"))
+	}
+	if len(rest) != 1 {
+		return 0, false, false
+	}
+	return rest[0], hasAddress, true
+}
+
+func consumeSedAddress(script string, start int) (int, bool, bool) {
+	i := start
+	for i < len(script) && script[i] == ' ' {
+		i++
+	}
+	if i >= len(script) {
+		return i, false, true
+	}
+	switch {
+	case script[i] >= '0' && script[i] <= '9':
+		for i < len(script) && script[i] >= '0' && script[i] <= '9' {
+			i++
+		}
+		return i, true, true
+	case script[i] == '$':
+		return i + 1, true, true
+	case script[i] == '/':
+		end, ok := consumeSedDelimitedAddress(script, i, '/')
+		return end, ok, ok
+	default:
+		return i, false, true
+	}
+}
+
+func consumeSedDelimitedAddress(script string, start int, delimiter byte) (int, bool) {
+	escaped := false
+	for i := start + 1; i < len(script); i++ {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if script[i] == '\\' {
+			escaped = true
+			continue
+		}
+		if script[i] == delimiter {
+			return i + 1, true
+		}
+	}
+	return 0, false
+}
+
+func classifyAwkFileRead(args []string) (fileReadCandidate, bool) {
+	if len(args) < 2 {
+		return fileReadCandidate{}, false
+	}
+	files := make([]string, 0, 1)
+	program := ""
+	for i := 0; i < len(args); i++ {
+		arg := strings.TrimSpace(args[i])
+		switch {
+		case arg == "":
+			return fileReadCandidate{}, false
+		case arg == "-f":
+			return fileReadCandidate{}, false
+		case arg == "-F" || arg == "-v":
+			if i+1 >= len(args) {
+				return fileReadCandidate{}, false
+			}
+			i++
+		case strings.HasPrefix(arg, "-F") && len(arg) > 2:
+		case strings.HasPrefix(arg, "-v") && len(arg) > 2:
+		case strings.HasPrefix(arg, "-"):
+			return fileReadCandidate{}, false
+		case program == "":
+			program = arg
+		default:
+			files = append(files, arg)
+		}
+	}
+	if !awkProgramMentionsNR(program) {
+		return fileReadCandidate{}, false
+	}
+	path, ok := singlePath(files)
+	if !ok {
+		return fileReadCandidate{}, false
+	}
+	return fileReadCandidate{path: path}, true
+}
+
+func awkProgramMentionsNR(program string) bool {
+	var identifier strings.Builder
+	flush := func() bool {
+		if identifier.String() == "NR" {
+			return true
+		}
+		identifier.Reset()
+		return false
+	}
+	for _, r := range program {
+		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_' {
+			identifier.WriteRune(r)
+			continue
+		}
+		if flush() {
+			return true
+		}
+	}
+	return flush()
+}
+
+func classifyPowerShellGetContent(args []string) (fileReadCandidate, bool) {
+	paths := make([]string, 0, 1)
+	partial := false
+	lineLimit := 0
+	limitKnown := false
+	for i := 0; i < len(args); i++ {
+		arg := strings.TrimSpace(args[i])
+		lower := strings.ToLower(arg)
+		switch {
+		case arg == "":
+			return fileReadCandidate{}, false
+		case lower == "-path" || lower == "-literalpath":
+			if i+1 >= len(args) {
+				return fileReadCandidate{}, false
+			}
+			paths = append(paths, args[i+1])
+			i++
+		case lower == "-totalcount" || lower == "-head" || lower == "-first" || lower == "-tail":
+			if i+1 >= len(args) {
+				return fileReadCandidate{}, false
+			}
+			partial = true
+			if nextLimit, ok := parsePositiveLineLimit(args[i+1]); ok {
+				lineLimit = nextLimit
+				limitKnown = true
+			}
+			i++
+		case strings.HasPrefix(lower, "-totalcount:"):
+			partial = true
+			if nextLimit, ok := parsePositiveLineLimit(strings.TrimPrefix(lower, "-totalcount:")); ok {
+				lineLimit = nextLimit
+				limitKnown = true
+			}
+		case strings.HasPrefix(lower, "-head:"):
+			partial = true
+			if nextLimit, ok := parsePositiveLineLimit(strings.TrimPrefix(lower, "-head:")); ok {
+				lineLimit = nextLimit
+				limitKnown = true
+			}
+		case strings.HasPrefix(lower, "-first:"):
+			partial = true
+			if nextLimit, ok := parsePositiveLineLimit(strings.TrimPrefix(lower, "-first:")); ok {
+				lineLimit = nextLimit
+				limitKnown = true
+			}
+		case strings.HasPrefix(lower, "-tail:"):
+			partial = true
+			if nextLimit, ok := parsePositiveLineLimit(strings.TrimPrefix(lower, "-tail:")); ok {
+				lineLimit = nextLimit
+				limitKnown = true
+			}
+		case strings.HasPrefix(arg, "-"):
+			return fileReadCandidate{}, false
+		default:
+			paths = append(paths, arg)
+		}
+	}
+	if !partial {
+		return fileReadCandidate{}, false
+	}
+	path, ok := singlePath(paths)
+	if !ok {
+		return fileReadCandidate{}, false
+	}
+	candidate := fileReadCandidate{path: path}
+	if limitKnown {
+		candidate.fullWhenLineCountAtMost = lineLimit
+		candidate.canInferFullFromLineCount = true
+	}
+	return candidate, true
+}
+
+func singlePath(paths []string) (string, bool) {
+	if len(paths) != 1 {
+		return "", false
+	}
+	path := strings.TrimSpace(paths[0])
+	return path, path != ""
+}

--- a/server/tools/shell/postprocess/file_read_context.go
+++ b/server/tools/shell/postprocess/file_read_context.go
@@ -71,9 +71,9 @@ func classifyFileRead(commandName string, args []string) (fileReadCandidate, boo
 	case "sed":
 		return classifySedFileRead(args[1:])
 	case "head":
-		return classifyHeadTailFileRead(args[1:])
+		return classifyHeadTailFileRead(false, args[1:])
 	case "tail":
-		return classifyHeadTailFileRead(args[1:])
+		return classifyHeadTailFileRead(true, args[1:])
 	case "get-content", "gc":
 		return classifyPowerShellGetContent(args[1:])
 	default:
@@ -152,9 +152,10 @@ func countSmallRegularFileLines(path string) (int, bool) {
 	return lines, true
 }
 
-func classifyHeadTailFileRead(args []string) (fileReadCandidate, bool) {
+func classifyHeadTailFileRead(isTail bool, args []string) (fileReadCandidate, bool) {
 	lineLimit := 10
 	limitKnown := true
+	wholeFileRead := false
 	paths := make([]string, 0, 1)
 
 	for i := 0; i < len(args); i++ {
@@ -169,19 +170,31 @@ func classifyHeadTailFileRead(args []string) (fileReadCandidate, bool) {
 			if i+1 >= len(args) {
 				return fileReadCandidate{}, false
 			}
-			nextLimit, ok := parsePositiveLineLimit(args[i+1])
+			nextLimit, wholeFile, ok := parseHeadTailLineLimit(isTail, args[i+1])
 			if !ok {
 				limitKnown = false
+				wholeFileRead = false
+			} else if wholeFile {
+				limitKnown = false
+				wholeFileRead = true
 			} else {
 				lineLimit = nextLimit
+				limitKnown = true
+				wholeFileRead = false
 			}
 			i++
 		case strings.HasPrefix(arg, "--lines="):
-			nextLimit, ok := parsePositiveLineLimit(strings.TrimPrefix(arg, "--lines="))
+			nextLimit, wholeFile, ok := parseHeadTailLineLimit(isTail, strings.TrimPrefix(arg, "--lines="))
 			if !ok {
 				limitKnown = false
+				wholeFileRead = false
+			} else if wholeFile {
+				limitKnown = false
+				wholeFileRead = true
 			} else {
 				lineLimit = nextLimit
+				limitKnown = true
+				wholeFileRead = false
 			}
 		case arg == "-c" || arg == "--bytes":
 			return fileReadCandidate{}, false
@@ -191,15 +204,24 @@ func classifyHeadTailFileRead(args []string) (fileReadCandidate, bool) {
 			nextLimit, ok := parsePositiveLineLimit(strings.TrimPrefix(arg, "-"))
 			if !ok {
 				limitKnown = false
+				wholeFileRead = false
 			} else {
 				lineLimit = nextLimit
+				limitKnown = true
+				wholeFileRead = false
 			}
 		case strings.HasPrefix(arg, "-n"):
-			nextLimit, ok := parsePositiveLineLimit(strings.TrimPrefix(arg, "-n"))
+			nextLimit, wholeFile, ok := parseHeadTailLineLimit(isTail, strings.TrimPrefix(arg, "-n"))
 			if !ok {
 				limitKnown = false
+				wholeFileRead = false
+			} else if wholeFile {
+				limitKnown = false
+				wholeFileRead = true
 			} else {
 				lineLimit = nextLimit
+				limitKnown = true
+				wholeFileRead = false
 			}
 		case arg == "-q" || arg == "-v" || arg == "-z" || arg == "--quiet" || arg == "--silent" || arg == "--verbose" || arg == "--zero-terminated":
 		case strings.HasPrefix(arg, "-"):
@@ -211,6 +233,9 @@ func classifyHeadTailFileRead(args []string) (fileReadCandidate, bool) {
 
 	path, ok := singlePath(paths)
 	if !ok {
+		return fileReadCandidate{}, false
+	}
+	if wholeFileRead {
 		return fileReadCandidate{}, false
 	}
 	candidate := fileReadCandidate{path: path}
@@ -231,6 +256,19 @@ func isHeadTailCompactLineOption(arg string) bool {
 		}
 	}
 	return true
+}
+
+func parseHeadTailLineLimit(isTail bool, value string) (int, bool, bool) {
+	trimmed := strings.TrimSpace(value)
+	if isTail && strings.HasPrefix(trimmed, "+") {
+		startLine, ok := parsePositiveLineLimit(strings.TrimPrefix(trimmed, "+"))
+		if !ok {
+			return 0, false, false
+		}
+		return 0, startLine <= 1, true
+	}
+	lineLimit, ok := parsePositiveLineLimit(trimmed)
+	return lineLimit, false, ok
 }
 
 func parsePositiveLineLimit(value string) (int, bool) {

--- a/server/tools/shell/postprocess/file_read_context.go
+++ b/server/tools/shell/postprocess/file_read_context.go
@@ -74,8 +74,6 @@ func classifyFileRead(commandName string, args []string) (fileReadCandidate, boo
 		return classifyHeadTailFileRead(args[1:])
 	case "tail":
 		return classifyHeadTailFileRead(args[1:])
-	case "awk", "gawk", "mawk", "nawk":
-		return classifyAwkFileRead(args[1:])
 	case "get-content", "gc":
 		return classifyPowerShellGetContent(args[1:])
 	default:
@@ -412,65 +410,6 @@ func consumeSedDelimitedAddress(script string, start int, delimiter byte) (int, 
 		}
 	}
 	return 0, false
-}
-
-func classifyAwkFileRead(args []string) (fileReadCandidate, bool) {
-	if len(args) < 2 {
-		return fileReadCandidate{}, false
-	}
-	files := make([]string, 0, 1)
-	program := ""
-	for i := 0; i < len(args); i++ {
-		arg := strings.TrimSpace(args[i])
-		switch {
-		case arg == "":
-			return fileReadCandidate{}, false
-		case arg == "-f":
-			return fileReadCandidate{}, false
-		case arg == "-F" || arg == "-v":
-			if i+1 >= len(args) {
-				return fileReadCandidate{}, false
-			}
-			i++
-		case strings.HasPrefix(arg, "-F") && len(arg) > 2:
-		case strings.HasPrefix(arg, "-v") && len(arg) > 2:
-		case strings.HasPrefix(arg, "-"):
-			return fileReadCandidate{}, false
-		case program == "":
-			program = arg
-		default:
-			files = append(files, arg)
-		}
-	}
-	if !awkProgramMentionsNR(program) {
-		return fileReadCandidate{}, false
-	}
-	path, ok := singlePath(files)
-	if !ok {
-		return fileReadCandidate{}, false
-	}
-	return fileReadCandidate{path: path}, true
-}
-
-func awkProgramMentionsNR(program string) bool {
-	var identifier strings.Builder
-	flush := func() bool {
-		if identifier.String() == "NR" {
-			return true
-		}
-		identifier.Reset()
-		return false
-	}
-	for _, r := range program {
-		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_' {
-			identifier.WriteRune(r)
-			continue
-		}
-		if flush() {
-			return true
-		}
-	}
-	return flush()
 }
 
 func classifyPowerShellGetContent(args []string) (fileReadCandidate, bool) {

--- a/server/tools/shell/postprocess/file_read_context.go
+++ b/server/tools/shell/postprocess/file_read_context.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"builder/server/tools/shellcmd"
 	"builder/shared/toolspec"
 )
 
@@ -40,7 +41,11 @@ func (fileReadContextProcessor) Process(_ context.Context, req Request) (Result,
 		return Result{Output: req.Output}, nil
 	}
 
-	candidate, ok := classifyFileRead(req.CommandName, req.ParsedArgs)
+	args, ok := fileReadArgsWithoutCommand(req.CommandName, req.ParsedArgs)
+	if !ok {
+		return Result{Output: req.Output}, nil
+	}
+	candidate, ok := classifyFileRead(req.CommandName, args)
 	if !ok {
 		return Result{Output: req.Output}, nil
 	}
@@ -66,16 +71,27 @@ func (fileReadContextProcessor) Process(_ context.Context, req Request) (Result,
 	}, nil
 }
 
+func fileReadArgsWithoutCommand(commandName string, parsedArgs []string) ([]string, bool) {
+	normalizedCommand := shellcmd.NormalizeCommandName(commandName)
+	if normalizedCommand == "" || len(parsedArgs) < 2 {
+		return nil, false
+	}
+	if shellcmd.NormalizeCommandName(parsedArgs[0]) != normalizedCommand {
+		return nil, false
+	}
+	return parsedArgs[1:], true
+}
+
 func classifyFileRead(commandName string, args []string) (fileReadCandidate, bool) {
 	switch strings.ToLower(strings.TrimSpace(commandName)) {
 	case "sed":
-		return classifySedFileRead(args[1:])
+		return classifySedFileRead(args)
 	case "head":
-		return classifyHeadTailFileRead(false, args[1:])
+		return classifyHeadTailFileRead(false, args)
 	case "tail":
-		return classifyHeadTailFileRead(true, args[1:])
+		return classifyHeadTailFileRead(true, args)
 	case "get-content", "gc":
-		return classifyPowerShellGetContent(args[1:])
+		return classifyPowerShellGetContent(args)
 	default:
 		return fileReadCandidate{}, false
 	}

--- a/server/tools/shell/postprocess/runner.go
+++ b/server/tools/shell/postprocess/runner.go
@@ -57,7 +57,7 @@ func NewRunner(settings Settings) *Runner {
 	return &Runner{
 		mode:       mode,
 		hookPath:   strings.TrimSpace(settings.HookPath),
-		processors: []Processor{goTestSuccessProcessor{}},
+		processors: []Processor{goTestSuccessProcessor{}, fileReadContextProcessor{}},
 	}
 }
 

--- a/server/tools/shell/postprocess/runner_test.go
+++ b/server/tools/shell/postprocess/runner_test.go
@@ -85,6 +85,205 @@ func TestRunnerBuiltinGoTestPreservesDetailedOutput(t *testing.T) {
 	}
 }
 
+func TestRunnerBuiltinFileReadAddsTotalLineCountForPartialSed(t *testing.T) {
+	path := writeTextFile(t, "example.txt", strings.Join([]string{
+		"line 1",
+		"line 2",
+		"line 3",
+		"line 4",
+		"line 5",
+	}, "\n")+"\n")
+	runner := NewRunner(Settings{Mode: config.ShellPostprocessingModeBuiltin})
+	exitCode := 0
+
+	result, err := runner.Apply(context.Background(), Request{
+		ToolName:    toolspec.ToolExecCommand,
+		CommandText: "sed -n '2,4p' " + shellQuote(path),
+		ExitCode:    &exitCode,
+		Output:      "line 2\nline 3\nline 4\n",
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !result.Processed {
+		t.Fatal("expected partial file read to be processed")
+	}
+	if result.Output != "[Total line count: 5]\nline 2\nline 3\nline 4\n" {
+		t.Fatalf("output = %q", result.Output)
+	}
+}
+
+func TestRunnerBuiltinFileReadAddsTotalLineCountForUnknownSedScriptFile(t *testing.T) {
+	path := writeTextFile(t, "example.txt", "line 1\nline 2\nline 3\n")
+	scriptPath := writeTextFile(t, "script.sed", "1,1p\n")
+	runner := NewRunner(Settings{Mode: config.ShellPostprocessingModeBuiltin})
+	exitCode := 0
+
+	result, err := runner.Apply(context.Background(), Request{
+		ToolName:    toolspec.ToolExecCommand,
+		CommandText: "sed -f " + shellQuote(scriptPath) + " " + shellQuote(path),
+		ExitCode:    &exitCode,
+		Output:      "line 1\n",
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !result.Processed {
+		t.Fatal("expected unknown sed script file to be processed conservatively")
+	}
+	if result.Output != "[Total line count: 3]\nline 1\n" {
+		t.Fatalf("output = %q", result.Output)
+	}
+}
+
+func TestRunnerBuiltinFileReadSkipsSedWhenFullFileIsKnown(t *testing.T) {
+	path := writeTextFile(t, "example.txt", "line 1\nline 2\n")
+	runner := NewRunner(Settings{Mode: config.ShellPostprocessingModeBuiltin})
+	exitCode := 0
+
+	result, err := runner.Apply(context.Background(), Request{
+		ToolName:    toolspec.ToolExecCommand,
+		CommandText: "sed -n p " + shellQuote(path),
+		ExitCode:    &exitCode,
+		Output:      "line 1\nline 2\n",
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if result.Processed {
+		t.Fatal("expected known full-file sed output to bypass file context marker")
+	}
+	if result.Output != "line 1\nline 2\n" {
+		t.Fatalf("output = %q", result.Output)
+	}
+}
+
+func TestRunnerBuiltinFileReadAddsTotalLineCountForHeadTailAwkAndPowerShell(t *testing.T) {
+	path := writeTextFile(t, "example.txt", strings.Join([]string{
+		"line 1",
+		"line 2",
+		"line 3",
+		"line 4",
+		"line 5",
+	}, "\n"))
+	runner := NewRunner(Settings{Mode: config.ShellPostprocessingModeBuiltin})
+	exitCode := 0
+	tests := []struct {
+		name    string
+		command string
+		output  string
+	}{
+		{name: "head", command: "head -n 2 " + shellQuote(path), output: "line 1\nline 2\n"},
+		{name: "tail", command: "tail -2 " + shellQuote(path), output: "line 4\nline 5\n"},
+		{name: "awk", command: "awk 'NR>=2 && NR<=3' " + shellQuote(path), output: "line 2\nline 3\n"},
+		{name: "powershell head", command: "Get-Content " + shellQuote(path) + " -TotalCount 2", output: "line 1\nline 2\n"},
+		{name: "powershell tail", command: "Get-Content " + shellQuote(path) + " -Tail 2", output: "line 4\nline 5\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := runner.Apply(context.Background(), Request{
+				ToolName:    toolspec.ToolExecCommand,
+				CommandText: tt.command,
+				ExitCode:    &exitCode,
+				Output:      tt.output,
+			})
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if !result.Processed {
+				t.Fatal("expected partial file read to be processed")
+			}
+			want := "[Total line count: 5]\n" + tt.output
+			if result.Output != want {
+				t.Fatalf("output = %q, want %q", result.Output, want)
+			}
+		})
+	}
+}
+
+func TestRunnerBuiltinFileReadSkipsFullHeadTailAndLargeFiles(t *testing.T) {
+	smallPath := writeTextFile(t, "small.txt", "line 1\nline 2\n")
+	largePath := filepath.Join(t.TempDir(), "large.txt")
+	if err := os.WriteFile(largePath, []byte(strings.Repeat("x", 1024*1024+1)), 0o644); err != nil {
+		t.Fatalf("write large file: %v", err)
+	}
+	binaryPath := filepath.Join(t.TempDir(), "binary.txt")
+	if err := os.WriteFile(binaryPath, []byte("line 1\x00line 2\n"), 0o644); err != nil {
+		t.Fatalf("write binary file: %v", err)
+	}
+	runner := NewRunner(Settings{Mode: config.ShellPostprocessingModeBuiltin})
+	exitCode := 0
+	tests := []struct {
+		name    string
+		command string
+		output  string
+	}{
+		{name: "head full", command: "head -n 10 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
+		{name: "tail full", command: "tail -n 10 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
+		{name: "powershell full", command: "Get-Content " + shellQuote(smallPath) + " -TotalCount 10", output: "line 1\nline 2\n"},
+		{name: "large file", command: "head -n 1 " + shellQuote(largePath), output: "x\n"},
+		{name: "binary file", command: "head -n 1 " + shellQuote(binaryPath), output: "line 1\n"},
+		{name: "head bytes", command: "head -c 3 " + shellQuote(smallPath), output: "lin"},
+		{name: "tail bytes", command: "tail --bytes=3 " + shellQuote(smallPath), output: "2\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := runner.Apply(context.Background(), Request{
+				ToolName:    toolspec.ToolExecCommand,
+				CommandText: tt.command,
+				ExitCode:    &exitCode,
+				Output:      tt.output,
+			})
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if result.Processed {
+				t.Fatal("expected file read marker to be skipped")
+			}
+			if result.Output != tt.output {
+				t.Fatalf("output = %q, want %q", result.Output, tt.output)
+			}
+		})
+	}
+}
+
+func TestRunnerBuiltinFileReadSkipsComposedCommandsAndWholeFileReads(t *testing.T) {
+	path := writeTextFile(t, "example.txt", "line 1\nline 2\n")
+	runner := NewRunner(Settings{Mode: config.ShellPostprocessingModeBuiltin})
+	exitCode := 0
+	tests := []struct {
+		name    string
+		command string
+		output  string
+	}{
+		{name: "cat", command: "cat " + shellQuote(path), output: "line 1\nline 2\n"},
+		{name: "pipeline", command: "nl -ba " + shellQuote(path) + " | sed -n '1,1p'", output: "     1\tline 1\n"},
+		{name: "sed transform", command: "sed 's/line/row/' " + shellQuote(path), output: "row 1\nrow 2\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := runner.Apply(context.Background(), Request{
+				ToolName:    toolspec.ToolExecCommand,
+				CommandText: tt.command,
+				ExitCode:    &exitCode,
+				Output:      tt.output,
+			})
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if result.Processed {
+				t.Fatal("expected file read marker to be skipped")
+			}
+			if result.Output != tt.output {
+				t.Fatalf("output = %q, want %q", result.Output, tt.output)
+			}
+		})
+	}
+}
+
 func TestRunnerRawBypassesBuiltinProcessing(t *testing.T) {
 	runner := NewRunner(Settings{Mode: config.ShellPostprocessingModeBuiltin})
 	exitCode := 0
@@ -235,6 +434,19 @@ func writeHookScript(t *testing.T, contents string) string {
 		t.Fatalf("write hook: %v", err)
 	}
 	return path
+}
+
+func writeTextFile(t *testing.T, name string, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write text file: %v", err)
+	}
+	return path
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 func TestRunnerAllModeAccumulatesWarnings(t *testing.T) {

--- a/server/tools/shell/postprocess/runner_test.go
+++ b/server/tools/shell/postprocess/runner_test.go
@@ -158,7 +158,8 @@ func TestRunnerBuiltinFileReadSkipsSedWhenFullFileIsKnown(t *testing.T) {
 	}
 }
 
-func TestRunnerBuiltinFileReadAddsTotalLineCountForHeadTailAwkAndPowerShell(t *testing.T) {
+func TestRunnerBuiltinFileReadAddsTotalLineCountForHeadTailAndPowerShell(t *testing.T) {
+	// File without trailing newline verifies non-POSIX file handling.
 	path := writeTextFile(t, "example.txt", strings.Join([]string{
 		"line 1",
 		"line 2",
@@ -175,7 +176,6 @@ func TestRunnerBuiltinFileReadAddsTotalLineCountForHeadTailAwkAndPowerShell(t *t
 	}{
 		{name: "head", command: "head -n 2 " + shellQuote(path), output: "line 1\nline 2\n"},
 		{name: "tail", command: "tail -2 " + shellQuote(path), output: "line 4\nline 5\n"},
-		{name: "awk", command: "awk 'NR>=2 && NR<=3' " + shellQuote(path), output: "line 2\nline 3\n"},
 		{name: "powershell head", command: "Get-Content " + shellQuote(path) + " -TotalCount 2", output: "line 1\nline 2\n"},
 		{name: "powershell tail", command: "Get-Content " + shellQuote(path) + " -Tail 2", output: "line 4\nline 5\n"},
 	}
@@ -261,6 +261,7 @@ func TestRunnerBuiltinFileReadSkipsComposedCommandsAndWholeFileReads(t *testing.
 		{name: "cat", command: "cat " + shellQuote(path), output: "line 1\nline 2\n"},
 		{name: "pipeline", command: "nl -ba " + shellQuote(path) + " | sed -n '1,1p'", output: "     1\tline 1\n"},
 		{name: "sed transform", command: "sed 's/line/row/' " + shellQuote(path), output: "row 1\nrow 2\n"},
+		{name: "awk", command: "awk 'NR>=2 && NR<=3' " + shellQuote(path), output: "line 2\n"},
 	}
 
 	for _, tt := range tests {

--- a/server/tools/shell/postprocess/runner_test.go
+++ b/server/tools/shell/postprocess/runner_test.go
@@ -221,6 +221,9 @@ func TestRunnerBuiltinFileReadSkipsFullHeadTailAndLargeFiles(t *testing.T) {
 	}{
 		{name: "head full", command: "head -n 10 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
 		{name: "tail full", command: "tail -n 10 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
+		{name: "tail from first line", command: "tail -n +1 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
+		{name: "tail compact from first line", command: "tail -n+1 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
+		{name: "tail long from first line", command: "tail --lines=+1 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
 		{name: "powershell full", command: "Get-Content " + shellQuote(smallPath) + " -TotalCount 10", output: "line 1\nline 2\n"},
 		{name: "large file", command: "head -n 1 " + shellQuote(largePath), output: "x\n"},
 		{name: "binary file", command: "head -n 1 " + shellQuote(binaryPath), output: "line 1\n"},

--- a/server/tools/shell/postprocess/runner_test.go
+++ b/server/tools/shell/postprocess/runner_test.go
@@ -252,6 +252,27 @@ func TestRunnerBuiltinFileReadSkipsFullHeadTailAndLargeFiles(t *testing.T) {
 	}
 }
 
+func TestRunnerBuiltinFileReadSkipsWhenParsedArgsOmitCommandName(t *testing.T) {
+	path := writeTextFile(t, "example.txt", "line 1\nline 2\nline 3\n")
+	runner := NewRunner(Settings{Mode: config.ShellPostprocessingModeBuiltin})
+	exitCode := 0
+
+	result, err := runner.Apply(context.Background(), Request{
+		ToolName:    toolspec.ToolExecCommand,
+		CommandName: "tail",
+		ParsedArgs:  []string{"-n", "2", path},
+		Workdir:     filepath.Dir(path),
+		ExitCode:    &exitCode,
+		Output:      "line 2\nline 3\n",
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if result.Processed || result.Output != "line 2\nline 3\n" {
+		t.Fatalf("expected invalid parsed args contract to skip processing, got processed=%t output=%q", result.Processed, result.Output)
+	}
+}
+
 func TestRunnerBuiltinFileReadSkipsComposedCommandsAndWholeFileReads(t *testing.T) {
 	path := writeTextFile(t, "example.txt", "line 1\nline 2\n")
 	runner := NewRunner(Settings{Mode: config.ShellPostprocessingModeBuiltin})

--- a/server/tools/shell/postprocess/runner_test.go
+++ b/server/tools/shell/postprocess/runner_test.go
@@ -221,6 +221,9 @@ func TestRunnerBuiltinFileReadSkipsFullHeadTailAndLargeFiles(t *testing.T) {
 	}{
 		{name: "head full", command: "head -n 10 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
 		{name: "tail full", command: "tail -n 10 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
+		{name: "tail negative full", command: "tail -n -5 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
+		{name: "tail compact negative full", command: "tail -n-5 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
+		{name: "tail long negative full", command: "tail --lines=-5 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
 		{name: "tail from first line", command: "tail -n +1 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
 		{name: "tail compact from first line", command: "tail -n+1 " + shellQuote(smallPath), output: "line 1\nline 2\n"},
 		{name: "tail long from first line", command: "tail --lines=+1 " + shellQuote(smallPath), output: "line 1\nline 2\n"},

--- a/server/tools/shell/tool.go
+++ b/server/tools/shell/tool.go
@@ -2,7 +2,9 @@ package shell
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"unicode"
@@ -27,6 +29,24 @@ func marshalNoHTMLEscape(v any) (json.RawMessage, error) {
 		return nil, err
 	}
 	return bytes.TrimSuffix(buf.Bytes(), []byte("\n")), nil
+}
+
+func formatToolCallError(toolName string, err error) string {
+	if err == nil {
+		return fmt.Sprintf("%s failed", toolName)
+	}
+	if errors.Is(err, context.Canceled) {
+		return fmt.Sprintf("%s failed: %s", toolName, cancellationMessage(err))
+	}
+	return fmt.Sprintf("%s failed: %v", toolName, err)
+}
+
+func cancellationMessage(err error) string {
+	var pollErr *PollingCanceledError
+	if errors.As(err, &pollErr) {
+		return pollErr.Error()
+	}
+	return "Canceled by user"
 }
 
 func enrichEnv(base []string) []string {

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -634,6 +634,54 @@ func TestExecCommandAppliesUserHookOutput(t *testing.T) {
 	}
 }
 
+func TestExecCommandFileReadPostprocessorHandlesDirectCommandOnly(t *testing.T) {
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "example.txt")
+	if err := os.WriteFile(path, []byte("alpha\nbeta\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+
+	directInput, _ := json.Marshal(map[string]any{
+		"cmd":           "sed -n '1,1p' " + shellSingleQuote(path),
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 1_000,
+	})
+	directResult, err := execTool.Call(context.Background(), tools.Call{ID: "file-read-direct", Name: toolspec.ToolExecCommand, Input: directInput})
+	if err != nil {
+		t.Fatalf("direct exec_command call error: %v", err)
+	}
+	if directResult.IsError {
+		t.Fatalf("unexpected direct exec_command error: %s", string(directResult.Output))
+	}
+	if got := decodeStringToolOutput(t, directResult); got != "[Total line count: 2]\nalpha" {
+		t.Fatalf("direct output = %q", got)
+	}
+
+	pipelineInput, _ := json.Marshal(map[string]any{
+		"cmd":           "nl -ba " + shellSingleQuote(path) + " | sed -n '1,1p'",
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 1_000,
+	})
+	pipelineResult, err := execTool.Call(context.Background(), tools.Call{ID: "file-read-pipeline", Name: toolspec.ToolExecCommand, Input: pipelineInput})
+	if err != nil {
+		t.Fatalf("pipeline exec_command call error: %v", err)
+	}
+	if pipelineResult.IsError {
+		t.Fatalf("unexpected pipeline exec_command error: %s", string(pipelineResult.Output))
+	}
+	pipelineOutput := decodeStringToolOutput(t, pipelineResult)
+	if strings.Contains(pipelineOutput, "[Total line count:") {
+		t.Fatalf("pipeline output should not include file-read context marker, got %q", pipelineOutput)
+	}
+	if !strings.Contains(pipelineOutput, "Exit code 0, output:") || !strings.Contains(pipelineOutput, "alpha") {
+		t.Fatalf("pipeline output missing normal shell response context, got %q", pipelineOutput)
+	}
+}
+
 func TestWriteStdinWarnsAndRetriesWhenFullLogReadFails(t *testing.T) {
 	workspace := t.TempDir()
 	manager := newBackgroundTestManager(t)
@@ -696,6 +744,10 @@ func TestWriteStdinWarnsAndRetriesWhenFullLogReadFails(t *testing.T) {
 	if !strings.Contains(secondText, "done") {
 		t.Fatalf("expected restored full output, got %q", secondText)
 	}
+}
+
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 func TestExecCommandClampsShortYieldTimeSilently(t *testing.T) {

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -7,6 +7,7 @@ import (
 	"builder/shared/toolspec"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -42,6 +43,23 @@ func waitForManagerCount(t *testing.T, manager *Manager, want int, timeout time.
 		time.Sleep(25 * time.Millisecond)
 	}
 	t.Fatalf("manager count = %d, want %d", manager.Count(), want)
+}
+
+func waitForEntryInteraction(t *testing.T, manager *Manager, id string, timeout time.Duration) {
+	t.Helper()
+	entry, err := manager.entry(id)
+	if err != nil {
+		t.Fatalf("background entry %s: %v", id, err)
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !entry.interactMu.TryLock() {
+			return
+		}
+		entry.interactMu.Unlock()
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for write_stdin to start interacting with session %s", id)
 }
 
 func writeExecutableScript(t *testing.T, contents string) string {
@@ -427,6 +445,99 @@ func TestExecCommandMovesToBackgroundAndPollsToCompletion(t *testing.T) {
 		t.Fatalf("expected command output in poll output, got %q", pollText)
 	}
 	waitForManagerCount(t, manager, 0, time.Second)
+}
+
+func TestWriteStdinCancellationReportsActiveProcess(t *testing.T) {
+	workspace := t.TempDir()
+	manager := newBackgroundTestManager(t)
+	pollTool := NewWriteStdinTool(16_000, manager)
+
+	result, err := manager.Start(context.Background(), ExecRequest{
+		Command:        []string{"sh", "-c", "sleep 2"},
+		DisplayCommand: "sleep 2",
+		Workdir:        workspace,
+		YieldTime:      250 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("start background process: %v", err)
+	}
+	if !result.Backgrounded {
+		t.Fatalf("expected backgrounded process, got %+v", result)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan tools.Result, 1)
+	go func() {
+		sessionID, err := strconv.Atoi(result.SessionID)
+		if err != nil {
+			t.Errorf("parse session id: %v", err)
+			done <- tools.Result{}
+			return
+		}
+		pollInput, _ := json.Marshal(map[string]any{
+			"session_id":    sessionID,
+			"yield_time_ms": 5_000,
+		})
+		pollResult, err := pollTool.Call(ctx, tools.Call{ID: "cancel-poll", Name: toolspec.ToolWriteStdin, Input: pollInput})
+		if err != nil {
+			t.Errorf("write_stdin call returned transport error: %v", err)
+		}
+		done <- pollResult
+	}()
+
+	waitForEntryInteraction(t, manager, result.SessionID, time.Second)
+	cancel()
+
+	select {
+	case pollResult := <-done:
+		if !pollResult.IsError {
+			t.Fatalf("expected write_stdin error result, got %+v", pollResult)
+		}
+		if !strings.Contains(pollResult.Summary, "Canceled polling by user, process active") {
+			t.Fatalf("expected active-process cancellation summary, got %q", pollResult.Summary)
+		}
+		if strings.Contains(pollResult.Summary, "context canceled") {
+			t.Fatalf("did not expect raw context cancellation summary, got %q", pollResult.Summary)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for canceled write_stdin")
+	}
+	if snapshot, err := manager.Snapshot(result.SessionID); err != nil || !snapshot.Running {
+		t.Fatalf("expected process to remain active after polling cancellation, snapshot=%+v err=%v", snapshot, err)
+	}
+}
+
+func TestManagerWriteStdinCancellationPreservesContextCanceled(t *testing.T) {
+	workspace := t.TempDir()
+	manager := newBackgroundTestManager(t)
+
+	result, err := manager.Start(context.Background(), ExecRequest{
+		Command:        []string{"sh", "-c", "sleep 2"},
+		DisplayCommand: "sleep 2",
+		Workdir:        workspace,
+		YieldTime:      250 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("start background process: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = manager.WriteStdin(ctx, WriteRequest{SessionID: result.SessionID, YieldTime: 5 * time.Second})
+	if err == nil {
+		t.Fatal("expected canceled polling error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected errors.Is(..., context.Canceled), got %v", err)
+	}
+	var pollErr *PollingCanceledError
+	if !errors.As(err, &pollErr) {
+		t.Fatalf("expected PollingCanceledError, got %T %v", err, err)
+	}
+	if !pollErr.Active {
+		t.Fatalf("expected active process metadata, got %+v", pollErr)
+	}
 }
 
 func TestExecCommandExportsAgentEnv(t *testing.T) {

--- a/server/tools/shell/write_stdin_tool.go
+++ b/server/tools/shell/write_stdin_tool.go
@@ -68,7 +68,7 @@ func (t *WriteStdinTool) Call(ctx context.Context, c tools.Call) (tools.Result, 
 		MaxOutputChars: maxChars,
 	})
 	if err != nil {
-		return tools.ErrorResultWith(c, fmt.Sprintf("write_stdin failed: %v", err), marshalNoHTMLEscape), nil
+		return tools.ErrorResultWith(c, formatToolCallError("write_stdin", err), marshalNoHTMLEscape), nil
 	}
 	body, marshalErr := marshalNoHTMLEscape(writeStdinOutput{
 		Output:              formatExecResponse(result),

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -945,6 +945,9 @@ func protocolError(err error) (int, string) {
 	}
 	message := strings.TrimSpace(err.Error())
 	if errors.Is(err, context.Canceled) {
+		if message == "" || message == context.Canceled.Error() {
+			message = "request canceled by client"
+		}
 		return protocol.ErrCodeRequestCanceled, message
 	}
 	if errors.Is(err, serverapi.ErrStreamGap) {

--- a/server/transport/gateway_test.go
+++ b/server/transport/gateway_test.go
@@ -6,12 +6,16 @@ import (
 	"builder/server/core"
 	"builder/server/metadata"
 	"builder/server/session"
+	shelltool "builder/server/tools/shell"
 	remoteclient "builder/shared/client"
 	"builder/shared/config"
 	"builder/shared/protocol"
+	"builder/shared/rpcwire"
 	"builder/shared/serverapi"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"golang.org/x/net/websocket"
 	"net/http/httptest"
 	"strconv"
@@ -41,6 +45,22 @@ func configureGatewayTestServerPort(t *testing.T) {
 
 var gatewayTestPortCounter atomic.Uint32
 
+func reportGatewayHandlerError(errs chan<- error, format string, args ...any) {
+	select {
+	case errs <- fmt.Errorf(format, args...):
+	default:
+	}
+}
+
+func requireNoGatewayHandlerError(t *testing.T, errs <-chan error) {
+	t.Helper()
+	select {
+	case err := <-errs:
+		t.Fatal(err)
+	default:
+	}
+}
+
 func TestProtocolErrorMapsRuntimeUnavailable(t *testing.T) {
 	code, _ := protocolError(serverapi.ErrRuntimeUnavailable)
 	if code != protocol.ErrCodeRuntimeUnavailable {
@@ -53,9 +73,62 @@ func TestProtocolErrorMapsContextCanceled(t *testing.T) {
 	if code != protocol.ErrCodeRequestCanceled {
 		t.Fatalf("protocol error code = %d, want %d", code, protocol.ErrCodeRequestCanceled)
 	}
-	if message != context.Canceled.Error() {
-		t.Fatalf("protocol error message = %q, want %q", message, context.Canceled.Error())
+	if message != "request canceled by client" {
+		t.Fatalf("protocol error message = %q, want request canceled by client", message)
 	}
+}
+
+func TestCancellationMessageRoundTripsThroughRemoteClient(t *testing.T) {
+	code, message := protocolError(&shelltool.PollingCanceledError{SessionID: "1000", Active: true})
+	if code != protocol.ErrCodeRequestCanceled {
+		t.Fatalf("protocol error code = %d, want %d", code, protocol.ErrCodeRequestCanceled)
+	}
+
+	handlerErrs := make(chan error, 8)
+	server := httptest.NewServer(rpcwire.NewWebSocketTransport().Handler(func(ctx context.Context, conn rpcwire.Conn) {
+		for event := range conn.Events() {
+			if event.Err != nil {
+				return
+			}
+			req := event.Frame.Request()
+			switch req.Method {
+			case protocol.MethodHandshake:
+				resp := protocol.NewSuccessResponse(req.ID, protocol.HandshakeResponse{Identity: protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"}})
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(resp)); err != nil {
+					reportGatewayHandlerError(handlerErrs, "send handshake: %w", err)
+					return
+				}
+			case protocol.MethodProjectList:
+				resp := protocol.NewErrorResponse(req.ID, code, message)
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(resp)); err != nil {
+					reportGatewayHandlerError(handlerErrs, "send project list error: %w", err)
+				}
+				return
+			default:
+				reportGatewayHandlerError(handlerErrs, "unexpected method %q", req.Method)
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	remote, err := remoteclient.DialRemoteURL(context.Background(), "ws"+server.URL[len("http"):])
+	if err != nil {
+		t.Fatalf("DialRemoteURL: %v", err)
+	}
+	defer func() { _ = remote.Close() }()
+
+	_, err = remote.ListProjects(context.Background(), serverapi.ProjectListRequest{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ListProjects error = %v, want context.Canceled", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "Canceled polling by user, process active") {
+		t.Fatalf("expected clear cancellation message, got %v", err)
+	}
+	if strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("did not expect raw context cancellation message, got %q", err.Error())
+	}
+	requireNoGatewayHandlerError(t, handlerErrs)
 }
 
 func newGatewayTestAuthSupport(t *testing.T, ready bool) serverbootstrap.AuthSupport {

--- a/server/transport/gateway_test.go
+++ b/server/transport/gateway_test.go
@@ -122,11 +122,11 @@ func TestCancellationMessageRoundTripsThroughRemoteClient(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("ListProjects error = %v, want context.Canceled", err)
 	}
-	if err == nil || !strings.Contains(err.Error(), "Canceled polling by user, process active") {
-		t.Fatalf("expected clear cancellation message, got %v", err)
+	if err == nil || err.Error() != message {
+		t.Fatalf("expected cancellation message %q, got %v", message, err)
 	}
-	if strings.Contains(err.Error(), "context canceled") {
-		t.Fatalf("did not expect raw context cancellation message, got %q", err.Error())
+	if message == context.Canceled.Error() {
+		t.Fatalf("test precondition failed: expected normalized message, got %q", message)
 	}
 	requireNoGatewayHandlerError(t, handlerErrs)
 }

--- a/shared/client/remote_rpc.go
+++ b/shared/client/remote_rpc.go
@@ -415,6 +415,9 @@ func protocolError(resp *protocol.ResponseError) error {
 		return nil
 	}
 	message := strings.TrimSpace(resp.Message)
+	if resp.Code == protocol.ErrCodeRequestCanceled {
+		return requestCanceledError{message: message}
+	}
 	if message == "" {
 		message = "protocol request failed"
 	}
@@ -447,8 +450,6 @@ func protocolError(resp *protocol.ResponseError) error {
 		return errors.Join(serverapi.ErrPromptAlreadyResolved, errors.New(message))
 	case protocol.ErrCodePromptUnsupported:
 		return errors.Join(serverapi.ErrPromptUnsupported, errors.New(message))
-	case protocol.ErrCodeRequestCanceled:
-		return requestCanceledError{message: message}
 	default:
 		return errors.New(message)
 	}

--- a/shared/client/remote_rpc.go
+++ b/shared/client/remote_rpc.go
@@ -23,6 +23,22 @@ var errRemoteClosed = errors.New("remote client is closed")
 
 const preferredLocalSocketProbeTimeout = 100 * time.Millisecond
 
+type requestCanceledError struct {
+	message string
+}
+
+func (e requestCanceledError) Error() string {
+	message := strings.TrimSpace(e.message)
+	if message == "" || message == context.Canceled.Error() {
+		return "request canceled by client"
+	}
+	return message
+}
+
+func (e requestCanceledError) Unwrap() error {
+	return context.Canceled
+}
+
 type remoteDialPlan struct {
 	endpoints []rpcwire.Endpoint
 }
@@ -432,7 +448,7 @@ func protocolError(resp *protocol.ResponseError) error {
 	case protocol.ErrCodePromptUnsupported:
 		return errors.Join(serverapi.ErrPromptUnsupported, errors.New(message))
 	case protocol.ErrCodeRequestCanceled:
-		return errors.Join(context.Canceled, errors.New(message))
+		return requestCanceledError{message: message}
 	default:
 		return errors.New(message)
 	}

--- a/shared/client/remote_test.go
+++ b/shared/client/remote_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -630,6 +631,19 @@ func TestProtocolErrorMapsAuthRequiredCode(t *testing.T) {
 func TestProtocolErrorMapsRuntimeUnavailableCode(t *testing.T) {
 	if err := protocolError(&protocol.ResponseError{Code: protocol.ErrCodeRuntimeUnavailable, Message: "runtime missing"}); !errors.Is(err, serverapi.ErrRuntimeUnavailable) {
 		t.Fatalf("expected runtime unavailable, got %v", err)
+	}
+}
+
+func TestProtocolErrorMapsRequestCanceledCodeToClearMessage(t *testing.T) {
+	err := protocolError(&protocol.ResponseError{Code: protocol.ErrCodeRequestCanceled, Message: "context canceled"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("did not expect raw context cancellation message, got %q", err.Error())
+	}
+	if err.Error() != "request canceled by client" {
+		t.Fatalf("request canceled error = %q, want request canceled by client", err.Error())
 	}
 }
 

--- a/shared/client/remote_test.go
+++ b/shared/client/remote_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"net/http/httptest"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -639,8 +638,15 @@ func TestProtocolErrorMapsRequestCanceledCodeToClearMessage(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
-	if strings.Contains(err.Error(), "context canceled") {
-		t.Fatalf("did not expect raw context cancellation message, got %q", err.Error())
+	if err.Error() != "request canceled by client" {
+		t.Fatalf("request canceled error = %q, want request canceled by client", err.Error())
+	}
+}
+
+func TestProtocolErrorMapsEmptyRequestCanceledCodeToClearMessage(t *testing.T) {
+	err := protocolError(&protocol.ResponseError{Code: protocol.ErrCodeRequestCanceled})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 	if err.Error() != "request canceled by client" {
 		t.Fatalf("request canceled error = %q, want request canceled by client", err.Error())


### PR DESCRIPTION
## Summary
- clarify shell/RPC cancellation messages
- render ask_question Markdown correctly
- drain queued messages after idle and preserve queue order
- ring terminal bell only when eligible completions need attention
- add file-read line count context for direct partial reads

## Verification
- ./scripts/test.sh ./...
- ./scripts/build.sh --output /Users/nek/Developer/builder-cli/bin/builder
- push preflight: formatting, go vet, go build, tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal focus tracking to suppress or defer notification bells and expose focus state in the UI
  * Better multi-line/Markdown rendering for ask-question prompts
  * Notifications for compaction completion and smarter queued-input handling
  * File-read context: shows total line counts for partial file reads

* **Bug Fixes**
  * Normalized/corrected cancellation messages
  * Improved macOS service restart/recovery when bootstrap fails

* **Documentation**
  * Updated command post-processing and skill-creation guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->