### PR TITLE
refactor: consolidate startup attachment policy

### DIFF
--- a/cli/app/commands/commands.go
+++ b/cli/app/commands/commands.go
@@ -60,9 +60,10 @@ type Result struct {
 type Handler func(args string) Result
 
 type Command struct {
-	Name         string
-	Description  string
-	RunWhileBusy bool
+	Name                       string
+	Description                string
+	RunWhileBusy               bool
+	PreservePromptHistoryDraft bool
 }
 
 type registeredCommand struct {
@@ -99,7 +100,7 @@ func NewDefaultRegistry() *Registry {
 	r.Register("compact", "Compact the current context (optional: /compact <instructions>)", func(args string) Result {
 		return Result{Handled: true, Action: ActionCompact, Args: strings.TrimSpace(args)}
 	})
-	r.RegisterWithOptions("name", "Set session title and terminal title (usage: /name <title>; empty resets)", RegisterOptions{RunWhileBusy: true}, func(args string) Result {
+	r.RegisterWithOptions("name", "Set session title and terminal title (usage: /name <title>; empty resets)", RegisterOptions{RunWhileBusy: true, PreservePromptHistoryDraft: true}, func(args string) Result {
 		return Result{Handled: true, Action: ActionSetName, SessionName: strings.TrimSpace(args)}
 	})
 	r.RegisterWithOptions("thinking", "Set or show thinking level (usage: /thinking <low|medium|high|xhigh>; empty shows current)", RegisterOptions{RunWhileBusy: true}, func(args string) Result {
@@ -114,10 +115,10 @@ func NewDefaultRegistry() *Registry {
 	r.RegisterWithOptions("autocompaction", "Toggle auto-compaction (usage: /autocompaction [on|off]; empty toggles)", RegisterOptions{RunWhileBusy: true}, func(args string) Result {
 		return Result{Handled: true, Action: ActionSetAutoCompaction, AutoCompactionMode: strings.ToLower(strings.TrimSpace(args))}
 	})
-	r.RegisterWithOptions("status", "Open a detailed status overlay for the current session/runtime", RegisterOptions{RunWhileBusy: true}, func(string) Result {
+	r.RegisterWithOptions("status", "Open a detailed status overlay for the current session/runtime", RegisterOptions{RunWhileBusy: true, PreservePromptHistoryDraft: true}, func(string) Result {
 		return Result{Handled: true, Action: ActionStatus}
 	})
-	r.RegisterWithOptions("goal", "Set or manage the current session goal (usage: /goal [show|pause|resume|clear|<objective>])", RegisterOptions{RunWhileBusy: true}, func(args string) Result {
+	r.RegisterWithOptions("goal", "Set or manage the current session goal (usage: /goal [show|pause|resume|clear|<objective>])", RegisterOptions{RunWhileBusy: true, PreservePromptHistoryDraft: true}, func(args string) Result {
 		mode := GoalModeShow
 		objective := strings.TrimSpace(args)
 		switch strings.ToLower(objective) {
@@ -140,14 +141,14 @@ func NewDefaultRegistry() *Registry {
 		}
 		return Result{Handled: true, Action: ActionGoal, GoalMode: mode, GoalObjective: objective}
 	})
-	r.RegisterWithOptions("ps", "List background processes or manage one (usage: /ps [kill|inline|logs] <id>)", RegisterOptions{RunWhileBusy: true}, func(args string) Result {
+	r.RegisterWithOptions("ps", "List background processes or manage one (usage: /ps [kill|inline|logs] <id>)", RegisterOptions{RunWhileBusy: true, PreservePromptHistoryDraft: true}, func(args string) Result {
 		return Result{Handled: true, Action: ActionProcesses, Args: strings.TrimSpace(args)}
 	})
-	r.RegisterWithOptions("worktree", "Manage git worktrees (usage: /worktree [create|switch|delete] ...)", RegisterOptions{}, func(args string) Result {
+	r.RegisterWithOptions("worktree", "Manage git worktrees (usage: /worktree [create|switch|delete] ...)", RegisterOptions{PreservePromptHistoryDraft: true}, func(args string) Result {
 		return Result{Handled: true, Action: ActionWorktree, Args: strings.TrimSpace(args)}
 	})
 	r.RegisterAlias("wt", "worktree")
-	r.RegisterWithOptions("copy", "Copy the last model final answer to the system clipboard", RegisterOptions{RunWhileBusy: true}, func(string) Result {
+	r.RegisterWithOptions("copy", "Copy the last model final answer to the system clipboard", RegisterOptions{RunWhileBusy: true, PreservePromptHistoryDraft: true}, func(string) Result {
 		return Result{Handled: true, Action: ActionCopy}
 	})
 	r.Register("back", "Jump to parent session if current session was spawned from another", func(string) Result {
@@ -171,11 +172,12 @@ func NewDefaultRegistry() *Registry {
 }
 
 type RegisterOptions struct {
-	RunWhileBusy bool
+	RunWhileBusy               bool
+	PreservePromptHistoryDraft bool
 }
 
 func (r *Registry) Register(name string, description string, h Handler) {
-	r.RegisterWithOptions(name, description, RegisterOptions{}, h)
+	r.RegisterWithOptions(name, description, RegisterOptions{PreservePromptHistoryDraft: true}, h)
 }
 
 func (r *Registry) RegisterWithOptions(name string, description string, options RegisterOptions, h Handler) {
@@ -187,7 +189,7 @@ func (r *Registry) RegisterWithOptions(name string, description string, options 
 		return
 	}
 	r.handlers[k] = registeredCommand{
-		command: Command{Name: k, Description: strings.TrimSpace(description), RunWhileBusy: options.RunWhileBusy},
+		command: Command{Name: k, Description: strings.TrimSpace(description), RunWhileBusy: options.RunWhileBusy, PreservePromptHistoryDraft: options.PreservePromptHistoryDraft},
 		handler: h,
 	}
 }

--- a/cli/app/embedded_server.go
+++ b/cli/app/embedded_server.go
@@ -90,6 +90,17 @@ func (s *embeddedAppServer) AuthStatusClient() client.AuthStatusClient {
 	return s.inner.AuthStatusClient()
 }
 
+func (s *embeddedAppServer) AuthBootstrapClient() client.AuthBootstrapClient {
+	if s == nil || s.inner == nil {
+		return nil
+	}
+	return s.inner.AuthBootstrapClient()
+}
+
+func (s *embeddedAppServer) SharesProcessWith(other *embeddedAppServer) bool {
+	return s != nil && other != nil && s.inner == other.inner
+}
+
 func (s *embeddedAppServer) ProjectID() string {
 	if s == nil {
 		return ""
@@ -157,10 +168,17 @@ func (s *embeddedAppServer) SessionLifecycleClient() client.SessionLifecycleClie
 	return s.inner.SessionLifecycleClient()
 }
 
+func (s *embeddedAppServer) RunPromptClient() client.RunPromptClient {
+	if s == nil || s.inner == nil {
+		return nil
+	}
+	return s.inner.RunPromptClient()
+}
+
 func (s *embeddedAppServer) Reauthenticate(ctx context.Context, interactor authInteractor) error {
 	if s == nil || s.inner == nil {
 		return errors.New("embedded server is required")
 	}
 	cfg := s.inner.Config()
-	return ensureRemoteAuthReady(ctx, s.inner.AuthBootstrapClient(), cfg.Settings, interactor)
+	return ensureRemoteAuthReady(ctx, s.AuthBootstrapClient(), cfg.Settings, interactor)
 }

--- a/cli/app/headless_prompt_server_test.go
+++ b/cli/app/headless_prompt_server_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 func newHeadlessRunPromptClient(server *embeddedAppServer) client.RunPromptClient {
-	runPrompt, err := runPromptClientForEmbeddedServer(server)
+	target, err := runPromptTargetForEmbeddedAttachment(server)
 	if err != nil {
 		panic(err)
 	}
-	return runPrompt
+	return target.Value.Client
 }
 
 func ensureSubagentSessionName(store *session.Store) error {

--- a/cli/app/internal/serverattach/attach.go
+++ b/cli/app/internal/serverattach/attach.go
@@ -1,0 +1,310 @@
+package serverattach
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"builder/cli/app/internal/remoteattach"
+	"builder/shared/client"
+	"builder/shared/config"
+	"builder/shared/protocol"
+)
+
+type Mode string
+
+const (
+	ModeInteractive Mode = "interactive"
+	ModeHeadless    Mode = "headless"
+)
+
+type ProjectViewRemote = remoteattach.ProjectViewRemote
+
+type Source string
+
+const (
+	SourceConfiguredRemote Source = "configured_remote"
+	SourceLaunchedDaemon   Source = "launched_daemon"
+	SourceEmbeddedFallback Source = "embedded_fallback"
+)
+
+type WorkspaceBindingState string
+
+const (
+	WorkspaceBindingUnknown             WorkspaceBindingState = "unknown"
+	WorkspaceBindingInteractiveOptional WorkspaceBindingState = "interactive_optional"
+	WorkspaceBindingInteractiveRequired WorkspaceBindingState = "interactive_required"
+	WorkspaceBindingHeadlessRequired    WorkspaceBindingState = "headless_required"
+)
+
+type OwnershipState string
+
+const (
+	OwnershipExternalDaemon OwnershipState = "external_daemon"
+	OwnershipLaunchedDaemon OwnershipState = "launched_daemon"
+	OwnershipEmbedded       OwnershipState = "embedded"
+)
+
+type CapabilityCompatibility string
+
+const (
+	CapabilityCompatibilityUnchecked    CapabilityCompatibility = "unchecked"
+	CapabilityCompatibilityCompatible   CapabilityCompatibility = "compatible"
+	CapabilityCompatibilityIncompatible CapabilityCompatibility = "incompatible"
+)
+
+type AuthReadiness string
+
+const (
+	AuthReadinessUnchecked AuthReadiness = "unchecked"
+	AuthReadinessValidated AuthReadiness = "validated"
+)
+
+type RemotePolicy struct {
+	Config           config.App
+	AttachTimeout    time.Duration
+	DiscoveryTimeout time.Duration
+	DialProjectView  remoteattach.DialProjectView
+	DialWorkspace    remoteattach.DialWorkspace
+	Supports         remoteattach.Supports
+	RequireBound     bool
+}
+
+type Target[T any] struct {
+	Value T
+	Close func() error
+}
+
+type DaemonTarget[T any] struct {
+	Value T
+	Close func() error
+}
+
+type Resolution[T any] struct {
+	Value                 T
+	Close                 func() error
+	Mode                  Mode
+	Source                Source
+	Config                config.App
+	WorkspaceBindingState WorkspaceBindingState
+	Ownership             OwnershipState
+	Capability            CapabilityCompatibility
+	Auth                  AuthReadiness
+}
+
+type LaunchedRemoteDialer func(context.Context, remoteattach.Accept) (*client.Remote, bool, error)
+
+type Request[T any] struct {
+	Mode          Mode
+	Remote        RemotePolicy
+	BypassRemote  func(context.Context) (bool, error)
+	LaunchDaemon  func(context.Context, LaunchedRemoteDialer) (DaemonTarget[*client.Remote], bool, error)
+	WrapRemote    func(*client.Remote, config.App, func() error) (Target[T], error)
+	StartEmbedded func(context.Context) (Target[T], error)
+	Validate      func(context.Context, Resolution[T]) (AuthReadiness, error)
+}
+
+func Resolve[T any](ctx context.Context, req Request[T]) (Resolution[T], error) {
+	if req.StartEmbedded == nil {
+		return Resolution[T]{}, errors.New("embedded target starter is required")
+	}
+	bypass, err := callBypassRemote(ctx, req.BypassRemote)
+	if err != nil {
+		return Resolution[T]{}, err
+	}
+	if bypass {
+		return startEmbedded(ctx, req, nil, CapabilityCompatibilityUnchecked)
+	}
+	capability := CapabilityCompatibilityUnchecked
+	if candidate, ok, err := dialConfiguredRemote(ctx, req, &capability); err != nil {
+		return Resolution[T]{}, err
+	} else if ok {
+		return validateResolution(ctx, req, candidate)
+	}
+	launchErr := error(nil)
+	if candidate, ok, err := launchDaemon(ctx, req, &capability); err != nil {
+		launchErr = err
+	} else if ok {
+		return validateResolution(ctx, req, candidate)
+	}
+	return startEmbedded(ctx, req, launchErr, capability)
+}
+
+func DialRemote(ctx context.Context, mode Mode, policy RemotePolicy, accept remoteattach.Accept) (*client.Remote, bool, error) {
+	remote, ok, err, _ := dialRemote(ctx, mode, policy, accept)
+	return remote, ok, err
+}
+
+func dialRemote(ctx context.Context, mode Mode, policy RemotePolicy, accept remoteattach.Accept) (*client.Remote, bool, error, CapabilityCompatibility) {
+	capability := CapabilityCompatibilityUnchecked
+	supports := policy.Supports
+	if supports != nil {
+		supports = func(flags protocol.CapabilityFlags) bool {
+			if policy.Supports(flags) {
+				capability = CapabilityCompatibilityCompatible
+				return true
+			}
+			capability = CapabilityCompatibilityIncompatible
+			return false
+		}
+	}
+	switch mode {
+	case ModeInteractive:
+		remote, ok := remoteattach.DialInteractive(ctx, remoteattach.InteractiveRequest{
+			Config:          policy.Config,
+			AttachTimeout:   policy.AttachTimeout,
+			DialProjectView: policy.DialProjectView,
+			DialWorkspace:   policy.DialWorkspace,
+			Accept:          accept,
+			Supports:        supports,
+			RequireBound:    policy.RequireBound,
+		})
+		return remote, ok, nil, capability
+	case ModeHeadless:
+		remote, ok, err := remoteattach.DialHeadless(ctx, remoteattach.HeadlessRequest{
+			Config:           policy.Config,
+			AttachTimeout:    policy.AttachTimeout,
+			DiscoveryTimeout: policy.DiscoveryTimeout,
+			DialProjectView:  policy.DialProjectView,
+			DialWorkspace:    policy.DialWorkspace,
+			Accept:           accept,
+			Supports:         supports,
+		})
+		return remote, ok, err, capability
+	default:
+		return nil, false, errors.New("unsupported server attachment mode"), capability
+	}
+}
+
+func callBypassRemote(ctx context.Context, fn func(context.Context) (bool, error)) (bool, error) {
+	if fn == nil {
+		return false, nil
+	}
+	return fn(ctx)
+}
+
+func dialConfiguredRemote[T any](ctx context.Context, req Request[T], capability *CapabilityCompatibility) (Resolution[T], bool, error) {
+	remote, ok, err, checkedCapability := dialRemote(ctx, req.Mode, req.Remote, nil)
+	recordCapability(capability, checkedCapability)
+	if err != nil || !ok {
+		return Resolution[T]{}, ok, err
+	}
+	target, err := wrapRemote(req, remote, remote.Close)
+	if err != nil {
+		_ = remote.Close()
+		return Resolution[T]{}, false, err
+	}
+	return newResolution(req, SourceConfiguredRemote, OwnershipExternalDaemon, target, valueCapability(capability)), true, nil
+}
+
+func launchDaemon[T any](ctx context.Context, req Request[T], capability *CapabilityCompatibility) (Resolution[T], bool, error) {
+	if req.LaunchDaemon == nil {
+		return Resolution[T]{}, false, nil
+	}
+	daemon, ok, err := req.LaunchDaemon(ctx, func(ctx context.Context, accept remoteattach.Accept) (*client.Remote, bool, error) {
+		remote, ok, err, checkedCapability := dialRemote(ctx, req.Mode, req.Remote, accept)
+		recordCapability(capability, checkedCapability)
+		return remote, ok, err
+	})
+	if err != nil || !ok {
+		return Resolution[T]{}, ok, err
+	}
+	target, err := wrapRemote(req, daemon.Value, daemon.Close)
+	if err != nil {
+		closeTarget(DaemonTarget[*client.Remote]{Close: daemon.Close})
+		return Resolution[T]{}, false, err
+	}
+	return newResolution(req, SourceLaunchedDaemon, OwnershipLaunchedDaemon, target, valueCapability(capability)), true, nil
+}
+
+func wrapRemote[T any](req Request[T], remote *client.Remote, closeFn func() error) (Target[T], error) {
+	if req.WrapRemote == nil {
+		return Target[T]{}, errors.New("remote target wrapper is required")
+	}
+	target, err := req.WrapRemote(remote, req.Remote.Config, closeFn)
+	if err != nil {
+		return Target[T]{}, err
+	}
+	if target.Close == nil {
+		target.Close = closeFn
+	}
+	return target, nil
+}
+
+func startEmbedded[T any](ctx context.Context, req Request[T], launchErr error, capability CapabilityCompatibility) (Resolution[T], error) {
+	target, err := req.StartEmbedded(ctx)
+	if err != nil {
+		if launchErr != nil {
+			return Resolution[T]{}, errors.Join(launchErr, err)
+		}
+		return Resolution[T]{}, err
+	}
+	return validateResolution(ctx, req, newResolution(req, SourceEmbeddedFallback, OwnershipEmbedded, target, capability))
+}
+
+func validateResolution[T any](ctx context.Context, req Request[T], resolution Resolution[T]) (Resolution[T], error) {
+	if req.Validate == nil {
+		return resolution, nil
+	}
+	auth, err := req.Validate(ctx, resolution)
+	if err != nil {
+		closeResolution(resolution)
+		return Resolution[T]{}, err
+	}
+	resolution.Auth = auth
+	return resolution, nil
+}
+
+func newResolution[T any](req Request[T], source Source, ownership OwnershipState, target Target[T], capability CapabilityCompatibility) Resolution[T] {
+	return Resolution[T]{
+		Value:                 target.Value,
+		Close:                 target.Close,
+		Mode:                  req.Mode,
+		Source:                source,
+		Config:                req.Remote.Config,
+		WorkspaceBindingState: workspaceBindingState(req.Mode, req.Remote.RequireBound),
+		Ownership:             ownership,
+		Capability:            capability,
+		Auth:                  AuthReadinessUnchecked,
+	}
+}
+
+func recordCapability(target *CapabilityCompatibility, checked CapabilityCompatibility) {
+	if target == nil || checked == CapabilityCompatibilityUnchecked {
+		return
+	}
+	*target = checked
+}
+
+func valueCapability(capability *CapabilityCompatibility) CapabilityCompatibility {
+	if capability == nil {
+		return CapabilityCompatibilityUnchecked
+	}
+	return *capability
+}
+
+func workspaceBindingState(mode Mode, requireBound bool) WorkspaceBindingState {
+	switch mode {
+	case ModeHeadless:
+		return WorkspaceBindingHeadlessRequired
+	case ModeInteractive:
+		if requireBound {
+			return WorkspaceBindingInteractiveRequired
+		}
+		return WorkspaceBindingInteractiveOptional
+	default:
+		return WorkspaceBindingUnknown
+	}
+}
+
+func closeResolution[T any](resolution Resolution[T]) {
+	if resolution.Close != nil {
+		_ = resolution.Close()
+	}
+}
+
+func closeTarget[T any](target DaemonTarget[T]) {
+	if target.Close != nil {
+		_ = target.Close()
+	}
+}

--- a/cli/app/internal/serverattach/attach_test.go
+++ b/cli/app/internal/serverattach/attach_test.go
@@ -1,0 +1,656 @@
+package serverattach
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"builder/cli/app/internal/remoteattach"
+	"builder/shared/client"
+	"builder/shared/config"
+	"builder/shared/protocol"
+	"builder/shared/serverapi"
+)
+
+type projectViewRemoteStub struct {
+	identity protocol.ServerIdentity
+	plan     func(context.Context, serverapi.ProjectBindingPlanRequest) (serverapi.ProjectBindingPlanResponse, error)
+	closed   bool
+}
+
+func (s *projectViewRemoteStub) Close() error {
+	s.closed = true
+	return nil
+}
+
+func (s *projectViewRemoteStub) Identity() protocol.ServerIdentity {
+	return s.identity
+}
+
+func (s *projectViewRemoteStub) PlanWorkspaceBinding(ctx context.Context, req serverapi.ProjectBindingPlanRequest) (serverapi.ProjectBindingPlanResponse, error) {
+	if s.plan != nil {
+		return s.plan(ctx, req)
+	}
+	return serverapi.ProjectBindingPlanResponse{}, errors.New("unexpected PlanWorkspaceBinding call")
+}
+
+func (*projectViewRemoteStub) ListProjects(context.Context, serverapi.ProjectListRequest) (serverapi.ProjectListResponse, error) {
+	return serverapi.ProjectListResponse{}, errors.New("unexpected ListProjects call")
+}
+
+func (*projectViewRemoteStub) ResolveProjectPath(context.Context, serverapi.ProjectResolvePathRequest) (serverapi.ProjectResolvePathResponse, error) {
+	return serverapi.ProjectResolvePathResponse{}, errors.New("unexpected ResolveProjectPath call")
+}
+
+func (*projectViewRemoteStub) CreateProject(context.Context, serverapi.ProjectCreateRequest) (serverapi.ProjectCreateResponse, error) {
+	return serverapi.ProjectCreateResponse{}, errors.New("unexpected CreateProject call")
+}
+
+func (*projectViewRemoteStub) AttachWorkspaceToProject(context.Context, serverapi.ProjectAttachWorkspaceRequest) (serverapi.ProjectAttachWorkspaceResponse, error) {
+	return serverapi.ProjectAttachWorkspaceResponse{}, errors.New("unexpected AttachWorkspaceToProject call")
+}
+
+func (*projectViewRemoteStub) RebindWorkspace(context.Context, serverapi.ProjectRebindWorkspaceRequest) (serverapi.ProjectRebindWorkspaceResponse, error) {
+	return serverapi.ProjectRebindWorkspaceResponse{}, errors.New("unexpected RebindWorkspace call")
+}
+
+func (*projectViewRemoteStub) GetProjectOverview(context.Context, serverapi.ProjectGetOverviewRequest) (serverapi.ProjectGetOverviewResponse, error) {
+	return serverapi.ProjectGetOverviewResponse{}, errors.New("unexpected GetProjectOverview call")
+}
+
+func (*projectViewRemoteStub) ListSessionsByProject(context.Context, serverapi.SessionListByProjectRequest) (serverapi.SessionListByProjectResponse, error) {
+	return serverapi.SessionListByProjectResponse{}, errors.New("unexpected ListSessionsByProject call")
+}
+
+func allCapabilities() protocol.CapabilityFlags {
+	return protocol.CapabilityFlags{
+		AuthBootstrap:           true,
+		ProjectAttach:           true,
+		RunPrompt:               true,
+		SessionPlan:             true,
+		SessionLifecycle:        true,
+		SessionTranscriptPaging: true,
+		SessionRuntime:          true,
+		RuntimeControl:          true,
+		PromptControl:           true,
+		PromptActivity:          true,
+		SessionActivity:         true,
+		ProcessOutput:           true,
+	}
+}
+
+func boundPlanResponse() serverapi.ProjectBindingPlanResponse {
+	return serverapi.ProjectBindingPlanResponse{
+		Kind:    serverapi.ProjectBindingPlanKindBound,
+		Binding: &serverapi.ProjectBinding{ProjectID: "project-1", WorkspaceID: "workspace-1"},
+	}
+}
+
+func boundProjectView(plan func(context.Context, serverapi.ProjectBindingPlanRequest) (serverapi.ProjectBindingPlanResponse, error)) *projectViewRemoteStub {
+	return &projectViewRemoteStub{
+		identity: protocol.ServerIdentity{Capabilities: allCapabilities()},
+		plan:     plan,
+	}
+}
+
+func TestResolveUsesSharedRemoteDaemonEmbeddedPolicyByMode(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		mode        Mode
+		planMode    serverapi.ProjectBindingPlanMode
+		planKind    serverapi.ProjectBindingPlanKind
+		requireBind bool
+		wantBinding WorkspaceBindingState
+	}{
+		{
+			name:        "interactive uses optional registration policy",
+			mode:        ModeInteractive,
+			planMode:    serverapi.ProjectBindingPlanModeInteractive,
+			planKind:    serverapi.ProjectBindingPlanKindBound,
+			requireBind: false,
+			wantBinding: WorkspaceBindingInteractiveOptional,
+		},
+		{
+			name:        "interactive daemon launch can require registered binding",
+			mode:        ModeInteractive,
+			planMode:    serverapi.ProjectBindingPlanModeInteractive,
+			planKind:    serverapi.ProjectBindingPlanKindBound,
+			requireBind: true,
+			wantBinding: WorkspaceBindingInteractiveRequired,
+		},
+		{
+			name:        "headless requires server binding policy",
+			mode:        ModeHeadless,
+			planMode:    serverapi.ProjectBindingPlanModeHeadless,
+			planKind:    serverapi.ProjectBindingPlanKindBound,
+			requireBind: true,
+			wantBinding: WorkspaceBindingHeadlessRequired,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.App{WorkspaceRoot: "/workspace"}
+			var modes []serverapi.ProjectBindingPlanMode
+			resolution, err := Resolve[string](context.Background(), Request[string]{
+				Mode: tc.mode,
+				Remote: RemotePolicy{
+					Config:        cfg,
+					AttachTimeout: time.Second,
+					DialProjectView: func(context.Context, config.App) (ProjectViewRemote, error) {
+						return &projectViewRemoteStub{
+							identity: protocol.ServerIdentity{Capabilities: protocol.CapabilityFlags{
+								AuthBootstrap:           true,
+								ProjectAttach:           true,
+								RunPrompt:               true,
+								SessionPlan:             true,
+								SessionLifecycle:        true,
+								SessionTranscriptPaging: true,
+								SessionRuntime:          true,
+								RuntimeControl:          true,
+								PromptControl:           true,
+								PromptActivity:          true,
+								SessionActivity:         true,
+								ProcessOutput:           true,
+							}},
+							plan: func(_ context.Context, req serverapi.ProjectBindingPlanRequest) (serverapi.ProjectBindingPlanResponse, error) {
+								modes = append(modes, req.Mode)
+								if tc.planKind == serverapi.ProjectBindingPlanKindBound {
+									return serverapi.ProjectBindingPlanResponse{
+										Kind:    tc.planKind,
+										Binding: &serverapi.ProjectBinding{ProjectID: "project-1", WorkspaceID: "workspace-1"},
+									}, nil
+								}
+								return serverapi.ProjectBindingPlanResponse{Kind: tc.planKind}, nil
+							},
+						}, nil
+					},
+					DialWorkspace: func(context.Context, config.App, string, string) (*client.Remote, error) {
+						return new(client.Remote), nil
+					},
+					Supports:     func(protocol.CapabilityFlags) bool { return true },
+					RequireBound: tc.requireBind,
+				},
+				WrapRemote: func(_ *client.Remote, _ config.App, _ func() error) (Target[string], error) {
+					return Target[string]{Value: "remote"}, nil
+				},
+				StartEmbedded: func(context.Context) (Target[string], error) {
+					return Target[string]{Value: "embedded"}, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if resolution.Value != "remote" {
+				t.Fatalf("value = %q, want remote", resolution.Value)
+			}
+			if resolution.Mode != tc.mode {
+				t.Fatalf("mode = %q, want %q", resolution.Mode, tc.mode)
+			}
+			if resolution.WorkspaceBindingState != tc.wantBinding {
+				t.Fatalf("binding = %q, want %q", resolution.WorkspaceBindingState, tc.wantBinding)
+			}
+			if !reflect.DeepEqual(modes, []serverapi.ProjectBindingPlanMode{tc.planMode}) {
+				t.Fatalf("plan modes = %v, want %v", modes, []serverapi.ProjectBindingPlanMode{tc.planMode})
+			}
+		})
+	}
+}
+
+func TestResolveLaunchesDaemonWithSameRemoteAttachmentPolicy(t *testing.T) {
+	acceptedPID := 0
+	dialProjectView := func(context.Context, config.App) (ProjectViewRemote, error) {
+		return &projectViewRemoteStub{
+			identity: protocol.ServerIdentity{PID: 42, Capabilities: protocol.CapabilityFlags{RunPrompt: true, AuthBootstrap: true, ProjectAttach: true}},
+			plan: func(_ context.Context, _ serverapi.ProjectBindingPlanRequest) (serverapi.ProjectBindingPlanResponse, error) {
+				return serverapi.ProjectBindingPlanResponse{
+					Kind:    serverapi.ProjectBindingPlanKindBound,
+					Binding: &serverapi.ProjectBinding{ProjectID: "project-1", WorkspaceID: "workspace-1"},
+				}, nil
+			},
+		}, nil
+	}
+	resolution, err := Resolve[string](context.Background(), Request[string]{
+		Mode: ModeHeadless,
+		Remote: RemotePolicy{
+			Config:           config.App{WorkspaceRoot: "/workspace"},
+			AttachTimeout:    time.Second,
+			DiscoveryTimeout: time.Second,
+			DialProjectView:  dialProjectView,
+			DialWorkspace: func(context.Context, config.App, string, string) (*client.Remote, error) {
+				return new(client.Remote), nil
+			},
+			Supports: func(protocol.CapabilityFlags) bool { return true },
+		},
+		LaunchDaemon: func(ctx context.Context, dial LaunchedRemoteDialer) (DaemonTarget[*client.Remote], bool, error) {
+			remote, ok, err := dial(ctx, func(identity protocol.ServerIdentity) bool {
+				acceptedPID = identity.PID
+				return identity.PID == 42
+			})
+			return DaemonTarget[*client.Remote]{Value: remote}, ok, err
+		},
+		WrapRemote: func(_ *client.Remote, _ config.App, _ func() error) (Target[string], error) {
+			return Target[string]{Value: "daemon"}, nil
+		},
+		StartEmbedded: func(context.Context) (Target[string], error) {
+			return Target[string]{Value: "embedded"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolution.Source != SourceConfiguredRemote {
+		t.Fatalf("source = %q, want configured remote before daemon", resolution.Source)
+	}
+
+	acceptedPID = 0
+	dialAttempts := 0
+	resolution, err = Resolve[string](context.Background(), Request[string]{
+		Mode: ModeHeadless,
+		Remote: RemotePolicy{
+			Config:           config.App{WorkspaceRoot: "/workspace"},
+			AttachTimeout:    time.Second,
+			DiscoveryTimeout: time.Second,
+			DialProjectView: func(context.Context, config.App) (ProjectViewRemote, error) {
+				dialAttempts++
+				if dialAttempts == 1 {
+					return nil, errors.New("configured remote unavailable")
+				}
+				return dialProjectView(context.Background(), config.App{})
+			},
+			DialWorkspace: func(context.Context, config.App, string, string) (*client.Remote, error) {
+				return new(client.Remote), nil
+			},
+			Supports: func(protocol.CapabilityFlags) bool { return true },
+		},
+		LaunchDaemon: func(ctx context.Context, dial LaunchedRemoteDialer) (DaemonTarget[*client.Remote], bool, error) {
+			remote, ok, err := dial(ctx, func(identity protocol.ServerIdentity) bool {
+				acceptedPID = identity.PID
+				return identity.PID == 42
+			})
+			return DaemonTarget[*client.Remote]{Value: remote}, ok, err
+		},
+		WrapRemote: func(_ *client.Remote, _ config.App, _ func() error) (Target[string], error) {
+			return Target[string]{Value: "daemon"}, nil
+		},
+		StartEmbedded: func(context.Context) (Target[string], error) {
+			return Target[string]{Value: "embedded"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve with daemon path: %v", err)
+	}
+	if resolution.Source != SourceLaunchedDaemon {
+		t.Fatalf("source = %q, want launched daemon", resolution.Source)
+	}
+	if acceptedPID != 42 {
+		t.Fatalf("accepted pid = %d, want 42", acceptedPID)
+	}
+}
+
+func TestResolveTargetResolutionPolicyTable(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		mode           Mode
+		dialProject    func(*testing.T, *string) func(context.Context, config.App) (ProjectViewRemote, error)
+		launchDaemon   func(context.Context, LaunchedRemoteDialer) (DaemonTarget[*client.Remote], bool, error)
+		supports       remoteattach.Supports
+		wantSource     Source
+		wantCapability CapabilityCompatibility
+		wantErr        error
+		wantDialTarget string
+	}{
+		{
+			name: "interactive configured remote available",
+			mode: ModeInteractive,
+			dialProject: func(t *testing.T, _ *string) func(context.Context, config.App) (ProjectViewRemote, error) {
+				t.Helper()
+				return func(context.Context, config.App) (ProjectViewRemote, error) {
+					return boundProjectView(func(context.Context, serverapi.ProjectBindingPlanRequest) (serverapi.ProjectBindingPlanResponse, error) {
+						return boundPlanResponse(), nil
+					}), nil
+				}
+			},
+			supports:       func(protocol.CapabilityFlags) bool { return true },
+			wantSource:     SourceConfiguredRemote,
+			wantCapability: CapabilityCompatibilityCompatible,
+		},
+		{
+			name: "headless configured remote unavailable launches daemon",
+			mode: ModeHeadless,
+			dialProject: func(t *testing.T, _ *string) func(context.Context, config.App) (ProjectViewRemote, error) {
+				t.Helper()
+				attempts := 0
+				return func(context.Context, config.App) (ProjectViewRemote, error) {
+					attempts++
+					if attempts == 1 {
+						return nil, errors.New("configured remote unavailable")
+					}
+					return boundProjectView(func(context.Context, serverapi.ProjectBindingPlanRequest) (serverapi.ProjectBindingPlanResponse, error) {
+						return boundPlanResponse(), nil
+					}), nil
+				}
+			},
+			launchDaemon: func(ctx context.Context, dial LaunchedRemoteDialer) (DaemonTarget[*client.Remote], bool, error) {
+				remote, ok, err := dial(ctx, nil)
+				return DaemonTarget[*client.Remote]{Value: remote}, ok, err
+			},
+			supports:       func(protocol.CapabilityFlags) bool { return true },
+			wantSource:     SourceLaunchedDaemon,
+			wantCapability: CapabilityCompatibilityCompatible,
+		},
+		{
+			name: "headless incompatible capabilities falls back embedded",
+			mode: ModeHeadless,
+			dialProject: func(t *testing.T, _ *string) func(context.Context, config.App) (ProjectViewRemote, error) {
+				t.Helper()
+				return func(context.Context, config.App) (ProjectViewRemote, error) {
+					return boundProjectView(func(context.Context, serverapi.ProjectBindingPlanRequest) (serverapi.ProjectBindingPlanResponse, error) {
+						t.Fatal("unsupported remote should be skipped before workspace planning")
+						return serverapi.ProjectBindingPlanResponse{}, nil
+					}), nil
+				}
+			},
+			supports:       func(protocol.CapabilityFlags) bool { return false },
+			wantSource:     SourceEmbeddedFallback,
+			wantCapability: CapabilityCompatibilityIncompatible,
+		},
+		{
+			name: "interactive daemon launch failure falls back embedded",
+			mode: ModeInteractive,
+			dialProject: func(t *testing.T, _ *string) func(context.Context, config.App) (ProjectViewRemote, error) {
+				t.Helper()
+				return func(context.Context, config.App) (ProjectViewRemote, error) {
+					return nil, errors.New("configured remote unavailable")
+				}
+			},
+			launchDaemon: func(context.Context, LaunchedRemoteDialer) (DaemonTarget[*client.Remote], bool, error) {
+				return DaemonTarget[*client.Remote]{}, false, errors.New("daemon launch failed")
+			},
+			supports:       func(protocol.CapabilityFlags) bool { return true },
+			wantSource:     SourceEmbeddedFallback,
+			wantCapability: CapabilityCompatibilityUnchecked,
+		},
+		{
+			name: "headless unregistered workspace fails fast",
+			mode: ModeHeadless,
+			dialProject: func(t *testing.T, _ *string) func(context.Context, config.App) (ProjectViewRemote, error) {
+				t.Helper()
+				return func(context.Context, config.App) (ProjectViewRemote, error) {
+					return boundProjectView(func(context.Context, serverapi.ProjectBindingPlanRequest) (serverapi.ProjectBindingPlanResponse, error) {
+						return serverapi.ProjectBindingPlanResponse{Kind: serverapi.ProjectBindingPlanKindLocalUnbound}, nil
+					}), nil
+				}
+			},
+			supports: func(protocol.CapabilityFlags) bool { return true },
+			wantErr:  serverapi.ErrWorkspaceNotRegistered,
+		},
+		{
+			name: "headless remote workspace selection dials selected workspace",
+			mode: ModeHeadless,
+			dialProject: func(t *testing.T, _ *string) func(context.Context, config.App) (ProjectViewRemote, error) {
+				t.Helper()
+				return func(context.Context, config.App) (ProjectViewRemote, error) {
+					return boundProjectView(func(context.Context, serverapi.ProjectBindingPlanRequest) (serverapi.ProjectBindingPlanResponse, error) {
+						return serverapi.ProjectBindingPlanResponse{
+							Kind:      serverapi.ProjectBindingPlanKindHeadlessRemoteSelected,
+							Workspace: &serverapi.ProjectWorkspacePlanSelected{ProjectID: "remote-project", WorkspaceID: "remote-workspace"},
+						}, nil
+					}), nil
+				}
+			},
+			supports:       func(protocol.CapabilityFlags) bool { return true },
+			wantSource:     SourceConfiguredRemote,
+			wantCapability: CapabilityCompatibilityCompatible,
+			wantDialTarget: "remote-project/remote-workspace",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dialTarget := ""
+			resolution, err := Resolve[string](context.Background(), Request[string]{
+				Mode: tc.mode,
+				Remote: RemotePolicy{
+					Config:           config.App{WorkspaceRoot: "/workspace"},
+					AttachTimeout:    time.Second,
+					DiscoveryTimeout: time.Second,
+					DialProjectView:  tc.dialProject(t, &dialTarget),
+					DialWorkspace: func(_ context.Context, _ config.App, projectID string, workspaceID string) (*client.Remote, error) {
+						dialTarget = projectID + "/" + workspaceID
+						return new(client.Remote), nil
+					},
+					Supports:     tc.supports,
+					RequireBound: tc.mode == ModeHeadless,
+				},
+				LaunchDaemon: tc.launchDaemon,
+				WrapRemote: func(_ *client.Remote, _ config.App, _ func() error) (Target[string], error) {
+					return Target[string]{Value: "remote"}, nil
+				},
+				StartEmbedded: func(context.Context) (Target[string], error) {
+					return Target[string]{Value: "embedded"}, nil
+				},
+			})
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("Resolve error = %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if resolution.Source != tc.wantSource {
+				t.Fatalf("source = %q, want %q", resolution.Source, tc.wantSource)
+			}
+			if resolution.Capability != tc.wantCapability {
+				t.Fatalf("capability = %q, want %q", resolution.Capability, tc.wantCapability)
+			}
+			if tc.wantDialTarget != "" && dialTarget != tc.wantDialTarget {
+				t.Fatalf("workspace dial target = %q, want %q", dialTarget, tc.wantDialTarget)
+			}
+		})
+	}
+}
+
+func TestResolveRecordsAuthReadinessFromValidation(t *testing.T) {
+	resolution, err := Resolve[string](context.Background(), Request[string]{
+		Mode: ModeInteractive,
+		Remote: RemotePolicy{
+			Config:        config.App{WorkspaceRoot: "/workspace"},
+			AttachTimeout: time.Second,
+			DialProjectView: func(context.Context, config.App) (ProjectViewRemote, error) {
+				return boundProjectView(func(context.Context, serverapi.ProjectBindingPlanRequest) (serverapi.ProjectBindingPlanResponse, error) {
+					return boundPlanResponse(), nil
+				}), nil
+			},
+			DialWorkspace: func(context.Context, config.App, string, string) (*client.Remote, error) {
+				return new(client.Remote), nil
+			},
+			Supports: func(protocol.CapabilityFlags) bool { return true },
+		},
+		WrapRemote: func(_ *client.Remote, _ config.App, _ func() error) (Target[string], error) {
+			return Target[string]{Value: "remote"}, nil
+		},
+		StartEmbedded: func(context.Context) (Target[string], error) {
+			return Target[string]{Value: "embedded"}, nil
+		},
+		Validate: func(context.Context, Resolution[string]) (AuthReadiness, error) {
+			return AuthReadinessValidated, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolution.Auth != AuthReadinessValidated {
+		t.Fatalf("auth readiness = %q, want %q", resolution.Auth, AuthReadinessValidated)
+	}
+	if resolution.Capability != CapabilityCompatibilityCompatible {
+		t.Fatalf("capability = %q, want %q", resolution.Capability, CapabilityCompatibilityCompatible)
+	}
+}
+
+func TestResolveClosesOwnedTargetOnValidationFailure(t *testing.T) {
+	wantErr := errors.New("auth bootstrap required")
+	for _, tc := range []struct {
+		name string
+		req  func(*int) Request[string]
+	}{
+		{
+			name: "configured remote",
+			req: func(closed *int) Request[string] {
+				return Request[string]{
+					Mode: ModeInteractive,
+					Remote: RemotePolicy{
+						Config:        config.App{WorkspaceRoot: "/workspace"},
+						AttachTimeout: time.Second,
+						DialProjectView: func(context.Context, config.App) (ProjectViewRemote, error) {
+							return boundProjectView(func(context.Context, serverapi.ProjectBindingPlanRequest) (serverapi.ProjectBindingPlanResponse, error) {
+								return boundPlanResponse(), nil
+							}), nil
+						},
+						DialWorkspace: func(context.Context, config.App, string, string) (*client.Remote, error) {
+							return new(client.Remote), nil
+						},
+						Supports: func(protocol.CapabilityFlags) bool { return true },
+					},
+					WrapRemote: func(_ *client.Remote, _ config.App, _ func() error) (Target[string], error) {
+						return Target[string]{Value: "remote", Close: func() error {
+							*closed = *closed + 1
+							return nil
+						}}, nil
+					},
+					StartEmbedded: func(context.Context) (Target[string], error) {
+						return Target[string]{Value: "embedded"}, nil
+					},
+				}
+			},
+		},
+		{
+			name: "launched daemon",
+			req: func(closed *int) Request[string] {
+				return Request[string]{
+					Mode: ModeInteractive,
+					Remote: RemotePolicy{
+						Config:           config.App{WorkspaceRoot: "/workspace"},
+						AttachTimeout:    time.Second,
+						DiscoveryTimeout: time.Second,
+						DialProjectView: func(context.Context, config.App) (ProjectViewRemote, error) {
+							return nil, errors.New("configured remote unavailable")
+						},
+						DialWorkspace: func(context.Context, config.App, string, string) (*client.Remote, error) {
+							return new(client.Remote), nil
+						},
+						Supports: func(protocol.CapabilityFlags) bool { return true },
+					},
+					LaunchDaemon: func(context.Context, LaunchedRemoteDialer) (DaemonTarget[*client.Remote], bool, error) {
+						return DaemonTarget[*client.Remote]{Value: new(client.Remote)}, true, nil
+					},
+					WrapRemote: func(_ *client.Remote, _ config.App, _ func() error) (Target[string], error) {
+						return Target[string]{Value: "daemon", Close: func() error {
+							*closed = *closed + 1
+							return nil
+						}}, nil
+					},
+					StartEmbedded: func(context.Context) (Target[string], error) {
+						return Target[string]{Value: "embedded"}, nil
+					},
+				}
+			},
+		},
+		{
+			name: "embedded fallback",
+			req: func(closed *int) Request[string] {
+				return Request[string]{
+					Mode: ModeInteractive,
+					Remote: RemotePolicy{
+						Config: config.App{WorkspaceRoot: "/workspace"},
+						DialProjectView: func(context.Context, config.App) (ProjectViewRemote, error) {
+							return nil, errors.New("configured remote unavailable")
+						},
+					},
+					StartEmbedded: func(context.Context) (Target[string], error) {
+						return Target[string]{Value: "embedded", Close: func() error {
+							*closed = *closed + 1
+							return nil
+						}}, nil
+					},
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			closed := 0
+			req := tc.req(&closed)
+			req.Validate = func(context.Context, Resolution[string]) (AuthReadiness, error) {
+				return AuthReadinessUnchecked, wantErr
+			}
+			_, err := Resolve[string](context.Background(), req)
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("Resolve error = %v, want %v", err, wantErr)
+			}
+			if closed != 1 {
+				t.Fatalf("closed = %d, want 1", closed)
+			}
+		})
+	}
+}
+
+func TestResolveDaemonWrapFailureClosesDaemonThenFallsBackEmbedded(t *testing.T) {
+	wrapErr := errors.New("wrap failed")
+	closed := 0
+	resolution, err := Resolve[string](context.Background(), Request[string]{
+		Mode: ModeInteractive,
+		Remote: RemotePolicy{
+			Config: config.App{WorkspaceRoot: "/workspace"},
+			DialProjectView: func(context.Context, config.App) (ProjectViewRemote, error) {
+				return nil, errors.New("configured remote unavailable")
+			},
+		},
+		LaunchDaemon: func(context.Context, LaunchedRemoteDialer) (DaemonTarget[*client.Remote], bool, error) {
+			return DaemonTarget[*client.Remote]{
+				Value: new(client.Remote),
+				Close: func() error {
+					closed++
+					return nil
+				},
+			}, true, nil
+		},
+		WrapRemote: func(_ *client.Remote, _ config.App, _ func() error) (Target[string], error) {
+			return Target[string]{}, wrapErr
+		},
+		StartEmbedded: func(context.Context) (Target[string], error) {
+			return Target[string]{Value: "embedded"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve should fall back to embedded after daemon wrap failure: %v", err)
+	}
+	if resolution.Source != SourceEmbeddedFallback {
+		t.Fatalf("source = %q, want %q", resolution.Source, SourceEmbeddedFallback)
+	}
+	if closed != 1 {
+		t.Fatalf("daemon close count = %d, want 1", closed)
+	}
+}
+
+func TestResolveJoinsLaunchAndEmbeddedErrors(t *testing.T) {
+	launchErr := errors.New("daemon launch failed")
+	embeddedErr := errors.New("embedded start failed")
+	_, err := Resolve[string](context.Background(), Request[string]{
+		Mode: ModeInteractive,
+		Remote: RemotePolicy{
+			Config: config.App{WorkspaceRoot: "/workspace"},
+			DialProjectView: func(context.Context, config.App) (ProjectViewRemote, error) {
+				return nil, errors.New("configured remote unavailable")
+			},
+		},
+		LaunchDaemon: func(context.Context, LaunchedRemoteDialer) (DaemonTarget[*client.Remote], bool, error) {
+			return DaemonTarget[*client.Remote]{}, false, launchErr
+		},
+		StartEmbedded: func(context.Context) (Target[string], error) {
+			return Target[string]{}, embeddedErr
+		},
+	})
+	if !errors.Is(err, launchErr) || !errors.Is(err, embeddedErr) {
+		t.Fatalf("Resolve error = %v, want joined launch and embedded errors", err)
+	}
+}

--- a/cli/app/run_prompt_target.go
+++ b/cli/app/run_prompt_target.go
@@ -10,8 +10,8 @@ import (
 	"builder/cli/app/internal/remoteattach"
 	"builder/cli/app/internal/runprompttarget"
 	"builder/cli/app/internal/servecommand"
+	"builder/cli/app/internal/serverattach"
 	"builder/cli/app/internal/startupconfig"
-	"builder/cli/app/internal/targetstartup"
 	"builder/shared/client"
 	"builder/shared/config"
 	"builder/shared/protocol"
@@ -44,43 +44,41 @@ func startRunPromptClient(ctx context.Context, opts Options) (client.RunPromptCl
 	}
 	opts = workspaceConfig.Options
 	cfg := workspaceConfig.Config
-	target, err := targetstartup.Resolve[runprompttarget.Target, *client.Remote](ctx, targetstartup.Request[runprompttarget.Target, *client.Remote]{
-		DialRemote: func(ctx context.Context) (targetstartup.Target[runprompttarget.Target], bool, error) {
-			remote, ok, err := tryDialMatchingConfiguredRunPromptRemoteWithConfig(ctx, opts, cfg, nil)
-			if err != nil || !ok {
-				return targetstartup.Target[runprompttarget.Target]{}, ok, err
-			}
-			return runprompttarget.Remote(remote, cfg), true, nil
-		},
-		LaunchDaemon: func(ctx context.Context) (targetstartup.DaemonTarget[*client.Remote], bool, error) {
+	target, err := serverattach.Resolve[runprompttarget.Target](ctx, serverattach.Request[runprompttarget.Target]{
+		Mode:   serverattach.ModeHeadless,
+		Remote: serverAttachRemotePolicy(cfg, remoteattach.SupportsRunPrompt, true),
+		LaunchDaemon: func(ctx context.Context, _ serverattach.LaunchedRemoteDialer) (serverattach.DaemonTarget[*client.Remote], bool, error) {
 			remote, closeFn, ok, err := launchRunPromptDaemon(ctx, opts)
 			if err != nil || !ok {
-				return targetstartup.DaemonTarget[*client.Remote]{}, ok, err
+				return serverattach.DaemonTarget[*client.Remote]{}, ok, err
 			}
-			return targetstartup.DaemonTarget[*client.Remote]{Value: remote, Close: closeFn}, true, nil
+			return serverattach.DaemonTarget[*client.Remote]{Value: remote, Close: closeFn}, true, nil
 		},
-		WrapDaemon: func(_ context.Context, daemon targetstartup.DaemonTarget[*client.Remote]) (targetstartup.Target[runprompttarget.Target], error) {
-			return runprompttarget.RemoteWithClose(daemon.Value, cfg, daemon.Close), nil
+		WrapRemote: func(remote *client.Remote, cfg config.App, closeFn func() error) (serverattach.Target[runprompttarget.Target], error) {
+			target := runprompttarget.RemoteWithClose(remote, cfg, closeFn)
+			return serverattach.Target[runprompttarget.Target]{Value: target.Value, Close: target.Close}, nil
 		},
-		StartEmbedded: func(ctx context.Context) (targetstartup.Target[runprompttarget.Target], error) {
+		StartEmbedded: func(ctx context.Context) (serverattach.Target[runprompttarget.Target], error) {
 			server, err := startEmbeddedServer(ctx, opts, newHeadlessAuthInteractor())
 			if err != nil {
-				return targetstartup.Target[runprompttarget.Target]{}, err
+				return serverattach.Target[runprompttarget.Target]{}, err
 			}
-			runPrompt, err := runPromptClientForEmbeddedServer(server)
-			if err != nil {
-				return targetstartup.Target[runprompttarget.Target]{}, err
-			}
-			return runprompttarget.Embedded(runPrompt, server.ProjectID, server.Close), nil
+			return runPromptTargetForEmbeddedAttachment(server)
 		},
-		Validate: func(ctx context.Context, _ targetstartup.Source, target runprompttarget.Target) error {
-			return runprompttarget.Validate(ctx, runprompttarget.ValidateRequest{
-				Target: target,
+		Validate: func(ctx context.Context, resolution serverattach.Resolution[runprompttarget.Target]) (serverattach.AuthReadiness, error) {
+			if err := runprompttarget.Validate(ctx, runprompttarget.ValidateRequest{
+				Target: resolution.Value,
 				Config: cfg,
 				EnsureAuthReady: func(ctx context.Context, auth client.AuthBootstrapClient) error {
 					return ensureRemoteAuthReady(ctx, auth, cfg.Settings, newHeadlessAuthInteractor())
 				},
-			})
+			}); err != nil {
+				return serverattach.AuthReadinessUnchecked, err
+			}
+			if resolution.Value.Auth == nil {
+				return serverattach.AuthReadinessUnchecked, nil
+			}
+			return serverattach.AuthReadinessValidated, nil
 		},
 	})
 	if err != nil {
@@ -89,11 +87,22 @@ func startRunPromptClient(ctx context.Context, opts Options) (client.RunPromptCl
 	return target.Value.Client, target.Close, nil
 }
 
-func runPromptClientForEmbeddedServer(server *embeddedAppServer) (client.RunPromptClient, error) {
-	if server == nil || server.inner == nil {
-		return nil, errors.New("embedded server is required")
+type embeddedRunPromptAttachment interface {
+	RunPromptClient() client.RunPromptClient
+	ProjectID() string
+	Close() error
+}
+
+func runPromptTargetForEmbeddedAttachment(server embeddedRunPromptAttachment) (serverattach.Target[runprompttarget.Target], error) {
+	if server == nil {
+		return serverattach.Target[runprompttarget.Target]{}, errors.New("embedded run prompt attachment is required")
 	}
-	return server.inner.RunPromptClient(), nil
+	runPrompt := server.RunPromptClient()
+	if runPrompt == nil {
+		return serverattach.Target[runprompttarget.Target]{}, errors.New("embedded run prompt client is required")
+	}
+	target := runprompttarget.Embedded(runPrompt, server.ProjectID, server.Close)
+	return serverattach.Target[runprompttarget.Target]{Value: target.Value, Close: target.Close}, nil
 }
 
 func tryDialConfiguredRunPromptRemote(ctx context.Context, opts Options) (*client.Remote, bool, error) {
@@ -109,15 +118,7 @@ func tryDialMatchingConfiguredRunPromptRemote(ctx context.Context, opts Options,
 }
 
 func tryDialMatchingConfiguredRunPromptRemoteWithConfig(ctx context.Context, _ Options, cfg config.App, accept func(protocol.ServerIdentity) bool) (*client.Remote, bool, error) {
-	return remoteattach.DialHeadless(ctx, remoteattach.HeadlessRequest{
-		Config:           cfg,
-		AttachTimeout:    configuredRemoteAttachTimeout,
-		DiscoveryTimeout: configuredRemoteWorkspaceDiscoveryTimeout,
-		DialProjectView:  dialConfiguredProjectViewRemote,
-		DialWorkspace:    dialConfiguredRemote,
-		Accept:           accept,
-		Supports:         remoteattach.SupportsRunPrompt,
-	})
+	return serverattach.DialRemote(ctx, serverattach.ModeHeadless, serverAttachRemotePolicy(cfg, remoteattach.SupportsRunPrompt, true), accept)
 }
 
 func tryDialConfiguredRemote(ctx context.Context, opts Options, supports func(protocol.CapabilityFlags) bool) (*client.Remote, bool) {
@@ -137,15 +138,11 @@ func tryDialMatchingConfiguredRemoteWithRequirement(ctx context.Context, opts Op
 	if err != nil {
 		return nil, false
 	}
-	return remoteattach.DialInteractive(ctx, remoteattach.InteractiveRequest{
-		Config:          cfg,
-		AttachTimeout:   configuredRemoteAttachTimeout,
-		DialProjectView: dialConfiguredProjectViewRemote,
-		DialWorkspace:   dialConfiguredRemote,
-		Accept:          accept,
-		Supports:        supports,
-		RequireBound:    requireRegistered,
-	})
+	remote, ok, err := serverattach.DialRemote(ctx, serverattach.ModeInteractive, serverAttachRemotePolicy(cfg, supports, requireRegistered), accept)
+	if err != nil {
+		return nil, false
+	}
+	return remote, ok
 }
 
 func startLocalRunPromptDaemon(ctx context.Context, opts Options) (*client.Remote, func() error, bool, error) {
@@ -211,5 +208,17 @@ func startupConfigRequest(opts Options) startupconfig.Request {
 			ModelTimeoutSeconds: opts.ModelTimeoutSeconds,
 			Tools:               opts.Tools,
 		},
+	}
+}
+
+func serverAttachRemotePolicy(cfg config.App, supports remoteattach.Supports, requireBound bool) serverattach.RemotePolicy {
+	return serverattach.RemotePolicy{
+		Config:           cfg,
+		AttachTimeout:    configuredRemoteAttachTimeout,
+		DiscoveryTimeout: configuredRemoteWorkspaceDiscoveryTimeout,
+		DialProjectView:  dialConfiguredProjectViewRemote,
+		DialWorkspace:    dialConfiguredRemote,
+		Supports:         supports,
+		RequireBound:     requireBound,
 	}
 }

--- a/cli/app/session_lifecycle.go
+++ b/cli/app/session_lifecycle.go
@@ -169,7 +169,7 @@ func shouldCloseReboundServer(original appServerCore, rebound appServerCore) boo
 	originalEmbedded, originalOK := original.(*embeddedAppServer)
 	reboundEmbedded, reboundOK := rebound.(*embeddedAppServer)
 	if originalOK && reboundOK {
-		return originalEmbedded.inner != reboundEmbedded.inner
+		return !originalEmbedded.SharesProcessWith(reboundEmbedded)
 	}
 	return true
 }

--- a/cli/app/session_server_target.go
+++ b/cli/app/session_server_target.go
@@ -5,9 +5,9 @@ import (
 
 	"builder/cli/app/internal/daemonlaunch"
 	"builder/cli/app/internal/remoteattach"
+	"builder/cli/app/internal/serverattach"
 	"builder/cli/app/internal/sessiontarget"
 	"builder/cli/app/internal/startupconfig"
-	"builder/cli/app/internal/targetstartup"
 	"builder/shared/client"
 	"builder/shared/config"
 	"builder/shared/protocol"
@@ -15,48 +15,44 @@ import (
 
 var launchSessionServerDaemon = startLocalInteractiveSessionDaemon
 var startInteractiveEmbeddedSessionServer = startEmbeddedServer
-var dialInteractiveRemoteSessionServer = tryDialConfiguredRemoteServer
 
 func startSessionServer(ctx context.Context, opts Options, interactor authInteractor) (interactiveSessionServer, error) {
-	target, err := targetstartup.Resolve[interactiveSessionServer, *client.Remote](ctx, targetstartup.Request[interactiveSessionServer, *client.Remote]{
+	cfg, err := loadSessionServerConfig(opts)
+	if err != nil {
+		return nil, err
+	}
+	target, err := serverattach.Resolve[interactiveSessionServer](ctx, serverattach.Request[interactiveSessionServer]{
+		Mode:   serverattach.ModeInteractive,
+		Remote: serverAttachRemotePolicy(cfg, remoteattach.SupportsInteractiveSession, false),
 		BypassRemote: func(context.Context) (bool, error) {
-			return shouldBypassRemoteStartupForInteractiveOnboarding(opts, interactor)
+			return shouldBypassRemoteStartupForInteractiveOnboardingWithConfig(cfg, interactor), nil
 		},
-		DialRemote: func(ctx context.Context) (targetstartup.Target[interactiveSessionServer], bool, error) {
-			remote, ok, err := dialInteractiveRemoteSessionServer(ctx, opts, interactor)
-			if err != nil || !ok {
-				return targetstartup.Target[interactiveSessionServer]{}, ok, err
-			}
-			return interactiveRemoteSessionTarget(remote), true, nil
-		},
-		LaunchDaemon: func(ctx context.Context) (targetstartup.DaemonTarget[*client.Remote], bool, error) {
+		LaunchDaemon: func(ctx context.Context, _ serverattach.LaunchedRemoteDialer) (serverattach.DaemonTarget[*client.Remote], bool, error) {
 			remote, closeFn, ok, err := launchSessionServerDaemon(ctx, opts)
 			if err != nil || !ok {
-				return targetstartup.DaemonTarget[*client.Remote]{}, ok, err
+				return serverattach.DaemonTarget[*client.Remote]{}, ok, err
 			}
-			return targetstartup.DaemonTarget[*client.Remote]{Value: remote, Close: closeFn}, true, nil
+			return serverattach.DaemonTarget[*client.Remote]{Value: remote, Close: closeFn}, true, nil
 		},
-		WrapDaemon: func(_ context.Context, daemon targetstartup.DaemonTarget[*client.Remote]) (targetstartup.Target[interactiveSessionServer], error) {
-			return sessiontarget.WrapDaemon(daemon, sessiontarget.WrapDaemonRequest[interactiveSessionServer, *client.Remote]{
-				LoadConfig: func() (config.App, error) {
-					return loadSessionServerConfig(opts)
-				},
-				NewRemote: func(remote *client.Remote, cfg config.App, closeFn func() error) interactiveSessionServer {
-					return newRemoteAppServerWithAuth(remote, cfg, closeFn)
-				},
-			})
+		WrapRemote: func(remote *client.Remote, cfg config.App, closeFn func() error) (serverattach.Target[interactiveSessionServer], error) {
+			server := newRemoteAppServerWithAuth(remote, cfg, closeFn)
+			return serverattach.Target[interactiveSessionServer]{Value: server, Close: server.Close}, nil
 		},
-		StartEmbedded: func(ctx context.Context) (targetstartup.Target[interactiveSessionServer], error) {
+		StartEmbedded: func(ctx context.Context) (serverattach.Target[interactiveSessionServer], error) {
 			server, err := startInteractiveEmbeddedSessionServer(ctx, opts, interactor)
 			if err != nil {
-				return targetstartup.Target[interactiveSessionServer]{}, err
+				return serverattach.Target[interactiveSessionServer]{}, err
 			}
-			return targetstartup.Target[interactiveSessionServer]{Value: server, Close: server.Close}, nil
+			return serverattach.Target[interactiveSessionServer]{Value: server, Close: server.Close}, nil
 		},
-		Validate: func(ctx context.Context, source targetstartup.Source, target interactiveSessionServer) error {
-			return sessiontarget.Validate(ctx, source, target, func(ctx context.Context, server interactiveSessionServer) error {
-				return server.Reauthenticate(ctx, interactor)
-			})
+		Validate: func(ctx context.Context, resolution serverattach.Resolution[interactiveSessionServer]) (serverattach.AuthReadiness, error) {
+			if resolution.Source == serverattach.SourceEmbeddedFallback {
+				return serverattach.AuthReadinessUnchecked, nil
+			}
+			if err := resolution.Value.Reauthenticate(ctx, interactor); err != nil {
+				return serverattach.AuthReadinessUnchecked, err
+			}
+			return serverattach.AuthReadinessValidated, nil
 		},
 	})
 	if err != nil {
@@ -65,32 +61,19 @@ func startSessionServer(ctx context.Context, opts Options, interactor authIntera
 	return target.Value, nil
 }
 
-func interactiveRemoteSessionTarget(server interactiveSessionServer) targetstartup.Target[interactiveSessionServer] {
-	return sessiontarget.Remote(server)
-}
-
 func shouldBypassRemoteStartupForInteractiveOnboarding(opts Options, interactor authInteractor) (bool, error) {
-	if interactor == nil || !interactor.Interactive() {
-		return false, nil
-	}
 	cfg, err := loadSessionServerConfig(opts)
 	if err != nil {
 		return false, err
 	}
-	return sessiontarget.ShouldBypassRemoteForFirstRun(interactor.Interactive(), cfg.Source.SettingsFileExists), nil
+	return shouldBypassRemoteStartupForInteractiveOnboardingWithConfig(cfg, interactor), nil
 }
 
-func tryDialConfiguredRemoteServer(ctx context.Context, opts Options, _ authInteractor) (*remoteAppServer, bool, error) {
-	remote, ok := tryDialMatchingConfiguredRemoteAllowUnregistered(ctx, opts, remoteattach.SupportsInteractiveSession, nil)
-	if !ok {
-		return nil, false, nil
+func shouldBypassRemoteStartupForInteractiveOnboardingWithConfig(cfg config.App, interactor authInteractor) bool {
+	if interactor == nil || !interactor.Interactive() {
+		return false
 	}
-	cfg, err := loadSessionServerConfig(opts)
-	if err != nil {
-		_ = remote.Close()
-		return nil, false, err
-	}
-	return newRemoteAppServerWithAuth(remote, cfg, nil), true, nil
+	return sessiontarget.ShouldBypassRemoteForFirstRun(interactor.Interactive(), cfg.Source.SettingsFileExists)
 }
 
 func startLocalInteractiveSessionDaemon(ctx context.Context, opts Options) (*client.Remote, func() error, bool, error) {

--- a/cli/app/session_server_target_part2_test.go
+++ b/cli/app/session_server_target_part2_test.go
@@ -560,11 +560,11 @@ func TestStartSessionServerOwnsLaunchedDaemonCloser(t *testing.T) {
 
 	called := false
 	originalLaunch := launchSessionServerDaemon
-	originalDial := dialInteractiveRemoteSessionServer
+	originalDial := dialConfiguredProjectViewRemote
 	t.Cleanup(func() { launchSessionServerDaemon = originalLaunch })
-	t.Cleanup(func() { dialInteractiveRemoteSessionServer = originalDial })
-	dialInteractiveRemoteSessionServer = func(context.Context, Options, authInteractor) (*remoteAppServer, bool, error) {
-		return nil, false, nil
+	t.Cleanup(func() { dialConfiguredProjectViewRemote = originalDial })
+	dialConfiguredProjectViewRemote = func(context.Context, config.App) (configuredProjectViewRemote, error) {
+		return nil, errors.New("configured remote unavailable")
 	}
 	launchSessionServerDaemon = func(context.Context, Options) (*client.Remote, func() error, bool, error) {
 		remote, err := client.DialRemoteURL(context.Background(), config.ServerRPCURL(loadCfg))

--- a/cli/app/session_server_target_test.go
+++ b/cli/app/session_server_target_test.go
@@ -788,11 +788,11 @@ func TestStartSessionServerBypassesRemoteAndDaemonOnFirstInteractiveRun(t *testi
 	t.Setenv("HOME", home)
 	registerAppWorkspace(t, workspace)
 
-	originalDial := dialInteractiveRemoteSessionServer
+	originalDial := dialConfiguredProjectViewRemote
 	originalLaunch := launchSessionServerDaemon
 	originalEmbedded := startInteractiveEmbeddedSessionServer
 	defer func() {
-		dialInteractiveRemoteSessionServer = originalDial
+		dialConfiguredProjectViewRemote = originalDial
 		launchSessionServerDaemon = originalLaunch
 		startInteractiveEmbeddedSessionServer = originalEmbedded
 	}()
@@ -804,9 +804,9 @@ func TestStartSessionServerBypassesRemoteAndDaemonOnFirstInteractiveRun(t *testi
 		embeddedCalled = true
 		return &embeddedAppServer{}, nil
 	}
-	dialInteractiveRemoteSessionServer = func(context.Context, Options, authInteractor) (*remoteAppServer, bool, error) {
+	dialConfiguredProjectViewRemote = func(context.Context, config.App) (configuredProjectViewRemote, error) {
 		remoteCalled = true
-		return nil, false, nil
+		return nil, errors.New("configured remote should be skipped")
 	}
 	launchSessionServerDaemon = func(context.Context, Options) (*client.Remote, func() error, bool, error) {
 		daemonCalled = true

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -439,6 +439,10 @@ func (m *uiModel) setTransientStatusWithKind(message string, kind uiStatusNotice
 	return m.sendTransientStatus(message, kind, transientStatusDuration, uiStatusNoticeReplace)
 }
 
+func (m *uiModel) setTransientStatusWithKindAndNoticeID(message string, kind uiStatusNoticeKind, noticeID string) tea.Cmd {
+	return m.sendTransientStatusWithNoticeID(message, kind, transientStatusDuration, uiStatusNoticeReplace, noticeID)
+}
+
 func (m *uiModel) enqueueTransientStatus(message string, kind uiStatusNoticeKind) tea.Cmd {
 	return m.sendTransientStatus(message, kind, transientStatusDuration, uiStatusNoticeQueue)
 }
@@ -448,10 +452,14 @@ func (m *uiModel) enqueueTransientStatusWithDuration(message string, kind uiStat
 }
 
 func (m *uiModel) sendTransientStatus(message string, kind uiStatusNoticeKind, duration time.Duration, delivery uiStatusNoticeDelivery) tea.Cmd {
+	return m.sendTransientStatusWithNoticeID(message, kind, duration, delivery, "")
+}
+
+func (m *uiModel) sendTransientStatusWithNoticeID(message string, kind uiStatusNoticeKind, duration time.Duration, delivery uiStatusNoticeDelivery, noticeID string) tea.Cmd {
 	if strings.TrimSpace(message) == "" {
 		return nil
 	}
-	notice := uiStatusNotice{Text: strings.TrimSpace(message), Kind: kind, Duration: duration}
+	notice := uiStatusNotice{Text: strings.TrimSpace(message), Kind: kind, Duration: duration, NoticeID: strings.TrimSpace(noticeID)}
 	if delivery == uiStatusNoticeQueue && strings.TrimSpace(m.transientStatus) != "" {
 		if m.transientStatus == notice.Text && m.transientStatusKind == notice.Kind {
 			return nil
@@ -473,6 +481,7 @@ func (m *uiModel) showTransientStatusNotice(notice uiStatusNotice) tea.Cmd {
 	token := m.transientStatusToken
 	m.transientStatus = strings.TrimSpace(notice.Text)
 	m.transientStatusKind = notice.Kind
+	m.transientStatusNoticeID = strings.TrimSpace(notice.NoticeID)
 	if notice.Kind == uiStatusNoticeUpdateAvailable {
 		m.startupUpdateShown = true
 	}
@@ -482,6 +491,7 @@ func (m *uiModel) showTransientStatusNotice(notice uiStatusNotice) tea.Cmd {
 func (m *uiModel) advanceTransientStatusQueue() tea.Cmd {
 	m.transientStatus = ""
 	m.transientStatusKind = uiStatusNoticeNeutral
+	m.transientStatusNoticeID = ""
 	if len(m.transientStatusQueue) == 0 {
 		m.syncViewport()
 		return nil

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -461,7 +461,7 @@ func (m *uiModel) sendTransientStatusWithNoticeID(message string, kind uiStatusN
 	}
 	notice := uiStatusNotice{Text: strings.TrimSpace(message), Kind: kind, Duration: duration, NoticeID: strings.TrimSpace(noticeID)}
 	if delivery == uiStatusNoticeQueue && strings.TrimSpace(m.transientStatus) != "" {
-		if m.transientStatus == notice.Text && m.transientStatusKind == notice.Kind {
+		if m.transientStatus == notice.Text && m.transientStatusKind == notice.Kind && m.transientStatusNoticeID == notice.NoticeID {
 			return nil
 		}
 		if len(m.transientStatusQueue) > 0 {

--- a/cli/app/ui_busy_commands_test.go
+++ b/cli/app/ui_busy_commands_test.go
@@ -399,12 +399,17 @@ func TestBusyQueuedFastAppliesToNextRuntimeRequestAfterTurnDrains(t *testing.T) 
 	m := newProjectedEngineUIModel(eng)
 	m.busy = true
 	m.activity = uiActivityRunning
+	m.promptHistoryDraft = "previous prompt"
+	m.promptHistoryDraftCursor = -1
 	m.input = "/fast on"
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	updated := next.(*uiModel)
 	if len(updated.queued) != 1 || updated.queued[0].Text != "/fast on" {
 		t.Fatalf("expected queued /fast command, got %+v", updated.queued)
+	}
+	if updated.input != "" || updated.promptHistoryDraft != "" || updated.promptHistoryDraftCursor != -1 {
+		t.Fatalf("expected queued /fast to discard prompt-history draft, input=%q draft=%q cursor=%d", updated.input, updated.promptHistoryDraft, updated.promptHistoryDraftCursor)
 	}
 
 	next, cmd := updated.Update(submitDoneMsg{message: "prior turn done"})

--- a/cli/app/ui_input_controller.go
+++ b/cli/app/ui_input_controller.go
@@ -247,6 +247,6 @@ func (m *uiModel) appendLocalEntryFallbackWithNoticeIDAndVisibility(role, text, 
 	m.transcriptEntries = append(m.transcriptEntries, entry)
 	m.transcriptTotalEntries = max(m.transcriptTotalEntries, m.transcriptBaseOffset+len(committedTranscriptEntriesForApp(m.transcriptEntries)))
 	m.refreshRollbackCandidates()
-	m.forwardToView(tui.AppendTranscriptMsg{Visibility: entry.Visibility, Role: transcriptRole, Text: text})
+	m.forwardToView(tui.AppendTranscriptMsg{Visibility: entry.Visibility, Role: transcriptRole, Text: text, NoticeID: entry.NoticeID})
 	return m.syncNativeHistoryFromTranscript()
 }

--- a/cli/app/ui_input_controller.go
+++ b/cli/app/ui_input_controller.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,6 +26,13 @@ func (c uiInputController) appendLocalEntry(role, text string) tea.Cmd {
 	return c.model.appendLocalEntry(role, text)
 }
 
+func (c uiInputController) appendLocalEntryWithNoticeID(role, text, noticeID string) tea.Cmd {
+	if c.model == nil {
+		return nil
+	}
+	return c.model.appendLocalEntryWithNoticeID(role, text, noticeID)
+}
+
 func (c uiInputController) appendSystemFeedback(text string) tea.Cmd {
 	return c.appendLocalEntry("system", text)
 }
@@ -43,6 +51,14 @@ func (c uiInputController) appendSystemFeedbackWithStatus(text string, status te
 
 func (c uiInputController) appendErrorFeedbackWithStatus(text string, status tea.Cmd) tea.Cmd {
 	return c.appendLocalEntryWithStatus("error", text, status)
+}
+
+func (c uiInputController) appendSystemFeedbackWithMirroredStatus(text string, kind uiStatusNoticeKind) tea.Cmd {
+	noticeID := c.model.nextLocalNoticeID()
+	return sequenceCmds(
+		c.appendLocalEntryWithNoticeID("system", text, noticeID),
+		c.model.setTransientStatusWithKindAndNoticeID(text, kind, noticeID),
+	)
 }
 
 type uiInputController struct {
@@ -68,6 +84,14 @@ var scheduleTransientStatusClear = func(duration time.Duration, token uint64) te
 var processListRefreshInterval = 1500 * time.Millisecond
 var rollbackDoubleEscWindow = 500 * time.Millisecond
 var csiShiftEnterDedupWindow = 120 * time.Millisecond
+
+func (m *uiModel) nextLocalNoticeID() string {
+	if m == nil {
+		return ""
+	}
+	m.localNoticeSequence++
+	return "local-notice-" + strconv.FormatUint(m.localNoticeSequence, 10)
+}
 
 func waitProcessListRefresh() tea.Cmd {
 	return tea.Tick(processListRefreshInterval, func(time.Time) tea.Msg {
@@ -184,17 +208,22 @@ func parseUserShellCommand(text string) (string, bool) {
 }
 
 func (m *uiModel) appendLocalEntry(role, text string) tea.Cmd {
+	return m.appendLocalEntryWithNoticeID(role, text, "")
+}
+
+func (m *uiModel) appendLocalEntryWithNoticeID(role, text, noticeID string) tea.Cmd {
 	role = strings.TrimSpace(role)
 	text = strings.TrimSpace(text)
+	noticeID = strings.TrimSpace(noticeID)
 	if role == "" || text == "" {
 		return nil
 	}
 	if m.hasRuntimeClient() {
-		if err := m.appendRuntimeLocalEntry(role, text); err == nil {
+		if err := m.appendRuntimeLocalEntryWithNoticeID(role, text, noticeID); err == nil {
 			return nil
 		}
 	}
-	return m.appendLocalEntryFallback(role, text)
+	return m.appendLocalEntryFallbackWithNoticeID(role, text, noticeID)
 }
 
 func (m *uiModel) appendLocalEntryFallback(role, text string) tea.Cmd {
@@ -202,11 +231,19 @@ func (m *uiModel) appendLocalEntryFallback(role, text string) tea.Cmd {
 }
 
 func (m *uiModel) appendLocalEntryFallbackWithVisibility(role, text string, visibility transcript.EntryVisibility) tea.Cmd {
+	return m.appendLocalEntryFallbackWithNoticeIDAndVisibility(role, text, "", visibility)
+}
+
+func (m *uiModel) appendLocalEntryFallbackWithNoticeID(role, text, noticeID string) tea.Cmd {
+	return m.appendLocalEntryFallbackWithNoticeIDAndVisibility(role, text, noticeID, transcript.EntryVisibilityAuto)
+}
+
+func (m *uiModel) appendLocalEntryFallbackWithNoticeIDAndVisibility(role, text, noticeID string, visibility transcript.EntryVisibility) tea.Cmd {
 	if m == nil {
 		return nil
 	}
 	transcriptRole := tui.TranscriptRoleFromWire(role)
-	entry := tui.TranscriptEntry{Visibility: transcript.NormalizeEntryVisibility(visibility), Role: transcriptRole, Text: text}
+	entry := tui.TranscriptEntry{Visibility: transcript.NormalizeEntryVisibility(visibility), Role: transcriptRole, Text: text, NoticeID: strings.TrimSpace(noticeID)}
 	m.transcriptEntries = append(m.transcriptEntries, entry)
 	m.transcriptTotalEntries = max(m.transcriptTotalEntries, m.transcriptBaseOffset+len(committedTranscriptEntriesForApp(m.transcriptEntries)))
 	m.refreshRollbackCandidates()

--- a/cli/app/ui_input_controller_commands.go
+++ b/cli/app/ui_input_controller_commands.go
@@ -248,7 +248,7 @@ func (c uiInputController) handleFastModeCommand(requested string) (tea.Model, t
 	}
 
 	status := fastModeToggleStatusMessage(m.fastModeEnabled, changed)
-	return m, c.appendSystemFeedbackWithStatus(status, c.showSuccessStatus(status))
+	return m, c.appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeSuccess)
 }
 
 func (c uiInputController) handleSupervisorModeCommand(requested string) (tea.Model, tea.Cmd) {
@@ -286,7 +286,7 @@ func (c uiInputController) handleSupervisorModeCommand(requested string) (tea.Mo
 	m.reviewerMode = nextMode
 	m.reviewerEnabled = nextMode != "off"
 	status := reviewerToggleStatusMessage(m.reviewerEnabled, nextMode, changed)
-	return m, c.appendSystemFeedbackWithStatus(status, c.showTransientStatus(status))
+	return m, c.appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral)
 }
 
 func (c uiInputController) handleAutoCompactionCommand(requested string) (tea.Model, tea.Cmd) {
@@ -325,5 +325,5 @@ func (c uiInputController) handleAutoCompactionCommand(requested string) (tea.Mo
 	}
 	m.autoCompactionEnabled = nextEnabled
 	status := autoCompactionToggleStatusMessage(nextEnabled, changed, currentCompactionMode)
-	return m, c.appendSystemFeedbackWithStatus(status, c.showTransientStatus(status))
+	return m, c.appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral)
 }

--- a/cli/app/ui_input_controller_keys.go
+++ b/cli/app/ui_input_controller_keys.go
@@ -205,9 +205,9 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return next, cmd
 		}
 		if commandResult := m.commandRegistry.Execute(text); commandResult.Handled {
+			command, _ := m.commandRegistry.Command(text)
 			recordCmd := m.recordPromptHistory(text)
-			m.clearInput()
-			m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
+			m.clearCommandInput(command, draftText, draftCursor, restoreDraft)
 			next, cmd := c.applyCommandResult(commandResult)
 			return next, finalizeSlashCommandCmd(commandResult.Action, cmd, recordCmd)
 		}

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -62,11 +62,26 @@ func (c uiInputController) queueOrStartSubmission(text string) (tea.Model, tea.C
 	}
 	draftText, draftCursor, restoreDraft := m.capturePromptHistoryDraftForReuse()
 	m.queueInput(text)
-	m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
+	if c.preservePromptHistoryDraftForQueuedText(text) {
+		m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
+	} else {
+		m.resetPromptHistoryNavigation()
+	}
 	if m.busy {
 		return m, nil
 	}
 	return c.flushQueuedInputs(queueDrainOne)
+}
+
+func (c uiInputController) preservePromptHistoryDraftForQueuedText(text string) bool {
+	if c.model == nil || c.model.commandRegistry == nil {
+		return true
+	}
+	command, knownCommand := c.model.commandRegistry.Command(text)
+	if !knownCommand {
+		return true
+	}
+	return command.PreservePromptHistoryDraft
 }
 
 func (c uiInputController) blockDisconnectedSubmission(restoreHidden bool, submittedText string) (bool, tea.Cmd) {

--- a/cli/app/ui_input_slash_commands.go
+++ b/cli/app/ui_input_slash_commands.go
@@ -44,12 +44,20 @@ func (c uiInputController) handleEnteredSlashCommandInput(text string) (bool, te
 	if commandResult := m.commandRegistry.Execute(commandText); commandResult.Handled {
 		draftText, draftCursor, restoreDraft := m.capturePromptHistoryDraftForReuse()
 		recordCmd := m.recordPromptHistory(commandText)
-		m.clearInput()
-		m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
+		m.clearCommandInput(command, draftText, draftCursor, restoreDraft)
 		next, cmd := c.applyCommandResult(commandResult)
 		return true, next, finalizeSlashCommandCmd(commandResult.Action, cmd, recordCmd)
 	}
 	return false, m, nil
+}
+
+func (m *uiModel) clearCommandInput(command commands.Command, draftText string, draftCursor int, restoreDraft bool) {
+	m.clearInput()
+	if command.PreservePromptHistoryDraft {
+		m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
+		return
+	}
+	m.resetPromptHistoryNavigation()
 }
 
 func finalizeSlashCommandCmd(action commands.Action, primary tea.Cmd, record tea.Cmd) tea.Cmd {

--- a/cli/app/ui_messages.go
+++ b/cli/app/ui_messages.go
@@ -227,6 +227,7 @@ type uiStatusNotice struct {
 	Text     string
 	Kind     uiStatusNoticeKind
 	Duration time.Duration
+	NoticeID string
 }
 
 type uiStatusNoticeDelivery uint8

--- a/cli/app/ui_native_scrollback_integration_part4_test.go
+++ b/cli/app/ui_native_scrollback_integration_part4_test.go
@@ -432,6 +432,100 @@ func TestNativeProgramConversationRefreshHydratesCommittedTranscriptWithoutRepla
 	}
 }
 
+func TestNativeProgramSlashLocalEntryDoesNotReplayPreviousPrompt(t *testing.T) {
+	out := &bytes.Buffer{}
+	runtimeEvents := make(chan clientui.Event, 8)
+	client := &slashLocalEntryRuntimeClient{
+		events: runtimeEvents,
+		startupTranscriptRuntimeClient: startupTranscriptRuntimeClient{
+			view: clientui.RuntimeMainView{
+				Session: clientui.RuntimeSessionView{SessionID: "session-1"},
+				Status:  clientui.RuntimeStatus{AutoCompactionEnabled: true},
+			},
+			page: clientui.TranscriptPage{
+				SessionID:    "session-1",
+				Revision:     1,
+				TotalEntries: 1,
+				NextOffset:   1,
+				Entries: []clientui.ChatEntry{{
+					Role: "user",
+					Text: "can u backfill this into the conversation so i can post this on twitter",
+				}},
+			},
+		},
+	}
+	model := newProjectedTestUIModel(client, runtimeEvents, closedAskEvents())
+	model.promptHistoryDraft = "can u backfill this into the conversation so i can post this on twitter"
+	model.promptHistoryDraftCursor = -1
+	program := tea.NewProgram(model, tea.WithInput(strings.NewReader("")), tea.WithOutput(out), tea.WithoutSignals())
+	done := make(chan error, 1)
+	go func() {
+		_, err := program.Run()
+		done <- err
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	program.Send(tea.WindowSizeMsg{Width: 120, Height: 30})
+	waitForTestCondition(t, 2*time.Second, "startup prompt visible once", func() bool {
+		return strings.Count(normalizedOutput(out.String()), "can u backfill this into the conversation") == 1
+	})
+	model.input = "/autocompaction"
+	program.Send(tea.KeyMsg{Type: tea.KeyEnter})
+	waitForTestCondition(t, 2*time.Second, "slash command feedback visible", func() bool {
+		return strings.Contains(normalizedOutput(out.String()), "Auto-compaction disabled")
+	})
+	program.Quit()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("program run failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("program did not terminate")
+	}
+
+	normalized := normalizedOutput(out.String())
+	if got := strings.Count(normalized, "can u backfill this into the conversation"); got != 1 {
+		t.Fatalf("expected previous prompt once after slash feedback, got %d in %q", got, normalized)
+	}
+	if got := strings.Count(normalized, "Auto-compaction disabled"); got != 1 {
+		t.Fatalf("expected slash feedback once, got %d in %q", got, normalized)
+	}
+}
+
+type slashLocalEntryRuntimeClient struct {
+	startupTranscriptRuntimeClient
+	events chan<- clientui.Event
+}
+
+func (c *slashLocalEntryRuntimeClient) SetAutoCompactionEnabled(enabled bool) (bool, bool, error) {
+	c.view.Status.AutoCompactionEnabled = enabled
+	return true, enabled, nil
+}
+
+func (c *slashLocalEntryRuntimeClient) AppendLocalEntry(role, text string) error {
+	return c.AppendLocalEntryWithNoticeID(role, text, "")
+}
+
+func (c *slashLocalEntryRuntimeClient) AppendLocalEntryWithNoticeID(role, text, noticeID string) error {
+	entry := clientui.ChatEntry{Role: role, Text: text, NoticeID: noticeID}
+	start := c.page.TotalEntries
+	c.page.Entries = append(c.page.Entries, entry)
+	c.page.TotalEntries++
+	c.page.NextOffset = c.page.TotalEntries
+	c.page.Revision++
+	c.events <- clientui.Event{
+		Kind:                       clientui.EventLocalEntryAdded,
+		CommittedTranscriptChanged: true,
+		TranscriptRevision:         c.page.Revision,
+		CommittedEntryCount:        c.page.TotalEntries,
+		CommittedEntryStart:        start,
+		CommittedEntryStartSet:     true,
+		TranscriptEntries:          []clientui.ChatEntry{entry},
+	}
+	return nil
+}
+
 func TestNativeStreamingInterleavedWithStatusRedrawStaysCoherent(t *testing.T) {
 	out := &bytes.Buffer{}
 	model := newProjectedTestUIModel(

--- a/cli/app/ui_part3_test.go
+++ b/cli/app/ui_part3_test.go
@@ -95,6 +95,22 @@ func TestTransientStatusQueueKeepsSameTextAndKindWithDifferentNoticeID(t *testin
 	}
 }
 
+func TestTransientStatusQueueDedupesSameTextKindAndNoticeID(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	first := m.sendTransientStatusWithNoticeID("same", uiStatusNoticeSuccess, transientStatusDuration, uiStatusNoticeQueue, "notice-1")
+	second := m.sendTransientStatusWithNoticeID("same", uiStatusNoticeSuccess, transientStatusDuration, uiStatusNoticeQueue, "notice-1")
+
+	if first == nil {
+		t.Fatal("expected first notice clear command")
+	}
+	if second != nil {
+		t.Fatalf("expected duplicate active notice suppressed, got %T", second())
+	}
+	if got := len(m.transientStatusQueue); got != 0 {
+		t.Fatalf("queued notice count = %d, want 0", got)
+	}
+}
+
 func TestTransientStatusReplaceUpdatesActiveNoticeImmediately(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	first := m.setTransientStatusWithKind("first", uiStatusNoticeSuccess)

--- a/cli/app/ui_part3_test.go
+++ b/cli/app/ui_part3_test.go
@@ -76,6 +76,25 @@ func TestTransientStatusQueuePromotesNextNoticeAfterClear(t *testing.T) {
 	}
 }
 
+func TestTransientStatusQueueKeepsSameTextAndKindWithDifferentNoticeID(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	first := m.sendTransientStatusWithNoticeID("same", uiStatusNoticeSuccess, transientStatusDuration, uiStatusNoticeQueue, "notice-1")
+	second := m.sendTransientStatusWithNoticeID("same", uiStatusNoticeSuccess, transientStatusDuration, uiStatusNoticeQueue, "notice-2")
+
+	if first == nil {
+		t.Fatal("expected first notice clear command")
+	}
+	if second != nil {
+		t.Fatalf("expected queued notice to wait for active clear, got %T", second())
+	}
+	if got := len(m.transientStatusQueue); got != 1 {
+		t.Fatalf("queued notice count = %d, want 1", got)
+	}
+	if got := m.transientStatusQueue[0].NoticeID; got != "notice-2" {
+		t.Fatalf("queued notice id = %q, want notice-2", got)
+	}
+}
+
 func TestTransientStatusReplaceUpdatesActiveNoticeImmediately(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	first := m.setTransientStatusWithKind("first", uiStatusNoticeSuccess)

--- a/cli/app/ui_part7_test.go
+++ b/cli/app/ui_part7_test.go
@@ -646,6 +646,43 @@ func TestBusySlashThinkingExecutesImmediatelyWithoutQueueing(t *testing.T) {
 	}
 }
 
+func TestLocalSlashCommandsDiscardPromptHistoryDraftAfterExecution(t *testing.T) {
+	for _, input := range []string{"/thinking low", "/fast on", "/supervisor on", "/autocompaction off"} {
+		t.Run(input, func(t *testing.T) {
+			m := newProjectedStaticUIModel(WithUIFastModeAvailable(true))
+			m.promptHistoryDraft = "previous user prompt"
+			m.promptHistoryDraftCursor = -1
+			m.input = input
+
+			next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			updated := next.(*uiModel)
+			if updated.input != "" {
+				t.Fatalf("expected %s to clear input instead of restoring prompt history draft, got %q", input, updated.input)
+			}
+			if updated.promptHistoryDraft != "" || updated.promptHistoryDraftCursor != -1 {
+				t.Fatalf("expected %s to clear prompt history draft, got text=%q cursor=%d", input, updated.promptHistoryDraft, updated.promptHistoryDraftCursor)
+			}
+		})
+	}
+}
+
+func TestMirroredTransientStatusClearsOnlyForMatchingNoticeID(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.transientStatus = "Fast mode enabled"
+	m.transientStatusKind = uiStatusNoticeSuccess
+	m.transientStatusNoticeID = "notice-1"
+
+	m.clearMirroredTransientStatus([]tui.TranscriptEntry{{Role: "system", Text: "Fast mode enabled", NoticeID: "notice-2"}})
+	if m.transientStatus != "Fast mode enabled" || m.transientStatusNoticeID != "notice-1" {
+		t.Fatalf("expected unmatched notice id to preserve transient status, got status=%q notice=%q", m.transientStatus, m.transientStatusNoticeID)
+	}
+
+	m.clearMirroredTransientStatus([]tui.TranscriptEntry{{Role: "system", Text: "different text", NoticeID: "notice-1"}})
+	if m.transientStatus != "" || m.transientStatusNoticeID != "" {
+		t.Fatalf("expected matching notice id to clear transient status, got status=%q notice=%q", m.transientStatus, m.transientStatusNoticeID)
+	}
+}
+
 func TestSlashFastTogglesAndShowsStatus(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUIFastModeAvailable(true))
 	m.termWidth = 100

--- a/cli/app/ui_part7_test.go
+++ b/cli/app/ui_part7_test.go
@@ -683,6 +683,19 @@ func TestMirroredTransientStatusClearsOnlyForMatchingNoticeID(t *testing.T) {
 	}
 }
 
+func TestLocalEntryFallbackForwardsNoticeIDToView(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	_ = m.appendLocalEntryFallbackWithNoticeID("system", "Fallback notice", "notice-1")
+
+	loaded := m.view.LoadedTranscriptEntries()
+	if len(loaded) != 1 {
+		t.Fatalf("loaded transcript entry count = %d, want 1", len(loaded))
+	}
+	if loaded[0].NoticeID != "notice-1" {
+		t.Fatalf("view notice id = %q, want notice-1", loaded[0].NoticeID)
+	}
+}
+
 func TestSlashFastTogglesAndShowsStatus(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUIFastModeAvailable(true))
 	m.termWidth = 100

--- a/cli/app/ui_runtime_adapter.go
+++ b/cli/app/ui_runtime_adapter.go
@@ -79,10 +79,6 @@ func (a uiRuntimeAdapter) applyProjectedRuntimeEvent(evt clientui.Event, flushNa
 	cmds := make([]tea.Cmd, 0, 4)
 	transcriptMutated := false
 	awaitsHydration := false
-	if shouldAppendSyntheticOngoingEntry(m, reduction.Transcript.SyntheticOngoingEntry) {
-		entry := transcriptEntryFromProjectedChatEntry(*reduction.Transcript.SyntheticOngoingEntry, true, false)
-		m.forwardToView(appendTranscriptMsgFromEntry(entry))
-	}
 	if shouldInvalidateTransientTranscriptStateForSync(transcriptSync) {
 		m.invalidateTransientTranscriptState()
 	}

--- a/cli/app/ui_runtime_adapter_part2_test.go
+++ b/cli/app/ui_runtime_adapter_part2_test.go
@@ -464,7 +464,7 @@ func TestHandleProjectedRuntimeEventDoesNotAppendPrePersistCompactionStatusEntry
 	}
 }
 
-func TestProjectedCompactionStatusClearsCompactingWithoutSyntheticNotice(t *testing.T) {
+func TestProjectedCompactionStatusClearsCompactingWithoutTranscriptNotice(t *testing.T) {
 	client := &runtimeControlFakeClient{}
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
 	m.termWidth = 100
@@ -492,7 +492,7 @@ func TestProjectedCompactionStatusClearsCompactingWithoutSyntheticNotice(t *test
 	})))
 	for _, msg := range msgs {
 		if _, ok := msg.(runtimeTranscriptRefreshedMsg); ok {
-			t.Fatalf("did not expect synthetic compaction notice to trigger transcript hydration, got %+v", msgs)
+			t.Fatalf("did not expect compaction status to trigger transcript hydration, got %+v", msgs)
 		}
 	}
 	if got, want := len(m.transcriptEntries), 1; got != want {
@@ -549,7 +549,7 @@ func TestProjectedCompactionStatusDoesNotDuplicateCommittedSummary(t *testing.T)
 	}
 }
 
-func TestProjectedCompactionStatusSkipsSyntheticOngoingNoticeInDetailMode(t *testing.T) {
+func TestProjectedCompactionStatusDoesNotAppendOngoingNoticeInDetailMode(t *testing.T) {
 	client := &runtimeControlFakeClient{}
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
 	m.termWidth = 100
@@ -583,7 +583,7 @@ func TestProjectedCompactionStatusSkipsSyntheticOngoingNoticeInDetailMode(t *tes
 		t.Fatalf("loaded transcript entry count = %d, want %d (%+v)", got, want, loaded)
 	}
 	if strings.Contains(stripANSIAndTrimRight(m.View()), "context compacted for the 1st time") {
-		t.Fatalf("did not expect synthetic compaction notice in detail view, got %q", stripANSIAndTrimRight(m.View()))
+		t.Fatalf("did not expect compaction status notice in detail view, got %q", stripANSIAndTrimRight(m.View()))
 	}
 }
 

--- a/cli/app/ui_runtime_adapter_test.go
+++ b/cli/app/ui_runtime_adapter_test.go
@@ -799,12 +799,12 @@ func TestApplyProjectedTranscriptEntriesForwardsCompactMetadataToLiveView(t *tes
 	}
 }
 
-func TestAppendTranscriptMsgFromEntryPreservesSyntheticCompactMetadata(t *testing.T) {
+func TestAppendTranscriptMsgFromEntryPreservesTransientCompactMetadata(t *testing.T) {
 	entry := transcriptEntryFromProjectedChatEntry(clientui.ChatEntry{
 		Visibility:        transcript.EntryVisibilityDetailOnly,
 		Role:              "warning",
-		Text:              "synthetic warning body",
-		OngoingText:       "synthetic warning",
+		Text:              "transient warning body",
+		OngoingText:       "transient warning",
 		Phase:             string(llm.MessagePhaseFinal),
 		MessageType:       string(llm.MessageTypeCompactionSoonReminder),
 		SourcePath:        "  docs/dev/decisions.md  ",
@@ -814,11 +814,11 @@ func TestAppendTranscriptMsgFromEntryPreservesSyntheticCompactMetadata(t *testin
 	}, true, false)
 
 	got := appendTranscriptMsgFromEntry(entry)
-	if !got.Transient || got.Committed || got.Visibility != transcript.EntryVisibilityDetailOnly || got.Role != "warning" || got.OngoingText != "synthetic warning" || got.Phase != llm.MessagePhaseFinal {
-		t.Fatalf("expected synthetic append state preserved, got %+v", got)
+	if !got.Transient || got.Committed || got.Visibility != transcript.EntryVisibilityDetailOnly || got.Role != "warning" || got.OngoingText != "transient warning" || got.Phase != llm.MessagePhaseFinal {
+		t.Fatalf("expected transient append state preserved, got %+v", got)
 	}
 	if got.MessageType != llm.MessageTypeCompactionSoonReminder || got.SourcePath != "docs/dev/decisions.md" || got.CompactLabel != "Compaction reminder" || got.ToolResultSummary != "summary text" || got.ToolCallID != "call-1" {
-		t.Fatalf("expected synthetic append to preserve compact metadata, got %+v", got)
+		t.Fatalf("expected transient append to preserve compact metadata, got %+v", got)
 	}
 }
 

--- a/cli/app/ui_runtime_client_control.go
+++ b/cli/app/ui_runtime_client_control.go
@@ -178,10 +178,14 @@ func cloneRuntimeGoal(goal *clientui.RuntimeGoal) *clientui.RuntimeGoal {
 }
 
 func (c *sessionRuntimeClient) AppendLocalEntry(role, text string) error {
+	return c.AppendLocalEntryWithNoticeID(role, text, "")
+}
+
+func (c *sessionRuntimeClient) AppendLocalEntryWithNoticeID(role, text, noticeID string) error {
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	return c.retryControlCallNoResult(ctx, func(controllerLeaseID string) error {
-		return c.controls.AppendLocalEntry(ctx, serverapi.RuntimeAppendLocalEntryRequest{ClientRequestID: uuid.NewString(), SessionID: c.sessionID, ControllerLeaseID: controllerLeaseID, Role: role, Text: text})
+		return c.controls.AppendLocalEntry(ctx, serverapi.RuntimeAppendLocalEntryRequest{ClientRequestID: uuid.NewString(), SessionID: c.sessionID, ControllerLeaseID: controllerLeaseID, Role: role, Text: text, NoticeID: strings.TrimSpace(noticeID)})
 	})
 }
 

--- a/cli/app/ui_runtime_control.go
+++ b/cli/app/ui_runtime_control.go
@@ -110,7 +110,18 @@ func (m *uiModel) clearRuntimeGoal() (*clientui.RuntimeGoal, error) {
 }
 
 func (m *uiModel) appendRuntimeLocalEntry(role, text string) error {
+	return m.appendRuntimeLocalEntryWithNoticeID(role, text, "")
+}
+
+func (m *uiModel) appendRuntimeLocalEntryWithNoticeID(role, text, noticeID string) error {
 	if client := m.runtimeClient(); client != nil {
+		if withNoticeID, ok := client.(interface {
+			AppendLocalEntryWithNoticeID(role, text, noticeID string) error
+		}); ok {
+			err := withNoticeID.AppendLocalEntryWithNoticeID(role, text, noticeID)
+			m.observeRuntimeRequestResult(err)
+			return err
+		}
 		err := client.AppendLocalEntry(role, text)
 		m.observeRuntimeRequestResult(err)
 		return err

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -146,15 +146,17 @@ type uiStatusFeatureState struct {
 	clipboardImagePaster        uiClipboardImagePaster
 	clipboardTextCopier         uiClipboardTextCopier
 
-	transientStatus       string
-	transientStatusKind   uiStatusNoticeKind
-	transientStatusToken  uint64
-	transientStatusQueue  []uiStatusNotice
-	startupUpdateNotice   bool
-	startupUpdateShown    bool
-	debugKeys             bool
-	debugMode             bool
-	transcriptDiagnostics bool
+	transientStatus         string
+	transientStatusKind     uiStatusNoticeKind
+	transientStatusNoticeID string
+	transientStatusToken    uint64
+	transientStatusQueue    []uiStatusNotice
+	localNoticeSequence     uint64
+	startupUpdateNotice     bool
+	startupUpdateShown      bool
+	debugKeys               bool
+	debugMode               bool
+	transcriptDiagnostics   bool
 }
 
 type uiTranscriptFeatureState struct {

--- a/cli/app/ui_transcript_entries.go
+++ b/cli/app/ui_transcript_entries.go
@@ -71,6 +71,7 @@ func transcriptEntryFromProjectedChatEntry(entry clientui.ChatEntry, transient b
 		CompactLabel:      strings.TrimSpace(entry.CompactLabel),
 		ToolResultSummary: strings.TrimSpace(entry.ToolResultSummary),
 		ToolCallID:        entry.ToolCallID,
+		NoticeID:          strings.TrimSpace(entry.NoticeID),
 		ToolCall:          transcriptToolCallMeta(entry.ToolCall),
 	}
 }
@@ -89,6 +90,7 @@ func appendTranscriptMsgFromEntry(entry tui.TranscriptEntry) tui.AppendTranscrip
 		CompactLabel:      strings.TrimSpace(entry.CompactLabel),
 		ToolResultSummary: strings.TrimSpace(entry.ToolResultSummary),
 		ToolCallID:        strings.TrimSpace(entry.ToolCallID),
+		NoticeID:          strings.TrimSpace(entry.NoticeID),
 		ToolCall:          entry.ToolCall,
 	}
 }
@@ -182,6 +184,7 @@ func transcriptPayloadFromTUIEntry(entry tui.TranscriptEntry) transcript.EntryPa
 		CompactLabel:      entry.CompactLabel,
 		ToolResultSummary: entry.ToolResultSummary,
 		ToolCallID:        entry.ToolCallID,
+		NoticeID:          entry.NoticeID,
 		ToolCall:          entry.ToolCall,
 	}
 }
@@ -199,6 +202,7 @@ func transcriptPayloadFromClientEntry(entry clientui.ChatEntry) transcript.Entry
 		CompactLabel:      entry.CompactLabel,
 		ToolResultSummary: entry.ToolResultSummary,
 		ToolCallID:        entry.ToolCallID,
+		NoticeID:          entry.NoticeID,
 		ToolCall:          transcriptToolCallMeta(entry.ToolCall),
 	}
 }

--- a/cli/app/ui_transcript_event_apply.go
+++ b/cli/app/ui_transcript_event_apply.go
@@ -71,11 +71,11 @@ func (a uiRuntimeAdapter) applyProjectedTranscriptEntries(evt clientui.Event, fl
 		convertedEntries = append(convertedEntries, transcriptEntryFromProjectedChatEntry(entry, reduction.projectedTransient, reduction.projectedCommitted))
 	}
 	showTransientInCurrentView := m.view.Mode() != tui.ModeDetail || !allTranscriptEntriesTransient(convertedEntries)
-	replaceLoadedSyntheticEntries := shouldReplaceLoadedSyntheticEntriesWithCommittedAppend(m, convertedEntries)
+	replaceLoadedTransientEntries := shouldReplaceLoadedTransientEntriesWithCommittedAppend(m, convertedEntries)
 	if plan.mode == projectedTranscriptEntryPlanAppend {
 		for _, transcriptEntry := range convertedEntries {
 			m.transcriptEntries = append(m.transcriptEntries, transcriptEntry)
-			if showTransientInCurrentView && !replaceLoadedSyntheticEntries {
+			if showTransientInCurrentView && !replaceLoadedTransientEntries {
 				m.forwardToView(appendTranscriptMsgFromEntry(transcriptEntry))
 			}
 		}
@@ -89,7 +89,7 @@ func (a uiRuntimeAdapter) applyProjectedTranscriptEntries(evt clientui.Event, fl
 	m.transcriptTotalEntries = max(m.transcriptTotalEntries, max(evt.CommittedEntryCount, m.transcriptBaseOffset+len(m.transcriptEntries)))
 	m.observeDirectCommittedEventDelivery(evt)
 	m.refreshRollbackCandidates()
-	if plan.mode == projectedTranscriptEntryPlanAppend && replaceLoadedSyntheticEntries {
+	if plan.mode == projectedTranscriptEntryPlanAppend && replaceLoadedTransientEntries {
 		m.forwardToView(tui.SetConversationMsg{
 			BaseOffset:   m.transcriptBaseOffset,
 			TotalEntries: m.transcriptTotalEntries,
@@ -130,12 +130,30 @@ func (a uiRuntimeAdapter) applyProjectedTranscriptEntries(evt clientui.Event, fl
 	if showTransientInCurrentView && m.view.Mode() == tui.ModeOngoing {
 		m.forwardToView(tui.SetOngoingScrollMsg{Scroll: m.view.OngoingScroll()})
 	}
+	if showTransientInCurrentView {
+		m.clearMirroredTransientStatus(convertedEntries)
+	}
 	if !flushNativeHistory {
 		m.logProjectedTranscriptAppliedDiag(evt, plan, incomingCount, len(entries), startOffset, entries, false)
 		return nil, true, false
 	}
 	m.logProjectedTranscriptAppliedDiag(evt, plan, incomingCount, len(entries), startOffset, entries, true)
 	return m.syncNativeHistoryFromTranscript(), true, false
+}
+
+func (m *uiModel) clearMirroredTransientStatus(entries []tui.TranscriptEntry) {
+	if m == nil || m.transientStatusNoticeID == "" {
+		return
+	}
+	for _, entry := range entries {
+		if entry.NoticeID != m.transientStatusNoticeID {
+			continue
+		}
+		m.transientStatus = ""
+		m.transientStatusKind = uiStatusNoticeNeutral
+		m.transientStatusNoticeID = ""
+		return
+	}
 }
 
 func (m *uiModel) observeDirectCommittedEventDelivery(evt clientui.Event) {

--- a/cli/app/ui_transcript_runtime_state.go
+++ b/cli/app/ui_transcript_runtime_state.go
@@ -53,24 +53,7 @@ func (m *uiModel) invalidateTransientTranscriptState() {
 	}
 }
 
-func shouldAppendSyntheticOngoingEntry(m *uiModel, entry *clientui.ChatEntry) bool {
-	if m == nil || entry == nil || !m.hasRuntimeClient() || m.view.Mode() != tui.ModeOngoing {
-		return false
-	}
-	role := tui.TranscriptRoleFromWire(entry.Role)
-	text := strings.TrimSpace(entry.Text)
-	if role == tui.TranscriptRoleUnknown || text == "" {
-		return false
-	}
-	for _, loaded := range m.view.LoadedTranscriptEntries() {
-		if transcriptEntryMatchesChatEntry(loaded, *entry) {
-			return false
-		}
-	}
-	return true
-}
-
-func shouldReplaceLoadedSyntheticEntriesWithCommittedAppend(m *uiModel, entries []tui.TranscriptEntry) bool {
+func shouldReplaceLoadedTransientEntriesWithCommittedAppend(m *uiModel, entries []tui.TranscriptEntry) bool {
 	if m == nil || m.view.Mode() != tui.ModeOngoing || len(entries) == 0 {
 		return false
 	}

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -37,6 +37,7 @@ type TranscriptEntry struct {
 	CompactLabel      string
 	ToolResultSummary string
 	ToolCallID        string
+	NoticeID          string
 	ToolCall          *transcript.ToolCallMeta
 }
 
@@ -88,6 +89,7 @@ type AppendTranscriptMsg struct {
 	CompactLabel      string
 	ToolResultSummary string
 	ToolCallID        string
+	NoticeID          string
 	ToolCall          *transcript.ToolCallMeta
 }
 

--- a/cli/tui/model_reducer.go
+++ b/cli/tui/model_reducer.go
@@ -199,6 +199,7 @@ func (m *Model) reduceAppendTranscriptMsg(msg AppendTranscriptMsg, result *model
 		CompactLabel:      strings.TrimSpace(msg.CompactLabel),
 		ToolResultSummary: strings.TrimSpace(msg.ToolResultSummary),
 		ToolCallID:        strings.TrimSpace(msg.ToolCallID),
+		NoticeID:          strings.TrimSpace(msg.NoticeID),
 		ToolCall:          cloneToolCallMeta(msg.ToolCall),
 	})
 	m.advanceTranscriptEntriesRevision()

--- a/docs/dev/decisions.md
+++ b/docs/dev/decisions.md
@@ -296,8 +296,8 @@
 - `type=compaction` items and encrypted reasoning/compaction payloads are treated as opaque and replayed unchanged.
 - Compaction lifecycle emits and persists started/completed/failed events.
 - Local compaction instructions are sent as `developer` messages, and local compaction summaries/checkpoints persist internally as `developer` messages with `message_type=compaction_summary`; any model-facing summary prefix is added only at the provider input boundary. Native/remote compaction has no transcript-message prompt equivalent because it uses provider `Instructions` plus opaque provider output, which Builder replays unchanged.
-- UI may surface a synthetic ongoing-only `context compacted for the Nth time` notice from compaction-completed runtime status. That live notice is not a durable transcript row and must not change detail-mode hydration or transcript authority.
-- Persisted compaction transcript rows still come only from server-owned transcript items/local entries. Ongoing suppresses detailed summary content; detail shows persisted compaction items in file order, including full local summary when available.
+- Compaction-completed runtime status never creates a UI-only transcript row. Transcript-visible compaction notices/summaries come only from server-owned transcript items/local entries.
+- Ongoing suppresses detailed summary content; detail shows persisted compaction items in file order, including full local summary when available.
 
 ## Model Defaults
 

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -24,6 +24,7 @@ type ChatEntry struct {
 	CompactLabel      string
 	ToolResultSummary string
 	ToolCallID        string
+	NoticeID          string
 	ToolCall          *transcript.ToolCallMeta
 }
 
@@ -227,14 +228,21 @@ func (s *chatStore) appendLocalEntryWithVisibility(role, text string, visibility
 }
 
 func (s *chatStore) appendLocalEntryWithOngoingTextAndVisibility(role, text, ongoingText string, visibility transcript.EntryVisibility) {
-	if strings.TrimSpace(text) == "" {
+	s.appendLocalEntryRecord(ChatEntry{Visibility: transcript.NormalizeEntryVisibility(visibility), Role: role, Text: text, OngoingText: strings.TrimSpace(ongoingText)})
+}
+
+func (s *chatStore) appendLocalEntryRecord(entry ChatEntry) {
+	if strings.TrimSpace(entry.Text) == "" {
 		return
 	}
+	entry.Visibility = transcript.NormalizeEntryVisibility(entry.Visibility)
+	entry.OngoingText = strings.TrimSpace(entry.OngoingText)
+	entry.NoticeID = strings.TrimSpace(entry.NoticeID)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	messageCount := s.messageCount
 	s.local = append(s.local, localChatEntry{
-		Entry:             ChatEntry{Visibility: transcript.NormalizeEntryVisibility(visibility), Role: role, Text: text, OngoingText: strings.TrimSpace(ongoingText)},
+		Entry:             entry,
 		AfterMessageCount: messageCount,
 	})
 	s.transcriptEntryCount++

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -178,6 +178,7 @@ func (e *Engine) appendPersistedLocalEntryRecord(stepID string, entry storedLoca
 	entry.Text = strings.TrimSpace(entry.Text)
 	entry.OngoingText = strings.TrimSpace(entry.OngoingText)
 	entry.DiagnosticKey = strings.TrimSpace(entry.DiagnosticKey)
+	entry.NoticeID = strings.TrimSpace(entry.NoticeID)
 	if entry.Role == "" || entry.Text == "" {
 		return nil
 	}
@@ -188,7 +189,7 @@ func (e *Engine) appendPersistedLocalEntryRecord(stepID string, entry storedLoca
 	}
 	_, err := e.store.AppendEvent(stepID, "local_entry", entry)
 	if err == nil {
-		e.chat.appendLocalEntryWithOngoingTextAndVisibility(entry.Role, entry.Text, entry.OngoingText, entry.Visibility)
+		e.chat.appendLocalEntryRecord(*localEntryChatEntry(entry))
 		e.emit(Event{Kind: EventLocalEntryAdded, StepID: stepID, LocalEntry: localEntryChatEntry(entry), CommittedTranscriptChanged: true})
 	}
 	return err
@@ -200,6 +201,7 @@ func localEntryChatEntry(entry storedLocalEntry) *ChatEntry {
 		Role:        strings.TrimSpace(entry.Role),
 		Text:        strings.TrimSpace(entry.Text),
 		OngoingText: strings.TrimSpace(entry.OngoingText),
+		NoticeID:    strings.TrimSpace(entry.NoticeID),
 	}
 }
 

--- a/server/runtime/engine_state.go
+++ b/server/runtime/engine_state.go
@@ -110,6 +110,15 @@ func (e *Engine) AppendLocalEntryWithVisibility(role, text string, visibility tr
 	})
 }
 
+func (e *Engine) AppendLocalEntryWithNoticeID(role, text, noticeID string) {
+	e.appendLocalEntry(storedLocalEntry{
+		Visibility: transcript.EntryVisibilityAuto,
+		Role:       strings.TrimSpace(role),
+		Text:       strings.TrimSpace(text),
+		NoticeID:   strings.TrimSpace(noticeID),
+	})
+}
+
 func (e *Engine) AppendLocalEntryWithOngoingText(role, text, ongoingText string) {
 	e.appendLocalEntry(storedLocalEntry{
 		Visibility:  transcript.EntryVisibilityAuto,
@@ -123,7 +132,7 @@ func (e *Engine) appendLocalEntry(entry storedLocalEntry) {
 	if entry.Role == "" || entry.Text == "" {
 		return
 	}
-	e.chat.appendLocalEntryWithOngoingTextAndVisibility(entry.Role, entry.Text, entry.OngoingText, entry.Visibility)
+	e.chat.appendLocalEntryRecord(*localEntryChatEntry(entry))
 	e.emit(Event{Kind: EventLocalEntryAdded, LocalEntry: localEntryChatEntry(entry)})
 	e.emitConversationUpdated("")
 }
@@ -430,6 +439,7 @@ type storedLocalEntry struct {
 	Text          string                     `json:"text"`
 	OngoingText   string                     `json:"ongoing_text,omitempty"`
 	DiagnosticKey string                     `json:"diagnostic_key,omitempty"`
+	NoticeID      string                     `json:"notice_id,omitempty"`
 }
 
 type historyReplacementPayload struct {

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -83,6 +83,7 @@ type localEntryMemoRequest struct {
 	Role       string
 	Text       string
 	Visibility transcript.EntryVisibility
+	NoticeID   string
 }
 
 type goalSetMemoRequest struct {
@@ -259,7 +260,7 @@ func (s *Service) AppendLocalEntry(ctx context.Context, req serverapi.RuntimeApp
 		return err
 	}
 	visibility := transcript.NormalizeEntryVisibility(transcript.EntryVisibility(req.Visibility))
-	memoReq := localEntryMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Role: strings.TrimSpace(req.Role), Text: req.Text, Visibility: visibility}
+	memoReq := localEntryMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Role: strings.TrimSpace(req.Role), Text: req.Text, Visibility: visibility, NoticeID: strings.TrimSpace(req.NoticeID)}
 	_, err := s.localEntries.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameLocalEntryMemoRequest, func(ctx context.Context) (struct{}, error) {
 		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
 			return struct{}{}, err
@@ -268,7 +269,9 @@ func (s *Service) AppendLocalEntry(ctx context.Context, req serverapi.RuntimeApp
 		if err != nil {
 			return struct{}{}, err
 		}
-		if visibility == transcript.EntryVisibilityAuto {
+		if visibility == transcript.EntryVisibilityAuto && strings.TrimSpace(req.NoticeID) != "" {
+			engine.AppendLocalEntryWithNoticeID(req.Role, req.Text, req.NoticeID)
+		} else if visibility == transcript.EntryVisibilityAuto {
 			engine.AppendLocalEntry(req.Role, req.Text)
 		} else {
 			engine.AppendLocalEntryWithVisibility(req.Role, req.Text, visibility)
@@ -672,7 +675,7 @@ func sameSessionOnlyMemoRequest(a sessionOnlyMemoRequest, b sessionOnlyMemoReque
 }
 
 func sameLocalEntryMemoRequest(a localEntryMemoRequest, b localEntryMemoRequest) bool {
-	return a.SessionID == b.SessionID && a.Role == b.Role && a.Text == b.Text && a.Visibility == b.Visibility
+	return a.SessionID == b.SessionID && a.Role == b.Role && a.Text == b.Text && a.Visibility == b.Visibility && a.NoticeID == b.NoticeID
 }
 
 func sameGoalSetMemoRequest(a goalSetMemoRequest, b goalSetMemoRequest) bool {

--- a/server/runtimeview/projection.go
+++ b/server/runtimeview/projection.go
@@ -189,6 +189,7 @@ func chatEntriesFromRuntime(entries []runtime.ChatEntry) []clientui.ChatEntry {
 			CompactLabel:      entry.CompactLabel,
 			ToolResultSummary: entry.ToolResultSummary,
 			ToolCallID:        entry.ToolCallID,
+			NoticeID:          entry.NoticeID,
 			ToolCall:          cloneToolCallMeta(entry.ToolCall),
 		})
 	}
@@ -242,6 +243,7 @@ func ChatSnapshotFromRuntime(snapshot runtime.ChatSnapshot) clientui.ChatSnapsho
 			CompactLabel:      entry.CompactLabel,
 			ToolResultSummary: entry.ToolResultSummary,
 			ToolCallID:        entry.ToolCallID,
+			NoticeID:          entry.NoticeID,
 			ToolCall:          cloneToolCallMeta(entry.ToolCall),
 		})
 	}

--- a/shared/architecture/boundary_test.go
+++ b/shared/architecture/boundary_test.go
@@ -108,6 +108,57 @@ func TestCLIAppUIFilesDoNotAddServerImports(t *testing.T) {
 	}
 }
 
+func TestCLIUIFilesDoNotBypassServerAttachService(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	violations := make([]string, 0)
+	for _, root := range []string{
+		filepath.Join(repoRoot, "cli", "app"),
+		filepath.Join(repoRoot, "cli", "tui"),
+	} {
+		if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if path != root && root == filepath.Join(repoRoot, "cli", "app") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			base := filepath.Base(path)
+			isAppUI := root == filepath.Join(repoRoot, "cli", "app") && strings.HasPrefix(base, "ui")
+			isTUI := strings.Contains(filepath.ToSlash(path), "/cli/tui/")
+			if !isAppUI && !isTUI {
+				return nil
+			}
+			fileSet := token.NewFileSet()
+			file, parseErr := parser.ParseFile(fileSet, path, nil, parser.ImportsOnly)
+			if parseErr != nil {
+				return parseErr
+			}
+			relPath, relErr := filepath.Rel(repoRoot, path)
+			if relErr != nil {
+				relPath = path
+			}
+			for _, spec := range file.Imports {
+				importPath := strings.Trim(spec.Path.Value, "\"")
+				if importPath == "builder/cli/app/internal/serverattach" || importPath == "builder/cli/app/internal/remoteattach" {
+					violations = append(violations, relPath+": UI files must not import startup attachment package "+importPath)
+				}
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("scan UI sources under %s: %v", root, err)
+		}
+	}
+	if len(violations) > 0 {
+		t.Fatalf("cli UI server attach bypass violations:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
 func TestCLIAppRootFilesDoNotImportServerPackages(t *testing.T) {
 	repoRoot := findRepoRoot(t)
 	violations := make([]string, 0)
@@ -138,6 +189,86 @@ func TestCLIAppDoesNotReintroduceEmbeddedServerServiceLocator(t *testing.T) {
 	})
 	if len(violations) > 0 {
 		t.Fatalf("cli app embeddedServer service-locator violations:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+func TestCLIAppStartupEntrypointsUseServerAttach(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	for _, relPath := range []string{
+		filepath.Join("cli", "app", "session_server_target.go"),
+		filepath.Join("cli", "app", "run_prompt_target.go"),
+	} {
+		path := filepath.Join(repoRoot, relPath)
+		fileSet := token.NewFileSet()
+		file, err := parser.ParseFile(fileSet, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse %s: %v", relPath, err)
+		}
+		importsServerAttach := false
+		violations := make([]string, 0)
+		for _, spec := range file.Imports {
+			importPath := strings.Trim(spec.Path.Value, "\"")
+			switch importPath {
+			case "builder/cli/app/internal/serverattach":
+				importsServerAttach = true
+			case "builder/cli/app/internal/targetstartup", "builder/cli/app/internal/targetresolve":
+				violations = append(violations, relPath+": startup entrypoint must use serverattach instead of "+importPath)
+			}
+		}
+		if !importsServerAttach {
+			violations = append(violations, relPath+": startup entrypoint must import serverattach")
+		}
+		usesResolve := false
+		ast.Inspect(file, func(node ast.Node) bool {
+			selector, ok := node.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := selector.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if ident.Name == "serverattach" && selector.Sel.Name == "Resolve" {
+				usesResolve = true
+			}
+			if ident.Name == "remoteattach" && (selector.Sel.Name == "DialHeadless" || selector.Sel.Name == "DialInteractive") {
+				violations = append(violations, relPath+": startup entrypoint must not call remoteattach."+selector.Sel.Name+" directly")
+			}
+			return true
+		})
+		if !usesResolve {
+			violations = append(violations, relPath+": startup entrypoint must resolve targets through serverattach.Resolve")
+		}
+		if len(violations) > 0 {
+			t.Fatalf("startup server attach boundary violations:\n%s", strings.Join(violations, "\n"))
+		}
+	}
+}
+
+func TestCLIAppStartupFilesDoNotReachIntoEmbeddedInternals(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	for _, relPath := range []string{
+		filepath.Join("cli", "app", "session_server_target.go"),
+		filepath.Join("cli", "app", "run_prompt_target.go"),
+		filepath.Join("cli", "app", "session_lifecycle.go"),
+	} {
+		path := filepath.Join(repoRoot, relPath)
+		fileSet := token.NewFileSet()
+		file, err := parser.ParseFile(fileSet, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse %s: %v", relPath, err)
+		}
+		violations := make([]string, 0)
+		ast.Inspect(file, func(node ast.Node) bool {
+			selector, ok := node.(*ast.SelectorExpr)
+			if ok && selector.Sel.Name == "inner" {
+				violations = append(violations, relPath+": startup files must use narrow embedded attachments instead of embeddedAppServer.inner")
+			}
+			return true
+		})
+		if len(violations) > 0 {
+			t.Fatalf("embedded startup boundary violations:\n%s", strings.Join(violations, "\n"))
+		}
 	}
 }
 
@@ -928,6 +1059,58 @@ func TestCLIAppInternalTargetStartupBoundary(t *testing.T) {
 	}
 	if len(violations) > 0 {
 		t.Fatalf("cli app internal target startup boundary violations:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+func TestCLIAppInternalServerAttachBoundary(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	root := filepath.Join(repoRoot, "cli", "app", "internal", "serverattach")
+	violations := make([]string, 0)
+	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fileSet := token.NewFileSet()
+		file, parseErr := parser.ParseFile(fileSet, path, nil, parser.SkipObjectResolution)
+		if parseErr != nil {
+			return parseErr
+		}
+		relPath, relErr := filepath.Rel(repoRoot, path)
+		if relErr != nil {
+			relPath = path
+		}
+		for _, spec := range file.Imports {
+			importPath := strings.Trim(spec.Path.Value, "\"")
+			switch {
+			case strings.HasPrefix(importPath, "builder/server/"):
+				violations = append(violations, relPath+": server attach package must not import server package "+importPath)
+			case importPath == "github.com/charmbracelet/bubbletea":
+				violations = append(violations, relPath+": server attach package must not import Bubble Tea")
+			case importPath == "builder/cli/app/commands":
+				violations = append(violations, relPath+": server attach package must not import app commands")
+			case importPath == "builder/cli/app":
+				violations = append(violations, relPath+": server attach package must not import app package")
+			}
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			ident, ok := node.(*ast.Ident)
+			if ok && ident.Name == "uiModel" {
+				violations = append(violations, relPath+": server attach package must not reference uiModel")
+			}
+			return true
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("scan cli app internal server attach sources: %v", err)
+	}
+	if len(violations) > 0 {
+		t.Fatalf("cli app internal server attach boundary violations:\n%s", strings.Join(violations, "\n"))
 	}
 }
 

--- a/shared/clientui/runtime_events.go
+++ b/shared/clientui/runtime_events.go
@@ -71,9 +71,8 @@ type RuntimeAssistantStreamCommand struct {
 }
 
 type RuntimeTranscriptReduction struct {
-	Sync                  RuntimeTranscriptSyncCommand
-	AssistantStream       []RuntimeAssistantStreamCommand
-	SyntheticOngoingEntry *ChatEntry
+	Sync            RuntimeTranscriptSyncCommand
+	AssistantStream []RuntimeAssistantStreamCommand
 }
 
 type RuntimeActivityCommand uint8

--- a/shared/clientui/runtime_events_test.go
+++ b/shared/clientui/runtime_events_test.go
@@ -217,7 +217,7 @@ func TestReduceRuntimeEvent_BackgroundCompletionFallsBackWithoutCompactText(t *t
 	}
 }
 
-func TestReduceRuntimeEvent_CompactionCompletedClearsCompactingWithoutSyntheticNotice(t *testing.T) {
+func TestReduceRuntimeEvent_CompactionCompletedClearsCompacting(t *testing.T) {
 	update := ReduceRuntimeEvent(
 		RuntimeRunState{Compacting: true},
 		RuntimeConversationState{},
@@ -230,8 +230,8 @@ func TestReduceRuntimeEvent_CompactionCompletedClearsCompactingWithoutSyntheticN
 	if update.RunState.State.Compacting {
 		t.Fatal("expected compaction completed to clear compacting state")
 	}
-	if update.Transcript.SyntheticOngoingEntry != nil {
-		t.Fatalf("did not expect synthetic ongoing compaction notice, got %+v", update.Transcript.SyntheticOngoingEntry)
+	if update.Transcript.Sync.IsSet() || len(update.Transcript.AssistantStream) != 0 {
+		t.Fatalf("expected compaction completed to leave transcript unchanged, got %+v", update.Transcript)
 	}
 }
 

--- a/shared/clientui/types.go
+++ b/shared/clientui/types.go
@@ -113,6 +113,7 @@ type ChatEntry struct {
 	CompactLabel      string
 	ToolResultSummary string
 	ToolCallID        string
+	NoticeID          string
 	ToolCall          *ToolCallMeta
 }
 

--- a/shared/serverapi/runtime_control.go
+++ b/shared/serverapi/runtime_control.go
@@ -65,6 +65,7 @@ type RuntimeAppendLocalEntryRequest struct {
 	Role              string `json:"role"`
 	Text              string `json:"text"`
 	Visibility        string `json:"visibility,omitempty"`
+	NoticeID          string `json:"notice_id,omitempty"`
 }
 
 type RuntimeShouldCompactBeforeUserMessageRequest struct {

--- a/shared/transcript/entry_compare.go
+++ b/shared/transcript/entry_compare.go
@@ -22,6 +22,7 @@ type EntryPayload struct {
 	CompactLabel      string
 	ToolResultSummary string
 	ToolCallID        string
+	NoticeID          string
 	ToolCall          *ToolCallMeta
 }
 
@@ -39,6 +40,7 @@ func EntryPayloadEqual(left, right EntryPayload) bool {
 		strings.TrimSpace(left.CompactLabel) == strings.TrimSpace(right.CompactLabel) &&
 		strings.TrimSpace(left.ToolResultSummary) == strings.TrimSpace(right.ToolResultSummary) &&
 		strings.TrimSpace(left.ToolCallID) == strings.TrimSpace(right.ToolCallID) &&
+		strings.TrimSpace(left.NoticeID) == strings.TrimSpace(right.NoticeID) &&
 		ToolCallMetaEqual(left.ToolCall, right.ToolCall)
 }
 


### PR DESCRIPTION
## Summary
- Add shared server attachment composition for interactive/headless startup target resolution
- Route session and run-prompt startup through shared remote/daemon/embedded policy
- Add capability/auth/ownership metadata tests and startup boundary checks

## Verification
- ./scripts/test.sh ./cli/app/internal/serverattach ./cli/app ./shared/architecture
- ./scripts/build.sh --output ./bin/builder
- pre-push hook: formatting, go vet, go build, test