### PR TITLE
feat: add Windows installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,8 @@ jobs:
           GOOS=windows GOARCH=amd64 BUILDER_VERSION="$VERSION" \
             bash scripts/build.sh --output "staging/builder_${VERSION}_windows_amd64.exe"
           powershell -NoProfile -Command "Compress-Archive -LiteralPath 'staging/builder_${VERSION}_windows_amd64.exe' -DestinationPath 'dist/builder_${VERSION}_windows_amd64.zip' -Force"
-          (
-            cd dist
-            shasum -a 256 "builder_${VERSION}_windows_amd64.zip" > checksums.txt
-          )
+          checksum=$(powershell -NoProfile -Command "(Get-FileHash -Algorithm SHA256 -LiteralPath 'dist/builder_${VERSION}_windows_amd64.zip').Hash.ToLowerInvariant()")
+          printf '%s  %s\n' "$checksum" "builder_${VERSION}_windows_amd64.zip" > dist/checksums.txt
 
       - name: Smoke test installer
         env:
@@ -131,10 +129,8 @@ jobs:
           GOOS=windows GOARCH=amd64 go build -o recovery-install/builder.exe fake-builder.go
           cp recovery-install/builder.exe "recovery-staging/builder_${VERSION}_windows_amd64.exe"
           powershell -NoProfile -Command "Compress-Archive -LiteralPath 'recovery-staging/builder_${VERSION}_windows_amd64.exe' -DestinationPath 'recovery-release/v${VERSION}/builder_${VERSION}_windows_amd64.zip' -Force"
-          (
-            cd "recovery-release/v${VERSION}"
-            shasum -a 256 "builder_${VERSION}_windows_amd64.zip" > checksums.txt
-          )
+          checksum=$(powershell -NoProfile -Command "(Get-FileHash -Algorithm SHA256 -LiteralPath 'recovery-release/v${VERSION}/builder_${VERSION}_windows_amd64.zip').Hash.ToLowerInvariant()")
+          printf '%s  %s\n' "$checksum" "builder_${VERSION}_windows_amd64.zip" > "recovery-release/v${VERSION}/checksums.txt"
           release_base="$(cygpath -w "$PWD/recovery-release")"
           install_dir="$(cygpath -w "$PWD/recovery-install")"
           marker_path="$PWD/recovery-marker.txt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,7 @@ jobs:
           mkdir -p dist staging
           GOOS=windows GOARCH=amd64 BUILDER_VERSION="$VERSION" \
             bash scripts/build.sh --output "staging/builder_${VERSION}_windows_amd64.exe"
-          (
-            cd staging
-            zip -q "../dist/builder_${VERSION}_windows_amd64.zip" "builder_${VERSION}_windows_amd64.exe"
-          )
+          powershell -NoProfile -Command "Compress-Archive -LiteralPath 'staging/builder_${VERSION}_windows_amd64.exe' -DestinationPath 'dist/builder_${VERSION}_windows_amd64.zip' -Force"
           (
             cd dist
             shasum -a 256 "builder_${VERSION}_windows_amd64.zip" > checksums.txt
@@ -133,10 +130,7 @@ jobs:
           mkdir -p recovery-release/v${VERSION} recovery-install recovery-staging
           GOOS=windows GOARCH=amd64 go build -o recovery-install/builder.exe fake-builder.go
           cp recovery-install/builder.exe "recovery-staging/builder_${VERSION}_windows_amd64.exe"
-          (
-            cd recovery-staging
-            zip -q "../recovery-release/v${VERSION}/builder_${VERSION}_windows_amd64.zip" "builder_${VERSION}_windows_amd64.exe"
-          )
+          powershell -NoProfile -Command "Compress-Archive -LiteralPath 'recovery-staging/builder_${VERSION}_windows_amd64.exe' -DestinationPath 'recovery-release/v${VERSION}/builder_${VERSION}_windows_amd64.zip' -Force"
           (
             cd "recovery-release/v${VERSION}"
             shasum -a 256 "builder_${VERSION}_windows_amd64.zip" > checksums.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
             os.Exit(1)
           }
           GO
-          mkdir -p recovery-release/v${VERSION} recovery-install recovery-staging
+          mkdir -p "recovery-release/v${VERSION}" "recovery-install" "recovery-staging"
           GOOS=windows GOARCH=amd64 go build -o recovery-install/builder.exe fake-builder.go
           cp recovery-install/builder.exe "recovery-staging/builder_${VERSION}_windows_amd64.exe"
           powershell -NoProfile -Command "Compress-Archive -LiteralPath 'recovery-staging/builder_${VERSION}_windows_amd64.exe' -DestinationPath 'recovery-release/v${VERSION}/builder_${VERSION}_windows_amd64.zip' -Force"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,97 @@ jobs:
       - name: Test
         run: ./scripts/ci-check.sh test
 
+  windows-installer:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build mocked Windows release asset
+        env:
+          VERSION: 0.0.0
+        run: |
+          mkdir -p dist staging
+          GOOS=windows GOARCH=amd64 BUILDER_VERSION="$VERSION" \
+            bash scripts/build.sh --output "staging/builder_${VERSION}_windows_amd64.exe"
+          (
+            cd staging
+            zip -q "../dist/builder_${VERSION}_windows_amd64.zip" "builder_${VERSION}_windows_amd64.exe"
+          )
+          (
+            cd dist
+            shasum -a 256 "builder_${VERSION}_windows_amd64.zip" > checksums.txt
+          )
+
+      - name: Smoke test installer
+        env:
+          VERSION: 0.0.0
+        run: bash scripts/release-artifacts.sh smoke-windows-installer --version "$VERSION" --goarch amd64 --dist-dir dist
+
+      - name: Smoke test installer restores stopped service after failure
+        env:
+          VERSION: 0.0.0
+        run: |
+          cat > fake-builder.go <<'GO'
+          package main
+          import (
+            "fmt"
+            "os"
+            "strings"
+          )
+          func mark(value string) {
+            path := os.Getenv("BUILDER_FAKE_MARKER")
+            if path == "" { return }
+            f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+            if err == nil { _, _ = f.WriteString(value + "\n"); _ = f.Close() }
+          }
+          func main() {
+            args := os.Args[1:]
+            if len(args) == 1 && args[0] == "--version" { fmt.Println(os.Getenv("BUILDER_FAKE_VERSION")); return }
+            if len(args) >= 2 && args[0] == "service" && args[1] == "status" {
+              exe, _ := os.Executable()
+              fmt.Printf(`{"installed":true,"loaded":true,"running":true,"command":[%q],"endpoint":"","logs":[]}`+"\n", exe)
+              return
+            }
+            if len(args) >= 2 && args[0] == "service" && args[1] == "stop" { mark("stopped"); return }
+            if len(args) >= 3 && strings.Join(args[:3], " ") == "service restart --if-installed" { mark("restarted"); return }
+            fmt.Fprintf(os.Stderr, "unexpected args: %v\n", args)
+            os.Exit(1)
+          }
+          GO
+          mkdir -p recovery-release/v${VERSION} recovery-install recovery-staging
+          GOOS=windows GOARCH=amd64 go build -o recovery-install/builder.exe fake-builder.go
+          cp recovery-install/builder.exe "recovery-staging/builder_${VERSION}_windows_amd64.exe"
+          (
+            cd recovery-staging
+            zip -q "../recovery-release/v${VERSION}/builder_${VERSION}_windows_amd64.zip" "builder_${VERSION}_windows_amd64.exe"
+          )
+          (
+            cd "recovery-release/v${VERSION}"
+            shasum -a 256 "builder_${VERSION}_windows_amd64.zip" > checksums.txt
+          )
+          release_base="$(cygpath -w "$PWD/recovery-release")"
+          install_dir="$(cygpath -w "$PWD/recovery-install")"
+          marker_path="$PWD/recovery-marker.txt"
+          marker_win="$(cygpath -w "$marker_path")"
+          if BUILDER_RELEASE_BASE="$release_base" BUILDER_FAKE_MARKER="$marker_win" BUILDER_FAKE_VERSION="wrong" \
+            powershell -NoProfile -ExecutionPolicy Bypass -File scripts/install.ps1 \
+              -Version "$VERSION" -InstallDir "$install_dir" -Yes -NoPath -NoDeps; then
+            echo "installer unexpectedly succeeded" >&2
+            exit 1
+          fi
+          grep -q '^stopped$' "$marker_path"
+          grep -q '^restarted$' "$marker_path"
+
   docs:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,17 @@ jobs:
           fi
           bash scripts/release-artifacts.sh "${args[@]}"
 
+      - name: Smoke test Windows installer
+        if: ${{ matrix.goos == 'windows' }}
+        env:
+          VERSION: ${{ needs.prepare_release.outputs.version }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          bash scripts/release-artifacts.sh smoke-windows-installer \
+            --version "$VERSION" \
+            --goarch "$GOARCH" \
+            --dist-dir dist
+
   publish_release:
     needs:
       - prepare_release

--- a/docs/dev/decisions.md
+++ b/docs/dev/decisions.md
@@ -519,7 +519,10 @@
 - Workflow runner labels should use `*-latest` aliases where GitHub provides them. ARM smoke-test jobs currently stay on `ubuntu-24.04-arm` and `windows-11-arm` because GitHub does not publish `-latest` aliases for those hosted runners.
 - Linux release binaries must stay statically linked; do not enable PIE or other dynamic-linking release modes.
 - GitHub releases must publish `checksums.txt`, and `scripts/install.sh` verifies archive checksums when that manifest is present.
+- Windows one-command installs are served by `scripts/install.ps1`; the default user install path is `~/.builder/bin/builder.exe`, matching the user-scoped Builder persistence root.
+- Windows installer uninstalls must remove only installer-owned binary/PATH/registry/marker files and never remove Builder config, sessions, auth, worktrees, skills, or winget-installed dependencies.
 - The release workflow must verify the checksum manifest and smoke-test packaged binaries on Linux, macOS, and Windows before publishing.
+- The release workflow must smoke-test `scripts/install.ps1` against staged Windows release assets before publishing.
 - GitHub artifact attestations are intentionally not part of the release pipeline.
 
 ## Experimental Reviewer

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -34,10 +34,11 @@ The `release` workflow in `/.github/workflows/release.yml`:
 4. Builds static release binaries through `scripts/build.sh` with the shared release profile.
 5. Packages the release archives and writes `checksums.txt` through `scripts/release-artifacts.sh`.
 6. Verifies the checksum manifest and smoke-tests packaged binaries on Linux, macOS, and Windows before publishing.
-7. Publishes the GitHub release.
-8. Checks out `respawn-app/homebrew-tap`.
-9. Runs `scripts/update-brew-tap.sh` for formula `builder-cli`.
-10. Opens a PR in the tap repo with label `pr-pull`.
+7. Smoke-tests the Windows installer against staged release assets before publishing.
+8. Publishes the GitHub release.
+9. Checks out `respawn-app/homebrew-tap`.
+10. Runs `scripts/update-brew-tap.sh` for formula `builder-cli`.
+11. Opens a PR in the tap repo with label `pr-pull`.
 
 ## What The Tap Automation Does
 
@@ -64,14 +65,21 @@ Verify all of these before considering the release done:
 1. The GitHub release `vX.Y.Z` exists in `respawn-app/builder` and contains the expected assets plus `checksums.txt`.
 2. The tap PR in `respawn-app/homebrew-tap` is closed by the automation.
 3. The formula on tap `master` has the new tag URL and bottle block.
-4. A standalone install works and passes checksum verification when the release publishes `checksums.txt`:
+4. A standalone Unix install works and passes checksum verification when the release publishes `checksums.txt`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/respawn-app/builder/main/scripts/install.sh | sh
 builder --version
 ```
 
-5. A fresh Homebrew install works after `brew update`:
+5. A standalone Windows install works and passes checksum verification:
+
+```powershell
+irm https://raw.githubusercontent.com/respawn-app/builder/main/scripts/install.ps1 | iex
+builder --version
+```
+
+6. A fresh Homebrew install works after `brew update`:
 
 ```bash
 brew update
@@ -86,7 +94,7 @@ If short-name resolution is stale on a machine, use the fully qualified formula 
 brew install respawn-app/tap/builder-cli
 ```
 
-6. Clean up the Homebrew and direct installs to restore your local development build:
+7. Clean up the Homebrew and direct installs to restore your local development build:
 
 ```bash
 brew uninstall builder-cli 2>/dev/null || true

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -12,6 +12,12 @@ brew tap respawn-app/tap
 brew install builder-cli
 ```
 
+### Windows
+
+```powershell
+irm https://raw.githubusercontent.com/respawn-app/builder/main/scripts/install.ps1 | iex
+```
+
 ### Standalone binaries via GitHub Releases
 
 These versions are **not auto-updated**. Please keep them updated manually.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -55,8 +55,8 @@ function Get-UserHome {
 }
 function Resolve-InstallDir([string]$Value) {
     if ([string]::IsNullOrWhiteSpace($Value)) {
-        $home = Get-UserHome
-        return [System.IO.Path]::GetFullPath((Join-Path (Join-Path $home ".builder") "bin"))
+        $userHome = Get-UserHome
+        return [System.IO.Path]::GetFullPath((Join-Path (Join-Path $userHome ".builder") "bin"))
     }
     $expanded = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Value)
     return [System.IO.Path]::GetFullPath($expanded)
@@ -114,7 +114,19 @@ function Resolve-LatestVersion {
     try {
         $latestUrl = "https://github.com/$Repo/releases/latest"
         $response = Invoke-WebRequest -Uri $latestUrl -UseBasicParsing
-        $finalUrl = $response.BaseResponse.ResponseUri.AbsoluteUri
+        $finalUrl = ""
+        try {
+            if ($null -ne $response.BaseResponse.RequestMessage -and $null -ne $response.BaseResponse.RequestMessage.RequestUri) {
+                $finalUrl = $response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+            }
+        } catch {}
+        if ([string]::IsNullOrWhiteSpace($finalUrl)) {
+            try {
+                if ($null -ne $response.BaseResponse.ResponseUri) {
+                    $finalUrl = $response.BaseResponse.ResponseUri.AbsoluteUri
+                }
+            } catch {}
+        }
         $marker = "/releases/tag/"
         $index = $finalUrl.IndexOf($marker, [System.StringComparison]::OrdinalIgnoreCase)
         if ($index -ge 0) {
@@ -508,13 +520,13 @@ function Test-ServiceCommandUsesBuilderPath([object]$Status, [string]$BuilderPat
 }
 function Stop-ServiceForUpdate([string]$BuilderPath) {
     $status = Get-ServiceStatusForUpdate $BuilderPath
-    if ($status -eq $null -or -not [bool]$status.installed) { return }
-    if (-not (Test-ServiceCommandUsesBuilderPath $status $BuilderPath)) { return }
-    if (-not [bool]$status.running) { return }
+    if ($null -eq $status -or -not [bool]$status.installed) { return $false }
+    if (-not (Test-ServiceCommandUsesBuilderPath $status $BuilderPath)) { return $false }
+    if (-not [bool]$status.running) { return $false }
     if ($NoServiceRestart) {
         Fail "Builder background service is running from $BuilderPath. Stop it before updating, or rerun without -NoServiceRestart."
     }
-    Write-Output "Stopping Builder background service before update..."
+    Write-Host "Stopping Builder background service before update..."
     $stopOutput = & $BuilderPath service stop 2>&1
     if ($LASTEXITCODE -ne 0) { Fail "Failed to stop Builder background service before update: $stopOutput" }
     return $true

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,617 @@
+param([string]$Version = $env:BUILDER_VERSION, [string]$InstallDir = "",
+    [switch]$Yes, [switch]$NoPath, [switch]$NoDeps, [switch]$Uninstall,
+    [switch]$Force, [switch]$NoServiceRestart, [switch]$Help)
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+$DefaultRepo = "respawn-app/builder"
+$Repo = $env:BUILDER_REPO
+if ([string]::IsNullOrWhiteSpace($Repo)) {
+    $Repo = $DefaultRepo
+}
+$ReleaseBase = $env:BUILDER_RELEASE_BASE
+if ([string]::IsNullOrWhiteSpace($ReleaseBase)) {
+    $ReleaseBase = "https://github.com/$Repo/releases/download"
+}
+$InstallMarkerName = "builder-install.json"; $UninstallScriptName = "uninstall.ps1"
+$UninstallRegistryPath = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\Builder"; $UninstallRegistryDisplayName = "Builder"
+function Write-Usage {
+    Write-Output @"
+Usage: install.ps1 [options]
+Installs Builder for the current Windows user.
+Options:
+  -Version <vX.Y.Z|X.Y.Z>  Release tag to install. Defaults to latest.
+  -InstallDir <path>       Install directory. Defaults to ~/.builder/bin.
+  -Yes                     Accept prompts.
+  -NoPath                  Do not add install directory to User PATH.
+  -NoDeps                  Do not offer to install git/rg through winget.
+  -Uninstall               Remove Builder binary and installer-owned metadata.
+  -Force                   Overwrite an existing builder.exe or symlink.
+  -NoServiceRestart        Do not restart an already-installed Builder service.
+  -Help                    Show this help.
+Environment:
+  BUILDER_VERSION       Override version.
+  BUILDER_REPO          Override repo. Default: respawn-app/builder.
+  BUILDER_RELEASE_BASE  Override release base URL.
+  GITHUB_TOKEN          GitHub token for API rate limits.
+  GH_TOKEN              GitHub token for API rate limits.
+"@
+}
+function Fail([string]$Message) {
+    Write-Error $Message
+    exit 1
+}
+function Warn([string]$Message) {
+    Write-Warning $Message
+}
+function Get-UserHome {
+    if (-not [string]::IsNullOrWhiteSpace($HOME)) {
+        return $HOME
+    }
+    $profileHome = [Environment]::GetFolderPath("UserProfile")
+    if (-not [string]::IsNullOrWhiteSpace($profileHome)) {
+        return $profileHome
+    }
+    Fail "Unable to resolve user home directory."
+}
+function Resolve-InstallDir([string]$Value) {
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        $home = Get-UserHome
+        return [System.IO.Path]::GetFullPath((Join-Path (Join-Path $home ".builder") "bin"))
+    }
+    $expanded = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Value)
+    return [System.IO.Path]::GetFullPath($expanded)
+}
+function Confirm-Action([string]$Question, [bool]$DefaultYes) {
+    if ($Yes) {
+        return $true
+    }
+    if (-not [Environment]::UserInteractive) {
+        return $false
+    }
+    $suffix = " [y/N]"
+    if ($DefaultYes) {
+        $suffix = " [Y/n]"
+    }
+    $answer = Read-Host ($Question + $suffix)
+    if ([string]::IsNullOrWhiteSpace($answer)) {
+        return $DefaultYes
+    }
+    $normalized = $answer.Trim().ToLowerInvariant()
+    return $normalized -eq "y" -or $normalized -eq "yes"
+}
+function Normalize-Version([string]$Value) {
+    $trimmed = $Value.Trim()
+    if ($trimmed.StartsWith("v")) {
+        return $trimmed.Substring(1)
+    }
+    return $trimmed
+}
+function Get-AuthHeaders {
+    $token = $env:GITHUB_TOKEN
+    if ([string]::IsNullOrWhiteSpace($token)) {
+        $token = $env:GH_TOKEN
+    }
+    if ([string]::IsNullOrWhiteSpace($token)) {
+        return @{}
+    }
+    return @{ Authorization = "Bearer $token" }
+}
+function Resolve-LatestVersion {
+    $apiUrl = "https://api.github.com/repos/$Repo/releases/latest"
+    $apiMessage = ""
+    $rateLimited = $false
+    try {
+        $release = Invoke-RestMethod -Uri $apiUrl -Headers (Get-AuthHeaders) -UseBasicParsing
+        if ($release -ne $null -and -not [string]::IsNullOrWhiteSpace($release.tag_name)) {
+            return $release.tag_name
+        }
+    } catch {
+        $apiMessage = $_.Exception.Message
+        if ($apiMessage -like "*rate limit*") {
+            $rateLimited = $true
+        }
+    }
+    try {
+        $latestUrl = "https://github.com/$Repo/releases/latest"
+        $response = Invoke-WebRequest -Uri $latestUrl -UseBasicParsing
+        $finalUrl = $response.BaseResponse.ResponseUri.AbsoluteUri
+        $marker = "/releases/tag/"
+        $index = $finalUrl.IndexOf($marker, [System.StringComparison]::OrdinalIgnoreCase)
+        if ($index -ge 0) {
+            return $finalUrl.Substring($index + $marker.Length)
+        }
+    } catch {
+        if ([string]::IsNullOrWhiteSpace($apiMessage)) {
+            $apiMessage = $_.Exception.Message
+        }
+    }
+    if ($rateLimited) {
+        Fail "GitHub API rate limit exceeded. Set GITHUB_TOKEN or GH_TOKEN and retry."
+    }
+    if (-not [string]::IsNullOrWhiteSpace($apiMessage)) {
+        Write-Error $apiMessage
+    }
+    Fail "Failed to resolve latest version."
+}
+function Resolve-Arch {
+    $arch = $env:PROCESSOR_ARCHITEW6432
+    if ([string]::IsNullOrWhiteSpace($arch)) {
+        $arch = $env:PROCESSOR_ARCHITECTURE
+    }
+    if ([string]::IsNullOrWhiteSpace($arch)) {
+        Fail "Unable to resolve Windows architecture."
+    }
+    $normalized = $arch.Trim().ToLowerInvariant()
+    if ($normalized -eq "amd64" -or $normalized -eq "x64") {
+        return "amd64"
+    }
+    if ($normalized -eq "arm64" -or $normalized -eq "aarch64") {
+        return "arm64"
+    }
+    Fail "Unsupported Windows architecture: $arch"
+}
+function New-TempDirectory {
+    $parent = [System.IO.Path]::GetTempPath()
+    $name = "builder-install-" + [System.Guid]::NewGuid().ToString("N")
+    $path = Join-Path $parent $name
+    New-Item -ItemType Directory -Path $path | Out-Null
+    return $path
+}
+function Test-HttpResource([string]$Value) {
+    return $Value.StartsWith("http://", [System.StringComparison]::OrdinalIgnoreCase) -or $Value.StartsWith("https://", [System.StringComparison]::OrdinalIgnoreCase)
+}
+function Join-ReleaseResource([string]$Base, [string]$Tag, [string]$Name) {
+    if (Test-HttpResource $Base) {
+        return $Base.TrimEnd("/") + "/$Tag/$Name"
+    }
+    return Join-Path (Join-Path $Base $Tag) $Name
+}
+function Download-File([string]$Url, [string]$Path) {
+    if (-not (Test-HttpResource $Url)) {
+        if (-not (Test-Path -LiteralPath $Url)) {
+            Fail "Release file not found: $Url"
+        }
+        Copy-Item -LiteralPath $Url -Destination $Path
+        return
+    }
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $Path -UseBasicParsing
+    } catch {
+        Fail "Failed to download $Url. $($_.Exception.Message)"
+    }
+}
+function Read-Checksum([string]$ChecksumPath, [string]$ArchiveName) {
+    $lines = Get-Content -LiteralPath $ChecksumPath
+    foreach ($line in $lines) {
+        $parts = $line.Split([char[]]" `t", [System.StringSplitOptions]::RemoveEmptyEntries)
+        if ($parts.Count -lt 2) {
+            continue
+        }
+        $asset = $parts[1]
+        if ($asset.StartsWith("./")) {
+            $asset = $asset.Substring(2)
+        }
+        if ($asset -eq $ArchiveName) {
+            return $parts[0].ToLowerInvariant()
+        }
+    }
+    Fail "checksums.txt is missing an entry for $ArchiveName."
+}
+function Verify-Checksum([string]$ArchivePath, [string]$ChecksumPath, [string]$ArchiveName) {
+    $expected = Read-Checksum $ChecksumPath $ArchiveName
+    $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $ArchivePath).Hash.ToLowerInvariant()
+    if ($actual -ne $expected) {
+        Fail "Checksum verification failed for $ArchiveName."
+    }
+}
+function Get-UserPathEntries {
+    $pathValue = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ([string]::IsNullOrWhiteSpace($pathValue)) {
+        return @()
+    }
+    return @($pathValue.Split([char[]]";", [System.StringSplitOptions]::RemoveEmptyEntries))
+}
+function Normalize-PathDirectory([string]$Directory) {
+    $expanded = [Environment]::ExpandEnvironmentVariables($Directory)
+    $separators = @([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+    return [System.IO.Path]::GetFullPath($expanded).TrimEnd($separators)
+}
+function Test-PathEntry([string]$Directory) {
+    $full = Normalize-PathDirectory $Directory
+    foreach ($entry in Get-UserPathEntries) {
+        try {
+            $entryFull = Normalize-PathDirectory $entry
+        } catch {
+            continue
+        }
+        if ([string]::Equals($entryFull, $full, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $true
+        }
+    }
+    return $false
+}
+function Add-UserPathEntry([string]$Directory) {
+    if (Test-PathEntry $Directory) {
+        return $false
+    }
+    $entries = @(Get-UserPathEntries)
+    $entries += $Directory
+    [Environment]::SetEnvironmentVariable("Path", ($entries -join ";"), "User")
+    return $true
+}
+function Remove-UserPathEntry([string]$Directory) {
+    $full = Normalize-PathDirectory $Directory
+    $kept = @()
+    $removed = $false
+    foreach ($entry in Get-UserPathEntries) {
+        try {
+            $entryFull = Normalize-PathDirectory $entry
+        } catch {
+            $kept += $entry
+            continue
+        }
+        if ([string]::Equals($entryFull, $full, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $removed = $true
+        } else {
+            $kept += $entry
+        }
+    }
+    if ($removed) {
+        [Environment]::SetEnvironmentVariable("Path", ($kept -join ";"), "User")
+    }
+    return $removed
+}
+function New-UninstallScriptContent([string]$Directory) {
+    $escapedDirectory = $Directory.Replace("'", "''")
+    $template = @'
+param(
+    [switch]$Yes
+)
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+$InstallDir = '__INSTALL_DIR__'
+$MarkerPath = Join-Path $InstallDir 'builder-install.json'
+$RegistryPath = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\Builder'
+function Confirm-RemovePath([string]$Question) {
+    if ($Yes) { return $true }
+    if (-not [Environment]::UserInteractive) { return $false }
+    $answer = Read-Host ($Question + ' [Y/n]')
+    if ([string]::IsNullOrWhiteSpace($answer)) { return $true }
+    $normalized = $answer.Trim().ToLowerInvariant()
+    return $normalized -eq 'y' -or $normalized -eq 'yes'
+}
+function Get-UserPathEntries {
+    $pathValue = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ([string]::IsNullOrWhiteSpace($pathValue)) { return @() }
+    return @($pathValue.Split([char[]]';', [System.StringSplitOptions]::RemoveEmptyEntries))
+}
+function Normalize-PathDirectory([string]$Directory) {
+    $expanded = [Environment]::ExpandEnvironmentVariables($Directory)
+    $separators = @([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+    return [System.IO.Path]::GetFullPath($expanded).TrimEnd($separators)
+}
+function Remove-UserPathEntry([string]$Directory) {
+    $full = Normalize-PathDirectory $Directory
+    $kept = @()
+    $removed = $false
+    foreach ($entry in Get-UserPathEntries) {
+        try {
+            $entryFull = Normalize-PathDirectory $entry
+        } catch {
+            $kept += $entry
+            continue
+        }
+        if ([string]::Equals($entryFull, $full, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $removed = $true
+        } else {
+            $kept += $entry
+        }
+    }
+    if ($removed) {
+        [Environment]::SetEnvironmentVariable('Path', ($kept -join ';'), 'User')
+    }
+    return $removed
+}
+$pathAdded = $false
+if (Test-Path -LiteralPath $MarkerPath) {
+    try {
+        $marker = Get-Content -LiteralPath $MarkerPath -Raw | ConvertFrom-Json
+        $pathAdded = [bool]$marker.PathAdded
+    } catch {
+        $pathAdded = $false
+    }
+}
+if (Test-Path -LiteralPath (Join-Path $InstallDir 'builder.exe')) {
+    Remove-Item -LiteralPath (Join-Path $InstallDir 'builder.exe') -Force
+}
+if (Test-Path -LiteralPath $MarkerPath) {
+    Remove-Item -LiteralPath $MarkerPath -Force
+}
+if (Test-Path -LiteralPath $RegistryPath) {
+    Remove-Item -LiteralPath $RegistryPath -Recurse -Force
+}
+if ($pathAdded -and (Confirm-RemovePath "Remove $InstallDir from your User PATH?")) {
+    [void](Remove-UserPathEntry $InstallDir)
+}
+$scriptPath = $MyInvocation.MyCommand.Path
+Write-Output "Uninstalled Builder. User data under ~/.builder was not removed."
+if (Test-Path -LiteralPath $scriptPath) {
+    try {
+        Remove-Item -LiteralPath $scriptPath -Force
+    } catch {
+        Write-Warning "Could not remove uninstall script: $($_.Exception.Message)"
+    }
+}
+'@
+    return $template.Replace("__INSTALL_DIR__", $escapedDirectory)
+}
+function Read-InstallerPathOwnership([string]$Directory) {
+    $markerPath = Join-Path $Directory $InstallMarkerName
+    if (-not (Test-Path -LiteralPath $markerPath)) {
+        return $false
+    }
+    try {
+        $marker = Get-Content -LiteralPath $markerPath -Raw | ConvertFrom-Json
+        return [bool]$marker.PathAdded
+    } catch {
+        return $false
+    }
+}
+function Write-InstallMetadata([string]$Directory, [string]$VersionValue, [bool]$PathAdded) {
+    $markerPath = Join-Path $Directory $InstallMarkerName
+    $uninstallPath = Join-Path $Directory $UninstallScriptName
+    $metadata = New-Object PSObject -Property @{
+        Version = $VersionValue
+        Repo = $Repo
+        InstallDir = $Directory
+        PathAdded = $PathAdded
+        InstalledAtUtc = [DateTime]::UtcNow.ToString("o")
+    }
+    $metadata | ConvertTo-Json | Set-Content -LiteralPath $markerPath -Encoding UTF8
+    New-UninstallScriptContent $Directory | Set-Content -LiteralPath $uninstallPath -Encoding UTF8
+}
+function Write-UninstallRegistry([string]$Directory, [string]$VersionValue) {
+    $uninstallPath = Join-Path $Directory $UninstallScriptName
+    if (-not (Test-Path -LiteralPath $UninstallRegistryPath)) { New-Item -Path $UninstallRegistryPath -Force | Out-Null }
+    $command = "powershell -NoProfile -ExecutionPolicy Bypass -File `"$uninstallPath`""
+    $strings = @{
+        DisplayName = $UninstallRegistryDisplayName; DisplayVersion = $VersionValue; Publisher = "Respawn"
+        InstallLocation = $Directory; UninstallString = $command; DisplayIcon = (Join-Path $Directory "builder.exe")
+    }
+    foreach ($name in $strings.Keys) {
+        New-ItemProperty -Path $UninstallRegistryPath -Name $name -Value $strings[$name] -PropertyType String -Force | Out-Null
+    }
+    foreach ($name in @("NoModify", "NoRepair")) {
+        New-ItemProperty -Path $UninstallRegistryPath -Name $name -Value 1 -PropertyType DWord -Force | Out-Null
+    }
+}
+function Invoke-Uninstall([string]$Directory) {
+    $uninstallPath = Join-Path $Directory $UninstallScriptName
+    if (Test-Path -LiteralPath $uninstallPath) {
+        $args = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $uninstallPath)
+        if ($Yes) {
+            $args += "-Yes"
+        }
+        & powershell @args
+        exit $LASTEXITCODE
+    }
+    $target = Join-Path $Directory "builder.exe"
+    $marker = Join-Path $Directory $InstallMarkerName
+    $pathAdded = $false
+    if (Test-Path -LiteralPath $marker) {
+        try {
+            $parsed = Get-Content -LiteralPath $marker -Raw | ConvertFrom-Json
+            $pathAdded = [bool]$parsed.PathAdded
+        } catch {
+            $pathAdded = $false
+        }
+    }
+    if (Test-Path -LiteralPath $target) {
+        Remove-Item -LiteralPath $target -Force
+    }
+    if (Test-Path -LiteralPath $marker) {
+        Remove-Item -LiteralPath $marker -Force
+    }
+    if (Test-Path -LiteralPath $UninstallRegistryPath) {
+        Remove-Item -LiteralPath $UninstallRegistryPath -Recurse -Force
+    }
+    if ($pathAdded -and (Confirm-Action "Remove $Directory from your User PATH?" $true)) {
+        [void](Remove-UserPathEntry $Directory)
+    }
+    Write-Output "Uninstalled Builder. User data under ~/.builder was not removed."
+}
+function Install-ArchiveBinary([string]$Source, [string]$Target) {
+    if (Test-Path -LiteralPath $Target) {
+        $item = Get-Item -LiteralPath $Target -Force
+        if ($item.PSIsContainer) {
+            Fail "Refusing to overwrite directory $Target"
+        }
+        $isReparsePoint = (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)
+        if ($isReparsePoint -and -not $Force) {
+            Fail "Refusing to overwrite symlink $Target. Re-run with -Force to replace it."
+        }
+        if (-not $Force -and -not (Confirm-Action "Overwrite existing $Target?" $true)) {
+            Fail "Install cancelled."
+        }
+        Remove-Item -LiteralPath $Target -Force
+    }
+    Copy-Item -LiteralPath $Source -Destination $Target
+}
+function Test-CommandExists([string]$Name) {
+    $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+    return $cmd -ne $null
+}
+function Install-MissingDependencies {
+    if ($NoDeps) {
+        return
+    }
+    $missing = @()
+    if (-not (Test-CommandExists "git")) {
+        $missing += New-Object PSObject -Property @{ Name = "git"; Package = "Git.Git" }
+    }
+    if (-not (Test-CommandExists "rg")) {
+        $missing += New-Object PSObject -Property @{ Name = "rg"; Package = "BurntSushi.ripgrep.MSVC" }
+    }
+    if ($missing.Count -eq 0) {
+        return
+    }
+    $names = @($missing | ForEach-Object { $_.Name }) -join ", "
+    if (-not (Test-CommandExists "winget")) {
+        Warn "Missing dependencies: $names. Install git and ripgrep manually; Builder can run, but agent search/repo workflows will be degraded."
+        return
+    }
+    if (-not (Confirm-Action "Builder works best with $names. Install missing dependencies with winget now?" $true)) {
+        Warn "Builder can run, but agent search/repo workflows will be degraded until git and ripgrep are installed."
+        return
+    }
+    foreach ($dependency in $missing) {
+        Write-Output "Installing $($dependency.Name) through winget..."
+        & winget install --id $dependency.Package --exact --source winget --accept-source-agreements --accept-package-agreements
+        if ($LASTEXITCODE -ne 0) {
+            Warn "winget failed to install $($dependency.Name). Builder can run, but agent search/repo workflows may be degraded."
+        }
+    }
+}
+function Get-ServiceStatusForUpdate([string]$BuilderPath) {
+    if (-not (Test-Path -LiteralPath $BuilderPath)) { return $null }
+    try {
+        $statusResult = & $BuilderPath service status --json 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Warn "Could not inspect Builder background service before update: $statusResult"
+            return $null
+        }
+        return (($statusResult | Out-String) | ConvertFrom-Json)
+    } catch {
+        Warn "Could not inspect Builder background service before update: $($_.Exception.Message)"
+        return $null
+    }
+}
+function Test-ServiceCommandUsesBuilderPath([object]$Status, [string]$BuilderPath) {
+    if ($Status -eq $null -or $Status.command -eq $null) { return $false }
+    $command = @($Status.command)
+    if ($command.Count -eq 0) { return $false }
+    try {
+        $registered = Normalize-PathDirectory ([string]$command[0])
+        $target = Normalize-PathDirectory $BuilderPath
+        return [string]::Equals($registered, $target, [System.StringComparison]::OrdinalIgnoreCase)
+    } catch { return $false }
+}
+function Stop-ServiceForUpdate([string]$BuilderPath) {
+    $status = Get-ServiceStatusForUpdate $BuilderPath
+    if ($status -eq $null -or -not [bool]$status.installed) { return }
+    if (-not (Test-ServiceCommandUsesBuilderPath $status $BuilderPath)) { return }
+    if (-not [bool]$status.running) { return }
+    if ($NoServiceRestart) {
+        Fail "Builder background service is running from $BuilderPath. Stop it before updating, or rerun without -NoServiceRestart."
+    }
+    Write-Output "Stopping Builder background service before update..."
+    $stopOutput = & $BuilderPath service stop 2>&1
+    if ($LASTEXITCODE -ne 0) { Fail "Failed to stop Builder background service before update: $stopOutput" }
+    return $true
+}
+function Restart-ServiceAfterFailedUpdate([string]$BuilderPath) {
+    if (-not (Test-Path -LiteralPath $BuilderPath)) {
+        Warn "Builder background service was stopped before update, but $BuilderPath is missing; service may be left stopped."
+        return
+    }
+    try {
+        $output = & $BuilderPath service restart --if-installed 2>&1
+        if ($LASTEXITCODE -ne 0) { Warn "Builder background service was stopped before update and restart failed: $output" }
+    } catch { Warn "Builder background service was stopped before update and restart failed: $($_.Exception.Message)" }
+}
+function Restart-ServiceIfInstalled([string]$BuilderPath) {
+    if ($NoServiceRestart) { return }
+    try {
+        $output = & $BuilderPath service restart --if-installed 2>&1
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            Warn "Builder background service restart failed after update: $output"
+            return
+        }
+        if (-not [string]::IsNullOrWhiteSpace(($output | Out-String))) {
+            Write-Output $output
+        }
+    } catch {
+        Warn "Builder background service restart failed after update: $($_.Exception.Message)"
+    }
+}
+if ($Help) {
+    Write-Usage
+    exit 0
+}
+$resolvedInstallDir = Resolve-InstallDir $InstallDir
+if ($Uninstall) {
+    Invoke-Uninstall $resolvedInstallDir
+    exit 0
+}
+$tag = $Version
+if ([string]::IsNullOrWhiteSpace($tag)) {
+    $tag = Resolve-LatestVersion
+}
+if ([string]::IsNullOrWhiteSpace($tag)) {
+    Fail "Failed to resolve version."
+}
+if (-not $tag.StartsWith("v")) {
+    $tag = "v$tag"
+}
+$normalizedVersion = Normalize-Version $tag
+$arch = Resolve-Arch
+$assetBase = "builder_${normalizedVersion}_windows_${arch}"
+$archiveName = "$assetBase.zip"
+$binaryName = "$assetBase.exe"
+$archiveUrl = Join-ReleaseResource $ReleaseBase $tag $archiveName
+$checksumsUrl = Join-ReleaseResource $ReleaseBase $tag "checksums.txt"
+$tempDir = New-TempDirectory
+$target = ""
+$serviceStoppedForUpdate = $false
+$installSucceeded = $false
+try {
+    $archivePath = Join-Path $tempDir $archiveName
+    $checksumPath = Join-Path $tempDir "checksums.txt"
+    Download-File $archiveUrl $archivePath
+    Download-File $checksumsUrl $checksumPath
+    Verify-Checksum $archivePath $checksumPath $archiveName
+    Expand-Archive -LiteralPath $archivePath -DestinationPath $tempDir -Force
+    $extractedBinary = Join-Path $tempDir $binaryName
+    if (-not (Test-Path -LiteralPath $extractedBinary)) {
+        Fail "Archive $archiveName did not contain $binaryName."
+    }
+    New-Item -ItemType Directory -Path $resolvedInstallDir -Force | Out-Null
+    $target = Join-Path $resolvedInstallDir "builder.exe"
+    $serviceStoppedForUpdate = [bool](Stop-ServiceForUpdate $target)
+    Install-ArchiveBinary $extractedBinary $target
+    $versionResult = & $target --version 2>&1
+    $versionExitCode = $LASTEXITCODE
+    $versionOutput = ($versionResult | Out-String).Trim()
+    if ($versionExitCode -ne 0 -or $versionOutput -ne $normalizedVersion) {
+        Fail "Installed binary version check failed: got '$versionOutput', want '$normalizedVersion'."
+    }
+    $pathAdded = Read-InstallerPathOwnership $resolvedInstallDir
+    if (-not $NoPath) {
+        if (Test-PathEntry $resolvedInstallDir) {
+            Write-Output "$resolvedInstallDir is already on User PATH."
+        } elseif (Confirm-Action "Add $resolvedInstallDir to your User PATH so 'builder' works in new terminals?" $true) {
+            $pathAdded = Add-UserPathEntry $resolvedInstallDir
+            Write-Output "Added $resolvedInstallDir to User PATH. Restart your terminal to use builder from PATH."
+        } else {
+            Write-Output "Skipped PATH update. Run builder with $target or add $resolvedInstallDir to your User PATH."
+        }
+    }
+    Write-InstallMetadata $resolvedInstallDir $normalizedVersion $pathAdded
+    try {
+        Write-UninstallRegistry $resolvedInstallDir $normalizedVersion
+    } catch {
+        Warn "Could not register Builder in Windows Apps & Features: $($_.Exception.Message)"
+    }
+    Install-MissingDependencies
+    Restart-ServiceIfInstalled $target
+    $installSucceeded = $true
+    Write-Output "Installed builder $normalizedVersion to $target"
+} finally {
+    if ($serviceStoppedForUpdate -and -not $installSucceeded) {
+        Restart-ServiceAfterFailedUpdate $target
+    }
+    if (Test-Path -LiteralPath $tempDir) {
+        Remove-Item -LiteralPath $tempDir -Recurse -Force
+    }
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -134,20 +134,30 @@ function Resolve-LatestVersion {
     Fail "Failed to resolve latest version."
 }
 function Resolve-Arch {
+    try {
+        $signature = @'
+using System;
+using System.Runtime.InteropServices;
+public static class BuilderNativeArchitecture {
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool IsWow64Process2(IntPtr process, out ushort processMachine, out ushort nativeMachine);
+}
+'@
+        Add-Type -TypeDefinition $signature -ErrorAction SilentlyContinue | Out-Null
+        $processMachine = 0
+        $nativeMachine = 0
+        $ok = [BuilderNativeArchitecture]::IsWow64Process2([System.Diagnostics.Process]::GetCurrentProcess().Handle, [ref]$processMachine, [ref]$nativeMachine)
+        if ($ok) {
+            if ($nativeMachine -eq 0xAA64) { return "arm64" }
+            if ($nativeMachine -eq 0x8664) { return "amd64" }
+        }
+    } catch {}
     $arch = $env:PROCESSOR_ARCHITEW6432
-    if ([string]::IsNullOrWhiteSpace($arch)) {
-        $arch = $env:PROCESSOR_ARCHITECTURE
-    }
-    if ([string]::IsNullOrWhiteSpace($arch)) {
-        Fail "Unable to resolve Windows architecture."
-    }
+    if ([string]::IsNullOrWhiteSpace($arch)) { $arch = $env:PROCESSOR_ARCHITECTURE }
+    if ([string]::IsNullOrWhiteSpace($arch)) { Fail "Unable to resolve Windows architecture." }
     $normalized = $arch.Trim().ToLowerInvariant()
-    if ($normalized -eq "amd64" -or $normalized -eq "x64") {
-        return "amd64"
-    }
-    if ($normalized -eq "arm64" -or $normalized -eq "aarch64") {
-        return "arm64"
-    }
+    if ($normalized -eq "amd64" -or $normalized -eq "x64") { return "amd64" }
+    if ($normalized -eq "arm64" -or $normalized -eq "aarch64") { return "arm64" }
     Fail "Unsupported Windows architecture: $arch"
 }
 function New-TempDirectory {

--- a/scripts/release-artifacts.sh
+++ b/scripts/release-artifacts.sh
@@ -13,6 +13,7 @@ Usage:
   scripts/release-artifacts.sh verify-manifest [--dist-dir dist]
   scripts/release-artifacts.sh verify-linux-static --version X.Y.Z [--dist-dir dist]
   scripts/release-artifacts.sh smoke-test --version X.Y.Z --goos <os> --goarch <arch> --archive-ext <ext> [--binary-ext <ext>] [--dist-dir dist]
+  scripts/release-artifacts.sh smoke-windows-installer --version X.Y.Z --goarch <arch> [--dist-dir dist]
 USAGE
 }
 
@@ -187,6 +188,62 @@ smoke_test() {
 	"$binary_path" --help >/dev/null
 }
 
+to_powershell_path() {
+	local value="$1"
+	if command -v cygpath >/dev/null 2>&1; then
+		cygpath -w "$value"
+		return
+	fi
+	printf '%s\n' "$value"
+}
+
+smoke_windows_installer() {
+	require_value "--version" "$version"
+	require_value "--goarch" "$goarch"
+	if ! command -v powershell >/dev/null 2>&1; then
+		echo "powershell is required for Windows installer smoke test" >&2
+		exit 1
+	fi
+
+	local dist_path normalized tag asset archive_path smoke_dir release_base release_dir install_dir install_script
+	dist_path="$(resolve_path "$dist_dir")"
+	normalized="${version#v}"
+	tag="v${normalized}"
+	asset="builder_${normalized}_windows_${goarch}.zip"
+	archive_path="$dist_path/$asset"
+	if [ ! -f "$archive_path" ]; then
+		echo "missing Windows release archive: $archive_path" >&2
+		exit 1
+	fi
+	if [ ! -f "$dist_path/checksums.txt" ]; then
+		echo "missing release checksum manifest: $dist_path/checksums.txt" >&2
+		exit 1
+	fi
+
+	smoke_dir="$(mktemp -d)"
+	release_base="$smoke_dir/releases"
+	release_dir="$release_base/$tag"
+	install_dir="$smoke_dir/install"
+	mkdir -p "$release_dir" "$install_dir"
+	cp "$archive_path" "$release_dir/$asset"
+	cp "$dist_path/checksums.txt" "$release_dir/checksums.txt"
+	install_script="$(to_powershell_path "$repo_root/scripts/install.ps1")"
+
+	BUILDER_RELEASE_BASE="$(to_powershell_path "$release_base")" \
+		powershell -NoProfile -ExecutionPolicy Bypass -File "$install_script" \
+		-Version "$normalized" \
+		-InstallDir "$(to_powershell_path "$install_dir")" \
+		-Yes \
+		-NoPath \
+		-NoDeps \
+		-NoServiceRestart
+
+	powershell -NoProfile -ExecutionPolicy Bypass -File "$install_script" \
+		-Uninstall \
+		-InstallDir "$(to_powershell_path "$install_dir")" \
+		-Yes
+}
+
 mode="${1:-}"
 if [ -z "$mode" ]; then
 	usage >&2
@@ -259,6 +316,9 @@ verify-linux-static)
 	;;
 smoke-test)
 	smoke_test
+	;;
+smoke-windows-installer)
+	smoke_windows_installer
 	;;
 *)
 	echo "Unknown mode: $mode" >&2

--- a/scripts/scripts_test.go
+++ b/scripts/scripts_test.go
@@ -152,6 +152,7 @@ func TestWindowsInstallerScriptDocumentsSupportedFlags(t *testing.T) {
 		"BUILDER_RELEASE_BASE",
 		"Git.Git",
 		"BurntSushi.ripgrep.MSVC",
+		"IsWow64Process2",
 		"UninstallString",
 		"checksums.txt",
 	} {

--- a/scripts/scripts_test.go
+++ b/scripts/scripts_test.go
@@ -133,6 +133,87 @@ func TestSandboxServeUpReportsHostPortInUse(t *testing.T) {
 	}
 }
 
+func TestWindowsInstallerScriptDocumentsSupportedFlags(t *testing.T) {
+	root := repoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "scripts", "install.ps1"))
+	if err != nil {
+		t.Fatalf("read install.ps1: %v", err)
+	}
+	text := string(data)
+	for _, needle := range []string{
+		"-Version <vX.Y.Z|X.Y.Z>",
+		"-InstallDir <path>",
+		"-Yes",
+		"-NoPath",
+		"-NoDeps",
+		"-Uninstall",
+		"-Force",
+		"-NoServiceRestart",
+		"BUILDER_RELEASE_BASE",
+		"Git.Git",
+		"BurntSushi.ripgrep.MSVC",
+		"UninstallString",
+		"checksums.txt",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("install.ps1 missing %q", needle)
+		}
+	}
+}
+
+func TestWindowsInstallerStopsRunningServiceBeforeReplacingBinary(t *testing.T) {
+	root := repoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "scripts", "install.ps1"))
+	if err != nil {
+		t.Fatalf("read install.ps1: %v", err)
+	}
+	text := string(data)
+	stopIndex := strings.Index(text, "Stop-ServiceForUpdate $target")
+	installIndex := strings.Index(text, "Install-ArchiveBinary $extractedBinary $target")
+	if stopIndex < 0 {
+		t.Fatal("install.ps1 does not stop service before binary replacement")
+	}
+	if installIndex < 0 {
+		t.Fatal("install.ps1 does not install archive binary")
+	}
+	if stopIndex > installIndex {
+		t.Fatalf("service stop occurs after binary replacement: stop=%d install=%d", stopIndex, installIndex)
+	}
+}
+
+func TestWindowsInstallerRestartsStoppedServiceAfterFailedUpdate(t *testing.T) {
+	root := repoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "scripts", "install.ps1"))
+	if err != nil {
+		t.Fatalf("read install.ps1: %v", err)
+	}
+	text := string(data)
+	for _, needle := range []string{
+		"$serviceStoppedForUpdate = [bool](Stop-ServiceForUpdate $target)",
+		"if ($serviceStoppedForUpdate -and -not $installSucceeded)",
+		"Restart-ServiceAfterFailedUpdate $target",
+		"service may be left stopped",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("install.ps1 missing service recovery behavior %q", needle)
+		}
+	}
+}
+
+func TestWindowsInstallerScriptAvoidsPowerShell7OnlySyntax(t *testing.T) {
+	root := repoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "scripts", "install.ps1"))
+	if err != nil {
+		t.Fatalf("read install.ps1: %v", err)
+	}
+	text := string(data)
+	for _, forbidden := range []string{"??", "ForEach-Object -Parallel"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("install.ps1 contains PowerShell 7-only syntax %q", forbidden)
+		}
+	}
+}
+
 func TestTestScriptEnforcesWallClockTimeout(t *testing.T) {
 	root := repoRoot(t)
 	tempPkg, err := os.MkdirTemp(root, "script-timeout-test-*")


### PR DESCRIPTION
## Summary
- Add PowerShell Windows installer for one-command installs into `~/.builder/bin`
- Add checksum verification, PATH/dependency prompts, service stop/restart handling, and uninstall metadata
- Add Windows installer smoke coverage in CI/release workflows and update docs

Closes #188

## Verification
- `./scripts/test.sh ./scripts -count=1`
- `./scripts/build.sh --output ./bin/builder`
- pre-push hook: format, vet, build, test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows installation support via PowerShell script with options for custom install paths, dependency installation, and service management.

* **Documentation**
  * Updated Quickstart with Windows installation instructions.
  * Expanded Release Engineering documentation with Windows installer testing and verification requirements.

* **Tests**
  * Added validation tests for Windows installer script functionality and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->