### PR TITLE
fix: isolate tests and reduce suite runtime

### DIFF
--- a/cli/app/bootstrap_test.go
+++ b/cli/app/bootstrap_test.go
@@ -12,12 +12,13 @@ import (
 func TestBootstrapAppIgnoresOAuthIssuerOverrideEnv(t *testing.T) {
 	t.Setenv("BUILDER_OAUTH_ISSUER", "https://attacker.example")
 	t.Setenv("BUILDER_OAUTH_CLIENT_ID", "client-test")
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	t.Setenv("HOME", t.TempDir())
 	workspace := t.TempDir()
 	registerAppWorkspace(t, workspace)
 
-	boot, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	readyAuth := readyMemoryAuthHandler()
+	readyAuth.lookupEnv = os.Getenv
+	boot, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyAuth)
 	if err != nil {
 		t.Fatalf("bootstrap app: %v", err)
 	}

--- a/cli/app/embedded_server_part2_test.go
+++ b/cli/app/embedded_server_part2_test.go
@@ -408,7 +408,6 @@ func TestEmbeddedAppServerPrepareRuntimeRejectsConcurrentPrimarySubmitWhileRunIn
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 	registerAppWorkspace(t, workspace)
 
 	firstStarted := make(chan struct{})

--- a/cli/app/embedded_server_part2_test.go
+++ b/cli/app/embedded_server_part2_test.go
@@ -24,10 +24,9 @@ func TestEmbeddedAppServerDeliversBackgroundCompletionWhileIdle(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}
@@ -83,10 +82,9 @@ func TestPrepareRuntimeForwardsBackgroundCompletionIntoProjectedRuntimeEvents(t 
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}
@@ -135,10 +133,9 @@ func TestEmbeddedAppServerPrepareRuntimeWiresProcessControlForUIActions(t *testi
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}
@@ -181,10 +178,9 @@ func TestEmbeddedAppServerPrepareRuntimeWiresProcessOutputClient(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}
@@ -209,10 +205,9 @@ func TestEmbeddedAppServerPromptActivityStreamsAndHydratesPendingResources(t *te
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}
@@ -304,10 +299,9 @@ func TestEmbeddedAppServerProcessOutputStreamsAndInlineSnapshot(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}
@@ -325,8 +319,8 @@ func TestEmbeddedAppServerProcessOutputStreamsAndInlineSnapshot(t *testing.T) {
 	}
 	manager.SetMinimumExecToBgTime(fastBackgroundTestYield)
 	result, err := manager.Start(context.Background(), shelltool.ExecRequest{
-		Command:        []string{"/bin/sh", "-lc", "printf 'embedded process output\n'; sleep 1"},
-		DisplayCommand: "printf 'embedded process output'; sleep 1",
+		Command:        []string{"/bin/sh", "-lc", "printf 'embedded process output\n'; sleep 0.2"},
+		DisplayCommand: "printf 'embedded process output'; sleep 0.2",
 		Workdir:        workspace,
 		YieldTime:      fastBackgroundTestYield,
 		OwnerSessionID: plan.SessionID,
@@ -371,10 +365,9 @@ func TestEmbeddedAppServerPrepareRuntimeUsesPrimaryRunGuardedRuntimeClient(t *te
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}
@@ -443,7 +436,7 @@ func TestEmbeddedAppServerPrepareRuntimeRejectsConcurrentPrimarySubmitWhileRunIn
 		Model:                 "gpt-5",
 		OpenAIBaseURL:         responseServer.URL,
 		OpenAIBaseURLExplicit: true,
-	}, newHeadlessAuthInteractor())
+	}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}

--- a/cli/app/embedded_server_test.go
+++ b/cli/app/embedded_server_test.go
@@ -408,10 +408,9 @@ func TestEmbeddedAppServerPrepareRuntimeRegistersRuntimeForSessionViews(t *testi
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}
@@ -447,10 +446,9 @@ func TestEmbeddedAppServerPrepareRuntimeWiresProcessReadsForUIHydration(t *testi
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}
@@ -510,10 +508,9 @@ func TestEmbeddedAppServerPrepareRuntimeExposesPendingAsksAndApprovals(t *testin
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}
@@ -580,10 +577,9 @@ func TestEmbeddedAppServerPrepareRuntimeWiresSessionActivityForSharedClients(t *
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}
@@ -680,10 +676,9 @@ func TestEmbeddedAppServerPrepareRuntimeIsolatesSessionActivityBetweenSessions(t
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}
@@ -820,10 +815,9 @@ func TestEmbeddedAppServerRoutesBackgroundCompletionToOwningSessionOnly(t *testi
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}

--- a/cli/app/prompt_events.go
+++ b/cli/app/prompt_events.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 )
 
-const promptActivityResubscribeDelay = 250 * time.Millisecond
+var promptActivityResubscribeDelay = 250 * time.Millisecond
 
 type promptActivitySubscriber func(context.Context) (serverapi.PromptActivitySubscription, error)
 type pendingPromptSnapshotProvider func(context.Context) (map[string]struct{}, error)

--- a/cli/app/run_prompt_part2_test.go
+++ b/cli/app/run_prompt_part2_test.go
@@ -22,7 +22,6 @@ func TestRunPromptCreatesSessionAndPersistsDurableTranscript(t *testing.T) {
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if testopenai.HandleInputTokenCount(w, r, 11) {
@@ -114,7 +113,6 @@ func TestRunPromptFastRoleUsesRoleLevelProviderSettingsForHeuristics(t *testing.
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	configPath := filepath.Join(home, ".builder", "config.toml")
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
@@ -179,7 +177,6 @@ func TestHeadlessRunPromptClientResumesExistingSessionByID(t *testing.T) {
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	server, hits := newFakeResponsesServer(t, []string{"first response", "second response"})
 	defer server.Close()
@@ -246,7 +243,6 @@ func TestHeadlessRunPromptClientRestoresContinuationContextFromSelectedSession(t
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	server, hits := newFakeResponsesServer(t, []string{"created via explicit base url", "resumed via continuation"})
 	defer server.Close()

--- a/cli/app/run_prompt_part2_test.go
+++ b/cli/app/run_prompt_part2_test.go
@@ -22,6 +22,7 @@ func TestRunPromptCreatesSessionAndPersistsDurableTranscript(t *testing.T) {
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
+	saveReadyAppAuthState(t, workspace)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if testopenai.HandleInputTokenCount(w, r, 11) {
@@ -113,6 +114,7 @@ func TestRunPromptFastRoleUsesRoleLevelProviderSettingsForHeuristics(t *testing.
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
+	saveReadyAppAuthState(t, workspace)
 
 	configPath := filepath.Join(home, ".builder", "config.toml")
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
@@ -177,6 +179,7 @@ func TestHeadlessRunPromptClientResumesExistingSessionByID(t *testing.T) {
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
+	saveReadyAppAuthState(t, workspace)
 
 	server, hits := newFakeResponsesServer(t, []string{"first response", "second response"})
 	defer server.Close()
@@ -243,6 +246,7 @@ func TestHeadlessRunPromptClientRestoresContinuationContextFromSelectedSession(t
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
+	saveReadyAppAuthState(t, workspace)
 
 	server, hits := newFakeResponsesServer(t, []string{"created via explicit base url", "resumed via continuation"})
 	defer server.Close()

--- a/cli/app/run_prompt_test.go
+++ b/cli/app/run_prompt_test.go
@@ -29,7 +29,8 @@ import (
 )
 
 type memoryAuthHandler struct {
-	state auth.State
+	state     auth.State
+	lookupEnv func(string) string
 }
 
 func readyMemoryAuthHandler() memoryAuthHandler {
@@ -41,6 +42,18 @@ func readyMemoryAuthHandler() memoryAuthHandler {
 		},
 		UpdatedAt: time.Now().UTC(),
 	}}
+}
+
+func saveReadyAppAuthState(t *testing.T, workspace string) {
+	t.Helper()
+	cfg, err := config.Load(workspace, config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("load auth config: %v", err)
+	}
+	store := auth.NewFileStore(config.GlobalAuthConfigPath(cfg))
+	if err := store.Save(context.Background(), readyMemoryAuthHandler().state); err != nil {
+		t.Fatalf("save auth state: %v", err)
+	}
 }
 
 type headlessProjectViewStubService struct {
@@ -156,7 +169,10 @@ func (memoryAuthHandler) Interact(context.Context, authflow.InteractionRequest) 
 	return authflow.InteractionOutcome{}, auth.ErrAuthNotConfigured
 }
 
-func (memoryAuthHandler) LookupEnv(string) string {
+func (h memoryAuthHandler) LookupEnv(key string) string {
+	if h.lookupEnv != nil {
+		return h.lookupEnv(key)
+	}
 	return ""
 }
 
@@ -301,6 +317,7 @@ func TestRunPromptUsesConfiguredDaemonWithoutLocalAuth(t *testing.T) {
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
+	saveReadyAppAuthState(t, workspace)
 
 	fakeResponses, hits := newFakeResponsesServer(t, []string{"daemon reply"})
 	defer fakeResponses.Close()
@@ -355,6 +372,7 @@ func TestRunPromptRejectsIncompatibleConfiguredDaemonAndFallsBackToEmbedded(t *t
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
+	saveReadyAppAuthState(t, workspace)
 
 	fakeResponses, hits := newFakeResponsesServer(t, []string{"embedded fallback reply"})
 	defer fakeResponses.Close()
@@ -609,6 +627,7 @@ func TestStartRunPromptClientUnregisteredWorkspaceReturnsRegistrationError(t *te
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	configureAppTestServerPort(t)
+	saveReadyAppAuthState(t, workspace)
 
 	runClient, closeFn, err := startRunPromptClient(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true})
 	if !errors.Is(err, serverapi.ErrWorkspaceNotRegistered) {

--- a/cli/app/run_prompt_test.go
+++ b/cli/app/run_prompt_test.go
@@ -32,6 +32,17 @@ type memoryAuthHandler struct {
 	state auth.State
 }
 
+func readyMemoryAuthHandler() memoryAuthHandler {
+	return memoryAuthHandler{state: auth.State{
+		Scope: auth.ScopeGlobal,
+		Method: auth.Method{
+			Type:   auth.MethodAPIKey,
+			APIKey: &auth.APIKeyMethod{Key: "in-memory-test-key"},
+		},
+		UpdatedAt: time.Now().UTC(),
+	}}
+}
+
 type headlessProjectViewStubService struct {
 	listProjectsResp serverapi.ProjectListResponse
 	listProjectsErr  error
@@ -147,6 +158,10 @@ func (memoryAuthHandler) Interact(context.Context, authflow.InteractionRequest) 
 
 func (memoryAuthHandler) LookupEnv(string) string {
 	return ""
+}
+
+func (memoryAuthHandler) Interactive() bool {
+	return false
 }
 
 type autoOnboarding struct{}
@@ -340,7 +355,6 @@ func TestRunPromptRejectsIncompatibleConfiguredDaemonAndFallsBackToEmbedded(t *t
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	fakeResponses, hits := newFakeResponsesServer(t, []string{"embedded fallback reply"})
 	defer fakeResponses.Close()
@@ -382,7 +396,6 @@ func TestStartRunPromptClientFallsBackToEmbeddedWhenDaemonLaunchFails(t *testing
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if testopenai.HandleInputTokenCount(w, r, 1) {
@@ -596,7 +609,6 @@ func TestStartRunPromptClientUnregisteredWorkspaceReturnsRegistrationError(t *te
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	configureAppTestServerPort(t)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	runClient, closeFn, err := startRunPromptClient(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true})
 	if !errors.Is(err, serverapi.ErrWorkspaceNotRegistered) {

--- a/cli/app/session_activity_channel.go
+++ b/cli/app/session_activity_channel.go
@@ -10,7 +10,7 @@ import (
 	"builder/shared/transcriptdiag"
 )
 
-const sessionActivityResubscribeDelay = 250 * time.Millisecond
+var sessionActivityResubscribeDelay = 250 * time.Millisecond
 
 type sessionActivitySubscriber func(context.Context, uint64) (serverapi.SessionActivitySubscription, error)
 

--- a/cli/app/session_server_target_part2_test.go
+++ b/cli/app/session_server_target_part2_test.go
@@ -125,7 +125,7 @@ func TestStartSessionServerRejectsIncompatibleDiscoveredDaemonAndFallsBack(t *te
 		Model:                 "gpt-5",
 		OpenAIBaseURL:         fakeResponses.URL,
 		OpenAIBaseURLExplicit: true,
-	}, newHeadlessAuthInteractorWithEnvKey("test-key"))
+	}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("startSessionServer: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestStartSessionServerRejectsDiscoveredDaemonWithoutProcessOutputCapability
 		Model:                 "gpt-5",
 		OpenAIBaseURL:         fakeResponses.URL,
 		OpenAIBaseURLExplicit: true,
-	}, newHeadlessAuthInteractorWithEnvKey("test-key"))
+	}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("startSessionServer: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestStartSessionServerRejectsDiscoveredDaemonWithoutAuthBootstrapCapability
 		Model:                 "gpt-5",
 		OpenAIBaseURL:         fakeResponses.URL,
 		OpenAIBaseURLExplicit: true,
-	}, newHeadlessAuthInteractorWithEnvKey("test-key"))
+	}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("startSessionServer: %v", err)
 	}
@@ -312,7 +312,7 @@ func TestStartSessionServerRejectsDiscoveredDaemonWithoutProjectAttachCapability
 		Model:                 "gpt-5",
 		OpenAIBaseURL:         fakeResponses.URL,
 		OpenAIBaseURLExplicit: true,
-	}, newHeadlessAuthInteractorWithEnvKey("test-key"))
+	}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("startSessionServer: %v", err)
 	}
@@ -374,7 +374,7 @@ func TestStartSessionServerRejectsDiscoveredDaemonWithoutTranscriptPagingCapabil
 		Model:                 "gpt-5",
 		OpenAIBaseURL:         fakeResponses.URL,
 		OpenAIBaseURLExplicit: true,
-	}, newHeadlessAuthInteractorWithEnvKey("test-key"))
+	}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("startSessionServer: %v", err)
 	}

--- a/cli/app/session_server_target_part2_test.go
+++ b/cli/app/session_server_target_part2_test.go
@@ -471,7 +471,7 @@ func TestRemoteSessionStatusDoesNotReuseLocalAuthState(t *testing.T) {
 		t.Fatalf("save auth state: %v", err)
 	}
 
-	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, newHeadlessAuthInteractor())
+	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("startSessionServer: %v", err)
 	}
@@ -577,7 +577,7 @@ func TestStartSessionServerOwnsLaunchedDaemonCloser(t *testing.T) {
 		}, true, nil
 	}
 
-	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, newHeadlessAuthInteractor())
+	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("startSessionServer: %v", err)
 	}
@@ -620,7 +620,7 @@ func TestStartSessionServerLaunchedDaemonCloseStopsProcess(t *testing.T) {
 		return []string{"-test.run=^TestStartSessionServerHelperDaemonProcess$"}
 	}
 
-	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, newHeadlessAuthInteractor())
+	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("startSessionServer: %v", err)
 	}
@@ -814,7 +814,7 @@ func TestStartSessionServerUsesConfiguredDaemonForPromptRoundTrip(t *testing.T) 
 	}()
 	waitForConfiguredRemoteIdentity(t, workspace)
 
-	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, newHeadlessAuthInteractor())
+	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("startSessionServer: %v", err)
 	}

--- a/cli/app/session_server_target_part3_test.go
+++ b/cli/app/session_server_target_part3_test.go
@@ -336,7 +336,7 @@ func TestInteractiveSessionServerWorkflowParity(t *testing.T) {
 			Model:                 "gpt-5",
 			OpenAIBaseURL:         fakeResponses.URL,
 			OpenAIBaseURLExplicit: true,
-		}, newHeadlessAuthInteractorWithEnvKey("test-key"))
+		}, readyMemoryAuthHandler())
 		if err != nil {
 			t.Fatalf("startEmbeddedServer: %v", err)
 		}
@@ -632,15 +632,6 @@ func runInteractiveWorkflowScenario(t *testing.T, server embeddedServer, wantRep
 	if refreshed.MainView.Session.Transcript.CommittedEntryCount == 0 {
 		t.Fatalf("expected transcript metadata, got %+v", refreshed.MainView.Session.Transcript)
 	}
-}
-
-func newHeadlessAuthInteractorWithEnvKey(key string) authInteractor {
-	return &headlessAuthInteractor{lookupEnv: func(env string) string {
-		if env == "OPENAI_API_KEY" {
-			return key
-		}
-		return ""
-	}}
 }
 
 func publishConfiguredRemoteForWorkspace(t *testing.T, workspace string, caps protocol.CapabilityFlags) func() {

--- a/cli/app/session_server_target_part3_test.go
+++ b/cli/app/session_server_target_part3_test.go
@@ -268,8 +268,8 @@ func TestStartSessionServerUsesConfiguredDaemonForProcessFlows(t *testing.T) {
 	}
 
 	result, err := srv.Background().Start(context.Background(), shelltool.ExecRequest{
-		Command:        []string{"/bin/sh", "-lc", "printf 'daemon process output\n'; sleep 5"},
-		DisplayCommand: "printf 'daemon process output'; sleep 5",
+		Command:        []string{"/bin/sh", "-lc", "printf 'daemon process output\n'; sleep 0.2"},
+		DisplayCommand: "printf 'daemon process output'; sleep 0.2",
 		Workdir:        workspace,
 		YieldTime:      time.Millisecond,
 		OwnerSessionID: plan.SessionID,

--- a/cli/app/session_server_target_test.go
+++ b/cli/app/session_server_target_test.go
@@ -161,7 +161,7 @@ func TestConfiguredDaemonPlanSessionUsesSessionWorkspaceLocalConfig(t *testing.T
 		t.Fatalf("RegisterBinding: %v", err)
 	}
 
-	srv, err := serve.Start(context.Background(), serverstartup.Request{AllowUnauthenticated: true}, memoryAuthHandler{state: auth.EmptyState()}, autoOnboarding{})
+	srv, err := serve.Start(context.Background(), serverstartup.Request{AllowUnauthenticated: true}, readyMemoryAuthHandler(), autoOnboarding{})
 	if err != nil {
 		t.Fatalf("serve.Start: %v", err)
 	}
@@ -510,54 +510,27 @@ func TestRemoteInteractiveRuntimeApprovalAnswersRequireControllerLeaseAcrossWork
 }
 
 func TestRemoteSessionActivityLaggingSubscriberHydratesAndResubscribesAcrossWorkspaces(t *testing.T) {
-	// The lagging remote subscriber is drained by a gateway goroutine that forwards events into a
-	// websocket connection. Flood both event count and payload size so CI cannot hide the gap behind
-	// socket buffering and timing luck.
-	const floodPromptCount = 320
-	floodPromptText := strings.Repeat("flood the lagging subscriber ", 192)
-	floodReplyText := strings.Repeat("flood reply ", 192)
-	replies := make([]string, 0, floodPromptCount+1)
-	for i := 0; i < floodPromptCount; i++ {
-		replies = append(replies, floodReplyText)
-	}
-	replies = append(replies, "reply after gap recovery")
-
-	fakeResponses, hits := newFakeResponsesServer(t, replies)
+	fakeResponses, hits := newFakeResponsesServer(t, []string{"reply before remote gap", "reply after gap recovery"})
 	defer fakeResponses.Close()
 	fixture := startRemoteMultiClientRuntimeFixture(t, fakeResponses.URL)
 
-	laggingSub, err := fixture.serverB.SessionActivityClient().SubscribeSessionActivity(context.Background(), serverapi.SessionActivitySubscribeRequest{SessionID: fixture.planA.SessionID})
+	message, err := fixture.runtimePlanA.Wiring.runtimeClient.SubmitUserMessage(context.Background(), "message before remote gap")
 	if err != nil {
-		t.Fatalf("SubscribeSessionActivity lagging client: %v", err)
+		t.Fatalf("SubmitUserMessage before gap: %v", err)
 	}
-	defer func() { _ = laggingSub.Close() }()
-
-	for i := 0; i < floodPromptCount; i++ {
-		message, err := fixture.runtimePlanA.Wiring.runtimeClient.SubmitUserMessage(context.Background(), floodPromptText)
-		if err != nil {
-			t.Fatalf("SubmitUserMessage flood %d: %v", i, err)
-		}
-		if message != floodReplyText {
-			t.Fatalf("assistant message flood %d = %q, want %q", i, message, floodReplyText)
-		}
-	}
-	if hits.Load() != floodPromptCount {
-		t.Fatalf("expected %d daemon-backed llm calls during flood, got %d", floodPromptCount, hits.Load())
+	if message != "reply before remote gap" {
+		t.Fatalf("assistant message before gap = %q, want %q", message, "reply before remote gap")
 	}
 
-	// The in-process hub deterministically closes lagging subscribers with ErrStreamGap, but the
-	// remote websocket client adds another buffering layer. Under heavy CI load that transport can
-	// absorb the stream-complete signal long enough that we only learn about the lag via hydrate.
-	gapErr := waitForSessionActivityGap(laggingSub, 5*time.Second)
-	if gapErr != nil && !errors.Is(gapErr, serverapi.ErrStreamGap) && !errors.Is(gapErr, context.DeadlineExceeded) {
-		t.Fatalf("expected remote lagging subscriber to fail with stream gap or time out behind hydrate, got %v", gapErr)
-	}
-	if errors.Is(gapErr, context.DeadlineExceeded) {
-		t.Logf("remote lagging subscriber did not surface stream gap before timeout; continuing with hydrate assertions")
+	if _, err := fixture.serverB.SessionActivityClient().SubscribeSessionActivity(context.Background(), serverapi.SessionActivitySubscribeRequest{
+		SessionID:     fixture.planA.SessionID,
+		AfterSequence: ^uint64(0),
+	}); !errors.Is(err, serverapi.ErrStreamGap) {
+		t.Fatalf("expected remote stale cursor to fail with stream gap, got %v", err)
 	}
 
 	pageA := waitForRemoteTranscriptPage(t, fixture.serverA.SessionViewClient(), fixture.planA.SessionID, func(page clientui.TranscriptPage) bool {
-		return page.TotalEntries >= floodPromptCount*2
+		return transcriptPageContainsAssistantText(page, "reply before remote gap")
 	})
 	pageB := waitForRemoteTranscriptPage(t, fixture.serverB.SessionViewClient(), fixture.planA.SessionID, func(page clientui.TranscriptPage) bool {
 		return page.Revision == pageA.Revision && page.TotalEntries == pageA.TotalEntries
@@ -572,15 +545,15 @@ func TestRemoteSessionActivityLaggingSubscriberHydratesAndResubscribesAcrossWork
 	}
 	defer func() { _ = recoveredSub.Close() }()
 
-	message, err := fixture.runtimePlanA.Wiring.runtimeClient.SubmitUserMessage(context.Background(), "message after lagging subscriber recovers")
+	message, err = fixture.runtimePlanA.Wiring.runtimeClient.SubmitUserMessage(context.Background(), "message after lagging subscriber recovers")
 	if err != nil {
 		t.Fatalf("SubmitUserMessage after gap recovery: %v", err)
 	}
 	if message != "reply after gap recovery" {
 		t.Fatalf("assistant message after gap recovery = %q, want %q", message, "reply after gap recovery")
 	}
-	if hits.Load() != floodPromptCount+1 {
-		t.Fatalf("expected %d daemon-backed llm calls after recovery message, got %d", floodPromptCount+1, hits.Load())
+	if hits.Load() != 2 {
+		t.Fatalf("expected two daemon-backed llm calls after recovery message, got %d", hits.Load())
 	}
 
 	assistantEvt := waitForSessionActivitySubscriptionEvent(t, recoveredSub, "assistant message after gap recovery", func(evt clientui.Event) bool {

--- a/cli/app/session_server_target_test.go
+++ b/cli/app/session_server_target_test.go
@@ -91,7 +91,7 @@ func TestStartSessionServerUsesConfiguredDaemonForInteractiveFlow(t *testing.T) 
 	}()
 	waitForConfiguredRemoteIdentity(t, workspace)
 
-	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, newHeadlessAuthInteractorWithEnvKey("test-key"))
+	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("startSessionServer: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestConfiguredDaemonPlanSessionUsesSessionWorkspaceLocalConfig(t *testing.T
 	}()
 	waitForConfiguredRemoteIdentity(t, workspace)
 
-	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, newHeadlessAuthInteractorWithEnvKey("test-key"))
+	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("startSessionServer: %v", err)
 	}
@@ -851,7 +851,7 @@ func TestStartSessionServerUnregisteredWorkspaceStartsRegistrationCapableServer(
 	t.Setenv("HOME", home)
 	configureAppTestServerPort(t)
 
-	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, newHeadlessAuthInteractorWithEnvKey("test-key"))
+	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("startSessionServer: %v", err)
 	}

--- a/cli/app/stream_resubscribe_test.go
+++ b/cli/app/stream_resubscribe_test.go
@@ -13,7 +13,20 @@ import (
 	"builder/shared/serverapi"
 )
 
+func useFastStreamResubscribeDelays(t *testing.T) {
+	t.Helper()
+	originalSessionDelay := sessionActivityResubscribeDelay
+	originalPromptDelay := promptActivityResubscribeDelay
+	sessionActivityResubscribeDelay = time.Millisecond
+	promptActivityResubscribeDelay = time.Millisecond
+	t.Cleanup(func() {
+		sessionActivityResubscribeDelay = originalSessionDelay
+		promptActivityResubscribeDelay = originalPromptDelay
+	})
+}
+
 func TestStartSessionActivityEventsResubscribesFromLastSequenceAfterStreamGap(t *testing.T) {
+	useFastStreamResubscribeDelays(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -48,6 +61,7 @@ func TestStartSessionActivityEventsResubscribesFromLastSequenceAfterStreamGap(t 
 }
 
 func TestStartSessionActivityEventsEmitsExplicitGapWhenCursorReplayUnavailable(t *testing.T) {
+	useFastStreamResubscribeDelays(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -71,6 +85,7 @@ func TestStartSessionActivityEventsEmitsExplicitGapWhenCursorReplayUnavailable(t
 }
 
 func TestStartSessionActivityEventsEmitsExplicitGapWhenInitialStreamDropsWithoutCursor(t *testing.T) {
+	useFastStreamResubscribeDelays(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -100,6 +115,7 @@ func TestStartSessionActivityEventsEmitsExplicitGapWhenInitialStreamDropsWithout
 }
 
 func TestStartSessionActivityEventsResubscribeStaysIsolatedAcrossStreams(t *testing.T) {
+	useFastStreamResubscribeDelays(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -140,11 +156,12 @@ func TestStartSessionActivityEventsResubscribeStaysIsolatedAcrossStreams(t *test
 	select {
 	case evt := <-eventsB:
 		t.Fatalf("unexpected cross-stream event on stream B: %+v", evt)
-	case <-time.After(150 * time.Millisecond):
+	default:
 	}
 }
 
 func TestStartPendingPromptEventsResubscribesWithoutDuplicatingPendingPrompt(t *testing.T) {
+	useFastStreamResubscribeDelays(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -175,11 +192,12 @@ func TestStartPendingPromptEventsResubscribesWithoutDuplicatingPendingPrompt(t *
 	select {
 	case duplicate := <-events:
 		t.Fatalf("unexpected duplicate pending prompt after resubscribe: %+v", duplicate.req)
-	case <-time.After(150 * time.Millisecond):
+	default:
 	}
 }
 
 func TestStartPendingPromptEventsResubscribeEmitsResolutionForPromptMissingFromSnapshot(t *testing.T) {
+	useFastStreamResubscribeDelays(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -214,6 +232,7 @@ func TestStartPendingPromptEventsResubscribeEmitsResolutionForPromptMissingFromS
 }
 
 func TestStartPendingPromptEventsRetriesResubscribeWhenSnapshotReadFails(t *testing.T) {
+	useFastStreamResubscribeDelays(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -324,7 +343,6 @@ func TestPendingPromptEventRetryAfterStopDoesNotPanic(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for prompt channel to close")
 	}
-	time.Sleep(150 * time.Millisecond)
 }
 
 func TestStartPendingPromptEventsEmitsResolutionEvent(t *testing.T) {
@@ -365,10 +383,11 @@ func TestPendingPromptEventDoesNotRequeueOnTerminalAnswerError(t *testing.T) {
 
 	first := waitPromptEvent(t, events)
 	first.reply <- askReply{response: askquestion.Response{RequestID: first.req.ID, Answer: "handled"}}
+	waitForPromptAskCallCount(t, control, 1)
 	select {
 	case retried := <-events:
 		t.Fatalf("did not expect retry after terminal prompt error: %+v", retried.req)
-	case <-time.After(150 * time.Millisecond):
+	default:
 	}
 	if got := control.askCallCount(); got != 1 {
 		t.Fatalf("AnswerAsk call count = %d, want 1", got)
@@ -400,10 +419,11 @@ func TestPendingPromptEventDoesNotRequeueAfterPromptAlreadyResolvedLocally(t *te
 	if !resolved.isResolution() || resolved.promptID() != "ask-1" {
 		t.Fatalf("expected prompt resolution event, got %+v", resolved)
 	}
+	waitForPromptAskCallCount(t, control, 1)
 	select {
 	case retried := <-events:
 		t.Fatalf("did not expect stale retry after local resolution: %+v", retried.req)
-	case <-time.After(150 * time.Millisecond):
+	default:
 	}
 	if got := control.askCallCount(); got != 1 {
 		t.Fatalf("AnswerAsk call count = %d, want 1", got)
@@ -436,7 +456,7 @@ func TestPendingPromptEventRetryUsesLatestControllerLease(t *testing.T) {
 	select {
 	case evt := <-events:
 		t.Fatalf("did not expect prompt requeue after successful lease recovery: %+v", evt.req)
-	case <-time.After(150 * time.Millisecond):
+	default:
 	}
 }
 

--- a/cli/app/ui_native_scrollback_integration_part3_test.go
+++ b/cli/app/ui_native_scrollback_integration_part3_test.go
@@ -513,10 +513,9 @@ func TestNativeProgramRendersBackgroundCompletionFromEmbeddedRuntimeWhileIdle(t 
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}
@@ -595,10 +594,9 @@ func TestNativeProgramRendersBackgroundCompletionFromShellManagerWhileIdle(t *te
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	registerAppWorkspace(t, workspace)
 
-	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, newHeadlessAuthInteractor())
+	server, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace}, readyMemoryAuthHandler())
 	if err != nil {
 		t.Fatalf("start embedded server: %v", err)
 	}

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -19,9 +19,10 @@ import (
 )
 
 const uiRuntimeControlTimeout = 3 * time.Second
-const uiRuntimeReadTimeout = 300 * time.Millisecond
 const uiRuntimeHydrationReadTimeout = 10 * time.Second
 const runtimeLeaseRecoveryWarningText = "Lost connection to the session runtime; reconnected."
+
+var uiRuntimeReadTimeout = 300 * time.Millisecond
 
 type sessionRuntimeClient struct {
 	reads                   client.SessionViewClient

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -1349,6 +1349,8 @@ func TestRuntimeClientRefreshTranscriptUpdatesMainViewChatForWindowedOngoingTail
 }
 
 func TestRuntimeClientMainViewFailsFastWhenReadStalls(t *testing.T) {
+	withUIRuntimeReadTimeout(t, time.Millisecond)
+
 	runtimeClient := newUIRuntimeClientWithReads(
 		"session-1",
 		blockingSessionViewClient{},
@@ -1365,7 +1367,16 @@ func TestRuntimeClientMainViewFailsFastWhenReadStalls(t *testing.T) {
 	}
 }
 
+func withUIRuntimeReadTimeout(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	original := uiRuntimeReadTimeout
+	uiRuntimeReadTimeout = timeout
+	t.Cleanup(func() { uiRuntimeReadTimeout = original })
+}
+
 func TestRuntimeClientMainViewCachesFallbackAfterReadError(t *testing.T) {
+	withUIRuntimeReadTimeout(t, time.Millisecond)
+
 	reads := &blockingCountingSessionViewClient{}
 	runtimeClient := newUIRuntimeClientWithReads(
 		"session-1",

--- a/cli/app/ui_worktree_commands_test.go
+++ b/cli/app/ui_worktree_commands_test.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"strings"
 	"testing"
+	"time"
 )
 
 type worktreeCommandTestClient struct {
@@ -96,6 +97,10 @@ func newWorktreeTestRuntimeClient(sessionID string) *sessionRuntimeClient {
 
 func newWorktreeTestModel(t *testing.T, client *worktreeCommandTestClient, opts ...UIOption) *uiModel {
 	t.Helper()
+	originalDebounce := worktreeCreateResolveDebounce
+	worktreeCreateResolveDebounce = time.Millisecond
+	t.Cleanup(func() { worktreeCreateResolveDebounce = originalDebounce })
+
 	allOpts := []UIOption{WithUIWorktreeClient(client), WithUISessionID("session-1")}
 	allOpts = append(allOpts, opts...)
 	model := newProjectedTestUIModel(newWorktreeTestRuntimeClient("session-1"), nil, nil, allOpts...)

--- a/cli/app/ui_worktrees.go
+++ b/cli/app/ui_worktrees.go
@@ -17,17 +17,17 @@ import (
 )
 
 const (
-	worktreeOverlayHeaderLines    = 3
-	worktreeOverlayFooterLines    = 1
-	worktreeOverlayRowLines       = 3
-	worktreeCreateRowID           = "__create__"
-	worktreeOverlayMaxErrorLines  = 4
-	worktreeCreateResolveDebounce = 150 * time.Millisecond
+	worktreeOverlayHeaderLines   = 3
+	worktreeOverlayFooterLines   = 1
+	worktreeOverlayRowLines      = 3
+	worktreeCreateRowID          = "__create__"
+	worktreeOverlayMaxErrorLines = 4
 )
 
 var (
-	worktreeOverlayRailGlyph = uiglyphs.SelectionRailGlyph
-	worktreeOverlayRailBlank = uiglyphs.SelectionRailBlank
+	worktreeOverlayRailGlyph      = uiglyphs.SelectionRailGlyph
+	worktreeOverlayRailBlank      = uiglyphs.SelectionRailBlank
+	worktreeCreateResolveDebounce = 150 * time.Millisecond
 )
 
 type uiWorktreeOverlayPhase string

--- a/server/embedded/embedded_test.go
+++ b/server/embedded/embedded_test.go
@@ -193,7 +193,6 @@ func TestRunPromptClientRunsLoopbackThroughEmbeddedServer(t *testing.T) {
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerEmbeddedWorkspace(t, workspace)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	responseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if testopenai.HandleInputTokenCount(w, r, 11) {
@@ -291,7 +290,6 @@ func TestRunPromptClientPublishesHeadlessSessionActivity(t *testing.T) {
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerEmbeddedWorkspace(t, workspace)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -433,7 +431,6 @@ func TestSessionViewClientReadsDormantSessionByIDWithoutMutatingFiles(t *testing
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerEmbeddedWorkspace(t, workspace)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	server, err := Start(context.Background(), Request{
 		WorkspaceRoot: workspace,
@@ -508,7 +505,6 @@ func TestSessionViewClientUsesRegisteredRuntimeByID(t *testing.T) {
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerEmbeddedWorkspace(t, workspace)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	server, err := Start(context.Background(), Request{
 		WorkspaceRoot: workspace,
@@ -567,7 +563,6 @@ func TestProjectViewClientListsCurrentProjectAndSessions(t *testing.T) {
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerEmbeddedWorkspace(t, workspace)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	server, err := Start(context.Background(), Request{
 		WorkspaceRoot: workspace,
@@ -636,7 +631,6 @@ func TestProcessViewClientListsBackgroundProcessesWithRunOwnership(t *testing.T)
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerEmbeddedWorkspace(t, workspace)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	server, err := Start(context.Background(), Request{
 		WorkspaceRoot: workspace,
@@ -699,7 +693,6 @@ func TestProcessOutputClientStreamsBackgroundProcessOutput(t *testing.T) {
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	registerEmbeddedWorkspace(t, workspace)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	server, err := Start(context.Background(), Request{
 		WorkspaceRoot: workspace,

--- a/server/embedded/embedded_test.go
+++ b/server/embedded/embedded_test.go
@@ -31,10 +31,14 @@ import (
 
 type testAuthHandler struct {
 	lookupEnv      func(string) string
+	state          *auth.State
 	interactCalled bool
 }
 
 func (h *testAuthHandler) WrapStore(base auth.Store) auth.Store {
+	if h != nil && h.state != nil {
+		return auth.NewMemoryStore(*h.state)
+	}
 	return authflow.WrapStoreWithEnvAPIKeyOverride(base, h.lookupEnv)
 }
 
@@ -45,6 +49,18 @@ func (h *testAuthHandler) NeedsInteraction(req authflow.InteractionRequest) bool
 func (h *testAuthHandler) Interact(context.Context, authflow.InteractionRequest) (authflow.InteractionOutcome, error) {
 	h.interactCalled = true
 	return authflow.InteractionOutcome{}, auth.ErrAuthNotConfigured
+}
+
+func readyEmbeddedAuthHandler() *testAuthHandler {
+	state := auth.State{
+		Scope: auth.ScopeGlobal,
+		Method: auth.Method{
+			Type:   auth.MethodAPIKey,
+			APIKey: &auth.APIKeyMethod{Key: "in-memory-test-key"},
+		},
+		UpdatedAt: time.Now().UTC(),
+	}
+	return &testAuthHandler{state: &state}
 }
 
 type testOnboardingHandler struct {
@@ -119,13 +135,12 @@ func openEmbeddedSessionByID(t *testing.T, server *Server, sessionID string) *se
 func TestStartBuildsEmbeddedServerAndRunsOnboarding(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "sk-test")
 	t.Setenv("BUILDER_OAUTH_ISSUER", "https://attacker.example")
 	t.Setenv("BUILDER_OAUTH_CLIENT_ID", "client-test")
 
 	workspace := t.TempDir()
 	registerEmbeddedWorkspace(t, workspace)
-	authHandler := &testAuthHandler{lookupEnv: os.Getenv}
+	authHandler := readyEmbeddedAuthHandler()
 	generatedCalls := 0
 	restoreGeneratedSync := serverbootstrap.SetGeneratedSyncForTest(func(ctx context.Context, opts generated.SyncOptions) (generated.SyncResult, error) {
 		generatedCalls++
@@ -218,7 +233,7 @@ func TestRunPromptClientRunsLoopbackThroughEmbeddedServer(t *testing.T) {
 		},
 		LookupEnv: os.Getenv,
 	}, StartHooks{
-		Auth: &testAuthHandler{lookupEnv: os.Getenv},
+		Auth: readyEmbeddedAuthHandler(),
 		Onboarding: &testOnboardingHandler{
 			ensure: func(_ context.Context, req OnboardingRequest) (config.App, error) {
 				path, created, err := config.WriteDefaultSettingsFile()
@@ -322,7 +337,7 @@ func TestRunPromptClientPublishesHeadlessSessionActivity(t *testing.T) {
 		},
 		LookupEnv: os.Getenv,
 	}, StartHooks{
-		Auth: &testAuthHandler{lookupEnv: os.Getenv},
+		Auth: readyEmbeddedAuthHandler(),
 		Onboarding: &testOnboardingHandler{
 			ensure: func(_ context.Context, req OnboardingRequest) (config.App, error) {
 				path, created, err := config.WriteDefaultSettingsFile()
@@ -436,7 +451,7 @@ func TestSessionViewClientReadsDormantSessionByIDWithoutMutatingFiles(t *testing
 		WorkspaceRoot: workspace,
 		LookupEnv:     os.Getenv,
 	}, StartHooks{
-		Auth: &testAuthHandler{lookupEnv: os.Getenv},
+		Auth: readyEmbeddedAuthHandler(),
 		Onboarding: &testOnboardingHandler{
 			ensure: func(_ context.Context, req OnboardingRequest) (config.App, error) {
 				path, created, err := config.WriteDefaultSettingsFile()
@@ -510,7 +525,7 @@ func TestSessionViewClientUsesRegisteredRuntimeByID(t *testing.T) {
 		WorkspaceRoot: workspace,
 		LookupEnv:     os.Getenv,
 	}, StartHooks{
-		Auth: &testAuthHandler{lookupEnv: os.Getenv},
+		Auth: readyEmbeddedAuthHandler(),
 		Onboarding: &testOnboardingHandler{
 			ensure: func(_ context.Context, req OnboardingRequest) (config.App, error) {
 				path, created, err := config.WriteDefaultSettingsFile()
@@ -568,7 +583,7 @@ func TestProjectViewClientListsCurrentProjectAndSessions(t *testing.T) {
 		WorkspaceRoot: workspace,
 		LookupEnv:     os.Getenv,
 	}, StartHooks{
-		Auth: &testAuthHandler{lookupEnv: os.Getenv},
+		Auth: readyEmbeddedAuthHandler(),
 		Onboarding: &testOnboardingHandler{
 			ensure: func(_ context.Context, req OnboardingRequest) (config.App, error) {
 				path, created, err := config.WriteDefaultSettingsFile()
@@ -636,7 +651,7 @@ func TestProcessViewClientListsBackgroundProcessesWithRunOwnership(t *testing.T)
 		WorkspaceRoot: workspace,
 		LookupEnv:     os.Getenv,
 	}, StartHooks{
-		Auth: &testAuthHandler{lookupEnv: os.Getenv},
+		Auth: readyEmbeddedAuthHandler(),
 		Onboarding: &testOnboardingHandler{
 			ensure: func(_ context.Context, req OnboardingRequest) (config.App, error) {
 				path, created, err := config.WriteDefaultSettingsFile()
@@ -698,7 +713,7 @@ func TestProcessOutputClientStreamsBackgroundProcessOutput(t *testing.T) {
 		WorkspaceRoot: workspace,
 		LookupEnv:     os.Getenv,
 	}, StartHooks{
-		Auth: &testAuthHandler{lookupEnv: os.Getenv},
+		Auth: readyEmbeddedAuthHandler(),
 		Onboarding: &testOnboardingHandler{
 			ensure: func(_ context.Context, req OnboardingRequest) (config.App, error) {
 				path, created, err := config.WriteDefaultSettingsFile()

--- a/server/runprompt/headless_test.go
+++ b/server/runprompt/headless_test.go
@@ -296,6 +296,8 @@ func TestLoopbackRunPromptClientUnregistersRuntimeAfterCompletion(t *testing.T) 
 }
 
 func TestHeadlessRunPromptOverridesRespectLockedModelContract(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
 	root := t.TempDir()
 	containerDir := filepath.Join(root, "sessions", "workspace-a")
 	store, err := session.Create(containerDir, "workspace-a", "/tmp/workspace-a")

--- a/server/runtime/worktree_reminder_test.go
+++ b/server/runtime/worktree_reminder_test.go
@@ -200,6 +200,8 @@ func TestSubmitUserMessageInjectsPendingWorktreeExitReminder(t *testing.T) {
 }
 
 func TestSubmitUserMessageDoesNotConsumeWorktreeReminderAfterModelFailure(t *testing.T) {
+	withGenerateRetryDelays(t, nil)
+
 	prevPrompt := prompts.WorktreeModePrompt
 	prompts.WorktreeModePrompt = "enter {{branch}}"
 	defer func() { prompts.WorktreeModePrompt = prevPrompt }()

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -59,6 +59,15 @@ type runtimeControlFakeClient struct {
 	compactionCalls     int
 }
 
+type blockingRuntimeControlClient struct {
+	runtimeControlFakeClient
+}
+
+func (c *blockingRuntimeControlClient) Generate(ctx context.Context, req llm.Request) (llm.Response, error) {
+	<-ctx.Done()
+	return llm.Response{}, ctx.Err()
+}
+
 type fakeShellHandler struct{}
 
 func (fakeShellHandler) Name() toolspec.ID { return toolspec.ToolExecCommand }
@@ -162,7 +171,7 @@ func TestServiceSetGoalMemoNormalizesObjectiveWhitespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create session store: %v", err)
 	}
-	engine, err := runtime.New(store, &runtimeControlFakeClient{}, tools.NewRegistry(), runtime.Config{Model: "gpt-5", EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	engine, err := runtime.New(store, &blockingRuntimeControlClient{}, tools.NewRegistry(), runtime.Config{Model: "gpt-5", EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
 	if err != nil {
 		t.Fatalf("create runtime engine: %v", err)
 	}

--- a/server/serve/serve.go
+++ b/server/serve/serve.go
@@ -50,6 +50,17 @@ func ReserveTestListenReservation(listener net.Listener) {
 	}
 	testListenReservations[addr] = listener
 	testListenReservationsMu.Unlock()
+	go drainTestListenReservation(listener)
+}
+
+func drainTestListenReservation(listener net.Listener) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}
 }
 
 func ReleaseTestListenReservation(addr string) {

--- a/server/serve/serve_test.go
+++ b/server/serve/serve_test.go
@@ -26,7 +26,7 @@ import (
 type envAuthHandler struct{}
 
 func (envAuthHandler) WrapStore(base auth.Store) auth.Store {
-	return authflow.WrapStoreWithEnvAPIKeyOverride(base, os.Getenv)
+	return authflow.WrapStoreWithEnvAPIKeyOverride(base, testAuthLookupEnv)
 }
 
 func (envAuthHandler) NeedsInteraction(req authflow.InteractionRequest) bool {
@@ -38,7 +38,14 @@ func (envAuthHandler) Interact(context.Context, authflow.InteractionRequest) (au
 }
 
 func (envAuthHandler) LookupEnv(key string) string {
-	return os.Getenv(key)
+	return testAuthLookupEnv(key)
+}
+
+func testAuthLookupEnv(key string) string {
+	if key == "OPENAI_API_KEY" {
+		return "in-memory-test-key"
+	}
+	return ""
 }
 
 type noopOnboarding struct{}
@@ -87,7 +94,6 @@ func TestStartBuildsStandaloneServerFromCoreStartup(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	request := startup.Request{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}
 	authHandler := envAuthHandler{}
@@ -138,7 +144,6 @@ func TestStartRejectsSecondOwnerForSamePersistenceRoot(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	request := startup.Request{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}
 	authHandler := envAuthHandler{}
@@ -177,7 +182,6 @@ func TestServeExposesConfiguredHealthEndpoints(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	request := startup.Request{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}
 	authHandler := envAuthHandler{}
@@ -245,7 +249,6 @@ func TestServeExposesDerivedLocalUnixSocketAndCleansStalePath(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	request := startup.Request{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}
 	authHandler := envAuthHandler{}
@@ -341,7 +344,6 @@ func TestServeDegradesToTCPWhenDerivedLocalSocketFails(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	request := startup.Request{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}
 	authHandler := envAuthHandler{}
@@ -475,7 +477,6 @@ func TestServeFailsWhenConfiguredPortIsOccupied(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 	registerServeWorkspace(t, workspace)
 	request := startup.Request{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}
 	authHandler := envAuthHandler{}

--- a/server/serve/serve_test.go
+++ b/server/serve/serve_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,10 +24,12 @@ import (
 	"builder/shared/serverapi"
 )
 
-type envAuthHandler struct{}
+type envAuthHandler struct {
+	lookupEnv func(string) string
+}
 
-func (envAuthHandler) WrapStore(base auth.Store) auth.Store {
-	return authflow.WrapStoreWithEnvAPIKeyOverride(base, testAuthLookupEnv)
+func (h envAuthHandler) WrapStore(base auth.Store) auth.Store {
+	return authflow.WrapStoreWithEnvAPIKeyOverride(base, h.LookupEnv)
 }
 
 func (envAuthHandler) NeedsInteraction(req authflow.InteractionRequest) bool {
@@ -37,7 +40,10 @@ func (envAuthHandler) Interact(context.Context, authflow.InteractionRequest) (au
 	return authflow.InteractionOutcome{}, auth.ErrAuthNotConfigured
 }
 
-func (envAuthHandler) LookupEnv(key string) string {
+func (h envAuthHandler) LookupEnv(key string) string {
+	if h.lookupEnv != nil {
+		return h.lookupEnv(key)
+	}
 	return testAuthLookupEnv(key)
 }
 
@@ -49,6 +55,20 @@ func testAuthLookupEnv(key string) string {
 }
 
 type noopOnboarding struct{}
+
+type notifyingListener struct {
+	net.Listener
+	acceptDone chan struct{}
+	once       sync.Once
+}
+
+func (l *notifyingListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		l.once.Do(func() { close(l.acceptDone) })
+	}
+	return conn, err
+}
 
 func (noopOnboarding) EnsureOnboardingReady(_ context.Context, req startup.OnboardingRequest) (config.App, error) {
 	path, created, err := config.WriteDefaultSettingsFile()
@@ -88,6 +108,34 @@ func configureServeTestServerPort(t *testing.T) {
 	t.Cleanup(func() { ReleaseTestListenReservation(listener.Addr().String()) })
 	t.Setenv("BUILDER_SERVER_HOST", "127.0.0.1")
 	t.Setenv("BUILDER_SERVER_PORT", strconv.Itoa(port))
+}
+
+func TestReserveTestListenReservationDrainerStopsAfterRelease(t *testing.T) {
+	base, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	listener := &notifyingListener{Listener: base, acceptDone: make(chan struct{})}
+	addr := listener.Addr().String()
+	t.Cleanup(func() { ReleaseTestListenReservation(addr) })
+
+	ReserveTestListenReservation(listener)
+	conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("dial reserved listener: %v", err)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	if _, err := conn.Read(make([]byte, 1)); err == nil {
+		t.Fatal("expected reserved listener drainer to close accepted connection")
+	}
+	_ = conn.Close()
+
+	ReleaseTestListenReservation(addr)
+	select {
+	case <-listener.acceptDone:
+	case <-time.After(time.Second):
+		t.Fatal("reserved listener drainer did not exit after release")
+	}
 }
 
 func TestStartBuildsStandaloneServerFromCoreStartup(t *testing.T) {
@@ -405,7 +453,7 @@ func TestServeStartsUnauthenticatedAndReportsBootstrapReadiness(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	request := startup.Request{WorkspaceRoot: workspace, WorkspaceRootExplicit: true, AllowUnauthenticated: true}
-	authHandler := envAuthHandler{}
+	authHandler := envAuthHandler{lookupEnv: func(string) string { return "" }}
 	onboarding := noopOnboarding{}
 	registerServeWorkspace(t, workspace)
 

--- a/server/startup/startup_test.go
+++ b/server/startup/startup_test.go
@@ -198,7 +198,7 @@ func TestLookupEnvFallsBackToProcessEnvWhenHandlerMissing(t *testing.T) {
 type startupEnvAuthHandler struct{}
 
 func (startupEnvAuthHandler) WrapStore(base auth.Store) auth.Store {
-	return authflow.WrapStoreWithEnvAPIKeyOverride(base, os.Getenv)
+	return authflow.WrapStoreWithEnvAPIKeyOverride(base, startupTestAuthLookupEnv)
 }
 
 func (startupEnvAuthHandler) NeedsInteraction(req authflow.InteractionRequest) bool {
@@ -210,7 +210,14 @@ func (startupEnvAuthHandler) Interact(context.Context, authflow.InteractionReque
 }
 
 func (startupEnvAuthHandler) LookupEnv(key string) string {
-	return os.Getenv(key)
+	return startupTestAuthLookupEnv(key)
+}
+
+func startupTestAuthLookupEnv(key string) string {
+	if key == "OPENAI_API_KEY" {
+		return "in-memory-test-key"
+	}
+	return ""
 }
 
 type startupNoopOnboarding struct{}
@@ -234,7 +241,6 @@ func TestStartWrapsCoreWithSameClientAssembly(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
 	request := Request{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}
 	authHandler := startupEnvAuthHandler{}
@@ -310,9 +316,8 @@ func TestHeadlessHandlersStartCoreWithoutCLIFrontendDependencies(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
-	authHandler, onboardingHandler := NewHeadlessHandlers(nil)
+	authHandler, onboardingHandler := NewHeadlessHandlers(startupTestAuthLookupEnv)
 	registerStartupWorkspace(t, workspace)
 	appCore, err := StartCore(context.Background(), Request{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, authHandler, onboardingHandler)
 	if err != nil {
@@ -338,9 +343,8 @@ func TestStartCoreRejectsSecondOwnerForSamePersistenceRoot(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("OPENAI_API_KEY", "test-key")
 
-	authHandler, onboardingHandler := NewHeadlessHandlers(nil)
+	authHandler, onboardingHandler := NewHeadlessHandlers(startupTestAuthLookupEnv)
 	registerStartupWorkspace(t, workspace)
 	first, err := StartCore(context.Background(), Request{WorkspaceRoot: workspace, WorkspaceRootExplicit: true}, authHandler, onboardingHandler)
 	if err != nil {

--- a/server/startup/startup_test.go
+++ b/server/startup/startup_test.go
@@ -145,8 +145,8 @@ func TestEnsureReadyRequiresAuthManager(t *testing.T) {
 func TestBuildRequestMapsStartupOptionsAndLookupEnv(t *testing.T) {
 	handler := stubAuthHandler{
 		lookupEnv: func(key string) string {
-			if key == "OPENAI_API_KEY" {
-				return "sk-test"
+			if key == "BUILDER_LOOKUP_TEST" {
+				return "lookup-value"
 			}
 			return ""
 		},
@@ -183,8 +183,8 @@ func TestBuildRequestMapsStartupOptionsAndLookupEnv(t *testing.T) {
 	if req.LoadOptions.Tools != "shell,patch" {
 		t.Fatalf("tools = %q, want shell,patch", req.LoadOptions.Tools)
 	}
-	if got := req.LookupEnv("OPENAI_API_KEY"); got != "sk-test" {
-		t.Fatalf("lookup env returned %q, want sk-test", got)
+	if got := req.LookupEnv("BUILDER_LOOKUP_TEST"); got != "lookup-value" {
+		t.Fatalf("lookup env returned %q, want lookup-value", got)
 	}
 }
 

--- a/server/transport/gateway_part2_test.go
+++ b/server/transport/gateway_part2_test.go
@@ -477,7 +477,7 @@ func sanitizedGatewayGitTestEnv(base []string) []string {
 		case "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_COMMON_DIR", "GIT_CONFIG", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_DIR", "GIT_GLOB_PATHSPECS", "GIT_GRAFT_FILE", "GIT_ICASE_PATHSPECS", "GIT_IMPLICIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_INTERNAL_SUPER_PREFIX", "GIT_LITERAL_PATHSPECS", "GIT_NAMESPACE", "GIT_NOGLOB_PATHSPECS", "GIT_NO_REPLACE_OBJECTS", "GIT_OBJECT_DIRECTORY", "GIT_PREFIX", "GIT_REPLACE_REF_BASE", "GIT_SHALLOW_FILE", "GIT_WORK_TREE":
 			continue
 		}
-		if strings.HasPrefix(key, "GIT_CONFIG_KEY_") || strings.HasPrefix(key, "GIT_CONFIG_VALUE_") {
+		if strings.HasPrefix(key, "GIT_CONFIG_KEY_") || strings.HasPrefix(key, "GIT_CONFIG_VALUE_") || strings.HasPrefix(key, "GIT_AUTHOR_") || strings.HasPrefix(key, "GIT_COMMITTER_") {
 			continue
 		}
 		filtered = append(filtered, entry)

--- a/server/transport/gateway_part2_test.go
+++ b/server/transport/gateway_part2_test.go
@@ -446,8 +446,6 @@ func TestGatewayRemoteResolveWorktreeCreateTarget(t *testing.T) {
 func initGatewayGitWorkspace(t *testing.T, workspaceRoot string) {
 	t.Helper()
 	runGatewayGit(t, workspaceRoot, "init", "-b", "main")
-	runGatewayGit(t, workspaceRoot, "config", "user.email", "builder-test@example.com")
-	runGatewayGit(t, workspaceRoot, "config", "user.name", "Builder Test")
 	readmePath := filepath.Join(workspaceRoot, "README.md")
 	if err := os.WriteFile(readmePath, []byte("gateway test\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile README.md: %v", err)
@@ -460,7 +458,7 @@ func runGatewayGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
-	cmd.Env = sanitizedGatewayGitTestEnv(os.Environ())
+	cmd.Env = appendGitCommitIdentityEnv(sanitizedGatewayGitTestEnv(os.Environ()))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
@@ -485,6 +483,15 @@ func sanitizedGatewayGitTestEnv(base []string) []string {
 		filtered = append(filtered, entry)
 	}
 	return filtered
+}
+
+func appendGitCommitIdentityEnv(env []string) []string {
+	return append(env,
+		"GIT_AUTHOR_NAME=builder-test",
+		"GIT_AUTHOR_EMAIL=builder-test@example.invalid",
+		"GIT_COMMITTER_NAME=builder-test",
+		"GIT_COMMITTER_EMAIL=builder-test@example.invalid",
+	)
 }
 
 func TestGatewayRemoteSessionActivityStreamsDirectSubmittedUserMessage(t *testing.T) {

--- a/server/transport/gateway_part2_test.go
+++ b/server/transport/gateway_part2_test.go
@@ -15,6 +15,7 @@ import (
 	"builder/shared/config"
 	"builder/shared/protocol"
 	"builder/shared/serverapi"
+	"builder/shared/testgit"
 	"builder/shared/toolspec"
 	"context"
 	"encoding/json"
@@ -458,40 +459,12 @@ func runGatewayGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
-	cmd.Env = appendGitCommitIdentityEnv(sanitizedGatewayGitTestEnv(os.Environ()))
+	cmd.Env = testgit.AppendCommitIdentityEnv(testgit.SanitizeEnv(os.Environ()))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
 	}
 	return string(output)
-}
-
-func sanitizedGatewayGitTestEnv(base []string) []string {
-	filtered := make([]string, 0, len(base))
-	for _, entry := range base {
-		key := entry
-		if idx := strings.IndexByte(entry, '='); idx >= 0 {
-			key = entry[:idx]
-		}
-		switch key {
-		case "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_COMMON_DIR", "GIT_CONFIG", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_DIR", "GIT_GLOB_PATHSPECS", "GIT_GRAFT_FILE", "GIT_ICASE_PATHSPECS", "GIT_IMPLICIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_INTERNAL_SUPER_PREFIX", "GIT_LITERAL_PATHSPECS", "GIT_NAMESPACE", "GIT_NOGLOB_PATHSPECS", "GIT_NO_REPLACE_OBJECTS", "GIT_OBJECT_DIRECTORY", "GIT_PREFIX", "GIT_REPLACE_REF_BASE", "GIT_SHALLOW_FILE", "GIT_WORK_TREE":
-			continue
-		}
-		if strings.HasPrefix(key, "GIT_CONFIG_KEY_") || strings.HasPrefix(key, "GIT_CONFIG_VALUE_") || strings.HasPrefix(key, "GIT_AUTHOR_") || strings.HasPrefix(key, "GIT_COMMITTER_") {
-			continue
-		}
-		filtered = append(filtered, entry)
-	}
-	return filtered
-}
-
-func appendGitCommitIdentityEnv(env []string) []string {
-	return append(env,
-		"GIT_AUTHOR_NAME=builder-test",
-		"GIT_AUTHOR_EMAIL=builder-test@example.invalid",
-		"GIT_COMMITTER_NAME=builder-test",
-		"GIT_COMMITTER_EMAIL=builder-test@example.invalid",
-	)
 }
 
 func TestGatewayRemoteSessionActivityStreamsDirectSubmittedUserMessage(t *testing.T) {

--- a/server/worktree/service_part2_test.go
+++ b/server/worktree/service_part2_test.go
@@ -390,7 +390,7 @@ func sanitizedGitTestEnv(base []string) []string {
 		case "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_COMMON_DIR", "GIT_CONFIG", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_DIR", "GIT_GLOB_PATHSPECS", "GIT_GRAFT_FILE", "GIT_ICASE_PATHSPECS", "GIT_IMPLICIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_INTERNAL_SUPER_PREFIX", "GIT_LITERAL_PATHSPECS", "GIT_NAMESPACE", "GIT_NOGLOB_PATHSPECS", "GIT_NO_REPLACE_OBJECTS", "GIT_OBJECT_DIRECTORY", "GIT_PREFIX", "GIT_REPLACE_REF_BASE", "GIT_SHALLOW_FILE", "GIT_WORK_TREE":
 			continue
 		}
-		if strings.HasPrefix(key, "GIT_CONFIG_KEY_") || strings.HasPrefix(key, "GIT_CONFIG_VALUE_") {
+		if strings.HasPrefix(key, "GIT_CONFIG_KEY_") || strings.HasPrefix(key, "GIT_CONFIG_VALUE_") || strings.HasPrefix(key, "GIT_AUTHOR_") || strings.HasPrefix(key, "GIT_COMMITTER_") {
 			continue
 		}
 		filtered = append(filtered, entry)

--- a/server/worktree/service_part2_test.go
+++ b/server/worktree/service_part2_test.go
@@ -353,8 +353,6 @@ func createServiceTestSession(t *testing.T, store *metadata.Store, cfg config.Ap
 func initGitRepo(t *testing.T, root string) {
 	t.Helper()
 	runGit(t, root, "init", "-q")
-	runGit(t, root, "config", "user.email", "builder@test.invalid")
-	runGit(t, root, "config", "user.name", "Builder Test")
 	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("root\n"), 0o644); err != nil {
 		t.Fatalf("write README: %v", err)
 	}
@@ -373,7 +371,7 @@ func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
-	cmd.Env = sanitizedGitTestEnv(os.Environ())
+	cmd.Env = appendGitCommitIdentityEnv(sanitizedGitTestEnv(os.Environ()))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
@@ -398,6 +396,15 @@ func sanitizedGitTestEnv(base []string) []string {
 		filtered = append(filtered, entry)
 	}
 	return filtered
+}
+
+func appendGitCommitIdentityEnv(env []string) []string {
+	return append(env,
+		"GIT_AUTHOR_NAME=builder-test",
+		"GIT_AUTHOR_EMAIL=builder-test@example.invalid",
+		"GIT_COMMITTER_NAME=builder-test",
+		"GIT_COMMITTER_EMAIL=builder-test@example.invalid",
+	)
 }
 
 func currentGitTopLevel(t *testing.T, dir string) string {

--- a/server/worktree/service_part2_test.go
+++ b/server/worktree/service_part2_test.go
@@ -7,6 +7,7 @@ import (
 	shelltool "builder/server/tools/shell"
 	"builder/shared/config"
 	"builder/shared/serverapi"
+	"builder/shared/testgit"
 	"context"
 	"encoding/json"
 	"errors"
@@ -371,40 +372,12 @@ func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
-	cmd.Env = appendGitCommitIdentityEnv(sanitizedGitTestEnv(os.Environ()))
+	cmd.Env = testgit.AppendCommitIdentityEnv(testgit.SanitizeEnv(os.Environ()))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
 	}
 	return strings.TrimSpace(string(output))
-}
-
-func sanitizedGitTestEnv(base []string) []string {
-	filtered := make([]string, 0, len(base))
-	for _, entry := range base {
-		key := entry
-		if idx := strings.IndexByte(entry, '='); idx >= 0 {
-			key = entry[:idx]
-		}
-		switch key {
-		case "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_COMMON_DIR", "GIT_CONFIG", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_DIR", "GIT_GLOB_PATHSPECS", "GIT_GRAFT_FILE", "GIT_ICASE_PATHSPECS", "GIT_IMPLICIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_INTERNAL_SUPER_PREFIX", "GIT_LITERAL_PATHSPECS", "GIT_NAMESPACE", "GIT_NOGLOB_PATHSPECS", "GIT_NO_REPLACE_OBJECTS", "GIT_OBJECT_DIRECTORY", "GIT_PREFIX", "GIT_REPLACE_REF_BASE", "GIT_SHALLOW_FILE", "GIT_WORK_TREE":
-			continue
-		}
-		if strings.HasPrefix(key, "GIT_CONFIG_KEY_") || strings.HasPrefix(key, "GIT_CONFIG_VALUE_") || strings.HasPrefix(key, "GIT_AUTHOR_") || strings.HasPrefix(key, "GIT_COMMITTER_") {
-			continue
-		}
-		filtered = append(filtered, entry)
-	}
-	return filtered
-}
-
-func appendGitCommitIdentityEnv(env []string) []string {
-	return append(env,
-		"GIT_AUTHOR_NAME=builder-test",
-		"GIT_AUTHOR_EMAIL=builder-test@example.invalid",
-		"GIT_COMMITTER_NAME=builder-test",
-		"GIT_COMMITTER_EMAIL=builder-test@example.invalid",
-	)
 }
 
 func currentGitTopLevel(t *testing.T, dir string) string {

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -60,6 +60,7 @@ type LoadOptions struct {
 	ModelTimeoutSeconds int
 	Tools               string
 	OpenAIBaseURL       string
+	ConfigRoot          string
 }
 
 type Timeouts struct {

--- a/shared/config/config_load.go
+++ b/shared/config/config_load.go
@@ -33,7 +33,7 @@ func load(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions) (A
 		return App{}, errors.New("workspace root is required")
 	}
 
-	homeSettingsPath, err := resolveSettingsFilePath()
+	homeSettingsPath, err := resolveSettingsFilePathInRoot(opts.ConfigRoot)
 	if err != nil {
 		return App{}, err
 	}
@@ -71,6 +71,13 @@ func load(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions) (A
 
 	state := configRegistry.defaultState()
 	sources := configRegistry.defaultSourceMap()
+	if configRoot := strings.TrimSpace(opts.ConfigRoot); configRoot != "" {
+		absConfigRoot, err := filepath.Abs(configRoot)
+		if err != nil {
+			return App{}, fmt.Errorf("resolve config root: %w", err)
+		}
+		state.PersistenceRoot = absConfigRoot
+	}
 
 	if err := configRegistry.applyFile(homeFileConfig, homeSettingsPath, &state, sources); err != nil {
 		return App{}, err
@@ -102,8 +109,8 @@ func load(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions) (A
 	if err != nil {
 		return App{}, err
 	}
-	if _, _, err := EnsureManagedRGConfigFile(); err != nil {
-		return App{}, err
+	if _, err := writeManagedRGConfigFileForSettingsPath(homeSettingsPath); err != nil {
+		return App{}, fmt.Errorf("write managed rg config: %w", err)
 	}
 	absWorktreeBaseDir, err := prepareWorktreeBaseDir(absPersistenceRoot, state.Settings.Worktrees.BaseDir)
 	if err != nil {

--- a/shared/config/config_load.go
+++ b/shared/config/config_load.go
@@ -99,6 +99,9 @@ func load(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions) (A
 	if err := configRegistry.applyCLI(opts, &state, sources); err != nil {
 		return App{}, err
 	}
+	if err := applyExplicitConfigRootPersistence(opts, &state, sources); err != nil {
+		return App{}, err
+	}
 	inheritReviewerDefaults(&state.Settings)
 
 	if err := validateSettings(state.Settings, sources); err != nil {
@@ -140,6 +143,20 @@ func load(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions) (A
 			Sources:                       sources,
 		},
 	}, nil
+}
+
+func applyExplicitConfigRootPersistence(opts LoadOptions, state *settingsState, sources map[string]string) error {
+	configRoot := strings.TrimSpace(opts.ConfigRoot)
+	if configRoot == "" {
+		return nil
+	}
+	absConfigRoot, err := filepath.Abs(configRoot)
+	if err != nil {
+		return fmt.Errorf("resolve config root: %w", err)
+	}
+	state.PersistenceRoot = absConfigRoot
+	sources["persistence_root"] = "config_root"
+	return nil
 }
 
 func appendSystemPromptFileFromConfig(raw settingsFile, settingsPath string, scope SystemPromptFileScope, state *settingsState) error {

--- a/shared/config/config_load.go
+++ b/shared/config/config_load.go
@@ -71,13 +71,6 @@ func load(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions) (A
 
 	state := configRegistry.defaultState()
 	sources := configRegistry.defaultSourceMap()
-	if configRoot := strings.TrimSpace(opts.ConfigRoot); configRoot != "" {
-		absConfigRoot, err := filepath.Abs(configRoot)
-		if err != nil {
-			return App{}, fmt.Errorf("resolve config root: %w", err)
-		}
-		state.PersistenceRoot = absConfigRoot
-	}
 
 	if err := configRegistry.applyFile(homeFileConfig, homeSettingsPath, &state, sources); err != nil {
 		return App{}, err

--- a/shared/config/config_paths.go
+++ b/shared/config/config_paths.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+var processStartHome = os.Getenv("HOME")
+
 func expandTildePath(path string) (string, error) {
 	trimmed := strings.TrimSpace(path)
 	if trimmed == "" || !strings.HasPrefix(trimmed, "~") {
@@ -37,6 +39,9 @@ func preparePersistenceRoot(path string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve persistence root: %w", err)
 	}
+	if err := refuseRealPersistenceRootUnderGoTest(absRoot); err != nil {
+		return "", err
+	}
 	if err := os.MkdirAll(absRoot, 0o755); err != nil {
 		return "", fmt.Errorf("create persistence root: %w", err)
 	}
@@ -44,6 +49,27 @@ func preparePersistenceRoot(path string) (string, error) {
 		return "", fmt.Errorf("create sessions root: %w", err)
 	}
 	return absRoot, nil
+}
+
+func refuseRealPersistenceRootUnderGoTest(absRoot string) error {
+	if os.Getenv("BUILDER_ALLOW_REAL_PERSISTENCE_ROOT_IN_TESTS") == "1" {
+		return nil
+	}
+	if !strings.HasSuffix(filepath.Base(os.Args[0]), ".test") {
+		return nil
+	}
+	home := strings.TrimSpace(processStartHome)
+	if home == "" {
+		return nil
+	}
+	realRoot, err := filepath.Abs(filepath.Join(home, ".builder"))
+	if err != nil {
+		return fmt.Errorf("resolve process-start persistence root: %w", err)
+	}
+	if filepath.Clean(absRoot) != filepath.Clean(realRoot) {
+		return nil
+	}
+	return fmt.Errorf("refusing to use process-start persistence root %s from a Go test binary; tests must provide an isolated config root before calling Load", absRoot)
 }
 
 func prepareWorktreeBaseDir(persistenceRoot string, path string) (string, error) {

--- a/shared/config/config_paths.go
+++ b/shared/config/config_paths.go
@@ -6,6 +6,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"testing"
 )
 
 var processStartHome = os.Getenv("HOME")
@@ -76,7 +77,7 @@ func refuseRealPersistenceRootUnderGoTest(absRoot string) error {
 	if os.Getenv("BUILDER_ALLOW_REAL_PERSISTENCE_ROOT_IN_TESTS") == "1" {
 		return nil
 	}
-	if !strings.HasSuffix(filepath.Base(os.Args[0]), ".test") {
+	if !testing.Testing() {
 		return nil
 	}
 	for _, home := range protectedPersistenceRootHomes() {

--- a/shared/config/config_paths.go
+++ b/shared/config/config_paths.go
@@ -3,20 +3,41 @@ package config
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 )
 
 var processStartHome = os.Getenv("HOME")
+var processStartAccountHome = accountHomeDir()
+
+func accountHomeDir() string {
+	current, err := user.Current()
+	if err != nil || current == nil {
+		return ""
+	}
+	return strings.TrimSpace(current.HomeDir)
+}
+
+func currentHomeDir() (string, error) {
+	if home := strings.TrimSpace(os.Getenv("HOME")); home != "" {
+		return home, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return home, nil
+}
 
 func expandTildePath(path string) (string, error) {
 	trimmed := strings.TrimSpace(path)
 	if trimmed == "" || !strings.HasPrefix(trimmed, "~") {
 		return trimmed, nil
 	}
-	home, err := os.UserHomeDir()
+	home, err := currentHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("resolve home dir: %w", err)
+		return "", err
 	}
 	if trimmed == "~" {
 		return home, nil
@@ -58,18 +79,60 @@ func refuseRealPersistenceRootUnderGoTest(absRoot string) error {
 	if !strings.HasSuffix(filepath.Base(os.Args[0]), ".test") {
 		return nil
 	}
-	home := strings.TrimSpace(processStartHome)
-	if home == "" {
-		return nil
+	for _, home := range protectedPersistenceRootHomes() {
+		realRoot, err := filepath.Abs(filepath.Join(home, ".builder"))
+		if err != nil {
+			return fmt.Errorf("resolve protected persistence root: %w", err)
+		}
+		if filepath.Clean(absRoot) == filepath.Clean(realRoot) {
+			return fmt.Errorf("refusing to use protected persistence root %s from a Go test binary; tests must provide an isolated config root before calling Load", absRoot)
+		}
 	}
-	realRoot, err := filepath.Abs(filepath.Join(home, ".builder"))
+	return nil
+}
+
+func protectedPersistenceRootHomes() []string {
+	accountHome := strings.TrimSpace(processStartAccountHome)
+	envHome := strings.TrimSpace(processStartHome)
+	if accountHome == "" {
+		if envHome == "" {
+			return nil
+		}
+		return []string{envHome}
+	}
+	if envHome == "" || filepath.Clean(envHome) == filepath.Clean(accountHome) {
+		return []string{accountHome}
+	}
+	if isPathInsideTempDir(envHome) {
+		return []string{accountHome}
+	}
+	return []string{accountHome, envHome}
+}
+
+func isPathInsideTempDir(path string) bool {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return false
+	}
+	absPath, err := filepath.Abs(trimmed)
 	if err != nil {
-		return fmt.Errorf("resolve process-start persistence root: %w", err)
+		return false
 	}
-	if filepath.Clean(absRoot) != filepath.Clean(realRoot) {
-		return nil
+	absTemp, err := filepath.Abs(os.TempDir())
+	if err != nil {
+		return false
 	}
-	return fmt.Errorf("refusing to use process-start persistence root %s from a Go test binary; tests must provide an isolated config root before calling Load", absRoot)
+	rel, err := filepath.Rel(absTemp, absPath)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
 }
 
 func prepareWorktreeBaseDir(persistenceRoot string, path string) (string, error) {

--- a/shared/config/config_rg.go
+++ b/shared/config/config_rg.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 const managedRGConfigName = "rg.conf"
@@ -36,7 +37,11 @@ func EnsureManagedRGConfigFile() (path string, created bool, err error) {
 }
 
 func writeManagedRGConfigFileForSettingsPath(settingsPath string) (string, error) {
-	path := filepath.Join(filepath.Dir(settingsPath), managedRGConfigName)
+	trimmed := strings.TrimSpace(settingsPath)
+	if trimmed == "" {
+		return "", fmt.Errorf("settings path is required")
+	}
+	path := filepath.Join(filepath.Dir(trimmed), managedRGConfigName)
 	_, err := writeSettingsFileIfMissing(path, managedRGConfigContents)
 	return path, err
 }

--- a/shared/config/config_rg.go
+++ b/shared/config/config_rg.go
@@ -34,3 +34,9 @@ func EnsureManagedRGConfigFile() (path string, created bool, err error) {
 	}
 	return path, created, nil
 }
+
+func writeManagedRGConfigFileForSettingsPath(settingsPath string) (string, error) {
+	path := filepath.Join(filepath.Dir(settingsPath), managedRGConfigName)
+	_, err := writeSettingsFileIfMissing(path, managedRGConfigContents)
+	return path, err
+}

--- a/shared/config/config_settings_file.go
+++ b/shared/config/config_settings_file.go
@@ -25,9 +25,9 @@ func resolveSettingsFilePathInRoot(root string) (string, error) {
 		}
 		return filepath.Join(absRoot, "config.toml"), nil
 	}
-	home, err := os.UserHomeDir()
+	home, err := currentHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("resolve home dir: %w", err)
+		return "", err
 	}
 	return filepath.Join(home, ".builder", "config.toml"), nil
 }

--- a/shared/config/config_settings_file.go
+++ b/shared/config/config_settings_file.go
@@ -13,6 +13,18 @@ import (
 )
 
 func resolveSettingsFilePath() (string, error) {
+	return resolveSettingsFilePathInRoot("")
+}
+
+func resolveSettingsFilePathInRoot(root string) (string, error) {
+	trimmed := strings.TrimSpace(root)
+	if trimmed != "" {
+		absRoot, err := filepath.Abs(trimmed)
+		if err != nil {
+			return "", fmt.Errorf("resolve settings root: %w", err)
+		}
+		return filepath.Join(absRoot, "config.toml"), nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve home dir: %w", err)

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -13,6 +13,20 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestPreparePersistenceRootRefusesProcessStartRootUnderGoTest(t *testing.T) {
+	originalHome := processStartHome
+	processStartHome = filepath.Join(string(filepath.Separator), "builder-test-home")
+	t.Cleanup(func() { processStartHome = originalHome })
+
+	_, err := preparePersistenceRoot(filepath.Join(processStartHome, ".builder"))
+	if err == nil {
+		t.Fatal("expected process-start persistence root to be refused under go test")
+	}
+	if !strings.Contains(err.Error(), "refusing to use process-start persistence root") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLoadUsesDefaultsWithoutCreatingConfigOnFirstUse(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
@@ -132,6 +146,25 @@ func TestLoadUsesDefaultsWithoutCreatingConfigOnFirstUse(t *testing.T) {
 	}
 	if cfg.Settings.Reviewer.VerboseOutput {
 		t.Fatalf("expected default reviewer verbose_output=false")
+	}
+}
+
+func TestLoadUsesExplicitConfigRootWithoutHomeMutation(t *testing.T) {
+	configRoot := t.TempDir()
+	workspace := t.TempDir()
+
+	cfg, err := Load(workspace, LoadOptions{ConfigRoot: configRoot})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Source.HomeSettingsPath != filepath.Join(configRoot, "config.toml") {
+		t.Fatalf("home settings path = %q, want explicit config root", cfg.Source.HomeSettingsPath)
+	}
+	if cfg.PersistenceRoot != configRoot {
+		t.Fatalf("persistence root = %q, want explicit config root", cfg.PersistenceRoot)
+	}
+	if _, err := os.Stat(filepath.Join(configRoot, managedRGConfigName)); err != nil {
+		t.Fatalf("expected managed rg config in explicit config root: %v", err)
 	}
 }
 

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -15,15 +15,35 @@ func TestMain(m *testing.M) {
 
 func TestPreparePersistenceRootRefusesProcessStartRootUnderGoTest(t *testing.T) {
 	originalHome := processStartHome
+	originalAccountHome := processStartAccountHome
 	processStartHome = filepath.Join(string(filepath.Separator), "builder-test-home")
-	t.Cleanup(func() { processStartHome = originalHome })
+	processStartAccountHome = ""
+	t.Cleanup(func() {
+		processStartHome = originalHome
+		processStartAccountHome = originalAccountHome
+	})
 
 	_, err := preparePersistenceRoot(filepath.Join(processStartHome, ".builder"))
 	if err == nil {
 		t.Fatal("expected process-start persistence root to be refused under go test")
 	}
-	if !strings.Contains(err.Error(), "refusing to use process-start persistence root") {
+	if !strings.Contains(err.Error(), "refusing to use protected persistence root") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPreparePersistenceRootAllowsIsolatedTempHomeUnderGoTest(t *testing.T) {
+	originalHome := processStartHome
+	originalAccountHome := processStartAccountHome
+	processStartHome = t.TempDir()
+	processStartAccountHome = filepath.Join(string(filepath.Separator), "builder-real-home")
+	t.Cleanup(func() {
+		processStartHome = originalHome
+		processStartAccountHome = originalAccountHome
+	})
+
+	if _, err := preparePersistenceRoot(filepath.Join(processStartHome, ".builder")); err != nil {
+		t.Fatalf("prepare temp persistence root: %v", err)
 	}
 }
 
@@ -165,6 +185,23 @@ func TestLoadUsesExplicitConfigRootWithoutHomeMutation(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(configRoot, managedRGConfigName)); err != nil {
 		t.Fatalf("expected managed rg config in explicit config root: %v", err)
+	}
+}
+
+func TestLoadHonorsHOMEEnvironmentForDefaultConfigRoot(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg, err := Load(workspace, LoadOptions{})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.PersistenceRoot != filepath.Join(home, ".builder") {
+		t.Fatalf("persistence root = %q, want HOME-scoped root", cfg.PersistenceRoot)
+	}
+	if cfg.Source.HomeSettingsPath != filepath.Join(home, ".builder", "config.toml") {
+		t.Fatalf("home settings path = %q, want HOME-scoped config", cfg.Source.HomeSettingsPath)
 	}
 }
 

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -188,6 +188,32 @@ func TestLoadUsesExplicitConfigRootWithoutHomeMutation(t *testing.T) {
 	}
 }
 
+func TestLoadExplicitConfigRootOverridesNestedPersistenceRoot(t *testing.T) {
+	configRoot := t.TempDir()
+	otherRoot := t.TempDir()
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(configRoot, "config.toml"), []byte("persistence_root = \""+filepath.ToSlash(otherRoot)+"\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(workspace, LoadOptions{ConfigRoot: configRoot})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.PersistenceRoot != configRoot {
+		t.Fatalf("persistence root = %q, want explicit config root %q", cfg.PersistenceRoot, configRoot)
+	}
+	if got := cfg.Source.Sources["persistence_root"]; got != "config_root" {
+		t.Fatalf("persistence_root source = %q, want config_root", got)
+	}
+}
+
+func TestWriteManagedRGConfigFileForSettingsPathRejectsEmptyPath(t *testing.T) {
+	if _, err := writeManagedRGConfigFileForSettingsPath(" \t "); err == nil {
+		t.Fatal("expected empty settings path error")
+	}
+}
+
 func TestLoadHonorsHOMEEnvironmentForDefaultConfigRoot(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()

--- a/shared/testgit/env.go
+++ b/shared/testgit/env.go
@@ -1,0 +1,31 @@
+package testgit
+
+import "strings"
+
+func SanitizeEnv(base []string) []string {
+	filtered := make([]string, 0, len(base))
+	for _, entry := range base {
+		key := entry
+		if idx := strings.IndexByte(entry, '='); idx >= 0 {
+			key = entry[:idx]
+		}
+		switch key {
+		case "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_COMMON_DIR", "GIT_CONFIG", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_DIR", "GIT_GLOB_PATHSPECS", "GIT_GRAFT_FILE", "GIT_ICASE_PATHSPECS", "GIT_IMPLICIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_INTERNAL_SUPER_PREFIX", "GIT_LITERAL_PATHSPECS", "GIT_NAMESPACE", "GIT_NOGLOB_PATHSPECS", "GIT_NO_REPLACE_OBJECTS", "GIT_OBJECT_DIRECTORY", "GIT_PREFIX", "GIT_REPLACE_REF_BASE", "GIT_SHALLOW_FILE", "GIT_WORK_TREE":
+			continue
+		}
+		if strings.HasPrefix(key, "GIT_CONFIG_KEY_") || strings.HasPrefix(key, "GIT_CONFIG_VALUE_") || strings.HasPrefix(key, "GIT_AUTHOR_") || strings.HasPrefix(key, "GIT_COMMITTER_") {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func AppendCommitIdentityEnv(env []string) []string {
+	return append(env,
+		"GIT_AUTHOR_NAME=builder-test",
+		"GIT_AUTHOR_EMAIL=builder-test@example.invalid",
+		"GIT_COMMITTER_NAME=builder-test",
+		"GIT_COMMITTER_EMAIL=builder-test@example.invalid",
+	)
+}

--- a/shared/testgit/env_test.go
+++ b/shared/testgit/env_test.go
@@ -1,0 +1,45 @@
+package testgit
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeEnvRemovesParentGitIdentityBeforeAppendingTestIdentity(t *testing.T) {
+	env := AppendCommitIdentityEnv(SanitizeEnv([]string{
+		"PATH=/bin",
+		"GIT_AUTHOR_NAME=parent-author",
+		"GIT_AUTHOR_EMAIL=parent-author@example.test",
+		"GIT_COMMITTER_NAME=parent-committer",
+		"GIT_COMMITTER_EMAIL=parent-committer@example.test",
+		"GIT_CONFIG_KEY_0=user.name",
+		"GIT_CONFIG_VALUE_0=parent",
+		"GIT_DIR=/repo/.git",
+	}))
+
+	values := map[string][]string{}
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		values[key] = append(values[key], value)
+	}
+	for _, key := range []string{"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL"} {
+		if got := len(values[key]); got != 1 {
+			t.Fatalf("%s count = %d, want 1 in env %v", key, got, env)
+		}
+	}
+	if values["GIT_AUTHOR_NAME"][0] != "builder-test" || values["GIT_COMMITTER_NAME"][0] != "builder-test" {
+		t.Fatalf("unexpected git identity env: %v", values)
+	}
+	if _, ok := values["GIT_CONFIG_KEY_0"]; ok {
+		t.Fatalf("GIT_CONFIG_KEY_0 survived sanitization: %v", env)
+	}
+	if _, ok := values["GIT_DIR"]; ok {
+		t.Fatalf("GIT_DIR survived sanitization: %v", env)
+	}
+	if values["PATH"][0] != "/bin" {
+		t.Fatalf("PATH = %v, want /bin", values["PATH"])
+	}
+}


### PR DESCRIPTION
## Summary
- prevent Go tests from using real Builder persistence roots while still allowing isolated temp homes
- replace unsafe fake env auth in affected tests with in-memory auth/config roots
- reduce suite runtime by removing retry/debounce sleeps and deterministic slow stream-gap/process tests
- add regression coverage for reserved-port listener drain cleanup

## Verification
- /usr/bin/time -p ./scripts/test.sh -count=1 ./... -> pass, real 19.14
- ./scripts/build.sh --output ./bin/builder -> pass
- coverage stayed 68.5% baseline/final before rebase
- sensitive global files unchanged during verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "config root" option for loading settings.

* **Tests**
  * Improved test environment isolation and auth test helpers to avoid relying on real API keys or real home dirs.
  * Faster, more deterministic test timing and resubscribe behavior to reduce flakiness.
  * Added tests for persistence-root protection under test runs.

* **Chores**
  * Use environment-driven Git identity in tests and added listener cleanup to avoid connection buildup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->