### PR TITLE
fix: gate service restart in builder shells

### DIFF
--- a/cli/builder/help.go
+++ b/cli/builder/help.go
@@ -384,6 +384,9 @@ func writeServiceRestartUsage(fs *flag.FlagSet) {
 	writeHelpSection(out, "Usage of builder service restart:",
 		"  builder service restart [--if-installed]",
 	)
+	writeHelpSection(out, "Notes:",
+		"  Refuses to run inside Builder shell commands to avoid halting active agent work.",
+	)
 	writeHelpSection(out, "Flags:")
 	fs.PrintDefaults()
 }

--- a/cli/builder/service_command.go
+++ b/cli/builder/service_command.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strings"
 	"time"
 
 	"builder/shared/config"
 	"builder/shared/protocol"
+	"builder/shared/sessionenv"
 )
 
 type serviceAction string
@@ -231,12 +233,15 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 		fmt.Fprintf(stdout, "Stopped %s.\n", serviceDisplayName)
 	case serviceActionRestart:
 		if !opts.IfInstalled {
+			if err := ensureServiceRestartAllowed(); err != nil {
+				fmt.Fprintln(stderr, err)
+				return 1
+			}
 			if err := ensureNoUnmanagedServerConflict(ctx, backend, spec); err != nil {
 				fmt.Fprintln(stderr, err)
 				return 1
 			}
-		}
-		if opts.IfInstalled {
+		} else {
 			status, err := backend.Status(ctx, spec)
 			if err != nil {
 				fmt.Fprintln(stderr, err)
@@ -244,6 +249,10 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 			}
 			if !status.Installed {
 				return 0
+			}
+			if err := ensureServiceRestartAllowed(); err != nil {
+				fmt.Fprintln(stderr, err)
+				return 1
 			}
 			if err := ensureNoUnmanagedServerConflict(ctx, backend, spec); err != nil {
 				fmt.Fprintln(stderr, err)
@@ -298,6 +307,15 @@ func ensureNoUnmanagedServerConflict(ctx context.Context, backend serviceBackend
 		}
 	}
 	return nil
+}
+
+const serviceRestartCurrentSessionError = "you may not restart the service now as restarting the service will kill your current session, halting your work. Ask the user to restart the service manually."
+
+func ensureServiceRestartAllowed() error {
+	if _, ok := sessionenv.LookupBuilderSessionID(os.LookupEnv); !ok {
+		return nil
+	}
+	return errors.New(serviceRestartCurrentSessionError)
 }
 
 func readServiceStatus(ctx context.Context, backend serviceBackend, spec serviceSpec) (serviceStatus, error) {

--- a/cli/builder/service_command_test.go
+++ b/cli/builder/service_command_test.go
@@ -429,8 +429,17 @@ func TestServiceRestartHelpMentionsBuilderShellGuard(t *testing.T) {
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q, want empty", stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "Refuses to run inside Builder shell commands") {
-		t.Fatalf("stderr = %q, want Builder shell guard note", stderr.String())
+	expected := "Usage of builder service restart:\n" +
+		"  builder service restart [--if-installed]\n" +
+		"\n" +
+		"Notes:\n" +
+		"  Refuses to run inside Builder shell commands to avoid halting active agent work.\n" +
+		"\n" +
+		"Flags:\n" +
+		"  -if-installed\n" +
+		"    \texit successfully without action when service is not installed\n"
+	if got := stderr.String(); got != expected {
+		t.Fatalf("stderr = %q, want exact help output %q", got, expected)
 	}
 }
 

--- a/cli/builder/service_command_test.go
+++ b/cli/builder/service_command_test.go
@@ -9,12 +9,19 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
 	"builder/shared/config"
 	"builder/shared/protocol"
+	"builder/shared/sessionenv"
 )
+
+func TestMain(m *testing.M) {
+	_ = os.Unsetenv(sessionenv.BuilderSessionID)
+	os.Exit(m.Run())
+}
 
 type stubServiceBackend struct {
 	status        serviceStatus
@@ -304,6 +311,7 @@ func TestServiceInstallAllowsHealthyServerOwnedByLoadedService(t *testing.T) {
 }
 
 func TestServiceRestartAllowsHealthyServerOwnedByLoadedServiceBeforePIDIsVisible(t *testing.T) {
+	t.Setenv(sessionenv.BuilderSessionID, "")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/healthz" {
 			http.NotFound(w, r)
@@ -329,6 +337,122 @@ func TestServiceRestartAllowsHealthyServerOwnedByLoadedServiceBeforePIDIsVisible
 	want := []serviceAction{serviceActionStatus, serviceActionRestart}
 	if strings.Join(actionsToStrings(backend.calls), ",") != strings.Join(actionsToStrings(want), ",") {
 		t.Fatalf("calls = %+v, want %+v", backend.calls, want)
+	}
+}
+
+func TestServiceRestartRejectsBuilderShellSession(t *testing.T) {
+	t.Setenv(sessionenv.BuilderSessionID, "session-123")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"status":"ok","pid":123}`)
+	}))
+	t.Cleanup(server.Close)
+	backend := &stubServiceBackend{status: serviceStatus{Installed: true, Loaded: true, Running: true, PID: 123}}
+	withServiceCommandTestBackendEndpoint(t, backend, server.URL)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"restart"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if len(backend.calls) != 0 {
+		t.Fatalf("calls = %+v, want no service backend calls", backend.calls)
+	}
+	if got := strings.TrimSpace(stderr.String()); got != serviceRestartCurrentSessionError {
+		t.Fatalf("stderr = %q, want current session restart guard", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestServiceRestartIfInstalledRejectsBuilderShellSession(t *testing.T) {
+	t.Setenv(sessionenv.BuilderSessionID, "session-123")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"status":"ok","pid":123}`)
+	}))
+	t.Cleanup(server.Close)
+	backend := &stubServiceBackend{status: serviceStatus{Installed: true, Loaded: true, Running: true, PID: 123}}
+	withServiceCommandTestBackendEndpoint(t, backend, server.URL)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"restart", "--if-installed"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if len(backend.calls) != 1 || backend.calls[0] != serviceActionStatus {
+		t.Fatalf("calls = %+v, want status only", backend.calls)
+	}
+	if got := strings.TrimSpace(stderr.String()); got != serviceRestartCurrentSessionError {
+		t.Fatalf("stderr = %q, want current session restart guard", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestServiceRestartIfInstalledSkipsCurrentShellSessionGuardWhenServiceMissing(t *testing.T) {
+	t.Setenv(sessionenv.BuilderSessionID, "session-123")
+	backend := &stubServiceBackend{status: serviceStatus{Installed: false}}
+	withServiceCommandTestBackend(t, backend)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"restart", "--if-installed"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if len(backend.calls) != 1 || backend.calls[0] != serviceActionStatus {
+		t.Fatalf("calls = %+v, want status only", backend.calls)
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("unexpected output stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestServiceRestartHelpMentionsBuilderShellGuard(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"restart", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Refuses to run inside Builder shell commands") {
+		t.Fatalf("stderr = %q, want Builder shell guard note", stderr.String())
+	}
+}
+
+func TestServiceRestartRejectsCurrentShellSessionBeforeHealthProbe(t *testing.T) {
+	t.Setenv(sessionenv.BuilderSessionID, "session-123")
+	backend := &stubServiceBackend{status: serviceStatus{Installed: true, Loaded: true, Running: true, PID: 123}}
+	withServiceCommandTestBackend(t, backend)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"restart"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if len(backend.calls) != 0 {
+		t.Fatalf("calls = %+v, want no service backend calls", backend.calls)
+	}
+	if got := strings.TrimSpace(stderr.String()); got != serviceRestartCurrentSessionError {
+		t.Fatalf("stderr = %q, want current session restart guard", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
 	}
 }
 

--- a/docs/dev/rtk-gradle-postprocessing.md
+++ b/docs/dev/rtk-gradle-postprocessing.md
@@ -1,0 +1,45 @@
+# RTK Gradle Post-Processing Inventory
+
+RTK source inspected at `/Users/nek/Developer/Tools/rtk`, commit `55f998d08cd80ece970fe5e61eaae3533512288b`.
+
+This tracked note mirrors key conclusions from ignored scratch audit `docs/tmp/rtk-post-processing-audit.md`, section `Build / Test / Lint / Format Families` -> `5. Gradle / Android family`.
+
+## Layers
+
+- Explicit wrapper: `rtk gradlew ...` in `src/cmds/jvm/gradlew_cmd.rs`.
+- Hook/rewrite rule: `./gradlew`, `gradlew.bat`, `gradlew`, and `gradle` route recognized Gradle task invocations toward `rtk gradlew`.
+- Generic TOML fallback: `src/filters/gradle.toml` provides weaker display-only stripping for raw fallback commands that match its regex.
+
+## Source Anchors
+
+- Wrapper CLI declaration/routing: `src/main.rs:730-735`, `src/main.rs:2143-2145`.
+- Raw fallback/TOML path: `src/main.rs:1131-1255`.
+- Rewrite rule: `src/discover/rules.rs:629-635`.
+- Wrapper task routing: `src/cmds/jvm/gradlew_cmd.rs:12-18`, `src/cmds/jvm/gradlew_cmd.rs:20-63`, `src/cmds/jvm/gradlew_cmd.rs:65-174`.
+- Wrapper output filters: `src/cmds/jvm/gradlew_cmd.rs:176-520`.
+- Built-in TOML filter: `src/filters/gradle.toml:1-35`.
+- TOML filter engine stages: `src/core/toml_filter.rs:425-533`.
+
+## Wrapper Behavior
+
+- Verbose/debug flags bypass filtering: `--stacktrace`, `--info`, `--debug`, `--full-stacktrace`.
+- Task detection uses last non-flag, non-`clean` arg. Mixed tasks use last task.
+- Caveat: task detection is not full Gradle CLI parsing. Non-flag option values can be misclassified as tasks when they are separate argv entries. Inline flag values like `-Pflavor=testRelease` are ignored because they start with `-`.
+- Build tasks stream line-filtered output, keeping status, actionable task count, errors, warnings, build scan links, and blank separators while stripping task/progress/config/daemon/Try noise.
+- Unit tests keep failed test lines, exception/message lines starting `java.` or `kotlin.`, first non-framework user stack frame, test summaries, build status, and actionable task count; passed/skipped tests and framework frames are stripped.
+- Connected tests strip instrumentation/device noise, special-case `No connected devices!`, then reuse unit-test filtering.
+- Lint keeps Android lint errors/warnings with up to 3 context lines, ktlint/detekt single-line violations, summaries, build status, and actionable task count; report paths are stripped.
+- Dependencies output becomes top-level dependency coordinates grouped by configuration; transitive deps and Gradle boilerplate are stripped.
+
+## TOML Fallback Behavior
+
+- Match regex is exactly `^(gradle|gradlew|\./)gradlew?\b`.
+- Regex caveat: because `gradlew?` is outside the alternation group, it can overmatch beyond obvious Gradle prefixes, including strings shaped like `gradlegradle`, `gradlegradlew`, `gradlewgradle`, `gradlewgradlew`, `./gradle`, and `./gradlew`.
+- Filter strips ANSI, removes common progress/task/cache/daemon lines, truncates remaining lines to 150 chars, caps output at 50 lines, and returns `gradle: ok` if empty.
+
+## Caveats
+
+- Build mode is streaming, so it is per-line keep/drop rather than multi-line structured parsing.
+- Unit test filtering keeps only first user-code stack frame after each failed test.
+- Lint context retention is Android-lint-specific; ktlint/detekt entries are single-line.
+- TOML filter is weaker than wrapper and should be treated as display-only.

--- a/docs/dev/rtk-search-listing-postprocessing.md
+++ b/docs/dev/rtk-search-listing-postprocessing.md
@@ -1,0 +1,16 @@
+# RTK Search/Listing Post-Processing Inventory
+
+RTK source inspected at `/Users/nek/Developer/Tools/rtk`, commit `55f998d08cd80ece970fe5e61eaae3533512288b`.
+
+This tracked note mirrors key conclusions from ignored scratch audit `docs/tmp/rtk-post-processing-audit.md`, section `System / Meta Command Families` -> `2. Search/listing family`.
+
+## Commands
+
+- `grep`: proxies through `rg` first, falls back to `grep`; parses `file:line:content`; trims and match-biased truncates lines; groups by file; caps total and per-file rows; passes through count/list/only-match/null output flags when those flags land in `extra_args`.
+- `find`: does an internal ignore-aware walk, not native `find`; supports limited native-like args and RTK args; rejects compound predicates/actions; groups basenames by parent dir; caps displayed files; prints extension summary.
+- `ls`: always runs `ls -la` with `LC_ALL=C`; parses English-date `ls` output; drops permissions/owner/group/date; hides noise dirs unless all entries requested; emits dirs first, then files with human sizes; TTY adds file/dir/extension summary.
+- `tree`: proxies native `tree`; injects `-I` with noise dirs unless all entries or ignore already requested; removes summary line and trims edge blank lines.
+- `wc`: strips padding and paths; formats single-file counts as bare numbers or `<lines>L <words>W <bytes>B`; formats multi-file rows with common path prefix stripped and `Σ` total rows.
+- `diff`: two-file mode performs same-index line comparison with char-set similarity for modified-vs-add/remove; stdin mode strips unified diff metadata, groups by file, prints all changed lines, but still appends stale `... +N more` when changes exceed 10.
+
+Source anchors live in the scratch audit next to each command bullet.

--- a/docs/dev/techdebt/techdebt.md
+++ b/docs/dev/techdebt/techdebt.md
@@ -20,7 +20,7 @@ Entry shape: checklist title line, summary evidence paragraph, impact paragraph,
 
 - [x] `TD-009` [P1] CLI packages import server-owned packages beyond the intended client boundary.
 
-- [ ] `TD-010` [P1] `shared/serverapi` mixes wire DTOs with server-owned service interfaces and headless runtime execution.
+- [x] `TD-010` [P1] `shared/serverapi` mixes wire DTOs with server-owned service interfaces and headless runtime execution.
 
   `shared/serverapi` defines request/response DTOs, validation, errors, 18 `*Service` interfaces, and concrete service behavior in one shared package. Examples include `shared/serverapi/runtime_control.go` defining `RuntimeControlService`, `shared/serverapi/session_view.go` defining `SessionViewService`, and `shared/serverapi/project_view.go` defining `ProjectViewService`. `shared/serverapi/run_prompt.go` goes further by defining `PromptSessionRuntime`, `HeadlessPromptLauncher`, concrete `PromptService`, `NewPromptService`, and `(*PromptService).RunPrompt`, which trims request input, prepares a runtime, applies timeout policy, submits the prompt, logs dropped runtime events, closes the runtime handle, and returns partial results on run errors. `shared/client` mirrors `shared/serverapi` with 16 matching non-test filenames such as `runtime_control.go`, `session_view.go`, `project_view.go`, and `worktree.go`.
 

--- a/docs/src/content/docs/server.md
+++ b/docs/src/content/docs/server.md
@@ -41,6 +41,7 @@ builder service uninstall --keep-running
 
 `install` starts the service after registration. `--no-start` only writes the service registration.
 `uninstall` stops the service before removing registration. `--keep-running` removes registration without stopping an already-running process.
+`restart` fails inside Builder shell commands, because stopping the service can halt active agent work. Ask the operator to restart it outside the session.
 
 ## Backends
 


### PR DESCRIPTION
## Summary
- prevent `builder service restart` from running inside Builder shell commands
- keep `restart --if-installed` no-op behavior when the service is not installed
- add service restart guard tests, CLI help note, public docs, and rtk postprocessing docs

## Verification
- ./scripts/test.sh ./cli/builder
- ./scripts/test.sh ./...
- ./scripts/build.sh --output ./bin/builder
- pnpm build (docs)

Closes #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `builder service restart` now prevents execution within active Builder shell sessions to avoid halting agent work.

* **Documentation**
  * Updated help text and user documentation with notes about the restart command's Builder shell limitation.
  * Added development documentation for RTK Gradle/Android and search/listing post-processing behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/respawn-app/builder/pull/256)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->