### PR TITLE
fix: enforce context window minimum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,5 @@ docs/tmp/
 .env
 .kent/config.toml
 .kent/plans/
+.kent/qa/
 .kent/proofs/

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -178,7 +178,8 @@
 - `theme=light` and `theme=dark` select fixed Kent palettes. `theme=auto` or omitted theme uses terminal background detection.
 - Global debug mode is configured by `debug = true` or `KENT_DEBUG=1` and enables developer-oriented strictness.
 - Thinking level applies only to OpenAI model families and passes configured values through unchanged.
-- Context window setting is `model_context_window`, default `272000`.
+- Context window setting is `model_context_window`, default `272000`, minimum `40000`.
+- Effective reviewer and subagent context windows must be at least `40000`.
 - `context_compaction_threshold_tokens < model_context_window` is required.
 - Responses API `store` is configurable with default `false`.
 - `tools.web_search` is enabled by default; `web_search` selects provider-native search (`native`) or disabled (`off`).
@@ -191,7 +192,7 @@
 - Runtime context needed after compaction, including workflow prompts and reminders, is steered into the new active list after replacement.
 - Kent may compact before submitting a queued user prompt when current context usage is within the runway reserve.
 - Pre-submit compaction uses `context_compaction_threshold_tokens - pre_submit_compaction_lead_tokens`, with default lead `35000`.
-- Startup rejects compaction settings that begin normal or pre-submit compaction below 50% of `model_context_window`.
+- Startup rejects compaction settings that begin normal or pre-submit compaction below 50% of `model_context_window`; this is separate from the `40000` minimum context window.
 - Auto-compaction failure aborts the current turn.
 - `compaction_mode=none` disables manual and automatic compaction.
 - Manual `/compact` is available while idle; arguments are appended as guidance.
@@ -234,6 +235,7 @@
 - `kent run "prompt"` is the supported headless/subagent interface.
 - Headless roles use `kent run --agent <role> "prompt"`; `--fast` selects the built-in fast role.
 - Subagent roles are file-only `[subagents.<role>]` config tables and inherit main config unless overridden.
+- Subagent role `model_context_window` and `reviewer.model_context_window` overrides must resolve to at least `40000`.
 - Subagent roles may set `agent_callable=false`; such roles are hidden from agent-facing role context and rejected for Kent-session subagent calls, while humans may still run them from ordinary shells.
 - Future frontend/status surfaces should mark non-callable roles distinctly when relevant instead of erasing the distinction.
 - The built-in `fast` role exists without config and may switch to a smaller/faster profile on exact OpenAI first-party setups.

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -132,7 +132,7 @@ verbose_output = false # show in ongoing transcript
 | `openai_base_url` | string | `""` | `KENT_OPENAI_BASE_URL` | `kent run --openai-base-url` | OpenAI-compatible base URL. Must be used with `provider_override=openai` or with no explicit provider override. Cannot be changed mid-session. |
 | `store` | bool | `false` | `KENT_STORE` |  | Sets OpenAI Responses `store=true` for main model requests. |
 | `allow_non_cwd_edits` | bool | `false` | `KENT_ALLOW_NON_CWD_EDITS` |  | Lets first-class file edit tools edit files outside the workspace root. This is not sandboxing - model can still bypass this easily. |
-| `model_context_window` | int | `272000` | `KENT_MODEL_CONTEXT_WINDOW` |  | Explicit context-window size used for compaction and token accounting. Must be `> 0`. |
+| `model_context_window` | int | `272000` | `KENT_MODEL_CONTEXT_WINDOW` |  | Explicit context-window size used for compaction and token accounting. Must be at least `40000`. |
 | `context_compaction_threshold_tokens` | int | `258400` | `KENT_CONTEXT_COMPACTION_THRESHOLD_TOKENS` |  | Auto-compaction threshold. Must be `> 0`, `< model_context_window`, and at least `50%` of `model_context_window`. The default is derived from the default context window. |
 | `pre_submit_compaction_lead_tokens` | int | `35000` | `KENT_PRE_SUBMIT_COMPACTION_LEAD_TOKENS` |  | Fixed pre-submit runway reserve before auto-compaction. Kent compacts before sending the next user prompt once (`context_compaction_threshold_tokens` - this threshold) is reached. |
 | `minimum_exec_to_bg_seconds` | int | `15` | `KENT_MINIMUM_EXEC_TO_BG_SECONDS` |  | Default floor for `exec_command` yield time before it moves to background and lets Kent manage it asynchronously. Must be `> 0`. Use if model frequently expects your commands to complete fast, they background, and force model to poll for them. |
@@ -164,7 +164,7 @@ Configure the supervisor agent that oversees model changes.
 | `reviewer.provider_override` | string | inherits `provider_override` | `KENT_REVIEWER_PROVIDER_OVERRIDE` | Forces provider family for the reviewer model. Allowed: `openai`, `anthropic`. |
 | `reviewer.openai_base_url` | string | inherits `openai_base_url` for OpenAI-family reviewer providers | `KENT_REVIEWER_OPENAI_BASE_URL` | OpenAI-compatible base URL for the reviewer model. Non-OpenAI endpoints can run without Kent auth when the server accepts anonymous requests. |
 | `reviewer.auth` | string | `inherit` | `KENT_REVIEWER_AUTH` | Reviewer auth policy. `inherit` uses Kent's configured auth. `none` sends no `Authorization` header; providers that require auth return their normal runtime error. |
-| `reviewer.model_context_window` | int | inherits `model_context_window` | `KENT_REVIEWER_MODEL_CONTEXT_WINDOW` | Explicit reviewer context-window size sent to the reviewer provider. |
+| `reviewer.model_context_window` | int | inherits `model_context_window` | `KENT_REVIEWER_MODEL_CONTEXT_WINDOW` | Explicit reviewer context-window size sent to the reviewer provider. The effective value must be at least `40000`. |
 | `reviewer.system_prompt_file` | string | `""` |  | Path to a custom supervisor system prompt file. Relative paths resolve from the config file directory. Workspace config overrides global config; no CLI or environment override is provided. |
 | `reviewer.timeout_seconds` | int | `60` | `KENT_REVIEWER_TIMEOUT_SECONDS` | Reviewer HTTP timeout. Must be `> 0`. |
 | `reviewer.verbose_output` | bool | `false` | `KENT_REVIEWER_VERBOSE_OUTPUT` | Controls whether reviewer suggestion text is shown at all. When `false`, Kent only shows the concise reviewer result/status line. When `true`, Kent shows the full suggestion list at the moment the reviewer issues it, and the later reviewer status stays concise after the follow-up is applied or ignored. |
@@ -240,6 +240,7 @@ Notes:
 `[subagents.<role>]` is a file-only table for named headless subagent roles. Fast is always-present, but you can add custom agents here.
 
 Subagent roles inherit the main config and then override only the keys set in that role table.
+Any effective main or reviewer context window used by a subagent role must be at least `40000`.
 Set `system_prompt_file` inside a subagent role to use a role-specific main system prompt for `kent run --agent <role>`.
 Set `description` to describe a behaviorally distinct role to other agents. Set `agent_callable = false` for roles that humans may run explicitly but agents should not call from Kent sessions.
 

--- a/server/launch/edit_tools_test.go
+++ b/server/launch/edit_tools_test.go
@@ -152,7 +152,7 @@ func validLaunchSettings(model string) config.Settings {
 		WebSearch:                        "native",
 		ServerHost:                       "127.0.0.1",
 		ServerPort:                       53082,
-		Reviewer:                         config.ReviewerSettings{Frequency: "edits", Model: model, ThinkingLevel: "medium", TimeoutSeconds: 60},
+		Reviewer:                         config.ReviewerSettings{Frequency: "edits", Model: model, ThinkingLevel: "medium", ModelContextWindow: 272000, TimeoutSeconds: 60},
 		Timeouts:                         config.Timeouts{ModelRequestSeconds: 400},
 		ShellOutputMaxChars:              16000,
 		MinimumExecToBgSeconds:           15,

--- a/shared/config/config_defaults.go
+++ b/shared/config/config_defaults.go
@@ -17,6 +17,7 @@ const (
 	defaultModelVerbosity                = ModelVerbosityMedium
 	defaultTheme                         = theme.Auto
 	defaultModelContextWindow            = 272_000
+	minimumModelContextWindow            = 40_000
 	defaultModelTimeoutSeconds           = 400
 	defaultMinimumExecToBgSec            = 15
 	defaultShellOutputMaxChars           = 16_000

--- a/shared/config/config_errors.go
+++ b/shared/config/config_errors.go
@@ -35,14 +35,15 @@ var (
 	errSubagentDescriptionTooLong = newConfigError("subagent description too long")
 
 	// Validation-rule sentinels for individual settings fields.
-	errProviderOverrideRequiresModel = newConfigError("provider_override requires an explicit model override")
-	errInvalidProviderOverride       = newConfigError("invalid provider_override")
-	errOpenAIBaseURLConflict         = newConfigError("provider_override conflicts with openai_base_url")
-	errProviderCapabilitiesNeedID    = newConfigError("provider_capabilities.provider_id must not be empty when provider capability overrides are set")
-	errInvalidModelVerbosity         = newConfigError("invalid model_verbosity")
-	errInvalidReviewerProvider       = newConfigError("invalid reviewer.provider_override")
-	errReviewerContextWindowNegative = newConfigError("reviewer.model_context_window must be >= 0")
-	errInvalidCacheWarningMode       = newConfigError("invalid cache_warning_mode")
+	errProviderOverrideRequiresModel  = newConfigError("provider_override requires an explicit model override")
+	errInvalidProviderOverride        = newConfigError("invalid provider_override")
+	errOpenAIBaseURLConflict          = newConfigError("provider_override conflicts with openai_base_url")
+	errProviderCapabilitiesNeedID     = newConfigError("provider_capabilities.provider_id must not be empty when provider capability overrides are set")
+	errInvalidModelVerbosity          = newConfigError("invalid model_verbosity")
+	errInvalidReviewerProvider        = newConfigError("invalid reviewer.provider_override")
+	errReviewerContextWindowNegative  = newConfigError("reviewer.model_context_window must be >= 0")
+	errModelContextWindowBelowMinimum = newConfigError("model context window below minimum")
+	errInvalidCacheWarningMode        = newConfigError("invalid cache_warning_mode")
 
 	// errCompactionThresholdBelowMinimum is returned when the configured
 	// compaction threshold falls below the minimum percentage of the model

--- a/shared/config/config_overlay.go
+++ b/shared/config/config_overlay.go
@@ -28,7 +28,7 @@ func inheritReviewerDefaultsWithSources(settings *Settings, sources map[string]s
 	settings.Reviewer.OpenAIBaseURL = reviewerProvider.OpenAIBaseURL
 	inheritReviewerModelCapabilities(settings, sources)
 	inheritReviewerProviderCapabilities(settings, sources, reviewerProviderSelectionExplicit)
-	if settings.Reviewer.ModelContextWindow == 0 {
+	if settings.Reviewer.ModelContextWindow == 0 && !hasConfiguredSource(sources, "reviewer.model_context_window") {
 		settings.Reviewer.ModelContextWindow = settings.ModelContextWindow
 	}
 }

--- a/shared/config/config_part2_test.go
+++ b/shared/config/config_part2_test.go
@@ -122,7 +122,7 @@ supports_prompt_cache_key = true
 	}
 
 	t.Setenv("KENT_REVIEWER_MODEL_VERBOSITY", "medium")
-	t.Setenv("KENT_REVIEWER_MODEL_CONTEXT_WINDOW", "32000")
+	t.Setenv("KENT_REVIEWER_MODEL_CONTEXT_WINDOW", "48000")
 	t.Setenv("KENT_REVIEWER_MODEL_CAPABILITIES_SUPPORTS_REASONING_EFFORT", "false")
 	t.Setenv("KENT_REVIEWER_MODEL_CAPABILITIES_SUPPORTS_VISION_INPUTS", "false")
 	t.Setenv("KENT_REVIEWER_PROVIDER_CAPABILITIES_PROVIDER_ID", "env-reviewer")
@@ -132,8 +132,8 @@ supports_prompt_cache_key = true
 	if cfg.Settings.Reviewer.ModelVerbosity != ModelVerbosityMedium {
 		t.Fatalf("expected env reviewer.model_verbosity=medium, got %q", cfg.Settings.Reviewer.ModelVerbosity)
 	}
-	if cfg.Settings.Reviewer.ModelContextWindow != 32000 {
-		t.Fatalf("expected env reviewer.model_context_window=32000, got %d", cfg.Settings.Reviewer.ModelContextWindow)
+	if cfg.Settings.Reviewer.ModelContextWindow != 48000 {
+		t.Fatalf("expected env reviewer.model_context_window=48000, got %d", cfg.Settings.Reviewer.ModelContextWindow)
 	}
 	if cfg.Settings.Reviewer.ModelCapabilities.SupportsReasoningEffort || cfg.Settings.Reviewer.ModelCapabilities.SupportsVisionInputs {
 		t.Fatalf("expected env reviewer model capability overrides to disable file values, got %+v", cfg.Settings.Reviewer.ModelCapabilities)
@@ -215,6 +215,30 @@ model_context_window = -1
 	}
 	if !errors.Is(err, errReviewerContextWindowNegative) {
 		t.Fatalf("expected reviewer.model_context_window validation error, got %v", err)
+	}
+}
+
+func TestLoadReviewerModelContextWindowRejectsBelowMinimum(t *testing.T) {
+	err := loadConfigTestFileError(t, `[reviewer]
+model_context_window = 39999
+`, LoadOptions{})
+	if err == nil {
+		t.Fatal("expected reviewer.model_context_window below minimum to fail")
+	}
+	if !errors.Is(err, errModelContextWindowBelowMinimum) {
+		t.Fatalf("expected model context window minimum validation detail, got %v", err)
+	}
+}
+
+func TestLoadReviewerModelContextWindowRejectsExplicitZero(t *testing.T) {
+	err := loadConfigTestFileError(t, `[reviewer]
+model_context_window = 0
+`, LoadOptions{})
+	if err == nil {
+		t.Fatal("expected explicit reviewer.model_context_window=0 to fail")
+	}
+	if !errors.Is(err, errModelContextWindowBelowMinimum) {
+		t.Fatalf("expected model context window minimum validation detail, got %v", err)
 	}
 }
 
@@ -353,6 +377,7 @@ func TestNormalizeSettingsForPersistencePreservesReviewerCapabilityFalseWithoutS
 func TestValidateSettingsWithSourcesAllowsSubagentReviewerAnthropicOverride(t *testing.T) {
 	settings := configRegistry.defaultState().Settings
 	settings.Reviewer.Model = settings.Model
+	settings.Reviewer.ModelContextWindow = settings.ModelContextWindow
 	settings.Reviewer.ProviderOverride = "anthropic"
 
 	sources := configRegistry.defaultSourceMap()

--- a/shared/config/config_part3_test.go
+++ b/shared/config/config_part3_test.go
@@ -190,6 +190,32 @@ func TestNormalizeSettingsForPersistence_AllowsProviderOverrideWithExplicitPersi
 	}
 }
 
+func TestNormalizeSettingsForPersistenceRejectsModelContextWindowBelowMinimum(t *testing.T) {
+	settings := configRegistry.defaultState().Settings
+	settings.ModelContextWindow = 39999
+	settings.ContextCompactionThresholdTokens = 30000
+
+	if _, err := NormalizeSettingsForPersistence(settings); err == nil {
+		t.Fatal("expected model_context_window below minimum validation error")
+	} else if !errors.Is(err, errModelContextWindowBelowMinimum) {
+		t.Fatalf("expected model context window minimum validation detail, got %v", err)
+	}
+}
+
+func TestNormalizeSettingsForPersistenceWithSourcesRejectsModelContextWindowBelowMinimum(t *testing.T) {
+	settings := configRegistry.defaultState().Settings
+	settings.ModelContextWindow = 39999
+	settings.ContextCompactionThresholdTokens = 30000
+	sources := configRegistry.defaultSourceMap()
+	sources["model_context_window"] = "file"
+
+	if _, err := NormalizeSettingsForPersistenceWithSources(settings, sources); err == nil {
+		t.Fatal("expected model_context_window below minimum validation error")
+	} else if !errors.Is(err, errModelContextWindowBelowMinimum) {
+		t.Fatalf("expected model context window minimum validation detail, got %v", err)
+	}
+}
+
 func TestLoadCanonicalTimeoutEnvAndSourceKeys(t *testing.T) {
 	_, workspace := newConfigTestEnv(t)
 	t.Setenv("KENT_TIMEOUTS_MODEL_REQUEST_SECONDS", "123")
@@ -395,6 +421,23 @@ func TestLoadModelContextWindowPrecedence(t *testing.T) {
 	}
 	if got := cfg.Source.Sources["model_context_window"]; got != "env" {
 		t.Fatalf("expected model_context_window source env, got %q", got)
+	}
+}
+
+func TestLoadRejectsModelContextWindowBelowMinimum(t *testing.T) {
+	err := loadConfigTestFileError(t, "model_context_window = 39999\ncontext_compaction_threshold_tokens = 30000\n", LoadOptions{})
+	if err == nil {
+		t.Fatal("expected model_context_window below minimum validation error")
+	}
+	if !errors.Is(err, errModelContextWindowBelowMinimum) {
+		t.Fatalf("expected model context window minimum validation detail, got %v", err)
+	}
+}
+
+func TestLoadAcceptsModelContextWindowMinimum(t *testing.T) {
+	_, _, cfg := loadConfigTestFileApp(t, "model_context_window = 40000\ncontext_compaction_threshold_tokens = 25000\npre_submit_compaction_lead_tokens = 1000\n", LoadOptions{})
+	if cfg.Settings.ModelContextWindow != 40000 {
+		t.Fatalf("expected model_context_window=40000, got %d", cfg.Settings.ModelContextWindow)
 	}
 }
 

--- a/shared/config/config_part3_test.go
+++ b/shared/config/config_part3_test.go
@@ -434,6 +434,16 @@ func TestLoadRejectsModelContextWindowBelowMinimum(t *testing.T) {
 	}
 }
 
+func TestLoadRejectsModelContextWindowZeroWithMinimumError(t *testing.T) {
+	err := loadConfigTestFileError(t, "model_context_window = 0\n", LoadOptions{})
+	if err == nil {
+		t.Fatal("expected model_context_window zero validation error")
+	}
+	if !errors.Is(err, errModelContextWindowBelowMinimum) {
+		t.Fatalf("expected model context window minimum validation detail, got %v", err)
+	}
+}
+
 func TestLoadAcceptsModelContextWindowMinimum(t *testing.T) {
 	_, _, cfg := loadConfigTestFileApp(t, "model_context_window = 40000\ncontext_compaction_threshold_tokens = 25000\npre_submit_compaction_lead_tokens = 1000\n", LoadOptions{})
 	if cfg.Settings.ModelContextWindow != 40000 {

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -295,6 +295,23 @@ func TestLoadGlobalSkipsWorkspaceConfigLayer(t *testing.T) {
 	}
 }
 
+func TestLoadGlobalRejectsModelContextWindowBelowMinimum(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, brand.ConfigDirName), 0o755); err != nil {
+		t.Fatalf("create home config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, brand.ConfigDirName, "config.toml"), []byte("model_context_window = 39999\ncontext_compaction_threshold_tokens = 30000\n"), 0o644); err != nil {
+		t.Fatalf("write home config: %v", err)
+	}
+
+	if _, err := LoadGlobal(LoadOptions{}); err == nil {
+		t.Fatal("expected model_context_window below minimum validation error")
+	} else if !errors.Is(err, errModelContextWindowBelowMinimum) {
+		t.Fatalf("expected model context window minimum validation detail, got %v", err)
+	}
+}
+
 func TestEnsureManagedRGConfigFilePreservesExistingContents(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -633,6 +650,55 @@ func TestLoadSubagentRoleRejectsInvalidValues(t *testing.T) {
 	}
 	if !errors.Is(err, errSubagentRole) {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadSubagentRoleRejectsModelContextWindowBelowMinimum(t *testing.T) {
+	err := loadConfigTestFileError(t, strings.Join([]string{
+		"[subagents.fast]",
+		"model_context_window = 39999",
+		"context_compaction_threshold_tokens = 30000",
+	}, "\n"), LoadOptions{})
+	if err == nil {
+		t.Fatal("expected subagent model_context_window below minimum validation error")
+	}
+	if !errors.Is(err, errSubagentRole) {
+		t.Fatalf("expected subagent role validation error, got %v", err)
+	}
+	if !errors.Is(err, errModelContextWindowBelowMinimum) {
+		t.Fatalf("expected model context window minimum validation detail, got %v", err)
+	}
+}
+
+func TestLoadSubagentRoleRejectsReviewerModelContextWindowBelowMinimum(t *testing.T) {
+	err := loadConfigTestFileError(t, strings.Join([]string{
+		"[subagents.fast.reviewer]",
+		"model_context_window = 39999",
+	}, "\n"), LoadOptions{})
+	if err == nil {
+		t.Fatal("expected subagent reviewer.model_context_window below minimum validation error")
+	}
+	if !errors.Is(err, errSubagentRole) {
+		t.Fatalf("expected subagent role validation error, got %v", err)
+	}
+	if !errors.Is(err, errModelContextWindowBelowMinimum) {
+		t.Fatalf("expected model context window minimum validation detail, got %v", err)
+	}
+}
+
+func TestLoadSubagentRoleRejectsReviewerModelContextWindowExplicitZero(t *testing.T) {
+	err := loadConfigTestFileError(t, strings.Join([]string{
+		"[subagents.fast.reviewer]",
+		"model_context_window = 0",
+	}, "\n"), LoadOptions{})
+	if err == nil {
+		t.Fatal("expected subagent reviewer.model_context_window=0 validation error")
+	}
+	if !errors.Is(err, errSubagentRole) {
+		t.Fatalf("expected subagent role validation error, got %v", err)
+	}
+	if !errors.Is(err, errModelContextWindowBelowMinimum) {
+		t.Fatalf("expected model context window minimum validation detail, got %v", err)
 	}
 }
 

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -670,6 +670,22 @@ func TestLoadSubagentRoleRejectsModelContextWindowBelowMinimum(t *testing.T) {
 	}
 }
 
+func TestLoadSubagentRoleRejectsModelContextWindowZeroWithMinimumError(t *testing.T) {
+	err := loadConfigTestFileError(t, strings.Join([]string{
+		"[subagents.fast]",
+		"model_context_window = 0",
+	}, "\n"), LoadOptions{})
+	if err == nil {
+		t.Fatal("expected subagent model_context_window zero validation error")
+	}
+	if !errors.Is(err, errSubagentRole) {
+		t.Fatalf("expected subagent role validation error, got %v", err)
+	}
+	if !errors.Is(err, errModelContextWindowBelowMinimum) {
+		t.Fatalf("expected model context window minimum validation detail, got %v", err)
+	}
+}
+
 func TestLoadSubagentRoleRejectsReviewerModelContextWindowBelowMinimum(t *testing.T) {
 	err := loadConfigTestFileError(t, strings.Join([]string{
 		"[subagents.fast.reviewer]",

--- a/shared/config/config_validation.go
+++ b/shared/config/config_validation.go
@@ -65,6 +65,11 @@ func validateSubagentRoleContext(state settingsState, sources map[string]string)
 	if hasWindow && state.Settings.ModelContextWindow <= 0 {
 		return fmt.Errorf("model_context_window must be > 0")
 	}
+	if hasWindow {
+		if err := validateModelContextWindowMinimum("model_context_window", state.Settings.ModelContextWindow); err != nil {
+			return err
+		}
+	}
 	if hasThreshold && state.Settings.ContextCompactionThresholdTokens <= 0 {
 		return fmt.Errorf("context_compaction_threshold_tokens must be > 0")
 	}
@@ -301,6 +306,9 @@ func validateContextWindow(state settingsState, _ map[string]string) error {
 	if state.Settings.ModelContextWindow <= 0 {
 		return fmt.Errorf("model_context_window must be > 0")
 	}
+	if err := validateModelContextWindowMinimum("model_context_window", state.Settings.ModelContextWindow); err != nil {
+		return err
+	}
 	if state.Settings.ContextCompactionThresholdTokens >= state.Settings.ModelContextWindow {
 		return fmt.Errorf("context_compaction_threshold_tokens must be < model_context_window")
 	}
@@ -373,6 +381,9 @@ func validateReviewer(state settingsState, sources map[string]string) error {
 	if reviewer.ModelContextWindow < 0 {
 		return errReviewerContextWindowNegative
 	}
+	if err := validateModelContextWindowMinimum("reviewer.model_context_window", reviewer.ModelContextWindow); err != nil {
+		return err
+	}
 	switch normalizeReviewerAuth(reviewer.Auth) {
 	case "inherit":
 	case "none":
@@ -383,6 +394,18 @@ func validateReviewer(state settingsState, sources map[string]string) error {
 		return fmt.Errorf("reviewer.timeout_seconds must be > 0")
 	}
 	return nil
+}
+
+func validateModelContextWindowMinimum(field string, window int) error {
+	if window >= minimumModelContextWindow {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: %s must be >= %d",
+		errModelContextWindowBelowMinimum,
+		field,
+		minimumModelContextWindow,
+	)
 }
 
 func validateReviewerProviderCapabilities(capabilities ProviderCapabilitiesOverride) error {

--- a/shared/config/config_validation.go
+++ b/shared/config/config_validation.go
@@ -62,9 +62,6 @@ func validateSubagentRoleContext(state settingsState, sources map[string]string)
 	if !hasWindow && !hasThreshold && !hasLead {
 		return nil
 	}
-	if hasWindow && state.Settings.ModelContextWindow <= 0 {
-		return fmt.Errorf("model_context_window must be > 0")
-	}
 	if hasWindow {
 		if err := validateModelContextWindowMinimum("model_context_window", state.Settings.ModelContextWindow); err != nil {
 			return err
@@ -302,9 +299,6 @@ func validateWorkflowSettings(state settingsState, _ map[string]string) error {
 func validateContextWindow(state settingsState, _ map[string]string) error {
 	if state.Settings.ContextCompactionThresholdTokens <= 0 {
 		return fmt.Errorf("context_compaction_threshold_tokens must be > 0")
-	}
-	if state.Settings.ModelContextWindow <= 0 {
-		return fmt.Errorf("model_context_window must be > 0")
 	}
 	if err := validateModelContextWindowMinimum("model_context_window", state.Settings.ModelContextWindow); err != nil {
 		return err


### PR DESCRIPTION
## Summary
- Enforces a 40,000-token minimum for effective main, reviewer, and subagent context windows in shared config validation.
- Keeps existing compaction threshold validation intact and preserves reviewer inheritance only when `reviewer.model_context_window` is genuinely unset.
- Updates public and internal config docs, and ignores local `.kent/qa/` artifacts.

## Verification
- `./scripts/test.sh ./shared/config`
- `./scripts/build.sh --output ./bin/kent`

## QA Evidence
Local QA artifacts were generated under `.kent/qa/BUI-54/` before the PR. Relevant evidence includes:
- `shared-config-test.log` and `go-focused-context-window-tests.log` for Go validation coverage.
- `manual-invalid-main.log`, `manual-invalid-reviewer.log`, `manual-invalid-subagent.log`, and `manual-invalid-subagent-reviewer.log` showing operator-facing hard errors for below-floor context windows.
- `docs-context-window-evidence.md` showing the docs/spec entries for the 40,000-token minimum.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated configuration specifications to enforce a 40,000 token minimum for context windows across core runtime tools and subagent roles.
  * Clarified context window validation requirements in configuration reference documentation.

* **Chores**
  * Updated ignore patterns for internal directories.

* **Tests**
  * Added comprehensive validation test coverage for context window minimum constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->