### PR TITLE
fix: keep TUI responsive under runtime load

### DIFF
--- a/cli/app/embedded_server_part2_test.go
+++ b/cli/app/embedded_server_part2_test.go
@@ -126,14 +126,14 @@ func TestEmbeddedAppServerPrepareRuntimeWiresProcessControlForUIActions(t *testi
 	runtimePlan.Wiring.processControls = controls
 	processClient := newUIProcessClientWithReads(runtimePlan.Wiring.processViews, runtimePlan.Wiring.processControls)
 
-	preview, logPath, err := processClient.InlineOutput("proc-1", 12_000)
+	preview, logPath, err := processClient.InlineOutput(context.Background(), "proc-1", 12_000)
 	if err != nil {
 		t.Fatalf("InlineOutput: %v", err)
 	}
 	if preview != "remote preview" || logPath != "/tmp/remote.log" {
 		t.Fatalf("unexpected inline output payload preview=%q logPath=%q", preview, logPath)
 	}
-	if err := processClient.KillProcess("proc-1"); err != nil {
+	if err := processClient.KillProcess(context.Background(), "proc-1"); err != nil {
 		t.Fatalf("KillProcess: %v", err)
 	}
 	if len(controls.killed) != 1 || controls.killed[0] != "proc-1" {

--- a/cli/app/embedded_server_test.go
+++ b/cli/app/embedded_server_test.go
@@ -519,7 +519,10 @@ func TestEmbeddedAppServerPrepareRuntimeWiresProcessReadsForUIHydration(t *testi
 	}}}}
 
 	processClient := newUIProcessClientWithReads(runtimePlan.Wiring.processViews, runtimePlan.Wiring.processControls)
-	got := processClient.ListProcesses()
+	got, err := processClient.ListProcesses(context.Background())
+	if err != nil {
+		t.Fatalf("ListProcesses: %v", err)
+	}
 	if len(got) != 1 || got[0].ID != "remote-proc" || got[0].OwnerRunID != "remote-run" || got[0].OwnerStepID != "remote-step" {
 		t.Fatalf("expected shared process reads to win over local manager snapshot, got %+v", got)
 	}

--- a/cli/app/internal/runtimestate/runtime_events.go
+++ b/cli/app/internal/runtimestate/runtime_events.go
@@ -124,6 +124,7 @@ type RuntimePendingInputReduction struct {
 	State                PendingInputState
 	DraftCommand         RuntimeDraftInputCommandKind
 	PromptHistoryCommand *RuntimePromptHistoryCommand
+	ConsumedQueueItemIDs []string
 }
 
 type RuntimeReasoningStreamCommandKind uint8
@@ -266,6 +267,7 @@ func ReduceRuntimePendingInputEvent(input PendingInputState, evt clientui.Event)
 		if len(consumed) > 0 {
 			reduction.State.PendingInjected = append([]clientui.QueuedUserMessage(nil), reduction.State.PendingInjected[len(consumed):]...)
 			reduction.PromptHistoryCommand = &RuntimePromptHistoryCommand{Text: evt.UserMessage}
+			reduction.ConsumedQueueItemIDs = append([]string(nil), evt.UserMessageBatchQueueItemIDs[:len(consumed)]...)
 		}
 		if reduction.State.Submission.IsLocked() && containsQueuedUserMessageID(consumed, reduction.State.LockedInjectID) {
 			if reduction.State.Input == reduction.State.LockedInjectText {

--- a/cli/app/internal/status/status.go
+++ b/cli/app/internal/status/status.go
@@ -46,6 +46,7 @@ type Request struct {
 	Settings              config.Settings
 	Source                config.SourceReport
 	AuthCacheIdentity     string
+	AuthCacheUnseedable   bool
 	CacheKeys             CacheKeys
 	AuthStatus            client.AuthStatusClient
 	AuthStatePath         string
@@ -224,6 +225,9 @@ func (r *memoryRepository) SeedSnapshot(req Request, base Snapshot, now time.Tim
 	seed := SeedResult{Snapshot: base, Warnings: map[Section]string{}}
 
 	authEntry, authCached := r.authByKey[strings.TrimSpace(req.CacheKeys.Auth)]
+	if req.AuthCacheUnseedable {
+		authCached = false
+	}
 	if authCached {
 		seed.Snapshot.Auth = authEntry.result.Auth
 		seed.Snapshot.Subscription = authEntry.result.Subscription

--- a/cli/app/internal/status/status_test.go
+++ b/cli/app/internal/status/status_test.go
@@ -88,6 +88,9 @@ func (s stubRuntimeClient) ResumeGoal() (*clientui.RuntimeGoal, error) { return 
 func (s stubRuntimeClient) ClearGoal() (*clientui.RuntimeGoal, error) { return nil, nil }
 
 func (s stubRuntimeClient) AppendLocalEntry(string, string) error { return nil }
+func (s stubRuntimeClient) AppendLocalEntryWithNoticeID(string, string, string) error {
+	return nil
+}
 
 func (s stubRuntimeClient) SubmitUserMessage(context.Context, string) (string, error) {
 	return "", nil

--- a/cli/app/testmain_test.go
+++ b/cli/app/testmain_test.go
@@ -8,8 +8,11 @@ import (
 
 func TestMain(m *testing.M) {
 	previousDuration := transientStatusDuration
+	previousStrictMode := defaultTUIStrictIOMode
 	transientStatusDuration = 30 * time.Millisecond
+	defaultTUIStrictIOMode = tuiStrictIOModePanic
 	code := m.Run()
 	transientStatusDuration = previousDuration
+	defaultTUIStrictIOMode = previousStrictMode
 	os.Exit(code)
 }

--- a/cli/app/testmain_test.go
+++ b/cli/app/testmain_test.go
@@ -8,11 +8,8 @@ import (
 
 func TestMain(m *testing.M) {
 	previousDuration := transientStatusDuration
-	previousStrictMode := defaultTUIStrictIOMode
 	transientStatusDuration = 30 * time.Millisecond
-	defaultTUIStrictIOMode = tuiStrictIOModePanic
 	code := m.Run()
 	transientStatusDuration = previousDuration
-	defaultTUIStrictIOMode = previousStrictMode
 	os.Exit(code)
 }

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -70,11 +70,10 @@ func NewProjectedUIModel(runtimeClient clientui.RuntimeClient, runtimeEvents <-c
 	mainView := m.runtimeMainView()
 	status := mainView.Status
 	m.applyRuntimeMainViewState(mainView)
-	m.refreshAuthSlashCommandState()
+	m.authSlashCommandName = "login"
 	if !m.hasRuntimeClient() {
 		m.reviewerEnabled = strings.TrimSpace(m.reviewerMode) != "" && strings.TrimSpace(m.reviewerMode) != "off"
 	}
-	m.refreshProcessEntries()
 	var startupNativeHistoryCmd tea.Cmd
 	if m.hasRuntimeClient() {
 		seedView := mainView.Session
@@ -269,6 +268,7 @@ func (m *uiModel) Init() tea.Cmd {
 }
 
 func (m *uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	defer m.enterUIMainThread("Update")()
 	if probe, ok := msg.(uiModelProbeMessage); ok {
 		probe.probeUIModel(m)
 		return m, nil
@@ -512,17 +512,7 @@ func (m *uiModel) startupUpdateNoticeCmd(status clientui.UpdateStatus) tea.Cmd {
 	if status.Checked {
 		return nil
 	}
-	client := m.runtimeClient()
-	if client == nil {
-		return nil
-	}
-	return func() tea.Msg {
-		refreshed, err := client.RefreshMainView()
-		if err != nil || !refreshed.Status.Update.Available || strings.TrimSpace(refreshed.Status.Update.LatestVersion) == "" {
-			return nil
-		}
-		return startupUpdateNoticeMsg{version: refreshed.Status.Update.LatestVersion}
-	}
+	return m.requestRuntimeMainViewRefreshForCause(runtimeMainViewRefreshCauseStartupUpdate)
 }
 
 func batchCmds(cmds ...tea.Cmd) tea.Cmd {

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -70,7 +70,6 @@ func NewProjectedUIModel(runtimeClient clientui.RuntimeClient, runtimeEvents <-c
 	mainView := m.runtimeMainView()
 	status := mainView.Status
 	m.applyRuntimeMainViewState(mainView)
-	m.authSlashCommandName = "login"
 	if !m.hasRuntimeClient() {
 		m.reviewerEnabled = strings.TrimSpace(m.reviewerMode) != "" && strings.TrimSpace(m.reviewerMode) != "off"
 	}

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -142,8 +142,9 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyCtrlC:
 		hasNext := c.answer(clientui.PromptAnswer{}, errors.New("interrupted"))
+		interruptCmd := tea.Cmd(nil)
 		if m.isBusy() {
-			_ = m.interruptRuntime()
+			interruptCmd = m.inputController().interruptBusyRuntime()
 			m.setBusy(false)
 		}
 		if hasNext {
@@ -151,7 +152,7 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else {
 			m.activity = uiActivityInterrupted
 		}
-		return m, nil
+		return m, interruptCmd
 	case tea.KeyEsc:
 		hasNext := c.answer(clientui.PromptAnswer{}, errors.New("question canceled"))
 		if hasNext {
@@ -191,10 +192,15 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					if !ok {
 						return m, nil
 					}
-					if commentary != "" {
-						m.enqueueInjectedInput(commentary)
-					}
+					queueCmd := m.enqueueInjectedInput(commentary)
 					resp = clientui.PromptAnswer{Approval: &clientui.ApprovalPromptAnswer{Decision: decision, Commentary: commentary}}
+					hasNext := c.answer(resp, nil)
+					if hasNext {
+						m.activity = uiActivityQuestion
+					} else {
+						m.activity = uiActivityRunning
+					}
+					return m, queueCmd
 				}
 			}
 			hasNext := c.answer(resp, nil)

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -119,6 +119,9 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if !m.ask.hasCurrent() {
 		return m, nil
 	}
+	if m.ask.answerPending {
+		return m, nil
+	}
 	if msg.Type != tea.KeyEnter && msg.Type != keyTypeShiftEnterCSI {
 		m.inputController().clearPendingCSIShiftEnter()
 	}
@@ -194,6 +197,7 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					}
 					resp = clientui.PromptAnswer{Approval: &clientui.ApprovalPromptAnswer{Decision: decision, Commentary: commentary}}
 					if queueCmd := m.enqueueInjectedInputWithApprovalAnswer(commentary, &resp); queueCmd != nil {
+						m.ask.answerPending = true
 						return m, queueCmd
 					}
 					hasNext := c.answer(resp, nil)
@@ -428,6 +432,7 @@ func (c uiAskController) answer(resp clientui.PromptAnswer, err error) bool {
 	if !m.ask.hasCurrent() {
 		return false
 	}
+	m.ask.answerPending = false
 	if resp.PromptID == "" {
 		resp.PromptID = m.ask.current.req.PromptID
 	}
@@ -464,6 +469,7 @@ func (c uiAskController) setActiveAsk(evt askEvent) {
 	current := evt
 	m.ask.currentToken = nextNonZeroToken(m.ask.currentToken)
 	m.ask.current = &current
+	m.ask.answerPending = false
 	m.ask.cursor = 0
 	m.clearAskInput()
 	m.ask.freeform = askOptionCount(current.req) == 0

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -192,15 +192,17 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					if !ok {
 						return m, nil
 					}
-					queueCmd := m.enqueueInjectedInput(commentary)
 					resp = clientui.PromptAnswer{Approval: &clientui.ApprovalPromptAnswer{Decision: decision, Commentary: commentary}}
+					if queueCmd := m.enqueueInjectedInputWithApprovalAnswer(commentary, &resp); queueCmd != nil {
+						return m, queueCmd
+					}
 					hasNext := c.answer(resp, nil)
 					if hasNext {
 						m.activity = uiActivityQuestion
 					} else {
 						m.activity = uiActivityRunning
 					}
-					return m, queueCmd
+					return m, nil
 				}
 			}
 			hasNext := c.answer(resp, nil)
@@ -445,6 +447,16 @@ func (c uiAskController) answer(resp clientui.PromptAnswer, err error) bool {
 	c.setActiveAsk(next)
 	m.setInputMode(uiInputModeAsk)
 	return true
+}
+
+func (m *uiModel) answerQueuedApprovalCommentary(resp clientui.PromptAnswer) tea.Cmd {
+	hasNext := m.askController().answer(resp, nil)
+	if hasNext {
+		m.activity = uiActivityQuestion
+	} else {
+		m.activity = uiActivityRunning
+	}
+	return nil
 }
 
 func (c uiAskController) setActiveAsk(evt askEvent) {

--- a/cli/app/ui_background_notifications_test.go
+++ b/cli/app/ui_background_notifications_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -16,18 +17,20 @@ type blockingProcessClient struct {
 	release     chan struct{}
 }
 
-func (c *blockingProcessClient) ListProcesses() []clientui.BackgroundProcess {
+func (c *blockingProcessClient) ListProcesses(context.Context) ([]clientui.BackgroundProcess, error) {
 	select {
 	case c.listStarted <- struct{}{}:
 	default:
 	}
 	<-c.release
-	return nil
+	return nil, nil
 }
 
-func (c *blockingProcessClient) KillProcess(string) error { return errors.New("not implemented") }
+func (c *blockingProcessClient) KillProcess(context.Context, string) error {
+	return errors.New("not implemented")
+}
 
-func (c *blockingProcessClient) InlineOutput(string, int) (string, string, error) {
+func (c *blockingProcessClient) InlineOutput(context.Context, string, int) (string, string, error) {
 	return "", "", errors.New("not implemented")
 }
 

--- a/cli/app/ui_busy_commands_test.go
+++ b/cli/app/ui_busy_commands_test.go
@@ -407,6 +407,10 @@ func TestBusyQueuedFastAppliesToNextRuntimeRequestAfterTurnDrains(t *testing.T) 
 	if cmd == nil {
 		t.Fatal("expected queued /fast feedback command")
 	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
 	if !eng.FastModeEnabled() {
 		t.Fatal("expected queued /fast to enable runtime fast mode")
 	}

--- a/cli/app/ui_clipboard.go
+++ b/cli/app/ui_clipboard.go
@@ -16,6 +16,8 @@ import (
 	"time"
 	"unicode/utf16"
 
+	"builder/shared/clientui"
+
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -531,13 +533,34 @@ func (m *uiModel) copyClipboardTextCmd(text string) tea.Cmd {
 	copier := m.clipboardTextCopier
 	copyText := text
 	return func() tea.Msg {
-		if copier == nil {
-			return clipboardTextCopyDoneMsg{Err: &uiClipboardCopyError{Kind: uiClipboardCopyErrorUnsupported, Message: "Clipboard copy is unavailable"}}
+		ctx, cancel := context.WithTimeout(context.Background(), clipboardTextCopyTimeout)
+		defer cancel()
+		return clipboardTextCopyDoneMsg{Err: copyClipboardText(ctx, copier, copyText)}
+	}
+}
+
+func (m *uiModel) copyLatestAssistantFinalAnswerFromRuntimeCmd(client clientui.RuntimeClient) tea.Cmd {
+	copier := m.clipboardTextCopier
+	return func() tea.Msg {
+		view, err := client.RefreshMainView()
+		if err != nil {
+			return copyFinalAnswerDoneMsg{RefreshErr: err}
+		}
+		answer := strings.TrimSpace(view.Status.LastCommittedAssistantFinalAnswer)
+		if answer == "" {
+			return copyFinalAnswerDoneMsg{NoAnswer: true}
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), clipboardTextCopyTimeout)
 		defer cancel()
-		return clipboardTextCopyDoneMsg{Err: copier.CopyText(ctx, copyText)}
+		return copyFinalAnswerDoneMsg{CopyErr: copyClipboardText(ctx, copier, view.Status.LastCommittedAssistantFinalAnswer)}
 	}
+}
+
+func copyClipboardText(ctx context.Context, copier uiClipboardTextCopier, text string) error {
+	if copier == nil {
+		return &uiClipboardCopyError{Kind: uiClipboardCopyErrorUnsupported, Message: "Clipboard copy is unavailable"}
+	}
+	return copier.CopyText(ctx, text)
 }
 
 func (m *uiModel) handleClipboardTextCopyDone(msg clipboardTextCopyDoneMsg) tea.Cmd {
@@ -546,6 +569,17 @@ func (m *uiModel) handleClipboardTextCopyDone(msg clipboardTextCopyDoneMsg) tea.
 		return m.setTransientStatusWithKind(message, kind)
 	}
 	return m.setTransientStatusWithKind("Copied final answer to clipboard", uiStatusNoticeSuccess)
+}
+
+func (m *uiModel) handleCopyFinalAnswerDone(msg copyFinalAnswerDoneMsg) tea.Cmd {
+	m.observeRuntimeRequestResult(msg.RefreshErr)
+	if msg.RefreshErr != nil {
+		return m.setTransientStatusWithKind("Failed to refresh final answer: "+msg.RefreshErr.Error(), uiStatusNoticeError)
+	}
+	if msg.NoAnswer {
+		return m.setTransientStatusWithKind("No final answer available to copy", uiStatusNoticeError)
+	}
+	return m.handleClipboardTextCopyDone(clipboardTextCopyDoneMsg{Err: msg.CopyErr})
 }
 
 func clipboardImagePasteStatus(err error) (string, uiStatusNoticeKind) {

--- a/cli/app/ui_clipboard.go
+++ b/cli/app/ui_clipboard.go
@@ -16,8 +16,6 @@ import (
 	"time"
 	"unicode/utf16"
 
-	"builder/shared/clientui"
-
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -539,23 +537,6 @@ func (m *uiModel) copyClipboardTextCmd(text string) tea.Cmd {
 	}
 }
 
-func (m *uiModel) copyLatestAssistantFinalAnswerFromRuntimeCmd(client clientui.RuntimeClient) tea.Cmd {
-	copier := m.clipboardTextCopier
-	return func() tea.Msg {
-		view, err := client.RefreshMainView()
-		if err != nil {
-			return copyFinalAnswerDoneMsg{RefreshErr: err}
-		}
-		answer := strings.TrimSpace(view.Status.LastCommittedAssistantFinalAnswer)
-		if answer == "" {
-			return copyFinalAnswerDoneMsg{NoAnswer: true}
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), clipboardTextCopyTimeout)
-		defer cancel()
-		return copyFinalAnswerDoneMsg{CopyErr: copyClipboardText(ctx, copier, view.Status.LastCommittedAssistantFinalAnswer)}
-	}
-}
-
 func copyClipboardText(ctx context.Context, copier uiClipboardTextCopier, text string) error {
 	if copier == nil {
 		return &uiClipboardCopyError{Kind: uiClipboardCopyErrorUnsupported, Message: "Clipboard copy is unavailable"}
@@ -569,17 +550,6 @@ func (m *uiModel) handleClipboardTextCopyDone(msg clipboardTextCopyDoneMsg) tea.
 		return m.setTransientStatusWithKind(message, kind)
 	}
 	return m.setTransientStatusWithKind("Copied final answer to clipboard", uiStatusNoticeSuccess)
-}
-
-func (m *uiModel) handleCopyFinalAnswerDone(msg copyFinalAnswerDoneMsg) tea.Cmd {
-	m.observeRuntimeRequestResult(msg.RefreshErr)
-	if msg.RefreshErr != nil {
-		return m.setTransientStatusWithKind("Failed to refresh final answer: "+msg.RefreshErr.Error(), uiStatusNoticeError)
-	}
-	if msg.NoAnswer {
-		return m.setTransientStatusWithKind("No final answer available to copy", uiStatusNoticeError)
-	}
-	return m.handleClipboardTextCopyDone(clipboardTextCopyDoneMsg{Err: msg.CopyErr})
 }
 
 func clipboardImagePasteStatus(err error) (string, uiStatusNoticeKind) {

--- a/cli/app/ui_clipboard_test.go
+++ b/cli/app/ui_clipboard_test.go
@@ -146,13 +146,63 @@ func TestCopySlashCommandDoesNotUseVisibleProjectionWhenRuntimeStatusIsStale(t *
 	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
 	if cmd == nil {
-		t.Fatal("expected transient-status command")
+		t.Fatal("expected runtime refresh command")
 	}
 	if copier.calls != 0 {
 		t.Fatalf("did not expect clipboard copy from visible projection, got %d", copier.calls)
 	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, cmd = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
+	if copier.calls != 0 {
+		t.Fatalf("did not expect clipboard copy from visible projection after refresh, got %d", copier.calls)
+	}
 	if updated.transientStatus != "No final answer available to copy" {
 		t.Fatalf("expected no-answer status, got %q", updated.transientStatus)
+	}
+	if cmd == nil {
+		t.Fatal("expected transient-status clear command")
+	}
+}
+
+func TestCopySlashCommandRefreshesRuntimeStatusBeforeCopying(t *testing.T) {
+	copier := &stubClipboardTextCopier{}
+	client := &runtimeControlFakeClient{
+		status: clientui.RuntimeStatus{LastCommittedAssistantFinalAnswer: "refreshed final"},
+		cachedMainView: clientui.RuntimeMainView{Status: clientui.RuntimeStatus{
+			LastCommittedAssistantFinalAnswer: "",
+		}},
+		hasCachedMainView: true,
+	}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUIClipboardTextCopier(copier))
+	m.input = "/copy"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected runtime refresh command")
+	}
+	if client.refreshMainViewCalls != 0 {
+		t.Fatalf("refresh happened during Update: %d", client.refreshMainViewCalls)
+	}
+
+	var followCmd tea.Cmd
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, followCmd = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
+	if client.refreshMainViewCalls != 1 {
+		t.Fatalf("expected one refresh from copy command, got %d", client.refreshMainViewCalls)
+	}
+	if copier.calls != 1 || copier.text != "refreshed final" {
+		t.Fatalf("expected refreshed final answer copied once, calls=%d text=%q", copier.calls, copier.text)
+	}
+	if updated.transientStatus != "Copied final answer to clipboard" {
+		t.Fatalf("unexpected transient status %q", updated.transientStatus)
+	}
+	if followCmd == nil {
+		t.Fatal("expected transient-status clear command")
 	}
 }
 

--- a/cli/app/ui_clipboard_test.go
+++ b/cli/app/ui_clipboard_test.go
@@ -146,63 +146,16 @@ func TestCopySlashCommandDoesNotUseVisibleProjectionWhenRuntimeStatusIsStale(t *
 	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
 	if cmd == nil {
-		t.Fatal("expected runtime refresh command")
+		t.Fatal("expected transient-status clear command")
 	}
 	if copier.calls != 0 {
 		t.Fatalf("did not expect clipboard copy from visible projection, got %d", copier.calls)
 	}
-	for _, msg := range collectCmdMessages(t, cmd) {
-		next, cmd = updated.Update(msg)
-		updated = next.(*uiModel)
-	}
-	if copier.calls != 0 {
-		t.Fatalf("did not expect clipboard copy from visible projection after refresh, got %d", copier.calls)
-	}
 	if updated.transientStatus != "No final answer available to copy" {
 		t.Fatalf("expected no-answer status, got %q", updated.transientStatus)
 	}
-	if cmd == nil {
-		t.Fatal("expected transient-status clear command")
-	}
-}
-
-func TestCopySlashCommandRefreshesRuntimeStatusBeforeCopying(t *testing.T) {
-	copier := &stubClipboardTextCopier{}
-	client := &runtimeControlFakeClient{
-		status: clientui.RuntimeStatus{LastCommittedAssistantFinalAnswer: "refreshed final"},
-		cachedMainView: clientui.RuntimeMainView{Status: clientui.RuntimeStatus{
-			LastCommittedAssistantFinalAnswer: "",
-		}},
-		hasCachedMainView: true,
-	}
-	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUIClipboardTextCopier(copier))
-	m.input = "/copy"
-
-	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
-	if cmd == nil {
-		t.Fatal("expected runtime refresh command")
-	}
 	if client.refreshMainViewCalls != 0 {
-		t.Fatalf("refresh happened during Update: %d", client.refreshMainViewCalls)
-	}
-
-	var followCmd tea.Cmd
-	for _, msg := range collectCmdMessages(t, cmd) {
-		next, followCmd = updated.Update(msg)
-		updated = next.(*uiModel)
-	}
-	if client.refreshMainViewCalls != 1 {
-		t.Fatalf("expected one refresh from copy command, got %d", client.refreshMainViewCalls)
-	}
-	if copier.calls != 1 || copier.text != "refreshed final" {
-		t.Fatalf("expected refreshed final answer copied once, calls=%d text=%q", copier.calls, copier.text)
-	}
-	if updated.transientStatus != "Copied final answer to clipboard" {
-		t.Fatalf("unexpected transient status %q", updated.transientStatus)
-	}
-	if followCmd == nil {
-		t.Fatal("expected transient-status clear command")
+		t.Fatalf("copy command refreshed runtime status %d times, want 0", client.refreshMainViewCalls)
 	}
 }
 

--- a/cli/app/ui_committed_suffix_delivery.go
+++ b/cli/app/ui_committed_suffix_delivery.go
@@ -138,6 +138,7 @@ func (m *uiModel) applyCommittedTranscriptSuffixAppend(suffix clientui.Committed
 		return nil
 	}
 	page := transcriptPageFromCommittedTranscriptSuffix(suffix)
+	page.Entries = m.suppressRenderedLocalEntryEchoesInChatEntries(page.Entries)
 	entries := transcriptEntriesFromPage(page)
 	expectedStart := committedTranscriptTailEnd(m)
 	if page.Offset > expectedStart && page.Offset <= loadedTranscriptTailEnd(m) {
@@ -158,6 +159,17 @@ func (m *uiModel) applyCommittedTranscriptSuffixAppend(suffix clientui.Committed
 			})
 		}
 		return m.syncNativeHistoryFromTranscript()
+	}
+	if len(entries) == 0 && suffix.NextEntryCount > suffix.StartEntryCount {
+		m.transcriptRevision = max(m.transcriptRevision, suffix.Revision)
+		m.transcriptTotalEntries = max(m.transcriptTotalEntries, suffix.CommittedEntryCount)
+		m.transcriptLiveDirty = true
+		m.ongoingCommittedDelivery.markApplied(max(committedOngoingLocalFrontierEnd(m), suffix.NextEntryCount), suffix.Revision)
+		m.refreshRollbackCandidates()
+		if m.view.Mode() == tui.ModeDetail {
+			m.detailTranscript.apply(page)
+		}
+		return nil
 	}
 	m.truncatePendingOngoingTailBeforeSuffix(expectedStart)
 	if shouldClearAssistantStreamForCommittedTranscriptEntries(entries, m.view.OngoingStreamingText()) {

--- a/cli/app/ui_committed_suffix_delivery.go
+++ b/cli/app/ui_committed_suffix_delivery.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"strings"
+
 	"builder/cli/tui"
 	"builder/shared/clientui"
 
@@ -138,7 +140,7 @@ func (m *uiModel) applyCommittedTranscriptSuffixAppend(suffix clientui.Committed
 		return nil
 	}
 	page := transcriptPageFromCommittedTranscriptSuffix(suffix)
-	page.Entries = m.suppressRenderedLocalEntryEchoesInChatEntries(page.Entries)
+	page = m.suppressLeadingRenderedLocalEntryEchoesInCommittedPage(page)
 	entries := transcriptEntriesFromPage(page)
 	expectedStart := committedTranscriptTailEnd(m)
 	if page.Offset > expectedStart && page.Offset <= loadedTranscriptTailEnd(m) {
@@ -231,6 +233,44 @@ func (m *uiModel) trackOngoingCommittedSuffixFlush(suffix clientui.CommittedTran
 		return m.requestRuntimeCommittedGapSync()
 	}
 	return nil
+}
+
+func (m *uiModel) suppressLeadingRenderedLocalEntryEchoesInCommittedPage(page clientui.TranscriptPage) clientui.TranscriptPage {
+	if m == nil || len(page.Entries) == 0 {
+		return page
+	}
+	suppressed := 0
+	for suppressed < len(page.Entries) {
+		noticeID := page.Entries[suppressed].NoticeID
+		if !m.shouldSuppressRenderedLocalEntryEcho(noticeID) {
+			break
+		}
+		m.markRenderedLocalEntryEchoCommitted(noticeID)
+		suppressed++
+	}
+	if suppressed == 0 {
+		return page
+	}
+	page.Offset += suppressed
+	page.Entries = append([]clientui.ChatEntry(nil), page.Entries[suppressed:]...)
+	return page
+}
+
+func (m *uiModel) markRenderedLocalEntryEchoCommitted(noticeID string) {
+	if m == nil {
+		return
+	}
+	noticeID = strings.TrimSpace(noticeID)
+	if noticeID == "" {
+		return
+	}
+	for index, entry := range m.transcriptEntries {
+		if strings.TrimSpace(entry.NoticeID) != noticeID {
+			continue
+		}
+		m.transcriptEntries[index].Committed = true
+		return
+	}
 }
 
 func (m *uiModel) trimCommittedTranscriptSuffixToDeliveryCursor(suffix clientui.CommittedTranscriptSuffix) clientui.CommittedTranscriptSuffix {

--- a/cli/app/ui_compaction_resume_test.go
+++ b/cli/app/ui_compaction_resume_test.go
@@ -32,14 +32,16 @@ func TestCompactDoneResumesQueuedSteeringAsNewTurn(t *testing.T) {
 	m.activity = uiActivityRunning
 	m.input = "steered message"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, createCmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	updated = applyFirstInjectedQueueCreateDoneForTest(t, updated, createCmd)
 	if len(updated.pendingInjected) != 1 || updated.pendingInjected[0].Text != "steered message" {
 		t.Fatalf("expected pending injected steering before compaction completes, got %+v", updated.pendingInjected)
 	}
 
 	next, cmd := updated.Update(compactDoneMsg{})
 	updated = next.(*uiModel)
+	updated, cmd = applyQueuedRuntimeWorkCheckForTest(t, updated, cmd)
 	if cmd == nil {
 		t.Fatal("expected compaction completion to resume queued steering")
 	}
@@ -120,10 +122,12 @@ func TestInterruptedResumedQueuedSteeringRestoresInput(t *testing.T) {
 	m.activity = uiActivityRunning
 	m.input = "steered message"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, createCmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	updated = applyFirstInjectedQueueCreateDoneForTest(t, updated, createCmd)
 	next, cmd := updated.Update(compactDoneMsg{})
 	updated = next.(*uiModel)
+	updated, cmd = applyQueuedRuntimeWorkCheckForTest(t, updated, cmd)
 	if cmd == nil {
 		t.Fatal("expected compaction completion to resume queued steering")
 	}

--- a/cli/app/ui_compaction_resume_test.go
+++ b/cli/app/ui_compaction_resume_test.go
@@ -137,9 +137,10 @@ func TestInterruptedResumedQueuedSteeringRestoresInput(t *testing.T) {
 
 	next, interruptCmd := updated.Update(submitDoneMsg{err: submissionerror.ErrInterrupted})
 	updated = next.(*uiModel)
-	if interruptCmd != nil {
-		t.Fatal("did not expect follow-up command after interrupted resumed steering")
+	if interruptCmd == nil {
+		t.Fatal("expected queued runtime cleanup command after interrupted resumed steering")
 	}
+	_ = collectCmdMessages(t, interruptCmd)
 	if updated.isBusy() {
 		t.Fatal("expected busy=false after interrupted resumed steering")
 	}
@@ -151,6 +152,13 @@ func TestInterruptedResumedQueuedSteeringRestoresInput(t *testing.T) {
 	}
 	if len(updated.pendingInjected) != 0 {
 		t.Fatalf("expected pending injected cleared after restore, got %+v", updated.pendingInjected)
+	}
+	hasWork, err := updated.runtimeClient().HasQueuedUserWork()
+	if err != nil {
+		t.Fatalf("check queued user work: %v", err)
+	}
+	if hasWork {
+		t.Fatal("expected interrupted resumed steering cleanup to discard runtime queued work")
 	}
 	plain := stripANSIAndTrimRight(updated.View())
 	if strings.Contains(strings.ToLower(plain), "interrupted") {

--- a/cli/app/ui_conversation_freshness.go
+++ b/cli/app/ui_conversation_freshness.go
@@ -3,6 +3,8 @@ package app
 import "builder/shared/clientui"
 
 func (m *uiModel) currentConversationFreshness() clientui.ConversationFreshness {
-	m.conversationFreshness = m.refreshRuntimeStatus().ConversationFreshness
+	if cached := m.cachedRuntimeStatus().ConversationFreshness; cached == clientui.ConversationFreshnessEstablished || m.conversationFreshness == clientui.ConversationFreshnessFresh {
+		m.conversationFreshness = cached
+	}
 	return m.conversationFreshness
 }

--- a/cli/app/ui_conversation_freshness.go
+++ b/cli/app/ui_conversation_freshness.go
@@ -3,8 +3,14 @@ package app
 import "builder/shared/clientui"
 
 func (m *uiModel) currentConversationFreshness() clientui.ConversationFreshness {
-	if cached := m.cachedRuntimeStatus().ConversationFreshness; cached == clientui.ConversationFreshnessEstablished || cached == clientui.ConversationFreshnessFresh {
+	switch cached := m.cachedRuntimeStatus().ConversationFreshness; cached {
+	case clientui.ConversationFreshnessEstablished:
 		m.conversationFreshness = cached
+		m.localConversationTurn = true
+	case clientui.ConversationFreshnessFresh:
+		if !m.localConversationTurn {
+			m.conversationFreshness = cached
+		}
 	}
 	return m.conversationFreshness
 }

--- a/cli/app/ui_conversation_freshness.go
+++ b/cli/app/ui_conversation_freshness.go
@@ -3,7 +3,7 @@ package app
 import "builder/shared/clientui"
 
 func (m *uiModel) currentConversationFreshness() clientui.ConversationFreshness {
-	if cached := m.cachedRuntimeStatus().ConversationFreshness; cached == clientui.ConversationFreshnessEstablished || m.conversationFreshness == clientui.ConversationFreshnessFresh {
+	if cached := m.cachedRuntimeStatus().ConversationFreshness; cached == clientui.ConversationFreshnessEstablished || cached == clientui.ConversationFreshnessFresh {
 		m.conversationFreshness = cached
 	}
 	return m.conversationFreshness

--- a/cli/app/ui_event_reducers.go
+++ b/cli/app/ui_event_reducers.go
@@ -119,11 +119,46 @@ func (m *uiModel) inputAsyncReducer() uiInputAsyncFeatureReducer {
 func (r uiInputAsyncFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 	m := r.model
 	switch msg := msg.(type) {
+	case authSlashCommandRefreshedMsg:
+		m.applyAuthSlashCommandRefreshed(msg)
+		m.syncViewport()
+		return handledUIFeatureUpdate(m, nil)
 	case promptHistoryPersistErrMsg:
+		m.observeRuntimeRequestResult(msg.err)
 		if msg.err == nil {
 			return handledUIFeatureUpdate(m, nil)
 		}
 		return handledUIFeatureUpdate(m, m.setTransientStatusWithKind("prompt history persistence failed: "+msg.err.Error(), uiStatusNoticeError))
+	case localEntryPersistDoneMsg:
+		m.observeRuntimeRequestResult(msg.err)
+		if msg.err == nil {
+			return handledUIFeatureUpdate(m, nil)
+		}
+		m.logf("local_entry.persist_error notice_id=%q err=%q", msg.noticeID, msg.err.Error())
+		return handledUIFeatureUpdate(m, nil)
+	case runtimeControlDoneMsg:
+		cmd := m.applyRuntimeControlDone(msg)
+		m.syncViewport()
+		return handledUIFeatureUpdate(m, cmd)
+	case goalRuntimeDoneMsg:
+		cmd := m.applyGoalRuntimeDone(msg)
+		m.syncViewport()
+		return handledUIFeatureUpdate(m, cmd)
+	case injectedQueueCreateDoneMsg:
+		next, cmd := m.inputController().handleInjectedQueueCreateDone(msg)
+		nextModel := next.(*uiModel)
+		nextModel.syncViewport()
+		return handledUIFeatureUpdate(nextModel, cmd)
+	case injectedQueueDiscardDoneMsg:
+		next, cmd := m.inputController().handleInjectedQueueDiscardDone(msg)
+		nextModel := next.(*uiModel)
+		nextModel.syncViewport()
+		return handledUIFeatureUpdate(nextModel, cmd)
+	case queuedRuntimeWorkCheckDoneMsg:
+		next, cmd := m.inputController().handleQueuedRuntimeWorkCheckDone(msg)
+		nextModel := next.(*uiModel)
+		nextModel.syncViewport()
+		return handledUIFeatureUpdate(nextModel, cmd)
 	case submitDoneMsg:
 		next, cmd := m.inputController().handleSubmitDone(msg)
 		nextModel := next.(*uiModel)
@@ -159,9 +194,32 @@ func (r uiProcessFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			m.syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
-		m.refreshProcessEntries()
+		refreshCmd := m.requestProcessListRefresh()
 		m.syncViewport()
-		return handledUIFeatureUpdate(m, tea.Batch(waitProcessListRefresh(), m.ensureSpinnerTicking()))
+		return handledUIFeatureUpdate(m, tea.Batch(refreshCmd, waitProcessListRefresh(), m.ensureSpinnerTicking()))
+	case processListRefreshDoneMsg:
+		if msg.token != m.processList.refreshToken {
+			m.syncViewport()
+			return handledUIFeatureUpdate(m, nil)
+		}
+		m.processList.refreshInFlight = false
+		m.processList.loading = false
+		if msg.err != nil {
+			m.processList.errorText = msg.err.Error()
+		} else {
+			m.applyProcessEntries(msg.entries)
+		}
+		var refreshCmd tea.Cmd
+		if m.processList.refreshDirty && m.processList.isOpen() {
+			m.processList.refreshDirty = false
+			refreshCmd = m.requestProcessListRefresh()
+		}
+		m.syncViewport()
+		return handledUIFeatureUpdate(m, tea.Batch(refreshCmd, m.ensureSpinnerTicking()))
+	case processActionDoneMsg:
+		cmd := m.applyProcessActionDone(msg)
+		m.syncViewport()
+		return handledUIFeatureUpdate(m, cmd)
 	case openProcessLogsDoneMsg:
 		m.syncViewport()
 		if msg.err != nil {
@@ -210,7 +268,7 @@ func (r uiNativeFlushFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		return handledUIFeatureUpdate(m, m.handleNativeHistoryFlush(msg))
 	case nativeStreamingStableFlushAckMsg:
 		m.ackNativeStreamingStableFlush(msg.Sequence)
-		return handledUIFeatureUpdate(m, nil)
+		return handledUIFeatureUpdate(m, m.releaseDeferredRuntimeSyncs())
 	}
 	return uiFeatureUpdateResult{}
 }

--- a/cli/app/ui_event_reducers.go
+++ b/cli/app/ui_event_reducers.go
@@ -249,10 +249,6 @@ func (r uiClipboardFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		cmd := m.handleClipboardTextCopyDone(msg)
 		m.syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
-	case copyFinalAnswerDoneMsg:
-		cmd := m.handleCopyFinalAnswerDone(msg)
-		m.syncViewport()
-		return handledUIFeatureUpdate(m, cmd)
 	}
 	return uiFeatureUpdateResult{}
 }

--- a/cli/app/ui_event_reducers.go
+++ b/cli/app/ui_event_reducers.go
@@ -249,6 +249,10 @@ func (r uiClipboardFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		cmd := m.handleClipboardTextCopyDone(msg)
 		m.syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
+	case copyFinalAnswerDoneMsg:
+		cmd := m.handleCopyFinalAnswerDone(msg)
+		m.syncViewport()
+		return handledUIFeatureUpdate(m, cmd)
 	}
 	return uiFeatureUpdateResult{}
 }

--- a/cli/app/ui_feature_reducers_test.go
+++ b/cli/app/ui_feature_reducers_test.go
@@ -45,11 +45,61 @@ func TestUIUpdateRoutesProcessRefreshThroughReducer(t *testing.T) {
 	next, cmd := m.Update(processListRefreshTickMsg{})
 	updated := next.(*uiModel)
 
+	if len(updated.processList.entries) != 0 {
+		t.Fatalf("expected process refresh tick to defer entries until command completion, got %#v", updated.processList.entries)
+	}
+	msgs := collectCmdMessages(t, cmd)
+	var refresh processListRefreshDoneMsg
+	foundRefresh := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(processListRefreshDoneMsg); ok {
+			refresh = typed
+			foundRefresh = true
+			break
+		}
+	}
+	if !foundRefresh {
+		t.Fatalf("expected process refresh command to produce completion, got %+v", msgs)
+	}
+	next, _ = updated.Update(refresh)
+	updated = next.(*uiModel)
+
 	if len(updated.processList.entries) != 1 || updated.processList.entries[0].ID != "proc-1" {
 		t.Fatalf("expected process refresh reducer to update entries, got %#v", updated.processList.entries)
 	}
-	if cmd == nil {
-		t.Fatal("expected process refresh reducer to schedule follow-up refresh")
+}
+
+func TestProcessRefreshSingleFlightSchedulesOneDirtyFollowUp(t *testing.T) {
+	m := newProjectedStaticUIModel(WithUIProcessClient(fixedUIProcessClient{
+		entries: []clientui.BackgroundProcess{{ID: "proc-1", Command: "sleep 1"}},
+	}))
+	m.processList.open = true
+
+	first := m.requestProcessListRefresh()
+	if first == nil {
+		t.Fatal("expected first refresh command")
+	}
+	second := m.requestProcessListRefresh()
+	if second != nil {
+		t.Fatal("expected in-flight refresh to coalesce instead of starting another command")
+	}
+	if !m.processList.refreshDirty {
+		t.Fatal("expected in-flight refresh to mark dirty follow-up")
+	}
+
+	next, followUp := m.Update(processListRefreshDoneMsg{
+		token:   m.processList.refreshToken,
+		entries: []clientui.BackgroundProcess{{ID: "proc-1", Command: "sleep 1"}},
+	})
+	updated := next.(*uiModel)
+	if !updated.processList.refreshInFlight {
+		t.Fatal("expected dirty follow-up refresh to start after first completion")
+	}
+	if updated.processList.refreshDirty {
+		t.Fatal("expected dirty flag cleared after scheduling follow-up")
+	}
+	if followUp == nil {
+		t.Fatal("expected follow-up refresh command")
 	}
 }
 

--- a/cli/app/ui_goal.go
+++ b/cli/app/ui_goal.go
@@ -19,57 +19,13 @@ func (c uiInputController) handleGoalCommand(mode commands.GoalMode, objective s
 	case commands.GoalModeShow, "":
 		return m, c.startGoalFlowCmd()
 	case commands.GoalModeSet:
-		current, err := m.showRuntimeGoal()
-		if err != nil {
-			detailErr := formatSubmissionError(err)
-			return m, c.appendErrorFeedbackWithStatus(detailErr, c.showErrorStatus(detailErr))
-		}
-		if goalIsActive(current) {
-			m.openGoalConfirmOverlay("replace", current, objective, nil)
-			if overlayCmd := m.pushGoalOverlayIfNeeded(); overlayCmd != nil {
-				return m, overlayCmd
-			}
-			return m, nil
-		}
-		_, err = m.setRuntimeGoal(objective)
-		if err != nil {
-			detailErr := formatSubmissionError(err)
-			return m, c.appendErrorFeedbackWithStatus(detailErr, c.showErrorStatus(detailErr))
-		}
-		return m, c.appendGoalFeedback("Goal set")
+		return m, m.goalRuntimeCommand(goalRuntimeCheckSet, objective)
 	case commands.GoalModePause:
-		_, err := m.pauseRuntimeGoal()
-		if err != nil {
-			detailErr := formatSubmissionError(err)
-			return m, c.appendErrorFeedbackWithStatus(detailErr, c.showErrorStatus(detailErr))
-		}
-		return m, c.appendGoalFeedback("Goal paused")
+		return m, m.goalRuntimeCommand(goalRuntimePause, "")
 	case commands.GoalModeResume:
-		_, err := m.resumeRuntimeGoal()
-		if err != nil {
-			detailErr := formatSubmissionError(err)
-			return m, c.appendErrorFeedbackWithStatus(detailErr, c.showErrorStatus(detailErr))
-		}
-		return m, c.appendGoalFeedback("Goal resumed")
+		return m, m.goalRuntimeCommand(goalRuntimeResume, "")
 	case commands.GoalModeClear:
-		current, err := m.showRuntimeGoal()
-		if err != nil {
-			detailErr := formatSubmissionError(err)
-			return m, c.appendErrorFeedbackWithStatus(detailErr, c.showErrorStatus(detailErr))
-		}
-		if goalRequiresClearConfirmation(current) {
-			m.openGoalConfirmOverlay("clear", current, "", nil)
-			if overlayCmd := m.pushGoalOverlayIfNeeded(); overlayCmd != nil {
-				return m, overlayCmd
-			}
-			return m, nil
-		}
-		_, err = m.clearRuntimeGoal()
-		if err != nil {
-			detailErr := formatSubmissionError(err)
-			return m, c.appendErrorFeedbackWithStatus(detailErr, c.showErrorStatus(detailErr))
-		}
-		return m, c.appendGoalFeedback("Goal cleared")
+		return m, m.goalRuntimeCommand(goalRuntimeCheckClear, "")
 	default:
 		errText := "Usage: /goal [show|pause|resume|clear|<objective>]"
 		return m, c.appendErrorFeedbackWithStatus(errText, c.showErrorStatus(errText))
@@ -90,12 +46,8 @@ func (c uiInputController) appendGoalFeedback(text string) tea.Cmd {
 
 func (c uiInputController) startGoalFlowCmd() tea.Cmd {
 	m := c.model
-	goal, err := m.showRuntimeGoal()
-	m.openGoalOverlay(goal, err)
-	if overlayCmd := m.pushGoalOverlayIfNeeded(); overlayCmd != nil {
-		return overlayCmd
-	}
-	return nil
+	m.openGoalOverlay(nil, nil)
+	return tea.Batch(m.pushGoalOverlayIfNeeded(), m.goalRuntimeCommand(goalRuntimeShow, ""))
 }
 
 func (c uiInputController) stopGoalFlowCmd() tea.Cmd {
@@ -113,8 +65,7 @@ func (c uiInputController) handleGoalOverlayKey(msg tea.KeyMsg) (tea.Model, tea.
 	switch strings.ToLower(msg.String()) {
 	case "ctrl+c":
 		if m.isBusy() {
-			c.interruptBusyRuntime()
-			return m, nil
+			return m, c.interruptBusyRuntime()
 		}
 		m.exitAction = UIActionExit
 		if overlayCmd := m.popGoalOverlayIfNeeded(); overlayCmd != nil {
@@ -145,8 +96,7 @@ func (c uiInputController) handleGoalConfirmKey(msg tea.KeyMsg) (tea.Model, tea.
 	switch strings.ToLower(msg.String()) {
 	case "ctrl+c":
 		if m.isBusy() {
-			c.interruptBusyRuntime()
-			return m, nil
+			return m, c.interruptBusyRuntime()
 		}
 		m.exitAction = UIActionExit
 		if overlayCmd := m.popGoalOverlayIfNeeded(); overlayCmd != nil {
@@ -170,23 +120,109 @@ func (c uiInputController) handleGoalConfirmKey(msg tea.KeyMsg) (tea.Model, tea.
 		objective := m.goal.pendingObjective
 		switch mode {
 		case "replace":
-			_, err := m.setRuntimeGoal(objective)
-			if err != nil {
-				m.goal.error = err.Error()
-				return m, nil
-			}
-			overlayCmd := c.stopGoalFlowCmd()
-			return m, sequenceCmds(overlayCmd, c.appendGoalFeedback("Goal set"))
+			return m, m.goalRuntimeCommand(goalRuntimeSet, objective)
 		case "clear":
-			if _, err := m.clearRuntimeGoal(); err != nil {
-				m.goal.error = err.Error()
-				return m, nil
-			}
-			overlayCmd := c.stopGoalFlowCmd()
-			return m, sequenceCmds(overlayCmd, c.appendGoalFeedback("Goal cleared"))
+			return m, m.goalRuntimeCommand(goalRuntimeClear, "")
 		}
 	}
 	return m, nil
+}
+
+func (m *uiModel) nextGoalRuntimeToken() uint64 {
+	m.goalRuntimeToken++
+	if m.goalRuntimeToken == 0 {
+		m.goalRuntimeToken++
+	}
+	return m.goalRuntimeToken
+}
+
+func (m *uiModel) goalRuntimeCommand(operation goalRuntimeOperation, objective string) tea.Cmd {
+	if m == nil {
+		return nil
+	}
+	client := m.runtimeClient()
+	token := m.nextGoalRuntimeToken()
+	objective = strings.TrimSpace(objective)
+	if client == nil {
+		return func() tea.Msg {
+			return goalRuntimeDoneMsg{token: token, operation: operation, objective: objective}
+		}
+	}
+	sessionID := strings.TrimSpace(m.sessionID)
+	return func() tea.Msg {
+		msg := goalRuntimeDoneMsg{token: token, sessionID: sessionID, operation: operation, objective: objective}
+		switch operation {
+		case goalRuntimeShow, goalRuntimeCheckSet, goalRuntimeCheckClear:
+			msg.goal, msg.err = client.ShowGoal()
+		case goalRuntimeSet:
+			msg.goal, msg.err = client.SetGoal(objective)
+		case goalRuntimePause:
+			msg.goal, msg.err = client.PauseGoal()
+		case goalRuntimeResume:
+			msg.goal, msg.err = client.ResumeGoal()
+		case goalRuntimeClear:
+			msg.goal, msg.err = client.ClearGoal()
+		}
+		return msg
+	}
+}
+
+func (m *uiModel) applyGoalRuntimeDone(msg goalRuntimeDoneMsg) tea.Cmd {
+	if m == nil || msg.token != m.goalRuntimeToken {
+		return nil
+	}
+	if msg.sessionID != "" && strings.TrimSpace(m.sessionID) != "" && msg.sessionID != strings.TrimSpace(m.sessionID) {
+		return nil
+	}
+	m.observeRuntimeRequestResult(msg.err)
+	if msg.err != nil {
+		detailErr := formatSubmissionError(msg.err)
+		if m.goal.isOpen() {
+			m.goal.error = detailErr
+			return nil
+		}
+		return m.inputController().appendErrorFeedbackWithStatus(detailErr, m.inputController().showErrorStatus(detailErr))
+	}
+	switch msg.operation {
+	case goalRuntimeShow:
+		m.goal.goal = cloneRuntimeGoal(msg.goal)
+		m.goal.error = ""
+		return nil
+	case goalRuntimeCheckSet:
+		if goalIsActive(msg.goal) {
+			m.openGoalConfirmOverlay("replace", msg.goal, msg.objective, nil)
+			return m.pushGoalOverlayIfNeeded()
+		}
+		return m.goalRuntimeCommand(goalRuntimeSet, msg.objective)
+	case goalRuntimeCheckClear:
+		if goalRequiresClearConfirmation(msg.goal) {
+			m.openGoalConfirmOverlay("clear", msg.goal, "", nil)
+			return m.pushGoalOverlayIfNeeded()
+		}
+		return m.goalRuntimeCommand(goalRuntimeClear, "")
+	case goalRuntimeSet:
+		m.goal.goal = cloneRuntimeGoal(msg.goal)
+		overlayCmd := tea.Cmd(nil)
+		if m.goal.isOpen() && strings.TrimSpace(m.goal.confirmMode) != "" {
+			overlayCmd = m.inputController().stopGoalFlowCmd()
+		}
+		return sequenceCmds(overlayCmd, m.inputController().appendGoalFeedback("Goal set"))
+	case goalRuntimePause:
+		m.goal.goal = cloneRuntimeGoal(msg.goal)
+		return m.inputController().appendGoalFeedback("Goal paused")
+	case goalRuntimeResume:
+		m.goal.goal = cloneRuntimeGoal(msg.goal)
+		return m.inputController().appendGoalFeedback("Goal resumed")
+	case goalRuntimeClear:
+		m.goal.goal = nil
+		overlayCmd := tea.Cmd(nil)
+		if m.goal.isOpen() && strings.TrimSpace(m.goal.confirmMode) != "" {
+			overlayCmd = m.inputController().stopGoalFlowCmd()
+		}
+		return sequenceCmds(overlayCmd, m.inputController().appendGoalFeedback("Goal cleared"))
+	default:
+		return nil
+	}
 }
 
 func (m *uiModel) openGoalOverlay(goal *clientui.RuntimeGoal, err error) {

--- a/cli/app/ui_goal.go
+++ b/cli/app/ui_goal.go
@@ -242,53 +242,55 @@ func (m *uiModel) applyGoalRuntimeDone(msg goalRuntimeDoneMsg) tea.Cmd {
 		}
 		return m.inputController().appendErrorFeedbackWithStatus(detailErr, m.inputController().showErrorStatus(detailErr))
 	}
+	var followUpCmd tea.Cmd
 	if goalRuntimeOperationMutates(msg.operation) {
 		pending := m.goalRuntimePending
 		if pending.inFlight && (pending.desiredOperation != pending.inFlightOperation || pending.desiredObjective != pending.inFlightObjective) {
 			m.goalRuntimePending.inFlight = false
-			return m.goalRuntimeCommand(pending.desiredOperation, pending.desiredObjective)
+			followUpCmd = m.goalRuntimeCommand(pending.desiredOperation, pending.desiredObjective)
+		} else {
+			m.goalRuntimePending = goalRuntimePendingState{}
 		}
-		m.goalRuntimePending = goalRuntimePendingState{}
 	}
 	switch msg.operation {
 	case goalRuntimeShow:
 		m.goal.goal = cloneRuntimeGoal(msg.goal)
 		m.goal.error = ""
-		return nil
+		return followUpCmd
 	case goalRuntimeCheckSet:
 		if goalIsActive(msg.goal) {
 			m.openGoalConfirmOverlay("replace", msg.goal, msg.objective, nil)
-			return m.pushGoalOverlayIfNeeded()
+			return sequenceCmds(m.pushGoalOverlayIfNeeded(), followUpCmd)
 		}
-		return m.goalRuntimeCommand(goalRuntimeSet, msg.objective)
+		return sequenceCmds(m.goalRuntimeCommand(goalRuntimeSet, msg.objective), followUpCmd)
 	case goalRuntimeCheckClear:
 		if goalRequiresClearConfirmation(msg.goal) {
 			m.openGoalConfirmOverlay("clear", msg.goal, "", nil)
-			return m.pushGoalOverlayIfNeeded()
+			return sequenceCmds(m.pushGoalOverlayIfNeeded(), followUpCmd)
 		}
-		return m.goalRuntimeCommand(goalRuntimeClear, "")
+		return sequenceCmds(m.goalRuntimeCommand(goalRuntimeClear, ""), followUpCmd)
 	case goalRuntimeSet:
 		m.goal.goal = cloneRuntimeGoal(msg.goal)
 		overlayCmd := tea.Cmd(nil)
 		if m.goal.isOpen() && strings.TrimSpace(m.goal.confirmMode) != "" {
 			overlayCmd = m.inputController().stopGoalFlowCmd()
 		}
-		return sequenceCmds(overlayCmd, m.inputController().appendGoalFeedback("Goal set"))
+		return sequenceCmds(overlayCmd, m.inputController().appendGoalFeedback("Goal set"), followUpCmd)
 	case goalRuntimePause:
 		m.goal.goal = cloneRuntimeGoal(msg.goal)
-		return m.inputController().appendGoalFeedback("Goal paused")
+		return sequenceCmds(m.inputController().appendGoalFeedback("Goal paused"), followUpCmd)
 	case goalRuntimeResume:
 		m.goal.goal = cloneRuntimeGoal(msg.goal)
-		return m.inputController().appendGoalFeedback("Goal resumed")
+		return sequenceCmds(m.inputController().appendGoalFeedback("Goal resumed"), followUpCmd)
 	case goalRuntimeClear:
 		m.goal.goal = nil
 		overlayCmd := tea.Cmd(nil)
 		if m.goal.isOpen() && strings.TrimSpace(m.goal.confirmMode) != "" {
 			overlayCmd = m.inputController().stopGoalFlowCmd()
 		}
-		return sequenceCmds(overlayCmd, m.inputController().appendGoalFeedback("Goal cleared"))
+		return sequenceCmds(overlayCmd, m.inputController().appendGoalFeedback("Goal cleared"), followUpCmd)
 	default:
-		return nil
+		return followUpCmd
 	}
 }
 

--- a/cli/app/ui_goal.go
+++ b/cli/app/ui_goal.go
@@ -164,6 +164,7 @@ func (m *uiModel) beginGoalRuntimeMutation(operation goalRuntimeOperation, sessi
 	if !goalRuntimeOperationMutates(operation) {
 		return m.nextGoalRuntimeToken(), true
 	}
+	m.goalRuntimeMutationSerial = nextNonZeroToken(m.goalRuntimeMutationSerial)
 	if m.goalRuntimePending.inFlight && m.goalRuntimePending.sessionID == sessionID {
 		m.goalRuntimePending.desiredOperation = operation
 		m.goalRuntimePending.desiredObjective = objective
@@ -189,17 +190,18 @@ func (m *uiModel) goalRuntimeCommand(operation goalRuntimeOperation, objective s
 	client := m.runtimeClient()
 	objective = strings.TrimSpace(objective)
 	sessionID := strings.TrimSpace(m.sessionID)
+	mutationSerial := m.goalRuntimeMutationSerial
 	token, shouldStart := m.beginGoalRuntimeMutation(operation, sessionID, objective)
 	if !shouldStart {
 		return nil
 	}
 	if client == nil {
 		return func() tea.Msg {
-			return goalRuntimeDoneMsg{token: token, operation: operation, objective: objective}
+			return goalRuntimeDoneMsg{token: token, mutationSerial: mutationSerial, operation: operation, objective: objective}
 		}
 	}
 	return func() tea.Msg {
-		msg := goalRuntimeDoneMsg{token: token, sessionID: sessionID, operation: operation, objective: objective}
+		msg := goalRuntimeDoneMsg{token: token, sessionID: sessionID, mutationSerial: mutationSerial, operation: operation, objective: objective}
 		switch operation {
 		case goalRuntimeShow, goalRuntimeCheckSet, goalRuntimeCheckClear:
 			msg.goal, msg.err = client.ShowGoal()
@@ -258,12 +260,18 @@ func (m *uiModel) applyGoalRuntimeDone(msg goalRuntimeDoneMsg) tea.Cmd {
 		m.goal.error = ""
 		return followUpCmd
 	case goalRuntimeCheckSet:
+		if msg.mutationSerial != m.goalRuntimeMutationSerial {
+			return followUpCmd
+		}
 		if goalIsActive(msg.goal) {
 			m.openGoalConfirmOverlay("replace", msg.goal, msg.objective, nil)
 			return sequenceCmds(m.pushGoalOverlayIfNeeded(), followUpCmd)
 		}
 		return sequenceCmds(m.goalRuntimeCommand(goalRuntimeSet, msg.objective), followUpCmd)
 	case goalRuntimeCheckClear:
+		if msg.mutationSerial != m.goalRuntimeMutationSerial {
+			return followUpCmd
+		}
 		if goalRequiresClearConfirmation(msg.goal) {
 			m.openGoalConfirmOverlay("clear", msg.goal, "", nil)
 			return sequenceCmds(m.pushGoalOverlayIfNeeded(), followUpCmd)

--- a/cli/app/ui_goal.go
+++ b/cli/app/ui_goal.go
@@ -136,19 +136,68 @@ func (m *uiModel) nextGoalRuntimeToken() uint64 {
 	return m.goalRuntimeToken
 }
 
+type goalRuntimePendingState struct {
+	token             uint64
+	sessionID         string
+	inFlight          bool
+	inFlightOperation goalRuntimeOperation
+	inFlightObjective string
+	desiredOperation  goalRuntimeOperation
+	desiredObjective  string
+}
+
+func goalRuntimeOperationMutates(operation goalRuntimeOperation) bool {
+	switch operation {
+	case goalRuntimeSet, goalRuntimePause, goalRuntimeResume, goalRuntimeClear:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *uiModel) beginGoalRuntimeMutation(operation goalRuntimeOperation, sessionID, objective string) (uint64, bool) {
+	if m == nil {
+		return 0, false
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	objective = strings.TrimSpace(objective)
+	if !goalRuntimeOperationMutates(operation) {
+		return m.nextGoalRuntimeToken(), true
+	}
+	if m.goalRuntimePending.inFlight && m.goalRuntimePending.sessionID == sessionID {
+		m.goalRuntimePending.desiredOperation = operation
+		m.goalRuntimePending.desiredObjective = objective
+		return 0, false
+	}
+	token := m.nextGoalRuntimeToken()
+	m.goalRuntimePending = goalRuntimePendingState{
+		token:             token,
+		sessionID:         sessionID,
+		inFlight:          true,
+		inFlightOperation: operation,
+		inFlightObjective: objective,
+		desiredOperation:  operation,
+		desiredObjective:  objective,
+	}
+	return token, true
+}
+
 func (m *uiModel) goalRuntimeCommand(operation goalRuntimeOperation, objective string) tea.Cmd {
 	if m == nil {
 		return nil
 	}
 	client := m.runtimeClient()
-	token := m.nextGoalRuntimeToken()
 	objective = strings.TrimSpace(objective)
+	sessionID := strings.TrimSpace(m.sessionID)
+	token, shouldStart := m.beginGoalRuntimeMutation(operation, sessionID, objective)
+	if !shouldStart {
+		return nil
+	}
 	if client == nil {
 		return func() tea.Msg {
 			return goalRuntimeDoneMsg{token: token, operation: operation, objective: objective}
 		}
 	}
-	sessionID := strings.TrimSpace(m.sessionID)
 	return func() tea.Msg {
 		msg := goalRuntimeDoneMsg{token: token, sessionID: sessionID, operation: operation, objective: objective}
 		switch operation {
@@ -168,7 +217,14 @@ func (m *uiModel) goalRuntimeCommand(operation goalRuntimeOperation, objective s
 }
 
 func (m *uiModel) applyGoalRuntimeDone(msg goalRuntimeDoneMsg) tea.Cmd {
-	if m == nil || msg.token != m.goalRuntimeToken {
+	if m == nil {
+		return nil
+	}
+	if goalRuntimeOperationMutates(msg.operation) {
+		if msg.token != m.goalRuntimePending.token {
+			return nil
+		}
+	} else if msg.token != m.goalRuntimeToken {
 		return nil
 	}
 	if msg.sessionID != "" && strings.TrimSpace(m.sessionID) != "" && msg.sessionID != strings.TrimSpace(m.sessionID) {
@@ -176,12 +232,23 @@ func (m *uiModel) applyGoalRuntimeDone(msg goalRuntimeDoneMsg) tea.Cmd {
 	}
 	m.observeRuntimeRequestResult(msg.err)
 	if msg.err != nil {
+		if goalRuntimeOperationMutates(msg.operation) {
+			m.goalRuntimePending = goalRuntimePendingState{}
+		}
 		detailErr := formatSubmissionError(msg.err)
 		if m.goal.isOpen() {
 			m.goal.error = detailErr
 			return nil
 		}
 		return m.inputController().appendErrorFeedbackWithStatus(detailErr, m.inputController().showErrorStatus(detailErr))
+	}
+	if goalRuntimeOperationMutates(msg.operation) {
+		pending := m.goalRuntimePending
+		if pending.inFlight && (pending.desiredOperation != pending.inFlightOperation || pending.desiredObjective != pending.inFlightObjective) {
+			m.goalRuntimePending.inFlight = false
+			return m.goalRuntimeCommand(pending.desiredOperation, pending.desiredObjective)
+		}
+		m.goalRuntimePending = goalRuntimePendingState{}
 	}
 	switch msg.operation {
 	case goalRuntimeShow:

--- a/cli/app/ui_goal_test.go
+++ b/cli/app/ui_goal_test.go
@@ -11,13 +11,29 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+func applyGoalCmdMessagesForTest(t *testing.T, model *uiModel, cmd tea.Cmd) *uiModel {
+	t.Helper()
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, nextCmd := model.Update(msg)
+		model = next.(*uiModel)
+		model = applyGoalCmdMessagesForTest(t, model, nextCmd)
+	}
+	return model
+}
+
+func updateGoalForTest(t *testing.T, model *uiModel, msg tea.Msg) *uiModel {
+	t.Helper()
+	next, cmd := model.Update(msg)
+	return applyGoalCmdMessagesForTest(t, next.(*uiModel), cmd)
+}
+
 func TestGoalCommandOpensGoalOverlay(t *testing.T) {
 	client := &runtimeControlFakeClient{goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: "active"}}
 	m := newSizedProjectedClosedUIModel(client, 100, 20)
 	m.input = "/goal"
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
+	updated := applyGoalCmdMessagesForTest(t, next.(*uiModel), cmd)
 	if !updated.goal.isOpen() {
 		t.Fatal("expected /goal to open goal overlay")
 	}
@@ -48,8 +64,7 @@ func TestGoalCommandOpensGoalOverlayWhileBusy(t *testing.T) {
 	m.activity = uiActivityRunning
 	m.input = "/goal"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
+	updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	if !updated.goal.isOpen() {
 		t.Fatal("expected /goal to open goal overlay while busy")
 	}
@@ -82,8 +97,7 @@ func TestGoalSetRendersCommittedGoalFeedbackBeforeLaterRuntimeEvents(t *testing.
 	m := newSizedProjectedRuntimeEventsUIModel(client, runtimeEvents, 100, 20)
 	m.input = "/goal ship feature"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
+	updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	if client.setGoalArg != "ship feature" {
 		t.Fatalf("set goal arg = %q, want ship feature", client.setGoalArg)
 	}
@@ -95,7 +109,7 @@ func TestGoalSetRendersCommittedGoalFeedbackBeforeLaterRuntimeEvents(t *testing.
 	if len(batch.events) != 1 || batch.events[0].AssistantDelta != "" {
 		t.Fatalf("expected first runtime batch to contain only goal feedback, got %+v", batch.events)
 	}
-	next, _ = updated.Update(batch)
+	next, _ := updated.Update(batch)
 	updated = next.(*uiModel)
 
 	if view := stripANSIAndTrimRight(updated.view.OngoingSnapshot()); !strings.Contains(view, `Goal set: "ship feature"`) {
@@ -153,10 +167,8 @@ func TestGoalLifecycleCommandsDoNotAppendDuplicateLocalFeedback(t *testing.T) {
 			initialGoal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: "active"},
 			drive: func(t *testing.T, m *uiModel, client *runtimeControlFakeClient) *uiModel {
 				t.Helper()
-				next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-				updated := next.(*uiModel)
-				next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
-				return next.(*uiModel)
+				updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+				return updateGoalForTest(t, updated, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 			},
 			check: func(t *testing.T, client *runtimeControlFakeClient) {
 				t.Helper()
@@ -177,8 +189,7 @@ func TestGoalLifecycleCommandsDoNotAppendDuplicateLocalFeedback(t *testing.T) {
 			if tt.drive != nil {
 				updated = tt.drive(t, m, client)
 			} else {
-				next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-				updated = next.(*uiModel)
+				updated = updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 			}
 			tt.check(t, client)
 			if client.appendedRole != "" || client.appendedText != "" {
@@ -198,8 +209,7 @@ func TestGoalCommandWithoutGoalShowsLocalHint(t *testing.T) {
 	m := newSizedProjectedClosedUIModel(&runtimeControlFakeClient{}, 100, 20)
 	m.input = "/goal"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
+	updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	plain := stripANSIAndTrimRight(updated.View())
 	if !strings.Contains(plain, noGoalHint) {
 		t.Fatalf("expected no-goal hint %q, got %q", noGoalHint, plain)
@@ -211,8 +221,7 @@ func TestGoalClearActiveGoalRequiresConfirmation(t *testing.T) {
 	m := newSizedProjectedClosedUIModel(client, 100, 20)
 	m.input = "/goal clear"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
+	updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	if !updated.goal.isOpen() || updated.goal.confirmMode != "clear" {
 		t.Fatalf("expected clear confirmation overlay, got %+v", updated.goal)
 	}
@@ -223,8 +232,7 @@ func TestGoalClearActiveGoalRequiresConfirmation(t *testing.T) {
 		t.Fatalf("expected clear confirmation text, got %q", plain)
 	}
 
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
-	updated = next.(*uiModel)
+	updated = updateGoalForTest(t, updated, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if updated.goal.isOpen() {
 		t.Fatal("expected goal overlay closed after confirm")
 	}
@@ -238,8 +246,7 @@ func TestGoalClearSuspendedActiveGoalSkipsConfirmation(t *testing.T) {
 	m := newSizedProjectedClosedUIModel(client, 100, 20)
 	m.input = "/goal clear"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
+	updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	if updated.goal.isOpen() {
 		t.Fatalf("expected suspended active clear to skip confirmation, got %+v", updated.goal)
 	}
@@ -253,10 +260,8 @@ func TestGoalConfirmationEnterUsesSelectedAction(t *testing.T) {
 	m := newSizedProjectedClosedUIModel(client, 100, 20)
 	m.input = "/goal clear"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated = next.(*uiModel)
+	updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updateGoalForTest(t, updated, tea.KeyMsg{Type: tea.KeyEnter})
 	if updated.goal.isOpen() {
 		t.Fatal("expected default cancel selection to close overlay")
 	}
@@ -266,12 +271,9 @@ func TestGoalConfirmationEnterUsesSelectedAction(t *testing.T) {
 
 	m = newSizedProjectedClosedUIModel(client, 100, 20)
 	m.input = "/goal clear"
-	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated = next.(*uiModel)
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyTab})
-	updated = next.(*uiModel)
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated = next.(*uiModel)
+	updated = updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updateGoalForTest(t, updated, tea.KeyMsg{Type: tea.KeyTab})
+	updated = updateGoalForTest(t, updated, tea.KeyMsg{Type: tea.KeyEnter})
 	if updated.goal.isOpen() {
 		t.Fatal("expected confirm selection to close overlay")
 	}
@@ -287,8 +289,7 @@ func TestGoalSetWhileBusyCanReplaceActiveGoalWithConfirmation(t *testing.T) {
 	m.activity = uiActivityRunning
 	m.input = "/goal new goal"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
+	updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	if !updated.goal.isOpen() || updated.goal.confirmMode != "replace" || updated.goal.pendingObjective != "new goal" {
 		t.Fatalf("expected busy replace confirmation overlay, got %+v", updated.goal)
 	}
@@ -296,8 +297,7 @@ func TestGoalSetWhileBusyCanReplaceActiveGoalWithConfirmation(t *testing.T) {
 		t.Fatalf("set goal before confirm = %q, want empty", client.setGoalArg)
 	}
 
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
-	updated = next.(*uiModel)
+	updated = updateGoalForTest(t, updated, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if updated.goal.isOpen() {
 		t.Fatal("expected goal overlay closed after confirm")
 	}
@@ -311,8 +311,7 @@ func TestGoalOverlayRendersObjectiveMarkdown(t *testing.T) {
 	m := newSizedProjectedClosedUIModel(client, 100, 20)
 	m.input = "/goal"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
+	updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	raw := updated.View()
 	plain := stripANSIAndTrimRight(raw)
 	if strings.Contains(plain, "**bold**") {
@@ -332,8 +331,7 @@ func TestGoalOverlayWrapsLongMarkdownObjective(t *testing.T) {
 	m := newSizedProjectedClosedUIModel(client, 32, 20)
 	m.input = "/goal"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
+	updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	plain := stripANSIAndTrimRight(updated.View())
 	if !strings.Contains(plain, "visible after wrapping") {
 		t.Fatalf("expected long markdown objective tail to survive wrapping, got %q", plain)
@@ -346,8 +344,7 @@ func TestGoalOverlayWrapsLongMarkdownListItem(t *testing.T) {
 	m := newSizedProjectedClosedUIModel(client, 34, 20)
 	m.input = "/goal"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
+	updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	plain := stripANSIAndTrimRight(updated.View())
 	if !strings.Contains(plain, "after wrapping") {
 		t.Fatalf("expected long markdown list item tail to survive wrapping, got %q", plain)
@@ -360,8 +357,7 @@ func TestGoalOverlayMarkdownCacheRewrapsAfterWidthChange(t *testing.T) {
 	m := newSizedProjectedClosedUIModel(client, 80, 20)
 	m.input = "/goal"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
+	updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	wide := stripANSIAndTrimRight(updated.View())
 	if !strings.Contains(wide, "important goal objective must change wrapping") {
 		t.Fatalf("expected wide render to keep phrase on one line, got %q", wide)
@@ -382,8 +378,7 @@ func TestGoalReplaceActiveGoalRequiresConfirmation(t *testing.T) {
 	m := newSizedProjectedClosedUIModel(client, 100, 20)
 	m.input = "/goal new goal"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated := next.(*uiModel)
+	updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	if !updated.goal.isOpen() || updated.goal.confirmMode != "replace" || updated.goal.pendingObjective != "new goal" {
 		t.Fatalf("expected replace confirmation overlay, got %+v", updated.goal)
 	}
@@ -394,8 +389,7 @@ func TestGoalReplaceActiveGoalRequiresConfirmation(t *testing.T) {
 		t.Fatalf("expected replace confirmation text, got %q", plain)
 	}
 
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
-	updated = next.(*uiModel)
+	updated = updateGoalForTest(t, updated, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if updated.goal.isOpen() {
 		t.Fatal("expected goal overlay closed after confirm")
 	}

--- a/cli/app/ui_goal_test.go
+++ b/cli/app/ui_goal_test.go
@@ -76,6 +76,43 @@ func TestGoalCommandOpensGoalOverlayWhileBusy(t *testing.T) {
 	}
 }
 
+func TestGoalMutationsCoalesceWhileInFlight(t *testing.T) {
+	client := &runtimeControlFakeClient{goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusPaused}}
+	m := newProjectedClosedUIModel(client)
+
+	firstCmd := m.goalRuntimeCommand(goalRuntimePause, "")
+	if firstCmd == nil {
+		t.Fatal("expected first goal mutation command")
+	}
+	secondCmd := m.goalRuntimeCommand(goalRuntimeResume, "")
+	if secondCmd != nil {
+		t.Fatal("did not expect second goal mutation command while first is in flight")
+	}
+	firstMsgs := collectCmdMessages(t, firstCmd)
+	if client.pauseGoalCalls != 1 || client.resumeGoalCalls != 0 {
+		t.Fatalf("unexpected pre-completion goal calls: pause=%d resume=%d", client.pauseGoalCalls, client.resumeGoalCalls)
+	}
+
+	var firstDone goalRuntimeDoneMsg
+	for _, msg := range firstMsgs {
+		if typed, ok := msg.(goalRuntimeDoneMsg); ok {
+			firstDone = typed
+		}
+	}
+	next, followUpCmd := m.Update(firstDone)
+	updated := next.(*uiModel)
+	if followUpCmd == nil {
+		t.Fatal("expected follow-up goal mutation command")
+	}
+	if updated.goal.goal != nil && updated.goal.goal.Status == clientui.RuntimeGoalStatusPaused {
+		t.Fatal("expected older pause completion not to update goal UI while resume is queued")
+	}
+	_ = collectCmdMessages(t, followUpCmd)
+	if client.resumeGoalCalls != 1 {
+		t.Fatalf("expected serialized resume call after pause completion, got %d", client.resumeGoalCalls)
+	}
+}
+
 func TestGoalSetRendersCommittedGoalFeedbackBeforeLaterRuntimeEvents(t *testing.T) {
 	runtimeEvents := make(chan clientui.Event, 2)
 	runtimeEvents <- clientui.Event{

--- a/cli/app/ui_goal_test.go
+++ b/cli/app/ui_goal_test.go
@@ -76,7 +76,7 @@ func TestGoalCommandOpensGoalOverlayWhileBusy(t *testing.T) {
 	}
 }
 
-func TestGoalMutationsCoalesceWhileInFlight(t *testing.T) {
+func TestGoalMutationsCoalesceAfterApplyingInFlightCompletion(t *testing.T) {
 	client := &runtimeControlFakeClient{goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusPaused}}
 	m := newProjectedClosedUIModel(client)
 
@@ -104,8 +104,8 @@ func TestGoalMutationsCoalesceWhileInFlight(t *testing.T) {
 	if followUpCmd == nil {
 		t.Fatal("expected follow-up goal mutation command")
 	}
-	if updated.goal.goal != nil && updated.goal.goal.Status == clientui.RuntimeGoalStatusPaused {
-		t.Fatal("expected older pause completion not to update goal UI while resume is queued")
+	if updated.goal.goal == nil || updated.goal.goal.Status != clientui.RuntimeGoalStatusPaused {
+		t.Fatalf("expected pause completion to update goal UI before follow-up, got %+v", updated.goal.goal)
 	}
 	_ = collectCmdMessages(t, followUpCmd)
 	if client.resumeGoalCalls != 1 {

--- a/cli/app/ui_goal_test.go
+++ b/cli/app/ui_goal_test.go
@@ -113,6 +113,50 @@ func TestGoalMutationsCoalesceAfterApplyingInFlightCompletion(t *testing.T) {
 	}
 }
 
+func TestGoalPreflightDoesNotStartMutationAfterLaterMutation(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedClosedUIModel(client)
+
+	checkCmd := m.goalRuntimeCommand(goalRuntimeCheckSet, "older objective")
+	if checkCmd == nil {
+		t.Fatal("expected goal check command")
+	}
+	pauseCmd := m.goalRuntimeCommand(goalRuntimePause, "")
+	if pauseCmd == nil {
+		t.Fatal("expected later goal pause command")
+	}
+
+	var pauseDone goalRuntimeDoneMsg
+	for _, msg := range collectCmdMessages(t, pauseCmd) {
+		if typed, ok := msg.(goalRuntimeDoneMsg); ok {
+			pauseDone = typed
+		}
+	}
+	next, _ := m.Update(pauseDone)
+	updated := next.(*uiModel)
+	if updated.goal.goal == nil || updated.goal.goal.Status != clientui.RuntimeGoalStatusPaused {
+		t.Fatalf("expected later pause mutation to apply, got %+v", updated.goal.goal)
+	}
+
+	var checkDone goalRuntimeDoneMsg
+	for _, msg := range collectCmdMessages(t, checkCmd) {
+		if typed, ok := msg.(goalRuntimeDoneMsg); ok {
+			checkDone = typed
+		}
+	}
+	next, followCmd := updated.Update(checkDone)
+	updated = next.(*uiModel)
+	if followCmd != nil {
+		t.Fatal("did not expect stale preflight to schedule older set-goal mutation")
+	}
+	if client.setGoalArg != "" {
+		t.Fatalf("stale preflight started set-goal mutation for %q", client.setGoalArg)
+	}
+	if updated.goal.goal == nil || updated.goal.goal.Status != clientui.RuntimeGoalStatusPaused {
+		t.Fatalf("expected stale preflight not to overwrite later pause, got %+v", updated.goal.goal)
+	}
+}
+
 func TestGoalSetRendersCommittedGoalFeedbackBeforeLaterRuntimeEvents(t *testing.T) {
 	runtimeEvents := make(chan clientui.Event, 2)
 	runtimeEvents <- clientui.Event{

--- a/cli/app/ui_input_buffer.go
+++ b/cli/app/ui_input_buffer.go
@@ -27,7 +27,7 @@ func (m *uiModel) replaceMainInput(text string, cursor int) {
 	m.input = text
 	m.inputCursor = cursor
 	m.syncPromptHistorySelectionToInput()
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 }
 
 func (m *uiModel) clearInput() {
@@ -56,7 +56,7 @@ func (m *uiModel) backspaceInput() bool {
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 	return true
 }
 
@@ -69,7 +69,7 @@ func (m *uiModel) deleteForwardInput() bool {
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 	return true
 }
 
@@ -83,7 +83,7 @@ func (m *uiModel) deleteBackwardWordInput() bool {
 	m.inputCursor = nextCursor
 	m.inputKillBuffer = killBuffer
 	m.syncPromptHistorySelectionToInput()
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 	return true
 }
 
@@ -97,7 +97,7 @@ func (m *uiModel) deleteForwardWordInput() bool {
 	m.inputCursor = nextCursor
 	m.inputKillBuffer = killBuffer
 	m.syncPromptHistorySelectionToInput()
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 	return true
 }
 
@@ -111,7 +111,7 @@ func (m *uiModel) killInputToLineStart() bool {
 	m.inputCursor = nextCursor
 	m.inputKillBuffer = killBuffer
 	m.syncPromptHistorySelectionToInput()
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 	return true
 }
 
@@ -125,7 +125,7 @@ func (m *uiModel) killInputToLineEnd() bool {
 	m.inputCursor = nextCursor
 	m.inputKillBuffer = killBuffer
 	m.syncPromptHistorySelectionToInput()
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 	return true
 }
 
@@ -138,51 +138,51 @@ func (m *uiModel) yankInput() bool {
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 	return true
 }
 
 func (m *uiModel) moveCursorLeft() {
 	m.inputCursor = moveBufferCursorLeft(m.input, m.inputCursor)
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 }
 
 func (m *uiModel) moveCursorRight() {
 	m.inputCursor = moveBufferCursorRight(m.input, m.inputCursor)
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 }
 
 func (m *uiModel) moveCursorStart() {
 	m.inputCursor = moveBufferCursorStart()
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 }
 
 func (m *uiModel) moveCursorEnd() {
 	m.inputCursor = moveBufferCursorEnd()
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 }
 
 func (m *uiModel) moveCursorWordLeft() {
 	m.inputCursor = moveBufferCursorWordLeft(m.input, m.inputCursor)
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 }
 
 func (m *uiModel) moveCursorWordRight() {
 	m.inputCursor = moveBufferCursorWordRight(m.input, m.inputCursor)
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 }
 
 func (m *uiModel) moveCursorUpLine() bool {
 	nextCursor, moved := moveBufferCursorUpLine(m.input, m.inputCursor, m.effectiveWidth(), m.layout().mainInputPrefix())
 	m.inputCursor = nextCursor
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 	return moved
 }
 
 func (m *uiModel) moveCursorDownLine() bool {
 	nextCursor, moved := moveBufferCursorDownLine(m.input, m.inputCursor, m.effectiveWidth(), m.layout().mainInputPrefix())
 	m.inputCursor = nextCursor
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 	return moved
 }
 
@@ -195,7 +195,7 @@ func (m *uiModel) deleteCurrentInputLine() bool {
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()
-	m.refreshAutocompleteFromInput()
+	m.refreshAutocompleteStateFromInput()
 	return true
 }
 

--- a/cli/app/ui_input_buffer.go
+++ b/cli/app/ui_input_buffer.go
@@ -1,6 +1,10 @@
 package app
 
-import tuiinput "builder/cli/tui/input"
+import (
+	tuiinput "builder/cli/tui/input"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
 
 func (m *uiModel) cursorIndex() int {
 	return bufferCursorIndex(m.input, m.inputCursor)
@@ -31,15 +35,16 @@ func (m *uiModel) clearInput() {
 	m.resetPromptHistoryNavigation()
 }
 
-func (m *uiModel) insertInputRunes(chars []rune) {
+func (m *uiModel) insertInputRunes(chars []rune) tea.Cmd {
 	updated, nextCursor, ok := insertBufferRunes(m.input, m.inputCursor, chars)
 	if !ok {
-		return
+		return nil
 	}
+	m.invalidateMainInputDraftToken()
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()
-	m.refreshAutocompleteFromInput()
+	return m.refreshAutocompleteFromInput()
 }
 
 func (m *uiModel) backspaceInput() bool {
@@ -47,6 +52,7 @@ func (m *uiModel) backspaceInput() bool {
 	if !ok {
 		return false
 	}
+	m.invalidateMainInputDraftToken()
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()
@@ -59,6 +65,7 @@ func (m *uiModel) deleteForwardInput() bool {
 	if !ok {
 		return false
 	}
+	m.invalidateMainInputDraftToken()
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()
@@ -71,6 +78,7 @@ func (m *uiModel) deleteBackwardWordInput() bool {
 	if !ok {
 		return false
 	}
+	m.invalidateMainInputDraftToken()
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.inputKillBuffer = killBuffer
@@ -84,6 +92,7 @@ func (m *uiModel) deleteForwardWordInput() bool {
 	if !ok {
 		return false
 	}
+	m.invalidateMainInputDraftToken()
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.inputKillBuffer = killBuffer
@@ -97,6 +106,7 @@ func (m *uiModel) killInputToLineStart() bool {
 	if !ok {
 		return false
 	}
+	m.invalidateMainInputDraftToken()
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.inputKillBuffer = killBuffer
@@ -110,6 +120,7 @@ func (m *uiModel) killInputToLineEnd() bool {
 	if !ok {
 		return false
 	}
+	m.invalidateMainInputDraftToken()
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.inputKillBuffer = killBuffer
@@ -123,6 +134,7 @@ func (m *uiModel) yankInput() bool {
 	if !ok {
 		return false
 	}
+	m.invalidateMainInputDraftToken()
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()
@@ -179,6 +191,7 @@ func (m *uiModel) deleteCurrentInputLine() bool {
 	if !ok {
 		return false
 	}
+	m.invalidateMainInputDraftToken()
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()

--- a/cli/app/ui_input_controller.go
+++ b/cli/app/ui_input_controller.go
@@ -7,11 +7,26 @@ import (
 
 	"builder/cli/app/internal/submissionerror"
 	"builder/cli/tui"
+	"builder/shared/clientui"
 	"builder/shared/transcript"
 
 	bubblespinner "github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+const localEntryEchoRetentionLimit = 512
+
+type uiLocalEntryEchoStatus uint8
+
+const (
+	uiLocalEntryEchoPending uiLocalEntryEchoStatus = iota + 1
+	uiLocalEntryEchoAcknowledged
+)
+
+type uiLocalEntryEchoState struct {
+	entries map[string]uiLocalEntryEchoStatus
+	order   []string
+}
 
 // Operator-facing turn-start failures must stay visible in ongoing scrollback.
 // Plain "error" remains reserved for detail-only diagnostics and raw failures.
@@ -185,10 +200,10 @@ func isInterruptedRuntimeError(err error) bool {
 	return submissionerror.IsInterrupted(err)
 }
 
-func (c uiInputController) interruptBusyRuntime() {
+func (c uiInputController) interruptBusyRuntime() tea.Cmd {
 	m := c.model
-	_ = m.interruptRuntime()
 	m.setPendingInterrupt(true)
+	return m.runtimeControlCommand(runtimeControlInterrupt, "", false, "")
 }
 
 func parseUserShellCommand(text string) (string, bool) {
@@ -214,12 +229,16 @@ func (m *uiModel) appendLocalEntryWithNoticeID(role, text, noticeID string) tea.
 	if role == "" || text == "" {
 		return nil
 	}
-	if m.hasRuntimeClient() {
-		if err := m.appendRuntimeLocalEntryWithNoticeID(role, text, noticeID); err == nil {
-			return nil
-		}
+	if noticeID == "" {
+		noticeID = m.nextLocalNoticeID()
 	}
-	return m.appendLocalEntryFallbackWithNoticeID(role, text, noticeID)
+	localCmd := m.appendLocalEntryFallbackWithNoticeID(role, text, noticeID)
+	if !m.hasRuntimeClient() {
+		return localCmd
+	}
+	m.trackPendingLocalEntryEcho(noticeID)
+	persistCmd := m.persistLocalEntryCmd(role, text, noticeID)
+	return sequenceCmds(localCmd, persistCmd)
 }
 
 func (m *uiModel) appendLocalEntryFallbackWithVisibility(role, text string, visibility transcript.EntryVisibility) tea.Cmd {
@@ -241,4 +260,133 @@ func (m *uiModel) appendLocalEntryFallbackWithNoticeIDAndVisibility(role, text, 
 	m.refreshRollbackCandidates()
 	m.forwardToView(tui.AppendTranscriptMsg{Visibility: entry.Visibility, Role: transcriptRole, Text: text, NoticeID: entry.NoticeID})
 	return m.syncNativeHistoryFromTranscript()
+}
+
+func (m *uiModel) persistLocalEntryCmd(role, text, noticeID string) tea.Cmd {
+	client := m.runtimeClient()
+	if client == nil {
+		return nil
+	}
+	role = strings.TrimSpace(role)
+	text = strings.TrimSpace(text)
+	noticeID = strings.TrimSpace(noticeID)
+	return func() tea.Msg {
+		err := client.AppendLocalEntryWithNoticeID(role, text, noticeID)
+		return localEntryPersistDoneMsg{noticeID: noticeID, err: err}
+	}
+}
+
+func (m *uiModel) trackPendingLocalEntryEcho(noticeID string) {
+	m.trackLocalEntryEcho(noticeID, uiLocalEntryEchoPending)
+}
+
+func (m *uiModel) trackLocalEntryEcho(noticeID string, status uiLocalEntryEchoStatus) {
+	if m == nil {
+		return
+	}
+	noticeID = strings.TrimSpace(noticeID)
+	if noticeID == "" {
+		return
+	}
+	if m.localEntryEcho.entries == nil {
+		m.localEntryEcho.entries = map[string]uiLocalEntryEchoStatus{}
+	}
+	if _, exists := m.localEntryEcho.entries[noticeID]; !exists {
+		m.localEntryEcho.order = append(m.localEntryEcho.order, noticeID)
+	}
+	m.localEntryEcho.entries[noticeID] = status
+	m.pruneLocalEntryEchoLedger()
+}
+
+func (m *uiModel) acknowledgeLocalEntryEcho(noticeID string) bool {
+	if m == nil {
+		return false
+	}
+	noticeID = strings.TrimSpace(noticeID)
+	if noticeID == "" || m.localEntryEcho.entries == nil {
+		return false
+	}
+	if _, ok := m.localEntryEcho.entries[noticeID]; !ok {
+		return false
+	}
+	m.localEntryEcho.entries[noticeID] = uiLocalEntryEchoAcknowledged
+	return true
+}
+
+func (m *uiModel) shouldSuppressLocalEntryEcho(noticeID string) bool {
+	return m.acknowledgeLocalEntryEcho(noticeID)
+}
+
+func (m *uiModel) acknowledgeLocalEntryEchoesInChatEntries(entries []clientui.ChatEntry) {
+	if m == nil {
+		return
+	}
+	for _, entry := range entries {
+		m.acknowledgeLocalEntryEcho(entry.NoticeID)
+	}
+}
+
+func (m *uiModel) suppressRenderedLocalEntryEchoesInChatEntries(entries []clientui.ChatEntry) []clientui.ChatEntry {
+	if m == nil || len(entries) == 0 {
+		return entries
+	}
+	filtered := entries[:0]
+	for _, entry := range entries {
+		if m.shouldSuppressRenderedLocalEntryEcho(entry.NoticeID) {
+			m.clearMirroredTransientStatusByNoticeID(entry.NoticeID)
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func (m *uiModel) shouldSuppressRenderedLocalEntryEcho(noticeID string) bool {
+	if m == nil {
+		return false
+	}
+	noticeID = strings.TrimSpace(noticeID)
+	if noticeID == "" || m.localEntryEcho.entries == nil {
+		return false
+	}
+	if _, ok := m.localEntryEcho.entries[noticeID]; !ok {
+		return false
+	}
+	m.acknowledgeLocalEntryEcho(noticeID)
+	return m.localEntryEchoRendered(noticeID)
+}
+
+func (m *uiModel) localEntryEchoRendered(noticeID string) bool {
+	if m == nil {
+		return false
+	}
+	noticeID = strings.TrimSpace(noticeID)
+	if noticeID == "" {
+		return false
+	}
+	for _, entry := range m.transcriptEntries {
+		if strings.TrimSpace(entry.NoticeID) == noticeID {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *uiModel) pruneLocalEntryEchoLedger() {
+	if m == nil || len(m.localEntryEcho.order) <= localEntryEchoRetentionLimit {
+		return
+	}
+	keep := m.localEntryEcho.order[:0]
+	for _, noticeID := range m.localEntryEcho.order {
+		if len(m.localEntryEcho.order)-len(keep) <= localEntryEchoRetentionLimit {
+			keep = append(keep, noticeID)
+			continue
+		}
+		if m.localEntryEcho.entries[noticeID] == uiLocalEntryEchoPending {
+			keep = append(keep, noticeID)
+			continue
+		}
+		delete(m.localEntryEcho.entries, noticeID)
+	}
+	m.localEntryEcho.order = keep
 }

--- a/cli/app/ui_input_controller.go
+++ b/cli/app/ui_input_controller.go
@@ -232,11 +232,11 @@ func (m *uiModel) appendLocalEntryWithNoticeID(role, text, noticeID string) tea.
 	if noticeID == "" {
 		noticeID = m.nextLocalNoticeID()
 	}
-	localCmd := m.appendLocalEntryFallbackWithNoticeID(role, text, noticeID)
 	if !m.hasRuntimeClient() {
-		return localCmd
+		return m.appendLocalEntryFallbackWithNoticeID(role, text, noticeID)
 	}
 	m.trackPendingLocalEntryEcho(noticeID)
+	localCmd := m.appendLocalEntryFallbackWithNoticeIDTransient(role, text, noticeID)
 	persistCmd := m.persistLocalEntryCmd(role, text, noticeID)
 	return sequenceCmds(localCmd, persistCmd)
 }
@@ -249,16 +249,24 @@ func (m *uiModel) appendLocalEntryFallbackWithNoticeID(role, text, noticeID stri
 	return m.appendLocalEntryFallbackWithNoticeIDAndVisibility(role, text, noticeID, transcript.EntryVisibilityAuto)
 }
 
+func (m *uiModel) appendLocalEntryFallbackWithNoticeIDTransient(role, text, noticeID string) tea.Cmd {
+	return m.appendLocalEntryFallbackWithNoticeIDAndVisibilityAndTransient(role, text, noticeID, transcript.EntryVisibilityAuto, true)
+}
+
 func (m *uiModel) appendLocalEntryFallbackWithNoticeIDAndVisibility(role, text, noticeID string, visibility transcript.EntryVisibility) tea.Cmd {
+	return m.appendLocalEntryFallbackWithNoticeIDAndVisibilityAndTransient(role, text, noticeID, visibility, false)
+}
+
+func (m *uiModel) appendLocalEntryFallbackWithNoticeIDAndVisibilityAndTransient(role, text, noticeID string, visibility transcript.EntryVisibility, transient bool) tea.Cmd {
 	if m == nil {
 		return nil
 	}
 	transcriptRole := tui.TranscriptRoleFromWire(role)
-	entry := tui.TranscriptEntry{Visibility: transcript.NormalizeEntryVisibility(visibility), Role: transcriptRole, Text: text, NoticeID: strings.TrimSpace(noticeID)}
+	entry := tui.TranscriptEntry{Visibility: transcript.NormalizeEntryVisibility(visibility), Transient: transient, Role: transcriptRole, Text: text, NoticeID: strings.TrimSpace(noticeID)}
 	m.transcriptEntries = append(m.transcriptEntries, entry)
 	m.transcriptTotalEntries = max(m.transcriptTotalEntries, m.transcriptBaseOffset+len(committedTranscriptEntriesForApp(m.transcriptEntries)))
 	m.refreshRollbackCandidates()
-	m.forwardToView(tui.AppendTranscriptMsg{Visibility: entry.Visibility, Role: transcriptRole, Text: text, NoticeID: entry.NoticeID})
+	m.forwardToView(tui.AppendTranscriptMsg{Visibility: entry.Visibility, Transient: entry.Transient, Role: transcriptRole, Text: text, NoticeID: entry.NoticeID})
 	return m.syncNativeHistoryFromTranscript()
 }
 

--- a/cli/app/ui_input_controller_commands.go
+++ b/cli/app/ui_input_controller_commands.go
@@ -113,7 +113,7 @@ func (c uiInputController) handleResumeCommand() (tea.Model, tea.Cmd) {
 
 func (c uiInputController) handleBackCommand() (tea.Model, tea.Cmd) {
 	m := c.model
-	status := m.runtimeStatus()
+	status := m.cachedRuntimeStatus()
 	if strings.TrimSpace(status.ParentSessionID) == "" {
 		return m, c.appendSystemFeedback("No parent session available")
 	}
@@ -128,19 +128,16 @@ func (m *uiModel) backTeleportInput() string {
 }
 
 func (m *uiModel) latestAssistantFinalAnswer() string {
-	return m.latestAssistantFinalAnswerFromStatus(true)
+	return m.latestAssistantFinalAnswerFromStatus()
 }
 
 func (m *uiModel) cachedLatestAssistantFinalAnswer() string {
-	return m.latestAssistantFinalAnswerFromStatus(false)
+	return m.latestAssistantFinalAnswerFromStatus()
 }
 
-func (m *uiModel) latestAssistantFinalAnswerFromStatus(refresh bool) string {
+func (m *uiModel) latestAssistantFinalAnswerFromStatus() string {
 	if m.hasRuntimeClient() {
 		status := m.cachedRuntimeStatus()
-		if refresh {
-			status = m.refreshRuntimeStatus()
-		}
 		if answer := strings.TrimSpace(status.LastCommittedAssistantFinalAnswer); answer != "" {
 			return status.LastCommittedAssistantFinalAnswer
 		}
@@ -164,10 +161,11 @@ func (c uiInputController) handleCopyCommand() (tea.Model, tea.Cmd) {
 
 func (c uiInputController) handleSessionNameCommand(sessionName string) (tea.Model, tea.Cmd) {
 	m := c.model
-	if err := m.setRuntimeSessionName(sessionName); err != nil {
-		return m, c.appendErrorFeedback(formatSubmissionError(err))
+	sessionName = strings.TrimSpace(sessionName)
+	if m.hasRuntimeClient() {
+		return m, m.runtimeControlCommand(runtimeControlSetSessionName, sessionName, false, "")
 	}
-	m.sessionName = strings.TrimSpace(sessionName)
+	m.sessionName = sessionName
 	return m, tea.SetWindowTitle(m.windowTitle())
 }
 
@@ -177,7 +175,7 @@ func (c uiInputController) handleThinkingLevelCommand(requested string) (tea.Mod
 	if requested == "" {
 		current := strings.TrimSpace(m.thinkingLevel)
 		if m.hasRuntimeClient() {
-			current = m.runtimeStatus().ThinkingLevel
+			current = m.cachedRuntimeStatus().ThinkingLevel
 		}
 		if current == "" {
 			current = "unknown"
@@ -190,12 +188,8 @@ func (c uiInputController) handleThinkingLevelCommand(requested string) (tea.Mod
 		errText := "invalid thinking level " + strconv.Quote(requested) + " (expected low|medium|high|xhigh)"
 		return m, c.appendErrorFeedback(errText)
 	}
-	if err := m.setRuntimeThinkingLevel(normalized); err != nil {
-		return m, c.appendErrorFeedback(formatSubmissionError(err))
-	}
 	if m.hasRuntimeClient() {
-		m.thinkingLevel = m.runtimeStatus().ThinkingLevel
-		return m, c.appendSystemFeedback("Thinking level set to " + m.thinkingLevel)
+		return m, m.runtimeControlCommand(runtimeControlSetThinkingLevel, normalized, false, "")
 	}
 	m.thinkingLevel = normalized
 	return m, c.appendSystemFeedback("Thinking level set to " + m.thinkingLevel)
@@ -204,6 +198,7 @@ func (c uiInputController) handleThinkingLevelCommand(requested string) (tea.Mod
 func (c uiInputController) handleFastModeCommand(requested string) (tea.Model, tea.Cmd) {
 	m := c.model
 	available, currentEnabled := m.fastModeState()
+	currentEnabled = m.runtimeControlPendingEnabled(runtimeControlSetFastMode, m.sessionID, currentEnabled)
 	if !available {
 		errText := "Fast mode is only available for OpenAI-based Responses providers"
 		return m, c.appendErrorFeedbackWithStatus(errText, c.showErrorStatus(errText))
@@ -236,13 +231,7 @@ func (c uiInputController) handleFastModeCommand(requested string) (tea.Model, t
 
 	changed := currentEnabled != targetEnabled
 	if m.hasRuntimeClient() {
-		var err error
-		changed, err = m.setRuntimeFastModeEnabled(targetEnabled)
-		if err != nil {
-			detailErr := formatSubmissionError(err)
-			return m, c.appendErrorFeedbackWithStatus(detailErr, c.showErrorStatus(detailErr))
-		}
-		m.fastModeEnabled = m.runtimeStatus().FastModeEnabled
+		return m, m.runtimeControlCommand(runtimeControlSetFastMode, "", targetEnabled, "")
 	} else {
 		m.fastModeEnabled = targetEnabled
 	}
@@ -255,6 +244,7 @@ func (c uiInputController) handleSupervisorModeCommand(requested string) (tea.Mo
 	m := c.model
 	requested = strings.ToLower(strings.TrimSpace(requested))
 	currentEnabled, currentMode := m.reviewerInvocationState()
+	currentEnabled = m.runtimeControlPendingEnabled(runtimeControlSetReviewer, m.sessionID, currentEnabled)
 	targetEnabled := currentEnabled
 	switch requested {
 	case "":
@@ -271,11 +261,7 @@ func (c uiInputController) handleSupervisorModeCommand(requested string) (tea.Mo
 	changed := false
 	nextMode := currentMode
 	if m.hasRuntimeClient() {
-		var err error
-		changed, nextMode, err = m.setRuntimeReviewerEnabled(targetEnabled)
-		if err != nil {
-			return m, c.appendErrorFeedback(formatSubmissionError(err))
-		}
+		return m, m.runtimeControlCommand(runtimeControlSetReviewer, "", targetEnabled, "")
 	} else {
 		nextMode = "off"
 		if targetEnabled {
@@ -293,9 +279,10 @@ func (c uiInputController) handleAutoCompactionCommand(requested string) (tea.Mo
 	m := c.model
 	requested = strings.ToLower(strings.TrimSpace(requested))
 	currentEnabled := m.autoCompactionState()
+	currentEnabled = m.runtimeControlPendingEnabled(runtimeControlSetAutoCompaction, m.sessionID, currentEnabled)
 	currentCompactionMode := "native"
 	if m.hasRuntimeClient() {
-		currentCompactionMode = m.runtimeStatus().CompactionMode
+		currentCompactionMode = m.cachedRuntimeStatus().CompactionMode
 	}
 	targetEnabled := currentEnabled
 	switch requested {
@@ -313,12 +300,7 @@ func (c uiInputController) handleAutoCompactionCommand(requested string) (tea.Mo
 	changed := false
 	nextEnabled := currentEnabled
 	if m.hasRuntimeClient() {
-		var err error
-		changed, nextEnabled, err = m.setRuntimeAutoCompactionEnabled(targetEnabled)
-		if err != nil {
-			errText := formatSubmissionError(err)
-			return m, c.appendErrorFeedbackWithStatus(errText, c.showTransientStatus(errText))
-		}
+		return m, m.runtimeControlCommand(runtimeControlSetAutoCompaction, "", targetEnabled, currentCompactionMode)
 	} else {
 		nextEnabled = targetEnabled
 		changed = currentEnabled != targetEnabled

--- a/cli/app/ui_input_controller_commands.go
+++ b/cli/app/ui_input_controller_commands.go
@@ -152,9 +152,6 @@ func (m *uiModel) hasAssistantFinalAnswerToCopy() bool {
 
 func (c uiInputController) handleCopyCommand() (tea.Model, tea.Cmd) {
 	m := c.model
-	if client := m.runtimeClient(); client != nil {
-		return m, m.copyLatestAssistantFinalAnswerFromRuntimeCmd(client)
-	}
 	text := m.latestAssistantFinalAnswer()
 	if strings.TrimSpace(text) == "" {
 		return m, c.showErrorStatus("No final answer available to copy")

--- a/cli/app/ui_input_controller_commands.go
+++ b/cli/app/ui_input_controller_commands.go
@@ -152,6 +152,9 @@ func (m *uiModel) hasAssistantFinalAnswerToCopy() bool {
 
 func (c uiInputController) handleCopyCommand() (tea.Model, tea.Cmd) {
 	m := c.model
+	if client := m.runtimeClient(); client != nil {
+		return m, m.copyLatestAssistantFinalAnswerFromRuntimeCmd(client)
+	}
 	text := m.latestAssistantFinalAnswer()
 	if strings.TrimSpace(text) == "" {
 		return m, c.showErrorStatus("No final answer available to copy")

--- a/cli/app/ui_input_controller_flows.go
+++ b/cli/app/ui_input_controller_flows.go
@@ -84,12 +84,13 @@ func (c uiInputController) startRollbackFork(text string) (tea.Model, tea.Cmd) {
 func (c uiInputController) startProcessListFlowCmd() tea.Cmd {
 	m := c.model
 	m.openProcessList()
+	initialRefreshCmd := m.requestProcessListRefresh()
 	refreshCmd := waitProcessListRefresh()
 	spinnerCmd := m.ensureSpinnerTicking()
 	if overlayCmd := m.pushProcessOverlayIfNeeded(); overlayCmd != nil {
-		return tea.Batch(overlayCmd, refreshCmd, spinnerCmd)
+		return tea.Batch(overlayCmd, initialRefreshCmd, refreshCmd, spinnerCmd)
 	}
-	return tea.Batch(refreshCmd, spinnerCmd)
+	return tea.Batch(initialRefreshCmd, refreshCmd, spinnerCmd)
 }
 
 func (c uiInputController) stopProcessListFlowCmd() tea.Cmd {
@@ -97,10 +98,11 @@ func (c uiInputController) stopProcessListFlowCmd() tea.Cmd {
 	overlayCmd := m.popProcessOverlayIfNeeded()
 	m.closeProcessList()
 	spinnerCmd := m.ensureSpinnerTicking()
+	releaseCmd := m.releaseDeferredRuntimeSyncs()
 	if overlayCmd != nil {
-		return tea.Batch(overlayCmd, spinnerCmd)
+		return tea.Batch(overlayCmd, spinnerCmd, releaseCmd)
 	}
-	return spinnerCmd
+	return tea.Batch(spinnerCmd, releaseCmd)
 }
 
 func (c uiInputController) markPendingCSIShiftEnter() {

--- a/cli/app/ui_input_controller_keys.go
+++ b/cli/app/ui_input_controller_keys.go
@@ -143,8 +143,7 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyCtrlC:
 		if m.isBusy() {
-			c.interruptBusyRuntime()
-			return m, nil
+			return m, c.interruptBusyRuntime()
 		}
 		m.exitAction = UIActionExit
 		return m, tea.Quit
@@ -192,9 +191,9 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
 				return m, nil
 			}
-			m.queueInjectedInput(text)
+			cmd := m.queueInjectedInput(text)
 			m.restoreCapturedPromptHistoryDraft(draftText, draftCursor, restoreDraft)
-			return m, nil
+			return m, cmd
 		}
 		if len(m.queued) > 0 {
 			m.queueInput(text)
@@ -301,7 +300,7 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if m.isInputLocked() {
 				return m, nil
 			}
-			m.insertInputRunes(msg.Runes)
+			return m, m.insertInputRunes(msg.Runes)
 		}
 		return m, nil
 	}

--- a/cli/app/ui_input_controller_status.go
+++ b/cli/app/ui_input_controller_status.go
@@ -7,7 +7,10 @@ import (
 )
 
 func (m *uiModel) reviewerInvocationState() (bool, string) {
-	mode := strings.ToLower(strings.TrimSpace(m.runtimeStatus().ReviewerFrequency))
+	mode := strings.ToLower(strings.TrimSpace(m.cachedRuntimeStatus().ReviewerFrequency))
+	if mode == "" {
+		mode = strings.ToLower(strings.TrimSpace(m.reviewerMode))
+	}
 	if mode == "" {
 		mode = "off"
 	}
@@ -15,11 +18,14 @@ func (m *uiModel) reviewerInvocationState() (bool, string) {
 }
 
 func (m *uiModel) autoCompactionState() bool {
-	return m.runtimeStatus().AutoCompactionEnabled
+	return m.cachedRuntimeStatus().AutoCompactionEnabled
 }
 
 func (m *uiModel) fastModeState() (bool, bool) {
-	status := m.runtimeStatus()
+	status := m.cachedRuntimeStatus()
+	if !status.FastModeAvailable && m.fastModeAvailable {
+		status.FastModeAvailable = true
+	}
 	return status.FastModeAvailable, status.FastModeEnabled
 }
 

--- a/cli/app/ui_input_mode.go
+++ b/cli/app/ui_input_mode.go
@@ -25,15 +25,16 @@ type uiInteractionState struct {
 }
 
 type uiAskState struct {
-	current      *askEvent
-	currentToken uint64
-	queue        []askEvent
-	cursor       int
-	freeform     bool
-	freeformMode askFreeformMode
-	input        string
-	inputCursor  int
-	inputKill    string
+	current       *askEvent
+	currentToken  uint64
+	queue         []askEvent
+	cursor        int
+	freeform      bool
+	freeformMode  askFreeformMode
+	answerPending bool
+	input         string
+	inputCursor   int
+	inputKill     string
 }
 
 type uiProcessListState struct {

--- a/cli/app/ui_input_mode.go
+++ b/cli/app/ui_input_mode.go
@@ -37,9 +37,17 @@ type uiAskState struct {
 }
 
 type uiProcessListState struct {
-	open      bool
-	selection int
-	entries   []clientui.BackgroundProcess
+	open              bool
+	selection         int
+	entries           []clientui.BackgroundProcess
+	loading           bool
+	errorText         string
+	refreshToken      uint64
+	refreshInFlight   bool
+	refreshDirty      bool
+	actionToken       uint64
+	actionInFlight    bool
+	surfaceGeneration uint64
 }
 
 type uiRollbackPhase string

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -22,6 +22,26 @@ type queuedInputItem struct {
 	Text string
 }
 
+type injectedRuntimeQueueState string
+
+const (
+	injectedRuntimeQueuePendingCreate        injectedRuntimeQueueState = "pendingCreate"
+	injectedRuntimeQueueEnqueued             injectedRuntimeQueueState = "enqueued"
+	injectedRuntimeQueueDiscardPending       injectedRuntimeQueueState = "discardPending"
+	injectedRuntimeQueueCanceledBeforeCreate injectedRuntimeQueueState = "canceledBeforeCreate"
+	injectedRuntimeQueueCreateFailed         injectedRuntimeQueueState = "createFailed"
+	injectedRuntimeQueueDiscardFailed        injectedRuntimeQueueState = "discardFailed"
+)
+
+type injectedRuntimeQueueItem struct {
+	LocalID      string
+	ServerID     string
+	Text         string
+	State        injectedRuntimeQueueState
+	CreateToken  uint64
+	DiscardToken uint64
+}
+
 func (m *uiModel) queueInput(text string) {
 	m.queued = append(m.queued, newQueuedInputItem(text))
 	m.clearInput()
@@ -31,25 +51,40 @@ func newQueuedInputItem(text string) queuedInputItem {
 	return queuedInputItem{ID: uuid.NewString(), Text: text}
 }
 
-func (m *uiModel) enqueueInjectedInput(text string) bool {
+func (m *uiModel) enqueueInjectedInput(text string) tea.Cmd {
 	trimmed := strings.TrimSpace(text)
 	if trimmed == "" {
-		return false
+		return nil
 	}
-	item, err := m.queueRuntimeUserMessage(trimmed)
-	if err != nil {
-		m.observeRuntimeRequestResult(err)
-		return false
+	localID := uuid.NewString()
+	if !m.hasRuntimeClient() {
+		item := clientui.QueuedUserMessage{ID: localID, Text: trimmed}
+		m.pendingInjected = append(m.pendingInjected, item)
+		m.injectedQueue = append(m.injectedQueue, injectedRuntimeQueueItem{LocalID: localID, ServerID: localID, Text: trimmed, State: injectedRuntimeQueueEnqueued})
+		return nil
 	}
-	m.pendingInjected = append(m.pendingInjected, item)
-	return true
+	token := m.nextInjectedQueueToken()
+	m.pendingInjected = append(m.pendingInjected, clientui.QueuedUserMessage{ID: localID, Text: trimmed})
+	m.injectedQueue = append(m.injectedQueue, injectedRuntimeQueueItem{
+		LocalID:     localID,
+		Text:        trimmed,
+		State:       injectedRuntimeQueuePendingCreate,
+		CreateToken: token,
+	})
+	client := m.runtimeClient()
+	return func() tea.Msg {
+		item, err := client.QueueUserMessage(trimmed)
+		return injectedQueueCreateDoneMsg{token: token, localID: localID, item: item, err: err}
+	}
 }
 
-func (m *uiModel) queueInjectedInput(text string) {
-	if !m.enqueueInjectedInput(text) {
-		return
+func (m *uiModel) queueInjectedInput(text string) tea.Cmd {
+	cmd := m.enqueueInjectedInput(text)
+	if strings.TrimSpace(text) == "" {
+		return nil
 	}
 	m.clearInput()
+	return cmd
 }
 
 func (c uiInputController) queueOrStartSubmission(text string) (tea.Model, tea.Cmd) {
@@ -90,9 +125,12 @@ func (c uiInputController) blockDisconnectedSubmission(restoreHidden bool, submi
 		return false, nil
 	}
 	if restoreHidden {
-		c.restorePendingInjectedIntoInput()
+		restoreCmd := c.restorePendingInjectedIntoInput()
 		c.restoreSubmittedTextIntoInput(submittedText)
 		c.restoreQueuedMessagesIntoInput()
+		m.activity = uiActivityError
+		m.syncViewport()
+		return true, tea.Batch(restoreCmd, m.appendOperatorErrorFeedback(runtimeDisconnectedStatusMessage))
 	}
 	m.activity = uiActivityError
 	m.syncViewport()
@@ -128,15 +166,16 @@ func (c uiInputController) restoreSubmittedTextIntoInput(text string) {
 	m.replaceMainInput(newInput, -1)
 }
 
-func (c uiInputController) restorePendingInjectedIntoInput() {
+func (c uiInputController) restorePendingInjectedIntoInput() tea.Cmd {
 	m := c.model
 	if len(m.pendingInjected) == 0 {
-		return
+		return nil
 	}
 	pending := append([]clientui.QueuedUserMessage(nil), m.pendingInjected...)
-	if m.hasRuntimeClient() {
-		for _, item := range pending {
-			m.discardQueuedRuntimeUserMessage(item.ID)
+	cmds := make([]tea.Cmd, 0, len(pending))
+	for _, item := range pending {
+		if cmd := m.markInjectedQueueDiscardRequested(item.ID); cmd != nil {
+			cmds = append(cmds, cmd)
 		}
 	}
 	joined := strings.Join(queuedUserMessageTexts(pending), "\n\n")
@@ -148,18 +187,20 @@ func (c uiInputController) restorePendingInjectedIntoInput() {
 		newInput = strings.TrimRight(m.input, "\n") + "\n\n" + joined
 	}
 	m.replaceMainInput(newInput, -1)
+	return tea.Batch(cmds...)
 }
 
-func (c uiInputController) unlockInputAfterSubmissionError() {
-	c.releaseLockedInjectedInput(true)
+func (c uiInputController) unlockInputAfterSubmissionError() tea.Cmd {
+	return c.releaseLockedInjectedInput(true)
 }
 
-func (c uiInputController) releaseLockedInjectedInput(discardEngineQueue bool) {
+func (c uiInputController) releaseLockedInjectedInput(discardEngineQueue bool) tea.Cmd {
 	m := c.model
 	if !m.isInputSubmitLocked() {
-		return
+		return nil
 	}
 	lockedID := strings.TrimSpace(m.lockedInjectID)
+	var discardCmd tea.Cmd
 	if lockedID != "" {
 		filtered := m.pendingInjected[:0]
 		for _, pending := range m.pendingInjected {
@@ -169,13 +210,14 @@ func (c uiInputController) releaseLockedInjectedInput(discardEngineQueue bool) {
 			filtered = append(filtered, pending)
 		}
 		m.pendingInjected = filtered
-		if discardEngineQueue && m.hasRuntimeClient() {
-			m.discardQueuedRuntimeUserMessage(lockedID)
+		if discardEngineQueue {
+			discardCmd = m.markInjectedQueueDiscardRequested(lockedID)
 		}
 	}
 	m.setInputSubmitLocked(false)
 	m.lockedInjectText = ""
 	m.lockedInjectID = ""
+	return discardCmd
 }
 
 func (c uiInputController) flushQueuedInputs(mode queueDrainMode) (tea.Model, tea.Cmd) {
@@ -201,7 +243,7 @@ func (c uiInputController) flushQueuedInputs(mode queueDrainMode) (tea.Model, te
 
 func (c uiInputController) resumeQueuedInputsAfterIdleRuntime() tea.Cmd {
 	m := c.model
-	if m == nil || m.isBusy() || m.ask.hasCurrent() || len(m.queued) == 0 || m.isInputLocked() || m.pendingQueuedDrainAfterHydration {
+	if m == nil || m.isBusy() || m.ask.hasCurrent() || len(m.queued) == 0 || m.isInputLocked() || m.pendingQueuedDrainAfterHydration || m.processList.actionInFlight {
 		return nil
 	}
 	if m.hasRuntimeClient() && c.queuedDrainRequiresHydration() {
@@ -233,7 +275,7 @@ func (c uiInputController) dispatchQueuedInput(item queuedInputItem) tea.Cmd {
 }
 
 func (m *uiModel) shouldContinueQueuedInputAutoDrain() bool {
-	if len(m.queued) == 0 || m.isBusy() || m.isInputLocked() || m.exitAction != UIActionNone || m.ask.hasCurrent() {
+	if len(m.queued) == 0 || m.isBusy() || m.isInputLocked() || m.exitAction != UIActionNone || m.ask.hasCurrent() || m.processList.actionInFlight {
 		return false
 	}
 	if m.inputMode() != uiInputModeMain {
@@ -279,4 +321,266 @@ func queuedUserMessageTexts(messages []clientui.QueuedUserMessage) []string {
 		texts = append(texts, message.Text)
 	}
 	return texts
+}
+
+func (m *uiModel) nextInjectedQueueToken() uint64 {
+	m.injectedQueueToken++
+	if m.injectedQueueToken == 0 {
+		m.injectedQueueToken++
+	}
+	return m.injectedQueueToken
+}
+
+func (m *uiModel) markInjectedQueueDiscardRequested(id string) tea.Cmd {
+	if m == nil || strings.TrimSpace(id) == "" {
+		return nil
+	}
+	index := m.injectedQueueIndexByAnyID(id)
+	if index < 0 {
+		if !m.hasRuntimeClient() {
+			return nil
+		}
+		return m.discardInjectedRuntimeQueueCommand("", id, m.nextInjectedQueueToken(), m.runtimeClient())
+	}
+	item := m.injectedQueue[index]
+	switch item.State {
+	case injectedRuntimeQueuePendingCreate:
+		item.State = injectedRuntimeQueueCanceledBeforeCreate
+		m.injectedQueue[index] = item
+		return nil
+	case injectedRuntimeQueueCanceledBeforeCreate, injectedRuntimeQueueDiscardPending:
+		return nil
+	case injectedRuntimeQueueEnqueued, injectedRuntimeQueueDiscardFailed:
+		serverID := strings.TrimSpace(item.ServerID)
+		if serverID == "" {
+			serverID = strings.TrimSpace(item.LocalID)
+		}
+		token := m.nextInjectedQueueToken()
+		item.State = injectedRuntimeQueueDiscardPending
+		item.DiscardToken = token
+		m.injectedQueue[index] = item
+		return m.discardInjectedRuntimeQueueCommand(item.LocalID, serverID, token, m.runtimeClient())
+	default:
+		return nil
+	}
+}
+
+func (m *uiModel) discardInjectedRuntimeQueueCommand(localID, serverID string, token uint64, client clientui.RuntimeClient) tea.Cmd {
+	if client == nil || strings.TrimSpace(serverID) == "" {
+		return nil
+	}
+	return func() tea.Msg {
+		return injectedQueueDiscardDoneMsg{
+			token:     token,
+			localID:   localID,
+			serverID:  serverID,
+			discarded: client.DiscardQueuedUserMessage(serverID),
+		}
+	}
+}
+
+func (m *uiModel) injectedQueueIndexByAnyID(id string) int {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return -1
+	}
+	for index, item := range m.injectedQueue {
+		if item.LocalID == id || item.ServerID == id {
+			return index
+		}
+	}
+	return -1
+}
+
+func (m *uiModel) injectedQueueBlocksDrain() bool {
+	if m == nil {
+		return false
+	}
+	for _, item := range m.injectedQueue {
+		switch item.State {
+		case injectedRuntimeQueuePendingCreate, injectedRuntimeQueueCanceledBeforeCreate, injectedRuntimeQueueDiscardPending, injectedRuntimeQueueDiscardFailed:
+			return true
+		}
+	}
+	return false
+}
+
+func (c uiInputController) handleInjectedQueueCreateDone(msg injectedQueueCreateDoneMsg) (tea.Model, tea.Cmd) {
+	m := c.model
+	index := m.injectedQueueIndexByAnyID(msg.localID)
+	if index < 0 {
+		return m, nil
+	}
+	item := m.injectedQueue[index]
+	if item.CreateToken != msg.token {
+		return m, nil
+	}
+	m.observeRuntimeRequestResult(msg.err)
+	if msg.err != nil {
+		m.injectedQueue[index].State = injectedRuntimeQueueCreateFailed
+		m.removePendingInjectedByID(item.LocalID)
+		if item.State == injectedRuntimeQueuePendingCreate {
+			c.restoreInjectedTextIntoInput(item.Text)
+			detailErr := formatSubmissionError(msg.err)
+			m.activity = uiActivityError
+			appendCmd := m.appendOperatorErrorFeedback(detailErr)
+			m.logf("queue_create.error err=%q", detailErr)
+			m.removeInjectedQueueItemAt(index)
+			m.syncViewport()
+			return m, appendCmd
+		}
+		m.removeInjectedQueueItemAt(index)
+		return m, nil
+	}
+	serverID := strings.TrimSpace(msg.item.ID)
+	if serverID == "" {
+		serverID = item.LocalID
+	}
+	serverText := strings.TrimSpace(msg.item.Text)
+	if serverText == "" {
+		serverText = item.Text
+	}
+	item.ServerID = serverID
+	item.Text = serverText
+	switch item.State {
+	case injectedRuntimeQueuePendingCreate:
+		item.State = injectedRuntimeQueueEnqueued
+		m.injectedQueue[index] = item
+		m.replacePendingInjectedID(item.LocalID, clientui.QueuedUserMessage{ID: serverID, Text: serverText})
+		if !m.isBusy() && !m.isInputLocked() && !m.injectedQueueBlocksDrain() {
+			return m, c.startQueuedInjectionSubmission()
+		}
+	case injectedRuntimeQueueCanceledBeforeCreate:
+		token := m.nextInjectedQueueToken()
+		item.State = injectedRuntimeQueueDiscardPending
+		item.DiscardToken = token
+		m.injectedQueue[index] = item
+		return m, m.discardInjectedRuntimeQueueCommand(item.LocalID, serverID, token, m.runtimeClient())
+	default:
+		m.injectedQueue[index] = item
+	}
+	return m, nil
+}
+
+func (c uiInputController) handleInjectedQueueDiscardDone(msg injectedQueueDiscardDoneMsg) (tea.Model, tea.Cmd) {
+	m := c.model
+	id := strings.TrimSpace(msg.localID)
+	if id == "" {
+		id = strings.TrimSpace(msg.serverID)
+	}
+	index := m.injectedQueueIndexByAnyID(id)
+	if index < 0 {
+		return m, nil
+	}
+	item := m.injectedQueue[index]
+	if item.DiscardToken != msg.token {
+		return m, nil
+	}
+	if msg.discarded {
+		m.removePendingInjectedByID(item.LocalID)
+		m.removePendingInjectedByID(item.ServerID)
+		m.removeInjectedQueueItemAt(index)
+		if !m.isBusy() && !m.isInputLocked() && !m.injectedQueueBlocksDrain() {
+			return m, c.startQueuedInjectionSubmission()
+		}
+		return m, nil
+	}
+	item.State = injectedRuntimeQueueDiscardFailed
+	m.injectedQueue[index] = item
+	m.ensurePendingInjectedVisible(item)
+	detailErr := "failed to discard queued runtime user message"
+	m.activity = uiActivityError
+	appendCmd := m.appendOperatorErrorFeedback(detailErr)
+	m.logf("queue_discard.error queue_item_id=%q", item.ServerID)
+	return m, appendCmd
+}
+
+func (c uiInputController) restoreInjectedTextIntoInput(text string) {
+	m := c.model
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return
+	}
+	if strings.TrimSpace(m.input) == "" {
+		m.replaceMainInput(trimmed, -1)
+		return
+	}
+	m.replaceMainInput(strings.TrimRight(m.input, "\n")+"\n\n"+trimmed, -1)
+}
+
+func (m *uiModel) replacePendingInjectedID(oldID string, next clientui.QueuedUserMessage) {
+	oldID = strings.TrimSpace(oldID)
+	for index, item := range m.pendingInjected {
+		if item.ID != oldID {
+			continue
+		}
+		m.pendingInjected[index] = next
+		return
+	}
+	m.pendingInjected = append(m.pendingInjected, next)
+}
+
+func (m *uiModel) removePendingInjectedByID(id string) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return
+	}
+	filtered := m.pendingInjected[:0]
+	for _, item := range m.pendingInjected {
+		if item.ID == id {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	m.pendingInjected = filtered
+}
+
+func (m *uiModel) removeInjectedQueueItemAt(index int) {
+	if index < 0 || index >= len(m.injectedQueue) {
+		return
+	}
+	m.injectedQueue = append(m.injectedQueue[:index], m.injectedQueue[index+1:]...)
+}
+
+func (m *uiModel) ensurePendingInjectedVisible(item injectedRuntimeQueueItem) {
+	id := strings.TrimSpace(item.ServerID)
+	if id == "" {
+		id = strings.TrimSpace(item.LocalID)
+	}
+	if id == "" {
+		return
+	}
+	for _, pending := range m.pendingInjected {
+		if pending.ID == id {
+			return
+		}
+	}
+	m.pendingInjected = append(m.pendingInjected, clientui.QueuedUserMessage{ID: id, Text: item.Text})
+}
+
+func (m *uiModel) removeInjectedQueueItemsByIDs(ids []string) {
+	if len(ids) == 0 || len(m.injectedQueue) == 0 {
+		return
+	}
+	filtered := m.injectedQueue[:0]
+	for _, item := range m.injectedQueue {
+		if containsInjectedQueueID(ids, item.ServerID) || containsInjectedQueueID(ids, item.LocalID) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	m.injectedQueue = filtered
+}
+
+func containsInjectedQueueID(values []string, target string) bool {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return false
+	}
+	for _, value := range values {
+		if strings.TrimSpace(value) == target {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -52,6 +52,10 @@ func newQueuedInputItem(text string) queuedInputItem {
 }
 
 func (m *uiModel) enqueueInjectedInput(text string) tea.Cmd {
+	return m.enqueueInjectedInputWithApprovalAnswer(text, nil)
+}
+
+func (m *uiModel) enqueueInjectedInputWithApprovalAnswer(text string, answer *clientui.PromptAnswer) tea.Cmd {
 	trimmed := strings.TrimSpace(text)
 	if trimmed == "" {
 		return nil
@@ -74,7 +78,7 @@ func (m *uiModel) enqueueInjectedInput(text string) tea.Cmd {
 	client := m.runtimeClient()
 	return func() tea.Msg {
 		item, err := client.QueueUserMessage(trimmed)
-		return injectedQueueCreateDoneMsg{token: token, localID: localID, item: item, err: err}
+		return injectedQueueCreateDoneMsg{token: token, localID: localID, item: item, approvalCommentaryAnswer: answer, err: err}
 	}
 }
 
@@ -243,8 +247,16 @@ func (c uiInputController) flushQueuedInputs(mode queueDrainMode) (tea.Model, te
 
 func (c uiInputController) resumeQueuedInputsAfterIdleRuntime() tea.Cmd {
 	m := c.model
-	if m == nil || m.isBusy() || m.ask.hasCurrent() || len(m.queued) == 0 || m.isInputLocked() || m.pendingQueuedDrainAfterHydration || m.processList.actionInFlight {
+	if m == nil || m.isBusy() || m.ask.hasCurrent() || m.isInputLocked() || m.pendingQueuedDrainAfterHydration || m.processList.actionInFlight {
 		return nil
+	}
+	hasQueuedInputs := len(m.queued) > 0
+	hasInjectedWork := m.hasRuntimeClient() && m.hasEnqueuedInjectedRuntimeWork()
+	if !hasQueuedInputs && !hasInjectedWork {
+		return nil
+	}
+	if !hasQueuedInputs {
+		return c.startQueuedInjectionSubmission()
 	}
 	if m.hasRuntimeClient() && c.queuedDrainRequiresHydration() {
 		m.pendingQueuedDrainAfterHydration = true
@@ -405,6 +417,18 @@ func (m *uiModel) injectedQueueBlocksDrain() bool {
 	return false
 }
 
+func (m *uiModel) hasEnqueuedInjectedRuntimeWork() bool {
+	if m == nil {
+		return false
+	}
+	for _, item := range m.injectedQueue {
+		if item.State == injectedRuntimeQueueEnqueued {
+			return true
+		}
+	}
+	return false
+}
+
 func (c uiInputController) handleInjectedQueueCreateDone(msg injectedQueueCreateDoneMsg) (tea.Model, tea.Cmd) {
 	m := c.model
 	index := m.injectedQueueIndexByAnyID(msg.localID)
@@ -447,6 +471,9 @@ func (c uiInputController) handleInjectedQueueCreateDone(msg injectedQueueCreate
 		item.State = injectedRuntimeQueueEnqueued
 		m.injectedQueue[index] = item
 		m.replacePendingInjectedID(item.LocalID, clientui.QueuedUserMessage{ID: serverID, Text: serverText})
+		if msg.approvalCommentaryAnswer != nil {
+			return m, m.answerQueuedApprovalCommentary(*msg.approvalCommentaryAnswer)
+		}
 		if !m.isBusy() && !m.isInputLocked() && !m.injectedQueueBlocksDrain() {
 			return m, c.startQueuedInjectionSubmission()
 		}

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -96,6 +96,9 @@ func (c uiInputController) queueOrStartSubmission(text string) (tea.Model, tea.C
 	if m.isInputLocked() {
 		return m, nil
 	}
+	if blocked, blockCmd := c.blockInjectedQueueSubmission(); blocked {
+		return m, blockCmd
+	}
 	if blocked, disconnectCmd := c.blockDisconnectedSubmission(false, ""); blocked {
 		return m, disconnectCmd
 	}
@@ -121,6 +124,17 @@ func (c uiInputController) preservePromptHistoryDraftForQueuedText(text string) 
 		return true
 	}
 	return command.PreservePromptHistoryDraft
+}
+
+func (c uiInputController) blockInjectedQueueSubmission() (bool, tea.Cmd) {
+	m := c.model
+	if m == nil || !m.injectedQueueBlocksDrain() {
+		return false, nil
+	}
+	detailErr := "queued runtime message is still pending; retry or discard it before submitting"
+	m.activity = uiActivityError
+	m.syncViewport()
+	return true, m.inputController().showErrorStatus(detailErr)
 }
 
 func (c uiInputController) blockDisconnectedSubmission(restoreHidden bool, submittedText string) (bool, tea.Cmd) {
@@ -451,6 +465,9 @@ func (c uiInputController) handleInjectedQueueCreateDone(msg injectedQueueCreate
 			m.logf("queue_create.error err=%q", detailErr)
 			m.removeInjectedQueueItemAt(index)
 			m.syncViewport()
+			if msg.approvalCommentaryAnswer != nil {
+				return m, sequenceCmds(appendCmd, m.answerQueuedApprovalCommentary(*msg.approvalCommentaryAnswer))
+			}
 			return m, appendCmd
 		}
 		m.removeInjectedQueueItemAt(index)

--- a/cli/app/ui_input_resume.go
+++ b/cli/app/ui_input_resume.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"builder/cli/app/internal/submissionerror"
+	"builder/shared/clientui"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -14,39 +15,75 @@ func (c uiInputController) startQueuedInjectionSubmission() tea.Cmd {
 	if blocked, disconnectCmd := c.blockDisconnectedSubmission(true, ""); blocked {
 		return disconnectCmd
 	}
-	queuedRuntimeWork, err := m.hasQueuedRuntimeUserWork()
-	if err != nil {
-		c.restorePendingInjectedIntoInput()
-		if isInterruptedRuntimeError(err) {
+	if m.injectedQueueBlocksDrain() {
+		return nil
+	}
+	return c.queuedRuntimeWorkCheckCmd()
+}
+
+func (c uiInputController) queuedRuntimeWorkCheckCmd() tea.Cmd {
+	m := c.model
+	if m == nil {
+		return nil
+	}
+	client := m.runtimeClient()
+	if client == nil {
+		return nil
+	}
+	token := m.nextInjectedQueueToken()
+	return func() tea.Msg {
+		hasWork, err := client.HasQueuedUserWork()
+		return queuedRuntimeWorkCheckDoneMsg{token: token, hasWork: hasWork, err: err}
+	}
+}
+
+func (c uiInputController) handleQueuedRuntimeWorkCheckDone(msg queuedRuntimeWorkCheckDoneMsg) (tea.Model, tea.Cmd) {
+	m := c.model
+	if msg.token == 0 || msg.token != m.injectedQueueToken {
+		return m, nil
+	}
+	compactionOrigin := m.queuedRuntimeWorkCheckCompactionOrigin
+	m.queuedRuntimeWorkCheckCompactionOrigin = uiCompactionOriginNone
+	m.observeRuntimeRequestResult(msg.err)
+	if msg.err != nil {
+		restoreCmd := c.restorePendingInjectedIntoInput()
+		if isInterruptedRuntimeError(msg.err) {
 			m.activity = uiActivityInterrupted
 			m.logf("step.interrupted")
 			m.syncViewport()
-			return nil
+			return m, restoreCmd
 		}
-		detailErr := formatSubmissionError(err)
+		detailErr := formatSubmissionError(msg.err)
 		m.activity = uiActivityError
 		appendCmd := m.appendOperatorErrorFeedback(detailErr)
 		m.logf("queue_check.error err=%q", detailErr)
 		m.syncViewport()
-		return appendCmd
+		return m, tea.Batch(restoreCmd, appendCmd)
 	}
-	if !queuedRuntimeWork {
-		return nil
+	if !msg.hasWork || m.injectedQueueBlocksDrain() {
+		if !msg.hasWork {
+			c.notifyUserCompactionCompleted(compactionOrigin, true)
+		} else {
+			c.notifyUserCompactionCompleted(compactionOrigin, false)
+		}
+		return m, nil
 	}
+	c.notifyUserCompactionCompleted(compactionOrigin, false)
 	c.startBusyActivity(false)
 	m.logf("step.resume_queued_injected pending_injected=%d", len(m.pendingInjected))
 	m.syncViewport()
-	return tea.Batch(c.submitQueuedUserMessagesCmd(), c.model.ensureSpinnerTicking())
+	return m, tea.Batch(c.submitQueuedUserMessagesCmd(), c.model.ensureSpinnerTicking())
 }
 
 func (c uiInputController) submitQueuedUserMessagesCmd() tea.Cmd {
 	m := c.model
 	token := m.beginSubmitAttempt("", "")
+	client := m.runtimeClient()
 	return func() tea.Msg {
-		if !m.hasRuntimeClient() {
+		if client == nil {
 			return newSubmitDoneMsg(token, "", "", errors.New("runtime engine is not configured"))
 		}
-		msg, err := m.submitQueuedRuntimeUserMessages(context.Background())
+		msg, err := submitQueuedRuntimeUserMessages(context.Background(), client)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return newSubmitDoneMsg(token, "", "", submissionerror.ErrInterrupted)
@@ -55,4 +92,11 @@ func (c uiInputController) submitQueuedUserMessagesCmd() tea.Cmd {
 		}
 		return newSubmitDoneMsg(token, msg, "", nil)
 	}
+}
+
+func submitQueuedRuntimeUserMessages(ctx context.Context, client clientui.RuntimeClient) (string, error) {
+	if client == nil {
+		return "", nil
+	}
+	return client.SubmitQueuedUserMessages(ctx)
 }

--- a/cli/app/ui_input_resume.go
+++ b/cli/app/ui_input_resume.go
@@ -96,7 +96,7 @@ func (c uiInputController) submitQueuedUserMessagesCmd() tea.Cmd {
 
 func submitQueuedRuntimeUserMessages(ctx context.Context, client clientui.RuntimeClient) (string, error) {
 	if client == nil {
-		return "", nil
+		return "", errors.New("runtime engine is not configured")
 	}
 	return client.SubmitQueuedUserMessages(ctx)
 }

--- a/cli/app/ui_input_resume.go
+++ b/cli/app/ui_input_resume.go
@@ -60,7 +60,7 @@ func (c uiInputController) handleQueuedRuntimeWorkCheckDone(msg queuedRuntimeWor
 		m.syncViewport()
 		return m, tea.Batch(restoreCmd, appendCmd)
 	}
-	if !msg.hasWork || m.injectedQueueBlocksDrain() {
+	if !msg.hasWork || m.injectedQueueBlocksDrain() || m.isBusy() || m.isInputLocked() {
 		if !msg.hasWork {
 			c.notifyUserCompactionCompleted(compactionOrigin, true)
 		} else {

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -286,6 +286,8 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 		}
 		m.forwardToView(tui.CommitAssistantMsg{})
 	}
+	m.conversationFreshness = clientui.ConversationFreshnessEstablished
+	m.localConversationTurn = true
 	m.logf("step.done assistant_chars=%d", len(msg.message))
 	m.sawAssistantDelta = false
 	if len(m.queued) > 0 {

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -77,11 +77,12 @@ func (c uiInputController) startSubmissionWithPromptHistoryAndQueuePositionAndID
 func (c uiInputController) submitCmd(text string, queuedID string) tea.Cmd {
 	m := c.model
 	token := m.beginSubmitAttempt(text, queuedID)
+	client := m.runtimeClient()
 	return func() tea.Msg {
-		if !m.hasRuntimeClient() {
+		if client == nil {
 			return newSubmitDoneMsg(token, "", text, errors.New("runtime engine is not configured"))
 		}
-		message, err := m.submitRuntimeUserMessage(context.Background(), text)
+		message, err := client.SubmitUserMessage(context.Background(), text)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return newSubmitDoneMsg(token, "", text, submissionerror.ErrInterrupted)
@@ -95,11 +96,12 @@ func (c uiInputController) submitCmd(text string, queuedID string) tea.Cmd {
 func (c uiInputController) submitUserShellCmd(originalText, command string) tea.Cmd {
 	m := c.model
 	token := m.beginSubmitAttempt(originalText, "")
+	client := m.runtimeClient()
 	return func() tea.Msg {
-		if !m.hasRuntimeClient() {
+		if client == nil {
 			return newSubmitDoneMsg(token, "", originalText, errors.New("runtime engine is not configured"))
 		}
-		err := m.submitRuntimeUserShellCommand(context.Background(), command)
+		err := client.SubmitUserShellCommand(context.Background(), command)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return newSubmitDoneMsg(token, "", originalText, submissionerror.ErrInterrupted)
@@ -189,11 +191,12 @@ func (c uiInputController) startCompactionWithOrigin(args string, origin uiCompa
 
 func (c uiInputController) compactCmd(args string) tea.Cmd {
 	m := c.model
+	client := m.runtimeClient()
 	return func() tea.Msg {
-		if !m.hasRuntimeClient() {
+		if client == nil {
 			return compactDoneMsg{err: errors.New("runtime engine is not configured")}
 		}
-		return compactDoneMsg{err: m.compactRuntimeContext(context.Background(), args)}
+		return compactDoneMsg{err: client.CompactContext(context.Background(), args)}
 	}
 }
 
@@ -237,6 +240,7 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 	if msg.token != 0 && msg.token != m.activeSubmit.token {
 		return m, nil
 	}
+	m.observeRuntimeRequestResult(msg.err)
 	restoreSubmittedText := true
 	if msg.token != 0 && m.activeSubmit.flushed {
 		restoreSubmittedText = false
@@ -249,8 +253,8 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 		if m.turnQueueHook != nil {
 			m.turnQueueHook.OnTurnQueueAborted()
 		}
-		c.unlockInputAfterSubmissionError()
-		c.restorePendingInjectedIntoInput()
+		unlockCmd := c.unlockInputAfterSubmissionError()
+		restoreInjectedCmd := c.restorePendingInjectedIntoInput()
 		if restoreSubmittedText {
 			c.restoreSubmittedTextIntoInput(msg.submittedText)
 		}
@@ -266,7 +270,7 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 		appendCmd := m.appendOperatorErrorFeedback(detailErr)
 		m.logf("step.error err=%q", detailErr)
 		m.syncViewport()
-		return m, appendCmd
+		return m, tea.Batch(unlockCmd, restoreInjectedCmd, appendCmd)
 	}
 
 	m.activity = uiActivityIdle
@@ -352,23 +356,24 @@ func (c uiInputController) handleCompactDone(msg compactDoneMsg) (tea.Model, tea
 	m := c.model
 	compactionOrigin := m.compactionOrigin
 	m.compactionOrigin = uiCompactionOriginNone
+	m.observeRuntimeRequestResult(msg.err)
 	c.finishBusyActivity(true)
-	c.releaseLockedInjectedInput(true)
+	releaseCmd := c.releaseLockedInjectedInput(true)
 	if msg.err != nil {
-		c.restorePendingInjectedIntoInput()
+		restoreInjectedCmd := c.restorePendingInjectedIntoInput()
 		c.restoreQueuedMessagesIntoInput()
 		if isInterruptedRuntimeError(msg.err) {
 			m.activity = uiActivityInterrupted
 			m.logf("step.interrupted")
 			m.syncViewport()
-			return m, nil
+			return m, tea.Batch(releaseCmd, restoreInjectedCmd)
 		}
 		detailErr := formatSubmissionError(msg.err)
 		m.activity = uiActivityError
 		appendCmd := m.appendOperatorErrorFeedback(detailErr)
 		m.logf("compaction.error err=%q", detailErr)
 		m.syncViewport()
-		return m, appendCmd
+		return m, tea.Batch(releaseCmd, restoreInjectedCmd, appendCmd)
 	}
 
 	m.activity = uiActivityIdle
@@ -377,31 +382,22 @@ func (c uiInputController) handleCompactDone(msg compactDoneMsg) (tea.Model, tea
 		c.notifyUserCompactionCompleted(compactionOrigin, false)
 		next, cmd := c.flushQueuedInputs(queueDrainAuto)
 		c.notifyTurnQueueDrainedIfIdle()
-		return next, cmd
+		return next, tea.Batch(releaseCmd, cmd)
 	}
-	queuedRuntimeWork, err := m.hasQueuedRuntimeUserWork()
-	if err != nil {
-		c.restorePendingInjectedIntoInput()
-		if isInterruptedRuntimeError(err) {
-			m.activity = uiActivityInterrupted
-			m.logf("step.interrupted")
-			m.syncViewport()
-			return m, nil
-		}
-		detailErr := formatSubmissionError(err)
-		m.activity = uiActivityError
-		appendCmd := m.appendOperatorErrorFeedback(detailErr)
-		m.logf("queue_check.error err=%q", detailErr)
-		m.syncViewport()
-		return m, appendCmd
-	}
-	if queuedRuntimeWork {
+	if m.injectedQueueBlocksDrain() {
 		c.notifyUserCompactionCompleted(compactionOrigin, false)
-		return m, c.startQueuedInjectionSubmission()
+		m.queuedRuntimeWorkCheckCompactionOrigin = compactionOrigin
+		m.syncViewport()
+		return m, releaseCmd
 	}
-	c.notifyUserCompactionCompleted(compactionOrigin, !m.pendingQueuedDrainAfterHydration)
+	if !m.hasRuntimeClient() {
+		c.notifyUserCompactionCompleted(compactionOrigin, !m.pendingQueuedDrainAfterHydration)
+		m.syncViewport()
+		return m, releaseCmd
+	}
+	m.queuedRuntimeWorkCheckCompactionOrigin = compactionOrigin
 	m.syncViewport()
-	return m, nil
+	return m, tea.Batch(releaseCmd, c.startQueuedInjectionSubmission())
 }
 
 func (c uiInputController) notifyUserCompactionCompleted(origin uiCompactionOrigin, queueDrained bool) {

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -263,7 +263,7 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 			m.activity = uiActivityInterrupted
 			m.logf("step.interrupted")
 			m.syncViewport()
-			return m, nil
+			return m, batchCmds(unlockCmd, restoreInjectedCmd)
 		}
 		detailErr := formatSubmissionError(msg.err)
 		m.activity = uiActivityError

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -25,6 +25,9 @@ func (c uiInputController) startSubmissionWithPreSubmitQueuePosition(text string
 	if blocked, disconnectCmd := c.blockDisconnectedSubmission(true, text); blocked {
 		return disconnectCmd
 	}
+	if blocked, blockCmd := c.blockInjectedQueueSubmission(); blocked {
+		return blockCmd
+	}
 	c.startBusyActivity(false)
 	command, isUserShell := parseUserShellCommand(text)
 	if isUserShell {

--- a/cli/app/ui_layout.go
+++ b/cli/app/ui_layout.go
@@ -39,6 +39,7 @@ type nativeLiveRegionState struct {
 }
 
 func (m *uiModel) View() string {
+	defer m.enterUIMainThread("View")()
 	return m.layout().render()
 }
 

--- a/cli/app/ui_layout_rendering_status.go
+++ b/cli/app/ui_layout_rendering_status.go
@@ -35,7 +35,7 @@ func (l uiViewLayout) renderStatusLine(width int, style uiStyles) string {
 	if branchLabel := l.statusBranchLabel(); branchLabel != "" {
 		segments = append(segments, style.meta.Render(branchLabel))
 	}
-	if label := processCountLabel(m.listProcesses()); label != "" {
+	if label := processCountLabel(m.processList.entries); label != "" {
 		segments = append(segments, style.meta.Render(label))
 	}
 	if serverOwnershipSection := l.renderServerOwnershipSection(style); serverOwnershipSection != "" {

--- a/cli/app/ui_main_thread_strict.go
+++ b/cli/app/ui_main_thread_strict.go
@@ -1,0 +1,85 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+type tuiStrictIOMode string
+
+const (
+	tuiStrictIOModeOff   tuiStrictIOMode = "off"
+	tuiStrictIOModeLog   tuiStrictIOMode = "log"
+	tuiStrictIOModePanic tuiStrictIOMode = "panic"
+)
+
+type uiMainThreadState struct {
+	depth    int
+	activity string
+}
+
+var defaultTUIStrictIOMode = tuiStrictIOModeLog
+
+func parseTUIStrictIOMode(value string) (tuiStrictIOMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return "", false
+	case string(tuiStrictIOModeOff), "0", "false", "no":
+		return tuiStrictIOModeOff, true
+	case string(tuiStrictIOModeLog), "warn", "warning", "1", "true", "yes":
+		return tuiStrictIOModeLog, true
+	case string(tuiStrictIOModePanic), "crash", "fail":
+		return tuiStrictIOModePanic, true
+	default:
+		return "", false
+	}
+}
+
+func initialTUIStrictIOMode(debug bool) (tuiStrictIOMode, bool) {
+	if mode, ok := parseTUIStrictIOMode(os.Getenv("BUILDER_TUI_STRICT_IO")); ok {
+		return mode, true
+	}
+	if debug {
+		return tuiStrictIOModePanic, false
+	}
+	return defaultTUIStrictIOMode, false
+}
+
+func (m *uiModel) enterUIMainThread(activity string) func() {
+	if m == nil {
+		return func() {}
+	}
+	previous := m.uiMainThread.activity
+	m.uiMainThread.depth++
+	m.uiMainThread.activity = strings.TrimSpace(activity)
+	return func() {
+		if m.uiMainThread.depth > 0 {
+			m.uiMainThread.depth--
+		}
+		if m.uiMainThread.depth == 0 {
+			m.uiMainThread.activity = previous
+		}
+	}
+}
+
+func (m *uiModel) checkTUIBlockingOperation(kind, detail string) {
+	if m == nil || m.uiMainThread.depth <= 0 {
+		return
+	}
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		kind = "blocking operation"
+	}
+	detail = strings.TrimSpace(detail)
+	message := fmt.Sprintf("TUI main-thread I/O violation during %s: %s", m.uiMainThread.activity, kind)
+	if detail != "" {
+		message += " (" + detail + ")"
+	}
+	switch m.tuiStrictIOMode {
+	case tuiStrictIOModePanic:
+		panic(message)
+	case tuiStrictIOModeLog:
+		m.logf("%s", message)
+	}
+}

--- a/cli/app/ui_main_thread_strict.go
+++ b/cli/app/ui_main_thread_strict.go
@@ -2,48 +2,12 @@ package app
 
 import (
 	"fmt"
-	"os"
 	"strings"
-)
-
-type tuiStrictIOMode string
-
-const (
-	tuiStrictIOModeOff   tuiStrictIOMode = "off"
-	tuiStrictIOModeLog   tuiStrictIOMode = "log"
-	tuiStrictIOModePanic tuiStrictIOMode = "panic"
 )
 
 type uiMainThreadState struct {
 	depth    int
 	activity string
-}
-
-var defaultTUIStrictIOMode = tuiStrictIOModeLog
-
-func parseTUIStrictIOMode(value string) (tuiStrictIOMode, bool) {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "":
-		return "", false
-	case string(tuiStrictIOModeOff), "0", "false", "no":
-		return tuiStrictIOModeOff, true
-	case string(tuiStrictIOModeLog), "warn", "warning", "1", "true", "yes":
-		return tuiStrictIOModeLog, true
-	case string(tuiStrictIOModePanic), "crash", "fail":
-		return tuiStrictIOModePanic, true
-	default:
-		return "", false
-	}
-}
-
-func initialTUIStrictIOMode(debug bool) (tuiStrictIOMode, bool) {
-	if mode, ok := parseTUIStrictIOMode(os.Getenv("BUILDER_TUI_STRICT_IO")); ok {
-		return mode, true
-	}
-	if debug {
-		return tuiStrictIOModePanic, false
-	}
-	return defaultTUIStrictIOMode, false
 }
 
 func (m *uiModel) enterUIMainThread(activity string) func() {
@@ -76,10 +40,8 @@ func (m *uiModel) checkTUIBlockingOperation(kind, detail string) {
 	if detail != "" {
 		message += " (" + detail + ")"
 	}
-	switch m.tuiStrictIOMode {
-	case tuiStrictIOModePanic:
+	if m.debugMode {
 		panic(message)
-	case tuiStrictIOModeLog:
-		m.logf("%s", message)
 	}
+	m.logf("%s", message)
 }

--- a/cli/app/ui_main_thread_strict_test.go
+++ b/cli/app/ui_main_thread_strict_test.go
@@ -1,0 +1,210 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	appstatus "builder/cli/app/internal/status"
+	"builder/shared/clientui"
+	"builder/shared/serverapi"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type strictBlockingProbeMsg struct{}
+
+func (strictBlockingProbeMsg) probeUIModel(m *uiModel) {
+	m.checkTUIBlockingOperation("test blocking read", "probe")
+}
+
+func TestTUIStrictIOPanicsInsideUpdateWhenDebugEnabled(t *testing.T) {
+	m := newProjectedStaticUIModel(WithUIDebug(true))
+
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatal("expected strict-mode panic")
+		}
+		if !strings.Contains(recovered.(string), "TUI main-thread I/O violation during Update") {
+			t.Fatalf("unexpected panic: %v", recovered)
+		}
+	}()
+
+	_, _ = m.Update(strictBlockingProbeMsg{})
+}
+
+type countingProcessClient struct {
+	listCalls int
+}
+
+func (c *countingProcessClient) ListProcesses(context.Context) ([]clientui.BackgroundProcess, error) {
+	c.listCalls++
+	return []clientui.BackgroundProcess{{ID: "proc-1", Running: true, State: "running"}}, nil
+}
+
+func (*countingProcessClient) KillProcess(context.Context, string) error {
+	return nil
+}
+
+func (*countingProcessClient) InlineOutput(context.Context, string, int) (string, string, error) {
+	return "", "", nil
+}
+
+func TestTUIStrictIOViewDoesNotFetchProcessesForStatusOrOverlay(t *testing.T) {
+	processes := &countingProcessClient{}
+	m := newProjectedStaticUIModel(
+		WithUIProcessClient(processes),
+		WithUITUIStrictIO("panic"),
+	)
+	m.termWidth = 100
+	m.termHeight = 14
+	m.windowSizeKnown = true
+	m.openProcessList()
+	m.activeSurface = uiSurfaceProcessList
+
+	_ = m.View()
+
+	if processes.listCalls != 0 {
+		t.Fatalf("expected View not to list processes, got %d calls", processes.listCalls)
+	}
+}
+
+func TestTUIStrictIOBusyEnterQueuesInjectedInputAsCommand(t *testing.T) {
+	client := &runtimeControlFakeClient{queueUserMessageID: "server-queue-1"}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUITUIStrictIO("panic"))
+	m.startupCmds = nil
+	m.setBusy(true)
+	m.input = "queued steering"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected queue create command")
+	}
+	if client.queueUserMessageCalls != 0 {
+		t.Fatalf("QueueUserMessage called during Update: %d", client.queueUserMessageCalls)
+	}
+	updated = applyFirstInjectedQueueCreateDoneForTest(t, updated, cmd)
+	if client.queueUserMessageCalls != 1 {
+		t.Fatalf("QueueUserMessage calls after command = %d, want 1", client.queueUserMessageCalls)
+	}
+	if len(updated.pendingInjected) != 1 || updated.pendingInjected[0].ID != "server-queue-1" {
+		t.Fatalf("expected server queue item after command, got %+v", updated.pendingInjected)
+	}
+}
+
+func TestTUIStrictIOCompactDoneChecksQueuedRuntimeWorkAsCommand(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUITUIStrictIO("panic"))
+	m.startupCmds = nil
+	m.setBusy(true)
+	m.setCompacting(true)
+	m.activity = uiActivityRunning
+
+	next, cmd := m.Update(compactDoneMsg{})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected queued-work check command")
+	}
+	if client.hasQueuedUserWorkCalls != 0 {
+		t.Fatalf("HasQueuedUserWork called during Update: %d", client.hasQueuedUserWorkCalls)
+	}
+	_, _ = applyQueuedRuntimeWorkCheckForTest(t, updated, cmd)
+	if client.hasQueuedUserWorkCalls != 1 {
+		t.Fatalf("HasQueuedUserWork calls after command = %d, want 1", client.hasQueuedUserWorkCalls)
+	}
+}
+
+func TestTUIStrictIORuntimeControlSlashRunsAsCommand(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUITUIStrictIO("panic"))
+	m.startupCmds = nil
+
+	handled, _, cmd := m.inputController().handleEnteredSlashCommandInput("/name New Name")
+	if !handled {
+		t.Fatal("expected /session slash command to be handled")
+	}
+	if cmd == nil {
+		t.Fatal("expected runtime-control command")
+	}
+	if client.setSessionNameArg != "" {
+		t.Fatalf("SetSessionName called during Update with %q", client.setSessionNameArg)
+	}
+	msgs := collectCmdMessages(t, cmd)
+	if client.setSessionNameArg != "New Name" {
+		t.Fatalf("SetSessionName after command = %q, want New Name; msgs=%+v", client.setSessionNameArg, msgs)
+	}
+}
+
+type strictCountingStatusCollector struct {
+	baseCalls int
+}
+
+func (c *strictCountingStatusCollector) Collect(context.Context, uiStatusRequest) (uiStatusSnapshot, error) {
+	return uiStatusSnapshot{}, nil
+}
+
+func (c *strictCountingStatusCollector) CollectBase(req uiStatusRequest) uiStatusSnapshot {
+	c.baseCalls++
+	return appstatus.Snapshot{CollectedAt: req.CurrentTime}
+}
+
+func (c *strictCountingStatusCollector) CollectAuth(context.Context, uiStatusRequest, uiStatusSnapshot) uiStatusAuthStageResult {
+	return uiStatusAuthStageResult{}
+}
+
+func (c *strictCountingStatusCollector) CollectGit(context.Context, uiStatusRequest, uiStatusSnapshot) uiStatusGitStageResult {
+	return uiStatusGitStageResult{}
+}
+
+func (c *strictCountingStatusCollector) CollectEnvironment(context.Context, uiStatusRequest, uiStatusSnapshot) uiStatusEnvironmentStageResult {
+	return uiStatusEnvironmentStageResult{}
+}
+
+func TestTUIStrictIOStatusOpenDefersCollectorBaseToCommand(t *testing.T) {
+	collector := &strictCountingStatusCollector{}
+	repository := newMemoryUIStatusRepository()
+	request := populateStatusRequestCacheKeys(uiStatusRequest{WorkspaceRoot: t.TempDir(), CurrentTime: time.Now()})
+	repository.StoreGit(request.CacheKeys.Git, uiStatusGitStageResult{Git: uiStatusGitInfo{Visible: true, Branch: "cached"}}, time.Now())
+	m := newProjectedStaticUIModel(
+		WithUITUIStrictIO("panic"),
+		WithUIStatusCollector(collector),
+		WithUIStatusRepository(repository),
+		WithUIStatusConfig(uiStatusConfig{WorkspaceRoot: request.WorkspaceRoot}),
+	)
+
+	cmd := m.inputController().startStatusFlowCmd()
+	if cmd == nil {
+		t.Fatal("expected status refresh command")
+	}
+	if collector.baseCalls != 0 {
+		t.Fatalf("CollectBase called before command: %d", collector.baseCalls)
+	}
+	_ = collectCmdMessages(t, cmd)
+	if collector.baseCalls == 0 {
+		t.Fatal("expected CollectBase after executing returned command")
+	}
+}
+
+func TestTUIStrictIOWorktreeSwitchRunsAsCommand(t *testing.T) {
+	resp := testMainWorktreeListResponse()
+	resp.Worktrees = append(resp.Worktrees, serverapi.WorktreeView{
+		WorktreeID: "wt-feature", DisplayName: "feature", CanonicalRoot: "/repo-feature", BranchName: "feature",
+	})
+	client := &worktreeCommandTestClient{listResp: resp}
+	m := newWorktreeTestModel(t, client, WithUITUIStrictIO("panic"))
+
+	_, cmd := m.inputController().handleWorktreeCommand("switch feature")
+	if cmd == nil {
+		t.Fatal("expected worktree switch command")
+	}
+	if len(client.listRequests) != 0 || len(client.switchRequests) != 0 {
+		t.Fatalf("worktree client called before command: list=%d switch=%d", len(client.listRequests), len(client.switchRequests))
+	}
+	_ = collectCmdMessages(t, cmd)
+	if len(client.listRequests) == 0 || len(client.switchRequests) == 0 {
+		t.Fatalf("expected worktree list/switch after command, list=%d switch=%d", len(client.listRequests), len(client.switchRequests))
+	}
+}

--- a/cli/app/ui_main_thread_strict_test.go
+++ b/cli/app/ui_main_thread_strict_test.go
@@ -56,7 +56,7 @@ func TestTUIStrictIOViewDoesNotFetchProcessesForStatusOrOverlay(t *testing.T) {
 	processes := &countingProcessClient{}
 	m := newProjectedStaticUIModel(
 		WithUIProcessClient(processes),
-		WithUITUIStrictIO("panic"),
+		WithUIDebug(true),
 	)
 	m.termWidth = 100
 	m.termHeight = 14
@@ -73,7 +73,7 @@ func TestTUIStrictIOViewDoesNotFetchProcessesForStatusOrOverlay(t *testing.T) {
 
 func TestTUIStrictIOBusyEnterQueuesInjectedInputAsCommand(t *testing.T) {
 	client := &runtimeControlFakeClient{queueUserMessageID: "server-queue-1"}
-	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUITUIStrictIO("panic"))
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUIDebug(true))
 	m.startupCmds = nil
 	m.setBusy(true)
 	m.input = "queued steering"
@@ -97,7 +97,7 @@ func TestTUIStrictIOBusyEnterQueuesInjectedInputAsCommand(t *testing.T) {
 
 func TestTUIStrictIOCompactDoneChecksQueuedRuntimeWorkAsCommand(t *testing.T) {
 	client := &runtimeControlFakeClient{}
-	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUITUIStrictIO("panic"))
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUIDebug(true))
 	m.startupCmds = nil
 	m.setBusy(true)
 	m.setCompacting(true)
@@ -119,7 +119,7 @@ func TestTUIStrictIOCompactDoneChecksQueuedRuntimeWorkAsCommand(t *testing.T) {
 
 func TestTUIStrictIORuntimeControlSlashRunsAsCommand(t *testing.T) {
 	client := &runtimeControlFakeClient{}
-	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUITUIStrictIO("panic"))
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUIDebug(true))
 	m.startupCmds = nil
 
 	handled, _, cmd := m.inputController().handleEnteredSlashCommandInput("/name New Name")
@@ -169,7 +169,7 @@ func TestTUIStrictIOStatusOpenDefersCollectorBaseToCommand(t *testing.T) {
 	request := populateStatusRequestCacheKeys(uiStatusRequest{WorkspaceRoot: t.TempDir(), CurrentTime: time.Now()})
 	repository.StoreGit(request.CacheKeys.Git, uiStatusGitStageResult{Git: uiStatusGitInfo{Visible: true, Branch: "cached"}}, time.Now())
 	m := newProjectedStaticUIModel(
-		WithUITUIStrictIO("panic"),
+		WithUIDebug(true),
 		WithUIStatusCollector(collector),
 		WithUIStatusRepository(repository),
 		WithUIStatusConfig(uiStatusConfig{WorkspaceRoot: request.WorkspaceRoot}),
@@ -194,7 +194,7 @@ func TestTUIStrictIOWorktreeSwitchRunsAsCommand(t *testing.T) {
 		WorktreeID: "wt-feature", DisplayName: "feature", CanonicalRoot: "/repo-feature", BranchName: "feature",
 	})
 	client := &worktreeCommandTestClient{listResp: resp}
-	m := newWorktreeTestModel(t, client, WithUITUIStrictIO("panic"))
+	m := newWorktreeTestModel(t, client, WithUIDebug(true))
 
 	_, cmd := m.inputController().handleWorktreeCommand("switch feature")
 	if cmd == nil {

--- a/cli/app/ui_messages.go
+++ b/cli/app/ui_messages.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"os/exec"
 	"strings"
 	"time"
 
@@ -30,6 +31,82 @@ type promptHistoryPersistErrMsg struct {
 	err error
 }
 
+type localEntryPersistDoneMsg struct {
+	noticeID string
+	err      error
+}
+
+type authSlashCommandRefreshedMsg struct {
+	token      uint64
+	generation uint64
+	name       string
+	err        error
+}
+
+type goalRuntimeOperation string
+
+const (
+	goalRuntimeShow       goalRuntimeOperation = "show"
+	goalRuntimeCheckSet   goalRuntimeOperation = "check_set"
+	goalRuntimeCheckClear goalRuntimeOperation = "check_clear"
+	goalRuntimeSet        goalRuntimeOperation = "set"
+	goalRuntimePause      goalRuntimeOperation = "pause"
+	goalRuntimeResume     goalRuntimeOperation = "resume"
+	goalRuntimeClear      goalRuntimeOperation = "clear"
+)
+
+type goalRuntimeDoneMsg struct {
+	token     uint64
+	sessionID string
+	operation goalRuntimeOperation
+	objective string
+	goal      *clientui.RuntimeGoal
+	err       error
+}
+
+type runtimeControlOperation string
+
+const (
+	runtimeControlSetSessionName    runtimeControlOperation = "set_session_name"
+	runtimeControlSetThinkingLevel  runtimeControlOperation = "set_thinking_level"
+	runtimeControlSetFastMode       runtimeControlOperation = "set_fast_mode"
+	runtimeControlSetReviewer       runtimeControlOperation = "set_reviewer"
+	runtimeControlSetAutoCompaction runtimeControlOperation = "set_auto_compaction"
+	runtimeControlInterrupt         runtimeControlOperation = "interrupt"
+)
+
+type runtimeControlDoneMsg struct {
+	token          uint64
+	sessionID      string
+	operation      runtimeControlOperation
+	text           string
+	enabled        bool
+	changed        bool
+	mode           string
+	compactionMode string
+	err            error
+}
+
+type injectedQueueCreateDoneMsg struct {
+	token   uint64
+	localID string
+	item    clientui.QueuedUserMessage
+	err     error
+}
+
+type injectedQueueDiscardDoneMsg struct {
+	token     uint64
+	localID   string
+	serverID  string
+	discarded bool
+}
+
+type queuedRuntimeWorkCheckDoneMsg struct {
+	token   uint64
+	hasWork bool
+	err     error
+}
+
 type compactDoneMsg struct {
 	err error
 }
@@ -51,6 +128,24 @@ type spinnerTickMsg struct {
 }
 
 type processListRefreshTickMsg struct{}
+
+type processListRefreshDoneMsg struct {
+	token   uint64
+	entries []clientui.BackgroundProcess
+	err     error
+}
+
+type processActionDoneMsg struct {
+	token             uint64
+	surfaceGeneration uint64
+	inputDraftToken   uint64
+	action            string
+	id                string
+	output            string
+	logPath           string
+	editorCmd         *exec.Cmd
+	err               error
+}
 
 type openProcessLogsDoneMsg struct {
 	err error
@@ -103,6 +198,7 @@ type runtimeLeaseRecoveryWarningMsg struct {
 
 type runtimeMainViewRefreshedMsg struct {
 	token uint64
+	req   runtimeMainViewRefreshRequest
 	view  clientui.RuntimeMainView
 	err   error
 }
@@ -110,6 +206,7 @@ type runtimeMainViewRefreshedMsg struct {
 type runtimeTranscriptRefreshedMsg struct {
 	token         uint64
 	req           clientui.TranscriptPageRequest
+	syncRequest   runtimeTranscriptSyncRequest
 	syncCause     runtimeTranscriptSyncCause
 	transcript    clientui.TranscriptPage
 	recoveryCause clientui.TranscriptRecoveryCause
@@ -133,6 +230,7 @@ type runtimeTranscriptRetryMsg struct {
 	syncCause     runtimeTranscriptSyncCause
 	token         uint64
 	recoveryCause clientui.TranscriptRecoveryCause
+	req           runtimeTranscriptSyncRequest
 }
 
 type runtimeTranscriptSyncCause string
@@ -145,6 +243,14 @@ const (
 	runtimeTranscriptSyncCauseDirtyFollowUp           runtimeTranscriptSyncCause = "dirty_follow_up"
 	runtimeTranscriptSyncCauseContinuityRecovery      runtimeTranscriptSyncCause = "continuity_recovery"
 	runtimeTranscriptSyncCauseManualTranscriptRefresh runtimeTranscriptSyncCause = "manual_transcript_refresh"
+)
+
+type runtimeMainViewRefreshCause string
+
+const (
+	runtimeMainViewRefreshCauseWorktreeMutation runtimeMainViewRefreshCause = "worktree_mutation"
+	runtimeMainViewRefreshCauseManual           runtimeMainViewRefreshCause = "manual"
+	runtimeMainViewRefreshCauseStartupUpdate    runtimeMainViewRefreshCause = "startup_update"
 )
 
 type detailTranscriptLoadMsg struct{}

--- a/cli/app/ui_messages.go
+++ b/cli/app/ui_messages.go
@@ -88,10 +88,11 @@ type runtimeControlDoneMsg struct {
 }
 
 type injectedQueueCreateDoneMsg struct {
-	token   uint64
-	localID string
-	item    clientui.QueuedUserMessage
-	err     error
+	token                    uint64
+	localID                  string
+	item                     clientui.QueuedUserMessage
+	approvalCommentaryAnswer *clientui.PromptAnswer
+	err                      error
 }
 
 type injectedQueueDiscardDoneMsg struct {

--- a/cli/app/ui_messages.go
+++ b/cli/app/ui_messages.go
@@ -56,12 +56,13 @@ const (
 )
 
 type goalRuntimeDoneMsg struct {
-	token     uint64
-	sessionID string
-	operation goalRuntimeOperation
-	objective string
-	goal      *clientui.RuntimeGoal
-	err       error
+	token          uint64
+	sessionID      string
+	mutationSerial uint64
+	operation      goalRuntimeOperation
+	objective      string
+	goal           *clientui.RuntimeGoal
+	err            error
 }
 
 type runtimeControlOperation string

--- a/cli/app/ui_messages.go
+++ b/cli/app/ui_messages.go
@@ -292,6 +292,12 @@ type clipboardTextCopyDoneMsg struct {
 	Err error
 }
 
+type copyFinalAnswerDoneMsg struct {
+	NoAnswer   bool
+	RefreshErr error
+	CopyErr    error
+}
+
 type askEvent struct {
 	req              clientui.PendingPromptEvent
 	reply            chan askReply

--- a/cli/app/ui_messages.go
+++ b/cli/app/ui_messages.go
@@ -293,12 +293,6 @@ type clipboardTextCopyDoneMsg struct {
 	Err error
 }
 
-type copyFinalAnswerDoneMsg struct {
-	NoAnswer   bool
-	RefreshErr error
-	CopyErr    error
-}
-
 type askEvent struct {
 	req              clientui.PendingPromptEvent
 	reply            chan askReply

--- a/cli/app/ui_model_defaults.go
+++ b/cli/app/ui_model_defaults.go
@@ -66,13 +66,17 @@ func newUISessionTransitionFeatureState() uiSessionTransitionFeatureState {
 }
 
 func newUIStatusFeatureState() uiStatusFeatureState {
+	debug := envFlagEnabled("BUILDER_DEBUG")
+	strictMode, strictExplicit := initialTUIStrictIOMode(debug)
 	return uiStatusFeatureState{
-		statusRepository:      newMemoryUIStatusRepository(),
-		clipboardImagePaster:  newSystemClipboardImagePaster(),
-		clipboardTextCopier:   newSystemClipboardTextCopier(),
-		debugKeys:             envFlagEnabled("BUILDER_DEBUG_KEYS"),
-		debugMode:             envFlagEnabled("BUILDER_DEBUG"),
-		transcriptDiagnostics: envFlagEnabled("BUILDER_TRANSCRIPT_DIAGNOSTICS"),
+		statusRepository:        newMemoryUIStatusRepository(),
+		clipboardImagePaster:    newSystemClipboardImagePaster(),
+		clipboardTextCopier:     newSystemClipboardTextCopier(),
+		debugKeys:               envFlagEnabled("BUILDER_DEBUG_KEYS"),
+		debugMode:               debug,
+		transcriptDiagnostics:   envFlagEnabled("BUILDER_TRANSCRIPT_DIAGNOSTICS"),
+		tuiStrictIOMode:         strictMode,
+		tuiStrictIOModeExplicit: strictExplicit,
 	}
 }
 

--- a/cli/app/ui_model_defaults.go
+++ b/cli/app/ui_model_defaults.go
@@ -67,16 +67,13 @@ func newUISessionTransitionFeatureState() uiSessionTransitionFeatureState {
 
 func newUIStatusFeatureState() uiStatusFeatureState {
 	debug := envFlagEnabled("BUILDER_DEBUG")
-	strictMode, strictExplicit := initialTUIStrictIOMode(debug)
 	return uiStatusFeatureState{
-		statusRepository:        newMemoryUIStatusRepository(),
-		clipboardImagePaster:    newSystemClipboardImagePaster(),
-		clipboardTextCopier:     newSystemClipboardTextCopier(),
-		debugKeys:               envFlagEnabled("BUILDER_DEBUG_KEYS"),
-		debugMode:               debug,
-		transcriptDiagnostics:   envFlagEnabled("BUILDER_TRANSCRIPT_DIAGNOSTICS"),
-		tuiStrictIOMode:         strictMode,
-		tuiStrictIOModeExplicit: strictExplicit,
+		statusRepository:      newMemoryUIStatusRepository(),
+		clipboardImagePaster:  newSystemClipboardImagePaster(),
+		clipboardTextCopier:   newSystemClipboardTextCopier(),
+		debugKeys:             envFlagEnabled("BUILDER_DEBUG_KEYS"),
+		debugMode:             debug,
+		transcriptDiagnostics: envFlagEnabled("BUILDER_TRANSCRIPT_DIAGNOSTICS"),
 	}
 }
 

--- a/cli/app/ui_native_scrollback_integration_part4_test.go
+++ b/cli/app/ui_native_scrollback_integration_part4_test.go
@@ -428,6 +428,10 @@ func (c *slashLocalEntryRuntimeClient) SetAutoCompactionEnabled(enabled bool) (b
 	return true, enabled, nil
 }
 
+func (c *slashLocalEntryRuntimeClient) CachedMainView() (clientui.RuntimeMainView, bool) {
+	return c.MainView(), true
+}
+
 func (c *slashLocalEntryRuntimeClient) AppendLocalEntry(role, text string) error {
 	return c.AppendLocalEntryWithNoticeID(role, text, "")
 }

--- a/cli/app/ui_options.go
+++ b/cli/app/ui_options.go
@@ -63,7 +63,21 @@ func WithUITranscriptDiagnostics(enabled bool) UIOption {
 func WithUIDebug(enabled bool) UIOption {
 	return func(m *uiModel) {
 		m.debugMode = enabled
+		if enabled && !m.tuiStrictIOModeExplicit {
+			m.tuiStrictIOMode = tuiStrictIOModePanic
+		}
 		m.updateTranscriptDiagnosticsMode()
+	}
+}
+
+func WithUITUIStrictIO(mode string) UIOption {
+	return func(m *uiModel) {
+		parsed, ok := parseTUIStrictIOMode(mode)
+		if !ok {
+			return
+		}
+		m.tuiStrictIOMode = parsed
+		m.tuiStrictIOModeExplicit = true
 	}
 }
 

--- a/cli/app/ui_options.go
+++ b/cli/app/ui_options.go
@@ -63,21 +63,7 @@ func WithUITranscriptDiagnostics(enabled bool) UIOption {
 func WithUIDebug(enabled bool) UIOption {
 	return func(m *uiModel) {
 		m.debugMode = enabled
-		if enabled && !m.tuiStrictIOModeExplicit {
-			m.tuiStrictIOMode = tuiStrictIOModePanic
-		}
 		m.updateTranscriptDiagnosticsMode()
-	}
-}
-
-func WithUITUIStrictIO(mode string) UIOption {
-	return func(m *uiModel) {
-		parsed, ok := parseTUIStrictIOMode(mode)
-		if !ok {
-			return
-		}
-		m.tuiStrictIOMode = parsed
-		m.tuiStrictIOModeExplicit = true
 	}
 }
 

--- a/cli/app/ui_part2_test.go
+++ b/cli/app/ui_part2_test.go
@@ -778,6 +778,52 @@ func TestApprovalAskAnswersWhenCommentaryQueueFails(t *testing.T) {
 	}
 }
 
+func TestApprovalAskIgnoresRepeatSubmitWhileCommentaryQueuePending(t *testing.T) {
+	client := &runtimeControlFakeClient{queueUserMessageID: "server-commentary-1"}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.setBusy(true)
+	reply := make(chan askReply, 1)
+	event := askEvent{req: clientui.PendingPromptEvent{Question: "Approve?", Approval: true, ApprovalOptions: []clientui.ApprovalOption{{Decision: clientui.ApprovalDecisionAllowOnce, Label: "Allow once"}, {Decision: clientui.ApprovalDecisionDeny, Label: "Deny"}}}, reply: reply}
+
+	next, _ := m.Update(askEventMsg{event: event})
+	updated := next.(*uiModel)
+	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyTab})
+	updated = next.(*uiModel)
+	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("queue once")})
+	updated = next.(*uiModel)
+	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected first approval commentary queue command")
+	}
+	if !updated.ask.answerPending {
+		t.Fatal("expected ask answer pending while commentary queues")
+	}
+	next, secondCmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = next.(*uiModel)
+	if secondCmd != nil {
+		t.Fatal("did not expect repeat submit command while commentary queues")
+	}
+	if len(updated.injectedQueue) != 1 || len(updated.pendingInjected) != 1 {
+		t.Fatalf("expected one queued commentary item, pending=%+v queue=%+v", updated.pendingInjected, updated.injectedQueue)
+	}
+	select {
+	case <-reply:
+		t.Fatal("did not expect approval answer before first queue completes")
+	default:
+	}
+
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, cmd = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
+	resp := <-reply
+	if resp.response.Approval == nil || resp.response.Approval.Commentary != "queue once" {
+		t.Fatalf("unexpected approval response after queued commentary: %+v", resp.response.Approval)
+	}
+}
+
 func TestAskEventsQueueUntilCurrentQuestionAnswered(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	reply1 := make(chan askReply, 1)

--- a/cli/app/ui_part2_test.go
+++ b/cli/app/ui_part2_test.go
@@ -731,6 +731,53 @@ func TestApprovalAskTabAllowsWithCommentary(t *testing.T) {
 	}
 }
 
+func TestApprovalAskAnswersWhenCommentaryQueueFails(t *testing.T) {
+	client := &runtimeControlFakeClient{queueUserMessageErr: errors.New("queue create failed")}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.setBusy(true)
+	reply := make(chan askReply, 1)
+	event := askEvent{req: clientui.PendingPromptEvent{Question: "Approve?", Approval: true, ApprovalOptions: []clientui.ApprovalOption{{Decision: clientui.ApprovalDecisionAllowOnce, Label: "Allow once"}, {Decision: clientui.ApprovalDecisionDeny, Label: "Deny"}}}, reply: reply}
+
+	next, _ := m.Update(askEventMsg{event: event})
+	updated := next.(*uiModel)
+	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyTab})
+	updated = next.(*uiModel)
+	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("please be careful")})
+	updated = next.(*uiModel)
+	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected approval commentary queue command")
+	}
+	select {
+	case <-reply:
+		t.Fatal("did not expect approval answer before failed queue completion")
+	default:
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, cmd = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
+
+	resp := <-reply
+	if resp.response.Approval == nil {
+		t.Fatal("expected approval answer after failed commentary queue")
+	}
+	if resp.response.Approval.Decision != clientui.ApprovalDecisionAllowOnce || resp.response.Approval.Commentary != "please be careful" {
+		t.Fatalf("unexpected approval response after failed queue: %+v", resp.response.Approval)
+	}
+	if updated.input != "please be careful" {
+		t.Fatalf("expected failed commentary restored into input, got %q", updated.input)
+	}
+	if len(updated.pendingInjected) != 0 || len(updated.injectedQueue) != 0 {
+		t.Fatalf("expected failed commentary queue removed, pending=%+v queue=%+v", updated.pendingInjected, updated.injectedQueue)
+	}
+	if testActiveAsk(updated) != nil {
+		t.Fatal("expected ask to resolve after failed approval commentary queue")
+	}
+}
+
 func TestAskEventsQueueUntilCurrentQuestionAnswered(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	reply1 := make(chan askReply, 1)

--- a/cli/app/ui_part2_test.go
+++ b/cli/app/ui_part2_test.go
@@ -701,8 +701,20 @@ func TestApprovalAskTabAllowsWithCommentary(t *testing.T) {
 
 	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("ok but please keep it minimal")})
 	updated = next.(*uiModel)
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected approval commentary queue command")
+	}
+	select {
+	case <-reply:
+		t.Fatal("did not expect approval answer before commentary queue command completes")
+	default:
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, cmd = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
 
 	resp := <-reply
 	if resp.response.Approval == nil {

--- a/cli/app/ui_part3_test.go
+++ b/cli/app/ui_part3_test.go
@@ -804,8 +804,20 @@ func TestApprovalAskTabCommentaryUsesCurrentSelection(t *testing.T) {
 	updated = next.(*uiModel)
 	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("session only")})
 	updated = next.(*uiModel)
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected approval commentary queue command")
+	}
+	select {
+	case <-reply:
+		t.Fatal("did not expect approval answer before commentary queue command completes")
+	default:
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, cmd = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
 
 	resp := <-reply
 	if resp.response.Approval == nil {

--- a/cli/app/ui_part4_test.go
+++ b/cli/app/ui_part4_test.go
@@ -123,6 +123,278 @@ func TestBusyEnterCanQueueMultipleSteeringMessages(t *testing.T) {
 	}
 }
 
+func TestBusyEnterQueuesInjectedInputWithoutRuntimeCreateDuringUpdate(t *testing.T) {
+	client := &runtimeControlFakeClient{queueUserMessageID: "server-queue-1"}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.setBusy(true)
+	m.input = "please continue with tests"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected async queue create command")
+	}
+	if client.queueUserMessageCalls != 0 {
+		t.Fatalf("QueueUserMessage called during Update: %d", client.queueUserMessageCalls)
+	}
+	if len(updated.pendingInjected) != 1 || updated.pendingInjected[0].ID == "server-queue-1" {
+		t.Fatalf("expected provisional pending injected item before command, got %+v", updated.pendingInjected)
+	}
+
+	msgs := collectCmdMessages(t, cmd)
+	if client.queueUserMessageCalls != 1 || client.queuedText != "please continue with tests" {
+		t.Fatalf("expected one command-time queue create, calls=%d text=%q", client.queueUserMessageCalls, client.queuedText)
+	}
+	var createDone injectedQueueCreateDoneMsg
+	for _, msg := range msgs {
+		if typed, ok := msg.(injectedQueueCreateDoneMsg); ok {
+			createDone = typed
+		}
+	}
+	if createDone.item.ID != "server-queue-1" {
+		t.Fatalf("expected server queue id in completion, got %+v", createDone)
+	}
+
+	next, _ = updated.Update(createDone)
+	updated = next.(*uiModel)
+	if len(updated.pendingInjected) != 1 || updated.pendingInjected[0].ID != "server-queue-1" {
+		t.Fatalf("expected pending injected item to adopt server id, got %+v", updated.pendingInjected)
+	}
+	if updated.injectedQueueBlocksDrain() {
+		t.Fatalf("did not expect enqueued item to block drain, state=%+v", updated.injectedQueue)
+	}
+}
+
+func TestPendingInjectedCreateCanceledBeforeCompletionDiscardsLateServerItem(t *testing.T) {
+	client := &runtimeControlFakeClient{queueUserMessageID: "server-queue-1", discardQueuedResult: true}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.setBusy(true)
+	m.input = "restore this steering"
+
+	next, createCmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	if createCmd == nil {
+		t.Fatal("expected async queue create command")
+	}
+	next, _ = updated.Update(submitDoneMsg{err: errors.New("network failure")})
+	updated = next.(*uiModel)
+	if updated.input != "restore this steering" {
+		t.Fatalf("expected pending injected text restored, got %q", updated.input)
+	}
+	if len(updated.pendingInjected) != 0 {
+		t.Fatalf("expected pending projection cleared before create completion, got %+v", updated.pendingInjected)
+	}
+	if client.discardQueuedCalls != 0 {
+		t.Fatalf("discard called before server id existed: %d", client.discardQueuedCalls)
+	}
+
+	msgs := collectCmdMessages(t, createCmd)
+	var createDone injectedQueueCreateDoneMsg
+	for _, msg := range msgs {
+		if typed, ok := msg.(injectedQueueCreateDoneMsg); ok {
+			createDone = typed
+		}
+	}
+	next, discardCmd := updated.Update(createDone)
+	updated = next.(*uiModel)
+	if discardCmd == nil {
+		t.Fatal("expected late create success to schedule discard")
+	}
+	if client.discardQueuedCalls != 0 {
+		t.Fatalf("discard called during create completion Update: %d", client.discardQueuedCalls)
+	}
+	discardMsgs := collectCmdMessages(t, discardCmd)
+	if client.discardQueuedCalls != 1 || client.discardQueuedID != "server-queue-1" {
+		t.Fatalf("expected command-time discard of late queue item, calls=%d id=%q", client.discardQueuedCalls, client.discardQueuedID)
+	}
+	var discardDone injectedQueueDiscardDoneMsg
+	for _, msg := range discardMsgs {
+		if typed, ok := msg.(injectedQueueDiscardDoneMsg); ok {
+			discardDone = typed
+		}
+	}
+	next, _ = updated.Update(discardDone)
+	updated = next.(*uiModel)
+	if len(updated.injectedQueue) != 0 {
+		t.Fatalf("expected late-created canceled item removed after discard, got %+v", updated.injectedQueue)
+	}
+}
+
+func TestDiscardFailedInjectedQueueBlocksRuntimeQueuedDrain(t *testing.T) {
+	client := &runtimeControlFakeClient{hasQueuedUserWork: true, queueUserMessageID: "server-queue-1"}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.pendingInjected = []clientui.QueuedUserMessage{{ID: "server-queue-1", Text: "blocked steering"}}
+	m.injectedQueue = []injectedRuntimeQueueItem{{
+		LocalID:  "local-queue-1",
+		ServerID: "server-queue-1",
+		Text:     "blocked steering",
+		State:    injectedRuntimeQueueEnqueued,
+	}}
+
+	restoreCmd := m.inputController().restorePendingInjectedIntoInput()
+	if restoreCmd == nil {
+		t.Fatal("expected restore to schedule discard")
+	}
+	msgs := collectCmdMessages(t, restoreCmd)
+	var discardDone injectedQueueDiscardDoneMsg
+	for _, msg := range msgs {
+		if typed, ok := msg.(injectedQueueDiscardDoneMsg); ok {
+			discardDone = typed
+		}
+	}
+	next, _ := m.Update(discardDone)
+	updated := next.(*uiModel)
+	if !updated.injectedQueueBlocksDrain() {
+		t.Fatalf("expected discard failure to block drain, state=%+v", updated.injectedQueue)
+	}
+	if cmd := updated.inputController().startQueuedInjectionSubmission(); cmd != nil {
+		t.Fatal("did not expect queued runtime work check while discard failure blocks drain")
+	}
+	if client.hasQueuedUserWorkCalls != 0 || client.submitQueuedCalls != 0 {
+		t.Fatalf("expected no runtime queued-work calls while blocked, check=%d submit=%d", client.hasQueuedUserWorkCalls, client.submitQueuedCalls)
+	}
+}
+
+func TestPendingInjectedCreateFailureRestoresInputAndSurfacesError(t *testing.T) {
+	boom := errors.New("queue create failed")
+	client := &runtimeControlFakeClient{queueUserMessageErr: boom}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.setBusy(true)
+	m.input = "restore failed create"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected async queue create command")
+	}
+	msgs := collectCmdMessages(t, cmd)
+	var createDone injectedQueueCreateDoneMsg
+	for _, msg := range msgs {
+		if typed, ok := msg.(injectedQueueCreateDoneMsg); ok {
+			createDone = typed
+		}
+	}
+	next, persistCmd := updated.Update(createDone)
+	updated = next.(*uiModel)
+	if updated.input != "restore failed create" {
+		t.Fatalf("expected failed queue text restored, got %q", updated.input)
+	}
+	if len(updated.pendingInjected) != 0 || len(updated.injectedQueue) != 0 {
+		t.Fatalf("expected failed queue removed, pending=%+v state=%+v", updated.pendingInjected, updated.injectedQueue)
+	}
+	if updated.activity != uiActivityError {
+		t.Fatalf("expected error activity, got %v", updated.activity)
+	}
+	_ = collectCmdMessages(t, persistCmd)
+	if client.appendedRole != string(transcript.EntryRoleDeveloperErrorFeedback) || !strings.Contains(client.appendedText, "queue create failed") {
+		t.Fatalf("expected runtime-persisted queue create error, role=%q text=%q", client.appendedRole, client.appendedText)
+	}
+}
+
+func TestCompactionCompletionWaitsForPendingInjectedCreateBeforeResumingQueuedRuntimeWork(t *testing.T) {
+	client := &runtimeControlFakeClient{hasQueuedUserWork: true, queueUserMessageID: "server-queue-1", submitQueuedResult: "done"}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.setBusy(true)
+	m.setCompacting(true)
+	m.activity = uiActivityRunning
+	m.input = "late steering"
+
+	next, createCmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	next, compactCmd := updated.Update(compactDoneMsg{})
+	updated = next.(*uiModel)
+	if compactCmd != nil {
+		t.Fatalf("did not expect queued-work check while create is pending, got %T", compactCmd())
+	}
+	if client.hasQueuedUserWorkCalls != 0 || client.submitQueuedCalls != 0 {
+		t.Fatalf("runtime queue checked/submitted before create completion: check=%d submit=%d", client.hasQueuedUserWorkCalls, client.submitQueuedCalls)
+	}
+
+	msgs := collectCmdMessages(t, createCmd)
+	var createDone injectedQueueCreateDoneMsg
+	for _, msg := range msgs {
+		if typed, ok := msg.(injectedQueueCreateDoneMsg); ok {
+			createDone = typed
+		}
+	}
+	next, checkCmd := updated.Update(createDone)
+	updated = next.(*uiModel)
+	if checkCmd == nil {
+		t.Fatal("expected create completion to schedule queued-work check")
+	}
+	updated, submitCmd := applyQueuedRuntimeWorkCheckForTest(t, updated, checkCmd)
+	if client.hasQueuedUserWorkCalls != 1 {
+		t.Fatalf("HasQueuedUserWork calls = %d, want 1", client.hasQueuedUserWorkCalls)
+	}
+	if submitCmd == nil || !updated.isBusy() {
+		t.Fatalf("expected queued runtime work to resume after safe create, busy=%t cmd=%v", updated.isBusy(), submitCmd)
+	}
+	_ = collectCmdMessages(t, submitCmd)
+	if client.submitQueuedCalls != 1 {
+		t.Fatalf("SubmitQueuedUserMessages calls = %d, want 1", client.submitQueuedCalls)
+	}
+}
+
+func TestLateCreateDiscardFailureBlocksDrainUntilRetrySucceeds(t *testing.T) {
+	client := &runtimeControlFakeClient{hasQueuedUserWork: true, queueUserMessageID: "server-queue-1"}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.setBusy(true)
+	m.input = "restore late create"
+
+	next, createCmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	next, _ = updated.Update(submitDoneMsg{err: errors.New("network failure")})
+	updated = next.(*uiModel)
+	msgs := collectCmdMessages(t, createCmd)
+	var createDone injectedQueueCreateDoneMsg
+	for _, msg := range msgs {
+		if typed, ok := msg.(injectedQueueCreateDoneMsg); ok {
+			createDone = typed
+		}
+	}
+	next, discardCmd := updated.Update(createDone)
+	updated = next.(*uiModel)
+	discardMsgs := collectCmdMessages(t, discardCmd)
+	var discardDone injectedQueueDiscardDoneMsg
+	for _, msg := range discardMsgs {
+		if typed, ok := msg.(injectedQueueDiscardDoneMsg); ok {
+			discardDone = typed
+		}
+	}
+	next, _ = updated.Update(discardDone)
+	updated = next.(*uiModel)
+	if !updated.injectedQueueBlocksDrain() {
+		t.Fatalf("expected late-create discard failure to block drain, state=%+v", updated.injectedQueue)
+	}
+	if len(updated.pendingInjected) != 1 || updated.pendingInjected[0].ID != "server-queue-1" {
+		t.Fatalf("expected failed discard to re-adopt server item visibly, got %+v", updated.pendingInjected)
+	}
+
+	client.discardQueuedResult = true
+	retryCmd := updated.inputController().restorePendingInjectedIntoInput()
+	if retryCmd == nil {
+		t.Fatal("expected discard retry command")
+	}
+	retryMsgs := collectCmdMessages(t, retryCmd)
+	var retryDone injectedQueueDiscardDoneMsg
+	for _, msg := range retryMsgs {
+		if typed, ok := msg.(injectedQueueDiscardDoneMsg); ok {
+			retryDone = typed
+		}
+	}
+	next, _ = updated.Update(retryDone)
+	updated = next.(*uiModel)
+	if updated.injectedQueueBlocksDrain() || len(updated.injectedQueue) != 0 {
+		t.Fatalf("expected successful retry to unblock drain, state=%+v", updated.injectedQueue)
+	}
+}
+
 func TestBusySteeringBatchFlushPreservesPostTurnQueueOrder(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.setBusy(true)
@@ -272,7 +544,7 @@ func TestRuntimeClientDirectSubmitInterruptRestoresInputWithoutQueueing(t *testi
 	if updated.activeSubmit.text != "direct submit" {
 		t.Fatalf("active submit text = %q, want direct submit", updated.activeSubmit.text)
 	}
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 	updated = next.(*uiModel)
 	updated = applyInterruptedRunStateForTest(t, updated)
 
@@ -282,8 +554,12 @@ func TestRuntimeClientDirectSubmitInterruptRestoresInputWithoutQueueing(t *testi
 	if len(updated.queued) != 0 {
 		t.Fatalf("interrupted direct submit should not enter visible queue, got %+v", updated.queued)
 	}
+	if client.interruptCalls != 0 {
+		t.Fatalf("interrupt calls during Update = %d, want 0", client.interruptCalls)
+	}
+	_ = collectCmdMessages(t, cmd)
 	if client.interruptCalls != 1 {
-		t.Fatalf("interrupt calls = %d, want 1", client.interruptCalls)
+		t.Fatalf("interrupt calls after command = %d, want 1", client.interruptCalls)
 	}
 }
 
@@ -1062,11 +1338,19 @@ func TestCompactDoneSurfacesQueuedRuntimeWorkProbeFailure(t *testing.T) {
 	m.setCompacting(true)
 	m.activity = uiActivityRunning
 
-	next, _ := m.Update(compactDoneMsg{})
+	next, cmd := m.Update(compactDoneMsg{})
 	updated := next.(*uiModel)
+	updated, cmd = applyQueuedRuntimeWorkCheckForTest(t, updated, cmd)
 	if updated.activity != uiActivityError {
 		t.Fatalf("expected error activity after queued runtime work probe failure, got %v", updated.activity)
 	}
+	if len(updated.transcriptEntries) != 1 || updated.transcriptEntries[0].Role != tui.TranscriptRoleDeveloperErrorFeedback || !strings.Contains(updated.transcriptEntries[0].Text, "daemon stalled") {
+		t.Fatalf("expected local error entry with probe failure, got %+v", updated.transcriptEntries)
+	}
+	if client.appendedRole != "" || client.appendedText != "" {
+		t.Fatalf("did not expect runtime append during Update, got role=%q text=%q", client.appendedRole, client.appendedText)
+	}
+	_ = collectCmdMessages(t, cmd)
 	if client.appendedRole != string(transcript.EntryRoleDeveloperErrorFeedback) || !strings.Contains(client.appendedText, "daemon stalled") {
 		t.Fatalf("expected runtime error entry with probe failure, role=%q text=%q", client.appendedRole, client.appendedText)
 	}
@@ -1080,8 +1364,9 @@ func TestCompactDoneSuppressesQueuedRuntimeWorkProbeCancellation(t *testing.T) {
 	m.setCompacting(true)
 	m.activity = uiActivityRunning
 
-	next, _ := m.Update(compactDoneMsg{})
+	next, cmd := m.Update(compactDoneMsg{})
 	updated := next.(*uiModel)
+	updated, _ = applyQueuedRuntimeWorkCheckForTest(t, updated, cmd)
 	if updated.activity != uiActivityInterrupted {
 		t.Fatalf("expected interrupted activity after queued runtime work probe cancellation, got %v", updated.activity)
 	}

--- a/cli/app/ui_part4_test.go
+++ b/cli/app/ui_part4_test.go
@@ -312,6 +312,18 @@ func TestDiscardFailedInjectedQueueBlocksRuntimeQueuedDrain(t *testing.T) {
 	if client.hasQueuedUserWorkCalls != 0 || client.submitQueuedCalls != 0 {
 		t.Fatalf("expected no runtime queued-work calls while blocked, check=%d submit=%d", client.hasQueuedUserWorkCalls, client.submitQueuedCalls)
 	}
+	next, submitCmd := updated.inputController().queueOrStartSubmission(updated.input)
+	updated = next.(*uiModel)
+	if submitCmd == nil {
+		t.Fatal("expected blocked normal submit to surface an error")
+	}
+	_ = collectCmdMessages(t, submitCmd)
+	if updated.isBusy() {
+		t.Fatal("did not expect normal submit while queued runtime message is still server-side")
+	}
+	if client.submitText != "" {
+		t.Fatalf("did not expect duplicate normal submit while discard failed, got %q", client.submitText)
+	}
 }
 
 func TestPendingInjectedCreateFailureRestoresInputAndSurfacesError(t *testing.T) {

--- a/cli/app/ui_part4_test.go
+++ b/cli/app/ui_part4_test.go
@@ -166,6 +166,62 @@ func TestBusyEnterQueuesInjectedInputWithoutRuntimeCreateDuringUpdate(t *testing
 	}
 }
 
+func TestQueuedRuntimeWorkCheckDoesNotSubmitWhenRuntimeBecameBusy(t *testing.T) {
+	client := &runtimeControlFakeClient{hasQueuedUserWork: true}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+
+	cmd := m.inputController().queuedRuntimeWorkCheckCmd()
+	if cmd == nil {
+		t.Fatal("expected queued runtime work check command")
+	}
+	m.setBusy(true)
+	raw := cmd()
+	msg, ok := raw.(queuedRuntimeWorkCheckDoneMsg)
+	if !ok {
+		t.Fatalf("unexpected queue check message %T", raw)
+	}
+	next, followCmd := m.Update(msg)
+	updated := next.(*uiModel)
+	if followCmd != nil {
+		t.Fatal("did not expect queued submit command while runtime is busy")
+	}
+	if client.submitQueuedCalls != 0 {
+		t.Fatalf("queued submit started while runtime busy: %d", client.submitQueuedCalls)
+	}
+	if !updated.isBusy() {
+		t.Fatal("expected busy state preserved")
+	}
+}
+
+func TestIdleRuntimeResumesInjectedQueueThatWasEnqueuedWhileBusy(t *testing.T) {
+	client := &runtimeControlFakeClient{hasQueuedUserWork: true, submitQueuedResult: "done"}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.injectedQueue = []injectedRuntimeQueueItem{{LocalID: "local-1", ServerID: "server-1", Text: "follow up", State: injectedRuntimeQueueEnqueued}}
+	m.pendingInjected = []clientui.QueuedUserMessage{{ID: "server-1", Text: "follow up"}}
+
+	cmd := m.inputController().resumeQueuedInputsAfterIdleRuntime()
+	if cmd == nil {
+		t.Fatal("expected idle runtime to resume enqueued injected work")
+	}
+	raw := cmd()
+	msg, ok := raw.(queuedRuntimeWorkCheckDoneMsg)
+	if !ok {
+		t.Fatalf("unexpected queue check message %T", raw)
+	}
+	next, submitCmd := m.Update(msg)
+	updated := next.(*uiModel)
+	if submitCmd == nil {
+		t.Fatal("expected queued submit command after idle injected resume")
+	}
+	if !updated.isBusy() {
+		t.Fatal("expected queued injected resume to mark UI busy")
+	}
+	_ = collectCmdMessages(t, submitCmd)
+	if client.submitQueuedCalls != 1 {
+		t.Fatalf("expected one queued submit call, got %d", client.submitQueuedCalls)
+	}
+}
+
 func TestPendingInjectedCreateCanceledBeforeCompletionDiscardsLateServerItem(t *testing.T) {
 	client := &runtimeControlFakeClient{queueUserMessageID: "server-queue-1", discardQueuedResult: true}
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())

--- a/cli/app/ui_part4_test.go
+++ b/cli/app/ui_part4_test.go
@@ -1037,6 +1037,31 @@ func TestInterruptedSubmitDoneRestoresQueueIntoInputAndDoesNotAutoDrain(t *testi
 	}
 }
 
+func TestInterruptedSubmitDoneRunsQueuedRuntimeDiscardCleanup(t *testing.T) {
+	client := &runtimeControlFakeClient{discardQueuedResult: true}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.setBusy(true)
+	m.setInputSubmitLocked(true)
+	m.lockedInjectID = "server-queue-1"
+	m.pendingInjected = []clientui.QueuedUserMessage{{ID: "server-queue-1", Text: "restore me"}}
+
+	next, cmd := m.Update(submitDoneMsg{err: submissionerror.ErrInterrupted})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected queued runtime discard cleanup command")
+	}
+	if updated.isInputSubmitLocked() {
+		t.Fatal("expected submit lock released after interrupted completion")
+	}
+	if updated.input != "" {
+		t.Fatalf("did not expect locked submitted input restored, got %q", updated.input)
+	}
+	_ = collectCmdMessages(t, cmd)
+	if client.discardQueuedCalls != 1 || client.discardQueuedID != "server-queue-1" {
+		t.Fatalf("expected runtime queued item discarded, calls=%d id=%q", client.discardQueuedCalls, client.discardQueuedID)
+	}
+}
+
 func TestInterruptedSubmitDoneDoesNotRestoreFlushedSubmittedText(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.setBusy(true)

--- a/cli/app/ui_part5_test.go
+++ b/cli/app/ui_part5_test.go
@@ -185,6 +185,7 @@ func TestPSOverlaySpinnerTickAnimatesRunningEntriesWhileIdle(t *testing.T) {
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	updated = completeProcessRefreshForTest(t, updated)
 	before := updated.View()
 	token := updated.spinnerTickToken
 	if token == 0 {
@@ -225,6 +226,7 @@ func TestPSOverlayIgnoresStaleSpinnerTickTokens(t *testing.T) {
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	updated = completeProcessRefreshForTest(t, updated)
 	currentToken := updated.spinnerTickToken
 	if currentToken == 0 {
 		t.Fatal("expected active spinner token for running /ps entries")
@@ -264,6 +266,7 @@ func TestPSOverlayIgnoresStaleSpinnerTickAfterRestart(t *testing.T) {
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	updated = completeProcessRefreshForTest(t, updated)
 	oldToken := updated.spinnerTickToken
 	if oldToken == 0 {
 		t.Fatal("expected active spinner token for running /ps entries")
@@ -279,6 +282,7 @@ func TestPSOverlayIgnoresStaleSpinnerTickAfterRestart(t *testing.T) {
 	updated.input = "/ps"
 	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
+	updated = completeProcessRefreshForTest(t, updated)
 	newToken := updated.spinnerTickToken
 	if newToken == 0 {
 		t.Fatal("expected restarted spinner token for running /ps entries")

--- a/cli/app/ui_part6_test.go
+++ b/cli/app/ui_part6_test.go
@@ -4,13 +4,11 @@ import (
 	"builder/cli/tui"
 	shelltool "builder/server/tools/shell"
 	"builder/shared/clientui"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	tea "github.com/charmbracelet/bubbletea"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -47,6 +45,7 @@ func TestPSOverlayInlineAppendsOutputToInputAndReturnsToOngoing(t *testing.T) {
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	updated = completeProcessRefreshForTest(t, updated)
 	selected, ok := updated.selectedProcess()
 	if !ok {
 		t.Fatal("expected a selected background process")
@@ -65,8 +64,9 @@ func TestPSOverlayInlineAppendsOutputToInputAndReturnsToOngoing(t *testing.T) {
 		t.Fatalf("expected moved selection to reach %s, got %s", firstID, selected.ID)
 	}
 
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
+	updated = applyProcessActionCommandForTest(t, updated, cmd)
 	if testProcessListOpen(updated) {
 		t.Fatal("expected inline paste to close the process overlay")
 	}
@@ -114,9 +114,11 @@ func TestPSOverlayInlineUnlocksLockedInputBeforeAppending(t *testing.T) {
 	controller := uiInputController{model: m}
 	_ = controller.startProcessListFlowCmd()
 	updated := m
+	updated = completeProcessRefreshForTest(t, updated)
 	var next tea.Model
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
+	updated = applyProcessActionCommandForTest(t, updated, cmd)
 
 	if updated.isInputSubmitLocked() {
 		t.Fatal("expected inline paste to unlock the input box")
@@ -158,8 +160,9 @@ func TestDirectPSInlineCommandPastesTranscriptIntoInput(t *testing.T) {
 	m := newProjectedStaticUIModel(withUIBackgroundManagerForTest(manager))
 	m.input = "/ps inline " + res.SessionID
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	updated = applyProcessActionCommandForTest(t, updated, cmd)
 
 	if updated.isBusy() {
 		t.Fatal("did not expect /ps inline to start a normal run")
@@ -175,6 +178,38 @@ func TestDirectPSInlineCommandPastesTranscriptIntoInput(t *testing.T) {
 	}
 	if !strings.Contains(stripANSIAndTrimRight(updated.renderStatusLine(120, uiThemeStyles("dark"))), "Pasted shell transcript") {
 		t.Fatal("expected direct /ps inline to show pasted shell transcript notice")
+	}
+}
+
+func TestDirectPSInlineCompletionDoesNotPasteIntoEditedDraft(t *testing.T) {
+	manager := newFastBackgroundTestManager(t)
+
+	workdir := t.TempDir()
+	res, err := manager.Start(context.Background(), shelltool.ExecRequest{
+		Command:        []string{"sh", "-c", "printf 'stale-inline\n'; sleep 1"},
+		DisplayCommand: "stale-inline",
+		Workdir:        workdir,
+		YieldTime:      fastBackgroundTestYield,
+	})
+	if err != nil {
+		t.Fatalf("start stale-inline: %v", err)
+	}
+	if !res.Backgrounded {
+		t.Fatal("expected background process")
+	}
+
+	m := newProjectedStaticUIModel(withUIBackgroundManagerForTest(manager))
+	m.input = "/ps inline " + res.SessionID
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	updated.insertInputRunes([]rune("typed while inline pending"))
+	updated = applyProcessActionCommandForTest(t, updated, cmd)
+
+	if strings.Contains(updated.input, "Output of bg shell "+res.SessionID+":") || strings.Contains(updated.input, "stale-inline") {
+		t.Fatalf("did not expect stale inline completion to paste into edited draft, got %q", updated.input)
+	}
+	if !strings.Contains(updated.input, "typed while inline pending") {
+		t.Fatalf("expected edited draft preserved, got %q", updated.input)
 	}
 }
 
@@ -206,8 +241,9 @@ func TestDirectPSLogsCommandUsesDefaultOpenSuccess(t *testing.T) {
 	m := newProjectedStaticUIModel(withUIBackgroundManagerForTest(manager))
 	m.input = "/ps logs " + res.SessionID
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	updated = applyProcessActionCommandForTest(t, updated, cmd)
 
 	if openedPath != res.OutputPath {
 		t.Fatalf("expected direct /ps logs to open %q, got %q", res.OutputPath, openedPath)
@@ -240,8 +276,9 @@ func TestDirectPSKillCommandSignalsBackgroundProcess(t *testing.T) {
 	m := newProjectedStaticUIModel(withUIBackgroundManagerForTest(manager))
 	m.input = "/ps kill " + res.SessionID
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	updated = applyProcessActionCommandForTest(t, updated, cmd)
 
 	if !strings.Contains(stripANSIAndTrimRight(updated.renderStatusLine(120, uiThemeStyles("dark"))), "sent terminate signal to "+res.SessionID) {
 		t.Fatalf("expected direct /ps kill to show kill notice, got %q", stripANSIAndTrimRight(updated.renderStatusLine(120, uiThemeStyles("dark"))))
@@ -302,6 +339,7 @@ func TestPSOverlayRefreshTickUpdatesEntriesWhileOpen(t *testing.T) {
 
 	next, cmd := updated.Update(processListRefreshTickMsg{})
 	updated = next.(*uiModel)
+	updated = completeProcessRefreshForTest(t, updated)
 	if got := len(updated.processList.entries); got != 1 {
 		t.Fatalf("expected refresh tick to pull new process entry, got %d", got)
 	}
@@ -337,7 +375,7 @@ func TestPSOverlayRefreshPreservesSelectionByProcessID(t *testing.T) {
 	}
 
 	m := newProjectedStaticUIModel(withUIBackgroundManagerForTest(manager))
-	m.refreshProcessEntries()
+	refreshProcessEntriesForTest(t, m)
 	if len(m.processList.entries) != 2 {
 		t.Fatalf("expected two process entries, got %d", len(m.processList.entries))
 	}
@@ -362,9 +400,43 @@ func TestPSOverlayRefreshPreservesSelectionByProcessID(t *testing.T) {
 		t.Fatalf("start third job: %v", err)
 	}
 
-	m.refreshProcessEntries()
+	refreshProcessEntriesForTest(t, m)
 	if m.processList.entries[m.processList.selection].ID != selectedID {
 		t.Fatalf("expected selection to remain on process %s, got %s", selectedID, m.processList.entries[m.processList.selection].ID)
+	}
+}
+
+func TestOpenLogsReportsErrorWhenDefaultOpenFails(t *testing.T) {
+	manager := newFastBackgroundTestManager(t)
+
+	workdir := t.TempDir()
+	res, err := manager.Start(context.Background(), shelltool.ExecRequest{
+		Command:        []string{"sh", "-c", "printf 'log-job\n'; sleep 1"},
+		DisplayCommand: "log-job",
+		Workdir:        workdir,
+		YieldTime:      fastBackgroundTestYield,
+	})
+	if err != nil {
+		t.Fatalf("start log-job: %v", err)
+	}
+	if !res.Backgrounded {
+		t.Fatal("expected log-job to move to background")
+	}
+
+	originalOpenDefault := openDefault
+	openDefault = func(string) error { return errors.New("forced open failure") }
+	defer func() { openDefault = originalOpenDefault }()
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "")
+
+	m := newProjectedStaticUIModel(withUIBackgroundManagerForTest(manager))
+	m.input = "/ps logs " + res.SessionID
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	updated = applyProcessActionCommandForTest(t, updated, cmd)
+	status := stripANSIAndTrimRight(updated.renderStatusLine(120, uiThemeStyles("dark")))
+	if !strings.Contains(status, "open logs failed") {
+		t.Fatalf("expected open failure status, got %q", status)
 	}
 }
 
@@ -388,73 +460,35 @@ func TestOpenLogsFallsBackToEditorCommandWhenDefaultOpenFails(t *testing.T) {
 	originalOpenDefault := openDefault
 	openDefault = func(string) error { return errors.New("forced open failure") }
 	defer func() { openDefault = originalOpenDefault }()
+	marker := t.TempDir() + "/editor-opened"
+	t.Setenv("VISUAL", "touch "+marker)
+	t.Setenv("EDITOR", "")
+	t.Setenv("SHELL", "/bin/sh")
 
-	marker := filepath.Join(t.TempDir(), "editor-opened")
-	oldVisual, hadVisual := os.LookupEnv("VISUAL")
-	oldEditor, hadEditor := os.LookupEnv("EDITOR")
-	oldShell, hadShell := os.LookupEnv("SHELL")
-	if err := os.Setenv("VISUAL", "touch "+marker); err != nil {
-		t.Fatalf("set VISUAL: %v", err)
-	}
-	if err := os.Unsetenv("EDITOR"); err != nil {
-		t.Fatalf("unset EDITOR: %v", err)
-	}
-	if err := os.Setenv("SHELL", "/bin/sh"); err != nil {
-		t.Fatalf("set SHELL: %v", err)
-	}
-	defer func() {
-		if hadVisual {
-			_ = os.Setenv("VISUAL", oldVisual)
-		} else {
-			_ = os.Unsetenv("VISUAL")
-		}
-		if hadEditor {
-			_ = os.Setenv("EDITOR", oldEditor)
-		} else {
-			_ = os.Unsetenv("EDITOR")
-		}
-		if hadShell {
-			_ = os.Setenv("SHELL", oldShell)
-		} else {
-			_ = os.Unsetenv("SHELL")
-		}
-	}()
-
-	out := &bytes.Buffer{}
-	model := newProjectedTestUIModel(nil, closedProjectedRuntimeEvents(), closedAskEvents(), withUIBackgroundManagerForTest(manager))
-	model.input = "/ps"
-	program := tea.NewProgram(model, tea.WithInput(strings.NewReader("")), tea.WithOutput(out), tea.WithoutSignals())
-	done := make(chan error, 1)
-	go func() {
-		_, runErr := program.Run()
-		done <- runErr
-	}()
-	time.Sleep(40 * time.Millisecond)
-	program.Send(tea.WindowSizeMsg{Width: 120, Height: 30})
-	time.Sleep(20 * time.Millisecond)
-	program.Send(tea.KeyMsg{Type: tea.KeyEnter})
-	time.Sleep(20 * time.Millisecond)
-	program.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
-
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		if _, statErr := os.Stat(marker); statErr == nil {
+	m := newProjectedStaticUIModel(withUIBackgroundManagerForTest(manager))
+	m.input = "/ps logs " + res.SessionID
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	msgs := collectCmdMessages(t, cmd)
+	var done processActionDoneMsg
+	found := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(processActionDoneMsg); ok {
+			done = typed
+			found = true
 			break
 		}
-		if time.Now().After(deadline) {
-			t.Fatal("expected editor fallback to execute via tea.ExecProcess")
-		}
-		time.Sleep(20 * time.Millisecond)
 	}
-
-	program.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
-	select {
-	case runErr := <-done:
-		if runErr != nil {
-			t.Fatalf("program run failed: %v", runErr)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("program did not terminate")
+	if !found {
+		t.Fatalf("expected process action completion, got %+v", msgs)
+	}
+	if done.editorCmd == nil {
+		t.Fatal("expected editor fallback command")
+	}
+	if err := done.editorCmd.Run(); err != nil {
+		t.Fatalf("run editor fallback: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("expected editor fallback to create marker: %v", err)
 	}
 }
 
@@ -716,8 +750,8 @@ func TestSubmitDoneWithQueuedWorkWaitsForInFlightTranscriptCatchUp(t *testing.T)
 	if !ok {
 		t.Fatalf("expected runtimeTranscriptRefreshedMsg from follow-up hydration command, got %T", applyCmd())
 	}
-	if refreshAgain.syncCause != runtimeTranscriptSyncCauseDirtyFollowUp {
-		t.Fatalf("follow-up sync cause = %q, want %q", refreshAgain.syncCause, runtimeTranscriptSyncCauseDirtyFollowUp)
+	if refreshAgain.syncCause != runtimeTranscriptSyncCauseQueuedDrain {
+		t.Fatalf("follow-up sync cause = %q, want %q", refreshAgain.syncCause, runtimeTranscriptSyncCauseQueuedDrain)
 	}
 
 	next, finalCmd := updated.Update(refreshAgain)

--- a/cli/app/ui_part7_test.go
+++ b/cli/app/ui_part7_test.go
@@ -9,6 +9,7 @@ import (
 	shelltool "builder/server/tools/shell"
 	"builder/shared/clientui"
 	"context"
+	"errors"
 	tea "github.com/charmbracelet/bubbletea"
 	"strings"
 	"testing"
@@ -160,6 +161,10 @@ func TestAutoDrainStopsAfterQueuedPSInlineAppendsToInput(t *testing.T) {
 	if updated.isBusy() {
 		t.Fatal("did not expect queued /ps inline to auto-submit the follow-up prompt")
 	}
+	if !updated.processList.actionInFlight {
+		t.Fatal("expected queued /ps inline action to remain in flight")
+	}
+	updated = applyProcessActionCommandForTest(t, updated, cmd)
 	if !strings.Contains(updated.input, "Output of bg shell "+res.SessionID+":") {
 		t.Fatalf("expected inline shell transcript pasted into input, got %q", updated.input)
 	}
@@ -172,6 +177,101 @@ func TestAutoDrainStopsAfterQueuedPSInlineAppendsToInput(t *testing.T) {
 	plain := stripANSIAndTrimRight(updated.view.OngoingSnapshot())
 	if strings.Contains(plain, "summarize this") {
 		t.Fatalf("did not expect follow-up prompt submitted without pasted transcript, got %q", plain)
+	}
+}
+
+func TestAutoDrainResumesAfterQueuedPSNonMutatingActions(t *testing.T) {
+	for _, action := range []string{"kill", "logs"} {
+		t.Run(action, func(t *testing.T) {
+			manager := newFastBackgroundTestManager(t)
+			workdir := t.TempDir()
+			res, err := manager.Start(context.Background(), shelltool.ExecRequest{
+				Command:        []string{"sh", "-c", "printf 'queued-action\n'; sleep 1"},
+				DisplayCommand: "queued-action",
+				Workdir:        workdir,
+				YieldTime:      fastBackgroundTestYield,
+			})
+			if err != nil {
+				t.Fatalf("start queued-action: %v", err)
+			}
+			if !res.Backgrounded {
+				t.Fatal("expected background process")
+			}
+			originalOpenDefault := openDefault
+			openDefault = func(string) error { return nil }
+			defer func() { openDefault = originalOpenDefault }()
+
+			m := newProjectedStaticUIModel(withUIBackgroundManagerForTest(manager))
+			m.setBusy(true)
+			m.activity = uiActivityRunning
+			m.queued = queuedInputsForTest("/ps "+action+" "+res.SessionID, "summarize this")
+
+			next, cmd := m.Update(submitDoneMsg{})
+			updated := next.(*uiModel)
+			if cmd == nil {
+				t.Fatal("expected command batch from queued /ps action execution")
+			}
+			if !updated.processList.actionInFlight {
+				t.Fatal("expected queued /ps action to remain in flight")
+			}
+
+			updated = applyProcessActionCommandForTest(t, updated, cmd)
+			if !updated.isBusy() {
+				t.Fatal("expected follow-up prompt to start after non-mutating /ps action")
+			}
+			if updated.activeSubmit.text != "summarize this" {
+				t.Fatalf("expected follow-up prompt active, got %q", updated.activeSubmit.text)
+			}
+			if len(updated.queued) != 0 {
+				t.Fatalf("expected follow-up queue drained, got %+v", updated.queued)
+			}
+		})
+	}
+}
+
+type failingQueuedProcessClient struct {
+	err error
+}
+
+func (c failingQueuedProcessClient) ListProcesses(context.Context) ([]clientui.BackgroundProcess, error) {
+	return nil, c.err
+}
+
+func (c failingQueuedProcessClient) KillProcess(context.Context, string) error {
+	return c.err
+}
+
+func (c failingQueuedProcessClient) InlineOutput(context.Context, string, int) (string, string, error) {
+	return "", "", c.err
+}
+
+func TestAutoDrainResumesAfterQueuedPSNonMutatingActionError(t *testing.T) {
+	m := newProjectedStaticUIModel(WithUIProcessClient(failingQueuedProcessClient{err: errors.New("kill failed")}))
+	m.setBusy(true)
+	m.activity = uiActivityRunning
+	m.queued = queuedInputsForTest("/ps kill proc-1", "summarize this")
+
+	next, cmd := m.Update(submitDoneMsg{})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected command batch from queued /ps action execution")
+	}
+	if !updated.processList.actionInFlight {
+		t.Fatal("expected queued /ps action to remain in flight")
+	}
+
+	updated = applyProcessActionCommandForTest(t, updated, cmd)
+	if !strings.Contains(updated.transientStatus, "kill failed") {
+		t.Fatalf("expected process error status, got %q", updated.transientStatus)
+	}
+	if !updated.isBusy() {
+		t.Fatal("expected follow-up prompt to start after non-mutating /ps action error")
+	}
+	if updated.activeSubmit.text != "summarize this" {
+		t.Fatalf("expected follow-up prompt active, got %q", updated.activeSubmit.text)
+	}
+	if len(updated.queued) != 0 {
+		t.Fatalf("expected follow-up queue drained, got %+v", updated.queued)
 	}
 }
 
@@ -797,7 +897,11 @@ func TestSlashFastWithEngineTogglesRuntime(t *testing.T) {
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
 	if cmd == nil {
-		t.Fatal("expected transient status clear timer cmd")
+		t.Fatal("expected runtime control command")
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
 	}
 	if !eng.FastModeEnabled() {
 		t.Fatal("expected runtime fast mode enabled")
@@ -807,8 +911,12 @@ func TestSlashFastWithEngineTogglesRuntime(t *testing.T) {
 	}
 
 	updated.input = "/fast off"
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
 	if eng.FastModeEnabled() {
 		t.Fatal("expected runtime fast mode disabled")
 	}
@@ -930,8 +1038,12 @@ func TestBusySlashSupervisorOffAppliesToInFlightRunCompletion(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	m.input = "/supervisor off"
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
 	if updated.reviewerEnabled || updated.reviewerMode != "off" {
 		t.Fatalf("expected ui reviewer disabled after /supervisor off, got enabled=%v mode=%q", updated.reviewerEnabled, updated.reviewerMode)
 	}

--- a/cli/app/ui_part7_test.go
+++ b/cli/app/ui_part7_test.go
@@ -305,6 +305,38 @@ func TestAutoDrainResumesAfterQueuedPSInlineActionError(t *testing.T) {
 	}
 }
 
+func TestAutoDrainResumesAfterDiscardedPSInlinePaste(t *testing.T) {
+	client := &countingProcessActionClient{}
+	m := newProjectedStaticUIModel(WithUIProcessClient(client))
+	m.queued = queuedInputsForTest("summarize this")
+	cmd := m.processActionCmd("inline", "proc-1", "", m.mainInputDraftToken)
+	if cmd == nil {
+		t.Fatal("expected inline action command")
+	}
+	if !m.processList.actionInFlight {
+		t.Fatal("expected inline action in flight")
+	}
+	m.replaceMainInput("edited draft", -1)
+
+	var done processActionDoneMsg
+	for _, msg := range collectCmdMessages(t, cmd) {
+		if typed, ok := msg.(processActionDoneMsg); ok {
+			done = typed
+		}
+	}
+	next, _ := m.Update(done)
+	updated := next.(*uiModel)
+	if !updated.isBusy() {
+		t.Fatal("expected queued prompt to start after stale inline paste is discarded")
+	}
+	if updated.activeSubmit.text != "summarize this" {
+		t.Fatalf("expected queued prompt active, got %q", updated.activeSubmit.text)
+	}
+	if len(updated.queued) != 0 {
+		t.Fatalf("expected queue drained after stale inline paste, got %+v", updated.queued)
+	}
+}
+
 type countingProcessActionClient struct {
 	killCalls int
 }

--- a/cli/app/ui_part7_test.go
+++ b/cli/app/ui_part7_test.go
@@ -275,6 +275,76 @@ func TestAutoDrainResumesAfterQueuedPSNonMutatingActionError(t *testing.T) {
 	}
 }
 
+func TestAutoDrainResumesAfterQueuedPSInlineActionError(t *testing.T) {
+	m := newProjectedStaticUIModel(WithUIProcessClient(failingQueuedProcessClient{err: errors.New("inline failed")}))
+	m.setBusy(true)
+	m.activity = uiActivityRunning
+	m.queued = queuedInputsForTest("/ps inline proc-1", "summarize this")
+
+	next, cmd := m.Update(submitDoneMsg{})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected command batch from queued /ps inline execution")
+	}
+	if !updated.processList.actionInFlight {
+		t.Fatal("expected queued /ps inline action to remain in flight")
+	}
+
+	updated = applyProcessActionCommandForTest(t, updated, cmd)
+	if !strings.Contains(updated.transientStatus, "inline failed") {
+		t.Fatalf("expected process error status, got %q", updated.transientStatus)
+	}
+	if !updated.isBusy() {
+		t.Fatal("expected follow-up prompt to start after inline action error")
+	}
+	if updated.activeSubmit.text != "summarize this" {
+		t.Fatalf("expected follow-up prompt active, got %q", updated.activeSubmit.text)
+	}
+	if len(updated.queued) != 0 {
+		t.Fatalf("expected follow-up queue drained, got %+v", updated.queued)
+	}
+}
+
+type countingProcessActionClient struct {
+	killCalls int
+}
+
+func (c *countingProcessActionClient) ListProcesses(context.Context) ([]clientui.BackgroundProcess, error) {
+	return []clientui.BackgroundProcess{{ID: "proc-1", LogPath: "/tmp/process.log"}}, nil
+}
+
+func (c *countingProcessActionClient) KillProcess(context.Context, string) error {
+	c.killCalls++
+	return nil
+}
+
+func (c *countingProcessActionClient) InlineOutput(context.Context, string, int) (string, string, error) {
+	return "output", "", nil
+}
+
+func TestPSActionsAreSerializedWhileInFlight(t *testing.T) {
+	client := &countingProcessActionClient{}
+	m := newProjectedStaticUIModel(WithUIProcessClient(client))
+	m.processList.entries = []clientui.BackgroundProcess{{ID: "proc-1", LogPath: "/tmp/process.log"}}
+
+	_, firstCmd := m.inputController().runProcessAction("kill", "proc-1")
+	if firstCmd == nil {
+		t.Fatal("expected first process action command")
+	}
+	_, secondCmd := m.inputController().runProcessAction("kill", "proc-1")
+	if secondCmd == nil {
+		t.Fatal("expected second process action to produce status feedback")
+	}
+	_ = collectCmdMessages(t, secondCmd)
+	if client.killCalls != 0 {
+		t.Fatalf("second action should not start an RPC while first is in flight, got %d calls", client.killCalls)
+	}
+	_ = applyProcessActionCommandForTest(t, m, firstCmd)
+	if client.killCalls != 1 {
+		t.Fatalf("expected exactly one process action RPC, got %d", client.killCalls)
+	}
+}
+
 func TestBusyQueuedReviewSlashCommandStartsFreshSessionAfterTurn(t *testing.T) {
 	m := newProjectedStaticUIModel(
 		WithUIConversationFreshness(clientui.ConversationFreshnessEstablished),

--- a/cli/app/ui_part8_test.go
+++ b/cli/app/ui_part8_test.go
@@ -55,8 +55,12 @@ func TestBusySlashSupervisorOnAppliesToInFlightRunCompletion(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	m.input = "/supervisor on"
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
 	if !updated.reviewerEnabled || updated.reviewerMode != "edits" {
 		t.Fatalf("expected ui reviewer enabled in edits mode after /supervisor on, got enabled=%v mode=%q", updated.reviewerEnabled, updated.reviewerMode)
 	}
@@ -88,7 +92,11 @@ func TestSlashSupervisorWithEngineTogglesRuntimeReviewer(t *testing.T) {
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
 	if cmd == nil {
-		t.Fatal("expected transient status clear timer cmd")
+		t.Fatal("expected runtime control command")
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
 	}
 	if got := eng.ReviewerFrequency(); got != "edits" {
 		t.Fatalf("expected runtime reviewer mode edits, got %q", got)
@@ -101,8 +109,12 @@ func TestSlashSupervisorWithEngineTogglesRuntimeReviewer(t *testing.T) {
 	}
 
 	updated.input = "/supervisor off"
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
 	if got := eng.ReviewerFrequency(); got != "off" {
 		t.Fatalf("expected runtime reviewer mode off, got %q", got)
 	}
@@ -192,7 +204,11 @@ func TestSlashAutoCompactionWithEngineTogglesRuntime(t *testing.T) {
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
 	if cmd == nil {
-		t.Fatal("expected transient status clear timer cmd")
+		t.Fatal("expected runtime control command")
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
 	}
 	if got := eng.AutoCompactionEnabled(); got {
 		t.Fatalf("expected runtime auto-compaction disabled, got %v", got)
@@ -202,8 +218,12 @@ func TestSlashAutoCompactionWithEngineTogglesRuntime(t *testing.T) {
 	}
 
 	updated.input = "/autocompaction on"
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
 	if got := eng.AutoCompactionEnabled(); !got {
 		t.Fatalf("expected runtime auto-compaction enabled, got %v", got)
 	}
@@ -222,7 +242,11 @@ func TestSlashAutoCompactionKeepsPriorStateWhenRuntimeToggleFails(t *testing.T) 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
 	if cmd == nil {
-		t.Fatal("expected transient status clear timer cmd")
+		t.Fatal("expected runtime control command")
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
 	}
 	if !updated.autoCompactionEnabled {
 		t.Fatal("expected prior auto-compaction state preserved on toggle failure")
@@ -237,8 +261,12 @@ func TestSlashAutoCompactionShowsCompactionModeNoneNote(t *testing.T) {
 	m := newProjectedEngineUIModel(eng)
 	m.input = "/autocompaction on"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
 	if !strings.Contains(updated.transientStatus, "compaction_mode=none") {
 		t.Fatalf("expected compaction_mode=none note in status, got %q", updated.transientStatus)
 	}
@@ -536,7 +564,17 @@ func TestBlockDisconnectedSubmissionBlocksEvenWhenRuntimeAppendSucceeds(t *testi
 		t.Fatal("expected disconnected submission to block")
 	}
 	if cmd != nil {
-		t.Fatal("did not expect fallback transcript cmd when runtime append succeeds")
+		if client.appendedRole != "" || client.appendedText != "" {
+			t.Fatalf("did not expect runtime append during disconnected submission block, got role=%q text=%q", client.appendedRole, client.appendedText)
+		}
+		_ = collectCmdMessages(t, cmd)
+	}
+	if len(m.transcriptEntries) != 1 {
+		t.Fatalf("expected immediate fallback transcript entry, got %+v", m.transcriptEntries)
+	}
+	entry := m.transcriptEntries[0]
+	if entry.Role != tui.TranscriptRoleDeveloperErrorFeedback || entry.Text != runtimeDisconnectedStatusMessage {
+		t.Fatalf("unexpected fallback transcript entry: %+v", entry)
 	}
 	if m.activity != uiActivityError {
 		t.Fatalf("expected error activity while disconnected, got %v", m.activity)
@@ -559,7 +597,10 @@ func TestDisconnectedQueuedFlushRestoresHiddenQueuedDrafts(t *testing.T) {
 	updated := next.(*uiModel)
 
 	if cmd != nil {
-		t.Fatal("did not expect queued flush command while disconnected")
+		if client.appendedRole != "" || client.appendedText != "" {
+			t.Fatalf("did not expect runtime append during disconnected queued flush, got role=%q text=%q", client.appendedRole, client.appendedText)
+		}
+		_ = collectCmdMessages(t, cmd)
 	}
 	if updated.input != "first queued\n\nsecond queued" {
 		t.Fatalf("expected hidden queued drafts restored into input, got %q", updated.input)
@@ -596,7 +637,10 @@ func TestDisconnectedQueuedInjectionSubmissionRestoresHiddenInjectedDrafts(t *te
 
 	cmd := m.inputController().startQueuedInjectionSubmission()
 	if cmd != nil {
-		t.Fatal("did not expect queued injection submission command while disconnected")
+		if client.appendedRole != "" || client.appendedText != "" {
+			t.Fatalf("did not expect runtime append during disconnected queued injection submission, got role=%q text=%q", client.appendedRole, client.appendedText)
+		}
+		_ = collectCmdMessages(t, cmd)
 	}
 	if m.input != "hidden steering" {
 		t.Fatalf("expected hidden injected draft restored into input, got %q", m.input)

--- a/cli/app/ui_path_reference_picker.go
+++ b/cli/app/ui_path_reference_picker.go
@@ -96,6 +96,11 @@ func (m *uiModel) refreshAutocompleteFromInput() tea.Cmd {
 	return cmd
 }
 
+func (m *uiModel) refreshAutocompleteStateFromInput() {
+	m.refreshSlashCommandFilterStateFromInput()
+	m.refreshPathReferenceFromInput()
+}
+
 func (m *uiModel) refreshPathReferenceFromInput() {
 	if m.pathReferenceSearch == nil {
 		m.clearPathReferenceState()

--- a/cli/app/ui_path_reference_picker.go
+++ b/cli/app/ui_path_reference_picker.go
@@ -3,6 +3,8 @@ package app
 import (
 	"strings"
 	"unicode"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func WithUIPathReferenceSearch(search uiPathReferenceSearch) UIOption {
@@ -88,9 +90,10 @@ func applyPathReferenceCompletion(input string, cursor int, query uiPathReferenc
 	return string(updated), nextCursor, true
 }
 
-func (m *uiModel) refreshAutocompleteFromInput() {
-	m.refreshSlashCommandFilterFromInput()
+func (m *uiModel) refreshAutocompleteFromInput() tea.Cmd {
+	cmd := m.refreshSlashCommandFilterFromInput()
 	m.refreshPathReferenceFromInput()
+	return cmd
 }
 
 func (m *uiModel) refreshPathReferenceFromInput() {

--- a/cli/app/ui_path_reference_picker_test.go
+++ b/cli/app/ui_path_reference_picker_test.go
@@ -104,10 +104,14 @@ func TestPathReferenceStartupPrewarmQueuedForWorkspace(t *testing.T) {
 		WithUIStatusConfig(uiStatusConfig{WorkspaceRoot: "/tmp/workspace"}),
 	)
 
-	if len(m.startupCmds) != 1 || m.startupCmds[0] == nil {
-		t.Fatalf("expected one startup prewarm command, got %d", len(m.startupCmds))
+	if len(m.startupCmds) == 0 {
+		t.Fatal("expected startup prewarm command")
 	}
-	_ = m.startupCmds[0]()
+	for _, cmd := range m.startupCmds {
+		if cmd != nil {
+			_ = cmd()
+		}
+	}
 	if len(search.prewarmRoots) != 1 || search.prewarmRoots[0] != "/tmp/workspace" {
 		t.Fatalf("unexpected prewarm roots: %+v", search.prewarmRoots)
 	}

--- a/cli/app/ui_process_client.go
+++ b/cli/app/ui_process_client.go
@@ -27,24 +27,36 @@ func (m *uiModel) listProcesses() []clientui.BackgroundProcess {
 	if m == nil || m.processClient == nil {
 		return nil
 	}
-	return m.processClient.ListProcesses()
-}
-
-func (c backgroundUIProcessClient) ListProcesses() []clientui.BackgroundProcess {
-	if c.reads != nil {
-		resp, err := c.reads.ListProcesses(context.Background(), serverapi.ProcessListRequest{})
-		if err != nil {
-			return nil
-		}
-		return resp.Processes
+	entries, err := m.listProcessesWithError(context.Background())
+	if err != nil {
+		return nil
 	}
-	return nil
+	return entries
 }
 
-func (c backgroundUIProcessClient) KillProcess(id string) error {
+func (m *uiModel) listProcessesWithError(ctx context.Context) ([]clientui.BackgroundProcess, error) {
+	if m == nil || m.processClient == nil {
+		return nil, nil
+	}
+	m.checkTUIBlockingOperation("process list read", "")
+	return m.processClient.ListProcesses(ctx)
+}
+
+func (c backgroundUIProcessClient) ListProcesses(ctx context.Context) ([]clientui.BackgroundProcess, error) {
+	if c.reads != nil {
+		resp, err := c.reads.ListProcesses(ctx, serverapi.ProcessListRequest{})
+		if err != nil {
+			return nil, err
+		}
+		return resp.Processes, nil
+	}
+	return nil, nil
+}
+
+func (c backgroundUIProcessClient) KillProcess(ctx context.Context, id string) error {
 	id = strings.TrimSpace(id)
 	if c.control != nil {
-		_, err := c.control.KillProcess(context.Background(), serverapi.ProcessKillRequest{ClientRequestID: uuid.NewString(), ProcessID: id})
+		_, err := c.control.KillProcess(ctx, serverapi.ProcessKillRequest{ClientRequestID: uuid.NewString(), ProcessID: id})
 		if err != nil {
 			return err
 		}
@@ -53,10 +65,10 @@ func (c backgroundUIProcessClient) KillProcess(id string) error {
 	return errors.New("process control client is unavailable")
 }
 
-func (c backgroundUIProcessClient) InlineOutput(id string, maxChars int) (string, string, error) {
+func (c backgroundUIProcessClient) InlineOutput(ctx context.Context, id string, maxChars int) (string, string, error) {
 	id = strings.TrimSpace(id)
 	if c.control != nil {
-		resp, err := c.control.GetInlineOutput(context.Background(), serverapi.ProcessInlineOutputRequest{ProcessID: id, MaxChars: maxChars})
+		resp, err := c.control.GetInlineOutput(ctx, serverapi.ProcessInlineOutputRequest{ProcessID: id, MaxChars: maxChars})
 		if err != nil {
 			return "", "", err
 		}

--- a/cli/app/ui_process_client_test.go
+++ b/cli/app/ui_process_client_test.go
@@ -73,15 +73,15 @@ func (s *stubProcessControlService) GetInlineOutput(context.Context, serverapi.P
 	return s.inlineResp, nil
 }
 
-func (c fixedUIProcessClient) ListProcesses() []clientui.BackgroundProcess {
+func (c fixedUIProcessClient) ListProcesses(context.Context) ([]clientui.BackgroundProcess, error) {
 	out := make([]clientui.BackgroundProcess, len(c.entries))
 	copy(out, c.entries)
-	return out
+	return out, nil
 }
 
-func (fixedUIProcessClient) KillProcess(string) error { return nil }
+func (fixedUIProcessClient) KillProcess(context.Context, string) error { return nil }
 
-func (fixedUIProcessClient) InlineOutput(string, int) (string, string, error) {
+func (fixedUIProcessClient) InlineOutput(context.Context, string, int) (string, string, error) {
 	return "", "", nil
 }
 
@@ -108,7 +108,11 @@ func TestUIProcessClientProjectsManagerSnapshots(t *testing.T) {
 		client.NewLoopbackProcessControlClient(processes),
 	)
 	waitForTestCondition(t, 2*time.Second, "background process to finish", func() bool {
-		for _, entry := range client.ListProcesses() {
+		entries, err := client.ListProcesses(context.Background())
+		if err != nil {
+			return false
+		}
+		for _, entry := range entries {
 			if entry.ID == res.SessionID {
 				return !entry.Running && entry.ExitCode != nil
 			}
@@ -118,7 +122,11 @@ func TestUIProcessClientProjectsManagerSnapshots(t *testing.T) {
 
 	var projectedExitCode *int
 	found := false
-	for _, entry := range client.ListProcesses() {
+	entries, err := client.ListProcesses(context.Background())
+	if err != nil {
+		t.Fatalf("ListProcesses: %v", err)
+	}
+	for _, entry := range entries {
 		if entry.ID != res.SessionID {
 			continue
 		}
@@ -143,7 +151,11 @@ func TestUIProcessClientProjectsManagerSnapshots(t *testing.T) {
 	}
 
 	*projectedExitCode = 0
-	for _, entry := range client.ListProcesses() {
+	entries, err = client.ListProcesses(context.Background())
+	if err != nil {
+		t.Fatalf("ListProcesses second: %v", err)
+	}
+	for _, entry := range entries {
 		if entry.ID == res.SessionID {
 			if entry.ExitCode == nil || *entry.ExitCode != 7 {
 				t.Fatalf("expected projected exit code clone to remain 7, got %+v", entry.ExitCode)
@@ -181,7 +193,10 @@ func TestUIProcessClientUsesLoopbackReadsWhenAvailable(t *testing.T) {
 		listResp: serverapi.ProcessListResponse{Processes: []clientui.BackgroundProcess{{ID: "proc-1", OwnerRunID: "run-1", OwnerStepID: "step-1"}}},
 	})
 	processClient := newUIProcessClientWithReads(reads, nil)
-	got := processClient.ListProcesses()
+	got, err := processClient.ListProcesses(context.Background())
+	if err != nil {
+		t.Fatalf("ListProcesses: %v", err)
+	}
 	if len(got) != 1 || got[0].ID != "proc-1" || got[0].OwnerRunID != "run-1" || got[0].OwnerStepID != "step-1" {
 		t.Fatalf("unexpected loopback process payload: %+v", got)
 	}
@@ -208,8 +223,8 @@ func TestUIProcessClientDoesNotBypassSharedReadBoundaryOnError(t *testing.T) {
 	}
 
 	processClient := newUIProcessClientWithReads(client.NewLoopbackProcessViewClient(&stubProcessViewService{err: errors.New("boom")}), nil)
-	if got := processClient.ListProcesses(); got != nil {
-		t.Fatalf("expected shared-read failure to fail closed, got %+v", got)
+	if got, err := processClient.ListProcesses(context.Background()); err == nil || got != nil {
+		t.Fatalf("expected shared-read failure to fail closed, got entries=%+v err=%v", got, err)
 	}
 }
 
@@ -217,14 +232,14 @@ func TestUIProcessClientUsesLoopbackControlWhenAvailable(t *testing.T) {
 	controls := &stubProcessControlService{inlineResp: serverapi.ProcessInlineOutputResponse{Output: "hello", LogPath: "/tmp/proc.log"}}
 	processClient := newUIProcessClientWithReads(nil, client.NewLoopbackProcessControlClient(controls))
 
-	preview, logPath, err := processClient.InlineOutput("proc-1", 123)
+	preview, logPath, err := processClient.InlineOutput(context.Background(), "proc-1", 123)
 	if err != nil {
 		t.Fatalf("InlineOutput: %v", err)
 	}
 	if preview != "hello" || logPath != "/tmp/proc.log" {
 		t.Fatalf("unexpected inline output payload preview=%q logPath=%q", preview, logPath)
 	}
-	if err := processClient.KillProcess("proc-1"); err != nil {
+	if err := processClient.KillProcess(context.Background(), "proc-1"); err != nil {
 		t.Fatalf("KillProcess: %v", err)
 	}
 	if len(controls.killed) != 1 || controls.killed[0] != "proc-1" {
@@ -253,10 +268,10 @@ func TestUIProcessClientDoesNotBypassSharedControlBoundaryOnError(t *testing.T) 
 	}
 
 	processClient := newUIProcessClientWithReads(nil, client.NewLoopbackProcessControlClient(&stubProcessControlService{err: errors.New("boom")}))
-	if _, _, err := processClient.InlineOutput(res.SessionID, 12_000); err == nil || err.Error() != "boom" {
+	if _, _, err := processClient.InlineOutput(context.Background(), res.SessionID, 12_000); err == nil || err.Error() != "boom" {
 		t.Fatalf("expected shared control error from InlineOutput, got %v", err)
 	}
-	if err := processClient.KillProcess(res.SessionID); err == nil || err.Error() != "boom" {
+	if err := processClient.KillProcess(context.Background(), res.SessionID); err == nil || err.Error() != "boom" {
 		t.Fatalf("expected shared control error from KillProcess, got %v", err)
 	}
 	for _, entry := range manager.List() {

--- a/cli/app/ui_process_render.go
+++ b/cli/app/ui_process_render.go
@@ -30,7 +30,6 @@ func (l uiViewLayout) renderProcessList(width, height int, style uiStyles) []str
 	if height < 1 {
 		return []string{padRight("", width)}
 	}
-	m.refreshProcessEntries()
 	headerLines := []string{renderProcessListHeader(m.processList.entries, width, style)}
 	remainingHeight := height - len(headerLines)
 	if remainingHeight < 0 {
@@ -45,18 +44,25 @@ func (l uiViewLayout) renderProcessList(width, height int, style uiStyles) []str
 	content := make([]string, 0, max(0, contentHeight))
 	if contentHeight > 0 {
 		if len(m.processList.entries) == 0 {
-			content = append(content, style.meta.Render("○ No background processes."))
+			content = append(content, renderEmptyProcessListMessage(m.processList, style))
 		} else {
-			visibleRows := make([]string, 0, len(m.processList.entries)*processListEntryLines)
-			for idx, entry := range m.processList.entries {
+			start := processListStartRow(m.processList.selection, len(m.processList.entries), contentHeight)
+			startEntry := start / processListEntryLines
+			rowOffset := start % processListEntryLines
+			visibleEntries := (contentHeight + rowOffset + processListEntryLines - 1) / processListEntryLines
+			if startEntry+visibleEntries > len(m.processList.entries) {
+				visibleEntries = len(m.processList.entries) - startEntry
+			}
+			visibleRows := make([]string, 0, max(0, visibleEntries)*processListEntryLines)
+			for idx := startEntry; idx < startEntry+visibleEntries; idx++ {
+				entry := m.processList.entries[idx]
 				visibleRows = append(visibleRows, renderProcessListEntry(entry, idx == m.processList.selection, width, m.theme, m.spinnerFrame, style)...)
 			}
-			start := processListStartRow(m.processList.selection, len(m.processList.entries), contentHeight)
-			end := start + contentHeight
-			if end > len(visibleRows) {
-				end = len(visibleRows)
+			if rowOffset > 0 && rowOffset < len(visibleRows) {
+				visibleRows = visibleRows[rowOffset:]
 			}
-			content = append(content, visibleRows[start:end]...)
+			end := min(contentHeight, len(visibleRows))
+			content = append(content, visibleRows[:end]...)
 		}
 		for len(content) < contentHeight {
 			content = append(content, "")
@@ -67,6 +73,16 @@ func (l uiViewLayout) renderProcessList(width, height int, style uiStyles) []str
 	lines = append(lines, content...)
 	lines = append(lines, footerLines...)
 	return l.renderChatContentLines(lines, nil, width, style)
+}
+
+func renderEmptyProcessListMessage(state uiProcessListState, style uiStyles) string {
+	if state.loading {
+		return style.meta.Render("○ Loading background processes...")
+	}
+	if errText := strings.TrimSpace(state.errorText); errText != "" {
+		return style.meta.Render("○ Failed to load background processes: " + errText)
+	}
+	return style.meta.Render("○ No background processes.")
 }
 
 func renderProcessListHeader(entries []clientui.BackgroundProcess, width int, style uiStyles) string {

--- a/cli/app/ui_process_test_helpers_test.go
+++ b/cli/app/ui_process_test_helpers_test.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func completeProcessRefreshForTest(t *testing.T, m *uiModel) *uiModel {
+	t.Helper()
+	if m == nil || m.processClient == nil {
+		t.Fatal("process client is required")
+	}
+	entries, err := m.processClient.ListProcesses(context.Background())
+	next, _ := m.Update(processListRefreshDoneMsg{
+		token:   m.processList.refreshToken,
+		entries: entries,
+		err:     err,
+	})
+	return next.(*uiModel)
+}
+
+func refreshProcessEntriesForTest(t *testing.T, m *uiModel) {
+	t.Helper()
+	if m == nil || m.processClient == nil {
+		t.Fatal("process client is required")
+	}
+	entries, err := m.processClient.ListProcesses(context.Background())
+	if err != nil {
+		t.Fatalf("ListProcesses: %v", err)
+	}
+	m.applyProcessEntries(entries)
+}
+
+func applyProcessActionCommandForTest(t *testing.T, m *uiModel, cmd tea.Cmd) *uiModel {
+	t.Helper()
+	msgs := collectCmdMessages(t, cmd)
+	for _, msg := range msgs {
+		if done, ok := msg.(processActionDoneMsg); ok {
+			next, _ := m.Update(done)
+			return next.(*uiModel)
+		}
+	}
+	t.Fatalf("expected process action completion, got %+v", msgs)
+	return m
+}

--- a/cli/app/ui_processes.go
+++ b/cli/app/ui_processes.go
@@ -1,28 +1,29 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
 	"builder/shared/clientui"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func (m *uiModel) refreshProcessEntries() {
+const uiProcessOperationTimeout = 5 * time.Second
+
+func (m *uiModel) applyProcessEntries(entries []clientui.BackgroundProcess) {
 	selectedID := ""
 	if m.processList.selection >= 0 && m.processList.selection < len(m.processList.entries) {
 		selectedID = m.processList.entries[m.processList.selection].ID
 	}
-	if m.processClient == nil {
-		m.processList.entries = nil
-		m.processList.selection = 0
-		return
-	}
-	m.processList.entries = m.listProcesses()
+	m.processList.entries = append([]clientui.BackgroundProcess(nil), entries...)
+	m.processList.errorText = ""
+	m.processList.loading = false
 	if len(m.processList.entries) == 0 {
 		m.processList.selection = 0
 		return
@@ -43,22 +44,100 @@ func (m *uiModel) refreshProcessEntries() {
 	}
 }
 
-func (m *uiModel) refreshProcessEntriesIfOpen() {
-	if m == nil || !m.processList.isOpen() {
+func (m *uiModel) applyBackgroundProcessEventToCache(evt *clientui.BackgroundShellEvent) {
+	if m == nil || evt == nil {
 		return
 	}
-	m.refreshProcessEntries()
+	id := strings.TrimSpace(evt.ID)
+	if id == "" {
+		return
+	}
+	state := strings.TrimSpace(evt.State)
+	remove := strings.EqualFold(strings.TrimSpace(evt.Type), "removed") || strings.EqualFold(state, "removed")
+	if remove {
+		for idx, entry := range m.processList.entries {
+			if entry.ID == id {
+				m.processList.entries = append(m.processList.entries[:idx], m.processList.entries[idx+1:]...)
+				if m.processList.selection >= len(m.processList.entries) {
+					m.processList.selection = max(0, len(m.processList.entries)-1)
+				}
+				return
+			}
+		}
+		return
+	}
+	upsert := clientui.BackgroundProcess{
+		ID:              id,
+		State:           state,
+		Command:         strings.TrimSpace(evt.Command),
+		Workdir:         strings.TrimSpace(evt.Workdir),
+		LogPath:         strings.TrimSpace(evt.LogPath),
+		RecentOutput:    evt.Preview,
+		OutputAvailable: strings.TrimSpace(evt.Preview) != "",
+		ExitCode:        evt.ExitCode,
+		Running:         backgroundProcessEventRunning(evt),
+		Backgrounded:    true,
+	}
+	for idx, existing := range m.processList.entries {
+		if existing.ID != id {
+			continue
+		}
+		m.processList.entries[idx] = mergeBackgroundProcessCacheEntry(existing, upsert)
+		return
+	}
+	m.processList.entries = append([]clientui.BackgroundProcess{upsert}, m.processList.entries...)
+}
+
+func mergeBackgroundProcessCacheEntry(existing, update clientui.BackgroundProcess) clientui.BackgroundProcess {
+	next := existing
+	if update.State != "" {
+		next.State = update.State
+		next.Running = update.Running
+	}
+	if update.Command != "" {
+		next.Command = update.Command
+	}
+	if update.Workdir != "" {
+		next.Workdir = update.Workdir
+	}
+	if update.LogPath != "" {
+		next.LogPath = update.LogPath
+	}
+	if update.RecentOutput != "" {
+		next.RecentOutput = update.RecentOutput
+		next.OutputAvailable = update.OutputAvailable
+	}
+	if update.ExitCode != nil {
+		next.ExitCode = update.ExitCode
+	}
+	next.Backgrounded = next.Backgrounded || update.Backgrounded
+	return next
+}
+
+func backgroundProcessEventRunning(evt *clientui.BackgroundShellEvent) bool {
+	if evt == nil {
+		return false
+	}
+	state := strings.ToLower(strings.TrimSpace(evt.State))
+	switch state {
+	case "starting", "running":
+		return true
+	case "completed", "failed", "canceled", "cancelled", "done", "exited", "killed", "removed":
+		return false
+	}
+	eventType := strings.ToLower(strings.TrimSpace(evt.Type))
+	return eventType == "started" || eventType == "running" || eventType == "backgrounded"
 }
 
 func (m *uiModel) openProcessList() {
 	m.processList.open = true
+	m.processList.surfaceGeneration++
 	m.setInputMode(uiInputModeProcessList)
-	m.refreshProcessEntries()
 }
 
 func (m *uiModel) closeProcessList() {
 	m.processList.open = false
-	m.refreshProcessEntries()
+	m.processList.surfaceGeneration++
 	m.restorePrimaryInputMode()
 }
 
@@ -124,6 +203,86 @@ func (m *uiModel) selectedProcess() (clientui.BackgroundProcess, bool) {
 	return m.processList.entries[m.processList.selection], true
 }
 
+func (m *uiModel) nextProcessActionToken() uint64 {
+	m.processList.actionToken++
+	return m.processList.actionToken
+}
+
+func (m *uiModel) requestProcessListRefresh() tea.Cmd {
+	if m == nil || !m.processList.isOpen() {
+		return nil
+	}
+	if m.processClient == nil {
+		m.processList.entries = nil
+		m.processList.selection = 0
+		m.processList.loading = false
+		m.processList.errorText = "background process client is unavailable"
+		return nil
+	}
+	if m.processList.refreshInFlight {
+		m.processList.refreshDirty = true
+		return nil
+	}
+	m.processList.refreshToken++
+	token := m.processList.refreshToken
+	m.processList.refreshInFlight = true
+	m.processList.refreshDirty = false
+	m.processList.loading = true
+	client := m.processClient
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), uiProcessOperationTimeout)
+		defer cancel()
+		entries, err := client.ListProcesses(ctx)
+		return processListRefreshDoneMsg{token: token, entries: entries, err: err}
+	}
+}
+
+func (m *uiModel) processActionCmd(action, id, logPath string, inputDraftToken uint64) tea.Cmd {
+	if m == nil || m.processClient == nil {
+		return nil
+	}
+	token := m.nextProcessActionToken()
+	surfaceGeneration := m.processList.surfaceGeneration
+	client := m.processClient
+	action = strings.ToLower(strings.TrimSpace(action))
+	id = strings.TrimSpace(id)
+	logPath = strings.TrimSpace(logPath)
+	m.processList.actionInFlight = true
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), uiProcessOperationTimeout)
+		defer cancel()
+		msg := processActionDoneMsg{
+			token:             token,
+			surfaceGeneration: surfaceGeneration,
+			inputDraftToken:   inputDraftToken,
+			action:            action,
+			id:                id,
+			logPath:           logPath,
+		}
+		switch action {
+		case "kill":
+			msg.err = client.KillProcess(ctx, id)
+		case "inline":
+			msg.output, msg.logPath, msg.err = client.InlineOutput(ctx, id, 12_000)
+		case "logs":
+			if msg.logPath == "" {
+				entries, err := client.ListProcesses(ctx)
+				if err != nil {
+					msg.err = err
+					return msg
+				}
+				msg.logPath, msg.err = processLogPath(entries, id)
+			}
+			if msg.err == nil {
+				msg.editorCmd, msg.err = openProcessLogPath(msg.logPath)
+			}
+		default:
+			msg.err = fmt.Errorf("unknown /ps action %q", action)
+		}
+		return msg
+	}
+}
+
 func (m *uiModel) processListHasRunningEntries() bool {
 	if m == nil || !m.processList.isOpen() {
 		return false
@@ -134,6 +293,64 @@ func (m *uiModel) processListHasRunningEntries() bool {
 		}
 	}
 	return false
+}
+
+func (m *uiModel) applyProcessActionDone(msg processActionDoneMsg) tea.Cmd {
+	if m == nil || msg.token != m.processList.actionToken {
+		return nil
+	}
+	m.processList.actionInFlight = false
+	if msg.err != nil {
+		statusCmd := m.setTransientStatusWithKind(msg.err.Error(), uiStatusNoticeError)
+		switch msg.action {
+		case "kill", "logs":
+			c := uiInputController{model: m}
+			return tea.Batch(statusCmd, c.resumeQueuedInputsAfterIdleRuntime())
+		default:
+			return statusCmd
+		}
+	}
+	c := uiInputController{model: m}
+	switch msg.action {
+	case "kill":
+		status := fmt.Sprintf("sent terminate signal to %s", msg.id)
+		var refreshCmd tea.Cmd
+		if m.processList.isOpen() && msg.surfaceGeneration == m.processList.surfaceGeneration {
+			refreshCmd = m.requestProcessListRefresh()
+		}
+		return tea.Batch(m.setTransientStatus(status), refreshCmd, c.resumeQueuedInputsAfterIdleRuntime())
+	case "inline":
+		if msg.inputDraftToken != 0 && msg.inputDraftToken != m.mainInputDraftToken {
+			return nil
+		}
+		preview := strings.TrimSpace(msg.output)
+		if preview == "" {
+			preview = "<no output yet>"
+		}
+		releaseCmd := c.releaseLockedInjectedInput(true)
+		m.appendProcessOutputToInput(msg.id, preview)
+		if m.processList.isOpen() && msg.surfaceGeneration == m.processList.surfaceGeneration {
+			return tea.Batch(releaseCmd, c.stopProcessListFlowCmd(), c.showTransientStatus("Pasted shell transcript"))
+		}
+		return tea.Batch(releaseCmd, c.showTransientStatus("Pasted shell transcript"))
+	case "logs":
+		statusCmd := c.showTransientStatus("Opened logs")
+		if msg.editorCmd != nil {
+			execCmd := tea.ExecProcess(msg.editorCmd, func(runErr error) tea.Msg {
+				return openProcessLogsDoneMsg{err: runErr}
+			})
+			if m.processList.isOpen() && msg.surfaceGeneration == m.processList.surfaceGeneration {
+				return tea.Batch(c.stopProcessListFlowCmd(), statusCmd, execCmd, c.resumeQueuedInputsAfterIdleRuntime())
+			}
+			return tea.Batch(statusCmd, execCmd, c.resumeQueuedInputsAfterIdleRuntime())
+		}
+		if m.processList.isOpen() && msg.surfaceGeneration == m.processList.surfaceGeneration {
+			return tea.Batch(c.stopProcessListFlowCmd(), statusCmd, c.resumeQueuedInputsAfterIdleRuntime())
+		}
+		return tea.Batch(statusCmd, c.resumeQueuedInputsAfterIdleRuntime())
+	default:
+		return nil
+	}
 }
 
 func (c uiInputController) handleProcessListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -167,8 +384,7 @@ func (c uiInputController) handleProcessListKey(msg tea.KeyMsg) (tea.Model, tea.
 		m.selectLastProcess()
 		return m, nil
 	case "r":
-		m.refreshProcessEntries()
-		return m, c.showTransientStatus(fmt.Sprintf("refreshed %d processes", len(m.processList.entries)))
+		return m, tea.Batch(m.requestProcessListRefresh(), c.showTransientStatus("refreshing processes"))
 	case "enter":
 		return c.runProcessListAction("inline")
 	case "k":
@@ -203,42 +419,18 @@ func (c uiInputController) runProcessAction(action, id string) (tea.Model, tea.C
 	}
 	switch action {
 	case "kill":
-		if err := m.processClient.KillProcess(id); err != nil {
-			return m, c.showErrorStatus(err.Error())
-		}
-		m.refreshProcessEntries()
-		return m, c.showTransientStatus(fmt.Sprintf("sent terminate signal to %s", id))
+		return m, m.processActionCmd(action, id, "", 0)
 	case "inline":
-		preview, _, err := m.processClient.InlineOutput(id, 12_000)
-		if err != nil {
-			return m, c.showErrorStatus(err.Error())
-		}
-		preview = strings.TrimSpace(preview)
-		if preview == "" {
-			preview = "<no output yet>"
-		}
-		c.releaseLockedInjectedInput(true)
-		m.appendProcessOutputToInput(id, preview)
-		return m, tea.Batch(c.stopProcessListFlowCmd(), c.showTransientStatus("Pasted shell transcript"))
+		return m, m.processActionCmd(action, id, "", m.mainInputDraftToken)
 	case "logs":
-		path, err := processLogPath(m.listProcesses(), id)
-		if err != nil {
-			return m, c.showErrorStatus(err.Error())
+		path := ""
+		for _, entry := range m.processList.entries {
+			if entry.ID == id {
+				path = entry.LogPath
+				break
+			}
 		}
-		if err := openDefault(path); err == nil {
-			return m, tea.Batch(c.stopProcessListFlowCmd(), c.showTransientStatus("Opened logs"))
-		}
-		editorCmd, err := editorCommand(path)
-		if err != nil {
-			return m, c.showErrorStatus(err.Error())
-		}
-		return m, tea.Batch(
-			c.stopProcessListFlowCmd(),
-			c.showTransientStatus("Opened logs"),
-			tea.ExecProcess(editorCmd, func(runErr error) tea.Msg {
-				return openProcessLogsDoneMsg{err: runErr}
-			}),
-		)
+		return m, m.processActionCmd(action, id, path, 0)
 	default:
 		return m, c.showErrorStatus(fmt.Sprintf("unknown /ps action %q", action))
 	}
@@ -270,6 +462,19 @@ func processLogPath(entries []clientui.BackgroundProcess, id string) (string, er
 	return "", fmt.Errorf("unknown session_id %s", id)
 }
 
+var openDefault = func(path string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", path)
+	case "linux":
+		cmd = exec.Command("xdg-open", path)
+	default:
+		return fmt.Errorf("open is not supported on %s", runtime.GOOS)
+	}
+	return cmd.Start()
+}
+
 func editorCommand(path string) (*exec.Cmd, error) {
 	editor := strings.TrimSpace(os.Getenv("VISUAL"))
 	if editor == "" {
@@ -287,15 +492,9 @@ func editorCommand(path string) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
-var openDefault = func(path string) error {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", path)
-	case "linux":
-		cmd = exec.Command("xdg-open", path)
-	default:
-		return fmt.Errorf("open is not supported on %s", runtime.GOOS)
+func openProcessLogPath(path string) (*exec.Cmd, error) {
+	if err := openDefault(path); err == nil {
+		return nil, nil
 	}
-	return cmd.Start()
+	return editorCommand(path)
 }

--- a/cli/app/ui_processes.go
+++ b/cli/app/ui_processes.go
@@ -327,7 +327,7 @@ func (m *uiModel) applyProcessActionDone(msg processActionDoneMsg) tea.Cmd {
 		return tea.Batch(m.setTransientStatus(status), refreshCmd, c.resumeQueuedInputsAfterIdleRuntime())
 	case "inline":
 		if msg.inputDraftToken != 0 && msg.inputDraftToken != m.mainInputDraftToken {
-			return nil
+			return c.resumeQueuedInputsAfterIdleRuntime()
 		}
 		preview := strings.TrimSpace(msg.output)
 		if preview == "" {

--- a/cli/app/ui_processes.go
+++ b/cli/app/ui_processes.go
@@ -14,7 +14,10 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-const uiProcessOperationTimeout = 5 * time.Second
+const (
+	uiProcessInlineMaxChars   = 12_000
+	uiProcessOperationTimeout = 5 * time.Second
+)
 
 func (m *uiModel) applyProcessEntries(entries []clientui.BackgroundProcess) {
 	selectedID := ""
@@ -263,7 +266,7 @@ func (m *uiModel) processActionCmd(action, id, logPath string, inputDraftToken u
 		case "kill":
 			msg.err = client.KillProcess(ctx, id)
 		case "inline":
-			msg.output, msg.logPath, msg.err = client.InlineOutput(ctx, id, 12_000)
+			msg.output, msg.logPath, msg.err = client.InlineOutput(ctx, id, uiProcessInlineMaxChars)
 		case "logs":
 			if msg.logPath == "" {
 				entries, err := client.ListProcesses(ctx)

--- a/cli/app/ui_processes.go
+++ b/cli/app/ui_processes.go
@@ -244,6 +244,9 @@ func (m *uiModel) processActionCmd(action, id, logPath string, inputDraftToken u
 	if m == nil || m.processClient == nil {
 		return nil
 	}
+	if m.processList.actionInFlight {
+		return nil
+	}
 	token := m.nextProcessActionToken()
 	surfaceGeneration := m.processList.surfaceGeneration
 	client := m.processClient
@@ -305,12 +308,12 @@ func (m *uiModel) applyProcessActionDone(msg processActionDoneMsg) tea.Cmd {
 	m.processList.actionInFlight = false
 	if msg.err != nil {
 		statusCmd := m.setTransientStatusWithKind(msg.err.Error(), uiStatusNoticeError)
+		c := uiInputController{model: m}
 		switch msg.action {
 		case "kill", "logs":
-			c := uiInputController{model: m}
 			return tea.Batch(statusCmd, c.resumeQueuedInputsAfterIdleRuntime())
 		default:
-			return statusCmd
+			return tea.Batch(statusCmd, c.resumeQueuedInputsAfterIdleRuntime())
 		}
 	}
 	c := uiInputController{model: m}
@@ -414,6 +417,9 @@ func (c uiInputController) runProcessAction(action, id string) (tea.Model, tea.C
 	m := c.model
 	if m.processClient == nil {
 		return m, c.showErrorStatus("background process client is unavailable")
+	}
+	if m.processList.actionInFlight {
+		return m, c.showTransientStatus("process action already in flight")
 	}
 	action = strings.ToLower(strings.TrimSpace(action))
 	id = strings.TrimSpace(id)

--- a/cli/app/ui_projected_runtime_test.go
+++ b/cli/app/ui_projected_runtime_test.go
@@ -311,55 +311,35 @@ func TestConversationUpdateHydrationFencesLaterRuntimeEvents(t *testing.T) {
 
 	next, cmd := m.Update(runtimeEventMsg{event: clientui.Event{Kind: clientui.EventConversationUpdated, CommittedTranscriptChanged: true}})
 	updated := next.(*uiModel)
-	if !updated.waitRuntimeEventAfterHydration {
-		t.Fatal("expected conversation update to arm hydration fence")
+	if updated.waitRuntimeEventAfterHydration {
+		t.Fatal("deferred routine conversation update must not arm hydration fence")
 	}
-	if updated.sawAssistantDelta {
-		t.Fatal("expected conversation update committed-advance sync to clear assistant delta state before hydration")
+	if !updated.runtimeTranscriptPendingSet {
+		t.Fatal("expected routine conversation update to defer transcript sync while streaming")
 	}
-	if updated.reasoningLiveDirty {
-		t.Fatal("expected conversation update committed-advance sync to clear reasoning live state before hydration")
+	if !updated.sawAssistantDelta {
+		t.Fatal("expected deferred conversation update to preserve assistant delta state")
 	}
-	if got := updated.view.OngoingStreamingText(); got != "" {
-		t.Fatalf("expected conversation update committed-advance sync to clear stale ongoing text before hydration, got %q", got)
+	if !updated.reasoningLiveDirty {
+		t.Fatal("expected deferred conversation update to preserve reasoning live state")
 	}
-	if len(runtimeEvents) != 1 {
-		t.Fatalf("expected later runtime event to remain unread until hydration completes, remaining=%d", len(runtimeEvents))
+	if got := updated.view.OngoingStreamingText(); got != "stale stream" {
+		t.Fatalf("expected deferred conversation update to preserve stale ongoing text, got %q", got)
 	}
 	msgs := collectCmdMessages(t, cmd)
-	var refresh runtimeTranscriptRefreshedMsg
-	refreshFound := false
+	resumed := false
 	for _, msg := range msgs {
 		switch typed := msg.(type) {
 		case runtimeTranscriptRefreshedMsg:
-			refresh = typed
-			refreshFound = true
+			t.Fatalf("did not expect routine refresh while streaming, got %+v", typed)
 		case runtimeEventBatchMsg:
-			t.Fatalf("did not expect runtime stream to resume before hydration completes, got %+v", typed)
-		}
-	}
-	if !refreshFound {
-		t.Fatalf("expected authoritative transcript refresh for conversation update, got %+v", msgs)
-	}
-
-	next, followCmd := updated.Update(refresh)
-	updated = next.(*uiModel)
-	if updated.waitRuntimeEventAfterHydration {
-		t.Fatal("expected hydration fence cleared after transcript refresh applies")
-	}
-	followMsgs := collectCmdMessages(t, followCmd)
-	resumed := false
-	for _, msg := range followMsgs {
-		batch, ok := msg.(runtimeEventBatchMsg)
-		if !ok {
-			continue
-		}
-		if len(batch.events) == 1 && batch.events[0].AssistantDelta == "later" {
-			resumed = true
+			if len(typed.events) == 1 && typed.events[0].AssistantDelta == "later" {
+				resumed = true
+			}
 		}
 	}
 	if !resumed {
-		t.Fatalf("expected runtime stream to resume after hydration, got %+v", followMsgs)
+		t.Fatalf("expected runtime stream to continue without hydration fence, got %+v", msgs)
 	}
 }
 
@@ -382,16 +362,16 @@ func TestStreamGapInvalidatesTransientStateBeforeHydrationFence(t *testing.T) {
 	next, cmd := m.Update(runtimeEventMsg{event: clientui.Event{Kind: clientui.EventStreamGap, RecoveryCause: clientui.TranscriptRecoveryCauseStreamGap}})
 	updated := next.(*uiModel)
 	if !updated.waitRuntimeEventAfterHydration {
-		t.Fatal("expected stream gap to arm hydration fence after transient state invalidation")
+		t.Fatal("expected stream gap recovery to arm hydration fence")
 	}
-	if updated.sawAssistantDelta {
-		t.Fatal("expected stream gap to clear assistant delta state before hydration")
+	if !updated.sawAssistantDelta {
+		t.Fatal("expected stream gap recovery to preserve assistant delta state before hydrate applies")
 	}
-	if updated.reasoningLiveDirty {
-		t.Fatal("expected stream gap to clear reasoning live state before hydration")
+	if !updated.reasoningLiveDirty {
+		t.Fatal("expected stream gap recovery to preserve reasoning live state before hydrate applies")
 	}
-	if got := updated.view.OngoingStreamingText(); got != "" {
-		t.Fatalf("expected stream gap to clear stale ongoing text before hydration, got %q", got)
+	if got := updated.view.OngoingStreamingText(); got != "stale stream" {
+		t.Fatalf("expected stream gap recovery to preserve stale ongoing text before hydrate applies, got %q", got)
 	}
 	if len(runtimeEvents) != 1 {
 		t.Fatalf("expected later runtime event to remain unread until hydration completes, remaining=%d", len(runtimeEvents))
@@ -803,13 +783,7 @@ func TestRuntimeModelRefreshesOngoingErrorOnDedicatedUpdateEvent(t *testing.T) {
 	msg := runtimeEventBatchFromCmd(t, m.waitRuntimeEventCmd(), "runtime wait")
 	next, cmd := m.Update(msg)
 	updated := next.(*uiModel)
-	if cmd == nil {
-		t.Fatal("expected refresh command for ongoing error update")
-	}
-	refresh, ok := cmd().(runtimeTranscriptRefreshedMsg)
-	if !ok {
-		t.Fatalf("expected runtimeTranscriptRefreshedMsg, got %T", cmd())
-	}
+	refresh := runtimeTranscriptRefreshOrReleaseDeferredForTest(t, updated, cmd)
 	next, _ = updated.Update(refresh)
 	updated = next.(*uiModel)
 	if got := updated.view.OngoingErrorText(); got != "background continuation failed" {
@@ -850,13 +824,7 @@ func TestRuntimeModelOngoingErrorUpdatedSetsAndClearsBannerLifecycle(t *testing.
 	firstMsg := runtimeEventBatchFromCmd(t, m.waitRuntimeEventCmd(), "runtime wait command for ongoing error set")
 	next, cmd := m.Update(firstMsg)
 	updated := next.(*uiModel)
-	if cmd == nil {
-		t.Fatal("expected refresh command for ongoing error set")
-	}
-	refresh, ok := cmd().(runtimeTranscriptRefreshedMsg)
-	if !ok {
-		t.Fatalf("expected runtimeTranscriptRefreshedMsg, got %T", cmd())
-	}
+	refresh := runtimeTranscriptRefreshOrReleaseDeferredForTest(t, updated, cmd)
 	next, _ = updated.Update(refresh)
 	updated = next.(*uiModel)
 	if got := updated.view.OngoingErrorText(); got != "background continuation failed" {
@@ -866,13 +834,7 @@ func TestRuntimeModelOngoingErrorUpdatedSetsAndClearsBannerLifecycle(t *testing.
 	secondMsg := runtimeEventBatchFromCmd(t, updated.waitRuntimeEventCmd(), "runtime wait command for ongoing error clear")
 	next, cmd = updated.Update(secondMsg)
 	updated = next.(*uiModel)
-	if cmd == nil {
-		t.Fatal("expected refresh command for ongoing error clear")
-	}
-	refresh, ok = cmd().(runtimeTranscriptRefreshedMsg)
-	if !ok {
-		t.Fatalf("expected runtimeTranscriptRefreshedMsg, got %T", cmd())
-	}
+	refresh = runtimeTranscriptRefreshOrReleaseDeferredForTest(t, updated, cmd)
 	next, _ = updated.Update(refresh)
 	updated = next.(*uiModel)
 	if got := updated.view.OngoingErrorText(); got != "" {

--- a/cli/app/ui_prompt_history.go
+++ b/cli/app/ui_prompt_history.go
@@ -205,11 +205,12 @@ func (m *uiModel) recordPromptHistory(text string) tea.Cmd {
 	}
 	m.promptHistory = append(m.promptHistory, text)
 	m.resetPromptHistoryNavigation()
-	if !m.hasRuntimeClient() {
+	client := m.runtimeClient()
+	if client == nil {
 		return nil
 	}
 	return func() tea.Msg {
-		if err := m.recordRuntimePromptHistory(text); err != nil {
+		if err := client.RecordPromptHistory(text); err != nil {
 			return promptHistoryPersistErrMsg{err: err}
 		}
 		return nil

--- a/cli/app/ui_queue_identity_test.go
+++ b/cli/app/ui_queue_identity_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"builder/shared/clientui"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func queuedUserMessagesForTest(texts ...string) []clientui.QueuedUserMessage {
@@ -39,4 +41,40 @@ func applyInterruptedRunStateForTest(t *testing.T, m *uiModel) *uiModel {
 		t.Fatalf("updated model = %T, want *uiModel", next)
 	}
 	return updated
+}
+
+func applyFirstInjectedQueueCreateDoneForTest(t *testing.T, m *uiModel, cmd tea.Cmd) *uiModel {
+	t.Helper()
+	if cmd == nil {
+		return m
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		if typed, ok := msg.(injectedQueueCreateDoneMsg); ok {
+			next, _ := m.Update(typed)
+			updated, ok := next.(*uiModel)
+			if !ok {
+				t.Fatalf("updated model = %T, want *uiModel", next)
+			}
+			return updated
+		}
+	}
+	return m
+}
+
+func applyQueuedRuntimeWorkCheckForTest(t *testing.T, m *uiModel, cmd tea.Cmd) (*uiModel, tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		return m, nil
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		if typed, ok := msg.(queuedRuntimeWorkCheckDoneMsg); ok {
+			next, nextCmd := m.Update(typed)
+			updated, ok := next.(*uiModel)
+			if !ok {
+				t.Fatalf("updated model = %T, want *uiModel", next)
+			}
+			return updated, nextCmd
+		}
+	}
+	return m, cmd
 }

--- a/cli/app/ui_runtime_adapter.go
+++ b/cli/app/ui_runtime_adapter.go
@@ -75,14 +75,15 @@ func (a uiRuntimeAdapter) applyProjectedRuntimeEvent(evt clientui.Event, flushNa
 	})
 	m.markActiveSubmitFlushed(evt)
 	m.applyRuntimeEventStatus(evt)
+	if !m.processList.isOpen() {
+		m.applyBackgroundProcessEventToCache(evt.Background)
+	}
 	cmds := make([]tea.Cmd, 0, 5)
 	cmds = append(cmds, a.applyRuntimeEventReduction(reduction))
-	a.reconcileInterruptFromRunState(evt)
+	cmds = append(cmds, a.reconcileInterruptFromRunState(evt))
 	transcriptMutated := false
 	awaitsHydration := false
-	if shouldInvalidateTransientTranscriptStateForSync(transcriptSync) {
-		m.invalidateTransientTranscriptState()
-	}
+	evt = m.suppressLocalEntryEchoesInEvent(evt)
 	if len(evt.TranscriptEntries) > 0 {
 		if shouldDeliverCommittedRuntimeEventFromSuffix(m, evt) {
 			m.observeNativeStreamingAssistantCommitCandidate(evt)
@@ -131,6 +132,7 @@ func (a uiRuntimeAdapter) applyProjectedRuntimeEvent(evt clientui.Event, flushNa
 			}
 			m.sawAssistantDelta = false
 			m.forwardToView(tui.ClearOngoingAssistantMsg{})
+			cmds = append(cmds, m.releaseDeferredRuntimeSyncs())
 		}
 	}
 	for _, streamCommand := range reduction.Reasoning.Stream {
@@ -144,6 +146,7 @@ func (a uiRuntimeAdapter) applyProjectedRuntimeEvent(evt clientui.Event, flushNa
 		case runtimestate.RuntimeReasoningStreamClear:
 			m.reasoningLiveDirty = false
 			m.forwardToView(tui.ClearStreamingReasoningMsg{})
+			cmds = append(cmds, m.releaseDeferredRuntimeSyncs())
 		}
 	}
 	if reduction.Notices.BackgroundNotice != nil {
@@ -157,21 +160,13 @@ func (a uiRuntimeAdapter) applyProjectedRuntimeEvent(evt clientui.Event, flushNa
 		cmds = append(cmds, m.recordPromptHistory(reduction.PendingInput.PromptHistoryCommand.Text))
 	}
 	if transcriptSync.IsSet() {
-		cmds = append(cmds, a.syncConversationFromRuntimeTranscriptCommand(transcriptSync))
-		awaitsHydration = awaitsHydration || shouldPauseRuntimeEventsForHydration(m)
+		syncDecision := a.syncConversationFromRuntimeTranscriptCommand(transcriptSync)
+		cmds = append(cmds, syncDecision.cmd)
+		awaitsHydration = awaitsHydration || syncDecision.awaitsHydration
 	} else if shouldRefreshDeferredCommittedTailOnRunEnd(m, evt) {
 		cmds = append(cmds, m.requestRuntimeCommittedConversationSync())
 	}
 	return runtimeEventApplyResult{cmd: batchCmds(cmds...), transcriptMutated: transcriptMutated, awaitsHydration: awaitsHydration}
-}
-
-func shouldInvalidateTransientTranscriptStateForSync(sync runtimestate.RuntimeTranscriptSyncCommand) bool {
-	switch sync.Reason {
-	case runtimestate.RuntimeTranscriptSyncRecovery, runtimestate.RuntimeTranscriptSyncStreamGap, runtimestate.RuntimeTranscriptSyncCommittedAdvance:
-		return true
-	default:
-		return false
-	}
 }
 
 func runtimeTranscriptSyncReasonLabel(sync runtimestate.RuntimeTranscriptSyncCommand) string {
@@ -181,23 +176,23 @@ func runtimeTranscriptSyncReasonLabel(sync runtimestate.RuntimeTranscriptSyncCom
 	return string(sync.Reason)
 }
 
-func (a uiRuntimeAdapter) syncConversationFromRuntimeTranscriptCommand(sync runtimestate.RuntimeTranscriptSyncCommand) tea.Cmd {
+func (a uiRuntimeAdapter) syncConversationFromRuntimeTranscriptCommand(sync runtimestate.RuntimeTranscriptSyncCommand) runtimeTranscriptSyncDecision {
 	switch sync.Reason {
 	case runtimestate.RuntimeTranscriptSyncRecovery, runtimestate.RuntimeTranscriptSyncStreamGap:
-		return a.model.requestRuntimeTranscriptSyncForContinuityLoss(sync.RecoveryCause)
+		return a.model.startRuntimeTranscriptPageRequestDecision(a.model.transcriptRequestForCurrentMode(), false, runtimeTranscriptSyncCauseContinuityRecovery, sync.RecoveryCause)
 	case runtimestate.RuntimeTranscriptSyncCommittedAdvance, runtimestate.RuntimeTranscriptSyncOngoingErrorUpdated:
 		return a.syncConversationFromEngine()
 	default:
-		return nil
+		return runtimeTranscriptSyncDecision{}
 	}
 }
 
-func (a uiRuntimeAdapter) syncConversationFromEngine() tea.Cmd {
+func (a uiRuntimeAdapter) syncConversationFromEngine() runtimeTranscriptSyncDecision {
 	m := a.model
 	if !m.hasRuntimeClient() {
-		return nil
+		return runtimeTranscriptSyncDecision{}
 	}
-	return m.requestRuntimeCommittedConversationSync()
+	return m.startRuntimeTranscriptPageRequestDecision(m.transcriptRequestForCurrentMode(), false, runtimeTranscriptSyncCauseCommittedConversation, clientui.TranscriptRecoveryCauseNone)
 }
 
 func waitAskEvent(ch <-chan askEvent) tea.Cmd {

--- a/cli/app/ui_runtime_adapter_part2_test.go
+++ b/cli/app/ui_runtime_adapter_part2_test.go
@@ -832,6 +832,47 @@ func TestLocalEntryAddedRemainsVisibleAfterHydrationSync(t *testing.T) {
 	}
 }
 
+func TestLocalFirstEntryHydrationAcknowledgesNoticeIDWithoutDroppingDistinctEntries(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedStaticUIModel()
+	m.engine = client
+	m.termWidth = 100
+	m.termHeight = 20
+	m.windowSizeKnown = true
+
+	if cmd := m.appendLocalEntryWithNoticeID("system", "same feedback", "notice-1"); cmd == nil {
+		t.Fatal("expected local entry persistence command")
+	}
+	_ = m.runtimeAdapter().handleProjectedRuntimeEvent(clientui.Event{
+		Kind:                clientui.EventLocalEntryAdded,
+		TranscriptRevision:  2,
+		CommittedEntryCount: 1,
+		TranscriptEntries:   []clientui.ChatEntry{{Role: "system", Text: "same feedback", NoticeID: "notice-1"}},
+	})
+
+	hydrated := clientui.TranscriptPage{
+		SessionID:    "session-1",
+		Revision:     2,
+		Offset:       0,
+		TotalEntries: 2,
+		Entries: []clientui.ChatEntry{
+			{Role: "system", Text: "same feedback", NoticeID: "notice-1"},
+			{Role: "system", Text: "same feedback", NoticeID: "notice-2"},
+		},
+	}
+	if cmd := m.runtimeAdapter().applyRuntimeTranscriptPage(clientui.TranscriptPageRequest{}, hydrated); cmd != nil {
+		_ = collectCmdMessages(t, cmd)
+	}
+
+	loaded := m.view.LoadedTranscriptEntries()
+	if len(loaded) != 2 {
+		t.Fatalf("expected two distinct NoticeID entries after hydration, got %+v", loaded)
+	}
+	if loaded[0].NoticeID != "notice-1" || loaded[1].NoticeID != "notice-2" {
+		t.Fatalf("unexpected hydrated NoticeIDs: %+v", loaded)
+	}
+}
+
 func TestHandleProjectedRuntimeEventAppendsCleanupAndBackgroundEntriesImmediately(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.forwardToView(tui.SetViewportSizeMsg{Lines: 20, Width: 80})

--- a/cli/app/ui_runtime_adapter_test.go
+++ b/cli/app/ui_runtime_adapter_test.go
@@ -354,6 +354,22 @@ func TestRuntimeAdapterBackgroundUpdateRefreshesOpenProcessListAndShowsNotice(t 
 		},
 	})
 
+	msgs := collectCmdMessages(t, cmd)
+	var refresh processListRefreshDoneMsg
+	foundRefresh := false
+	for _, msg := range msgs {
+		if typed, ok := msg.(processListRefreshDoneMsg); ok {
+			refresh = typed
+			foundRefresh = true
+			break
+		}
+	}
+	if !foundRefresh {
+		t.Fatalf("expected background update to schedule process refresh completion, got %+v", msgs)
+	}
+	next, _ := m.Update(refresh)
+	m = next.(*uiModel)
+
 	if len(m.processList.entries) != 1 || m.processList.entries[0].ID != "proc-1" {
 		t.Fatalf("process entries = %+v, want refreshed proc-1", m.processList.entries)
 	}
@@ -365,6 +381,29 @@ func TestRuntimeAdapterBackgroundUpdateRefreshesOpenProcessListAndShowsNotice(t 
 	}
 	if cmd == nil {
 		t.Fatal("expected notice clear command")
+	}
+}
+
+func TestRuntimeAdapterBackgroundUpdateCachesProcessStatusWithoutListRead(t *testing.T) {
+	processes := &countingProcessClient{}
+	m := newProjectedStaticUIModel(WithUIProcessClient(processes))
+
+	_ = m.runtimeAdapter().handleProjectedRuntimeEvent(clientui.Event{
+		Kind: clientui.EventBackgroundUpdated,
+		Background: &clientui.BackgroundShellEvent{
+			Type:    "started",
+			ID:      "proc-1",
+			State:   "running",
+			Command: "sleep 1",
+		},
+	})
+
+	if processes.listCalls != 0 {
+		t.Fatalf("expected background status cache update not to list processes, got %d calls", processes.listCalls)
+	}
+	status := stripANSIAndTrimRight(m.renderStatusLine(120, uiThemeStyles("dark")))
+	if !strings.Contains(status, "ps 1") {
+		t.Fatalf("expected cached process count in status line, got %q", status)
 	}
 }
 

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -395,6 +395,8 @@ func (c *sessionRuntimeClient) refreshTranscriptPageSync(req clientui.Transcript
 		page.SessionID = c.sessionID
 	}
 	c.patchMainView(func(view *clientui.RuntimeMainView) {
+		view.Status.ConversationFreshness = page.ConversationFreshness
+		view.Session.ConversationFreshness = page.ConversationFreshness
 		view.Session.Transcript = clientui.TranscriptMetadata{
 			Revision:            page.Revision,
 			CommittedEntryCount: page.TotalEntries,
@@ -448,6 +450,8 @@ func (c *sessionRuntimeClient) refreshCommittedTranscriptSuffixSync(req clientui
 		suffix.SessionID = c.sessionID
 	}
 	c.patchMainView(func(view *clientui.RuntimeMainView) {
+		view.Status.ConversationFreshness = suffix.ConversationFreshness
+		view.Session.ConversationFreshness = suffix.ConversationFreshness
 		view.Session.Transcript = clientui.TranscriptMetadata{
 			Revision:            suffix.Revision,
 			CommittedEntryCount: suffix.CommittedEntryCount,

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -911,6 +911,48 @@ func TestCommittedSuffixAppendSuppressesAcknowledgedLocalEntryEcho(t *testing.T)
 	}
 }
 
+func TestCommittedSuffixAppendSuppressesLeadingEchoWithoutShiftingLaterEntries(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedStaticUIModel()
+	m.engine = client
+	m.windowSizeKnown = true
+	m.termWidth = 100
+	m.termHeight = 20
+	m.ongoingCommittedDelivery = newOngoingCommittedDeliveryCursor(0, 1)
+
+	_ = m.appendLocalEntryWithNoticeID("system", "Fast mode enabled", "notice-1")
+	cmd := m.applyCommittedTranscriptSuffixAppend(clientui.CommittedTranscriptSuffix{
+		Revision:            2,
+		CommittedEntryCount: 2,
+		StartEntryCount:     0,
+		NextEntryCount:      2,
+		Entries: []clientui.ChatEntry{
+			{Role: "system", Text: "Fast mode enabled", NoticeID: "notice-1"},
+			{Role: "assistant", Text: "authoritative answer", Phase: string(llm.MessagePhaseFinal)},
+		},
+	})
+	if cmd != nil {
+		_ = collectCmdMessages(t, cmd)
+	}
+
+	loaded := m.view.LoadedTranscriptEntries()
+	if len(loaded) != 2 {
+		t.Fatalf("expected local echo and assistant exactly once, got %+v", loaded)
+	}
+	if loaded[0].NoticeID != "notice-1" || loaded[0].Text != "Fast mode enabled" {
+		t.Fatalf("unexpected local echo entry: %+v", loaded[0])
+	}
+	if loaded[1].Role != "assistant" || loaded[1].Text != "authoritative answer" {
+		t.Fatalf("unexpected assistant suffix entry: %+v", loaded[1])
+	}
+	if got := m.ongoingCommittedDelivery.lastAppliedCommittedEntryCount; got != 2 {
+		t.Fatalf("delivery cursor applied count = %d, want 2", got)
+	}
+	if got := committedTranscriptTailEnd(m); got != 2 {
+		t.Fatalf("committed transcript tail = %d, want 2", got)
+	}
+}
+
 func TestCommittedSuffixAppendClearsStreamBeforeFinalAnswerAppend(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.windowSizeKnown = true

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -31,6 +31,7 @@ type countingSessionViewClient struct {
 	suffixErr         error
 	pageForRequest    func(serverapi.SessionTranscriptPageRequest) clientui.TranscriptPage
 	count             atomic.Int32
+	mainViewCount     atomic.Int32
 	pageCount         atomic.Int32
 	suffixCount       atomic.Int32
 	lastTranscriptReq serverapi.SessionTranscriptPageRequest
@@ -39,6 +40,7 @@ type countingSessionViewClient struct {
 
 func (c *countingSessionViewClient) GetSessionMainView(context.Context, serverapi.SessionMainViewRequest) (serverapi.SessionMainViewResponse, error) {
 	c.count.Add(1)
+	c.mainViewCount.Add(1)
 	return serverapi.SessionMainViewResponse{MainView: c.view}, nil
 }
 
@@ -411,6 +413,7 @@ func TestWidthResizeReplayFetchesCommittedSuffixBeforeFullReplay(t *testing.T) {
 		NextEntryCount:      3,
 		Entries:             []clientui.ChatEntry{{Role: "assistant", Text: "fresh-0"}, {Role: "assistant", Text: "fresh-1"}, {Role: "assistant", Text: "fresh-2"}},
 	}
+	reads.mainViewCount.Store(0)
 
 	next, resizeCmd := model.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
 	model = next.(*uiModel)
@@ -429,6 +432,9 @@ func TestWidthResizeReplayFetchesCommittedSuffixBeforeFullReplay(t *testing.T) {
 	}
 	if reads.lastSuffixReq.AfterEntryCount != 0 || reads.lastSuffixReq.Limit != clientui.MaxCommittedTranscriptSuffixLimit {
 		t.Fatalf("unexpected resize suffix request: %+v", reads.lastSuffixReq)
+	}
+	if got := reads.mainViewCount.Load(); got != 0 {
+		t.Fatalf("native resize requested main view %d time(s), want 0", got)
 	}
 	next, replayCmd := model.Update(refresh)
 	model = next.(*uiModel)
@@ -841,6 +847,43 @@ func TestCommittedSuffixAppendTrimsOverlappedRowsAlreadyDelivered(t *testing.T) 
 	}
 	if counts["assistant:updated final after review"] != 1 {
 		t.Fatalf("expected updated final once in transcript, got %+v", m.transcriptEntries)
+	}
+}
+
+func TestCommittedSuffixAppendSuppressesAcknowledgedLocalEntryEcho(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedStaticUIModel()
+	m.engine = client
+	m.windowSizeKnown = true
+	m.termWidth = 100
+	m.termHeight = 20
+	m.ongoingCommittedDelivery = newOngoingCommittedDeliveryCursor(0, 1)
+
+	if cmd := m.appendLocalEntryWithNoticeID("system", "Fast mode enabled", "notice-1"); cmd == nil {
+		t.Fatal("expected local entry persistence command")
+	}
+	m.trackLocalEntryEcho("notice-1", uiLocalEntryEchoAcknowledged)
+
+	cmd := m.applyCommittedTranscriptSuffixAppend(clientui.CommittedTranscriptSuffix{
+		Revision:            2,
+		CommittedEntryCount: 1,
+		StartEntryCount:     0,
+		NextEntryCount:      1,
+		Entries:             []clientui.ChatEntry{{Role: "system", Text: "Fast mode enabled", NoticeID: "notice-1"}},
+	})
+	if cmd != nil {
+		_ = collectCmdMessages(t, cmd)
+	}
+
+	loaded := m.view.LoadedTranscriptEntries()
+	if len(loaded) != 1 {
+		t.Fatalf("expected acknowledged local entry exactly once, got %+v", loaded)
+	}
+	if loaded[0].NoticeID != "notice-1" || loaded[0].Text != "Fast mode enabled" {
+		t.Fatalf("unexpected loaded transcript entry: %+v", loaded[0])
+	}
+	if got := m.ongoingCommittedDelivery.lastAppliedCommittedEntryCount; got != 1 {
+		t.Fatalf("delivery cursor applied count = %d, want 1", got)
 	}
 }
 

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -38,6 +38,30 @@ type countingSessionViewClient struct {
 	lastSuffixReq     serverapi.SessionCommittedTranscriptSuffixRequest
 }
 
+type runtimeClientWithoutCachedMainView struct {
+	clientui.RuntimeClient
+	mainView      clientui.RuntimeMainView
+	mainViewCalls int
+	suffixReq     clientui.CommittedTranscriptSuffixRequest
+}
+
+func (c *runtimeClientWithoutCachedMainView) MainView() clientui.RuntimeMainView {
+	c.mainViewCalls++
+	return c.mainView
+}
+
+func (c *runtimeClientWithoutCachedMainView) RefreshCommittedTranscriptSuffix(req clientui.CommittedTranscriptSuffixRequest) (clientui.CommittedTranscriptSuffix, error) {
+	c.suffixReq = req
+	return clientui.CommittedTranscriptSuffix{
+		SessionID:             c.mainView.Session.SessionID,
+		Revision:              c.mainView.Session.Transcript.Revision,
+		CommittedEntryCount:   c.mainView.Session.Transcript.CommittedEntryCount,
+		StartEntryCount:       req.AfterEntryCount,
+		NextEntryCount:        c.mainView.Session.Transcript.CommittedEntryCount,
+		ConversationFreshness: c.mainView.Session.ConversationFreshness,
+	}, nil
+}
+
 func (c *countingSessionViewClient) GetSessionMainView(context.Context, serverapi.SessionMainViewRequest) (serverapi.SessionMainViewResponse, error) {
 	c.count.Add(1)
 	c.mainViewCount.Add(1)
@@ -1134,6 +1158,44 @@ func TestCommittedSuffixMultiToolDetailRoundTripLeavesNoLiveSpinnerAfterFinalRes
 		if counts[key] != 1 {
 			t.Fatalf("committed transcript row count %s = %d, want 1; entries=%+v", key, counts[key], m.transcriptEntries)
 		}
+	}
+}
+
+func TestNativeResizeCommittedTranscriptSuffixFallsBackToMainViewWhenCacheUnavailable(t *testing.T) {
+	client := &runtimeClientWithoutCachedMainView{
+		RuntimeClient: &runtimeControlFakeClient{},
+		mainView: clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{
+			SessionID: "session-1",
+			Transcript: clientui.TranscriptMetadata{
+				Revision:            9,
+				CommittedEntryCount: 900,
+			},
+		}},
+	}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	client.mainViewCalls = 0
+
+	cmd := m.requestNativeResizeCommittedTranscriptSuffix(3)
+	if cmd == nil {
+		t.Fatal("expected native resize suffix request command")
+	}
+	if client.mainViewCalls != 0 {
+		t.Fatalf("main view fallback happened during Update: %d calls", client.mainViewCalls)
+	}
+	raw := cmd()
+	msg, ok := raw.(nativeResizeTranscriptSuffixRefreshedMsg)
+	if !ok {
+		t.Fatalf("unexpected command message type %T", raw)
+	}
+	if msg.token != 3 || msg.err != nil {
+		t.Fatalf("unexpected resize suffix response: %+v", msg)
+	}
+	if client.mainViewCalls != 1 {
+		t.Fatalf("expected main view fallback in command, got %d calls", client.mainViewCalls)
+	}
+	wantAfter := 900 - clientui.MaxCommittedTranscriptSuffixLimit
+	if client.suffixReq.AfterEntryCount != wantAfter || client.suffixReq.Limit != clientui.MaxCommittedTranscriptSuffixLimit {
+		t.Fatalf("resize suffix request = %+v, want after=%d limit=%d", client.suffixReq, wantAfter, clientui.MaxCommittedTranscriptSuffixLimit)
 	}
 }
 

--- a/cli/app/ui_runtime_control.go
+++ b/cli/app/ui_runtime_control.go
@@ -2,9 +2,11 @@ package app
 
 import (
 	"context"
+	"strings"
 
 	"builder/shared/clientui"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/google/uuid"
 )
 
@@ -20,6 +22,7 @@ func (m *uiModel) hasRuntimeClient() bool {
 }
 
 func (m *uiModel) setRuntimeSessionName(name string) error {
+	m.checkTUIBlockingOperation("runtime control mutation", "set session name")
 	if client := m.runtimeClient(); client != nil {
 		err := client.SetSessionName(name)
 		m.observeRuntimeRequestResult(err)
@@ -29,6 +32,7 @@ func (m *uiModel) setRuntimeSessionName(name string) error {
 }
 
 func (m *uiModel) setRuntimeThinkingLevel(level string) error {
+	m.checkTUIBlockingOperation("runtime control mutation", "set thinking level")
 	if client := m.runtimeClient(); client != nil {
 		err := client.SetThinkingLevel(level)
 		m.observeRuntimeRequestResult(err)
@@ -38,6 +42,7 @@ func (m *uiModel) setRuntimeThinkingLevel(level string) error {
 }
 
 func (m *uiModel) setRuntimeFastModeEnabled(enabled bool) (bool, error) {
+	m.checkTUIBlockingOperation("runtime control mutation", "set fast mode")
 	if client := m.runtimeClient(); client != nil {
 		changed, err := client.SetFastModeEnabled(enabled)
 		m.observeRuntimeRequestResult(err)
@@ -47,6 +52,7 @@ func (m *uiModel) setRuntimeFastModeEnabled(enabled bool) (bool, error) {
 }
 
 func (m *uiModel) setRuntimeReviewerEnabled(enabled bool) (bool, string, error) {
+	m.checkTUIBlockingOperation("runtime control mutation", "set reviewer")
 	if client := m.runtimeClient(); client != nil {
 		changed, mode, err := client.SetReviewerEnabled(enabled)
 		m.observeRuntimeRequestResult(err)
@@ -56,6 +62,7 @@ func (m *uiModel) setRuntimeReviewerEnabled(enabled bool) (bool, string, error) 
 }
 
 func (m *uiModel) setRuntimeAutoCompactionEnabled(enabled bool) (bool, bool, error) {
+	m.checkTUIBlockingOperation("runtime control mutation", "set auto compaction")
 	if client := m.runtimeClient(); client != nil {
 		changed, nextEnabled, err := client.SetAutoCompactionEnabled(enabled)
 		m.observeRuntimeRequestResult(err)
@@ -65,6 +72,7 @@ func (m *uiModel) setRuntimeAutoCompactionEnabled(enabled bool) (bool, bool, err
 }
 
 func (m *uiModel) showRuntimeGoal() (*clientui.RuntimeGoal, error) {
+	m.checkTUIBlockingOperation("runtime control read", "show goal")
 	if client := m.runtimeClient(); client != nil {
 		goal, err := client.ShowGoal()
 		m.observeRuntimeRequestResult(err)
@@ -74,6 +82,7 @@ func (m *uiModel) showRuntimeGoal() (*clientui.RuntimeGoal, error) {
 }
 
 func (m *uiModel) setRuntimeGoal(objective string) (*clientui.RuntimeGoal, error) {
+	m.checkTUIBlockingOperation("runtime control mutation", "set goal")
 	if client := m.runtimeClient(); client != nil {
 		goal, err := client.SetGoal(objective)
 		m.observeRuntimeRequestResult(err)
@@ -83,6 +92,7 @@ func (m *uiModel) setRuntimeGoal(objective string) (*clientui.RuntimeGoal, error
 }
 
 func (m *uiModel) pauseRuntimeGoal() (*clientui.RuntimeGoal, error) {
+	m.checkTUIBlockingOperation("runtime control mutation", "pause goal")
 	if client := m.runtimeClient(); client != nil {
 		goal, err := client.PauseGoal()
 		m.observeRuntimeRequestResult(err)
@@ -92,6 +102,7 @@ func (m *uiModel) pauseRuntimeGoal() (*clientui.RuntimeGoal, error) {
 }
 
 func (m *uiModel) resumeRuntimeGoal() (*clientui.RuntimeGoal, error) {
+	m.checkTUIBlockingOperation("runtime control mutation", "resume goal")
 	if client := m.runtimeClient(); client != nil {
 		goal, err := client.ResumeGoal()
 		m.observeRuntimeRequestResult(err)
@@ -101,6 +112,7 @@ func (m *uiModel) resumeRuntimeGoal() (*clientui.RuntimeGoal, error) {
 }
 
 func (m *uiModel) clearRuntimeGoal() (*clientui.RuntimeGoal, error) {
+	m.checkTUIBlockingOperation("runtime control mutation", "clear goal")
 	if client := m.runtimeClient(); client != nil {
 		goal, err := client.ClearGoal()
 		m.observeRuntimeRequestResult(err)
@@ -115,14 +127,7 @@ func (m *uiModel) appendRuntimeLocalEntry(role, text string) error {
 
 func (m *uiModel) appendRuntimeLocalEntryWithNoticeID(role, text, noticeID string) error {
 	if client := m.runtimeClient(); client != nil {
-		if withNoticeID, ok := client.(interface {
-			AppendLocalEntryWithNoticeID(role, text, noticeID string) error
-		}); ok {
-			err := withNoticeID.AppendLocalEntryWithNoticeID(role, text, noticeID)
-			m.observeRuntimeRequestResult(err)
-			return err
-		}
-		err := client.AppendLocalEntry(role, text)
+		err := client.AppendLocalEntryWithNoticeID(role, text, noticeID)
 		m.observeRuntimeRequestResult(err)
 		return err
 	}
@@ -148,6 +153,7 @@ func (m *uiModel) submitRuntimeUserShellCommand(ctx context.Context, command str
 }
 
 func (m *uiModel) compactRuntimeContext(ctx context.Context, args string) error {
+	m.checkTUIBlockingOperation("runtime control mutation", "compact")
 	if client := m.runtimeClient(); client != nil {
 		err := client.CompactContext(ctx, args)
 		m.observeRuntimeRequestResult(err)
@@ -157,6 +163,7 @@ func (m *uiModel) compactRuntimeContext(ctx context.Context, args string) error 
 }
 
 func (m *uiModel) hasQueuedRuntimeUserWork() (bool, error) {
+	m.checkTUIBlockingOperation("runtime queue read", "has queued user work")
 	if client := m.runtimeClient(); client != nil {
 		hasWork, err := client.HasQueuedUserWork()
 		m.observeRuntimeRequestResult(err)
@@ -166,6 +173,7 @@ func (m *uiModel) hasQueuedRuntimeUserWork() (bool, error) {
 }
 
 func (m *uiModel) submitQueuedRuntimeUserMessages(ctx context.Context) (string, error) {
+	m.checkTUIBlockingOperation("runtime queue mutation", "submit queued user messages")
 	if client := m.runtimeClient(); client != nil {
 		message, err := client.SubmitQueuedUserMessages(ctx)
 		m.observeRuntimeRequestResult(err)
@@ -175,6 +183,7 @@ func (m *uiModel) submitQueuedRuntimeUserMessages(ctx context.Context) (string, 
 }
 
 func (m *uiModel) interruptRuntime() error {
+	m.checkTUIBlockingOperation("runtime control mutation", "interrupt")
 	if client := m.runtimeClient(); client != nil {
 		err := client.Interrupt()
 		m.observeRuntimeRequestResult(err)
@@ -184,6 +193,7 @@ func (m *uiModel) interruptRuntime() error {
 }
 
 func (m *uiModel) queueRuntimeUserMessage(text string) (clientui.QueuedUserMessage, error) {
+	m.checkTUIBlockingOperation("runtime queue mutation", "queue user message")
 	if client := m.runtimeClient(); client != nil {
 		return client.QueueUserMessage(text)
 	}
@@ -191,6 +201,7 @@ func (m *uiModel) queueRuntimeUserMessage(text string) (clientui.QueuedUserMessa
 }
 
 func (m *uiModel) discardQueuedRuntimeUserMessage(queueItemID string) bool {
+	m.checkTUIBlockingOperation("runtime queue mutation", "discard queued user message")
 	if client := m.runtimeClient(); client != nil {
 		return client.DiscardQueuedUserMessage(queueItemID)
 	}
@@ -198,10 +209,184 @@ func (m *uiModel) discardQueuedRuntimeUserMessage(queueItemID string) bool {
 }
 
 func (m *uiModel) recordRuntimePromptHistory(text string) error {
+	m.checkTUIBlockingOperation("runtime control mutation", "record prompt history")
 	if client := m.runtimeClient(); client != nil {
 		err := client.RecordPromptHistory(text)
 		m.observeRuntimeRequestResult(err)
 		return err
 	}
 	return nil
+}
+
+type runtimeControlPendingState struct {
+	sessionID       string
+	inFlight        bool
+	inFlightEnabled bool
+	desiredEnabled  bool
+	compactionMode  string
+}
+
+func (m *uiModel) nextRuntimeControlToken(operation runtimeControlOperation) uint64 {
+	m.runtimeControlToken++
+	if m.runtimeControlToken == 0 {
+		m.runtimeControlToken++
+	}
+	if m.runtimeControlTokens == nil {
+		m.runtimeControlTokens = make(map[runtimeControlOperation]uint64)
+	}
+	m.runtimeControlTokens[operation] = m.runtimeControlToken
+	return m.runtimeControlToken
+}
+
+func (m *uiModel) runtimeControlTokenFor(operation runtimeControlOperation) uint64 {
+	if m == nil || m.runtimeControlTokens == nil {
+		return 0
+	}
+	return m.runtimeControlTokens[operation]
+}
+
+func (m *uiModel) beginRuntimeControlMutation(operation runtimeControlOperation, sessionID string, enabled bool, compactionMode string) (uint64, bool) {
+	if m == nil {
+		return 0, false
+	}
+	if !runtimeControlOperationUsesEnabledTarget(operation) {
+		return m.nextRuntimeControlToken(operation), true
+	}
+	if m.runtimeControlPending == nil {
+		m.runtimeControlPending = make(map[runtimeControlOperation]runtimeControlPendingState)
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if pending, ok := m.runtimeControlPending[operation]; ok && pending.inFlight && pending.sessionID == sessionID {
+		pending.desiredEnabled = enabled
+		pending.compactionMode = strings.TrimSpace(compactionMode)
+		m.runtimeControlPending[operation] = pending
+		return 0, false
+	}
+	token := m.nextRuntimeControlToken(operation)
+	m.runtimeControlPending[operation] = runtimeControlPendingState{
+		sessionID:       sessionID,
+		inFlight:        true,
+		inFlightEnabled: enabled,
+		desiredEnabled:  enabled,
+		compactionMode:  strings.TrimSpace(compactionMode),
+	}
+	return token, true
+}
+
+func (m *uiModel) clearRuntimeControlPending(operation runtimeControlOperation) {
+	if m == nil || m.runtimeControlPending == nil {
+		return
+	}
+	delete(m.runtimeControlPending, operation)
+}
+
+func (m *uiModel) runtimeControlPendingEnabled(operation runtimeControlOperation, sessionID string, fallback bool) bool {
+	if m == nil || m.runtimeControlPending == nil {
+		return fallback
+	}
+	pending, ok := m.runtimeControlPending[operation]
+	if !ok {
+		return fallback
+	}
+	if pending.sessionID != strings.TrimSpace(sessionID) {
+		return fallback
+	}
+	return pending.desiredEnabled
+}
+
+func runtimeControlOperationUsesEnabledTarget(operation runtimeControlOperation) bool {
+	switch operation {
+	case runtimeControlSetFastMode, runtimeControlSetReviewer, runtimeControlSetAutoCompaction:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *uiModel) runtimeControlCommand(operation runtimeControlOperation, text string, enabled bool, compactionMode string) tea.Cmd {
+	if m == nil {
+		return nil
+	}
+	client := m.runtimeClient()
+	if client == nil {
+		return nil
+	}
+	sessionID := strings.TrimSpace(m.sessionID)
+	token, shouldStart := m.beginRuntimeControlMutation(operation, sessionID, enabled, compactionMode)
+	if !shouldStart {
+		return nil
+	}
+	text = strings.TrimSpace(text)
+	return func() tea.Msg {
+		msg := runtimeControlDoneMsg{token: token, sessionID: sessionID, operation: operation, text: text, enabled: enabled, compactionMode: compactionMode}
+		switch operation {
+		case runtimeControlSetSessionName:
+			msg.err = client.SetSessionName(text)
+		case runtimeControlSetThinkingLevel:
+			msg.err = client.SetThinkingLevel(text)
+		case runtimeControlSetFastMode:
+			msg.changed, msg.err = client.SetFastModeEnabled(enabled)
+		case runtimeControlSetReviewer:
+			msg.changed, msg.mode, msg.err = client.SetReviewerEnabled(enabled)
+		case runtimeControlSetAutoCompaction:
+			msg.changed, msg.enabled, msg.err = client.SetAutoCompactionEnabled(enabled)
+		case runtimeControlInterrupt:
+			msg.err = client.Interrupt()
+		}
+		return msg
+	}
+}
+
+func (m *uiModel) applyRuntimeControlDone(msg runtimeControlDoneMsg) tea.Cmd {
+	if m == nil || msg.token != m.runtimeControlTokenFor(msg.operation) {
+		return nil
+	}
+	if msg.sessionID != "" && strings.TrimSpace(m.sessionID) != "" && msg.sessionID != strings.TrimSpace(m.sessionID) {
+		m.clearRuntimeControlPending(msg.operation)
+		return nil
+	}
+	m.observeRuntimeRequestResult(msg.err)
+	if msg.err != nil {
+		m.clearRuntimeControlPending(msg.operation)
+		errText := formatSubmissionError(msg.err)
+		return m.inputController().appendErrorFeedbackWithStatus(errText, m.setTransientStatusWithKind(errText, uiStatusNoticeError))
+	}
+	if runtimeControlOperationUsesEnabledTarget(msg.operation) {
+		pending := m.runtimeControlPending[msg.operation]
+		if pending.inFlight && pending.desiredEnabled != pending.inFlightEnabled {
+			pending.inFlight = false
+			m.runtimeControlPending[msg.operation] = pending
+			return m.runtimeControlCommand(msg.operation, "", pending.desiredEnabled, pending.compactionMode)
+		}
+		m.clearRuntimeControlPending(msg.operation)
+	}
+	switch msg.operation {
+	case runtimeControlSetSessionName:
+		m.sessionName = strings.TrimSpace(msg.text)
+		return tea.SetWindowTitle(m.windowTitle())
+	case runtimeControlSetThinkingLevel:
+		m.thinkingLevel = strings.TrimSpace(msg.text)
+		return m.inputController().appendSystemFeedback("Thinking level set to " + m.thinkingLevel)
+	case runtimeControlSetFastMode:
+		m.fastModeEnabled = msg.enabled
+		status := fastModeToggleStatusMessage(m.fastModeEnabled, msg.changed)
+		return m.inputController().appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeSuccess)
+	case runtimeControlSetReviewer:
+		nextMode := strings.TrimSpace(msg.mode)
+		if nextMode == "" {
+			nextMode = "off"
+		}
+		m.reviewerMode = nextMode
+		m.reviewerEnabled = nextMode != "off"
+		status := reviewerToggleStatusMessage(m.reviewerEnabled, nextMode, msg.changed)
+		return m.inputController().appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral)
+	case runtimeControlSetAutoCompaction:
+		m.autoCompactionEnabled = msg.enabled
+		status := autoCompactionToggleStatusMessage(msg.enabled, msg.changed, msg.compactionMode)
+		return m.inputController().appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral)
+	case runtimeControlInterrupt:
+		return nil
+	default:
+		return nil
+	}
 }

--- a/cli/app/ui_runtime_control.go
+++ b/cli/app/ui_runtime_control.go
@@ -221,7 +221,9 @@ func (m *uiModel) recordRuntimePromptHistory(text string) error {
 type runtimeControlPendingState struct {
 	sessionID       string
 	inFlight        bool
+	inFlightText    string
 	inFlightEnabled bool
+	desiredText     string
 	desiredEnabled  bool
 	compactionMode  string
 }
@@ -245,20 +247,25 @@ func (m *uiModel) runtimeControlTokenFor(operation runtimeControlOperation) uint
 	return m.runtimeControlTokens[operation]
 }
 
-func (m *uiModel) beginRuntimeControlMutation(operation runtimeControlOperation, sessionID string, enabled bool, compactionMode string) (uint64, bool) {
+func (m *uiModel) beginRuntimeControlMutation(operation runtimeControlOperation, sessionID, text string, enabled bool, compactionMode string) (uint64, bool) {
 	if m == nil {
 		return 0, false
 	}
-	if !runtimeControlOperationUsesEnabledTarget(operation) {
+	sessionID = strings.TrimSpace(sessionID)
+	text = strings.TrimSpace(text)
+	if !runtimeControlOperationUsesEnabledTarget(operation) && !runtimeControlOperationUsesTextTarget(operation) {
 		return m.nextRuntimeControlToken(operation), true
 	}
 	if m.runtimeControlPending == nil {
 		m.runtimeControlPending = make(map[runtimeControlOperation]runtimeControlPendingState)
 	}
-	sessionID = strings.TrimSpace(sessionID)
 	if pending, ok := m.runtimeControlPending[operation]; ok && pending.inFlight && pending.sessionID == sessionID {
-		pending.desiredEnabled = enabled
-		pending.compactionMode = strings.TrimSpace(compactionMode)
+		if runtimeControlOperationUsesTextTarget(operation) {
+			pending.desiredText = text
+		} else {
+			pending.desiredEnabled = enabled
+			pending.compactionMode = strings.TrimSpace(compactionMode)
+		}
 		m.runtimeControlPending[operation] = pending
 		return 0, false
 	}
@@ -266,7 +273,9 @@ func (m *uiModel) beginRuntimeControlMutation(operation runtimeControlOperation,
 	m.runtimeControlPending[operation] = runtimeControlPendingState{
 		sessionID:       sessionID,
 		inFlight:        true,
+		inFlightText:    text,
 		inFlightEnabled: enabled,
+		desiredText:     text,
 		desiredEnabled:  enabled,
 		compactionMode:  strings.TrimSpace(compactionMode),
 	}
@@ -303,6 +312,15 @@ func runtimeControlOperationUsesEnabledTarget(operation runtimeControlOperation)
 	}
 }
 
+func runtimeControlOperationUsesTextTarget(operation runtimeControlOperation) bool {
+	switch operation {
+	case runtimeControlSetSessionName, runtimeControlSetThinkingLevel:
+		return true
+	default:
+		return false
+	}
+}
+
 func (m *uiModel) runtimeControlCommand(operation runtimeControlOperation, text string, enabled bool, compactionMode string) tea.Cmd {
 	if m == nil {
 		return nil
@@ -312,11 +330,11 @@ func (m *uiModel) runtimeControlCommand(operation runtimeControlOperation, text 
 		return nil
 	}
 	sessionID := strings.TrimSpace(m.sessionID)
-	token, shouldStart := m.beginRuntimeControlMutation(operation, sessionID, enabled, compactionMode)
+	text = strings.TrimSpace(text)
+	token, shouldStart := m.beginRuntimeControlMutation(operation, sessionID, text, enabled, compactionMode)
 	if !shouldStart {
 		return nil
 	}
-	text = strings.TrimSpace(text)
 	return func() tea.Msg {
 		msg := runtimeControlDoneMsg{token: token, sessionID: sessionID, operation: operation, text: text, enabled: enabled, compactionMode: compactionMode}
 		switch operation {
@@ -357,6 +375,15 @@ func (m *uiModel) applyRuntimeControlDone(msg runtimeControlDoneMsg) tea.Cmd {
 			pending.inFlight = false
 			m.runtimeControlPending[msg.operation] = pending
 			return m.runtimeControlCommand(msg.operation, "", pending.desiredEnabled, pending.compactionMode)
+		}
+		m.clearRuntimeControlPending(msg.operation)
+	}
+	if runtimeControlOperationUsesTextTarget(msg.operation) {
+		pending := m.runtimeControlPending[msg.operation]
+		if pending.inFlight && pending.desiredText != pending.inFlightText {
+			pending.inFlight = false
+			m.runtimeControlPending[msg.operation] = pending
+			return m.runtimeControlCommand(msg.operation, pending.desiredText, false, "")
 		}
 		m.clearRuntimeControlPending(msg.operation)
 	}

--- a/cli/app/ui_runtime_control.go
+++ b/cli/app/ui_runtime_control.go
@@ -369,35 +369,38 @@ func (m *uiModel) applyRuntimeControlDone(msg runtimeControlDoneMsg) tea.Cmd {
 		errText := formatSubmissionError(msg.err)
 		return m.inputController().appendErrorFeedbackWithStatus(errText, m.setTransientStatusWithKind(errText, uiStatusNoticeError))
 	}
+	var followUpCmd tea.Cmd
 	if runtimeControlOperationUsesEnabledTarget(msg.operation) {
 		pending := m.runtimeControlPending[msg.operation]
 		if pending.inFlight && pending.desiredEnabled != pending.inFlightEnabled {
 			pending.inFlight = false
 			m.runtimeControlPending[msg.operation] = pending
-			return m.runtimeControlCommand(msg.operation, "", pending.desiredEnabled, pending.compactionMode)
+			followUpCmd = m.runtimeControlCommand(msg.operation, "", pending.desiredEnabled, pending.compactionMode)
+		} else {
+			m.clearRuntimeControlPending(msg.operation)
 		}
-		m.clearRuntimeControlPending(msg.operation)
 	}
 	if runtimeControlOperationUsesTextTarget(msg.operation) {
 		pending := m.runtimeControlPending[msg.operation]
 		if pending.inFlight && pending.desiredText != pending.inFlightText {
 			pending.inFlight = false
 			m.runtimeControlPending[msg.operation] = pending
-			return m.runtimeControlCommand(msg.operation, pending.desiredText, false, "")
+			followUpCmd = m.runtimeControlCommand(msg.operation, pending.desiredText, false, "")
+		} else {
+			m.clearRuntimeControlPending(msg.operation)
 		}
-		m.clearRuntimeControlPending(msg.operation)
 	}
 	switch msg.operation {
 	case runtimeControlSetSessionName:
 		m.sessionName = strings.TrimSpace(msg.text)
-		return tea.SetWindowTitle(m.windowTitle())
+		return sequenceCmds(tea.SetWindowTitle(m.windowTitle()), followUpCmd)
 	case runtimeControlSetThinkingLevel:
 		m.thinkingLevel = strings.TrimSpace(msg.text)
-		return m.inputController().appendSystemFeedback("Thinking level set to " + m.thinkingLevel)
+		return sequenceCmds(m.inputController().appendSystemFeedback("Thinking level set to "+m.thinkingLevel), followUpCmd)
 	case runtimeControlSetFastMode:
 		m.fastModeEnabled = msg.enabled
 		status := fastModeToggleStatusMessage(m.fastModeEnabled, msg.changed)
-		return m.inputController().appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeSuccess)
+		return sequenceCmds(m.inputController().appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeSuccess), followUpCmd)
 	case runtimeControlSetReviewer:
 		nextMode := strings.TrimSpace(msg.mode)
 		if nextMode == "" {
@@ -406,14 +409,14 @@ func (m *uiModel) applyRuntimeControlDone(msg runtimeControlDoneMsg) tea.Cmd {
 		m.reviewerMode = nextMode
 		m.reviewerEnabled = nextMode != "off"
 		status := reviewerToggleStatusMessage(m.reviewerEnabled, nextMode, msg.changed)
-		return m.inputController().appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral)
+		return sequenceCmds(m.inputController().appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral), followUpCmd)
 	case runtimeControlSetAutoCompaction:
 		m.autoCompactionEnabled = msg.enabled
 		status := autoCompactionToggleStatusMessage(msg.enabled, msg.changed, msg.compactionMode)
-		return m.inputController().appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral)
+		return sequenceCmds(m.inputController().appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral), followUpCmd)
 	case runtimeControlInterrupt:
-		return nil
+		return followUpCmd
 	default:
-		return nil
+		return followUpCmd
 	}
 }

--- a/cli/app/ui_runtime_control_test.go
+++ b/cli/app/ui_runtime_control_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"strings"
 	"testing"
 
 	"builder/cli/tui"
@@ -23,6 +24,7 @@ type runtimeControlFakeClient struct {
 	setSessionNameArg      string
 	setThinkingLevelArg    string
 	setFastModeArg         bool
+	setFastModeCalls       int
 	setReviewerArg         bool
 	setAutoCompactArg      bool
 	goal                   *clientui.RuntimeGoal
@@ -40,13 +42,22 @@ type runtimeControlFakeClient struct {
 	submitShellCommand     string
 	compactArgs            string
 	hasQueuedUserWork      bool
+	hasQueuedUserWorkCalls int
 	submitQueuedResult     string
+	submitQueuedCalls      int
 	interruptCalls         int
 	queuedText             string
+	queueUserMessageCalls  int
+	queueUserMessageErr    error
+	queueUserMessageID     string
 	discardQueuedID        string
+	discardQueuedCalls     int
+	discardQueuedResult    bool
 	discardQueuedCount     int
 	recordedPromptHistory  string
 	refreshMainViewCalls   int
+	refreshTranscriptCalls int
+	loadTranscriptCalls    int
 	err                    error
 	appendErr              error
 	shouldCompactErr       error
@@ -89,10 +100,12 @@ func (f *runtimeControlFakeClient) RefreshTranscript() (clientui.TranscriptPage,
 	return f.Transcript(), f.err
 }
 func (f *runtimeControlFakeClient) RefreshTranscriptPage(req clientui.TranscriptPageRequest) (clientui.TranscriptPage, error) {
+	f.refreshTranscriptCalls++
 	return f.LoadTranscriptPage(req)
 }
 func (f *runtimeControlFakeClient) LoadTranscriptPage(req clientui.TranscriptPageRequest) (clientui.TranscriptPage, error) {
 	_ = req
+	f.loadTranscriptCalls++
 	return f.Transcript(), f.err
 }
 func (f *runtimeControlFakeClient) Status() clientui.RuntimeStatus { return f.status }
@@ -109,6 +122,7 @@ func (f *runtimeControlFakeClient) SetThinkingLevel(level string) error {
 }
 func (f *runtimeControlFakeClient) SetFastModeEnabled(enabled bool) (bool, error) {
 	f.setFastModeArg = enabled
+	f.setFastModeCalls++
 	f.status.FastModeEnabled = enabled
 	return true, f.err
 }
@@ -150,6 +164,9 @@ func (f *runtimeControlFakeClient) ClearGoal() (*clientui.RuntimeGoal, error) {
 	return nil, f.err
 }
 func (f *runtimeControlFakeClient) AppendLocalEntry(role, text string) error {
+	return f.AppendLocalEntryWithNoticeID(role, text, "")
+}
+func (f *runtimeControlFakeClient) AppendLocalEntryWithNoticeID(role, text, noticeID string) error {
 	f.appendedRole = role
 	f.appendedText = text
 	if f.appendErr != nil {
@@ -194,12 +211,14 @@ func (f *runtimeControlFakeClient) CompactContextForPreSubmit(context.Context) e
 	return f.err
 }
 func (f *runtimeControlFakeClient) HasQueuedUserWork() (bool, error) {
+	f.hasQueuedUserWorkCalls++
 	if f.hasQueuedUserWorkErr != nil {
 		return f.hasQueuedUserWork, f.hasQueuedUserWorkErr
 	}
 	return f.hasQueuedUserWork, f.err
 }
 func (f *runtimeControlFakeClient) SubmitQueuedUserMessages(context.Context) (string, error) {
+	f.submitQueuedCalls++
 	if f.submitQueuedErr != nil {
 		return f.submitQueuedResult, f.submitQueuedErr
 	}
@@ -213,11 +232,23 @@ func (f *runtimeControlFakeClient) Interrupt() error {
 	return f.err
 }
 func (f *runtimeControlFakeClient) QueueUserMessage(text string) (clientui.QueuedUserMessage, error) {
+	f.queueUserMessageCalls++
 	f.queuedText = text
-	return clientui.QueuedUserMessage{ID: "queue-1", Text: text}, nil
+	if f.queueUserMessageErr != nil {
+		return clientui.QueuedUserMessage{}, f.queueUserMessageErr
+	}
+	id := strings.TrimSpace(f.queueUserMessageID)
+	if id == "" {
+		id = "queue-1"
+	}
+	return clientui.QueuedUserMessage{ID: id, Text: text}, nil
 }
 func (f *runtimeControlFakeClient) DiscardQueuedUserMessage(queueItemID string) bool {
+	f.discardQueuedCalls++
 	f.discardQueuedID = queueItemID
+	if f.discardQueuedResult {
+		return true
+	}
 	return f.discardQueuedCount > 0
 }
 func (f *runtimeControlFakeClient) RecordPromptHistory(text string) error {
@@ -325,6 +356,131 @@ func TestRuntimeControlHelpersDelegateToRuntimeClient(t *testing.T) {
 	}
 }
 
+func TestRuntimeControlCompletionsAreScopedPerOperation(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+
+	sessionCmd := m.runtimeControlCommand(runtimeControlSetSessionName, "incident triage", false, "")
+	thinkingCmd := m.runtimeControlCommand(runtimeControlSetThinkingLevel, "high", false, "")
+	sessionMsgs := collectCmdMessages(t, sessionCmd)
+	thinkingMsgs := collectCmdMessages(t, thinkingCmd)
+
+	var sessionDone runtimeControlDoneMsg
+	for _, msg := range sessionMsgs {
+		if typed, ok := msg.(runtimeControlDoneMsg); ok {
+			sessionDone = typed
+		}
+	}
+	var thinkingDone runtimeControlDoneMsg
+	for _, msg := range thinkingMsgs {
+		if typed, ok := msg.(runtimeControlDoneMsg); ok {
+			thinkingDone = typed
+		}
+	}
+
+	next, _ := m.Update(thinkingDone)
+	updated := next.(*uiModel)
+	next, _ = updated.Update(sessionDone)
+	updated = next.(*uiModel)
+	if updated.thinkingLevel != "high" || updated.sessionName != "incident triage" {
+		t.Fatalf("expected independent completions to apply, session=%q thinking=%q", updated.sessionName, updated.thinkingLevel)
+	}
+}
+
+func TestRuntimeControlRapidFastToggleUsesPendingTargetAndIgnoresOlderCompletion(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.fastModeAvailable = true
+	m.fastModeEnabled = false
+
+	_, firstCmd := m.inputController().handleFastModeCommand("")
+	if firstCmd == nil {
+		t.Fatal("expected first fast toggle command")
+	}
+	_, secondCmd := m.inputController().handleFastModeCommand("")
+	if secondCmd != nil {
+		t.Fatal("did not expect second fast toggle command while first is in flight")
+	}
+
+	firstMsgs := collectCmdMessages(t, firstCmd)
+	if client.setFastModeCalls != 1 || client.setFastModeArg != true {
+		t.Fatalf("first fast target calls=%d arg=%t, want one true", client.setFastModeCalls, client.setFastModeArg)
+	}
+
+	var firstDone runtimeControlDoneMsg
+	for _, msg := range firstMsgs {
+		if typed, ok := msg.(runtimeControlDoneMsg); ok {
+			firstDone = typed
+		}
+	}
+	next, followUpCmd := m.Update(firstDone)
+	updated := next.(*uiModel)
+	if updated.fastModeEnabled {
+		t.Fatal("expected older fast toggle completion to be ignored")
+	}
+	if followUpCmd == nil {
+		t.Fatal("expected follow-up command for coalesced fast target")
+	}
+	followUpMsgs := collectCmdMessages(t, followUpCmd)
+	if client.setFastModeCalls != 2 || client.setFastModeArg != false {
+		t.Fatalf("follow-up fast target calls=%d arg=%t, want second false", client.setFastModeCalls, client.setFastModeArg)
+	}
+	var followUpDone runtimeControlDoneMsg
+	for _, msg := range followUpMsgs {
+		if typed, ok := msg.(runtimeControlDoneMsg); ok {
+			followUpDone = typed
+		}
+	}
+	next, _ = updated.Update(followUpDone)
+	updated = next.(*uiModel)
+	if updated.fastModeEnabled {
+		t.Fatal("expected rapid double-toggle to end disabled")
+	}
+}
+
+func TestRuntimeControlStaleSessionCompletionClearsPendingToggle(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.sessionID = "session-old"
+	m.fastModeAvailable = true
+
+	cmd := m.runtimeControlCommand(runtimeControlSetFastMode, "", true, "")
+	msgs := collectCmdMessages(t, cmd)
+	var done runtimeControlDoneMsg
+	for _, msg := range msgs {
+		if typed, ok := msg.(runtimeControlDoneMsg); ok {
+			done = typed
+		}
+	}
+
+	m.sessionID = "session-new"
+	_, blockedCmd := m.inputController().handleFastModeCommand("on")
+	if blockedCmd == nil {
+		t.Fatal("expected new-session fast toggle to start even while old-session command is in flight")
+	}
+	_ = collectCmdMessages(t, blockedCmd)
+	if client.setFastModeArg != true {
+		t.Fatalf("new-session bare fast toggle should target true from cached state, got %t", client.setFastModeArg)
+	}
+
+	next, _ := m.Update(done)
+	updated := next.(*uiModel)
+	pending, exists := updated.runtimeControlPending[runtimeControlSetFastMode]
+	if !exists || pending.sessionID != "session-new" {
+		t.Fatalf("expected stale-session completion to preserve new-session pending toggle, got %+v", updated.runtimeControlPending)
+	}
+	_, nextCmd := updated.inputController().handleFastModeCommand("off")
+	if nextCmd != nil {
+		t.Fatal("expected new-session follow-up target to coalesce without a concurrent command")
+	}
+	if pending := updated.runtimeControlPending[runtimeControlSetFastMode]; pending.desiredEnabled {
+		t.Fatalf("expected coalesced new-session desired target to be false, got %+v", pending)
+	}
+}
+
 func TestRuntimeControlHelpersFallbackWithoutRuntimeClient(t *testing.T) {
 	m := newProjectedStaticUIModel()
 
@@ -398,7 +554,7 @@ func TestSubmitErrorWithRuntimeClientAppendsActivePrimaryRunEntry(t *testing.T) 
 	m.engine = client
 	m.setBusy(true)
 
-	next, _ := m.Update(submitDoneMsg{err: primaryrun.ErrActivePrimaryRun})
+	next, cmd := m.Update(submitDoneMsg{err: primaryrun.ErrActivePrimaryRun})
 	updated := next.(*uiModel)
 	if updated.isBusy() {
 		t.Fatal("did not expect busy after active primary run error")
@@ -406,6 +562,17 @@ func TestSubmitErrorWithRuntimeClientAppendsActivePrimaryRunEntry(t *testing.T) 
 	if updated.activity != uiActivityError {
 		t.Fatalf("expected error activity, got %v", updated.activity)
 	}
+	if len(updated.transcriptEntries) != 1 {
+		t.Fatalf("expected one immediate local transcript entry, got %+v", updated.transcriptEntries)
+	}
+	entry := updated.transcriptEntries[0]
+	if entry.Role != tui.TranscriptRoleDeveloperErrorFeedback || entry.Text != primaryrun.ErrActivePrimaryRun.Error() {
+		t.Fatalf("unexpected immediate local transcript entry: %+v", entry)
+	}
+	if client.appendedRole != "" || client.appendedText != "" {
+		t.Fatalf("did not expect runtime append during Update, got role=%q text=%q", client.appendedRole, client.appendedText)
+	}
+	_ = collectCmdMessages(t, cmd)
 	if client.appendedRole != string(transcript.EntryRoleDeveloperErrorFeedback) || client.appendedText != primaryrun.ErrActivePrimaryRun.Error() {
 		t.Fatalf("unexpected runtime local entry: role=%q text=%q", client.appendedRole, client.appendedText)
 	}
@@ -417,12 +584,16 @@ func TestActiveSubmitErrorFallsBackToVisibleTranscriptWhenRuntimeAppendFails(t *
 	m.engine = client
 	m.setBusy(true)
 
-	next, _ := m.Update(submitDoneMsg{err: primaryrun.ErrActivePrimaryRun})
+	next, cmd := m.Update(submitDoneMsg{err: primaryrun.ErrActivePrimaryRun})
 	updated := next.(*uiModel)
 
 	if updated.activity != uiActivityError {
 		t.Fatalf("expected error activity, got %v", updated.activity)
 	}
+	if client.appendedRole != "" || client.appendedText != "" {
+		t.Fatalf("did not expect runtime append during Update, got role=%q text=%q", client.appendedRole, client.appendedText)
+	}
+	_ = collectCmdMessages(t, cmd)
 	if client.appendedRole != string(transcript.EntryRoleDeveloperErrorFeedback) || client.appendedText != primaryrun.ErrActivePrimaryRun.Error() {
 		t.Fatalf("unexpected runtime local entry attempt: role=%q text=%q", client.appendedRole, client.appendedText)
 	}

--- a/cli/app/ui_runtime_control_test.go
+++ b/cli/app/ui_runtime_control_test.go
@@ -393,6 +393,56 @@ func TestRuntimeControlCompletionsAreScopedPerOperation(t *testing.T) {
 	}
 }
 
+func TestRuntimeControlTextMutationsCoalesceUntilInFlightCompletion(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+
+	firstCmd := m.runtimeControlCommand(runtimeControlSetThinkingLevel, "high", false, "")
+	if firstCmd == nil {
+		t.Fatal("expected first thinking-level command")
+	}
+	secondCmd := m.runtimeControlCommand(runtimeControlSetThinkingLevel, "low", false, "")
+	if secondCmd != nil {
+		t.Fatal("did not expect second thinking-level command while first is in flight")
+	}
+	firstMsgs := collectCmdMessages(t, firstCmd)
+	if client.setThinkingLevelArg != "high" {
+		t.Fatalf("first thinking-level RPC = %q, want high", client.setThinkingLevelArg)
+	}
+
+	var firstDone runtimeControlDoneMsg
+	for _, msg := range firstMsgs {
+		if typed, ok := msg.(runtimeControlDoneMsg); ok {
+			firstDone = typed
+		}
+	}
+	next, followUpCmd := m.Update(firstDone)
+	updated := next.(*uiModel)
+	if updated.thinkingLevel == "high" {
+		t.Fatal("expected coalesced older thinking-level completion not to update UI")
+	}
+	if followUpCmd == nil {
+		t.Fatal("expected follow-up command for coalesced thinking-level target")
+	}
+	followUpMsgs := collectCmdMessages(t, followUpCmd)
+	if client.setThinkingLevelArg != "low" {
+		t.Fatalf("follow-up thinking-level RPC = %q, want low", client.setThinkingLevelArg)
+	}
+
+	var followUpDone runtimeControlDoneMsg
+	for _, msg := range followUpMsgs {
+		if typed, ok := msg.(runtimeControlDoneMsg); ok {
+			followUpDone = typed
+		}
+	}
+	next, _ = updated.Update(followUpDone)
+	updated = next.(*uiModel)
+	if updated.thinkingLevel != "low" {
+		t.Fatalf("thinking level = %q, want low", updated.thinkingLevel)
+	}
+}
+
 func TestRuntimeControlRapidFastToggleUsesPendingTargetAndIgnoresOlderCompletion(t *testing.T) {
 	client := &runtimeControlFakeClient{}
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())

--- a/cli/app/ui_runtime_control_test.go
+++ b/cli/app/ui_runtime_control_test.go
@@ -20,6 +20,8 @@ type runtimeControlFakeClient struct {
 	status                 clientui.RuntimeStatus
 	sessionView            clientui.RuntimeSessionView
 	mainView               clientui.RuntimeMainView
+	cachedMainView         clientui.RuntimeMainView
+	hasCachedMainView      bool
 	transcript             clientui.TranscriptPage
 	setSessionNameArg      string
 	setThinkingLevelArg    string
@@ -83,6 +85,9 @@ func (f *runtimeControlFakeClient) MainView() clientui.RuntimeMainView {
 	return clientui.RuntimeMainView{Status: f.status, Session: f.sessionView}
 }
 func (f *runtimeControlFakeClient) CachedMainView() (clientui.RuntimeMainView, bool) {
+	if f.hasCachedMainView {
+		return f.cachedMainView, true
+	}
 	return f.MainView(), true
 }
 func (f *runtimeControlFakeClient) RefreshMainView() (clientui.RuntimeMainView, error) {

--- a/cli/app/ui_runtime_control_test.go
+++ b/cli/app/ui_runtime_control_test.go
@@ -393,7 +393,7 @@ func TestRuntimeControlCompletionsAreScopedPerOperation(t *testing.T) {
 	}
 }
 
-func TestRuntimeControlTextMutationsCoalesceUntilInFlightCompletion(t *testing.T) {
+func TestRuntimeControlTextMutationsCoalesceAfterApplyingInFlightCompletion(t *testing.T) {
 	client := &runtimeControlFakeClient{}
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
 	m.startupCmds = nil
@@ -419,8 +419,8 @@ func TestRuntimeControlTextMutationsCoalesceUntilInFlightCompletion(t *testing.T
 	}
 	next, followUpCmd := m.Update(firstDone)
 	updated := next.(*uiModel)
-	if updated.thinkingLevel == "high" {
-		t.Fatal("expected coalesced older thinking-level completion not to update UI")
+	if updated.thinkingLevel != "high" {
+		t.Fatalf("expected first thinking-level completion to update UI before follow-up, got %q", updated.thinkingLevel)
 	}
 	if followUpCmd == nil {
 		t.Fatal("expected follow-up command for coalesced thinking-level target")
@@ -443,7 +443,7 @@ func TestRuntimeControlTextMutationsCoalesceUntilInFlightCompletion(t *testing.T
 	}
 }
 
-func TestRuntimeControlRapidFastToggleUsesPendingTargetAndIgnoresOlderCompletion(t *testing.T) {
+func TestRuntimeControlRapidFastToggleUsesPendingTargetAfterApplyingOlderCompletion(t *testing.T) {
 	client := &runtimeControlFakeClient{}
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
 	m.startupCmds = nil
@@ -472,8 +472,8 @@ func TestRuntimeControlRapidFastToggleUsesPendingTargetAndIgnoresOlderCompletion
 	}
 	next, followUpCmd := m.Update(firstDone)
 	updated := next.(*uiModel)
-	if updated.fastModeEnabled {
-		t.Fatal("expected older fast toggle completion to be ignored")
+	if !updated.fastModeEnabled {
+		t.Fatal("expected first fast toggle completion to apply before follow-up")
 	}
 	if followUpCmd == nil {
 		t.Fatal("expected follow-up command for coalesced fast target")

--- a/cli/app/ui_runtime_event_reduction.go
+++ b/cli/app/ui_runtime_event_reduction.go
@@ -67,6 +67,7 @@ func (a uiRuntimeAdapter) applyRuntimeEventReduction(reduction runtimestate.Runt
 	m.conversationFreshness = reduction.Conversation.State.Freshness
 	m.reasoningStatusHeader = reduction.Reasoning.State.StatusHeader
 	m.pendingInjected = reduction.PendingInput.State.PendingInjected
+	m.removeInjectedQueueItemsByIDs(reduction.PendingInput.ConsumedQueueItemIDs)
 	m.lockedInjectText = reduction.PendingInput.State.LockedInjectText
 	m.lockedInjectID = reduction.PendingInput.State.LockedInjectID
 	m.setInputSubmitLocked(reduction.PendingInput.State.Submission.IsLocked())
@@ -79,23 +80,27 @@ func (a uiRuntimeAdapter) applyRuntimeEventReduction(reduction runtimestate.Runt
 		m.activity = uiActivityRunning
 	case runtimestate.RuntimeActivityIdle:
 		m.activity = uiActivityIdle
+		cmd = tea.Batch(cmd, m.releaseDeferredRuntimeSyncs())
 	}
 	switch reduction.BackgroundProcesses.Command {
 	case runtimestate.RuntimeBackgroundProcessRefresh:
-		m.refreshProcessEntriesIfOpen()
+		if m.processList.isOpen() {
+			cmd = tea.Batch(cmd, m.requestProcessListRefresh())
+		}
 	}
 	return cmd
 }
 
-func (a uiRuntimeAdapter) reconcileInterruptFromRunState(evt clientui.Event) {
+func (a uiRuntimeAdapter) reconcileInterruptFromRunState(evt clientui.Event) tea.Cmd {
 	m := a.model
 	if m == nil || evt.Kind != clientui.EventRunStateChanged || evt.RunState == nil || evt.RunState.Lifecycle.IsRunning() {
-		return
+		return nil
 	}
 	if evt.RunState.Status != clientui.RunStatusInterrupted {
 		m.setPendingInterrupt(false)
-		return
+		return nil
 	}
+	var cmd tea.Cmd
 	if m.hasPendingInterrupt() {
 		if m.activeSubmit.restoreOnInterrupt && !m.activeSubmit.flushed {
 			c := uiInputController{model: m}
@@ -103,13 +108,13 @@ func (a uiRuntimeAdapter) reconcileInterruptFromRunState(evt clientui.Event) {
 		}
 		m.activeSubmit = activeSubmitState{}
 		c := uiInputController{model: m}
-		c.releaseLockedInjectedInput(true)
-		c.restorePendingInjectedIntoInput()
+		cmd = tea.Batch(c.releaseLockedInjectedInput(true), c.restorePendingInjectedIntoInput())
 		c.restoreQueuedMessagesIntoInput()
 		m.setPendingInterrupt(false)
 	}
 	m.activity = uiActivityInterrupted
 	m.clearReviewerState()
+	return cmd
 }
 
 func (a uiRuntimeAdapter) effectiveRuntimeTranscriptSync(evt clientui.Event, proposed runtimestate.RuntimeTranscriptSyncCommand) runtimestate.RuntimeTranscriptSyncCommand {

--- a/cli/app/ui_runtime_reducer.go
+++ b/cli/app/ui_runtime_reducer.go
@@ -65,7 +65,11 @@ func (r uiRuntimeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			m.syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
-		cmd := m.startRuntimeTranscriptPageRequest(m.transcriptRequestForCurrentMode(), false, msg.syncCause, msg.recoveryCause)
+		req := msg.req
+		if req == (runtimeTranscriptSyncRequest{}) {
+			req = runtimeTranscriptSyncRequestForPage(m.transcriptRequestForCurrentMode(), false, msg.syncCause, msg.recoveryCause)
+		}
+		cmd := m.startRuntimeTranscriptSyncRequest(req).cmd
 		m.syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	case detailTranscriptLoadMsg:

--- a/cli/app/ui_runtime_session_view.go
+++ b/cli/app/ui_runtime_session_view.go
@@ -3,6 +3,7 @@ package app
 import "builder/shared/clientui"
 
 func (m *uiModel) runtimeSessionView() clientui.RuntimeSessionView {
+	m.checkTUIBlockingOperation("runtime session-view read", "SessionView/MainView")
 	return m.runtimeMainView().Session
 }
 

--- a/cli/app/ui_runtime_status.go
+++ b/cli/app/ui_runtime_status.go
@@ -30,6 +30,7 @@ func (m *uiModel) applyRuntimeMainViewState(view clientui.RuntimeMainView) {
 }
 
 func (m *uiModel) runtimeMainView() clientui.RuntimeMainView {
+	m.checkTUIBlockingOperation("runtime main-view read", "MainView")
 	if client := m.runtimeClient(); client != nil {
 		return client.MainView()
 	}
@@ -40,6 +41,7 @@ func (m *uiModel) runtimeMainView() clientui.RuntimeMainView {
 }
 
 func (m *uiModel) refreshRuntimeMainView() clientui.RuntimeMainView {
+	m.checkTUIBlockingOperation("runtime main-view refresh", "RefreshMainView")
 	if client := m.runtimeClient(); client != nil {
 		view, err := client.RefreshMainView()
 		if err == nil {
@@ -56,6 +58,7 @@ func (m *uiModel) refreshRuntimeMainView() clientui.RuntimeMainView {
 }
 
 func (m *uiModel) runtimeStatus() clientui.RuntimeStatus {
+	m.checkTUIBlockingOperation("runtime status read", "Status/MainView")
 	view := m.runtimeMainView()
 	status := view.Status
 	if m.runtimeContextUsageAppliesTo(view.Session.SessionID) {
@@ -89,6 +92,7 @@ func (m *uiModel) cachedRuntimeStatus() clientui.RuntimeStatus {
 }
 
 func (m *uiModel) refreshRuntimeStatus() clientui.RuntimeStatus {
+	m.checkTUIBlockingOperation("runtime status refresh", "RefreshMainView")
 	view := m.refreshRuntimeMainView()
 	status := view.Status
 	if m.runtimeContextUsageAppliesTo(view.Session.SessionID) {
@@ -140,12 +144,20 @@ func (m *uiModel) currentRuntimeSessionID() string {
 		return sessionID
 	}
 	if client := m.runtimeClient(); client != nil {
-		return strings.TrimSpace(client.MainView().Session.SessionID)
+		if cached, ok := client.(interface {
+			CachedMainView() (clientui.RuntimeMainView, bool)
+		}); ok {
+			view, hasCached := cached.CachedMainView()
+			if hasCached {
+				return strings.TrimSpace(view.Session.SessionID)
+			}
+		}
 	}
 	return ""
 }
 
 func (m *uiModel) runtimeTranscript() clientui.TranscriptPage {
+	m.checkTUIBlockingOperation("runtime transcript read", "Transcript")
 	if client := m.runtimeClient(); client != nil {
 		return client.Transcript()
 	}

--- a/cli/app/ui_runtime_status_test.go
+++ b/cli/app/ui_runtime_status_test.go
@@ -70,6 +70,22 @@ func TestCurrentConversationFreshnessAcceptsCachedFreshness(t *testing.T) {
 	}
 }
 
+func TestCurrentConversationFreshnessDoesNotDowngradeLocalTurnFromCachedFresh(t *testing.T) {
+	client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{
+		ConversationFreshness: clientui.ConversationFreshnessFresh,
+	}}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.conversationFreshness = clientui.ConversationFreshnessEstablished
+	m.localConversationTurn = true
+
+	if got := m.currentConversationFreshness(); got != clientui.ConversationFreshnessEstablished {
+		t.Fatalf("conversation freshness = %v, want established", got)
+	}
+	if m.conversationFreshness != clientui.ConversationFreshnessEstablished {
+		t.Fatalf("cached stale freshness downgraded local turn state: %v", m.conversationFreshness)
+	}
+}
+
 func TestRuntimeStatusLineHidesGoalStatusText(t *testing.T) {
 	for _, goalStatus := range []clientui.RuntimeGoalStatus{clientui.RuntimeGoalStatusActive, clientui.RuntimeGoalStatusPaused, clientui.RuntimeGoalStatusComplete} {
 		client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{

--- a/cli/app/ui_runtime_status_test.go
+++ b/cli/app/ui_runtime_status_test.go
@@ -86,6 +86,37 @@ func TestCurrentConversationFreshnessDoesNotDowngradeLocalTurnFromCachedFresh(t 
 	}
 }
 
+func TestRuntimeBackedLocalEntryFallbackIsTransientUntilEcho(t *testing.T) {
+	m := newProjectedTestUIModel(&runtimeControlFakeClient{}, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+
+	_ = m.appendLocalEntry("developer_feedback", "local feedback")
+	if len(m.transcriptEntries) != 1 {
+		t.Fatalf("expected optimistic local entry, got %+v", m.transcriptEntries)
+	}
+	if !m.transcriptEntries[0].Transient {
+		t.Fatalf("expected runtime-backed optimistic entry to be transient, got %+v", m.transcriptEntries[0])
+	}
+	if committed := committedTranscriptEntriesForApp(m.transcriptEntries); len(committed) != 0 {
+		t.Fatalf("optimistic local entry advanced committed transcript entries: %+v", committed)
+	}
+}
+
+func TestStaticLocalEntryFallbackRemainsCommitted(t *testing.T) {
+	m := newProjectedStaticUIModel()
+
+	_ = m.appendLocalEntry("developer_feedback", "local feedback")
+	if len(m.transcriptEntries) != 1 {
+		t.Fatalf("expected local entry, got %+v", m.transcriptEntries)
+	}
+	if m.transcriptEntries[0].Transient {
+		t.Fatalf("expected static local entry to remain committed, got %+v", m.transcriptEntries[0])
+	}
+	if committed := committedTranscriptEntriesForApp(m.transcriptEntries); len(committed) != 1 {
+		t.Fatalf("expected static local entry in committed transcript entries, got %+v", committed)
+	}
+}
+
 func TestRuntimeStatusLineHidesGoalStatusText(t *testing.T) {
 	for _, goalStatus := range []clientui.RuntimeGoalStatus{clientui.RuntimeGoalStatusActive, clientui.RuntimeGoalStatusPaused, clientui.RuntimeGoalStatusComplete} {
 		client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{

--- a/cli/app/ui_runtime_status_test.go
+++ b/cli/app/ui_runtime_status_test.go
@@ -55,6 +55,21 @@ func TestRuntimeStatusUsesLocalFallbackWhenRuntimeClientMissing(t *testing.T) {
 	}
 }
 
+func TestCurrentConversationFreshnessAcceptsCachedFreshness(t *testing.T) {
+	client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{
+		ConversationFreshness: clientui.ConversationFreshnessFresh,
+	}}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.conversationFreshness = clientui.ConversationFreshnessEstablished
+
+	if got := m.currentConversationFreshness(); got != clientui.ConversationFreshnessFresh {
+		t.Fatalf("conversation freshness = %v, want fresh", got)
+	}
+	if m.conversationFreshness != clientui.ConversationFreshnessFresh {
+		t.Fatalf("cached freshness did not update model state: %v", m.conversationFreshness)
+	}
+}
+
 func TestRuntimeStatusLineHidesGoalStatusText(t *testing.T) {
 	for _, goalStatus := range []clientui.RuntimeGoalStatus{clientui.RuntimeGoalStatusActive, clientui.RuntimeGoalStatusPaused, clientui.RuntimeGoalStatusComplete} {
 		client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{

--- a/cli/app/ui_runtime_sync.go
+++ b/cli/app/ui_runtime_sync.go
@@ -13,17 +13,77 @@ import (
 
 var uiRuntimeHydrationRetryDelay = 750 * time.Millisecond
 
+type runtimeSyncPolicyClass uint8
+
+const (
+	runtimeSyncPolicyClassRoutine runtimeSyncPolicyClass = iota + 1
+	runtimeSyncPolicyClassAllowed
+)
+
+type runtimeTranscriptSyncRequest struct {
+	page               clientui.TranscriptPageRequest
+	allowDuplicateSkip bool
+	syncCause          runtimeTranscriptSyncCause
+	recoveryCause      clientui.TranscriptRecoveryCause
+	class              runtimeSyncPolicyClass
+	priority           int
+}
+
+type runtimeTranscriptSyncDecision struct {
+	cmd             tea.Cmd
+	started         bool
+	deferred        bool
+	busyPending     bool
+	awaitsHydration bool
+}
+
+type runtimeMainViewRefreshRequest struct {
+	cause    runtimeMainViewRefreshCause
+	class    runtimeSyncPolicyClass
+	priority int
+}
+
+type runtimeMainViewRefreshDecision struct {
+	cmd         tea.Cmd
+	started     bool
+	deferred    bool
+	busyPending bool
+}
+
 func (m *uiModel) requestRuntimeMainViewRefresh() tea.Cmd {
+	return m.requestRuntimeMainViewRefreshForCause(runtimeMainViewRefreshCauseWorktreeMutation)
+}
+
+func (m *uiModel) requestRuntimeMainViewRefreshForCause(cause runtimeMainViewRefreshCause) tea.Cmd {
+	return m.startRuntimeMainViewRefreshRequest(runtimeMainViewRefreshRequestForCause(cause)).cmd
+}
+
+func (m *uiModel) startRuntimeMainViewRefreshRequest(request runtimeMainViewRefreshRequest) runtimeMainViewRefreshDecision {
 	if !m.hasRuntimeClient() {
-		return nil
+		return runtimeMainViewRefreshDecision{}
+	}
+	request = normalizeRuntimeMainViewRefreshRequest(request)
+	if m.shouldDeferRuntimeMainViewRefresh(request) {
+		m.mergePendingRuntimeMainViewRefresh(request)
+		m.logf("ui.runtime.main_view.defer cause=%s streaming=%t process_overlay=%t", request.cause, m.runtimeSyncBlockedByStreaming(), m.runtimeSyncBlockedByProcessOverlay())
+		return runtimeMainViewRefreshDecision{deferred: true}
+	}
+	if m.runtimeMainViewBusy {
+		m.mergePendingRuntimeMainViewRefresh(request)
+		m.logf("ui.runtime.main_view.busy_pending cause=%s", request.cause)
+		return runtimeMainViewRefreshDecision{busyPending: true}
 	}
 	m.runtimeMainViewToken++
 	token := m.runtimeMainViewToken
 	client := m.runtimeClient()
-	return func() tea.Msg {
+	m.runtimeMainViewBusy = true
+	m.runtimeMainViewActiveRequest = request
+	m.logf("ui.runtime.main_view.start token=%d cause=%s", token, request.cause)
+	cmd := func() tea.Msg {
 		view, err := client.RefreshMainView()
-		return runtimeMainViewRefreshedMsg{token: token, view: view, err: err}
+		return runtimeMainViewRefreshedMsg{token: token, req: request, view: view, err: err}
 	}
+	return runtimeMainViewRefreshDecision{cmd: cmd, started: true}
 }
 
 func (m *uiModel) requestRuntimeTranscriptPage(request clientui.TranscriptPageRequest) tea.Cmd {
@@ -84,37 +144,48 @@ func (m *uiModel) requestRuntimeTranscriptSyncForContinuityLoss(cause clientui.T
 	return m.startRuntimeTranscriptPageRequest(m.transcriptRequestForCurrentMode(), false, runtimeTranscriptSyncCauseContinuityRecovery, cause)
 }
 
-func (m *uiModel) requestRuntimeDirtyFollowUpTranscriptSync(cause clientui.TranscriptRecoveryCause) tea.Cmd {
-	if !m.hasRuntimeClient() {
-		return nil
-	}
-	return m.startRuntimeTranscriptPageRequest(m.transcriptRequestForCurrentMode(), false, runtimeTranscriptSyncCauseDirtyFollowUp, cause)
+func (m *uiModel) startRuntimeTranscriptPageRequest(request clientui.TranscriptPageRequest, allowDuplicateSkip bool, syncCause runtimeTranscriptSyncCause, recoveryCause clientui.TranscriptRecoveryCause) tea.Cmd {
+	return m.startRuntimeTranscriptPageRequestDecision(request, allowDuplicateSkip, syncCause, recoveryCause).cmd
 }
 
-func (m *uiModel) startRuntimeTranscriptPageRequest(request clientui.TranscriptPageRequest, allowDuplicateSkip bool, syncCause runtimeTranscriptSyncCause, recoveryCause clientui.TranscriptRecoveryCause) tea.Cmd {
-	fetchRequest := m.transcriptHydrationRequest(request, allowDuplicateSkip)
-	if m.runtimeTranscriptBusy {
-		m.runtimeTranscriptDirty = true
-		if recoveryCause != clientui.TranscriptRecoveryCauseNone {
-			m.runtimeTranscriptDirtyRecoveryCause = recoveryCause
-		}
-		m.logf("ui.runtime.transcript.mark_dirty sync_cause=%s recovery_cause=%s", syncCause, recoveryCause)
-		return nil
+func (m *uiModel) startRuntimeTranscriptPageRequestDecision(request clientui.TranscriptPageRequest, allowDuplicateSkip bool, syncCause runtimeTranscriptSyncCause, recoveryCause clientui.TranscriptRecoveryCause) runtimeTranscriptSyncDecision {
+	return m.startRuntimeTranscriptSyncRequest(runtimeTranscriptSyncRequestForPage(request, allowDuplicateSkip, syncCause, recoveryCause))
+}
+
+func (m *uiModel) startRuntimeTranscriptSyncRequest(syncRequest runtimeTranscriptSyncRequest) runtimeTranscriptSyncDecision {
+	syncRequest = m.normalizeRuntimeTranscriptSyncRequest(syncRequest)
+	if !m.hasRuntimeClient() {
+		return runtimeTranscriptSyncDecision{}
 	}
-	if allowDuplicateSkip && m.shouldSkipTranscriptPageRequest(request) {
-		m.logf("ui.runtime.transcript.skip_duplicate mode=%s offset=%d limit=%d window=%s sync_cause=%s", m.view.Mode(), request.Offset, request.Limit, request.Window, syncCause)
-		return nil
+	if syncRequest.allowDuplicateSkip && m.shouldSkipTranscriptPageRequest(syncRequest.page) {
+		request := syncRequest.page
+		m.logf("ui.runtime.transcript.skip_duplicate mode=%s offset=%d limit=%d window=%s sync_cause=%s", m.view.Mode(), request.Offset, request.Limit, request.Window, syncRequest.syncCause)
+		return runtimeTranscriptSyncDecision{}
+	}
+	if m.shouldDeferRuntimeTranscriptSync(syncRequest) {
+		m.mergePendingRuntimeTranscriptSync(syncRequest)
+		m.logRuntimeTranscriptPolicyDecision("defer", syncRequest)
+		return runtimeTranscriptSyncDecision{deferred: true}
+	}
+	if m.runtimeTranscriptBusy {
+		m.mergePendingRuntimeTranscriptSync(syncRequest)
+		m.logRuntimeTranscriptPolicyDecision("busy_pending", syncRequest)
+		return runtimeTranscriptSyncDecision{busyPending: true, awaitsHydration: true}
 	}
 	m.runtimeTranscriptBusy = true
-	m.runtimeTranscriptDirty = false
-	m.runtimeTranscriptDirtyRecoveryCause = clientui.TranscriptRecoveryCauseNone
+	m.runtimeTranscriptActiveRequest = syncRequest
 	m.runtimeTranscriptToken++
 	token := m.runtimeTranscriptToken
 	client := m.runtimeClient()
 	if client == nil {
 		m.runtimeTranscriptBusy = false
-		return nil
+		m.runtimeTranscriptActiveRequest = runtimeTranscriptSyncRequest{}
+		return runtimeTranscriptSyncDecision{}
 	}
+	syncCause := syncRequest.syncCause
+	recoveryCause := syncRequest.recoveryCause
+	fetchRequest := syncRequest.page
+	m.logRuntimeTranscriptPolicyDecision("start", syncRequest)
 	m.logf("ui.runtime.transcript.start token=%d sync_cause=%s", token, syncCause)
 	fields := map[string]string{
 		"session_id":            m.sessionID,
@@ -131,18 +202,216 @@ func (m *uiModel) startRuntimeTranscriptPageRequest(request clientui.TranscriptP
 		fields[key] = value
 	}
 	m.logTranscriptDiag(transcriptdiag.FormatLine("transcript.diag.client.hydrate_start", fields))
-	return func() tea.Msg {
+	cmd := func() tea.Msg {
 		var (
 			transcript clientui.TranscriptPage
 			err        error
 		)
-		if allowDuplicateSkip {
+		if syncRequest.allowDuplicateSkip {
 			transcript, err = client.LoadTranscriptPage(fetchRequest)
 		} else {
 			transcript, err = client.RefreshTranscriptPage(fetchRequest)
 		}
-		return runtimeTranscriptRefreshedMsg{token: token, req: fetchRequest, syncCause: syncCause, transcript: transcript, recoveryCause: recoveryCause, err: err}
+		return runtimeTranscriptRefreshedMsg{token: token, req: fetchRequest, syncRequest: syncRequest, syncCause: syncCause, transcript: transcript, recoveryCause: recoveryCause, err: err}
 	}
+	return runtimeTranscriptSyncDecision{cmd: cmd, started: true, awaitsHydration: true}
+}
+
+func runtimeTranscriptSyncRequestForPage(request clientui.TranscriptPageRequest, allowDuplicateSkip bool, syncCause runtimeTranscriptSyncCause, recoveryCause clientui.TranscriptRecoveryCause) runtimeTranscriptSyncRequest {
+	req := runtimeTranscriptSyncRequest{
+		page:               request,
+		allowDuplicateSkip: allowDuplicateSkip,
+		syncCause:          syncCause,
+		recoveryCause:      recoveryCause,
+		class:              runtimeSyncPolicyClassRoutine,
+		priority:           10,
+	}
+	switch syncCause {
+	case runtimeTranscriptSyncCauseContinuityRecovery:
+		req.class = runtimeSyncPolicyClassAllowed
+		req.priority = 100
+	case runtimeTranscriptSyncCauseCommittedGap:
+		req.class = runtimeSyncPolicyClassAllowed
+		req.priority = 90
+	case runtimeTranscriptSyncCauseQueuedDrain:
+		req.class = runtimeSyncPolicyClassAllowed
+		req.priority = 80
+	case runtimeTranscriptSyncCauseManualTranscriptRefresh:
+		req.class = runtimeSyncPolicyClassAllowed
+		req.priority = 70
+	case runtimeTranscriptSyncCauseBootstrap:
+		req.class = runtimeSyncPolicyClassAllowed
+		req.priority = 60
+	case runtimeTranscriptSyncCauseCommittedConversation, runtimeTranscriptSyncCauseDirtyFollowUp:
+		req.class = runtimeSyncPolicyClassRoutine
+		req.priority = 10
+	default:
+		if recoveryCause != clientui.TranscriptRecoveryCauseNone {
+			req.class = runtimeSyncPolicyClassAllowed
+			req.priority = 100
+		}
+	}
+	if recoveryCause != clientui.TranscriptRecoveryCauseNone {
+		req.class = runtimeSyncPolicyClassAllowed
+		req.priority = max(req.priority, 100)
+	}
+	return req
+}
+
+func normalizeRuntimeMainViewRefreshRequest(req runtimeMainViewRefreshRequest) runtimeMainViewRefreshRequest {
+	if req.cause == "" {
+		req.cause = runtimeMainViewRefreshCauseManual
+	}
+	if req.class == 0 {
+		req.class = runtimeSyncPolicyClassRoutine
+	}
+	if req.priority == 0 {
+		req.priority = 10
+	}
+	return req
+}
+
+func runtimeMainViewRefreshRequestForCause(cause runtimeMainViewRefreshCause) runtimeMainViewRefreshRequest {
+	priority := 10
+	if cause == runtimeMainViewRefreshCauseStartupUpdate {
+		priority = 20
+	}
+	return normalizeRuntimeMainViewRefreshRequest(runtimeMainViewRefreshRequest{
+		cause:    cause,
+		class:    runtimeSyncPolicyClassRoutine,
+		priority: priority,
+	})
+}
+
+func (m *uiModel) normalizeRuntimeTranscriptSyncRequest(req runtimeTranscriptSyncRequest) runtimeTranscriptSyncRequest {
+	req.page = m.transcriptHydrationRequest(req.page, req.allowDuplicateSkip)
+	if req.syncCause == "" {
+		req.syncCause = runtimeTranscriptSyncCauseCommittedConversation
+	}
+	if req.class == 0 || req.priority == 0 {
+		req = runtimeTranscriptSyncRequestForPage(req.page, req.allowDuplicateSkip, req.syncCause, req.recoveryCause)
+	}
+	return req
+}
+
+func (m *uiModel) runtimeSyncBlockedByProcessOverlay() bool {
+	return m != nil && m.processList.isOpen()
+}
+
+func (m *uiModel) runtimeSyncBlockedByStreaming() bool {
+	if m == nil {
+		return false
+	}
+	return strings.TrimSpace(m.view.OngoingStreamingText()) != "" ||
+		m.sawAssistantDelta ||
+		m.nativeStreamingActive ||
+		strings.TrimSpace(m.nativeStreamingText) != "" ||
+		m.isBusy() ||
+		m.isCompacting() ||
+		m.isReviewerRunning()
+}
+
+func (m *uiModel) shouldDeferRuntimeTranscriptSync(req runtimeTranscriptSyncRequest) bool {
+	if req.class != runtimeSyncPolicyClassRoutine {
+		return false
+	}
+	return m.runtimeSyncBlockedByProcessOverlay() || m.runtimeSyncBlockedByStreaming()
+}
+
+func (m *uiModel) shouldDeferRuntimeMainViewRefresh(req runtimeMainViewRefreshRequest) bool {
+	if req.class != runtimeSyncPolicyClassRoutine {
+		return false
+	}
+	return m.runtimeSyncBlockedByProcessOverlay() || m.runtimeSyncBlockedByStreaming()
+}
+
+func (m *uiModel) mergePendingRuntimeTranscriptSync(req runtimeTranscriptSyncRequest) {
+	if m == nil {
+		return
+	}
+	req = m.normalizeRuntimeTranscriptSyncRequest(req)
+	if !m.runtimeTranscriptPendingSet || shouldReplacePendingRuntimeTranscriptSync(m.runtimeTranscriptPending, req) {
+		m.runtimeTranscriptPending = req
+		m.runtimeTranscriptPendingSet = true
+	}
+}
+
+func shouldReplacePendingRuntimeTranscriptSync(current, next runtimeTranscriptSyncRequest) bool {
+	if next.priority != current.priority {
+		return next.priority > current.priority
+	}
+	if next.page.Window != current.page.Window {
+		return next.page.Window == clientui.TranscriptWindowOngoingTail
+	}
+	if next.page.Limit != current.page.Limit {
+		return next.page.Limit > current.page.Limit
+	}
+	return next.page.Offset >= current.page.Offset
+}
+
+func (m *uiModel) mergePendingRuntimeMainViewRefresh(req runtimeMainViewRefreshRequest) {
+	if m == nil {
+		return
+	}
+	req = normalizeRuntimeMainViewRefreshRequest(req)
+	if !m.runtimeMainViewPendingSet || req.priority >= m.runtimeMainViewPending.priority {
+		m.runtimeMainViewPending = req
+		m.runtimeMainViewPendingSet = true
+	}
+}
+
+func (m *uiModel) drainPendingRuntimeTranscriptSync() runtimeTranscriptSyncDecision {
+	if m == nil || !m.runtimeTranscriptPendingSet || m.runtimeTranscriptBusy {
+		return runtimeTranscriptSyncDecision{}
+	}
+	req := m.runtimeTranscriptPending
+	m.runtimeTranscriptPending = runtimeTranscriptSyncRequest{}
+	m.runtimeTranscriptPendingSet = false
+	decision := m.startRuntimeTranscriptSyncRequest(req)
+	if decision.deferred || decision.busyPending {
+		return decision
+	}
+	m.logRuntimeTranscriptPolicyDecision("release", req)
+	return decision
+}
+
+func (m *uiModel) drainPendingRuntimeMainViewRefresh() runtimeMainViewRefreshDecision {
+	if m == nil || !m.runtimeMainViewPendingSet || m.runtimeMainViewBusy {
+		return runtimeMainViewRefreshDecision{}
+	}
+	req := m.runtimeMainViewPending
+	m.runtimeMainViewPending = runtimeMainViewRefreshRequest{}
+	m.runtimeMainViewPendingSet = false
+	decision := m.startRuntimeMainViewRefreshRequest(req)
+	if decision.deferred || decision.busyPending {
+		return decision
+	}
+	m.logf("ui.runtime.main_view.release cause=%s", req.cause)
+	return decision
+}
+
+func (m *uiModel) releaseDeferredRuntimeSyncs() tea.Cmd {
+	transcript := m.drainPendingRuntimeTranscriptSync()
+	mainView := m.drainPendingRuntimeMainViewRefresh()
+	return tea.Batch(transcript.cmd, mainView.cmd)
+}
+
+func (m *uiModel) logRuntimeTranscriptPolicyDecision(outcome string, req runtimeTranscriptSyncRequest) {
+	if m == nil {
+		return
+	}
+	m.logf(
+		"ui.runtime.transcript.policy outcome=%s sync_cause=%s recovery_cause=%s priority=%d streaming=%t process_overlay=%t window=%s offset=%d limit=%d",
+		outcome,
+		req.syncCause,
+		req.recoveryCause,
+		req.priority,
+		m.runtimeSyncBlockedByStreaming(),
+		m.runtimeSyncBlockedByProcessOverlay(),
+		req.page.Window,
+		req.page.Offset,
+		req.page.Limit,
+	)
 }
 
 func (m *uiModel) transcriptHydrationRequest(request clientui.TranscriptPageRequest, allowDuplicateSkip bool) clientui.TranscriptPageRequest {
@@ -154,7 +423,7 @@ func (m *uiModel) transcriptHydrationRequest(request clientui.TranscriptPageRequ
 }
 
 func (m *uiModel) shouldSkipTranscriptPageRequest(req clientui.TranscriptPageRequest) bool {
-	if m.runtimeTranscriptDirty || m.transcriptLiveDirty || m.reasoningLiveDirty {
+	if m.runtimeTranscriptPendingSet || m.transcriptLiveDirty || m.reasoningLiveDirty {
 		return false
 	}
 	if m.view.Mode() != tui.ModeDetail {
@@ -170,26 +439,68 @@ func (m *uiModel) scheduleRuntimeTranscriptRetry(syncCause runtimeTranscriptSync
 	if !m.hasRuntimeClient() {
 		return nil
 	}
+	return m.scheduleRuntimeTranscriptRetryForRequest(runtimeTranscriptSyncRequestForPage(m.transcriptRequestForCurrentMode(), false, syncCause, cause))
+}
+
+func (m *uiModel) scheduleRuntimeTranscriptRetryForRequest(req runtimeTranscriptSyncRequest) tea.Cmd {
+	if !m.hasRuntimeClient() {
+		return nil
+	}
+	req = m.normalizeRuntimeTranscriptSyncRequest(req)
 	m.runtimeTranscriptRetry++
 	token := m.runtimeTranscriptRetry
-	m.logf("ui.runtime.transcript.retry_scheduled token=%d sync_cause=%s recovery_cause=%s delay=%s", token, syncCause, cause, uiRuntimeHydrationRetryDelay)
+	m.logf("ui.runtime.transcript.retry_scheduled token=%d sync_cause=%s recovery_cause=%s delay=%s", token, req.syncCause, req.recoveryCause, uiRuntimeHydrationRetryDelay)
 	return tea.Tick(uiRuntimeHydrationRetryDelay, func(time.Time) tea.Msg {
-		return runtimeTranscriptRetryMsg{token: token, syncCause: syncCause, recoveryCause: cause}
+		return runtimeTranscriptRetryMsg{token: token, syncCause: req.syncCause, recoveryCause: req.recoveryCause, req: req}
 	})
+}
+
+func (m *uiModel) resumeRuntimeEventsAfterHydrationIfUnowned() tea.Cmd {
+	if m == nil || !m.waitRuntimeEventAfterHydration {
+		return nil
+	}
+	m.waitRuntimeEventAfterHydration = false
+	return m.waitRuntimeEventCmd()
 }
 
 func (m *uiModel) handleRuntimeMainViewRefreshed(msg runtimeMainViewRefreshedMsg) tea.Cmd {
 	if msg.token != m.runtimeMainViewToken {
 		return nil
 	}
+	m.runtimeMainViewBusy = false
+	req := msg.req
+	if req == (runtimeMainViewRefreshRequest{}) {
+		req = m.runtimeMainViewActiveRequest
+	}
+	req = normalizeRuntimeMainViewRefreshRequest(req)
+	m.runtimeMainViewActiveRequest = runtimeMainViewRefreshRequest{}
+	if m.shouldDeferRuntimeMainViewRefresh(req) {
+		m.mergePendingRuntimeMainViewRefresh(req)
+		m.logf("ui.runtime.main_view.drop_response_blocked cause=%s streaming=%t process_overlay=%t", req.cause, m.runtimeSyncBlockedByStreaming(), m.runtimeSyncBlockedByProcessOverlay())
+		return m.drainPendingRuntimeMainViewRefresh().cmd
+	}
 	if msg.err != nil {
 		m.observeRuntimeRequestResult(msg.err)
 		m.logf("ui.runtime.main_view err=%q", msg.err.Error())
-		return nil
+		return m.drainPendingRuntimeMainViewRefresh().cmd
 	}
 	m.observeRuntimeRequestResult(nil)
 	m.applyRuntimeMainViewState(msg.view)
-	return m.runtimeAdapter().applyProjectedSessionMetadata(msg.view.Session)
+	noticeCmd := runtimeMainViewStartupUpdateNoticeCmd(req, msg.view)
+	return sequenceCmds(m.runtimeAdapter().applyProjectedSessionMetadata(msg.view.Session), noticeCmd, m.drainPendingRuntimeMainViewRefresh().cmd)
+}
+
+func runtimeMainViewStartupUpdateNoticeCmd(req runtimeMainViewRefreshRequest, view clientui.RuntimeMainView) tea.Cmd {
+	if req.cause != runtimeMainViewRefreshCauseStartupUpdate {
+		return nil
+	}
+	status := view.Status.Update
+	if !status.Available || strings.TrimSpace(status.LatestVersion) == "" {
+		return nil
+	}
+	return func() tea.Msg {
+		return startupUpdateNoticeMsg{version: status.LatestVersion}
+	}
 }
 
 func (m *uiModel) handleRuntimeTranscriptRefreshed(msg runtimeTranscriptRefreshedMsg) tea.Cmd {
@@ -197,8 +508,29 @@ func (m *uiModel) handleRuntimeTranscriptRefreshed(msg runtimeTranscriptRefreshe
 		return nil
 	}
 	m.runtimeTranscriptBusy = false
+	activeReq := m.runtimeTranscriptActiveRequest
+	if msg.syncRequest != (runtimeTranscriptSyncRequest{}) {
+		activeReq = msg.syncRequest
+	}
+	if activeReq == (runtimeTranscriptSyncRequest{}) {
+		activeReq = runtimeTranscriptSyncRequestForPage(msg.req, false, msg.syncCause, msg.recoveryCause)
+	}
+	activeReq = m.normalizeRuntimeTranscriptSyncRequest(activeReq)
+	m.runtimeTranscriptActiveRequest = runtimeTranscriptSyncRequest{}
+	if m.shouldDeferRuntimeTranscriptSync(activeReq) {
+		m.mergePendingRuntimeTranscriptSync(activeReq)
+		m.logRuntimeTranscriptPolicyDecision("drop_response_blocked", activeReq)
+		resumeCmd := m.resumeRuntimeEventsAfterHydrationIfUnowned()
+		drain := m.drainPendingRuntimeTranscriptSync()
+		if drain.started {
+			if resumeCmd != nil {
+				m.waitRuntimeEventAfterHydration = true
+			}
+			return drain.cmd
+		}
+		return sequenceCmds(drain.cmd, resumeCmd)
+	}
 	if msg.err != nil {
-		m.invalidateTransientTranscriptState()
 		m.observeRuntimeRequestResult(msg.err)
 		m.logf("ui.runtime.transcript err=%q sync_cause=%s recovery_cause=%s", msg.err.Error(), msg.syncCause, msg.recoveryCause)
 		m.logTranscriptDiag(transcriptdiag.FormatLine("transcript.diag.client.hydrate_response", map[string]string{
@@ -210,12 +542,16 @@ func (m *uiModel) handleRuntimeTranscriptRefreshed(msg runtimeTranscriptRefreshe
 			"recovery_cause": string(msg.recoveryCause),
 			"err":            msg.err.Error(),
 		}))
-		resumeCmd := tea.Cmd(nil)
-		if m.waitRuntimeEventAfterHydration {
-			m.waitRuntimeEventAfterHydration = false
-			resumeCmd = m.waitRuntimeEventCmd()
+		retryCmd := m.scheduleRuntimeTranscriptRetryForRequest(activeReq)
+		resumeCmd := m.resumeRuntimeEventsAfterHydrationIfUnowned()
+		drain := m.drainPendingRuntimeTranscriptSync()
+		if drain.started {
+			if resumeCmd != nil {
+				m.waitRuntimeEventAfterHydration = true
+			}
+			return tea.Batch(retryCmd, drain.cmd)
 		}
-		return tea.Batch(m.scheduleRuntimeTranscriptRetry(msg.syncCause, msg.recoveryCause), resumeCmd)
+		return tea.Batch(retryCmd, drain.cmd, resumeCmd)
 	}
 	m.observeRuntimeRequestResult(nil)
 	m.logTranscriptPageDiag("transcript.diag.client.hydrate_response", msg.req, msg.transcript, map[string]string{
@@ -232,21 +568,18 @@ func (m *uiModel) handleRuntimeTranscriptRefreshed(msg runtimeTranscriptRefreshe
 		m.logf("ui.runtime.transcript.recovered token=%d", msg.token)
 	}
 	applyCmd := m.runtimeAdapter().applyRuntimeTranscriptPageWithRecovery(msg.req, msg.transcript, msg.recoveryCause)
-	if !m.runtimeTranscriptDirty {
-		if m.pendingQueuedDrainAfterHydration {
-			m.queuedDrainReadyAfterHydration = true
+	resumeCmd := m.resumeRuntimeEventsAfterHydrationIfUnowned()
+	drain := m.drainPendingRuntimeTranscriptSync()
+	if drain.started {
+		if resumeCmd != nil {
+			m.waitRuntimeEventAfterHydration = true
 		}
-		resumeCmd := tea.Cmd(nil)
-		if m.waitRuntimeEventAfterHydration {
-			m.waitRuntimeEventAfterHydration = false
-			resumeCmd = m.waitRuntimeEventCmd()
-		}
-		return sequenceCmds(applyCmd, m.flushQueuedInputsAfterHydration(), resumeCmd)
+		return sequenceCmds(applyCmd, drain.cmd)
 	}
-	m.runtimeTranscriptDirty = false
-	m.logf("ui.runtime.transcript.repeat_after_dirty token=%d sync_cause=%s", msg.token, runtimeTranscriptSyncCauseDirtyFollowUp)
-	followUpRecoveryCause := m.runtimeTranscriptDirtyRecoveryCause
-	return sequenceCmds(applyCmd, m.requestRuntimeDirtyFollowUpTranscriptSync(followUpRecoveryCause))
+	if m.pendingQueuedDrainAfterHydration {
+		m.queuedDrainReadyAfterHydration = true
+	}
+	return sequenceCmds(applyCmd, drain.cmd, m.flushQueuedInputsAfterHydration(), resumeCmd)
 }
 
 func (m *uiModel) handleRuntimeCommittedTranscriptSuffixRefreshed(msg runtimeCommittedTranscriptSuffixRefreshedMsg) tea.Cmd {
@@ -262,7 +595,7 @@ func (m *uiModel) handleRuntimeCommittedTranscriptSuffixRefreshed(msg runtimeCom
 		}
 		m.observeRuntimeRequestResult(msg.err)
 		m.logf("ui.runtime.committed_suffix err=%q after_entry_count=%d limit=%d", msg.err.Error(), msg.req.AfterEntryCount, msg.req.Limit)
-		return m.requestRuntimeCommittedConversationSync()
+		return m.requestRuntimeCommittedGapSync()
 	}
 	m.observeRuntimeRequestResult(nil)
 	if committedTranscriptSuffixStartsAfterDeliveryCursor(m, msg.suffix) {

--- a/cli/app/ui_slash_command_picker.go
+++ b/cli/app/ui_slash_command_picker.go
@@ -90,6 +90,14 @@ func normalizeSlashCommandToken(token string) string {
 }
 
 func (m *uiModel) refreshSlashCommandFilterFromInput() tea.Cmd {
+	return m.refreshSlashCommandFilterFromInputWithAuth(true)
+}
+
+func (m *uiModel) refreshSlashCommandFilterStateFromInput() {
+	_ = m.refreshSlashCommandFilterFromInputWithAuth(false)
+}
+
+func (m *uiModel) refreshSlashCommandFilterFromInputWithAuth(scheduleAuth bool) tea.Cmd {
 	parsed := parseSlashCommandInput(m.input)
 	if !parsed.active || parsed.argumentMode {
 		m.authSlashSessionOpen = false
@@ -104,7 +112,9 @@ func (m *uiModel) refreshSlashCommandFilterFromInput() tea.Cmd {
 		m.authSlashSessionOpen = true
 		m.authSlashGeneration = nextNonZeroToken(m.authSlashGeneration)
 	}
-	cmd = m.requestAuthSlashCommandRefresh()
+	if scheduleAuth {
+		cmd = m.requestAuthSlashCommandRefresh()
+	}
 	normalized := normalizeSlashCommandToken(parsed.token)
 	if !m.slashCommandFilterSet || m.slashCommandFilter != normalized {
 		m.slashCommandSelection = 0
@@ -193,6 +203,7 @@ func (m *uiModel) requestAuthSlashCommandRefresh() tea.Cmd {
 	token := m.authSlashToken
 	generation := m.authSlashGeneration
 	loader := m.statusConfig.AuthManager
+	m.authSlashLoading = true
 	return func() tea.Msg {
 		name, err := authcommand.SlashCommandName(context.Background(), loader)
 		return authSlashCommandRefreshedMsg{token: token, generation: generation, name: name, err: err}

--- a/cli/app/ui_slash_command_picker.go
+++ b/cli/app/ui_slash_command_picker.go
@@ -7,6 +7,8 @@ import (
 
 	"builder/cli/app/commands"
 	"builder/cli/app/internal/authcommand"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 const slashCommandPickerLines = 7
@@ -57,18 +59,21 @@ func normalizeSlashCommandToken(token string) string {
 	return strings.ToLower(strings.TrimSpace(token))
 }
 
-func (m *uiModel) refreshSlashCommandFilterFromInput() {
+func (m *uiModel) refreshSlashCommandFilterFromInput() tea.Cmd {
 	parsed := parseSlashCommandInput(m.input)
 	if !parsed.active || parsed.argumentMode {
 		m.authSlashSessionOpen = false
+		m.authSlashLoading = false
 		m.slashCommandFilter = ""
 		m.slashCommandFilterSet = false
 		m.slashCommandSelection = 0
-		return
+		return nil
 	}
+	cmd := tea.Cmd(nil)
 	if !m.authSlashSessionOpen {
-		m.refreshAuthSlashCommandState()
 		m.authSlashSessionOpen = true
+		m.authSlashGeneration = nextNonZeroToken(m.authSlashGeneration)
+		cmd = m.requestAuthSlashCommandRefresh()
 	}
 	normalized := normalizeSlashCommandToken(parsed.token)
 	if !m.slashCommandFilterSet || m.slashCommandFilter != normalized {
@@ -77,6 +82,7 @@ func (m *uiModel) refreshSlashCommandFilterFromInput() {
 	m.slashCommandFilter = normalized
 	m.slashCommandFilterSet = true
 	m.clampSlashCommandSelection()
+	return cmd
 }
 
 func (m *uiModel) currentSlashCommandQuery(token string) string {
@@ -139,21 +145,46 @@ func isAuthSlashCommand(name string) bool {
 	}
 }
 
-func (m *uiModel) refreshAuthSlashCommandState() {
-	name, err := m.resolveAuthSlashCommandName()
-	m.authSlashCommandName = name
-	if err != nil {
-		m.authSlashCommandErr = err.Error()
-		return
+func (m *uiModel) requestAuthSlashCommandRefresh() tea.Cmd {
+	if m == nil {
+		return nil
 	}
-	m.authSlashCommandErr = ""
+	if m.statusConfig.AuthManager == nil {
+		m.authSlashCommandName = "login"
+		m.authSlashCommandErr = ""
+		m.authSlashResolved = m.authSlashGeneration
+		m.authSlashLoading = false
+		return nil
+	}
+	if m.authSlashResolved == m.authSlashGeneration || m.authSlashLoading {
+		return nil
+	}
+	m.authSlashToken = nextNonZeroToken(m.authSlashToken)
+	token := m.authSlashToken
+	generation := m.authSlashGeneration
+	loader := m.statusConfig.AuthManager
+	m.authSlashLoading = true
+	return func() tea.Msg {
+		name, err := authcommand.SlashCommandName(context.Background(), loader)
+		return authSlashCommandRefreshedMsg{token: token, generation: generation, name: name, err: err}
+	}
 }
 
-func (m *uiModel) resolveAuthSlashCommandName() (string, error) {
-	if m == nil || m.statusConfig.AuthManager == nil {
-		return "login", nil
+func (m *uiModel) applyAuthSlashCommandRefreshed(msg authSlashCommandRefreshedMsg) {
+	if m == nil || msg.token != m.authSlashToken || msg.generation != m.authSlashGeneration {
+		return
 	}
-	return authcommand.SlashCommandName(context.Background(), m.statusConfig.AuthManager)
+	m.authSlashLoading = false
+	m.authSlashResolved = msg.generation
+	if msg.err != nil {
+		m.authSlashCommandName = ""
+		m.authSlashCommandErr = msg.err.Error()
+		m.clampSlashCommandSelection()
+		return
+	}
+	m.authSlashCommandName = strings.TrimSpace(msg.name)
+	m.authSlashCommandErr = ""
+	m.clampSlashCommandSelection()
 }
 
 func (m *uiModel) resumeCommandAvailable() bool {

--- a/cli/app/ui_slash_command_picker.go
+++ b/cli/app/ui_slash_command_picker.go
@@ -103,8 +103,8 @@ func (m *uiModel) refreshSlashCommandFilterFromInput() tea.Cmd {
 	if !m.authSlashSessionOpen {
 		m.authSlashSessionOpen = true
 		m.authSlashGeneration = nextNonZeroToken(m.authSlashGeneration)
-		cmd = m.requestAuthSlashCommandRefresh()
 	}
+	cmd = m.requestAuthSlashCommandRefresh()
 	normalized := normalizeSlashCommandToken(parsed.token)
 	if !m.slashCommandFilterSet || m.slashCommandFilter != normalized {
 		m.slashCommandSelection = 0
@@ -193,7 +193,6 @@ func (m *uiModel) requestAuthSlashCommandRefresh() tea.Cmd {
 	token := m.authSlashToken
 	generation := m.authSlashGeneration
 	loader := m.statusConfig.AuthManager
-	m.authSlashLoading = true
 	return func() tea.Msg {
 		name, err := authcommand.SlashCommandName(context.Background(), loader)
 		return authSlashCommandRefreshedMsg{token: token, generation: generation, name: name, err: err}

--- a/cli/app/ui_slash_command_picker.go
+++ b/cli/app/ui_slash_command_picker.go
@@ -13,6 +13,36 @@ import (
 
 const slashCommandPickerLines = 7
 
+type authSlashCommandKind uint8
+
+const (
+	authSlashCommandUnknown authSlashCommandKind = iota
+	authSlashCommandLogin
+	authSlashCommandLogout
+)
+
+func authSlashCommandFromName(name string) authSlashCommandKind {
+	switch strings.TrimSpace(name) {
+	case "login":
+		return authSlashCommandLogin
+	case "logout":
+		return authSlashCommandLogout
+	default:
+		return authSlashCommandUnknown
+	}
+}
+
+func (k authSlashCommandKind) commandName() string {
+	switch k {
+	case authSlashCommandLogin:
+		return "login"
+	case authSlashCommandLogout:
+		return "logout"
+	default:
+		return ""
+	}
+}
+
 type slashCommandPickerState struct {
 	visible   bool
 	matches   []commands.Command
@@ -128,7 +158,7 @@ func (m *uiModel) filterSlashCommandMatches(matches []commands.Command) []comman
 		if command.Name == "copy" && !m.hasAssistantFinalAnswerToCopy() {
 			continue
 		}
-		if isAuthSlashCommand(command.Name) && command.Name != m.authSlashCommandName {
+		if isAuthSlashCommand(command.Name) && command.Name != m.authSlashCommand.commandName() {
 			continue
 		}
 		filtered = append(filtered, command)
@@ -150,7 +180,7 @@ func (m *uiModel) requestAuthSlashCommandRefresh() tea.Cmd {
 		return nil
 	}
 	if m.statusConfig.AuthManager == nil {
-		m.authSlashCommandName = "login"
+		m.authSlashCommand = authSlashCommandLogin
 		m.authSlashCommandErr = ""
 		m.authSlashResolved = m.authSlashGeneration
 		m.authSlashLoading = false
@@ -177,12 +207,12 @@ func (m *uiModel) applyAuthSlashCommandRefreshed(msg authSlashCommandRefreshedMs
 	m.authSlashLoading = false
 	m.authSlashResolved = msg.generation
 	if msg.err != nil {
-		m.authSlashCommandName = ""
+		m.authSlashCommand = authSlashCommandUnknown
 		m.authSlashCommandErr = msg.err.Error()
 		m.clampSlashCommandSelection()
 		return
 	}
-	m.authSlashCommandName = strings.TrimSpace(msg.name)
+	m.authSlashCommand = authSlashCommandFromName(msg.name)
 	m.authSlashCommandErr = ""
 	m.clampSlashCommandSelection()
 }

--- a/cli/app/ui_slash_command_picker_test.go
+++ b/cli/app/ui_slash_command_picker_test.go
@@ -619,8 +619,8 @@ func TestSlashCommandPickerTypingSlashDefersAuthLoadToCommand(t *testing.T) {
 	}
 }
 
-func TestSlashCommandPickerDroppedAuthRefreshCanBeRescheduled(t *testing.T) {
-	manager := auth.NewManager(auth.NewMemoryStore(auth.State{
+func TestSlashCommandPickerAuthRefreshSingleFlightsAfterScheduledCommand(t *testing.T) {
+	store := &countingAuthStore{state: auth.State{
 		Scope: auth.ScopeGlobal,
 		Method: auth.Method{
 			Type: auth.MethodOAuth,
@@ -629,21 +629,35 @@ func TestSlashCommandPickerDroppedAuthRefreshCanBeRescheduled(t *testing.T) {
 				TokenType:   "Bearer",
 			},
 		},
-	}), nil, nil)
+	}}
+	manager := auth.NewManager(store, nil, nil)
 	m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{AuthManager: manager}))
 	m.replaceMainInput("/", -1)
-	droppedCmd := m.refreshSlashCommandFilterFromInput()
-	if droppedCmd == nil {
-		t.Fatal("expected first auth slash refresh command")
+	if m.authSlashLoading {
+		t.Fatal("replaceMainInput must not mark an unscheduled auth refresh in flight")
 	}
 
 	cmd := m.refreshSlashCommandFilterFromInput()
 	if cmd == nil {
-		t.Fatal("expected dropped auth slash refresh to be rescheduled")
+		t.Fatal("expected auth slash refresh command after state-only input replacement")
+	}
+	if !m.authSlashLoading {
+		t.Fatal("expected scheduled auth slash refresh to be marked loading")
+	}
+	m.input = "/lo"
+	secondCmd := m.refreshSlashCommandFilterFromInput()
+	if secondCmd != nil {
+		t.Fatal("did not expect concurrent auth slash refresh while first is loading")
+	}
+	if store.loads != 0 {
+		t.Fatalf("expected no auth load before command executes, got %d", store.loads)
 	}
 	for _, msg := range collectCmdMessages(t, cmd) {
 		next, _ := m.Update(msg)
 		m = next.(*uiModel)
+	}
+	if store.loads != 1 {
+		t.Fatalf("expected one auth load after command executes, got %d", store.loads)
 	}
 	if state := m.slashCommandPicker(); !slashPickerContainsCommand(state, "logout") {
 		t.Fatalf("expected /logout after rescheduled auth refresh, got %+v", slashPickerCommandNames(state))

--- a/cli/app/ui_slash_command_picker_test.go
+++ b/cli/app/ui_slash_command_picker_test.go
@@ -16,6 +16,15 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+func refreshSlashCommandFilterForTest(t *testing.T, m *uiModel) {
+	t.Helper()
+	cmd := m.refreshSlashCommandFilterFromInput()
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ := m.Update(msg)
+		m = next.(*uiModel)
+	}
+}
+
 func TestSlashCommandEnterIgnoresWhitespaceImmediatelyAfterSlash(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.sessionName = "existing"
@@ -110,7 +119,7 @@ func TestSlashCommandPickerHighlightTracksFilteredVisibleCommands(t *testing.T) 
 			opts := append([]UIOption{WithUIHasOtherSessions(true, false)}, tc.opts...)
 			m := newProjectedStaticUIModel(opts...)
 			m.input = "/"
-			m.refreshSlashCommandFilterFromInput()
+			refreshSlashCommandFilterForTest(t, m)
 
 			state := m.slashCommandPicker()
 			for _, hidden := range tc.hidden {
@@ -260,6 +269,10 @@ func TestBusyEnterRunsExactFastCommandEvenWhenPickerHidesIt(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected transient status command for busy /fast")
 	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
 	if len(updated.queued) != 0 {
 		t.Fatalf("expected no queued messages, got %+v", updated.queued)
 	}
@@ -316,7 +329,7 @@ func TestBusyTabBackWithoutParentShowsLocalErrorAndDoesNotQueue(t *testing.T) {
 func TestSlashCommandPickerHidesResumeWithoutOtherSessions(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUIHasOtherSessions(true, false))
 	m.input = "/re"
-	m.refreshSlashCommandFilterFromInput()
+	refreshSlashCommandFilterForTest(t, m)
 
 	state := m.slashCommandPicker()
 	if slashPickerContainsCommand(state, "resume") {
@@ -327,7 +340,7 @@ func TestSlashCommandPickerHidesResumeWithoutOtherSessions(t *testing.T) {
 func TestSlashCommandPickerShowsResumeWhenOtherSessionAvailabilityIsUnknown(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUIHasOtherSessions(false, false))
 	m.input = "/re"
-	m.refreshSlashCommandFilterFromInput()
+	refreshSlashCommandFilterForTest(t, m)
 
 	state := m.slashCommandPicker()
 	if !slashPickerContainsCommand(state, "resume") {
@@ -394,7 +407,7 @@ func TestSlashCommandPickerShowsLoginWhenAuthIsMissingOrAPIKey(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{AuthManager: tc.manager}))
 			m.input = "/"
-			m.refreshSlashCommandFilterFromInput()
+			refreshSlashCommandFilterForTest(t, m)
 
 			state := m.slashCommandPicker()
 			if !slashPickerContainsCommand(state, "login") {
@@ -469,7 +482,7 @@ func TestSlashCommandPickerShowsLogoutForOAuthAuth(t *testing.T) {
 	}), nil, nil)
 	m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{AuthManager: manager}))
 	m.input = "/"
-	m.refreshSlashCommandFilterFromInput()
+	refreshSlashCommandFilterForTest(t, m)
 
 	state := m.slashCommandPicker()
 	if !slashPickerContainsCommand(state, "logout") {
@@ -484,7 +497,7 @@ func TestSlashCommandPickerHidesAuthCommandsWhenAuthStateCannotLoad(t *testing.T
 	manager := auth.NewManager(errorAuthStore{err: errors.New("permission denied")}, nil, nil)
 	m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{AuthManager: manager}))
 	m.input = "/"
-	m.refreshSlashCommandFilterFromInput()
+	refreshSlashCommandFilterForTest(t, m)
 
 	state := m.slashCommandPicker()
 	if slashPickerContainsCommand(state, "login") || slashPickerContainsCommand(state, "logout") {
@@ -520,7 +533,7 @@ func TestSlashCommandPickerRefreshesAuthStateAfterModelInit(t *testing.T) {
 	}
 
 	m.input = "/"
-	m.refreshSlashCommandFilterFromInput()
+	refreshSlashCommandFilterForTest(t, m)
 	state := m.slashCommandPicker()
 	if !slashPickerContainsCommand(state, "logout") {
 		t.Fatalf("expected refreshed /logout in slash picker, got %+v", slashPickerCommandNames(state))
@@ -547,7 +560,7 @@ func TestSlashCommandPickerLoadsAuthStateOncePerSlashSession(t *testing.T) {
 
 	for _, input := range []string{"/", "/l", "/lo"} {
 		m.input = input
-		m.refreshSlashCommandFilterFromInput()
+		refreshSlashCommandFilterForTest(t, m)
 	}
 	if got := store.loads - loadsAfterInit; got != 1 {
 		t.Fatalf("expected one auth load while editing one slash session, got %d", got)
@@ -556,9 +569,44 @@ func TestSlashCommandPickerLoadsAuthStateOncePerSlashSession(t *testing.T) {
 	m.input = "ordinary prompt"
 	m.refreshSlashCommandFilterFromInput()
 	m.input = "/"
-	m.refreshSlashCommandFilterFromInput()
+	refreshSlashCommandFilterForTest(t, m)
 	if got := store.loads - loadsAfterInit; got != 2 {
 		t.Fatalf("expected auth load after starting a new slash session, got %d", got)
+	}
+}
+
+func TestSlashCommandPickerTypingSlashDefersAuthLoadToCommand(t *testing.T) {
+	store := &countingAuthStore{state: auth.State{
+		Scope: auth.ScopeGlobal,
+		Method: auth.Method{
+			Type: auth.MethodOAuth,
+			OAuth: &auth.OAuthMethod{
+				AccessToken: "access-token",
+				TokenType:   "Bearer",
+			},
+		},
+	}}
+	manager := auth.NewManager(store, nil, nil)
+	m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{AuthManager: manager}))
+	loadsAfterInit := store.loads
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected auth slash refresh command")
+	}
+	if got := store.loads - loadsAfterInit; got != 0 {
+		t.Fatalf("expected no auth load during Update, got %d", got)
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
+	if got := store.loads - loadsAfterInit; got != 1 {
+		t.Fatalf("expected auth load after command executes, got %d", got)
+	}
+	if state := updated.slashCommandPicker(); !slashPickerContainsCommand(state, "logout") {
+		t.Fatalf("expected /logout after async auth refresh, got %+v", slashPickerCommandNames(state))
 	}
 }
 

--- a/cli/app/ui_slash_command_picker_test.go
+++ b/cli/app/ui_slash_command_picker_test.go
@@ -413,6 +413,9 @@ func TestSlashCommandPickerShowsLoginWhenAuthIsMissingOrAPIKey(t *testing.T) {
 			if !slashPickerContainsCommand(state, "login") {
 				t.Fatalf("expected /login in slash picker, got %+v", slashPickerCommandNames(state))
 			}
+			if m.authSlashCommand != authSlashCommandLogin {
+				t.Fatalf("expected typed auth slash command login, got %v", m.authSlashCommand)
+			}
 			if slashPickerContainsCommand(state, "logout") {
 				t.Fatalf("did not expect /logout in slash picker, got %+v", slashPickerCommandNames(state))
 			}
@@ -488,6 +491,9 @@ func TestSlashCommandPickerShowsLogoutForOAuthAuth(t *testing.T) {
 	if !slashPickerContainsCommand(state, "logout") {
 		t.Fatalf("expected /logout in slash picker, got %+v", slashPickerCommandNames(state))
 	}
+	if m.authSlashCommand != authSlashCommandLogout {
+		t.Fatalf("expected typed auth slash command logout, got %v", m.authSlashCommand)
+	}
 	if slashPickerContainsCommand(state, "login") {
 		t.Fatalf("did not expect /login in slash picker, got %+v", slashPickerCommandNames(state))
 	}
@@ -505,6 +511,9 @@ func TestSlashCommandPickerHidesAuthCommandsWhenAuthStateCannotLoad(t *testing.T
 	}
 	if m.authSlashCommandErr == "" {
 		t.Fatal("expected auth slash command error to be recorded")
+	}
+	if m.authSlashCommand != authSlashCommandUnknown {
+		t.Fatalf("expected typed auth slash command unknown on load error, got %v", m.authSlashCommand)
 	}
 }
 

--- a/cli/app/ui_slash_command_picker_test.go
+++ b/cli/app/ui_slash_command_picker_test.go
@@ -619,6 +619,37 @@ func TestSlashCommandPickerTypingSlashDefersAuthLoadToCommand(t *testing.T) {
 	}
 }
 
+func TestSlashCommandPickerDroppedAuthRefreshCanBeRescheduled(t *testing.T) {
+	manager := auth.NewManager(auth.NewMemoryStore(auth.State{
+		Scope: auth.ScopeGlobal,
+		Method: auth.Method{
+			Type: auth.MethodOAuth,
+			OAuth: &auth.OAuthMethod{
+				AccessToken: "access-token",
+				TokenType:   "Bearer",
+			},
+		},
+	}), nil, nil)
+	m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{AuthManager: manager}))
+	m.replaceMainInput("/", -1)
+	droppedCmd := m.refreshSlashCommandFilterFromInput()
+	if droppedCmd == nil {
+		t.Fatal("expected first auth slash refresh command")
+	}
+
+	cmd := m.refreshSlashCommandFilterFromInput()
+	if cmd == nil {
+		t.Fatal("expected dropped auth slash refresh to be rescheduled")
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ := m.Update(msg)
+		m = next.(*uiModel)
+	}
+	if state := m.slashCommandPicker(); !slashPickerContainsCommand(state, "logout") {
+		t.Fatalf("expected /logout after rescheduled auth refresh, got %+v", slashPickerCommandNames(state))
+	}
+}
+
 type errorAuthStore struct {
 	err error
 }

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -60,16 +60,22 @@ type uiInputFeatureState struct {
 	reviewerMode             string
 	autoCompactionEnabled    bool
 	conversationFreshness    clientui.ConversationFreshness
+	runtimeControlToken      uint64
+	runtimeControlTokens     map[runtimeControlOperation]uint64
+	runtimeControlPending    map[runtimeControlOperation]runtimeControlPendingState
 
 	// UI-side post-turn input queue. It may contain slash commands, shell
 	// commands, and other client-only actions; server queues only runtime
 	// injected user work.
-	queued           []queuedInputItem
-	compactionOrigin uiCompactionOrigin
-	submitToken      uint64
-	activeSubmit     activeSubmitState
+	queued                                 []queuedInputItem
+	compactionOrigin                       uiCompactionOrigin
+	queuedRuntimeWorkCheckCompactionOrigin uiCompactionOrigin
+	submitToken                            uint64
+	activeSubmit                           activeSubmitState
 
 	pendingInjected    []clientui.QueuedUserMessage
+	injectedQueue      []injectedRuntimeQueueItem
+	injectedQueueToken uint64
 	lockedInjectText   string
 	lockedInjectID     string
 	inputSubmission    runtimestate.InputSubmissionLifecycle
@@ -92,6 +98,10 @@ type uiInputFeatureState struct {
 	authSlashCommandName  string
 	authSlashCommandErr   string
 	authSlashSessionOpen  bool
+	authSlashLoading      bool
+	authSlashToken        uint64
+	authSlashGeneration   uint64
+	authSlashResolved     uint64
 	slashCommandFilter    string
 	slashCommandFilterSet bool
 	slashCommandSelection int
@@ -110,6 +120,7 @@ type uiPresentationFeatureState struct {
 	windowSizeKnown bool
 	helpVisible     bool
 	startupCmds     []tea.Cmd
+	uiMainThread    uiMainThreadState
 }
 
 type uiConversationFeatureState struct {
@@ -140,6 +151,7 @@ type uiStatusFeatureState struct {
 	statusRepository            uiStatusRepository
 	status                      uiStatusOverlayState
 	goal                        uiGoalOverlayState
+	goalRuntimeToken            uint64
 	statusGitBackgroundInFlight bool
 	clipboardImagePaster        uiClipboardImagePaster
 	clipboardTextCopier         uiClipboardTextCopier
@@ -150,36 +162,44 @@ type uiStatusFeatureState struct {
 	transientStatusToken    uint64
 	transientStatusQueue    []uiStatusNotice
 	localNoticeSequence     uint64
+	localEntryEcho          uiLocalEntryEchoState
 	startupUpdateNotice     bool
 	startupUpdateShown      bool
 	debugKeys               bool
 	debugMode               bool
 	transcriptDiagnostics   bool
+	tuiStrictIOMode         tuiStrictIOMode
+	tuiStrictIOModeExplicit bool
 }
 
 type uiTranscriptFeatureState struct {
-	sawAssistantDelta                   bool
-	lastCommittedAssistantStepID        string
-	transcriptEntries                   []tui.TranscriptEntry
-	transcriptBaseOffset                int
-	transcriptTotalEntries              int
-	transcriptRevision                  int64
-	ongoingCommittedDelivery            ongoingCommittedDeliveryCursor
-	deferredCommittedTail               []deferredProjectedTranscriptTail
-	runtimeConnection                   clientui.RuntimeConnectionLifecycle
-	transcriptLiveDirty                 bool
-	reasoningLiveDirty                  bool
-	detailTranscript                    uiDetailTranscriptWindow
-	runtimeMainViewToken                uint64
-	runtimeTranscriptToken              uint64
-	runtimeCommittedSuffixToken         uint64
-	runtimeTranscriptRetry              uint64
-	runtimeTranscriptBusy               bool
-	runtimeTranscriptDirty              bool
-	runtimeTranscriptDirtyRecoveryCause clientui.TranscriptRecoveryCause
-	pendingQueuedDrainAfterHydration    bool
-	queuedDrainReadyAfterHydration      bool
-	waitRuntimeEventAfterHydration      bool
+	sawAssistantDelta                bool
+	lastCommittedAssistantStepID     string
+	transcriptEntries                []tui.TranscriptEntry
+	transcriptBaseOffset             int
+	transcriptTotalEntries           int
+	transcriptRevision               int64
+	ongoingCommittedDelivery         ongoingCommittedDeliveryCursor
+	deferredCommittedTail            []deferredProjectedTranscriptTail
+	runtimeConnection                clientui.RuntimeConnectionLifecycle
+	transcriptLiveDirty              bool
+	reasoningLiveDirty               bool
+	detailTranscript                 uiDetailTranscriptWindow
+	runtimeMainViewToken             uint64
+	runtimeMainViewBusy              bool
+	runtimeMainViewActiveRequest     runtimeMainViewRefreshRequest
+	runtimeMainViewPendingSet        bool
+	runtimeMainViewPending           runtimeMainViewRefreshRequest
+	runtimeTranscriptToken           uint64
+	runtimeCommittedSuffixToken      uint64
+	runtimeTranscriptRetry           uint64
+	runtimeTranscriptBusy            bool
+	runtimeTranscriptActiveRequest   runtimeTranscriptSyncRequest
+	runtimeTranscriptPendingSet      bool
+	runtimeTranscriptPending         runtimeTranscriptSyncRequest
+	pendingQueuedDrainAfterHydration bool
+	queuedDrainReadyAfterHydration   bool
+	waitRuntimeEventAfterHydration   bool
 }
 
 type uiNativeHistoryFeatureState struct {

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -60,6 +60,7 @@ type uiInputFeatureState struct {
 	reviewerMode             string
 	autoCompactionEnabled    bool
 	conversationFreshness    clientui.ConversationFreshness
+	localConversationTurn    bool
 	runtimeControlToken      uint64
 	runtimeControlTokens     map[runtimeControlOperation]uint64
 	runtimeControlPending    map[runtimeControlOperation]runtimeControlPendingState

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -152,6 +152,7 @@ type uiStatusFeatureState struct {
 	status                      uiStatusOverlayState
 	goal                        uiGoalOverlayState
 	goalRuntimeToken            uint64
+	goalRuntimeMutationSerial   uint64
 	goalRuntimePending          goalRuntimePendingState
 	statusGitBackgroundInFlight bool
 	clipboardImagePaster        uiClipboardImagePaster

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -152,6 +152,7 @@ type uiStatusFeatureState struct {
 	status                      uiStatusOverlayState
 	goal                        uiGoalOverlayState
 	goalRuntimeToken            uint64
+	goalRuntimePending          goalRuntimePendingState
 	statusGitBackgroundInFlight bool
 	clipboardImagePaster        uiClipboardImagePaster
 	clipboardTextCopier         uiClipboardTextCopier

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -169,8 +169,6 @@ type uiStatusFeatureState struct {
 	debugKeys               bool
 	debugMode               bool
 	transcriptDiagnostics   bool
-	tuiStrictIOMode         tuiStrictIOMode
-	tuiStrictIOModeExplicit bool
 }
 
 type uiTranscriptFeatureState struct {

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -95,7 +95,7 @@ type uiInputFeatureState struct {
 	commandRegistry       *commands.Registry
 	hasOtherSessions      bool
 	hasOtherSessionsKnown bool
-	authSlashCommandName  string
+	authSlashCommand      authSlashCommandKind
 	authSlashCommandErr   string
 	authSlashSessionOpen  bool
 	authSlashLoading      bool

--- a/cli/app/ui_status.go
+++ b/cli/app/ui_status.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"os"
 	"strings"
 	"time"
 
@@ -152,14 +151,13 @@ func WithUIStatusRepository(repository uiStatusRepository) UIOption {
 
 func (m *uiModel) newStatusRequest(now time.Time) uiStatusRequest {
 	request := uiStatusRequest{
-		Runtime:               m.engine,
 		WorkspaceRoot:         strings.TrimSpace(m.statusConfig.WorkspaceRoot),
 		PersistenceRoot:       strings.TrimSpace(m.statusConfig.PersistenceRoot),
 		ExecutionTarget:       m.statusConfig.ExecutionTarget,
 		SessionViews:          m.statusConfig.SessionViews,
 		Settings:              m.statusConfig.Settings,
 		Source:                m.statusConfig.Source,
-		AuthCacheIdentity:     statusAuthCacheIdentity(m.statusConfig.AuthManager),
+		AuthCacheIdentity:     m.cachedStatusAuthCacheIdentity(),
 		AuthStatus:            m.statusConfig.AuthStatus,
 		AuthStatePath:         strings.TrimSpace(m.statusConfig.AuthStatePath),
 		SessionName:           strings.TrimSpace(m.sessionName),
@@ -176,6 +174,28 @@ func (m *uiModel) newStatusRequest(now time.Time) uiStatusRequest {
 		CurrentTime:           now,
 	}
 	return populateStatusRequestCacheKeys(request)
+}
+
+func (m *uiModel) newStatusCollectorRequest(seed uiStatusRequest) uiStatusRequest {
+	request := seed
+	request.Runtime = m.engine
+	return request
+}
+
+func (m *uiModel) cachedStatusAuthCacheIdentity() string {
+	if m == nil {
+		return "auth:none"
+	}
+	if strings.TrimSpace(m.statusConfig.AuthStatePath) != "" {
+		return "auth:path:" + strings.TrimSpace(m.statusConfig.AuthStatePath)
+	}
+	if m.statusConfig.AuthStatus != nil {
+		return "auth:status-client"
+	}
+	if m.statusConfig.AuthManager != nil {
+		return "auth:configured"
+	}
+	return "auth:none"
 }
 
 func populateStatusRequestCacheKeys(req uiStatusRequest) uiStatusRequest {
@@ -350,26 +370,27 @@ func (m *uiModel) statusRefreshCmd() tea.Cmd {
 		collector = defaultUIStatusCollector{authManager: m.statusConfig.AuthManager}
 	}
 	if progressive, ok := collector.(uiStatusProgressiveCollector); ok {
-		base := progressive.CollectBase(request)
-		seed := uiStatusSeedResult{Snapshot: base}
+		seedBase := defaultUIStatusCollector{}.CollectBase(request)
+		seed := uiStatusSeedResult{Snapshot: seedBase}
 		if m.statusRepository != nil {
-			seed = m.statusRepository.SeedSnapshot(request, base, request.CurrentTime)
+			seed = m.statusRepository.SeedSnapshot(request, seedBase, request.CurrentTime)
 		}
+		collectorRequest := m.newStatusCollectorRequest(request)
 		m.status.snapshot = seed.Snapshot
 		m.status.error = ""
 		m.status.pendingSections = nil
 		m.status.sectionWarnings = seed.Warnings
 		m.startStatusSectionRefresh(append([]uiStatusSection{uiStatusSectionBase}, seed.PendingSections...)...)
 		cmds := make([]tea.Cmd, 0, len(seed.PendingSections)+1)
-		cmds = append(cmds, m.statusBaseRefreshCmd(token, request, base))
+		cmds = append(cmds, m.statusBaseRefreshCmd(token, collectorRequest, progressive))
 		for _, section := range seed.PendingSections {
 			switch section {
 			case uiStatusSectionAuth:
-				cmds = append(cmds, m.statusAuthRefreshCmd(token, request.CacheKeys.Auth, request, progressive, base))
+				cmds = append(cmds, m.statusAuthRefreshCmd(token, request.CacheKeys.Auth, collectorRequest, progressive, seedBase))
 			case uiStatusSectionGit:
-				cmds = append(cmds, m.statusGitRefreshCmd(token, request.CacheKeys.Git, request, progressive, base))
+				cmds = append(cmds, m.statusGitRefreshCmd(token, request.CacheKeys.Git, collectorRequest, progressive, seedBase))
 			case uiStatusSectionEnvironment:
-				cmds = append(cmds, m.statusEnvironmentRefreshCmd(token, request.CacheKeys.Environment, request, progressive, base))
+				cmds = append(cmds, m.statusEnvironmentRefreshCmd(token, request.CacheKeys.Environment, collectorRequest, progressive, seedBase))
 			}
 		}
 		if len(cmds) == 0 {
@@ -379,10 +400,11 @@ func (m *uiModel) statusRefreshCmd() tea.Cmd {
 		}
 		return tea.Batch(cmds...)
 	}
+	collectorRequest := m.newStatusCollectorRequest(request)
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), statusRefreshTimeout)
 		defer cancel()
-		snapshot, err := collector.Collect(ctx, request)
+		snapshot, err := collector.Collect(ctx, collectorRequest)
 		return statusRefreshDoneMsg{token: token, snapshot: snapshot, err: err}
 	}
 }
@@ -403,22 +425,21 @@ func (m *uiModel) statusLineGitRefreshCmd() tea.Cmd {
 	if !ok {
 		progressive = defaultUIStatusCollector{authManager: m.statusConfig.AuthManager}
 	}
-	base := progressive.CollectBase(request)
 	gitRoot := statusGitRoot(request)
-	if trimmedGitRoot := strings.TrimSpace(gitRoot); trimmedGitRoot == "" {
-		return nil
-	} else if info, err := os.Stat(trimmedGitRoot); err != nil || !info.IsDir() {
+	if strings.TrimSpace(gitRoot) == "" {
 		return nil
 	}
+	base := defaultUIStatusCollector{}.CollectBase(request)
 	cacheKey := statusGitCacheKey(gitRoot)
 	m.statusGitBackgroundInFlight = true
-	return m.statusGitRefreshCmd(token, cacheKey, request, progressive, base, true)
+	return m.statusGitRefreshCmd(token, cacheKey, m.newStatusCollectorRequest(request), progressive, base, true)
 }
 
-func (m *uiModel) statusBaseRefreshCmd(token uint64, request uiStatusRequest, base uiStatusSnapshot) tea.Cmd {
+func (m *uiModel) statusBaseRefreshCmd(token uint64, request uiStatusRequest, collector uiStatusProgressiveCollector) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), statusRefreshTimeout)
 		defer cancel()
+		base := collector.CollectBase(request)
 		return statusBaseRefreshDoneMsg{token: token, snapshot: enrichStatusBaseSnapshot(ctx, request, base)}
 	}
 }
@@ -473,8 +494,7 @@ func (c uiInputController) handleStatusOverlayKey(msg tea.KeyMsg) (tea.Model, te
 	switch strings.ToLower(msg.String()) {
 	case "ctrl+c":
 		if m.isBusy() {
-			c.interruptBusyRuntime()
-			return m, nil
+			return m, c.interruptBusyRuntime()
 		}
 		m.exitAction = UIActionExit
 		if overlayCmd := m.popStatusOverlayIfNeeded(); overlayCmd != nil {

--- a/cli/app/ui_status.go
+++ b/cli/app/ui_status.go
@@ -158,6 +158,7 @@ func (m *uiModel) newStatusRequest(now time.Time) uiStatusRequest {
 		Settings:              m.statusConfig.Settings,
 		Source:                m.statusConfig.Source,
 		AuthCacheIdentity:     m.cachedStatusAuthCacheIdentity(),
+		AuthCacheUnseedable:   m.statusAuthCacheUnseedable(),
 		AuthStatus:            m.statusConfig.AuthStatus,
 		AuthStatePath:         strings.TrimSpace(m.statusConfig.AuthStatePath),
 		SessionName:           strings.TrimSpace(m.sessionName),
@@ -196,6 +197,13 @@ func (m *uiModel) cachedStatusAuthCacheIdentity() string {
 		return "auth:configured"
 	}
 	return "auth:none"
+}
+
+func (m *uiModel) statusAuthCacheUnseedable() bool {
+	if m == nil {
+		return false
+	}
+	return strings.TrimSpace(m.statusConfig.AuthStatePath) != ""
 }
 
 func populateStatusRequestCacheKeys(req uiStatusRequest) uiStatusRequest {

--- a/cli/app/ui_status_part2_test.go
+++ b/cli/app/ui_status_part2_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"builder/cli/app/internal/statuscollect"
+	"builder/server/auth"
 	"builder/server/sessionview"
 	"builder/shared/client"
 	"builder/shared/clientui"
@@ -177,6 +178,43 @@ func TestStatusRefreshCmdSchedulesBaseEnrichmentForProgressiveCollector(t *testi
 	if baseMsg.snapshot.ParentSessionName != "incident-root" {
 		t.Fatalf("parent session name = %q, want incident-root", baseMsg.snapshot.ParentSessionName)
 	}
+}
+
+func TestStatusRefreshDefersRuntimeAndAuthReadsToCommands(t *testing.T) {
+	store := &countingAuthStore{}
+	manager := auth.NewManager(store, nil, nil)
+	runtimeClient := &statusRefreshRuntimeClient{}
+	m := newProjectedStaticUIModel(WithUIStatusConfig(uiStatusConfig{AuthManager: manager}))
+	m.engine = runtimeClient
+
+	cmd := m.statusRefreshCmd()
+	if cmd == nil {
+		t.Fatal("expected status refresh command")
+	}
+	if runtimeClient.statusCalls != 0 {
+		t.Fatalf("expected no runtime status read before command executes, got %d", runtimeClient.statusCalls)
+	}
+	if store.loads != 0 {
+		t.Fatalf("expected no auth load before command executes, got %d", store.loads)
+	}
+
+	_ = collectCmdMessages(t, cmd)
+	if runtimeClient.statusCalls == 0 {
+		t.Fatal("expected runtime status read after command executes")
+	}
+	if store.loads == 0 {
+		t.Fatal("expected auth load after command executes")
+	}
+}
+
+type statusRefreshRuntimeClient struct {
+	runtimeControlFakeClient
+	statusCalls int
+}
+
+func (c *statusRefreshRuntimeClient) Status() clientui.RuntimeStatus {
+	c.statusCalls++
+	return clientui.RuntimeStatus{ParentSessionID: "parent-session"}
 }
 
 func TestStatusVisibleAuthSummarySuppressesGenericSubscriptionWhenPlanPresent(t *testing.T) {

--- a/cli/app/ui_status_test.go
+++ b/cli/app/ui_status_test.go
@@ -323,13 +323,19 @@ func TestStatusCommandProgressivelyLoadsSections(t *testing.T) {
 	m.windowSizeKnown = true
 	m.input = "/status"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected progressive status command")
+	}
 	plain := stripANSIAndTrimRight(updated.View())
-	for _, want := range []string{"Loading account...", "CWD: /tmp/workdir", "Model: gpt-5 high fast", "Loading git..."} {
+	for _, want := range []string{"Loading account...", "CWD: /tmp/workdir", "Model: <unset>", "Loading git..."} {
 		if !strings.Contains(plain, want) {
-			t.Fatalf("expected progressive base render to contain %q, got %q", want, plain)
+			t.Fatalf("expected pure status seed render to contain %q, got %q", want, plain)
 		}
+	}
+	if strings.Contains(plain, "gpt-5 high fast") {
+		t.Fatalf("did not expect custom collector base before command completion, got %q", plain)
 	}
 
 	next, _ = updated.Update(statusGitRefreshDoneMsg{token: updated.status.refreshToken, result: collector.gitResult})
@@ -339,6 +345,12 @@ func TestStatusCommandProgressivelyLoadsSections(t *testing.T) {
 		t.Fatalf("expected parallel git render before base snapshot, got %q", plain)
 	}
 
+	next, _ = updated.Update(statusBaseRefreshDoneMsg{token: updated.status.refreshToken, snapshot: collector.base})
+	updated = next.(*uiModel)
+	plain = stripANSIAndTrimRight(updated.View())
+	if !strings.Contains(plain, "Model: gpt-5 high fast") {
+		t.Fatalf("expected custom base snapshot after base completion, got %q", plain)
+	}
 }
 
 func TestStatusCommandRunsForegroundGitRefreshWhileStartupGitInFlight(t *testing.T) {

--- a/cli/app/ui_status_test.go
+++ b/cli/app/ui_status_test.go
@@ -645,6 +645,42 @@ func TestStatusRepositorySeparatesOpaqueOAuthCacheByTokenFingerprint(t *testing.
 	}
 }
 
+func TestStatusRepositoryDoesNotSeedPathBackedAuthCache(t *testing.T) {
+	repo := newMemoryUIStatusRepository()
+	req := newStatusRequestForTest(withStatusWorkspaceRoot("/tmp/workdir"))
+	req.AuthCacheIdentity = "auth:path:/tmp/builder-auth.json"
+	req.AuthCacheUnseedable = true
+	req.CacheKeys.Auth = statusAuthCacheKey(req)
+	base := uiStatusSnapshot{Workdir: "/tmp/workdir"}
+
+	repo.StoreAuth(req.CacheKeys.Auth, uiStatusAuthStageResult{
+		Auth:         uiStatusAuthInfo{Summary: "previous@example.com"},
+		Subscription: uiStatusSubscriptionInfo{Applicable: true, Summary: "Previous subscription"},
+	}, time.Now())
+
+	seed := repo.SeedSnapshot(req, base, time.Now())
+	if got := seed.Snapshot.Auth.Summary; got != "" {
+		t.Fatalf("expected path-backed auth cache not to seed stale auth, got %q", got)
+	}
+	if got := seed.Snapshot.Subscription.Summary; got != "" {
+		t.Fatalf("expected path-backed auth cache not to seed stale subscription, got %q", got)
+	}
+	if len(seed.PendingSections) == 0 || seed.PendingSections[0] != uiStatusSectionAuth {
+		t.Fatalf("expected auth refresh pending for unseedable auth cache, got %+v", seed.PendingSections)
+	}
+}
+
+func TestStatusRequestMarksAuthStatePathCacheUnseedable(t *testing.T) {
+	m := newProjectedStaticUIModel(
+		WithUIStatusConfig(uiStatusConfig{WorkspaceRoot: "/tmp/workdir", AuthStatePath: "/tmp/builder-auth.json"}),
+	)
+
+	req := m.newStatusRequest(time.Now())
+	if !req.AuthCacheUnseedable {
+		t.Fatal("expected auth-state-path status request to disable auth cache seeding")
+	}
+}
+
 func TestStatusRepositoryStoresAuthUnderCapturedIdentityKey(t *testing.T) {
 	store := auth.NewMemoryStore(auth.State{
 		Method: auth.Method{Type: auth.MethodOAuth, OAuth: &auth.OAuthMethod{AccessToken: "token-a", AccountID: "acct-a", Email: "a@example.com"}},

--- a/cli/app/ui_test.go
+++ b/cli/app/ui_test.go
@@ -603,8 +603,20 @@ func TestApprovalAskUsesSingleDenyOptionAndTabCommentary(t *testing.T) {
 
 	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("blocked by policy")})
 	updated = next.(*uiModel)
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected approval commentary queue command")
+	}
+	select {
+	case <-reply:
+		t.Fatal("did not expect approval answer before commentary queue command completes")
+	default:
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, cmd = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
 
 	resp := <-reply
 	if resp.response.Approval == nil {

--- a/cli/app/ui_transcript_event_apply.go
+++ b/cli/app/ui_transcript_event_apply.go
@@ -11,6 +11,9 @@ import (
 
 func (a uiRuntimeAdapter) applyProjectedTranscriptEntries(evt clientui.Event, flushNativeHistory bool) (tea.Cmd, bool, bool) {
 	m := a.model
+	if len(evt.TranscriptEntries) == 0 {
+		return nil, false, false
+	}
 	incomingCount := len(evt.TranscriptEntries)
 	reduction := reduceProjectedTranscriptEvent(newProjectedTranscriptEventState(projectedTranscriptEventSnapshotFromModel(m)), evt)
 	if reduction.decision == projectedTranscriptDecisionSkip && reduction.duplicateToolStarts {
@@ -144,6 +147,22 @@ func (a uiRuntimeAdapter) applyProjectedTranscriptEntries(evt clientui.Event, fl
 	return m.syncNativeHistoryFromTranscript(), true, false
 }
 
+func (m *uiModel) suppressLocalEntryEchoesInEvent(evt clientui.Event) clientui.Event {
+	if m == nil || evt.Kind != clientui.EventLocalEntryAdded || len(evt.TranscriptEntries) == 0 {
+		return evt
+	}
+	filtered := evt.TranscriptEntries[:0]
+	for _, entry := range evt.TranscriptEntries {
+		if m.shouldSuppressLocalEntryEcho(entry.NoticeID) {
+			m.clearMirroredTransientStatusByNoticeID(entry.NoticeID)
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	evt.TranscriptEntries = filtered
+	return evt
+}
+
 func (m *uiModel) clearMirroredTransientStatus(entries []tui.TranscriptEntry) {
 	if m == nil || m.transientStatusNoticeID == "" {
 		return
@@ -157,6 +176,18 @@ func (m *uiModel) clearMirroredTransientStatus(entries []tui.TranscriptEntry) {
 		m.transientStatusNoticeID = ""
 		return
 	}
+}
+
+func (m *uiModel) clearMirroredTransientStatusByNoticeID(noticeID string) {
+	if m == nil || m.transientStatusNoticeID == "" || noticeID == "" {
+		return
+	}
+	if noticeID != m.transientStatusNoticeID {
+		return
+	}
+	m.transientStatus = ""
+	m.transientStatusKind = uiStatusNoticeNeutral
+	m.transientStatusNoticeID = ""
 }
 
 func (m *uiModel) observeDirectCommittedEventDelivery(evt clientui.Event) {

--- a/cli/app/ui_transcript_page_apply.go
+++ b/cli/app/ui_transcript_page_apply.go
@@ -112,6 +112,7 @@ func (a uiRuntimeAdapter) applyRuntimeTranscriptPageWithRecovery(req clientui.Tr
 		m.sessionName = strings.TrimSpace(page.SessionName)
 	}
 	m.conversationFreshness = page.ConversationFreshness
+	m.acknowledgeLocalEntryEchoesInChatEntries(page.Entries)
 	reduction := reduceRuntimeTranscriptPage(newRuntimeTranscriptPageState(runtimeTranscriptPageSnapshotFromModel(m)), req, page, recoveryCause)
 	pageReq := reduction.request
 	page = reduction.page

--- a/cli/app/ui_transcript_sync_policy_test.go
+++ b/cli/app/ui_transcript_sync_policy_test.go
@@ -1,0 +1,434 @@
+package app
+
+import (
+	"testing"
+
+	"builder/cli/tui"
+	"builder/shared/clientui"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestRuntimeSyncPolicyDefersRoutineCommittedUpdateWhileStreaming(t *testing.T) {
+	client := &runtimeControlFakeClient{
+		transcript: clientui.TranscriptPage{
+			SessionID:    "session-1",
+			Revision:     3,
+			TotalEntries: 2,
+			Entries: []clientui.ChatEntry{
+				{Role: "assistant", Text: "seed"},
+				{Role: "assistant", Text: "authoritative"},
+			},
+		},
+	}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.setBusy(true)
+	m.sawAssistantDelta = true
+	m.forwardToView(tui.StreamAssistantMsg{Delta: "live assistant"})
+
+	next, cmd := m.Update(runtimeEventBatchMsg{events: []clientui.Event{{
+		Kind:                       clientui.EventConversationUpdated,
+		CommittedTranscriptChanged: true,
+		TranscriptRevision:         4,
+		CommittedEntryCount:        3,
+	}}})
+	updated := next.(*uiModel)
+	msgs := collectCmdMessages(t, cmd)
+
+	assertNoRuntimeTranscriptRefreshMsg(t, msgs)
+	if client.refreshTranscriptCalls != 0 || client.loadTranscriptCalls != 0 {
+		t.Fatalf("transcript page calls = refresh:%d load:%d, want none", client.refreshTranscriptCalls, client.loadTranscriptCalls)
+	}
+	if !updated.runtimeTranscriptPendingSet {
+		t.Fatal("expected routine committed update to be deferred")
+	}
+	if updated.waitRuntimeEventAfterHydration {
+		t.Fatal("deferred routine sync must not arm hydration fence")
+	}
+	if got := updated.view.OngoingStreamingText(); got != "live assistant" {
+		t.Fatalf("live assistant text = %q, want preserved", got)
+	}
+}
+
+func TestRuntimeSyncPolicyReleasesDeferredTranscriptWhenProcessOverlayCloses(t *testing.T) {
+	client := &runtimeControlFakeClient{
+		transcript: clientui.TranscriptPage{
+			SessionID:    "session-1",
+			Revision:     3,
+			TotalEntries: 2,
+			Entries: []clientui.ChatEntry{
+				{Role: "assistant", Text: "seed"},
+				{Role: "assistant", Text: "authoritative"},
+			},
+		},
+	}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.openProcessList()
+
+	cmd := m.runtimeAdapter().handleProjectedRuntimeEvent(clientui.Event{
+		Kind:                       clientui.EventConversationUpdated,
+		CommittedTranscriptChanged: true,
+		TranscriptRevision:         4,
+		CommittedEntryCount:        3,
+	})
+	assertNoRuntimeTranscriptRefreshMsg(t, collectCmdMessages(t, cmd))
+	if !m.runtimeTranscriptPendingSet {
+		t.Fatal("expected routine transcript sync deferred while /ps is open")
+	}
+
+	closeCmd := (uiInputController{model: m}).stopProcessListFlowCmd()
+	msgs := collectCmdMessages(t, closeCmd)
+	if _, ok := findRuntimeTranscriptRefreshMsg(msgs); !ok {
+		t.Fatalf("expected deferred transcript sync to run after /ps close, got %+v", msgs)
+	}
+	if client.refreshTranscriptCalls != 1 {
+		t.Fatalf("refresh transcript calls = %d, want 1", client.refreshTranscriptCalls)
+	}
+}
+
+func TestRuntimeSyncPolicyAllowsRecoveryWhileStreaming(t *testing.T) {
+	client := &runtimeControlFakeClient{
+		transcript: clientui.TranscriptPage{
+			SessionID:    "session-1",
+			Revision:     2,
+			TotalEntries: 1,
+			Entries:      []clientui.ChatEntry{{Role: "assistant", Text: "recovered"}},
+		},
+	}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.setBusy(true)
+	m.sawAssistantDelta = true
+	m.forwardToView(tui.StreamAssistantMsg{Delta: "live assistant"})
+
+	next, cmd := m.Update(runtimeEventBatchMsg{events: []clientui.Event{{
+		Kind:          clientui.EventStreamGap,
+		RecoveryCause: clientui.TranscriptRecoveryCauseStreamGap,
+	}}})
+	updated := next.(*uiModel)
+	msgs := collectCmdMessages(t, cmd)
+	refresh, ok := findRuntimeTranscriptRefreshMsg(msgs)
+	if !ok {
+		t.Fatalf("expected recovery hydrate while streaming, got %+v", msgs)
+	}
+	if refresh.syncCause != runtimeTranscriptSyncCauseContinuityRecovery {
+		t.Fatalf("sync cause = %q, want continuity recovery", refresh.syncCause)
+	}
+	if !updated.waitRuntimeEventAfterHydration {
+		t.Fatal("allowed recovery hydrate should own runtime event hydration fence")
+	}
+}
+
+func TestRuntimeSyncPolicyDropsRoutineTranscriptResponseWhenBlockerAppears(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	client.transcript = clientui.TranscriptPage{
+		SessionID:    "session-1",
+		Revision:     2,
+		TotalEntries: 1,
+		Entries:      []clientui.ChatEntry{{Role: "assistant", Text: "authoritative"}},
+	}
+	cmd := m.requestRuntimeCommittedConversationSync()
+	if cmd == nil {
+		t.Fatal("expected unblocked routine transcript request to start")
+	}
+	msg := cmd().(runtimeTranscriptRefreshedMsg)
+
+	m.setBusy(true)
+	if !m.shouldDeferRuntimeTranscriptSync(m.runtimeTranscriptActiveRequest) {
+		t.Fatalf("test fixture did not block active transcript request: busy=%t class=%d req=%+v", m.isBusy(), m.runtimeTranscriptActiveRequest.class, m.runtimeTranscriptActiveRequest)
+	}
+	if !m.shouldDeferRuntimeTranscriptSync(msg.syncRequest) {
+		t.Fatalf("test fixture did not block response transcript request: busy=%t class=%d req=%+v", m.isBusy(), msg.syncRequest.class, msg.syncRequest)
+	}
+	m.waitRuntimeEventAfterHydration = true
+	next, followCmd := m.Update(msg)
+	updated := next.(*uiModel)
+	_ = collectCmdMessages(t, followCmd)
+
+	if len(updated.transcriptEntries) != 0 {
+		t.Fatalf("dropped routine response should not apply transcript entries, got %+v", updated.transcriptEntries)
+	}
+	if !updated.runtimeTranscriptPendingSet {
+		t.Fatal("expected dropped routine response to become pending")
+	}
+	if updated.waitRuntimeEventAfterHydration {
+		t.Fatal("blocked routine drop should release hydration fence when no allowed hydrate owns it")
+	}
+}
+
+func TestRuntimeSyncPolicyDefersAndReleasesMainViewRefresh(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	client.mainView = clientui.RuntimeMainView{
+		Session: clientui.RuntimeSessionView{SessionID: "session-1", SessionName: "server-name"},
+	}
+	m.setBusy(true)
+
+	if cmd := m.requestRuntimeMainViewRefresh(); cmd != nil {
+		t.Fatalf("expected main-view refresh deferred while streaming/busy, got %T", cmd)
+	}
+	if client.refreshMainViewCalls != 0 {
+		t.Fatalf("RefreshMainView calls = %d, want none while blocked", client.refreshMainViewCalls)
+	}
+	if !m.runtimeMainViewPendingSet {
+		t.Fatal("expected pending main-view refresh")
+	}
+
+	m.setBusy(false)
+	msgs := collectCmdMessages(t, m.releaseDeferredRuntimeSyncs())
+	refresh, ok := findRuntimeMainViewRefreshMsg(msgs)
+	if !ok {
+		t.Fatalf("expected deferred main-view refresh to run, got %+v", msgs)
+	}
+	next, _ := m.Update(refresh)
+	updated := next.(*uiModel)
+	if client.refreshMainViewCalls != 1 {
+		t.Fatalf("RefreshMainView calls = %d, want 1", client.refreshMainViewCalls)
+	}
+	if updated.sessionName != "server-name" {
+		t.Fatalf("session name = %q, want server-name", updated.sessionName)
+	}
+}
+
+func TestRuntimeSyncPolicyDropsRoutineMainViewResponseWhenBlockerAppears(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	client.mainView = clientui.RuntimeMainView{
+		Session: clientui.RuntimeSessionView{SessionID: "session-1", SessionName: "server-name"},
+	}
+	cmd := m.requestRuntimeMainViewRefresh()
+	if cmd == nil {
+		t.Fatal("expected unblocked main-view refresh to start")
+	}
+	msg := cmd().(runtimeMainViewRefreshedMsg)
+
+	m.setBusy(true)
+	if !m.shouldDeferRuntimeMainViewRefresh(m.runtimeMainViewActiveRequest) {
+		t.Fatalf("test fixture did not block active main-view request: busy=%t class=%d req=%+v", m.isBusy(), m.runtimeMainViewActiveRequest.class, m.runtimeMainViewActiveRequest)
+	}
+	next, followCmd := m.Update(msg)
+	updated := next.(*uiModel)
+	_ = collectCmdMessages(t, followCmd)
+
+	if updated.sessionName == "server-name" {
+		t.Fatal("blocked routine main-view response should not apply session metadata")
+	}
+	if !updated.runtimeMainViewPendingSet {
+		t.Fatal("expected dropped main-view response to become pending")
+	}
+}
+
+func TestRuntimeSyncPolicyQueuedDrainSurvivesRecoveryCoalescing(t *testing.T) {
+	client := &runtimeControlFakeClient{
+		transcript: clientui.TranscriptPage{
+			SessionID:    "session-1",
+			Revision:     2,
+			TotalEntries: 1,
+			Entries:      []clientui.ChatEntry{{Role: "assistant", Text: "recovered"}},
+		},
+	}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.runtimeTranscriptBusy = true
+	m.runtimeTranscriptToken = 7
+	m.pendingQueuedDrainAfterHydration = true
+
+	if cmd := m.requestRuntimeQueuedDrainTranscriptSync(); cmd != nil {
+		t.Fatalf("expected queued-drain request to wait behind busy hydration, got %T", cmd)
+	}
+	if got := m.runtimeTranscriptPending.syncCause; got != runtimeTranscriptSyncCauseQueuedDrain {
+		t.Fatalf("pending sync after queued drain = %q, want queued_drain", got)
+	}
+	if cmd := m.requestRuntimeTranscriptSyncForContinuityLoss(clientui.TranscriptRecoveryCauseStreamGap); cmd != nil {
+		t.Fatalf("expected recovery request to wait behind busy hydration, got %T", cmd)
+	}
+	if got := m.runtimeTranscriptPending.syncCause; got != runtimeTranscriptSyncCauseContinuityRecovery {
+		t.Fatalf("pending sync after recovery = %q, want continuity_recovery", got)
+	}
+
+	next, followCmd := m.Update(runtimeTranscriptRefreshedMsg{
+		token:      7,
+		transcript: clientui.TranscriptPage{SessionID: "session-1", Revision: 1},
+	})
+	m = next.(*uiModel)
+	msgs := collectCmdMessages(t, followCmd)
+	recoveryMsg, ok := findRuntimeTranscriptRefreshMsg(msgs)
+	if !ok {
+		t.Fatalf("expected coalesced recovery hydrate to start, got %+v", msgs)
+	}
+	if recoveryMsg.syncCause != runtimeTranscriptSyncCauseContinuityRecovery {
+		t.Fatalf("coalesced sync cause = %q, want continuity recovery", recoveryMsg.syncCause)
+	}
+	if !m.pendingQueuedDrainAfterHydration || m.queuedDrainReadyAfterHydration {
+		t.Fatalf("queued drain should remain armed but not ready before coalesced recovery completes: pending=%t ready=%t", m.pendingQueuedDrainAfterHydration, m.queuedDrainReadyAfterHydration)
+	}
+
+	next, finalCmd := m.Update(recoveryMsg)
+	m = next.(*uiModel)
+	_ = collectCmdMessages(t, finalCmd)
+	if m.pendingQueuedDrainAfterHydration || m.queuedDrainReadyAfterHydration {
+		t.Fatalf("expected successful coalesced recovery to release queued-drain state, pending=%t ready=%t", m.pendingQueuedDrainAfterHydration, m.queuedDrainReadyAfterHydration)
+	}
+}
+
+func TestStartupUpdateNoticeUsesMainViewPolicyWhenUnchecked(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	client.mainView = clientui.RuntimeMainView{
+		Status: clientui.RuntimeStatus{
+			Update: clientui.UpdateStatus{Available: true, LatestVersion: "v9.9.9"},
+		},
+		Session: clientui.RuntimeSessionView{SessionID: "session-1"},
+	}
+
+	cmd := m.startupUpdateNoticeCmd(clientui.UpdateStatus{})
+	msgs := collectCmdMessages(t, cmd)
+	refresh, ok := findRuntimeMainViewRefreshMsg(msgs)
+	if !ok {
+		t.Fatalf("expected unchecked startup update status to refresh through main-view policy, got %+v", msgs)
+	}
+	if client.refreshMainViewCalls != 1 {
+		t.Fatalf("RefreshMainView calls = %d, want 1", client.refreshMainViewCalls)
+	}
+	next, followCmd := m.Update(refresh)
+	updated := next.(*uiModel)
+	notice, ok := findStartupUpdateNoticeMsg(collectCmdMessages(t, followCmd))
+	if !ok {
+		t.Fatal("expected startup update notice after policy refresh applies")
+	}
+	if notice.version != "v9.9.9" {
+		t.Fatalf("startup update notice version = %q, want v9.9.9", notice.version)
+	}
+	if updated.runtimeMainViewPendingSet {
+		t.Fatal("did not expect pending main-view refresh after unblocked startup update refresh")
+	}
+}
+
+func TestStartupUpdateNoticeDefersMainViewRefreshWhenBlocked(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	client.mainView = clientui.RuntimeMainView{
+		Status: clientui.RuntimeStatus{
+			Update: clientui.UpdateStatus{Available: true, LatestVersion: "v9.9.9"},
+		},
+		Session: clientui.RuntimeSessionView{SessionID: "session-1"},
+	}
+	m.setBusy(true)
+
+	if cmd := m.startupUpdateNoticeCmd(clientui.UpdateStatus{}); cmd != nil {
+		t.Fatalf("expected blocked startup update refresh to defer, got %T", cmd)
+	}
+	if client.refreshMainViewCalls != 0 {
+		t.Fatalf("RefreshMainView calls while blocked = %d, want none", client.refreshMainViewCalls)
+	}
+	if !m.runtimeMainViewPendingSet {
+		t.Fatal("expected pending startup update main-view refresh while blocked")
+	}
+
+	m.setBusy(false)
+	msgs := collectCmdMessages(t, m.releaseDeferredRuntimeSyncs())
+	refresh, ok := findRuntimeMainViewRefreshMsg(msgs)
+	if !ok {
+		t.Fatalf("expected deferred startup update refresh after blocker clears, got %+v", msgs)
+	}
+	next, followCmd := m.Update(refresh)
+	_ = next.(*uiModel)
+	if _, ok := findStartupUpdateNoticeMsg(collectCmdMessages(t, followCmd)); !ok {
+		t.Fatal("expected startup update notice after deferred policy refresh applies")
+	}
+}
+
+func TestStartupUpdateNoticePendingRefreshSurvivesWorktreeRefreshCoalescing(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	client.mainView = clientui.RuntimeMainView{
+		Status: clientui.RuntimeStatus{
+			Update: clientui.UpdateStatus{Available: true, LatestVersion: "v9.9.9"},
+		},
+		Session: clientui.RuntimeSessionView{SessionID: "session-1"},
+	}
+	m.setBusy(true)
+
+	if cmd := m.startupUpdateNoticeCmd(clientui.UpdateStatus{}); cmd != nil {
+		t.Fatalf("expected blocked startup update refresh to defer, got %T", cmd)
+	}
+	if m.runtimeMainViewPending.cause != runtimeMainViewRefreshCauseStartupUpdate {
+		t.Fatalf("pending main-view cause = %q, want startup_update", m.runtimeMainViewPending.cause)
+	}
+	if cmd := m.requestRuntimeMainViewRefresh(); cmd != nil {
+		t.Fatalf("expected blocked worktree refresh to coalesce, got %T", cmd)
+	}
+	if m.runtimeMainViewPending.cause != runtimeMainViewRefreshCauseStartupUpdate {
+		t.Fatalf("coalesced pending main-view cause = %q, want startup_update", m.runtimeMainViewPending.cause)
+	}
+
+	m.setBusy(false)
+	msgs := collectCmdMessages(t, m.releaseDeferredRuntimeSyncs())
+	refresh, ok := findRuntimeMainViewRefreshMsg(msgs)
+	if !ok {
+		t.Fatalf("expected coalesced startup update refresh after blocker clears, got %+v", msgs)
+	}
+	next, followCmd := m.Update(refresh)
+	_ = next.(*uiModel)
+	if _, ok := findStartupUpdateNoticeMsg(collectCmdMessages(t, followCmd)); !ok {
+		t.Fatal("expected startup update notice after coalesced refresh applies")
+	}
+}
+
+func findRuntimeTranscriptRefreshMsg(msgs []tea.Msg) (runtimeTranscriptRefreshedMsg, bool) {
+	for _, msg := range msgs {
+		if typed, ok := msg.(runtimeTranscriptRefreshedMsg); ok {
+			return typed, true
+		}
+	}
+	return runtimeTranscriptRefreshedMsg{}, false
+}
+
+func assertNoRuntimeTranscriptRefreshMsg(t *testing.T, msgs []tea.Msg) {
+	t.Helper()
+	if refresh, ok := findRuntimeTranscriptRefreshMsg(msgs); ok {
+		t.Fatalf("did not expect transcript refresh msg, got %+v", refresh)
+	}
+}
+
+func runtimeTranscriptRefreshOrReleaseDeferredForTest(t *testing.T, m *uiModel, cmd tea.Cmd) runtimeTranscriptRefreshedMsg {
+	t.Helper()
+	msgs := collectCmdMessages(t, cmd)
+	if refresh, ok := findRuntimeTranscriptRefreshMsg(msgs); ok {
+		return refresh
+	}
+	if !m.runtimeTranscriptPendingSet {
+		t.Fatalf("expected transcript refresh or deferred pending sync, got msgs=%+v", msgs)
+	}
+	m.nativeStreamingActive = false
+	m.nativeStreamingText = ""
+	m.sawAssistantDelta = false
+	refresh, ok := findRuntimeTranscriptRefreshMsg(collectCmdMessages(t, m.releaseDeferredRuntimeSyncs()))
+	if !ok {
+		t.Fatalf("expected deferred transcript refresh after blocker clears")
+	}
+	return refresh
+}
+
+func findRuntimeMainViewRefreshMsg(msgs []tea.Msg) (runtimeMainViewRefreshedMsg, bool) {
+	for _, msg := range msgs {
+		if typed, ok := msg.(runtimeMainViewRefreshedMsg); ok {
+			return typed, true
+		}
+	}
+	return runtimeMainViewRefreshedMsg{}, false
+}
+
+func findStartupUpdateNoticeMsg(msgs []tea.Msg) (startupUpdateNoticeMsg, bool) {
+	for _, msg := range msgs {
+		if typed, ok := msg.(startupUpdateNoticeMsg); ok {
+			return typed, true
+		}
+	}
+	return startupUpdateNoticeMsg{}, false
+}

--- a/cli/app/ui_transcript_sync_recovery_test.go
+++ b/cli/app/ui_transcript_sync_recovery_test.go
@@ -150,10 +150,10 @@ func TestDetailHydrationStillReadsSupervisorTerminalRowsFromSSOT(t *testing.T) {
 		t.Fatalf("mode = %q, want detail", m.view.Mode())
 	}
 
-	// The real workaround is an authoritative detail hydration. The dirty flag
-	// avoids the duplicate-page short-circuit because this repro intentionally
-	// starts from an already-primed detail tail.
-	m.runtimeTranscriptDirty = true
+	// The real workaround is an authoritative detail hydration. The live-dirty
+	// flag avoids the duplicate-page short-circuit because this repro
+	// intentionally starts from an already-primed detail tail.
+	m.transcriptLiveDirty = true
 	next, cmd = m.Update(detailTranscriptLoadMsg{})
 	m = next.(*uiModel)
 	msgs := collectCmdMessages(t, cmd)
@@ -331,11 +331,11 @@ func TestDeferredContinuityRefreshPreservesRecoveryCauseAcrossBusyHydration(t *t
 	if cmd := m.requestRuntimeTranscriptSyncForContinuityLoss(clientui.TranscriptRecoveryCauseStreamGap); cmd != nil {
 		t.Fatalf("expected no command while hydration is already in flight, got %T", cmd)
 	}
-	if !m.runtimeTranscriptDirty {
-		t.Fatal("expected dirty hydrate follow-up after deferred continuity refresh")
+	if !m.runtimeTranscriptPendingSet {
+		t.Fatal("expected pending hydrate follow-up after deferred continuity refresh")
 	}
-	if got := m.runtimeTranscriptDirtyRecoveryCause; got != clientui.TranscriptRecoveryCauseStreamGap {
-		t.Fatalf("dirty recovery cause = %q, want %q", got, clientui.TranscriptRecoveryCauseStreamGap)
+	if got := m.runtimeTranscriptPending.recoveryCause; got != clientui.TranscriptRecoveryCauseStreamGap {
+		t.Fatalf("pending recovery cause = %q, want %q", got, clientui.TranscriptRecoveryCauseStreamGap)
 	}
 
 	next, followCmd := m.Update(runtimeTranscriptRefreshedMsg{token: 7, transcript: clientui.TranscriptPage{SessionID: "session-1"}})
@@ -349,11 +349,11 @@ func TestDeferredContinuityRefreshPreservesRecoveryCauseAcrossBusyHydration(t *t
 	if followMsg.recoveryCause != clientui.TranscriptRecoveryCauseStreamGap {
 		t.Fatalf("follow-up recovery cause = %q, want %q", followMsg.recoveryCause, clientui.TranscriptRecoveryCauseStreamGap)
 	}
-	if followMsg.syncCause != runtimeTranscriptSyncCauseDirtyFollowUp {
-		t.Fatalf("follow-up sync cause = %q, want %q", followMsg.syncCause, runtimeTranscriptSyncCauseDirtyFollowUp)
+	if followMsg.syncCause != runtimeTranscriptSyncCauseContinuityRecovery {
+		t.Fatalf("follow-up sync cause = %q, want %q", followMsg.syncCause, runtimeTranscriptSyncCauseContinuityRecovery)
 	}
 	updated := next.(*uiModel)
-	if updated.runtimeTranscriptDirty {
-		t.Fatal("expected dirty hydrate flag cleared once follow-up request starts")
+	if updated.runtimeTranscriptPendingSet {
+		t.Fatal("expected pending hydrate cleared once follow-up request starts")
 	}
 }

--- a/cli/app/ui_turn_completion_bell_test.go
+++ b/cli/app/ui_turn_completion_bell_test.go
@@ -174,8 +174,9 @@ func TestManualCompactRingsWhenIdleAfterCompaction(t *testing.T) {
 		t.Fatalf("expected compactDoneMsg, got %+v", msgs)
 	}
 
-	next, _ = updated.Update(done)
+	next, cmd = updated.Update(done)
 	updated = next.(*uiModel)
+	updated, _ = applyQueuedRuntimeWorkCheckForTest(t, updated, cmd)
 	if updated.isBusy() || updated.isCompacting() {
 		t.Fatalf("expected idle after manual compaction, busy=%t compacting=%t", updated.isBusy(), updated.isCompacting())
 	}
@@ -220,8 +221,9 @@ func TestQueuedCompactRingsAfterCompactionWhenQueueIsDrained(t *testing.T) {
 		t.Fatalf("expected compactDoneMsg from queued compact, got %+v", msgs)
 	}
 
-	next, _ = updated.Update(done)
+	next, cmd = updated.Update(done)
 	updated = next.(*uiModel)
+	updated, _ = applyQueuedRuntimeWorkCheckForTest(t, updated, cmd)
 	if updated.isBusy() || updated.isCompacting() {
 		t.Fatalf("expected idle after queued compaction, busy=%t compacting=%t", updated.isBusy(), updated.isCompacting())
 	}
@@ -330,13 +332,15 @@ func TestManualCompactWithQueuedSteeringDoesNotRing(t *testing.T) {
 	m.compactionOrigin = uiCompactionOriginManual
 	m.input = "steer after compact"
 
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, createCmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
+	updated = applyFirstInjectedQueueCreateDoneForTest(t, updated, createCmd)
 	if len(updated.pendingInjected) != 1 {
 		t.Fatalf("expected queued steering, got %+v", updated.pendingInjected)
 	}
 	next, cmd := updated.Update(compactDoneMsg{})
 	updated = next.(*uiModel)
+	updated, cmd = applyQueuedRuntimeWorkCheckForTest(t, updated, cmd)
 	if cmd == nil {
 		t.Fatal("expected queued steering to resume after compact")
 	}

--- a/cli/app/ui_window_reducer.go
+++ b/cli/app/ui_window_reducer.go
@@ -112,11 +112,40 @@ func (m *uiModel) requestNativeResizeCommittedTranscriptSuffix(token uint64) tea
 	if !ok {
 		return nil
 	}
-	req := m.startupCommittedTranscriptSuffixRequest()
+	req := m.nativeResizeCommittedTranscriptSuffixRequest()
 	return func() tea.Msg {
 		suffix, err := client.RefreshCommittedTranscriptSuffix(req)
 		return nativeResizeTranscriptSuffixRefreshedMsg{token: token, suffix: suffix, err: err}
 	}
+}
+
+func (m *uiModel) nativeResizeCommittedTranscriptSuffixRequest() clientui.CommittedTranscriptSuffixRequest {
+	committedCount := m.cachedServerCommittedTranscriptEntryCount()
+	limit := clientui.MaxCommittedTranscriptSuffixLimit
+	after := committedCount - limit
+	if after < 0 {
+		after = 0
+	}
+	return clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: after, Limit: limit}
+}
+
+func (m *uiModel) cachedServerCommittedTranscriptEntryCount() int {
+	if m == nil {
+		return 0
+	}
+	committedCount := 0
+	if m.ongoingCommittedDelivery.initialized {
+		committedCount = max(committedCount, m.ongoingCommittedDelivery.lastAppliedCommittedEntryCount)
+		committedCount = max(committedCount, m.ongoingCommittedDelivery.lastEmittedCommittedEntryCount)
+	}
+	if cached, ok := m.runtimeClient().(interface {
+		CachedMainView() (clientui.RuntimeMainView, bool)
+	}); ok {
+		if view, hasCached := cached.CachedMainView(); hasCached {
+			committedCount = max(committedCount, view.Session.Transcript.CommittedEntryCount)
+		}
+	}
+	return committedCount
 }
 
 func (m *uiModel) applyCommittedTranscriptSuffixForNativeReplay(suffix clientui.CommittedTranscriptSuffix) tea.Cmd {

--- a/cli/app/ui_window_reducer.go
+++ b/cli/app/ui_window_reducer.go
@@ -106,21 +106,30 @@ func (m *uiModel) requestNativeResizeCommittedTranscriptSuffix(token uint64) tea
 	if m == nil || !m.hasRuntimeClient() {
 		return nil
 	}
-	client, ok := m.runtimeClient().(interface {
+	runtimeClient := m.runtimeClient()
+	client, ok := runtimeClient.(interface {
 		RefreshCommittedTranscriptSuffix(clientui.CommittedTranscriptSuffixRequest) (clientui.CommittedTranscriptSuffix, error)
 	})
 	if !ok {
 		return nil
 	}
-	req := m.nativeResizeCommittedTranscriptSuffixRequest()
+	committedCount, hasCachedServerCount := m.cachedServerCommittedTranscriptEntryCount()
 	return func() tea.Msg {
+		if !hasCachedServerCount {
+			committedCount = max(committedCount, runtimeClient.MainView().Session.Transcript.CommittedEntryCount)
+		}
+		req := nativeResizeCommittedTranscriptSuffixRequestForCommittedCount(committedCount)
 		suffix, err := client.RefreshCommittedTranscriptSuffix(req)
 		return nativeResizeTranscriptSuffixRefreshedMsg{token: token, suffix: suffix, err: err}
 	}
 }
 
 func (m *uiModel) nativeResizeCommittedTranscriptSuffixRequest() clientui.CommittedTranscriptSuffixRequest {
-	committedCount := m.cachedServerCommittedTranscriptEntryCount()
+	committedCount, _ := m.cachedServerCommittedTranscriptEntryCount()
+	return nativeResizeCommittedTranscriptSuffixRequestForCommittedCount(committedCount)
+}
+
+func nativeResizeCommittedTranscriptSuffixRequestForCommittedCount(committedCount int) clientui.CommittedTranscriptSuffixRequest {
 	limit := clientui.MaxCommittedTranscriptSuffixLimit
 	after := committedCount - limit
 	if after < 0 {
@@ -129,9 +138,9 @@ func (m *uiModel) nativeResizeCommittedTranscriptSuffixRequest() clientui.Commit
 	return clientui.CommittedTranscriptSuffixRequest{AfterEntryCount: after, Limit: limit}
 }
 
-func (m *uiModel) cachedServerCommittedTranscriptEntryCount() int {
+func (m *uiModel) cachedServerCommittedTranscriptEntryCount() (int, bool) {
 	if m == nil {
-		return 0
+		return 0, false
 	}
 	committedCount := 0
 	if m.ongoingCommittedDelivery.initialized {
@@ -143,9 +152,10 @@ func (m *uiModel) cachedServerCommittedTranscriptEntryCount() int {
 	}); ok {
 		if view, hasCached := cached.CachedMainView(); hasCached {
 			committedCount = max(committedCount, view.Session.Transcript.CommittedEntryCount)
+			return committedCount, true
 		}
 	}
-	return committedCount
+	return committedCount, false
 }
 
 func (m *uiModel) applyCommittedTranscriptSuffixForNativeReplay(suffix clientui.CommittedTranscriptSuffix) tea.Cmd {

--- a/cli/app/ui_worktree_commands.go
+++ b/cli/app/ui_worktree_commands.go
@@ -67,8 +67,8 @@ func (m *uiModel) worktreeSwitchCommandForTarget(targetToken, worktreeID string)
 		return nil
 	}
 	service := m.worktreeMutationService()
-	m.worktrees.mutationToken++
-	switchToken := m.worktrees.mutationToken
+	m.worktrees.switchToken++
+	switchToken := m.worktrees.switchToken
 	m.worktrees.switchPending = true
 	targetToken = strings.TrimSpace(targetToken)
 	worktreeID = strings.TrimSpace(worktreeID)

--- a/cli/app/ui_worktree_commands.go
+++ b/cli/app/ui_worktree_commands.go
@@ -5,6 +5,7 @@ import (
 
 	"builder/cli/app/internal/worktreemutation"
 	"builder/cli/app/internal/worktreeview"
+	"builder/shared/clientui"
 	"builder/shared/serverapi"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -53,24 +54,26 @@ func (c uiInputController) handleWorktreeCommand(args string) (tea.Model, tea.Cm
 
 func (c uiInputController) handleWorktreeSwitchCommand(token string) (tea.Model, tea.Cmd) {
 	m := c.model
-	resolved, err := m.resolveWorktreeToken(token)
-	if err != nil {
-		errText := formatSubmissionError(err)
-		return m, c.appendErrorFeedbackWithStatus(errText, c.showErrorStatus(errText))
+	service := m.worktreeMutationService()
+	m.worktrees.mutationToken++
+	switchToken := m.worktrees.mutationToken
+	m.worktrees.switchPending = true
+	target := strings.TrimSpace(token)
+	return m, func() tea.Msg {
+		resolved, err := service.ResolveToken(target)
+		if err != nil {
+			return worktreeSwitchDoneMsg{token: switchToken, err: err}
+		}
+		resp, err := service.Switch(resolved.WorktreeID)
+		return worktreeSwitchDoneMsg{token: switchToken, resp: resp, err: err}
 	}
-	resp, err := m.worktreeMutationService().Switch(resolved.WorktreeID)
-	if err != nil {
-		errText := formatSubmissionError(err)
-		return m, c.appendErrorFeedbackWithStatus(errText, c.showErrorStatus(errText))
-	}
-	status := "Switched to " + worktreeDisplayName(resp.Worktree)
-	return m, tea.Batch(c.showSuccessStatus(status), m.requestRuntimeMainViewRefresh())
 }
 
 func (m *uiModel) listWorktreesForCurrentSession(includeDirtyCount bool) (serverapi.WorktreeListResponse, error) {
 	if m == nil {
 		return serverapi.WorktreeListResponse{}, worktreemutation.ErrClientUnavailable
 	}
+	m.checkTUIBlockingOperation("worktree service read", "list worktrees")
 	return m.worktreeMutationService().List(includeDirtyCount)
 }
 
@@ -78,6 +81,7 @@ func (m *uiModel) resolveWorktreeToken(token string) (serverapi.WorktreeView, er
 	if m == nil {
 		return serverapi.WorktreeView{}, worktreemutation.ErrClientUnavailable
 	}
+	m.checkTUIBlockingOperation("worktree service read", "resolve worktree")
 	return m.worktreeMutationService().ResolveToken(token)
 }
 
@@ -85,8 +89,12 @@ func (m *uiModel) suggestedWorktreeSessionName() string {
 	if trimmed := strings.TrimSpace(m.sessionName); trimmed != "" {
 		return trimmed
 	}
-	if client := m.runtimeClient(); client != nil {
-		return strings.TrimSpace(client.SessionView().SessionName)
+	if cached, ok := m.runtimeClient().(interface {
+		CachedMainView() (clientui.RuntimeMainView, bool)
+	}); ok {
+		if view, hasCached := cached.CachedMainView(); hasCached {
+			return strings.TrimSpace(view.Session.SessionName)
+		}
 	}
 	return ""
 }

--- a/cli/app/ui_worktree_commands.go
+++ b/cli/app/ui_worktree_commands.go
@@ -54,17 +54,34 @@ func (c uiInputController) handleWorktreeCommand(args string) (tea.Model, tea.Cm
 
 func (c uiInputController) handleWorktreeSwitchCommand(token string) (tea.Model, tea.Cmd) {
 	m := c.model
+	target := strings.TrimSpace(token)
+	if m.worktrees.switchPending {
+		m.worktrees.queuedSwitch = uiWorktreeQueuedSwitch{TargetToken: target}
+		return m, nil
+	}
+	return m, m.worktreeSwitchCommandForTarget(target, "")
+}
+
+func (m *uiModel) worktreeSwitchCommandForTarget(targetToken, worktreeID string) tea.Cmd {
+	if m == nil {
+		return nil
+	}
 	service := m.worktreeMutationService()
 	m.worktrees.mutationToken++
 	switchToken := m.worktrees.mutationToken
 	m.worktrees.switchPending = true
-	target := strings.TrimSpace(token)
-	return m, func() tea.Msg {
-		resolved, err := service.ResolveToken(target)
-		if err != nil {
-			return worktreeSwitchDoneMsg{token: switchToken, err: err}
+	targetToken = strings.TrimSpace(targetToken)
+	worktreeID = strings.TrimSpace(worktreeID)
+	return func() tea.Msg {
+		resolvedID := worktreeID
+		if resolvedID == "" {
+			resolved, err := service.ResolveToken(targetToken)
+			if err != nil {
+				return worktreeSwitchDoneMsg{token: switchToken, err: err}
+			}
+			resolvedID = resolved.WorktreeID
 		}
-		resp, err := service.Switch(resolved.WorktreeID)
+		resp, err := service.Switch(resolvedID)
 		return worktreeSwitchDoneMsg{token: switchToken, resp: resp, err: err}
 	}
 }

--- a/cli/app/ui_worktree_commands_part2_test.go
+++ b/cli/app/ui_worktree_commands_part2_test.go
@@ -192,7 +192,7 @@ func TestProjectedSessionMetadataAppliesExecutionTarget(t *testing.T) {
 
 func TestWorktreeSwitchDoneAppliesTargetAfterMainViewRefresh(t *testing.T) {
 	m := newWorktreeTestModel(t, &worktreeCommandTestClient{})
-	m.worktrees.mutationToken = 7
+	m.worktrees.switchToken = 7
 	m.worktrees.switchPending = true
 	m.statusConfig.WorkspaceRoot = "/repo"
 

--- a/cli/app/ui_worktree_commands_test.go
+++ b/cli/app/ui_worktree_commands_test.go
@@ -1019,6 +1019,35 @@ func TestWorktreeSwitchCompletionAppliesBeforeQueuedSwitchRuns(t *testing.T) {
 	}
 }
 
+func TestWorktreeSwitchCompletionUsesSwitchTokenNotMutationToken(t *testing.T) {
+	client := &worktreeCommandTestClient{
+		listResp:   testLinkedWorktreeListResponse(),
+		switchResp: serverapi.WorktreeSwitchResponse{Worktree: serverapi.WorktreeView{WorktreeID: "wt-feature", DisplayName: "feature-a"}},
+	}
+	m := newWorktreeTestModel(t, client)
+
+	next, switchCmd := m.inputController().handleWorktreeSwitchCommand("feature-a")
+	updated := next.(*uiModel)
+	if switchCmd == nil {
+		t.Fatal("expected switch command")
+	}
+	var switchDone worktreeSwitchDoneMsg
+	for _, msg := range collectCmdMessages(t, switchCmd) {
+		if typed, ok := msg.(worktreeSwitchDoneMsg); ok {
+			switchDone = typed
+		}
+	}
+	updated.worktrees.mutationToken++
+	next, _ = updated.Update(switchDone)
+	updated = next.(*uiModel)
+	if updated.worktrees.switchPending {
+		t.Fatal("expected switch completion to clear pending state despite unrelated mutation token change")
+	}
+	if updated.transientStatus != "Switched to feature-a" {
+		t.Fatalf("expected switch completion to apply, got status %q", updated.transientStatus)
+	}
+}
+
 func TestWorktreeDeleteTargetResolutionPrefersDisplayNameMatchBeforeBranchMatch(t *testing.T) {
 	resp := testMainWorktreeListResponse()
 	resp.Worktrees = append(resp.Worktrees,

--- a/cli/app/ui_worktree_commands_test.go
+++ b/cli/app/ui_worktree_commands_test.go
@@ -963,6 +963,62 @@ func TestWorktreeSwitchCommandsCoalesceWhileInFlight(t *testing.T) {
 	}
 }
 
+func TestWorktreeSwitchCompletionAppliesBeforeQueuedSwitchRuns(t *testing.T) {
+	client := &worktreeCommandTestClient{
+		listResp:   testLinkedWorktreeListResponse(),
+		switchResp: serverapi.WorktreeSwitchResponse{Worktree: serverapi.WorktreeView{WorktreeID: "wt-feature", DisplayName: "feature-a"}},
+	}
+	m := newWorktreeTestModel(t, client)
+
+	next, firstCmd := m.inputController().handleWorktreeSwitchCommand("feature-a")
+	updated := next.(*uiModel)
+	if firstCmd == nil {
+		t.Fatal("expected first switch command")
+	}
+	next, secondCmd := updated.inputController().handleWorktreeSwitchCommand("main")
+	updated = next.(*uiModel)
+	if secondCmd != nil {
+		t.Fatal("did not expect second switch command while first is in flight")
+	}
+
+	var firstDone worktreeSwitchDoneMsg
+	foundFirst := false
+	for _, msg := range collectCmdMessages(t, firstCmd) {
+		if typed, ok := msg.(worktreeSwitchDoneMsg); ok {
+			firstDone = typed
+			foundFirst = true
+		}
+	}
+	if !foundFirst {
+		t.Fatal("expected first worktree switch completion")
+	}
+	client.switchErr = errors.New("queued switch failed")
+	next, followCmd := updated.Update(firstDone)
+	updated = next.(*uiModel)
+	if updated.transientStatus != "Switched to feature-a" {
+		t.Fatalf("expected first switch success status before queued follow-up, got %q", updated.transientStatus)
+	}
+	msgs := collectCmdMessages(t, followCmd)
+	sawRefresh := false
+	sawQueuedSwitch := false
+	for _, msg := range msgs {
+		switch typed := msg.(type) {
+		case runtimeMainViewRefreshedMsg:
+			sawRefresh = true
+		case worktreeSwitchDoneMsg:
+			if typed.err != nil {
+				sawQueuedSwitch = true
+			}
+		}
+	}
+	if !sawRefresh {
+		t.Fatalf("expected first switch to schedule main-view refresh before queued failure, got %+v", msgs)
+	}
+	if !sawQueuedSwitch {
+		t.Fatalf("expected queued switch command to still run, got %+v", msgs)
+	}
+}
+
 func TestWorktreeDeleteTargetResolutionPrefersDisplayNameMatchBeforeBranchMatch(t *testing.T) {
 	resp := testMainWorktreeListResponse()
 	resp.Worktrees = append(resp.Worktrees,

--- a/cli/app/ui_worktree_commands_test.go
+++ b/cli/app/ui_worktree_commands_test.go
@@ -930,6 +930,39 @@ func TestWorktreeSwitchCommandPrefersDisplayNameMatchBeforeBranchMatch(t *testin
 	}
 }
 
+func TestWorktreeSwitchCommandsCoalesceWhileInFlight(t *testing.T) {
+	client := &worktreeCommandTestClient{
+		listResp:   testLinkedWorktreeListResponse(),
+		switchResp: serverapi.WorktreeSwitchResponse{Worktree: serverapi.WorktreeView{WorktreeID: "wt-main", DisplayName: "main"}},
+	}
+	m := newWorktreeTestModel(t, client)
+
+	next, firstCmd := m.inputController().handleWorktreeSwitchCommand("feature-a")
+	updated := next.(*uiModel)
+	if firstCmd == nil {
+		t.Fatal("expected first switch command")
+	}
+	next, secondCmd := updated.inputController().handleWorktreeSwitchCommand("main")
+	updated = next.(*uiModel)
+	if secondCmd != nil {
+		t.Fatal("did not expect second switch command while first is in flight")
+	}
+	if len(client.switchRequests) != 0 {
+		t.Fatalf("switch RPC started before command execution: %+v", client.switchRequests)
+	}
+
+	updated = applyWorktreeCmdMessages(t, updated, firstCmd)
+	if len(client.switchRequests) != 2 {
+		t.Fatalf("expected serialized first and follow-up switch RPCs, got %+v", client.switchRequests)
+	}
+	if client.switchRequests[0].WorktreeID != "wt-feature" || client.switchRequests[1].WorktreeID != "wt-main" {
+		t.Fatalf("unexpected switch request order: %+v", client.switchRequests)
+	}
+	if updated.worktrees.switchPending {
+		t.Fatal("expected switch pending cleared after serialized follow-up completion")
+	}
+}
+
 func TestWorktreeDeleteTargetResolutionPrefersDisplayNameMatchBeforeBranchMatch(t *testing.T) {
 	resp := testMainWorktreeListResponse()
 	resp.Worktrees = append(resp.Worktrees,

--- a/cli/app/ui_worktree_create_controller.go
+++ b/cli/app/ui_worktree_create_controller.go
@@ -111,8 +111,9 @@ func (m *uiModel) worktreeCreateTargetResolveCmd(query string, token uint64) tea
 	if m == nil || m.worktreeClient == nil {
 		return nil
 	}
+	service := m.worktreeMutationService()
 	return func() tea.Msg {
-		resp, err := m.worktreeMutationService().ResolveCreateTarget(query)
+		resp, err := service.ResolveCreateTarget(query)
 		return worktreeCreateTargetResolveDoneMsg{token: token, query: query, resp: resp, err: err}
 	}
 }

--- a/cli/app/ui_worktree_list_controller.go
+++ b/cli/app/ui_worktree_list_controller.go
@@ -118,8 +118,7 @@ func (c uiInputController) handleWorktreeOverlayKey(msg tea.KeyMsg) (tea.Model, 
 	switch strings.ToLower(msg.String()) {
 	case "ctrl+c":
 		if m.isBusy() {
-			c.interruptBusyRuntime()
-			return m, nil
+			return m, c.interruptBusyRuntime()
 		}
 		m.exitAction = UIActionExit
 		if overlayCmd := m.popWorktreeOverlayIfNeeded(); overlayCmd != nil {

--- a/cli/app/ui_worktree_reducer.go
+++ b/cli/app/ui_worktree_reducer.go
@@ -62,7 +62,7 @@ func (r uiWorktreeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		m.syncViewport()
 		return handledUIFeatureUpdate(m, tea.Batch(overlayCmd, feedbackCmd, m.requestRuntimeMainViewRefresh(), m.ensureSpinnerTicking()))
 	case worktreeSwitchDoneMsg:
-		if msg.token != m.worktrees.mutationToken {
+		if msg.token != m.worktrees.switchToken {
 			m.syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}

--- a/cli/app/ui_worktree_reducer.go
+++ b/cli/app/ui_worktree_reducer.go
@@ -67,6 +67,10 @@ func (r uiWorktreeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			return handledUIFeatureUpdate(m, nil)
 		}
 		m.worktrees.switchPending = false
+		if followUp := m.takeQueuedWorktreeSwitchCmd(); followUp != nil {
+			m.syncViewport()
+			return handledUIFeatureUpdate(m, tea.Batch(followUp, m.ensureSpinnerTicking()))
+		}
 		if msg.err != nil {
 			if !m.worktrees.isOpen() {
 				status := formatSubmissionError(msg.err)

--- a/cli/app/ui_worktree_reducer.go
+++ b/cli/app/ui_worktree_reducer.go
@@ -67,19 +67,17 @@ func (r uiWorktreeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			return handledUIFeatureUpdate(m, nil)
 		}
 		m.worktrees.switchPending = false
-		if followUp := m.takeQueuedWorktreeSwitchCmd(); followUp != nil {
-			m.syncViewport()
-			return handledUIFeatureUpdate(m, tea.Batch(followUp, m.ensureSpinnerTicking()))
-		}
+		followUp := tea.Cmd(nil)
 		if msg.err != nil {
+			followUp = m.takeQueuedWorktreeSwitchCmd()
 			if !m.worktrees.isOpen() {
 				status := formatSubmissionError(msg.err)
 				m.syncViewport()
-				return handledUIFeatureUpdate(m, m.setTransientStatusWithKind(status, uiStatusNoticeError))
+				return handledUIFeatureUpdate(m, tea.Batch(m.setTransientStatusWithKind(status, uiStatusNoticeError), followUp))
 			}
 			m.worktrees.errorText = formatSubmissionError(msg.err)
 			m.syncViewport()
-			return handledUIFeatureUpdate(m, m.ensureSpinnerTicking())
+			return handledUIFeatureUpdate(m, tea.Batch(followUp, m.ensureSpinnerTicking()))
 		}
 		var overlayCmd tea.Cmd
 		if m.worktrees.isOpen() {
@@ -88,8 +86,9 @@ func (r uiWorktreeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		}
 		status := "Switched to " + worktreeDisplayName(msg.resp.Worktree)
 		feedbackCmd := m.setTransientStatusWithKind(status, uiStatusNoticeSuccess)
+		followUp = m.takeQueuedWorktreeSwitchCmd()
 		m.syncViewport()
-		return handledUIFeatureUpdate(m, tea.Batch(overlayCmd, feedbackCmd, m.requestRuntimeMainViewRefresh(), m.ensureSpinnerTicking()))
+		return handledUIFeatureUpdate(m, tea.Batch(overlayCmd, feedbackCmd, m.requestRuntimeMainViewRefresh(), followUp, m.ensureSpinnerTicking()))
 	case worktreeDeleteDoneMsg:
 		if msg.token != m.worktrees.mutationToken {
 			m.syncViewport()

--- a/cli/app/ui_worktrees.go
+++ b/cli/app/ui_worktrees.go
@@ -202,8 +202,9 @@ func (m *uiModel) requestWorktreeListCmd() tea.Cmd {
 	includeDirtyCount := m.worktrees.intent.OpenDelete || m.worktrees.phase == uiWorktreeOverlayPhaseDeleteConfirm
 	m.worktrees.loading = true
 	m.worktrees.errorText = ""
+	service := m.worktreeMutationService()
 	return func() tea.Msg {
-		resp, err := m.listWorktreesForCurrentSession(includeDirtyCount)
+		resp, err := service.List(includeDirtyCount)
 		return worktreeListDoneMsg{token: token, resp: resp, err: err}
 	}
 }
@@ -318,8 +319,9 @@ func (m *uiModel) worktreeCreateCmd(req serverapi.WorktreeCreateRequest) tea.Cmd
 	token := m.worktrees.mutationToken
 	m.worktrees.create.errorText = ""
 	m.worktrees.create.submitting = true
+	service := m.worktreeMutationService()
 	return func() tea.Msg {
-		resp, err := m.worktreeMutationService().Create(req)
+		resp, err := service.Create(req)
 		return worktreeCreateDoneMsg{token: token, resp: resp, err: err}
 	}
 }
@@ -332,8 +334,9 @@ func (m *uiModel) worktreeSwitchCmd(target serverapi.WorktreeView) tea.Cmd {
 	m.worktrees.switchPending = true
 	token := m.worktrees.mutationToken
 	m.worktrees.errorText = ""
+	service := m.worktreeMutationService()
 	return func() tea.Msg {
-		resp, err := m.worktreeMutationService().Switch(target.WorktreeID)
+		resp, err := service.Switch(target.WorktreeID)
 		return worktreeSwitchDoneMsg{token: token, resp: resp, err: err}
 	}
 }
@@ -346,8 +349,9 @@ func (m *uiModel) worktreeDeleteCmd(target serverapi.WorktreeView, deleteBranch 
 	token := m.worktrees.mutationToken
 	m.worktrees.deleteConfirm.errorText = ""
 	m.worktrees.deleteConfirm.submitting = true
+	service := m.worktreeMutationService()
 	return func() tea.Msg {
-		resp, err := m.worktreeMutationService().Delete(target.WorktreeID, deleteBranch)
+		resp, err := service.Delete(target.WorktreeID, deleteBranch)
 		return worktreeDeleteDoneMsg{token: token, resp: resp, err: err}
 	}
 }

--- a/cli/app/ui_worktrees.go
+++ b/cli/app/ui_worktrees.go
@@ -92,6 +92,7 @@ type uiWorktreeOverlayState struct {
 	errorText     string
 	refreshToken  uint64
 	mutationToken uint64
+	switchToken   uint64
 	switchPending bool
 	queuedSwitch  uiWorktreeQueuedSwitch
 	selectedID    string

--- a/cli/app/ui_worktrees.go
+++ b/cli/app/ui_worktrees.go
@@ -93,11 +93,17 @@ type uiWorktreeOverlayState struct {
 	refreshToken  uint64
 	mutationToken uint64
 	switchPending bool
+	queuedSwitch  uiWorktreeQueuedSwitch
 	selectedID    string
 	intent        uiWorktreeOpenIntent
 	create        uiWorktreeCreateDialogState
 	deleteConfirm uiWorktreeDeleteDialogState
 	inputCursor   uiInputFieldCursor
+}
+
+type uiWorktreeQueuedSwitch struct {
+	TargetToken string
+	WorktreeID  string
 }
 
 type worktreeListDoneMsg struct {
@@ -330,15 +336,26 @@ func (m *uiModel) worktreeSwitchCmd(target serverapi.WorktreeView) tea.Cmd {
 	if m == nil {
 		return nil
 	}
-	m.worktrees.mutationToken++
-	m.worktrees.switchPending = true
-	token := m.worktrees.mutationToken
-	m.worktrees.errorText = ""
-	service := m.worktreeMutationService()
-	return func() tea.Msg {
-		resp, err := service.Switch(target.WorktreeID)
-		return worktreeSwitchDoneMsg{token: token, resp: resp, err: err}
+	worktreeID := strings.TrimSpace(target.WorktreeID)
+	if m.worktrees.switchPending {
+		m.worktrees.queuedSwitch = uiWorktreeQueuedSwitch{WorktreeID: worktreeID}
+		return nil
 	}
+	m.worktrees.errorText = ""
+	return m.worktreeSwitchCommandForTarget("", worktreeID)
+}
+
+func (m *uiModel) takeQueuedWorktreeSwitchCmd() tea.Cmd {
+	if m == nil {
+		return nil
+	}
+	queued := m.worktrees.queuedSwitch
+	m.worktrees.queuedSwitch = uiWorktreeQueuedSwitch{}
+	if strings.TrimSpace(queued.WorktreeID) == "" && strings.TrimSpace(queued.TargetToken) == "" {
+		return nil
+	}
+	m.worktrees.switchPending = false
+	return m.worktreeSwitchCommandForTarget(queued.TargetToken, queued.WorktreeID)
 }
 
 func (m *uiModel) worktreeDeleteCmd(target serverapi.WorktreeView, deleteBranch bool) tea.Cmd {

--- a/server/primaryrun/runtime_client.go
+++ b/server/primaryrun/runtime_client.go
@@ -62,6 +62,9 @@ func (c *gatedRuntimeClient) ClearGoal() (*clientui.RuntimeGoal, error)  { retur
 func (c *gatedRuntimeClient) AppendLocalEntry(role, text string) error {
 	return c.inner.AppendLocalEntry(role, text)
 }
+func (c *gatedRuntimeClient) AppendLocalEntryWithNoticeID(role, text, noticeID string) error {
+	return c.inner.AppendLocalEntryWithNoticeID(role, text, noticeID)
+}
 func (c *gatedRuntimeClient) SubmitUserMessage(ctx context.Context, text string) (string, error) {
 	lease, err := c.gate.AcquirePrimaryRun(c.sessionID)
 	if err != nil {

--- a/server/primaryrun/runtime_client_test.go
+++ b/server/primaryrun/runtime_client_test.go
@@ -51,6 +51,9 @@ func (s *stubRuntimeClient) ResumeGoal() (*clientui.RuntimeGoal, error) {
 }
 func (s *stubRuntimeClient) ClearGoal() (*clientui.RuntimeGoal, error) { return nil, nil }
 func (s *stubRuntimeClient) AppendLocalEntry(string, string) error     { return nil }
+func (s *stubRuntimeClient) AppendLocalEntryWithNoticeID(string, string, string) error {
+	return nil
+}
 func (s *stubRuntimeClient) SubmitUserMessage(context.Context, string) (string, error) {
 	s.submitCalls++
 	return "ok", nil

--- a/shared/clientui/process.go
+++ b/shared/clientui/process.go
@@ -1,6 +1,9 @@
 package clientui
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type BackgroundProcess struct {
 	ID                      string
@@ -26,7 +29,7 @@ type BackgroundProcess struct {
 }
 
 type ProcessClient interface {
-	ListProcesses() []BackgroundProcess
-	KillProcess(id string) error
-	InlineOutput(id string, maxChars int) (string, string, error)
+	ListProcesses(ctx context.Context) ([]BackgroundProcess, error)
+	KillProcess(ctx context.Context, id string) error
+	InlineOutput(ctx context.Context, id string, maxChars int) (string, string, error)
 }

--- a/shared/clientui/runtime.go
+++ b/shared/clientui/runtime.go
@@ -163,6 +163,7 @@ type RuntimeClient interface {
 	ResumeGoal() (*RuntimeGoal, error)
 	ClearGoal() (*RuntimeGoal, error)
 	AppendLocalEntry(role, text string) error
+	AppendLocalEntryWithNoticeID(role, text, noticeID string) error
 	SubmitUserMessage(ctx context.Context, text string) (string, error)
 	SubmitUserShellCommand(ctx context.Context, command string) error
 	CompactContext(ctx context.Context, args string) error


### PR DESCRIPTION
## Summary
- add TUI strict-mode blocking-operation guard and move /ps reads/actions/render paths off Bubble Tea Update/View hot paths
- convert runtime-control, worktree, status/auth/git, queue, and local feedback paths to command-backed flows with stale-completion guards
- add transcript/main-view sync policy that defers routine full refetches while streaming or /ps is active while preserving recovery/manual/detail/queued-drain paths

Closes #317

## Verification
- ./scripts/test.sh ./cli/app
- ./scripts/test.sh ./cli/app ./cli/tui
- ./scripts/build.sh --output ./bin/builder
- git diff --check
- plan review: no findings
- code review: no findings

## Notes
- Unrelated local docs edits under docs/dev/specs and the local scripts/export-reviewer-request.sh helper are intentionally not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added async process-list refresh with improved empty-state messaging for status indication
  * Implemented command-driven goal operations (set, pause, resume, clear) for more reliable interaction
  * Enhanced queued input recovery with better tracking of pending items

* **Bug Fixes**
  * Improved handling of interrupted submissions with proper cleanup of queued state
  * Fixed worktree switch command coalescing to prevent duplicate operations
  * Better conversation freshness tracking during local turns

* **Improvements**
  * Converted runtime operations to async command-driven flows for improved responsiveness
  * Enhanced process action serialization to prevent concurrent operation conflicts
  * Improved transcript echo suppression for cleaner conversation rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->