### PR TITLE
Fix worktree statusline and picker rendering regressions

### DIFF
--- a/cli/app/internal/status/status.go
+++ b/cli/app/internal/status/status.go
@@ -40,6 +40,7 @@ type Request struct {
 	Runtime               clientui.RuntimeClient
 	WorkspaceRoot         string
 	PersistenceRoot       string
+	ExecutionTarget       clientui.SessionExecutionTarget
 	SessionViews          client.SessionViewClient
 	Settings              config.Settings
 	Source                config.SourceReport
@@ -318,6 +319,9 @@ func EnvironmentCacheKey(req Request) string {
 }
 
 func ExecutionTarget(req Request) clientui.SessionExecutionTarget {
+	if !clientui.SessionExecutionTargetIsZero(req.ExecutionTarget) {
+		return req.ExecutionTarget
+	}
 	if req.Runtime == nil {
 		return clientui.SessionExecutionTarget{}
 	}

--- a/cli/app/internal/status/status_test.go
+++ b/cli/app/internal/status/status_test.go
@@ -1,0 +1,114 @@
+package status
+
+import (
+	"context"
+	"testing"
+
+	"builder/shared/clientui"
+)
+
+func TestExecutionTargetPrefersExplicitRequestTargetOverRuntimeView(t *testing.T) {
+	runtimeTarget := clientui.SessionExecutionTarget{WorktreeRoot: "/old", EffectiveWorkdir: "/old/pkg"}
+	explicitTarget := clientui.SessionExecutionTarget{WorktreeRoot: "/new", EffectiveWorkdir: "/new/pkg"}
+
+	got := ExecutionTarget(Request{
+		Runtime:         stubRuntimeClient{target: runtimeTarget},
+		ExecutionTarget: explicitTarget,
+	})
+
+	if !clientui.SessionExecutionTargetsEqual(got, explicitTarget) {
+		t.Fatalf("execution target = %+v, want explicit %+v", got, explicitTarget)
+	}
+}
+
+func TestExecutionTargetFallsBackToRuntimeViewWhenExplicitTargetIsEmpty(t *testing.T) {
+	runtimeTarget := clientui.SessionExecutionTarget{WorktreeRoot: "/runtime", EffectiveWorkdir: "/runtime/pkg"}
+
+	got := ExecutionTarget(Request{Runtime: stubRuntimeClient{target: runtimeTarget}})
+
+	if !clientui.SessionExecutionTargetsEqual(got, runtimeTarget) {
+		t.Fatalf("execution target = %+v, want runtime %+v", got, runtimeTarget)
+	}
+}
+
+type stubRuntimeClient struct {
+	target clientui.SessionExecutionTarget
+}
+
+func (s stubRuntimeClient) MainView() clientui.RuntimeMainView {
+	return clientui.RuntimeMainView{Session: s.SessionView()}
+}
+
+func (s stubRuntimeClient) RefreshMainView() (clientui.RuntimeMainView, error) {
+	return s.MainView(), nil
+}
+
+func (s stubRuntimeClient) Transcript() clientui.TranscriptPage { return clientui.TranscriptPage{} }
+
+func (s stubRuntimeClient) RefreshTranscript() (clientui.TranscriptPage, error) {
+	return clientui.TranscriptPage{}, nil
+}
+
+func (s stubRuntimeClient) RefreshTranscriptPage(clientui.TranscriptPageRequest) (clientui.TranscriptPage, error) {
+	return clientui.TranscriptPage{}, nil
+}
+
+func (s stubRuntimeClient) LoadTranscriptPage(clientui.TranscriptPageRequest) (clientui.TranscriptPage, error) {
+	return clientui.TranscriptPage{}, nil
+}
+
+func (s stubRuntimeClient) Status() clientui.RuntimeStatus { return clientui.RuntimeStatus{} }
+
+func (s stubRuntimeClient) SessionView() clientui.RuntimeSessionView {
+	return clientui.RuntimeSessionView{ExecutionTarget: s.target}
+}
+
+func (s stubRuntimeClient) SetSessionName(string) error { return nil }
+
+func (s stubRuntimeClient) SetThinkingLevel(string) error { return nil }
+
+func (s stubRuntimeClient) SetFastModeEnabled(bool) (bool, error) { return false, nil }
+
+func (s stubRuntimeClient) SetReviewerEnabled(bool) (bool, string, error) {
+	return false, "", nil
+}
+
+func (s stubRuntimeClient) SetAutoCompactionEnabled(bool) (bool, bool, error) {
+	return false, false, nil
+}
+
+func (s stubRuntimeClient) ShowGoal() (*clientui.RuntimeGoal, error) { return nil, nil }
+
+func (s stubRuntimeClient) SetGoal(string) (*clientui.RuntimeGoal, error) { return nil, nil }
+
+func (s stubRuntimeClient) PauseGoal() (*clientui.RuntimeGoal, error) { return nil, nil }
+
+func (s stubRuntimeClient) ResumeGoal() (*clientui.RuntimeGoal, error) { return nil, nil }
+
+func (s stubRuntimeClient) ClearGoal() (*clientui.RuntimeGoal, error) { return nil, nil }
+
+func (s stubRuntimeClient) AppendLocalEntry(string, string) error { return nil }
+
+func (s stubRuntimeClient) SubmitUserMessage(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (s stubRuntimeClient) SubmitUserShellCommand(context.Context, string) error { return nil }
+
+func (s stubRuntimeClient) CompactContext(context.Context, string) error { return nil }
+
+func (s stubRuntimeClient) HasQueuedUserWork() (bool, error) { return false, nil }
+
+func (s stubRuntimeClient) SubmitQueuedUserMessages(context.Context) (string, error) {
+	return "", nil
+}
+
+func (s stubRuntimeClient) Interrupt() error { return nil }
+
+func (s stubRuntimeClient) QueueUserMessage(string) (clientui.QueuedUserMessage, error) {
+	return clientui.QueuedUserMessage{}, nil
+}
+
+func (s stubRuntimeClient) DiscardQueuedUserMessage(string) bool { return false }
+
+func (s stubRuntimeClient) RecordPromptHistory(string) error { return nil }

--- a/cli/app/internal/statuscollect/auth.go
+++ b/cli/app/internal/statuscollect/auth.go
@@ -70,7 +70,7 @@ func AuthInfo(state auth.State, settings config.Settings, statusErr error) appst
 		}
 		return appstatus.AuthInfo{Summary: summary, Details: details, Visible: true}
 	case auth.MethodAPIKey:
-		summary := apiKeyAuthSummary(state.Method.APIKey)
+		summary := auth.MaskedAPIKeySummary(state.Method.APIKey)
 		if provider := ProviderLabel(state, settings); provider != "" {
 			details = append(details, provider)
 		}
@@ -87,22 +87,6 @@ func AuthInfo(state auth.State, settings config.Settings, statusErr error) appst
 		}
 		return appstatus.AuthInfo{Summary: "No Auth", Visible: true}
 	}
-}
-
-func apiKeyAuthSummary(apiKey *auth.APIKeyMethod) string {
-	key := ""
-	if apiKey != nil {
-		key = strings.TrimSpace(apiKey.Key)
-	}
-	if key == "" {
-		return "API Key"
-	}
-	runes := []rune(key)
-	start := len(runes) - 4
-	if start < 0 {
-		start = 0
-	}
-	return "API Key ..." + string(runes[start:])
 }
 
 func AuthCacheIdentity(manager AuthStateLoader) string {

--- a/cli/app/internal/statuscollect/auth.go
+++ b/cli/app/internal/statuscollect/auth.go
@@ -70,7 +70,7 @@ func AuthInfo(state auth.State, settings config.Settings, statusErr error) appst
 		}
 		return appstatus.AuthInfo{Summary: summary, Details: details, Visible: true}
 	case auth.MethodAPIKey:
-		summary := "API key"
+		summary := apiKeyAuthSummary(state.Method.APIKey)
 		if provider := ProviderLabel(state, settings); provider != "" {
 			details = append(details, provider)
 		}
@@ -85,8 +85,24 @@ func AuthInfo(state auth.State, settings config.Settings, statusErr error) appst
 		if statusErr != nil {
 			return appstatus.AuthInfo{Summary: "Auth unavailable", Details: []string{statusErr.Error()}, Visible: true}
 		}
-		return appstatus.AuthInfo{}
+		return appstatus.AuthInfo{Summary: "No Auth", Visible: true}
 	}
+}
+
+func apiKeyAuthSummary(apiKey *auth.APIKeyMethod) string {
+	key := ""
+	if apiKey != nil {
+		key = strings.TrimSpace(apiKey.Key)
+	}
+	if key == "" {
+		return "API Key"
+	}
+	runes := []rune(key)
+	start := len(runes) - 4
+	if start < 0 {
+		start = 0
+	}
+	return "API Key ..." + string(runes[start:])
 }
 
 func AuthCacheIdentity(manager AuthStateLoader) string {

--- a/cli/app/internal/statuscollect/collector_test.go
+++ b/cli/app/internal/statuscollect/collector_test.go
@@ -79,6 +79,19 @@ func TestCollectorUsesRefreshedOAuthStateForUsageFetch(t *testing.T) {
 	}
 }
 
+func TestAuthInfoSummarizesNoAuthAndAPIKey(t *testing.T) {
+	noAuth := AuthInfo(auth.State{}, config.Settings{}, nil)
+	if noAuth.Summary != "No Auth" || !noAuth.Visible {
+		t.Fatalf("no-auth summary = %+v, want visible No Auth", noAuth)
+	}
+	apiKey := AuthInfo(auth.State{
+		Method: auth.Method{Type: auth.MethodAPIKey, APIKey: &auth.APIKeyMethod{Key: "sk-test-1234"}},
+	}, config.Settings{}, nil)
+	if apiKey.Summary != "API Key ...1234" || !apiKey.Visible {
+		t.Fatalf("api-key summary = %+v, want masked API key", apiKey)
+	}
+}
+
 func TestCollectorPreservesStoredAuthStateWhenRefreshFails(t *testing.T) {
 	now := time.Date(2026, time.January, 1, 10, 0, 0, 0, time.UTC)
 	store := auth.NewMemoryStore(auth.State{

--- a/cli/app/ui_diff_render_test.go
+++ b/cli/app/ui_diff_render_test.go
@@ -102,7 +102,7 @@ func TestCustomPatchToolCallRendersSummaryOngoingAndHighlightedDiffDetail(t *tes
 	}))
 
 	ongoing := stripANSIAndTrimRight(m.view.OngoingSnapshot())
-	if !strings.Contains(ongoing, "⇄ ./cli/app/ui_status.go +2 -1") || strings.Contains(ongoing, "Edited:") {
+	if !strings.Contains(ongoing, "⇄ ./cli/app/ui_status.go -1 +2") || strings.Contains(ongoing, "Edited:") {
 		t.Fatalf("expected custom patch summary in ongoing transcript, got %q", ongoing)
 	}
 	if strings.Contains(ongoing, "*** Begin Patch") || strings.Contains(ongoing, "+\tReady bool") {

--- a/cli/app/ui_layout_rendering_status_overlay.go
+++ b/cli/app/ui_layout_rendering_status_overlay.go
@@ -97,41 +97,6 @@ func (l uiViewLayout) statusOverlayContentLines(width int) []string {
 
 	snapshot := m.status.snapshot
 
-	authSummary := statusVisibleAuthSummary(snapshot.Auth, snapshot.Subscription)
-	subscriptionSummary := strings.TrimSpace(snapshot.Subscription.Summary)
-	hasSubscriptionRows := len(snapshot.Subscription.Windows) > 0
-	showAccountSection := authSummary != "" || subscriptionSummary != "" || hasSubscriptionRows || l.statusSectionLoading(uiStatusSectionAuth)
-	if showAccountSection {
-		if subscriptionSummary != "" || hasSubscriptionRows {
-			appendSectionTitle("Subscription")
-		} else {
-			appendSectionTitle("Account")
-		}
-		if authSummary != "" {
-			appendWrapped(authSummary, boldStyle)
-		} else if subscriptionSummary == "" && !hasSubscriptionRows && l.statusSectionLoading(uiStatusSectionAuth) {
-			appendWrapped("Loading account...", subtleStyle)
-		}
-		if subscriptionSummary != "" {
-			if strings.TrimSpace(snapshot.Subscription.Error) != "" {
-				appendWrapped(subscriptionSummary, warningStyle)
-			} else {
-				appendWrapped(subscriptionSummary, boldStyle)
-			}
-		}
-		if hasSubscriptionRows {
-			labelWidth := statusSubscriptionLabelWidth(snapshot.Subscription.Windows)
-			for _, window := range snapshot.Subscription.Windows {
-				appendANSI(l.renderStatusSubscriptionLine(width, window, labelWidth))
-			}
-		} else if subscriptionSummary != "" && l.statusSectionLoading(uiStatusSectionAuth) {
-			appendWrapped("Loading limits...", subtleStyle)
-		}
-		for _, detail := range snapshot.Auth.Details {
-			appendWrapped(detail, subtleStyle)
-		}
-	}
-
 	appendSectionTitle("Session")
 	if snapshot.OwnsServer {
 		appendWrapped("Server: owned by this CLI", lipgloss.Style{})
@@ -171,6 +136,48 @@ func (l uiViewLayout) statusOverlayContentLines(width int) []string {
 	appendWrapped("debug "+statusOnOff(snapshot.Config.Debug), lipgloss.Style{})
 	appendWrapped(fmt.Sprintf("%d compactions", snapshot.CompactionCount), lipgloss.Style{})
 
+	authSummary := statusVisibleAuthSummary(snapshot.Auth, snapshot.Subscription)
+	subscriptionSummary := strings.TrimSpace(snapshot.Subscription.Summary)
+	hasSubscriptionRows := len(snapshot.Subscription.Windows) > 0
+	showAccountSection := authSummary != "" || subscriptionSummary != "" || hasSubscriptionRows || l.statusSectionLoading(uiStatusSectionAuth)
+	if showAccountSection {
+		if subscriptionSummary != "" || hasSubscriptionRows {
+			appendSectionTitle("Subscription")
+		} else {
+			appendSectionTitle("Account")
+		}
+		if authSummary != "" {
+			appendWrapped(authSummary, boldStyle)
+		} else if subscriptionSummary == "" && !hasSubscriptionRows && l.statusSectionLoading(uiStatusSectionAuth) {
+			appendWrapped("Loading account...", subtleStyle)
+		}
+		if subscriptionSummary != "" {
+			if strings.TrimSpace(snapshot.Subscription.Error) != "" {
+				appendWrapped(subscriptionSummary, warningStyle)
+			} else {
+				appendWrapped(subscriptionSummary, boldStyle)
+			}
+		}
+		if hasSubscriptionRows {
+			labelWidth := statusSubscriptionLabelWidth(snapshot.Subscription.Windows)
+			for _, window := range snapshot.Subscription.Windows {
+				appendANSI(l.renderStatusSubscriptionLine(width, window, labelWidth))
+			}
+		} else if subscriptionSummary != "" && l.statusSectionLoading(uiStatusSectionAuth) {
+			appendWrapped("Loading limits...", subtleStyle)
+		}
+		for _, detail := range snapshot.Auth.Details {
+			appendWrapped(detail, subtleStyle)
+		}
+	}
+
+	appendSectionTitle("Config")
+	appendWrapped(statusDisplayPath(snapshot.Config.SettingsPath, snapshot.Workdir), subtleStyle)
+	if len(snapshot.Config.OverrideSources) > 0 {
+		appendWrapped("overrides: "+strings.Join(snapshot.Config.OverrideSources, ", "), lipgloss.Style{})
+	}
+	appendWrapped("supervisor "+snapshot.Config.Supervisor, lipgloss.Style{})
+
 	loadedSkills, failedSkills := statusPartitionSkills(snapshot.Skills)
 	subheaderStyle := lipgloss.NewStyle().Foreground(palette.primary).Bold(true)
 	directoryStyle := lipgloss.NewStyle().Foreground(palette.foreground)
@@ -209,13 +216,6 @@ func (l uiViewLayout) statusOverlayContentLines(width int) []string {
 			appendWrapped(statusAgentTokenLine(path, snapshot.AgentTokenCounts, snapshot.Workdir), lipgloss.Style{})
 		}
 	}
-
-	appendSectionTitle("Config")
-	appendWrapped(statusDisplayPath(snapshot.Config.SettingsPath, snapshot.Workdir), subtleStyle)
-	if len(snapshot.Config.OverrideSources) > 0 {
-		appendWrapped("overrides: "+strings.Join(snapshot.Config.OverrideSources, ", "), lipgloss.Style{})
-	}
-	appendWrapped("supervisor "+snapshot.Config.Supervisor, lipgloss.Style{})
 
 	if warning := strings.TrimSpace(snapshot.CollectorWarning); warning != "" {
 		appendSectionTitle("Warnings")

--- a/cli/app/ui_layout_rendering_status_overlay.go
+++ b/cli/app/ui_layout_rendering_status_overlay.go
@@ -198,7 +198,9 @@ func (l uiViewLayout) statusOverlayContentLines(width int) []string {
 				}
 				line := treeStyle.Render(branch + " ")
 				if skill.Loaded {
-					line += statusSkillLine(skill, snapshot.SkillTokenCounts)
+					line += statusSkillLineStyled(skill, snapshot.SkillTokenCounts, func(label string) string {
+						return subtleStyle.Render(label)
+					})
 				} else {
 					line += errorStyle.Render("! ") + statusSkillFailureLine(skill)
 				}

--- a/cli/app/ui_layout_rendering_status_overlay.go
+++ b/cli/app/ui_layout_rendering_status_overlay.go
@@ -31,6 +31,31 @@ func (l uiViewLayout) renderStatusOverlay(width, height int, _ uiStyles) []strin
 	return visible
 }
 
+type statusOverlayLineStyle uint8
+
+const (
+	statusOverlayLineStyleNormal statusOverlayLineStyle = iota
+	statusOverlayLineStyleBold
+	statusOverlayLineStyleSubtle
+)
+
+type statusOverlayLine struct {
+	Text  string
+	Style statusOverlayLineStyle
+}
+
+func statusOverlaySessionLines(snapshot uiStatusSnapshot) []statusOverlayLine {
+	lines := make([]statusOverlayLine, 0, 3)
+	if sessionName := strings.TrimSpace(snapshot.SessionName); sessionName != "" {
+		lines = append(lines, statusOverlayLine{Text: sessionName, Style: statusOverlayLineStyleBold})
+	}
+	lines = append(lines, statusOverlayLine{Text: "Session ID: " + statusValueOrFallback(snapshot.SessionID, "session unknown"), Style: statusOverlayLineStyleNormal})
+	if parentSummary := statusParentSessionSummary(snapshot); parentSummary != "" {
+		lines = append(lines, statusOverlayLine{Text: parentSummary, Style: statusOverlayLineStyleSubtle})
+	}
+	return lines
+}
+
 func (l uiViewLayout) statusOverlayContentLines(width int) []string {
 	m := l.model
 	palette := uiPalette(m.theme)
@@ -116,12 +141,15 @@ func (l uiViewLayout) statusOverlayContentLines(width int) []string {
 	if updateLine := l.renderStatusUpdateLine(width, snapshot.Update); updateLine != "" {
 		appendANSI(updateLine)
 	}
-	if sessionName := strings.TrimSpace(snapshot.SessionName); sessionName != "" {
-		appendWrapped(sessionName, boldStyle)
-	}
-	appendWrapped("Session ID: "+statusValueOrFallback(snapshot.SessionID, "session unknown"), lipgloss.Style{})
-	if parentSummary := statusParentSessionSummary(snapshot); parentSummary != "" {
-		appendWrapped(parentSummary, subtleStyle)
+	for _, line := range statusOverlaySessionLines(snapshot) {
+		switch line.Style {
+		case statusOverlayLineStyleBold:
+			appendWrapped(line.Text, boldStyle)
+		case statusOverlayLineStyleSubtle:
+			appendWrapped(line.Text, subtleStyle)
+		default:
+			appendWrapped(line.Text, lipgloss.Style{})
+		}
 	}
 
 	if l.statusSectionLoading(uiStatusSectionGit) || snapshot.Git.Visible || strings.TrimSpace(snapshot.Git.Error) != "" {

--- a/cli/app/ui_layout_rendering_status_overlay.go
+++ b/cli/app/ui_layout_rendering_status_overlay.go
@@ -198,9 +198,7 @@ func (l uiViewLayout) statusOverlayContentLines(width int) []string {
 				}
 				line := treeStyle.Render(branch + " ")
 				if skill.Loaded {
-					line += statusSkillLineStyled(skill, snapshot.SkillTokenCounts, func(label string) string {
-						return subtleStyle.Render(label)
-					})
+					line += statusSkillLineStyled(skill, snapshot.SkillTokenCounts, subtleStyle)
 				} else {
 					line += errorStyle.Render("! ") + statusSkillFailureLine(skill)
 				}

--- a/cli/app/ui_layout_rendering_status_overlay.go
+++ b/cli/app/ui_layout_rendering_status_overlay.go
@@ -141,11 +141,7 @@ func (l uiViewLayout) statusOverlayContentLines(width int) []string {
 	hasSubscriptionRows := len(snapshot.Subscription.Windows) > 0
 	showAccountSection := authSummary != "" || subscriptionSummary != "" || hasSubscriptionRows || l.statusSectionLoading(uiStatusSectionAuth)
 	if showAccountSection {
-		if subscriptionSummary != "" || hasSubscriptionRows {
-			appendSectionTitle("Subscription")
-		} else {
-			appendSectionTitle("Account")
-		}
+		appendSectionTitle("Auth")
 		if authSummary != "" {
 			appendWrapped(authSummary, boldStyle)
 		} else if subscriptionSummary == "" && !hasSubscriptionRows && l.statusSectionLoading(uiStatusSectionAuth) {

--- a/cli/app/ui_layout_rendering_status_overlay.go
+++ b/cli/app/ui_layout_rendering_status_overlay.go
@@ -119,10 +119,10 @@ func (l uiViewLayout) statusOverlayContentLines(width int) []string {
 	if sessionName := strings.TrimSpace(snapshot.SessionName); sessionName != "" {
 		appendWrapped(sessionName, boldStyle)
 	}
+	appendWrapped("Session ID: "+statusValueOrFallback(snapshot.SessionID, "session unknown"), lipgloss.Style{})
 	if parentSummary := statusParentSessionSummary(snapshot); parentSummary != "" {
-		appendWrapped(parentSummary, lipgloss.Style{})
+		appendWrapped(parentSummary, subtleStyle)
 	}
-	appendWrapped(statusValueOrFallback(snapshot.SessionID, "session unknown"), subtleStyle)
 
 	if l.statusSectionLoading(uiStatusSectionGit) || snapshot.Git.Visible || strings.TrimSpace(snapshot.Git.Error) != "" {
 		appendSectionTitle("Git")

--- a/cli/app/ui_path_reference_picker.go
+++ b/cli/app/ui_path_reference_picker.go
@@ -295,31 +295,25 @@ func (m *uiModel) slashCommandPresentation() uiPickerPresentation {
 	if !state.visible {
 		return uiPickerPresentation{}
 	}
-	rows := make([]uiPickerRow, 0, slashCommandPickerLines)
-	for row := 0; row < slashCommandPickerLines; row++ {
-		idx := state.start + row
-		if idx < len(state.matches) {
-			rows = append(rows, uiPickerRow{
-				primary:     "/" + state.matches[idx].Name,
-				secondary:   strings.TrimSpace(state.matches[idx].Description),
-				boldPrimary: true,
-				selectable:  true,
-			})
-			continue
-		}
-		if len(state.matches) == 0 && row == 0 {
-			rows = append(rows, uiPickerRow{primary: "No matching commands", muted: true})
-			continue
-		}
-		rows = append(rows, uiPickerRow{})
+	rows := make([]uiPickerRow, 0, max(1, len(state.matches)))
+	for idx := range state.matches {
+		rows = append(rows, uiPickerRow{
+			primary:     "/" + state.matches[idx].Name,
+			secondary:   strings.TrimSpace(state.matches[idx].Description),
+			boldPrimary: true,
+			selectable:  true,
+		})
+	}
+	if len(state.matches) == 0 {
+		rows = append(rows, uiPickerRow{primary: "No matching commands", muted: true})
 	}
 	return uiPickerPresentation{
 		kind:      uiPickerKindSlashCommand,
 		visible:   true,
 		rows:      rows,
 		selection: state.selection,
-		start:     0,
-		lineCount: len(rows),
+		start:     state.start,
+		lineCount: slashCommandPickerLines,
 	}
 }
 

--- a/cli/app/ui_path_reference_picker_test.go
+++ b/cli/app/ui_path_reference_picker_test.go
@@ -248,6 +248,33 @@ func TestPathReferenceUpDownNavigatesSelectionWithoutRewritingInput(t *testing.T
 	}
 }
 
+func TestPathReferencePickerHighlightTracksAbsoluteSelectionAfterViewportScroll(t *testing.T) {
+	withTrueColor(t)
+	m := newProjectedStaticUIModel()
+	m.pathReference.tracked = uiPathReferenceQuery{Active: true, Start: 0, End: 3, RawQuery: "ab", NormalizedQuery: "ab"}
+	m.pathReference.matches = []uiPathReferenceCandidate{
+		{Path: "match-00.go"},
+		{Path: "match-01.go"},
+		{Path: "match-02.go"},
+		{Path: "match-03.go"},
+		{Path: "match-04.go"},
+		{Path: "match-05.go"},
+		{Path: "match-06.go"},
+		{Path: "match-07.go"},
+		{Path: "match-08.go"},
+	}
+	m.pathReference.selection = 7
+
+	state := m.pathReferencePicker()
+	if state.start == 0 {
+		t.Fatalf("expected path picker viewport to scroll, got %+v", state)
+	}
+	if len(state.rows) != len(m.pathReference.matches) {
+		t.Fatalf("expected path picker rows to keep full absolute row list, got %d rows for %d matches", len(state.rows), len(m.pathReference.matches))
+	}
+	assertActivePickerHighlightedSelection(t, m, 80)
+}
+
 func TestPathReferencePickerSanitizesControlCharactersForDisplay(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.pathReference.tracked = uiPathReferenceQuery{Active: true, Start: 0, End: 3, RawQuery: "ab", NormalizedQuery: "ab"}

--- a/cli/app/ui_slash_command_picker_test.go
+++ b/cli/app/ui_slash_command_picker_test.go
@@ -36,18 +36,7 @@ func TestSlashCommandEnterIgnoresWhitespaceImmediatelyAfterSlash(t *testing.T) {
 
 func TestSlashCommandPickerHighlightTracksSelectionAfterViewportScroll(t *testing.T) {
 	withTrueColor(t)
-	r := commands.NewRegistry()
-	registerSlashPickerTestCommand := func(name string) {
-		r.Register(name, "test command "+name, func(string) commands.Result {
-			return commands.Result{Handled: true}
-		})
-	}
-	for _, name := range []string{"aa00", "aa01", "aa02", "aa03", "aa04", "aa05", "aa06", "aa07", "aa08", "goal"} {
-		registerSlashPickerTestCommand(name)
-	}
-	m := newProjectedStaticUIModel(WithUICommandRegistry(r))
-	m.input = "/"
-	m.refreshSlashCommandFilterFromInput()
+	m := newSlashPickerScrollTestModel()
 
 	targetIndex := slashPickerCommandIndex(m.slashCommandPicker(), "goal")
 	if targetIndex <= slashCommandPickerLines/2 {
@@ -65,9 +54,108 @@ func TestSlashCommandPickerHighlightTracksSelectionAfterViewportScroll(t *testin
 	if m.input != "/goal" {
 		t.Fatalf("expected logical slash selection to update input to /goal, got %q", m.input)
 	}
-	selectedLine := selectedSlashPickerRenderLine(t, m, 80)
-	if !strings.Contains(stripANSIAndTrimRight(selectedLine), "/goal") {
-		t.Fatalf("expected highlighted slash picker row to be /goal, got %q in %q", selectedLine, strings.Join(m.layout().renderActivePicker(80), "\n"))
+	assertActivePickerHighlightedSelection(t, m, 80)
+}
+
+func TestSlashCommandPickerHighlightTracksSelectionWhenViewportShiftsBothDirections(t *testing.T) {
+	withTrueColor(t)
+	m := newSlashPickerScrollTestModel()
+	assertActivePickerHighlightedSelection(t, m, 80)
+
+	state := m.slashCommandPicker()
+	for step := 1; step < len(state.matches); step++ {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = next.(*uiModel)
+		assertActivePickerHighlightedSelection(t, m, 80)
+	}
+	for step := len(state.matches) - 2; step >= 0; step-- {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+		m = next.(*uiModel)
+		assertActivePickerHighlightedSelection(t, m, 80)
+	}
+}
+
+func TestSlashCommandPickerHighlightTracksFilteredVisibleCommands(t *testing.T) {
+	withTrueColor(t)
+	oauthManager := auth.NewManager(auth.NewMemoryStore(auth.State{
+		Scope: auth.ScopeGlobal,
+		Method: auth.Method{
+			Type: auth.MethodOAuth,
+			OAuth: &auth.OAuthMethod{
+				AccessToken: "access-token",
+				TokenType:   "Bearer",
+			},
+		},
+	}), nil, nil)
+	cases := []struct {
+		name    string
+		opts    []UIOption
+		visible []string
+		hidden  []string
+	}{
+		{
+			name:    "no auth hides logout fast resume",
+			visible: []string{"login"},
+			hidden:  []string{"logout", "fast", "resume"},
+		},
+		{
+			name:    "oauth hides login fast resume",
+			opts:    []UIOption{WithUIStatusConfig(uiStatusConfig{AuthManager: oauthManager})},
+			visible: []string{"logout"},
+			hidden:  []string{"login", "fast", "resume"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := append([]UIOption{WithUIHasOtherSessions(true, false)}, tc.opts...)
+			m := newProjectedStaticUIModel(opts...)
+			m.input = "/"
+			m.refreshSlashCommandFilterFromInput()
+
+			state := m.slashCommandPicker()
+			for _, hidden := range tc.hidden {
+				if slashPickerContainsCommand(state, hidden) {
+					t.Fatalf("did not expect gated /%s in slash picker, got %+v", hidden, slashPickerCommandNames(state))
+				}
+			}
+			for _, visible := range tc.visible {
+				if !slashPickerContainsCommand(state, visible) {
+					t.Fatalf("expected visible /%s in slash picker, got %+v", visible, slashPickerCommandNames(state))
+				}
+			}
+
+			assertActivePickerHighlightAcrossVisibleMatches(t, m, 80)
+		})
+	}
+}
+
+func newSlashPickerScrollTestModel() *uiModel {
+	r := commands.NewRegistry()
+	registerSlashPickerTestCommand := func(name string) {
+		r.Register(name, "test command "+name, func(string) commands.Result {
+			return commands.Result{Handled: true}
+		})
+	}
+	for _, name := range []string{"aa00", "aa01", "aa02", "aa03", "aa04", "aa05", "aa06", "aa07", "aa08", "goal"} {
+		registerSlashPickerTestCommand(name)
+	}
+	m := newProjectedStaticUIModel(WithUICommandRegistry(r))
+	m.input = "/"
+	m.refreshSlashCommandFilterFromInput()
+	return m
+}
+
+func assertActivePickerHighlightAcrossVisibleMatches(t *testing.T, m *uiModel, width int) {
+	t.Helper()
+	state := m.activePickerPresentation()
+	if !state.visible || len(state.rows) == 0 {
+		t.Fatalf("expected visible picker with rows, got %+v", state)
+	}
+	assertActivePickerHighlightedSelection(t, m, width)
+	for step := 1; step < len(state.rows); step++ {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = next.(*uiModel)
+		assertActivePickerHighlightedSelection(t, m, width)
 	}
 }
 
@@ -80,17 +168,48 @@ func slashPickerCommandIndex(state slashCommandPickerState, name string) int {
 	return -1
 }
 
-func selectedSlashPickerRenderLine(t *testing.T, m *uiModel, width int) string {
+func assertActivePickerHighlightedSelection(t *testing.T, m *uiModel, width int) {
+	t.Helper()
+	state := m.activePickerPresentation()
+	if !state.visible || len(state.rows) == 0 {
+		t.Fatalf("expected visible picker with rows, got %+v", state)
+	}
+	expectedRow := state.selection - state.start
+	if expectedRow < 0 || expectedRow >= state.lineCount {
+		t.Fatalf("expected visible selected row, got state %+v", state)
+	}
+	if state.selection < 0 || state.selection >= len(state.rows) {
+		t.Fatalf("selected row index out of range for state %+v", state)
+	}
+	selectedRow, selectedLine := selectedActivePickerRenderLine(t, m, width)
+	if selectedRow != expectedRow {
+		t.Fatalf("highlight row = %d, want %d for state %+v in %q", selectedRow, expectedRow, state, strings.Join(m.layout().renderActivePicker(width), "\n"))
+	}
+	expectedPrimary := state.rows[state.selection].primary
+	if !strings.Contains(stripANSIAndTrimRight(selectedLine), expectedPrimary) {
+		t.Fatalf("expected highlighted picker row to be %s, got %q in %q", expectedPrimary, selectedLine, strings.Join(m.layout().renderActivePicker(width), "\n"))
+	}
+}
+
+func selectedActivePickerRenderLine(t *testing.T, m *uiModel, width int) (int, string) {
 	t.Helper()
 	primary := foregroundTrueColorEscape(theme.ResolvePalette(m.theme).App.Primary.TrueColor)
 	primaryFragment := strings.TrimSuffix(strings.TrimPrefix(primary, "\x1b["), "m")
-	for _, line := range m.layout().renderActivePicker(width) {
+	selectedRow := -1
+	selectedLine := ""
+	for row, line := range m.layout().renderActivePicker(width) {
 		if strings.Contains(line, primaryFragment) {
-			return line
+			if selectedRow >= 0 {
+				t.Fatalf("expected one selected picker row, got rows %d and %d in %q", selectedRow, row, strings.Join(m.layout().renderActivePicker(width), "\n"))
+			}
+			selectedRow = row
+			selectedLine = line
 		}
 	}
-	t.Fatalf("expected selected slash picker row with primary color fragment %q in %q", primaryFragment, strings.Join(m.layout().renderActivePicker(width), "\n"))
-	return ""
+	if selectedRow < 0 {
+		t.Fatalf("expected selected picker row with primary color fragment %q in %q", primaryFragment, strings.Join(m.layout().renderActivePicker(width), "\n"))
+	}
+	return selectedRow, selectedLine
 }
 
 func TestBuiltInReviewSlashCommandWithWhitespaceAfterSlashDoesNotDuplicateArgs(t *testing.T) {

--- a/cli/app/ui_slash_command_picker_test.go
+++ b/cli/app/ui_slash_command_picker_test.go
@@ -11,6 +11,7 @@ import (
 	"builder/server/auth"
 	"builder/server/llm"
 	"builder/shared/clientui"
+	"builder/shared/theme"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -31,6 +32,65 @@ func TestSlashCommandEnterIgnoresWhitespaceImmediatelyAfterSlash(t *testing.T) {
 	if updated.input != "" {
 		t.Fatalf("expected input cleared after slash command execution, got %q", updated.input)
 	}
+}
+
+func TestSlashCommandPickerHighlightTracksSelectionAfterViewportScroll(t *testing.T) {
+	withTrueColor(t)
+	r := commands.NewRegistry()
+	registerSlashPickerTestCommand := func(name string) {
+		r.Register(name, "test command "+name, func(string) commands.Result {
+			return commands.Result{Handled: true}
+		})
+	}
+	for _, name := range []string{"aa00", "aa01", "aa02", "aa03", "aa04", "aa05", "aa06", "aa07", "aa08", "goal"} {
+		registerSlashPickerTestCommand(name)
+	}
+	m := newProjectedStaticUIModel(WithUICommandRegistry(r))
+	m.input = "/"
+	m.refreshSlashCommandFilterFromInput()
+
+	targetIndex := slashPickerCommandIndex(m.slashCommandPicker(), "goal")
+	if targetIndex <= slashCommandPickerLines/2 {
+		t.Fatalf("test setup expected /goal past centered viewport threshold, got index %d", targetIndex)
+	}
+	for step := 0; step < targetIndex; step++ {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = next.(*uiModel)
+	}
+
+	state := m.slashCommandPicker()
+	if state.start == 0 {
+		t.Fatalf("expected slash picker viewport to scroll for /goal, got %+v", state)
+	}
+	if m.input != "/goal" {
+		t.Fatalf("expected logical slash selection to update input to /goal, got %q", m.input)
+	}
+	selectedLine := selectedSlashPickerRenderLine(t, m, 80)
+	if !strings.Contains(stripANSIAndTrimRight(selectedLine), "/goal") {
+		t.Fatalf("expected highlighted slash picker row to be /goal, got %q in %q", selectedLine, strings.Join(m.layout().renderActivePicker(80), "\n"))
+	}
+}
+
+func slashPickerCommandIndex(state slashCommandPickerState, name string) int {
+	for idx, command := range state.matches {
+		if command.Name == name {
+			return idx
+		}
+	}
+	return -1
+}
+
+func selectedSlashPickerRenderLine(t *testing.T, m *uiModel, width int) string {
+	t.Helper()
+	primary := foregroundTrueColorEscape(theme.ResolvePalette(m.theme).App.Primary.TrueColor)
+	primaryFragment := strings.TrimSuffix(strings.TrimPrefix(primary, "\x1b["), "m")
+	for _, line := range m.layout().renderActivePicker(width) {
+		if strings.Contains(line, primaryFragment) {
+			return line
+		}
+	}
+	t.Fatalf("expected selected slash picker row with primary color fragment %q in %q", primaryFragment, strings.Join(m.layout().renderActivePicker(width), "\n"))
+	return ""
 }
 
 func TestBuiltInReviewSlashCommandWithWhitespaceAfterSlashDoesNotDuplicateArgs(t *testing.T) {

--- a/cli/app/ui_status.go
+++ b/cli/app/ui_status.go
@@ -43,6 +43,7 @@ func cloneStatusTokenMap(input map[string]int) map[string]int {
 type uiStatusConfig struct {
 	WorkspaceRoot   string
 	PersistenceRoot string
+	ExecutionTarget clientui.SessionExecutionTarget
 	SessionViews    client.SessionViewClient
 	Settings        config.Settings
 	Source          config.SourceReport
@@ -158,6 +159,7 @@ func (m *uiModel) newStatusRequest(now time.Time) uiStatusRequest {
 		Runtime:               m.engine,
 		WorkspaceRoot:         strings.TrimSpace(m.statusConfig.WorkspaceRoot),
 		PersistenceRoot:       strings.TrimSpace(m.statusConfig.PersistenceRoot),
+		ExecutionTarget:       m.statusConfig.ExecutionTarget,
 		SessionViews:          m.statusConfig.SessionViews,
 		Settings:              m.statusConfig.Settings,
 		Source:                m.statusConfig.Source,
@@ -417,6 +419,10 @@ func (m *uiModel) statusRefreshCmd() tea.Cmd {
 }
 
 func (m *uiModel) statusLineGitStartupCmd() tea.Cmd {
+	return m.statusLineGitRefreshCmd()
+}
+
+func (m *uiModel) statusLineGitRefreshCmd() tea.Cmd {
 	request := m.newStatusRequest(time.Now())
 	token := m.status.refreshToken
 	request.CurrentTime = time.Now()
@@ -436,6 +442,7 @@ func (m *uiModel) statusLineGitStartupCmd() tea.Cmd {
 		return nil
 	}
 	cacheKey := statusGitCacheKey(gitRoot)
+	m.statusGitBackgroundInFlight = true
 	return m.statusGitRefreshCmd(token, cacheKey, request, progressive, base, true)
 }
 

--- a/cli/app/ui_status_overlay_format.go
+++ b/cli/app/ui_status_overlay_format.go
@@ -252,13 +252,21 @@ func statusContextCompactionSummary(context uiStatusContextInfo) string {
 }
 
 func statusSkillLine(skill uiStatusSkillInspection, tokenCounts map[string]int) string {
+	return statusSkillLineStyled(skill, tokenCounts, func(label string) string { return label })
+}
+
+func statusSkillLineStyled(skill uiStatusSkillInspection, tokenCounts map[string]int, generatedLabel func(string) string) string {
 	name := strings.TrimSpace(skill.Name)
 	if name == "" {
 		name = filepath.Base(filepath.Dir(skill.Path))
 	}
 	labels := make([]string, 0, 3)
 	if skill.SourceKind == "generated" {
-		labels = append(labels, "generated")
+		rendered := "generated"
+		if generatedLabel != nil {
+			rendered = generatedLabel(rendered)
+		}
+		labels = append(labels, rendered)
 	}
 	if skill.Disabled {
 		labels = append(labels, lipgloss.NewStyle().Foreground(statusRedColor()).Bold(true).Render("disabled"))

--- a/cli/app/ui_status_overlay_format.go
+++ b/cli/app/ui_status_overlay_format.go
@@ -252,21 +252,17 @@ func statusContextCompactionSummary(context uiStatusContextInfo) string {
 }
 
 func statusSkillLine(skill uiStatusSkillInspection, tokenCounts map[string]int) string {
-	return statusSkillLineStyled(skill, tokenCounts, func(label string) string { return label })
+	return statusSkillLineStyled(skill, tokenCounts, lipgloss.Style{})
 }
 
-func statusSkillLineStyled(skill uiStatusSkillInspection, tokenCounts map[string]int, generatedLabel func(string) string) string {
+func statusSkillLineStyled(skill uiStatusSkillInspection, tokenCounts map[string]int, generatedStyle lipgloss.Style) string {
 	name := strings.TrimSpace(skill.Name)
 	if name == "" {
 		name = filepath.Base(filepath.Dir(skill.Path))
 	}
 	labels := make([]string, 0, 3)
 	if skill.SourceKind == "generated" {
-		rendered := "generated"
-		if generatedLabel != nil {
-			rendered = generatedLabel(rendered)
-		}
-		labels = append(labels, rendered)
+		labels = append(labels, generatedStyle.Render("generated"))
 	}
 	if skill.Disabled {
 		labels = append(labels, lipgloss.NewStyle().Foreground(statusRedColor()).Bold(true).Render("disabled"))

--- a/cli/app/ui_status_part2_test.go
+++ b/cli/app/ui_status_part2_test.go
@@ -186,7 +186,7 @@ func TestStatusVisibleAuthSummarySuppressesGenericSubscriptionWhenPlanPresent(t 
 	if got := statusVisibleAuthSummary(uiStatusAuthInfo{Summary: "user@example.com", Visible: true}, uiStatusSubscriptionInfo{Summary: "Pro subscription"}); got != "user@example.com" {
 		t.Fatalf("visible auth summary = %q", got)
 	}
-	if got := statusVisibleAuthSummary(uiStatusAuthInfo{Summary: "Not configured"}, uiStatusSubscriptionInfo{Summary: "Pro subscription"}); got != "" {
+	if got := statusVisibleAuthSummary(uiStatusAuthInfo{Summary: "No Auth", Visible: true}, uiStatusSubscriptionInfo{Summary: "Pro subscription"}); got != "No Auth" {
 		t.Fatalf("visible auth summary = %q", got)
 	}
 }

--- a/cli/app/ui_status_part2_test.go
+++ b/cli/app/ui_status_part2_test.go
@@ -68,6 +68,34 @@ func TestStatusLineGitStartupUsesRuntimeWorktreeRootBranch(t *testing.T) {
 	}
 }
 
+func TestStatusLineGitRefreshesAfterExecutionTargetChange(t *testing.T) {
+	workspaceRoot := initStatusLineGitRepo(t, "workspace-branch")
+	worktreeRoot := initStatusLineGitRepo(t, "worktree-branch")
+	m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{WorkspaceRoot: workspaceRoot}))
+	m.status.snapshot.Git = uiStatusGitInfo{Visible: true, Branch: "workspace-branch"}
+
+	next, cmd := m.Update(runtimeMainViewRefreshedMsg{
+		token: m.runtimeMainViewToken,
+		view: clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{
+			SessionID: "session-1",
+			ExecutionTarget: clientui.SessionExecutionTarget{
+				WorkspaceRoot:    workspaceRoot,
+				WorktreeRoot:     worktreeRoot,
+				EffectiveWorkdir: worktreeRoot,
+			},
+		}},
+	})
+	updated := drainStatusLineStartupCommands(t, next.(*uiModel), cmd)
+
+	status := stripANSIAndTrimRight(updated.renderStatusLine(120, uiThemeStyles("dark")))
+	if !strings.Contains(status, "worktree-branch") {
+		t.Fatalf("expected refreshed worktree git branch in status line, got %q", status)
+	}
+	if strings.Contains(status, "workspace-branch") {
+		t.Fatalf("did not expect stale workspace branch in status line, got %q", status)
+	}
+}
+
 func initStatusLineGitRepo(t *testing.T, branch string) string {
 	t.Helper()
 	repoRoot := t.TempDir()

--- a/cli/app/ui_status_test.go
+++ b/cli/app/ui_status_test.go
@@ -247,6 +247,44 @@ func TestStatusOverlaySessionSectionLabelsSessionIDBeforeMutedParent(t *testing.
 	}
 }
 
+func TestStatusOverlaySectionOrderPrioritizesSessionGitContext(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.status.snapshot = uiStatusSnapshot{
+		Workdir:   "/tmp/workdir",
+		SessionID: "session-123",
+		Git:       uiStatusGitInfo{Visible: true, Branch: "main"},
+		Context:   uiStatusContextInfo{AvailableTokens: 100, ThresholdTokens: 50},
+		Config:    uiStatusConfigInfo{SettingsPath: "/tmp/workdir/.builder/config.toml", Supervisor: "edits"},
+		Subscription: uiStatusSubscriptionInfo{
+			Applicable: true,
+			Summary:    "Pro subscription",
+		},
+		Skills: []uiStatusSkillInspection{{Name: "apiresult", Path: "/tmp/workdir/.builder/skills/apiresult/SKILL.md", Loaded: true}},
+	}
+	lines := stripANSIAndTrimRight(strings.Join(m.layout().statusOverlayContentLines(100), "\n"))
+
+	session := statusLineIndex(t, lines, "Session")
+	git := statusLineIndex(t, lines, "Git")
+	context := statusLineIndex(t, lines, "Context")
+	subscription := statusLineIndex(t, lines, "Subscription")
+	config := statusLineIndex(t, lines, "Config")
+	skills := statusLineIndex(t, lines, "1 skills")
+	if !(session < git && git < context && context < subscription && subscription < config && config < skills) {
+		t.Fatalf("unexpected status section order: session=%d git=%d context=%d subscription=%d config=%d skills=%d\n%s", session, git, context, subscription, config, skills, lines)
+	}
+}
+
+func statusLineIndex(t *testing.T, lines string, want string) int {
+	t.Helper()
+	for idx, line := range strings.Split(lines, "\n") {
+		if strings.TrimSpace(line) == want {
+			return idx
+		}
+	}
+	t.Fatalf("status line %q not found in %q", want, lines)
+	return -1
+}
+
 func TestStatusCommandProgressivelyLoadsSections(t *testing.T) {
 	collector := &stubProgressiveStatusCollector{
 		base: uiStatusSnapshot{

--- a/cli/app/ui_status_test.go
+++ b/cli/app/ui_status_test.go
@@ -277,19 +277,24 @@ func TestStatusOverlaySectionOrderPrioritizesSessionGitContext(t *testing.T) {
 }
 
 func TestStatusOverlayAuthSectionShowsNoAuthAndAPIKey(t *testing.T) {
+	withTrueColor(t)
 	noAuth := newProjectedStaticUIModel()
 	noAuth.status.snapshot = uiStatusSnapshot{Auth: uiStatusAuthInfo{Summary: "No Auth", Visible: true}}
-	noAuthLines := stripANSIAndTrimRight(strings.Join(noAuth.layout().statusOverlayContentLines(100), "\n"))
+	noAuthRawLines := noAuth.layout().statusOverlayContentLines(100)
+	noAuthLines := stripANSIAndTrimRight(strings.Join(noAuthRawLines, "\n"))
 	if !strings.Contains(noAuthLines, "Auth\nNo Auth") {
 		t.Fatalf("expected no-auth status section, got %q", noAuthLines)
 	}
+	assertStatusOverlayPrimaryLine(t, findRawStatusOverlayLine(t, noAuthRawLines, "No Auth"), "No Auth")
 
 	apiKey := newProjectedStaticUIModel()
 	apiKey.status.snapshot = uiStatusSnapshot{Auth: uiStatusAuthInfo{Summary: "API Key ...1234", Visible: true}}
-	apiKeyLines := stripANSIAndTrimRight(strings.Join(apiKey.layout().statusOverlayContentLines(100), "\n"))
+	apiKeyRawLines := apiKey.layout().statusOverlayContentLines(100)
+	apiKeyLines := stripANSIAndTrimRight(strings.Join(apiKeyRawLines, "\n"))
 	if !strings.Contains(apiKeyLines, "Auth\nAPI Key ...1234") {
 		t.Fatalf("expected api-key status section, got %q", apiKeyLines)
 	}
+	assertStatusOverlayPrimaryLine(t, findRawStatusOverlayLine(t, apiKeyRawLines, "API Key ...1234"), "API Key ...1234")
 }
 
 func statusLineIndex(t *testing.T, lines string, want string) int {
@@ -550,6 +555,13 @@ func assertGeneratedLabelStyled(t *testing.T, rawLine string) {
 	t.Helper()
 	if !strings.Contains(stripANSIAndTrimRight(rawLine), "generated") || !strings.Contains(rawLine, "\x1b[") {
 		t.Fatalf("expected generated label to be styled in %q", rawLine)
+	}
+}
+
+func assertStatusOverlayPrimaryLine(t *testing.T, rawLine string, want string) {
+	t.Helper()
+	if strings.TrimSpace(stripANSIAndTrimRight(rawLine)) != want || !strings.Contains(rawLine, "\x1b[") {
+		t.Fatalf("expected primary styled status line %q, got %q", want, rawLine)
 	}
 }
 

--- a/cli/app/ui_status_test.go
+++ b/cli/app/ui_status_test.go
@@ -445,6 +445,20 @@ func TestStatusSkillLineMarksGeneratedAndShadowed(t *testing.T) {
 	}
 }
 
+func TestStatusSkillLineRendersGeneratedLabelWithInjectedMutedStyle(t *testing.T) {
+	line := statusSkillLineStyled(uiStatusSkillInspection{
+		Name:       "skill-creator",
+		Path:       "/Users/test/.builder/.generated/skills/skill-creator/SKILL.md",
+		Loaded:     true,
+		SourceKind: "generated",
+	}, nil, func(label string) string {
+		return "<muted>" + label + "</muted>"
+	})
+	if !strings.Contains(line, "skill-creator (0k) <muted>generated</muted>") {
+		t.Fatalf("expected generated label to use injected muted style, got %q", line)
+	}
+}
+
 func TestStatusSkillLinePreservesTokenCountForActiveGeneratedSkill(t *testing.T) {
 	path := "/Users/test/.builder/.generated/skills/skill-creator/SKILL.md"
 	active := stripANSIAndTrimRight(statusSkillLine(uiStatusSkillInspection{

--- a/cli/app/ui_status_test.go
+++ b/cli/app/ui_status_test.go
@@ -176,10 +176,13 @@ func TestStatusCommandOpensStatusSurfaceInNativeMode(t *testing.T) {
 	next, _ = updated.Update(statusRefreshDoneMsg{token: updated.status.refreshToken, snapshot: collector.snapshot})
 	updated = next.(*uiModel)
 	plain := stripANSIAndTrimRight(updated.View())
-	for _, want := range []string{"Pro subscription", "Server: owned by this CLI", "CWD: /tmp/workdir", "Model: gpt-5 high fast", "Update: available 1.2.3", "incident", "Parent session: incident-root <parent-456>", "session-123", "master", "dirty | ahead 2 | behind 1"} {
+	for _, want := range []string{"Pro subscription", "Server: owned by this CLI", "CWD: /tmp/workdir", "Model: gpt-5 high fast", "Update: available 1.2.3", "incident", "Session ID: session-123", "Parent session: incident-root <parent-456>", "master", "dirty | ahead 2 | behind 1"} {
 		if !strings.Contains(plain, want) {
 			t.Fatalf("expected status overlay to contain %q, got %q", want, plain)
 		}
+	}
+	if !strings.Contains(plain, "incident\nSession ID: session-123\nParent session: incident-root <parent-456>") {
+		t.Fatalf("expected session id before parent session id, got %q", plain)
 	}
 	for _, want := range []string{"4 skills", "/Users/test/.builder/skills", "apiresult (0k)", "local helper disabled", "! broken (missing SKILL.md)", "/Users/test/.builder/.generated/skills", "skill-creator (0k) generated"} {
 		if !strings.Contains(plain, want) {

--- a/cli/app/ui_status_test.go
+++ b/cli/app/ui_status_test.go
@@ -215,6 +215,38 @@ func TestStatusCommandOpensStatusSurfaceInNativeMode(t *testing.T) {
 	}
 }
 
+func TestStatusOverlaySessionSectionLabelsSessionIDBeforeMutedParent(t *testing.T) {
+	snapshot := uiStatusSnapshot{
+		Workdir:           "/tmp/workdir",
+		SessionName:       "incident",
+		SessionID:         "session-123",
+		ParentSessionID:   "parent-456",
+		ParentSessionName: "incident-root",
+		Model:             uiStatusModelInfo{Summary: "gpt-5 high"},
+	}
+	sessionLines := statusOverlaySessionLines(snapshot)
+	if len(sessionLines) != 3 {
+		t.Fatalf("session lines = %+v, want 3 lines", sessionLines)
+	}
+	if sessionLines[0].Text != "incident" || sessionLines[0].Style != statusOverlayLineStyleBold {
+		t.Fatalf("session name line = %+v, want bold incident", sessionLines[0])
+	}
+	if sessionLines[1].Text != "Session ID: session-123" || sessionLines[1].Style != statusOverlayLineStyleNormal {
+		t.Fatalf("session id line = %+v, want full-color labeled session id", sessionLines[1])
+	}
+	if sessionLines[2].Text != "Parent session: incident-root <parent-456>" || sessionLines[2].Style != statusOverlayLineStyleSubtle {
+		t.Fatalf("parent session line = %+v, want muted parent session", sessionLines[2])
+	}
+
+	m := newProjectedStaticUIModel()
+	m.status.snapshot = snapshot
+	lines := m.layout().statusOverlayContentLines(100)
+	plain := stripANSIAndTrimRight(strings.Join(lines, "\n"))
+	if !strings.Contains(plain, "incident\nSession ID: session-123\nParent session: incident-root <parent-456>") {
+		t.Fatalf("expected session id before parent session in focused status section, got %q", plain)
+	}
+}
+
 func TestStatusCommandProgressivelyLoadsSections(t *testing.T) {
 	collector := &stubProgressiveStatusCollector{
 		base: uiStatusSnapshot{

--- a/cli/app/ui_status_test.go
+++ b/cli/app/ui_status_test.go
@@ -10,6 +10,8 @@ import (
 	"builder/shared/config"
 	"context"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -445,53 +447,105 @@ func TestStatusSkillLineMarksGeneratedAndShadowed(t *testing.T) {
 	}
 }
 
-func TestStatusSkillLineRendersGeneratedLabelWithInjectedMutedStyle(t *testing.T) {
+func TestStatusSkillLineRendersGeneratedLabelWithMutedStyle(t *testing.T) {
+	withTrueColor(t)
 	line := statusSkillLineStyled(uiStatusSkillInspection{
 		Name:       "skill-creator",
 		Path:       "/Users/test/.builder/.generated/skills/skill-creator/SKILL.md",
 		Loaded:     true,
 		SourceKind: "generated",
-	}, nil, func(label string) string {
-		return "<muted>" + label + "</muted>"
-	})
-	if !strings.Contains(line, "skill-creator (0k) <muted>generated</muted>") {
-		t.Fatalf("expected generated label to use injected muted style, got %q", line)
+	}, nil, generatedSkillTestStyle())
+	if !strings.Contains(stripANSIAndTrimRight(line), "skill-creator (0k) generated") || !strings.Contains(line, "\x1b[") {
+		t.Fatalf("expected generated label to use muted ANSI style, got %q", line)
 	}
 }
 
 func TestStatusSkillLinePreservesTokenCountForActiveGeneratedSkill(t *testing.T) {
 	path := "/Users/test/.builder/.generated/skills/skill-creator/SKILL.md"
-	active := stripANSIAndTrimRight(statusSkillLine(uiStatusSkillInspection{
+	withTrueColor(t)
+	activeRaw := statusSkillLineStyled(uiStatusSkillInspection{
 		Name:       "skill-creator",
 		Path:       path,
 		Loaded:     true,
 		SourceKind: "generated",
-	}, map[string]int{path: 1234}))
+	}, map[string]int{path: 1234}, generatedSkillTestStyle())
+	active := stripANSIAndTrimRight(activeRaw)
 	for _, want := range []string{"skill-creator", "(1.2k)", "generated"} {
 		if !strings.Contains(active, want) {
 			t.Fatalf("expected active generated line to contain %q, got %q", want, active)
 		}
 	}
-	disabled := stripANSIAndTrimRight(statusSkillLine(uiStatusSkillInspection{
+	assertGeneratedLabelStyled(t, activeRaw)
+	disabledRaw := statusSkillLineStyled(uiStatusSkillInspection{
 		Name:       "disabled-skill",
 		Path:       path,
 		Loaded:     true,
 		SourceKind: "generated",
 		Disabled:   true,
-	}, map[string]int{path: 1234}))
+	}, map[string]int{path: 1234}, generatedSkillTestStyle())
+	disabled := stripANSIAndTrimRight(disabledRaw)
 	if !strings.Contains(disabled, "generated") || !strings.Contains(disabled, "disabled") || strings.Contains(disabled, "(1.2k)") {
 		t.Fatalf("expected disabled generated line to be label-only, got %q", disabled)
 	}
-	shadowed := stripANSIAndTrimRight(statusSkillLine(uiStatusSkillInspection{
+	assertGeneratedLabelStyled(t, disabledRaw)
+	shadowedRaw := statusSkillLineStyled(uiStatusSkillInspection{
 		Name:       "shadowed-skill",
 		Path:       path,
 		Loaded:     true,
 		SourceKind: "generated",
 		Shadowed:   true,
-	}, map[string]int{path: 1234}))
+	}, map[string]int{path: 1234}, generatedSkillTestStyle())
+	shadowed := stripANSIAndTrimRight(shadowedRaw)
 	if !strings.Contains(shadowed, "generated") || !strings.Contains(shadowed, "shadowed") || strings.Contains(shadowed, "(1.2k)") {
 		t.Fatalf("expected shadowed generated line to be label-only, got %q", shadowed)
 	}
+	assertGeneratedLabelStyled(t, shadowedRaw)
+}
+
+func TestStatusOverlayGeneratedSkillLabelRendersMuted(t *testing.T) {
+	withTrueColor(t)
+	m := newProjectedStaticUIModel()
+	m.status.snapshot = uiStatusSnapshot{
+		Workdir: "/tmp/workdir",
+		Skills: []uiStatusSkillInspection{{
+			Name:       "skill-creator",
+			Path:       "/tmp/workdir/.builder/.generated/skills/skill-creator/SKILL.md",
+			Loaded:     true,
+			SourceKind: "generated",
+		}},
+	}
+	lines := m.layout().statusOverlayContentLines(100)
+	raw := findRawStatusOverlayLine(t, lines, "skill-creator (0k) generated")
+	assertGeneratedLabelStyled(t, raw)
+}
+
+func withTrueColor(t *testing.T) {
+	t.Helper()
+	previousProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(previousProfile) })
+}
+
+func generatedSkillTestStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(uiPalette("dark").muted).Faint(true)
+}
+
+func assertGeneratedLabelStyled(t *testing.T, rawLine string) {
+	t.Helper()
+	if !strings.Contains(stripANSIAndTrimRight(rawLine), "generated") || !strings.Contains(rawLine, "\x1b[") {
+		t.Fatalf("expected generated label to be styled in %q", rawLine)
+	}
+}
+
+func findRawStatusOverlayLine(t *testing.T, lines []string, want string) string {
+	t.Helper()
+	for _, line := range lines {
+		if strings.Contains(stripANSIAndTrimRight(line), want) {
+			return line
+		}
+	}
+	t.Fatalf("status overlay line %q not found in %q", want, stripANSIAndTrimRight(strings.Join(lines, "\n")))
+	return ""
 }
 
 func TestStatusEnvironmentWarnsWhenRecoveredGeneratedFilesExist(t *testing.T) {

--- a/cli/app/ui_status_test.go
+++ b/cli/app/ui_status_test.go
@@ -178,7 +178,7 @@ func TestStatusCommandOpensStatusSurfaceInNativeMode(t *testing.T) {
 	next, _ = updated.Update(statusRefreshDoneMsg{token: updated.status.refreshToken, snapshot: collector.snapshot})
 	updated = next.(*uiModel)
 	plain := stripANSIAndTrimRight(updated.View())
-	for _, want := range []string{"Pro subscription", "Server: owned by this CLI", "CWD: /tmp/workdir", "Model: gpt-5 high fast", "Update: available 1.2.3", "incident", "Session ID: session-123", "Parent session: incident-root <parent-456>", "master", "dirty | ahead 2 | behind 1"} {
+	for _, want := range []string{"Auth", "Pro subscription", "Server: owned by this CLI", "CWD: /tmp/workdir", "Model: gpt-5 high fast", "Update: available 1.2.3", "incident", "Session ID: session-123", "Parent session: incident-root <parent-456>", "master", "dirty | ahead 2 | behind 1"} {
 		if !strings.Contains(plain, want) {
 			t.Fatalf("expected status overlay to contain %q, got %q", want, plain)
 		}
@@ -268,11 +268,27 @@ func TestStatusOverlaySectionOrderPrioritizesSessionGitContext(t *testing.T) {
 	session := statusLineIndex(t, lines, "Session")
 	git := statusLineIndex(t, lines, "Git")
 	context := statusLineIndex(t, lines, "Context")
-	subscription := statusLineIndex(t, lines, "Subscription")
+	auth := statusLineIndex(t, lines, "Auth")
 	config := statusLineIndex(t, lines, "Config")
 	skills := statusLineIndex(t, lines, "1 skills")
-	if !(session < git && git < context && context < subscription && subscription < config && config < skills) {
-		t.Fatalf("unexpected status section order: session=%d git=%d context=%d subscription=%d config=%d skills=%d\n%s", session, git, context, subscription, config, skills, lines)
+	if !(session < git && git < context && context < auth && auth < config && config < skills) {
+		t.Fatalf("unexpected status section order: session=%d git=%d context=%d auth=%d config=%d skills=%d\n%s", session, git, context, auth, config, skills, lines)
+	}
+}
+
+func TestStatusOverlayAuthSectionShowsNoAuthAndAPIKey(t *testing.T) {
+	noAuth := newProjectedStaticUIModel()
+	noAuth.status.snapshot = uiStatusSnapshot{Auth: uiStatusAuthInfo{Summary: "No Auth", Visible: true}}
+	noAuthLines := stripANSIAndTrimRight(strings.Join(noAuth.layout().statusOverlayContentLines(100), "\n"))
+	if !strings.Contains(noAuthLines, "Auth\nNo Auth") {
+		t.Fatalf("expected no-auth status section, got %q", noAuthLines)
+	}
+
+	apiKey := newProjectedStaticUIModel()
+	apiKey.status.snapshot = uiStatusSnapshot{Auth: uiStatusAuthInfo{Summary: "API Key ...1234", Visible: true}}
+	apiKeyLines := stripANSIAndTrimRight(strings.Join(apiKey.layout().statusOverlayContentLines(100), "\n"))
+	if !strings.Contains(apiKeyLines, "Auth\nAPI Key ...1234") {
+		t.Fatalf("expected api-key status section, got %q", apiKeyLines)
 	}
 }
 

--- a/cli/app/ui_transcript_page_apply.go
+++ b/cli/app/ui_transcript_page_apply.go
@@ -24,7 +24,7 @@ func (a uiRuntimeAdapter) applyProjectedChatSnapshot(snapshot clientui.ChatSnaps
 
 func (a uiRuntimeAdapter) applyProjectedSessionView(view clientui.RuntimeSessionView) tea.Cmd {
 	transcript := transcriptPageFromSessionView(view)
-	return sequenceCmds(a.applyProjectedSessionMetadata(view), a.applyRuntimeTranscriptPageWithRecovery(clientui.TranscriptPageRequest{}, transcript, clientui.TranscriptRecoveryCauseNone))
+	return batchCmds(a.applyProjectedSessionMetadata(view), a.applyRuntimeTranscriptPageWithRecovery(clientui.TranscriptPageRequest{}, transcript, clientui.TranscriptRecoveryCauseNone))
 }
 
 func (a uiRuntimeAdapter) applyProjectedSessionMetadata(view clientui.RuntimeSessionView) tea.Cmd {
@@ -44,34 +44,49 @@ func (a uiRuntimeAdapter) applyProjectedSessionMetadata(view clientui.RuntimeSes
 	m.sessionID = strings.TrimSpace(view.SessionID)
 	m.sessionName = strings.TrimSpace(view.SessionName)
 	m.conversationFreshness = view.ConversationFreshness
-	a.applyProjectedExecutionTarget(view.ExecutionTarget)
+	targetCmd := a.applyProjectedExecutionTarget(view.ExecutionTarget)
 	if view.Transcript.Revision > m.transcriptRevision {
 		m.transcriptRevision = view.Transcript.Revision
 	}
+	titleCmd := tea.Cmd(nil)
 	if previousWindowTitle != m.windowTitle() {
-		return tea.SetWindowTitle(m.windowTitle())
+		titleCmd = tea.SetWindowTitle(m.windowTitle())
 	}
-	return nil
+	return sequenceCmds(titleCmd, targetCmd)
 }
 
-func (a uiRuntimeAdapter) applyProjectedExecutionTarget(target clientui.SessionExecutionTarget) {
+func (a uiRuntimeAdapter) applyProjectedExecutionTarget(target clientui.SessionExecutionTarget) tea.Cmd {
 	m := a.model
 	if m == nil {
-		return
+		return nil
 	}
 	workdir := strings.TrimSpace(target.EffectiveWorkdir)
 	if workdir == "" {
 		workdir = strings.TrimSpace(target.WorkspaceRoot)
 	}
-	if workdir == "" || strings.TrimSpace(m.statusConfig.WorkspaceRoot) == workdir {
-		return
+	previousWorkdir := strings.TrimSpace(m.statusConfig.WorkspaceRoot)
+	previousTarget := m.statusConfig.ExecutionTarget
+	if workdir == "" {
+		if !clientui.SessionExecutionTargetsEqual(previousTarget, target) {
+			m.statusConfig.ExecutionTarget = target
+		}
+		return nil
 	}
+	targetChanged := !clientui.SessionExecutionTargetsEqual(previousTarget, target)
+	workdirChanged := previousWorkdir != workdir
 	m.statusConfig.WorkspaceRoot = workdir
-	m.statusRepository = newMemoryUIStatusRepository()
-	m.clearPathReferenceState()
-	if m.pathReferenceSearch != nil {
+	m.statusConfig.ExecutionTarget = target
+	if !workdirChanged && !targetChanged {
+		return nil
+	}
+	if workdirChanged {
+		m.statusRepository = newMemoryUIStatusRepository()
+		m.clearPathReferenceState()
+	}
+	if workdirChanged && m.pathReferenceSearch != nil {
 		m.pathReferenceSearch.StartPrewarm(workdir)
 	}
+	return m.statusLineGitRefreshCmd()
 }
 
 func (a uiRuntimeAdapter) applyProjectedTranscriptPage(page clientui.TranscriptPage) tea.Cmd {

--- a/cli/app/ui_worktree_commands_part2_test.go
+++ b/cli/app/ui_worktree_commands_part2_test.go
@@ -152,6 +152,30 @@ func TestWorktreeSwitchCommandRemainsDirectShortcut(t *testing.T) {
 	}
 }
 
+func TestWorktreeSwitchCommandRefreshesStatusLineBranchAfterRuntimeTargetRefresh(t *testing.T) {
+	mainRoot := initStatusLineGitRepo(t, "main-branch")
+	featureRoot := initStatusLineGitRepo(t, "feature-branch")
+	client := &worktreeCommandTestClient{
+		listResp: worktreeListResponseForRoots(mainRoot, featureRoot),
+		switchResp: serverapi.WorktreeSwitchResponse{
+			Target:   clientui.SessionExecutionTarget{WorkspaceRoot: mainRoot, WorktreeRoot: featureRoot, EffectiveWorkdir: featureRoot},
+			Worktree: serverapi.WorktreeView{WorktreeID: "wt-feature", DisplayName: "feature", CanonicalRoot: featureRoot, BranchName: "feature-branch"},
+		},
+	}
+	m := newWorktreeTestModel(t, client, WithUIStatusConfig(uiStatusConfig{WorkspaceRoot: mainRoot}))
+	m.status.snapshot.Git = uiStatusGitInfo{Visible: true, Branch: "main-branch"}
+	m.input = "/worktree switch feature"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := applyWorktreeCmdMessages(t, next.(*uiModel), cmd)
+	updated = applyRuntimeTargetRefreshAndDrainStatus(t, updated, client.switchResp.Target)
+
+	status := worktreeStatusLine(updated)
+	if !strings.Contains(status, "feature-branch") || strings.Contains(status, "main-branch") {
+		t.Fatalf("status line = %q, want refreshed feature branch without stale main branch", status)
+	}
+}
+
 func TestProjectedSessionMetadataAppliesExecutionTarget(t *testing.T) {
 	m := newProjectedTestUIModel(&runtimeControlFakeClient{}, nil, nil, WithUISessionID("session-1"))
 	m.statusConfig.WorkspaceRoot = "/repo"
@@ -372,15 +396,18 @@ func TestWorktreeOverlayEnterSwitchesSelectedItemAndCloses(t *testing.T) {
 }
 
 func TestWorktreeCreateDialogSubmitsAndClosesOnSuccess(t *testing.T) {
+	mainRoot := initStatusLineGitRepo(t, "main-branch")
+	featureRoot := initStatusLineGitRepo(t, "created-branch")
 	client := &worktreeCommandTestClient{
-		listResp: testMainWorktreeListResponse(),
+		listResp: worktreeListResponseForRoots(mainRoot, ""),
 		createResp: serverapi.WorktreeCreateResponse{
-			Target:        clientui.SessionExecutionTarget{EffectiveWorkdir: "/wt/feature-branch"},
-			Worktree:      serverapi.WorktreeView{WorktreeID: "wt-new", DisplayName: "feature-branch", CanonicalRoot: "/wt/feature-branch", BranchName: "feature/branch"},
+			Target:        clientui.SessionExecutionTarget{WorkspaceRoot: mainRoot, WorktreeRoot: featureRoot, EffectiveWorkdir: featureRoot},
+			Worktree:      serverapi.WorktreeView{WorktreeID: "wt-new", DisplayName: "feature-branch", CanonicalRoot: featureRoot, BranchName: "feature/branch"},
 			CreatedBranch: true,
 		},
 	}
-	m := newWorktreeTestModel(t, client)
+	m := newWorktreeTestModel(t, client, WithUIStatusConfig(uiStatusConfig{WorkspaceRoot: mainRoot}))
+	m.status.snapshot.Git = uiStatusGitInfo{Visible: true, Branch: "main-branch"}
 	m.input = "/wt create"
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := applyWorktreeCmdMessages(t, next.(*uiModel), cmd)
@@ -405,6 +432,11 @@ func TestWorktreeCreateDialogSubmitsAndClosesOnSuccess(t *testing.T) {
 	}
 	if got := client.createRequests[0]; got.BaseRef != "HEAD" || !got.CreateBranch || got.BranchName != "feature/branch" || got.RootPath != "" {
 		t.Fatalf("unexpected create request: %+v", got)
+	}
+	updated = applyRuntimeTargetRefreshAndDrainStatus(t, updated, client.createResp.Target)
+	status := worktreeStatusLine(updated)
+	if !strings.Contains(status, "created-branch") || strings.Contains(status, "main-branch") {
+		t.Fatalf("status line = %q, want refreshed created branch without stale main branch", status)
 	}
 }
 
@@ -436,15 +468,18 @@ func TestWorktreeCreateDialogDetachedRefResolutionCreatesWithoutBranch(t *testin
 }
 
 func TestWorktreeDeleteDialogStaysOpenAfterSuccess(t *testing.T) {
+	mainRoot := initStatusLineGitRepo(t, "main-branch")
+	featureRoot := initStatusLineGitRepo(t, "feature-branch")
 	client := &worktreeCommandTestClient{
-		listResp:   testLinkedWorktreeListResponse(),
-		deleteResp: serverapi.WorktreeDeleteResponse{Target: clientui.SessionExecutionTarget{EffectiveWorkdir: "/repo"}, Worktree: serverapi.WorktreeView{WorktreeID: "wt-feature", DisplayName: "feature-a", CanonicalRoot: "/wt/feature-a"}},
+		listResp:   worktreeListResponseForRoots(mainRoot, featureRoot),
+		deleteResp: serverapi.WorktreeDeleteResponse{Target: clientui.SessionExecutionTarget{WorkspaceRoot: mainRoot, EffectiveWorkdir: mainRoot}, Worktree: serverapi.WorktreeView{WorktreeID: "wt-feature", DisplayName: "feature", CanonicalRoot: featureRoot}},
 	}
-	m := newWorktreeTestModel(t, client)
+	m := newWorktreeTestModel(t, client, WithUIStatusConfig(uiStatusConfig{WorkspaceRoot: featureRoot}))
+	m.status.snapshot.Git = uiStatusGitInfo{Visible: true, Branch: "feature-branch"}
 	m.input = "/wt delete"
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := applyWorktreeCmdMessages(t, next.(*uiModel), cmd)
-	client.listResp = testMainWorktreeListResponse()
+	client.listResp = worktreeListResponseForRoots(mainRoot, "")
 
 	next, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = applyWorktreeCmdMessages(t, next.(*uiModel), cmd)
@@ -457,6 +492,11 @@ func TestWorktreeDeleteDialogStaysOpenAfterSuccess(t *testing.T) {
 	}
 	if len(client.deleteRequests) != 1 || client.deleteRequests[0].DeleteBranch {
 		t.Fatalf("unexpected delete request: %+v", client.deleteRequests)
+	}
+	updated = applyRuntimeTargetRefreshAndDrainStatus(t, updated, client.deleteResp.Target)
+	status := worktreeStatusLine(updated)
+	if !strings.Contains(status, "main-branch") || strings.Contains(status, "feature-branch") {
+		t.Fatalf("status line = %q, want refreshed main branch without stale feature branch", status)
 	}
 }
 

--- a/cli/app/ui_worktree_commands_test.go
+++ b/cli/app/ui_worktree_commands_test.go
@@ -128,6 +128,18 @@ func worktreeStatusLine(model *uiModel) string {
 	return stripANSIAndTrimRight(model.renderStatusLine(120, uiThemeStyles("dark")))
 }
 
+func applyRuntimeTargetRefreshAndDrainStatus(t *testing.T, model *uiModel, target clientui.SessionExecutionTarget) *uiModel {
+	t.Helper()
+	next, cmd := model.Update(runtimeMainViewRefreshedMsg{
+		token: model.runtimeMainViewToken,
+		view: clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{
+			SessionID:       "session-1",
+			ExecutionTarget: target,
+		}},
+	})
+	return drainStatusLineStartupCommands(t, next.(*uiModel), cmd)
+}
+
 func assertWorktreeOverlayLocalErrorOnly(t *testing.T, model *uiModel, expectedVisible []string, unexpectedVisible []string) {
 	t.Helper()
 	status := worktreeStatusLine(model)
@@ -160,6 +172,41 @@ func testMainWorktreeListResponse() serverapi.WorktreeListResponse {
 			IsCurrent:     true,
 		}},
 	}
+}
+
+func worktreeListResponseForRoots(mainRoot string, featureRoot string) serverapi.WorktreeListResponse {
+	resp := serverapi.WorktreeListResponse{
+		Target: clientui.SessionExecutionTarget{
+			WorkspaceID:      "workspace-1",
+			WorkspaceRoot:    mainRoot,
+			EffectiveWorkdir: mainRoot,
+		},
+		Worktrees: []serverapi.WorktreeView{{
+			WorktreeID:    "wt-main",
+			DisplayName:   "main",
+			CanonicalRoot: mainRoot,
+			BranchName:    "main",
+			IsMain:        true,
+			IsCurrent:     featureRoot == "",
+		}},
+	}
+	if strings.TrimSpace(featureRoot) != "" {
+		resp.Target.WorktreeID = "wt-feature"
+		resp.Target.WorktreeRoot = featureRoot
+		resp.Target.EffectiveWorkdir = featureRoot
+		resp.Worktrees[0].IsCurrent = false
+		resp.Worktrees = append(resp.Worktrees, serverapi.WorktreeView{
+			WorktreeID:      "wt-feature",
+			DisplayName:     "feature",
+			CanonicalRoot:   featureRoot,
+			BranchName:      "feature",
+			IsCurrent:       true,
+			BuilderManaged:  true,
+			CreatedBranch:   true,
+			OriginSessionID: "session-1",
+		})
+	}
+	return resp
 }
 
 func testLinkedWorktreeListResponse() serverapi.WorktreeListResponse {

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -4,7 +4,6 @@ import (
 	"builder/shared/clientui"
 	"builder/shared/transcript"
 	"fmt"
-	"regexp"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -20,8 +19,6 @@ const (
 	TranscriptDivider   = "────────────────────────"
 	detailItemSeparator = ""
 )
-
-var patchCountTokenPattern = regexp.MustCompile(`([+-]\d+)\b`)
 
 type TranscriptEntry struct {
 	Visibility        transcript.EntryVisibility

--- a/cli/tui/model_rendering_entries.go
+++ b/cli/tui/model_rendering_entries.go
@@ -218,6 +218,12 @@ func truncateRenderedLineToWidthWithEllipsis(line string, width int, forceEllips
 }
 
 func (m Model) renderEntryContentStage(role RenderIntent, text string, width int, toolMeta *transcript.ToolCallMeta, muteText bool) transcriptRenderContent {
+	_ = text
+	if isPatchToolBlock(role, toolMeta) {
+		if content, ok := m.renderPatchSummaryContent(toolMeta); ok {
+			return content
+		}
+	}
 	if !muteText {
 		if diffLines, ok := m.renderDiffToolLines(text, width, toolMeta); ok {
 			return transcriptRenderContent{Lines: diffLines, WrapMode: transcriptRenderWrapModePreserved}
@@ -277,7 +283,7 @@ func (m Model) layoutEntryContentStage(role RenderIntent, content transcriptRend
 	continuationPrefix := m.entryContinuationPrefix(role, symbolOverride)
 	out := make([]transcriptLayoutLine, 0, len(content.Lines))
 	for idx, line := range content.Lines {
-		layoutLine := transcriptLayoutLine{Text: line.Text, Intents: line.Intents}
+		layoutLine := transcriptLayoutLine{Text: line.Text, Intents: line.Intents, PatchSummary: line.PatchSummary}
 		if idx == 0 {
 			layoutLine.ShowRoleSymbol = hasRoleSymbol
 		} else {
@@ -337,7 +343,11 @@ func (m Model) decorateEntryLayoutBodyStage(role RenderIntent, lines []transcrip
 			if idx == 0 {
 				display = m.renderToolHeadline(display, renderWidth)
 			}
-			display = m.styleToolLine(display, isPatchBlock)
+			if line.PatchSummary != nil {
+				display = m.renderPatchSummaryLine(*line.PatchSummary)
+			} else {
+				display = m.styleToolLine(display)
+			}
 		}
 		if !strings.Contains(display, "\x1b[") {
 			display = applyANSIStyleIntents(display, m.ansiIntentPalette(), line.Intents)

--- a/cli/tui/model_rendering_tools.go
+++ b/cli/tui/model_rendering_tools.go
@@ -4,6 +4,7 @@ import (
 	"builder/shared/textutil"
 	"builder/shared/toolspec"
 	"builder/shared/transcript"
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -305,6 +306,61 @@ func splitToolInlineMeta(line string) (string, string) {
 	return transcript.SplitInlineMeta(line)
 }
 
+func (m Model) renderPatchSummaryContent(meta *transcript.ToolCallMeta) (transcriptRenderContent, bool) {
+	if meta == nil || meta.PatchRender == nil {
+		return transcriptRenderContent{}, false
+	}
+	lines := make([]transcriptRenderLine, 0, len(meta.PatchRender.SummaryLines))
+	for _, summary := range meta.PatchRender.SummaryLines {
+		if summary.Kind != "file" || summary.FileIndex < 0 || summary.FileIndex >= len(meta.PatchRender.Files) {
+			continue
+		}
+		file := meta.PatchRender.Files[summary.FileIndex]
+		path := strings.TrimSpace(file.RelPath)
+		if path == "" {
+			path = strings.TrimSpace(file.AbsPath)
+		}
+		if path == "" {
+			continue
+		}
+		plain := patchSummaryPlainLine(path, file.Added, file.Removed)
+		lines = append(lines, transcriptRenderLine{
+			Text: plain,
+			PatchSummary: &transcriptPatchSummaryLine{
+				Path:    path,
+				Added:   file.Added,
+				Removed: file.Removed,
+			},
+		})
+	}
+	if len(lines) == 0 {
+		return transcriptRenderContent{}, false
+	}
+	return transcriptRenderContent{Lines: lines, WrapMode: transcriptRenderWrapModePreserved}, true
+}
+
+func patchSummaryPlainLine(path string, added int, removed int) string {
+	parts := []string{path}
+	if removed > 0 {
+		parts = append(parts, fmt.Sprintf("-%d", removed))
+	}
+	if added > 0 {
+		parts = append(parts, fmt.Sprintf("+%d", added))
+	}
+	return strings.Join(parts, " ")
+}
+
+func (m Model) renderPatchSummaryLine(line transcriptPatchSummaryLine) string {
+	parts := []string{line.Path}
+	if line.Removed > 0 {
+		parts = append(parts, m.palette().toolError.Render(fmt.Sprintf("-%d", line.Removed)))
+	}
+	if line.Added > 0 {
+		parts = append(parts, m.palette().toolSuccess.Render(fmt.Sprintf("+%d", line.Added)))
+	}
+	return strings.Join(parts, " ")
+}
+
 func (m Model) renderToolHeadline(line string, width int) string {
 	command, meta := splitToolInlineMeta(line)
 	if meta == "" {
@@ -346,7 +402,7 @@ func (m Model) diffLineBackgroundEscapes() (string, string) {
 	return bgEscape(p.diffAddBackground), bgEscape(p.diffRemoveBackground)
 }
 
-func (m Model) styleToolLine(line string, isPatchBlock bool) string {
+func (m Model) styleToolLine(line string) string {
 	trimmed := strings.TrimSpace(line)
 	if trimmed == "" {
 		return line
@@ -357,29 +413,5 @@ func (m Model) styleToolLine(line string, isPatchBlock bool) string {
 	if strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---") {
 		return m.palette().toolError.Render("-") + line[1:]
 	}
-	successCountStyle := m.palette().toolSuccess
-	errorCountStyle := m.palette().toolError
-	if isPatchBlock {
-		return patchCountTokenPattern.ReplaceAllStringFunc(line, func(token string) string {
-			if strings.HasPrefix(token, "+") {
-				return successCountStyle.Render(token)
-			}
-			if strings.HasPrefix(token, "-") {
-				return errorCountStyle.Render(token)
-			}
-			return token
-		})
-	}
-	if !strings.HasPrefix(trimmed, "./") {
-		return line
-	}
-	return patchCountTokenPattern.ReplaceAllStringFunc(line, func(token string) string {
-		if strings.HasPrefix(token, "+") {
-			return successCountStyle.Render(token)
-		}
-		if strings.HasPrefix(token, "-") {
-			return errorCountStyle.Render(token)
-		}
-		return token
-	})
+	return line
 }

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -796,6 +796,67 @@ func TestOngoingMultilineToolBlocksRenderTreeGuides(t *testing.T) {
 	}
 }
 
+func TestOngoingPatchSummaryRendersPathAsPlainContiguousText(t *testing.T) {
+	path := "./.builder/plans/td-006-runtime-state-ownership.md"
+	m := NewModel(WithPreviewLines(20))
+	m = updateModel(t, m, AppendTranscriptMsg{
+		Role:       "tool_call",
+		Text:       "Patch",
+		ToolCallID: "call_patch",
+		ToolCall: &transcript.ToolCallMeta{
+			ToolName:     "patch",
+			Command:      path + " +63",
+			CompactText:  path + " +63",
+			PatchSummary: path + " +63",
+			PatchRender: &patchformat.RenderedPatch{
+				Files:        []patchformat.RenderedFile{{RelPath: path, Added: 63}},
+				SummaryLines: []patchformat.RenderedLine{{Kind: patchformat.RenderedLineKindFile, Text: path + " +63", FileIndex: 0, Path: path}},
+			},
+		},
+	})
+	m = updateModel(t, m, AppendTranscriptMsg{Role: "tool_result_ok", ToolCallID: "call_patch"})
+
+	raw := m.View()
+	if !strings.Contains(raw, path) {
+		t.Fatalf("expected raw transcript to contain clickable plain path %q, got %q", path, raw)
+	}
+	if strings.Contains(raw, "td\x1b") || strings.Contains(raw, "\x1b[31m-006") || strings.Contains(raw, "\x1b[38;2;255;") {
+		t.Fatalf("expected path to remain unstyled, got raw %q", raw)
+	}
+	plain := plainTranscript(raw)
+	if !strings.Contains(plain, path+" +63") {
+		t.Fatalf("expected patch summary count after plain path, got %q", plain)
+	}
+}
+
+func TestPatchSummaryRenderingUsesStructuredPathRemovedAddedParts(t *testing.T) {
+	path := "./.builder/plans/td-006+runtime-state-ownership.md"
+	model := NewModel(WithPreviewLines(20))
+	content, ok := model.renderPatchSummaryContent(&transcript.ToolCallMeta{
+		PatchRender: &patchformat.RenderedPatch{
+			Files:        []patchformat.RenderedFile{{RelPath: path, Added: 5, Removed: 2}},
+			SummaryLines: []patchformat.RenderedLine{{Kind: patchformat.RenderedLineKindFile, Text: "ignored serialized text", FileIndex: 0, Path: path}},
+		},
+	})
+	if !ok || len(content.Lines) != 1 {
+		t.Fatalf("expected one structured patch summary line, got ok=%t content=%+v", ok, content)
+	}
+	line := content.Lines[0]
+	if line.Text != path+" -2 +5" {
+		t.Fatalf("plain summary line = %q, want path removed added", line.Text)
+	}
+	if line.PatchSummary == nil || line.PatchSummary.Path != path || line.PatchSummary.Removed != 2 || line.PatchSummary.Added != 5 {
+		t.Fatalf("structured summary = %+v", line.PatchSummary)
+	}
+	rendered := model.renderPatchSummaryLine(*line.PatchSummary)
+	if !strings.Contains(rendered, path) {
+		t.Fatalf("rendered summary path is not contiguous/plain: %q", rendered)
+	}
+	if plainTranscript(rendered) != path+" -2 +5" {
+		t.Fatalf("rendered summary = %q, want path removed added", plainTranscript(rendered))
+	}
+}
+
 func TestOngoingEditResultUsesPatchSummaryHeadline(t *testing.T) {
 	m := NewModel(WithPreviewLines(20))
 	m = updateModel(t, m, AppendTranscriptMsg{

--- a/cli/tui/render_style_intents.go
+++ b/cli/tui/render_style_intents.go
@@ -33,14 +33,22 @@ type transcriptRenderContent struct {
 }
 
 type transcriptRenderLine struct {
-	Text    string
-	Intents StyleIntent
+	Text         string
+	Intents      StyleIntent
+	PatchSummary *transcriptPatchSummaryLine
+}
+
+type transcriptPatchSummaryLine struct {
+	Path    string
+	Added   int
+	Removed int
 }
 
 type transcriptLayoutLine struct {
 	Prefix         string
 	Text           string
 	Intents        StyleIntent
+	PatchSummary   *transcriptPatchSummaryLine
 	ShowRoleSymbol bool
 }
 

--- a/server/auth/types.go
+++ b/server/auth/types.go
@@ -91,6 +91,22 @@ type APIKeyMethod struct {
 	Key string `json:"key"`
 }
 
+func MaskedAPIKeySummary(apiKey *APIKeyMethod) string {
+	key := ""
+	if apiKey != nil {
+		key = strings.TrimSpace(apiKey.Key)
+	}
+	if key == "" {
+		return "API Key"
+	}
+	runes := []rune(key)
+	start := len(runes) - 4
+	if start < 0 {
+		start = 0
+	}
+	return "API Key ..." + string(runes[start:])
+}
+
 type OAuthMethod struct {
 	AccessToken  string    `json:"access_token"`
 	RefreshToken string    `json:"refresh_token"`

--- a/server/authstatus/service.go
+++ b/server/authstatus/service.go
@@ -91,7 +91,7 @@ func authInfo(state auth.State, settings config.Settings, statusErr error) serve
 		}
 		return serverapi.AuthStatusInfo{Summary: summary, Details: details, Visible: true}
 	case auth.MethodAPIKey:
-		summary := apiKeyAuthSummary(state.Method.APIKey)
+		summary := auth.MaskedAPIKeySummary(state.Method.APIKey)
 		if provider := providerLabel(state, settings); provider != "" {
 			details = append(details, provider)
 		}
@@ -108,22 +108,6 @@ func authInfo(state auth.State, settings config.Settings, statusErr error) serve
 		}
 		return serverapi.AuthStatusInfo{Summary: "No Auth", Visible: true}
 	}
-}
-
-func apiKeyAuthSummary(apiKey *auth.APIKeyMethod) string {
-	key := ""
-	if apiKey != nil {
-		key = strings.TrimSpace(apiKey.Key)
-	}
-	if key == "" {
-		return "API Key"
-	}
-	runes := []rune(key)
-	start := len(runes) - 4
-	if start < 0 {
-		start = 0
-	}
-	return "API Key ..." + string(runes[start:])
 }
 
 func (s *Service) subscriptionStatus(ctx context.Context, settings config.Settings, state auth.State, authStateErr error) serverapi.AuthSubscriptionInfo {

--- a/server/authstatus/service.go
+++ b/server/authstatus/service.go
@@ -91,7 +91,7 @@ func authInfo(state auth.State, settings config.Settings, statusErr error) serve
 		}
 		return serverapi.AuthStatusInfo{Summary: summary, Details: details, Visible: true}
 	case auth.MethodAPIKey:
-		summary := "API key"
+		summary := apiKeyAuthSummary(state.Method.APIKey)
 		if provider := providerLabel(state, settings); provider != "" {
 			details = append(details, provider)
 		}
@@ -106,8 +106,24 @@ func authInfo(state auth.State, settings config.Settings, statusErr error) serve
 		if statusErr != nil {
 			return serverapi.AuthStatusInfo{Summary: "Auth unavailable", Details: []string{statusErr.Error()}, Visible: true}
 		}
-		return serverapi.AuthStatusInfo{}
+		return serverapi.AuthStatusInfo{Summary: "No Auth", Visible: true}
 	}
+}
+
+func apiKeyAuthSummary(apiKey *auth.APIKeyMethod) string {
+	key := ""
+	if apiKey != nil {
+		key = strings.TrimSpace(apiKey.Key)
+	}
+	if key == "" {
+		return "API Key"
+	}
+	runes := []rune(key)
+	start := len(runes) - 4
+	if start < 0 {
+		start = 0
+	}
+	return "API Key ..." + string(runes[start:])
 }
 
 func (s *Service) subscriptionStatus(ctx context.Context, settings config.Settings, state auth.State, authStateErr error) serverapi.AuthSubscriptionInfo {

--- a/server/authstatus/service_test.go
+++ b/server/authstatus/service_test.go
@@ -63,8 +63,8 @@ func TestServiceUsesServerSettingsForAPIKeyProviderLabel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAuthStatus: %v", err)
 	}
-	if resp.Auth.Summary != "API key" {
-		t.Fatalf("auth summary = %q, want API key", resp.Auth.Summary)
+	if resp.Auth.Summary != "API Key ...test" {
+		t.Fatalf("auth summary = %q, want masked API key", resp.Auth.Summary)
 	}
 	if len(resp.Auth.Details) != 1 || resp.Auth.Details[0] != "internal-openai" {
 		t.Fatalf("auth details = %+v, want server provider override", resp.Auth.Details)

--- a/shared/clientui/runtime.go
+++ b/shared/clientui/runtime.go
@@ -2,6 +2,7 @@ package clientui
 
 import (
 	"context"
+	"strings"
 	"time"
 )
 
@@ -108,6 +109,29 @@ type SessionExecutionTarget struct {
 	WorktreeAvailability  string
 	CwdRelpath            string
 	EffectiveWorkdir      string
+}
+
+func NormalizeSessionExecutionTarget(target SessionExecutionTarget) SessionExecutionTarget {
+	return SessionExecutionTarget{
+		WorkspaceID:           strings.TrimSpace(target.WorkspaceID),
+		WorkspaceName:         strings.TrimSpace(target.WorkspaceName),
+		WorkspaceRoot:         strings.TrimSpace(target.WorkspaceRoot),
+		WorkspaceAvailability: strings.TrimSpace(target.WorkspaceAvailability),
+		WorktreeID:            strings.TrimSpace(target.WorktreeID),
+		WorktreeName:          strings.TrimSpace(target.WorktreeName),
+		WorktreeRoot:          strings.TrimSpace(target.WorktreeRoot),
+		WorktreeAvailability:  strings.TrimSpace(target.WorktreeAvailability),
+		CwdRelpath:            strings.TrimSpace(target.CwdRelpath),
+		EffectiveWorkdir:      strings.TrimSpace(target.EffectiveWorkdir),
+	}
+}
+
+func SessionExecutionTargetIsZero(target SessionExecutionTarget) bool {
+	return NormalizeSessionExecutionTarget(target) == SessionExecutionTarget{}
+}
+
+func SessionExecutionTargetsEqual(a SessionExecutionTarget, b SessionExecutionTarget) bool {
+	return NormalizeSessionExecutionTarget(a) == NormalizeSessionExecutionTarget(b)
 }
 
 type RuntimeSessionView struct {


### PR DESCRIPTION
## Summary
- refresh statusline git branch after worktree execution-target changes
- render patch summaries from structured patch data instead of parsing text
- update /status session/auth/config ordering and styling
- keep slash/path picker highlight synced with absolute selection and viewport offset

## Verification
- ./scripts/test.sh ./cli/app
- ./scripts/test.sh ./server/auth ./cli/app ./cli/app/internal/statuscollect ./server/authstatus ./server/runtime ./server/tools ./shared/serverapi
- ./scripts/build.sh --output ./bin/builder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added execution target tracking to status overlay for better workspace/branch visibility.
  * Enhanced auth display to show masked API key summaries and explicit "No Auth" status.

* **Bug Fixes**
  * Fixed Git branch display to refresh correctly when switching execution targets.
  * Corrected status overlay section ordering and session information layout.

* **Improvements**
  * Improved patch summary rendering with cleaner path and change count display.
  * Enhanced slash command and path reference pickers with viewport scrolling support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/respawn-app/builder/pull/243)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->