### PR TITLE
fix: prevent slash feedback replaying prompts

### DIFF
--- a/cli/app/commands/commands.go
+++ b/cli/app/commands/commands.go
@@ -60,9 +60,10 @@ type Result struct {
 type Handler func(args string) Result
 
 type Command struct {
-	Name         string
-	Description  string
-	RunWhileBusy bool
+	Name                       string
+	Description                string
+	RunWhileBusy               bool
+	PreservePromptHistoryDraft bool
 }
 
 type registeredCommand struct {
@@ -99,7 +100,7 @@ func NewDefaultRegistry() *Registry {
 	r.Register("compact", "Compact the current context (optional: /compact <instructions>)", func(args string) Result {
 		return Result{Handled: true, Action: ActionCompact, Args: strings.TrimSpace(args)}
 	})
-	r.RegisterWithOptions("name", "Set session title and terminal title (usage: /name <title>; empty resets)", RegisterOptions{RunWhileBusy: true}, func(args string) Result {
+	r.RegisterWithOptions("name", "Set session title and terminal title (usage: /name <title>; empty resets)", RegisterOptions{RunWhileBusy: true, PreservePromptHistoryDraft: true}, func(args string) Result {
 		return Result{Handled: true, Action: ActionSetName, SessionName: strings.TrimSpace(args)}
 	})
 	r.RegisterWithOptions("thinking", "Set or show thinking level (usage: /thinking <low|medium|high|xhigh>; empty shows current)", RegisterOptions{RunWhileBusy: true}, func(args string) Result {
@@ -114,10 +115,10 @@ func NewDefaultRegistry() *Registry {
 	r.RegisterWithOptions("autocompaction", "Toggle auto-compaction (usage: /autocompaction [on|off]; empty toggles)", RegisterOptions{RunWhileBusy: true}, func(args string) Result {
 		return Result{Handled: true, Action: ActionSetAutoCompaction, AutoCompactionMode: strings.ToLower(strings.TrimSpace(args))}
 	})
-	r.RegisterWithOptions("status", "Open a detailed status overlay for the current session/runtime", RegisterOptions{RunWhileBusy: true}, func(string) Result {
+	r.RegisterWithOptions("status", "Open a detailed status overlay for the current session/runtime", RegisterOptions{RunWhileBusy: true, PreservePromptHistoryDraft: true}, func(string) Result {
 		return Result{Handled: true, Action: ActionStatus}
 	})
-	r.RegisterWithOptions("goal", "Set or manage the current session goal (usage: /goal [show|pause|resume|clear|<objective>])", RegisterOptions{RunWhileBusy: true}, func(args string) Result {
+	r.RegisterWithOptions("goal", "Set or manage the current session goal (usage: /goal [show|pause|resume|clear|<objective>])", RegisterOptions{RunWhileBusy: true, PreservePromptHistoryDraft: true}, func(args string) Result {
 		mode := GoalModeShow
 		objective := strings.TrimSpace(args)
 		switch strings.ToLower(objective) {
@@ -140,14 +141,14 @@ func NewDefaultRegistry() *Registry {
 		}
 		return Result{Handled: true, Action: ActionGoal, GoalMode: mode, GoalObjective: objective}
 	})
-	r.RegisterWithOptions("ps", "List background processes or manage one (usage: /ps [kill|inline|logs] <id>)", RegisterOptions{RunWhileBusy: true}, func(args string) Result {
+	r.RegisterWithOptions("ps", "List background processes or manage one (usage: /ps [kill|inline|logs] <id>)", RegisterOptions{RunWhileBusy: true, PreservePromptHistoryDraft: true}, func(args string) Result {
 		return Result{Handled: true, Action: ActionProcesses, Args: strings.TrimSpace(args)}
 	})
-	r.RegisterWithOptions("worktree", "Manage git worktrees (usage: /worktree [create|switch|delete] ...)", RegisterOptions{}, func(args string) Result {
+	r.RegisterWithOptions("worktree", "Manage git worktrees (usage: /worktree [create|switch|delete] ...)", RegisterOptions{PreservePromptHistoryDraft: true}, func(args string) Result {
 		return Result{Handled: true, Action: ActionWorktree, Args: strings.TrimSpace(args)}
 	})
 	r.RegisterAlias("wt", "worktree")
-	r.RegisterWithOptions("copy", "Copy the last model final answer to the system clipboard", RegisterOptions{RunWhileBusy: true}, func(string) Result {
+	r.RegisterWithOptions("copy", "Copy the last model final answer to the system clipboard", RegisterOptions{RunWhileBusy: true, PreservePromptHistoryDraft: true}, func(string) Result {
 		return Result{Handled: true, Action: ActionCopy}
 	})
 	r.Register("back", "Jump to parent session if current session was spawned from another", func(string) Result {
@@ -171,11 +172,12 @@ func NewDefaultRegistry() *Registry {
 }
 
 type RegisterOptions struct {
-	RunWhileBusy bool
+	RunWhileBusy               bool
+	PreservePromptHistoryDraft bool
 }
 
 func (r *Registry) Register(name string, description string, h Handler) {
-	r.RegisterWithOptions(name, description, RegisterOptions{}, h)
+	r.RegisterWithOptions(name, description, RegisterOptions{PreservePromptHistoryDraft: true}, h)
 }
 
 func (r *Registry) RegisterWithOptions(name string, description string, options RegisterOptions, h Handler) {
@@ -187,7 +189,7 @@ func (r *Registry) RegisterWithOptions(name string, description string, options 
 		return
 	}
 	r.handlers[k] = registeredCommand{
-		command: Command{Name: k, Description: strings.TrimSpace(description), RunWhileBusy: options.RunWhileBusy},
+		command: Command{Name: k, Description: strings.TrimSpace(description), RunWhileBusy: options.RunWhileBusy, PreservePromptHistoryDraft: options.PreservePromptHistoryDraft},
 		handler: h,
 	}
 }

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -439,6 +439,10 @@ func (m *uiModel) setTransientStatusWithKind(message string, kind uiStatusNotice
 	return m.sendTransientStatus(message, kind, transientStatusDuration, uiStatusNoticeReplace)
 }
 
+func (m *uiModel) setTransientStatusWithKindAndNoticeID(message string, kind uiStatusNoticeKind, noticeID string) tea.Cmd {
+	return m.sendTransientStatusWithNoticeID(message, kind, transientStatusDuration, uiStatusNoticeReplace, noticeID)
+}
+
 func (m *uiModel) enqueueTransientStatus(message string, kind uiStatusNoticeKind) tea.Cmd {
 	return m.sendTransientStatus(message, kind, transientStatusDuration, uiStatusNoticeQueue)
 }
@@ -448,10 +452,14 @@ func (m *uiModel) enqueueTransientStatusWithDuration(message string, kind uiStat
 }
 
 func (m *uiModel) sendTransientStatus(message string, kind uiStatusNoticeKind, duration time.Duration, delivery uiStatusNoticeDelivery) tea.Cmd {
+	return m.sendTransientStatusWithNoticeID(message, kind, duration, delivery, "")
+}
+
+func (m *uiModel) sendTransientStatusWithNoticeID(message string, kind uiStatusNoticeKind, duration time.Duration, delivery uiStatusNoticeDelivery, noticeID string) tea.Cmd {
 	if strings.TrimSpace(message) == "" {
 		return nil
 	}
-	notice := uiStatusNotice{Text: strings.TrimSpace(message), Kind: kind, Duration: duration}
+	notice := uiStatusNotice{Text: strings.TrimSpace(message), Kind: kind, Duration: duration, NoticeID: strings.TrimSpace(noticeID)}
 	if delivery == uiStatusNoticeQueue && strings.TrimSpace(m.transientStatus) != "" {
 		if m.transientStatus == notice.Text && m.transientStatusKind == notice.Kind {
 			return nil
@@ -473,6 +481,7 @@ func (m *uiModel) showTransientStatusNotice(notice uiStatusNotice) tea.Cmd {
 	token := m.transientStatusToken
 	m.transientStatus = strings.TrimSpace(notice.Text)
 	m.transientStatusKind = notice.Kind
+	m.transientStatusNoticeID = strings.TrimSpace(notice.NoticeID)
 	if notice.Kind == uiStatusNoticeUpdateAvailable {
 		m.startupUpdateShown = true
 	}
@@ -482,6 +491,7 @@ func (m *uiModel) showTransientStatusNotice(notice uiStatusNotice) tea.Cmd {
 func (m *uiModel) advanceTransientStatusQueue() tea.Cmd {
 	m.transientStatus = ""
 	m.transientStatusKind = uiStatusNoticeNeutral
+	m.transientStatusNoticeID = ""
 	if len(m.transientStatusQueue) == 0 {
 		m.syncViewport()
 		return nil

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -461,7 +461,7 @@ func (m *uiModel) sendTransientStatusWithNoticeID(message string, kind uiStatusN
 	}
 	notice := uiStatusNotice{Text: strings.TrimSpace(message), Kind: kind, Duration: duration, NoticeID: strings.TrimSpace(noticeID)}
 	if delivery == uiStatusNoticeQueue && strings.TrimSpace(m.transientStatus) != "" {
-		if m.transientStatus == notice.Text && m.transientStatusKind == notice.Kind {
+		if m.transientStatus == notice.Text && m.transientStatusKind == notice.Kind && m.transientStatusNoticeID == notice.NoticeID {
 			return nil
 		}
 		if len(m.transientStatusQueue) > 0 {

--- a/cli/app/ui_busy_commands_test.go
+++ b/cli/app/ui_busy_commands_test.go
@@ -399,12 +399,17 @@ func TestBusyQueuedFastAppliesToNextRuntimeRequestAfterTurnDrains(t *testing.T) 
 	m := newProjectedEngineUIModel(eng)
 	m.busy = true
 	m.activity = uiActivityRunning
+	m.promptHistoryDraft = "previous prompt"
+	m.promptHistoryDraftCursor = -1
 	m.input = "/fast on"
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	updated := next.(*uiModel)
 	if len(updated.queued) != 1 || updated.queued[0].Text != "/fast on" {
 		t.Fatalf("expected queued /fast command, got %+v", updated.queued)
+	}
+	if updated.input != "" || updated.promptHistoryDraft != "" || updated.promptHistoryDraftCursor != -1 {
+		t.Fatalf("expected queued /fast to discard prompt-history draft, input=%q draft=%q cursor=%d", updated.input, updated.promptHistoryDraft, updated.promptHistoryDraftCursor)
 	}
 
 	next, cmd := updated.Update(submitDoneMsg{message: "prior turn done"})

--- a/cli/app/ui_input_controller.go
+++ b/cli/app/ui_input_controller.go
@@ -247,6 +247,6 @@ func (m *uiModel) appendLocalEntryFallbackWithNoticeIDAndVisibility(role, text, 
 	m.transcriptEntries = append(m.transcriptEntries, entry)
 	m.transcriptTotalEntries = max(m.transcriptTotalEntries, m.transcriptBaseOffset+len(committedTranscriptEntriesForApp(m.transcriptEntries)))
 	m.refreshRollbackCandidates()
-	m.forwardToView(tui.AppendTranscriptMsg{Visibility: entry.Visibility, Role: transcriptRole, Text: text})
+	m.forwardToView(tui.AppendTranscriptMsg{Visibility: entry.Visibility, Role: transcriptRole, Text: text, NoticeID: entry.NoticeID})
 	return m.syncNativeHistoryFromTranscript()
 }

--- a/cli/app/ui_input_controller.go
+++ b/cli/app/ui_input_controller.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,6 +26,13 @@ func (c uiInputController) appendLocalEntry(role, text string) tea.Cmd {
 	return c.model.appendLocalEntry(role, text)
 }
 
+func (c uiInputController) appendLocalEntryWithNoticeID(role, text, noticeID string) tea.Cmd {
+	if c.model == nil {
+		return nil
+	}
+	return c.model.appendLocalEntryWithNoticeID(role, text, noticeID)
+}
+
 func (c uiInputController) appendSystemFeedback(text string) tea.Cmd {
 	return c.appendLocalEntry("system", text)
 }
@@ -43,6 +51,14 @@ func (c uiInputController) appendSystemFeedbackWithStatus(text string, status te
 
 func (c uiInputController) appendErrorFeedbackWithStatus(text string, status tea.Cmd) tea.Cmd {
 	return c.appendLocalEntryWithStatus("error", text, status)
+}
+
+func (c uiInputController) appendSystemFeedbackWithMirroredStatus(text string, kind uiStatusNoticeKind) tea.Cmd {
+	noticeID := c.model.nextLocalNoticeID()
+	return sequenceCmds(
+		c.appendLocalEntryWithNoticeID("system", text, noticeID),
+		c.model.setTransientStatusWithKindAndNoticeID(text, kind, noticeID),
+	)
 }
 
 type uiInputController struct {
@@ -68,6 +84,14 @@ var scheduleTransientStatusClear = func(duration time.Duration, token uint64) te
 var processListRefreshInterval = 1500 * time.Millisecond
 var rollbackDoubleEscWindow = 500 * time.Millisecond
 var csiShiftEnterDedupWindow = 120 * time.Millisecond
+
+func (m *uiModel) nextLocalNoticeID() string {
+	if m == nil {
+		return ""
+	}
+	m.localNoticeSequence++
+	return "local-notice-" + strconv.FormatUint(m.localNoticeSequence, 10)
+}
 
 func waitProcessListRefresh() tea.Cmd {
 	return tea.Tick(processListRefreshInterval, func(time.Time) tea.Msg {
@@ -184,17 +208,22 @@ func parseUserShellCommand(text string) (string, bool) {
 }
 
 func (m *uiModel) appendLocalEntry(role, text string) tea.Cmd {
+	return m.appendLocalEntryWithNoticeID(role, text, "")
+}
+
+func (m *uiModel) appendLocalEntryWithNoticeID(role, text, noticeID string) tea.Cmd {
 	role = strings.TrimSpace(role)
 	text = strings.TrimSpace(text)
+	noticeID = strings.TrimSpace(noticeID)
 	if role == "" || text == "" {
 		return nil
 	}
 	if m.hasRuntimeClient() {
-		if err := m.appendRuntimeLocalEntry(role, text); err == nil {
+		if err := m.appendRuntimeLocalEntryWithNoticeID(role, text, noticeID); err == nil {
 			return nil
 		}
 	}
-	return m.appendLocalEntryFallback(role, text)
+	return m.appendLocalEntryFallbackWithNoticeID(role, text, noticeID)
 }
 
 func (m *uiModel) appendLocalEntryFallback(role, text string) tea.Cmd {
@@ -202,11 +231,19 @@ func (m *uiModel) appendLocalEntryFallback(role, text string) tea.Cmd {
 }
 
 func (m *uiModel) appendLocalEntryFallbackWithVisibility(role, text string, visibility transcript.EntryVisibility) tea.Cmd {
+	return m.appendLocalEntryFallbackWithNoticeIDAndVisibility(role, text, "", visibility)
+}
+
+func (m *uiModel) appendLocalEntryFallbackWithNoticeID(role, text, noticeID string) tea.Cmd {
+	return m.appendLocalEntryFallbackWithNoticeIDAndVisibility(role, text, noticeID, transcript.EntryVisibilityAuto)
+}
+
+func (m *uiModel) appendLocalEntryFallbackWithNoticeIDAndVisibility(role, text, noticeID string, visibility transcript.EntryVisibility) tea.Cmd {
 	if m == nil {
 		return nil
 	}
 	transcriptRole := tui.TranscriptRoleFromWire(role)
-	entry := tui.TranscriptEntry{Visibility: transcript.NormalizeEntryVisibility(visibility), Role: transcriptRole, Text: text}
+	entry := tui.TranscriptEntry{Visibility: transcript.NormalizeEntryVisibility(visibility), Role: transcriptRole, Text: text, NoticeID: strings.TrimSpace(noticeID)}
 	m.transcriptEntries = append(m.transcriptEntries, entry)
 	m.transcriptTotalEntries = max(m.transcriptTotalEntries, m.transcriptBaseOffset+len(committedTranscriptEntriesForApp(m.transcriptEntries)))
 	m.refreshRollbackCandidates()

--- a/cli/app/ui_input_controller_commands.go
+++ b/cli/app/ui_input_controller_commands.go
@@ -248,7 +248,7 @@ func (c uiInputController) handleFastModeCommand(requested string) (tea.Model, t
 	}
 
 	status := fastModeToggleStatusMessage(m.fastModeEnabled, changed)
-	return m, c.appendSystemFeedbackWithStatus(status, c.showSuccessStatus(status))
+	return m, c.appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeSuccess)
 }
 
 func (c uiInputController) handleSupervisorModeCommand(requested string) (tea.Model, tea.Cmd) {
@@ -286,7 +286,7 @@ func (c uiInputController) handleSupervisorModeCommand(requested string) (tea.Mo
 	m.reviewerMode = nextMode
 	m.reviewerEnabled = nextMode != "off"
 	status := reviewerToggleStatusMessage(m.reviewerEnabled, nextMode, changed)
-	return m, c.appendSystemFeedbackWithStatus(status, c.showTransientStatus(status))
+	return m, c.appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral)
 }
 
 func (c uiInputController) handleAutoCompactionCommand(requested string) (tea.Model, tea.Cmd) {
@@ -325,5 +325,5 @@ func (c uiInputController) handleAutoCompactionCommand(requested string) (tea.Mo
 	}
 	m.autoCompactionEnabled = nextEnabled
 	status := autoCompactionToggleStatusMessage(nextEnabled, changed, currentCompactionMode)
-	return m, c.appendSystemFeedbackWithStatus(status, c.showTransientStatus(status))
+	return m, c.appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral)
 }

--- a/cli/app/ui_input_controller_keys.go
+++ b/cli/app/ui_input_controller_keys.go
@@ -205,9 +205,9 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return next, cmd
 		}
 		if commandResult := m.commandRegistry.Execute(text); commandResult.Handled {
+			command, _ := m.commandRegistry.Command(text)
 			recordCmd := m.recordPromptHistory(text)
-			m.clearInput()
-			m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
+			m.clearCommandInput(command, draftText, draftCursor, restoreDraft)
 			next, cmd := c.applyCommandResult(commandResult)
 			return next, finalizeSlashCommandCmd(commandResult.Action, cmd, recordCmd)
 		}

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -62,11 +62,26 @@ func (c uiInputController) queueOrStartSubmission(text string) (tea.Model, tea.C
 	}
 	draftText, draftCursor, restoreDraft := m.capturePromptHistoryDraftForReuse()
 	m.queueInput(text)
-	m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
+	if c.preservePromptHistoryDraftForQueuedText(text) {
+		m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
+	} else {
+		m.resetPromptHistoryNavigation()
+	}
 	if m.busy {
 		return m, nil
 	}
 	return c.flushQueuedInputs(queueDrainOne)
+}
+
+func (c uiInputController) preservePromptHistoryDraftForQueuedText(text string) bool {
+	if c.model == nil || c.model.commandRegistry == nil {
+		return true
+	}
+	command, knownCommand := c.model.commandRegistry.Command(text)
+	if !knownCommand {
+		return true
+	}
+	return command.PreservePromptHistoryDraft
 }
 
 func (c uiInputController) blockDisconnectedSubmission(restoreHidden bool, submittedText string) (bool, tea.Cmd) {

--- a/cli/app/ui_input_slash_commands.go
+++ b/cli/app/ui_input_slash_commands.go
@@ -44,12 +44,20 @@ func (c uiInputController) handleEnteredSlashCommandInput(text string) (bool, te
 	if commandResult := m.commandRegistry.Execute(commandText); commandResult.Handled {
 		draftText, draftCursor, restoreDraft := m.capturePromptHistoryDraftForReuse()
 		recordCmd := m.recordPromptHistory(commandText)
-		m.clearInput()
-		m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
+		m.clearCommandInput(command, draftText, draftCursor, restoreDraft)
 		next, cmd := c.applyCommandResult(commandResult)
 		return true, next, finalizeSlashCommandCmd(commandResult.Action, cmd, recordCmd)
 	}
 	return false, m, nil
+}
+
+func (m *uiModel) clearCommandInput(command commands.Command, draftText string, draftCursor int, restoreDraft bool) {
+	m.clearInput()
+	if command.PreservePromptHistoryDraft {
+		m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
+		return
+	}
+	m.resetPromptHistoryNavigation()
 }
 
 func finalizeSlashCommandCmd(action commands.Action, primary tea.Cmd, record tea.Cmd) tea.Cmd {

--- a/cli/app/ui_messages.go
+++ b/cli/app/ui_messages.go
@@ -227,6 +227,7 @@ type uiStatusNotice struct {
 	Text     string
 	Kind     uiStatusNoticeKind
 	Duration time.Duration
+	NoticeID string
 }
 
 type uiStatusNoticeDelivery uint8

--- a/cli/app/ui_native_scrollback_integration_part4_test.go
+++ b/cli/app/ui_native_scrollback_integration_part4_test.go
@@ -432,6 +432,100 @@ func TestNativeProgramConversationRefreshHydratesCommittedTranscriptWithoutRepla
 	}
 }
 
+func TestNativeProgramSlashLocalEntryDoesNotReplayPreviousPrompt(t *testing.T) {
+	out := &bytes.Buffer{}
+	runtimeEvents := make(chan clientui.Event, 8)
+	client := &slashLocalEntryRuntimeClient{
+		events: runtimeEvents,
+		startupTranscriptRuntimeClient: startupTranscriptRuntimeClient{
+			view: clientui.RuntimeMainView{
+				Session: clientui.RuntimeSessionView{SessionID: "session-1"},
+				Status:  clientui.RuntimeStatus{AutoCompactionEnabled: true},
+			},
+			page: clientui.TranscriptPage{
+				SessionID:    "session-1",
+				Revision:     1,
+				TotalEntries: 1,
+				NextOffset:   1,
+				Entries: []clientui.ChatEntry{{
+					Role: "user",
+					Text: "can u backfill this into the conversation so i can post this on twitter",
+				}},
+			},
+		},
+	}
+	model := newProjectedTestUIModel(client, runtimeEvents, closedAskEvents())
+	model.promptHistoryDraft = "can u backfill this into the conversation so i can post this on twitter"
+	model.promptHistoryDraftCursor = -1
+	program := tea.NewProgram(model, tea.WithInput(strings.NewReader("")), tea.WithOutput(out), tea.WithoutSignals())
+	done := make(chan error, 1)
+	go func() {
+		_, err := program.Run()
+		done <- err
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	program.Send(tea.WindowSizeMsg{Width: 120, Height: 30})
+	waitForTestCondition(t, 2*time.Second, "startup prompt visible once", func() bool {
+		return strings.Count(normalizedOutput(out.String()), "can u backfill this into the conversation") == 1
+	})
+	model.input = "/autocompaction"
+	program.Send(tea.KeyMsg{Type: tea.KeyEnter})
+	waitForTestCondition(t, 2*time.Second, "slash command feedback visible", func() bool {
+		return strings.Contains(normalizedOutput(out.String()), "Auto-compaction disabled")
+	})
+	program.Quit()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("program run failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("program did not terminate")
+	}
+
+	normalized := normalizedOutput(out.String())
+	if got := strings.Count(normalized, "can u backfill this into the conversation"); got != 1 {
+		t.Fatalf("expected previous prompt once after slash feedback, got %d in %q", got, normalized)
+	}
+	if got := strings.Count(normalized, "Auto-compaction disabled"); got != 1 {
+		t.Fatalf("expected slash feedback once, got %d in %q", got, normalized)
+	}
+}
+
+type slashLocalEntryRuntimeClient struct {
+	startupTranscriptRuntimeClient
+	events chan<- clientui.Event
+}
+
+func (c *slashLocalEntryRuntimeClient) SetAutoCompactionEnabled(enabled bool) (bool, bool, error) {
+	c.view.Status.AutoCompactionEnabled = enabled
+	return true, enabled, nil
+}
+
+func (c *slashLocalEntryRuntimeClient) AppendLocalEntry(role, text string) error {
+	return c.AppendLocalEntryWithNoticeID(role, text, "")
+}
+
+func (c *slashLocalEntryRuntimeClient) AppendLocalEntryWithNoticeID(role, text, noticeID string) error {
+	entry := clientui.ChatEntry{Role: role, Text: text, NoticeID: noticeID}
+	start := c.page.TotalEntries
+	c.page.Entries = append(c.page.Entries, entry)
+	c.page.TotalEntries++
+	c.page.NextOffset = c.page.TotalEntries
+	c.page.Revision++
+	c.events <- clientui.Event{
+		Kind:                       clientui.EventLocalEntryAdded,
+		CommittedTranscriptChanged: true,
+		TranscriptRevision:         c.page.Revision,
+		CommittedEntryCount:        c.page.TotalEntries,
+		CommittedEntryStart:        start,
+		CommittedEntryStartSet:     true,
+		TranscriptEntries:          []clientui.ChatEntry{entry},
+	}
+	return nil
+}
+
 func TestNativeStreamingInterleavedWithStatusRedrawStaysCoherent(t *testing.T) {
 	out := &bytes.Buffer{}
 	model := newProjectedTestUIModel(

--- a/cli/app/ui_part3_test.go
+++ b/cli/app/ui_part3_test.go
@@ -95,6 +95,22 @@ func TestTransientStatusQueueKeepsSameTextAndKindWithDifferentNoticeID(t *testin
 	}
 }
 
+func TestTransientStatusQueueDedupesSameTextKindAndNoticeID(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	first := m.sendTransientStatusWithNoticeID("same", uiStatusNoticeSuccess, transientStatusDuration, uiStatusNoticeQueue, "notice-1")
+	second := m.sendTransientStatusWithNoticeID("same", uiStatusNoticeSuccess, transientStatusDuration, uiStatusNoticeQueue, "notice-1")
+
+	if first == nil {
+		t.Fatal("expected first notice clear command")
+	}
+	if second != nil {
+		t.Fatalf("expected duplicate active notice suppressed, got %T", second())
+	}
+	if got := len(m.transientStatusQueue); got != 0 {
+		t.Fatalf("queued notice count = %d, want 0", got)
+	}
+}
+
 func TestTransientStatusReplaceUpdatesActiveNoticeImmediately(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	first := m.setTransientStatusWithKind("first", uiStatusNoticeSuccess)

--- a/cli/app/ui_part3_test.go
+++ b/cli/app/ui_part3_test.go
@@ -76,6 +76,25 @@ func TestTransientStatusQueuePromotesNextNoticeAfterClear(t *testing.T) {
 	}
 }
 
+func TestTransientStatusQueueKeepsSameTextAndKindWithDifferentNoticeID(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	first := m.sendTransientStatusWithNoticeID("same", uiStatusNoticeSuccess, transientStatusDuration, uiStatusNoticeQueue, "notice-1")
+	second := m.sendTransientStatusWithNoticeID("same", uiStatusNoticeSuccess, transientStatusDuration, uiStatusNoticeQueue, "notice-2")
+
+	if first == nil {
+		t.Fatal("expected first notice clear command")
+	}
+	if second != nil {
+		t.Fatalf("expected queued notice to wait for active clear, got %T", second())
+	}
+	if got := len(m.transientStatusQueue); got != 1 {
+		t.Fatalf("queued notice count = %d, want 1", got)
+	}
+	if got := m.transientStatusQueue[0].NoticeID; got != "notice-2" {
+		t.Fatalf("queued notice id = %q, want notice-2", got)
+	}
+}
+
 func TestTransientStatusReplaceUpdatesActiveNoticeImmediately(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	first := m.setTransientStatusWithKind("first", uiStatusNoticeSuccess)

--- a/cli/app/ui_part7_test.go
+++ b/cli/app/ui_part7_test.go
@@ -646,6 +646,43 @@ func TestBusySlashThinkingExecutesImmediatelyWithoutQueueing(t *testing.T) {
 	}
 }
 
+func TestLocalSlashCommandsDiscardPromptHistoryDraftAfterExecution(t *testing.T) {
+	for _, input := range []string{"/thinking low", "/fast on", "/supervisor on", "/autocompaction off"} {
+		t.Run(input, func(t *testing.T) {
+			m := newProjectedStaticUIModel(WithUIFastModeAvailable(true))
+			m.promptHistoryDraft = "previous user prompt"
+			m.promptHistoryDraftCursor = -1
+			m.input = input
+
+			next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			updated := next.(*uiModel)
+			if updated.input != "" {
+				t.Fatalf("expected %s to clear input instead of restoring prompt history draft, got %q", input, updated.input)
+			}
+			if updated.promptHistoryDraft != "" || updated.promptHistoryDraftCursor != -1 {
+				t.Fatalf("expected %s to clear prompt history draft, got text=%q cursor=%d", input, updated.promptHistoryDraft, updated.promptHistoryDraftCursor)
+			}
+		})
+	}
+}
+
+func TestMirroredTransientStatusClearsOnlyForMatchingNoticeID(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.transientStatus = "Fast mode enabled"
+	m.transientStatusKind = uiStatusNoticeSuccess
+	m.transientStatusNoticeID = "notice-1"
+
+	m.clearMirroredTransientStatus([]tui.TranscriptEntry{{Role: "system", Text: "Fast mode enabled", NoticeID: "notice-2"}})
+	if m.transientStatus != "Fast mode enabled" || m.transientStatusNoticeID != "notice-1" {
+		t.Fatalf("expected unmatched notice id to preserve transient status, got status=%q notice=%q", m.transientStatus, m.transientStatusNoticeID)
+	}
+
+	m.clearMirroredTransientStatus([]tui.TranscriptEntry{{Role: "system", Text: "different text", NoticeID: "notice-1"}})
+	if m.transientStatus != "" || m.transientStatusNoticeID != "" {
+		t.Fatalf("expected matching notice id to clear transient status, got status=%q notice=%q", m.transientStatus, m.transientStatusNoticeID)
+	}
+}
+
 func TestSlashFastTogglesAndShowsStatus(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUIFastModeAvailable(true))
 	m.termWidth = 100

--- a/cli/app/ui_part7_test.go
+++ b/cli/app/ui_part7_test.go
@@ -683,6 +683,19 @@ func TestMirroredTransientStatusClearsOnlyForMatchingNoticeID(t *testing.T) {
 	}
 }
 
+func TestLocalEntryFallbackForwardsNoticeIDToView(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	_ = m.appendLocalEntryFallbackWithNoticeID("system", "Fallback notice", "notice-1")
+
+	loaded := m.view.LoadedTranscriptEntries()
+	if len(loaded) != 1 {
+		t.Fatalf("loaded transcript entry count = %d, want 1", len(loaded))
+	}
+	if loaded[0].NoticeID != "notice-1" {
+		t.Fatalf("view notice id = %q, want notice-1", loaded[0].NoticeID)
+	}
+}
+
 func TestSlashFastTogglesAndShowsStatus(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUIFastModeAvailable(true))
 	m.termWidth = 100

--- a/cli/app/ui_runtime_adapter.go
+++ b/cli/app/ui_runtime_adapter.go
@@ -79,10 +79,6 @@ func (a uiRuntimeAdapter) applyProjectedRuntimeEvent(evt clientui.Event, flushNa
 	cmds := make([]tea.Cmd, 0, 4)
 	transcriptMutated := false
 	awaitsHydration := false
-	if shouldAppendSyntheticOngoingEntry(m, reduction.Transcript.SyntheticOngoingEntry) {
-		entry := transcriptEntryFromProjectedChatEntry(*reduction.Transcript.SyntheticOngoingEntry, true, false)
-		m.forwardToView(appendTranscriptMsgFromEntry(entry))
-	}
 	if shouldInvalidateTransientTranscriptStateForSync(transcriptSync) {
 		m.invalidateTransientTranscriptState()
 	}

--- a/cli/app/ui_runtime_adapter_part2_test.go
+++ b/cli/app/ui_runtime_adapter_part2_test.go
@@ -464,7 +464,7 @@ func TestHandleProjectedRuntimeEventDoesNotAppendPrePersistCompactionStatusEntry
 	}
 }
 
-func TestProjectedCompactionStatusClearsCompactingWithoutSyntheticNotice(t *testing.T) {
+func TestProjectedCompactionStatusClearsCompactingWithoutTranscriptNotice(t *testing.T) {
 	client := &runtimeControlFakeClient{}
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
 	m.termWidth = 100
@@ -492,7 +492,7 @@ func TestProjectedCompactionStatusClearsCompactingWithoutSyntheticNotice(t *test
 	})))
 	for _, msg := range msgs {
 		if _, ok := msg.(runtimeTranscriptRefreshedMsg); ok {
-			t.Fatalf("did not expect synthetic compaction notice to trigger transcript hydration, got %+v", msgs)
+			t.Fatalf("did not expect compaction status to trigger transcript hydration, got %+v", msgs)
 		}
 	}
 	if got, want := len(m.transcriptEntries), 1; got != want {
@@ -549,7 +549,7 @@ func TestProjectedCompactionStatusDoesNotDuplicateCommittedSummary(t *testing.T)
 	}
 }
 
-func TestProjectedCompactionStatusSkipsSyntheticOngoingNoticeInDetailMode(t *testing.T) {
+func TestProjectedCompactionStatusDoesNotAppendOngoingNoticeInDetailMode(t *testing.T) {
 	client := &runtimeControlFakeClient{}
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
 	m.termWidth = 100
@@ -583,7 +583,7 @@ func TestProjectedCompactionStatusSkipsSyntheticOngoingNoticeInDetailMode(t *tes
 		t.Fatalf("loaded transcript entry count = %d, want %d (%+v)", got, want, loaded)
 	}
 	if strings.Contains(stripANSIAndTrimRight(m.View()), "context compacted for the 1st time") {
-		t.Fatalf("did not expect synthetic compaction notice in detail view, got %q", stripANSIAndTrimRight(m.View()))
+		t.Fatalf("did not expect compaction status notice in detail view, got %q", stripANSIAndTrimRight(m.View()))
 	}
 }
 

--- a/cli/app/ui_runtime_adapter_test.go
+++ b/cli/app/ui_runtime_adapter_test.go
@@ -799,12 +799,12 @@ func TestApplyProjectedTranscriptEntriesForwardsCompactMetadataToLiveView(t *tes
 	}
 }
 
-func TestAppendTranscriptMsgFromEntryPreservesSyntheticCompactMetadata(t *testing.T) {
+func TestAppendTranscriptMsgFromEntryPreservesTransientCompactMetadata(t *testing.T) {
 	entry := transcriptEntryFromProjectedChatEntry(clientui.ChatEntry{
 		Visibility:        transcript.EntryVisibilityDetailOnly,
 		Role:              "warning",
-		Text:              "synthetic warning body",
-		OngoingText:       "synthetic warning",
+		Text:              "transient warning body",
+		OngoingText:       "transient warning",
 		Phase:             string(llm.MessagePhaseFinal),
 		MessageType:       string(llm.MessageTypeCompactionSoonReminder),
 		SourcePath:        "  docs/dev/decisions.md  ",
@@ -814,11 +814,11 @@ func TestAppendTranscriptMsgFromEntryPreservesSyntheticCompactMetadata(t *testin
 	}, true, false)
 
 	got := appendTranscriptMsgFromEntry(entry)
-	if !got.Transient || got.Committed || got.Visibility != transcript.EntryVisibilityDetailOnly || got.Role != "warning" || got.OngoingText != "synthetic warning" || got.Phase != llm.MessagePhaseFinal {
-		t.Fatalf("expected synthetic append state preserved, got %+v", got)
+	if !got.Transient || got.Committed || got.Visibility != transcript.EntryVisibilityDetailOnly || got.Role != "warning" || got.OngoingText != "transient warning" || got.Phase != llm.MessagePhaseFinal {
+		t.Fatalf("expected transient append state preserved, got %+v", got)
 	}
 	if got.MessageType != llm.MessageTypeCompactionSoonReminder || got.SourcePath != "docs/dev/decisions.md" || got.CompactLabel != "Compaction reminder" || got.ToolResultSummary != "summary text" || got.ToolCallID != "call-1" {
-		t.Fatalf("expected synthetic append to preserve compact metadata, got %+v", got)
+		t.Fatalf("expected transient append to preserve compact metadata, got %+v", got)
 	}
 }
 

--- a/cli/app/ui_runtime_client_control.go
+++ b/cli/app/ui_runtime_client_control.go
@@ -178,10 +178,14 @@ func cloneRuntimeGoal(goal *clientui.RuntimeGoal) *clientui.RuntimeGoal {
 }
 
 func (c *sessionRuntimeClient) AppendLocalEntry(role, text string) error {
+	return c.AppendLocalEntryWithNoticeID(role, text, "")
+}
+
+func (c *sessionRuntimeClient) AppendLocalEntryWithNoticeID(role, text, noticeID string) error {
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	return c.retryControlCallNoResult(ctx, func(controllerLeaseID string) error {
-		return c.controls.AppendLocalEntry(ctx, serverapi.RuntimeAppendLocalEntryRequest{ClientRequestID: uuid.NewString(), SessionID: c.sessionID, ControllerLeaseID: controllerLeaseID, Role: role, Text: text})
+		return c.controls.AppendLocalEntry(ctx, serverapi.RuntimeAppendLocalEntryRequest{ClientRequestID: uuid.NewString(), SessionID: c.sessionID, ControllerLeaseID: controllerLeaseID, Role: role, Text: text, NoticeID: strings.TrimSpace(noticeID)})
 	})
 }
 

--- a/cli/app/ui_runtime_control.go
+++ b/cli/app/ui_runtime_control.go
@@ -110,7 +110,18 @@ func (m *uiModel) clearRuntimeGoal() (*clientui.RuntimeGoal, error) {
 }
 
 func (m *uiModel) appendRuntimeLocalEntry(role, text string) error {
+	return m.appendRuntimeLocalEntryWithNoticeID(role, text, "")
+}
+
+func (m *uiModel) appendRuntimeLocalEntryWithNoticeID(role, text, noticeID string) error {
 	if client := m.runtimeClient(); client != nil {
+		if withNoticeID, ok := client.(interface {
+			AppendLocalEntryWithNoticeID(role, text, noticeID string) error
+		}); ok {
+			err := withNoticeID.AppendLocalEntryWithNoticeID(role, text, noticeID)
+			m.observeRuntimeRequestResult(err)
+			return err
+		}
 		err := client.AppendLocalEntry(role, text)
 		m.observeRuntimeRequestResult(err)
 		return err

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -146,15 +146,17 @@ type uiStatusFeatureState struct {
 	clipboardImagePaster        uiClipboardImagePaster
 	clipboardTextCopier         uiClipboardTextCopier
 
-	transientStatus       string
-	transientStatusKind   uiStatusNoticeKind
-	transientStatusToken  uint64
-	transientStatusQueue  []uiStatusNotice
-	startupUpdateNotice   bool
-	startupUpdateShown    bool
-	debugKeys             bool
-	debugMode             bool
-	transcriptDiagnostics bool
+	transientStatus         string
+	transientStatusKind     uiStatusNoticeKind
+	transientStatusNoticeID string
+	transientStatusToken    uint64
+	transientStatusQueue    []uiStatusNotice
+	localNoticeSequence     uint64
+	startupUpdateNotice     bool
+	startupUpdateShown      bool
+	debugKeys               bool
+	debugMode               bool
+	transcriptDiagnostics   bool
 }
 
 type uiTranscriptFeatureState struct {

--- a/cli/app/ui_transcript_entries.go
+++ b/cli/app/ui_transcript_entries.go
@@ -71,6 +71,7 @@ func transcriptEntryFromProjectedChatEntry(entry clientui.ChatEntry, transient b
 		CompactLabel:      strings.TrimSpace(entry.CompactLabel),
 		ToolResultSummary: strings.TrimSpace(entry.ToolResultSummary),
 		ToolCallID:        entry.ToolCallID,
+		NoticeID:          strings.TrimSpace(entry.NoticeID),
 		ToolCall:          transcriptToolCallMeta(entry.ToolCall),
 	}
 }
@@ -89,6 +90,7 @@ func appendTranscriptMsgFromEntry(entry tui.TranscriptEntry) tui.AppendTranscrip
 		CompactLabel:      strings.TrimSpace(entry.CompactLabel),
 		ToolResultSummary: strings.TrimSpace(entry.ToolResultSummary),
 		ToolCallID:        strings.TrimSpace(entry.ToolCallID),
+		NoticeID:          strings.TrimSpace(entry.NoticeID),
 		ToolCall:          entry.ToolCall,
 	}
 }
@@ -182,6 +184,7 @@ func transcriptPayloadFromTUIEntry(entry tui.TranscriptEntry) transcript.EntryPa
 		CompactLabel:      entry.CompactLabel,
 		ToolResultSummary: entry.ToolResultSummary,
 		ToolCallID:        entry.ToolCallID,
+		NoticeID:          entry.NoticeID,
 		ToolCall:          entry.ToolCall,
 	}
 }
@@ -199,6 +202,7 @@ func transcriptPayloadFromClientEntry(entry clientui.ChatEntry) transcript.Entry
 		CompactLabel:      entry.CompactLabel,
 		ToolResultSummary: entry.ToolResultSummary,
 		ToolCallID:        entry.ToolCallID,
+		NoticeID:          entry.NoticeID,
 		ToolCall:          transcriptToolCallMeta(entry.ToolCall),
 	}
 }

--- a/cli/app/ui_transcript_event_apply.go
+++ b/cli/app/ui_transcript_event_apply.go
@@ -71,11 +71,11 @@ func (a uiRuntimeAdapter) applyProjectedTranscriptEntries(evt clientui.Event, fl
 		convertedEntries = append(convertedEntries, transcriptEntryFromProjectedChatEntry(entry, reduction.projectedTransient, reduction.projectedCommitted))
 	}
 	showTransientInCurrentView := m.view.Mode() != tui.ModeDetail || !allTranscriptEntriesTransient(convertedEntries)
-	replaceLoadedSyntheticEntries := shouldReplaceLoadedSyntheticEntriesWithCommittedAppend(m, convertedEntries)
+	replaceLoadedTransientEntries := shouldReplaceLoadedTransientEntriesWithCommittedAppend(m, convertedEntries)
 	if plan.mode == projectedTranscriptEntryPlanAppend {
 		for _, transcriptEntry := range convertedEntries {
 			m.transcriptEntries = append(m.transcriptEntries, transcriptEntry)
-			if showTransientInCurrentView && !replaceLoadedSyntheticEntries {
+			if showTransientInCurrentView && !replaceLoadedTransientEntries {
 				m.forwardToView(appendTranscriptMsgFromEntry(transcriptEntry))
 			}
 		}
@@ -89,7 +89,7 @@ func (a uiRuntimeAdapter) applyProjectedTranscriptEntries(evt clientui.Event, fl
 	m.transcriptTotalEntries = max(m.transcriptTotalEntries, max(evt.CommittedEntryCount, m.transcriptBaseOffset+len(m.transcriptEntries)))
 	m.observeDirectCommittedEventDelivery(evt)
 	m.refreshRollbackCandidates()
-	if plan.mode == projectedTranscriptEntryPlanAppend && replaceLoadedSyntheticEntries {
+	if plan.mode == projectedTranscriptEntryPlanAppend && replaceLoadedTransientEntries {
 		m.forwardToView(tui.SetConversationMsg{
 			BaseOffset:   m.transcriptBaseOffset,
 			TotalEntries: m.transcriptTotalEntries,
@@ -130,12 +130,30 @@ func (a uiRuntimeAdapter) applyProjectedTranscriptEntries(evt clientui.Event, fl
 	if showTransientInCurrentView && m.view.Mode() == tui.ModeOngoing {
 		m.forwardToView(tui.SetOngoingScrollMsg{Scroll: m.view.OngoingScroll()})
 	}
+	if showTransientInCurrentView {
+		m.clearMirroredTransientStatus(convertedEntries)
+	}
 	if !flushNativeHistory {
 		m.logProjectedTranscriptAppliedDiag(evt, plan, incomingCount, len(entries), startOffset, entries, false)
 		return nil, true, false
 	}
 	m.logProjectedTranscriptAppliedDiag(evt, plan, incomingCount, len(entries), startOffset, entries, true)
 	return m.syncNativeHistoryFromTranscript(), true, false
+}
+
+func (m *uiModel) clearMirroredTransientStatus(entries []tui.TranscriptEntry) {
+	if m == nil || m.transientStatusNoticeID == "" {
+		return
+	}
+	for _, entry := range entries {
+		if entry.NoticeID != m.transientStatusNoticeID {
+			continue
+		}
+		m.transientStatus = ""
+		m.transientStatusKind = uiStatusNoticeNeutral
+		m.transientStatusNoticeID = ""
+		return
+	}
 }
 
 func (m *uiModel) observeDirectCommittedEventDelivery(evt clientui.Event) {

--- a/cli/app/ui_transcript_runtime_state.go
+++ b/cli/app/ui_transcript_runtime_state.go
@@ -53,24 +53,7 @@ func (m *uiModel) invalidateTransientTranscriptState() {
 	}
 }
 
-func shouldAppendSyntheticOngoingEntry(m *uiModel, entry *clientui.ChatEntry) bool {
-	if m == nil || entry == nil || !m.hasRuntimeClient() || m.view.Mode() != tui.ModeOngoing {
-		return false
-	}
-	role := tui.TranscriptRoleFromWire(entry.Role)
-	text := strings.TrimSpace(entry.Text)
-	if role == tui.TranscriptRoleUnknown || text == "" {
-		return false
-	}
-	for _, loaded := range m.view.LoadedTranscriptEntries() {
-		if transcriptEntryMatchesChatEntry(loaded, *entry) {
-			return false
-		}
-	}
-	return true
-}
-
-func shouldReplaceLoadedSyntheticEntriesWithCommittedAppend(m *uiModel, entries []tui.TranscriptEntry) bool {
+func shouldReplaceLoadedTransientEntriesWithCommittedAppend(m *uiModel, entries []tui.TranscriptEntry) bool {
 	if m == nil || m.view.Mode() != tui.ModeOngoing || len(entries) == 0 {
 		return false
 	}

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -37,6 +37,7 @@ type TranscriptEntry struct {
 	CompactLabel      string
 	ToolResultSummary string
 	ToolCallID        string
+	NoticeID          string
 	ToolCall          *transcript.ToolCallMeta
 }
 
@@ -88,6 +89,7 @@ type AppendTranscriptMsg struct {
 	CompactLabel      string
 	ToolResultSummary string
 	ToolCallID        string
+	NoticeID          string
 	ToolCall          *transcript.ToolCallMeta
 }
 

--- a/cli/tui/model_reducer.go
+++ b/cli/tui/model_reducer.go
@@ -199,6 +199,7 @@ func (m *Model) reduceAppendTranscriptMsg(msg AppendTranscriptMsg, result *model
 		CompactLabel:      strings.TrimSpace(msg.CompactLabel),
 		ToolResultSummary: strings.TrimSpace(msg.ToolResultSummary),
 		ToolCallID:        strings.TrimSpace(msg.ToolCallID),
+		NoticeID:          strings.TrimSpace(msg.NoticeID),
 		ToolCall:          cloneToolCallMeta(msg.ToolCall),
 	})
 	m.advanceTranscriptEntriesRevision()

--- a/docs/dev/decisions.md
+++ b/docs/dev/decisions.md
@@ -296,8 +296,8 @@
 - `type=compaction` items and encrypted reasoning/compaction payloads are treated as opaque and replayed unchanged.
 - Compaction lifecycle emits and persists started/completed/failed events.
 - Local compaction instructions are sent as `developer` messages, and local compaction summaries/checkpoints persist internally as `developer` messages with `message_type=compaction_summary`; any model-facing summary prefix is added only at the provider input boundary. Native/remote compaction has no transcript-message prompt equivalent because it uses provider `Instructions` plus opaque provider output, which Builder replays unchanged.
-- UI may surface a synthetic ongoing-only `context compacted for the Nth time` notice from compaction-completed runtime status. That live notice is not a durable transcript row and must not change detail-mode hydration or transcript authority.
-- Persisted compaction transcript rows still come only from server-owned transcript items/local entries. Ongoing suppresses detailed summary content; detail shows persisted compaction items in file order, including full local summary when available.
+- Compaction-completed runtime status never creates a UI-only transcript row. Transcript-visible compaction notices/summaries come only from server-owned transcript items/local entries.
+- Ongoing suppresses detailed summary content; detail shows persisted compaction items in file order, including full local summary when available.
 
 ## Model Defaults
 

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -24,6 +24,7 @@ type ChatEntry struct {
 	CompactLabel      string
 	ToolResultSummary string
 	ToolCallID        string
+	NoticeID          string
 	ToolCall          *transcript.ToolCallMeta
 }
 
@@ -227,14 +228,21 @@ func (s *chatStore) appendLocalEntryWithVisibility(role, text string, visibility
 }
 
 func (s *chatStore) appendLocalEntryWithOngoingTextAndVisibility(role, text, ongoingText string, visibility transcript.EntryVisibility) {
-	if strings.TrimSpace(text) == "" {
+	s.appendLocalEntryRecord(ChatEntry{Visibility: transcript.NormalizeEntryVisibility(visibility), Role: role, Text: text, OngoingText: strings.TrimSpace(ongoingText)})
+}
+
+func (s *chatStore) appendLocalEntryRecord(entry ChatEntry) {
+	if strings.TrimSpace(entry.Text) == "" {
 		return
 	}
+	entry.Visibility = transcript.NormalizeEntryVisibility(entry.Visibility)
+	entry.OngoingText = strings.TrimSpace(entry.OngoingText)
+	entry.NoticeID = strings.TrimSpace(entry.NoticeID)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	messageCount := s.messageCount
 	s.local = append(s.local, localChatEntry{
-		Entry:             ChatEntry{Visibility: transcript.NormalizeEntryVisibility(visibility), Role: role, Text: text, OngoingText: strings.TrimSpace(ongoingText)},
+		Entry:             entry,
 		AfterMessageCount: messageCount,
 	})
 	s.transcriptEntryCount++

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -178,6 +178,7 @@ func (e *Engine) appendPersistedLocalEntryRecord(stepID string, entry storedLoca
 	entry.Text = strings.TrimSpace(entry.Text)
 	entry.OngoingText = strings.TrimSpace(entry.OngoingText)
 	entry.DiagnosticKey = strings.TrimSpace(entry.DiagnosticKey)
+	entry.NoticeID = strings.TrimSpace(entry.NoticeID)
 	if entry.Role == "" || entry.Text == "" {
 		return nil
 	}
@@ -188,7 +189,7 @@ func (e *Engine) appendPersistedLocalEntryRecord(stepID string, entry storedLoca
 	}
 	_, err := e.store.AppendEvent(stepID, "local_entry", entry)
 	if err == nil {
-		e.chat.appendLocalEntryWithOngoingTextAndVisibility(entry.Role, entry.Text, entry.OngoingText, entry.Visibility)
+		e.chat.appendLocalEntryRecord(*localEntryChatEntry(entry))
 		e.emit(Event{Kind: EventLocalEntryAdded, StepID: stepID, LocalEntry: localEntryChatEntry(entry), CommittedTranscriptChanged: true})
 	}
 	return err
@@ -200,6 +201,7 @@ func localEntryChatEntry(entry storedLocalEntry) *ChatEntry {
 		Role:        strings.TrimSpace(entry.Role),
 		Text:        strings.TrimSpace(entry.Text),
 		OngoingText: strings.TrimSpace(entry.OngoingText),
+		NoticeID:    strings.TrimSpace(entry.NoticeID),
 	}
 }
 

--- a/server/runtime/engine_part6_test.go
+++ b/server/runtime/engine_part6_test.go
@@ -415,6 +415,33 @@ func TestRestoreMessagesKeepsStoredReviewerEntriesVerbatim(t *testing.T) {
 	}
 }
 
+func TestRestoreMessagesPreservesStoredLocalEntryNoticeID(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	if _, err := store.AppendEvent("legacy-step", "local_entry", storedLocalEntry{
+		Role:     "system",
+		Text:     "Mirrored notice",
+		NoticeID: "notice-1",
+	}); err != nil {
+		t.Fatalf("append local entry: %v", err)
+	}
+
+	restored, err := New(store, &fakeClient{}, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("restore engine: %v", err)
+	}
+	snapshot := restored.ChatSnapshot()
+	if len(snapshot.Entries) != 1 {
+		t.Fatalf("expected 1 restored entry, got %+v", snapshot.Entries)
+	}
+	if snapshot.Entries[0].NoticeID != "notice-1" {
+		t.Fatalf("notice id = %q, want notice-1", snapshot.Entries[0].NoticeID)
+	}
+}
+
 func TestAppendPersistedLocalEntryRecordDoesNotMutateChatOnAppendFailure(t *testing.T) {
 	localEntryErr := errors.New("injected local entry persistence failure")
 	dir := t.TempDir()

--- a/server/runtime/engine_state.go
+++ b/server/runtime/engine_state.go
@@ -110,6 +110,15 @@ func (e *Engine) AppendLocalEntryWithVisibility(role, text string, visibility tr
 	})
 }
 
+func (e *Engine) AppendLocalEntryWithNoticeID(role, text, noticeID string) {
+	e.appendLocalEntry(storedLocalEntry{
+		Visibility: transcript.EntryVisibilityAuto,
+		Role:       strings.TrimSpace(role),
+		Text:       strings.TrimSpace(text),
+		NoticeID:   strings.TrimSpace(noticeID),
+	})
+}
+
 func (e *Engine) AppendLocalEntryWithOngoingText(role, text, ongoingText string) {
 	e.appendLocalEntry(storedLocalEntry{
 		Visibility:  transcript.EntryVisibilityAuto,
@@ -123,7 +132,7 @@ func (e *Engine) appendLocalEntry(entry storedLocalEntry) {
 	if entry.Role == "" || entry.Text == "" {
 		return
 	}
-	e.chat.appendLocalEntryWithOngoingTextAndVisibility(entry.Role, entry.Text, entry.OngoingText, entry.Visibility)
+	e.chat.appendLocalEntryRecord(*localEntryChatEntry(entry))
 	e.emit(Event{Kind: EventLocalEntryAdded, LocalEntry: localEntryChatEntry(entry)})
 	e.emitConversationUpdated("")
 }
@@ -430,6 +439,7 @@ type storedLocalEntry struct {
 	Text          string                     `json:"text"`
 	OngoingText   string                     `json:"ongoing_text,omitempty"`
 	DiagnosticKey string                     `json:"diagnostic_key,omitempty"`
+	NoticeID      string                     `json:"notice_id,omitempty"`
 }
 
 type historyReplacementPayload struct {

--- a/server/runtime/message_lifecycle.go
+++ b/server/runtime/message_lifecycle.go
@@ -47,7 +47,7 @@ func (m *defaultMessageLifecycle) RestoreMessages() error {
 				return fmt.Errorf("decode local_entry event: %w", err)
 			}
 			e.restoreLocalDiagnostic(entry.DiagnosticKey)
-			e.chat.appendLocalEntryWithOngoingTextAndVisibility(entry.Role, entry.Text, entry.OngoingText, entry.Visibility)
+			e.chat.appendLocalEntryRecord(*localEntryChatEntry(entry))
 		case sessionEventCacheWarning:
 			if err := applyPersistedCacheWarningToChat(e.chat, evt.Payload, e.cfg.CacheWarningMode); err != nil {
 				return err

--- a/server/runtime/transcript_projector.go
+++ b/server/runtime/transcript_projector.go
@@ -50,7 +50,7 @@ func (p *TranscriptProjector) ApplyPersistedEvent(evt session.Event) error {
 		if err := json.Unmarshal(evt.Payload, &entry); err != nil {
 			return fmt.Errorf("decode local_entry event: %w", err)
 		}
-		p.chat.appendLocalEntryWithOngoingTextAndVisibility(entry.Role, entry.Text, entry.OngoingText, entry.Visibility)
+		p.chat.appendLocalEntryRecord(*localEntryChatEntry(entry))
 	case sessionEventCacheWarning:
 		if err := applyPersistedCacheWarningToChat(p.chat, evt.Payload, p.cacheWarningMode); err != nil {
 			return err

--- a/server/runtime/transcript_projector_test.go
+++ b/server/runtime/transcript_projector_test.go
@@ -85,6 +85,21 @@ func TestTranscriptProjectorPreservesErrorLocalEntries(t *testing.T) {
 	}
 }
 
+func TestTranscriptProjectorPreservesPersistedLocalEntryNoticeID(t *testing.T) {
+	projector := NewTranscriptProjector()
+	if err := projector.ApplyPersistedEvent(mustPersistedEvent(t, "local_entry", storedLocalEntry{Role: "system", Text: "Mirrored notice", NoticeID: "notice-1"})); err != nil {
+		t.Fatalf("ApplyPersistedEvent(local_entry notice): %v", err)
+	}
+
+	snapshot := projector.ChatSnapshot()
+	if len(snapshot.Entries) != 1 {
+		t.Fatalf("entry count = %d, want 1", len(snapshot.Entries))
+	}
+	if got := snapshot.Entries[0].NoticeID; got != "notice-1" {
+		t.Fatalf("notice id = %q, want notice-1", got)
+	}
+}
+
 func mustPersistedEvent(t *testing.T, kind string, payload any) session.Event {
 	t.Helper()
 	body, err := json.Marshal(payload)

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -83,6 +83,7 @@ type localEntryMemoRequest struct {
 	Role       string
 	Text       string
 	Visibility transcript.EntryVisibility
+	NoticeID   string
 }
 
 type goalSetMemoRequest struct {
@@ -259,7 +260,7 @@ func (s *Service) AppendLocalEntry(ctx context.Context, req serverapi.RuntimeApp
 		return err
 	}
 	visibility := transcript.NormalizeEntryVisibility(transcript.EntryVisibility(req.Visibility))
-	memoReq := localEntryMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Role: strings.TrimSpace(req.Role), Text: req.Text, Visibility: visibility}
+	memoReq := localEntryMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Role: strings.TrimSpace(req.Role), Text: req.Text, Visibility: visibility, NoticeID: strings.TrimSpace(req.NoticeID)}
 	_, err := s.localEntries.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameLocalEntryMemoRequest, func(ctx context.Context) (struct{}, error) {
 		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
 			return struct{}{}, err
@@ -268,7 +269,9 @@ func (s *Service) AppendLocalEntry(ctx context.Context, req serverapi.RuntimeApp
 		if err != nil {
 			return struct{}{}, err
 		}
-		if visibility == transcript.EntryVisibilityAuto {
+		if visibility == transcript.EntryVisibilityAuto && strings.TrimSpace(req.NoticeID) != "" {
+			engine.AppendLocalEntryWithNoticeID(req.Role, req.Text, req.NoticeID)
+		} else if visibility == transcript.EntryVisibilityAuto {
 			engine.AppendLocalEntry(req.Role, req.Text)
 		} else {
 			engine.AppendLocalEntryWithVisibility(req.Role, req.Text, visibility)
@@ -672,7 +675,7 @@ func sameSessionOnlyMemoRequest(a sessionOnlyMemoRequest, b sessionOnlyMemoReque
 }
 
 func sameLocalEntryMemoRequest(a localEntryMemoRequest, b localEntryMemoRequest) bool {
-	return a.SessionID == b.SessionID && a.Role == b.Role && a.Text == b.Text && a.Visibility == b.Visibility
+	return a.SessionID == b.SessionID && a.Role == b.Role && a.Text == b.Text && a.Visibility == b.Visibility && a.NoticeID == b.NoticeID
 }
 
 func sameGoalSetMemoRequest(a goalSetMemoRequest, b goalSetMemoRequest) bool {

--- a/server/runtimeview/projection.go
+++ b/server/runtimeview/projection.go
@@ -189,6 +189,7 @@ func chatEntriesFromRuntime(entries []runtime.ChatEntry) []clientui.ChatEntry {
 			CompactLabel:      entry.CompactLabel,
 			ToolResultSummary: entry.ToolResultSummary,
 			ToolCallID:        entry.ToolCallID,
+			NoticeID:          entry.NoticeID,
 			ToolCall:          cloneToolCallMeta(entry.ToolCall),
 		})
 	}
@@ -242,6 +243,7 @@ func ChatSnapshotFromRuntime(snapshot runtime.ChatSnapshot) clientui.ChatSnapsho
 			CompactLabel:      entry.CompactLabel,
 			ToolResultSummary: entry.ToolResultSummary,
 			ToolCallID:        entry.ToolCallID,
+			NoticeID:          entry.NoticeID,
 			ToolCall:          cloneToolCallMeta(entry.ToolCall),
 		})
 	}

--- a/shared/clientui/runtime_events.go
+++ b/shared/clientui/runtime_events.go
@@ -71,9 +71,8 @@ type RuntimeAssistantStreamCommand struct {
 }
 
 type RuntimeTranscriptReduction struct {
-	Sync                  RuntimeTranscriptSyncCommand
-	AssistantStream       []RuntimeAssistantStreamCommand
-	SyntheticOngoingEntry *ChatEntry
+	Sync            RuntimeTranscriptSyncCommand
+	AssistantStream []RuntimeAssistantStreamCommand
 }
 
 type RuntimeActivityCommand uint8

--- a/shared/clientui/runtime_events_test.go
+++ b/shared/clientui/runtime_events_test.go
@@ -217,7 +217,7 @@ func TestReduceRuntimeEvent_BackgroundCompletionFallsBackWithoutCompactText(t *t
 	}
 }
 
-func TestReduceRuntimeEvent_CompactionCompletedClearsCompactingWithoutSyntheticNotice(t *testing.T) {
+func TestReduceRuntimeEvent_CompactionCompletedClearsCompacting(t *testing.T) {
 	update := ReduceRuntimeEvent(
 		RuntimeRunState{Compacting: true},
 		RuntimeConversationState{},
@@ -230,8 +230,8 @@ func TestReduceRuntimeEvent_CompactionCompletedClearsCompactingWithoutSyntheticN
 	if update.RunState.State.Compacting {
 		t.Fatal("expected compaction completed to clear compacting state")
 	}
-	if update.Transcript.SyntheticOngoingEntry != nil {
-		t.Fatalf("did not expect synthetic ongoing compaction notice, got %+v", update.Transcript.SyntheticOngoingEntry)
+	if update.Transcript.Sync.IsSet() || len(update.Transcript.AssistantStream) != 0 {
+		t.Fatalf("expected compaction completed to leave transcript unchanged, got %+v", update.Transcript)
 	}
 }
 

--- a/shared/clientui/types.go
+++ b/shared/clientui/types.go
@@ -113,6 +113,7 @@ type ChatEntry struct {
 	CompactLabel      string
 	ToolResultSummary string
 	ToolCallID        string
+	NoticeID          string
 	ToolCall          *ToolCallMeta
 }
 

--- a/shared/serverapi/runtime_control.go
+++ b/shared/serverapi/runtime_control.go
@@ -65,6 +65,7 @@ type RuntimeAppendLocalEntryRequest struct {
 	Role              string `json:"role"`
 	Text              string `json:"text"`
 	Visibility        string `json:"visibility,omitempty"`
+	NoticeID          string `json:"notice_id,omitempty"`
 }
 
 type RuntimeShouldCompactBeforeUserMessageRequest struct {

--- a/shared/transcript/entry_compare.go
+++ b/shared/transcript/entry_compare.go
@@ -22,6 +22,7 @@ type EntryPayload struct {
 	CompactLabel      string
 	ToolResultSummary string
 	ToolCallID        string
+	NoticeID          string
 	ToolCall          *ToolCallMeta
 }
 
@@ -39,6 +40,7 @@ func EntryPayloadEqual(left, right EntryPayload) bool {
 		strings.TrimSpace(left.CompactLabel) == strings.TrimSpace(right.CompactLabel) &&
 		strings.TrimSpace(left.ToolResultSummary) == strings.TrimSpace(right.ToolResultSummary) &&
 		strings.TrimSpace(left.ToolCallID) == strings.TrimSpace(right.ToolCallID) &&
+		strings.TrimSpace(left.NoticeID) == strings.TrimSpace(right.NoticeID) &&
 		ToolCallMetaEqual(left.ToolCall, right.ToolCall)
 }
 


### PR DESCRIPTION
## Summary
- discard prompt-history drafts for local slash toggle/status commands so previous prompts are not replayed after feedback rows
- add structured notice IDs for mirrored transient status/local transcript entries instead of matching by notice text
- remove dead SyntheticOngoingEntry plumbing and document compaction transcript authority

## Verification
- ./scripts/test.sh ./server/runtimecontrol ./server/runtime ./server/runtimeview ./shared/clientui ./shared/serverapi ./shared/transcript ./cli/tui ./cli/app/commands ./cli/app
- ./scripts/build.sh --output ./bin/builder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notice ID support to distinguish and manage multiple transient status messages.
  * Introduced selective prompt history draft preservation for slash commands like `/thinking`, `/fast`, `/supervisor`, and `/autocompaction`.

* **Improvements**
  * Enhanced feedback messaging for toggle-style commands using mirrored status system.
  * Improved transient status tracking with notice ID-based deduplication.

* **Bug Fixes**
  * Removed synthetic compaction completion notices from appearing in transcript view.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/respawn-app/builder/pull/238)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->