### PR TITLE
fix workflow workspace binding for worktrees

### DIFF
--- a/apps/desktop/src/features/workflow-editor/WorkflowEditorRoute.test.tsx
+++ b/apps/desktop/src/features/workflow-editor/WorkflowEditorRoute.test.tsx
@@ -1400,7 +1400,7 @@ describe("WorkflowEditorRoute", () => {
       expect(copied).toEqual(["edge-2"]);
     });
 
-    fireEvent.change(within(inspector).getByRole("textbox", { name: "Transition group" }), {
+    fireEvent.change(within(inspector).getByRole("textbox", { name: "Transition text" }), {
       target: { value: "Review" },
     });
     fireEvent.change(within(inspector).getByRole("textbox", { name: "Transition ID" }), {
@@ -1426,7 +1426,7 @@ describe("WorkflowEditorRoute", () => {
     if (routeSection === undefined) {
       throw new Error("Expected a merged edge route section.");
     }
-    expect(within(routeSection).getByRole("textbox", { name: "Transition group" })).toBeInTheDocument();
+    expect(within(routeSection).getByRole("textbox", { name: "Transition text" })).toBeInTheDocument();
     expect(within(routeSection).getByRole("textbox", { name: "Transition ID" })).toBeInTheDocument();
     expect(within(routeSection).getByRole("textbox", { name: "Key" })).toBeInTheDocument();
     expect(

--- a/apps/desktop/src/features/workflow-editor/WorkflowInspectorSidebar.tsx
+++ b/apps/desktop/src/features/workflow-editor/WorkflowInspectorSidebar.tsx
@@ -247,7 +247,7 @@ function EdgeDraftDetails({
         title={t("workflowEditor.route")}
       >
         <TextInput
-          label={t("workflowEditor.transitionGroup")}
+          label={t("workflowEditor.transitionText")}
           onChange={(event) => {
             controller.dispatch({
               input: { edgeID: edge.id, transitionName: event.target.value },

--- a/apps/desktop/src/i18n/workflowEditorEn.ts
+++ b/apps/desktop/src/i18n/workflowEditorEn.ts
@@ -75,6 +75,7 @@ export const workflowEditorEnglish = {
   members: "Members",
   sortOrder: "Sort order",
   transitionID: "Transition ID",
+  transitionText: "Transition text",
   transitionGroup: "Transition group",
   route: "Route",
   sourceNode: "Source node",

--- a/cli/builder/workflow_command_test.go
+++ b/cli/builder/workflow_command_test.go
@@ -23,9 +23,10 @@ import (
 
 type workflowCommandLoopbackRemote struct {
 	client.WorkflowClient
-	cfg     config.App
-	binding metadata.Binding
-	store   *workflowstore.Store
+	cfg                   config.App
+	binding               metadata.Binding
+	projectBindingsByRoot map[string]serverapi.ProjectBinding
+	store                 *workflowstore.Store
 }
 
 func (r *workflowCommandLoopbackRemote) Close() error { return nil }
@@ -43,6 +44,9 @@ func (r *failingWorkflowEdgeUpdateRemote) UpdateWorkflowEdge(ctx context.Context
 }
 
 func (r *workflowCommandLoopbackRemote) ResolveProjectPath(ctx context.Context, req serverapi.ProjectResolvePathRequest) (serverapi.ProjectResolvePathResponse, error) {
+	if binding, ok := r.projectBindingsByRoot[req.Path]; ok {
+		return serverapi.ProjectResolvePathResponse{CanonicalRoot: req.Path, Binding: &binding}, nil
+	}
 	if req.Path != r.cfg.WorkspaceRoot {
 		return serverapi.ProjectResolvePathResponse{}, nil
 	}
@@ -544,6 +548,43 @@ func TestTaskShowFindsSameProjectTaskOutsideSelectedWorkflow(t *testing.T) {
 	}
 	if strings.Contains(showOut, "[Note:") {
 		t.Fatalf("task show output = %q, did not expect cross-project note", showOut)
+	}
+}
+
+func TestTaskShowUsesRegisteredTaskWorktreeRootAsCurrentProject(t *testing.T) {
+	cfg, binding, remote := newWorkflowCommandLoopback(t)
+	worktreeRoot := t.TempDir()
+	worktreeCfg := cfg
+	worktreeCfg.WorkspaceRoot = worktreeRoot
+	remote.projectBindingsByRoot = map[string]serverapi.ProjectBinding{
+		worktreeRoot: {
+			ProjectID:     binding.ProjectID,
+			ProjectKey:    binding.ProjectKey,
+			ProjectName:   binding.ProjectName,
+			WorkspaceID:   binding.WorkspaceID,
+			CanonicalRoot: worktreeRoot,
+		},
+	}
+	restore := replaceWorkflowCommandRemoteOpener(t, worktreeCfg, remote)
+	defer restore()
+
+	workflowID := createRunnableWorkflowForCommandTest(t, "Task Worktree Workflow")
+	if _, linkErr, code := runWorkflowRootCommand("workflow", "link", binding.ProjectID, workflowID, "--default"); code != 0 {
+		t.Fatalf("workflow link exit=%d stderr=%q", code, linkErr)
+	}
+	taskOut, taskErr, code := runWorkflowRootCommand("task", "create", "--title", "Worktree Task", "--body", "Body", "--workflow", workflowID, "--project", binding.ProjectID)
+	if code != 0 {
+		t.Fatalf("task create exit=%d stderr=%q", code, taskErr)
+	}
+	taskID := labeledOutputValue(t, taskOut, "task_id")
+	shortID := labeledOutputValue(t, taskOut, "short_id")
+
+	showOut, showErr, code := runWorkflowRootCommand("task", "show", shortID)
+	if code != 0 {
+		t.Fatalf("task show from worktree root exit=%d stderr=%q", code, showErr)
+	}
+	if !strings.Contains(showOut, "task_id\t"+taskID) {
+		t.Fatalf("task show output = %q, want task id %s", showOut, taskID)
 	}
 }
 

--- a/docs/dev/specs/terminology.md
+++ b/docs/dev/specs/terminology.md
@@ -80,9 +80,17 @@ A derived runtime mapping from a target required input to the same-named transit
 
 A stable identifier for a transition group leaving a node. Agent nodes choose a transition ID when more than one transition group is available.
 
+### Transition Text
+
+The human-facing label for a transition group. In the workflow editor edge inspector, the `Transition text` field edits the transition group display name. Transition text is distinct from `transition_id`, which agents emit as the selected transition value.
+
 ### Transition Group
 
 One or more outgoing edges selected together by a transition ID. One edge is a normal transition. Multiple edges fan out into parallel target nodes.
+
+### Edge Key
+
+A stable identifier for one edge inside a transition group. Edge keys distinguish fan-out branch edges and join-provider references; they are not the agent-selected transition ID.
 
 ### Context-Preservation Mode
 

--- a/prompts/workflow/workflow_task_instructions.md
+++ b/prompts/workflow/workflow_task_instructions.md
@@ -1,4 +1,4 @@
-Heads up: You're working on ticket `{{.TaskShortId}}` titled "{{.TaskTitle}}" as part of workflow `{{.WorkflowShortId}}`. Workflows are teams of agents working together autonomously without direct user supervision. You are one of the agents doing their part of the ticket.
+Heads up: You're working on ticket `{{.TaskShortId}}` titled "{{.TaskTitle}}" as part of workflow `{{.WorkflowShortId}}`. Workflows are teams of agents working together autonomously without direct user supervision. You are one of the agents doing your part of the workflow to close the ticket.
 
 ## Workflow mode guidelines:
 - You **can** still use `ask_question` in this mode and the user will still answer, however they aren't directly monitoring your work, so avoid giving updates, commentary, or issuing preambles.

--- a/server/metadata/queries.sql
+++ b/server/metadata/queries.sql
@@ -511,9 +511,25 @@ FROM (
 -- name: CountTaskEdgeReferences :one
 SELECT CAST(COUNT(*) AS INTEGER) AS ref_count
 FROM (
-    SELECT te.id FROM task_transition_edges te WHERE te.workflow_edge_id = sqlc.arg(edge_id)
+    -- Only live unresolved references block edge deletion. Completed historical
+    -- transition edges intentionally rely on ON DELETE SET NULL.
+    SELECT te.id
+    FROM task_transition_edges te
+    JOIN task_transition_records tt ON tt.id = te.task_transition_id
+    JOIN task_records t ON t.id = tt.task_id
+    WHERE te.workflow_edge_id = sqlc.arg(edge_id)
+      AND t.canceled_at_unix_ms = 0
+      AND tt.state = 'pending_approval'
+      AND te.state = 'pending'
     UNION ALL
-    SELECT p.id FROM task_node_placements p WHERE p.parallel_branch_edge_id = sqlc.arg(edge_id)
+    SELECT p.id
+    FROM task_node_placements p
+    JOIN task_records t ON t.id = p.task_id
+    JOIN workflow_nodes n ON n.id = p.node_id
+    WHERE p.parallel_branch_edge_id = sqlc.arg(edge_id)
+      AND p.state IN ('active', 'waiting_approval')
+      AND t.canceled_at_unix_ms = 0
+      AND n.kind != 'terminal'
 );
 
 -- name: GetWorkflowGraphActiveWorkPolicyImpact :one

--- a/server/metadata/sqlitegen/queries.sql.go
+++ b/server/metadata/sqlitegen/queries.sql.go
@@ -376,9 +376,25 @@ func (q *Queries) CountProjectWorkspaces(ctx context.Context, projectID string) 
 const countTaskEdgeReferences = `-- name: CountTaskEdgeReferences :one
 SELECT CAST(COUNT(*) AS INTEGER) AS ref_count
 FROM (
-    SELECT te.id FROM task_transition_edges te WHERE te.workflow_edge_id = ?1
+    -- Only live unresolved references block edge deletion. Completed historical
+    -- transition edges intentionally rely on ON DELETE SET NULL.
+    SELECT te.id
+    FROM task_transition_edges te
+    JOIN task_transition_records tt ON tt.id = te.task_transition_id
+    JOIN task_records t ON t.id = tt.task_id
+    WHERE te.workflow_edge_id = ?1
+      AND t.canceled_at_unix_ms = 0
+      AND tt.state = 'pending_approval'
+      AND te.state = 'pending'
     UNION ALL
-    SELECT p.id FROM task_node_placements p WHERE p.parallel_branch_edge_id = ?1
+    SELECT p.id
+    FROM task_node_placements p
+    JOIN task_records t ON t.id = p.task_id
+    JOIN workflow_nodes n ON n.id = p.node_id
+    WHERE p.parallel_branch_edge_id = ?1
+      AND p.state IN ('active', 'waiting_approval')
+      AND t.canceled_at_unix_ms = 0
+      AND n.kind != 'terminal'
 )
 `
 
@@ -701,6 +717,7 @@ SELECT
             JOIN workflow_nodes n ON n.id = p.node_id
             WHERE t.project_id = ?1
               AND t.canceled_at_unix_ms = 0
+              -- Backlog/start-node tasks are drafts, not active project work.
               AND n.kind NOT IN ('start', 'terminal')
             UNION
             SELECT t.id

--- a/server/metadata/store.go
+++ b/server/metadata/store.go
@@ -217,6 +217,20 @@ func (s *Store) ResolveWorkspacePath(ctx context.Context, workspaceRoot string) 
 		return canonicalRoot, &binding, nil
 	}
 	if errors.Is(err, sql.ErrNoRows) {
+		// Managed task worktrees are tracked as worktrees rather than standalone
+		// workspace bindings, but project-scoped commands run from the worktree
+		// root still need to resolve to the owning project.
+		worktree, worktreeErr := s.GetWorktreeRecordByCanonicalRoot(ctx, canonicalRoot)
+		if worktreeErr == nil {
+			binding, bindingErr := s.LookupWorkspaceBindingByID(ctx, worktree.WorkspaceID)
+			if bindingErr != nil {
+				return "", nil, bindingErr
+			}
+			return canonicalRoot, &binding, nil
+		}
+		if !errors.Is(worktreeErr, sql.ErrNoRows) {
+			return "", nil, worktreeErr
+		}
 		return canonicalRoot, nil, nil
 	}
 	return "", nil, err

--- a/server/projectview/service_test.go
+++ b/server/projectview/service_test.go
@@ -602,6 +602,37 @@ func TestMetadataServiceResolveProjectPathLeavesNestedDirectoryUnbound(t *testin
 	}
 }
 
+func TestMetadataServiceResolveProjectPathMapsRegisteredWorktreeRootToProject(t *testing.T) {
+	store, _, binding := newProjectViewMetadataStore(t)
+	worktreeRoot := filepath.Join(t.TempDir(), "task-worktree")
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll worktree root: %v", err)
+	}
+	canonicalWorktreeRoot, err := config.CanonicalWorkspaceRoot(worktreeRoot)
+	if err != nil {
+		t.Fatalf("CanonicalWorkspaceRoot worktree: %v", err)
+	}
+	if err := store.UpsertWorktreeRecord(context.Background(), metadata.WorktreeRecord{
+		ID:            "worktree-task",
+		WorkspaceID:   binding.WorkspaceID,
+		CanonicalRoot: canonicalWorktreeRoot,
+	}); err != nil {
+		t.Fatalf("UpsertWorktreeRecord: %v", err)
+	}
+	svc := newProjectViewMetadataService(t, store, "")
+
+	resolved, err := svc.ResolveProjectPath(context.Background(), serverapi.ProjectResolvePathRequest{Path: worktreeRoot})
+	if err != nil {
+		t.Fatalf("ResolveProjectPath worktree root: %v", err)
+	}
+	if resolved.CanonicalRoot != canonicalWorktreeRoot {
+		t.Fatalf("canonical root = %q, want worktree root %q", resolved.CanonicalRoot, canonicalWorktreeRoot)
+	}
+	if resolved.Binding == nil || resolved.Binding.ProjectID != binding.ProjectID || resolved.Binding.WorkspaceID != binding.WorkspaceID {
+		t.Fatalf("resolved binding = %+v, want owning project/workspace %+v", resolved.Binding, binding)
+	}
+}
+
 func TestMetadataServicePlansInteractiveLocalUnboundWorkspace(t *testing.T) {
 	store, _, binding := newProjectViewMetadataStore(t)
 	workspace := t.TempDir()

--- a/server/workflowstore/store_test.go
+++ b/server/workflowstore/store_test.go
@@ -3503,7 +3503,7 @@ func TestWorkflowPerEntityMutationsUseGraphEditPolicy(t *testing.T) {
 	})
 }
 
-func TestWorkflowGraphSaveBlocksRemovedTaskReferences(t *testing.T) {
+func TestWorkflowGraphSaveAllowsRemovedCompletedEdgeReferences(t *testing.T) {
 	ctx, store, binding := newTestStoreContext(t)
 	workflowID := createLinkedValidWorkflow(t, ctx, store, binding.ProjectID)
 	task := createDefaultTask(t, ctx, store, binding.ProjectID)
@@ -3514,17 +3514,63 @@ func TestWorkflowGraphSaveBlocksRemovedTaskReferences(t *testing.T) {
 		t.Fatalf("GetDefinition: %v", err)
 	}
 
-	edgeRemoval := workflowGraphSaveRequestFromDefinition(workflowID, record.Version, true, def)
+	edgeRemoval := workflowGraphSaveRequestFromDefinition(workflowID, record.Version, false, def)
 	edgeRemoval.Edges = removeWorkflowGraphSaveEdge(edgeRemoval.Edges, workflow.EdgeID("edge-done-"+string(workflowID)))
 	edgeRemoval.TransitionGroups = removeWorkflowGraphSaveTransitionGroupByID(edgeRemoval.TransitionGroups, workflow.TransitionGroupID("group-done-"+string(workflowID)))
-	edgeBlocked, err := store.SaveWorkflowGraph(ctx, edgeRemoval)
+	preview, err := store.PreviewWorkflowGraphSave(ctx, edgeRemoval)
+	if err != nil {
+		t.Fatalf("PreviewWorkflowGraphSave edge removal: %v", err)
+	}
+	if workflowGraphSaveBlockerCount(preview.Blockers, "edge_task_references") != 0 {
+		t.Fatalf("edge removal preview = %+v, want no edge task-reference blocker", preview)
+	}
+	edgeSaved, err := store.SaveWorkflowGraph(ctx, confirmWorkflowGraphSaveRequest(edgeRemoval, preview.Impact))
 	if err != nil {
 		t.Fatalf("SaveWorkflowGraph edge removal: %v", err)
 	}
-	if edgeBlocked.Saved || workflowGraphSaveBlockerCount(edgeBlocked.Blockers, "edge_task_references") == 0 {
-		t.Fatalf("edge removal graph save = %+v, want edge task-reference blocker", edgeBlocked)
+	if !edgeSaved.Saved || workflowGraphSaveBlockerCount(edgeSaved.Blockers, "edge_task_references") != 0 {
+		t.Fatalf("edge removal graph save = %+v, want saved without edge task-reference blocker", edgeSaved)
+	}
+}
+
+func TestWorkflowGraphSaveBlocksRemovedPendingEdgeReferences(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	workflowID := createApprovalWorkflow(t, ctx, store)
+	linkWorkflow(t, ctx, store, binding.ProjectID, workflowID, true)
+	task := createDefaultTask(t, ctx, store, binding.ProjectID)
+	started := startTask(t, ctx, store, task.ID)
+	completeRun(t, ctx, store, CompleteRunRequest{RunID: started.RunID, TransitionID: "done"})
+	def, record, err := store.GetDefinition(ctx, workflowID)
+	if err != nil {
+		t.Fatalf("GetDefinition: %v", err)
 	}
 
+	req := workflowGraphSaveRequestFromDefinition(workflowID, record.Version, false, def)
+	req.Edges = removeWorkflowGraphSaveEdge(req.Edges, workflow.EdgeID("edge-done-approval-"+string(workflowID)))
+	req.TransitionGroups = removeWorkflowGraphSaveTransitionGroupByID(req.TransitionGroups, workflow.TransitionGroupID("group-done-"+string(workflowID)))
+	preview, err := store.PreviewWorkflowGraphSave(ctx, req)
+	if err != nil {
+		t.Fatalf("PreviewWorkflowGraphSave pending edge removal: %v", err)
+	}
+	blocked, err := store.SaveWorkflowGraph(ctx, confirmWorkflowGraphSaveRequest(req, preview.Impact))
+	if err != nil {
+		t.Fatalf("SaveWorkflowGraph pending edge removal: %v", err)
+	}
+	if blocked.Saved || workflowGraphSaveBlockerCount(blocked.Blockers, "edge_task_references") == 0 {
+		t.Fatalf("pending edge removal graph save = %+v, want edge task-reference blocker", blocked)
+	}
+}
+
+func TestWorkflowGraphSaveBlocksRemovedNodeTaskReferences(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	workflowID := createLinkedValidWorkflow(t, ctx, store, binding.ProjectID)
+	task := createDefaultTask(t, ctx, store, binding.ProjectID)
+	started := startTask(t, ctx, store, task.ID)
+	completeRun(t, ctx, store, CompleteRunRequest{RunID: started.RunID, TransitionID: "done"})
+	def, record, err := store.GetDefinition(ctx, workflowID)
+	if err != nil {
+		t.Fatalf("GetDefinition: %v", err)
+	}
 	nodeRemoval := workflowGraphSaveRequestFromDefinition(workflowID, record.Version, true, def)
 	agentID := workflow.NodeID("node-agent-" + string(workflowID))
 	nodeRemoval.Nodes = removeWorkflowGraphSaveNode(nodeRemoval.Nodes, agentID)
@@ -3538,9 +3584,9 @@ func TestWorkflowGraphSaveBlocksRemovedTaskReferences(t *testing.T) {
 		t.Fatalf("node removal graph save = %+v, want node task-reference blocker", nodeBlocked)
 	}
 	if _, unchanged, err := store.GetDefinition(ctx, workflowID); err != nil {
-		t.Fatalf("GetDefinition after blocked graph saves: %v", err)
+		t.Fatalf("GetDefinition after blocked graph save: %v", err)
 	} else if unchanged.Version != record.Version {
-		t.Fatalf("workflow version after blocked graph saves = %d, want %d", unchanged.Version, record.Version)
+		t.Fatalf("workflow version after blocked graph save = %d, want %d", unchanged.Version, record.Version)
 	}
 }
 
@@ -3793,8 +3839,8 @@ func TestGuardedGraphDeletesRespectTaskHistory(t *testing.T) {
 	if err := store.DeleteNode(ctx, agentID); err == nil || !strings.Contains(err.Error(), "task history") {
 		t.Fatalf("expected node history delete guard, got %v", err)
 	}
-	if err := store.DeleteEdge(ctx, workflow.EdgeID("edge-done-"+string(workflowID))); err == nil || !strings.Contains(err.Error(), "task history") {
-		t.Fatalf("expected edge history delete guard, got %v", err)
+	if err := store.DeleteEdge(ctx, workflow.EdgeID("edge-done-"+string(workflowID))); err != nil {
+		t.Fatalf("DeleteEdge completed history edge: %v", err)
 	}
 	def, _, err := store.GetDefinition(ctx, workflowID)
 	if err != nil {

--- a/server/workflowstore/store_test.go
+++ b/server/workflowstore/store_test.go
@@ -3559,6 +3559,11 @@ func TestWorkflowGraphSaveBlocksRemovedPendingEdgeReferences(t *testing.T) {
 	if blocked.Saved || workflowGraphSaveBlockerCount(blocked.Blockers, "edge_task_references") == 0 {
 		t.Fatalf("pending edge removal graph save = %+v, want edge task-reference blocker", blocked)
 	}
+	if _, unchanged, err := store.GetDefinition(ctx, workflowID); err != nil {
+		t.Fatalf("GetDefinition after blocked pending edge save: %v", err)
+	} else if unchanged.Version != record.Version {
+		t.Fatalf("workflow version after blocked pending edge save = %d, want %d", unchanged.Version, record.Version)
+	}
 }
 
 func TestWorkflowGraphSaveBlocksRemovedNodeTaskReferences(t *testing.T) {


### PR DESCRIPTION
## Summary
- bind workflow/project metadata lookups to worktree-aware workspace identity
- cover workflow command, project view, and workflow store worktree behavior
- update workflow task instructions and terminology spec

## Verification
- git push pre-push hooks: frontend dependency policy, formatting, go vet, go build, tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Updated transition field label to "Transition text"

* **Improvements**
  * Refined edge deletion logic to properly distinguish between completed and pending edges
  * Enhanced workspace path resolution for registered worktree roots

* **Documentation**
  * Added workflow editor terminology definitions for transition text and edge identifiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->