### PR TITLE
fix: release idle session runtimes

### DIFF
--- a/cli/app/internal/runtimeattach/lease.go
+++ b/cli/app/internal/runtimeattach/lease.go
@@ -77,6 +77,7 @@ func Release(service servicecontract.SessionRuntimeService, sessionID string, le
 		SessionID:       sessionID,
 		LeaseID:         trimmedLeaseID,
 		OnlyIfIdle:      true,
+		DropOwner:       true,
 	})
 }
 

--- a/cli/app/internal/runtimeattach/lease.go
+++ b/cli/app/internal/runtimeattach/lease.go
@@ -76,6 +76,7 @@ func Release(service servicecontract.SessionRuntimeService, sessionID string, le
 		ClientRequestID: newClientRequestID(nil),
 		SessionID:       sessionID,
 		LeaseID:         trimmedLeaseID,
+		OnlyIfIdle:      true,
 	})
 }
 

--- a/cli/app/internal/runtimeattach/lease_test.go
+++ b/cli/app/internal/runtimeattach/lease_test.go
@@ -138,7 +138,7 @@ func TestReleaseSkipsNilOrEmptyLeaseAndIgnoresReleaseError(t *testing.T) {
 		t.Fatalf("release requests = %d, want 1", len(service.releaseRequests))
 	}
 	req := service.releaseRequests[0]
-	if req.SessionID != "session-1" || req.LeaseID != "lease-1" || req.ClientRequestID == "" || !req.OnlyIfIdle {
+	if req.SessionID != "session-1" || req.LeaseID != "lease-1" || req.ClientRequestID == "" || !req.OnlyIfIdle || !req.DropOwner {
 		t.Fatalf("release request = %+v, want session/lease/request ids", req)
 	}
 }

--- a/cli/app/internal/runtimeattach/lease_test.go
+++ b/cli/app/internal/runtimeattach/lease_test.go
@@ -138,7 +138,7 @@ func TestReleaseSkipsNilOrEmptyLeaseAndIgnoresReleaseError(t *testing.T) {
 		t.Fatalf("release requests = %d, want 1", len(service.releaseRequests))
 	}
 	req := service.releaseRequests[0]
-	if req.SessionID != "session-1" || req.LeaseID != "lease-1" || req.ClientRequestID == "" {
+	if req.SessionID != "session-1" || req.LeaseID != "lease-1" || req.ClientRequestID == "" || !req.OnlyIfIdle {
 		t.Fatalf("release request = %+v, want session/lease/request ids", req)
 	}
 }

--- a/cli/app/ui_layout_rendering_status.go
+++ b/cli/app/ui_layout_rendering_status.go
@@ -234,7 +234,7 @@ func (l uiViewLayout) renderServerOwnershipSection(style uiStyles) string {
 }
 
 func (l uiViewLayout) renderContextUsage(style uiStyles) string {
-	usage := l.model.runtimeStatus().ContextUsage
+	usage := l.model.cachedRuntimeStatus().ContextUsage
 	if usage.WindowTokens <= 0 {
 		return ""
 	}

--- a/cli/app/ui_runtime_control_test.go
+++ b/cli/app/ui_runtime_control_test.go
@@ -71,6 +71,9 @@ func (f *runtimeControlFakeClient) MainView() clientui.RuntimeMainView {
 	}
 	return clientui.RuntimeMainView{Status: f.status, Session: f.sessionView}
 }
+func (f *runtimeControlFakeClient) CachedMainView() (clientui.RuntimeMainView, bool) {
+	return f.MainView(), true
+}
 func (f *runtimeControlFakeClient) RefreshMainView() (clientui.RuntimeMainView, error) {
 	f.refreshMainViewCalls++
 	return f.MainView(), f.err

--- a/cli/app/ui_runtime_status.go
+++ b/cli/app/ui_runtime_status.go
@@ -64,23 +64,23 @@ func (m *uiModel) runtimeStatus() clientui.RuntimeStatus {
 	return status
 }
 
-func (m *uiModel) cachedRuntimeStatus() clientui.RuntimeStatus {
+func (m *uiModel) cachedRuntimeMainView() clientui.RuntimeMainView {
 	client := m.runtimeClient()
-	view := clientui.RuntimeMainView{}
 	if cached, ok := client.(interface {
 		CachedMainView() (clientui.RuntimeMainView, bool)
 	}); ok {
 		if cachedView, hasCached := cached.CachedMainView(); hasCached {
-			view = cachedView
-		}
-	} else if client != nil {
-		view = client.MainView()
-	} else {
-		view = clientui.RuntimeMainView{
-			Status:  m.localRuntimeStatus(),
-			Session: m.localRuntimeSessionView(),
+			return cachedView
 		}
 	}
+	return clientui.RuntimeMainView{
+		Status:  m.localRuntimeStatus(),
+		Session: m.localRuntimeSessionView(),
+	}
+}
+
+func (m *uiModel) cachedRuntimeStatus() clientui.RuntimeStatus {
+	view := m.cachedRuntimeMainView()
 	status := view.Status
 	if m.runtimeContextUsageAppliesTo(view.Session.SessionID) {
 		status.ContextUsage = m.runtimeContextUsage

--- a/cli/app/ui_runtime_status_test.go
+++ b/cli/app/ui_runtime_status_test.go
@@ -90,6 +90,70 @@ func TestRuntimeStatusLineShowsGoalProgressWord(t *testing.T) {
 	}
 }
 
+func TestStatusLineRenderDoesNotRefreshMainViewWhenCacheMissing(t *testing.T) {
+	reads := &countingSessionViewClient{view: clientui.RuntimeMainView{
+		Session: clientui.RuntimeSessionView{SessionID: "session-1"},
+		Status: clientui.RuntimeStatus{
+			ContextUsage: clientui.RuntimeContextUsage{UsedTokens: 100, WindowTokens: 1_000},
+		},
+	}}
+	client := newTestSessionRuntimeClient(reads, &leaseRetryRuntimeControlClient{})
+	m := newSizedProjectedClosedUIModel(client, 120, 20, WithUISessionID("session-1"))
+	clearSessionRuntimeClientMainViewCache(client)
+	reads.count.Store(0)
+
+	_ = uiViewLayout{model: m}.renderStatusLine(120, uiThemeStyles(m.theme))
+
+	if got := reads.count.Load(); got != 0 {
+		t.Fatalf("status-line render performed %d synchronous main-view reads, want 0", got)
+	}
+}
+
+func TestViewRenderDoesNotRefreshMainViewWhenCacheMissing(t *testing.T) {
+	reads := &countingSessionViewClient{view: clientui.RuntimeMainView{
+		Session: clientui.RuntimeSessionView{SessionID: "session-1"},
+		Status: clientui.RuntimeStatus{
+			ContextUsage: clientui.RuntimeContextUsage{UsedTokens: 100, WindowTokens: 1_000},
+		},
+	}}
+	client := newTestSessionRuntimeClient(reads, &leaseRetryRuntimeControlClient{})
+	m := newSizedProjectedClosedUIModel(client, 120, 20, WithUISessionID("session-1"))
+	clearSessionRuntimeClientMainViewCache(client)
+	reads.count.Store(0)
+
+	_ = m.View()
+
+	if got := reads.count.Load(); got != 0 {
+		t.Fatalf("view render performed %d synchronous main-view reads, want 0", got)
+	}
+}
+
+func TestSlashCommandPickerRenderDoesNotRefreshMainViewWhenCacheMissing(t *testing.T) {
+	reads := &countingSessionViewClient{view: clientui.RuntimeMainView{
+		Session: clientui.RuntimeSessionView{SessionID: "session-1"},
+		Status:  clientui.RuntimeStatus{ParentSessionID: "parent-1"},
+	}}
+	client := newTestSessionRuntimeClient(reads, &leaseRetryRuntimeControlClient{})
+	m := newSizedProjectedClosedUIModel(client, 120, 20, WithUISessionID("session-1"))
+	m.input = "/ba"
+	m.refreshSlashCommandFilterFromInput()
+	clearSessionRuntimeClientMainViewCache(client)
+	reads.count.Store(0)
+
+	_ = m.View()
+
+	if got := reads.count.Load(); got != 0 {
+		t.Fatalf("slash-command render performed %d synchronous main-view reads, want 0", got)
+	}
+}
+
+func clearSessionRuntimeClientMainViewCache(client *sessionRuntimeClient) {
+	client.mu.Lock()
+	client.hasMainView = false
+	client.mainView = clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{SessionID: client.sessionID}}
+	client.mu.Unlock()
+}
+
 func TestRuntimeStatusLocalFallbackSkipsTrailingDeveloperFeedback(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.transcriptEntries = []tui.TranscriptEntry{

--- a/cli/app/ui_slash_command_picker.go
+++ b/cli/app/ui_slash_command_picker.go
@@ -164,7 +164,7 @@ func (m *uiModel) resumeCommandAvailable() bool {
 }
 
 func (m *uiModel) hasParentSession() bool {
-	return strings.TrimSpace(m.runtimeStatus().ParentSessionID) != ""
+	return strings.TrimSpace(m.cachedRuntimeStatus().ParentSessionID) != ""
 }
 
 func (m *uiModel) clampSlashCommandSelection() {

--- a/server/metadata/db_test.go
+++ b/server/metadata/db_test.go
@@ -108,10 +108,13 @@ func TestOpenMigratesRuntimeLeaseLivenessColumnsAway(t *testing.T) {
 	}
 	defer func() { _ = store.Close() }()
 	columns := runtimeLeaseColumns(t, store.db)
-	for _, removed := range []string{"state", "released_at_unix_ms", "expires_at_unix_ms"} {
+	for _, removed := range []string{"state", "expires_at_unix_ms"} {
 		if columns[removed] {
 			t.Fatalf("runtime_leases column %q should have been removed; columns=%+v", removed, columns)
 		}
+	}
+	if !columns["released_at_unix_ms"] {
+		t.Fatalf("runtime_leases.released_at_unix_ms should exist after release-state migration; columns=%+v", columns)
 	}
 	if _, err := store.ValidateRuntimeLease(t.Context(), "session-1", "lease-1"); err != nil {
 		t.Fatalf("ValidateRuntimeLease after migration: %v", err)
@@ -146,6 +149,9 @@ func TestOpenMigratesCommentsAndRuntimeLeasesToMinimalStorage(t *testing.T) {
 		if columnExists(t, store.db, "runtime_leases", column) {
 			t.Fatalf("runtime_leases.%s should have been removed", column)
 		}
+	}
+	if !columnExists(t, store.db, "runtime_leases", "released_at_unix_ms") {
+		t.Fatal("runtime_leases.released_at_unix_ms should exist after release-state migration")
 	}
 	comments, err := store.DB().QueryContext(t.Context(), `SELECT id, body FROM task_comments ORDER BY updated_at_unix_ms DESC`)
 	if err != nil {

--- a/server/metadata/migrations/00028_runtime_lease_release_state.up.sql
+++ b/server/metadata/migrations/00028_runtime_lease_release_state.up.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+
+ALTER TABLE runtime_leases
+ADD COLUMN released_at_unix_ms INTEGER NOT NULL DEFAULT 0;

--- a/server/metadata/queries.sql
+++ b/server/metadata/queries.sql
@@ -1993,7 +1993,15 @@ INSERT INTO runtime_leases (
 SELECT
     id,
     session_id,
-    created_at_unix_ms
+    created_at_unix_ms,
+    released_at_unix_ms
 FROM runtime_leases
 WHERE id = sqlc.arg(lease_id)
 LIMIT 1;
+
+-- name: ReleaseRuntimeLease :exec
+UPDATE runtime_leases
+SET released_at_unix_ms = sqlc.arg(released_at_unix_ms)
+WHERE id = sqlc.arg(lease_id)
+  AND session_id = sqlc.arg(session_id)
+  AND released_at_unix_ms = 0;

--- a/server/metadata/sqlitegen/models.go
+++ b/server/metadata/sqlitegen/models.go
@@ -38,9 +38,10 @@ type ProjectWorkflowLinkRecord struct {
 }
 
 type RuntimeLease struct {
-	ID              string
-	SessionID       string
-	CreatedAtUnixMs int64
+	ID               string
+	SessionID        string
+	CreatedAtUnixMs  int64
+	ReleasedAtUnixMs int64
 }
 
 type Session struct {

--- a/server/metadata/sqlitegen/queries.sql.go
+++ b/server/metadata/sqlitegen/queries.sql.go
@@ -783,7 +783,8 @@ const getRuntimeLeaseByID = `-- name: GetRuntimeLeaseByID :one
 SELECT
     id,
     session_id,
-    created_at_unix_ms
+    created_at_unix_ms,
+    released_at_unix_ms
 FROM runtime_leases
 WHERE id = ?1
 LIMIT 1
@@ -792,7 +793,12 @@ LIMIT 1
 func (q *Queries) GetRuntimeLeaseByID(ctx context.Context, leaseID string) (RuntimeLease, error) {
 	row := q.db.QueryRowContext(ctx, getRuntimeLeaseByID, leaseID)
 	var i RuntimeLease
-	err := row.Scan(&i.ID, &i.SessionID, &i.CreatedAtUnixMs)
+	err := row.Scan(
+		&i.ID,
+		&i.SessionID,
+		&i.CreatedAtUnixMs,
+		&i.ReleasedAtUnixMs,
+	)
 	return i, err
 }
 
@@ -4330,6 +4336,25 @@ func (q *Queries) ListWorktreesByWorkspaceID(ctx context.Context, workspaceID st
 		return nil, err
 	}
 	return items, nil
+}
+
+const releaseRuntimeLease = `-- name: ReleaseRuntimeLease :exec
+UPDATE runtime_leases
+SET released_at_unix_ms = ?1
+WHERE id = ?2
+  AND session_id = ?3
+  AND released_at_unix_ms = 0
+`
+
+type ReleaseRuntimeLeaseParams struct {
+	ReleasedAtUnixMs int64
+	LeaseID          string
+	SessionID        string
+}
+
+func (q *Queries) ReleaseRuntimeLease(ctx context.Context, arg ReleaseRuntimeLeaseParams) error {
+	_, err := q.db.ExecContext(ctx, releaseRuntimeLease, arg.ReleasedAtUnixMs, arg.LeaseID, arg.SessionID)
+	return err
 }
 
 const setProjectDisplayName = `-- name: SetProjectDisplayName :execrows

--- a/server/metadata/store.go
+++ b/server/metadata/store.go
@@ -49,13 +49,14 @@ type Binding struct {
 	WorkspaceStatus string
 }
 
-// Runtime leases are durable controller tokens, not durable runtime liveness.
-// Do not add active/released state here: whether a session runtime is active is
-// process-local state owned by sessionruntime.Service and RuntimeRegistry.
+// Runtime leases are durable controller tokens with release invalidation.
+// Runtime active/liveness ownership remains process-local state owned by
+// sessionruntime.Service and RuntimeRegistry.
 type RuntimeLeaseRecord struct {
-	LeaseID   string
-	SessionID string
-	CreatedAt time.Time
+	LeaseID    string
+	SessionID  string
+	CreatedAt  time.Time
+	ReleasedAt time.Time
 }
 
 type WorktreeRecord struct {
@@ -89,6 +90,7 @@ var (
 	ErrInvalidProjectKey      = errors.New("invalid project key")
 	ErrProjectKeyImmutable    = errors.New("project key immutable")
 	ErrProjectKeyAlreadyInUse = errors.New("project key already in use")
+	ErrInvalidRuntimeLease    = errors.New("invalid runtime lease")
 )
 
 func (s *Store) PersistenceRoot() string {
@@ -1567,29 +1569,65 @@ func (s *Store) CreateRuntimeLease(ctx context.Context, sessionID string) (Runti
 	return record, nil
 }
 
-// ValidateRuntimeLease validates that a durable controller token exists and
-// belongs to the session. It intentionally does not persist release/liveness
-// state; active runtime ownership is process-local and must stay out of SQLite.
+// ValidateRuntimeLease validates that a durable controller token exists,
+// belongs to the session, and has not been released. Active runtime ownership is
+// process-local and must stay out of SQLite.
 func (s *Store) ValidateRuntimeLease(ctx context.Context, sessionID string, leaseID string) (RuntimeLeaseRecord, error) {
 	if s == nil || s.queries == nil {
 		return RuntimeLeaseRecord{}, errors.New("metadata store is required")
 	}
 	trimmedSessionID := strings.TrimSpace(sessionID)
 	if trimmedSessionID == "" {
-		return RuntimeLeaseRecord{}, errors.New("session id is required")
+		return RuntimeLeaseRecord{}, fmt.Errorf("%w: session id is required", ErrInvalidRuntimeLease)
 	}
 	trimmedLeaseID := strings.TrimSpace(leaseID)
 	if trimmedLeaseID == "" {
-		return RuntimeLeaseRecord{}, errors.New("lease id is required")
+		return RuntimeLeaseRecord{}, fmt.Errorf("%w: lease id is required", ErrInvalidRuntimeLease)
 	}
 	record, err := s.getRuntimeLeaseByID(ctx, trimmedLeaseID)
 	if err != nil {
 		return RuntimeLeaseRecord{}, err
 	}
 	if strings.TrimSpace(record.SessionID) != trimmedSessionID {
-		return RuntimeLeaseRecord{}, fmt.Errorf("runtime lease %q does not belong to session %q", trimmedLeaseID, trimmedSessionID)
+		return RuntimeLeaseRecord{}, fmt.Errorf("%w: runtime lease %q does not belong to session %q", ErrInvalidRuntimeLease, trimmedLeaseID, trimmedSessionID)
+	}
+	if !record.ReleasedAt.IsZero() {
+		return RuntimeLeaseRecord{}, fmt.Errorf("%w: runtime lease %q has been released", ErrInvalidRuntimeLease, trimmedLeaseID)
 	}
 	return record, nil
+}
+
+func (s *Store) ReleaseRuntimeLease(ctx context.Context, sessionID string, leaseID string) (RuntimeLeaseRecord, error) {
+	if s == nil || s.queries == nil {
+		return RuntimeLeaseRecord{}, errors.New("metadata store is required")
+	}
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	if trimmedSessionID == "" {
+		return RuntimeLeaseRecord{}, fmt.Errorf("%w: session id is required", ErrInvalidRuntimeLease)
+	}
+	trimmedLeaseID := strings.TrimSpace(leaseID)
+	if trimmedLeaseID == "" {
+		return RuntimeLeaseRecord{}, fmt.Errorf("%w: lease id is required", ErrInvalidRuntimeLease)
+	}
+	record, err := s.getRuntimeLeaseByID(ctx, trimmedLeaseID)
+	if err != nil {
+		return RuntimeLeaseRecord{}, err
+	}
+	if strings.TrimSpace(record.SessionID) != trimmedSessionID {
+		return RuntimeLeaseRecord{}, fmt.Errorf("%w: runtime lease %q does not belong to session %q", ErrInvalidRuntimeLease, trimmedLeaseID, trimmedSessionID)
+	}
+	if !record.ReleasedAt.IsZero() {
+		return record, nil
+	}
+	releasedAt := time.Now().UTC()
+	if err := s.queries.ReleaseRuntimeLease(ctx, sqlitegen.ReleaseRuntimeLeaseParams{
+		LeaseID:          trimmedLeaseID,
+		SessionID:        trimmedSessionID,
+		ReleasedAtUnixMs: releasedAt.UnixMilli(),
+	}); err != nil {
+		return RuntimeLeaseRecord{}, fmt.Errorf("release runtime lease: %w", err)
+	}
+	return s.getRuntimeLeaseByID(ctx, trimmedLeaseID)
 }
 
 func (s *Store) ResolvePersistedSession(ctx context.Context, sessionID string) (session.PersistedSessionRecord, error) {
@@ -1760,6 +1798,9 @@ func sessionLaunchVisible(meta session.Meta) bool {
 func (s *Store) getRuntimeLeaseByID(ctx context.Context, leaseID string) (RuntimeLeaseRecord, error) {
 	row, err := s.queries.GetRuntimeLeaseByID(ctx, strings.TrimSpace(leaseID))
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return RuntimeLeaseRecord{}, fmt.Errorf("%w: runtime lease %q was not found", ErrInvalidRuntimeLease, strings.TrimSpace(leaseID))
+		}
 		return RuntimeLeaseRecord{}, fmt.Errorf("get runtime lease: %w", err)
 	}
 	return runtimeLeaseRecordFromRow(row), nil
@@ -1940,9 +1981,10 @@ func sessionExecutionTargetFromRow(row sqlitegen.GetSessionExecutionTargetByIDRo
 
 func runtimeLeaseRecordFromRow(row sqlitegen.RuntimeLease) RuntimeLeaseRecord {
 	return RuntimeLeaseRecord{
-		LeaseID:   row.ID,
-		SessionID: row.SessionID,
-		CreatedAt: timeFromStoredTimestamp(row.CreatedAtUnixMs),
+		LeaseID:    row.ID,
+		SessionID:  row.SessionID,
+		CreatedAt:  timeFromStoredTimestamp(row.CreatedAtUnixMs),
+		ReleasedAt: timeFromStoredTimestamp(row.ReleasedAtUnixMs),
 	}
 }
 

--- a/server/metadata/store_part2_test.go
+++ b/server/metadata/store_part2_test.go
@@ -242,7 +242,7 @@ func TestResolvePersistedSessionUsesReboundWorkspaceRoot(t *testing.T) {
 	}
 }
 
-func TestRuntimeLeaseRecordsAreDurableControllerTokensOnly(t *testing.T) {
+func TestRuntimeLeaseReleaseInvalidatesControllerToken(t *testing.T) {
 	ctx := context.Background()
 	store, cfg, binding := newMetadataTestStore(t)
 	sess := createMetadataTestSession(t, store, cfg, binding)
@@ -253,6 +253,9 @@ func TestRuntimeLeaseRecordsAreDurableControllerTokensOnly(t *testing.T) {
 	}
 	if lease.LeaseID == "" || lease.SessionID != sess.Meta().SessionID || lease.CreatedAt.IsZero() {
 		t.Fatalf("unexpected lease record: %+v", lease)
+	}
+	if !lease.ReleasedAt.IsZero() {
+		t.Fatalf("new lease released at = %v, want zero", lease.ReleasedAt)
 	}
 
 	validated, err := store.ValidateRuntimeLease(ctx, sess.Meta().SessionID, lease.LeaseID)
@@ -269,6 +272,24 @@ func TestRuntimeLeaseRecordsAreDurableControllerTokensOnly(t *testing.T) {
 	}
 	if again.LeaseID != lease.LeaseID || again.SessionID != lease.SessionID {
 		t.Fatalf("retry validated lease = %+v, want %+v", again, lease)
+	}
+
+	released, err := store.ReleaseRuntimeLease(ctx, sess.Meta().SessionID, lease.LeaseID)
+	if err != nil {
+		t.Fatalf("ReleaseRuntimeLease: %v", err)
+	}
+	if released.LeaseID != lease.LeaseID || released.SessionID != lease.SessionID || released.ReleasedAt.IsZero() {
+		t.Fatalf("released lease = %+v, want released %+v", released, lease)
+	}
+	if _, err := store.ValidateRuntimeLease(ctx, sess.Meta().SessionID, lease.LeaseID); err == nil || !strings.Contains(err.Error(), "released") {
+		t.Fatalf("ValidateRuntimeLease after release err = %v, want released error", err)
+	}
+	releasedAgain, err := store.ReleaseRuntimeLease(ctx, sess.Meta().SessionID, lease.LeaseID)
+	if err != nil {
+		t.Fatalf("ReleaseRuntimeLease retry: %v", err)
+	}
+	if releasedAgain.ReleasedAt.IsZero() || !releasedAgain.ReleasedAt.Equal(released.ReleasedAt) {
+		t.Fatalf("retry released lease = %+v, want released_at %v", releasedAgain, released.ReleasedAt)
 	}
 }
 

--- a/server/metadata/workflow_schema_test.go
+++ b/server/metadata/workflow_schema_test.go
@@ -162,6 +162,9 @@ func TestOpenCreatesWorkflowSchemaAndForeignKeys(t *testing.T) {
 			t.Fatalf("runtime_leases.%s should not exist; runtime leases store durable token facts only", column)
 		}
 	}
+	if !columnExists(t, store.db, "runtime_leases", "released_at_unix_ms") {
+		t.Fatal("runtime_leases.released_at_unix_ms should exist for released-lease invalidation")
+	}
 	var foreignKeys int
 	if err := store.db.QueryRow("PRAGMA foreign_keys").Scan(&foreignKeys); err != nil {
 		t.Fatalf("PRAGMA foreign_keys: %v", err)

--- a/server/registry/prompt_activity_broker.go
+++ b/server/registry/prompt_activity_broker.go
@@ -132,6 +132,15 @@ func (b *promptActivityBroker) Publish(evt clientui.PendingPromptEvent) {
 	}
 }
 
+func (b *promptActivityBroker) SubscriberCount() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.subscribers)
+}
+
 func (b *promptActivityBroker) canReplayLocked(afterSequence uint64) bool {
 	if afterSequence == 0 || afterSequence == b.nextSeq {
 		return true

--- a/server/registry/runtime_registry.go
+++ b/server/registry/runtime_registry.go
@@ -22,8 +22,15 @@ type RuntimeRegistry struct {
 	directory  *runtimeDirectory
 	leases     *primaryRunLeaseStore
 	observerMu sync.Mutex
-	observer   func(sessionID string)
+	observer   func(sessionID string, reason RuntimeInterestReason)
 }
+
+type RuntimeInterestReason int
+
+const (
+	RuntimeInterestChanged RuntimeInterestReason = iota
+	RuntimeInterestRunFinished
+)
 
 func NewRuntimeRegistry() *RuntimeRegistry {
 	return &RuntimeRegistry{
@@ -76,7 +83,11 @@ func (r *RuntimeRegistry) PublishRuntimeEvent(sessionID string, evt runtime.Even
 	}
 	entry.sessionActivity.Publish(runtimeview.EventFromRuntime(evt))
 	if evt.RunState != nil {
-		r.notifyInterestChanged(sessionID)
+		reason := RuntimeInterestChanged
+		if evt.RunState.Lifecycle.Phase == runtime.RunLifecycleFinished {
+			reason = RuntimeInterestRunFinished
+		}
+		r.notifyInterestChanged(sessionID, reason)
 	}
 }
 
@@ -97,9 +108,9 @@ func (r *RuntimeRegistry) SubscribeSessionActivityFrom(_ context.Context, req se
 	if err != nil {
 		return nil, err
 	}
-	r.notifyInterestChanged(id)
+	r.notifyInterestChanged(id, RuntimeInterestChanged)
 	return &notifyingSessionActivitySubscription{SessionActivitySubscription: sub, onClose: func() {
-		r.notifyInterestChanged(id)
+		r.notifyInterestChanged(id, RuntimeInterestChanged)
 	}}, nil
 }
 
@@ -121,9 +132,9 @@ func (r *RuntimeRegistry) SubscribePromptActivityFrom(_ context.Context, req ser
 		if err != nil {
 			return nil, err
 		}
-		r.notifyInterestChanged(id)
+		r.notifyInterestChanged(id, RuntimeInterestChanged)
 		return &notifyingPromptActivitySubscription{PromptActivitySubscription: sub, onClose: func() {
-			r.notifyInterestChanged(id)
+			r.notifyInterestChanged(id, RuntimeInterestChanged)
 		}}, nil
 	}
 	sub, err := entry.promptActivity.Subscribe(nil, req.AfterSequence)
@@ -133,9 +144,9 @@ func (r *RuntimeRegistry) SubscribePromptActivityFrom(_ context.Context, req ser
 	if sub == nil {
 		return nil, fmt.Errorf("prompt activity stream for %q is unavailable: %w", id, serverapi.ErrStreamUnavailable)
 	}
-	r.notifyInterestChanged(id)
+	r.notifyInterestChanged(id, RuntimeInterestChanged)
 	return &notifyingPromptActivitySubscription{PromptActivitySubscription: sub, onClose: func() {
-		r.notifyInterestChanged(id)
+		r.notifyInterestChanged(id, RuntimeInterestChanged)
 	}}, nil
 }
 
@@ -216,7 +227,7 @@ func (r *RuntimeRegistry) AcquirePrimaryRun(sessionID string) (primaryrun.Lease,
 	return r.leases.Acquire(sessionID)
 }
 
-func (r *RuntimeRegistry) SetInterestObserver(observer func(sessionID string)) {
+func (r *RuntimeRegistry) SetInterestObserver(observer func(sessionID string, reason RuntimeInterestReason)) {
 	if r == nil {
 		return
 	}
@@ -236,7 +247,7 @@ func (r *RuntimeRegistry) HasRuntimeSubscribers(sessionID string) bool {
 	return entry.sessionActivity.SubscriberCount() > 0 || entry.promptActivity.SubscriberCount() > 0
 }
 
-func (r *RuntimeRegistry) notifyInterestChanged(sessionID string) {
+func (r *RuntimeRegistry) notifyInterestChanged(sessionID string, reason RuntimeInterestReason) {
 	if r == nil {
 		return
 	}
@@ -248,7 +259,7 @@ func (r *RuntimeRegistry) notifyInterestChanged(sessionID string) {
 	observer := r.observer
 	r.observerMu.Unlock()
 	if observer != nil {
-		observer(id)
+		observer(id, reason)
 	}
 }
 

--- a/server/registry/runtime_registry.go
+++ b/server/registry/runtime_registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 
 	"builder/server/primaryrun"
 	"builder/server/runtime"
@@ -18,8 +19,10 @@ const (
 )
 
 type RuntimeRegistry struct {
-	directory *runtimeDirectory
-	leases    *primaryRunLeaseStore
+	directory  *runtimeDirectory
+	leases     *primaryRunLeaseStore
+	observerMu sync.Mutex
+	observer   func(sessionID string)
 }
 
 func NewRuntimeRegistry() *RuntimeRegistry {
@@ -72,6 +75,9 @@ func (r *RuntimeRegistry) PublishRuntimeEvent(sessionID string, evt runtime.Even
 		return
 	}
 	entry.sessionActivity.Publish(runtimeview.EventFromRuntime(evt))
+	if evt.RunState != nil {
+		r.notifyInterestChanged(sessionID)
+	}
 }
 
 func (r *RuntimeRegistry) SubscribeSessionActivity(_ context.Context, sessionID string) (serverapi.SessionActivitySubscription, error) {
@@ -87,7 +93,14 @@ func (r *RuntimeRegistry) SubscribeSessionActivityFrom(_ context.Context, req se
 	if entry == nil || entry.sessionActivity == nil {
 		return nil, fmt.Errorf("session activity stream for %q is unavailable: %w", id, serverapi.ErrSessionActivityUnavailable)
 	}
-	return entry.sessionActivity.Subscribe(req.AfterSequence)
+	sub, err := entry.sessionActivity.Subscribe(req.AfterSequence)
+	if err != nil {
+		return nil, err
+	}
+	r.notifyInterestChanged(id)
+	return &notifyingSessionActivitySubscription{SessionActivitySubscription: sub, onClose: func() {
+		r.notifyInterestChanged(id)
+	}}, nil
 }
 
 func (r *RuntimeRegistry) SubscribePromptActivity(_ context.Context, sessionID string) (serverapi.PromptActivitySubscription, error) {
@@ -104,7 +117,14 @@ func (r *RuntimeRegistry) SubscribePromptActivityFrom(_ context.Context, req ser
 		return nil, fmt.Errorf("prompt activity stream for %q is unavailable: %w", id, serverapi.ErrStreamUnavailable)
 	}
 	if req.AfterSequence == 0 {
-		return entry.SubscribePromptActivityInitial(id, nil)
+		sub, err := entry.SubscribePromptActivityInitial(id, nil)
+		if err != nil {
+			return nil, err
+		}
+		r.notifyInterestChanged(id)
+		return &notifyingPromptActivitySubscription{PromptActivitySubscription: sub, onClose: func() {
+			r.notifyInterestChanged(id)
+		}}, nil
 	}
 	sub, err := entry.promptActivity.Subscribe(nil, req.AfterSequence)
 	if err != nil {
@@ -113,7 +133,10 @@ func (r *RuntimeRegistry) SubscribePromptActivityFrom(_ context.Context, req ser
 	if sub == nil {
 		return nil, fmt.Errorf("prompt activity stream for %q is unavailable: %w", id, serverapi.ErrStreamUnavailable)
 	}
-	return sub, nil
+	r.notifyInterestChanged(id)
+	return &notifyingPromptActivitySubscription{PromptActivitySubscription: sub, onClose: func() {
+		r.notifyInterestChanged(id)
+	}}, nil
 }
 
 func (r *RuntimeRegistry) BeginPendingPrompt(sessionID string, req askquestion.Request) {
@@ -191,4 +214,78 @@ func (r *RuntimeRegistry) AcquirePrimaryRun(sessionID string) (primaryrun.Lease,
 		return nil, primaryrun.ErrActivePrimaryRun
 	}
 	return r.leases.Acquire(sessionID)
+}
+
+func (r *RuntimeRegistry) SetInterestObserver(observer func(sessionID string)) {
+	if r == nil {
+		return
+	}
+	r.observerMu.Lock()
+	r.observer = observer
+	r.observerMu.Unlock()
+}
+
+func (r *RuntimeRegistry) HasRuntimeSubscribers(sessionID string) bool {
+	if r == nil {
+		return false
+	}
+	entry := r.directory.Entry(sessionID)
+	if entry == nil {
+		return false
+	}
+	return entry.sessionActivity.SubscriberCount() > 0 || entry.promptActivity.SubscriberCount() > 0
+}
+
+func (r *RuntimeRegistry) notifyInterestChanged(sessionID string) {
+	if r == nil {
+		return
+	}
+	id := normalizeRegistrySessionID(sessionID)
+	if id == "" {
+		return
+	}
+	r.observerMu.Lock()
+	observer := r.observer
+	r.observerMu.Unlock()
+	if observer != nil {
+		observer(id)
+	}
+}
+
+type notifyingSessionActivitySubscription struct {
+	serverapi.SessionActivitySubscription
+	once    sync.Once
+	onClose func()
+}
+
+func (s *notifyingSessionActivitySubscription) Close() error {
+	var err error
+	if s != nil && s.SessionActivitySubscription != nil {
+		err = s.SessionActivitySubscription.Close()
+	}
+	s.once.Do(func() {
+		if s.onClose != nil {
+			s.onClose()
+		}
+	})
+	return err
+}
+
+type notifyingPromptActivitySubscription struct {
+	serverapi.PromptActivitySubscription
+	once    sync.Once
+	onClose func()
+}
+
+func (s *notifyingPromptActivitySubscription) Close() error {
+	var err error
+	if s != nil && s.PromptActivitySubscription != nil {
+		err = s.PromptActivitySubscription.Close()
+	}
+	s.once.Do(func() {
+		if s.onClose != nil {
+			s.onClose()
+		}
+	})
+	return err
 }

--- a/server/registry/runtime_registry_test.go
+++ b/server/registry/runtime_registry_test.go
@@ -144,6 +144,34 @@ func TestRuntimeRegistryReplaysSessionActivityFromCursor(t *testing.T) {
 	}
 }
 
+func TestRuntimeRegistryReportsRunFinishedInterestReason(t *testing.T) {
+	registry := NewRuntimeRegistry()
+	engine := &runtime.Engine{}
+	registry.Register("session-1", engine)
+	t.Cleanup(func() { registry.Unregister("session-1", engine) })
+	reasons := make(chan RuntimeInterestReason, 1)
+	registry.SetInterestObserver(func(sessionID string, reason RuntimeInterestReason) {
+		if sessionID == "session-1" {
+			reasons <- reason
+		}
+	})
+
+	registry.PublishRuntimeEvent("session-1", runtime.Event{
+		Kind:     runtime.EventRunStateChanged,
+		StepID:   "step-1",
+		RunState: &runtime.RunState{Lifecycle: runtime.FinishedRunLifecycle(runtime.RunModeTurn)},
+	})
+
+	select {
+	case reason := <-reasons:
+		if reason != RuntimeInterestRunFinished {
+			t.Fatalf("interest reason = %v, want run finished", reason)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for interest observer")
+	}
+}
+
 func TestRuntimeRegistryDeliversReplayBeforePostSubscribeLiveEvents(t *testing.T) {
 	registry := NewRuntimeRegistry()
 	engine := &runtime.Engine{}

--- a/server/registry/session_activity_broker.go
+++ b/server/registry/session_activity_broker.go
@@ -95,6 +95,15 @@ func (b *sessionActivityBroker) Publish(evt clientui.Event) {
 	}
 }
 
+func (b *sessionActivityBroker) SubscriberCount() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.subscribers)
+}
+
 func (b *sessionActivityBroker) canReplayLocked(afterSequence uint64) bool {
 	if afterSequence == 0 || afterSequence == b.nextSeq {
 		return true

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -311,10 +311,11 @@ func (e *Engine) Close() error {
 		return nil
 	}
 	e.ensureLifecycle()
+	interruptErr := e.Interrupt()
 	e.lifecycleMu.Lock()
 	if e.lifecycleClosed {
 		e.lifecycleMu.Unlock()
-		return nil
+		return interruptErr
 	}
 	e.lifecycleClosed = true
 	cancel := e.lifecycleCancel
@@ -323,7 +324,7 @@ func (e *Engine) Close() error {
 		cancel()
 	}
 	e.lifecycleWG.Wait()
-	return nil
+	return interruptErr
 }
 
 func (e *Engine) ensureLifecycle() {

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -146,6 +146,13 @@ func (s *Service) requireControllerLease(ctx context.Context, sessionID string, 
 	return s.control.RequireControllerLease(ctx, sessionID, leaseID)
 }
 
+func detachedRuntimeContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return context.WithoutCancel(ctx)
+}
+
 func (s *Service) resolve(ctx context.Context, sessionID string) (*runtime.Engine, error) {
 	if s == nil || s.runtimes == nil {
 		return nil, fmt.Errorf("runtime resolver is required")
@@ -336,7 +343,7 @@ func (s *Service) SubmitUserMessage(ctx context.Context, req serverapi.RuntimeSu
 		if err != nil {
 			return serverapi.RuntimeSubmitUserMessageResponse{}, err
 		}
-		msg, err := engine.SubmitUserMessage(ctx, memoReq.Text)
+		msg, err := engine.SubmitUserMessage(detachedRuntimeContext(ctx), memoReq.Text)
 		if err != nil {
 			return serverapi.RuntimeSubmitUserMessageResponse{}, err
 		}
@@ -362,7 +369,7 @@ func (s *Service) SubmitUserShellCommand(ctx context.Context, req serverapi.Runt
 		if err != nil {
 			return struct{}{}, err
 		}
-		_, err = engine.SubmitUserShellCommand(ctx, memoReq.Command)
+		_, err = engine.SubmitUserShellCommand(detachedRuntimeContext(ctx), memoReq.Command)
 		return struct{}{}, err
 	})
 	return err
@@ -381,7 +388,7 @@ func (s *Service) CompactContext(ctx context.Context, req serverapi.RuntimeCompa
 		if err != nil {
 			return struct{}{}, err
 		}
-		return struct{}{}, engine.CompactContext(ctx, req.Args)
+		return struct{}{}, engine.CompactContext(detachedRuntimeContext(ctx), req.Args)
 	})
 	return err
 }
@@ -399,7 +406,7 @@ func (s *Service) CompactContextForPreSubmit(ctx context.Context, req serverapi.
 		if err != nil {
 			return struct{}{}, err
 		}
-		return struct{}{}, engine.CompactContextForPreSubmit(ctx)
+		return struct{}{}, engine.CompactContextForPreSubmit(detachedRuntimeContext(ctx))
 	})
 	return err
 }
@@ -433,7 +440,7 @@ func (s *Service) SubmitQueuedUserMessages(ctx context.Context, req serverapi.Ru
 		if err != nil {
 			return serverapi.RuntimeSubmitQueuedUserMessagesResponse{}, err
 		}
-		msg, err := engine.SubmitQueuedUserMessages(ctx)
+		msg, err := engine.SubmitQueuedUserMessages(detachedRuntimeContext(ctx))
 		if err != nil {
 			return serverapi.RuntimeSubmitQueuedUserMessagesResponse{}, err
 		}

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -71,6 +71,47 @@ func (c *blockingRuntimeControlClient) Generate(ctx context.Context, req llm.Req
 	return llm.Response{}, ctx.Err()
 }
 
+type cancelObservingRuntimeControlClient struct {
+	started     chan struct{}
+	release     chan struct{}
+	ctxCanceled chan struct{}
+}
+
+func newCancelObservingRuntimeControlClient() *cancelObservingRuntimeControlClient {
+	return &cancelObservingRuntimeControlClient{
+		started:     make(chan struct{}),
+		release:     make(chan struct{}),
+		ctxCanceled: make(chan struct{}),
+	}
+}
+
+func (c *cancelObservingRuntimeControlClient) Generate(ctx context.Context, req llm.Request) (llm.Response, error) {
+	_ = req
+	select {
+	case <-c.started:
+	default:
+		close(c.started)
+	}
+	if done := ctx.Done(); done != nil {
+		go func() {
+			<-done
+			close(c.ctxCanceled)
+		}()
+	}
+	<-c.release
+	if err := ctx.Err(); err != nil {
+		return llm.Response{}, err
+	}
+	return llm.Response{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done", Phase: llm.MessagePhaseFinal},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}, nil
+}
+
+func (c *cancelObservingRuntimeControlClient) ProviderCapabilities(context.Context) (llm.ProviderCapabilities, error) {
+	return llm.ProviderCapabilities{}, nil
+}
+
 type fakeShellHandler struct{}
 
 func (fakeShellHandler) Name() toolspec.ID { return toolspec.ToolExecCommand }
@@ -155,6 +196,67 @@ func TestServiceSubmitUserMessageReturnsTypedRuntimeUnavailable(t *testing.T) {
 	_, err := service.SubmitUserMessage(context.Background(), req)
 	if !errors.Is(err, serverapi.ErrRuntimeUnavailable) {
 		t.Fatalf("SubmitUserMessage error = %v, want ErrRuntimeUnavailable", err)
+	}
+}
+
+func TestServiceSubmitUserMessageDetachesRunFromCallerCancellation(t *testing.T) {
+	client := newCancelObservingRuntimeControlClient()
+	store, _, service := newRuntimeControlTestService(t, client, nil, runtime.Config{})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := service.SubmitUserMessage(ctx, runtimeControlUserMessageRequest(store, "req-detached", "hello"))
+		done <- err
+	}()
+
+	select {
+	case <-client.started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for submit to start")
+	}
+	cancel()
+	select {
+	case <-client.ctxCanceled:
+		t.Fatal("runtime context was canceled by caller cancellation")
+	case <-time.After(50 * time.Millisecond):
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("submit returned before runtime was released: %v", err)
+	default:
+	}
+
+	close(client.release)
+	if err := <-done; err != nil {
+		t.Fatalf("SubmitUserMessage: %v", err)
+	}
+}
+
+func TestServiceSubmitUserMessageStillCancelsOnExplicitInterrupt(t *testing.T) {
+	client := newCancelObservingRuntimeControlClient()
+	store, engine, service := newRuntimeControlTestService(t, client, nil, runtime.Config{})
+	done := make(chan error, 1)
+	go func() {
+		_, err := service.SubmitUserMessage(context.Background(), runtimeControlUserMessageRequest(store, "req-interrupt", "hello"))
+		done <- err
+	}()
+
+	select {
+	case <-client.started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for submit to start")
+	}
+	if err := engine.Interrupt(); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+	select {
+	case <-client.ctxCanceled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runtime context was not canceled by explicit interrupt")
+	}
+	close(client.release)
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("SubmitUserMessage error = %v, want context canceled", err)
 	}
 }
 

--- a/server/runtimecontrol/service_turn_submission.go
+++ b/server/runtimecontrol/service_turn_submission.go
@@ -25,19 +25,20 @@ func (s *Service) SubmitUserTurn(ctx context.Context, req serverapi.RuntimeSubmi
 		if err != nil {
 			return serverapi.RuntimeSubmitUserTurnResponse{}, err
 		}
-		shouldCompact, err := engine.ShouldCompactBeforeUserMessage(ctx, memoReq.Text)
+		runCtx := detachedRuntimeContext(ctx)
+		shouldCompact, err := engine.ShouldCompactBeforeUserMessage(runCtx, memoReq.Text)
 		if err != nil {
 			return serverapi.RuntimeSubmitUserTurnResponse{}, err
 		}
 		if shouldCompact {
-			if err := engine.CompactContextForPreSubmit(ctx); err != nil {
+			if err := engine.CompactContextForPreSubmit(runCtx); err != nil {
 				return serverapi.RuntimeSubmitUserTurnResponse{}, err
 			}
 		}
 		if err := engine.RecordPromptHistory(memoReq.Text); err != nil {
 			return serverapi.RuntimeSubmitUserTurnResponse{}, err
 		}
-		msg, err := engine.SubmitUserMessage(ctx, memoReq.Text)
+		msg, err := engine.SubmitUserMessage(runCtx, memoReq.Text)
 		if err != nil {
 			return serverapi.RuntimeSubmitUserTurnResponse{}, err
 		}

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -602,6 +602,7 @@ func (s *Service) runScheduledIdleUnload(sessionID string, generation uint64) {
 		SessionID:       trimmedSessionID,
 		LeaseID:         leaseID,
 		OnlyIfIdle:      true,
+		DropOwner:       true,
 	})
 }
 

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -199,6 +199,7 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 		if err := waitForRuntimeHandleReady(ctx, handle); err != nil {
 			return serverapi.SessionRuntimeActivateResponse{}, err
 		}
+		s.addRuntimeHandleOwnerRef(sessionID, handle)
 		return activationResponseForHandle(handle)
 	}
 	if claim == activationClaimTakeoverReuse {
@@ -380,6 +381,11 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 	}
 	var primaryLease primaryrun.Lease
 	if req.OnlyIfIdle {
+		if req.DropOwner && current.ownerRefs > 1 {
+			current.ownerRefs--
+			s.mu.Unlock()
+			return serverapi.SessionRuntimeReleaseResponse{}, nil
+		}
 		s.mu.Unlock()
 		lease, err := s.acquirePrimaryRunLease(sessionID)
 		if errors.Is(err, primaryrun.ErrActivePrimaryRun) {
@@ -478,10 +484,28 @@ func (s *Service) markRuntimeHandleOrphaned(sessionID string, handle *runtimeHan
 	s.mu.Lock()
 	current := s.handles[trimmedSessionID]
 	if current == handle && strings.TrimSpace(current.controllerLeaseID) == trimmedLeaseID {
-		current.ownerRefs = 0
+		if current.ownerRefs > 0 {
+			current.ownerRefs--
+		}
 	}
 	s.mu.Unlock()
 	s.scheduleIdleUnload(trimmedSessionID, s.defaultIdleUnloadDelay())
+}
+
+func (s *Service) addRuntimeHandleOwnerRef(sessionID string, handle *runtimeHandle) {
+	if s == nil || handle == nil {
+		return
+	}
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	if trimmedSessionID == "" {
+		return
+	}
+	s.mu.Lock()
+	if current := s.handles[trimmedSessionID]; current == handle {
+		current.ownerRefs++
+	}
+	s.mu.Unlock()
+	s.cancelScheduledIdleUnload(trimmedSessionID)
 }
 
 func (s *Service) runtimeInterestChanged(sessionID string, reason registry.RuntimeInterestReason) {

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -379,7 +379,9 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 		s.mu.Unlock()
 		lease, err := s.acquirePrimaryRunLease(sessionID)
 		if errors.Is(err, primaryrun.ErrActivePrimaryRun) {
-			s.markRuntimeHandleOrphaned(sessionID, handle, leaseID)
+			if req.DropOwner {
+				s.markRuntimeHandleOrphaned(sessionID, handle, leaseID)
+			}
 			return serverapi.SessionRuntimeReleaseResponse{Active: true}, nil
 		}
 		if err != nil {
@@ -397,7 +399,9 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 			if primaryLease != nil {
 				primaryLease.Release()
 			}
-			s.markRuntimeHandleOrphaned(sessionID, handle, leaseID)
+			if req.DropOwner {
+				s.markRuntimeHandleOrphaned(sessionID, handle, leaseID)
+			}
 			return serverapi.SessionRuntimeReleaseResponse{Active: true}, nil
 		}
 		s.mu.Lock()

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -374,6 +374,10 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 		s.mu.Unlock()
 		return serverapi.SessionRuntimeReleaseResponse{}, invalidControllerLeaseError(sessionID)
 	}
+	if leaseErr != nil {
+		s.mu.Unlock()
+		return serverapi.SessionRuntimeReleaseResponse{}, leaseErr
+	}
 	var primaryLease primaryrun.Lease
 	if req.OnlyIfIdle {
 		s.mu.Unlock()
@@ -443,9 +447,6 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 	}
 	s.mu.Unlock()
 	s.clearScheduledIdleUnload(sessionID)
-	if leaseErr != nil {
-		return serverapi.SessionRuntimeReleaseResponse{}, leaseErr
-	}
 	_, err := s.releaseRuntimeLease(ctx, sessionID, leaseID)
 	return serverapi.SessionRuntimeReleaseResponse{Released: err == nil}, err
 }

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -56,6 +56,7 @@ type runtimeHandle struct {
 	controllerRequestID string
 	controllerLeaseID   string
 	ownerRefs           int
+	ownerIDs            map[string]struct{}
 	activationErr       error
 	closing             bool
 	takeover            *runtimeTakeover
@@ -176,6 +177,7 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 	}
 	sessionID := strings.TrimSpace(req.SessionID)
 	requestID := strings.TrimSpace(req.ClientRequestID)
+	ownerID := strings.TrimSpace(req.OwnerID)
 	var handle *runtimeHandle
 	var takeover *runtimeTakeover
 	var claim activationClaim
@@ -184,7 +186,7 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 		if s.confirmExternalSessionRuntimeActive(ctx, sessionID) {
 			return serverapi.SessionRuntimeActivateResponse{ReadOnly: true}, nil
 		}
-		handle, takeover, claim, err = s.claimActivation(sessionID, requestID)
+		handle, takeover, claim, err = s.claimActivation(sessionID, requestID, ownerID)
 		if err != nil {
 			return serverapi.SessionRuntimeActivateResponse{}, err
 		}
@@ -199,7 +201,7 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 		if err := waitForRuntimeHandleReady(ctx, handle); err != nil {
 			return serverapi.SessionRuntimeActivateResponse{}, err
 		}
-		s.addRuntimeHandleOwnerRef(sessionID, handle)
+		s.addRuntimeHandleOwnerRef(sessionID, handle, ownerID)
 		return activationResponseForHandle(handle)
 	}
 	if claim == activationClaimTakeoverReuse {
@@ -390,7 +392,7 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 		lease, err := s.acquirePrimaryRunLease(sessionID)
 		if errors.Is(err, primaryrun.ErrActivePrimaryRun) {
 			if req.DropOwner {
-				s.markRuntimeHandleOrphaned(sessionID, handle, leaseID)
+				s.markRuntimeHandleOrphaned(sessionID, handle, leaseID, req.OwnerID)
 			}
 			return serverapi.SessionRuntimeReleaseResponse{Active: true}, nil
 		}
@@ -410,7 +412,7 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 				primaryLease.Release()
 			}
 			if req.DropOwner {
-				s.markRuntimeHandleOrphaned(sessionID, handle, leaseID)
+				s.markRuntimeHandleOrphaned(sessionID, handle, leaseID, req.OwnerID)
 			}
 			return serverapi.SessionRuntimeReleaseResponse{Active: true}, nil
 		}
@@ -419,7 +421,7 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 				primaryLease.Release()
 			}
 			if req.DropOwner {
-				s.markRuntimeHandleOrphaned(sessionID, handle, leaseID)
+				s.markRuntimeHandleOrphaned(sessionID, handle, leaseID, req.OwnerID)
 			}
 			return serverapi.SessionRuntimeReleaseResponse{}, nil
 		}
@@ -475,7 +477,7 @@ func (s *Service) runtimeHasActiveRun(ctx context.Context, sessionID string) (bo
 	return engine.ActiveRun() != nil, nil
 }
 
-func (s *Service) markRuntimeHandleOrphaned(sessionID string, handle *runtimeHandle, leaseID string) {
+func (s *Service) markRuntimeHandleOrphaned(sessionID string, handle *runtimeHandle, leaseID string, ownerID string) {
 	if s == nil || handle == nil {
 		return
 	}
@@ -484,7 +486,15 @@ func (s *Service) markRuntimeHandleOrphaned(sessionID string, handle *runtimeHan
 	s.mu.Lock()
 	current := s.handles[trimmedSessionID]
 	if current == handle && strings.TrimSpace(current.controllerLeaseID) == trimmedLeaseID {
-		if current.ownerRefs > 0 {
+		trimmedOwnerID := strings.TrimSpace(ownerID)
+		if trimmedOwnerID != "" && len(current.ownerIDs) > 0 {
+			if _, ok := current.ownerIDs[trimmedOwnerID]; ok {
+				delete(current.ownerIDs, trimmedOwnerID)
+				if current.ownerRefs > 0 {
+					current.ownerRefs--
+				}
+			}
+		} else if current.ownerRefs > 0 {
 			current.ownerRefs--
 		}
 	}
@@ -492,7 +502,7 @@ func (s *Service) markRuntimeHandleOrphaned(sessionID string, handle *runtimeHan
 	s.scheduleIdleUnload(trimmedSessionID, s.defaultIdleUnloadDelay())
 }
 
-func (s *Service) addRuntimeHandleOwnerRef(sessionID string, handle *runtimeHandle) {
+func (s *Service) addRuntimeHandleOwnerRef(sessionID string, handle *runtimeHandle, ownerID string) {
 	if s == nil || handle == nil {
 		return
 	}
@@ -502,7 +512,17 @@ func (s *Service) addRuntimeHandleOwnerRef(sessionID string, handle *runtimeHand
 	}
 	s.mu.Lock()
 	if current := s.handles[trimmedSessionID]; current == handle {
-		current.ownerRefs++
+		if trimmedOwnerID := strings.TrimSpace(ownerID); trimmedOwnerID != "" {
+			if current.ownerIDs == nil {
+				current.ownerIDs = make(map[string]struct{})
+			}
+			if _, exists := current.ownerIDs[trimmedOwnerID]; !exists {
+				current.ownerIDs[trimmedOwnerID] = struct{}{}
+				current.ownerRefs++
+			}
+		} else {
+			current.ownerRefs++
+		}
 	}
 	s.mu.Unlock()
 	s.cancelScheduledIdleUnload(trimmedSessionID)
@@ -893,7 +913,7 @@ func (s *Service) activeRuntimeHandle(ctx context.Context, sessionID string) (*r
 // Phase 2 temporarily allows many attached readers, but exactly one controlling
 // client per session. A second activation must fail explicitly instead of
 // joining the active runtime.
-func (s *Service) claimActivation(sessionID string, requestID string) (*runtimeHandle, *runtimeTakeover, activationClaim, error) {
+func (s *Service) claimActivation(sessionID string, requestID string, ownerID string) (*runtimeHandle, *runtimeTakeover, activationClaim, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if current := s.handles[sessionID]; current != nil {
@@ -919,18 +939,22 @@ func (s *Service) claimActivation(sessionID string, requestID string) (*runtimeH
 		}
 		return nil, nil, activationClaimOwner, errors.Join(serverapi.ErrSessionAlreadyControlled, fmt.Errorf("session %q is already controlled by another client", sessionID))
 	}
-	handle := newRuntimeHandle(requestID)
+	handle := newRuntimeHandle(requestID, ownerID)
 	s.handles[sessionID] = handle
 	return handle, nil, activationClaimOwner, nil
 }
 
-func newRuntimeHandle(requestID string) *runtimeHandle {
-	return &runtimeHandle{
+func newRuntimeHandle(requestID string, ownerID string) *runtimeHandle {
+	handle := &runtimeHandle{
 		controllerRequestID: strings.TrimSpace(requestID),
 		ownerRefs:           1,
 		ready:               make(chan struct{}),
 		closed:              make(chan struct{}),
 	}
+	if trimmedOwnerID := strings.TrimSpace(ownerID); trimmedOwnerID != "" {
+		handle.ownerIDs = map[string]struct{}{trimmedOwnerID: {}}
+	}
+	return handle
 }
 
 func (s *Service) takeOverActivation(ctx context.Context, sessionID string, requestID string, handle *runtimeHandle, takeover *runtimeTakeover) (serverapi.SessionRuntimeActivateResponse, error) {

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -211,7 +211,7 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 		return activationResponseForTakeover(takeover)
 	}
 	if claim == activationClaimTakeover {
-		return s.takeOverActivation(ctx, sessionID, requestID, handle, takeover)
+		return s.takeOverActivation(ctx, sessionID, requestID, ownerID, handle, takeover)
 	}
 	var leaseID string
 	var cleanup func()
@@ -957,7 +957,7 @@ func newRuntimeHandle(requestID string, ownerID string) *runtimeHandle {
 	return handle
 }
 
-func (s *Service) takeOverActivation(ctx context.Context, sessionID string, requestID string, handle *runtimeHandle, takeover *runtimeTakeover) (serverapi.SessionRuntimeActivateResponse, error) {
+func (s *Service) takeOverActivation(ctx context.Context, sessionID string, requestID string, ownerID string, handle *runtimeHandle, takeover *runtimeTakeover) (serverapi.SessionRuntimeActivateResponse, error) {
 	if err := waitForRuntimeHandleReady(ctx, handle); err != nil {
 		s.failTakeover(sessionID, handle, takeover, err)
 		return serverapi.SessionRuntimeActivateResponse{}, err
@@ -972,7 +972,7 @@ func (s *Service) takeOverActivation(ctx context.Context, sessionID string, requ
 		return serverapi.SessionRuntimeActivateResponse{}, err
 	}
 	leaseID := strings.TrimSpace(lease.LeaseID)
-	ok, completeErr := s.completeTakeover(ctx, sessionID, handle, takeover, requestID, leaseID)
+	ok, completeErr := s.completeTakeover(ctx, sessionID, handle, takeover, requestID, leaseID, ownerID)
 	if completeErr != nil {
 		if strings.TrimSpace(leaseID) != "" {
 			s.releaseRuntimeLeaseBestEffort(sessionID, leaseID)
@@ -1027,7 +1027,7 @@ func (s *Service) completeActivation(handle *runtimeHandle, leaseID string, clos
 	close(handle.ready)
 }
 
-func (s *Service) completeTakeover(ctx context.Context, sessionID string, handle *runtimeHandle, takeover *runtimeTakeover, requestID string, leaseID string) (bool, error) {
+func (s *Service) completeTakeover(ctx context.Context, sessionID string, handle *runtimeHandle, takeover *runtimeTakeover, requestID string, leaseID string, ownerID string) (bool, error) {
 	if handle == nil || takeover == nil {
 		return false, nil
 	}
@@ -1061,6 +1061,10 @@ func (s *Service) completeTakeover(ctx context.Context, sessionID string, handle
 	current.controllerRequestID = strings.TrimSpace(requestID)
 	current.controllerLeaseID = trimmedLeaseID
 	current.ownerRefs = 1
+	current.ownerIDs = nil
+	if trimmedOwnerID := strings.TrimSpace(ownerID); trimmedOwnerID != "" {
+		current.ownerIDs = map[string]struct{}{trimmedOwnerID: {}}
+	}
 	current.takeover = nil
 	s.mu.Unlock()
 	s.cancelScheduledIdleUnload(trimmedSessionID)

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -7,9 +7,11 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"builder/server/auth"
 	"builder/server/metadata"
+	"builder/server/primaryrun"
 	"builder/server/registry"
 	"builder/server/runprompt"
 	"builder/server/runtime"
@@ -44,11 +46,15 @@ type Service struct {
 
 	mu      sync.Mutex
 	handles map[string]*runtimeHandle
+
+	idleUnloadDelay time.Duration
+	idleTimers      map[string]*runtimeIdleTimer
 }
 
 type runtimeHandle struct {
 	controllerRequestID string
 	controllerLeaseID   string
+	ownerRefs           int
 	activationErr       error
 	closing             bool
 	takeover            *runtimeTakeover
@@ -58,6 +64,13 @@ type runtimeHandle struct {
 	rebind              func(string) error
 	close               func()
 }
+
+type runtimeIdleTimer struct {
+	generation uint64
+	timer      *time.Timer
+}
+
+const defaultRuntimeIdleUnloadDelay = 5 * time.Second
 
 type runtimeTakeover struct {
 	requestID string
@@ -78,7 +91,7 @@ const (
 )
 
 func NewService(persistenceRoot string, metadataStore *metadata.Store, authManager *auth.Manager, fastModeState *runtime.FastModeState, background *shelltool.Manager, backgroundRouter *runtimewire.BackgroundEventRouter, runtimes *registry.RuntimeRegistry, sessionStores *registry.SessionStoreRegistry, storeOptions ...session.StoreOption) *Service {
-	return &Service{
+	svc := &Service{
 		persistenceRoot:  strings.TrimSpace(persistenceRoot),
 		metadataStore:    metadataStore,
 		authManager:      authManager,
@@ -89,7 +102,13 @@ func NewService(persistenceRoot string, metadataStore *metadata.Store, authManag
 		sessionStores:    sessionStores,
 		storeOptions:     append([]session.StoreOption(nil), storeOptions...),
 		handles:          make(map[string]*runtimeHandle),
+		idleUnloadDelay:  defaultRuntimeIdleUnloadDelay,
+		idleTimers:       make(map[string]*runtimeIdleTimer),
 	}
+	if runtimes != nil {
+		runtimes.SetInterestObserver(svc.runtimeInterestChanged)
+	}
+	return svc
 }
 
 func (s *Service) WithGeneratedRecoveredWarning(warning string) *Service {
@@ -195,7 +214,7 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 			cleanup()
 		}
 		if strings.TrimSpace(leaseID) != "" {
-			_, _ = s.validateRuntimeLease(context.Background(), sessionID, leaseID)
+			_, _ = s.releaseRuntimeLease(context.Background(), sessionID, leaseID)
 		}
 		s.failActivation(sessionID, handle, err)
 	}()
@@ -280,6 +299,7 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 	}
 	handle.rebind = runtimeRebindFunc(localRebind, wiring.Engine)
 	s.completeActivation(handle, leaseID, cleanup)
+	s.cancelScheduledIdleUnload(sessionID)
 	cleanup = nil
 	return serverapi.SessionRuntimeActivateResponse{LeaseID: leaseID}, nil
 }
@@ -332,7 +352,8 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 	handle := s.handles[sessionID]
 	if handle == nil {
 		s.mu.Unlock()
-		return serverapi.SessionRuntimeReleaseResponse{}, leaseErr
+		_, err := s.releaseRuntimeLease(ctx, sessionID, leaseID)
+		return serverapi.SessionRuntimeReleaseResponse{Released: err == nil}, err
 	}
 	s.mu.Unlock()
 	if err := waitForRuntimeHandleReady(ctx, handle); err != nil {
@@ -347,10 +368,51 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 		s.mu.Unlock()
 		return serverapi.SessionRuntimeReleaseResponse{}, invalidControllerLeaseError(sessionID)
 	}
+	var primaryLease primaryrun.Lease
+	if req.OnlyIfIdle {
+		s.mu.Unlock()
+		lease, err := s.acquirePrimaryRunLease(sessionID)
+		if errors.Is(err, primaryrun.ErrActivePrimaryRun) {
+			s.markRuntimeHandleOrphaned(sessionID, handle, leaseID)
+			return serverapi.SessionRuntimeReleaseResponse{Active: true}, nil
+		}
+		if err != nil {
+			return serverapi.SessionRuntimeReleaseResponse{}, err
+		}
+		primaryLease = lease
+		active, err := s.runtimeHasActiveRun(ctx, sessionID)
+		if err != nil {
+			if primaryLease != nil {
+				primaryLease.Release()
+			}
+			return serverapi.SessionRuntimeReleaseResponse{}, err
+		}
+		if active {
+			if primaryLease != nil {
+				primaryLease.Release()
+			}
+			s.markRuntimeHandleOrphaned(sessionID, handle, leaseID)
+			return serverapi.SessionRuntimeReleaseResponse{Active: true}, nil
+		}
+		s.mu.Lock()
+		current = s.handles[sessionID]
+		if current == nil || current != handle || strings.TrimSpace(current.controllerLeaseID) != leaseID {
+			s.mu.Unlock()
+			if primaryLease != nil {
+				primaryLease.Release()
+			}
+			return serverapi.SessionRuntimeReleaseResponse{}, invalidControllerLeaseError(sessionID)
+		}
+	}
 	current.closing = true
 	closeFn := current.close
 	takeover := current.takeover
 	s.mu.Unlock()
+	defer func() {
+		if primaryLease != nil {
+			primaryLease.Release()
+		}
+	}()
 	finishRuntimeTakeover(takeover, "", invalidControllerLeaseError(sessionID))
 	if closeFn != nil {
 		closeFn()
@@ -361,7 +423,156 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 		signalRuntimeHandleClosed(current)
 	}
 	s.mu.Unlock()
-	return serverapi.SessionRuntimeReleaseResponse{}, leaseErr
+	s.clearScheduledIdleUnload(sessionID)
+	if leaseErr != nil {
+		return serverapi.SessionRuntimeReleaseResponse{}, leaseErr
+	}
+	_, err := s.releaseRuntimeLease(ctx, sessionID, leaseID)
+	return serverapi.SessionRuntimeReleaseResponse{Released: err == nil}, err
+}
+
+func (s *Service) acquirePrimaryRunLease(sessionID string) (primaryrun.Lease, error) {
+	if s == nil || s.runtimes == nil {
+		return primaryrun.LeaseFunc(func() {}), nil
+	}
+	return s.runtimes.AcquirePrimaryRun(strings.TrimSpace(sessionID))
+}
+
+func (s *Service) runtimeHasActiveRun(ctx context.Context, sessionID string) (bool, error) {
+	if s == nil || s.runtimes == nil {
+		return false, nil
+	}
+	engine, err := s.runtimes.ResolveRuntime(ctx, strings.TrimSpace(sessionID))
+	if err != nil || engine == nil {
+		return false, err
+	}
+	return engine.ActiveRun() != nil, nil
+}
+
+func (s *Service) markRuntimeHandleOrphaned(sessionID string, handle *runtimeHandle, leaseID string) {
+	if s == nil || handle == nil {
+		return
+	}
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	trimmedLeaseID := strings.TrimSpace(leaseID)
+	s.mu.Lock()
+	current := s.handles[trimmedSessionID]
+	if current == handle && strings.TrimSpace(current.controllerLeaseID) == trimmedLeaseID {
+		current.ownerRefs = 0
+	}
+	s.mu.Unlock()
+	s.scheduleIdleUnload(trimmedSessionID)
+}
+
+func (s *Service) runtimeInterestChanged(sessionID string) {
+	s.scheduleIdleUnload(sessionID)
+}
+
+func (s *Service) cancelScheduledIdleUnload(sessionID string) {
+	if s == nil {
+		return
+	}
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	if trimmedSessionID == "" {
+		return
+	}
+	s.mu.Lock()
+	state := s.idleTimers[trimmedSessionID]
+	if state != nil {
+		state.generation++
+		if state.timer != nil {
+			state.timer.Stop()
+		}
+	}
+	s.mu.Unlock()
+}
+
+func (s *Service) clearScheduledIdleUnload(sessionID string) {
+	if s == nil {
+		return
+	}
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	if trimmedSessionID == "" {
+		return
+	}
+	s.mu.Lock()
+	state := s.idleTimers[trimmedSessionID]
+	if state != nil && state.timer != nil {
+		state.timer.Stop()
+	}
+	delete(s.idleTimers, trimmedSessionID)
+	s.mu.Unlock()
+}
+
+func (s *Service) scheduleIdleUnload(sessionID string) {
+	if s == nil {
+		return
+	}
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	if trimmedSessionID == "" || s.idleUnloadDelay <= 0 {
+		return
+	}
+	s.mu.Lock()
+	if s.idleTimers == nil {
+		s.idleTimers = make(map[string]*runtimeIdleTimer)
+	}
+	state := s.idleTimers[trimmedSessionID]
+	if state == nil {
+		state = &runtimeIdleTimer{}
+		s.idleTimers[trimmedSessionID] = state
+	}
+	state.generation++
+	generation := state.generation
+	if state.timer != nil {
+		state.timer.Stop()
+	}
+	delay := s.idleUnloadDelay
+	state.timer = time.AfterFunc(delay, func() {
+		s.runScheduledIdleUnload(trimmedSessionID, generation)
+	})
+	s.mu.Unlock()
+}
+
+func (s *Service) runScheduledIdleUnload(sessionID string, generation uint64) {
+	if s == nil {
+		return
+	}
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	if trimmedSessionID == "" {
+		return
+	}
+	s.mu.Lock()
+	state := s.idleTimers[trimmedSessionID]
+	if state == nil || state.generation != generation {
+		s.mu.Unlock()
+		return
+	}
+	handle := s.handles[trimmedSessionID]
+	if handle == nil || handle.closing || handle.ownerRefs > 0 {
+		s.mu.Unlock()
+		return
+	}
+	leaseID := strings.TrimSpace(handle.controllerLeaseID)
+	s.mu.Unlock()
+	if leaseID == "" || s.runtimeHasSubscribers(trimmedSessionID) {
+		return
+	}
+	if active, err := s.runtimeHasActiveRun(context.Background(), trimmedSessionID); err != nil || active {
+		return
+	}
+	_, _ = s.ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: uuid.NewString(),
+		SessionID:       trimmedSessionID,
+		LeaseID:         leaseID,
+		OnlyIfIdle:      true,
+	})
+}
+
+func (s *Service) runtimeHasSubscribers(sessionID string) bool {
+	if s == nil || s.runtimes == nil {
+		return false
+	}
+	return s.runtimes.HasRuntimeSubscribers(strings.TrimSpace(sessionID))
 }
 
 func (s *Service) closeReleasedRuntimeHandle(sessionID string, handle *runtimeHandle) {
@@ -389,6 +600,7 @@ func (s *Service) closeReleasedRuntimeHandle(sessionID string, handle *runtimeHa
 		signalRuntimeHandleClosed(current)
 	}
 	s.mu.Unlock()
+	s.clearScheduledIdleUnload(trimmedSessionID)
 }
 
 func (s *Service) RequireControllerLease(ctx context.Context, sessionID string, leaseID string) error {
@@ -648,6 +860,7 @@ func (s *Service) claimActivation(sessionID string, requestID string) (*runtimeH
 func newRuntimeHandle(requestID string) *runtimeHandle {
 	return &runtimeHandle{
 		controllerRequestID: strings.TrimSpace(requestID),
+		ownerRefs:           1,
 		ready:               make(chan struct{}),
 		closed:              make(chan struct{}),
 	}
@@ -668,9 +881,16 @@ func (s *Service) takeOverActivation(ctx context.Context, sessionID string, requ
 		return serverapi.SessionRuntimeActivateResponse{}, err
 	}
 	leaseID := strings.TrimSpace(lease.LeaseID)
-	if !s.completeTakeover(sessionID, handle, takeover, requestID, leaseID) {
+	ok, completeErr := s.completeTakeover(ctx, sessionID, handle, takeover, requestID, leaseID)
+	if completeErr != nil {
 		if strings.TrimSpace(leaseID) != "" {
-			_, _ = s.validateRuntimeLease(context.Background(), sessionID, leaseID)
+			_, _ = s.releaseRuntimeLease(context.Background(), sessionID, leaseID)
+		}
+		return serverapi.SessionRuntimeActivateResponse{}, completeErr
+	}
+	if !ok {
+		if strings.TrimSpace(leaseID) != "" {
+			_, _ = s.releaseRuntimeLease(context.Background(), sessionID, leaseID)
 		}
 		err := errors.Join(serverapi.ErrSessionAlreadyControlled, fmt.Errorf("session %q is already controlled by another client", sessionID))
 		finishRuntimeTakeover(takeover, "", err)
@@ -710,12 +930,15 @@ func (s *Service) completeActivation(handle *runtimeHandle, leaseID string, clos
 	handle.takeover = nil
 	handle.controllerLeaseID = strings.TrimSpace(leaseID)
 	handle.close = closeFn
+	if handle.ownerRefs <= 0 {
+		handle.ownerRefs = 1
+	}
 	close(handle.ready)
 }
 
-func (s *Service) completeTakeover(sessionID string, handle *runtimeHandle, takeover *runtimeTakeover, requestID string, leaseID string) bool {
+func (s *Service) completeTakeover(ctx context.Context, sessionID string, handle *runtimeHandle, takeover *runtimeTakeover, requestID string, leaseID string) (bool, error) {
 	if handle == nil || takeover == nil {
-		return false
+		return false, nil
 	}
 	trimmedSessionID := strings.TrimSpace(sessionID)
 	trimmedLeaseID := strings.TrimSpace(leaseID)
@@ -723,14 +946,25 @@ func (s *Service) completeTakeover(sessionID string, handle *runtimeHandle, take
 	current := s.handles[trimmedSessionID]
 	if current == nil || current != handle || current.takeover != takeover {
 		s.mu.Unlock()
-		return false
+		return false, nil
+	}
+	previousLeaseID := strings.TrimSpace(current.controllerLeaseID)
+	if previousLeaseID != "" {
+		if _, err := s.releaseRuntimeLease(ctx, trimmedSessionID, previousLeaseID); err != nil {
+			current.takeover = nil
+			s.mu.Unlock()
+			finishRuntimeTakeover(takeover, "", err)
+			return false, err
+		}
 	}
 	current.controllerRequestID = strings.TrimSpace(requestID)
 	current.controllerLeaseID = trimmedLeaseID
+	current.ownerRefs = 1
 	current.takeover = nil
 	s.mu.Unlock()
+	s.cancelScheduledIdleUnload(trimmedSessionID)
 	finishRuntimeTakeover(takeover, trimmedLeaseID, nil)
-	return true
+	return true, nil
 }
 
 func (s *Service) failTakeover(sessionID string, handle *runtimeHandle, takeover *runtimeTakeover, err error) {
@@ -798,7 +1032,28 @@ func (s *Service) validateRuntimeLease(ctx context.Context, sessionID string, le
 	if s == nil || s.metadataStore == nil {
 		return metadata.RuntimeLeaseRecord{}, fmt.Errorf("metadata store is required")
 	}
-	return s.metadataStore.ValidateRuntimeLease(ctx, sessionID, leaseID)
+	record, err := s.metadataStore.ValidateRuntimeLease(ctx, sessionID, leaseID)
+	if err != nil {
+		if errors.Is(err, metadata.ErrInvalidRuntimeLease) {
+			return metadata.RuntimeLeaseRecord{}, errors.Join(serverapi.ErrInvalidControllerLease, err)
+		}
+		return metadata.RuntimeLeaseRecord{}, err
+	}
+	return record, nil
+}
+
+func (s *Service) releaseRuntimeLease(ctx context.Context, sessionID string, leaseID string) (metadata.RuntimeLeaseRecord, error) {
+	if s == nil || s.metadataStore == nil {
+		return metadata.RuntimeLeaseRecord{}, fmt.Errorf("metadata store is required")
+	}
+	record, err := s.metadataStore.ReleaseRuntimeLease(ctx, sessionID, leaseID)
+	if err != nil {
+		if errors.Is(err, metadata.ErrInvalidRuntimeLease) {
+			return metadata.RuntimeLeaseRecord{}, errors.Join(serverapi.ErrInvalidControllerLease, err)
+		}
+		return metadata.RuntimeLeaseRecord{}, err
+	}
+	return record, nil
 }
 
 func waitForRuntimeHandleReady(ctx context.Context, handle *runtimeHandle) error {

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -671,6 +671,11 @@ func (s *Service) RequireControllerLease(ctx context.Context, sessionID string, 
 	if controllerLeaseID != trimmedLeaseID {
 		return invalidControllerLeaseError(trimmedSessionID)
 	}
+	if s.metadataStore != nil {
+		if _, err := s.validateRuntimeLease(ctx, trimmedSessionID, trimmedLeaseID); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -47,8 +47,9 @@ type Service struct {
 	mu      sync.Mutex
 	handles map[string]*runtimeHandle
 
-	idleUnloadDelay time.Duration
-	idleTimers      map[string]*runtimeIdleTimer
+	idleUnloadDelay        time.Duration
+	runFinishedUnloadDelay time.Duration
+	idleTimers             map[string]*runtimeIdleTimer
 }
 
 type runtimeHandle struct {
@@ -72,6 +73,7 @@ type runtimeIdleTimer struct {
 
 const (
 	defaultRuntimeIdleUnloadDelay        = 5 * time.Second
+	defaultRunFinishedIdleUnloadDelay    = 3 * time.Minute
 	bestEffortRuntimeLeaseReleaseTimeout = 2 * time.Second
 )
 
@@ -95,18 +97,19 @@ const (
 
 func NewService(persistenceRoot string, metadataStore *metadata.Store, authManager *auth.Manager, fastModeState *runtime.FastModeState, background *shelltool.Manager, backgroundRouter *runtimewire.BackgroundEventRouter, runtimes *registry.RuntimeRegistry, sessionStores *registry.SessionStoreRegistry, storeOptions ...session.StoreOption) *Service {
 	svc := &Service{
-		persistenceRoot:  strings.TrimSpace(persistenceRoot),
-		metadataStore:    metadataStore,
-		authManager:      authManager,
-		fastModeState:    fastModeState,
-		background:       background,
-		backgroundRouter: backgroundRouter,
-		runtimes:         runtimes,
-		sessionStores:    sessionStores,
-		storeOptions:     append([]session.StoreOption(nil), storeOptions...),
-		handles:          make(map[string]*runtimeHandle),
-		idleUnloadDelay:  defaultRuntimeIdleUnloadDelay,
-		idleTimers:       make(map[string]*runtimeIdleTimer),
+		persistenceRoot:        strings.TrimSpace(persistenceRoot),
+		metadataStore:          metadataStore,
+		authManager:            authManager,
+		fastModeState:          fastModeState,
+		background:             background,
+		backgroundRouter:       backgroundRouter,
+		runtimes:               runtimes,
+		sessionStores:          sessionStores,
+		storeOptions:           append([]session.StoreOption(nil), storeOptions...),
+		handles:                make(map[string]*runtimeHandle),
+		idleUnloadDelay:        defaultRuntimeIdleUnloadDelay,
+		runFinishedUnloadDelay: defaultRunFinishedIdleUnloadDelay,
+		idleTimers:             make(map[string]*runtimeIdleTimer),
 	}
 	if runtimes != nil {
 		runtimes.SetInterestObserver(svc.runtimeInterestChanged)
@@ -464,11 +467,15 @@ func (s *Service) markRuntimeHandleOrphaned(sessionID string, handle *runtimeHan
 		current.ownerRefs = 0
 	}
 	s.mu.Unlock()
-	s.scheduleIdleUnload(trimmedSessionID)
+	s.scheduleIdleUnload(trimmedSessionID, s.defaultIdleUnloadDelay())
 }
 
-func (s *Service) runtimeInterestChanged(sessionID string) {
-	s.scheduleIdleUnload(sessionID)
+func (s *Service) runtimeInterestChanged(sessionID string, reason registry.RuntimeInterestReason) {
+	delay := s.defaultIdleUnloadDelay()
+	if reason == registry.RuntimeInterestRunFinished {
+		delay = s.runFinishedIdleUnloadDelay()
+	}
+	s.scheduleIdleUnload(sessionID, delay)
 }
 
 func (s *Service) cancelScheduledIdleUnload(sessionID string) {
@@ -507,12 +514,26 @@ func (s *Service) clearScheduledIdleUnload(sessionID string) {
 	s.mu.Unlock()
 }
 
-func (s *Service) scheduleIdleUnload(sessionID string) {
+func (s *Service) defaultIdleUnloadDelay() time.Duration {
+	if s == nil || s.idleUnloadDelay <= 0 {
+		return defaultRuntimeIdleUnloadDelay
+	}
+	return s.idleUnloadDelay
+}
+
+func (s *Service) runFinishedIdleUnloadDelay() time.Duration {
+	if s == nil || s.runFinishedUnloadDelay <= 0 {
+		return defaultRunFinishedIdleUnloadDelay
+	}
+	return s.runFinishedUnloadDelay
+}
+
+func (s *Service) scheduleIdleUnload(sessionID string, delay time.Duration) {
 	if s == nil {
 		return
 	}
 	trimmedSessionID := strings.TrimSpace(sessionID)
-	if trimmedSessionID == "" || s.idleUnloadDelay <= 0 {
+	if trimmedSessionID == "" || delay <= 0 {
 		return
 	}
 	s.mu.Lock()
@@ -529,7 +550,6 @@ func (s *Service) scheduleIdleUnload(sessionID string) {
 	if state.timer != nil {
 		state.timer.Stop()
 	}
-	delay := s.idleUnloadDelay
 	state.timer = time.AfterFunc(delay, func() {
 		s.runScheduledIdleUnload(trimmedSessionID, generation)
 	})

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -404,6 +404,15 @@ func (s *Service) ReleaseSessionRuntime(ctx context.Context, req serverapi.Sessi
 			}
 			return serverapi.SessionRuntimeReleaseResponse{Active: true}, nil
 		}
+		if s.runtimeHasSubscribers(sessionID) {
+			if primaryLease != nil {
+				primaryLease.Release()
+			}
+			if req.DropOwner {
+				s.markRuntimeHandleOrphaned(sessionID, handle, leaseID)
+			}
+			return serverapi.SessionRuntimeReleaseResponse{}, nil
+		}
 		s.mu.Lock()
 		current = s.handles[sessionID]
 		if current == nil || current != handle || strings.TrimSpace(current.controllerLeaseID) != leaseID {

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -70,7 +70,10 @@ type runtimeIdleTimer struct {
 	timer      *time.Timer
 }
 
-const defaultRuntimeIdleUnloadDelay = 5 * time.Second
+const (
+	defaultRuntimeIdleUnloadDelay        = 5 * time.Second
+	bestEffortRuntimeLeaseReleaseTimeout = 2 * time.Second
+)
 
 type runtimeTakeover struct {
 	requestID string
@@ -214,7 +217,7 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 			cleanup()
 		}
 		if strings.TrimSpace(leaseID) != "" {
-			_, _ = s.releaseRuntimeLease(context.Background(), sessionID, leaseID)
+			s.releaseRuntimeLeaseBestEffort(sessionID, leaseID)
 		}
 		s.failActivation(sessionID, handle, err)
 	}()
@@ -884,13 +887,13 @@ func (s *Service) takeOverActivation(ctx context.Context, sessionID string, requ
 	ok, completeErr := s.completeTakeover(ctx, sessionID, handle, takeover, requestID, leaseID)
 	if completeErr != nil {
 		if strings.TrimSpace(leaseID) != "" {
-			_, _ = s.releaseRuntimeLease(context.Background(), sessionID, leaseID)
+			s.releaseRuntimeLeaseBestEffort(sessionID, leaseID)
 		}
 		return serverapi.SessionRuntimeActivateResponse{}, completeErr
 	}
 	if !ok {
 		if strings.TrimSpace(leaseID) != "" {
-			_, _ = s.releaseRuntimeLease(context.Background(), sessionID, leaseID)
+			s.releaseRuntimeLeaseBestEffort(sessionID, leaseID)
 		}
 		err := errors.Join(serverapi.ErrSessionAlreadyControlled, fmt.Errorf("session %q is already controlled by another client", sessionID))
 		finishRuntimeTakeover(takeover, "", err)
@@ -949,13 +952,23 @@ func (s *Service) completeTakeover(ctx context.Context, sessionID string, handle
 		return false, nil
 	}
 	previousLeaseID := strings.TrimSpace(current.controllerLeaseID)
+	s.mu.Unlock()
 	if previousLeaseID != "" {
 		if _, err := s.releaseRuntimeLease(ctx, trimmedSessionID, previousLeaseID); err != nil {
-			current.takeover = nil
+			s.mu.Lock()
+			if s.handles[trimmedSessionID] == current && current.takeover == takeover {
+				current.takeover = nil
+			}
 			s.mu.Unlock()
 			finishRuntimeTakeover(takeover, "", err)
 			return false, err
 		}
+	}
+	s.mu.Lock()
+	current = s.handles[trimmedSessionID]
+	if current == nil || current != handle || current.takeover != takeover {
+		s.mu.Unlock()
+		return false, nil
 	}
 	current.controllerRequestID = strings.TrimSpace(requestID)
 	current.controllerLeaseID = trimmedLeaseID
@@ -1054,6 +1067,12 @@ func (s *Service) releaseRuntimeLease(ctx context.Context, sessionID string, lea
 		return metadata.RuntimeLeaseRecord{}, err
 	}
 	return record, nil
+}
+
+func (s *Service) releaseRuntimeLeaseBestEffort(sessionID string, leaseID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), bestEffortRuntimeLeaseReleaseTimeout)
+	defer cancel()
+	_, _ = s.releaseRuntimeLease(ctx, sessionID, leaseID)
 }
 
 func waitForRuntimeHandleReady(ctx context.Context, handle *runtimeHandle) error {

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -663,6 +663,7 @@ func TestReleaseSessionRuntimeOnlyIfIdleKeepsActivePrimaryRun(t *testing.T) {
 	handle := &runtimeHandle{
 		controllerRequestID: "req-1",
 		controllerLeaseID:   lease.LeaseID,
+		ownerRefs:           1,
 		ready:               make(chan struct{}),
 		close: func() {
 			closed.Add(1)
@@ -696,6 +697,50 @@ func TestReleaseSessionRuntimeOnlyIfIdleKeepsActivePrimaryRun(t *testing.T) {
 	}
 	if _, err := fixture.service.validateRuntimeLease(context.Background(), fixture.store.Meta().SessionID, lease.LeaseID); err != nil {
 		t.Fatalf("active runtime lease should remain valid: %v", err)
+	}
+	if handle.ownerRefs != 1 {
+		t.Fatalf("connected owner refs = %d, want preserved owner", handle.ownerRefs)
+	}
+}
+
+func TestReleaseSessionRuntimeOnlyIfIdleDropsOwnerWhenRequested(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	runtimeRegistry := registry.NewRuntimeRegistry()
+	fixture.service.runtimes = runtimeRegistry
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ownerRefs:           1,
+		ready:               make(chan struct{}),
+		close:               func() {},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+	active, err := runtimeRegistry.AcquirePrimaryRun(fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("AcquirePrimaryRun: %v", err)
+	}
+	defer active.Release()
+
+	resp, err := fixture.service.ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "rel-1",
+		SessionID:       fixture.store.Meta().SessionID,
+		LeaseID:         lease.LeaseID,
+		OnlyIfIdle:      true,
+		DropOwner:       true,
+	})
+	if err != nil {
+		t.Fatalf("ReleaseSessionRuntime OnlyIfIdle DropOwner: %v", err)
+	}
+	if !resp.Active || resp.Released {
+		t.Fatalf("release response = %+v, want active not released", resp)
+	}
+	if handle.ownerRefs != 0 {
+		t.Fatalf("owner refs = %d, want dropped owner", handle.ownerRefs)
 	}
 }
 

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -884,6 +884,46 @@ func TestIdleRuntimeUnloadReleasesOrphanedRuntimeAfterPrimaryRunFinishes(t *test
 	}
 }
 
+func TestIdleRuntimeUnloadRetriesAfterNonRuntimePrimaryWorkFinishes(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	runtimeRegistry := registry.NewRuntimeRegistry()
+	fixture.service.runtimes = runtimeRegistry
+	fixture.service.idleUnloadDelay = 20 * time.Millisecond
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	closed := make(chan struct{}, 1)
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ownerRefs:           0,
+		ready:               make(chan struct{}),
+		close: func() {
+			closed <- struct{}{}
+		},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+	active, err := runtimeRegistry.AcquirePrimaryRun(fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("AcquirePrimaryRun: %v", err)
+	}
+
+	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID, registry.RuntimeInterestChanged)
+	select {
+	case <-closed:
+		t.Fatal("idle reaper closed runtime while primary work was active")
+	case <-time.After(60 * time.Millisecond):
+	}
+	active.Release()
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for idle reaper retry after primary work finished")
+	}
+}
+
 func TestIdleRuntimeUnloadUsesThreeMinuteDefaultAfterRunFinishes(t *testing.T) {
 	fixture := newSessionRuntimeFixture(t)
 	if fixture.service.runFinishedIdleUnloadDelay() != 3*time.Minute {

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -1098,7 +1098,7 @@ func TestReleaseSessionRuntimeClosesHandleWhenLeaseValidatedAndWaitCanceled(t *t
 	}
 }
 
-func TestReleaseSessionRuntimeStillClosesHandleWhenLeaseValidationFails(t *testing.T) {
+func TestReleaseSessionRuntimeRejectsInvalidLeaseWithoutClosingHandle(t *testing.T) {
 	fixture := newSessionRuntimeFixture(t)
 	closed := atomic.Int32{}
 	handle := &runtimeHandle{
@@ -1119,11 +1119,49 @@ func TestReleaseSessionRuntimeStillClosesHandleWhenLeaseValidationFails(t *testi
 	if err == nil {
 		t.Fatal("expected lease validation error for missing lease record")
 	}
-	if closed.Load() != 1 {
-		t.Fatalf("expected closeFn to run exactly once, got %d", closed.Load())
+	if closed.Load() != 0 {
+		t.Fatalf("expected invalid lease to preserve runtime handle, close count = %d", closed.Load())
 	}
 	if _, ok := fixture.service.handles[fixture.store.Meta().SessionID]; ok {
-		t.Fatal("expected runtime handle to be removed even when lease validation fails")
+		return
+	}
+	t.Fatal("expected runtime handle to remain when lease validation fails")
+}
+
+func TestReleaseSessionRuntimeRejectsReleasedLeaseWithoutClosingHandle(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	if _, err := fixture.metadata.ReleaseRuntimeLease(context.Background(), fixture.store.Meta().SessionID, lease.LeaseID); err != nil {
+		t.Fatalf("ReleaseRuntimeLease setup: %v", err)
+	}
+	closed := atomic.Int32{}
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ready:               make(chan struct{}),
+		close: func() {
+			closed.Add(1)
+		},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+
+	_, err = fixture.service.ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "rel-1",
+		SessionID:       fixture.store.Meta().SessionID,
+		LeaseID:         lease.LeaseID,
+	})
+	if !errors.Is(err, serverapi.ErrInvalidControllerLease) {
+		t.Fatalf("ReleaseSessionRuntime error = %v, want invalid controller lease", err)
+	}
+	if closed.Load() != 0 {
+		t.Fatalf("released stale lease closed runtime handle, close count = %d", closed.Load())
+	}
+	if got := fixture.service.handles[fixture.store.Meta().SessionID]; got != handle {
+		t.Fatalf("runtime handle = %+v, want preserved handle", got)
 	}
 }
 

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -355,6 +355,59 @@ func TestActivateSessionRuntimeReplaysDuplicateRequestAfterReady(t *testing.T) {
 	if got := (<-done).LeaseID; got != "lease-1" {
 		t.Fatalf("lease id = %q, want lease-1", got)
 	}
+	if handle.ownerRefs != 1 {
+		t.Fatalf("owner refs after replay = %d, want 1", handle.ownerRefs)
+	}
+}
+
+func TestActivateSessionRuntimeReplayOwnerSurvivesOriginalDisconnect(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	closed := atomic.Int32{}
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ownerRefs:           1,
+		ready:               make(chan struct{}),
+		close: func() {
+			closed.Add(1)
+		},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+
+	resp, err := fixture.service.ActivateSessionRuntime(context.Background(), serverapi.SessionRuntimeActivateRequest{
+		ClientRequestID: "req-1",
+		SessionID:       fixture.store.Meta().SessionID,
+	})
+	if err != nil {
+		t.Fatalf("ActivateSessionRuntime replay: %v", err)
+	}
+	if resp.LeaseID != lease.LeaseID {
+		t.Fatalf("replay lease = %q, want %q", resp.LeaseID, lease.LeaseID)
+	}
+	release, err := fixture.service.ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "rel-1",
+		SessionID:       fixture.store.Meta().SessionID,
+		LeaseID:         lease.LeaseID,
+		OnlyIfIdle:      true,
+		DropOwner:       true,
+	})
+	if err != nil {
+		t.Fatalf("ReleaseSessionRuntime original disconnect: %v", err)
+	}
+	if release.Released {
+		t.Fatalf("release response = %+v, want unreleased while replay owner remains", release)
+	}
+	if closed.Load() != 0 {
+		t.Fatalf("runtime closed despite replay owner, close count = %d", closed.Load())
+	}
+	if handle.ownerRefs != 1 {
+		t.Fatalf("owner refs after original disconnect = %d, want replay owner", handle.ownerRefs)
+	}
 }
 
 func TestActivateSessionRuntimeReissuesControllerLeaseForTakeover(t *testing.T) {

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -147,7 +147,8 @@ func TestClaimActivationReusesPendingTakeoverRequest(t *testing.T) {
 	if reusedTakeover != takeover {
 		t.Fatal("expected pending retry to return same takeover state")
 	}
-	if !svc.completeTakeover("session-1", handle, takeover, "req-2", "lease-2") {
+	handle.controllerLeaseID = ""
+	if ok, err := svc.completeTakeover(context.Background(), "session-1", handle, takeover, "req-2", "lease-2"); err != nil || !ok {
 		t.Fatal("expected completeTakeover to succeed")
 	}
 	resp, err := activationResponseForTakeover(reusedTakeover)
@@ -386,6 +387,57 @@ func TestActivateSessionRuntimeReissuesControllerLeaseForTakeover(t *testing.T) 
 	if handle.controllerLeaseID != resp.LeaseID {
 		t.Fatalf("controller lease id = %q, want %q", handle.controllerLeaseID, resp.LeaseID)
 	}
+	if _, err := fixture.service.validateRuntimeLease(context.Background(), fixture.store.Meta().SessionID, lease.LeaseID); !errors.Is(err, serverapi.ErrInvalidControllerLease) {
+		t.Fatalf("old takeover lease validation error = %v, want invalid controller lease", err)
+	}
+	if _, err := fixture.service.validateRuntimeLease(context.Background(), fixture.store.Meta().SessionID, resp.LeaseID); err != nil {
+		t.Fatalf("new takeover lease should validate: %v", err)
+	}
+}
+
+func TestCompleteTakeoverDoesNotMutateHandleWhenPreviousLeaseReleaseFails(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	takeover := &runtimeTakeover{requestID: "req-2", ready: make(chan struct{})}
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ready:               make(chan struct{}),
+		takeover:            takeover,
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ok, err := fixture.service.completeTakeover(ctx, fixture.store.Meta().SessionID, handle, takeover, "req-2", "lease-new")
+	if err == nil || errors.Is(err, serverapi.ErrInvalidControllerLease) {
+		t.Fatalf("completeTakeover error = %v, want operational error without invalid controller lease marker", err)
+	}
+	if ok {
+		t.Fatal("completeTakeover ok = true, want false when previous lease release fails")
+	}
+	if handle.controllerRequestID != "req-1" || handle.controllerLeaseID != lease.LeaseID || handle.takeover != nil {
+		t.Fatalf("handle mutated after failed takeover completion: %+v", handle)
+	}
+	select {
+	case <-takeover.ready:
+		if !errors.Is(takeover.err, context.Canceled) {
+			t.Fatalf("takeover error = %v, want context canceled", takeover.err)
+		}
+	default:
+		t.Fatal("takeover waiter was not signaled after failed takeover completion")
+	}
+	_, retryTakeover, claim, err := fixture.service.claimActivation(fixture.store.Meta().SessionID, "req-3")
+	if err != nil {
+		t.Fatalf("claimActivation retry: %v", err)
+	}
+	if claim != activationClaimTakeover || retryTakeover == nil || retryTakeover == takeover {
+		t.Fatalf("retry claim = %v takeover=%+v, want fresh takeover", claim, retryTakeover)
+	}
 }
 
 func TestActivateSessionRuntimeHonorsCanceledContextBeforeInstallingHandle(t *testing.T) {
@@ -398,6 +450,25 @@ func TestActivateSessionRuntimeHonorsCanceledContextBeforeInstallingHandle(t *te
 	}
 	if len(fixture.service.handles) != 0 {
 		t.Fatalf("expected no installed handles after canceled activation, got %+v", fixture.service.handles)
+	}
+}
+
+func TestActivateSessionRuntimeReleasesLeaseOnActivationFailure(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	_, err := fixture.service.ActivateSessionRuntime(context.Background(), serverapi.SessionRuntimeActivateRequest{
+		ClientRequestID: "req-1",
+		SessionID:       fixture.store.Meta().SessionID,
+		EnabledToolIDs:  []string{"not-a-tool"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown tool id") {
+		t.Fatalf("ActivateSessionRuntime error = %v, want unknown tool id", err)
+	}
+	var leaseID string
+	if err := fixture.metadata.DB().QueryRowContext(context.Background(), `SELECT id FROM runtime_leases WHERE session_id = ?`, fixture.store.Meta().SessionID).Scan(&leaseID); err != nil {
+		t.Fatalf("query activation failure lease: %v", err)
+	}
+	if _, err := fixture.service.validateRuntimeLease(context.Background(), fixture.store.Meta().SessionID, leaseID); !errors.Is(err, serverapi.ErrInvalidControllerLease) {
+		t.Fatalf("activation failure lease validation error = %v, want invalid controller lease", err)
 	}
 }
 
@@ -580,6 +651,272 @@ func TestReleaseSessionRuntimeWaitsForHandleReadyBeforeClose(t *testing.T) {
 	}
 }
 
+func TestReleaseSessionRuntimeOnlyIfIdleKeepsActivePrimaryRun(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	runtimeRegistry := registry.NewRuntimeRegistry()
+	fixture.service.runtimes = runtimeRegistry
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	closed := atomic.Int32{}
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ready:               make(chan struct{}),
+		close: func() {
+			closed.Add(1)
+		},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+	active, err := runtimeRegistry.AcquirePrimaryRun(fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("AcquirePrimaryRun: %v", err)
+	}
+	defer active.Release()
+
+	resp, err := fixture.service.ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "rel-1",
+		SessionID:       fixture.store.Meta().SessionID,
+		LeaseID:         lease.LeaseID,
+		OnlyIfIdle:      true,
+	})
+	if err != nil {
+		t.Fatalf("ReleaseSessionRuntime OnlyIfIdle: %v", err)
+	}
+	if !resp.Active || resp.Released {
+		t.Fatalf("release response = %+v, want active not released", resp)
+	}
+	if closed.Load() != 0 {
+		t.Fatalf("runtime close count = %d, want 0", closed.Load())
+	}
+	if got := fixture.service.handles[fixture.store.Meta().SessionID]; got != handle {
+		t.Fatalf("runtime handle = %+v, want preserved active handle", got)
+	}
+	if _, err := fixture.service.validateRuntimeLease(context.Background(), fixture.store.Meta().SessionID, lease.LeaseID); err != nil {
+		t.Fatalf("active runtime lease should remain valid: %v", err)
+	}
+}
+
+func TestReleaseSessionRuntimeOnlyIfIdleClosesIdleRuntime(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	fixture.service.runtimes = registry.NewRuntimeRegistry()
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	closed := atomic.Int32{}
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ready:               make(chan struct{}),
+		close: func() {
+			closed.Add(1)
+		},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+
+	resp, err := fixture.service.ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "rel-1",
+		SessionID:       fixture.store.Meta().SessionID,
+		LeaseID:         lease.LeaseID,
+		OnlyIfIdle:      true,
+	})
+	if err != nil {
+		t.Fatalf("ReleaseSessionRuntime OnlyIfIdle: %v", err)
+	}
+	if !resp.Released || resp.Active {
+		t.Fatalf("release response = %+v, want released not active", resp)
+	}
+	if closed.Load() != 1 {
+		t.Fatalf("runtime close count = %d, want 1", closed.Load())
+	}
+	if _, ok := fixture.service.handles[fixture.store.Meta().SessionID]; ok {
+		t.Fatal("expected runtime handle removed after idle release")
+	}
+	if _, err := fixture.service.validateRuntimeLease(context.Background(), fixture.store.Meta().SessionID, lease.LeaseID); !errors.Is(err, serverapi.ErrInvalidControllerLease) {
+		t.Fatalf("released runtime lease validation error = %v, want invalid controller lease", err)
+	}
+}
+
+func TestIdleRuntimeUnloadReleasesOrphanedRuntimeAfterPrimaryRunFinishes(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	runtimeRegistry := registry.NewRuntimeRegistry()
+	runtimeRegistry.SetInterestObserver(fixture.service.runtimeInterestChanged)
+	fixture.service.runtimes = runtimeRegistry
+	fixture.service.idleUnloadDelay = 10 * time.Millisecond
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	closed := make(chan struct{}, 1)
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ownerRefs:           0,
+		ready:               make(chan struct{}),
+		close: func() {
+			closed <- struct{}{}
+		},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+	active, err := runtimeRegistry.AcquirePrimaryRun(fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("AcquirePrimaryRun: %v", err)
+	}
+	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID)
+	select {
+	case <-closed:
+		t.Fatal("idle reaper closed runtime while primary run was active")
+	case <-time.After(30 * time.Millisecond):
+	}
+	active.Release()
+	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID)
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for idle reaper to close orphaned runtime")
+	}
+}
+
+func TestIdleRuntimeUnloadWaitsForTransientSubscriberReconnect(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	runtimeRegistry := registry.NewRuntimeRegistry()
+	runtimeRegistry.SetInterestObserver(fixture.service.runtimeInterestChanged)
+	fixture.service.runtimes = runtimeRegistry
+	fixture.service.idleUnloadDelay = 30 * time.Millisecond
+	engine, err := runtimepkg.New(fixture.store, &sessionRuntimeTestLLMClient{}, tools.NewRegistry(), runtimepkg.Config{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("runtime.New: %v", err)
+	}
+	t.Cleanup(func() { _ = engine.Close() })
+	runtimeRegistry.Register(fixture.store.Meta().SessionID, engine)
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	closed := make(chan struct{}, 1)
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ownerRefs:           0,
+		ready:               make(chan struct{}),
+		close: func() {
+			closed <- struct{}{}
+		},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+	sub, err := runtimeRegistry.SubscribeSessionActivity(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("SubscribeSessionActivity: %v", err)
+	}
+	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID)
+	select {
+	case <-closed:
+		t.Fatal("idle reaper closed runtime while subscriber was connected")
+	case <-time.After(60 * time.Millisecond):
+	}
+	if err := sub.Close(); err != nil {
+		t.Fatalf("close subscription: %v", err)
+	}
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for idle reaper to close after subscriber disconnect")
+	}
+}
+
+func TestIdleRuntimeUnloadWaitsForSubscriberReconnectBeforeDebounce(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	runtimeRegistry := registry.NewRuntimeRegistry()
+	runtimeRegistry.SetInterestObserver(fixture.service.runtimeInterestChanged)
+	fixture.service.runtimes = runtimeRegistry
+	fixture.service.idleUnloadDelay = 40 * time.Millisecond
+	engine, err := runtimepkg.New(fixture.store, &sessionRuntimeTestLLMClient{}, tools.NewRegistry(), runtimepkg.Config{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("runtime.New: %v", err)
+	}
+	t.Cleanup(func() { _ = engine.Close() })
+	runtimeRegistry.Register(fixture.store.Meta().SessionID, engine)
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	closed := make(chan struct{}, 1)
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ownerRefs:           0,
+		ready:               make(chan struct{}),
+		close: func() {
+			closed <- struct{}{}
+		},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+
+	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID)
+	time.Sleep(15 * time.Millisecond)
+	sub, err := runtimeRegistry.SubscribeSessionActivity(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("SubscribeSessionActivity reconnect: %v", err)
+	}
+	select {
+	case <-closed:
+		t.Fatal("idle reaper closed runtime despite subscriber reconnect before debounce")
+	case <-time.After(80 * time.Millisecond):
+	}
+	if err := sub.Close(); err != nil {
+		t.Fatalf("close subscription: %v", err)
+	}
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for idle reaper to close after reconnected subscriber disconnect")
+	}
+}
+
+func TestIdleRuntimeUnloadIgnoresStaleTimerAfterOwnerReconnect(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	fixture.service.runtimes = registry.NewRuntimeRegistry()
+	fixture.service.idleUnloadDelay = 30 * time.Millisecond
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	closed := make(chan struct{}, 1)
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ownerRefs:           0,
+		ready:               make(chan struct{}),
+		close: func() {
+			closed <- struct{}{}
+		},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+
+	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID)
+	fixture.service.mu.Lock()
+	handle.ownerRefs = 1
+	fixture.service.mu.Unlock()
+	fixture.service.cancelScheduledIdleUnload(fixture.store.Meta().SessionID)
+
+	select {
+	case <-closed:
+		t.Fatal("idle reaper closed runtime after owner reconnected")
+	case <-time.After(90 * time.Millisecond):
+	}
+	if _, err := fixture.service.validateRuntimeLease(context.Background(), fixture.store.Meta().SessionID, lease.LeaseID); err != nil {
+		t.Fatalf("owner reconnect should keep runtime lease valid: %v", err)
+	}
+}
+
 func TestReleaseSessionRuntimeClosesHandleWhenLeaseValidatedAndWaitCanceled(t *testing.T) {
 	fixture := newSessionRuntimeFixture(t)
 	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
@@ -680,12 +1017,59 @@ func TestReleaseSessionRuntimeValidatesPersistedLeaseWhenHandleAlreadyMissing(t 
 		t.Fatalf("ReleaseSessionRuntime: %v", err)
 	}
 
-	validated, err := fixture.metadata.ValidateRuntimeLease(context.Background(), fixture.store.Meta().SessionID, lease.LeaseID)
-	if err != nil {
-		t.Fatalf("ValidateRuntimeLease verification: %v", err)
+	if _, err := fixture.service.validateRuntimeLease(context.Background(), fixture.store.Meta().SessionID, lease.LeaseID); !errors.Is(err, serverapi.ErrInvalidControllerLease) {
+		t.Fatalf("released lease validation error = %v, want invalid controller lease", err)
 	}
-	if validated.LeaseID != lease.LeaseID || validated.SessionID != lease.SessionID {
-		t.Fatalf("validated lease = %+v, want %+v", validated, lease)
+}
+
+func TestReleasedRuntimeLeaseCannotBeValidatedAgain(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ready:               make(chan struct{}),
+		close:               func() {},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+
+	if _, err := fixture.service.ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "rel-1",
+		SessionID:       fixture.store.Meta().SessionID,
+		LeaseID:         lease.LeaseID,
+	}); err != nil {
+		t.Fatalf("ReleaseSessionRuntime: %v", err)
+	}
+	if _, err := fixture.service.validateRuntimeLease(context.Background(), fixture.store.Meta().SessionID, lease.LeaseID); !errors.Is(err, serverapi.ErrInvalidControllerLease) {
+		t.Fatalf("released runtime lease still validates: %v", err)
+	}
+	if _, err := fixture.service.ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "rel-2",
+		SessionID:       fixture.store.Meta().SessionID,
+		LeaseID:         lease.LeaseID,
+	}); err != nil {
+		t.Fatalf("ReleaseSessionRuntime retry should be idempotent: %v", err)
+	}
+}
+
+func TestOperationalLeaseErrorsAreNotClassifiedAsInvalidControllerLease(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := fixture.service.validateRuntimeLease(ctx, fixture.store.Meta().SessionID, lease.LeaseID); err == nil || errors.Is(err, serverapi.ErrInvalidControllerLease) {
+		t.Fatalf("validateRuntimeLease canceled error = %v, want operational error without invalid controller lease marker", err)
+	}
+	if _, err := fixture.service.releaseRuntimeLease(ctx, fixture.store.Meta().SessionID, lease.LeaseID); err == nil || errors.Is(err, serverapi.ErrInvalidControllerLease) {
+		t.Fatalf("releaseRuntimeLease canceled error = %v, want operational error without invalid controller lease marker", err)
 	}
 }
 

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -1346,6 +1346,29 @@ func TestRequireControllerLeaseAcceptsActiveController(t *testing.T) {
 	}
 }
 
+func TestRequireControllerLeaseRejectsReleasedControllerLease(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	if _, err := fixture.metadata.ReleaseRuntimeLease(context.Background(), fixture.store.Meta().SessionID, lease.LeaseID); err != nil {
+		t.Fatalf("ReleaseRuntimeLease: %v", err)
+	}
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ready:               make(chan struct{}),
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+
+	err = fixture.service.RequireControllerLease(context.Background(), fixture.store.Meta().SessionID, lease.LeaseID)
+	if !errors.Is(err, serverapi.ErrInvalidControllerLease) {
+		t.Fatalf("RequireControllerLease error = %v, want invalid controller lease", err)
+	}
+}
+
 func TestRequireControllerLeaseRejectsUnknownLease(t *testing.T) {
 	svc := &Service{handles: map[string]*runtimeHandle{
 		"session-1": {

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -744,6 +744,62 @@ func TestReleaseSessionRuntimeOnlyIfIdleDropsOwnerWhenRequested(t *testing.T) {
 	}
 }
 
+func TestReleaseSessionRuntimeOnlyIfIdleKeepsSubscriberRuntime(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	runtimeRegistry := registry.NewRuntimeRegistry()
+	fixture.service.runtimes = runtimeRegistry
+	engine, err := runtimepkg.New(fixture.store, &sessionRuntimeTestLLMClient{}, tools.NewRegistry(), runtimepkg.Config{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("runtime.New: %v", err)
+	}
+	t.Cleanup(func() { _ = engine.Close() })
+	runtimeRegistry.Register(fixture.store.Meta().SessionID, engine)
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	closed := atomic.Int32{}
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ownerRefs:           1,
+		ready:               make(chan struct{}),
+		close: func() {
+			closed.Add(1)
+		},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+	sub, err := runtimeRegistry.SubscribeSessionActivity(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("SubscribeSessionActivity: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+
+	resp, err := fixture.service.ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "rel-1",
+		SessionID:       fixture.store.Meta().SessionID,
+		LeaseID:         lease.LeaseID,
+		OnlyIfIdle:      true,
+		DropOwner:       true,
+	})
+	if err != nil {
+		t.Fatalf("ReleaseSessionRuntime OnlyIfIdle with subscriber: %v", err)
+	}
+	if resp.Released {
+		t.Fatalf("release response = %+v, want unreleased while subscriber is connected", resp)
+	}
+	if closed.Load() != 0 {
+		t.Fatalf("runtime close count = %d, want 0", closed.Load())
+	}
+	if handle.ownerRefs != 0 {
+		t.Fatalf("owner refs = %d, want dropped owner", handle.ownerRefs)
+	}
+	if _, err := fixture.service.validateRuntimeLease(context.Background(), fixture.store.Meta().SessionID, lease.LeaseID); err != nil {
+		t.Fatalf("subscriber runtime lease should remain valid: %v", err)
+	}
+}
+
 func TestReleaseSessionRuntimeOnlyIfIdleClosesIdleRuntime(t *testing.T) {
 	fixture := newSessionRuntimeFixture(t)
 	fixture.service.runtimes = registry.NewRuntimeRegistry()

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -77,7 +77,7 @@ func TestClaimActivationReusesDuplicateRequest(t *testing.T) {
 	}}
 	close(svc.handles["session-1"].ready)
 
-	handle, takeover, claim, err := svc.claimActivation("session-1", "req-1")
+	handle, takeover, claim, err := svc.claimActivation("session-1", "req-1", "")
 	if err != nil {
 		t.Fatalf("claimActivation: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestClaimActivationAllowsTakeoverAfterReady(t *testing.T) {
 	}}
 	close(svc.handles["session-1"].ready)
 
-	handle, takeover, claim, err := svc.claimActivation("session-1", "req-2")
+	handle, takeover, claim, err := svc.claimActivation("session-1", "req-2", "")
 	if err != nil {
 		t.Fatalf("claimActivation: %v", err)
 	}
@@ -127,14 +127,14 @@ func TestClaimActivationReusesPendingTakeoverRequest(t *testing.T) {
 	}}
 	close(svc.handles["session-1"].ready)
 
-	handle, takeover, claim, err := svc.claimActivation("session-1", "req-2")
+	handle, takeover, claim, err := svc.claimActivation("session-1", "req-2", "")
 	if err != nil {
 		t.Fatalf("claimActivation first takeover: %v", err)
 	}
 	if claim != activationClaimTakeover {
 		t.Fatalf("first claimActivation claim = %v, want takeover", claim)
 	}
-	reusedHandle, reusedTakeover, reusedClaim, err := svc.claimActivation("session-1", "req-2")
+	reusedHandle, reusedTakeover, reusedClaim, err := svc.claimActivation("session-1", "req-2", "")
 	if err != nil {
 		t.Fatalf("claimActivation pending retry: %v", err)
 	}
@@ -170,14 +170,14 @@ func TestPendingTakeoverRetryUnblocksWhenTakeoverFails(t *testing.T) {
 	}}
 	close(svc.handles["session-1"].ready)
 
-	handle, takeover, claim, err := svc.claimActivation("session-1", "req-2")
+	handle, takeover, claim, err := svc.claimActivation("session-1", "req-2", "")
 	if err != nil {
 		t.Fatalf("claimActivation first takeover: %v", err)
 	}
 	if claim != activationClaimTakeover {
 		t.Fatalf("first claimActivation claim = %v, want takeover", claim)
 	}
-	_, reusedTakeover, reusedClaim, err := svc.claimActivation("session-1", "req-2")
+	_, reusedTakeover, reusedClaim, err := svc.claimActivation("session-1", "req-2", "")
 	if err != nil {
 		t.Fatalf("claimActivation pending retry: %v", err)
 	}
@@ -213,14 +213,14 @@ func TestCloseReleasedRuntimeHandleSignalsPendingTakeoverWaiters(t *testing.T) {
 	}}
 	close(svc.handles["session-1"].ready)
 
-	handle, takeover, claim, err := svc.claimActivation("session-1", "req-2")
+	handle, takeover, claim, err := svc.claimActivation("session-1", "req-2", "")
 	if err != nil {
 		t.Fatalf("claimActivation first takeover: %v", err)
 	}
 	if claim != activationClaimTakeover {
 		t.Fatalf("first claimActivation claim = %v, want takeover", claim)
 	}
-	_, reusedTakeover, reusedClaim, err := svc.claimActivation("session-1", "req-2")
+	_, reusedTakeover, reusedClaim, err := svc.claimActivation("session-1", "req-2", "")
 	if err != nil {
 		t.Fatalf("claimActivation pending retry: %v", err)
 	}
@@ -261,14 +261,14 @@ func TestClaimActivationRejectsConcurrentDifferentTakeoverRequest(t *testing.T) 
 	}}
 	close(svc.handles["session-1"].ready)
 
-	_, _, claim, err := svc.claimActivation("session-1", "req-2")
+	_, _, claim, err := svc.claimActivation("session-1", "req-2", "")
 	if err != nil {
 		t.Fatalf("claimActivation first takeover: %v", err)
 	}
 	if claim != activationClaimTakeover {
 		t.Fatalf("first claimActivation claim = %v, want takeover", claim)
 	}
-	_, _, _, err = svc.claimActivation("session-1", "req-3")
+	_, _, _, err = svc.claimActivation("session-1", "req-3", "")
 	if !errors.Is(err, serverapi.ErrSessionAlreadyControlled) {
 		t.Fatalf("claimActivation competing takeover error = %v, want session already controlled", err)
 	}
@@ -371,6 +371,7 @@ func TestActivateSessionRuntimeReplayOwnerSurvivesOriginalDisconnect(t *testing.
 		controllerRequestID: "req-1",
 		controllerLeaseID:   lease.LeaseID,
 		ownerRefs:           1,
+		ownerIDs:            map[string]struct{}{"owner-1": {}},
 		ready:               make(chan struct{}),
 		close: func() {
 			closed.Add(1)
@@ -382,6 +383,7 @@ func TestActivateSessionRuntimeReplayOwnerSurvivesOriginalDisconnect(t *testing.
 	resp, err := fixture.service.ActivateSessionRuntime(context.Background(), serverapi.SessionRuntimeActivateRequest{
 		ClientRequestID: "req-1",
 		SessionID:       fixture.store.Meta().SessionID,
+		OwnerID:         "owner-2",
 	})
 	if err != nil {
 		t.Fatalf("ActivateSessionRuntime replay: %v", err)
@@ -395,6 +397,7 @@ func TestActivateSessionRuntimeReplayOwnerSurvivesOriginalDisconnect(t *testing.
 		LeaseID:         lease.LeaseID,
 		OnlyIfIdle:      true,
 		DropOwner:       true,
+		OwnerID:         "owner-1",
 	})
 	if err != nil {
 		t.Fatalf("ReleaseSessionRuntime original disconnect: %v", err)
@@ -407,6 +410,55 @@ func TestActivateSessionRuntimeReplayOwnerSurvivesOriginalDisconnect(t *testing.
 	}
 	if handle.ownerRefs != 1 {
 		t.Fatalf("owner refs after original disconnect = %d, want replay owner", handle.ownerRefs)
+	}
+}
+
+func TestActivateSessionRuntimeIdempotentReplayDoesNotDoubleCountSameOwner(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	closed := atomic.Int32{}
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ownerRefs:           1,
+		ownerIDs:            map[string]struct{}{"owner-1": {}},
+		ready:               make(chan struct{}),
+		close: func() {
+			closed.Add(1)
+		},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+
+	if _, err := fixture.service.ActivateSessionRuntime(context.Background(), serverapi.SessionRuntimeActivateRequest{
+		ClientRequestID: "req-1",
+		SessionID:       fixture.store.Meta().SessionID,
+		OwnerID:         "owner-1",
+	}); err != nil {
+		t.Fatalf("ActivateSessionRuntime replay: %v", err)
+	}
+	if handle.ownerRefs != 1 {
+		t.Fatalf("owner refs after same-owner replay = %d, want 1", handle.ownerRefs)
+	}
+	release, err := fixture.service.ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "rel-1",
+		SessionID:       fixture.store.Meta().SessionID,
+		LeaseID:         lease.LeaseID,
+		OnlyIfIdle:      true,
+		DropOwner:       true,
+		OwnerID:         "owner-1",
+	})
+	if err != nil {
+		t.Fatalf("ReleaseSessionRuntime: %v", err)
+	}
+	if !release.Released {
+		t.Fatalf("release response = %+v, want released after single owner disconnect", release)
+	}
+	if closed.Load() != 1 {
+		t.Fatalf("runtime close count = %d, want 1", closed.Load())
 	}
 }
 
@@ -484,7 +536,7 @@ func TestCompleteTakeoverDoesNotMutateHandleWhenPreviousLeaseReleaseFails(t *tes
 	default:
 		t.Fatal("takeover waiter was not signaled after failed takeover completion")
 	}
-	_, retryTakeover, claim, err := fixture.service.claimActivation(fixture.store.Meta().SessionID, "req-3")
+	_, retryTakeover, claim, err := fixture.service.claimActivation(fixture.store.Meta().SessionID, "req-3", "")
 	if err != nil {
 		t.Fatalf("claimActivation retry: %v", err)
 	}

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -148,7 +148,7 @@ func TestClaimActivationReusesPendingTakeoverRequest(t *testing.T) {
 		t.Fatal("expected pending retry to return same takeover state")
 	}
 	handle.controllerLeaseID = ""
-	if ok, err := svc.completeTakeover(context.Background(), "session-1", handle, takeover, "req-2", "lease-2"); err != nil || !ok {
+	if ok, err := svc.completeTakeover(context.Background(), "session-1", handle, takeover, "req-2", "lease-2", ""); err != nil || !ok {
 		t.Fatal("expected completeTakeover to succeed")
 	}
 	resp, err := activationResponseForTakeover(reusedTakeover)
@@ -500,6 +500,53 @@ func TestActivateSessionRuntimeReissuesControllerLeaseForTakeover(t *testing.T) 
 	}
 }
 
+func TestActivateSessionRuntimeTakeoverResetsOwnerIDs(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	oldLease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease old: %v", err)
+	}
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   oldLease.LeaseID,
+		ownerRefs:           1,
+		ownerIDs:            map[string]struct{}{"owner-old": {}},
+		ready:               make(chan struct{}),
+		close:               func() {},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+
+	resp, err := fixture.service.ActivateSessionRuntime(context.Background(), serverapi.SessionRuntimeActivateRequest{
+		ClientRequestID: "req-2",
+		SessionID:       fixture.store.Meta().SessionID,
+		OwnerID:         "owner-new",
+	})
+	if err != nil {
+		t.Fatalf("ActivateSessionRuntime takeover: %v", err)
+	}
+	if strings.TrimSpace(resp.LeaseID) == "" || resp.LeaseID == oldLease.LeaseID {
+		t.Fatalf("takeover response = %+v, want new lease", resp)
+	}
+	if handle.ownerRefs != 1 {
+		t.Fatalf("owner refs after takeover = %d, want 1", handle.ownerRefs)
+	}
+	if _, ok := handle.ownerIDs["owner-new"]; !ok || len(handle.ownerIDs) != 1 {
+		t.Fatalf("owner ids after takeover = %+v, want only new owner", handle.ownerIDs)
+	}
+
+	if _, err := fixture.service.ActivateSessionRuntime(context.Background(), serverapi.SessionRuntimeActivateRequest{
+		ClientRequestID: "req-2",
+		SessionID:       fixture.store.Meta().SessionID,
+		OwnerID:         "owner-new",
+	}); err != nil {
+		t.Fatalf("ActivateSessionRuntime takeover replay: %v", err)
+	}
+	if handle.ownerRefs != 1 {
+		t.Fatalf("owner refs after takeover replay = %d, want 1", handle.ownerRefs)
+	}
+}
+
 func TestCompleteTakeoverDoesNotMutateHandleWhenPreviousLeaseReleaseFails(t *testing.T) {
 	fixture := newSessionRuntimeFixture(t)
 	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
@@ -518,7 +565,7 @@ func TestCompleteTakeoverDoesNotMutateHandleWhenPreviousLeaseReleaseFails(t *tes
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	ok, err := fixture.service.completeTakeover(ctx, fixture.store.Meta().SessionID, handle, takeover, "req-2", "lease-new")
+	ok, err := fixture.service.completeTakeover(ctx, fixture.store.Meta().SessionID, handle, takeover, "req-2", "lease-new", "")
 	if err == nil || errors.Is(err, serverapi.ErrInvalidControllerLease) {
 		t.Fatalf("completeTakeover error = %v, want operational error without invalid controller lease marker", err)
 	}

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -746,7 +746,8 @@ func TestIdleRuntimeUnloadReleasesOrphanedRuntimeAfterPrimaryRunFinishes(t *test
 	runtimeRegistry := registry.NewRuntimeRegistry()
 	runtimeRegistry.SetInterestObserver(fixture.service.runtimeInterestChanged)
 	fixture.service.runtimes = runtimeRegistry
-	fixture.service.idleUnloadDelay = 10 * time.Millisecond
+	fixture.service.idleUnloadDelay = 100 * time.Millisecond
+	fixture.service.runFinishedUnloadDelay = 40 * time.Millisecond
 	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
 	if err != nil {
 		t.Fatalf("CreateRuntimeLease: %v", err)
@@ -767,18 +768,60 @@ func TestIdleRuntimeUnloadReleasesOrphanedRuntimeAfterPrimaryRunFinishes(t *test
 	if err != nil {
 		t.Fatalf("AcquirePrimaryRun: %v", err)
 	}
-	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID)
+	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID, registry.RuntimeInterestChanged)
 	select {
 	case <-closed:
 		t.Fatal("idle reaper closed runtime while primary run was active")
 	case <-time.After(30 * time.Millisecond):
 	}
 	active.Release()
-	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID)
+	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID, registry.RuntimeInterestRunFinished)
 	select {
 	case <-closed:
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for idle reaper to close orphaned runtime")
+	}
+}
+
+func TestIdleRuntimeUnloadUsesThreeMinuteDefaultAfterRunFinishes(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	if fixture.service.runFinishedIdleUnloadDelay() != 3*time.Minute {
+		t.Fatalf("run finished idle unload delay = %s, want 3m", fixture.service.runFinishedIdleUnloadDelay())
+	}
+}
+
+func TestIdleRuntimeUnloadUsesRunFinishedDebounceInsteadOfDisconnectDebounce(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	fixture.service.runtimes = registry.NewRuntimeRegistry()
+	fixture.service.idleUnloadDelay = 10 * time.Millisecond
+	fixture.service.runFinishedUnloadDelay = 40 * time.Millisecond
+	lease, err := fixture.metadata.CreateRuntimeLease(context.Background(), fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("CreateRuntimeLease: %v", err)
+	}
+	closed := make(chan struct{}, 1)
+	handle := &runtimeHandle{
+		controllerRequestID: "req-1",
+		controllerLeaseID:   lease.LeaseID,
+		ownerRefs:           0,
+		ready:               make(chan struct{}),
+		close: func() {
+			closed <- struct{}{}
+		},
+	}
+	close(handle.ready)
+	fixture.service.handles[fixture.store.Meta().SessionID] = handle
+
+	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID, registry.RuntimeInterestRunFinished)
+	select {
+	case <-closed:
+		t.Fatal("idle reaper used disconnect debounce after run finished")
+	case <-time.After(25 * time.Millisecond):
+	}
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for run-finished idle reaper")
 	}
 }
 
@@ -814,7 +857,7 @@ func TestIdleRuntimeUnloadWaitsForTransientSubscriberReconnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SubscribeSessionActivity: %v", err)
 	}
-	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID)
+	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID, registry.RuntimeInterestChanged)
 	select {
 	case <-closed:
 		t.Fatal("idle reaper closed runtime while subscriber was connected")
@@ -859,7 +902,7 @@ func TestIdleRuntimeUnloadWaitsForSubscriberReconnectBeforeDebounce(t *testing.T
 	close(handle.ready)
 	fixture.service.handles[fixture.store.Meta().SessionID] = handle
 
-	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID)
+	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID, registry.RuntimeInterestChanged)
 	time.Sleep(15 * time.Millisecond)
 	sub, err := runtimeRegistry.SubscribeSessionActivity(context.Background(), fixture.store.Meta().SessionID)
 	if err != nil {
@@ -901,7 +944,7 @@ func TestIdleRuntimeUnloadIgnoresStaleTimerAfterOwnerReconnect(t *testing.T) {
 	close(handle.ready)
 	fixture.service.handles[fixture.store.Meta().SessionID] = handle
 
-	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID)
+	fixture.service.runtimeInterestChanged(fixture.store.Meta().SessionID, registry.RuntimeInterestChanged)
 	fixture.service.mu.Lock()
 	handle.ownerRefs = 1
 	fixture.service.mu.Unlock()

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -242,6 +242,7 @@ func (g *Gateway) cleanupConnectionRuntimeLeases(state *connectionState) {
 			SessionID:       lease.SessionID,
 			LeaseID:         lease.LeaseID,
 			OnlyIfIdle:      true,
+			DropOwner:       true,
 		})
 		cancel()
 	}

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"time"
 
 	"builder/server/auth"
 	"builder/server/metadata"
@@ -17,6 +18,8 @@ import (
 	"builder/shared/rpccontract"
 	"builder/shared/rpcwire"
 	"builder/shared/serverapi"
+
+	"github.com/google/uuid"
 )
 
 type Gateway struct {
@@ -115,6 +118,12 @@ type connectionState struct {
 	attachedWorkspaceID   string
 	attachedWorkspaceRoot string
 	attachedSession       string
+	ownedRuntimeLeases    map[string]connectionOwnedRuntimeLease
+}
+
+type connectionOwnedRuntimeLease struct {
+	SessionID string
+	LeaseID   string
 }
 
 type gatewaySubscriptionHandler func(g *Gateway, conn rpcwire.Conn, ctx context.Context, state *connectionState, route rpccontract.Route, req protocol.Request)
@@ -192,6 +201,7 @@ func (g *Gateway) handleConn(ctx context.Context, conn rpcwire.Conn) {
 		cancel()
 	}()
 	state := &connectionState{}
+	defer g.cleanupConnectionRuntimeLeases(state)
 	for {
 		req, err := receiveRequest(connCtx, conn)
 		if err != nil {
@@ -211,6 +221,29 @@ func (g *Gateway) handleConn(ctx context.Context, conn rpcwire.Conn) {
 		if !sendResponse(connCtx, conn, resp) {
 			return
 		}
+	}
+}
+
+const gatewayRuntimeCleanupTimeout = 3 * time.Second
+
+func (g *Gateway) cleanupConnectionRuntimeLeases(state *connectionState) {
+	owned := state.takeOwnedRuntimeLeases()
+	if len(owned) == 0 || g == nil || isNilGatewayDependencies(g.deps) {
+		return
+	}
+	client := g.deps.SessionRuntimeClient()
+	if client == nil {
+		return
+	}
+	for _, lease := range owned {
+		ctx, cancel := context.WithTimeout(context.Background(), gatewayRuntimeCleanupTimeout)
+		_, _ = client.ReleaseSessionRuntime(ctx, serverapi.SessionRuntimeReleaseRequest{
+			ClientRequestID: uuid.NewString(),
+			SessionID:       lease.SessionID,
+			LeaseID:         lease.LeaseID,
+			OnlyIfIdle:      true,
+		})
+		cancel()
 	}
 }
 

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -118,12 +118,14 @@ type connectionState struct {
 	attachedWorkspaceID   string
 	attachedWorkspaceRoot string
 	attachedSession       string
+	runtimeOwnerID        string
 	ownedRuntimeLeases    map[string]connectionOwnedRuntimeLease
 }
 
 type connectionOwnedRuntimeLease struct {
 	SessionID string
 	LeaseID   string
+	OwnerID   string
 }
 
 type gatewaySubscriptionHandler func(g *Gateway, conn rpcwire.Conn, ctx context.Context, state *connectionState, route rpccontract.Route, req protocol.Request)
@@ -200,7 +202,7 @@ func (g *Gateway) handleConn(ctx context.Context, conn rpcwire.Conn) {
 		}
 		cancel()
 	}()
-	state := &connectionState{}
+	state := &connectionState{runtimeOwnerID: uuid.NewString()}
 	defer g.cleanupConnectionRuntimeLeases(state)
 	for {
 		req, err := receiveRequest(connCtx, conn)
@@ -243,6 +245,7 @@ func (g *Gateway) cleanupConnectionRuntimeLeases(state *connectionState) {
 			LeaseID:         lease.LeaseID,
 			OnlyIfIdle:      true,
 			DropOwner:       true,
+			OwnerID:         lease.OwnerID,
 		})
 		cancel()
 	}

--- a/server/transport/gateway_runtime_ownership.go
+++ b/server/transport/gateway_runtime_ownership.go
@@ -14,7 +14,7 @@ func (s *connectionState) recordOwnedRuntimeLease(sessionID string, leaseID stri
 	if s.ownedRuntimeLeases == nil {
 		s.ownedRuntimeLeases = make(map[string]connectionOwnedRuntimeLease)
 	}
-	s.ownedRuntimeLeases[trimmedSessionID] = connectionOwnedRuntimeLease{SessionID: trimmedSessionID, LeaseID: trimmedLeaseID}
+	s.ownedRuntimeLeases[trimmedSessionID] = connectionOwnedRuntimeLease{SessionID: trimmedSessionID, LeaseID: trimmedLeaseID, OwnerID: strings.TrimSpace(s.runtimeOwnerID)}
 }
 
 func (s *connectionState) removeOwnedRuntimeLease(sessionID string, leaseID string) {

--- a/server/transport/gateway_runtime_ownership.go
+++ b/server/transport/gateway_runtime_ownership.go
@@ -1,0 +1,46 @@
+package transport
+
+import "strings"
+
+func (s *connectionState) recordOwnedRuntimeLease(sessionID string, leaseID string) {
+	if s == nil {
+		return
+	}
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	trimmedLeaseID := strings.TrimSpace(leaseID)
+	if trimmedSessionID == "" || trimmedLeaseID == "" {
+		return
+	}
+	if s.ownedRuntimeLeases == nil {
+		s.ownedRuntimeLeases = make(map[string]connectionOwnedRuntimeLease)
+	}
+	s.ownedRuntimeLeases[trimmedSessionID] = connectionOwnedRuntimeLease{SessionID: trimmedSessionID, LeaseID: trimmedLeaseID}
+}
+
+func (s *connectionState) removeOwnedRuntimeLease(sessionID string, leaseID string) {
+	if s == nil || len(s.ownedRuntimeLeases) == 0 {
+		return
+	}
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	trimmedLeaseID := strings.TrimSpace(leaseID)
+	owned := s.ownedRuntimeLeases[trimmedSessionID]
+	if strings.TrimSpace(owned.LeaseID) != trimmedLeaseID {
+		return
+	}
+	delete(s.ownedRuntimeLeases, trimmedSessionID)
+}
+
+func (s *connectionState) takeOwnedRuntimeLeases() []connectionOwnedRuntimeLease {
+	if s == nil || len(s.ownedRuntimeLeases) == 0 {
+		return nil
+	}
+	owned := make([]connectionOwnedRuntimeLease, 0, len(s.ownedRuntimeLeases))
+	for sessionID, lease := range s.ownedRuntimeLeases {
+		if strings.TrimSpace(lease.SessionID) == "" {
+			lease.SessionID = sessionID
+		}
+		owned = append(owned, lease)
+	}
+	s.ownedRuntimeLeases = nil
+	return owned
+}

--- a/server/transport/gateway_runtime_ownership_test.go
+++ b/server/transport/gateway_runtime_ownership_test.go
@@ -1,0 +1,25 @@
+package transport
+
+import "testing"
+
+func TestConnectionStateRuntimeOwnershipRemovesOnlyMatchingExplicitRelease(t *testing.T) {
+	state := &connectionState{}
+	state.recordOwnedRuntimeLease("session-1", "lease-1")
+	state.removeOwnedRuntimeLease("session-1", "lease-other")
+	if owned := state.takeOwnedRuntimeLeases(); len(owned) != 1 || owned[0].SessionID != "session-1" || owned[0].LeaseID != "lease-1" {
+		t.Fatalf("mismatched release removed ownership: %+v", owned)
+	}
+
+	state.recordOwnedRuntimeLease("session-1", "lease-1")
+	state.removeOwnedRuntimeLease("session-1", "lease-1")
+	if owned := state.takeOwnedRuntimeLeases(); len(owned) != 0 {
+		t.Fatalf("matching explicit release left owned leases: %+v", owned)
+	}
+}
+
+func TestConnectionStateRuntimeOwnershipIgnoresCloseBeforeActivationResponse(t *testing.T) {
+	state := &connectionState{}
+	if owned := state.takeOwnedRuntimeLeases(); len(owned) != 0 {
+		t.Fatalf("empty connection state owned leases = %+v, want none", owned)
+	}
+}

--- a/server/transport/gateway_test.go
+++ b/server/transport/gateway_test.go
@@ -5,6 +5,7 @@ import (
 	serverbootstrap "builder/server/bootstrap"
 	"builder/server/core"
 	"builder/server/metadata"
+	"builder/server/runtime"
 	"builder/server/session"
 	shelltool "builder/server/tools/shell"
 	remoteclient "builder/shared/client"
@@ -23,6 +24,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func registerGatewayWorkspace(t *testing.T, workspace string) {
@@ -213,6 +215,275 @@ func releaseGatewayController(t *testing.T, appCore *core.Core, sessionID string
 	}); err != nil {
 		t.Fatalf("ReleaseSessionRuntime: %v", err)
 	}
+}
+
+func gatewayRuntimeActivateRequest(appCore *core.Core, sessionID string, requestID string) serverapi.SessionRuntimeActivateRequest {
+	settings := appCore.Config().Settings
+	if strings.TrimSpace(settings.Model) == "" {
+		settings.Model = "gpt-5"
+	}
+	if strings.TrimSpace(settings.ProviderOverride) == "" && strings.TrimSpace(settings.OpenAIBaseURL) == "" {
+		settings.ProviderOverride = "openai"
+	}
+	return serverapi.SessionRuntimeActivateRequest{
+		ClientRequestID: strings.TrimSpace(requestID),
+		SessionID:       strings.TrimSpace(sessionID),
+		ActiveSettings:  settings,
+		Source:          appCore.Config().Source,
+	}
+}
+
+func waitForGatewayCondition(t *testing.T, label string, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", label)
+}
+
+type countingSessionRuntimeClient struct {
+	remoteclient.SessionRuntimeClient
+	releaseCount atomic.Int32
+	activateErr  error
+}
+
+func (c *countingSessionRuntimeClient) ActivateSessionRuntime(ctx context.Context, req serverapi.SessionRuntimeActivateRequest) (serverapi.SessionRuntimeActivateResponse, error) {
+	if c.activateErr != nil {
+		return serverapi.SessionRuntimeActivateResponse{}, c.activateErr
+	}
+	return c.SessionRuntimeClient.ActivateSessionRuntime(ctx, req)
+}
+
+func (c *countingSessionRuntimeClient) ReleaseSessionRuntime(ctx context.Context, req serverapi.SessionRuntimeReleaseRequest) (serverapi.SessionRuntimeReleaseResponse, error) {
+	c.releaseCount.Add(1)
+	return c.SessionRuntimeClient.ReleaseSessionRuntime(ctx, req)
+}
+
+type gatewayRuntimeClientOverride struct {
+	*core.Core
+	runtimeClient remoteclient.SessionRuntimeClient
+}
+
+func (d *gatewayRuntimeClientOverride) SessionRuntimeClient() remoteclient.SessionRuntimeClient {
+	return d.runtimeClient
+}
+
+func newGatewayRuntimeClientOverrideServer(t *testing.T, runtimeClient remoteclient.SessionRuntimeClient) (*core.Core, *httptest.Server) {
+	t.Helper()
+	appCore, _ := newGatewayTestCore(t, true, true)
+	gateway, err := NewGateway(&gatewayRuntimeClientOverride{Core: appCore, runtimeClient: runtimeClient}, protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"})
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+	return appCore, httptest.NewServer(gateway.Handler())
+}
+
+func TestGatewayConnectionCloseReleasesOwnedIdleRuntime(t *testing.T) {
+	appCore, server := newGatewayTestServer(t)
+	defer func() { _ = appCore.Close() }()
+	defer server.Close()
+	store := createGatewayAuthoritativeSession(t, appCore)
+	appCore.RegisterSessionStore(store)
+
+	conn := dialGateway(t, server)
+	handshakeGateway(t, conn)
+	var activation serverapi.SessionRuntimeActivateResponse
+	callGateway(t, conn, "activate-runtime", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "activate-runtime"), &activation)
+	if strings.TrimSpace(activation.LeaseID) == "" {
+		t.Fatalf("activation response missing lease: %+v", activation)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close gateway connection: %v", err)
+	}
+
+	metadataStore, err := metadata.Open(appCore.Config().PersistenceRoot)
+	if err != nil {
+		t.Fatalf("metadata.Open: %v", err)
+	}
+	defer func() { _ = metadataStore.Close() }()
+	waitForGatewayCondition(t, "idle runtime lease release", func() bool {
+		_, err := metadataStore.ValidateRuntimeLease(context.Background(), store.Meta().SessionID, activation.LeaseID)
+		return err != nil
+	})
+}
+
+func TestGatewayConnectionCloseKeepsActiveOwnedRuntime(t *testing.T) {
+	appCore, server := newGatewayTestServer(t)
+	defer func() { _ = appCore.Close() }()
+	defer server.Close()
+	store := createGatewayAuthoritativeSession(t, appCore)
+	appCore.RegisterSessionStore(store)
+
+	conn := dialGateway(t, server)
+	handshakeGateway(t, conn)
+	var activation serverapi.SessionRuntimeActivateResponse
+	callGateway(t, conn, "activate-runtime", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "activate-runtime"), &activation)
+	if strings.TrimSpace(activation.LeaseID) == "" {
+		t.Fatalf("activation response missing lease: %+v", activation)
+	}
+	active, err := appCore.AcquirePrimaryRun(store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("AcquirePrimaryRun: %v", err)
+	}
+	defer active.Release()
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close gateway connection: %v", err)
+	}
+
+	metadataStore, err := metadata.Open(appCore.Config().PersistenceRoot)
+	if err != nil {
+		t.Fatalf("metadata.Open: %v", err)
+	}
+	defer func() { _ = metadataStore.Close() }()
+	time.Sleep(100 * time.Millisecond)
+	if _, err := metadataStore.ValidateRuntimeLease(context.Background(), store.Meta().SessionID, activation.LeaseID); err != nil {
+		t.Fatalf("active runtime lease should remain valid after owner disconnect: %v", err)
+	}
+}
+
+func TestGatewayExplicitReleaseRemovesOwnedRuntimeLeaseBeforeConnectionClose(t *testing.T) {
+	appCore, _ := newGatewayTestCore(t, true, true)
+	counter := &countingSessionRuntimeClient{SessionRuntimeClient: appCore.SessionRuntimeClient()}
+	gateway, err := NewGateway(&gatewayRuntimeClientOverride{Core: appCore, runtimeClient: counter}, protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"})
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+	server := httptest.NewServer(gateway.Handler())
+	defer func() { _ = appCore.Close() }()
+	defer server.Close()
+	store := createGatewayAuthoritativeSession(t, appCore)
+	appCore.RegisterSessionStore(store)
+
+	conn := dialGateway(t, server)
+	handshakeGateway(t, conn)
+	var activation serverapi.SessionRuntimeActivateResponse
+	callGateway(t, conn, "activate-runtime", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "activate-runtime"), &activation)
+	if strings.TrimSpace(activation.LeaseID) == "" {
+		t.Fatalf("activation response missing lease: %+v", activation)
+	}
+	var release serverapi.SessionRuntimeReleaseResponse
+	callGateway(t, conn, "release-runtime", protocol.MethodSessionRuntimeRelease, serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "release-runtime",
+		SessionID:       store.Meta().SessionID,
+		LeaseID:         activation.LeaseID,
+	}, &release)
+	if !release.Released {
+		t.Fatalf("release response = %+v, want released", release)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close gateway connection: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := counter.releaseCount.Load(); got != 1 {
+		t.Fatalf("runtime release call count = %d, want only explicit release", got)
+	}
+}
+
+func TestGatewayFailedActivationDoesNotRecordOwnedRuntimeLease(t *testing.T) {
+	appCore, _ := newGatewayTestCore(t, true, true)
+	counter := &countingSessionRuntimeClient{SessionRuntimeClient: appCore.SessionRuntimeClient(), activateErr: errors.New("activation failed before lease")}
+	gateway, err := NewGateway(&gatewayRuntimeClientOverride{Core: appCore, runtimeClient: counter}, protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"})
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+	server := httptest.NewServer(gateway.Handler())
+	defer func() { _ = appCore.Close() }()
+	defer server.Close()
+	store := createGatewayAuthoritativeSession(t, appCore)
+	appCore.RegisterSessionStore(store)
+
+	conn := dialGateway(t, server)
+	handshakeGateway(t, conn)
+	_ = callGatewayExpectError(t, conn, "activate-runtime", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "activate-runtime"))
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close gateway connection: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := counter.releaseCount.Load(); got != 0 {
+		t.Fatalf("runtime release call count after failed activation = %d, want 0", got)
+	}
+}
+
+func TestGatewayReadOnlyRuntimeActivationDoesNotRecordOwnedLease(t *testing.T) {
+	appCore, server := newGatewayTestServer(t)
+	defer func() { _ = appCore.Close() }()
+	defer server.Close()
+	store := createGatewayAuthoritativeSession(t, appCore)
+	appCore.RegisterSessionStore(store)
+	engine := &runtime.Engine{}
+	appCore.RegisterRuntime(store.Meta().SessionID, engine)
+	defer appCore.UnregisterRuntime(store.Meta().SessionID, engine)
+
+	conn := dialGateway(t, server)
+	handshakeGateway(t, conn)
+	var activation serverapi.SessionRuntimeActivateResponse
+	callGateway(t, conn, "activate-runtime", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "activate-runtime"), &activation)
+	if !activation.ReadOnly || strings.TrimSpace(activation.LeaseID) != "" {
+		t.Fatalf("activation response = %+v, want read-only without lease", activation)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close gateway connection: %v", err)
+	}
+
+	conn = dialGateway(t, server)
+	defer func() { _ = conn.Close() }()
+	handshakeGateway(t, conn)
+	callGateway(t, conn, "activate-runtime-again", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "activate-runtime-again"), &activation)
+	if !activation.ReadOnly || strings.TrimSpace(activation.LeaseID) != "" {
+		t.Fatalf("activation after read-only disconnect = %+v, want read-only without lease", activation)
+	}
+}
+
+func TestGatewayTakeoverConnectionCloseDoesNotReleaseNewOwnerLease(t *testing.T) {
+	appCore, server := newGatewayTestServer(t)
+	defer func() { _ = appCore.Close() }()
+	defer server.Close()
+	store := createGatewayAuthoritativeSession(t, appCore)
+	appCore.RegisterSessionStore(store)
+
+	first := dialGateway(t, server)
+	handshakeGateway(t, first)
+	var firstActivation serverapi.SessionRuntimeActivateResponse
+	callGateway(t, first, "activate-runtime-1", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "activate-runtime-1"), &firstActivation)
+	if strings.TrimSpace(firstActivation.LeaseID) == "" {
+		t.Fatalf("first activation response missing lease: %+v", firstActivation)
+	}
+
+	second := dialGateway(t, server)
+	defer func() { _ = second.Close() }()
+	handshakeGateway(t, second)
+	var secondActivation serverapi.SessionRuntimeActivateResponse
+	callGateway(t, second, "activate-runtime-2", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "activate-runtime-2"), &secondActivation)
+	if strings.TrimSpace(secondActivation.LeaseID) == "" || secondActivation.LeaseID == firstActivation.LeaseID {
+		t.Fatalf("second activation response = %+v, want distinct takeover lease", secondActivation)
+	}
+
+	metadataStore, err := metadata.Open(appCore.Config().PersistenceRoot)
+	if err != nil {
+		t.Fatalf("metadata.Open: %v", err)
+	}
+	defer func() { _ = metadataStore.Close() }()
+	if _, err := metadataStore.ValidateRuntimeLease(context.Background(), store.Meta().SessionID, firstActivation.LeaseID); err == nil {
+		t.Fatal("first owner lease should be invalid after takeover")
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first gateway connection: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if _, err := metadataStore.ValidateRuntimeLease(context.Background(), store.Meta().SessionID, secondActivation.LeaseID); err != nil {
+		t.Fatalf("second owner lease should remain valid after first connection closes: %v", err)
+	}
+	if err := second.Close(); err != nil {
+		t.Fatalf("close second gateway connection: %v", err)
+	}
+	waitForGatewayCondition(t, "second owner lease release", func() bool {
+		_, err := metadataStore.ValidateRuntimeLease(context.Background(), store.Meta().SessionID, secondActivation.LeaseID)
+		return err != nil
+	})
 }
 
 func TestGatewayHandshakeAndProjectList(t *testing.T) {

--- a/server/transport/gateway_test.go
+++ b/server/transport/gateway_test.go
@@ -383,6 +383,57 @@ func TestGatewayExplicitReleaseRemovesOwnedRuntimeLeaseBeforeConnectionClose(t *
 	}
 }
 
+func TestGatewayActiveOnlyIfIdleReleaseKeepsOwnedRuntimeLeaseForCloseCleanup(t *testing.T) {
+	appCore, _ := newGatewayTestCore(t, true, true)
+	counter := &countingSessionRuntimeClient{SessionRuntimeClient: appCore.SessionRuntimeClient()}
+	gateway, err := NewGateway(&gatewayRuntimeClientOverride{Core: appCore, runtimeClient: counter}, protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"})
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+	server := httptest.NewServer(gateway.Handler())
+	defer func() { _ = appCore.Close() }()
+	defer server.Close()
+	store := createGatewayAuthoritativeSession(t, appCore)
+	appCore.RegisterSessionStore(store)
+
+	conn := dialGateway(t, server)
+	handshakeGateway(t, conn)
+	var activation serverapi.SessionRuntimeActivateResponse
+	callGateway(t, conn, "activate-runtime", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "activate-runtime"), &activation)
+	if strings.TrimSpace(activation.LeaseID) == "" {
+		t.Fatalf("activation response missing lease: %+v", activation)
+	}
+	active, err := appCore.AcquirePrimaryRun(store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("AcquirePrimaryRun: %v", err)
+	}
+	defer active.Release()
+	var release serverapi.SessionRuntimeReleaseResponse
+	callGateway(t, conn, "release-runtime", protocol.MethodSessionRuntimeRelease, serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "release-runtime",
+		SessionID:       store.Meta().SessionID,
+		LeaseID:         activation.LeaseID,
+		OnlyIfIdle:      true,
+	}, &release)
+	if !release.Active || release.Released {
+		t.Fatalf("release response = %+v, want active and unreleased", release)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close gateway connection: %v", err)
+	}
+	waitForGatewayCondition(t, "close cleanup release retry", func() bool {
+		return counter.releaseCount.Load() >= 2
+	})
+	metadataStore, err := metadata.Open(appCore.Config().PersistenceRoot)
+	if err != nil {
+		t.Fatalf("metadata.Open: %v", err)
+	}
+	defer func() { _ = metadataStore.Close() }()
+	if _, err := metadataStore.ValidateRuntimeLease(context.Background(), store.Meta().SessionID, activation.LeaseID); err != nil {
+		t.Fatalf("active runtime lease should remain valid after close cleanup retry: %v", err)
+	}
+}
+
 func TestGatewayFailedActivationDoesNotRecordOwnedRuntimeLease(t *testing.T) {
 	appCore, _ := newGatewayTestCore(t, true, true)
 	counter := &countingSessionRuntimeClient{SessionRuntimeClient: appCore.SessionRuntimeClient(), activateErr: errors.New("activation failed before lease")}

--- a/server/transport/gateway_unary_handlers.go
+++ b/server/transport/gateway_unary_handlers.go
@@ -216,17 +216,33 @@ var gatewayUnaryHandlerEntries = map[string]gatewayUnaryHandler{
 			return suffixClient.GetSessionCommittedTranscriptSuffix(ctx, params)
 		})
 	},
-	protocol.MethodSessionGetInitialInput:                gatewayClientCall[client.SessionLifecycleClient, serverapi.SessionInitialInputRequest, serverapi.SessionInitialInputResponse](gatewaySessionLifecycleClient, client.SessionLifecycleClient.GetInitialInput),
-	protocol.MethodSessionPersistInputDraft:              gatewayClientCall[client.SessionLifecycleClient, serverapi.SessionPersistInputDraftRequest, serverapi.SessionPersistInputDraftResponse](gatewaySessionLifecycleClient, client.SessionLifecycleClient.PersistInputDraft),
-	protocol.MethodSessionRetargetWorkspace:              gatewayClientCall[client.SessionLifecycleClient, serverapi.SessionRetargetWorkspaceRequest, serverapi.SessionRetargetWorkspaceResponse](gatewaySessionLifecycleClient, client.SessionLifecycleClient.RetargetSessionWorkspace),
-	protocol.MethodSessionResolveTransition:              gatewayClientCall[client.SessionLifecycleClient, serverapi.SessionResolveTransitionRequest, serverapi.SessionResolveTransitionResponse](gatewaySessionLifecycleClient, client.SessionLifecycleClient.ResolveTransition),
-	protocol.MethodWorktreeList:                          gatewayClientCall[client.WorktreeClient, serverapi.WorktreeListRequest, serverapi.WorktreeListResponse](gatewayWorktreeClient, client.WorktreeClient.ListWorktrees),
-	protocol.MethodWorktreeCreateTargetResolve:           gatewayClientCall[client.WorktreeClient, serverapi.WorktreeCreateTargetResolveRequest, serverapi.WorktreeCreateTargetResolveResponse](gatewayWorktreeClient, client.WorktreeClient.ResolveWorktreeCreateTarget),
-	protocol.MethodWorktreeCreate:                        gatewayClientCall[client.WorktreeClient, serverapi.WorktreeCreateRequest, serverapi.WorktreeCreateResponse](gatewayWorktreeClient, client.WorktreeClient.CreateWorktree),
-	protocol.MethodWorktreeSwitch:                        gatewayClientCall[client.WorktreeClient, serverapi.WorktreeSwitchRequest, serverapi.WorktreeSwitchResponse](gatewayWorktreeClient, client.WorktreeClient.SwitchWorktree),
-	protocol.MethodWorktreeDelete:                        gatewayClientCall[client.WorktreeClient, serverapi.WorktreeDeleteRequest, serverapi.WorktreeDeleteResponse](gatewayWorktreeClient, client.WorktreeClient.DeleteWorktree),
-	protocol.MethodSessionRuntimeActivate:                gatewayClientCall[client.SessionRuntimeClient, serverapi.SessionRuntimeActivateRequest, serverapi.SessionRuntimeActivateResponse](gatewaySessionRuntimeClient, client.SessionRuntimeClient.ActivateSessionRuntime),
-	protocol.MethodSessionRuntimeRelease:                 gatewayClientCall[client.SessionRuntimeClient, serverapi.SessionRuntimeReleaseRequest, serverapi.SessionRuntimeReleaseResponse](gatewaySessionRuntimeClient, client.SessionRuntimeClient.ReleaseSessionRuntime),
+	protocol.MethodSessionGetInitialInput:      gatewayClientCall[client.SessionLifecycleClient, serverapi.SessionInitialInputRequest, serverapi.SessionInitialInputResponse](gatewaySessionLifecycleClient, client.SessionLifecycleClient.GetInitialInput),
+	protocol.MethodSessionPersistInputDraft:    gatewayClientCall[client.SessionLifecycleClient, serverapi.SessionPersistInputDraftRequest, serverapi.SessionPersistInputDraftResponse](gatewaySessionLifecycleClient, client.SessionLifecycleClient.PersistInputDraft),
+	protocol.MethodSessionRetargetWorkspace:    gatewayClientCall[client.SessionLifecycleClient, serverapi.SessionRetargetWorkspaceRequest, serverapi.SessionRetargetWorkspaceResponse](gatewaySessionLifecycleClient, client.SessionLifecycleClient.RetargetSessionWorkspace),
+	protocol.MethodSessionResolveTransition:    gatewayClientCall[client.SessionLifecycleClient, serverapi.SessionResolveTransitionRequest, serverapi.SessionResolveTransitionResponse](gatewaySessionLifecycleClient, client.SessionLifecycleClient.ResolveTransition),
+	protocol.MethodWorktreeList:                gatewayClientCall[client.WorktreeClient, serverapi.WorktreeListRequest, serverapi.WorktreeListResponse](gatewayWorktreeClient, client.WorktreeClient.ListWorktrees),
+	protocol.MethodWorktreeCreateTargetResolve: gatewayClientCall[client.WorktreeClient, serverapi.WorktreeCreateTargetResolveRequest, serverapi.WorktreeCreateTargetResolveResponse](gatewayWorktreeClient, client.WorktreeClient.ResolveWorktreeCreateTarget),
+	protocol.MethodWorktreeCreate:              gatewayClientCall[client.WorktreeClient, serverapi.WorktreeCreateRequest, serverapi.WorktreeCreateResponse](gatewayWorktreeClient, client.WorktreeClient.CreateWorktree),
+	protocol.MethodWorktreeSwitch:              gatewayClientCall[client.WorktreeClient, serverapi.WorktreeSwitchRequest, serverapi.WorktreeSwitchResponse](gatewayWorktreeClient, client.WorktreeClient.SwitchWorktree),
+	protocol.MethodWorktreeDelete:              gatewayClientCall[client.WorktreeClient, serverapi.WorktreeDeleteRequest, serverapi.WorktreeDeleteResponse](gatewayWorktreeClient, client.WorktreeClient.DeleteWorktree),
+	protocol.MethodSessionRuntimeActivate: func(g *Gateway, ctx context.Context, state *connectionState, req protocol.Request) protocol.Response {
+		return decodeAndHandle(req, func(params serverapi.SessionRuntimeActivateRequest) (serverapi.SessionRuntimeActivateResponse, error) {
+			resp, err := g.deps.SessionRuntimeClient().ActivateSessionRuntime(ctx, params)
+			if err == nil && !resp.ReadOnly {
+				state.recordOwnedRuntimeLease(params.SessionID, resp.LeaseID)
+			}
+			return resp, err
+		})
+	},
+	protocol.MethodSessionRuntimeRelease: func(g *Gateway, ctx context.Context, state *connectionState, req protocol.Request) protocol.Response {
+		return decodeAndHandle(req, func(params serverapi.SessionRuntimeReleaseRequest) (serverapi.SessionRuntimeReleaseResponse, error) {
+			resp, err := g.deps.SessionRuntimeClient().ReleaseSessionRuntime(ctx, params)
+			if err == nil {
+				state.removeOwnedRuntimeLease(params.SessionID, params.LeaseID)
+			}
+			return resp, err
+		})
+	},
 	protocol.MethodRunGet:                                gatewayClientCall[client.SessionViewClient, serverapi.RunGetRequest, serverapi.RunGetResponse](gatewaySessionViewClient, client.SessionViewClient.GetRun),
 	protocol.MethodRuntimeSetSessionName:                 gatewayClientCallNoResponse[client.RuntimeControlClient, serverapi.RuntimeSetSessionNameRequest](gatewayRuntimeControlClient, client.RuntimeControlClient.SetSessionName),
 	protocol.MethodRuntimeSetThinkingLevel:               gatewayClientCallNoResponse[client.RuntimeControlClient, serverapi.RuntimeSetThinkingLevelRequest](gatewayRuntimeControlClient, client.RuntimeControlClient.SetThinkingLevel),

--- a/server/transport/gateway_unary_handlers.go
+++ b/server/transport/gateway_unary_handlers.go
@@ -227,6 +227,7 @@ var gatewayUnaryHandlerEntries = map[string]gatewayUnaryHandler{
 	protocol.MethodWorktreeDelete:              gatewayClientCall[client.WorktreeClient, serverapi.WorktreeDeleteRequest, serverapi.WorktreeDeleteResponse](gatewayWorktreeClient, client.WorktreeClient.DeleteWorktree),
 	protocol.MethodSessionRuntimeActivate: func(g *Gateway, ctx context.Context, state *connectionState, req protocol.Request) protocol.Response {
 		return decodeAndHandle(req, func(params serverapi.SessionRuntimeActivateRequest) (serverapi.SessionRuntimeActivateResponse, error) {
+			params.OwnerID = state.runtimeOwnerID
 			resp, err := g.deps.SessionRuntimeClient().ActivateSessionRuntime(ctx, params)
 			if err == nil && !resp.ReadOnly {
 				state.recordOwnedRuntimeLease(params.SessionID, resp.LeaseID)
@@ -236,6 +237,7 @@ var gatewayUnaryHandlerEntries = map[string]gatewayUnaryHandler{
 	},
 	protocol.MethodSessionRuntimeRelease: func(g *Gateway, ctx context.Context, state *connectionState, req protocol.Request) protocol.Response {
 		return decodeAndHandle(req, func(params serverapi.SessionRuntimeReleaseRequest) (serverapi.SessionRuntimeReleaseResponse, error) {
+			params.OwnerID = state.runtimeOwnerID
 			resp, err := g.deps.SessionRuntimeClient().ReleaseSessionRuntime(ctx, params)
 			if err == nil && resp.Released {
 				state.removeOwnedRuntimeLease(params.SessionID, params.LeaseID)

--- a/server/transport/gateway_unary_handlers.go
+++ b/server/transport/gateway_unary_handlers.go
@@ -237,7 +237,7 @@ var gatewayUnaryHandlerEntries = map[string]gatewayUnaryHandler{
 	protocol.MethodSessionRuntimeRelease: func(g *Gateway, ctx context.Context, state *connectionState, req protocol.Request) protocol.Response {
 		return decodeAndHandle(req, func(params serverapi.SessionRuntimeReleaseRequest) (serverapi.SessionRuntimeReleaseResponse, error) {
 			resp, err := g.deps.SessionRuntimeClient().ReleaseSessionRuntime(ctx, params)
-			if err == nil {
+			if err == nil && resp.Released {
 				state.removeOwnedRuntimeLease(params.SessionID, params.LeaseID)
 			}
 			return resp, err

--- a/shared/serverapi/session_runtime.go
+++ b/shared/serverapi/session_runtime.go
@@ -25,6 +25,7 @@ type SessionRuntimeReleaseRequest struct {
 	SessionID       string `json:"session_id"`
 	LeaseID         string `json:"lease_id"`
 	OnlyIfIdle      bool   `json:"only_if_idle,omitempty"`
+	DropOwner       bool   `json:"drop_owner,omitempty"`
 }
 
 type SessionRuntimeReleaseResponse struct {

--- a/shared/serverapi/session_runtime.go
+++ b/shared/serverapi/session_runtime.go
@@ -10,6 +10,7 @@ import (
 type SessionRuntimeActivateRequest struct {
 	ClientRequestID string              `json:"client_request_id"`
 	SessionID       string              `json:"session_id"`
+	OwnerID         string              `json:"owner_id,omitempty"`
 	ActiveSettings  config.Settings     `json:"active_settings"`
 	EnabledToolIDs  []string            `json:"enabled_tool_ids"`
 	Source          config.SourceReport `json:"source"`
@@ -26,6 +27,7 @@ type SessionRuntimeReleaseRequest struct {
 	LeaseID         string `json:"lease_id"`
 	OnlyIfIdle      bool   `json:"only_if_idle,omitempty"`
 	DropOwner       bool   `json:"drop_owner,omitempty"`
+	OwnerID         string `json:"owner_id,omitempty"`
 }
 
 type SessionRuntimeReleaseResponse struct {

--- a/shared/serverapi/session_runtime.go
+++ b/shared/serverapi/session_runtime.go
@@ -24,9 +24,13 @@ type SessionRuntimeReleaseRequest struct {
 	ClientRequestID string `json:"client_request_id"`
 	SessionID       string `json:"session_id"`
 	LeaseID         string `json:"lease_id"`
+	OnlyIfIdle      bool   `json:"only_if_idle,omitempty"`
 }
 
-type SessionRuntimeReleaseResponse struct{}
+type SessionRuntimeReleaseResponse struct {
+	Released bool `json:"released"`
+	Active   bool `json:"active,omitempty"`
+}
 
 func (r SessionRuntimeActivateRequest) Validate() error {
 	if strings.TrimSpace(r.ClientRequestID) == "" {


### PR DESCRIPTION
## Summary
- make TUI render/status runtime reads cache-only to avoid server-backed render stalls
- restore runtime lease release invalidation and idle-safe release semantics
- track websocket-owned runtimes, preserve active work on disconnect, and debounce idle orphan unloads
- detach active runtime run contexts from request/websocket cancellation while preserving explicit interrupt cancellation

## Verification
- ./scripts/test.sh ./server/transport -run 'TestGatewayExplicitReleaseRemovesOwnedRuntimeLeaseBeforeConnectionClose|TestGatewayFailedActivationDoesNotRecordOwnedRuntimeLease|TestGatewayConnectionCloseKeepsActiveOwnedRuntime|TestGatewayTakeoverConnectionCloseDoesNotReleaseNewOwnerLease' -count=1
- ./scripts/test.sh ./cli/app ./cli/app/internal/runtimeattach ./server/metadata ./server/sessionruntime ./server/runtimecontrol ./server/runtime ./server/transport ./server/registry ./server/sessionview -count=1
- ./scripts/build.sh --output ./bin/builder
- git push pre-push hook: frontend dependency policy, formatting, go vet, go build, test

## Deferred
- Observability counters from Workstream F are intentionally deferred; there was no low-risk existing status/debug surface to extend in this lifecycle fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session runtimes can be conditionally released only when idle and ownership dropped
  * Automatic cleanup of runtime leases when connections close

* **Improvements**
  * Idle runtime resources are automatically unloaded with smarter debounce/timers
  * Runtime work is isolated from caller cancellation to improve reliability
  * Runtime context usage is read from a cached source for more stable UI reporting

* **Tests**
  * Expanded tests for lease lifecycle, idle-unload, gateway cleanup, and UI rendering behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->