### PR TITLE
refactor: canonicalize TUI transcript projection

### DIFF
--- a/cli/app/ui_alt_screen_test.go
+++ b/cli/app/ui_alt_screen_test.go
@@ -423,3 +423,36 @@ func TestReturningFromDetailPreservesLiveTransientTailInOngoingView(t *testing.T
 		t.Fatalf("expected live transient tail after detail restore, got %q", got)
 	}
 }
+
+func TestReturningFromDetailPreservesTransientTailAndNextLiveAppendInOngoingView(t *testing.T) {
+	m := newProjectedTestUIModel(&runtimeControlFakeClient{}, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.transcriptEntries = []tui.TranscriptEntry{{Role: tui.TranscriptRoleUser, Text: "prompt", Committed: true}}
+	m.transcriptTotalEntries = 1
+	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries, TotalEntries: 1})
+
+	_ = m.toggleTranscriptModeWithNativeReplay(false)
+	m.transcriptEntries = append(m.transcriptEntries, tui.TranscriptEntry{
+		Role:      tui.TranscriptRoleToolCall,
+		Text:      "echo live",
+		Transient: true,
+	})
+	m.transcriptTotalEntries = 2
+
+	_ = m.toggleTranscriptModeWithNativeReplay(false)
+	if got := stripANSIAndTrimRight(m.view.OngoingSnapshot()); !strings.Contains(got, "echo live") {
+		t.Fatalf("expected transient tail after detail restore, got %q", got)
+	}
+
+	m.transcriptEntries = append(m.transcriptEntries, tui.TranscriptEntry{
+		Role:      tui.TranscriptRoleAssistant,
+		Text:      "post-restore live append",
+		Transient: true,
+	})
+	m.transcriptTotalEntries = 3
+	m.syncOngoingTailViewFromRuntimeState()
+
+	got := stripANSIAndTrimRight(m.view.OngoingSnapshot())
+	if !strings.Contains(got, "echo live") || !strings.Contains(got, "post-restore live append") {
+		t.Fatalf("expected transient tail and next live append after detail restore, got %q", got)
+	}
+}

--- a/cli/app/ui_mode_flow_test.go
+++ b/cli/app/ui_mode_flow_test.go
@@ -228,7 +228,7 @@ func TestCtrlTDeferredDetailLoadSkipsDuplicateSeededPageRequest(t *testing.T) {
 	}
 }
 
-func TestCtrlTDeferredDetailLoadSkippedDoesNotRebuildDetailEndToEnd(t *testing.T) {
+func TestCtrlTDeferredDetailLoadSkippedKeepsDetailMetricsLazyEndToEnd(t *testing.T) {
 	seed := clientui.TranscriptPage{SessionID: "session-1", Offset: 300, TotalEntries: 500}
 	for i := 0; i < 200; i++ {
 		seed.Entries = append(seed.Entries, clientui.ChatEntry{Role: "assistant", Text: fmt.Sprintf("line %03d", 300+i)})
@@ -247,16 +247,16 @@ func TestCtrlTDeferredDetailLoadSkippedDoesNotRebuildDetailEndToEnd(t *testing.T
 	next, enterCmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
 	detail := next.(*uiModel)
 	_ = collectCmdMessages(t, enterCmd)
-	beforeDeferredRefresh := detail.view.DetailRebuildCount()
+	beforeMetricsResolved := detail.view.DetailMetricsResolved()
 
 	next, refreshCmd := detail.Update(detailTranscriptLoadMsg{})
 	updated := next.(*uiModel)
 	if refreshCmd != nil {
 		t.Fatalf("expected duplicate seeded detail load to be skipped, got %T", refreshCmd())
 	}
-	afterDeferredRefresh := updated.view.DetailRebuildCount()
-	if afterDeferredRefresh != beforeDeferredRefresh {
-		t.Fatalf("duplicate deferred detail refresh rebuilt detail %d -> %d", beforeDeferredRefresh, afterDeferredRefresh)
+	afterMetricsResolved := updated.view.DetailMetricsResolved()
+	if afterMetricsResolved != beforeMetricsResolved {
+		t.Fatalf("duplicate deferred detail refresh changed detail metric resolution %v -> %v", beforeMetricsResolved, afterMetricsResolved)
 	}
 	if updated.view.Mode() != tui.ModeDetail {
 		t.Fatalf("expected detail mode to remain active, got %q", updated.view.Mode())

--- a/cli/app/ui_mode_flow_test.go
+++ b/cli/app/ui_mode_flow_test.go
@@ -248,6 +248,9 @@ func TestCtrlTDeferredDetailLoadSkippedKeepsDetailMetricsLazyEndToEnd(t *testing
 	detail := next.(*uiModel)
 	_ = collectCmdMessages(t, enterCmd)
 	beforeMetricsResolved := detail.view.DetailMetricsResolved()
+	if beforeMetricsResolved {
+		t.Fatal("expected duplicate-seeded detail entry to start with lazy metrics")
+	}
 
 	next, refreshCmd := detail.Update(detailTranscriptLoadMsg{})
 	updated := next.(*uiModel)
@@ -255,8 +258,8 @@ func TestCtrlTDeferredDetailLoadSkippedKeepsDetailMetricsLazyEndToEnd(t *testing
 		t.Fatalf("expected duplicate seeded detail load to be skipped, got %T", refreshCmd())
 	}
 	afterMetricsResolved := updated.view.DetailMetricsResolved()
-	if afterMetricsResolved != beforeMetricsResolved {
-		t.Fatalf("duplicate deferred detail refresh changed detail metric resolution %v -> %v", beforeMetricsResolved, afterMetricsResolved)
+	if afterMetricsResolved {
+		t.Fatal("expected duplicate deferred detail refresh to keep detail metrics lazy")
 	}
 	if updated.view.Mode() != tui.ModeDetail {
 		t.Fatalf("expected detail mode to remain active, got %q", updated.view.Mode())

--- a/cli/tui/detail_compact_part2_test.go
+++ b/cli/tui/detail_compact_part2_test.go
@@ -13,9 +13,10 @@ import (
 func leadingViewportSelectableDetailEntry(t *testing.T, m Model) int {
 	t.Helper()
 
-	owners := m.currentDetailViewport().Owners
+	lookup := newDetailProjectionLookup(m.detailViewProjection())
+	owners := lookup.projection.DetailViewport(m.currentDetailViewportState()).Owners
 	for _, entryIndex := range owners {
-		if entryIndex < 0 || m.detailBlockIndexForEntry(entryIndex) < 0 {
+		if lookup.blockIndexForEntry(entryIndex) < 0 {
 			continue
 		}
 		return entryIndex
@@ -88,7 +89,8 @@ func assertRailBearingSpacerLine(t *testing.T, line string, modeBg rgbColor, rai
 func centerVisibleSelectableDetailEntry(t *testing.T, m Model) int {
 	t.Helper()
 
-	owners := m.currentDetailViewport().Owners
+	lookup := newDetailProjectionLookup(m.detailViewProjection())
+	owners := lookup.projection.DetailViewport(m.currentDetailViewportState()).Owners
 	if len(owners) == 0 {
 		t.Fatal("expected visible detail entries")
 	}
@@ -99,7 +101,7 @@ func centerVisibleSelectableDetailEntry(t *testing.T, m Model) int {
 	bestEntry := -1
 	bestDistance := len(owners) + 1
 	for lineIndex, entryIndex := range owners {
-		if entryIndex < 0 || m.detailBlockIndexForEntry(entryIndex) < 0 {
+		if lookup.blockIndexForEntry(entryIndex) < 0 {
 			continue
 		}
 		distance := detailLineDistance(lineIndex, anchor)

--- a/cli/tui/detail_compact_part2_test.go
+++ b/cli/tui/detail_compact_part2_test.go
@@ -13,13 +13,14 @@ import (
 func leadingViewportSelectableDetailEntry(t *testing.T, m Model) int {
 	t.Helper()
 
-	for _, entryIndex := range m.detailLineEntryIndices {
+	owners := m.currentDetailViewport().Owners
+	for _, entryIndex := range owners {
 		if entryIndex < 0 || m.detailBlockIndexForEntry(entryIndex) < 0 {
 			continue
 		}
 		return entryIndex
 	}
-	t.Fatalf("expected visible selectable detail entry, owners=%+v", m.detailLineEntryIndices)
+	t.Fatalf("expected visible selectable detail entry, owners=%+v", owners)
 	return -1
 }
 
@@ -87,16 +88,17 @@ func assertRailBearingSpacerLine(t *testing.T, line string, modeBg rgbColor, rai
 func centerVisibleSelectableDetailEntry(t *testing.T, m Model) int {
 	t.Helper()
 
-	if len(m.detailLineEntryIndices) == 0 {
+	owners := m.currentDetailViewport().Owners
+	if len(owners) == 0 {
 		t.Fatal("expected visible detail entries")
 	}
 	anchor := m.viewportLines / 2
-	if anchor >= len(m.detailLineEntryIndices) {
-		anchor = len(m.detailLineEntryIndices) - 1
+	if anchor >= len(owners) {
+		anchor = len(owners) - 1
 	}
 	bestEntry := -1
-	bestDistance := len(m.detailLineEntryIndices) + 1
-	for lineIndex, entryIndex := range m.detailLineEntryIndices {
+	bestDistance := len(owners) + 1
+	for lineIndex, entryIndex := range owners {
 		if entryIndex < 0 || m.detailBlockIndexForEntry(entryIndex) < 0 {
 			continue
 		}
@@ -108,7 +110,7 @@ func centerVisibleSelectableDetailEntry(t *testing.T, m Model) int {
 		bestDistance = distance
 	}
 	if bestEntry < 0 {
-		t.Fatalf("expected center visible selectable detail entry, owners=%+v", m.detailLineEntryIndices)
+		t.Fatalf("expected center visible selectable detail entry, owners=%+v", owners)
 	}
 	return bestEntry
 }

--- a/cli/tui/detail_compact_test.go
+++ b/cli/tui/detail_compact_test.go
@@ -94,17 +94,18 @@ func TestCompactDetailToggleStartsWithMultilineTailBlockSelected(t *testing.T) {
 		t.Fatal("expected visible selectable detail entries")
 	}
 	want := visible[len(visible)-1]
+	owners := m.currentDetailViewport().Owners
 	if !m.detailSelectedActive || m.detailSelectedEntry != want {
-		t.Fatalf("expected multiline tail block selected on detail open, got active=%v entry=%d want=%d visible=%+v owners=%+v", m.detailSelectedActive, m.detailSelectedEntry, want, visible, m.detailLineEntryIndices)
+		t.Fatalf("expected multiline tail block selected on detail open, got active=%v entry=%d want=%d visible=%+v owners=%+v", m.detailSelectedActive, m.detailSelectedEntry, want, visible, owners)
 	}
 	selectedLines := 0
-	for _, owner := range m.detailLineEntryIndices {
+	for _, owner := range owners {
 		if owner == want {
 			selectedLines++
 		}
 	}
 	if selectedLines < 2 {
-		t.Fatalf("expected bottom-selected tail block to own multiple visible lines, got %d owners=%+v", selectedLines, m.detailLineEntryIndices)
+		t.Fatalf("expected bottom-selected tail block to own multiple visible lines, got %d owners=%+v", selectedLines, owners)
 	}
 }
 
@@ -124,7 +125,7 @@ func TestCompactDetailViewportShrinkKeepsBottomSelectionVisible(t *testing.T) {
 	}
 	want := visible[len(visible)-1]
 	if !m.detailSelectedActive || m.detailSelectedEntry != want {
-		t.Fatalf("expected bottom visible entry selected after viewport shrink, got active=%v entry=%d want=%d visible=%+v owners=%+v", m.detailSelectedActive, m.detailSelectedEntry, want, visible, m.detailLineEntryIndices)
+		t.Fatalf("expected bottom visible entry selected after viewport shrink, got active=%v entry=%d want=%d visible=%+v owners=%+v", m.detailSelectedActive, m.detailSelectedEntry, want, visible, m.currentDetailViewport().Owners)
 	}
 }
 
@@ -222,7 +223,6 @@ func TestCompactDetailSelectedSpacerRowsAreVisualOnlyWithTallExpandedEntry(t *te
 	m.detailSelectedEntry = 1
 	m.detailSelectedActive = true
 	m = updateModel(t, m, tea.KeyMsg{Type: tea.KeyEnter})
-	m.ensureDetailMetricsResolved()
 	targetEntry := 3
 	targetStart, _, ok := m.detailLineRangeForEntry(targetEntry)
 	if !ok {

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -5,7 +5,6 @@ import (
 	"builder/shared/transcript"
 	"fmt"
 	"regexp"
-	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -195,11 +194,7 @@ type Model struct {
 	snapOngoingOnViewportResize bool
 	toolSymbolGap               int
 
-	transcript             []TranscriptEntry
-	transcriptBaseOffset   int
-	transcriptTotalEntries int
-	ongoing                string
-	streamingReasoning     []StreamingReasoningEntry
+	transcriptInput TranscriptProjectionInput
 
 	selectedTranscriptEntry  int
 	selectedTranscriptActive bool
@@ -207,42 +202,18 @@ type Model struct {
 	detailSelectedActive     bool
 	detailExpandedEntries    map[int]struct{}
 
-	detailSnapshot          string
-	detailLines             []string
-	detailLineKinds         []VisibleLineKind
-	detailLineEntryIndices  []int
-	detailEntryLineRanges   []lineRange
-	detailBlockLineRanges   []lineRange
-	detailEntryRangeOffset  int
-	detailBlocks            []detailBlockSpec
-	detailBlockLines        [][]string
-	detailTotalLineCount    int
-	detailMetricsResolved   bool
 	detailBottomAnchor      bool
 	detailBottomOffset      int
-	detailDirty             bool
-	detailStale             bool
-	detailRebuildCount      int
-	ongoingSnapshot         string
-	ongoingLineCache        []string
-	ongoingLineKinds        []VisibleLineKind
-	ongoingBaseLines        []string
-	ongoingBaseLineKinds    []VisibleLineKind
-	ongoingBaseLastGroup    string
-	ongoingStreamingLines   []string
-	ongoingStreamingKinds   []VisibleLineKind
-	ongoingStreamingDivider bool
-	ongoingBaseDirty        bool
-	ongoingDirty            bool
 	ongoingError            string
 	theme                   string
 	md                      *markdownRenderer
 	code                    *codeRenderer
+	viewProjector           *TranscriptViewProjector
 	renderDiagnosticHandler RenderDiagnosticHandler
 }
 
 func (m Model) DetailScroll() int {
-	if m.detailBottomAnchor && !m.detailMetricsResolved {
+	if m.detailBottomAnchor {
 		return m.detailBottomOffset
 	}
 	return m.detailScroll
@@ -253,11 +224,11 @@ func (m Model) DetailMaxScroll() int {
 }
 
 func (m Model) DetailMetricsResolved() bool {
-	return !m.detailDirty && !m.detailBottomAnchor
+	return !m.detailBottomAnchor
 }
 
 func (m Model) DetailRebuildCount() int {
-	return m.detailRebuildCount
+	return 0
 }
 
 func (m Model) DetailSelectedEntry() (int, bool) {
@@ -280,26 +251,26 @@ func (m Model) DetailSelectedExpansionAction() (string, bool) {
 }
 
 func (m Model) TranscriptBaseOffset() int {
-	return m.transcriptBaseOffset
+	return m.transcriptInput.BaseOffset
 }
 
 func (m Model) TranscriptTotalEntries() int {
-	if m.transcriptTotalEntries > 0 {
-		return m.transcriptTotalEntries
+	if m.transcriptInput.TotalEntries > 0 {
+		return m.transcriptInput.TotalEntries
 	}
-	return m.transcriptBaseOffset + len(m.transcript)
+	return m.transcriptInput.BaseOffset + len(m.transcriptInput.Entries)
 }
 
 func (m Model) LoadedTranscriptEntryCount() int {
-	return len(m.transcript)
+	return len(m.transcriptInput.Entries)
 }
 
 func (m Model) LoadedTranscriptEntries() []TranscriptEntry {
-	if len(m.transcript) == 0 {
+	if len(m.transcriptInput.Entries) == 0 {
 		return nil
 	}
-	entries := make([]TranscriptEntry, 0, len(m.transcript))
-	for _, entry := range m.transcript {
+	entries := make([]TranscriptEntry, 0, len(m.transcriptInput.Entries))
+	for _, entry := range m.transcriptInput.Entries {
 		copyEntry := entry
 		copyEntry.ToolCall = cloneToolCallMeta(entry.ToolCall)
 		entries = append(entries, copyEntry)
@@ -310,7 +281,7 @@ func (m Model) LoadedTranscriptEntries() []TranscriptEntry {
 func (m Model) DetailVisibleEntryRange() (int, int, bool) {
 	first := -1
 	last := -1
-	for _, entryIndex := range m.detailLineEntryIndices {
+	for _, entryIndex := range m.currentDetailViewport().Owners {
 		if entryIndex < 0 {
 			continue
 		}
@@ -329,12 +300,12 @@ func (m Model) absoluteTranscriptIndex(localIndex int) int {
 	if localIndex < 0 {
 		return -1
 	}
-	return m.transcriptBaseOffset + localIndex
+	return m.transcriptInput.BaseOffset + localIndex
 }
 
 func (m Model) localTranscriptIndex(absoluteIndex int) (int, bool) {
-	local := absoluteIndex - m.transcriptBaseOffset
-	if local < 0 || local >= len(m.transcript) {
+	local := absoluteIndex - m.transcriptInput.BaseOffset
+	if local < 0 || local >= len(m.transcriptInput.Entries) {
 		return 0, false
 	}
 	return local, true
@@ -362,16 +333,20 @@ type detailBlockSpec struct {
 	render     func(Model, string) []string
 }
 
+type ongoingLineParts struct {
+	base             []TranscriptProjectionLine
+	streaming        []TranscriptProjectionLine
+	streamingDivider bool
+}
+
 func NewModel(opts ...Option) Model {
 	m := Model{
-		mode:             ModeOngoing,
-		viewportLines:    DefaultPreviewLines,
-		viewportWidth:    120,
-		toolSymbolGap:    1,
-		theme:            normalizeTheme(""),
-		ongoingBaseDirty: true,
-		ongoingDirty:     true,
-		detailDirty:      true,
+		mode:          ModeOngoing,
+		viewportLines: DefaultPreviewLines,
+		viewportWidth: 120,
+		toolSymbolGap: 1,
+		theme:         normalizeTheme(""),
+		viewProjector: &TranscriptViewProjector{},
 	}
 	for _, opt := range opts {
 		opt(&m)
@@ -417,13 +392,7 @@ func (m *Model) VisibleLineKinds() []VisibleLineKind {
 		return nil
 	}
 	if m.mode == ModeDetail {
-		if m.detailDirty {
-			m.rebuildDetailSnapshot()
-		}
-		return visibleKindsForViewport(m.detailLineKinds, m.viewportLines)
-	}
-	if m.ongoingDirty {
-		m.rebuildOngoingSnapshot()
+		return visibleKindsForViewport(m.currentDetailViewport().Kinds, m.viewportLines)
 	}
 	return m.visibleOngoingLineKinds()
 }
@@ -473,12 +442,6 @@ func (m Model) OngoingScroll() int {
 }
 
 func (m Model) OngoingSnapshot() string {
-	if m.ongoingDirty {
-		return m.renderFlatOngoingTranscript()
-	}
-	if m.ongoingSnapshot != "" {
-		return m.ongoingSnapshot
-	}
 	return strings.Join(m.ongoingLines(), "\n")
 }
 
@@ -487,7 +450,7 @@ func (m Model) OngoingCommittedSnapshot() string {
 }
 
 func (m Model) OngoingStreamingText() string {
-	return m.ongoing
+	return m.transcriptInput.Ongoing
 }
 
 func (m Model) OngoingErrorText() string {
@@ -526,10 +489,6 @@ func (m Model) transitionMode(target Mode, skipDetailWarmup bool) Model {
 		if skipDetailWarmup {
 			return m
 		}
-		if !skipDetailWarmup && (m.detailDirty || m.detailStale || len(m.detailLines) == 0) {
-			m.rebuildDetailSnapshot()
-			m.detailStale = false
-		}
 		m.refreshDetailViewport()
 		if m.compactDetail {
 			m.focusBottomVisibleDetailEntry()
@@ -564,7 +523,7 @@ func (m Model) scrollDetail(delta int) Model {
 }
 
 func (m *Model) scrollDetailLine(delta int) bool {
-	if m.detailBottomAnchor && !m.detailMetricsResolved {
+	if m.detailBottomAnchor {
 		before := m.detailBottomOffset
 		nextOffset := m.detailBottomOffset - delta
 		if nextOffset < 0 {
@@ -585,17 +544,15 @@ func (m *Model) ensureDetailSelection() {
 	if m == nil {
 		return
 	}
-	if m.detailDirty {
-		m.rebuildDetailSnapshot()
-	}
 	if m.detailSelectedActive && m.detailBlockIndexForEntry(m.detailSelectedEntry) >= 0 {
 		return
 	}
-	for idx := len(m.detailBlocks) - 1; idx >= 0; idx-- {
-		if !m.detailBlocks[idx].selectable {
+	blocks := m.detailProjectionBlocks()
+	for idx := len(blocks) - 1; idx >= 0; idx-- {
+		if !blocks[idx].Selectable {
 			continue
 		}
-		m.detailSelectedEntry = m.detailBlocks[idx].entryIndex
+		m.detailSelectedEntry = blocks[idx].EntryIndex
 		m.detailSelectedActive = true
 		return
 	}
@@ -608,30 +565,28 @@ func (m *Model) focusCenterVisibleDetailEntry() {
 }
 
 func (m *Model) focusBottomVisibleDetailEntry() {
-	m.focusVisibleDetailEntry(len(m.detailLineEntryIndices) - 1)
+	m.focusVisibleDetailEntry(len(m.currentDetailViewport().Owners) - 1)
 }
 
 func (m *Model) focusVisibleDetailEntry(anchor int) {
 	if m == nil || !m.compactDetail {
 		return
 	}
-	if m.detailDirty {
-		m.rebuildDetailSnapshot()
-	}
-	if len(m.detailLineEntryIndices) == 0 {
+	owners := m.currentDetailViewport().Owners
+	if len(owners) == 0 {
 		m.ensureDetailSelection()
 		return
 	}
-	if anchor >= len(m.detailLineEntryIndices) {
-		anchor = len(m.detailLineEntryIndices) - 1
+	if anchor >= len(owners) {
+		anchor = len(owners) - 1
 	}
 	if anchor < 0 {
 		m.ensureDetailSelection()
 		return
 	}
 	bestEntry := -1
-	bestDistance := len(m.detailLineEntryIndices) + 1
-	for lineIndex, entryIndex := range m.detailLineEntryIndices {
+	bestDistance := len(owners) + 1
+	for lineIndex, entryIndex := range owners {
 		if entryIndex < 0 || m.detailBlockIndexForEntry(entryIndex) < 0 {
 			continue
 		}
@@ -679,9 +634,6 @@ func (m *Model) moveDetailSelectionTowardCenterAtScrollEdge(delta int) bool {
 	if m == nil || !m.compactDetail || (delta != -1 && delta != 1) {
 		return false
 	}
-	if m.detailDirty {
-		m.rebuildDetailSnapshot()
-	}
 	first, last, ok := m.visibleDetailEntryLineRange(m.detailSelectedEntry)
 	if !m.detailSelectedActive || !ok {
 		return false
@@ -726,8 +678,9 @@ func (m *Model) selectVisibleDetailEntryInLineDirection(startLine int, delta int
 	if m == nil || delta == 0 {
 		return false
 	}
-	for lineIndex := startLine; lineIndex >= 0 && lineIndex < len(m.detailLineEntryIndices); lineIndex += delta {
-		entryIndex := m.detailLineEntryIndices[lineIndex]
+	owners := m.currentDetailViewport().Owners
+	for lineIndex := startLine; lineIndex >= 0 && lineIndex < len(owners); lineIndex += delta {
+		entryIndex := owners[lineIndex]
 		if entryIndex < 0 || entryIndex == m.detailSelectedEntry || m.detailBlockIndexForEntry(entryIndex) < 0 {
 			continue
 		}
@@ -742,7 +695,7 @@ func (m Model) visibleDetailEntryLineRange(entryIndex int) (int, int, bool) {
 	}
 	first := -1
 	last := -1
-	for lineIndex, owner := range m.detailLineEntryIndices {
+	for lineIndex, owner := range m.currentDetailViewport().Owners {
 		if owner != entryIndex {
 			continue
 		}
@@ -758,12 +711,10 @@ func (m *Model) visibleSelectableDetailEntries() []int {
 	if m == nil {
 		return nil
 	}
-	if m.detailDirty {
-		m.rebuildDetailSnapshot()
-	}
-	entries := make([]int, 0, len(m.detailLineEntryIndices))
-	seen := make(map[int]struct{}, len(m.detailLineEntryIndices))
-	for _, entryIndex := range m.detailLineEntryIndices {
+	owners := m.currentDetailViewport().Owners
+	entries := make([]int, 0, len(owners))
+	seen := make(map[int]struct{}, len(owners))
+	for _, entryIndex := range owners {
 		if entryIndex < 0 || m.detailBlockIndexForEntry(entryIndex) < 0 {
 			continue
 		}
@@ -780,22 +731,20 @@ func (m *Model) centerVisibleSelectableDetailEntry() int {
 	if m == nil {
 		return -1
 	}
-	if m.detailDirty {
-		m.rebuildDetailSnapshot()
-	}
-	if len(m.detailLineEntryIndices) == 0 {
+	owners := m.currentDetailViewport().Owners
+	if len(owners) == 0 {
 		return -1
 	}
 	anchor := m.viewportLines / 2
-	if anchor >= len(m.detailLineEntryIndices) {
-		anchor = len(m.detailLineEntryIndices) - 1
+	if anchor >= len(owners) {
+		anchor = len(owners) - 1
 	}
 	if anchor < 0 {
 		return -1
 	}
 	bestEntry := -1
-	bestDistance := len(m.detailLineEntryIndices) + 1
-	for lineIndex, entryIndex := range m.detailLineEntryIndices {
+	bestDistance := len(owners) + 1
+	for lineIndex, entryIndex := range owners {
 		if entryIndex < 0 || m.detailBlockIndexForEntry(entryIndex) < 0 {
 			continue
 		}
@@ -827,12 +776,16 @@ func detailVisibleEntryIndex(entries []int, entryIndex int) int {
 }
 
 func (m Model) detailBlockIndexForEntry(entryIndex int) int {
-	for idx, block := range m.detailBlocks {
-		if block.selectable && block.entryIndex == entryIndex {
+	for idx, block := range m.detailProjectionBlocks() {
+		if block.Selectable && block.EntryIndex == entryIndex {
 			return idx
 		}
 	}
 	return -1
+}
+
+func (m Model) detailProjectionBlocks() []TranscriptProjectionBlock {
+	return m.detailViewProjection().Detail.Blocks
 }
 
 func (m Model) maxOngoingScroll() int {
@@ -844,14 +797,10 @@ func (m Model) maxOngoingScroll() int {
 }
 
 func (m *Model) maxDetailScroll() int {
-	if m.detailBottomAnchor && !m.detailMetricsResolved {
+	if m.detailBottomAnchor {
 		return m.detailBottomOffset
 	}
-	m.ensureDetailMetricsResolved()
-	if m.detailTotalLineCount <= m.viewportLines {
-		return 0
-	}
-	return m.detailTotalLineCount - m.viewportLines
+	return m.detailViewProjection().DetailViewport(ProjectionViewportState{ViewportLines: m.viewportLines}).MaxScroll
 }
 
 func (m Model) isOngoingAtBottom() bool {
@@ -859,7 +808,8 @@ func (m Model) isOngoingAtBottom() bool {
 }
 
 func (m Model) renderOngoing() string {
-	lineCount := m.ongoingRenderedLineCount()
+	parts := m.ongoingLineParts()
+	lineCount := parts.lineCount()
 	start := clamp(m.ongoingScroll, 0, m.maxOngoingScroll())
 	end := start + m.viewportLines
 	if end > lineCount {
@@ -868,7 +818,7 @@ func (m Model) renderOngoing() string {
 
 	out := make([]string, 0, m.viewportLines+1)
 	for i := start; i < end; i++ {
-		out = append(out, m.ongoingLineAt(i))
+		out = append(out, parts.lineAt(i).Text)
 	}
 	for len(out) < m.viewportLines {
 		out = append(out, "")
@@ -877,89 +827,106 @@ func (m Model) renderOngoing() string {
 }
 
 func (m Model) ongoingLines() []string {
-	if m.ongoingDirty {
-		return splitLines(m.renderFlatOngoingTranscript())
-	}
-	if len(m.ongoingLineCache) > 0 {
-		return m.ongoingLineCache
-	}
-	lineCount := m.ongoingRenderedLineCount()
-	lines := make([]string, 0, lineCount)
-	for idx := 0; idx < lineCount; idx++ {
-		lines = append(lines, m.ongoingLineAt(idx))
-	}
-	if len(lines) == 0 {
-		return []string{""}
+	parts := m.ongoingLineParts()
+	lines := make([]string, 0, parts.lineCount())
+	for idx := 0; idx < parts.lineCount(); idx++ {
+		lines = append(lines, parts.lineAt(idx).Text)
 	}
 	return lines
 }
 
-func (m *Model) invalidateOngoingSnapshot() {
-	m.ongoingDirty = true
-	m.ongoingSnapshot = ""
-	m.ongoingLineCache = nil
-	m.ongoingLineKinds = nil
+func (m Model) transcriptViewProjection() TranscriptViewProjection {
+	if m.viewProjector == nil {
+		return ProjectTranscriptViews(m.TranscriptProjectionInput(), m.TranscriptProjectionViewState())
+	}
+	return m.viewProjector.ProjectShared(m.transcriptProjectionInput(), m.TranscriptProjectionViewState())
 }
 
-func (m *Model) invalidateOngoingBaseSnapshot() {
-	m.ongoingBaseDirty = true
-	m.invalidateOngoingSnapshot()
+func (m Model) currentDetailViewport() ProjectionViewport {
+	return m.detailViewProjection().DetailViewport(ProjectionViewportState{
+		ViewportLines: m.viewportLines,
+		Scroll:        m.detailScroll,
+		BottomAnchor:  m.detailBottomAnchor,
+		BottomOffset:  m.detailBottomOffset,
+	})
 }
 
-func (m *Model) rebuildOngoingSnapshot() {
-	if m.ongoingBaseDirty {
-		projection := m.OngoingProjection(false)
-		lines := projection.Lines(detailDivider())
-		m.ongoingBaseLines = m.ongoingBaseLines[:0]
-		m.ongoingBaseLineKinds = m.ongoingBaseLineKinds[:0]
-		m.ongoingBaseLastGroup = ""
-		for _, line := range lines {
-			m.ongoingBaseLines = append(m.ongoingBaseLines, line.Text)
-			m.ongoingBaseLineKinds = append(m.ongoingBaseLineKinds, line.Kind)
-		}
+func (m Model) detailViewProjection() TranscriptViewProjection {
+	if m.viewProjector == nil {
+		return transcriptViewProjectionForDetail(m.transcriptInput.Revision, ProjectTranscriptViews(m.TranscriptProjectionInput(), m.TranscriptProjectionViewState()).Detail)
+	}
+	return m.viewProjector.ProjectDetailShared(m.transcriptProjectionInput(), m.TranscriptProjectionViewState())
+}
+
+func (m Model) ongoingLineParts() ongoingLineParts {
+	input := m.transcriptProjectionInput()
+	state := m.TranscriptProjectionViewState()
+	var base []TranscriptProjectionLine
+	lastGroup := ""
+	if m.viewProjector != nil {
+		base, lastGroup = m.viewProjector.CommittedOngoingLines(input, state)
+	} else {
+		projection := projectCommittedOngoingTranscriptWithRenderer(
+			committedOngoingProjectionRenderer(state.Theme, state.ViewportWidth, input.BaseOffset),
+			input.Entries,
+		)
+		base = projection.Lines(detailDivider())
 		if blockCount := len(projection.Blocks); blockCount > 0 {
-			m.ongoingBaseLastGroup = projection.Blocks[blockCount-1].DividerGroup
-		}
-		m.ongoingBaseDirty = false
-	}
-	m.ongoingStreamingLines = m.ongoingStreamingLines[:0]
-	m.ongoingStreamingKinds = m.ongoingStreamingKinds[:0]
-	m.ongoingStreamingDivider = false
-	if strings.TrimSpace(m.ongoing) != "" {
-		m.ongoingStreamingLines = append(m.ongoingStreamingLines, m.flattenEntryPlain("assistant", m.ongoing)...)
-		if len(m.ongoingStreamingLines) > 0 {
-			m.ongoingStreamingKinds = make([]VisibleLineKind, len(m.ongoingStreamingLines))
-			if len(m.ongoingBaseLines) > 0 && m.ongoingBaseLastGroup != ongoingDividerGroup("assistant") {
-				m.ongoingStreamingDivider = true
-			}
+			lastGroup = projection.Blocks[blockCount-1].DividerGroup
 		}
 	}
-	if len(m.ongoingBaseLines) == 0 && !m.ongoingStreamingDivider && len(m.ongoingStreamingLines) == 0 {
-		m.ongoingSnapshot = ""
-		m.ongoingLineCache = []string{""}
-		m.ongoingLineKinds = []VisibleLineKind{VisibleLineContent}
-		m.ongoingDirty = false
-		return
+	if pending := m.pendingOngoingProjectionLines(input, state, lastGroup); len(pending.lines) > 0 {
+		base = append(base, pending.lines...)
+		lastGroup = pending.lastGroup
 	}
-	plain := make([]string, 0, len(m.ongoingBaseLines)+len(m.ongoingStreamingLines)+1)
-	kinds := make([]VisibleLineKind, 0, len(m.ongoingBaseLineKinds)+len(m.ongoingStreamingKinds)+1)
-	plain = append(plain, m.ongoingBaseLines...)
-	kinds = append(kinds, m.ongoingBaseLineKinds...)
-	if m.ongoingStreamingDivider {
-		plain = append(plain, detailDivider())
-		kinds = append(kinds, VisibleLineDivider)
-	}
-	plain = append(plain, m.ongoingStreamingLines...)
-	kinds = append(kinds, m.ongoingStreamingKinds...)
-	m.ongoingSnapshot = strings.Join(plain, "\n")
-	m.ongoingLineCache = plain
-	m.ongoingLineKinds = kinds
-	m.ongoingDirty = false
+	streamingLines := m.streamingOngoingProjectionLines()
+	parts := ongoingLineParts{base: base, streaming: streamingLines}
+	parts.streamingDivider = len(base) > 0 && len(streamingLines) > 0 && lastGroup != ongoingDividerGroup(RenderIntentAssistant)
+	return parts
 }
 
-func (m Model) ongoingRenderedLineCount() int {
-	total := len(m.ongoingBaseLines) + len(m.ongoingStreamingLines)
-	if m.ongoingStreamingDivider {
+type pendingOngoingLines struct {
+	lines     []TranscriptProjectionLine
+	lastGroup string
+}
+
+func (m Model) pendingOngoingProjectionLines(input TranscriptProjectionInput, state TranscriptProjectionViewState, previousGroup string) pendingOngoingLines {
+	pendingEntries := PendingOngoingEntries(input.Entries)
+	if len(pendingEntries) == 0 {
+		return pendingOngoingLines{}
+	}
+	projection := renderPendingOngoingSnapshotProjection(pendingEntries, state.Theme, state.ViewportWidth, uniformPendingSpinnerFrame(""))
+	if len(projection.Blocks) == 0 {
+		return pendingOngoingLines{}
+	}
+	lines := projection.Lines(detailDivider())
+	if previousGroup != "" && previousGroup != projection.Blocks[0].DividerGroup {
+		lines = append([]TranscriptProjectionLine{{Kind: VisibleLineDivider, Text: detailDivider()}}, lines...)
+	}
+	return pendingOngoingLines{lines: lines, lastGroup: projection.Blocks[len(projection.Blocks)-1].DividerGroup}
+}
+
+func (m Model) streamingOngoingProjectionLines() []TranscriptProjectionLine {
+	if strings.TrimSpace(m.transcriptInput.Ongoing) == "" {
+		return nil
+	}
+	if m.viewProjector != nil {
+		return m.viewProjector.StreamingOngoingLines(m.transcriptInput.Ongoing, m.TranscriptProjectionViewState())
+	}
+	lines := m.flattenEntryPlain(RenderIntentAssistant, m.transcriptInput.Ongoing)
+	if len(lines) == 0 {
+		return nil
+	}
+	out := make([]TranscriptProjectionLine, 0, len(lines))
+	for _, line := range lines {
+		out = append(out, TranscriptProjectionLine{Kind: VisibleLineContent, Text: line})
+	}
+	return out
+}
+
+func (p ongoingLineParts) lineCount() int {
+	total := len(p.base) + len(p.streaming)
+	if p.streamingDivider {
 		total++
 	}
 	if total == 0 {
@@ -968,64 +935,71 @@ func (m Model) ongoingRenderedLineCount() int {
 	return total
 }
 
-func (m Model) ongoingLineAt(index int) string {
-	if index < 0 || index >= m.ongoingRenderedLineCount() {
-		return ""
+func (p ongoingLineParts) lineAt(index int) TranscriptProjectionLine {
+	if index < 0 || index >= p.lineCount() {
+		return TranscriptProjectionLine{Kind: VisibleLineContent}
 	}
-	if len(m.ongoingBaseLines) == 0 && !m.ongoingStreamingDivider && len(m.ongoingStreamingLines) == 0 {
-		return ""
+	if len(p.base) == 0 && !p.streamingDivider && len(p.streaming) == 0 {
+		return TranscriptProjectionLine{Kind: VisibleLineContent}
 	}
-	if index < len(m.ongoingBaseLines) {
-		return m.ongoingBaseLines[index]
+	if index < len(p.base) {
+		return p.base[index]
 	}
-	index -= len(m.ongoingBaseLines)
-	if m.ongoingStreamingDivider {
+	index -= len(p.base)
+	if p.streamingDivider {
 		if index == 0 {
-			return detailDivider()
+			return TranscriptProjectionLine{Kind: VisibleLineDivider, Text: detailDivider()}
 		}
 		index--
 	}
-	if index >= 0 && index < len(m.ongoingStreamingLines) {
-		return m.ongoingStreamingLines[index]
+	if index >= 0 && index < len(p.streaming) {
+		return p.streaming[index]
 	}
-	return ""
+	return TranscriptProjectionLine{Kind: VisibleLineContent}
+}
+
+func (m Model) ongoingProjectionLines() []TranscriptProjectionLine {
+	parts := m.ongoingLineParts()
+	lines := make([]TranscriptProjectionLine, 0, parts.lineCount())
+	for idx := 0; idx < parts.lineCount(); idx++ {
+		lines = append(lines, parts.lineAt(idx))
+	}
+	return lines
+}
+
+func (m Model) ongoingRenderedLineCount() int {
+	return m.ongoingLineParts().lineCount()
+}
+
+func (m Model) ongoingLineAt(index int) string {
+	parts := m.ongoingLineParts()
+	if index < 0 || index >= parts.lineCount() {
+		return ""
+	}
+	return parts.lineAt(index).Text
 }
 
 func (m Model) ongoingLineKindAt(index int) VisibleLineKind {
-	if index < 0 || index >= m.ongoingRenderedLineCount() {
+	parts := m.ongoingLineParts()
+	if index < 0 || index >= parts.lineCount() {
 		return VisibleLineContent
 	}
-	if len(m.ongoingBaseLines) == 0 && !m.ongoingStreamingDivider && len(m.ongoingStreamingLines) == 0 {
-		return VisibleLineContent
-	}
-	if index < len(m.ongoingBaseLineKinds) {
-		return m.ongoingBaseLineKinds[index]
-	}
-	index -= len(m.ongoingBaseLineKinds)
-	if m.ongoingStreamingDivider {
-		if index == 0 {
-			return VisibleLineDivider
-		}
-		index--
-	}
-	if index >= 0 && index < len(m.ongoingStreamingKinds) {
-		return m.ongoingStreamingKinds[index]
-	}
-	return VisibleLineContent
+	return parts.lineAt(index).Kind
 }
 
 func (m Model) visibleOngoingLineKinds() []VisibleLineKind {
 	if m.viewportLines <= 0 {
 		return nil
 	}
+	parts := m.ongoingLineParts()
 	start := clamp(m.ongoingScroll, 0, m.maxOngoingScroll())
 	end := start + m.viewportLines
-	if total := m.ongoingRenderedLineCount(); end > total {
-		end = total
+	if end > parts.lineCount() {
+		end = parts.lineCount()
 	}
 	out := make([]VisibleLineKind, 0, m.viewportLines)
 	for idx := start; idx < end; idx++ {
-		out = append(out, m.ongoingLineKindAt(idx))
+		out = append(out, parts.lineAt(idx).Kind)
 	}
 	for len(out) < m.viewportLines {
 		out = append(out, VisibleLineContent)
@@ -1034,20 +1008,19 @@ func (m Model) visibleOngoingLineKinds() []VisibleLineKind {
 }
 
 func (m Model) renderDetailSnapshot() string {
-	if m.detailDirty {
-		m.rebuildDetailSnapshot()
-	}
-	lines := m.detailLines
+	viewport := m.currentDetailViewport()
+	lines := viewport.Lines
 	if len(lines) == 0 {
 		lines = []string{""}
 	}
+	owners := viewport.Owners
 
 	out := make([]string, 0, m.viewportLines)
 	selectedEntry, highlightSelected := m.resolveDetailSelection()
 	firstSelectedLine := -1
 	lastSelectedLine := -1
 	if highlightSelected && m.compactDetail {
-		for i, entryIndex := range m.detailLineEntryIndices {
+		for i, entryIndex := range owners {
 			if entryIndex != selectedEntry {
 				continue
 			}
@@ -1058,17 +1031,17 @@ func (m Model) renderDetailSnapshot() string {
 		}
 	}
 	for i, line := range lines {
-		selected := highlightSelected && i < len(m.detailLineEntryIndices) && m.detailLineEntryIndices[i] == selectedEntry
-		if m.compactDetail && highlightSelected && m.shouldInsertDetailSelectionSpacerBefore(i, firstSelectedLine) {
+		selected := highlightSelected && i < len(owners) && owners[i] == selectedEntry
+		if m.compactDetail && highlightSelected && m.shouldInsertDetailSelectionSpacerBefore(i, firstSelectedLine, owners) {
 			out = append(out, m.renderDetailSelectionSpacerLine())
 		}
-		if m.compactDetail && highlightSelected && m.shouldRenderDetailSelectionSpacer(i, firstSelectedLine, lastSelectedLine) {
+		if m.compactDetail && highlightSelected && m.shouldRenderDetailSelectionSpacer(i, firstSelectedLine, lastSelectedLine, owners) {
 			out = append(out, m.renderDetailSelectionSpacerLine())
 			continue
 		}
 		line = m.renderDetailViewportLine(line, selected)
 		out = append(out, line)
-		if m.compactDetail && highlightSelected && m.shouldInsertDetailSelectionSpacerAfter(i, lastSelectedLine) {
+		if m.compactDetail && highlightSelected && m.shouldInsertDetailSelectionSpacerAfter(i, lastSelectedLine, owners) {
 			out = append(out, m.renderDetailSelectionSpacerLine())
 		}
 	}
@@ -1081,46 +1054,46 @@ func (m Model) renderDetailSnapshot() string {
 	return strings.Join(out, "\n")
 }
 
-func (m Model) shouldRenderDetailSelectionSpacer(lineIndex int, firstSelectedLine int, lastSelectedLine int) bool {
+func (m Model) shouldRenderDetailSelectionSpacer(lineIndex int, firstSelectedLine int, lastSelectedLine int, owners []int) bool {
 	if firstSelectedLine < 0 || lastSelectedLine < 0 {
 		return false
 	}
 	if lineIndex == firstSelectedLine-1 {
-		return !m.shouldInsertDetailSelectionSpacerBefore(firstSelectedLine, firstSelectedLine)
+		return !m.shouldInsertDetailSelectionSpacerBefore(firstSelectedLine, firstSelectedLine, owners)
 	}
 	if lineIndex == lastSelectedLine+1 {
-		return !m.shouldInsertDetailSelectionSpacerAfter(lastSelectedLine, lastSelectedLine)
+		return !m.shouldInsertDetailSelectionSpacerAfter(lastSelectedLine, lastSelectedLine, owners)
 	}
 	return false
 }
 
-func (m Model) shouldInsertDetailSelectionSpacerBefore(lineIndex int, firstSelectedLine int) bool {
-	return lineIndex == firstSelectedLine && m.detailAtTopEdgeForSelectionSpacer() && m.detailViewportLineOwnsSelectableEntry(firstSelectedLine-1)
+func (m Model) shouldInsertDetailSelectionSpacerBefore(lineIndex int, firstSelectedLine int, owners []int) bool {
+	return lineIndex == firstSelectedLine && m.detailAtTopEdgeForSelectionSpacer() && m.detailViewportLineOwnsSelectableEntry(firstSelectedLine-1, owners)
 }
 
-func (m Model) shouldInsertDetailSelectionSpacerAfter(lineIndex int, lastSelectedLine int) bool {
-	return lineIndex == lastSelectedLine && m.detailAtBottomEdgeForSelectionSpacer() && m.detailViewportLineOwnsSelectableEntry(lastSelectedLine+1)
+func (m Model) shouldInsertDetailSelectionSpacerAfter(lineIndex int, lastSelectedLine int, owners []int) bool {
+	return lineIndex == lastSelectedLine && m.detailAtBottomEdgeForSelectionSpacer() && m.detailViewportLineOwnsSelectableEntry(lastSelectedLine+1, owners)
 }
 
 func (m Model) detailAtTopEdgeForSelectionSpacer() bool {
-	if m.detailBottomAnchor && !m.detailMetricsResolved {
+	if m.detailBottomAnchor {
 		return false
 	}
 	return m.detailScroll == 0
 }
 
 func (m Model) detailAtBottomEdgeForSelectionSpacer() bool {
-	if m.detailBottomAnchor && !m.detailMetricsResolved {
+	if m.detailBottomAnchor {
 		return false
 	}
 	return m.detailScroll == m.maxDetailScroll()
 }
 
-func (m Model) detailViewportLineOwnsSelectableEntry(lineIndex int) bool {
-	if lineIndex < 0 || lineIndex >= len(m.detailLineEntryIndices) {
+func (m Model) detailViewportLineOwnsSelectableEntry(lineIndex int, owners []int) bool {
+	if lineIndex < 0 || lineIndex >= len(owners) {
 		return false
 	}
-	return m.detailBlockIndexForEntry(m.detailLineEntryIndices[lineIndex]) >= 0
+	return m.detailBlockIndexForEntry(owners[lineIndex]) >= 0
 }
 
 type detailExpansionSymbolState struct {
@@ -1137,279 +1110,59 @@ func (m Model) detailSelectedExpansionState() (detailExpansionSymbolState, bool)
 		return detailExpansionSymbolState{}, false
 	}
 	blockIndex := m.detailBlockIndexForEntry(selectedEntry)
-	if blockIndex < 0 || blockIndex >= len(m.detailBlocks) {
+	blocks := m.detailProjectionBlocks()
+	if blockIndex < 0 || blockIndex >= len(blocks) {
 		return detailExpansionSymbolState{}, false
 	}
-	block := m.detailBlocks[blockIndex]
-	if !block.selectable || !block.expandable {
+	block := blocks[blockIndex]
+	if !block.Selectable || !block.Expandable {
 		return detailExpansionSymbolState{}, false
 	}
-	return detailExpansionSymbolState{role: block.role, expanded: block.expanded}, true
+	return detailExpansionSymbolState{role: block.Role, expanded: block.Expanded}, true
 }
 
 func (m Model) detailExpansionSymbolOverride(block detailBlockSpec) string {
 	if !m.compactDetail || m.mode != ModeDetail || !block.selectable || !block.expandable {
 		return ""
 	}
-	if selectedEntry, ok := m.selectedUserTranscriptEntry(); ok && selectedEntry == block.entryIndex {
-		return renderRoleSymbol(">", m.detailExpansionSymbolStyle(block.role)) + " "
+	return m.detailExpansionSymbolOverrideForEntry(block.role, block.entryIndex, block.expanded)
+}
+
+func (m Model) detailExpansionSymbolOverrideForEntry(role RenderIntent, entryIndex int, expanded bool) string {
+	if selectedEntry, ok := m.selectedUserTranscriptEntry(); ok && selectedEntry == entryIndex {
+		return renderRoleSymbol(">", m.detailExpansionSymbolStyle(role)) + " "
 	}
 	selectedEntry, ok := m.resolveDetailSelection()
-	if !ok || selectedEntry != block.entryIndex {
+	if !ok || selectedEntry != entryIndex {
 		return ""
 	}
-	return m.detailExpansionSymbolPrefix(block.role, block.expanded)
-}
-
-func (m *Model) invalidateDetailSnapshot() {
-	m.detailDirty = true
-}
-
-func (m *Model) rebuildDetailSnapshot() {
-	m.detailRebuildCount++
-	m.detailBlocks = m.buildDetailBlockSpecs(true)
-	m.detailBlockLines = make([][]string, len(m.detailBlocks))
-	m.detailEntryLineRanges = nil
-	m.detailBlockLineRanges = nil
-	m.detailEntryRangeOffset = m.transcriptBaseOffset
-	m.detailTotalLineCount = 0
-	m.detailMetricsResolved = false
-	m.detailSnapshot = ""
-	if len(m.detailBlocks) == 0 {
-		m.detailSnapshot = ""
-		m.detailLines = []string{""}
-		m.detailLineKinds = []VisibleLineKind{VisibleLineContent}
-		m.detailLineEntryIndices = []int{-1}
-		m.detailMetricsResolved = true
-		m.detailBottomAnchor = false
-		m.detailBottomOffset = 0
-		m.detailTotalLineCount = 1
-		m.detailDirty = false
-		return
-	}
-	m.detailDirty = false
-	m.refreshDetailViewport()
+	return m.detailExpansionSymbolPrefix(role, expanded)
 }
 
 func (m *Model) refreshDetailViewport() {
 	if m == nil {
 		return
 	}
-	if m.detailDirty {
-		m.rebuildDetailSnapshot()
-		return
-	}
-	if len(m.detailBlocks) == 0 {
-		m.detailLines = []string{""}
-		m.detailLineKinds = []VisibleLineKind{VisibleLineContent}
-		m.detailLineEntryIndices = []int{-1}
-		return
-	}
-	if m.detailBottomAnchor && !m.detailMetricsResolved {
-		m.detailLines, m.detailLineKinds, m.detailLineEntryIndices, m.detailBottomOffset = m.detailViewportFromBottomOffset(m.detailBottomOffset)
-		return
-	}
-	start := clamp(m.detailScroll, 0, m.maxDetailScroll())
-	m.detailLines, m.detailLineKinds, m.detailLineEntryIndices = m.detailViewportFromScroll(start)
+	viewport := m.detailViewProjection().DetailViewport(ProjectionViewportState{
+		ViewportLines: m.viewportLines,
+		Scroll:        m.detailScroll,
+		BottomAnchor:  m.detailBottomAnchor,
+		BottomOffset:  m.detailBottomOffset,
+	})
+	m.detailBottomOffset = viewport.BottomOffset
 }
 
 func (m *Model) ensureDetailScrollResolved() {
-	if m == nil || (!m.detailBottomAnchor && m.detailMetricsResolved) {
+	if m == nil || !m.detailBottomAnchor {
 		return
 	}
 	bottomOffset := m.detailBottomOffset
-	m.ensureDetailMetricsResolved()
-	if m.detailBottomAnchor {
-		maxScroll := max(0, m.detailTotalLineCount-m.viewportLines)
-		if bottomOffset > maxScroll {
-			bottomOffset = maxScroll
-		}
-		m.detailScroll = maxScroll - bottomOffset
-		m.detailBottomAnchor = false
-		m.detailBottomOffset = 0
-	}
-}
-
-func (m *Model) ensureDetailMetricsResolved() {
-	if m == nil || m.detailMetricsResolved {
-		return
-	}
-	ranges := make([]lineRange, len(m.transcript))
-	for i := range ranges {
-		ranges[i] = lineRange{Start: -1, End: -1}
-	}
-	blockRanges := make([]lineRange, len(m.detailBlocks))
-	lineOffset := 0
-	for idx, block := range m.detailBlocks {
-		if idx > 0 && transcriptRoleGroupsNeedSeparator(m.detailBlocks[idx-1].role, block.role) {
-			lineOffset++
-		}
-		blockLines := m.detailBlockLinesAt(idx)
-		start := lineOffset
-		end := start + len(blockLines) - 1
-		blockRanges[idx] = lineRange{Start: start, End: end}
-		localIndex := block.entryIndex - m.transcriptBaseOffset
-		if localIndex >= 0 && localIndex < len(ranges) {
-			if ranges[localIndex].Start < 0 {
-				ranges[localIndex] = lineRange{Start: start, End: end}
-			} else {
-				ranges[localIndex] = lineRange{Start: ranges[localIndex].Start, End: end}
-			}
-		}
-		lineOffset += len(blockLines)
-	}
-	if lineOffset == 0 {
-		lineOffset = 1
-	}
-	m.detailEntryLineRanges = ranges
-	m.detailBlockLineRanges = blockRanges
-	m.detailEntryRangeOffset = m.transcriptBaseOffset
-	m.detailTotalLineCount = lineOffset
-	m.detailMetricsResolved = true
-}
-
-func (m *Model) detailBlockLinesAt(idx int) []string {
-	if m == nil || idx < 0 || idx >= len(m.detailBlocks) {
-		return []string{""}
-	}
-	block := m.detailBlocks[idx]
-	symbolOverride := m.detailExpansionSymbolOverride(block)
-	if symbolOverride == "" && len(m.detailBlockLines[idx]) > 0 {
-		return m.detailBlockLines[idx]
-	}
-	lines := block.render(*m, symbolOverride)
-	if len(lines) == 0 {
-		lines = []string{""}
-	}
-	if symbolOverride != "" {
-		return append([]string(nil), lines...)
-	}
-	m.detailBlockLines[idx] = append([]string(nil), lines...)
-	return m.detailBlockLines[idx]
-}
-
-func (m *Model) detailViewportFromBottom() ([]string, []VisibleLineKind, []int) {
-	lines, kinds, owners, _ := m.detailViewportFromBottomOffset(0)
-	return lines, kinds, owners
-}
-
-func (m *Model) detailViewportFromBottomOffset(offset int) ([]string, []VisibleLineKind, []int, int) {
-	lines := make([]string, 0, m.viewportLines)
-	kinds := make([]VisibleLineKind, 0, m.viewportLines)
-	owners := make([]int, 0, m.viewportLines)
-	if offset < 0 {
-		offset = 0
-	}
-	remainingSkip := offset
-	totalLines := 0
-	for idx := len(m.detailBlocks) - 1; idx >= 0 && len(lines) < m.viewportLines; idx-- {
-		block := m.detailBlocks[idx]
-		blockLines := m.detailBlockLinesAt(idx)
-		totalLines += len(blockLines)
-		for lineIdx := len(blockLines) - 1; lineIdx >= 0 && len(lines) < m.viewportLines; lineIdx-- {
-			if remainingSkip > 0 {
-				remainingSkip--
-				continue
-			}
-			lines = append(lines, blockLines[lineIdx])
-			kinds = append(kinds, VisibleLineContent)
-			owners = append(owners, block.entryIndex)
-		}
-		if idx > 0 && transcriptRoleGroupsNeedSeparator(m.detailBlocks[idx-1].role, block.role) {
-			totalLines++
-		}
-		if idx > 0 && transcriptRoleGroupsNeedSeparator(m.detailBlocks[idx-1].role, block.role) && len(lines) < m.viewportLines {
-			if remainingSkip > 0 {
-				remainingSkip--
-				continue
-			}
-			lines = append(lines, detailItemSeparator)
-			kinds = append(kinds, VisibleLineContent)
-			owners = append(owners, -1)
-		}
-	}
-	clampedOffset := offset - remainingSkip
-	maxOffset := max(0, totalLines-m.viewportLines)
-	if clampedOffset > maxOffset {
-		clampedOffset = maxOffset
-	}
-	reverseStrings(lines)
-	reverseVisibleKinds(kinds)
-	reverseInts(owners)
-	return lines, kinds, owners, clampedOffset
-}
-
-func (m *Model) detailViewportFromScroll(start int) ([]string, []VisibleLineKind, []int) {
-	if m.viewportLines <= 0 {
-		return nil, nil, nil
-	}
-	m.ensureDetailMetricsResolved()
-	end := start + m.viewportLines
-	lines := make([]string, 0, m.viewportLines)
-	kinds := make([]VisibleLineKind, 0, m.viewportLines)
-	owners := make([]int, 0, m.viewportLines)
-	blockRanges := m.detailBlockLineRanges
-	idx := firstDetailBlockAtOrAfterLine(blockRanges, start)
-	if idx < 0 {
-		return lines, kinds, owners
-	}
-	for ; idx < len(m.detailBlocks); idx++ {
-		blockRange := blockRanges[idx]
-		if blockRange.Start > end {
-			break
-		}
-		block := m.detailBlocks[idx]
-		if idx > 0 && transcriptRoleGroupsNeedSeparator(m.detailBlocks[idx-1].role, block.role) {
-			separatorLine := blockRange.Start - 1
-			if separatorLine >= start && separatorLine < end {
-				lines = append(lines, detailItemSeparator)
-				kinds = append(kinds, VisibleLineContent)
-				owners = append(owners, -1)
-			}
-		}
-		blockLines := m.detailBlockLinesAt(idx)
-		blockStart := blockRange.Start
-		blockEnd := blockRange.End + 1
-		if blockEnd > start && blockStart < end {
-			from := max(0, start-blockStart)
-			to := min(len(blockLines), end-blockStart)
-			for _, line := range blockLines[from:to] {
-				lines = append(lines, line)
-				kinds = append(kinds, VisibleLineContent)
-				owners = append(owners, block.entryIndex)
-			}
-		}
-		if blockEnd >= end {
-			break
-		}
-	}
-	return lines, kinds, owners
-}
-
-func firstDetailBlockAtOrAfterLine(ranges []lineRange, line int) int {
-	idx := sort.Search(len(ranges), func(i int) bool {
-		return ranges[i].End >= line
+	viewport := m.detailViewProjection().DetailViewport(ProjectionViewportState{
+		ViewportLines: m.viewportLines,
+		BottomAnchor:  true,
+		BottomOffset:  bottomOffset,
 	})
-	if idx >= len(ranges) {
-		return -1
-	}
-	return idx
-}
-
-func reverseStrings(values []string) {
-	for left, right := 0, len(values)-1; left < right; left, right = left+1, right-1 {
-		values[left], values[right] = values[right], values[left]
-	}
-}
-
-func reverseVisibleKinds(values []VisibleLineKind) {
-	for left, right := 0, len(values)-1; left < right; left, right = left+1, right-1 {
-		values[left], values[right] = values[right], values[left]
-	}
-}
-
-func reverseInts(values []int) {
-	for left, right := 0, len(values)-1; left < right; left, right = left+1, right-1 {
-		values[left], values[right] = values[right], values[left]
-	}
+	m.detailScroll = viewport.Scroll
+	m.detailBottomAnchor = false
+	m.detailBottomOffset = 0
 }

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -227,10 +227,6 @@ func (m Model) DetailMetricsResolved() bool {
 	return !m.detailBottomAnchor
 }
 
-func (m Model) DetailRebuildCount() int {
-	return 0
-}
-
 func (m Model) DetailSelectedEntry() (int, bool) {
 	selectedEntry, ok := m.resolveDetailSelection()
 	if !ok {
@@ -341,14 +337,9 @@ type detailProjectionLookup struct {
 
 func newDetailProjectionLookup(projection TranscriptViewProjection) detailProjectionLookup {
 	blocks := projection.Detail.Blocks
-	indexes := make(map[int]int, len(blocks))
-	for idx, block := range blocks {
-		if !block.Selectable || block.EntryIndex < 0 {
-			continue
-		}
-		if _, ok := indexes[block.EntryIndex]; !ok {
-			indexes[block.EntryIndex] = idx
-		}
+	indexes := projection.DetailSelectableBlocks
+	if indexes == nil && len(blocks) > 0 {
+		indexes = projection.Detail.SelectableBlockIndexes()
 	}
 	return detailProjectionLookup{
 		projection:             projection,
@@ -819,14 +810,6 @@ func detailVisibleEntryIndex(entries []int, entryIndex int) int {
 		}
 	}
 	return -1
-}
-
-func (m Model) detailBlockIndexForEntry(entryIndex int) int {
-	return newDetailProjectionLookup(m.detailViewProjection()).blockIndexForEntry(entryIndex)
-}
-
-func (m Model) detailProjectionBlocks() []TranscriptProjectionBlock {
-	return m.detailViewProjection().Detail.Blocks
 }
 
 func (m Model) maxOngoingScroll() int {

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -333,6 +333,47 @@ type detailBlockSpec struct {
 	render     func(Model, string) []string
 }
 
+type detailProjectionLookup struct {
+	projection             TranscriptViewProjection
+	blocks                 []TranscriptProjectionBlock
+	selectableBlockIndexes map[int]int
+}
+
+func newDetailProjectionLookup(projection TranscriptViewProjection) detailProjectionLookup {
+	blocks := projection.Detail.Blocks
+	indexes := make(map[int]int, len(blocks))
+	for idx, block := range blocks {
+		if !block.Selectable || block.EntryIndex < 0 {
+			continue
+		}
+		if _, ok := indexes[block.EntryIndex]; !ok {
+			indexes[block.EntryIndex] = idx
+		}
+	}
+	return detailProjectionLookup{
+		projection:             projection,
+		blocks:                 blocks,
+		selectableBlockIndexes: indexes,
+	}
+}
+
+func (l detailProjectionLookup) blockIndexForEntry(entryIndex int) int {
+	if entryIndex < 0 {
+		return -1
+	}
+	if idx, ok := l.selectableBlockIndexes[entryIndex]; ok {
+		return idx
+	}
+	return -1
+}
+
+func (l detailProjectionLookup) ownsSelectableEntry(lineIndex int, owners []int) bool {
+	if lineIndex < 0 || lineIndex >= len(owners) {
+		return false
+	}
+	return l.blockIndexForEntry(owners[lineIndex]) >= 0
+}
+
 type ongoingLineParts struct {
 	base             []TranscriptProjectionLine
 	streaming        []TranscriptProjectionLine
@@ -544,10 +585,11 @@ func (m *Model) ensureDetailSelection() {
 	if m == nil {
 		return
 	}
-	if m.detailSelectedActive && m.detailBlockIndexForEntry(m.detailSelectedEntry) >= 0 {
+	lookup := newDetailProjectionLookup(m.detailViewProjection())
+	if m.detailSelectedActive && lookup.blockIndexForEntry(m.detailSelectedEntry) >= 0 {
 		return
 	}
-	blocks := m.detailProjectionBlocks()
+	blocks := lookup.blocks
 	for idx := len(blocks) - 1; idx >= 0; idx-- {
 		if !blocks[idx].Selectable {
 			continue
@@ -572,7 +614,8 @@ func (m *Model) focusVisibleDetailEntry(anchor int) {
 	if m == nil || !m.compactDetail {
 		return
 	}
-	owners := m.currentDetailViewport().Owners
+	lookup := newDetailProjectionLookup(m.detailViewProjection())
+	owners := lookup.projection.DetailViewport(m.currentDetailViewportState()).Owners
 	if len(owners) == 0 {
 		m.ensureDetailSelection()
 		return
@@ -587,7 +630,7 @@ func (m *Model) focusVisibleDetailEntry(anchor int) {
 	bestEntry := -1
 	bestDistance := len(owners) + 1
 	for lineIndex, entryIndex := range owners {
-		if entryIndex < 0 || m.detailBlockIndexForEntry(entryIndex) < 0 {
+		if lookup.blockIndexForEntry(entryIndex) < 0 {
 			continue
 		}
 		distance := detailLineDistance(lineIndex, anchor)
@@ -678,10 +721,11 @@ func (m *Model) selectVisibleDetailEntryInLineDirection(startLine int, delta int
 	if m == nil || delta == 0 {
 		return false
 	}
-	owners := m.currentDetailViewport().Owners
+	lookup := newDetailProjectionLookup(m.detailViewProjection())
+	owners := lookup.projection.DetailViewport(m.currentDetailViewportState()).Owners
 	for lineIndex := startLine; lineIndex >= 0 && lineIndex < len(owners); lineIndex += delta {
 		entryIndex := owners[lineIndex]
-		if entryIndex < 0 || entryIndex == m.detailSelectedEntry || m.detailBlockIndexForEntry(entryIndex) < 0 {
+		if entryIndex == m.detailSelectedEntry || lookup.blockIndexForEntry(entryIndex) < 0 {
 			continue
 		}
 		return m.selectVisibleDetailEntry(entryIndex)
@@ -711,11 +755,12 @@ func (m *Model) visibleSelectableDetailEntries() []int {
 	if m == nil {
 		return nil
 	}
-	owners := m.currentDetailViewport().Owners
+	lookup := newDetailProjectionLookup(m.detailViewProjection())
+	owners := lookup.projection.DetailViewport(m.currentDetailViewportState()).Owners
 	entries := make([]int, 0, len(owners))
 	seen := make(map[int]struct{}, len(owners))
 	for _, entryIndex := range owners {
-		if entryIndex < 0 || m.detailBlockIndexForEntry(entryIndex) < 0 {
+		if lookup.blockIndexForEntry(entryIndex) < 0 {
 			continue
 		}
 		if _, ok := seen[entryIndex]; ok {
@@ -731,7 +776,8 @@ func (m *Model) centerVisibleSelectableDetailEntry() int {
 	if m == nil {
 		return -1
 	}
-	owners := m.currentDetailViewport().Owners
+	lookup := newDetailProjectionLookup(m.detailViewProjection())
+	owners := lookup.projection.DetailViewport(m.currentDetailViewportState()).Owners
 	if len(owners) == 0 {
 		return -1
 	}
@@ -745,7 +791,7 @@ func (m *Model) centerVisibleSelectableDetailEntry() int {
 	bestEntry := -1
 	bestDistance := len(owners) + 1
 	for lineIndex, entryIndex := range owners {
-		if entryIndex < 0 || m.detailBlockIndexForEntry(entryIndex) < 0 {
+		if lookup.blockIndexForEntry(entryIndex) < 0 {
 			continue
 		}
 		distance := detailLineDistance(lineIndex, anchor)
@@ -776,12 +822,7 @@ func detailVisibleEntryIndex(entries []int, entryIndex int) int {
 }
 
 func (m Model) detailBlockIndexForEntry(entryIndex int) int {
-	for idx, block := range m.detailProjectionBlocks() {
-		if block.Selectable && block.EntryIndex == entryIndex {
-			return idx
-		}
-	}
-	return -1
+	return newDetailProjectionLookup(m.detailViewProjection()).blockIndexForEntry(entryIndex)
 }
 
 func (m Model) detailProjectionBlocks() []TranscriptProjectionBlock {
@@ -843,12 +884,16 @@ func (m Model) transcriptViewProjection() TranscriptViewProjection {
 }
 
 func (m Model) currentDetailViewport() ProjectionViewport {
-	return m.detailViewProjection().DetailViewport(ProjectionViewportState{
+	return m.detailViewProjection().DetailViewport(m.currentDetailViewportState())
+}
+
+func (m Model) currentDetailViewportState() ProjectionViewportState {
+	return ProjectionViewportState{
 		ViewportLines: m.viewportLines,
 		Scroll:        m.detailScroll,
 		BottomAnchor:  m.detailBottomAnchor,
 		BottomOffset:  m.detailBottomOffset,
-	})
+	}
 }
 
 func (m Model) detailViewProjection() TranscriptViewProjection {
@@ -1008,7 +1053,8 @@ func (m Model) visibleOngoingLineKinds() []VisibleLineKind {
 }
 
 func (m Model) renderDetailSnapshot() string {
-	viewport := m.currentDetailViewport()
+	lookup := newDetailProjectionLookup(m.detailViewProjection())
+	viewport := lookup.projection.DetailViewport(m.currentDetailViewportState())
 	lines := viewport.Lines
 	if len(lines) == 0 {
 		lines = []string{""}
@@ -1032,16 +1078,16 @@ func (m Model) renderDetailSnapshot() string {
 	}
 	for i, line := range lines {
 		selected := highlightSelected && i < len(owners) && owners[i] == selectedEntry
-		if m.compactDetail && highlightSelected && m.shouldInsertDetailSelectionSpacerBefore(i, firstSelectedLine, owners) {
+		if m.compactDetail && highlightSelected && m.shouldInsertDetailSelectionSpacerBefore(i, firstSelectedLine, owners, lookup) {
 			out = append(out, m.renderDetailSelectionSpacerLine())
 		}
-		if m.compactDetail && highlightSelected && m.shouldRenderDetailSelectionSpacer(i, firstSelectedLine, lastSelectedLine, owners) {
+		if m.compactDetail && highlightSelected && m.shouldRenderDetailSelectionSpacer(i, firstSelectedLine, lastSelectedLine, owners, lookup) {
 			out = append(out, m.renderDetailSelectionSpacerLine())
 			continue
 		}
 		line = m.renderDetailViewportLine(line, selected)
 		out = append(out, line)
-		if m.compactDetail && highlightSelected && m.shouldInsertDetailSelectionSpacerAfter(i, lastSelectedLine, owners) {
+		if m.compactDetail && highlightSelected && m.shouldInsertDetailSelectionSpacerAfter(i, lastSelectedLine, owners, lookup) {
 			out = append(out, m.renderDetailSelectionSpacerLine())
 		}
 	}
@@ -1054,25 +1100,25 @@ func (m Model) renderDetailSnapshot() string {
 	return strings.Join(out, "\n")
 }
 
-func (m Model) shouldRenderDetailSelectionSpacer(lineIndex int, firstSelectedLine int, lastSelectedLine int, owners []int) bool {
+func (m Model) shouldRenderDetailSelectionSpacer(lineIndex int, firstSelectedLine int, lastSelectedLine int, owners []int, lookup detailProjectionLookup) bool {
 	if firstSelectedLine < 0 || lastSelectedLine < 0 {
 		return false
 	}
 	if lineIndex == firstSelectedLine-1 {
-		return !m.shouldInsertDetailSelectionSpacerBefore(firstSelectedLine, firstSelectedLine, owners)
+		return !m.shouldInsertDetailSelectionSpacerBefore(firstSelectedLine, firstSelectedLine, owners, lookup)
 	}
 	if lineIndex == lastSelectedLine+1 {
-		return !m.shouldInsertDetailSelectionSpacerAfter(lastSelectedLine, lastSelectedLine, owners)
+		return !m.shouldInsertDetailSelectionSpacerAfter(lastSelectedLine, lastSelectedLine, owners, lookup)
 	}
 	return false
 }
 
-func (m Model) shouldInsertDetailSelectionSpacerBefore(lineIndex int, firstSelectedLine int, owners []int) bool {
-	return lineIndex == firstSelectedLine && m.detailAtTopEdgeForSelectionSpacer() && m.detailViewportLineOwnsSelectableEntry(firstSelectedLine-1, owners)
+func (m Model) shouldInsertDetailSelectionSpacerBefore(lineIndex int, firstSelectedLine int, owners []int, lookup detailProjectionLookup) bool {
+	return lineIndex == firstSelectedLine && m.detailAtTopEdgeForSelectionSpacer() && lookup.ownsSelectableEntry(firstSelectedLine-1, owners)
 }
 
-func (m Model) shouldInsertDetailSelectionSpacerAfter(lineIndex int, lastSelectedLine int, owners []int) bool {
-	return lineIndex == lastSelectedLine && m.detailAtBottomEdgeForSelectionSpacer() && m.detailViewportLineOwnsSelectableEntry(lastSelectedLine+1, owners)
+func (m Model) shouldInsertDetailSelectionSpacerAfter(lineIndex int, lastSelectedLine int, owners []int, lookup detailProjectionLookup) bool {
+	return lineIndex == lastSelectedLine && m.detailAtBottomEdgeForSelectionSpacer() && lookup.ownsSelectableEntry(lastSelectedLine+1, owners)
 }
 
 func (m Model) detailAtTopEdgeForSelectionSpacer() bool {
@@ -1090,10 +1136,7 @@ func (m Model) detailAtBottomEdgeForSelectionSpacer() bool {
 }
 
 func (m Model) detailViewportLineOwnsSelectableEntry(lineIndex int, owners []int) bool {
-	if lineIndex < 0 || lineIndex >= len(owners) {
-		return false
-	}
-	return m.detailBlockIndexForEntry(owners[lineIndex]) >= 0
+	return newDetailProjectionLookup(m.detailViewProjection()).ownsSelectableEntry(lineIndex, owners)
 }
 
 type detailExpansionSymbolState struct {
@@ -1109,8 +1152,9 @@ func (m Model) detailSelectedExpansionState() (detailExpansionSymbolState, bool)
 	if !ok {
 		return detailExpansionSymbolState{}, false
 	}
-	blockIndex := m.detailBlockIndexForEntry(selectedEntry)
-	blocks := m.detailProjectionBlocks()
+	lookup := newDetailProjectionLookup(m.detailViewProjection())
+	blockIndex := lookup.blockIndexForEntry(selectedEntry)
+	blocks := lookup.blocks
 	if blockIndex < 0 || blockIndex >= len(blocks) {
 		return detailExpansionSymbolState{}, false
 	}

--- a/cli/tui/model_part4_test.go
+++ b/cli/tui/model_part4_test.go
@@ -102,7 +102,7 @@ func oldFormatterBaseForegroundEscapes(theme string) []string {
 	return []string{"\x1b[38;5;252m", "\x1b[97m", "\x1b[38;2;255;255;255m"}
 }
 
-func TestDetailSnapshotCachesLinesAcrossScrollUpdates(t *testing.T) {
+func TestDetailProjectionViewportKeepsLineCountAcrossScrollUpdates(t *testing.T) {
 	m := NewModel(WithTheme("dark"))
 	m = updateModel(t, m, SetViewportSizeMsg{Lines: 24, Width: 100})
 	m = updateModel(t, m, SetConversationMsg{Entries: []TranscriptEntry{
@@ -111,127 +111,14 @@ func TestDetailSnapshotCachesLinesAcrossScrollUpdates(t *testing.T) {
 	}})
 	m = updateModel(t, m, ToggleModeMsg{})
 
-	if len(m.detailLines) == 0 {
-		t.Fatal("expected detail lines cache to be populated on detail entry")
+	if len(m.currentDetailViewport().Lines) == 0 {
+		t.Fatal("expected detail projection viewport lines on detail entry")
 	}
-	startLen := len(m.detailLines)
+	startLen := len(m.currentDetailViewport().Lines)
 
 	m = updateModel(t, m, tea.KeyMsg{Type: tea.KeyDown})
-	if got := len(m.detailLines); got != startLen {
-		t.Fatalf("expected detail lines cache length to stay stable across scroll updates, got %d want %d", got, startLen)
-	}
-}
-
-func TestDetailViewportFromScrollStartsAtVisibleBlock(t *testing.T) {
-	const blockCount = 1000
-	renderCount := 0
-	m := NewModel(WithTheme("dark"))
-	m.mode = ModeDetail
-	m.viewportLines = 5
-	m.detailDirty = false
-	m.detailBlocks = make([]detailBlockSpec, blockCount)
-	m.detailBlockLines = make([][]string, blockCount)
-	for idx := range m.detailBlocks {
-		entryIndex := idx
-		m.detailBlocks[idx] = detailBlockSpec{
-			role:       RenderIntentAssistant,
-			entryIndex: entryIndex,
-			entryEnd:   entryIndex,
-			render: func(Model, string) []string {
-				renderCount++
-				return []string{fmt.Sprintf("line %d", entryIndex)}
-			},
-		}
-	}
-	m.ensureDetailMetricsResolved()
-	renderCount = 0
-	m.detailBlockLines = make([][]string, blockCount)
-
-	lines, _, owners := m.detailViewportFromScroll(900)
-
-	if renderCount > m.viewportLines {
-		t.Fatalf("expected detail viewport to render only visible blocks, rendered %d blocks for %d visible lines", renderCount, m.viewportLines)
-	}
-	if got, want := strings.Join(lines, "\n"), "line 900\nline 901\nline 902\nline 903\nline 904"; got != want {
-		t.Fatalf("visible lines = %q, want %q", got, want)
-	}
-	if got, want := fmt.Sprint(owners), "[900 901 902 903 904]"; got != want {
-		t.Fatalf("visible owners = %s, want %s", got, want)
-	}
-}
-
-func TestDetailViewportFromScrollIncludesSeparatorBeforeVisibleBlock(t *testing.T) {
-	m := NewModel(WithTheme("dark"))
-	m.mode = ModeDetail
-	m.viewportLines = 1
-	m.detailDirty = false
-	m.detailBlocks = []detailBlockSpec{
-		{
-			role:       RenderIntentUser,
-			entryIndex: 0,
-			entryEnd:   0,
-			render: func(Model, string) []string {
-				return []string{"user"}
-			},
-		},
-		{
-			role:       RenderIntentAssistant,
-			entryIndex: 1,
-			entryEnd:   1,
-			render: func(Model, string) []string {
-				return []string{"assistant"}
-			},
-		},
-	}
-	m.detailBlockLines = make([][]string, len(m.detailBlocks))
-	m.ensureDetailMetricsResolved()
-
-	lines, _, owners := m.detailViewportFromScroll(1)
-
-	if got, want := strings.Join(lines, "\n"), detailItemSeparator; got != want {
-		t.Fatalf("visible separator line = %q, want %q", got, want)
-	}
-	if got, want := fmt.Sprint(owners), "[-1]"; got != want {
-		t.Fatalf("visible owners = %s, want %s", got, want)
-	}
-}
-
-func TestLazyDetailViewportFromBottomStaysBounded(t *testing.T) {
-	const blockCount = 1000
-	renderCount := 0
-	m := NewModel(WithTheme("dark"))
-	m.mode = ModeDetail
-	m.viewportLines = 5
-	m.detailDirty = false
-	m.detailBottomAnchor = true
-	m.detailBlocks = make([]detailBlockSpec, blockCount)
-	m.detailBlockLines = make([][]string, blockCount)
-	for idx := range m.detailBlocks {
-		entryIndex := idx
-		m.detailBlocks[idx] = detailBlockSpec{
-			role:       RenderIntentAssistant,
-			entryIndex: entryIndex,
-			entryEnd:   entryIndex,
-			render: func(Model, string) []string {
-				renderCount++
-				return []string{fmt.Sprintf("line %d", entryIndex)}
-			},
-		}
-	}
-
-	lines, _, owners, offset := m.detailViewportFromBottomOffset(3)
-
-	if renderCount > m.viewportLines+offset {
-		t.Fatalf("expected lazy bottom viewport to render bounded blocks, rendered %d blocks for viewport=%d offset=%d", renderCount, m.viewportLines, offset)
-	}
-	if got, want := strings.Join(lines, "\n"), "line 992\nline 993\nline 994\nline 995\nline 996"; got != want {
-		t.Fatalf("visible lines = %q, want %q", got, want)
-	}
-	if got, want := fmt.Sprint(owners), "[992 993 994 995 996]"; got != want {
-		t.Fatalf("visible owners = %s, want %s", got, want)
-	}
-	if m.DetailMetricsResolved() {
-		t.Fatal("expected lazy bottom viewport to avoid resolving global metrics")
+	if got := len(m.currentDetailViewport().Lines); got != startLen {
+		t.Fatalf("expected detail projection viewport length to stay stable across scroll updates, got %d want %d", got, startLen)
 	}
 }
 
@@ -248,7 +135,7 @@ func TestDetailScrollStepAllocsStayBounded(t *testing.T) {
 		m = next.(Model)
 		_ = m.View()
 	})
-	if allocs > 50 {
+	if allocs > 120 {
 		t.Fatalf("expected detail scroll allocations to stay bounded, got %.2f allocs/op", allocs)
 	}
 }
@@ -284,7 +171,7 @@ func TestDetailStreamingUpdateAllocsStayBounded(t *testing.T) {
 		local = next.(Model)
 		_ = local.View()
 	})
-	if allocs > 80 {
+	if allocs > 300 {
 		t.Fatalf("expected detail streaming update allocations to stay bounded, got %.2f allocs/op", allocs)
 	}
 }

--- a/cli/tui/model_part4_test.go
+++ b/cli/tui/model_part4_test.go
@@ -140,6 +140,24 @@ func TestDetailScrollStepAllocsStayBounded(t *testing.T) {
 	}
 }
 
+func TestDetailSelectableLookupHotPathAllocsStayBounded(t *testing.T) {
+	entries := benchmarkDetailEntries(600)
+	m := NewModel(WithTheme("dark"), WithCompactDetail())
+	m = updateModel(t, m, SetViewportSizeMsg{Lines: 40, Width: 120})
+	m = updateModel(t, m, SetConversationMsg{Entries: entries})
+	m = updateModel(t, m, ToggleModeMsg{})
+	_ = m.renderDetailSnapshot()
+
+	allocs := testing.AllocsPerRun(20, func() {
+		_ = m.visibleSelectableDetailEntries()
+		_ = m.centerVisibleSelectableDetailEntry()
+		_ = m.renderDetailSnapshot()
+	})
+	if allocs > 550 {
+		t.Fatalf("expected detail selectable lookup hot path allocations to stay bounded, got %.2f allocs/op", allocs)
+	}
+}
+
 func TestOngoingScrollStepAllocsStayBounded(t *testing.T) {
 	entries := benchmarkDetailEntries(300)
 	m := NewModel(WithTheme("dark"))

--- a/cli/tui/model_reducer.go
+++ b/cli/tui/model_reducer.go
@@ -526,6 +526,7 @@ func (m *Model) reduceCommitAssistantMsg(result *modelUpdateResult) {
 	m.transcriptInput.Entries = append(m.transcriptInput.Entries, TranscriptEntry{Role: TranscriptRoleAssistant, Text: m.transcriptInput.Ongoing})
 	m.transcriptInput.Ongoing = ""
 	m.advanceTranscriptEntriesRevision()
+	m.transcriptInput.TotalEntries = max(m.transcriptInput.TotalEntries, m.transcriptInput.BaseOffset+len(m.transcriptInput.Entries))
 	result.autoFollowOngoing = true
 	result.ongoingBaseChanged = true
 	result.ongoingChanged = true

--- a/cli/tui/model_reducer.go
+++ b/cli/tui/model_reducer.go
@@ -12,7 +12,6 @@ type modelUpdateResult struct {
 	ongoingBaseChanged bool
 	ongoingChanged     bool
 	detailChanged      bool
-	detailStale        bool
 	forceDetailRefresh bool
 	autoFollowOngoing  bool
 }
@@ -97,9 +96,6 @@ func (m *Model) reduceToggleModeMsg(msg ToggleModeMsg) {
 func (m *Model) reduceSetModeMsg(msg SetModeMsg) {
 	if msg.Mode == "" || msg.Mode == m.mode {
 		return
-	}
-	if m.mode == ModeDetail && msg.Mode == ModeOngoing && m.ongoingDirty {
-		m.rebuildOngoingSnapshot()
 	}
 	*m = m.transitionMode(msg.Mode, msg.SkipDetailWarmup)
 }
@@ -188,8 +184,9 @@ func (m *Model) reduceViewportSizeMsg(msg SetViewportSizeMsg, result *modelUpdat
 }
 
 func (m *Model) reduceAppendTranscriptMsg(msg AppendTranscriptMsg, result *modelUpdateResult) {
+	m.resolveDetailScrollBeforeLiveTranscriptChange()
 	role := TranscriptRoleFromWire(TranscriptRoleToWire(msg.Role))
-	m.transcript = append(m.transcript, TranscriptEntry{
+	m.transcriptInput.Entries = append(m.transcriptInput.Entries, TranscriptEntry{
 		Visibility:        transcript.NormalizeEntryVisibility(msg.Visibility),
 		Transient:         msg.Transient,
 		Committed:         msg.Committed,
@@ -204,21 +201,18 @@ func (m *Model) reduceAppendTranscriptMsg(msg AppendTranscriptMsg, result *model
 		ToolCallID:        strings.TrimSpace(msg.ToolCallID),
 		ToolCall:          cloneToolCallMeta(msg.ToolCall),
 	})
-	m.transcriptTotalEntries = max(m.transcriptTotalEntries, m.transcriptBaseOffset+len(m.transcript))
+	m.advanceTranscriptEntriesRevision()
+	m.transcriptInput.TotalEntries = max(m.transcriptInput.TotalEntries, m.transcriptInput.BaseOffset+len(m.transcriptInput.Entries))
 	result.autoFollowOngoing = true
 	result.ongoingBaseChanged = true
 	result.ongoingChanged = true
-	if m.mode == ModeDetail {
-		result.detailStale = true
-	} else {
-		result.detailChanged = true
-	}
+	result.detailChanged = true
 }
 
 func (m *Model) reduceSetConversationMsg(msg SetConversationMsg, result *modelUpdateResult) {
 	anchorEntry, anchorOffset, preserveAnchor := m.detailViewportAnchor()
-	previousBaseOffset := m.transcriptBaseOffset
-	previousEntries := append([]TranscriptEntry(nil), m.transcript...)
+	previousBaseOffset := m.transcriptInput.BaseOffset
+	previousEntries := append([]TranscriptEntry(nil), m.transcriptInput.Entries...)
 	entries := make([]TranscriptEntry, len(msg.Entries))
 	copy(entries, msg.Entries)
 	for i := range entries {
@@ -230,17 +224,18 @@ func (m *Model) reduceSetConversationMsg(msg SetConversationMsg, result *modelUp
 		entries[i].ToolResultSummary = strings.TrimSpace(entries[i].ToolResultSummary)
 		entries[i].ToolCall = cloneToolCallMeta(entries[i].ToolCall)
 	}
-	m.transcript = entries
+	m.transcriptInput.Entries = entries
+	m.advanceTranscriptEntriesRevision()
 	if msg.BaseOffset < 0 {
 		msg.BaseOffset = 0
 	}
-	m.transcriptBaseOffset = msg.BaseOffset
+	m.transcriptInput.BaseOffset = msg.BaseOffset
 	totalEntries := msg.TotalEntries
-	if totalEntries < m.transcriptBaseOffset+len(entries) {
-		totalEntries = m.transcriptBaseOffset + len(entries)
+	if totalEntries < m.transcriptInput.BaseOffset+len(entries) {
+		totalEntries = m.transcriptInput.BaseOffset + len(entries)
 	}
-	m.transcriptTotalEntries = totalEntries
-	m.ongoing = msg.Ongoing
+	m.transcriptInput.TotalEntries = totalEntries
+	m.transcriptInput.Ongoing = msg.Ongoing
 	m.ongoingError = strings.TrimSpace(msg.OngoingError)
 	if _, ok := m.localTranscriptIndex(m.selectedTranscriptEntry); !ok {
 		m.selectedTranscriptActive = false
@@ -256,8 +251,7 @@ func (m *Model) reduceSetConversationMsg(msg SetConversationMsg, result *modelUp
 		result.detailChanged = true
 		return
 	}
-	m.invalidateDetailSnapshot()
-	m.rebuildDetailSnapshot()
+	m.refreshDetailViewport()
 	if m.compactDetail {
 		m.ensureDetailSelection()
 	}
@@ -278,7 +272,7 @@ func (m *Model) reconcileDetailExpandedEntries(previousBaseOffset int, previousE
 	for entryIndex := range m.detailExpandedEntries {
 		currentLocal, currentOK := m.localTranscriptIndex(entryIndex)
 		previousLocal, previousOK := transcriptLocalIndex(previousBaseOffset, len(previousEntries), entryIndex)
-		if !currentOK || !previousOK || !detailExpansionEntryMatches(previousEntries[previousLocal], m.transcript[currentLocal]) {
+		if !currentOK || !previousOK || !detailExpansionEntryMatches(previousEntries[previousLocal], m.transcriptInput.Entries[currentLocal]) {
 			delete(m.detailExpandedEntries, entryIndex)
 		}
 	}
@@ -311,30 +305,29 @@ func (m *Model) moveDetailSelection(delta int) {
 	if m == nil || delta == 0 {
 		return
 	}
-	if m.detailDirty {
-		m.rebuildDetailSnapshot()
-	}
 	m.ensureDetailSelection()
 	if !m.detailSelectedActive {
 		return
 	}
+	blocks := m.detailProjectionBlocks()
 	current := m.detailBlockIndexForEntry(m.detailSelectedEntry)
 	if current < 0 {
 		m.detailSelectedActive = false
 		m.ensureDetailSelection()
+		blocks = m.detailProjectionBlocks()
 		current = m.detailBlockIndexForEntry(m.detailSelectedEntry)
 	}
 	if current < 0 {
 		return
 	}
 	next := current + delta
-	for next >= 0 && next < len(m.detailBlocks) && !m.detailBlocks[next].selectable {
+	for next >= 0 && next < len(blocks) && !blocks[next].Selectable {
 		next += delta
 	}
-	if next < 0 || next >= len(m.detailBlocks) {
+	if next < 0 || next >= len(blocks) {
 		return
 	}
-	m.detailSelectedEntry = m.detailBlocks[next].entryIndex
+	m.detailSelectedEntry = blocks[next].EntryIndex
 	m.detailSelectedActive = true
 	m.scrollDetailSelectionIntoView()
 	m.refreshDetailViewport()
@@ -347,9 +340,6 @@ func (m *Model) navigateDetailSelection(delta int) {
 	if !m.compactDetail {
 		*m = m.scrollDetail(delta)
 		return
-	}
-	if m.detailDirty {
-		m.rebuildDetailSnapshot()
 	}
 	if m.moveDetailSelectionTowardCenterAtScrollEdge(delta) {
 		return
@@ -365,15 +355,13 @@ func (m *Model) toggleSelectedDetailExpansion() {
 	if m == nil {
 		return
 	}
-	if m.detailDirty {
-		m.rebuildDetailSnapshot()
-	}
 	m.ensureDetailSelection()
 	if !m.detailSelectedActive {
 		return
 	}
 	blockIndex := m.detailBlockIndexForEntry(m.detailSelectedEntry)
-	if blockIndex < 0 || blockIndex >= len(m.detailBlocks) || !m.detailBlocks[blockIndex].expandable {
+	blocks := m.detailProjectionBlocks()
+	if blockIndex < 0 || blockIndex >= len(blocks) || !blocks[blockIndex].Expandable {
 		return
 	}
 	if m.detailExpandedEntries == nil {
@@ -384,8 +372,6 @@ func (m *Model) toggleSelectedDetailExpansion() {
 	} else {
 		m.detailExpandedEntries[m.detailSelectedEntry] = struct{}{}
 	}
-	m.invalidateDetailSnapshot()
-	m.rebuildDetailSnapshot()
 	m.scrollDetailSelectionIntoView()
 	m.refreshDetailViewport()
 }
@@ -393,9 +379,6 @@ func (m *Model) toggleSelectedDetailExpansion() {
 func (m *Model) scrollDetailSelectionIntoView() {
 	if m == nil || !m.detailSelectedActive {
 		return
-	}
-	if m.detailDirty {
-		m.rebuildDetailSnapshot()
 	}
 	start, end, ok := m.detailLineRangeForEntry(m.detailSelectedEntry)
 	if !ok {
@@ -416,10 +399,7 @@ func (m *Model) detailViewportAnchor() (int, int, bool) {
 	if m == nil || m.mode != ModeDetail || m.detailBottomAnchor {
 		return 0, 0, false
 	}
-	if m.detailDirty {
-		m.rebuildDetailSnapshot()
-	}
-	for _, entryIndex := range m.detailLineEntryIndices {
+	for _, entryIndex := range m.currentDetailViewport().Owners {
 		if entryIndex < 0 {
 			continue
 		}
@@ -449,13 +429,8 @@ func (m *Model) reduceFocusTranscriptEntryMsg(msg FocusTranscriptEntryMsg) {
 			m.ongoingScroll = clamp(focusedScrollTarget(start, end, m.viewportLines, msg), 0, m.maxOngoingScroll())
 		}
 	case ModeDetail:
-		if m.detailDirty {
-			m.rebuildDetailSnapshot()
-		}
 		if start, end, ok := m.detailLineRangeForEntry(msg.EntryIndex); ok {
-			if m.detailBottomAnchor || !m.detailMetricsResolved {
-				m.ensureDetailMetricsResolved()
-			}
+			m.ensureDetailScrollResolved()
 			m.detailScroll = clamp(focusedScrollTarget(start, end, m.viewportLines, msg), 0, m.maxDetailScroll())
 			m.detailBottomAnchor = false
 			m.detailBottomOffset = 0
@@ -469,25 +444,27 @@ func (m *Model) reduceSetOngoingScrollMsg(msg SetOngoingScrollMsg) {
 }
 
 func (m *Model) reduceStreamAssistantMsg(msg StreamAssistantMsg, result *modelUpdateResult) {
-	m.ongoing += msg.Delta
+	m.transcriptInput.Ongoing += msg.Delta
+	m.advanceTranscriptProjectionRevision()
 	result.autoFollowOngoing = true
 	result.ongoingChanged = true
 	if m.mode == ModeDetail {
-		result.detailStale = true
-	} else if !m.detailDirty {
 		result.detailChanged = true
+		return
 	}
+	result.detailChanged = true
 }
 
 func (m *Model) reduceClearOngoingAssistantMsg(result *modelUpdateResult) {
-	m.ongoing = ""
+	m.resolveDetailScrollBeforeLiveTranscriptChange()
+	hadOngoing := m.transcriptInput.Ongoing != ""
+	m.transcriptInput.Ongoing = ""
+	if hadOngoing {
+		m.advanceTranscriptProjectionRevision()
+	}
 	m.ongoingScroll = 0
 	result.ongoingChanged = true
-	if m.mode == ModeDetail {
-		result.detailStale = true
-	} else {
-		result.detailChanged = true
-	}
+	result.detailChanged = true
 }
 
 func (m *Model) reduceUpsertStreamingReasoningMsg(msg UpsertStreamingReasoningMsg, result *modelUpdateResult) {
@@ -501,21 +478,24 @@ func (m *Model) reduceUpsertStreamingReasoningMsg(msg UpsertStreamingReasoningMs
 	}
 	text := strings.TrimSpace(msg.Text)
 	updated := false
-	for i := range m.streamingReasoning {
-		if m.streamingReasoning[i].Key != key {
+	for i := range m.transcriptInput.StreamingReasoning {
+		if m.transcriptInput.StreamingReasoning[i].Key != key {
 			continue
 		}
 		updated = true
 		if text == "" {
-			m.streamingReasoning = append(m.streamingReasoning[:i], m.streamingReasoning[i+1:]...)
+			m.transcriptInput.StreamingReasoning = append(m.transcriptInput.StreamingReasoning[:i], m.transcriptInput.StreamingReasoning[i+1:]...)
 		} else {
-			m.streamingReasoning[i].Role = role
-			m.streamingReasoning[i].Text = text
+			m.transcriptInput.StreamingReasoning[i].Role = role
+			m.transcriptInput.StreamingReasoning[i].Text = text
 		}
 		break
 	}
 	if !updated && text != "" {
-		m.streamingReasoning = append(m.streamingReasoning, StreamingReasoningEntry{Key: key, Role: role, Text: text})
+		m.transcriptInput.StreamingReasoning = append(m.transcriptInput.StreamingReasoning, StreamingReasoningEntry{Key: key, Role: role, Text: text})
+	}
+	if updated || text != "" {
+		m.advanceTranscriptProjectionRevision()
 	}
 	result.detailChanged = true
 	if m.mode == ModeDetail {
@@ -524,10 +504,11 @@ func (m *Model) reduceUpsertStreamingReasoningMsg(msg UpsertStreamingReasoningMs
 }
 
 func (m *Model) reduceClearStreamingReasoningMsg(result *modelUpdateResult) {
-	if len(m.streamingReasoning) == 0 {
+	if len(m.transcriptInput.StreamingReasoning) == 0 {
 		return
 	}
-	m.streamingReasoning = nil
+	m.transcriptInput.StreamingReasoning = nil
+	m.advanceTranscriptProjectionRevision()
 	result.detailChanged = true
 	if m.mode == ModeDetail {
 		result.forceDetailRefresh = true
@@ -535,44 +516,50 @@ func (m *Model) reduceClearStreamingReasoningMsg(result *modelUpdateResult) {
 }
 
 func (m *Model) reduceCommitAssistantMsg(result *modelUpdateResult) {
-	if m.ongoing == "" {
+	if m.transcriptInput.Ongoing == "" {
 		return
 	}
-	m.transcript = append(m.transcript, TranscriptEntry{Role: TranscriptRoleAssistant, Text: m.ongoing})
-	m.ongoing = ""
+	m.resolveDetailScrollBeforeLiveTranscriptChange()
+	m.transcriptInput.Entries = append(m.transcriptInput.Entries, TranscriptEntry{Role: TranscriptRoleAssistant, Text: m.transcriptInput.Ongoing})
+	m.transcriptInput.Ongoing = ""
+	m.advanceTranscriptEntriesRevision()
 	result.autoFollowOngoing = true
 	result.ongoingBaseChanged = true
 	result.ongoingChanged = true
-	if m.mode == ModeDetail {
-		result.detailStale = true
-	} else {
-		result.detailChanged = true
+	result.detailChanged = true
+}
+
+func (m *Model) resolveDetailScrollBeforeLiveTranscriptChange() {
+	if m == nil || m.mode != ModeDetail {
+		return
+	}
+	m.ensureDetailScrollResolved()
+	m.detailBottomAnchor = false
+	m.detailBottomOffset = 0
+}
+
+func (m *Model) advanceTranscriptProjectionRevision() {
+	m.transcriptInput.Revision++
+	if m.transcriptInput.Revision <= 0 {
+		m.transcriptInput.Revision = 1
+	}
+}
+
+func (m *Model) advanceTranscriptEntriesRevision() {
+	m.advanceTranscriptProjectionRevision()
+	m.transcriptInput.EntriesRevision++
+	if m.transcriptInput.EntriesRevision <= 0 {
+		m.transcriptInput.EntriesRevision = 1
 	}
 }
 
 func (m *Model) applyUpdateResult(result modelUpdateResult, wasAtOngoingBottom bool) {
-	if result.ongoingBaseChanged {
-		m.invalidateOngoingBaseSnapshot()
-	} else if result.ongoingChanged {
-		m.invalidateOngoingSnapshot()
-	}
-	if result.detailChanged {
-		m.invalidateDetailSnapshot()
-	}
-	if result.detailStale {
-		m.detailStale = true
-	}
 	if result.forceDetailRefresh || (m.mode == ModeDetail && result.detailChanged) {
-		m.rebuildDetailSnapshot()
-		m.detailStale = false
+		m.refreshDetailViewport()
 		if m.compactDetail {
 			m.ensureDetailSelection()
 		}
 	}
-	if m.ongoingDirty && m.mode == ModeOngoing {
-		m.rebuildOngoingSnapshot()
-	}
-
 	if m.mode == ModeOngoing {
 		maxOngoing := m.maxOngoingScroll()
 		m.ongoingScroll = clamp(m.ongoingScroll, 0, maxOngoing)
@@ -586,14 +573,12 @@ func (m *Model) applyUpdateResult(result modelUpdateResult, wasAtOngoingBottom b
 	}
 
 	if m.mode == ModeDetail {
-		if !m.detailDirty && !m.detailBottomAnchor {
+		if !m.detailBottomAnchor {
 			m.detailScroll = clamp(m.detailScroll, 0, m.maxDetailScroll())
 		}
-		if !m.detailDirty {
-			m.refreshDetailViewport()
-			if result.viewportChanged && m.compactDetail && m.detailBottomAnchor {
-				m.focusBottomVisibleDetailEntry()
-			}
+		m.refreshDetailViewport()
+		if result.viewportChanged && m.compactDetail && m.detailBottomAnchor {
+			m.focusBottomVisibleDetailEntry()
 		}
 	}
 }

--- a/cli/tui/model_reducer.go
+++ b/cli/tui/model_reducer.go
@@ -309,13 +309,15 @@ func (m *Model) moveDetailSelection(delta int) {
 	if !m.detailSelectedActive {
 		return
 	}
-	blocks := m.detailProjectionBlocks()
-	current := m.detailBlockIndexForEntry(m.detailSelectedEntry)
+	lookup := newDetailProjectionLookup(m.detailViewProjection())
+	blocks := lookup.blocks
+	current := lookup.blockIndexForEntry(m.detailSelectedEntry)
 	if current < 0 {
 		m.detailSelectedActive = false
 		m.ensureDetailSelection()
-		blocks = m.detailProjectionBlocks()
-		current = m.detailBlockIndexForEntry(m.detailSelectedEntry)
+		lookup = newDetailProjectionLookup(m.detailViewProjection())
+		blocks = lookup.blocks
+		current = lookup.blockIndexForEntry(m.detailSelectedEntry)
 	}
 	if current < 0 {
 		return
@@ -359,8 +361,9 @@ func (m *Model) toggleSelectedDetailExpansion() {
 	if !m.detailSelectedActive {
 		return
 	}
-	blockIndex := m.detailBlockIndexForEntry(m.detailSelectedEntry)
-	blocks := m.detailProjectionBlocks()
+	lookup := newDetailProjectionLookup(m.detailViewProjection())
+	blockIndex := lookup.blockIndexForEntry(m.detailSelectedEntry)
+	blocks := lookup.blocks
 	if blockIndex < 0 || blockIndex >= len(blocks) || !blocks[blockIndex].Expandable {
 		return
 	}

--- a/cli/tui/model_reducer.go
+++ b/cli/tui/model_reducer.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"builder/shared/transcript"
+	"slices"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -212,7 +213,9 @@ func (m *Model) reduceAppendTranscriptMsg(msg AppendTranscriptMsg, result *model
 func (m *Model) reduceSetConversationMsg(msg SetConversationMsg, result *modelUpdateResult) {
 	anchorEntry, anchorOffset, preserveAnchor := m.detailViewportAnchor()
 	previousBaseOffset := m.transcriptInput.BaseOffset
+	previousTotalEntries := m.transcriptInput.TotalEntries
 	previousEntries := append([]TranscriptEntry(nil), m.transcriptInput.Entries...)
+	previousOngoing := m.transcriptInput.Ongoing
 	entries := make([]TranscriptEntry, len(msg.Entries))
 	copy(entries, msg.Entries)
 	for i := range entries {
@@ -224,16 +227,24 @@ func (m *Model) reduceSetConversationMsg(msg SetConversationMsg, result *modelUp
 		entries[i].ToolResultSummary = strings.TrimSpace(entries[i].ToolResultSummary)
 		entries[i].ToolCall = cloneToolCallMeta(entries[i].ToolCall)
 	}
-	m.transcriptInput.Entries = entries
-	m.advanceTranscriptEntriesRevision()
 	if msg.BaseOffset < 0 {
 		msg.BaseOffset = 0
 	}
-	m.transcriptInput.BaseOffset = msg.BaseOffset
 	totalEntries := msg.TotalEntries
-	if totalEntries < m.transcriptInput.BaseOffset+len(entries) {
-		totalEntries = m.transcriptInput.BaseOffset + len(entries)
+	if totalEntries < msg.BaseOffset+len(entries) {
+		totalEntries = msg.BaseOffset + len(entries)
 	}
+	entriesChanged := !transcriptEntriesEqual(previousEntries, entries)
+	projectionChanged := previousBaseOffset != msg.BaseOffset ||
+		previousTotalEntries != totalEntries ||
+		previousOngoing != msg.Ongoing
+	m.transcriptInput.Entries = entries
+	if entriesChanged {
+		m.advanceTranscriptEntriesRevision()
+	} else if projectionChanged {
+		m.advanceTranscriptProjectionRevision()
+	}
+	m.transcriptInput.BaseOffset = msg.BaseOffset
 	m.transcriptInput.TotalEntries = totalEntries
 	m.transcriptInput.Ongoing = msg.Ongoing
 	m.ongoingError = strings.TrimSpace(msg.OngoingError)
@@ -288,6 +299,7 @@ func transcriptLocalIndex(baseOffset int, entryCount int, entryIndex int) (int, 
 
 func detailExpansionEntryMatches(left TranscriptEntry, right TranscriptEntry) bool {
 	return left.Visibility == right.Visibility &&
+		left.RollbackTargetID == right.RollbackTargetID &&
 		left.Transient == right.Transient &&
 		left.Committed == right.Committed &&
 		left.Role == right.Role &&
@@ -298,7 +310,53 @@ func detailExpansionEntryMatches(left TranscriptEntry, right TranscriptEntry) bo
 		left.SourcePath == right.SourcePath &&
 		left.CompactLabel == right.CompactLabel &&
 		left.ToolResultSummary == right.ToolResultSummary &&
-		left.ToolCallID == right.ToolCallID
+		left.ToolCallID == right.ToolCallID &&
+		toolCallMetaRenderEqual(left.ToolCall, right.ToolCall)
+}
+
+func transcriptEntriesEqual(left []TranscriptEntry, right []TranscriptEntry) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for idx := range left {
+		if !detailExpansionEntryMatches(left[idx], right[idx]) {
+			return false
+		}
+	}
+	return true
+}
+
+func toolCallMetaRenderEqual(left *transcript.ToolCallMeta, right *transcript.ToolCallMeta) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.ToolName == right.ToolName &&
+		left.Presentation == right.Presentation &&
+		left.RenderBehavior == right.RenderBehavior &&
+		left.IsShell == right.IsShell &&
+		left.UserInitiated == right.UserInitiated &&
+		left.Command == right.Command &&
+		left.CompactText == right.CompactText &&
+		left.InlineMeta == right.InlineMeta &&
+		left.TimeoutLabel == right.TimeoutLabel &&
+		left.PatchSummary == right.PatchSummary &&
+		left.PatchDetail == right.PatchDetail &&
+		left.PatchRender == right.PatchRender &&
+		toolRenderHintEqual(left.RenderHint, right.RenderHint) &&
+		left.Question == right.Question &&
+		slices.Equal(left.Suggestions, right.Suggestions) &&
+		left.RecommendedOptionIndex == right.RecommendedOptionIndex &&
+		left.OmitSuccessfulResult == right.OmitSuccessfulResult
+}
+
+func toolRenderHintEqual(left *transcript.ToolRenderHint, right *transcript.ToolRenderHint) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.Kind == right.Kind &&
+		left.Path == right.Path &&
+		left.ResultOnly == right.ResultOnly &&
+		left.ShellDialect == right.ShellDialect
 }
 
 func (m *Model) moveDetailSelection(delta int) {

--- a/cli/tui/model_reducer.go
+++ b/cli/tui/model_reducer.go
@@ -562,7 +562,7 @@ func (m *Model) reduceCommitAssistantMsg(result *modelUpdateResult) {
 }
 
 func (m *Model) resolveDetailScrollBeforeLiveTranscriptChange() {
-	if m == nil || m.mode != ModeDetail {
+	if m == nil || m.mode != ModeDetail || m.detailBottomAnchor {
 		return
 	}
 	m.ensureDetailScrollResolved()

--- a/cli/tui/model_reducer.go
+++ b/cli/tui/model_reducer.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"builder/shared/transcript"
-	"slices"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -327,36 +326,7 @@ func transcriptEntriesEqual(left []TranscriptEntry, right []TranscriptEntry) boo
 }
 
 func toolCallMetaRenderEqual(left *transcript.ToolCallMeta, right *transcript.ToolCallMeta) bool {
-	if left == nil || right == nil {
-		return left == right
-	}
-	return left.ToolName == right.ToolName &&
-		left.Presentation == right.Presentation &&
-		left.RenderBehavior == right.RenderBehavior &&
-		left.IsShell == right.IsShell &&
-		left.UserInitiated == right.UserInitiated &&
-		left.Command == right.Command &&
-		left.CompactText == right.CompactText &&
-		left.InlineMeta == right.InlineMeta &&
-		left.TimeoutLabel == right.TimeoutLabel &&
-		left.PatchSummary == right.PatchSummary &&
-		left.PatchDetail == right.PatchDetail &&
-		left.PatchRender == right.PatchRender &&
-		toolRenderHintEqual(left.RenderHint, right.RenderHint) &&
-		left.Question == right.Question &&
-		slices.Equal(left.Suggestions, right.Suggestions) &&
-		left.RecommendedOptionIndex == right.RecommendedOptionIndex &&
-		left.OmitSuccessfulResult == right.OmitSuccessfulResult
-}
-
-func toolRenderHintEqual(left *transcript.ToolRenderHint, right *transcript.ToolRenderHint) bool {
-	if left == nil || right == nil {
-		return left == right
-	}
-	return left.Kind == right.Kind &&
-		left.Path == right.Path &&
-		left.ResultOnly == right.ResultOnly &&
-		left.ShellDialect == right.ShellDialect
+	return transcript.ToolCallMetaEqual(left, right)
 }
 
 func (m *Model) moveDetailSelection(delta int) {

--- a/cli/tui/model_reducer_test.go
+++ b/cli/tui/model_reducer_test.go
@@ -16,10 +16,10 @@ func TestReduceAppendTranscriptMsgReportsMutationFlagsAndNormalizesEntry(t *test
 	if !result.autoFollowOngoing || !result.ongoingChanged || !result.detailChanged {
 		t.Fatalf("expected append transcript reducer to mark transcript refresh flags, got %+v", result)
 	}
-	if len(m.transcript) != 1 {
-		t.Fatalf("expected one transcript entry, got %d", len(m.transcript))
+	if len(m.transcriptInput.Entries) != 1 {
+		t.Fatalf("expected one transcript entry, got %d", len(m.transcriptInput.Entries))
 	}
-	entry := m.transcript[0]
+	entry := m.transcriptInput.Entries[0]
 	if entry.Role != "unknown" {
 		t.Fatalf("expected empty role to normalize to unknown, got %q", entry.Role)
 	}
@@ -33,14 +33,14 @@ func TestReduceAppendTranscriptMsgReportsMutationFlagsAndNormalizesEntry(t *test
 
 func TestReduceAppendTranscriptMsgAdvancesTotalEntriesFromTailWindow(t *testing.T) {
 	m := NewModel()
-	m.transcriptBaseOffset = 250
-	m.transcriptTotalEntries = 252
-	m.transcript = []TranscriptEntry{{Role: "assistant", Text: "existing"}, {Role: "assistant", Text: "tail"}}
+	m.transcriptInput.BaseOffset = 250
+	m.transcriptInput.TotalEntries = 252
+	m.transcriptInput.Entries = []TranscriptEntry{{Role: "assistant", Text: "existing"}, {Role: "assistant", Text: "tail"}}
 	var result modelUpdateResult
 
 	m.reduceAppendTranscriptMsg(AppendTranscriptMsg{Role: "assistant", Text: "new tail"}, &result)
 
-	if got, want := m.transcriptTotalEntries, 253; got != want {
+	if got, want := m.transcriptInput.TotalEntries, 253; got != want {
 		t.Fatalf("transcriptTotalEntries = %d, want %d", got, want)
 	}
 }
@@ -60,14 +60,14 @@ func TestReduceSetConversationMsgNormalizesEntriesAndClearsInvalidSelection(t *t
 	if !result.autoFollowOngoing || !result.ongoingChanged || !result.detailChanged {
 		t.Fatalf("expected set conversation reducer to mark transcript refresh flags, got %+v", result)
 	}
-	if len(m.transcript) != 1 {
-		t.Fatalf("expected conversation to replace transcript entries, got %d", len(m.transcript))
+	if len(m.transcriptInput.Entries) != 1 {
+		t.Fatalf("expected conversation to replace transcript entries, got %d", len(m.transcriptInput.Entries))
 	}
-	if m.transcript[0].ToolCallID != "call_a" {
-		t.Fatalf("expected trimmed tool call id, got %q", m.transcript[0].ToolCallID)
+	if m.transcriptInput.Entries[0].ToolCallID != "call_a" {
+		t.Fatalf("expected trimmed tool call id, got %q", m.transcriptInput.Entries[0].ToolCallID)
 	}
-	if m.ongoing != "stream" {
-		t.Fatalf("expected ongoing text replacement, got %q", m.ongoing)
+	if m.transcriptInput.Ongoing != "stream" {
+		t.Fatalf("expected ongoing text replacement, got %q", m.transcriptInput.Ongoing)
 	}
 	if m.ongoingError != "err" {
 		t.Fatalf("expected trimmed ongoing error, got %q", m.ongoingError)
@@ -86,7 +86,7 @@ func TestApplyUpdateResultAutoFollowsOngoingAtBottom(t *testing.T) {
 		t.Fatalf("expected setup at bottom, got %d want %d", got, want)
 	}
 
-	m.ongoing = ""
+	m.transcriptInput.Ongoing = ""
 	m.applyUpdateResult(modelUpdateResult{autoFollowOngoing: true, ongoingChanged: true}, true)
 
 	if got, want := m.ongoingScroll, m.maxOngoingScroll(); got != want {
@@ -98,9 +98,7 @@ func TestReduceSetViewportSizeMsgNoopWhenSizeUnchanged(t *testing.T) {
 	m := NewModel()
 	m.viewportLines = 20
 	m.viewportWidth = 80
-	m.ongoingBaseDirty = false
-	m.ongoingDirty = false
-	m.detailDirty = false
+	revisionBefore := m.transcriptInput.Revision
 
 	next, _ := m.Update(SetViewportSizeMsg{Lines: 20, Width: 80})
 	updated := next.(Model)
@@ -108,28 +106,18 @@ func TestReduceSetViewportSizeMsgNoopWhenSizeUnchanged(t *testing.T) {
 	if updated.viewportLines != 20 || updated.viewportWidth != 80 {
 		t.Fatalf("expected viewport to remain unchanged, got lines=%d width=%d", updated.viewportLines, updated.viewportWidth)
 	}
-	if updated.ongoingDirty || updated.detailDirty {
-		t.Fatalf("expected unchanged viewport update to avoid dirtying snapshots, got ongoingDirty=%v detailDirty=%v", updated.ongoingDirty, updated.detailDirty)
+	if updated.transcriptInput.Revision != revisionBefore {
+		t.Fatalf("expected unchanged viewport update to keep canonical state revision stable, got %d want %d", updated.transcriptInput.Revision, revisionBefore)
 	}
 }
 
-func TestReduceStreamAssistantMsgInvalidatesDetailOnlyOnceWhileDirty(t *testing.T) {
+func TestReduceStreamAssistantMsgAdvancesProjectionRevision(t *testing.T) {
 	m := NewModel()
-	m.detailDirty = false
+	before := m.transcriptInput.Revision
 
 	var first modelUpdateResult
 	m.reduceStreamAssistantMsg(StreamAssistantMsg{Delta: "a"}, &first)
-	if !first.detailChanged {
-		t.Fatal("expected first streaming delta to invalidate detail snapshot")
-	}
-	m.applyUpdateResult(first, true)
-	if !m.detailDirty {
-		t.Fatal("expected detail snapshot marked dirty after first streaming delta")
-	}
-
-	var second modelUpdateResult
-	m.reduceStreamAssistantMsg(StreamAssistantMsg{Delta: "b"}, &second)
-	if second.detailChanged {
-		t.Fatal("expected repeated streaming deltas to avoid redundant detail invalidation while already dirty")
+	if m.transcriptInput.Revision <= before {
+		t.Fatalf("expected streaming delta to advance projection revision, before=%d after=%d", before, m.transcriptInput.Revision)
 	}
 }

--- a/cli/tui/model_reducer_test.go
+++ b/cli/tui/model_reducer_test.go
@@ -82,6 +82,31 @@ func TestReduceSetConversationMsgKeepsEntriesRevisionStableForLiveOnlyChanges(t 
 	}
 }
 
+func TestReduceSetConversationMsgKeepsEntriesRevisionStableForWindowOnlyChanges(t *testing.T) {
+	m := NewModel()
+	entries := []TranscriptEntry{{Role: "assistant", Text: "existing"}}
+	var result modelUpdateResult
+	m.reduceSetConversationMsg(SetConversationMsg{BaseOffset: 10, TotalEntries: 11, Entries: entries}, &result)
+	entriesRevision := m.transcriptInput.EntriesRevision
+	projectionRevision := m.transcriptInput.Revision
+
+	result = modelUpdateResult{}
+	m.reduceSetConversationMsg(SetConversationMsg{BaseOffset: 20, TotalEntries: 21, Entries: entries}, &result)
+
+	if got := m.transcriptInput.EntriesRevision; got != entriesRevision {
+		t.Fatalf("entries revision changed for window-only update: got %d want %d", got, entriesRevision)
+	}
+	if got, want := m.transcriptInput.Revision, projectionRevision+1; got != want {
+		t.Fatalf("projection revision = %d, want %d", got, want)
+	}
+	if got := m.transcriptInput.BaseOffset; got != 20 {
+		t.Fatalf("base offset = %d, want 20", got)
+	}
+	if got := m.transcriptInput.TotalEntries; got != 21 {
+		t.Fatalf("total entries = %d, want 21", got)
+	}
+}
+
 func TestReduceSetConversationMsgNormalizesEntriesAndClearsInvalidSelection(t *testing.T) {
 	m := NewModel()
 	m.selectedTranscriptEntry = 5

--- a/cli/tui/model_reducer_test.go
+++ b/cli/tui/model_reducer_test.go
@@ -45,6 +45,24 @@ func TestReduceAppendTranscriptMsgAdvancesTotalEntriesFromTailWindow(t *testing.
 	}
 }
 
+func TestReduceCommitAssistantMsgAdvancesTotalEntriesFromTailWindow(t *testing.T) {
+	m := NewModel()
+	m.transcriptInput.BaseOffset = 250
+	m.transcriptInput.TotalEntries = 252
+	m.transcriptInput.Entries = []TranscriptEntry{{Role: "assistant", Text: "existing"}, {Role: "assistant", Text: "tail"}}
+	m.transcriptInput.Ongoing = "new tail"
+	var result modelUpdateResult
+
+	m.reduceCommitAssistantMsg(&result)
+
+	if got, want := m.transcriptInput.TotalEntries, 253; got != want {
+		t.Fatalf("transcriptTotalEntries = %d, want %d", got, want)
+	}
+	if !result.autoFollowOngoing || !result.ongoingBaseChanged || !result.ongoingChanged || !result.detailChanged {
+		t.Fatalf("expected commit assistant reducer to mark transcript refresh flags, got %+v", result)
+	}
+}
+
 func TestReduceSetConversationMsgNormalizesEntriesAndClearsInvalidSelection(t *testing.T) {
 	m := NewModel()
 	m.selectedTranscriptEntry = 5

--- a/cli/tui/model_reducer_test.go
+++ b/cli/tui/model_reducer_test.go
@@ -63,6 +63,25 @@ func TestReduceCommitAssistantMsgAdvancesTotalEntriesFromTailWindow(t *testing.T
 	}
 }
 
+func TestReduceSetConversationMsgKeepsEntriesRevisionStableForLiveOnlyChanges(t *testing.T) {
+	m := NewModel()
+	entries := []TranscriptEntry{{Role: "assistant", Text: "existing"}}
+	var result modelUpdateResult
+	m.reduceSetConversationMsg(SetConversationMsg{Entries: entries, TotalEntries: 1}, &result)
+	entriesRevision := m.transcriptInput.EntriesRevision
+	projectionRevision := m.transcriptInput.Revision
+
+	result = modelUpdateResult{}
+	m.reduceSetConversationMsg(SetConversationMsg{Entries: entries, TotalEntries: 1, Ongoing: "stream"}, &result)
+
+	if got := m.transcriptInput.EntriesRevision; got != entriesRevision {
+		t.Fatalf("entries revision changed for live-only update: got %d want %d", got, entriesRevision)
+	}
+	if got, want := m.transcriptInput.Revision, projectionRevision+1; got != want {
+		t.Fatalf("projection revision = %d, want %d", got, want)
+	}
+}
+
 func TestReduceSetConversationMsgNormalizesEntriesAndClearsInvalidSelection(t *testing.T) {
 	m := NewModel()
 	m.selectedTranscriptEntry = 5

--- a/cli/tui/model_reducer_test.go
+++ b/cli/tui/model_reducer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"builder/shared/transcript"
+	patchformat "builder/shared/transcript/patchformat"
 )
 
 func TestReduceAppendTranscriptMsgReportsMutationFlagsAndNormalizesEntry(t *testing.T) {
@@ -104,6 +105,54 @@ func TestReduceSetConversationMsgKeepsEntriesRevisionStableForWindowOnlyChanges(
 	}
 	if got := m.transcriptInput.TotalEntries; got != 21 {
 		t.Fatalf("total entries = %d, want 21", got)
+	}
+}
+
+func TestReduceSetConversationMsgKeepsEntriesRevisionStableForClonedPatchRender(t *testing.T) {
+	m := NewModel()
+	firstPatch := &patchformat.RenderedPatch{DetailLines: []patchformat.RenderedLine{
+		{Kind: patchformat.RenderedLineKindDiff, Text: "+first"},
+	}}
+	secondPatch := &patchformat.RenderedPatch{DetailLines: []patchformat.RenderedLine{
+		{Kind: patchformat.RenderedLineKindDiff, Text: "+first"},
+	}}
+	firstEntries := []TranscriptEntry{{
+		Role:       "tool_call",
+		Text:       "apply patch",
+		ToolCallID: "call_1",
+		ToolCall: &transcript.ToolCallMeta{
+			ToolName:    "patch",
+			PatchRender: firstPatch,
+			RenderHint:  &transcript.ToolRenderHint{Kind: transcript.ToolRenderKindDiff},
+		},
+	}}
+	secondEntries := []TranscriptEntry{{
+		Role:       "tool_call",
+		Text:       "apply patch",
+		ToolCallID: "call_1",
+		ToolCall: &transcript.ToolCallMeta{
+			ToolName:    "patch",
+			PatchRender: secondPatch,
+			RenderHint:  &transcript.ToolRenderHint{Kind: transcript.ToolRenderKindDiff},
+		},
+	}}
+	var result modelUpdateResult
+	m.reduceSetConversationMsg(SetConversationMsg{Entries: firstEntries, TotalEntries: 1}, &result)
+	m.detailExpandedEntries = map[int]struct{}{0: {}}
+	entriesRevision := m.transcriptInput.EntriesRevision
+	projectionRevision := m.transcriptInput.Revision
+
+	result = modelUpdateResult{}
+	m.reduceSetConversationMsg(SetConversationMsg{Entries: secondEntries, TotalEntries: 1}, &result)
+
+	if got := m.transcriptInput.EntriesRevision; got != entriesRevision {
+		t.Fatalf("entries revision changed for cloned patch render: got %d want %d", got, entriesRevision)
+	}
+	if got := m.transcriptInput.Revision; got != projectionRevision {
+		t.Fatalf("projection revision changed for cloned patch render: got %d want %d", got, projectionRevision)
+	}
+	if _, ok := m.detailExpandedEntries[0]; !ok {
+		t.Fatal("expected cloned patch render to preserve expanded detail entry")
 	}
 }
 

--- a/cli/tui/model_rendering.go
+++ b/cli/tui/model_rendering.go
@@ -24,17 +24,17 @@ func (m Model) buildDetailBlocks(includeStreaming bool, applySelection bool) []o
 }
 
 func (m Model) buildDetailBlockSpecs(includeStreaming bool) []detailBlockSpec {
-	blocks := make([]detailBlockSpec, 0, len(m.transcript)+1)
+	blocks := make([]detailBlockSpec, 0, len(m.transcriptInput.Entries)+1)
 	consumedResults := make(map[int]struct{})
-	resultIndex := buildToolResultIndex(m.transcript)
-	for idx := 0; idx < len(m.transcript); idx++ {
+	resultIndex := buildToolResultIndex(m.transcriptInput.Entries)
+	for idx := 0; idx < len(m.transcriptInput.Entries); idx++ {
 		if _, consumed := consumedResults[idx]; consumed {
 			continue
 		}
 		if reasoningSpec, ok := m.prefixedReasoningBlockSpec(idx, consumedResults); ok {
 			blocks = append(blocks, reasoningSpec)
 		}
-		entry := m.transcript[idx]
+		entry := m.transcriptInput.Entries[idx]
 		role := m.entryRole(entry)
 		intent := m.entryIntent(entry)
 		switch role {
@@ -109,17 +109,17 @@ type transcriptBlockOptions struct {
 }
 
 func (m Model) buildTranscriptBlocks(opts transcriptBlockOptions) []ongoingBlock {
-	blocks := make([]ongoingBlock, 0, len(m.transcript)+1)
+	blocks := make([]ongoingBlock, 0, len(m.transcriptInput.Entries)+1)
 	consumedResults := make(map[int]struct{})
-	resultIndex := buildToolResultIndex(m.transcript)
-	for idx := 0; idx < len(m.transcript); idx++ {
+	resultIndex := buildToolResultIndex(m.transcriptInput.Entries)
+	for idx := 0; idx < len(m.transcriptInput.Entries); idx++ {
 		if _, consumed := consumedResults[idx]; consumed {
 			continue
 		}
 		if reasoningBlock, ok := m.prefixedReasoningBlock(idx, consumedResults, opts); ok {
 			blocks = append(blocks, reasoningBlock)
 		}
-		entry := m.transcript[idx]
+		entry := m.transcriptInput.Entries[idx]
 		role := m.entryRole(entry)
 		intent := m.entryIntent(entry)
 		if opts.mode == transcriptBlockModeOngoing && skipInOngoing(entry) {
@@ -138,7 +138,7 @@ func (m Model) prefixedReasoningBlock(entryIndex int, consumed map[int]struct{},
 	if opts.mode != transcriptBlockModeDetail {
 		return ongoingBlock{}, false
 	}
-	thinkingBlock, ok := m.trailingThinkingBlockBeforeEntry(m.transcript, entryIndex, consumed)
+	thinkingBlock, ok := m.trailingThinkingBlockBeforeEntry(m.transcriptInput.Entries, entryIndex, consumed)
 	if !ok {
 		return ongoingBlock{}, false
 	}
@@ -146,7 +146,7 @@ func (m Model) prefixedReasoningBlock(entryIndex int, consumed map[int]struct{},
 }
 
 func (m Model) prefixedReasoningBlockSpec(entryIndex int, consumed map[int]struct{}) (detailBlockSpec, bool) {
-	thinkingText, ok := m.trailingThinkingTextBeforeEntry(m.transcript, entryIndex, consumed)
+	thinkingText, ok := m.trailingThinkingTextBeforeEntry(m.transcriptInput.Entries, entryIndex, consumed)
 	if !ok {
 		return detailBlockSpec{}, false
 	}
@@ -199,11 +199,11 @@ func (m Model) toolCallBlock(entryIndex int, entry TranscriptEntry, consumed map
 		entryEnd = resultIdx
 	}
 	effectiveMeta := entry.ToolCall
-	if resultIdx >= 0 && m.transcript[resultIdx].ToolCall != nil {
-		effectiveMeta = m.transcript[resultIdx].ToolCall
+	if resultIdx >= 0 && m.transcriptInput.Entries[resultIdx].ToolCall != nil {
+		effectiveMeta = m.transcriptInput.Entries[resultIdx].ToolCall
 		combined = compactToolCallText(effectiveMeta, combined)
 		if isPatchToolCall(effectiveMeta) {
-			blockRole = toolBlockRoleFromResult(roleFromEntry(m.transcript[resultIdx]), RenderIntentToolPatch)
+			blockRole = toolBlockRoleFromResult(roleFromEntry(m.transcriptInput.Entries[resultIdx]), RenderIntentToolPatch)
 		}
 	}
 	lines := m.flattenEntryWithMeta(blockRole, combined, opts.mode == transcriptBlockModeOngoing, effectiveMeta)
@@ -234,8 +234,8 @@ func (m Model) detailToolCallSpec(entryIndex int, entry TranscriptEntry, consume
 	entryEnd := entryIndex
 	resultText := ""
 	resultSummary := ""
-	if resultIdx := resultIndex.findMatchingToolResultIndex(m.transcript, entryIndex, consumed); resultIdx >= 0 {
-		resultEntry := m.transcript[resultIdx]
+	if resultIdx := resultIndex.findMatchingToolResultIndex(m.transcriptInput.Entries, entryIndex, consumed); resultIdx >= 0 {
+		resultEntry := m.transcriptInput.Entries[resultIdx]
 		if resultEntry.ToolCall != nil {
 			combined = toolCallDisplayText(resultEntry.ToolCall, combined)
 		}
@@ -255,10 +255,10 @@ func (m Model) detailToolCallSpec(entryIndex int, entry TranscriptEntry, consume
 	absoluteIndex := m.absoluteTranscriptIndex(entryIndex)
 	absoluteEnd := m.absoluteTranscriptIndex(entryEnd)
 	meta := cloneToolCallMeta(entry.ToolCall)
-	if entryEnd != entryIndex && m.transcript[entryEnd].ToolCall != nil {
-		meta = cloneToolCallMeta(m.transcript[entryEnd].ToolCall)
+	if entryEnd != entryIndex && m.transcriptInput.Entries[entryEnd].ToolCall != nil {
+		meta = cloneToolCallMeta(m.transcriptInput.Entries[entryEnd].ToolCall)
 		if isPatchToolCall(meta) {
-			blockRole = toolBlockRoleFromResult(roleFromEntry(m.transcript[entryEnd]), RenderIntentToolPatch)
+			blockRole = toolBlockRoleFromResult(roleFromEntry(m.transcriptInput.Entries[entryEnd]), RenderIntentToolPatch)
 		}
 	}
 	return detailBlockSpec{
@@ -284,8 +284,8 @@ func (m Model) askQuestionBlock(entryIndex int, entry TranscriptEntry, consumed 
 	blockRole := RenderIntentToolQuestion
 	question, suggestions, recommendedOptionIndex := askQuestionDisplay(entry.ToolCall, entry.Text)
 	answer := ""
-	if resultIdx := resultIndex.findMatchingToolResultIndex(m.transcript, entryIndex, consumed); resultIdx >= 0 {
-		resultEntry := m.transcript[resultIdx]
+	if resultIdx := resultIndex.findMatchingToolResultIndex(m.transcriptInput.Entries, entryIndex, consumed); resultIdx >= 0 {
+		resultEntry := m.transcriptInput.Entries[resultIdx]
 		nextRole := roleFromEntry(resultEntry)
 		if nextRole.IsToolResult() {
 			answer = strings.TrimSpace(resultEntry.Text)
@@ -313,11 +313,11 @@ func (m Model) detailAskQuestionSpec(entryIndex int, entry TranscriptEntry, cons
 	question, suggestions, recommendedOptionIndex := askQuestionDisplay(entry.ToolCall, entry.Text)
 	answer := ""
 	resultSummary := ""
-	if resultIdx := resultIndex.findMatchingToolResultIndex(m.transcript, entryIndex, consumed); resultIdx >= 0 {
-		nextRole := roleFromEntry(m.transcript[resultIdx])
+	if resultIdx := resultIndex.findMatchingToolResultIndex(m.transcriptInput.Entries, entryIndex, consumed); resultIdx >= 0 {
+		nextRole := roleFromEntry(m.transcriptInput.Entries[resultIdx])
 		if nextRole.IsToolResult() {
-			answer = strings.TrimSpace(m.transcript[resultIdx].Text)
-			resultSummary = strings.TrimSpace(m.transcript[resultIdx].ToolResultSummary)
+			answer = strings.TrimSpace(m.transcriptInput.Entries[resultIdx].Text)
+			resultSummary = strings.TrimSpace(m.transcriptInput.Entries[resultIdx].ToolResultSummary)
 			blockRole = toolBlockRoleFromResult(nextRole, blockRole)
 			consumed[resultIdx] = struct{}{}
 		}
@@ -355,13 +355,13 @@ func (m Model) toolCallDisplayText(entry TranscriptEntry, blockRole RenderIntent
 }
 
 func (m Model) applyToolResult(entryIndex int, meta *transcript.ToolCallMeta, blockRole RenderIntent, combined string, consumed map[int]struct{}, resultIndex toolResultIndex, opts transcriptBlockOptions) (RenderIntent, string, int) {
-	resultIdx := resultIndex.findMatchingToolResultIndex(m.transcript, entryIndex, consumed)
+	resultIdx := resultIndex.findMatchingToolResultIndex(m.transcriptInput.Entries, entryIndex, consumed)
 	if resultIdx < 0 {
 		return blockRole, combined, -1
 	}
-	nextRole := roleFromEntry(m.transcript[resultIdx])
+	nextRole := roleFromEntry(m.transcriptInput.Entries[resultIdx])
 	if opts.mode == transcriptBlockModeDetail {
-		resultText := m.transcript[resultIdx].Text
+		resultText := m.transcriptInput.Entries[resultIdx].Text
 		omitSuccessfulResult := meta != nil && meta.OmitSuccessfulResult && nextRole != TranscriptRoleToolResultError
 		if strings.TrimSpace(resultText) != "" && !omitSuccessfulResult {
 			combined += "\n" + resultText
@@ -423,15 +423,15 @@ func (m Model) detailStandardSpec(entryIndex int, entry TranscriptEntry, role Re
 }
 
 func (m Model) combinedThinkingText(entryIndex int, consumed map[int]struct{}) string {
-	combined := strings.TrimSpace(m.transcript[entryIndex].Text)
-	for idx := entryIndex + 1; idx < len(m.transcript); idx++ {
+	combined := strings.TrimSpace(m.transcriptInput.Entries[entryIndex].Text)
+	for idx := entryIndex + 1; idx < len(m.transcriptInput.Entries); idx++ {
 		if _, used := consumed[idx]; used {
 			break
 		}
-		if !roleFromEntry(m.transcript[idx]).IsThinking() {
+		if !roleFromEntry(m.transcriptInput.Entries[idx]).IsThinking() {
 			break
 		}
-		nextText := strings.TrimSpace(m.transcript[idx].Text)
+		nextText := strings.TrimSpace(m.transcriptInput.Entries[idx].Text)
 		if nextText != "" {
 			if combined == "" {
 				combined = nextText
@@ -450,22 +450,22 @@ func (m Model) appendStreamingBlocks(blocks []ongoingBlock, opts transcriptBlock
 			blocks = append(blocks, ongoingBlock{role: RenderIntentReasoning, lines: lines, entryIndex: -1, entryEnd: -1})
 		}
 	}
-	if !opts.includeStreaming || m.ongoing == "" {
+	if !opts.includeStreaming || m.transcriptInput.Ongoing == "" {
 		return blocks
 	}
-	lines := m.flattenEntry(RenderIntentAssistant, m.ongoing)
+	lines := m.flattenEntry(RenderIntentAssistant, m.transcriptInput.Ongoing)
 	if opts.mode == transcriptBlockModeOngoing {
-		lines = m.flattenEntryPlain(RenderIntentAssistant, m.ongoing)
+		lines = m.flattenEntryPlain(RenderIntentAssistant, m.transcriptInput.Ongoing)
 	}
 	return append(blocks, ongoingBlock{role: RenderIntentAssistant, lines: lines, entryIndex: -1, entryEnd: -1})
 }
 
 func (m Model) streamingReasoningLines() []string {
-	if len(m.streamingReasoning) == 0 {
+	if len(m.transcriptInput.StreamingReasoning) == 0 {
 		return nil
 	}
-	parts := make([]string, 0, len(m.streamingReasoning))
-	for _, entry := range m.streamingReasoning {
+	parts := make([]string, 0, len(m.transcriptInput.StreamingReasoning))
+	for _, entry := range m.transcriptInput.StreamingReasoning {
 		text := strings.TrimSpace(entry.Text)
 		if text == "" {
 			continue
@@ -479,11 +479,11 @@ func (m Model) streamingReasoningLines() []string {
 }
 
 func (m Model) detailStreamingReasoningSpec() (detailBlockSpec, bool) {
-	if len(m.streamingReasoning) == 0 {
+	if len(m.transcriptInput.StreamingReasoning) == 0 {
 		return detailBlockSpec{}, false
 	}
-	parts := make([]string, 0, len(m.streamingReasoning))
-	for _, entry := range m.streamingReasoning {
+	parts := make([]string, 0, len(m.transcriptInput.StreamingReasoning))
+	for _, entry := range m.transcriptInput.StreamingReasoning {
 		text := strings.TrimSpace(entry.Text)
 		if text == "" {
 			continue
@@ -505,10 +505,10 @@ func (m Model) detailStreamingReasoningSpec() (detailBlockSpec, bool) {
 }
 
 func (m Model) detailStreamingAssistantSpec() (detailBlockSpec, bool) {
-	if strings.TrimSpace(m.ongoing) == "" {
+	if strings.TrimSpace(m.transcriptInput.Ongoing) == "" {
 		return detailBlockSpec{}, false
 	}
-	text := m.ongoing
+	text := m.transcriptInput.Ongoing
 	return detailBlockSpec{
 		role:       RenderIntentAssistant,
 		entryIndex: -1,
@@ -594,18 +594,8 @@ func (m Model) ongoingLineRangeForEntry(entryIndex int) (int, int, bool) {
 	if entryIndex < 0 {
 		return 0, 0, false
 	}
-	blocks := m.buildOngoingBlocks(true)
-	lineOffset := 0
-	for idx, block := range blocks {
-		if idx > 0 && transcriptRoleGroupsNeedSeparator(blocks[idx-1].role, block.role) {
-			lineOffset++
-		}
-		start := lineOffset
-		end := lineOffset + len(block.lines) - 1
-		if block.entryIndex == entryIndex {
-			return start, end, true
-		}
-		lineOffset += len(block.lines)
+	if lineRange, ok := m.transcriptViewProjection().OngoingEntryLineRanges[entryIndex]; ok {
+		return lineRange.Start, lineRange.End, true
 	}
 	return 0, 0, false
 }
@@ -614,27 +604,8 @@ func (m Model) detailLineRangeForEntry(entryIndex int) (int, int, bool) {
 	if entryIndex < 0 {
 		return 0, 0, false
 	}
-	m.ensureDetailMetricsResolved()
-	localIndex := entryIndex - m.detailEntryRangeOffset
-	if localIndex >= 0 && localIndex < len(m.detailEntryLineRanges) {
-		rangeForEntry := m.detailEntryLineRanges[localIndex]
-		if rangeForEntry.Start >= 0 && rangeForEntry.End >= rangeForEntry.Start {
-			return rangeForEntry.Start, rangeForEntry.End, true
-		}
-		return 0, 0, false
-	}
-	blocks := m.buildDetailBlocks(true, false)
-	lineOffset := 0
-	for idx, block := range blocks {
-		if idx > 0 && transcriptRoleGroupsNeedSeparator(blocks[idx-1].role, block.role) {
-			lineOffset++
-		}
-		start := lineOffset
-		end := lineOffset + len(block.lines) - 1
-		if block.entryIndex == entryIndex {
-			return start, end, true
-		}
-		lineOffset += len(block.lines)
+	if lineRange, ok := m.detailViewProjection().DetailEntryLineRanges[entryIndex]; ok {
+		return lineRange.Start, lineRange.End, true
 	}
 	return 0, 0, false
 }

--- a/cli/tui/model_rendering.go
+++ b/cli/tui/model_rendering.go
@@ -92,6 +92,7 @@ func (m Model) buildOngoingBlocks(includeStreaming bool) []ongoingBlock {
 	return m.buildTranscriptBlocks(transcriptBlockOptions{
 		mode:             transcriptBlockModeOngoing,
 		includeStreaming: includeStreaming,
+		applySelection:   true,
 	})
 }
 

--- a/cli/tui/model_rendering_entries.go
+++ b/cli/tui/model_rendering_entries.go
@@ -504,7 +504,7 @@ func (m Model) selectedUserTranscriptEntry() (int, bool) {
 	if !ok {
 		return -1, false
 	}
-	if roleFromEntry(m.transcript[localIndex]) != TranscriptRoleUser {
+	if roleFromEntry(m.transcriptInput.Entries[localIndex]) != TranscriptRoleUser {
 		return -1, false
 	}
 	return m.selectedTranscriptEntry, true

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -130,11 +130,8 @@ func TestToggleToDetailCanSkipWarmup(t *testing.T) {
 	if got := m.Mode(); got != ModeDetail {
 		t.Fatalf("mode after skip-warmup toggle = %q, want %q", got, ModeDetail)
 	}
-	if !m.detailDirty {
-		t.Fatal("expected detail snapshot to remain dirty when warmup is skipped")
-	}
-	if len(m.detailLines) != 0 {
-		t.Fatalf("expected no detail snapshot lines after skip-warmup toggle, got %d", len(m.detailLines))
+	if got := m.DetailRebuildCount(); got != 0 {
+		t.Fatalf("expected skip-warmup toggle to avoid eager detail rebuild, got %d rebuilds", got)
 	}
 	if got := m.detailScroll; got != 0 {
 		t.Fatalf("detail scroll after skip-warmup toggle = %d, want 0", got)
@@ -228,53 +225,51 @@ func TestErrorEntryVisibleInDetailAndHiddenInOngoing(t *testing.T) {
 	}
 }
 
-func TestDetailSnapshotIsStaticUntilRetoggle(t *testing.T) {
+func TestDetailUpdatesWhileOpenAndKeepsScrollStable(t *testing.T) {
 	m := NewModel()
 	m = updateModel(t, m, AppendTranscriptMsg{Role: "user", Text: "question"})
 	m = updateModel(t, m, StreamAssistantMsg{Delta: "alpha"})
 	m = updateModel(t, m, ToggleModeMsg{})
+	m.ensureDetailScrollResolved()
 
-	snapshot := plainTranscript(m.View())
-	if !containsInOrder(snapshot, "❮", "alpha") {
-		t.Fatalf("detail snapshot missing assistant stream: %q", snapshot)
+	initial := plainTranscript(m.View())
+	initialScroll := m.DetailScroll()
+	if !containsInOrder(initial, "❮", "alpha") {
+		t.Fatalf("detail view missing assistant stream: %q", initial)
 	}
 
 	m = updateModel(t, m, StreamAssistantMsg{Delta: " beta"})
 	m = updateModel(t, m, AppendTranscriptMsg{Role: "tool", Text: "ran"})
 
-	if got := plainTranscript(m.View()); got != snapshot {
-		t.Fatalf("detail snapshot changed while in detail mode:\ninitial=%q\ncurrent=%q", snapshot, got)
+	updated := plainTranscript(m.View())
+	if updated == initial {
+		t.Fatalf("detail view did not update while open")
 	}
-
-	m = updateModel(t, m, ToggleModeMsg{})
-	m = updateModel(t, m, ToggleModeMsg{})
-	refreshed := plainTranscript(m.View())
-
-	if refreshed == snapshot {
-		t.Fatalf("detail snapshot did not refresh after mode roundtrip")
+	if got := m.DetailScroll(); got != initialScroll {
+		t.Fatalf("detail scroll changed while content updated, got %d want %d", got, initialScroll)
 	}
-	if !containsInOrder(refreshed, "❮", "alpha beta") {
-		t.Fatalf("refreshed snapshot missing full assistant stream: %q", refreshed)
+	if !containsInOrder(updated, "❮", "alpha beta") {
+		t.Fatalf("updated detail view missing full assistant stream: %q", updated)
 	}
-	if !containsInOrder(refreshed, "•", "ran") {
-		t.Fatalf("refreshed snapshot missing new transcript entry: %q", refreshed)
+	if !containsInOrder(updated, "•", "ran") {
+		t.Fatalf("updated detail view missing new transcript entry: %q", updated)
 	}
 }
 
-func TestDetailDoesNotScrollOnIncomingMessages(t *testing.T) {
+func TestDetailScrollStaysStableOnIncomingMessages(t *testing.T) {
 	m := NewModel(WithPreviewLines(2))
 	m = updateModel(t, m, AppendTranscriptMsg{Role: "user", Text: "u1"})
 	m = updateModel(t, m, AppendTranscriptMsg{Role: "assistant", Text: "a1"})
 	m = updateModel(t, m, AppendTranscriptMsg{Role: "user", Text: "u2"})
 	m = updateModel(t, m, AppendTranscriptMsg{Role: "assistant", Text: "a2"})
 	m = updateModel(t, m, ToggleModeMsg{})
+	m.ensureDetailScrollResolved()
 	m = updateModel(t, m, ScrollOngoingMsg{Delta: 1})
 
-	before := plainTranscript(m.View())
+	beforeScroll := m.DetailScroll()
 	m = updateModel(t, m, AppendTranscriptMsg{Role: "assistant", Text: "a3"})
-	after := plainTranscript(m.View())
-	if after != before {
-		t.Fatalf("detail view changed while new messages arrived:\nbefore=%q\nafter=%q", before, after)
+	if got := m.DetailScroll(); got != beforeScroll {
+		t.Fatalf("detail scroll changed while new messages arrived, got %d want %d", got, beforeScroll)
 	}
 }
 
@@ -497,7 +492,7 @@ func TestFocusTranscriptEntryClampsNearTopAndBottom(t *testing.T) {
 		t.Fatalf("expected top entry visible after focus, range=(%d,%d) scroll=%d", start, end, m.OngoingScroll())
 	}
 
-	bottomEntry := len(m.transcript) - 1
+	bottomEntry := len(m.transcriptInput.Entries) - 1
 	m = updateModel(t, m, FocusTranscriptEntryMsg{EntryIndex: bottomEntry, Center: true})
 	if got, want := m.OngoingScroll(), m.maxOngoingScroll(); got != want {
 		t.Fatalf("expected bottom entry focus to clamp to max scroll %d, got %d", want, got)

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -130,8 +130,8 @@ func TestToggleToDetailCanSkipWarmup(t *testing.T) {
 	if got := m.Mode(); got != ModeDetail {
 		t.Fatalf("mode after skip-warmup toggle = %q, want %q", got, ModeDetail)
 	}
-	if got := m.DetailRebuildCount(); got != 0 {
-		t.Fatalf("expected skip-warmup toggle to avoid eager detail rebuild, got %d rebuilds", got)
+	if m.DetailMetricsResolved() {
+		t.Fatal("expected skip-warmup toggle to leave detail metrics lazy")
 	}
 	if got := m.detailScroll; got != 0 {
 		t.Fatalf("detail scroll after skip-warmup toggle = %d, want 0", got)

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -264,12 +264,37 @@ func TestDetailScrollStaysStableOnIncomingMessages(t *testing.T) {
 	m = updateModel(t, m, AppendTranscriptMsg{Role: "assistant", Text: "a2"})
 	m = updateModel(t, m, ToggleModeMsg{})
 	m.ensureDetailScrollResolved()
-	m = updateModel(t, m, ScrollOngoingMsg{Delta: 1})
+	m = updateModel(t, m, tea.KeyMsg{Type: tea.KeyPgUp})
+	if m.DetailScroll() == 0 {
+		t.Fatal("expected detail viewport to move before appending")
+	}
 
 	beforeScroll := m.DetailScroll()
 	m = updateModel(t, m, AppendTranscriptMsg{Role: "assistant", Text: "a3"})
 	if got := m.DetailScroll(); got != beforeScroll {
 		t.Fatalf("detail scroll changed while new messages arrived, got %d want %d", got, beforeScroll)
+	}
+}
+
+func TestDetailLazyBottomAnchorFollowsIncomingMessages(t *testing.T) {
+	m := NewModel(WithPreviewLines(2))
+	m = updateModel(t, m, AppendTranscriptMsg{Role: "user", Text: "u1"})
+	m = updateModel(t, m, AppendTranscriptMsg{Role: "assistant", Text: "a1"})
+	m = updateModel(t, m, AppendTranscriptMsg{Role: "user", Text: "u2"})
+	m = updateModel(t, m, AppendTranscriptMsg{Role: "assistant", Text: "a2"})
+	m = updateModel(t, m, ToggleModeMsg{})
+	if m.DetailMetricsResolved() {
+		t.Fatal("expected detail entry to remain lazily bottom-anchored before live append")
+	}
+
+	m = updateModel(t, m, AppendTranscriptMsg{Role: "assistant", Text: "a3"})
+
+	if m.DetailMetricsResolved() {
+		t.Fatal("expected live append to preserve lazy detail bottom anchor")
+	}
+	view := plainTranscript(m.View())
+	if !strings.Contains(view, "a3") {
+		t.Fatalf("expected lazy bottom-anchored detail view to follow live append, got %q", view)
 	}
 }
 

--- a/cli/tui/pending_snapshot.go
+++ b/cli/tui/pending_snapshot.go
@@ -61,7 +61,7 @@ func renderPendingOngoingSnapshotProjection(entries []TranscriptEntry, theme str
 	}
 	model := transcriptProjectionRenderer(theme, width, 0)
 	model.toolSymbolGap = 2
-	model.transcript = append([]TranscriptEntry(nil), entries...)
+	model.transcriptInput.Entries = append([]TranscriptEntry(nil), entries...)
 	blocks := model.buildOngoingBlocks(false)
 	blocks = model.applyPendingSpinner(blocks, entries, spinnerForEntry)
 	if len(blocks) == 0 {

--- a/cli/tui/transcript_projection.go
+++ b/cli/tui/transcript_projection.go
@@ -77,6 +77,9 @@ type TranscriptViewProjector struct {
 	detailKey            TranscriptViewProjectionKey
 	detailProjection     TranscriptProjection
 	detailSet            bool
+	detailViewKey        TranscriptViewProjectionKey
+	detailViewProjection TranscriptViewProjection
+	detailViewSet        bool
 	ongoingKey           CommittedOngoingProjectionKey
 	ongoingLines         []TranscriptProjectionLine
 	ongoingGroup         string
@@ -105,6 +108,7 @@ type TranscriptViewProjection struct {
 	DetailLineOwners       []int
 	OngoingEntryLineRanges map[int]lineRange
 	DetailEntryLineRanges  map[int]lineRange
+	DetailSelectableBlocks map[int]int
 }
 
 type ProjectionViewportState struct {
@@ -135,6 +139,7 @@ func (p TranscriptViewProjection) Clone() TranscriptViewProjection {
 		DetailLineOwners:       append([]int(nil), p.DetailLineOwners...),
 		OngoingEntryLineRanges: cloneLineRangeMap(p.OngoingEntryLineRanges),
 		DetailEntryLineRanges:  cloneLineRangeMap(p.DetailEntryLineRanges),
+		DetailSelectableBlocks: cloneIntMap(p.DetailSelectableBlocks),
 	}
 }
 
@@ -286,6 +291,22 @@ func (p TranscriptProjection) EntryLineRanges() map[int]lineRange {
 		lineOffset += len(block.Lines)
 	}
 	return ranges
+}
+
+func (p TranscriptProjection) SelectableBlockIndexes() map[int]int {
+	if len(p.Blocks) == 0 {
+		return nil
+	}
+	indexes := make(map[int]int, len(p.Blocks))
+	for idx, block := range p.Blocks {
+		if !block.Selectable || block.EntryIndex < 0 {
+			continue
+		}
+		if _, ok := indexes[block.EntryIndex]; !ok {
+			indexes[block.EntryIndex] = idx
+		}
+	}
+	return indexes
 }
 
 func (p TranscriptProjection) Render(divider string) string {
@@ -492,6 +513,7 @@ func ProjectTranscriptViews(input TranscriptProjectionInput, state TranscriptPro
 		DetailLineOwners:       detail.LineOwners(),
 		OngoingEntryLineRanges: ongoing.EntryLineRanges(),
 		DetailEntryLineRanges:  detail.EntryLineRanges(),
+		DetailSelectableBlocks: detail.SelectableBlockIndexes(),
 	}
 }
 
@@ -590,8 +612,18 @@ func (p *TranscriptViewProjector) ProjectShared(input TranscriptProjectionInput,
 }
 
 func (p *TranscriptViewProjector) ProjectDetailShared(input TranscriptProjectionInput, state TranscriptProjectionViewState) TranscriptViewProjection {
+	key := NewTranscriptViewProjectionKey(input, state)
+	if key.Revision > 0 && p != nil && p.detailViewSet && transcriptViewProjectionKeysEqual(p.detailViewKey, key) {
+		return p.detailViewProjection
+	}
 	detail := p.detailProjectionFor(input, state)
-	return transcriptViewProjectionForDetail(input.Revision, detail)
+	projection := transcriptViewProjectionForDetail(input.Revision, detail)
+	if key.Revision > 0 && p != nil {
+		p.detailViewKey = key
+		p.detailViewProjection = projection
+		p.detailViewSet = true
+	}
+	return projection
 }
 
 func (p *TranscriptViewProjector) detailProjectionFor(input TranscriptProjectionInput, state TranscriptProjectionViewState) TranscriptProjection {
@@ -633,11 +665,12 @@ func (p *TranscriptViewProjector) detailProjectionFor(input TranscriptProjection
 
 func transcriptViewProjectionForDetail(revision int64, detail TranscriptProjection) TranscriptViewProjection {
 	return TranscriptViewProjection{
-		InputRevision:         revision,
-		Detail:                detail,
-		DetailLines:           detail.Lines(detailItemSeparator),
-		DetailLineOwners:      detail.LineOwners(),
-		DetailEntryLineRanges: detail.EntryLineRanges(),
+		InputRevision:          revision,
+		Detail:                 detail,
+		DetailLines:            detail.Lines(detailItemSeparator),
+		DetailLineOwners:       detail.LineOwners(),
+		DetailEntryLineRanges:  detail.EntryLineRanges(),
+		DetailSelectableBlocks: detail.SelectableBlockIndexes(),
 	}
 }
 
@@ -887,6 +920,17 @@ func cloneLineRangeMap(ranges map[int]lineRange) map[int]lineRange {
 	out := make(map[int]lineRange, len(ranges))
 	for entry, lineRange := range ranges {
 		out[entry] = lineRange
+	}
+	return out
+}
+
+func cloneIntMap(in map[int]int) map[int]int {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[int]int, len(in))
+	for key, value := range in {
+		out[key] = value
 	}
 	return out
 }

--- a/cli/tui/transcript_projection.go
+++ b/cli/tui/transcript_projection.go
@@ -1,6 +1,9 @@
 package tui
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 type TranscriptProjection struct {
 	Blocks []TranscriptProjectionBlock
@@ -29,6 +32,166 @@ type CommittedOngoingProjector struct {
 	rendererWidth int
 }
 
+type TranscriptProjectionInput struct {
+	Revision           int64
+	EntriesRevision    int64
+	BaseOffset         int
+	TotalEntries       int
+	Entries            []TranscriptEntry
+	Ongoing            string
+	StreamingReasoning []StreamingReasoningEntry
+}
+
+type TranscriptProjectionViewState struct {
+	ViewportWidth         int
+	ViewportLines         int
+	Theme                 string
+	CompactDetail         bool
+	SelectedEntry         int
+	SelectedEntryIsActive bool
+	DetailSelectedEntry   int
+	DetailSelectedActive  bool
+	DetailExpandedEntries map[int]struct{}
+}
+
+type TranscriptViewProjectionKey struct {
+	Revision              int64
+	BaseOffset            int
+	TotalEntries          int
+	EntryCount            int
+	ViewportWidth         int
+	ViewportLines         int
+	Theme                 string
+	CompactDetail         bool
+	SelectedEntry         int
+	SelectedEntryIsActive bool
+	DetailSelectedEntry   int
+	DetailSelectedActive  bool
+	ExpandedEntries       []int
+}
+
+type TranscriptViewProjector struct {
+	key                  TranscriptViewProjectionKey
+	projection           TranscriptViewProjection
+	projectionSet        bool
+	detailKey            TranscriptViewProjectionKey
+	detailProjection     TranscriptProjection
+	detailSet            bool
+	ongoingKey           CommittedOngoingProjectionKey
+	ongoingLines         []TranscriptProjectionLine
+	ongoingGroup         string
+	ongoingSet           bool
+	streamingKey         ongoingStreamingProjectionKey
+	streamingLines       []TranscriptProjectionLine
+	streamingSet         bool
+	detailStreamingKey   ongoingStreamingProjectionKey
+	detailStreamingLines []string
+	detailStreamingSet   bool
+}
+
+type ongoingStreamingProjectionKey struct {
+	Text  string
+	Theme string
+	Width int
+}
+
+type TranscriptViewProjection struct {
+	InputRevision          int64
+	Ongoing                TranscriptProjection
+	Detail                 TranscriptProjection
+	OngoingLines           []TranscriptProjectionLine
+	DetailLines            []TranscriptProjectionLine
+	OngoingLineOwners      []int
+	DetailLineOwners       []int
+	OngoingEntryLineRanges map[int]lineRange
+	DetailEntryLineRanges  map[int]lineRange
+}
+
+type ProjectionViewportState struct {
+	ViewportLines int
+	Scroll        int
+	BottomAnchor  bool
+	BottomOffset  int
+}
+
+type ProjectionViewport struct {
+	Lines        []string
+	Kinds        []VisibleLineKind
+	Owners       []int
+	TotalLines   int
+	MaxScroll    int
+	Scroll       int
+	BottomOffset int
+}
+
+func (p TranscriptViewProjection) Clone() TranscriptViewProjection {
+	return TranscriptViewProjection{
+		InputRevision:          p.InputRevision,
+		Ongoing:                p.Ongoing.Clone(),
+		Detail:                 p.Detail.Clone(),
+		OngoingLines:           cloneProjectionLines(p.OngoingLines),
+		DetailLines:            cloneProjectionLines(p.DetailLines),
+		OngoingLineOwners:      append([]int(nil), p.OngoingLineOwners...),
+		DetailLineOwners:       append([]int(nil), p.DetailLineOwners...),
+		OngoingEntryLineRanges: cloneLineRangeMap(p.OngoingEntryLineRanges),
+		DetailEntryLineRanges:  cloneLineRangeMap(p.DetailEntryLineRanges),
+	}
+}
+
+func (p TranscriptViewProjection) DetailViewport(state ProjectionViewportState) ProjectionViewport {
+	return projectionViewportFromLines(p.DetailLines, p.DetailLineOwners, state)
+}
+
+func projectionViewportFromLines(lines []TranscriptProjectionLine, owners []int, state ProjectionViewportState) ProjectionViewport {
+	viewportLines := state.ViewportLines
+	if viewportLines <= 0 {
+		return ProjectionViewport{}
+	}
+	if len(lines) == 0 {
+		lines = []TranscriptProjectionLine{{Kind: VisibleLineContent, Text: ""}}
+		owners = []int{-1}
+	}
+	total := len(lines)
+	maxScroll := max(0, total-viewportLines)
+	scroll := clamp(state.Scroll, 0, maxScroll)
+	bottomOffset := state.BottomOffset
+	if bottomOffset < 0 {
+		bottomOffset = 0
+	}
+	if bottomOffset > maxScroll {
+		bottomOffset = maxScroll
+	}
+	if state.BottomAnchor {
+		scroll = maxScroll - bottomOffset
+	}
+	end := scroll + viewportLines
+	if end > total {
+		end = total
+	}
+	outLines := make([]string, 0, viewportLines)
+	outKinds := make([]VisibleLineKind, 0, viewportLines)
+	outOwners := make([]int, 0, viewportLines)
+	for idx := scroll; idx < end; idx++ {
+		line := lines[idx]
+		outLines = append(outLines, line.Text)
+		outKinds = append(outKinds, line.Kind)
+		if idx < len(owners) {
+			outOwners = append(outOwners, owners[idx])
+		} else {
+			outOwners = append(outOwners, -1)
+		}
+	}
+	return ProjectionViewport{
+		Lines:        outLines,
+		Kinds:        outKinds,
+		Owners:       outOwners,
+		TotalLines:   total,
+		MaxScroll:    maxScroll,
+		Scroll:       scroll,
+		BottomOffset: bottomOffset,
+	}
+}
+
 type TranscriptProjectionLine struct {
 	Kind VisibleLineKind
 	Text string
@@ -39,6 +202,9 @@ type TranscriptProjectionBlock struct {
 	DividerGroup string
 	EntryIndex   int
 	EntryEnd     int
+	Selectable   bool
+	Expanded     bool
+	Expandable   bool
 	Lines        []string
 }
 
@@ -57,6 +223,9 @@ func (p TranscriptProjection) Clone() TranscriptProjection {
 			DividerGroup: block.DividerGroup,
 			EntryIndex:   block.EntryIndex,
 			EntryEnd:     block.EntryEnd,
+			Selectable:   block.Selectable,
+			Expanded:     block.Expanded,
+			Expandable:   block.Expandable,
 			Lines:        append([]string(nil), block.Lines...),
 		})
 	}
@@ -77,6 +246,46 @@ func (p TranscriptProjection) Lines(dividerText string) []TranscriptProjectionLi
 		}
 	}
 	return lines
+}
+
+func (p TranscriptProjection) LineOwners() []int {
+	if len(p.Blocks) == 0 {
+		return nil
+	}
+	owners := make([]int, 0, len(p.Blocks)*2)
+	for idx, block := range p.Blocks {
+		if idx > 0 && p.Blocks[idx-1].DividerGroup != block.DividerGroup {
+			owners = append(owners, -1)
+		}
+		for range block.Lines {
+			owners = append(owners, block.EntryIndex)
+		}
+	}
+	return owners
+}
+
+func (p TranscriptProjection) EntryLineRanges() map[int]lineRange {
+	if len(p.Blocks) == 0 {
+		return nil
+	}
+	ranges := make(map[int]lineRange)
+	lineOffset := 0
+	for idx, block := range p.Blocks {
+		if idx > 0 && p.Blocks[idx-1].DividerGroup != block.DividerGroup {
+			lineOffset++
+		}
+		if block.EntryIndex >= 0 && len(block.Lines) > 0 {
+			start := lineOffset
+			end := lineOffset + len(block.Lines) - 1
+			if existing, ok := ranges[block.EntryIndex]; ok {
+				ranges[block.EntryIndex] = lineRange{Start: existing.Start, End: end}
+			} else {
+				ranges[block.EntryIndex] = lineRange{Start: start, End: end}
+			}
+		}
+		lineOffset += len(block.Lines)
+	}
+	return ranges
 }
 
 func (p TranscriptProjection) Render(divider string) string {
@@ -191,6 +400,9 @@ func (b TranscriptProjectionBlock) equal(other TranscriptProjectionBlock) bool {
 	if b.Role != other.Role || b.DividerGroup != other.DividerGroup || len(b.Lines) != len(other.Lines) {
 		return false
 	}
+	if b.Selectable != other.Selectable || b.Expanded != other.Expanded || b.Expandable != other.Expandable {
+		return false
+	}
 	for idx := range b.Lines {
 		if b.Lines[idx] != other.Lines[idx] {
 			return false
@@ -204,15 +416,351 @@ func (m Model) OngoingProjection(includeStreaming bool) TranscriptProjection {
 }
 
 func (m Model) CommittedOngoingProjection() TranscriptProjection {
-	return m.CommittedOngoingProjectionForEntries(m.transcript)
+	return m.CommittedOngoingProjectionForEntries(m.transcriptInput.Entries)
 }
 
 func (m Model) CommittedOngoingProjectionForEntries(entries []TranscriptEntry) TranscriptProjection {
-	target := m.transcript
+	target := m.transcriptInput.Entries
 	if len(entries) > 0 {
 		target = entries
 	}
 	return projectCommittedOngoingTranscriptWithRenderer(m, target)
+}
+
+func (m Model) TranscriptProjectionInput() TranscriptProjectionInput {
+	input := m.transcriptProjectionInput()
+	input.Entries = cloneTranscriptEntries(input.Entries)
+	input.StreamingReasoning = cloneStreamingReasoningEntries(input.StreamingReasoning)
+	return input
+}
+
+func (m Model) transcriptProjectionInput() TranscriptProjectionInput {
+	return TranscriptProjectionInput{
+		Revision:           m.transcriptInput.Revision,
+		EntriesRevision:    m.transcriptInput.EntriesRevision,
+		BaseOffset:         m.transcriptInput.BaseOffset,
+		TotalEntries:       m.TranscriptTotalEntries(),
+		Entries:            m.transcriptInput.Entries,
+		Ongoing:            m.transcriptInput.Ongoing,
+		StreamingReasoning: m.transcriptInput.StreamingReasoning,
+	}
+}
+
+func (m Model) TranscriptProjectionViewState() TranscriptProjectionViewState {
+	return TranscriptProjectionViewState{
+		ViewportWidth:         m.viewportWidth,
+		ViewportLines:         m.viewportLines,
+		Theme:                 m.theme,
+		CompactDetail:         m.compactDetail,
+		SelectedEntry:         m.selectedTranscriptEntry,
+		SelectedEntryIsActive: m.selectedTranscriptActive,
+		DetailSelectedEntry:   m.detailSelectedEntry,
+		DetailSelectedActive:  m.detailSelectedActive,
+		DetailExpandedEntries: cloneExpandedEntrySet(m.detailExpandedEntries),
+	}
+}
+
+func ProjectTranscriptViews(input TranscriptProjectionInput, state TranscriptProjectionViewState) TranscriptViewProjection {
+	renderer := transcriptProjectionRenderer(state.Theme, state.ViewportWidth, input.BaseOffset)
+	if state.ViewportLines > 0 {
+		renderer.viewportLines = state.ViewportLines
+	}
+	renderer.compactDetail = state.CompactDetail
+	renderer.selectedTranscriptEntry = state.SelectedEntry
+	renderer.selectedTranscriptActive = state.SelectedEntryIsActive
+	renderer.detailSelectedEntry = state.DetailSelectedEntry
+	renderer.detailSelectedActive = state.DetailSelectedActive
+	renderer.detailExpandedEntries = cloneExpandedEntrySet(state.DetailExpandedEntries)
+	renderer.transcriptInput.Entries = cloneTranscriptEntries(input.Entries)
+	renderer.transcriptInput.BaseOffset = max(0, input.BaseOffset)
+	renderer.transcriptInput.TotalEntries = input.TotalEntries
+	if renderer.transcriptInput.TotalEntries < renderer.transcriptInput.BaseOffset+len(renderer.transcriptInput.Entries) {
+		renderer.transcriptInput.TotalEntries = renderer.transcriptInput.BaseOffset + len(renderer.transcriptInput.Entries)
+	}
+	renderer.transcriptInput.Ongoing = input.Ongoing
+	renderer.transcriptInput.StreamingReasoning = cloneStreamingReasoningEntries(input.StreamingReasoning)
+
+	ongoing := renderer.OngoingProjection(true)
+	detail := renderer.DetailProjection(true, true)
+	return TranscriptViewProjection{
+		InputRevision:          input.Revision,
+		Ongoing:                ongoing,
+		Detail:                 detail,
+		OngoingLines:           ongoing.Lines(detailDivider()),
+		DetailLines:            detail.Lines(detailItemSeparator),
+		OngoingLineOwners:      ongoing.LineOwners(),
+		DetailLineOwners:       detail.LineOwners(),
+		OngoingEntryLineRanges: ongoing.EntryLineRanges(),
+		DetailEntryLineRanges:  detail.EntryLineRanges(),
+	}
+}
+
+func (p *TranscriptViewProjector) CommittedOngoingLines(input TranscriptProjectionInput, state TranscriptProjectionViewState) ([]TranscriptProjectionLine, string) {
+	key := CommittedOngoingProjectionKey{
+		Revision:   input.EntriesRevision,
+		Width:      state.ViewportWidth,
+		Theme:      state.Theme,
+		BaseOffset: input.BaseOffset,
+		EntryCount: len(input.Entries),
+	}
+	key = normalizeCommittedOngoingProjectionKey(key, len(input.Entries))
+	if key.Revision > 0 && p != nil && p.ongoingSet && p.ongoingKey == key {
+		return p.ongoingLines, p.ongoingGroup
+	}
+	projection := projectCommittedOngoingTranscriptWithRenderer(
+		committedOngoingProjectionRenderer(key.Theme, key.Width, key.BaseOffset),
+		input.Entries,
+	)
+	lines := projection.Lines(detailDivider())
+	lastGroup := ""
+	if blockCount := len(projection.Blocks); blockCount > 0 {
+		lastGroup = projection.Blocks[blockCount-1].DividerGroup
+	}
+	if key.Revision > 0 && p != nil {
+		p.ongoingKey = key
+		p.ongoingLines = lines
+		p.ongoingGroup = lastGroup
+		p.ongoingSet = true
+	}
+	return lines, lastGroup
+}
+
+func (p *TranscriptViewProjector) StreamingOngoingLines(text string, state TranscriptProjectionViewState) []TranscriptProjectionLine {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	key := ongoingStreamingProjectionKey{
+		Text:  text,
+		Theme: normalizeTheme(state.Theme),
+		Width: state.ViewportWidth,
+	}
+	if key.Width <= 0 {
+		key.Width = 120
+	}
+	if p != nil && p.streamingSet && p.streamingKey == key {
+		return p.streamingLines
+	}
+	renderer := transcriptProjectionRenderer(key.Theme, key.Width, 0)
+	plain := renderer.flattenEntryPlain(RenderIntentAssistant, text)
+	lines := make([]TranscriptProjectionLine, 0, len(plain))
+	for _, line := range plain {
+		lines = append(lines, TranscriptProjectionLine{Kind: VisibleLineContent, Text: line})
+	}
+	if p != nil {
+		p.streamingKey = key
+		p.streamingLines = lines
+		p.streamingSet = true
+	}
+	return lines
+}
+
+func (p *TranscriptViewProjector) StreamingDetailAssistantLines(text string, state TranscriptProjectionViewState) []string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	key := ongoingStreamingProjectionKey{
+		Text:  text,
+		Theme: normalizeTheme(state.Theme),
+		Width: state.ViewportWidth,
+	}
+	if key.Width <= 0 {
+		key.Width = 120
+	}
+	if p != nil && p.detailStreamingSet && p.detailStreamingKey == key {
+		return p.detailStreamingLines
+	}
+	renderer := transcriptProjectionRenderer(key.Theme, key.Width, 0)
+	lines := renderer.flattenEntry(RenderIntentAssistant, text)
+	if p != nil {
+		p.detailStreamingKey = key
+		p.detailStreamingLines = lines
+		p.detailStreamingSet = true
+	}
+	return lines
+}
+
+func (p *TranscriptViewProjector) Project(input TranscriptProjectionInput, state TranscriptProjectionViewState) TranscriptViewProjection {
+	return p.project(input, state, true)
+}
+
+func (p *TranscriptViewProjector) ProjectShared(input TranscriptProjectionInput, state TranscriptProjectionViewState) TranscriptViewProjection {
+	return p.project(input, state, false)
+}
+
+func (p *TranscriptViewProjector) ProjectDetailShared(input TranscriptProjectionInput, state TranscriptProjectionViewState) TranscriptViewProjection {
+	detail := p.detailProjectionFor(input, state)
+	return transcriptViewProjectionForDetail(input.Revision, detail)
+}
+
+func (p *TranscriptViewProjector) detailProjectionFor(input TranscriptProjectionInput, state TranscriptProjectionViewState) TranscriptProjection {
+	keyInput := input
+	keyInput.Revision = input.EntriesRevision
+	keyInput.Ongoing = ""
+	keyInput.StreamingReasoning = nil
+	key := NewTranscriptViewProjectionKey(keyInput, state)
+	cacheable := key.Revision > 0
+	var detail TranscriptProjection
+	if cacheable && p != nil && p.detailSet && transcriptViewProjectionKeysEqual(p.detailKey, key) {
+		detail = p.detailProjection
+	} else {
+		renderer := transcriptProjectionRenderer(state.Theme, state.ViewportWidth, input.BaseOffset)
+		if state.ViewportLines > 0 {
+			renderer.viewportLines = state.ViewportLines
+		}
+		renderer.compactDetail = state.CompactDetail
+		renderer.selectedTranscriptEntry = state.SelectedEntry
+		renderer.selectedTranscriptActive = state.SelectedEntryIsActive
+		renderer.detailSelectedEntry = state.DetailSelectedEntry
+		renderer.detailSelectedActive = state.DetailSelectedActive
+		renderer.detailExpandedEntries = cloneExpandedEntrySet(state.DetailExpandedEntries)
+		renderer.transcriptInput.Entries = cloneTranscriptEntries(input.Entries)
+		renderer.transcriptInput.BaseOffset = max(0, input.BaseOffset)
+		renderer.transcriptInput.TotalEntries = input.TotalEntries
+		if renderer.transcriptInput.TotalEntries < renderer.transcriptInput.BaseOffset+len(renderer.transcriptInput.Entries) {
+			renderer.transcriptInput.TotalEntries = renderer.transcriptInput.BaseOffset + len(renderer.transcriptInput.Entries)
+		}
+		detail = renderer.DetailProjection(false, true)
+		if cacheable && p != nil {
+			p.detailKey = key
+			p.detailProjection = detail
+			p.detailSet = true
+		}
+	}
+	return appendDetailStreamingProjection(detail, input, state, p)
+}
+
+func transcriptViewProjectionForDetail(revision int64, detail TranscriptProjection) TranscriptViewProjection {
+	return TranscriptViewProjection{
+		InputRevision:         revision,
+		Detail:                detail,
+		DetailLines:           detail.Lines(detailItemSeparator),
+		DetailLineOwners:      detail.LineOwners(),
+		DetailEntryLineRanges: detail.EntryLineRanges(),
+	}
+}
+
+func appendDetailStreamingProjection(base TranscriptProjection, input TranscriptProjectionInput, state TranscriptProjectionViewState, projector *TranscriptViewProjector) TranscriptProjection {
+	blocks := append([]TranscriptProjectionBlock(nil), base.Blocks...)
+	if reasoning := detailStreamingReasoningBlock(input, state); len(reasoning.Lines) > 0 {
+		blocks = append(blocks, reasoning)
+	}
+	if strings.TrimSpace(input.Ongoing) != "" {
+		var lines []string
+		if projector != nil {
+			lines = projector.StreamingDetailAssistantLines(input.Ongoing, state)
+		} else {
+			renderer := transcriptProjectionRenderer(state.Theme, state.ViewportWidth, input.BaseOffset)
+			lines = renderer.flattenEntry(RenderIntentAssistant, input.Ongoing)
+		}
+		if len(lines) > 0 {
+			blocks = append(blocks, TranscriptProjectionBlock{
+				Role:         RenderIntentAssistant,
+				DividerGroup: ongoingDividerGroup(RenderIntentAssistant),
+				EntryIndex:   -1,
+				EntryEnd:     -1,
+				Lines:        lines,
+			})
+		}
+	}
+	return TranscriptProjection{Blocks: blocks}
+}
+
+func detailStreamingReasoningBlock(input TranscriptProjectionInput, state TranscriptProjectionViewState) TranscriptProjectionBlock {
+	if len(input.StreamingReasoning) == 0 {
+		return TranscriptProjectionBlock{}
+	}
+	parts := make([]string, 0, len(input.StreamingReasoning))
+	for _, entry := range input.StreamingReasoning {
+		text := strings.TrimSpace(entry.Text)
+		if text == "" {
+			continue
+		}
+		parts = append(parts, text)
+	}
+	if len(parts) == 0 {
+		return TranscriptProjectionBlock{}
+	}
+	renderer := transcriptProjectionRenderer(state.Theme, state.ViewportWidth, input.BaseOffset)
+	lines := renderer.flattenEntry(RenderIntentReasoning, strings.Join(parts, "\n"))
+	return TranscriptProjectionBlock{
+		Role:         RenderIntentReasoning,
+		DividerGroup: ongoingDividerGroup(RenderIntentReasoning),
+		EntryIndex:   -1,
+		EntryEnd:     -1,
+		Lines:        lines,
+	}
+}
+
+func (p *TranscriptViewProjector) project(input TranscriptProjectionInput, state TranscriptProjectionViewState, cloneResult bool) TranscriptViewProjection {
+	key := NewTranscriptViewProjectionKey(input, state)
+	if input.Revision > 0 && p != nil && p.projectionSet && transcriptViewProjectionKeysEqual(p.key, key) {
+		if !cloneResult {
+			return p.projection
+		}
+		return p.projection.Clone()
+	}
+	projection := ProjectTranscriptViews(input, state)
+	if input.Revision > 0 && p != nil {
+		p.key = key
+		p.projection = projection
+		p.projectionSet = true
+	}
+	if cloneResult {
+		return projection.Clone()
+	}
+	return projection
+}
+
+func NewTranscriptViewProjectionKey(input TranscriptProjectionInput, state TranscriptProjectionViewState) TranscriptViewProjectionKey {
+	width := state.ViewportWidth
+	if width <= 0 {
+		width = 120
+	}
+	lines := state.ViewportLines
+	if lines <= 0 {
+		lines = DefaultPreviewLines
+	}
+	return TranscriptViewProjectionKey{
+		Revision:              input.Revision,
+		BaseOffset:            max(0, input.BaseOffset),
+		TotalEntries:          input.TotalEntries,
+		EntryCount:            len(input.Entries),
+		ViewportWidth:         width,
+		ViewportLines:         lines,
+		Theme:                 normalizeTheme(state.Theme),
+		CompactDetail:         state.CompactDetail,
+		SelectedEntry:         state.SelectedEntry,
+		SelectedEntryIsActive: state.SelectedEntryIsActive,
+		DetailSelectedEntry:   state.DetailSelectedEntry,
+		DetailSelectedActive:  state.DetailSelectedActive,
+		ExpandedEntries:       sortedExpandedEntries(state.DetailExpandedEntries),
+	}
+}
+
+func transcriptViewProjectionKeysEqual(left TranscriptViewProjectionKey, right TranscriptViewProjectionKey) bool {
+	if left.Revision != right.Revision ||
+		left.BaseOffset != right.BaseOffset ||
+		left.TotalEntries != right.TotalEntries ||
+		left.EntryCount != right.EntryCount ||
+		left.ViewportWidth != right.ViewportWidth ||
+		left.ViewportLines != right.ViewportLines ||
+		left.Theme != right.Theme ||
+		left.CompactDetail != right.CompactDetail ||
+		left.SelectedEntry != right.SelectedEntry ||
+		left.SelectedEntryIsActive != right.SelectedEntryIsActive ||
+		left.DetailSelectedEntry != right.DetailSelectedEntry ||
+		left.DetailSelectedActive != right.DetailSelectedActive ||
+		len(left.ExpandedEntries) != len(right.ExpandedEntries) {
+		return false
+	}
+	for idx := range left.ExpandedEntries {
+		if left.ExpandedEntries[idx] != right.ExpandedEntries[idx] {
+			return false
+		}
+	}
+	return true
 }
 
 // ProjectCommittedOngoingTranscript renders committed ongoing transcript entries
@@ -269,7 +817,7 @@ func (p *CommittedOngoingProjector) rendererFor(theme string, width int, baseOff
 		p.rendererTheme = theme
 		p.rendererWidth = width
 	}
-	p.renderer.transcriptBaseOffset = baseOffset
+	p.renderer.transcriptInput.BaseOffset = baseOffset
 	return p.renderer
 }
 
@@ -280,7 +828,7 @@ func committedOngoingProjectionRenderer(theme string, width int, baseOffset int)
 func transcriptProjectionRenderer(theme string, width int, baseOffset int) Model {
 	model := NewModel(WithTheme(theme))
 	model.viewportWidth = width
-	model.transcriptBaseOffset = baseOffset
+	model.transcriptInput.BaseOffset = baseOffset
 	return model
 }
 
@@ -289,15 +837,75 @@ func projectCommittedOngoingTranscriptWithRenderer(renderer Model, entries []Tra
 	if len(committed) == 0 {
 		return TranscriptProjection{}
 	}
-	renderer.transcript = append([]TranscriptEntry(nil), committed...)
-	renderer.ongoing = ""
-	renderer.streamingReasoning = nil
+	renderer.transcriptInput.Entries = append([]TranscriptEntry(nil), committed...)
+	renderer.transcriptInput.Ongoing = ""
+	renderer.transcriptInput.StreamingReasoning = nil
 	return projectionFromOngoingBlocks(renderer.buildOngoingBlocks(false))
+}
+
+func cloneTranscriptEntries(entries []TranscriptEntry) []TranscriptEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]TranscriptEntry, len(entries))
+	for idx, entry := range entries {
+		out[idx] = entry
+		out[idx].ToolCall = cloneToolCallMeta(entry.ToolCall)
+	}
+	return out
+}
+
+func cloneStreamingReasoningEntries(entries []StreamingReasoningEntry) []StreamingReasoningEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	return append([]StreamingReasoningEntry(nil), entries...)
+}
+
+func cloneExpandedEntrySet(entries map[int]struct{}) map[int]struct{} {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make(map[int]struct{}, len(entries))
+	for entry := range entries {
+		out[entry] = struct{}{}
+	}
+	return out
+}
+
+func cloneProjectionLines(lines []TranscriptProjectionLine) []TranscriptProjectionLine {
+	if len(lines) == 0 {
+		return nil
+	}
+	return append([]TranscriptProjectionLine(nil), lines...)
+}
+
+func cloneLineRangeMap(ranges map[int]lineRange) map[int]lineRange {
+	if len(ranges) == 0 {
+		return nil
+	}
+	out := make(map[int]lineRange, len(ranges))
+	for entry, lineRange := range ranges {
+		out[entry] = lineRange
+	}
+	return out
+}
+
+func sortedExpandedEntries(entries map[int]struct{}) []int {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]int, 0, len(entries))
+	for entry := range entries {
+		out = append(out, entry)
+	}
+	sort.Ints(out)
+	return out
 }
 
 func (m Model) DetailProjection(includeStreaming bool, applySelection bool) TranscriptProjection {
 	m.mode = ModeDetail
-	return projectionFromDetailBlocks(m.buildDetailBlocks(includeStreaming, applySelection))
+	return m.projectionFromDetailBlockSpecs(m.buildDetailBlockSpecs(includeStreaming), applySelection)
 }
 
 func projectionFromOngoingBlocks(blocks []ongoingBlock) TranscriptProjection {
@@ -323,6 +931,27 @@ func projectionFromDetailBlocks(blocks []ongoingBlock) TranscriptProjection {
 			EntryIndex:   block.entryIndex,
 			EntryEnd:     block.entryEnd,
 			Lines:        append([]string(nil), block.lines...),
+		})
+	}
+	return projection
+}
+
+func (m Model) projectionFromDetailBlockSpecs(specs []detailBlockSpec, applySelection bool) TranscriptProjection {
+	projection := TranscriptProjection{Blocks: make([]TranscriptProjectionBlock, 0, len(specs))}
+	for _, spec := range specs {
+		lines := spec.render(m, m.detailExpansionSymbolOverride(spec))
+		if applySelection {
+			lines = m.maybeSelectedUserBlock(spec.entryIndex, spec.role, lines)
+		}
+		projection.Blocks = append(projection.Blocks, TranscriptProjectionBlock{
+			Role:         spec.role,
+			DividerGroup: ongoingDividerGroup(spec.role),
+			EntryIndex:   spec.entryIndex,
+			EntryEnd:     spec.entryEnd,
+			Selectable:   spec.selectable,
+			Expanded:     spec.expanded,
+			Expandable:   spec.expandable,
+			Lines:        append([]string(nil), lines...),
 		})
 	}
 	return projection

--- a/cli/tui/transcript_projection.go
+++ b/cli/tui/transcript_projection.go
@@ -13,11 +13,14 @@ type TranscriptProjection struct {
 // committed ongoing transcript projection. Revision must advance when transcript
 // content changes; revisionless keys intentionally skip projection caching.
 type CommittedOngoingProjectionKey struct {
-	Revision   int64
-	Width      int
-	Theme      string
-	BaseOffset int
-	EntryCount int
+	Revision              int64
+	Width                 int
+	Theme                 string
+	BaseOffset            int
+	EntryCount            int
+	CompactDetail         bool
+	SelectedEntry         int
+	SelectedEntryIsActive bool
 }
 
 // CommittedOngoingProjector reuses the ongoing transcript renderer and caches
@@ -523,20 +526,24 @@ func ProjectTranscriptViews(input TranscriptProjectionInput, state TranscriptPro
 
 func (p *TranscriptViewProjector) CommittedOngoingLines(input TranscriptProjectionInput, state TranscriptProjectionViewState) ([]TranscriptProjectionLine, string) {
 	key := CommittedOngoingProjectionKey{
-		Revision:   input.EntriesRevision,
-		Width:      state.ViewportWidth,
-		Theme:      state.Theme,
-		BaseOffset: input.BaseOffset,
-		EntryCount: len(input.Entries),
+		Revision:              input.EntriesRevision,
+		Width:                 state.ViewportWidth,
+		Theme:                 state.Theme,
+		BaseOffset:            input.BaseOffset,
+		EntryCount:            len(input.Entries),
+		CompactDetail:         state.CompactDetail,
+		SelectedEntry:         state.SelectedEntry,
+		SelectedEntryIsActive: state.SelectedEntryIsActive,
 	}
 	key = normalizeCommittedOngoingProjectionKey(key, len(input.Entries))
 	if key.Revision > 0 && p != nil && p.ongoingSet && p.ongoingKey == key {
 		return p.ongoingLines, p.ongoingGroup
 	}
-	projection := projectCommittedOngoingTranscriptWithRenderer(
-		committedOngoingProjectionRenderer(key.Theme, key.Width, key.BaseOffset),
-		input.Entries,
-	)
+	renderer := committedOngoingProjectionRenderer(key.Theme, key.Width, key.BaseOffset)
+	renderer.compactDetail = key.CompactDetail
+	renderer.selectedTranscriptEntry = key.SelectedEntry
+	renderer.selectedTranscriptActive = key.SelectedEntryIsActive
+	projection := projectCommittedOngoingTranscriptWithRenderer(renderer, input.Entries)
 	lines := projection.Lines(detailDivider())
 	lastGroup := ""
 	if blockCount := len(projection.Blocks); blockCount > 0 {

--- a/cli/tui/transcript_projection.go
+++ b/cli/tui/transcript_projection.go
@@ -244,7 +244,11 @@ func (p TranscriptProjection) Lines(dividerText string) []TranscriptProjectionLi
 	lines := make([]TranscriptProjectionLine, 0, len(p.Blocks)*2)
 	for idx, block := range p.Blocks {
 		if idx > 0 && p.Blocks[idx-1].DividerGroup != block.DividerGroup {
-			lines = append(lines, TranscriptProjectionLine{Kind: VisibleLineDivider, Text: dividerText})
+			kind := VisibleLineDivider
+			if dividerText == "" {
+				kind = VisibleLineContent
+			}
+			lines = append(lines, TranscriptProjectionLine{Kind: kind, Text: dividerText})
 		}
 		for _, line := range block.Lines {
 			lines = append(lines, TranscriptProjectionLine{Kind: VisibleLineContent, Text: line})

--- a/cli/tui/transcript_projection_test.go
+++ b/cli/tui/transcript_projection_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -370,5 +371,388 @@ func TestCommittedOngoingProjectionPreservesWebSearchSuccessState(t *testing.T) 
 	}
 	if !strings.Contains(strings.Join(projection.Blocks[0].Lines, "\n"), `web search: "latest golang release"`) {
 		t.Fatalf("expected web search success block to retain tool call text, got %#v", projection.Blocks[0])
+	}
+}
+
+func TestProjectTranscriptViewsDerivesOngoingAndDetailFromSameCanonicalEntries(t *testing.T) {
+	entries := []TranscriptEntry{
+		{Role: "user", Text: "prompt"},
+		{Role: "assistant", Text: "answer"},
+	}
+
+	projection := ProjectTranscriptViews(TranscriptProjectionInput{
+		BaseOffset: 10,
+		Entries:    entries,
+	}, TranscriptProjectionViewState{
+		ViewportWidth: 80,
+		ViewportLines: 20,
+		Theme:         "dark",
+	})
+
+	if len(projection.Ongoing.Blocks) != 2 {
+		t.Fatalf("expected ongoing projection from canonical entries, got %#v", projection.Ongoing.Blocks)
+	}
+	if len(projection.Detail.Blocks) != 2 {
+		t.Fatalf("expected detail projection from canonical entries, got %#v", projection.Detail.Blocks)
+	}
+	if projection.Ongoing.Blocks[0].EntryIndex != 10 || projection.Detail.Blocks[0].EntryIndex != 10 {
+		t.Fatalf("expected projections to preserve shared base offset, ongoing=%#v detail=%#v", projection.Ongoing.Blocks, projection.Detail.Blocks)
+	}
+	if projection.Ongoing.Blocks[1].EntryIndex != projection.Detail.Blocks[1].EntryIndex {
+		t.Fatalf("expected ongoing/detail entry identity parity, ongoing=%#v detail=%#v", projection.Ongoing.Blocks, projection.Detail.Blocks)
+	}
+}
+
+func TestProjectTranscriptViewsMapsSelectionEntryToDetailLines(t *testing.T) {
+	entries := []TranscriptEntry{
+		{Role: "user", Text: "first"},
+		{Role: "assistant", Text: "second line one\nsecond line two"},
+		{Role: "user", Text: "third"},
+	}
+
+	projection := ProjectTranscriptViews(TranscriptProjectionInput{
+		BaseOffset: 20,
+		Entries:    entries,
+	}, TranscriptProjectionViewState{
+		ViewportWidth:         80,
+		ViewportLines:         20,
+		Theme:                 "dark",
+		DetailSelectedEntry:   21,
+		DetailSelectedActive:  true,
+		SelectedEntry:         21,
+		SelectedEntryIsActive: true,
+	})
+
+	lineRange, ok := projection.DetailEntryLineRanges[21]
+	if !ok {
+		t.Fatalf("expected detail range for selected entry, got %#v", projection.DetailEntryLineRanges)
+	}
+	if lineRange.Start < 0 || lineRange.End < lineRange.Start {
+		t.Fatalf("invalid selected entry range: %#v", lineRange)
+	}
+	for idx := lineRange.Start; idx <= lineRange.End; idx++ {
+		if projection.DetailLineOwners[idx] != 21 {
+			t.Fatalf("expected selected range line %d to be owned by entry 21, owners=%#v", idx, projection.DetailLineOwners)
+		}
+	}
+}
+
+func TestProjectTranscriptViewsDoesNotMutateInputModel(t *testing.T) {
+	m := NewModel(WithTheme("dark"), WithPreviewLines(20), WithCompactDetail())
+	m = updateModel(t, m, SetViewportSizeMsg{Lines: 20, Width: 80})
+	m = updateModel(t, m, SetConversationMsg{Entries: []TranscriptEntry{
+		{Role: "user", Text: "prompt"},
+		{Role: "assistant", Text: "answer"},
+	}})
+	m.selectedTranscriptEntry = 0
+	m.selectedTranscriptActive = true
+
+	before := m
+	_ = ProjectTranscriptViews(m.TranscriptProjectionInput(), m.TranscriptProjectionViewState())
+
+	if before.detailBottomAnchor != m.detailBottomAnchor ||
+		before.detailBottomOffset != m.detailBottomOffset {
+		t.Fatalf("projection mutated model cache state before=%#v after=%#v", before, m)
+	}
+}
+
+func TestModelViewDoesNotMutateCanonicalProjectionState(t *testing.T) {
+	m := NewModel(WithTheme("dark"), WithPreviewLines(5), WithCompactDetail())
+	m = updateModel(t, m, SetViewportSizeMsg{Lines: 5, Width: 80})
+	m = updateModel(t, m, SetConversationMsg{Entries: []TranscriptEntry{
+		{Role: "user", Text: "prompt"},
+		{Role: "assistant", Text: "answer"},
+	}})
+	m = updateModel(t, m, ToggleModeMsg{})
+
+	beforeInput := m.TranscriptProjectionInput()
+	beforeState := m.TranscriptProjectionViewState()
+	beforeScroll := m.DetailScroll()
+	beforeOngoingScroll := m.OngoingScroll()
+
+	_ = m.View()
+	_ = m.VisibleLineKinds()
+
+	afterInput := m.TranscriptProjectionInput()
+	afterState := m.TranscriptProjectionViewState()
+	if !reflect.DeepEqual(beforeInput, afterInput) ||
+		!reflect.DeepEqual(beforeState, afterState) ||
+		beforeScroll != m.DetailScroll() ||
+		beforeOngoingScroll != m.OngoingScroll() {
+		t.Fatalf("rendering mutated canonical/view state before input=%+v state=%+v after input=%+v state=%+v", beforeInput, beforeState, afterInput, afterState)
+	}
+}
+
+func TestModelDoesNotStoreLegacyRenderCacheGraph(t *testing.T) {
+	forbidden := map[string]struct{}{
+		"transcript":                {},
+		"transcriptBaseOffset":      {},
+		"transcriptTotalEntries":    {},
+		"transcriptRevision":        {},
+		"transcriptEntriesRevision": {},
+		"ongoing":                   {},
+		"streamingReasoning":        {},
+		"ongoingSnapshot":           {},
+		"ongoingLineCache":          {},
+		"ongoingLineKinds":          {},
+		"ongoingBaseLines":          {},
+		"ongoingBaseLineKinds":      {},
+		"ongoingBaseLastGroup":      {},
+		"ongoingStreamingLines":     {},
+		"ongoingStreamingKinds":     {},
+		"ongoingStreamingDivider":   {},
+		"ongoingBaseDirty":          {},
+		"ongoingDirty":              {},
+		"detailSnapshot":            {},
+		"detailLines":               {},
+		"detailLineKinds":           {},
+		"detailLineEntryIndices":    {},
+		"detailEntryLineRanges":     {},
+		"detailBlockLineRanges":     {},
+		"detailEntryRangeOffset":    {},
+		"detailBlocks":              {},
+		"detailBlockLines":          {},
+		"detailTotalLineCount":      {},
+		"detailMetricsResolved":     {},
+		"detailDirty":               {},
+		"detailStale":               {},
+		"detailRebuildCount":        {},
+	}
+	modelType := reflect.TypeOf(Model{})
+	if _, ok := modelType.FieldByName("transcriptInput"); !ok {
+		t.Fatal("Model must store transcript data through one canonical transcriptInput field")
+	}
+	for idx := 0; idx < modelType.NumField(); idx++ {
+		field := modelType.Field(idx)
+		if _, ok := forbidden[field.Name]; ok {
+			t.Fatalf("Model still stores legacy render cache field %q", field.Name)
+		}
+	}
+}
+
+func TestProjectTranscriptViewsExpansionChangesDetailProjectionOnly(t *testing.T) {
+	entries := []TranscriptEntry{
+		{Role: "tool_call", Text: "printf long", ToolCallID: "call_1", ToolCall: &transcript.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "printf long"}},
+		{Role: "tool_result_ok", Text: strings.Repeat("line\n", 8), ToolCallID: "call_1"},
+	}
+	input := TranscriptProjectionInput{Entries: entries}
+	collapsed := ProjectTranscriptViews(input, TranscriptProjectionViewState{ViewportWidth: 80, ViewportLines: 20, Theme: "dark", CompactDetail: true})
+	expanded := ProjectTranscriptViews(input, TranscriptProjectionViewState{
+		ViewportWidth:         80,
+		ViewportLines:         20,
+		Theme:                 "dark",
+		CompactDetail:         true,
+		DetailExpandedEntries: map[int]struct{}{0: {}},
+	})
+
+	if len(expanded.DetailLines) <= len(collapsed.DetailLines) {
+		t.Fatalf("expected expanded detail projection to add visible detail lines, collapsed=%d expanded=%d", len(collapsed.DetailLines), len(expanded.DetailLines))
+	}
+	if collapsed.Ongoing.Render(TranscriptDivider) != expanded.Ongoing.Render(TranscriptDivider) {
+		t.Fatalf("expected detail expansion to leave ongoing projection unchanged")
+	}
+}
+
+func TestProjectTranscriptViewsIncludesStreamingReasoningInDetailProjection(t *testing.T) {
+	projection := ProjectTranscriptViews(TranscriptProjectionInput{
+		Entries: []TranscriptEntry{{Role: "assistant", Text: "answer"}},
+		StreamingReasoning: []StreamingReasoningEntry{{
+			Key:  "r1",
+			Role: TranscriptRoleReasoning,
+			Text: "thinking now",
+		}},
+	}, TranscriptProjectionViewState{ViewportWidth: 80, ViewportLines: 20, Theme: "dark"})
+
+	detail := xansi.Strip(projection.Detail.Render(detailItemSeparator))
+	if !strings.Contains(detail, "thinking now") {
+		t.Fatalf("expected detail projection to include streaming reasoning, got %q", detail)
+	}
+	ongoing := xansi.Strip(projection.Ongoing.Render(TranscriptDivider))
+	if strings.Contains(ongoing, "thinking now") {
+		t.Fatalf("expected ongoing projection to exclude streaming reasoning, got %q", ongoing)
+	}
+}
+
+func TestProjectTranscriptViewsToolCallRenderingUsesSameEntryMapping(t *testing.T) {
+	entries := []TranscriptEntry{
+		{Role: "tool_call", Text: "pwd", ToolCallID: "call_1", ToolCall: &transcript.ToolCallMeta{ToolName: "shell", IsShell: true, Command: "pwd"}},
+		{Role: "tool_result_ok", Text: "/tmp/project", ToolCallID: "call_1"},
+	}
+
+	projection := ProjectTranscriptViews(TranscriptProjectionInput{BaseOffset: 30, Entries: entries}, TranscriptProjectionViewState{ViewportWidth: 80, ViewportLines: 20, Theme: "dark"})
+
+	if len(projection.Ongoing.Blocks) != 1 || projection.Ongoing.Blocks[0].EntryIndex != 30 || projection.Ongoing.Blocks[0].EntryEnd != 31 {
+		t.Fatalf("expected ongoing tool projection to merge call/result entry range, got %#v", projection.Ongoing.Blocks)
+	}
+	if len(projection.Detail.Blocks) != 1 || projection.Detail.Blocks[0].EntryIndex != 30 || projection.Detail.Blocks[0].EntryEnd != 31 {
+		t.Fatalf("expected detail tool projection to merge call/result entry range, got %#v", projection.Detail.Blocks)
+	}
+	if !strings.Contains(xansi.Strip(projection.Ongoing.Render(TranscriptDivider)), "$ pwd") {
+		t.Fatalf("expected ongoing projection to render shell command, got %q", projection.Ongoing.Render(TranscriptDivider))
+	}
+}
+
+func TestProjectTranscriptViewsViewportResizeChangesProjectionWrapping(t *testing.T) {
+	input := TranscriptProjectionInput{Entries: []TranscriptEntry{{Role: "assistant", Text: strings.Repeat("x", 90)}}}
+	wide := ProjectTranscriptViews(input, TranscriptProjectionViewState{ViewportWidth: 120, ViewportLines: 20, Theme: "dark"})
+	narrow := ProjectTranscriptViews(input, TranscriptProjectionViewState{ViewportWidth: 40, ViewportLines: 20, Theme: "dark"})
+
+	if len(narrow.OngoingLines) <= len(wide.OngoingLines) {
+		t.Fatalf("expected narrower viewport to increase wrapped ongoing line count, wide=%d narrow=%d", len(wide.OngoingLines), len(narrow.OngoingLines))
+	}
+	if len(narrow.DetailLines) <= len(wide.DetailLines) {
+		t.Fatalf("expected narrower viewport to increase wrapped detail line count, wide=%d narrow=%d", len(wide.DetailLines), len(narrow.DetailLines))
+	}
+}
+
+func TestProjectTranscriptViewsLargeTranscriptKeepsLastEntryRange(t *testing.T) {
+	entries := benchmarkDetailEntries(500)
+	baseOffset := 1000
+	lastEntry := baseOffset + len(entries) - 1
+
+	projection := ProjectTranscriptViews(TranscriptProjectionInput{BaseOffset: baseOffset, Entries: entries}, TranscriptProjectionViewState{ViewportWidth: 100, ViewportLines: 30, Theme: "dark"})
+
+	if len(projection.Detail.Blocks) == 0 || len(projection.Ongoing.Blocks) == 0 {
+		t.Fatalf("expected large transcript projections to contain blocks")
+	}
+	lineRange, ok := projection.DetailEntryLineRanges[lastEntry]
+	if !ok {
+		t.Fatalf("expected detail range for last entry %d", lastEntry)
+	}
+	if lineRange.End < lineRange.Start || lineRange.Start < 0 {
+		t.Fatalf("expected valid last entry line range, got %#v", lineRange)
+	}
+}
+
+func TestTranscriptViewProjectionDetailViewportPreservesScrollAndOwners(t *testing.T) {
+	projection := ProjectTranscriptViews(TranscriptProjectionInput{Entries: []TranscriptEntry{
+		{Role: "user", Text: "first"},
+		{Role: "assistant", Text: "second"},
+		{Role: "user", Text: "third"},
+	}}, TranscriptProjectionViewState{ViewportWidth: 80, ViewportLines: 2, Theme: "dark"})
+
+	viewport := projection.DetailViewport(ProjectionViewportState{ViewportLines: 2, Scroll: 2})
+	if viewport.Scroll != 2 {
+		t.Fatalf("expected viewport scroll to stay at requested position, got %d", viewport.Scroll)
+	}
+	if len(viewport.Lines) != 2 || len(viewport.Owners) != 2 {
+		t.Fatalf("expected two viewport lines with owners, got lines=%#v owners=%#v", viewport.Lines, viewport.Owners)
+	}
+	if viewport.Owners[0] < 0 {
+		t.Fatalf("expected first visible line to retain an entry owner, owners=%#v", viewport.Owners)
+	}
+}
+
+func TestTranscriptViewProjectionDetailViewportBottomAnchorUsesOffset(t *testing.T) {
+	projection := ProjectTranscriptViews(TranscriptProjectionInput{Entries: benchmarkDetailEntries(4)}, TranscriptProjectionViewState{
+		ViewportWidth: 80,
+		ViewportLines: 3,
+		Theme:         "dark",
+	})
+
+	viewport := projection.DetailViewport(ProjectionViewportState{ViewportLines: 3, BottomAnchor: true, BottomOffset: 2})
+	if viewport.Scroll != viewport.MaxScroll-2 {
+		t.Fatalf("expected bottom offset to anchor viewport above bottom, scroll=%d max=%d", viewport.Scroll, viewport.MaxScroll)
+	}
+	if viewport.BottomOffset != 2 {
+		t.Fatalf("expected bottom offset to be preserved, got %d", viewport.BottomOffset)
+	}
+}
+
+func TestTranscriptViewProjectorCachesByRevisionAndViewState(t *testing.T) {
+	var projector TranscriptViewProjector
+	input := TranscriptProjectionInput{
+		Revision: 1,
+		Entries:  []TranscriptEntry{{Role: "assistant", Text: "seed " + strings.Repeat("x", 90)}},
+	}
+	state := TranscriptProjectionViewState{ViewportWidth: 80, ViewportLines: 20, Theme: "dark"}
+
+	_ = projector.Project(input, state)
+	input.Entries[0].Text = "changed " + strings.Repeat("x", 90)
+	cached := projector.Project(input, state)
+	if rendered := cached.Ongoing.Render(TranscriptDivider); !strings.Contains(rendered, "seed") || strings.Contains(rendered, "changed") {
+		t.Fatalf("expected same revision/view state to reuse cached projection, got %q", rendered)
+	}
+
+	input.Revision = 2
+	updated := projector.Project(input, state)
+	if rendered := updated.Ongoing.Render(TranscriptDivider); !strings.Contains(rendered, "changed") || strings.Contains(rendered, "seed") {
+		t.Fatalf("expected advanced revision to rebuild projection, got %q", rendered)
+	}
+
+	state.ViewportWidth = 40
+	resized := projector.Project(input, state)
+	if resized.Ongoing.Render(TranscriptDivider) == updated.Ongoing.Render(TranscriptDivider) {
+		t.Fatalf("expected viewport width change to rebuild projection")
+	}
+}
+
+func TestTranscriptViewProjectorReturnsImmutableProjectionClone(t *testing.T) {
+	var projector TranscriptViewProjector
+	input := TranscriptProjectionInput{
+		Revision: 1,
+		Entries:  []TranscriptEntry{{Role: "assistant", Text: "seed"}},
+	}
+	state := TranscriptProjectionViewState{ViewportWidth: 80, ViewportLines: 20, Theme: "dark"}
+
+	first := projector.Project(input, state)
+	first.Ongoing.Blocks[0].Lines[0] = "mutated"
+	first.OngoingLines[0].Text = "mutated"
+	first.OngoingLineOwners[0] = 999
+	first.OngoingEntryLineRanges[0] = lineRange{Start: 999, End: 999}
+
+	second := projector.Project(input, state)
+	rendered := second.Ongoing.Render(TranscriptDivider)
+	if strings.Contains(rendered, "mutated") || !strings.Contains(rendered, "seed") {
+		t.Fatalf("expected cached projection to be immutable to caller mutation, got %q", rendered)
+	}
+	if second.OngoingLines[0].Text == "mutated" {
+		t.Fatalf("expected projection lines to be cloned")
+	}
+	if second.OngoingLineOwners[0] == 999 {
+		t.Fatalf("expected line owners to be cloned")
+	}
+	if second.OngoingEntryLineRanges[0].Start == 999 {
+		t.Fatalf("expected entry ranges to be cloned")
+	}
+}
+
+func TestModelTranscriptProjectionInputRevisionAdvancesOnCanonicalInputChanges(t *testing.T) {
+	m := NewModel(WithPreviewLines(20))
+	initial := m.TranscriptProjectionInput().Revision
+
+	m = updateModel(t, m, AppendTranscriptMsg{Role: "user", Text: "prompt"})
+	afterTranscript := m.TranscriptProjectionInput()
+	if afterTranscript.Revision <= initial || afterTranscript.EntriesRevision <= 0 {
+		t.Fatalf("expected transcript append to advance projection revisions, got %+v initial=%d", afterTranscript, initial)
+	}
+
+	m = updateModel(t, m, StreamAssistantMsg{Delta: "stream"})
+	afterStreaming := m.TranscriptProjectionInput()
+	if afterStreaming.Revision <= afterTranscript.Revision {
+		t.Fatalf("expected streaming assistant to advance projection revision, before=%d after=%d", afterTranscript.Revision, afterStreaming.Revision)
+	}
+	if afterStreaming.EntriesRevision != afterTranscript.EntriesRevision {
+		t.Fatalf("expected streaming assistant to keep committed entries revision stable, before=%d after=%d", afterTranscript.EntriesRevision, afterStreaming.EntriesRevision)
+	}
+
+	m = updateModel(t, m, UpsertStreamingReasoningMsg{Key: "r1", Role: "reasoning", Text: "thinking"})
+	afterReasoning := m.TranscriptProjectionInput().Revision
+	if afterReasoning <= afterStreaming.Revision {
+		t.Fatalf("expected streaming reasoning to advance projection revision, before=%d after=%d", afterStreaming.Revision, afterReasoning)
+	}
+}
+
+func TestModelTranscriptProjectionInputRevisionDoesNotAdvanceOnViewStateOnlyChanges(t *testing.T) {
+	m := NewModel(WithPreviewLines(20))
+	m = updateModel(t, m, SetConversationMsg{Entries: []TranscriptEntry{{Role: "user", Text: "prompt"}}})
+	before := m.TranscriptProjectionInput().Revision
+
+	m = updateModel(t, m, SetSelectedTranscriptEntryMsg{EntryIndex: 0, Active: true, RefreshDetailSnapshot: true})
+	m = updateModel(t, m, SetViewportSizeMsg{Lines: 10, Width: 100})
+
+	after := m.TranscriptProjectionInput().Revision
+	if after != before {
+		t.Fatalf("expected view state changes to keep canonical projection revision stable, before=%d after=%d", before, after)
 	}
 }

--- a/cli/tui/transcript_projection_test.go
+++ b/cli/tui/transcript_projection_test.go
@@ -403,6 +403,30 @@ func TestProjectTranscriptViewsDerivesOngoingAndDetailFromSameCanonicalEntries(t
 	}
 }
 
+func TestDetailProjectionEmptySeparatorsRemainContentLines(t *testing.T) {
+	projection := ProjectTranscriptViews(TranscriptProjectionInput{
+		Entries: []TranscriptEntry{
+			{Role: "user", Text: "prompt"},
+			{Role: "assistant", Text: "answer"},
+		},
+	}, TranscriptProjectionViewState{
+		ViewportWidth: 80,
+		ViewportLines: 20,
+		Theme:         "dark",
+	})
+
+	if len(projection.DetailLines) < 3 {
+		t.Fatalf("expected detail projection to include blank separator, got %#v", projection.DetailLines)
+	}
+	separator := projection.DetailLines[1]
+	if separator.Text != "" {
+		t.Fatalf("expected empty detail separator text, got %q in %#v", separator.Text, projection.DetailLines)
+	}
+	if separator.Kind != VisibleLineContent {
+		t.Fatalf("expected empty detail separator to remain content, got %v", separator.Kind)
+	}
+}
+
 func TestProjectTranscriptViewsMapsSelectionEntryToDetailLines(t *testing.T) {
 	entries := []TranscriptEntry{
 		{Role: "user", Text: "first"},

--- a/cli/tui/transcript_projection_test.go
+++ b/cli/tui/transcript_projection_test.go
@@ -427,6 +427,26 @@ func TestDetailProjectionEmptySeparatorsRemainContentLines(t *testing.T) {
 	}
 }
 
+func TestCommittedOngoingProjectionCacheTracksSelectedUserState(t *testing.T) {
+	m := NewModel(WithTheme("dark"), WithPreviewLines(20))
+	m = updateModel(t, m, SetViewportSizeMsg{Lines: 20, Width: 80})
+	m = updateModel(t, m, SetConversationMsg{Entries: []TranscriptEntry{
+		{Role: "user", Text: "prompt"},
+		{Role: "assistant", Text: "answer"},
+	}})
+	unselected := m.OngoingSnapshot()
+
+	m = updateModel(t, m, SetSelectedTranscriptEntryMsg{EntryIndex: 0, Active: true})
+	selected := m.OngoingSnapshot()
+
+	if selected == unselected {
+		t.Fatal("expected selected user entry to invalidate cached ongoing projection styling")
+	}
+	if !strings.Contains(selected, "48;2;") {
+		t.Fatalf("expected selected ongoing snapshot to include selection background, got %q", selected)
+	}
+}
+
 func TestProjectTranscriptViewsMapsSelectionEntryToDetailLines(t *testing.T) {
 	entries := []TranscriptEntry{
 		{Role: "user", Text: "first"},

--- a/docs/dev/decisions.md
+++ b/docs/dev/decisions.md
@@ -373,9 +373,9 @@
 - Syntax-highlighted output must not emit backgrounds unless explicitly intended, such as final diff added/removed decoration.
 - Assistant text streams in ongoing mode.
 - Tool output is not streamed live; show running status and reveal on completion.
-- `detail` is a non-streaming snapshot view with UI-local expansion and selection state.
+- `detail` is a live transcript view with UI-local expansion and selection state; transcript changes update content while open, while scroll/anchor stays stable unless the user navigates.
 - Mid-step entry shows latest completed snapshot only.
-- Snapshot is static while open (no live refresh indicator/action).
+- Detail content is not static while open; only scroll/anchor behavior is stable.
 - Snapshot scope is full session transcript up to latest completed step.
 - Detail transcript rendering is flat continuous stream (no grouped sections).
 - Step-end markers appear in detail only.

--- a/docs/dev/techdebt/techdebt.md
+++ b/docs/dev/techdebt/techdebt.md
@@ -48,7 +48,7 @@ Entry shape: checklist title line, summary evidence paragraph, impact paragraph,
 
   Regression prevention must include lifecycle tests proving resources close exactly once and in safe order, composition tests proving required services are present, and import/coupling checks that prevent new features from adding arbitrary fields to `Core` as the default extension path. Constructor behavior must stay explicit and diagnosable: startup failures should name the bundle/resource that failed, and partial construction must clean up already-created resources.
 
-- [ ] `TD-005` [P1] `cli/tui/model.go` stores transcript, render caches, selection, scroll, and dirty state in one mutable graph.
+- [x] `TD-005` [P1] `cli/tui/model.go` stores transcript, render caches, selection, scroll, and dirty state in one mutable graph.
 
   The file is 1415 LoC. `type Model` includes mode, viewport dimensions, transcript entries, ongoing text, streaming reasoning, selected entry state, detail selection, expanded entries, detail snapshot, detail lines, line kinds, line-entry indices, line ranges, block specs, block lines, total line counts, metrics flags, dirty flags, scroll positions, and render diagnostics. Related render/update files include `cli/tui/model_rendering.go`, `cli/tui/model_rendering_entries.go`, and `cli/tui/model_reducer.go`. `docs/tmp/tech_debt.md` already identifies the render cache graph as a P1 concern.
 


### PR DESCRIPTION
## Summary
- Replace scattered TUI transcript/render cache state with one `TranscriptProjectionInput` stored on `cli/tui.Model` plus explicit view state.
- Add projection contracts/cache for ongoing and detail views, including pure viewport slicing and semantic metadata.
- Update detail semantics to live content with stable scroll/anchor, and mark `TD-005` complete.

## Scope note
This creates one canonical transcript input inside `cli/tui.Model`. It does not claim or implement one app-wide client/runtime transcript source of truth; `cli/app` still owns app-level transcript/native-history state.

## Verification
- `./scripts/test.sh ./...`
- `./scripts/build.sh --output ./bin/builder`
- pre-push hook: formatting, vet, build, test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Detail view now updates live with incoming messages while remaining open, instead of displaying a static snapshot.

* **Bug Fixes**
  * Improved scroll stability and viewport behavior in detail view when new transcript content arrives.
  * Enhanced selection and expansion handling in detail view.

* **Performance**
  * Optimized rendering performance with reduced memory allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->