### PR TITLE
fix: restore reviewer provider auth flexibility

### DIFF
--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -158,9 +158,9 @@ Configure the supervisor agent that oversees model changes.
 | `reviewer.model` | string | inherits `model` | `BUILDER_REVIEWER_MODEL` | Separate model for the reviewer pass. If unset, Builder uses main `model`. |
 | `reviewer.thinking_level` | string | inherits `thinking_level` | `BUILDER_REVIEWER_THINKING_LEVEL` | Allowed: `low`, `medium`, `high`, `xhigh`. |
 | `reviewer.model_verbosity` | string | inherits `model_verbosity` | `BUILDER_REVIEWER_MODEL_VERBOSITY` | Text verbosity hint for supported reviewer models. Allowed: `""`, `low`, `medium`, `high`. |
-| `reviewer.provider_override` | string | inherits `provider_override` | `BUILDER_REVIEWER_PROVIDER_OVERRIDE` | Forces provider family for the reviewer model. Allowed: `openai`. |
+| `reviewer.provider_override` | string | inherits `provider_override` | `BUILDER_REVIEWER_PROVIDER_OVERRIDE` | Forces provider family for the reviewer model. Allowed: `openai`, `anthropic`. |
 | `reviewer.openai_base_url` | string | inherits `openai_base_url` for OpenAI-family reviewer providers | `BUILDER_REVIEWER_OPENAI_BASE_URL` | OpenAI-compatible base URL for the reviewer model. Non-OpenAI endpoints can run without Builder auth when the server accepts anonymous requests. |
-| `reviewer.auth` | string | `inherit` | `BUILDER_REVIEWER_AUTH` | Reviewer auth policy. `inherit` uses Builder's configured auth. `none` sends no `Authorization` header and requires a compatible explicit or inherited base URL such as a local server. |
+| `reviewer.auth` | string | `inherit` | `BUILDER_REVIEWER_AUTH` | Reviewer auth policy. `inherit` uses Builder's configured auth. `none` sends no `Authorization` header; providers that require auth return their normal runtime error. |
 | `reviewer.model_context_window` | int | inherits `model_context_window` | `BUILDER_REVIEWER_MODEL_CONTEXT_WINDOW` | Explicit reviewer context-window size sent to the reviewer provider. |
 | `reviewer.system_prompt_file` | string | `""` |  | Path to a custom supervisor system prompt file. Relative paths resolve from the config file directory. Workspace config overrides global config; no CLI or environment override is provided. |
 | `reviewer.timeout_seconds` | int | `60` | `BUILDER_REVIEWER_TIMEOUT_SECONDS` | Reviewer HTTP timeout. Must be `> 0`. |

--- a/shared/config/config_part2_test.go
+++ b/shared/config/config_part2_test.go
@@ -444,7 +444,7 @@ func TestNormalizeSettingsForPersistencePreservesReviewerCapabilityFalseWithoutS
 	}
 }
 
-func TestValidateSettingsWithSourcesTreatsSubagentReviewerOverridesAsConfigured(t *testing.T) {
+func TestValidateSettingsWithSourcesAllowsSubagentReviewerAnthropicOverride(t *testing.T) {
 	settings := defaultSettings()
 	settings.Reviewer.Model = settings.Model
 	settings.Reviewer.ProviderOverride = "anthropic"
@@ -453,11 +453,8 @@ func TestValidateSettingsWithSourcesTreatsSubagentReviewerOverridesAsConfigured(
 	sources["reviewer.provider_override"] = "subagent"
 
 	err := ValidateSettingsWithSources(settings, sources)
-	if err == nil {
-		t.Fatal("expected subagent reviewer.provider_override=anthropic to be rejected")
-	}
-	if !strings.Contains(err.Error(), "reviewer.provider_override") {
-		t.Fatalf("expected reviewer.provider_override error, got %v", err)
+	if err != nil {
+		t.Fatalf("validate settings with subagent reviewer anthropic override: %v", err)
 	}
 }
 
@@ -530,7 +527,7 @@ provider_override = "openai"
 	}
 }
 
-func TestLoadReviewerProviderRejectsInheritedAnthropicProvider(t *testing.T) {
+func TestLoadReviewerProviderInheritsAnthropicProvider(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
@@ -545,12 +542,39 @@ provider_override = "anthropic"
 		t.Fatalf("write config: %v", err)
 	}
 
-	_, err := Load(workspace, LoadOptions{})
-	if err == nil {
-		t.Fatal("expected inherited anthropic reviewer provider to fail")
+	cfg, err := Load(workspace, LoadOptions{})
+	if err != nil {
+		t.Fatalf("load: %v", err)
 	}
-	if !strings.Contains(err.Error(), "not supported for reviewer models") {
-		t.Fatalf("expected unsupported reviewer provider error, got %v", err)
+	if cfg.Settings.Reviewer.ProviderOverride != "anthropic" {
+		t.Fatalf("expected reviewer provider to inherit anthropic, got %q", cfg.Settings.Reviewer.ProviderOverride)
+	}
+}
+
+func TestLoadReviewerProviderAllowsExplicitAnthropicProvider(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configPath := filepath.Join(home, ".builder", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`model = "gpt-5.5"
+
+[reviewer]
+model = "claude-test"
+provider_override = "anthropic"
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(workspace, LoadOptions{})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Settings.Reviewer.ProviderOverride != "anthropic" {
+		t.Fatalf("expected reviewer provider override anthropic, got %q", cfg.Settings.Reviewer.ProviderOverride)
 	}
 }
 
@@ -1069,10 +1093,10 @@ verbose_output = true
 		t.Fatal("expected invalid reviewer frequency")
 	}
 	t.Setenv("BUILDER_REVIEWER_FREQUENCY", "all")
-	t.Setenv("BUILDER_REVIEWER_PROVIDER_OVERRIDE", "anthropic")
+	t.Setenv("BUILDER_REVIEWER_PROVIDER_OVERRIDE", "bogus")
 	t.Setenv("BUILDER_REVIEWER_OPENAI_BASE_URL", "")
-	if _, err := Load(workspace, LoadOptions{}); err == nil || !strings.Contains(err.Error(), "not supported for reviewer models") {
-		t.Fatalf("expected unsupported reviewer provider error, got %v", err)
+	if _, err := Load(workspace, LoadOptions{}); err == nil || !strings.Contains(err.Error(), "invalid reviewer.provider_override") {
+		t.Fatalf("expected invalid reviewer provider error, got %v", err)
 	}
 }
 
@@ -1333,7 +1357,7 @@ func TestLoadToolPreamblesPrecedence(t *testing.T) {
 	}
 }
 
-func TestLoadRejectsReviewerAuthNoneWithoutCompatibleBaseURL(t *testing.T) {
+func TestLoadAllowsReviewerAuthNoneWithoutBaseURL(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
@@ -1348,16 +1372,16 @@ auth = "none"
 		t.Fatalf("write config: %v", err)
 	}
 
-	_, err := Load(workspace, LoadOptions{})
-	if err == nil {
-		t.Fatal("expected reviewer.auth=none without compatible base URL to fail")
+	cfg, err := Load(workspace, LoadOptions{})
+	if err != nil {
+		t.Fatalf("load: %v", err)
 	}
-	if !strings.Contains(err.Error(), "reviewer.auth") || !strings.Contains(err.Error(), "api.openai.com") {
-		t.Fatalf("expected reviewer.auth api.openai.com guard error, got %v", err)
+	if cfg.Settings.Reviewer.Auth != "none" {
+		t.Fatalf("expected reviewer.auth=none, got %q", cfg.Settings.Reviewer.Auth)
 	}
 }
 
-func TestLoadRejectsReviewerAuthNoneWithFirstPartyOpenAIBaseURL(t *testing.T) {
+func TestLoadAllowsReviewerAuthNoneWithFirstPartyOpenAIBaseURL(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
@@ -1373,12 +1397,12 @@ auth = "none"
 		t.Fatalf("write config: %v", err)
 	}
 
-	_, err := Load(workspace, LoadOptions{})
-	if err == nil {
-		t.Fatal("expected reviewer.auth=none with first-party OpenAI base URL to fail")
+	cfg, err := Load(workspace, LoadOptions{})
+	if err != nil {
+		t.Fatalf("load: %v", err)
 	}
-	if !strings.Contains(err.Error(), "reviewer.auth") || !strings.Contains(err.Error(), "api.openai.com") {
-		t.Fatalf("expected reviewer.auth api.openai.com guard error, got %v", err)
+	if cfg.Settings.Reviewer.Auth != "none" {
+		t.Fatalf("expected reviewer.auth=none, got %q", cfg.Settings.Reviewer.Auth)
 	}
 }
 

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -639,7 +639,7 @@ func TestLoadSubagentRoleAllowsReviewerAuthNoneToInheritParentBaseURL(t *testing
 	}
 }
 
-func TestLoadSubagentRoleRejectsReviewerAuthNoneWithExplicitFirstPartyBaseURL(t *testing.T) {
+func TestLoadSubagentRoleAllowsReviewerAuthNoneWithExplicitFirstPartyBaseURL(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
@@ -658,12 +658,13 @@ func TestLoadSubagentRoleRejectsReviewerAuthNoneWithExplicitFirstPartyBaseURL(t 
 		t.Fatalf("write config: %v", err)
 	}
 
-	_, err := Load(workspace, LoadOptions{})
-	if err == nil {
-		t.Fatal("expected explicit first-party reviewer base URL in subagent role to fail")
+	cfg, err := Load(workspace, LoadOptions{})
+	if err != nil {
+		t.Fatalf("load: %v", err)
 	}
-	if !strings.Contains(err.Error(), "api.openai.com") {
-		t.Fatalf("expected api.openai.com guard error, got %v", err)
+	role := cfg.Settings.Subagents[BuiltInSubagentRoleFast]
+	if role.Settings.Reviewer.Auth != "none" {
+		t.Fatalf("expected subagent reviewer.auth=none, got %q", role.Settings.Reviewer.Auth)
 	}
 }
 

--- a/shared/config/config_validation.go
+++ b/shared/config/config_validation.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 
 	"builder/shared/compaction"
@@ -42,7 +41,7 @@ func validateSubagentRoleState(state settingsState, sources map[string]string) e
 		{enabled: hasExplicitSource(sources, "shell.postprocessing_mode", "shell.postprocess_hook"), check: validateShellPostprocessing},
 		{enabled: hasExplicitSource(sources, "cache_warning_mode"), check: validateCacheWarningMode},
 		{enabled: hasExplicitSource(sources, "compaction_mode"), check: validateCompactionMode},
-		{enabled: hasExplicitPrefix(sources, "reviewer."), check: validateSubagentReviewer},
+		{enabled: hasExplicitPrefix(sources, "reviewer."), check: validateReviewer},
 	}
 	for _, check := range checks {
 		if !check.enabled {
@@ -323,19 +322,7 @@ func validateCompactionMode(state settingsState, _ map[string]string) error {
 	}
 }
 
-type reviewerValidationOptions struct {
-	AllowAnonymousAuthWithoutBaseURL bool
-}
-
 func validateReviewer(state settingsState, sources map[string]string) error {
-	return validateReviewerWithOptions(state, sources, reviewerValidationOptions{})
-}
-
-func validateSubagentReviewer(state settingsState, sources map[string]string) error {
-	return validateReviewerWithOptions(state, sources, reviewerValidationOptions{AllowAnonymousAuthWithoutBaseURL: true})
-}
-
-func validateReviewerWithOptions(state settingsState, sources map[string]string, opts reviewerValidationOptions) error {
 	reviewer := state.Settings.Reviewer
 	switch strings.ToLower(strings.TrimSpace(reviewer.Frequency)) {
 	case "off", "all", "edits":
@@ -352,11 +339,9 @@ func validateReviewerWithOptions(state settingsState, sources map[string]string,
 	}
 	provider := normalizeProviderOverride(reviewer.ProviderOverride)
 	switch provider {
-	case "", "openai":
-	case "anthropic":
-		return fmt.Errorf("reviewer.provider_override %q is not supported for reviewer models", reviewer.ProviderOverride)
+	case "", "openai", "anthropic":
 	default:
-		return fmt.Errorf("invalid reviewer.provider_override %q (expected openai)", reviewer.ProviderOverride)
+		return fmt.Errorf("invalid reviewer.provider_override %q (expected openai|anthropic)", reviewer.ProviderOverride)
 	}
 	if strings.TrimSpace(reviewer.OpenAIBaseURL) != "" && provider != "" && provider != "openai" {
 		return fmt.Errorf("reviewer.provider_override %q conflicts with reviewer.openai_base_url; reviewer.openai_base_url requires reviewer.provider_override=openai or unset", reviewer.ProviderOverride)
@@ -370,12 +355,6 @@ func validateReviewerWithOptions(state settingsState, sources map[string]string,
 	switch normalizeReviewerAuth(reviewer.Auth) {
 	case "inherit":
 	case "none":
-		if !reviewerAllowsAnonymousAuth(reviewer) {
-			if opts.AllowAnonymousAuthWithoutBaseURL && strings.TrimSpace(reviewer.OpenAIBaseURL) == "" {
-				break
-			}
-			return fmt.Errorf("reviewer.auth %q requires reviewer.openai_base_url or inherited openai_base_url to be set and not point at api.openai.com", reviewer.Auth)
-		}
 	default:
 		return fmt.Errorf("invalid reviewer.auth %q (expected inherit|none)", reviewer.Auth)
 	}
@@ -383,19 +362,6 @@ func validateReviewerWithOptions(state settingsState, sources map[string]string,
 		return fmt.Errorf("reviewer.timeout_seconds must be > 0")
 	}
 	return nil
-}
-
-func reviewerAllowsAnonymousAuth(reviewer ReviewerSettings) bool {
-	baseURL := strings.TrimSpace(reviewer.OpenAIBaseURL)
-	if baseURL == "" {
-		return false
-	}
-	parsed, err := url.Parse(baseURL)
-	if err != nil {
-		return false
-	}
-	hostname := strings.TrimSpace(parsed.Hostname())
-	return hostname != "" && !strings.EqualFold(hostname, "api.openai.com")
 }
 
 func validateReviewerProviderCapabilities(capabilities ProviderCapabilitiesOverride) error {


### PR DESCRIPTION
## Summary
- allow `reviewer.auth = "none"` as an explicit auth-header opt-out without endpoint-specific config rejection
- allow reviewer provider selection/inheritance to use `anthropic`, matching main provider behavior
- update config docs and regression tests for the restored behavior

## Verification
- `./scripts/test.sh ./shared/config`
- `./scripts/test.sh ./...`
- `pnpm --dir docs test`
- `./scripts/build.sh --output ./bin/builder`
- pre-push hook: formatting, `go vet`, `go build`, tests

## Context
Follow-up to PR #215. These restore behavior that Nikita confirmed should not have been changed during review: `reviewer.auth = "none"` should be allowed wherever configured and provider/runtime should report auth failures if endpoint needs auth; reviewer provider should inherit/allow Anthropic when configured.