### PR TITLE
fix: drop 'depends_on git' from generated kent formula

### DIFF
--- a/scripts/update-brew-tap.sh
+++ b/scripts/update-brew-tap.sh
@@ -182,7 +182,6 @@ class ${formula_class} < Formula
   depends_on "go" => :build
   depends_on "node" => :build
   depends_on "pnpm" => :build
-  depends_on "git"
   depends_on "ripgrep"
 
   def install


### PR DESCRIPTION
The Homebrew tap's first `kent.rb` PR failed `brew test-bot --only-formulae` on the strict new-formula audit:

```
brew audit --formula respawn-llc/tap/kent --online --new
Error: Don't use 'git' as a dependency (it's always available)
```

`scripts/update-brew-tap.sh` emits `depends_on "git"` into the generated formula. Homebrew forbids this for new formulae (git is provided by macOS CLT and by Homebrew on Linux), so kent resolves git at runtime without declaring it. Removing the line here so future releases don't regenerate the rejected formula.

The in-flight `kent.rb` tap PR was already hand-patched to unblock the 2.0.0 release; this keeps the generator in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unnecessary dependency from the Homebrew formula, streamlining the installation process for users who install via Homebrew.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->