### PR TITLE
fix: handle escape rune rollback shortcut

### DIFF
--- a/cli/app/ui_keymap.go
+++ b/cli/app/ui_keymap.go
@@ -39,6 +39,11 @@ func normalizeKeyMsg(msg tea.Msg) (tea.KeyMsg, bool) {
 func normalizeKeyMsgWithSource(msg tea.Msg) (tea.KeyMsg, bool, string) {
 	if keyMsg, ok := msg.(tea.KeyMsg); ok {
 		if keyMsg.Type == tea.KeyRunes {
+			if len(keyMsg.Runes) == 1 && keyMsg.Runes[0] == '\x1b' {
+				keyMsg.Type = tea.KeyEsc
+				keyMsg.Runes = nil
+				return keyMsg, true, "keymsg_escape_rune"
+			}
 			filtered, removed := stripMouseSGRRunes(keyMsg.Runes)
 			if removed {
 				if len(filtered) == 0 {

--- a/cli/app/ui_keymap_test.go
+++ b/cli/app/ui_keymap_test.go
@@ -36,6 +36,20 @@ func TestNormalizeKeyMsgPreservesNonMouseRunes(t *testing.T) {
 	}
 }
 
+func TestNormalizeKeyMsgConvertsBareEscapeRune(t *testing.T) {
+	message := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'\x1b'}}
+	normalized, ok := normalizeKeyMsg(message)
+	if !ok {
+		t.Fatal("expected bare escape rune to normalize")
+	}
+	if normalized.Type != tea.KeyEsc {
+		t.Fatalf("expected KeyEsc, got %v", normalized.Type)
+	}
+	if len(normalized.Runes) != 0 {
+		t.Fatalf("expected normalized escape to clear runes, got %q", string(normalized.Runes))
+	}
+}
+
 func TestNormalizeKeyMsgRecognizesShiftEnterCSIUVariants(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cli/app/ui_test.go
+++ b/cli/app/ui_test.go
@@ -772,6 +772,26 @@ func TestDoubleEscEntersRollbackSelectionAndEnterStartsEditing(t *testing.T) {
 	}
 }
 
+func TestBareEscapeRuneDoubleEscEntersRollbackSelection(t *testing.T) {
+	m := newProjectedStaticUIModel(WithUIInitialTranscript([]UITranscriptEntry{
+		{Role: "user", Text: "u1"},
+		{Role: "assistant", Text: "a1"},
+	}))
+
+	escapeRune := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'\x1b'}}
+	next, _ := m.Update(escapeRune)
+	updated := next.(*uiModel)
+	next, _ = updated.Update(escapeRune)
+	updated = next.(*uiModel)
+
+	if !testRollbackSelecting(updated) {
+		t.Fatal("expected rollback selection mode after double bare escape rune")
+	}
+	if updated.input != "" {
+		t.Fatalf("expected bare escape rune not to enter prompt text, got %q", updated.input)
+	}
+}
+
 func TestRollbackSelectionHighlightsSelectedMessageFullWidth(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUIInitialTranscript([]UITranscriptEntry{
 		{Role: "user", Text: "first user"},


### PR DESCRIPTION
## Summary
- normalize bare `ESC` rune key events to `tea.KeyEsc`
- prevent invisible escape characters from entering the prompt and blocking the second Esc
- add regression coverage for bare escape rune double-Esc opening rollback selection

## Verification
- `./scripts/test.sh ./cli/app -run 'Test(NormalizeKeyMsgConvertsBareEscapeRune|BareEscapeRuneDoubleEscEntersRollbackSelection|DoubleEscEntersRollbackSelectionAndEnterStartsEditing)'`
- `./scripts/test.sh ./...`
- `./scripts/build.sh --output ./bin/builder`
- pre-push hook: formatting, `go vet`, `go build`, tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed escape key normalization to ensure reliable keyboard input handling in the CLI interface
  * Improved rollback selection mode to correctly process escape key sequences without entering input mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->