### PR TITLE
fix: improve ongoing question rendering

### DIFF
--- a/cli/app/ui_layout_rendering_input.go
+++ b/cli/app/ui_layout_rendering_input.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"builder/cli/tui"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -139,12 +140,16 @@ func (l uiViewLayout) wrappedAskPromptLines(width int) ([]wrappedAskPromptLine, 
 	if len(promptLines) == 0 {
 		promptLines = []askPromptLine{{Text: "", Kind: askPromptLineKindQuestion}}
 	}
+	promptLines = renderMarkdownAskQuestionPromptLines(promptLines, l.model.theme, width)
 	out := make([]wrappedAskPromptLine, 0, len(promptLines)*2)
 	cursorLineIndex := -1
 	for _, line := range promptLines {
 		parts := wrapLine(line.Text, width)
 		lineCursor := -1
 		lineCursorCol := 0
+		if line.Kind == askPromptLineKindQuestion {
+			parts = []string{truncateANSIRight(line.Text, width)}
+		}
 		if line.Kind == askPromptLineKindInput {
 			spec := uiEditableInputRenderSpec{Prefix: line.InputPrefix, Text: line.InputText, CursorIndex: line.InputCursor, RenderCursor: line.ShowsCursor}
 			renderedInput := renderEditableInputField(width, 0, spec)
@@ -176,6 +181,36 @@ func (l uiViewLayout) wrappedAskPromptLines(width int) ([]wrappedAskPromptLine, 
 		return []wrappedAskPromptLine{{Text: "", Line: askPromptLine{Kind: askPromptLineKindQuestion}}}, -1
 	}
 	return out, cursorLineIndex
+}
+
+func renderMarkdownAskQuestionPromptLines(lines []askPromptLine, theme string, width int) []askPromptLine {
+	if len(lines) == 0 {
+		return nil
+	}
+	out := make([]askPromptLine, 0, len(lines))
+	for idx := 0; idx < len(lines); {
+		line := lines[idx]
+		if line.Kind != askPromptLineKindQuestion {
+			out = append(out, line)
+			idx++
+			continue
+		}
+		start := idx
+		parts := make([]string, 0, 4)
+		for idx < len(lines) && lines[idx].Kind == askPromptLineKindQuestion {
+			parts = append(parts, lines[idx].Text)
+			idx++
+		}
+		rendered := tui.RenderInlineAskQuestionMarkdownLines(strings.Join(parts, "\n"), theme, width)
+		if len(rendered) == 0 {
+			out = append(out, lines[start:idx]...)
+			continue
+		}
+		for _, text := range rendered {
+			out = append(out, askPromptLine{Text: text, Kind: askPromptLineKindQuestion})
+		}
+	}
+	return out
 }
 
 func (l uiViewLayout) visibleAskPromptLines(width int) []wrappedAskPromptLine {

--- a/cli/app/ui_layout_rendering_input.go
+++ b/cli/app/ui_layout_rendering_input.go
@@ -140,8 +140,7 @@ func (l uiViewLayout) wrappedAskPromptLines(width int) ([]wrappedAskPromptLine, 
 	if len(promptLines) == 0 {
 		promptLines = []askPromptLine{{Text: "", Kind: askPromptLineKindQuestion}}
 	}
-	ellipsizeQuestionLines := askPromptUsesInlineQuestionPicker(promptLines)
-	promptLines = renderMarkdownAskQuestionPromptLines(promptLines, l.model.theme, width, ellipsizeQuestionLines)
+	promptLines = renderMarkdownAskQuestionPromptLines(promptLines, l.model.theme, width)
 	out := make([]wrappedAskPromptLine, 0, len(promptLines)*2)
 	cursorLineIndex := -1
 	for _, line := range promptLines {
@@ -149,11 +148,7 @@ func (l uiViewLayout) wrappedAskPromptLines(width int) ([]wrappedAskPromptLine, 
 		lineCursor := -1
 		lineCursorCol := 0
 		if line.Kind == askPromptLineKindQuestion {
-			if ellipsizeQuestionLines {
-				parts = []string{truncateANSIRight(line.Text, width)}
-			} else {
-				parts = []string{line.Text}
-			}
+			parts = []string{line.Text}
 		}
 		if line.Kind == askPromptLineKindInput {
 			spec := uiEditableInputRenderSpec{Prefix: line.InputPrefix, Text: line.InputText, CursorIndex: line.InputCursor, RenderCursor: line.ShowsCursor}
@@ -188,16 +183,7 @@ func (l uiViewLayout) wrappedAskPromptLines(width int) ([]wrappedAskPromptLine, 
 	return out, cursorLineIndex
 }
 
-func askPromptUsesInlineQuestionPicker(lines []askPromptLine) bool {
-	for _, line := range lines {
-		if line.Kind == askPromptLineKindOption {
-			return true
-		}
-	}
-	return false
-}
-
-func renderMarkdownAskQuestionPromptLines(lines []askPromptLine, theme string, width int, inlinePicker bool) []askPromptLine {
+func renderMarkdownAskQuestionPromptLines(lines []askPromptLine, theme string, width int) []askPromptLine {
 	if len(lines) == 0 {
 		return nil
 	}
@@ -216,9 +202,6 @@ func renderMarkdownAskQuestionPromptLines(lines []askPromptLine, theme string, w
 			idx++
 		}
 		rendered := tui.RenderAskQuestionMarkdownLines(strings.Join(parts, "\n"), theme, width)
-		if inlinePicker {
-			rendered = tui.RenderInlineAskQuestionMarkdownLines(strings.Join(parts, "\n"), theme, width)
-		}
 		if len(rendered) == 0 {
 			out = append(out, lines[start:idx]...)
 			continue

--- a/cli/app/ui_layout_rendering_input.go
+++ b/cli/app/ui_layout_rendering_input.go
@@ -140,7 +140,8 @@ func (l uiViewLayout) wrappedAskPromptLines(width int) ([]wrappedAskPromptLine, 
 	if len(promptLines) == 0 {
 		promptLines = []askPromptLine{{Text: "", Kind: askPromptLineKindQuestion}}
 	}
-	promptLines = renderMarkdownAskQuestionPromptLines(promptLines, l.model.theme, width)
+	ellipsizeQuestionLines := askPromptUsesInlineQuestionPicker(promptLines)
+	promptLines = renderMarkdownAskQuestionPromptLines(promptLines, l.model.theme, width, ellipsizeQuestionLines)
 	out := make([]wrappedAskPromptLine, 0, len(promptLines)*2)
 	cursorLineIndex := -1
 	for _, line := range promptLines {
@@ -148,7 +149,11 @@ func (l uiViewLayout) wrappedAskPromptLines(width int) ([]wrappedAskPromptLine, 
 		lineCursor := -1
 		lineCursorCol := 0
 		if line.Kind == askPromptLineKindQuestion {
-			parts = []string{truncateANSIRight(line.Text, width)}
+			if ellipsizeQuestionLines {
+				parts = []string{truncateANSIRight(line.Text, width)}
+			} else {
+				parts = []string{line.Text}
+			}
 		}
 		if line.Kind == askPromptLineKindInput {
 			spec := uiEditableInputRenderSpec{Prefix: line.InputPrefix, Text: line.InputText, CursorIndex: line.InputCursor, RenderCursor: line.ShowsCursor}
@@ -183,7 +188,16 @@ func (l uiViewLayout) wrappedAskPromptLines(width int) ([]wrappedAskPromptLine, 
 	return out, cursorLineIndex
 }
 
-func renderMarkdownAskQuestionPromptLines(lines []askPromptLine, theme string, width int) []askPromptLine {
+func askPromptUsesInlineQuestionPicker(lines []askPromptLine) bool {
+	for _, line := range lines {
+		if line.Kind == askPromptLineKindOption {
+			return true
+		}
+	}
+	return false
+}
+
+func renderMarkdownAskQuestionPromptLines(lines []askPromptLine, theme string, width int, inlinePicker bool) []askPromptLine {
 	if len(lines) == 0 {
 		return nil
 	}
@@ -201,7 +215,10 @@ func renderMarkdownAskQuestionPromptLines(lines []askPromptLine, theme string, w
 			parts = append(parts, lines[idx].Text)
 			idx++
 		}
-		rendered := tui.RenderInlineAskQuestionMarkdownLines(strings.Join(parts, "\n"), theme, width)
+		rendered := tui.RenderAskQuestionMarkdownLines(strings.Join(parts, "\n"), theme, width)
+		if inlinePicker {
+			rendered = tui.RenderInlineAskQuestionMarkdownLines(strings.Join(parts, "\n"), theme, width)
+		}
 		if len(rendered) == 0 {
 			out = append(out, lines[start:idx]...)
 			continue

--- a/cli/app/ui_test.go
+++ b/cli/app/ui_test.go
@@ -732,7 +732,7 @@ func TestAskQuestionLargeMarkdownPromptPreservesLogicalLines(t *testing.T) {
 	}
 }
 
-func TestAskQuestionPromptQuestionLinesEllipsizeInsteadOfWrapping(t *testing.T) {
+func TestAskQuestionPickerQuestionLinesWrapInsteadOfEllipsizing(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.termWidth = 40
 	m.termHeight = 12
@@ -749,11 +749,19 @@ func TestAskQuestionPromptQuestionLinesEllipsizeInsteadOfWrapping(t *testing.T) 
 	if len(wrapped) == 0 {
 		t.Fatal("expected ask prompt lines")
 	}
-	if got := wrapped[0].Text; !strings.HasSuffix(ansi.Strip(got), "…") || lipgloss.Width(got) > 32 {
-		t.Fatalf("expected long live question line ellipsized to width, got %q width=%d", got, lipgloss.Width(got))
+	questionLines := 0
+	plain := make([]string, 0, len(wrapped))
+	for _, line := range wrapped {
+		if line.Line.Kind == askPromptLineKindQuestion {
+			questionLines++
+			plain = append(plain, ansi.Strip(line.Text))
+			if strings.HasSuffix(ansi.Strip(line.Text), "…") {
+				t.Fatalf("expected picker question line to wrap, not ellipsize: %+v", line)
+			}
+		}
 	}
-	if len(wrapped) > 1 && wrapped[1].Line.Kind == askPromptLineKindQuestion {
-		t.Fatalf("expected long question to stay on one ellipsized live line, got next question line %+v", wrapped[1])
+	if questionLines < 2 {
+		t.Fatalf("expected long picker question to wrap across multiple lines, got %d in %q", questionLines, strings.Join(plain, "\n"))
 	}
 }
 

--- a/cli/app/ui_test.go
+++ b/cli/app/ui_test.go
@@ -757,6 +757,33 @@ func TestAskQuestionPromptQuestionLinesEllipsizeInsteadOfWrapping(t *testing.T) 
 	}
 }
 
+func TestAskQuestionFreeformPromptQuestionLinesWrapInsteadOfEllipsizing(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.termWidth = 40
+	m.termHeight = 12
+	m.windowSizeKnown = true
+	m.syncViewport()
+	testSetActiveAsk(m, &askEvent{req: clientui.PendingPromptEvent{
+		Question: "This question is intentionally far too long to fit in the live ask input area on one line.",
+	}, reply: make(chan askReply, 1)})
+
+	wrapped, _ := m.layout().wrappedAskPromptLines(32)
+	questionLines := 0
+	plain := make([]string, 0, len(wrapped))
+	for _, line := range wrapped {
+		if line.Line.Kind == askPromptLineKindQuestion {
+			questionLines++
+			plain = append(plain, ansi.Strip(line.Text))
+			if strings.HasSuffix(ansi.Strip(line.Text), "…") {
+				t.Fatalf("expected freeform question line to wrap, not ellipsize: %+v", line)
+			}
+		}
+	}
+	if questionLines < 2 {
+		t.Fatalf("expected long freeform question to wrap across multiple lines, got %d in %q", questionLines, strings.Join(plain, "\n"))
+	}
+}
+
 func TestAskQuestionMarkdownPromptCursorTracksInputAfterExpandedQuestion(t *testing.T) {
 	question := strings.Join([]string{
 		"Review **this plan** before answer:",

--- a/cli/app/ui_test.go
+++ b/cli/app/ui_test.go
@@ -709,26 +709,84 @@ func TestAskQuestionLargeMarkdownPromptPreservesLogicalLines(t *testing.T) {
 		if strings.Contains(line.Text, "\n") {
 			t.Fatalf("ask prompt line contains embedded newline: %+v", line)
 		}
-		gotLines = append(gotLines, strings.TrimRight(line.Text, " "))
+		gotLines = append(gotLines, strings.TrimRight(ansi.Strip(line.Text), " "))
 	}
 	got := strings.Join(gotLines, "\n")
-	want := strings.Join([]string{
-		"    val preserved = true",
+	if strings.Contains(got, "```") || strings.Contains(got, "- Keep") || strings.Contains(got, "**") {
+		t.Fatalf("expected inline ask question markdown rendered, got %q", got)
+	}
+	for _, want := range []string{
+		"val preserved = true",
 		"Please review this plan before I continue:",
-		"",
-		"```kotlin",
 		"fun main() {",
 		"    println(\"hi\")",
 		"}",
-		"```",
-		"",
-		"- Keep the four leading spaces in the code block.",
-		"- Do not collapse blank lines.",
+		"• Keep the four leading spaces in the code block.",
+		"• Do not collapse blank lines.",
 		"›",
 		"Enter to submit",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("ask prompt markdown missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestAskQuestionPromptQuestionLinesEllipsizeInsteadOfWrapping(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.termWidth = 40
+	m.termHeight = 12
+	m.windowSizeKnown = true
+	m.syncViewport()
+	testSetActiveAsk(m, &askEvent{req: clientui.PendingPromptEvent{
+		Question: "This question is intentionally far too long to fit in the live ask input area on one line.",
+		Suggestions: []string{
+			"Proceed",
+		},
+	}, reply: make(chan askReply, 1)})
+
+	wrapped, _ := m.layout().wrappedAskPromptLines(32)
+	if len(wrapped) == 0 {
+		t.Fatal("expected ask prompt lines")
+	}
+	if got := wrapped[0].Text; !strings.HasSuffix(ansi.Strip(got), "…") || lipgloss.Width(got) > 32 {
+		t.Fatalf("expected long live question line ellipsized to width, got %q width=%d", got, lipgloss.Width(got))
+	}
+	if len(wrapped) > 1 && wrapped[1].Line.Kind == askPromptLineKindQuestion {
+		t.Fatalf("expected long question to stay on one ellipsized live line, got next question line %+v", wrapped[1])
+	}
+}
+
+func TestAskQuestionMarkdownPromptCursorTracksInputAfterExpandedQuestion(t *testing.T) {
+	question := strings.Join([]string{
+		"Review **this plan** before answer:",
+		"",
+		"- First item",
+		"- Second item",
 	}, "\n")
-	if got != want {
-		t.Fatalf("ask prompt snapshot mismatch:\n--- got ---\n%q\n--- want ---\n%q", got, want)
+	m := newProjectedStaticUIModel()
+	m.termWidth = 72
+	m.termHeight = 12
+	m.windowSizeKnown = true
+	m.syncViewport()
+	testSetActiveAsk(m, &askEvent{req: clientui.PendingPromptEvent{Question: question}, reply: make(chan askReply, 1)})
+	m.ask.input = "typed"
+	m.ask.inputCursor = len([]rune(m.ask.input))
+
+	wrapped, cursorLine := m.layout().wrappedAskPromptLines(64)
+	if cursorLine < 0 || cursorLine >= len(wrapped) {
+		t.Fatalf("expected cursor line in wrapped prompt, got %d of %d", cursorLine, len(wrapped))
+	}
+	if wrapped[cursorLine].Line.Kind != askPromptLineKindInput {
+		t.Fatalf("expected cursor to land on input after markdown-expanded question, got line %+v", wrapped[cursorLine])
+	}
+
+	visible, visibleCursor := m.layout().visibleAskPromptLinesWithCursor(64)
+	if visibleCursor < 0 || visibleCursor >= len(visible) {
+		t.Fatalf("expected cursor line in visible prompt, got %d of %d", visibleCursor, len(visible))
+	}
+	if visible[visibleCursor].Line.Kind != askPromptLineKindInput {
+		t.Fatalf("expected visible cursor to land on input after markdown-expanded question, got line %+v", visible[visibleCursor])
 	}
 }
 

--- a/cli/tui/markdown_renderer.go
+++ b/cli/tui/markdown_renderer.go
@@ -17,6 +17,7 @@ type markdownRenderer struct {
 	theme               string
 	styles              rendererStyleAdapter
 	renderers           map[int]*glamour.TermRenderer
+	wrappedRenderers    map[int]*glamour.TermRenderer
 	cache               map[string]string
 	reportErr           markdownRendererErrorReporter
 	newTermRenderer     func(...glamour.TermRendererOption) (*glamour.TermRenderer, error)
@@ -25,16 +26,25 @@ type markdownRenderer struct {
 
 func newMarkdownRenderer(theme string, reportErr markdownRendererErrorReporter) *markdownRenderer {
 	return &markdownRenderer{
-		theme:           theme,
-		styles:          newRendererStyleAdapter(theme),
-		renderers:       make(map[int]*glamour.TermRenderer, 8),
-		cache:           make(map[string]string, 128),
-		reportErr:       reportErr,
-		newTermRenderer: glamour.NewTermRenderer,
+		theme:            theme,
+		styles:           newRendererStyleAdapter(theme),
+		renderers:        make(map[int]*glamour.TermRenderer, 8),
+		wrappedRenderers: make(map[int]*glamour.TermRenderer, 8),
+		cache:            make(map[string]string, 128),
+		reportErr:        reportErr,
+		newTermRenderer:  glamour.NewTermRenderer,
 	}
 }
 
 func (r *markdownRenderer) render(role RenderIntent, text string, width int) (string, error) {
+	return r.renderWithRenderer(role, text, width, "plain", r.getRenderer)
+}
+
+func (r *markdownRenderer) renderWrapped(role RenderIntent, text string, width int) (string, error) {
+	return r.renderWithRenderer(role, text, width, "wrapped", r.getWrappedRenderer)
+}
+
+func (r *markdownRenderer) renderWithRenderer(role RenderIntent, text string, width int, variant string, rendererForWidth func(int) (*glamour.TermRenderer, error)) (string, error) {
 	if strings.TrimSpace(text) == "" {
 		return "", nil
 	}
@@ -45,12 +55,12 @@ func (r *markdownRenderer) render(role RenderIntent, text string, width int) (st
 		width = 1
 	}
 
-	key := fmt.Sprintf("%s|%s|%d|%x", r.theme, role, width, hashString(text))
+	key := fmt.Sprintf("%s|%s|%s|%d|%x", r.theme, role, variant, width, hashString(text))
 	if cached, ok := r.cache[key]; ok {
 		return cached, nil
 	}
 
-	renderer, err := r.getRenderer(width)
+	renderer, err := rendererForWidth(width)
 	if err != nil {
 		if !r.reportedInitFailure && r.reportErr != nil {
 			r.reportedInitFailure = true
@@ -88,6 +98,21 @@ func (r *markdownRenderer) getRenderer(width int) (*glamour.TermRenderer, error)
 		return nil, err
 	}
 	r.renderers[width] = termRenderer
+	return termRenderer, nil
+}
+
+func (r *markdownRenderer) getWrappedRenderer(width int) (*glamour.TermRenderer, error) {
+	if existing, ok := r.wrappedRenderers[width]; ok {
+		return existing, nil
+	}
+	termRenderer, err := r.newTermRenderer(
+		glamour.WithWordWrap(width),
+		glamour.WithStyles(r.styleConfig()),
+	)
+	if err != nil {
+		return nil, err
+	}
+	r.wrappedRenderers[width] = termRenderer
 	return termRenderer, nil
 }
 

--- a/cli/tui/model_rendering.go
+++ b/cli/tui/model_rendering.go
@@ -285,6 +285,7 @@ func (m Model) askQuestionBlock(entryIndex int, entry TranscriptEntry, consumed 
 	blockRole := RenderIntentToolQuestion
 	question, suggestions, recommendedOptionIndex := askQuestionDisplay(entry.ToolCall, entry.Text)
 	answer := ""
+	entryEnd := entryIndex
 	if resultIdx := resultIndex.findMatchingToolResultIndex(m.transcriptInput.Entries, entryIndex, consumed); resultIdx >= 0 {
 		resultEntry := m.transcriptInput.Entries[resultIdx]
 		nextRole := roleFromEntry(resultEntry)
@@ -295,6 +296,7 @@ func (m Model) askQuestionBlock(entryIndex int, entry TranscriptEntry, consumed 
 			}
 			blockRole = toolBlockRoleFromResult(nextRole, blockRole)
 			consumed[resultIdx] = struct{}{}
+			entryEnd = resultIdx
 		}
 	}
 	lines := m.flattenAskQuestionEntry(blockRole, question, suggestions, recommendedOptionIndex, answer, opts.mode == transcriptBlockModeDetail)
@@ -305,7 +307,7 @@ func (m Model) askQuestionBlock(entryIndex int, entry TranscriptEntry, consumed 
 		role:       blockRole,
 		lines:      lines,
 		entryIndex: m.absoluteTranscriptIndex(entryIndex),
-		entryEnd:   m.absoluteTranscriptIndex(entryIndex),
+		entryEnd:   m.absoluteTranscriptIndex(entryEnd),
 	}
 }
 

--- a/cli/tui/model_rendering_entries_test.go
+++ b/cli/tui/model_rendering_entries_test.go
@@ -34,6 +34,25 @@ func TestResolveToolRenderHintPreservesShellDialectOnShellPreviewFallback(t *tes
 	}
 }
 
+func TestRenderInlineAskQuestionMarkdownLinesRendersMarkdownWithoutWrapping(t *testing.T) {
+	question := strings.Join([]string{
+		"Review **bold plan** and the [design note](https://example.com/really/long/path).",
+		"",
+		"```go",
+		"fmt.Println(\"tail-marker\")",
+		"```",
+	}, "\n")
+
+	lines := RenderInlineAskQuestionMarkdownLines(question, "dark", 24)
+	plain := xansi.Strip(strings.Join(lines, "\n"))
+	if strings.Contains(plain, "**bold plan**") || strings.Contains(plain, "```") {
+		t.Fatalf("expected inline ask question markdown rendered, got %q", plain)
+	}
+	if !strings.Contains(plain, "Review bold plan") || !strings.Contains(plain, "fmt.Println(\"tail-marker\")") {
+		t.Fatalf("expected inline ask question markdown content preserved, got %q", plain)
+	}
+}
+
 func TestWrapTextForViewportDoesNotOverflowWhenPunctuationFollowsFullLine(t *testing.T) {
 	for _, punctuation := range []string{".", ",", ";", "+", "-", "|"} {
 		t.Run(punctuation, func(t *testing.T) {

--- a/cli/tui/model_rendering_tools.go
+++ b/cli/tui/model_rendering_tools.go
@@ -106,11 +106,17 @@ func askQuestionDisplay(meta *transcript.ToolCallMeta, text string) (string, []s
 	return question, suggestions, recommendedOptionIndex
 }
 
+// RenderAskQuestionMarkdownLines renders question markdown for committed
+// ask_question transcript entries using theme and width, returning wrapped
+// display lines.
 func RenderAskQuestionMarkdownLines(question string, theme string, width int) []string {
 	renderer := transcriptProjectionRenderer(theme, width, 0)
 	return renderer.renderAskQuestionMarkdownLines(RenderIntentToolQuestion, question, width)
 }
 
+// RenderInlineAskQuestionMarkdownLines renders question markdown for compact
+// inline previews using theme and width, returning display lines without
+// transcript wrapping. It clamps width and falls back to raw line splitting.
 func RenderInlineAskQuestionMarkdownLines(question string, theme string, width int) []string {
 	renderer := transcriptProjectionRenderer(theme, width, 0)
 	if width < 1 {

--- a/cli/tui/model_rendering_tools.go
+++ b/cli/tui/model_rendering_tools.go
@@ -217,8 +217,6 @@ func (m Model) flattenAskQuestionEntryWithSymbol(role RenderIntent, question str
 	for idx, line := range lines {
 		display := line.text
 		switch line.kind {
-		case "question":
-			display = applyANSIStyleIntents(display, m.ansiIntentPalette(), Faint)
 		case "suggestion":
 			display = m.palette().preview.Faint(true).Render(display)
 		case "recommended_suggestion":

--- a/cli/tui/model_rendering_tools.go
+++ b/cli/tui/model_rendering_tools.go
@@ -16,6 +16,9 @@ func detailDivider() string {
 
 func ongoingDividerGroup(role RenderIntent) string {
 	normalized := normalizeOngoingDividerRole(role)
+	if normalized == RenderIntentToolQuestion || normalized == RenderIntentToolQuestionError {
+		return "question"
+	}
 	if normalized.IsToolHeadline() {
 		return "tool"
 	}
@@ -103,6 +106,41 @@ func askQuestionDisplay(meta *transcript.ToolCallMeta, text string) (string, []s
 	return question, suggestions, recommendedOptionIndex
 }
 
+func RenderAskQuestionMarkdownLines(question string, theme string, width int) []string {
+	renderer := transcriptProjectionRenderer(theme, width, 0)
+	return renderer.renderAskQuestionMarkdownLines(RenderIntentToolQuestion, question, width)
+}
+
+func RenderInlineAskQuestionMarkdownLines(question string, theme string, width int) []string {
+	renderer := transcriptProjectionRenderer(theme, width, 0)
+	if width < 1 {
+		width = 1
+	}
+	if renderer.md != nil {
+		if rendered, err := renderer.md.render(RenderIntentToolQuestion, question, width); err == nil {
+			lines := trimZeroWidthEdgeLines(splitLines(rendered))
+			if len(lines) > 0 {
+				return lines
+			}
+		}
+	}
+	lines := splitLines(question)
+	if len(lines) == 0 {
+		return []string{""}
+	}
+	return lines
+}
+
+func trimZeroWidthEdgeLines(lines []string) []string {
+	for len(lines) > 0 && lipgloss.Width(lines[0]) == 0 {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && lipgloss.Width(lines[len(lines)-1]) == 0 {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
 func normalizeAskQuestionQuestion(question string) string {
 	trimmed := strings.TrimSpace(question)
 	if trimmed == "" {
@@ -179,6 +217,8 @@ func (m Model) flattenAskQuestionEntryWithSymbol(role RenderIntent, question str
 	for idx, line := range lines {
 		display := line.text
 		switch line.kind {
+		case "question":
+			display = applyANSIStyleIntents(display, m.ansiIntentPalette(), Faint)
 		case "suggestion":
 			display = m.palette().preview.Faint(true).Render(display)
 		case "recommended_suggestion":
@@ -212,8 +252,8 @@ func (m Model) renderAskQuestionMarkdownLines(role RenderIntent, question string
 		renderWidth = 1
 	}
 	if m.md != nil {
-		if rendered, err := m.md.render(role, question, renderWidth); err == nil {
-			lines := splitLines(rendered)
+		if rendered, err := m.md.renderWrapped(role, question, renderWidth); err == nil {
+			lines := splitLines(hardWrapOverflowingRenderedLines(rendered, renderWidth))
 			if len(lines) > 0 {
 				return lines
 			}

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -876,6 +876,9 @@ func TestOngoingAskQuestionQuestionTextIsFaintAndNotTruncated(t *testing.T) {
 	if !containsInOrder(plain, "Review the generated", "tail-marker visible?", "└ yes") {
 		t.Fatalf("expected wrapped question content preserved, got %q", plain)
 	}
+	if strings.Contains(plain, "…") {
+		t.Fatalf("expected committed ongoing question text to wrap without ellipsis, got %q", plain)
+	}
 	for _, line := range strings.Split(rendered, "\n") {
 		if width := lipgloss.Width(line); width > 36 {
 			t.Fatalf("expected question line width <= viewport, got %d for %q in %q", width, line, rendered)

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -849,7 +849,7 @@ func TestOngoingAskQuestionsKeepModelOrderAndSeparateToolGroup(t *testing.T) {
 	}
 }
 
-func TestOngoingAskQuestionQuestionTextIsFaintAndNotTruncated(t *testing.T) {
+func TestOngoingAskQuestionQuestionTextWrapsWithoutEllipsis(t *testing.T) {
 	m := NewModel(WithPreviewLines(20), WithTheme("dark"))
 	m = updateModel(t, m, SetViewportSizeMsg{Lines: 20, Width: 36})
 	m = updateModel(t, m, AppendTranscriptMsg{
@@ -870,11 +870,11 @@ func TestOngoingAskQuestionQuestionTextIsFaintAndNotTruncated(t *testing.T) {
 
 	rendered := m.View()
 	plain := plainTranscript(rendered)
-	if !strings.Contains(rendered, "\x1b[2m") {
-		t.Fatalf("expected faint ANSI styling on question text, got %q", rendered)
-	}
 	if !containsInOrder(plain, "Review the generated", "tail-marker visible?", "└ yes") {
 		t.Fatalf("expected wrapped question content preserved, got %q", plain)
+	}
+	if strings.Contains(rendered, "\x1b[2m") {
+		t.Fatalf("did not expect faint ANSI styling on committed question text, got %q", rendered)
 	}
 	if strings.Contains(plain, "…") {
 		t.Fatalf("expected committed ongoing question text to wrap without ellipsis, got %q", plain)
@@ -927,15 +927,15 @@ func TestOngoingAskQuestionMarkdownWrapsWithinViewport(t *testing.T) {
 	}
 }
 
-func TestPendingOngoingAskQuestionsUseQuestionGroupAndFaintQuestionText(t *testing.T) {
+func TestPendingOngoingAskQuestionsUseQuestionGroupAndEllipsizeQuestionText(t *testing.T) {
 	entries := []TranscriptEntry{
 		{
 			Role:       "tool_call",
-			Text:       "First pending question?",
+			Text:       "First pending question keeps going until tail-marker should not fit?",
 			ToolCallID: "call_first",
 			ToolCall: &transcript.ToolCallMeta{
 				ToolName: "ask_question",
-				Question: "First pending question?",
+				Question: "First pending question keeps going until tail-marker should not fit?",
 			},
 		},
 		{
@@ -959,16 +959,19 @@ func TestPendingOngoingAskQuestionsUseQuestionGroupAndFaintQuestionText(t *testi
 		},
 	}
 
-	rendered := RenderPendingOngoingSnapshot(entries, "dark", 80, "*")
+	rendered := RenderPendingOngoingSnapshot(entries, "dark", 42, "*")
 	plain := plainTranscript(rendered)
-	if !containsInOrder(plain, "* First pending question?", "* pwd", "* Second pending question?") {
+	if !containsInOrder(plain, "* First pending question", "* pwd", "* Second pending question?") {
 		t.Fatalf("expected pending questions and tool in model order, got %q", plain)
 	}
 	if got := strings.Count(plain, TranscriptDivider); got != 2 {
 		t.Fatalf("expected pending question/tool/question grouping to place two dividers, got %d in %q", got, plain)
 	}
-	if !strings.Contains(rendered, "\x1b[2m") {
-		t.Fatalf("expected pending question text to be faint, got %q", rendered)
+	if !strings.Contains(plain, "…") || strings.Contains(plain, "tail-marker") {
+		t.Fatalf("expected pending live question text to ellipsize, got %q", plain)
+	}
+	if strings.Contains(rendered, "\x1b[2m") {
+		t.Fatalf("did not expect faint ANSI styling on pending question text, got %q", rendered)
 	}
 }
 

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -6,6 +6,7 @@ import (
 	patchformat "builder/shared/transcript/patchformat"
 	"fmt"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"strings"
 	"testing"
 )
@@ -773,6 +774,198 @@ func TestOngoingAskQuestionRendersSelectedOptionText(t *testing.T) {
 	}
 	if strings.Contains(plain, "option #2") || strings.Contains(plain, "flat scan") {
 		t.Fatalf("expected ongoing answer to omit numeric summary and unchosen suggestions, got %q", plain)
+	}
+}
+
+func TestOngoingAskQuestionPreservesLiteralUserAnsweredPrefix(t *testing.T) {
+	m := NewModel(WithPreviewLines(20))
+	m = updateModel(t, m, AppendTranscriptMsg{
+		Role:       "tool_call",
+		Text:       "What should we do?",
+		ToolCallID: "call_ask",
+		ToolCall: &transcript.ToolCallMeta{
+			ToolName: "ask_question",
+			Question: "What should we do?",
+		},
+	})
+	m = updateModel(t, m, AppendTranscriptMsg{
+		Role:        "tool_result_ok",
+		ToolCallID:  "call_ask",
+		Text:        "User answered: keep going",
+		OngoingText: "User answered: keep going",
+	})
+
+	plain := plainTranscript(m.View())
+	if !containsInOrder(plain, "? What should we do?", "└ User answered: keep going") {
+		t.Fatalf("expected ongoing freeform answer to preserve literal prefix, got %q", plain)
+	}
+	if strings.Contains(plain, "└ keep going") {
+		t.Fatalf("expected ongoing answer not to strip literal prefix, got %q", plain)
+	}
+}
+
+func TestOngoingAskQuestionsKeepModelOrderAndSeparateToolGroup(t *testing.T) {
+	entries := []TranscriptEntry{
+		{
+			Role:       "tool_call",
+			Text:       "First question?",
+			ToolCallID: "call_first",
+			ToolCall: &transcript.ToolCallMeta{
+				ToolName: "ask_question",
+				Question: "First question?",
+			},
+		},
+		{
+			Role:       "tool_call",
+			Text:       "pwd",
+			ToolCallID: "call_shell",
+			ToolCall: &transcript.ToolCallMeta{
+				ToolName: "exec_command",
+				IsShell:  true,
+				Command:  "pwd",
+			},
+		},
+		{
+			Role:       "tool_call",
+			Text:       "Second question?",
+			ToolCallID: "call_second",
+			ToolCall: &transcript.ToolCallMeta{
+				ToolName: "ask_question",
+				Question: "Second question?",
+			},
+		},
+		{Role: "tool_result_ok", ToolCallID: "call_second", Text: "second answer", OngoingText: "second answer"},
+		{Role: "tool_result_ok", ToolCallID: "call_shell", Text: "/tmp", OngoingText: "/tmp"},
+		{Role: "tool_result_ok", ToolCallID: "call_first", Text: "first answer", OngoingText: "first answer"},
+	}
+
+	rendered := ProjectCommittedOngoingTranscript(entries, "dark", 80).Render(TranscriptDivider)
+	plain := plainTranscript(rendered)
+	if !containsInOrder(plain, "? First question?", "└ first answer", "$ pwd", "? Second question?", "└ second answer") {
+		t.Fatalf("expected questions emitted in model tool-call order, got %q", plain)
+	}
+	if got := strings.Count(plain, TranscriptDivider); got != 2 {
+		t.Fatalf("expected question/tool/question grouping to place two dividers around tool block, got %d in %q", got, plain)
+	}
+}
+
+func TestOngoingAskQuestionQuestionTextIsFaintAndNotTruncated(t *testing.T) {
+	m := NewModel(WithPreviewLines(20), WithTheme("dark"))
+	m = updateModel(t, m, SetViewportSizeMsg{Lines: 20, Width: 36})
+	m = updateModel(t, m, AppendTranscriptMsg{
+		Role:       "tool_call",
+		Text:       "Review the generated transcript projection question text and keep tail-marker visible?",
+		ToolCallID: "call_ask",
+		ToolCall: &transcript.ToolCallMeta{
+			ToolName: "ask_question",
+			Question: "Review the generated transcript projection question text and keep tail-marker visible?",
+		},
+	})
+	m = updateModel(t, m, AppendTranscriptMsg{
+		Role:        "tool_result_ok",
+		ToolCallID:  "call_ask",
+		Text:        "yes",
+		OngoingText: "yes",
+	})
+
+	rendered := m.View()
+	plain := plainTranscript(rendered)
+	if !strings.Contains(rendered, "\x1b[2m") {
+		t.Fatalf("expected faint ANSI styling on question text, got %q", rendered)
+	}
+	if !containsInOrder(plain, "Review the generated", "tail-marker visible?", "└ yes") {
+		t.Fatalf("expected wrapped question content preserved, got %q", plain)
+	}
+	for _, line := range strings.Split(rendered, "\n") {
+		if width := lipgloss.Width(line); width > 36 {
+			t.Fatalf("expected question line width <= viewport, got %d for %q in %q", width, line, rendered)
+		}
+	}
+}
+
+func TestOngoingAskQuestionMarkdownWrapsWithinViewport(t *testing.T) {
+	question := strings.Join([]string{
+		"Review **generated plan** and the [design note](https://example.com/really/long/path).",
+		"",
+		"```go",
+		"fmt.Println(\"tail-marker\")",
+		"```",
+	}, "\n")
+	m := NewModel(WithPreviewLines(20), WithTheme("dark"))
+	m = updateModel(t, m, SetViewportSizeMsg{Lines: 20, Width: 42})
+	m = updateModel(t, m, AppendTranscriptMsg{
+		Role:       "tool_call",
+		Text:       question,
+		ToolCallID: "call_ask",
+		ToolCall: &transcript.ToolCallMeta{
+			ToolName: "ask_question",
+			Question: question,
+		},
+	})
+	m = updateModel(t, m, AppendTranscriptMsg{
+		Role:        "tool_result_ok",
+		ToolCallID:  "call_ask",
+		Text:        "approved",
+		OngoingText: "approved",
+	})
+
+	rendered := m.View()
+	plain := plainTranscript(rendered)
+	if strings.Contains(plain, "**generated plan**") || strings.Contains(plain, "```") {
+		t.Fatalf("expected ongoing markdown question rendered without source markers, got %q", plain)
+	}
+	if !containsInOrder(plain, "Review generated plan", "design", "note", "https://example.com/really/long/path.", "fmt.Println(\"tail-marker\")", "└ approved") {
+		t.Fatalf("expected ongoing markdown question content preserved, got %q", plain)
+	}
+	for _, line := range strings.Split(rendered, "\n") {
+		if width := lipgloss.Width(line); width > 42 {
+			t.Fatalf("expected markdown question line width <= viewport, got %d for %q in %q", width, line, rendered)
+		}
+	}
+}
+
+func TestPendingOngoingAskQuestionsUseQuestionGroupAndFaintQuestionText(t *testing.T) {
+	entries := []TranscriptEntry{
+		{
+			Role:       "tool_call",
+			Text:       "First pending question?",
+			ToolCallID: "call_first",
+			ToolCall: &transcript.ToolCallMeta{
+				ToolName: "ask_question",
+				Question: "First pending question?",
+			},
+		},
+		{
+			Role:       "tool_call",
+			Text:       "pwd",
+			ToolCallID: "call_shell",
+			ToolCall: &transcript.ToolCallMeta{
+				ToolName: "exec_command",
+				IsShell:  true,
+				Command:  "pwd",
+			},
+		},
+		{
+			Role:       "tool_call",
+			Text:       "Second pending question?",
+			ToolCallID: "call_second",
+			ToolCall: &transcript.ToolCallMeta{
+				ToolName: "ask_question",
+				Question: "Second pending question?",
+			},
+		},
+	}
+
+	rendered := RenderPendingOngoingSnapshot(entries, "dark", 80, "*")
+	plain := plainTranscript(rendered)
+	if !containsInOrder(plain, "* First pending question?", "* pwd", "* Second pending question?") {
+		t.Fatalf("expected pending questions and tool in model order, got %q", plain)
+	}
+	if got := strings.Count(plain, TranscriptDivider); got != 2 {
+		t.Fatalf("expected pending question/tool/question grouping to place two dividers, got %d in %q", got, plain)
+	}
+	if !strings.Contains(rendered, "\x1b[2m") {
+		t.Fatalf("expected pending question text to be faint, got %q", rendered)
 	}
 }
 

--- a/cli/tui/pending_snapshot.go
+++ b/cli/tui/pending_snapshot.go
@@ -82,8 +82,18 @@ func (m Model) applyPendingSpinner(blocks []ongoingBlock, entries []TranscriptEn
 			out = append(out, block)
 			continue
 		}
+		if block.entryIndex < 0 || block.entryIndex >= len(entries) {
+			out = append(out, block)
+			continue
+		}
 		spinner := spinnerForEntry(entries[block.entryIndex], block.entryIndex)
 		if strings.TrimSpace(spinner) == "" {
+			if isAskQuestionToolCall(entries[block.entryIndex].ToolCall) {
+				if rebuilt, ok := m.renderPendingSpinnerBlock(block, entries, ""); ok {
+					out = append(out, rebuilt)
+					continue
+				}
+			}
 			out = append(out, block)
 			continue
 		}
@@ -108,14 +118,49 @@ func (m Model) renderPendingSpinnerBlock(block ongoingBlock, entries []Transcrip
 	}
 	lines := block.lines
 	if isAskQuestionToolCall(entry.ToolCall) {
-		question, suggestions, recommendedOptionIndex := askQuestionDisplay(entry.ToolCall, entry.Text)
-		lines = m.flattenAskQuestionEntryWithSymbol(block.role, question, suggestions, recommendedOptionIndex, "", false, spinnerSymbol)
+		question, _, _ := askQuestionDisplay(entry.ToolCall, entry.Text)
+		lines = m.flattenPendingAskQuestionEntryWithSymbol(block.role, question, spinnerSymbol)
 	} else {
 		combined := m.toolCallDisplayText(entry, block.role, transcriptBlockOptions{mode: transcriptBlockModeOngoing})
 		lines = m.flattenEntryWithMetaAndSymbol(block.role, combined, true, entry.ToolCall, spinnerSymbol)
 	}
 	lines = m.ongoingToolWithTreeGuideWithSymbol(block.role, lines, spinnerSymbol)
 	return ongoingBlock{role: block.role, lines: lines, entryIndex: block.entryIndex, entryEnd: block.entryEnd}, true
+}
+
+func (m Model) flattenPendingAskQuestionEntryWithSymbol(role RenderIntent, question string, symbolOverride string) []string {
+	renderWidth := m.entryRenderWidth(role, symbolOverride)
+	if renderWidth < 1 {
+		renderWidth = 1
+	}
+	question = strings.TrimSpace(question)
+	if question == "" {
+		question = "ask question"
+	}
+	lines := RenderInlineAskQuestionMarkdownLines(question, m.theme, renderWidth)
+	text := firstNonEmptyLine(lines)
+	if text == "" {
+		text = "ask question"
+	}
+	forceEllipsis := len(lines) > 1
+	text = truncateRenderedLineToWidthWithEllipsis(text, renderWidth, forceEllipsis)
+	prefix := m.entryPrefix(role, symbolOverride)
+	if prefix == "" {
+		return []string{text}
+	}
+	return []string{prefix + text}
+}
+
+func firstNonEmptyLine(lines []string) string {
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			return line
+		}
+	}
+	if len(lines) > 0 {
+		return lines[0]
+	}
+	return ""
 }
 
 func (m Model) shouldRenderPendingSpinner(block ongoingBlock, entries []TranscriptEntry, consumedResults map[int]struct{}, resultIndex toolResultIndex) bool {

--- a/server/tools/askquestion/tool.go
+++ b/server/tools/askquestion/tool.go
@@ -313,7 +313,7 @@ func freeformToolOutputSummary(freeform string) string {
 func buildOngoingToolOutputText(req Request, resp Response) string {
 	freeform := normalizedFreeformAnswer(resp)
 	if resp.SelectedOptionNumber <= 0 {
-		return freeformToolOutputSummary(freeform)
+		return freeform
 	}
 	suggestions := normalizedSuggestions(req.Suggestions)
 	optionIndex := resp.SelectedOptionNumber - 1

--- a/server/tools/askquestion/tool_test.go
+++ b/server/tools/askquestion/tool_test.go
@@ -644,6 +644,39 @@ func TestToolCallSerializesPureFreeformAsPlainText(t *testing.T) {
 	if payload == "" {
 		t.Fatal("expected non-empty plain-text summary")
 	}
+	if result.OngoingText != "need extra context" {
+		t.Fatalf("expected ongoing freeform answer without model prefix, got %q", result.OngoingText)
+	}
+}
+
+func TestToolCallOngoingTextPreservesLiteralUserAnsweredFreeformPrefix(t *testing.T) {
+	b := NewBroker()
+	b.SetAskHandler(func(req Request) (Response, error) {
+		return Response{RequestID: req.ID, FreeformAnswer: "User answered: keep going"}, nil
+	})
+	tl := NewTool(b)
+
+	result, err := tl.Call(context.Background(), tools.Call{
+		ID:    "call-freeform-literal-prefix",
+		Name:  toolspec.ToolAskQuestion,
+		Input: json.RawMessage(`{"question":"What else?"}`),
+	})
+	if err != nil {
+		t.Fatalf("unexpected call error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success result, got %+v", result)
+	}
+	if result.OngoingText != "User answered: keep going" {
+		t.Fatalf("expected ongoing freeform answer to preserve literal prefix, got %q", result.OngoingText)
+	}
+	var payload string
+	if err := json.Unmarshal(result.Output, &payload); err != nil {
+		t.Fatalf("decode tool output: %v", err)
+	}
+	if payload != "User answered: User answered: keep going" {
+		t.Fatalf("expected model-facing payload to keep summary prefix, got %q", payload)
+	}
 }
 
 func TestToolCallAllowsFreeformOnlyWithoutRecommendedOptionIndex(t *testing.T) {


### PR DESCRIPTION
## Summary
- Render ask_question groups separately from other tools in ongoing transcript
- Preserve model-call order for grouped questions and answers
- Render question markdown consistently in ongoing transcript and inline prompts
- Keep inline picker/freeform prompts full and wrapped; ellipsize only pending live-area question previews
- Preserve literal freeform answers and remove faint styling from question text

## Verification
- ./scripts/test.sh ./cli/tui ./cli/app ./server/tools/askquestion
- ./scripts/test.sh ./...
- ./scripts/build.sh --output ./bin/builder
- git diff --check
- git push pre-push hook (format, vet, build, test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ask-question prompts render markdown inline (styled output without raw markers) and use a width-aware renderer to produce wrapped/plain variants.
* **Bug Fixes**
  * Picker and freeform question text now wrap across lines instead of being ellipsized; pending-question previews still truncate with ellipsis.
  * Cursor placement remains correct after markdown expansion.
  * Freeform answers shown without added prefixes.
* **Tests**
  * Added/updated tests covering markdown rendering, wrapping, cursor behavior, and ongoing/pending ask-question UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/respawn-app/builder/pull/259)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->