### PR TITLE
feat: add edit tool

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -53,7 +53,7 @@ func effectiveSettings(base config.Settings, locked *session.LockedContract) con
 	return launch.EffectiveSettings(base, locked)
 }
 
-func activeToolIDs(settings config.Settings, source config.SourceReport, locked *session.LockedContract) []toolspec.ID {
+func activeToolIDs(settings config.Settings, source config.SourceReport, locked *session.LockedContract) ([]toolspec.ID, error) {
 	return launch.ActiveToolIDs(settings, source, locked)
 }
 

--- a/cli/app/app_test.go
+++ b/cli/app/app_test.go
@@ -20,7 +20,10 @@ func TestEffectiveSettingsKeepsBaseThinkingLevelEvenWhenSessionIsLocked(t *testi
 
 func TestActiveToolIDs_UsesLockedEnabledToolsVerbatim(t *testing.T) {
 	locked := &session.LockedContract{EnabledTools: []string{string(toolspec.ToolExecCommand)}}
-	ids := activeToolIDs(config.Settings{Model: "gpt-5.4"}, config.SourceReport{}, locked)
+	ids, err := activeToolIDs(config.Settings{Model: "gpt-5.4"}, config.SourceReport{}, locked)
+	if err != nil {
+		t.Fatalf("activeToolIDs: %v", err)
+	}
 	if !containsToolID(ids, toolspec.ToolExecCommand) || len(ids) != 1 {
 		t.Fatalf("expected locked enabled tools to be used verbatim, got %+v", ids)
 	}

--- a/cli/app/launch_planner.go
+++ b/cli/app/launch_planner.go
@@ -161,7 +161,7 @@ func (p *launchPlanner) PlanSession(ctx context.Context, req sessionLaunchReques
 		WorkspaceRoot: resp.Plan.WorkspaceRoot,
 		Source:        resp.Plan.Source,
 	}
-	return applyCLIOverridesToSessionPlan(plan, cfg), nil
+	return applyCLIOverridesToSessionPlan(plan, cfg)
 }
 
 func loadSelectedSessionWorkspaceRoot(ctx context.Context, sessionViews sessionViewReader, sessionID string) (string, error) {
@@ -269,7 +269,7 @@ func (p *launchPlanner) resolveHasOtherSessions(ctx context.Context, resolved re
 	return false, true
 }
 
-func applyCLIOverridesToSessionPlan(plan sessionLaunchPlan, cfg config.App) sessionLaunchPlan {
+func applyCLIOverridesToSessionPlan(plan sessionLaunchPlan, cfg config.App) (sessionLaunchPlan, error) {
 	sources := cfg.Source.Sources
 	mergedSource := mergeCLISources(plan.Source, cfg.Source)
 	if sourceIsCLI(sources, "model") && !plan.ModelContractLocked {
@@ -296,13 +296,17 @@ func applyCLIOverridesToSessionPlan(plan sessionLaunchPlan, cfg config.App) sess
 			plan.ActiveSettings.EnabledTools = cloneEnabledToolSet(cfg.Settings.EnabledTools)
 		}
 		if hasCLIToolOverride(cfg.Source) || sourceIsCLI(sources, "model") {
-			plan.EnabledTools = dedupeSortToolIDs(activeToolIDs(plan.ActiveSettings, mergedSource, nil))
+			enabledTools, err := activeToolIDs(plan.ActiveSettings, mergedSource, nil)
+			if err != nil {
+				return sessionLaunchPlan{}, err
+			}
+			plan.EnabledTools = dedupeSortToolIDs(enabledTools)
 		}
 	}
 	plan.Source = mergedSource
 	plan.StatusConfig.Settings = plan.ActiveSettings
 	plan.StatusConfig.Source = plan.Source
-	return plan
+	return plan, nil
 }
 
 func sourceIsCLI(sources map[string]string, key string) bool {

--- a/cli/app/launch_planner_test.go
+++ b/cli/app/launch_planner_test.go
@@ -429,7 +429,10 @@ func TestApplyCLIOverridesToSessionPlanIgnoresNonCLISources(t *testing.T) {
 		"timeouts.model_request_seconds": "env",
 	}}}
 
-	updated := applyCLIOverridesToSessionPlan(plan, cfg)
+	updated, err := applyCLIOverridesToSessionPlan(plan, cfg)
+	if err != nil {
+		t.Fatalf("applyCLIOverridesToSessionPlan: %v", err)
+	}
 	if updated.ActiveSettings.Model != "server-model" || updated.ConfiguredModelName != "server-model" {
 		t.Fatalf("expected server model preserved, got %+v", updated.ActiveSettings)
 	}
@@ -468,7 +471,10 @@ func TestApplyCLIOverridesToSessionPlanRespectsLockedModelContract(t *testing.T)
 		"tools.patch": "cli",
 	}}}
 
-	updated := applyCLIOverridesToSessionPlan(plan, cfg)
+	updated, err := applyCLIOverridesToSessionPlan(plan, cfg)
+	if err != nil {
+		t.Fatalf("applyCLIOverridesToSessionPlan: %v", err)
+	}
 	if updated.ActiveSettings.Model != "locked-model" || updated.ConfiguredModelName != "locked-model" {
 		t.Fatalf("expected locked model preserved, got %+v", updated.ActiveSettings)
 	}
@@ -497,7 +503,10 @@ func TestApplyCLIOverridesToSessionPlanAppliesCLIToolOverrideWithoutModelOverrid
 		"tools.patch": "cli",
 	}}}
 
-	updated := applyCLIOverridesToSessionPlan(plan, cfg)
+	updated, err := applyCLIOverridesToSessionPlan(plan, cfg)
+	if err != nil {
+		t.Fatalf("applyCLIOverridesToSessionPlan: %v", err)
+	}
 	if updated.ActiveSettings.EnabledTools[toolspec.ToolExecCommand] {
 		t.Fatalf("expected shell disabled by cli override, got %+v", updated.ActiveSettings.EnabledTools)
 	}
@@ -531,7 +540,10 @@ func TestApplyCLIOverridesToSessionPlanRecomputesEnabledToolsForCLIModelOverride
 		"tools.shell": "default",
 	}}}
 
-	updated := applyCLIOverridesToSessionPlan(plan, cfg)
+	updated, err := applyCLIOverridesToSessionPlan(plan, cfg)
+	if err != nil {
+		t.Fatalf("applyCLIOverridesToSessionPlan: %v", err)
+	}
 	if updated.ActiveSettings.Model != "gpt-5.3-codex" {
 		t.Fatalf("expected cli model override, got %q", updated.ActiveSettings.Model)
 	}
@@ -559,11 +571,42 @@ func TestApplyCLIOverridesToSessionPlanKeepsExplicitCLIToolsWhenModelAlsoOverrid
 		"tools.shell": "cli",
 	}}}
 
-	updated := applyCLIOverridesToSessionPlan(plan, cfg)
+	updated, err := applyCLIOverridesToSessionPlan(plan, cfg)
+	if err != nil {
+		t.Fatalf("applyCLIOverridesToSessionPlan: %v", err)
+	}
 	if updated.ActiveSettings.Model != "gpt-5.3-codex" {
 		t.Fatalf("expected cli model override, got %q", updated.ActiveSettings.Model)
 	}
 	if len(updated.EnabledTools) != 1 || updated.EnabledTools[0] != toolspec.ToolExecCommand {
 		t.Fatalf("expected explicit cli tools to suppress model defaults, got %+v", updated.EnabledTools)
+	}
+}
+
+func TestApplyCLIOverridesToSessionPlanPropagatesToolSelectionConflict(t *testing.T) {
+	plan := sessionLaunchPlan{
+		ActiveSettings: config.Settings{
+			Model:        "claude-sonnet-4.5",
+			EnabledTools: map[toolspec.ID]bool{toolspec.ToolExecCommand: true},
+		},
+		EnabledTools:        []toolspec.ID{toolspec.ToolExecCommand},
+		ConfiguredModelName: "claude-sonnet-4.5",
+		Source:              config.SourceReport{Sources: map[string]string{"model": "file", "tools.patch": "default", "tools.edit": "default"}},
+		StatusConfig:        uiStatusConfig{},
+	}
+	cfg := config.App{Settings: config.Settings{
+		Model: "claude-sonnet-4.5",
+		EnabledTools: map[toolspec.ID]bool{
+			toolspec.ToolPatch: true,
+			toolspec.ToolEdit:  true,
+		},
+	}, Source: config.SourceReport{Sources: map[string]string{
+		"tools.patch": "cli",
+		"tools.edit":  "cli",
+	}}}
+
+	_, err := applyCLIOverridesToSessionPlan(plan, cfg)
+	if err == nil || !strings.Contains(err.Error(), "tools.patch and tools.edit cannot both be enabled") {
+		t.Fatalf("error = %v, want tool conflict", err)
 	}
 }

--- a/cli/tui/model_rendering.go
+++ b/cli/tui/model_rendering.go
@@ -198,7 +198,14 @@ func (m Model) toolCallBlock(entryIndex int, entry TranscriptEntry, consumed map
 	if resultIdx >= 0 {
 		entryEnd = resultIdx
 	}
-	lines := m.flattenEntryWithMeta(blockRole, combined, opts.mode == transcriptBlockModeOngoing, entry.ToolCall)
+	effectiveMeta := entry.ToolCall
+	if resultIdx >= 0 && m.transcript[resultIdx].ToolCall != nil {
+		effectiveMeta = m.transcript[resultIdx].ToolCall
+		if isPatchToolCall(effectiveMeta) {
+			blockRole = toolBlockRoleFromResult(roleFromEntry(m.transcript[resultIdx]), RenderIntentToolPatch)
+		}
+	}
+	lines := m.flattenEntryWithMeta(blockRole, combined, opts.mode == transcriptBlockModeOngoing, effectiveMeta)
 	if opts.mode == transcriptBlockModeOngoing {
 		lines = m.ongoingToolWithTreeGuideWithSymbol(blockRole, lines, "")
 	}
@@ -228,6 +235,9 @@ func (m Model) detailToolCallSpec(entryIndex int, entry TranscriptEntry, consume
 	resultSummary := ""
 	if resultIdx := resultIndex.findMatchingToolResultIndex(m.transcript, entryIndex, consumed); resultIdx >= 0 {
 		resultEntry := m.transcript[resultIdx]
+		if resultEntry.ToolCall != nil {
+			combined = toolCallDisplayText(resultEntry.ToolCall, combined)
+		}
 		resultRole := roleFromEntry(resultEntry)
 		resultSummary = strings.TrimSpace(resultEntry.ToolResultSummary)
 		omitSuccessfulResult := entry.ToolCall != nil && entry.ToolCall.OmitSuccessfulResult && resultRole != TranscriptRoleToolResultError
@@ -244,6 +254,12 @@ func (m Model) detailToolCallSpec(entryIndex int, entry TranscriptEntry, consume
 	absoluteIndex := m.absoluteTranscriptIndex(entryIndex)
 	absoluteEnd := m.absoluteTranscriptIndex(entryEnd)
 	meta := cloneToolCallMeta(entry.ToolCall)
+	if entryEnd != entryIndex && m.transcript[entryEnd].ToolCall != nil {
+		meta = cloneToolCallMeta(m.transcript[entryEnd].ToolCall)
+		if isPatchToolCall(meta) {
+			blockRole = toolBlockRoleFromResult(roleFromEntry(m.transcript[entryEnd]), RenderIntentToolPatch)
+		}
+	}
 	return detailBlockSpec{
 		role:       blockRole,
 		entryIndex: absoluteIndex,

--- a/cli/tui/model_rendering.go
+++ b/cli/tui/model_rendering.go
@@ -201,6 +201,7 @@ func (m Model) toolCallBlock(entryIndex int, entry TranscriptEntry, consumed map
 	effectiveMeta := entry.ToolCall
 	if resultIdx >= 0 && m.transcript[resultIdx].ToolCall != nil {
 		effectiveMeta = m.transcript[resultIdx].ToolCall
+		combined = compactToolCallText(effectiveMeta, combined)
 		if isPatchToolCall(effectiveMeta) {
 			blockRole = toolBlockRoleFromResult(roleFromEntry(m.transcript[resultIdx]), RenderIntentToolPatch)
 		}

--- a/cli/tui/model_rendering_tools.go
+++ b/cli/tui/model_rendering_tools.go
@@ -259,7 +259,15 @@ func isShellToolCall(meta *transcript.ToolCallMeta, text string) bool {
 }
 
 func isPatchToolCall(meta *transcript.ToolCallMeta) bool {
-	return meta != nil && (meta.HasPatchDetail() || strings.TrimSpace(meta.ToolName) == "patch")
+	if meta == nil {
+		return false
+	}
+	switch strings.TrimSpace(meta.ToolName) {
+	case "patch", "edit":
+		return true
+	default:
+		return meta.HasPatchDetail()
+	}
 }
 
 func isPatchToolBlock(role RenderIntent, meta *transcript.ToolCallMeta) bool {

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -808,6 +808,39 @@ func TestOngoingEditResultUsesPatchSummaryHeadline(t *testing.T) {
 	}
 }
 
+func TestDetailEditResultUsesPatchSummaryHeadline(t *testing.T) {
+	m := NewModel(WithPreviewLines(20))
+	m = updateModel(t, m, AppendTranscriptMsg{
+		Role:       "tool_call",
+		Text:       "edit server/runtime/compaction.go",
+		ToolCallID: "call_edit",
+		ToolCall: &transcript.ToolCallMeta{
+			ToolName:    "edit",
+			Command:     "server/runtime/compaction.go",
+			CompactText: "server/runtime/compaction.go",
+		},
+	})
+	m = updateModel(t, m, AppendTranscriptMsg{
+		Role:       "tool_result_ok",
+		ToolCallID: "call_edit",
+		ToolCall: &transcript.ToolCallMeta{
+			ToolName:     "edit",
+			Command:      "server/runtime/compaction.go +2 -1",
+			CompactText:  "server/runtime/compaction.go +2 -1",
+			PatchSummary: "server/runtime/compaction.go +2 -1",
+		},
+	})
+	m = updateModel(t, m, ToggleModeMsg{})
+
+	plain := plainTranscript(m.View())
+	if !strings.Contains(plain, "⇄ server/runtime/compaction.go +2 -1") {
+		t.Fatalf("expected detail edit result to use patch summary headline, got %q", plain)
+	}
+	if strings.Contains(plain, "⇄ edit server/runtime/compaction.go") {
+		t.Fatalf("expected detail edit headline to omit tool name, got %q", plain)
+	}
+}
+
 func TestOngoingWrappedToolBlocksRenderTreeGuides(t *testing.T) {
 	m := NewModel(WithPreviewLines(20))
 	m = updateModel(t, m, SetViewportSizeMsg{Lines: 20, Width: 34})

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -776,6 +776,38 @@ func TestOngoingMultilineToolBlocksRenderTreeGuides(t *testing.T) {
 	}
 }
 
+func TestOngoingEditResultUsesPatchSummaryHeadline(t *testing.T) {
+	m := NewModel(WithPreviewLines(20))
+	m = updateModel(t, m, AppendTranscriptMsg{
+		Role:       "tool_call",
+		Text:       "edit server/runtime/compaction.go",
+		ToolCallID: "call_edit",
+		ToolCall: &transcript.ToolCallMeta{
+			ToolName:    "edit",
+			Command:     "server/runtime/compaction.go",
+			CompactText: "server/runtime/compaction.go",
+		},
+	})
+	m = updateModel(t, m, AppendTranscriptMsg{
+		Role:       "tool_result_ok",
+		ToolCallID: "call_edit",
+		ToolCall: &transcript.ToolCallMeta{
+			ToolName:     "edit",
+			Command:      "server/runtime/compaction.go +2 -1",
+			CompactText:  "server/runtime/compaction.go +2 -1",
+			PatchSummary: "server/runtime/compaction.go +2 -1",
+		},
+	})
+
+	plain := plainTranscript(m.View())
+	if !strings.Contains(plain, "⇄ server/runtime/compaction.go +2 -1") {
+		t.Fatalf("expected edit result to use patch summary headline, got %q", plain)
+	}
+	if strings.Contains(plain, "⇄ edit server/runtime/compaction.go") {
+		t.Fatalf("expected edit headline to omit tool name, got %q", plain)
+	}
+}
+
 func TestOngoingWrappedToolBlocksRenderTreeGuides(t *testing.T) {
 	m := NewModel(WithPreviewLines(20))
 	m = updateModel(t, m, SetViewportSizeMsg{Lines: 20, Width: 34})

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -61,7 +61,9 @@ model_request_seconds = 400
 
 [tools]
 shell = true
-patch = true
+# Leave both patch/edit commented to use Builder's model-based default.
+# patch = true
+# edit = false
 view_image = true
 web_search = true
 trigger_handoff = true # proactive compaction by the model
@@ -121,7 +123,7 @@ verbose_output = false # show in ongoing transcript
 | `provider_override` | string | `""` | `BUILDER_PROVIDER_OVERRIDE` | `builder run --provider-override` | Forces provider family for custom or alias model names. Allowed: `openai`, `anthropic`. Requires an explicit `model` override. |
 | `openai_base_url` | string | `""` | `BUILDER_OPENAI_BASE_URL` | `builder run --openai-base-url` | OpenAI-compatible base URL. Must be used with `provider_override=openai` or with no explicit provider override. Cannot be changed mid-session. |
 | `store` | bool | `false` | `BUILDER_STORE` |  | Sets OpenAI Responses `store=true` for main model requests. |
-| `allow_non_cwd_edits` | bool | `false` | `BUILDER_ALLOW_NON_CWD_EDITS` |  | Lets the `patch` tool edit files outside the workspace root. This is not sandboxing - model can still bypass this easily. |
+| `allow_non_cwd_edits` | bool | `false` | `BUILDER_ALLOW_NON_CWD_EDITS` |  | Lets first-class file edit tools edit files outside the workspace root. This is not sandboxing - model can still bypass this easily. |
 | `model_context_window` | int | `272000` | `BUILDER_MODEL_CONTEXT_WINDOW` |  | Explicit context-window size used for compaction and token accounting. Must be `> 0`. |
 | `context_compaction_threshold_tokens` | int | `258400` | `BUILDER_CONTEXT_COMPACTION_THRESHOLD_TOKENS` |  | Auto-compaction threshold. Must be `> 0`, `< model_context_window`, and at least `50%` of `model_context_window`. The default is derived from the default context window. |
 | `pre_submit_compaction_lead_tokens` | int | `35000` | `BUILDER_PRE_SUBMIT_COMPACTION_LEAD_TOKENS` |  | Fixed pre-submit runway reserve before auto-compaction. Builder compacts before sending the next user prompt once (`context_compaction_threshold_tokens` - this threshold) is reached. |
@@ -146,7 +148,7 @@ Configure the supervisor agent that oversees model changes.
 
 | Key | Type | Default | Env | Description |
 | --- | --- | --- | --- | --- |
-| `reviewer.frequency` | string | `edits` | `BUILDER_REVIEWER_FREQUENCY` | Allowed: `off`, `all`, `edits`. `all` runs the reviewer after every completed assistant turn. `edits` runs it only after successful `patch` edits. |
+| `reviewer.frequency` | string | `edits` | `BUILDER_REVIEWER_FREQUENCY` | Allowed: `off`, `all`, `edits`. `all` runs the reviewer after every completed assistant turn. `edits` runs it only after successful first-class file edits. |
 | `reviewer.model` | string | inherits `model` | `BUILDER_REVIEWER_MODEL` | Separate model for the reviewer pass. If unset, Builder uses main `model`. |
 | `reviewer.thinking_level` | string | inherits `thinking_level` | `BUILDER_REVIEWER_THINKING_LEVEL` | Allowed: `low`, `medium`, `high`, `xhigh`. |
 | `reviewer.system_prompt_file` | string | `""` |  | Path to a custom supervisor system prompt file. Relative paths resolve from the config file directory. Workspace config overrides global config; no CLI or environment override is provided. |
@@ -188,7 +190,8 @@ File-based tool toggles merge with defaults. `BUILDER_TOOLS` and `builder run --
 | --- | --- | --- |
 | `tools.ask_question` | `true` | Tool to ask interactive questions |
 | `tools.shell` | `true` | The primary shell tool. Internally this maps to `exec_command`. |
-| `tools.patch` | `true` | The edit tool |
+| `tools.patch` | dynamic | Freeform patch grammar edit tool |
+| `tools.edit` | dynamic | JSON text replacement/create/delete edit tool |
 | `tools.trigger_handoff` | `false` | Experimental tool the agents can use to proactively compact their own context. |
 | `tools.view_image` | `true` | Ability to view images and PDFs (if supported) |
 | `tools.web_search` | `true` | Tool to search the web |
@@ -197,6 +200,8 @@ File-based tool toggles merge with defaults. `BUILDER_TOOLS` and `builder run --
 Notes:
 
 - `tools.web_search = true` does not force web search on. Native search still depends on `web_search = "native"` and provider support.
+- `tools.patch` and `tools.edit` are mutually exclusive. If both are left at their defaults, Builder chooses `patch` for first-party OpenAI providers or `gpt-*` model names, and `edit` otherwise.
+- To force `edit`, set `edit = true` and `patch = false`. To force `patch`, set `patch = true` and `edit = false`.
 
 ### Subagents
 

--- a/prompts/embed.go
+++ b/prompts/embed.go
@@ -13,11 +13,13 @@ import (
 
 type SystemPromptTemplateArgs struct {
 	EstimatedToolCallsForContext int
+	ManualEditInstruction        string
 }
 
 type systemPromptTemplateData struct {
 	BuilderRunCommand            string
 	EstimatedToolCallsForContext int
+	ManualEditInstruction        string
 	DefaultSystemPrompt          string
 }
 
@@ -186,6 +188,7 @@ func renderSystemPromptTemplateErr(text string, args SystemPromptTemplateArgs, d
 	if err := tmpl.Execute(&out, systemPromptTemplateData{
 		BuilderRunCommand:            selfcmd.RunCommandPrefix(),
 		EstimatedToolCallsForContext: args.EstimatedToolCallsForContext,
+		ManualEditInstruction:        strings.TrimSpace(args.ManualEditInstruction),
 		DefaultSystemPrompt:          strings.TrimSpace(defaultSystemPrompt),
 	}); err != nil {
 		return "", fmt.Errorf("render system prompt template: %w", err)

--- a/prompts/embed_test.go
+++ b/prompts/embed_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 func TestRenderSystemPromptTemplateUsesTypedFields(t *testing.T) {
-	rendered := renderSystemPromptTemplate("calls={{.EstimatedToolCallsForContext}} cmd={{.BuilderRunCommand}}", SystemPromptTemplateArgs{
+	rendered := renderSystemPromptTemplate("calls={{.EstimatedToolCallsForContext}} cmd={{.BuilderRunCommand}} edit={{.ManualEditInstruction}}", SystemPromptTemplateArgs{
 		EstimatedToolCallsForContext: 123,
+		ManualEditInstruction:        "Use edit.",
 	}, "")
 	if !strings.Contains(rendered, "calls=123") {
 		t.Fatalf("expected estimated tool calls rendered, got %q", rendered)
@@ -17,6 +18,9 @@ func TestRenderSystemPromptTemplateUsesTypedFields(t *testing.T) {
 	expectedCmd := "cmd=" + selfcmd.RunCommandPrefix()
 	if !strings.Contains(rendered, expectedCmd) || strings.Contains(rendered, "{{") {
 		t.Fatalf("expected %q in rendered output, got %q", expectedCmd, rendered)
+	}
+	if !strings.Contains(rendered, "edit=Use edit.") {
+		t.Fatalf("expected manual edit instruction rendered, got %q", rendered)
 	}
 }
 

--- a/prompts/system_prompt.md
+++ b/prompts/system_prompt.md
@@ -26,7 +26,7 @@ These best practices are here to make your life better; follow them unless the u
 
 - **NEVER** use destructive commands like `git reset --hard` or `git checkout --` unless specifically requested by the user.
 - Default to ASCII when editing or creating files. Only introduce non-ASCII or other Unicode characters when there is a clear justification and the file already uses them.
-- Use `patch` for manual code edits. Do not use cat or any other commands when creating or editing files. Formatting commands or bulk edits don't need to be done with the patch tool.
+- {{.ManualEditInstruction}}
 - Do not use Python to read/write files when a simple shell command or patch would suffice.
 - You may be in a dirty git worktree.
   * Do not revert existing changes you did not make unless explicitly requested, since these changes were made by the user.

--- a/server/launch/edit_tools_test.go
+++ b/server/launch/edit_tools_test.go
@@ -1,0 +1,144 @@
+package launch
+
+import (
+	"strings"
+	"testing"
+
+	"builder/server/auth"
+	"builder/server/session"
+	"builder/shared/config"
+	"builder/shared/serverapi"
+	"builder/shared/toolspec"
+)
+
+func TestActiveToolIDsDynamicDefaultChoosesPatchForGPTModels(t *testing.T) {
+	settings := validLaunchSettings("gpt-5.5")
+	source := defaultToolSources()
+
+	ids, err := ActiveToolIDsForPlan(settings, source, nil)
+	if err != nil {
+		t.Fatalf("ActiveToolIDsForPlan: %v", err)
+	}
+	if !containsTool(ids, toolspec.ToolPatch) || containsTool(ids, toolspec.ToolEdit) {
+		t.Fatalf("enabled tools = %+v, want patch without edit", ids)
+	}
+}
+
+func TestActiveToolIDsDynamicDefaultChoosesEditForNonGPTModels(t *testing.T) {
+	settings := validLaunchSettings("claude-sonnet-4.5")
+	source := defaultToolSources()
+
+	ids, err := ActiveToolIDsForPlan(settings, source, nil)
+	if err != nil {
+		t.Fatalf("ActiveToolIDsForPlan: %v", err)
+	}
+	if containsTool(ids, toolspec.ToolPatch) || !containsTool(ids, toolspec.ToolEdit) {
+		t.Fatalf("enabled tools = %+v, want edit without patch", ids)
+	}
+}
+
+func TestActiveToolIDsRejectsEffectivePatchAndEdit(t *testing.T) {
+	settings := validLaunchSettings("claude-sonnet-4.5")
+	settings.EnabledTools[toolspec.ToolEdit] = true
+	source := defaultToolSources()
+	source.Sources["tools.edit"] = "file"
+
+	_, err := ActiveToolIDsForPlan(settings, source, nil)
+	if err == nil || !strings.Contains(err.Error(), "tools.patch and tools.edit cannot both be enabled") {
+		t.Fatalf("error = %v, want mutual exclusion failure", err)
+	}
+}
+
+func TestActiveToolIDsLockedSessionPreservesPatchAndEdit(t *testing.T) {
+	settings := validLaunchSettings("claude-sonnet-4.5")
+	locked := &session.LockedContract{EnabledTools: []string{"patch", "edit"}}
+
+	ids, err := ActiveToolIDsForPlan(settings, defaultToolSources(), locked)
+	if err != nil {
+		t.Fatalf("ActiveToolIDsForPlan: %v", err)
+	}
+	if !containsTool(ids, toolspec.ToolPatch) || !containsTool(ids, toolspec.ToolEdit) {
+		t.Fatalf("enabled tools = %+v, want locked patch+edit preserved", ids)
+	}
+}
+
+func TestApplyRunPromptOverridesSubagentExplicitEditToolWins(t *testing.T) {
+	store, err := session.Create(t.TempDir(), "workspace-a", t.TempDir())
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	settings := validLaunchSettings("gpt-5.5")
+	settings.Subagents = map[string]config.SubagentRole{
+		"worker": {
+			Settings: config.Settings{
+				Model: "gpt-5.5",
+				EnabledTools: map[toolspec.ID]bool{
+					toolspec.ToolPatch: false,
+					toolspec.ToolEdit:  true,
+				},
+			},
+			Sources: map[string]string{
+				"tools.patch": "file",
+				"tools.edit":  "file",
+			},
+		},
+	}
+	plan := SessionPlan{
+		Store:          store,
+		ActiveSettings: settings,
+		EnabledTools:   []toolspec.ID{toolspec.ToolPatch},
+		Source:         defaultToolSources(),
+	}
+
+	updated, _, err := ApplyRunPromptOverrides(plan, serverapi.RunPromptOverrides{AgentRole: "worker"}, auth.EmptyState())
+	if err != nil {
+		t.Fatalf("ApplyRunPromptOverrides: %v", err)
+	}
+	if containsTool(updated.EnabledTools, toolspec.ToolPatch) || !containsTool(updated.EnabledTools, toolspec.ToolEdit) {
+		t.Fatalf("enabled tools = %+v, want explicit subagent edit without patch", updated.EnabledTools)
+	}
+}
+
+func defaultToolSources() config.SourceReport {
+	sources := map[string]string{}
+	for _, id := range toolspec.CatalogIDs() {
+		sources["tools."+toolspec.ConfigName(id)] = "default"
+	}
+	return config.SourceReport{Sources: sources}
+}
+
+func validLaunchSettings(model string) config.Settings {
+	return config.Settings{
+		Model:                            model,
+		ThinkingLevel:                    "medium",
+		NotificationMethod:               "auto",
+		Theme:                            "auto",
+		WebSearch:                        "native",
+		ServerHost:                       "127.0.0.1",
+		ServerPort:                       53082,
+		Reviewer:                         config.ReviewerSettings{Frequency: "edits", Model: model, ThinkingLevel: "medium", TimeoutSeconds: 60},
+		Timeouts:                         config.Timeouts{ModelRequestSeconds: 400},
+		ShellOutputMaxChars:              16000,
+		MinimumExecToBgSeconds:           15,
+		CompactionMode:                   "local",
+		BGShellsOutput:                   "default",
+		Shell:                            config.ShellSettings{PostprocessingMode: "builtin"},
+		CacheWarningMode:                 "default",
+		ModelContextWindow:               272000,
+		ContextCompactionThresholdTokens: 258400,
+		PreSubmitCompactionLeadTokens:    35000,
+		EnabledTools: map[toolspec.ID]bool{
+			toolspec.ToolPatch: true,
+			toolspec.ToolEdit:  false,
+		},
+	}
+}
+
+func containsTool(ids []toolspec.ID, target toolspec.ID) bool {
+	for _, id := range ids {
+		if id == target {
+			return true
+		}
+	}
+	return false
+}

--- a/server/launch/edit_tools_test.go
+++ b/server/launch/edit_tools_test.go
@@ -99,6 +99,48 @@ func TestApplyRunPromptOverridesSubagentExplicitEditToolWins(t *testing.T) {
 	}
 }
 
+func TestApplyRunPromptOverridesSubagentToolSourceSurvivesModelOverride(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, err := session.Create(t.TempDir(), "workspace-a", t.TempDir())
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	settings := validLaunchSettings("gpt-5.5")
+	settings.Subagents = map[string]config.SubagentRole{
+		"worker": {
+			Settings: config.Settings{
+				Model: "gpt-5.5",
+				EnabledTools: map[toolspec.ID]bool{
+					toolspec.ToolPatch: false,
+					toolspec.ToolEdit:  true,
+				},
+			},
+			Sources: map[string]string{
+				"tools.patch": "file",
+				"tools.edit":  "file",
+			},
+		},
+	}
+	plan := SessionPlan{
+		Store:          store,
+		ActiveSettings: settings,
+		EnabledTools:   []toolspec.ID{toolspec.ToolPatch},
+		WorkspaceRoot:  t.TempDir(),
+		Source:         defaultToolSources(),
+	}
+
+	updated, _, err := ApplyRunPromptOverrides(plan, serverapi.RunPromptOverrides{AgentRole: "worker", Model: "gpt-5.5"}, auth.EmptyState())
+	if err != nil {
+		t.Fatalf("ApplyRunPromptOverrides: %v", err)
+	}
+	if containsTool(updated.EnabledTools, toolspec.ToolPatch) || !containsTool(updated.EnabledTools, toolspec.ToolEdit) {
+		t.Fatalf("enabled tools = %+v, want explicit subagent edit preserved across model override", updated.EnabledTools)
+	}
+	if updated.Source.Sources["tools.edit"] != "subagent" || updated.Source.Sources["tools.patch"] != "subagent" {
+		t.Fatalf("tool sources = %+v, want subagent markers preserved", updated.Source.Sources)
+	}
+}
+
 func defaultToolSources() config.SourceReport {
 	sources := map[string]string{}
 	for _, id := range toolspec.CatalogIDs() {

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -107,10 +107,14 @@ func (p Planner) PlanSession(ctx context.Context, req SessionRequest) (SessionPl
 	if err := store.SetContinuationContext(session.ContinuationContext{OpenAIBaseURL: active.OpenAIBaseURL}); err != nil {
 		return SessionPlan{}, err
 	}
+	enabledTools, err := ActiveToolIDsForPlan(active, p.Config.Source, meta.Locked)
+	if err != nil {
+		return SessionPlan{}, err
+	}
 	return SessionPlan{
 		Store:               store,
 		ActiveSettings:      active,
-		EnabledTools:        ActiveToolIDs(active, p.Config.Source, meta.Locked),
+		EnabledTools:        enabledTools,
 		ConfiguredModelName: p.Config.Settings.Model,
 		SessionName:         meta.Name,
 		ModelContractLocked: meta.Locked != nil,
@@ -150,7 +154,13 @@ func ApplyRunPromptOverrides(plan SessionPlan, overrides serverapi.RunPromptOver
 		if !plan.ModelContractLocked {
 			next.ConfiguredModelName = resolved.Model
 		}
-		next.EnabledTools = ActiveToolIDs(next.ActiveSettings, next.Source, plan.Store.Meta().Locked)
+		roleSource := sourceReportWithSubagentRoleSources(next.Source, plan.ActiveSettings, roleName)
+		enabledTools, err := ActiveToolIDsForPlan(next.ActiveSettings, roleSource, plan.Store.Meta().Locked)
+		if err != nil {
+			return SessionPlan{}, nil, err
+		}
+		next.EnabledTools = enabledTools
+		next.Source = roleSource
 		if strings.TrimSpace(warning) != "" {
 			warnings = append(warnings, warning)
 		}
@@ -207,7 +217,11 @@ func ApplyRunPromptOverrides(plan SessionPlan, overrides serverapi.RunPromptOver
 			next.ActiveSettings.EnabledTools = cloneEnabledToolSet(loaded.Settings.EnabledTools)
 		}
 		if strings.TrimSpace(overrides.Tools) != "" || strings.TrimSpace(overrides.Model) != "" {
-			next.EnabledTools = ActiveToolIDs(next.ActiveSettings, mergedSource, locked)
+			enabledTools, err := ActiveToolIDsForPlan(next.ActiveSettings, mergedSource, locked)
+			if err != nil {
+				return SessionPlan{}, nil, err
+			}
+			next.EnabledTools = enabledTools
 		}
 	}
 	if strings.TrimSpace(overrides.OpenAIBaseURL) != "" {
@@ -238,6 +252,23 @@ func mergeOverrideSources(base config.SourceReport, override config.SourceReport
 		}
 	}
 	return merged
+}
+
+func sourceReportWithSubagentRoleSources(base config.SourceReport, settings config.Settings, roleName string) config.SourceReport {
+	normalizedRole := config.NormalizeSubagentRole(roleName)
+	if normalizedRole == "" {
+		return base
+	}
+	role, ok := settings.Subagents[normalizedRole]
+	if !ok || len(role.Sources) == 0 {
+		return base
+	}
+	next := base
+	next.Sources = cloneStringMap(base.Sources)
+	for key := range role.Sources {
+		next.Sources[key] = "subagent"
+	}
+	return next
 }
 
 func (p Planner) openStore(ctx context.Context, req SessionRequest) (*session.Store, error) {
@@ -473,6 +504,11 @@ func EffectiveSettings(base config.Settings, locked *session.LockedContract) con
 }
 
 func ActiveToolIDs(settings config.Settings, source config.SourceReport, locked *session.LockedContract) []toolspec.ID {
+	ids, _ := ActiveToolIDsForPlan(settings, source, locked)
+	return ids
+}
+
+func ActiveToolIDsForPlan(settings config.Settings, source config.SourceReport, locked *session.LockedContract) ([]toolspec.ID, error) {
 	if locked != nil {
 		ids := make([]toolspec.ID, 0, len(locked.EnabledTools))
 		for _, raw := range locked.EnabledTools {
@@ -480,9 +516,43 @@ func ActiveToolIDs(settings config.Settings, source config.SourceReport, locked 
 				ids = append(ids, id)
 			}
 		}
-		return DedupeSortToolIDs(ids)
+		return DedupeSortToolIDs(ids), nil
 	}
-	return DedupeSortToolIDs(config.EnabledToolIDs(settings))
+	enabled := cloneEnabledToolSet(settings.EnabledTools)
+	if bothEditToolSourcesDefault(source) {
+		if prefersPatchTool(settings) {
+			enabled[toolspec.ToolPatch] = true
+			enabled[toolspec.ToolEdit] = false
+		} else {
+			enabled[toolspec.ToolPatch] = false
+			enabled[toolspec.ToolEdit] = true
+		}
+	}
+	if enabled[toolspec.ToolPatch] && enabled[toolspec.ToolEdit] {
+		return nil, fmt.Errorf("tools.patch and tools.edit cannot both be enabled; set one to false")
+	}
+	return DedupeSortToolIDs(enabledToolIDs(enabled)), nil
+}
+
+func bothEditToolSourcesDefault(source config.SourceReport) bool {
+	return strings.TrimSpace(source.Sources["tools.patch"]) == "default" && strings.TrimSpace(source.Sources["tools.edit"]) == "default"
+}
+
+func prefersPatchTool(settings config.Settings) bool {
+	if settings.ProviderCapabilities.IsOpenAIFirstParty {
+		return true
+	}
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(settings.Model)), "gpt-")
+}
+
+func enabledToolIDs(enabled map[toolspec.ID]bool) []toolspec.ID {
+	ids := make([]toolspec.ID, 0, len(enabled))
+	for _, id := range toolspec.CatalogIDs() {
+		if enabled[id] {
+			ids = append(ids, id)
+		}
+	}
+	return ids
 }
 
 func cloneEnabledToolSet(in map[toolspec.ID]bool) map[toolspec.ID]bool {

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -503,9 +503,8 @@ func EffectiveSettings(base config.Settings, locked *session.LockedContract) con
 	return out
 }
 
-func ActiveToolIDs(settings config.Settings, source config.SourceReport, locked *session.LockedContract) []toolspec.ID {
-	ids, _ := ActiveToolIDsForPlan(settings, source, locked)
-	return ids
+func ActiveToolIDs(settings config.Settings, source config.SourceReport, locked *session.LockedContract) ([]toolspec.ID, error) {
+	return ActiveToolIDsForPlan(settings, source, locked)
 }
 
 func ActiveToolIDsForPlan(settings config.Settings, source config.SourceReport, locked *session.LockedContract) ([]toolspec.ID, error) {

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -186,7 +186,7 @@ func ApplyRunPromptOverrides(plan SessionPlan, overrides serverapi.RunPromptOver
 		return SessionPlan{}, nil, err
 	}
 	locked := plan.Store.Meta().Locked
-	mergedSource := mergeOverrideSources(plan.Source, loaded.Source)
+	mergedSource := mergeOverrideSources(next.Source, loaded.Source)
 	if strings.TrimSpace(overrides.Model) != "" && !next.ModelContractLocked {
 		originalModel := strings.TrimSpace(next.ActiveSettings.Model)
 		explicitSources := map[string]string{}

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -39,12 +39,13 @@ type TranscriptWindowSnapshot struct {
 }
 
 type storedToolCompletion struct {
-	CallID      string          `json:"call_id"`
-	Name        string          `json:"name"`
-	IsError     bool            `json:"is_error"`
-	Output      json.RawMessage `json:"output"`
-	Summary     string          `json:"summary,omitempty"`
-	OngoingText string          `json:"ongoing_text,omitempty"`
+	CallID       string                   `json:"call_id"`
+	Name         string                   `json:"name"`
+	IsError      bool                     `json:"is_error"`
+	Output       json.RawMessage          `json:"output"`
+	Summary      string                   `json:"summary,omitempty"`
+	OngoingText  string                   `json:"ongoing_text,omitempty"`
+	Presentation *transcript.ToolCallMeta `json:"presentation,omitempty"`
 }
 
 type chatStore struct {
@@ -155,12 +156,13 @@ func (s *chatStore) restoreToolCompletionPayload(payload []byte) error {
 		return fmt.Errorf("decode tool_completed event: %w", err)
 	}
 	s.recordToolCompletion(tools.Result{
-		CallID:      completion.CallID,
-		Name:        toolspec.ID(completion.Name),
-		IsError:     completion.IsError,
-		Output:      completion.Output,
-		Summary:     completion.Summary,
-		OngoingText: completion.OngoingText,
+		CallID:       completion.CallID,
+		Name:         toolspec.ID(completion.Name),
+		IsError:      completion.IsError,
+		Output:       completion.Output,
+		Summary:      completion.Summary,
+		OngoingText:  completion.OngoingText,
+		Presentation: completion.Presentation,
 	})
 	return nil
 }

--- a/server/runtime/edit_e2e_test.go
+++ b/server/runtime/edit_e2e_test.go
@@ -1,0 +1,107 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"builder/server/llm"
+	"builder/server/session"
+	"builder/server/tools"
+	edittool "builder/server/tools/edit"
+	"builder/shared/toolspec"
+)
+
+func TestEditAliasCompletionDiffAndReviewerEditsFlow(t *testing.T) {
+	workspace := t.TempDir()
+	target := filepath.Join(workspace, "a.txt")
+	if err := os.WriteFile(target, []byte("old\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	store, err := session.Create(filepath.Join(t.TempDir(), "sessions"), "ws", workspace)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	editTool, err := edittool.New(workspace, true)
+	if err != nil {
+		t.Fatalf("new edit tool: %v", err)
+	}
+	editInput, _ := json.Marshal(map[string]any{
+		"path":       "a.txt",
+		"old_string": "old",
+		"new_string": "new",
+	})
+	mainClient := &fakeClient{responses: []llm.Response{
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "working", Phase: llm.MessagePhaseCommentary},
+			ToolCalls: []llm.ToolCall{{
+				ID:    "call-edit-1",
+				Name:  "replace",
+				Input: editInput,
+			}},
+			Usage: llm.Usage{WindowTokens: 200000},
+		},
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "final", Phase: llm.MessagePhaseFinal},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+	}}
+	reviewerClient := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: `{"suggestions":[]}`},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+
+	eng, err := New(store, mainClient, tools.NewRegistry(editTool), Config{
+		Model:        "claude",
+		EnabledTools: []toolspec.ID{toolspec.ToolEdit},
+		Reviewer: ReviewerConfig{
+			Frequency:     "edits",
+			Model:         "claude",
+			ThinkingLevel: "low",
+			Client:        reviewerClient,
+		},
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	msg, err := eng.SubmitUserMessage(context.Background(), "edit file")
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if msg.Content != "final" {
+		t.Fatalf("assistant content = %q, want final", msg.Content)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read edited file: %v", err)
+	}
+	if string(data) != "new\n" {
+		t.Fatalf("edited content = %q, want new", string(data))
+	}
+	if len(reviewerClient.calls) != 1 {
+		t.Fatalf("expected reviewer to run after edit, got %d calls", len(reviewerClient.calls))
+	}
+
+	snapshot := eng.ChatSnapshot()
+	var callMetaName string
+	var resultHasDiff bool
+	for _, entry := range snapshot.Entries {
+		if entry.ToolCallID != "call-edit-1" || entry.ToolCall == nil {
+			continue
+		}
+		if entry.Role == "tool_call" {
+			callMetaName = entry.ToolCall.ToolName
+		}
+		if entry.Role == "tool_result_ok" && entry.ToolCall.PatchRender != nil {
+			resultHasDiff = true
+		}
+	}
+	if callMetaName != string(toolspec.ToolEdit) {
+		t.Fatalf("tool call metadata name = %q, want edit", callMetaName)
+	}
+	if !resultHasDiff {
+		t.Fatalf("expected edit completion result to carry diff metadata, snapshot=%+v", snapshot.Entries)
+	}
+}

--- a/server/runtime/edit_prompt_test.go
+++ b/server/runtime/edit_prompt_test.go
@@ -1,0 +1,32 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"builder/shared/toolspec"
+)
+
+func TestManualEditInstructionMatchesActiveEditTool(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled []toolspec.ID
+		want    string
+		absent  string
+	}{
+		{name: "patch", enabled: []toolspec.ID{toolspec.ToolPatch}, want: "Use `patch`", absent: "Use `edit`"},
+		{name: "edit", enabled: []toolspec.ID{toolspec.ToolEdit}, want: "Use `edit`", absent: "Use `patch`"},
+		{name: "neither", enabled: []toolspec.ID{toolspec.ToolExecCommand}, want: "Use shell carefully", absent: "Use `patch`"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := manualEditInstruction(tt.enabled)
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("instruction = %q, want %q", got, tt.want)
+			}
+			if strings.Contains(got, tt.absent) {
+				t.Fatalf("instruction = %q, should not contain %q", got, tt.absent)
+			}
+		})
+	}
+}

--- a/server/runtime/edit_tool_executor_test.go
+++ b/server/runtime/edit_tool_executor_test.go
@@ -53,8 +53,8 @@ func TestExecuteToolCallsCanonicalizesEditAliases(t *testing.T) {
 	if got := meta.ToolName; got != string(toolspec.ToolEdit) {
 		t.Fatalf("started tool name = %q, want edit", got)
 	}
-	if got := meta.Command; got != "edit a.go" {
-		t.Fatalf("started text = %q, want edit a.go", got)
+	if got := meta.Command; got != "a.go" {
+		t.Fatalf("started text = %q, want a.go", got)
 	}
 }
 

--- a/server/runtime/edit_tool_executor_test.go
+++ b/server/runtime/edit_tool_executor_test.go
@@ -106,6 +106,8 @@ func (t capturingTool) Call(_ context.Context, c tools.Call) (tools.Result, erro
 	var payload map[string]any
 	if err := json.Unmarshal(c.Input, &payload); err != nil {
 		out, _ := json.Marshal("Edit failed: expected JSON object input.")
+		// Tool-logic failures are returned in Result.IsError, not as a Go error.
+		//nolint:nilerr
 		return tools.Result{CallID: c.ID, Name: c.Name, Output: out, IsError: true, Summary: "Edit failed: expected JSON object input."}, nil
 	}
 	out, _ := json.Marshal("ok")

--- a/server/runtime/edit_tool_executor_test.go
+++ b/server/runtime/edit_tool_executor_test.go
@@ -104,7 +104,7 @@ func (t capturingTool) Name() toolspec.ID { return t.name }
 
 func (t capturingTool) Call(_ context.Context, c tools.Call) (tools.Result, error) {
 	var payload map[string]any
-	if err := json.Unmarshal(c.Input, &payload); err != nil {
+	if err := json.Unmarshal(c.Input, &payload); err != nil || payload == nil {
 		out, _ := json.Marshal("Edit failed: expected JSON object input.")
 		// Tool-logic failures are returned in Result.IsError, not as a Go error.
 		//nolint:nilerr

--- a/server/runtime/edit_tool_executor_test.go
+++ b/server/runtime/edit_tool_executor_test.go
@@ -1,0 +1,113 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"builder/server/llm"
+	"builder/server/session"
+	"builder/server/tools"
+	"builder/shared/toolspec"
+)
+
+func TestExecuteToolCallsCanonicalizesEditAliases(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	var events []Event
+	eng, err := New(store, &fakeClient{}, tools.NewRegistry(capturingTool{name: toolspec.ToolEdit}), Config{
+		Model:        "claude",
+		EnabledTools: []toolspec.ID{toolspec.ToolEdit},
+		OnEvent: func(evt Event) {
+			events = append(events, evt)
+		},
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+
+	results, err := eng.executeToolCalls(context.Background(), "step", []llm.ToolCall{{
+		ID:    "call-replace",
+		Name:  "replace",
+		Input: json.RawMessage(`{"path":"a.go","old_string":"old","new_string":"new"}`),
+	}})
+	if err != nil {
+		t.Fatalf("execute tool calls: %v", err)
+	}
+	if len(results) != 1 || results[0].Name != toolspec.ToolEdit {
+		t.Fatalf("results = %+v, want canonical edit", results)
+	}
+	var started *llm.ToolCall
+	for _, evt := range events {
+		if evt.Kind == EventToolCallStarted && evt.ToolCall != nil && evt.ToolCall.ID == "call-replace" {
+			started = evt.ToolCall
+		}
+	}
+	if started == nil {
+		t.Fatalf("events = %+v, want started event", events)
+	}
+	meta := transcriptToolCallMeta(*started, dir)
+	if got := meta.ToolName; got != string(toolspec.ToolEdit) {
+		t.Fatalf("started tool name = %q, want edit", got)
+	}
+	if got := meta.Command; got != "edit a.go" {
+		t.Fatalf("started text = %q, want edit a.go", got)
+	}
+}
+
+func TestExecuteToolCallsAcceptsCustomEditJSONAndRejectsPlainText(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	eng, err := New(store, &fakeClient{}, tools.NewRegistry(capturingTool{name: toolspec.ToolEdit}), Config{Model: "claude", EnabledTools: []toolspec.ID{toolspec.ToolEdit}})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+
+	okResults, err := eng.executeToolCalls(context.Background(), "step-json", []llm.ToolCall{{
+		ID:          "call-json",
+		Name:        "edit",
+		Custom:      true,
+		CustomInput: `{"path":"a.go","old_string":"old","new_string":"new"}`,
+	}})
+	if err != nil {
+		t.Fatalf("execute json custom tool call: %v", err)
+	}
+	if len(okResults) != 1 || okResults[0].IsError {
+		t.Fatalf("json custom results = %+v, want success", okResults)
+	}
+
+	badResults, err := eng.executeToolCalls(context.Background(), "step-text", []llm.ToolCall{{
+		ID:          "call-text",
+		Name:        "edit",
+		Custom:      true,
+		CustomInput: "not json",
+	}})
+	if err != nil {
+		t.Fatalf("execute text custom tool call: %v", err)
+	}
+	if len(badResults) != 1 || !badResults[0].IsError {
+		t.Fatalf("plain custom results = %+v, want error", badResults)
+	}
+}
+
+type capturingTool struct {
+	name toolspec.ID
+}
+
+func (t capturingTool) Name() toolspec.ID { return t.name }
+
+func (t capturingTool) Call(_ context.Context, c tools.Call) (tools.Result, error) {
+	var payload map[string]any
+	if err := json.Unmarshal(c.Input, &payload); err != nil {
+		out, _ := json.Marshal("Edit failed: expected JSON object input.")
+		return tools.Result{CallID: c.ID, Name: c.Name, Output: out, IsError: true, Summary: "Edit failed: expected JSON object input."}, nil
+	}
+	out, _ := json.Marshal("ok")
+	return tools.Result{CallID: c.ID, Name: c.Name, Output: out}, nil
+}

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -33,6 +33,9 @@ func (e *Engine) persistToolCompletion(stepID string, r tools.Result) error {
 	if r.OngoingText != "" {
 		payload["ongoing_text"] = r.OngoingText
 	}
+	if r.Presentation != nil {
+		payload["presentation"] = r.Presentation
+	}
 	_, err := e.store.AppendEvent(stepID, "tool_completed", payload)
 	if err == nil {
 		e.markCurrentRequestShapeDirtyForSignificantMutation()

--- a/server/runtime/persisted_event_entries.go
+++ b/server/runtime/persisted_event_entries.go
@@ -30,12 +30,13 @@ func VisibleChatEntriesFromPersistedEvent(evt session.Event, cacheWarningMode co
 			return nil, false, fmt.Errorf("decode tool_completed event: %w", err)
 		}
 		entry := toolResultChatEntry(tools.Result{
-			CallID:      completion.CallID,
-			Name:        toolspec.ID(completion.Name),
-			IsError:     completion.IsError,
-			Output:      completion.Output,
-			Summary:     completion.Summary,
-			OngoingText: completion.OngoingText,
+			CallID:       completion.CallID,
+			Name:         toolspec.ID(completion.Name),
+			IsError:      completion.IsError,
+			Output:       completion.Output,
+			Summary:      completion.Summary,
+			OngoingText:  completion.OngoingText,
+			Presentation: completion.Presentation,
 		})
 		return []ChatEntry{entry}, false, nil
 	case "local_entry":

--- a/server/runtime/step_executor.go
+++ b/server/runtime/step_executor.go
@@ -248,7 +248,7 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 		}
 		customToolCalls := customToolCallIDs(localToolCalls)
 		for _, result := range results {
-			if result.Name == toolspec.ToolPatch && !result.IsError {
+			if isSuccessfulFileEditResult(result) {
 				patchEditsApplied = true
 			}
 			msg := llm.Message{Role: llm.RoleTool, Content: string(result.Output), ToolCallID: result.CallID, Name: string(result.Name)}
@@ -261,6 +261,13 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 			return stepLoopResult{}, err
 		}
 	}
+}
+
+func isSuccessfulFileEditResult(result tools.Result) bool {
+	if result.IsError {
+		return false
+	}
+	return result.Name == toolspec.ToolPatch || result.Name == toolspec.ToolEdit
 }
 
 func customToolCallIDs(calls []llm.ToolCall) map[string]bool {

--- a/server/runtime/system_prompt_snapshot.go
+++ b/server/runtime/system_prompt_snapshot.go
@@ -10,6 +10,7 @@ import (
 	"builder/prompts"
 	"builder/server/session"
 	"builder/shared/config"
+	"builder/shared/toolspec"
 )
 
 type systemPromptSnapshotOptions struct {
@@ -28,6 +29,7 @@ func (e *Engine) buildSystemPromptSnapshotForRoot(locked session.LockedContract,
 	}
 	args := prompts.SystemPromptTemplateArgs{
 		EstimatedToolCallsForContext: e.estimatedToolCallsForLockedContext(locked),
+		ManualEditInstruction:        manualEditInstruction(e.cfg.EnabledTools),
 	}
 	template, sourcePath, hasCustom, err := readSystemPromptTemplate(systemPromptSnapshotOptions{
 		WorkspaceRoot:     workspaceRoot,
@@ -44,6 +46,18 @@ func (e *Engine) buildSystemPromptSnapshotForRoot(locked session.LockedContract,
 		return rendered, nil
 	}
 	return prompts.MainSystemPrompt(includeToolPreambles, args), nil
+}
+
+func manualEditInstruction(enabled []toolspec.ID) string {
+	for _, id := range enabled {
+		if id == toolspec.ToolPatch {
+			return "Use `patch` for manual code edits. Do not use cat or any other commands when creating or editing files. Formatting commands or bulk edits don't need to be done with the patch tool."
+		}
+		if id == toolspec.ToolEdit {
+			return "Use `edit` for manual code edits. Do not use cat or any other commands when creating or editing files. Formatting commands or bulk edits don't need to be done with the edit tool."
+		}
+	}
+	return "Use shell carefully for manual code edits when no dedicated edit tool is enabled."
 }
 
 func (e *Engine) systemPromptWorkspaceRoot() string {

--- a/server/runtime/tool_executor.go
+++ b/server/runtime/tool_executor.go
@@ -32,6 +32,9 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 		}
 		toolID, knownTool := toolspec.ParseID(call.Name)
 		executableCall := call
+		if knownTool {
+			executableCall.Name = string(toolID)
+		}
 		if call.Custom && knownTool {
 			executableCall.Input = executorInputForCustomTool(toolID, call.CustomInput)
 		}

--- a/server/runtime/transcript_event_entries.go
+++ b/server/runtime/transcript_event_entries.go
@@ -8,6 +8,7 @@ import (
 	"builder/server/tools"
 	"builder/shared/cachewarn"
 	"builder/shared/toolspec"
+	"builder/shared/transcript"
 )
 
 func VisibleChatEntriesFromMessage(msg llm.Message) []ChatEntry {
@@ -115,11 +116,17 @@ func toolResultChatEntry(result tools.Result) ChatEntry {
 	if result.IsError {
 		role = "tool_result_error"
 	}
+	presentation := result.Presentation
+	if presentation != nil {
+		normalized := transcript.NormalizeToolCallMeta(*presentation)
+		presentation = &normalized
+	}
 	return ChatEntry{
 		Role:              role,
 		Text:              formatToolResult(result),
 		OngoingText:       strings.TrimSpace(result.OngoingText),
 		ToolCallID:        strings.TrimSpace(result.CallID),
 		ToolResultSummary: strings.TrimSpace(result.Summary),
+		ToolCall:          presentation,
 	}
 }

--- a/server/runtime/transcript_scan.go
+++ b/server/runtime/transcript_scan.go
@@ -144,6 +144,7 @@ func (s *inMemoryTranscriptScan) visibleEntriesFromMessage(msg llm.Message) []Ch
 			result.IsError = completion.IsError
 			result.Summary = completion.Summary
 			result.OngoingText = completion.OngoingText
+			result.Presentation = completion.Presentation
 		}
 		if result.Name == "" {
 			result.Name = toolspec.ID("tool")

--- a/server/runtimewire/tool_registry.go
+++ b/server/runtimewire/tool_registry.go
@@ -3,6 +3,7 @@ package runtimewire
 import (
 	"builder/server/tools"
 	askquestion "builder/server/tools/askquestion"
+	edittool "builder/server/tools/edit"
 	patchtool "builder/server/tools/patch"
 	readimagetool "builder/server/tools/readimage"
 	shelltool "builder/server/tools/shell"
@@ -62,6 +63,16 @@ func BuildLocalRuntimeHandler(def tools.Definition, ctx LocalToolRuntimeContext)
 			true,
 			patchtool.WithAllowOutsideWorkspace(ctx.AllowNonCwdEdits),
 			patchtool.WithOutsideWorkspaceApprover(ctx.OutsideWorkspaceEditApprover),
+		)
+	case tools.LocalRuntimeBuilderEdit:
+		if ctx.OutsideWorkspaceEditApprover == nil {
+			return nil, fmt.Errorf("edit outside-workspace approver is unavailable")
+		}
+		return edittool.New(
+			ctx.WorkspaceRoot,
+			true,
+			edittool.WithAllowOutsideWorkspace(ctx.AllowNonCwdEdits),
+			edittool.WithOutsideWorkspaceApprover(ctx.OutsideWorkspaceEditApprover),
 		)
 	case tools.LocalRuntimeBuilderAskQuestion:
 		if ctx.AskQuestionBroker == nil {

--- a/server/tools/contract.go
+++ b/server/tools/contract.go
@@ -78,6 +78,7 @@ const (
 	LocalRuntimeBuilderWriteStdin     LocalRuntimeBuilder = "write_stdin"
 	LocalRuntimeBuilderViewImage      LocalRuntimeBuilder = "view_image"
 	LocalRuntimeBuilderPatch          LocalRuntimeBuilder = "patch"
+	LocalRuntimeBuilderEdit           LocalRuntimeBuilder = "edit"
 	LocalRuntimeBuilderAskQuestion    LocalRuntimeBuilder = "ask_question"
 	LocalRuntimeBuilderTriggerHandoff LocalRuntimeBuilder = "trigger_handoff"
 )

--- a/server/tools/definitions.go
+++ b/server/tools/definitions.go
@@ -163,6 +163,44 @@ var catalogEntries = []CatalogEntry{
 }`),
 	},
 	{
+		ID:             toolspec.ToolEdit,
+		Aliases:        []string{"replace", "write"},
+		Description:    "Replace text in a file, create a missing or empty file, or delete matched text. old_string should match current file content and include enough context to be unique.",
+		DefaultEnabled: false,
+		Contract: localContract(
+			LocalRuntimeBuilderEdit,
+			RequestExposure{Enabled: true},
+			transcript.ToolPresentationDefault,
+			transcript.ToolCallRenderBehaviorDefault,
+			true,
+			editToolCallMeta(toolspec.ToolEdit),
+			formatEditToolResult,
+		),
+		Schema: json.RawMessage(`{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["path", "old_string", "new_string"],
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "File path to edit. Relative paths resolve from the workspace root; absolute paths are allowed."
+    },
+    "old_string": {
+      "type": "string",
+      "description": "Exact current text to replace. Include enough surrounding context to make the match unique. Use an empty string only to create a missing or empty file."
+    },
+    "new_string": {
+      "type": "string",
+      "description": "Replacement text. Use an empty string to delete the matched text."
+    },
+    "replace_all": {
+      "type": "boolean",
+      "description": "Replace all occurrences of the selected match. Defaults to false."
+    }
+  }
+}`),
+	},
+	{
 		ID:             toolspec.ToolAskQuestion,
 		Aliases:        nil,
 		Description:    "Ask the user a question. You should ask the user when planning or working to make product decisions, resolve ambiguities, define missing pieces that you cannot resolve by yourself, brainstorming with the user. You should ask the user a lot of questions when you're planning/brainstorming together to learn their desires, preferences, design, product vision, architecture, and sometimes ask them questions when already working if you encounter a problem you can't resolve, a caveat, an undefined area that materially affects the result or direction of your work, etc. You should avoid asking the user obvious or harmless questions like 'Should I run tests?' or 'Where is file X?' which you can answer yourself. Stick to ONE question per this tool call, for multiple questions call this tool in parallel. Strive to provide multiple suggestions/options with every question if applicable, and providing one recommended option you deem best for user goals.",

--- a/server/tools/edit/errors.go
+++ b/server/tools/edit/errors.go
@@ -32,7 +32,7 @@ func editErrorResult(c tools.Call, err error) tools.Result {
 	if err != nil {
 		message = err.Error()
 	}
-	if !strings.HasPrefix(strings.TrimSpace(message), "Edit failed:") {
+	if !strings.HasPrefix(strings.TrimSpace(message), "Edit failed") {
 		message = "Edit failed: " + strings.TrimSpace(message)
 	}
 	body, _ := json.Marshal(message)

--- a/server/tools/edit/errors.go
+++ b/server/tools/edit/errors.go
@@ -1,0 +1,49 @@
+package edit
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"builder/server/tools"
+)
+
+type failure struct {
+	Message string
+}
+
+func (f failure) Error() string {
+	message := strings.TrimSpace(f.Message)
+	if message == "" {
+		return "Edit failed."
+	}
+	if strings.HasPrefix(message, "Edit failed:") {
+		return message
+	}
+	return "Edit failed: " + message
+}
+
+func failf(format string, args ...any) error {
+	return failure{Message: fmt.Sprintf(format, args...)}
+}
+
+func editErrorResult(c tools.Call, err error) tools.Result {
+	message := "Edit failed."
+	if err != nil {
+		message = err.Error()
+	}
+	if !strings.HasPrefix(strings.TrimSpace(message), "Edit failed:") {
+		message = "Edit failed: " + strings.TrimSpace(message)
+	}
+	body, _ := json.Marshal(message)
+	return tools.Result{CallID: c.ID, Name: c.Name, Output: body, IsError: true, Summary: message}
+}
+
+func editSuccessResult(c tools.Call, message string) tools.Result {
+	trimmed := strings.TrimSpace(message)
+	if trimmed == "" {
+		trimmed = "ok"
+	}
+	body, _ := json.Marshal(trimmed)
+	return tools.Result{CallID: c.ID, Name: c.Name, Output: body, Summary: trimmed}
+}

--- a/server/tools/edit/input.go
+++ b/server/tools/edit/input.go
@@ -1,0 +1,104 @@
+package edit
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type input struct {
+	Path       string
+	OldString  string
+	NewString  string
+	ReplaceAll bool
+}
+
+func parseInput(raw json.RawMessage) (input, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return input{}, failf("expected JSON object input.")
+	}
+	if fields == nil {
+		return input{}, failf("expected JSON object input.")
+	}
+	path, err := pickString(fields, "path", "file_path", "filePath")
+	if err != nil {
+		return input{}, err
+	}
+	oldString, err := pickString(fields, "old_string", "oldString", "oldText")
+	if err != nil {
+		return input{}, err
+	}
+	newString, err := pickString(fields, "new_string", "newString", "newText")
+	if err != nil {
+		return input{}, err
+	}
+	replaceAll, err := pickBool(fields, "replace_all", "replaceAll")
+	if err != nil {
+		return input{}, err
+	}
+	if strings.TrimSpace(path) == "" {
+		return input{}, failf("path is required.")
+	}
+	if oldString == newString {
+		return input{}, failf("old_string and new_string must be different.")
+	}
+	return input{Path: path, OldString: oldString, NewString: newString, ReplaceAll: replaceAll}, nil
+}
+
+func pickString(fields map[string]json.RawMessage, names ...string) (string, error) {
+	var selected []byte
+	found := ""
+	for _, name := range names {
+		raw, ok := fields[name]
+		if !ok {
+			continue
+		}
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return "", failf("%s must be a string.", name)
+		}
+		encoded, _ := json.Marshal(value)
+		if found != "" && !bytes.Equal(selected, encoded) {
+			return "", failf("conflicting aliases for %s.", names[0])
+		}
+		found = name
+		selected = encoded
+	}
+	if found == "" {
+		return "", failf("%s is required.", names[0])
+	}
+	var value string
+	_ = json.Unmarshal(selected, &value)
+	return value, nil
+}
+
+func pickBool(fields map[string]json.RawMessage, names ...string) (bool, error) {
+	var selected []byte
+	found := ""
+	for _, name := range names {
+		raw, ok := fields[name]
+		if !ok {
+			continue
+		}
+		var value bool
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return false, failf("%s must be a boolean.", name)
+		}
+		encoded, _ := json.Marshal(value)
+		if found != "" && !bytes.Equal(selected, encoded) {
+			return false, failf("conflicting aliases for %s.", names[0])
+		}
+		found = name
+		selected = encoded
+	}
+	if found == "" {
+		return false, nil
+	}
+	var value bool
+	if err := json.Unmarshal(selected, &value); err != nil {
+		return false, fmt.Errorf("decode %s: %w", names[0], err)
+	}
+	return value, nil
+}

--- a/server/tools/edit/matcher.go
+++ b/server/tools/edit/matcher.go
@@ -1,0 +1,380 @@
+package edit
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type rangeMatch struct {
+	start           int
+	end             int
+	actual          string
+	quoteNormalized bool
+}
+
+type replacementSelection struct {
+	matches []rangeMatch
+	newText string
+}
+
+func selectReplacement(content string, in input) (replacementSelection, error) {
+	matches := findMatches(content, in.OldString)
+	if len(matches) == 0 {
+		return replacementSelection{}, failf("old_string matched 0 occurrences")
+	}
+	if !in.ReplaceAll && len(matches) != 1 {
+		return replacementSelection{}, failf("old_string matched multiple occurrences")
+	}
+	selected := matches
+	if in.ReplaceAll {
+		selected = exactOccurrences(content, matches[0].actual, false)
+	}
+	newText := convertReplacementLineEndings(in.NewString, dominantLineEnding(matches[0].actual))
+	if matches[0].quoteNormalized {
+		newText = preserveCurlyQuotes(matches[0].actual, newText)
+	}
+	if newText == "" {
+		selected = extendDeletionNewline(content, selected)
+	}
+	return replacementSelection{matches: selected, newText: newText}, nil
+}
+
+func applyReplacement(content string, selection replacementSelection) string {
+	matches := append([]rangeMatch(nil), selection.matches...)
+	sort.Slice(matches, func(i, j int) bool { return matches[i].start > matches[j].start })
+	out := content
+	for _, match := range matches {
+		out = out[:match.start] + selection.newText + out[match.end:]
+	}
+	return out
+}
+
+func findMatches(content, old string) []rangeMatch {
+	if matches := exactOccurrences(content, old, false); len(matches) > 0 {
+		return matches
+	}
+	strategies := []func(string, string) []rangeMatch{
+		lineTrimmedMatches,
+		blockAnchorMatches,
+		whitespaceNormalizedMatches,
+		indentFlexibleMatches,
+		quoteNormalizedMatches,
+		escapedStringMatches,
+		trimmedBoundaryMatches,
+		contextAwareMatches,
+	}
+	for _, strategy := range strategies {
+		matches := uniqueRanges(strategy(content, old))
+		if len(matches) > 0 {
+			return matches
+		}
+	}
+	return exactOccurrences(content, old, true)
+}
+
+func exactOccurrences(content, needle string, convertLineEndings bool) []rangeMatch {
+	candidates := []string{needle}
+	if convertLineEndings {
+		if strings.Contains(content, "\r\n") {
+			candidates = append(candidates, strings.ReplaceAll(needle, "\n", "\r\n"))
+		}
+		candidates = append(candidates, strings.ReplaceAll(needle, "\r\n", "\n"))
+	}
+	var out []rangeMatch
+	seen := map[string]struct{}{}
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		start := 0
+		for {
+			idx := strings.Index(content[start:], candidate)
+			if idx < 0 {
+				break
+			}
+			abs := start + idx
+			key := strconv.Itoa(abs) + ":" + strconv.Itoa(abs+len(candidate))
+			if _, ok := seen[key]; !ok {
+				seen[key] = struct{}{}
+				out = append(out, rangeMatch{start: abs, end: abs + len(candidate), actual: candidate})
+			}
+			start = abs + max(1, len(candidate))
+		}
+	}
+	return out
+}
+
+func lineTrimmedMatches(content, old string) []rangeMatch {
+	return lineWindowMatches(content, old, func(actual, expected string) bool {
+		return strings.TrimRight(actual, " \t") == strings.TrimRight(expected, " \t")
+	})
+}
+
+func blockAnchorMatches(content, old string) []rangeMatch {
+	expected := nonEmptyLines(old)
+	if len(expected) < 2 {
+		return nil
+	}
+	first := strings.TrimSpace(expected[0])
+	last := strings.TrimSpace(expected[len(expected)-1])
+	return lineWindowMatches(content, old, funcWindow(len(expected), func(actual []lineSpan) bool {
+		return strings.TrimSpace(actual[0].text) == first && strings.TrimSpace(actual[len(actual)-1].text) == last
+	}))
+}
+
+func whitespaceNormalizedMatches(content, old string) []rangeMatch {
+	want := normalizeWhitespace(old)
+	return lineWindowMatches(content, old, func(actual, expected string) bool {
+		return normalizeWhitespace(actual) == want
+	})
+}
+
+func indentFlexibleMatches(content, old string) []rangeMatch {
+	want := stripCommonIndent(old)
+	return lineWindowMatches(content, old, func(actual, expected string) bool {
+		return stripCommonIndent(actual) == want
+	})
+}
+
+func escapedStringMatches(content, old string) []rangeMatch {
+	unquoted, err := strconv.Unquote(`"` + strings.ReplaceAll(old, `"`, `\"`) + `"`)
+	if err != nil || unquoted == old {
+		return nil
+	}
+	return exactOccurrences(content, unquoted, true)
+}
+
+func quoteNormalizedMatches(content, old string) []rangeMatch {
+	needle := normalizeQuotes(old)
+	if needle == old {
+		return nil
+	}
+	var out []rangeMatch
+	for _, match := range lineWindowMatches(content, old, func(actual, expected string) bool {
+		return normalizeQuotes(actual) == needle
+	}) {
+		match.quoteNormalized = true
+		out = append(out, match)
+	}
+	return out
+}
+
+func trimmedBoundaryMatches(content, old string) []rangeMatch {
+	trimmed := strings.TrimSpace(old)
+	if trimmed == "" || trimmed == old {
+		return nil
+	}
+	return exactOccurrences(content, trimmed, true)
+}
+
+func normalizeQuotes(text string) string {
+	replacer := strings.NewReplacer(
+		"“", `"`,
+		"”", `"`,
+		"„", `"`,
+		"«", `"`,
+		"»", `"`,
+		"‘", "'",
+		"’", "'",
+		"‚", "'",
+	)
+	return replacer.Replace(text)
+}
+
+func contextAwareMatches(content, old string) []rangeMatch {
+	expected := nonEmptyLines(old)
+	if len(expected) < 3 {
+		return nil
+	}
+	middle := strings.TrimSpace(expected[len(expected)/2])
+	return lineWindowMatches(content, old, func(actual, expected string) bool {
+		return strings.Contains(normalizeWhitespace(actual), normalizeWhitespace(middle))
+	})
+}
+
+type lineSpan struct {
+	text  string
+	start int
+	end   int
+}
+
+func lineWindowMatches(content, old string, predicate any) []rangeMatch {
+	lines := lineSpans(content)
+	expected := lineSpans(old)
+	if len(expected) == 0 || len(lines) < len(expected) {
+		return nil
+	}
+	var out []rangeMatch
+	for i := 0; i+len(expected) <= len(lines); i++ {
+		window := lines[i : i+len(expected)]
+		ok := false
+		switch p := predicate.(type) {
+		case func(string, string) bool:
+			ok = p(sliceText(window), old)
+		case func([]lineSpan) bool:
+			ok = p(window)
+		}
+		if ok {
+			start := window[0].start
+			end := window[len(window)-1].end
+			out = append(out, rangeMatch{start: start, end: end, actual: content[start:end]})
+		}
+	}
+	return out
+}
+
+func funcWindow(_ int, fn func([]lineSpan) bool) func([]lineSpan) bool {
+	return fn
+}
+
+func lineSpans(text string) []lineSpan {
+	if text == "" {
+		return nil
+	}
+	var out []lineSpan
+	start := 0
+	for start < len(text) {
+		end := start
+		for end < len(text) && text[end] != '\n' {
+			end++
+		}
+		lineEnd := end
+		if end < len(text) {
+			end++
+		}
+		out = append(out, lineSpan{text: strings.TrimSuffix(text[start:lineEnd], "\r"), start: start, end: end})
+		start = end
+	}
+	return out
+}
+
+func sliceText(lines []lineSpan) string {
+	if len(lines) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(lines))
+	for _, line := range lines {
+		parts = append(parts, line.text)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func nonEmptyLines(text string) []string {
+	spans := lineSpans(text)
+	out := make([]string, 0, len(spans))
+	for _, span := range spans {
+		if strings.TrimSpace(span.text) != "" {
+			out = append(out, span.text)
+		}
+	}
+	return out
+}
+
+func normalizeWhitespace(text string) string {
+	fields := strings.Fields(text)
+	return strings.Join(fields, " ")
+}
+
+func stripCommonIndent(text string) string {
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	minIndent := -1
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		indent := len(line) - len(strings.TrimLeft(line, " \t"))
+		if minIndent < 0 || indent < minIndent {
+			minIndent = indent
+		}
+	}
+	if minIndent <= 0 {
+		return strings.TrimSpace(strings.Join(lines, "\n"))
+	}
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if len(line) >= minIndent {
+			out = append(out, line[minIndent:])
+		} else {
+			out = append(out, line)
+		}
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+func uniqueRanges(matches []rangeMatch) []rangeMatch {
+	seen := map[string]struct{}{}
+	out := make([]rangeMatch, 0, len(matches))
+	for _, match := range matches {
+		key := strconv.Itoa(match.start) + ":" + strconv.Itoa(match.end)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, match)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].start < out[j].start })
+	return out
+}
+
+func dominantLineEnding(text string) string {
+	if strings.Contains(text, "\r\n") {
+		return "\r\n"
+	}
+	return "\n"
+}
+
+func convertReplacementLineEndings(text, ending string) string {
+	if ending != "\r\n" {
+		return strings.ReplaceAll(text, "\r\n", "\n")
+	}
+	normalized := strings.ReplaceAll(text, "\r\n", "\n")
+	return strings.ReplaceAll(normalized, "\n", "\r\n")
+}
+
+func extendDeletionNewline(content string, matches []rangeMatch) []rangeMatch {
+	out := append([]rangeMatch(nil), matches...)
+	for i, match := range out {
+		if strings.HasSuffix(match.actual, "\n") || match.end >= len(content) {
+			continue
+		}
+		if strings.HasPrefix(content[match.end:], "\r\n") {
+			out[i].end += 2
+			out[i].actual += "\r\n"
+		} else if content[match.end] == '\n' {
+			out[i].end++
+			out[i].actual += "\n"
+		}
+	}
+	return out
+}
+
+func preserveCurlyQuotes(actual, replacement string) string {
+	if !strings.ContainsAny(actual, "“”‘’") {
+		return replacement
+	}
+	var out strings.Builder
+	inWord := false
+	for _, r := range replacement {
+		switch r {
+		case '"':
+			if inWord {
+				out.WriteRune('”')
+			} else {
+				out.WriteRune('“')
+			}
+			inWord = !inWord
+		case '\'':
+			out.WriteRune('’')
+		default:
+			out.WriteRune(r)
+			if unicode.IsLetter(r) || unicode.IsDigit(r) {
+				inWord = true
+			} else if unicode.IsSpace(r) {
+				inWord = false
+			}
+		}
+	}
+	return out.String()
+}

--- a/server/tools/edit/matcher.go
+++ b/server/tools/edit/matcher.go
@@ -380,6 +380,8 @@ func preserveCurlyQuotes(actual, replacement string) string {
 	}
 	var out strings.Builder
 	inWord := false
+	var prev rune
+	hasPrev := false
 	for _, r := range replacement {
 		switch r {
 		case '"':
@@ -390,7 +392,12 @@ func preserveCurlyQuotes(actual, replacement string) string {
 			}
 			inWord = !inWord
 		case '\'':
-			out.WriteRune('’')
+			if isOpeningSingleQuote(prev, hasPrev) {
+				out.WriteRune('‘')
+			} else {
+				out.WriteRune('’')
+			}
+			inWord = false
 		default:
 			out.WriteRune(r)
 			if unicode.IsLetter(r) || unicode.IsDigit(r) {
@@ -399,6 +406,18 @@ func preserveCurlyQuotes(actual, replacement string) string {
 				inWord = false
 			}
 		}
+		prev = r
+		hasPrev = true
 	}
 	return out.String()
+}
+
+func isOpeningSingleQuote(prev rune, hasPrev bool) bool {
+	if !hasPrev {
+		return true
+	}
+	if unicode.IsSpace(prev) {
+		return true
+	}
+	return strings.ContainsRune("([{<", prev)
 }

--- a/server/tools/edit/matcher.go
+++ b/server/tools/edit/matcher.go
@@ -184,14 +184,32 @@ func normalizeQuotes(text string) string {
 }
 
 func contextAwareMatches(content, old string) []rangeMatch {
-	expected := nonEmptyLines(old)
+	expected := normalizedNonEmptyLines(old)
 	if len(expected) < 3 {
 		return nil
 	}
-	middle := strings.TrimSpace(expected[len(expected)/2])
-	return lineWindowMatches(content, old, func(actual, expected string) bool {
-		return strings.Contains(normalizeWhitespace(actual), normalizeWhitespace(middle))
-	})
+	middleIndex := len(expected) / 2
+	return lineWindowMatches(content, old, funcWindow(len(lineSpans(old)), func(actual []lineSpan) bool {
+		actualLines := normalizedNonEmptyLines(sliceText(actual))
+		if len(actualLines) != len(expected) {
+			return false
+		}
+		return actualLines[0] == expected[0] &&
+			actualLines[middleIndex] == expected[middleIndex] &&
+			actualLines[len(actualLines)-1] == expected[len(expected)-1]
+	}))
+}
+
+func normalizedNonEmptyLines(text string) []string {
+	lines := nonEmptyLines(text)
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		normalized := normalizeWhitespace(line)
+		if normalized != "" {
+			out = append(out, normalized)
+		}
+	}
+	return out
 }
 
 type lineSpan struct {

--- a/server/tools/edit/matcher.go
+++ b/server/tools/edit/matcher.go
@@ -25,7 +25,7 @@ func selectReplacement(content string, in input) (replacementSelection, error) {
 		return replacementSelection{}, failf("old_string matched 0 occurrences")
 	}
 	if !in.ReplaceAll && len(matches) != 1 {
-		return replacementSelection{}, failf("old_string matched multiple occurrences")
+		return replacementSelection{}, failf("old_string matched %d occurrences; pass replace_all=true or extend old_string with surrounding context to make it unique", len(matches))
 	}
 	selected := matches
 	if in.ReplaceAll {

--- a/server/tools/edit/matcher.go
+++ b/server/tools/edit/matcher.go
@@ -188,16 +188,22 @@ func contextAwareMatches(content, old string) []rangeMatch {
 	if len(expected) < 3 {
 		return nil
 	}
-	middleIndex := len(expected) / 2
 	return lineWindowMatches(content, old, funcWindow(len(lineSpans(old)), func(actual []lineSpan) bool {
 		actualLines := normalizedNonEmptyLines(sliceText(actual))
-		if len(actualLines) != len(expected) {
+		return stringSlicesEqual(actualLines, expected)
+	}))
+}
+
+func stringSlicesEqual(actual []string, expected []string) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for idx, value := range actual {
+		if value != expected[idx] {
 			return false
 		}
-		return actualLines[0] == expected[0] &&
-			actualLines[middleIndex] == expected[middleIndex] &&
-			actualLines[len(actualLines)-1] == expected[len(expected)-1]
-	}))
+	}
+	return true
 }
 
 func normalizedNonEmptyLines(text string) []string {

--- a/server/tools/edit/options.go
+++ b/server/tools/edit/options.go
@@ -1,0 +1,17 @@
+package edit
+
+import "builder/server/tools/fsguard"
+
+type Option func(*Tool)
+
+func WithAllowOutsideWorkspace(allow bool) Option {
+	return func(t *Tool) {
+		t.allowOutsideWorkspace = allow
+	}
+}
+
+func WithOutsideWorkspaceApprover(approver fsguard.Approver) Option {
+	return func(t *Tool) {
+		t.outsideWorkspaceApprover = approver
+	}
+}

--- a/server/tools/edit/tool.go
+++ b/server/tools/edit/tool.go
@@ -1,0 +1,483 @@
+package edit
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"unicode/utf8"
+
+	"builder/server/tools"
+	"builder/server/tools/fsguard"
+	patchtool "builder/server/tools/patch"
+	"builder/shared/toolspec"
+	"builder/shared/transcript"
+	patchformat "builder/shared/transcript/patchformat"
+)
+
+const (
+	maxEditableBytes = 100 * 1024 * 1024
+	utf8BOM          = "\xef\xbb\xbf"
+)
+
+type Tool struct {
+	workspaceRoot                string
+	workspaceRootReal            string
+	workspaceRootInfo            os.FileInfo
+	workspaceOnly                bool
+	allowOutsideWorkspace        bool
+	outsideWorkspaceApprover     fsguard.Approver
+	outsideWorkspaceSessionMu    sync.RWMutex
+	outsideWorkspaceSessionAllow bool
+}
+
+type resolvedPath struct {
+	requested string
+	cleaned   string
+	real      string
+	symlink   bool
+}
+
+func New(workspaceRoot string, workspaceOnly bool, opts ...Option) (*Tool, error) {
+	abs, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve workspace root: %w", err)
+	}
+	real, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return nil, tools.WrapMissingWorkspaceRootError(abs, fmt.Errorf("resolve workspace real path: %w", err))
+	}
+	rootInfo, err := os.Stat(real)
+	if err != nil {
+		return nil, tools.WrapMissingWorkspaceRootError(abs, fmt.Errorf("stat workspace root: %w", err))
+	}
+	t := &Tool{workspaceRoot: abs, workspaceRootReal: real, workspaceRootInfo: rootInfo, workspaceOnly: workspaceOnly}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(t)
+		}
+	}
+	return t, nil
+}
+
+func (t *Tool) Name() toolspec.ID {
+	return toolspec.ToolEdit
+}
+
+func (t *Tool) Call(ctx context.Context, c tools.Call) (tools.Result, error) {
+	in, err := parseInput(c.Input)
+	if err != nil {
+		return editErrorResult(c, err), nil
+	}
+	resolved, err := t.resolvePath(ctx, in.Path)
+	if err != nil {
+		return editErrorResult(c, err), nil
+	}
+	unlock := fsguard.LockPaths([]string{resolved.real})
+	defer unlock()
+	outcome, err := t.apply(ctx, resolved, in)
+	if err != nil {
+		return editErrorResult(c, err), nil
+	}
+	message := "ok"
+	if resolved.symlink {
+		message = "ok; warning: edited through symlink, real path is " + resolved.real + "; use that path directly next time"
+	}
+	result := editSuccessResult(c, message)
+	result.Presentation = &transcript.ToolCallMeta{
+		ToolName:     string(toolspec.ToolEdit),
+		Command:      "edit " + resolved.requested,
+		CompactText:  "edit " + resolved.requested,
+		PatchRender:  outcome.rendered,
+		RenderHint:   &transcript.ToolRenderHint{Kind: transcript.ToolRenderKindDiff},
+		PatchSummary: outcome.rendered.SummaryText(),
+		PatchDetail:  outcome.rendered.DetailText(),
+	}
+	return result, nil
+}
+
+type applyOutcome struct {
+	rendered *patchformat.RenderedPatch
+}
+
+func (t *Tool) apply(ctx context.Context, path resolvedPath, in input) (applyOutcome, error) {
+	select {
+	case <-ctx.Done():
+		return applyOutcome{}, ctx.Err()
+	default:
+	}
+	info, statErr := os.Stat(path.real)
+	if statErr == nil && info.IsDir() {
+		return applyOutcome{}, failf("path is a directory: %s.", path.real)
+	}
+	if in.OldString == "" {
+		return t.create(path, in.NewString, info, statErr)
+	}
+	if errors.Is(statErr, os.ErrNotExist) {
+		return applyOutcome{}, failf("old_string matched 0 occurrences in %s. Provide exact current text or more context.", path.real)
+	}
+	if statErr != nil {
+		return applyOutcome{}, failf("stat path %s: %v", path.real, statErr)
+	}
+	if !info.Mode().IsRegular() {
+		return applyOutcome{}, failf("path is not a regular file: %s.", path.real)
+	}
+	if info.Size() > maxEditableBytes {
+		return applyOutcome{}, failf("maximum editable text file size is 100 MiB.")
+	}
+	if err := rejectBinaryExtension(path.real); err != nil {
+		return applyOutcome{}, err
+	}
+	original, err := os.ReadFile(path.real)
+	if err != nil {
+		return applyOutcome{}, failf("read %s: %v", path.real, err)
+	}
+	text, bom, err := decodeText(original, path.real)
+	if err != nil {
+		return applyOutcome{}, err
+	}
+	selection, err := selectReplacement(text, in)
+	if err != nil {
+		return applyOutcome{}, failf("%s in %s. Provide exact current text or more context.", err.Error(), path.real)
+	}
+	updatedText := applyReplacement(text, selection)
+	next := []byte(updatedText)
+	if bom {
+		next = append([]byte(utf8BOM), next...)
+	}
+	if bytes.Equal(next, original) {
+		return applyOutcome{}, failf("replacement produced no changes.")
+	}
+	if len(next) > maxEditableBytes {
+		return applyOutcome{}, failf("maximum editable text file size is 100 MiB.")
+	}
+	if err := writeAtomicallyIfUnchanged(path.real, next, info); err != nil {
+		return applyOutcome{}, err
+	}
+	return applyOutcome{rendered: renderEditDiff(path.requested, text, updatedText)}, nil
+}
+
+func (t *Tool) create(path resolvedPath, newText string, info os.FileInfo, statErr error) (applyOutcome, error) {
+	if len([]byte(newText)) > maxEditableBytes {
+		return applyOutcome{}, failf("maximum editable text file size is 100 MiB.")
+	}
+	if err := rejectBinaryExtension(path.real); err != nil {
+		return applyOutcome{}, err
+	}
+	if hasMixedLineEndings(newText) {
+		return applyOutcome{}, failf("create content uses mixed line endings.")
+	}
+	if err := rejectBinaryBytes([]byte(newText), path.real); err != nil {
+		return applyOutcome{}, err
+	}
+	existingBOM := false
+	if statErr == nil {
+		if info.IsDir() {
+			return applyOutcome{}, failf("path is a directory: %s.", path.real)
+		}
+		if !info.Mode().IsRegular() {
+			return applyOutcome{}, failf("path is not a regular file: %s.", path.real)
+		}
+		if info.Size() > maxEditableBytes {
+			return applyOutcome{}, failf("maximum editable text file size is 100 MiB.")
+		}
+		data, err := os.ReadFile(path.real)
+		if err != nil {
+			return applyOutcome{}, failf("read %s: %v", path.real, err)
+		}
+		text, bom, err := decodeText(data, path.real)
+		if err != nil {
+			return applyOutcome{}, err
+		}
+		if strings.TrimSpace(text) != "" {
+			return applyOutcome{}, failf("target file already contains text: %s.", path.real)
+		}
+		existingBOM = bom
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return applyOutcome{}, failf("stat path %s: %v", path.real, statErr)
+	}
+	next := []byte(newText)
+	if existingBOM && !strings.HasPrefix(newText, utf8BOM) {
+		next = append([]byte(utf8BOM), next...)
+	}
+	var before os.FileInfo
+	if statErr == nil {
+		before = info
+	}
+	if err := writeAtomicallyIfUnchanged(path.real, next, before); err != nil {
+		return applyOutcome{}, err
+	}
+	return applyOutcome{rendered: renderEditDiff(path.requested, "", string(next))}, nil
+}
+
+func decodeText(data []byte, path string) (string, bool, error) {
+	bom := bytes.HasPrefix(data, []byte(utf8BOM))
+	if bom {
+		data = data[len(utf8BOM):]
+	}
+	if len(data) > maxEditableBytes {
+		return "", false, failf("maximum editable text file size is 100 MiB.")
+	}
+	if err := rejectBinaryBytes(data, path); err != nil {
+		return "", false, err
+	}
+	return string(data), bom, nil
+}
+
+func rejectBinaryBytes(data []byte, path string) error {
+	if bytes.Contains(data, []byte{0}) {
+		return failf("binary file rejected: %s.", path)
+	}
+	if !utf8.Valid(data) {
+		return failf("invalid UTF-8 text file: %s.", path)
+	}
+	prefix := data
+	if len(prefix) > 8192 {
+		prefix = prefix[:8192]
+	}
+	for _, b := range prefix {
+		if b < 0x20 && b != '\t' && b != '\n' && b != '\r' {
+			return failf("binary file rejected: %s.", path)
+		}
+	}
+	return nil
+}
+
+func rejectBinaryExtension(path string) error {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".bmp", ".tiff", ".pdf", ".zip", ".gz", ".tgz", ".xz", ".bz2", ".7z", ".rar", ".tar", ".mp3", ".mp4", ".mov", ".avi", ".mkv", ".exe", ".dll", ".dylib", ".so", ".a", ".o", ".class", ".jar", ".wasm", ".woff", ".woff2", ".ttf", ".otf", ".sqlite", ".sqlite3", ".db":
+		return failf("binary file extension rejected: %s.", path)
+	default:
+		return nil
+	}
+}
+
+func hasMixedLineEndings(text string) bool {
+	hasCRLF := strings.Contains(text, "\r\n")
+	withoutCRLF := strings.ReplaceAll(text, "\r\n", "")
+	hasLF := strings.Contains(withoutCRLF, "\n")
+	hasCR := strings.Contains(withoutCRLF, "\r")
+	styles := 0
+	if hasCRLF {
+		styles++
+	}
+	if hasLF {
+		styles++
+	}
+	if hasCR {
+		styles++
+	}
+	return styles > 1
+}
+
+func writeAtomicallyIfUnchanged(path string, data []byte, before os.FileInfo) error {
+	if before != nil {
+		current, err := os.Stat(path)
+		if err != nil {
+			return failf("target changed before commit: %s.", path)
+		}
+		if current.Size() != before.Size() || !current.ModTime().Equal(before.ModTime()) || current.Mode().Perm() != before.Mode().Perm() {
+			return failf("target changed before commit: %s.", path)
+		}
+	} else if _, err := os.Stat(path); err == nil {
+		return failf("target appeared before commit: %s.", path)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return failf("stat path %s: %v", path, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return failf("create parent dir for %s: %v", path, err)
+	}
+	mode := os.FileMode(0o644)
+	if before != nil {
+		mode = before.Mode().Perm()
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".builder-edit-"+filepath.Base(path)+"-*")
+	if err != nil {
+		return failf("stage write failed: %v", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return failf("stage write failed: %v", err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return failf("stage write failed: %v", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return failf("stage write failed: %v", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return failf("stage write failed: %v", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return failf("commit write %s: %v", path, err)
+	}
+	if dir, err := os.Open(filepath.Dir(path)); err == nil {
+		_ = dir.Sync()
+		_ = dir.Close()
+	}
+	return nil
+}
+
+func (t *Tool) outsideWorkspaceSessionAllowed() bool {
+	t.outsideWorkspaceSessionMu.RLock()
+	defer t.outsideWorkspaceSessionMu.RUnlock()
+	return t.outsideWorkspaceSessionAllow
+}
+
+func (t *Tool) setOutsideWorkspaceSessionAllowed(allow bool) {
+	t.outsideWorkspaceSessionMu.Lock()
+	t.outsideWorkspaceSessionAllow = allow
+	t.outsideWorkspaceSessionMu.Unlock()
+}
+
+func (t *Tool) resolvePath(ctx context.Context, requested string) (resolvedPath, error) {
+	if runtime.GOOS == "windows" && (strings.HasPrefix(requested, `\\`) || strings.HasPrefix(requested, `//`)) {
+		return resolvedPath{}, failf("UNC paths are not allowed.")
+	}
+	candidate := requested
+	if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(t.workspaceRoot, candidate)
+	}
+	cleaned := filepath.Clean(candidate)
+	approved := map[string]bool{}
+	if _, err := t.outsideGuard().Allow(ctx, requested, cleaned, approved); err != nil {
+		return resolvedPath{}, err
+	}
+	real, err := resolveRealTarget(cleaned)
+	if err != nil {
+		return resolvedPath{}, err
+	}
+	if _, err := t.outsideGuard().Allow(ctx, requested, real, approved); err != nil {
+		return resolvedPath{}, err
+	}
+	return resolvedPath{requested: requested, cleaned: cleaned, real: real, symlink: t.isUserSymlink(cleaned, real)}, nil
+}
+
+func (t *Tool) isUserSymlink(cleaned string, real string) bool {
+	if cleaned == real {
+		return false
+	}
+	rel, err := filepath.Rel(t.workspaceRoot, cleaned)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return true
+	}
+	expected := filepath.Clean(filepath.Join(t.workspaceRootReal, rel))
+	return expected != real
+}
+
+func resolveRealTarget(cleaned string) (string, error) {
+	if real, err := filepath.EvalSymlinks(cleaned); err == nil {
+		return filepath.Clean(real), nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", failf("resolve path %q: %v", cleaned, err)
+	}
+	parent := filepath.Dir(cleaned)
+	for {
+		info, err := os.Stat(parent)
+		if err == nil {
+			if !info.IsDir() {
+				return "", failf("parent path is not a directory: %s.", parent)
+			}
+			parentReal, evalErr := filepath.EvalSymlinks(parent)
+			if evalErr != nil {
+				return "", failf("resolve parent path for %q: %v", cleaned, evalErr)
+			}
+			rel, relErr := filepath.Rel(parent, cleaned)
+			if relErr != nil {
+				return "", failf("resolve path %q: %v", cleaned, relErr)
+			}
+			return filepath.Clean(filepath.Join(parentReal, rel)), nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", failf("stat parent path for %q: %v", cleaned, err)
+		}
+		next := filepath.Dir(parent)
+		if next == parent {
+			return "", failf("resolve parent path for %q: no existing ancestor", cleaned)
+		}
+		parent = next
+	}
+}
+
+func (t *Tool) outsideGuard() fsguard.Guard {
+	return fsguard.New(
+		t.workspaceRoot,
+		t.workspaceRootReal,
+		t.workspaceRootInfo,
+		t.workspaceOnly,
+		t.allowOutsideWorkspace,
+		t.outsideWorkspaceApprover,
+		t.outsideWorkspaceSessionAllowed,
+		t.setOutsideWorkspaceSessionAllowed,
+		"If it's essential to the task, ask the user to make the edit manually at the end of the task.",
+		fsguard.ErrorLabels{
+			OutsidePath: "edit target outside workspace",
+		},
+		fsguard.FailureFactory{
+			NoPermission: func(path string, reason string) error {
+				return failf("no file edit permission for %s. %s", path, reason)
+			},
+			DefaultApprovalFailed: func(path string, reason string) error {
+				return failf("file edit approval failed for %s. %s", path, reason)
+			},
+			DefaultUserDenied: func(path string, commentary string) error {
+				if strings.TrimSpace(commentary) == "" {
+					return failf("user denied the edit for %s.", path)
+				}
+				return failf("user denied the edit for %s.\nUser said: %s", path, commentary)
+			},
+		},
+		patchtool.IsPathInTemporaryDir,
+		nil,
+	)
+}
+
+func renderEditDiff(path string, oldText string, newText string) *patchformat.RenderedPatch {
+	doc := patchformat.Document{Hunks: []any{patchformat.UpdateFile{
+		Path:    path,
+		Changes: diffLines(oldText, newText),
+	}}}
+	rendered := patchformat.Format(doc, "")
+	return &rendered
+}
+
+func diffLines(oldText, newText string) []patchformat.ChangeLine {
+	oldLines := strings.Split(strings.TrimSuffix(strings.ReplaceAll(oldText, "\r\n", "\n"), "\n"), "\n")
+	newLines := strings.Split(strings.TrimSuffix(strings.ReplaceAll(newText, "\r\n", "\n"), "\n"), "\n")
+	if len(oldLines) == 1 && oldLines[0] == "" {
+		oldLines = nil
+	}
+	if len(newLines) == 1 && newLines[0] == "" {
+		newLines = nil
+	}
+	commonPrefix := 0
+	for commonPrefix < len(oldLines) && commonPrefix < len(newLines) && oldLines[commonPrefix] == newLines[commonPrefix] {
+		commonPrefix++
+	}
+	oldSuffix := len(oldLines)
+	newSuffix := len(newLines)
+	for oldSuffix > commonPrefix && newSuffix > commonPrefix && oldLines[oldSuffix-1] == newLines[newSuffix-1] {
+		oldSuffix--
+		newSuffix--
+	}
+	out := make([]patchformat.ChangeLine, 0, oldSuffix-commonPrefix+newSuffix-commonPrefix)
+	for _, line := range oldLines[commonPrefix:oldSuffix] {
+		out = append(out, patchformat.ChangeLine{Kind: '-', Content: line})
+	}
+	for _, line := range newLines[commonPrefix:newSuffix] {
+		out = append(out, patchformat.ChangeLine{Kind: '+', Content: line})
+	}
+	if len(out) == 0 && oldText != newText {
+		out = append(out, patchformat.ChangeLine{Kind: '-', Content: oldText}, patchformat.ChangeLine{Kind: '+', Content: newText})
+	}
+	return out
+}

--- a/server/tools/edit/tool.go
+++ b/server/tools/edit/tool.go
@@ -371,7 +371,7 @@ func canReuseOutsideApproval(cleaned string, real string) bool {
 	}
 	info, err := os.Lstat(cleaned)
 	if err != nil {
-		return false
+		return errors.Is(err, os.ErrNotExist)
 	}
 	return info.Mode()&os.ModeSymlink == 0
 }

--- a/server/tools/edit/tool.go
+++ b/server/tools/edit/tool.go
@@ -356,6 +356,9 @@ func (t *Tool) resolvePath(ctx context.Context, requested string) (resolvedPath,
 	if err != nil {
 		return resolvedPath{}, err
 	}
+	if approved[cleaned] {
+		approved[real] = true
+	}
 	if _, err := t.outsideGuard().Allow(ctx, requested, real, approved); err != nil {
 		return resolvedPath{}, err
 	}

--- a/server/tools/edit/tool.go
+++ b/server/tools/edit/tool.go
@@ -91,8 +91,8 @@ func (t *Tool) Call(ctx context.Context, c tools.Call) (tools.Result, error) {
 	result := editSuccessResult(c, message)
 	result.Presentation = &transcript.ToolCallMeta{
 		ToolName:     string(toolspec.ToolEdit),
-		Command:      "edit " + resolved.requested,
-		CompactText:  "edit " + resolved.requested,
+		Command:      outcome.rendered.DetailText(),
+		CompactText:  outcome.rendered.SummaryText(),
 		PatchRender:  outcome.rendered,
 		RenderHint:   &transcript.ToolRenderHint{Kind: transcript.ToolRenderKindDiff},
 		PatchSummary: outcome.rendered.SummaryText(),

--- a/server/tools/edit/tool.go
+++ b/server/tools/edit/tool.go
@@ -356,13 +356,24 @@ func (t *Tool) resolvePath(ctx context.Context, requested string) (resolvedPath,
 	if err != nil {
 		return resolvedPath{}, err
 	}
-	if approved[cleaned] {
+	if approved[cleaned] && canReuseOutsideApproval(cleaned, real) {
 		approved[real] = true
 	}
 	if _, err := t.outsideGuard().Allow(ctx, requested, real, approved); err != nil {
 		return resolvedPath{}, err
 	}
 	return resolvedPath{requested: requested, cleaned: cleaned, real: real, symlink: t.isUserSymlink(cleaned, real)}, nil
+}
+
+func canReuseOutsideApproval(cleaned string, real string) bool {
+	if cleaned == real {
+		return true
+	}
+	info, err := os.Lstat(cleaned)
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeSymlink == 0
 }
 
 func (t *Tool) isUserSymlink(cleaned string, real string) bool {

--- a/server/tools/edit/tool_test.go
+++ b/server/tools/edit/tool_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"builder/server/tools"
+	"builder/server/tools/fsguard"
 	"builder/shared/toolspec"
 )
 
@@ -165,6 +166,79 @@ func TestDeletionIncludesFollowingNewlineAfterUniqueness(t *testing.T) {
 	}
 	if string(got) != "before\nafter\n" {
 		t.Fatalf("deleted content = %q", string(got))
+	}
+}
+
+func TestContextAwareFallbackRejectsCommonMiddleLineWithoutBoundaryMatch(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "a.txt")
+	original := "alpha\nTODO\nomega\n"
+	if err := os.WriteFile(target, []byte(original), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	tool := newTestTool(t, dir)
+
+	result := callEdit(t, tool, map[string]any{
+		"path":       "a.txt",
+		"old_string": "before\nTODO\nafter\n",
+		"new_string": "changed\n",
+	})
+	if !result.IsError || !strings.Contains(toolResultText(t, result), "matched 0 occurrences") {
+		t.Fatalf("expected 0-match failure, got %+v text=%q", result, toolResultText(t, result))
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("file was unexpectedly changed: %q", string(got))
+	}
+}
+
+func TestOutsideWorkspaceSymlinkAliasUsesSingleCallApproval(t *testing.T) {
+	workspace := t.TempDir()
+	outside, err := os.MkdirTemp(".", "edit-outside-approval-")
+	if err != nil {
+		t.Fatalf("create outside dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(outside) })
+	outside, err = filepath.Abs(outside)
+	if err != nil {
+		t.Fatalf("resolve outside dir: %v", err)
+	}
+	if filepath.IsAbs(outside) && strings.Contains(outside, string(filepath.Separator)+"tmp"+string(filepath.Separator)) {
+		t.Skip("test outside dir is under temporary editable root")
+	}
+	target := filepath.Join(outside, "target.txt")
+	if err := os.WriteFile(target, []byte("old\n"), 0o644); err != nil {
+		t.Fatalf("seed outside target: %v", err)
+	}
+	link := filepath.Join(outside, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	prompts := 0
+	tool, err := New(workspace, true, WithOutsideWorkspaceApprover(func(context.Context, fsguard.Request) (fsguard.Approval, error) {
+		prompts++
+		return fsguard.Approval{Decision: fsguard.DecisionAllowOnce}, nil
+	}))
+	if err != nil {
+		t.Fatalf("new edit tool: %v", err)
+	}
+
+	result := callEdit(t, tool, map[string]any{"path": link, "old_string": "old", "new_string": "new"})
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+	if prompts != 1 {
+		t.Fatalf("outside approval prompts = %d, want 1", prompts)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "new\n" {
+		t.Fatalf("target content = %q", string(got))
 	}
 }
 

--- a/server/tools/edit/tool_test.go
+++ b/server/tools/edit/tool_test.go
@@ -248,6 +248,42 @@ func TestOutsideWorkspaceAncestorAliasUsesSingleCallApproval(t *testing.T) {
 	}
 }
 
+func TestOutsideWorkspaceMissingAncestorAliasUsesSingleCallApproval(t *testing.T) {
+	workspace := t.TempDir()
+	outside := newNonTemporaryOutsideDir(t)
+	targetDir := filepath.Join(outside, "target")
+	if err := os.Mkdir(targetDir, 0o755); err != nil {
+		t.Fatalf("create outside target dir: %v", err)
+	}
+	alias := filepath.Join(outside, "alias")
+	if err := os.Symlink(targetDir, alias); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	prompts := 0
+	tool, err := New(workspace, true, WithOutsideWorkspaceApprover(func(context.Context, fsguard.Request) (fsguard.Approval, error) {
+		prompts++
+		return fsguard.Approval{Decision: fsguard.DecisionAllowOnce}, nil
+	}))
+	if err != nil {
+		t.Fatalf("new edit tool: %v", err)
+	}
+
+	result := callEdit(t, tool, map[string]any{"path": filepath.Join(alias, "new.txt"), "old_string": "", "new_string": "new\n"})
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+	if prompts != 1 {
+		t.Fatalf("outside approval prompts = %d, want 1", prompts)
+	}
+	got, err := os.ReadFile(filepath.Join(targetDir, "new.txt"))
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "new\n" {
+		t.Fatalf("target content = %q", string(got))
+	}
+}
+
 func TestOutsideWorkspaceFinalSymlinkRequiresRealPathApproval(t *testing.T) {
 	workspace := t.TempDir()
 	outside := newNonTemporaryOutsideDir(t)

--- a/server/tools/edit/tool_test.go
+++ b/server/tools/edit/tool_test.go
@@ -1,0 +1,208 @@
+package edit
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"builder/server/tools"
+	"builder/shared/toolspec"
+)
+
+func TestCreateMissingFileReturnsJSONStringAndDiff(t *testing.T) {
+	dir := t.TempDir()
+	tool := newTestTool(t, dir)
+
+	result := callEdit(t, tool, map[string]any{
+		"path":       "nested/a.txt",
+		"old_string": "",
+		"new_string": "hello\n",
+	})
+
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+	assertJSONText(t, result.Output, "ok")
+	got, err := os.ReadFile(filepath.Join(dir, "nested", "a.txt"))
+	if err != nil {
+		t.Fatalf("read created file: %v", err)
+	}
+	if string(got) != "hello\n" {
+		t.Fatalf("created content = %q", string(got))
+	}
+	if result.Presentation == nil || result.Presentation.PatchRender == nil {
+		t.Fatalf("expected result diff metadata, got %+v", result.Presentation)
+	}
+	if summary := result.Presentation.PatchRender.SummaryText(); !strings.Contains(summary, "nested/a.txt") || !strings.Contains(summary, "+1") {
+		t.Fatalf("unexpected diff summary: %q", summary)
+	}
+}
+
+func TestExactReplaceAndReplaceAll(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(target, []byte("one two one\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	tool := newTestTool(t, dir)
+
+	first := callEdit(t, tool, map[string]any{
+		"path":       "a.txt",
+		"old_string": "one",
+		"new_string": "ONE",
+	})
+	if !first.IsError || !strings.Contains(toolResultText(t, first), "multiple occurrences") {
+		t.Fatalf("expected multiple occurrence failure, got %+v text=%q", first, toolResultText(t, first))
+	}
+
+	second := callEdit(t, tool, map[string]any{
+		"path":        "a.txt",
+		"old_string":  "one",
+		"new_string":  "ONE",
+		"replace_all": true,
+	})
+	if second.IsError {
+		t.Fatalf("expected success, got %s", string(second.Output))
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read edited file: %v", err)
+	}
+	if string(data) != "ONE two ONE\n" {
+		t.Fatalf("edited content = %q", string(data))
+	}
+}
+
+func TestInputAliasesAndConflicts(t *testing.T) {
+	dir := t.TempDir()
+	tool := newTestTool(t, dir)
+
+	ok := callEdit(t, tool, map[string]any{
+		"filePath":   "a.txt",
+		"oldText":    "",
+		"newText":    "hello",
+		"replaceAll": true,
+	})
+	if ok.IsError {
+		t.Fatalf("expected alias success, got %s", string(ok.Output))
+	}
+
+	conflict := callEdit(t, tool, map[string]any{
+		"path":      "a.txt",
+		"file_path": "b.txt",
+		"oldText":   "",
+		"newText":   "hello",
+	})
+	if !conflict.IsError || !strings.Contains(toolResultText(t, conflict), "conflicting aliases") {
+		t.Fatalf("expected conflict failure, got %q", toolResultText(t, conflict))
+	}
+}
+
+func TestCreateRejectsNonEmptyAndAllowsWhitespaceOnly(t *testing.T) {
+	dir := t.TempDir()
+	nonEmpty := filepath.Join(dir, "non-empty.txt")
+	if err := os.WriteFile(nonEmpty, []byte("already\n"), 0o644); err != nil {
+		t.Fatalf("seed non-empty: %v", err)
+	}
+	blank := filepath.Join(dir, "blank.txt")
+	if err := os.WriteFile(blank, []byte("  \n\t"), 0o644); err != nil {
+		t.Fatalf("seed blank: %v", err)
+	}
+	tool := newTestTool(t, dir)
+
+	rejected := callEdit(t, tool, map[string]any{"path": "non-empty.txt", "old_string": "", "new_string": "new"})
+	if !rejected.IsError || !strings.Contains(toolResultText(t, rejected), "already contains text") {
+		t.Fatalf("expected non-empty rejection, got %q", toolResultText(t, rejected))
+	}
+	allowed := callEdit(t, tool, map[string]any{"path": "blank.txt", "old_string": "", "new_string": "new"})
+	if allowed.IsError {
+		t.Fatalf("expected blank replacement success, got %s", string(allowed.Output))
+	}
+	got, err := os.ReadFile(blank)
+	if err != nil {
+		t.Fatalf("read blank replacement: %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("blank replacement = %q", string(got))
+	}
+}
+
+func TestEncodingAndBinaryGuards(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "nul.txt"), []byte{'a', 0, 'b'}, 0o644); err != nil {
+		t.Fatalf("seed nul: %v", err)
+	}
+	tool := newTestTool(t, dir)
+
+	nul := callEdit(t, tool, map[string]any{"path": "nul.txt", "old_string": "a", "new_string": "b"})
+	if !nul.IsError || !strings.Contains(toolResultText(t, nul), "binary file rejected") {
+		t.Fatalf("expected binary rejection, got %q", toolResultText(t, nul))
+	}
+	png := callEdit(t, tool, map[string]any{"path": "image.png", "old_string": "", "new_string": "text"})
+	if !png.IsError || !strings.Contains(toolResultText(t, png), "binary file extension") {
+		t.Fatalf("expected extension rejection, got %q", toolResultText(t, png))
+	}
+}
+
+func TestDeletionIncludesFollowingNewlineAfterUniqueness(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(target, []byte("before\nremove me\nafter\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	tool := newTestTool(t, dir)
+
+	result := callEdit(t, tool, map[string]any{"path": "a.txt", "old_string": "remove me", "new_string": ""})
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read edited file: %v", err)
+	}
+	if string(got) != "before\nafter\n" {
+		t.Fatalf("deleted content = %q", string(got))
+	}
+}
+
+func newTestTool(t *testing.T, dir string) *Tool {
+	t.Helper()
+	tool, err := New(dir, true)
+	if err != nil {
+		t.Fatalf("new edit tool: %v", err)
+	}
+	return tool
+}
+
+func callEdit(t *testing.T, tool *Tool, payload map[string]any) tools.Result {
+	t.Helper()
+	input, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal input: %v", err)
+	}
+	result, err := tool.Call(context.Background(), tools.Call{ID: "call", Name: toolspec.ToolEdit, Input: input})
+	if err != nil {
+		t.Fatalf("edit call error: %v", err)
+	}
+	return result
+}
+
+func toolResultText(t *testing.T, result tools.Result) string {
+	t.Helper()
+	var text string
+	if err := json.Unmarshal(result.Output, &text); err != nil {
+		t.Fatalf("decode result output: %v", err)
+	}
+	return text
+}
+
+func assertJSONText(t *testing.T, raw json.RawMessage, want string) {
+	t.Helper()
+	got := toolResultText(t, tools.Result{Output: raw})
+	if got != want {
+		t.Fatalf("result output = %q, want %q", got, want)
+	}
+}

--- a/server/tools/edit/tool_test.go
+++ b/server/tools/edit/tool_test.go
@@ -55,7 +55,7 @@ func TestExactReplaceAndReplaceAll(t *testing.T) {
 		"old_string": "one",
 		"new_string": "ONE",
 	})
-	if !first.IsError || !strings.Contains(toolResultText(t, first), "multiple occurrences") {
+	if !first.IsError || !strings.Contains(toolResultText(t, first), "matched 2 occurrences") {
 		t.Fatalf("expected multiple occurrence failure, got %+v text=%q", first, toolResultText(t, first))
 	}
 
@@ -195,20 +195,62 @@ func TestContextAwareFallbackRejectsCommonMiddleLineWithoutBoundaryMatch(t *test
 	}
 }
 
-func TestOutsideWorkspaceSymlinkAliasUsesSingleCallApproval(t *testing.T) {
+func TestContextAwareFallbackAcceptsNormalizedBoundaryAndMiddleLines(t *testing.T) {
+	content := "alpha   beta\nTODO item\nomega   tail\n"
+	old := "alpha beta\nTODO item\nomega tail\n"
+
+	matches := contextAwareMatches(content, old)
+	if len(matches) != 1 {
+		t.Fatalf("context-aware matches = %d, want 1", len(matches))
+	}
+	if matches[0].actual != content {
+		t.Fatalf("matched actual = %q, want %q", matches[0].actual, content)
+	}
+}
+
+func TestOutsideWorkspaceAncestorAliasUsesSingleCallApproval(t *testing.T) {
 	workspace := t.TempDir()
-	outside, err := os.MkdirTemp(".", "edit-outside-approval-")
+	outside := newNonTemporaryOutsideDir(t)
+	targetDir := filepath.Join(outside, "target")
+	if err := os.Mkdir(targetDir, 0o755); err != nil {
+		t.Fatalf("create outside target dir: %v", err)
+	}
+	target := filepath.Join(targetDir, "target.txt")
+	if err := os.WriteFile(target, []byte("old\n"), 0o644); err != nil {
+		t.Fatalf("seed outside target: %v", err)
+	}
+	alias := filepath.Join(outside, "alias")
+	if err := os.Symlink(targetDir, alias); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	prompts := 0
+	tool, err := New(workspace, true, WithOutsideWorkspaceApprover(func(context.Context, fsguard.Request) (fsguard.Approval, error) {
+		prompts++
+		return fsguard.Approval{Decision: fsguard.DecisionAllowOnce}, nil
+	}))
 	if err != nil {
-		t.Fatalf("create outside dir: %v", err)
+		t.Fatalf("new edit tool: %v", err)
 	}
-	t.Cleanup(func() { _ = os.RemoveAll(outside) })
-	outside, err = filepath.Abs(outside)
+
+	result := callEdit(t, tool, map[string]any{"path": filepath.Join(alias, "target.txt"), "old_string": "old", "new_string": "new"})
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+	if prompts != 1 {
+		t.Fatalf("outside approval prompts = %d, want 1", prompts)
+	}
+	got, err := os.ReadFile(target)
 	if err != nil {
-		t.Fatalf("resolve outside dir: %v", err)
+		t.Fatalf("read target: %v", err)
 	}
-	if filepath.IsAbs(outside) && strings.Contains(outside, string(filepath.Separator)+"tmp"+string(filepath.Separator)) {
-		t.Skip("test outside dir is under temporary editable root")
+	if string(got) != "new\n" {
+		t.Fatalf("target content = %q", string(got))
 	}
+}
+
+func TestOutsideWorkspaceFinalSymlinkRequiresRealPathApproval(t *testing.T) {
+	workspace := t.TempDir()
+	outside := newNonTemporaryOutsideDir(t)
 	target := filepath.Join(outside, "target.txt")
 	if err := os.WriteFile(target, []byte("old\n"), 0o644); err != nil {
 		t.Fatalf("seed outside target: %v", err)
@@ -230,16 +272,26 @@ func TestOutsideWorkspaceSymlinkAliasUsesSingleCallApproval(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("expected success, got %s", string(result.Output))
 	}
-	if prompts != 1 {
-		t.Fatalf("outside approval prompts = %d, want 1", prompts)
+	if prompts != 2 {
+		t.Fatalf("outside approval prompts = %d, want 2", prompts)
 	}
-	got, err := os.ReadFile(target)
+}
+
+func newNonTemporaryOutsideDir(t *testing.T) string {
+	t.Helper()
+	outside, err := os.MkdirTemp(".", "edit-outside-approval-")
 	if err != nil {
-		t.Fatalf("read target: %v", err)
+		t.Fatalf("create outside dir: %v", err)
 	}
-	if string(got) != "new\n" {
-		t.Fatalf("target content = %q", string(got))
+	t.Cleanup(func() { _ = os.RemoveAll(outside) })
+	outside, err = filepath.Abs(outside)
+	if err != nil {
+		t.Fatalf("resolve outside dir: %v", err)
 	}
+	if filepath.IsAbs(outside) && strings.Contains(outside, string(filepath.Separator)+"tmp"+string(filepath.Separator)) {
+		t.Skip("test outside dir is under temporary editable root")
+	}
+	return outside
 }
 
 func newTestTool(t *testing.T, dir string) *Tool {

--- a/server/tools/edit/tool_test.go
+++ b/server/tools/edit/tool_test.go
@@ -218,6 +218,13 @@ func TestContextAwareFallbackAcceptsNormalizedBoundaryAndMiddleLines(t *testing.
 	}
 }
 
+func TestPreserveCurlyQuotesKeepsOpeningSingleQuote(t *testing.T) {
+	got := preserveCurlyQuotes("‘old’", "'new'")
+	if got != "‘new’" {
+		t.Fatalf("preserved quote replacement = %q, want %q", got, "‘new’")
+	}
+}
+
 func TestOutsideWorkspaceAncestorAliasUsesSingleCallApproval(t *testing.T) {
 	workspace := t.TempDir()
 	outside := newNonTemporaryOutsideDir(t)

--- a/server/tools/edit/tool_test.go
+++ b/server/tools/edit/tool_test.go
@@ -195,6 +195,16 @@ func TestContextAwareFallbackRejectsCommonMiddleLineWithoutBoundaryMatch(t *test
 	}
 }
 
+func TestContextAwareFallbackRejectsMismatchedInteriorLines(t *testing.T) {
+	content := "header\nkeep one\nTODO\nkeep two\nfooter\n"
+	old := "header\nwant one\nTODO\nwant two\nfooter\n"
+
+	matches := contextAwareMatches(content, old)
+	if len(matches) != 0 {
+		t.Fatalf("context-aware matches = %+v, want none", matches)
+	}
+}
+
 func TestContextAwareFallbackAcceptsNormalizedBoundaryAndMiddleLines(t *testing.T) {
 	content := "alpha   beta\nTODO item\nomega   tail\n"
 	old := "alpha beta\nTODO item\nomega tail\n"

--- a/server/tools/fsguard/guard.go
+++ b/server/tools/fsguard/guard.go
@@ -141,7 +141,7 @@ func (g Guard) Allow(ctx context.Context, requestedPath string, resolvedPath str
 		if g.failures.UserDenied != nil {
 			return "", g.failures.UserDenied(req, approval, g.rejectionInstruction)
 		}
-		return "", g.userDenied(requestedPath, approval.Commentary)
+		return "", g.userDenied(requestedPath, approval.Commentary, g.rejectionInstruction)
 	}
 }
 
@@ -199,14 +199,18 @@ func (g Guard) approvalFailed(path, reason string) error {
 	return fmt.Errorf("file edit approval failed for %s: %s", path, reason)
 }
 
-func (g Guard) userDenied(path, commentary string) error {
+func (g Guard) userDenied(path, commentary string, instruction string) error {
 	if g.failures.DefaultUserDenied != nil {
 		return g.failures.DefaultUserDenied(path, commentary)
 	}
-	if strings.TrimSpace(commentary) == "" {
-		return fmt.Errorf("user denied edit for %s", path)
+	message := fmt.Sprintf("user denied edit for %s", path)
+	if strings.TrimSpace(commentary) != "" {
+		message += ": " + strings.TrimSpace(commentary)
 	}
-	return fmt.Errorf("user denied edit for %s: %s", path, commentary)
+	if strings.TrimSpace(instruction) != "" {
+		message += ": " + strings.TrimSpace(instruction)
+	}
+	return errors.New(message)
 }
 
 func (g Guard) logApproved(req Request, reason string) {

--- a/server/tools/fsguard/guard.go
+++ b/server/tools/fsguard/guard.go
@@ -162,7 +162,15 @@ func (g Guard) isWithinWorkspace(real string) (bool, error) {
 	for {
 		info, statErr := os.Stat(current)
 		if statErr != nil {
-			return false, fmt.Errorf("stat candidate path %q: %w", current, statErr)
+			if !errors.Is(statErr, os.ErrNotExist) {
+				return false, fmt.Errorf("stat candidate path %q: %w", current, statErr)
+			}
+			next := filepath.Dir(current)
+			if next == current {
+				return false, fmt.Errorf("stat candidate path %q: %w", real, statErr)
+			}
+			current = next
+			continue
 		}
 		if os.SameFile(info, g.workspaceRootInfo) {
 			return true, nil

--- a/server/tools/fsguard/guard.go
+++ b/server/tools/fsguard/guard.go
@@ -1,0 +1,208 @@
+package fsguard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type ErrorLabels struct {
+	OutsidePath          string
+	ApprovalFailed       string
+	RejectedByUserPrefix string
+}
+
+type FailureFactory struct {
+	ApprovalFailed        func(Request, error) error
+	UserDenied            func(Request, Approval, string) error
+	NoPermission          func(string, string) error
+	DefaultApprovalFailed func(string, string) error
+	DefaultUserDenied     func(string, string) error
+}
+
+type Request struct {
+	RequestedPath string
+	ResolvedPath  string
+	WorkspaceRoot string
+}
+
+type Decision int
+
+const (
+	DecisionDeny Decision = iota
+	DecisionAllowOnce
+	DecisionAllowSession
+)
+
+type Approval struct {
+	Decision   Decision
+	Commentary string
+}
+
+type Approver func(context.Context, Request) (Approval, error)
+
+type Guard struct {
+	workspaceRoot         string
+	workspaceRootReal     string
+	workspaceRootInfo     os.FileInfo
+	workspaceOnly         bool
+	allowOutsideWorkspace bool
+	approver              Approver
+	sessionAllowed        func() bool
+	setSessionAllowed     func(bool)
+	rejectionInstruction  string
+	errorLabels           ErrorLabels
+	failures              FailureFactory
+	temporaryPathAllowed  func(string) bool
+	onApproved            func(Request, string)
+}
+
+func New(workspaceRoot string, workspaceRootReal string, workspaceRootInfo os.FileInfo, workspaceOnly bool, allowOutsideWorkspace bool, approver Approver, sessionAllowed func() bool, setSessionAllowed func(bool), rejectionInstruction string, errorLabels ErrorLabels, failures FailureFactory, temporaryPathAllowed func(string) bool, onApproved func(Request, string)) Guard {
+	return Guard{
+		workspaceRoot:         workspaceRoot,
+		workspaceRootReal:     workspaceRootReal,
+		workspaceRootInfo:     workspaceRootInfo,
+		workspaceOnly:         workspaceOnly,
+		allowOutsideWorkspace: allowOutsideWorkspace,
+		approver:              approver,
+		sessionAllowed:        sessionAllowed,
+		setSessionAllowed:     setSessionAllowed,
+		rejectionInstruction:  rejectionInstruction,
+		errorLabels:           errorLabels,
+		failures:              failures,
+		temporaryPathAllowed:  temporaryPathAllowed,
+		onApproved:            onApproved,
+	}
+}
+
+func (g Guard) Allow(ctx context.Context, requestedPath string, resolvedPath string, approvedOutside map[string]bool) (string, error) {
+	if !g.workspaceOnly {
+		return resolvedPath, nil
+	}
+	insideWorkspace, containmentErr := g.isWithinWorkspace(resolvedPath)
+	if containmentErr != nil {
+		return "", fmt.Errorf("workspace boundary check for %q: %w", requestedPath, containmentErr)
+	}
+	if insideWorkspace {
+		return resolvedPath, nil
+	}
+
+	req := Request{
+		RequestedPath: requestedPath,
+		ResolvedPath:  resolvedPath,
+		WorkspaceRoot: g.workspaceRoot,
+	}
+	if g.temporaryPathAllowed != nil && g.temporaryPathAllowed(resolvedPath) {
+		g.logApproved(req, "temporary_allow")
+		return resolvedPath, nil
+	}
+	if g.allowOutsideWorkspace {
+		g.logApproved(req, "configured_allow")
+		return resolvedPath, nil
+	}
+	if g.sessionAllowed != nil && g.sessionAllowed() {
+		g.logApproved(req, "session_allow")
+		return resolvedPath, nil
+	}
+	if approvedOutside != nil && approvedOutside[resolvedPath] {
+		g.logApproved(req, "call_allow")
+		return resolvedPath, nil
+	}
+	if g.approver == nil {
+		return "", g.noPermission(requestedPath, g.errorLabels.OutsidePath)
+	}
+	approval, approveErr := g.approver(ctx, req)
+	if approveErr != nil {
+		if g.failures.ApprovalFailed != nil {
+			return "", g.failures.ApprovalFailed(req, approveErr)
+		}
+		return "", g.approvalFailed(requestedPath, approveErr.Error())
+	}
+	switch approval.Decision {
+	case DecisionAllowOnce:
+		if approvedOutside != nil {
+			approvedOutside[resolvedPath] = true
+		}
+		g.logApproved(req, "allow_once")
+		return resolvedPath, nil
+	case DecisionAllowSession:
+		if g.setSessionAllowed != nil {
+			g.setSessionAllowed(true)
+		}
+		if approvedOutside != nil {
+			approvedOutside[resolvedPath] = true
+		}
+		g.logApproved(req, "allow_session")
+		return resolvedPath, nil
+	default:
+		if g.failures.UserDenied != nil {
+			return "", g.failures.UserDenied(req, approval, g.rejectionInstruction)
+		}
+		return "", g.userDenied(requestedPath, approval.Commentary)
+	}
+}
+
+func (g Guard) isWithinWorkspace(real string) (bool, error) {
+	rel, relErr := filepath.Rel(g.workspaceRootReal, real)
+	if relErr == nil {
+		if rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	if g.workspaceRootInfo == nil {
+		return false, errors.New("workspace root info unavailable")
+	}
+
+	current := real
+	for {
+		info, statErr := os.Stat(current)
+		if statErr != nil {
+			return false, fmt.Errorf("stat candidate path %q: %w", current, statErr)
+		}
+		if os.SameFile(info, g.workspaceRootInfo) {
+			return true, nil
+		}
+		next := filepath.Dir(current)
+		if next == current {
+			break
+		}
+		current = next
+	}
+
+	return false, nil
+}
+
+func (g Guard) noPermission(path, reason string) error {
+	if g.failures.NoPermission != nil {
+		return g.failures.NoPermission(path, reason)
+	}
+	return fmt.Errorf("no file edit permission for %s: %s", path, reason)
+}
+
+func (g Guard) approvalFailed(path, reason string) error {
+	if g.failures.DefaultApprovalFailed != nil {
+		return g.failures.DefaultApprovalFailed(path, reason)
+	}
+	return fmt.Errorf("file edit approval failed for %s: %s", path, reason)
+}
+
+func (g Guard) userDenied(path, commentary string) error {
+	if g.failures.DefaultUserDenied != nil {
+		return g.failures.DefaultUserDenied(path, commentary)
+	}
+	if strings.TrimSpace(commentary) == "" {
+		return fmt.Errorf("user denied edit for %s", path)
+	}
+	return fmt.Errorf("user denied edit for %s: %s", path, commentary)
+}
+
+func (g Guard) logApproved(req Request, reason string) {
+	if g.onApproved != nil {
+		g.onApproved(req, reason)
+	}
+}

--- a/server/tools/fsguard/guard_test.go
+++ b/server/tools/fsguard/guard_test.go
@@ -1,0 +1,47 @@
+package fsguard
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultUserDeniedIncludesRejectionInstruction(t *testing.T) {
+	workspace := t.TempDir()
+	real, err := filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatalf("resolve workspace: %v", err)
+	}
+	info, err := os.Stat(real)
+	if err != nil {
+		t.Fatalf("stat workspace: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	guard := New(
+		workspace,
+		real,
+		info,
+		true,
+		false,
+		func(context.Context, Request) (Approval, error) {
+			return Approval{Decision: DecisionDeny, Commentary: "no"}, nil
+		},
+		nil,
+		nil,
+		"ask user for a safe path",
+		ErrorLabels{OutsidePath: "outside"},
+		FailureFactory{},
+		nil,
+		nil,
+	)
+
+	_, err = guard.Allow(context.Background(), outside, outside, nil)
+	if err == nil {
+		t.Fatal("expected denial error")
+	}
+	if got := err.Error(); !strings.Contains(got, "no") || !strings.Contains(got, "ask user for a safe path") {
+		t.Fatalf("denial error = %q, want commentary and instruction", got)
+	}
+}

--- a/server/tools/fsguard/locks.go
+++ b/server/tools/fsguard/locks.go
@@ -1,6 +1,7 @@
 package fsguard
 
 import (
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -9,7 +10,8 @@ import (
 var pathLocks sync.Map
 
 func LockPath(path string) func() {
-	value, _ := pathLocks.LoadOrStore(path, &sync.Mutex{})
+	key := canonicalLockKey(path)
+	value, _ := pathLocks.LoadOrStore(key, &sync.Mutex{})
 	mu := value.(*sync.Mutex)
 	mu.Lock()
 	return mu.Unlock
@@ -22,15 +24,15 @@ func LockPaths(paths []string) func() {
 	seen := map[string]struct{}{}
 	ordered := make([]string, 0, len(paths))
 	for _, path := range paths {
-		trimmed := strings.TrimSpace(path)
-		if trimmed == "" {
+		key := canonicalLockKey(path)
+		if key == "" {
 			continue
 		}
-		if _, ok := seen[trimmed]; ok {
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[trimmed] = struct{}{}
-		ordered = append(ordered, trimmed)
+		seen[key] = struct{}{}
+		ordered = append(ordered, key)
 	}
 	sort.Strings(ordered)
 	unlocks := make([]func(), 0, len(ordered))
@@ -42,4 +44,15 @@ func LockPaths(paths []string) func() {
 			unlocks[i]()
 		}
 	}
+}
+
+func canonicalLockKey(path string) string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return ""
+	}
+	if abs, err := filepath.Abs(trimmed); err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(trimmed)
 }

--- a/server/tools/fsguard/locks.go
+++ b/server/tools/fsguard/locks.go
@@ -11,6 +11,9 @@ var pathLocks sync.Map
 
 func LockPath(path string) func() {
 	key := canonicalLockKey(path)
+	if key == "" {
+		return func() {}
+	}
 	value, _ := pathLocks.LoadOrStore(key, &sync.Mutex{})
 	mu := value.(*sync.Mutex)
 	mu.Lock()

--- a/server/tools/fsguard/locks.go
+++ b/server/tools/fsguard/locks.go
@@ -1,0 +1,45 @@
+package fsguard
+
+import (
+	"sort"
+	"strings"
+	"sync"
+)
+
+var pathLocks sync.Map
+
+func LockPath(path string) func() {
+	value, _ := pathLocks.LoadOrStore(path, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
+func LockPaths(paths []string) func() {
+	if len(paths) == 0 {
+		return func() {}
+	}
+	seen := map[string]struct{}{}
+	ordered := make([]string, 0, len(paths))
+	for _, path := range paths {
+		trimmed := strings.TrimSpace(path)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		ordered = append(ordered, trimmed)
+	}
+	sort.Strings(ordered)
+	unlocks := make([]func(), 0, len(ordered))
+	for _, path := range ordered {
+		unlocks = append(unlocks, LockPath(path))
+	}
+	return func() {
+		for i := len(unlocks) - 1; i >= 0; i-- {
+			unlocks[i]()
+		}
+	}
+}

--- a/server/tools/fsguard/locks_test.go
+++ b/server/tools/fsguard/locks_test.go
@@ -38,3 +38,24 @@ func TestLockPathsDoesNotBlockUnrelatedPaths(t *testing.T) {
 		t.Fatal("same path lock did not unblock")
 	}
 }
+
+func TestLockPathsNormalizesEquivalentPaths(t *testing.T) {
+	unlockA := LockPaths([]string{"a/../x"})
+	same := make(chan struct{})
+	go func() {
+		unlockB := LockPaths([]string{"./x"})
+		unlockB()
+		close(same)
+	}()
+	select {
+	case <-same:
+		t.Fatal("equivalent path lock did not block")
+	case <-time.After(50 * time.Millisecond):
+	}
+	unlockA()
+	select {
+	case <-same:
+	case <-time.After(time.Second):
+		t.Fatal("equivalent path lock did not unblock")
+	}
+}

--- a/server/tools/fsguard/locks_test.go
+++ b/server/tools/fsguard/locks_test.go
@@ -59,3 +59,19 @@ func TestLockPathsNormalizesEquivalentPaths(t *testing.T) {
 		t.Fatal("equivalent path lock did not unblock")
 	}
 }
+
+func TestLockPathEmptyKeyIsNoop(t *testing.T) {
+	unlock := LockPath(" \t")
+	done := make(chan struct{})
+	go func() {
+		unlockB := LockPath("")
+		unlockB()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("empty lock path blocked")
+	}
+	unlock()
+}

--- a/server/tools/fsguard/locks_test.go
+++ b/server/tools/fsguard/locks_test.go
@@ -1,0 +1,40 @@
+package fsguard
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLockPathsDoesNotBlockUnrelatedPaths(t *testing.T) {
+	unlockA := LockPaths([]string{"a"})
+
+	unrelated := make(chan struct{})
+	go func() {
+		unlockB := LockPaths([]string{"b"})
+		unlockB()
+		close(unrelated)
+	}()
+	select {
+	case <-unrelated:
+	case <-time.After(time.Second):
+		t.Fatal("unrelated path lock blocked")
+	}
+
+	same := make(chan struct{})
+	go func() {
+		unlockA2 := LockPaths([]string{"a"})
+		unlockA2()
+		close(same)
+	}()
+	select {
+	case <-same:
+		t.Fatal("same path lock did not block")
+	case <-time.After(50 * time.Millisecond):
+	}
+	unlockA()
+	select {
+	case <-same:
+	case <-time.After(time.Second):
+		t.Fatal("same path lock did not unblock")
+	}
+}

--- a/server/tools/patch/outside_workspace_guard.go
+++ b/server/tools/patch/outside_workspace_guard.go
@@ -1,160 +1,42 @@
 package patch
 
 import (
-	"context"
-	"errors"
-	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
+
+	"builder/server/tools/fsguard"
 )
 
-type OutsideWorkspaceErrorLabels struct {
-	OutsidePath          string
-	ApprovalFailed       string
-	RejectedByUserPrefix string
-}
-
-type OutsideWorkspaceFailureFactory struct {
-	ApprovalFailed func(OutsideWorkspaceRequest, error) error
-	UserDenied     func(OutsideWorkspaceRequest, OutsideWorkspaceApproval, string) error
-}
-
-type OutsideWorkspaceGuard struct {
-	workspaceRoot         string
-	workspaceRootReal     string
-	workspaceRootInfo     os.FileInfo
-	workspaceOnly         bool
-	allowOutsideWorkspace bool
-	approver              OutsideWorkspaceApprover
-	sessionAllowed        func() bool
-	setSessionAllowed     func(bool)
-	rejectionInstruction  string
-	errorLabels           OutsideWorkspaceErrorLabels
-	failures              OutsideWorkspaceFailureFactory
-	temporaryPathAllowed  func(string) bool
-	onApproved            func(OutsideWorkspaceRequest, string)
-}
+type OutsideWorkspaceErrorLabels = fsguard.ErrorLabels
+type OutsideWorkspaceFailureFactory = fsguard.FailureFactory
+type OutsideWorkspaceGuard = fsguard.Guard
 
 func NewOutsideWorkspaceGuard(workspaceRoot string, workspaceRootReal string, workspaceRootInfo os.FileInfo, workspaceOnly bool, allowOutsideWorkspace bool, approver OutsideWorkspaceApprover, sessionAllowed func() bool, setSessionAllowed func(bool), rejectionInstruction string, errorLabels OutsideWorkspaceErrorLabels, failures OutsideWorkspaceFailureFactory, temporaryPathAllowed func(string) bool, onApproved func(OutsideWorkspaceRequest, string)) OutsideWorkspaceGuard {
-	return OutsideWorkspaceGuard{
-		workspaceRoot:         workspaceRoot,
-		workspaceRootReal:     workspaceRootReal,
-		workspaceRootInfo:     workspaceRootInfo,
-		workspaceOnly:         workspaceOnly,
-		allowOutsideWorkspace: allowOutsideWorkspace,
-		approver:              approver,
-		sessionAllowed:        sessionAllowed,
-		setSessionAllowed:     setSessionAllowed,
-		rejectionInstruction:  rejectionInstruction,
-		errorLabels:           errorLabels,
-		failures:              failures,
-		temporaryPathAllowed:  temporaryPathAllowed,
-		onApproved:            onApproved,
+	if failures.NoPermission == nil {
+		failures.NoPermission = noPermissionFailure
 	}
-}
-
-func (g OutsideWorkspaceGuard) Allow(ctx context.Context, requestedPath string, resolvedPath string, approvedOutside map[string]bool) (string, error) {
-	if !g.workspaceOnly {
-		return resolvedPath, nil
+	if failures.DefaultApprovalFailed == nil {
+		failures.DefaultApprovalFailed = approvalFailedFailure
 	}
-	insideWorkspace, containmentErr := g.isWithinWorkspace(resolvedPath)
-	if containmentErr != nil {
-		return "", fmt.Errorf("workspace boundary check for %q: %w", requestedPath, containmentErr)
+	if failures.DefaultUserDenied == nil {
+		failures.DefaultUserDenied = userDeniedFailure
 	}
-	if insideWorkspace {
-		return resolvedPath, nil
-	}
-
-	req := OutsideWorkspaceRequest{
-		RequestedPath: requestedPath,
-		ResolvedPath:  resolvedPath,
-		WorkspaceRoot: g.workspaceRoot,
-	}
-	if g.temporaryPathAllowed != nil && g.temporaryPathAllowed(resolvedPath) {
-		g.logApproved(req, "temporary_allow")
-		return resolvedPath, nil
-	}
-	if g.allowOutsideWorkspace {
-		g.logApproved(req, "configured_allow")
-		return resolvedPath, nil
-	}
-	if g.sessionAllowed != nil && g.sessionAllowed() {
-		g.logApproved(req, "session_allow")
-		return resolvedPath, nil
-	}
-	if approvedOutside != nil && approvedOutside[resolvedPath] {
-		g.logApproved(req, "call_allow")
-		return resolvedPath, nil
-	}
-	if g.approver == nil {
-		return "", noPermissionFailure(requestedPath, g.errorLabels.OutsidePath)
-	}
-	approval, approveErr := g.approver(ctx, req)
-	if approveErr != nil {
-		if g.failures.ApprovalFailed != nil {
-			return "", g.failures.ApprovalFailed(req, approveErr)
-		}
-		return "", approvalFailedFailure(requestedPath, approveErr.Error())
-	}
-	switch approval.Decision {
-	case OutsideWorkspaceDecisionAllowOnce:
-		if approvedOutside != nil {
-			approvedOutside[resolvedPath] = true
-		}
-		g.logApproved(req, "allow_once")
-		return resolvedPath, nil
-	case OutsideWorkspaceDecisionAllowSession:
-		if g.setSessionAllowed != nil {
-			g.setSessionAllowed(true)
-		}
-		if approvedOutside != nil {
-			approvedOutside[resolvedPath] = true
-		}
-		g.logApproved(req, "allow_session")
-		return resolvedPath, nil
-	default:
-		if g.failures.UserDenied != nil {
-			return "", g.failures.UserDenied(req, approval, g.rejectionInstruction)
-		}
-		return "", userDeniedFailure(requestedPath, approval.Commentary)
-	}
-}
-
-func (g OutsideWorkspaceGuard) isWithinWorkspace(real string) (bool, error) {
-	rel, relErr := filepath.Rel(g.workspaceRootReal, real)
-	if relErr == nil {
-		if rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
-			return true, nil
-		}
-		return false, nil
-	}
-
-	if g.workspaceRootInfo == nil {
-		return false, errors.New("workspace root info unavailable")
-	}
-
-	current := real
-	for {
-		info, statErr := os.Stat(current)
-		if statErr != nil {
-			return false, fmt.Errorf("stat candidate path %q: %w", current, statErr)
-		}
-		if os.SameFile(info, g.workspaceRootInfo) {
-			return true, nil
-		}
-		next := filepath.Dir(current)
-		if next == current {
-			break
-		}
-		current = next
-	}
-
-	return false, nil
-}
-
-func (g OutsideWorkspaceGuard) logApproved(req OutsideWorkspaceRequest, reason string) {
-	if g.onApproved != nil {
-		g.onApproved(req, reason)
-	}
+	return fsguard.New(
+		workspaceRoot,
+		workspaceRootReal,
+		workspaceRootInfo,
+		workspaceOnly,
+		allowOutsideWorkspace,
+		fsguard.Approver(approver),
+		sessionAllowed,
+		setSessionAllowed,
+		rejectionInstruction,
+		errorLabels,
+		failures,
+		temporaryPathAllowed,
+		func(req fsguard.Request, reason string) {
+			if onApproved != nil {
+				onApproved(req, reason)
+			}
+		},
+	)
 }

--- a/server/tools/patch/tool.go
+++ b/server/tools/patch/tool.go
@@ -84,6 +84,11 @@ func (t *Tool) Call(ctx context.Context, c tools.Call) (tools.Result, error) {
 
 func (t *Tool) apply(ctx context.Context, doc patchformat.Document) error {
 	state := newApplyState(t, ctx)
+	unlock, err := state.lockDocumentPaths(doc)
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	for _, h := range doc.Hunks {
 		switch op := h.(type) {
 		case patchformat.AddFile:

--- a/server/tools/patch/tool_paths.go
+++ b/server/tools/patch/tool_paths.go
@@ -7,28 +7,21 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"builder/server/tools/fsguard"
 )
 
-type OutsideWorkspaceRequest struct {
-	RequestedPath string
-	ResolvedPath  string
-	WorkspaceRoot string
-}
-
-type OutsideWorkspaceDecision int
+type OutsideWorkspaceRequest = fsguard.Request
+type OutsideWorkspaceDecision = fsguard.Decision
 
 const (
-	OutsideWorkspaceDecisionDeny OutsideWorkspaceDecision = iota
-	OutsideWorkspaceDecisionAllowOnce
-	OutsideWorkspaceDecisionAllowSession
+	OutsideWorkspaceDecisionDeny         = fsguard.DecisionDeny
+	OutsideWorkspaceDecisionAllowOnce    = fsguard.DecisionAllowOnce
+	OutsideWorkspaceDecisionAllowSession = fsguard.DecisionAllowSession
 )
 
-type OutsideWorkspaceApproval struct {
-	Decision   OutsideWorkspaceDecision
-	Commentary string
-}
-
-type OutsideWorkspaceApprover func(context.Context, OutsideWorkspaceRequest) (OutsideWorkspaceApproval, error)
+type OutsideWorkspaceApproval = fsguard.Approval
+type OutsideWorkspaceApprover = fsguard.Approver
 
 type Option func(*Tool)
 

--- a/server/tools/patch/tool_state.go
+++ b/server/tools/patch/tool_state.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"builder/server/tools/fsguard"
 	patchformat "builder/shared/transcript/patchformat"
 )
 
@@ -49,6 +50,43 @@ func (s *applyState) hasDeletedAncestor(path string) bool {
 
 func (s *applyState) resolve(path string, mustExist bool) (string, error) {
 	return s.tool.resolvePath(s.ctx, path, mustExist, s.approvedOutside)
+}
+
+func (s *applyState) lockDocumentPaths(doc patchformat.Document) (func(), error) {
+	paths := make([]string, 0, len(doc.Hunks))
+	addPath := func(raw string, mustExist bool) error {
+		if strings.TrimSpace(raw) == "" {
+			return nil
+		}
+		resolved, err := s.resolve(raw, mustExist)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, resolved)
+		return nil
+	}
+	for _, hunk := range doc.Hunks {
+		switch op := hunk.(type) {
+		case patchformat.AddFile:
+			if err := addPath(op.Path, false); err != nil {
+				return nil, err
+			}
+		case patchformat.DeleteFile:
+			if err := addPath(op.Path, true); err != nil {
+				return nil, err
+			}
+		case patchformat.UpdateFile:
+			if err := addPath(op.Path, false); err != nil {
+				return nil, err
+			}
+			if strings.TrimSpace(op.MoveTo) != "" {
+				if err := addPath(op.MoveTo, false); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return fsguard.LockPaths(paths), nil
 }
 
 func (s *applyState) getState(path string) (*patchFileState, error) {

--- a/server/tools/transcript_contracts.go
+++ b/server/tools/transcript_contracts.go
@@ -171,9 +171,9 @@ func patchToolCallMeta(toolID toolspec.ID) func(ToolCallContext, json.RawMessage
 func editToolCallMeta(toolID toolspec.ID) func(ToolCallContext, json.RawMessage) transcript.ToolCallMeta {
 	return func(ctx ToolCallContext, raw json.RawMessage) transcript.ToolCallMeta {
 		path := parseEditToolCallPath(raw)
-		command := "edit"
-		if path != "" {
-			command += " " + path
+		command := path
+		if command == "" {
+			command = "file change"
 		}
 		return transcript.ToolCallMeta{
 			ToolName:    string(toolID),

--- a/server/tools/transcript_contracts.go
+++ b/server/tools/transcript_contracts.go
@@ -168,6 +168,22 @@ func patchToolCallMeta(toolID toolspec.ID) func(ToolCallContext, json.RawMessage
 	}
 }
 
+func editToolCallMeta(toolID toolspec.ID) func(ToolCallContext, json.RawMessage) transcript.ToolCallMeta {
+	return func(ctx ToolCallContext, raw json.RawMessage) transcript.ToolCallMeta {
+		path := parseEditToolCallPath(raw)
+		command := "edit"
+		if path != "" {
+			command += " " + path
+		}
+		return transcript.ToolCallMeta{
+			ToolName:    string(toolID),
+			Command:     command,
+			CompactText: command,
+			RenderHint:  &transcript.ToolRenderHint{Kind: transcript.ToolRenderKindDiff},
+		}
+	}
+}
+
 func formatGenericToolResult(result Result) string {
 	output := strings.TrimSpace(formatOutputDefault(result.Output))
 	if output == "" {
@@ -313,6 +329,14 @@ func formatPatchToolResult(result Result) string {
 	return formatGenericToolResult(result)
 }
 
+func formatEditToolResult(result Result) string {
+	var message string
+	if err := json.Unmarshal(result.Output, &message); err == nil {
+		return strings.TrimSpace(message)
+	}
+	return formatGenericToolResult(result)
+}
+
 func formatViewImageToolResult(result Result) string {
 	if summary, ok := formatViewImageOutput(result.Output); ok {
 		return summary
@@ -432,6 +456,24 @@ func parsePatchToolCall(raw json.RawMessage, cwd string) (detail string, compact
 	}
 	r := patchformat.Render(patchText, cwd)
 	return r.DetailText(), r.SummaryText(), &r, true
+}
+
+func parseEditToolCallPath(raw json.RawMessage) string {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return ""
+	}
+	for _, name := range []string{"path", "file_path", "filePath"} {
+		rawValue, ok := obj[name]
+		if !ok {
+			continue
+		}
+		var value string
+		if err := json.Unmarshal(rawValue, &value); err == nil {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
 }
 
 func detectShellRenderHint(ctx ToolCallContext, toolID toolspec.ID, raw json.RawMessage, command string) *transcript.ToolRenderHint {

--- a/server/tools/types.go
+++ b/server/tools/types.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"builder/shared/toolspec"
+	"builder/shared/transcript"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -17,12 +18,13 @@ type Call struct {
 }
 
 type Result struct {
-	CallID      string          `json:"call_id"`
-	Name        toolspec.ID     `json:"name"`
-	Output      json.RawMessage `json:"output"`
-	IsError     bool            `json:"is_error"`
-	Summary     string          `json:"summary,omitempty"`
-	OngoingText string          `json:"ongoing_text,omitempty"`
+	CallID       string                   `json:"call_id"`
+	Name         toolspec.ID              `json:"name"`
+	Output       json.RawMessage          `json:"output"`
+	IsError      bool                     `json:"is_error"`
+	Summary      string                   `json:"summary,omitempty"`
+	OngoingText  string                   `json:"ongoing_text,omitempty"`
+	Presentation *transcript.ToolCallMeta `json:"presentation,omitempty"`
 }
 
 type Definition struct {

--- a/server/tools/types_test.go
+++ b/server/tools/types_test.go
@@ -160,6 +160,20 @@ func TestDefinitionContractsDriveRuntimeAndRequestExposure(t *testing.T) {
 	if webSearch.EnablesNativeWebSearch("off") {
 		t.Fatalf("expected %s native web search to honor disabled mode", toolspec.ToolWebSearch)
 	}
+
+	edit, ok := DefinitionFor(toolspec.ToolEdit)
+	if !ok {
+		t.Fatalf("expected %s definition", toolspec.ToolEdit)
+	}
+	if !edit.AvailableInLocalRuntime() {
+		t.Fatalf("expected %s to be available in local runtime", toolspec.ToolEdit)
+	}
+	if edit.LocalRuntimeBuilder() != LocalRuntimeBuilderEdit {
+		t.Fatalf("expected %s local runtime builder, got %q", toolspec.ToolEdit, edit.LocalRuntimeBuilder())
+	}
+	if !edit.ExposedToModelRequest(RequestExposureContext{}) {
+		t.Fatalf("expected %s to be request-exposed when enabled", toolspec.ToolEdit)
+	}
 }
 
 func TestDefinitionContractsBuildTranscriptMetadata(t *testing.T) {
@@ -198,6 +212,15 @@ func TestDefinitionContractsBuildTranscriptMetadata(t *testing.T) {
 	freeformPatchMeta := patch.BuildToolCallMeta(ToolCallContext{WorkingDir: "/workspace"}, json.RawMessage(`"*** Begin Patch\n*** Update File: custom.go\n-old\n+new\n*** End Patch\n"`))
 	if freeformPatchMeta.PatchSummary != "./custom.go +1 -1" {
 		t.Fatalf("expected custom freeform patch input summary, got %+v", freeformPatchMeta)
+	}
+
+	edit, _ := DefinitionFor(toolspec.ToolEdit)
+	editMeta := edit.BuildToolCallMeta(ToolCallContext{}, json.RawMessage(`{"path":"a.go","old_string":"old","new_string":"new"}`))
+	if editMeta.ToolName != string(toolspec.ToolEdit) || editMeta.Command != "edit a.go" || editMeta.CompactText != "edit a.go" {
+		t.Fatalf("unexpected edit transcript metadata: %+v", editMeta)
+	}
+	if editMeta.RenderHint == nil || editMeta.RenderHint.Kind != transcript.ToolRenderKindDiff {
+		t.Fatalf("expected edit diff render hint, got %+v", editMeta.RenderHint)
 	}
 
 	askQuestion, _ := DefinitionFor(toolspec.ToolAskQuestion)

--- a/server/tools/types_test.go
+++ b/server/tools/types_test.go
@@ -216,7 +216,7 @@ func TestDefinitionContractsBuildTranscriptMetadata(t *testing.T) {
 
 	edit, _ := DefinitionFor(toolspec.ToolEdit)
 	editMeta := edit.BuildToolCallMeta(ToolCallContext{}, json.RawMessage(`{"path":"a.go","old_string":"old","new_string":"new"}`))
-	if editMeta.ToolName != string(toolspec.ToolEdit) || editMeta.Command != "edit a.go" || editMeta.CompactText != "edit a.go" {
+	if editMeta.ToolName != string(toolspec.ToolEdit) || editMeta.Command != "a.go" || editMeta.CompactText != "a.go" {
 		t.Fatalf("unexpected edit transcript metadata: %+v", editMeta)
 	}
 	if editMeta.RenderHint == nil || editMeta.RenderHint.Kind != transcript.ToolRenderKindDiff {

--- a/shared/config/config_defaults.go
+++ b/shared/config/config_defaults.go
@@ -117,6 +117,8 @@ func settingsTOMLWithRenderingOptions(settings Settings, includeToolSection bool
 	}
 	if includeToolSection {
 		out.WriteString("\n[tools]\n")
+		out.WriteString("# Leave both patch/edit commented to use Builder's model-based default:\n")
+		out.WriteString("# patch for first-party OpenAI or gpt-* models, edit otherwise.\n")
 		writeToolLines(&out, state.Settings.EnabledTools)
 	}
 	shellLines := annotateRenderedLines(filterDefaultLines(lines, "shell"), filterDefaultLines(defaultLines, "shell"), nil)

--- a/shared/toolspec/toolspec.go
+++ b/shared/toolspec/toolspec.go
@@ -12,6 +12,7 @@ const (
 	ToolWriteStdin     ID = "write_stdin"
 	ToolViewImage      ID = "view_image"
 	ToolPatch          ID = "patch"
+	ToolEdit           ID = "edit"
 	ToolAskQuestion    ID = "ask_question"
 	ToolTriggerHandoff ID = "trigger_handoff"
 	ToolWebSearch      ID = "web_search"
@@ -19,6 +20,7 @@ const (
 
 var catalogIDs = []ID{
 	ToolAskQuestion,
+	ToolEdit,
 	ToolExecCommand,
 	ToolPatch,
 	ToolTriggerHandoff,
@@ -41,6 +43,7 @@ var parseAliases = map[string]ID{
 	"bash":            ToolExecCommand,
 	"bash_command":    ToolExecCommand,
 	"exec_command":    ToolExecCommand,
+	"edit":            ToolEdit,
 	"patch":           ToolPatch,
 	"read_image":      ToolViewImage,
 	"shell":           ToolExecCommand,
@@ -48,11 +51,14 @@ var parseAliases = map[string]ID{
 	"trigger_handoff": ToolTriggerHandoff,
 	"view_image":      ToolViewImage,
 	"web_search":      ToolWebSearch,
+	"replace":         ToolEdit,
+	"write":           ToolEdit,
 	"write_stdin":     ToolWriteStdin,
 }
 
 var configAliases = map[string]ID{
 	"ask_question":    ToolAskQuestion,
+	"edit":            ToolEdit,
 	"exec_command":    ToolExecCommand,
 	"patch":           ToolPatch,
 	"read_image":      ToolViewImage,

--- a/shared/toolspec/toolspec_test.go
+++ b/shared/toolspec/toolspec_test.go
@@ -17,6 +17,9 @@ func TestParseID(t *testing.T) {
 		{in: "view_image", want: ToolViewImage, ok: true},
 		{in: "read_image", want: ToolViewImage, ok: true},
 		{in: "patch", want: ToolPatch, ok: true},
+		{in: "edit", want: ToolEdit, ok: true},
+		{in: "replace", want: ToolEdit, ok: true},
+		{in: "write", want: ToolEdit, ok: true},
 		{in: "ask_question", want: ToolAskQuestion, ok: true},
 		{in: "trigger_handoff", want: ToolTriggerHandoff, ok: true},
 		{in: "web_search", want: ToolWebSearch, ok: true},
@@ -40,6 +43,14 @@ func TestParseConfigIDAndConfigName(t *testing.T) {
 	}
 	if got, ok := ParseConfigID("bash"); ok {
 		t.Fatalf("ParseConfigID(bash) unexpectedly resolved to %q", got)
+	}
+	if got, ok := ParseConfigID("edit"); !ok || got != ToolEdit {
+		t.Fatalf("ParseConfigID(edit) = %q, %t", got, ok)
+	}
+	for _, alias := range []string{"replace", "write"} {
+		if got, ok := ParseConfigID(alias); ok {
+			t.Fatalf("ParseConfigID(%s) unexpectedly resolved to %q", alias, got)
+		}
 	}
 	if got := ConfigName(ToolExecCommand); got != "shell" {
 		t.Fatalf("ConfigName(exec_command) = %q, want shell", got)


### PR DESCRIPTION
## Summary
- add first-class `edit` tool with create/replace/delete, robust matching, text/binary guards, atomic writes, symlink warning, and diff metadata
- add dynamic `patch`/`edit` tool selection, mutual exclusion, aliases, prompt conditioning, reviewer edits trigger, and runtime/TUI diff rendering support
- extract reusable filesystem guard/locking helpers and update config docs

## Tests
- `./scripts/test.sh ./server/tools/edit ./server/tools/patch ./server/tools/fsguard ./server/tools ./server/runtime ./server/runtimewire ./server/launch ./shared/toolspec ./shared/config ./prompts ./cli/tui`
- `./scripts/build.sh --output ./bin/builder`
- push hook: formatting, go vet, go build, tests

Closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "edit" file-edit tool alongside "patch", with dynamic default selection based on model and enforced mutual exclusivity.
  * Improved diff/patch rendering and display metadata for clearer transcript and tool-call summaries.
  * CLI/launch now surfaces tool-selection conflicts as errors instead of silently proceeding.

* **Documentation**
  * Config docs updated to show tools.patch/tools.edit as commented options and explain dynamic selection and mutual-exclusion behavior.

* **Tests**
  * Expanded test coverage for edit/patch selection, edit behaviors, and reviewer invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->