### PR TITLE
fix: show verbose supervisor suggestions

### DIFF
--- a/cli/app/ui_messages.go
+++ b/cli/app/ui_messages.go
@@ -69,9 +69,10 @@ type nativeResizeReplayMsg struct {
 }
 
 type nativeHistoryFlushMsg struct {
-	Text       string
-	AllowBlank bool
-	Sequence   uint64
+	Text             string
+	AllowBlank       bool
+	ClearBelowBefore bool
+	Sequence         uint64
 }
 
 type nativeStreamingStableFlushAckMsg struct {

--- a/cli/app/ui_native_history.go
+++ b/cli/app/ui_native_history.go
@@ -246,8 +246,16 @@ func (m *uiModel) finalizeNativeStreamingCommit(projection tui.TranscriptProject
 	}
 	hadCommittedHistory := previousCommittedCount > 0
 	finalUpdate := m.nativeStreamingController.FinalizeSource(committedEntries[streamedAssistantIndex].Text)
-	flushTail := m.emitNativeRenderedText(renderStyledNativeProjectionLines(m.nativeStreamingFinalizeLines(finalUpdate.stable, hadCommittedHistory), m.theme, m.nativeReplayRenderWidth()))
-	postAssistant := m.emitNativeProjectionLinesForEntryRangeExcluding(projection, previousCommittedCount, committedCount, streamedAssistantIndex)
+	flushTailText := renderStyledNativeProjectionLines(m.nativeStreamingFinalizeLines(finalUpdate.stable, hadCommittedHistory), m.theme, m.nativeReplayRenderWidth())
+	postAssistantText := m.nativeProjectionTextForEntryRangeExcluding(projection, previousCommittedCount, committedCount, streamedAssistantIndex)
+	var flushTail tea.Cmd
+	var postAssistant tea.Cmd
+	if strings.TrimSpace(flushTailText) != "" {
+		flushTail = m.emitNativeRenderedTextClearingBelow(flushTailText)
+		postAssistant = m.emitNativeRenderedText(postAssistantText)
+	} else {
+		postAssistant = m.emitNativeRenderedTextClearingBelow(postAssistantText)
+	}
 	m.consumeNativeHistoryReplayPermit()
 	m.rebaseNativeProjection(projection, m.transcriptBaseOffset, committedCount)
 	m.acceptNativeProjectionWithoutReplay(projection)
@@ -294,8 +302,16 @@ func (m *uiModel) emitNativeProjectionLinesAfterEntry(projection tui.TranscriptP
 }
 
 func (m *uiModel) emitNativeProjectionLinesForEntryRangeExcluding(projection tui.TranscriptProjection, startIndex int, endIndex int, excludedIndex int) tea.Cmd {
-	if m == nil || startIndex >= endIndex {
+	styled := m.nativeProjectionTextForEntryRangeExcluding(projection, startIndex, endIndex, excludedIndex)
+	if strings.TrimSpace(styled) == "" {
 		return nil
+	}
+	return m.emitNativeRenderedText(styled)
+}
+
+func (m *uiModel) nativeProjectionTextForEntryRangeExcluding(projection tui.TranscriptProjection, startIndex int, endIndex int, excludedIndex int) string {
+	if m == nil || startIndex >= endIndex {
+		return ""
 	}
 	startAbsolute := m.transcriptBaseOffset + startIndex
 	endAbsolute := m.transcriptBaseOffset + endIndex
@@ -319,9 +335,9 @@ func (m *uiModel) emitNativeProjectionLinesForEntryRangeExcluding(projection tui
 	}
 	styled := renderStyledNativeProjectionLines(lines, m.theme, m.nativeReplayRenderWidth())
 	if strings.TrimSpace(styled) == "" {
-		return nil
+		return ""
 	}
-	return m.emitNativeRenderedText(styled)
+	return styled
 }
 
 func (m *uiModel) armNativeHistoryReplayPermit(permit nativeHistoryReplayPermit) {

--- a/cli/app/ui_native_history.go
+++ b/cli/app/ui_native_history.go
@@ -161,7 +161,6 @@ func (m *uiModel) resetNativeHistoryState() {
 func (m *uiModel) resetNativeStreamingState() {
 	m.nativeStreamingController = newNativeAssistantStreamController(m.theme, m.nativeReplayRenderWidth())
 	m.nativeStreamingTail = nil
-	m.nativeStreamingUnflushedStable = nil
 	m.nativeStreamingStableFlushSequence = 0
 	m.nativeStreamingText = ""
 	m.nativeStreamingStepID = ""
@@ -191,9 +190,9 @@ func (m *uiModel) syncNativeStreamingScrollback() tea.Cmd {
 	m.nativeStreamingText = m.nativeStreamingController.source
 	m.nativeStreamingWidth = width
 	m.nativeStreamingFlushedLineCount = m.nativeStreamingController.enqueuedStableLineCount
-	if len(update.stable) > 0 {
-		m.nativeStreamingUnflushedStable = append(m.nativeStreamingUnflushedStable, update.stable...)
-	}
+	// Stable lines are now owned by native scrollback once a flush is scheduled.
+	// Keeping them in the mutable live tail lets a final commit render the same
+	// prefix again if terminal output and runtime events interleave.
 	m.nativeStreamingTail = m.nativeStreamingLiveTail(update.tail)
 	if len(update.stable) == 0 {
 		return nil
@@ -269,13 +268,7 @@ func (m *uiModel) nativeStreamingFinalizeLines(stable []tui.TranscriptProjection
 }
 
 func (m *uiModel) nativeStreamingLiveTail(tail []tui.TranscriptProjectionLine) []tui.TranscriptProjectionLine {
-	if len(m.nativeStreamingUnflushedStable) == 0 {
-		return cloneNativeStreamProjectionLines(tail)
-	}
-	lines := make([]tui.TranscriptProjectionLine, 0, len(m.nativeStreamingUnflushedStable)+len(tail))
-	lines = append(lines, m.nativeStreamingUnflushedStable...)
-	lines = append(lines, tail...)
-	return lines
+	return cloneNativeStreamProjectionLines(tail)
 }
 
 func (m *uiModel) emitNativeProjectionLinesAfterEntry(projection tui.TranscriptProjection, entryIndex int) tea.Cmd {

--- a/cli/app/ui_native_history_part2_test.go
+++ b/cli/app/ui_native_history_part2_test.go
@@ -525,3 +525,110 @@ func TestProjectedRuntimeAssistantFinalAfterPromotionDoesNotDuplicateEarlierStre
 		t.Fatalf("expected streaming promotion state reset after commit, got text=%q flushed=%d divider=%v", m.nativeStreamingText, m.nativeStreamingFlushedLineCount, m.nativeStreamingDividerFlushed)
 	}
 }
+
+func TestRuntimeBatchDefersFinalUntilStreamingPromotionFlushes(t *testing.T) {
+	m := newProjectedTestUIModel(nil, closedProjectedRuntimeEvents(), nil,
+		WithUIInitialTranscript([]UITranscriptEntry{{Role: "user", Text: "capture board"}}),
+	)
+	next, startupCmd := m.Update(tea.WindowSizeMsg{Width: 80, Height: 8})
+	m = next.(*uiModel)
+	_ = collectCmdMessages(t, startupCmd)
+	m.discardPendingNativeHistoryFlushes()
+
+	prefix := "Captured the Kent project board in the browser:\n\n"
+	path := "/Users/nek/.builder/worktrees/builder-cli-c2f75fc8-68f5-4deb-a23c-21cc5820436d/gui-fixes/.builder/proofs/gui-browser-kent-board/screenshot-1779219845652.png"
+	tail := "\n\nI opened it via the browser client against `ws://127.0.0.1:53082/rpc`."
+	finalText := prefix + path + tail
+
+	next, firstCmd := m.Update(runtimeEventBatchMsg{events: []clientui.Event{
+		projectRuntimeEvent(runtime.Event{Kind: runtime.EventAssistantDelta, StepID: "step-1", AssistantDelta: prefix + path + "\n"}),
+		projectRuntimeEvent(runtime.Event{Kind: runtime.EventAssistantDelta, StepID: "step-1", AssistantDelta: tail}),
+		projectRuntimeEvent(runtime.Event{
+			Kind:                       runtime.EventAssistantMessage,
+			StepID:                     "step-1",
+			CommittedTranscriptChanged: true,
+			CommittedEntryStart:        1,
+			CommittedEntryStartSet:     true,
+			CommittedEntryCount:        2,
+			Message:                    llm.Message{Role: llm.RoleAssistant, Content: finalText, Phase: llm.MessagePhaseFinal},
+		}),
+	}})
+	m = next.(*uiModel)
+	firstFlush := collectNativeHistoryFlushText(collectCmdMessages(t, firstCmd))
+	if !strings.Contains(firstFlush, "Captured the Kent project board") {
+		t.Fatalf("expected first batch to promote stable streaming prefix, got %q", firstFlush)
+	}
+	if strings.Contains(firstFlush, "I opened it via the browser client") {
+		t.Fatalf("expected final tail to wait behind streaming flush, got %q", firstFlush)
+	}
+	if got := len(m.pendingRuntimeEvents); got != 2 {
+		t.Fatalf("expected remaining delta and final to wait behind native flush, got %d pending events", got)
+	}
+	if m.waitRuntimeEventAfterFlushSequence == 0 {
+		t.Fatal("expected runtime events to be fenced behind native streaming flush")
+	}
+
+	resumeCmd := m.handleNativeHistoryFlush(firstNativeHistoryFlushMsg(t, firstCmd))
+	msgs := collectCmdMessages(t, resumeCmd)
+	var resumed runtimeEventBatchMsg
+	found := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(runtimeEventBatchMsg); ok {
+			resumed = typed
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected runtime events to resume after native flush ack, got %+v", msgs)
+	}
+	next, secondCmd := m.Update(resumed)
+	m = next.(*uiModel)
+	secondFlush := collectNativeHistoryFlushText(collectCmdMessages(t, secondCmd))
+	if strings.Contains(secondFlush, "Captured the Kent project board") {
+		t.Fatalf("expected resumed streaming/final flush to avoid duplicate prefix, got %q", secondFlush)
+	}
+	if len(m.pendingRuntimeEvents) != 1 {
+		t.Fatalf("expected final event to remain pending until second streaming flush, got %d pending events", len(m.pendingRuntimeEvents))
+	}
+
+	resumeFinalCmd := m.handleNativeHistoryFlush(firstNativeHistoryFlushMsg(t, secondCmd))
+	finalMsgs := collectCmdMessages(t, resumeFinalCmd)
+	found = false
+	for _, msg := range finalMsgs {
+		if typed, ok := msg.(runtimeEventBatchMsg); ok {
+			resumed = typed
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected final event to resume after second native flush ack, got %+v", finalMsgs)
+	}
+	next, finalCmd := m.Update(resumed)
+	m = next.(*uiModel)
+	finalFlush := collectNativeHistoryFlushText(collectCmdMessages(t, finalCmd))
+	if strings.Contains(finalFlush, "Captured the Kent project board") {
+		t.Fatalf("expected final flush to avoid duplicate prefix, got %q", finalFlush)
+	}
+	if !strings.Contains(finalFlush, "I opened it via the browser client") {
+		t.Fatalf("expected final flush to include unpromoted tail, got %q", finalFlush)
+	}
+	combinedFlush := firstFlush + secondFlush + finalFlush
+	if got := strings.Count(combinedFlush, "Captured the Kent project board"); got != 1 {
+		t.Fatalf("expected promoted prefix once across native flushes, got %d in %q", got, combinedFlush)
+	}
+	if got := strings.Count(combinedFlush, "I opened it via the browser client"); got != 1 {
+		t.Fatalf("expected promoted tail once across native flushes, got %d in %q", got, combinedFlush)
+	}
+}
+
+func firstNativeHistoryFlushMsg(t *testing.T, cmd tea.Cmd) nativeHistoryFlushMsg {
+	t.Helper()
+	msgs := collectCmdMessages(t, cmd)
+	for _, msg := range msgs {
+		if flush, ok := msg.(nativeHistoryFlushMsg); ok {
+			return flush
+		}
+	}
+	t.Fatalf("expected nativeHistoryFlushMsg, got %+v", msgs)
+	return nativeHistoryFlushMsg{}
+}

--- a/cli/app/ui_native_history_part3_test.go
+++ b/cli/app/ui_native_history_part3_test.go
@@ -627,7 +627,7 @@ func TestNativeHistoryFlushWaitsForTargetSequenceBeforeRearmingRuntimeEvents(t *
 	}
 }
 
-func TestNativeStreamingStableTailClearsOnlyAfterFlushAck(t *testing.T) {
+func TestNativeStreamingStableTailIsRemovedBeforeNativeFlushAck(t *testing.T) {
 	m := newProjectedStaticUIModel(
 		WithUIInitialTranscript([]UITranscriptEntry{{Role: "user", Text: "prompt"}}),
 	)
@@ -643,8 +643,8 @@ func TestNativeStreamingStableTailClearsOnlyAfterFlushAck(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected streaming stable flush, got %T", streamCmd())
 	}
-	if got := joinedPlainProjectionLines(m.nativeStreamingUnflushedStable); !strings.Contains(got, "line1") {
-		t.Fatalf("expected stable line retained in live tail before flush ack, got %q", got)
+	if got := joinedPlainProjectionLines(m.nativeStreamingTail); strings.Contains(got, "line1") || !strings.Contains(got, "line2") {
+		t.Fatalf("expected scheduled stable line removed from live tail before flush ack, got %q", got)
 	}
 
 	laterCmd := m.emitNativeRenderedText("later")
@@ -655,30 +655,36 @@ func TestNativeStreamingStableTailClearsOnlyAfterFlushAck(t *testing.T) {
 	if cmd := m.handleNativeHistoryFlush(laterFlush); cmd != nil {
 		t.Fatalf("expected out-of-order later flush to buffer without commands, got %T", cmd())
 	}
-	if got := joinedPlainProjectionLines(m.nativeStreamingUnflushedStable); !strings.Contains(got, "line1") {
-		t.Fatalf("expected out-of-order flush not to clear stable live tail, got %q", got)
+	if got := joinedPlainProjectionLines(m.nativeStreamingTail); strings.Contains(got, "line1") || !strings.Contains(got, "line2") {
+		t.Fatalf("expected out-of-order flush not to restore scheduled stable line to live tail, got %q", got)
 	}
 
 	flushCmd := m.handleNativeHistoryFlush(streamFlush)
 	msgs := collectCmdMessages(t, flushCmd)
-	if got := joinedPlainProjectionLines(m.nativeStreamingUnflushedStable); !strings.Contains(got, "line1") {
-		t.Fatalf("expected stable live tail retained until explicit ack message, got %q", got)
-	}
 	var ack nativeStreamingStableFlushAckMsg
+	runtimeEventIndex := -1
+	ackIndex := -1
 	foundAck := false
-	for _, msg := range msgs {
+	for idx, msg := range msgs {
 		if typed, ok := msg.(nativeStreamingStableFlushAckMsg); ok {
 			ack = typed
 			foundAck = true
+			ackIndex = idx
+		}
+		if _, ok := msg.(runtimeEventBatchMsg); ok {
+			runtimeEventIndex = idx
 		}
 	}
 	if !foundAck {
 		t.Fatalf("expected stable flush ack message after ordered native flush, got %#v", msgs)
 	}
+	if runtimeEventIndex >= 0 && ackIndex > runtimeEventIndex {
+		t.Fatalf("expected stable flush ack before resumed runtime events, got msgs=%#v", msgs)
+	}
 
 	m.ackNativeStreamingStableFlush(ack.Sequence)
-	if got := joinedPlainProjectionLines(m.nativeStreamingUnflushedStable); got != "" {
-		t.Fatalf("expected ack to clear unflushed stable lines, got %q", got)
+	if m.nativeStreamingStableFlushSequence != 0 {
+		t.Fatalf("expected ack to clear stable flush sequence, got %d", m.nativeStreamingStableFlushSequence)
 	}
 	if got := joinedPlainProjectionLines(m.nativeStreamingTail); strings.Contains(got, "line1") || !strings.Contains(got, "line2") {
 		t.Fatalf("expected acked live tail to keep only mutable tail, got %q", got)

--- a/cli/app/ui_native_history_projection.go
+++ b/cli/app/ui_native_history_projection.go
@@ -127,16 +127,24 @@ func nativePendingEntries(entries []tui.TranscriptEntry) []tui.TranscriptEntry {
 }
 
 func (m *uiModel) emitNativeRenderedText(rendered string) tea.Cmd {
+	return m.emitNativeRenderedTextWithOptions(rendered, false)
+}
+
+func (m *uiModel) emitNativeRenderedTextClearingBelow(rendered string) tea.Cmd {
+	return m.emitNativeRenderedTextWithOptions(rendered, true)
+}
+
+func (m *uiModel) emitNativeRenderedTextWithOptions(rendered string, clearBelowBefore bool) tea.Cmd {
 	if len(rendered) <= 64*1024 {
-		return m.emitNativeHistoryFlush(rendered, false)
+		return m.emitNativeHistoryFlushWithOptions(rendered, false, clearBelowBefore)
 	}
 	chunks := splitNativeScrollbackChunks(rendered, 64*1024)
 	if len(chunks) == 0 {
 		return nil
 	}
 	cmds := make([]tea.Cmd, 0, len(chunks))
-	for _, chunk := range chunks {
-		if cmd := m.emitNativeHistoryFlush(chunk, false); cmd != nil {
+	for idx, chunk := range chunks {
+		if cmd := m.emitNativeHistoryFlushWithOptions(chunk, false, clearBelowBefore && idx == 0); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	}
@@ -150,6 +158,10 @@ func (m *uiModel) emitNativeRenderedText(rendered string) tea.Cmd {
 }
 
 func (m *uiModel) emitNativeHistoryFlush(text string, allowBlank bool) tea.Cmd {
+	return m.emitNativeHistoryFlushWithOptions(text, allowBlank, false)
+}
+
+func (m *uiModel) emitNativeHistoryFlushWithOptions(text string, allowBlank bool, clearBelowBefore bool) tea.Cmd {
 	if text == "" {
 		return nil
 	}
@@ -157,7 +169,7 @@ func (m *uiModel) emitNativeHistoryFlush(text string, allowBlank bool) tea.Cmd {
 		return nil
 	}
 	m.nativeFlushSequence++
-	msg := nativeHistoryFlushMsg{Text: text, AllowBlank: allowBlank, Sequence: m.nativeFlushSequence}
+	msg := nativeHistoryFlushMsg{Text: text, AllowBlank: allowBlank, ClearBelowBefore: clearBelowBefore, Sequence: m.nativeFlushSequence}
 	return func() tea.Msg {
 		return msg
 	}
@@ -207,7 +219,11 @@ func (m *uiModel) handleNativeHistoryFlush(msg nativeHistoryFlushMsg) tea.Cmd {
 	for {
 		m.nativeFlushedSequence = current.Sequence
 		if current.AllowBlank || strings.TrimSpace(current.Text) != "" {
-			cmds = append(cmds, tea.Printf("%s", current.Text))
+			text := current.Text
+			if current.ClearBelowBefore {
+				text = "\x1b[J" + text
+			}
+			cmds = append(cmds, tea.Printf("%s", text))
 		}
 		next, ok := m.nativePendingFlushes[m.nativeFlushedSequence+1]
 		if !ok {

--- a/cli/app/ui_native_history_projection.go
+++ b/cli/app/ui_native_history_projection.go
@@ -217,14 +217,14 @@ func (m *uiModel) handleNativeHistoryFlush(msg nativeHistoryFlushMsg) tea.Cmd {
 		current = next
 	}
 	ackSequence := m.nativeStreamingStableFlushAckSequence()
-	if m.waitRuntimeEventAfterFlushSequence != 0 && m.nativeFlushedSequence >= m.waitRuntimeEventAfterFlushSequence {
-		m.waitRuntimeEventAfterFlushSequence = 0
-		cmds = append(cmds, m.waitRuntimeEventCmd())
-	}
 	if ackSequence != 0 {
 		cmds = append(cmds, func() tea.Msg {
 			return nativeStreamingStableFlushAckMsg{Sequence: ackSequence}
 		})
+	}
+	if m.waitRuntimeEventAfterFlushSequence != 0 && m.nativeFlushedSequence >= m.waitRuntimeEventAfterFlushSequence {
+		m.waitRuntimeEventAfterFlushSequence = 0
+		cmds = append(cmds, m.waitRuntimeEventCmd())
 	}
 	return sequenceCmds(cmds...)
 }
@@ -240,7 +240,6 @@ func (m *uiModel) ackNativeStreamingStableFlush(sequence uint64) {
 	if sequence == 0 || m.nativeStreamingStableFlushSequence == 0 || sequence < m.nativeStreamingStableFlushSequence {
 		return
 	}
-	m.nativeStreamingUnflushedStable = nil
 	m.nativeStreamingStableFlushSequence = 0
 	m.nativeStreamingTail = m.nativeStreamingController.Tail()
 }

--- a/cli/app/ui_native_history_projection_test.go
+++ b/cli/app/ui_native_history_projection_test.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"builder/cli/tui"
@@ -87,6 +89,23 @@ func TestNativeHistoryFlushBuffersPendingSequencesInOrder(t *testing.T) {
 	}
 	if len(m.nativePendingFlushes) != 0 {
 		t.Fatalf("pending flushes = %d, want drained", len(m.nativePendingFlushes))
+	}
+}
+
+func TestNativeHistoryFlushClearBelowPrefixesPrintedText(t *testing.T) {
+	m := newProjectedStaticUIModel()
+
+	msgs := collectCmdMessages(t, m.handleNativeHistoryFlush(nativeHistoryFlushMsg{
+		Text:             "committed tail",
+		ClearBelowBefore: true,
+		Sequence:         1,
+	}))
+	if len(msgs) != 1 {
+		t.Fatalf("flush messages = %d, want 1", len(msgs))
+	}
+	printed := fmt.Sprintf("%+v", msgs[0])
+	if !strings.Contains(printed, "\x1b[Jcommitted tail") {
+		t.Fatalf("expected clear-below CSI before printed text, got %#v", msgs[0])
 	}
 }
 

--- a/cli/app/ui_native_scrollback_integration_part5_test.go
+++ b/cli/app/ui_native_scrollback_integration_part5_test.go
@@ -175,6 +175,10 @@ func TestNativeStreamedMultilineMarkdownFinalThenCommitAppearsOnceInScrollback(t
 	})
 	waitForTestCondition(t, 2*time.Second, "committed multiline final rendered", func() bool {
 		return strings.TrimSpace(model.view.OngoingStreamingText()) == "" &&
+			!model.nativeStreamingActive &&
+			model.nativeFlushedSequence >= model.nativeFlushSequence &&
+			model.waitRuntimeEventAfterFlushSequence == 0 &&
+			len(model.nativePendingFlushes) == 0 &&
 			strings.Contains(normalizedOutput(out.String()), "I opened it via the browser client")
 	})
 	program.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
@@ -291,7 +295,10 @@ func (t *replayTerminal) handleCSI(cmd xansi.Cmd, params xansi.Params) {
 		t.col = max(0, col-1)
 	case 'J':
 		mode, _, _ := params.Param(0, 0)
-		if mode == 2 {
+		switch mode {
+		case 0:
+			t.eraseScreenBelow()
+		case 2:
 			t.lines = nil
 			t.row = 0
 			t.col = 0
@@ -299,6 +306,16 @@ func (t *replayTerminal) handleCSI(cmd xansi.Cmd, params xansi.Params) {
 	case 'K':
 		mode, _, _ := params.Param(0, 0)
 		t.eraseLine(mode)
+	}
+}
+
+func (t *replayTerminal) eraseScreenBelow() {
+	t.ensureLine(t.row)
+	if t.col < len(t.lines[t.row]) {
+		t.lines[t.row] = t.lines[t.row][:t.col]
+	}
+	for idx := t.row + 1; idx < len(t.lines); idx++ {
+		t.lines[idx] = nil
 	}
 }
 

--- a/cli/app/ui_native_scrollback_integration_part5_test.go
+++ b/cli/app/ui_native_scrollback_integration_part5_test.go
@@ -4,6 +4,7 @@ import (
 	"builder/cli/tui"
 	"builder/server/llm"
 	"builder/server/runtime"
+	"builder/shared/clientui"
 	"bytes"
 	tea "github.com/charmbracelet/bubbletea"
 	xansi "github.com/charmbracelet/x/ansi"
@@ -139,6 +140,196 @@ func TestNativeStreamedFinalThenCommitAppearsOnceInScrollback(t *testing.T) {
 	if got := strings.Count(normalized, "final answer"); got != 1 {
 		t.Fatalf("expected streamed final plus commit to appear once, got %d in %q", got, normalized)
 	}
+}
+
+func TestNativeStreamedMultilineMarkdownFinalThenCommitAppearsOnceInScrollback(t *testing.T) {
+	out := &bytes.Buffer{}
+	runtimeEvents := make(chan clientui.Event, 8)
+	model := newProjectedTestUIModel(nil, runtimeEvents, closedAskEvents())
+	program := tea.NewProgram(model, tea.WithInput(strings.NewReader("")), tea.WithOutput(out), tea.WithoutSignals())
+	done := make(chan error, 1)
+	go func() {
+		_, err := program.Run()
+		done <- err
+	}()
+	time.Sleep(30 * time.Millisecond)
+	program.Send(tea.WindowSizeMsg{Width: 80, Height: 30})
+
+	prefix := "Captured the Kent project board in the browser:\n\n"
+	path := "/Users/nek/.builder/worktrees/builder-cli-c2f75fc8-68f5-4deb-a23c-21cc5820436d/gui-fixes/.builder/proofs/gui-browser-kent-board/screenshot-1779219845652.png"
+	tail := "\n\nI opened it via the browser client against `ws://127.0.0.1:53082/rpc`; the board URL was `http://127.0.0.1:1433/projects/project-94b18685-19ed-4513-96bb-bcffa10410ff?workflowId=workflow-9f88e01d-f923-45a6-8c96-95298da24815&taskId=&resumeRunId=`."
+	finalText := prefix + path + tail
+
+	runtimeEvents <- projectRuntimeEvent(runtime.Event{Kind: runtime.EventAssistantDelta, StepID: "step-1", AssistantDelta: prefix + path + "\n"})
+	waitForTestCondition(t, 2*time.Second, "streamed markdown prefix visible", func() bool {
+		return strings.Contains(normalizedOutput(out.String()), "Captured the Kent project board")
+	})
+	runtimeEvents <- projectRuntimeEvent(runtime.Event{Kind: runtime.EventAssistantDelta, StepID: "step-1", AssistantDelta: tail})
+	runtimeEvents <- projectRuntimeEvent(runtime.Event{
+		Kind:                       runtime.EventAssistantMessage,
+		StepID:                     "step-1",
+		CommittedTranscriptChanged: true,
+		CommittedEntryCount:        1,
+		CommittedEntryStartSet:     true,
+		Message:                    llm.Message{Role: llm.RoleAssistant, Content: finalText, Phase: llm.MessagePhaseFinal},
+	})
+	waitForTestCondition(t, 2*time.Second, "committed multiline final rendered", func() bool {
+		return strings.TrimSpace(model.view.OngoingStreamingText()) == "" &&
+			strings.Contains(normalizedOutput(out.String()), "I opened it via the browser client")
+	})
+	program.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("program run failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("program did not terminate")
+	}
+	normalized := normalizedOutput(out.String())
+	if got := strings.Count(normalized, "Captured the Kent project board"); got != 1 {
+		t.Fatalf("expected streamed multiline final prefix once, got %d in %q", got, normalized)
+	}
+	finalTerminal := normalizedOutput(replayTerminalPlainText(out.String()))
+	if got := strings.Count(finalTerminal, "Captured the Kent project board"); got != 1 {
+		t.Fatalf("expected final terminal prefix once, got %d in %q", got, finalTerminal)
+	}
+	if got := strings.Count(finalTerminal, "I opened it via the browser client"); got != 1 {
+		t.Fatalf("expected final terminal tail once, got %d in %q", got, finalTerminal)
+	}
+	committed := normalizedOutput(model.view.OngoingCommittedSnapshot())
+	if got := strings.Count(committed, "Captured the Kent project board"); got != 1 {
+		t.Fatalf("expected committed multiline final prefix once, got %d in %q", got, committed)
+	}
+	if got := strings.Count(committed, "I opened it via the browser client"); got != 1 {
+		t.Fatalf("expected committed multiline final tail once, got %d in %q", got, committed)
+	}
+}
+
+type replayTerminal struct {
+	lines [][]rune
+	row   int
+	col   int
+}
+
+func replayTerminalPlainText(output string) string {
+	terminal := &replayTerminal{}
+	parser := xansi.NewParser()
+	parser.SetHandler(xansi.Handler{
+		Print: terminal.print,
+		Execute: func(b byte) {
+			switch b {
+			case '\r':
+				terminal.col = 0
+			case '\n':
+				terminal.row++
+				terminal.col = 0
+			case '\b':
+				if terminal.col > 0 {
+					terminal.col--
+				}
+			case '\t':
+				spaces := 4 - terminal.col%4
+				for idx := 0; idx < spaces; idx++ {
+					terminal.print(' ')
+				}
+			}
+		},
+		HandleCsi: func(cmd xansi.Cmd, params xansi.Params) {
+			terminal.handleCSI(cmd, params)
+		},
+	})
+	for idx := 0; idx < len(output); idx++ {
+		parser.Advance(output[idx])
+	}
+	return terminal.String()
+}
+
+func (t *replayTerminal) print(r rune) {
+	if r == '\n' || r == '\r' {
+		return
+	}
+	t.ensureLine(t.row)
+	line := t.lines[t.row]
+	for len(line) < t.col {
+		line = append(line, ' ')
+	}
+	if t.col < len(line) {
+		line[t.col] = r
+	} else {
+		line = append(line, r)
+	}
+	t.lines[t.row] = line
+	t.col++
+}
+
+func (t *replayTerminal) handleCSI(cmd xansi.Cmd, params xansi.Params) {
+	n, _, ok := params.Param(0, 1)
+	if !ok {
+		n = 1
+	}
+	switch cmd.Final() {
+	case 'A':
+		t.row -= n
+		if t.row < 0 {
+			t.row = 0
+		}
+	case 'B':
+		t.row += n
+	case 'C':
+		t.col += n
+	case 'D':
+		t.col -= n
+		if t.col < 0 {
+			t.col = 0
+		}
+	case 'G':
+		t.col = max(0, n-1)
+	case 'H', 'f':
+		col, _, _ := params.Param(1, 1)
+		t.row = max(0, n-1)
+		t.col = max(0, col-1)
+	case 'J':
+		mode, _, _ := params.Param(0, 0)
+		if mode == 2 {
+			t.lines = nil
+			t.row = 0
+			t.col = 0
+		}
+	case 'K':
+		mode, _, _ := params.Param(0, 0)
+		t.eraseLine(mode)
+	}
+}
+
+func (t *replayTerminal) eraseLine(mode int) {
+	t.ensureLine(t.row)
+	switch mode {
+	case 0:
+		if t.col < len(t.lines[t.row]) {
+			t.lines[t.row] = t.lines[t.row][:t.col]
+		}
+	case 1:
+		for idx := 0; idx <= t.col && idx < len(t.lines[t.row]); idx++ {
+			t.lines[t.row][idx] = ' '
+		}
+	case 2:
+		t.lines[t.row] = nil
+	}
+}
+
+func (t *replayTerminal) ensureLine(row int) {
+	for len(t.lines) <= row {
+		t.lines = append(t.lines, nil)
+	}
+}
+
+func (t *replayTerminal) String() string {
+	lines := make([]string, 0, len(t.lines))
+	for _, line := range t.lines {
+		lines = append(lines, strings.TrimRight(string(line), " "))
+	}
+	return strings.Join(lines, "\n")
 }
 
 func TestNativeStreamingTinyDeltasRemainContiguous(t *testing.T) {

--- a/cli/app/ui_runtime_events_test.go
+++ b/cli/app/ui_runtime_events_test.go
@@ -62,6 +62,36 @@ func TestWaitRuntimeEventDoesNotDeferCommittedGoalFeedback(t *testing.T) {
 	}
 }
 
+func TestSplitRuntimeBatchAtAssistantDeltaKeepsMultipleDeltasOrdered(t *testing.T) {
+	events := []clientui.Event{
+		{Kind: clientui.EventAssistantDelta, AssistantDelta: "first"},
+		{Kind: clientui.EventAssistantDelta, AssistantDelta: "second"},
+		{Kind: clientui.EventAssistantMessage},
+	}
+
+	head, tail, split := splitRuntimeBatchAtAssistantDelta(events)
+	if !split {
+		t.Fatal("expected first assistant delta to split later events into pending tail")
+	}
+	if len(head) != 1 || head[0].AssistantDelta != "first" {
+		t.Fatalf("head = %+v, want only first assistant delta", head)
+	}
+	if len(tail) != 2 || tail[0].AssistantDelta != "second" || tail[1].Kind != clientui.EventAssistantMessage {
+		t.Fatalf("tail = %+v, want second assistant delta followed by final commit", tail)
+	}
+
+	nextHead, nextTail, nextSplit := splitRuntimeBatchAtAssistantDelta(tail)
+	if !nextSplit {
+		t.Fatal("expected second assistant delta to split final commit into pending tail")
+	}
+	if len(nextHead) != 1 || nextHead[0].AssistantDelta != "second" {
+		t.Fatalf("next head = %+v, want only second assistant delta", nextHead)
+	}
+	if len(nextTail) != 1 || nextTail[0].Kind != clientui.EventAssistantMessage {
+		t.Fatalf("next tail = %+v, want final commit", nextTail)
+	}
+}
+
 func TestRuntimeEventCoversDeferredCommittedConversationUpdate(t *testing.T) {
 	update := clientui.Event{
 		Kind:                       clientui.EventConversationUpdated,

--- a/cli/app/ui_runtime_reducer.go
+++ b/cli/app/ui_runtime_reducer.go
@@ -34,6 +34,10 @@ func (r uiRuntimeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			}))
 			m.pendingRuntimeEvents = append([]clientui.Event{*msg.carry}, m.pendingRuntimeEvents...)
 		}
+		if head, tail, split := splitRuntimeBatchAtAssistantDelta(msg.events); split {
+			m.pendingRuntimeEvents = append(append([]clientui.Event(nil), tail...), m.pendingRuntimeEvents...)
+			msg.events = head
+		}
 		next, cmd := m.handleRuntimeEventBatch(msg.events)
 		return handledUIFeatureUpdate(next, cmd)
 	case runtimeConnectionStateChangedMsg:
@@ -70,4 +74,27 @@ func (r uiRuntimeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		return handledUIFeatureUpdate(m, cmd)
 	}
 	return uiFeatureUpdateResult{}
+}
+
+func splitRuntimeBatchAtAssistantDelta(events []clientui.Event) ([]clientui.Event, []clientui.Event, bool) {
+	for idx, evt := range events {
+		if evt.Kind != clientui.EventAssistantDelta {
+			continue
+		}
+		// Assistant deltas can schedule native scrollback flushes. Anything after
+		// the first delta must wait for the normal-buffer flush fence so a final
+		// commit cannot render before the promoted streaming prefix is immutable.
+		if idx == len(events)-1 {
+			return events, nil, false
+		}
+		if idx == 0 {
+			head := append([]clientui.Event(nil), events[:1]...)
+			tail := append([]clientui.Event(nil), events[1:]...)
+			return head, tail, true
+		}
+		head := append([]clientui.Event(nil), events[:idx]...)
+		tail := append([]clientui.Event(nil), events[idx:]...)
+		return head, tail, true
+	}
+	return events, nil, false
 }

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -203,7 +203,6 @@ type uiNativeHistoryFeatureState struct {
 	nativeStreamingActive              bool
 	nativeStreamingController          nativeAssistantStreamController
 	nativeStreamingTail                []tui.TranscriptProjectionLine
-	nativeStreamingUnflushedStable     []tui.TranscriptProjectionLine
 	nativeStreamingStableFlushSequence uint64
 	nativeStreamingText                string
 	nativeStreamingStepID              string

--- a/server/runtime/engine_part5_test.go
+++ b/server/runtime/engine_part5_test.go
@@ -885,11 +885,12 @@ func TestReviewerAppliedFollowUpRemainsVisibleInTranscript(t *testing.T) {
 	foundAppliedStatus := false
 	suggestionsIdx := -1
 	followUpIdx := -1
+	wantSuggestionsOngoingText := "Supervisor suggested:\n1. Add final verification notes."
 	for idx, entry := range snapshot.Entries {
 		if entry.Role == "reviewer_suggestions" && strings.Contains(entry.Text, "Supervisor suggested:") {
 			suggestionsIdx = idx
-			if entry.OngoingText != "Supervisor made 1 suggestion." {
-				t.Fatalf("expected compact reviewer suggestions ongoing text, got %+v", entry)
+			if entry.OngoingText != wantSuggestionsOngoingText {
+				t.Fatalf("expected verbose reviewer suggestions ongoing text, got %+v", entry)
 			}
 		}
 		if entry.Role == "assistant" && strings.Contains(entry.Text, "updated final after review") {
@@ -973,8 +974,8 @@ func TestReviewerAppliedFollowUpRemainsVisibleInTranscript(t *testing.T) {
 			continue
 		}
 		foundRestoredSuggestions = true
-		if entry.OngoingText != "Supervisor made 1 suggestion." {
-			t.Fatalf("expected restored compact reviewer suggestions ongoing text, got %+v", entry)
+		if entry.OngoingText != wantSuggestionsOngoingText {
+			t.Fatalf("expected restored verbose reviewer suggestions ongoing text, got %+v", entry)
 		}
 	}
 	if !foundRestoredSuggestions {

--- a/server/runtime/engine_part6_test.go
+++ b/server/runtime/engine_part6_test.go
@@ -741,8 +741,9 @@ func TestReviewerVerboseOutputShowsSuggestionsWhenIssuedAndKeepsFinalStatusConci
 	snapshot := eng.ChatSnapshot()
 	foundVerboseSuggestions := false
 	foundConciseStatus := false
+	wantSuggestionsOngoingText := "Supervisor suggested:\n1. Add final verification notes."
 	for _, entry := range snapshot.Entries {
-		if entry.Role == "reviewer_suggestions" && entry.OngoingText == "Supervisor made 1 suggestion." {
+		if entry.Role == "reviewer_suggestions" && entry.OngoingText == wantSuggestionsOngoingText {
 			foundVerboseSuggestions = true
 		}
 		if entry.Role == "reviewer_status" && entry.Text == "Supervisor ran: 1 suggestion, applied." {
@@ -764,7 +765,7 @@ func TestReviewerVerboseOutputShowsSuggestionsWhenIssuedAndKeepsFinalStatusConci
 	foundRestoredVerboseSuggestions := false
 	foundRestoredConciseStatus := false
 	for _, entry := range restoredSnapshot.Entries {
-		if entry.Role == "reviewer_suggestions" && entry.OngoingText == "Supervisor made 1 suggestion." {
+		if entry.Role == "reviewer_suggestions" && entry.OngoingText == wantSuggestionsOngoingText {
 			foundRestoredVerboseSuggestions = true
 		}
 		if entry.Role == "reviewer_status" && entry.Text == "Supervisor ran: 1 suggestion, applied." {

--- a/server/runtime/reviewer_pipeline.go
+++ b/server/runtime/reviewer_pipeline.go
@@ -46,11 +46,12 @@ func (r *defaultReviewerPipeline) RunFollowUp(ctx context.Context, stepID string
 		return reviewerFollowUpResult{Message: original, Completion: &status, AssistantCommittedStart: originalCommittedStart, AssistantCommittedStartSet: originalCommittedStartSet}, nil
 	}
 	if e.cfg.Reviewer.VerboseOutput {
+		suggestionsText := reviewerSuggestionsText(suggestions)
 		_ = e.appendPersistedLocalEntryWithOngoingText(
 			stepID,
 			"reviewer_suggestions",
-			reviewerSuggestionsText(suggestions),
-			reviewerSuggestionsCompactLabel(len(suggestions)),
+			suggestionsText,
+			suggestionsText,
 		)
 	}
 


### PR DESCRIPTION
## Summary
- show full supervisor suggestions in ongoing mode when reviewer verbose output is enabled
- clear stale native live-region tails atomically when finalizing streamed assistant commits
- add regression coverage for verbose supervisor suggestions and native clear-below flush behavior

## Tests
- ./scripts/test.sh ./server/runtime ./cli/app ./cli/tui
- ./scripts/build.sh --output ./bin/builder
- go test ./cli/app -run TestNativeStreamedMultilineMarkdownFinalThenCommitAppearsOnceInScrollback -count=100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for clearing terminal content before rendering new flushed text in native UI mode.

* **Bug Fixes**
  * Improved handling of streamed assistant messages to prevent duplicate final content in scrollback.
  * Enhanced deferred processing of runtime events containing assistant deltas.
  * Fixed terminal rendering order for stable stream acknowledgments.

* **Tests**
  * Added comprehensive tests for streaming message promotion, multiline markdown content rendering, and event batch splitting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/respawn-app/builder/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->