### PR TITLE
fix: repair scrollback and optimize view_image

### DIFF
--- a/cli/app/session_activity_channel.go
+++ b/cli/app/session_activity_channel.go
@@ -35,7 +35,7 @@ func startSessionActivityEvents(ctx context.Context, sub serverapi.SessionActivi
 					}))
 				}
 				_ = current.Close()
-				if errors.Is(err, context.Canceled) {
+				if errors.Is(err, context.Canceled) && pollCtx.Err() != nil {
 					return
 				}
 				current, err = resubscribeSessionActivity(pollCtx, subscribe, lastSequence)
@@ -97,7 +97,7 @@ func resubscribeSessionActivity(ctx context.Context, subscribe sessionActivitySu
 		if errors.Is(err, serverapi.ErrStreamGap) {
 			return nil, err
 		}
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && ctx.Err() != nil {
 			return nil, err
 		}
 	}

--- a/cli/app/stream_resubscribe_test.go
+++ b/cli/app/stream_resubscribe_test.go
@@ -113,6 +113,68 @@ func TestStartSessionActivityEventsEmitsExplicitGapWhenInitialStreamDropsWithout
 	}
 }
 
+func TestStartSessionActivityEventsKeepsResubscribingAfterTransientSubscribeTimeout(t *testing.T) {
+	useFastStreamResubscribeDelays(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initial := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{evt: clientui.Event{Sequence: 41, Kind: clientui.EventAssistantDelta, AssistantDelta: "before drop"}}, {err: io.EOF}}}
+	recovered := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{evt: clientui.Event{Sequence: 42, Kind: clientui.EventAssistantMessage, TranscriptEntries: []clientui.ChatEntry{{Role: "assistant", Text: "after reconnect"}}}}}}
+	subscribeCalls := 0
+	events, stop := startSessionActivityEvents(ctx, initial, func(context.Context, uint64) (serverapi.SessionActivitySubscription, error) {
+		subscribeCalls++
+		if subscribeCalls == 1 {
+			return nil, context.DeadlineExceeded
+		}
+		return recovered, nil
+	}, func() bool { return false }, nil)
+	defer stop()
+
+	first := waitSessionActivityEvent(t, events)
+	if first.AssistantDelta != "before drop" {
+		t.Fatalf("unexpected initial event: %+v", first)
+	}
+	reconnected := waitSessionActivityEvent(t, events)
+	if reconnected.Kind != clientui.EventAssistantMessage || len(reconnected.TranscriptEntries) != 1 || reconnected.TranscriptEntries[0].Text != "after reconnect" {
+		t.Fatalf("unexpected reconnected event: %+v", reconnected)
+	}
+	if subscribeCalls != 2 {
+		t.Fatalf("subscribe calls = %d, want 2", subscribeCalls)
+	}
+}
+
+func TestStartSessionActivityEventsStopsRetryingWhenParentContextCancelsDuringResubscribe(t *testing.T) {
+	useFastStreamResubscribeDelays(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	initial := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{err: io.EOF}}}
+	subscribeCalled := make(chan struct{})
+	events, stop := startSessionActivityEvents(ctx, initial, func(context.Context, uint64) (serverapi.SessionActivitySubscription, error) {
+		select {
+		case <-subscribeCalled:
+		default:
+			close(subscribeCalled)
+		}
+		return nil, context.DeadlineExceeded
+	}, func() bool { return false }, nil)
+	defer stop()
+
+	select {
+	case <-subscribeCalled:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for resubscribe attempt")
+	}
+	cancel()
+
+	select {
+	case _, ok := <-events:
+		if ok {
+			t.Fatal("expected session activity channel to close after parent cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for session activity retry loop to stop after parent cancellation")
+	}
+}
+
 func TestStartSessionActivityEventsResubscribeStaysIsolatedAcrossStreams(t *testing.T) {
 	useFastStreamResubscribeDelays(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cli/app/ui_committed_suffix_delivery.go
+++ b/cli/app/ui_committed_suffix_delivery.go
@@ -22,6 +22,25 @@ func shouldDeliverCommittedRuntimeEventFromSuffix(m *uiModel, evt clientui.Event
 	return true
 }
 
+func suffixSessionChanged(m *uiModel, suffix clientui.CommittedTranscriptSuffix) bool {
+	if m == nil || suffix.SessionID == "" || m.sessionID == "" {
+		return false
+	}
+	return suffix.SessionID != m.sessionID
+}
+
+func committedTranscriptSuffixStartsAfterDeliveryCursor(m *uiModel, suffix clientui.CommittedTranscriptSuffix) bool {
+	if m == nil {
+		return false
+	}
+	expectedStart := committedTranscriptTailEnd(m)
+	suffix = m.trimCommittedTranscriptSuffixToDeliveryCursor(suffix)
+	if suffix.NextEntryCount <= suffix.StartEntryCount || suffix.StartEntryCount <= expectedStart {
+		return false
+	}
+	return suffix.StartEntryCount > loadedTranscriptTailEnd(m)
+}
+
 func committedTranscriptSuffixRequestForEvent(m *uiModel, evt clientui.Event) clientui.CommittedTranscriptSuffixRequest {
 	after := committedTranscriptTailEnd(m)
 	limit := clientui.DefaultCommittedTranscriptSuffixLimit
@@ -68,6 +87,17 @@ func committedOngoingLocalFrontierEnd(m *uiModel) int {
 	return m.transcriptBaseOffset + len(committedTranscriptEntriesForApp(m.transcriptEntries))
 }
 
+func loadedTranscriptTailEnd(m *uiModel) int {
+	if m == nil {
+		return 0
+	}
+	end := m.transcriptBaseOffset + len(m.transcriptEntries)
+	if end < 0 {
+		return 0
+	}
+	return end
+}
+
 func (m *uiModel) truncatePendingOngoingTailBeforeSuffix(startEntryCount int) {
 	if m == nil {
 		return
@@ -110,7 +140,13 @@ func (m *uiModel) applyCommittedTranscriptSuffixAppend(suffix clientui.Committed
 	page := transcriptPageFromCommittedTranscriptSuffix(suffix)
 	entries := transcriptEntriesFromPage(page)
 	expectedStart := committedTranscriptTailEnd(m)
+	if page.Offset > expectedStart && page.Offset <= loadedTranscriptTailEnd(m) {
+		expectedStart = page.Offset
+	}
 	if page.Offset != expectedStart {
+		if page.Offset > expectedStart {
+			return m.requestRuntimeCommittedGapSync()
+		}
 		m.runtimeAdapter().applyAuthoritativeOngoingTailPage(page, entries, false)
 		if m.view.Mode() == tui.ModeOngoing {
 			m.forwardToView(tui.SetConversationMsg{

--- a/cli/app/ui_native_scrollback_integration_part4_test.go
+++ b/cli/app/ui_native_scrollback_integration_part4_test.go
@@ -5,10 +5,13 @@ import (
 	"builder/server/llm"
 	"builder/server/runtime"
 	"builder/shared/clientui"
+	"builder/shared/serverapi"
 	"builder/shared/transcript"
 	"bytes"
+	"context"
 	tea "github.com/charmbracelet/bubbletea"
 	xansi "github.com/charmbracelet/x/ansi"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -567,8 +570,8 @@ func TestNativeStreamingInterleavedWithStatusRedrawStaysCoherent(t *testing.T) {
 		t.Fatalf("expected bounded streamed line visibility under redraw pressure, got line1=%d line2=%d output=%q", line1Count, line2Count, normalizedOutput(raw))
 	}
 	normalized := normalizedOutput(raw)
-	if strings.Index(normalized, "line1") > strings.Index(normalized, "line2") {
-		t.Fatalf("expected streamed line order preserved, got %q", normalized)
+	if strings.LastIndex(normalized, "line1") > strings.LastIndex(normalized, "line2") {
+		t.Fatalf("expected final streamed line order preserved, got %q", normalized)
 	}
 	for _, line := range strings.Split(plain, "\n") {
 		if strings.Count(line, statusStateCircleGlyph+statusLineSpinnerSeparator) > 1 {
@@ -885,6 +888,78 @@ func TestRuntimeContinuityRecoveryReplaysOngoingScrollbackAndLaterAssistantAppen
 	}
 	if strings.Contains(detail, "before") {
 		t.Fatalf("expected detail mode to exclude stale assistant tail after continuity recovery, got %q", detail)
+	}
+}
+
+func TestNativeOngoingScrollbackContinuesAfterTransientActivityResubscribeTimeout(t *testing.T) {
+	useFastStreamResubscribeDelays(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initial := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{
+		{evt: clientui.Event{
+			Sequence:                   1,
+			Kind:                       clientui.EventAssistantMessage,
+			CommittedTranscriptChanged: true,
+			TranscriptRevision:         1,
+			CommittedEntryCount:        1,
+			CommittedEntryStartSet:     true,
+			TranscriptEntries:          []clientui.ChatEntry{{Role: "assistant", Text: "before disconnect", Phase: string(llm.MessagePhaseFinal)}},
+		}},
+		{err: io.EOF},
+	}}
+	recovered := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{evt: clientui.Event{
+		Sequence:                   2,
+		Kind:                       clientui.EventAssistantMessage,
+		CommittedTranscriptChanged: true,
+		TranscriptRevision:         2,
+		CommittedEntryCount:        2,
+		CommittedEntryStart:        1,
+		CommittedEntryStartSet:     true,
+		TranscriptEntries:          []clientui.ChatEntry{{Role: "assistant", Text: "after reconnect", Phase: string(llm.MessagePhaseFinal)}},
+	}}}}
+	subscribeCalls := 0
+	runtimeEvents, stopRuntimeEvents := startSessionActivityEvents(ctx, initial, func(context.Context, uint64) (serverapi.SessionActivitySubscription, error) {
+		subscribeCalls++
+		if subscribeCalls == 1 {
+			return nil, context.DeadlineExceeded
+		}
+		return recovered, nil
+	}, func() bool { return false }, nil)
+	defer stopRuntimeEvents()
+
+	out := &bytes.Buffer{}
+	model := newProjectedTestUIModel(&runtimeControlFakeClient{sessionView: clientui.RuntimeSessionView{SessionID: "session-1"}}, runtimeEvents, closedAskEvents())
+	program := tea.NewProgram(model, tea.WithInput(strings.NewReader("")), tea.WithOutput(out), tea.WithoutSignals())
+	done := make(chan error, 1)
+	go func() {
+		_, err := program.Run()
+		done <- err
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	program.Send(tea.WindowSizeMsg{Width: 120, Height: 30})
+	waitForTestCondition(t, 2*time.Second, "initial activity emitted", func() bool {
+		return strings.Contains(normalizedOutput(out.String()), "before disconnect")
+	})
+	waitForTestCondition(t, 2*time.Second, "activity after reconnect emitted", func() bool {
+		return containsInOrder(normalizedOutput(out.String()), "before disconnect", "after reconnect")
+	})
+
+	program.Quit()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("program run failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("program did not terminate")
+	}
+	if subscribeCalls != 2 {
+		t.Fatalf("subscribe calls = %d, want 2", subscribeCalls)
+	}
+	if got := strings.Count(normalizedOutput(out.String()), "after reconnect"); got != 1 {
+		t.Fatalf("after reconnect emitted %d times in %q", got, normalizedOutput(out.String()))
 	}
 }
 

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -15,6 +15,7 @@ import (
 	"builder/shared/toolspec"
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -605,6 +606,69 @@ func TestCommittedSuffixResponsesAcceptOlderRangeAfterNewerRequestIssued(t *test
 	loaded := m.view.LoadedTranscriptEntries()
 	if len(loaded) != 2 || loaded[0].Text != "message1" || loaded[1].Text != "Fast mode enabled" {
 		t.Fatalf("loaded transcript = %+v, want message then toggle", loaded)
+	}
+}
+
+func TestCommittedSuffixStaleErrorDoesNotRequestFullTranscriptSync(t *testing.T) {
+	reads := &countingSessionViewClient{
+		view: clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{SessionID: "session-1"}},
+		page: clientui.TranscriptPage{
+			SessionID:    "session-1",
+			Revision:     3,
+			Offset:       0,
+			TotalEntries: 2,
+			Entries: []clientui.ChatEntry{
+				{Role: "user", Text: "message1"},
+				{Role: "system", Text: "Fast mode enabled"},
+			},
+		},
+	}
+	client := newUIRuntimeClientWithReads("session-1", reads, sharedclient.NewLoopbackRuntimeControlClient(runtimecontrol.NewService(nil, nil)))
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.runtimeCommittedSuffixToken = 2
+
+	cmd := m.handleRuntimeCommittedTranscriptSuffixRefreshed(runtimeCommittedTranscriptSuffixRefreshedMsg{
+		token: 1,
+		req:   clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 0, Limit: 1},
+		err:   errors.New("stale timeout"),
+	})
+	if cmd != nil {
+		t.Fatalf("stale suffix error produced command: %+v", collectCmdMessages(t, cmd))
+	}
+	if reads.pageCount.Load() != 0 {
+		t.Fatalf("stale suffix error requested full transcript sync")
+	}
+}
+
+func TestCommittedSuffixStaleHasMoreDoesNotRequestFollowUp(t *testing.T) {
+	reads := &countingSessionViewClient{
+		view: clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{SessionID: "session-1"}},
+	}
+	client := newUIRuntimeClientWithReads("session-1", reads, sharedclient.NewLoopbackRuntimeControlClient(runtimecontrol.NewService(nil, nil)))
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.windowSizeKnown = true
+	m.termWidth = 100
+	m.termHeight = 20
+	m.runtimeCommittedSuffixToken = 2
+	m.ongoingCommittedDelivery = newOngoingCommittedDeliveryCursor(2, 3)
+
+	cmd := m.handleRuntimeCommittedTranscriptSuffixRefreshed(runtimeCommittedTranscriptSuffixRefreshedMsg{
+		token: 1,
+		req:   clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 0, Limit: 1},
+		suffix: clientui.CommittedTranscriptSuffix{
+			SessionID:           "session-1",
+			Revision:            2,
+			CommittedEntryCount: 3,
+			StartEntryCount:     0,
+			NextEntryCount:      1,
+			HasMore:             true,
+			Entries:             []clientui.ChatEntry{{Role: "user", Text: "stale message"}},
+		},
+	})
+	for _, msg := range collectCmdMessages(t, cmd) {
+		if _, ok := msg.(runtimeCommittedTranscriptSuffixRefreshedMsg); ok {
+			t.Fatalf("stale no-op suffix requested follow-up page: %+v", msg)
+		}
 	}
 }
 

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -563,6 +563,161 @@ func TestUserMessageFlushedAdvancesDeliveryCursorBeforeFollowingSuffix(t *testin
 	}
 }
 
+func TestCommittedSuffixResponsesAcceptOlderRangeAfterNewerRequestIssued(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.windowSizeKnown = true
+	m.termWidth = 100
+	m.termHeight = 20
+	m.runtimeCommittedSuffixToken = 2
+
+	firstCmd := m.handleRuntimeCommittedTranscriptSuffixRefreshed(runtimeCommittedTranscriptSuffixRefreshedMsg{
+		token: 1,
+		req:   clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 0, Limit: 1},
+		suffix: clientui.CommittedTranscriptSuffix{
+			SessionID:           "session-1",
+			Revision:            2,
+			CommittedEntryCount: 2,
+			StartEntryCount:     0,
+			NextEntryCount:      1,
+			Entries:             []clientui.ChatEntry{{Role: "user", Text: "message1"}},
+		},
+	})
+	secondCmd := m.handleRuntimeCommittedTranscriptSuffixRefreshed(runtimeCommittedTranscriptSuffixRefreshedMsg{
+		token: 2,
+		req:   clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 1, Limit: 1},
+		suffix: clientui.CommittedTranscriptSuffix{
+			SessionID:           "session-1",
+			Revision:            3,
+			CommittedEntryCount: 2,
+			StartEntryCount:     1,
+			NextEntryCount:      2,
+			Entries:             []clientui.ChatEntry{{Role: "system", Text: "Fast mode enabled"}},
+		},
+	})
+
+	flushText := normalizedOutput(collectNativeHistoryFlushText(append(collectCmdMessages(t, firstCmd), collectCmdMessages(t, secondCmd)...)))
+	if !containsInOrder(flushText, "message1", "Fast mode enabled") {
+		t.Fatalf("expected stale older suffix and newer suffix in order, got %q", flushText)
+	}
+	if strings.Count(flushText, "message1") != 1 {
+		t.Fatalf("expected message1 once in permanent output, got %q", flushText)
+	}
+	loaded := m.view.LoadedTranscriptEntries()
+	if len(loaded) != 2 || loaded[0].Text != "message1" || loaded[1].Text != "Fast mode enabled" {
+		t.Fatalf("loaded transcript = %+v, want message then toggle", loaded)
+	}
+}
+
+func TestFutureCommittedSuffixDoesNotReplaceMissingPrefix(t *testing.T) {
+	reads := &countingSessionViewClient{
+		view: clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{SessionID: "session-1"}},
+		page: clientui.TranscriptPage{
+			SessionID:    "session-1",
+			Revision:     3,
+			Offset:       0,
+			TotalEntries: 2,
+			Entries: []clientui.ChatEntry{
+				{Role: "user", Text: "message1"},
+				{Role: "system", Text: "Fast mode enabled"},
+			},
+		},
+	}
+	client := newUIRuntimeClientWithReads("session-1", reads, sharedclient.NewLoopbackRuntimeControlClient(runtimecontrol.NewService(nil, nil)))
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.windowSizeKnown = true
+	m.termWidth = 100
+	m.termHeight = 20
+	m.runtimeCommittedSuffixToken = 2
+
+	cmd := m.handleRuntimeCommittedTranscriptSuffixRefreshed(runtimeCommittedTranscriptSuffixRefreshedMsg{
+		token: 2,
+		req:   clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: 1, Limit: 1},
+		suffix: clientui.CommittedTranscriptSuffix{
+			SessionID:           "session-1",
+			Revision:            3,
+			CommittedEntryCount: 2,
+			StartEntryCount:     1,
+			NextEntryCount:      2,
+			Entries:             []clientui.ChatEntry{{Role: "system", Text: "Fast mode enabled"}},
+		},
+	})
+
+	msgs := collectCmdMessages(t, cmd)
+	for _, msg := range msgs {
+		if flush, ok := msg.(nativeHistoryFlushMsg); ok && strings.Contains(stripANSIText(flush.Text), "Fast mode enabled") {
+			t.Fatalf("future suffix was emitted before missing prefix recovery: %q", stripANSIText(flush.Text))
+		}
+	}
+	foundHydration := false
+	for _, msg := range msgs {
+		if _, ok := msg.(runtimeTranscriptRefreshedMsg); ok {
+			foundHydration = true
+		}
+	}
+	if !foundHydration {
+		t.Fatalf("expected future suffix gap to request transcript recovery, got %+v", msgs)
+	}
+	if loaded := m.view.LoadedTranscriptEntries(); len(loaded) != 0 {
+		t.Fatalf("future suffix replaced missing prefix in loaded transcript: %+v", loaded)
+	}
+}
+
+func TestCommittedSuffixResponseFromPreviousSessionIsIgnored(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.sessionID = "session-current"
+	m.runtimeCommittedSuffixToken = 1
+
+	cmd := m.handleRuntimeCommittedTranscriptSuffixRefreshed(runtimeCommittedTranscriptSuffixRefreshedMsg{
+		token: 1,
+		suffix: clientui.CommittedTranscriptSuffix{
+			SessionID:           "session-previous",
+			Revision:            2,
+			CommittedEntryCount: 1,
+			StartEntryCount:     0,
+			NextEntryCount:      1,
+			Entries:             []clientui.ChatEntry{{Role: "assistant", Text: "previous session answer"}},
+		},
+	})
+
+	if cmd != nil {
+		t.Fatalf("previous-session suffix produced command: %+v", collectCmdMessages(t, cmd))
+	}
+	if loaded := m.view.LoadedTranscriptEntries(); len(loaded) != 0 {
+		t.Fatalf("previous-session suffix mutated transcript: %+v", loaded)
+	}
+}
+
+func TestCommittedSuffixAppendUsesLoadedTailWhenDeliveryCursorLags(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.windowSizeKnown = true
+	m.termWidth = 100
+	m.termHeight = 20
+	m.transcriptEntries = []tui.TranscriptEntry{{Role: tui.TranscriptRoleUser, Text: "prompt", Committed: true}}
+	m.transcriptTotalEntries = 1
+	m.ongoingCommittedDelivery = newOngoingCommittedDeliveryCursor(0, 1)
+	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries, TotalEntries: 1})
+
+	cmd := m.applyCommittedTranscriptSuffixAppend(clientui.CommittedTranscriptSuffix{
+		Revision:            2,
+		CommittedEntryCount: 2,
+		StartEntryCount:     1,
+		NextEntryCount:      2,
+		Entries:             []clientui.ChatEntry{{Role: "assistant", Text: "answer"}},
+	})
+
+	flushText := normalizedOutput(collectNativeHistoryFlushText(collectCmdMessages(t, cmd)))
+	if !containsInOrder(flushText, "prompt", "answer") {
+		t.Fatalf("expected loaded prefix and suffix in permanent output, got %q", flushText)
+	}
+	loaded := m.view.LoadedTranscriptEntries()
+	if len(loaded) != 2 || loaded[0].Text != "prompt" || loaded[1].Text != "answer" {
+		t.Fatalf("loaded transcript = %+v, want prompt then answer", loaded)
+	}
+	if got := m.ongoingCommittedDelivery.lastAppliedCommittedEntryCount; got != 2 {
+		t.Fatalf("delivery cursor applied count = %d, want 2", got)
+	}
+}
+
 func TestCommittedSuffixAppendTrimsOverlappedRowsAlreadyDelivered(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.windowSizeKnown = true

--- a/cli/app/ui_runtime_sync.go
+++ b/cli/app/ui_runtime_sync.go
@@ -257,6 +257,9 @@ func (m *uiModel) handleRuntimeCommittedTranscriptSuffixRefreshed(msg runtimeCom
 		return nil
 	}
 	if msg.err != nil {
+		if msg.token < m.runtimeCommittedSuffixToken {
+			return nil
+		}
 		m.observeRuntimeRequestResult(msg.err)
 		m.logf("ui.runtime.committed_suffix err=%q after_entry_count=%d limit=%d", msg.err.Error(), msg.req.AfterEntryCount, msg.req.Limit)
 		return m.requestRuntimeCommittedConversationSync()
@@ -265,12 +268,23 @@ func (m *uiModel) handleRuntimeCommittedTranscriptSuffixRefreshed(msg runtimeCom
 	if committedTranscriptSuffixStartsAfterDeliveryCursor(m, msg.suffix) {
 		return m.requestRuntimeCommittedGapSync()
 	}
+	staleResponse := msg.token < m.runtimeCommittedSuffixToken
+	trimmedSuffix := m.trimCommittedTranscriptSuffixToDeliveryCursor(msg.suffix)
 	applyCmd := m.applyCommittedTranscriptSuffixAppend(msg.suffix)
-	if !msg.suffix.HasMore {
+	hasMore := msg.suffix.HasMore
+	nextEntryCount := msg.suffix.NextEntryCount
+	if staleResponse {
+		hasMore = trimmedSuffix.HasMore
+		nextEntryCount = trimmedSuffix.NextEntryCount
+		if trimmedSuffix.NextEntryCount <= trimmedSuffix.StartEntryCount {
+			return applyCmd
+		}
+	}
+	if !hasMore {
 		return applyCmd
 	}
 	nextReq := clientui.NormalizeCommittedTranscriptSuffixRequest(clientui.CommittedTranscriptSuffixRequest{
-		AfterEntryCount: msg.suffix.NextEntryCount,
+		AfterEntryCount: nextEntryCount,
 		Limit:           msg.req.Limit,
 	})
 	return sequenceCmds(applyCmd, m.requestRuntimeCommittedTranscriptSuffix(nextReq))

--- a/cli/app/ui_runtime_sync.go
+++ b/cli/app/ui_runtime_sync.go
@@ -250,7 +250,10 @@ func (m *uiModel) handleRuntimeTranscriptRefreshed(msg runtimeTranscriptRefreshe
 }
 
 func (m *uiModel) handleRuntimeCommittedTranscriptSuffixRefreshed(msg runtimeCommittedTranscriptSuffixRefreshedMsg) tea.Cmd {
-	if msg.token != m.runtimeCommittedSuffixToken {
+	if msg.token <= 0 {
+		return nil
+	}
+	if suffixSessionChanged(m, msg.suffix) {
 		return nil
 	}
 	if msg.err != nil {
@@ -259,6 +262,9 @@ func (m *uiModel) handleRuntimeCommittedTranscriptSuffixRefreshed(msg runtimeCom
 		return m.requestRuntimeCommittedConversationSync()
 	}
 	m.observeRuntimeRequestResult(nil)
+	if committedTranscriptSuffixStartsAfterDeliveryCursor(m, msg.suffix) {
+		return m.requestRuntimeCommittedGapSync()
+	}
 	applyCmd := m.applyCommittedTranscriptSuffixAppend(msg.suffix)
 	if !msg.suffix.HasMore {
 		return applyCmd

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -224,7 +224,7 @@ File-based tool toggles merge with defaults. `BUILDER_TOOLS` and `builder run --
 | `tools.patch` | dynamic | Freeform patch grammar edit tool |
 | `tools.edit` | dynamic | JSON text replacement/create/delete edit tool |
 | `tools.trigger_handoff` | `false` | Experimental tool the agents can use to proactively compact their own context. |
-| `tools.view_image` | `true` | Ability to view images and PDFs (if supported) |
+| `tools.view_image` | `true` | Ability to view images, still GIFs, and PDFs (if supported) |
 | `tools.web_search` | `true` | Tool to search the web |
 | `tools.write_stdin` | `true` | Interaction with background shells. |
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/deepteams/webp v1.2.2
 	github.com/gofrs/flock v0.13.0
 	github.com/google/uuid v1.6.0
 	github.com/lxzan/gws v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deepteams/webp v1.2.2 h1:+efc13KBkm8pOZJAruwHkGjGkZINmBJu58iGB8+zbHU=
+github.com/deepteams/webp v1.2.2/go.mod h1:J8Ap+HAixxpKKRN9IpEeSKlfvhsef1v43jKTO7m3f4c=
 github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
 github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/prompts/handoff.go
+++ b/prompts/handoff.go
@@ -1,0 +1,12 @@
+package prompts
+
+import "strings"
+
+const (
+	HandoffFutureAgentMessagePrefix = `The previous agent also left an additional message: "`
+	HandoffFutureAgentMessageSuffix = `"`
+)
+
+func FormatHandoffFutureAgentMessage(content string) string {
+	return HandoffFutureAgentMessagePrefix + strings.TrimSpace(content) + HandoffFutureAgentMessageSuffix
+}

--- a/prompts/handoff.go
+++ b/prompts/handoff.go
@@ -1,12 +1,14 @@
 package prompts
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 const (
-	HandoffFutureAgentMessagePrefix = `The previous agent also left an additional message: "`
-	HandoffFutureAgentMessageSuffix = `"`
+	HandoffFutureAgentMessagePrefix = `The previous agent also left an additional message: `
 )
 
 func FormatHandoffFutureAgentMessage(content string) string {
-	return HandoffFutureAgentMessagePrefix + strings.TrimSpace(content) + HandoffFutureAgentMessageSuffix
+	return HandoffFutureAgentMessagePrefix + strconv.Quote(strings.TrimSpace(content))
 }

--- a/prompts/handoff_test.go
+++ b/prompts/handoff_test.go
@@ -1,0 +1,12 @@
+package prompts
+
+import "testing"
+
+func TestFormatHandoffFutureAgentMessage(t *testing.T) {
+	raw := " left \"quoted\"\nnext step "
+	got := FormatHandoffFutureAgentMessage(raw)
+	want := "The previous agent also left an additional message: \"left \"quoted\"\nnext step\""
+	if got != want {
+		t.Fatalf("FormatHandoffFutureAgentMessage() = %q, want %q", got, want)
+	}
+}

--- a/prompts/handoff_test.go
+++ b/prompts/handoff_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestFormatHandoffFutureAgentMessage(t *testing.T) {
 	raw := " left \"quoted\"\nnext step "
 	got := FormatHandoffFutureAgentMessage(raw)
-	want := "The previous agent also left an additional message: \"left \"quoted\"\nnext step\""
+	want := `The previous agent also left an additional message: "left \"quoted\"\nnext step"`
 	if got != want {
 		t.Fatalf("FormatHandoffFutureAgentMessage() = %q, want %q", got, want)
 	}

--- a/server/runtime/chat_store_test.go
+++ b/server/runtime/chat_store_test.go
@@ -803,13 +803,13 @@ func TestChatStoreSnapshotIncludesHeadlessModeVariantsAsDeveloperContext(t *test
 
 func TestChatStoreSnapshotIncludesHandoffFutureMessageAsDeveloperContext(t *testing.T) {
 	s := newChatStore()
-	s.appendMessage(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeHandoffFutureMessage, Content: "resume with tests"})
+	s.appendMessage(handoffFutureAgentMessage("resume with tests"))
 
 	snap := s.snapshot()
 	if len(snap.Entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d (%+v)", len(snap.Entries), snap.Entries)
 	}
-	if snap.Entries[0].Role != string(transcript.EntryRoleDeveloperContext) || snap.Entries[0].Text != "resume with tests" {
+	if snap.Entries[0].Role != string(transcript.EntryRoleDeveloperContext) || snap.Entries[0].Text != handoffFutureAgentMessageContent("resume with tests") {
 		t.Fatalf("unexpected handoff future message entry: %+v", snap.Entries[0])
 	}
 }

--- a/server/runtime/compaction_carryover.go
+++ b/server/runtime/compaction_carryover.go
@@ -3,11 +3,17 @@ package runtime
 import (
 	"strings"
 
+	"builder/prompts"
 	"builder/server/llm"
 )
 
 type compactionCarryoverCoordinator struct {
 	engine *Engine
+}
+
+type postCompactionMessage struct {
+	message                  llm.Message
+	pendingHandoffFutureText string
 }
 
 func newCompactionCarryoverCoordinator(engine *Engine) compactionCarryoverCoordinator {
@@ -35,44 +41,52 @@ func handoffFutureAgentMessage(text string) llm.Message {
 	return llm.Message{
 		Role:        llm.RoleDeveloper,
 		MessageType: llm.MessageTypeHandoffFutureMessage,
-		Content:     trimmed,
+		Content:     handoffFutureAgentMessageContent(trimmed),
 	}
 }
 
-func (e *Engine) postCompactionMessages(mode compactionMode, manualCarryover string, wasHeadless bool) []llm.Message {
+func handoffFutureAgentMessageContent(text string) string {
+	return prompts.FormatHandoffFutureAgentMessage(text)
+}
+
+func (e *Engine) postCompactionMessages(mode compactionMode, manualCarryover string, wasHeadless bool) []postCompactionMessage {
 	return newCompactionCarryoverCoordinator(e).postCompactionMessages(mode, manualCarryover, wasHeadless)
 }
 
-func (c compactionCarryoverCoordinator) postCompactionMessages(mode compactionMode, manualCarryover string, wasHeadless bool) []llm.Message {
+func (c compactionCarryoverCoordinator) postCompactionMessages(mode compactionMode, manualCarryover string, wasHeadless bool) []postCompactionMessage {
 	e := c.engine
-	out := make([]llm.Message, 0, 3)
+	out := make([]postCompactionMessage, 0, 3)
 	if mode == compactionModeManual {
 		if carryover := manualCompactionCarryoverMessage(manualCarryover); strings.TrimSpace(carryover.Content) != "" {
-			out = append(out, carryover)
+			out = append(out, postCompactionMessage{message: carryover})
 		}
 	}
 	if mode == compactionModeHandoff {
 		if req := e.pendingHandoffRequestSnapshot(); req != nil {
 			if futureMessage := handoffFutureAgentMessage(req.futureAgentMessage); strings.TrimSpace(futureMessage.Content) != "" {
-				out = append(out, futureMessage)
+				out = append(out, postCompactionMessage{
+					message:                  futureMessage,
+					pendingHandoffFutureText: req.futureAgentMessage,
+				})
 			}
 		}
 	}
 	if wasHeadless {
 		if headless, ok := headlessModeMetaMessage(); ok {
-			out = append(out, headless)
+			out = append(out, postCompactionMessage{message: headless})
 		}
 	}
 	return out
 }
 
-func (e *Engine) appendPostCompactionMessages(stepID string, messages []llm.Message) error {
+func (e *Engine) appendPostCompactionMessages(stepID string, messages []postCompactionMessage) error {
 	return newCompactionCarryoverCoordinator(e).appendPostCompactionMessages(stepID, messages)
 }
 
-func (c compactionCarryoverCoordinator) appendPostCompactionMessages(stepID string, messages []llm.Message) error {
+func (c compactionCarryoverCoordinator) appendPostCompactionMessages(stepID string, messages []postCompactionMessage) error {
 	e := c.engine
-	for _, message := range messages {
+	for _, item := range messages {
+		message := item.message
 		switch message.MessageType {
 		case llm.MessageTypeManualCompactionCarryover:
 			if err := e.appendMessageWithoutConversationUpdate(stepID, message); err != nil {
@@ -81,7 +95,7 @@ func (c compactionCarryoverCoordinator) appendPostCompactionMessages(stepID stri
 		default:
 			if err := e.appendMessage(stepID, message); err != nil {
 				if message.MessageType == llm.MessageTypeHandoffFutureMessage {
-					e.queuePendingHandoffFutureMessage(message.Content)
+					e.queuePendingHandoffFutureMessage(item.pendingHandoffFutureText)
 				}
 				return err
 			}

--- a/server/runtime/compaction_carryover.go
+++ b/server/runtime/compaction_carryover.go
@@ -63,7 +63,8 @@ func (c compactionCarryoverCoordinator) postCompactionMessages(mode compactionMo
 	}
 	if mode == compactionModeHandoff {
 		if req := e.pendingHandoffRequestSnapshot(); req != nil {
-			if futureMessage := handoffFutureAgentMessage(req.futureAgentMessage); strings.TrimSpace(futureMessage.Content) != "" {
+			if strings.TrimSpace(req.futureAgentMessage) != "" {
+				futureMessage := handoffFutureAgentMessage(req.futureAgentMessage)
 				out = append(out, postCompactionMessage{
 					message:                  futureMessage,
 					pendingHandoffFutureText: req.futureAgentMessage,

--- a/server/runtime/compaction_carryover_test.go
+++ b/server/runtime/compaction_carryover_test.go
@@ -1,0 +1,15 @@
+package runtime
+
+import (
+	"testing"
+
+	"builder/prompts"
+)
+
+func TestHandoffFutureAgentMessageWrapsContentForModelAndTranscript(t *testing.T) {
+	msg := handoffFutureAgentMessage(" resume with tests ")
+
+	if got, want := msg.Content, prompts.FormatHandoffFutureAgentMessage("resume with tests"); got != want {
+		t.Fatalf("future-agent message content = %q, want %q", got, want)
+	}
+}

--- a/server/runtime/compaction_carryover_test.go
+++ b/server/runtime/compaction_carryover_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"builder/prompts"
+	"builder/server/llm"
 )
 
 func TestHandoffFutureAgentMessageWrapsContentForModelAndTranscript(t *testing.T) {
@@ -11,5 +12,18 @@ func TestHandoffFutureAgentMessageWrapsContentForModelAndTranscript(t *testing.T
 
 	if got, want := msg.Content, prompts.FormatHandoffFutureAgentMessage("resume with tests"); got != want {
 		t.Fatalf("future-agent message content = %q, want %q", got, want)
+	}
+}
+
+func TestPostCompactionMessagesSkipsEmptyHandoffFutureMessage(t *testing.T) {
+	state := newHandoffRuntimeState()
+	state.QueueRequest("keep API details", " \n\t ")
+	eng := &Engine{handoffState: state}
+
+	messages := eng.postCompactionMessages(compactionModeHandoff, "", false)
+	for _, message := range messages {
+		if message.message.MessageType == llm.MessageTypeHandoffFutureMessage {
+			t.Fatalf("did not expect empty handoff future message carryover: %+v", message)
+		}
 	}
 }

--- a/server/runtime/engine_part13_test.go
+++ b/server/runtime/engine_part13_test.go
@@ -323,7 +323,7 @@ func TestTriggerHandoffSchedulesCompactionAndAppendsFutureMessageWithoutManualCa
 	foundFutureMessage := false
 	foundManualCarryover := false
 	for _, message := range messages {
-		if message.MessageType == llm.MessageTypeHandoffFutureMessage && message.Content == "resume with tests" {
+		if message.MessageType == llm.MessageTypeHandoffFutureMessage && message.Content == handoffFutureAgentMessageContent("resume with tests") {
 			foundFutureMessage = true
 		}
 		if message.MessageType == llm.MessageTypeManualCompactionCarryover {
@@ -340,7 +340,7 @@ func TestTriggerHandoffSchedulesCompactionAndAppendsFutureMessageWithoutManualCa
 	entries := eng.ChatSnapshot().Entries
 	foundDeveloperContext := false
 	for _, entry := range entries {
-		if entry.Role == string(transcript.EntryRoleDeveloperContext) && entry.Text == "resume with tests" {
+		if entry.Role == string(transcript.EntryRoleDeveloperContext) && entry.Text == handoffFutureAgentMessageContent("resume with tests") {
 			foundDeveloperContext = true
 		}
 		if entry.Role == string(transcript.EntryRoleManualCompactionCarryover) {
@@ -876,7 +876,7 @@ func TestPendingTriggerHandoffRetriesAfterCompactionFailure(t *testing.T) {
 	messages := eng.snapshotMessages()
 	foundFutureMessage := false
 	for _, message := range messages {
-		if message.MessageType == llm.MessageTypeHandoffFutureMessage && message.Content == "resume with tests" {
+		if message.MessageType == llm.MessageTypeHandoffFutureMessage && message.Content == handoffFutureAgentMessageContent("resume with tests") {
 			foundFutureMessage = true
 			break
 		}
@@ -909,8 +909,9 @@ func TestPendingTriggerHandoffRetriesFutureMessageAfterAppendFailureWithoutRecom
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setCompactionSoonReminderIssued(true)
+	futureAgentMessage := "resume \"with tests\"\nthen inspect logs"
 
-	_, _, err = eng.TriggerHandoff(context.Background(), "step-1", llm.ToolCall{ID: "call_handoff_append_retry", Name: string(toolspec.ToolTriggerHandoff)}, "keep API details", "resume with tests")
+	_, _, err = eng.TriggerHandoff(context.Background(), "step-1", llm.ToolCall{ID: "call_handoff_append_retry", Name: string(toolspec.ToolTriggerHandoff)}, "keep API details", futureAgentMessage)
 	if err != nil {
 		t.Fatalf("trigger handoff: %v", err)
 	}
@@ -932,7 +933,9 @@ func TestPendingTriggerHandoffRetriesFutureMessageAfterAppendFailureWithoutRecom
 	if eng.pendingHandoffRequestSnapshot() != nil {
 		t.Fatalf("expected compaction-success path to consume original handoff request, got %+v", eng.pendingHandoffRequestSnapshot())
 	}
-	if got, want := eng.pendingHandoffFutureMessageSnapshot(), "resume with tests"; got != want {
+	// The retry queue keeps the raw tool argument so retry emission cannot wrap
+	// already-formatted future-agent context a second time.
+	if got, want := eng.pendingHandoffFutureMessageSnapshot(), futureAgentMessage; got != want {
 		t.Fatalf("pending future-agent message after append failure = %q, want %q", got, want)
 	}
 
@@ -950,7 +953,7 @@ func TestPendingTriggerHandoffRetriesFutureMessageAfterAppendFailureWithoutRecom
 	messages := eng.snapshotMessages()
 	foundFutureMessage := false
 	for _, message := range messages {
-		if message.MessageType == llm.MessageTypeHandoffFutureMessage && message.Content == "resume with tests" {
+		if message.MessageType == llm.MessageTypeHandoffFutureMessage && message.Content == handoffFutureAgentMessageContent(futureAgentMessage) {
 			foundFutureMessage = true
 			break
 		}
@@ -1059,7 +1062,7 @@ func TestReopenedSessionAfterTriggerHandoffFutureMessageAppendFailureRetriesWith
 	}
 	foundFuture := false
 	for _, item := range resumedClient.calls[0].Items {
-		if item.Type == llm.ResponseItemTypeMessage && item.MessageType == llm.MessageTypeHandoffFutureMessage && item.Content == "resume after restart" {
+		if item.Type == llm.ResponseItemTypeMessage && item.MessageType == llm.MessageTypeHandoffFutureMessage && item.Content == handoffFutureAgentMessageContent("resume after restart") {
 			foundFuture = true
 			break
 		}
@@ -1143,7 +1146,7 @@ func TestRunStepLoopTriggerHandoffOmitsCallAndOutputFromFollowUpRequestAndKeepsF
 			foundCall = true
 		case item.Type == llm.ResponseItemTypeFunctionCallOutput && item.CallID == "call_handoff_1":
 			foundOutput = true
-		case item.Type == llm.ResponseItemTypeMessage && item.MessageType == llm.MessageTypeHandoffFutureMessage && item.Content == "resume with tests":
+		case item.Type == llm.ResponseItemTypeMessage && item.MessageType == llm.MessageTypeHandoffFutureMessage && item.Content == handoffFutureAgentMessageContent("resume with tests"):
 			futureIdx = idx
 		}
 	}
@@ -1241,7 +1244,7 @@ func TestRunStepLoopInjectsReminderBeforeTriggerHandoffAndOmitsCallOutputFromFol
 			foundCall = true
 		case item.Type == llm.ResponseItemTypeFunctionCallOutput && item.CallID == "call_handoff_2":
 			foundOutput = true
-		case item.Type == llm.ResponseItemTypeMessage && item.MessageType == llm.MessageTypeHandoffFutureMessage && item.Content == "resume with tests":
+		case item.Type == llm.ResponseItemTypeMessage && item.MessageType == llm.MessageTypeHandoffFutureMessage && item.Content == handoffFutureAgentMessageContent("resume with tests"):
 			futureIdx = idx
 		}
 	}

--- a/server/runtime/engine_part14_test.go
+++ b/server/runtime/engine_part14_test.go
@@ -121,7 +121,7 @@ func TestReopenedSessionAfterSuccessfulTriggerHandoffRequeuesPendingHandoff(t *t
 			foundCall = true
 		case item.Type == llm.ResponseItemTypeFunctionCallOutput && item.CallID == handoffCall.ID:
 			foundOutput = true
-		case item.Type == llm.ResponseItemTypeMessage && item.MessageType == llm.MessageTypeHandoffFutureMessage && item.Content == "resume after restart":
+		case item.Type == llm.ResponseItemTypeMessage && item.MessageType == llm.MessageTypeHandoffFutureMessage && item.Content == handoffFutureAgentMessageContent("resume after restart"):
 			foundFuture = true
 		}
 	}

--- a/server/tools/definitions.go
+++ b/server/tools/definitions.go
@@ -113,7 +113,7 @@ var catalogEntries = []CatalogEntry{
 	{
 		ID:             toolspec.ToolViewImage,
 		Aliases:        []string{"read_image"},
-		Description:    "View a local image or PDF file by path. You will see PDFs as images (not OCR/text).",
+		Description:    "View a local image, still GIF, or PDF file by path. Images may be compressed before model input unless raw=true. You will see PDFs as images (not OCR/text).",
 		DefaultEnabled: true,
 		Contract: localContract(
 			LocalRuntimeBuilderViewImage,
@@ -132,6 +132,10 @@ var catalogEntries = []CatalogEntry{
     "path": {
       "type": "string",
       "description": "Local filesystem path to an image or PDF file. Relative paths resolve from the workspace root."
+    },
+    "raw": {
+      "type": "boolean",
+      "description": "Whether to bypass image compression and postprocessing. Defaults to false. The file size cap still applies."
     }
   }
 }`),

--- a/server/tools/readimage/gif.go
+++ b/server/tools/readimage/gif.go
@@ -1,0 +1,93 @@
+package readimage
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+)
+
+func countGIFFrames(data []byte, maxFrames int) (int, error) {
+	reader := bytes.NewReader(data)
+	header := make([]byte, 13)
+	if _, err := io.ReadFull(reader, header); err != nil {
+		return 0, err
+	}
+	signature := string(header[:6])
+	if signature != "GIF87a" && signature != "GIF89a" {
+		return 0, errors.New("invalid GIF header")
+	}
+	if err := skipGIFColorTable(reader, header[10]); err != nil {
+		return 0, err
+	}
+
+	frames := 0
+	for {
+		blockType, err := reader.ReadByte()
+		if err != nil {
+			return frames, err
+		}
+		switch blockType {
+		case 0x3b:
+			return frames, nil
+		case 0x21:
+			if _, err := reader.ReadByte(); err != nil {
+				return frames, err
+			}
+			if err := skipGIFSubBlocks(reader); err != nil {
+				return frames, err
+			}
+		case 0x2c:
+			descriptor := make([]byte, 9)
+			if _, err := io.ReadFull(reader, descriptor); err != nil {
+				return frames, err
+			}
+			if err := skipGIFColorTable(reader, descriptor[8]); err != nil {
+				return frames, err
+			}
+			if _, err := reader.ReadByte(); err != nil {
+				return frames, err
+			}
+			if err := skipGIFSubBlocks(reader); err != nil {
+				return frames, err
+			}
+			frames++
+			if maxFrames > 0 && frames >= maxFrames {
+				return frames, nil
+			}
+		default:
+			return frames, fmt.Errorf("unknown GIF block type 0x%02x", blockType)
+		}
+	}
+}
+
+func skipGIFColorTable(reader *bytes.Reader, packed byte) error {
+	if packed&0x80 == 0 {
+		return nil
+	}
+	colorTableSize := 3 * (1 << ((packed & 0x07) + 1))
+	return skipBytes(reader, int64(colorTableSize))
+}
+
+func skipGIFSubBlocks(reader *bytes.Reader) error {
+	for {
+		size, err := reader.ReadByte()
+		if err != nil {
+			return err
+		}
+		if size == 0 {
+			return nil
+		}
+		if err := skipBytes(reader, int64(size)); err != nil {
+			return err
+		}
+	}
+}
+
+func skipBytes(reader *bytes.Reader, n int64) error {
+	if n < 0 || int64(reader.Len()) < n {
+		return io.ErrUnexpectedEOF
+	}
+	_, err := reader.Seek(n, io.SeekCurrent)
+	return err
+}

--- a/server/tools/readimage/open_nofollow_fallback.go
+++ b/server/tools/readimage/open_nofollow_fallback.go
@@ -10,3 +10,7 @@ import (
 func openReadOnlyNoFollow(path string) (*os.File, error) {
 	return nil, errors.New("safe image file opening is unsupported on this platform")
 }
+
+func setReadBlocking(*os.File) error {
+	return nil
+}

--- a/server/tools/readimage/open_nofollow_fallback.go
+++ b/server/tools/readimage/open_nofollow_fallback.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux && !windows
+
+package readimage
+
+import (
+	"errors"
+	"os"
+)
+
+func openReadOnlyNoFollow(path string) (*os.File, error) {
+	return nil, errors.New("safe image file opening is unsupported on this platform")
+}

--- a/server/tools/readimage/open_nofollow_unix.go
+++ b/server/tools/readimage/open_nofollow_unix.go
@@ -14,3 +14,7 @@ func openReadOnlyNoFollow(path string) (*os.File, error) {
 	}
 	return os.NewFile(uintptr(fd), path), nil
 }
+
+func setReadBlocking(file *os.File) error {
+	return syscall.SetNonblock(int(file.Fd()), false)
+}

--- a/server/tools/readimage/open_nofollow_unix.go
+++ b/server/tools/readimage/open_nofollow_unix.go
@@ -1,0 +1,16 @@
+//go:build darwin || linux
+
+package readimage
+
+import (
+	"os"
+	"syscall"
+)
+
+func openReadOnlyNoFollow(path string) (*os.File, error) {
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_CLOEXEC|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}

--- a/server/tools/readimage/open_nofollow_windows.go
+++ b/server/tools/readimage/open_nofollow_windows.go
@@ -27,3 +27,7 @@ func openReadOnlyNoFollow(path string) (*os.File, error) {
 	}
 	return os.NewFile(uintptr(handle), path), nil
 }
+
+func setReadBlocking(*os.File) error {
+	return nil
+}

--- a/server/tools/readimage/open_nofollow_windows.go
+++ b/server/tools/readimage/open_nofollow_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package readimage
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func openReadOnlyNoFollow(path string) (*os.File, error) {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := windows.CreateFile(
+		p,
+		windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(handle), path), nil
+}

--- a/server/tools/readimage/tool.go
+++ b/server/tools/readimage/tool.go
@@ -150,7 +150,7 @@ func (t *Tool) Call(ctx context.Context, c tools.Call) (tools.Result, error) {
 	if err != nil {
 		return tools.ErrorResult(c, err.Error()), nil
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	if isPDFPath(resolvedPath) && info.Size() > maxFileSizeBytes {
 		return tools.ErrorResult(c, maxAttachmentSizeError(resolvedPath, info.Size())), nil
 	}
@@ -292,15 +292,21 @@ func openResolvedRegularFile(path string) (*os.File, os.FileInfo, error) {
 	}
 	info, err := file.Stat()
 	if err != nil {
-		file.Close()
+		if closeErr := file.Close(); closeErr != nil {
+			return nil, nil, fmt.Errorf("stat file at %q: %v; close file: %w", path, err, closeErr)
+		}
 		return nil, nil, fmt.Errorf("stat file at %q: %v", path, err)
 	}
 	if !info.Mode().IsRegular() {
-		file.Close()
+		if closeErr := file.Close(); closeErr != nil {
+			return nil, nil, fmt.Errorf("path %q is not a regular file; close file: %w", path, closeErr)
+		}
 		return nil, nil, fmt.Errorf("path %q is not a regular file", path)
 	}
 	if !os.SameFile(pathInfo, info) {
-		file.Close()
+		if closeErr := file.Close(); closeErr != nil {
+			return nil, nil, fmt.Errorf("path %q changed while opening; retry the tool call; close file: %w", path, closeErr)
+		}
 		return nil, nil, fmt.Errorf("path %q changed while opening; retry the tool call", path)
 	}
 	return file, info, nil

--- a/server/tools/readimage/tool.go
+++ b/server/tools/readimage/tool.go
@@ -309,6 +309,12 @@ func openResolvedRegularFile(path string) (*os.File, os.FileInfo, error) {
 		}
 		return nil, nil, fmt.Errorf("path %q changed while opening; retry the tool call", path)
 	}
+	if err := setReadBlocking(file); err != nil {
+		if closeErr := file.Close(); closeErr != nil {
+			return nil, nil, fmt.Errorf("set file blocking mode at %q: %v; close file: %w", path, err, closeErr)
+		}
+		return nil, nil, fmt.Errorf("set file blocking mode at %q: %v", path, err)
+	}
 	return file, info, nil
 }
 

--- a/server/tools/readimage/tool.go
+++ b/server/tools/readimage/tool.go
@@ -1,11 +1,17 @@
 package readimage
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"image"
+	"image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"io"
 	"io/fs"
 	"mime"
 	"net/http"
@@ -18,9 +24,13 @@ import (
 	"builder/server/tools"
 	patchtool "builder/server/tools/patch"
 	"builder/shared/toolspec"
+	"github.com/deepteams/webp"
 )
 
-const maxFileSizeBytes int64 = 500 << 10
+const maxFileSizeBytes int64 = 800 << 10
+const maxOriginalRasterSizeBytes int64 = 10 << 20
+const minOptimizationSizeBytes int64 = 100 << 10
+const maxDecodedPixels int64 = 16_000_000
 
 const outsideWorkspaceRejectionInstruction = "If it's essential to the task, ask the user to place the file inside the workspace root."
 
@@ -74,6 +84,7 @@ func WithOutsideWorkspaceAuditLogger(logger OutsideWorkspaceAuditLogger) Option 
 
 type input struct {
 	Path string `json:"path"`
+	Raw  bool   `json:"raw,omitempty"`
 }
 
 type contentItem struct {
@@ -135,24 +146,41 @@ func (t *Tool) Call(ctx context.Context, c tools.Call) (tools.Result, error) {
 		return tools.ErrorResult(c, err.Error()), nil
 	}
 
-	info, err := os.Stat(resolvedPath)
+	file, info, err := openResolvedRegularFile(resolvedPath)
 	if err != nil {
-		return tools.ErrorResult(c, fmt.Sprintf("unable to locate file at %q: %v", resolvedPath, err)), nil
+		return tools.ErrorResult(c, err.Error()), nil
 	}
-	if !info.Mode().IsRegular() {
-		return tools.ErrorResult(c, fmt.Sprintf("path %q is not a regular file", resolvedPath)), nil
+	defer file.Close()
+	if isPDFPath(resolvedPath) && info.Size() > maxFileSizeBytes {
+		return tools.ErrorResult(c, maxAttachmentSizeError(resolvedPath, info.Size())), nil
 	}
-	if info.Size() > maxFileSizeBytes {
-		return tools.ErrorResult(c, fmt.Sprintf("file %q is too large (%d bytes). max supported size is %d bytes (500 KiB). compress the image or PDF and try again", resolvedPath, info.Size(), maxFileSizeBytes)), nil
+	if in.Raw && info.Size() > maxFileSizeBytes {
+		return tools.ErrorResult(c, rawAttachmentSizeError(resolvedPath, info.Size())), nil
+	}
+	if info.Size() > maxOriginalRasterSizeBytes {
+		return tools.ErrorResult(c, fmt.Sprintf("file %q is too large (%d bytes). max readable size is %d bytes (10 MiB). resize or compress the image or PDF and try again", resolvedPath, info.Size(), maxOriginalRasterSizeBytes)), nil
 	}
 
-	data, err := os.ReadFile(resolvedPath)
+	data, err := readLimitedFile(file, maxOriginalRasterSizeBytes)
 	if err != nil {
 		return tools.ErrorResult(c, fmt.Sprintf("unable to read file at %q: %v", resolvedPath, err)), nil
 	}
+	if isPDFPath(resolvedPath) && int64(len(data)) > maxFileSizeBytes {
+		return tools.ErrorResult(c, maxAttachmentSizeError(resolvedPath, int64(len(data)))), nil
+	}
+	if in.Raw && int64(len(data)) > maxFileSizeBytes {
+		return tools.ErrorResult(c, rawAttachmentSizeError(resolvedPath, int64(len(data)))), nil
+	}
 	mimeType := detectFileMIME(resolvedPath, data)
+	contentData, contentMIME, prepareErr := prepareFileForAttachment(resolvedPath, mimeType, data, in.Raw)
+	if prepareErr != nil {
+		return tools.ErrorResult(c, prepareErr.Error()), nil
+	}
+	if int64(len(contentData)) > maxFileSizeBytes {
+		return tools.ErrorResult(c, maxAttachmentSizeError(resolvedPath, int64(len(contentData)))), nil
+	}
 
-	items, buildErr := buildContentItemsForFile(resolvedPath, mimeType, data)
+	items, buildErr := buildContentItemsForFile(resolvedPath, contentMIME, contentData)
 	if buildErr != nil {
 		return tools.ErrorResult(c, buildErr.Error()), nil
 	}
@@ -250,6 +278,48 @@ func normalizeMIME(raw string) string {
 	return strings.ToLower(main)
 }
 
+func openResolvedRegularFile(path string) (*os.File, os.FileInfo, error) {
+	pathInfo, err := os.Lstat(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat path at %q: %v", path, err)
+	}
+	if !pathInfo.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("path %q is not a regular file", path)
+	}
+	file, err := openReadOnlyNoFollow(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to locate file at %q: %v", path, err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, nil, fmt.Errorf("stat file at %q: %v", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		file.Close()
+		return nil, nil, fmt.Errorf("path %q is not a regular file", path)
+	}
+	if !os.SameFile(pathInfo, info) {
+		file.Close()
+		return nil, nil, fmt.Errorf("path %q changed while opening; retry the tool call", path)
+	}
+	return file, info, nil
+}
+
+func readLimitedFile(file *os.File, limit int64) ([]byte, error) {
+	if limit < 0 {
+		return nil, errors.New("read limit must be non-negative")
+	}
+	data, err := io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("file exceeds max readable size of %d bytes (10 MiB)", limit)
+	}
+	return data, nil
+}
+
 func readImageOutsideWorkspaceApprovalFailed(req patchtool.OutsideWorkspaceRequest, err error) error {
 	path := readImageOutsideWorkspacePath(req)
 	reason := strings.TrimSpace(err.Error())
@@ -299,7 +369,7 @@ func readImageOutsideWorkspacePath(req patchtool.OutsideWorkspaceRequest) string
 }
 
 func buildContentItemsForFile(path, mimeType string, data []byte) ([]contentItem, error) {
-	if mimeType == "application/pdf" || strings.EqualFold(filepath.Ext(path), ".pdf") {
+	if mimeType == "application/pdf" || isPDFPath(path) {
 		filename := filepath.Base(path)
 		if strings.TrimSpace(filename) == "" {
 			filename = "document.pdf"
@@ -323,4 +393,141 @@ func buildContentItemsForFile(path, mimeType string, data []byte) ([]contentItem
 	}
 
 	return nil, fmt.Errorf("unsupported file type at %q: expected an image or PDF", path)
+}
+
+func prepareFileForAttachment(path, mimeType string, data []byte, raw bool) ([]byte, string, error) {
+	if mimeType == "application/pdf" || isPDFPath(path) {
+		return data, "application/pdf", nil
+	}
+
+	if !strings.HasPrefix(mimeType, "image/") {
+		return data, mimeType, nil
+	}
+	img, decodedMIME, err := decodeSupportedRasterImage(path, data)
+	if err != nil {
+		return data, mimeType, err
+	}
+	if raw || int64(len(data)) < minOptimizationSizeBytes {
+		return data, decodedMIME, nil
+	}
+
+	optimized, optimizedMIME, ok := optimizeRasterImage(img)
+	if !ok || len(optimized) >= len(data) {
+		return data, decodedMIME, nil
+	}
+	return optimized, optimizedMIME, nil
+}
+
+func decodeSupportedRasterImage(path string, data []byte) (image.Image, string, error) {
+	cfg, format, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot attach image at %q: unable to decode image: %v", path, err)
+	}
+	mimeType, ok := mimeTypeForImageFormat(format)
+	if !ok {
+		return nil, "", fmt.Errorf("cannot attach image at %q: unsupported image format %q", path, format)
+	}
+	if _, ok := supportedImageMIMEs[mimeType]; !ok {
+		return nil, "", fmt.Errorf("cannot attach image at %q: unsupported image format %q", path, mimeType)
+	}
+	if err := validateDecodedDimensions(path, cfg.Width, cfg.Height); err != nil {
+		return nil, "", err
+	}
+	switch mimeType {
+	case "image/gif":
+		img, err := decodeStillGIF(path, data)
+		if err != nil {
+			return nil, "", err
+		}
+		return img, mimeType, nil
+	case "image/webp":
+		if err := validateStillWebP(path, data); err != nil {
+			return nil, "", err
+		}
+	}
+	img, decodedFormat, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot attach image at %q: unable to decode image: %v", path, err)
+	}
+	decodedMIME, ok := mimeTypeForImageFormat(decodedFormat)
+	if !ok {
+		return nil, "", fmt.Errorf("cannot attach image at %q: unsupported image format %q", path, decodedFormat)
+	}
+	return img, decodedMIME, nil
+}
+
+func decodeStillGIF(path string, data []byte) (image.Image, error) {
+	frames, err := countGIFFrames(data, 2)
+	if err != nil {
+		return nil, fmt.Errorf("cannot attach GIF at %q: %v", path, err)
+	}
+	if frames != 1 {
+		return nil, fmt.Errorf("cannot attach GIF at %q: animated GIFs are not supported; use a still image or PDF", path)
+	}
+	img, err := gif.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("cannot attach GIF at %q: %v", path, err)
+	}
+	return img, nil
+}
+
+func validateStillWebP(path string, data []byte) error {
+	features, err := webp.GetFeatures(bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("cannot attach WebP at %q: %v", path, err)
+	}
+	if features.HasAnimation {
+		return fmt.Errorf("cannot attach WebP at %q: animated WebP images are not supported; use a still image or PDF", path)
+	}
+	return nil
+}
+
+func validateDecodedDimensions(path string, width, height int) error {
+	if width <= 0 || height <= 0 {
+		return fmt.Errorf("cannot attach image at %q: invalid image dimensions %dx%d", path, width, height)
+	}
+	pixels := int64(width) * int64(height)
+	if pixels > maxDecodedPixels {
+		return fmt.Errorf("cannot attach image at %q: decoded image dimensions %dx%d exceed the supported pixel limit of %d", path, width, height, maxDecodedPixels)
+	}
+	return nil
+}
+
+func mimeTypeForImageFormat(format string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "png":
+		return "image/png", true
+	case "jpeg":
+		return "image/jpeg", true
+	case "gif":
+		return "image/gif", true
+	case "webp":
+		return "image/webp", true
+	default:
+		return "", false
+	}
+}
+
+func optimizeRasterImage(img image.Image) ([]byte, string, bool) {
+	if img == nil {
+		return nil, "", false
+	}
+	var out bytes.Buffer
+	opts := webp.OptionsForPreset(webp.PresetPicture, 80)
+	if err := webp.Encode(&out, img, opts); err != nil {
+		return nil, "", false
+	}
+	return out.Bytes(), "image/webp", true
+}
+
+func maxAttachmentSizeError(path string, size int64) string {
+	return fmt.Sprintf("file %q is too large (%d bytes). max supported size is %d bytes (800 KiB). compress the image or PDF and try again", path, size, maxFileSizeBytes)
+}
+
+func rawAttachmentSizeError(path string, size int64) string {
+	return maxAttachmentSizeError(path, size) + ". raw=true bypasses compression and postprocessing, but the 800 KiB cap still applies; retry without raw=true to allow optimization"
+}
+
+func isPDFPath(path string) bool {
+	return strings.EqualFold(filepath.Ext(path), ".pdf")
 }

--- a/server/tools/readimage/tool_optimization_test.go
+++ b/server/tools/readimage/tool_optimization_test.go
@@ -1,0 +1,429 @@
+package readimage
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"hash/crc32"
+	"image"
+	"image/color"
+	"image/gif"
+	"image/jpeg"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"builder/server/tools"
+	"builder/shared/toolspec"
+	"github.com/deepteams/webp"
+	"github.com/deepteams/webp/animation"
+)
+
+func TestCall_OptimizesLargeJPEGToSmallerWebPOutput(t *testing.T) {
+	workspace := t.TempDir()
+	var original bytes.Buffer
+	if err := jpeg.Encode(&original, generatedPhotoLikeImage(1024), &jpeg.Options{Quality: 95}); err != nil {
+		t.Fatalf("encode jpeg: %v", err)
+	}
+	if int64(original.Len()) < minOptimizationSizeBytes {
+		t.Fatalf("test image is too small for optimization path: %d", original.Len())
+	}
+	if int64(original.Len()) <= maxFileSizeBytes {
+		t.Fatalf("test image must exceed attachment cap before optimization: %d", original.Len())
+	}
+	imagePath := filepath.Join(workspace, "photo.jpg")
+	if err := os.WriteFile(imagePath, original.Bytes(), 0o644); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+
+	tool, err := New(workspace, true)
+	if err != nil {
+		t.Fatalf("new tool: %v", err)
+	}
+
+	result, err := tool.Call(context.Background(), tools.Call{
+		ID:    "call-optimized",
+		Name:  toolspec.ToolViewImage,
+		Input: json.RawMessage(`{"path":"photo.jpg"}`),
+	})
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success result, got error payload: %s", string(result.Output))
+	}
+
+	mimeType, payload := decodeSingleImageDataURL(t, result)
+	if mimeType != "image/webp" {
+		t.Fatalf("expected optimized webp output, got %q", mimeType)
+	}
+	if len(payload) >= original.Len() {
+		t.Fatalf("expected optimized output smaller than original, got optimized=%d original=%d", len(payload), original.Len())
+	}
+	if int64(len(payload)) > maxFileSizeBytes {
+		t.Fatalf("expected optimized output under attachment cap, got %d", len(payload))
+	}
+}
+
+func TestCall_RawImageSkipsOptimization(t *testing.T) {
+	workspace := t.TempDir()
+	var original bytes.Buffer
+	if err := jpeg.Encode(&original, generatedPhotoLikeImage(512), &jpeg.Options{Quality: 95}); err != nil {
+		t.Fatalf("encode jpeg: %v", err)
+	}
+	imagePath := filepath.Join(workspace, "photo.jpg")
+	if err := os.WriteFile(imagePath, original.Bytes(), 0o644); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+
+	tool, err := New(workspace, true)
+	if err != nil {
+		t.Fatalf("new tool: %v", err)
+	}
+
+	result, err := tool.Call(context.Background(), tools.Call{
+		ID:    "call-raw",
+		Name:  toolspec.ToolViewImage,
+		Input: json.RawMessage(`{"path":"photo.jpg","raw":true}`),
+	})
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success result, got error payload: %s", string(result.Output))
+	}
+
+	mimeType, payload := decodeSingleImageDataURL(t, result)
+	if mimeType != "image/jpeg" {
+		t.Fatalf("expected raw jpeg output, got %q", mimeType)
+	}
+	if !bytes.Equal(payload, original.Bytes()) {
+		t.Fatalf("expected raw image bytes to be preserved")
+	}
+}
+
+func TestCall_RawImageStillEnforcesAttachmentCap(t *testing.T) {
+	workspace := t.TempDir()
+	var original bytes.Buffer
+	if err := jpeg.Encode(&original, generatedPhotoLikeImage(1024), &jpeg.Options{Quality: 95}); err != nil {
+		t.Fatalf("encode jpeg: %v", err)
+	}
+	if int64(original.Len()) <= maxFileSizeBytes {
+		t.Fatalf("test image must exceed attachment cap: %d", original.Len())
+	}
+	imagePath := filepath.Join(workspace, "large.jpg")
+	if err := os.WriteFile(imagePath, original.Bytes(), 0o644); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+
+	tool, err := New(workspace, true)
+	if err != nil {
+		t.Fatalf("new tool: %v", err)
+	}
+
+	result, err := tool.Call(context.Background(), tools.Call{
+		ID:    "call-raw-large",
+		Name:  toolspec.ToolViewImage,
+		Input: json.RawMessage(`{"path":"large.jpg","raw":true}`),
+	})
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected raw oversized image to be rejected")
+	}
+	if got := toolError(t, result); !strings.Contains(got, "max supported size is 819200 bytes (800 KiB)") {
+		t.Fatalf("expected attachment cap error, got %q", got)
+	}
+}
+
+func TestCall_StillGIFAcceptedAndAnimatedGIFRejected(t *testing.T) {
+	workspace := t.TempDir()
+	stillPath := filepath.Join(workspace, "still.gif")
+	if err := os.WriteFile(stillPath, encodedGIF(t, 1), 0o644); err != nil {
+		t.Fatalf("write still gif: %v", err)
+	}
+	animatedPath := filepath.Join(workspace, "animated.gif")
+	if err := os.WriteFile(animatedPath, encodedGIF(t, 2), 0o644); err != nil {
+		t.Fatalf("write animated gif: %v", err)
+	}
+
+	tool, err := New(workspace, true)
+	if err != nil {
+		t.Fatalf("new tool: %v", err)
+	}
+
+	still, err := tool.Call(context.Background(), tools.Call{
+		ID:    "call-still-gif",
+		Name:  toolspec.ToolViewImage,
+		Input: json.RawMessage(`{"path":"still.gif"}`),
+	})
+	if err != nil {
+		t.Fatalf("still gif call: %v", err)
+	}
+	if still.IsError {
+		t.Fatalf("expected still gif success, got %s", string(still.Output))
+	}
+	mimeType, _ := decodeSingleImageDataURL(t, still)
+	if mimeType != "image/gif" {
+		t.Fatalf("expected still gif output, got %q", mimeType)
+	}
+
+	animated, err := tool.Call(context.Background(), tools.Call{
+		ID:    "call-animated-gif",
+		Name:  toolspec.ToolViewImage,
+		Input: json.RawMessage(`{"path":"animated.gif"}`),
+	})
+	if err != nil {
+		t.Fatalf("animated gif call: %v", err)
+	}
+	if !animated.IsError {
+		t.Fatalf("expected animated gif to be rejected")
+	}
+	if got := toolError(t, animated); !strings.Contains(got, "animated GIFs are not supported") {
+		t.Fatalf("expected animated GIF guidance, got %q", got)
+	}
+}
+
+func TestCall_AnimatedWebPRejected(t *testing.T) {
+	workspace := t.TempDir()
+	imagePath := filepath.Join(workspace, "animated.webp")
+	if err := os.WriteFile(imagePath, encodedAnimatedWebP(t), 0o644); err != nil {
+		t.Fatalf("write animated webp: %v", err)
+	}
+
+	tool, err := New(workspace, true)
+	if err != nil {
+		t.Fatalf("new tool: %v", err)
+	}
+
+	result, err := tool.Call(context.Background(), tools.Call{
+		ID:    "call-animated-webp",
+		Name:  toolspec.ToolViewImage,
+		Input: json.RawMessage(`{"path":"animated.webp"}`),
+	})
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected animated webp to be rejected")
+	}
+	if got := toolError(t, result); !strings.Contains(got, "animated WebP images are not supported") {
+		t.Fatalf("expected animated WebP guidance, got %q", got)
+	}
+}
+
+func TestCall_StillWebPAccepted(t *testing.T) {
+	workspace := t.TempDir()
+	imagePath := filepath.Join(workspace, "still.webp")
+	if err := os.WriteFile(imagePath, encodedStillWebP(t), 0o644); err != nil {
+		t.Fatalf("write still webp: %v", err)
+	}
+
+	tool, err := New(workspace, true)
+	if err != nil {
+		t.Fatalf("new tool: %v", err)
+	}
+
+	result, err := tool.Call(context.Background(), tools.Call{
+		ID:    "call-still-webp",
+		Name:  toolspec.ToolViewImage,
+		Input: json.RawMessage(`{"path":"still.webp"}`),
+	})
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected still WebP success, got %s", string(result.Output))
+	}
+	mimeType, _ := decodeSingleImageDataURL(t, result)
+	if mimeType != "image/webp" {
+		t.Fatalf("expected still WebP output, got %q", mimeType)
+	}
+}
+
+func TestCall_CorruptImageReturnsToolError(t *testing.T) {
+	workspace := t.TempDir()
+	imagePath := filepath.Join(workspace, "corrupt.png")
+	if err := os.WriteFile(imagePath, make([]byte, 1024), 0o644); err != nil {
+		t.Fatalf("write corrupt image: %v", err)
+	}
+
+	tool, err := New(workspace, true)
+	if err != nil {
+		t.Fatalf("new tool: %v", err)
+	}
+
+	result, err := tool.Call(context.Background(), tools.Call{
+		ID:    "call-corrupt",
+		Name:  toolspec.ToolViewImage,
+		Input: json.RawMessage(`{"path":"corrupt.png"}`),
+	})
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected tool error result for corrupt image")
+	}
+	if got := toolError(t, result); !strings.Contains(got, "unable to decode image") {
+		t.Fatalf("expected decode error, got %q", got)
+	}
+}
+
+func TestCall_HugeDecodedDimensionsRejected(t *testing.T) {
+	workspace := t.TempDir()
+	imagePath := filepath.Join(workspace, "huge-dimensions.png")
+	if err := os.WriteFile(imagePath, pngWithDimensions(t, 100_000, 100_000), 0o644); err != nil {
+		t.Fatalf("write huge-dimension image: %v", err)
+	}
+
+	tool, err := New(workspace, true)
+	if err != nil {
+		t.Fatalf("new tool: %v", err)
+	}
+
+	result, err := tool.Call(context.Background(), tools.Call{
+		ID:    "call-huge-dimensions",
+		Name:  toolspec.ToolViewImage,
+		Input: json.RawMessage(`{"path":"huge-dimensions.png"}`),
+	})
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected huge decoded dimensions to be rejected")
+	}
+	if got := toolError(t, result); !strings.Contains(got, "exceed the supported pixel limit") {
+		t.Fatalf("expected decoded pixel limit error, got %q", got)
+	}
+}
+
+func generatedPhotoLikeImage(size int) image.Image {
+	img := image.NewRGBA(image.Rect(0, 0, size, size))
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			img.SetRGBA(x, y, color.RGBA{
+				R: uint8((x*13 + y*7) % 256),
+				G: uint8((x*5 + y*11) % 256),
+				B: uint8((x*3 + y*17) % 256),
+				A: 255,
+			})
+		}
+	}
+	return img
+}
+
+func encodedGIF(t *testing.T, frames int) []byte {
+	t.Helper()
+	palette := []color.Color{color.Black, color.White}
+	images := make([]*image.Paletted, 0, frames)
+	delays := make([]int, 0, frames)
+	for idx := 0; idx < frames; idx++ {
+		img := image.NewPaletted(image.Rect(0, 0, 2, 2), palette)
+		img.SetColorIndex(idx%2, idx%2, 1)
+		images = append(images, img)
+		delays = append(delays, 0)
+	}
+	var buf bytes.Buffer
+	if err := gif.EncodeAll(&buf, &gif.GIF{Image: images, Delay: delays}); err != nil {
+		t.Fatalf("encode gif: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func encodedAnimatedWebP(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	encoder := animation.NewEncoder(&buf, 2, 2, &animation.EncodeOptions{Quality: 80, Kmax: 1})
+	if encoder == nil {
+		t.Fatal("create animated WebP encoder")
+	}
+	first := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	first.Set(0, 0, color.White)
+	second := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	second.Set(1, 1, color.White)
+	if err := encoder.AddFrame(first, 100*time.Millisecond); err != nil {
+		t.Fatalf("add first WebP frame: %v", err)
+	}
+	if err := encoder.AddFrame(second, 100*time.Millisecond); err != nil {
+		t.Fatalf("add second WebP frame: %v", err)
+	}
+	if err := encoder.Close(); err != nil {
+		t.Fatalf("close animated WebP encoder: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func encodedStillWebP(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.White)
+	if err := webp.Encode(&buf, img, webp.OptionsForPreset(webp.PresetPicture, 80)); err != nil {
+		t.Fatalf("encode still WebP: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func pngWithDimensions(t *testing.T, width, height uint32) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	buf.Write([]byte{137, 80, 78, 71, 13, 10, 26, 10})
+
+	ihdr := make([]byte, 13)
+	binary.BigEndian.PutUint32(ihdr[0:4], width)
+	binary.BigEndian.PutUint32(ihdr[4:8], height)
+	ihdr[8] = 8
+	ihdr[9] = 2
+	writePNGChunk(&buf, "IHDR", ihdr)
+	writePNGChunk(&buf, "IEND", nil)
+	return buf.Bytes()
+}
+
+func writePNGChunk(buf *bytes.Buffer, chunkType string, data []byte) {
+	var length [4]byte
+	binary.BigEndian.PutUint32(length[:], uint32(len(data)))
+	buf.Write(length[:])
+	buf.WriteString(chunkType)
+	buf.Write(data)
+	checksum := crc32.NewIEEE()
+	_, _ = checksum.Write([]byte(chunkType))
+	_, _ = checksum.Write(data)
+	var crc [4]byte
+	binary.BigEndian.PutUint32(crc[:], checksum.Sum32())
+	buf.Write(crc[:])
+}
+
+func decodeSingleImageDataURL(t *testing.T, result tools.Result) (string, []byte) {
+	t.Helper()
+	var items []map[string]any
+	if err := json.Unmarshal(result.Output, &items); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one content item, got %d", len(items))
+	}
+	if got := items[0]["type"]; got != "input_image" {
+		t.Fatalf("expected input_image type, got %#v", got)
+	}
+	url, ok := items[0]["image_url"].(string)
+	if !ok {
+		t.Fatalf("expected image_url string, got %#v", items[0]["image_url"])
+	}
+	if !strings.HasPrefix(url, "data:") {
+		t.Fatalf("expected data URL, got %q", url)
+	}
+	parts := strings.SplitN(strings.TrimPrefix(url, "data:"), ";base64,", 2)
+	if len(parts) != 2 {
+		t.Fatalf("expected base64 data URL, got %q", url)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode base64 image: %v", err)
+	}
+	return parts[0], decoded
+}

--- a/server/tools/readimage/tool_optimization_unix_test.go
+++ b/server/tools/readimage/tool_optimization_unix_test.go
@@ -1,0 +1,43 @@
+//go:build darwin || linux
+
+package readimage
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"builder/server/tools"
+	"builder/shared/toolspec"
+)
+
+func TestCall_FIFOPathReturnsToolError(t *testing.T) {
+	workspace := t.TempDir()
+	fifoPath := filepath.Join(workspace, "pipe.png")
+	if err := syscall.Mkfifo(fifoPath, 0o644); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+
+	tool, err := New(workspace, true)
+	if err != nil {
+		t.Fatalf("new tool: %v", err)
+	}
+
+	result, err := tool.Call(context.Background(), tools.Call{
+		ID:    "call-fifo",
+		Name:  toolspec.ToolViewImage,
+		Input: json.RawMessage(`{"path":"pipe.png"}`),
+	})
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected FIFO path to be rejected")
+	}
+	if got := toolError(t, result); !strings.Contains(got, "not a regular file") {
+		t.Fatalf("expected regular file error, got %q", got)
+	}
+}

--- a/server/tools/readimage/tool_test.go
+++ b/server/tools/readimage/tool_test.go
@@ -214,11 +214,9 @@ func TestCall_OversizedFileReturnsCompressionGuidance(t *testing.T) {
 	workspace := t.TempDir()
 	oversized := make([]byte, int(maxFileSizeBytes)+1)
 
-	for _, name := range []string{"huge.png", "huge.pdf"} {
-		path := filepath.Join(workspace, name)
-		if err := os.WriteFile(path, oversized, 0o644); err != nil {
-			t.Fatalf("write oversized file %q: %v", name, err)
-		}
+	path := filepath.Join(workspace, "huge.pdf")
+	if err := os.WriteFile(path, oversized, 0o644); err != nil {
+		t.Fatalf("write oversized pdf: %v", err)
 	}
 
 	tool, err := New(workspace, true)
@@ -226,35 +224,30 @@ func TestCall_OversizedFileReturnsCompressionGuidance(t *testing.T) {
 		t.Fatalf("new tool: %v", err)
 	}
 
-	for _, name := range []string{"huge.png", "huge.pdf"} {
-		name := name
-		t.Run(name, func(t *testing.T) {
-			result, callErr := tool.Call(context.Background(), tools.Call{
-				ID:    "call-oversized",
-				Name:  toolspec.ToolViewImage,
-				Input: json.RawMessage(`{"path":"` + name + `"}`),
-			})
-			if callErr != nil {
-				t.Fatalf("call: %v", callErr)
-			}
-			if !result.IsError {
-				t.Fatalf("expected tool error result for oversized file")
-			}
-			errMessage := toolError(t, result)
-			if !strings.Contains(errMessage, "max supported size is 512000 bytes (500 KiB)") {
-				t.Fatalf("expected size limit in error, got %q", errMessage)
-			}
-			if !strings.Contains(errMessage, "compress the image or PDF and try again") {
-				t.Fatalf("expected compression guidance in error, got %q", errMessage)
-			}
-		})
+	result, err := tool.Call(context.Background(), tools.Call{
+		ID:    "call-oversized",
+		Name:  toolspec.ToolViewImage,
+		Input: json.RawMessage(`{"path":"huge.pdf"}`),
+	})
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected tool error result for oversized file")
+	}
+	errMessage := toolError(t, result)
+	if !strings.Contains(errMessage, "max supported size is 819200 bytes (800 KiB)") {
+		t.Fatalf("expected size limit in error, got %q", errMessage)
+	}
+	if !strings.Contains(errMessage, "compress the image or PDF and try again") {
+		t.Fatalf("expected compression guidance in error, got %q", errMessage)
 	}
 }
 
 func TestCall_FileSizeBoundary(t *testing.T) {
 	workspace := t.TempDir()
-	exactPath := filepath.Join(workspace, "exact.png")
-	oversizedPath := filepath.Join(workspace, "oversized.png")
+	exactPath := filepath.Join(workspace, "exact.pdf")
+	oversizedPath := filepath.Join(workspace, "oversized.pdf")
 
 	if err := os.WriteFile(exactPath, make([]byte, int(maxFileSizeBytes)), 0o644); err != nil {
 		t.Fatalf("write exact-size file: %v", err)
@@ -271,7 +264,7 @@ func TestCall_FileSizeBoundary(t *testing.T) {
 	exactResult, err := tool.Call(context.Background(), tools.Call{
 		ID:    "call-exact-size",
 		Name:  toolspec.ToolViewImage,
-		Input: json.RawMessage(`{"path":"exact.png"}`),
+		Input: json.RawMessage(`{"path":"exact.pdf"}`),
 	})
 	if err != nil {
 		t.Fatalf("exact-size call: %v", err)
@@ -283,7 +276,7 @@ func TestCall_FileSizeBoundary(t *testing.T) {
 	oversizedResult, err := tool.Call(context.Background(), tools.Call{
 		ID:    "call-oversized-size",
 		Name:  toolspec.ToolViewImage,
-		Input: json.RawMessage(`{"path":"oversized.png"}`),
+		Input: json.RawMessage(`{"path":"oversized.pdf"}`),
 	})
 	if err != nil {
 		t.Fatalf("oversized call: %v", err)


### PR DESCRIPTION
## Summary
- Repair ongoing scrollback delivery and handoff context handling from existing branch commits.
- Optimize `view_image` attachments by converting larger raster images to smaller WebP payloads when beneficial.
- Add `raw=true`, raise the attachment cap to 800 KiB, reject animated GIF/WebP, and harden image file reads/validation.

## Verification
- `./scripts/test.sh`
- `./scripts/test.sh ./server/tools ./server/llm ./server/runtime`
- `./scripts/test.sh ./server/tools/readimage`
- `CGO_ENABLED=0 go test ./server/tools/readimage -count=1`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -exec=true ./server/tools/readimage`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -exec=true ./server/tools/readimage`
- `./scripts/build.sh --output ./bin/builder`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Image viewing tool now supports animated GIFs and PDFs alongside images
  * Added "raw" mode for images to preserve original format
  * Images automatically optimized to WebP format when beneficial for size reduction

* **Bug Fixes**
  * Improved session activity subscription retry behavior during temporary failures
  * Enhanced transcript synchronization and handling for consistency

* **Documentation**
  * Updated image viewing tool documentation to reflect GIF and PDF support

* **Tests**
  * Added comprehensive test coverage for session activity recovery and transcript operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/respawn-app/builder/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->