### PR TITLE
fix: preserve subagent session ownership

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -13,6 +13,7 @@ type Options struct {
 	SessionID                 string
 	WorkspaceContextSessionID string
 	AgentRole                 string
+	AgentRoleSet              bool
 	Model                     string
 	ProviderOverride          string
 	ThinkingLevel             string

--- a/cli/app/internal/runtimeattach/activity.go
+++ b/cli/app/internal/runtimeattach/activity.go
@@ -12,6 +12,7 @@ type ActivityRequest struct {
 	SessionID       string
 	Runtime         servicecontract.SessionRuntimeService
 	LeaseID         string
+	ReadOnly        bool
 	SessionActivity servicecontract.SessionActivityService
 	PromptActivity  servicecontract.PromptActivityService
 }
@@ -23,23 +24,33 @@ type Activities struct {
 
 func SubscribeActivities(ctx context.Context, req ActivityRequest) (Activities, error) {
 	if req.SessionActivity == nil {
-		Release(req.Runtime, req.SessionID, req.LeaseID)
+		releaseIfOwned(req)
 		return Activities{}, errors.New("session activity service is required")
 	}
-	if req.PromptActivity == nil {
-		Release(req.Runtime, req.SessionID, req.LeaseID)
+	if req.PromptActivity == nil && !req.ReadOnly {
+		releaseIfOwned(req)
 		return Activities{}, errors.New("prompt activity service is required")
 	}
 	sessionSub, err := req.SessionActivity.SubscribeSessionActivity(ctx, serverapi.SessionActivitySubscribeRequest{SessionID: req.SessionID})
 	if err != nil {
-		Release(req.Runtime, req.SessionID, req.LeaseID)
+		releaseIfOwned(req)
 		return Activities{}, err
+	}
+	if req.ReadOnly {
+		return Activities{Session: sessionSub}, nil
 	}
 	promptSub, err := req.PromptActivity.SubscribePromptActivity(ctx, serverapi.PromptActivitySubscribeRequest{SessionID: req.SessionID})
 	if err != nil {
 		_ = sessionSub.Close()
-		Release(req.Runtime, req.SessionID, req.LeaseID)
+		releaseIfOwned(req)
 		return Activities{}, err
 	}
 	return Activities{Session: sessionSub, Prompt: promptSub}, nil
+}
+
+func releaseIfOwned(req ActivityRequest) {
+	if req.ReadOnly {
+		return
+	}
+	Release(req.Runtime, req.SessionID, req.LeaseID)
 }

--- a/cli/app/internal/runtimeattach/activity_test.go
+++ b/cli/app/internal/runtimeattach/activity_test.go
@@ -116,3 +116,38 @@ func TestSubscribeActivitiesClosesSessionSubscriptionAndReleasesLeaseOnPromptFai
 		t.Fatalf("release requests = %d, want 1", len(runtime.releaseRequests))
 	}
 }
+
+func TestSubscribeActivitiesDoesNotReleaseReadOnlyAttachOnFailure(t *testing.T) {
+	runtime := &fakeRuntimeService{}
+	_, err := SubscribeActivities(context.Background(), ActivityRequest{
+		SessionID:       "session-1",
+		Runtime:         runtime,
+		ReadOnly:        true,
+		SessionActivity: &fakeSessionActivityService{err: errors.New("session subscribe failed")},
+		PromptActivity:  &fakePromptActivityService{sub: fakePromptActivitySubscription{}},
+	})
+	if err == nil {
+		t.Fatal("expected subscribe failure")
+	}
+	if len(runtime.releaseRequests) != 0 {
+		t.Fatalf("release requests = %d, want none for read-only attach", len(runtime.releaseRequests))
+	}
+}
+
+func TestSubscribeActivitiesReadOnlyDoesNotRequirePromptActivity(t *testing.T) {
+	sessionSub := &fakeSessionActivitySubscription{}
+	activities, err := SubscribeActivities(context.Background(), ActivityRequest{
+		SessionID:       "session-1",
+		ReadOnly:        true,
+		SessionActivity: &fakeSessionActivityService{sub: sessionSub},
+	})
+	if err != nil {
+		t.Fatalf("SubscribeActivities: %v", err)
+	}
+	if activities.Session != sessionSub {
+		t.Fatal("expected session subscription")
+	}
+	if activities.Prompt != nil {
+		t.Fatal("expected no prompt subscription for read-only attach")
+	}
+}

--- a/cli/app/internal/runtimeattach/lease.go
+++ b/cli/app/internal/runtimeattach/lease.go
@@ -16,6 +16,7 @@ import (
 const ReleaseTimeout = 3 * time.Second
 
 var ErrEmptyControllerLease = errors.New("session runtime activation returned empty controller lease id")
+var ErrReadOnlyControllerLease = errors.New("session runtime activation switched to read-only mode")
 
 type Request struct {
 	SessionID          string
@@ -52,6 +53,9 @@ func Activate(ctx context.Context, service servicecontract.SessionRuntimeService
 			resp, err := service.ActivateSessionRuntime(ctx, activateRequest(req))
 			if err != nil {
 				return "", err
+			}
+			if resp.ReadOnly {
+				return "", ErrReadOnlyControllerLease
 			}
 			return normalizeLeaseID(resp.LeaseID)
 		},

--- a/cli/app/internal/runtimeattach/lease.go
+++ b/cli/app/internal/runtimeattach/lease.go
@@ -26,8 +26,9 @@ type Request struct {
 }
 
 type Lease struct {
-	ID      string
-	Recover func(context.Context) (string, error)
+	ID       string
+	ReadOnly bool
+	Recover  func(context.Context) (string, error)
 }
 
 func Activate(ctx context.Context, service servicecontract.SessionRuntimeService, req Request) (Lease, error) {
@@ -37,6 +38,9 @@ func Activate(ctx context.Context, service servicecontract.SessionRuntimeService
 	resp, err := service.ActivateSessionRuntime(ctx, activateRequest(req))
 	if err != nil {
 		return Lease{}, err
+	}
+	if resp.ReadOnly {
+		return Lease{ReadOnly: true}, nil
 	}
 	leaseID, err := normalizeLeaseID(resp.LeaseID)
 	if err != nil {

--- a/cli/app/internal/runtimeattach/lease_test.go
+++ b/cli/app/internal/runtimeattach/lease_test.go
@@ -89,6 +89,21 @@ func TestActivateRecoverReactivatesRuntimeWithFreshRequestID(t *testing.T) {
 	}
 }
 
+func TestActivateRecoverReportsReadOnlyTransition(t *testing.T) {
+	service := &fakeRuntimeService{activateResponses: []serverapi.SessionRuntimeActivateResponse{{LeaseID: "lease-1"}, {ReadOnly: true}}}
+	lease, err := Activate(context.Background(), service, Request{
+		SessionID:          "session-1",
+		NewClientRequestID: fixedIDs("request-1", "request-2"),
+	})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	_, err = lease.Recover(context.Background())
+	if !errors.Is(err, ErrReadOnlyControllerLease) {
+		t.Fatalf("Recover error = %v, want read-only transition", err)
+	}
+}
+
 func TestActivateRejectsEmptyLease(t *testing.T) {
 	service := &fakeRuntimeService{activateResponses: []serverapi.SessionRuntimeActivateResponse{{LeaseID: " "}}}
 	_, err := Activate(context.Background(), service, Request{NewClientRequestID: fixedIDs("request-1")})

--- a/cli/app/internal/runtimeattach/lease_test.go
+++ b/cli/app/internal/runtimeattach/lease_test.go
@@ -97,6 +97,20 @@ func TestActivateRejectsEmptyLease(t *testing.T) {
 	}
 }
 
+func TestActivateAcceptsReadOnlyWithoutLease(t *testing.T) {
+	service := &fakeRuntimeService{activateResponses: []serverapi.SessionRuntimeActivateResponse{{ReadOnly: true}}}
+	lease, err := Activate(context.Background(), service, Request{NewClientRequestID: fixedIDs("request-1")})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if !lease.ReadOnly {
+		t.Fatal("expected read-only lease")
+	}
+	if lease.ID != "" {
+		t.Fatalf("lease id = %q, want empty", lease.ID)
+	}
+}
+
 func TestReleaseSkipsNilOrEmptyLeaseAndIgnoresReleaseError(t *testing.T) {
 	Release(nil, "session-1", "lease-1")
 	service := &fakeRuntimeService{releaseErr: errors.New("release failed")}

--- a/cli/app/internal/worktreemutation/service.go
+++ b/cli/app/internal/worktreemutation/service.go
@@ -102,6 +102,9 @@ func (s Service) Delete(worktreeID string, deleteBranch bool) (serverapi.Worktre
 
 func runMutation[T any](s Service, call func(context.Context, string) (T, error)) (T, error) {
 	var zero T
+	if s.Runtime.ReadOnly != nil && s.Runtime.ReadOnly() {
+		return zero, ErrReadOnlyRuntime
+	}
 	ctx, cancel, _, err := s.controlContextWithLease()
 	if err != nil {
 		return zero, err
@@ -118,9 +121,6 @@ func (s Service) controlContextWithLease() (context.Context, context.CancelFunc,
 	}
 	if s.Runtime.Context == nil || s.Runtime.CurrentLeaseID == nil || s.Runtime.RecoverLease == nil {
 		return nil, nil, "", ErrControllerLeaseUnavailable
-	}
-	if s.Runtime.ReadOnly != nil && s.Runtime.ReadOnly() {
-		return nil, nil, "", ErrReadOnlyRuntime
 	}
 	ctx, cancel := s.Runtime.Context()
 	if ctx == nil || cancel == nil {

--- a/cli/app/internal/worktreemutation/service.go
+++ b/cli/app/internal/worktreemutation/service.go
@@ -36,6 +36,10 @@ type Service struct {
 }
 
 func (s Service) List(includeDirtyCount bool) (serverapi.WorktreeListResponse, error) {
+	if s.Runtime.ReadOnly != nil && s.Runtime.ReadOnly() {
+		// Server-side listing syncs workspace metadata under the controller lease.
+		return serverapi.WorktreeListResponse{}, ErrReadOnlyRuntime
+	}
 	ctx, cancel, leaseID, err := s.controlContextWithLease()
 	if err != nil {
 		return serverapi.WorktreeListResponse{}, err

--- a/cli/app/internal/worktreemutation/service.go
+++ b/cli/app/internal/worktreemutation/service.go
@@ -17,12 +17,14 @@ const defaultResolveTimeout = 3 * time.Second
 var (
 	ErrClientUnavailable          = errors.New("worktree client is unavailable")
 	ErrControllerLeaseUnavailable = errors.New("controller lease is unavailable")
+	ErrReadOnlyRuntime            = errors.New("runtime is read-only")
 )
 
 type RuntimeControl struct {
 	Context        func() (context.Context, context.CancelFunc)
 	CurrentLeaseID func() string
 	RecoverLease   func(context.Context, error) error
+	ReadOnly       func() bool
 }
 
 type Service struct {
@@ -116,6 +118,9 @@ func (s Service) controlContextWithLease() (context.Context, context.CancelFunc,
 	}
 	if s.Runtime.Context == nil || s.Runtime.CurrentLeaseID == nil || s.Runtime.RecoverLease == nil {
 		return nil, nil, "", ErrControllerLeaseUnavailable
+	}
+	if s.Runtime.ReadOnly != nil && s.Runtime.ReadOnly() {
+		return nil, nil, "", ErrReadOnlyRuntime
 	}
 	ctx, cancel := s.Runtime.Context()
 	if ctx == nil || cancel == nil {

--- a/cli/app/internal/worktreemutation/service_test.go
+++ b/cli/app/internal/worktreemutation/service_test.go
@@ -188,6 +188,23 @@ func TestReadOnlyRuntimeControlRejectsMutationsBeforeRPC(t *testing.T) {
 	}
 }
 
+func TestReadOnlyRuntimeControlAllowsList(t *testing.T) {
+	client := &testWorktreeClient{listResp: serverapi.WorktreeListResponse{Target: clientui.SessionExecutionTarget{EffectiveWorkdir: "/repo"}}}
+	service := newTestService(client)
+	service.Runtime.ReadOnly = func() bool { return true }
+
+	resp, err := service.List(false)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if resp.Target.EffectiveWorkdir != "/repo" {
+		t.Fatalf("target = %+v, want /repo", resp.Target)
+	}
+	if len(client.listRequests) != 1 {
+		t.Fatalf("list requests = %+v, want one", client.listRequests)
+	}
+}
+
 func newTestService(client *testWorktreeClient) Service {
 	return Service{
 		Client:    client,

--- a/cli/app/internal/worktreemutation/service_test.go
+++ b/cli/app/internal/worktreemutation/service_test.go
@@ -188,20 +188,16 @@ func TestReadOnlyRuntimeControlRejectsMutationsBeforeRPC(t *testing.T) {
 	}
 }
 
-func TestReadOnlyRuntimeControlAllowsList(t *testing.T) {
-	client := &testWorktreeClient{listResp: serverapi.WorktreeListResponse{Target: clientui.SessionExecutionTarget{EffectiveWorkdir: "/repo"}}}
+func TestReadOnlyRuntimeControlRejectsListBeforeRPC(t *testing.T) {
+	client := &testWorktreeClient{}
 	service := newTestService(client)
 	service.Runtime.ReadOnly = func() bool { return true }
 
-	resp, err := service.List(false)
-	if err != nil {
-		t.Fatalf("List: %v", err)
+	if _, err := service.List(false); !errors.Is(err, ErrReadOnlyRuntime) {
+		t.Fatalf("List error = %v, want ErrReadOnlyRuntime", err)
 	}
-	if resp.Target.EffectiveWorkdir != "/repo" {
-		t.Fatalf("target = %+v, want /repo", resp.Target)
-	}
-	if len(client.listRequests) != 1 {
-		t.Fatalf("list requests = %+v, want one", client.listRequests)
+	if len(client.listRequests) != 0 {
+		t.Fatalf("list requests = %d, want none", len(client.listRequests))
 	}
 }
 

--- a/cli/app/internal/worktreemutation/service_test.go
+++ b/cli/app/internal/worktreemutation/service_test.go
@@ -175,6 +175,19 @@ func TestMissingRuntimeControlReturnsLeaseUnavailable(t *testing.T) {
 	}
 }
 
+func TestReadOnlyRuntimeControlRejectsMutationsBeforeRPC(t *testing.T) {
+	client := &testWorktreeClient{}
+	service := newTestService(client)
+	service.Runtime.ReadOnly = func() bool { return true }
+
+	if _, err := service.Switch("wt-1"); !errors.Is(err, ErrReadOnlyRuntime) {
+		t.Fatalf("Switch error = %v, want ErrReadOnlyRuntime", err)
+	}
+	if len(client.switchRequests) != 0 {
+		t.Fatalf("switch requests = %d, want none", len(client.switchRequests))
+	}
+}
+
 func newTestService(client *testWorktreeClient) Service {
 	return Service{
 		Client:    client,

--- a/cli/app/launch_planner.go
+++ b/cli/app/launch_planner.go
@@ -60,6 +60,7 @@ type runtimeLaunchPlan struct {
 	Logger            *runLogger
 	Wiring            *runtimeWiring
 	ControllerLeaseID string
+	ReadOnly          bool
 	controllerLease   *controllerLeaseManager
 	close             func()
 }

--- a/cli/app/run_prompt.go
+++ b/cli/app/run_prompt.go
@@ -46,6 +46,7 @@ func runPrompt(ctx context.Context, client client.RunPromptClient, opts Options,
 func runPromptOverridesFromOptions(opts Options) serverapi.RunPromptOverrides {
 	return serverapi.RunPromptOverrides{
 		AgentRole:           strings.TrimSpace(opts.AgentRole),
+		AgentRoleSet:        opts.AgentRoleSet,
 		Model:               strings.TrimSpace(opts.Model),
 		ProviderOverride:    strings.TrimSpace(opts.ProviderOverride),
 		ThinkingLevel:       strings.TrimSpace(opts.ThinkingLevel),

--- a/cli/app/runtime_attachment.go
+++ b/cli/app/runtime_attachment.go
@@ -54,11 +54,14 @@ func prepareSharedRuntime(ctx context.Context, source runtimeAttachmentSource, p
 		Logger:            logger,
 		Wiring:            wiring,
 		ControllerLeaseID: lease.ID,
+		ReadOnly:          lease.ReadOnly,
 		controllerLease:   leaseManager,
 		close: func() {
 			stopAskEvents()
 			stopRuntimeEvents()
-			runtimeattach.Release(clients.SessionRuntime, plan.SessionID, leaseManager.Value())
+			if !lease.ReadOnly {
+				runtimeattach.Release(clients.SessionRuntime, plan.SessionID, leaseManager.Value())
+			}
 		},
 	}, nil
 }
@@ -73,6 +76,9 @@ func activateSharedRuntime(ctx context.Context, clients runtimeAttachmentClients
 	if err != nil {
 		return runtimeattach.Lease{}, nil, err
 	}
+	if lease.ReadOnly {
+		return lease, nil, nil
+	}
 	leaseManager := newControllerLeaseManager(lease.ID)
 	leaseManager.SetRecoverFunc(lease.Recover)
 	return lease, leaseManager, nil
@@ -83,6 +89,7 @@ func subscribeSharedRuntimeActivities(ctx context.Context, clients runtimeAttach
 		SessionID:       sessionID,
 		Runtime:         clients.SessionRuntime,
 		LeaseID:         leaseID,
+		ReadOnly:        strings.TrimSpace(leaseID) == "",
 		SessionActivity: clients.SessionActivity,
 		PromptActivity:  clients.PromptActivity,
 	})
@@ -90,7 +97,11 @@ func subscribeSharedRuntimeActivities(ctx context.Context, clients runtimeAttach
 
 func prepareSharedRuntimeWiring(ctx context.Context, clients runtimeAttachmentClients, plan sessionLaunchPlan, activities runtimeattach.Activities, leaseManager *controllerLeaseManager, logger *runLogger) (*runtimeWiring, func(), func()) {
 	runtimeClient := newUIRuntimeClientWithReads(plan.SessionID, clients.SessionViews, clients.RuntimeControls).(*sessionRuntimeClient)
-	runtimeClient.SetControllerLeaseManager(leaseManager)
+	if leaseManager != nil {
+		runtimeClient.SetControllerLeaseManager(leaseManager)
+	} else {
+		runtimeClient.SetReadOnly(true)
+	}
 	runtimeClient.SetTranscriptDiagnosticsEnabled(transcriptdiag.EnabledForProcess(plan.ActiveSettings.Debug))
 	runtimeEvents, stopRuntimeEvents := startSessionActivityEvents(ctx, activities.Session, func(ctx context.Context, afterSequence uint64) (serverapi.SessionActivitySubscription, error) {
 		return clients.SessionActivity.SubscribeSessionActivity(ctx, serverapi.SessionActivitySubscribeRequest{SessionID: plan.SessionID, AfterSequence: afterSequence})
@@ -106,9 +117,12 @@ func prepareSharedRuntimeWiring(ctx context.Context, clients runtimeAttachmentCl
 		}
 		return strings.TrimSpace(plan.SessionName)
 	}, terminalFocus.FocusedForAttention)
-	askEvents, stopAskEvents := startPendingPromptEvents(ctx, activities.Prompt, func(ctx context.Context, afterSequence uint64) (serverapi.PromptActivitySubscription, error) {
-		return clients.PromptActivity.SubscribePromptActivity(ctx, serverapi.PromptActivitySubscribeRequest{SessionID: plan.SessionID, AfterSequence: afterSequence})
-	}, clients.PromptControl, leaseManager)
+	askEvents, stopAskEvents := newClosedAskEventStream()
+	if leaseManager != nil && activities.Prompt != nil {
+		askEvents, stopAskEvents = startPendingPromptEvents(ctx, activities.Prompt, func(ctx context.Context, afterSequence uint64) (serverapi.PromptActivitySubscription, error) {
+			return clients.PromptActivity.SubscribePromptActivity(ctx, serverapi.PromptActivitySubscribeRequest{SessionID: plan.SessionID, AfterSequence: afterSequence})
+		}, clients.PromptControl, leaseManager)
+	}
 	wiring := &runtimeWiring{
 		runtimeEvents:         runtimeEvents,
 		askEvents:             askEvents,
@@ -130,4 +144,10 @@ func prepareSharedRuntimeWiring(ctx context.Context, clients runtimeAttachmentCl
 		hasOtherSessionsKnown: plan.HasOtherSessionsKnown,
 	}
 	return wiring, stopRuntimeEvents, stopAskEvents
+}
+
+func newClosedAskEventStream() (<-chan askEvent, func()) {
+	ch := make(chan askEvent)
+	close(ch)
+	return ch, func() {}
 }

--- a/cli/app/runtime_attachment_test.go
+++ b/cli/app/runtime_attachment_test.go
@@ -146,6 +146,49 @@ func TestRuntimeAttachmentCloseReleasesRuntime(t *testing.T) {
 	}
 }
 
+func TestRuntimeAttachmentReadOnlyCloseDoesNotReleaseRuntime(t *testing.T) {
+	releaseCount := 0
+	server := runtimeAttachmentTestServer{
+		runtime: &recordingSessionRuntimeClient{
+			activate: func(context.Context, serverapi.SessionRuntimeActivateRequest) (serverapi.SessionRuntimeActivateResponse, error) {
+				return serverapi.SessionRuntimeActivateResponse{ReadOnly: true}, nil
+			},
+			release: func(context.Context, serverapi.SessionRuntimeReleaseRequest) (serverapi.SessionRuntimeReleaseResponse, error) {
+				releaseCount++
+				return serverapi.SessionRuntimeReleaseResponse{}, nil
+			},
+		},
+		sessionEvents: &recordingSessionActivityClient{
+			subscribe: func(context.Context, serverapi.SessionActivitySubscribeRequest) (serverapi.SessionActivitySubscription, error) {
+				return noOpSessionActivitySubscription{}, nil
+			},
+		},
+		promptEvents: &recordingPromptActivityClient{
+			subscribe: func(context.Context, serverapi.PromptActivitySubscribeRequest) (serverapi.PromptActivitySubscription, error) {
+				t.Fatal("read-only attach should not subscribe to prompt control stream")
+				return nil, nil
+			},
+		},
+		sessionViews:   &countingSessionViewClient{},
+		runtimeControl: &leaseRetryRuntimeControlClient{},
+	}
+
+	plan, err := prepareSharedRuntime(context.Background(), server, sessionLaunchPlan{SessionID: "session-readonly"}, io.Discard, "test")
+	if err != nil {
+		t.Fatalf("prepareSharedRuntime: %v", err)
+	}
+	if !plan.ReadOnly {
+		t.Fatal("expected read-only runtime plan")
+	}
+	if _, err := plan.Wiring.runtimeClient.SubmitUserMessage(context.Background(), "hello"); !errors.Is(err, errReadOnlyRuntime) {
+		t.Fatalf("SubmitUserMessage error = %v, want read-only runtime", err)
+	}
+	plan.Close()
+	if releaseCount != 0 {
+		t.Fatalf("release count = %d, want none for read-only attach", releaseCount)
+	}
+}
+
 func TestRuntimeAttachmentLeaseRecoveryUsesActivation(t *testing.T) {
 	activateCalls := 0
 	server := runtimeAttachmentTestServer{

--- a/cli/app/session_lifecycle.go
+++ b/cli/app/session_lifecycle.go
@@ -143,7 +143,12 @@ func runSessionLifecycle(ctx context.Context, server interactiveSessionServer, i
 			runtimePlan.Close()
 			return nil
 		}
-		resolved, err := resolveSessionAction(ctx, server, interactor, plan.SessionID, runtimePlan.CurrentControllerLeaseID(), transition)
+		var resolved resolvedSessionAction
+		if runtimePlan.ReadOnly {
+			resolved, err = resolveReadOnlySessionAction(transition)
+		} else {
+			resolved, err = resolveSessionAction(ctx, server, interactor, plan.SessionID, runtimePlan.CurrentControllerLeaseID(), transition)
+		}
 		runtimePlan.Close()
 		if err != nil {
 			return err
@@ -218,6 +223,30 @@ type resolvedSessionAction struct {
 	ParentSessionID string
 	ForceNewSession bool
 	ShouldContinue  bool
+}
+
+func resolveReadOnlySessionAction(transition UITransition) (resolvedSessionAction, error) {
+	switch transition.Action {
+	case UIActionNewSession:
+		return resolvedSessionAction{
+			InitialPrompt:   transition.InitialPrompt,
+			ParentSessionID: transition.ParentSessionID,
+			ForceNewSession: true,
+			ShouldContinue:  true,
+		}, nil
+	case UIActionResume:
+		return resolvedSessionAction{ShouldContinue: true}, nil
+	case UIActionOpenSession:
+		return resolvedSessionAction{
+			NextSessionID:  transition.TargetSessionID,
+			InitialInput:   transition.InitialInput,
+			ShouldContinue: true,
+		}, nil
+	case UIActionExit, "":
+		return resolvedSessionAction{}, nil
+	default:
+		return resolvedSessionAction{}, errReadOnlyRuntime
+	}
 }
 
 func resolveSessionAction(ctx context.Context, server sessionTransitionServer, interactor authInteractor, sessionID string, controllerLeaseID string, transition UITransition) (resolvedSessionAction, error) {

--- a/cli/app/session_lifecycle.go
+++ b/cli/app/session_lifecycle.go
@@ -197,6 +197,9 @@ func persistSessionDraftToServer(ctx context.Context, server sessionDraftPersist
 	if strings.TrimSpace(sessionID) == "" {
 		return nil
 	}
+	if strings.TrimSpace(controllerLeaseID) == "" {
+		return nil
+	}
 	ui, ok := model.(*uiModel)
 	if !ok || ui == nil {
 		return nil

--- a/cli/app/session_lifecycle.go
+++ b/cli/app/session_lifecycle.go
@@ -145,7 +145,7 @@ func runSessionLifecycle(ctx context.Context, server interactiveSessionServer, i
 		}
 		var resolved resolvedSessionAction
 		if runtimePlan.ReadOnly {
-			resolved, err = resolveReadOnlySessionAction(transition)
+			resolved, err = resolveReadOnlySessionAction(ctx, server, interactor, plan.SessionID, transition)
 		} else {
 			resolved, err = resolveSessionAction(ctx, server, interactor, plan.SessionID, runtimePlan.CurrentControllerLeaseID(), transition)
 		}
@@ -225,7 +225,7 @@ type resolvedSessionAction struct {
 	ShouldContinue  bool
 }
 
-func resolveReadOnlySessionAction(transition UITransition) (resolvedSessionAction, error) {
+func resolveReadOnlySessionAction(ctx context.Context, server sessionTransitionServer, interactor authInteractor, sessionID string, transition UITransition) (resolvedSessionAction, error) {
 	switch transition.Action {
 	case UIActionNewSession:
 		return resolvedSessionAction{
@@ -242,6 +242,14 @@ func resolveReadOnlySessionAction(transition UITransition) (resolvedSessionActio
 			InitialInput:   transition.InitialInput,
 			ShouldContinue: true,
 		}, nil
+	case UIActionLogout:
+		if server == nil {
+			return resolvedSessionAction{}, errors.New("session lifecycle client is required")
+		}
+		if err := server.Reauthenticate(ctx, interactor); err != nil {
+			return resolvedSessionAction{}, err
+		}
+		return resolvedSessionAction{NextSessionID: strings.TrimSpace(sessionID), ShouldContinue: true}, nil
 	case UIActionExit, "":
 		return resolvedSessionAction{}, nil
 	default:

--- a/cli/app/session_lifecycle_test.go
+++ b/cli/app/session_lifecycle_test.go
@@ -634,7 +634,7 @@ func TestResolveReadOnlySessionActionHandlesPureNavigationLocally(t *testing.T) 
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolveReadOnlySessionAction(tt.in)
+			got, err := resolveReadOnlySessionAction(context.Background(), nil, nil, "session-1", tt.in)
 			if err != nil {
 				t.Fatalf("resolveReadOnlySessionAction: %v", err)
 			}
@@ -646,9 +646,34 @@ func TestResolveReadOnlySessionActionHandlesPureNavigationLocally(t *testing.T) 
 }
 
 func TestResolveReadOnlySessionActionRejectsRollbackFork(t *testing.T) {
-	_, err := resolveReadOnlySessionAction(UITransition{Action: UIActionForkRollback})
+	_, err := resolveReadOnlySessionAction(context.Background(), nil, nil, "session-1", UITransition{Action: UIActionForkRollback})
 	if !errors.Is(err, errReadOnlyRuntime) {
 		t.Fatalf("error = %v, want read-only runtime", err)
+	}
+}
+
+func TestResolveReadOnlySessionActionLogoutReauthenticatesWithoutLease(t *testing.T) {
+	reauthCalls := 0
+	resolved, err := resolveReadOnlySessionAction(
+		context.Background(),
+		narrowSessionLifecycleServer{
+			reauthenticate: func(context.Context, authInteractor) error {
+				reauthCalls++
+				return nil
+			},
+		},
+		nil,
+		"session-1",
+		UITransition{Action: UIActionLogout},
+	)
+	if err != nil {
+		t.Fatalf("resolveReadOnlySessionAction logout: %v", err)
+	}
+	if reauthCalls != 1 {
+		t.Fatalf("reauth calls = %d, want 1", reauthCalls)
+	}
+	if !resolved.ShouldContinue || resolved.NextSessionID != "session-1" {
+		t.Fatalf("resolved = %+v, want continue same session", resolved)
 	}
 }
 

--- a/cli/app/session_lifecycle_test.go
+++ b/cli/app/session_lifecycle_test.go
@@ -610,6 +610,48 @@ func TestResolveSessionActionResumeReopensPicker(t *testing.T) {
 	}
 }
 
+func TestResolveReadOnlySessionActionHandlesPureNavigationLocally(t *testing.T) {
+	tests := []struct {
+		name string
+		in   UITransition
+		want resolvedSessionAction
+	}{
+		{
+			name: "new session",
+			in:   UITransition{Action: UIActionNewSession, InitialPrompt: "start", ParentSessionID: "parent-1"},
+			want: resolvedSessionAction{InitialPrompt: "start", ParentSessionID: "parent-1", ForceNewSession: true, ShouldContinue: true},
+		},
+		{
+			name: "resume picker",
+			in:   UITransition{Action: UIActionResume},
+			want: resolvedSessionAction{ShouldContinue: true},
+		},
+		{
+			name: "open session",
+			in:   UITransition{Action: UIActionOpenSession, TargetSessionID: "next-1", InitialInput: "draft"},
+			want: resolvedSessionAction{NextSessionID: "next-1", InitialInput: "draft", ShouldContinue: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveReadOnlySessionAction(tt.in)
+			if err != nil {
+				t.Fatalf("resolveReadOnlySessionAction: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolved = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveReadOnlySessionActionRejectsRollbackFork(t *testing.T) {
+	_, err := resolveReadOnlySessionAction(UITransition{Action: UIActionForkRollback})
+	if !errors.Is(err, errReadOnlyRuntime) {
+		t.Fatalf("error = %v, want read-only runtime", err)
+	}
+}
+
 func TestResolveSessionActionExitStaysClientLocal(t *testing.T) {
 	resolved, err := resolveSessionAction(
 		context.Background(),

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -51,13 +51,20 @@ func (c *sessionRuntimeClient) ensureWritable() error {
 	if c == nil {
 		return errReadOnlyRuntime
 	}
-	c.mu.RLock()
-	readOnly := c.readOnly
-	c.mu.RUnlock()
-	if readOnly {
+	if c.isReadOnly() {
 		return errReadOnlyRuntime
 	}
 	return nil
+}
+
+func (c *sessionRuntimeClient) isReadOnly() bool {
+	if c == nil {
+		return true
+	}
+	c.mu.RLock()
+	readOnly := c.readOnly
+	c.mu.RUnlock()
+	return readOnly
 }
 
 func newRuntimeClient(sessionID string, reads client.SessionViewClient, controls client.RuntimeControlClient) clientui.RuntimeClient {

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -19,6 +19,7 @@ const uiRuntimeHydrationReadTimeout = 10 * time.Second
 const runtimeLeaseRecoveryWarningText = "Lost connection to the session runtime; reconnected."
 
 var uiRuntimeReadTimeout = 300 * time.Millisecond
+var errReadOnlyRuntime = errors.New("session is read-only because it is controlled by an active headless run")
 
 type sessionRuntimeClient struct {
 	reads                   client.SessionViewClient
@@ -29,11 +30,34 @@ type sessionRuntimeClient struct {
 	transcriptDiagnostics   bool
 	connectionStateObserver func(error)
 	leaseRecoveryWarning    func(string, clientui.EntryVisibility)
+	readOnly                bool
 
 	mu                   sync.RWMutex
 	mainView             clientui.RuntimeMainView
 	hasMainView          bool
 	suffixRPCUnsupported bool
+}
+
+func (c *sessionRuntimeClient) SetReadOnly(readOnly bool) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.readOnly = readOnly
+	c.mu.Unlock()
+}
+
+func (c *sessionRuntimeClient) ensureWritable() error {
+	if c == nil {
+		return errReadOnlyRuntime
+	}
+	c.mu.RLock()
+	readOnly := c.readOnly
+	c.mu.RUnlock()
+	if readOnly {
+		return errReadOnlyRuntime
+	}
+	return nil
 }
 
 func newRuntimeClient(sessionID string, reads client.SessionViewClient, controls client.RuntimeControlClient) clientui.RuntimeClient {

--- a/cli/app/ui_runtime_client_control.go
+++ b/cli/app/ui_runtime_client_control.go
@@ -10,6 +10,9 @@ import (
 )
 
 func (c *sessionRuntimeClient) SetSessionName(name string) error {
+	if err := c.ensureWritable(); err != nil {
+		return err
+	}
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	if err := c.retryControlCallNoResult(ctx, func(controllerLeaseID string) error {
@@ -24,6 +27,9 @@ func (c *sessionRuntimeClient) SetSessionName(name string) error {
 }
 
 func (c *sessionRuntimeClient) SetThinkingLevel(level string) error {
+	if err := c.ensureWritable(); err != nil {
+		return err
+	}
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	if err := c.retryControlCallNoResult(ctx, func(controllerLeaseID string) error {
@@ -38,6 +44,9 @@ func (c *sessionRuntimeClient) SetThinkingLevel(level string) error {
 }
 
 func (c *sessionRuntimeClient) SetFastModeEnabled(enabled bool) (bool, error) {
+	if err := c.ensureWritable(); err != nil {
+		return false, err
+	}
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	resp, err := retryRuntimeControlCall(ctx, c.controllerLeaseIDValue, c.recoverControllerLease, func(controllerLeaseID string) (serverapi.RuntimeSetFastModeEnabledResponse, error) {
@@ -52,6 +61,9 @@ func (c *sessionRuntimeClient) SetFastModeEnabled(enabled bool) (bool, error) {
 }
 
 func (c *sessionRuntimeClient) SetReviewerEnabled(enabled bool) (bool, string, error) {
+	if err := c.ensureWritable(); err != nil {
+		return false, "", err
+	}
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	resp, err := retryRuntimeControlCall(ctx, c.controllerLeaseIDValue, c.recoverControllerLease, func(controllerLeaseID string) (serverapi.RuntimeSetReviewerEnabledResponse, error) {
@@ -67,6 +79,9 @@ func (c *sessionRuntimeClient) SetReviewerEnabled(enabled bool) (bool, string, e
 }
 
 func (c *sessionRuntimeClient) SetAutoCompactionEnabled(enabled bool) (bool, bool, error) {
+	if err := c.ensureWritable(); err != nil {
+		return false, false, err
+	}
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	resp, err := retryRuntimeControlCall(ctx, c.controllerLeaseIDValue, c.recoverControllerLease, func(controllerLeaseID string) (serverapi.RuntimeSetAutoCompactionEnabledResponse, error) {
@@ -98,6 +113,9 @@ func (c *sessionRuntimeClient) ShowGoal() (*clientui.RuntimeGoal, error) {
 }
 
 func (c *sessionRuntimeClient) SetGoal(objective string) (*clientui.RuntimeGoal, error) {
+	if err := c.ensureWritable(); err != nil {
+		return nil, err
+	}
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	resp, err := retryRuntimeControlCall(ctx, c.controllerLeaseIDValue, c.recoverControllerLease, func(controllerLeaseID string) (serverapi.RuntimeGoalShowResponse, error) {
@@ -126,6 +144,9 @@ func (c *sessionRuntimeClient) ResumeGoal() (*clientui.RuntimeGoal, error) {
 }
 
 func (c *sessionRuntimeClient) ClearGoal() (*clientui.RuntimeGoal, error) {
+	if err := c.ensureWritable(); err != nil {
+		return nil, err
+	}
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	resp, err := retryRuntimeControlCall(ctx, c.controllerLeaseIDValue, c.recoverControllerLease, func(controllerLeaseID string) (serverapi.RuntimeGoalShowResponse, error) {
@@ -142,6 +163,9 @@ func (c *sessionRuntimeClient) ClearGoal() (*clientui.RuntimeGoal, error) {
 }
 
 func (c *sessionRuntimeClient) setGoalStatus(call func(context.Context, serverapi.RuntimeGoalStatusRequest) (serverapi.RuntimeGoalShowResponse, error)) (*clientui.RuntimeGoal, error) {
+	if err := c.ensureWritable(); err != nil {
+		return nil, err
+	}
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	resp, err := retryRuntimeControlCall(ctx, c.controllerLeaseIDValue, c.recoverControllerLease, func(controllerLeaseID string) (serverapi.RuntimeGoalShowResponse, error) {
@@ -182,6 +206,9 @@ func (c *sessionRuntimeClient) AppendLocalEntry(role, text string) error {
 }
 
 func (c *sessionRuntimeClient) AppendLocalEntryWithNoticeID(role, text, noticeID string) error {
+	if err := c.ensureWritable(); err != nil {
+		return err
+	}
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	return c.retryControlCallNoResult(ctx, func(controllerLeaseID string) error {
@@ -190,6 +217,9 @@ func (c *sessionRuntimeClient) AppendLocalEntryWithNoticeID(role, text, noticeID
 }
 
 func (c *sessionRuntimeClient) SubmitUserMessage(ctx context.Context, text string) (string, error) {
+	if err := c.ensureWritable(); err != nil {
+		return "", err
+	}
 	resp, err := retryRuntimeControlCall(ctx, c.controllerLeaseIDValue, c.recoverControllerLease, func(controllerLeaseID string) (serverapi.RuntimeSubmitUserTurnResponse, error) {
 		return c.controls.SubmitUserTurn(ctx, serverapi.RuntimeSubmitUserTurnRequest{ClientRequestID: uuid.NewString(), SessionID: c.sessionID, ControllerLeaseID: controllerLeaseID, Text: text})
 	})
@@ -197,12 +227,18 @@ func (c *sessionRuntimeClient) SubmitUserMessage(ctx context.Context, text strin
 }
 
 func (c *sessionRuntimeClient) SubmitUserShellCommand(ctx context.Context, command string) error {
+	if err := c.ensureWritable(); err != nil {
+		return err
+	}
 	return c.retryControlCallNoResult(ctx, func(controllerLeaseID string) error {
 		return c.controls.SubmitUserShellCommand(ctx, serverapi.RuntimeSubmitUserShellCommandRequest{ClientRequestID: uuid.NewString(), SessionID: c.sessionID, ControllerLeaseID: controllerLeaseID, Command: command})
 	})
 }
 
 func (c *sessionRuntimeClient) CompactContext(ctx context.Context, args string) error {
+	if err := c.ensureWritable(); err != nil {
+		return err
+	}
 	return c.retryControlCallNoResult(ctx, func(controllerLeaseID string) error {
 		return c.controls.CompactContext(ctx, serverapi.RuntimeCompactContextRequest{ClientRequestID: uuid.NewString(), SessionID: c.sessionID, ControllerLeaseID: controllerLeaseID, Args: args})
 	})
@@ -221,6 +257,9 @@ func (c *sessionRuntimeClient) HasQueuedUserWork() (bool, error) {
 }
 
 func (c *sessionRuntimeClient) SubmitQueuedUserMessages(ctx context.Context) (string, error) {
+	if err := c.ensureWritable(); err != nil {
+		return "", err
+	}
 	resp, err := retryRuntimeControlCall(ctx, c.controllerLeaseIDValue, c.recoverControllerLease, func(controllerLeaseID string) (serverapi.RuntimeSubmitQueuedUserMessagesResponse, error) {
 		return c.controls.SubmitQueuedUserMessages(ctx, serverapi.RuntimeSubmitQueuedUserMessagesRequest{ClientRequestID: uuid.NewString(), SessionID: c.sessionID, ControllerLeaseID: controllerLeaseID})
 	})
@@ -228,6 +267,9 @@ func (c *sessionRuntimeClient) SubmitQueuedUserMessages(ctx context.Context) (st
 }
 
 func (c *sessionRuntimeClient) Interrupt() error {
+	if err := c.ensureWritable(); err != nil {
+		return err
+	}
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	return c.retryControlCallNoResult(ctx, func(controllerLeaseID string) error {
@@ -236,6 +278,9 @@ func (c *sessionRuntimeClient) Interrupt() error {
 }
 
 func (c *sessionRuntimeClient) QueueUserMessage(text string) (clientui.QueuedUserMessage, error) {
+	if err := c.ensureWritable(); err != nil {
+		return clientui.QueuedUserMessage{}, err
+	}
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	resp, err := retryRuntimeControlCall(ctx, c.controllerLeaseIDValue, c.recoverControllerLease, func(controllerLeaseID string) (serverapi.RuntimeQueueUserMessageResponse, error) {
@@ -249,6 +294,9 @@ func (c *sessionRuntimeClient) QueueUserMessage(text string) (clientui.QueuedUse
 }
 
 func (c *sessionRuntimeClient) DiscardQueuedUserMessage(queueItemID string) bool {
+	if err := c.ensureWritable(); err != nil {
+		return false
+	}
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	resp, err := retryRuntimeControlCall(ctx, c.controllerLeaseIDValue, c.recoverControllerLease, func(controllerLeaseID string) (serverapi.RuntimeDiscardQueuedUserMessageResponse, error) {
@@ -261,6 +309,9 @@ func (c *sessionRuntimeClient) DiscardQueuedUserMessage(queueItemID string) bool
 }
 
 func (c *sessionRuntimeClient) RecordPromptHistory(text string) error {
+	if err := c.ensureWritable(); err != nil {
+		return err
+	}
 	ctx, cancel := c.controlContext()
 	defer cancel()
 	return c.retryControlCallNoResult(ctx, func(controllerLeaseID string) error {

--- a/cli/app/ui_worktrees.go
+++ b/cli/app/ui_worktrees.go
@@ -368,6 +368,7 @@ func (m *uiModel) worktreeMutationService() worktreemutation.Service {
 			Context:        client.controlContext,
 			CurrentLeaseID: client.controllerLeaseIDValue,
 			RecoverLease:   client.recoverControllerLease,
+			ReadOnly:       client.isReadOnly,
 		}
 	}
 	return service

--- a/cli/builder/main.go
+++ b/cli/builder/main.go
@@ -227,6 +227,7 @@ func runSubcommand(args []string) int {
 		emitRunUsageError(outputMode, err.Error())
 		return 2
 	}
+	agentRoleSet := flagExplicit(runFS, "agent") || *fastRole
 
 	remaining := runFS.Args()
 	if len(remaining) == 0 {
@@ -259,6 +260,7 @@ func runSubcommand(args []string) int {
 		SessionID:                 sessionID,
 		WorkspaceContextSessionID: workspaceContextSessionID,
 		AgentRole:                 agentRole,
+		AgentRoleSet:              agentRoleSet,
 		Model:                     flags.Model,
 		ProviderOverride:          flags.ProviderOverride,
 		ThinkingLevel:             flags.ThinkingLevel,
@@ -401,6 +403,19 @@ func markExplicitCommonFlags(fs *flag.FlagSet, flags *commonFlags) {
 			flags.OpenAIBaseURLExplicit = true
 		}
 	})
+}
+
+func flagExplicit(fs *flag.FlagSet, name string) bool {
+	if fs == nil {
+		return false
+	}
+	found := false
+	fs.Visit(func(f *flag.Flag) {
+		if strings.TrimSpace(f.Name) == name {
+			found = true
+		}
+	})
+	return found
 }
 
 func parseRunTimeout(raw string) (time.Duration, error) {

--- a/cli/builder/main_test.go
+++ b/cli/builder/main_test.go
@@ -618,6 +618,54 @@ func TestRunSubcommandDefaultAgentWithFastUsesFastRole(t *testing.T) {
 	}
 }
 
+func TestRunSubcommandContinueDefaultAgentAliasesMarkExplicitRoleOverride(t *testing.T) {
+	for _, alias := range []string{"default", "none", "self"} {
+		t.Run(alias, func(t *testing.T) {
+			original := runPromptApp
+			t.Cleanup(func() {
+				runPromptApp = original
+			})
+			var gotOpts app.Options
+			runPromptApp = func(ctx context.Context, opts app.Options, prompt string, timeout time.Duration, progress io.Writer) (app.RunPromptResult, error) {
+				gotOpts = opts
+				return app.RunPromptResult{Result: "done"}, nil
+			}
+
+			originalStdout := os.Stdout
+			originalStderr := os.Stderr
+			stdoutFile, err := os.CreateTemp(t.TempDir(), "stdout")
+			if err != nil {
+				t.Fatalf("create stdout temp file: %v", err)
+			}
+			stderrFile, err := os.CreateTemp(t.TempDir(), "stderr")
+			if err != nil {
+				t.Fatalf("create stderr temp file: %v", err)
+			}
+			os.Stdout = stdoutFile
+			os.Stderr = stderrFile
+			t.Cleanup(func() {
+				os.Stdout = originalStdout
+				os.Stderr = originalStderr
+				_ = stdoutFile.Close()
+				_ = stderrFile.Close()
+			})
+
+			if code := rootCommand([]string{"run", "--continue", "session-123", "--agent", alias, "hello"}, strings.NewReader(""), io.Discard, io.Discard); code != 0 {
+				t.Fatalf("exit code = %d, want 0", code)
+			}
+			if gotOpts.SessionID != "session-123" {
+				t.Fatalf("session id = %q, want session-123", gotOpts.SessionID)
+			}
+			if gotOpts.AgentRole != "" {
+				t.Fatalf("agent role = %q, want empty default role", gotOpts.AgentRole)
+			}
+			if !gotOpts.AgentRoleSet {
+				t.Fatal("expected default alias to mark explicit role override")
+			}
+		})
+	}
+}
+
 func TestSessionIDSubcommandPrintsBuilderSessionEnv(t *testing.T) {
 	t.Setenv(sessionenv.BuilderSessionID, " session-from-env ")
 	var stdout bytes.Buffer

--- a/docs/dev/decisions.md
+++ b/docs/dev/decisions.md
@@ -523,6 +523,8 @@
 - JSON mode emits exactly one final object on `stdout`: `status`, `result`/`error`, `session_id`, `session_name`, `duration_ms`, plus continuation metadata and startup `warnings` when available.
 - Final-text mode emits startup warnings first, then the final assistant text, and optionally a continue hint.
 - Progress is quiet by default and is emitted to `stderr` only when `--progress-mode=stderr`.
+- A headless run owns the active session runtime it registers. Interactive activation for the same active session attaches read-only instead of creating a competing engine or interrupting the run.
+- Resuming a session with persisted subagent role metadata reapplies that role best-effort when the role exists. Missing roles do not block explicit continuation.
 
 ## Release Engineering
 

--- a/docs/src/content/docs/headless.md
+++ b/docs/src/content/docs/headless.md
@@ -59,7 +59,8 @@ Useful role-specific keys include:
 
 Headless runs are non-interactive. They do not stop to ask the human operator questions mid-run or issue tool preambles. That makes them suitable for background execution and automation and saves tokens, but it also means a headless run should be treated as a single unattended turn. If you continue the headless session as an interactive one (e.g. from the UI), expect the model to be less talkative going forward.
 
-- Continuing a session reuses most of initial config and parameters.
+- Continuing a session with a stored subagent role reapplies that role when it still exists. If the role was removed from config, continuation uses the base config.
+- An active headless run owns its session runtime until it exits. Opening the same session interactively attaches as a read-only watcher without interrupting the headless `builder run` process.
 - Sessions with a goal cannot be continued headlessly. Clear the goal from the interactive session before using `builder run --continue`.
 
 ## Workspace Binding

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -92,18 +92,22 @@ func (p Planner) PlanSession(ctx context.Context, req SessionRequest) (SessionPl
 	meta := store.Meta()
 	baseActive := EffectiveSettings(p.Config.Settings, meta.Locked)
 	baseSource := p.Config.Source
+	continuationAgentRole := ""
+	continuationBaseURL := ""
 	if meta.Continuation != nil {
-		if baseURL := strings.TrimSpace(meta.Continuation.OpenAIBaseURL); baseURL != "" {
-			baseActive.OpenAIBaseURL = baseURL
-		}
+		continuationAgentRole = strings.TrimSpace(meta.Continuation.AgentRole)
+		continuationBaseURL = strings.TrimSpace(meta.Continuation.OpenAIBaseURL)
 	}
 	active, source := baseActive, baseSource
 	if meta.Continuation != nil {
-		active, source = applyPersistedSubagentRoleSettings(baseActive, baseSource, meta.Continuation.AgentRole, meta.Locked == nil)
+		active, source = applyPersistedSubagentRoleSettings(baseActive, baseSource, continuationAgentRole, meta.Locked == nil)
+		if shouldApplyPersistedContinuationBaseURL(baseActive, continuationAgentRole) && continuationBaseURL != "" {
+			active.OpenAIBaseURL = continuationBaseURL
+		}
 	}
 	continuation := session.ContinuationContext{OpenAIBaseURL: active.OpenAIBaseURL}
 	if meta.Continuation != nil {
-		continuation.AgentRole = strings.TrimSpace(meta.Continuation.AgentRole)
+		continuation.AgentRole = continuationAgentRole
 	}
 	if err := store.SetContinuationContext(continuation); err != nil {
 		return SessionPlan{}, err
@@ -142,14 +146,24 @@ func applyPersistedSubagentRoleSettings(base config.Settings, source config.Sour
 	resolved := cloneSettings(base)
 	_ = applyBuiltInRoleHeuristics(&resolved, normalizedRole, persistedRoleProviderID(base), allowModelOverride)
 	applySubagentRoleOverrides(&resolved, role, allowModelOverride)
-	effectiveSource := sourceReportWithSubagentRoleSources(source, base, normalizedRole)
+	effectiveSource := sourceReportWithSubagentRoleSources(source, base, normalizedRole, allowModelOverride)
 	effectiveSources := cloneStringMap(effectiveSource.Sources)
-	for key := range role.Sources {
-		effectiveSources[key] = "subagent"
-	}
 	applyReviewerInheritance(&resolved, effectiveSources)
 	effectiveSource.Sources = effectiveSources
 	return resolved, effectiveSource
+}
+
+func shouldApplyPersistedContinuationBaseURL(base config.Settings, roleName string) bool {
+	normalizedRole := config.NormalizeSubagentSelector(roleName)
+	if normalizedRole == "" {
+		return true
+	}
+	role, hasRole := base.Subagents[normalizedRole]
+	if !hasRole && normalizedRole != config.BuiltInSubagentRoleFast {
+		return false
+	}
+	_, hasRoleBaseURL := role.Sources["openai_base_url"]
+	return !hasRoleBaseURL
 }
 
 func persistedRoleProviderID(settings config.Settings) string {
@@ -224,7 +238,7 @@ func ApplyRunPromptOverrides(plan SessionPlan, overrides serverapi.RunPromptOver
 		if !plan.ModelContractLocked {
 			next.ConfiguredModelName = resolved.Model
 		}
-		roleSource := sourceReportWithSubagentRoleSources(baseSource, baseSettings, roleName)
+		roleSource := sourceReportWithSubagentRoleSources(baseSource, baseSettings, roleName, !plan.ModelContractLocked)
 		enabledTools, err := ActiveToolIDsForPlan(next.ActiveSettings, roleSource, plan.Store.Meta().Locked)
 		if err != nil {
 			return SessionPlan{}, nil, err
@@ -324,7 +338,7 @@ func mergeOverrideSources(base config.SourceReport, override config.SourceReport
 	return merged
 }
 
-func sourceReportWithSubagentRoleSources(base config.SourceReport, settings config.Settings, roleName string) config.SourceReport {
+func sourceReportWithSubagentRoleSources(base config.SourceReport, settings config.Settings, roleName string, allowModelOverride bool) config.SourceReport {
 	normalizedRole := config.NormalizeSubagentRole(roleName)
 	if normalizedRole == "" {
 		return base
@@ -336,6 +350,9 @@ func sourceReportWithSubagentRoleSources(base config.SourceReport, settings conf
 	next := base
 	next.Sources = cloneStringMap(base.Sources)
 	for key := range role.Sources {
+		if key == "model" && !allowModelOverride {
+			continue
+		}
 		next.Sources[key] = "subagent"
 	}
 	return next

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -175,9 +175,15 @@ func persistedRoleProviderID(settings config.Settings) string {
 	if providerOverride := strings.TrimSpace(settings.ProviderOverride); providerOverride != "" {
 		return providerOverride
 	}
+	if baseURL := strings.TrimSpace(settings.OpenAIBaseURL); baseURL != "" {
+		if llm.IsOpenAIFirstPartyBaseURL(baseURL) {
+			return "openai"
+		}
+		return "openai-compatible"
+	}
 	provider, err := llm.InferProviderFromModel(settings.Model)
 	if err != nil {
-		return ""
+		return "openai"
 	}
 	return string(provider)
 }

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -144,7 +144,9 @@ func applyPersistedSubagentRoleSettings(base config.Settings, source config.Sour
 		return base, source
 	}
 	resolved := cloneSettings(base)
-	_ = applyBuiltInRoleHeuristics(&resolved, normalizedRole, persistedRoleProviderID(base), allowModelOverride)
+	providerSettings := cloneSettings(base)
+	applySubagentProviderOverrides(&providerSettings, role)
+	_ = applyBuiltInRoleHeuristics(&resolved, normalizedRole, persistedRoleProviderID(providerSettings), allowModelOverride)
 	applySubagentRoleOverrides(&resolved, role, allowModelOverride)
 	effectiveSource := sourceReportWithSubagentRoleSources(source, base, normalizedRole, allowModelOverride)
 	effectiveSources := cloneStringMap(effectiveSource.Sources)
@@ -169,6 +171,9 @@ func shouldApplyPersistedContinuationBaseURL(base config.Settings, roleName stri
 func persistedRoleProviderID(settings config.Settings) string {
 	if providerID := strings.TrimSpace(settings.ProviderCapabilities.ProviderID); providerID != "" {
 		return providerID
+	}
+	if providerOverride := strings.TrimSpace(settings.ProviderOverride); providerOverride != "" {
+		return providerOverride
 	}
 	provider, err := llm.InferProviderFromModel(settings.Model)
 	if err != nil {

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"builder/server/auth"
+	"builder/server/llm"
 	"builder/server/metadata"
 	"builder/server/session"
 	"builder/server/sessionpath"
@@ -61,12 +62,14 @@ type SessionRequest struct {
 type SessionPlan struct {
 	Store               *session.Store
 	ActiveSettings      config.Settings
+	BaseSettings        config.Settings
 	EnabledTools        []toolspec.ID
 	ConfiguredModelName string
 	SessionName         string
 	ModelContractLocked bool
 	WorkspaceRoot       string
 	Source              config.SourceReport
+	BaseSource          config.SourceReport
 }
 
 func (p Planner) PlanSession(ctx context.Context, req SessionRequest) (SessionPlan, error) {
@@ -87,11 +90,16 @@ func (p Planner) PlanSession(ctx context.Context, req SessionRequest) (SessionPl
 		}
 	}
 	meta := store.Meta()
-	active := EffectiveSettings(p.Config.Settings, meta.Locked)
+	baseActive := EffectiveSettings(p.Config.Settings, meta.Locked)
+	baseSource := p.Config.Source
 	if meta.Continuation != nil {
 		if baseURL := strings.TrimSpace(meta.Continuation.OpenAIBaseURL); baseURL != "" {
-			active.OpenAIBaseURL = baseURL
+			baseActive.OpenAIBaseURL = baseURL
 		}
+	}
+	active, source := baseActive, baseSource
+	if meta.Continuation != nil {
+		active, source = applyPersistedSubagentRoleSettings(baseActive, baseSource, meta.Continuation.AgentRole, meta.Locked == nil)
 	}
 	continuation := session.ContinuationContext{OpenAIBaseURL: active.OpenAIBaseURL}
 	if meta.Continuation != nil {
@@ -100,20 +108,59 @@ func (p Planner) PlanSession(ctx context.Context, req SessionRequest) (SessionPl
 	if err := store.SetContinuationContext(continuation); err != nil {
 		return SessionPlan{}, err
 	}
-	enabledTools, err := ActiveToolIDsForPlan(active, p.Config.Source, meta.Locked)
+	enabledTools, err := ActiveToolIDsForPlan(active, source, meta.Locked)
 	if err != nil {
 		return SessionPlan{}, err
+	}
+	configuredModelName := p.Config.Settings.Model
+	if meta.Locked == nil {
+		configuredModelName = active.Model
 	}
 	return SessionPlan{
 		Store:               store,
 		ActiveSettings:      active,
+		BaseSettings:        baseActive,
 		EnabledTools:        enabledTools,
-		ConfiguredModelName: p.Config.Settings.Model,
+		ConfiguredModelName: configuredModelName,
 		SessionName:         meta.Name,
 		ModelContractLocked: meta.Locked != nil,
 		WorkspaceRoot:       p.Config.WorkspaceRoot,
-		Source:              p.Config.Source,
+		Source:              source,
+		BaseSource:          baseSource,
 	}, nil
+}
+
+func applyPersistedSubagentRoleSettings(base config.Settings, source config.SourceReport, roleName string, allowModelOverride bool) (config.Settings, config.SourceReport) {
+	normalizedRole := config.NormalizeSubagentSelector(roleName)
+	if normalizedRole == "" {
+		return base, source
+	}
+	role, hasRole := base.Subagents[normalizedRole]
+	if !hasRole && normalizedRole != config.BuiltInSubagentRoleFast {
+		return base, source
+	}
+	resolved := cloneSettings(base)
+	_ = applyBuiltInRoleHeuristics(&resolved, normalizedRole, persistedRoleProviderID(base), allowModelOverride)
+	applySubagentRoleOverrides(&resolved, role, allowModelOverride)
+	effectiveSource := sourceReportWithSubagentRoleSources(source, base, normalizedRole)
+	effectiveSources := cloneStringMap(effectiveSource.Sources)
+	for key := range role.Sources {
+		effectiveSources[key] = "subagent"
+	}
+	applyReviewerInheritance(&resolved, effectiveSources)
+	effectiveSource.Sources = effectiveSources
+	return resolved, effectiveSource
+}
+
+func persistedRoleProviderID(settings config.Settings) string {
+	if providerID := strings.TrimSpace(settings.ProviderCapabilities.ProviderID); providerID != "" {
+		return providerID
+	}
+	provider, err := llm.InferProviderFromModel(settings.Model)
+	if err != nil {
+		return ""
+	}
+	return string(provider)
 }
 
 func ApplyRunPromptOverrides(plan SessionPlan, overrides serverapi.RunPromptOverrides, authState auth.State) (SessionPlan, []string, error) {
@@ -122,6 +169,14 @@ func ApplyRunPromptOverrides(plan SessionPlan, overrides serverapi.RunPromptOver
 	}
 	var warnings []string
 	next := plan
+	baseSettings := plan.BaseSettings
+	if strings.TrimSpace(baseSettings.Model) == "" {
+		baseSettings = plan.ActiveSettings
+	}
+	baseSource := plan.BaseSource
+	if baseSource.Sources == nil {
+		baseSource = plan.Source
+	}
 	shouldPersistContinuation := false
 	continuationAgentRole := ""
 	if plan.Store.Meta().Continuation != nil {
@@ -137,17 +192,31 @@ func ApplyRunPromptOverrides(plan SessionPlan, overrides serverapi.RunPromptOver
 		return SessionPlan{}, nil, fmt.Errorf("invalid agent role %q", trimmedRole)
 	}
 	roleName := config.NormalizeSubagentSelector(overrides.AgentRole)
-	if roleName != "" {
+	if overrides.AgentRoleSet || roleName != "" {
 		shouldPersistContinuation = true
 		continuationAgentRole = roleName
-		providerBase := cloneSettings(plan.ActiveSettings)
+		next.ActiveSettings = cloneSettings(baseSettings)
+		next.Source = baseSource
+		if !plan.ModelContractLocked {
+			next.ConfiguredModelName = next.ActiveSettings.Model
+		}
+		if roleName == "" {
+			enabledTools, err := ActiveToolIDsForPlan(next.ActiveSettings, next.Source, plan.Store.Meta().Locked)
+			if err != nil {
+				return SessionPlan{}, nil, err
+			}
+			next.EnabledTools = enabledTools
+		}
+	}
+	if roleName != "" {
+		providerBase := cloneSettings(baseSettings)
 		if value := strings.TrimSpace(overrides.ProviderOverride); value != "" {
 			providerBase.ProviderOverride = value
 		}
 		if value := strings.TrimSpace(overrides.OpenAIBaseURL); value != "" {
 			providerBase.OpenAIBaseURL = value
 		}
-		resolved, warning, err := resolveSubagentSettings(plan.ActiveSettings, providerBase, plan.Source.Sources, roleName, authState, !plan.ModelContractLocked)
+		resolved, warning, err := resolveSubagentSettings(baseSettings, providerBase, baseSource.Sources, roleName, authState, !plan.ModelContractLocked)
 		if err != nil {
 			return SessionPlan{}, nil, err
 		}
@@ -155,7 +224,7 @@ func ApplyRunPromptOverrides(plan SessionPlan, overrides serverapi.RunPromptOver
 		if !plan.ModelContractLocked {
 			next.ConfiguredModelName = resolved.Model
 		}
-		roleSource := sourceReportWithSubagentRoleSources(next.Source, plan.ActiveSettings, roleName)
+		roleSource := sourceReportWithSubagentRoleSources(baseSource, baseSettings, roleName)
 		enabledTools, err := ActiveToolIDsForPlan(next.ActiveSettings, roleSource, plan.Store.Meta().Locked)
 		if err != nil {
 			return SessionPlan{}, nil, err

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -270,6 +270,95 @@ func TestPlannerIgnoresMissingPersistedSubagentRoleOnResume(t *testing.T) {
 	}
 }
 
+func TestPlannerKeepsRoleBaseURLOutOfBaseSettingsOnResume(t *testing.T) {
+	root := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	loaded, err := config.Load(workspace, config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	containerDir := filepath.Join(root, "sessions", "workspace-a")
+	store, err := session.Create(containerDir, "workspace-a", workspace)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.SetContinuationContext(session.ContinuationContext{
+		OpenAIBaseURL: "https://worker.example/v1",
+		AgentRole:     "worker",
+	}); err != nil {
+		t.Fatalf("SetContinuationContext: %v", err)
+	}
+	settings := loaded.Settings
+	settings.OpenAIBaseURL = "https://base.example/v1"
+	workerSettings := cloneSettings(settings)
+	workerSettings.OpenAIBaseURL = "https://worker.example/v1"
+	researchSettings := cloneSettings(settings)
+	researchSettings.ThinkingLevel = "high"
+	settings.Subagents = map[string]config.SubagentRole{
+		"worker": {
+			Settings: workerSettings,
+			Sources:  map[string]string{"openai_base_url": "file"},
+		},
+		"research": {
+			Settings: researchSettings,
+			Sources:  map[string]string{"thinking_level": "file"},
+		},
+	}
+	source := loaded.Source
+	source.Sources = cloneStringMap(loaded.Source.Sources)
+	source.Sources["openai_base_url"] = "file"
+	source.Sources["thinking_level"] = "file"
+	planner := Planner{
+		Config: config.App{
+			WorkspaceRoot:   workspace,
+			PersistenceRoot: root,
+			Settings:        settings,
+			Source:          source,
+		},
+		ContainerDir: containerDir,
+	}
+
+	plan, err := planner.PlanSession(context.Background(), SessionRequest{Mode: ModeInteractive, SelectedSessionID: store.Meta().SessionID})
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if plan.ActiveSettings.OpenAIBaseURL != "https://worker.example/v1" {
+		t.Fatalf("active base url = %q, want worker", plan.ActiveSettings.OpenAIBaseURL)
+	}
+	if plan.BaseSettings.OpenAIBaseURL != "https://base.example/v1" {
+		t.Fatalf("base settings url = %q, want base", plan.BaseSettings.OpenAIBaseURL)
+	}
+
+	cleared, warnings, err := ApplyRunPromptOverrides(plan, serverapi.RunPromptOverrides{AgentRoleSet: true}, auth.EmptyState())
+	if err != nil {
+		t.Fatalf("ApplyRunPromptOverrides clear: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %+v", warnings)
+	}
+	if cleared.ActiveSettings.OpenAIBaseURL != "https://base.example/v1" {
+		t.Fatalf("cleared base url = %q, want base", cleared.ActiveSettings.OpenAIBaseURL)
+	}
+	if got := plan.Store.Meta().Continuation; got != nil && got.AgentRole != "" {
+		t.Fatalf("continuation after clear = %+v, want no role", got)
+	}
+
+	if err := plan.Store.SetContinuationContext(session.ContinuationContext{OpenAIBaseURL: "https://worker.example/v1", AgentRole: "worker"}); err != nil {
+		t.Fatalf("reset continuation: %v", err)
+	}
+	switched, warnings, err := ApplyRunPromptOverrides(plan, serverapi.RunPromptOverrides{AgentRole: "research"}, auth.EmptyState())
+	if err != nil {
+		t.Fatalf("ApplyRunPromptOverrides switch: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected switch warnings: %+v", warnings)
+	}
+	if switched.ActiveSettings.OpenAIBaseURL != "https://base.example/v1" {
+		t.Fatalf("switched base url = %q, want base", switched.ActiveSettings.OpenAIBaseURL)
+	}
+}
+
 func TestApplyRunPromptOverridesExplicitRoleUsesBaseSettingsAfterPersistedRoleResume(t *testing.T) {
 	root := t.TempDir()
 	workspace := t.TempDir()
@@ -522,6 +611,65 @@ func TestApplyRunPromptOverridesResumedRoleMatrix(t *testing.T) {
 				t.Fatalf("continuation role = %q, want %q", gotRole, tt.wantAgentRole)
 			}
 		})
+	}
+}
+
+func TestApplyRunPromptOverridesLockedModelDoesNotMarkModelSourceAsSubagent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	workspace := t.TempDir()
+	loaded, err := config.Load(workspace, config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	baseSettings := loaded.Settings
+	baseSettings.Model = "locked-model"
+	workerSettings := cloneSettings(baseSettings)
+	workerSettings.Model = "gpt-5.4-mini"
+	workerSettings.ThinkingLevel = "high"
+	baseSettings.Subagents = map[string]config.SubagentRole{
+		"worker": {
+			Settings: workerSettings,
+			Sources:  map[string]string{"model": "file", "thinking_level": "file"},
+		},
+	}
+	baseSource := loaded.Source
+	baseSource.Sources = cloneStringMap(loaded.Source.Sources)
+	baseSource.Sources["model"] = "file"
+	baseSource.Sources["thinking_level"] = "file"
+	store, err := session.Create(filepath.Join(t.TempDir(), "sessions", "workspace-a"), "workspace-a", workspace)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.MarkModelDispatchLocked(session.LockedContract{Model: "locked-model", EnabledTools: []string{"shell"}}); err != nil {
+		t.Fatalf("MarkModelDispatchLocked: %v", err)
+	}
+	plan := SessionPlan{
+		Store:               store,
+		ActiveSettings:      baseSettings,
+		BaseSettings:        baseSettings,
+		EnabledTools:        []toolspec.ID{toolspec.ToolExecCommand},
+		ConfiguredModelName: "gpt-5.5",
+		WorkspaceRoot:       workspace,
+		Source:              baseSource,
+		BaseSource:          baseSource,
+		ModelContractLocked: true,
+	}
+
+	updated, warnings, err := ApplyRunPromptOverrides(plan, serverapi.RunPromptOverrides{AgentRole: "worker"}, auth.EmptyState())
+	if err != nil {
+		t.Fatalf("ApplyRunPromptOverrides: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %+v", warnings)
+	}
+	if updated.ActiveSettings.Model != "locked-model" {
+		t.Fatalf("model = %q, want locked-model", updated.ActiveSettings.Model)
+	}
+	if updated.Source.Sources["model"] != "file" {
+		t.Fatalf("model source = %q, want original file source under lock", updated.Source.Sources["model"])
+	}
+	if updated.Source.Sources["thinking_level"] != "subagent" {
+		t.Fatalf("thinking source = %q, want subagent", updated.Source.Sources["thinking_level"])
 	}
 }
 
@@ -979,7 +1127,7 @@ func TestSubagentRoleMetadataSurvivesCloneAndSourceReport(t *testing.T) {
 		t.Fatalf("metadata did not survive clone: %+v", cloned.Subagents["worker"])
 	}
 
-	report := sourceReportWithSubagentRoleSources(config.SourceReport{Sources: map[string]string{"model": "file"}}, settings, "worker")
+	report := sourceReportWithSubagentRoleSources(config.SourceReport{Sources: map[string]string{"model": "file"}}, settings, "worker", true)
 	if report.Sources["model"] != "subagent" {
 		t.Fatalf("source report model source = %q, want subagent", report.Sources["model"])
 	}

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -169,6 +169,362 @@ func TestPlannerInteractiveReopensSelectedSessionID(t *testing.T) {
 	}
 }
 
+func TestPlannerReappliesPersistedSubagentRoleSettingsOnResume(t *testing.T) {
+	root := t.TempDir()
+	workspace := t.TempDir()
+	containerDir := filepath.Join(root, "sessions", "workspace-a")
+	store, err := session.Create(containerDir, "workspace-a", workspace)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.SetContinuationContext(session.ContinuationContext{AgentRole: "smart_reviewer"}); err != nil {
+		t.Fatalf("SetContinuationContext: %v", err)
+	}
+	settings := config.Settings{
+		Model:         "gpt-5.5",
+		ThinkingLevel: "medium",
+		EnabledTools: map[toolspec.ID]bool{
+			toolspec.ToolExecCommand: true,
+			toolspec.ToolPatch:       true,
+		},
+		Subagents: map[string]config.SubagentRole{
+			"smart_reviewer": {
+				Settings: config.Settings{
+					Model:         "gpt-5.5",
+					ThinkingLevel: "xhigh",
+					EnabledTools: map[toolspec.ID]bool{
+						toolspec.ToolExecCommand: true,
+						toolspec.ToolPatch:       false,
+					},
+				},
+				Sources: map[string]string{"thinking_level": "file", "tools.patch": "file"},
+			},
+		},
+	}
+	planner := Planner{
+		Config: config.App{
+			WorkspaceRoot:   workspace,
+			PersistenceRoot: root,
+			Settings:        settings,
+			Source: config.SourceReport{Sources: map[string]string{
+				"model":          "file",
+				"thinking_level": "file",
+				"tools.shell":    "file",
+				"tools.patch":    "file",
+				"tools.edit":     "file",
+			}},
+		},
+		ContainerDir: containerDir,
+	}
+
+	plan, err := planner.PlanSession(context.Background(), SessionRequest{Mode: ModeInteractive, SelectedSessionID: store.Meta().SessionID})
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if plan.ActiveSettings.ThinkingLevel != "xhigh" {
+		t.Fatalf("thinking level = %q, want persisted subagent role xhigh", plan.ActiveSettings.ThinkingLevel)
+	}
+	if plan.ActiveSettings.EnabledTools[toolspec.ToolPatch] {
+		t.Fatalf("patch tool should be disabled by persisted role: %+v", plan.ActiveSettings.EnabledTools)
+	}
+	if plan.Source.Sources["thinking_level"] != "subagent" || plan.Source.Sources["tools.patch"] != "subagent" {
+		t.Fatalf("source report did not mark role overrides as subagent: %+v", plan.Source.Sources)
+	}
+	if got := plan.Store.Meta().Continuation; got == nil || got.AgentRole != "smart_reviewer" {
+		t.Fatalf("continuation = %+v, want smart_reviewer preserved", got)
+	}
+}
+
+func TestPlannerIgnoresMissingPersistedSubagentRoleOnResume(t *testing.T) {
+	root := t.TempDir()
+	workspace := t.TempDir()
+	containerDir := filepath.Join(root, "sessions", "workspace-a")
+	store, err := session.Create(containerDir, "workspace-a", workspace)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.SetContinuationContext(session.ContinuationContext{AgentRole: "deleted_role"}); err != nil {
+		t.Fatalf("SetContinuationContext: %v", err)
+	}
+	planner := Planner{
+		Config: config.App{
+			WorkspaceRoot:   workspace,
+			PersistenceRoot: root,
+			Settings: config.Settings{
+				Model:         "gpt-5.5",
+				ThinkingLevel: "medium",
+			},
+		},
+		ContainerDir: containerDir,
+	}
+
+	plan, err := planner.PlanSession(context.Background(), SessionRequest{Mode: ModeInteractive, SelectedSessionID: store.Meta().SessionID})
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if plan.ActiveSettings.ThinkingLevel != "medium" {
+		t.Fatalf("thinking level = %q, want base config when role is missing", plan.ActiveSettings.ThinkingLevel)
+	}
+	if got := plan.Store.Meta().Continuation; got == nil || got.AgentRole != "deleted_role" {
+		t.Fatalf("continuation = %+v, want missing role preserved", got)
+	}
+}
+
+func TestApplyRunPromptOverridesExplicitRoleUsesBaseSettingsAfterPersistedRoleResume(t *testing.T) {
+	root := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	loaded, err := config.Load(workspace, config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	store, err := session.Create(filepath.Join(root, "sessions", "workspace-a"), "workspace-a", workspace)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.SetContinuationContext(session.ContinuationContext{AgentRole: "old_role"}); err != nil {
+		t.Fatalf("SetContinuationContext: %v", err)
+	}
+	baseSettings := loaded.Settings
+	baseSettings.EnabledTools = cloneEnabledToolSet(baseSettings.EnabledTools)
+	baseSettings.EnabledTools[toolspec.ToolExecCommand] = true
+	baseSettings.EnabledTools[toolspec.ToolPatch] = true
+	workerSettings := cloneSettings(baseSettings)
+	workerSettings.ThinkingLevel = "high"
+	baseSettings.Subagents = map[string]config.SubagentRole{
+		"worker": {
+			Settings: workerSettings,
+			Sources:  map[string]string{"thinking_level": "file"},
+		},
+	}
+	resumedSettings := cloneSettings(baseSettings)
+	resumedSettings.ThinkingLevel = "xhigh"
+	resumedSettings.EnabledTools[toolspec.ToolPatch] = false
+	baseSource := loaded.Source
+	baseSource.Sources = cloneStringMap(loaded.Source.Sources)
+	baseSource.Sources["thinking_level"] = "file"
+	baseSource.Sources["tools.shell"] = "file"
+	baseSource.Sources["tools.patch"] = "file"
+	baseSource.Sources["tools.edit"] = "file"
+	resumedSource := baseSource
+	resumedSource.Sources = cloneStringMap(baseSource.Sources)
+	resumedSource.Sources["thinking_level"] = "subagent"
+	resumedSource.Sources["tools.patch"] = "subagent"
+	plan := SessionPlan{
+		Store:               store,
+		ActiveSettings:      resumedSettings,
+		BaseSettings:        baseSettings,
+		EnabledTools:        []toolspec.ID{toolspec.ToolExecCommand},
+		ConfiguredModelName: "gpt-5.5",
+		WorkspaceRoot:       workspace,
+		Source:              resumedSource,
+		BaseSource:          baseSource,
+	}
+
+	updated, warnings, err := ApplyRunPromptOverrides(plan, serverapi.RunPromptOverrides{AgentRole: "worker"}, auth.EmptyState())
+	if err != nil {
+		t.Fatalf("ApplyRunPromptOverrides: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %+v", warnings)
+	}
+	if updated.ActiveSettings.ThinkingLevel != "high" {
+		t.Fatalf("thinking level = %q, want new role", updated.ActiveSettings.ThinkingLevel)
+	}
+	if !updated.ActiveSettings.EnabledTools[toolspec.ToolPatch] {
+		t.Fatalf("patch tool should come from base settings, got %+v", updated.ActiveSettings.EnabledTools)
+	}
+	if updated.Source.Sources["tools.patch"] != "file" {
+		t.Fatalf("tools.patch source = %q, want base source", updated.Source.Sources["tools.patch"])
+	}
+	if got := store.Meta().Continuation; got == nil || got.AgentRole != "worker" {
+		t.Fatalf("continuation = %+v, want worker", got)
+	}
+}
+
+func TestApplyRunPromptOverridesExplicitDefaultClearsPersistedRole(t *testing.T) {
+	root := t.TempDir()
+	workspace := t.TempDir()
+	store, err := session.Create(filepath.Join(root, "sessions", "workspace-a"), "workspace-a", workspace)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.SetContinuationContext(session.ContinuationContext{AgentRole: "old_role"}); err != nil {
+		t.Fatalf("SetContinuationContext: %v", err)
+	}
+	baseSettings := config.Settings{
+		Model:         "gpt-5.5",
+		ThinkingLevel: "medium",
+		EnabledTools:  map[toolspec.ID]bool{toolspec.ToolExecCommand: true},
+	}
+	resumedSettings := cloneSettings(baseSettings)
+	resumedSettings.ThinkingLevel = "xhigh"
+	plan := SessionPlan{
+		Store:               store,
+		ActiveSettings:      resumedSettings,
+		BaseSettings:        baseSettings,
+		EnabledTools:        []toolspec.ID{toolspec.ToolExecCommand},
+		ConfiguredModelName: "gpt-5.5",
+		WorkspaceRoot:       workspace,
+		Source:              config.SourceReport{Sources: map[string]string{"thinking_level": "subagent"}},
+		BaseSource:          config.SourceReport{Sources: map[string]string{"thinking_level": "file"}},
+	}
+
+	updated, warnings, err := ApplyRunPromptOverrides(plan, serverapi.RunPromptOverrides{AgentRoleSet: true}, auth.EmptyState())
+	if err != nil {
+		t.Fatalf("ApplyRunPromptOverrides: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %+v", warnings)
+	}
+	if updated.ActiveSettings.ThinkingLevel != "medium" {
+		t.Fatalf("thinking level = %q, want base config", updated.ActiveSettings.ThinkingLevel)
+	}
+	if updated.Source.Sources["thinking_level"] != "file" {
+		t.Fatalf("thinking source = %q, want base source", updated.Source.Sources["thinking_level"])
+	}
+	if got := store.Meta().Continuation; got != nil && got.AgentRole != "" {
+		t.Fatalf("continuation = %+v, want cleared role", got)
+	}
+}
+
+func TestApplyRunPromptOverridesResumedRoleMatrix(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	workspace := t.TempDir()
+	loaded, err := config.Load(workspace, config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	baseSettings := loaded.Settings
+	baseSettings.EnabledTools = cloneEnabledToolSet(baseSettings.EnabledTools)
+	baseSettings.Model = "gpt-5.5"
+	baseSettings.ThinkingLevel = "medium"
+	baseSettings.EnabledTools[toolspec.ToolExecCommand] = true
+	baseSettings.EnabledTools[toolspec.ToolPatch] = true
+	workerSettings := cloneSettings(baseSettings)
+	workerSettings.Model = "gpt-5.4-mini"
+	workerSettings.ThinkingLevel = "high"
+	baseSettings.Subagents = map[string]config.SubagentRole{
+		"worker": {
+			Settings: workerSettings,
+			Sources:  map[string]string{"model": "file", "thinking_level": "file"},
+		},
+	}
+	baseSource := loaded.Source
+	baseSource.Sources = cloneStringMap(loaded.Source.Sources)
+	baseSource.Sources["model"] = "file"
+	baseSource.Sources["thinking_level"] = "file"
+	baseSource.Sources["tools.shell"] = "file"
+	baseSource.Sources["tools.patch"] = "file"
+	baseSource.Sources["tools.edit"] = "file"
+	resumedSettings := cloneSettings(baseSettings)
+	resumedSettings.ThinkingLevel = "xhigh"
+	resumedSettings.EnabledTools[toolspec.ToolPatch] = false
+	resumedSource := baseSource
+	resumedSource.Sources = cloneStringMap(baseSource.Sources)
+	resumedSource.Sources["thinking_level"] = "subagent"
+	resumedSource.Sources["tools.patch"] = "subagent"
+
+	tests := []struct {
+		name             string
+		locked           bool
+		overrides        serverapi.RunPromptOverrides
+		wantModel        string
+		wantThinking     string
+		wantPatchSetting bool
+		wantAgentRole    string
+	}{
+		{
+			name:             "no override keeps resumed role",
+			overrides:        serverapi.RunPromptOverrides{},
+			wantModel:        "gpt-5.5",
+			wantThinking:     "xhigh",
+			wantPatchSetting: false,
+			wantAgentRole:    "old_role",
+		},
+		{
+			name:             "new role starts from base settings",
+			overrides:        serverapi.RunPromptOverrides{AgentRole: "worker"},
+			wantModel:        "gpt-5.4-mini",
+			wantThinking:     "high",
+			wantPatchSetting: true,
+			wantAgentRole:    "worker",
+		},
+		{
+			name:             "default alias clears resumed role",
+			overrides:        serverapi.RunPromptOverrides{AgentRoleSet: true},
+			wantModel:        "gpt-5.5",
+			wantThinking:     "medium",
+			wantPatchSetting: true,
+			wantAgentRole:    "",
+		},
+		{
+			name:             "locked model blocks new role model override",
+			locked:           true,
+			overrides:        serverapi.RunPromptOverrides{AgentRole: "worker"},
+			wantModel:        "locked-model",
+			wantThinking:     "high",
+			wantPatchSetting: true,
+			wantAgentRole:    "worker",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := session.Create(filepath.Join(t.TempDir(), "sessions", "workspace-a"), "workspace-a", workspace)
+			if err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+			if err := store.SetContinuationContext(session.ContinuationContext{AgentRole: "old_role"}); err != nil {
+				t.Fatalf("SetContinuationContext: %v", err)
+			}
+			planBaseSettings := cloneSettings(baseSettings)
+			planResumedSettings := cloneSettings(resumedSettings)
+			if tt.locked {
+				if err := store.MarkModelDispatchLocked(session.LockedContract{Model: "locked-model", EnabledTools: []string{"shell"}}); err != nil {
+					t.Fatalf("MarkModelDispatchLocked: %v", err)
+				}
+				planBaseSettings.Model = "locked-model"
+				planResumedSettings.Model = "locked-model"
+			}
+			plan := SessionPlan{
+				Store:               store,
+				ActiveSettings:      planResumedSettings,
+				BaseSettings:        planBaseSettings,
+				EnabledTools:        []toolspec.ID{toolspec.ToolExecCommand},
+				ConfiguredModelName: "gpt-5.5",
+				WorkspaceRoot:       workspace,
+				Source:              resumedSource,
+				BaseSource:          baseSource,
+				ModelContractLocked: tt.locked,
+			}
+
+			updated, warnings, err := ApplyRunPromptOverrides(plan, tt.overrides, auth.EmptyState())
+			if err != nil {
+				t.Fatalf("ApplyRunPromptOverrides: %v", err)
+			}
+			if len(warnings) != 0 {
+				t.Fatalf("unexpected warnings: %+v", warnings)
+			}
+			if updated.ActiveSettings.Model != tt.wantModel {
+				t.Fatalf("model = %q, want %q", updated.ActiveSettings.Model, tt.wantModel)
+			}
+			if updated.ActiveSettings.ThinkingLevel != tt.wantThinking {
+				t.Fatalf("thinking = %q, want %q", updated.ActiveSettings.ThinkingLevel, tt.wantThinking)
+			}
+			if updated.ActiveSettings.EnabledTools[toolspec.ToolPatch] != tt.wantPatchSetting {
+				t.Fatalf("patch setting = %t, want %t", updated.ActiveSettings.EnabledTools[toolspec.ToolPatch], tt.wantPatchSetting)
+			}
+			gotRole := ""
+			if continuation := store.Meta().Continuation; continuation != nil {
+				gotRole = continuation.AgentRole
+			}
+			if gotRole != tt.wantAgentRole {
+				t.Fatalf("continuation role = %q, want %q", gotRole, tt.wantAgentRole)
+			}
+		})
+	}
+}
+
 func TestPlannerNewChildSessionPreservesParentWorktreeContext(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -1708,6 +1708,56 @@ func TestApplyRunPromptOverridesFastRoleUsesCLIProviderOverrideForHeuristic(t *t
 	}
 }
 
+func TestPlannerResumeFastRoleUsesProviderOverrideForHeuristic(t *testing.T) {
+	root := t.TempDir()
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	configPath := filepath.Join(home, ".builder", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	contents := strings.Join([]string{
+		"model = \"my-team-alias\"",
+		"provider_override = \"openai\"",
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	loaded, err := config.Load(workspace, config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	containerDir := filepath.Join(root, "sessions", "workspace-a")
+	store, err := session.Create(containerDir, "workspace-a", workspace)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.SetContinuationContext(session.ContinuationContext{AgentRole: config.BuiltInSubagentRoleFast}); err != nil {
+		t.Fatalf("SetContinuationContext: %v", err)
+	}
+	planner := Planner{
+		Config: config.App{
+			WorkspaceRoot:   workspace,
+			PersistenceRoot: root,
+			Settings:        loaded.Settings,
+			Source:          loaded.Source,
+		},
+		ContainerDir: containerDir,
+	}
+
+	plan, err := planner.PlanSession(context.Background(), SessionRequest{Mode: ModeInteractive, SelectedSessionID: store.Meta().SessionID})
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if plan.ActiveSettings.Model != "gpt-5.4-mini" {
+		t.Fatalf("model = %q, want fast heuristic model", plan.ActiveSettings.Model)
+	}
+	if !plan.ActiveSettings.PriorityRequestMode {
+		t.Fatal("expected fast heuristic priority mode")
+	}
+}
+
 func TestApplyRunPromptOverridesFailedConfigOverrideDoesNotPersistContinuation(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -1758,6 +1758,56 @@ func TestPlannerResumeFastRoleUsesProviderOverrideForHeuristic(t *testing.T) {
 	}
 }
 
+func TestPlannerResumeFastRoleUsesOpenAIBaseURLForHeuristic(t *testing.T) {
+	root := t.TempDir()
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	configPath := filepath.Join(home, ".builder", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	contents := strings.Join([]string{
+		"model = \"my-team-alias\"",
+		"openai_base_url = \"https://api.openai.com/v1\"",
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	loaded, err := config.Load(workspace, config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	containerDir := filepath.Join(root, "sessions", "workspace-a")
+	store, err := session.Create(containerDir, "workspace-a", workspace)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.SetContinuationContext(session.ContinuationContext{AgentRole: config.BuiltInSubagentRoleFast}); err != nil {
+		t.Fatalf("SetContinuationContext: %v", err)
+	}
+	planner := Planner{
+		Config: config.App{
+			WorkspaceRoot:   workspace,
+			PersistenceRoot: root,
+			Settings:        loaded.Settings,
+			Source:          loaded.Source,
+		},
+		ContainerDir: containerDir,
+	}
+
+	plan, err := planner.PlanSession(context.Background(), SessionRequest{Mode: ModeInteractive, SelectedSessionID: store.Meta().SessionID})
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if plan.ActiveSettings.Model != "gpt-5.4-mini" {
+		t.Fatalf("model = %q, want fast heuristic model", plan.ActiveSettings.Model)
+	}
+	if !plan.ActiveSettings.PriorityRequestMode {
+		t.Fatal("expected fast heuristic priority mode")
+	}
+}
+
 func TestApplyRunPromptOverridesFailedConfigOverrideDoesNotPersistContinuation(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()

--- a/server/runtime/meta_context.go
+++ b/server/runtime/meta_context.go
@@ -261,9 +261,9 @@ func (b metaContextBuilder) subagentsMetaMessage() (llm.Message, bool) {
 	}
 	lines := make([]string, 0, len(roles)+3)
 	lines = append(lines, "Available subagent roles:")
-	lines = append(lines, "- default: not specifying any role will invoke an exact clone of you, the general-purpose agent")
+	lines = append(lines, "- `default`: not specifying any role will invoke the default general-purpose agent")
 	for _, role := range roles {
-		lines = append(lines, "- "+role.Name+": "+role.Description)
+		lines = append(lines, "- `"+role.Name+"`: "+role.Description)
 	}
 	lines = append(lines, "---")
 	lines = append(lines, "Invoke with `"+prompts.BuilderRunCommand()+" --agent=<role> \"<prompt>\"`.")

--- a/server/runtime/subagents_test.go
+++ b/server/runtime/subagents_test.go
@@ -62,8 +62,8 @@ func TestSubagentsMetaMessageRendersCallableNonNoopRoles(t *testing.T) {
 	content := result.Subagents[0].Content
 	for _, want := range []string{
 		"Available subagent roles:",
-		"- default: not specifying any role will invoke an exact clone of you, the general-purpose agent",
-		"- research: Repo research specialist.",
+		"- `default`: not specifying any role will invoke the default general-purpose agent",
+		"- `research`: Repo research specialist.",
 		"Invoke with `",
 		"--agent=<role> \"<prompt>\"`.",
 	} {
@@ -108,7 +108,7 @@ func TestSubagentsMetaMessageUsesFallbackAndRequiresCallerShell(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if len(result.Subagents) != 1 || !strings.Contains(result.Subagents[0].Content, "- worker: gpt-5.4-mini, thinking high, fast mode on, can edit, can call shell") {
+	if len(result.Subagents) != 1 || !strings.Contains(result.Subagents[0].Content, "- `worker`: gpt-5.4-mini, thinking high, fast mode on, can edit, can call shell") {
 		t.Fatalf("unexpected fallback content: %+v", result.Subagents)
 	}
 
@@ -154,7 +154,7 @@ func TestSubagentsMetaMessageCurrentNonCallableRoleDoesNotDisableOtherRoles(t *t
 		t.Fatalf("subagent messages = %d, want 1", len(result.Subagents))
 	}
 	content := result.Subagents[0].Content
-	if !strings.Contains(content, "- worker: Callable helper.") {
+	if !strings.Contains(content, "- `worker`: Callable helper.") {
 		t.Fatalf("expected callable helper in context:\n%s", content)
 	}
 	if strings.Contains(content, "current") {
@@ -197,7 +197,7 @@ func TestCompactionReinjectsSubagentsMetaContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compactionReinjectedBaseMessages: %v", err)
 	}
-	if !hasSubagentCatalog(messages, "- worker: Callable helper.") {
+	if !hasSubagentCatalog(messages, "- `worker`: Callable helper.") {
 		t.Fatalf("expected compaction-reinjected subagent catalog, got %+v", messages)
 	}
 }
@@ -245,7 +245,7 @@ func TestManualCompactionPersistsSubagentCatalogInCanonicalTranscript(t *testing
 	if err := eng.CompactContext(context.Background(), ""); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
-	if !hasSubagentCatalog(eng.snapshotMessages(), "- worker: Callable helper.") {
+	if !hasSubagentCatalog(eng.snapshotMessages(), "- `worker`: Callable helper.") {
 		t.Fatalf("expected in-memory canonical transcript to keep subagent catalog, got %+v", eng.snapshotMessages())
 	}
 
@@ -257,7 +257,7 @@ func TestManualCompactionPersistsSubagentCatalogInCanonicalTranscript(t *testing
 	if err != nil {
 		t.Fatalf("restore engine: %v", err)
 	}
-	if !hasSubagentCatalog(restored.snapshotMessages(), "- worker: Callable helper.") {
+	if !hasSubagentCatalog(restored.snapshotMessages(), "- `worker`: Callable helper.") {
 		t.Fatalf("expected persisted canonical transcript to keep subagent catalog, got %+v", restored.snapshotMessages())
 	}
 }

--- a/server/sessionlaunch/service.go
+++ b/server/sessionlaunch/service.go
@@ -82,7 +82,7 @@ func (s *Service) PlanLaunchSession(ctx context.Context, req serverapi.SessionPl
 			return PlanResult{}, err
 		}
 		authState := auth.EmptyState()
-		if req.Overrides.HasAny() && s.authStates != nil {
+		if req.Overrides.NeedsAuthState() && s.authStates != nil {
 			var authErr error
 			authState, authErr = s.authStates.CurrentState(ctx)
 			if authErr != nil {

--- a/server/sessionlaunch/service_test.go
+++ b/server/sessionlaunch/service_test.go
@@ -2,9 +2,11 @@ package sessionlaunch
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
+	"builder/server/auth"
 	"builder/server/launch"
 	"builder/server/registry"
 	"builder/server/session"
@@ -12,6 +14,12 @@ import (
 	"builder/shared/serverapi"
 	"builder/shared/toolspec"
 )
+
+type failingAuthStateReader struct{}
+
+func (failingAuthStateReader) CurrentState(context.Context) (auth.State, error) {
+	return auth.State{}, errors.New("auth unavailable")
+}
 
 func TestServicePlanSessionRegistersStoreAndReturnsPlan(t *testing.T) {
 	persistenceRoot := t.TempDir()
@@ -203,5 +211,27 @@ func TestServicePlanSessionPropagatesOverrideToolConflict(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "tools.patch and tools.edit cannot both be enabled") {
 		t.Fatalf("error = %v, want tool conflict", err)
+	}
+}
+
+func TestServicePlanSessionDefaultRoleClearDoesNotRequireAuthState(t *testing.T) {
+	workspace := t.TempDir()
+	containerDir := t.TempDir()
+	service := NewService(launch.Planner{
+		Config: config.App{
+			WorkspaceRoot:   workspace,
+			PersistenceRoot: t.TempDir(),
+			Settings:        config.Settings{Model: "gpt-5.5"},
+		},
+		ContainerDir: containerDir,
+	}, registry.NewSessionStoreRegistry()).WithAuthStateReader(failingAuthStateReader{})
+
+	if _, err := service.PlanSession(context.Background(), serverapi.SessionPlanRequest{
+		ClientRequestID: "req-1",
+		Mode:            serverapi.SessionLaunchModeInteractive,
+		ForceNewSession: true,
+		Overrides:       serverapi.RunPromptOverrides{AgentRoleSet: true},
+	}); err != nil {
+		t.Fatalf("PlanSession with default role clear should not read auth state: %v", err)
 	}
 }

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -148,7 +148,7 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 	}
 	sessionID := strings.TrimSpace(req.SessionID)
 	requestID := strings.TrimSpace(req.ClientRequestID)
-	if s.externalSessionRuntimeActive(sessionID) {
+	if s.confirmExternalSessionRuntimeActive(ctx, sessionID) {
 		return serverapi.SessionRuntimeActivateResponse{ReadOnly: true}, nil
 	}
 	handle, takeover, claim, err := s.claimActivation(sessionID, requestID)
@@ -276,6 +276,17 @@ func (s *Service) externalSessionRuntimeActive(sessionID string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.handles[strings.TrimSpace(sessionID)] == nil
+}
+
+func (s *Service) confirmExternalSessionRuntimeActive(ctx context.Context, sessionID string) bool {
+	if !s.externalSessionRuntimeActive(sessionID) || s.runtimes == nil {
+		return false
+	}
+	engine, err := s.runtimes.ResolveRuntime(ctx, sessionID)
+	if err != nil || engine == nil {
+		return false
+	}
+	return s.externalSessionRuntimeActive(sessionID)
 }
 
 func runtimeRebindFunc(localRebind func(string) error, engine *runtime.Engine) func(string) error {

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -53,6 +53,8 @@ type runtimeHandle struct {
 	closing             bool
 	takeover            *runtimeTakeover
 	ready               chan struct{}
+	closed              chan struct{}
+	closedOnce          sync.Once
 	rebind              func(string) error
 	close               func()
 }
@@ -70,6 +72,7 @@ type activationClaim int
 const (
 	activationClaimOwner activationClaim = iota
 	activationClaimReuse
+	activationClaimClosing
 	activationClaimTakeoverReuse
 	activationClaimTakeover
 )
@@ -148,12 +151,24 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 	}
 	sessionID := strings.TrimSpace(req.SessionID)
 	requestID := strings.TrimSpace(req.ClientRequestID)
-	if s.confirmExternalSessionRuntimeActive(ctx, sessionID) {
-		return serverapi.SessionRuntimeActivateResponse{ReadOnly: true}, nil
-	}
-	handle, takeover, claim, err := s.claimActivation(sessionID, requestID)
-	if err != nil {
-		return serverapi.SessionRuntimeActivateResponse{}, err
+	var handle *runtimeHandle
+	var takeover *runtimeTakeover
+	var claim activationClaim
+	var err error
+	for {
+		if s.confirmExternalSessionRuntimeActive(ctx, sessionID) {
+			return serverapi.SessionRuntimeActivateResponse{ReadOnly: true}, nil
+		}
+		handle, takeover, claim, err = s.claimActivation(sessionID, requestID)
+		if err != nil {
+			return serverapi.SessionRuntimeActivateResponse{}, err
+		}
+		if claim != activationClaimClosing {
+			break
+		}
+		if err := waitForRuntimeHandleClosed(ctx, handle); err != nil {
+			return serverapi.SessionRuntimeActivateResponse{}, err
+		}
 	}
 	if claim == activationClaimReuse {
 		if err := waitForRuntimeHandleReady(ctx, handle); err != nil {
@@ -343,6 +358,7 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 	s.mu.Lock()
 	if s.handles[sessionID] == current {
 		delete(s.handles, sessionID)
+		signalRuntimeHandleClosed(current)
 	}
 	s.mu.Unlock()
 	return serverapi.SessionRuntimeReleaseResponse{}, leaseErr
@@ -370,6 +386,7 @@ func (s *Service) closeReleasedRuntimeHandle(sessionID string, handle *runtimeHa
 	s.mu.Lock()
 	if s.handles[trimmedSessionID] == current {
 		delete(s.handles, trimmedSessionID)
+		signalRuntimeHandleClosed(current)
 	}
 	s.mu.Unlock()
 }
@@ -602,7 +619,7 @@ func (s *Service) claimActivation(sessionID string, requestID string) (*runtimeH
 	defer s.mu.Unlock()
 	if current := s.handles[sessionID]; current != nil {
 		if current.closing {
-			return nil, nil, activationClaimOwner, errors.Join(serverapi.ErrSessionAlreadyControlled, fmt.Errorf("session %q is closing its active controller", sessionID))
+			return current, nil, activationClaimClosing, nil
 		}
 		if current.controllerRequestID == requestID {
 			return current, nil, activationClaimReuse, nil
@@ -623,9 +640,17 @@ func (s *Service) claimActivation(sessionID string, requestID string) (*runtimeH
 		}
 		return nil, nil, activationClaimOwner, errors.Join(serverapi.ErrSessionAlreadyControlled, fmt.Errorf("session %q is already controlled by another client", sessionID))
 	}
-	handle := &runtimeHandle{controllerRequestID: requestID, ready: make(chan struct{})}
+	handle := newRuntimeHandle(requestID)
 	s.handles[sessionID] = handle
 	return handle, nil, activationClaimOwner, nil
+}
+
+func newRuntimeHandle(requestID string) *runtimeHandle {
+	return &runtimeHandle{
+		controllerRequestID: strings.TrimSpace(requestID),
+		ready:               make(chan struct{}),
+		closed:              make(chan struct{}),
+	}
 }
 
 func (s *Service) takeOverActivation(ctx context.Context, sessionID string, requestID string, handle *runtimeHandle, takeover *runtimeTakeover) (serverapi.SessionRuntimeActivateResponse, error) {
@@ -786,6 +811,27 @@ func waitForRuntimeHandleReady(ctx context.Context, handle *runtimeHandle) error
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+func waitForRuntimeHandleClosed(ctx context.Context, handle *runtimeHandle) error {
+	if handle == nil || handle.closed == nil {
+		return nil
+	}
+	select {
+	case <-handle.closed:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func signalRuntimeHandleClosed(handle *runtimeHandle) {
+	if handle == nil || handle.closed == nil {
+		return
+	}
+	handle.closedOnce.Do(func() {
+		close(handle.closed)
+	})
 }
 
 func activationResponseForHandle(handle *runtimeHandle) (serverapi.SessionRuntimeActivateResponse, error) {

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -147,6 +147,9 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 	}
 	sessionID := strings.TrimSpace(req.SessionID)
 	requestID := strings.TrimSpace(req.ClientRequestID)
+	if s.externalSessionRuntimeActive(sessionID) {
+		return serverapi.SessionRuntimeActivateResponse{ReadOnly: true}, nil
+	}
 	handle, takeover, claim, err := s.claimActivation(sessionID, requestID)
 	if err != nil {
 		return serverapi.SessionRuntimeActivateResponse{}, err
@@ -263,6 +266,15 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 	s.completeActivation(handle, leaseID, cleanup)
 	cleanup = nil
 	return serverapi.SessionRuntimeActivateResponse{LeaseID: leaseID}, nil
+}
+
+func (s *Service) externalSessionRuntimeActive(sessionID string) bool {
+	if s == nil || s.runtimes == nil || !s.runtimes.IsSessionRuntimeActive(sessionID) {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.handles[strings.TrimSpace(sessionID)] == nil
 }
 
 func runtimeRebindFunc(localRebind func(string) error, engine *runtime.Engine) func(string) error {

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -50,6 +50,7 @@ type runtimeHandle struct {
 	controllerRequestID string
 	controllerLeaseID   string
 	activationErr       error
+	closing             bool
 	takeover            *runtimeTakeover
 	ready               chan struct{}
 	rebind              func(string) error
@@ -320,7 +321,7 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 		s.mu.Unlock()
 		return serverapi.SessionRuntimeReleaseResponse{}, invalidControllerLeaseError(sessionID)
 	}
-	delete(s.handles, sessionID)
+	current.closing = true
 	closeFn := current.close
 	takeover := current.takeover
 	s.mu.Unlock()
@@ -328,6 +329,11 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 	if closeFn != nil {
 		closeFn()
 	}
+	s.mu.Lock()
+	if s.handles[sessionID] == current {
+		delete(s.handles, sessionID)
+	}
+	s.mu.Unlock()
 	return serverapi.SessionRuntimeReleaseResponse{}, leaseErr
 }
 
@@ -342,7 +348,7 @@ func (s *Service) closeReleasedRuntimeHandle(sessionID string, handle *runtimeHa
 		s.mu.Unlock()
 		return
 	}
-	delete(s.handles, trimmedSessionID)
+	current.closing = true
 	closeFn := current.close
 	takeover := current.takeover
 	s.mu.Unlock()
@@ -350,6 +356,11 @@ func (s *Service) closeReleasedRuntimeHandle(sessionID string, handle *runtimeHa
 	if closeFn != nil {
 		closeFn()
 	}
+	s.mu.Lock()
+	if s.handles[trimmedSessionID] == current {
+		delete(s.handles, trimmedSessionID)
+	}
+	s.mu.Unlock()
 }
 
 func (s *Service) RequireControllerLease(ctx context.Context, sessionID string, leaseID string) error {
@@ -579,6 +590,9 @@ func (s *Service) claimActivation(sessionID string, requestID string) (*runtimeH
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if current := s.handles[sessionID]; current != nil {
+		if current.closing {
+			return nil, nil, activationClaimOwner, errors.Join(serverapi.ErrSessionAlreadyControlled, fmt.Errorf("session %q is closing its active controller", sessionID))
+		}
 		if current.controllerRequestID == requestID {
 			return current, nil, activationClaimReuse, nil
 		}

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -273,6 +273,57 @@ func TestClaimActivationRejectsConcurrentDifferentTakeoverRequest(t *testing.T) 
 	}
 }
 
+func TestActivateSessionRuntimeWaitsForClosingHandleBeforeClaiming(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	fixture.service.authManager = auth.NewManager(auth.NewMemoryStore(auth.State{
+		Scope: auth.ScopeGlobal,
+		Method: auth.Method{
+			Type:   auth.MethodAPIKey,
+			APIKey: &auth.APIKeyMethod{Key: "sk-test"},
+		},
+	}), nil, time.Now)
+	ready := make(chan struct{})
+	close(ready)
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   "lease-1",
+		closing:             true,
+		ready:               ready,
+		closed:              make(chan struct{}),
+	}
+	fixture.service.handles = map[string]*runtimeHandle{fixture.store.Meta().SessionID: handle}
+
+	done := make(chan serverapi.SessionRuntimeActivateResponse, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		resp, err := fixture.service.ActivateSessionRuntime(context.Background(), serverapi.SessionRuntimeActivateRequest{
+			ClientRequestID: "req-2",
+			SessionID:       fixture.store.Meta().SessionID,
+			ActiveSettings: config.Settings{
+				Model: "gpt-5",
+				Reviewer: config.ReviewerSettings{
+					Frequency: "off",
+				},
+			},
+		})
+		done <- resp
+		errCh <- err
+	}()
+	select {
+	case <-done:
+		t.Fatal("expected activation to wait for closing handle")
+	default:
+	}
+
+	fixture.service.closeReleasedRuntimeHandle(fixture.store.Meta().SessionID, handle)
+	if err := <-errCh; err != nil {
+		t.Fatalf("ActivateSessionRuntime: %v", err)
+	}
+	if strings.TrimSpace((<-done).LeaseID) == "" {
+		t.Fatal("expected replacement activation lease id")
+	}
+}
+
 func TestActivateSessionRuntimeReplaysDuplicateRequestAfterReady(t *testing.T) {
 	fixture := newSessionRuntimeFixture(t)
 	handle := &runtimeHandle{

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -381,6 +381,37 @@ func TestActivateSessionRuntimeIgnoresRecoveredWarningProviderError(t *testing.T
 	}
 }
 
+func TestActivateSessionRuntimeAttachesReadOnlyToExternalActiveRuntime(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	runtimes := registry.NewRuntimeRegistry()
+	engine, err := runtimepkg.New(fixture.store, &sessionRuntimeTestLLMClient{}, tools.NewRegistry(), runtimepkg.Config{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("runtime.New: %v", err)
+	}
+	defer func() { _ = engine.Close() }()
+	runtimes.Register(fixture.store.Meta().SessionID, engine)
+	t.Cleanup(func() { runtimes.Unregister(fixture.store.Meta().SessionID, engine) })
+	fixture.service.runtimes = runtimes
+
+	resp, err := fixture.service.ActivateSessionRuntime(context.Background(), serverapi.SessionRuntimeActivateRequest{
+		ClientRequestID: "req-external",
+		SessionID:       fixture.store.Meta().SessionID,
+		ActiveSettings:  config.Settings{Model: "gpt-5"},
+	})
+	if err != nil {
+		t.Fatalf("ActivateSessionRuntime: %v", err)
+	}
+	if !resp.ReadOnly || strings.TrimSpace(resp.LeaseID) != "" {
+		t.Fatalf("response = %+v, want read-only without lease", resp)
+	}
+	if len(fixture.service.handles) != 0 {
+		t.Fatalf("external active runtime should not leave controller handles, got %+v", fixture.service.handles)
+	}
+	if !runtimes.IsSessionRuntimeActive(fixture.store.Meta().SessionID) {
+		t.Fatal("expected external runtime to remain registered")
+	}
+}
+
 func TestAppendRecoveredWarningIfNeededPersistsOnce(t *testing.T) {
 	fixture := newSessionRuntimeFixture(t)
 	warning := "generated warning"

--- a/shared/serverapi/run_prompt.go
+++ b/shared/serverapi/run_prompt.go
@@ -3,6 +3,8 @@ package serverapi
 import (
 	"strings"
 	"time"
+
+	"builder/shared/config"
 )
 
 type RunPromptRequest struct {
@@ -45,6 +47,10 @@ func (o RunPromptOverrides) HasConfigOverrides() bool {
 		o.ModelTimeoutSeconds > 0 ||
 		strings.TrimSpace(o.Tools) != "" ||
 		strings.TrimSpace(o.OpenAIBaseURL) != ""
+}
+
+func (o RunPromptOverrides) NeedsAuthState() bool {
+	return config.NormalizeSubagentSelector(o.AgentRole) != ""
 }
 
 type RunPromptResponse struct {

--- a/shared/serverapi/run_prompt.go
+++ b/shared/serverapi/run_prompt.go
@@ -15,6 +15,7 @@ type RunPromptRequest struct {
 
 type RunPromptOverrides struct {
 	AgentRole           string
+	AgentRoleSet        bool
 	Model               string
 	ProviderOverride    string
 	ThinkingLevel       string
@@ -25,7 +26,8 @@ type RunPromptOverrides struct {
 }
 
 func (o RunPromptOverrides) HasAny() bool {
-	return strings.TrimSpace(o.AgentRole) != "" ||
+	return o.AgentRoleSet ||
+		strings.TrimSpace(o.AgentRole) != "" ||
 		strings.TrimSpace(o.Model) != "" ||
 		strings.TrimSpace(o.ProviderOverride) != "" ||
 		strings.TrimSpace(o.ThinkingLevel) != "" ||

--- a/shared/serverapi/run_prompt_test.go
+++ b/shared/serverapi/run_prompt_test.go
@@ -1,0 +1,47 @@
+package serverapi
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRunPromptOverridesAgentRoleSetJSONRoundTrip(t *testing.T) {
+	req := SessionPlanRequest{
+		ClientRequestID: "req-1",
+		Mode:            SessionLaunchModeHeadless,
+		ForceNewSession: true,
+		Overrides: RunPromptOverrides{
+			AgentRoleSet: true,
+		},
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got SessionPlanRequest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !got.Overrides.AgentRoleSet {
+		t.Fatalf("AgentRoleSet = false after round trip: %s", data)
+	}
+	if !got.Overrides.HasAny() {
+		t.Fatal("default-role override presence should count as an override")
+	}
+}
+
+func TestRunPromptOverridesAgentRoleCompatJSON(t *testing.T) {
+	var got SessionPlanRequest
+	if err := json.Unmarshal([]byte(`{"ClientRequestID":"req-1","Mode":"headless","ForceNewSession":true,"Overrides":{"AgentRole":"worker"}}`), &got); err != nil {
+		t.Fatalf("Unmarshal legacy request: %v", err)
+	}
+	if got.Overrides.AgentRole != "worker" {
+		t.Fatalf("AgentRole = %q, want worker", got.Overrides.AgentRole)
+	}
+	if got.Overrides.AgentRoleSet {
+		t.Fatal("legacy JSON without AgentRoleSet should leave AgentRoleSet false")
+	}
+	if !got.Overrides.HasAny() {
+		t.Fatal("legacy AgentRole should still count as an override")
+	}
+}

--- a/shared/serverapi/session_runtime.go
+++ b/shared/serverapi/session_runtime.go
@@ -16,7 +16,8 @@ type SessionRuntimeActivateRequest struct {
 }
 
 type SessionRuntimeActivateResponse struct {
-	LeaseID string `json:"lease_id"`
+	LeaseID  string `json:"lease_id"`
+	ReadOnly bool   `json:"read_only,omitempty"`
 }
 
 type SessionRuntimeReleaseRequest struct {


### PR DESCRIPTION
## Summary
- reapply persisted subagent role settings on resume without blocking continuation when roles are missing
- update model-visible subagent catalog wording and backtick role labels
- attach TUI to active headless sessions as read-only so the original builder run remains the runtime owner
- preserve explicit --agent default/none/self clearing semantics for continued headless runs

## Verification
- ./scripts/test.sh ./...
- ./scripts/build.sh --output ./bin/builder
- git diff --check
- push hook: formatting, go vet, go build, test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attach to active sessions in read-only mode so interactive viewers don’t interrupt headless runs.
  * Explicit agent-role overrides are tracked so choosing/clearing a role is honored and persisted correctly.
  * UI now prevents edits when connected in read-only mode.

* **Documentation**
  * Clarified headless/session continuation behavior and agent-role reapplication in docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/respawn-app/builder/pull/261)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->