### PR TITLE
Add subagent role context

### DIFF
--- a/cli/app/internal/serverbridge/serverbridge.go
+++ b/cli/app/internal/serverbridge/serverbridge.go
@@ -137,6 +137,10 @@ func ResolveConfig(req BootstrapRequest) (BootstrapConfigPlan, error) {
 	return serverbootstrap.ResolveConfig(req)
 }
 
+func ResolveSessionAgentRole(persistenceRoot string, sessionID string) (string, error) {
+	return serverbootstrap.ResolveSessionAgentRole(persistenceRoot, sessionID)
+}
+
 func StartEmbedded(ctx context.Context, req StartupRequest, authHandler StartupAuthHandler, onboardingHandler StartupOnboardingHandler) (*Server, error) {
 	return serverstartup.Start(ctx, req, authHandler, onboardingHandler)
 }

--- a/cli/app/internal/startupconfig/config.go
+++ b/cli/app/internal/startupconfig/config.go
@@ -26,6 +26,7 @@ type Request struct {
 type RunPromptResult struct {
 	Config                config.App
 	ResolvedWorkspaceRoot string
+	ContextAgentRole      string
 }
 
 func ResolveSessionConfig(req Request) (config.App, error) {
@@ -70,11 +71,17 @@ func ResolveRunPromptConfig(req Request) (RunPromptResult, error) {
 		}
 		return RunPromptResult{}, err
 	}
+	contextAgentRole := ""
+	if contextSessionID != "" {
+		if agentRole, err := serverbridge.ResolveSessionAgentRole(plan.Config.PersistenceRoot, contextSessionID); err == nil {
+			contextAgentRole = agentRole
+		}
+	}
 	resolvedRoot := workspaceRoot
 	if strings.TrimSpace(plan.Config.WorkspaceRoot) != "" && plan.Config.WorkspaceRoot != workspaceRoot {
 		resolvedRoot = plan.Config.WorkspaceRoot
 	}
-	return RunPromptResult{Config: plan.Config, ResolvedWorkspaceRoot: resolvedRoot}, nil
+	return RunPromptResult{Config: plan.Config, ResolvedWorkspaceRoot: resolvedRoot, ContextAgentRole: contextAgentRole}, nil
 }
 
 func ResolveWorkspaceRoot(workspaceRoot string) (string, error) {

--- a/cli/app/run_prompt_target.go
+++ b/cli/app/run_prompt_target.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"time"
 
@@ -44,6 +45,9 @@ func startRunPromptClient(ctx context.Context, opts Options) (client.RunPromptCl
 	}
 	opts = workspaceConfig.Options
 	cfg := workspaceConfig.Config
+	if err := validateRunPromptAgentRole(cfg.Settings, opts.AgentRole, strings.TrimSpace(opts.WorkspaceContextSessionID) != ""); err != nil {
+		return nil, nil, err
+	}
 	target, err := serverattach.Resolve[runprompttarget.Target](ctx, serverattach.Request[runprompttarget.Target]{
 		Mode:   serverattach.ModeHeadless,
 		Remote: serverAttachRemotePolicy(cfg, remoteattach.SupportsRunPrompt, true),
@@ -85,6 +89,30 @@ func startRunPromptClient(ctx context.Context, opts Options) (client.RunPromptCl
 		return nil, nil, err
 	}
 	return target.Value.Client, target.Close, nil
+}
+
+const nonCallableSubagentRoleMessage = "User has disallowed calling this agent by other agents like you. Do not try to circumvent this, pick another suitable agent or do the work manually and let the user know your desire to use the subagent at the end of the task"
+
+func validateRunPromptAgentRole(settings config.Settings, rawRole string, builderSessionCaller bool) error {
+	roleName := config.NormalizeSubagentSelector(rawRole)
+	if roleName == "" {
+		if strings.TrimSpace(rawRole) != "" && !config.IsReservedSubagentRoleName(rawRole) {
+			return errors.New("invalid agent role " + strconv.Quote(rawRole))
+		}
+		return nil
+	}
+	role, exists := settings.Subagents[roleName]
+	if !exists && roleName != config.BuiltInSubagentRoleFast {
+		return unrecognizedRunPromptRoleError(roleName, config.AvailableSubagentRoleNames(settings, builderSessionCaller))
+	}
+	if builderSessionCaller && !config.SubagentRoleCallable(role) {
+		return errors.New(nonCallableSubagentRoleMessage)
+	}
+	return nil
+}
+
+func unrecognizedRunPromptRoleError(role string, available []string) error {
+	return errors.New("Unrecognized role " + strconv.Quote(role) + ". It may have been removed by the user during the session. Available roles: [" + strings.Join(available, ", ") + "]")
 }
 
 type embeddedRunPromptAttachment interface {

--- a/cli/app/run_prompt_target.go
+++ b/cli/app/run_prompt_target.go
@@ -34,8 +34,9 @@ var configuredRemoteWorkspaceDiscoveryTimeout = 5 * time.Second
 type configuredProjectViewRemote = remoteattach.ProjectViewRemote
 
 type runPromptWorkspaceConfig struct {
-	Options Options
-	Config  config.App
+	Options          Options
+	Config           config.App
+	ContextAgentRole string
 }
 
 func startRunPromptClient(ctx context.Context, opts Options) (client.RunPromptClient, func() error, error) {
@@ -45,7 +46,9 @@ func startRunPromptClient(ctx context.Context, opts Options) (client.RunPromptCl
 	}
 	opts = workspaceConfig.Options
 	cfg := workspaceConfig.Config
-	if err := validateRunPromptAgentRole(cfg.Settings, opts.AgentRole, strings.TrimSpace(opts.WorkspaceContextSessionID) != ""); err != nil {
+	builderSessionCaller := strings.TrimSpace(opts.WorkspaceContextSessionID) != ""
+	contextAgentRole := strings.TrimSpace(workspaceConfig.ContextAgentRole)
+	if err := validateRunPromptAgentRole(cfg.Settings, opts.AgentRole, builderSessionCaller, contextAgentRole); err != nil {
 		return nil, nil, err
 	}
 	target, err := serverattach.Resolve[runprompttarget.Target](ctx, serverattach.Request[runprompttarget.Target]{
@@ -93,11 +96,16 @@ func startRunPromptClient(ctx context.Context, opts Options) (client.RunPromptCl
 
 const nonCallableSubagentRoleMessage = "User has disallowed calling this agent by other agents like you. Do not try to circumvent this, pick another suitable agent or do the work manually and let the user know your desire to use the subagent at the end of the task"
 
-func validateRunPromptAgentRole(settings config.Settings, rawRole string, builderSessionCaller bool) error {
+func validateRunPromptAgentRole(settings config.Settings, rawRole string, builderSessionCaller bool, contextAgentRole string) error {
 	roleName := config.NormalizeSubagentSelector(rawRole)
 	if roleName == "" {
 		if strings.TrimSpace(rawRole) != "" && !config.IsReservedSubagentRoleName(rawRole) {
 			return errors.New("invalid agent role " + strconv.Quote(rawRole))
+		}
+		if builderSessionCaller {
+			if err := validateContextAgentRoleCallable(settings, contextAgentRole); err != nil {
+				return err
+			}
 		}
 		return nil
 	}
@@ -106,6 +114,21 @@ func validateRunPromptAgentRole(settings config.Settings, rawRole string, builde
 		return unrecognizedRunPromptRoleError(roleName, config.AvailableSubagentRoleNames(settings, builderSessionCaller))
 	}
 	if builderSessionCaller && !config.SubagentRoleCallable(role) {
+		return errors.New(nonCallableSubagentRoleMessage)
+	}
+	return nil
+}
+
+func validateContextAgentRoleCallable(settings config.Settings, rawRole string) error {
+	roleName := config.NormalizeSubagentSelector(rawRole)
+	if roleName == "" {
+		return nil
+	}
+	role, exists := settings.Subagents[roleName]
+	if !exists && roleName != config.BuiltInSubagentRoleFast {
+		return unrecognizedRunPromptRoleError(roleName, config.AvailableSubagentRoleNames(settings, true))
+	}
+	if !config.SubagentRoleCallable(role) {
 		return errors.New(nonCallableSubagentRoleMessage)
 	}
 	return nil
@@ -217,7 +240,7 @@ func resolveRunPromptWorkspaceConfig(opts Options) (runPromptWorkspaceConfig, er
 	if strings.TrimSpace(result.ResolvedWorkspaceRoot) != "" && result.ResolvedWorkspaceRoot != opts.WorkspaceRoot {
 		resolvedOpts.WorkspaceRoot = result.ResolvedWorkspaceRoot
 	}
-	return runPromptWorkspaceConfig{Options: resolvedOpts, Config: result.Config}, nil
+	return runPromptWorkspaceConfig{Options: resolvedOpts, Config: result.Config, ContextAgentRole: result.ContextAgentRole}, nil
 }
 
 func startupConfigRequest(opts Options) startupconfig.Request {

--- a/cli/app/run_prompt_target_test.go
+++ b/cli/app/run_prompt_target_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"builder/server/session"
 	"builder/shared/config"
 )
 
@@ -15,14 +16,14 @@ func TestValidateRunPromptAgentRoleBlocksNonCallableRoleForBuilderSession(t *tes
 		"worker": {AgentCallable: false, AgentCallableSet: true, Sources: map[string]string{"model": "file"}},
 	}}
 
-	err := validateRunPromptAgentRole(settings, "worker", true)
+	err := validateRunPromptAgentRole(settings, "worker", true, "")
 	if err == nil {
 		t.Fatal("expected non-callable role to fail for Builder session")
 	}
 	if err.Error() != nonCallableSubagentRoleMessage {
 		t.Fatalf("error = %q, want non-callable message", err.Error())
 	}
-	if err := validateRunPromptAgentRole(settings, "worker", false); err != nil {
+	if err := validateRunPromptAgentRole(settings, "worker", false, ""); err != nil {
 		t.Fatalf("human/no-session role validation failed: %v", err)
 	}
 }
@@ -37,7 +38,7 @@ func TestValidateRunPromptAgentRoleUnknownRoleListsCallableRolesForBuilderSessio
 		},
 	}
 
-	err := validateRunPromptAgentRole(settings, "missing", true)
+	err := validateRunPromptAgentRole(settings, "missing", true, "")
 	if err == nil {
 		t.Fatal("expected unknown role to fail")
 	}
@@ -87,13 +88,73 @@ func TestStartRunPromptClientUnknownRoleBuilderSessionErrorUsesCallableAvailable
 	}
 }
 
+func TestStartRunPromptClientDefaultAliasBlocksNonCallableContextRole(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	configPath := filepath.Join(home, ".builder", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	contents := strings.Join([]string{
+		"[subagents.blocked]",
+		"model = \"gpt-5.4-mini\"",
+		"agent_callable = false",
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := config.Load(workspace, config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	registerAppWorkspace(t, cfg.WorkspaceRoot)
+	parent := createAuthoritativeAppSession(t, cfg.PersistenceRoot, cfg.WorkspaceRoot)
+	if err := parent.SetContinuationContext(session.ContinuationContext{AgentRole: "blocked"}); err != nil {
+		t.Fatalf("SetContinuationContext: %v", err)
+	}
+
+	_, _, err = startRunPromptClient(context.Background(), Options{
+		WorkspaceRoot:             cfg.WorkspaceRoot,
+		WorkspaceRootExplicit:     true,
+		WorkspaceContextSessionID: parent.Meta().SessionID,
+		AgentRole:                 "default",
+	})
+	if err == nil {
+		t.Fatal("expected default alias to fail from non-callable context role")
+	}
+	if err.Error() != nonCallableSubagentRoleMessage {
+		t.Fatalf("error = %q, want non-callable message", err.Error())
+	}
+}
+
 func TestValidateRunPromptAgentRoleAliasesDefaultSelectors(t *testing.T) {
 	settings := config.Settings{Subagents: map[string]config.SubagentRole{}}
 	for _, alias := range []string{"default", "none", "self"} {
 		t.Run(alias, func(t *testing.T) {
-			if err := validateRunPromptAgentRole(settings, alias, true); err != nil {
+			if err := validateRunPromptAgentRole(settings, alias, true, ""); err != nil {
 				t.Fatalf("validateRunPromptAgentRole(%q): %v", alias, err)
 			}
 		})
+	}
+}
+
+func TestValidateRunPromptAgentRoleBlocksDefaultAliasFromNonCallableContextRole(t *testing.T) {
+	settings := config.Settings{Subagents: map[string]config.SubagentRole{
+		"blocked": {AgentCallable: false, AgentCallableSet: true, Sources: map[string]string{"model": "file"}},
+	}}
+	for _, rawRole := range []string{"", "default", "none", "self"} {
+		t.Run(rawRole, func(t *testing.T) {
+			err := validateRunPromptAgentRole(settings, rawRole, true, "blocked")
+			if err == nil {
+				t.Fatal("expected non-callable context role to block default invocation")
+			}
+			if err.Error() != nonCallableSubagentRoleMessage {
+				t.Fatalf("error = %q, want non-callable message", err.Error())
+			}
+		})
+	}
+	if err := validateRunPromptAgentRole(settings, "default", false, "blocked"); err != nil {
+		t.Fatalf("human/no-session default alias should not enforce context role: %v", err)
 	}
 }

--- a/cli/app/run_prompt_target_test.go
+++ b/cli/app/run_prompt_target_test.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"builder/shared/config"
+)
+
+func TestValidateRunPromptAgentRoleBlocksNonCallableRoleForBuilderSession(t *testing.T) {
+	settings := config.Settings{Subagents: map[string]config.SubagentRole{
+		"worker": {AgentCallable: false, AgentCallableSet: true, Sources: map[string]string{"model": "file"}},
+	}}
+
+	err := validateRunPromptAgentRole(settings, "worker", true)
+	if err == nil {
+		t.Fatal("expected non-callable role to fail for Builder session")
+	}
+	if err.Error() != nonCallableSubagentRoleMessage {
+		t.Fatalf("error = %q, want non-callable message", err.Error())
+	}
+	if err := validateRunPromptAgentRole(settings, "worker", false); err != nil {
+		t.Fatalf("human/no-session role validation failed: %v", err)
+	}
+}
+
+func TestValidateRunPromptAgentRoleUnknownRoleListsCallableRolesForBuilderSession(t *testing.T) {
+	settings := config.Settings{
+		Model:         "gpt-5.5",
+		ThinkingLevel: "medium",
+		Subagents: map[string]config.SubagentRole{
+			"callable":    {Settings: config.Settings{Model: "gpt-5.4-mini"}, Sources: map[string]string{"model": "file"}},
+			"noncallable": {Settings: config.Settings{Model: "gpt-5.4-mini"}, Sources: map[string]string{"model": "file"}, AgentCallable: false, AgentCallableSet: true},
+		},
+	}
+
+	err := validateRunPromptAgentRole(settings, "missing", true)
+	if err == nil {
+		t.Fatal("expected unknown role to fail")
+	}
+	text := err.Error()
+	for _, want := range []string{`Unrecognized role "missing"`, "Available roles: [fast, callable]"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("error = %q, want %q", text, want)
+		}
+	}
+	if strings.Contains(text, "noncallable") {
+		t.Fatalf("builder-session available list should omit non-callable role: %q", text)
+	}
+}
+
+func TestStartRunPromptClientUnknownRoleBuilderSessionErrorUsesCallableAvailableRoles(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	configPath := filepath.Join(home, ".builder", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	contents := strings.Join([]string{
+		"[subagents.worker]",
+		"model = \"gpt-5.4-mini\"",
+		"",
+		"[subagents.blocked]",
+		"model = \"gpt-5.4-mini\"",
+		"agent_callable = false",
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, _, err := startRunPromptClient(context.Background(), Options{
+		WorkspaceRoot:             workspace,
+		WorkspaceRootExplicit:     true,
+		WorkspaceContextSessionID: "session-from-env",
+		AgentRole:                 "missing",
+	})
+	if err == nil {
+		t.Fatal("expected unknown role error")
+	}
+	want := `Unrecognized role "missing". It may have been removed by the user during the session. Available roles: [fast, worker]`
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestValidateRunPromptAgentRoleAliasesDefaultSelectors(t *testing.T) {
+	settings := config.Settings{Subagents: map[string]config.SubagentRole{}}
+	for _, alias := range []string{"default", "none", "self"} {
+		t.Run(alias, func(t *testing.T) {
+			if err := validateRunPromptAgentRole(settings, alias, true); err != nil {
+				t.Fatalf("validateRunPromptAgentRole(%q): %v", alias, err)
+			}
+		})
+	}
+}

--- a/cli/builder/main.go
+++ b/cli/builder/main.go
@@ -504,8 +504,9 @@ func emitWarnings(w io.Writer, warnings []string) {
 }
 
 func effectiveRunAgentRole(raw string, fast bool) (string, error) {
-	normalized := config.NormalizeSubagentRole(raw)
-	if strings.TrimSpace(raw) != "" && normalized == "" {
+	trimmed := strings.TrimSpace(raw)
+	normalized := config.NormalizeSubagentSelector(trimmed)
+	if trimmed != "" && normalized == "" && !config.IsReservedSubagentRoleName(trimmed) {
 		return "", fmt.Errorf("invalid --agent value %q", raw)
 	}
 	if fast {

--- a/cli/builder/main_test.go
+++ b/cli/builder/main_test.go
@@ -580,6 +580,44 @@ func TestRunSubcommandUsesBuilderSessionEnvAsWorkspaceContext(t *testing.T) {
 	}
 }
 
+func TestRunSubcommandDefaultAgentWithFastUsesFastRole(t *testing.T) {
+	original := runPromptApp
+	t.Cleanup(func() {
+		runPromptApp = original
+	})
+	var gotOpts app.Options
+	runPromptApp = func(ctx context.Context, opts app.Options, prompt string, timeout time.Duration, progress io.Writer) (app.RunPromptResult, error) {
+		gotOpts = opts
+		return app.RunPromptResult{Result: "done"}, nil
+	}
+
+	originalStdout := os.Stdout
+	originalStderr := os.Stderr
+	stdoutFile, err := os.CreateTemp(t.TempDir(), "stdout")
+	if err != nil {
+		t.Fatalf("create stdout temp file: %v", err)
+	}
+	stderrFile, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatalf("create stderr temp file: %v", err)
+	}
+	os.Stdout = stdoutFile
+	os.Stderr = stderrFile
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		os.Stderr = originalStderr
+		_ = stdoutFile.Close()
+		_ = stderrFile.Close()
+	})
+
+	if code := rootCommand([]string{"run", "--agent=default", "--fast", "hello"}, strings.NewReader(""), io.Discard, io.Discard); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if gotOpts.AgentRole != config.BuiltInSubagentRoleFast {
+		t.Fatalf("agent role = %q, want fast", gotOpts.AgentRole)
+	}
+}
+
 func TestSessionIDSubcommandPrintsBuilderSessionEnv(t *testing.T) {
 	t.Setenv(sessionenv.BuilderSessionID, " session-from-env ")
 	var stdout bytes.Buffer
@@ -627,6 +665,27 @@ func TestEffectiveRunAgentRoleRejectsConflictingFastFlag(t *testing.T) {
 	role, err := effectiveRunAgentRole("fast", true)
 	if err != nil {
 		t.Fatalf("effectiveRunAgentRole: %v", err)
+	}
+	if role != config.BuiltInSubagentRoleFast {
+		t.Fatalf("role = %q, want fast", role)
+	}
+}
+
+func TestEffectiveRunAgentRoleAliasesDefaultSelectors(t *testing.T) {
+	for _, alias := range []string{"default", "none", "self"} {
+		t.Run(alias, func(t *testing.T) {
+			role, err := effectiveRunAgentRole(alias, false)
+			if err != nil {
+				t.Fatalf("effectiveRunAgentRole: %v", err)
+			}
+			if role != "" {
+				t.Fatalf("role = %q, want empty", role)
+			}
+		})
+	}
+	role, err := effectiveRunAgentRole("default", true)
+	if err != nil {
+		t.Fatalf("effectiveRunAgentRole default+fast: %v", err)
 	}
 	if role != config.BuiltInSubagentRoleFast {
 		t.Fatalf("role = %q, want fast", role)

--- a/docs/dev/decisions.md
+++ b/docs/dev/decisions.md
@@ -160,6 +160,7 @@
 - In server-browsing mode, the client may open existing server projects/workspaces only; it must not offer "bind this workspace" or "create a project for this client path".
 - First setup for server-browsing mode is server-admin only for now. Remote filesystem traversal/browsing is out of scope for this slice.
 - Headless startup in an unregistered workspace fails fast; it must not auto-create hidden project/workspace state.
+- Subagent roles may be configured as not callable by other agents via `agent_callable=false`; future frontend/status surfaces should mark non-callable roles distinctly rather than hiding the distinction.
 - To support agent recovery in that fail-fast model, Builder will expose explicit workspace-binding CLI commands: `builder project [path]` to inspect the project bound to a path, `builder attach [path]` to bind a workspace to the project already bound to `cwd`, and `builder attach --project <project-id> [path]` as the explicit project-id override. All forms default `path` to `cwd`.
 - The minimum server-admin setup command surface is `builder project list`, `builder project create --path <server-path> --name <project-name>`, and `builder attach --project <project-id> <server-path>`.
 - Those server-admin commands must prefer RPC to the configured running daemon when one exists; they must not require shutting the server down or taking local ownership of the persistence root.

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -89,6 +89,8 @@ verbose_output = false # show in ongoing transcript
 
 # custom subagent roles config, fast is the default one, always provided
 [subagents.fast]
+# agent_callable = true
+# description = ""
 # model = "gpt-5.4-mini"
 # priority_request_mode = true
 ```
@@ -238,6 +240,7 @@ Notes:
 
 Subagent roles inherit the main config and then override only the keys set in that role table.
 Set `system_prompt_file` inside a subagent role to use a role-specific main system prompt for `builder run --agent <role>`.
+Set `description` to describe a behaviorally distinct role to other agents. Set `agent_callable = false` for roles that humans may run explicitly but agents should not call from Builder sessions.
 
 More info on the [Subagents page](../headless.md).
 

--- a/docs/src/content/docs/headless.md
+++ b/docs/src/content/docs/headless.md
@@ -29,6 +29,7 @@ Roles are needed to create specialized subagent types for different tasks. Treat
 model = "gpt-5.5"
 thinking_level = "xhigh"
 system_prompt_file = "research-agent.md"
+description = "Finds source and documentation context for implementation planning."
 priority_request_mode = true
 
 [subagents.research.tools]
@@ -40,12 +41,16 @@ patch = false
 
 - The built-in `fast` role exists even without config. On exact OpenAI first-party setups, Builder heuristically switches it to a smaller/faster model profile.
 - Subagent roles inherit the main config and then override only the keys you set in that role table.
+- Agents see callable custom roles when their current session can run shell commands. Roles with no behavioral difference from the default agent are not listed, even if they have a description.
+- `agent_callable = false` hides a role from agent-facing role context and rejects Builder-session calls to it. Humans can run the role from ordinary shells.
+- `--agent default`, `--agent none`, and `--agent self` are accepted as aliases for omitting `--agent`.
 
 Useful role-specific keys include:
 
 - `model`, `provider_override`, `openai_base_url`
 - `thinking_level`, `model_verbosity`, `priority_request_mode`
 - `system_prompt_file`
+- `description`, `agent_callable`
 - `[subagents.<role>.tools]`
 - `[subagents.<role>.skills]`
 - `shell_output_max_chars`, `bg_shells_output`

--- a/prompts/embed.go
+++ b/prompts/embed.go
@@ -126,6 +126,10 @@ func BaseSystemPrompt(args SystemPromptTemplateArgs) string {
 	return renderSystemPromptTemplate(strings.TrimSpace(SystemPrompt), args, "")
 }
 
+func BuilderRunCommand() string {
+	return selfcmd.RunCommandPrefix()
+}
+
 func RenderCompactionSoonReminderPrompt(triggerHandoffEnabled bool) string {
 	if triggerHandoffEnabled {
 		return strings.TrimSpace(CompactionSoonReminderTriggerHandoffPrompt)

--- a/server/bootstrap/embedded.go
+++ b/server/bootstrap/embedded.go
@@ -35,6 +35,10 @@ type ConfigPlan struct {
 	ContainerDir string
 }
 
+func ResolveSessionAgentRole(persistenceRoot string, sessionID string) (string, error) {
+	return launch.ResolveSessionAgentRole(persistenceRoot, sessionID)
+}
+
 type AuthSupport struct {
 	OAuthOptions auth.OpenAIOAuthOptions
 	AuthManager  *auth.Manager

--- a/server/launch/bootstrap.go
+++ b/server/launch/bootstrap.go
@@ -23,6 +23,18 @@ type BootstrapPlan struct {
 	UseOpenAIBaseURL bool
 }
 
+func ResolveSessionAgentRole(persistenceRoot string, sessionID string) (string, error) {
+	store, err := openSessionByID(persistenceRoot, sessionID)
+	if err != nil {
+		return "", err
+	}
+	meta := store.Meta()
+	if meta.Continuation == nil {
+		return "", nil
+	}
+	return strings.TrimSpace(meta.Continuation.AgentRole), nil
+}
+
 func ResolveBootstrapPlan(persistenceRoot string, req BootstrapRequest) (BootstrapPlan, error) {
 	plan := BootstrapPlan{
 		WorkspaceRoot:    strings.TrimSpace(req.WorkspaceRoot),
@@ -35,19 +47,7 @@ func ResolveBootstrapPlan(persistenceRoot string, req BootstrapRequest) (Bootstr
 	if strings.TrimSpace(persistenceRoot) == "" {
 		return BootstrapPlan{}, errors.New("launch planner persistence root is required")
 	}
-	store, err := session.OpenByID(persistenceRoot, req.SessionID)
-	if err != nil {
-		primaryErr := err
-		metadataStore, metadataErr := metadata.Open(persistenceRoot)
-		if metadataErr != nil {
-			return BootstrapPlan{}, fmt.Errorf("%w; metadata.Open fallback failed: %v", primaryErr, metadataErr)
-		}
-		defer func() { _ = metadataStore.Close() }()
-		store, err = session.OpenByID(persistenceRoot, req.SessionID, metadataStore.AuthoritativeSessionStoreOptions()...)
-		if err != nil {
-			return BootstrapPlan{}, fmt.Errorf("%w; session.OpenByID fallback failed: %v", primaryErr, err)
-		}
-	}
+	store, err := openSessionByID(persistenceRoot, req.SessionID)
 	if err != nil {
 		return BootstrapPlan{}, err
 	}
@@ -63,4 +63,22 @@ func ResolveBootstrapPlan(persistenceRoot string, req BootstrapRequest) (Bootstr
 		plan.UseOpenAIBaseURL = true
 	}
 	return plan, nil
+}
+
+func openSessionByID(persistenceRoot string, sessionID string) (*session.Store, error) {
+	store, err := session.OpenByID(persistenceRoot, sessionID)
+	if err == nil {
+		return store, nil
+	}
+	primaryErr := err
+	metadataStore, metadataErr := metadata.Open(persistenceRoot)
+	if metadataErr != nil {
+		return nil, fmt.Errorf("%w; metadata.Open fallback failed: %v", primaryErr, metadataErr)
+	}
+	defer func() { _ = metadataStore.Close() }()
+	store, err = session.OpenByID(persistenceRoot, sessionID, metadataStore.AuthoritativeSessionStoreOptions()...)
+	if err != nil {
+		return nil, fmt.Errorf("%w; session.OpenByID fallback failed: %v", primaryErr, err)
+	}
+	return store, nil
 }

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -122,10 +122,10 @@ func ApplyRunPromptOverrides(plan SessionPlan, overrides serverapi.RunPromptOver
 	persistContinuation := func() error {
 		return next.Store.SetContinuationContext(session.ContinuationContext{OpenAIBaseURL: next.ActiveSettings.OpenAIBaseURL})
 	}
-	if trimmedRole := strings.TrimSpace(overrides.AgentRole); trimmedRole != "" && config.NormalizeSubagentRole(trimmedRole) == "" {
+	if trimmedRole := strings.TrimSpace(overrides.AgentRole); trimmedRole != "" && config.NormalizeSubagentSelector(trimmedRole) == "" && !config.IsReservedSubagentRoleName(trimmedRole) {
 		return SessionPlan{}, nil, fmt.Errorf("invalid agent role %q", trimmedRole)
 	}
-	roleName := config.NormalizeSubagentRole(overrides.AgentRole)
+	roleName := config.NormalizeSubagentSelector(overrides.AgentRole)
 	if roleName != "" {
 		shouldPersistContinuation = true
 		providerBase := cloneSettings(plan.ActiveSettings)

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -93,7 +93,11 @@ func (p Planner) PlanSession(ctx context.Context, req SessionRequest) (SessionPl
 			active.OpenAIBaseURL = baseURL
 		}
 	}
-	if err := store.SetContinuationContext(session.ContinuationContext{OpenAIBaseURL: active.OpenAIBaseURL}); err != nil {
+	continuation := session.ContinuationContext{OpenAIBaseURL: active.OpenAIBaseURL}
+	if meta.Continuation != nil {
+		continuation.AgentRole = strings.TrimSpace(meta.Continuation.AgentRole)
+	}
+	if err := store.SetContinuationContext(continuation); err != nil {
 		return SessionPlan{}, err
 	}
 	enabledTools, err := ActiveToolIDsForPlan(active, p.Config.Source, meta.Locked)
@@ -119,8 +123,15 @@ func ApplyRunPromptOverrides(plan SessionPlan, overrides serverapi.RunPromptOver
 	var warnings []string
 	next := plan
 	shouldPersistContinuation := false
+	continuationAgentRole := ""
+	if plan.Store.Meta().Continuation != nil {
+		continuationAgentRole = strings.TrimSpace(plan.Store.Meta().Continuation.AgentRole)
+	}
 	persistContinuation := func() error {
-		return next.Store.SetContinuationContext(session.ContinuationContext{OpenAIBaseURL: next.ActiveSettings.OpenAIBaseURL})
+		return next.Store.SetContinuationContext(session.ContinuationContext{
+			OpenAIBaseURL: next.ActiveSettings.OpenAIBaseURL,
+			AgentRole:     continuationAgentRole,
+		})
 	}
 	if trimmedRole := strings.TrimSpace(overrides.AgentRole); trimmedRole != "" && config.NormalizeSubagentSelector(trimmedRole) == "" && !config.IsReservedSubagentRoleName(trimmedRole) {
 		return SessionPlan{}, nil, fmt.Errorf("invalid agent role %q", trimmedRole)
@@ -128,6 +139,7 @@ func ApplyRunPromptOverrides(plan SessionPlan, overrides serverapi.RunPromptOver
 	roleName := config.NormalizeSubagentSelector(overrides.AgentRole)
 	if roleName != "" {
 		shouldPersistContinuation = true
+		continuationAgentRole = roleName
 		providerBase := cloneSettings(plan.ActiveSettings)
 		if value := strings.TrimSpace(overrides.ProviderOverride); value != "" {
 			providerBase.ProviderOverride = value

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -1306,8 +1306,8 @@ func TestApplyRunPromptOverridesRoleOnlyOverridePersistsContinuation(t *testing.
 		t.Fatalf("openai base url = %q, want worker override", updated.ActiveSettings.OpenAIBaseURL)
 	}
 	got := store.Meta().Continuation
-	if got == nil || got.OpenAIBaseURL != "https://worker.example/v1" {
-		t.Fatalf("continuation = %+v, want worker base url", got)
+	if got == nil || got.OpenAIBaseURL != "https://worker.example/v1" || got.AgentRole != "worker" {
+		t.Fatalf("continuation = %+v, want worker base url and agent role", got)
 	}
 }
 

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -595,6 +595,77 @@ func TestApplyRunPromptOverridesOverridesHeadlessSettingsWithoutMutatingBasePlan
 	}
 }
 
+func TestSubagentRoleMetadataSurvivesCloneAndSourceReport(t *testing.T) {
+	settings := config.Settings{
+		Subagents: map[string]config.SubagentRole{
+			"worker": {
+				Settings:         config.Settings{Model: "gpt-5.4-mini"},
+				Sources:          map[string]string{"model": "file"},
+				Description:      "Worker role",
+				AgentCallable:    false,
+				AgentCallableSet: true,
+			},
+		},
+	}
+
+	cloned := cloneSettings(settings)
+	copiedRole := cloned.Subagents["worker"]
+	copiedRole.Description = "changed"
+	copiedRole.Sources["model"] = "changed"
+	cloned.Subagents["worker"] = copiedRole
+	if settings.Subagents["worker"].Description != "Worker role" {
+		t.Fatalf("clone mutated source description: %+v", settings.Subagents["worker"])
+	}
+	if settings.Subagents["worker"].Sources["model"] != "file" {
+		t.Fatalf("clone mutated source map: %+v", settings.Subagents["worker"].Sources)
+	}
+	if !cloned.Subagents["worker"].AgentCallableSet || cloned.Subagents["worker"].AgentCallable {
+		t.Fatalf("metadata did not survive clone: %+v", cloned.Subagents["worker"])
+	}
+
+	report := sourceReportWithSubagentRoleSources(config.SourceReport{Sources: map[string]string{"model": "file"}}, settings, "worker")
+	if report.Sources["model"] != "subagent" {
+		t.Fatalf("source report model source = %q, want subagent", report.Sources["model"])
+	}
+}
+
+func TestResolveSubagentSettingsPreservesSubagentCatalogMetadata(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfg, err := config.Load(t.TempDir(), config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	base := cfg.Settings
+	workerSettings := base
+	workerSettings.ThinkingLevel = "high"
+	blockedSettings := base
+	blockedSettings.Model = "gpt-5.4-mini"
+	base.Subagents = map[string]config.SubagentRole{
+		"worker": {
+			Settings:    workerSettings,
+			Sources:     map[string]string{"thinking_level": "file"},
+			Description: "Worker role",
+		},
+		"blocked": {
+			Settings:         blockedSettings,
+			Sources:          map[string]string{"model": "file"},
+			AgentCallable:    false,
+			AgentCallableSet: true,
+		},
+	}
+
+	resolved, _, err := resolveSubagentSettings(base, base, cfg.Source.Sources, "worker", auth.EmptyState(), true)
+	if err != nil {
+		t.Fatalf("resolveSubagentSettings: %v", err)
+	}
+	if resolved.Subagents["worker"].Description != "Worker role" {
+		t.Fatalf("worker metadata lost after resolve: %+v", resolved.Subagents["worker"])
+	}
+	if !resolved.Subagents["blocked"].AgentCallableSet || resolved.Subagents["blocked"].AgentCallable {
+		t.Fatalf("blocked metadata lost after resolve: %+v", resolved.Subagents["blocked"])
+	}
+}
+
 func TestApplyRunPromptOverridesRejectsInvalidAgentRole(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("HOME", t.TempDir())

--- a/server/launch/subagents.go
+++ b/server/launch/subagents.go
@@ -15,16 +15,15 @@ import (
 const fastRoleSameAsMainWarning = "Warning: user configuration for fast agents is the same as for other agents. Consider asking the user to edit their config to pick a faster, smaller model at the end of your task. More info at https://opensource.respawn.pro/builder"
 
 func resolveSubagentSettings(base config.Settings, providerBase config.Settings, baseSources map[string]string, roleName string, authState auth.State, allowModelOverride bool) (config.Settings, string, error) {
-	normalizedRole := config.NormalizeSubagentRole(roleName)
+	normalizedRole := config.NormalizeSubagentSelector(roleName)
 	if normalizedRole == "" {
 		return config.Settings{}, "", fmt.Errorf("invalid subagent role %q", roleName)
 	}
 	role, hasRole := base.Subagents[normalizedRole]
 	if !hasRole && normalizedRole != config.BuiltInSubagentRoleFast {
-		return config.Settings{}, "", fmt.Errorf("unknown subagent role %q", normalizedRole)
+		return config.Settings{}, "", unrecognizedSubagentRoleError(normalizedRole, config.AvailableSubagentRoleNames(base, false))
 	}
 	resolved := cloneSettings(base)
-	resolved.Subagents = nil
 	providerSettings := cloneSettings(providerBase)
 	providerSettings.Subagents = nil
 	applySubagentProviderOverrides(&providerSettings, role)
@@ -47,6 +46,10 @@ func resolveSubagentSettings(base config.Settings, providerBase config.Settings,
 		warning = fastRoleSameAsMainWarning
 	}
 	return resolved, warning, nil
+}
+
+func unrecognizedSubagentRoleError(role string, available []string) error {
+	return fmt.Errorf("Unrecognized role %q. It may have been removed by the user during the session. Available roles: [%s]", role, strings.Join(available, ", "))
 }
 
 func applyBuiltInRoleHeuristics(settings *config.Settings, roleName string, providerID string, allowModelOverride bool) bool {

--- a/server/llm/types.go
+++ b/server/llm/types.go
@@ -43,6 +43,7 @@ type MessageType = clientui.MessageType
 const (
 	MessageTypeAgentsMD                  = clientui.MessageTypeAgentsMD
 	MessageTypeSkills                    = clientui.MessageTypeSkills
+	MessageTypeSubagents                 = clientui.MessageTypeSubagents
 	MessageTypeEnvironment               = clientui.MessageTypeEnvironment
 	MessageTypeCompactionSummary         = clientui.MessageTypeCompactionSummary
 	MessageTypeInterruption              = clientui.MessageTypeInterruption

--- a/server/metadata/store.go
+++ b/server/metadata/store.go
@@ -1132,7 +1132,7 @@ func sessionMetaFromRecordRow(row sqlitegen.GetSessionRecordByIDRow) (session.Me
 	if err := unmarshalStoredJSON(row.ContinuationJson, continuation); err != nil {
 		return session.Meta{}, fmt.Errorf("decode continuation json: %w", err)
 	}
-	if strings.TrimSpace(continuation.OpenAIBaseURL) == "" {
+	if strings.TrimSpace(continuation.OpenAIBaseURL) == "" && strings.TrimSpace(continuation.AgentRole) == "" {
 		continuation = nil
 	}
 	locked := &session.LockedContract{}

--- a/server/runtime/compaction.go
+++ b/server/runtime/compaction.go
@@ -721,12 +721,8 @@ func (e *Engine) buildCanonicalCompactionReplacement(prefix []llm.ResponseItem) 
 }
 
 func (e *Engine) compactionReinjectedBaseMessages() ([]llm.Message, error) {
-	builder := newActiveMetaContextBuilder(e.store.Meta(), e.currentModel(), e.ThinkingLevel(), e.cfg.DisabledSkills, time.Now())
-	metaResult, err := builder.Build(metaContextBuildOptions{
-		IncludeAgents:      true,
-		IncludeSkills:      true,
-		IncludeEnvironment: true,
-	})
+	builder := e.newActiveBaseMetaContextBuilder(e.currentModel(), time.Now())
+	metaResult, err := builder.Build(baseMetaContextBuildOptions(false))
 	if err != nil {
 		return nil, err
 	}

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -92,6 +92,7 @@ type Config struct {
 	ProviderCapabilitiesOverride  *llm.ProviderCapabilities
 	EnabledTools                  []toolspec.ID
 	DisabledSkills                map[string]bool
+	SubagentCatalogSettings       config.Settings
 	SystemPromptFiles             []config.SystemPromptFile
 	AutoCompactTokenLimit         int
 	PreSubmitCompactionLeadTokens int

--- a/server/runtime/engine_reviewer_helpers.go
+++ b/server/runtime/engine_reviewer_helpers.go
@@ -76,6 +76,7 @@ func buildReviewerRequestMessagesWithNow(messages []llm.Message, workspaceRoot s
 
 func buildReviewerRequestMessagesWithBuilder(messages []llm.Message, builder metaContextBuilder, headless bool) ([]llm.Message, error) {
 	metaMessages, transcriptSource := splitMetaContextMessages(messages)
+	metaMessages = filterReviewerMetaMessages(metaMessages)
 	metaResult, err := builder.Build(metaContextBuildOptions{
 		ExistingMessages:          metaMessages,
 		IncludeAgents:             true,
@@ -338,6 +339,7 @@ func reviewerPromptCacheKey(sessionID string, compactionCount int) string {
 
 func appendMissingReviewerMetaContext(messages []llm.Message, workspaceRoot string, model string, thinkingLevel string, headless bool, disabledSkills map[string]bool) ([]llm.Message, error) {
 	metaMessages, transcript := splitMetaContextMessages(messages)
+	metaMessages = filterReviewerMetaMessages(metaMessages)
 	builder := newMetaContextBuilder(workspaceRoot, model, thinkingLevel, disabledSkills, time.Now())
 	metaResult, err := builder.Build(metaContextBuildOptions{
 		ExistingMessages:          metaMessages,
@@ -352,4 +354,18 @@ func appendMissingReviewerMetaContext(messages []llm.Message, workspaceRoot stri
 	}
 	out := append(metaResult.OrderedMetaMessages(), transcript...)
 	return out, nil
+}
+
+func filterReviewerMetaMessages(messages []llm.Message) []llm.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := make([]llm.Message, 0, len(messages))
+	for _, message := range messages {
+		if message.Role == llm.RoleDeveloper && message.MessageType == llm.MessageTypeSubagents {
+			continue
+		}
+		out = append(out, message)
+	}
+	return out
 }

--- a/server/runtime/message_lifecycle.go
+++ b/server/runtime/message_lifecycle.go
@@ -307,13 +307,8 @@ func (m *defaultMessageLifecycle) InjectAgentsIfNeeded(stepID string) error {
 	if meta.AgentsInjected {
 		return nil
 	}
-	builder := newActiveMetaContextBuilder(meta, e.cfg.Model, e.ThinkingLevel(), e.cfg.DisabledSkills, time.Now())
-	metaResult, err := builder.Build(metaContextBuildOptions{
-		IncludeAgents:        true,
-		IncludeSkills:        true,
-		IncludeEnvironment:   true,
-		IncludeSkillWarnings: true,
-	})
+	builder := e.newActiveBaseMetaContextBuilder(e.cfg.Model, time.Now())
+	metaResult, err := builder.Build(baseMetaContextBuildOptions(true))
 	if err != nil {
 		return err
 	}

--- a/server/runtime/meta_context.go
+++ b/server/runtime/meta_context.go
@@ -12,6 +12,8 @@ import (
 	"builder/prompts"
 	"builder/server/llm"
 	"builder/server/session"
+	"builder/shared/config"
+	"builder/shared/toolspec"
 )
 
 type metaContextKind uint8
@@ -20,6 +22,7 @@ const (
 	metaContextKindUnknown metaContextKind = iota
 	metaContextKindAgents
 	metaContextKindSkills
+	metaContextKindSubagents
 	metaContextKindEnvironment
 	metaContextKindHeadless
 	metaContextKindHeadlessExit
@@ -38,6 +41,7 @@ type metaContextBuildOptions struct {
 	ExistingMessages          []llm.Message
 	IncludeAgents             bool
 	IncludeSkills             bool
+	IncludeSubagents          bool
 	IncludeEnvironment        bool
 	IncludeHeadless           bool
 	IncludeHeadlessExit       bool
@@ -49,6 +53,7 @@ type metaContextBuildResult struct {
 	Agents        []llm.Message
 	SkillWarnings []string
 	Skills        []llm.Message
+	Subagents     []llm.Message
 	Environment   []llm.Message
 	Headless      []llm.Message
 	HeadlessExit  []llm.Message
@@ -57,7 +62,7 @@ type metaContextBuildResult struct {
 }
 
 func (r metaContextBuildResult) OrderedMetaMessages() []llm.Message {
-	out := make([]llm.Message, 0, len(r.Agents)+len(r.Skills)+len(r.Environment)+len(r.Headless)+len(r.HeadlessExit)+len(r.Worktree)+len(r.WorktreeExit))
+	out := make([]llm.Message, 0, len(r.Agents)+len(r.Skills)+len(r.Subagents)+len(r.Environment)+len(r.Headless)+len(r.HeadlessExit)+len(r.Worktree)+len(r.WorktreeExit))
 	out = append(out, r.OrderedBaseMessages()...)
 	out = append(out, r.Headless...)
 	out = append(out, r.HeadlessExit...)
@@ -67,9 +72,10 @@ func (r metaContextBuildResult) OrderedMetaMessages() []llm.Message {
 }
 
 func (r metaContextBuildResult) OrderedBaseMessages() []llm.Message {
-	out := make([]llm.Message, 0, len(r.Agents)+len(r.Skills)+len(r.Environment))
+	out := make([]llm.Message, 0, len(r.Agents)+len(r.Skills)+len(r.Subagents)+len(r.Environment))
 	out = append(out, r.Environment...)
 	out = append(out, r.Skills...)
+	out = append(out, r.Subagents...)
 	out = append(out, r.Agents...)
 	return out
 }
@@ -79,12 +85,14 @@ func (r metaContextBuildResult) OrderedInjectionMessages() []llm.Message {
 }
 
 type metaContextBuilder struct {
-	workspaceRoot  string
-	environmentCWD string
-	model          string
-	thinkingLevel  string
-	disabledSkills map[string]bool
-	now            time.Time
+	workspaceRoot    string
+	environmentCWD   string
+	model            string
+	thinkingLevel    string
+	disabledSkills   map[string]bool
+	subagentSettings config.Settings
+	enabledTools     []toolspec.ID
+	now              time.Time
 }
 
 func newMetaContextBuilder(workspaceRoot, model, thinkingLevel string, disabledSkills map[string]bool, now time.Time) metaContextBuilder {
@@ -99,10 +107,31 @@ func newMetaContextBuilder(workspaceRoot, model, thinkingLevel string, disabledS
 	}
 }
 
+func (e *Engine) newActiveBaseMetaContextBuilder(model string, now time.Time) metaContextBuilder {
+	return newActiveMetaContextBuilder(e.store.Meta(), model, e.ThinkingLevel(), e.cfg.DisabledSkills, now).
+		withSubagents(e.cfg.SubagentCatalogSettings, e.cfg.EnabledTools)
+}
+
+func baseMetaContextBuildOptions(includeSkillWarnings bool) metaContextBuildOptions {
+	return metaContextBuildOptions{
+		IncludeAgents:        true,
+		IncludeSkills:        true,
+		IncludeSubagents:     true,
+		IncludeEnvironment:   true,
+		IncludeSkillWarnings: includeSkillWarnings,
+	}
+}
+
 func (b metaContextBuilder) withEnvironmentCWD(cwd string) metaContextBuilder {
 	if trimmed := strings.TrimSpace(cwd); trimmed != "" {
 		b.environmentCWD = trimmed
 	}
+	return b
+}
+
+func (b metaContextBuilder) withSubagents(settings config.Settings, enabledTools []toolspec.ID) metaContextBuilder {
+	b.subagentSettings = settings
+	b.enabledTools = append([]toolspec.ID(nil), enabledTools...)
 	return b
 }
 
@@ -136,6 +165,12 @@ func (b metaContextBuilder) Build(opts metaContextBuildOptions) (metaContextBuil
 				MessageType: llm.MessageTypeSkills,
 				Content:     renderSkillsContext(skills),
 			}})
+		}
+	}
+
+	if opts.IncludeSubagents {
+		if message, ok := b.subagentsMetaMessage(); ok {
+			collector.addMessages([]llm.Message{message})
 		}
 	}
 
@@ -214,6 +249,115 @@ func (b metaContextBuilder) discoverAgents(permissive bool) ([]llm.Message, erro
 
 func renderAgentsContext(path, contents string) string {
 	return fmt.Sprintf("%s\nsource: %s\n\n```%s\n%s\n```", agentsInjectedHeader, path, agentsInjectedFenceLabel, contents)
+}
+
+func (b metaContextBuilder) subagentsMetaMessage() (llm.Message, bool) {
+	if !toolEnabled(b.enabledTools, toolspec.ToolExecCommand) {
+		return llm.Message{}, false
+	}
+	roles := b.renderableSubagentRoles()
+	if len(roles) == 0 {
+		return llm.Message{}, false
+	}
+	lines := make([]string, 0, len(roles)+3)
+	lines = append(lines, "Available subagent roles:")
+	lines = append(lines, "- default: not specifying any role will invoke an exact clone of you, the general-purpose agent")
+	for _, role := range roles {
+		lines = append(lines, "- "+role.Name+": "+role.Description)
+	}
+	lines = append(lines, "---")
+	lines = append(lines, "Invoke with `"+prompts.BuilderRunCommand()+" --agent=<role> \"<prompt>\"`.")
+	return llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeSubagents, Content: strings.Join(lines, "\n")}, true
+}
+
+type renderedSubagentRole struct {
+	Name        string
+	Description string
+}
+
+func (b metaContextBuilder) renderableSubagentRoles() []renderedSubagentRole {
+	settings := b.subagentSettings
+	if len(settings.Subagents) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(settings.Subagents))
+	for name := range settings.Subagents {
+		normalized := config.NormalizeSubagentRole(name)
+		if normalized == "" || normalized == config.BuiltInSubagentRoleFast {
+			continue
+		}
+		names = append(names, normalized)
+	}
+	sort.Strings(names)
+	out := make([]renderedSubagentRole, 0, len(names))
+	for _, name := range names {
+		role := settings.Subagents[name]
+		if !config.SubagentRoleCallable(role) || !config.SubagentRoleHasMeaningfulDiff(settings, role) {
+			continue
+		}
+		description := strings.TrimSpace(role.Description)
+		if description == "" {
+			description = fallbackSubagentDescription(settings, role)
+		}
+		if description == "" {
+			continue
+		}
+		out = append(out, renderedSubagentRole{Name: name, Description: description})
+	}
+	return out
+}
+
+func fallbackSubagentDescription(base config.Settings, role config.SubagentRole) string {
+	model := base.Model
+	if _, ok := role.Sources["model"]; ok {
+		model = role.Settings.Model
+	}
+	thinking := base.ThinkingLevel
+	if _, ok := role.Sources["thinking_level"]; ok {
+		thinking = role.Settings.ThinkingLevel
+	}
+	parts := []string{strings.TrimSpace(model), "thinking " + strings.TrimSpace(thinking)}
+	if role.Sources["priority_request_mode"] == "file" && role.Settings.PriorityRequestMode {
+		parts = append(parts, "fast mode on")
+	}
+	tools := effectiveRoleToolMap(base.EnabledTools, role)
+	if tools[toolspec.ToolPatch] || tools[toolspec.ToolEdit] {
+		parts = append(parts, "can edit")
+	}
+	if tools[toolspec.ToolExecCommand] {
+		parts = append(parts, "can call shell")
+	}
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			filtered = append(filtered, trimmed)
+		}
+	}
+	return strings.Join(filtered, ", ")
+}
+
+func effectiveRoleToolMap(base map[toolspec.ID]bool, role config.SubagentRole) map[toolspec.ID]bool {
+	out := make(map[toolspec.ID]bool, len(base))
+	for key, enabled := range base {
+		out[key] = enabled
+	}
+	for _, id := range toolspec.CatalogIDs() {
+		sourceKey := "tools." + toolspec.ConfigName(id)
+		if _, ok := role.Sources[sourceKey]; ok {
+			out[id] = role.Settings.EnabledTools[id]
+		}
+	}
+	return out
+}
+
+func toolEnabled(enabled []toolspec.ID, want toolspec.ID) bool {
+	for _, id := range enabled {
+		if id == want {
+			return true
+		}
+	}
+	return false
 }
 
 func headlessModeMetaMessage() (llm.Message, bool) {
@@ -296,6 +440,7 @@ type metaContextCollector struct {
 	seenWarningMessages map[string]bool
 	agents              []metaContextAgentMessage
 	skills              *llm.Message
+	subagents           *llm.Message
 	environment         *llm.Message
 	headless            *llm.Message
 	headlessExit        *llm.Message
@@ -367,6 +512,8 @@ func (c *metaContextCollector) slot(kind metaContextKind) **llm.Message {
 	switch kind {
 	case metaContextKindSkills:
 		return &c.skills
+	case metaContextKindSubagents:
+		return &c.subagents
 	case metaContextKindEnvironment:
 		return &c.environment
 	case metaContextKindHeadless:
@@ -398,6 +545,9 @@ func (c *metaContextCollector) result() metaContextBuildResult {
 	}
 	if c.skills != nil {
 		result.Skills = []llm.Message{*c.skills}
+	}
+	if c.subagents != nil {
+		result.Subagents = []llm.Message{*c.subagents}
 	}
 	if c.environment != nil {
 		result.Environment = []llm.Message{*c.environment}
@@ -448,6 +598,8 @@ func classifyMetaContextMessage(message llm.Message) (metaContextClassification,
 		}, true
 	case llm.MessageTypeSkills:
 		return metaContextClassification{kind: metaContextKindSkills, key: "skills", messageType: llm.MessageTypeSkills}, true
+	case llm.MessageTypeSubagents:
+		return metaContextClassification{kind: metaContextKindSubagents, key: "subagents", messageType: llm.MessageTypeSubagents}, true
 	case llm.MessageTypeEnvironment:
 		return metaContextClassification{kind: metaContextKindEnvironment, key: "environment", messageType: llm.MessageTypeEnvironment}, true
 	case llm.MessageTypeHeadlessMode:

--- a/server/runtime/subagents_test.go
+++ b/server/runtime/subagents_test.go
@@ -1,0 +1,303 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"builder/server/llm"
+	"builder/server/session"
+	"builder/server/tools"
+	"builder/shared/config"
+	"builder/shared/toolspec"
+)
+
+func TestSubagentsMetaMessageRendersCallableNonNoopRoles(t *testing.T) {
+	settings := config.Settings{
+		Model:         "gpt-5.5",
+		ThinkingLevel: "medium",
+		EnabledTools: map[toolspec.ID]bool{
+			toolspec.ToolExecCommand: true,
+			toolspec.ToolPatch:       true,
+		},
+		Subagents: map[string]config.SubagentRole{
+			"research": {
+				Settings: config.Settings{
+					Model:         "gpt-5.4-mini",
+					ThinkingLevel: "high",
+					EnabledTools: map[toolspec.ID]bool{
+						toolspec.ToolExecCommand: true,
+						toolspec.ToolPatch:       false,
+					},
+				},
+				Sources:     map[string]string{"model": "file", "thinking_level": "file", "tools.patch": "file"},
+				Description: "Repo research specialist.",
+			},
+			"placebo": {
+				Settings:    config.Settings{Model: "gpt-5.5"},
+				Sources:     map[string]string{"model": "file"},
+				Description: "Sounds useful, but no behavior differs.",
+			},
+			"blocked": {
+				Settings:         config.Settings{Model: "gpt-5.4-mini"},
+				Sources:          map[string]string{"model": "file"},
+				AgentCallable:    false,
+				AgentCallableSet: true,
+			},
+			config.BuiltInSubagentRoleFast: {
+				Description: "ignored for now",
+			},
+		},
+	}
+	builder := newMetaContextBuilder("/tmp/work", "gpt-5.5", "medium", nil, time.Unix(0, 0)).
+		withSubagents(settings, []toolspec.ID{toolspec.ToolExecCommand})
+	result, err := builder.Build(metaContextBuildOptions{IncludeSubagents: true})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(result.Subagents) != 1 {
+		t.Fatalf("subagent messages = %d, want 1", len(result.Subagents))
+	}
+	content := result.Subagents[0].Content
+	for _, want := range []string{
+		"Available subagent roles:",
+		"- default: not specifying any role will invoke an exact clone of you, the general-purpose agent",
+		"- research: Repo research specialist.",
+		"Invoke with `",
+		"--agent=<role> \"<prompt>\"`.",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("content missing %q:\n%s", want, content)
+		}
+	}
+	for _, unwanted := range []string{"placebo", "blocked", "fast:"} {
+		if strings.Contains(content, unwanted) {
+			t.Fatalf("content should not include %q:\n%s", unwanted, content)
+		}
+	}
+}
+
+func TestSubagentsMetaMessageUsesFallbackAndRequiresCallerShell(t *testing.T) {
+	settings := config.Settings{
+		Model:               "gpt-5.5",
+		ThinkingLevel:       "medium",
+		PriorityRequestMode: true,
+		EnabledTools: map[toolspec.ID]bool{
+			toolspec.ToolExecCommand: true,
+			toolspec.ToolPatch:       false,
+		},
+		Subagents: map[string]config.SubagentRole{
+			"worker": {
+				Settings: config.Settings{
+					Model:               "gpt-5.4-mini",
+					ThinkingLevel:       "high",
+					PriorityRequestMode: true,
+					EnabledTools: map[toolspec.ID]bool{
+						toolspec.ToolExecCommand: true,
+						toolspec.ToolPatch:       true,
+					},
+				},
+				Sources: map[string]string{"model": "file", "thinking_level": "file", "priority_request_mode": "file", "tools.patch": "file"},
+			},
+		},
+	}
+	withShell := newMetaContextBuilder("/tmp/work", "gpt-5.5", "medium", nil, time.Unix(0, 0)).
+		withSubagents(settings, []toolspec.ID{toolspec.ToolExecCommand})
+	result, err := withShell.Build(metaContextBuildOptions{IncludeSubagents: true})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(result.Subagents) != 1 || !strings.Contains(result.Subagents[0].Content, "- worker: gpt-5.4-mini, thinking high, fast mode on, can edit, can call shell") {
+		t.Fatalf("unexpected fallback content: %+v", result.Subagents)
+	}
+
+	withoutShell := newMetaContextBuilder("/tmp/work", "gpt-5.5", "medium", nil, time.Unix(0, 0)).
+		withSubagents(settings, []toolspec.ID{toolspec.ToolPatch})
+	result, err = withoutShell.Build(metaContextBuildOptions{IncludeSubagents: true})
+	if err != nil {
+		t.Fatalf("Build without shell: %v", err)
+	}
+	if len(result.Subagents) != 0 {
+		t.Fatalf("expected no subagent context without caller shell, got %+v", result.Subagents)
+	}
+}
+
+func TestSubagentsMetaMessageCurrentNonCallableRoleDoesNotDisableOtherRoles(t *testing.T) {
+	settings := config.Settings{
+		Model:         "gpt-5.5",
+		ThinkingLevel: "medium",
+		EnabledTools: map[toolspec.ID]bool{
+			toolspec.ToolExecCommand: true,
+		},
+		Subagents: map[string]config.SubagentRole{
+			"current": {
+				Settings:         config.Settings{Model: "gpt-5.4-mini"},
+				Sources:          map[string]string{"model": "file"},
+				AgentCallable:    false,
+				AgentCallableSet: true,
+			},
+			"worker": {
+				Settings:    config.Settings{ThinkingLevel: "high"},
+				Sources:     map[string]string{"thinking_level": "file"},
+				Description: "Callable helper.",
+			},
+		},
+	}
+	builder := newMetaContextBuilder("/tmp/work", "gpt-5.5", "medium", nil, time.Unix(0, 0)).
+		withSubagents(settings, []toolspec.ID{toolspec.ToolExecCommand})
+	result, err := builder.Build(metaContextBuildOptions{IncludeSubagents: true})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(result.Subagents) != 1 {
+		t.Fatalf("subagent messages = %d, want 1", len(result.Subagents))
+	}
+	content := result.Subagents[0].Content
+	if !strings.Contains(content, "- worker: Callable helper.") {
+		t.Fatalf("expected callable helper in context:\n%s", content)
+	}
+	if strings.Contains(content, "current") {
+		t.Fatalf("non-callable current role should not be listed:\n%s", content)
+	}
+}
+
+func TestCompactionReinjectsSubagentsMetaContext(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	workspace := t.TempDir()
+	store, err := session.Create(t.TempDir(), "ws", workspace)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	settings := config.Settings{
+		Model:         "gpt-5.5",
+		ThinkingLevel: "medium",
+		EnabledTools: map[toolspec.ID]bool{
+			toolspec.ToolExecCommand: true,
+		},
+		Subagents: map[string]config.SubagentRole{
+			"worker": {
+				Settings:    config.Settings{ThinkingLevel: "high"},
+				Sources:     map[string]string{"thinking_level": "file"},
+				Description: "Callable helper.",
+			},
+		},
+	}
+	eng, err := New(store, &fakeClient{}, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), Config{
+		Model:                   "gpt-5.5",
+		ThinkingLevel:           "medium",
+		EnabledTools:            []toolspec.ID{toolspec.ToolExecCommand},
+		SubagentCatalogSettings: settings,
+	})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+
+	messages, err := eng.compactionReinjectedBaseMessages()
+	if err != nil {
+		t.Fatalf("compactionReinjectedBaseMessages: %v", err)
+	}
+	if !hasSubagentCatalog(messages, "- worker: Callable helper.") {
+		t.Fatalf("expected compaction-reinjected subagent catalog, got %+v", messages)
+	}
+}
+
+func TestManualCompactionPersistsSubagentCatalogInCanonicalTranscript(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	workspace := t.TempDir()
+	store, err := session.Create(t.TempDir(), "ws", workspace)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	settings := config.Settings{
+		Model:         "gpt-5.5",
+		ThinkingLevel: "medium",
+		EnabledTools: map[toolspec.ID]bool{
+			toolspec.ToolExecCommand: true,
+		},
+		Subagents: map[string]config.SubagentRole{
+			"worker": {
+				Settings:    config.Settings{ThinkingLevel: "high"},
+				Sources:     map[string]string{"thinking_level": "file"},
+				Description: "Callable helper.",
+			},
+		},
+	}
+	cfg := Config{
+		Model:                   "gpt-5.5",
+		ThinkingLevel:           "medium",
+		CompactionMode:          "local",
+		EnabledTools:            []toolspec.ID{toolspec.ToolExecCommand},
+		SubagentCatalogSettings: settings,
+	}
+	client := &fakeCompactionClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "condensed summary"},
+		Usage:     llm.Usage{InputTokens: 1000, OutputTokens: 100, WindowTokens: 200000},
+	}}}
+	eng, err := New(store, client, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), cfg)
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	if err := eng.appendMessage("", llm.Message{Role: llm.RoleUser, Content: "seed"}); err != nil {
+		t.Fatalf("append user message: %v", err)
+	}
+
+	if err := eng.CompactContext(context.Background(), ""); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	if !hasSubagentCatalog(eng.snapshotMessages(), "- worker: Callable helper.") {
+		t.Fatalf("expected in-memory canonical transcript to keep subagent catalog, got %+v", eng.snapshotMessages())
+	}
+
+	reopenedStore, err := session.Open(store.Dir())
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	restored, err := New(reopenedStore, &fakeClient{}, tools.NewRegistry(fakeTool{name: toolspec.ToolExecCommand}), cfg)
+	if err != nil {
+		t.Fatalf("restore engine: %v", err)
+	}
+	if !hasSubagentCatalog(restored.snapshotMessages(), "- worker: Callable helper.") {
+		t.Fatalf("expected persisted canonical transcript to keep subagent catalog, got %+v", restored.snapshotMessages())
+	}
+}
+
+func TestSplitMetaContextMessagesTreatsSubagentsAsMeta(t *testing.T) {
+	subagents := llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeSubagents, Content: "Available subagent roles:"}
+	messages := []llm.Message{
+		subagents,
+		{Role: llm.RoleUser, Content: "request"},
+	}
+	meta, transcript := splitMetaContextMessages(messages)
+	if len(meta) != 1 || meta[0].MessageType != llm.MessageTypeSubagents {
+		t.Fatalf("expected subagents meta message, got %+v", meta)
+	}
+	if len(transcript) != 1 || transcript[0].Role != llm.RoleUser {
+		t.Fatalf("expected user transcript, got %+v", transcript)
+	}
+}
+
+func hasSubagentCatalog(messages []llm.Message, content string) bool {
+	for _, message := range messages {
+		if message.MessageType == llm.MessageTypeSubagents && strings.Contains(message.Content, content) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestReviewerPromptFiltersSubagentsMetaContext(t *testing.T) {
+	messages := []llm.Message{
+		{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeSubagents, Content: "Available subagent roles:\n- worker: specialist"},
+		{Role: llm.RoleUser, Content: "request"},
+	}
+	got, err := buildReviewerRequestMessagesWithBuilder(messages, newMetaContextBuilder(t.TempDir(), "gpt-5.5", "medium", nil, time.Unix(0, 0)), false)
+	if err != nil {
+		t.Fatalf("buildReviewerRequestMessagesWithBuilder: %v", err)
+	}
+	for _, message := range got {
+		if message.MessageType == llm.MessageTypeSubagents || strings.Contains(message.Content, "Available subagent roles") {
+			t.Fatalf("reviewer messages leaked subagent context: %+v", got)
+		}
+	}
+}

--- a/server/runtimewire/wiring.go
+++ b/server/runtimewire/wiring.go
@@ -106,6 +106,7 @@ func NewRuntimeWiringWithBackground(store *session.Store, active config.Settings
 		ProviderCapabilitiesOverride:  mainProvider.ProviderCapabilitiesOverride,
 		EnabledTools:                  enabledTools,
 		DisabledSkills:                config.DisabledSkillToggles(active),
+		SubagentCatalogSettings:       active,
 		SystemPromptFiles:             active.SystemPromptFiles,
 		AutoCompactTokenLimit:         active.ContextCompactionThresholdTokens,
 		PreSubmitCompactionLeadTokens: active.PreSubmitCompactionLeadTokens,

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -989,10 +989,11 @@ func (s *Store) observePersistence(observation *persistenceObservation) error {
 
 func normalizeContinuationContext(ctx ContinuationContext) *ContinuationContext {
 	openAIBaseURL := strings.TrimSpace(ctx.OpenAIBaseURL)
-	if openAIBaseURL == "" {
+	agentRole := strings.TrimSpace(ctx.AgentRole)
+	if openAIBaseURL == "" && agentRole == "" {
 		return nil
 	}
-	return &ContinuationContext{OpenAIBaseURL: openAIBaseURL}
+	return &ContinuationContext{OpenAIBaseURL: openAIBaseURL, AgentRole: agentRole}
 }
 
 func normalizeUsageState(state *UsageState) *UsageState {

--- a/server/session/types.go
+++ b/server/session/types.go
@@ -43,6 +43,7 @@ type LockedProviderCapabilities struct {
 
 type ContinuationContext struct {
 	OpenAIBaseURL string `json:"openai_base_url,omitempty"`
+	AgentRole     string `json:"agent_role,omitempty"`
 }
 
 type UsageState struct {

--- a/shared/clientui/transcript_contract.go
+++ b/shared/clientui/transcript_contract.go
@@ -25,6 +25,7 @@ type MessageType string
 const (
 	MessageTypeAgentsMD                  MessageType = "agents.md"
 	MessageTypeSkills                    MessageType = "skills"
+	MessageTypeSubagents                 MessageType = "subagents"
 	MessageTypeEnvironment               MessageType = "environment"
 	MessageTypeCompactionSummary         MessageType = "compaction_summary"
 	MessageTypeInterruption              MessageType = "interruption"

--- a/shared/clientui/transcript_contract_test.go
+++ b/shared/clientui/transcript_contract_test.go
@@ -19,6 +19,7 @@ func TestTranscriptMessageContractWireValues(t *testing.T) {
 	messageTypes := map[MessageType]string{
 		MessageTypeAgentsMD:                  "agents.md",
 		MessageTypeSkills:                    "skills",
+		MessageTypeSubagents:                 "subagents",
 		MessageTypeEnvironment:               "environment",
 		MessageTypeCompactionSummary:         "compaction_summary",
 		MessageTypeInterruption:              "interruption",

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -73,8 +73,11 @@ type ShellSettings struct {
 }
 
 type SubagentRole struct {
-	Settings Settings
-	Sources  map[string]string
+	Settings         Settings
+	Sources          map[string]string
+	Description      string
+	AgentCallable    bool
+	AgentCallableSet bool
 }
 
 type SystemPromptFileScope string

--- a/shared/config/config_defaults.go
+++ b/shared/config/config_defaults.go
@@ -165,6 +165,8 @@ func writeBuiltInSubagentSections(builder *strings.Builder) {
 	}
 	builder.WriteString("\n[subagents.fast]\n")
 	builder.WriteString("# inherits all main settings unless overridden\n")
+	builder.WriteString("# agent_callable = true # set false to hide/block this role from Builder-session subagent calls\n")
+	builder.WriteString("# description = \"\" # model-visible role description for future/catalog uses\n")
 	builder.WriteString("# model = \"gpt-5.4-mini\" # built-in heuristic on exact OpenAI first-party setups\n")
 	builder.WriteString("# priority_request_mode = true # built-in heuristic on exact OpenAI first-party setups\n")
 	builder.WriteString("# model_context_window = 272000 # conservative default; larger API-key windows can be added later\n")

--- a/shared/config/config_registry.go
+++ b/shared/config/config_registry.go
@@ -1078,6 +1078,8 @@ func registerSubagentFileKeys(tree *fileKeyTree, settings []registrySetting) {
 		return
 	}
 	template := newFileKeyTree()
+	template.allowPath([]string{"description"})
+	template.allowPath([]string{"agent_callable"})
 	for _, setting := range settings {
 		if _, ok := setting.(subagentsSetting); ok {
 			continue
@@ -1085,7 +1087,7 @@ func registerSubagentFileKeys(tree *fileKeyTree, settings []registrySetting) {
 		setting.registerFileKeys(template)
 	}
 	tree.allowDynamicChildren([]string{"subagents"}, func(key string) bool {
-		return normalizeSubagentRoleKey(key) != ""
+		return IsSubagentRoleNameShape(key)
 	}, template)
 }
 
@@ -1095,6 +1097,14 @@ func parseSubagentRole(raw settingsFile, settingsPath string, roleKey string) (S
 	}
 	if err := validateSettingsFileKeys(raw, subagentRoleKeyTree(configRegistry.settings)); err != nil {
 		return SubagentRole{}, err
+	}
+	description, err := parseSubagentDescription(raw)
+	if err != nil {
+		return SubagentRole{}, fmt.Errorf("invalid subagents.%s: %w", roleKey, err)
+	}
+	agentCallable, agentCallableSet, err := parseSubagentAgentCallable(raw)
+	if err != nil {
+		return SubagentRole{}, fmt.Errorf("invalid subagents.%s: %w", roleKey, err)
 	}
 	roleState := configRegistry.defaultState()
 	roleSources := configRegistry.defaultSourceMap()
@@ -1134,11 +1144,19 @@ func parseSubagentRole(raw settingsFile, settingsPath string, roleKey string) (S
 		}
 	}
 	roleState.Settings.Subagents = nil
-	return SubagentRole{Settings: roleState.Settings, Sources: explicitSources}, nil
+	return SubagentRole{
+		Settings:         roleState.Settings,
+		Sources:          explicitSources,
+		Description:      description,
+		AgentCallable:    agentCallable,
+		AgentCallableSet: agentCallableSet,
+	}, nil
 }
 
 func subagentRoleKeyTree(settings []registrySetting) *fileKeyTree {
 	tree := newFileKeyTree()
+	tree.allowPath([]string{"description"})
+	tree.allowPath([]string{"agent_callable"})
 	for _, setting := range settings {
 		if _, ok := setting.(subagentsSetting); ok {
 			continue
@@ -1146,6 +1164,33 @@ func subagentRoleKeyTree(settings []registrySetting) *fileKeyTree {
 		setting.registerFileKeys(tree)
 	}
 	return tree
+}
+
+func parseSubagentDescription(raw settingsFile) (string, error) {
+	value, ok, err := lookupFileValue(raw, []string{"description"})
+	if err != nil || !ok {
+		return "", err
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", invalidSettingsTypeError([]string{"description"}, "string")
+	}
+	description := SanitizeSubagentDescription(text)
+	if len([]rune(description)) > MaxSubagentDescriptionChars {
+		return "", fmt.Errorf("description must be <= %d characters after whitespace normalization", MaxSubagentDescriptionChars)
+	}
+	return description, nil
+}
+
+func parseSubagentAgentCallable(raw settingsFile) (bool, bool, error) {
+	value, ok, err := lookupFileBool(raw, []string{"agent_callable"})
+	if err != nil {
+		return false, false, err
+	}
+	if !ok {
+		return true, false, nil
+	}
+	return value, true, nil
 }
 
 func newFileKeyTree() *fileKeyTree {

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -396,6 +396,148 @@ func TestLoadSubagentRoleFromFile(t *testing.T) {
 	}
 }
 
+func TestLoadSubagentRoleMetadataFromFile(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	configPath := filepath.Join(home, ".builder", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	contents := strings.Join([]string{
+		"[subagents.research]",
+		"description = \"  Deep    repo\\nresearch  \"",
+		"agent_callable = false",
+		"thinking_level = \"high\"",
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(workspace, LoadOptions{})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	role := cfg.Settings.Subagents["research"]
+	if role.Description != "Deep repo research" {
+		t.Fatalf("description = %q, want normalized description", role.Description)
+	}
+	if role.AgentCallable || !role.AgentCallableSet {
+		t.Fatalf("agent callable metadata = (%t, %t), want false set", role.AgentCallable, role.AgentCallableSet)
+	}
+	if _, exists := role.Sources["description"]; exists {
+		t.Fatalf("description should not be runtime source, got %+v", role.Sources)
+	}
+	if _, exists := role.Sources["agent_callable"]; exists {
+		t.Fatalf("agent_callable should not be runtime source, got %+v", role.Sources)
+	}
+}
+
+func TestLoadSubagentRoleRejectsReservedNames(t *testing.T) {
+	for _, reserved := range []string{"default", "none", "self"} {
+		t.Run(reserved, func(t *testing.T) {
+			home := t.TempDir()
+			workspace := t.TempDir()
+			t.Setenv("HOME", home)
+			configPath := filepath.Join(home, ".builder", "config.toml")
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+				t.Fatalf("mkdir config dir: %v", err)
+			}
+			if err := os.WriteFile(configPath, []byte("[subagents."+reserved+"]\nmodel = \"gpt-5.5\"\n"), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			_, err := Load(workspace, LoadOptions{})
+			if err == nil {
+				t.Fatal("expected reserved role to fail")
+			}
+			if !strings.Contains(err.Error(), "invalid subagents key") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadSubagentRoleRejectsInvalidMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{name: "description type", body: "[subagents.worker]\ndescription = 123\n", wantErr: "expected string"},
+		{name: "agent callable type", body: "[subagents.worker]\nagent_callable = \"no\"\n", wantErr: "expected boolean"},
+		{name: "description length", body: "[subagents.worker]\ndescription = \"" + strings.Repeat("x", MaxSubagentDescriptionChars+1) + "\"\n", wantErr: "description must be <="},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			workspace := t.TempDir()
+			t.Setenv("HOME", home)
+			configPath := filepath.Join(home, ".builder", "config.toml")
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+				t.Fatalf("mkdir config dir: %v", err)
+			}
+			if err := os.WriteFile(configPath, []byte(tt.body), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			_, err := Load(workspace, LoadOptions{})
+			if err == nil {
+				t.Fatal("expected metadata error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSubagentRoleHasMeaningfulDiffComparesProviderReviewerAndTimeoutValues(t *testing.T) {
+	base := Settings{
+		Timeouts: Timeouts{ModelRequestSeconds: 100},
+		ProviderCapabilities: ProviderCapabilitiesOverride{
+			ProviderID:           "openai",
+			SupportsResponsesAPI: true,
+		},
+		Reviewer: ReviewerSettings{
+			Model:          "gpt-5.5",
+			TimeoutSeconds: 60,
+		},
+	}
+
+	same := SubagentRole{
+		Settings: base,
+		Sources: map[string]string{
+			"timeouts.model_request_seconds":                        "file",
+			"provider_capabilities.supports_responses_api":          "file",
+			"reviewer.model":                                        "file",
+			"reviewer.provider_capabilities.supports_responses_api": "file",
+		},
+	}
+	if SubagentRoleHasMeaningfulDiff(base, same) {
+		t.Fatal("expected equal provider/reviewer/timeout values to be no-op")
+	}
+
+	changedTimeout := same
+	changedTimeout.Settings = base
+	changedTimeout.Settings.Timeouts.ModelRequestSeconds = 200
+	if !SubagentRoleHasMeaningfulDiff(base, changedTimeout) {
+		t.Fatal("expected timeout change to be meaningful")
+	}
+
+	changedProvider := same
+	changedProvider.Settings = base
+	changedProvider.Settings.ProviderCapabilities.SupportsResponsesAPI = false
+	if !SubagentRoleHasMeaningfulDiff(base, changedProvider) {
+		t.Fatal("expected provider capability change to be meaningful")
+	}
+
+	changedReviewer := same
+	changedReviewer.Settings = base
+	changedReviewer.Settings.Reviewer.Model = "gpt-5.4-mini"
+	if !SubagentRoleHasMeaningfulDiff(base, changedReviewer) {
+		t.Fatal("expected reviewer change to be meaningful")
+	}
+}
+
 func TestAppendSystemPromptFileFromConfigResolvesConfigRelativePath(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), ".builder", "config.toml")
 	state := configRegistry.defaultState()

--- a/shared/config/subagents.go
+++ b/shared/config/subagents.go
@@ -1,12 +1,27 @@
 package config
 
-import "strings"
+import (
+	"sort"
+	"strings"
+
+	"builder/shared/toolspec"
+)
 
 const BuiltInSubagentRoleFast = "fast"
+const MaxSubagentDescriptionChars = 5000
+
+var reservedSubagentRoleNames = map[string]bool{
+	"default": true,
+	"none":    true,
+	"self":    true,
+}
 
 func NormalizeSubagentRole(raw string) string {
 	normalized := strings.ToLower(strings.TrimSpace(raw))
 	if normalized == "" {
+		return ""
+	}
+	if reservedSubagentRoleNames[normalized] {
 		return ""
 	}
 	for _, r := range normalized {
@@ -24,6 +39,209 @@ func NormalizeSubagentRole(raw string) string {
 		}
 	}
 	return normalized
+}
+
+func NormalizeSubagentSelector(raw string) string {
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	if reservedSubagentRoleNames[normalized] {
+		return ""
+	}
+	return NormalizeSubagentRole(raw)
+}
+
+func IsReservedSubagentRoleName(raw string) bool {
+	return reservedSubagentRoleNames[strings.ToLower(strings.TrimSpace(raw))]
+}
+
+func IsSubagentRoleNameShape(raw string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	if normalized == "" {
+		return false
+	}
+	for _, r := range normalized {
+		if r >= 'a' && r <= 'z' {
+			continue
+		}
+		if r >= '0' && r <= '9' {
+			continue
+		}
+		switch r {
+		case '-', '_':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func SanitizeSubagentDescription(raw string) string {
+	return strings.Join(strings.Fields(raw), " ")
+}
+
+func SubagentRoleCallable(role SubagentRole) bool {
+	return !role.AgentCallableSet || role.AgentCallable
+}
+
+func AvailableSubagentRoleNames(settings Settings, agentCallableOnly bool) []string {
+	names := []string{}
+	if !agentCallableOnly || SubagentRoleCallable(settings.Subagents[BuiltInSubagentRoleFast]) {
+		names = append(names, BuiltInSubagentRoleFast)
+	}
+	for name, role := range settings.Subagents {
+		normalized := NormalizeSubagentRole(name)
+		if normalized == "" || normalized == BuiltInSubagentRoleFast {
+			continue
+		}
+		if !SubagentRoleHasMeaningfulDiff(settings, role) {
+			continue
+		}
+		if agentCallableOnly && !SubagentRoleCallable(role) {
+			continue
+		}
+		names = append(names, normalized)
+	}
+	sort.Strings(names)
+	for i, name := range names {
+		if name == BuiltInSubagentRoleFast {
+			copy(names[1:i+1], names[0:i])
+			names[0] = BuiltInSubagentRoleFast
+			break
+		}
+	}
+	return names
+}
+
+func SubagentRoleHasMeaningfulDiff(base Settings, role SubagentRole) bool {
+	for key := range role.Sources {
+		if subagentSourceDiffers(base, role, key) {
+			return true
+		}
+	}
+	return false
+}
+
+func subagentSourceDiffers(base Settings, role SubagentRole, key string) bool {
+	switch key {
+	case "model":
+		return strings.TrimSpace(base.Model) != strings.TrimSpace(role.Settings.Model)
+	case "thinking_level":
+		return strings.TrimSpace(base.ThinkingLevel) != strings.TrimSpace(role.Settings.ThinkingLevel)
+	case "model_verbosity":
+		return strings.TrimSpace(string(base.ModelVerbosity)) != strings.TrimSpace(string(role.Settings.ModelVerbosity))
+	case "model_capabilities.supports_reasoning_effort":
+		return base.ModelCapabilities.SupportsReasoningEffort != role.Settings.ModelCapabilities.SupportsReasoningEffort
+	case "model_capabilities.supports_vision_inputs":
+		return base.ModelCapabilities.SupportsVisionInputs != role.Settings.ModelCapabilities.SupportsVisionInputs
+	case "system_prompt_file":
+		return strings.TrimSpace(base.SystemPromptFile) != strings.TrimSpace(role.Settings.SystemPromptFile)
+	case "priority_request_mode":
+		return base.PriorityRequestMode != role.Settings.PriorityRequestMode
+	case "provider_override":
+		return strings.TrimSpace(base.ProviderOverride) != strings.TrimSpace(role.Settings.ProviderOverride)
+	case "openai_base_url":
+		return strings.TrimSpace(base.OpenAIBaseURL) != strings.TrimSpace(role.Settings.OpenAIBaseURL)
+	case "provider_capabilities.provider_id":
+		return strings.TrimSpace(base.ProviderCapabilities.ProviderID) != strings.TrimSpace(role.Settings.ProviderCapabilities.ProviderID)
+	case "provider_capabilities.supports_responses_api":
+		return base.ProviderCapabilities.SupportsResponsesAPI != role.Settings.ProviderCapabilities.SupportsResponsesAPI
+	case "provider_capabilities.supports_responses_compact":
+		return base.ProviderCapabilities.SupportsResponsesCompact != role.Settings.ProviderCapabilities.SupportsResponsesCompact
+	case "provider_capabilities.supports_request_input_token_count":
+		return base.ProviderCapabilities.SupportsRequestInputTokenCount != role.Settings.ProviderCapabilities.SupportsRequestInputTokenCount
+	case "provider_capabilities.supports_prompt_cache_key":
+		return base.ProviderCapabilities.SupportsPromptCacheKey != role.Settings.ProviderCapabilities.SupportsPromptCacheKey
+	case "provider_capabilities.supports_native_web_search":
+		return base.ProviderCapabilities.SupportsNativeWebSearch != role.Settings.ProviderCapabilities.SupportsNativeWebSearch
+	case "provider_capabilities.supports_reasoning_encrypted":
+		return base.ProviderCapabilities.SupportsReasoningEncrypted != role.Settings.ProviderCapabilities.SupportsReasoningEncrypted
+	case "provider_capabilities.supports_server_side_context_edit":
+		return base.ProviderCapabilities.SupportsServerSideContextEdit != role.Settings.ProviderCapabilities.SupportsServerSideContextEdit
+	case "provider_capabilities.is_openai_first_party":
+		return base.ProviderCapabilities.IsOpenAIFirstParty != role.Settings.ProviderCapabilities.IsOpenAIFirstParty
+	case "web_search":
+		return strings.TrimSpace(base.WebSearch) != strings.TrimSpace(role.Settings.WebSearch)
+	case "tool_preambles":
+		return base.ToolPreambles != role.Settings.ToolPreambles
+	case "model_context_window":
+		return base.ModelContextWindow != role.Settings.ModelContextWindow
+	case "context_compaction_threshold_tokens":
+		return base.ContextCompactionThresholdTokens != role.Settings.ContextCompactionThresholdTokens
+	case "pre_submit_compaction_lead_tokens":
+		return base.PreSubmitCompactionLeadTokens != role.Settings.PreSubmitCompactionLeadTokens
+	case "minimum_exec_to_bg_seconds":
+		return base.MinimumExecToBgSeconds != role.Settings.MinimumExecToBgSeconds
+	case "shell_output_max_chars":
+		return base.ShellOutputMaxChars != role.Settings.ShellOutputMaxChars
+	case "bg_shells_output":
+		return strings.TrimSpace(string(base.BGShellsOutput)) != strings.TrimSpace(string(role.Settings.BGShellsOutput))
+	case "cache_warning_mode":
+		return strings.TrimSpace(string(base.CacheWarningMode)) != strings.TrimSpace(string(role.Settings.CacheWarningMode))
+	case "compaction_mode":
+		return strings.TrimSpace(string(base.CompactionMode)) != strings.TrimSpace(string(role.Settings.CompactionMode))
+	case "timeouts.model_request_seconds":
+		return base.Timeouts.ModelRequestSeconds != role.Settings.Timeouts.ModelRequestSeconds
+	case "shell.postprocessing_mode":
+		return strings.TrimSpace(string(base.Shell.PostprocessingMode)) != strings.TrimSpace(string(role.Settings.Shell.PostprocessingMode))
+	case "shell.postprocess_hook":
+		return strings.TrimSpace(base.Shell.PostprocessHook) != strings.TrimSpace(role.Settings.Shell.PostprocessHook)
+	case "reviewer.frequency":
+		return strings.TrimSpace(base.Reviewer.Frequency) != strings.TrimSpace(role.Settings.Reviewer.Frequency)
+	case "reviewer.model":
+		return strings.TrimSpace(base.Reviewer.Model) != strings.TrimSpace(role.Settings.Reviewer.Model)
+	case "reviewer.thinking_level":
+		return strings.TrimSpace(base.Reviewer.ThinkingLevel) != strings.TrimSpace(role.Settings.Reviewer.ThinkingLevel)
+	case "reviewer.model_verbosity":
+		return strings.TrimSpace(string(base.Reviewer.ModelVerbosity)) != strings.TrimSpace(string(role.Settings.Reviewer.ModelVerbosity))
+	case "reviewer.provider_override":
+		return strings.TrimSpace(base.Reviewer.ProviderOverride) != strings.TrimSpace(role.Settings.Reviewer.ProviderOverride)
+	case "reviewer.openai_base_url":
+		return strings.TrimSpace(base.Reviewer.OpenAIBaseURL) != strings.TrimSpace(role.Settings.Reviewer.OpenAIBaseURL)
+	case "reviewer.model_context_window":
+		return base.Reviewer.ModelContextWindow != role.Settings.Reviewer.ModelContextWindow
+	case "reviewer.auth":
+		return strings.TrimSpace(base.Reviewer.Auth) != strings.TrimSpace(role.Settings.Reviewer.Auth)
+	case "reviewer.system_prompt_file":
+		return strings.TrimSpace(base.Reviewer.SystemPromptFile) != strings.TrimSpace(role.Settings.Reviewer.SystemPromptFile)
+	case "reviewer.timeout_seconds":
+		return base.Reviewer.TimeoutSeconds != role.Settings.Reviewer.TimeoutSeconds
+	case "reviewer.verbose_output":
+		return base.Reviewer.VerboseOutput != role.Settings.Reviewer.VerboseOutput
+	case "reviewer.model_capabilities.supports_reasoning_effort":
+		return base.Reviewer.ModelCapabilities.SupportsReasoningEffort != role.Settings.Reviewer.ModelCapabilities.SupportsReasoningEffort
+	case "reviewer.model_capabilities.supports_vision_inputs":
+		return base.Reviewer.ModelCapabilities.SupportsVisionInputs != role.Settings.Reviewer.ModelCapabilities.SupportsVisionInputs
+	case "reviewer.provider_capabilities.provider_id":
+		return strings.TrimSpace(base.Reviewer.ProviderCapabilities.ProviderID) != strings.TrimSpace(role.Settings.Reviewer.ProviderCapabilities.ProviderID)
+	case "reviewer.provider_capabilities.supports_responses_api":
+		return base.Reviewer.ProviderCapabilities.SupportsResponsesAPI != role.Settings.Reviewer.ProviderCapabilities.SupportsResponsesAPI
+	case "reviewer.provider_capabilities.supports_responses_compact":
+		return base.Reviewer.ProviderCapabilities.SupportsResponsesCompact != role.Settings.Reviewer.ProviderCapabilities.SupportsResponsesCompact
+	case "reviewer.provider_capabilities.supports_request_input_token_count":
+		return base.Reviewer.ProviderCapabilities.SupportsRequestInputTokenCount != role.Settings.Reviewer.ProviderCapabilities.SupportsRequestInputTokenCount
+	case "reviewer.provider_capabilities.supports_prompt_cache_key":
+		return base.Reviewer.ProviderCapabilities.SupportsPromptCacheKey != role.Settings.Reviewer.ProviderCapabilities.SupportsPromptCacheKey
+	case "reviewer.provider_capabilities.supports_native_web_search":
+		return base.Reviewer.ProviderCapabilities.SupportsNativeWebSearch != role.Settings.Reviewer.ProviderCapabilities.SupportsNativeWebSearch
+	case "reviewer.provider_capabilities.supports_reasoning_encrypted":
+		return base.Reviewer.ProviderCapabilities.SupportsReasoningEncrypted != role.Settings.Reviewer.ProviderCapabilities.SupportsReasoningEncrypted
+	case "reviewer.provider_capabilities.supports_server_side_context_edit":
+		return base.Reviewer.ProviderCapabilities.SupportsServerSideContextEdit != role.Settings.Reviewer.ProviderCapabilities.SupportsServerSideContextEdit
+	case "reviewer.provider_capabilities.is_openai_first_party":
+		return base.Reviewer.ProviderCapabilities.IsOpenAIFirstParty != role.Settings.Reviewer.ProviderCapabilities.IsOpenAIFirstParty
+	}
+	if strings.HasPrefix(key, "tools.") {
+		toolName := strings.TrimPrefix(key, "tools.")
+		if id, ok := toolspec.ParseConfigID(toolName); ok {
+			return base.EnabledTools[id] != role.Settings.EnabledTools[id]
+		}
+		return true
+	}
+	if strings.HasPrefix(key, "skills.") {
+		name := strings.TrimPrefix(key, "skills.")
+		return base.SkillToggles[name] != role.Settings.SkillToggles[name]
+	}
+	return true
 }
 
 func normalizeSubagentRoleKey(raw string) string {


### PR DESCRIPTION
## Summary
- add subagent role metadata (`description`, `agent_callable`) with validation and selector aliases
- inject model-visible callable subagent catalog for shell-enabled Builder sessions
- enforce non-callable roles for Builder-session subagent calls and preserve catalog across compaction
- document config/headless behavior and add internal decision note

## Verification
- `./scripts/test.sh ./...`
- `./scripts/build.sh --output ./bin/builder`
- `git diff --check`
- push hook: formatting, go vet, go build, test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Subagent roles can now be marked as non-callable via `agent_callable = false` configuration, allowing roles for human use only.
  * Subagents now support custom descriptions to explain their purpose and capabilities.
  * Available callable subagent roles are displayed during agent interactions.
  * Added support for role aliases: `default`, `none`, and `self`.

* **Documentation**
  * Updated configuration guide with `agent_callable` and `description` field explanations.
  * Enhanced headless documentation for subagent role discovery and access controls.
  * Added async workflow orchestration design documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/respawn-app/builder/pull/258)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->