### PR TITLE
fix: serialize workflow questions

### DIFF
--- a/apps/desktop/src/api/jsonRpc.test.ts
+++ b/apps/desktop/src/api/jsonRpc.test.ts
@@ -212,6 +212,100 @@ describe("JsonRpcWebSocketTransport", () => {
     expect(errors).toEqual(["Subscription socket closed."]);
     subscription.close();
   });
+
+  it("reopens subscription socket after server complete notification", async () => {
+    const transport = createJsonRpcTransport("ws://127.0.0.1:53082/rpc");
+    const completions: string[] = [];
+    const errors: string[] = [];
+    const subscription = transport.subscribe(
+      "workflow.subscribeProject",
+      { project_id: "project-1" },
+      {
+        onEvent() {
+          return;
+        },
+        onComplete(code, message) {
+          completions.push(`${code.toString()}:${message}`);
+        },
+        onError(error) {
+          errors.push(error.message);
+        },
+      },
+    );
+
+    const firstSocket = sockets[0] ?? failTest("subscription socket missing");
+    firstSocket.open();
+    await waitForSent(firstSocket, 1);
+    ack(firstSocket, 0);
+    await waitForSent(firstSocket, 2);
+    ack(firstSocket, 1);
+    await flushPromises();
+
+    firstSocket.receive(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "workflow.project.complete",
+        params: { code: 409, message: "stream gap" },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(sockets.length).toBeGreaterThanOrEqual(2);
+    });
+    const secondSocket = sockets[1] ?? failTest("resubscription socket missing");
+    secondSocket.open();
+    await waitForSent(secondSocket, 1);
+    ack(secondSocket, 0);
+    await waitForSent(secondSocket, 2);
+
+    expect(frame(secondSocket, 1)).toMatchObject({ method: "workflow.subscribeProject" });
+    expect(completions).toEqual(["409:stream gap"]);
+    expect(errors).toEqual(["Subscription socket closed."]);
+    subscription.close();
+  });
+
+  it("does not reconnect after normal server complete notification", async () => {
+    const transport = createJsonRpcTransport("ws://127.0.0.1:53082/rpc");
+    const completions: string[] = [];
+    const errors: string[] = [];
+    const subscription = transport.subscribe(
+      "workflow.subscribeProject",
+      { project_id: "project-1" },
+      {
+        onEvent() {
+          return;
+        },
+        onComplete(code, message) {
+          completions.push(`${code.toString()}:${message}`);
+        },
+        onError(error) {
+          errors.push(error.message);
+        },
+      },
+    );
+
+    const socket = sockets[0] ?? failTest("subscription socket missing");
+    socket.open();
+    await waitForSent(socket, 1);
+    ack(socket, 0);
+    await waitForSent(socket, 2);
+    ack(socket, 1);
+    await flushPromises();
+
+    socket.receive(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "workflow.project.complete",
+        params: { code: 0, message: "" },
+      }),
+    );
+    await flushPromises();
+
+    expect(completions).toEqual(["0:"]);
+    expect(errors).toEqual([]);
+    expect(sockets).toHaveLength(1);
+    subscription.close();
+  });
 });
 
 function ack(socket: MockWebSocket, sentIndex: number): void {

--- a/apps/desktop/src/api/jsonRpc.test.ts
+++ b/apps/desktop/src/api/jsonRpc.test.ts
@@ -306,6 +306,49 @@ describe("JsonRpcWebSocketTransport", () => {
     expect(sockets).toHaveLength(1);
     subscription.close();
   });
+
+  it("keeps subscriptions active for non-terminal events ending with complete", async () => {
+    const transport = createJsonRpcTransport("ws://127.0.0.1:53082/rpc");
+    const events: string[] = [];
+    const completions: string[] = [];
+    const subscription = transport.subscribe(
+      "workflow.subscribeProject",
+      { project_id: "project-1" },
+      {
+        onEvent(method) {
+          events.push(method);
+        },
+        onComplete(code, message) {
+          completions.push(`${code.toString()}:${message}`);
+        },
+        onError(error) {
+          throw error;
+        },
+      },
+    );
+
+    const socket = sockets[0] ?? failTest("subscription socket missing");
+    socket.open();
+    await waitForSent(socket, 1);
+    ack(socket, 0);
+    await waitForSent(socket, 2);
+    ack(socket, 1);
+    await flushPromises();
+
+    socket.receive(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "workflow.project.task.complete",
+        params: { event: { project_id: "project-1" } },
+      }),
+    );
+    await flushPromises();
+
+    expect(events).toEqual(["workflow.project.task.complete"]);
+    expect(completions).toEqual([]);
+    expect(sockets).toHaveLength(1);
+    subscription.close();
+  });
 });
 
 function ack(socket: MockWebSocket, sentIndex: number): void {

--- a/apps/desktop/src/api/jsonRpc.ts
+++ b/apps/desktop/src/api/jsonRpc.ts
@@ -13,6 +13,7 @@ import {
   responseSchema,
   sendSocketRequest,
   socketRequestError,
+  subscriptionCompleteMethod,
   waitForSubscriptionEnd,
 } from "./jsonRpcSocket";
 import type { RpcEventHandler, RpcSubscription, RpcTransport } from "./transport";
@@ -215,8 +216,9 @@ class JsonRpcWebSocketTransport implements RpcTransport {
     const terminalCompleteRef: { current: Readonly<{ code: number; message: string }> | null } = {
       current: null,
     };
+    const completeMethod = subscriptionCompleteMethod(method);
     const subscriptionListener = (event: MessageEvent<unknown>) => {
-      const result = handleSubscriptionMessage(event, handler);
+      const result = handleSubscriptionMessage(event, handler, completeMethod);
       if (result.kind === "complete") {
         terminalCompleteRef.current = { code: result.code, message: result.message };
         socket.close();

--- a/apps/desktop/src/api/jsonRpc.ts
+++ b/apps/desktop/src/api/jsonRpc.ts
@@ -212,14 +212,26 @@ class JsonRpcWebSocketTransport implements RpcTransport {
       { once: true },
     );
     await handshakeSubscription(socket, rpcRequestTimeoutMs);
+    const terminalCompleteRef: { current: Readonly<{ code: number; message: string }> | null } = {
+      current: null,
+    };
     const subscriptionListener = (event: MessageEvent<unknown>) => {
-      handleSubscriptionMessage(event, handler);
+      const result = handleSubscriptionMessage(event, handler);
+      if (result.kind === "complete") {
+        terminalCompleteRef.current = { code: result.code, message: result.message };
+        socket.close();
+      }
     };
     socket.addEventListener("message", subscriptionListener);
     try {
       await sendSocketRequest(socket, method, params, rpcRequestTimeoutMs);
       handler.onOpen?.();
       await waitForSubscriptionEnd(socket, signal);
+    } catch (error) {
+      if (terminalCompleteRef.current?.code === 0) {
+        return;
+      }
+      throw error;
     } finally {
       socket.removeEventListener("message", subscriptionListener);
       socket.close();

--- a/apps/desktop/src/api/jsonRpcSocket.ts
+++ b/apps/desktop/src/api/jsonRpcSocket.ts
@@ -193,24 +193,29 @@ export async function delay(milliseconds: number, signal: AbortSignal): Promise<
   });
 }
 
-export function handleSubscriptionMessage(event: MessageEvent<unknown>, handler: RpcEventHandler): void {
+export type SubscriptionMessageResult = Readonly<
+  | { kind: "active" }
+  | { kind: "complete"; code: number; message: string }
+>;
+
+export function handleSubscriptionMessage(event: MessageEvent<unknown>, handler: RpcEventHandler): SubscriptionMessageResult {
   if (typeof event.data !== "string") {
-    return;
+    return { kind: "active" };
   }
   const parsed = parseFrame(event.data);
   const notification = notificationSchema.safeParse(parsed);
   if (!notification.success) {
-    return;
+    return { kind: "active" };
   }
   if (notification.data.method.endsWith(".complete")) {
     const complete = z
       .object({ code: z.number().optional(), message: z.string().optional() })
       .safeParse(notification.data.params);
-    handler.onComplete(
-      complete.success ? (complete.data.code ?? 0) : 0,
-      complete.success ? (complete.data.message ?? "") : "",
-    );
-    return;
+    const code = complete.success ? (complete.data.code ?? 0) : 0;
+    const message = complete.success ? (complete.data.message ?? "") : "";
+    handler.onComplete(code, message);
+    return { kind: "complete", code, message };
   }
   handler.onEvent(notification.data.method, notification.data.params);
+  return { kind: "active" };
 }

--- a/apps/desktop/src/api/jsonRpcSocket.ts
+++ b/apps/desktop/src/api/jsonRpcSocket.ts
@@ -198,7 +198,22 @@ export type SubscriptionMessageResult = Readonly<
   | { kind: "complete"; code: number; message: string }
 >;
 
-export function handleSubscriptionMessage(event: MessageEvent<unknown>, handler: RpcEventHandler): SubscriptionMessageResult {
+export function subscriptionCompleteMethod(subscriptionMethod: string): string | null {
+  switch (subscriptionMethod) {
+    case "workflow.subscribe":
+      return "workflow.complete";
+    case "workflow.subscribeProject":
+      return "workflow.project.complete";
+    default:
+      return null;
+  }
+}
+
+export function handleSubscriptionMessage(
+  event: MessageEvent<unknown>,
+  handler: RpcEventHandler,
+  completeMethod: string | null,
+): SubscriptionMessageResult {
   if (typeof event.data !== "string") {
     return { kind: "active" };
   }
@@ -207,7 +222,7 @@ export function handleSubscriptionMessage(event: MessageEvent<unknown>, handler:
   if (!notification.success) {
     return { kind: "active" };
   }
-  if (notification.data.method.endsWith(".complete")) {
+  if (completeMethod !== null && notification.data.method === completeMethod) {
     const complete = z
       .object({ code: z.number().optional(), message: z.string().optional() })
       .safeParse(notification.data.params);

--- a/apps/desktop/src/app/workflowProjectEvents.test.ts
+++ b/apps/desktop/src/app/workflowProjectEvents.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  workflowProjectEvent,
+  workflowProjectEventCanChangeAttention,
+  workflowProjectQuestionTaskID,
+} from "./workflowProjectEvents";
+
+describe("workflowProjectEvent", () => {
+  it("parses workflow project event params", () => {
+    expect(
+      workflowProjectEvent({
+        event: {
+          action: "question_waiting",
+          changed_ids: ["task-1", "run-1", "ask-1"],
+          project_id: "project-1",
+          resource: "task",
+          workflow_id: "workflow-1",
+        },
+      }),
+    ).toEqual({
+      action: "question_waiting",
+      changedIDs: ["task-1", "run-1", "ask-1"],
+      projectID: "project-1",
+      resource: "task",
+      workflowID: "workflow-1",
+    });
+  });
+
+  it("recognizes resources that can affect attention", () => {
+    expect(workflowProjectEventCanChangeAttention({ event: { resource: "task" } })).toBe(true);
+    expect(workflowProjectEventCanChangeAttention({ event: { resource: "workflow_link" } })).toBe(true);
+    expect(workflowProjectEventCanChangeAttention({ event: { resource: "runtime_log" } })).toBe(false);
+    expect(workflowProjectEventCanChangeAttention({})).toBe(false);
+  });
+
+  it("extracts task ids from question lifecycle events", () => {
+    expect(
+      workflowProjectQuestionTaskID({
+        event: {
+          action: "question_waiting",
+          changed_ids: ["task-1", "run-1", "ask-1"],
+          resource: "task",
+        },
+      }),
+    ).toBe("task-1");
+    expect(workflowProjectQuestionTaskID({ event: { action: "completed", changed_ids: ["task-1"], resource: "task" } })).toBeNull();
+    expect(workflowProjectQuestionTaskID({ event: { action: "question_waiting", changed_ids: [], resource: "task" } })).toBeNull();
+  });
+});

--- a/apps/desktop/src/app/workflowProjectEvents.ts
+++ b/apps/desktop/src/app/workflowProjectEvents.ts
@@ -1,0 +1,55 @@
+export type WorkflowProjectEvent = Readonly<{
+  action: string;
+  changedIDs: readonly string[];
+  projectID: string;
+  resource: string;
+  workflowID: string;
+}>;
+
+export function workflowProjectEvent(params: unknown): WorkflowProjectEvent | null {
+  if (!isRecord(params) || !("event" in params)) {
+    return null;
+  }
+  const rawEvent = params.event;
+  if (!isRecord(rawEvent)) {
+    return null;
+  }
+  return {
+    action: stringField(rawEvent, "action"),
+    changedIDs: stringArrayField(rawEvent, "changed_ids"),
+    projectID: stringField(rawEvent, "project_id"),
+    resource: stringField(rawEvent, "resource"),
+    workflowID: stringField(rawEvent, "workflow_id"),
+  };
+}
+
+export function workflowProjectEventCanChangeAttention(params: unknown): boolean {
+  const event = workflowProjectEvent(params);
+  return event !== null && attentionResources.has(event.resource);
+}
+
+export function workflowProjectQuestionTaskID(params: unknown): string | null {
+  const event = workflowProjectEvent(params);
+  if (event?.resource !== "task" || !questionActions.has(event.action)) {
+    return null;
+  }
+  const taskID = event.changedIDs[0] ?? "";
+  return taskID.length > 0 ? taskID : null;
+}
+
+const attentionResources = new Set(["task", "workflow", "workflow_link"]);
+const questionActions = new Set(["question_waiting", "question_cleared", "question_answered"]);
+
+function stringField(value: Readonly<Record<string, unknown>>, key: string): string {
+  const raw = value[key];
+  return typeof raw === "string" ? raw : "";
+}
+
+function stringArrayField(value: Readonly<Record<string, unknown>>, key: string): readonly string[] {
+  const raw = value[key];
+  return Array.isArray(raw) ? raw.filter((item): item is string => typeof item === "string") : [];
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/desktop/src/features/board/BoardCardMotionModel.test.ts
+++ b/apps/desktop/src/features/board/BoardCardMotionModel.test.ts
@@ -124,6 +124,7 @@ describe("BoardCardMotionModel", () => {
         pendingMove,
       ),
     ).toBe(false);
+    expect(pendingBoardCardMoveDestinationMissing(boardCardSnapshotFromEntries([["backlog", []]]), pendingMove)).toBe(false);
     expect(pendingBoardCardMoveDestinationMissing(boardCardSnapshotFromEntries([]), null)).toBe(false);
   });
 });

--- a/apps/desktop/src/features/board/BoardCardMotionModel.test.ts
+++ b/apps/desktop/src/features/board/BoardCardMotionModel.test.ts
@@ -8,6 +8,7 @@ import {
   boardCardSnapshotsEqual,
   boardCardViewTransitionName,
   dirtyBoardCardCountColumnIDs,
+  pendingBoardCardMoveDestinationMissing,
 } from "./BoardCardMotionModel";
 
 describe("BoardCardMotionModel", () => {
@@ -100,6 +101,30 @@ describe("BoardCardMotionModel", () => {
       "backlog",
       "recon",
     ]);
+  });
+
+  it("detects pending manual move snapshots that are still missing the destination card", () => {
+    const pendingMove = { taskID: "task-1", targetColumnID: "review" };
+
+    expect(
+      pendingBoardCardMoveDestinationMissing(
+        boardCardSnapshotFromEntries([
+          ["backlog", []],
+          ["review", []],
+        ]),
+        pendingMove,
+      ),
+    ).toBe(true);
+    expect(
+      pendingBoardCardMoveDestinationMissing(
+        boardCardSnapshotFromEntries([
+          ["backlog", []],
+          ["review", [card("task-1")]],
+        ]),
+        pendingMove,
+      ),
+    ).toBe(false);
+    expect(pendingBoardCardMoveDestinationMissing(boardCardSnapshotFromEntries([]), null)).toBe(false);
   });
 });
 

--- a/apps/desktop/src/features/board/BoardCardMotionModel.ts
+++ b/apps/desktop/src/features/board/BoardCardMotionModel.ts
@@ -115,7 +115,10 @@ export function pendingBoardCardMoveDestinationMissing(
   if (pendingMove === null) {
     return false;
   }
-  const targetCards = snapshot.get(pendingMove.targetColumnID) ?? [];
+  const targetCards = snapshot.get(pendingMove.targetColumnID);
+  if (targetCards === undefined) {
+    return false;
+  }
   return !targetCards.some((card) => card.id === pendingMove.taskID);
 }
 

--- a/apps/desktop/src/features/board/BoardCardMotionModel.ts
+++ b/apps/desktop/src/features/board/BoardCardMotionModel.ts
@@ -10,6 +10,11 @@ export type BoardCardMotionParticipants = Readonly<{
   revealCardIDs: ReadonlySet<string>;
 }>;
 
+export type PendingBoardCardMove = Readonly<{
+  targetColumnID: string;
+  taskID: string;
+}>;
+
 export function boardCardViewTransitionName(taskID: string): string {
   const encoded = Array.from(taskID, (char) => {
     const codePoint = char.codePointAt(0);
@@ -101,6 +106,17 @@ export function boardCardColumnCountSnapshot(
 
 export function boardCardColumnIDsWithCards(snapshot: BoardCardColumnsSnapshot): ReadonlySet<string> {
   return new Set(Array.from(snapshot, ([columnID, cards]) => (cards.length > 0 ? columnID : "")).filter(Boolean));
+}
+
+export function pendingBoardCardMoveDestinationMissing(
+  snapshot: BoardCardColumnsSnapshot,
+  pendingMove: PendingBoardCardMove | null,
+): boolean {
+  if (pendingMove === null) {
+    return false;
+  }
+  const targetCards = snapshot.get(pendingMove.targetColumnID) ?? [];
+  return !targetCards.some((card) => card.id === pendingMove.taskID);
 }
 
 export function boardRailLayoutSignature(

--- a/apps/desktop/src/features/board/BoardRailMotionController.tsx
+++ b/apps/desktop/src/features/board/BoardRailMotionController.tsx
@@ -25,8 +25,10 @@ import {
   cardBelongsToColumn,
   dirtyBoardCardCountColumnIDs,
   dirtyBoardCardColumnIDs,
+  pendingBoardCardMoveDestinationMissing,
   type BoardCardColumnCountSnapshot,
   type BoardCardColumnsSnapshot,
+  type PendingBoardCardMove,
 } from "./BoardCardMotionModel";
 import { toKanbanCardVM, toKanbanColumnVM, toKanbanGroupVM, type KanbanCardVM } from "./BoardColumnViewModel";
 import type { BoardCardDragPayload, BoardColumnDropState } from "./BoardDragTypes";
@@ -78,11 +80,13 @@ export type BoardRailMotionControllerProps = Readonly<{
   onInterruptedRunObserved: (input: Readonly<{ runID: string; taskID: string }>) => void;
   onInterruptTask: (taskID: string, runID: string) => void;
   onResumeTask: (taskID: string, runID: string) => void;
+  pendingCardMove: PendingBoardCardMove | null;
   scrollportRef: RefObject<HTMLDivElement | null>;
 }>;
 
 const staleSnapshotTimeoutMs = 900;
 const emptyColumnsSnapshot: BoardCardColumnsSnapshot = new Map();
+const emptyPendingMoveColumnIDs: ReadonlySet<string> = new Set();
 
 export function BoardRailMotionController({
   actionsDisabled,
@@ -100,6 +104,7 @@ export function BoardRailMotionController({
   onInterruptedRunObserved,
   onInterruptTask,
   onResumeTask,
+  pendingCardMove,
   scrollportRef,
 }: BoardRailMotionControllerProps) {
   const sections = useMemo(() => boardSections(board), [board]);
@@ -118,6 +123,12 @@ export function BoardRailMotionController({
   const displayedColumns = displayedSnapshot.layoutSignature === layoutSignature ? displayedSnapshot.columns : emptyColumnsSnapshot;
   const displayedColumnCounts =
     displayedSnapshot.layoutSignature === layoutSignature ? displayedSnapshot.columnCounts : boardColumnCounts;
+  const pendingMoveColumnIDs = useMemo(() => {
+    if (pendingCardMove === null) {
+      return emptyPendingMoveColumnIDs;
+    }
+    return new Set([...boardCardColumnIDsWithCards(displayedColumns), pendingCardMove.targetColumnID]);
+  }, [displayedColumns, pendingCardMove]);
   const latestColumnsRef = useRef<ReadonlyMap<string, BoardColumnQuerySnapshot>>(new Map());
   const displayedColumnsRef = useRef(displayedColumns);
   const displayedColumnCountsRef = useRef(displayedColumnCounts);
@@ -163,7 +174,7 @@ export function BoardRailMotionController({
           dirtyCountColumnSet.has(columnID),
         ),
       );
-      if (!fromTimeout && !dirtySettled) {
+      if (!dirtySettled && (!fromTimeout || pendingBoardCardMoveDestinationMissing(nextDisplayed, pendingCardMove))) {
         clearStaleSnapshotTimer(timeoutRef);
         timeoutRef.current = window.setTimeout(() => {
           timeoutRef.current = null;
@@ -196,7 +207,7 @@ export function BoardRailMotionController({
         revealCardIDs: participants.revealCardIDs,
       });
     },
-    [latestSnapshot, layoutSignature],
+    [latestSnapshot, layoutSignature, pendingCardMove],
   );
 
   useLayoutEffect(() => {
@@ -357,7 +368,7 @@ export function BoardRailMotionController({
   );
 
   function effectiveColumnIsCollapsed(column: BoardColumn): boolean {
-    return columnIsCollapsed(column) && !heldExpandedColumnIDs.has(column.id);
+    return columnIsCollapsed(column) && !heldExpandedColumnIDs.has(column.id) && !pendingMoveColumnIDs.has(column.id);
   }
 
   return (

--- a/apps/desktop/src/features/board/BoardRailMotionController.tsx
+++ b/apps/desktop/src/features/board/BoardRailMotionController.tsx
@@ -394,7 +394,7 @@ export function BoardRailMotionController({
                   isCollapsed={effectiveColumnIsCollapsed(column)}
                   isFirstActive={column.id === firstActiveID}
                   key={`${board.projectID}:${board.selectedWorkflow.id}:${column.id}`}
-                  latestIsCollapsed={columnIsCollapsed(column)}
+                  latestIsCollapsed={effectiveColumnIsCollapsed(column)}
                   onCardClick={onCardClick}
                   onCardDragEnd={onCardDragEnd}
                   onCardDragStart={onCardDragStart}
@@ -420,7 +420,7 @@ export function BoardRailMotionController({
               isCollapsed={effectiveColumnIsCollapsed(section.column)}
               isFirstActive={section.column.id === firstActiveID}
               key={`${board.projectID}:${board.selectedWorkflow.id}:${section.id}`}
-              latestIsCollapsed={columnIsCollapsed(section.column)}
+              latestIsCollapsed={effectiveColumnIsCollapsed(section.column)}
               onCardClick={onCardClick}
               onCardDragEnd={onCardDragEnd}
               onCardDragStart={onCardDragStart}

--- a/apps/desktop/src/features/board/BoardRoute.tsx
+++ b/apps/desktop/src/features/board/BoardRoute.tsx
@@ -31,6 +31,7 @@ import {
   type PendingDrop,
   type PendingMissingInputDrop,
 } from "./BoardDropActions";
+import type { PendingBoardCardMove } from "./BoardCardMotionModel";
 import { MissingInputsDialog, RollbackStartDialog } from "./BoardDropDialogs";
 import "./board.css";
 import { useBoard, useBoardTaskActions, useProjectBoardSubscription } from "./useBoardData";
@@ -145,6 +146,7 @@ function BoardContent({
   const { t } = useTranslation();
   const [workflowIssuesCollapsed, setWorkflowIssuesCollapsed] = useState(false);
   const [activeDrag, setActiveDrag] = useState<BoardCardDragPayload | null>(null);
+  const [pendingCardMove, setPendingCardMove] = useState<PendingBoardCardMove | null>(null);
   const [expandedEmptyColumns, setExpandedEmptyColumns] = useState<
     Readonly<{ ids: ReadonlySet<string>; scope: string }>
   >(() => ({ ids: new Set(), scope: "" }));
@@ -253,7 +255,14 @@ function BoardContent({
     }
     const dropAction = classifyDrop(column, dragPayload, firstActive?.id);
     if (dropAction.kind === "start") {
-      void actions.start.mutateAsync(dragPayload.taskID).catch(reportStartError);
+      const pendingMove = { taskID: dragPayload.taskID, targetColumnID: column.id };
+      setPendingCardMove(pendingMove);
+      void actions.start
+        .mutateAsync(dragPayload.taskID)
+        .catch(reportStartError)
+        .finally(() => {
+          clearPendingCardMove(pendingMove);
+        });
       return;
     }
     if (dropAction.kind === "move") {
@@ -265,10 +274,15 @@ function BoardContent({
           : { allowMissingEdge: dropAction.allowMissingEdge }),
         ...(dropAction.autoApprove === undefined ? {} : { autoApprove: dropAction.autoApprove }),
       };
+      const pendingMove = { taskID: dragPayload.taskID, targetColumnID: column.id };
+      setPendingCardMove(pendingMove);
       void actions.move
         .mutateAsync(moveInput)
         .then(moveRunFeedback.trackMoveRunIDs)
-        .catch(reportMoveError);
+        .catch(reportMoveError)
+        .finally(() => {
+          clearPendingCardMove(pendingMove);
+        });
       return;
     }
     if (dropAction.kind === "confirmRollback") {
@@ -377,10 +391,15 @@ function BoardContent({
     }
     const drop = rollbackDrop;
     setRollbackDrop(null);
+    const pendingMove = { taskID: drop.taskID, targetColumnID: drop.targetColumn.id };
+    setPendingCardMove(pendingMove);
     void actions.move
       .mutateAsync({ taskID: drop.taskID, targetNodeID: drop.targetColumn.id, autoApprove: true })
       .then(moveRunFeedback.trackMoveRunIDs)
-      .catch(reportMoveError);
+      .catch(reportMoveError)
+      .finally(() => {
+        clearPendingCardMove(pendingMove);
+      });
   }
 
   function submitMissingInputDrop(event: SyntheticEvent<HTMLFormElement>): void {
@@ -390,6 +409,8 @@ function BoardContent({
     }
     const drop = missingInputDrop;
     setMissingInputDrop(null);
+    const pendingMove = { taskID: drop.taskID, targetColumnID: drop.targetColumn.id };
+    setPendingCardMove(pendingMove);
     void actions.move
       .mutateAsync({
         taskID: drop.taskID,
@@ -399,7 +420,16 @@ function BoardContent({
         autoApprove: drop.targetColumn.kind === "agent",
       })
       .then(moveRunFeedback.trackMoveRunIDs)
-      .catch(reportMoveError);
+      .catch(reportMoveError)
+      .finally(() => {
+        clearPendingCardMove(pendingMove);
+      });
+  }
+
+  function clearPendingCardMove(pendingMove: PendingBoardCardMove): void {
+    setPendingCardMove((current) =>
+      current?.taskID === pendingMove.taskID && current.targetColumnID === pendingMove.targetColumnID ? null : current,
+    );
   }
 
   function openTask(taskID: string): void {
@@ -466,6 +496,7 @@ function BoardContent({
           onExpandColumn={expandColumn}
           onInterruptedRunObserved={moveRunFeedback.observeInterruptedRun}
           onInterruptTask={interruptTask}
+          pendingCardMove={pendingCardMove}
           onResumeTask={resumeTask}
           scrollportRef={scrollportRef}
         />

--- a/apps/desktop/src/features/board/useBoardData.test.ts
+++ b/apps/desktop/src/features/board/useBoardData.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldRefreshBoardFromProjectEvent } from "./useBoardData";
+
+describe("shouldRefreshBoardFromProjectEvent", () => {
+  it("refreshes active workflow task events", () => {
+    expect(
+      shouldRefreshBoardFromProjectEvent(
+        eventParams({ resource: "task", workflow_id: "workflow-active" }),
+        "workflow-route",
+        "workflow-active",
+      ),
+    ).toBe(true);
+  });
+
+  it("skips unrelated workflow task events", () => {
+    expect(
+      shouldRefreshBoardFromProjectEvent(
+        eventParams({ resource: "task", workflow_id: "workflow-other" }),
+        "workflow-route",
+        "workflow-active",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps workflow-link and unknown events conservative", () => {
+    expect(
+      shouldRefreshBoardFromProjectEvent(
+        eventParams({ resource: "workflow_link", workflow_id: "workflow-other" }),
+        "workflow-route",
+        "workflow-active",
+      ),
+    ).toBe(true);
+    expect(shouldRefreshBoardFromProjectEvent({}, "workflow-route", "workflow-active")).toBe(true);
+  });
+});
+
+function eventParams(event: Readonly<Record<string, unknown>>) {
+  return { event };
+}

--- a/apps/desktop/src/features/board/useBoardData.ts
+++ b/apps/desktop/src/features/board/useBoardData.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from "react";
 import { queryKeys } from "../../app/queryKeys";
 import { useAppServices } from "../../app/useAppServices";
 import { useConnectionSnapshot } from "../../app/useConnectionSnapshot";
+import { workflowProjectEvent, workflowProjectQuestionTaskID } from "../../app/workflowProjectEvents";
 
 export function useBoard(projectID: string, workflowID: string) {
   const { api } = useAppServices();
@@ -61,6 +62,17 @@ export function useProjectBoardSubscription(
       await queryClient.invalidateQueries({ queryKey: queryKeys.attention("") });
       await queryClient.invalidateQueries({ queryKey: queryKeys.attention(projectID) });
     }
+    async function refreshQuestionTask(params: unknown): Promise<void> {
+      const taskID = workflowProjectQuestionTaskID(params);
+      if (taskID === null) {
+        return;
+      }
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.task(taskID), refetchType: "active" }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.activity(taskID), refetchType: "active" }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.allPendingAsks, refetchType: "active" }),
+      ]);
+    }
     const subscription = api.subscribeProject(projectID, {
       onOpen() {
         void refresh().catch(consumeBackgroundError);
@@ -69,10 +81,13 @@ export function useProjectBoardSubscription(
         if (isDeletedTaskEvent(params, selectedTaskID)) {
           onSelectedTaskDeleted?.();
         }
-        void refresh().catch(consumeBackgroundError);
+        void refreshQuestionTask(params).catch(consumeBackgroundError);
+        if (shouldRefreshBoardFromProjectEvent(params, boardQueryWorkflowID, selectedWorkflowID)) {
+          void refresh().catch(consumeBackgroundError);
+        }
       },
       onComplete() {
-        return;
+        void refresh().catch(consumeBackgroundError);
       },
       onError() {
         void refresh().catch(consumeBackgroundError);
@@ -98,35 +113,37 @@ export function useProjectBoardSubscription(
 
 function isDeletedTaskEvent(params: unknown, taskID: string): boolean {
   const trimmedTaskID = taskID.trim();
-  if (trimmedTaskID.length === 0 || !isRecord(params) || !("event" in params)) {
-    return false;
-  }
-  const rawEvent = params.event;
-  if (!isRecord(rawEvent)) {
+  const event = workflowProjectEvent(params);
+  if (trimmedTaskID.length === 0 || event === null) {
     return false;
   }
   return (
-    stringField(rawEvent, "resource") === "task" &&
-    stringField(rawEvent, "action") === "deleted" &&
-    stringArrayField(rawEvent, "changed_ids").includes(trimmedTaskID)
+    event.resource === "task" &&
+    event.action === "deleted" &&
+    event.changedIDs.includes(trimmedTaskID)
   );
 }
 
-function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function stringField(value: Readonly<Record<string, unknown>>, key: string): string {
-  const raw = value[key];
-  return typeof raw === "string" ? raw : "";
-}
-
-function stringArrayField(value: Readonly<Record<string, unknown>>, key: string): readonly string[] {
-  const raw = value[key];
-  if (!Array.isArray(raw)) {
-    return [];
+export function shouldRefreshBoardFromProjectEvent(
+  params: unknown,
+  boardQueryWorkflowID: string,
+  selectedWorkflowID: string,
+): boolean {
+  const event = workflowProjectEvent(params);
+  if (event === null) {
+    return true;
   }
-  return raw.filter((item): item is string => typeof item === "string");
+  if (event.resource === "workflow_link") {
+    return true;
+  }
+  if (event.resource === "workflow" || event.resource === "task") {
+    return (
+      event.workflowID.length === 0 ||
+      event.workflowID === boardQueryWorkflowID ||
+      event.workflowID === selectedWorkflowID
+    );
+  }
+  return false;
 }
 
 export function useBoardTaskActions(

--- a/apps/desktop/src/features/home/HomeRoute.tsx
+++ b/apps/desktop/src/features/home/HomeRoute.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { memo, useCallback, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
@@ -24,6 +24,7 @@ import { HomePrimaryPane, type HomePrimaryTab } from "./HomePrimaryPane";
 import { ProjectCreateDialog, type ProjectDraft } from "./ProjectCreateForm";
 import {
   useGlobalAttentionPages,
+  useGlobalAttentionEvents,
   useProjectCreation,
   useProjectCreationEvents,
   useProjectPages,
@@ -41,6 +42,7 @@ export function HomeRoute() {
   const creation = useProjectCreation();
   const projects = useProjectPages();
   const attention = useGlobalAttentionPages();
+  useGlobalAttentionEvents();
   const [primaryTab, setPrimaryTab] = useState<HomePrimaryTab>("projects");
   const projectItems = projects.data?.pages.flatMap((page) => page.projects) ?? [];
   const attentionItems = attention.data?.pages.flatMap((page) => page.items) ?? [];
@@ -231,7 +233,7 @@ function AttentionList({ items, query }: AttentionListProps) {
   );
 }
 
-function AttentionRow({
+const AttentionRow = memo(function AttentionRow({
   item,
   navigation,
   openSidebar,
@@ -282,6 +284,35 @@ function AttentionRow({
       <span className="min-w-0 text-sm break-words">{item.message}</span>
       <span className="text-sm text-[var(--color-muted)]">{formatRelativeTime(item.occurredAt)}</span>
     </button>
+  );
+}, attentionRowPropsEqual);
+
+function attentionRowPropsEqual(
+  previous: Readonly<{
+    item: AttentionItem;
+    navigation: ReturnType<typeof useAppNavigation>;
+    openSidebar: ReturnType<typeof useSidebar>["openSidebar"];
+  }>,
+  next: Readonly<{
+    item: AttentionItem;
+    navigation: ReturnType<typeof useAppNavigation>;
+    openSidebar: ReturnType<typeof useSidebar>["openSidebar"];
+  }>,
+): boolean {
+  return previous.openSidebar === next.openSidebar && previous.navigation === next.navigation && attentionItemsEqual(previous.item, next.item);
+}
+
+function attentionItemsEqual(previous: AttentionItem, next: AttentionItem): boolean {
+  return (
+    previous.id === next.id &&
+    previous.kind === next.kind &&
+    previous.projectID === next.projectID &&
+    previous.workflowID === next.workflowID &&
+    previous.taskID === next.taskID &&
+    previous.taskShortID === next.taskShortID &&
+    previous.taskTitle === next.taskTitle &&
+    previous.message === next.message &&
+    previous.occurredAt === next.occurredAt
   );
 }
 

--- a/apps/desktop/src/features/home/useHomeData.ts
+++ b/apps/desktop/src/features/home/useHomeData.ts
@@ -1,11 +1,16 @@
 import { useEffect } from "react";
-import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import type { ProjectBinding } from "../../api";
 import { errorMessage } from "../../api/errors";
 import type { NativeProjectBinding } from "@app/native-bridge";
 import { queryKeys } from "../../app/queryKeys";
 import { useAppServices } from "../../app/useAppServices";
+import { useConnectionSnapshot } from "../../app/useConnectionSnapshot";
+import {
+  workflowProjectEventCanChangeAttention,
+  workflowProjectQuestionTaskID,
+} from "../../app/workflowProjectEvents";
 
 export function useProjectPages() {
   const { api } = useAppServices();
@@ -21,6 +26,7 @@ export function useProjectPages() {
     queryFn: async ({ pageParam }) => api.listProjects(pageParam),
     initialPageParam: "",
     getNextPageParam: (lastPage) => (lastPage.nextPageToken.length > 0 ? lastPage.nextPageToken : undefined),
+    placeholderData: keepPreviousData,
   });
 }
 
@@ -31,7 +37,63 @@ export function useGlobalAttentionPages() {
     queryFn: async ({ pageParam }) => api.listAttention("", pageParam),
     initialPageParam: "",
     getNextPageParam: (lastPage) => (lastPage.nextPageToken.length > 0 ? lastPage.nextPageToken : undefined),
+    placeholderData: keepPreviousData,
   });
+}
+
+export function useGlobalAttentionEvents() {
+  const { api, logger } = useAppServices();
+  const connection = useConnectionSnapshot();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (connection.phase !== "connected") {
+      return;
+    }
+    let refreshFrame: number | null = null;
+    const refreshAttention = () => {
+      if (refreshFrame !== null) {
+        return;
+      }
+      refreshFrame = window.requestAnimationFrame(() => {
+        refreshFrame = null;
+        void queryClient.invalidateQueries({ queryKey: queryKeys.allAttention, refetchType: "active" });
+      });
+    };
+    const refreshQuestionTask = (params: unknown) => {
+      const taskID = workflowProjectQuestionTaskID(params);
+      if (taskID === null) {
+        return;
+      }
+      void queryClient.invalidateQueries({ queryKey: queryKeys.task(taskID), refetchType: "active" });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.activity(taskID), refetchType: "active" });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.allPendingAsks, refetchType: "active" });
+    };
+    const subscription = api.subscribeProject("", {
+      onOpen() {
+        refreshAttention();
+      },
+      onEvent(_method, params) {
+        refreshQuestionTask(params);
+        if (workflowProjectEventCanChangeAttention(params)) {
+          refreshAttention();
+        }
+      },
+      onComplete() {
+        return;
+      },
+      onError(error) {
+        refreshAttention();
+        void logger.append("warn", "Global attention subscription failed.", { error: errorMessage(error) });
+      },
+    });
+    return () => {
+      if (refreshFrame !== null) {
+        window.cancelAnimationFrame(refreshFrame);
+      }
+      subscription.close();
+    };
+  }, [api, connection.generation, connection.phase, logger, queryClient]);
 }
 
 export function useProjectCreationEvents(onCreated: (binding: NativeProjectBinding) => void) {

--- a/apps/desktop/src/features/task-detail/TaskDetailActivity.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailActivity.tsx
@@ -61,7 +61,7 @@ export function CommentComposer({
           aria-label={editing === null ? t("task.addComment") : t("task.editComment")}
           className={cx(
             fieldIslandInputClassName(1),
-            "col-start-1 row-start-1 block min-h-[112px] resize-none p-[var(--space-2)] pb-12",
+            "relative z-0 col-start-1 row-start-1 block min-h-[112px] resize-none p-[var(--space-2)] pb-12",
           )}
           disabled={interactionDisabled}
           id="task-comment-body"
@@ -80,7 +80,7 @@ export function CommentComposer({
         />
         <Button
           aria-label={editing === null ? t("task.submitComment") : t("task.saveComment")}
-          className="col-start-1 row-start-1 grid h-9 w-9 place-items-center self-end justify-self-end rounded-full !p-0"
+          className="relative z-10 col-start-1 row-start-1 grid h-9 w-9 place-items-center self-end justify-self-end rounded-full !p-0"
           data-testid="task-comment-save"
           disabled={interactionDisabled || commentBody.trim().length === 0}
           onClick={() => void submit()}

--- a/apps/desktop/src/features/task-detail/TaskDetailAttention.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailAttention.tsx
@@ -39,7 +39,7 @@ export function QuestionBox({
   const recommendedOption = recommendedOptionNumber(suggestions, recommendedOptionSource);
 
   return (
-    <Island aria-label={t("task.question")} className="p-[var(--space-2)]" level={1} unpadded>
+    <Island aria-label={t("task.question")} className="p-[var(--space-4)]" level={1} unpadded>
       <QuestionForm
         answerQuestion={mutations.answerQuestion}
         attention={attention}

--- a/apps/desktop/src/features/task-detail/TaskDetailDialog.test.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailDialog.test.tsx
@@ -130,13 +130,14 @@ describe("TaskDetailSurface", () => {
 
     render(<App services={services} />);
 
-    const composer = await screen.findByRole("textbox", { name: "Add comment" });
+    const composerFrame = await screen.findByTestId("task-comment-input-frame");
+    const composer = within(composerFrame).getByRole("textbox");
     composer.focus();
     expect(composer).toHaveFocus();
     fireEvent.change(composer, {
       target: { value: "Focused composer comment" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Submit comment" }));
+    fireEvent.click(screen.getByTestId("task-comment-save"));
 
     await waitFor(() => {
       expect(services.transport.calls).toContainEqual({

--- a/apps/desktop/src/features/task-detail/TaskDetailDialog.test.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailDialog.test.tsx
@@ -118,6 +118,34 @@ describe("TaskDetailSurface", () => {
     });
   });
 
+  it("submits a comment after the focused composer receives typed input", async () => {
+    window.history.pushState(null, "", "/tasks/task-1");
+    const services = createTestServices([
+      ...startupRoutes,
+      { method: "workflow.task.get", result: taskDetailResponse },
+      { method: "workflow.task.comment.list", result: commentListResponse },
+      { method: "workflow.task.activity.list", result: activityResponse },
+      { method: "workflow.task.comment.add", result: commentAddResponse },
+    ]);
+
+    render(<App services={services} />);
+
+    const composer = await screen.findByRole("textbox", { name: "Add comment" });
+    composer.focus();
+    expect(composer).toHaveFocus();
+    fireEvent.change(composer, {
+      target: { value: "Focused composer comment" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Submit comment" }));
+
+    await waitFor(() => {
+      expect(services.transport.calls).toContainEqual({
+        method: "workflow.task.comment.add",
+        params: { author: guiTaskCommentAuthor, body: "Focused composer comment", task_id: "task-1" },
+      });
+    });
+  });
+
   it("surfaces failed comment deletes through the status toast surface", async () => {
     window.history.pushState(null, "", "/tasks/task-1");
     const services = createTestServices([

--- a/apps/desktop/src/features/task-detail/TaskDetailInbox.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailInbox.tsx
@@ -80,11 +80,15 @@ function InboxItem({
       return;
     }
     scrolledRef.current = true;
+    let cancelAlignedScroll: (() => void) | undefined;
     const cancelScroll = scheduleScroll(() => {
-      focusTargetRef.current?.scrollIntoView({ block: "start", behavior: "auto" });
+      cancelAlignedScroll = scheduleScroll(() => {
+        focusTargetRef.current?.scrollIntoView({ block: "start", behavior: "auto" });
+      });
     });
     return () => {
       cancelScroll();
+      cancelAlignedScroll?.();
     };
   }, [focusOnMount]);
 
@@ -129,12 +133,16 @@ function InboxItem({
 
 function scheduleScroll(callback: () => void): () => void {
   if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
-    const frame = window.requestAnimationFrame(callback);
+    const frame = window.requestAnimationFrame(() => {
+      callback();
+    });
     return () => {
       window.cancelAnimationFrame(frame);
     };
   }
-  const timeout = setTimeout(callback, 0);
+  const timeout = setTimeout(() => {
+    callback();
+  }, 0);
   return () => {
     clearTimeout(timeout);
   };

--- a/apps/desktop/src/features/task-detail/TaskDetailList.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailList.tsx
@@ -106,6 +106,8 @@ export function TaskDetailList({
       estimateSize={() => 160}
       getItemKey={taskDetailListItemKey}
       hasNextPage={paging.hasNextPage}
+      initialScrollKey={initialFocus === "firstQuestion" ? "inbox" : undefined}
+      initialScrollRequestKey={initialFocus === "firstQuestion" ? detail.id : undefined}
       isFetchingNextPage={paging.isFetchingNextPage}
       items={listItems}
       loadingLabel={t("app.loadingMore")}

--- a/apps/desktop/src/ui/VirtualizedInfiniteList.test.tsx
+++ b/apps/desktop/src/ui/VirtualizedInfiniteList.test.tsx
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  resolveVirtualizedInitialScroll,
+  virtualizedInitialScrollIndex,
+} from "./virtualizedInfiniteListInitialScroll";
 import { resolveLoadMore } from "./virtualizedInfiniteListLoadMore";
 
 const atBottom = {
@@ -63,5 +67,63 @@ describe("resolveLoadMore", () => {
     expect(
       resolveLoadMore({ ...atBottom, atBottom: false, lastLoadMoreKey: "", loadMoreKey: "page-1" }),
     ).toEqual({ shouldLoad: false, lastLoadMoreKey: "" });
+  });
+});
+
+describe("virtualizedInitialScrollIndex", () => {
+  const items = [{ key: "header" }, { key: "inbox" }, { key: "activity" }];
+  const getItemKey = (item: (typeof items)[number]): string => item.key;
+
+  it("finds the target item after the virtual list header", () => {
+    expect(
+      virtualizedInitialScrollIndex({
+        getItemKey,
+        headerCount: 1,
+        initialScrollKey: "inbox",
+        items,
+      }),
+    ).toBe(2);
+  });
+
+  it("ignores missing or empty initial scroll keys", () => {
+    expect(
+      virtualizedInitialScrollIndex({
+        getItemKey,
+        headerCount: 1,
+        initialScrollKey: "",
+        items,
+      }),
+    ).toBeNull();
+    expect(
+      virtualizedInitialScrollIndex({
+        getItemKey,
+        headerCount: 1,
+        initialScrollKey: "missing",
+        items,
+      }),
+    ).toBeNull();
+  });
+
+  it("suppresses repeated request keys while allowing the same target for a new request", () => {
+    expect(
+      resolveVirtualizedInitialScroll({
+        getItemKey,
+        headerCount: 1,
+        initialScrollKey: "inbox",
+        initialScrollRequestKey: "task-1",
+        items,
+        lastRequestKey: "task-1",
+      }),
+    ).toBeNull();
+    expect(
+      resolveVirtualizedInitialScroll({
+        getItemKey,
+        headerCount: 1,
+        initialScrollKey: "inbox",
+        initialScrollRequestKey: "task-2",
+        items,
+        lastRequestKey: "task-1",
+      }),
+    ).toEqual({ requestKey: "task-2", scrollIndex: 2 });
   });
 });

--- a/apps/desktop/src/ui/VirtualizedInfiniteList.tsx
+++ b/apps/desktop/src/ui/VirtualizedInfiniteList.tsx
@@ -3,6 +3,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { cx } from "./classes";
 import { Spinner } from "./Spinner";
+import { resolveVirtualizedInitialScroll } from "./virtualizedInfiniteListInitialScroll";
 import { resolveLoadMore } from "./virtualizedInfiniteListLoadMore";
 
 export type VirtualizedInfiniteListProps<TItem> = Readonly<{
@@ -20,6 +21,8 @@ export type VirtualizedInfiniteListProps<TItem> = Readonly<{
   ariaLabel?: string | undefined;
   rowSpacing?: "default" | "compact" | undefined;
   testId?: string | undefined;
+  initialScrollKey?: string | undefined;
+  initialScrollRequestKey?: string | undefined;
   paddingEnd?: number | undefined;
   paddingStart?: number | undefined;
   className?: string | undefined;
@@ -40,11 +43,14 @@ export function VirtualizedInfiniteList<TItem>({
   ariaLabel,
   rowSpacing = "default",
   testId,
+  initialScrollKey,
+  initialScrollRequestKey,
   paddingEnd = 0,
   paddingStart = 0,
   className,
 }: VirtualizedInfiniteListProps<TItem>) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const lastInitialScrollKeyRef = useRef("");
   const lastLoadMoreKeyRef = useRef("");
   const wasFetchingNextPageRef = useRef(false);
   const headerCount = header === undefined ? 0 : 1;
@@ -85,6 +91,25 @@ export function VirtualizedInfiniteList<TItem>({
       renderItem,
       virtualIndex,
     });
+
+  useEffect(() => {
+    if (initialScrollKey === undefined || initialScrollKey.length === 0) {
+      return;
+    }
+    const scroll = resolveVirtualizedInitialScroll({
+      getItemKey,
+      headerCount,
+      initialScrollKey,
+      initialScrollRequestKey,
+      items,
+      lastRequestKey: lastInitialScrollKeyRef.current,
+    });
+    if (scroll === null) {
+      return;
+    }
+    lastInitialScrollKeyRef.current = scroll.requestKey;
+    virtualizer.scrollToIndex(scroll.scrollIndex, { align: "start", behavior: "auto" });
+  }, [getItemKey, headerCount, initialScrollKey, initialScrollRequestKey, items, virtualizer]);
 
   useEffect(() => {
     const lastItem = virtualItems.at(-1);

--- a/apps/desktop/src/ui/virtualizedInfiniteListInitialScroll.ts
+++ b/apps/desktop/src/ui/virtualizedInfiniteListInitialScroll.ts
@@ -1,0 +1,48 @@
+export function virtualizedInitialScrollIndex<TItem>({
+  getItemKey,
+  headerCount,
+  initialScrollKey,
+  items,
+}: Readonly<{
+  getItemKey: (item: TItem) => string;
+  headerCount: number;
+  initialScrollKey: string | undefined;
+  items: readonly TItem[];
+}>): number | null {
+  if (initialScrollKey === undefined || initialScrollKey.length === 0) {
+    return null;
+  }
+  const itemIndex = items.findIndex((item) => getItemKey(item) === initialScrollKey);
+  return itemIndex < 0 ? null : headerCount + itemIndex;
+}
+
+export function resolveVirtualizedInitialScroll<TItem>({
+  getItemKey,
+  headerCount,
+  initialScrollKey,
+  initialScrollRequestKey,
+  items,
+  lastRequestKey,
+}: Readonly<{
+  getItemKey: (item: TItem) => string;
+  headerCount: number;
+  initialScrollKey: string | undefined;
+  initialScrollRequestKey: string | undefined;
+  items: readonly TItem[];
+  lastRequestKey: string;
+}>): Readonly<{ requestKey: string; scrollIndex: number }> | null {
+  if (initialScrollKey === undefined || initialScrollKey.length === 0) {
+    return null;
+  }
+  const requestKey = initialScrollRequestKey ?? initialScrollKey;
+  if (lastRequestKey === requestKey) {
+    return null;
+  }
+  const scrollIndex = virtualizedInitialScrollIndex({
+    getItemKey,
+    headerCount,
+    initialScrollKey,
+    items,
+  });
+  return scrollIndex === null ? null : { requestKey, scrollIndex };
+}

--- a/docs/dev/specs/workflow-editor.md
+++ b/docs/dev/specs/workflow-editor.md
@@ -22,7 +22,7 @@
 - Runtime/task state remains in Kanban and task detail. The editor edits workflow definitions, not live task execution.
 - The canvas renders start/backlog, agent, join, terminal/done, disconnected nodes, and node groups.
 - Join nodes are inspectable internal merge plumbing. Board/Kanban read models still omit join columns.
-- Board/Kanban column order is derived from workflow graph structure. Persisted node list order is not a board-order source; structurally ambiguous sibling branches are ordered by node key.
+- Board/Kanban column order is derived from workflow graph structure. Persisted node list order is not a board-order source; structurally ambiguous non-terminal sibling branches are ordered by node key, and reachable terminal columns sort after reachable non-terminal columns when graph precedence does not decide their order.
 - GUI-authored node groups are execution-shaped parallel groups. A saved node group contains branch nodes and one join; its fan-out is represented by one fan-out transition.
 - One-node node groups may exist only as unsaved invalid drafts while the operator is building the parallel group.
 - Agent nodes show name plus assignee role. Non-agent/no-role nodes have blank role line.

--- a/docs/dev/specs/workflow-editor.md
+++ b/docs/dev/specs/workflow-editor.md
@@ -22,6 +22,7 @@
 - Runtime/task state remains in Kanban and task detail. The editor edits workflow definitions, not live task execution.
 - The canvas renders start/backlog, agent, join, terminal/done, disconnected nodes, and node groups.
 - Join nodes are inspectable internal merge plumbing. Board/Kanban read models still omit join columns.
+- Board/Kanban column order is derived from workflow graph structure. Persisted node list order is not a board-order source; structurally ambiguous sibling branches are ordered by node key.
 - GUI-authored node groups are execution-shaped parallel groups. A saved node group contains branch nodes and one join; its fan-out is represented by one fan-out transition.
 - One-node node groups may exist only as unsaved invalid drafts while the operator is building the parallel group.
 - Agent nodes show name plus assignee role. Non-agent/no-role nodes have blank role line.

--- a/scripts/import_gh.sh
+++ b/scripts/import_gh.sh
@@ -22,12 +22,23 @@ require_command() {
 	fi
 }
 
+is_decimal_number() {
+	case "$1" in
+	"" | *[!0123456789]*)
+		return 1
+		;;
+	*)
+		return 0
+		;;
+	esac
+}
+
 parse_issue_ref() {
 	local ref="$1"
 	repo=""
 	number=""
 
-	if [[ "$ref" =~ ^[0-9]+$ ]]; then
+	if is_decimal_number "$ref"; then
 		repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
 		number="$ref"
 		return
@@ -54,7 +65,7 @@ parse_issue_ref() {
 		;;
 	esac
 
-	if [[ ! "$number" =~ ^[0-9]+$ ]]; then
+	if ! is_decimal_number "$number"; then
 		fail "Expected a GitHub issue number or URL."
 	fi
 }

--- a/scripts/import_gh.sh
+++ b/scripts/import_gh.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-exec 2>&1
 
 usage() {
 	cat <<'USAGE'
@@ -13,7 +12,7 @@ USAGE
 }
 
 fail() {
-	echo "$1"
+	echo "$1" >&2
 	exit 1
 }
 

--- a/scripts/import_gh.sh
+++ b/scripts/import_gh.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+exec 2>&1
+
+usage() {
+	cat <<'USAGE'
+Usage: ./scripts/import_gh.sh <number-or-url>
+
+Imports one GitHub issue into the Kent Task workflow linked as the default for
+the current working directory.
+USAGE
+}
+
+fail() {
+	echo "$1"
+	exit 1
+}
+
+require_command() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		fail "$1 is required."
+	fi
+}
+
+parse_issue_ref() {
+	local ref="$1"
+	repo=""
+	number=""
+
+	if [[ "$ref" =~ ^[0-9]+$ ]]; then
+		repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+		number="$ref"
+		return
+	fi
+
+	local normalized="${ref#http://}"
+	normalized="${normalized#https://}"
+	normalized="${normalized#www.}"
+	normalized="${normalized%%\?*}"
+	normalized="${normalized%%#*}"
+
+	case "$normalized" in
+	github.com/*/*/issues/*)
+		local path="${normalized#github.com/}"
+		local owner="${path%%/*}"
+		local rest="${path#*/}"
+		local repo_name="${rest%%/*}"
+		local issue_path="${rest#*/issues/}"
+		number="${issue_path%%/*}"
+		repo="$owner/$repo_name"
+		;;
+	*)
+		fail "Expected a GitHub issue number or URL."
+		;;
+	esac
+
+	if [[ ! "$number" =~ ^[0-9]+$ ]]; then
+		fail "Expected a GitHub issue number or URL."
+	fi
+}
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+kent_bin="${KENT_BIN:-}"
+if [ -z "$kent_bin" ]; then
+	if [ -x "$repo_root/bin/kent" ]; then
+		kent_bin="$repo_root/bin/kent"
+	else
+		kent_bin="kent"
+	fi
+fi
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+	usage
+	exit 0
+fi
+
+if [ "$#" -ne 1 ]; then
+	usage
+	exit 2
+fi
+
+require_command gh
+require_command jq
+if ! command -v "$kent_bin" >/dev/null 2>&1 && [ ! -x "$kent_bin" ]; then
+	fail "kent is required. Set KENT_BIN or build ./bin/kent."
+fi
+
+repo=""
+number=""
+parse_issue_ref "$1"
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+	if command -v trash >/dev/null 2>&1; then
+		trash "$tmpdir" >/dev/null 2>&1 || true
+	else
+		find "$tmpdir" -depth -delete >/dev/null 2>&1 || true
+	fi
+}
+trap cleanup EXIT
+
+issue_file="$tmpdir/issue.json"
+comments_file="$tmpdir/comments.json"
+body_file="$tmpdir/body.md"
+
+gh api "repos/$repo/issues/$number" >"$issue_file"
+
+if [ "$(jq -r 'has("pull_request")' "$issue_file")" = "true" ]; then
+	fail "GH #$number in $repo is a pull request, not an issue."
+fi
+
+title="$(jq -r '.title // ""' "$issue_file")"
+issue_body="$(jq -r '.body // ""' "$issue_file")"
+issue_url="$(jq -r '.html_url // ""' "$issue_file")"
+import_date="$(date +%F)"
+
+{
+	if [ -n "$issue_body" ]; then
+		printf '%s\n\n' "$issue_body"
+	fi
+	printf 'imported from GH #%s on %s\n' "$number" "$import_date"
+} >"$body_file"
+
+task_title="GH #$number: $title"
+create_json="$("$kent_bin" task create --project . --title "$task_title" --body-file "$body_file" --source-url "$issue_url" --json)"
+
+task_ref="$(jq -r '.summary.short_id // ""' <<<"$create_json")"
+task_id="$(jq -r '.summary.task_id // .summary.id // ""' <<<"$create_json")"
+if [ -z "$task_ref" ] || [ "$task_ref" = "null" ]; then
+	fail "Imported task was created, but its short id could not be read from kent output."
+fi
+echo "Created Kent task $task_ref ($task_id) for GH #$number."
+
+gh api --paginate --slurp "repos/$repo/issues/$number/comments" >"$comments_file"
+
+comment_count="$(jq '[.[][]] | length' "$comments_file")"
+if [ "$comment_count" -eq 0 ]; then
+	echo "Imported GH #$number into $task_ref with no comments."
+	exit 0
+fi
+
+comment_index=0
+while IFS= read -r comment_json; do
+	comment_index=$((comment_index + 1))
+	comment_author="$(jq -r '.user.login // "unknown"' <<<"$comment_json")"
+	comment_body="$(jq -r '.body // ""' <<<"$comment_json")"
+	comment_file="$tmpdir/comment-$comment_index.md"
+	printf '%s\n' "$comment_body" >"$comment_file"
+	"$kent_bin" task comment add --project . "$task_ref" --author user --author-id "$comment_author" --body-file "$comment_file"
+done < <(jq -c '.[][]' "$comments_file")
+
+echo "Imported GH #$number into $task_ref with $comment_count comments."

--- a/server/runtime/engine_part8_test.go
+++ b/server/runtime/engine_part8_test.go
@@ -8,6 +8,7 @@ import (
 	"core/server/session"
 	"core/server/tools"
 	shelltool "core/server/tools/shell"
+	"core/shared/config"
 	"core/shared/toolspec"
 	"core/shared/transcript"
 	"core/shared/transcript/toolcodec"
@@ -684,6 +685,116 @@ func TestParallelToolCompletionAppearsInChatSnapshotBeforeAllToolsFinish(t *test
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for submit completion")
+	}
+}
+
+func TestAskQuestionToolCallsExecuteSequentiallyInDeclaredOrder(t *testing.T) {
+	store := mustCreateTestSession(t)
+	sequencer := &serialPairProbeTool{
+		firstID:       "call-ask-1",
+		secondID:      "call-ask-2",
+		firstStarted:  make(chan struct{}),
+		secondStarted: make(chan struct{}),
+		releaseFirst:  make(chan struct{}),
+	}
+	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(
+		tools.HandlerRegistration{ID: toolspec.ToolAskQuestion, Handler: sequencer},
+	), Config{Model: "gpt-5", EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+
+	done := make(chan struct {
+		results []tools.Result
+		err     error
+	}, 1)
+	go func() {
+		results, err := eng.executeToolCalls(context.Background(), "step", []llm.ToolCall{
+			{ID: "call-ask-1", Name: string(toolspec.ToolAskQuestion), Input: json.RawMessage(`{}`)},
+			{ID: "call-ask-2", Name: string(toolspec.ToolAskQuestion), Input: json.RawMessage(`{}`)},
+		})
+		done <- struct {
+			results []tools.Result
+			err     error
+		}{results: results, err: err}
+	}()
+
+	select {
+	case <-sequencer.firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first ask_question call to start")
+	}
+	select {
+	case <-sequencer.secondStarted:
+		t.Fatal("second ask_question call started before first completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(sequencer.releaseFirst)
+	select {
+	case <-sequencer.secondStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second ask_question call to start")
+	}
+	select {
+	case result := <-done:
+		if result.err != nil {
+			t.Fatalf("execute tool calls: %v", result.err)
+		}
+		if len(result.results) != 2 || result.results[0].CallID != "call-ask-1" || result.results[1].CallID != "call-ask-2" {
+			t.Fatalf("results = %+v, want declared ask order", result.results)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for ask_question tool calls to finish")
+	}
+}
+
+func TestWorkflowPromptCapableToolCallsSerializeWithAskQuestion(t *testing.T) {
+	store := mustCreateTestSession(t)
+	sequencer := &serialPairProbeTool{
+		firstID:       "call-patch",
+		secondID:      "call-ask",
+		firstStarted:  make(chan struct{}),
+		secondStarted: make(chan struct{}),
+		releaseFirst:  make(chan struct{}),
+	}
+	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(
+		tools.HandlerRegistration{ID: toolspec.ToolPatch, Handler: sequencer},
+		tools.HandlerRegistration{ID: toolspec.ToolAskQuestion, Handler: sequencer},
+	), Config{
+		Model:        "gpt-5",
+		EnabledTools: []toolspec.ID{toolspec.ToolPatch, toolspec.ToolAskQuestion},
+		WorkflowRun:  testWorkflowConfig(&fakeWorkflowController{}, config.WorkflowCompletionModeTool),
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := eng.executeToolCalls(context.Background(), "step", []llm.ToolCall{
+			{ID: "call-patch", Name: string(toolspec.ToolPatch), Input: json.RawMessage(`{}`)},
+			{ID: "call-ask", Name: string(toolspec.ToolAskQuestion), Input: json.RawMessage(`{}`)},
+		})
+		done <- err
+	}()
+
+	select {
+	case <-sequencer.firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for workflow prompt-capable tool to start")
+	}
+	select {
+	case <-sequencer.secondStarted:
+		t.Fatal("ask_question started before earlier workflow prompt-capable tool completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(sequencer.releaseFirst)
+	select {
+	case <-sequencer.secondStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for ask_question to start")
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("execute tool calls: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for workflow prompt-capable tool calls to finish")
 	}
 }
 

--- a/server/runtime/engine_test.go
+++ b/server/runtime/engine_test.go
@@ -309,6 +309,26 @@ func (t blockingTool) Call(_ context.Context, c tools.Call) (tools.Result, error
 	return tools.Result{CallID: c.ID, Name: c.Name, Output: out}, nil
 }
 
+type serialPairProbeTool struct {
+	firstID       string
+	secondID      string
+	firstStarted  chan struct{}
+	secondStarted chan struct{}
+	releaseFirst  chan struct{}
+}
+
+func (t *serialPairProbeTool) Call(_ context.Context, c tools.Call) (tools.Result, error) {
+	switch c.ID {
+	case t.firstID:
+		close(t.firstStarted)
+		<-t.releaseFirst
+	case t.secondID:
+		close(t.secondStarted)
+	}
+	out, _ := json.Marshal(map[string]any{"tool": string(c.Name)})
+	return tools.Result{CallID: c.ID, Name: c.Name, Output: out}, nil
+}
+
 type fakeStreamClient struct {
 	mu       sync.Mutex
 	attempts int

--- a/server/runtime/tool_executor.go
+++ b/server/runtime/tool_executor.go
@@ -25,6 +25,9 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 	callErrs := make([]error, len(calls))
 	wg := sync.WaitGroup{}
 	runID := activeRunIDForStep(e, stepID)
+	workflowActive := e.workflowRunActive()
+	serialGate := newSerialToolGate()
+	nextSerialOrdinal := 0
 
 	for i := range calls {
 		call := calls[i]
@@ -50,12 +53,21 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 			continue
 		}
 		idx := i
+		serialOrdinal := -1
+		if serialToolExecutionRequired(toolID, workflowActive) {
+			serialOrdinal = nextSerialOrdinal
+			nextSerialOrdinal++
+		}
 		wg.Add(1)
-		go func(tc llm.ToolCall, toolID toolspec.ID, knownTool bool) {
+		go func(tc llm.ToolCall, toolID toolspec.ID, knownTool bool, serialOrdinal int) {
 			defer wg.Done()
 			defer e.forgetPendingToolCallStart(tc.ID)
 			var callErr error
 
+			if serialOrdinal >= 0 {
+				serialGate.wait(serialOrdinal)
+				defer serialGate.done(serialOrdinal)
+			}
 			if !knownTool {
 				results[idx] = tools.Result{CallID: tc.ID, Name: toolspec.ID(tc.Name), IsError: true, Output: mustJSON(map[string]any{"error": "unknown tool"}), Summary: "unknown tool"}
 				if err := e.steer(stepID, steerToolCompletionIntent(results[idx])); err != nil {
@@ -102,7 +114,7 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 				return
 			}
 			callErrs[idx] = callErr
-		}(executableCall, toolID, knownTool)
+		}(executableCall, toolID, knownTool, serialOrdinal)
 	}
 
 	wg.Wait()
@@ -114,6 +126,46 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 		return results, joined
 	}
 	return results, nil
+}
+
+type serialToolGate struct {
+	mu   sync.Mutex
+	cond *sync.Cond
+	next int
+}
+
+func newSerialToolGate() *serialToolGate {
+	gate := &serialToolGate{}
+	gate.cond = sync.NewCond(&gate.mu)
+	return gate
+}
+
+func (g *serialToolGate) wait(ordinal int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for g.next != ordinal {
+		g.cond.Wait()
+	}
+}
+
+func (g *serialToolGate) done(ordinal int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.next == ordinal {
+		g.next++
+		g.cond.Broadcast()
+	}
+}
+
+func serialToolExecutionRequired(toolID toolspec.ID, workflowActive bool) bool {
+	switch toolID {
+	case toolspec.ToolAskQuestion:
+		return true
+	case toolspec.ToolPatch, toolspec.ToolEdit, toolspec.ToolViewImage:
+		return workflowActive
+	default:
+		return false
+	}
 }
 
 func (t *defaultToolExecutor) executeCompleteNodeTool(ctx context.Context, stepID string, call llm.ToolCall) tools.Result {

--- a/server/tools/shell/manager_types.go
+++ b/server/tools/shell/manager_types.go
@@ -275,6 +275,7 @@ func (p *processEntry) writeOutput(chunk []byte) error {
 
 func (p *processEntry) setExited(exitCode int, state string) {
 	p.mu.Lock()
+	p.running = false
 	p.finishedAt = time.Now().UTC()
 	p.lastUpdatedAt = p.finishedAt
 	p.exitCode = &exitCode
@@ -282,9 +283,6 @@ func (p *processEntry) setExited(exitCode int, state string) {
 	stdin, log := p.detachResourcesLocked()
 	p.mu.Unlock()
 	closeDetachedResources(stdin, log)
-	p.mu.Lock()
-	p.running = false
-	p.mu.Unlock()
 	p.signal()
 }
 

--- a/server/tools/shell/manager_types.go
+++ b/server/tools/shell/manager_types.go
@@ -275,7 +275,6 @@ func (p *processEntry) writeOutput(chunk []byte) error {
 
 func (p *processEntry) setExited(exitCode int, state string) {
 	p.mu.Lock()
-	p.running = false
 	p.finishedAt = time.Now().UTC()
 	p.lastUpdatedAt = p.finishedAt
 	p.exitCode = &exitCode
@@ -283,6 +282,9 @@ func (p *processEntry) setExited(exitCode int, state string) {
 	stdin, log := p.detachResourcesLocked()
 	p.mu.Unlock()
 	closeDetachedResources(stdin, log)
+	p.mu.Lock()
+	p.running = false
+	p.mu.Unlock()
 	p.signal()
 }
 
@@ -294,7 +296,6 @@ func (p *processEntry) isBackgrounded() bool {
 
 func (p *processEntry) closeOnExit(exitCode int, state string) Snapshot {
 	p.mu.Lock()
-	p.running = false
 	p.finishedAt = time.Now().UTC()
 	p.lastUpdatedAt = p.finishedAt
 	p.exitCode = &exitCode
@@ -303,6 +304,7 @@ func (p *processEntry) closeOnExit(exitCode int, state string) Snapshot {
 	p.mu.Unlock()
 	closeDetachedResources(stdin, log)
 	p.mu.Lock()
+	p.running = false
 	snapshot := p.snapshotLocked()
 	p.mu.Unlock()
 	p.signal()

--- a/server/workflowrunner/starter_test.go
+++ b/server/workflowrunner/starter_test.go
@@ -151,6 +151,68 @@ func TestWorkflowRuntimeAskQuestionWaitsAndResumesSameRunSession(t *testing.T) {
 	}
 }
 
+func TestWorkflowRuntimeMultipleAskQuestionsInOneToolBatchResumeSequentially(t *testing.T) {
+	completeInput := json.RawMessage(`{"commentary":"answered both and finished"}`)
+	fixture := newStarterFixture(t, config.WorkflowCompletionModeTool,
+		workflowtest.ToolBatch("questions",
+			llm.ToolCall{ID: "call-ask-1", Name: "ask_question", Input: json.RawMessage(`{"question":"First direction?","suggestions":["ship","stop"],"recommended_option_index":1}`)},
+			llm.ToolCall{ID: "call-ask-2", Name: "ask_question", Input: json.RawMessage(`{"question":"Second direction?","suggestions":["fast","safe"],"recommended_option_index":2}`)},
+		),
+		workflowtest.ToolBatch("complete", llm.ToolCall{ID: "call-complete", Name: "complete_node", Input: completeInput}),
+	)
+	role := fixture.cfg.Settings.Subagents["coder"]
+	role.Settings.EnabledTools = map[toolspec.ID]bool{toolspec.ToolAskQuestion: true}
+	role.Sources["tools."+toolspec.ConfigName(toolspec.ToolAskQuestion)] = "test"
+	fixture.cfg.Settings.Subagents["coder"] = role
+	fixture.rebuildStarter(t)
+	task := fixture.createStartedTask(t)
+	scheduler := fixture.scheduler(t)
+
+	if err := scheduler.Process(context.Background()); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	first := fixture.waitForWaitingAsk(t, task.ID, "call-ask-1")
+	if err := fixture.runtimes.SubmitPromptResponse(first.SessionID, askquestion.Response{RequestID: "call-ask-1", Answer: "Ship it"}, nil); err != nil {
+		t.Fatalf("SubmitPromptResponse first: %v", err)
+	}
+	second := fixture.waitForWaitingAsk(t, task.ID, "call-ask-2")
+	if second.SessionID != first.SessionID {
+		t.Fatalf("second ask session = %q, want first session %q", second.SessionID, first.SessionID)
+	}
+	if err := fixture.runtimes.SubmitPromptResponse(second.SessionID, askquestion.Response{RequestID: "call-ask-2", Answer: "Keep it safe"}, nil); err != nil {
+		t.Fatalf("SubmitPromptResponse second: %v", err)
+	}
+	fixture.waitForCompletedRun(t, task.ID)
+	runs, err := fixture.store.ListRuns(context.Background(), task.ID)
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 1 || runs[0].SessionID != first.SessionID || runs[0].WaitingAskID != "" {
+		t.Fatalf("run after answers = %+v, want same session and cleared waiting ask", runs)
+	}
+	askResults := workflowRequestAskQuestionToolMessages(fixture.client.Requests())
+	if len(askResults) != 2 {
+		t.Fatalf("ask_question tool results = %+v, want two completed asks", askResults)
+	}
+	seenAskResults := map[string]bool{}
+	for _, msg := range askResults {
+		seenAskResults[msg.ToolCallID] = true
+		trimmed := strings.TrimSpace(msg.Content)
+		if strings.HasPrefix(trimmed, "{") {
+			var payload map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
+				t.Fatalf("decode ask_question tool message: %v", err)
+			}
+			if _, ok := payload["error"]; ok {
+				t.Fatalf("ask_question tool result contains error payload: %+v", msg)
+			}
+		}
+	}
+	if !seenAskResults["call-ask-1"] || !seenAskResults["call-ask-2"] {
+		t.Fatalf("ask_question tool result call IDs = %+v, want both asks", askResults)
+	}
+}
+
 func TestWorkflowRuntimeStarterCloseCancelsInFlightRun(t *testing.T) {
 	client := newBlockingClient()
 	fixture := newStarterFixture(t, config.WorkflowCompletionModeStructuredOutput, workflowtest.FinalAnswer("{}"))
@@ -836,6 +898,22 @@ func (f starterFixture) sessionEventsText(t *testing.T, sessionID string) string
 		t.Fatalf("read events.jsonl: %v", err)
 	}
 	return string(data)
+}
+
+func workflowRequestAskQuestionToolMessages(reqs []llm.Request) []llm.Message {
+	messages := []llm.Message{}
+	for _, req := range reqs {
+		for _, msg := range llm.MessagesFromItems(req.Items) {
+			if msg.Role != llm.RoleTool || msg.Name != string(toolspec.ToolAskQuestion) {
+				continue
+			}
+			switch msg.ToolCallID {
+			case "call-ask-1", "call-ask-2":
+				messages = append(messages, msg)
+			}
+		}
+	}
+	return messages
 }
 
 // historyReplacedWorkflowRunID decodes the latest history_replaced event in the

--- a/server/workflowrunner/starter_test.go
+++ b/server/workflowrunner/starter_test.go
@@ -198,11 +198,8 @@ func TestWorkflowRuntimeMultipleAskQuestionsInOneToolBatchResumeSequentially(t *
 	for _, msg := range askResults {
 		seenAskResults[msg.ToolCallID] = true
 		trimmed := strings.TrimSpace(msg.Content)
-		if strings.HasPrefix(trimmed, "{") {
-			var payload map[string]json.RawMessage
-			if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
-				t.Fatalf("decode ask_question tool message: %v", err)
-			}
+		var payload map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(trimmed), &payload); err == nil {
 			if _, ok := payload["error"]; ok {
 				t.Fatalf("ask_question tool result contains error payload: %+v", msg)
 			}

--- a/server/workflowstore/runs.go
+++ b/server/workflowstore/runs.go
@@ -485,8 +485,9 @@ func (s *Store) SetRunWaitingAsk(ctx context.Context, runID workflow.RunID, expe
 	if trimmedAskID == "" {
 		return fmt.Errorf("ask id is required")
 	}
+	now := s.now().UnixMilli()
 	result, err := s.db.ExecContext(ctx, strings.TrimSuffix(setRunWaitingAskQuery, "\n"),
-		s.now().UnixMilli(),
+		now,
 		trimmedAskID,
 		string(runID),
 		expectedGeneration,
@@ -501,7 +502,11 @@ func (s *Store) SetRunWaitingAsk(ctx context.Context, runID workflow.RunID, expe
 	if updated != 1 {
 		return sql.ErrNoRows
 	}
-	return nil
+	event, err := runWaitingAskWorkflowEvent(ctx, s.db, string(runID), "question_waiting", trimmedAskID, now)
+	if err != nil {
+		return err
+	}
+	return s.PublishWorkflowEvent(ctx, event)
 }
 
 func (s *Store) ClearRunWaitingAsk(ctx context.Context, runID workflow.RunID, expectedGeneration int64, askID string) error {
@@ -509,8 +514,9 @@ func (s *Store) ClearRunWaitingAsk(ctx context.Context, runID workflow.RunID, ex
 	if trimmedAskID == "" {
 		return fmt.Errorf("ask id is required")
 	}
+	now := s.now().UnixMilli()
 	result, err := s.db.ExecContext(ctx, strings.TrimSuffix(clearRunWaitingAskQuery, "\n"),
-		s.now().UnixMilli(),
+		now,
 		string(runID),
 		expectedGeneration,
 		trimmedAskID,
@@ -525,7 +531,41 @@ func (s *Store) ClearRunWaitingAsk(ctx context.Context, runID workflow.RunID, ex
 	if updated != 1 {
 		return sql.ErrNoRows
 	}
-	return nil
+	event, err := runWaitingAskWorkflowEvent(ctx, s.db, string(runID), "question_cleared", trimmedAskID, now)
+	if err != nil {
+		return err
+	}
+	return s.PublishWorkflowEvent(ctx, event)
+}
+
+func runWaitingAskWorkflowEvent(
+	ctx context.Context,
+	db *sql.DB,
+	runID string,
+	action string,
+	askID string,
+	occurredAtUnixMs int64,
+) (WorkflowEventRecord, error) {
+	var projectID string
+	var workflowID string
+	var taskID string
+	if err := db.QueryRowContext(ctx, `
+SELECT t.project_id, t.workflow_id, t.id
+FROM task_runs r
+JOIN task_node_placements p ON p.id = r.placement_id
+JOIN task_records t ON t.id = p.task_id
+WHERE r.id = ?
+`, strings.TrimSpace(runID)).Scan(&projectID, &workflowID, &taskID); err != nil {
+		return WorkflowEventRecord{}, fmt.Errorf("load waiting ask event run identity: %w", err)
+	}
+	return WorkflowEventRecord{
+		ProjectID:        projectID,
+		WorkflowID:       workflowID,
+		Resource:         "task",
+		Action:           action,
+		ChangedIDs:       []string{taskID, strings.TrimSpace(runID), strings.TrimSpace(askID)},
+		OccurredAtUnixMs: occurredAtUnixMs,
+	}, nil
 }
 
 func (s *Store) ResolveTaskWaitingAsk(ctx context.Context, taskID workflow.TaskID, runID workflow.RunID, askID string) (RunRecord, error) {

--- a/server/workflowstore/store_test.go
+++ b/server/workflowstore/store_test.go
@@ -2859,6 +2859,49 @@ func TestSetAndClearRunWaitingAskGenerationGuard(t *testing.T) {
 	}
 }
 
+func TestSetAndClearRunWaitingAskPublishTaskEvents(t *testing.T) {
+	ctx, store, binding, cfg := newTestStoreWithConfigContext(t)
+	store.now = func() time.Time { return time.UnixMilli(1234).UTC() }
+	createLinkedValidWorkflow(t, ctx, store, binding.ProjectID)
+	sessionID := createTestSession(t, ctx, store, binding, cfg)
+	task := createDefaultTask(t, ctx, store, binding.ProjectID)
+	started := startTask(t, ctx, store, task.ID)
+	claimed, err := store.ClaimRun(ctx, started.RunID, 0)
+	if err != nil {
+		t.Fatalf("ClaimRun: %v", err)
+	}
+	if err := store.AttachRunSession(ctx, started.RunID, claimed.Generation, sessionID); err != nil {
+		t.Fatalf("AttachRunSession: %v", err)
+	}
+	sink := &recordingWorkflowEventPublisher{}
+	store.SetWorkflowEventPublisher(sink)
+
+	if err := store.SetRunWaitingAsk(ctx, started.RunID, claimed.Generation, "ask-1"); err != nil {
+		t.Fatalf("SetRunWaitingAsk: %v", err)
+	}
+	if err := store.ClearRunWaitingAsk(ctx, started.RunID, claimed.Generation, "ask-1"); err != nil {
+		t.Fatalf("ClearRunWaitingAsk: %v", err)
+	}
+
+	if len(sink.records) != 2 {
+		t.Fatalf("published records = %+v, want waiting and cleared events", sink.records)
+	}
+	for _, record := range sink.records {
+		if record.ProjectID != binding.ProjectID || record.WorkflowID != string(task.WorkflowID) || record.Resource != "task" {
+			t.Fatalf("published record identity = %+v", record)
+		}
+		if record.OccurredAtUnixMs != 1234 {
+			t.Fatalf("published record time = %d, want 1234", record.OccurredAtUnixMs)
+		}
+		if len(record.ChangedIDs) != 3 || record.ChangedIDs[0] != string(task.ID) || record.ChangedIDs[1] != string(started.RunID) || record.ChangedIDs[2] != "ask-1" {
+			t.Fatalf("published record changed ids = %+v", record.ChangedIDs)
+		}
+	}
+	if sink.records[0].Action != "question_waiting" || sink.records[1].Action != "question_cleared" {
+		t.Fatalf("published actions = %+v, want question_waiting then question_cleared", []string{sink.records[0].Action, sink.records[1].Action})
+	}
+}
+
 func TestInterruptRunGenerationGuard(t *testing.T) {
 	ctx, store, binding := newTestStoreContext(t)
 	createLinkedValidWorkflow(t, ctx, store, binding.ProjectID)

--- a/server/workflowview/board_order.go
+++ b/server/workflowview/board_order.go
@@ -1,0 +1,327 @@
+package workflowview
+
+import (
+	"sort"
+
+	"core/server/workflow"
+	"core/shared/serverapi"
+)
+
+func boardColumnNodes(def serverapi.WorkflowDefinition) []serverapi.WorkflowNode {
+	graph := newBoardColumnGraph(def)
+	reachable := graph.reachableNodeIDs()
+	orderedIDs := graph.orderedReachableVisibleNodeIDs(reachable)
+	ordered := make([]serverapi.WorkflowNode, 0, len(graph.visibleNodes))
+	emitted := make(map[string]bool, len(graph.visibleNodes))
+	for _, nodeID := range orderedIDs {
+		node, ok := graph.nodesByID[nodeID]
+		if !ok || !boardVisibleNodeKind(node.Kind) || !reachable[nodeID] {
+			continue
+		}
+		ordered = append(ordered, node)
+		emitted[nodeID] = true
+	}
+	unreachable := make([]serverapi.WorkflowNode, 0, len(graph.visibleNodes)-len(ordered))
+	for _, node := range graph.visibleNodes {
+		if emitted[node.ID] || reachable[node.ID] {
+			continue
+		}
+		unreachable = append(unreachable, node)
+	}
+	sortWorkflowNodesByKey(unreachable)
+	return append(ordered, unreachable...)
+}
+
+type boardColumnGraph struct {
+	nodesByID        map[string]serverapi.WorkflowNode
+	visibleNodes     []serverapi.WorkflowNode
+	startNodeIDs     []string
+	outgoingBySource map[string][]string
+}
+
+func newBoardColumnGraph(def serverapi.WorkflowDefinition) boardColumnGraph {
+	nodesByID := make(map[string]serverapi.WorkflowNode, len(def.Nodes))
+	visibleNodes := make([]serverapi.WorkflowNode, 0, len(def.Nodes))
+	startNodeIDs := make([]string, 0, 1)
+	for _, node := range def.Nodes {
+		nodesByID[node.ID] = node
+		if boardVisibleNodeKind(node.Kind) {
+			visibleNodes = append(visibleNodes, node)
+		}
+		if workflow.NodeKind(node.Kind) == workflow.NodeKindStart {
+			startNodeIDs = append(startNodeIDs, node.ID)
+		}
+	}
+	sortWorkflowNodeIDsByNodeKey(startNodeIDs, nodesByID)
+	groupSourceByID := make(map[string]string, len(def.TransitionGroups))
+	for _, group := range def.TransitionGroups {
+		groupSourceByID[group.ID] = group.SourceNodeID
+	}
+	outgoingBySource := make(map[string][]string, len(def.TransitionGroups))
+	for _, edge := range def.Edges {
+		sourceID := groupSourceByID[edge.TransitionGroupID]
+		if _, ok := nodesByID[sourceID]; !ok {
+			continue
+		}
+		if _, ok := nodesByID[edge.TargetNodeID]; !ok {
+			continue
+		}
+		outgoingBySource[sourceID] = append(outgoingBySource[sourceID], edge.TargetNodeID)
+	}
+	for sourceID, targetIDs := range outgoingBySource {
+		sortWorkflowNodeIDsByNodeKey(targetIDs, nodesByID)
+		outgoingBySource[sourceID] = dedupeStrings(targetIDs)
+	}
+	graph := boardColumnGraph{
+		nodesByID:        nodesByID,
+		visibleNodes:     visibleNodes,
+		startNodeIDs:     startNodeIDs,
+		outgoingBySource: outgoingBySource,
+	}
+	return graph
+}
+
+func (g boardColumnGraph) reachableNodeIDs() map[string]bool {
+	reachable := make(map[string]bool, len(g.nodesByID))
+	queue := append([]string(nil), g.startNodeIDs...)
+	for len(queue) > 0 {
+		nodeID := queue[0]
+		queue = queue[1:]
+		if reachable[nodeID] {
+			continue
+		}
+		reachable[nodeID] = true
+		queue = append(queue, g.outgoingBySource[nodeID]...)
+	}
+	return reachable
+}
+
+func (g boardColumnGraph) orderedReachableVisibleNodeIDs(reachable map[string]bool) []string {
+	precedence := make(map[string]map[string]bool, len(g.visibleNodes))
+	reachableVisibleIDs := make([]string, 0, len(g.visibleNodes))
+	for _, node := range g.visibleNodes {
+		if !reachable[node.ID] {
+			continue
+		}
+		reachableVisibleIDs = append(reachableVisibleIDs, node.ID)
+	}
+	for _, source := range g.visibleNodes {
+		if !reachable[source.ID] {
+			continue
+		}
+		for _, targetID := range g.visibleTargetsFrom(source.ID) {
+			if !reachable[targetID] || source.ID == targetID {
+				continue
+			}
+			if precedence[source.ID] == nil {
+				precedence[source.ID] = map[string]bool{}
+			}
+			precedence[source.ID][targetID] = true
+		}
+	}
+	return g.topologicalVisibleNodeIDs(reachableVisibleIDs, precedence)
+}
+
+func (g boardColumnGraph) topologicalVisibleNodeIDs(reachableVisibleIDs []string, precedence map[string]map[string]bool) []string {
+	components := g.stronglyConnectedVisibleComponents(reachableVisibleIDs, precedence)
+	componentByNodeID := make(map[string]int, len(reachableVisibleIDs))
+	for componentID, component := range components {
+		for _, nodeID := range component {
+			componentByNodeID[nodeID] = componentID
+		}
+	}
+	componentEdges := make(map[int]map[int]bool, len(components))
+	indegree := make(map[int]int, len(components))
+	for componentID := range components {
+		indegree[componentID] = 0
+	}
+	for sourceID, targetIDs := range precedence {
+		sourceComponent := componentByNodeID[sourceID]
+		for targetID := range targetIDs {
+			targetComponent := componentByNodeID[targetID]
+			if sourceComponent == targetComponent {
+				continue
+			}
+			if componentEdges[sourceComponent] == nil {
+				componentEdges[sourceComponent] = map[int]bool{}
+			}
+			if componentEdges[sourceComponent][targetComponent] {
+				continue
+			}
+			componentEdges[sourceComponent][targetComponent] = true
+			indegree[targetComponent]++
+		}
+	}
+	available := make([]int, 0, len(components))
+	for componentID := range components {
+		if indegree[componentID] == 0 {
+			available = append(available, componentID)
+		}
+	}
+	orderedComponents := make([]int, 0, len(components))
+	emitted := make(map[int]bool, len(components))
+	for len(available) > 0 {
+		g.sortComponentIDsByKey(available, components)
+		componentID := available[0]
+		available = available[1:]
+		if emitted[componentID] {
+			continue
+		}
+		orderedComponents = append(orderedComponents, componentID)
+		emitted[componentID] = true
+		targetComponentIDs := mapIntKeys(componentEdges[componentID])
+		g.sortComponentIDsByKey(targetComponentIDs, components)
+		for _, targetComponentID := range targetComponentIDs {
+			indegree[targetComponentID]--
+			if indegree[targetComponentID] == 0 {
+				available = append(available, targetComponentID)
+			}
+		}
+	}
+	if len(orderedComponents) != len(components) {
+		for componentID := range components {
+			if !emitted[componentID] {
+				orderedComponents = append(orderedComponents, componentID)
+			}
+		}
+	}
+	ordered := make([]string, 0, len(reachableVisibleIDs))
+	for _, componentID := range orderedComponents {
+		ordered = append(ordered, components[componentID]...)
+	}
+	return ordered
+}
+
+func (g boardColumnGraph) stronglyConnectedVisibleComponents(nodeIDs []string, precedence map[string]map[string]bool) [][]string {
+	indexByNodeID := make(map[string]int, len(nodeIDs))
+	lowByNodeID := make(map[string]int, len(nodeIDs))
+	onStack := make(map[string]bool, len(nodeIDs))
+	stack := make([]string, 0, len(nodeIDs))
+	nextIndex := 0
+	components := make([][]string, 0)
+	orderedNodeIDs := append([]string(nil), nodeIDs...)
+	sortWorkflowNodeIDsByNodeKey(orderedNodeIDs, g.nodesByID)
+	var visit func(string)
+	visit = func(nodeID string) {
+		indexByNodeID[nodeID] = nextIndex
+		lowByNodeID[nodeID] = nextIndex
+		nextIndex++
+		stack = append(stack, nodeID)
+		onStack[nodeID] = true
+		targetIDs := mapKeys(precedence[nodeID])
+		sortWorkflowNodeIDsByNodeKey(targetIDs, g.nodesByID)
+		for _, targetID := range targetIDs {
+			if _, seen := indexByNodeID[targetID]; !seen {
+				visit(targetID)
+				lowByNodeID[nodeID] = min(lowByNodeID[nodeID], lowByNodeID[targetID])
+				continue
+			}
+			if onStack[targetID] {
+				lowByNodeID[nodeID] = min(lowByNodeID[nodeID], indexByNodeID[targetID])
+			}
+		}
+		if lowByNodeID[nodeID] != indexByNodeID[nodeID] {
+			return
+		}
+		component := make([]string, 0)
+		for len(stack) > 0 {
+			stackNodeID := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			onStack[stackNodeID] = false
+			component = append(component, stackNodeID)
+			if stackNodeID == nodeID {
+				break
+			}
+		}
+		sortWorkflowNodeIDsByNodeKey(component, g.nodesByID)
+		components = append(components, component)
+	}
+	for _, nodeID := range orderedNodeIDs {
+		if _, seen := indexByNodeID[nodeID]; !seen {
+			visit(nodeID)
+		}
+	}
+	return components
+}
+
+func (g boardColumnGraph) sortComponentIDsByKey(componentIDs []int, components [][]string) {
+	sort.SliceStable(componentIDs, func(i, j int) bool {
+		return workflowNodeKeyLess(g.nodesByID[components[componentIDs[i]][0]], g.nodesByID[components[componentIDs[j]][0]])
+	})
+}
+
+func (g boardColumnGraph) visibleTargetsFrom(sourceID string) []string {
+	targets := make([]string, 0)
+	seenHidden := map[string]bool{}
+	queue := append([]string(nil), g.outgoingBySource[sourceID]...)
+	for len(queue) > 0 {
+		nodeID := queue[0]
+		queue = queue[1:]
+		node, ok := g.nodesByID[nodeID]
+		if !ok {
+			continue
+		}
+		if boardVisibleNodeKind(node.Kind) {
+			targets = append(targets, nodeID)
+			continue
+		}
+		if seenHidden[nodeID] {
+			continue
+		}
+		seenHidden[nodeID] = true
+		queue = append(queue, g.outgoingBySource[nodeID]...)
+	}
+	sortWorkflowNodeIDsByNodeKey(targets, g.nodesByID)
+	return dedupeStrings(targets)
+}
+
+func sortWorkflowNodesByKey(nodes []serverapi.WorkflowNode) {
+	sort.SliceStable(nodes, func(i, j int) bool {
+		return workflowNodeKeyLess(nodes[i], nodes[j])
+	})
+}
+
+func sortWorkflowNodeIDsByNodeKey(nodeIDs []string, nodesByID map[string]serverapi.WorkflowNode) {
+	sort.SliceStable(nodeIDs, func(i, j int) bool {
+		return workflowNodeKeyLess(nodesByID[nodeIDs[i]], nodesByID[nodeIDs[j]])
+	})
+}
+
+func workflowNodeKeyLess(left serverapi.WorkflowNode, right serverapi.WorkflowNode) bool {
+	if left.Key != right.Key {
+		return left.Key < right.Key
+	}
+	return left.ID < right.ID
+}
+
+func dedupeStrings(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	deduped := values[:0]
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		deduped = append(deduped, value)
+	}
+	return deduped
+}
+
+func mapKeys(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func mapIntKeys(values map[int]bool) []int {
+	keys := make([]int, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/server/workflowview/board_order.go
+++ b/server/workflowview/board_order.go
@@ -246,8 +246,22 @@ func (g boardColumnGraph) stronglyConnectedVisibleComponents(nodeIDs []string, p
 
 func (g boardColumnGraph) sortComponentIDsByKey(componentIDs []int, components [][]string) {
 	sort.SliceStable(componentIDs, func(i, j int) bool {
+		leftTerminal := g.componentHasTerminalNode(components[componentIDs[i]])
+		rightTerminal := g.componentHasTerminalNode(components[componentIDs[j]])
+		if leftTerminal != rightTerminal {
+			return !leftTerminal
+		}
 		return workflowNodeKeyLess(g.nodesByID[components[componentIDs[i]][0]], g.nodesByID[components[componentIDs[j]][0]])
 	})
+}
+
+func (g boardColumnGraph) componentHasTerminalNode(component []string) bool {
+	for _, nodeID := range component {
+		if workflow.NodeKind(g.nodesByID[nodeID].Kind) == workflow.NodeKindTerminal {
+			return true
+		}
+	}
+	return false
 }
 
 func (g boardColumnGraph) visibleTargetsFrom(sourceID string) []string {

--- a/server/workflowview/service.go
+++ b/server/workflowview/service.go
@@ -1817,11 +1817,12 @@ func selectWorkflow(picker []serverapi.WorkflowPickerItem, requested string) ser
 }
 
 func boardGroups(def serverapi.WorkflowDefinition) []serverapi.WorkflowBoardGroup {
+	columnNodes := boardColumnNodes(def)
 	groups := make([]serverapi.WorkflowBoardGroup, 0, len(def.NodeGroups))
 	for _, group := range def.NodeGroups {
 		dto := serverapi.WorkflowBoardGroup{GroupID: group.GroupID, Key: group.GroupKey, DisplayName: group.DisplayName, SortOrder: group.SortOrder}
-		for _, node := range def.Nodes {
-			if node.GroupID == group.GroupID && boardVisibleNodeKind(node.Kind) {
+		for _, node := range columnNodes {
+			if node.GroupID == group.GroupID {
 				dto.NodeIDs = append(dto.NodeIDs, node.ID)
 			}
 		}
@@ -1837,10 +1838,7 @@ func boardColumns(def serverapi.WorkflowDefinition) []serverapi.WorkflowBoardCol
 	columns := make([]serverapi.WorkflowBoardColumn, 0, len(def.Nodes))
 	domainDef := definitionForValidation(def)
 	derived := workflow.DeriveWiring(domainDef)
-	for index, node := range def.Nodes {
-		if !boardVisibleNodeKind(node.Kind) {
-			continue
-		}
+	for index, node := range boardColumnNodes(def) {
 		columns = append(columns, serverapi.WorkflowBoardColumn{
 			Node: serverapi.WorkflowBoardNodeSummary{
 				NodeID:                 node.ID,

--- a/server/workflowview/service_test.go
+++ b/server/workflowview/service_test.go
@@ -251,6 +251,167 @@ func TestBoardGroupsHideJoinNodesAndJoinOnlyGroups(t *testing.T) {
 	}
 }
 
+func TestBoardColumnsUseWorkflowStructureInsteadOfDefinitionNodeOrder(t *testing.T) {
+	def := serverapi.WorkflowDefinition{
+		Workflow: serverapi.WorkflowRecord{ID: "workflow-1"},
+		Nodes: []serverapi.WorkflowNode{
+			{ID: "node-start", Key: "backlog", Kind: string(workflow.NodeKindStart), DisplayName: "Backlog"},
+			{ID: "node-done", Key: "done", Kind: string(workflow.NodeKindTerminal), DisplayName: "Done"},
+			{ID: "node-plan", Key: "plan", Kind: string(workflow.NodeKindAgent), DisplayName: "Planning"},
+			{ID: "node-implementation", Key: "implementation", Kind: string(workflow.NodeKindAgent), DisplayName: "Implementation"},
+			{ID: "node-plan-review", Key: "plan_review", Kind: string(workflow.NodeKindAgent), DisplayName: "Plan Review"},
+		},
+		TransitionGroups: []serverapi.WorkflowTransitionGroup{
+			{ID: "transition-start", SourceNodeID: "node-start", TransitionID: "start"},
+			{ID: "transition-plan", SourceNodeID: "node-plan", TransitionID: "plan_review"},
+			{ID: "transition-review-approved", SourceNodeID: "node-plan-review", TransitionID: "approved"},
+			{ID: "transition-review-rejected", SourceNodeID: "node-plan-review", TransitionID: "rejected"},
+			{ID: "transition-implementation", SourceNodeID: "node-implementation", TransitionID: "done"},
+		},
+		Edges: []serverapi.WorkflowEdge{
+			{ID: "edge-start", TransitionGroupID: "transition-start", Key: "start", TargetNodeID: "node-plan"},
+			{ID: "edge-plan-review", TransitionGroupID: "transition-plan", Key: "plan_review", TargetNodeID: "node-plan-review"},
+			{ID: "edge-approved", TransitionGroupID: "transition-review-approved", Key: "approved", TargetNodeID: "node-implementation"},
+			{ID: "edge-rejected", TransitionGroupID: "transition-review-rejected", Key: "rejected", TargetNodeID: "node-plan"},
+			{ID: "edge-done", TransitionGroupID: "transition-implementation", Key: "done", TargetNodeID: "node-done"},
+		},
+	}
+
+	keys := workflowViewBoardColumnKeys(boardColumns(def))
+	want := []string{"backlog", "plan", "plan_review", "implementation", "done"}
+	if strings.Join(keys, ",") != strings.Join(want, ",") {
+		t.Fatalf("board column keys = %+v, want structural order %+v", keys, want)
+	}
+}
+
+func TestBoardColumnsOrderAmbiguousSiblingsByNodeKey(t *testing.T) {
+	def := serverapi.WorkflowDefinition{
+		Workflow: serverapi.WorkflowRecord{ID: "workflow-1"},
+		Nodes: []serverapi.WorkflowNode{
+			{ID: "node-start", Key: "backlog", Kind: string(workflow.NodeKindStart), DisplayName: "Backlog"},
+			{ID: "node-zeta", Key: "zeta", Kind: string(workflow.NodeKindAgent), DisplayName: "Zeta"},
+			{ID: "node-alpha", Key: "alpha", Kind: string(workflow.NodeKindAgent), DisplayName: "Alpha"},
+			{ID: "node-done", Key: "done", Kind: string(workflow.NodeKindTerminal), DisplayName: "Done"},
+		},
+		TransitionGroups: []serverapi.WorkflowTransitionGroup{
+			{ID: "transition-start", SourceNodeID: "node-start", TransitionID: "start"},
+			{ID: "transition-alpha", SourceNodeID: "node-alpha", TransitionID: "done"},
+			{ID: "transition-zeta", SourceNodeID: "node-zeta", TransitionID: "done"},
+		},
+		Edges: []serverapi.WorkflowEdge{
+			{ID: "edge-zeta", TransitionGroupID: "transition-start", Key: "zeta", TargetNodeID: "node-zeta"},
+			{ID: "edge-alpha", TransitionGroupID: "transition-start", Key: "alpha", TargetNodeID: "node-alpha"},
+			{ID: "edge-alpha-done", TransitionGroupID: "transition-alpha", Key: "done", TargetNodeID: "node-done"},
+			{ID: "edge-zeta-done", TransitionGroupID: "transition-zeta", Key: "done", TargetNodeID: "node-done"},
+		},
+	}
+
+	keys := workflowViewBoardColumnKeys(boardColumns(def))
+	want := []string{"backlog", "alpha", "zeta", "done"}
+	if strings.Join(keys, ",") != strings.Join(want, ",") {
+		t.Fatalf("board column keys = %+v, want key-tied sibling order %+v", keys, want)
+	}
+}
+
+func TestBoardColumnsUseExplicitSiblingEdgeBeforeNodeKeyTie(t *testing.T) {
+	def := serverapi.WorkflowDefinition{
+		Workflow: serverapi.WorkflowRecord{ID: "workflow-1"},
+		Nodes: []serverapi.WorkflowNode{
+			{ID: "node-start", Key: "backlog", Kind: string(workflow.NodeKindStart), DisplayName: "Backlog"},
+			{ID: "node-alpha", Key: "alpha", Kind: string(workflow.NodeKindAgent), DisplayName: "Alpha"},
+			{ID: "node-zeta", Key: "zeta", Kind: string(workflow.NodeKindAgent), DisplayName: "Zeta"},
+			{ID: "node-done", Key: "done", Kind: string(workflow.NodeKindTerminal), DisplayName: "Done"},
+		},
+		TransitionGroups: []serverapi.WorkflowTransitionGroup{
+			{ID: "transition-start", SourceNodeID: "node-start", TransitionID: "start"},
+			{ID: "transition-zeta", SourceNodeID: "node-zeta", TransitionID: "alpha"},
+			{ID: "transition-alpha", SourceNodeID: "node-alpha", TransitionID: "done"},
+		},
+		Edges: []serverapi.WorkflowEdge{
+			{ID: "edge-alpha", TransitionGroupID: "transition-start", Key: "alpha", TargetNodeID: "node-alpha"},
+			{ID: "edge-zeta", TransitionGroupID: "transition-start", Key: "zeta", TargetNodeID: "node-zeta"},
+			{ID: "edge-zeta-alpha", TransitionGroupID: "transition-zeta", Key: "alpha", TargetNodeID: "node-alpha"},
+			{ID: "edge-alpha-done", TransitionGroupID: "transition-alpha", Key: "done", TargetNodeID: "node-done"},
+		},
+	}
+
+	keys := workflowViewBoardColumnKeys(boardColumns(def))
+	want := []string{"backlog", "zeta", "alpha", "done"}
+	if strings.Join(keys, ",") != strings.Join(want, ",") {
+		t.Fatalf("board column keys = %+v, want explicit sibling edge order %+v", keys, want)
+	}
+}
+
+func TestBoardColumnsAppendUnreachableVisibleNodesByKey(t *testing.T) {
+	def := serverapi.WorkflowDefinition{
+		Workflow: serverapi.WorkflowRecord{ID: "workflow-1"},
+		Nodes: []serverapi.WorkflowNode{
+			{ID: "node-start", Key: "backlog", Kind: string(workflow.NodeKindStart), DisplayName: "Backlog"},
+			{ID: "node-zeta", Key: "zeta", Kind: string(workflow.NodeKindAgent), DisplayName: "Zeta"},
+			{ID: "node-reachable", Key: "reachable", Kind: string(workflow.NodeKindAgent), DisplayName: "Reachable"},
+			{ID: "node-alpha", Key: "alpha", Kind: string(workflow.NodeKindAgent), DisplayName: "Alpha"},
+			{ID: "node-done", Key: "done", Kind: string(workflow.NodeKindTerminal), DisplayName: "Done"},
+		},
+		TransitionGroups: []serverapi.WorkflowTransitionGroup{
+			{ID: "transition-start", SourceNodeID: "node-start", TransitionID: "start"},
+			{ID: "transition-reachable", SourceNodeID: "node-reachable", TransitionID: "done"},
+		},
+		Edges: []serverapi.WorkflowEdge{
+			{ID: "edge-start", TransitionGroupID: "transition-start", Key: "start", TargetNodeID: "node-reachable"},
+			{ID: "edge-done", TransitionGroupID: "transition-reachable", Key: "done", TargetNodeID: "node-done"},
+		},
+	}
+
+	keys := workflowViewBoardColumnKeys(boardColumns(def))
+	want := []string{"backlog", "reachable", "done", "alpha", "zeta"}
+	if strings.Join(keys, ",") != strings.Join(want, ",") {
+		t.Fatalf("board column keys = %+v, want unreachable nodes appended by key %+v", keys, want)
+	}
+}
+
+func TestBoardGroupsUseStructuralColumnOrderAndTraverseJoinNodes(t *testing.T) {
+	def := serverapi.WorkflowDefinition{
+		Workflow: serverapi.WorkflowRecord{ID: "workflow-1"},
+		NodeGroups: []serverapi.WorkflowNodeGroup{
+			{GroupID: "group-implementation", GroupKey: "implementation", DisplayName: "Implementation"},
+		},
+		Nodes: []serverapi.WorkflowNode{
+			{ID: "node-start", Key: "backlog", Kind: string(workflow.NodeKindStart), DisplayName: "Backlog"},
+			{ID: "node-zeta", Key: "zeta", Kind: string(workflow.NodeKindAgent), DisplayName: "Zeta", GroupID: "group-implementation"},
+			{ID: "node-alpha", Key: "alpha", Kind: string(workflow.NodeKindAgent), DisplayName: "Alpha", GroupID: "group-implementation"},
+			{ID: "node-join", Key: "join", Kind: string(workflow.NodeKindJoin), DisplayName: "Join", GroupID: "group-implementation"},
+			{ID: "node-synth", Key: "synth", Kind: string(workflow.NodeKindAgent), DisplayName: "Synthesize", GroupID: "group-implementation"},
+			{ID: "node-done", Key: "done", Kind: string(workflow.NodeKindTerminal), DisplayName: "Done"},
+		},
+		TransitionGroups: []serverapi.WorkflowTransitionGroup{
+			{ID: "transition-start", SourceNodeID: "node-start", TransitionID: "start"},
+			{ID: "transition-alpha", SourceNodeID: "node-alpha", TransitionID: "join"},
+			{ID: "transition-zeta", SourceNodeID: "node-zeta", TransitionID: "join"},
+			{ID: "transition-join", SourceNodeID: "node-join", TransitionID: "synth"},
+			{ID: "transition-synth", SourceNodeID: "node-synth", TransitionID: "done"},
+		},
+		Edges: []serverapi.WorkflowEdge{
+			{ID: "edge-zeta", TransitionGroupID: "transition-start", Key: "zeta", TargetNodeID: "node-zeta"},
+			{ID: "edge-alpha", TransitionGroupID: "transition-start", Key: "alpha", TargetNodeID: "node-alpha"},
+			{ID: "edge-alpha-join", TransitionGroupID: "transition-alpha", Key: "join", TargetNodeID: "node-join"},
+			{ID: "edge-zeta-join", TransitionGroupID: "transition-zeta", Key: "join", TargetNodeID: "node-join"},
+			{ID: "edge-synth", TransitionGroupID: "transition-join", Key: "synth", TargetNodeID: "node-synth"},
+			{ID: "edge-done", TransitionGroupID: "transition-synth", Key: "done", TargetNodeID: "node-done"},
+		},
+	}
+
+	keys := workflowViewBoardColumnKeys(boardColumns(def))
+	wantKeys := []string{"backlog", "alpha", "zeta", "synth", "done"}
+	if strings.Join(keys, ",") != strings.Join(wantKeys, ",") {
+		t.Fatalf("board column keys = %+v, want join-traversed order %+v", keys, wantKeys)
+	}
+	groups := boardGroups(def)
+	wantNodeIDs := []string{"node-alpha", "node-zeta", "node-synth"}
+	if len(groups) != 1 || strings.Join(groups[0].NodeIDs, ",") != strings.Join(wantNodeIDs, ",") {
+		t.Fatalf("board groups = %+v, want structural visible node ids %+v", groups, wantNodeIDs)
+	}
+}
+
 func TestBoardSelectsWorkflowAndReturnsPickerAndGroups(t *testing.T) {
 	ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
 	defaultWorkflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
@@ -1624,6 +1785,14 @@ func workflowViewColumnByKey(t *testing.T, board serverapi.WorkflowBoard, key st
 	}
 	t.Fatalf("missing board column key %q in %+v", key, board.Columns)
 	return serverapi.WorkflowBoardColumn{}
+}
+
+func workflowViewBoardColumnKeys(columns []serverapi.WorkflowBoardColumn) []string {
+	keys := make([]string, 0, len(columns))
+	for _, column := range columns {
+		keys = append(keys, column.Node.Key)
+	}
+	return keys
 }
 
 func TestWorkflowViewRejectsMissingIDs(t *testing.T) {

--- a/server/workflowview/service_test.go
+++ b/server/workflowview/service_test.go
@@ -313,6 +313,30 @@ func TestBoardColumnsOrderAmbiguousSiblingsByNodeKey(t *testing.T) {
 	}
 }
 
+func TestBoardColumnsKeepReachableTerminalAfterAmbiguousSibling(t *testing.T) {
+	def := serverapi.WorkflowDefinition{
+		Workflow: serverapi.WorkflowRecord{ID: "workflow-1"},
+		Nodes: []serverapi.WorkflowNode{
+			{ID: "node-start", Key: "backlog", Kind: string(workflow.NodeKindStart), DisplayName: "Backlog"},
+			{ID: "node-zeta", Key: "zeta", Kind: string(workflow.NodeKindAgent), DisplayName: "Zeta"},
+			{ID: "node-done", Key: "done", Kind: string(workflow.NodeKindTerminal), DisplayName: "Done"},
+		},
+		TransitionGroups: []serverapi.WorkflowTransitionGroup{
+			{ID: "transition-start", SourceNodeID: "node-start", TransitionID: "start"},
+		},
+		Edges: []serverapi.WorkflowEdge{
+			{ID: "edge-done", TransitionGroupID: "transition-start", Key: "done", TargetNodeID: "node-done"},
+			{ID: "edge-zeta", TransitionGroupID: "transition-start", Key: "zeta", TargetNodeID: "node-zeta"},
+		},
+	}
+
+	keys := workflowViewBoardColumnKeys(boardColumns(def))
+	want := []string{"backlog", "zeta", "done"}
+	if strings.Join(keys, ",") != strings.Join(want, ",") {
+		t.Fatalf("board column keys = %+v, want terminal after ambiguous non-terminal sibling %+v", keys, want)
+	}
+}
+
 func TestBoardColumnsUseExplicitSiblingEdgeBeforeNodeKeyTie(t *testing.T) {
 	def := serverapi.WorkflowDefinition{
 		Workflow: serverapi.WorkflowRecord{ID: "workflow-1"},


### PR DESCRIPTION
## Summary
- serialize ask_question calls in declared order so multiple model questions are forwarded deterministically
- serialize workflow prompt-capable tools with ask_question to avoid racing the workflow waiting-question slot
- add runtime and workflowrunner regressions for multi-question batches

## Verification
- ./scripts/test.sh ./server/workflowrunner -count=1
- ./scripts/test.sh ./server/runtime -count=1
- ./scripts/test.sh ./server/workflowstore -count=1
- ./scripts/build.sh --output ./bin/kent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Board columns now order based on workflow structure rather than definition order, with node-key tie-breaking.
  * Serialized execution of question tool calls ensures proper sequencing in multi-question workflows.
  * Enhanced question event handling (waiting, cleared, answered) with improved attention state management.

* **Bug Fixes**
  * Improved WebSocket subscription completion with better error handling.
  * Fixed initial scroll positioning in task detail list for question focus.

* **Performance**
  * Added memoization for attention rows to reduce unnecessary re-renders.
  * Improved query refresh with placeholder data retention during refetches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->