### PR TITLE
fix: warn for raw or truncated shell output

### DIFF
--- a/cli/app/ui_transcript_entries.go
+++ b/cli/app/ui_transcript_entries.go
@@ -234,6 +234,8 @@ func transcriptToolCallMeta(meta *clientui.ToolCallMeta) *transcript.ToolCallMet
 		Question:               meta.Question,
 		RecommendedOptionIndex: meta.RecommendedOptionIndex,
 		OmitSuccessfulResult:   meta.OmitSuccessfulResult,
+		RawOutputRequested:     meta.RawOutputRequested,
+		OutputTruncated:        meta.OutputTruncated,
 	}
 	if len(meta.Suggestions) > 0 {
 		out.Suggestions = append([]string(nil), meta.Suggestions...)
@@ -271,6 +273,8 @@ func transcriptToolCallMetaClient(meta *transcript.ToolCallMeta) *clientui.ToolC
 		Question:               meta.Question,
 		RecommendedOptionIndex: meta.RecommendedOptionIndex,
 		OmitSuccessfulResult:   meta.OmitSuccessfulResult,
+		RawOutputRequested:     meta.RawOutputRequested,
+		OutputTruncated:        meta.OutputTruncated,
 	}
 	if len(meta.Suggestions) > 0 {
 		out.Suggestions = append([]string(nil), meta.Suggestions...)

--- a/cli/tui/model_rendering.go
+++ b/cli/tui/model_rendering.go
@@ -24,7 +24,8 @@ func (m Model) buildDetailBlockSpecs(includeStreaming bool) []detailBlockSpec {
 		case TranscriptRoleToolCall:
 			blocks = append(blocks, m.detailToolCallSpec(idx, entry, consumedResults, resultIndex))
 		case TranscriptRoleToolResult, TranscriptRoleToolResultOK, TranscriptRoleToolResultError:
-			blockRole := RenderIntentTool.BaseToolResultIntent(role)
+			meta := cloneToolCallMeta(entry.ToolCall)
+			blockRole := resultOnlyToolBlockRole(role, meta)
 			text := entry.Text
 			absoluteIndex := m.absoluteTranscriptIndex(idx)
 			expandable := false
@@ -39,10 +40,13 @@ func (m Model) buildDetailBlockSpecs(includeStreaming bool) []detailBlockSpec {
 				expanded:   m.detailEntryExpanded(absoluteIndex),
 				expandable: expandable,
 				render: func(model Model, symbolOverride string) []string {
-					if model.detailEntryExpanded(absoluteIndex) || blockRole == RenderIntentToolError {
-						return model.detailWithTreeGuideWithSymbol(blockRole, model.flattenEntryWithMetaAndSymbol(blockRole, text, false, nil, symbolOverride), true, symbolOverride)
+					if symbolOverride == "" {
+						symbolOverride = model.shellWarningSymbolOverride(blockRole, meta)
 					}
-					return model.detailWithTreeGuideWithSymbol(blockRole, model.flattenEntryWithMetaAndSymbol(blockRole, model.firstDetailPreviewLine(text, "Tool output"), false, nil, symbolOverride), false, symbolOverride)
+					if model.detailEntryExpanded(absoluteIndex) || blockRole.IsToolErrorHeadline() {
+						return model.detailWithTreeGuideWithSymbol(blockRole, model.flattenEntryWithMetaAndSymbol(blockRole, text, false, meta, symbolOverride), true, symbolOverride)
+					}
+					return model.detailWithTreeGuideWithSymbol(blockRole, model.flattenEntryWithMetaAndSymbol(blockRole, model.firstDetailPreviewLine(text, "Tool output"), false, meta, symbolOverride), false, symbolOverride)
 				},
 			})
 		default:
@@ -136,16 +140,33 @@ func (m Model) entryBlock(entryIndex int, entry TranscriptEntry, role Transcript
 		if opts.mode == transcriptBlockModeOngoing {
 			return ongoingBlock{}, false
 		}
-		blockRole := RenderIntentTool.BaseToolResultIntent(role)
+		meta := cloneToolCallMeta(entry.ToolCall)
+		blockRole := resultOnlyToolBlockRole(role, meta)
+		symbolOverride := m.shellWarningSymbolOverride(blockRole, meta)
 		return ongoingBlock{
 			role:       blockRole,
-			lines:      m.flattenEntryWithMetaAndSymbol(blockRole, entry.Text, false, nil, ""),
+			lines:      m.flattenEntryWithMetaAndSymbol(blockRole, entry.Text, false, meta, symbolOverride),
 			entryIndex: m.absoluteTranscriptIndex(entryIndex),
 			entryEnd:   m.absoluteTranscriptIndex(entryIndex),
 		}, true
 	default:
 		return m.standardEntryBlock(entryIndex, entry, intent, consumed, opts), true
 	}
+}
+
+func resultOnlyToolBlockRole(resultRole TranscriptRole, meta *transcript.ToolCallMeta) RenderIntent {
+	blockRole := RenderIntentTool
+	switch {
+	case isAskQuestionToolCall(meta):
+		blockRole = RenderIntentToolQuestion
+	case isWebSearchToolCall(meta):
+		blockRole = RenderIntentToolWebSearch
+	case isPatchToolCall(meta):
+		blockRole = RenderIntentToolPatch
+	case meta != nil && meta.UsesShellRendering():
+		blockRole = RenderIntentToolShell
+	}
+	return blockRole.BaseToolResultIntent(resultRole)
 }
 
 func (m Model) toolCallBlock(entryIndex int, entry TranscriptEntry, consumed map[int]struct{}, resultIndex toolResultIndex, opts transcriptBlockOptions) ongoingBlock {
@@ -168,15 +189,16 @@ func (m Model) toolCallBlock(entryIndex int, entry TranscriptEntry, consumed map
 	}
 	effectiveMeta := entry.ToolCall
 	if resultIdx >= 0 && m.transcriptInput.Entries[resultIdx].ToolCall != nil {
-		effectiveMeta = m.transcriptInput.Entries[resultIdx].ToolCall
+		effectiveMeta = effectiveToolCallMeta(entry.ToolCall, m.transcriptInput.Entries[resultIdx].ToolCall)
 		combined = transcript.CompactToolCallText(effectiveMeta, combined)
 		if isPatchToolCall(effectiveMeta) {
 			blockRole = RenderIntentToolPatch.BaseToolResultIntent(TranscriptRoleFromWire(string(m.transcriptInput.Entries[resultIdx].Role)))
 		}
 	}
-	lines := m.flattenEntryWithMetaAndSymbol(blockRole, combined, opts.mode == transcriptBlockModeOngoing, effectiveMeta, "")
+	symbolOverride := m.shellWarningSymbolOverride(blockRole, effectiveMeta)
+	lines := m.flattenEntryWithMetaAndSymbol(blockRole, combined, opts.mode == transcriptBlockModeOngoing, effectiveMeta, symbolOverride)
 	if opts.mode == transcriptBlockModeOngoing {
-		lines = m.ongoingToolWithTreeGuideWithSymbol(blockRole, lines, "")
+		lines = m.ongoingToolWithTreeGuideWithSymbol(blockRole, lines, symbolOverride)
 	}
 	return ongoingBlock{
 		role:       blockRole,
@@ -224,7 +246,7 @@ func (m Model) detailToolCallSpec(entryIndex int, entry TranscriptEntry, consume
 	absoluteEnd := m.absoluteTranscriptIndex(entryEnd)
 	meta := cloneToolCallMeta(entry.ToolCall)
 	if entryEnd != entryIndex && m.transcriptInput.Entries[entryEnd].ToolCall != nil {
-		meta = cloneToolCallMeta(m.transcriptInput.Entries[entryEnd].ToolCall)
+		meta = effectiveToolCallMeta(entry.ToolCall, m.transcriptInput.Entries[entryEnd].ToolCall)
 		if isPatchToolCall(meta) {
 			blockRole = RenderIntentToolPatch.BaseToolResultIntent(TranscriptRoleFromWire(string(m.transcriptInput.Entries[entryEnd].Role)))
 		}
@@ -237,6 +259,9 @@ func (m Model) detailToolCallSpec(entryIndex int, entry TranscriptEntry, consume
 		expanded:   m.detailEntryExpanded(absoluteIndex),
 		expandable: m.detailToolCallExpandable(blockRole, entry, resultSummary, combined, meta, resultText),
 		render: func(model Model, symbolOverride string) []string {
+			if symbolOverride == "" {
+				symbolOverride = model.shellWarningSymbolOverride(blockRole, meta)
+			}
 			if !model.detailEntryExpanded(absoluteIndex) {
 				return model.detailCollapsedToolLinesWithSymbol(blockRole, entry, resultSummary, symbolOverride)
 			}
@@ -246,6 +271,33 @@ func (m Model) detailToolCallSpec(entryIndex int, entry TranscriptEntry, consume
 			return model.detailWithTreeGuideWithSymbol(blockRole, model.flattenEntryWithMetaAndSymbol(blockRole, combined, false, meta, symbolOverride), true, symbolOverride)
 		},
 	}
+}
+
+func effectiveToolCallMeta(callMeta, resultMeta *transcript.ToolCallMeta) *transcript.ToolCallMeta {
+	if resultMeta == nil {
+		return cloneToolCallMeta(callMeta)
+	}
+	normalizedResult := transcript.NormalizeToolCallMeta(*resultMeta)
+	if callMeta == nil || !isShellStatusOnlyToolCallMeta(normalizedResult) {
+		return cloneToolCallMeta(&normalizedResult)
+	}
+	merged := transcript.NormalizeToolCallMeta(*callMeta)
+	merged.RawOutputRequested = merged.RawOutputRequested || normalizedResult.RawOutputRequested
+	merged.OutputTruncated = merged.OutputTruncated || normalizedResult.OutputTruncated
+	return &merged
+}
+
+func isShellStatusOnlyToolCallMeta(meta transcript.ToolCallMeta) bool {
+	return meta.IsShell &&
+		strings.TrimSpace(meta.Command) == "" &&
+		strings.TrimSpace(meta.CompactText) == "" &&
+		strings.TrimSpace(meta.PatchSummary) == "" &&
+		strings.TrimSpace(meta.PatchDetail) == "" &&
+		meta.PatchRender == nil &&
+		meta.Question == "" &&
+		len(meta.Suggestions) == 0 &&
+		meta.RecommendedOptionIndex == 0 &&
+		(meta.RawOutputRequested || meta.OutputTruncated)
 }
 
 func (m Model) askQuestionBlock(entryIndex int, entry TranscriptEntry, consumed map[int]struct{}, resultIndex toolResultIndex, opts transcriptBlockOptions, defaultRole RenderIntent) ongoingBlock {

--- a/cli/tui/model_rendering_style.go
+++ b/cli/tui/model_rendering_style.go
@@ -130,6 +130,29 @@ func renderRoleSymbol(prefix string, style roleSymbolColorStyle) string {
 	return styleEscape(transform, false) + prefix + "\x1b[0m"
 }
 
+func (m Model) shellWarningSymbolOverride(role RenderIntent, meta *transcript.ToolCallMeta) string {
+	if !usesWarningShellSymbol(role, meta) {
+		return ""
+	}
+	prefix := rolePrefix(role)
+	if prefix == "" {
+		return ""
+	}
+	symbol := renderRoleSymbol(prefix, roleSymbolColorStyle{color: m.palette().warningColor})
+	if role.IsToolHeadline() && m.toolSymbolGap > 1 {
+		return symbol + strings.Repeat(" ", m.toolSymbolGap)
+	}
+	return symbol + " "
+}
+
+func usesWarningShellSymbol(role RenderIntent, meta *transcript.ToolCallMeta) bool {
+	if !role.IsShellPreview() || meta == nil {
+		return false
+	}
+	normalized := transcript.NormalizeToolCallMeta(*meta)
+	return normalized.RawOutputRequested || normalized.OutputTruncated
+}
+
 func rolePrefix(role RenderIntent) string {
 	if TranscriptRole(role).IsCompaction() {
 		return "@"

--- a/cli/tui/model_rendering_style_test.go
+++ b/cli/tui/model_rendering_style_test.go
@@ -1,6 +1,11 @@
 package tui
 
-import "testing"
+import (
+	"testing"
+
+	"builder/shared/transcript"
+	"github.com/charmbracelet/lipgloss"
+)
 
 func TestStyleForRoleAssistantCommentaryMatchesAssistant(t *testing.T) {
 	m := NewModel(WithTheme("dark"))
@@ -52,5 +57,77 @@ func TestToolResultIndexFindMatchingToolResultIndexPrefersAdjacentMatch(t *testi
 	got := index.findMatchingToolResultIndex(entries, 0, map[int]struct{}{})
 	if got != 1 {
 		t.Fatalf("expected adjacent result to win, got %d", got)
+	}
+}
+
+func TestUsesWarningShellSymbolForRawOrTruncatedShellOutput(t *testing.T) {
+	testCases := []struct {
+		name string
+		role RenderIntent
+		meta *transcript.ToolCallMeta
+		want bool
+	}{
+		{
+			name: "raw shell request",
+			role: RenderIntentToolShell,
+			meta: &transcript.ToolCallMeta{ToolName: "exec_command", IsShell: true, RawOutputRequested: true},
+			want: true,
+		},
+		{
+			name: "truncated shell success",
+			role: RenderIntentToolShellSuccess,
+			meta: &transcript.ToolCallMeta{ToolName: "exec_command", IsShell: true, OutputTruncated: true},
+			want: true,
+		},
+		{
+			name: "truncated shell error",
+			role: RenderIntentToolShellError,
+			meta: &transcript.ToolCallMeta{ToolName: "exec_command", IsShell: true, OutputTruncated: true},
+			want: true,
+		},
+		{
+			name: "normal shell success",
+			role: RenderIntentToolShellSuccess,
+			meta: &transcript.ToolCallMeta{ToolName: "exec_command", IsShell: true},
+			want: false,
+		},
+		{
+			name: "non shell role",
+			role: RenderIntentToolSuccess,
+			meta: &transcript.ToolCallMeta{ToolName: "exec_command", IsShell: true, OutputTruncated: true},
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := usesWarningShellSymbol(tc.role, tc.meta); got != tc.want {
+				t.Fatalf("usesWarningShellSymbol = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResultOnlyToolBlockRoleUsesShellMetadata(t *testing.T) {
+	meta := &transcript.ToolCallMeta{ToolName: "exec_command", IsShell: true, OutputTruncated: true}
+
+	if got := resultOnlyToolBlockRole(TranscriptRoleToolResultOK, meta); got != RenderIntentToolShellSuccess {
+		t.Fatalf("success role = %q, want %q", got, RenderIntentToolShellSuccess)
+	}
+	if got := resultOnlyToolBlockRole(TranscriptRoleToolResultError, meta); got != RenderIntentToolShellError {
+		t.Fatalf("error role = %q, want %q", got, RenderIntentToolShellError)
+	}
+}
+
+func TestShellWarningSymbolOverridePreservesPrefixWidth(t *testing.T) {
+	meta := &transcript.ToolCallMeta{ToolName: "exec_command", IsShell: true, OutputTruncated: true}
+	m := NewModel()
+	m.toolSymbolGap = 2
+
+	got := m.shellWarningSymbolOverride(RenderIntentToolShellSuccess, meta)
+	wantWidth := lipgloss.Width(m.entryPrefix(RenderIntentToolShellSuccess, ""))
+
+	if lipgloss.Width(got) != wantWidth {
+		t.Fatalf("warning shell prefix width = %d, want %d", lipgloss.Width(got), wantWidth)
 	}
 }

--- a/server/runtimeview/projection.go
+++ b/server/runtimeview/projection.go
@@ -290,6 +290,8 @@ func cloneToolCallMeta(meta *transcript.ToolCallMeta) *clientui.ToolCallMeta {
 		Question:               meta.Question,
 		RecommendedOptionIndex: meta.RecommendedOptionIndex,
 		OmitSuccessfulResult:   meta.OmitSuccessfulResult,
+		RawOutputRequested:     meta.RawOutputRequested,
+		OutputTruncated:        meta.OutputTruncated,
 	}
 	if len(meta.Suggestions) > 0 {
 		copyMeta.Suggestions = append([]string(nil), meta.Suggestions...)

--- a/server/sessionview/snapshot_capability_test.go
+++ b/server/sessionview/snapshot_capability_test.go
@@ -82,6 +82,8 @@ func TestSessionSnapshotCapabilitiesCoverReadModelFields(t *testing.T) {
 			"Suggestions",
 			"RecommendedOptionIndex",
 			"OmitSuccessfulResult",
+			"RawOutputRequested",
+			"OutputTruncated",
 		),
 		reflect.TypeOf(clientui.ToolRenderHint{}): fieldSet("Kind", "Path", "ResultOnly", "ShellDialect"),
 		reflect.TypeOf(clientui.TranscriptPageRequest{}): fieldSet(

--- a/server/tools/shell/exec_command_tool.go
+++ b/server/tools/shell/exec_command_tool.go
@@ -10,6 +10,8 @@ import (
 
 	"builder/server/tools"
 	"builder/server/tools/shell/postprocess"
+	"builder/shared/toolspec"
+	"builder/shared/transcript"
 )
 
 type execCommandInput struct {
@@ -111,5 +113,21 @@ func (t *ExecCommandTool) Call(ctx context.Context, c tools.Call) (tools.Result,
 	if marshalErr != nil {
 		return tools.Result{}, marshalErr
 	}
-	return tools.Result{CallID: c.ID, Name: c.Name, Output: body}, nil
+	toolResult := tools.Result{CallID: c.ID, Name: c.Name, Output: body}
+	if in.Raw || result.Truncated {
+		toolResult.Presentation = shellOutputStatusPresentation(c.Name, in.Raw, result.Truncated)
+	}
+	return toolResult, nil
+}
+
+func shellOutputStatusPresentation(name toolspec.ID, rawRequested bool, truncated bool) *transcript.ToolCallMeta {
+	if !rawRequested && !truncated {
+		return nil
+	}
+	return &transcript.ToolCallMeta{
+		ToolName:           string(name),
+		IsShell:            true,
+		RawOutputRequested: rawRequested,
+		OutputTruncated:    truncated,
+	}
 }

--- a/server/tools/shell/manager.go
+++ b/server/tools/shell/manager.go
@@ -215,9 +215,10 @@ func (m *Manager) Start(ctx context.Context, req ExecRequest) (ExecResult, error
 		return ExecResult{}, err
 	}
 	result := ExecResult{
-		SessionID:  id,
-		WallTime:   time.Since(start),
-		OutputPath: logPath,
+		SessionID:          id,
+		WallTime:           time.Since(start),
+		OutputPath:         logPath,
+		RawOutputRequested: req.Raw,
 	}
 	snapshot, backgrounded := entry.transitionToBackground()
 	if !backgrounded {
@@ -340,16 +341,17 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (ExecResult,
 		entry.markCompletionNoticeConsumed()
 	}
 	return ExecResult{
-		SessionID:    id,
-		WallTime:     time.Since(start),
-		Warning:      postprocess.JoinWarnings(warning, processed.Warning),
-		ToolError:    processed.UnrecoverableError,
-		Output:       display,
-		OutputPath:   snapshot.LogPath,
-		Running:      snapshot.Running,
-		Backgrounded: snapshot.Backgrounded,
-		ExitCode:     postprocess.CloneIntPtr(snapshot.ExitCode),
-		Truncated:    sourceTruncated || displayTruncated,
+		SessionID:          id,
+		WallTime:           time.Since(start),
+		Warning:            postprocess.JoinWarnings(warning, processed.Warning),
+		ToolError:          processed.UnrecoverableError,
+		Output:             display,
+		OutputPath:         snapshot.LogPath,
+		Running:            snapshot.Running,
+		Backgrounded:       snapshot.Backgrounded,
+		ExitCode:           postprocess.CloneIntPtr(snapshot.ExitCode),
+		RawOutputRequested: snapshot.RawOutputRequested,
+		Truncated:          sourceTruncated || displayTruncated,
 	}, nil
 }
 

--- a/server/tools/shell/manager.go
+++ b/server/tools/shell/manager.go
@@ -228,9 +228,10 @@ func (m *Manager) Start(ctx context.Context, req ExecRequest) (ExecResult, error
 		if err != nil {
 			return ExecResult{}, err
 		}
-		display, _, _ := truncateWithTemplate(processed.Output, maxOutputChars, truncationBannerTemplate)
+		display, truncated, _ := truncateWithTemplate(processed.Output, maxOutputChars, truncationBannerTemplate)
 		result.ExitCode = postprocess.CloneIntPtr(snapshot.ExitCode)
 		result.Output = display
+		result.Truncated = truncated
 		result.Warning = processed.Warning
 		result.ToolError = processed.UnrecoverableError
 		m.releaseEntry(id)
@@ -241,11 +242,12 @@ func (m *Manager) Start(ctx context.Context, req ExecRequest) (ExecResult, error
 	if err != nil {
 		return ExecResult{}, err
 	}
-	display, _, _ := truncateWithTemplate(processed.Output, maxOutputChars, backgroundTruncationBannerTemplate)
+	display, truncated, _ := truncateWithTemplate(processed.Output, maxOutputChars, backgroundTruncationBannerTemplate)
 	result.Running = true
 	result.Backgrounded = true
 	result.MovedToBackground = true
 	result.Output = display
+	result.Truncated = truncated
 	result.Warning = processed.Warning
 	result.ToolError = processed.UnrecoverableError
 	m.emitEvent(Event{Type: EventBackgrounded, Snapshot: snapshot})
@@ -304,6 +306,7 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (ExecResult,
 	snapshot := entry.snapshot()
 	consumedCompletion := false
 	warning := ""
+	sourceTruncated := false
 	var processed postprocess.Result
 	if snapshot.Backgrounded && snapshot.ExitCode != nil && !entry.completionNoticeConsumed() {
 		fullOutput, readErr := readOutputFileLimited(snapshot.LogPath, maxFullLogPostprocessBytes)
@@ -314,10 +317,12 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (ExecResult,
 			}
 			consumedCompletion = true
 		} else {
-			preview, _, _, previewErr := readBackgroundSummaryFromFile(snapshot.LogPath, maxOutputChars, BackgroundOutputDefault, !snapshot.RawOutput)
+			var previewTruncated bool
+			preview, _, previewTruncated, previewErr := readBackgroundSummaryFromFile(snapshot.LogPath, maxOutputChars, BackgroundOutputDefault, !snapshot.RawOutput)
 			if previewErr == nil {
 				processed = postprocess.Result{Output: preview}
 				consumedCompletion = true
+				sourceTruncated = previewTruncated
 				warning = postprocess.JoinWarnings(warning, fmt.Sprintf("full output log skipped: %v", readErr))
 			} else {
 				warning = postprocess.JoinWarnings(warning, fmt.Sprintf("failed to read full output log: %v", readErr))
@@ -330,7 +335,7 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (ExecResult,
 			return ExecResult{}, err
 		}
 	}
-	display, _, _ := truncateWithTemplate(processed.Output, maxOutputChars, backgroundTruncationBannerTemplate)
+	display, displayTruncated, _ := truncateWithTemplate(processed.Output, maxOutputChars, backgroundTruncationBannerTemplate)
 	if snapshot.Backgrounded && snapshot.ExitCode != nil && consumedCompletion {
 		entry.markCompletionNoticeConsumed()
 	}
@@ -344,6 +349,7 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (ExecResult,
 		Running:      snapshot.Running,
 		Backgrounded: snapshot.Backgrounded,
 		ExitCode:     postprocess.CloneIntPtr(snapshot.ExitCode),
+		Truncated:    sourceTruncated || displayTruncated,
 	}, nil
 }
 

--- a/server/tools/shell/manager_types.go
+++ b/server/tools/shell/manager_types.go
@@ -92,6 +92,7 @@ type ExecResult struct {
 	Running           bool
 	Backgrounded      bool
 	MovedToBackground bool
+	Truncated         bool
 }
 
 type BackgroundNoticeSummary struct {

--- a/server/tools/shell/manager_types.go
+++ b/server/tools/shell/manager_types.go
@@ -60,6 +60,7 @@ type Snapshot struct {
 	OutputAvailable         bool
 	OutputRetainedFromBytes int64
 	OutputRetainedToBytes   int64
+	RawOutputRequested      bool
 	RawOutput               bool
 	Running                 bool
 	StdinOpen               bool
@@ -82,17 +83,18 @@ type ExecRequest struct {
 }
 
 type ExecResult struct {
-	SessionID         string
-	WallTime          time.Duration
-	Warning           string
-	ToolError         string
-	Output            string
-	OutputPath        string
-	ExitCode          *int
-	Running           bool
-	Backgrounded      bool
-	MovedToBackground bool
-	Truncated         bool
+	SessionID          string
+	WallTime           time.Duration
+	Warning            string
+	ToolError          string
+	Output             string
+	OutputPath         string
+	ExitCode           *int
+	Running            bool
+	Backgrounded       bool
+	MovedToBackground  bool
+	RawOutputRequested bool
+	Truncated          bool
 }
 
 type BackgroundNoticeSummary struct {
@@ -216,6 +218,7 @@ func (p *processEntry) snapshotLocked() Snapshot {
 		OutputAvailable:         p.logPath != "",
 		OutputRetainedFromBytes: 0,
 		OutputRetainedToBytes:   p.outputBytes,
+		RawOutputRequested:      p.raw,
 		RawOutput:               p.preserveOutput,
 		Running:                 p.running,
 		StdinOpen:               p.stdinOpen,

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -1044,6 +1044,38 @@ func TestExecCommandRawOutputAddsPresentationMetadata(t *testing.T) {
 	}
 }
 
+func TestWriteStdinRawSessionAddsPresentationMetadata(t *testing.T) {
+	workspace := t.TempDir()
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+	stdinTool := NewWriteStdinTool(16_000, manager)
+
+	result := callExecCommand(t, execTool, "raw-tty-1", map[string]any{
+		"cmd":           "read line; printf '\\033[31m%s\\033[0m' \"$line\"",
+		"shell":         "/bin/sh",
+		"login":         false,
+		"raw":           true,
+		"tty":           true,
+		"yield_time_ms": 250,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected exec_command error: %s", string(result.Output))
+	}
+
+	stdinResult := callWriteStdin(t, stdinTool, "raw-tty-2", map[string]any{
+		"session_id":    1000,
+		"chars":         "raw builder\n",
+		"yield_time_ms": 2_000,
+	})
+	if stdinResult.IsError {
+		t.Fatalf("unexpected write_stdin error: %s", string(stdinResult.Output))
+	}
+	if stdinResult.Presentation == nil || !stdinResult.Presentation.RawOutputRequested || stdinResult.Presentation.OutputTruncated {
+		t.Fatalf("expected raw write_stdin presentation metadata without truncation, got %+v", stdinResult.Presentation)
+	}
+	waitForManagerCount(t, manager, 0, time.Second)
+}
+
 func TestWriteStdinSendsInputToInteractiveProcess(t *testing.T) {
 	workspace := t.TempDir()
 	manager := newBackgroundTestManager(t)

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -1016,8 +1016,31 @@ func TestExecCommandForegroundTruncationUsesForegroundBanner(t *testing.T) {
 	if strings.Contains(text, "Process moved to background.") {
 		t.Fatalf("expected immediate completion, got %q", text)
 	}
+	if result.Presentation == nil || !result.Presentation.OutputTruncated {
+		t.Fatalf("expected foreground truncation presentation metadata, got %+v", result.Presentation)
+	}
 	if manager.Count() != 0 {
 		t.Fatalf("manager count = %d, want 0", manager.Count())
+	}
+}
+
+func TestExecCommandRawOutputAddsPresentationMetadata(t *testing.T) {
+	workspace := t.TempDir()
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+
+	result := callExecCommand(t, execTool, "raw-presentation-1", map[string]any{
+		"cmd":           "printf raw",
+		"shell":         "/bin/sh",
+		"login":         false,
+		"raw":           true,
+		"yield_time_ms": 2_000,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected exec_command error: %s", string(result.Output))
+	}
+	if result.Presentation == nil || !result.Presentation.RawOutputRequested || result.Presentation.OutputTruncated {
+		t.Fatalf("expected raw output presentation metadata without truncation, got %+v", result.Presentation)
 	}
 }
 
@@ -1103,6 +1126,41 @@ func TestWriteStdinUsesBackgroundTruncationBannerOnCompletion(t *testing.T) {
 	}
 	if !strings.Contains(stdinText, "Log file:") {
 		t.Fatalf("expected completed background shell response to include log file, got %q", stdinText)
+	}
+	if stdinResult.Presentation == nil || !stdinResult.Presentation.OutputTruncated {
+		t.Fatalf("expected write_stdin truncation presentation metadata, got %+v", stdinResult.Presentation)
+	}
+	waitForManagerCount(t, manager, 0, 3*time.Second)
+}
+
+func TestWriteStdinPreservesBackgroundSummaryTruncationMetadata(t *testing.T) {
+	workspace := t.TempDir()
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+	stdinTool := NewWriteStdinTool(16_000, manager)
+
+	result := callExecCommand(t, execTool, "tty-summary-trunc-1", map[string]any{
+		"cmd":           "read line; head -c 2200000 /dev/zero | tr '\\0' x",
+		"shell":         "/bin/sh",
+		"login":         false,
+		"tty":           true,
+		"yield_time_ms": 250,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected exec_command error: %s", string(result.Output))
+	}
+
+	stdinResult := callWriteStdin(t, stdinTool, "tty-summary-trunc-2", map[string]any{
+		"session_id":        1000,
+		"chars":             "go\n",
+		"yield_time_ms":     5_000,
+		"max_output_tokens": 10,
+	})
+	if stdinResult.IsError {
+		t.Fatalf("unexpected write_stdin error: %s", string(stdinResult.Output))
+	}
+	if stdinResult.Presentation == nil || !stdinResult.Presentation.OutputTruncated {
+		t.Fatalf("expected source truncation presentation metadata, got %+v", stdinResult.Presentation)
 	}
 	waitForManagerCount(t, manager, 0, 3*time.Second)
 }

--- a/server/tools/shell/write_stdin_tool.go
+++ b/server/tools/shell/write_stdin_tool.go
@@ -81,8 +81,8 @@ func (t *WriteStdinTool) Call(ctx context.Context, c tools.Call) (tools.Result, 
 		return tools.Result{}, marshalErr
 	}
 	toolResult := tools.Result{CallID: c.ID, Name: c.Name, Output: body}
-	if result.Truncated {
-		toolResult.Presentation = shellOutputStatusPresentation(c.Name, false, result.Truncated)
+	if result.RawOutputRequested || result.Truncated {
+		toolResult.Presentation = shellOutputStatusPresentation(c.Name, result.RawOutputRequested, result.Truncated)
 	}
 	return toolResult, nil
 }

--- a/server/tools/shell/write_stdin_tool.go
+++ b/server/tools/shell/write_stdin_tool.go
@@ -80,5 +80,9 @@ func (t *WriteStdinTool) Call(ctx context.Context, c tools.Call) (tools.Result, 
 	if marshalErr != nil {
 		return tools.Result{}, marshalErr
 	}
-	return tools.Result{CallID: c.ID, Name: c.Name, Output: body}, nil
+	toolResult := tools.Result{CallID: c.ID, Name: c.Name, Output: body}
+	if result.Truncated {
+		toolResult.Presentation = shellOutputStatusPresentation(c.Name, false, result.Truncated)
+	}
+	return toolResult, nil
 }

--- a/server/tools/transcript_contracts.go
+++ b/server/tools/transcript_contracts.go
@@ -81,14 +81,15 @@ func shellToolCallMeta(toolID toolspec.ID) func(ToolCallContext, json.RawMessage
 			renderHint = nil
 		}
 		return transcript.ToolCallMeta{
-			ToolName:      string(toolID),
-			IsShell:       true,
-			UserInitiated: parseShellToolCallUserInitiated(raw),
-			Command:       command,
-			CompactText:   command,
-			InlineMeta:    inlineMeta,
-			TimeoutLabel:  inlineMeta,
-			RenderHint:    renderHint,
+			ToolName:           string(toolID),
+			IsShell:            true,
+			UserInitiated:      parseShellToolCallUserInitiated(raw),
+			Command:            command,
+			CompactText:        command,
+			InlineMeta:         inlineMeta,
+			TimeoutLabel:       inlineMeta,
+			RenderHint:         renderHint,
+			RawOutputRequested: parseShellToolCallRawOutputRequested(raw),
 		}
 	}
 }
@@ -379,6 +380,16 @@ func parseShellToolCallUserInitiated(raw json.RawMessage) bool {
 		return false
 	}
 	return in.UserInitiated
+}
+
+func parseShellToolCallRawOutputRequested(raw json.RawMessage) bool {
+	var in struct {
+		Raw bool `json:"raw"`
+	}
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return false
+	}
+	return in.Raw
 }
 
 func parseAskQuestionToolCall(raw json.RawMessage) (string, []string, int, bool) {

--- a/server/tools/types_test.go
+++ b/server/tools/types_test.go
@@ -195,6 +195,10 @@ func TestDefinitionContractsBuildTranscriptMetadata(t *testing.T) {
 	if shellMeta.RenderHint == nil || shellMeta.RenderHint.Kind != transcript.ToolRenderKindShell || shellMeta.RenderHint.ShellDialect != transcript.ToolShellDialectPosix {
 		t.Fatalf("expected shell render hint with posix dialect, got %+v", shellMeta.RenderHint)
 	}
+	rawShellMeta := execTool.BuildToolCallMeta(ToolCallContext{DefaultShellPath: "/bin/zsh", GOOS: "darwin"}, json.RawMessage(`{"command":"printf raw","raw":true}`))
+	if !rawShellMeta.RawOutputRequested {
+		t.Fatalf("expected raw exec_command transcript metadata to record raw output request, got %+v", rawShellMeta)
+	}
 
 	patch, _ := DefinitionFor(toolspec.ToolPatch)
 	patchMeta := patch.BuildToolCallMeta(ToolCallContext{WorkingDir: "/workspace"}, json.RawMessage(`"*** Begin Patch\n*** Update File: a.go\n-old\n+new\n*** End Patch\n"`))

--- a/shared/clientui/types.go
+++ b/shared/clientui/types.go
@@ -240,4 +240,6 @@ type ToolCallMeta struct {
 	Suggestions            []string
 	RecommendedOptionIndex int
 	OmitSuccessfulResult   bool
+	RawOutputRequested     bool
+	OutputTruncated        bool
 }

--- a/shared/transcript/entry_compare.go
+++ b/shared/transcript/entry_compare.go
@@ -74,7 +74,9 @@ func ToolCallMetaEqual(left, right *ToolCallMeta) bool {
 		normalizedLeft.Question == normalizedRight.Question &&
 		slices.Equal(normalizedLeft.Suggestions, normalizedRight.Suggestions) &&
 		normalizedLeft.RecommendedOptionIndex == normalizedRight.RecommendedOptionIndex &&
-		normalizedLeft.OmitSuccessfulResult == normalizedRight.OmitSuccessfulResult
+		normalizedLeft.OmitSuccessfulResult == normalizedRight.OmitSuccessfulResult &&
+		normalizedLeft.RawOutputRequested == normalizedRight.RawOutputRequested &&
+		normalizedLeft.OutputTruncated == normalizedRight.OutputTruncated
 }
 
 func toolCallMetaEmpty(meta ToolCallMeta) bool {
@@ -94,7 +96,9 @@ func toolCallMetaEmpty(meta ToolCallMeta) bool {
 		meta.Question == "" &&
 		len(meta.Suggestions) == 0 &&
 		meta.RecommendedOptionIndex == 0 &&
-		!meta.OmitSuccessfulResult
+		!meta.OmitSuccessfulResult &&
+		!meta.RawOutputRequested &&
+		!meta.OutputTruncated
 }
 
 func toolRenderHintsEqual(left, right *ToolRenderHint) bool {

--- a/shared/transcript/toolcodec/codec.go
+++ b/shared/transcript/toolcodec/codec.go
@@ -41,6 +41,8 @@ func isEmptyToolCallMeta(meta transcript.ToolCallMeta) bool {
 		strings.TrimSpace(meta.Question) == "" &&
 		len(meta.Suggestions) == 0 &&
 		meta.RecommendedOptionIndex == 0 &&
+		!meta.RawOutputRequested &&
+		!meta.OutputTruncated &&
 		meta.RenderHint == nil &&
 		meta.PatchRender == nil
 }

--- a/shared/transcript/toolcodec/codec_test.go
+++ b/shared/transcript/toolcodec/codec_test.go
@@ -45,3 +45,19 @@ func TestEncodeDecodeToolCallMetaRoundTripsShellDialect(t *testing.T) {
 		t.Fatalf("expected shell dialect to round-trip, got %+v", meta.RenderHint)
 	}
 }
+
+func TestEncodeDecodeToolCallMetaRoundTripsShellOutputStatus(t *testing.T) {
+	raw := EncodeToolCallMeta(transcript.ToolCallMeta{
+		ToolName:           "exec_command",
+		IsShell:            true,
+		RawOutputRequested: true,
+		OutputTruncated:    true,
+	})
+	meta, ok := DecodeToolCallMeta(raw)
+	if !ok {
+		t.Fatal("expected tool metadata to decode successfully")
+	}
+	if !meta.RawOutputRequested || !meta.OutputTruncated {
+		t.Fatalf("expected shell output status to round-trip, got %+v", meta)
+	}
+}

--- a/shared/transcript/types.go
+++ b/shared/transcript/types.go
@@ -62,6 +62,8 @@ type ToolCallMeta struct {
 	Suggestions            []string
 	RecommendedOptionIndex int
 	OmitSuccessfulResult   bool
+	RawOutputRequested     bool
+	OutputTruncated        bool
 }
 
 func NormalizeToolCallMeta(in ToolCallMeta) ToolCallMeta {

--- a/shared/transcript/types_test.go
+++ b/shared/transcript/types_test.go
@@ -24,3 +24,22 @@ func TestNormalizeToolCallMetaPreservesExplicitRenderHint(t *testing.T) {
 		t.Fatalf("expected explicit render hint preserved, got %+v", meta.RenderHint)
 	}
 }
+
+func TestToolCallMetaEqualIncludesShellOutputStatus(t *testing.T) {
+	left := &ToolCallMeta{ToolName: "exec_command", IsShell: true, RawOutputRequested: true}
+	right := &ToolCallMeta{ToolName: "exec_command", IsShell: true}
+
+	if ToolCallMetaEqual(left, right) {
+		t.Fatal("expected raw output status to affect tool metadata equality")
+	}
+
+	right.RawOutputRequested = true
+	if !ToolCallMetaEqual(left, right) {
+		t.Fatal("expected matching raw output status to be equal")
+	}
+
+	right.OutputTruncated = true
+	if ToolCallMetaEqual(left, right) {
+		t.Fatal("expected truncation status to affect tool metadata equality")
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell commands now track and display raw output mode requests.
  * Output truncation is now detected and displayed with visual warning indicators in the terminal interface.
  * Enhanced metadata preservation for shell tool output status across execution and display.

* **Tests**
  * Added comprehensive test coverage for output truncation tracking and raw output mode functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->