### PR TITLE
fix: prevent native stream slice panic on resize/finalize (#267)

### DIFF
--- a/cli/app/ui_native_stream_controller.go
+++ b/cli/app/ui_native_stream_controller.go
@@ -79,13 +79,20 @@ func (c *nativeAssistantStreamController) Configure(theme string, width int) {
 }
 
 func (c *nativeAssistantStreamController) updateForStableTarget(stableTarget int, done bool) nativeAssistantStreamUpdate {
+	renderedLen := len(c.rendered)
 	if c.invalidatedByResize && !done {
 		stableTarget = c.enqueuedStableLineCount
 	}
-	stableTarget = clampNativeStreamLineCount(stableTarget, c.enqueuedStableLineCount, len(c.rendered))
-	stable := cloneNativeStreamProjectionLines(c.rendered[c.enqueuedStableLineCount:stableTarget])
-	c.enqueuedStableLineCount = stableTarget
-	tail := cloneNativeStreamProjectionLines(c.rendered[c.enqueuedStableLineCount:])
+	// Already-committed scrollback lines are immutable: never retract or re-emit
+	// them. A re-render (notably after a width change that unwraps lines) can
+	// yield fewer lines than were already committed during incremental
+	// streaming, so clamp the slice bounds to the rendered length to avoid
+	// slicing with a low bound past the slice end.
+	committed := min(c.enqueuedStableLineCount, renderedLen)
+	stableTarget = clampNativeStreamLineCount(stableTarget, committed, renderedLen)
+	stable := cloneNativeStreamProjectionLines(c.rendered[committed:stableTarget])
+	c.enqueuedStableLineCount = max(c.enqueuedStableLineCount, stableTarget)
+	tail := cloneNativeStreamProjectionLines(c.rendered[min(c.enqueuedStableLineCount, renderedLen):])
 	if c.invalidatedByResize {
 		tail = cloneNativeStreamProjectionLines(c.rendered)
 	}

--- a/cli/app/ui_native_stream_controller_test.go
+++ b/cli/app/ui_native_stream_controller_test.go
@@ -134,6 +134,52 @@ func TestNativeAssistantStreamControllerResizeInvalidatesFurtherPromotion(t *tes
 	}
 }
 
+func TestNativeAssistantStreamControllerReRenderShorterThanCommittedDoesNotPanic(t *testing.T) {
+	controller := newNativeAssistantStreamController("dark", 24)
+
+	// Promote a wrapped paragraph as several stable lines at a narrow width.
+	controller.Append("This is a fairly long paragraph that wraps across several lines.\n\n")
+	if controller.enqueuedStableLineCount < 2 {
+		t.Fatalf("expected wrapped paragraph to promote multiple stable lines, got %d", controller.enqueuedStableLineCount)
+	}
+
+	// Re-render the same source at a wider layout so it unwraps into fewer lines
+	// than were already committed to scrollback. This models a pane-width change
+	// such as toggling detail mode, not just a terminal resize.
+	controller.Configure(controller.theme, 400)
+	if got := len(controller.rendered); got >= controller.enqueuedStableLineCount {
+		t.Fatalf("expected widened re-render to produce fewer lines than committed, rendered %d committed %d", got, controller.enqueuedStableLineCount)
+	}
+
+	// Finalizing while the re-render is shorter than the committed count must
+	// not slice past the rendered output, and must not retract committed lines.
+	final := controller.Finalize()
+	if got := len(final.stable); got != 0 {
+		t.Fatalf("expected no stable promotion when re-render shrank below committed count, got %#v", final.stable)
+	}
+	if final.tail != nil {
+		t.Fatalf("expected finalize to clear the live tail, got %#v", final.tail)
+	}
+}
+
+func TestNativeAssistantStreamControllerApplySourceShorterThanCommittedDoesNotPanic(t *testing.T) {
+	controller := newNativeAssistantStreamController("dark", 24)
+
+	// Promote wrapped lines at a narrow width via the streaming sync entry point.
+	controller.ApplySource("This is a fairly long paragraph that wraps across several lines.\n\n", "dark", 24)
+	if controller.enqueuedStableLineCount < 2 {
+		t.Fatalf("expected wrapped paragraph to promote multiple stable lines, got %d", controller.enqueuedStableLineCount)
+	}
+
+	// Re-applying the prefix-continuation source at a wider width (e.g. on a
+	// detail-mode toggle) re-renders into fewer lines than already committed and
+	// must not panic.
+	update := controller.ApplySource("This is a fairly long paragraph that wraps across several lines.\n\n", "dark", 400)
+	if got := len(update.stable); got != 0 {
+		t.Fatalf("expected no stable promotion when re-render shrank below committed count, got %#v", update.stable)
+	}
+}
+
 func joinedPlainProjectionLines(lines []tui.TranscriptProjectionLine) string {
 	parts := make([]string, 0, len(lines))
 	for _, line := range lines {


### PR DESCRIPTION
## Summary

Fixes #267 — a TUI panic (`slice bounds out of range`, e.g. `[10:9]` / `[3:1]`) in `nativeAssistantStreamController.updateForStableTarget`.

## Root cause

`enqueuedStableLineCount` tracks lines already promoted to (immutable) scrollback. A re-render of the live stream can produce **fewer** lines than were already committed — this happens when the live area is re-rendered at a **different pane width**, which unwraps previously wrapped lines. No terminal resize is required: toggling detail mode re-applies the source via `syncNativeStreamingScrollback` at a different `nativeReplayRenderWidth()`, which matches the reported repro (cancel stream mid-stream, then enter/leave detail mode).

When `len(rendered) < enqueuedStableLineCount`, the code sliced `rendered[enqueuedStableLineCount:stableTarget]` with a low bound past the slice end, panicking the whole program. The existing `clampNativeStreamLineCount` only lowered the *target*, leaving the slice's low bound unbounded.

## Fix

In `updateForStableTarget`, clamp every slice low bound to the rendered length and never retract already-committed lines:
- `committed = min(enqueuedStableLineCount, len(rendered))` for slice starts
- keep `enqueuedStableLineCount` monotonic via `max(...)` so committed scrollback is never re-emitted (preserving the append-only scrollback invariant)

When the re-render is shorter than the committed count, no new stable lines are emitted and the tail is empty — no panic.

## Tests

- `TestNativeAssistantStreamControllerReRenderShorterThanCommittedDoesNotPanic` — promotes wrapped lines at a narrow width, re-renders wider (models a detail-mode/pane-width change), then finalizes. Reproduces the exact `slice bounds out of range [3:1]` panic before the fix.
- `TestNativeAssistantStreamControllerApplySourceShorterThanCommittedDoesNotPanic` — same shrink through the `ApplySource` streaming-sync path.

All `cli/app` tests pass; `./scripts/build.sh` succeeds.