### PR TITLE
refactor: inline trivial wrapper functions across the codebase

### DIFF
--- a/cli/app/app_test.go
+++ b/cli/app/app_test.go
@@ -21,7 +21,7 @@ func TestEffectiveSettingsKeepsBaseThinkingLevelEvenWhenSessionIsLocked(t *testi
 
 func TestActiveToolIDs_UsesLockedEnabledToolsVerbatim(t *testing.T) {
 	locked := &session.LockedContract{EnabledTools: []string{string(toolspec.ToolExecCommand)}}
-	ids, err := launch.ActiveToolIDs(config.Settings{Model: "gpt-5.4"}, config.SourceReport{}, locked)
+	ids, err := launch.ActiveToolIDsForPlan(config.Settings{Model: "gpt-5.4"}, config.SourceReport{}, locked)
 	if err != nil {
 		t.Fatalf("activeToolIDs: %v", err)
 	}

--- a/cli/app/bootstrap_test.go
+++ b/cli/app/bootstrap_test.go
@@ -3,11 +3,11 @@ package app
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"core/server/auth"
 	"core/server/metadata"
-	"core/shared/config"
 )
 
 func TestBootstrapAppIgnoresOAuthIssuerOverrideEnv(t *testing.T) {
@@ -32,7 +32,7 @@ func TestBootstrapAppIgnoresOAuthIssuerOverrideEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve bootstrap binding: %v", err)
 	}
-	containerDir := config.ProjectSessionsRoot(boot.Config(), binding.ProjectID)
+	containerDir := filepath.Join(filepath.Join(boot.Config().PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	if _, err := os.Stat(containerDir); err != nil {
 		t.Fatalf("expected bootstrap container dir to exist: %v", err)
 	}

--- a/cli/app/embedded_server_test.go
+++ b/cli/app/embedded_server_test.go
@@ -22,6 +22,7 @@ import (
 	"core/shared/serverapi"
 	"errors"
 	"io"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -324,7 +325,7 @@ func (s *testEmbeddedServer) SessionLaunchClient() client.SessionLaunchClient {
 	if metadataStore, binding, ok := s.metadataBinding(); ok {
 		service := sessionlaunch.NewService(launch.Planner{
 			Config:       s.cfg,
-			ContainerDir: config.ProjectSessionsRoot(s.cfg, binding.ProjectID),
+			ContainerDir: filepath.Join(filepath.Join(s.cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 			StoreOptions: metadataStore.AuthoritativeSessionStoreOptions(),
 		}, s.sessionStoreRegistry())
 		return client.NewLoopbackSessionLaunchClient(service)
@@ -343,7 +344,7 @@ func (s *testEmbeddedServer) SessionLifecycleClient() client.SessionLifecycleCli
 	}
 	if metadataStore, binding, ok := s.metadataBinding(); ok {
 		service := sessionservice.NewSessionLifecycleService(
-			config.ProjectSessionsRoot(s.cfg, binding.ProjectID),
+			filepath.Join(filepath.Join(s.cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 			s.sessionStoreRegistry(),
 			s.authManager,
 			metadataStore.AuthoritativeSessionStoreOptions()...,
@@ -356,7 +357,7 @@ func (s *testEmbeddedServer) SessionLifecycleClient() client.SessionLifecycleCli
 		if projectID == "" {
 			projectID = "test-project"
 		}
-		containerDir = config.ProjectSessionsRoot(s.cfg, projectID)
+		containerDir = filepath.Join(filepath.Join(s.cfg.PersistenceRoot, "projects"), projectID, "sessions")
 	}
 	service := sessionservice.NewSessionLifecycleService(containerDir, s.sessionStoreRegistry(), s.authManager).WithPersistenceRoot(s.cfg.PersistenceRoot).WithControllerLeaseVerifier(noopEmbeddedSessionLifecycleLeaseVerifier{})
 	return client.NewLoopbackSessionLifecycleClient(service)

--- a/cli/app/internal/runtimestate/runtime_events_test.go
+++ b/cli/app/internal/runtimestate/runtime_events_test.go
@@ -47,7 +47,7 @@ func TestReduceRuntimeEvent_UserMessageFlushedProducesPendingInputAndConversatio
 
 func TestReduceRuntimeEvent_RunStateStoppedClearsReasoningAndReturnsToIdle(t *testing.T) {
 	update := ReduceRuntimeEvent(
-		RuntimeRunState{Run: clientui.RunningRunLifecycle(clientui.RunModeTurn)},
+		RuntimeRunState{Run: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)},
 		RuntimeConversationState{},
 		PendingInputState{},
 		RuntimeReasoningState{StatusHeader: "Running checks"},
@@ -76,7 +76,7 @@ func TestReduceRuntimeEvent_RunStateStartedDoesNotRequestTranscriptSync(t *testi
 		PendingInputState{},
 		RuntimeReasoningState{},
 		false,
-		clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)}},
+		clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)}},
 	)
 
 	if !update.RunState.State.Run.IsRunning() {
@@ -97,7 +97,7 @@ func TestReduceRuntimeEvent_GoalRunStateTracksOnlyBusyGoalTurns(t *testing.T) {
 		PendingInputState{},
 		RuntimeReasoningState{},
 		false,
-		clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeGoalLoop)}},
+		clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeGoalLoop)}},
 	)
 	if !started.RunState.State.Run.IsGoalLoopRunning() {
 		t.Fatalf("expected goal loop run state after start, got %+v", started.RunState.State)
@@ -109,7 +109,7 @@ func TestReduceRuntimeEvent_GoalRunStateTracksOnlyBusyGoalTurns(t *testing.T) {
 		PendingInputState{},
 		RuntimeReasoningState{},
 		true,
-		clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.FinishedRunLifecycle(clientui.RunModeGoalLoop)}},
+		clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleFinished, clientui.RunModeGoalLoop)}},
 	)
 	if stopped.RunState.State.Run.IsGoalLoopRunning() {
 		t.Fatalf("expected goal loop run state cleared after stop, got %+v", stopped.RunState.State)
@@ -311,7 +311,7 @@ func TestReduceRuntimeEvent_CompactionCompletedClearsCompacting(t *testing.T) {
 }
 
 func TestReduceRuntimeRunStateEventRejectsInvalidLifecycleAtReducerBoundary(t *testing.T) {
-	initial := RuntimeRunState{Run: clientui.RunningRunLifecycle(clientui.RunModeTurn)}
+	initial := RuntimeRunState{Run: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)}
 	reduction := ReduceRuntimeRunStateEvent(
 		initial,
 		true,

--- a/cli/app/launch_planner.go
+++ b/cli/app/launch_planner.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
+	"strconv"
 	"strings"
 
 	"core/cli/app/internal/projectbinding"
@@ -293,7 +295,7 @@ func (p *launchPlanner) sessionPickerHeaderInfo(cfg config.App) sessionPickerHea
 		StatusRequest: statusReq,
 		AuthManager:   status.NormalizeAuthStateResolver(authState.Resolver),
 		OwnsServer:    p != nil && p.server != nil && p.server.OwnsServer(),
-		ServerAddress: config.ServerListenAddress(cfg),
+		ServerAddress: net.JoinHostPort(cfg.Settings.ServerHost, strconv.Itoa(cfg.Settings.ServerPort)),
 	}
 }
 

--- a/cli/app/launch_planner_test.go
+++ b/cli/app/launch_planner_test.go
@@ -182,7 +182,7 @@ func TestSessionLaunchPlannerHeadlessCreatesNewSessionAndAppliesContinuationCont
 	root := t.TempDir()
 	workspaceRoot := "/tmp/workspace-a"
 	binding := mustRegisterAppBinding(t, root, workspaceRoot)
-	containerDir := config.ProjectSessionsRoot(config.App{PersistenceRoot: root}, binding.ProjectID)
+	containerDir := filepath.Join(filepath.Join(config.App{PersistenceRoot: root}.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	planner := newSessionLaunchPlanner(&testEmbeddedServer{
 		cfg: config.App{
 			WorkspaceRoot:   workspaceRoot,
@@ -222,7 +222,7 @@ func TestSessionLaunchPlannerInteractiveUsesPickerSelection(t *testing.T) {
 
 	cfg := loadAppTestConfig(t, workspace, config.LoadOptions{})
 	binding := mustRegisterAppBinding(t, cfg.PersistenceRoot, cfg.WorkspaceRoot)
-	containerDir := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	containerDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 
 	first := createAuthoritativeAppSession(t, cfg.PersistenceRoot, cfg.WorkspaceRoot)
 	if err := first.SetName("first"); err != nil {
@@ -288,7 +288,7 @@ func TestSessionLaunchPlannerMarksNoOtherSessionsForDirectSingleSessionResume(t 
 
 	cfg := loadAppTestConfig(t, workspace, config.LoadOptions{})
 	binding := mustRegisterAppBinding(t, cfg.PersistenceRoot, cfg.WorkspaceRoot)
-	containerDir := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	containerDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	single := createAuthoritativeAppSession(t, cfg.PersistenceRoot, cfg.WorkspaceRoot)
 	planner := newSessionLaunchPlanner(&testEmbeddedServer{
 		cfg: config.App{
@@ -366,7 +366,7 @@ func TestSessionLaunchPlannerPropagatesServerOwnershipToStatusConfig(t *testing.
 			root := t.TempDir()
 			workspaceRoot := "/tmp/workspace-a"
 			binding := mustRegisterAppBinding(t, root, workspaceRoot)
-			containerDir := config.ProjectSessionsRoot(config.App{PersistenceRoot: root}, binding.ProjectID)
+			containerDir := filepath.Join(filepath.Join(config.App{PersistenceRoot: root}.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 			planner := newSessionLaunchPlanner(&plannerOwnershipServer{
 				testEmbeddedServer: &testEmbeddedServer{
 					cfg: config.App{
@@ -400,7 +400,7 @@ func TestSessionLaunchPlannerDefaultsMissingAuthStateProviderToEmptyStatusMetada
 			PersistenceRoot: root,
 			Settings:        config.Settings{Theme: "dark"},
 		},
-		containerDir: config.ProjectSessionsRoot(config.App{PersistenceRoot: root}, binding.ProjectID),
+		containerDir: filepath.Join(filepath.Join(config.App{PersistenceRoot: root}.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 	}})
 
 	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeHeadless})
@@ -419,7 +419,7 @@ func TestSessionLaunchPlannerSelectedSessionIDBypassesPicker(t *testing.T) {
 	root := t.TempDir()
 	workspaceRoot := "/tmp/workspace-a"
 	binding := mustRegisterAppBinding(t, root, workspaceRoot)
-	containerDir := config.ProjectSessionsRoot(config.App{PersistenceRoot: root}, binding.ProjectID)
+	containerDir := filepath.Join(filepath.Join(config.App{PersistenceRoot: root}.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	store := createAuthoritativeAppSession(t, root, workspaceRoot)
 	if err := store.SetName("selected"); err != nil {
 		t.Fatalf("persist selected session meta: %v", err)

--- a/cli/app/project_binding_flow_test.go
+++ b/cli/app/project_binding_flow_test.go
@@ -49,7 +49,7 @@ func TestEnsureInteractiveProjectBindingBindsRegisteredWorkspaceWithoutPrompt(t 
 
 	server := &testEmbeddedServer{
 		cfg:               cfg,
-		containerDir:      config.ProjectSessionsRoot(cfg, binding.ProjectID),
+		containerDir:      filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 		projectViewClient: projectViewClient,
 	}
 
@@ -154,7 +154,7 @@ func TestEnsureInteractiveProjectBindingTreatsNestedDirectoryAsUnknownWorkspace(
 
 	server := &testEmbeddedServer{
 		cfg:               nestedCfg,
-		containerDir:      config.ProjectSessionsRoot(nestedCfg, "project-placeholder"),
+		containerDir:      filepath.Join(filepath.Join(nestedCfg.PersistenceRoot, "projects"), "project-placeholder", "sessions"),
 		projectViewClient: projectViewClient,
 	}
 
@@ -206,7 +206,7 @@ func TestEnsureInteractiveProjectBindingCreatesProjectForUnknownWorkspace(t *tes
 
 	server := &testEmbeddedServer{
 		cfg:               cfg,
-		containerDir:      config.ProjectSessionsRoot(cfg, "project-placeholder"),
+		containerDir:      filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), "project-placeholder", "sessions"),
 		projectViewClient: projectViewClient,
 	}
 
@@ -280,7 +280,7 @@ func TestEnsureInteractiveProjectBindingUsesServerBrowsingForMissingServerPath(t
 
 	server := &testEmbeddedServer{
 		cfg:               cfg,
-		containerDir:      config.ProjectSessionsRoot(cfg, "project-placeholder"),
+		containerDir:      filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), "project-placeholder", "sessions"),
 		projectViewClient: client.NewLoopbackProjectViewClient(service),
 	}
 
@@ -318,7 +318,7 @@ func TestEnsureInteractiveProjectBindingRebindsSameProjectToResolvedWorkspace(t 
 
 	server := &testEmbeddedServer{
 		cfg:               cfg,
-		containerDir:      config.ProjectSessionsRoot(cfg, "project-1"),
+		containerDir:      filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), "project-1", "sessions"),
 		projectID:         "project-1",
 		boundWorkspaceID:  "workspace-a",
 		projectViewClient: client.NewLoopbackProjectViewClient(service),
@@ -374,7 +374,7 @@ func TestEnsureInteractiveProjectBindingAttachesUnknownWorkspaceToExistingProjec
 
 	server := &testEmbeddedServer{
 		cfg:               cfgB,
-		containerDir:      config.ProjectSessionsRoot(cfgB, bindingA.ProjectID),
+		containerDir:      filepath.Join(filepath.Join(cfgB.PersistenceRoot, "projects"), bindingA.ProjectID, "sessions"),
 		projectViewClient: projectViewClient,
 	}
 
@@ -418,7 +418,7 @@ func TestEnsureInteractiveProjectBindingFormatsMissingSelectedProjectError(t *te
 
 	server := &testEmbeddedServer{
 		cfg:               cfg,
-		containerDir:      config.ProjectSessionsRoot(cfg, "project-placeholder"),
+		containerDir:      filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), "project-placeholder", "sessions"),
 		projectViewClient: projectViewClient,
 	}
 
@@ -454,7 +454,7 @@ func TestEnsureInteractiveProjectBindingReturnsCancelWhenPickerAborts(t *testing
 
 	server := &testEmbeddedServer{
 		cfg:               cfg,
-		containerDir:      config.ProjectSessionsRoot(cfg, "project-placeholder"),
+		containerDir:      filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), "project-placeholder", "sessions"),
 		projectViewClient: projectViewClient,
 	}
 
@@ -488,7 +488,7 @@ func TestEnsureInteractiveProjectBindingReturnsCancelWhenProjectNamingAborts(t *
 
 	server := &testEmbeddedServer{
 		cfg:               cfg,
-		containerDir:      config.ProjectSessionsRoot(cfg, "project-placeholder"),
+		containerDir:      filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), "project-placeholder", "sessions"),
 		projectViewClient: projectViewClient,
 	}
 
@@ -550,7 +550,7 @@ func TestEnsureInteractiveServerBrowsingBindingUsesConfiguredServerPickerNotice(
 
 	server := &testEmbeddedServer{
 		cfg:               cfg,
-		containerDir:      config.ProjectSessionsRoot(cfg, "project-placeholder"),
+		containerDir:      filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), "project-placeholder", "sessions"),
 		projectViewClient: client.NewLoopbackProjectViewClient(service),
 	}
 
@@ -577,7 +577,7 @@ func TestEnsureInteractiveProjectBindingFormatsMissingBoundProjectError(t *testi
 	server := &failingBindProjectServer{
 		testEmbeddedServer: &testEmbeddedServer{
 			cfg:               cfg,
-			containerDir:      config.ProjectSessionsRoot(cfg, binding.ProjectID),
+			containerDir:      filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 			projectViewClient: projectViewClient,
 		},
 		bindErr: fmt.Errorf("bind project: %w", serverapi.ErrProjectNotFound),
@@ -606,7 +606,7 @@ func TestEnsureInteractiveProjectBindingFormatsUnavailableBoundProjectError(t *t
 	server := &failingBindProjectServer{
 		testEmbeddedServer: &testEmbeddedServer{
 			cfg:               cfg,
-			containerDir:      config.ProjectSessionsRoot(cfg, binding.ProjectID),
+			containerDir:      filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 			projectViewClient: projectViewClient,
 		},
 		bindErr: serverapi.ProjectUnavailableError{ProjectID: binding.ProjectID, RootPath: cfg.WorkspaceRoot, Availability: clientui.ProjectAvailabilityMissing},
@@ -635,7 +635,7 @@ func TestEnsureInteractiveProjectBindingFormatsInaccessibleBoundProjectError(t *
 	server := &failingBindProjectServer{
 		testEmbeddedServer: &testEmbeddedServer{
 			cfg:               cfg,
-			containerDir:      config.ProjectSessionsRoot(cfg, binding.ProjectID),
+			containerDir:      filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 			projectViewClient: projectViewClient,
 		},
 		bindErr: serverapi.ProjectUnavailableError{ProjectID: binding.ProjectID, RootPath: cfg.WorkspaceRoot, Availability: clientui.ProjectAvailabilityInaccessible},

--- a/cli/app/run_prompt_target.go
+++ b/cli/app/run_prompt_target.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -27,7 +28,7 @@ var resolveDaemonExecutablePath = startupconfig.ServeExecutablePath
 var buildServeArgsFunc = func(_ string, _ Options) []string { return startupconfig.ServeArgs() }
 var buildServeEnvFunc = startupconfig.ServeEnv
 var releaseServeReservationFunc = func(cfg config.App) {
-	serverstartup.ReleaseTestListenReservation(config.ServerListenAddress(cfg))
+	serverstartup.ReleaseTestListenReservation(net.JoinHostPort(cfg.Settings.ServerHost, strconv.Itoa(cfg.Settings.ServerPort)))
 }
 
 var configuredRemoteAttachTimeout = 500 * time.Millisecond

--- a/cli/app/runtime_attachment.go
+++ b/cli/app/runtime_attachment.go
@@ -99,7 +99,7 @@ func prepareSharedRuntimeWiring(ctx context.Context, clients runtimeAttachmentCl
 	} else {
 		runtimeClient.SetReadOnly(true)
 	}
-	runtimeClient.SetTranscriptDiagnosticsEnabled(transcriptdiag.EnabledForProcess(plan.ActiveSettings.Debug))
+	runtimeClient.SetTranscriptDiagnosticsEnabled(transcriptdiag.Enabled(plan.ActiveSettings.Debug, os.Getenv))
 	runtimeEvents, stopRuntimeEvents := startSessionActivityEvents(ctx, activities.Session, func(ctx context.Context, afterSequence uint64) (serverapi.SessionActivitySubscription, error) {
 		return clients.SessionActivity.SubscribeSessionActivity(ctx, serverapi.SessionActivitySubscribeRequest{SessionID: plan.SessionID, AfterSequence: afterSequence})
 	}, runtimeClient.transcriptDiagnosticsEnabled, func(line string) {

--- a/cli/app/session_lifecycle_test.go
+++ b/cli/app/session_lifecycle_test.go
@@ -545,7 +545,7 @@ func createAttachedAuthoritativeAppSession(t *testing.T, persistenceRoot string,
 		t.Fatalf("AttachWorkspaceToProject: %v", err)
 	}
 	store, err := session.Create(
-		config.ProjectSessionsRoot(config.App{PersistenceRoot: persistenceRoot}, projectID),
+		filepath.Join(filepath.Join(config.App{PersistenceRoot: persistenceRoot}.PersistenceRoot, "projects"), projectID, "sessions"),
 		filepath.Base(filepath.Clean(workspaceRoot)),
 		workspaceRoot,
 		metadataStore.AuthoritativeSessionStoreOptions()...,
@@ -836,7 +836,7 @@ func TestReviewTeleportLifecyclePreservesParentWorktreeContext(t *testing.T) {
 		t.Fatalf("RegisterWorkspaceBinding: %v", err)
 	}
 	parent, err := session.Create(
-		config.ProjectSessionsRoot(cfg, binding.ProjectID),
+		filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 		filepath.Base(filepath.Clean(cfg.WorkspaceRoot)),
 		cfg.WorkspaceRoot,
 		metadataStore.AuthoritativeSessionStoreOptions()...,

--- a/cli/app/stream_resubscribe_test.go
+++ b/cli/app/stream_resubscribe_test.go
@@ -30,7 +30,7 @@ func TestStartSessionActivityEventsResubscribesFromLastSequenceAfterStreamGap(t 
 	defer cancel()
 
 	initial := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{evt: clientui.Event{Sequence: 41, Kind: clientui.EventAssistantDelta, AssistantDelta: "first"}}, {err: serverapi.ErrStreamGap}}}
-	resubscribed := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{evt: clientui.Event{Sequence: 42, Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)}}}}}
+	resubscribed := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{evt: clientui.Event{Sequence: 42, Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)}}}}}
 	remaining := []serverapi.SessionActivitySubscription{resubscribed}
 	var requestedAfter uint64
 
@@ -144,7 +144,7 @@ func TestStartSessionActivityEventsEmitsExplicitGapWhenInitialStreamDropsWithout
 	defer cancel()
 
 	initial := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{err: io.EOF}}}
-	resubscribed := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{evt: clientui.Event{Sequence: 1, Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)}}}}}
+	resubscribed := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{evt: clientui.Event{Sequence: 1, Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)}}}}}
 	var requestedAfter []uint64
 	events, stop := startSessionActivityEvents(ctx, initial, func(_ context.Context, afterSequence uint64) (serverapi.SessionActivitySubscription, error) {
 		requestedAfter = append(requestedAfter, afterSequence)
@@ -236,7 +236,7 @@ func TestStartSessionActivityEventsResubscribeStaysIsolatedAcrossStreams(t *test
 	defer cancel()
 
 	initialA := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{evt: clientui.Event{Sequence: 1, Kind: clientui.EventAssistantDelta, AssistantDelta: "a-first"}}, {err: serverapi.ErrStreamGap}}}
-	resubA := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{evt: clientui.Event{Sequence: 2, Kind: clientui.EventRunStateChanged, StepID: "step-a", RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)}}}}}
+	resubA := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{evt: clientui.Event{Sequence: 2, Kind: clientui.EventRunStateChanged, StepID: "step-a", RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)}}}}}
 	remainingA := []serverapi.SessionActivitySubscription{resubA}
 
 	initialB := &stubSessionActivitySubscription{steps: []stubSessionActivityStep{{evt: clientui.Event{Kind: clientui.EventAssistantDelta, AssistantDelta: "b-first"}}}}

--- a/cli/app/transcript_diag_gate_test.go
+++ b/cli/app/transcript_diag_gate_test.go
@@ -23,7 +23,7 @@ func TestTranscriptDiagnosticGateUsesSharedHelper(t *testing.T) {
 		},
 		{
 			path:           filepath.Join(root, "cli", "app", "ui_runtime_client.go"),
-			mustContain:    "EnabledForProcess(false)",
+			mustContain:    "transcriptdiag.Enabled(false, os.Getenv)",
 			mustNotContain: "EnabledFromEnv(",
 		},
 	}

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -118,12 +118,6 @@ func (m *uiModel) handleRenderDiagnostic(diag tui.RenderDiagnostic) {
 	})
 }
 
-func (m *uiModel) handleRunLoggerDiagnostic(diag runLoggerDiagnostic) {
-	m.startupCmds = append(m.startupCmds, func() tea.Msg {
-		return runLoggerDiagnosticMsg{diagnostic: diag}
-	})
-}
-
 func (m *uiModel) applyRenderDiagnostic(diag tui.RenderDiagnostic) tea.Cmd {
 	message := strings.TrimSpace(diag.Message)
 	if message == "" {

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -107,7 +107,7 @@ func NewProjectedUIModel(runtimeClient clientui.RuntimeClient, runtimeEvents <-c
 	if m.startupUpdateNotice && m.hasRuntimeClient() {
 		m.startupCmds = append(m.startupCmds, m.startupUpdateNoticeCmd(status.Update))
 	}
-	m.syncViewport()
+	m.layout().syncViewport()
 	return m
 }
 
@@ -175,7 +175,7 @@ func (m *uiModel) handleRuntimeEventBatch(events []clientui.Event) (*uiModel, te
 		cmd = sequenceCmds(cmd, m.flushQueuedInputsAfterHydration())
 		cmd = sequenceCmds(cmd, m.inputController().resumeQueuedInputsAfterIdleRuntime())
 	}
-	m.syncViewport()
+	m.layout().syncViewport()
 	if !result.transcriptMutated {
 		cmd = sequenceCmds(cmd, m.syncNativeStreamingScrollback())
 	}
@@ -292,11 +292,11 @@ func (m *uiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if _, ok := msg.(tea.MouseMsg); ok && m.rollback.isActive() {
-		m.syncViewport()
+		m.layout().syncViewport()
 		return m, nil
 	}
 	m.forwardToView(msg)
-	m.syncViewport()
+	m.layout().syncViewport()
 	return m, m.maybeRequestDetailTranscriptPage()
 }
 
@@ -454,13 +454,13 @@ func (m *uiModel) advanceTransientStatusQueue() tea.Cmd {
 	m.transientStatusKind = uiStatusNoticeNeutral
 	m.transientStatusNoticeID = ""
 	if len(m.transientStatusQueue) == 0 {
-		m.syncViewport()
+		m.layout().syncViewport()
 		return nil
 	}
 	next := m.transientStatusQueue[0]
 	m.transientStatusQueue = append([]uiStatusNotice(nil), m.transientStatusQueue[1:]...)
 	cmd := m.showTransientStatusNotice(next)
-	m.syncViewport()
+	m.layout().syncViewport()
 	return cmd
 }
 

--- a/cli/app/ui.go
+++ b/cli/app/ui.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -384,7 +385,7 @@ func (m *uiModel) transcriptDiagnosticsEnabled() bool {
 	if m == nil {
 		return false
 	}
-	return m.transcriptDiagnostics || transcriptdiag.EnabledForProcess(m.debugMode)
+	return m.transcriptDiagnostics || transcriptdiag.Enabled(m.debugMode, os.Getenv)
 }
 
 func (m *uiModel) updateTranscriptDiagnosticsMode() {

--- a/cli/app/ui_animation.go
+++ b/cli/app/ui_animation.go
@@ -30,10 +30,6 @@ func (c *frameAnimationClock) Stop() {
 	c.anchor = time.Time{}
 }
 
-func (c frameAnimationClock) Running() bool {
-	return !c.anchor.IsZero()
-}
-
 func (c frameAnimationClock) Frame(now time.Time, frameCount int, frameDuration time.Duration) int {
 	if frameCount <= 1 || frameDuration <= 0 {
 		return 0
@@ -58,7 +54,7 @@ func (c frameAnimationClock) NextDelay(now time.Time, frameDuration time.Duratio
 }
 
 func (c frameAnimationClock) Elapsed(now time.Time) time.Duration {
-	if !c.Running() {
+	if c.anchor.IsZero() {
 		return 0
 	}
 	if now.IsZero() {

--- a/cli/app/ui_animation_test.go
+++ b/cli/app/ui_animation_test.go
@@ -68,7 +68,7 @@ func TestRuntimeBusyEventStartsSpinnerTicking(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	next, cmd := m.Update(runtimeEventMsg{event: clientui.Event{
 		Kind:     clientui.EventRunStateChanged,
-		RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)},
+		RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)},
 	}})
 	updated := next.(*uiModel)
 	if !updated.isBusy() {

--- a/cli/app/ui_ask_deferred_test.go
+++ b/cli/app/ui_ask_deferred_test.go
@@ -17,7 +17,7 @@ func TestAskEventDefersWhileDetailModeActive(t *testing.T) {
 	m.termHeight = 12
 	m.windowSizeKnown = true
 	m.input = "hidden draft"
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	for i := 0; i < 16; i++ {
 		m.forwardToView(tui.AppendTranscriptMsg{Role: "assistant", Text: strings.Repeat("line ", i+1)})
@@ -122,7 +122,7 @@ func TestDetailModeIgnoresHiddenMainInputKeys(t *testing.T) {
 	m.windowSizeKnown = true
 	m.input = "draft"
 	m.inputCursor = -1
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	for i := 0; i < 12; i++ {
 		m.forwardToView(tui.AppendTranscriptMsg{Role: "assistant", Text: strings.Repeat("line ", i+1)})

--- a/cli/app/ui_diff_render_test.go
+++ b/cli/app/ui_diff_render_test.go
@@ -19,7 +19,7 @@ func TestCustomPatchToolCallRendersSummaryOngoingAndHighlightedDiffDetail(t *tes
 	m := newProjectedStaticUIModel()
 	m.termWidth = viewportWidth
 	m.termHeight = 18
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	_ = m.runtimeAdapter().applyProjectedRuntimeEvent(projectRuntimeEvent(runtime.Event{
 		Kind:   runtime.EventToolCallStarted,

--- a/cli/app/ui_event_reducers.go
+++ b/cli/app/ui_event_reducers.go
@@ -20,11 +20,11 @@ func (r uiDiagnosticsFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 	switch msg := msg.(type) {
 	case renderDiagnosticMsg:
 		cmd := m.applyRenderDiagnostic(msg.diagnostic)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	case runLoggerDiagnosticMsg:
 		cmd := m.applyRunLoggerDiagnostic(msg.diagnostic)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	}
 	return uiFeatureUpdateResult{}
@@ -43,7 +43,7 @@ func (r uiAskFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 	switch msg := msg.(type) {
 	case askEventMsg:
 		m.askController().acceptEvent(msg.event)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, waitAskEvent(m.askEvents))
 	}
 	return uiFeatureUpdateResult{}
@@ -62,19 +62,19 @@ func (r uiPathReferenceFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult
 	switch msg := msg.(type) {
 	case uiPathReferenceCorpusReadyMsg:
 		m.handlePathReferenceCorpusReady(msg)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, waitPathReferenceSearchEvent(m.pathReferenceEvents))
 	case uiPathReferenceCorpusFailedMsg:
 		m.handlePathReferenceCorpusFailed(msg)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, waitPathReferenceSearchEvent(m.pathReferenceEvents))
 	case uiPathReferenceMatchResultMsg:
 		m.handlePathReferenceMatchResult(msg)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, waitPathReferenceSearchEvent(m.pathReferenceEvents))
 	case uiPathReferenceLoadingDelayMsg:
 		m.handlePathReferenceLoadingDelay(msg)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, waitPathReferenceSearchEvent(m.pathReferenceEvents))
 	}
 	return uiFeatureUpdateResult{}
@@ -95,15 +95,15 @@ func (r uiNoticeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		if msg.token == m.transientStatusToken {
 			return handledUIFeatureUpdate(m, m.advanceTransientStatusQueue())
 		}
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, nil)
 	case startupUpdateNoticeMsg:
 		if m.startupUpdateShown {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		cmd := m.sendTransientStatusWithNoticeID("update available: "+strings.TrimSpace(msg.version), uiStatusNoticeUpdateAvailable, updateNoticeDuration, uiStatusNoticeQueue, "")
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	}
 	return uiFeatureUpdateResult{}
@@ -122,7 +122,7 @@ func (r uiInputAsyncFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 	switch msg := msg.(type) {
 	case authSlashCommandRefreshedMsg:
 		m.applyAuthSlashCommandRefreshed(msg)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, nil)
 	case promptHistoryPersistErrMsg:
 		m.observeRuntimeRequestResult(msg.err)
@@ -139,41 +139,41 @@ func (r uiInputAsyncFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		return handledUIFeatureUpdate(m, m.sendTransientStatusWithNoticeID(msg.err.Error(), uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, ""))
 	case runtimeControlDoneMsg:
 		cmd := m.applyRuntimeControlDone(msg)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	case goalRuntimeDoneMsg:
 		cmd := m.applyGoalRuntimeDone(msg)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	case injectedQueueCreateDoneMsg:
 		next, cmd := m.inputController().handleInjectedQueueCreateDone(msg)
 		nextModel := next.(*uiModel)
-		nextModel.syncViewport()
+		nextModel.layout().syncViewport()
 		return handledUIFeatureUpdate(nextModel, cmd)
 	case injectedQueueDiscardDoneMsg:
 		next, cmd := m.inputController().handleInjectedQueueDiscardDone(msg)
 		nextModel := next.(*uiModel)
-		nextModel.syncViewport()
+		nextModel.layout().syncViewport()
 		return handledUIFeatureUpdate(nextModel, cmd)
 	case queuedRuntimeWorkCheckDoneMsg:
 		next, cmd := m.inputController().handleQueuedRuntimeWorkCheckDone(msg)
 		nextModel := next.(*uiModel)
-		nextModel.syncViewport()
+		nextModel.layout().syncViewport()
 		return handledUIFeatureUpdate(nextModel, cmd)
 	case submitDoneMsg:
 		next, cmd := m.inputController().handleSubmitDone(msg)
 		nextModel := next.(*uiModel)
-		nextModel.syncViewport()
+		nextModel.layout().syncViewport()
 		return handledUIFeatureUpdate(nextModel, cmd)
 	case compactDoneMsg:
 		next, cmd := m.inputController().handleCompactDone(msg)
 		nextModel := next.(*uiModel)
-		nextModel.syncViewport()
+		nextModel.layout().syncViewport()
 		return handledUIFeatureUpdate(nextModel, cmd)
 	case spinnerTickMsg:
 		next, cmd := m.inputController().handleSpinnerTick(msg)
 		nextModel := next.(*uiModel)
-		nextModel.syncViewport()
+		nextModel.layout().syncViewport()
 		return handledUIFeatureUpdate(nextModel, cmd)
 	}
 	return uiFeatureUpdateResult{}
@@ -192,15 +192,15 @@ func (r uiProcessFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 	switch msg := msg.(type) {
 	case processListRefreshTickMsg:
 		if !m.processList.open {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		refreshCmd := m.requestProcessListRefresh()
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, tea.Batch(refreshCmd, tea.Tick(processListRefreshInterval, func(time.Time) tea.Msg { return processListRefreshTickMsg{} }), m.reconcileSpinnerTicking(false)))
 	case processListRefreshDoneMsg:
 		if msg.token != m.processList.refreshToken {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		m.processList.refreshInFlight = false
@@ -215,14 +215,14 @@ func (r uiProcessFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			m.processList.refreshDirty = false
 			refreshCmd = m.requestProcessListRefresh()
 		}
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, tea.Batch(refreshCmd, m.reconcileSpinnerTicking(false)))
 	case processActionDoneMsg:
 		cmd := m.applyProcessActionDone(msg)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	case openProcessLogsDoneMsg:
-		m.syncViewport()
+		m.layout().syncViewport()
 		if msg.err != nil {
 			return handledUIFeatureUpdate(m, m.sendTransientStatusWithNoticeID(msg.err.Error(), uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, ""))
 		}
@@ -244,11 +244,11 @@ func (r uiClipboardFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 	switch msg := msg.(type) {
 	case clipboardImagePasteDoneMsg:
 		cmd := m.handleClipboardImagePasteDone(msg)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	case clipboardTextCopyDoneMsg:
 		cmd := m.handleClipboardTextCopyDone(msg)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	}
 	return uiFeatureUpdateResult{}

--- a/cli/app/ui_feature_reducers.go
+++ b/cli/app/ui_feature_reducers.go
@@ -57,7 +57,7 @@ func (r uiStatusFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 	switch msg := msg.(type) {
 	case statusRefreshDoneMsg:
 		if msg.token != m.status.refreshToken {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		m.status.pendingSections = nil
@@ -65,16 +65,16 @@ func (r uiStatusFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		m.status.loading = false
 		if msg.err != nil {
 			m.status.error = msg.err.Error()
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, m.sendTransientStatusWithNoticeID(msg.err.Error(), uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, ""))
 		}
 		m.status.error = ""
 		m.status.snapshot = msg.snapshot
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, nil)
 	case statusBaseRefreshDoneMsg:
 		if msg.token != m.status.refreshToken {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		m.status.error = ""
@@ -100,11 +100,11 @@ func (r uiStatusFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		}
 		m.status.snapshot = snapshot
 		m.finishStatusSectionRefresh(uiStatusSectionBase, msg.snapshot.CollectorWarning)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, nil)
 	case statusAuthRefreshDoneMsg:
 		if msg.token != m.status.refreshToken {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		m.status.snapshot.Auth = msg.result.Auth
@@ -113,14 +113,14 @@ func (r uiStatusFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			m.statusRepository.StoreAuth(msg.cacheKey, msg.result, time.Now())
 		}
 		m.finishStatusSectionRefresh(uiStatusSectionAuth, msg.result.Warning)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, nil)
 	case statusGitRefreshDoneMsg:
 		if msg.background {
 			m.statusGitBackgroundInFlight = false
 		}
 		if msg.token != m.status.refreshToken {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		m.status.snapshot.Git = msg.result.Git
@@ -128,11 +128,11 @@ func (r uiStatusFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			m.statusRepository.StoreGit(msg.cacheKey, msg.result, time.Now())
 		}
 		m.finishStatusSectionRefresh(uiStatusSectionGit, "")
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, nil)
 	case statusEnvironmentRefreshDoneMsg:
 		if msg.token != m.status.refreshToken {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		m.status.snapshot.Skills = msg.result.Skills
@@ -143,7 +143,7 @@ func (r uiStatusFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			m.statusRepository.StoreEnvironment(msg.cacheKey, msg.result, time.Now())
 		}
 		m.finishStatusSectionRefresh(uiStatusSectionEnvironment, msg.result.CollectorWarning)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, nil)
 	}
 	return uiFeatureUpdateResult{}

--- a/cli/app/ui_goal.go
+++ b/cli/app/ui_goal.go
@@ -420,13 +420,6 @@ func (b *goalOverlayLineBuilder) goalMarkdownRenderer() *glamour.TermRenderer {
 	return renderer
 }
 
-// appendRendered appends an already-styled, full-width line without re-wrapping
-// or re-styling it. Used for pre-rendered UI-kit primitives (e.g. choice groups)
-// whose ANSI must be preserved verbatim.
-func (b *goalOverlayLineBuilder) appendRendered(line string) {
-	b.lines = append(b.lines, padANSIRight(line, b.width))
-}
-
 func (b *goalOverlayLineBuilder) appendGap() {
 	if len(b.lines) > 0 {
 		b.lines = append(b.lines, padRight("", b.width))
@@ -526,7 +519,7 @@ func (l uiViewLayout) goalConfirmContentLines(width int, titleStyle, boldStyle, 
 	}
 	builder.appendGap()
 	buttons := []uiChoiceOption{{Label: "Cancel"}, {Label: "Confirm"}}
-	builder.appendRendered(renderUIChoiceGroupLine(width, m.theme, uiChoiceGroupKindButton, buttons, m.goal.confirmSelection))
+	builder.lines = append(builder.lines, padANSIRight(renderUIChoiceGroupLine(width, m.theme, uiChoiceGroupKindButton, buttons, m.goal.confirmSelection), builder.width))
 	builder.appendWrapped("Tab/←/→ select. Enter confirms. ↑/↓ scroll. Esc cancels.", subtleStyle)
 	return builder.lines
 }

--- a/cli/app/ui_input_buffer.go
+++ b/cli/app/ui_input_buffer.go
@@ -14,12 +14,8 @@ func nextNonZeroToken(token uint64) uint64 {
 	return token
 }
 
-func (m *uiModel) invalidateMainInputDraftToken() {
-	m.mainInputDraftToken = nextNonZeroToken(m.mainInputDraftToken)
-}
-
 func (m *uiModel) replaceMainInput(text string, cursor int) {
-	m.invalidateMainInputDraftToken()
+	m.mainInputDraftToken = nextNonZeroToken(m.mainInputDraftToken)
 	m.input = text
 	m.inputCursor = cursor
 	m.syncPromptHistorySelectionToInput()
@@ -36,7 +32,7 @@ func (m *uiModel) insertInputRunes(chars []rune) tea.Cmd {
 	if !ok {
 		return nil
 	}
-	m.invalidateMainInputDraftToken()
+	m.mainInputDraftToken = nextNonZeroToken(m.mainInputDraftToken)
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()
@@ -48,7 +44,7 @@ func (m *uiModel) backspaceInput() bool {
 	if !ok {
 		return false
 	}
-	m.invalidateMainInputDraftToken()
+	m.mainInputDraftToken = nextNonZeroToken(m.mainInputDraftToken)
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()
@@ -61,7 +57,7 @@ func (m *uiModel) deleteForwardInput() bool {
 	if !ok {
 		return false
 	}
-	m.invalidateMainInputDraftToken()
+	m.mainInputDraftToken = nextNonZeroToken(m.mainInputDraftToken)
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()
@@ -74,7 +70,7 @@ func (m *uiModel) deleteBackwardWordInput() bool {
 	if !ok {
 		return false
 	}
-	m.invalidateMainInputDraftToken()
+	m.mainInputDraftToken = nextNonZeroToken(m.mainInputDraftToken)
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.inputKillBuffer = killBuffer
@@ -88,7 +84,7 @@ func (m *uiModel) deleteForwardWordInput() bool {
 	if !ok {
 		return false
 	}
-	m.invalidateMainInputDraftToken()
+	m.mainInputDraftToken = nextNonZeroToken(m.mainInputDraftToken)
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.inputKillBuffer = killBuffer
@@ -102,7 +98,7 @@ func (m *uiModel) killInputToLineStart() bool {
 	if !ok {
 		return false
 	}
-	m.invalidateMainInputDraftToken()
+	m.mainInputDraftToken = nextNonZeroToken(m.mainInputDraftToken)
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.inputKillBuffer = killBuffer
@@ -116,7 +112,7 @@ func (m *uiModel) killInputToLineEnd() bool {
 	if !ok {
 		return false
 	}
-	m.invalidateMainInputDraftToken()
+	m.mainInputDraftToken = nextNonZeroToken(m.mainInputDraftToken)
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.inputKillBuffer = killBuffer
@@ -130,7 +126,7 @@ func (m *uiModel) yankInput() bool {
 	if !ok {
 		return false
 	}
-	m.invalidateMainInputDraftToken()
+	m.mainInputDraftToken = nextNonZeroToken(m.mainInputDraftToken)
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()
@@ -187,7 +183,7 @@ func (m *uiModel) deleteCurrentInputLine() bool {
 	if !ok {
 		return false
 	}
-	m.invalidateMainInputDraftToken()
+	m.mainInputDraftToken = nextNonZeroToken(m.mainInputDraftToken)
 	m.input = updated
 	m.inputCursor = nextCursor
 	m.syncPromptHistorySelectionToInput()

--- a/cli/app/ui_input_buffer.go
+++ b/cli/app/ui_input_buffer.go
@@ -4,6 +4,7 @@ import (
 	tuiinput "core/cli/tui/input"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rivo/uniseg"
 )
 
 func nextNonZeroToken(token uint64) uint64 {
@@ -380,8 +381,8 @@ func moveBufferCursorVertical(text string, cursor int, width int, prefix string,
 	targetIndex := lineIndex + delta
 	currentLine := lines[lineIndex]
 	targetLine := lines[targetIndex]
-	targetCol := tuiinput.DisplayWidth(renderText[currentLine.Start:editor.Cursor()])
-	prefixWidth := tuiinput.DisplayWidth(prefix)
+	targetCol := uniseg.StringWidth(renderText[currentLine.Start:editor.Cursor()])
+	prefixWidth := uniseg.StringWidth(prefix)
 	currentHasPrefix := currentLine.Start < len(prefix)
 	targetHasPrefix := targetLine.Start < len(prefix)
 	switch {

--- a/cli/app/ui_input_controller.go
+++ b/cli/app/ui_input_controller.go
@@ -176,7 +176,7 @@ func (m *uiModel) persistLocalEntryCmd(role, text, noticeID string) tea.Cmd {
 }
 
 func statusKindForLocalEntryRole(role string) uiStatusNoticeKind {
-	switch transcript.NormalizeEntryRole(role) {
+	switch strings.ToLower(strings.TrimSpace(role)) {
 	case string(transcript.EntryRoleDeveloperErrorFeedback), "error":
 		return uiStatusNoticeError
 	case "warning":

--- a/cli/app/ui_input_controller.go
+++ b/cli/app/ui_input_controller.go
@@ -78,7 +78,7 @@ func (m *uiModel) reconcileSpinnerTicking(force bool) tea.Cmd {
 		return nil
 	}
 	now := uiAnimationNow()
-	if m.spinnerTickToken != 0 && m.spinnerClock.Running() && !m.spinnerTickDue.IsZero() {
+	if m.spinnerTickToken != 0 && !m.spinnerClock.anchor.IsZero() && !m.spinnerTickDue.IsZero() {
 		rearmAfter := m.spinnerTickDue.Add(spinnerTickRearmGrace)
 		if force {
 			rearmAfter = m.spinnerTickDue
@@ -87,7 +87,7 @@ func (m *uiModel) reconcileSpinnerTicking(force bool) tea.Cmd {
 			return nil
 		}
 	}
-	if !m.spinnerClock.Running() {
+	if m.spinnerClock.anchor.IsZero() {
 		m.spinnerClock.Start(now)
 		m.spinnerFrame = 0
 	} else {

--- a/cli/app/ui_input_controller_commands.go
+++ b/cli/app/ui_input_controller_commands.go
@@ -6,6 +6,7 @@ import (
 
 	"core/cli/app/commands"
 	"core/shared/clientui"
+	"core/shared/serverapi"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -223,7 +224,7 @@ func (c uiInputController) handleFastModeCommand(requested string) (tea.Model, t
 		m.fastModeEnabled = targetEnabled
 	}
 
-	status := fastModeToggleStatusMessage(m.fastModeEnabled, changed)
+	status := serverapi.FastModeToggleStatusMessage(m.fastModeEnabled, changed)
 	return m, c.appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeSuccess)
 }
 
@@ -258,7 +259,7 @@ func (c uiInputController) handleSupervisorModeCommand(requested string) (tea.Mo
 	}
 	m.reviewerMode = nextMode
 	m.reviewerEnabled = nextMode != "off"
-	status := reviewerToggleStatusMessage(m.reviewerEnabled, nextMode, changed)
+	status := serverapi.ReviewerToggleStatusMessage(m.reviewerEnabled, nextMode, changed)
 	return m, c.appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral)
 }
 
@@ -288,7 +289,7 @@ func (c uiInputController) handleQuestionsCommand(requested string) (tea.Model, 
 		changed = currentEnabled != targetEnabled
 	}
 	m.questionsEnabled = nextEnabled
-	status := questionsToggleStatusMessage(nextEnabled, changed)
+	status := serverapi.QuestionsToggleStatusMessage(nextEnabled, changed)
 	return m, c.appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral)
 }
 
@@ -323,6 +324,6 @@ func (c uiInputController) handleAutoCompactionCommand(requested string) (tea.Mo
 		changed = currentEnabled != targetEnabled
 	}
 	m.autoCompactionEnabled = nextEnabled
-	status := autoCompactionToggleStatusMessage(nextEnabled, changed, currentCompactionMode)
+	status := serverapi.AutoCompactionToggleStatusMessage(nextEnabled, changed, currentCompactionMode)
 	return m, c.appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral)
 }

--- a/cli/app/ui_input_controller_keys.go
+++ b/cli/app/ui_input_controller_keys.go
@@ -24,22 +24,22 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	if inputState.Mode == uiInputModeStatus {
 		next, cmd := c.handleStatusOverlayKey(msg)
-		next.(*uiModel).syncViewport()
+		next.(*uiModel).layout().syncViewport()
 		return next, cmd
 	}
 	if inputState.Mode == uiInputModeGoal {
 		next, cmd := c.handleGoalOverlayKey(msg)
-		next.(*uiModel).syncViewport()
+		next.(*uiModel).layout().syncViewport()
 		return next, cmd
 	}
 	if inputState.Mode == uiInputModeWorktree {
 		next, cmd := c.handleWorktreeOverlayKey(msg)
-		next.(*uiModel).syncViewport()
+		next.(*uiModel).layout().syncViewport()
 		return next, cmd
 	}
 	if inputState.Mode == uiInputModeProcessList {
 		next, cmd := c.handleProcessListKey(msg)
-		next.(*uiModel).syncViewport()
+		next.(*uiModel).layout().syncViewport()
 		return next, cmd
 	}
 	if m.view.Mode() == tui.ModeDetail && inputState.Mode != uiInputModeRollbackEdit {

--- a/cli/app/ui_input_controller_status.go
+++ b/cli/app/ui_input_controller_status.go
@@ -2,8 +2,6 @@ package app
 
 import (
 	"strings"
-
-	"core/shared/serverapi"
 )
 
 func (m *uiModel) reviewerInvocationState() (bool, string) {
@@ -23,20 +21,4 @@ func (m *uiModel) fastModeState() (bool, bool) {
 		status.FastModeAvailable = true
 	}
 	return status.FastModeAvailable, status.FastModeEnabled
-}
-
-func fastModeToggleStatusMessage(enabled bool, changed bool) string {
-	return serverapi.FastModeToggleStatusMessage(enabled, changed)
-}
-
-func reviewerToggleStatusMessage(enabled bool, mode string, changed bool) string {
-	return serverapi.ReviewerToggleStatusMessage(enabled, mode, changed)
-}
-
-func questionsToggleStatusMessage(enabled bool, changed bool) string {
-	return serverapi.QuestionsToggleStatusMessage(enabled, changed)
-}
-
-func autoCompactionToggleStatusMessage(enabled bool, changed bool, compactionMode string) string {
-	return serverapi.AutoCompactionToggleStatusMessage(enabled, changed, compactionMode)
 }

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -130,7 +130,7 @@ func (c uiInputController) blockInjectedQueueSubmission() (bool, tea.Cmd) {
 	}
 	detailErr := "queued runtime message is still pending; retry or discard it before submitting"
 	m.activity = uiActivityError
-	m.syncViewport()
+	m.layout().syncViewport()
 	return true, m.sendTransientStatusWithNoticeID(detailErr, uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, "")
 }
 
@@ -144,11 +144,11 @@ func (c uiInputController) blockDisconnectedSubmission(restoreHidden bool, submi
 		c.restoreSubmittedTextIntoInput(submittedText)
 		c.restoreQueuedMessagesIntoInput()
 		m.activity = uiActivityError
-		m.syncViewport()
+		m.layout().syncViewport()
 		return true, tea.Batch(restoreCmd, m.appendLocalEntryWithNoticeID(operatorErrorFeedbackRole, runtimeDisconnectedStatusMessage, ""))
 	}
 	m.activity = uiActivityError
-	m.syncViewport()
+	m.layout().syncViewport()
 	return true, m.appendLocalEntryWithNoticeID(operatorErrorFeedbackRole, runtimeDisconnectedStatusMessage, "")
 }
 
@@ -270,7 +270,7 @@ func (c uiInputController) resumeQueuedInputsAfterIdleRuntime() tea.Cmd {
 	if m.hasRuntimeClient() && c.queuedDrainRequiresHydration() {
 		m.pendingQueuedDrainAfterHydration = true
 		m.queuedDrainReadyAfterHydration = false
-		m.syncViewport()
+		m.layout().syncViewport()
 		return m.requestRuntimeQueuedDrainTranscriptSync()
 	}
 	_, cmd := c.flushQueuedInputs(queueDrainAuto)
@@ -461,7 +461,7 @@ func (c uiInputController) handleInjectedQueueCreateDone(msg injectedQueueCreate
 			appendCmd := m.appendLocalEntryWithNoticeID(operatorErrorFeedbackRole, detailErr, "")
 			m.logf("queue_create.error err=%q", detailErr)
 			m.removeInjectedQueueItemAt(index)
-			m.syncViewport()
+			m.layout().syncViewport()
 			if msg.approvalCommentaryAnswer != nil {
 				return m, sequenceCmds(appendCmd, m.answerQueuedApprovalCommentary(*msg.approvalCommentaryAnswer))
 			}

--- a/cli/app/ui_input_resume.go
+++ b/cli/app/ui_input_resume.go
@@ -50,14 +50,14 @@ func (c uiInputController) handleQueuedRuntimeWorkCheckDone(msg queuedRuntimeWor
 		if errors.Is(msg.err, runtimeattach.ErrSubmissionInterrupted) || errors.Is(msg.err, context.Canceled) {
 			m.activity = uiActivityInterrupted
 			m.logf("step.interrupted")
-			m.syncViewport()
+			m.layout().syncViewport()
 			return m, restoreCmd
 		}
 		detailErr := runtimeattach.FormatSubmissionError(msg.err)
 		m.activity = uiActivityError
 		appendCmd := m.appendLocalEntryWithNoticeID(operatorErrorFeedbackRole, detailErr, "")
 		m.logf("queue_check.error err=%q", detailErr)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return m, tea.Batch(restoreCmd, appendCmd)
 	}
 	if !msg.hasWork || m.injectedQueueBlocksDrain() || m.isBusy() ||
@@ -72,7 +72,7 @@ func (c uiInputController) handleQueuedRuntimeWorkCheckDone(msg queuedRuntimeWor
 	c.notifyUserCompactionCompleted(compactionOrigin, false)
 	c.startBusyActivity(false)
 	m.logf("step.resume_queued_injected pending_injected=%d", len(m.pendingInjected))
-	m.syncViewport()
+	m.layout().syncViewport()
 	return m, tea.Batch(c.submitQueuedUserMessagesCmd(), c.model.reconcileSpinnerTicking(false))
 }
 

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -43,7 +43,7 @@ func (c uiInputController) startSubmissionWithPreSubmitQueuePosition(text string
 			m.forwardToView(tui.AppendTranscriptMsg{Role: "user", Text: text})
 		}
 	}
-	m.syncViewport()
+	m.layout().syncViewport()
 	if isUserShell {
 		return tea.Batch(c.submitUserShellCmd(text, command), m.reconcileSpinnerTicking(false))
 	}
@@ -169,7 +169,7 @@ func (c uiInputController) startCompactionWithOrigin(args string, origin uiCompa
 	c.startBusyActivity(true)
 	m.compactionOrigin = origin
 	m.logf("compaction.start args_chars=%d", len(strings.TrimSpace(args)))
-	m.syncViewport()
+	m.layout().syncViewport()
 	return tea.Batch(c.compactCmd(args), m.reconcileSpinnerTicking(false))
 }
 
@@ -246,14 +246,14 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 		if errors.Is(msg.err, runtimeattach.ErrSubmissionInterrupted) || errors.Is(msg.err, context.Canceled) {
 			m.activity = uiActivityInterrupted
 			m.logf("step.interrupted")
-			m.syncViewport()
+			m.layout().syncViewport()
 			return m, batchCmds(unlockCmd, restoreInjectedCmd)
 		}
 		detailErr := runtimeattach.FormatSubmissionError(msg.err)
 		m.activity = uiActivityError
 		appendCmd := m.appendLocalEntryWithNoticeID(operatorErrorFeedbackRole, detailErr, "")
 		m.logf("step.error err=%q", detailErr)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return m, tea.Batch(unlockCmd, restoreInjectedCmd, appendCmd)
 	}
 
@@ -275,7 +275,7 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 		if m.hasRuntimeClient() && c.queuedDrainRequiresHydration() {
 			m.pendingQueuedDrainAfterHydration = true
 			m.queuedDrainReadyAfterHydration = false
-			m.syncViewport()
+			m.layout().syncViewport()
 			return m, m.requestRuntimeQueuedDrainTranscriptSync()
 		}
 		next, drainCmd := c.flushQueuedInputs(queueDrainAuto)
@@ -283,7 +283,7 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 		return next, drainCmd
 	}
 	c.notifyTurnQueueDrainedIfIdle()
-	m.syncViewport()
+	m.layout().syncViewport()
 	return m, nil
 }
 
@@ -334,7 +334,7 @@ func (c uiInputController) handleSpinnerTick(msg spinnerTickMsg) (tea.Model, tea
 		tickAt = tickAt.Add(time.Duration(m.spinnerFrame+1) * spinnerTickInterval)
 	}
 	m.spinnerFrame = m.spinnerClock.Frame(tickAt, frameCount, spinnerTickInterval)
-	m.syncViewport()
+	m.layout().syncViewport()
 	return m, m.scheduleSpinnerTick(msg.token, tickAt)
 }
 
@@ -351,14 +351,14 @@ func (c uiInputController) handleCompactDone(msg compactDoneMsg) (tea.Model, tea
 		if errors.Is(msg.err, runtimeattach.ErrSubmissionInterrupted) || errors.Is(msg.err, context.Canceled) {
 			m.activity = uiActivityInterrupted
 			m.logf("step.interrupted")
-			m.syncViewport()
+			m.layout().syncViewport()
 			return m, tea.Batch(releaseCmd, restoreInjectedCmd)
 		}
 		detailErr := runtimeattach.FormatSubmissionError(msg.err)
 		m.activity = uiActivityError
 		appendCmd := m.appendLocalEntryWithNoticeID(operatorErrorFeedbackRole, detailErr, "")
 		m.logf("compaction.error err=%q", detailErr)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return m, tea.Batch(releaseCmd, restoreInjectedCmd, appendCmd)
 	}
 
@@ -373,16 +373,16 @@ func (c uiInputController) handleCompactDone(msg compactDoneMsg) (tea.Model, tea
 	if m.injectedQueueBlocksDrain() {
 		c.notifyUserCompactionCompleted(compactionOrigin, false)
 		m.queuedRuntimeWorkCheckCompactionOrigin = compactionOrigin
-		m.syncViewport()
+		m.layout().syncViewport()
 		return m, releaseCmd
 	}
 	if !m.hasRuntimeClient() {
 		c.notifyUserCompactionCompleted(compactionOrigin, !m.pendingQueuedDrainAfterHydration)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return m, releaseCmd
 	}
 	m.queuedRuntimeWorkCheckCompactionOrigin = compactionOrigin
-	m.syncViewport()
+	m.layout().syncViewport()
 	return m, tea.Batch(releaseCmd, c.startQueuedInjectionSubmission())
 }
 

--- a/cli/app/ui_key_reducer.go
+++ b/cli/app/ui_key_reducer.go
@@ -24,26 +24,26 @@ func (r uiKeyFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			m.helpVisible = false
 			if isHelpKey(keyMsg, m) && m.canShowHelp() {
 				m.lastEscAt = time.Time{}
-				m.syncViewport()
+				m.layout().syncViewport()
 				return handledUIFeatureUpdate(m, nil)
 			}
 		}
 		if isHelpKey(keyMsg, m) && m.canShowHelp() {
 			m.lastEscAt = time.Time{}
 			m.helpVisible = !m.helpVisible
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		switch m.inputModeState().Mode {
 		case uiInputModeAsk:
 			next, cmd := m.askController().handleKey(keyMsg)
 			nextModel := next.(*uiModel)
-			nextModel.syncViewport()
+			nextModel.layout().syncViewport()
 			return handledUIFeatureUpdate(nextModel, cmd)
 		default:
 			next, cmd := m.inputController().handleKey(keyMsg)
 			nextModel := next.(*uiModel)
-			nextModel.syncViewport()
+			nextModel.layout().syncViewport()
 			return handledUIFeatureUpdate(nextModel, cmd)
 		}
 	}
@@ -52,7 +52,7 @@ func (r uiKeyFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			m.helpVisible = false
 		}
 		m.lastEscAt = time.Time{}
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, nil)
 	}
 	return uiFeatureUpdateResult{}

--- a/cli/app/ui_layout_rendering_helpers.go
+++ b/cli/app/ui_layout_rendering_helpers.go
@@ -11,10 +11,6 @@ import (
 	"github.com/mattn/go-runewidth"
 )
 
-func (m *uiModel) syncViewport() {
-	m.layout().syncViewport()
-}
-
 type uiEditableInputRenderSpec struct {
 	Prefix       string
 	Text         string

--- a/cli/app/ui_lifecycle_state.go
+++ b/cli/app/ui_lifecycle_state.go
@@ -28,7 +28,7 @@ func (m *uiModel) setBusy(busy bool) {
 	if m.isGoalRun() {
 		mode = clientui.RunModeGoalLoop
 	}
-	m.runtimeLifecycle.Run = clientui.RunningRunLifecycle(mode)
+	m.runtimeLifecycle.Run = clientui.MustRunLifecycle(clientui.RunLifecycleRunning, mode)
 }
 
 func (m *uiModel) isGoalRun() bool {
@@ -41,11 +41,11 @@ func (m *uiModel) setGoalRun(goalRun bool) {
 	}
 	if !goalRun {
 		if m.isBusy() {
-			m.runtimeLifecycle.Run = clientui.RunningRunLifecycle(clientui.RunModeTurn)
+			m.runtimeLifecycle.Run = clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)
 		}
 		return
 	}
-	m.runtimeLifecycle.Run = clientui.RunningRunLifecycle(clientui.RunModeGoalLoop)
+	m.runtimeLifecycle.Run = clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeGoalLoop)
 }
 
 func (m *uiModel) setRunLifecycle(lifecycle clientui.RunLifecycle) error {

--- a/cli/app/ui_mode_flow_test.go
+++ b/cli/app/ui_mode_flow_test.go
@@ -38,7 +38,7 @@ func TestScenarioDetailWhileAgentWorksReturnsToLatestOngoingTail(t *testing.T) {
 	m := setTestUITerminalSize(newProjectedStaticUIModel(), 100, 18)
 	m.input = "/"
 	m.refreshSlashCommandFilterFromInputWithAuth(true)
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	for i := 1; i <= 20; i++ {
 		m = updateUIModel(t, m, tui.AppendTranscriptMsg{Role: "assistant", Text: fmt.Sprintf("line %02d", i)})
@@ -59,7 +59,7 @@ func TestScenarioDetailWhileAgentWorksReturnsToLatestOngoingTail(t *testing.T) {
 		t.Fatalf("expected ongoing mode, got %q", ongoing.view.Mode())
 	}
 	ongoing = sizedTestUIModel(ongoing, 100, 18)
-	ongoing.syncViewport()
+	ongoing.layout().syncViewport()
 
 	view := stripANSIAndTrimRight(ongoing.view.OngoingSnapshot())
 	if !containsAny(view, "line 30", "line 29", "line 28") {
@@ -73,7 +73,7 @@ func TestScenarioDetailWhileAgentWorksReturnsToLatestOngoingTail(t *testing.T) {
 
 func TestCtrlTTogglesTranscriptModeLikeShiftTab(t *testing.T) {
 	m := setTestUITerminalSize(newProjectedStaticUIModel(), 100, 16)
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyCtrlT})
 	if m.view.Mode() != tui.ModeDetail {
@@ -88,7 +88,7 @@ func TestCtrlTTogglesTranscriptModeLikeShiftTab(t *testing.T) {
 
 func TestCtrlTShowsLatestDetailTailWithoutResolvingMetricsEagerly(t *testing.T) {
 	m := setTestUITerminalSize(newProjectedStaticUIModel(), 100, 12)
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	for i := 0; i < 24; i++ {
 		m = updateUIModel(t, m, tui.AppendTranscriptMsg{Role: "assistant", Text: fmt.Sprintf("line %02d", i)})
@@ -132,7 +132,7 @@ func TestCtrlTPrimesDetailFromCurrentTailWhenPreviousDetailPageIsStale(t *testin
 		TotalEntries: currentPage.TotalEntries,
 		Entries:      transcriptEntriesFromPage(currentPage),
 	})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
 	_ = cmd
@@ -151,7 +151,7 @@ func TestCtrlTPrimesDetailFromCurrentTailWhenPreviousDetailPageIsStale(t *testin
 
 func TestCtrlTPrimesDetailFromCurrentTailAfterOngoingAdvancedSincePreviousDetail(t *testing.T) {
 	m := setTestUITerminalSize(newProjectedStaticUIModel(), 100, 12)
-	m.syncViewport()
+	m.layout().syncViewport()
 	m = updateUIModel(t, m, tui.AppendTranscriptMsg{Role: "assistant", Text: "old detail tail", Committed: true})
 
 	detail := updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyCtrlT})
@@ -185,7 +185,7 @@ func TestCtrlTPreservesLoadedDetailWindowWhenNoLocalTailIsKnown(t *testing.T) {
 	m := setTestUITerminalSize(newProjectedClosedUIModel(client), 100, 12)
 	m.sessionID = "session-1"
 	m.detailTranscript.replace(stalePage)
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
 	_ = cmd
@@ -207,7 +207,7 @@ func TestDetailEdgePagingWaitsForFirstNavigationToResolveMetrics(t *testing.T) {
 		loadPage: clientui.TranscriptPage{SessionID: "session-1"},
 	}
 	m := setTestUITerminalSize(newProjectedClosedUIModel(client), 100, 12)
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	page := clientui.TranscriptPage{SessionID: "session-1", Offset: 100, TotalEntries: 500}
 	for i := 0; i < 250; i++ {
@@ -262,7 +262,7 @@ func TestCtrlTDeferredDetailLoadSkipsDuplicateSeededPageRequest(t *testing.T) {
 	client := &recordingTranscriptRuntimeClient{loadPage: seed}
 	m := setTestUITerminalSize(newProjectedClosedUIModel(client), 100, 12)
 	_ = m.runtimeAdapter().applyRuntimeTranscriptPageWithRecovery(clientui.TranscriptPageRequest{Window: clientui.TranscriptWindowOngoingTail}, seed, clientui.TranscriptRecoveryCauseNone)
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, enterCmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
 	detail := next.(*uiModel)
@@ -306,7 +306,7 @@ func TestCtrlTDeferredDetailLoadSkippedKeepsDetailMetricsLazyEndToEnd(t *testing
 	client := &recordingTranscriptRuntimeClient{loadPage: seed}
 	m := setTestUITerminalSize(newProjectedClosedUIModel(client), 100, 12)
 	_ = m.runtimeAdapter().applyRuntimeTranscriptPageWithRecovery(clientui.TranscriptPageRequest{Window: clientui.TranscriptWindowOngoingTail}, seed, clientui.TranscriptRecoveryCauseNone)
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, enterCmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
 	detail := next.(*uiModel)
@@ -341,7 +341,7 @@ func TestDeferredDetailLoadRefreshesWhenTranscriptDirty(t *testing.T) {
 	client := &recordingTranscriptRuntimeClient{loadPage: seed}
 	m := setTestUITerminalSize(newProjectedClosedUIModel(client), 100, 12)
 	_ = m.runtimeAdapter().applyRuntimeTranscriptPageWithRecovery(clientui.TranscriptPageRequest{Window: clientui.TranscriptWindowOngoingTail}, seed, clientui.TranscriptRecoveryCauseNone)
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, enterCmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
 	detail := next.(*uiModel)
@@ -389,7 +389,7 @@ func TestCtrlTDeferredDetailLoadDoesNotMutateNativeHistoryState(t *testing.T) {
 	if cmd := m.runtimeAdapter().applyRuntimeTranscriptPageWithRecovery(clientui.TranscriptPageRequest{Window: clientui.TranscriptWindowOngoingTail}, seed, clientui.TranscriptRecoveryCauseNone); cmd != nil {
 		_ = collectCmdMessages(t, cmd)
 	}
-	m.syncViewport()
+	m.layout().syncViewport()
 	baselineProjection := m.nativeProjection
 	baselineRenderedProjection := m.nativeRenderedProjection
 	baselineRenderedSnapshot := m.nativeRenderedSnapshot
@@ -437,7 +437,7 @@ func TestScenarioHarnessRestartAndSessionResumeKeepsTranscriptVisible(t *testing
 
 	eng := newAppRuntimeEngineWithStore(t, store, statusLineFakeClient{}, runtime.Config{})
 	m := setTestUITerminalSize(newProjectedEngineUIModel(eng), 90, 16)
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	first := stripANSIAndTrimRight(m.view.OngoingSnapshot())
 	if !strings.Contains(first, "a2 tail") {
@@ -457,7 +457,7 @@ func TestScenarioHarnessRestartAndSessionResumeKeepsTranscriptVisible(t *testing
 	}
 	eng2 := newAppRuntimeEngineWithStore(t, reopened, statusLineFakeClient{}, runtime.Config{})
 	m2 := setTestUITerminalSize(newProjectedEngineUIModel(eng2), 90, 16)
-	m2.syncViewport()
+	m2.layout().syncViewport()
 
 	afterRestart := stripANSIAndTrimRight(m2.view.OngoingSnapshot())
 	if !strings.Contains(afterRestart, "a2 tail") {
@@ -498,7 +498,7 @@ func TestScenarioSessionResumeNormalizesLegacyReviewerEntriesInOngoingMode(t *te
 	}
 	eng := newAppRuntimeEngineWithStore(t, reopened, statusLineFakeClient{}, runtime.Config{})
 	m := setTestUITerminalSize(newProjectedEngineUIModel(eng), 90, 16)
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	ongoing := stripANSIAndTrimRight(m.view.OngoingSnapshot())
 	if !containsInOrder(ongoing, "Supervisor made 1 suggestion.", "Supervisor ran, applied 1 suggestion:") {
@@ -524,7 +524,7 @@ func TestScenarioTeleportBetweenSessionsResetsVisibleConversation(t *testing.T) 
 
 	engA := newAppRuntimeEngineWithStore(t, storeA, statusLineFakeClient{}, runtime.Config{})
 	modelA := setTestUITerminalSize(newProjectedEngineUIModel(engA), 80, 14)
-	modelA.syncViewport()
+	modelA.layout().syncViewport()
 	viewA := stripANSIAndTrimRight(modelA.view.OngoingSnapshot())
 	if !strings.Contains(viewA, "session-a-tail") {
 		t.Fatalf("expected session A tail, got %q", viewA)
@@ -532,7 +532,7 @@ func TestScenarioTeleportBetweenSessionsResetsVisibleConversation(t *testing.T) 
 
 	engB := newAppRuntimeEngineWithStore(t, storeB, statusLineFakeClient{}, runtime.Config{})
 	modelB := setTestUITerminalSize(newProjectedEngineUIModel(engB), 80, 14)
-	modelB.syncViewport()
+	modelB.layout().syncViewport()
 	viewB := stripANSIAndTrimRight(modelB.view.OngoingSnapshot())
 	if !strings.Contains(viewB, "session-b-tail") || strings.Contains(viewB, "session-a-tail") {
 		t.Fatalf("expected teleported session B view only, got %q", viewB)
@@ -544,7 +544,7 @@ func TestScenarioTeleportBetweenSessionsResetsVisibleConversation(t *testing.T) 
 	}
 	engA2 := newAppRuntimeEngineWithStore(t, reopenA, statusLineFakeClient{}, runtime.Config{})
 	modelA2 := setTestUITerminalSize(newProjectedEngineUIModel(engA2), 80, 14)
-	modelA2.syncViewport()
+	modelA2.layout().syncViewport()
 	viewA2 := stripANSIAndTrimRight(modelA2.view.OngoingSnapshot())
 	if !strings.Contains(viewA2, "session-a-tail") || strings.Contains(viewA2, "session-b-tail") {
 		t.Fatalf("expected teleported-back session A view only, got %q", viewA2)
@@ -553,7 +553,7 @@ func TestScenarioTeleportBetweenSessionsResetsVisibleConversation(t *testing.T) 
 
 func TestScenarioScrollAttemptsAcrossModesAfterLongDetailStay(t *testing.T) {
 	m := setTestUITerminalSize(newProjectedStaticUIModel(), 80, 10)
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	for i := 1; i <= 40; i++ {
 		m = updateUIModel(t, m, tui.AppendTranscriptMsg{Role: "assistant", Text: fmt.Sprintf("line %02d", i)})

--- a/cli/app/ui_native_history_part2_test.go
+++ b/cli/app/ui_native_history_part2_test.go
@@ -81,7 +81,7 @@ func TestNativePendingToolCallStaysLiveUntilResultThenAppendsFinalBlock(t *testi
 	}
 	m.transcriptEntries = append(m.transcriptEntries, call)
 	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries})
-	m.syncViewport()
+	m.layout().syncViewport()
 	if cmd := m.syncNativeHistoryFromTranscript(); cmd != nil {
 		t.Fatalf("expected pending tool call to stay out of committed scrollback, got %T", cmd())
 	}
@@ -92,7 +92,7 @@ func TestNativePendingToolCallStaysLiveUntilResultThenAppendsFinalBlock(t *testi
 	result := tui.TranscriptEntry{Role: "tool_result_ok", Text: "/tmp", ToolCallID: "call_1"}
 	m.transcriptEntries = append(m.transcriptEntries, result)
 	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries})
-	m.syncViewport()
+	m.layout().syncViewport()
 	cmd := m.syncNativeHistoryFromTranscript()
 	if cmd == nil {
 		t.Fatal("expected finalized tool block to append to native scrollback")
@@ -133,14 +133,14 @@ func TestNativeParallelToolCompletionWaitsForStablePrefixBeforeAppend(t *testing
 	}
 	m.transcriptEntries = entries
 	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries})
-	m.syncViewport()
+	m.layout().syncViewport()
 	if cmd := m.syncNativeHistoryFromTranscript(); cmd != nil {
 		t.Fatalf("expected no committed flush before first pending call resolves, got %T", cmd())
 	}
 
 	m.transcriptEntries = append(m.transcriptEntries, tui.TranscriptEntry{Role: "tool_result_ok", Text: "out-a", ToolCallID: "call_a"})
 	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries})
-	m.syncViewport()
+	m.layout().syncViewport()
 	cmd := m.syncNativeHistoryFromTranscript()
 	if cmd == nil {
 		t.Fatal("expected append once the stable prefix advances")
@@ -300,14 +300,14 @@ func TestNativeOngoingShrinksLiveRegionAfterInputShrinkWhenNotStreaming(t *testi
 	m.termHeight = 20
 	m.windowSizeKnown = true
 	m.input = "line 1\nline 2\nline 3"
-	m.syncViewport()
+	m.layout().syncViewport()
 	firstPad := m.nativeLiveRegionPad
 	first := strings.Split(m.View(), "\n")
 	if len(first) != 20 {
 		t.Fatalf("expected fresh conversation to fill terminal height before shrink, got %d lines", len(first))
 	}
 	m.input = ""
-	m.syncViewport()
+	m.layout().syncViewport()
 	secondPad := m.nativeLiveRegionPad
 	second := strings.Split(m.View(), "\n")
 	if len(second) != 20 {
@@ -333,12 +333,12 @@ func TestNativeOngoingClearsLiveRegionPadWhenStreamingEnds(t *testing.T) {
 	m.termHeight = 12
 	m.windowSizeKnown = true
 	m.forwardToView(tui.SetConversationMsg{Ongoing: "line1\nline2"})
-	m.syncViewport()
+	m.layout().syncViewport()
 	if !m.nativeStreamingActive {
 		t.Fatal("expected streaming active after ongoing stream snapshot")
 	}
 	m.forwardToView(tui.SetConversationMsg{Ongoing: ""})
-	m.syncViewport()
+	m.layout().syncViewport()
 	if m.nativeLiveRegionPad <= 0 {
 		t.Fatalf("expected fresh conversation to restore top padding after streaming ends, got %d", m.nativeLiveRegionPad)
 	}

--- a/cli/app/ui_native_history_part3_test.go
+++ b/cli/app/ui_native_history_part3_test.go
@@ -401,7 +401,7 @@ func TestNativeStreamingResizeInvalidatesPromotionAtNewWidth(t *testing.T) {
 	lineCount := 8
 	streamText := makeStreamingLines(lineCount)
 	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries, Ongoing: streamText})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	firstCmd := m.syncNativeHistoryFromTranscript()
 	firstFlush := collectNativeHistoryFlushText(collectCmdMessages(t, firstCmd))
@@ -419,7 +419,7 @@ func TestNativeStreamingResizeInvalidatesPromotionAtNewWidth(t *testing.T) {
 	resizedCount := lineCount + 1
 	resizedStream := makeStreamingLines(resizedCount)
 	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries, Ongoing: resizedStream})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	secondCmd := m.syncNativeHistoryFromTranscript()
 	secondFlush := collectNativeHistoryFlushText(collectCmdMessages(t, secondCmd))
@@ -448,7 +448,7 @@ func TestNativeStreamingLinesRenderAssistantMarkdown(t *testing.T) {
 	m.setBusy(true)
 	m.sawAssistantDelta = true
 	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries, Ongoing: "**hello**\n`world`"})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	raw := m.View()
 	plain := stripANSIPreserve(raw)
@@ -568,7 +568,7 @@ func TestNativeStreamingDividerPersistsInTightViewport(t *testing.T) {
 	m.setBusy(true)
 	m.sawAssistantDelta = true
 	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries, Ongoing: "line1\nline2\nline3"})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	plain := stripANSIPreserve(m.View())
 	if !strings.Contains(plain, strings.Repeat("─", m.termWidth)) {

--- a/cli/app/ui_native_scrollback_integration_part2_test.go
+++ b/cli/app/ui_native_scrollback_integration_part2_test.go
@@ -568,7 +568,7 @@ func TestNativeDeferredFinalWithQueuedInjectionSurvivesDetailRoundTripBeforeComm
 	_ = model.runtimeAdapter().applyProjectedRuntimeEvent(clientui.Event{
 		Kind:     clientui.EventRunStateChanged,
 		StepID:   "step-1",
-		RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)},
+		RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)},
 	}, true).cmd
 	_ = model.runtimeAdapter().applyProjectedRuntimeEvent(clientui.Event{
 		Kind:           clientui.EventAssistantDelta,

--- a/cli/app/ui_native_scrollback_integration_part3_test.go
+++ b/cli/app/ui_native_scrollback_integration_part3_test.go
@@ -104,7 +104,7 @@ func TestNativeProgramKeepsPendingToolTailLiveOnlyUntilCompletion(t *testing.T) 
 	}
 	model.transcriptEntries = append(model.transcriptEntries, call)
 	model.forwardToView(tui.SetConversationMsg{Entries: model.transcriptEntries})
-	model.syncViewport()
+	model.layout().syncViewport()
 	if cmd := model.syncNativeHistoryFromTranscript(); cmd != nil {
 		t.Fatalf("expected pending tool call not to flush committed history, got %T", cmd())
 	}
@@ -119,7 +119,7 @@ func TestNativeProgramKeepsPendingToolTailLiveOnlyUntilCompletion(t *testing.T) 
 	result := tui.TranscriptEntry{Role: "tool_result_ok", Text: "/tmp", ToolCallID: "call_1"}
 	model.transcriptEntries = append(model.transcriptEntries, result)
 	model.forwardToView(tui.SetConversationMsg{Entries: model.transcriptEntries})
-	model.syncViewport()
+	model.layout().syncViewport()
 	cmd := model.syncNativeHistoryFromTranscript()
 	if cmd == nil {
 		t.Fatal("expected finalized tool block flush")

--- a/cli/app/ui_native_scrollback_integration_part4_test.go
+++ b/cli/app/ui_native_scrollback_integration_part4_test.go
@@ -194,7 +194,7 @@ func TestNativeProgramUserFlushHydratesCommittedGapWhileAssistantStreamIsLive(t 
 	})
 	baselineLoadCalls := client.LoadCalls()
 
-	runtimeEvents <- clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)}}
+	runtimeEvents <- clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)}}
 	runtimeEvents <- clientui.Event{Kind: clientui.EventAssistantDelta, StepID: "step-1", AssistantDelta: "foreground done"}
 	waitForTestCondition(t, 2*time.Second, "assistant delta visible", func() bool {
 		return strings.Contains(normalizedOutput(out.String()), "foreground done")

--- a/cli/app/ui_native_scrollback_integration_part4_test.go
+++ b/cli/app/ui_native_scrollback_integration_part4_test.go
@@ -55,7 +55,7 @@ func TestNativeProgramUserFlushDoesNotTriggerTranscriptSyncThatDropsCommentary(t
 		normalized := normalizedOutput(out.String())
 		return containsInOrder(normalized, "seed", "say hi", "working")
 	})
-	if committed := stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot()); !strings.Contains(committed, "say hi") {
+	if committed := stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider)); !strings.Contains(committed, "say hi") {
 		t.Fatalf("expected committed ongoing surface to retain flushed user row before later runtime events, got %q", committed)
 	}
 	if currentLoadCalls := client.LoadCalls(); currentLoadCalls != baselineLoadCalls {
@@ -114,8 +114,8 @@ func TestNativeProgramCommittedToolStartReplacesMatchingTransientToolRowWithoutH
 	waitForTestCondition(t, 2*time.Second, "transient tool row buffered locally", func() bool {
 		return len(model.transcriptEntries) == 2 && model.transcriptEntries[1].Transient
 	})
-	if strings.Contains(stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot()), "pwd") {
-		t.Fatalf("expected transient tool row to stay out of committed ongoing surface, got %q", stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot()))
+	if strings.Contains(stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider)), "pwd") {
+		t.Fatalf("expected transient tool row to stay out of committed ongoing surface, got %q", stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider)))
 	}
 
 	runtimeEvents <- clientui.Event{
@@ -152,7 +152,7 @@ func TestNativeProgramCommittedToolStartReplacesMatchingTransientToolRowWithoutH
 	}
 
 	waitForTestCondition(t, 2*time.Second, "committed tool pair visible without hydrate", func() bool {
-		committed := stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot())
+		committed := stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 		return strings.Contains(committed, "pwd")
 	})
 	if currentLoadCalls := client.LoadCalls(); currentLoadCalls != baselineLoadCalls {
@@ -160,7 +160,7 @@ func TestNativeProgramCommittedToolStartReplacesMatchingTransientToolRowWithoutH
 	}
 
 	program.QuitAndWait(2 * time.Second)
-	if committed := stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot()); !strings.Contains(committed, "pwd") {
+	if committed := stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider)); !strings.Contains(committed, "pwd") {
 		t.Fatalf("expected committed tool pair in ongoing committed surface after replacement, got %q", committed)
 	}
 }
@@ -218,7 +218,7 @@ func TestNativeProgramUserFlushHydratesCommittedGapWhileAssistantStreamIsLive(t 
 	userFlushDeadline := time.Now().Add(2 * time.Second)
 	userFlushVisible := false
 	for time.Now().Before(userFlushDeadline) {
-		committed := stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot())
+		committed := stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 		if containsInOrder(committed, "seed", "steered message") {
 			userFlushVisible = true
 			break
@@ -226,7 +226,7 @@ func TestNativeProgramUserFlushHydratesCommittedGapWhileAssistantStreamIsLive(t 
 		time.Sleep(10 * time.Millisecond)
 	}
 	if !userFlushVisible {
-		t.Fatalf("expected user flush visible after hydrate, committed=%q load_calls=%d output=%q", stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot()), client.LoadCalls(), normalizedOutput(out.String()))
+		t.Fatalf("expected user flush visible after hydrate, committed=%q load_calls=%d output=%q", stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider)), client.LoadCalls(), normalizedOutput(out.String()))
 	}
 	if got := len(model.deferredCommittedTail); got != 0 {
 		t.Fatalf("expected queued user flush path to avoid deferred committed tail, got %d", got)
@@ -249,7 +249,7 @@ func TestNativeProgramUserFlushHydratesCommittedGapWhileAssistantStreamIsLive(t 
 	}
 
 	waitForTestCondition(t, 2*time.Second, "assistant response appends after hydrated user row", func() bool {
-		committed := stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot())
+		committed := stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 		return containsInOrder(committed, "seed", "steered message", "after follow-up")
 	})
 	if currentLoadCalls := client.LoadCalls(); currentLoadCalls != baselineLoadCalls {
@@ -257,7 +257,7 @@ func TestNativeProgramUserFlushHydratesCommittedGapWhileAssistantStreamIsLive(t 
 	}
 
 	program.QuitAndWait(2 * time.Second)
-	if committed := stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot()); !containsInOrder(committed, "seed", "steered message", "after follow-up") {
+	if committed := stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider)); !containsInOrder(committed, "seed", "steered message", "after follow-up") {
 		t.Fatalf("expected hydrated committed user flush to remain visible in ongoing committed surface, got %q", committed)
 	}
 }
@@ -296,7 +296,7 @@ func TestNativeProgramReviewerTerminalMessageRemainsVisibleWithoutHydration(t *t
 	}
 
 	waitForTestCondition(t, 2*time.Second, "reviewer terminal message visible without hydrate", func() bool {
-		committed := stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot())
+		committed := stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 		return containsInOrder(committed, "seed", "Supervisor ran: no changes.")
 	})
 	if currentLoadCalls := client.LoadCalls(); currentLoadCalls != baselineLoadCalls {
@@ -304,7 +304,7 @@ func TestNativeProgramReviewerTerminalMessageRemainsVisibleWithoutHydration(t *t
 	}
 
 	program.QuitAndWait(2 * time.Second)
-	if committed := stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot()); !containsInOrder(committed, "seed", "Supervisor ran: no changes.") {
+	if committed := stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider)); !containsInOrder(committed, "seed", "Supervisor ran: no changes.") {
 		t.Fatalf("expected reviewer terminal message in ongoing committed surface, got %q", committed)
 	}
 }
@@ -621,13 +621,13 @@ func TestQueuedFollowUpRemainsHiddenUntilFinalCatchUpThenAppendsOnceInRenderedOn
 		t.Fatal("timed out waiting for transcript catch-up refresh to start")
 	}
 	time.Sleep(80 * time.Millisecond)
-	if strings.Contains(stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot()), "follow up") {
-		t.Fatalf("expected queued follow-up to stay out of committed ongoing transcript before final catch-up, got %q", stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot()))
+	if strings.Contains(stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider)), "follow up") {
+		t.Fatalf("expected queued follow-up to stay out of committed ongoing transcript before final catch-up, got %q", stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider)))
 	}
 
 	close(client.releaseRefresh)
 	waitForTestCondition(t, 2*time.Second, "final answer visible before queued follow-up", func() bool {
-		committed := stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot())
+		committed := stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 		return strings.Contains(committed, "final answer") && !strings.Contains(committed, "follow up")
 	})
 
@@ -648,7 +648,7 @@ func TestQueuedFollowUpRemainsHiddenUntilFinalCatchUpThenAppendsOnceInRenderedOn
 	program.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
 	program.Wait(2 * time.Second)
 
-	committed := stripANSIAndTrimRight(model.view.OngoingCommittedSnapshot())
+	committed := stripANSIAndTrimRight(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 	if strings.Count(committed, "final answer") != 1 {
 		t.Fatalf("expected final answer exactly once in committed ongoing transcript, got %d in %q", strings.Count(committed, "final answer"), committed)
 	}

--- a/cli/app/ui_native_scrollback_integration_part5_test.go
+++ b/cli/app/ui_native_scrollback_integration_part5_test.go
@@ -109,7 +109,7 @@ func TestNativeStreamedFinalThenCommitAppearsOnceInScrollback(t *testing.T) {
 	if got := strings.Count(finalTerminal, "final answer"); got != 1 {
 		t.Fatalf("expected streamed final plus commit to appear once in terminal, got %d in %q", got, finalTerminal)
 	}
-	committed := normalizedOutput(model.view.OngoingCommittedSnapshot())
+	committed := normalizedOutput(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 	if got := strings.Count(committed, "final answer"); got != 1 {
 		t.Fatalf("expected committed final once in rendered committed ongoing transcript, got %d in %q", got, committed)
 	}
@@ -162,7 +162,7 @@ func TestNativeStreamedMultilineMarkdownFinalThenCommitAppearsOnceInScrollback(t
 	if got := strings.Count(finalTerminal, "I opened it via the browser client"); got != 1 {
 		t.Fatalf("expected final terminal tail once, got %d in %q", got, finalTerminal)
 	}
-	committed := normalizedOutput(model.view.OngoingCommittedSnapshot())
+	committed := normalizedOutput(model.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 	if got := strings.Count(committed, "Captured the Kent project board"); got != 1 {
 		t.Fatalf("expected committed multiline final prefix once, got %d in %q", got, committed)
 	}

--- a/cli/app/ui_part10_test.go
+++ b/cli/app/ui_part10_test.go
@@ -18,7 +18,7 @@ func TestLockedInputEditKeysDismissHelpAndStillNoOp(t *testing.T) {
 	m.setInputSubmitLocked(true)
 	m.setBusy(true)
 	m.input = "locked"
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(customKeyMsg{Kind: customKeyHelp})
 	updated := next.(*uiModel)

--- a/cli/app/ui_part2_test.go
+++ b/cli/app/ui_part2_test.go
@@ -322,7 +322,7 @@ func TestNativeRollbackOverlayFullSelectionFlowPreservesHistory(t *testing.T) {
 	if startupCmd == nil {
 		t.Fatal("expected native startup replay command")
 	}
-	committedBefore := stripANSIAndTrimRight(updated.view.OngoingCommittedSnapshot())
+	committedBefore := stripANSIAndTrimRight(updated.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 
 	assertSelectionCentered := func(model *uiModel) {
 		t.Helper()
@@ -384,7 +384,7 @@ func TestNativeRollbackOverlayFullSelectionFlowPreservesHistory(t *testing.T) {
 		t.Fatalf("expected final esc to cancel rollback overlay back to ongoing, mode=%q rollback=%t", updated.view.Mode(), testRollbackSelecting(updated))
 	}
 
-	committedAfter := stripANSIAndTrimRight(updated.view.OngoingCommittedSnapshot())
+	committedAfter := stripANSIAndTrimRight(updated.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 	if committedAfter != committedBefore {
 		t.Fatal("expected committed history unchanged after rollback overlay cancel chain")
 	}
@@ -408,7 +408,7 @@ func TestNativeRollbackEditCancelPreservesCommittedHistory(t *testing.T) {
 	if startupCmd == nil {
 		t.Fatal("expected startup replay command")
 	}
-	originalCommitted := stripANSIAndTrimRight(updated.view.OngoingCommittedSnapshot())
+	originalCommitted := stripANSIAndTrimRight(updated.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 
 	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	updated = next.(*uiModel)
@@ -440,7 +440,7 @@ func TestNativeRollbackEditCancelPreservesCommittedHistory(t *testing.T) {
 		t.Fatalf("expected ongoing mode after cancel chain, got %q", updated.view.Mode())
 	}
 
-	afterCommitted := stripANSIAndTrimRight(updated.view.OngoingCommittedSnapshot())
+	afterCommitted := stripANSIAndTrimRight(updated.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 	if afterCommitted != originalCommitted {
 		t.Fatalf("expected committed history preserved after rollback cancel chain")
 	}

--- a/cli/app/ui_part2_test.go
+++ b/cli/app/ui_part2_test.go
@@ -27,7 +27,7 @@ func TestRollbackSelectionUsesAbsoluteTranscriptEntryIndexWhenPaged(t *testing.T
 	m.transcriptBaseOffset = 200
 	m.transcriptTotalEntries = 203
 	m.forwardToView(tui.SetConversationMsg{BaseOffset: m.transcriptBaseOffset, TotalEntries: m.transcriptTotalEntries, Entries: m.transcriptEntries})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	updated := next.(*uiModel)
@@ -93,7 +93,7 @@ func TestRollbackSelectionRecentersTranscript(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUIInitialTranscript(entries))
 	m.termWidth = 100
 	m.termHeight = 8
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	updated := next.(*uiModel)
@@ -135,7 +135,7 @@ func TestRollbackSelectionEdgeArrowRecentersWhenNoPageAvailable(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUIInitialTranscript(entries))
 	m.termWidth = 100
 	m.termHeight = 8
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyEsc})
 	m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyEsc})
@@ -182,7 +182,7 @@ func TestRollbackSelectionCancelRestoresPriorOngoingScroll(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUIInitialTranscript(entries))
 	m.termWidth = 100
 	m.termHeight = 10
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
 	updated := next.(*uiModel)
@@ -223,7 +223,7 @@ func TestRollbackTransitionsUseDetailOverlayInNativeMode(t *testing.T) {
 	)
 	m.termWidth = 100
 	m.termHeight = 10
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	updated := next.(*uiModel)
@@ -458,7 +458,7 @@ func TestRollbackEditCancelChainRestoresPriorOngoingScroll(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUIInitialTranscript(entries))
 	m.termWidth = 100
 	m.termHeight = 10
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
 	updated := next.(*uiModel)

--- a/cli/app/ui_part3_test.go
+++ b/cli/app/ui_part3_test.go
@@ -887,7 +887,7 @@ func TestViewRendersOverlayCursorWithoutShiftingText(t *testing.T) {
 	m.termHeight = 16
 	m.windowSizeKnown = true
 	m.input = "hello world"
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	view := m.View()
 	if !strings.Contains(view, ansiHideCursor) {
@@ -906,7 +906,7 @@ func TestViewCursorMovementDoesNotDropCharacters(t *testing.T) {
 	m.windowSizeKnown = true
 	m.input = "hello"
 	m.inputCursor = 2
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	plain := stripANSIAndTrimRight(m.View())
 	if !strings.Contains(plain, "› hello") {
@@ -921,7 +921,7 @@ func TestViewHidesCursorWhenInputLocked(t *testing.T) {
 	m.windowSizeKnown = true
 	m.setInputSubmitLocked(true)
 	m.input = "hello world"
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	view := m.View()
 	if !strings.Contains(view, ansiHideCursor) {

--- a/cli/app/ui_part4_test.go
+++ b/cli/app/ui_part4_test.go
@@ -22,7 +22,7 @@ func TestMainInputViewportTracksCursorLine(t *testing.T) {
 	m.windowSizeKnown = true
 	m.input = "first\nsecond\nthird\nfourth"
 	m.inputCursor = 1
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	plain := stripANSIAndTrimRight(strings.Join(m.layout().renderInputLines(20, uiThemeStyles("dark")), "\n"))
 	if !strings.Contains(plain, "› first") || !strings.Contains(plain, "second") {

--- a/cli/app/ui_part4_test.go
+++ b/cli/app/ui_part4_test.go
@@ -1143,7 +1143,7 @@ func TestInterruptedSubmitDoneDoesNotRestoreFlushedSubmittedText(t *testing.T) {
 	next, _ := m.Update(runtimeEventMsg{event: clientui.Event{
 		Kind:     clientui.EventRunStateChanged,
 		StepID:   "step-1",
-		RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)},
+		RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)},
 	}})
 	updated := next.(*uiModel)
 
@@ -1220,7 +1220,7 @@ func TestVerboseReviewerSuggestionsStaySingleAfterInterruptAndNextSubmit(t *test
 	m.activeSubmit = activeSubmitState{token: 21, text: suggestions}
 
 	events := []clientui.Event{
-		{Kind: clientui.EventRunStateChanged, StepID: "step-1", RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)}},
+		{Kind: clientui.EventRunStateChanged, StepID: "step-1", RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)}},
 		{
 			Kind:                       clientui.EventUserMessageFlushed,
 			StepID:                     "step-1",
@@ -1265,7 +1265,7 @@ func TestVerboseReviewerSuggestionsStaySingleAfterInterruptAndNextSubmit(t *test
 	next, _ = updated.Update(runtimeEventMsg{event: clientui.Event{
 		Kind:     clientui.EventRunStateChanged,
 		StepID:   "step-2",
-		RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)},
+		RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)},
 	}})
 	updated = next.(*uiModel)
 	next, _ = updated.Update(runtimeEventMsg{event: clientui.Event{

--- a/cli/app/ui_part5_test.go
+++ b/cli/app/ui_part5_test.go
@@ -28,7 +28,7 @@ func TestViewDuringActiveWorkKeepsCommittedTranscriptVisible(t *testing.T) {
 	m.windowSizeKnown = true
 	m.setBusy(true)
 	m.sawAssistantDelta = true
-	m.syncViewport()
+	m.layout().syncViewport()
 	m.forwardToView(tui.SetConversationMsg{
 		Entries: []tui.TranscriptEntry{
 			{Role: "user", Text: "prior user"},

--- a/cli/app/ui_part7_test.go
+++ b/cli/app/ui_part7_test.go
@@ -900,7 +900,7 @@ func TestSlashFastTogglesAndShowsStatus(t *testing.T) {
 	m.termWidth = 100
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 	m.input = "/fast"
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -959,7 +959,7 @@ func TestSlashFastStatusNoticeReplacesWithoutWaitingForClear(t *testing.T) {
 	m.termWidth = 100
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 	m.input = "/fast on"
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -988,7 +988,7 @@ func TestSlashFastUnavailableShowsError(t *testing.T) {
 	m.termWidth = 100
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 	m.input = "/fast on"
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -1045,7 +1045,7 @@ func TestSlashSupervisorTogglesReviewerInvocationAndShowsStatus(t *testing.T) {
 	m.termWidth = 100
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 	m.input = "/supervisor"
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})

--- a/cli/app/ui_part7_test.go
+++ b/cli/app/ui_part7_test.go
@@ -39,7 +39,7 @@ func TestHydrationCompletionKeepsDeferredQueuedDrainArmedUntilUnrelatedBusyState
 		t.Fatal("expected queued drain deferred until hydration completes")
 	}
 
-	next, _ = updated.Update(runtimeEventMsg{event: clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)}}})
+	next, _ = updated.Update(runtimeEventMsg{event: clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)}}})
 	updated = next.(*uiModel)
 	if !updated.isBusy() {
 		t.Fatal("expected unrelated runtime activity to mark UI busy before hydration completes")

--- a/cli/app/ui_part8_test.go
+++ b/cli/app/ui_part8_test.go
@@ -125,7 +125,7 @@ func TestSlashAutoCompactionTogglesAndShowsStatus(t *testing.T) {
 	m.termWidth = 100
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 	m.input = "/autocompaction"
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})

--- a/cli/app/ui_part9_test.go
+++ b/cli/app/ui_part9_test.go
@@ -257,7 +257,7 @@ func TestHelpDismissesOnRegisteredKeyAndAppliesAction(t *testing.T) {
 	m.termWidth = 80
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(customKeyMsg{Kind: customKeyHelp})
 	updated := next.(*uiModel)
@@ -278,7 +278,7 @@ func TestHelpDismissesOnAnyKeypress(t *testing.T) {
 	m.termHeight = 24
 	m.windowSizeKnown = true
 	testSetActiveAsk(m, &askEvent{req: clientui.PendingPromptEvent{Question: "Proceed?", Suggestions: []string{"Yes", "No"}}})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(customKeyMsg{Kind: customKeyHelp})
 	updated := next.(*uiModel)
@@ -298,7 +298,7 @@ func TestQuestionMarkTogglesHelpWhenInputIsEmpty(t *testing.T) {
 	m.termWidth = 80
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
 	updated := next.(*uiModel)
@@ -315,7 +315,7 @@ func TestQuestionMarkInsertsLiteralWhenInputIsNotEmpty(t *testing.T) {
 	m.windowSizeKnown = true
 	m.input = "draft"
 	m.inputCursor = len([]rune(m.input))
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
 	updated := next.(*uiModel)
@@ -333,7 +333,7 @@ func TestAltQuestionMarkTogglesHelp(t *testing.T) {
 	m.termWidth = 80
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}, Alt: true})
 	updated := next.(*uiModel)
@@ -348,7 +348,7 @@ func TestF1TogglesHelp(t *testing.T) {
 	m.termWidth = 80
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyF1})
 	updated := next.(*uiModel)
@@ -450,7 +450,7 @@ func TestAltSlashTogglesHelp(t *testing.T) {
 	m.termWidth = 80
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}, Alt: true})
 	updated := next.(*uiModel)
@@ -465,7 +465,7 @@ func TestHelpToggleClearsRollbackEscArming(t *testing.T) {
 	m.termWidth = 80
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	updated := next.(*uiModel)
@@ -500,7 +500,7 @@ func TestCmdSlashCSIUTogglesHelp(t *testing.T) {
 	m.termWidth = 80
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(adaptCustomKeyMsg(testBubbleTeaUnknownCSISequence("\x1b[47;10u")))
 	updated := next.(*uiModel)
@@ -515,7 +515,7 @@ func TestHelpToggleKeyHidesVisibleHelp(t *testing.T) {
 	m.termWidth = 80
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(customKeyMsg{Kind: customKeyHelp})
 	updated := next.(*uiModel)
@@ -533,7 +533,7 @@ func TestHelpToggleIgnoredInDetailMode(t *testing.T) {
 	m.termHeight = 24
 	m.windowSizeKnown = true
 	m.forwardToView(tui.ToggleModeMsg{})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(customKeyMsg{Kind: customKeyHelp})
 	updated := next.(*uiModel)
@@ -548,7 +548,7 @@ func TestTranscriptToggleClosesVisibleHelp(t *testing.T) {
 	m.termWidth = 80
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(customKeyMsg{Kind: customKeyHelp})
 	updated := next.(*uiModel)
@@ -572,7 +572,7 @@ func TestHelpRollbackSelectionDismissesAndMovesSelection(t *testing.T) {
 	if !m.startRollbackSelectionMode() {
 		t.Fatal("expected rollback selection mode to start")
 	}
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(customKeyMsg{Kind: customKeyHelp})
 	updated := next.(*uiModel)
@@ -601,7 +601,7 @@ func TestHelpRollbackEditDismissesAndReturnsToSelection(t *testing.T) {
 		t.Fatal("expected rollback editing mode to start")
 	}
 	m.input = ""
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(customKeyMsg{Kind: customKeyHelp})
 	updated := next.(*uiModel)

--- a/cli/app/ui_process_render.go
+++ b/cli/app/ui_process_render.go
@@ -8,7 +8,6 @@ import (
 
 	appprocessview "core/cli/app/internal/status"
 	"core/shared/clientui"
-	"core/shared/textutil"
 	sharedtheme "core/shared/theme"
 
 	"github.com/charmbracelet/lipgloss"
@@ -269,13 +268,12 @@ func compactProcessCommandPreview(command string) string {
 	if preview == "" {
 		preview = "<no command>"
 	}
-	normalizedPreview := textutil.NormalizeCRLF(preview)
-	previewLines := textutil.SplitLinesCRLF(normalizedPreview)
+	previewLines := strings.Split(strings.ReplaceAll(preview, "\r\n", "\n"), "\n")
 	preview = strings.TrimSpace(previewLines[0])
 	if preview == "" {
 		preview = "<no command>"
 	}
-	normalizedCommand := textutil.NormalizeCRLF(strings.TrimSpace(command))
+	normalizedCommand := strings.ReplaceAll(strings.TrimSpace(command), "\r\n", "\n")
 	truncated := len(previewLines) > 1 || (strings.Contains(normalizedCommand, "\n") && strings.TrimSpace(normalizedCommand) != preview)
 	if truncated && !strings.HasSuffix(preview, " …") {
 		preview += " …"
@@ -284,7 +282,7 @@ func compactProcessCommandPreview(command string) string {
 }
 
 func processListOutputPreview(output string) string {
-	lines := textutil.SplitLinesCRLF(output)
+	lines := strings.Split(strings.ReplaceAll(output, "\r\n", "\n"), "\n")
 	for idx := len(lines) - 1; idx >= 0; idx-- {
 		line := strings.TrimSpace(lines[idx])
 		if line != "" {

--- a/cli/app/ui_projected_runtime_reconnect_test.go
+++ b/cli/app/ui_projected_runtime_reconnect_test.go
@@ -42,7 +42,7 @@ func TestSessionActivityStreamGapHydratesThenRearmsOngoingRuntimeWait(t *testing
 	m.termWidth = 90
 	m.termHeight = 16
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	firstMsg, ok := m.waitRuntimeEventCmd()().(runtimeEventBatchMsg)
 	if !ok {

--- a/cli/app/ui_projected_runtime_test.go
+++ b/cli/app/ui_projected_runtime_test.go
@@ -458,8 +458,8 @@ func TestHydratingClientAndLiveClientConvergeWithoutDuplicateCommittedRows(t *te
 	hydrating = next.(*uiModel)
 	_ = finalCmd
 
-	hydratingCommitted := stripANSIAndTrimRight(hydrating.view.OngoingCommittedSnapshot())
-	liveCommitted := stripANSIAndTrimRight(live.view.OngoingCommittedSnapshot())
+	hydratingCommitted := stripANSIAndTrimRight(hydrating.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
+	liveCommitted := stripANSIAndTrimRight(live.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 	if got := len(hydrating.transcriptEntries); got != 2 {
 		t.Fatalf("hydrating client transcript entry count = %d, want 2", got)
 	}

--- a/cli/app/ui_projected_runtime_test.go
+++ b/cli/app/ui_projected_runtime_test.go
@@ -68,9 +68,9 @@ func TestWaitRuntimeEventReturnsProjectedMessage(t *testing.T) {
 
 func TestWaitRuntimeEventDrainsQueuedBatch(t *testing.T) {
 	ch := make(chan clientui.Event, 3)
-	ch <- clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)}}
+	ch <- clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)}}
 	ch <- clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.IdleRunLifecycle()}}
-	ch <- clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)}}
+	ch <- clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)}}
 	assertRuntimeEventBatchLen(t, nextRuntimeEventBatch(t, ch), 3)
 }
 
@@ -78,7 +78,7 @@ func TestWaitRuntimeEventDoesNotCoalesceAssistantDeltas(t *testing.T) {
 	ch := make(chan clientui.Event, 3)
 	ch <- clientui.Event{Kind: clientui.EventAssistantDelta, AssistantDelta: "hello"}
 	ch <- clientui.Event{Kind: clientui.EventAssistantDelta, AssistantDelta: " world"}
-	ch <- clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)}}
+	ch <- clientui.Event{Kind: clientui.EventRunStateChanged, RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)}}
 
 	msg := nextRuntimeEventBatch(t, ch)
 	assertRuntimeEventBatchLen(t, msg, 1)

--- a/cli/app/ui_render_diagnostic_test.go
+++ b/cli/app/ui_render_diagnostic_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"core/cli/tui"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 type testUILogger struct {
@@ -60,9 +62,11 @@ func TestApplyRunLoggerDiagnosticSetsErrorTransientStatus(t *testing.T) {
 	logger := &testUILogger{}
 	m := newProjectedStaticUIModel(WithUILogger(logger))
 
-	m.handleRunLoggerDiagnostic(runLoggerDiagnostic{
-		Kind:    "write_failed",
-		Message: "run log write failed; observability degraded: disk full",
+	m.startupCmds = append(m.startupCmds, func() tea.Msg {
+		return runLoggerDiagnosticMsg{diagnostic: runLoggerDiagnostic{
+			Kind:    "write_failed",
+			Message: "run log write failed; observability degraded: disk full",
+		}}
 	})
 	runLogMsg, ok := startupCmdMessage[runLoggerDiagnosticMsg](m.startupCmds)
 	if !ok {

--- a/cli/app/ui_runtime_adapter_part2_test.go
+++ b/cli/app/ui_runtime_adapter_part2_test.go
@@ -147,7 +147,7 @@ func TestProjectedAssistantMessageUpdatesDetailViewImmediatelyWhenCommitted(t *t
 		_ = collectCmdMessages(t, cmd)
 	}
 	m.forwardToView(tui.SetModeMsg{Mode: tui.ModeDetail, SkipDetailWarmup: true})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	cmd := m.runtimeAdapter().applyProjectedRuntimeEvent(clientui.Event{
 		Kind:                       clientui.EventAssistantMessage,
@@ -207,7 +207,7 @@ func TestProjectedReviewerCompletedUpdatesDetailViewImmediatelyWhenCommitted(t *
 		_ = collectCmdMessages(t, cmd)
 	}
 	m.forwardToView(tui.SetModeMsg{Mode: tui.ModeDetail, SkipDetailWarmup: true})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	cmd := m.runtimeAdapter().applyProjectedRuntimeEvent(clientui.Event{
 		Kind:                       clientui.EventLocalEntryAdded,
@@ -567,7 +567,7 @@ func TestProjectedCompactionStatusDoesNotAppendOngoingNoticeInDetailMode(t *test
 		_ = collectCmdMessages(t, cmd)
 	}
 	m.forwardToView(tui.SetModeMsg{Mode: tui.ModeDetail, SkipDetailWarmup: true})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	_ = m.runtimeAdapter().applyProjectedRuntimeEvent(projectRuntimeEvent(runtime.Event{
 		Kind:   runtime.EventCompactionCompleted,

--- a/cli/app/ui_runtime_adapter_part3_test.go
+++ b/cli/app/ui_runtime_adapter_part3_test.go
@@ -185,7 +185,7 @@ func TestApplyRuntimeTranscriptPageSkipsDuplicateDetailRefresh(t *testing.T) {
 	m.detailTranscript.replace(page)
 	m.forwardToView(tui.SetConversationMsg{BaseOffset: page.Offset, TotalEntries: page.TotalEntries, Entries: entries})
 	m.forwardToView(tui.SetModeMsg{Mode: tui.ModeDetail, SkipDetailWarmup: true})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	cmd := m.runtimeAdapter().applyRuntimeTranscriptPageWithRecovery(clientui.TranscriptPageRequest{Offset: page.Offset, Limit: len(page.Entries)}, page, clientui.TranscriptRecoveryCauseNone)
 	if cmd != nil {
@@ -258,7 +258,7 @@ func TestApplyRuntimeTranscriptPageInDetailModeAdvancesRevisionEvenWhenPageMatch
 		_ = collectCmdMessages(t, cmd)
 	}
 	m.forwardToView(tui.SetModeMsg{Mode: tui.ModeDetail, SkipDetailWarmup: true})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	updated := page
 	updated.Revision = 11

--- a/cli/app/ui_runtime_adapter_part5_test.go
+++ b/cli/app/ui_runtime_adapter_part5_test.go
@@ -146,7 +146,7 @@ func TestConversationSnapshotCommitClearsSawAssistantDelta(t *testing.T) {
 
 	_ = m.runtimeAdapter().applyChatSnapshot(runtime.ChatSnapshot{Entries: []runtime.ChatEntry{{Role: "assistant", Text: "partial"}}, Ongoing: ""})
 	m.setBusy(false)
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	if m.sawAssistantDelta {
 		t.Fatal("expected sawAssistantDelta cleared after commit snapshot")
@@ -172,7 +172,7 @@ func TestApplyChatSnapshotShowsMixedParallelPendingStatesInLiveView(t *testing.T
 	if cmd != nil {
 		_ = cmd()
 	}
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	view := stripANSIPreserve(m.View())
 	callA := m.transcriptEntries[1]
@@ -206,7 +206,7 @@ func TestApplyChatSnapshotOffsetsParallelPendingToolSpinners(t *testing.T) {
 	if cmd != nil {
 		_ = cmd()
 	}
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	alphaFrame := pendingToolSpinnerFrameForEntry(0, m.transcriptEntries[0], 0)
 	betaFrame := pendingToolSpinnerFrameForEntry(0, m.transcriptEntries[1], 1)
@@ -507,7 +507,7 @@ func TestProjectedCommittedToolAndFinalEventsDoNotScheduleTranscriptRefresh(t *t
 	m.transcriptTotalEntries = len(m.transcriptEntries)
 	m.transcriptRevision = 10
 	m.forwardToView(tui.SetConversationMsg{BaseOffset: 0, TotalEntries: len(m.transcriptEntries), Entries: m.transcriptEntries})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	callMeta := transcript.ToolCallMeta{ToolName: "shell", Command: "pwd", CompactText: "pwd", IsShell: true}
 	events := []clientui.Event{
@@ -618,7 +618,7 @@ func TestProjectedConversationUpdatedEntriesAdvanceCommittedTranscriptAndDetailV
 		_ = collectCmdMessages(t, cmd)
 	}
 	m.forwardToView(tui.SetModeMsg{Mode: tui.ModeDetail, SkipDetailWarmup: true})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	cmd := m.runtimeAdapter().applyProjectedRuntimeEvent(clientui.Event{
 		Kind:                       clientui.EventConversationUpdated,

--- a/cli/app/ui_runtime_adapter_part5_test.go
+++ b/cli/app/ui_runtime_adapter_part5_test.go
@@ -846,8 +846,8 @@ func TestBootstrapRefreshRejectsStaleAuthoritativePageAfterLocalCommittedEvent(t
 	if got := updated.transcriptEntries[1].Text; got != "live commit" {
 		t.Fatalf("second transcript entry = %q, want live commit", got)
 	}
-	if strings.Count(stripANSIAndTrimRight(updated.view.OngoingCommittedSnapshot()), "live commit") != 1 {
-		t.Fatalf("expected live commit exactly once after stale bootstrap refresh, got %q", stripANSIAndTrimRight(updated.view.OngoingCommittedSnapshot()))
+	if strings.Count(stripANSIAndTrimRight(updated.view.CommittedOngoingProjection().Render(tui.TranscriptDivider)), "live commit") != 1 {
+		t.Fatalf("expected live commit exactly once after stale bootstrap refresh, got %q", stripANSIAndTrimRight(updated.view.CommittedOngoingProjection().Render(tui.TranscriptDivider)))
 	}
 }
 

--- a/cli/app/ui_runtime_adapter_part6_test.go
+++ b/cli/app/ui_runtime_adapter_part6_test.go
@@ -138,7 +138,7 @@ func TestProjectedAssistantMessageReplacesNonTailCommittedRangeWithoutHydration(
 	m.transcriptRevision = 10
 	m.transcriptTotalEntries = len(m.transcriptEntries)
 	m.forwardToView(tui.SetConversationMsg{BaseOffset: 0, TotalEntries: len(m.transcriptEntries), Entries: m.transcriptEntries})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	cmd := m.runtimeAdapter().applyProjectedRuntimeEvent(clientui.Event{
 		Kind:                       clientui.EventAssistantMessage,

--- a/cli/app/ui_runtime_adapter_part6_test.go
+++ b/cli/app/ui_runtime_adapter_part6_test.go
@@ -168,7 +168,7 @@ func TestProjectedAssistantMessageReplacesNonTailCommittedRangeWithoutHydration(
 	if got := m.transcriptEntries[2].Role; got != "reviewer_status" {
 		t.Fatalf("suffix role = %q, want reviewer_status", got)
 	}
-	committed := stripANSIAndTrimRight(m.view.OngoingCommittedSnapshot())
+	committed := stripANSIAndTrimRight(m.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 	if !containsInOrder(committed, "seed", "reviewed final", "Supervisor ran: no changes.") {
 		t.Fatalf("expected committed ongoing surface to keep reviewer suffix after assistant replacement, got %q", committed)
 	}

--- a/cli/app/ui_runtime_adapter_test.go
+++ b/cli/app/ui_runtime_adapter_test.go
@@ -290,7 +290,7 @@ func TestRuntimeAdapterRunStartAppliesPendingInputBeforeActivityEffect(t *testin
 
 	_ = m.runtimeAdapter().applyProjectedRuntimeEvent(clientui.Event{
 		Kind:     clientui.EventRunStateChanged,
-		RunState: &clientui.RunState{Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn)},
+		RunState: &clientui.RunState{Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)},
 	}, true).cmd
 
 	if m.activity != uiActivityRunning {

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -486,7 +487,7 @@ func (c *sessionRuntimeClient) transcriptDiagnosticsEnabled() bool {
 	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.transcriptDiagnostics || transcriptdiag.EnabledForProcess(false)
+	return c.transcriptDiagnostics || transcriptdiag.Enabled(false, os.Getenv)
 }
 
 func (c *sessionRuntimeClient) notifyConnectionState(err error) {

--- a/cli/app/ui_runtime_control.go
+++ b/cli/app/ui_runtime_control.go
@@ -6,6 +6,7 @@ import (
 
 	"core/cli/app/internal/runtimeattach"
 	"core/shared/clientui"
+	"core/shared/serverapi"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/google/uuid"
@@ -417,7 +418,7 @@ func (m *uiModel) applyRuntimeControlDone(msg runtimeControlDoneMsg) tea.Cmd {
 		return sequenceCmds(m.appendLocalEntryWithNoticeID("system", "Thinking level set to "+m.thinkingLevel, ""), followUpCmd)
 	case runtimeControlSetFastMode:
 		m.fastModeEnabled = msg.enabled
-		status := fastModeToggleStatusMessage(m.fastModeEnabled, msg.changed)
+		status := serverapi.FastModeToggleStatusMessage(m.fastModeEnabled, msg.changed)
 		return sequenceCmds(m.sendTransientStatusWithNoticeID(status, uiStatusNoticeSuccess, transientStatusDuration, uiStatusNoticeReplace, ""), followUpCmd)
 	case runtimeControlSetReviewer:
 		nextMode := strings.TrimSpace(msg.mode)
@@ -426,15 +427,15 @@ func (m *uiModel) applyRuntimeControlDone(msg runtimeControlDoneMsg) tea.Cmd {
 		}
 		m.reviewerMode = nextMode
 		m.reviewerEnabled = nextMode != "off"
-		status := reviewerToggleStatusMessage(m.reviewerEnabled, nextMode, msg.changed)
+		status := serverapi.ReviewerToggleStatusMessage(m.reviewerEnabled, nextMode, msg.changed)
 		return sequenceCmds(m.sendTransientStatusWithNoticeID(status, uiStatusNoticeNeutral, transientStatusDuration, uiStatusNoticeReplace, ""), followUpCmd)
 	case runtimeControlSetAutoCompaction:
 		m.autoCompactionEnabled = msg.enabled
-		status := autoCompactionToggleStatusMessage(msg.enabled, msg.changed, msg.compactionMode)
+		status := serverapi.AutoCompactionToggleStatusMessage(msg.enabled, msg.changed, msg.compactionMode)
 		return sequenceCmds(m.inputController().appendSystemFeedbackWithMirroredStatus(status, uiStatusNoticeNeutral), followUpCmd)
 	case runtimeControlSetQuestions:
 		m.questionsEnabled = msg.enabled
-		status := questionsToggleStatusMessage(msg.enabled, msg.changed)
+		status := serverapi.QuestionsToggleStatusMessage(msg.enabled, msg.changed)
 		return sequenceCmds(m.sendTransientStatusWithNoticeID(status, uiStatusNoticeNeutral, transientStatusDuration, uiStatusNoticeReplace, ""), followUpCmd)
 	case runtimeControlInterrupt:
 		return followUpCmd

--- a/cli/app/ui_runtime_reducer.go
+++ b/cli/app/ui_runtime_reducer.go
@@ -42,27 +42,27 @@ func (r uiRuntimeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		return handledUIFeatureUpdate(next, cmd)
 	case runtimeConnectionStateChangedMsg:
 		m.observeRuntimeRequestResult(msg.err)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, waitRuntimeConnectionStateChange(m.runtimeConnectionEvents))
 	case runtimeLeaseRecoveryWarningMsg:
 		cmd := m.sendTransientStatusWithNoticeID(msg.text, uiStatusNoticeNeutral, transientStatusDuration, uiStatusNoticeReplace, "")
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, sequenceCmds(cmd, waitRuntimeLeaseRecoveryWarning(m.runtimeLeaseRecoveryWarning)))
 	case runtimeMainViewRefreshedMsg:
 		cmd := m.handleRuntimeMainViewRefreshed(msg)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	case runtimeTranscriptRefreshedMsg:
 		cmd := m.handleRuntimeTranscriptRefreshed(msg)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	case runtimeCommittedTranscriptSuffixRefreshedMsg:
 		cmd := m.handleRuntimeCommittedTranscriptSuffixRefreshed(msg)
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	case runtimeTranscriptRetryMsg:
 		if msg.token != m.runtimeTranscriptRetry {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		req := msg.req
@@ -70,11 +70,11 @@ func (r uiRuntimeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			req = runtimeTranscriptSyncRequestForPage(m.transcriptRequestForCurrentMode(), false, msg.syncCause, msg.recoveryCause)
 		}
 		cmd := m.startRuntimeTranscriptSyncRequest(req).cmd
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	case detailTranscriptLoadMsg:
 		cmd := m.startRuntimeTranscriptSyncRequest(runtimeTranscriptSyncRequestForPage(m.transcriptRequestForCurrentMode(), true, runtimeTranscriptSyncCauseManualTranscriptRefresh, clientui.TranscriptRecoveryCauseNone)).cmd
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, cmd)
 	}
 	return uiFeatureUpdateResult{}

--- a/cli/app/ui_runtime_status_test.go
+++ b/cli/app/ui_runtime_status_test.go
@@ -392,7 +392,7 @@ func TestRuntimeMainViewActiveRunSeedsBusyGoalState(t *testing.T) {
 			SessionID: "session-1",
 			StepID:    "step-1",
 			Status:    clientui.RunStatusRunning,
-			Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeGoalLoop),
+			Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeGoalLoop),
 		},
 	}}
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents(), WithUISessionID("session-1"))

--- a/cli/app/ui_scroll_keys_test.go
+++ b/cli/app/ui_scroll_keys_test.go
@@ -42,7 +42,7 @@ func TestDetailModeUpDownScrollTranscript(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.termWidth = 80
 	m.termHeight = 8
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	for i := 0; i < 16; i++ {
 		m.forwardToView(tui.AppendTranscriptMsg{Role: "assistant", Text: fmt.Sprintf("line %d", i)})
@@ -73,7 +73,7 @@ func TestDetailModeLineScrollRoundTripsScrollAndSelectionState(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.termWidth = 80
 	m.termHeight = 8
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	for idx := 0; idx < 20; idx++ {
 		m.forwardToView(tui.AppendTranscriptMsg{Role: "assistant", Text: fmt.Sprintf("state entry %02d", idx)})
@@ -104,7 +104,7 @@ func TestDetailModeCompactExpansionRoutesThroughUIModel(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.termWidth = 80
 	m.termHeight = 12
-	m.syncViewport()
+	m.layout().syncViewport()
 	m.forwardToView(tui.AppendTranscriptMsg{
 		Role:       "tool_call",
 		Text:       "cat large.txt",
@@ -133,7 +133,7 @@ func TestDetailModeStatusLineShowsSelectedExpansionAction(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.termWidth = 80
 	m.termHeight = 12
-	m.syncViewport()
+	m.layout().syncViewport()
 	m.forwardToView(tui.AppendTranscriptMsg{
 		Role:       "tool_call",
 		Text:       "cat large.txt",
@@ -159,7 +159,7 @@ func TestDetailModeStatusLineFallsBackWhenSelectionIsNotExpandable(t *testing.T)
 	m := newProjectedStaticUIModel()
 	m.termWidth = 80
 	m.termHeight = 8
-	m.syncViewport()
+	m.layout().syncViewport()
 	errorLines := make([]string, 0, 16)
 	for idx := 0; idx < 16; idx++ {
 		errorLines = append(errorLines, fmt.Sprintf("non expandable error line %02d", idx))
@@ -199,7 +199,7 @@ func TestDetailModeEnterOnShortSelectedMessageDoesNotShowExpansionHintOrMutateSt
 	m := newProjectedStaticUIModel()
 	m.termWidth = 80
 	m.termHeight = 8
-	m.syncViewport()
+	m.layout().syncViewport()
 	m.forwardToView(tui.AppendTranscriptMsg{Role: "user", Text: "short user"})
 	m.forwardToView(tui.AppendTranscriptMsg{Role: "assistant", Text: "short assistant"})
 	m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyShiftTab})
@@ -222,7 +222,7 @@ func TestDetailModeArrowScrollsDetailByLineAndTracksCenterSelection(t *testing.T
 	m := newProjectedStaticUIModel()
 	m.termWidth = 80
 	m.termHeight = 8
-	m.syncViewport()
+	m.layout().syncViewport()
 	m.forwardToView(tui.AppendTranscriptMsg{
 		Role:       "tool_call",
 		Text:       "first-command",
@@ -300,7 +300,7 @@ func TestDetailModeReviewerSuggestionsCollapseAndExpandThroughUIModel(t *testing
 	m := newProjectedStaticUIModel()
 	m.termWidth = 80
 	m.termHeight = 12
-	m.syncViewport()
+	m.layout().syncViewport()
 	m.forwardToView(tui.AppendTranscriptMsg{
 		Role:        "reviewer_suggestions",
 		Text:        "Supervisor suggested:\n1. Add app-level coverage.\n2. Rebuild before final answer.",
@@ -327,7 +327,7 @@ func TestDetailModeEnterRoutesThroughInputControllerWhenInputLocked(t *testing.T
 	m := newProjectedStaticUIModel()
 	m.termWidth = 80
 	m.termHeight = 12
-	m.syncViewport()
+	m.layout().syncViewport()
 	m.input = "locked draft"
 	m.setInputSubmitLocked(true)
 	m.lockedInjectText = "locked draft"
@@ -360,7 +360,7 @@ func TestDetailModeEnterDoesNotRequestTranscriptPage(t *testing.T) {
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
 	m.termWidth = 80
 	m.termHeight = 12
-	m.syncViewport()
+	m.layout().syncViewport()
 	for idx := 0; idx < 4; idx++ {
 		m.forwardToView(tui.AppendTranscriptMsg{Role: "assistant", Text: fmt.Sprintf("entry %02d\nhidden", idx)})
 	}
@@ -387,7 +387,7 @@ func TestDetailModeMouseWheelScrollTranscript(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.termWidth = 80
 	m.termHeight = 8
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	for i := 0; i < 16; i++ {
 		m.forwardToView(tui.AppendTranscriptMsg{Role: "assistant", Text: fmt.Sprintf("line %d", i)})
@@ -419,7 +419,7 @@ func TestDetailModeUpAfterBottomScrollbackWalksHighlightOneVisualLine(t *testing
 	m := newProjectedStaticUIModel()
 	m.termWidth = 80
 	m.termHeight = 8
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	for idx := 0; idx < 24; idx++ {
 		m.forwardToView(tui.AppendTranscriptMsg{Role: "assistant", Text: fmt.Sprintf("line %02d", idx)})
@@ -463,7 +463,7 @@ func TestDetailModeScrollThenEnterExpandsCenterSelectedItem(t *testing.T) {
 			m := newProjectedStaticUIModel()
 			m.termWidth = 80
 			m.termHeight = 8
-			m.syncViewport()
+			m.layout().syncViewport()
 
 			for idx := 0; idx < 8; idx++ {
 				callID := fmt.Sprintf("call_%d", idx)
@@ -501,7 +501,7 @@ func TestRollbackSelectionInDetailUsesPagedDetailWindow(t *testing.T) {
 	}))
 	m.termWidth = 80
 	m.termHeight = 10
-	m.syncViewport()
+	m.layout().syncViewport()
 	detailPage := clientui.TranscriptPage{
 		Offset:       100,
 		TotalEntries: 104,
@@ -575,7 +575,7 @@ func TestRollbackForkSubmissionUsesPagedDetailAbsoluteIndex(t *testing.T) {
 	}))
 	m.termWidth = 80
 	m.termHeight = 10
-	m.syncViewport()
+	m.layout().syncViewport()
 	detailPage := clientui.TranscriptPage{
 		Offset:       40,
 		TotalEntries: 44,
@@ -633,7 +633,7 @@ func TestRollbackSelectionPagesBeforeCompactionTail(t *testing.T) {
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
 	m.termWidth = 80
 	m.termHeight = 10
-	m.syncViewport()
+	m.layout().syncViewport()
 	tailEntries := make([]clientui.ChatEntry, 60)
 	for idx := range tailEntries {
 		tailEntries[idx] = clientui.ChatEntry{Role: "assistant", Text: fmt.Sprintf("post-compaction answer %03d", idx)}
@@ -739,7 +739,7 @@ func TestRollbackSelectionPagesToFirstUserAcrossTrimmedDetailWindow(t *testing.T
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
 	m.termWidth = 80
 	m.termHeight = 10
-	m.syncViewport()
+	m.layout().syncViewport()
 	tailEntries := make([]clientui.ChatEntry, 252)
 	for idx := range tailEntries {
 		absolute := 1250 + idx
@@ -809,7 +809,7 @@ func TestRollbackTransitionsUseFixedDetailAltScreen(t *testing.T) {
 		)
 		m.termWidth = 80
 		m.termHeight = 10
-		m.syncViewport()
+		m.layout().syncViewport()
 
 		m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyEsc})
 		next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
@@ -859,7 +859,7 @@ func TestRollbackTransitionsUseFixedDetailAltScreen(t *testing.T) {
 		)
 		m.termWidth = 80
 		m.termHeight = 10
-		m.syncViewport()
+		m.layout().syncViewport()
 		m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyShiftTab})
 		if m.view.Mode() != tui.ModeDetail || m.altScreenActive != altOnEntry {
 			t.Fatalf("unexpected detail state before picker: mode=%q alt=%t", m.view.Mode(), m.altScreenActive)
@@ -895,7 +895,7 @@ func TestUpDownRouteByTranscriptMode(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUIPromptHistory([]string{"hello"}))
 	m.termWidth = 80
 	m.termHeight = 8
-	m.syncViewport()
+	m.layout().syncViewport()
 	for i := 0; i < 20; i++ {
 		m.forwardToView(tui.AppendTranscriptMsg{Role: "assistant", Text: fmt.Sprintf("line %d", i)})
 	}
@@ -995,7 +995,7 @@ func TestMainInputUpDownAtBoundsStayInInput(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.termWidth = 80
 	m.termHeight = 8
-	m.syncViewport()
+	m.layout().syncViewport()
 	for i := 0; i < 20; i++ {
 		m.forwardToView(tui.AppendTranscriptMsg{Role: "assistant", Text: fmt.Sprintf("line %d", i)})
 	}
@@ -1048,7 +1048,7 @@ func TestReviewerRunStillAllowsEditingWithoutTranscriptScroll(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.termWidth = 80
 	m.termHeight = 8
-	m.syncViewport()
+	m.layout().syncViewport()
 	for i := 0; i < 20; i++ {
 		m.forwardToView(tui.AppendTranscriptMsg{Role: "assistant", Text: fmt.Sprintf("line %d", i)})
 	}

--- a/cli/app/ui_slash_command_picker.go
+++ b/cli/app/ui_slash_command_picker.go
@@ -342,7 +342,7 @@ func (m *uiModel) navigateSlashCommandPicker(delta int) bool {
 	}
 	nextSelection := clampSlashPickerIndex(state.selection+delta, 0, len(state.matches)-1)
 	m.slashCommandSelection = nextSelection
-	m.invalidateMainInputDraftToken()
+	m.mainInputDraftToken = nextNonZeroToken(m.mainInputDraftToken)
 	m.input = "/" + state.matches[nextSelection].Name
 	m.inputCursor = -1
 	m.refreshPathReferenceFromInput()

--- a/cli/app/ui_terminal_cursor_test.go
+++ b/cli/app/ui_terminal_cursor_test.go
@@ -310,7 +310,7 @@ func TestUITerminalCursorPlacementTracksWrappedOngoingInputAcrossWidthChanges(t 
 	m.windowSizeKnown = true
 	m.input = "alpha beta gamma delta epsilon"
 	m.inputCursor = -1
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	view := m.View()
 	assertRenderedLinesFitWidth(t, view, m.termWidth)
@@ -329,7 +329,7 @@ func TestUITerminalCursorPlacementTracksWrappedOngoingInputAcrossWidthChanges(t 
 	}
 
 	m.termWidth = 16
-	m.syncViewport()
+	m.layout().syncViewport()
 	view = m.View()
 	assertRenderedLinesFitWidth(t, view, m.termWidth)
 	narrow, ok := state.Snapshot()
@@ -353,7 +353,7 @@ func TestUITerminalCursorPlacementTracksWrappedAltScreenInputAcrossWidthChanges(
 	m.altScreenActive = true
 	m.input = "one two three four five six"
 	m.inputCursor = -1
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	view := m.View()
 	assertRenderedLinesFitWidth(t, view, m.termWidth)
@@ -366,7 +366,7 @@ func TestUITerminalCursorPlacementTracksWrappedAltScreenInputAcrossWidthChanges(
 	}
 
 	m.termWidth = 18
-	m.syncViewport()
+	m.layout().syncViewport()
 	view = m.View()
 	assertRenderedLinesFitWidth(t, view, m.termWidth)
 	narrow, ok := state.Snapshot()
@@ -392,7 +392,7 @@ func TestMainInputCursorUsesSharedFieldDisplayWidth(t *testing.T) {
 	m.windowSizeKnown = true
 	m.input = "ab👍cd"
 	m.inputCursor = 3
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	cursor := m.layout().inputPaneCursor(m.termWidth)
 	if !cursor.Visible {
@@ -418,7 +418,7 @@ func TestAskInputCursorUsesSharedFieldDisplayWidth(t *testing.T) {
 	testSetActiveAsk(m, &askEvent{req: clientui.PendingPromptEvent{Question: "Question?"}, reply: reply})
 	m.ask.input = "ab👍cd"
 	m.ask.inputCursor = 3
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	cursor := m.layout().inputPaneCursor(m.termWidth)
 	if !cursor.Visible {
@@ -442,7 +442,7 @@ func TestTerminalCursorHiddenWhenInputLocked(t *testing.T) {
 	m.windowSizeKnown = true
 	m.setInputSubmitLocked(true)
 	m.input = "locked"
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	view := m.View()
 	assertRenderedLinesFitWidth(t, view, m.termWidth)
@@ -458,7 +458,7 @@ func TestViewDoesNotAppendHideCursorWhenRealTerminalCursorVisible(t *testing.T) 
 	m.termHeight = 10
 	m.windowSizeKnown = true
 	m.input = "visible cursor"
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	view := m.View()
 	assertRenderedLinesFitWidth(t, view, m.termWidth)
@@ -476,12 +476,12 @@ func TestRealCursorFrameChangesWhenOnlyInputSpacesMoveCursor(t *testing.T) {
 	m.termWidth = 24
 	m.termHeight = 10
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	emptyView := m.View()
 	m.input = " "
 	m.inputCursor = -1
-	m.syncViewport()
+	m.layout().syncViewport()
 	spaceView := m.View()
 	if emptyView == spaceView {
 		t.Fatal("expected real-cursor frame to change when only trailing spaces move cursor")
@@ -502,14 +502,14 @@ func TestRealCursorFrameChangesAfterTypingEachSpace(t *testing.T) {
 	m.termWidth = 24
 	m.termHeight = 10
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 	previous := m.View()
 
 	for i := range 3 {
 		next, _ := model.Update(tea.KeyMsg{Type: tea.KeySpace})
 		model = next
 		updated := model.(*uiModel)
-		updated.syncViewport()
+		updated.layout().syncViewport()
 		current := updated.View()
 		if current == previous {
 			t.Fatalf("view did not change after typing space %d", i+1)
@@ -534,7 +534,7 @@ func TestRealCursorFrameMarkerNotRenderedWithoutRealCursor(t *testing.T) {
 	m.termHeight = 10
 	m.windowSizeKnown = true
 	m.input = " "
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	view := m.View()
 	if strings.Contains(view, realCursorFrameMarker(1)) {
@@ -555,7 +555,7 @@ func TestRealCursorFrameMarkerNotRenderedInDetailMode(t *testing.T) {
 	m.termHeight = 10
 	m.windowSizeKnown = true
 	m.forwardToView(tui.SetModeMsg{Mode: tui.ModeDetail})
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	view := m.View()
 	if strings.Contains(view, realCursorFrameMarker(1)) {

--- a/cli/app/ui_test.go
+++ b/cli/app/ui_test.go
@@ -634,7 +634,7 @@ func TestDetailModeHidesInputBox(t *testing.T) {
 	m.termWidth = 80
 	m.termHeight = 16
 	m.input = "draft input should be hidden"
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
 	updated := next.(*uiModel)
@@ -659,7 +659,7 @@ func TestDetailModeStatusLineOmitsModeLabel(t *testing.T) {
 	m.termHeight = 16
 	m.windowSizeKnown = true
 	m.status.snapshot.Git = uiStatusGitInfo{Visible: true, Branch: "detail-mode-v2"}
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
 	updated := next.(*uiModel)
@@ -698,7 +698,7 @@ func TestAskQuestionLargeMarkdownPromptPreservesLogicalLines(t *testing.T) {
 	m.termWidth = 72
 	m.termHeight = 24
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 	testSetActiveAsk(m, &askEvent{req: clientui.PendingPromptEvent{Question: question}, reply: make(chan askReply, 1)})
 
 	wrapped, _ := m.layout().wrappedAskPromptLines(64)
@@ -735,7 +735,7 @@ func TestAskQuestionPickerQuestionLinesWrapInsteadOfEllipsizing(t *testing.T) {
 	m.termWidth = 40
 	m.termHeight = 12
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 	testSetActiveAsk(m, &askEvent{req: clientui.PendingPromptEvent{
 		Question: "This question is intentionally far too long to fit in the live ask input area on one line.",
 		Suggestions: []string{
@@ -768,7 +768,7 @@ func TestAskQuestionFreeformPromptQuestionLinesWrapInsteadOfEllipsizing(t *testi
 	m.termWidth = 40
 	m.termHeight = 12
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 	testSetActiveAsk(m, &askEvent{req: clientui.PendingPromptEvent{
 		Question: "This question is intentionally far too long to fit in the live ask input area on one line.",
 	}, reply: make(chan askReply, 1)})
@@ -801,7 +801,7 @@ func TestAskQuestionMarkdownPromptCursorTracksInputAfterExpandedQuestion(t *test
 	m.termWidth = 72
 	m.termHeight = 12
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 	testSetActiveAsk(m, &askEvent{req: clientui.PendingPromptEvent{Question: question}, reply: make(chan askReply, 1)})
 	m.ask.input = "typed"
 	m.ask.inputCursor = len([]rune(m.ask.input))
@@ -893,7 +893,7 @@ func TestRollbackSelectionHighlightsSelectedMessageFullWidth(t *testing.T) {
 	m.termWidth = 80
 	m.termHeight = 16
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	updated := next.(*uiModel)

--- a/cli/app/ui_test.go
+++ b/cli/app/ui_test.go
@@ -147,7 +147,7 @@ func TestCustomKeyShiftEnterThenEnterDoesNotSubmitTrailingNewline(t *testing.T) 
 	if !updated.isBusy() {
 		t.Fatal("expected submission started")
 	}
-	snapshot := stripANSIAndTrimRight(updated.view.OngoingCommittedSnapshot())
+	snapshot := stripANSIAndTrimRight(updated.view.CommittedOngoingProjection().Render(tui.TranscriptDivider))
 	if strings.Contains(snapshot, "❯ hello\n\n") {
 		t.Fatalf("expected submitted user message without trailing blank line, got %q", snapshot)
 	}

--- a/cli/app/ui_transcript_sync_recovery_test.go
+++ b/cli/app/ui_transcript_sync_recovery_test.go
@@ -48,7 +48,7 @@ func TestSessionActivityGapRecoveryEventuallyHydratesCommittedTranscriptInBothMo
 	m.termWidth = 90
 	m.termHeight = 16
 	m.windowSizeKnown = true
-	m.syncViewport()
+	m.layout().syncViewport()
 
 	evt := waitSessionActivityEvent(t, events)
 	if evt.Kind != clientui.EventStreamGap {

--- a/cli/app/ui_window_reducer.go
+++ b/cli/app/ui_window_reducer.go
@@ -26,7 +26,7 @@ func (r uiWindowFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		m.termWidth = msg.Width
 		m.termHeight = msg.Height
 		m.windowSizeKnown = true
-		m.syncViewport()
+		m.layout().syncViewport()
 		if previousWidth > 0 && previousWidth != msg.Width {
 			m.nativeStreamingController.Configure(m.nativeStreamingController.theme, msg.Width)
 			m.nativeStreamingWidth = msg.Width

--- a/cli/app/ui_worktree_reducer.go
+++ b/cli/app/ui_worktree_reducer.go
@@ -20,34 +20,34 @@ func (r uiWorktreeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 	switch msg := msg.(type) {
 	case worktreeListDoneMsg:
 		if !m.worktrees.open || msg.token != m.worktrees.refreshToken {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		m.worktrees.loading = false
 		if msg.err != nil {
 			m.worktrees.errorText = runtimeattach.FormatSubmissionError(msg.err)
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, m.reconcileSpinnerTicking(false))
 		}
 		m.worktrees.errorText = ""
 		m.applyWorktreeListResponse(msg.resp)
 		cmd := m.applyWorktreeIntent()
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, tea.Batch(cmd, m.reconcileSpinnerTicking(false)))
 	case worktreeCreateDoneMsg:
 		if msg.token != m.worktrees.mutationToken {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		m.worktrees.create.submitting = false
 		if msg.err != nil {
 			if !m.worktrees.open {
 				status := runtimeattach.FormatSubmissionError(msg.err)
-				m.syncViewport()
+				m.layout().syncViewport()
 				return handledUIFeatureUpdate(m, m.sendTransientStatusWithNoticeID(status, uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, ""))
 			}
 			m.worktrees.create.errorText = runtimeattach.FormatSubmissionError(msg.err)
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, m.reconcileSpinnerTicking(false))
 		}
 		var overlayCmd tea.Cmd
@@ -60,11 +60,11 @@ func (r uiWorktreeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			status += " and started setup"
 		}
 		feedbackCmd := m.sendTransientStatusWithNoticeID(status, uiStatusNoticeSuccess, transientStatusDuration, uiStatusNoticeReplace, "")
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, tea.Batch(overlayCmd, feedbackCmd, m.startRuntimeMainViewRefreshRequest(runtimeMainViewRefreshRequestForCause(runtimeMainViewRefreshCauseWorktreeMutation)).cmd, m.reconcileSpinnerTicking(false)))
 	case worktreeSwitchDoneMsg:
 		if msg.token != m.worktrees.switchToken {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		m.worktrees.switchPending = false
@@ -73,11 +73,11 @@ func (r uiWorktreeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			followUp = m.takeQueuedWorktreeSwitchCmd()
 			if !m.worktrees.open {
 				status := runtimeattach.FormatSubmissionError(msg.err)
-				m.syncViewport()
+				m.layout().syncViewport()
 				return handledUIFeatureUpdate(m, tea.Batch(m.sendTransientStatusWithNoticeID(status, uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, ""), followUp))
 			}
 			m.worktrees.errorText = runtimeattach.FormatSubmissionError(msg.err)
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, tea.Batch(followUp, m.reconcileSpinnerTicking(false)))
 		}
 		var overlayCmd tea.Cmd
@@ -88,22 +88,22 @@ func (r uiWorktreeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 		status := "Switched to " + worktreeui.DisplayName(msg.resp.Worktree)
 		feedbackCmd := m.sendTransientStatusWithNoticeID(status, uiStatusNoticeSuccess, transientStatusDuration, uiStatusNoticeReplace, "")
 		followUp = m.takeQueuedWorktreeSwitchCmd()
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, tea.Batch(overlayCmd, feedbackCmd, m.startRuntimeMainViewRefreshRequest(runtimeMainViewRefreshRequestForCause(runtimeMainViewRefreshCauseWorktreeMutation)).cmd, followUp, m.reconcileSpinnerTicking(false)))
 	case worktreeDeleteDoneMsg:
 		if msg.token != m.worktrees.mutationToken {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		m.worktrees.deleteConfirm.submitting = false
 		if msg.err != nil {
 			if !m.worktrees.open {
 				status := runtimeattach.FormatSubmissionError(msg.err)
-				m.syncViewport()
+				m.layout().syncViewport()
 				return handledUIFeatureUpdate(m, m.sendTransientStatusWithNoticeID(status, uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, ""))
 			}
 			m.worktrees.deleteConfirm.errorText = runtimeattach.FormatSubmissionError(msg.err)
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, m.reconcileSpinnerTicking(false))
 		}
 		var listCmd tea.Cmd
@@ -113,24 +113,24 @@ func (r uiWorktreeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			listCmd = m.requestWorktreeListCmd()
 		}
 		feedbackCmd := m.sendTransientStatusWithNoticeID(worktreeDeleteSuccessStatus(msg.resp), uiStatusNoticeSuccess, transientStatusDuration, uiStatusNoticeReplace, "")
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, tea.Batch(feedbackCmd, listCmd, m.startRuntimeMainViewRefreshRequest(runtimeMainViewRefreshRequestForCause(runtimeMainViewRefreshCauseWorktreeMutation)).cmd, m.reconcileSpinnerTicking(false)))
 	case worktreeCreateTargetResolveDebounceMsg:
 		if !m.worktrees.open || m.worktrees.phase != uiWorktreeOverlayPhaseCreate {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		state, outcome := worktreeui.DebounceReady(m.worktrees.create.resolveState(), msg.token, m.worktrees.create.branchTarget.Text())
 		m.worktrees.create.applyResolveState(state)
 		if outcome.Ignored || !outcome.Start {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
-		m.syncViewport()
+		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, m.worktreeCreateTargetResolveCmd(outcome.Query, outcome.Token))
 	case worktreeCreateTargetResolveDoneMsg:
 		if !m.worktrees.open || m.worktrees.phase != uiWorktreeOverlayPhaseCreate {
-			m.syncViewport()
+			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
 		errorText := ""
@@ -146,12 +146,12 @@ func (r uiWorktreeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			ErrorText:     errorText,
 		})
 		m.worktrees.create.applyResolveState(state)
-		m.syncViewport()
+		m.layout().syncViewport()
 		if outcome.Submit {
 			req, err := worktreeui.Request(m.worktrees.create.branchTarget.Text(), m.worktrees.create.baseRef.Text(), outcome.SubmitKind)
 			if err != nil {
 				m.worktrees.create.errorText = err.Error()
-				m.syncViewport()
+				m.layout().syncViewport()
 				return handledUIFeatureUpdate(m, nil)
 			}
 			return handledUIFeatureUpdate(m, m.worktreeCreateCmd(req))

--- a/cli/app/workspace_registration_test.go
+++ b/cli/app/workspace_registration_test.go
@@ -162,7 +162,7 @@ func createAuthoritativeAppSession(t *testing.T, persistenceRoot string, workspa
 	// Keep the metadata store alive for the lifetime of the session store so
 	// persistence observer writes continue to succeed during the test.
 	store, err := session.Create(
-		config.ProjectSessionsRoot(config.App{PersistenceRoot: persistenceRoot}, binding.ProjectID),
+		filepath.Join(filepath.Join(config.App{PersistenceRoot: persistenceRoot}.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 		filepath.Base(filepath.Clean(workspaceRoot)),
 		workspaceRoot,
 		metadataStore.AuthoritativeSessionStoreOptions()...,

--- a/cli/kent/binding_commands_test.go
+++ b/cli/kent/binding_commands_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -190,7 +191,7 @@ func newBindingCommandSession(t *testing.T, workspace string) (*metadata.Store, 
 		t.Fatalf("RegisterBinding oldWorkspace: %v", err)
 	}
 	sess, err := session.Create(
-		config.ProjectSessionsRoot(cfg, binding.ProjectID),
+		filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 		filepath.Base(cfg.WorkspaceRoot),
 		cfg.WorkspaceRoot,
 		store.AuthoritativeSessionStoreOptions()...,
@@ -230,7 +231,7 @@ func startBindingCommandServer(t *testing.T, workspace string) func() {
 	if err != nil {
 		t.Fatalf("config.Load server workspace: %v", err)
 	}
-	serverstartup.ReleaseTestListenReservation(config.ServerListenAddress(cfg))
+	serverstartup.ReleaseTestListenReservation(net.JoinHostPort(cfg.Settings.ServerHost, strconv.Itoa(cfg.Settings.ServerPort)))
 	srv, err := serverstartup.StartServeServer(context.Background(), serverstartup.Request{WorkspaceRoot: workspace, WorkspaceRootExplicit: true, Model: "gpt-5"}, bindingCommandMemoryAuthHandler{state: auth.State{
 		Scope:     auth.ScopeGlobal,
 		Method:    auth.Method{Type: auth.MethodAPIKey, APIKey: &auth.APIKeyMethod{Key: "test-key"}},

--- a/cli/kent/goal_command_test.go
+++ b/cli/kent/goal_command_test.go
@@ -314,7 +314,7 @@ func TestGoalCommandSubprocessTargetsLiveSessionFromUnboundWorktree(t *testing.T
 		t.Fatalf("RegisterWorkspaceBinding: %v", err)
 	}
 	store, err := session.Create(
-		config.ProjectSessionsRoot(cfg, binding.ProjectID),
+		filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 		filepath.Base(cfg.WorkspaceRoot),
 		cfg.WorkspaceRoot,
 		metadataStore.AuthoritativeSessionStoreOptions()...,
@@ -459,7 +459,7 @@ func TestGoalCommandSubprocessSetPersistsWhilePrimaryRunActive(t *testing.T) {
 		t.Fatalf("RegisterWorkspaceBinding: %v", err)
 	}
 	store, err := session.Create(
-		config.ProjectSessionsRoot(cfg, binding.ProjectID),
+		filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 		filepath.Base(cfg.WorkspaceRoot),
 		cfg.WorkspaceRoot,
 		metadataStore.AuthoritativeSessionStoreOptions()...,

--- a/cli/kent/service_backend_darwin.go
+++ b/cli/kent/service_backend_darwin.go
@@ -119,7 +119,7 @@ func (launchdServiceBackend) Start(ctx context.Context, spec serviceSpec) error 
 	if loaded, _ := launchdLoaded(ctx); !loaded {
 		return bootstrapLaunchdService(ctx, spec, path)
 	}
-	_, err = runServiceCommand(ctx, "launchctl", "kickstart", "-k", launchdDomain()+"/"+serviceLaunchdLabel)
+	_, err = runServiceCommand(ctx, "launchctl", "kickstart", "-k", fmt.Sprintf("gui/%d", os.Getuid())+"/"+serviceLaunchdLabel)
 	return err
 }
 
@@ -127,7 +127,7 @@ func (launchdServiceBackend) Stop(ctx context.Context, spec serviceSpec) error {
 	if loaded, _ := launchdLoaded(ctx); !loaded {
 		return nil
 	}
-	_, err := runServiceCommand(ctx, "launchctl", "bootout", launchdDomain()+"/"+serviceLaunchdLabel)
+	_, err := runServiceCommand(ctx, "launchctl", "bootout", fmt.Sprintf("gui/%d", os.Getuid())+"/"+serviceLaunchdLabel)
 	return err
 }
 
@@ -181,7 +181,7 @@ func (launchdServiceBackend) Status(ctx context.Context, spec serviceSpec) (serv
 func reloadLaunchdService(ctx context.Context, spec serviceSpec, path string) error {
 	verifyStartup := false
 	if loaded, _ := launchdLoaded(ctx); loaded {
-		if _, err := runServiceCommand(ctx, "launchctl", "bootout", launchdDomain()+"/"+serviceLaunchdLabel); err != nil {
+		if _, err := runServiceCommand(ctx, "launchctl", "bootout", fmt.Sprintf("gui/%d", os.Getuid())+"/"+serviceLaunchdLabel); err != nil {
 			return err
 		}
 		if err := waitForLaunchdServiceShutdown(ctx, spec); err != nil {
@@ -330,7 +330,7 @@ func waitForLaunchdServiceShutdown(ctx context.Context, spec serviceSpec) error 
 }
 
 func bootstrapLaunchdService(ctx context.Context, spec serviceSpec, path string) error {
-	if _, err := runServiceCommand(ctx, "launchctl", "bootstrap", launchdDomain(), path); err != nil {
+	if _, err := runServiceCommand(ctx, "launchctl", "bootstrap", fmt.Sprintf("gui/%d", os.Getuid()), path); err != nil {
 		if !isTransientLaunchdBootstrapError(err) {
 			return err
 		}
@@ -348,14 +348,14 @@ func isTransientLaunchdBootstrapError(err error) bool {
 }
 
 func replaceStaleLaunchdService(ctx context.Context, spec serviceSpec, path string, cause error) error {
-	target := launchdDomain() + "/" + serviceLaunchdLabel
+	target := fmt.Sprintf("gui/%d", os.Getuid()) + "/" + serviceLaunchdLabel
 	if _, err := runServiceCommand(ctx, "launchctl", "bootout", target); err != nil {
 		return errors.Join(cause, err)
 	}
 	if err := waitForLaunchdServiceShutdown(ctx, spec); err != nil {
 		return errors.Join(cause, err)
 	}
-	if _, err := runServiceCommand(ctx, "launchctl", "bootstrap", launchdDomain(), path); err != nil {
+	if _, err := runServiceCommand(ctx, "launchctl", "bootstrap", fmt.Sprintf("gui/%d", os.Getuid()), path); err != nil {
 		return errors.Join(cause, err)
 	}
 	return nil
@@ -428,12 +428,8 @@ func launchdPlistPath() (string, error) {
 	return filepath.Join(home, "Library", "LaunchAgents", serviceLaunchdLabel+".plist"), nil
 }
 
-func launchdDomain() string {
-	return fmt.Sprintf("gui/%d", os.Getuid())
-}
-
 func launchdLoaded(ctx context.Context) (bool, string) {
-	result, err := runServiceCommand(ctx, "launchctl", "print", launchdDomain()+"/"+serviceLaunchdLabel)
+	result, err := runServiceCommand(ctx, "launchctl", "print", fmt.Sprintf("gui/%d", os.Getuid())+"/"+serviceLaunchdLabel)
 	if err != nil {
 		return false, strings.TrimSpace(strings.Join([]string{result.Stdout, result.Stderr}, "\n"))
 	}

--- a/cli/kent/service_command.go
+++ b/cli/kent/service_command.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -272,10 +273,10 @@ func ensureNoUnmanagedServerConflictForAction(ctx context.Context, backend servi
 			return nil
 		}
 		dialer := net.Dialer{Timeout: 500 * time.Millisecond}
-		conn, err := dialer.DialContext(ctx, "tcp", config.ServerListenAddress(spec.Config))
+		conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(spec.Config.Settings.ServerHost, strconv.Itoa(spec.Config.Settings.ServerPort)))
 		if err == nil {
 			_ = conn.Close()
-			return fmt.Errorf("server port %s is already in use, but it is not responding as "+config.Product+". Stop the process using that port before installing the background service", config.ServerListenAddress(spec.Config))
+			return fmt.Errorf("server port %s is already in use, but it is not responding as "+config.Product+". Stop the process using that port before installing the background service", net.JoinHostPort(spec.Config.Settings.ServerHost, strconv.Itoa(spec.Config.Settings.ServerPort)))
 		}
 	}
 	return nil

--- a/cli/kent/task_command.go
+++ b/cli/kent/task_command.go
@@ -1238,7 +1238,7 @@ func writeTaskDetail(stdout io.Writer, task serverapi.WorkflowTaskDetail) {
 	fmt.Fprintf(stdout, "Status: %s\n", taskDetailStatus(task))
 	fmt.Fprintf(stdout, "Project: %q (%s)\n", task.Project.DisplayName, task.Project.ProjectID)
 	fmt.Fprintf(stdout, "Workflow: %q (%s)\n", task.Workflow.DisplayName, task.Workflow.WorkflowID)
-	fmt.Fprintf(stdout, "Created at %s UTC\n", utcISO(task.Summary.CreatedAtUnixMs))
+	fmt.Fprintf(stdout, "Created at %s UTC\n", time.UnixMilli(task.Summary.CreatedAtUnixMs).UTC().Format(time.RFC3339))
 	if len(task.Runs) > 0 {
 		fmt.Fprintf(stdout, "Total agent runs: %d\n", len(task.Runs))
 	}
@@ -1298,7 +1298,7 @@ func writeTaskCommentBlocks(stdout io.Writer, sortedComments []serverapi.Workflo
 		if i > 0 {
 			fmt.Fprintln(stdout, "---")
 		}
-		fmt.Fprintf(stdout, "%s at %s UTC:\n%s\n", readableTaskCommentAuthor(comment), utcISO(comment.CreatedAtUnixMs), comment.Body)
+		fmt.Fprintf(stdout, "%s at %s UTC:\n%s\n", readableTaskCommentAuthor(comment), time.UnixMilli(comment.CreatedAtUnixMs).UTC().Format(time.RFC3339), comment.Body)
 	}
 }
 
@@ -1318,8 +1318,4 @@ func readableTaskCommentAuthor(comment serverapi.WorkflowTaskComment) string {
 		return "Unknown"
 	}
 	return strings.ToUpper(author[:1]) + author[1:]
-}
-
-func utcISO(unixMs int64) string {
-	return time.UnixMilli(unixMs).UTC().Format(time.RFC3339)
 }

--- a/cli/kent/workflow_command_test.go
+++ b/cli/kent/workflow_command_test.go
@@ -1750,7 +1750,7 @@ func newWorkflowCommandLoopback(t *testing.T) (config.App, metadata.Binding, *wo
 func createWorkflowCommandTestSession(t *testing.T, cfg config.App, binding metadata.Binding, metadataStore *metadata.Store) string {
 	t.Helper()
 	store, err := session.Create(
-		config.ProjectSessionsRoot(cfg, binding.ProjectID),
+		filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 		filepath.Base(cfg.WorkspaceRoot),
 		cfg.WorkspaceRoot,
 		metadataStore.AuthoritativeSessionStoreOptions()...,

--- a/cli/tui/detail_compact_test.go
+++ b/cli/tui/detail_compact_test.go
@@ -84,7 +84,7 @@ func TestCompactDetailToggleStartsWithMultilineTailBlockSelected(t *testing.T) {
 		t.Fatal("expected visible selectable detail entries")
 	}
 	want := visible[len(visible)-1]
-	owners := m.currentDetailViewport().Owners
+	owners := m.detailViewProjection().DetailViewport(m.currentDetailViewportState()).Owners
 	if !m.detailSelectedActive || m.detailSelectedEntry != want {
 		t.Fatalf("expected multiline tail block selected on detail open, got active=%v entry=%d want=%d visible=%+v owners=%+v", m.detailSelectedActive, m.detailSelectedEntry, want, visible, owners)
 	}
@@ -112,7 +112,7 @@ func TestCompactDetailViewportShrinkKeepsBottomSelectionVisible(t *testing.T) {
 	}
 	want := visible[len(visible)-1]
 	if !m.detailSelectedActive || m.detailSelectedEntry != want {
-		t.Fatalf("expected bottom visible entry selected after viewport shrink, got active=%v entry=%d want=%d visible=%+v owners=%+v", m.detailSelectedActive, m.detailSelectedEntry, want, visible, m.currentDetailViewport().Owners)
+		t.Fatalf("expected bottom visible entry selected after viewport shrink, got active=%v entry=%d want=%d visible=%+v owners=%+v", m.detailSelectedActive, m.detailSelectedEntry, want, visible, m.detailViewProjection().DetailViewport(m.currentDetailViewportState()).Owners)
 	}
 }
 
@@ -184,7 +184,7 @@ func TestCompactDetailSelectedSpacerRowsAreVisualOnlyWithTallExpandedEntry(t *te
 
 	beforeScroll := m.DetailScroll()
 	beforeFirst, beforeLast, beforeRangeOK := m.DetailVisibleEntryRange()
-	owners := m.currentDetailViewport().Owners
+	owners := m.detailViewProjection().DetailViewport(m.currentDetailViewportState()).Owners
 	if center <= 0 || center >= len(owners)-1 {
 		t.Fatalf("center line %d outside spacer assertion range, owners=%d", center, len(owners))
 	}

--- a/cli/tui/input/editor.go
+++ b/cli/tui/input/editor.go
@@ -276,10 +276,6 @@ func (e *Editor) CursorAtDisplayColumn(line LineRange, targetCol int) int {
 	return cursorAtDisplayColumn(e.text, line, targetCol)
 }
 
-func DisplayWidth(text string) int {
-	return uniseg.StringWidth(text)
-}
-
 func (e *Editor) replaceRange(start int, end int, replacement string) {
 	start = clampCursor(e.text, start)
 	end = clampCursor(e.text, end)

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -458,10 +458,6 @@ func (m Model) OngoingSnapshot() string {
 	return strings.Join(m.ongoingLines(), "\n")
 }
 
-func (m Model) OngoingCommittedSnapshot() string {
-	return m.CommittedOngoingProjection().Render(TranscriptDivider)
-}
-
 func (m Model) OngoingStreamingText() string {
 	return m.transcriptInput.Ongoing
 }

--- a/cli/tui/model.go
+++ b/cli/tui/model.go
@@ -277,7 +277,7 @@ func (m Model) LoadedTranscriptEntries() []TranscriptEntry {
 func (m Model) DetailVisibleEntryRange() (int, int, bool) {
 	first := -1
 	last := -1
-	for _, entryIndex := range m.currentDetailViewport().Owners {
+	for _, entryIndex := range m.detailViewProjection().DetailViewport(m.currentDetailViewportState()).Owners {
 		if entryIndex < 0 {
 			continue
 		}
@@ -424,7 +424,7 @@ func (m *Model) VisibleLineKinds() []VisibleLineKind {
 		return nil
 	}
 	if m.mode == ModeDetail {
-		return visibleKindsForViewport(m.currentDetailViewport().Kinds, m.viewportLines)
+		return visibleKindsForViewport(m.detailViewProjection().DetailViewport(m.currentDetailViewportState()).Kinds, m.viewportLines)
 	}
 	return m.visibleOngoingLineKinds()
 }
@@ -496,7 +496,7 @@ func (m Model) transitionMode(target Mode, skipDetailWarmup bool) Model {
 		}
 		m.refreshDetailViewport()
 		if m.compactDetail {
-			m.focusVisibleDetailEntry(len(m.currentDetailViewport().Owners) - 1)
+			m.focusVisibleDetailEntry(len(m.detailViewProjection().DetailViewport(m.currentDetailViewportState()).Owners) - 1)
 		}
 	case ModeOngoing:
 		m.mode = ModeOngoing
@@ -695,7 +695,7 @@ func (m Model) visibleDetailEntryLineRange(entryIndex int) (int, int, bool) {
 	}
 	first := -1
 	last := -1
-	for lineIndex, owner := range m.currentDetailViewport().Owners {
+	for lineIndex, owner := range m.detailViewProjection().DetailViewport(m.currentDetailViewportState()).Owners {
 		if owner != entryIndex {
 			continue
 		}
@@ -828,11 +828,7 @@ func (m Model) transcriptViewProjection() TranscriptViewProjection {
 	if m.viewProjector == nil {
 		return ProjectTranscriptViews(m.TranscriptProjectionInput(), m.TranscriptProjectionViewState())
 	}
-	return m.viewProjector.ProjectShared(m.transcriptProjectionInput(), m.TranscriptProjectionViewState())
-}
-
-func (m Model) currentDetailViewport() ProjectionViewport {
-	return m.detailViewProjection().DetailViewport(m.currentDetailViewportState())
+	return m.viewProjector.project(m.transcriptProjectionInput(), m.TranscriptProjectionViewState(), false)
 }
 
 func (m Model) currentDetailViewportState() ProjectionViewportState {

--- a/cli/tui/model_part4_test.go
+++ b/cli/tui/model_part4_test.go
@@ -23,13 +23,13 @@ func TestDetailProjectionViewportKeepsLineCountAcrossScrollUpdates(t *testing.T)
 	}})
 	m = updateModel(t, m, ToggleModeMsg{})
 
-	if len(m.currentDetailViewport().Lines) == 0 {
+	if len(m.detailViewProjection().DetailViewport(m.currentDetailViewportState()).Lines) == 0 {
 		t.Fatal("expected detail projection viewport lines on detail entry")
 	}
-	startLen := len(m.currentDetailViewport().Lines)
+	startLen := len(m.detailViewProjection().DetailViewport(m.currentDetailViewportState()).Lines)
 
 	m = updateModel(t, m, tea.KeyMsg{Type: tea.KeyDown})
-	if got := len(m.currentDetailViewport().Lines); got != startLen {
+	if got := len(m.detailViewProjection().DetailViewport(m.currentDetailViewportState()).Lines); got != startLen {
 		t.Fatalf("expected detail projection viewport length to stay stable across scroll updates, got %d want %d", got, startLen)
 	}
 }

--- a/cli/tui/model_reducer.go
+++ b/cli/tui/model_reducer.go
@@ -47,7 +47,7 @@ func (m *Model) reduce(msg tea.Msg) {
 	case FocusTranscriptEntryMsg:
 		m.reduceFocusTranscriptEntryMsg(msg)
 	case SetOngoingScrollMsg:
-		m.reduceSetOngoingScrollMsg(msg)
+		m.ongoingScroll = clamp(msg.Scroll, 0, m.maxOngoingScroll())
 	case StreamAssistantMsg:
 		m.reduceStreamAssistantMsg(msg, &result)
 	case ClearOngoingAssistantMsg:
@@ -393,7 +393,7 @@ func (m *Model) detailViewportAnchor() (int, int, bool) {
 	if m == nil || m.mode != ModeDetail || m.detailBottomAnchor {
 		return 0, 0, false
 	}
-	for _, entryIndex := range m.currentDetailViewport().Owners {
+	for _, entryIndex := range m.detailViewProjection().DetailViewport(m.currentDetailViewportState()).Owners {
 		if entryIndex < 0 {
 			continue
 		}
@@ -431,10 +431,6 @@ func (m *Model) reduceFocusTranscriptEntryMsg(msg FocusTranscriptEntryMsg) {
 			m.refreshDetailViewport()
 		}
 	}
-}
-
-func (m *Model) reduceSetOngoingScrollMsg(msg SetOngoingScrollMsg) {
-	m.ongoingScroll = clamp(msg.Scroll, 0, m.maxOngoingScroll())
 }
 
 func (m *Model) reduceStreamAssistantMsg(msg StreamAssistantMsg, result *modelUpdateResult) {
@@ -573,7 +569,7 @@ func (m *Model) applyUpdateResult(result modelUpdateResult, wasAtOngoingBottom b
 		}
 		m.refreshDetailViewport()
 		if result.viewportChanged && m.compactDetail && m.detailBottomAnchor {
-			m.focusVisibleDetailEntry(len(m.currentDetailViewport().Owners) - 1)
+			m.focusVisibleDetailEntry(len(m.detailViewProjection().DetailViewport(m.currentDetailViewportState()).Owners) - 1)
 		}
 	}
 }

--- a/cli/tui/model_rendering.go
+++ b/cli/tui/model_rendering.go
@@ -94,7 +94,7 @@ func (m Model) buildTranscriptBlocks(opts transcriptBlockOptions) []ongoingBlock
 		entry := m.transcriptInput.Entries[idx]
 		role := TranscriptRoleFromWire(string(entry.Role))
 		intent := role.DisplayIntent(entry.Phase)
-		if opts.mode == transcriptBlockModeOngoing && skipInOngoing(entry) {
+		if opts.mode == transcriptBlockModeOngoing && !isVisibleInOngoing(entry) {
 			continue
 		}
 		block, ok := m.entryBlock(idx, entry, role, intent, consumedResults, resultIndex, opts)

--- a/cli/tui/model_rendering_tools.go
+++ b/cli/tui/model_rendering_tools.go
@@ -28,10 +28,6 @@ func normalizeOngoingDividerRole(role RenderIntent) RenderIntent {
 	return role
 }
 
-func skipInOngoing(entry TranscriptEntry) bool {
-	return !isVisibleInOngoing(entry)
-}
-
 func compactOngoingShellPreviewText(command string) string {
 	normalized := textutil.NormalizeCRLF(command)
 	if !strings.Contains(normalized, "\n") {

--- a/cli/tui/model_rendering_tools.go
+++ b/cli/tui/model_rendering_tools.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"core/shared/textutil"
 	"core/shared/toolspec"
 	"core/shared/transcript"
 	"fmt"
@@ -29,7 +28,7 @@ func normalizeOngoingDividerRole(role RenderIntent) RenderIntent {
 }
 
 func compactOngoingShellPreviewText(command string) string {
-	normalized := textutil.NormalizeCRLF(command)
+	normalized := strings.ReplaceAll(command, "\r\n", "\n")
 	if !strings.Contains(normalized, "\n") {
 		return command
 	}

--- a/cli/tui/model_test.go
+++ b/cli/tui/model_test.go
@@ -935,7 +935,7 @@ func TestPendingOngoingAskQuestionsUseQuestionGroupAndEllipsizeQuestionText(t *t
 		},
 	}
 
-	rendered := RenderPendingOngoingSnapshot(entries, "dark", 42, "*")
+	rendered := renderPendingOngoingSnapshotProjection(entries, "dark", 42, uniformPendingSpinnerFrame("*")).Render(TranscriptDivider)
 	plain := plainTranscript(rendered)
 	if !containsInOrder(plain, "* First pending question", "* pwd", "* Second pending question?") {
 		t.Fatalf("expected pending questions and tool in model order, got %q", plain)
@@ -1130,7 +1130,7 @@ func TestPendingOngoingMultilineToolBlockRendersTreeGuidesWithSpinner(t *testing
 		},
 	}}
 
-	plain := plainTranscript(RenderPendingOngoingSnapshot(entries, "dark", 80, "*"))
+	plain := plainTranscript(renderPendingOngoingSnapshotProjection(entries, "dark", 80, uniformPendingSpinnerFrame("*")).Render(TranscriptDivider))
 	if !containsInOrder(plain, "* ./docs/a.md +2", "└ ./docs/b.md +5") {
 		t.Fatalf("expected pending multiline ongoing tool block to render tree guides with spinner, got %q", plain)
 	}

--- a/cli/tui/pending_snapshot.go
+++ b/cli/tui/pending_snapshot.go
@@ -6,10 +6,6 @@ import (
 
 type PendingSpinnerFrameFunc func(entry TranscriptEntry, entryIndex int) string
 
-func RenderPendingOngoingSnapshot(entries []TranscriptEntry, theme string, width int, spinner string) string {
-	return renderPendingOngoingSnapshotProjection(entries, theme, width, uniformPendingSpinnerFrame(spinner)).Render(TranscriptDivider)
-}
-
 func RenderPendingOngoingSnapshotLinesWithSpinnerFrames(entries []TranscriptEntry, theme string, width int, spinnerForEntry PendingSpinnerFrameFunc) []TranscriptProjectionLine {
 	return renderPendingOngoingSnapshotProjection(entries, theme, width, spinnerForEntry).Lines(TranscriptDivider)
 }

--- a/cli/tui/transcript_intents.go
+++ b/cli/tui/transcript_intents.go
@@ -75,7 +75,7 @@ const (
 )
 
 func TranscriptRoleFromWire(role string) TranscriptRole {
-	normalized := transcript.NormalizeEntryRole(role)
+	normalized := strings.ToLower(strings.TrimSpace(role))
 	if normalized == "" {
 		return TranscriptRoleUnknown
 	}

--- a/cli/tui/transcript_projection.go
+++ b/cli/tui/transcript_projection.go
@@ -629,10 +629,6 @@ func (p *TranscriptViewProjector) StreamingDetailAssistantLines(text string, sta
 	return lines
 }
 
-func (p *TranscriptViewProjector) Project(input TranscriptProjectionInput, state TranscriptProjectionViewState) TranscriptViewProjection {
-	return p.project(input, state, true)
-}
-
 func (p *TranscriptViewProjector) ProjectDetailShared(input TranscriptProjectionInput, state TranscriptProjectionViewState) TranscriptViewProjection {
 	key := NewTranscriptViewProjectionKey(input, state)
 	if key.Revision > 0 && p != nil && p.detailViewSet && transcriptViewProjectionKeysEqual(p.detailViewKey, key) {

--- a/cli/tui/transcript_projection.go
+++ b/cli/tui/transcript_projection.go
@@ -633,10 +633,6 @@ func (p *TranscriptViewProjector) Project(input TranscriptProjectionInput, state
 	return p.project(input, state, true)
 }
 
-func (p *TranscriptViewProjector) ProjectShared(input TranscriptProjectionInput, state TranscriptProjectionViewState) TranscriptViewProjection {
-	return p.project(input, state, false)
-}
-
 func (p *TranscriptViewProjector) ProjectDetailShared(input TranscriptProjectionInput, state TranscriptProjectionViewState) TranscriptViewProjection {
 	key := NewTranscriptViewProjectionKey(input, state)
 	if key.Revision > 0 && p != nil && p.detailViewSet && transcriptViewProjectionKeysEqual(p.detailViewKey, key) {

--- a/cli/tui/transcript_projection_test.go
+++ b/cli/tui/transcript_projection_test.go
@@ -708,21 +708,21 @@ func TestTranscriptViewProjectorCachesByRevisionAndViewState(t *testing.T) {
 	}
 	state := TranscriptProjectionViewState{ViewportWidth: 80, ViewportLines: 20, Theme: "dark"}
 
-	_ = projector.Project(input, state)
+	_ = projector.project(input, state, true)
 	input.Entries[0].Text = "changed " + strings.Repeat("x", 90)
-	cached := projector.Project(input, state)
+	cached := projector.project(input, state, true)
 	if rendered := cached.Ongoing.Render(TranscriptDivider); !strings.Contains(rendered, "seed") || strings.Contains(rendered, "changed") {
 		t.Fatalf("expected same revision/view state to reuse cached projection, got %q", rendered)
 	}
 
 	input.Revision = 2
-	updated := projector.Project(input, state)
+	updated := projector.project(input, state, true)
 	if rendered := updated.Ongoing.Render(TranscriptDivider); !strings.Contains(rendered, "changed") || strings.Contains(rendered, "seed") {
 		t.Fatalf("expected advanced revision to rebuild projection, got %q", rendered)
 	}
 
 	state.ViewportWidth = 40
-	resized := projector.Project(input, state)
+	resized := projector.project(input, state, true)
 	if resized.Ongoing.Render(TranscriptDivider) == updated.Ongoing.Render(TranscriptDivider) {
 		t.Fatalf("expected viewport width change to rebuild projection")
 	}
@@ -736,13 +736,13 @@ func TestTranscriptViewProjectorReturnsImmutableProjectionClone(t *testing.T) {
 	}
 	state := TranscriptProjectionViewState{ViewportWidth: 80, ViewportLines: 20, Theme: "dark"}
 
-	first := projector.Project(input, state)
+	first := projector.project(input, state, true)
 	first.Ongoing.Blocks[0].Lines[0] = "mutated"
 	first.OngoingLines[0].Text = "mutated"
 	first.OngoingLineOwners[0] = 999
 	first.OngoingEntryLineRanges[0] = lineRange{Start: 999, End: 999}
 
-	second := projector.Project(input, state)
+	second := projector.project(input, state, true)
 	rendered := second.Ongoing.Render(TranscriptDivider)
 	if strings.Contains(rendered, "mutated") || !strings.Contains(rendered, "seed") {
 		t.Fatalf("expected cached projection to be immutable to caller mutation, got %q", rendered)

--- a/prompts/embed.go
+++ b/prompts/embed.go
@@ -266,10 +266,6 @@ var (
 //go:embed skills/**
 var GeneratedSkillsFS embed.FS
 
-func MainSystemPrompt(includeToolPreambles bool, args SystemPromptTemplateArgs) string {
-	return WithToolPreambles(BaseSystemPrompt(args), includeToolPreambles)
-}
-
 func RenderCustomSystemPrompt(text string, includeToolPreambles bool, args SystemPromptTemplateArgs) (string, error) {
 	sections, err := renderSystemPromptSections(args)
 	if err != nil {

--- a/prompts/embed.go
+++ b/prompts/embed.go
@@ -412,7 +412,7 @@ func newWorkflowTaskInstructionsTemplateData(args WorkflowNodeContextArgs, nodeC
 		NodeCompletionInstructions: strings.TrimSpace(nodeCompletionInstructions),
 		ShowTaskCommentsReminder:   args.TaskNumberOfComments > 0,
 		TaskCommentsLabel:          taskCommentsLabel(args.TaskNumberOfComments),
-		TaskCommentListCommand:     taskCommentListCommand(args.TaskShortId),
+		TaskCommentListCommand:     strings.Join([]string{LaunchCommand(), "task", "comment", "list", strings.TrimSpace(args.TaskShortId)}, " "),
 	}
 }
 
@@ -421,10 +421,6 @@ func taskCommentsLabel(numberOfComments int64) string {
 		return "1 comment"
 	}
 	return fmt.Sprintf("%d comments", numberOfComments)
-}
-
-func taskCommentListCommand(taskShortID string) string {
-	return strings.Join([]string{LaunchCommand(), "task", "comment", "list", strings.TrimSpace(taskShortID)}, " ")
 }
 
 func RenderWorkflowToolCompletionInstructions(workflowShortId string) (string, error) {

--- a/server/auth/manager.go
+++ b/server/auth/manager.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"context"
 	"time"
+
+	sharedauth "core/shared/auth"
 )
 
 type Manager struct {
@@ -86,7 +88,7 @@ func (m *Manager) SwitchMethodAndSetEnvAPIKeyPreference(
 	setPreference bool,
 	isIdle bool,
 ) (State, error) {
-	if err := EnsureIdleForMethodSwitch(isIdle); err != nil {
+	if err := sharedauth.EnsureIdleForMethodSwitch(isIdle); err != nil {
 		return State{}, err
 	}
 	if err := method.Validate(); err != nil {
@@ -107,7 +109,7 @@ func (m *Manager) SwitchMethodAndSetEnvAPIKeyPreference(
 }
 
 func (m *Manager) ClearMethod(ctx context.Context, isIdle bool) (State, error) {
-	if err := EnsureIdleForMethodSwitch(isIdle); err != nil {
+	if err := sharedauth.EnsureIdleForMethodSwitch(isIdle); err != nil {
 		return State{}, err
 	}
 	return m.updateState(ctx, func(state *State) error {
@@ -118,7 +120,7 @@ func (m *Manager) ClearMethod(ctx context.Context, isIdle bool) (State, error) {
 }
 
 func (m *Manager) SetEnvAPIKeyPreference(ctx context.Context, preference EnvAPIKeyPreference, isIdle bool) (State, error) {
-	if err := EnsureIdleForMethodSwitch(isIdle); err != nil {
+	if err := sharedauth.EnsureIdleForMethodSwitch(isIdle); err != nil {
 		return State{}, err
 	}
 	if err := preference.Validate(); err != nil {

--- a/server/auth/types.go
+++ b/server/auth/types.go
@@ -55,7 +55,3 @@ func EvaluateStartupGate(state State) StartupGate {
 func EnsureStartupReady(state State) error {
 	return sharedauth.EnsureStartupReady(state)
 }
-
-func EnsureIdleForMethodSwitch(isIdle bool) error {
-	return sharedauth.EnsureIdleForMethodSwitch(isIdle)
-}

--- a/server/core/bundles.go
+++ b/server/core/bundles.go
@@ -113,14 +113,14 @@ type WorkflowBundle struct {
 
 func (s *Core) safeBundles() *Bundles {
 	if s == nil {
-		return emptyBundles()
+		return (&Bundles{}).withDefaults()
 	}
 	return s.bundles.withDefaults()
 }
 
 func (b *Bundles) withDefaults() *Bundles {
 	if b == nil {
-		return emptyBundles()
+		return (&Bundles{}).withDefaults()
 	}
 	withDefaults := *b
 	if withDefaults.Auth == nil {
@@ -154,10 +154,6 @@ func (b *Bundles) withDefaults() *Bundles {
 		withDefaults.Worktrees = &WorktreeBundle{}
 	}
 	return &withDefaults
-}
-
-func emptyBundles() *Bundles {
-	return (&Bundles{}).withDefaults()
 }
 
 func emptySessionBundle() *SessionBundle {

--- a/server/core/composition.go
+++ b/server/core/composition.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"core/prompts"
@@ -200,7 +201,7 @@ func NewWithContext(ctx context.Context, cfg config.App, authSupport serverboots
 		}
 		if err == nil {
 			core.bundles.Projects.projectID = binding.ProjectID
-			core.bundles.Projects.containerDir = config.ProjectSessionsRoot(cfg, binding.ProjectID)
+			core.bundles.Projects.containerDir = filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 			if err := os.MkdirAll(core.bundles.Projects.containerDir, 0o755); err != nil {
 				_ = core.Close()
 				return nil, fmt.Errorf("projects bundle: sessions root: %w", err)

--- a/server/core/composition_test.go
+++ b/server/core/composition_test.go
@@ -15,7 +15,6 @@ import (
 	askquestion "core/server/tools"
 	"core/server/workflow"
 	"core/server/workflowstore"
-	"core/shared/config"
 	"core/shared/serverapi"
 	"core/shared/toolspec"
 )
@@ -169,7 +168,7 @@ func TestComposedWorkflowTaskDetailResolvesPendingQuestionFromSessionTranscript(
 	if err != nil {
 		t.Fatalf("ClaimRun: %v", err)
 	}
-	sessionsDir := config.ProjectSessionsRoot(resolved.Config, binding.ProjectID)
+	sessionsDir := filepath.Join(filepath.Join(resolved.Config.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	sessionStore, err := session.Create(sessionsDir, filepath.Base(sessionsDir), resolved.Config.WorkspaceRoot, metadataStore.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("session.Create: %v", err)

--- a/server/core/core.go
+++ b/server/core/core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -153,7 +154,7 @@ func (s *Core) resolveProjectContext(ctx context.Context, projectID string, work
 			config:         projectCfg,
 			projectID:      trimmedProjectID,
 			projectRoot:    binding.CanonicalRoot,
-			projectSession: config.ProjectSessionsRoot(projectCfg, trimmedProjectID),
+			projectSession: filepath.Join(filepath.Join(projectCfg.PersistenceRoot, "projects"), trimmedProjectID, "sessions"),
 		}, nil
 	}
 	trimmedWorkspaceRoot := strings.TrimSpace(workspaceRoot)
@@ -171,7 +172,7 @@ func (s *Core) resolveProjectContext(ctx context.Context, projectID string, work
 				config:         projectCfg,
 				projectID:      trimmedProjectID,
 				projectRoot:    binding.CanonicalRoot,
-				projectSession: config.ProjectSessionsRoot(projectCfg, trimmedProjectID),
+				projectSession: filepath.Join(filepath.Join(projectCfg.PersistenceRoot, "projects"), trimmedProjectID, "sessions"),
 			}, nil
 		}
 		if !errors.Is(err, serverapi.ErrWorkspaceNotRegistered) {
@@ -201,7 +202,7 @@ func (s *Core) resolveProjectContext(ctx context.Context, projectID string, work
 		config:         projectCfg,
 		projectID:      trimmedProjectID,
 		projectRoot:    overview.Project.RootPath,
-		projectSession: config.ProjectSessionsRoot(projectCfg, trimmedProjectID),
+		projectSession: filepath.Join(filepath.Join(projectCfg.PersistenceRoot, "projects"), trimmedProjectID, "sessions"),
 	}, nil
 }
 

--- a/server/core/repo_boundary_test.go
+++ b/server/core/repo_boundary_test.go
@@ -117,7 +117,6 @@ func TestSharedClientUIRemainsDTOOnly(t *testing.T) {
 	allowedFuncs := map[string]struct{}{
 		"CompactionLifecycle.IsRunning":             {},
 		"ConversationFreshness.IsFresh":             {},
-		"FinishedRunLifecycle":                      {},
 		"IdleRunLifecycle":                          {},
 		"MustRunLifecycle":                          {},
 		"NewCompactionLifecycle":                    {},
@@ -136,7 +135,6 @@ func TestSharedClientUIRemainsDTOOnly(t *testing.T) {
 		"RunLifecycle.IsGoalLoopRunning":            {},
 		"RunLifecycle.IsRunning":                    {},
 		"RunLifecycle.Validate":                     {},
-		"RunningRunLifecycle":                       {},
 		"RuntimeConnectionLifecycle.IsDisconnected": {},
 		"SessionExecutionTargetIsZero":              {},
 		"SessionExecutionTargetsEqual":              {},

--- a/server/launch/bootstrap_test.go
+++ b/server/launch/bootstrap_test.go
@@ -119,7 +119,7 @@ func TestResolveBootstrapPlanUsesReboundWorkspaceRootFromMetadataAuthority(t *te
 	if err != nil {
 		t.Fatalf("RegisterWorkspaceBinding: %v", err)
 	}
-	projectSessionsDir := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	projectSessionsDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	store := createTestSessionInContainer(t, projectSessionsDir, filepath.Base(projectSessionsDir), cfg.WorkspaceRoot, metadataStore.AuthoritativeSessionStoreOptions()...)
 	if err := store.SetName("hello"); err != nil {
 		t.Fatalf("SetName: %v", err)

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -588,10 +588,6 @@ func EffectiveSettings(base config.Settings, locked *session.LockedContract) con
 	return out
 }
 
-func ActiveToolIDs(settings config.Settings, source config.SourceReport, locked *session.LockedContract) ([]toolspec.ID, error) {
-	return ActiveToolIDsForPlan(settings, source, locked)
-}
-
 func ActiveToolIDsForPlan(settings config.Settings, source config.SourceReport, locked *session.LockedContract) ([]toolspec.ID, error) {
 	if locked != nil {
 		ids := make([]toolspec.ID, 0, len(locked.EnabledTools))

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -601,7 +601,7 @@ func TestPlannerNewChildSessionPreservesParentWorktreeContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RegisterWorkspaceBinding: %v", err)
 	}
-	containerDir := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	containerDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	parent := createTestSessionInContainer(t, containerDir, filepath.Base(containerDir), cfg.WorkspaceRoot, metadataStore.AuthoritativeSessionStoreOptions()...)
 	if err := parent.EnsureDurable(); err != nil {
 		t.Fatalf("EnsureDurable parent: %v", err)
@@ -885,7 +885,7 @@ func TestPlannerNewChildSessionRollsBackDurableChildWhenExecutionTargetCopyFails
 	if err != nil {
 		t.Fatalf("RegisterWorkspaceBinding: %v", err)
 	}
-	containerDir := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	containerDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	parent := createTestSessionInContainer(t, containerDir, filepath.Base(containerDir), cfg.WorkspaceRoot, metadataStore.SessionStoreOptions()...)
 	if err := parent.EnsureDurable(); err != nil {
 		t.Fatalf("EnsureDurable parent: %v", err)

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -1106,7 +1106,7 @@ func TestResolveSubagentSettingsPreservesSubagentCatalogMetadata(t *testing.T) {
 		},
 	}
 
-	resolved, _, err := resolveSubagentSettings(base, base, cfg.Source.Sources, "worker", auth.EmptyState(), true)
+	resolved, _, err := resolveSubagentSettingsWithValidation(base, base, cfg.Source.Sources, "worker", auth.EmptyState(), true, true)
 	if err != nil {
 		t.Fatalf("resolveSubagentSettings: %v", err)
 	}
@@ -1131,7 +1131,7 @@ func TestResolveSubagentSettingsRejectsRoleContextWindowBelowMinimum(t *testing.
 		},
 	}
 
-	_, _, err := resolveSubagentSettings(base, base, cfg.Source.Sources, "worker", auth.EmptyState(), true)
+	_, _, err := resolveSubagentSettingsWithValidation(base, base, cfg.Source.Sources, "worker", auth.EmptyState(), true, true)
 	if err == nil {
 		t.Fatal("expected role context window below minimum to fail")
 	}
@@ -1152,7 +1152,7 @@ func TestResolveSubagentSettingsRejectsRoleReviewerContextWindowBelowMinimum(t *
 		},
 	}
 
-	_, _, err := resolveSubagentSettings(base, base, cfg.Source.Sources, "worker", auth.EmptyState(), true)
+	_, _, err := resolveSubagentSettingsWithValidation(base, base, cfg.Source.Sources, "worker", auth.EmptyState(), true, true)
 	if err == nil {
 		t.Fatal("expected role reviewer context window below minimum to fail")
 	}

--- a/server/launch/subagents.go
+++ b/server/launch/subagents.go
@@ -13,10 +13,6 @@ import (
 
 const fastRoleSameAsMainWarning = "Warning: user configuration for fast agents is the same as for other agents. Consider asking the user to edit their config to pick a faster, smaller model at the end of your task. More info at " + config.DocsURL
 
-func resolveSubagentSettings(base config.Settings, providerBase config.Settings, baseSources map[string]string, roleName string, authState auth.State, allowModelOverride bool) (config.Settings, string, error) {
-	return resolveSubagentSettingsWithValidation(base, providerBase, baseSources, roleName, authState, allowModelOverride, true)
-}
-
 func resolveSubagentSettingsWithValidation(base config.Settings, providerBase config.Settings, baseSources map[string]string, roleName string, authState auth.State, allowModelOverride bool, validate bool) (config.Settings, string, error) {
 	normalizedRole := config.NormalizeSubagentSelector(roleName)
 	if normalizedRole == "" {

--- a/server/launch/test_helpers_test.go
+++ b/server/launch/test_helpers_test.go
@@ -111,7 +111,7 @@ func createMetadataBackedSession(
 	if err != nil {
 		t.Fatalf("RegisterWorkspaceBinding: %v", err)
 	}
-	containerDir := config.ProjectSessionsRoot(config.App{PersistenceRoot: persistenceRoot}, binding.ProjectID)
+	containerDir := filepath.Join(filepath.Join(config.App{PersistenceRoot: persistenceRoot}.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	store := createTestSessionInContainer(
 		t,
 		containerDir,

--- a/server/llm/errors.go
+++ b/server/llm/errors.go
@@ -15,10 +15,6 @@ const (
 	UnifiedErrorCodeProviderContract      = llmerrors.UnifiedErrorCodeProviderContract
 )
 
-func NewProviderContractError(providerID string, statusCode int, cause error) *ProviderAPIError {
-	return llmerrors.NewProviderContractError(providerID, statusCode, cause)
-}
-
 func IsAuthenticationError(err error) bool {
 	return llmerrors.IsAuthenticationError(err)
 }

--- a/server/llm/openai_http.go
+++ b/server/llm/openai_http.go
@@ -93,7 +93,11 @@ func (t *HTTPTransport) Generate(ctx context.Context, request OpenAIRequest) (Op
 		return OpenAIResponse{}, err
 	}
 
-	service := t.newResponseService(mode)
+	service := responses.NewResponseService(
+		option.WithBaseURL(t.serviceBaseURL(mode)),
+		option.WithHTTPClient(t.Client),
+		option.WithMaxRetries(0),
+	)
 	reqOpts := t.buildRequestOptions(authHeader, mode, request.SessionID)
 	var rawResp *http.Response
 	reqOpts = append(reqOpts, option.WithResponseInto(&rawResp))
@@ -142,7 +146,11 @@ func (t *HTTPTransport) GenerateStreamWithEvents(ctx context.Context, request Op
 		return OpenAIResponse{}, err
 	}
 
-	service := t.newResponseService(mode)
+	service := responses.NewResponseService(
+		option.WithBaseURL(t.serviceBaseURL(mode)),
+		option.WithHTTPClient(t.Client),
+		option.WithMaxRetries(0),
+	)
 	reqOpts := t.buildRequestOptions(authHeader, mode, request.SessionID)
 	var rawResp *http.Response
 	reqOpts = append(reqOpts, option.WithResponseInto(&rawResp))
@@ -178,12 +186,16 @@ func (t *HTTPTransport) Compact(ctx context.Context, request OpenAICompactionReq
 		return OpenAICompactionResponse{}, err
 	}
 
-	payload, err := t.buildCompactPayload(request)
+	payload, err := newOpenAIRequestPayloadBuilder(t.Store, t.ModelVerbosity, ProviderCapabilities{}).BuildCompact(request)
 	if err != nil {
 		return OpenAICompactionResponse{}, err
 	}
 
-	service := t.newResponseService(mode)
+	service := responses.NewResponseService(
+		option.WithBaseURL(t.serviceBaseURL(mode)),
+		option.WithHTTPClient(t.Client),
+		option.WithMaxRetries(0),
+	)
 	reqOpts := t.buildRequestOptions(authHeader, mode, request.SessionID)
 	var rawResp *http.Response
 	var rawBody []byte

--- a/server/llm/openai_http_errors.go
+++ b/server/llm/openai_http_errors.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"core/shared/llmerrors"
 )
 
 type openAIRequestErrorMapper struct {
@@ -25,7 +27,7 @@ func (m openAIRequestErrorMapper) Map(err error, rawResp *http.Response, prefix 
 				rawResp.Body = nil
 			}
 		}
-		return fmt.Errorf("%s: %w", prefix, NewProviderContractError(m.providerID, statusCode, reducerErr))
+		return fmt.Errorf("%s: %w", prefix, llmerrors.NewProviderContractError(m.providerID, statusCode, reducerErr))
 	}
 	reducedErr, ok := reducer.Reduce(err, rawResp)
 	if ok && reducedErr != nil {

--- a/server/llm/openai_http_part2_test.go
+++ b/server/llm/openai_http_part2_test.go
@@ -635,7 +635,7 @@ func TestInputTokenCountPayloadMatchesCompactPayloadInputShape(t *testing.T) {
 		{Type: ResponseItemTypeCompaction, ID: "cmp_1", EncryptedContent: "enc_compaction"},
 	})
 
-	compactPayload, err := transport.buildCompactPayload(OpenAICompactionRequest{
+	compactPayload, err := newOpenAIRequestPayloadBuilder(transport.Store, transport.ModelVerbosity, ProviderCapabilities{}).BuildCompact(OpenAICompactionRequest{
 		Model:        "gpt-5",
 		Instructions: "compaction instructions",
 		InputItems:   canonicalItems,
@@ -679,7 +679,7 @@ func TestOpenAIRequestBuildersRejectUnmaterializedViewImageInputFileOutput(t *te
 	_, err = transport.buildInputTokenCountParams(OpenAIRequest{Model: "gpt-5", Items: unpreparedItems}, caps)
 	checkErr("buildInputTokenCountParams", err)
 
-	_, err = transport.buildCompactPayload(OpenAICompactionRequest{Model: "gpt-5", InputItems: unpreparedItems})
+	_, err = newOpenAIRequestPayloadBuilder(transport.Store, transport.ModelVerbosity, ProviderCapabilities{}).BuildCompact(OpenAICompactionRequest{Model: "gpt-5", InputItems: unpreparedItems})
 	checkErr("buildCompactPayload", err)
 }
 

--- a/server/llm/openai_http_payloads.go
+++ b/server/llm/openai_http_payloads.go
@@ -36,10 +36,6 @@ func (t *HTTPTransport) buildInputTokenCountParams(request OpenAIRequest, capabi
 	return builder.BuildInputTokenCount(request)
 }
 
-func (t *HTTPTransport) buildCompactPayload(request OpenAICompactionRequest) (responses.ResponseCompactParams, error) {
-	return newOpenAIRequestPayloadBuilder(t.Store, t.ModelVerbosity, ProviderCapabilities{}).BuildCompact(request)
-}
-
 func (b openAIRequestPayloadBuilder) BuildResponse(request OpenAIRequest, mode openAIAuthMode) (responses.ResponseNewParams, error) {
 	input, err := buildResponsesInput(request.Items)
 	if err != nil {

--- a/server/llm/openai_http_transport_helpers.go
+++ b/server/llm/openai_http_transport_helpers.go
@@ -7,17 +7,11 @@ import (
 	"strconv"
 	"strings"
 
+	"core/shared/llmerrors"
+
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/responses"
 )
-
-func (t *HTTPTransport) newResponseService(mode openAIAuthMode) responses.ResponseService {
-	return responses.NewResponseService(
-		option.WithBaseURL(t.serviceBaseURL(mode)),
-		option.WithHTTPClient(t.Client),
-		option.WithMaxRetries(0),
-	)
-}
 
 func (t *HTTPTransport) serviceBaseURL(mode openAIAuthMode) string {
 	if mode.IsOAuth && !t.BaseURLExplicit {
@@ -72,7 +66,7 @@ func (t *HTTPTransport) providerVariantForMode(mode openAIAuthMode) (ProviderVar
 		if providerID == "" {
 			providerID = "unknown-provider"
 		}
-		return ProviderVariantContract{}, NewProviderContractError(providerID, 0, err)
+		return ProviderVariantContract{}, llmerrors.NewProviderContractError(providerID, 0, err)
 	}
 	return variant, nil
 }

--- a/server/llm/reasoning_summary.go
+++ b/server/llm/reasoning_summary.go
@@ -2,15 +2,13 @@ package llm
 
 import (
 	"strings"
-
-	"core/shared/textutil"
 )
 
 func normalizeReasoningEntries(entries []ReasoningEntry) []ReasoningEntry {
 	out := make([]ReasoningEntry, 0, len(entries))
 	for _, entry := range entries {
 		role := strings.TrimSpace(entry.Role)
-		summary := normalizeReasoningSummaryLines(textutil.SplitLinesCRLF(entry.Text))
+		summary := normalizeReasoningSummaryLines(strings.Split(strings.ReplaceAll(entry.Text, "\r\n", "\n"), "\n"))
 		if role == "" || summary == "" {
 			continue
 		}
@@ -23,7 +21,7 @@ func reasoningSummaryDeltaFromText(key, role, text string) ReasoningSummaryDelta
 	return ReasoningSummaryDelta{
 		Key:  key,
 		Role: role,
-		Text: normalizeReasoningSummaryLines(textutil.SplitLinesCRLF(text)),
+		Text: normalizeReasoningSummaryLines(strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")),
 	}
 }
 

--- a/server/llm/reasoning_summary_test.go
+++ b/server/llm/reasoning_summary_test.go
@@ -1,13 +1,12 @@
 package llm
 
 import (
+	"strings"
 	"testing"
-
-	"core/shared/textutil"
 )
 
 func TestNormalizeReasoningSummaryTextPreservesBoldMarkers(t *testing.T) {
-	text := normalizeReasoningSummaryLines(textutil.SplitLinesCRLF("**Preparing patch**\n\nI am exploring options.\n**Running checks**"))
+	text := normalizeReasoningSummaryLines(strings.Split(strings.ReplaceAll("**Preparing patch**\n\nI am exploring options.\n**Running checks**", "\r\n", "\n"), "\n"))
 	if text != "**Preparing patch**\n\nI am exploring options.\n**Running checks**" {
 		t.Fatalf("unexpected normalized text: %q", text)
 	}

--- a/server/metadata/store.go
+++ b/server/metadata/store.go
@@ -729,7 +729,7 @@ func (s *Store) UnlinkProjectWorkspace(ctx context.Context, projectID string, wo
 		return nil, fmt.Errorf("%w: %q", serverapi.ErrWorkspaceNotRegistered, trimmedWorkspaceID)
 	}
 
-	blockers, err := s.workspaceUnlinkBlockers(ctx, trimmedProjectID, workspace)
+	blockers, err := workspaceUnlinkBlockersWithQueries(ctx, s.queries, trimmedProjectID, workspace)
 	if err != nil {
 		return nil, err
 	}
@@ -770,10 +770,6 @@ func (s *Store) UnlinkProjectWorkspace(ctx context.Context, projectID string, wo
 		return nil, fmt.Errorf("commit workspace unlink tx: %w", err)
 	}
 	return nil, nil
-}
-
-func (s *Store) workspaceUnlinkBlockers(ctx context.Context, projectID string, workspace sqlitegen.Workspace) ([]serverapi.ProjectWorkspaceUnlinkBlocker, error) {
-	return workspaceUnlinkBlockersWithQueries(ctx, s.queries, projectID, workspace)
 }
 
 func workspaceUnlinkBlockersWithQueries(ctx context.Context, q *sqlitegen.Queries, projectID string, workspace sqlitegen.Workspace) ([]serverapi.ProjectWorkspaceUnlinkBlocker, error) {

--- a/server/metadata/store_part2_test.go
+++ b/server/metadata/store_part2_test.go
@@ -157,7 +157,7 @@ func TestUpdateSessionExecutionTargetByIDRejectsCrossWorkspaceWorktree(t *testin
 	if err != nil {
 		t.Fatalf("RegisterWorkspaceBinding workspaceB: %v", err)
 	}
-	projectSessionsDir := config.ProjectSessionsRoot(cfgA, bindingA.ProjectID)
+	projectSessionsDir := filepath.Join(filepath.Join(cfgA.PersistenceRoot, "projects"), bindingA.ProjectID, "sessions")
 	sess, err := session.Create(projectSessionsDir, filepath.Base(projectSessionsDir), cfgA.WorkspaceRoot, store.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("session.Create: %v", err)
@@ -207,7 +207,7 @@ func TestUpsertWorktreeRecordRejectsMissingRequiredFields(t *testing.T) {
 func TestResolvePersistedSessionUsesReboundWorkspaceRoot(t *testing.T) {
 	ctx := context.Background()
 	store, cfg, binding := newMetadataTestStore(t)
-	projectSessionsDir := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	projectSessionsDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	sess, err := session.Create(projectSessionsDir, filepath.Base(projectSessionsDir), cfg.WorkspaceRoot, store.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("session.Create: %v", err)
@@ -465,7 +465,7 @@ func newMetadataTestStoreForBoundWorkspace(t *testing.T, workspace string) (*Sto
 
 func createMetadataTestSession(t *testing.T, store *Store, cfg config.App, binding Binding) *session.Store {
 	t.Helper()
-	projectSessionsDir := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	projectSessionsDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	sess, err := session.Create(projectSessionsDir, filepath.Base(projectSessionsDir), cfg.WorkspaceRoot, store.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("session.Create: %v", err)

--- a/server/metadata/store_test.go
+++ b/server/metadata/store_test.go
@@ -497,7 +497,7 @@ func TestRetargetSessionWorkspaceAttachesTargetAndUpdatesSession(t *testing.T) {
 
 	store, cfg, bindingA := newMetadataTestStoreForBoundWorkspace(t, workspaceA)
 	sess, err := session.Create(
-		config.ProjectSessionsRoot(cfg, bindingA.ProjectID),
+		filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), bindingA.ProjectID, "sessions"),
 		filepath.Base(cfg.WorkspaceRoot),
 		cfg.WorkspaceRoot,
 		store.AuthoritativeSessionStoreOptions()...,
@@ -603,7 +603,7 @@ func TestRetargetSessionWorkspaceAttachesTargetAndUpdatesSession(t *testing.T) {
 func TestResolvePersistedSessionPreservesWorktreeReminderStateFromMetadata(t *testing.T) {
 	store, cfg, binding := newMetadataTestStore(t)
 	sess, err := session.Create(
-		config.ProjectSessionsRoot(cfg, binding.ProjectID),
+		filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 		filepath.Base(cfg.WorkspaceRoot),
 		cfg.WorkspaceRoot,
 		store.AuthoritativeSessionStoreOptions()...,
@@ -640,7 +640,7 @@ func TestResolvePersistedSessionPreservesWorktreeReminderStateFromMetadata(t *te
 func TestResolvePersistedSessionPreservesGoalStateFromMetadata(t *testing.T) {
 	store, cfg, binding := newMetadataTestStore(t)
 	sess, err := session.Create(
-		config.ProjectSessionsRoot(cfg, binding.ProjectID),
+		filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 		filepath.Base(cfg.WorkspaceRoot),
 		cfg.WorkspaceRoot,
 		store.AuthoritativeSessionStoreOptions()...,
@@ -695,7 +695,7 @@ func TestRebindWorkspaceRetargetsDescendantWorktrees(t *testing.T) {
 	`, worktreeID, binding.WorkspaceID, canonicalOldWorktree, "{}", now, now); err != nil {
 		t.Fatalf("insert worktree: %v", err)
 	}
-	projectSessionsDir := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	projectSessionsDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	sess, err := session.Create(projectSessionsDir, filepath.Base(projectSessionsDir), cfg.WorkspaceRoot, store.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("session.Create: %v", err)

--- a/server/projectview/home_sort_test.go
+++ b/server/projectview/home_sort_test.go
@@ -11,7 +11,6 @@ import (
 	"core/server/metadata"
 	"core/server/session"
 	"core/server/workflowstore"
-	"core/shared/config"
 	"core/shared/serverapi"
 )
 
@@ -76,7 +75,7 @@ func TestMetadataServiceSortsProjectHomeByLatestTaskActivityOrEdit(t *testing.T)
 		t.Fatalf("project order after edit = %+v, want [%s %s]", got, newer.Binding.ProjectID, older.ProjectID)
 	}
 
-	projectSessionsDir := config.ProjectSessionsRoot(cfg, older.ProjectID)
+	projectSessionsDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), older.ProjectID, "sessions")
 	sess, err := session.Create(projectSessionsDir, filepath.Base(projectSessionsDir), cfg.WorkspaceRoot, store.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("session.Create: %v", err)

--- a/server/projectview/service_test.go
+++ b/server/projectview/service_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestServiceListsSingleProjectAndSessions(t *testing.T) {
 	store, cfg, binding := newProjectViewMetadataStore(t)
-	containerDir := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	containerDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	first, err := session.Create(containerDir, filepath.Base(containerDir), cfg.WorkspaceRoot, store.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("create first session: %v", err)
@@ -86,7 +86,7 @@ func TestServiceRejectsUnknownProjectID(t *testing.T) {
 
 func TestServiceDeletesProjectMetadataAndSessionArtifacts(t *testing.T) {
 	store, cfg, binding := newProjectViewMetadataStore(t)
-	sessionDir := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	sessionDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	created, err := session.Create(sessionDir, filepath.Base(sessionDir), cfg.WorkspaceRoot, store.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("create session: %v", err)
@@ -150,7 +150,7 @@ func TestServiceDeletesProjectWithBacklogTasks(t *testing.T) {
 
 func TestServiceDeleteProjectBlocksActiveSession(t *testing.T) {
 	store, cfg, binding := newProjectViewMetadataStore(t)
-	sessionDir := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	sessionDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	created, err := session.Create(sessionDir, filepath.Base(sessionDir), cfg.WorkspaceRoot, store.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("create session: %v", err)

--- a/server/runprompt/headless.go
+++ b/server/runprompt/headless.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"core/server/auth"
@@ -125,7 +126,7 @@ func (l *headlessPromptLauncher) prepareRuntime(plan launch.SessionPlan, progres
 		Sources:  plan.Source.Sources,
 		OnEvent: func(evt runtime.Event) {
 			logger.Logf("%s", FormatRuntimeEvent(evt))
-			if transcriptdiag.EnabledForProcess(plan.ActiveSettings.Debug) {
+			if transcriptdiag.Enabled(plan.ActiveSettings.Debug, os.Getenv) {
 				projected := runtimeview.EventFromRuntime(evt)
 				logger.Logf("%s", FormatTranscriptProjectionDiagnostic(plan.Store.Meta().SessionID, projected))
 				logger.Logf("%s", FormatTranscriptPublishDiagnostic(plan.Store.Meta().SessionID, projected))

--- a/server/runtime/background.go
+++ b/server/runtime/background.go
@@ -27,10 +27,6 @@ type queuedBackgroundNotice struct {
 	intent    steeringIntent
 }
 
-func (e *Engine) HandleBackgroundShellEvent(evt BackgroundShellEvent) {
-	e.HandleBackgroundShellUpdate(evt, true)
-}
-
 func (e *Engine) HandleBackgroundShellUpdate(evt BackgroundShellEvent, queueNotice bool) {
 	e.ensureOrchestrationCollaborators()
 	e.backgroundFlow.HandleBackgroundShellUpdate(evt, queueNotice)

--- a/server/runtime/background.go
+++ b/server/runtime/background.go
@@ -37,7 +37,7 @@ func (e *Engine) HandleBackgroundShellUpdate(evt BackgroundShellEvent, queueNoti
 }
 
 func (b *defaultBackgroundNoticeScheduler) HandleBackgroundShellUpdate(evt BackgroundShellEvent, queueNotice bool) {
-	_ = b.engine.steerEvent("", Event{Kind: EventBackgroundUpdated, Background: &evt})
+	_ = b.engine.steer("", steerEventIntent(Event{Kind: EventBackgroundUpdated, Background: &evt}))
 	if !queueNotice {
 		return
 	}
@@ -89,7 +89,7 @@ func (b *defaultBackgroundNoticeScheduler) QueueDeveloperNotice(msg llm.Message)
 	shouldSchedule := false
 	notice := queuedBackgroundNotice{
 		sessionID: strings.TrimSpace(msg.Name),
-		intent:    steerMessageIntent(msg),
+		intent:    steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{msg}),
 	}
 	b.mu.Lock()
 	b.pending = append(b.pending, notice)

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -463,7 +463,7 @@ func (s *chatStore) ongoingTailSnapshot(maxEntries int) TranscriptWindowSnapshot
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	items, localEntries := s.detailTranscriptSourceLocked()
+	items, localEntries := llm.CloneResponseItems(s.items), append([]localChatEntry(nil), s.local...)
 	materializedToolResults := collectMaterializedToolCalls(items)
 	scan := newInMemoryTranscriptScan(inMemoryTranscriptScanRequest{
 		TrackOngoingTail: true,
@@ -510,7 +510,7 @@ func (s *chatStore) transcriptPageSnapshot(offset, limit int) transcriptPageSnap
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	items, localEntries := s.detailTranscriptSourceLocked()
+	items, localEntries := llm.CloneResponseItems(s.items), append([]localChatEntry(nil), s.local...)
 	materializedToolResults := collectMaterializedToolCalls(items)
 	scan := newInMemoryTranscriptScan(inMemoryTranscriptScanRequest{Offset: offset, Limit: limit}, s.toolCompletions, materializedToolResults)
 	localIndex := 0
@@ -541,10 +541,6 @@ func (s *chatStore) transcriptPageSnapshot(offset, limit int) transcriptPageSnap
 	return page
 }
 
-func (s *chatStore) detailTranscriptSourceLocked() ([]llm.ResponseItem, []localChatEntry) {
-	return llm.CloneResponseItems(s.items), append([]localChatEntry(nil), s.local...)
-}
-
 type materializedChatSnapshot struct {
 	Snapshot             ChatSnapshot
 	CompactionEntryStart int
@@ -554,7 +550,7 @@ func (s *chatStore) snapshotWithMetadata() materializedChatSnapshot {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	items, localEntries := s.detailTranscriptSourceLocked()
+	items, localEntries := llm.CloneResponseItems(s.items), append([]localChatEntry(nil), s.local...)
 	materializedToolResults := collectMaterializedToolCalls(items)
 	scan := newInMemoryTranscriptScan(inMemoryTranscriptScanRequest{Offset: 0, Limit: 0}, s.toolCompletions, materializedToolResults)
 	localIndex := 0

--- a/server/runtime/committed_transcript_events_test.go
+++ b/server/runtime/committed_transcript_events_test.go
@@ -53,19 +53,19 @@ func TestCommittedTranscriptChangedMarksOnlyDurableTranscriptMutations(t *testin
 	assertEventFlags(t, events[start:], []eventFlagExpectation{{kind: EventLocalEntryAdded, stepID: "persist-step", committedChanged: true}})
 
 	start = len(events)
-	if err := eng.replaceHistory("compact-step", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}})); err != nil {
+	if err := newCompactionPersistence(eng).replaceHistory("compact-step", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}})); err != nil {
 		t.Fatalf("replace history for compaction: %v", err)
 	}
 	assertEventFlags(t, events[start:], []eventFlagExpectation{{kind: EventLocalEntryAdded, stepID: "compact-step", committedChanged: true}, {kind: EventConversationUpdated, stepID: "compact-step", committedChanged: false}})
 
 	start = len(events)
-	if err := eng.steer("message-step", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Content: "persisted assistant", Phase: llm.MessagePhaseFinal})); err != nil {
+	if err := eng.steer("message-step", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Content: "persisted assistant", Phase: llm.MessagePhaseFinal}})); err != nil {
 		t.Fatalf("append persisted message: %v", err)
 	}
 	assertEventFlags(t, events[start:], nil)
 
 	start = len(events)
-	if err := eng.steer("goal-step", steerMessageIntent(eng.goalDeveloperMessage("Goal paused.", "Goal paused"))); err != nil {
+	if err := eng.steer("goal-step", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{normalizeMessageForTranscript(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeGoal, Content: "Goal paused.", CompactContent: "Goal paused"}, eng.transcriptWorkingDir())})); err != nil {
 		t.Fatalf("append goal feedback: %v", err)
 	}
 	assertEventFlags(t, events[start:], []eventFlagExpectation{{kind: EventConversationUpdated, stepID: "goal-step", committedChanged: true}})
@@ -307,7 +307,7 @@ func TestHistoryReplacementSerializesAgainstCommittedLocalEntryAppend(t *testing
 
 	replaceDone := make(chan error, 1)
 	go func() {
-		replaceDone <- eng.replaceHistory("compact-step", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{
+		replaceDone <- newCompactionPersistence(eng).replaceHistory("compact-step", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{
 			Role:        llm.RoleDeveloper,
 			MessageType: llm.MessageTypeCompactionSummary,
 			Content:     "summary",
@@ -351,7 +351,7 @@ func TestToolResultMirrorMessageDoesNotEmitGenericCommittedAdvance(t *testing.T)
 	})
 
 	call := llm.ToolCall{ID: "call-1", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{"command":"pwd"}`)}
-	if err := eng.steer("step-1", steerMessageWithoutDerivedEventIntent(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{call}})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventNone, true, []llm.Message{{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{call}}})); err != nil {
 		t.Fatalf("append assistant message: %v", err)
 	}
 	result := tools.Result{CallID: call.ID, Name: toolspec.ToolExecCommand, Output: json.RawMessage(`{"output":"/tmp","exit_code":0,"truncated":false}`)}
@@ -360,7 +360,7 @@ func TestToolResultMirrorMessageDoesNotEmitGenericCommittedAdvance(t *testing.T)
 	}
 
 	start := len(events)
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleTool, ToolCallID: call.ID, Name: string(result.Name), Content: string(result.Output)})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleTool, ToolCallID: call.ID, Name: string(result.Name), Content: string(result.Output)}})); err != nil {
 		t.Fatalf("append tool mirror message: %v", err)
 	}
 	if got := events[start:]; len(got) != 0 {

--- a/server/runtime/compaction.go
+++ b/server/runtime/compaction.go
@@ -145,10 +145,6 @@ func (c *defaultContextCompactor) AutoCompactIfNeeded(ctx context.Context, stepI
 	return err
 }
 
-func (e *Engine) shouldAutoCompact() bool {
-	return e.shouldAutoCompactWithContext(context.Background())
-}
-
 func (e *Engine) shouldAutoCompactWithContext(ctx context.Context) bool {
 	snapshot := e.compactionPlanningSnapshot()
 	planner := e.compactionPlannerState()
@@ -160,10 +156,6 @@ func (e *Engine) shouldAutoCompactWithContext(ctx context.Context) bool {
 		return false
 	}
 	return e.usageAtOrAboveLimit(ctx, limit)
-}
-
-func (e *Engine) preSubmitCompactionTokenLimit(ctx context.Context) int {
-	return e.compactionPlannerState().preSubmitTokenLimit(e.compactionPlanningSnapshot())
 }
 
 func (e *Engine) ShouldCompactBeforeUserMessage(ctx context.Context, text string) (bool, error) {
@@ -290,10 +282,6 @@ func (e *Engine) currentInputTokensPrecisely(ctx context.Context) (int, bool) {
 		return 0, false
 	}
 	return e.requestInputTokensPreciselyTracked(ctx, req, true)
-}
-
-func (e *Engine) currentInputTokensPreciselyIfDue(ctx context.Context, limit int) (int, bool) {
-	return e.currentInputTokensPreciselyIfDueWithPriority(ctx, limit, false)
 }
 
 func (e *Engine) currentInputTokensPreciselyIfDueWithPriority(ctx context.Context, limit int, critical bool) (int, bool) {

--- a/server/runtime/compaction.go
+++ b/server/runtime/compaction.go
@@ -99,10 +99,10 @@ func (c *defaultContextCompactor) TriggerHandoff(ctx context.Context, stepID str
 	if planner.mode(planningSnapshot.compactionMode) == "none" {
 		return "", false, errors.New("User explicitly disabled compaction in configuration.")
 	}
-	if !e.handoffToolEnabled() {
+	if !e.compactionRuntimeState().SoonReminderIssued() {
 		return "", false, errHandoffTooEarly
 	}
-	e.queueHandoffRequest(summarizerPrompt, futureAgentMessage)
+	e.handoffRuntimeState().QueueRequest(summarizerPrompt, futureAgentMessage)
 	summary := "Handoff scheduled to run now."
 	appended := strings.TrimSpace(futureAgentMessage) != ""
 	return summary, appended, nil
@@ -116,7 +116,7 @@ func (c *defaultContextCompactor) compactContext(ctx context.Context, mode compa
 		}
 		_, err := e.compactNow(stepCtx, stepID, mode, args, includeManualCarryover)
 		if err == nil {
-			e.clearPendingHandoffRequest()
+			e.handoffRuntimeState().ClearRequest()
 		}
 		return err
 	})
@@ -134,7 +134,7 @@ func (c *defaultContextCompactor) AutoCompactIfNeeded(ctx context.Context, stepI
 	}
 	_, err := e.compactNow(ctx, stepID, mode, "", false)
 	if err == nil {
-		e.clearPendingHandoffRequest()
+		e.handoffRuntimeState().ClearRequest()
 	}
 	if err != nil && mode == compactionModeAuto {
 		return fmt.Errorf("auto compaction failed: %w", err)
@@ -188,7 +188,7 @@ func (c *defaultContextCompactor) ShouldCompactBeforeUserMessage(ctx context.Con
 	reservedOutput := planner.reservedOutputTokens(planningSnapshot)
 	preSubmitLimit := planner.preSubmitTokenLimit(planningSnapshot)
 	if preSubmitLimit > 0 {
-		_, _ = e.currentInputTokensPreciselyIfCritical(ctx, preSubmitLimit)
+		_, _ = e.currentInputTokensPreciselyIfDueWithPriority(ctx, preSubmitLimit, true)
 	}
 	estimatedCurrentTotal := e.currentTokenUsage() + reservedOutput
 	if preSubmitLimit > 0 && estimatedCurrentTotal >= preSubmitLimit {
@@ -205,7 +205,7 @@ func (c *defaultContextCompactor) ShouldCompactBeforeUserMessage(ctx context.Con
 	if err != nil {
 		return false, err
 	}
-	if preciseInput, ok := e.requestInputTokensPrecisely(ctx, req); ok {
+	if preciseInput, ok := e.requestInputTokensPreciselyTracked(ctx, req, false); ok {
 		return preciseInput+reservedOutput >= limit, nil
 	}
 	return estimatedCurrentTotal+promptEstimate >= limit, nil
@@ -224,7 +224,7 @@ func (e *Engine) resolveContextWindowTokens(ctx context.Context) int {
 			return resolved
 		}
 	}
-	return e.contextWindowTokens()
+	return e.compactionPlannerState().contextWindowTokens(e.compactionPlanningSnapshot())
 }
 
 func (e *Engine) configuredContextWindowTokens() int {
@@ -252,10 +252,6 @@ func (e *Engine) currentModel() string {
 	return strings.TrimSpace(e.cfg.Model)
 }
 
-func (e *Engine) reservedOutputTokens() int {
-	return e.compactionPlannerState().reservedOutputTokens(e.compactionPlanningSnapshot())
-}
-
 func autoCompactPrecisionMarginForLimit(limit int) int {
 	if limit <= 0 {
 		return autoCompactNearLimitMargin
@@ -271,8 +267,8 @@ func (e *Engine) usageAtOrAboveLimit(ctx context.Context, limit int) bool {
 	if limit <= 0 {
 		return false
 	}
-	reservedOutput := e.reservedOutputTokens()
-	if preciseInput, ok := e.currentInputTokensPreciselyIfCritical(ctx, limit); ok {
+	reservedOutput := e.compactionPlannerState().reservedOutputTokens(e.compactionPlanningSnapshot())
+	if preciseInput, ok := e.currentInputTokensPreciselyIfDueWithPriority(ctx, limit, true); ok {
 		return preciseInput+reservedOutput >= limit
 	}
 	estimatedInput := e.currentTokenUsage()
@@ -300,10 +296,6 @@ func (e *Engine) currentInputTokensPreciselyIfDue(ctx context.Context, limit int
 	return e.currentInputTokensPreciselyIfDueWithPriority(ctx, limit, false)
 }
 
-func (e *Engine) currentInputTokensPreciselyIfCritical(ctx context.Context, limit int) (int, bool) {
-	return e.currentInputTokensPreciselyIfDueWithPriority(ctx, limit, true)
-}
-
 func (e *Engine) currentInputTokensPreciselyIfDueWithPriority(ctx context.Context, limit int, critical bool) (int, bool) {
 	if precise, ok := e.lookupCurrentPreciseInputTokens(); ok {
 		if !e.shouldRefreshCurrentPreciseInputTokens(limit, critical) {
@@ -318,10 +310,6 @@ func (e *Engine) currentInputTokensPreciselyIfDueWithPriority(ctx context.Contex
 		return 0, false
 	}
 	return e.requestInputTokensPreciselyTracked(ctx, req, true)
-}
-
-func (e *Engine) requestInputTokensPrecisely(ctx context.Context, req llm.Request) (int, bool) {
-	return e.requestInputTokensPreciselyTracked(ctx, req, false)
 }
 
 func (e *Engine) requestInputTokensPreciselyTracked(ctx context.Context, req llm.Request, current bool) (int, bool) {
@@ -345,7 +333,7 @@ func (e *Engine) requestInputTokensPreciselyTracked(ctx context.Context, req llm
 			return cached, true
 		}
 	}
-	if e.hasPersistedDiagnostic(preciseTokenCountFailureDiagnostic) {
+	if e.diagnosticDedupeStore().HasPersisted(preciseTokenCountFailureDiagnostic) {
 		return 0, false
 	}
 	count, err := counter.CountRequestInputTokens(ctx, req)
@@ -487,10 +475,6 @@ func (e *Engine) shouldRefreshCurrentPreciseInputTokens(limit int, critical bool
 	return e.modelRequests().TokenUsage().currentCheckpointDue(e.estimatedCurrentTokenUsage(), limit, critical)
 }
 
-func (e *Engine) contextWindowTokens() int {
-	return e.compactionPlannerState().contextWindowTokens(e.compactionPlanningSnapshot())
-}
-
 func (e *Engine) estimatedCurrentTokenUsage() int {
 	estimated := 0
 	if e != nil {
@@ -504,7 +488,7 @@ func (e *Engine) estimatedCurrentTokenUsage() int {
 	if estimated > 0 {
 		return estimated
 	}
-	usage := e.lastUsageSnapshot()
+	usage := e.usageTrackingState().Last()
 	if usage.InputTokens > 0 {
 		return usage.InputTokens
 	}
@@ -528,7 +512,7 @@ func (e *Engine) compactNow(ctx context.Context, stepID string, mode compactionM
 		return compactionResult{}, errCompactionDisabledModeNone
 	}
 
-	input := e.snapshotItems()
+	input := e.transcriptRuntimeState().SnapshotItems()
 	if len(input) == 0 {
 		return compactionResult{}, nil
 	}
@@ -544,7 +528,7 @@ func (e *Engine) compactNow(ctx context.Context, stepID string, mode compactionM
 		providerID = "unknown"
 	}
 
-	if err := e.emitCompactionStatus(stepID, EventCompactionStarted, mode, "selector", providerID, 0, 0, ""); err != nil {
+	if err := newCompactionPersistence(e).emitStatus(stepID, EventCompactionStarted, mode, "selector", providerID, 0, 0, ""); err != nil {
 		return compactionResult{}, err
 	}
 
@@ -564,21 +548,21 @@ func (e *Engine) compactNow(ctx context.Context, stepID string, mode compactionM
 		result, err = e.compactLocal(ctx, input, providerID, instructions, mode)
 	}
 	if err != nil {
-		statusErr := e.emitCompactionStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
+		statusErr := newCompactionPersistence(e).emitStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
 		return compactionResult{}, errors.Join(err, statusErr)
 	}
 
 	if len(result.items) == 0 {
 		err := errors.New("compaction returned empty replacement history")
-		statusErr := e.emitCompactionStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
+		statusErr := newCompactionPersistence(e).emitStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
 		return compactionResult{}, errors.Join(err, statusErr)
 	}
 
-	compactionNumber := e.compactionCountSnapshot() + 1
-	result.items = withCompactionSummaryLabel(result.items, CompactionNoticeText(compactionNumber))
+	compactionNumber := e.compactionRuntimeState().Count() + 1
+	result.items = withCompactionSummaryLabel(result.items, fmt.Sprintf("context compacted for the %s time", ordinal(compactionNumber)))
 	postReplacementMeta, err := e.compactionReinjectedMetaMessages(ctx)
 	if err != nil {
-		statusErr := e.emitCompactionStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
+		statusErr := newCompactionPersistence(e).emitStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
 		return compactionResult{}, errors.Join(err, statusErr)
 	}
 	// Reinject base meta as part of the single history_replaced commit so the
@@ -586,14 +570,14 @@ func (e *Engine) compactNow(ctx context.Context, stepID string, mode compactionM
 	// a compacted session that has a summary but no base meta, and the summary
 	// precedes the reinjected meta in both provider and transcript order.
 	replacementItems := append(llm.CloneResponseItems(result.items), llm.ItemsFromMessages(postReplacementMeta)...)
-	if err := e.replaceHistory(stepID, result.engine, mode, replacementItems); err != nil {
-		statusErr := e.emitCompactionStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
+	if err := newCompactionPersistence(e).replaceHistory(stepID, result.engine, mode, replacementItems); err != nil {
+		statusErr := newCompactionPersistence(e).emitStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
 		return compactionResult{}, errors.Join(err, statusErr)
 	}
 	if strings.TrimSpace(result.summary) != "" && result.engine != "local" {
 		summary := strings.TrimSpace(result.summary)
 		if err := e.steer(stepID, steerLocalEntryIntent(storedLocalEntry{Role: "compaction_summary", Text: summary})); err != nil {
-			statusErr := e.emitCompactionStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
+			statusErr := newCompactionPersistence(e).emitStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
 			return compactionResult{}, errors.Join(err, statusErr)
 		}
 	}
@@ -604,20 +588,20 @@ func (e *Engine) compactNow(ctx context.Context, stepID string, mode compactionM
 			result.overflowRepair.PatchInputsCollapsed,
 			result.overflowRepair.EstimatedSavedTokens,
 		)})); err != nil {
-			statusErr := e.emitCompactionStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
+			statusErr := newCompactionPersistence(e).emitStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
 			return compactionResult{}, errors.Join(err, statusErr)
 		}
 	}
-	if err := e.appendPostCompactionMessages(stepID, e.postCompactionMessages(mode, manualCarryover, e.store.Meta().HeadlessActive)); err != nil {
-		statusErr := e.emitCompactionStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
+	if err := newCompactionCarryoverCoordinator(e).appendPostCompactionMessages(stepID, newCompactionCarryoverCoordinator(e).postCompactionMessages(mode, manualCarryover, e.store.Meta().HeadlessActive)); err != nil {
+		statusErr := newCompactionPersistence(e).emitStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())
 		return compactionResult{}, errors.Join(err, statusErr)
 	}
-	compactionNumber = e.nextCompactionCount()
+	compactionNumber = e.compactionRuntimeState().IncrementCount()
 	windowTokens := result.usage.WindowTokens
 	if windowTokens <= 0 {
-		windowTokens = e.contextWindowTokens()
+		windowTokens = e.compactionPlannerState().contextWindowTokens(e.compactionPlanningSnapshot())
 	}
-	inputTokens := estimateItemsTokens(e.snapshotItems())
+	inputTokens := estimateItemsTokens(e.transcriptRuntimeState().SnapshotItems())
 	if preciseInput, ok := e.currentInputTokensPrecisely(ctx); ok {
 		inputTokens = preciseInput
 	}
@@ -629,7 +613,7 @@ func (e *Engine) compactNow(ctx context.Context, stepID string, mode compactionM
 		return compactionResult{}, err
 	}
 
-	if err := e.emitCompactionStatus(stepID, EventCompactionCompleted, mode, result.engine, providerID, result.trimmedItemsCount, compactionNumber, ""); err != nil {
+	if err := newCompactionPersistence(e).emitStatus(stepID, EventCompactionCompleted, mode, result.engine, providerID, result.trimmedItemsCount, compactionNumber, ""); err != nil {
 		return compactionResult{}, err
 	}
 	return result, nil
@@ -657,30 +641,6 @@ func lastVisibleUserMessageSinceLatestCompaction(items []llm.ResponseItem) strin
 	return ""
 }
 
-func (e *Engine) queueHandoffRequest(summarizerPrompt string, futureAgentMessage string) {
-	e.handoffRuntimeState().QueueRequest(summarizerPrompt, futureAgentMessage)
-}
-
-func (e *Engine) clearPendingHandoffRequest() {
-	e.handoffRuntimeState().ClearRequest()
-}
-
-func (e *Engine) queuePendingHandoffFutureMessage(message string) {
-	e.handoffRuntimeState().QueueFutureMessage(message)
-}
-
-func (e *Engine) clearPendingHandoffFutureMessage() {
-	e.handoffRuntimeState().ClearFutureMessage()
-}
-
-func (e *Engine) pendingHandoffRequestSnapshot() *handoffRequest {
-	return e.handoffRuntimeState().RequestSnapshot()
-}
-
-func (e *Engine) pendingHandoffFutureMessageSnapshot() string {
-	return e.handoffRuntimeState().FutureMessageSnapshot()
-}
-
 func (e *Engine) handoffRuntimeState() *handoffRuntimeState {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -691,24 +651,24 @@ func (e *Engine) handoffRuntimeState() *handoffRuntimeState {
 }
 
 func (e *Engine) applyPendingHandoffIfNeeded(ctx context.Context, stepID string) (bool, error) {
-	if futureMessage := e.pendingHandoffFutureMessageSnapshot(); futureMessage != "" {
-		if err := e.steer(stepID, steerMessageIntent(handoffFutureAgentMessage(futureMessage))); err != nil {
+	if futureMessage := e.handoffRuntimeState().FutureMessageSnapshot(); futureMessage != "" {
+		if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{handoffFutureAgentMessage(futureMessage)})); err != nil {
 			return false, err
 		}
-		e.clearPendingHandoffFutureMessage()
+		e.handoffRuntimeState().ClearFutureMessage()
 		return false, nil
 	}
-	req := e.pendingHandoffRequestSnapshot()
+	req := e.handoffRuntimeState().RequestSnapshot()
 	if req == nil {
 		return false, nil
 	}
 	if _, err := e.compactNow(ctx, stepID, compactionModeHandoff, req.summarizerPrompt, false); err != nil {
-		if e.pendingHandoffFutureMessageSnapshot() != "" {
-			e.clearPendingHandoffRequest()
+		if e.handoffRuntimeState().FutureMessageSnapshot() != "" {
+			e.handoffRuntimeState().ClearRequest()
 		}
 		return false, err
 	}
-	e.clearPendingHandoffRequest()
+	e.handoffRuntimeState().ClearRequest()
 	return true, nil
 }
 
@@ -755,7 +715,7 @@ func (e *Engine) compactionPlanningSnapshot() compactionPlanningSnapshot {
 	}
 	e.mu.Unlock()
 	snapshot.lockedMaxOutputTokens = e.lockedContractState().MaxOutputToken()
-	snapshot.lastUsage = e.lastUsageSnapshot()
+	snapshot.lastUsage = e.usageTrackingState().Last()
 	snapshot.currentUsedTokens = e.currentTokenUsage()
 	return snapshot
 }

--- a/server/runtime/compaction_carryover.go
+++ b/server/runtime/compaction_carryover.go
@@ -45,10 +45,6 @@ func handoffFutureAgentMessage(text string) llm.Message {
 	}
 }
 
-func (e *Engine) postCompactionMessages(mode compactionMode, manualCarryover string, headlessActive bool) []postCompactionMessage {
-	return newCompactionCarryoverCoordinator(e).postCompactionMessages(mode, manualCarryover, headlessActive)
-}
-
 func (c compactionCarryoverCoordinator) postCompactionMessages(mode compactionMode, manualCarryover string, headlessActive bool) []postCompactionMessage {
 	e := c.engine
 	out := make([]postCompactionMessage, 0, 3)
@@ -58,7 +54,7 @@ func (c compactionCarryoverCoordinator) postCompactionMessages(mode compactionMo
 		}
 	}
 	if mode == compactionModeHandoff {
-		if req := e.pendingHandoffRequestSnapshot(); req != nil {
+		if req := e.handoffRuntimeState().RequestSnapshot(); req != nil {
 			if strings.TrimSpace(req.futureAgentMessage) != "" {
 				futureMessage := handoffFutureAgentMessage(req.futureAgentMessage)
 				out = append(out, postCompactionMessage{
@@ -81,28 +77,24 @@ func (c compactionCarryoverCoordinator) postCompactionMessages(mode compactionMo
 	return out
 }
 
-func (e *Engine) appendPostCompactionMessages(stepID string, messages []postCompactionMessage) error {
-	return newCompactionCarryoverCoordinator(e).appendPostCompactionMessages(stepID, messages)
-}
-
 func (c compactionCarryoverCoordinator) appendPostCompactionMessages(stepID string, messages []postCompactionMessage) error {
 	e := c.engine
 	for _, item := range messages {
 		message := item.message
 		switch message.MessageType {
 		case llm.MessageTypeManualCompactionCarryover:
-			if err := e.steer(stepID, steerMessageWithoutDerivedEventIntent(message)); err != nil {
+			if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventNone, true, []llm.Message{message})); err != nil {
 				return err
 			}
 		default:
-			if err := e.steer(stepID, steerMessageIntent(message)); err != nil {
+			if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{message})); err != nil {
 				if message.MessageType == llm.MessageTypeHandoffFutureMessage {
-					e.queuePendingHandoffFutureMessage(item.pendingHandoffFutureText)
+					e.handoffRuntimeState().QueueFutureMessage(item.pendingHandoffFutureText)
 				}
 				return err
 			}
 			if message.MessageType == llm.MessageTypeHandoffFutureMessage {
-				e.clearPendingHandoffFutureMessage()
+				e.handoffRuntimeState().ClearFutureMessage()
 			}
 		}
 	}

--- a/server/runtime/compaction_carryover_test.go
+++ b/server/runtime/compaction_carryover_test.go
@@ -20,7 +20,7 @@ func TestPostCompactionMessagesSkipsEmptyHandoffFutureMessage(t *testing.T) {
 	state.QueueRequest("keep API details", " \n\t ")
 	eng := &Engine{handoffState: state}
 
-	messages := eng.postCompactionMessages(compactionModeHandoff, "", false)
+	messages := newCompactionCarryoverCoordinator(eng).postCompactionMessages(compactionModeHandoff, "", false)
 	for _, message := range messages {
 		if message.message.MessageType == llm.MessageTypeHandoffFutureMessage {
 			t.Fatalf("did not expect empty handoff future message carryover: %+v", message)

--- a/server/runtime/compaction_executor.go
+++ b/server/runtime/compaction_executor.go
@@ -72,7 +72,7 @@ func (e *Engine) compactWithContextRepairRetry(
 ) (llm.CompactionResponse, []llm.ResponseItem, compactionOverflowRepairStats, error) {
 	currentInput := llm.CloneResponseItems(request.InputItems)
 	repairStats := compactionOverflowRepairStats{}
-	contextWindowTokens := e.contextWindowTokens()
+	contextWindowTokens := e.compactionPlannerState().contextWindowTokens(e.compactionPlanningSnapshot())
 
 	// send issues one compaction request. canRepair is set only for the first,
 	// uncollapsed send: a missing-tool-output HTTP 400 there is repaired in place
@@ -97,7 +97,7 @@ func (e *Engine) compactWithContextRepairRetry(
 		if repaired == 0 {
 			return resp, items, err
 		}
-		repairedItems := llm.CloneResponseItems(e.snapshotItems())
+		repairedItems := llm.CloneResponseItems(e.transcriptRuntimeState().SnapshotItems())
 		req.InputItems = llm.CloneResponseItems(repairedItems)
 		resp, err = e.compactWithRetry(ctx, stepID, client, req)
 		return resp, repairedItems, err
@@ -179,7 +179,7 @@ func (e *Engine) compactionCacheObservationRequest(ctx context.Context, request 
 	if e == nil {
 		return llm.Request{}, false, nil
 	}
-	cacheKey := e.conversationPromptCacheKey()
+	cacheKey := conversationPromptCacheKey(e.SessionID(), e.compactionRuntimeState().Count())
 	if cacheKey == "" {
 		return llm.Request{}, false, nil
 	}
@@ -202,7 +202,7 @@ func (e *Engine) compactionCacheObservationRequest(ctx context.Context, request 
 	}
 	req.ReasoningEffort = e.ThinkingLevel()
 	req.FastMode = e.FastModeEnabled()
-	req.SessionID = e.conversationSessionID()
+	req.SessionID = e.SessionID()
 	req.PromptCacheKey = cacheKey
 	req.PromptCacheScope = transcript.CacheWarningScopeConversation
 	return req, true, nil
@@ -227,7 +227,7 @@ func (e *Engine) compactLocal(ctx context.Context, input []llm.ResponseItem, pro
 	return compactionResult{
 		engine:            "local",
 		items:             replacement,
-		usage:             llm.Usage{InputTokens: usageInputTokens, WindowTokens: e.contextWindowTokens()},
+		usage:             llm.Usage{InputTokens: usageInputTokens, WindowTokens: e.compactionPlannerState().contextWindowTokens(e.compactionPlanningSnapshot())},
 		trimmedItemsCount: 0,
 		overflowRepair:    repairStats,
 		provider:          providerID,
@@ -256,7 +256,7 @@ func (e *Engine) localCompactionSummaryWithRepair(ctx context.Context, input []l
 	requestTools := e.requestTools(ctx, workflowMode)
 	window := localCompactionWindow(input)
 	repairStats := compactionOverflowRepairStats{}
-	contextWindowTokens := e.contextWindowTokens()
+	contextWindowTokens := e.compactionPlannerState().contextWindowTokens(e.compactionPlanningSnapshot())
 	// summarize mirrors the remote send closure: it repairs a missing-tool-output
 	// HTTP 400 (append + re-snapshot + retry) only on the first, uncollapsed
 	// window. After a collapse, output items are preserved, so a missing-output
@@ -276,7 +276,7 @@ func (e *Engine) localCompactionSummaryWithRepair(ctx context.Context, input []l
 		if repaired == 0 {
 			return summary, w, err
 		}
-		repairedWindow := localCompactionWindow(e.snapshotItems())
+		repairedWindow := localCompactionWindow(e.transcriptRuntimeState().SnapshotItems())
 		summary, err = e.localCompactionSummaryFromWindow(ctx, locked, systemPrompt, repairedWindow, instructions, requestTools, mode)
 		return summary, repairedWindow, err
 	}
@@ -317,15 +317,15 @@ func (e *Engine) localCompactionSummaryFromWindow(ctx context.Context, locked se
 		}
 		req.ReasoningEffort = e.ThinkingLevel()
 		req.FastMode = e.FastModeEnabled()
-		req.SessionID = e.conversationSessionID()
+		req.SessionID = e.SessionID()
 		if e.supportsPromptCacheKey(ctx) {
-			if cacheKey := e.conversationPromptCacheKey(); cacheKey != "" {
+			if cacheKey := conversationPromptCacheKey(e.SessionID(), e.compactionRuntimeState().Count()); cacheKey != "" {
 				req.PromptCacheKey = cacheKey
 				req.PromptCacheScope = transcript.CacheWarningScopeConversation
 			}
 		}
 
-		resp, err := e.generateWithRetry(ctx, "", req, nil, nil, nil)
+		resp, err := e.generateWithRetryClient(ctx, "", e.llm, req, nil, nil, nil)
 		if err != nil {
 			return "", err
 		}

--- a/server/runtime/compaction_overflow_repair_test.go
+++ b/server/runtime/compaction_overflow_repair_test.go
@@ -178,22 +178,22 @@ func TestLocalCompactionCollapsesToolPayloadAfterOverflow(t *testing.T) {
 		}},
 	}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
 		ID:    "call-shell",
 		Name:  string(toolspec.ToolExecCommand),
 		Input: json.RawMessage(`{"cmd":"go test ./..."}`),
-	}}})); err != nil {
+	}}}})); err != nil {
 		t.Fatalf("append assistant tool call: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{
 		Role:       llm.RoleTool,
 		ToolCallID: "call-shell",
 		Name:       string(toolspec.ToolExecCommand),
 		Content:    `{"output":"` + strings.Repeat("x", 120_000) + `"}`,
-	})); err != nil {
+	}})); err != nil {
 		t.Fatalf("append tool output: %v", err)
 	}
 
@@ -240,13 +240,13 @@ func TestLocalCompactionFailsFastWhenOverflowHasNoCollapsibleToolPayload(t *test
 		}},
 	}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: strings.Repeat("chat-heavy-history", 12_000)})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: strings.Repeat("chat-heavy-history", 12_000)}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, ReasoningItems: []llm.ReasoningItem{{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, ReasoningItems: []llm.ReasoningItem{{
 		ID:               "rs-heavy",
 		EncryptedContent: strings.Repeat("reasoning-heavy-history", 12_000),
-	}}})); err != nil {
+	}}}})); err != nil {
 		t.Fatalf("append reasoning message: %v", err)
 	}
 
@@ -276,30 +276,30 @@ func TestLocalCompactionUsesTenTwentyFortyPercentRepairScheduleFromConfiguredCon
 		}},
 	}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local", ContextWindowTokens: 100_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, ReasoningItems: []llm.ReasoningItem{{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, ReasoningItems: []llm.ReasoningItem{{
 		ID:               "rs-keep",
 		EncryptedContent: strings.Repeat("reasoning", 2_000),
-	}}})); err != nil {
+	}}}})); err != nil {
 		t.Fatalf("append reasoning item: %v", err)
 	}
 	for idx := 0; idx < 5; idx++ {
 		callID := fmt.Sprintf("call-shell-%d", idx)
-		if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
+		if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
 			ID:    callID,
 			Name:  string(toolspec.ToolExecCommand),
 			Input: json.RawMessage(`{"cmd":"echo hi"}`),
-		}}})); err != nil {
+		}}}})); err != nil {
 			t.Fatalf("append assistant tool call %d: %v", idx, err)
 		}
-		if err := eng.steer("", steerMessageIntent(llm.Message{
+		if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{
 			Role:       llm.RoleTool,
 			ToolCallID: callID,
 			Name:       string(toolspec.ToolExecCommand),
 			Content:    `{"output":"` + strings.Repeat("x", 48_000) + `"}`,
-		})); err != nil {
+		}})); err != nil {
 			t.Fatalf("append tool output %d: %v", idx, err)
 		}
 	}

--- a/server/runtime/compaction_persistence.go
+++ b/server/runtime/compaction_persistence.go
@@ -15,10 +15,6 @@ func newCompactionPersistence(engine *Engine) compactionPersistence {
 	return compactionPersistence{engine: engine}
 }
 
-func (e *Engine) replaceHistory(stepID, engine string, mode compactionMode, items []llm.ResponseItem) error {
-	return newCompactionPersistence(e).replaceHistory(stepID, engine, mode, items)
-}
-
 func (p compactionPersistence) replaceHistory(stepID, engine string, mode compactionMode, items []llm.ResponseItem) error {
 	e := p.engine
 	workflowRunID := ""
@@ -26,10 +22,6 @@ func (p compactionPersistence) replaceHistory(stepID, engine string, mode compac
 		workflowRunID = strings.TrimSpace(string(e.cfg.WorkflowRun.RunID))
 	}
 	return e.steer(stepID, steerHistoryReplacementIntent(engine, mode, workflowRunID, items))
-}
-
-func (e *Engine) emitCompactionStatus(stepID string, kind EventKind, mode compactionMode, engine, provider string, trimmed, count int, errText string) error {
-	return newCompactionPersistence(e).emitStatus(stepID, kind, mode, engine, provider, trimmed, count, errText)
 }
 
 func (p compactionPersistence) emitStatus(stepID string, kind EventKind, mode compactionMode, engine, provider string, trimmed, count int, errText string) error {
@@ -45,35 +37,39 @@ func (p compactionPersistence) emitStatus(stepID string, kind EventKind, mode co
 
 	switch kind {
 	case EventCompactionStarted:
-		return e.steerEvent(stepID, Event{
+		return e.steer(stepID, steerEventIntent(Event{
 			Kind:       kind,
 			StepID:     stepID,
 			Compaction: status,
-		})
+		}))
+
 	case EventCompactionCompleted:
-		return e.steerEvent(stepID, Event{
+		return e.steer(stepID, steerEventIntent(Event{
 			Kind:       kind,
 			StepID:     stepID,
 			Compaction: status,
-		})
+		}))
+
 	case EventCompactionFailed:
 		message := fmt.Sprintf("Context compaction failed (%s): %s", status.Mode, status.Error)
 		if strings.TrimSpace(status.Error) == "" {
 			message = fmt.Sprintf("Context compaction failed (%s).", status.Mode)
 		}
 		if err := e.steer(stepID, steerLocalEntryIntent(storedLocalEntry{Role: "error", Text: message})); err != nil {
-			_ = e.steerEvent(stepID, Event{
+			_ = e.steer(stepID, steerEventIntent(Event{
 				Kind:       kind,
 				StepID:     stepID,
 				Compaction: status,
-			})
+			}))
+
 			return err
 		}
-		return e.steerEvent(stepID, Event{
+		return e.steer(stepID, steerEventIntent(Event{
 			Kind:       kind,
 			StepID:     stepID,
 			Compaction: status,
-		})
+		}))
+
 	default:
 		return nil
 	}

--- a/server/runtime/compaction_reminder.go
+++ b/server/runtime/compaction_reminder.go
@@ -16,10 +16,6 @@ func newCompactionReminderCoordinator(engine *Engine) compactionReminderCoordina
 	return compactionReminderCoordinator{engine: engine}
 }
 
-func (e *Engine) maybeAppendCompactionSoonReminder(ctx context.Context, stepID string) error {
-	return newCompactionReminderCoordinator(e).maybeAppend(ctx, stepID)
-}
-
 func (c compactionReminderCoordinator) maybeAppend(ctx context.Context, stepID string) error {
 	e := c.engine
 	planningSnapshot := e.compactionPlanningSnapshot()
@@ -53,11 +49,11 @@ func (c compactionReminderCoordinator) maybeAppend(ctx context.Context, stepID s
 	if content == "" {
 		return nil
 	}
-	if err := e.steer(stepID, steerMessageIntent(llm.Message{
+	if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{
 		Role:        llm.RoleDeveloper,
 		MessageType: llm.MessageTypeCompactionSoonReminder,
 		Content:     content,
-	})); err != nil {
+	}})); err != nil {
 		return err
 	}
 	return e.persistCompactionSoonReminderIssued(true)
@@ -67,16 +63,8 @@ func (e *Engine) estimatedToolCallsUntilForcedHandoff() int {
 	return e.compactionPlannerState().estimatedToolCallsUntilForcedHandoff(e.compactionPlanningSnapshot())
 }
 
-func (e *Engine) handoffToolEnabled() bool {
-	return e.compactionRuntimeState().SoonReminderIssued()
-}
-
-func (e *Engine) setCompactionSoonReminderIssued(issued bool) {
-	e.compactionRuntimeState().SetSoonReminderIssued(issued)
-}
-
 func (e *Engine) persistCompactionSoonReminderIssued(issued bool) error {
-	e.setCompactionSoonReminderIssued(issued)
+	e.compactionRuntimeState().SetSoonReminderIssued(issued)
 	return e.store.SetCompactionSoonReminderIssued(issued)
 }
 

--- a/server/runtime/compaction_trim_test.go
+++ b/server/runtime/compaction_trim_test.go
@@ -28,13 +28,13 @@ func TestCompactionCacheObservationRequestAppendsPromptToConversationReplica(t *
 		t.Fatalf("inject agents: %v", err)
 	}
 
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: seedContent})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: seedContent}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "call-1", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{"command":"pwd"}`)}}})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "call-1", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{"command":"pwd"}`)}}}})); err != nil {
 		t.Fatalf("append assistant tool call: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleTool, ToolCallID: "call-1", Name: string(toolspec.ToolExecCommand), Content: `{"output":"/tmp"}`})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleTool, ToolCallID: "call-1", Name: string(toolspec.ToolExecCommand), Content: `{"output":"/tmp"}`}})); err != nil {
 		t.Fatalf("append tool output message: %v", err)
 	}
 
@@ -42,7 +42,7 @@ func TestCompactionCacheObservationRequestAppendsPromptToConversationReplica(t *
 	request, ok, err := eng.compactionCacheObservationRequest(context.Background(), llm.CompactionRequest{
 		Model:        "gpt-5",
 		Instructions: compactionInstructions(args),
-		InputItems:   eng.snapshotItems(),
+		InputItems:   eng.transcriptRuntimeState().SnapshotItems(),
 	})
 	if err != nil {
 		t.Fatalf("build compaction cache observation request: %v", err)
@@ -51,7 +51,7 @@ func TestCompactionCacheObservationRequestAppendsPromptToConversationReplica(t *
 		t.Fatal("expected compaction cache observation request")
 	}
 
-	wantItems := append(llm.CloneResponseItems(eng.snapshotItems()), llm.ResponseItem{
+	wantItems := append(llm.CloneResponseItems(eng.transcriptRuntimeState().SnapshotItems()), llm.ResponseItem{
 		Type:    llm.ResponseItemTypeMessage,
 		Role:    llm.RoleDeveloper,
 		Content: compactionInstructions(args),
@@ -76,7 +76,7 @@ func TestCompactionCacheObservationRequestAppendsPromptToConversationReplica(t *
 	if !foundSeed {
 		t.Fatalf("expected compaction cache request to preserve exact ANSI message %q, messages=%+v", seedContent, requestMessages(request))
 	}
-	if got, want := request.PromptCacheKey, eng.conversationPromptCacheKey(); got != want {
+	if got, want := request.PromptCacheKey, conversationPromptCacheKey(eng.SessionID(), eng.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("PromptCacheKey = %q, want %q", got, want)
 	}
 	if got, want := request.PromptCacheScope, transcript.CacheWarningScopeConversation; got != want {
@@ -125,24 +125,24 @@ func TestRemoteCompactionCollapsesToolPayloadAfterOverflowAndWarnsOnCacheBreak(t
 		t.Fatalf("inject agents: %v", err)
 	}
 
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 	reasoningPayload := strings.Repeat("encrypted-reasoning", 4_000)
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, ReasoningItems: []llm.ReasoningItem{{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, ReasoningItems: []llm.ReasoningItem{{
 		ID:               "rs-preserve",
 		EncryptedContent: reasoningPayload,
-	}}})); err != nil {
+	}}}})); err != nil {
 		t.Fatalf("append reasoning message: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "call-1", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{"command":"pwd"}`)}}})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "call-1", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{"command":"pwd"}`)}}}})); err != nil {
 		t.Fatalf("append assistant tool call: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleTool, ToolCallID: "call-1", Name: string(toolspec.ToolExecCommand), Content: `{"output":"` + strings.Repeat("x", 120_000) + `"}`})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleTool, ToolCallID: "call-1", Name: string(toolspec.ToolExecCommand), Content: `{"output":"` + strings.Repeat("x", 120_000) + `"}`}})); err != nil {
 		t.Fatalf("append tool output message: %v", err)
 	}
 
-	initialSnapshot := eng.snapshotItems()
+	initialSnapshot := eng.transcriptRuntimeState().SnapshotItems()
 	initialJSON, err := json.Marshal(initialSnapshot)
 	if err != nil {
 		t.Fatalf("marshal initial snapshot: %v", err)
@@ -261,26 +261,26 @@ func TestRemoteCompactionDoesNotRepairUnsupportedViewImagePayload(t *testing.T) 
 		t.Fatalf("inject agents: %v", err)
 	}
 
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
 		ID:    "call-view-image-1",
 		Name:  string(toolspec.ToolViewImage),
 		Input: json.RawMessage(`{"path":"doc.pdf"}`),
-	}}})); err != nil {
+	}}}})); err != nil {
 		t.Fatalf("append assistant tool call: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{
 		Role:       llm.RoleTool,
 		ToolCallID: "call-view-image-1",
 		Name:       string(toolspec.ToolViewImage),
 		Content:    `[{"type":"input_file","file_data":"data:application/pdf;base64,Zm9v","filename":"doc.pdf"}]`,
-	})); err != nil {
+	}})); err != nil {
 		t.Fatalf("append tool output message: %v", err)
 	}
 
-	initialSnapshot := eng.snapshotItems()
+	initialSnapshot := eng.transcriptRuntimeState().SnapshotItems()
 	initialCall, initialOutput, initialPromoted := viewImageProviderUnitPresence(initialSnapshot, "call-view-image-1")
 	if !initialCall || !initialOutput || !initialPromoted {
 		t.Fatalf("expected initial snapshot to include complete promoted view_image unit, got call=%v output=%v promoted=%v items=%+v", initialCall, initialOutput, initialPromoted, initialSnapshot)
@@ -329,13 +329,13 @@ func TestRemoteCompactionFailsFastWhenOverflowHasNoCollapsibleToolPayload(t *tes
 	if err := eng.steerBaseMetaContextIfNeeded("seed-step"); err != nil {
 		t.Fatalf("inject agents: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: strings.Repeat("chat-heavy-history", 12_000)})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: strings.Repeat("chat-heavy-history", 12_000)}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, ReasoningItems: []llm.ReasoningItem{{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, ReasoningItems: []llm.ReasoningItem{{
 		ID:               "rs-heavy",
 		EncryptedContent: strings.Repeat("reasoning-heavy-history", 12_000),
-	}}})); err != nil {
+	}}}})); err != nil {
 		t.Fatalf("append reasoning message: %v", err)
 	}
 
@@ -392,7 +392,7 @@ func TestCompactionTransientRetryObservesCacheLineageOnce(t *testing.T) {
 	if err := eng.steerBaseMetaContextIfNeeded("seed-step"); err != nil {
 		t.Fatalf("inject agents: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 

--- a/server/runtime/compaction_utils.go
+++ b/server/runtime/compaction_utils.go
@@ -40,10 +40,6 @@ func (e *Engine) currentProviderCapabilities(ctx context.Context) (llm.ProviderC
 	return providerCaps, nil
 }
 
-func CompactionNoticeText(count int) string {
-	return fmt.Sprintf("context compacted for the %s time", ordinal(count))
-}
-
 func ordinal(v int) string {
 	if v <= 0 {
 		return "0th"
@@ -68,7 +64,7 @@ func (e *Engine) inputTokensForItems(ctx context.Context, model string, instruct
 	if !ok {
 		return 0, false
 	}
-	return e.requestInputTokensPrecisely(ctx, req)
+	return e.requestInputTokensPreciselyTracked(ctx, req, false)
 }
 
 func buildTokenCountRequestForItems(model string, instructions string, items []llm.ResponseItem) (llm.Request, bool) {

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -319,7 +319,7 @@ func New(store *session.Store, client llm.Client, registry *tools.Registry, cfg 
 	}
 	eng.restorePersistedUsageState(meta.UsageState)
 	if meta.InFlightStep {
-		if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeInterruption, Content: interruptMessage})); err != nil {
+		if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeInterruption, Content: interruptMessage}})); err != nil {
 			return nil, err
 		}
 		if err := store.MarkInFlight(false); err != nil {
@@ -416,14 +416,14 @@ func (e *Engine) SubmitUserMessage(ctx context.Context, text string) (assistant 
 		}
 		userMessage := llm.Message{Role: llm.RoleUser, Content: text}
 		if !hasQueuedInjected {
-			intents := []steeringIntent{steerUserMessageWithoutDerivedEventIntent(userMessage)}
+			intents := []steeringIntent{steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventNone, true, []llm.Message{userMessage})}
 			if flushed := flushedUserMessageEvent(userMessage, stepID); flushed != nil {
 				intents = append(intents, steerEventIntent(*flushed))
 			}
 			if err := e.steer(stepID, intents...); err != nil {
 				return err
 			}
-		} else if err := e.steer(stepID, steerUserMessageIntent(userMessage)); err != nil {
+		} else if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventDefault, true, []llm.Message{userMessage})); err != nil {
 			return err
 		}
 		msg, runErr := e.runStepLoop(stepCtx, stepID)
@@ -470,17 +470,17 @@ func (e *Engine) SubmitUserShellCommand(ctx context.Context, command string) (re
 				"user_initiated": true,
 			}),
 		}
-		if err := e.steer(stepID, steerMessageWithoutDerivedEventIntent(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{call}})); err != nil {
+		if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventNone, true, []llm.Message{{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{call}}})); err != nil {
 			return err
 		}
 		if _, ok := e.registry.Get(toolspec.ToolExecCommand); !ok {
 			transcriptCall := normalizeToolCallForTranscript(call, e.transcriptWorkingDir())
-			_ = e.steerEvent(stepID, Event{Kind: EventToolCallStarted, StepID: stepID, ToolCall: &transcriptCall, CommittedTranscriptChanged: true})
+			_ = e.steer(stepID, steerEventIntent(Event{Kind: EventToolCallStarted, StepID: stepID, ToolCall: &transcriptCall, CommittedTranscriptChanged: true}))
 			result = tools.Result{CallID: call.ID, Name: toolspec.ToolExecCommand, IsError: true, Output: mustJSON(map[string]any{"error": "unknown tool"}), Summary: "unknown tool"}
 			if err := e.steer(stepID, steerToolCompletionIntent(result)); err != nil {
 				return fmt.Errorf("%w (call_id=%s tool=%s): %w", errPersistToolCompletion, call.ID, result.Name, err)
 			}
-			if appendErr := e.steer(stepID, steerMessageIntent(llm.Message{Role: llm.RoleTool, Content: string(result.Output), ToolCallID: result.CallID, Name: string(result.Name)})); appendErr != nil {
+			if appendErr := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleTool, Content: string(result.Output), ToolCallID: result.CallID, Name: string(result.Name)}})); appendErr != nil {
 				return appendErr
 			}
 			return errUnknownTool
@@ -491,7 +491,7 @@ func (e *Engine) SubmitUserShellCommand(ctx context.Context, command string) (re
 			return errors.New("shell tool execution returned no result")
 		}
 		result = results[0]
-		if appendErr := e.steer(stepID, steerMessageIntent(llm.Message{Role: llm.RoleTool, Content: string(result.Output), ToolCallID: result.CallID, Name: string(result.Name)})); appendErr != nil {
+		if appendErr := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleTool, Content: string(result.Output), ToolCallID: result.CallID, Name: string(result.Name)}})); appendErr != nil {
 			return errors.Join(execErr, appendErr)
 		}
 		return execErr
@@ -501,7 +501,7 @@ func (e *Engine) SubmitUserShellCommand(ctx context.Context, command string) (re
 
 func (e *Engine) runStepLoop(ctx context.Context, stepID string) (llm.Message, error) {
 	reviewerFrequency := e.ReviewerFrequency()
-	reviewerClient := e.reviewerClientSnapshot()
+	reviewerClient := e.reviewerRuntimeState().Client()
 	result, err := e.runStepLoopWithOptions(ctx, stepID, reviewerFrequency, reviewerClient, true, true)
 	if result.NoopFinalAnswer {
 		return llm.Message{}, err
@@ -575,10 +575,6 @@ func (e *Engine) ensureLocked() (session.LockedContract, error) {
 	return lock, nil
 }
 
-func (e *Engine) generateWithRetry(ctx context.Context, stepID string, req llm.Request, onDelta func(string), onReasoningDelta func(llm.ReasoningSummaryDelta), onAttemptReset func()) (llm.Response, error) {
-	return e.generateWithRetryClient(ctx, stepID, e.llm, req, onDelta, onReasoningDelta, onAttemptReset)
-}
-
 // generateWithMissingToolOutputRepair runs a model turn, and on a provider HTTP
 // 400 attempts an append-only repair that closes any interrupted tool calls that
 // lack outputs, then rebuilds the request and retries. The request is rebuilt
@@ -610,7 +606,7 @@ func (e *Engine) generateWithMissingToolOutputRepair(ctx context.Context, stepID
 				onReasoningDelta(delta)
 			}
 		}
-		resp, err := e.generateWithRetry(ctx, stepID, req, wrappedDelta, wrappedReasoningDelta, onAttemptReset)
+		resp, err := e.generateWithRetryClient(ctx, stepID, e.llm, req, wrappedDelta, wrappedReasoningDelta, onAttemptReset)
 		if err == nil {
 			return resp, nil
 		}

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -34,7 +34,7 @@ func (e *Engine) persistToolCompletionRaw(stepID string, r tools.Result) error {
 	_, _, err := e.store.AppendEvent(stepID, "tool_completed", payload)
 	if err == nil {
 		e.markCurrentRequestShapeDirtyForSignificantMutation()
-		e.transcriptPersistence().RecordStoredToolCompletion(payload)
+		newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).RecordStoredToolCompletion(payload)
 	}
 	return err
 }
@@ -45,7 +45,7 @@ func (e *Engine) providerItemsForToolCompletion(r tools.Result) []llm.ResponseIt
 		return nil
 	}
 	var callItem *llm.ResponseItem
-	for _, item := range e.snapshotItems() {
+	for _, item := range e.transcriptRuntimeState().SnapshotItems() {
 		if !isToolCallItem(item.Type) {
 			continue
 		}
@@ -82,7 +82,7 @@ func (e *Engine) steerPersistedDiagnosticEntry(stepID, diagnosticKey, role, text
 			Text:       text,
 		}))
 	}
-	if !e.beginLocalDiagnostic(diagnosticKey) {
+	if !e.diagnosticDedupeStore().BeginLocal(diagnosticKey) {
 		return nil
 	}
 	entry := storedLocalEntry{
@@ -95,11 +95,11 @@ func (e *Engine) steerPersistedDiagnosticEntry(stepID, diagnosticKey, role, text
 	entry.Text = strings.TrimSpace(entry.Text)
 	entry.DiagnosticKey = strings.TrimSpace(entry.DiagnosticKey)
 	if entry.Role == "" || entry.Text == "" {
-		e.clearLocalDiagnostic(diagnosticKey)
+		e.diagnosticDedupeStore().ClearLocal(diagnosticKey)
 		return nil
 	}
 	if err := e.steer(stepID, steerLocalEntryIntent(entry)); err != nil {
-		e.clearLocalDiagnostic(diagnosticKey)
+		e.diagnosticDedupeStore().ClearLocal(diagnosticKey)
 		return err
 	}
 	return nil
@@ -121,7 +121,7 @@ func (e *Engine) appendPersistedLocalEntryRecordRaw(stepID string, entry storedL
 	}
 	_, _, err := e.store.AppendEvent(stepID, "local_entry", entry)
 	if err == nil {
-		e.transcriptPersistence().AppendLocalEntryRecord(*localEntryChatEntry(entry))
+		newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).AppendLocalEntryRecord(*localEntryChatEntry(entry))
 		e.emitRaw(Event{Kind: EventLocalEntryAdded, StepID: stepID, LocalEntry: localEntryChatEntry(entry), CommittedTranscriptChanged: true})
 	}
 	return err
@@ -135,22 +135,6 @@ func localEntryChatEntry(entry storedLocalEntry) *ChatEntry {
 		OngoingText: strings.TrimSpace(entry.OngoingText),
 		NoticeID:    strings.TrimSpace(entry.NoticeID),
 	}
-}
-
-func (e *Engine) beginLocalDiagnostic(key string) bool {
-	return e.diagnosticDedupeStore().BeginLocal(key)
-}
-
-func (e *Engine) clearLocalDiagnostic(key string) {
-	e.diagnosticDedupeStore().ClearLocal(key)
-}
-
-func (e *Engine) restoreLocalDiagnostic(key string) {
-	e.diagnosticDedupeStore().RestoreLocal(key)
-}
-
-func (e *Engine) hasPersistedDiagnostic(key string) bool {
-	return e.diagnosticDedupeStore().HasPersisted(key)
 }
 
 func (e *Engine) resetLocalDiagnostics() {
@@ -182,7 +166,7 @@ func (e *Engine) appendMessageRaw(stepID string, msg llm.Message, eventPolicy st
 	} else {
 		e.markCurrentRequestShapeDirty()
 	}
-	e.transcriptPersistence().AppendMessage(msg)
+	newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).AppendMessage(msg)
 	if persist {
 		if _, _, err := e.store.AppendEvent(stepID, "message", msg); err != nil {
 			return err
@@ -214,7 +198,7 @@ func (e *Engine) appendQueuedUserMessageFlush(stepID string, text string, batch 
 	if _, _, err := e.store.AppendEvent(stepID, "message", msg); err != nil {
 		return err
 	}
-	e.transcriptPersistence().AppendMessage(msg)
+	newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).AppendMessage(msg)
 	e.emitRaw(Event{
 		Kind:                         EventUserMessageFlushed,
 		StepID:                       stepID,
@@ -241,7 +225,7 @@ func normalizedQueueItemIDs(raw []string) []string {
 }
 
 func (e *Engine) clearStreamingAssistantStateRaw(stepID string) {
-	e.transcriptPersistence().ClearStreamingAssistantState()
+	newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).ClearStreamingAssistantState()
 	e.emitRaw(Event{Kind: EventConversationUpdated, StepID: stepID})
 	e.emitRaw(Event{Kind: EventAssistantDeltaReset, StepID: stepID})
 	e.emitRaw(Event{Kind: EventReasoningDeltaReset, StepID: stepID})

--- a/server/runtime/engine_part10_test.go
+++ b/server/runtime/engine_part10_test.go
@@ -514,7 +514,7 @@ func TestManualCompactionReinjectsHeadlessEnterOnlyWhileHeadlessRemainsActive(t 
 	if err := store.SetHeadlessActive(true); err != nil {
 		t.Fatalf("mark headless active: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "continue"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "continue"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 
@@ -522,7 +522,7 @@ func TestManualCompactionReinjectsHeadlessEnterOnlyWhileHeadlessRemainsActive(t 
 		t.Fatalf("compact: %v", err)
 	}
 
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	headlessCount := 0
 	exitCount := 0
 	for _, message := range messages {
@@ -548,13 +548,13 @@ func TestManualCompactionDoesNotReinjectHeadlessEnterAfterExit(t *testing.T) {
 		Usage:     llm.Usage{InputTokens: 200, WindowTokens: 2_000},
 	}}}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeHeadlessMode, Content: "headless mode instructions"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeHeadlessMode, Content: "headless mode instructions"}})); err != nil {
 		t.Fatalf("append headless mode: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeHeadlessModeExit, Content: "interactive mode instructions"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeHeadlessModeExit, Content: "interactive mode instructions"}})); err != nil {
 		t.Fatalf("append headless exit: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "continue"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "continue"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 
@@ -562,7 +562,7 @@ func TestManualCompactionDoesNotReinjectHeadlessEnterAfterExit(t *testing.T) {
 		t.Fatalf("compact: %v", err)
 	}
 
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	for _, message := range messages {
 		if message.MessageType == llm.MessageTypeHeadlessMode {
 			t.Fatalf("did not expect headless enter reinjection after exit, got messages=%+v", messages)

--- a/server/runtime/engine_part11_test.go
+++ b/server/runtime/engine_part11_test.go
@@ -229,7 +229,7 @@ func TestRequestMessagesPreserveANSIEscapes(t *testing.T) {
 
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{})
 
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: seedContent})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: seedContent}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 
@@ -379,7 +379,7 @@ func TestContextUsageUsesLastUsageWhenAvailable(t *testing.T) {
 
 func TestContextUsageFallsBackToEstimatedTokens(t *testing.T) {
 	eng := mustNewTestEngine(t, mustCreateTestSession(t), &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{ContextWindowTokens: 410_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "estimate me"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "estimate me"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -415,11 +415,11 @@ func TestContextUsageTracksWeightedCacheHitPercentageFromModelUsage(t *testing.T
 func TestContextUsageUsesEstimatedTokensWhenLastUsageIsStale(t *testing.T) {
 	eng := mustNewTestEngine(t, mustCreateTestSession(t), &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{ContextWindowTokens: 410_000})
 	eng.setLastUsage(llm.Usage{InputTokens: 100, OutputTokens: 0, WindowTokens: 410_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: strings.Repeat("x", 1600)})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: strings.Repeat("x", 1600)}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
-	estimated := estimateItemsTokens(eng.snapshotItems())
+	estimated := estimateItemsTokens(eng.transcriptRuntimeState().SnapshotItems())
 	if estimated <= 100 {
 		t.Fatalf("expected estimated tokens above stale usage baseline, got %d", estimated)
 	}
@@ -433,16 +433,16 @@ func TestContextUsageUsesEstimatedTokensWhenLastUsageIsStale(t *testing.T) {
 
 func TestContextUsageAddsOnlyPostCheckpointEstimateDelta(t *testing.T) {
 	eng := mustNewTestEngine(t, mustCreateTestSession(t), &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{ContextWindowTokens: 410_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: strings.Repeat("seed-", 100)})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: strings.Repeat("seed-", 100)}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
-	checkpointEstimate := estimateItemsTokens(eng.snapshotItems())
+	checkpointEstimate := estimateItemsTokens(eng.transcriptRuntimeState().SnapshotItems())
 	eng.setLastUsage(llm.Usage{InputTokens: 900, OutputTokens: 120, WindowTokens: 410_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: strings.Repeat("delta-", 40)})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: strings.Repeat("delta-", 40)}})); err != nil {
 		t.Fatalf("append delta message: %v", err)
 	}
 
-	currentEstimate := estimateItemsTokens(eng.snapshotItems())
+	currentEstimate := estimateItemsTokens(eng.transcriptRuntimeState().SnapshotItems())
 	deltaEstimate := currentEstimate - checkpointEstimate
 	if deltaEstimate <= 0 {
 		t.Fatalf("expected positive estimated delta, got checkpoint=%d current=%d", checkpointEstimate, currentEstimate)
@@ -458,21 +458,21 @@ func TestContextUsageAddsOnlyPostCheckpointEstimateDelta(t *testing.T) {
 func TestReopenedSessionRestoresUsageCheckpointDeltaAccounting(t *testing.T) {
 	store := mustCreateTestSession(t)
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{ContextWindowTokens: 410_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: strings.Repeat("seed-", 100)})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: strings.Repeat("seed-", 100)}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
-	checkpointEstimate := estimateItemsTokens(eng.snapshotItems())
+	checkpointEstimate := estimateItemsTokens(eng.transcriptRuntimeState().SnapshotItems())
 	if err := eng.recordLastUsage(llm.Usage{InputTokens: 900, OutputTokens: 120, WindowTokens: 410_000, CachedInputTokens: 45, HasCachedInputTokens: true}); err != nil {
 		t.Fatalf("record last usage: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: strings.Repeat("delta-", 40)})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: strings.Repeat("delta-", 40)}})); err != nil {
 		t.Fatalf("append delta message: %v", err)
 	}
 
 	reopenedStore := mustOpenTestSession(t, store.Dir())
 	restored := mustNewTestEngine(t, reopenedStore, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{ContextWindowTokens: 410_000})
 
-	currentEstimate := estimateItemsTokens(restored.snapshotItems())
+	currentEstimate := estimateItemsTokens(restored.transcriptRuntimeState().SnapshotItems())
 	deltaEstimate := currentEstimate - checkpointEstimate
 	if deltaEstimate <= 0 {
 		t.Fatalf("expected positive estimated delta after reopen, got checkpoint=%d current=%d", checkpointEstimate, currentEstimate)
@@ -493,7 +493,7 @@ func TestHistoryReplacementResetsDiagnosticDedupe(t *testing.T) {
 	if err := eng.steerPersistedDiagnosticEntry("step-1", preciseTokenCountFailureDiagnostic, "error", "first fallback"); err != nil {
 		t.Fatalf("append first diagnostic: %v", err)
 	}
-	if err := eng.replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleAssistant, Content: "summary"}})); err != nil {
+	if err := newCompactionPersistence(eng).replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleAssistant, Content: "summary"}})); err != nil {
 		t.Fatalf("replace history: %v", err)
 	}
 	if err := eng.steerPersistedDiagnosticEntry("step-2", preciseTokenCountFailureDiagnostic, "error", "second fallback"); err != nil {
@@ -528,7 +528,7 @@ func TestReopenedSessionHistoryReplacementResetsDiagnosticDedupe(t *testing.T) {
 	if err := eng.steerPersistedDiagnosticEntry("step-1", preciseTokenCountFailureDiagnostic, "error", "first fallback"); err != nil {
 		t.Fatalf("append first diagnostic: %v", err)
 	}
-	if err := eng.replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleAssistant, Content: "summary"}})); err != nil {
+	if err := newCompactionPersistence(eng).replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleAssistant, Content: "summary"}})); err != nil {
 		t.Fatalf("replace history: %v", err)
 	}
 
@@ -584,12 +584,12 @@ func TestContextUsageDoesNotInflateInlineImagePayloadByBase64Length(t *testing.T
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 410_000})
 	eng.setLastUsage(llm.Usage{InputTokens: 100, OutputTokens: 0, WindowTokens: 410_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{
 		Role:       llm.RoleTool,
 		ToolCallID: "call-1",
 		Name:       string(toolspec.ToolViewImage),
 		Content:    `[{"type":"input_image","image_url":"data:image/png;base64,` + strings.Repeat("A", 24_000) + `"}]`,
-	})); err != nil {
+	}})); err != nil {
 		t.Fatalf("append tool message: %v", err)
 	}
 
@@ -611,7 +611,7 @@ func TestShouldAutoCompactAccountsForMessagesAppendedAfterLastUsage(t *testing.T
 		AutoCompactTokenLimit: 300,
 	})
 	eng.setLastUsage(llm.Usage{InputTokens: 120, OutputTokens: 0, WindowTokens: 410_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: strings.Repeat("stale-usage-gap-", 120)})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: strings.Repeat("stale-usage-gap-", 120)}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -629,7 +629,7 @@ func TestShouldAutoCompactUsesPreciseRequestInputTokenCountWhenAvailable(t *test
 		ContextWindowTokens:   400_000,
 		AutoCompactTokenLimit: 900,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "short"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "short"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -687,7 +687,7 @@ func TestShouldCompactBeforeUserMessageUsesPromptGrowthBelowPreSubmitBand(t *tes
 		ContextWindowTokens:           1000,
 		PreSubmitCompactionLeadTokens: 50,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: strings.Repeat("a", 3400)})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: strings.Repeat("a", 3400)}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -714,7 +714,7 @@ func TestShouldCompactBeforeUserMessageFallsBackWhenExactCountUnsupported(t *tes
 		ContextWindowTokens:           1000,
 		PreSubmitCompactionLeadTokens: 50,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: strings.Repeat("a", 3400)})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: strings.Repeat("a", 3400)}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 

--- a/server/runtime/engine_part11_test.go
+++ b/server/runtime/engine_part11_test.go
@@ -615,7 +615,7 @@ func TestShouldAutoCompactAccountsForMessagesAppendedAfterLastUsage(t *testing.T
 		t.Fatalf("append message: %v", err)
 	}
 
-	if !eng.shouldAutoCompact() {
+	if !eng.shouldAutoCompactWithContext(context.Background()) {
 		t.Fatalf("expected auto compaction to trigger from appended message growth")
 	}
 }
@@ -633,7 +633,7 @@ func TestShouldAutoCompactUsesPreciseRequestInputTokenCountWhenAvailable(t *test
 		t.Fatalf("append message: %v", err)
 	}
 
-	if !eng.shouldAutoCompact() {
+	if !eng.shouldAutoCompactWithContext(context.Background()) {
 		t.Fatalf("expected auto compaction to trigger from precise input token count")
 	}
 }
@@ -670,7 +670,7 @@ func TestPreSubmitCompactionTokenLimitUsesFixedRunwayReserve(t *testing.T) {
 				PreSubmitCompactionLeadTokens: tt.runway,
 			})
 
-			if got := eng.preSubmitCompactionTokenLimit(context.Background()); got != tt.expected {
+			if got := eng.compactionPlannerState().preSubmitTokenLimit(eng.compactionPlanningSnapshot()); got != tt.expected {
 				t.Fatalf("unexpected pre-submit compaction threshold: got %d want %d", got, tt.expected)
 			}
 		})

--- a/server/runtime/engine_part12_test.go
+++ b/server/runtime/engine_part12_test.go
@@ -103,7 +103,7 @@ func TestShouldAutoCompactRechecksProviderBeforeCompactingOnLargeEstimate(t *tes
 		t.Fatalf("append tool message: %v", err)
 	}
 
-	if eng.shouldAutoCompact() {
+	if eng.shouldAutoCompactWithContext(context.Background()) {
 		t.Fatalf("expected provider token count to prevent over-eager compaction")
 	}
 	if client.countCalls != 1 {
@@ -124,7 +124,7 @@ func TestShouldAutoCompactPrefersConfiguredThresholdOverResolvedContextWindow(t 
 		t.Fatalf("append message: %v", err)
 	}
 
-	if eng.shouldAutoCompact() {
+	if eng.shouldAutoCompactWithContext(context.Background()) {
 		t.Fatalf("expected auto compaction to honor configured threshold and remain below limit")
 	}
 	if client.resolveCalls != 0 {
@@ -151,7 +151,7 @@ func TestShouldAutoCompactAccountsForReservedOutputBudget(t *testing.T) {
 		t.Fatalf("append message: %v", err)
 	}
 
-	if !eng.shouldAutoCompact() {
+	if !eng.shouldAutoCompactWithContext(context.Background()) {
 		t.Fatalf("expected auto compaction when input + reserved output exceeds threshold")
 	}
 }
@@ -169,7 +169,7 @@ func TestShouldAutoCompactSkipsPreciseCountWhenFarBelowThreshold(t *testing.T) {
 		t.Fatalf("append message: %v", err)
 	}
 
-	if eng.shouldAutoCompact() {
+	if eng.shouldAutoCompactWithContext(context.Background()) {
 		t.Fatalf("expected no compaction when far below configured threshold")
 	}
 	if client.countCalls != 0 {
@@ -188,10 +188,10 @@ func TestShouldAutoCompactMemoizesPreciseCountForUnchangedRequest(t *testing.T) 
 	})
 	eng.setLastUsage(llm.Usage{InputTokens: 95_000, WindowTokens: 400_000})
 
-	if eng.shouldAutoCompact() {
+	if eng.shouldAutoCompactWithContext(context.Background()) {
 		t.Fatalf("expected no compaction for precise count below threshold")
 	}
-	if eng.shouldAutoCompact() {
+	if eng.shouldAutoCompactWithContext(context.Background()) {
 		t.Fatalf("expected no compaction for repeated unchanged request")
 	}
 	if client.countCalls != 1 {

--- a/server/runtime/engine_part12_test.go
+++ b/server/runtime/engine_part12_test.go
@@ -33,7 +33,7 @@ func TestShouldCompactBeforeUserMessageSkipsExactCountWhenProviderOverrideDisabl
 		},
 		PreSubmitCompactionLeadTokens: 50,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: strings.Repeat("a", 3400)})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: strings.Repeat("a", 3400)}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -69,7 +69,7 @@ func TestShouldCompactBeforeUserMessageSkipsExactCountWhenLockedContractDisables
 		ContextWindowTokens:           1000,
 		PreSubmitCompactionLeadTokens: 50,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: strings.Repeat("a", 3400)})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: strings.Repeat("a", 3400)}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -94,12 +94,12 @@ func TestShouldAutoCompactRechecksProviderBeforeCompactingOnLargeEstimate(t *tes
 		ContextWindowTokens:   400_000,
 		AutoCompactTokenLimit: 2,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{
 		Role:       llm.RoleTool,
 		ToolCallID: "call-1",
 		Name:       string(toolspec.ToolViewImage),
 		Content:    `[{"type":"input_image","image_url":"data:image/png;base64,` + strings.Repeat("A", 24_000) + `"}]`,
-	})); err != nil {
+	}})); err != nil {
 		t.Fatalf("append tool message: %v", err)
 	}
 
@@ -120,7 +120,7 @@ func TestShouldAutoCompactPrefersConfiguredThresholdOverResolvedContextWindow(t 
 		ContextWindowTokens:   400_000,
 		AutoCompactTokenLimit: 360_000,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "short"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "short"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -147,7 +147,7 @@ func TestShouldAutoCompactAccountsForReservedOutputBudget(t *testing.T) {
 		AutoCompactTokenLimit: 900,
 		MaxTokens:             100,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "short"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "short"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -165,7 +165,7 @@ func TestShouldAutoCompactSkipsPreciseCountWhenFarBelowThreshold(t *testing.T) {
 		ContextWindowTokens:   400_000,
 		AutoCompactTokenLimit: 100_000,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "short"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "short"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -208,7 +208,7 @@ func TestCompactionSoonReminderStaysSingleShotAfterReEnablingAutoCompactionAbove
 		AutoCompactTokenLimit: 1_000,
 		CompactionMode:        "local",
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 890, WindowTokens: 2_000})
@@ -217,7 +217,7 @@ func TestCompactionSoonReminderStaysSingleShotAfterReEnablingAutoCompactionAbove
 	if !changed || enabled {
 		t.Fatalf("expected auto compaction toggle off, changed=%v enabled=%v", changed, enabled)
 	}
-	if err := eng.maybeAppendCompactionSoonReminder(context.Background(), "step-off"); err != nil {
+	if err := newCompactionReminderCoordinator(eng).maybeAppend(context.Background(), "step-off"); err != nil {
 		t.Fatalf("reminder while disabled: %v", err)
 	}
 
@@ -230,10 +230,10 @@ func TestCompactionSoonReminderStaysSingleShotAfterReEnablingAutoCompactionAbove
 	if !changed || !enabled {
 		t.Fatalf("expected auto compaction toggle on, changed=%v enabled=%v", changed, enabled)
 	}
-	if err := eng.maybeAppendCompactionSoonReminder(context.Background(), "step-on"); err != nil {
+	if err := newCompactionReminderCoordinator(eng).maybeAppend(context.Background(), "step-on"); err != nil {
 		t.Fatalf("reminder after re-enable: %v", err)
 	}
-	if err := eng.maybeAppendCompactionSoonReminder(context.Background(), "step-on-duplicate"); err != nil {
+	if err := newCompactionReminderCoordinator(eng).maybeAppend(context.Background(), "step-on-duplicate"); err != nil {
 		t.Fatalf("duplicate reminder check: %v", err)
 	}
 
@@ -249,11 +249,11 @@ func TestCompactionSoonReminderStaysSingleShotAfterReEnablingAutoCompactionAbove
 	}
 
 	eng.setLastUsage(llm.Usage{InputTokens: 800, WindowTokens: 2_000})
-	if err := eng.maybeAppendCompactionSoonReminder(context.Background(), "step-reset"); err != nil {
+	if err := newCompactionReminderCoordinator(eng).maybeAppend(context.Background(), "step-reset"); err != nil {
 		t.Fatalf("reset reminder state: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 860, WindowTokens: 2_000})
-	if err := eng.maybeAppendCompactionSoonReminder(context.Background(), "step-reissue"); err != nil {
+	if err := newCompactionReminderCoordinator(eng).maybeAppend(context.Background(), "step-reissue"); err != nil {
 		t.Fatalf("reissue reminder: %v", err)
 	}
 
@@ -278,10 +278,10 @@ func TestReopenedSessionRestoresCompactionSoonReminderIssuedState(t *testing.T) 
 		AutoCompactTokenLimit: 1_000,
 		CompactionMode:        "local",
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSoonReminder, Content: prompts.RenderCompactionSoonReminderPrompt(false, eng.estimatedToolCallsUntilForcedHandoff())})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSoonReminder, Content: prompts.RenderCompactionSoonReminderPrompt(false, eng.estimatedToolCallsUntilForcedHandoff())}})); err != nil {
 		t.Fatalf("append reminder: %v", err)
 	}
 
@@ -302,7 +302,7 @@ func TestReopenedSessionRestoresCompactionSoonReminderIssuedState(t *testing.T) 
 	if !reopenedStore.Meta().CompactionSoonReminderIssued {
 		t.Fatal("expected reopened session meta to persist reminder-issued state")
 	}
-	if err := restored.maybeAppendCompactionSoonReminder(context.Background(), "step-restore"); err != nil {
+	if err := newCompactionReminderCoordinator(restored).maybeAppend(context.Background(), "step-restore"); err != nil {
 		t.Fatalf("reminder after reopen: %v", err)
 	}
 	if reminders := countCompactionSoonReminderWarnings(restored, restored.ChatSnapshot()); reminders != 1 {
@@ -319,7 +319,7 @@ func TestForkedSessionBeforeReminderDoesNotCopyReminderIssuedState(t *testing.T)
 		AutoCompactTokenLimit: 1_000,
 		CompactionMode:        "local",
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	if err := eng.persistCompactionSoonReminderIssued(true); err != nil {
@@ -346,7 +346,7 @@ func TestForkedSessionBeforeReminderDoesNotCopyReminderIssuedState(t *testing.T)
 	if forked.compactionRuntimeState().SoonReminderIssued() {
 		t.Fatal("expected forked session before reminder to start with cleared reminder-issued state")
 	}
-	if err := forked.maybeAppendCompactionSoonReminder(context.Background(), "step-fork"); err != nil {
+	if err := newCompactionReminderCoordinator(forked).maybeAppend(context.Background(), "step-fork"); err != nil {
 		t.Fatalf("reminder after fork: %v", err)
 	}
 	if reminders := countCompactionSoonReminderWarnings(forked, forked.ChatSnapshot()); reminders != 1 {
@@ -358,7 +358,7 @@ func TestForkedSessionDoesNotCopyPersistedUsageState(t *testing.T) {
 	store := mustCreateTestSession(t)
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 410_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	if err := eng.recordLastUsage(llm.Usage{InputTokens: 900, WindowTokens: 410_000}); err != nil {
@@ -386,16 +386,16 @@ func TestForkedSessionAfterReminderPreservesCompactionSoonReminderIssuedState(t 
 		AutoCompactTokenLimit: 1_000,
 		CompactionMode:        "local",
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	if err := eng.persistCompactionSoonReminderIssued(true); err != nil {
 		t.Fatalf("persist reminder-issued state: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSoonReminder, Content: "compact soon"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSoonReminder, Content: "compact soon"}})); err != nil {
 		t.Fatalf("append reminder message: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "after reminder"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "after reminder"}})); err != nil {
 		t.Fatalf("append second user message: %v", err)
 	}
 
@@ -421,11 +421,11 @@ func TestRealCompactionClearsPersistedCompactionSoonReminderStateAcrossReopenAnd
 		AutoCompactTokenLimit: 1_000,
 		CompactionMode:        "local",
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 890, WindowTokens: 2_000})
-	if err := eng.maybeAppendCompactionSoonReminder(context.Background(), "step-warning"); err != nil {
+	if err := newCompactionReminderCoordinator(eng).maybeAppend(context.Background(), "step-warning"); err != nil {
 		t.Fatalf("append reminder: %v", err)
 	}
 	if !store.Meta().CompactionSoonReminderIssued {
@@ -478,7 +478,7 @@ func TestLegacyReviewerRollbackHistoryReplacementIsIgnoredAcrossReopen(t *testin
 	store := mustCreateTestSession(t)
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 410_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	if err := eng.recordLastUsage(llm.Usage{InputTokens: 900, WindowTokens: 410_000}); err != nil {
@@ -524,11 +524,11 @@ func TestCompactionSoonReminderSkipsPreciseCountingWhenSuppressed(t *testing.T) 
 				AutoCompactTokenLimit: 1_000,
 				CompactionMode:        tt.compactionMode,
 			})
-			if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+			if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 				t.Fatalf("append seed message: %v", err)
 			}
 			eng.setLastUsage(llm.Usage{InputTokens: 890, WindowTokens: 2_000})
-			eng.setCompactionSoonReminderIssued(true)
+			eng.compactionRuntimeState().SetSoonReminderIssued(true)
 
 			if tt.disableAuto {
 				changed, enabled := eng.SetAutoCompactionEnabled(false)
@@ -537,7 +537,7 @@ func TestCompactionSoonReminderSkipsPreciseCountingWhenSuppressed(t *testing.T) 
 				}
 			}
 
-			if err := eng.maybeAppendCompactionSoonReminder(context.Background(), "suppressed"); err != nil {
+			if err := newCompactionReminderCoordinator(eng).maybeAppend(context.Background(), "suppressed"); err != nil {
 				t.Fatalf("suppressed reminder check: %v", err)
 			}
 			if client.countCalls != 0 {
@@ -575,7 +575,7 @@ func TestRunStepLoopSkipsCompactionSoonReminderWhenImmediateAutoCompactionRuns(t
 		MaxTokens:             20,
 		CompactionMode:        "native",
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 9_990, WindowTokens: 20_000})
@@ -620,7 +620,7 @@ func TestRunStepLoopInjectsCompactionSoonReminderBeforeFinalAnswerRequest(t *tes
 		AutoCompactTokenLimit: 1_000,
 		CompactionMode:        "local",
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 890, WindowTokens: 2_000})
@@ -702,7 +702,7 @@ func TestRunStepLoopAppendsCompactionSoonReminderImmediatelyAfterToolOutputBound
 		AutoCompactTokenLimit: 1_000,
 		CompactionMode:        "local",
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 

--- a/server/runtime/engine_part13_test.go
+++ b/server/runtime/engine_part13_test.go
@@ -54,7 +54,7 @@ func TestRunStepLoopDoesNotDuplicateCompactionSoonReminderAfterAutoCompactionIsD
 		AutoCompactTokenLimit: 1_000,
 		CompactionMode:        "local",
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 
@@ -69,7 +69,7 @@ func TestRunStepLoopDoesNotDuplicateCompactionSoonReminderAfterAutoCompactionIsD
 	if !changed || enabled {
 		t.Fatalf("expected auto compaction toggle off, changed=%v enabled=%v", changed, enabled)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "continue"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "continue"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 
@@ -115,12 +115,12 @@ func TestCompactionSoonReminderIncludesTriggerHandoffAdditionWhenConfigured(t *t
 		ContextWindowTokens:   2_000,
 		AutoCompactTokenLimit: 1_000,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 890, WindowTokens: 2_000})
 
-	if err := eng.maybeAppendCompactionSoonReminder(context.Background(), "step-1"); err != nil {
+	if err := newCompactionReminderCoordinator(eng).maybeAppend(context.Background(), "step-1"); err != nil {
 		t.Fatalf("append reminder: %v", err)
 	}
 
@@ -143,32 +143,32 @@ func TestCompactionSoonReminderRechecksPreciselyAfterTranscriptMutation(t *testi
 		ContextWindowTokens:   2_000,
 		AutoCompactTokenLimit: 1_000,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 860, WindowTokens: 2_000})
 
-	if err := eng.maybeAppendCompactionSoonReminder(context.Background(), "step-1"); err != nil {
+	if err := newCompactionReminderCoordinator(eng).maybeAppend(context.Background(), "step-1"); err != nil {
 		t.Fatalf("reminder below exact threshold: %v", err)
 	}
 	if client.countCalls != 1 {
 		t.Fatalf("expected first reminder probe to count precisely once, got %d", client.countCalls)
 	}
-	if eng.handoffToolEnabled() {
+	if eng.compactionRuntimeState().SoonReminderIssued() {
 		t.Fatal("did not expect handoff tool to become enabled below the exact reminder threshold")
 	}
 
 	client.inputTokenCount = 860
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Content: "mutation"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Content: "mutation"}})); err != nil {
 		t.Fatalf("append mutation: %v", err)
 	}
-	if err := eng.maybeAppendCompactionSoonReminder(context.Background(), "step-2"); err != nil {
+	if err := newCompactionReminderCoordinator(eng).maybeAppend(context.Background(), "step-2"); err != nil {
 		t.Fatalf("reminder above exact threshold after mutation: %v", err)
 	}
 	if client.countCalls != 2 {
 		t.Fatalf("expected transcript mutation to force a fresh precise reminder check, got %d calls", client.countCalls)
 	}
-	if !eng.handoffToolEnabled() {
+	if !eng.compactionRuntimeState().SoonReminderIssued() {
 		t.Fatal("expected reminder to enable trigger_handoff after exact recount")
 	}
 	reminders := 0
@@ -197,7 +197,7 @@ func TestTriggerHandoffFailsWhenAutoCompactionDisabled(t *testing.T) {
 	store := mustCreateTestSession(t)
 
 	eng := mustNewHandoffTestEngine(t, store, &fakeClient{}, Config{})
-	eng.setCompactionSoonReminderIssued(true)
+	eng.compactionRuntimeState().SetSoonReminderIssued(true)
 	changed, enabled := eng.SetAutoCompactionEnabled(false)
 	if !changed || enabled {
 		t.Fatalf("expected auto compaction toggle off, changed=%v enabled=%v", changed, enabled)
@@ -216,10 +216,10 @@ func TestTriggerHandoffSchedulesCompactionAndAppendsFutureMessageWithoutManualCa
 		responses: []llm.Response{{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "summary"}}},
 	}
 	eng := mustNewHandoffTestEngine(t, store, client, Config{})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
-	eng.setCompactionSoonReminderIssued(true)
+	eng.compactionRuntimeState().SetSoonReminderIssued(true)
 	activeCall := llm.ToolCall{ID: "call-handoff-1", Name: string(toolspec.ToolTriggerHandoff), Input: json.RawMessage(`{"summarizer_prompt":"keep API details","future_agent_message":"resume with tests"}`)}
 
 	summary, futureAdded, err := eng.TriggerHandoff(context.Background(), "step-1", activeCall, "keep API details", "resume with tests")
@@ -250,7 +250,7 @@ func TestTriggerHandoffSchedulesCompactionAndAppendsFutureMessageWithoutManualCa
 		t.Fatalf("expected handoff to reuse compaction instructions, got %+v", client.calls[0].Items)
 	}
 
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	foundFutureMessage := false
 	foundManualCarryover := false
 	for _, message := range messages {
@@ -298,11 +298,11 @@ func TestPrepareModelTurnSkipsAutoCompactionAfterPendingHandoffCompaction(t *tes
 		ContextWindowTokens:   2_000,
 		AutoCompactTokenLimit: 1_000,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 1_900, WindowTokens: 2_000})
-	eng.queueHandoffRequest("keep runtime details", "")
+	eng.handoffRuntimeState().QueueRequest("keep runtime details", "")
 
 	executor := &defaultStepExecutor{engine: eng}
 	if err := executor.prepareModelTurn(context.Background(), "step-1"); err != nil {
@@ -339,18 +339,18 @@ func TestPrepareModelTurnMaterializesWorktreeReminderAfterPendingHandoffCompacti
 		ContextWindowTokens:   2_000,
 		AutoCompactTokenLimit: 1_000,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 1_900, WindowTokens: 2_000})
-	eng.queueHandoffRequest("keep runtime details", "")
+	eng.handoffRuntimeState().QueueRequest("keep runtime details", "")
 
 	executor := &defaultStepExecutor{engine: eng}
 	if err := executor.prepareModelTurn(context.Background(), "step-1"); err != nil {
 		t.Fatalf("prepare model turn: %v", err)
 	}
 
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	reminderCount := 0
 	for _, message := range messages {
 		if message.Role == llm.RoleDeveloper && message.MessageType == llm.MessageTypeWorktreeMode {
@@ -399,11 +399,11 @@ func TestPrepareModelTurnHandoffReminderPersistenceFailureRetriesWithoutDuplicat
 		ContextWindowTokens:   2_000,
 		AutoCompactTokenLimit: 1_000,
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 1_900, WindowTokens: 2_000})
-	eng.queueHandoffRequest("keep runtime details", "")
+	eng.handoffRuntimeState().QueueRequest("keep runtime details", "")
 	executor := &defaultStepExecutor{engine: eng}
 
 	if err := executor.prepareModelTurn(context.Background(), "step-1"); err == nil || !strings.Contains(err.Error(), "persist observer failed") {
@@ -411,7 +411,7 @@ func TestPrepareModelTurnHandoffReminderPersistenceFailureRetriesWithoutDuplicat
 	}
 	assertWorktreeReminderEntryCount(t, eng.ChatSnapshot(), 1)
 
-	eng.queueHandoffRequest("keep runtime details", "")
+	eng.handoffRuntimeState().QueueRequest("keep runtime details", "")
 	if err := executor.prepareModelTurn(context.Background(), "step-2"); err != nil {
 		t.Fatalf("retry prepare model turn: %v", err)
 	}
@@ -447,10 +447,10 @@ func TestPendingTriggerHandoffFailsToolCallsAndRetriesLocalSummary(t *testing.T)
 		CompactionMode: "local",
 		EnabledTools:   []toolspec.ID{toolspec.ToolExecCommand, toolspec.ToolWebSearch, toolspec.ToolTriggerHandoff},
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
-	eng.setCompactionSoonReminderIssued(true)
+	eng.compactionRuntimeState().SetSoonReminderIssued(true)
 
 	_, _, err := eng.TriggerHandoff(context.Background(), "step-1", llm.ToolCall{ID: "call_handoff_tool_retry", Name: string(toolspec.ToolTriggerHandoff)}, "keep API details", "")
 	if err != nil {
@@ -459,8 +459,8 @@ func TestPendingTriggerHandoffFailsToolCallsAndRetriesLocalSummary(t *testing.T)
 	if _, err := eng.applyPendingHandoffIfNeeded(context.Background(), "step-1"); err != nil {
 		t.Fatalf("apply pending handoff: %v", err)
 	}
-	if eng.pendingHandoffRequestSnapshot() != nil {
-		t.Fatalf("expected successful retry to clear pending handoff, got %+v", eng.pendingHandoffRequestSnapshot())
+	if eng.handoffRuntimeState().RequestSnapshot() != nil {
+		t.Fatalf("expected successful retry to clear pending handoff, got %+v", eng.handoffRuntimeState().RequestSnapshot())
 	}
 	if len(client.calls) != 2 {
 		t.Fatalf("expected local summary retry after failed tool call, got %d requests", len(client.calls))
@@ -501,10 +501,10 @@ func TestPendingTriggerHandoffFailsMalformedToolCallWithEmptyID(t *testing.T) {
 		Usage: llm.Usage{InputTokens: 100, WindowTokens: 2_000},
 	}}}
 	eng := mustNewHandoffTestEngine(t, store, client, Config{})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
-	eng.setCompactionSoonReminderIssued(true)
+	eng.compactionRuntimeState().SetSoonReminderIssued(true)
 
 	_, _, err := eng.TriggerHandoff(context.Background(), "step-1", llm.ToolCall{ID: "call_handoff_empty_id", Name: string(toolspec.ToolTriggerHandoff)}, "keep API details", "resume with tests")
 	if err != nil {
@@ -513,7 +513,7 @@ func TestPendingTriggerHandoffFailsMalformedToolCallWithEmptyID(t *testing.T) {
 	if _, err := eng.applyPendingHandoffIfNeeded(context.Background(), "step-1"); !errors.Is(err, errLocalCompactionToolCallEmptyID) {
 		t.Fatalf("expected errLocalCompactionToolCallEmptyID, got %v", err)
 	}
-	if eng.pendingHandoffRequestSnapshot() == nil {
+	if eng.handoffRuntimeState().RequestSnapshot() == nil {
 		t.Fatal("expected malformed handoff failure to keep pending request queued")
 	}
 	if len(client.calls) != 1 {
@@ -568,10 +568,10 @@ func TestPendingTriggerHandoffRetriesCustomToolCallOutput(t *testing.T) {
 		CompactionMode: "local",
 		EnabledTools:   []toolspec.ID{toolspec.ToolPatch, toolspec.ToolTriggerHandoff},
 	}, toolspec.ToolPatch)
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
-	eng.setCompactionSoonReminderIssued(true)
+	eng.compactionRuntimeState().SetSoonReminderIssued(true)
 
 	_, _, err := eng.TriggerHandoff(context.Background(), "step-1", llm.ToolCall{ID: "call_handoff_custom_tool_retry", Name: string(toolspec.ToolTriggerHandoff)}, "keep API details", "")
 	if err != nil {
@@ -648,10 +648,10 @@ func TestPendingTriggerHandoffLeavesRequestPendingWhenSummaryRetryStillToolCalls
 		},
 	}}
 	eng := mustNewHandoffTestEngine(t, store, client, Config{})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
-	eng.setCompactionSoonReminderIssued(true)
+	eng.compactionRuntimeState().SetSoonReminderIssued(true)
 
 	_, _, err := eng.TriggerHandoff(context.Background(), "step-1", llm.ToolCall{ID: "call_handoff_second_failure", Name: string(toolspec.ToolTriggerHandoff)}, "keep API details", "resume with tests")
 	if err != nil {
@@ -660,10 +660,10 @@ func TestPendingTriggerHandoffLeavesRequestPendingWhenSummaryRetryStillToolCalls
 	if _, err := eng.applyPendingHandoffIfNeeded(context.Background(), "step-1"); !errors.Is(err, errLocalCompactionAttemptedToolCalls) {
 		t.Fatalf("expected errLocalCompactionAttemptedToolCalls, got %v", err)
 	}
-	if eng.pendingHandoffRequestSnapshot() == nil {
+	if eng.handoffRuntimeState().RequestSnapshot() == nil {
 		t.Fatal("expected failed handoff retry to keep pending request queued")
 	}
-	if got, want := eng.pendingHandoffRequestSnapshot().futureAgentMessage, "resume with tests"; got != want {
+	if got, want := eng.handoffRuntimeState().RequestSnapshot().futureAgentMessage, "resume with tests"; got != want {
 		t.Fatalf("pending future_agent_message after retry failure = %q, want %q", got, want)
 	}
 	if len(client.calls) != 4 {
@@ -687,16 +687,16 @@ func TestPendingTriggerHandoffRetriesAfterCompactionFailure(t *testing.T) {
 		},
 	}}
 	eng := mustNewHandoffTestEngine(t, store, client, Config{})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
-	eng.setCompactionSoonReminderIssued(true)
+	eng.compactionRuntimeState().SetSoonReminderIssued(true)
 
 	_, _, err := eng.TriggerHandoff(context.Background(), "step-1", llm.ToolCall{ID: "call_handoff_retry", Name: string(toolspec.ToolTriggerHandoff)}, "keep API details", "resume with tests")
 	if err != nil {
 		t.Fatalf("trigger handoff: %v", err)
 	}
-	if eng.pendingHandoffRequestSnapshot() == nil {
+	if eng.handoffRuntimeState().RequestSnapshot() == nil {
 		t.Fatal("expected queued handoff before compaction attempt")
 	}
 
@@ -704,13 +704,13 @@ func TestPendingTriggerHandoffRetriesAfterCompactionFailure(t *testing.T) {
 	if _, err := eng.applyPendingHandoffIfNeeded(context.Background(), "step-1"); err == nil {
 		t.Fatal("expected first pending handoff attempt to fail when compaction summary response is missing")
 	}
-	if eng.pendingHandoffRequestSnapshot() == nil {
+	if eng.handoffRuntimeState().RequestSnapshot() == nil {
 		t.Fatal("expected failed handoff compaction to leave pending request queued for retry")
 	}
-	if got, want := eng.pendingHandoffRequestSnapshot().summarizerPrompt, "keep API details"; got != want {
+	if got, want := eng.handoffRuntimeState().RequestSnapshot().summarizerPrompt, "keep API details"; got != want {
 		t.Fatalf("pending summarizer_prompt after failure = %q, want %q", got, want)
 	}
-	if got, want := eng.pendingHandoffRequestSnapshot().futureAgentMessage, "resume with tests"; got != want {
+	if got, want := eng.handoffRuntimeState().RequestSnapshot().futureAgentMessage, "resume with tests"; got != want {
 		t.Fatalf("pending future_agent_message after failure = %q, want %q", got, want)
 	}
 
@@ -721,11 +721,11 @@ func TestPendingTriggerHandoffRetriesAfterCompactionFailure(t *testing.T) {
 	if _, err := eng.applyPendingHandoffIfNeeded(context.Background(), "step-1"); err != nil {
 		t.Fatalf("retry pending handoff: %v", err)
 	}
-	if eng.pendingHandoffRequestSnapshot() != nil {
-		t.Fatalf("expected successful retry to clear pending handoff, got %+v", eng.pendingHandoffRequestSnapshot())
+	if eng.handoffRuntimeState().RequestSnapshot() != nil {
+		t.Fatalf("expected successful retry to clear pending handoff, got %+v", eng.handoffRuntimeState().RequestSnapshot())
 	}
 
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	foundFutureMessage := false
 	for _, message := range messages {
 		if message.MessageType == llm.MessageTypeHandoffFutureMessage && message.Content == prompts.FormatHandoffFutureAgentMessage("resume with tests") {
@@ -746,10 +746,10 @@ func TestPendingTriggerHandoffRetriesFutureMessageAfterAppendFailureWithoutRecom
 		Usage:     llm.Usage{InputTokens: 200, WindowTokens: 2_000},
 	}}}
 	eng := mustNewHandoffTestEngine(t, store, client, Config{})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
-	eng.setCompactionSoonReminderIssued(true)
+	eng.compactionRuntimeState().SetSoonReminderIssued(true)
 	futureAgentMessage := "resume \"with tests\"\nthen inspect logs"
 
 	_, _, err := eng.TriggerHandoff(context.Background(), "step-1", llm.ToolCall{ID: "call_handoff_append_retry", Name: string(toolspec.ToolTriggerHandoff)}, "keep API details", futureAgentMessage)
@@ -771,12 +771,12 @@ func TestPendingTriggerHandoffRetriesFutureMessageAfterAppendFailureWithoutRecom
 	if len(client.calls) != 1 {
 		t.Fatalf("expected exactly one compaction summary call after append failure, got %d", len(client.calls))
 	}
-	if eng.pendingHandoffRequestSnapshot() != nil {
-		t.Fatalf("expected compaction-success path to consume original handoff request, got %+v", eng.pendingHandoffRequestSnapshot())
+	if eng.handoffRuntimeState().RequestSnapshot() != nil {
+		t.Fatalf("expected compaction-success path to consume original handoff request, got %+v", eng.handoffRuntimeState().RequestSnapshot())
 	}
 	// The retry queue keeps the raw tool argument so retry emission cannot wrap
 	// already-formatted future-agent context a second time.
-	if got, want := eng.pendingHandoffFutureMessageSnapshot(), futureAgentMessage; got != want {
+	if got, want := eng.handoffRuntimeState().FutureMessageSnapshot(), futureAgentMessage; got != want {
 		t.Fatalf("pending future-agent message after append failure = %q, want %q", got, want)
 	}
 
@@ -787,11 +787,11 @@ func TestPendingTriggerHandoffRetriesFutureMessageAfterAppendFailureWithoutRecom
 	if len(client.calls) != 1 {
 		t.Fatalf("expected retry after future-message append failure not to re-run compaction, got %d compaction calls", len(client.calls))
 	}
-	if got := eng.pendingHandoffFutureMessageSnapshot(); got != "" {
+	if got := eng.handoffRuntimeState().FutureMessageSnapshot(); got != "" {
 		t.Fatalf("expected successful retry to clear pending future-agent message, got %q", got)
 	}
 
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	foundFutureMessage := false
 	for _, message := range messages {
 		if message.MessageType == llm.MessageTypeHandoffFutureMessage && message.Content == prompts.FormatHandoffFutureAgentMessage(futureAgentMessage) {
@@ -812,7 +812,7 @@ func TestReopenedSessionAfterTriggerHandoffFutureMessageAppendFailureRetriesWith
 		Usage:     llm.Usage{InputTokens: 200, WindowTokens: 2_000},
 	}}}
 	eng := mustNewHandoffTestEngine(t, store, client, Config{})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	handoffCall := llm.ToolCall{
@@ -820,7 +820,7 @@ func TestReopenedSessionAfterTriggerHandoffFutureMessageAppendFailureRetriesWith
 		Name:  string(toolspec.ToolTriggerHandoff),
 		Input: mustJSON(map[string]any{"summarizer_prompt": "keep API details", "future_agent_message": "resume after restart"}),
 	}
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Content: "handing off", Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{handoffCall}})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Content: "handing off", Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{handoffCall}}})); err != nil {
 		t.Fatalf("append assistant tool call: %v", err)
 	}
 	resultOutput := mustJSON(triggerhandofftool.TriggerHandoffResultPayload{
@@ -830,10 +830,10 @@ func TestReopenedSessionAfterTriggerHandoffFutureMessageAppendFailureRetriesWith
 	if err := eng.steer("step-1", steerToolCompletionIntent(tools.Result{CallID: handoffCall.ID, Name: toolspec.ToolTriggerHandoff, Output: resultOutput})); err != nil {
 		t.Fatalf("persist tool completion: %v", err)
 	}
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleTool, ToolCallID: handoffCall.ID, Name: string(toolspec.ToolTriggerHandoff), Content: string(resultOutput)})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleTool, ToolCallID: handoffCall.ID, Name: string(toolspec.ToolTriggerHandoff), Content: string(resultOutput)}})); err != nil {
 		t.Fatalf("append tool result: %v", err)
 	}
-	eng.queueHandoffRequest("keep API details", "resume after restart")
+	eng.handoffRuntimeState().QueueRequest("keep API details", "resume after restart")
 
 	eng.beforePersistMessage = func(msg llm.Message) error {
 		if msg.MessageType == llm.MessageTypeHandoffFutureMessage {
@@ -847,8 +847,8 @@ func TestReopenedSessionAfterTriggerHandoffFutureMessageAppendFailureRetriesWith
 	if len(client.calls) != 1 {
 		t.Fatalf("expected exactly one compaction summary call before reopen, got %d", len(client.calls))
 	}
-	if eng.pendingHandoffRequestSnapshot() != nil {
-		t.Fatalf("expected successful compaction to consume queued handoff request before reopen, got %+v", eng.pendingHandoffRequestSnapshot())
+	if eng.handoffRuntimeState().RequestSnapshot() != nil {
+		t.Fatalf("expected successful compaction to consume queued handoff request before reopen, got %+v", eng.handoffRuntimeState().RequestSnapshot())
 	}
 
 	reopenedStore, err := session.Open(store.Dir())
@@ -860,10 +860,10 @@ func TestReopenedSessionAfterTriggerHandoffFutureMessageAppendFailureRetriesWith
 		Usage:     llm.Usage{InputTokens: 300, WindowTokens: 2_000},
 	}}}
 	restored := mustNewHandoffTestEngine(t, reopenedStore, resumedClient, Config{})
-	if restored.pendingHandoffRequestSnapshot() != nil {
-		t.Fatalf("did not expect restore to requeue handoff after successful compaction, got %+v", restored.pendingHandoffRequestSnapshot())
+	if restored.handoffRuntimeState().RequestSnapshot() != nil {
+		t.Fatalf("did not expect restore to requeue handoff after successful compaction, got %+v", restored.handoffRuntimeState().RequestSnapshot())
 	}
-	if got, want := restored.pendingHandoffFutureMessageSnapshot(), "resume after restart"; got != want {
+	if got, want := restored.handoffRuntimeState().FutureMessageSnapshot(), "resume after restart"; got != want {
 		t.Fatalf("pending future-agent message after reopen = %q, want %q", got, want)
 	}
 
@@ -877,10 +877,10 @@ func TestReopenedSessionAfterTriggerHandoffFutureMessageAppendFailureRetriesWith
 	if len(resumedClient.calls) != 1 {
 		t.Fatalf("expected reopened retry to append future-agent message without re-running compaction, got %d requests", len(resumedClient.calls))
 	}
-	if got, want := resumedClient.calls[0].SessionID, restored.conversationSessionID(); got != want {
+	if got, want := resumedClient.calls[0].SessionID, restored.SessionID(); got != want {
 		t.Fatalf("expected reopened request session id to stay on the main conversation after restored handoff compaction, got %q want %q", got, want)
 	}
-	if got, want := resumedClient.calls[0].PromptCacheKey, restored.conversationPromptCacheKey(); got != want {
+	if got, want := resumedClient.calls[0].PromptCacheKey, conversationPromptCacheKey(restored.SessionID(), restored.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("expected reopened request prompt cache key to stay rotated after restored handoff compaction, got %q want %q", got, want)
 	}
 	foundFuture := false
@@ -929,10 +929,10 @@ func TestRunStepLoopTriggerHandoffOmitsCallAndOutputFromFollowUpRequestAndKeepsF
 		CompactionMode: "local",
 		EnabledTools:   []toolspec.ID{toolspec.ToolExecCommand, toolspec.ToolTriggerHandoff},
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
-	eng.setCompactionSoonReminderIssued(true)
+	eng.compactionRuntimeState().SetSoonReminderIssued(true)
 
 	msg, err := eng.runStepLoop(context.Background(), "step-1")
 	if err != nil {
@@ -944,10 +944,10 @@ func TestRunStepLoopTriggerHandoffOmitsCallAndOutputFromFollowUpRequestAndKeepsF
 	if len(client.calls) != 3 {
 		t.Fatalf("expected tool call, local compaction summary, and follow-up requests, got %d", len(client.calls))
 	}
-	if got, want := client.calls[2].SessionID, eng.conversationSessionID(); got != want {
+	if got, want := client.calls[2].SessionID, eng.SessionID(); got != want {
 		t.Fatalf("expected follow-up request session id to stay on the main conversation after handoff compaction, got %q want %q", got, want)
 	}
-	if got, want := client.calls[2].PromptCacheKey, eng.conversationPromptCacheKey(); got != want {
+	if got, want := client.calls[2].PromptCacheKey, conversationPromptCacheKey(eng.SessionID(), eng.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("expected follow-up request prompt cache key to rotate after handoff compaction, got %q want %q", got, want)
 	}
 
@@ -1009,7 +1009,7 @@ func TestRunStepLoopInjectsReminderBeforeTriggerHandoffAndOmitsCallOutputFromFol
 		AutoCompactTokenLimit: 10_000,
 		EnabledTools:          []toolspec.ID{toolspec.ToolExecCommand, toolspec.ToolTriggerHandoff},
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 8_900, WindowTokens: 20_000})
@@ -1024,10 +1024,10 @@ func TestRunStepLoopInjectsReminderBeforeTriggerHandoffAndOmitsCallOutputFromFol
 	if len(client.calls) != 3 {
 		t.Fatalf("expected trigger request, local compaction summary, and follow-up requests, got %d", len(client.calls))
 	}
-	if got, want := client.calls[2].SessionID, eng.conversationSessionID(); got != want {
+	if got, want := client.calls[2].SessionID, eng.SessionID(); got != want {
 		t.Fatalf("expected follow-up request session id to stay on the main conversation after handoff compaction, got %q want %q", got, want)
 	}
-	if got, want := client.calls[2].PromptCacheKey, eng.conversationPromptCacheKey(); got != want {
+	if got, want := client.calls[2].PromptCacheKey, conversationPromptCacheKey(eng.SessionID(), eng.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("expected follow-up request prompt cache key to rotate after handoff compaction, got %q want %q", got, want)
 	}
 
@@ -1095,7 +1095,7 @@ func TestReopenedSessionAfterTriggerHandoffUsesRotatedRequestSessionAndOmitsLing
 		CompactionMode: "local",
 		EnabledTools:   []toolspec.ID{toolspec.ToolExecCommand, toolspec.ToolTriggerHandoff},
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	// Match real startup semantics: the initial runtime session has already injected
@@ -1106,7 +1106,7 @@ func TestReopenedSessionAfterTriggerHandoffUsesRotatedRequestSessionAndOmitsLing
 	if err := eng.steerBaseMetaContextIfNeeded("seed-meta"); err != nil {
 		t.Fatalf("inject agents: %v", err)
 	}
-	eng.setCompactionSoonReminderIssued(true)
+	eng.compactionRuntimeState().SetSoonReminderIssued(true)
 
 	if _, err := eng.runStepLoop(context.Background(), "step-1"); err != nil {
 		t.Fatalf("runStepLoop: %v", err)
@@ -1132,10 +1132,10 @@ func TestReopenedSessionAfterTriggerHandoffUsesRotatedRequestSessionAndOmitsLing
 	if len(resumedClient.calls) != 1 {
 		t.Fatalf("expected one resumed model call, got %d", len(resumedClient.calls))
 	}
-	if got, want := resumedClient.calls[0].SessionID, restored.conversationSessionID(); got != want {
+	if got, want := resumedClient.calls[0].SessionID, restored.SessionID(); got != want {
 		t.Fatalf("expected resumed request session id to stay on the main conversation after restore, got %q want %q", got, want)
 	}
-	if got, want := resumedClient.calls[0].PromptCacheKey, restored.conversationPromptCacheKey(); got != want {
+	if got, want := resumedClient.calls[0].PromptCacheKey, conversationPromptCacheKey(restored.SessionID(), restored.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("expected resumed request prompt cache key to stay rotated after restore, got %q want %q", got, want)
 	}
 	for _, item := range resumedClient.calls[0].Items {

--- a/server/runtime/engine_part14_test.go
+++ b/server/runtime/engine_part14_test.go
@@ -20,7 +20,7 @@ func TestReopenedSessionAfterSuccessfulTriggerHandoffRequeuesPendingHandoff(t *t
 	store := mustCreateTestSession(t)
 
 	eng := mustNewHandoffTestEngine(t, store, &fakeClient{}, Config{})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	handoffCall := llm.ToolCall{
@@ -28,7 +28,7 @@ func TestReopenedSessionAfterSuccessfulTriggerHandoffRequeuesPendingHandoff(t *t
 		Name:  string(toolspec.ToolTriggerHandoff),
 		Input: mustJSON(map[string]any{"summarizer_prompt": "keep API details", "future_agent_message": "resume after restart"}),
 	}
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Content: "handing off", Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{handoffCall}})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Content: "handing off", Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{handoffCall}}})); err != nil {
 		t.Fatalf("append assistant tool call: %v", err)
 	}
 	resultOutput := mustJSON(triggerhandofftool.TriggerHandoffResultPayload{
@@ -38,7 +38,7 @@ func TestReopenedSessionAfterSuccessfulTriggerHandoffRequeuesPendingHandoff(t *t
 	if err := eng.steer("step-1", steerToolCompletionIntent(tools.Result{CallID: handoffCall.ID, Name: toolspec.ToolTriggerHandoff, Output: resultOutput})); err != nil {
 		t.Fatalf("persist tool completion: %v", err)
 	}
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleTool, ToolCallID: handoffCall.ID, Name: string(toolspec.ToolTriggerHandoff), Content: string(resultOutput)})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleTool, ToolCallID: handoffCall.ID, Name: string(toolspec.ToolTriggerHandoff), Content: string(resultOutput)}})); err != nil {
 		t.Fatalf("append tool result: %v", err)
 	}
 
@@ -57,13 +57,13 @@ func TestReopenedSessionAfterSuccessfulTriggerHandoffRequeuesPendingHandoff(t *t
 		},
 	}}
 	restored := mustNewHandoffTestEngine(t, reopenedStore, resumedClient, Config{})
-	if restored.pendingHandoffRequestSnapshot() == nil {
+	if restored.handoffRuntimeState().RequestSnapshot() == nil {
 		t.Fatal("expected restore to recover pending handoff request")
 	}
-	if got, want := restored.pendingHandoffRequestSnapshot().summarizerPrompt, "keep API details"; got != want {
+	if got, want := restored.handoffRuntimeState().RequestSnapshot().summarizerPrompt, "keep API details"; got != want {
 		t.Fatalf("pending summarizer_prompt = %q, want %q", got, want)
 	}
-	if got, want := restored.pendingHandoffRequestSnapshot().futureAgentMessage, "resume after restart"; got != want {
+	if got, want := restored.handoffRuntimeState().RequestSnapshot().futureAgentMessage, "resume after restart"; got != want {
 		t.Fatalf("pending future_agent_message = %q, want %q", got, want)
 	}
 
@@ -89,10 +89,10 @@ func TestReopenedSessionAfterSuccessfulTriggerHandoffRequeuesPendingHandoff(t *t
 		t.Fatalf("expected restored handoff compaction request to include summarizer prompt, items=%+v", first.Items)
 	}
 	followUp := resumedClient.calls[1]
-	if got, want := followUp.SessionID, restored.conversationSessionID(); got != want {
+	if got, want := followUp.SessionID, restored.SessionID(); got != want {
 		t.Fatalf("expected follow-up request session id to stay on the main conversation after restored handoff compaction, got %q want %q", got, want)
 	}
-	if got, want := followUp.PromptCacheKey, restored.conversationPromptCacheKey(); got != want {
+	if got, want := followUp.PromptCacheKey, conversationPromptCacheKey(restored.SessionID(), restored.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("expected follow-up request prompt cache key to rotate after restored handoff compaction, got %q want %q", got, want)
 	}
 	foundCall := false
@@ -120,7 +120,7 @@ func TestForkedSessionAfterTriggerHandoffRequeuesPendingHandoff(t *testing.T) {
 	store := mustCreateTestSession(t)
 
 	eng := mustNewHandoffTestEngine(t, store, &fakeClient{}, Config{})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	handoffCall := llm.ToolCall{
@@ -128,7 +128,7 @@ func TestForkedSessionAfterTriggerHandoffRequeuesPendingHandoff(t *testing.T) {
 		Name:  string(toolspec.ToolTriggerHandoff),
 		Input: mustJSON(map[string]any{"future_agent_message": "resume after fork"}),
 	}
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Content: "handing off", Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{handoffCall}})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Content: "handing off", Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{handoffCall}}})); err != nil {
 		t.Fatalf("append assistant tool call: %v", err)
 	}
 	resultOutput := mustJSON(triggerhandofftool.TriggerHandoffResultPayload{
@@ -138,10 +138,10 @@ func TestForkedSessionAfterTriggerHandoffRequeuesPendingHandoff(t *testing.T) {
 	if err := eng.steer("step-1", steerToolCompletionIntent(tools.Result{CallID: handoffCall.ID, Name: toolspec.ToolTriggerHandoff, Output: resultOutput})); err != nil {
 		t.Fatalf("persist tool completion: %v", err)
 	}
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleTool, ToolCallID: handoffCall.ID, Name: string(toolspec.ToolTriggerHandoff), Content: string(resultOutput)})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleTool, ToolCallID: handoffCall.ID, Name: string(toolspec.ToolTriggerHandoff), Content: string(resultOutput)}})); err != nil {
 		t.Fatalf("append tool result: %v", err)
 	}
-	if err := eng.steer("step-2", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "edit anchor"})); err != nil {
+	if err := eng.steer("step-2", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "edit anchor"}})); err != nil {
 		t.Fatalf("append second user message: %v", err)
 	}
 
@@ -150,10 +150,10 @@ func TestForkedSessionAfterTriggerHandoffRequeuesPendingHandoff(t *testing.T) {
 		t.Fatalf("fork session: %v", err)
 	}
 	forked := mustNewHandoffTestEngine(t, forkedStore, &fakeClient{}, Config{})
-	if forked.pendingHandoffRequestSnapshot() == nil {
+	if forked.handoffRuntimeState().RequestSnapshot() == nil {
 		t.Fatal("expected forked session to recover pending handoff request")
 	}
-	if got, want := forked.pendingHandoffRequestSnapshot().futureAgentMessage, "resume after fork"; got != want {
+	if got, want := forked.handoffRuntimeState().RequestSnapshot().futureAgentMessage, "resume after fork"; got != want {
 		t.Fatalf("forked pending future_agent_message = %q, want %q", got, want)
 	}
 }
@@ -162,7 +162,7 @@ func TestReopenedSessionAfterTriggerHandoffDoesNotRequeueWhenAnyCompactionAlread
 	store := mustCreateTestSession(t)
 
 	eng := mustNewHandoffTestEngine(t, store, &fakeClient{}, Config{})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	handoffCall := llm.ToolCall{
@@ -170,7 +170,7 @@ func TestReopenedSessionAfterTriggerHandoffDoesNotRequeueWhenAnyCompactionAlread
 		Name:  string(toolspec.ToolTriggerHandoff),
 		Input: mustJSON(map[string]any{"future_agent_message": "resume after manual compact"}),
 	}
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Content: "handing off", Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{handoffCall}})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Content: "handing off", Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{handoffCall}}})); err != nil {
 		t.Fatalf("append assistant tool call: %v", err)
 	}
 	resultOutput := mustJSON(triggerhandofftool.TriggerHandoffResultPayload{
@@ -180,7 +180,7 @@ func TestReopenedSessionAfterTriggerHandoffDoesNotRequeueWhenAnyCompactionAlread
 	if err := eng.steer("step-1", steerToolCompletionIntent(tools.Result{CallID: handoffCall.ID, Name: toolspec.ToolTriggerHandoff, Output: resultOutput})); err != nil {
 		t.Fatalf("persist tool completion: %v", err)
 	}
-	if err := eng.replaceHistory("step-1", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}})); err != nil {
+	if err := newCompactionPersistence(eng).replaceHistory("step-1", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}})); err != nil {
 		t.Fatalf("replace history: %v", err)
 	}
 
@@ -193,8 +193,8 @@ func TestReopenedSessionAfterTriggerHandoffDoesNotRequeueWhenAnyCompactionAlread
 		Usage:     llm.Usage{InputTokens: 300, WindowTokens: 2_000},
 	}}}
 	restored := mustNewHandoffTestEngine(t, reopenedStore, resumedClient, Config{})
-	if restored.pendingHandoffRequestSnapshot() != nil {
-		t.Fatalf("did not expect restore to requeue handoff after later compaction, got %+v", restored.pendingHandoffRequestSnapshot())
+	if restored.handoffRuntimeState().RequestSnapshot() != nil {
+		t.Fatalf("did not expect restore to requeue handoff after later compaction, got %+v", restored.handoffRuntimeState().RequestSnapshot())
 	}
 
 	msg, err := restored.SubmitUserMessage(context.Background(), "continue")
@@ -207,10 +207,10 @@ func TestReopenedSessionAfterTriggerHandoffDoesNotRequeueWhenAnyCompactionAlread
 	if len(resumedClient.calls) != 1 {
 		t.Fatalf("expected compaction-satisfied session to resume with a single request, got %d", len(resumedClient.calls))
 	}
-	if got, want := resumedClient.calls[0].SessionID, restored.conversationSessionID(); got != want {
+	if got, want := resumedClient.calls[0].SessionID, restored.SessionID(); got != want {
 		t.Fatalf("expected resumed request session id to stay on the main conversation after restored compaction, got %q want %q", got, want)
 	}
-	if got, want := resumedClient.calls[0].PromptCacheKey, restored.conversationPromptCacheKey(); got != want {
+	if got, want := resumedClient.calls[0].PromptCacheKey, conversationPromptCacheKey(restored.SessionID(), restored.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("expected resumed request prompt cache key to stay rotated after restored compaction, got %q want %q", got, want)
 	}
 	for _, item := range resumedClient.calls[0].Items {
@@ -227,7 +227,7 @@ func TestReopenedSessionAfterFailedTriggerHandoffDoesNotRequeuePendingHandoff(t 
 	store := mustCreateTestSession(t)
 
 	eng := mustNewHandoffTestEngine(t, store, &fakeClient{}, Config{})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	handoffCall := llm.ToolCall{
@@ -235,7 +235,7 @@ func TestReopenedSessionAfterFailedTriggerHandoffDoesNotRequeuePendingHandoff(t 
 		Name:  string(toolspec.ToolTriggerHandoff),
 		Input: mustJSON(map[string]any{"future_agent_message": "should not resume"}),
 	}
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Content: "attempting handoff", Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{handoffCall}})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Content: "attempting handoff", Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{handoffCall}}})); err != nil {
 		t.Fatalf("append assistant tool call: %v", err)
 	}
 	failedOutput := mustJSON(map[string]any{"error": handoffDisabledByUserMessage})
@@ -248,8 +248,8 @@ func TestReopenedSessionAfterFailedTriggerHandoffDoesNotRequeuePendingHandoff(t 
 		t.Fatalf("re-open store: %v", err)
 	}
 	restored := mustNewHandoffTestEngine(t, reopenedStore, &fakeClient{}, Config{})
-	if restored.pendingHandoffRequestSnapshot() != nil {
-		t.Fatalf("did not expect failed trigger_handoff completion to requeue handoff, got %+v", restored.pendingHandoffRequestSnapshot())
+	if restored.handoffRuntimeState().RequestSnapshot() != nil {
+		t.Fatalf("did not expect failed trigger_handoff completion to requeue handoff, got %+v", restored.handoffRuntimeState().RequestSnapshot())
 	}
 }
 
@@ -257,7 +257,7 @@ func TestReopenedSessionAfterLegacyReviewerRollbackStillRequeuesPendingTriggerHa
 	store := mustCreateTestSession(t)
 
 	eng := mustNewHandoffTestEngine(t, store, &fakeClient{}, Config{})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	handoffCall := llm.ToolCall{
@@ -265,7 +265,7 @@ func TestReopenedSessionAfterLegacyReviewerRollbackStillRequeuesPendingTriggerHa
 		Name:  string(toolspec.ToolTriggerHandoff),
 		Input: mustJSON(map[string]any{"future_agent_message": "resume after rollback"}),
 	}
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Content: "handing off", Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{handoffCall}})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Content: "handing off", Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{handoffCall}}})); err != nil {
 		t.Fatalf("append assistant tool call: %v", err)
 	}
 	resultOutput := mustJSON(triggerhandofftool.TriggerHandoffResultPayload{
@@ -284,10 +284,10 @@ func TestReopenedSessionAfterLegacyReviewerRollbackStillRequeuesPendingTriggerHa
 		t.Fatalf("re-open store: %v", err)
 	}
 	restored := mustNewHandoffTestEngine(t, reopenedStore, &fakeClient{}, Config{})
-	if restored.pendingHandoffRequestSnapshot() == nil {
+	if restored.handoffRuntimeState().RequestSnapshot() == nil {
 		t.Fatal("expected ignored legacy reviewer rollback to preserve pending handoff recovery")
 	}
-	if got, want := restored.pendingHandoffRequestSnapshot().futureAgentMessage, "resume after rollback"; got != want {
+	if got, want := restored.handoffRuntimeState().RequestSnapshot().futureAgentMessage, "resume after rollback"; got != want {
 		t.Fatalf("pending future_agent_message = %q, want %q", got, want)
 	}
 }
@@ -307,23 +307,23 @@ func TestManualCompactionClearsQueuedTriggerHandoff(t *testing.T) {
 	}}
 
 	eng := mustNewHandoffTestEngine(t, store, client, Config{})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
-	eng.setCompactionSoonReminderIssued(true)
+	eng.compactionRuntimeState().SetSoonReminderIssued(true)
 
 	_, _, err := eng.TriggerHandoff(context.Background(), "step-1", llm.ToolCall{ID: "call_handoff_manual_clear", Name: string(toolspec.ToolTriggerHandoff)}, "", "resume after manual compact")
 	if err != nil {
 		t.Fatalf("trigger handoff: %v", err)
 	}
-	if eng.pendingHandoffRequestSnapshot() == nil {
+	if eng.handoffRuntimeState().RequestSnapshot() == nil {
 		t.Fatal("expected queued handoff before manual compaction")
 	}
 	if err := eng.CompactContext(context.Background(), "manual compact now"); err != nil {
 		t.Fatalf("manual compact: %v", err)
 	}
-	if eng.pendingHandoffRequestSnapshot() != nil {
-		t.Fatalf("expected manual compaction to clear queued handoff, got %+v", eng.pendingHandoffRequestSnapshot())
+	if eng.handoffRuntimeState().RequestSnapshot() != nil {
+		t.Fatalf("expected manual compaction to clear queued handoff, got %+v", eng.handoffRuntimeState().RequestSnapshot())
 	}
 
 	msg, err := eng.SubmitUserMessage(context.Background(), "continue")
@@ -354,7 +354,7 @@ func TestManualCompactionRemotePassesSlashCommandArgumentsAsInstructions(t *test
 	}
 
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -379,7 +379,7 @@ func TestManualCompactionLocalAppendsSlashCommandArgumentsToPrompt(t *testing.T)
 		},
 	}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -416,7 +416,7 @@ func TestManualCompactionLocalSendsPromptAsDeveloperMessage(t *testing.T) {
 		}},
 	}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -458,10 +458,10 @@ func TestManualCompactionAppendsLastVisibleUserMessageCarryover(t *testing.T) {
 	}
 
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "older summary"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "older summary"}})); err != nil {
 		t.Fatalf("append compaction summary: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "please keep tests green"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "please keep tests green"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 
@@ -469,7 +469,7 @@ func TestManualCompactionAppendsLastVisibleUserMessageCarryover(t *testing.T) {
 		t.Fatalf("compact: %v", err)
 	}
 
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	if len(messages) == 0 {
 		t.Fatal("expected messages after manual compaction")
 	}
@@ -524,7 +524,7 @@ func TestManualLocalCompactionRebuildsCanonicalContextOrder(t *testing.T) {
 		Usage:     llm.Usage{InputTokens: 1000, OutputTokens: 100, WindowTokens: 200000},
 	}}}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "please keep tests green"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "please keep tests green"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 
@@ -532,7 +532,7 @@ func TestManualLocalCompactionRebuildsCanonicalContextOrder(t *testing.T) {
 		t.Fatalf("compact: %v", err)
 	}
 
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	if len(messages) < 6 {
 		t.Fatalf("expected canonical post-compaction messages, got %+v", messages)
 	}
@@ -566,16 +566,16 @@ func TestHandoffCompactionAppendsFutureMessageBeforeHeadlessReentry(t *testing.T
 	if err := store.SetHeadlessActive(true); err != nil {
 		t.Fatalf("mark headless active: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "continue"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "continue"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
-	eng.queueHandoffRequest("", "resume with tests")
+	eng.handoffRuntimeState().QueueRequest("", "resume with tests")
 
 	if _, err := eng.applyPendingHandoffIfNeeded(context.Background(), "step-1"); err != nil {
 		t.Fatalf("apply pending handoff: %v", err)
 	}
 
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	futureIdx := -1
 	headlessIdx := -1
 	for idx, message := range messages {
@@ -610,7 +610,7 @@ func TestManualLocalCompactionPlacesSummaryBeforeCarryoverInTranscript(t *testin
 	}
 
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "please keep tests green"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "please keep tests green"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 
@@ -657,10 +657,10 @@ func TestManualLocalCompactionOmitsCarryoverWithoutNewUserMessageSincePreviousCo
 	}
 
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "older user message"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "older user message"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "previous compaction summary"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "previous compaction summary"}})); err != nil {
 		t.Fatalf("append previous compaction summary: %v", err)
 	}
 
@@ -668,9 +668,9 @@ func TestManualLocalCompactionOmitsCarryoverWithoutNewUserMessageSincePreviousCo
 		t.Fatalf("compact: %v", err)
 	}
 
-	for _, message := range eng.snapshotMessages() {
+	for _, message := range eng.transcriptRuntimeState().SnapshotMessages() {
 		if message.MessageType == llm.MessageTypeManualCompactionCarryover {
-			t.Fatalf("did not expect manual carryover message when no user message followed prior compaction, got %+v", eng.snapshotMessages())
+			t.Fatalf("did not expect manual carryover message when no user message followed prior compaction, got %+v", eng.transcriptRuntimeState().SnapshotMessages())
 		}
 	}
 	for _, entry := range eng.ChatSnapshot().Entries {
@@ -691,7 +691,7 @@ func TestReopenedManualCompactionKeepsCarryoverAsSingleDetailTranscriptEntry(t *
 	}
 
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "please keep tests green"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "please keep tests green"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 	if err := eng.CompactContext(context.Background(), ""); err != nil {
@@ -704,7 +704,7 @@ func TestReopenedManualCompactionKeepsCarryoverAsSingleDetailTranscriptEntry(t *
 	}
 	restored := mustNewExecTestEngine(t, reopenedStore, &fakeClient{}, Config{CompactionMode: "local"})
 
-	messages := restored.snapshotMessages()
+	messages := restored.transcriptRuntimeState().SnapshotMessages()
 	carryoverMessages := 0
 	for _, message := range messages {
 		if message.MessageType != llm.MessageTypeManualCompactionCarryover {

--- a/server/runtime/engine_part15_test.go
+++ b/server/runtime/engine_part15_test.go
@@ -41,7 +41,7 @@ func TestRemoteCompactionUsesSublinearPreciseTokenCountCalls(t *testing.T) {
 
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 400_000})
 	for i := 0; i < 600; i++ {
-		if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Content: "a"})); err != nil {
+		if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Content: "a"}})); err != nil {
 			t.Fatalf("append assistant message %d: %v", i, err)
 		}
 	}
@@ -80,7 +80,7 @@ func TestLocalCompactionCarryoverUsesSublinearPreciseTokenCountCalls(t *testing.
 		CompactionMode:      "local",
 	})
 	for i := 0; i < 512; i++ {
-		if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "u"})); err != nil {
+		if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "u"}})); err != nil {
 			t.Fatalf("append user message %d: %v", i, err)
 		}
 	}
@@ -119,22 +119,22 @@ func TestManualCompactionLocalUsesHistorySinceLastCompactionCheckpoint(t *testin
 		},
 	}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, Content: "canonical context"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, Content: "canonical context"}})); err != nil {
 		t.Fatalf("append canonical context: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "old user request"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "old user request"}})); err != nil {
 		t.Fatalf("append old user message: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Content: "old assistant response"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Content: "old assistant response"}})); err != nil {
 		t.Fatalf("append old assistant message: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "old compacted summary"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "old compacted summary"}})); err != nil {
 		t.Fatalf("append compaction checkpoint: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "new user request"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "new user request"}})); err != nil {
 		t.Fatalf("append new user message: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Content: "new assistant response"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Content: "new assistant response"}})); err != nil {
 		t.Fatalf("append new assistant message: %v", err)
 	}
 
@@ -203,7 +203,7 @@ func TestManualCompactionLocalFailsWhenModelAttemptsToolCalls(t *testing.T) {
 		},
 	}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -226,7 +226,7 @@ func TestManualCompactionDisabledWhenModeNone(t *testing.T) {
 
 	client := &fakeCompactionClient{}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "none"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -258,7 +258,7 @@ func TestAutoCompactionRecomputesUsageFromReplacementHistory(t *testing.T) {
 	}
 
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 190000, OutputTokens: 0, WindowTokens: 200000})
@@ -267,7 +267,7 @@ func TestAutoCompactionRecomputesUsageFromReplacementHistory(t *testing.T) {
 		t.Fatalf("auto compact failed: %v", err)
 	}
 	if eng.shouldAutoCompact() {
-		t.Fatalf("expected auto compact threshold to be cleared after replacement, usage=%+v", eng.lastUsageSnapshot())
+		t.Fatalf("expected auto compact threshold to be cleared after replacement, usage=%+v", eng.usageTrackingState().Last())
 	}
 }
 
@@ -287,7 +287,7 @@ func TestCompactionLabelsSingleSummaryEntry(t *testing.T) {
 	}
 
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 190000, OutputTokens: 0, WindowTokens: 200000})
@@ -329,7 +329,7 @@ func TestEmitCompactionStatusStillPublishesFailureEventWhenErrorPersistenceFails
 		return nil
 	}
 
-	err := eng.emitCompactionStatus("step-1", EventCompactionFailed, compactionModeAuto, "remote", "openai", 0, 2, "quota exceeded")
+	err := newCompactionPersistence(eng).emitStatus("step-1", EventCompactionFailed, compactionModeAuto, "remote", "openai", 0, 2, "quota exceeded")
 	if !errors.Is(err, localEntryErr) {
 		t.Fatalf("emitCompactionStatus error = %v, want %v", err, localEntryErr)
 	}
@@ -350,10 +350,10 @@ func TestEmitCompactionStatusStillPublishesFailureEventWhenErrorPersistenceFails
 func TestReplaceHistoryDoesNotMutateRuntimeStateWhenEventAppendFails(t *testing.T) {
 	store := mustCreateTestSession(t)
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "pre-compaction"})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "pre-compaction"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
-	eng.setCompactionSoonReminderIssued(true)
+	eng.compactionRuntimeState().SetSoonReminderIssued(true)
 
 	eventsPath := filepath.Join(store.Dir(), "events.jsonl")
 	if err := os.Chmod(eventsPath, 0o444); err != nil {
@@ -363,11 +363,11 @@ func TestReplaceHistoryDoesNotMutateRuntimeStateWhenEventAppendFails(t *testing.
 		_ = os.Chmod(eventsPath, 0o644)
 	}()
 
-	err := eng.replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}}))
+	err := newCompactionPersistence(eng).replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}}))
 	if err == nil {
 		t.Fatal("expected replaceHistory persistence failure")
 	}
-	if messages := eng.snapshotMessages(); len(messages) != 1 || messages[0].Content != "pre-compaction" {
+	if messages := eng.transcriptRuntimeState().SnapshotMessages(); len(messages) != 1 || messages[0].Content != "pre-compaction" {
 		t.Fatalf("runtime transcript mutated despite persistence failure: %+v", messages)
 	}
 	if !eng.compactionRuntimeState().SoonReminderIssued() {
@@ -404,19 +404,19 @@ func TestReplaceHistoryUpdatesRuntimeStateWhenMetadataPersistFailsAfterEventAppe
 	observer := &failOnCompactionReminderResetObservation{}
 	store := mustCreateTestSessionAt(t, dir, session.WithPersistenceObserver(observer))
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "pre-compaction"})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "pre-compaction"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	if err := store.SetCompactionSoonReminderIssued(true); err != nil {
 		t.Fatalf("persist seed reminder state: %v", err)
 	}
-	eng.setCompactionSoonReminderIssued(true)
+	eng.compactionRuntimeState().SetSoonReminderIssued(true)
 
-	err := eng.replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}}))
+	err := newCompactionPersistence(eng).replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}}))
 	if err == nil {
 		t.Fatal("expected replaceHistory metadata persistence failure")
 	}
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	if len(messages) != 1 || messages[0].Content != "summary" {
 		t.Fatalf("runtime transcript not updated after durable history replacement: %+v", messages)
 	}
@@ -430,7 +430,7 @@ func TestReplaceHistoryUpdatesRuntimeStateWhenUsageMetadataPersistFailsAfterEven
 	observer := &failOnUsageStateResetObservation{}
 	store := mustCreateTestSessionAt(t, dir, session.WithPersistenceObserver(observer))
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "pre-compaction"})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "pre-compaction"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	if err := store.SetUsageState(&session.UsageState{InputTokens: 42, WindowTokens: 100}); err != nil {
@@ -438,11 +438,11 @@ func TestReplaceHistoryUpdatesRuntimeStateWhenUsageMetadataPersistFailsAfterEven
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 42, WindowTokens: 100})
 
-	err := eng.replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}}))
+	err := newCompactionPersistence(eng).replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}}))
 	if err == nil {
 		t.Fatal("expected replaceHistory usage metadata persistence failure")
 	}
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	if len(messages) != 1 || messages[0].Content != "summary" {
 		t.Fatalf("runtime transcript not updated after durable history replacement: %+v", messages)
 	}
@@ -618,7 +618,7 @@ func TestRemoteCompactionReinjectsActiveWorkflowPrompt(t *testing.T) {
 	}}}
 	workflowCfg := testWorkflowConfig(&fakeWorkflowController{}, config.WorkflowCompletionModeTool)
 	eng := mustNewWorkflowTestEngine(t, store, client, workflowCfg, Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 
@@ -626,9 +626,9 @@ func TestRemoteCompactionReinjectsActiveWorkflowPrompt(t *testing.T) {
 		t.Fatalf("compactNow: %v", err)
 	}
 
-	workflowMessages := workflowModeMessagesFromItems(eng.snapshotItems())
+	workflowMessages := workflowModeMessagesFromItems(eng.transcriptRuntimeState().SnapshotItems())
 	if len(workflowMessages) != 1 {
-		t.Fatalf("workflow prompt count after compaction = %d, want 1; items=%+v", len(workflowMessages), eng.snapshotItems())
+		t.Fatalf("workflow prompt count after compaction = %d, want 1; items=%+v", len(workflowMessages), eng.transcriptRuntimeState().SnapshotItems())
 	}
 	workflowPrompt := workflowMessages[0]
 	if workflowPrompt.SourcePath != "run-1" {
@@ -654,10 +654,10 @@ func TestRemoteCompactionRefreshesWorkflowTaskCommentCount(t *testing.T) {
 	workflowCfg := testWorkflowConfig(&fakeWorkflowController{}, config.WorkflowCompletionModeTool)
 	workflowCfg.TaskCommentCounter = counter
 	eng := mustNewWorkflowTestEngine(t, store, client, workflowCfg, Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeWorkflowMode, SourcePath: "run-1", Content: "old workflow prompt with 1 comment"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeWorkflowMode, SourcePath: "run-1", Content: "old workflow prompt with 1 comment"}})); err != nil {
 		t.Fatalf("append stale workflow prompt: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 
@@ -668,9 +668,9 @@ func TestRemoteCompactionRefreshesWorkflowTaskCommentCount(t *testing.T) {
 	if got := counter.calls.Load(); got != 1 {
 		t.Fatalf("CountTaskComments calls = %d, want 1", got)
 	}
-	workflowMessages := workflowModeMessagesFromItems(eng.snapshotItems())
+	workflowMessages := workflowModeMessagesFromItems(eng.transcriptRuntimeState().SnapshotItems())
 	if len(workflowMessages) != 1 {
-		t.Fatalf("workflow prompt count after compaction = %d, want 1; items=%+v", len(workflowMessages), eng.snapshotItems())
+		t.Fatalf("workflow prompt count after compaction = %d, want 1; items=%+v", len(workflowMessages), eng.transcriptRuntimeState().SnapshotItems())
 	}
 	if strings.Contains(workflowMessages[0].Content, "old workflow prompt") || !strings.Contains(workflowMessages[0].Content, "3 comments") {
 		t.Fatalf("workflow prompt was not refreshed from current comment count:\n%s", workflowMessages[0].Content)
@@ -690,7 +690,7 @@ func TestRemoteCompactionTaskCommentCountErrorDoesNotReplaceHistory(t *testing.T
 	workflowCfg := testWorkflowConfig(&fakeWorkflowController{}, config.WorkflowCompletionModeTool)
 	workflowCfg.TaskCommentCounter = &fakeTaskCommentCounter{err: countErr}
 	eng := mustNewWorkflowTestEngine(t, store, client, workflowCfg, Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 
@@ -698,7 +698,7 @@ func TestRemoteCompactionTaskCommentCountErrorDoesNotReplaceHistory(t *testing.T
 	if !errors.Is(err, countErr) {
 		t.Fatalf("compactNow error = %v, want %v", err, countErr)
 	}
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	if len(messages) != 1 || messages[0].Role != llm.RoleUser || messages[0].Content != "seed" {
 		t.Fatalf("active list mutated after comment count error: %+v", messages)
 	}
@@ -723,7 +723,7 @@ func TestCompactionReplacementPayloadEmbedsReinjectedBaseMetaAtomically(t *testi
 		Usage: llm.Usage{InputTokens: 1000, OutputTokens: 100, WindowTokens: 200000},
 	}}}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 
@@ -799,11 +799,11 @@ func TestHistoryReplacementDurableAfterAppendObserverFailure(t *testing.T) {
 	observer := &failOnHistoryReplacementAgentResetObservation{}
 	store := mustCreateNamedTestSessionAt(t, storeRoot, "ws", workspace, session.WithPersistenceObserver(observer))
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "before replacement"})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "before replacement"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 
-	err := eng.replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary seed"}}))
+	err := newCompactionPersistence(eng).replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary seed"}}))
 	if err == nil {
 		t.Fatal("expected replacement observer failure")
 	}
@@ -833,15 +833,15 @@ func TestHistoryReplacementAppendObserverFailureUpdatesLiveActiveListForNextTurn
 	store := mustCreateNamedTestSessionAt(t, storeRoot, "ws", workspace, session.WithPersistenceObserver(observer))
 	client := &fakeClient{responses: []llm.Response{{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done"}, Usage: llm.Usage{WindowTokens: 200000}}}}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("step-1", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "before replacement"})); err != nil {
+	if err := eng.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "before replacement"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 
-	err := eng.replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary seed"}}))
+	err := newCompactionPersistence(eng).replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSummary, Content: "summary seed"}}))
 	if err == nil {
 		t.Fatal("expected replacement observer failure")
 	}
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	if len(messages) != 1 || messages[0].MessageType != llm.MessageTypeCompactionSummary || messages[0].Content != "summary seed" {
 		t.Fatalf("live active list after committed replacement error = %+v, want compacted seed", messages)
 	}
@@ -881,7 +881,7 @@ func TestWorkflowRequestAfterCompactionDoesNotDuplicateReinjectedWorkflowPrompt(
 	}
 	workflowCfg := testWorkflowConfig(controller, config.WorkflowCompletionModeTool)
 	eng := mustNewWorkflowTestEngine(t, store, client, workflowCfg, Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	if _, err := eng.compactNow(context.Background(), "step-1", compactionModeManual, "", false); err != nil {
@@ -949,7 +949,7 @@ func TestManualRemoteCompactionRebuildsCanonicalPrefixOrder(t *testing.T) {
 	if err := store.SetHeadlessActive(true); err != nil {
 		t.Fatalf("mark headless active: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 
@@ -957,7 +957,7 @@ func TestManualRemoteCompactionRebuildsCanonicalPrefixOrder(t *testing.T) {
 		t.Fatalf("compactNow: %v", err)
 	}
 
-	items := eng.snapshotItems()
+	items := eng.transcriptRuntimeState().SnapshotItems()
 	if len(items) < 7 {
 		t.Fatalf("expected canonical remote compaction prefix, got %+v", items)
 	}

--- a/server/runtime/engine_part15_test.go
+++ b/server/runtime/engine_part15_test.go
@@ -266,7 +266,7 @@ func TestAutoCompactionRecomputesUsageFromReplacementHistory(t *testing.T) {
 	if err := eng.autoCompactIfNeeded(context.Background(), "step-1", compactionModeAuto); err != nil {
 		t.Fatalf("auto compact failed: %v", err)
 	}
-	if eng.shouldAutoCompact() {
+	if eng.shouldAutoCompactWithContext(context.Background()) {
 		t.Fatalf("expected auto compact threshold to be cleared after replacement, usage=%+v", eng.usageTrackingState().Last())
 	}
 }

--- a/server/runtime/engine_part4_test.go
+++ b/server/runtime/engine_part4_test.go
@@ -383,7 +383,7 @@ func TestAutoCompactionStatusEventDoesNotPublishCommittedEntryStart(t *testing.T
 			eventsMu.Unlock()
 		},
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 190000, OutputTokens: 0, WindowTokens: 200000})
@@ -423,7 +423,7 @@ func TestReplaceHistoryPublishesProjectedTranscriptEntriesBeforeCompactionStatus
 			events = append(events, evt)
 		},
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "before compaction"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "before compaction"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 
@@ -431,10 +431,10 @@ func TestReplaceHistoryPublishesProjectedTranscriptEntriesBeforeCompactionStatus
 		{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeEnvironment, Content: "environment info"},
 		{Role: llm.RoleUser, MessageType: llm.MessageTypeCompactionSummary, Content: "condensed summary"},
 	})
-	if err := eng.replaceHistory("step-1", "local", compactionModeManual, replacement); err != nil {
+	if err := newCompactionPersistence(eng).replaceHistory("step-1", "local", compactionModeManual, replacement); err != nil {
 		t.Fatalf("replace history: %v", err)
 	}
-	if err := eng.emitCompactionStatus("step-1", EventCompactionCompleted, compactionModeManual, "local", "", 2, 1, ""); err != nil {
+	if err := newCompactionPersistence(eng).emitStatus("step-1", EventCompactionCompleted, compactionModeManual, "local", "", 2, 1, ""); err != nil {
 		t.Fatalf("emit compaction status: %v", err)
 	}
 

--- a/server/runtime/engine_part5_test.go
+++ b/server/runtime/engine_part5_test.go
@@ -278,7 +278,7 @@ func TestFinalNoopAnswerIsInvisibleAndSkipsReviewer(t *testing.T) {
 
 	finalAssistantContents := make([]string, 0)
 	noopFinalCount := 0
-	for _, persisted := range eng.snapshotMessages() {
+	for _, persisted := range eng.transcriptRuntimeState().SnapshotMessages() {
 		if persisted.Role == llm.RoleAssistant && persisted.Phase == llm.MessagePhaseFinal {
 			finalAssistantContents = append(finalAssistantContents, persisted.Content)
 		}
@@ -287,7 +287,7 @@ func TestFinalNoopAnswerIsInvisibleAndSkipsReviewer(t *testing.T) {
 		}
 	}
 	if noopFinalCount != 1 {
-		t.Fatalf("noop final count = %d, want 1; messages=%+v", noopFinalCount, eng.snapshotMessages())
+		t.Fatalf("noop final count = %d, want 1; messages=%+v", noopFinalCount, eng.transcriptRuntimeState().SnapshotMessages())
 	}
 	if len(finalAssistantContents) != 1 || finalAssistantContents[0] != reviewerNoopToken {
 		t.Fatalf("expected hidden persisted noop final assistant message, got %q", finalAssistantContents)

--- a/server/runtime/engine_part6_test.go
+++ b/server/runtime/engine_part6_test.go
@@ -157,7 +157,7 @@ func TestRunReviewerFollowUpReturnsCompletionWhenReviewerInstructionAppendFails(
 		Model:    "gpt-5",
 		Reviewer: ReviewerConfig{Model: "gpt-5"},
 	})
-	if err := eng.steer("prep-1", steerUserMessageIntent(llm.Message{Role: llm.RoleUser, Content: "first request"})); err != nil {
+	if err := eng.steer("prep-1", steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "first request"}})); err != nil {
 		t.Fatalf("append first message: %v", err)
 	}
 
@@ -241,7 +241,7 @@ func TestRunStepLoopFailsWhenReviewerStatusPersistenceFailsAfterReviewerInstruct
 		}
 		return nil
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "do task"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "do task"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 
@@ -520,7 +520,7 @@ func TestRestoreMessagesIgnoresLegacyReviewerRollbackHistoryReplacement(t *testi
 	case <-time.After(2 * time.Second):
 		t.Fatal("restore engine timed out while ignoring legacy reviewer_rollback history replacement")
 	}
-	items := restored.snapshotItems()
+	items := restored.transcriptRuntimeState().SnapshotItems()
 	if len(items) != 0 {
 		t.Fatalf("expected legacy reviewer rollback replacement to be ignored, got %+v", items)
 	}

--- a/server/runtime/engine_part7_test.go
+++ b/server/runtime/engine_part7_test.go
@@ -305,7 +305,7 @@ func TestFastExecCommandCompletionDoesNotQueueBackgroundNotice(t *testing.T) {
 	if callCount != 2 {
 		t.Fatalf("model call count = %d, want 2", callCount)
 	}
-	for _, msg := range eng.snapshotMessages() {
+	for _, msg := range eng.transcriptRuntimeState().SnapshotMessages() {
 		if msg.Role == llm.RoleDeveloper && msg.MessageType == llm.MessageTypeBackgroundNotice {
 			t.Fatalf("did not expect background notice for foreground exec_command completion: %+v", msg)
 		}
@@ -789,7 +789,7 @@ func TestBackgroundShellNoticeSameTurnNoopAddsNoAssistantMessage(t *testing.T) {
 	finalAssistantContents := make([]string, 0)
 	foundBackgroundNotice := false
 	noopFinalCount := 0
-	for _, persisted := range eng.snapshotMessages() {
+	for _, persisted := range eng.transcriptRuntimeState().SnapshotMessages() {
 		if persisted.Role == llm.RoleAssistant && persisted.Phase == llm.MessagePhaseFinal {
 			finalAssistantContents = append(finalAssistantContents, persisted.Content)
 		}
@@ -801,10 +801,10 @@ func TestBackgroundShellNoticeSameTurnNoopAddsNoAssistantMessage(t *testing.T) {
 		}
 	}
 	if !foundBackgroundNotice {
-		t.Fatalf("expected persisted background notice, got %+v", eng.snapshotMessages())
+		t.Fatalf("expected persisted background notice, got %+v", eng.transcriptRuntimeState().SnapshotMessages())
 	}
 	if noopFinalCount != 1 {
-		t.Fatalf("noop final count = %d, want 1; messages=%+v", noopFinalCount, eng.snapshotMessages())
+		t.Fatalf("noop final count = %d, want 1; messages=%+v", noopFinalCount, eng.transcriptRuntimeState().SnapshotMessages())
 	}
 	if len(finalAssistantContents) != 1 || finalAssistantContents[0] != reviewerNoopToken {
 		t.Fatalf("expected hidden persisted noop final assistant message, got %q", finalAssistantContents)

--- a/server/runtime/engine_part7_test.go
+++ b/server/runtime/engine_part7_test.go
@@ -272,7 +272,7 @@ func TestFastExecCommandCompletionDoesNotQueueBackgroundNotice(t *testing.T) {
 	registry := tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: shelltool.NewExecCommandTool(dir, 16_000, manager, "")})
 	eng := mustNewTestEngine(t, store, client, registry, Config{Model: "gpt-5"})
 	manager.SetEventHandler(func(evt shelltool.Event) {
-		eng.HandleBackgroundShellEvent(BackgroundShellEvent{
+		eng.HandleBackgroundShellUpdate(BackgroundShellEvent{
 			Type:    string(evt.Type),
 			ID:      evt.Snapshot.ID,
 			State:   evt.Snapshot.State,
@@ -288,7 +288,7 @@ func TestFastExecCommandCompletionDoesNotQueueBackgroundNotice(t *testing.T) {
 				out := *evt.Snapshot.ExitCode
 				return &out
 			}(),
-		})
+		}, true)
 	})
 
 	assistant, err := eng.SubmitUserMessage(context.Background(), "run fast command")
@@ -361,12 +361,12 @@ func TestBackgroundShellNoticeFlushesOnFirstAvailableSlot(t *testing.T) {
 		t.Fatal("timed out waiting for tool call to start")
 	}
 
-	eng.HandleBackgroundShellEvent(BackgroundShellEvent{
+	eng.HandleBackgroundShellUpdate(BackgroundShellEvent{
 		Type:       "completed",
 		ID:         "1000",
 		State:      "completed",
 		NoticeText: "Background shell 1000 completed.\nExit code: 0\nOutput:\ndone",
-	})
+	}, true)
 
 	client.mu.Lock()
 	callCountWhileBusy := len(client.calls)
@@ -487,12 +487,12 @@ func TestDeferredFinalWithBackgroundNoticeStillRunsReviewerAndEmitsAssistantEven
 		t.Fatal("timed out waiting for tool call to start")
 	}
 
-	eng.HandleBackgroundShellEvent(BackgroundShellEvent{
+	eng.HandleBackgroundShellUpdate(BackgroundShellEvent{
 		Type:       "completed",
 		ID:         "1000",
 		State:      "completed",
 		NoticeText: "Background shell 1000 completed.\nExit code: 0\nOutput:\ndone",
-	})
+	}, true)
 
 	close(release)
 	result := <-submitDone
@@ -743,12 +743,12 @@ func TestBackgroundShellNoticeSameTurnNoopAddsNoAssistantMessage(t *testing.T) {
 		t.Fatal("timed out waiting for tool call to start")
 	}
 
-	eng.HandleBackgroundShellEvent(BackgroundShellEvent{
+	eng.HandleBackgroundShellUpdate(BackgroundShellEvent{
 		Type:       "completed",
 		ID:         "1000",
 		State:      "completed",
 		NoticeText: "Background shell 1000 completed.\nExit code: 0\nOutput:\ndone",
-	})
+	}, true)
 
 	close(release)
 	result := <-submitDone

--- a/server/runtime/engine_part8_test.go
+++ b/server/runtime/engine_part8_test.go
@@ -56,18 +56,18 @@ func TestMultipleBackgroundShellNoticesFlushTogetherOnFirstAvailableSlot(t *test
 		t.Fatal("timed out waiting for tool call to start")
 	}
 
-	eng.HandleBackgroundShellEvent(BackgroundShellEvent{
+	eng.HandleBackgroundShellUpdate(BackgroundShellEvent{
 		Type:       "completed",
 		ID:         "1000",
 		State:      "completed",
 		NoticeText: "Background shell 1000 completed.\nExit code: 0\nOutput:\ndone-a",
-	})
-	eng.HandleBackgroundShellEvent(BackgroundShellEvent{
+	}, true)
+	eng.HandleBackgroundShellUpdate(BackgroundShellEvent{
 		Type:       "completed",
 		ID:         "1001",
 		State:      "completed",
 		NoticeText: "Background shell 1001 completed.\nExit code: 0\nOutput:\ndone-b",
-	})
+	}, true)
 
 	close(release)
 	result := <-submitDone

--- a/server/runtime/engine_part8_test.go
+++ b/server/runtime/engine_part8_test.go
@@ -185,7 +185,7 @@ func TestWriteStdinCompletionDoesNotQueueDuplicateBackgroundNotice(t *testing.T)
 	if callCount != 3 {
 		t.Fatalf("model call count = %d, want 3", callCount)
 	}
-	for _, msg := range eng.snapshotMessages() {
+	for _, msg := range eng.transcriptRuntimeState().SnapshotMessages() {
 		if msg.Role == llm.RoleDeveloper && msg.MessageType == llm.MessageTypeBackgroundNotice {
 			t.Fatalf("did not expect background notice after write_stdin harvested completion: %+v", msg)
 		}
@@ -301,7 +301,7 @@ func TestNewNormalizesPersistedInFlightStepOnReopen(t *testing.T) {
 	if reopenedStore.Meta().InFlightStep {
 		t.Fatal("expected reopen path to clear persisted in-flight flag")
 	}
-	messages := restored.snapshotMessages()
+	messages := restored.transcriptRuntimeState().SnapshotMessages()
 	if len(messages) != 2 {
 		t.Fatalf("expected original user message plus interruption marker, got %+v", messages)
 	}
@@ -446,7 +446,7 @@ func TestSubmitUserShellCommandPersistsDeveloperNoticeAndToolEntries(t *testing.
 		t.Fatalf("unexpected tool result name: %+v", result)
 	}
 
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	if len(messages) == 0 {
 		t.Fatal("expected persisted messages")
 	}
@@ -516,7 +516,7 @@ func TestSubmitUserShellCommandReturnsUnknownToolErrorWhenShellNotRegistered(t *
 		t.Fatalf("expected unknown tool output payload, got %v", payload)
 	}
 
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	foundToolOutput := false
 	for _, msg := range messages {
 		if msg.Role != llm.RoleTool {

--- a/server/runtime/engine_part9_test.go
+++ b/server/runtime/engine_part9_test.go
@@ -61,7 +61,7 @@ func TestCriticalExactRecountsAfterToolCompletionBeforeToolMessageAppend(t *test
 	}}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 400_000})
 	call := llm.ToolCall{ID: "call-1", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{"command":"pwd"}`)}
-	if err := eng.steer("step", steerMessageWithoutDerivedEventIntent(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{call}})); err != nil {
+	if err := eng.steer("step", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventNone, true, []llm.Message{{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{call}}})); err != nil {
 		t.Fatalf("append assistant tool call: %v", err)
 	}
 	if precise, ok := eng.currentInputTokensPrecisely(context.Background()); !ok || precise != 100 {
@@ -91,7 +91,7 @@ func TestCriticalExactRecountsAfterToolCompletionBeforeToolMessageAppend(t *test
 	if !foundOutput {
 		t.Fatalf("expected synthesized function_call_output before tool message append, items=%+v", req.Items)
 	}
-	if precise, ok := eng.currentInputTokensPreciselyIfCritical(context.Background(), 1_000); !ok || precise != 200 {
+	if precise, ok := eng.currentInputTokensPreciselyIfDueWithPriority(context.Background(), 1_000, true); !ok || precise != 200 {
 		t.Fatalf("critical exact recount = (%d, %v), want (200, true)", precise, ok)
 	}
 	if client.countInputTokenCalls != 2 {
@@ -283,7 +283,7 @@ func TestRestoreMessagesPreservesRecoveredMultiToolProviderOrder(t *testing.T) {
 		t.Fatalf("append second tool completion: %v", err)
 	}
 	restored := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	items := restored.snapshotItems()
+	items := restored.transcriptRuntimeState().SnapshotItems()
 	if len(items) != 4 {
 		t.Fatalf("expected 4 restored items, got %d (%+v)", len(items), items)
 	}
@@ -323,7 +323,7 @@ func TestRestoreMessagesPreservesRecoveredMultiToolExactTokenParity(t *testing.T
 	live := mustNewTestEngine(t, liveStore, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 400_000})
 	call1 := llm.ToolCall{ID: "call-1", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{"command":"pwd"}`)}
 	call2 := llm.ToolCall{ID: "call-2", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{"command":"ls"}`)}
-	if err := live.steer("step", steerMessageWithoutDerivedEventIntent(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{call1, call2}})); err != nil {
+	if err := live.steer("step", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventNone, true, []llm.Message{{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{call1, call2}}})); err != nil {
 		t.Fatalf("append live assistant tool calls: %v", err)
 	}
 	if _, err := live.executeToolCalls(context.Background(), "step", []llm.ToolCall{call1, call2}); err != nil {
@@ -333,7 +333,7 @@ func TestRestoreMessagesPreservesRecoveredMultiToolExactTokenParity(t *testing.T
 	if err != nil {
 		t.Fatalf("build live request: %v", err)
 	}
-	liveCount, ok := live.requestInputTokensPrecisely(context.Background(), liveReq)
+	liveCount, ok := live.requestInputTokensPreciselyTracked(context.Background(), liveReq, false)
 	if !ok {
 		t.Fatal("expected live precise token count")
 	}
@@ -351,7 +351,7 @@ func TestRestoreMessagesPreservesRecoveredMultiToolExactTokenParity(t *testing.T
 	if err != nil {
 		t.Fatalf("build restored request: %v", err)
 	}
-	restoredCount, ok := restored.requestInputTokensPrecisely(context.Background(), restoredReq)
+	restoredCount, ok := restored.requestInputTokensPreciselyTracked(context.Background(), restoredReq, false)
 	if !ok {
 		t.Fatal("expected restored precise token count")
 	}

--- a/server/runtime/engine_queue_submission_test.go
+++ b/server/runtime/engine_queue_submission_test.go
@@ -62,11 +62,11 @@ func TestQueuedUserMessagesCoalesceFromStoredSteeringIntents(t *testing.T) {
 	pending := []queuedUserSteeringIntent{
 		{
 			message: QueuedUserMessage{ID: "queue-1", Text: "stale metadata"},
-			intent:  steerUserMessageWithoutDerivedEventIntent(llm.Message{Role: llm.RoleUser, Content: "intent text"}),
+			intent:  steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventNone, true, []llm.Message{{Role: llm.RoleUser, Content: "intent text"}}),
 		},
 		{
 			message: QueuedUserMessage{ID: "queue-2"},
-			intent:  steerUserMessageWithoutDerivedEventIntent(llm.Message{Role: llm.RoleUser, Content: "second intent"}),
+			intent:  steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventNone, true, []llm.Message{{Role: llm.RoleUser, Content: "second intent"}}),
 		},
 	}
 

--- a/server/runtime/engine_request.go
+++ b/server/runtime/engine_request.go
@@ -20,7 +20,7 @@ type requestBuildPlan struct {
 }
 
 func (e *Engine) buildRequest(ctx context.Context, stepID string, allowTools bool) (llm.Request, error) {
-	plan, err := e.buildRequestPlan(ctx, stepID, allowTools)
+	plan, err := e.buildRequestPlanWithExtraItems(ctx, stepID, nil, allowTools)
 	if err != nil {
 		return llm.Request{}, err
 	}
@@ -33,10 +33,6 @@ func (e *Engine) buildRequestWithExtraItems(ctx context.Context, stepID string, 
 		return llm.Request{}, err
 	}
 	return plan.Request, nil
-}
-
-func (e *Engine) buildRequestPlan(ctx context.Context, stepID string, allowTools bool) (requestBuildPlan, error) {
-	return e.buildRequestPlanWithExtraItems(ctx, stepID, nil, allowTools)
 }
 
 func (e *Engine) buildRequestPlanWithExtraItems(ctx context.Context, stepID string, extra []llm.ResponseItem, allowTools bool) (requestBuildPlan, error) {
@@ -60,7 +56,7 @@ func (e *Engine) buildRequestPlanWithExtraItems(ctx context.Context, stepID stri
 		requestTools = []llm.Tool{}
 	}
 
-	items := e.snapshotItems()
+	items := e.transcriptRuntimeState().SnapshotItems()
 	if len(extra) > 0 {
 		items = append(items, llm.CloneResponseItems(extra)...)
 	}
@@ -74,9 +70,9 @@ func (e *Engine) buildRequestPlanWithExtraItems(ctx context.Context, stepID stri
 	}
 	req.ReasoningEffort = e.ThinkingLevel()
 	req.FastMode = e.FastModeEnabled()
-	req.SessionID = e.conversationSessionID()
+	req.SessionID = e.SessionID()
 	if e.supportsPromptCacheKey(ctx) {
-		if cacheKey := e.conversationPromptCacheKey(); cacheKey != "" {
+		if cacheKey := conversationPromptCacheKey(e.SessionID(), e.compactionRuntimeState().Count()); cacheKey != "" {
 			req.PromptCacheKey = cacheKey
 			req.PromptCacheScope = transcript.CacheWarningScopeConversation
 		}
@@ -159,7 +155,7 @@ func (e *Engine) systemPrompt(locked session.LockedContract) (string, error) {
 	if prompt := strings.TrimSpace(locked.SystemPrompt); prompt != "" {
 		return prompt, nil
 	}
-	prompt, err := e.buildSystemPromptSnapshot(locked)
+	prompt, err := e.buildSystemPromptSnapshotForRoot(locked, e.systemPromptWorkspaceRoot())
 	if err != nil {
 		return "", err
 	}

--- a/server/runtime/engine_state.go
+++ b/server/runtime/engine_state.go
@@ -14,14 +14,6 @@ import (
 	"core/shared/transcript"
 )
 
-func (e *Engine) snapshotMessages() []llm.Message {
-	return e.transcriptRuntimeState().SnapshotMessages()
-}
-
-func (e *Engine) snapshotItems() []llm.ResponseItem {
-	return e.transcriptRuntimeState().SnapshotItems()
-}
-
 func (e *Engine) ChatSnapshot() ChatSnapshot {
 	return e.transcriptRuntimeState().Snapshot()
 }
@@ -81,9 +73,9 @@ func messagePreservesLastCommittedAssistantFinalAnswer(message llm.Message) bool
 }
 
 func (e *Engine) ContextUsage() ContextUsage {
-	window := e.contextWindowTokens()
+	window := e.compactionPlannerState().contextWindowTokens(e.compactionPlanningSnapshot())
 	used := e.currentTokenUsage()
-	cacheHitPercent, hasCacheHitPercentage := e.cacheHitSnapshot()
+	cacheHitPercent, hasCacheHitPercentage := e.usageTrackingState().CacheHitSnapshot()
 	if used < 0 {
 		used = 0
 	}
@@ -136,13 +128,13 @@ func (e *Engine) appendCommittedEntry(entry storedLocalEntry) error {
 }
 
 func (e *Engine) SetOngoingError(text string) {
-	e.transcriptPersistence().SetOngoingError(text)
-	_ = e.steerEvent("", Event{Kind: EventOngoingErrorUpdated})
+	newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).SetOngoingError(text)
+	_ = e.steer("", steerEventIntent(Event{Kind: EventOngoingErrorUpdated}))
 }
 
 func (e *Engine) ClearOngoingError() {
-	e.transcriptPersistence().ClearOngoingError()
-	_ = e.steerEvent("", Event{Kind: EventOngoingErrorUpdated})
+	newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).ClearOngoingError()
+	_ = e.steer("", steerEventIntent(Event{Kind: EventOngoingErrorUpdated}))
 }
 
 func (e *Engine) SetSessionName(name string) error {
@@ -489,15 +481,7 @@ func (e *Engine) CompactionMode() string {
 func (e *Engine) initReviewerClient() error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	return e.initReviewerClientLocked()
-}
-
-func (e *Engine) initReviewerClientLocked() error {
 	return e.reviewerRuntimeStateLocked().EnsureClient(e.cfg.Reviewer.ClientFactory)
-}
-
-func (e *Engine) reviewerClientSnapshot() llm.Client {
-	return e.reviewerRuntimeState().Client()
 }
 
 func (e *Engine) reviewerTurnConfigSnapshot() (string, llm.Client) {
@@ -529,15 +513,6 @@ func (e *Engine) SessionID() string {
 	return strings.TrimSpace(e.store.Meta().SessionID)
 }
 
-func (e *Engine) compactionCountSnapshot() int {
-	return e.compactionRuntimeState().Count()
-}
-
-func (e *Engine) conversationSessionID() string {
-	return e.SessionID()
-
-}
-
 func conversationPromptCacheKey(sessionID string, compactionCount int) string {
 	trimmed := strings.TrimSpace(sessionID)
 	if trimmed == "" {
@@ -547,10 +522,6 @@ func conversationPromptCacheKey(sessionID string, compactionCount int) string {
 		return trimmed
 	}
 	return fmt.Sprintf("%s/compact-%d", trimmed, compactionCount)
-}
-
-func (e *Engine) conversationPromptCacheKey() string {
-	return conversationPromptCacheKey(e.conversationSessionID(), e.compactionCountSnapshot())
 }
 
 func (e *Engine) ParentSessionID() string {
@@ -618,16 +589,12 @@ func toToolNames(ids []toolspec.ID) []string {
 	return out
 }
 
-func (e *Engine) lastUsageSnapshot() llm.Usage {
-	return e.usageTrackingState().Last()
-}
-
 func (e *Engine) setLastUsage(usage llm.Usage) {
 	baselineEstimate := 0
 	if e != nil {
 		baselineEstimate = e.transcriptRuntimeState().EstimatedProviderTokens()
 	}
-	normalizedUsage, totalInputTokens, totalCachedInputTokens := e.nextUsageTrackingState(usage)
+	normalizedUsage, totalInputTokens, totalCachedInputTokens := e.usageTrackingState().Next(usage)
 	e.applyUsageTrackingState(normalizedUsage, baselineEstimate, totalInputTokens, totalCachedInputTokens)
 }
 
@@ -636,7 +603,7 @@ func (e *Engine) recordLastUsage(usage llm.Usage) error {
 	if e != nil {
 		baselineEstimate = e.transcriptRuntimeState().EstimatedProviderTokens()
 	}
-	normalizedUsage, totalInputTokens, totalCachedInputTokens := e.nextUsageTrackingState(usage)
+	normalizedUsage, totalInputTokens, totalCachedInputTokens := e.usageTrackingState().Next(usage)
 	if e != nil && e.store != nil {
 		if err := e.store.SetUsageState(&session.UsageState{
 			InputTokens:             normalizedUsage.InputTokens,
@@ -674,10 +641,6 @@ func (e *Engine) restorePersistedUsageState(state *session.UsageState) {
 	)
 }
 
-func (e *Engine) nextUsageTrackingState(usage llm.Usage) (llm.Usage, int, int) {
-	return e.usageTrackingState().Next(usage)
-}
-
 func (e *Engine) applyUsageTrackingState(usage llm.Usage, baselineEstimate, totalInputTokens, totalCachedInputTokens int) {
 	if baselineEstimate < 0 {
 		baselineEstimate = 0
@@ -686,10 +649,6 @@ func (e *Engine) applyUsageTrackingState(usage llm.Usage, baselineEstimate, tota
 	if e.modelRequests().TokenUsage() != nil {
 		e.modelRequests().TokenUsage().storeUsageBaseline(usage.InputTokens, baselineEstimate)
 	}
-}
-
-func (e *Engine) cacheHitSnapshot() (int, bool) {
-	return e.usageTrackingState().CacheHitSnapshot()
 }
 
 func (e *Engine) usageTrackingState() *usageTrackingState {
@@ -721,10 +680,6 @@ func (e *Engine) transcriptRuntimeState() *transcriptRuntimeState {
 		e.transcriptState = newTranscriptRuntimeState(transcriptWorkingDir(e.cfg.TranscriptWorkingDir, e.store.Meta().WorkspaceRoot))
 	}
 	return e.transcriptState
-}
-
-func (e *Engine) transcriptPersistence() transcriptPersistenceCoordinator {
-	return newTranscriptPersistenceCoordinator(e.transcriptRuntimeState())
 }
 
 func (e *Engine) lockedContractState() *lockedContractState {
@@ -818,20 +773,12 @@ func (e *Engine) pendingToolCallStartStore() *pendingToolCallStartStore {
 	return e.toolCallStarts
 }
 
-func (e *Engine) nextCompactionCount() int {
-	return e.compactionRuntimeState().IncrementCount()
-}
-
 // LastCompactionWorkflowRunID reports the workflow run that committed the most
 // recent history replacement in this session, reconstructed from the
 // history_replaced event on restore. Empty when no compaction has run under a
 // workflow run. Workflow continuation gating reads this to compact exactly once.
 func (e *Engine) LastCompactionWorkflowRunID() string {
 	return e.compactionRuntimeState().LastWorkflowRunID()
-}
-
-func (e *Engine) setLastCompactionWorkflowRunID(runID string) {
-	e.compactionRuntimeState().SetLastWorkflowRunID(runID)
 }
 
 func (e *Engine) compactionRuntimeState() *compactionRuntimeState {

--- a/server/runtime/engine_test.go
+++ b/server/runtime/engine_test.go
@@ -375,10 +375,10 @@ func TestLastCommittedAssistantFinalAnswerSkipsTrailingReminderEntries(t *testin
 	store := mustCreateTestSession(t)
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "final handoff"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "final handoff"}})); err != nil {
 		t.Fatalf("append assistant final: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSoonReminder, Content: "heads up"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeCompactionSoonReminder, Content: "heads up"}})); err != nil {
 		t.Fatalf("append reminder: %v", err)
 	}
 
@@ -391,10 +391,10 @@ func TestLastCommittedAssistantFinalAnswerSkipsTrailingErrorFeedback(t *testing.
 	store := mustCreateTestSession(t)
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "final handoff"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "final handoff"}})); err != nil {
 		t.Fatalf("append assistant final: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: "phase mismatch"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: "phase mismatch"}})); err != nil {
 		t.Fatalf("append warning: %v", err)
 	}
 
@@ -407,10 +407,10 @@ func TestLastCommittedAssistantFinalAnswerSkipsTrailingHandoffFutureMessage(t *t
 	store := mustCreateTestSession(t)
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "final handoff"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "final handoff"}})); err != nil {
 		t.Fatalf("append assistant final: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeHandoffFutureMessage, Content: "resume with tests"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeHandoffFutureMessage, Content: "resume with tests"}})); err != nil {
 		t.Fatalf("append handoff future message: %v", err)
 	}
 
@@ -423,10 +423,10 @@ func TestLastCommittedAssistantFinalAnswerSkipsTrailingReviewerFeedback(t *testi
 	store := mustCreateTestSession(t)
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "final handoff"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "final handoff"}})); err != nil {
 		t.Fatalf("append assistant final: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeReviewerFeedback, Content: "reviewer suggestions"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeReviewerFeedback, Content: "reviewer suggestions"}})); err != nil {
 		t.Fatalf("append reviewer feedback: %v", err)
 	}
 
@@ -439,10 +439,10 @@ func TestLastCommittedAssistantFinalAnswerSkipsTrailingGoalFeedback(t *testing.T
 	store := mustCreateTestSession(t)
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "final handoff"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "final handoff"}})); err != nil {
 		t.Fatalf("append assistant final: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(eng.goalDeveloperMessage(prompts.RenderGoalSetPrompt("ship goal mode"), "Goal set: \"ship goal mode\""))); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{normalizeMessageForTranscript(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeGoal, Content: prompts.RenderGoalSetPrompt("ship goal mode"), CompactContent: "Goal set: \"ship goal mode\""}, eng.transcriptWorkingDir())})); err != nil {
 		t.Fatalf("append goal feedback: %v", err)
 	}
 
@@ -455,10 +455,10 @@ func TestLastCommittedAssistantFinalAnswerDoesNotSkipTrailingUntypedDeveloperMes
 	store := mustCreateTestSession(t)
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "final handoff"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "final handoff"}})); err != nil {
 		t.Fatalf("append assistant final: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, Content: "User ran shell command directly:\npwd"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, Content: "User ran shell command directly:\npwd"}})); err != nil {
 		t.Fatalf("append developer message: %v", err)
 	}
 

--- a/server/runtime/exclusive_step.go
+++ b/server/runtime/exclusive_step.go
@@ -61,12 +61,13 @@ func (s *defaultExclusiveStepLifecycle) Run(ctx context.Context, options exclusi
 			if snapshot.GoalLoop {
 				mode = RunModeGoalLoop
 			}
-			_ = s.engine.steerEvent(stepID, Event{Kind: EventRunStateChanged, StepID: stepID, RunState: &RunState{
+			_ = s.engine.steer(stepID, steerEventIntent(Event{Kind: EventRunStateChanged, StepID: stepID, RunState: &RunState{
 				Lifecycle: RunningRunLifecycle(mode),
 				RunID:     snapshot.RunID,
 				Status:    snapshot.Status,
 				StartedAt: snapshot.StartedAt,
-			}})
+			}}))
+
 		}
 	}
 	defer func() {
@@ -91,7 +92,7 @@ func (s *defaultExclusiveStepLifecycle) Run(ctx context.Context, options exclusi
 				state.StartedAt = snapshot.StartedAt
 				state.FinishedAt = snapshot.FinishedAt
 			}
-			_ = s.engine.steerEvent(stepID, Event{Kind: EventRunStateChanged, StepID: stepID, RunState: state})
+			_ = s.engine.steer(stepID, steerEventIntent(Event{Kind: EventRunStateChanged, StepID: stepID, RunState: state}))
 		}
 		if options.PersistRunLifecycle && snapshot != nil {
 			if _, persistErr := s.engine.store.AppendRunFinished(session.RunRecord{
@@ -106,7 +107,7 @@ func (s *defaultExclusiveStepLifecycle) Run(ctx context.Context, options exclusi
 		}
 		if clearErr := s.engine.store.MarkInFlight(false); clearErr != nil {
 			wrapped := fmt.Errorf("%w: %w", errMarkInFlightFalse, clearErr)
-			_ = s.engine.steerEvent(stepID, Event{Kind: EventInFlightClearFailed, StepID: stepID, Error: wrapped.Error()})
+			_ = s.engine.steer(stepID, steerEventIntent(Event{Kind: EventInFlightClearFailed, StepID: stepID, Error: wrapped.Error()}))
 			err = errors.Join(err, wrapped)
 		} else {
 			if s.background != nil {
@@ -135,7 +136,7 @@ func (s *defaultExclusiveStepLifecycle) Interrupt() error {
 		return nil
 	}
 	s.mu.Unlock()
-	if err := s.engine.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeInterruption, Content: interruptMessage})); err != nil {
+	if err := s.engine.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeInterruption, Content: interruptMessage}})); err != nil {
 		return err
 	}
 	if err := s.engine.store.MarkInFlight(false); err != nil {

--- a/server/runtime/exclusive_step_test.go
+++ b/server/runtime/exclusive_step_test.go
@@ -349,7 +349,7 @@ func TestExclusiveStepLifecycleInterruptAppendsMessageAndClearsInFlight(t *testi
 		t.Fatal("expected in-flight step to remain cleared after interrupted run exits")
 	}
 
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	if len(messages) == 0 {
 		t.Fatal("expected interruption message")
 	}
@@ -421,8 +421,8 @@ func TestExclusiveStepLifecycleInterruptSkipsStaleRunCleanup(t *testing.T) {
 	if !store.Meta().InFlightStep {
 		t.Fatal("expected stale interrupt to leave new run in-flight marker intact")
 	}
-	if len(eng.snapshotMessages()) != 0 {
-		t.Fatalf("expected stale interrupt to avoid appending interruption message, got %+v", eng.snapshotMessages())
+	if len(eng.transcriptRuntimeState().SnapshotMessages()) != 0 {
+		t.Fatalf("expected stale interrupt to avoid appending interruption message, got %+v", eng.transcriptRuntimeState().SnapshotMessages())
 	}
 }
 
@@ -533,7 +533,7 @@ func TestContextCompactorUsesExclusiveStepLifecycle(t *testing.T) {
 		Usage:     llm.Usage{WindowTokens: 200000},
 	}}}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 

--- a/server/runtime/goal.go
+++ b/server/runtime/goal.go
@@ -38,14 +38,14 @@ func (e *Engine) SetGoal(objective string, actor session.GoalActor) (session.Goa
 	if e == nil || e.store == nil {
 		return session.GoalState{}, fmt.Errorf("runtime engine is required")
 	}
-	msg := e.goalDeveloperMessage(prompts.RenderGoalSetPrompt(strings.TrimSpace(objective)), goalSetCompactText(objective))
+	msg := normalizeMessageForTranscript(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeGoal, Content: prompts.RenderGoalSetPrompt(strings.TrimSpace(objective)), CompactContent: goalSetCompactText(objective)}, e.transcriptWorkingDir())
 	e.controlMutationMu.Lock()
 	defer e.controlMutationMu.Unlock()
 	goal, err := e.store.SetGoalWithEvents(objective, actor, []session.EventInput{{Kind: "message", Payload: msg}})
 	if err != nil {
 		return session.GoalState{}, err
 	}
-	if err := e.steer("", steerStoredMessageProjectionIntent(msg), steerGoalStatusUpdateIntent(goalStatusUpdateFromState(goal))); err != nil {
+	if err := e.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, false, []llm.Message{msg}), steerGoalStatusUpdateIntent(goalStatusUpdateFromState(goal))); err != nil {
 		return session.GoalState{}, err
 	}
 	return goal, nil
@@ -71,7 +71,7 @@ func (e *Engine) SetGoalStatus(status session.GoalStatus, actor session.GoalActo
 	if err != nil {
 		return session.GoalState{}, err
 	}
-	if err := e.steer("", steerStoredMessageProjectionIntent(msg), steerGoalStatusUpdateIntent(goalStatusUpdateFromState(goal))); err != nil {
+	if err := e.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, false, []llm.Message{msg}), steerGoalStatusUpdateIntent(goalStatusUpdateFromState(goal))); err != nil {
 		return session.GoalState{}, err
 	}
 	return goal, nil
@@ -81,14 +81,14 @@ func (e *Engine) ClearGoal(actor session.GoalActor) (session.GoalState, error) {
 	if e == nil || e.store == nil {
 		return session.GoalState{}, fmt.Errorf("runtime engine is required")
 	}
-	msg := e.goalDeveloperMessage(prompts.GoalClearPrompt, "Goal cleared")
+	msg := normalizeMessageForTranscript(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeGoal, Content: prompts.GoalClearPrompt, CompactContent: "Goal cleared"}, e.transcriptWorkingDir())
 	e.controlMutationMu.Lock()
 	defer e.controlMutationMu.Unlock()
 	goal, err := e.store.ClearGoalWithEvents(actor, []session.EventInput{{Kind: "message", Payload: msg}})
 	if err != nil {
 		return session.GoalState{}, err
 	}
-	if err := e.steer("", steerStoredMessageProjectionIntent(msg), steerGoalStatusUpdateIntent(goalStatusClearUpdate())); err != nil {
+	if err := e.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, false, []llm.Message{msg}), steerGoalStatusUpdateIntent(goalStatusClearUpdate())); err != nil {
 		return session.GoalState{}, err
 	}
 	return goal, nil
@@ -179,7 +179,7 @@ func (e *Engine) runGoalTurn(ctx context.Context, appendNudge bool) (assistant l
 			return errGoalLoopInactive
 		}
 		if appendNudge {
-			if err := e.steer(stepID, steerMessageIntent(e.goalDeveloperMessage(prompts.RenderGoalNudgePrompt(goal.Objective, string(goal.Status)), goalNudgeCompactText(*goal)))); err != nil {
+			if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{normalizeMessageForTranscript(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeGoal, Content: prompts.RenderGoalNudgePrompt(goal.Objective, string(goal.Status)), CompactContent: goalNudgeCompactText(*goal)}, e.transcriptWorkingDir())})); err != nil {
 				return err
 			}
 		}
@@ -245,15 +245,6 @@ func (e *Engine) goalLoopState() *goalLoopState {
 		e.goalLoop = newGoalLoopState()
 	}
 	return e.goalLoop
-}
-
-func (e *Engine) goalDeveloperMessage(content string, compact string) llm.Message {
-	return normalizeMessageForTranscript(llm.Message{
-		Role:           llm.RoleDeveloper,
-		MessageType:    llm.MessageTypeGoal,
-		Content:        content,
-		CompactContent: compact,
-	}, e.transcriptWorkingDir())
 }
 
 func (e *Engine) requireAskQuestionForActiveGoal() error {

--- a/server/runtime/message_lifecycle.go
+++ b/server/runtime/message_lifecycle.go
@@ -37,13 +37,13 @@ func (m *defaultMessageLifecycle) RestoreMessages() error {
 			if err := json.Unmarshal(evt.Payload, &msg); err != nil {
 				return fmt.Errorf("decode message event: %w", err)
 			}
-			e.transcriptPersistence().AppendMessage(msg)
+			newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).AppendMessage(msg)
 			recoveredHandoff.ApplyMessage(msg)
 			if isCompactionSoonReminderMessage(msg) {
 				reminderIssued = true
 			}
 		case "tool_completed":
-			if err := e.transcriptPersistence().RestoreToolCompletionPayload(evt.Payload); err != nil {
+			if err := newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).RestoreToolCompletionPayload(evt.Payload); err != nil {
 				return err
 			}
 			if err := recoveredHandoff.ApplyToolCompletion(evt.Payload); err != nil {
@@ -54,10 +54,10 @@ func (m *defaultMessageLifecycle) RestoreMessages() error {
 			if err := json.Unmarshal(evt.Payload, &entry); err != nil {
 				return fmt.Errorf("decode local_entry event: %w", err)
 			}
-			e.restoreLocalDiagnostic(entry.DiagnosticKey)
-			e.transcriptPersistence().AppendLocalEntryRecord(*localEntryChatEntry(entry))
+			e.diagnosticDedupeStore().RestoreLocal(entry.DiagnosticKey)
+			newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).AppendLocalEntryRecord(*localEntryChatEntry(entry))
 		case sessionEventCacheWarning:
-			if err := applyPersistedCacheWarningToTranscript(e.transcriptPersistence(), evt.Payload, e.cfg.CacheWarningMode); err != nil {
+			if err := applyPersistedCacheWarningToTranscript(newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()), evt.Payload, e.cfg.CacheWarningMode); err != nil {
 				return err
 			}
 		case sessionEventCacheRequestObserved:
@@ -77,9 +77,9 @@ func (m *defaultMessageLifecycle) RestoreMessages() error {
 				return nil
 			}
 			e.resetLocalDiagnostics()
-			e.transcriptPersistence().ReplaceHistory(payload.Items)
-			e.nextCompactionCount()
-			e.setLastCompactionWorkflowRunID(payload.WorkflowRunID)
+			newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).ReplaceHistory(payload.Items)
+			e.compactionRuntimeState().IncrementCount()
+			e.compactionRuntimeState().SetLastWorkflowRunID(payload.WorkflowRunID)
 			recoveredHandoff.ClearSatisfiedByCompaction()
 			reminderIssued = false
 		}
@@ -87,7 +87,7 @@ func (m *defaultMessageLifecycle) RestoreMessages() error {
 	}); err != nil {
 		return err
 	}
-	e.setCompactionSoonReminderIssued(reminderIssued)
+	e.compactionRuntimeState().SetSoonReminderIssued(reminderIssued)
 	if err := e.store.SetCompactionSoonReminderIssued(reminderIssued); err != nil {
 		return err
 	}
@@ -96,12 +96,12 @@ func (m *defaultMessageLifecycle) RestoreMessages() error {
 	// history_replaced payload). Any restored history therefore already carries
 	// it, so a non-empty restore means injection has happened. This is a
 	// deterministic length check, never a scan of which messages are present.
-	e.baseMetaInjected = len(e.snapshotMessages()) > 0
+	e.baseMetaInjected = len(e.transcriptRuntimeState().SnapshotMessages()) > 0
 	if futureMessage := recoveredHandoff.PendingFutureMessage(); futureMessage != "" {
-		e.queuePendingHandoffFutureMessage(futureMessage)
+		e.handoffRuntimeState().QueueFutureMessage(futureMessage)
 	}
 	if req, ok := recoveredHandoff.PendingRequest(); ok {
-		e.queueHandoffRequest(req.summarizerPrompt, req.futureAgentMessage)
+		e.handoffRuntimeState().QueueRequest(req.summarizerPrompt, req.futureAgentMessage)
 	}
 	return nil
 }

--- a/server/runtime/meta_context.go
+++ b/server/runtime/meta_context.go
@@ -88,10 +88,6 @@ func (r metaContextBuildResult) OrderedBaseMessages() []llm.Message {
 	return out
 }
 
-func (r metaContextBuildResult) OrderedInjectionMessages() []llm.Message {
-	return r.OrderedBaseMessages()
-}
-
 type metaContextBuilder struct {
 	workspaceRoot    string
 	environmentCWD   string
@@ -113,11 +109,6 @@ func newMetaContextBuilder(workspaceRoot, model, thinkingLevel string, disabledS
 		disabledSkills: normalizedDisabledSkills(disabledSkills),
 		now:            now,
 	}
-}
-
-func (e *Engine) newActiveBaseMetaContextBuilder(model string, now time.Time) metaContextBuilder {
-	return newActiveMetaContextBuilder(e.store.Meta(), model, e.ThinkingLevel(), e.cfg.DisabledSkills, now).
-		withSubagents(e.cfg.SubagentCatalogSettings, e.cfg.EnabledTools)
 }
 
 func baseMetaContextBuildOptions(includeSkillWarnings bool) metaContextBuildOptions {

--- a/server/runtime/meta_context_runtime.go
+++ b/server/runtime/meta_context_runtime.go
@@ -41,7 +41,7 @@ func (e *Engine) steerBaseMetaContextIfNeeded(stepID string) error {
 	if e.baseMetaInjected {
 		return nil
 	}
-	builder := e.newActiveBaseMetaContextBuilder(e.cfg.Model, time.Now())
+	builder := newActiveMetaContextBuilder(e.store.Meta(), e.cfg.Model, e.ThinkingLevel(), e.cfg.DisabledSkills, time.Now()).withSubagents(e.cfg.SubagentCatalogSettings, e.cfg.EnabledTools)
 	metaResult, err := builder.Build(baseMetaContextBuildOptions(true))
 	if err != nil {
 		return err
@@ -54,7 +54,7 @@ func (e *Engine) steerBaseMetaContextIfNeeded(stepID string) error {
 			Text:       combined,
 		}))
 	}
-	intents = append(intents, steerRuntimeContextMessagesIntent(metaResult.OrderedInjectionMessages()))
+	intents = append(intents, steerMessagesWithPersistenceIntent(steeringPriorityRuntimeContext, steeringMessageEventDefault, true, metaResult.OrderedBaseMessages()))
 	if err := e.steer(stepID, intents...); err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func (e *Engine) steerHeadlessModeTransitionIfNeeded(stepID string) error {
 		if err != nil {
 			return err
 		}
-		if err := e.steer(stepID, steerRuntimeContextMessagesIntent(metaResult.Headless)); err != nil {
+		if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityRuntimeContext, steeringMessageEventDefault, true, metaResult.Headless)); err != nil {
 			return err
 		}
 		return e.store.SetHeadlessActive(true)
@@ -92,7 +92,7 @@ func (e *Engine) steerHeadlessModeTransitionIfNeeded(stepID string) error {
 	if err != nil {
 		return err
 	}
-	if err := e.steer(stepID, steerRuntimeContextMessagesIntent(metaResult.HeadlessExit)); err != nil {
+	if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityRuntimeContext, steeringMessageEventDefault, true, metaResult.HeadlessExit)); err != nil {
 		return err
 	}
 	return e.store.SetHeadlessActive(false)
@@ -103,7 +103,7 @@ func (e *Engine) steerWorkflowModeIfNeeded(ctx context.Context, stepID string) e
 		return nil
 	}
 	runID := strings.TrimSpace(string(e.cfg.WorkflowRun.Contract.RunID))
-	for _, msg := range e.snapshotMessages() {
+	for _, msg := range e.transcriptRuntimeState().SnapshotMessages() {
 		if msg.Role == llm.RoleDeveloper && msg.MessageType == llm.MessageTypeWorkflowMode && strings.TrimSpace(msg.SourcePath) == runID {
 			return nil
 		}
@@ -124,11 +124,11 @@ func (e *Engine) steerWorkflowModeIfNeeded(ctx context.Context, stepID string) e
 		return nil
 	}
 	message.SourcePath = runID
-	return e.steer(stepID, steerRuntimeContextMessagesIntent([]llm.Message{message}))
+	return e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityRuntimeContext, steeringMessageEventDefault, true, []llm.Message{message}))
 }
 
 func (e *Engine) compactionReinjectedMetaMessages(ctx context.Context) ([]llm.Message, error) {
-	builder := e.newActiveBaseMetaContextBuilder(e.currentModel(), time.Now())
+	builder := newActiveMetaContextBuilder(e.store.Meta(), e.currentModel(), e.ThinkingLevel(), e.cfg.DisabledSkills, time.Now()).withSubagents(e.cfg.SubagentCatalogSettings, e.cfg.EnabledTools)
 	opts := baseMetaContextBuildOptions(false)
 	if e.workflowRunActive() {
 		mode, err := e.workflowCompletionMode(ctx)

--- a/server/runtime/missing_tool_output_repair_test.go
+++ b/server/runtime/missing_tool_output_repair_test.go
@@ -96,11 +96,11 @@ func TestMissingToolOutputRepairAppendsSyntheticOutputAndRetries(t *testing.T) {
 	if !repairItemsContainOutput(client.calls[1].Items, "missing") {
 		t.Fatalf("retry request should include the synthetic output, got %+v", client.calls[1].Items)
 	}
-	if !repairItemsContainCall(eng.snapshotItems(), "missing") {
-		t.Fatalf("projection must keep the call (not remove it), got %+v", eng.snapshotItems())
+	if !repairItemsContainCall(eng.transcriptRuntimeState().SnapshotItems(), "missing") {
+		t.Fatalf("projection must keep the call (not remove it), got %+v", eng.transcriptRuntimeState().SnapshotItems())
 	}
-	if !repairItemsContainOutput(eng.snapshotItems(), "missing") {
-		t.Fatalf("projection must include the synthetic output, got %+v", eng.snapshotItems())
+	if !repairItemsContainOutput(eng.transcriptRuntimeState().SnapshotItems(), "missing") {
+		t.Fatalf("projection must include the synthetic output, got %+v", eng.transcriptRuntimeState().SnapshotItems())
 	}
 	if got := countPersistedLocalEntries(readRepairEvents(t, store)); got != 1 {
 		t.Fatalf("persisted operator warnings = %d, want 1", got)
@@ -219,7 +219,7 @@ func TestCompactionMissingToolOutputRepairAppendsAndRetries(t *testing.T) {
 		}},
 	}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(), Config{Model: "gpt-5"})
-	baseRequest := llm.CompactionRequest{Model: "gpt-5", SessionID: store.Meta().SessionID, InputItems: eng.snapshotItems()}
+	baseRequest := llm.CompactionRequest{Model: "gpt-5", SessionID: store.Meta().SessionID, InputItems: eng.transcriptRuntimeState().SnapshotItems()}
 
 	if _, _, _, err := eng.compactWithContextRepairRetry(context.Background(), "compact", client, baseRequest); err != nil {
 		t.Fatalf("compact with repair retry: %v", err)
@@ -251,7 +251,7 @@ func TestCompactionMissingToolOutputRepairRunsSinglePass(t *testing.T) {
 		},
 	}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(), Config{Model: "gpt-5"})
-	baseRequest := llm.CompactionRequest{Model: "gpt-5", SessionID: store.Meta().SessionID, InputItems: eng.snapshotItems()}
+	baseRequest := llm.CompactionRequest{Model: "gpt-5", SessionID: store.Meta().SessionID, InputItems: eng.transcriptRuntimeState().SnapshotItems()}
 
 	_, _, _, err := eng.compactWithContextRepairRetry(context.Background(), "compact", client, baseRequest)
 	if !llm.HasHTTPStatus(err, 400) {
@@ -280,23 +280,23 @@ func TestCompactionMissingOutputRepairDoesNotConsumeOverflowAttempt(t *testing.T
 		}},
 	}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", CompactionMode: "local"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
 		ID: "call-shell", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{"cmd":"go test ./..."}`),
-	}}})); err != nil {
+	}}}})); err != nil {
 		t.Fatalf("append shell call: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{
 		Role: llm.RoleTool, ToolCallID: "call-shell", Name: string(toolspec.ToolExecCommand),
 		Content: `{"output":"` + strings.Repeat("x", 120_000) + `"}`,
-	})); err != nil {
+	}})); err != nil {
 		t.Fatalf("append shell output: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
 		ID: "call-missing", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{}`),
-	}}})); err != nil {
+	}}}})); err != nil {
 		t.Fatalf("append dangling call: %v", err)
 	}
 
@@ -335,23 +335,23 @@ func TestCompactionMissingOutputAfterCollapsePanics(t *testing.T) {
 		},
 	}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5"})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
 		ID: "call-shell", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{"cmd":"go test ./..."}`),
-	}}})); err != nil {
+	}}}})); err != nil {
 		t.Fatalf("append shell call: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{
 		Role: llm.RoleTool, ToolCallID: "call-shell", Name: string(toolspec.ToolExecCommand),
 		Content: `{"output":"` + strings.Repeat("x", 120_000) + `"}`,
-	})); err != nil {
+	}})); err != nil {
 		t.Fatalf("append shell output: %v", err)
 	}
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{
 		ID: "call-missing", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{}`),
-	}}})); err != nil {
+	}}}})); err != nil {
 		t.Fatalf("append dangling call: %v", err)
 	}
-	baseRequest := llm.CompactionRequest{Model: "gpt-5", SessionID: store.Meta().SessionID, InputItems: eng.snapshotItems()}
+	baseRequest := llm.CompactionRequest{Model: "gpt-5", SessionID: store.Meta().SessionID, InputItems: eng.transcriptRuntimeState().SnapshotItems()}
 
 	defer func() {
 		if recover() == nil {

--- a/server/runtime/model_cancellation_test.go
+++ b/server/runtime/model_cancellation_test.go
@@ -28,7 +28,7 @@ func TestGenerateWithRetryPropagatesContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		_, err := eng.generateWithRetry(ctx, "step-1", llm.Request{Model: "gpt-5"}, nil, nil, nil)
+		_, err := eng.generateWithRetryClient(ctx, "step-1", eng.llm, llm.Request{Model: "gpt-5"}, nil, nil, nil)
 		done <- err
 	}()
 

--- a/server/runtime/output_steering.go
+++ b/server/runtime/output_steering.go
@@ -85,34 +85,6 @@ const (
 	steeringMessageEventNone
 )
 
-func steerMessageIntent(msg llm.Message) steeringIntent {
-	return steerMessagesIntent(steeringPriorityNormal, steeringMessageEventDefault, []llm.Message{msg})
-}
-
-func steerMessageWithoutDerivedEventIntent(msg llm.Message) steeringIntent {
-	return steerMessagesIntent(steeringPriorityNormal, steeringMessageEventNone, []llm.Message{msg})
-}
-
-func steerRuntimeContextMessagesIntent(messages []llm.Message) steeringIntent {
-	return steerMessagesIntent(steeringPriorityRuntimeContext, steeringMessageEventDefault, messages)
-}
-
-func steerUserMessageIntent(msg llm.Message) steeringIntent {
-	return steerMessagesIntent(steeringPriorityUser, steeringMessageEventDefault, []llm.Message{msg})
-}
-
-func steerUserMessageWithoutDerivedEventIntent(msg llm.Message) steeringIntent {
-	return steerMessagesIntent(steeringPriorityUser, steeringMessageEventNone, []llm.Message{msg})
-}
-
-func steerMessagesIntent(priority steeringPriority, eventPolicy steeringMessageEventPolicy, messages []llm.Message) steeringIntent {
-	return steerMessagesWithPersistenceIntent(priority, eventPolicy, true, messages)
-}
-
-func steerStoredMessageProjectionIntent(msg llm.Message) steeringIntent {
-	return steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, false, []llm.Message{msg})
-}
-
 func steerMessagesWithPersistenceIntent(priority steeringPriority, eventPolicy steeringMessageEventPolicy, persist bool, messages []llm.Message) steeringIntent {
 	items := make([]steeringItem, 0, len(messages))
 	for _, message := range messages {
@@ -231,10 +203,6 @@ func steerCacheObservationIntent(events []session.EventInput, warning transcript
 	}
 }
 
-func (e *Engine) steerEvent(stepID string, evt Event) error {
-	return e.steer(stepID, steerEventIntent(evt))
-}
-
 func (e *Engine) steer(stepID string, intents ...steeringIntent) error {
 	ordered := make([]steeringIntent, 0, len(intents))
 	for _, intent := range intents {
@@ -292,7 +260,7 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 	if item.cacheWarning != nil {
 		warning := item.cacheWarning.warning
 		visibility := transcript.NormalizeEntryVisibility(item.cacheWarning.visibility)
-		e.transcriptPersistence().AppendCommittedEntryWithVisibility(cacheWarningTranscriptRole, transcript.CacheWarningText(warning), visibility)
+		newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).AppendCommittedEntryWithVisibility(cacheWarningTranscriptRole, transcript.CacheWarningText(warning), visibility)
 		if item.cacheWarning.emit {
 			e.emitRaw(Event{Kind: EventCacheWarning, StepID: stepID, CacheWarning: copyCacheWarning(&warning), CacheWarningVisibility: visibility, CommittedTranscriptChanged: true})
 		}
@@ -310,7 +278,7 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 		}
 		warning := observation.warning
 		visibility := transcript.NormalizeEntryVisibility(observation.visibility)
-		e.transcriptPersistence().AppendCommittedEntryWithVisibility(cacheWarningTranscriptRole, transcript.CacheWarningText(warning), visibility)
+		newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).AppendCommittedEntryWithVisibility(cacheWarningTranscriptRole, transcript.CacheWarningText(warning), visibility)
 		if observation.emit {
 			e.emitRaw(Event{Kind: EventCacheWarning, StepID: stepID, CacheWarning: copyCacheWarning(&warning), CacheWarningVisibility: visibility, CommittedTranscriptChanged: true})
 		}
@@ -319,7 +287,7 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 	if item.streaming != nil {
 		if item.streaming.assistantDelta != nil {
 			delta := *item.streaming.assistantDelta
-			e.transcriptPersistence().AppendOngoingDelta(delta)
+			newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).AppendOngoingDelta(delta)
 			e.emitRaw(Event{Kind: EventAssistantDelta, StepID: stepID, AssistantDelta: delta})
 			return nil
 		}
@@ -351,11 +319,11 @@ func (e *Engine) replaceHistoryRaw(stepID string, replacement steeringHistoryRep
 	// The committed event is the single durable record of this compaction's
 	// provenance; mirror it into runtime state so an in-process gate sees it
 	// without re-reading the transcript, matching what restore reconstructs.
-	e.setLastCompactionWorkflowRunID(replacement.workflowRunID)
+	e.compactionRuntimeState().SetLastWorkflowRunID(replacement.workflowRunID)
 	e.resetCurrentPreciseInputTracking()
 	e.resetLocalDiagnostics()
-	e.transcriptPersistence().ReplaceHistory(preparedItems)
-	e.setCompactionSoonReminderIssued(false)
+	newTranscriptPersistenceCoordinator(e.transcriptRuntimeState()).ReplaceHistory(preparedItems)
+	e.compactionRuntimeState().SetSoonReminderIssued(false)
 	e.emitProjectedHistoryReplacementEntriesRaw(stepID, projectedStart, replacement.projectedEntries)
 	e.emitRaw(Event{Kind: EventConversationUpdated, StepID: stepID})
 	return errors.Join(

--- a/server/runtime/prompt_cache_continuity_test.go
+++ b/server/runtime/prompt_cache_continuity_test.go
@@ -271,10 +271,10 @@ func seedPromptCacheContinuityConversation(t *testing.T, engine *Engine) {
 	if err := engine.steerBaseMetaContextIfNeeded("seed-meta"); err != nil {
 		t.Fatalf("inject agents: %v", err)
 	}
-	if err := engine.steer("turn-1", steerUserMessageIntent(llm.Message{Role: llm.RoleUser, Content: "Need a prompt cache continuity test that survives a server restart."})); err != nil {
+	if err := engine.steer("turn-1", steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "Need a prompt cache continuity test that survives a server restart."}})); err != nil {
 		t.Fatalf("append first user message: %v", err)
 	}
-	if err := engine.steer("turn-1", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Phase: llm.MessagePhaseCommentary, Content: "I am reconstructing the live runtime state before comparing serialized OpenAI payloads."})); err != nil {
+	if err := engine.steer("turn-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Phase: llm.MessagePhaseCommentary, Content: "I am reconstructing the live runtime state before comparing serialized OpenAI payloads."}})); err != nil {
 		t.Fatalf("append assistant commentary: %v", err)
 	}
 	toolCall := llm.ToolCall{
@@ -285,7 +285,7 @@ func seedPromptCacheContinuityConversation(t *testing.T, engine *Engine) {
 			"workdir": ".",
 		}),
 	}
-	if err := engine.steer("turn-1", steerMessageWithoutDerivedEventIntent(llm.Message{Role: llm.RoleAssistant, Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{toolCall}})); err != nil {
+	if err := engine.steer("turn-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventNone, true, []llm.Message{{Role: llm.RoleAssistant, Phase: llm.MessagePhaseCommentary, ToolCalls: []llm.ToolCall{toolCall}}})); err != nil {
 		t.Fatalf("append tool call: %v", err)
 	}
 	toolResult := tools.Result{
@@ -299,10 +299,10 @@ func seedPromptCacheContinuityConversation(t *testing.T, engine *Engine) {
 	if err := engine.steer("turn-1", steerToolCompletionIntent(toolResult)); err != nil {
 		t.Fatalf("persist tool completion: %v", err)
 	}
-	if err := engine.steer("turn-1", steerMessageIntent(llm.Message{Role: llm.RoleTool, ToolCallID: toolResult.CallID, Name: string(toolResult.Name), Content: string(toolResult.Output)})); err != nil {
+	if err := engine.steer("turn-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleTool, ToolCallID: toolResult.CallID, Name: string(toolResult.Name), Content: string(toolResult.Output)}})); err != nil {
 		t.Fatalf("append tool result message: %v", err)
 	}
-	if err := engine.steer("turn-1", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, Content: "Keep the persisted transcript byte-stable across hydrate and restart before sending the next model request."})); err != nil {
+	if err := engine.steer("turn-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, Content: "Keep the persisted transcript byte-stable across hydrate and restart before sending the next model request."}})); err != nil {
 		t.Fatalf("append developer entry: %v", err)
 	}
 	if err := engine.steer("turn-1", steerLocalEntryIntent(storedLocalEntry{
@@ -313,10 +313,10 @@ func seedPromptCacheContinuityConversation(t *testing.T, engine *Engine) {
 	})); err != nil {
 		t.Fatalf("append local entry: %v", err)
 	}
-	if err := engine.steer("turn-1", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "The runtime state is seeded. I only need the post-restart payload comparison now."})); err != nil {
+	if err := engine.steer("turn-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "The runtime state is seeded. I only need the post-restart payload comparison now."}})); err != nil {
 		t.Fatalf("append assistant final answer: %v", err)
 	}
-	if err := engine.steer("turn-2", steerUserMessageIntent(llm.Message{Role: llm.RoleUser, Content: "Continue after restart and compare the exact OpenAI payload bytes."})); err != nil {
+	if err := engine.steer("turn-2", steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "Continue after restart and compare the exact OpenAI payload bytes."}})); err != nil {
 		t.Fatalf("append second user message: %v", err)
 	}
 }

--- a/server/runtime/queued_user_messages.go
+++ b/server/runtime/queued_user_messages.go
@@ -24,7 +24,7 @@ func newQueuedUserMessageStore() *queuedUserMessageStore {
 
 func (s *queuedUserMessageStore) Queue(text string) QueuedUserMessage {
 	item := QueuedUserMessage{ID: uuid.NewString(), Text: text}
-	intent := steerUserMessageWithoutDerivedEventIntent(llm.Message{Role: llm.RoleUser, Content: item.Text})
+	intent := steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventNone, true, []llm.Message{{Role: llm.RoleUser, Content: item.Text}})
 	s.mu.Lock()
 	s.pending = append(s.pending, queuedUserSteeringIntent{message: item, intent: intent})
 	s.mu.Unlock()

--- a/server/runtime/request_cache_lineage_test.go
+++ b/server/runtime/request_cache_lineage_test.go
@@ -243,10 +243,10 @@ func TestBuildRequest_UsesBasePromptCacheKeyBeforeFirstCompactionWhenProviderSup
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
-	if got, want := req.SessionID, eng.conversationSessionID(); got != want {
+	if got, want := req.SessionID, eng.SessionID(); got != want {
 		t.Fatalf("SessionID = %q, want %q", got, want)
 	}
-	if got, want := req.PromptCacheKey, eng.conversationPromptCacheKey(); got != want {
+	if got, want := req.PromptCacheKey, conversationPromptCacheKey(eng.SessionID(), eng.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("PromptCacheKey = %q, want %q", got, want)
 	}
 	if req.PromptCacheScope != transcript.CacheWarningScopeConversation {
@@ -263,10 +263,10 @@ func TestBuildRequest_RotatesPromptCacheKeyWithRequestSessionIDAfterCompaction(t
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
-	if got, want := req.SessionID, eng.conversationSessionID(); got != want {
+	if got, want := req.SessionID, eng.SessionID(); got != want {
 		t.Fatalf("SessionID = %q, want %q", got, want)
 	}
-	if got, want := req.PromptCacheKey, eng.conversationPromptCacheKey(); got != want {
+	if got, want := req.PromptCacheKey, conversationPromptCacheKey(eng.SessionID(), eng.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("PromptCacheKey = %q, want %q", got, want)
 	}
 }
@@ -291,10 +291,10 @@ func TestBuildRequest_RotatesPromptCacheKeyFromPersistedCompactionOnReopen(t *te
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
-	if got, want := req.SessionID, eng.conversationSessionID(); got != want {
+	if got, want := req.SessionID, eng.SessionID(); got != want {
 		t.Fatalf("SessionID = %q, want %q", got, want)
 	}
-	if got, want := req.PromptCacheKey, eng.conversationPromptCacheKey(); got != want {
+	if got, want := req.PromptCacheKey, conversationPromptCacheKey(eng.SessionID(), eng.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("PromptCacheKey = %q, want %q", got, want)
 	}
 }
@@ -319,10 +319,10 @@ func TestLocalCompactionSummary_UsesMainConversationRequestIdentityAndPrompt(t *
 	if err != nil {
 		t.Fatalf("ensure locked: %v", err)
 	}
-	if got, want := req.SessionID, eng.conversationSessionID(); got != want {
+	if got, want := req.SessionID, eng.SessionID(); got != want {
 		t.Fatalf("SessionID = %q, want %q", got, want)
 	}
-	if got, want := req.PromptCacheKey, eng.conversationPromptCacheKey(); got != want {
+	if got, want := req.PromptCacheKey, conversationPromptCacheKey(eng.SessionID(), eng.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("PromptCacheKey = %q, want %q", got, want)
 	}
 	if got, want := req.PromptCacheScope, transcript.CacheWarningScopeConversation; got != want {
@@ -406,7 +406,7 @@ func TestOpenAIResponsesPayload_UsesExpectedCacheKeyShapesAcrossConversationSupe
 	if got, want := reopenedReq.SessionID, reopened.Meta().SessionID; got != want {
 		t.Fatalf("reopened SessionID = %q, want %q", got, want)
 	}
-	if got, want := stringValue(reopenedPayload["prompt_cache_key"]), conversationPromptCacheKey(reopened.Meta().SessionID, reopenedEng.compactionCountSnapshot()); got != want {
+	if got, want := stringValue(reopenedPayload["prompt_cache_key"]), conversationPromptCacheKey(reopened.Meta().SessionID, reopenedEng.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("reopened prompt_cache_key = %q, want %q", got, want)
 	}
 	if got, want := stringValue(reopenedPayload["instructions"]), stringValue(conversationPayload["instructions"]); got != want {
@@ -533,7 +533,7 @@ func TestOpenAITransport_UsesExpectedSessionHeadersAndPromptCacheKeysAcrossConve
 	if got, want := reopenedMain.sessionID, reopened.Meta().SessionID; got != want {
 		t.Fatalf("reopened main session_id header = %q, want %q", got, want)
 	}
-	if got, want := stringValue(reopenedMain.payload["prompt_cache_key"]), conversationPromptCacheKey(reopened.Meta().SessionID, reopenedEng.compactionCountSnapshot()); got != want {
+	if got, want := stringValue(reopenedMain.payload["prompt_cache_key"]), conversationPromptCacheKey(reopened.Meta().SessionID, reopenedEng.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("reopened main prompt_cache_key = %q, want %q", got, want)
 	}
 
@@ -545,7 +545,7 @@ func TestOpenAITransport_UsesExpectedSessionHeadersAndPromptCacheKeysAcrossConve
 	if got, want := reopenedReviewer.sessionID, reviewerSessionID(reopened.Meta().SessionID); got != want {
 		t.Fatalf("reopened reviewer session_id header = %q, want %q", got, want)
 	}
-	if got, want := stringValue(reopenedReviewer.payload["prompt_cache_key"]), conversationPromptCacheKey(reviewerSessionID(reopened.Meta().SessionID), reopenedEng.compactionCountSnapshot()); got != want {
+	if got, want := stringValue(reopenedReviewer.payload["prompt_cache_key"]), conversationPromptCacheKey(reviewerSessionID(reopened.Meta().SessionID), reopenedEng.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("reopened reviewer prompt_cache_key = %q, want %q", got, want)
 	}
 }
@@ -590,7 +590,7 @@ func TestReviewerSuggestions_UsesReviewerClientPromptCacheCapability(t *testing.
 	if got, want := reviewerClient.calls[0].SessionID, reviewerSessionID(store.Meta().SessionID); got != want {
 		t.Fatalf("reviewer SessionID = %q, want %q", got, want)
 	}
-	if got, want := reviewerClient.calls[0].PromptCacheKey, conversationPromptCacheKey(reviewerSessionID(store.Meta().SessionID), eng.compactionCountSnapshot()); got != want {
+	if got, want := reviewerClient.calls[0].PromptCacheKey, conversationPromptCacheKey(reviewerSessionID(store.Meta().SessionID), eng.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("reviewer PromptCacheKey = %q, want %q", got, want)
 	}
 	if reviewerClient.calls[0].PromptCacheScope != transcript.CacheWarningScopeReviewer {
@@ -627,7 +627,7 @@ func TestReviewerSuggestions_PromptCacheKeyStaysOnReviewerSessionAfterConversati
 	if got, want := reviewerClient.calls[0].SessionID, reviewerSessionID(reopened.Meta().SessionID); got != want {
 		t.Fatalf("reviewer SessionID = %q, want %q", got, want)
 	}
-	if got, want := reviewerClient.calls[0].PromptCacheKey, conversationPromptCacheKey(reviewerSessionID(reopened.Meta().SessionID), eng.compactionCountSnapshot()); got != want {
+	if got, want := reviewerClient.calls[0].PromptCacheKey, conversationPromptCacheKey(reviewerSessionID(reopened.Meta().SessionID), eng.compactionRuntimeState().Count()); got != want {
 		t.Fatalf("reviewer PromptCacheKey = %q, want %q", got, want)
 	}
 }
@@ -673,7 +673,7 @@ func TestGenerateWithRetryClient_CompactionRotatesConversationCacheKeyWithoutWar
 	if _, err := eng.generateWithRetryClient(context.Background(), "step-1", client, testPromptCacheRequest("cache-key-1", "alpha"), nil, nil, nil); err != nil {
 		t.Fatalf("first generate: %v", err)
 	}
-	if err := eng.replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleAssistant, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}})); err != nil {
+	if err := newCompactionPersistence(eng).replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleAssistant, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}})); err != nil {
 		t.Fatalf("replace history: %v", err)
 	}
 	if len(persistedCacheWarnings(t, store)) != 0 {
@@ -734,7 +734,7 @@ func TestGenerateWithRetryClient_RestorePreservesRotatedCompactionKeyWithoutWarn
 	if _, err := eng.generateWithRetryClient(context.Background(), "step-1", client, testPromptCacheRequest("cache-key-1", "alpha"), nil, nil, nil); err != nil {
 		t.Fatalf("first generate: %v", err)
 	}
-	if err := eng.replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleAssistant, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}})); err != nil {
+	if err := newCompactionPersistence(eng).replaceHistory("step-compact", "local", compactionModeManual, llm.ItemsFromMessages([]llm.Message{{Role: llm.RoleAssistant, MessageType: llm.MessageTypeCompactionSummary, Content: "summary"}})); err != nil {
 		t.Fatalf("replace history: %v", err)
 	}
 	if err := eng.Close(); err != nil {

--- a/server/runtime/reviewer_pipeline.go
+++ b/server/runtime/reviewer_pipeline.go
@@ -31,7 +31,7 @@ func (r *defaultReviewerPipeline) ShouldRunTurn(frequency string, reviewerClient
 
 func (r *defaultReviewerPipeline) RunFollowUp(ctx context.Context, stepID string, original llm.Message, originalCommittedStart int, originalCommittedStartSet bool, reviewerClient llm.Client) (reviewerFollowUpResult, error) {
 	e := r.engine
-	_ = e.steerEvent(stepID, Event{Kind: EventReviewerStarted, StepID: stepID})
+	_ = e.steer(stepID, steerEventIntent(Event{Kind: EventReviewerStarted, StepID: stepID}))
 	reviewerResult, err := r.RunSuggestions(ctx, stepID, reviewerClient)
 	if err != nil {
 		status := ReviewerStatus{
@@ -51,7 +51,7 @@ func (r *defaultReviewerPipeline) RunFollowUp(ctx context.Context, stepID string
 	}
 
 	instruction := formatReviewerDeveloperInstruction(suggestions)
-	if err := e.steer(stepID, steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeReviewerFeedback, Content: instruction})); err != nil {
+	if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeReviewerFeedback, Content: instruction}})); err != nil {
 		status := ReviewerStatus{
 			Outcome:               "followup_failed",
 			SuggestionsCount:      len(suggestions),

--- a/server/runtime/reviewer_request_builder.go
+++ b/server/runtime/reviewer_request_builder.go
@@ -29,7 +29,7 @@ func reviewerSuggestionsStructuredOutput() *llm.StructuredOutput {
 
 func (e *Engine) buildReviewerRequest(ctx context.Context, reviewerClient llm.Client) (llm.Request, error) {
 	reviewerCfg := e.reviewerRequestConfigSnapshot()
-	reviewerItems, err := buildReviewerRequestItemsWithBuilder(e.snapshotItems(), newActiveMetaContextBuilder(e.store.Meta(), e.cfg.Model, e.ThinkingLevel(), e.cfg.DisabledSkills, e.reviewerMetaTimestamp()), e.cfg.HeadlessMode)
+	reviewerItems, err := buildReviewerRequestItemsWithBuilder(e.transcriptRuntimeState().SnapshotItems(), newActiveMetaContextBuilder(e.store.Meta(), e.cfg.Model, e.ThinkingLevel(), e.cfg.DisabledSkills, e.reviewerMetaTimestamp()), e.cfg.HeadlessMode)
 	if err != nil {
 		return llm.Request{}, err
 	}
@@ -51,7 +51,7 @@ func (e *Engine) buildReviewerRequest(ctx context.Context, reviewerClient llm.Cl
 		StructuredOutput:        reviewerSuggestionsStructuredOutput(),
 	}
 	if supportsPromptCacheKeyForClient(ctx, reviewerClient) {
-		if cacheKey := conversationPromptCacheKey(reviewerSessionID(e.store.Meta().SessionID), e.compactionCountSnapshot()); cacheKey != "" {
+		if cacheKey := conversationPromptCacheKey(reviewerSessionID(e.store.Meta().SessionID), e.compactionRuntimeState().Count()); cacheKey != "" {
 			req.PromptCacheKey = cacheKey
 			req.PromptCacheScope = transcript.CacheWarningScopeReviewer
 		}

--- a/server/runtime/reviewer_request_test.go
+++ b/server/runtime/reviewer_request_test.go
@@ -105,7 +105,7 @@ func TestBuildReviewerRequestPreservesTranscriptBytes(t *testing.T) {
 		Model:    "gpt-5",
 		Reviewer: ReviewerConfig{Model: "gpt-5"},
 	})
-	if err := eng.steer("seed-step", steerUserMessageIntent(llm.Message{Role: llm.RoleUser, Content: seedContent})); err != nil {
+	if err := eng.steer("seed-step", steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: seedContent}})); err != nil {
 		t.Fatalf("append seed message: %v", err)
 	}
 
@@ -136,7 +136,7 @@ func TestReviewerSuggestions_ReopenKeepsPromptCachePrefixStable(t *testing.T) {
 	}
 	eng := mustNewTestEngine(t, store, engineClient, tools.NewRegistry(), Config{Model: "gpt-5", Reviewer: ReviewerConfig{Model: "gpt-5"}})
 	t.Cleanup(func() { _ = eng.Close() })
-	if err := eng.steer("prep-1", steerUserMessageIntent(llm.Message{Role: llm.RoleUser, Content: "first request"})); err != nil {
+	if err := eng.steer("prep-1", steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "first request"}})); err != nil {
 		t.Fatalf("append first message: %v", err)
 	}
 	if _, err := eng.runReviewerSuggestions(context.Background(), "step-1", reviewerClient); err != nil {
@@ -152,7 +152,7 @@ func TestReviewerSuggestions_ReopenKeepsPromptCachePrefixStable(t *testing.T) {
 	}
 	reopenedEng := mustNewTestEngine(t, reopened, engineClient, tools.NewRegistry(), Config{Model: "gpt-5", Reviewer: ReviewerConfig{Model: "gpt-5"}})
 	t.Cleanup(func() { _ = reopenedEng.Close() })
-	if err := reopenedEng.steer("prep-2", steerUserMessageIntent(llm.Message{Role: llm.RoleUser, Content: "second request"})); err != nil {
+	if err := reopenedEng.steer("prep-2", steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "second request"}})); err != nil {
 		t.Fatalf("append second message: %v", err)
 	}
 	if _, err := reopenedEng.runReviewerSuggestions(context.Background(), "step-2", reviewerClient); err != nil {

--- a/server/runtime/status_inspection.go
+++ b/server/runtime/status_inspection.go
@@ -22,7 +22,7 @@ type SkillInspection struct {
 }
 
 func (e *Engine) CompactionCount() int {
-	return e.compactionCountSnapshot()
+	return e.compactionRuntimeState().Count()
 }
 
 func InspectSkills(workspaceRoot string, disabledSkills map[string]bool) ([]SkillInspection, error) {

--- a/server/runtime/step_executor.go
+++ b/server/runtime/step_executor.go
@@ -35,7 +35,7 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 			ctx,
 			stepID,
 			func() (llm.Request, error) {
-				requestPlan, buildErr := e.buildRequestPlan(ctx, stepID, true)
+				requestPlan, buildErr := e.buildRequestPlanWithExtraItems(ctx, stepID, nil, true)
 				if buildErr != nil {
 					return llm.Request{}, buildErr
 				}
@@ -100,11 +100,11 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 			assistantMsg.ToolCalls = nil
 			localToolCalls = nil
 			hostedToolExecutions = nil
-			_ = e.steerEvent(stepID, Event{Kind: EventConversationUpdated, StepID: stepID, CommittedTranscriptChanged: true})
+			_ = e.steer(stepID, steerEventIntent(Event{Kind: EventConversationUpdated, StepID: stepID, CommittedTranscriptChanged: true}))
 		}
 
 		if !noopFinalAnswer {
-			_ = e.steerEvent(stepID, Event{
+			_ = e.steer(stepID, steerEventIntent(Event{
 				Kind:   EventModelResponse,
 				StepID: stepID,
 				ModelResponse: &ModelResponseTrace{
@@ -114,9 +114,10 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 					OutputItemsCount: len(resp.OutputItems),
 					OutputItemTypes:  summarizeOutputItemTypes(resp.OutputItems),
 				},
-			})
+			}))
+
 		}
-		if err := e.steer(stepID, steerMessageWithoutDerivedEventIntent(assistantMsg)); err != nil {
+		if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventNone, true, []llm.Message{assistantMsg})); err != nil {
 			return stepLoopResult{}, err
 		}
 		if !noopFinalAnswer {
@@ -130,14 +131,15 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 			assistantCommittedStart, toolCallStarts = committedStartsForPersistedAssistantMessage(e, assistantMsg, executableCallIDs)
 			e.rememberPendingToolCallStarts(toolCallStarts)
 			if liveAssistant, ok := liveCommittedAssistantEventMessage(assistantMsg); ok && options.EmitAssistantEvent {
-				_ = e.steerEvent(stepID, Event{
+				_ = e.steer(stepID, steerEventIntent(Event{
 					Kind:                       EventAssistantMessage,
 					StepID:                     stepID,
 					Message:                    liveAssistant,
 					CommittedTranscriptChanged: true,
 					CommittedEntryStart:        assistantCommittedStart,
 					CommittedEntryStartSet:     assistantCommittedStart >= 0,
-				})
+				}))
+
 			}
 			for _, entry := range resp.Reasoning {
 				if err := e.steer(stepID, steerLocalEntryIntent(storedLocalEntry{
@@ -149,7 +151,7 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 				}
 			}
 			if phaseTurn.MissingAssistantPhase {
-				if err := e.steer(stepID, steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: missingAssistantPhaseWarning})); err != nil {
+				if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: missingAssistantPhaseWarning}})); err != nil {
 					return stepLoopResult{}, err
 				}
 			}
@@ -160,7 +162,7 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 				return stepLoopResult{}, err
 			}
 			msg := llm.Message{Role: llm.RoleTool, Content: string(hosted.Result.Output), ToolCallID: hosted.Result.CallID, Name: string(hosted.Result.Name)}
-			if err := e.steer(stepID, steerMessageIntent(msg)); err != nil {
+			if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{msg})); err != nil {
 				return stepLoopResult{}, err
 			}
 		}
@@ -181,7 +183,7 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 		if len(localToolCalls) == 0 {
 			if phaseTurn.MissingAssistantPhase {
 				if len(hostedToolExecutions) > 0 {
-					_ = e.steerEvent(stepID, Event{Kind: EventConversationUpdated, StepID: stepID, CommittedTranscriptChanged: true})
+					_ = e.steer(stepID, steerEventIntent(Event{Kind: EventConversationUpdated, StepID: stepID, CommittedTranscriptChanged: true}))
 				}
 				if _, err := s.messages.FlushPendingUserInjections(stepID); err != nil {
 					return stepLoopResult{}, err
@@ -189,7 +191,7 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 				continue
 			}
 			if phaseTurn.EnforcePhaseProtocol && assistantMsg.Phase != llm.MessagePhaseFinal {
-				if err := e.steer(stepID, steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: commentaryWithoutToolCallsWarning})); err != nil {
+				if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: commentaryWithoutToolCallsWarning}})); err != nil {
 					return stepLoopResult{}, err
 				}
 				if _, err := s.messages.FlushPendingUserInjections(stepID); err != nil {
@@ -198,7 +200,7 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 				continue
 			}
 			if phaseTurn.EnforcePhaseProtocol && assistantMsg.Phase == llm.MessagePhaseFinal && strings.TrimSpace(assistantMsg.Content) == "" && !noopFinalAnswer {
-				if err := e.steer(stepID, steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: finalWithoutContentWarning})); err != nil {
+				if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: finalWithoutContentWarning}})); err != nil {
 					return stepLoopResult{}, err
 				}
 				if _, err := s.messages.FlushPendingUserInjections(stepID); err != nil {
@@ -220,7 +222,7 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 				continue
 			}
 			if len(hostedToolExecutions) > 0 {
-				_ = e.steerEvent(stepID, Event{Kind: EventConversationUpdated, StepID: stepID, CommittedTranscriptChanged: true})
+				_ = e.steer(stepID, steerEventIntent(Event{Kind: EventConversationUpdated, StepID: stepID, CommittedTranscriptChanged: true}))
 				continue
 			}
 
@@ -239,7 +241,7 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 			}
 			if resolvedNoopFinalAnswer {
 				if e.goalActive() {
-					if err := e.steer(stepID, steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: goalNoopFinalWarning})); err != nil {
+					if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: goalNoopFinalWarning}})); err != nil {
 						return stepLoopResult{}, err
 					}
 					continue
@@ -258,7 +260,7 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 					// The answer is already committed before supervisor entries are appended.
 					// Publish it first so live clients never see supervisor entries as a gap
 					// after an unannounced committed assistant message.
-					_ = e.steerEvent(stepID, Event{Kind: EventAssistantMessage, StepID: stepID, Message: resolved, CommittedTranscriptChanged: true, CommittedEntryStart: resolvedCommittedStart, CommittedEntryStartSet: resolvedCommittedStartSet})
+					_ = e.steer(stepID, steerEventIntent(Event{Kind: EventAssistantMessage, StepID: stepID, Message: resolved, CommittedTranscriptChanged: true, CommittedEntryStart: resolvedCommittedStart, CommittedEntryStartSet: resolvedCommittedStartSet}))
 					assistantEventEmitted = true
 				}
 				preReviewMessage := resolved
@@ -272,13 +274,13 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 				assistantEventEmitted = assistantEventEmitted && sameVisibleAssistantMessage(preReviewMessage, resolved)
 			}
 			if options.EmitAssistantEvent && !assistantEventEmitted {
-				_ = e.steerEvent(stepID, Event{Kind: EventAssistantMessage, StepID: stepID, Message: resolved, CommittedTranscriptChanged: true, CommittedEntryStart: resolvedCommittedStart, CommittedEntryStartSet: resolvedCommittedStartSet})
+				_ = e.steer(stepID, steerEventIntent(Event{Kind: EventAssistantMessage, StepID: stepID, Message: resolved, CommittedTranscriptChanged: true, CommittedEntryStart: resolvedCommittedStart, CommittedEntryStartSet: resolvedCommittedStartSet}))
 			}
 			if reviewerCompletion != nil {
 				if err := e.steer(stepID, steerLocalEntryIntent(storedLocalEntry{Role: "reviewer_status", Text: reviewerStatusText(*reviewerCompletion, nil)})); err != nil {
 					return stepLoopResult{}, err
 				}
-				_ = e.steerEvent(stepID, Event{Kind: EventReviewerCompleted, StepID: stepID, Reviewer: reviewerCompletion})
+				_ = e.steer(stepID, steerEventIntent(Event{Kind: EventReviewerCompleted, StepID: stepID, Reviewer: reviewerCompletion}))
 			}
 			return stepLoopResult{Message: resolved, ExecutedToolCall: executedToolCall, AssistantCommittedStart: resolvedCommittedStart, AssistantCommittedStartSet: resolvedCommittedStartSet}, nil
 		}
@@ -307,7 +309,7 @@ func (s *defaultStepExecutor) materializeFinalAnswerToolCalls(ctx context.Contex
 	for _, hosted := range hostedToolExecutions {
 		toolCallMessage.ToolCalls = append(toolCallMessage.ToolCalls, hosted.Call)
 	}
-	if err := e.steer(stepID, steerMessageWithoutDerivedEventIntent(toolCallMessage)); err != nil {
+	if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventNone, true, []llm.Message{toolCallMessage})); err != nil {
 		return false, false, err
 	}
 
@@ -348,7 +350,7 @@ func (s *defaultStepExecutor) executeLocalToolCallsAndAppendResults(ctx context.
 		}
 		msg := llm.Message{Role: llm.RoleTool, Content: string(result.Output), ToolCallID: result.CallID, Name: string(result.Name)}
 		msg.MessageType = llm.ToolOutputMessageType(customToolCalls[result.CallID])
-		if err := e.steer(stepID, steerMessageIntent(msg)); err != nil {
+		if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{msg})); err != nil {
 			return false, false, err
 		}
 	}
@@ -362,7 +364,7 @@ func (s *defaultStepExecutor) appendHostedToolExecutionResults(stepID string, ho
 			return err
 		}
 		msg := llm.Message{Role: llm.RoleTool, Content: string(hosted.Result.Output), ToolCallID: hosted.Result.CallID, Name: string(hosted.Result.Name)}
-		if err := e.steer(stepID, steerMessageIntent(msg)); err != nil {
+		if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{msg})); err != nil {
 			return err
 		}
 	}
@@ -407,7 +409,7 @@ func (s *defaultStepExecutor) handleWorkflowAssistantWithoutTools(ctx context.Co
 		if record.Interrupted {
 			return true, true, nil
 		}
-		if err := e.steer(stepID, steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: workflowFinalAnswerNudge})); err != nil {
+		if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: workflowFinalAnswerNudge}})); err != nil {
 			return true, false, err
 		}
 		return true, false, nil
@@ -428,7 +430,7 @@ func (s *defaultStepExecutor) appendWorkflowInvalidCompletionNudge(ctx context.C
 	if strings.TrimSpace(err.Error()) != "" {
 		content += "\n\n" + err.Error()
 	}
-	return false, e.steer(stepID, steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: content}))
+	return false, e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeErrorFeedback, Content: content}}))
 }
 
 func customToolCallIDs(calls []llm.ToolCall) map[string]bool {
@@ -446,8 +448,8 @@ func customToolCallIDs(calls []llm.ToolCall) map[string]bool {
 
 func (s *defaultStepExecutor) prepareModelTurn(ctx context.Context, stepID string) error {
 	e := s.engine
-	compactionCountBeforeReminder := e.compactionCountSnapshot()
-	handoffRequestPending := e.pendingHandoffRequestSnapshot() != nil
+	compactionCountBeforeReminder := e.compactionRuntimeState().Count()
+	handoffRequestPending := e.handoffRuntimeState().RequestSnapshot() != nil
 	if !handoffRequestPending {
 		if err := e.materializePendingWorktreeReminder(stepID); err != nil {
 			return err
@@ -464,7 +466,7 @@ func (s *defaultStepExecutor) prepareModelTurn(ctx context.Context, stepID strin
 		if err := e.materializePendingWorktreeReminder(stepID); err != nil {
 			return err
 		}
-		return e.maybeAppendCompactionSoonReminder(ctx, stepID)
+		return newCompactionReminderCoordinator(e).maybeAppend(ctx, stepID)
 	}
 	if handoffRequestPending {
 		if err := e.materializePendingWorktreeReminder(stepID); err != nil {
@@ -477,7 +479,7 @@ func (s *defaultStepExecutor) prepareModelTurn(ctx context.Context, stepID strin
 	if err := e.materializePendingWorktreeReminderAfterCompaction(stepID, compactionCountBeforeReminder); err != nil {
 		return err
 	}
-	return e.maybeAppendCompactionSoonReminder(ctx, stepID)
+	return newCompactionReminderCoordinator(e).maybeAppend(ctx, stepID)
 }
 
 func liveCommittedAssistantEventMessage(msg llm.Message) (llm.Message, bool) {

--- a/server/runtime/subagents_test.go
+++ b/server/runtime/subagents_test.go
@@ -226,15 +226,15 @@ func TestManualCompactionPersistsSubagentCatalogInCanonicalTranscript(t *testing
 		Usage:     llm.Usage{InputTokens: 1000, OutputTokens: 100, WindowTokens: 200000},
 	}}}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), cfg)
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 
 	if err := eng.CompactContext(context.Background(), ""); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
-	if !hasSubagentCatalog(eng.snapshotMessages(), "- `worker`: Callable helper.") {
-		t.Fatalf("expected in-memory canonical transcript to keep subagent catalog, got %+v", eng.snapshotMessages())
+	if !hasSubagentCatalog(eng.transcriptRuntimeState().SnapshotMessages(), "- `worker`: Callable helper.") {
+		t.Fatalf("expected in-memory canonical transcript to keep subagent catalog, got %+v", eng.transcriptRuntimeState().SnapshotMessages())
 	}
 
 	reopenedStore, err := session.Open(store.Dir())
@@ -242,8 +242,8 @@ func TestManualCompactionPersistsSubagentCatalogInCanonicalTranscript(t *testing
 		t.Fatalf("reopen store: %v", err)
 	}
 	restored := mustNewTestEngine(t, reopenedStore, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), cfg)
-	if !hasSubagentCatalog(restored.snapshotMessages(), "- `worker`: Callable helper.") {
-		t.Fatalf("expected persisted canonical transcript to keep subagent catalog, got %+v", restored.snapshotMessages())
+	if !hasSubagentCatalog(restored.transcriptRuntimeState().SnapshotMessages(), "- `worker`: Callable helper.") {
+		t.Fatalf("expected persisted canonical transcript to keep subagent catalog, got %+v", restored.transcriptRuntimeState().SnapshotMessages())
 	}
 }
 

--- a/server/runtime/system_prompt_snapshot.go
+++ b/server/runtime/system_prompt_snapshot.go
@@ -41,7 +41,7 @@ func (e *Engine) buildSystemPromptSnapshotForRoot(locked session.LockedContract,
 		}
 		return rendered, nil
 	}
-	return prompts.MainSystemPrompt(includeToolPreambles, args), nil
+	return prompts.WithToolPreambles(prompts.BaseSystemPrompt(args), includeToolPreambles), nil
 }
 
 func editingToolName(enabled []toolspec.ID) string {

--- a/server/runtime/system_prompt_snapshot.go
+++ b/server/runtime/system_prompt_snapshot.go
@@ -18,10 +18,6 @@ type systemPromptSnapshotOptions struct {
 	SystemPromptFiles []config.SystemPromptFile
 }
 
-func (e *Engine) buildSystemPromptSnapshot(locked session.LockedContract) (string, error) {
-	return e.buildSystemPromptSnapshotForRoot(locked, e.systemPromptWorkspaceRoot())
-}
-
 func (e *Engine) buildSystemPromptSnapshotForRoot(locked session.LockedContract, workspaceRoot string) (string, error) {
 	includeToolPreambles := true
 	if locked.ToolPreambles != nil {

--- a/server/runtime/token_usage_test.go
+++ b/server/runtime/token_usage_test.go
@@ -139,7 +139,7 @@ func TestCurrentInputTokensPreciselyRechecksAfterTranscriptMutation(t *testing.T
 
 	client := &preciseCompactionClient{inputTokenCount: 240, contextWindow: 400000}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 400_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "hello"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "hello"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -157,7 +157,7 @@ func TestCurrentInputTokensPreciselyRechecksAfterTranscriptMutation(t *testing.T
 	}
 
 	client.inputTokenCount = 360
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleAssistant, Content: "world"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleAssistant, Content: "world"}})); err != nil {
 		t.Fatalf("append assistant message: %v", err)
 	}
 	if precise, ok := eng.currentInputTokensPrecisely(context.Background()); !ok || precise != 360 {
@@ -174,7 +174,7 @@ func TestContextUsagePrefersFreshPreciseCurrentTokens(t *testing.T) {
 	client := &preciseCompactionClient{inputTokenCount: 180, contextWindow: 400000}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 400_000})
 	eng.setLastUsage(llm.Usage{InputTokens: 900, OutputTokens: 100, WindowTokens: 400_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "precise me"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "precise me"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -192,7 +192,7 @@ func TestCurrentInputTokensPreciselyRechecksAfterFastModeToggle(t *testing.T) {
 
 	client := &preciseCompactionClient{inputTokenCount: 180, contextWindow: 400000}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 400_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "hello"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "hello"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 	if _, ok := eng.currentInputTokensPrecisely(context.Background()); !ok {
@@ -222,7 +222,7 @@ func TestCurrentInputTokensPreciselyIfDueSkipsBackendFarBelowCheckpoint(t *testi
 
 	client := &preciseCompactionClient{inputTokenCount: 999, contextWindow: 400000}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 400_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "short"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "short"}})); err != nil {
 		t.Fatalf("append message: %v", err)
 	}
 
@@ -239,7 +239,7 @@ func TestCurrentInputTokensPreciselyIfCriticalForcesRefreshAfterSignificantMutat
 
 	client := &preciseCompactionClient{inputTokenCount: 180, contextWindow: 400000}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 400_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "hello"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "hello"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 	if _, ok := eng.currentInputTokensPrecisely(context.Background()); !ok {
@@ -249,13 +249,13 @@ func TestCurrentInputTokensPreciselyIfCriticalForcesRefreshAfterSignificantMutat
 		t.Fatalf("count calls=%d, want 1", client.countCalls)
 	}
 	client.inputTokenCount = 220
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleDeveloper, Content: "background shell completed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, Content: "background shell completed"}})); err != nil {
 		t.Fatalf("append developer mutation: %v", err)
 	}
 	if precise, ok := eng.currentInputTokensPreciselyIfDue(context.Background(), 1_000); ok || precise != 0 {
 		t.Fatalf("scheduled exact recount = (%d, %v), want no refresh below 50%%", precise, ok)
 	}
-	if precise, ok := eng.currentInputTokensPreciselyIfCritical(context.Background(), 1_000); !ok || precise != 220 {
+	if precise, ok := eng.currentInputTokensPreciselyIfDueWithPriority(context.Background(), 1_000, true); !ok || precise != 220 {
 		t.Fatalf("critical exact recount = (%d, %v), want (220, true)", precise, ok)
 	}
 	if client.countCalls != 2 {
@@ -268,7 +268,7 @@ func TestCurrentInputTokensPreciselyPersistsTranscriptErrorOnceOnCountFailure(t 
 
 	client := &preciseCompactionClient{countErr: errors.New("chatgpt-codex status 404"), contextWindow: 400000}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 400_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "hello"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "hello"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 	if precise, ok := eng.currentInputTokensPrecisely(context.Background()); ok || precise != 0 {
@@ -343,10 +343,10 @@ func TestCurrentInputTokensPreciselyDoesNotPersistFailureForRepairable400(t *tes
 		contextWindow: 400000,
 	}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(), Config{Model: "gpt-5", ContextWindowTokens: 400_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{
 		Role:      llm.RoleAssistant,
 		ToolCalls: []llm.ToolCall{{ID: "missing", Name: "exec", Input: json.RawMessage(`{}`)}},
-	})); err != nil {
+	}})); err != nil {
 		t.Fatalf("append dangling tool call: %v", err)
 	}
 
@@ -384,7 +384,7 @@ func TestCurrentInputTokensPreciselySkipsUnsupportedCountClient(t *testing.T) {
 	supported := false
 	client := &preciseCompactionClient{inputTokenCount: 123, contextWindow: 400000, countSupported: &supported}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 400_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "hello"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "hello"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 
@@ -418,7 +418,7 @@ func TestCurrentInputTokensPreciselyPersistsTranscriptErrorOnSupportProbeFailure
 
 	client := &preciseCompactionClient{inputTokenCount: 123, contextWindow: 400000, supportErr: errors.New("oauth metadata unavailable")}
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 400_000})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "hello"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "hello"}})); err != nil {
 		t.Fatalf("append user message: %v", err)
 	}
 

--- a/server/runtime/token_usage_test.go
+++ b/server/runtime/token_usage_test.go
@@ -226,7 +226,7 @@ func TestCurrentInputTokensPreciselyIfDueSkipsBackendFarBelowCheckpoint(t *testi
 		t.Fatalf("append message: %v", err)
 	}
 
-	if precise, ok := eng.currentInputTokensPreciselyIfDue(context.Background(), 100_000); ok || precise != 0 {
+	if precise, ok := eng.currentInputTokensPreciselyIfDueWithPriority(context.Background(), 100_000, false); ok || precise != 0 {
 		t.Fatalf("currentInputTokensPreciselyIfDue = (%d, %v), want no refresh", precise, ok)
 	}
 	if client.countCalls != 0 {
@@ -252,7 +252,7 @@ func TestCurrentInputTokensPreciselyIfCriticalForcesRefreshAfterSignificantMutat
 	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleDeveloper, Content: "background shell completed"}})); err != nil {
 		t.Fatalf("append developer mutation: %v", err)
 	}
-	if precise, ok := eng.currentInputTokensPreciselyIfDue(context.Background(), 1_000); ok || precise != 0 {
+	if precise, ok := eng.currentInputTokensPreciselyIfDueWithPriority(context.Background(), 1_000, false); ok || precise != 0 {
 		t.Fatalf("scheduled exact recount = (%d, %v), want no refresh below 50%%", precise, ok)
 	}
 	if precise, ok := eng.currentInputTokensPreciselyIfDueWithPriority(context.Background(), 1_000, true); !ok || precise != 220 {

--- a/server/runtime/tool_executor.go
+++ b/server/runtime/tool_executor.go
@@ -48,7 +48,7 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 			started.CommittedEntryStart = start
 			started.CommittedEntryStartSet = true
 		}
-		if err := e.steerEvent(stepID, started); err != nil {
+		if err := e.steer(stepID, steerEventIntent(started)); err != nil {
 			callErrs[i] = fmt.Errorf("persist tool started (call_id=%s tool=%s): %w", call.ID, executableCall.Name, err)
 			continue
 		}

--- a/server/runtime/transcript_event_entries.go
+++ b/server/runtime/transcript_event_entries.go
@@ -122,7 +122,7 @@ func toolResultChatEntry(result tools.Result) ChatEntry {
 	}
 	return ChatEntry{
 		Role:              role,
-		Text:              tools.FormatToolResultForTranscript(result),
+		Text:              tools.FormatToolResultByName(string(result.Name), result.Output, result.IsError),
 		OngoingText:       strings.TrimSpace(result.OngoingText),
 		ToolCallID:        strings.TrimSpace(result.CallID),
 		ToolResultSummary: strings.TrimSpace(result.Summary),

--- a/server/runtime/workflow_completion_test.go
+++ b/server/runtime/workflow_completion_test.go
@@ -246,9 +246,9 @@ func TestWorkflowModePromptCommentCountErrorFailsBeforeWorkflowPromptAppend(t *t
 		t.Fatalf("SubmitWorkflowTurn error = %v, want %v", err, countErr)
 	}
 	assertModelCallCount(t, client, 0)
-	for _, msg := range eng.snapshotMessages() {
+	for _, msg := range eng.transcriptRuntimeState().SnapshotMessages() {
 		if msg.Role == llm.RoleDeveloper && msg.MessageType == llm.MessageTypeWorkflowMode {
-			t.Fatalf("workflow prompt should not be appended after count error: %+v", eng.snapshotMessages())
+			t.Fatalf("workflow prompt should not be appended after count error: %+v", eng.transcriptRuntimeState().SnapshotMessages())
 		}
 	}
 }
@@ -382,13 +382,13 @@ func TestCompleteNodeOutsideWorkflowReturnsToolError(t *testing.T) {
 		t.Fatalf("submit: %v", err)
 	}
 	found := false
-	for _, msg := range eng.snapshotMessages() {
+	for _, msg := range eng.transcriptRuntimeState().SnapshotMessages() {
 		if msg.Role == llm.RoleTool && msg.Name == string(toolspec.ToolCompleteNode) && strings.Contains(msg.Content, "only available during a workflow run") {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatalf("complete_node error output missing from messages: %+v", eng.snapshotMessages())
+		t.Fatalf("complete_node error output missing from messages: %+v", eng.transcriptRuntimeState().SnapshotMessages())
 	}
 }
 
@@ -626,7 +626,7 @@ func assertSchemaRequiredFields(t *testing.T, schema json.RawMessage, expected [
 
 func assertDeveloperErrorFeedbackAfterAssistantFinal(t *testing.T, eng *Engine, assistantContent string, feedbackContent string) {
 	t.Helper()
-	messages := eng.snapshotMessages()
+	messages := eng.transcriptRuntimeState().SnapshotMessages()
 	for index, message := range messages {
 		if message.Role != llm.RoleAssistant || message.Phase != llm.MessagePhaseFinal || message.Content != assistantContent {
 			continue

--- a/server/runtime/worktree_reminder.go
+++ b/server/runtime/worktree_reminder.go
@@ -12,7 +12,7 @@ func (e *Engine) materializePendingWorktreeReminder(stepID string) error {
 }
 
 func (e *Engine) materializePendingWorktreeReminderAfterCompaction(stepID string, previousCompactionCount int) error {
-	if e.compactionCountSnapshot() == previousCompactionCount {
+	if e.compactionRuntimeState().Count() == previousCompactionCount {
 		return nil
 	}
 	return e.materializePendingWorktreeReminderWithOptions(stepID, worktreeReminderMaterializationOptions{ignoreChatEntryDedupe: true})
@@ -24,7 +24,7 @@ type worktreeReminderMaterializationOptions struct {
 
 func (e *Engine) materializePendingWorktreeReminderWithOptions(stepID string, opts worktreeReminderMaterializationOptions) error {
 	state := cloneRuntimeWorktreeReminderState(e.store.Meta().WorktreeReminder)
-	compactionCount := e.compactionCountSnapshot()
+	compactionCount := e.compactionRuntimeState().Count()
 	if !shouldInjectWorktreeReminder(state, compactionCount) {
 		return nil
 	}
@@ -32,16 +32,16 @@ func (e *Engine) materializePendingWorktreeReminderWithOptions(stepID string, op
 	if !ok {
 		return nil
 	}
-	if latestMaterializedWorktreeReminderMatches(e.snapshotItems(), message) || (!opts.ignoreChatEntryDedupe && latestMaterializedWorktreeReminderEntryMatches(e.ChatSnapshot().Entries, message)) {
+	if latestMaterializedWorktreeReminderMatches(e.transcriptRuntimeState().SnapshotItems(), message) || (!opts.ignoreChatEntryDedupe && latestMaterializedWorktreeReminderEntryMatches(e.ChatSnapshot().Entries, message)) {
 		state.HasIssuedInGeneration = true
 		state.IssuedCompactionCount = compactionCount
 		return e.store.SetWorktreeReminderState(state)
 	}
-	if err := e.steer(stepID, steerMessageIntent(message)); err != nil {
+	if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{message})); err != nil {
 		return err
 	}
 	state.HasIssuedInGeneration = true
-	state.IssuedCompactionCount = e.compactionCountSnapshot()
+	state.IssuedCompactionCount = e.compactionRuntimeState().Count()
 	return e.store.SetWorktreeReminderState(state)
 }
 

--- a/server/runtime/worktree_reminder_test.go
+++ b/server/runtime/worktree_reminder_test.go
@@ -225,7 +225,7 @@ func TestRunStepLoopCountsPendingWorktreeReminderBeforeAutoCompaction(t *testing
 		AutoCompactTokenLimit: 1_000,
 		CompactionMode:        "native",
 	})
-	if err := eng.steer("", steerMessageIntent(llm.Message{Role: llm.RoleUser, Content: "seed"})); err != nil {
+	if err := eng.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, true, []llm.Message{{Role: llm.RoleUser, Content: "seed"}})); err != nil {
 		t.Fatalf("append seed: %v", err)
 	}
 	eng.setLastUsage(llm.Usage{InputTokens: 999, WindowTokens: 2_000})

--- a/server/runtimeview/projection.go
+++ b/server/runtimeview/projection.go
@@ -227,7 +227,7 @@ func RunViewFromRuntime(sessionID string, snapshot *runtime.RunSnapshot) *client
 		SessionID:  sessionID,
 		StepID:     snapshot.StepID,
 		Status:     clientui.RunStatus(snapshot.Status),
-		Lifecycle:  clientui.RunningRunLifecycle(mode),
+		Lifecycle:  clientui.MustRunLifecycle(clientui.RunLifecycleRunning, mode),
 		StartedAt:  snapshot.StartedAt,
 		FinishedAt: snapshot.FinishedAt,
 	}
@@ -237,9 +237,9 @@ func RunViewFromSessionRecord(sessionID string, record *session.RunRecord) *clie
 	if record == nil {
 		return nil
 	}
-	lifecycle := clientui.FinishedRunLifecycle(clientui.RunModeTurn)
+	lifecycle := clientui.MustRunLifecycle(clientui.RunLifecycleFinished, clientui.RunModeTurn)
 	if record.Status == session.RunStatusRunning {
-		lifecycle = clientui.RunningRunLifecycle(clientui.RunModeTurn)
+		lifecycle = clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)
 	}
 	return &clientui.RunView{
 		RunID:      record.RunID,

--- a/server/runtimewire/wiring.go
+++ b/server/runtimewire/wiring.go
@@ -250,7 +250,7 @@ func modelCapabilitySourceConfigured(sources map[string]string, key string) bool
 }
 
 func reviewerProviderRuntimeSettings(active config.Settings) providerRuntimeSettings {
-	reviewer := config.EffectiveReviewerSettings(active)
+	reviewer := active.Reviewer
 	reviewerProvider := config.ResolveReviewerProviderSettings(config.Settings{
 		ProviderOverride: active.ProviderOverride,
 		OpenAIBaseURL:    active.OpenAIBaseURL,

--- a/server/session/goal_test.go
+++ b/server/session/goal_test.go
@@ -89,8 +89,10 @@ func TestGoalWithEventsRollsBackMetadataWhenEventAppendFails(t *testing.T) {
 	}
 	previous := *store.Meta().Goal
 	makeEventsPathDirectory(t, store)
-	if _, err := store.SetGoalStatusWithEvents(GoalStatusPaused, GoalActorUser, []EventInput{{Kind: "message", Payload: "goal feedback"}}); err == nil {
-		t.Fatal("expected SetGoalStatusWithEvents to fail when event append fails")
+	if _, err := store.SetGoalStatusWithEventBuilder(GoalStatusPaused, GoalActorUser, func(GoalState) ([]EventInput, error) {
+		return []EventInput{{Kind: "message", Payload: "goal feedback"}}, nil
+	}); err == nil {
+		t.Fatal("expected SetGoalStatusWithEventBuilder to fail when event append fails")
 	}
 	if got := store.Meta().Goal; got == nil || !reflect.DeepEqual(*got, previous) {
 		t.Fatalf("goal after failed status update = %+v, want %+v", got, previous)

--- a/server/session/snapshot.go
+++ b/server/session/snapshot.go
@@ -15,7 +15,7 @@ type Snapshot struct {
 }
 
 func SnapshotFromDir(sessionDir string) (Snapshot, error) {
-	meta, err := ReadMetaFromDir(sessionDir)
+	meta, err := readMetaFile(filepath.Join(sessionDir, sessionFile))
 	if err != nil {
 		return Snapshot{}, err
 	}
@@ -32,10 +32,6 @@ func SnapshotFromDir(sessionDir string) (Snapshot, error) {
 		Runs:                  runsFromEvents(parsed.events),
 		ConversationFreshness: conversationFreshnessFromEvents(parsed.events),
 	}, nil
-}
-
-func ReadMetaFromDir(sessionDir string) (Meta, error) {
-	return readMetaFile(filepath.Join(sessionDir, sessionFile))
 }
 
 func readMetaFile(path string) (Meta, error) {

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -412,12 +412,8 @@ func (s *Store) SetGoalWithEvents(objective string, actor GoalActor, extraEvents
 }
 
 func (s *Store) SetGoalStatus(status GoalStatus, actor GoalActor) (GoalState, error) {
-	return s.SetGoalStatusWithEvents(status, actor, nil)
-}
-
-func (s *Store) SetGoalStatusWithEvents(status GoalStatus, actor GoalActor, extraEvents []EventInput) (GoalState, error) {
 	return s.SetGoalStatusWithEventBuilder(status, actor, func(GoalState) ([]EventInput, error) {
-		return extraEvents, nil
+		return nil, nil
 	})
 }
 

--- a/server/sessionlaunch/service_test.go
+++ b/server/sessionlaunch/service_test.go
@@ -41,7 +41,7 @@ func TestServicePlanSessionReadsPromptHistoryFromMetadataOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RegisterWorkspaceBinding: %v", err)
 	}
-	containerDir := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	containerDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	store, err := session.Create(containerDir, filepath.Base(containerDir), cfg.WorkspaceRoot, meta.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("session.Create: %v", err)

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -268,7 +269,7 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 		Sources:  req.Source.Sources,
 		OnEvent: func(evt runtime.Event) {
 			logger.Logf("%s", runprompt.FormatRuntimeEvent(evt))
-			if transcriptdiag.EnabledForProcess(req.ActiveSettings.Debug) {
+			if transcriptdiag.Enabled(req.ActiveSettings.Debug, os.Getenv) {
 				projected := runtimeview.EventFromRuntime(evt)
 				logger.Logf("%s", runprompt.FormatTranscriptProjectionDiagnostic(sessionID, projected))
 				logger.Logf("%s", runprompt.FormatTranscriptPublishDiagnostic(sessionID, projected))

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -1928,7 +1928,7 @@ func newSessionRuntimeFixture(t *testing.T) sessionRuntimeFixture {
 	if err != nil {
 		t.Fatalf("RegisterWorkspaceBinding: %v", err)
 	}
-	projectSessionsDir := config.ProjectSessionsRoot(appCfg, binding.ProjectID)
+	projectSessionsDir := filepath.Join(filepath.Join(appCfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	store, err := session.Create(projectSessionsDir, filepath.Base(projectSessionsDir), appCfg.WorkspaceRoot, metadataStore.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("session.Create: %v", err)

--- a/server/sessionservice/session_lifecycle_service.go
+++ b/server/sessionservice/session_lifecycle_service.go
@@ -249,7 +249,7 @@ func (s *SessionLifecycleService) resolveTransitionOnce(ctx context.Context, req
 		if err != nil {
 			return serverapi.SessionResolveTransitionResponse{}, err
 		}
-		forkUserMessageIndex, resolveErr := s.resolveForkUserMessageIndex(req.Transition)
+		forkUserMessageIndex, resolveErr := rollbacktarget.DecodeUserMessageIndex(req.Transition.ForkRollbackTargetID)
 		if resolveErr != nil {
 			return serverapi.SessionResolveTransitionResponse{}, resolveErr
 		}
@@ -331,10 +331,6 @@ func (s *SessionLifecycleService) preserveForkExecutionTarget(ctx context.Contex
 		return err
 	}
 	return metadataStore.UpdateSessionExecutionTargetByID(ctx, trimmedChildID, target.WorkspaceID, target.WorktreeID, target.CwdRelpath)
-}
-
-func (s *SessionLifecycleService) resolveForkUserMessageIndex(transition serverapi.SessionTransition) (int, error) {
-	return rollbacktarget.DecodeUserMessageIndex(transition.ForkRollbackTargetID)
 }
 
 func (s *SessionLifecycleService) openStore(sessionID string) (*session.Store, error) {

--- a/server/sessionservice/session_lifecycle_service_test.go
+++ b/server/sessionservice/session_lifecycle_service_test.go
@@ -68,7 +68,7 @@ func createAuthoritativeSessionLifecycleSession(t *testing.T, workspaceRoot stri
 		t.Fatalf("RegisterWorkspaceBinding: %v", err)
 	}
 	sess, err := session.Create(
-		config.ProjectSessionsRoot(cfg, binding.ProjectID),
+		filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions"),
 		filepath.Base(cfg.WorkspaceRoot),
 		cfg.WorkspaceRoot,
 		store.AuthoritativeSessionStoreOptions()...,

--- a/server/startup/embedded_server_test.go
+++ b/server/startup/embedded_server_test.go
@@ -127,7 +127,7 @@ func createEmbeddedProjectSession(t *testing.T, server *EmbeddedServer, workspac
 	// Keep the metadata store alive for the lifetime of the session store so
 	// persistence observer writes continue to succeed during the test.
 	store, err := session.Create(
-		config.ProjectSessionsRoot(server.Config(), server.ProjectID()),
+		filepath.Join(filepath.Join(server.Config().PersistenceRoot, "projects"), server.ProjectID(), "sessions"),
 		filepath.Base(filepath.Clean(workspace)),
 		workspace,
 		metadataStore.AuthoritativeSessionStoreOptions()...,
@@ -203,7 +203,7 @@ func TestStartBuildsEmbeddedServerAndRunsOnboarding(t *testing.T) {
 	if got := server.OAuthOptions().ClientID; got != "client-test" {
 		t.Fatalf("oauth client id = %q", got)
 	}
-	wantContainerDir := config.ProjectSessionsRoot(server.Config(), server.ProjectID())
+	wantContainerDir := filepath.Join(filepath.Join(server.Config().PersistenceRoot, "projects"), server.ProjectID(), "sessions")
 	if server.ContainerDir() != wantContainerDir {
 		t.Fatalf("container dir = %q, want %q", server.ContainerDir(), wantContainerDir)
 	}

--- a/server/startup/serve_server.go
+++ b/server/startup/serve_server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -94,7 +95,8 @@ func (s *ServeServer) Serve(ctx context.Context) error {
 	if s == nil || s.Core == nil {
 		return errors.New("server core is required")
 	}
-	listenAddress := config.ServerListenAddress(s.Config())
+	listenCfg := s.Config()
+	listenAddress := net.JoinHostPort(listenCfg.Settings.ServerHost, strconv.Itoa(listenCfg.Settings.ServerPort))
 	ReleaseTestListenReservation(listenAddress)
 	tcpListener, err := net.Listen("tcp", listenAddress)
 	if err != nil {

--- a/server/startup/serve_server_test.go
+++ b/server/startup/serve_server_test.go
@@ -615,8 +615,8 @@ func TestServeFailsWhenConfiguredPortIsOccupied(t *testing.T) {
 	if err != nil {
 		t.Fatalf("config.Load: %v", err)
 	}
-	ReleaseTestListenReservation(config.ServerListenAddress(loadCfg))
-	listener, err := net.Listen("tcp", config.ServerListenAddress(loadCfg))
+	ReleaseTestListenReservation(net.JoinHostPort(loadCfg.Settings.ServerHost, strconv.Itoa(loadCfg.Settings.ServerPort)))
+	listener, err := net.Listen("tcp", net.JoinHostPort(loadCfg.Settings.ServerHost, strconv.Itoa(loadCfg.Settings.ServerPort)))
 	if err != nil {
 		t.Fatalf("occupy configured port: %v", err)
 	}

--- a/server/tools/contract.go
+++ b/server/tools/contract.go
@@ -250,10 +250,6 @@ func NeedsNativeWebSearch(ids []toolspec.ID, mode string) bool {
 	return false
 }
 
-func FormatToolResultForTranscript(result Result) string {
-	return FormatToolResultByName(string(result.Name), result.Output, result.IsError)
-}
-
 func HostedExecutionsFromOutputs(items []HostedToolOutput, defs []Definition) []HostedExecution {
 	if len(items) == 0 || len(defs) == 0 {
 		return nil

--- a/server/tools/contract.go
+++ b/server/tools/contract.go
@@ -109,10 +109,6 @@ func (d Definition) LocalRuntimeBuilder() LocalRuntimeBuilder {
 	return d.contract.Runtime.LocalBuilder
 }
 
-func (d Definition) ExposedToModelRequest(ctx RequestExposureContext) bool {
-	return d.contract.Request.Allowed(ctx)
-}
-
 func (d Definition) BuildToolCallMeta(ctx ToolCallContext, raw json.RawMessage) transcript.ToolCallMeta {
 	meta := transcript.ToolCallMeta{ToolName: string(d.ID)}
 	if d.contract.Transcript.BuildCallMeta != nil {
@@ -201,7 +197,7 @@ func FormatToolResultByName(toolName string, raw json.RawMessage, isError bool) 
 	if ok {
 		return def.FormatToolResult(Result{Name: def.ID, Output: raw, IsError: isError})
 	}
-	output := strings.TrimSpace(FormatGenericOutput(raw))
+	output := strings.TrimSpace(formatOutputDefault(raw))
 	if output == "" {
 		if isError {
 			return "tool failed"
@@ -231,20 +227,16 @@ func DefinitionsFor(ids []toolspec.ID) []Definition {
 func FilterRequestExposedDefinitions(defs []Definition, ctx RequestExposureContext) []Definition {
 	out := make([]Definition, 0, len(defs))
 	for _, def := range defs {
-		if def.ExposedToModelRequest(ctx) {
+		if def.contract.Request.Allowed(ctx) {
 			out = append(out, def)
 		}
 	}
 	return out
 }
 
-func RequestExposedDefinitions(ids []toolspec.ID, ctx RequestExposureContext) []Definition {
-	return FilterRequestExposedDefinitions(DefinitionsFor(ids), ctx)
-}
-
 func RequestExposedDefinitionsForSession(enabled []toolspec.ID, registered []Definition, ctx RequestExposureContext) []Definition {
 	if len(enabled) > 0 {
-		return RequestExposedDefinitions(enabled, ctx)
+		return FilterRequestExposedDefinitions(DefinitionsFor(enabled), ctx)
 	}
 	return FilterRequestExposedDefinitions(registered, ctx)
 }
@@ -278,8 +270,4 @@ func HostedExecutionsFromOutputs(items []HostedToolOutput, defs []Definition) []
 		}
 	}
 	return out
-}
-
-func FormatGenericOutput(raw json.RawMessage) string {
-	return formatOutputDefault(raw)
 }

--- a/server/tools/patch/tool_apply.go
+++ b/server/tools/patch/tool_apply.go
@@ -5,12 +5,11 @@ import (
 	"strconv"
 	"strings"
 
-	"core/shared/textutil"
 	patchformat "core/shared/transcript/patchformat"
 )
 
 func splitLines(s string) []string {
-	s = textutil.NormalizeCRLF(s)
+	s = strings.ReplaceAll(s, "\r\n", "\n")
 	s = strings.TrimSuffix(s, "\n")
 	if s == "" {
 		return nil

--- a/server/tools/shell/postprocess/hook.go
+++ b/server/tools/shell/postprocess/hook.go
@@ -87,7 +87,7 @@ func (p userHookProcessor) Process(ctx context.Context, envelope Envelope) (Deci
 	}
 
 	var response hookResponse
-	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+	if err := json.Unmarshal(stdout.buffer.Bytes(), &response); err != nil {
 		return Decision{}, ProcessorError{Severity: FailureRecoverable, Message: "command postprocess hook returned invalid JSON", Err: err}
 	}
 	if !response.Processed {
@@ -123,10 +123,6 @@ func (b *limitedBuffer) Write(p []byte) (int, error) {
 	_, _ = b.buffer.Write(chunk)
 	b.remaining -= int64(len(chunk))
 	return written, nil
-}
-
-func (b *limitedBuffer) Bytes() []byte {
-	return b.buffer.Bytes()
 }
 
 func (b *limitedBuffer) String() string {

--- a/server/tools/types_test.go
+++ b/server/tools/types_test.go
@@ -107,7 +107,7 @@ func TestDefinitionContractsDriveRuntimeAndRequestExposure(t *testing.T) {
 	if execTool.LocalRuntimeBuilder() != LocalRuntimeBuilderExecCommand {
 		t.Fatalf("expected %s local runtime builder, got %q", toolspec.ToolExecCommand, execTool.LocalRuntimeBuilder())
 	}
-	if !execTool.ExposedToModelRequest(RequestExposureContext{}) {
+	if !execTool.contract.Request.Allowed(RequestExposureContext{}) {
 		t.Fatalf("expected %s to be request-exposed without vision", toolspec.ToolExecCommand)
 	}
 
@@ -121,10 +121,10 @@ func TestDefinitionContractsDriveRuntimeAndRequestExposure(t *testing.T) {
 	if viewImage.LocalRuntimeBuilder() != LocalRuntimeBuilderViewImage {
 		t.Fatalf("expected %s local runtime builder, got %q", toolspec.ToolViewImage, viewImage.LocalRuntimeBuilder())
 	}
-	if viewImage.ExposedToModelRequest(RequestExposureContext{}) {
+	if viewImage.contract.Request.Allowed(RequestExposureContext{}) {
 		t.Fatalf("expected %s to remain hidden without vision support", toolspec.ToolViewImage)
 	}
-	if !viewImage.ExposedToModelRequest(RequestExposureContext{SupportsVision: true}) {
+	if !viewImage.contract.Request.Allowed(RequestExposureContext{SupportsVision: true}) {
 		t.Fatalf("expected %s to be request-exposed with vision support", toolspec.ToolViewImage)
 	}
 
@@ -138,7 +138,7 @@ func TestDefinitionContractsDriveRuntimeAndRequestExposure(t *testing.T) {
 	if triggerHandoff.LocalRuntimeBuilder() != LocalRuntimeBuilderTriggerHandoff {
 		t.Fatalf("expected %s local runtime builder, got %q", toolspec.ToolTriggerHandoff, triggerHandoff.LocalRuntimeBuilder())
 	}
-	if !triggerHandoff.ExposedToModelRequest(RequestExposureContext{}) {
+	if !triggerHandoff.contract.Request.Allowed(RequestExposureContext{}) {
 		t.Fatalf("expected %s to be request-exposed when enabled", toolspec.ToolTriggerHandoff)
 	}
 
@@ -152,7 +152,7 @@ func TestDefinitionContractsDriveRuntimeAndRequestExposure(t *testing.T) {
 	if webSearch.LocalRuntimeBuilder() != "" {
 		t.Fatalf("expected %s to have no local runtime builder, got %q", toolspec.ToolWebSearch, webSearch.LocalRuntimeBuilder())
 	}
-	if webSearch.ExposedToModelRequest(RequestExposureContext{SupportsVision: true}) {
+	if webSearch.contract.Request.Allowed(RequestExposureContext{SupportsVision: true}) {
 		t.Fatalf("expected %s to stay hidden from request tool declarations", toolspec.ToolWebSearch)
 	}
 	if !webSearch.EnablesNativeWebSearch("native") {
@@ -172,7 +172,7 @@ func TestDefinitionContractsDriveRuntimeAndRequestExposure(t *testing.T) {
 	if edit.LocalRuntimeBuilder() != LocalRuntimeBuilderEdit {
 		t.Fatalf("expected %s local runtime builder, got %q", toolspec.ToolEdit, edit.LocalRuntimeBuilder())
 	}
-	if !edit.ExposedToModelRequest(RequestExposureContext{}) {
+	if !edit.contract.Request.Allowed(RequestExposureContext{}) {
 		t.Fatalf("expected %s to be request-exposed when enabled", toolspec.ToolEdit)
 	}
 }

--- a/server/transport/gateway_part2_test.go
+++ b/server/transport/gateway_part2_test.go
@@ -131,7 +131,7 @@ func TestGatewayAttachSessionClearsWorkspaceOverrideForLaterPlans(t *testing.T) 
 	_, server := newGatewayTestServerForConfig(t, resolvedA.Config)
 
 	storeB, err := session.Create(
-		config.ProjectSessionsRoot(resolvedA.Config, bindingB.ProjectID),
+		filepath.Join(filepath.Join(resolvedA.Config.PersistenceRoot, "projects"), bindingB.ProjectID, "sessions"),
 		"workspace-b",
 		resolvedB.Config.WorkspaceRoot,
 		metadataStore.AuthoritativeSessionStoreOptions()...,
@@ -187,7 +187,7 @@ func TestGatewayScopesProcessAPIsToAttachedProject(t *testing.T) {
 	storeA := createGatewayAuthoritativeSession(t, appCore)
 	appCore.RegisterSessionStore(storeA)
 	storeB, err := session.Create(
-		config.ProjectSessionsRoot(resolvedB.Config, bindingB.ProjectID),
+		filepath.Join(filepath.Join(resolvedB.Config.PersistenceRoot, "projects"), bindingB.ProjectID, "sessions"),
 		"workspace-b",
 		resolvedB.Config.WorkspaceRoot,
 		metadataStore.AuthoritativeSessionStoreOptions()...,

--- a/server/transport/gateway_part3_test.go
+++ b/server/transport/gateway_part3_test.go
@@ -5,7 +5,6 @@ import (
 	"core/server/core"
 	"core/server/metadata"
 	"core/server/session"
-	"core/shared/config"
 	"core/shared/protocol"
 	"core/shared/serverapi"
 	"encoding/json"
@@ -80,7 +79,7 @@ func createGatewayAuthoritativeSession(t *testing.T, appCore *core.Core) *sessio
 	}
 	t.Cleanup(func() { _ = metadataStore.Close() })
 	store, err := session.Create(
-		config.ProjectSessionsRoot(appCore.Config(), appCore.ProjectID()),
+		filepath.Join(filepath.Join(appCore.Config().PersistenceRoot, "projects"), appCore.ProjectID(), "sessions"),
 		filepath.Base(appCore.Config().WorkspaceRoot),
 		appCore.Config().WorkspaceRoot,
 		metadataStore.AuthoritativeSessionStoreOptions()...,

--- a/server/transport/gateway_test.go
+++ b/server/transport/gateway_test.go
@@ -11,7 +11,6 @@ import (
 	shelltool "core/server/tools/shell"
 	rpccontract "core/shared/apicontract"
 	remoteclient "core/shared/client"
-	"core/shared/config"
 	"core/shared/protocol"
 	"core/shared/rpcwire"
 	"core/shared/serverapi"
@@ -20,6 +19,7 @@ import (
 	"golang.org/x/net/websocket"
 	"io"
 	"net/http/httptest"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -850,7 +850,7 @@ func TestGatewayRejectsSessionAccessOutsideAttachedProject(t *testing.T) {
 	}
 	defer func() { _ = metadataStore.Close() }()
 	foreignSession, err := session.Create(
-		config.ProjectSessionsRoot(resolvedB.Config, bindingB.ProjectID),
+		filepath.Join(filepath.Join(resolvedB.Config.PersistenceRoot, "projects"), bindingB.ProjectID, "sessions"),
 		"workspace-b",
 		resolvedB.Config.WorkspaceRoot,
 		metadataStore.SessionStoreOptions()...,
@@ -940,7 +940,7 @@ func TestGatewayAllowsUnscopedSessionRetargetOutsideServerDefaultProject(t *test
 	}
 	defer func() { _ = metadataStore.Close() }()
 	foreignSession, err := session.Create(
-		config.ProjectSessionsRoot(resolvedB.Config, bindingB.ProjectID),
+		filepath.Join(filepath.Join(resolvedB.Config.PersistenceRoot, "projects"), bindingB.ProjectID, "sessions"),
 		"workspace-b",
 		resolvedB.Config.WorkspaceRoot,
 		metadataStore.AuthoritativeSessionStoreOptions()...,

--- a/server/transport/route_policy_test.go
+++ b/server/transport/route_policy_test.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -14,7 +15,6 @@ import (
 	shelltool "core/server/tools/shell"
 	rpccontract "core/shared/apicontract"
 	"core/shared/clientui"
-	"core/shared/config"
 	"core/shared/protocol"
 	"core/shared/serverapi"
 )
@@ -424,7 +424,7 @@ func newRoutePolicyFixture(t *testing.T) routePolicyFixture {
 	ownStore := createGatewayAuthoritativeSession(t, appCore)
 	appCore.RegisterSessionStore(ownStore)
 	foreignStore, err := session.Create(
-		config.ProjectSessionsRoot(resolvedB.Config, bindingB.ProjectID),
+		filepath.Join(filepath.Join(resolvedB.Config.PersistenceRoot, "projects"), bindingB.ProjectID, "sessions"),
 		"workspace-b",
 		resolvedB.Config.WorkspaceRoot,
 		metadataStore.AuthoritativeSessionStoreOptions()...,

--- a/server/workflow/types.go
+++ b/server/workflow/types.go
@@ -315,10 +315,6 @@ func (r ValidationResult) HasBlockingErrors() bool {
 	return false
 }
 
-func (r ValidationResult) Valid() bool {
-	return !r.HasBlockingErrors()
-}
-
 func (r ValidationResult) BlockingErrors() []ValidationError {
 	out := make([]ValidationError, 0, len(r.Errors))
 	for _, err := range r.Errors {

--- a/server/workflow/validation_test.go
+++ b/server/workflow/validation_test.go
@@ -18,7 +18,7 @@ func TestValidateDefaultWorkflowPasses(t *testing.T) {
 	if result.HasErrors() {
 		t.Fatalf("expected valid workflow, got errors: %+v", result.Errors)
 	}
-	if !result.Valid() {
+	if result.HasBlockingErrors() {
 		t.Fatalf("expected result.Valid()")
 	}
 }

--- a/server/workflowrunner/starter.go
+++ b/server/workflowrunner/starter.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"text/template"
@@ -310,7 +312,7 @@ func (s *Starter) planSession(ctx context.Context, input workflowstore.RunStartC
 	if projectID == "" {
 		return launch.SessionPlan{}, nil, errors.New("workflow task project id is required")
 	}
-	containerDir := config.ProjectSessionsRoot(cfg, projectID)
+	containerDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), projectID, "sessions")
 	planner := launch.Planner{
 		Config:       cfg,
 		ContainerDir: containerDir,
@@ -481,7 +483,7 @@ func (s *Starter) run(ctx context.Context, req SchedulerStartRunRequest, input w
 		},
 		OnEvent: func(evt runtime.Event) {
 			logger.Logf("%s", runprompt.FormatRuntimeEvent(evt))
-			if transcriptdiag.EnabledForProcess(plan.ActiveSettings.Debug) {
+			if transcriptdiag.Enabled(plan.ActiveSettings.Debug, os.Getenv) {
 				projected := runtimeview.EventFromRuntime(evt)
 				logger.Logf("%s", runprompt.FormatTranscriptProjectionDiagnostic(plan.Store.Meta().SessionID, projected))
 				logger.Logf("%s", runprompt.FormatTranscriptPublishDiagnostic(plan.Store.Meta().SessionID, projected))

--- a/server/workflowrunner/starter_test.go
+++ b/server/workflowrunner/starter_test.go
@@ -511,7 +511,7 @@ func TestWorkflowRuntimeCompactAndContinueAllowsCrossRole(t *testing.T) {
 	if len(runs) != 2 || runs[1].InterruptedAt != 0 || runs[1].CompletedAt == 0 || runs[0].SessionID != runs[1].SessionID {
 		t.Fatalf("runs = %+v, want cross-role compact_and_continue to complete in source session", runs)
 	}
-	containerDir := config.ProjectSessionsRoot(fixture.cfg, fixture.projectID)
+	containerDir := filepath.Join(filepath.Join(fixture.cfg.PersistenceRoot, "projects"), fixture.projectID, "sessions")
 	sourceDir, err := session.ResolveScopedSessionDir(containerDir, runs[1].SessionID)
 	if err != nil {
 		t.Fatalf("ResolveScopedSessionDir: %v", err)
@@ -536,7 +536,7 @@ func TestWorkflowRuntimeDefaultRoleClearsInvalidPersistedRoleBeforeValidation(t 
 		Sources:  map[string]string{"model": "test", "context_compaction_threshold_tokens": "test"},
 	}
 	fixture.rebuildStarter(t)
-	containerDir := config.ProjectSessionsRoot(fixture.cfg, fixture.projectID)
+	containerDir := filepath.Join(filepath.Join(fixture.cfg.PersistenceRoot, "projects"), fixture.projectID, "sessions")
 	source, err := session.Create(containerDir, filepath.Base(containerDir), fixture.cfg.WorkspaceRoot, fixture.metadata.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("create source session: %v", err)
@@ -668,7 +668,7 @@ func TestRemoveFanoutCloneDeletesOrphanedClone(t *testing.T) {
 		t.Fatalf("ListRuns = %+v, err %v", runs, err)
 	}
 
-	containerDir := config.ProjectSessionsRoot(fixture.cfg, fixture.projectID)
+	containerDir := filepath.Join(filepath.Join(fixture.cfg.PersistenceRoot, "projects"), fixture.projectID, "sessions")
 	cloneID, err := fixture.starter.cloneSourceSessionForFanout(containerDir, runs[0].SessionID)
 	if err != nil {
 		t.Fatalf("cloneSourceSessionForFanout: %v", err)
@@ -945,7 +945,7 @@ func (f starterFixture) assertRunSessionUsesTaskWorktree(t *testing.T, sessionID
 	if err != nil {
 		t.Fatalf("ResolvePersistedSession: %v", err)
 	}
-	if got, want := filepath.Dir(record.SessionDir), config.ProjectSessionsRoot(f.cfg, f.projectID); got != want {
+	if got, want := filepath.Dir(record.SessionDir), filepath.Join(filepath.Join(f.cfg.PersistenceRoot, "projects"), f.projectID, "sessions"); got != want {
 		t.Fatalf("session dir parent = %q, want project sessions root %q", got, want)
 	}
 	target, err := f.metadata.ResolveSessionExecutionTarget(context.Background(), sessionID)

--- a/server/workflowruntime/completion.go
+++ b/server/workflowruntime/completion.go
@@ -171,22 +171,18 @@ func SelectCompletionMode(mode config.WorkflowCompletionMode, caps llm.ProviderC
 	case config.WorkflowCompletionModeTool:
 		return CompletionModeTool, nil
 	case config.WorkflowCompletionModeStructuredOutput:
-		if !ProviderSupportsStructuredOutput(caps) {
+		if !caps.SupportsResponsesAPI {
 			return "", ErrStructuredOutputUnsupported
 		}
 		return CompletionModeStructuredOutput, nil
 	case config.WorkflowCompletionModeAuto, "":
-		if ProviderSupportsStructuredOutput(caps) {
+		if caps.SupportsResponsesAPI {
 			return CompletionModeStructuredOutput, nil
 		}
 		return CompletionModeTool, nil
 	default:
 		return "", fmt.Errorf("invalid workflow completion mode %q", mode)
 	}
-}
-
-func ProviderSupportsStructuredOutput(caps llm.ProviderCapabilities) bool {
-	return caps.SupportsResponsesAPI
 }
 
 func StructuredOutput(contract CompletionContract) (*llm.StructuredOutput, error) {

--- a/server/workflowstore/store_test.go
+++ b/server/workflowstore/store_test.go
@@ -4539,7 +4539,7 @@ func newTestStoreWithConfig(t *testing.T) (*Store, metadata.Binding, config.App)
 
 func createTestSession(t *testing.T, ctx context.Context, store *Store, binding metadata.Binding, cfg config.App) string {
 	t.Helper()
-	sessionRoot := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	sessionRoot := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	sessionStore, err := session.Create(sessionRoot, filepath.Base(cfg.WorkspaceRoot), cfg.WorkspaceRoot, store.metadata.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("session.Create: %v", err)

--- a/server/workflowsvc/events.go
+++ b/server/workflowsvc/events.go
@@ -34,14 +34,6 @@ func newWorkflowProjectEventBroker() *workflowProjectEventBroker {
 	return &workflowProjectEventBroker{subscribers: make(map[uint64]*workflowProjectSubscription)}
 }
 
-func (b *workflowProjectEventBroker) Subscribe(projectID string) (*workflowProjectSubscription, error) {
-	return b.subscribe(projectID, "")
-}
-
-func (b *workflowProjectEventBroker) SubscribeWorkflow(workflowID string) (*workflowProjectSubscription, error) {
-	return b.subscribe("", workflowID)
-}
-
 func (b *workflowProjectEventBroker) subscribe(projectID string, workflowID string) (*workflowProjectSubscription, error) {
 	sub := &workflowProjectSubscription{
 		projectID:  projectID,

--- a/server/workflowsvc/service.go
+++ b/server/workflowsvc/service.go
@@ -609,7 +609,7 @@ func (s *Service) ApproveWorkflowTask(ctx context.Context, req serverapi.Workflo
 	if transitionID == "" {
 		transitionID = strings.TrimSpace(req.TransitionID)
 	}
-	taskID, projectID, workflowID, err := s.taskIdentityForTransition(ctx, transitionID)
+	taskID, projectID, workflowID, err := s.store.TaskIdentityForTransition(ctx, workflow.TransitionID(transitionID))
 	if err != nil {
 		return serverapi.WorkflowTaskApproveResponse{}, err
 	}
@@ -743,10 +743,6 @@ func (s *Service) AnswerWorkflowTaskQuestion(ctx context.Context, req serverapi.
 	return err
 }
 
-func (s *Service) taskIdentityForTransition(ctx context.Context, transitionID string) (taskID string, projectID string, workflowID string, err error) {
-	return s.store.TaskIdentityForTransition(ctx, workflow.TransitionID(transitionID))
-}
-
 func sameTaskQuestionAnswerMemoRequest(a taskQuestionAnswerMemoRequest, b taskQuestionAnswerMemoRequest) bool {
 	return a.TaskID == b.TaskID &&
 		a.RunID == b.RunID &&
@@ -830,7 +826,7 @@ func (s *Service) ReplaceWorkflowTaskComment(ctx context.Context, req serverapi.
 	if err := req.Validate(); err != nil {
 		return err
 	}
-	taskID, projectID, workflowID, err := s.taskIdentityForComment(ctx, req.CommentID)
+	taskID, projectID, workflowID, err := s.store.TaskIdentityForComment(ctx, strings.TrimSpace(req.CommentID))
 	if err != nil {
 		return err
 	}
@@ -845,7 +841,7 @@ func (s *Service) DeleteWorkflowTaskComment(ctx context.Context, req serverapi.W
 	if err := req.Validate(); err != nil {
 		return err
 	}
-	taskID, projectID, workflowID, err := s.taskIdentityForComment(ctx, req.CommentID)
+	taskID, projectID, workflowID, err := s.store.TaskIdentityForComment(ctx, strings.TrimSpace(req.CommentID))
 	if err != nil {
 		return err
 	}
@@ -885,7 +881,7 @@ func (s *Service) SubscribeWorkflowProject(ctx context.Context, req serverapi.Wo
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	return s.events.Subscribe(strings.TrimSpace(req.ProjectID))
+	return s.events.subscribe(strings.TrimSpace(req.ProjectID), "")
 }
 
 func (s *Service) SubscribeWorkflow(ctx context.Context, req serverapi.WorkflowSubscribeRequest) (serverapi.WorkflowSubscription, error) {
@@ -896,7 +892,7 @@ func (s *Service) SubscribeWorkflow(ctx context.Context, req serverapi.WorkflowS
 	if _, err := s.GetWorkflow(ctx, serverapi.WorkflowGetRequest{WorkflowID: workflowID}); err != nil {
 		return nil, err
 	}
-	return s.events.SubscribeWorkflow(workflowID)
+	return s.events.subscribe("", workflowID)
 }
 
 func (s *Service) GetWorkflowTask(ctx context.Context, req serverapi.WorkflowTaskGetRequest) (serverapi.WorkflowTaskGetResponse, error) {
@@ -1154,10 +1150,6 @@ func workflowGraphSaveBlockers(blockers []workflowstore.WorkflowGraphSaveBlocker
 
 func commentRecord(row workflowstore.CommentRecord) serverapi.WorkflowTaskComment {
 	return serverapi.WorkflowTaskComment{ID: row.ID, TaskID: string(row.TaskID), Body: row.Body, Author: row.Author, AuthorID: row.AuthorID, CreatedAtUnixMs: row.CreatedAt, UpdatedAt: row.UpdatedAt}
-}
-
-func (s *Service) taskIdentityForComment(ctx context.Context, commentID string) (taskID string, projectID string, workflowID string, err error) {
-	return s.store.TaskIdentityForComment(ctx, strings.TrimSpace(commentID))
 }
 
 func inputFields(in []serverapi.WorkflowInputField) []workflow.InputField {

--- a/server/workflowsvc/service.go
+++ b/server/workflowsvc/service.go
@@ -1063,7 +1063,7 @@ func (s *Service) workflowGraphDraftDefinition(ctx context.Context, workflowID s
 }
 
 func workflowValidationResponse(workflowID workflow.WorkflowID, result workflow.ValidationResult) serverapi.WorkflowValidateResponse {
-	resp := serverapi.WorkflowValidateResponse{Valid: result.Valid()}
+	resp := serverapi.WorkflowValidateResponse{Valid: !result.HasBlockingErrors()}
 	resp.Errors = workflowview.ValidationErrors(string(workflowID), result.Errors)
 	return resp
 }

--- a/server/workflowview/board_order.go
+++ b/server/workflowview/board_order.go
@@ -28,7 +28,9 @@ func boardColumnNodes(def serverapi.WorkflowDefinition) []serverapi.WorkflowNode
 		}
 		unreachable = append(unreachable, node)
 	}
-	sortWorkflowNodesByKey(unreachable)
+	sort.SliceStable(unreachable, func(i, j int) bool {
+		return workflowNodeKeyLess(unreachable[i], unreachable[j])
+	})
 	return append(ordered, unreachable...)
 }
 
@@ -52,7 +54,9 @@ func newBoardColumnGraph(def serverapi.WorkflowDefinition) boardColumnGraph {
 			startNodeIDs = append(startNodeIDs, node.ID)
 		}
 	}
-	sortWorkflowNodeIDsByNodeKey(startNodeIDs, nodesByID)
+	sort.SliceStable(startNodeIDs, func(i, j int) bool {
+		return workflowNodeKeyLess(nodesByID[startNodeIDs[i]], nodesByID[startNodeIDs[j]])
+	})
 	groupSourceByID := make(map[string]string, len(def.TransitionGroups))
 	for _, group := range def.TransitionGroups {
 		groupSourceByID[group.ID] = group.SourceNodeID
@@ -69,7 +73,9 @@ func newBoardColumnGraph(def serverapi.WorkflowDefinition) boardColumnGraph {
 		outgoingBySource[sourceID] = append(outgoingBySource[sourceID], edge.TargetNodeID)
 	}
 	for sourceID, targetIDs := range outgoingBySource {
-		sortWorkflowNodeIDsByNodeKey(targetIDs, nodesByID)
+		sort.SliceStable(targetIDs, func(i, j int) bool {
+			return workflowNodeKeyLess(nodesByID[targetIDs[i]], nodesByID[targetIDs[j]])
+		})
 		outgoingBySource[sourceID] = dedupeStrings(targetIDs)
 	}
 	graph := boardColumnGraph{
@@ -161,7 +167,14 @@ func (g boardColumnGraph) topologicalVisibleNodeIDs(reachableVisibleIDs []string
 	orderedComponents := make([]int, 0, len(components))
 	emitted := make(map[int]bool, len(components))
 	for len(available) > 0 {
-		g.sortComponentIDsByKey(available, components)
+		sort.SliceStable(available, func(i, j int) bool {
+			leftTerminal := g.componentHasTerminalNode(components[available[i]])
+			rightTerminal := g.componentHasTerminalNode(components[available[j]])
+			if leftTerminal != rightTerminal {
+				return !leftTerminal
+			}
+			return workflowNodeKeyLess(g.nodesByID[components[available[i]][0]], g.nodesByID[components[available[j]][0]])
+		})
 		componentID := available[0]
 		available = available[1:]
 		if emitted[componentID] {
@@ -170,7 +183,14 @@ func (g boardColumnGraph) topologicalVisibleNodeIDs(reachableVisibleIDs []string
 		orderedComponents = append(orderedComponents, componentID)
 		emitted[componentID] = true
 		targetComponentIDs := mapIntKeys(componentEdges[componentID])
-		g.sortComponentIDsByKey(targetComponentIDs, components)
+		sort.SliceStable(targetComponentIDs, func(i, j int) bool {
+			leftTerminal := g.componentHasTerminalNode(components[targetComponentIDs[i]])
+			rightTerminal := g.componentHasTerminalNode(components[targetComponentIDs[j]])
+			if leftTerminal != rightTerminal {
+				return !leftTerminal
+			}
+			return workflowNodeKeyLess(g.nodesByID[components[targetComponentIDs[i]][0]], g.nodesByID[components[targetComponentIDs[j]][0]])
+		})
 		for _, targetComponentID := range targetComponentIDs {
 			indegree[targetComponentID]--
 			if indegree[targetComponentID] == 0 {
@@ -200,7 +220,9 @@ func (g boardColumnGraph) stronglyConnectedVisibleComponents(nodeIDs []string, p
 	nextIndex := 0
 	components := make([][]string, 0)
 	orderedNodeIDs := append([]string(nil), nodeIDs...)
-	sortWorkflowNodeIDsByNodeKey(orderedNodeIDs, g.nodesByID)
+	sort.SliceStable(orderedNodeIDs, func(i, j int) bool {
+		return workflowNodeKeyLess(g.nodesByID[orderedNodeIDs[i]], g.nodesByID[orderedNodeIDs[j]])
+	})
 	var visit func(string)
 	visit = func(nodeID string) {
 		indexByNodeID[nodeID] = nextIndex
@@ -209,7 +231,9 @@ func (g boardColumnGraph) stronglyConnectedVisibleComponents(nodeIDs []string, p
 		stack = append(stack, nodeID)
 		onStack[nodeID] = true
 		targetIDs := mapKeys(precedence[nodeID])
-		sortWorkflowNodeIDsByNodeKey(targetIDs, g.nodesByID)
+		sort.SliceStable(targetIDs, func(i, j int) bool {
+			return workflowNodeKeyLess(g.nodesByID[targetIDs[i]], g.nodesByID[targetIDs[j]])
+		})
 		for _, targetID := range targetIDs {
 			if _, seen := indexByNodeID[targetID]; !seen {
 				visit(targetID)
@@ -233,7 +257,9 @@ func (g boardColumnGraph) stronglyConnectedVisibleComponents(nodeIDs []string, p
 				break
 			}
 		}
-		sortWorkflowNodeIDsByNodeKey(component, g.nodesByID)
+		sort.SliceStable(component, func(i, j int) bool {
+			return workflowNodeKeyLess(g.nodesByID[component[i]], g.nodesByID[component[j]])
+		})
 		components = append(components, component)
 	}
 	for _, nodeID := range orderedNodeIDs {
@@ -242,17 +268,6 @@ func (g boardColumnGraph) stronglyConnectedVisibleComponents(nodeIDs []string, p
 		}
 	}
 	return components
-}
-
-func (g boardColumnGraph) sortComponentIDsByKey(componentIDs []int, components [][]string) {
-	sort.SliceStable(componentIDs, func(i, j int) bool {
-		leftTerminal := g.componentHasTerminalNode(components[componentIDs[i]])
-		rightTerminal := g.componentHasTerminalNode(components[componentIDs[j]])
-		if leftTerminal != rightTerminal {
-			return !leftTerminal
-		}
-		return workflowNodeKeyLess(g.nodesByID[components[componentIDs[i]][0]], g.nodesByID[components[componentIDs[j]][0]])
-	})
 }
 
 func (g boardColumnGraph) componentHasTerminalNode(component []string) bool {
@@ -285,20 +300,10 @@ func (g boardColumnGraph) visibleTargetsFrom(sourceID string) []string {
 		seenHidden[nodeID] = true
 		queue = append(queue, g.outgoingBySource[nodeID]...)
 	}
-	sortWorkflowNodeIDsByNodeKey(targets, g.nodesByID)
+	sort.SliceStable(targets, func(i, j int) bool {
+		return workflowNodeKeyLess(g.nodesByID[targets[i]], g.nodesByID[targets[j]])
+	})
 	return dedupeStrings(targets)
-}
-
-func sortWorkflowNodesByKey(nodes []serverapi.WorkflowNode) {
-	sort.SliceStable(nodes, func(i, j int) bool {
-		return workflowNodeKeyLess(nodes[i], nodes[j])
-	})
-}
-
-func sortWorkflowNodeIDsByNodeKey(nodeIDs []string, nodesByID map[string]serverapi.WorkflowNode) {
-	sort.SliceStable(nodeIDs, func(i, j int) bool {
-		return workflowNodeKeyLess(nodesByID[nodeIDs[i]], nodesByID[nodeIDs[j]])
-	})
 }
 
 func workflowNodeKeyLess(left serverapi.WorkflowNode, right serverapi.WorkflowNode) bool {

--- a/server/workflowview/service.go
+++ b/server/workflowview/service.go
@@ -174,7 +174,7 @@ func (s *Service) GetBoard(ctx context.Context, req serverapi.WorkflowBoardReque
 			Description:          def.Workflow.Description,
 			Version:              def.Workflow.Version,
 			IsProjectDefault:     link.ID != "" && link.IsDefault != 0,
-			ValidForTaskCreation: validation.Valid() && link.ID != "",
+			ValidForTaskCreation: !validation.HasBlockingErrors() && link.ID != "",
 			ValidationErrors:     ValidationErrors(def.Workflow.ID, validation.Errors),
 		})
 	}
@@ -784,7 +784,7 @@ func (s *Service) attentionItemFromCandidate(ctx context.Context, row attentionC
 			return serverapi.WorkflowAttentionItem{}, false, err
 		}
 		validation := workflow.ValidateDefinition(definitionForValidation(def), workflow.ValidationOptions{Context: workflow.ValidationContextExecution, RoleResolver: roleResolver})
-		if validation.Valid() {
+		if !validation.HasBlockingErrors() {
 			return serverapi.WorkflowAttentionItem{}, false, nil
 		}
 		return serverapi.WorkflowAttentionItem{ID: row.id, Kind: "validation_blocker", ProjectID: row.projectID, WorkflowID: row.workflowID, Message: fmt.Sprintf("Workflow %q is invalid for task start", def.Workflow.Name), OccurredAtUnixMs: row.occurredAtUnixMs}, true, nil
@@ -935,7 +935,7 @@ func workflowNodeByID(def serverapi.WorkflowDefinition) map[string]serverapi.Wor
 func workflowPickerItem(def serverapi.WorkflowDefinition, link sqlitegen.ProjectWorkflowLinkRecord, validation *workflow.ValidationResult) serverapi.WorkflowPickerItem {
 	item := serverapi.WorkflowPickerItem{WorkflowID: def.Workflow.ID, DisplayName: def.Workflow.Name, Description: def.Workflow.Description, Version: def.Workflow.Version, IsProjectDefault: link.ID != "" && link.IsDefault != 0, ValidForTaskCreation: link.ID != ""}
 	if validation != nil {
-		item.ValidForTaskCreation = link.ID != "" && validation.Valid()
+		item.ValidForTaskCreation = link.ID != "" && !validation.HasBlockingErrors()
 		item.ValidationErrors = ValidationErrors(def.Workflow.ID, validation.Errors)
 	}
 	return item
@@ -1663,7 +1663,7 @@ func (s *Service) validationAttentionItems(ctx context.Context, projectID string
 			return nil, err
 		}
 		validation := workflow.ValidateDefinition(definitionForValidation(def), workflow.ValidationOptions{Context: workflow.ValidationContextExecution, RoleResolver: roleResolver})
-		if validation.Valid() {
+		if !validation.HasBlockingErrors() {
 			continue
 		}
 		items = append(items, serverapi.WorkflowAttentionItem{ID: "validation_blocker:" + link.projectID + ":" + link.workflowID, Kind: "validation_blocker", ProjectID: link.projectID, WorkflowID: link.workflowID, Message: fmt.Sprintf("Workflow %q is invalid for task start", def.Workflow.Name), OccurredAtUnixMs: link.occurredAt})

--- a/server/workflowview/service.go
+++ b/server/workflowview/service.go
@@ -730,7 +730,7 @@ func (s *Service) attentionItemsPage(ctx context.Context, projectID string, page
 			}
 			items = append(items, item)
 			if len(items) == pageSize {
-				return items, attentionCandidatePageToken(projectID, candidate), nil
+				return items, attentionPageTokenFor(projectID, candidate.occurredAtUnixMs, candidate.id), nil
 			}
 		}
 		if !moreCandidates {
@@ -1441,10 +1441,6 @@ func attentionPageTokenFor(projectID string, occurredAtUnixMs int64, id string) 
 	return base64.RawURLEncoding.EncodeToString([]byte(strings.TrimSpace(projectID))) + "|" +
 		strconv.FormatInt(occurredAtUnixMs, 10) + "|" +
 		base64.RawURLEncoding.EncodeToString([]byte(id))
-}
-
-func attentionCandidatePageToken(projectID string, item attentionCandidateRow) string {
-	return attentionPageTokenFor(projectID, item.occurredAtUnixMs, item.id)
 }
 
 func (s *Service) approvalAttentionItems(ctx context.Context, projectID string, taskID string) ([]serverapi.WorkflowAttentionItem, error) {

--- a/server/worktree/git.go
+++ b/server/worktree/git.go
@@ -263,14 +263,6 @@ func (i *GitInspector) Prune(ctx context.Context, workspaceRoot string) error {
 	return err
 }
 
-func (i *GitInspector) DeleteBranch(ctx context.Context, workspaceRoot string, branchName string) error {
-	return i.deleteBranch(ctx, workspaceRoot, branchName, false)
-}
-
-func (i *GitInspector) ForceDeleteBranch(ctx context.Context, workspaceRoot string, branchName string) error {
-	return i.deleteBranch(ctx, workspaceRoot, branchName, true)
-}
-
 func (i *GitInspector) deleteBranch(ctx context.Context, workspaceRoot string, branchName string, force bool) error {
 	if i == nil {
 		return fmt.Errorf("git inspector is required")

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -433,7 +433,7 @@ func (s *Service) deleteTaskWorktreeBranch(ctx context.Context, workspaceRoot st
 	if branchName == "" {
 		return false, nil
 	}
-	if err := s.git.ForceDeleteBranch(ctx, workspaceRoot, branchName); err != nil {
+	if err := s.git.deleteBranch(ctx, workspaceRoot, branchName, true); err != nil {
 		return false, fmt.Errorf("delete task worktree branch %q: %w", branchName, err)
 	}
 	return true, nil
@@ -617,7 +617,7 @@ func (s *Service) cleanupFailedCreate(ctx context.Context, cleanup failedCreateC
 		collected = append(collected, err)
 	}
 	if cleanup.createdBranch && strings.TrimSpace(cleanup.branchName) != "" {
-		if err := s.git.DeleteBranch(cleanupCtx, cleanup.workspaceRoot, cleanup.branchName); err != nil {
+		if err := s.git.deleteBranch(cleanupCtx, cleanup.workspaceRoot, cleanup.branchName, false); err != nil {
 			collected = append(collected, fmt.Errorf("delete created branch %q for failed worktree create: %w", cleanup.branchName, err))
 		}
 	}
@@ -743,7 +743,7 @@ func (s *Service) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDele
 	branchDeleted := false
 	branchCleanupMessage := s.branchCleanupSkippedMessage(targetWorktree, req.DeleteBranch)
 	if s.shouldAttemptBranchCleanup(targetWorktree, req.DeleteBranch) {
-		if err := s.git.DeleteBranch(ctx, workspaceCtx.workspaceRoot, targetWorktree.git.BranchName); err != nil {
+		if err := s.git.deleteBranch(ctx, workspaceCtx.workspaceRoot, targetWorktree.git.BranchName, false); err != nil {
 			branchCleanupMessage = fmt.Sprintf("Kept branch %s: %v", targetWorktree.git.BranchName, err)
 		} else {
 			branchDeleted = true
@@ -899,7 +899,7 @@ func (s *Service) syncWorkspace(ctx context.Context, workspaceID string, workspa
 		if _, ok := seenRoots[strings.TrimSpace(record.CanonicalRoot)]; ok {
 			continue
 		}
-		if err := s.retargetSessionsFromMissingWorktree(ctx, strings.TrimSpace(workspaceID), strings.TrimSpace(workspaceRoot), record); err != nil {
+		if err := s.retargetSessionsFromWorktree(ctx, strings.TrimSpace(workspaceID), strings.TrimSpace(workspaceRoot), record, worktreeSessionRetargetOptions{reminder: worktreeReminderStateForExitedWorktree}); err != nil {
 			return nil, err
 		}
 		if err := s.metadata.DeleteWorktreeRecordByID(ctx, record.ID); err != nil {
@@ -946,10 +946,6 @@ type worktreeSessionRetargetOptions struct {
 type pendingWorktreeSessionRetarget struct {
 	sessionID      string
 	previousTarget clientui.SessionExecutionTarget
-}
-
-func (s *Service) retargetSessionsFromMissingWorktree(ctx context.Context, workspaceID string, workspaceRoot string, worktree metadata.WorktreeRecord) error {
-	return s.retargetSessionsFromWorktree(ctx, workspaceID, workspaceRoot, worktree, worktreeSessionRetargetOptions{reminder: worktreeReminderStateForExitedWorktree})
 }
 
 func (s *Service) retargetActiveSessionsFromDeletedWorktree(ctx context.Context, workspaceID string, workspaceRoot string, worktree metadata.WorktreeRecord, currentSessionID string) error {

--- a/server/worktree/service_part2_test.go
+++ b/server/worktree/service_part2_test.go
@@ -318,7 +318,7 @@ func newServiceTestEnv(t *testing.T) *serviceTestEnv {
 
 func createServiceTestSession(t *testing.T, store *metadata.Store, cfg config.App, binding metadata.Binding) *session.Store {
 	t.Helper()
-	projectSessionsDir := config.ProjectSessionsRoot(cfg, binding.ProjectID)
+	projectSessionsDir := filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), binding.ProjectID, "sessions")
 	sess, err := session.Create(projectSessionsDir, filepath.Base(projectSessionsDir), cfg.WorkspaceRoot, store.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
 		t.Fatalf("session.Create: %v", err)

--- a/server/worktree/service_part2_test.go
+++ b/server/worktree/service_part2_test.go
@@ -225,7 +225,7 @@ func TestRetargetSessionsFromMissingWorktreeRollsBackActiveSessionMetadataOnRunt
 	env.runtime.rebindCalls = nil
 	env.runtime.reminderCalls = nil
 
-	err = env.service.retargetSessionsFromMissingWorktree(env.ctx, env.binding.WorkspaceID, env.workspaceRoot, record)
+	err = env.service.retargetSessionsFromWorktree(env.ctx, env.binding.WorkspaceID, env.workspaceRoot, record, worktreeSessionRetargetOptions{reminder: worktreeReminderStateForExitedWorktree})
 	if err == nil || !strings.Contains(err.Error(), "runtime rebind failed") {
 		t.Fatalf("retargetSessionsFromMissingWorktree error = %v, want runtime rebind failed", err)
 	}

--- a/shared/clientui/lifecycle.go
+++ b/shared/clientui/lifecycle.go
@@ -64,14 +64,6 @@ func IdleRunLifecycle() RunLifecycle {
 	return RunLifecycle{Phase: RunLifecycleIdle}
 }
 
-func RunningRunLifecycle(mode RunMode) RunLifecycle {
-	return MustRunLifecycle(RunLifecycleRunning, mode)
-}
-
-func FinishedRunLifecycle(mode RunMode) RunLifecycle {
-	return MustRunLifecycle(RunLifecycleFinished, mode)
-}
-
 func (s RunLifecycle) Validate() error {
 	_, err := NewRunLifecycle(s.Phase, s.Mode)
 	return err

--- a/shared/clientui/lifecycle_test.go
+++ b/shared/clientui/lifecycle_test.go
@@ -9,11 +9,11 @@ func TestRunLifecycleTransitionTable(t *testing.T) {
 		wantRunning bool
 		wantGoal    bool
 	}{
-		{name: "run start", lifecycle: RunningRunLifecycle(RunModeTurn), wantRunning: true},
-		{name: "goal start", lifecycle: RunningRunLifecycle(RunModeGoalLoop), wantRunning: true, wantGoal: true},
-		{name: "run finish", lifecycle: FinishedRunLifecycle(RunModeTurn)},
-		{name: "interrupt", lifecycle: FinishedRunLifecycle(RunModeTurn)},
-		{name: "panic failure", lifecycle: FinishedRunLifecycle(RunModeTurn)},
+		{name: "run start", lifecycle: MustRunLifecycle(RunLifecycleRunning, RunModeTurn), wantRunning: true},
+		{name: "goal start", lifecycle: MustRunLifecycle(RunLifecycleRunning, RunModeGoalLoop), wantRunning: true, wantGoal: true},
+		{name: "run finish", lifecycle: MustRunLifecycle(RunLifecycleFinished, RunModeTurn)},
+		{name: "interrupt", lifecycle: MustRunLifecycle(RunLifecycleFinished, RunModeTurn)},
+		{name: "panic failure", lifecycle: MustRunLifecycle(RunLifecycleFinished, RunModeTurn)},
 		{name: "idle hydration", lifecycle: IdleRunLifecycle()},
 	}
 	for _, tt := range tests {

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -216,16 +216,8 @@ func EnabledToolIDs(v Settings) []toolspec.ID {
 	return ids
 }
 
-func ProjectsRoot(cfg App) string {
-	return filepath.Join(cfg.PersistenceRoot, "projects")
-}
-
-func ProjectRoot(cfg App, projectID string) string {
-	return filepath.Join(ProjectsRoot(cfg), projectID)
-}
-
 func ProjectSessionsRoot(cfg App, projectID string) string {
-	return filepath.Join(ProjectRoot(cfg, projectID), "sessions")
+	return filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), projectID, "sessions")
 }
 
 func ProjectSessionDir(cfg App, projectID string, sessionID string) string {

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -216,26 +216,18 @@ func EnabledToolIDs(v Settings) []toolspec.ID {
 	return ids
 }
 
-func ProjectSessionsRoot(cfg App, projectID string) string {
-	return filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), projectID, "sessions")
-}
-
 func ProjectSessionDir(cfg App, projectID string, sessionID string) string {
-	return filepath.Join(ProjectSessionsRoot(cfg, projectID), sessionID)
+	return filepath.Join(filepath.Join(filepath.Join(cfg.PersistenceRoot, "projects"), projectID, "sessions"), sessionID)
 }
 
 func GlobalAuthConfigPath(cfg App) string {
 	return filepath.Join(cfg.PersistenceRoot, globalAuthConfigName)
 }
 
-func ServerListenAddress(cfg App) string {
-	return net.JoinHostPort(cfg.Settings.ServerHost, strconv.Itoa(cfg.Settings.ServerPort))
-}
-
 func ServerRPCURL(cfg App) string {
-	return "ws://" + ServerListenAddress(cfg) + protocol.RPCPath
+	return "ws://" + net.JoinHostPort(cfg.Settings.ServerHost, strconv.Itoa(cfg.Settings.ServerPort)) + protocol.RPCPath
 }
 
 func ServerHTTPBaseURL(cfg App) string {
-	return "http://" + ServerListenAddress(cfg)
+	return "http://" + net.JoinHostPort(cfg.Settings.ServerHost, strconv.Itoa(cfg.Settings.ServerPort))
 }

--- a/shared/config/config_overlay.go
+++ b/shared/config/config_overlay.go
@@ -8,10 +8,6 @@ import (
 	"core/shared/toolspec"
 )
 
-func EffectiveReviewerSettings(settings Settings) ReviewerSettings {
-	return settings.Reviewer
-}
-
 func inheritReviewerDefaultsWithSources(settings *Settings, sources map[string]string) {
 	reviewerProviderSelectionExplicit := ReviewerUsesIndependentProviderSelection(*settings)
 	if strings.TrimSpace(settings.Reviewer.Model) == "" {

--- a/shared/config/config_overlay.go
+++ b/shared/config/config_overlay.go
@@ -190,10 +190,6 @@ func hasAnyConfiguredSource(sources map[string]string, keys ...string) bool {
 	return false
 }
 
-func NormalizeSettingsForPersistence(settings Settings) (Settings, error) {
-	return NormalizeSettingsForPersistenceWithSources(settings, nil)
-}
-
 func NormalizeSettingsForPersistenceWithSources(settings Settings, sources map[string]string) (Settings, error) {
 	normalized := settings
 	if normalized.EnabledTools == nil {

--- a/shared/config/config_part2_test.go
+++ b/shared/config/config_part2_test.go
@@ -361,7 +361,7 @@ func TestNormalizeSettingsForPersistencePreservesReviewerCapabilityFalseWithoutS
 	settings.Reviewer.ProviderCapabilities.SupportsResponsesAPI = false
 	settings.Reviewer.ProviderCapabilities.SupportsPromptCacheKey = false
 
-	normalized, err := NormalizeSettingsForPersistence(settings)
+	normalized, err := NormalizeSettingsForPersistenceWithSources(settings, nil)
 	if err != nil {
 		t.Fatalf("normalize settings for persistence: %v", err)
 	}

--- a/shared/config/config_part2_test.go
+++ b/shared/config/config_part2_test.go
@@ -196,7 +196,7 @@ provider_id = "reviewer-provider"
 supports_responses_api = false
 supports_prompt_cache_key = false
 `, LoadOptions{})
-	reviewer := EffectiveReviewerSettings(cfg.Settings)
+	reviewer := cfg.Settings.Reviewer
 	if reviewer.ModelCapabilities.SupportsReasoningEffort || reviewer.ModelCapabilities.SupportsVisionInputs {
 		t.Fatalf("expected explicit false reviewer model capabilities to survive effective helper, got %+v", reviewer.ModelCapabilities)
 	}

--- a/shared/config/config_part3_test.go
+++ b/shared/config/config_part3_test.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"errors"
+	"net"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
@@ -340,7 +342,7 @@ func TestLoadServerHostPortPrecedenceAndValidation(t *testing.T) {
 	}
 	assertConfigSource(t, cfg, "server_host", "env")
 	assertConfigSource(t, cfg, "server_port", "env")
-	if got := ServerListenAddress(cfg); got != "[::1]:65432" {
+	if got := net.JoinHostPort(cfg.Settings.ServerHost, strconv.Itoa(cfg.Settings.ServerPort)); got != "[::1]:65432" {
 		t.Fatalf("ServerListenAddress = %q, want [::1]:65432", got)
 	}
 	if got := ServerHTTPBaseURL(cfg); got != "http://[::1]:65432" {

--- a/shared/config/config_part3_test.go
+++ b/shared/config/config_part3_test.go
@@ -164,7 +164,7 @@ func TestNormalizeSettingsForPersistence_AllowsDisabledThinkingWithReviewerInher
 		VerboseOutput:  false,
 	}
 
-	normalized, err := NormalizeSettingsForPersistence(settings)
+	normalized, err := NormalizeSettingsForPersistenceWithSources(settings, nil)
 	if err != nil {
 		t.Fatalf("normalize settings for persistence: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestNormalizeSettingsForPersistence_AllowsProviderOverrideWithExplicitPersi
 	settings.Model = "my-team-alias"
 	settings.ProviderOverride = "openai"
 
-	normalized, err := NormalizeSettingsForPersistence(settings)
+	normalized, err := NormalizeSettingsForPersistenceWithSources(settings, nil)
 	if err != nil {
 		t.Fatalf("normalize settings for persistence: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestNormalizeSettingsForPersistenceRejectsModelContextWindowBelowMinimum(t 
 	settings.ModelContextWindow = 39999
 	settings.ContextCompactionThresholdTokens = 30000
 
-	if _, err := NormalizeSettingsForPersistence(settings); err == nil {
+	if _, err := NormalizeSettingsForPersistenceWithSources(settings, nil); err == nil {
 		t.Fatal("expected model_context_window below minimum validation error")
 	} else if !errors.Is(err, errModelContextWindowBelowMinimum) {
 		t.Fatalf("expected model context window minimum validation detail, got %v", err)

--- a/shared/config/config_registry.go
+++ b/shared/config/config_registry.go
@@ -1199,7 +1199,7 @@ func parseSubagentDescription(raw settingsFile) (string, error) {
 	if !ok {
 		return "", &SettingsKeyTypeError{Key: strings.Join([]string{"description"}, "."), ExpectedType: "string"}
 	}
-	description := SanitizeSubagentDescription(text)
+	description := strings.Join(strings.Fields(text), " ")
 	if len([]rune(description)) > MaxSubagentDescriptionChars {
 		return "", fmt.Errorf("%w: must be <= %d characters after whitespace normalization", errSubagentDescriptionTooLong, MaxSubagentDescriptionChars)
 	}

--- a/shared/config/config_settings_file.go
+++ b/shared/config/config_settings_file.go
@@ -128,7 +128,7 @@ func WriteSettingsFileForOnboardingWithOptions(settings Settings, options Onboar
 	if err != nil {
 		return "", err
 	}
-	normalized, err := NormalizeSettingsForPersistence(settings)
+	normalized, err := NormalizeSettingsForPersistenceWithSources(settings, nil)
 	if err != nil {
 		return "", err
 	}

--- a/shared/config/subagents.go
+++ b/shared/config/subagents.go
@@ -75,10 +75,6 @@ func IsSubagentRoleNameShape(raw string) bool {
 	return true
 }
 
-func SanitizeSubagentDescription(raw string) string {
-	return strings.Join(strings.Fields(raw), " ")
-}
-
 func SubagentRoleCallable(role SubagentRole) bool {
 	return !role.AgentCallableSet || role.AgentCallable
 }

--- a/shared/rpcwire/websocket.go
+++ b/shared/rpcwire/websocket.go
@@ -65,7 +65,7 @@ func (WebSocketTransport) Dial(ctx context.Context, endpoint Endpoint) (Conn, er
 		_ = rawConn.Close()
 		return nil, err
 	}
-	adapter.attach(socket)
+	adapter.socket = socket
 	adapter.startReadLoop(socket)
 	return adapter, nil
 }
@@ -78,7 +78,7 @@ func (WebSocketTransport) Handler(handler func(context.Context, Conn)) http.Hand
 		if err != nil {
 			return
 		}
-		adapter.attach(socket)
+		adapter.socket = socket
 		defer func() { _ = adapter.Close() }()
 		adapter.startReadLoop(socket)
 		handler(r.Context(), adapter)
@@ -100,10 +100,6 @@ func newWebSocketConn() *webSocketConn {
 		events: make(chan Event, 16),
 		closed: make(chan struct{}),
 	}
-}
-
-func (c *webSocketConn) attach(socket *gws.Conn) {
-	c.socket = socket
 }
 
 func (c *webSocketConn) Send(ctx context.Context, frame Frame) error {

--- a/shared/textutil/textutil.go
+++ b/shared/textutil/textutil.go
@@ -10,11 +10,3 @@ func FirstNonEmpty(values ...string) string {
 	}
 	return ""
 }
-
-func NormalizeCRLF(input string) string {
-	return strings.ReplaceAll(input, "\r\n", "\n")
-}
-
-func SplitLinesCRLF(input string) []string {
-	return strings.Split(NormalizeCRLF(input), "\n")
-}

--- a/shared/textutil/textutil_test.go
+++ b/shared/textutil/textutil_test.go
@@ -1,18 +1,21 @@
 package textutil
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestNormalizeCRLF(t *testing.T) {
-	if got := NormalizeCRLF("a\r\nb\r\n"); got != "a\nb\n" {
+	if got := strings.ReplaceAll("a\r\nb\r\n", "\r\n", "\n"); got != "a\nb\n" {
 		t.Fatalf("unexpected normalization: %q", got)
 	}
-	if got := NormalizeCRLF("a\rb"); got != "a\rb" {
+	if got := strings.ReplaceAll("a\rb", "\r\n", "\n"); got != "a\rb" {
 		t.Fatalf("unexpected single-CR normalization: %q", got)
 	}
 }
 
 func TestSplitLinesCRLF(t *testing.T) {
-	got := SplitLinesCRLF("a\r\nb\n")
+	got := strings.Split(strings.ReplaceAll("a\r\nb\n", "\r\n", "\n"), "\n")
 	if len(got) != 3 || got[0] != "a" || got[1] != "b" || got[2] != "" {
 		t.Fatalf("unexpected split result: %#v", got)
 	}

--- a/shared/transcript/entry_compare.go
+++ b/shared/transcript/entry_compare.go
@@ -31,7 +31,7 @@ type EntryPayload struct {
 func EntryPayloadEqual(left, right EntryPayload) bool {
 	return NormalizeEntryVisibility(left.Visibility) == NormalizeEntryVisibility(right.Visibility) &&
 		strings.TrimSpace(left.RollbackTargetID) == strings.TrimSpace(right.RollbackTargetID) &&
-		NormalizeEntryRole(left.Role) == NormalizeEntryRole(right.Role) &&
+		strings.ToLower(strings.TrimSpace(left.Role)) == strings.ToLower(strings.TrimSpace(right.Role)) &&
 		left.Text == right.Text &&
 		left.OngoingText == right.OngoingText &&
 		strings.TrimSpace(left.Phase) == strings.TrimSpace(right.Phase) &&

--- a/shared/transcript/patchformat/parse.go
+++ b/shared/transcript/patchformat/parse.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-
-	"core/shared/textutil"
 )
 
 func Parse(src string) (Document, error) {
@@ -133,7 +131,7 @@ func (s *scanner) consumeMarker(v string) bool {
 }
 
 func splitRawLines(in string) []string {
-	in = textutil.NormalizeCRLF(in)
+	in = strings.ReplaceAll(in, "\r\n", "\n")
 	reader := bufio.NewScanner(bytes.NewBufferString(in))
 	out := []string{}
 	for reader.Scan() {

--- a/shared/transcript/patchformat/render.go
+++ b/shared/transcript/patchformat/render.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-
-	"core/shared/textutil"
 )
 
 func Render(src, cwd string) RenderedPatch {
@@ -27,14 +25,14 @@ func Raw(src string) RenderedPatch {
 	if trimmed == "" {
 		return RenderedPatch{SummaryLines: summary, DetailLines: detail}
 	}
-	for _, line := range textutil.SplitLinesCRLF(trimmed) {
+	for _, line := range strings.Split(strings.ReplaceAll(trimmed, "\r\n", "\n"), "\n") {
 		detail = append(detail, RenderedLine{Kind: RenderedLineKindRaw, Text: line, FileIndex: -1})
 	}
 	return RenderedPatch{SummaryLines: summary, DetailLines: detail}
 }
 
 func StripEditedLabel(text string) string {
-	lines := textutil.SplitLinesCRLF(strings.TrimSpace(text))
+	lines := strings.Split(strings.ReplaceAll(strings.TrimSpace(text), "\r\n", "\n"), "\n")
 	if len(lines) == 0 {
 		return ""
 	}

--- a/shared/transcript/roles.go
+++ b/shared/transcript/roles.go
@@ -1,7 +1,5 @@
 package transcript
 
-import "strings"
-
 type EntryRole string
 
 // EntryRoleCompactionSummary marks a persisted compaction or handoff summary.
@@ -28,7 +26,3 @@ const EntryRoleInterruption EntryRole = "interruption"
 
 // EntryRoleGoalFeedback marks user-facing goal lifecycle notices.
 const EntryRoleGoalFeedback EntryRole = "goal_feedback"
-
-func NormalizeEntryRole(role string) string {
-	return strings.ToLower(strings.TrimSpace(role))
-}

--- a/shared/transcriptdiag/diag.go
+++ b/shared/transcriptdiag/diag.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -33,10 +32,6 @@ func Enabled(debug bool, getenv func(string) string) bool {
 		return true
 	}
 	return EnabledFromEnv(getenv)
-}
-
-func EnabledForProcess(debug bool) bool {
-	return Enabled(debug, os.Getenv)
 }
 
 func EntriesDigest(entries []clientui.ChatEntry) string {

--- a/shared/transcriptdiag/diag_test.go
+++ b/shared/transcriptdiag/diag_test.go
@@ -11,14 +11,14 @@ func TestEventDigestIncludesRunLifecycleMode(t *testing.T) {
 		Kind:   clientui.EventRunStateChanged,
 		StepID: "step-1",
 		RunState: &clientui.RunState{
-			Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeTurn),
+			Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn),
 			RunID:     "run-1",
 			Status:    clientui.RunStatusRunning,
 		},
 	}
 	goal := base
 	goal.RunState = &clientui.RunState{
-		Lifecycle: clientui.RunningRunLifecycle(clientui.RunModeGoalLoop),
+		Lifecycle: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeGoalLoop),
 		RunID:     "run-1",
 		Status:    clientui.RunStatusRunning,
 	}


### PR DESCRIPTION
## What

Removes ~109 trivial wrapper functions/methods across the Go codebase and inlines them at their call sites. These are pure forwarders, renames, parameter unpack/reorder helpers, getters, and 1-3 line passthroughs with no real logic.

**Net: −437 lines** (219 files, +1189 / −1626). No product behavior change — purely a readability/indirection cleanup.

## How it was scoped

A type-aware AST analysis (go/packages, not regex) classified every trivial-looking function and filtered to what is *safe* to remove — excluding mandatory interface methods (`tea.Model.Init`, `fmt.Stringer.String`, `Unwrap` for `errors.Is/As`, …), func-values, and inlines that would be inaccessible cross-package.

## What was inlined

- **87 same-package forwarders** — runtime intent constructors / snapshot getters / steering helpers, plus config / session / tools / workflow / cli / shared forwards.
- **12 cross-package trivial helpers** — `textutil.NormalizeCRLF/SplitLinesCRLF`, `transcript.NormalizeEntryRole`, `transcriptdiag.EnabledForProcess`, `config.ProjectSessionsRoot/ServerListenAddress/EffectiveReviewerSettings`, `workflow.ValidationResult.Valid`, `input.DisplayWidth`, `tools.FormatToolResultForTranscript`, `clientui.Running/FinishedRunLifecycle`, `prompts.MainSystemPrompt`.
- **10 test-only convenience wrappers** — inlined into their test call sites (e.g. `shouldAutoCompact`→`shouldAutoCompactWithContext(ctx)`, `ActiveToolIDs`→`ActiveToolIDsForPlan`).

## Intentionally retained

To keep the build green and behavior identical, the following are left in place:
- Cross-package public accessors whose bodies touch unexported state (inlining would not compile).
- Deliberate facade re-export packages (`server/llm`, `server/auth`, `server/bootstrap`, `onboarding`).
- `Unwrap` methods (drive `errors.Is/As`), interface methods, and public API constructors (`core.New`, `DialRemoteURL`, `SetGoal`, …).
- Architecture-boundary wrappers guarded by tests (e.g. `Engine.AppendCommittedEntry`, kept so `AppendCommittedEntryWithOngoingText` stays behind the output-boundary guard), plus platform `*_unix.go` seams and addressability cases.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...` (74 packages), and `./scripts/build.sh` all pass.
