### PR TITLE
feat: support collaborative external runtime steering

### DIFF
--- a/apps/desktop/src/features/workflows/WorkflowLibraryRoute.test.tsx
+++ b/apps/desktop/src/features/workflows/WorkflowLibraryRoute.test.tsx
@@ -118,7 +118,7 @@ describe("WorkflowLibraryRoute", () => {
 
     expect(await screen.findByRole("button", { name: "Delivery Updated rev 2" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Delivery rev 1" })).not.toBeInTheDocument();
-  });
+  }, 10000);
 
   it("opens existing workflow delete confirmation flow from the workflow picker context menu", async () => {
     const opened: NativeDialogWindowOptions[] = [];

--- a/cli/app/internal/runtimeattach/activity.go
+++ b/cli/app/internal/runtimeattach/activity.go
@@ -3,6 +3,7 @@ package runtimeattach
 import (
 	"context"
 	"errors"
+	"strings"
 
 	servicecontract "core/shared/apicontract"
 	"core/shared/serverapi"
@@ -12,6 +13,7 @@ type ActivityRequest struct {
 	SessionID       string
 	Runtime         servicecontract.SessionRuntimeService
 	LeaseID         string
+	Mode            serverapi.SessionRuntimeAttachMode
 	ReadOnly        bool
 	SessionActivity servicecontract.SessionActivityService
 	PromptActivity  servicecontract.PromptActivityService
@@ -27,7 +29,7 @@ func SubscribeActivities(ctx context.Context, req ActivityRequest) (Activities, 
 		releaseIfOwned(req)
 		return Activities{}, errors.New("session activity service is required")
 	}
-	if req.PromptActivity == nil && !req.ReadOnly {
+	if req.PromptActivity == nil && shouldSubscribePromptActivity(req) {
 		releaseIfOwned(req)
 		return Activities{}, errors.New("prompt activity service is required")
 	}
@@ -36,7 +38,7 @@ func SubscribeActivities(ctx context.Context, req ActivityRequest) (Activities, 
 		releaseIfOwned(req)
 		return Activities{}, err
 	}
-	if req.ReadOnly {
+	if !shouldSubscribePromptActivity(req) {
 		return Activities{Session: sessionSub}, nil
 	}
 	promptSub, err := req.PromptActivity.SubscribePromptActivity(ctx, serverapi.PromptActivitySubscribeRequest{SessionID: req.SessionID})
@@ -49,8 +51,12 @@ func SubscribeActivities(ctx context.Context, req ActivityRequest) (Activities, 
 }
 
 func releaseIfOwned(req ActivityRequest) {
-	if req.ReadOnly {
+	if req.ReadOnly || req.Mode == serverapi.SessionRuntimeAttachModeCollaborative || strings.TrimSpace(req.LeaseID) == "" {
 		return
 	}
 	Release(req.Runtime, req.SessionID, req.LeaseID)
+}
+
+func shouldSubscribePromptActivity(req ActivityRequest) bool {
+	return !req.ReadOnly && req.Mode != serverapi.SessionRuntimeAttachModeNoControl
 }

--- a/cli/app/internal/runtimeattach/activity_test.go
+++ b/cli/app/internal/runtimeattach/activity_test.go
@@ -151,3 +151,43 @@ func TestSubscribeActivitiesReadOnlyDoesNotRequirePromptActivity(t *testing.T) {
 		t.Fatal("expected no prompt subscription for read-only attach")
 	}
 }
+
+func TestSubscribeActivitiesCollaborativeSubscribesPromptActivityWithoutLease(t *testing.T) {
+	sessionSub := &fakeSessionActivitySubscription{}
+	promptSub := fakePromptActivitySubscription{}
+	sessionActivity := &fakeSessionActivityService{sub: sessionSub}
+	promptActivity := &fakePromptActivityService{sub: promptSub}
+	activities, err := SubscribeActivities(context.Background(), ActivityRequest{
+		SessionID:       "session-1",
+		Mode:            serverapi.SessionRuntimeAttachModeCollaborative,
+		SessionActivity: sessionActivity,
+		PromptActivity:  promptActivity,
+	})
+	if err != nil {
+		t.Fatalf("SubscribeActivities: %v", err)
+	}
+	if activities.Session != sessionSub || activities.Prompt == nil {
+		t.Fatalf("activities = %+v, want session and prompt subscriptions", activities)
+	}
+	if len(promptActivity.subscribeRequests) != 1 || promptActivity.subscribeRequests[0].SessionID != "session-1" {
+		t.Fatalf("prompt requests = %#v, want collaborative prompt subscription", promptActivity.subscribeRequests)
+	}
+}
+
+func TestSubscribeActivitiesNoControlDoesNotRequirePromptActivity(t *testing.T) {
+	sessionSub := &fakeSessionActivitySubscription{}
+	activities, err := SubscribeActivities(context.Background(), ActivityRequest{
+		SessionID:       "session-1",
+		Mode:            serverapi.SessionRuntimeAttachModeNoControl,
+		SessionActivity: &fakeSessionActivityService{sub: sessionSub},
+	})
+	if err != nil {
+		t.Fatalf("SubscribeActivities: %v", err)
+	}
+	if activities.Session != sessionSub {
+		t.Fatal("expected session subscription")
+	}
+	if activities.Prompt != nil {
+		t.Fatal("expected no prompt subscription for no-control attach")
+	}
+}

--- a/cli/app/internal/runtimeattach/lease.go
+++ b/cli/app/internal/runtimeattach/lease.go
@@ -28,9 +28,11 @@ type Request struct {
 }
 
 type Lease struct {
-	ID       string
-	ReadOnly bool
-	Recover  func(context.Context) (string, error)
+	ID                string
+	Mode              serverapi.SessionRuntimeAttachMode
+	AllowedOperations []serverapi.SessionRuntimeOperation
+	ReadOnly          bool
+	Recover           func(context.Context) (string, error)
 }
 
 func Activate(ctx context.Context, service servicecontract.SessionRuntimeService, req Request) (Lease, error) {
@@ -41,26 +43,59 @@ func Activate(ctx context.Context, service servicecontract.SessionRuntimeService
 	if err != nil {
 		return Lease{}, err
 	}
-	if resp.ReadOnly {
-		return Lease{ReadOnly: true}, nil
+	mode := normalizeAttachMode(resp)
+	if mode == serverapi.SessionRuntimeAttachModeNoControl {
+		return Lease{Mode: mode, ReadOnly: true}, nil
+	}
+	if mode == serverapi.SessionRuntimeAttachModeCollaborative {
+		return Lease{
+			Mode:              mode,
+			AllowedOperations: collaborativeOperationsOrDefault(resp.AllowedOperations),
+		}, nil
 	}
 	leaseID, err := normalizeLeaseID(resp.LeaseID)
 	if err != nil {
 		return Lease{}, err
 	}
 	return Lease{
-		ID: leaseID,
+		ID:   leaseID,
+		Mode: serverapi.SessionRuntimeAttachModeController,
 		Recover: func(ctx context.Context) (string, error) {
 			resp, err := service.ActivateSessionRuntime(ctx, activateRequest(req))
 			if err != nil {
 				return "", err
 			}
-			if resp.ReadOnly {
+			if normalizeAttachMode(resp) != serverapi.SessionRuntimeAttachModeController {
 				return "", ErrReadOnlyControllerLease
 			}
 			return normalizeLeaseID(resp.LeaseID)
 		},
 	}, nil
+}
+
+func normalizeAttachMode(resp serverapi.SessionRuntimeActivateResponse) serverapi.SessionRuntimeAttachMode {
+	switch resp.Mode {
+	case serverapi.SessionRuntimeAttachModeController, serverapi.SessionRuntimeAttachModeCollaborative, serverapi.SessionRuntimeAttachModeNoControl:
+		return resp.Mode
+	}
+	if resp.ReadOnly {
+		return serverapi.SessionRuntimeAttachModeNoControl
+	}
+	if strings.TrimSpace(resp.LeaseID) != "" {
+		return serverapi.SessionRuntimeAttachModeController
+	}
+	return serverapi.SessionRuntimeAttachModeController
+}
+
+func collaborativeOperationsOrDefault(operations []serverapi.SessionRuntimeOperation) []serverapi.SessionRuntimeOperation {
+	if len(operations) > 0 {
+		return append([]serverapi.SessionRuntimeOperation(nil), operations...)
+	}
+	return []serverapi.SessionRuntimeOperation{
+		serverapi.SessionRuntimeOperationSubmitUserTurn,
+		serverapi.SessionRuntimeOperationQueueUserMessage,
+		serverapi.SessionRuntimeOperationPromptAnswer,
+	}
 }
 
 func Release(service servicecontract.SessionRuntimeService, sessionID string, leaseID string) {

--- a/cli/app/internal/runtimeattach/lease_test.go
+++ b/cli/app/internal/runtimeattach/lease_test.go
@@ -112,6 +112,7 @@ func TestActivateAcceptsCollaborativeWithoutLease(t *testing.T) {
 	service := &fakeRuntimeService{activateResponses: []serverapi.SessionRuntimeActivateResponse{{
 		Mode:              serverapi.SessionRuntimeAttachModeCollaborative,
 		AllowedOperations: operations,
+		ReadOnly:          true,
 	}}}
 	lease, err := Activate(context.Background(), service, Request{NewClientRequestID: fixedIDs("request-1")})
 	if err != nil {

--- a/cli/app/internal/runtimeattach/lease_test.go
+++ b/cli/app/internal/runtimeattach/lease_test.go
@@ -104,6 +104,27 @@ func TestActivateRecoverReportsReadOnlyTransition(t *testing.T) {
 	}
 }
 
+func TestActivateAcceptsCollaborativeWithoutLease(t *testing.T) {
+	operations := []serverapi.SessionRuntimeOperation{
+		serverapi.SessionRuntimeOperationSubmitUserTurn,
+		serverapi.SessionRuntimeOperationQueueUserMessage,
+	}
+	service := &fakeRuntimeService{activateResponses: []serverapi.SessionRuntimeActivateResponse{{
+		Mode:              serverapi.SessionRuntimeAttachModeCollaborative,
+		AllowedOperations: operations,
+	}}}
+	lease, err := Activate(context.Background(), service, Request{NewClientRequestID: fixedIDs("request-1")})
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if lease.Mode != serverapi.SessionRuntimeAttachModeCollaborative || lease.ReadOnly || lease.ID != "" {
+		t.Fatalf("lease = %+v, want collaborative no lease and not read-only", lease)
+	}
+	if !reflect.DeepEqual(lease.AllowedOperations, operations) {
+		t.Fatalf("allowed operations = %#v, want %#v", lease.AllowedOperations, operations)
+	}
+}
+
 func TestActivateRejectsEmptyLease(t *testing.T) {
 	service := &fakeRuntimeService{activateResponses: []serverapi.SessionRuntimeActivateResponse{{LeaseID: " "}}}
 	_, err := Activate(context.Background(), service, Request{NewClientRequestID: fixedIDs("request-1")})
@@ -112,17 +133,20 @@ func TestActivateRejectsEmptyLease(t *testing.T) {
 	}
 }
 
-func TestActivateAcceptsReadOnlyWithoutLease(t *testing.T) {
+func TestActivateTreatsLegacyReadOnlyWithoutLeaseAsNoControl(t *testing.T) {
 	service := &fakeRuntimeService{activateResponses: []serverapi.SessionRuntimeActivateResponse{{ReadOnly: true}}}
 	lease, err := Activate(context.Background(), service, Request{NewClientRequestID: fixedIDs("request-1")})
 	if err != nil {
 		t.Fatalf("Activate: %v", err)
 	}
 	if !lease.ReadOnly {
-		t.Fatal("expected read-only lease")
+		t.Fatal("expected legacy read-only response to remain no-control")
 	}
-	if lease.ID != "" {
-		t.Fatalf("lease id = %q, want empty", lease.ID)
+	if lease.Mode != serverapi.SessionRuntimeAttachModeNoControl {
+		t.Fatalf("mode = %q, want no-control", lease.Mode)
+	}
+	if len(lease.AllowedOperations) != 0 {
+		t.Fatalf("allowed operations = %#v, want none for no-control", lease.AllowedOperations)
 	}
 }
 

--- a/cli/app/internal/runtimestate/runtime_events.go
+++ b/cli/app/internal/runtimestate/runtime_events.go
@@ -89,9 +89,10 @@ const (
 )
 
 type RuntimeRunStateReduction struct {
-	State    RuntimeRunState
-	Activity RuntimeActivityCommand
-	Err      error
+	State           RuntimeRunState
+	Activity        RuntimeActivityCommand
+	ExternalRuntime *clientui.ExternalRuntimeStatus
+	Err             error
 }
 
 type RuntimeDraftInputCommandKind uint8
@@ -105,6 +106,7 @@ type RuntimePendingInputReduction struct {
 	State                PendingInputState
 	DraftCommand         RuntimeDraftInputCommandKind
 	ConsumedQueueItemIDs []string
+	RestoredText         string
 }
 
 type RuntimeReasoningStreamCommandKind uint8
@@ -233,8 +235,41 @@ func ReduceRuntimeRunStateEvent(state RuntimeRunState, activityRunning bool, evt
 		if activityRunning {
 			reduction.Activity = RuntimeActivityIdle
 		}
+	case clientui.EventExternalRuntimeStatus:
+		reduction.ExternalRuntime = cloneExternalRuntimeStatus(evt.ExternalRuntimeStatus)
+		if externalRuntimeBusy(evt.ExternalRuntimeStatus) {
+			reduction.Activity = RuntimeActivityRunning
+			return reduction
+		}
+		if reduction.State.Run.IsRunning() {
+			reduction.Activity = RuntimeActivityRunning
+			return reduction
+		}
+		if activityRunning {
+			reduction.Activity = RuntimeActivityIdle
+		}
 	}
 	return reduction
+}
+
+func cloneExternalRuntimeStatus(status *clientui.ExternalRuntimeStatus) *clientui.ExternalRuntimeStatus {
+	if status == nil {
+		return nil
+	}
+	next := *status
+	return &next
+}
+
+func externalRuntimeBusy(status *clientui.ExternalRuntimeStatus) bool {
+	if status == nil {
+		return false
+	}
+	switch status.State {
+	case clientui.ExternalRuntimeStateOwnerRunning, clientui.ExternalRuntimeStateDraining, clientui.ExternalRuntimeStateClosing:
+		return true
+	default:
+		return false
+	}
 }
 
 func ReduceRuntimePendingInputEvent(input PendingInputState, evt clientui.Event) RuntimePendingInputReduction {
@@ -258,8 +293,47 @@ func ReduceRuntimePendingInputEvent(input PendingInputState, evt clientui.Event)
 			reduction.State.LockedInjectID = ""
 			reduction.State.Submission = InputSubmissionUnlocked
 		}
+	case clientui.EventQueuedUserMessageStatus:
+		status := evt.QueuedUserMessageStatus
+		if status == nil {
+			break
+		}
+		switch status.Status {
+		case clientui.QueuedUserMessageSubmitted, clientui.QueuedUserMessageDiscarded:
+			if _, removed := removePendingQueuedUserMessageByStatus(&reduction.State.PendingInjected, status); removed {
+				reduction.consumeQueuedStatusIDs(status)
+				reduction.unlockSubmittedPendingInput(status.QueueItemID)
+			}
+		case clientui.QueuedUserMessageFailed:
+			if _, removed := removePendingQueuedUserMessageByStatus(&reduction.State.PendingInjected, status); removed {
+				reduction.consumeQueuedStatusIDs(status)
+				reduction.unlockSubmittedPendingInput(status.QueueItemID)
+				reduction.RestoredText = strings.TrimSpace(status.RestoreText)
+			}
+		}
 	}
 	return reduction
+}
+
+func (reduction *RuntimePendingInputReduction) consumeQueuedStatusIDs(status *clientui.QueuedUserMessageStatusEvent) {
+	if reduction == nil || status == nil {
+		return
+	}
+	if id := strings.TrimSpace(status.QueueItemID); id != "" {
+		reduction.ConsumedQueueItemIDs = append(reduction.ConsumedQueueItemIDs, id)
+	}
+	if id := strings.TrimSpace(status.ClientRequestID); id != "" {
+		reduction.ConsumedQueueItemIDs = append(reduction.ConsumedQueueItemIDs, id)
+	}
+}
+
+func (reduction *RuntimePendingInputReduction) unlockSubmittedPendingInput(queueItemID string) {
+	if reduction.State.Submission != InputSubmissionLocked || !queuedUserMessageIDMatches(reduction.State.LockedInjectID, queueItemID) {
+		return
+	}
+	reduction.State.LockedInjectText = ""
+	reduction.State.LockedInjectID = ""
+	reduction.State.Submission = InputSubmissionUnlocked
 }
 
 func ReduceRuntimeReasoningEvent(state RuntimeReasoningState, evt clientui.Event) RuntimeReasoningReduction {
@@ -362,6 +436,62 @@ func containsQueuedUserMessageID(messages []clientui.QueuedUserMessage, id strin
 		}
 	}
 	return false
+}
+
+func removePendingQueuedUserMessageByID(messages *[]clientui.QueuedUserMessage, id string) bool {
+	id = strings.TrimSpace(id)
+	if id == "" || messages == nil || len(*messages) == 0 {
+		return false
+	}
+	removed := false
+	filtered := (*messages)[:0]
+	for _, message := range *messages {
+		if queuedUserMessageIDMatches(message.ID, id) {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, message)
+	}
+	*messages = filtered
+	return removed
+}
+
+func removePendingQueuedUserMessageByStatus(messages *[]clientui.QueuedUserMessage, status *clientui.QueuedUserMessageStatusEvent) (clientui.QueuedUserMessage, bool) {
+	if status == nil || messages == nil || len(*messages) == 0 {
+		return clientui.QueuedUserMessage{}, false
+	}
+	removed := false
+	var removedMessage clientui.QueuedUserMessage
+	filtered := (*messages)[:0]
+	for _, message := range *messages {
+		if queuedUserMessageMatchesStatus(message, status) {
+			removed = true
+			removedMessage = message
+			continue
+		}
+		filtered = append(filtered, message)
+	}
+	*messages = filtered
+	return removedMessage, removed
+}
+
+func queuedUserMessageMatchesStatus(message clientui.QueuedUserMessage, status *clientui.QueuedUserMessageStatusEvent) bool {
+	if status == nil {
+		return false
+	}
+	localRequestID := strings.TrimSpace(message.ClientRequestID)
+	statusRequestID := strings.TrimSpace(status.ClientRequestID)
+	if localRequestID != "" {
+		if statusRequestID != "" {
+			return localRequestID == statusRequestID
+		}
+		return queuedUserMessageIDMatches(message.ID, status.QueueItemID)
+	}
+	return queuedUserMessageIDMatches(message.ID, status.QueueItemID)
+}
+
+func queuedUserMessageIDMatches(left, right string) bool {
+	return strings.TrimSpace(left) != "" && strings.TrimSpace(left) == strings.TrimSpace(right)
 }
 
 func cloneReasoningDelta(delta *clientui.ReasoningDelta) *clientui.ReasoningDelta {

--- a/cli/app/internal/runtimestate/runtime_events.go
+++ b/cli/app/internal/runtimestate/runtime_events.go
@@ -438,24 +438,6 @@ func containsQueuedUserMessageID(messages []clientui.QueuedUserMessage, id strin
 	return false
 }
 
-func removePendingQueuedUserMessageByID(messages *[]clientui.QueuedUserMessage, id string) bool {
-	id = strings.TrimSpace(id)
-	if id == "" || messages == nil || len(*messages) == 0 {
-		return false
-	}
-	removed := false
-	filtered := (*messages)[:0]
-	for _, message := range *messages {
-		if queuedUserMessageIDMatches(message.ID, id) {
-			removed = true
-			continue
-		}
-		filtered = append(filtered, message)
-	}
-	*messages = filtered
-	return removed
-}
-
 func removePendingQueuedUserMessageByStatus(messages *[]clientui.QueuedUserMessage, status *clientui.QueuedUserMessageStatusEvent) (clientui.QueuedUserMessage, bool) {
 	if status == nil || messages == nil || len(*messages) == 0 {
 		return clientui.QueuedUserMessage{}, false

--- a/cli/app/internal/runtimestate/runtime_events_test.go
+++ b/cli/app/internal/runtimestate/runtime_events_test.go
@@ -45,6 +45,155 @@ func TestReduceRuntimeEvent_UserMessageFlushedProducesPendingInputAndConversatio
 	}
 }
 
+func TestReduceRuntimeEvent_QueuedStatusSubmittedRemovesPendingInputByID(t *testing.T) {
+	update := ReduceRuntimeEvent(
+		RuntimeRunState{},
+		RuntimeConversationState{},
+		PendingInputState{
+			PendingInjected: []clientui.QueuedUserMessage{{ID: "queue-1", Text: "steered message"}, {ID: "queue-2", Text: "follow-up"}},
+		},
+		RuntimeReasoningState{},
+		false,
+		clientui.Event{
+			Kind: clientui.EventQueuedUserMessageStatus,
+			QueuedUserMessageStatus: &clientui.QueuedUserMessageStatusEvent{
+				QueueItemID: "queue-1",
+				Status:      clientui.QueuedUserMessageSubmitted,
+			},
+		},
+	)
+
+	if len(update.PendingInput.ConsumedQueueItemIDs) != 1 || update.PendingInput.ConsumedQueueItemIDs[0] != "queue-1" {
+		t.Fatalf("consumed queue item ids = %+v, want queue-1", update.PendingInput.ConsumedQueueItemIDs)
+	}
+	if len(update.PendingInput.State.PendingInjected) != 1 || update.PendingInput.State.PendingInjected[0].ID != "queue-2" {
+		t.Fatalf("pending injected = %+v, want only queue-2", update.PendingInput.State.PendingInjected)
+	}
+	if update.PendingInput.RestoredText != "" {
+		t.Fatalf("restored text = %q, want empty", update.PendingInput.RestoredText)
+	}
+}
+
+func TestReduceRuntimeEvent_QueuedStatusFailedRemovesPendingInputAndRestoresText(t *testing.T) {
+	update := ReduceRuntimeEvent(
+		RuntimeRunState{},
+		RuntimeConversationState{},
+		PendingInputState{
+			PendingInjected:  []clientui.QueuedUserMessage{{ID: "queue-1", Text: "steered message", ClientRequestID: "req-local"}},
+			LockedInjectText: "steered message",
+			LockedInjectID:   "queue-1",
+			Submission:       InputSubmissionLocked,
+		},
+		RuntimeReasoningState{},
+		false,
+		clientui.Event{
+			Kind: clientui.EventQueuedUserMessageStatus,
+			QueuedUserMessageStatus: &clientui.QueuedUserMessageStatusEvent{
+				QueueItemID:     "queue-1",
+				ClientRequestID: "req-local",
+				Status:          clientui.QueuedUserMessageFailed,
+				RestoreText:     "steered message",
+				FailureReason:   clientui.QueuedUserMessageFailureTerminalWorkflowCompletion,
+			},
+		},
+	)
+
+	if len(update.PendingInput.State.PendingInjected) != 0 {
+		t.Fatalf("pending injected = %+v, want empty", update.PendingInput.State.PendingInjected)
+	}
+	if update.PendingInput.State.Submission != InputSubmissionUnlocked {
+		t.Fatalf("submission = %q, want unlocked", update.PendingInput.State.Submission)
+	}
+	if update.PendingInput.RestoredText != "steered message" {
+		t.Fatalf("restored text = %q, want queued text", update.PendingInput.RestoredText)
+	}
+}
+
+func TestReduceRuntimeEvent_QueuedStatusFailedMatchesProvisionalPendingInputByClientRequestID(t *testing.T) {
+	update := ReduceRuntimeEvent(
+		RuntimeRunState{},
+		RuntimeConversationState{},
+		PendingInputState{
+			PendingInjected: []clientui.QueuedUserMessage{{ID: "local-provisional", Text: "steered message", ClientRequestID: "req-local"}},
+		},
+		RuntimeReasoningState{},
+		false,
+		clientui.Event{
+			Kind: clientui.EventQueuedUserMessageStatus,
+			QueuedUserMessageStatus: &clientui.QueuedUserMessageStatusEvent{
+				QueueItemID:     "server-queue-1",
+				ClientRequestID: "req-local",
+				Status:          clientui.QueuedUserMessageFailed,
+				RestoreText:     "steered message",
+				FailureReason:   clientui.QueuedUserMessageFailureClosing,
+			},
+		},
+	)
+
+	if len(update.PendingInput.State.PendingInjected) != 0 {
+		t.Fatalf("pending injected = %+v, want provisional item removed by client request id", update.PendingInput.State.PendingInjected)
+	}
+	if update.PendingInput.RestoredText != "steered message" {
+		t.Fatalf("restored text = %q, want queued text", update.PendingInput.RestoredText)
+	}
+	if len(update.PendingInput.ConsumedQueueItemIDs) != 2 || update.PendingInput.ConsumedQueueItemIDs[0] != "server-queue-1" || update.PendingInput.ConsumedQueueItemIDs[1] != "req-local" {
+		t.Fatalf("consumed ids = %+v, want server queue id and client request id", update.PendingInput.ConsumedQueueItemIDs)
+	}
+}
+
+func TestReduceRuntimeEvent_QueuedStatusFailedIgnoresOtherClientRestoreText(t *testing.T) {
+	update := ReduceRuntimeEvent(
+		RuntimeRunState{},
+		RuntimeConversationState{},
+		PendingInputState{
+			PendingInjected: []clientui.QueuedUserMessage{{ID: "queue-1", Text: "local message", ClientRequestID: "req-local"}},
+		},
+		RuntimeReasoningState{},
+		false,
+		clientui.Event{
+			Kind: clientui.EventQueuedUserMessageStatus,
+			QueuedUserMessageStatus: &clientui.QueuedUserMessageStatusEvent{
+				QueueItemID:     "queue-1",
+				ClientRequestID: "req-other",
+				Status:          clientui.QueuedUserMessageFailed,
+				RestoreText:     "other client message",
+				FailureReason:   clientui.QueuedUserMessageFailureTerminalWorkflowCompletion,
+			},
+		},
+	)
+
+	if update.PendingInput.RestoredText != "" {
+		t.Fatalf("restored text = %q, want empty for other client failure", update.PendingInput.RestoredText)
+	}
+	if len(update.PendingInput.State.PendingInjected) != 1 || update.PendingInput.State.PendingInjected[0].ClientRequestID != "req-local" {
+		t.Fatalf("pending injected = %+v, want local queued item preserved", update.PendingInput.State.PendingInjected)
+	}
+}
+
+func TestReduceRuntimeEvent_QueuedStatusFailedWithoutLocalPendingInputDoesNotRestoreText(t *testing.T) {
+	update := ReduceRuntimeEvent(
+		RuntimeRunState{},
+		RuntimeConversationState{},
+		PendingInputState{},
+		RuntimeReasoningState{},
+		false,
+		clientui.Event{
+			Kind: clientui.EventQueuedUserMessageStatus,
+			QueuedUserMessageStatus: &clientui.QueuedUserMessageStatusEvent{
+				QueueItemID:     "queue-other",
+				ClientRequestID: "req-other",
+				Status:          clientui.QueuedUserMessageFailed,
+				RestoreText:     "other client message",
+				FailureReason:   clientui.QueuedUserMessageFailureTerminalWorkflowCompletion,
+			},
+		},
+	)
+
+	if update.PendingInput.RestoredText != "" {
+		t.Fatalf("restored text = %q, want empty without local queued item", update.PendingInput.RestoredText)
+	}
+}
+
 func TestReduceRuntimeEvent_RunStateStoppedClearsReasoningAndReturnsToIdle(t *testing.T) {
 	update := ReduceRuntimeEvent(
 		RuntimeRunState{Run: clientui.MustRunLifecycle(clientui.RunLifecycleRunning, clientui.RunModeTurn)},
@@ -87,6 +236,41 @@ func TestReduceRuntimeEvent_RunStateStartedDoesNotRequestTranscriptSync(t *testi
 	}
 	if update.Transcript.Sync.Reason != RuntimeTranscriptSyncNone {
 		t.Fatal("did not expect started run to request transcript sync")
+	}
+}
+
+func TestReduceRuntimeEvent_ExternalRuntimeStatusDrivesActivity(t *testing.T) {
+	running := ReduceRuntimeEvent(
+		RuntimeRunState{Run: clientui.IdleRunLifecycle()},
+		RuntimeConversationState{},
+		PendingInputState{},
+		RuntimeReasoningState{},
+		false,
+		clientui.Event{
+			Kind:                  clientui.EventExternalRuntimeStatus,
+			ExternalRuntimeStatus: &clientui.ExternalRuntimeStatus{State: clientui.ExternalRuntimeStateDraining},
+		},
+	)
+	if running.RunState.Activity != RuntimeActivityRunning {
+		t.Fatalf("draining external activity = %v, want running", running.RunState.Activity)
+	}
+	if running.RunState.ExternalRuntime == nil || running.RunState.ExternalRuntime.State != clientui.ExternalRuntimeStateDraining {
+		t.Fatalf("external runtime reduction = %+v, want draining", running.RunState.ExternalRuntime)
+	}
+
+	idle := ReduceRuntimeEvent(
+		RuntimeRunState{Run: clientui.IdleRunLifecycle()},
+		RuntimeConversationState{},
+		PendingInputState{},
+		RuntimeReasoningState{},
+		true,
+		clientui.Event{
+			Kind:                  clientui.EventExternalRuntimeStatus,
+			ExternalRuntimeStatus: &clientui.ExternalRuntimeStatus{State: clientui.ExternalRuntimeStateRegisteredIdle, QueueAccepting: true},
+		},
+	)
+	if idle.RunState.Activity != RuntimeActivityIdle {
+		t.Fatalf("registered-idle external activity = %v, want idle", idle.RunState.Activity)
 	}
 }
 

--- a/cli/app/internal/worktreeui/worktreemutation_service.go
+++ b/cli/app/internal/worktreeui/worktreemutation_service.go
@@ -150,8 +150,12 @@ func (s Service) clientRequestID() string {
 }
 
 func retryControlCall[T any](ctx context.Context, currentLeaseID func() string, recoverLease func(context.Context, error, bool) error, appendRecoveryWarning bool, call func(string) (T, error)) (T, error) {
-	value, err := call(currentLeaseID())
+	leaseID := strings.TrimSpace(currentLeaseID())
+	value, err := call(leaseID)
 	if !isRecoverableControlError(err) {
+		return value, err
+	}
+	if leaseID == "" {
 		return value, err
 	}
 	var zero T

--- a/cli/app/internal/worktreeui/worktreemutation_service_test.go
+++ b/cli/app/internal/worktreeui/worktreemutation_service_test.go
@@ -201,6 +201,26 @@ func TestReadOnlyRuntimeControlRejectsListBeforeRPC(t *testing.T) {
 	}
 }
 
+func TestCollaborativeRuntimeControlUsesEmptyLeaseForListAndMutations(t *testing.T) {
+	client := &testWorktreeClient{}
+	service := newTestService(client)
+	service.Runtime.CurrentLeaseID = func() string { return "" }
+	service.Runtime.ReadOnly = func() bool { return false }
+
+	if _, err := service.List(false); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if _, err := service.Switch("wt-1"); err != nil {
+		t.Fatalf("Switch: %v", err)
+	}
+	if got := client.listRequests[0].ControllerLeaseID; got != "" {
+		t.Fatalf("list lease id = %q, want empty collaborative lease", got)
+	}
+	if got := client.switchRequests[0].ControllerLeaseID; got != "" {
+		t.Fatalf("switch lease id = %q, want empty collaborative lease", got)
+	}
+}
+
 func newTestService(client *testWorktreeClient) Service {
 	return Service{
 		Client:    client,

--- a/cli/app/launch_planner.go
+++ b/cli/app/launch_planner.go
@@ -64,6 +64,7 @@ type runtimeLaunchPlan struct {
 	Wiring            *runtimeWiring
 	ControllerLeaseID string
 	ReadOnly          bool
+	AccessMode        serverapi.SessionRuntimeAttachMode
 	controllerLease   *controllerLeaseManager
 	close             func()
 }
@@ -85,6 +86,10 @@ func (p *runtimeLaunchPlan) CurrentControllerLeaseID() string {
 		}
 	}
 	return strings.TrimSpace(p.ControllerLeaseID)
+}
+
+func (p *runtimeLaunchPlan) HasControllerLease() bool {
+	return strings.TrimSpace(p.CurrentControllerLeaseID()) != ""
 }
 
 type sessionPickerRunner func([]clientui.SessionSummary, string, sessionPickerHeaderInfo) (sessionPickerResult, error)

--- a/cli/app/runtime_attachment.go
+++ b/cli/app/runtime_attachment.go
@@ -47,7 +47,8 @@ func prepareSharedRuntime(ctx context.Context, source runtimeAttachmentSource, p
 		SessionID:       plan.SessionID,
 		Runtime:         clients.SessionRuntime,
 		LeaseID:         lease.ID,
-		ReadOnly:        strings.TrimSpace(lease.ID) == "",
+		Mode:            lease.Mode,
+		ReadOnly:        lease.ReadOnly,
 		SessionActivity: clients.SessionActivity,
 		PromptActivity:  clients.PromptActivity,
 	})
@@ -57,17 +58,18 @@ func prepareSharedRuntime(ctx context.Context, source runtimeAttachmentSource, p
 	logger := &runLogger{}
 	_ = diagnosticWriter
 	logger.Logf("%s", startLogLine)
-	wiring, stopRuntimeEvents, stopAskEvents := prepareSharedRuntimeWiring(ctx, clients, plan, activities, leaseManager, logger)
+	wiring, stopRuntimeEvents, stopAskEvents := prepareSharedRuntimeWiring(ctx, clients, plan, activities, lease, leaseManager, logger)
 	return &runtimeLaunchPlan{
 		Logger:            logger,
 		Wiring:            wiring,
 		ControllerLeaseID: lease.ID,
 		ReadOnly:          lease.ReadOnly,
+		AccessMode:        lease.Mode,
 		controllerLease:   leaseManager,
 		close: func() {
 			stopAskEvents()
 			stopRuntimeEvents()
-			if !lease.ReadOnly {
+			if lease.Mode == serverapi.SessionRuntimeAttachModeController {
 				runtimeattach.Release(clients.SessionRuntime, plan.SessionID, leaseManager.Value())
 			}
 		},
@@ -84,7 +86,7 @@ func activateSharedRuntime(ctx context.Context, clients runtimeAttachmentClients
 	if err != nil {
 		return runtimeattach.Lease{}, nil, err
 	}
-	if lease.ReadOnly {
+	if lease.Mode != serverapi.SessionRuntimeAttachModeController {
 		return lease, nil, nil
 	}
 	leaseManager := newControllerLeaseManager(lease.ID)
@@ -92,12 +94,11 @@ func activateSharedRuntime(ctx context.Context, clients runtimeAttachmentClients
 	return lease, leaseManager, nil
 }
 
-func prepareSharedRuntimeWiring(ctx context.Context, clients runtimeAttachmentClients, plan sessionLaunchPlan, activities runtimeattach.Activities, leaseManager *controllerLeaseManager, logger *runLogger) (*runtimeWiring, func(), func()) {
+func prepareSharedRuntimeWiring(ctx context.Context, clients runtimeAttachmentClients, plan sessionLaunchPlan, activities runtimeattach.Activities, lease runtimeattach.Lease, leaseManager *controllerLeaseManager, logger *runLogger) (*runtimeWiring, func(), func()) {
 	runtimeClient := newUIRuntimeClientWithReads(plan.SessionID, clients.SessionViews, clients.RuntimeControls).(*sessionRuntimeClient)
+	runtimeClient.SetAccessMode(lease.Mode, lease.AllowedOperations)
 	if leaseManager != nil {
 		runtimeClient.SetControllerLeaseManager(leaseManager)
-	} else {
-		runtimeClient.SetReadOnly(true)
 	}
 	runtimeClient.SetTranscriptDiagnosticsEnabled(transcriptdiag.Enabled(plan.ActiveSettings.Debug, os.Getenv))
 	runtimeEvents, stopRuntimeEvents := startSessionActivityEvents(ctx, activities.Session, func(ctx context.Context, afterSequence uint64) (serverapi.SessionActivitySubscription, error) {
@@ -115,7 +116,7 @@ func prepareSharedRuntimeWiring(ctx context.Context, clients runtimeAttachmentCl
 		return strings.TrimSpace(plan.SessionName)
 	}, terminalFocus.FocusedForAttention)
 	askEvents, stopAskEvents := newClosedAskEventStream()
-	if leaseManager != nil && activities.Prompt != nil {
+	if activities.Prompt != nil {
 		askEvents, stopAskEvents = startPendingPromptEvents(ctx, activities.Prompt, func(ctx context.Context, afterSequence uint64) (serverapi.PromptActivitySubscription, error) {
 			return clients.PromptActivity.SubscribePromptActivity(ctx, serverapi.PromptActivitySubscribeRequest{SessionID: plan.SessionID, AfterSequence: afterSequence})
 		}, clients.PromptControl, leaseManager)

--- a/cli/app/runtime_attachment_test.go
+++ b/cli/app/runtime_attachment_test.go
@@ -146,8 +146,9 @@ func TestRuntimeAttachmentCloseReleasesRuntime(t *testing.T) {
 	}
 }
 
-func TestRuntimeAttachmentReadOnlyCloseDoesNotReleaseRuntime(t *testing.T) {
+func TestRuntimeAttachmentLegacyReadOnlyActivationIsNoControl(t *testing.T) {
 	releaseCount := 0
+	controls := &leaseRetryRuntimeControlClient{allowEmptySubmit: true}
 	server := runtimeAttachmentTestServer{
 		runtime: &recordingSessionRuntimeClient{
 			activate: func(context.Context, serverapi.SessionRuntimeActivateRequest) (serverapi.SessionRuntimeActivateResponse, error) {
@@ -165,27 +166,86 @@ func TestRuntimeAttachmentReadOnlyCloseDoesNotReleaseRuntime(t *testing.T) {
 		},
 		promptEvents: &recordingPromptActivityClient{
 			subscribe: func(context.Context, serverapi.PromptActivitySubscribeRequest) (serverapi.PromptActivitySubscription, error) {
-				t.Fatal("read-only attach should not subscribe to prompt control stream")
 				return nil, nil
 			},
 		},
 		sessionViews:   &countingSessionViewClient{},
-		runtimeControl: &leaseRetryRuntimeControlClient{},
+		runtimeControl: controls,
 	}
 
 	plan, err := prepareSharedRuntime(context.Background(), server, sessionLaunchPlan{SessionID: "session-readonly"}, io.Discard, "test")
 	if err != nil {
 		t.Fatalf("prepareSharedRuntime: %v", err)
 	}
-	if !plan.ReadOnly {
-		t.Fatal("expected read-only runtime plan")
+	if !plan.ReadOnly || plan.AccessMode != serverapi.SessionRuntimeAttachModeNoControl {
+		t.Fatalf("plan readOnly=%v mode=%q, want read-only no-control", plan.ReadOnly, plan.AccessMode)
 	}
-	if _, err := plan.Wiring.runtimeClient.SubmitUserMessage(context.Background(), "hello"); !errors.Is(err, errReadOnlyRuntime) {
-		t.Fatalf("SubmitUserMessage error = %v, want read-only runtime", err)
+	if _, err := plan.Wiring.runtimeClient.SubmitUserMessage(context.Background(), "hello"); err != nil {
+		if !errors.Is(err, errReadOnlyRuntime) {
+			t.Fatalf("SubmitUserMessage error = %v, want read-only runtime", err)
+		}
+	} else {
+		t.Fatal("SubmitUserMessage unexpectedly succeeded for read-only no-control attach")
 	}
 	plan.Close()
 	if releaseCount != 0 {
 		t.Fatalf("release count = %d, want none for read-only attach", releaseCount)
+	}
+}
+
+func TestRuntimeAttachmentCollaborativeSubmitUsesLiveRuntimeWithoutLeaseOrRelease(t *testing.T) {
+	releaseCount := 0
+	controls := &leaseRetryRuntimeControlClient{allowEmptySubmit: true}
+	server := runtimeAttachmentTestServer{
+		runtime: &recordingSessionRuntimeClient{
+			activate: func(context.Context, serverapi.SessionRuntimeActivateRequest) (serverapi.SessionRuntimeActivateResponse, error) {
+				return serverapi.SessionRuntimeActivateResponse{
+					Mode: serverapi.SessionRuntimeAttachModeCollaborative,
+					AllowedOperations: []serverapi.SessionRuntimeOperation{
+						serverapi.SessionRuntimeOperationSubmitUserTurn,
+						serverapi.SessionRuntimeOperationQueueUserMessage,
+					},
+				}, nil
+			},
+			release: func(context.Context, serverapi.SessionRuntimeReleaseRequest) (serverapi.SessionRuntimeReleaseResponse, error) {
+				releaseCount++
+				return serverapi.SessionRuntimeReleaseResponse{}, nil
+			},
+		},
+		sessionEvents: &recordingSessionActivityClient{
+			subscribe: func(context.Context, serverapi.SessionActivitySubscribeRequest) (serverapi.SessionActivitySubscription, error) {
+				return noOpSessionActivitySubscription{}, nil
+			},
+		},
+		promptEvents: &recordingPromptActivityClient{
+			subscribe: func(context.Context, serverapi.PromptActivitySubscribeRequest) (serverapi.PromptActivitySubscription, error) {
+				return nil, nil
+			},
+		},
+		sessionViews:   &countingSessionViewClient{},
+		runtimeControl: controls,
+	}
+
+	plan, err := prepareSharedRuntime(context.Background(), server, sessionLaunchPlan{SessionID: "session-collab"}, io.Discard, "test")
+	if err != nil {
+		t.Fatalf("prepareSharedRuntime: %v", err)
+	}
+	if plan.ReadOnly || plan.HasControllerLease() {
+		t.Fatalf("plan readOnly=%v lease=%q, want collaborative without controller lease", plan.ReadOnly, plan.CurrentControllerLeaseID())
+	}
+	message, err := plan.Wiring.runtimeClient.SubmitUserMessage(context.Background(), "steer live runtime")
+	if err != nil {
+		t.Fatalf("SubmitUserMessage: %v", err)
+	}
+	if message != "collaborative" {
+		t.Fatalf("message = %q, want collaborative", message)
+	}
+	if got := controls.submitLeaseIDs(); len(got) != 1 || got[0] != "" {
+		t.Fatalf("submit lease ids = %+v, want one empty lease", got)
+	}
+	plan.Close()
+	if releaseCount != 0 {
+		t.Fatalf("release count = %d, want no release for collaborative attach", releaseCount)
 	}
 }
 

--- a/cli/app/runtime_factory_test.go
+++ b/cli/app/runtime_factory_test.go
@@ -643,7 +643,7 @@ func TestBackgroundEventRouterDoesNotRetroactivelyQueueNoticeAfterOwnerSessionRe
 	if !res.Backgrounded {
 		t.Fatal("expected process to background")
 	}
-	router.ClearActiveSession(storeA.Meta().SessionID)
+	router.ClearActiveSession(storeA.Meta().SessionID, engA)
 	router.SetActiveSession(storeB.Meta().SessionID, engB)
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -684,7 +684,7 @@ func TestBackgroundEventRouterDropsNoticeWhenNoSessionIsActive(t *testing.T) {
 	client := &busyToggleFakeClient{responses: []llm.Response{{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done", Phase: llm.MessagePhaseFinal}, Usage: llm.Usage{WindowTokens: 200_000}}}}
 	eng := newAppRuntimeEngineWithStore(t, store, client, runtime.Config{})
 	router.SetActiveSession(store.Meta().SessionID, eng)
-	router.ClearActiveSession(store.Meta().SessionID)
+	router.ClearActiveSession(store.Meta().SessionID, eng)
 	router.handle(shelltool.Event{Snapshot: shelltool.Snapshot{ID: "1002", OwnerSessionID: store.Meta().SessionID, State: "completed"}, Type: shelltool.EventCompleted, Preview: "done"})
 	time.Sleep(50 * time.Millisecond)
 	if got := client.CallCount(); got != 0 {

--- a/cli/app/runtime_factory_test_helpers_test.go
+++ b/cli/app/runtime_factory_test_helpers_test.go
@@ -46,9 +46,9 @@ func (r *backgroundEventRouter) SetActiveSession(sessionID string, engine *runti
 	}
 }
 
-func (r *backgroundEventRouter) ClearActiveSession(sessionID string) {
+func (r *backgroundEventRouter) ClearActiveSession(sessionID string, engine *runtime.Engine) {
 	if inner := r.ensureInner(); inner != nil {
-		inner.ClearActiveSession(sessionID)
+		inner.ClearActiveSession(sessionID, engine)
 	}
 }
 

--- a/cli/app/session_lifecycle.go
+++ b/cli/app/session_lifecycle.go
@@ -148,10 +148,14 @@ func runSessionLifecycle(ctx context.Context, server interactiveSessionServer, i
 			return nil
 		}
 		var resolved resolvedSessionAction
-		if runtimePlan.ReadOnly {
+		if runtimePlan.HasControllerLease() {
+			resolved, err = resolveSessionAction(ctx, server, interactor, plan.SessionID, runtimePlan.CurrentControllerLeaseID(), transition)
+		} else if runtimePlan.AccessMode == serverapi.SessionRuntimeAttachModeCollaborative {
+			resolved, err = resolveCollaborativeSessionAction(ctx, server, interactor, plan.SessionID, transition)
+		} else if runtimePlan.ReadOnly {
 			resolved, err = resolveReadOnlySessionAction(ctx, server, interactor, plan.SessionID, transition)
 		} else {
-			resolved, err = resolveSessionAction(ctx, server, interactor, plan.SessionID, runtimePlan.CurrentControllerLeaseID(), transition)
+			resolved, err = resolveCollaborativeSessionAction(ctx, server, interactor, plan.SessionID, transition)
 		}
 		runtimePlan.Close()
 		if err != nil {
@@ -232,6 +236,14 @@ type resolvedSessionAction struct {
 }
 
 func resolveReadOnlySessionAction(ctx context.Context, server sessionTransitionServer, interactor authInteractor, sessionID string, transition UITransition) (resolvedSessionAction, error) {
+	return resolvePureNavigationSessionAction(ctx, server, interactor, sessionID, transition, errReadOnlyRuntime)
+}
+
+func resolveCollaborativeSessionAction(ctx context.Context, server sessionTransitionServer, interactor authInteractor, sessionID string, transition UITransition) (resolvedSessionAction, error) {
+	return resolvePureNavigationSessionAction(ctx, server, interactor, sessionID, transition, errCollaborativeOperationBlocked)
+}
+
+func resolvePureNavigationSessionAction(ctx context.Context, server sessionTransitionServer, interactor authInteractor, sessionID string, transition UITransition, blockedErr error) (resolvedSessionAction, error) {
 	switch transition.Action {
 	case UIActionNewSession:
 		return resolvedSessionAction{
@@ -260,7 +272,7 @@ func resolveReadOnlySessionAction(ctx context.Context, server sessionTransitionS
 	case UIActionExit, "":
 		return resolvedSessionAction{}, nil
 	default:
-		return resolvedSessionAction{}, errReadOnlyRuntime
+		return resolvedSessionAction{}, blockedErr
 	}
 }
 

--- a/cli/app/session_lifecycle_test.go
+++ b/cli/app/session_lifecycle_test.go
@@ -667,6 +667,78 @@ func TestResolveReadOnlySessionActionLogoutReauthenticatesWithoutLease(t *testin
 	}
 }
 
+func TestResolveCollaborativeSessionActionHandlesPureNavigationLocally(t *testing.T) {
+	tests := []struct {
+		name string
+		in   UITransition
+		want resolvedSessionAction
+	}{
+		{
+			name: "new session",
+			in:   UITransition{Action: UIActionNewSession, InitialPrompt: "start", ParentSessionID: "parent-1"},
+			want: resolvedSessionAction{InitialPrompt: "start", ParentSessionID: "parent-1", ForceNewSession: true, ShouldContinue: true},
+		},
+		{
+			name: "resume picker",
+			in:   UITransition{Action: UIActionResume},
+			want: resolvedSessionAction{ShouldContinue: true},
+		},
+		{
+			name: "open session",
+			in:   UITransition{Action: UIActionOpenSession, TargetSessionID: "next-1", InitialInput: "draft"},
+			want: resolvedSessionAction{NextSessionID: "next-1", InitialInput: "draft", ShouldContinue: true},
+		},
+		{
+			name: "new review handoff",
+			in:   UITransition{Action: UIActionNewSession, InitialPrompt: "review this", InitialPromptHistoryRecorded: true, ParentSessionID: "parent-1"},
+			want: resolvedSessionAction{InitialPrompt: "review this", InitialPromptHistoryRecorded: true, ParentSessionID: "parent-1", ForceNewSession: true, ShouldContinue: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveCollaborativeSessionAction(context.Background(), nil, nil, "session-1", tt.in)
+			if err != nil {
+				t.Fatalf("resolveCollaborativeSessionAction: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolved = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveCollaborativeSessionActionRejectsRollbackFork(t *testing.T) {
+	_, err := resolveCollaborativeSessionAction(context.Background(), nil, nil, "session-1", UITransition{Action: UIActionForkRollback})
+	if !errors.Is(err, errCollaborativeOperationBlocked) {
+		t.Fatalf("error = %v, want collaborative runtime block", err)
+	}
+}
+
+func TestResolveCollaborativeSessionActionLogoutReauthenticatesWithoutLease(t *testing.T) {
+	reauthCalls := 0
+	resolved, err := resolveCollaborativeSessionAction(
+		context.Background(),
+		narrowSessionLifecycleServer{
+			reauthenticate: func(context.Context, authInteractor) error {
+				reauthCalls++
+				return nil
+			},
+		},
+		nil,
+		"session-1",
+		UITransition{Action: UIActionLogout},
+	)
+	if err != nil {
+		t.Fatalf("resolveCollaborativeSessionAction logout: %v", err)
+	}
+	if reauthCalls != 1 {
+		t.Fatalf("reauth calls = %d, want 1", reauthCalls)
+	}
+	if !resolved.ShouldContinue || resolved.NextSessionID != "session-1" {
+		t.Fatalf("resolved = %+v, want continue same session", resolved)
+	}
+}
+
 func TestResolveSessionActionExitStaysClientLocal(t *testing.T) {
 	resolved, err := resolveSessionAction(
 		context.Background(),

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -53,6 +53,12 @@ func (c uiAskController) acceptEvent(evt askEvent) {
 		return
 	}
 	c.notifyAskPending(evt.req)
+	incomingPromptID := strings.TrimSpace(evt.req.PromptID)
+	if incomingPromptID != "" && m.ask.hasCurrent() && strings.TrimSpace(m.ask.current.req.PromptID) == incomingPromptID {
+		m.ask.current.req = evt.req
+		m.ask.answerPending = false
+		return
+	}
 	if !m.ask.hasCurrent() {
 		c.setActiveAsk(evt)
 		m.activity = uiActivityQuestion
@@ -436,11 +442,20 @@ func (c uiAskController) answer(resp clientui.PromptAnswer, err error) bool {
 	if !m.ask.hasCurrent() {
 		return false
 	}
-	m.ask.answerPending = false
+	m.ask.answerPending = true
 	if resp.PromptID == "" {
 		resp.PromptID = m.ask.current.req.PromptID
 	}
 	m.ask.current.reply <- askReply{response: resp, err: err}
+	if strings.TrimSpace(m.ask.current.req.SessionID) == "" || strings.TrimSpace(m.ask.current.req.PromptID) == "" {
+		return c.resolveAnsweredPromptOptimistically()
+	}
+	return false
+}
+
+func (c uiAskController) resolveAnsweredPromptOptimistically() bool {
+	m := c.model
+	m.ask.answerPending = false
 	if len(m.ask.queue) == 0 {
 		m.ask.current = nil
 		m.ask.currentToken = nextNonZeroToken(m.ask.currentToken)

--- a/cli/app/ui_goal.go
+++ b/cli/app/ui_goal.go
@@ -14,9 +14,13 @@ import (
 )
 
 const noGoalHint = "No goal to manage yet. First, start a goal with /goal <objective>"
+const workflowGoalUnavailableMessage = "Goal control is unavailable for workflow task sessions"
 
 func (c uiInputController) handleGoalCommand(mode commands.GoalMode, objective string) (tea.Model, tea.Cmd) {
 	m := c.model
+	if m.workflowSessionActive() {
+		return m, m.sendTransientStatusWithNoticeID(workflowGoalUnavailableMessage, uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, "")
+	}
 	switch mode {
 	case commands.GoalModeShow, "":
 		return m, c.startGoalFlowCmd()
@@ -32,6 +36,17 @@ func (c uiInputController) handleGoalCommand(mode commands.GoalMode, objective s
 		errText := "Usage: /goal [show|pause|resume|clear|<objective>]"
 		return m, sequenceCmds(c.model.appendLocalEntryWithNoticeID("error", errText, ""), c.model.sendTransientStatusWithNoticeID(errText, uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, ""))
 	}
+}
+
+func (m *uiModel) workflowSessionActive() bool {
+	if m == nil || !m.hasRuntimeClient() {
+		return false
+	}
+	if direct := m.runtimeClient().Status(); direct.WorkflowActive || direct.WorkflowSession != nil {
+		return true
+	}
+	status := m.cachedRuntimeStatus()
+	return status.WorkflowActive || status.WorkflowSession != nil
 }
 
 func goalIsActive(goal *clientui.RuntimeGoal) bool {

--- a/cli/app/ui_goal_test.go
+++ b/cli/app/ui_goal_test.go
@@ -297,6 +297,22 @@ func TestGoalCommandWithoutGoalShowsLocalHint(t *testing.T) {
 	}
 }
 
+func TestWorkflowSessionGoalCommandIsBlockedBeforeRuntimeCall(t *testing.T) {
+	client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{WorkflowSession: &clientui.WorkflowSessionStatus{RunID: "run-1"}}}
+	m := newSizedProjectedClosedUIModel(client, 100, 20)
+	m.input = "/goal ship workflow"
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+
+	if client.setGoalArg != "" || client.showGoalCalls != 0 {
+		t.Fatalf("goal runtime calls should be blocked, set=%q show=%d", client.setGoalArg, client.showGoalCalls)
+	}
+	if updated.transientStatus != workflowGoalUnavailableMessage {
+		t.Fatalf("transient status = %q, want workflow goal block", updated.transientStatus)
+	}
+}
+
 func TestGoalClearActiveGoalRequiresConfirmation(t *testing.T) {
 	client := &runtimeControlFakeClient{goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: "active"}}
 	m := newSizedProjectedClosedUIModel(client, 100, 20)

--- a/cli/app/ui_input_controller.go
+++ b/cli/app/ui_input_controller.go
@@ -158,6 +158,9 @@ func (m *uiModel) appendLocalEntryWithNoticeID(role, text, noticeID string) tea.
 	if !m.hasRuntimeClient() {
 		return m.sendTransientStatusWithNoticeID(text, statusKindForLocalEntryRole(role), transientStatusDuration, uiStatusNoticeReplace, noticeID)
 	}
+	if capability, ok := m.runtimeClient().(interface{ CanAppendCommittedEntries() bool }); ok && !capability.CanAppendCommittedEntries() {
+		return m.sendTransientStatusWithNoticeID(text, statusKindForLocalEntryRole(role), transientStatusDuration, uiStatusNoticeReplace, noticeID)
+	}
 	return m.persistLocalEntryCmd(role, text, noticeID)
 }
 

--- a/cli/app/ui_input_controller_commands.go
+++ b/cli/app/ui_input_controller_commands.go
@@ -245,7 +245,6 @@ func (c uiInputController) handleSupervisorModeCommand(requested string) (tea.Mo
 		errText := "invalid supervisor mode " + strconv.Quote(requested) + " (expected on|off)"
 		return m, c.model.appendLocalEntryWithNoticeID("error", errText, "")
 	}
-
 	changed := false
 	nextMode := currentMode
 	if m.hasRuntimeClient() {
@@ -313,6 +312,10 @@ func (c uiInputController) handleAutoCompactionCommand(requested string) (tea.Mo
 	default:
 		errText := "invalid autocompaction mode " + strconv.Quote(requested) + " (expected on|off)"
 		return m, c.model.appendLocalEntryWithNoticeID("error", errText, "")
+	}
+	if m.workflowSessionActive() && !targetEnabled {
+		errText := "Auto-compaction cannot be disabled for workflow task sessions"
+		return m, c.model.sendTransientStatusWithNoticeID(errText, uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, "")
 	}
 
 	changed := false

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -35,12 +35,13 @@ const (
 )
 
 type injectedRuntimeQueueItem struct {
-	LocalID      string
-	ServerID     string
-	Text         string
-	State        injectedRuntimeQueueState
-	CreateToken  uint64
-	DiscardToken uint64
+	LocalID         string
+	ServerID        string
+	Text            string
+	ClientRequestID string
+	State           injectedRuntimeQueueState
+	CreateToken     uint64
+	DiscardToken    uint64
 }
 
 func (m *uiModel) queueInput(text string) {
@@ -65,18 +66,31 @@ func (m *uiModel) enqueueInjectedInputWithApprovalAnswer(text string, answer *cl
 		return nil
 	}
 	token := m.nextInjectedQueueToken()
-	m.pendingInjected = append(m.pendingInjected, clientui.QueuedUserMessage{ID: localID, Text: trimmed})
+	clientRequestID := uuid.NewString()
+	m.pendingInjected = append(m.pendingInjected, clientui.QueuedUserMessage{ID: localID, Text: trimmed, ClientRequestID: clientRequestID})
 	m.injectedQueue = append(m.injectedQueue, injectedRuntimeQueueItem{
-		LocalID:     localID,
-		Text:        trimmed,
-		State:       injectedRuntimeQueuePendingCreate,
-		CreateToken: token,
+		LocalID:         localID,
+		Text:            trimmed,
+		ClientRequestID: clientRequestID,
+		State:           injectedRuntimeQueuePendingCreate,
+		CreateToken:     token,
 	})
 	client := m.runtimeClient()
 	return func() tea.Msg {
-		item, err := client.QueueUserMessage(trimmed)
+		item, err := queueRuntimeUserMessage(client, trimmed, clientRequestID)
 		return injectedQueueCreateDoneMsg{token: token, localID: localID, item: item, approvalCommentaryAnswer: answer, err: err}
 	}
+}
+
+type runtimeQueueUserMessageWithClientRequestID interface {
+	QueueUserMessageWithClientRequestID(text string, clientRequestID string) (clientui.QueuedUserMessage, error)
+}
+
+func queueRuntimeUserMessage(client clientui.RuntimeClient, text string, clientRequestID string) (clientui.QueuedUserMessage, error) {
+	if queueClient, ok := client.(runtimeQueueUserMessageWithClientRequestID); ok {
+		return queueClient.QueueUserMessageWithClientRequestID(text, clientRequestID)
+	}
+	return client.QueueUserMessage(text)
 }
 
 func (m *uiModel) queueInjectedInput(text string) tea.Cmd {
@@ -480,11 +494,12 @@ func (c uiInputController) handleInjectedQueueCreateDone(msg injectedQueueCreate
 	}
 	item.ServerID = serverID
 	item.Text = serverText
+	item.ClientRequestID = strings.TrimSpace(msg.item.ClientRequestID)
 	switch item.State {
 	case injectedRuntimeQueuePendingCreate:
 		item.State = injectedRuntimeQueueEnqueued
 		m.injectedQueue[index] = item
-		m.replacePendingInjectedID(item.LocalID, clientui.QueuedUserMessage{ID: serverID, Text: serverText})
+		m.replacePendingInjectedID(item.LocalID, clientui.QueuedUserMessage{ID: serverID, Text: serverText, ClientRequestID: item.ClientRequestID})
 		m.rememberPromptHistoryLocally(serverText)
 		if msg.approvalCommentaryAnswer != nil {
 			return m, m.answerQueuedApprovalCommentary(*msg.approvalCommentaryAnswer)
@@ -571,7 +586,7 @@ func (m *uiModel) removePendingInjectedByID(id string) {
 	}
 	filtered := m.pendingInjected[:0]
 	for _, item := range m.pendingInjected {
-		if item.ID == id {
+		if item.ID == id || item.ClientRequestID == id {
 			continue
 		}
 		filtered = append(filtered, item)
@@ -595,11 +610,11 @@ func (m *uiModel) ensurePendingInjectedVisible(item injectedRuntimeQueueItem) {
 		return
 	}
 	for _, pending := range m.pendingInjected {
-		if pending.ID == id {
+		if pending.ID == id || pending.ClientRequestID == id {
 			return
 		}
 	}
-	m.pendingInjected = append(m.pendingInjected, clientui.QueuedUserMessage{ID: id, Text: item.Text})
+	m.pendingInjected = append(m.pendingInjected, clientui.QueuedUserMessage{ID: id, Text: item.Text, ClientRequestID: item.ClientRequestID})
 }
 
 func (m *uiModel) removeInjectedQueueItemsByIDs(ids []string) {
@@ -608,7 +623,7 @@ func (m *uiModel) removeInjectedQueueItemsByIDs(ids []string) {
 	}
 	filtered := m.injectedQueue[:0]
 	for _, item := range m.injectedQueue {
-		if containsInjectedQueueID(ids, item.ServerID) || containsInjectedQueueID(ids, item.LocalID) {
+		if containsInjectedQueueID(ids, item.ServerID) || containsInjectedQueueID(ids, item.LocalID) || containsInjectedQueueID(ids, item.ClientRequestID) {
 			continue
 		}
 		filtered = append(filtered, item)

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -35,13 +35,14 @@ const (
 )
 
 type injectedRuntimeQueueItem struct {
-	LocalID         string
-	ServerID        string
-	Text            string
-	ClientRequestID string
-	State           injectedRuntimeQueueState
-	CreateToken     uint64
-	DiscardToken    uint64
+	LocalID                  string
+	ServerID                 string
+	Text                     string
+	ClientRequestID          string
+	State                    injectedRuntimeQueueState
+	CreateToken              uint64
+	DiscardToken             uint64
+	ApprovalCommentaryAnswer *clientui.PromptAnswer
 }
 
 func (m *uiModel) queueInput(text string) {
@@ -67,13 +68,19 @@ func (m *uiModel) enqueueInjectedInputWithApprovalAnswer(text string, answer *cl
 	}
 	token := m.nextInjectedQueueToken()
 	clientRequestID := uuid.NewString()
+	var approvalCommentaryAnswer *clientui.PromptAnswer
+	if answer != nil {
+		snap := *answer
+		approvalCommentaryAnswer = &snap
+	}
 	m.pendingInjected = append(m.pendingInjected, clientui.QueuedUserMessage{ID: localID, Text: trimmed, ClientRequestID: clientRequestID})
 	m.injectedQueue = append(m.injectedQueue, injectedRuntimeQueueItem{
-		LocalID:         localID,
-		Text:            trimmed,
-		ClientRequestID: clientRequestID,
-		State:           injectedRuntimeQueuePendingCreate,
-		CreateToken:     token,
+		LocalID:                  localID,
+		Text:                     trimmed,
+		ClientRequestID:          clientRequestID,
+		State:                    injectedRuntimeQueuePendingCreate,
+		CreateToken:              token,
+		ApprovalCommentaryAnswer: approvalCommentaryAnswer,
 	})
 	client := m.runtimeClient()
 	return func() tea.Msg {
@@ -464,6 +471,10 @@ func (c uiInputController) handleInjectedQueueCreateDone(msg injectedQueueCreate
 	if item.CreateToken != msg.token {
 		return m, nil
 	}
+	approvalCommentaryAnswer := item.ApprovalCommentaryAnswer
+	if approvalCommentaryAnswer == nil {
+		approvalCommentaryAnswer = msg.approvalCommentaryAnswer
+	}
 	m.observeRuntimeRequestResult(msg.err)
 	if msg.err != nil {
 		m.injectedQueue[index].State = injectedRuntimeQueueCreateFailed
@@ -476,8 +487,8 @@ func (c uiInputController) handleInjectedQueueCreateDone(msg injectedQueueCreate
 			m.logf("queue_create.error err=%q", detailErr)
 			m.removeInjectedQueueItemAt(index)
 			m.layout().syncViewport()
-			if msg.approvalCommentaryAnswer != nil {
-				return m, sequenceCmds(appendCmd, m.answerQueuedApprovalCommentary(*msg.approvalCommentaryAnswer))
+			if approvalCommentaryAnswer != nil {
+				return m, sequenceCmds(appendCmd, m.answerQueuedApprovalCommentary(*approvalCommentaryAnswer))
 			}
 			return m, appendCmd
 		}
@@ -495,14 +506,15 @@ func (c uiInputController) handleInjectedQueueCreateDone(msg injectedQueueCreate
 	item.ServerID = serverID
 	item.Text = serverText
 	item.ClientRequestID = strings.TrimSpace(msg.item.ClientRequestID)
+	item.ApprovalCommentaryAnswer = nil
 	switch item.State {
 	case injectedRuntimeQueuePendingCreate:
 		item.State = injectedRuntimeQueueEnqueued
 		m.injectedQueue[index] = item
 		m.replacePendingInjectedID(item.LocalID, clientui.QueuedUserMessage{ID: serverID, Text: serverText, ClientRequestID: item.ClientRequestID})
 		m.rememberPromptHistoryLocally(serverText)
-		if msg.approvalCommentaryAnswer != nil {
-			return m, m.answerQueuedApprovalCommentary(*msg.approvalCommentaryAnswer)
+		if approvalCommentaryAnswer != nil {
+			return m, m.answerQueuedApprovalCommentary(*approvalCommentaryAnswer)
 		}
 		if !m.isBusy() && !m.isInputSubmitLocked() &&
 			!m.injectedQueueBlocksDrain() {
@@ -617,18 +629,23 @@ func (m *uiModel) ensurePendingInjectedVisible(item injectedRuntimeQueueItem) {
 	m.pendingInjected = append(m.pendingInjected, clientui.QueuedUserMessage{ID: id, Text: item.Text, ClientRequestID: item.ClientRequestID})
 }
 
-func (m *uiModel) removeInjectedQueueItemsByIDs(ids []string) {
+func (m *uiModel) removeInjectedQueueItemsByIDs(ids []string) []clientui.PromptAnswer {
 	if len(ids) == 0 || len(m.injectedQueue) == 0 {
-		return
+		return nil
 	}
+	var approvalAnswers []clientui.PromptAnswer
 	filtered := m.injectedQueue[:0]
 	for _, item := range m.injectedQueue {
 		if containsInjectedQueueID(ids, item.ServerID) || containsInjectedQueueID(ids, item.LocalID) || containsInjectedQueueID(ids, item.ClientRequestID) {
+			if item.ApprovalCommentaryAnswer != nil {
+				approvalAnswers = append(approvalAnswers, *item.ApprovalCommentaryAnswer)
+			}
 			continue
 		}
 		filtered = append(filtered, item)
 	}
 	m.injectedQueue = filtered
+	return approvalAnswers
 }
 
 func containsInjectedQueueID(values []string, target string) bool {

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -236,6 +236,8 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 	m.discardQueuedInput(activeQueuedID)
 	if msg.err != nil {
 		if errors.Is(msg.err, serverapi.ErrActivePrimaryRun) && m.canQueueOnCollaborativeActiveOwner() && strings.TrimSpace(msg.submittedText) != "" {
+			m.setExternalRuntimeStatus(&clientui.ExternalRuntimeStatus{State: clientui.ExternalRuntimeStateOwnerRunning, QueueAccepting: true})
+			m.setBusy(true)
 			m.activity = uiActivityRunning
 			m.layout().syncViewport()
 			return m, c.enqueueSubmittedTextAfterActiveOwnerRace(msg.submittedText)

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -9,6 +9,7 @@ import (
 	"core/cli/app/internal/runtimeattach"
 	"core/cli/tui"
 	"core/shared/clientui"
+	"core/shared/serverapi"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -234,6 +235,11 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 	c.finishBusyActivity(false)
 	m.discardQueuedInput(activeQueuedID)
 	if msg.err != nil {
+		if errors.Is(msg.err, serverapi.ErrActivePrimaryRun) && m.canQueueOnCollaborativeActiveOwner() && strings.TrimSpace(msg.submittedText) != "" {
+			m.activity = uiActivityRunning
+			m.layout().syncViewport()
+			return m, c.enqueueSubmittedTextAfterActiveOwnerRace(msg.submittedText)
+		}
 		if m.turnQueueHook != nil {
 			m.turnQueueHook.OnTurnQueueAborted()
 		}
@@ -285,6 +291,20 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 	c.notifyTurnQueueDrainedIfIdle()
 	m.layout().syncViewport()
 	return m, nil
+}
+
+func (m *uiModel) canQueueOnCollaborativeActiveOwner() bool {
+	if m == nil || !m.hasRuntimeClient() {
+		return false
+	}
+	client, ok := m.runtimeClient().(interface{ IsCollaborativeRuntime() bool })
+	return ok && client.IsCollaborativeRuntime()
+}
+
+func (c uiInputController) enqueueSubmittedTextAfterActiveOwnerRace(text string) tea.Cmd {
+	m := c.model
+	cmd := m.enqueueInjectedInputWithApprovalAnswer(text, nil)
+	return cmd
 }
 
 func (c uiInputController) queuedDrainRequiresHydration() bool {

--- a/cli/app/ui_part2_test.go
+++ b/cli/app/ui_part2_test.go
@@ -828,6 +828,58 @@ func TestApprovalAskIgnoresRepeatSubmitWhileCommentaryQueuePending(t *testing.T)
 	}
 }
 
+func TestApprovalAskAnswersWhenQueuedCommentarySubmitsBeforeCreateAck(t *testing.T) {
+	client := &runtimeControlFakeClient{queueUserMessageID: "server-commentary-1"}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.setBusy(true)
+	reply := make(chan askReply, 2)
+	event := askEvent{req: clientui.PendingPromptEvent{Question: "Approve?", Approval: true, ApprovalOptions: []clientui.ApprovalOption{{Decision: clientui.ApprovalDecisionAllowOnce, Label: "Allow once"}, {Decision: clientui.ApprovalDecisionDeny, Label: "Deny"}}}, reply: reply}
+
+	next, _ := m.Update(askEventMsg{event: event})
+	updated := next.(*uiModel)
+	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyTab})
+	updated = next.(*uiModel)
+	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("queue then ack")})
+	updated = next.(*uiModel)
+	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = next.(*uiModel)
+	if cmd == nil || len(updated.pendingInjected) != 1 {
+		t.Fatalf("expected queued commentary create command and pending item, cmd=%v pending=%+v", cmd, updated.pendingInjected)
+	}
+	clientRequestID := updated.pendingInjected[0].ClientRequestID
+
+	next, _ = updated.Update(runtimeEventMsg{event: clientui.Event{
+		Kind: clientui.EventQueuedUserMessageStatus,
+		QueuedUserMessageStatus: &clientui.QueuedUserMessageStatusEvent{
+			QueueItemID:     "server-commentary-1",
+			ClientRequestID: clientRequestID,
+			Status:          clientui.QueuedUserMessageSubmitted,
+		},
+	}})
+	updated = next.(*uiModel)
+	resp := <-reply
+	if resp.response.Approval == nil || resp.response.Approval.Commentary != "queue then ack" {
+		t.Fatalf("unexpected approval response after early submitted status: %+v", resp.response.Approval)
+	}
+	if len(updated.pendingInjected) != 0 || len(updated.injectedQueue) != 0 {
+		t.Fatalf("expected early status to consume queued commentary, pending=%+v queue=%+v", updated.pendingInjected, updated.injectedQueue)
+	}
+
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
+	select {
+	case extra := <-reply:
+		t.Fatalf("unexpected duplicate approval response after late create ack: %+v", extra.response.Approval)
+	default:
+	}
+	if len(updated.pendingInjected) != 0 || len(updated.injectedQueue) != 0 {
+		t.Fatalf("late create ack re-added queued commentary, pending=%+v queue=%+v", updated.pendingInjected, updated.injectedQueue)
+	}
+}
+
 func TestAskEventsQueueUntilCurrentQuestionAnswered(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	reply1 := make(chan askReply, 1)

--- a/cli/app/ui_part4_test.go
+++ b/cli/app/ui_part4_test.go
@@ -167,6 +167,62 @@ func TestBusyEnterQueuesInjectedInputWithoutRuntimeCreateDuringUpdate(t *testing
 	}
 }
 
+func TestQueuedInjectedInputEarlyFailureStatusClearsProvisionalQueue(t *testing.T) {
+	client := &runtimeControlFakeClient{queueUserMessageID: "server-queue-1"}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.startupCmds = nil
+	m.setBusy(true)
+	m.input = "please continue with tests"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected async queue create command")
+	}
+	if len(updated.pendingInjected) != 1 {
+		t.Fatalf("expected one provisional pending item, got %+v", updated.pendingInjected)
+	}
+	clientRequestID := updated.pendingInjected[0].ClientRequestID
+	if clientRequestID == "" {
+		t.Fatalf("expected provisional pending item to have client request id, got %+v", updated.pendingInjected[0])
+	}
+
+	msgs := collectCmdMessages(t, cmd)
+	var createDone injectedQueueCreateDoneMsg
+	for _, msg := range msgs {
+		if typed, ok := msg.(injectedQueueCreateDoneMsg); ok {
+			createDone = typed
+		}
+	}
+	if createDone.item.ID != "server-queue-1" || createDone.item.ClientRequestID != clientRequestID {
+		t.Fatalf("expected queue response with server id and request id, got %+v request=%q", createDone.item, clientRequestID)
+	}
+
+	next, _ = updated.Update(runtimeEventMsg{event: clientui.Event{
+		Kind: clientui.EventQueuedUserMessageStatus,
+		QueuedUserMessageStatus: &clientui.QueuedUserMessageStatusEvent{
+			QueueItemID:     "server-queue-1",
+			ClientRequestID: clientRequestID,
+			Status:          clientui.QueuedUserMessageFailed,
+			RestoreText:     "please continue with tests",
+			FailureReason:   clientui.QueuedUserMessageFailureClosing,
+		},
+	}})
+	updated = next.(*uiModel)
+	if len(updated.pendingInjected) != 0 || len(updated.injectedQueue) != 0 {
+		t.Fatalf("expected early status to clear provisional queue, pending=%+v injected=%+v", updated.pendingInjected, updated.injectedQueue)
+	}
+	if updated.input != "please continue with tests" {
+		t.Fatalf("expected failed queued text restored, got %q", updated.input)
+	}
+
+	next, _ = updated.Update(createDone)
+	updated = next.(*uiModel)
+	if len(updated.pendingInjected) != 0 || len(updated.injectedQueue) != 0 {
+		t.Fatalf("expected delayed create completion ignored after failure, pending=%+v injected=%+v", updated.pendingInjected, updated.injectedQueue)
+	}
+}
+
 func TestQueuedRuntimeWorkCheckDoesNotSubmitWhenRuntimeBecameBusy(t *testing.T) {
 	client := &runtimeControlFakeClient{hasQueuedUserWork: true}
 	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())

--- a/cli/app/ui_part8_test.go
+++ b/cli/app/ui_part8_test.go
@@ -284,7 +284,7 @@ func TestWorkflowSessionAutoCompactionOffBlockedBeforeRuntimeCall(t *testing.T) 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
 
-	if client.setAutoCompactArg {
+	if client.setAutoCompactCalls != 0 {
 		t.Fatal("did not expect runtime auto-compaction disable call")
 	}
 	if !strings.Contains(updated.transientStatus, "Auto-compaction cannot be disabled") {

--- a/cli/app/ui_part8_test.go
+++ b/cli/app/ui_part8_test.go
@@ -6,6 +6,7 @@ import (
 	"core/server/llm"
 	"core/server/runtime"
 	"core/server/tools"
+	"core/shared/clientui"
 	"core/shared/toolspec"
 	"core/shared/transcript"
 	"errors"
@@ -266,6 +267,31 @@ func TestSlashAutoCompactionShowsCompactionModeNoneNote(t *testing.T) {
 	}
 	if !strings.Contains(updated.transientStatus, "compaction_mode=none") {
 		t.Fatalf("expected compaction_mode=none note in status, got %q", updated.transientStatus)
+	}
+}
+
+func TestWorkflowSessionAutoCompactionOffBlockedBeforeRuntimeCall(t *testing.T) {
+	client := &runtimeControlFakeClient{
+		status: clientui.RuntimeStatus{
+			AutoCompactionEnabled: true,
+			WorkflowSession:       &clientui.WorkflowSessionStatus{RunID: "run-1"},
+		},
+	}
+	m := newProjectedStaticUIModel()
+	m.engine = client
+	m.input = "/autocompaction off"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := next.(*uiModel)
+
+	if client.setAutoCompactArg {
+		t.Fatal("did not expect runtime auto-compaction disable call")
+	}
+	if !strings.Contains(updated.transientStatus, "Auto-compaction cannot be disabled") {
+		t.Fatalf("transient status = %q, want workflow auto-compaction block", updated.transientStatus)
+	}
+	if cmd == nil {
+		t.Fatal("expected transient status clear command")
 	}
 }
 

--- a/cli/app/ui_runtime_adapter_part5_test.go
+++ b/cli/app/ui_runtime_adapter_part5_test.go
@@ -355,6 +355,62 @@ func TestWorktreeReminderBeforeUserFlushRendersOnceInOngoing(t *testing.T) {
 	}
 }
 
+func TestQueuedUserMessageFailedStatusRestoresPendingInjectedInput(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.pendingInjected = []clientui.QueuedUserMessage{{ID: "queue-1", Text: "steered message"}}
+	m.injectedQueue = []injectedRuntimeQueueItem{{LocalID: "local-1", ServerID: "queue-1", Text: "steered message", State: injectedRuntimeQueueEnqueued}}
+
+	cmd := m.runtimeAdapter().applyProjectedRuntimeEvent(clientui.Event{
+		Kind: clientui.EventQueuedUserMessageStatus,
+		QueuedUserMessageStatus: &clientui.QueuedUserMessageStatusEvent{
+			QueueItemID:   "queue-1",
+			Status:        clientui.QueuedUserMessageFailed,
+			RestoreText:   "steered message",
+			FailureReason: clientui.QueuedUserMessageFailureClosing,
+		},
+	}, true).cmd
+
+	if len(m.pendingInjected) != 0 || len(m.injectedQueue) != 0 {
+		t.Fatalf("expected failed queued item removed, pending=%+v queue=%+v", m.pendingInjected, m.injectedQueue)
+	}
+	if strings.TrimSpace(m.input) != "steered message" {
+		t.Fatalf("input = %q, want restored queued text", m.input)
+	}
+	if m.transientStatus == "" || m.transientStatusKind != uiStatusNoticeError {
+		t.Fatalf("expected transient queue failure status, got %q kind=%d", m.transientStatus, m.transientStatusKind)
+	}
+	if cmd == nil {
+		t.Fatal("expected transient status clear command")
+	}
+}
+
+func TestQueuedUserMessageSubmittedStatusRemovesPendingInjectedInput(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	m.pendingInjected = []clientui.QueuedUserMessage{{ID: "queue-1", Text: "steered message"}, {ID: "queue-2", Text: "follow-up"}}
+	m.injectedQueue = []injectedRuntimeQueueItem{
+		{LocalID: "local-1", ServerID: "queue-1", Text: "steered message", State: injectedRuntimeQueueEnqueued},
+		{LocalID: "local-2", ServerID: "queue-2", Text: "follow-up", State: injectedRuntimeQueueEnqueued},
+	}
+
+	_ = m.runtimeAdapter().applyProjectedRuntimeEvent(clientui.Event{
+		Kind: clientui.EventQueuedUserMessageStatus,
+		QueuedUserMessageStatus: &clientui.QueuedUserMessageStatusEvent{
+			QueueItemID: "queue-1",
+			Status:      clientui.QueuedUserMessageSubmitted,
+		},
+	}, true).cmd
+
+	if len(m.pendingInjected) != 1 || m.pendingInjected[0].ID != "queue-2" {
+		t.Fatalf("pending injected = %+v, want only queue-2", m.pendingInjected)
+	}
+	if len(m.injectedQueue) != 1 || m.injectedQueue[0].ServerID != "queue-2" {
+		t.Fatalf("injected queue = %+v, want only queue-2", m.injectedQueue)
+	}
+	if m.input != "" {
+		t.Fatalf("input = %q, want unchanged empty input", m.input)
+	}
+}
+
 func TestProjectedUserMessageFlushedWithSameTextAndNewCommittedCountAppendsDistinctEntry(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.termWidth = 100

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -18,6 +18,7 @@ import (
 
 const uiRuntimeControlTimeout = 3 * time.Second
 const uiRuntimeHydrationReadTimeout = 10 * time.Second
+const collaborativeFallbackRefreshCooldown = 750 * time.Millisecond
 const runtimeLeaseRecoveryWarningText = "Lost connection to the session runtime; reconnected."
 
 var uiRuntimeReadTimeout = 300 * time.Millisecond
@@ -41,6 +42,7 @@ type sessionRuntimeClient struct {
 	mainView             clientui.RuntimeMainView
 	hasMainView          bool
 	mainViewFallback     bool
+	mainViewRetryAfter   time.Time
 	suffixRPCUnsupported bool
 }
 
@@ -74,10 +76,12 @@ func (c *sessionRuntimeClient) SetAccessMode(mode serverapi.SessionRuntimeAttach
 		c.controllerLease = nil
 		if c.applyCollaborativeMainViewFallbackLocked(&c.mainView) {
 			c.mainViewFallback = true
+			c.mainViewRetryAfter = time.Time{}
 		}
 		c.hasMainView = true
 	} else {
 		c.mainViewFallback = false
+		c.mainViewRetryAfter = time.Time{}
 	}
 	c.mu.Unlock()
 }
@@ -320,7 +324,7 @@ func (c *sessionRuntimeClient) SetLeaseRecoveryWarningObserver(observer func(str
 
 func (c *sessionRuntimeClient) MainView() clientui.RuntimeMainView {
 	view, hasView, fallback := c.cachedMainViewState()
-	if !hasView || fallback {
+	if !hasView || (fallback && c.claimMainViewFallbackRefresh()) {
 		refreshed, err := c.refreshMainViewSync(uiRuntimeReadTimeout)
 		if err == nil {
 			return refreshed
@@ -384,6 +388,23 @@ func (c *sessionRuntimeClient) cachedMainViewState() (clientui.RuntimeMainView, 
 	return view, true, c.mainViewFallback
 }
 
+func (c *sessionRuntimeClient) claimMainViewFallbackRefresh() bool {
+	if c == nil {
+		return false
+	}
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.mainViewFallback {
+		return false
+	}
+	if !c.mainViewRetryAfter.IsZero() && now.Before(c.mainViewRetryAfter) {
+		return false
+	}
+	c.mainViewRetryAfter = now.Add(collaborativeFallbackRefreshCooldown)
+	return true
+}
+
 func (c *sessionRuntimeClient) CachedMainView() (clientui.RuntimeMainView, bool) {
 	if c == nil {
 		return clientui.RuntimeMainView{}, false
@@ -399,6 +420,7 @@ func (c *sessionRuntimeClient) storeMainView(view clientui.RuntimeMainView) clie
 	c.mainView = view
 	c.hasMainView = true
 	c.mainViewFallback = false
+	c.mainViewRetryAfter = time.Time{}
 	c.mu.Unlock()
 	return view
 }
@@ -460,6 +482,7 @@ func (c *sessionRuntimeClient) refreshMainViewSync(timeout time.Duration) (clien
 		}
 		if c.applyCollaborativeMainViewFallbackLocked(&view) {
 			c.mainViewFallback = true
+			c.mainViewRetryAfter = time.Now().Add(collaborativeFallbackRefreshCooldown)
 		}
 		c.mainView = view
 		c.hasMainView = true

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -21,7 +21,8 @@ const uiRuntimeHydrationReadTimeout = 10 * time.Second
 const runtimeLeaseRecoveryWarningText = "Lost connection to the session runtime; reconnected."
 
 var uiRuntimeReadTimeout = 300 * time.Millisecond
-var errReadOnlyRuntime = errors.New("session is read-only because it is controlled by an active headless run")
+var errReadOnlyRuntime = errors.New("session is unavailable for runtime control attachment")
+var errCollaborativeOperationBlocked = errors.New("operation is unavailable for collaborative runtime attach")
 
 type sessionRuntimeClient struct {
 	reads                   client.SessionViewClient
@@ -33,10 +34,13 @@ type sessionRuntimeClient struct {
 	connectionStateObserver func(error)
 	leaseRecoveryWarning    func(string, clientui.EntryVisibility)
 	readOnly                bool
+	accessMode              serverapi.SessionRuntimeAttachMode
+	allowedOperations       map[serverapi.SessionRuntimeOperation]bool
 
 	mu                   sync.RWMutex
 	mainView             clientui.RuntimeMainView
 	hasMainView          bool
+	mainViewFallback     bool
 	suffixRPCUnsupported bool
 }
 
@@ -47,6 +51,72 @@ func (c *sessionRuntimeClient) SetReadOnly(readOnly bool) {
 	c.mu.Lock()
 	c.readOnly = readOnly
 	c.mu.Unlock()
+}
+
+func (c *sessionRuntimeClient) SetAccessMode(mode serverapi.SessionRuntimeAttachMode, operations []serverapi.SessionRuntimeOperation) {
+	if c == nil {
+		return
+	}
+	allowed := make(map[serverapi.SessionRuntimeOperation]bool, len(operations))
+	for _, op := range operations {
+		allowed[op] = true
+	}
+	if mode == serverapi.SessionRuntimeAttachModeCollaborative && len(allowed) == 0 {
+		for _, op := range defaultCollaborativeRuntimeOperations() {
+			allowed[op] = true
+		}
+	}
+	c.mu.Lock()
+	c.accessMode = mode
+	c.readOnly = mode == serverapi.SessionRuntimeAttachModeNoControl
+	c.allowedOperations = allowed
+	if mode == serverapi.SessionRuntimeAttachModeCollaborative {
+		c.controllerLease = nil
+		if c.applyCollaborativeMainViewFallbackLocked(&c.mainView) {
+			c.mainViewFallback = true
+		}
+		c.hasMainView = true
+	} else {
+		c.mainViewFallback = false
+	}
+	c.mu.Unlock()
+}
+
+func (c *sessionRuntimeClient) applyCollaborativeMainViewFallbackLocked(view *clientui.RuntimeMainView) bool {
+	if c == nil || view == nil || c.accessMode != serverapi.SessionRuntimeAttachModeCollaborative {
+		return false
+	}
+	if view.Session.SessionID == "" {
+		view.Session.SessionID = c.sessionID
+	}
+	if view.ExternalRuntime == nil || view.ExternalRuntime.State == "" {
+		status := clientui.ExternalRuntimeStatus{State: clientui.ExternalRuntimeStateOwnerRunning, QueueAccepting: true}
+		view.ExternalRuntime = &status
+		return true
+	}
+	return false
+}
+
+func defaultCollaborativeRuntimeOperations() []serverapi.SessionRuntimeOperation {
+	return []serverapi.SessionRuntimeOperation{
+		serverapi.SessionRuntimeOperationSubmitUserTurn,
+		serverapi.SessionRuntimeOperationQueueUserMessage,
+		serverapi.SessionRuntimeOperationPromptAnswer,
+	}
+}
+
+func (c *sessionRuntimeClient) ensureOperation(op serverapi.SessionRuntimeOperation) error {
+	if err := c.ensureWritable(); err != nil {
+		return err
+	}
+	c.mu.RLock()
+	mode := c.accessMode
+	allowed := c.allowedOperations[op]
+	c.mu.RUnlock()
+	if mode == serverapi.SessionRuntimeAttachModeCollaborative && !allowed {
+		return errCollaborativeOperationBlocked
+	}
+	return nil
 }
 
 func (c *sessionRuntimeClient) ensureWritable() error {
@@ -69,12 +139,30 @@ func (c *sessionRuntimeClient) isReadOnly() bool {
 	return readOnly
 }
 
+func (c *sessionRuntimeClient) isCollaborative() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.accessMode == serverapi.SessionRuntimeAttachModeCollaborative
+}
+
+func (c *sessionRuntimeClient) IsCollaborativeRuntime() bool {
+	return c.isCollaborative()
+}
+
+func (c *sessionRuntimeClient) CanAppendCommittedEntries() bool {
+	return c != nil && !c.isReadOnly() && !c.isCollaborative()
+}
+
 func newUIRuntimeClientWithReads(sessionID string, reads client.SessionViewClient, controls client.RuntimeControlClient) clientui.RuntimeClient {
 	if reads == nil || controls == nil {
 		return nil
 	}
 	return &sessionRuntimeClient{
 		sessionID:       sessionID,
+		accessMode:      serverapi.SessionRuntimeAttachModeController,
 		controllerLease: newControllerLeaseManager("local-ui-controller"),
 		reads:           reads,
 		controls:        controls,
@@ -164,8 +252,12 @@ func (c *sessionRuntimeClient) retryControlCallNoResult(ctx context.Context, cal
 }
 
 func retryRuntimeControlCall[T any](ctx context.Context, currentLeaseID func() string, recoverLease func(context.Context, error, bool) error, appendRecoveryWarning bool, call func(controllerLeaseID string) (T, error)) (T, error) {
-	value, err := call(currentLeaseID())
+	leaseID := strings.TrimSpace(currentLeaseID())
+	value, err := call(leaseID)
 	if !isRecoverableRuntimeControlError(err) {
+		return value, err
+	}
+	if leaseID == "" {
 		return value, err
 	}
 	var zero T
@@ -227,8 +319,8 @@ func (c *sessionRuntimeClient) SetLeaseRecoveryWarningObserver(observer func(str
 }
 
 func (c *sessionRuntimeClient) MainView() clientui.RuntimeMainView {
-	view, hasView := c.cachedMainView()
-	if !hasView {
+	view, hasView, fallback := c.cachedMainViewState()
+	if !hasView || fallback {
 		refreshed, err := c.refreshMainViewSync(uiRuntimeReadTimeout)
 		if err == nil {
 			return refreshed
@@ -278,13 +370,18 @@ func (c *sessionRuntimeClient) readContext(timeout time.Duration) (context.Conte
 }
 
 func (c *sessionRuntimeClient) cachedMainView() (clientui.RuntimeMainView, bool) {
+	view, hasView, _ := c.cachedMainViewState()
+	return view, hasView
+}
+
+func (c *sessionRuntimeClient) cachedMainViewState() (clientui.RuntimeMainView, bool, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	view := c.mainView
 	if !c.hasMainView {
-		return view, false
+		return view, false, false
 	}
-	return view, true
+	return view, true, c.mainViewFallback
 }
 
 func (c *sessionRuntimeClient) CachedMainView() (clientui.RuntimeMainView, bool) {
@@ -301,6 +398,7 @@ func (c *sessionRuntimeClient) storeMainView(view clientui.RuntimeMainView) clie
 	c.mu.Lock()
 	c.mainView = view
 	c.hasMainView = true
+	c.mainViewFallback = false
 	c.mu.Unlock()
 	return view
 }
@@ -359,6 +457,9 @@ func (c *sessionRuntimeClient) refreshMainViewSync(timeout time.Duration) (clien
 		view := c.mainView
 		if view.Session.SessionID == "" {
 			view.Session.SessionID = c.sessionID
+		}
+		if c.applyCollaborativeMainViewFallbackLocked(&view) {
+			c.mainViewFallback = true
 		}
 		c.mainView = view
 		c.hasMainView = true

--- a/cli/app/ui_runtime_client_control.go
+++ b/cli/app/ui_runtime_client_control.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (c *sessionRuntimeClient) SetSessionName(name string) error {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationSettingsSessionName); err != nil {
 		return err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)
@@ -28,7 +28,7 @@ func (c *sessionRuntimeClient) SetSessionName(name string) error {
 }
 
 func (c *sessionRuntimeClient) SetThinkingLevel(level string) error {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationSettingsThinkingLevel); err != nil {
 		return err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)
@@ -45,7 +45,7 @@ func (c *sessionRuntimeClient) SetThinkingLevel(level string) error {
 }
 
 func (c *sessionRuntimeClient) SetFastModeEnabled(enabled bool) (bool, error) {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationSettingsFastMode); err != nil {
 		return false, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)
@@ -62,8 +62,8 @@ func (c *sessionRuntimeClient) SetFastModeEnabled(enabled bool) (bool, error) {
 }
 
 func (c *sessionRuntimeClient) SetReviewerEnabled(enabled bool) (bool, string, error) {
-	if err := c.ensureWritable(); err != nil {
-		return false, "", err
+	if c.isReadOnly() || c.isCollaborative() {
+		return false, "", errCollaborativeOperationBlocked
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)
 	defer cancel()
@@ -80,7 +80,7 @@ func (c *sessionRuntimeClient) SetReviewerEnabled(enabled bool) (bool, string, e
 }
 
 func (c *sessionRuntimeClient) SetAutoCompactionEnabled(enabled bool) (bool, bool, error) {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationSettingsAutoCompaction); err != nil {
 		return false, false, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)
@@ -98,7 +98,7 @@ func (c *sessionRuntimeClient) SetAutoCompactionEnabled(enabled bool) (bool, boo
 }
 
 func (c *sessionRuntimeClient) SetQuestionsEnabled(enabled bool) (bool, error) {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationSettingsQuestions); err != nil {
 		return false, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)
@@ -132,7 +132,7 @@ func (c *sessionRuntimeClient) ShowGoal() (*clientui.RuntimeGoal, error) {
 }
 
 func (c *sessionRuntimeClient) SetGoal(objective string) (*clientui.RuntimeGoal, error) {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationGoalManage); err != nil {
 		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)
@@ -163,7 +163,7 @@ func (c *sessionRuntimeClient) ResumeGoal() (*clientui.RuntimeGoal, error) {
 }
 
 func (c *sessionRuntimeClient) ClearGoal() (*clientui.RuntimeGoal, error) {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationGoalManage); err != nil {
 		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)
@@ -182,7 +182,7 @@ func (c *sessionRuntimeClient) ClearGoal() (*clientui.RuntimeGoal, error) {
 }
 
 func (c *sessionRuntimeClient) setGoalStatus(call func(context.Context, serverapi.RuntimeGoalStatusRequest) (serverapi.RuntimeGoalShowResponse, error)) (*clientui.RuntimeGoal, error) {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationGoalManage); err != nil {
 		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)
@@ -225,8 +225,8 @@ func (c *sessionRuntimeClient) AppendCommittedEntry(role, text string) error {
 }
 
 func (c *sessionRuntimeClient) AppendCommittedEntryWithNoticeID(role, text, noticeID string) error {
-	if err := c.ensureWritable(); err != nil {
-		return err
+	if c.isReadOnly() || c.isCollaborative() {
+		return errCollaborativeOperationBlocked
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)
 	defer cancel()
@@ -236,7 +236,7 @@ func (c *sessionRuntimeClient) AppendCommittedEntryWithNoticeID(role, text, noti
 }
 
 func (c *sessionRuntimeClient) SubmitUserMessage(ctx context.Context, text string) (string, error) {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationSubmitUserTurn); err != nil {
 		return "", err
 	}
 	requestID := uuid.NewString()
@@ -247,7 +247,7 @@ func (c *sessionRuntimeClient) SubmitUserMessage(ctx context.Context, text strin
 }
 
 func (c *sessionRuntimeClient) SubmitUserMessageWithPromptHistoryRecorded(ctx context.Context, text string) (string, error) {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationSubmitUserTurn); err != nil {
 		return "", err
 	}
 	requestID := uuid.NewString()
@@ -258,8 +258,8 @@ func (c *sessionRuntimeClient) SubmitUserMessageWithPromptHistoryRecorded(ctx co
 }
 
 func (c *sessionRuntimeClient) SubmitUserShellCommand(ctx context.Context, command string) error {
-	if err := c.ensureWritable(); err != nil {
-		return err
+	if c.isReadOnly() || c.isCollaborative() {
+		return errCollaborativeOperationBlocked
 	}
 	return c.retryControlCallNoResult(ctx, func(controllerLeaseID string) error {
 		return c.controls.SubmitUserShellCommand(ctx, serverapi.RuntimeSubmitUserShellCommandRequest{ClientRequestID: uuid.NewString(), SessionID: c.sessionID, ControllerLeaseID: controllerLeaseID, Command: command})
@@ -267,7 +267,7 @@ func (c *sessionRuntimeClient) SubmitUserShellCommand(ctx context.Context, comma
 }
 
 func (c *sessionRuntimeClient) CompactContext(ctx context.Context, args string) error {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationCompactManual); err != nil {
 		return err
 	}
 	return c.retryControlCallNoResult(ctx, func(controllerLeaseID string) error {
@@ -288,7 +288,7 @@ func (c *sessionRuntimeClient) HasQueuedUserWork() (bool, error) {
 }
 
 func (c *sessionRuntimeClient) SubmitQueuedUserMessages(ctx context.Context) (string, error) {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationSubmitQueuedUserMessages); err != nil {
 		return "", err
 	}
 	resp, err := retryRuntimeControlCall(ctx, c.controllerLeaseIDValue, c.recoverControllerLeaseWithWarning, true, func(controllerLeaseID string) (serverapi.RuntimeSubmitQueuedUserMessagesResponse, error) {
@@ -298,8 +298,8 @@ func (c *sessionRuntimeClient) SubmitQueuedUserMessages(ctx context.Context) (st
 }
 
 func (c *sessionRuntimeClient) Interrupt() error {
-	if err := c.ensureWritable(); err != nil {
-		return err
+	if c.isReadOnly() || c.isCollaborative() {
+		return errCollaborativeOperationBlocked
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)
 	defer cancel()
@@ -309,12 +309,19 @@ func (c *sessionRuntimeClient) Interrupt() error {
 }
 
 func (c *sessionRuntimeClient) QueueUserMessage(text string) (clientui.QueuedUserMessage, error) {
-	if err := c.ensureWritable(); err != nil {
+	return c.QueueUserMessageWithClientRequestID(text, uuid.NewString())
+}
+
+func (c *sessionRuntimeClient) QueueUserMessageWithClientRequestID(text string, clientRequestID string) (clientui.QueuedUserMessage, error) {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationQueueUserMessage); err != nil {
 		return clientui.QueuedUserMessage{}, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)
 	defer cancel()
-	requestID := uuid.NewString()
+	requestID := strings.TrimSpace(clientRequestID)
+	if requestID == "" {
+		requestID = uuid.NewString()
+	}
 	resp, err := retryRuntimeControlCall(ctx, c.controllerLeaseIDValue, c.recoverControllerLeaseWithWarning, true, func(controllerLeaseID string) (serverapi.RuntimeQueueUserMessageResponse, error) {
 		return c.controls.QueueUserMessage(ctx, serverapi.RuntimeQueueUserMessageRequest{ClientRequestID: requestID, SessionID: c.sessionID, ControllerLeaseID: controllerLeaseID, Text: text})
 	})
@@ -322,11 +329,15 @@ func (c *sessionRuntimeClient) QueueUserMessage(text string) (clientui.QueuedUse
 		c.notifyConnectionState(err)
 		return clientui.QueuedUserMessage{}, err
 	}
-	return clientui.QueuedUserMessage{ID: resp.QueueItemID, Text: resp.Text}, nil
+	responseClientRequestID := strings.TrimSpace(resp.ClientRequestID)
+	if responseClientRequestID == "" {
+		responseClientRequestID = requestID
+	}
+	return clientui.QueuedUserMessage{ID: resp.QueueItemID, Text: resp.Text, ClientRequestID: responseClientRequestID}, nil
 }
 
 func (c *sessionRuntimeClient) DiscardQueuedUserMessage(queueItemID string) bool {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationDiscardQueuedUserMessage); err != nil {
 		return false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)
@@ -341,7 +352,7 @@ func (c *sessionRuntimeClient) DiscardQueuedUserMessage(queueItemID string) bool
 }
 
 func (c *sessionRuntimeClient) RecordPromptHistory(text string) error {
-	if err := c.ensureWritable(); err != nil {
+	if err := c.ensureOperation(serverapi.SessionRuntimeOperationRecordPromptHistory); err != nil {
 		return err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), uiRuntimeControlTimeout)

--- a/cli/app/ui_runtime_client_part2_test.go
+++ b/cli/app/ui_runtime_client_part2_test.go
@@ -43,28 +43,29 @@ func TestRuntimeClientMainViewDoesNotRefreshCachedSnapshotBehindUIBack(t *testin
 }
 
 type leaseRetryRuntimeControlClient struct {
-	mu              sync.Mutex
-	firstSubmitErr  error
-	appendErr       error
-	compactErr      error
-	compactCalls    int
-	showGoalErr     error
-	showGoalCalls   int
-	queuedWorkErr   error
-	queuedWork      bool
-	queuedWorkCalls int
-	submitLeaseID   []string
-	submitRequestID []string
-	submitRecorded  []bool
-	queueRequestID  []string
-	recordRequestID []string
-	goalLeaseID     []string
-	localEntries    []serverapi.RuntimeAppendCommittedEntryRequest
-	showGoalResp    serverapi.RuntimeGoalShowResponse
-	setGoalResp     serverapi.RuntimeGoalShowResponse
-	pauseGoalResp   serverapi.RuntimeGoalShowResponse
-	resumeGoalResp  serverapi.RuntimeGoalShowResponse
-	clearGoalResp   serverapi.RuntimeGoalShowResponse
+	mu               sync.Mutex
+	firstSubmitErr   error
+	allowEmptySubmit bool
+	appendErr        error
+	compactErr       error
+	compactCalls     int
+	showGoalErr      error
+	showGoalCalls    int
+	queuedWorkErr    error
+	queuedWork       bool
+	queuedWorkCalls  int
+	submitLeaseID    []string
+	submitRequestID  []string
+	submitRecorded   []bool
+	queueRequestID   []string
+	recordRequestID  []string
+	goalLeaseID      []string
+	localEntries     []serverapi.RuntimeAppendCommittedEntryRequest
+	showGoalResp     serverapi.RuntimeGoalShowResponse
+	setGoalResp      serverapi.RuntimeGoalShowResponse
+	pauseGoalResp    serverapi.RuntimeGoalShowResponse
+	resumeGoalResp   serverapi.RuntimeGoalShowResponse
+	clearGoalResp    serverapi.RuntimeGoalShowResponse
 }
 
 func (c *leaseRetryRuntimeControlClient) submitLeaseIDs() []string {
@@ -180,6 +181,9 @@ func (c *leaseRetryRuntimeControlClient) SubmitUserTurn(_ context.Context, req s
 	c.submitLeaseID = append(c.submitLeaseID, req.ControllerLeaseID)
 	c.submitRequestID = append(c.submitRequestID, req.ClientRequestID)
 	c.submitRecorded = append(c.submitRecorded, req.PromptHistoryRecorded)
+	if c.allowEmptySubmit && req.ControllerLeaseID == "" {
+		return serverapi.RuntimeSubmitUserTurnResponse{Message: "collaborative"}, nil
+	}
 	switch req.ControllerLeaseID {
 	case "lease-old":
 		if c.firstSubmitErr != nil {
@@ -508,6 +512,36 @@ func TestRuntimeClientSubmitUserMessageRecoversInvalidControllerLease(t *testing
 	}
 }
 
+func TestRuntimeClientCollaborativeSubmitDoesNotRecoverControllerLease(t *testing.T) {
+	controls := &leaseRetryRuntimeControlClient{}
+	runtimeClient := newTestSessionRuntimeClientWithControls(controls)
+	runtimeClient.SetAccessMode(serverapi.SessionRuntimeAttachModeCollaborative, []serverapi.SessionRuntimeOperation{
+		serverapi.SessionRuntimeOperationSubmitUserTurn,
+	})
+
+	_, err := runtimeClient.SubmitUserMessage(context.Background(), "hello")
+	if err == nil || !strings.Contains(err.Error(), "unexpected controller lease") {
+		t.Fatalf("SubmitUserMessage error = %v, want original server error", err)
+	}
+	if got := controls.submitLeaseIDs(); !reflect.DeepEqual(got, []string{""}) {
+		t.Fatalf("submit lease ids = %+v, want one empty collaborative lease", got)
+	}
+}
+
+func TestRuntimeClientCollaborativeEmptyOperationsStillAllowsSteering(t *testing.T) {
+	controls := &leaseRetryRuntimeControlClient{}
+	runtimeClient := newTestSessionRuntimeClientWithControls(controls)
+	runtimeClient.SetAccessMode(serverapi.SessionRuntimeAttachModeCollaborative, nil)
+
+	_, err := runtimeClient.SubmitUserMessage(context.Background(), "hello")
+	if err == nil || !strings.Contains(err.Error(), "unexpected controller lease") {
+		t.Fatalf("SubmitUserMessage error = %v, want original server error after allowed collaborative submit", err)
+	}
+	if got := controls.submitLeaseIDs(); !reflect.DeepEqual(got, []string{""}) {
+		t.Fatalf("submit lease ids = %+v, want one empty collaborative lease", got)
+	}
+}
+
 func TestRuntimeClientSubmitUserMessageCanSkipPromptHistoryAcrossLeaseRecovery(t *testing.T) {
 	controls := &leaseRetryRuntimeControlClient{firstSubmitErr: serverapi.ErrRuntimeUnavailable}
 	runtimeClient := newTestSessionRuntimeClientWithControls(controls)
@@ -546,6 +580,8 @@ func TestRuntimeClientQueueUserMessageReusesRequestIDAcrossLeaseRecovery(t *test
 	}
 	if got := controls.queueRequestIDs(); len(got) != 2 || got[0] == "" || got[0] != got[1] {
 		t.Fatalf("queue request ids = %+v, want same non-empty id across retry", got)
+	} else if item.ClientRequestID != got[0] {
+		t.Fatalf("queued item client request id = %q, want %q", item.ClientRequestID, got[0])
 	}
 }
 

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -1787,6 +1787,22 @@ func TestRuntimeClientCollaborativeMainViewSeedsBusyFallbackBeforeHydration(t *t
 	}
 }
 
+func TestRuntimeClientCollaborativeMainViewThrottlesFallbackHydrationRetry(t *testing.T) {
+	withUIRuntimeReadTimeout(t, time.Millisecond)
+
+	reads := &blockingCountingSessionViewClient{}
+	runtimeClient := newRuntimeClientReadTest(reads).(*sessionRuntimeClient)
+	runtimeClient.SetAccessMode(serverapi.SessionRuntimeAttachModeCollaborative, []serverapi.SessionRuntimeOperation{
+		serverapi.SessionRuntimeOperationQueueUserMessage,
+	})
+
+	_ = runtimeClient.MainView()
+	_ = runtimeClient.MainView()
+	if got := reads.count.Load(); got != 1 {
+		t.Fatalf("main view read count before fallback retry cooldown = %d, want 1", got)
+	}
+}
+
 func TestRuntimeClientCollaborativeRefreshMainViewKeepsBusyFallbackOnReadError(t *testing.T) {
 	runtimeClient := newRuntimeClientReadTest(&blockingCountingSessionViewClient{}).(*sessionRuntimeClient)
 	runtimeClient.SetAccessMode(serverapi.SessionRuntimeAttachModeCollaborative, nil)

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -1766,6 +1766,57 @@ func TestRuntimeClientMainViewFailsFastWhenReadStalls(t *testing.T) {
 	}
 }
 
+func TestRuntimeClientCollaborativeMainViewSeedsBusyFallbackBeforeHydration(t *testing.T) {
+	withUIRuntimeReadTimeout(t, time.Millisecond)
+
+	reads := &blockingCountingSessionViewClient{}
+	runtimeClient := newRuntimeClientReadTest(reads).(*sessionRuntimeClient)
+	runtimeClient.SetAccessMode(serverapi.SessionRuntimeAttachModeCollaborative, []serverapi.SessionRuntimeOperation{
+		serverapi.SessionRuntimeOperationQueueUserMessage,
+	})
+
+	view := runtimeClient.MainView()
+	if view.Session.SessionID != "session-1" {
+		t.Fatalf("fallback session id = %q, want session-1", view.Session.SessionID)
+	}
+	if view.ExternalRuntime == nil || view.ExternalRuntime.State != clientui.ExternalRuntimeStateOwnerRunning || !view.ExternalRuntime.QueueAccepting {
+		t.Fatalf("external runtime fallback = %+v, want owner-running accepting", view.ExternalRuntime)
+	}
+	if got := reads.count.Load(); got != 1 {
+		t.Fatalf("main view read count = %d, want one hydration attempt before fallback", got)
+	}
+}
+
+func TestRuntimeClientCollaborativeRefreshMainViewKeepsBusyFallbackOnReadError(t *testing.T) {
+	runtimeClient := newRuntimeClientReadTest(&blockingCountingSessionViewClient{}).(*sessionRuntimeClient)
+	runtimeClient.SetAccessMode(serverapi.SessionRuntimeAttachModeCollaborative, nil)
+
+	view, err := runtimeClient.refreshMainViewSync(time.Millisecond)
+	if err == nil {
+		t.Fatal("expected refresh error")
+	}
+	if view.ExternalRuntime == nil || view.ExternalRuntime.State != clientui.ExternalRuntimeStateOwnerRunning || !view.ExternalRuntime.QueueAccepting {
+		t.Fatalf("external runtime fallback = %+v, want owner-running accepting", view.ExternalRuntime)
+	}
+}
+
+func TestRuntimeClientCollaborativeRefreshMainViewAllowsAuthoritativeDowngrade(t *testing.T) {
+	reads := &countingSessionViewClient{view: clientui.RuntimeMainView{
+		Session:         clientui.RuntimeSessionView{SessionID: "session-1"},
+		ExternalRuntime: &clientui.ExternalRuntimeStatus{State: clientui.ExternalRuntimeStateRegisteredIdle, QueueAccepting: true},
+	}}
+	runtimeClient := newRuntimeClientReadTest(reads).(*sessionRuntimeClient)
+	runtimeClient.SetAccessMode(serverapi.SessionRuntimeAttachModeCollaborative, nil)
+
+	view, err := runtimeClient.RefreshMainView()
+	if err != nil {
+		t.Fatalf("RefreshMainView: %v", err)
+	}
+	if view.ExternalRuntime == nil || view.ExternalRuntime.State != clientui.ExternalRuntimeStateRegisteredIdle || !view.ExternalRuntime.QueueAccepting {
+		t.Fatalf("external runtime state = %+v, want authoritative registered-idle accepting", view.ExternalRuntime)
+	}
+}
+
 func withUIRuntimeReadTimeout(t *testing.T, timeout time.Duration) {
 	t.Helper()
 	original := uiRuntimeReadTimeout

--- a/cli/app/ui_runtime_control_test.go
+++ b/cli/app/ui_runtime_control_test.go
@@ -680,6 +680,12 @@ func TestCollaborativeSubmitActiveOwnerRaceQueuesSubmittedText(t *testing.T) {
 	if len(updated.pendingInjected) != 1 || updated.pendingInjected[0].Text != "race text" {
 		t.Fatalf("pending injected = %+v, want queued submitted text", updated.pendingInjected)
 	}
+	if !updated.isBusy() {
+		t.Fatal("expected active-owner fallback to stay busy while queued text waits for owner")
+	}
+	if client.submitQueuedCalls != 0 {
+		t.Fatalf("SubmitQueuedUserMessages calls = %d, want none while owner is active", client.submitQueuedCalls)
+	}
 	if updated.input != "" {
 		t.Fatalf("input = %q, want no restored text after successful queue", updated.input)
 	}

--- a/cli/app/ui_runtime_control_test.go
+++ b/cli/app/ui_runtime_control_test.go
@@ -29,6 +29,7 @@ type runtimeControlFakeClient struct {
 	setFastModeCalls       int
 	setReviewerArg         bool
 	setAutoCompactArg      bool
+	setAutoCompactCalls    int
 	goal                   *clientui.RuntimeGoal
 	showGoalCalls          int
 	setGoalArg             string
@@ -142,6 +143,7 @@ func (f *runtimeControlFakeClient) SetReviewerEnabled(enabled bool) (bool, strin
 }
 func (f *runtimeControlFakeClient) SetAutoCompactionEnabled(enabled bool) (bool, bool, error) {
 	f.setAutoCompactArg = enabled
+	f.setAutoCompactCalls++
 	return true, enabled, f.err
 }
 func (f *runtimeControlFakeClient) SetQuestionsEnabled(enabled bool) (bool, error) {

--- a/cli/app/ui_runtime_control_test.go
+++ b/cli/app/ui_runtime_control_test.go
@@ -12,6 +12,7 @@ import (
 	"core/server/llm"
 	"core/server/primaryrun"
 	"core/shared/clientui"
+	"core/shared/serverapi"
 	"core/shared/transcript"
 )
 
@@ -29,6 +30,7 @@ type runtimeControlFakeClient struct {
 	setReviewerArg         bool
 	setAutoCompactArg      bool
 	goal                   *clientui.RuntimeGoal
+	showGoalCalls          int
 	setGoalArg             string
 	pauseGoalCalls         int
 	resumeGoalCalls        int
@@ -49,6 +51,7 @@ type runtimeControlFakeClient struct {
 	submitQueuedCalls      int
 	interruptCalls         int
 	queuedText             string
+	queuedClientRequestID  string
 	queueUserMessageCalls  int
 	queueUserMessageErr    error
 	queueUserMessageID     string
@@ -70,6 +73,7 @@ type runtimeControlFakeClient struct {
 	submitQueuedErr        error
 	interruptErr           error
 	recordPromptHistoryErr error
+	collaborative          bool
 }
 
 type timeoutNetError struct{}
@@ -79,11 +83,12 @@ func (timeoutNetError) Timeout() bool   { return true }
 func (timeoutNetError) Temporary() bool { return false }
 
 func (f *runtimeControlFakeClient) MainView() clientui.RuntimeMainView {
-	if f.mainView.Session.SessionID != "" || f.mainView.Status.ThinkingLevel != "" || f.mainView.ActiveRun != nil {
+	if f.mainView.Session.SessionID != "" || f.mainView.Status.ThinkingLevel != "" || f.mainView.ActiveRun != nil || f.mainView.ExternalRuntime != nil || f.mainView.Status.WorkflowSession != nil || f.mainView.Status.WorkflowActive {
 		return f.mainView
 	}
 	return clientui.RuntimeMainView{Status: f.status, Session: f.sessionView}
 }
+func (f *runtimeControlFakeClient) IsCollaborativeRuntime() bool { return f.collaborative }
 func (f *runtimeControlFakeClient) CachedMainView() (clientui.RuntimeMainView, bool) {
 	if f.hasCachedMainView {
 		return f.cachedMainView, true
@@ -143,6 +148,7 @@ func (f *runtimeControlFakeClient) SetQuestionsEnabled(enabled bool) (bool, erro
 	return true, f.err
 }
 func (f *runtimeControlFakeClient) ShowGoal() (*clientui.RuntimeGoal, error) {
+	f.showGoalCalls++
 	return cloneRuntimeGoal(f.goal), f.err
 }
 func (f *runtimeControlFakeClient) SetGoal(objective string) (*clientui.RuntimeGoal, error) {
@@ -248,8 +254,13 @@ func (f *runtimeControlFakeClient) Interrupt() error {
 	return f.err
 }
 func (f *runtimeControlFakeClient) QueueUserMessage(text string) (clientui.QueuedUserMessage, error) {
+	return f.QueueUserMessageWithClientRequestID(text, "")
+}
+
+func (f *runtimeControlFakeClient) QueueUserMessageWithClientRequestID(text string, clientRequestID string) (clientui.QueuedUserMessage, error) {
 	f.queueUserMessageCalls++
 	f.queuedText = text
+	f.queuedClientRequestID = strings.TrimSpace(clientRequestID)
 	if f.queueUserMessageErr != nil {
 		return clientui.QueuedUserMessage{}, f.queueUserMessageErr
 	}
@@ -257,7 +268,7 @@ func (f *runtimeControlFakeClient) QueueUserMessage(text string) (clientui.Queue
 	if id == "" {
 		id = "queue-1"
 	}
-	return clientui.QueuedUserMessage{ID: id, Text: text}, nil
+	return clientui.QueuedUserMessage{ID: id, Text: text, ClientRequestID: f.queuedClientRequestID}, nil
 }
 func (f *runtimeControlFakeClient) DiscardQueuedUserMessage(queueItemID string) bool {
 	f.discardQueuedCalls++
@@ -643,6 +654,58 @@ func TestSubmitErrorWithRuntimeClientAppendsActivePrimaryRunEntry(t *testing.T) 
 	}
 }
 
+func TestCollaborativeSubmitActiveOwnerRaceQueuesSubmittedText(t *testing.T) {
+	client := &runtimeControlFakeClient{collaborative: true}
+	m := newProjectedStaticUIModel()
+	m.engine = client
+	m.setBusy(true)
+
+	next, cmd := m.Update(submitDoneMsg{err: serverapi.ErrActivePrimaryRun, submittedText: "race text"})
+	updated := next.(*uiModel)
+	if updated.activity != uiActivityRunning {
+		t.Fatalf("activity = %v, want running while queue create is pending", updated.activity)
+	}
+	if updated.input != "" {
+		t.Fatalf("input = %q, want submitted text kept out of input while queued", updated.input)
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
+	if client.queueUserMessageCalls != 1 || client.queuedText != "race text" {
+		t.Fatalf("queue calls=%d text=%q, want one queue of submitted text", client.queueUserMessageCalls, client.queuedText)
+	}
+	if len(updated.pendingInjected) != 1 || updated.pendingInjected[0].Text != "race text" {
+		t.Fatalf("pending injected = %+v, want queued submitted text", updated.pendingInjected)
+	}
+	if updated.input != "" {
+		t.Fatalf("input = %q, want no restored text after successful queue", updated.input)
+	}
+}
+
+func TestCollaborativeSubmitActiveOwnerRaceQueueFailureRestoresSubmittedText(t *testing.T) {
+	client := &runtimeControlFakeClient{collaborative: true, queueUserMessageErr: errors.New("queue closed")}
+	m := newProjectedStaticUIModel()
+	m.engine = client
+	m.setBusy(true)
+
+	next, cmd := m.Update(submitDoneMsg{err: serverapi.ErrActivePrimaryRun, submittedText: "race text"})
+	updated := next.(*uiModel)
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
+	if client.queueUserMessageCalls != 1 {
+		t.Fatalf("queue calls=%d, want one queue attempt", client.queueUserMessageCalls)
+	}
+	if len(updated.pendingInjected) != 0 {
+		t.Fatalf("pending injected = %+v, want restored after queue failure", updated.pendingInjected)
+	}
+	if strings.TrimSpace(updated.input) != "race text" {
+		t.Fatalf("input = %q, want restored submitted text", updated.input)
+	}
+}
+
 func TestActiveSubmitErrorShowsStatusOnlyWhenRuntimeAppendFails(t *testing.T) {
 	client := &runtimeControlFakeClient{appendErr: errors.New("append failed")}
 	m := newProjectedStaticUIModel()
@@ -824,5 +887,83 @@ func TestRuntimeControlOpTimeoutDoesNotMarkDisconnect(t *testing.T) {
 	}
 	if m.runtimeDisconnectStatusVisible() {
 		t.Fatal("did not expect op timeout to mark disconnect")
+	}
+}
+
+func TestCollaborativeRuntimeLocalFeedbackDoesNotAppendCommittedEntry(t *testing.T) {
+	controls := &leaseRetryRuntimeControlClient{}
+	runtimeClient := newTestSessionRuntimeClientWithControls(controls)
+	runtimeClient.SetAccessMode(serverapi.SessionRuntimeAttachModeCollaborative, []serverapi.SessionRuntimeOperation{
+		serverapi.SessionRuntimeOperationSubmitUserTurn,
+	})
+	m := newProjectedStaticUIModel()
+	m.engine = runtimeClient
+
+	cmd := m.appendLocalEntryWithNoticeID("error", "blocked command", "notice-1")
+
+	if cmd == nil {
+		t.Fatal("expected transient status clear command")
+	}
+	if m.transientStatus != "blocked command" || m.transientStatusKind != uiStatusNoticeError {
+		t.Fatalf("transient status = %q kind=%d, want local error feedback", m.transientStatus, m.transientStatusKind)
+	}
+	if entries := controls.appendedLocalEntries(); len(entries) != 0 {
+		t.Fatalf("did not expect collaborative local feedback to append committed entries, got %+v", entries)
+	}
+}
+
+func TestRuntimeMainViewExternalOwnerStateDrivesBusyFallback(t *testing.T) {
+	tests := []struct {
+		name string
+		view clientui.RuntimeMainView
+		busy bool
+	}{
+		{
+			name: "owner running",
+			view: clientui.RuntimeMainView{ExternalRuntime: &clientui.ExternalRuntimeStatus{State: clientui.ExternalRuntimeStateOwnerRunning, QueueAccepting: true}},
+			busy: true,
+		},
+		{
+			name: "closing",
+			view: clientui.RuntimeMainView{ExternalRuntime: &clientui.ExternalRuntimeStatus{State: clientui.ExternalRuntimeStateClosing}},
+			busy: true,
+		},
+		{
+			name: "draining",
+			view: clientui.RuntimeMainView{ExternalRuntime: &clientui.ExternalRuntimeStatus{State: clientui.ExternalRuntimeStateDraining}},
+			busy: true,
+		},
+		{
+			name: "registered idle",
+			view: clientui.RuntimeMainView{ExternalRuntime: &clientui.ExternalRuntimeStatus{State: clientui.ExternalRuntimeStateRegisteredIdle, QueueAccepting: true}},
+			busy: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newProjectedStaticUIModel()
+			m.applyRuntimeMainViewState(tt.view)
+			if m.isBusy() != tt.busy {
+				t.Fatalf("busy = %v, want %v", m.isBusy(), tt.busy)
+			}
+		})
+	}
+}
+
+func TestExternalOwnerStatusEventKeepsIdleRunStateBusy(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	adapter := uiRuntimeAdapter{model: m}
+	adapter.applyProjectedRuntimeEvent(clientui.Event{
+		Kind:                  clientui.EventExternalRuntimeStatus,
+		ExternalRuntimeStatus: &clientui.ExternalRuntimeStatus{State: clientui.ExternalRuntimeStateDraining},
+	}, false)
+
+	adapter.applyProjectedRuntimeEvent(clientui.Event{
+		Kind:     clientui.EventRunStateChanged,
+		RunState: &clientui.RunState{Lifecycle: clientui.IdleRunLifecycle()},
+	}, false)
+
+	if !m.isBusy() || m.activity != uiActivityRunning {
+		t.Fatalf("busy=%t activity=%v, want busy running while external owner drains", m.isBusy(), m.activity)
 	}
 }

--- a/cli/app/ui_runtime_event_reduction.go
+++ b/cli/app/ui_runtime_event_reduction.go
@@ -68,6 +68,9 @@ func (a uiRuntimeAdapter) applyRuntimeEventReduction(reduction runtimestate.Runt
 	m.setCompacting(reduction.RunState.State.Compaction.IsRunning())
 	m.setReviewerRunning(reduction.RunState.State.Reviewer.IsRunning())
 	m.setReviewerBlocking(reduction.RunState.State.Reviewer.IsBlocking())
+	if reduction.RunState.ExternalRuntime != nil {
+		m.setExternalRuntimeStatus(reduction.RunState.ExternalRuntime)
+	}
 	m.conversationFreshness = reduction.Conversation.State.Freshness
 	m.reasoningStatusHeader = reduction.Reasoning.State.StatusHeader
 	m.pendingInjected = reduction.PendingInput.State.PendingInjected
@@ -75,6 +78,10 @@ func (a uiRuntimeAdapter) applyRuntimeEventReduction(reduction runtimestate.Runt
 	m.lockedInjectText = reduction.PendingInput.State.LockedInjectText
 	m.lockedInjectID = reduction.PendingInput.State.LockedInjectID
 	m.setInputSubmitLocked(reduction.PendingInput.State.Submission == runtimestate.InputSubmissionLocked)
+	if reduction.PendingInput.RestoredText != "" {
+		m.inputController().restoreInjectedTextIntoInput(reduction.PendingInput.RestoredText)
+		cmd = tea.Batch(cmd, m.sendTransientStatusWithNoticeID("queued message was not submitted; restored to input", uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, ""))
+	}
 	switch reduction.PendingInput.DraftCommand {
 	case runtimestate.RuntimePendingInputClearDraft:
 		m.clearInput()
@@ -82,9 +89,16 @@ func (a uiRuntimeAdapter) applyRuntimeEventReduction(reduction runtimestate.Runt
 	switch reduction.RunState.Activity {
 	case runtimestate.RuntimeActivityRunning:
 		m.activity = uiActivityRunning
+		m.setBusy(true)
 	case runtimestate.RuntimeActivityIdle:
-		m.activity = uiActivityIdle
-		cmd = tea.Batch(cmd, m.releaseDeferredRuntimeSyncs())
+		if m.externalRuntimeBusy() {
+			m.activity = uiActivityRunning
+			m.setBusy(true)
+		} else {
+			m.activity = uiActivityIdle
+			m.setBusy(false)
+			cmd = tea.Batch(cmd, m.releaseDeferredRuntimeSyncs())
+		}
 	}
 	switch reduction.BackgroundProcesses.Command {
 	case runtimestate.RuntimeBackgroundProcessRefresh:

--- a/cli/app/ui_runtime_event_reduction.go
+++ b/cli/app/ui_runtime_event_reduction.go
@@ -74,7 +74,9 @@ func (a uiRuntimeAdapter) applyRuntimeEventReduction(reduction runtimestate.Runt
 	m.conversationFreshness = reduction.Conversation.State.Freshness
 	m.reasoningStatusHeader = reduction.Reasoning.State.StatusHeader
 	m.pendingInjected = reduction.PendingInput.State.PendingInjected
-	m.removeInjectedQueueItemsByIDs(reduction.PendingInput.ConsumedQueueItemIDs)
+	for _, answer := range m.removeInjectedQueueItemsByIDs(reduction.PendingInput.ConsumedQueueItemIDs) {
+		cmd = tea.Batch(cmd, m.answerQueuedApprovalCommentary(answer))
+	}
 	m.lockedInjectText = reduction.PendingInput.State.LockedInjectText
 	m.lockedInjectID = reduction.PendingInput.State.LockedInjectID
 	m.setInputSubmitLocked(reduction.PendingInput.State.Submission == runtimestate.InputSubmissionLocked)

--- a/cli/app/ui_runtime_status.go
+++ b/cli/app/ui_runtime_status.go
@@ -29,14 +29,47 @@ func (m *uiModel) applyRuntimeMainViewState(view clientui.RuntimeMainView) {
 	m.fastModeEnabled = status.FastModeEnabled
 	m.conversationFreshness = status.ConversationFreshness
 	m.setRuntimeContextUsage(view.Session.SessionID, status.ContextUsage)
-	active := view.ActiveRun != nil && view.ActiveRun.Status == clientui.RunStatusRunning
+	m.setExternalRuntimeStatus(view.ExternalRuntime)
+	activeRun := view.ActiveRun != nil && view.ActiveRun.Status == clientui.RunStatusRunning
+	active := activeRun || m.externalRuntimeBusy()
 	m.setBusy(active)
-	m.setGoalRun(active && view.ActiveRun.Lifecycle.IsGoalLoopRunning())
+	m.setGoalRun(activeRun && view.ActiveRun.Lifecycle.IsGoalLoopRunning())
 	if active {
 		m.activity = uiActivityRunning
 		return
 	}
 	m.activity = uiActivityIdle
+}
+
+func externalRuntimeBusy(status *clientui.ExternalRuntimeStatus) bool {
+	if status == nil {
+		return false
+	}
+	switch status.State {
+	case clientui.ExternalRuntimeStateOwnerRunning, clientui.ExternalRuntimeStateDraining, clientui.ExternalRuntimeStateClosing:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *uiModel) setExternalRuntimeStatus(status *clientui.ExternalRuntimeStatus) {
+	if m == nil {
+		return
+	}
+	if status == nil || status.State == "" {
+		m.externalRuntimeStatus = nil
+		return
+	}
+	next := *status
+	m.externalRuntimeStatus = &next
+}
+
+func (m *uiModel) externalRuntimeBusy() bool {
+	if m == nil {
+		return false
+	}
+	return externalRuntimeBusy(m.externalRuntimeStatus)
 }
 
 func (m *uiModel) runtimeMainView() clientui.RuntimeMainView {

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -56,6 +56,7 @@ type uiInputFeatureState struct {
 	promptHistoryDraftCursor int
 	activity                 uiActivity
 	runtimeLifecycle         runtimestate.RuntimeRunState
+	externalRuntimeStatus    *clientui.ExternalRuntimeStatus
 	reviewerEnabled          bool
 	reviewerMode             string
 	autoCompactionEnabled    bool

--- a/cli/kent/goal_command_test.go
+++ b/cli/kent/goal_command_test.go
@@ -385,17 +385,12 @@ func TestGoalCommandSubprocessTargetsLiveSessionFromUnboundWorktree(t *testing.T
 		t.Fatalf("goal set overwrite stdout = %q, want empty", overwriteOutput)
 	}
 	for _, want := range []string{
-		"status: active",
-		"<goal>\nexercise live goal CLI\n</goal>",
-		"Overwriting an existing goal is not allowed",
-		"active or paused",
+		"collaborative runtime",
+		"unavailable",
 	} {
 		if !strings.Contains(overwriteErr, want) {
 			t.Fatalf("goal set overwrite stderr missing %q: %q", want, overwriteErr)
 		}
-	}
-	if strings.Contains(overwriteErr, "Detected invocation by the agent") {
-		t.Fatalf("goal set overwrite stderr used generic agent-denial reason: %q", overwriteErr)
 	}
 	record, err = metadataStore.ResolvePersistedSession(context.Background(), store.Meta().SessionID)
 	if err != nil {
@@ -405,30 +400,30 @@ func TestGoalCommandSubprocessTargetsLiveSessionFromUnboundWorktree(t *testing.T
 		t.Fatalf("persisted goal after rejected overwrite = %+v", goal)
 	}
 
-	completeOutput, completeErr := runGoalCommandSubprocess(t, kentPath, unboundWorktree, store.Meta().SessionID, "complete", "--confirm")
-	if completeErr != "" {
-		t.Fatalf("goal complete stderr = %q", completeErr)
+	completeOutput, completeErr, completeRunErr := runGoalCommandSubprocessRaw(t, kentPath, unboundWorktree, store.Meta().SessionID, "complete", "--confirm")
+	if completeRunErr == nil {
+		t.Fatalf("goal complete unexpectedly succeeded stdout=%q stderr=%q", completeOutput, completeErr)
 	}
-	if !strings.Contains(completeOutput, "Status: complete") {
-		t.Fatalf("complete stdout = %q", completeOutput)
+	if completeOutput != "" {
+		t.Fatalf("goal complete stdout = %q, want empty", completeOutput)
+	}
+	if !strings.Contains(completeErr, "collaborative runtime") || !strings.Contains(completeErr, "unavailable") {
+		t.Fatalf("goal complete stderr = %q, want collaborative runtime unavailable", completeErr)
 	}
 
-	setOutput, setErr := runGoalCommandSubprocess(t, kentPath, unboundWorktree, store.Meta().SessionID, "set", "follow-up live goal CLI")
-	if setErr != "" {
-		t.Fatalf("goal set after complete stderr = %q", setErr)
-	}
-	if !strings.Contains(setOutput, "Goal: follow-up live goal CLI") || !strings.Contains(setOutput, "Status: active") {
-		t.Fatalf("goal set after complete stdout = %q", setOutput)
+	setOutput, setErr, setRunErr := runGoalCommandSubprocessRaw(t, kentPath, unboundWorktree, store.Meta().SessionID, "set", "follow-up live goal CLI")
+	if setRunErr == nil {
+		t.Fatalf("goal set after rejected complete unexpectedly succeeded stdout=%q stderr=%q", setOutput, setErr)
 	}
 	record, err = metadataStore.ResolvePersistedSession(context.Background(), store.Meta().SessionID)
 	if err != nil {
-		t.Fatalf("ResolvePersistedSession after follow-up set: %v", err)
+		t.Fatalf("ResolvePersistedSession after rejected follow-up set: %v", err)
 	}
 	if record.Meta == nil {
-		t.Fatal("persisted metadata missing after follow-up set")
+		t.Fatal("persisted metadata missing after rejected follow-up set")
 	}
-	if goal := record.Meta.Goal; goal == nil || goal.Objective != "follow-up live goal CLI" || goal.Status != session.GoalStatusActive {
-		t.Fatalf("persisted follow-up goal = %+v", goal)
+	if goal := record.Meta.Goal; goal == nil || goal.Objective != "exercise live goal CLI" || goal.Status != session.GoalStatusActive {
+		t.Fatalf("persisted goal after rejected follow-up set = %+v", goal)
 	}
 }
 
@@ -542,14 +537,14 @@ func TestGoalCommandSubprocessSetPersistsWhilePrimaryRunActive(t *testing.T) {
 	}
 
 	stdout, stderr, err := runGoalCommandSubprocessRaw(t, kentPath, unboundWorktree, "", "set", "--session", store.Meta().SessionID, "new goal while busy")
-	if err != nil {
-		t.Fatalf("goal set failed during active primary run: %v stdout=%q stderr=%q", err, stdout, stderr)
+	if err == nil {
+		t.Fatalf("goal set unexpectedly succeeded during active primary run stdout=%q stderr=%q", stdout, stderr)
 	}
-	if stderr != "" {
-		t.Fatalf("goal set stderr = %q, want empty", stderr)
+	if stdout != "" {
+		t.Fatalf("goal set stdout = %q, want empty", stdout)
 	}
-	if !strings.Contains(stdout, "Goal: new goal while busy") || !strings.Contains(stdout, "Status: active") {
-		t.Fatalf("goal set stdout = %q", stdout)
+	if !strings.Contains(stderr, "active primary run") {
+		t.Fatalf("goal set stderr = %q, want active primary run rejection", stderr)
 	}
 	record, err := metadataStore.ResolvePersistedSession(context.Background(), store.Meta().SessionID)
 	if err != nil {
@@ -558,8 +553,8 @@ func TestGoalCommandSubprocessSetPersistsWhilePrimaryRunActive(t *testing.T) {
 	if record.Meta == nil {
 		t.Fatal("persisted session metadata missing")
 	}
-	if goal := record.Meta.Goal; goal == nil || goal.Objective != "new goal while busy" || goal.Status != session.GoalStatusActive {
-		t.Fatalf("persisted goal = %+v", goal)
+	if goal := record.Meta.Goal; goal != nil {
+		t.Fatalf("persisted goal after rejected busy set = %+v, want nil", goal)
 	}
 	events, err := store.ReadEvents()
 	if err != nil {
@@ -571,8 +566,8 @@ func TestGoalCommandSubprocessSetPersistsWhilePrimaryRunActive(t *testing.T) {
 			foundGoalSet = true
 		}
 	}
-	if !foundGoalSet {
-		t.Fatalf("goal_set event not persisted after busy subprocess set")
+	if foundGoalSet {
+		t.Fatalf("goal_set event persisted after rejected busy subprocess set")
 	}
 
 	cancelSubmit()

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -246,7 +246,11 @@
 - Output modes are explicit: `final-text` default and optional `json`.
 - JSON mode emits exactly one final object on stdout.
 - Progress is quiet by default and emits to stderr only with `--progress-mode=stderr`.
-- A headless run owns the active session runtime it registers. Interactive activation for the same active session attaches read-only.
+- A headless run owns the active session runtime it registers. Interactive activation for the same active session attaches in limited-control mode: live transcript/status, user steering and queued messages, prompt/approval answers, and explicitly allowed controls operate against the active runtime without controller ownership.
+- Queued steering accepted from a limited-control attach is submitted by the active owner before the runtime unregisters, unless terminal workflow completion wins first; in that case the client receives a visible failure instead of a silent drop. Queue requests made while the runtime is closing are rejected so the client can restore the input.
+- Limited-control attaches report the active runtime phase from shared runtime state and use an active/busy fallback while the external owner is executing, draining, or closing, including periods with no active engine-step snapshot. Registered-idle external runtimes remain collaborative and can accept allowed idle operations.
+- Prompt and approval resolution uses server-acknowledged shared prompt state. Clients do not locally finalize a pending prompt before the server accepts the answer and publishes/returns the resolved state.
+- Worktree controls are available from limited-control attaches when the active runtime is idle; worktree mutation remains serialized by the primary-run and workspace locks and rejects while the external owner is executing, draining, or closing.
 - Resuming a session with persisted subagent role metadata reapplies that role best-effort when it exists. Missing roles do not block explicit continuation.
 
 ## Provider Wiring

--- a/docs/dev/specs/workflow-orchestration.md
+++ b/docs/dev/specs/workflow-orchestration.md
@@ -90,6 +90,8 @@
 - Workflow runtime builds on reusable headless/session infrastructure for session launch, runtime wiring, logging, progress, subagent role handling, and mode prompts.
 - `RunPromptService.RunPrompt` final text is not workflow completion authority.
 - Existing user goal state is not reused as workflow autonomy state.
+- Workflow task sessions reject `/goal`; the workflow node/run is the task objective driver.
+- If terminal workflow completion commits before accepted limited-control steering is drained, the queued steering resolves with a visible failure and is not applied to the completed run.
 - Task comment bodies are not automatically injected into agent context. When a task has visible comments, workflow-mode instructions include the visible comment count and a `kent task comment list <task>` pull command. Kent re-queries the visible comment count each time the workflow instructions are appended without mutating previously persisted model-visible prompt items.
 
 ## Questions And Approvals
@@ -97,6 +99,7 @@
 - User questions use existing `ask_question` tool-call/session infrastructure.
 - A model does not report `needs_user_input` as a completion status; it calls `ask_question`.
 - The run pauses until answered.
+- TUI and GUI prompt/approval state is derived from shared server prompt state. A client marks a question or approval resolved only after server acknowledgement.
 - V1 must not introduce a shadow task-question table. If existing ask persistence cannot support workflow asks, upgrade ask persistence as source of truth.
 - Ask rehydration must be proven before scheduler recovery depends on it.
 - Scheduler uses a boundary such as `PendingAskResolver.CanRehydrate(sessionID, runID, askID)`.

--- a/server/core/composition.go
+++ b/server/core/composition.go
@@ -107,16 +107,17 @@ func NewWithContext(ctx context.Context, cfg config.App, authSupport serverboots
 			}
 			return prompts.RecoveredWarning(), true, nil
 		})
-	promptControlService := promptcontrol.NewPromptControlService(runtimeRegistry).WithControllerLeaseVerifier(sessionRuntimeService)
+	sessionStoreResolver := registry.NewGlobalPersistenceSessionResolver(cfg.PersistenceRoot, storeOptions...)
+	promptControlService := promptcontrol.NewPromptControlService(runtimeRegistry).WithControllerLeaseVerifier(sessionRuntimeService).WithCollaborativeRuntimeResolver(sessionRuntimeService)
 	promptActivityService := promptcontrol.NewPromptActivityService(runtimeRegistry)
-	runtimeControlService := runtimecontrol.NewService(runtimeRegistry, runtimeRegistry).WithControllerLeaseVerifier(sessionRuntimeService).WithPromptHistoryStore(metadataStore)
+	runtimeControlService := runtimecontrol.NewService(runtimeRegistry, runtimeRegistry).WithControllerLeaseVerifier(sessionRuntimeService).WithCollaborativeRuntimeResolver(sessionRuntimeService).WithPromptHistoryStore(metadataStore).WithWorkflowSessionResolver(sessionStoreResolver)
 	worktreeService := worktree.NewService(metadataStore, nil, runtimeRegistry, sessionRuntimeService, runtimeSupport.Background, runtimeControlService, worktree.ServiceOptions{BaseDir: cfg.Settings.Worktrees.BaseDir, SetupScript: cfg.Settings.Worktrees.SetupScript})
 	projectViews := client.NewLoopbackProjectViewClient(projectService)
 	authBootstrapService := authservice.NewBootstrapService(authSupport.AuthManager, authSupport.OAuthOptions, cfg.Settings, rpccontract.AllowedPreAuthMethods())
 	authStatusService := authservice.NewStatusService(authSupport.AuthManager, cfg.Settings)
 	serverStatusService := serverstatus.NewServerStatusService(authSupport.AuthManager, cfg)
 	updateStatusService := serverstatus.NewUpdateStatusService(config.Version)
-	sessionViewService := sessionview.NewService(registry.NewGlobalPersistenceSessionResolver(cfg.PersistenceRoot, storeOptions...), runtimeRegistry, metadataStore).WithCacheWarningMode(cfg.Settings.CacheWarningMode).WithUpdateStatusProvider(updateStatusService)
+	sessionViewService := sessionview.NewService(sessionStoreResolver, runtimeRegistry, metadataStore).WithCacheWarningMode(cfg.Settings.CacheWarningMode).WithUpdateStatusProvider(updateStatusService)
 	sessionLifecycleService := sessionservice.NewGlobalSessionLifecycleService(cfg.PersistenceRoot, sessionStoreRegistry, authSupport.AuthManager, storeOptions...).WithControllerLeaseVerifier(sessionRuntimeService)
 	sessionActivityService := sessionservice.NewSessionActivityService(runtimeRegistry)
 	var workflowRuntimeStarter *workflowrunner.Starter

--- a/server/core/repo_boundary_test.go
+++ b/server/core/repo_boundary_test.go
@@ -68,6 +68,8 @@ func TestSharedClientUIRemainsDTOOnly(t *testing.T) {
 		"EntryVisibility":                  {},
 		"Event":                            {},
 		"EventKind":                        {},
+		"ExternalRuntimeState":             {},
+		"ExternalRuntimeStatus":            {},
 		"MessagePhase":                     {},
 		"MessageType":                      {},
 		"PendingApproval":                  {},
@@ -82,6 +84,9 @@ func TestSharedClientUIRemainsDTOOnly(t *testing.T) {
 		"ProjectWorkspaceSummary":          {},
 		"PromptAnswer":                     {},
 		"QueuedUserMessage":                {},
+		"QueuedUserMessageFailureReason":   {},
+		"QueuedUserMessageStatus":          {},
+		"QueuedUserMessageStatusEvent":     {},
 		"ReasoningDelta":                   {},
 		"ReviewerLifecycle":                {},
 		"RunLifecycle":                     {},
@@ -113,6 +118,7 @@ func TestSharedClientUIRemainsDTOOnly(t *testing.T) {
 		"TranscriptRecoveryCause":          {},
 		"TranscriptWindow":                 {},
 		"UpdateStatus":                     {},
+		"WorkflowSessionStatus":            {},
 	}
 	allowedFuncs := map[string]struct{}{
 		"CompactionLifecycle.IsRunning":             {},

--- a/server/primaryrun/gate.go
+++ b/server/primaryrun/gate.go
@@ -1,8 +1,8 @@
 package primaryrun
 
-import "errors"
+import "core/shared/serverapi"
 
-var ErrActivePrimaryRun = errors.New("session already has an active primary run")
+var ErrActivePrimaryRun = serverapi.ErrActivePrimaryRun
 
 type Lease interface {
 	Release()

--- a/server/promptcontrol/service.go
+++ b/server/promptcontrol/service.go
@@ -3,7 +3,9 @@ package promptcontrol
 import (
 	"context"
 	"errors"
+	"strings"
 
+	"core/server/registry"
 	"core/server/requestmemo"
 	askquestion "core/server/tools"
 	servicecontract "core/shared/apicontract"
@@ -19,11 +21,25 @@ type ControllerLeaseVerifier interface {
 	RequireControllerLease(ctx context.Context, sessionID string, leaseID string) error
 }
 
+type CollaborativePromptResponderResolver interface {
+	WithCollaborativePromptResponder(ctx context.Context, sessionID string, op serverapi.SessionRuntimeOperation, fn func(registry.GuardedPromptResponder) error) error
+}
+
 type PromptControlService struct {
-	prompts   PendingPromptResponder
-	control   ControllerLeaseVerifier
-	asks      *requestmemo.Memo[askAnswerMemoRequest, struct{}]
-	approvals *requestmemo.Memo[approvalAnswerMemoRequest, struct{}]
+	prompts       PendingPromptResponder
+	control       ControllerLeaseVerifier
+	collaborative CollaborativePromptResponderResolver
+	asks          *requestmemo.Memo[askAnswerMemoRequest, struct{}]
+	approvals     *requestmemo.Memo[approvalAnswerMemoRequest, struct{}]
+}
+
+type guardedPromptResponder struct {
+	sessionID string
+	prompts   registry.GuardedPromptResponder
+}
+
+func (r guardedPromptResponder) SubmitPromptResponse(_ string, resp askquestion.AskQuestionResponse, err error) error {
+	return r.prompts.SubmitPromptResponse(resp, err)
 }
 
 type askAnswerMemoRequest struct {
@@ -59,11 +75,34 @@ func (s *PromptControlService) WithControllerLeaseVerifier(verifier ControllerLe
 	return s
 }
 
+func (s *PromptControlService) WithCollaborativeRuntimeResolver(resolver CollaborativePromptResponderResolver) *PromptControlService {
+	if s == nil {
+		return nil
+	}
+	s.collaborative = resolver
+	return s
+}
+
 func (s *PromptControlService) requireControllerLease(ctx context.Context, sessionID string, leaseID string) error {
 	if s == nil || s.control == nil {
 		return nil
 	}
 	return s.control.RequireControllerLease(ctx, sessionID, leaseID)
+}
+
+func (s *PromptControlService) withPromptAccess(ctx context.Context, sessionID string, leaseID string, fn func(PendingPromptResponder) error) error {
+	if strings.TrimSpace(leaseID) != "" {
+		if err := s.requireControllerLease(ctx, sessionID, leaseID); err != nil {
+			return err
+		}
+		return fn(s.prompts)
+	}
+	if s == nil || s.collaborative == nil {
+		return serverapi.ErrInvalidControllerLease
+	}
+	return s.collaborative.WithCollaborativePromptResponder(ctx, sessionID, serverapi.SessionRuntimeOperationPromptAnswer, func(prompts registry.GuardedPromptResponder) error {
+		return fn(guardedPromptResponder{sessionID: sessionID, prompts: prompts})
+	})
 }
 
 func (s *PromptControlService) AnswerAsk(ctx context.Context, req serverapi.AskAnswerRequest) error {
@@ -82,18 +121,17 @@ func (s *PromptControlService) AnswerAsk(ctx context.Context, req serverapi.AskA
 		FreeformAnswer:       req.FreeformAnswer,
 	}
 	_, err := s.asks.Do(ctx, req.ClientRequestID, memoReq, sameAskAnswerMemoRequest, func(ctx context.Context) (struct{}, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return struct{}{}, err
-		}
-		if req.ErrorMessage != "" {
-			return struct{}{}, s.prompts.SubmitPromptResponse(req.SessionID, askquestion.AskQuestionResponse{RequestID: req.AskID}, errors.New(req.ErrorMessage))
-		}
-		return struct{}{}, s.prompts.SubmitPromptResponse(req.SessionID, askquestion.AskQuestionResponse{
-			RequestID:            req.AskID,
-			Answer:               req.Answer,
-			SelectedOptionNumber: req.SelectedOptionNumber,
-			FreeformAnswer:       req.FreeformAnswer,
-		}, nil)
+		return struct{}{}, s.withPromptAccess(ctx, req.SessionID, req.ControllerLeaseID, func(prompts PendingPromptResponder) error {
+			if req.ErrorMessage != "" {
+				return prompts.SubmitPromptResponse(req.SessionID, askquestion.AskQuestionResponse{RequestID: req.AskID}, errors.New(req.ErrorMessage))
+			}
+			return prompts.SubmitPromptResponse(req.SessionID, askquestion.AskQuestionResponse{
+				RequestID:            req.AskID,
+				Answer:               req.Answer,
+				SelectedOptionNumber: req.SelectedOptionNumber,
+				FreeformAnswer:       req.FreeformAnswer,
+			}, nil)
+		})
 	})
 	return err
 }
@@ -113,19 +151,18 @@ func (s *PromptControlService) AnswerApproval(ctx context.Context, req serverapi
 		Commentary:   req.Commentary,
 	}
 	_, err := s.approvals.Do(ctx, req.ClientRequestID, memoReq, sameApprovalAnswerMemoRequest, func(ctx context.Context) (struct{}, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return struct{}{}, err
-		}
-		if req.ErrorMessage != "" {
-			return struct{}{}, s.prompts.SubmitPromptResponse(req.SessionID, askquestion.AskQuestionResponse{RequestID: req.ApprovalID}, errors.New(req.ErrorMessage))
-		}
-		return struct{}{}, s.prompts.SubmitPromptResponse(req.SessionID, askquestion.AskQuestionResponse{
-			RequestID: req.ApprovalID,
-			Approval: &askquestion.AskQuestionApprovalPayload{
-				Decision:   askquestion.AskQuestionApprovalDecision(req.Decision),
-				Commentary: req.Commentary,
-			},
-		}, nil)
+		return struct{}{}, s.withPromptAccess(ctx, req.SessionID, req.ControllerLeaseID, func(prompts PendingPromptResponder) error {
+			if req.ErrorMessage != "" {
+				return prompts.SubmitPromptResponse(req.SessionID, askquestion.AskQuestionResponse{RequestID: req.ApprovalID}, errors.New(req.ErrorMessage))
+			}
+			return prompts.SubmitPromptResponse(req.SessionID, askquestion.AskQuestionResponse{
+				RequestID: req.ApprovalID,
+				Approval: &askquestion.AskQuestionApprovalPayload{
+					Decision:   askquestion.AskQuestionApprovalDecision(req.Decision),
+					Commentary: req.Commentary,
+				},
+			}, nil)
+		})
 	})
 	return err
 }

--- a/server/promptcontrol/service_test.go
+++ b/server/promptcontrol/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"core/server/registry"
 	"core/server/requestmemo"
 	askquestion "core/server/tools"
 	"core/shared/clientui"
@@ -30,6 +31,34 @@ func (s *stubPromptResponder) SubmitPromptResponse(sessionID string, resp askque
 type stubLeaseVerifier struct {
 	calls int
 	err   error
+}
+
+type stubCollaborativeRuntimeResolver struct {
+	calls     int
+	op        serverapi.SessionRuntimeOperation
+	err       error
+	responder *stubPromptResponder
+}
+
+func (s *stubCollaborativeRuntimeResolver) WithCollaborativePromptResponder(ctx context.Context, sessionID string, op serverapi.SessionRuntimeOperation, fn func(registry.GuardedPromptResponder) error) error {
+	s.calls++
+	s.op = op
+	if s.err != nil {
+		return s.err
+	}
+	return fn(stubGuardedPromptResponder{sessionID: sessionID, responder: s.responder})
+}
+
+type stubGuardedPromptResponder struct {
+	sessionID string
+	responder *stubPromptResponder
+}
+
+func (s stubGuardedPromptResponder) SubmitPromptResponse(resp askquestion.AskQuestionResponse, err error) error {
+	if s.responder == nil {
+		return nil
+	}
+	return s.responder.SubmitPromptResponse(s.sessionID, resp, err)
 }
 
 func (s *stubLeaseVerifier) RequireControllerLease(context.Context, string, string) error {
@@ -80,6 +109,55 @@ func TestServiceAnswerAskRequiresControllerLease(t *testing.T) {
 	}
 	if responder.calls != 0 {
 		t.Fatalf("responder call count = %d, want 0", responder.calls)
+	}
+}
+
+func TestServiceAnswerAskAllowsCollaborativeEmptyLease(t *testing.T) {
+	responder := &stubPromptResponder{}
+	verifier := &stubLeaseVerifier{err: errors.New("lease should not be required")}
+	collaborative := &stubCollaborativeRuntimeResolver{responder: responder}
+	service := NewPromptControlService(responder).WithControllerLeaseVerifier(verifier).WithCollaborativeRuntimeResolver(collaborative)
+	req := serverapi.AskAnswerRequest{
+		ClientRequestID: "req-1",
+		SessionID:       "session-1",
+		AskID:           "ask-1",
+		Answer:          "hello",
+	}
+
+	if err := service.AnswerAsk(context.Background(), req); err != nil {
+		t.Fatalf("AnswerAsk: %v", err)
+	}
+	if verifier.calls != 0 {
+		t.Fatalf("lease verifier call count = %d, want 0", verifier.calls)
+	}
+	if collaborative.calls != 1 || collaborative.op != serverapi.SessionRuntimeOperationPromptAnswer {
+		t.Fatalf("collaborative calls=%d op=%q, want prompt answer", collaborative.calls, collaborative.op)
+	}
+	if responder.calls != 1 || responder.response.Answer != "hello" {
+		t.Fatalf("unexpected responder state: calls=%d response=%+v", responder.calls, responder.response)
+	}
+}
+
+func TestServiceAnswerAskCollaborativeUsesGuardedPromptResponder(t *testing.T) {
+	unguarded := &stubPromptResponder{}
+	guarded := &stubPromptResponder{}
+	collaborative := &stubCollaborativeRuntimeResolver{responder: guarded}
+	service := NewPromptControlService(unguarded).WithCollaborativeRuntimeResolver(collaborative)
+	req := serverapi.AskAnswerRequest{
+		ClientRequestID: "req-guarded",
+		SessionID:       "session-1",
+		AskID:           "ask-1",
+		Answer:          "guarded answer",
+	}
+
+	if err := service.AnswerAsk(context.Background(), req); err != nil {
+		t.Fatalf("AnswerAsk: %v", err)
+	}
+	if unguarded.calls != 0 {
+		t.Fatalf("unguarded responder calls = %d, want 0", unguarded.calls)
+	}
+	if guarded.calls != 1 || guarded.response.Answer != "guarded answer" {
+		t.Fatalf("guarded responder state: calls=%d response=%+v", guarded.calls, guarded.response)
 	}
 }
 

--- a/server/registry/primary_run_lease_store.go
+++ b/server/registry/primary_run_lease_store.go
@@ -52,6 +52,20 @@ func (s *primaryRunLeaseStore) Clear(sessionID string) {
 	s.mu.Unlock()
 }
 
+func (s *primaryRunLeaseStore) Active(sessionID string) bool {
+	if s == nil {
+		return false
+	}
+	id := strings.TrimSpace(sessionID)
+	if id == "" {
+		return false
+	}
+	s.mu.Lock()
+	_, active := s.leases[id]
+	s.mu.Unlock()
+	return active
+}
+
 func (s *primaryRunLeaseStore) release(sessionID string, leaseID uint64) {
 	if s == nil {
 		return

--- a/server/registry/runtime_directory.go
+++ b/server/registry/runtime_directory.go
@@ -1,19 +1,30 @@
 package registry
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"sync"
 
 	"core/server/runtime"
+	askquestion "core/server/tools"
 )
 
 type runtimeDirectory struct {
-	mu      sync.RWMutex
-	entries map[string]*runtimeEntry
+	mu         sync.RWMutex
+	entries    map[string]*runtimeEntry
+	generation uint64
 }
 
 type runtimeEntry struct {
+	mu              sync.Mutex
+	cond            *sync.Cond
+	generation      uint64
+	closing         bool
+	closeDraining   bool
+	inFlight        int
 	engine          *runtime.Engine
+	rebind          func(string) error
 	sessionActivity *sessionActivityBroker
 	promptActivity  *promptActivityBroker
 	pendingPrompts  *pendingPromptStore
@@ -23,16 +34,20 @@ func newRuntimeDirectory() *runtimeDirectory {
 	return &runtimeDirectory{entries: make(map[string]*runtimeEntry)}
 }
 
-func newRuntimeEntry(engine *runtime.Engine) *runtimeEntry {
-	return &runtimeEntry{
+func newRuntimeEntry(engine *runtime.Engine, generation uint64, rebind func(string) error) *runtimeEntry {
+	entry := &runtimeEntry{
+		generation:      generation,
 		engine:          engine,
+		rebind:          rebind,
 		sessionActivity: newSessionActivityBroker(),
 		promptActivity:  newPromptActivityBroker(),
 		pendingPrompts:  newPendingPromptStore(),
 	}
+	entry.cond = sync.NewCond(&entry.mu)
+	return entry
 }
 
-func (d *runtimeDirectory) Register(sessionID string, engine *runtime.Engine) *runtimeEntry {
+func (d *runtimeDirectory) Register(sessionID string, engine *runtime.Engine, rebind func(string) error, beforeReplace func(*runtimeEntry)) *runtimeEntry {
 	if d == nil || engine == nil {
 		return nil
 	}
@@ -40,12 +55,48 @@ func (d *runtimeDirectory) Register(sessionID string, engine *runtime.Engine) *r
 	if id == "" {
 		return nil
 	}
-	entry := newRuntimeEntry(engine)
-	d.mu.Lock()
-	previous := d.entries[id]
-	d.entries[id] = entry
-	d.mu.Unlock()
-	return previous
+	for {
+		d.mu.Lock()
+		previous := d.entries[id]
+		if previous == nil {
+			d.generation++
+			entry := newRuntimeEntry(engine, d.generation, rebind)
+			d.entries[id] = entry
+			d.mu.Unlock()
+			return nil
+		}
+		previous.markClosing()
+		d.mu.Unlock()
+
+		previous.waitForGuards()
+
+		d.mu.Lock()
+		if d.entries[id] != previous {
+			d.mu.Unlock()
+			continue
+		}
+		ref, ok := previous.beginReplacement()
+		if !ok {
+			d.mu.Unlock()
+			continue
+		}
+		d.mu.Unlock()
+		if beforeReplace != nil {
+			beforeReplace(previous)
+		}
+		d.mu.Lock()
+		if d.entries[id] != previous {
+			d.mu.Unlock()
+			ref.Release()
+			continue
+		}
+		d.generation++
+		entry := newRuntimeEntry(engine, d.generation, rebind)
+		d.entries[id] = entry
+		d.mu.Unlock()
+		ref.Release()
+		return previous
+	}
 }
 
 func (d *runtimeDirectory) Unregister(sessionID string, engine *runtime.Engine) (string, *runtimeEntry) {
@@ -56,9 +107,67 @@ func (d *runtimeDirectory) Unregister(sessionID string, engine *runtime.Engine) 
 	if id == "" {
 		return "", nil
 	}
-	d.mu.Lock()
+	for {
+		d.mu.Lock()
+		entry := d.entries[id]
+		if entry == nil || (engine != nil && entry.engine != engine) {
+			d.mu.Unlock()
+			return "", nil
+		}
+		entry.markClosing()
+		d.mu.Unlock()
+
+		entry.waitForGuards()
+
+		d.mu.Lock()
+		if d.entries[id] != entry {
+			d.mu.Unlock()
+			return "", nil
+		}
+		if entry.hasInFlight() {
+			d.mu.Unlock()
+			continue
+		}
+		delete(d.entries, id)
+		d.mu.Unlock()
+		return id, entry
+	}
+}
+
+func (d *runtimeDirectory) BeginClose(sessionID string, engine *runtime.Engine) (string, *runtimeEntry, *runtimeCloseDrainRef) {
+	if d == nil {
+		return "", nil, nil
+	}
+	id := strings.TrimSpace(sessionID)
+	if id == "" {
+		return "", nil, nil
+	}
+	d.mu.RLock()
 	entry := d.entries[id]
 	if entry == nil || (engine != nil && entry.engine != engine) {
+		d.mu.RUnlock()
+		return "", nil, nil
+	}
+	ref, ok := entry.beginCloseDrain()
+	if !ok {
+		d.mu.RUnlock()
+		return "", nil, nil
+	}
+	d.mu.RUnlock()
+	return id, entry, ref
+}
+
+func (d *runtimeDirectory) RemoveClosing(sessionID string, engine *runtime.Engine, closingEntry *runtimeEntry) (string, *runtimeEntry) {
+	if d == nil {
+		return "", nil
+	}
+	id := strings.TrimSpace(sessionID)
+	if id == "" || closingEntry == nil {
+		return "", nil
+	}
+	d.mu.Lock()
+	entry := d.entries[id]
+	if entry == nil || entry != closingEntry || (engine != nil && entry.engine != engine) {
 		d.mu.Unlock()
 		return "", nil
 	}
@@ -106,10 +215,271 @@ func (d *runtimeDirectory) Entry(sessionID string) *runtimeEntry {
 	return entry
 }
 
+func (d *runtimeDirectory) BeginGuard(ctx context.Context, sessionID string) (*runtimeGuard, error) {
+	if d == nil {
+		return nil, fmt.Errorf("runtime directory is required")
+	}
+	id := strings.TrimSpace(sessionID)
+	if id == "" {
+		return nil, fmt.Errorf("runtime session id is required")
+	}
+	d.mu.RLock()
+	entry := d.entries[id]
+	if entry == nil {
+		d.mu.RUnlock()
+		return nil, fmt.Errorf("runtime %q is unavailable", id)
+	}
+	guard, err := entry.beginGuard(ctx, id)
+	d.mu.RUnlock()
+	return guard, err
+}
+
+func (d *runtimeDirectory) Closing(sessionID string) bool {
+	if d == nil {
+		return false
+	}
+	id := strings.TrimSpace(sessionID)
+	if id == "" {
+		return false
+	}
+	d.mu.RLock()
+	entry := d.entries[id]
+	if entry == nil {
+		d.mu.RUnlock()
+		return false
+	}
+	closing := entry.isClosing()
+	d.mu.RUnlock()
+	return closing
+}
+
+func (e *runtimeEntry) beginGuard(ctx context.Context, sessionID string) (*runtimeGuard, error) {
+	if e == nil {
+		return nil, fmt.Errorf("runtime entry is unavailable")
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.closing {
+		return nil, fmt.Errorf("runtime entry is closing")
+	}
+	e.inFlight++
+	return &runtimeGuard{entry: e, engine: e.engine, sessionID: strings.TrimSpace(sessionID), generation: e.generation}, nil
+}
+
+func (e *runtimeEntry) beginCloseDrain() (*runtimeCloseDrainRef, bool) {
+	if e == nil {
+		return nil, false
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.closing || e.closeDraining {
+		return nil, false
+	}
+	e.closing = true
+	e.closeDraining = true
+	e.inFlight++
+	e.cond.Broadcast()
+	return &runtimeCloseDrainRef{entry: e}, true
+}
+
+func (e *runtimeEntry) beginReplacement() (*runtimeReplacementRef, bool) {
+	if e == nil {
+		return nil, false
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.inFlight > 0 {
+		return nil, false
+	}
+	e.inFlight++
+	e.cond.Broadcast()
+	return &runtimeReplacementRef{entry: e}, true
+}
+
+func (e *runtimeEntry) isClosing() bool {
+	if e == nil {
+		return false
+	}
+	e.mu.Lock()
+	closing := e.closing
+	e.mu.Unlock()
+	return closing
+}
+
+func (e *runtimeEntry) markClosing() {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	e.closing = true
+	e.cond.Broadcast()
+	e.mu.Unlock()
+}
+
+func (e *runtimeEntry) waitForGuards() {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	for e.inFlight > 0 {
+		e.cond.Wait()
+	}
+	e.mu.Unlock()
+}
+
+func (e *runtimeEntry) hasInFlight() bool {
+	if e == nil {
+		return false
+	}
+	e.mu.Lock()
+	hasInFlight := e.inFlight > 0
+	e.mu.Unlock()
+	return hasInFlight
+}
+
+func (e *runtimeEntry) waitForGuardsExceptCloseDrain() {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	for e.inFlight > 1 {
+		e.cond.Wait()
+	}
+	e.mu.Unlock()
+}
+
+type runtimeCloseDrainRef struct {
+	entry     *runtimeEntry
+	releaseMu sync.Mutex
+	released  bool
+}
+
+type runtimeReplacementRef struct {
+	entry     *runtimeEntry
+	releaseMu sync.Mutex
+	released  bool
+}
+
+func (r *runtimeReplacementRef) Release() {
+	if r == nil || r.entry == nil {
+		return
+	}
+	r.releaseMu.Lock()
+	if r.released {
+		r.releaseMu.Unlock()
+		return
+	}
+	r.released = true
+	r.releaseMu.Unlock()
+	r.entry.mu.Lock()
+	if r.entry.inFlight > 0 {
+		r.entry.inFlight--
+	}
+	r.entry.cond.Broadcast()
+	r.entry.mu.Unlock()
+}
+
+func (r *runtimeCloseDrainRef) WaitForGuards() {
+	if r == nil || r.entry == nil {
+		return
+	}
+	r.entry.waitForGuardsExceptCloseDrain()
+}
+
+func (r *runtimeCloseDrainRef) Release() {
+	if r == nil || r.entry == nil {
+		return
+	}
+	r.releaseMu.Lock()
+	if r.released {
+		r.releaseMu.Unlock()
+		return
+	}
+	r.released = true
+	r.releaseMu.Unlock()
+	r.entry.mu.Lock()
+	if r.entry.inFlight > 0 {
+		r.entry.inFlight--
+	}
+	r.entry.closeDraining = false
+	r.entry.cond.Broadcast()
+	r.entry.mu.Unlock()
+}
+
+type runtimeGuard struct {
+	entry      *runtimeEntry
+	engine     *runtime.Engine
+	sessionID  string
+	generation uint64
+	releaseMu  sync.Mutex
+	released   bool
+}
+
+func (g *runtimeGuard) Engine() *runtime.Engine {
+	if g == nil {
+		return nil
+	}
+	return g.engine
+}
+
+func (g *runtimeGuard) Generation() uint64 {
+	if g == nil {
+		return 0
+	}
+	return g.generation
+}
+
+func (g *runtimeGuard) Rebind(workdir string) error {
+	if g == nil {
+		return fmt.Errorf("runtime guard is unavailable")
+	}
+	trimmedWorkdir := strings.TrimSpace(workdir)
+	if trimmedWorkdir == "" {
+		return fmt.Errorf("runtime workdir is required")
+	}
+	if g.entry != nil && g.entry.rebind != nil {
+		return g.entry.rebind(trimmedWorkdir)
+	}
+	if g.engine != nil {
+		g.engine.SetTranscriptWorkingDir(trimmedWorkdir)
+	}
+	return nil
+}
+
+func (g *runtimeGuard) SubmitPromptResponse(resp askquestion.AskQuestionResponse, err error) error {
+	if g == nil || g.entry == nil {
+		return fmt.Errorf("runtime guard is unavailable")
+	}
+	return g.entry.pendingPrompts.Submit(resp, err, func(snapshot PendingPromptSnapshot, eventType pendingPromptEventType) {
+		g.entry.PublishPendingPrompt(g.sessionID, snapshot, eventType)
+	})
+}
+
+func (g *runtimeGuard) Release() {
+	if g == nil || g.entry == nil {
+		return
+	}
+	g.releaseMu.Lock()
+	if g.released {
+		g.releaseMu.Unlock()
+		return
+	}
+	g.released = true
+	g.releaseMu.Unlock()
+	g.entry.mu.Lock()
+	if g.entry.inFlight > 0 {
+		g.entry.inFlight--
+	}
+	g.entry.cond.Broadcast()
+	g.entry.mu.Unlock()
+}
+
 func closeRuntimeEntry(entry *runtimeEntry, err error) {
 	if entry == nil {
 		return
 	}
+	entry.markClosing()
+	entry.waitForGuards()
 	entry.pendingPrompts.Close(err)
 	entry.promptActivity.Close(err)
 	entry.sessionActivity.Close(err)

--- a/server/registry/runtime_directory.go
+++ b/server/registry/runtime_directory.go
@@ -234,25 +234,6 @@ func (d *runtimeDirectory) BeginGuard(ctx context.Context, sessionID string) (*r
 	return guard, err
 }
 
-func (d *runtimeDirectory) Closing(sessionID string) bool {
-	if d == nil {
-		return false
-	}
-	id := strings.TrimSpace(sessionID)
-	if id == "" {
-		return false
-	}
-	d.mu.RLock()
-	entry := d.entries[id]
-	if entry == nil {
-		d.mu.RUnlock()
-		return false
-	}
-	closing := entry.isClosing()
-	d.mu.RUnlock()
-	return closing
-}
-
 func (e *runtimeEntry) beginGuard(ctx context.Context, sessionID string) (*runtimeGuard, error) {
 	if e == nil {
 		return nil, fmt.Errorf("runtime entry is unavailable")
@@ -296,14 +277,15 @@ func (e *runtimeEntry) beginReplacement() (*runtimeReplacementRef, bool) {
 	return &runtimeReplacementRef{entry: e}, true
 }
 
-func (e *runtimeEntry) isClosing() bool {
+func (e *runtimeEntry) closeState() (bool, bool) {
 	if e == nil {
-		return false
+		return false, false
 	}
 	e.mu.Lock()
 	closing := e.closing
+	draining := e.closeDraining
 	e.mu.Unlock()
-	return closing
+	return closing, draining
 }
 
 func (e *runtimeEntry) markClosing() {

--- a/server/registry/runtime_registry.go
+++ b/server/registry/runtime_registry.go
@@ -139,12 +139,32 @@ func (r *RuntimeRegistry) IsSessionRuntimeActive(sessionID string) bool {
 }
 
 func (r *RuntimeRegistry) ExternalRuntimeStatus(sessionID string) clientui.ExternalRuntimeStatus {
-	if r == nil || !r.directory.Active(sessionID) {
+	if r == nil {
 		return clientui.ExternalRuntimeStatus{}
 	}
-	if r.directory.Closing(sessionID) {
+	id := strings.TrimSpace(sessionID)
+	if id == "" {
+		return clientui.ExternalRuntimeStatus{}
+	}
+	entry := r.directory.Entry(id)
+	if entry == nil {
+		return clientui.ExternalRuntimeStatus{}
+	}
+	return r.externalRuntimeStatusForEntry(id, entry)
+}
+
+func (r *RuntimeRegistry) externalRuntimeStatusForEntry(sessionID string, entry *runtimeEntry) clientui.ExternalRuntimeStatus {
+	if r == nil || entry == nil {
+		return clientui.ExternalRuntimeStatus{}
+	}
+	closing, draining := entry.closeState()
+	if closing {
+		state := clientui.ExternalRuntimeStateClosing
+		if draining {
+			state = clientui.ExternalRuntimeStateDraining
+		}
 		return clientui.ExternalRuntimeStatus{
-			State:          clientui.ExternalRuntimeStateDraining,
+			State:          state,
 			QueueAccepting: false,
 		}
 	}
@@ -428,7 +448,7 @@ func (r *RuntimeRegistry) publishExternalRuntimeStatus(sessionID string) {
 	if entry == nil {
 		return
 	}
-	publishExternalRuntimeStatusToEntry(entry, r.ExternalRuntimeStatus(id))
+	publishExternalRuntimeStatusToEntry(entry, r.externalRuntimeStatusForEntry(id, entry))
 }
 
 func publishExternalRuntimeStatusToEntry(entry *runtimeEntry, status clientui.ExternalRuntimeStatus) {

--- a/server/registry/runtime_registry.go
+++ b/server/registry/runtime_registry.go
@@ -11,6 +11,7 @@ import (
 	"core/server/runtime"
 	"core/server/runtimeview"
 	askquestion "core/server/tools"
+	"core/shared/clientui"
 	"core/shared/serverapi"
 )
 
@@ -30,6 +31,10 @@ type RuntimeRegistry struct {
 	runningSessions map[string]bool
 }
 
+type GuardedPromptResponder interface {
+	SubmitPromptResponse(resp askquestion.AskQuestionResponse, err error) error
+}
+
 type RuntimeInterestReason int
 
 const (
@@ -46,10 +51,17 @@ func NewRuntimeRegistry() *RuntimeRegistry {
 }
 
 func (r *RuntimeRegistry) Register(sessionID string, engine *runtime.Engine) {
+	r.RegisterRuntimeHooks(sessionID, engine, nil)
+}
+
+func (r *RuntimeRegistry) RegisterRuntimeHooks(sessionID string, engine *runtime.Engine, rebind func(string) error) {
 	if r == nil || engine == nil {
 		return
 	}
-	previous := r.directory.Register(sessionID, engine)
+	previous := r.directory.Register(sessionID, engine, rebind, func(previous *runtimeEntry) {
+		publishExternalRuntimeStatusToEntry(previous, clientui.ExternalRuntimeStatus{State: clientui.ExternalRuntimeStateClosing, QueueAccepting: false})
+		failRuntimeEntryQueuedMessages(previous, runtime.QueuedUserMessageFailureClosing)
+	})
 	closeRuntimeEntry(previous, io.EOF)
 	if previous != nil {
 		r.updateAggregateRunState(sessionID, false)
@@ -64,9 +76,52 @@ func (r *RuntimeRegistry) Unregister(sessionID string, engine *runtime.Engine) {
 	if id == "" {
 		return
 	}
+	publishExternalRuntimeStatusToEntry(entry, clientui.ExternalRuntimeStatus{State: clientui.ExternalRuntimeStateClosing, QueueAccepting: false})
+	publishExternalRuntimeStatusToEntry(entry, clientui.ExternalRuntimeStatus{})
 	r.leases.Clear(id)
 	closeRuntimeEntry(entry, io.EOF)
 	r.updateAggregateRunState(id, false)
+}
+
+func (r *RuntimeRegistry) CloseRuntimeWithDrain(ctx context.Context, sessionID string, engine *runtime.Engine, drain func(context.Context) error) error {
+	if r == nil {
+		return nil
+	}
+	id, entry, drainRef := r.directory.BeginClose(sessionID, engine)
+	if id == "" || entry == nil || drainRef == nil {
+		return nil
+	}
+	publishExternalRuntimeStatusToEntry(entry, clientui.ExternalRuntimeStatus{State: clientui.ExternalRuntimeStateDraining, QueueAccepting: false})
+	drainRef.WaitForGuards()
+	var drainErr error
+	if drain != nil {
+		drainErr = drain(ctx)
+	}
+	removedID, removedEntry := r.directory.RemoveClosing(id, engine, entry)
+	if removedID == "" || removedEntry == nil {
+		drainRef.Release()
+		return drainErr
+	}
+	publishExternalRuntimeStatusToEntry(removedEntry, clientui.ExternalRuntimeStatus{})
+	drainRef.Release()
+	closeRuntimeEntry(removedEntry, io.EOF)
+	r.updateAggregateRunState(removedID, false)
+	return drainErr
+}
+
+type RuntimeGuard interface {
+	Engine() *runtime.Engine
+	Generation() uint64
+	Rebind(workdir string) error
+	GuardedPromptResponder
+	Release()
+}
+
+func (r *RuntimeRegistry) BeginRuntimeGuard(ctx context.Context, sessionID string) (RuntimeGuard, error) {
+	if r == nil {
+		return nil, fmt.Errorf("runtime registry is required")
+	}
+	return r.directory.BeginGuard(ctx, sessionID)
 }
 
 func (r *RuntimeRegistry) ResolveRuntime(_ context.Context, sessionID string) (*runtime.Engine, error) {
@@ -81,6 +136,28 @@ func (r *RuntimeRegistry) IsSessionRuntimeActive(sessionID string) bool {
 		return false
 	}
 	return r.directory.Active(sessionID)
+}
+
+func (r *RuntimeRegistry) ExternalRuntimeStatus(sessionID string) clientui.ExternalRuntimeStatus {
+	if r == nil || !r.directory.Active(sessionID) {
+		return clientui.ExternalRuntimeStatus{}
+	}
+	if r.directory.Closing(sessionID) {
+		return clientui.ExternalRuntimeStatus{
+			State:          clientui.ExternalRuntimeStateDraining,
+			QueueAccepting: false,
+		}
+	}
+	if r.leases.Active(sessionID) {
+		return clientui.ExternalRuntimeStatus{
+			State:          clientui.ExternalRuntimeStateOwnerRunning,
+			QueueAccepting: true,
+		}
+	}
+	return clientui.ExternalRuntimeStatus{
+		State:          clientui.ExternalRuntimeStateRegisteredIdle,
+		QueueAccepting: true,
+	}
 }
 
 func (r *RuntimeRegistry) PublishRuntimeEventToAll(evt runtime.Event) {
@@ -246,7 +323,16 @@ func (r *RuntimeRegistry) AcquirePrimaryRun(sessionID string) (primaryrun.Lease,
 	if r == nil {
 		return nil, primaryrun.ErrActivePrimaryRun
 	}
-	return r.leases.Acquire(sessionID)
+	id := strings.TrimSpace(sessionID)
+	lease, err := r.leases.Acquire(id)
+	if err != nil {
+		return nil, err
+	}
+	r.publishExternalRuntimeStatus(id)
+	return primaryrun.LeaseFunc(func() {
+		lease.Release()
+		r.publishExternalRuntimeStatus(id)
+	}), nil
 }
 
 func (r *RuntimeRegistry) SetInterestObserver(observer func(sessionID string, reason RuntimeInterestReason)) {
@@ -321,6 +407,38 @@ func (r *RuntimeRegistry) updateAggregateRunState(sessionID string, running bool
 	if observer != nil {
 		observer(active)
 	}
+}
+
+func failRuntimeEntryQueuedMessages(entry *runtimeEntry, reason runtime.QueuedUserMessageFailureReason) {
+	if entry == nil || entry.engine == nil {
+		return
+	}
+	entry.engine.FailQueuedUserMessages(reason)
+}
+
+func (r *RuntimeRegistry) publishExternalRuntimeStatus(sessionID string) {
+	if r == nil {
+		return
+	}
+	id := strings.TrimSpace(sessionID)
+	if id == "" {
+		return
+	}
+	entry := r.directory.Entry(id)
+	if entry == nil {
+		return
+	}
+	publishExternalRuntimeStatusToEntry(entry, r.ExternalRuntimeStatus(id))
+}
+
+func publishExternalRuntimeStatusToEntry(entry *runtimeEntry, status clientui.ExternalRuntimeStatus) {
+	if entry == nil || entry.sessionActivity == nil {
+		return
+	}
+	entry.sessionActivity.Publish(clientui.Event{
+		Kind:                  clientui.EventExternalRuntimeStatus,
+		ExternalRuntimeStatus: &status,
+	})
 }
 
 type notifyingSessionActivitySubscription struct {

--- a/server/registry/runtime_registry_test.go
+++ b/server/registry/runtime_registry_test.go
@@ -9,12 +9,38 @@ import (
 	"testing"
 	"time"
 
+	"core/server/llm"
 	"core/server/primaryrun"
 	"core/server/runtime"
+	"core/server/session"
 	askquestion "core/server/tools"
 	"core/shared/clientui"
 	"core/shared/serverapi"
 )
+
+type registryRuntimeFakeClient struct{}
+
+func (registryRuntimeFakeClient) Generate(context.Context, llm.Request) (llm.Response, error) {
+	return llm.Response{}, nil
+}
+
+func (registryRuntimeFakeClient) ProviderCapabilities(context.Context) (llm.ProviderCapabilities, error) {
+	return llm.ProviderCapabilities{ProviderID: "fake", SupportsResponsesAPI: true}, nil
+}
+
+func newRegistryTestRuntime(t *testing.T, onEvent func(runtime.Event)) *runtime.Engine {
+	t.Helper()
+	store, err := session.Create(t.TempDir(), "workspace", t.TempDir())
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	engine, err := runtime.New(store, registryRuntimeFakeClient{}, askquestion.NewRegistry(), runtime.Config{Model: "gpt-5", OnEvent: onEvent})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	t.Cleanup(func() { _ = engine.Close() })
+	return engine
+}
 
 func TestRuntimeRegistryBroadcastsSessionActivityToMultipleSubscribers(t *testing.T) {
 	registry := NewRuntimeRegistry()
@@ -278,6 +304,192 @@ func TestRuntimeRegistrySleepObserverUnregisterLastRunningSessionReportsIdle(t *
 	}
 }
 
+func TestRuntimeRegistryScopedGuardRejectsReplacementAndClosingEntries(t *testing.T) {
+	registry := NewRuntimeRegistry()
+	first := &runtime.Engine{}
+	second := &runtime.Engine{}
+	registry.Register("session-1", first)
+	firstGuard, err := registry.BeginRuntimeGuard(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("BeginRuntimeGuard first: %v", err)
+	}
+	if firstGuard.Engine() != first {
+		t.Fatal("expected first guard to reference first engine")
+	}
+
+	replaced := make(chan struct{})
+	go func() {
+		registry.Register("session-1", second)
+		close(replaced)
+	}()
+	assertNoClose(t, replaced)
+	firstGuard.Release()
+	waitClosed(t, replaced)
+
+	replacementGuard, err := registry.BeginRuntimeGuard(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("BeginRuntimeGuard replacement: %v", err)
+	}
+	replacementGuard.Release()
+	registry.Unregister("session-1", second)
+	if _, err := registry.BeginRuntimeGuard(context.Background(), "session-1"); err == nil {
+		t.Fatal("expected guard for unregistered runtime to fail")
+	}
+}
+
+func TestRuntimeRegistryReplacementDoesNotHoldDirectoryLockWhileWaitingForGuard(t *testing.T) {
+	registry := NewRuntimeRegistry()
+	first := &runtime.Engine{}
+	second := &runtime.Engine{}
+	other := &runtime.Engine{}
+	registry.Register("session-1", first)
+	guard, err := registry.BeginRuntimeGuard(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("BeginRuntimeGuard: %v", err)
+	}
+
+	replaced := make(chan struct{})
+	go func() {
+		registry.Register("session-1", second)
+		close(replaced)
+	}()
+	assertNoClose(t, replaced)
+
+	registeredOther := make(chan struct{})
+	go func() {
+		registry.Register("session-2", other)
+		close(registeredOther)
+	}()
+	waitClosed(t, registeredOther)
+
+	guard.Release()
+	waitClosed(t, replaced)
+	registry.Unregister("session-1", second)
+	registry.Unregister("session-2", other)
+}
+
+func TestRuntimeRegistryReplacementWaitsForCloseDrainOwnership(t *testing.T) {
+	registry := NewRuntimeRegistry()
+	first := &runtime.Engine{}
+	second := &runtime.Engine{}
+	registry.Register("session-1", first)
+
+	drainStarted := make(chan struct{})
+	releaseDrain := make(chan struct{})
+	drainDone := make(chan struct{})
+	go func() {
+		err := registry.CloseRuntimeWithDrain(context.Background(), "session-1", first, func(context.Context) error {
+			close(drainStarted)
+			<-releaseDrain
+			return nil
+		})
+		if err != nil {
+			t.Errorf("CloseRuntimeWithDrain: %v", err)
+		}
+		close(drainDone)
+	}()
+	waitClosed(t, drainStarted)
+
+	replaced := make(chan struct{})
+	go func() {
+		registry.Register("session-1", second)
+		close(replaced)
+	}()
+	assertNoClose(t, replaced)
+
+	close(releaseDrain)
+	waitClosed(t, drainDone)
+	waitClosed(t, replaced)
+	if registry.directory.Resolve("session-1") != second {
+		t.Fatal("expected replacement runtime after drain completes")
+	}
+	registry.Unregister("session-1", second)
+}
+
+func TestRuntimeRegistryCloseDrainDoesNotClearOwnerPrimaryRunLease(t *testing.T) {
+	registry := NewRuntimeRegistry()
+	engine := &runtime.Engine{}
+	registry.Register("session-1", engine)
+	ownerLease, err := registry.AcquirePrimaryRun("session-1")
+	if err != nil {
+		t.Fatalf("AcquirePrimaryRun owner: %v", err)
+	}
+
+	if err := registry.CloseRuntimeWithDrain(context.Background(), "session-1", engine, nil); err != nil {
+		t.Fatalf("CloseRuntimeWithDrain: %v", err)
+	}
+	if _, err := registry.AcquirePrimaryRun("session-1"); !errors.Is(err, primaryrun.ErrActivePrimaryRun) {
+		t.Fatalf("AcquirePrimaryRun before owner release error = %v, want active primary run", err)
+	}
+	ownerLease.Release()
+	if lease, err := registry.AcquirePrimaryRun("session-1"); err != nil {
+		t.Fatalf("AcquirePrimaryRun after owner release: %v", err)
+	} else {
+		lease.Release()
+	}
+}
+
+func TestRuntimeRegistryUnregisterWaitsForCloseDrainOwnership(t *testing.T) {
+	registry := NewRuntimeRegistry()
+	engine := &runtime.Engine{}
+	registry.Register("session-1", engine)
+
+	drainStarted := make(chan struct{})
+	releaseDrain := make(chan struct{})
+	drainDone := make(chan struct{})
+	go func() {
+		err := registry.CloseRuntimeWithDrain(context.Background(), "session-1", engine, func(context.Context) error {
+			close(drainStarted)
+			<-releaseDrain
+			return nil
+		})
+		if err != nil {
+			t.Errorf("CloseRuntimeWithDrain: %v", err)
+		}
+		close(drainDone)
+	}()
+	waitClosed(t, drainStarted)
+
+	unregistered := make(chan struct{})
+	go func() {
+		registry.Unregister("session-1", engine)
+		close(unregistered)
+	}()
+	assertNoClose(t, unregistered)
+
+	close(releaseDrain)
+	waitClosed(t, drainDone)
+	waitClosed(t, unregistered)
+	if registry.IsSessionRuntimeActive("session-1") {
+		t.Fatal("expected runtime to be inactive after drain and unregister complete")
+	}
+}
+
+func TestRuntimeRegistryUnregisterWaitsForInFlightGuard(t *testing.T) {
+	registry := NewRuntimeRegistry()
+	engine := &runtime.Engine{}
+	registry.Register("session-1", engine)
+	guard, err := registry.BeginRuntimeGuard(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("BeginRuntimeGuard: %v", err)
+	}
+
+	unregistered := make(chan struct{})
+	go func() {
+		registry.Unregister("session-1", engine)
+		close(unregistered)
+	}()
+	assertNoClose(t, unregistered)
+	if _, err := registry.BeginRuntimeGuard(context.Background(), "session-1"); err == nil {
+		t.Fatal("expected closing runtime to reject new guarded mutation")
+	}
+	guard.Release()
+	waitClosed(t, unregistered)
+	if registry.IsSessionRuntimeActive("session-1") {
+		t.Fatal("expected runtime to unregister after guard release")
+	}
+}
+
 func TestRuntimeRegistrySleepObserverReplacingRunningSessionReportsIdleOnce(t *testing.T) {
 	registry := NewRuntimeRegistry()
 	first := &runtime.Engine{}
@@ -427,6 +639,24 @@ func assertNoSleepObserverState(t *testing.T, notifications <-chan bool) {
 	case active := <-notifications:
 		t.Fatalf("unexpected sleep observer notification: %v", active)
 	default:
+	}
+}
+
+func assertNoClose(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatal("channel closed before release")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func waitClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for channel close")
 	}
 }
 
@@ -817,6 +1047,203 @@ func TestRuntimeRegistryPreservesPrimaryRunLeaseWhenRuntimeIsReplaced(t *testing
 	secondLease.Release()
 }
 
+func TestRuntimeRegistryBeginRuntimeGuardUsesCurrentEntryAfterReplacement(t *testing.T) {
+	registry := NewRuntimeRegistry()
+	older := &runtime.Engine{}
+	newer := &runtime.Engine{}
+	registry.Register("session-1", older)
+	registry.Register("session-1", newer)
+	t.Cleanup(func() { registry.Unregister("session-1", newer) })
+
+	guard, err := registry.BeginRuntimeGuard(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("BeginRuntimeGuard: %v", err)
+	}
+	defer guard.Release()
+	if guard.Engine() != newer {
+		t.Fatalf("guard engine = %p, want current replacement %p", guard.Engine(), newer)
+	}
+}
+
+func TestRuntimeRegistryRegisterFailsPreviousQueuedMessagesOnReplacement(t *testing.T) {
+	registry := NewRuntimeRegistry()
+	sessionID := "session-1"
+	older := newRegistryTestRuntime(t, func(evt runtime.Event) {
+		registry.PublishRuntimeEvent(sessionID, evt)
+	})
+	newer := newRegistryTestRuntime(t, func(evt runtime.Event) {
+		registry.PublishRuntimeEvent(sessionID, evt)
+	})
+	registry.Register(sessionID, older)
+	oldSub, err := registry.SubscribeSessionActivity(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("SubscribeSessionActivity old: %v", err)
+	}
+	defer func() { _ = oldSub.Close() }()
+	queued := older.QueueUserMessageWithClientRequestID("restore me", "req-replace")
+
+	registry.Register(sessionID, newer)
+	t.Cleanup(func() { registry.Unregister(sessionID, newer) })
+
+	if older.HasQueuedUserWork() {
+		t.Fatal("previous runtime kept queued work after replacement")
+	}
+	statuses := make([]clientui.QueuedUserMessageStatusEvent, 0, 2)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	for {
+		evt, err := oldSub.Next(ctx)
+		if err != nil {
+			t.Fatalf("old subscription closed before replacement queued failure: %v; statuses=%+v", err, statuses)
+		}
+		if evt.QueuedUserMessageStatus == nil {
+			continue
+		}
+		statuses = append(statuses, *evt.QueuedUserMessageStatus)
+		if evt.QueuedUserMessageStatus.Status == clientui.QueuedUserMessageFailed {
+			break
+		}
+	}
+	if len(statuses) != 2 || statuses[0].Status != clientui.QueuedUserMessageAccepted || statuses[1].Status != clientui.QueuedUserMessageFailed {
+		t.Fatalf("queued statuses = %+v, want accepted then failed", statuses)
+	}
+	if statuses[1].QueueItemID != queued.ID || statuses[1].ClientRequestID != "req-replace" || statuses[1].RestoreText != "restore me" || statuses[1].FailureReason != clientui.QueuedUserMessageFailureClosing {
+		t.Fatalf("failed status = %+v, want replacement close restore", statuses[1])
+	}
+	currentEntry := registry.directory.Entry(sessionID)
+	if currentEntry == nil || currentEntry.sessionActivity == nil {
+		t.Fatal("replacement session activity entry is unavailable")
+	}
+	for _, evt := range currentEntry.sessionActivity.history {
+		if evt.QueuedUserMessageStatus != nil && evt.QueuedUserMessageStatus.QueueItemID == queued.ID {
+			t.Fatalf("replacement broker received stale previous queued status: %+v", evt.QueuedUserMessageStatus)
+		}
+	}
+}
+
+func TestRuntimeRegistryRegisterWaitsForOldGuardsBeforePublishingReplacement(t *testing.T) {
+	registry := NewRuntimeRegistry()
+	older := &runtime.Engine{}
+	newer := &runtime.Engine{}
+	registry.Register("session-1", older)
+	guard, err := registry.BeginRuntimeGuard(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("BeginRuntimeGuard: %v", err)
+	}
+	registered := make(chan struct{})
+	go func() {
+		registry.Register("session-1", newer)
+		close(registered)
+	}()
+	select {
+	case <-registered:
+		t.Fatal("replacement registered before old guard was released")
+	case <-time.After(50 * time.Millisecond):
+	}
+	guard.Release()
+	select {
+	case <-registered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for replacement registration")
+	}
+	resolved, err := registry.ResolveRuntime(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("ResolveRuntime after replacement: %v", err)
+	}
+	if resolved != newer {
+		t.Fatalf("runtime after replacement = %p, want newer %p", resolved, newer)
+	}
+	t.Cleanup(func() { registry.Unregister("session-1", newer) })
+}
+
+func TestRuntimeRegistryExternalRuntimeStatusReflectsPrimaryRunAndCloseBarrier(t *testing.T) {
+	registry := NewRuntimeRegistry()
+	engine := &runtime.Engine{}
+	registry.Register("session-1", engine)
+
+	status := registry.ExternalRuntimeStatus("session-1")
+	if status.State != clientui.ExternalRuntimeStateRegisteredIdle || !status.QueueAccepting {
+		t.Fatalf("idle external status = %+v, want registered idle accepting", status)
+	}
+	lease, err := registry.AcquirePrimaryRun("session-1")
+	if err != nil {
+		t.Fatalf("AcquirePrimaryRun: %v", err)
+	}
+	status = registry.ExternalRuntimeStatus("session-1")
+	if status.State != clientui.ExternalRuntimeStateOwnerRunning || !status.QueueAccepting {
+		t.Fatalf("running external status = %+v, want owner running accepting", status)
+	}
+	lease.Release()
+
+	started := make(chan struct{})
+	releaseDrain := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- registry.CloseRuntimeWithDrain(context.Background(), "session-1", engine, func(context.Context) error {
+			close(started)
+			<-releaseDrain
+			return nil
+		})
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for close drain")
+	}
+	status = registry.ExternalRuntimeStatus("session-1")
+	if status.State != clientui.ExternalRuntimeStateDraining || status.QueueAccepting {
+		t.Fatalf("draining external status = %+v, want draining not accepting", status)
+	}
+	close(releaseDrain)
+	if err := <-done; err != nil {
+		t.Fatalf("CloseRuntimeWithDrain: %v", err)
+	}
+	if status := registry.ExternalRuntimeStatus("session-1"); status.State != "" || status.QueueAccepting {
+		t.Fatalf("removed external status = %+v, want zero", status)
+	}
+}
+
+func TestRuntimeRegistryPublishesExternalRuntimeStatusEvents(t *testing.T) {
+	registry := NewRuntimeRegistry()
+	engine := &runtime.Engine{}
+	registry.Register("session-1", engine)
+	sub, err := registry.SubscribeSessionActivity(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("SubscribeSessionActivity: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+
+	lease, err := registry.AcquirePrimaryRun("session-1")
+	if err != nil {
+		t.Fatalf("AcquirePrimaryRun: %v", err)
+	}
+	assertNextExternalRuntimeStatus(t, sub, clientui.ExternalRuntimeStateOwnerRunning, true)
+	lease.Release()
+	assertNextExternalRuntimeStatus(t, sub, clientui.ExternalRuntimeStateRegisteredIdle, true)
+
+	started := make(chan struct{})
+	releaseDrain := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- registry.CloseRuntimeWithDrain(context.Background(), "session-1", engine, func(context.Context) error {
+			close(started)
+			<-releaseDrain
+			return nil
+		})
+	}()
+	assertNextExternalRuntimeStatus(t, sub, clientui.ExternalRuntimeStateDraining, false)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for close drain")
+	}
+	close(releaseDrain)
+	assertNextExternalRuntimeStatus(t, sub, "", false)
+	if err := <-done; err != nil {
+		t.Fatalf("CloseRuntimeWithDrain: %v", err)
+	}
+}
+
 func TestRuntimeRegistryClearsPrimaryRunLeaseWhenRuntimeIsRemoved(t *testing.T) {
 	registry := NewRuntimeRegistry()
 	engine := &runtime.Engine{}
@@ -834,6 +1261,22 @@ func TestRuntimeRegistryClearsPrimaryRunLeaseWhenRuntimeIsRemoved(t *testing.T) 
 		t.Fatalf("AcquirePrimaryRun after unregister: %v", err)
 	}
 	thirdLease.Release()
+}
+
+func assertNextExternalRuntimeStatus(t *testing.T, sub serverapi.SessionActivitySubscription, state clientui.ExternalRuntimeState, queueAccepting bool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	evt, err := sub.Next(ctx)
+	if err != nil {
+		t.Fatalf("Next external runtime status: %v", err)
+	}
+	if evt.Kind != clientui.EventExternalRuntimeStatus || evt.ExternalRuntimeStatus == nil {
+		t.Fatalf("event = %+v, want external runtime status", evt)
+	}
+	if evt.ExternalRuntimeStatus.State != state || evt.ExternalRuntimeStatus.QueueAccepting != queueAccepting {
+		t.Fatalf("external runtime status = %+v, want state=%q queue=%t", evt.ExternalRuntimeStatus, state, queueAccepting)
+	}
 }
 
 func TestPendingPromptStoreCloseDoesNotBlockWhenResponseAlreadyBuffered(t *testing.T) {

--- a/server/registry/runtime_registry_test.go
+++ b/server/registry/runtime_registry_test.go
@@ -1174,12 +1174,34 @@ func TestRuntimeRegistryExternalRuntimeStatusReflectsPrimaryRunAndCloseBarrier(t
 		t.Fatalf("running external status = %+v, want owner running accepting", status)
 	}
 	lease.Release()
+	guard, err := registry.BeginRuntimeGuard(context.Background(), "session-1")
+	if err != nil {
+		t.Fatalf("BeginRuntimeGuard: %v", err)
+	}
+	unregistered := make(chan struct{})
+	go func() {
+		registry.Unregister("session-1", engine)
+		close(unregistered)
+	}()
+	waitForExternalRuntimeStatus(t, registry, "session-1", clientui.ExternalRuntimeStateClosing, false)
+	guard.Release()
+	select {
+	case <-unregistered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for unregister")
+	}
+	if status := registry.ExternalRuntimeStatus("session-1"); status.State != "" || status.QueueAccepting {
+		t.Fatalf("removed external status after unregister = %+v, want zero", status)
+	}
+
+	drainEngine := &runtime.Engine{}
+	registry.Register("session-1", drainEngine)
 
 	started := make(chan struct{})
 	releaseDrain := make(chan struct{})
 	done := make(chan error, 1)
 	go func() {
-		done <- registry.CloseRuntimeWithDrain(context.Background(), "session-1", engine, func(context.Context) error {
+		done <- registry.CloseRuntimeWithDrain(context.Background(), "session-1", drainEngine, func(context.Context) error {
 			close(started)
 			<-releaseDrain
 			return nil
@@ -1200,6 +1222,22 @@ func TestRuntimeRegistryExternalRuntimeStatusReflectsPrimaryRunAndCloseBarrier(t
 	}
 	if status := registry.ExternalRuntimeStatus("session-1"); status.State != "" || status.QueueAccepting {
 		t.Fatalf("removed external status = %+v, want zero", status)
+	}
+}
+
+func waitForExternalRuntimeStatus(t *testing.T, registry *RuntimeRegistry, sessionID string, state clientui.ExternalRuntimeState, queueAccepting bool) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		status := registry.ExternalRuntimeStatus(sessionID)
+		if status.State == state && status.QueueAccepting == queueAccepting {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("external runtime status = %+v, want state=%q queue=%t", status, state, queueAccepting)
+		case <-time.After(10 * time.Millisecond):
+		}
 	}
 }
 

--- a/server/runprompt/headless.go
+++ b/server/runprompt/headless.go
@@ -82,15 +82,18 @@ func (l *headlessPromptLauncher) PrepareHeadlessPrompt(ctx context.Context, req 
 		return nil, err
 	}
 	plan := result.Plan
-	if plan.Store.Meta().Goal != nil {
-		return nil, fmt.Errorf("%w", ErrHeadlessGoalSession)
-	}
 	var primaryLease primaryrun.Lease
 	if l.boot.RuntimeRegistry != nil {
 		primaryLease, err = l.boot.RuntimeRegistry.AcquirePrimaryRun(plan.Store.Meta().SessionID)
 		if err != nil {
 			return nil, err
 		}
+	}
+	if plan.Store.Meta().Goal != nil {
+		if primaryLease != nil {
+			primaryLease.Release()
+		}
+		return nil, fmt.Errorf("%w", ErrHeadlessGoalSession)
 	}
 	runtimePlan, err := l.prepareRuntime(plan, progress, primaryLease)
 	if err != nil {

--- a/server/runprompt/headless.go
+++ b/server/runprompt/headless.go
@@ -18,6 +18,7 @@ import (
 	"core/server/sessionlaunch"
 	askquestion "core/server/tools"
 	shelltool "core/server/tools/shell"
+	servicecontract "core/shared/apicontract"
 	"core/shared/client"
 	"core/shared/serverapi"
 	"core/shared/transcriptdiag"
@@ -50,7 +51,7 @@ type HeadlessBootstrap struct {
 
 func NewLoopbackRunPromptClient(boot HeadlessBootstrap) client.RunPromptClient {
 	launcher := &headlessPromptLauncher{boot: boot}
-	service := primaryrun.NewGuardingPromptService(boot.RuntimeRegistry, NewPromptService(launcher))
+	var service servicecontract.RunPromptService = NewPromptService(launcher)
 	if service != nil {
 		service = &memoizingPromptService{
 			inner: service,
@@ -84,8 +85,18 @@ func (l *headlessPromptLauncher) PrepareHeadlessPrompt(ctx context.Context, req 
 	if plan.Store.Meta().Goal != nil {
 		return nil, fmt.Errorf("%w", ErrHeadlessGoalSession)
 	}
-	runtimePlan, err := l.prepareRuntime(plan, progress)
+	var primaryLease primaryrun.Lease
+	if l.boot.RuntimeRegistry != nil {
+		primaryLease, err = l.boot.RuntimeRegistry.AcquirePrimaryRun(plan.Store.Meta().SessionID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	runtimePlan, err := l.prepareRuntime(plan, progress, primaryLease)
 	if err != nil {
+		if primaryLease != nil {
+			primaryLease.Release()
+		}
 		return nil, err
 	}
 	return &headlessPromptRuntime{plan: runtimePlan, warnings: result.Warnings, history: l.boot.PromptHistory}, nil
@@ -105,7 +116,7 @@ func (p *headlessRuntimePlan) Close() {
 	p.close()
 }
 
-func (l *headlessPromptLauncher) prepareRuntime(plan launch.SessionPlan, progress serverapi.RunPromptProgressSink) (*headlessRuntimePlan, error) {
+func (l *headlessPromptLauncher) prepareRuntime(plan launch.SessionPlan, progress serverapi.RunPromptProgressSink, primaryLease primaryrun.Lease) (*headlessRuntimePlan, error) {
 	logger, err := NewRunLogger(plan.Store.Dir(), func(diag RunLoggerDiagnostic) {
 		if progress != nil {
 			progress.PublishRunPromptProgress(serverapi.RunPromptProgress{Kind: serverapi.RunPromptProgressKindWarning, Message: "Run logging degraded"})
@@ -152,13 +163,22 @@ func (l *headlessPromptLauncher) prepareRuntime(plan launch.SessionPlan, progres
 	if l.boot.BackgroundRouter != nil {
 		backgroundRouter = l.boot.BackgroundRouter
 	}
-	registration := runtimewire.RegisterSessionRuntime(plan.Store.Meta().SessionID, wiring.Engine, runtimeRegistry, backgroundRouter)
+	var rebind func(string) error
+	if wiring.LocalTools != nil {
+		rebind = runtimewire.RuntimeRebindFunc(wiring.LocalTools.Rebind, wiring.Engine)
+	}
+	registration := runtimewire.RegisterSessionRuntime(plan.Store.Meta().SessionID, wiring.Engine, runtimeRegistry, backgroundRouter, runtimewire.WithRuntimeRebind(rebind))
 	return &headlessRuntimePlan{
 		logger:      logger,
 		engine:      wiring.Engine,
 		eventBridge: wiring.EventBridge,
 		close: func() {
-			registration.Close()
+			if primaryLease != nil {
+				defer primaryLease.Release()
+			}
+			_ = registration.CloseWithDrain(context.Background(), func(ctx context.Context) error {
+				return wiring.Engine.DrainQueuedUserMessagesBeforeClose(ctx)
+			})
 			_ = wiring.Close()
 			_ = logger.Close()
 		},

--- a/server/runprompt/headless_test.go
+++ b/server/runprompt/headless_test.go
@@ -20,6 +20,7 @@ import (
 	"core/server/requestmemo"
 	"core/server/session"
 	"core/server/sessionlaunch"
+	"core/shared/clientui"
 	"core/shared/config"
 	"core/shared/serverapi"
 	"core/shared/toolspec"
@@ -335,6 +336,10 @@ func TestLoopbackRunPromptClientUnregistersRuntimeAfterCompletion(t *testing.T) 
 	}
 	if !runtimes.IsSessionRuntimeActive(store.Meta().SessionID) {
 		t.Fatalf("expected run prompt runtime active while request is in flight")
+	}
+	status := runtimes.ExternalRuntimeStatus(store.Meta().SessionID)
+	if status.State != clientui.ExternalRuntimeStateOwnerRunning || !status.QueueAccepting {
+		t.Fatalf("external runtime status while headless request is in flight = %+v, want owner_running queue-accepting", status)
 	}
 	releaseOnce.Do(func() { close(release) })
 	select {

--- a/server/runtime/committed_transcript_events_test.go
+++ b/server/runtime/committed_transcript_events_test.go
@@ -75,7 +75,11 @@ func TestCommittedTranscriptChangedMarksOnlyDurableTranscriptMutations(t *testin
 	if _, err := eng.flushPendingUserInjections("flush-step"); err != nil {
 		t.Fatalf("flush pending user injections: %v", err)
 	}
-	assertEventFlags(t, events[start:], []eventFlagExpectation{{kind: EventUserMessageFlushed, stepID: "flush-step", committedChanged: true}})
+	assertEventFlags(t, events[start:], []eventFlagExpectation{
+		{kind: EventQueuedUserMessageStatus, stepID: "", committedChanged: false},
+		{kind: EventUserMessageFlushed, stepID: "flush-step", committedChanged: true},
+		{kind: EventQueuedUserMessageStatus, stepID: "", committedChanged: false},
+	})
 
 	eng.ensureOrchestrationCollaborators()
 	start = len(events)

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -139,7 +139,8 @@ type ContextUsage struct {
 }
 
 type Engine struct {
-	mu sync.Mutex
+	mu               sync.Mutex
+	workflowTerminal WorkflowTerminalState
 
 	lifecycleMu     sync.Mutex
 	lifecycleOnce   sync.Once
@@ -380,18 +381,29 @@ func (e *Engine) launchLifecycleTask(task func(context.Context)) bool {
 }
 
 type QueuedUserMessage struct {
-	ID   string
-	Text string
+	ID              string
+	Text            string
+	ClientRequestID string
 }
 
 func (e *Engine) QueueUserMessage(text string) QueuedUserMessage {
+	return e.QueueUserMessageWithClientRequestID(text, "")
+}
+
+func (e *Engine) QueueUserMessageWithClientRequestID(text string, clientRequestID string) QueuedUserMessage {
 	e.ensureOrchestrationCollaborators()
-	return e.messageFlow.QueueUserMessage(text)
+	item := e.messageFlow.QueueUserMessage(text, clientRequestID)
+	e.emitQueuedUserMessageStatus(item, QueuedUserMessageAccepted, "", false)
+	return item
 }
 
 func (e *Engine) DiscardQueuedUserMessage(queueItemID string) bool {
 	e.ensureOrchestrationCollaborators()
-	return e.messageFlow.DiscardQueuedUserMessage(queueItemID)
+	item, discarded := e.messageFlow.DiscardQueuedUserMessage(queueItemID)
+	if discarded {
+		e.emitQueuedUserMessageStatus(item, QueuedUserMessageDiscarded, "", false)
+	}
+	return discarded
 }
 
 func (e *Engine) Interrupt() error {

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -179,7 +179,7 @@ func (e *Engine) appendMessageRaw(stepID string, msg llm.Message, eventPolicy st
 	return nil
 }
 
-func (e *Engine) appendQueuedUserMessageFlush(stepID string, text string, batch []string, queueItemIDs []string) error {
+func (e *Engine) appendQueuedUserMessageFlush(stepID string, text string, batch []string, queueItems []QueuedUserMessage) error {
 	msg := normalizeMessageForTranscript(llm.Message{Role: llm.RoleUser, Content: text}, e.transcriptWorkingDir())
 	if strings.TrimSpace(msg.Content) == "" {
 		return nil
@@ -194,7 +194,8 @@ func (e *Engine) appendQueuedUserMessageFlush(stepID string, text string, batch 
 	} else {
 		e.markCurrentRequestShapeDirty()
 	}
-	normalizedIDs := normalizedQueueItemIDs(queueItemIDs)
+	normalizedItems := normalizedQueuedUserMessageStatusItems(queueItems)
+	normalizedIDs := queuedUserMessageStatusItemIDs(normalizedItems)
 	if _, _, err := e.store.AppendEvent(stepID, "message", msg); err != nil {
 		return err
 	}
@@ -207,21 +208,71 @@ func (e *Engine) appendQueuedUserMessageFlush(stepID string, text string, batch 
 		UserMessageBatchQueueItemIDs: normalizedIDs,
 		CommittedTranscriptChanged:   true,
 	})
+	for _, item := range normalizedItems {
+		e.emitRaw(Event{
+			Kind: EventQueuedUserMessageStatus,
+			QueuedUserMessageStatus: &QueuedUserMessageStatusEvent{
+				SessionID:       e.SessionID(),
+				QueueItemID:     item.ID,
+				ClientRequestID: item.ClientRequestID,
+				Status:          QueuedUserMessageSubmitted,
+			},
+		})
+	}
 	return nil
 }
 
-func normalizedQueueItemIDs(raw []string) []string {
-	out := make([]string, 0, len(raw))
+func normalizedQueuedUserMessageStatusItems(raw []QueuedUserMessage) []QueuedUserMessage {
+	out := make([]QueuedUserMessage, 0, len(raw))
 	seen := map[string]bool{}
-	for _, id := range raw {
-		trimmed := strings.TrimSpace(id)
-		if trimmed == "" || seen[trimmed] {
+	for _, item := range raw {
+		item.ID = strings.TrimSpace(item.ID)
+		item.ClientRequestID = strings.TrimSpace(item.ClientRequestID)
+		if item.ID == "" || seen[item.ID] {
 			continue
 		}
-		seen[trimmed] = true
-		out = append(out, trimmed)
+		seen[item.ID] = true
+		out = append(out, item)
 	}
 	return out
+}
+
+func queuedUserMessageStatusItemIDs(items []QueuedUserMessage) []string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		if strings.TrimSpace(item.ID) != "" {
+			ids = append(ids, strings.TrimSpace(item.ID))
+		}
+	}
+	return ids
+}
+
+func (e *Engine) emitQueuedUserMessageStatus(item QueuedUserMessage, status QueuedUserMessageStatus, reason QueuedUserMessageFailureReason, restore bool) {
+	if e == nil || item.ID == "" {
+		return
+	}
+	event := &QueuedUserMessageStatusEvent{
+		SessionID:       e.SessionID(),
+		QueueItemID:     item.ID,
+		ClientRequestID: item.ClientRequestID,
+		Status:          status,
+		FailureReason:   reason,
+	}
+	if restore {
+		event.RestoreText = item.Text
+	}
+	e.emitRaw(Event{Kind: EventQueuedUserMessageStatus, QueuedUserMessageStatus: event})
+}
+
+func (e *Engine) FailQueuedUserMessages(reason QueuedUserMessageFailureReason) []QueuedUserMessage {
+	e.ensureOrchestrationCollaborators()
+	pending := e.messageFlow.DrainPendingUserInjections()
+	messages := make([]QueuedUserMessage, 0, len(pending))
+	for _, item := range pending {
+		messages = append(messages, item)
+		e.emitQueuedUserMessageStatus(item, QueuedUserMessageFailed, reason, true)
+	}
+	return messages
 }
 
 func (e *Engine) clearStreamingAssistantStateRaw(stepID string) {

--- a/server/runtime/engine_queue_submission.go
+++ b/server/runtime/engine_queue_submission.go
@@ -53,3 +53,26 @@ func (e *Engine) HasQueuedUserWork() bool {
 	}
 	return false
 }
+
+func (e *Engine) DrainQueuedUserMessagesBeforeClose(ctx context.Context) error {
+	if e == nil {
+		return nil
+	}
+	if e.WorkflowTerminalState().Completed {
+		e.FailQueuedUserMessages(QueuedUserMessageFailureTerminalWorkflowCompletion)
+		return nil
+	}
+	if !e.HasQueuedUserWork() {
+		return nil
+	}
+	_, err := e.SubmitQueuedUserMessages(ctx)
+	if err != nil {
+		if e.WorkflowTerminalState().Completed {
+			e.FailQueuedUserMessages(QueuedUserMessageFailureTerminalWorkflowCompletion)
+			return nil
+		}
+		e.FailQueuedUserMessages(QueuedUserMessageFailureClosing)
+		return err
+	}
+	return nil
+}

--- a/server/runtime/engine_queue_submission_test.go
+++ b/server/runtime/engine_queue_submission_test.go
@@ -58,6 +58,57 @@ func TestSubmitQueuedUserMessagesStartsTurnFromQueuedInjection(t *testing.T) {
 	}
 }
 
+func TestQueuedUserMessageStatusEventsCoverAcceptedSubmittedAndFailed(t *testing.T) {
+	store := mustCreateTestSession(t)
+	client := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "after queued steer"},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	var statuses []QueuedUserMessageStatusEvent
+	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(), Config{
+		Model: "gpt-5",
+		OnEvent: func(evt Event) {
+			if evt.QueuedUserMessageStatus != nil {
+				statuses = append(statuses, *evt.QueuedUserMessageStatus)
+			}
+		},
+	})
+
+	first := eng.QueueUserMessageWithClientRequestID("steer now", "req-1")
+	if _, err := eng.SubmitQueuedUserMessages(context.Background()); err != nil {
+		t.Fatalf("SubmitQueuedUserMessages: %v", err)
+	}
+	second := eng.QueueUserMessageWithClientRequestID("restore me", "req-2")
+	failed := eng.FailQueuedUserMessages(QueuedUserMessageFailureClosing)
+
+	if len(failed) != 1 || failed[0].ID != second.ID {
+		t.Fatalf("failed queued messages = %+v, want second queue item", failed)
+	}
+	want := []QueuedUserMessageStatus{
+		QueuedUserMessageAccepted,
+		QueuedUserMessageSubmitted,
+		QueuedUserMessageAccepted,
+		QueuedUserMessageFailed,
+	}
+	if len(statuses) != len(want) {
+		t.Fatalf("statuses = %+v, want %d events", statuses, len(want))
+	}
+	for i, status := range want {
+		if statuses[i].Status != status {
+			t.Fatalf("status[%d] = %q, want %q in %+v", i, statuses[i].Status, status, statuses)
+		}
+	}
+	if statuses[0].QueueItemID != first.ID || statuses[0].ClientRequestID != "req-1" {
+		t.Fatalf("accepted status = %+v, want first id/client request", statuses[0])
+	}
+	if statuses[1].QueueItemID != first.ID || statuses[1].ClientRequestID != "req-1" {
+		t.Fatalf("submitted status = %+v, want first id/client request", statuses[1])
+	}
+	if statuses[3].QueueItemID != second.ID || statuses[3].ClientRequestID != "req-2" || statuses[3].RestoreText != "restore me" || statuses[3].FailureReason != QueuedUserMessageFailureClosing {
+		t.Fatalf("failed status = %+v, want correlated restore", statuses[3])
+	}
+}
+
 func TestQueuedUserMessagesCoalesceFromStoredSteeringIntents(t *testing.T) {
 	pending := []queuedUserSteeringIntent{
 		{
@@ -74,9 +125,9 @@ func TestQueuedUserMessagesCoalesceFromStoredSteeringIntents(t *testing.T) {
 	if len(messages) != 2 || messages[0] != "intent text" || messages[1] != "second intent" {
 		t.Fatalf("queued messages = %+v, want stored intent content", messages)
 	}
-	ids := queuedUserMessageIDs(pending)
-	if len(ids) != 2 || ids[0] != "queue-1" || ids[1] != "queue-2" {
-		t.Fatalf("queued message ids = %+v, want ids for non-empty stored intents", ids)
+	items := queuedUserMessagesForFlush(pending)
+	if len(items) != 2 || items[0].ID != "queue-1" || items[1].ID != "queue-2" {
+		t.Fatalf("queued message items = %+v, want ids for non-empty stored intents", items)
 	}
 }
 
@@ -121,6 +172,91 @@ func TestSubmitQueuedUserMessagesRetriesTransientBusyErrors(t *testing.T) {
 	}
 	if !hasQueuedUser {
 		t.Fatalf("expected retried request to include queued user message, got %+v", requestMessages(client.calls[0]))
+	}
+}
+
+func TestDrainQueuedUserMessagesBeforeCloseProcessesQueuedSteeringAfterFinalAnswer(t *testing.T) {
+	store := mustCreateTestSession(t)
+	client := &fakeClient{responses: []llm.Response{
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done", Phase: llm.MessagePhaseFinal},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "ack queued steer", Phase: llm.MessagePhaseFinal},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+	}}
+	var statuses []QueuedUserMessageStatusEvent
+	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(), Config{
+		Model: "gpt-5",
+		OnEvent: func(evt Event) {
+			if evt.QueuedUserMessageStatus != nil {
+				statuses = append(statuses, *evt.QueuedUserMessageStatus)
+			}
+		},
+	})
+	if _, err := eng.SubmitUserMessage(context.Background(), "initial"); err != nil {
+		t.Fatalf("SubmitUserMessage: %v", err)
+	}
+	queued := eng.QueueUserMessageWithClientRequestID("queued steer", "req-queued")
+	if err := eng.DrainQueuedUserMessagesBeforeClose(context.Background()); err != nil {
+		t.Fatalf("DrainQueuedUserMessagesBeforeClose: %v", err)
+	}
+	if len(client.calls) != 2 {
+		t.Fatalf("model calls = %d, want initial plus queued drain", len(client.calls))
+	}
+	hasQueuedUser := false
+	for _, message := range requestMessages(client.calls[1]) {
+		if message.Role == llm.RoleUser && message.Content == "queued steer" {
+			hasQueuedUser = true
+			break
+		}
+	}
+	if !hasQueuedUser {
+		t.Fatalf("expected drained request to include queued user message, got %+v", requestMessages(client.calls[1]))
+	}
+	if len(statuses) != 2 || statuses[0].Status != QueuedUserMessageAccepted || statuses[1].Status != QueuedUserMessageSubmitted || statuses[1].QueueItemID != queued.ID || statuses[1].ClientRequestID != "req-queued" {
+		t.Fatalf("queued statuses = %+v, want accepted then submitted for %q", statuses, queued.ID)
+	}
+}
+
+func TestDrainQueuedUserMessagesBeforeCloseFailsRestoredQueueWhenFlushPersistenceFails(t *testing.T) {
+	store := mustCreateTestSession(t)
+	client := &fakeClient{responses: []llm.Response{{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "unused"},
+		Usage:     llm.Usage{WindowTokens: 200000},
+	}}}
+	persistErr := errors.New("persist queued flush")
+	var statuses []QueuedUserMessageStatusEvent
+	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(), Config{
+		Model: "gpt-5",
+		OnEvent: func(evt Event) {
+			if evt.QueuedUserMessageStatus != nil {
+				statuses = append(statuses, *evt.QueuedUserMessageStatus)
+			}
+		},
+	})
+	eng.beforePersistMessage = func(msg llm.Message) error {
+		if msg.Role == llm.RoleUser && msg.Content == "queued steer" {
+			return persistErr
+		}
+		return nil
+	}
+	queued := eng.QueueUserMessageWithClientRequestID("queued steer", "req-queued")
+
+	err := eng.DrainQueuedUserMessagesBeforeClose(context.Background())
+	if !errors.Is(err, persistErr) {
+		t.Fatalf("DrainQueuedUserMessagesBeforeClose error = %v, want %v", err, persistErr)
+	}
+	if eng.HasQueuedUserWork() {
+		t.Fatal("queued user work remained after close-drain failure")
+	}
+	if len(statuses) != 2 || statuses[0].Status != QueuedUserMessageAccepted || statuses[1].Status != QueuedUserMessageFailed {
+		t.Fatalf("queued statuses = %+v, want accepted then failed", statuses)
+	}
+	if statuses[1].QueueItemID != queued.ID || statuses[1].ClientRequestID != "req-queued" || statuses[1].RestoreText != "queued steer" || statuses[1].FailureReason != QueuedUserMessageFailureClosing {
+		t.Fatalf("failed status = %+v, want correlated close failure restore", statuses[1])
 	}
 }
 

--- a/server/runtime/engine_request.go
+++ b/server/runtime/engine_request.go
@@ -137,6 +137,10 @@ func (e *Engine) workflowRunActive() bool {
 	return e != nil && e.cfg.WorkflowRun != nil && strings.TrimSpace(string(e.cfg.WorkflowRun.Contract.RunID)) != ""
 }
 
+func (e *Engine) WorkflowRunConfigured() bool {
+	return e.workflowRunActive()
+}
+
 func (e *Engine) workflowCompletionMode(ctx context.Context) (workflowruntime.CompletionMode, error) {
 	if !e.workflowRunActive() {
 		return "", nil

--- a/server/runtime/events.go
+++ b/server/runtime/events.go
@@ -11,30 +11,57 @@ import (
 type EventKind string
 
 const (
-	EventConversationUpdated EventKind = "conversation_updated"
-	EventAssistantDelta      EventKind = "assistant_delta"
-	EventAssistantDeltaReset EventKind = "assistant_delta_reset"
-	EventOngoingErrorUpdated EventKind = "ongoing_error_updated"
-	EventReasoningDelta      EventKind = "reasoning_delta"
-	EventReasoningDeltaReset EventKind = "reasoning_delta_reset"
-	EventAssistantMessage    EventKind = "assistant_message"
-	EventModelResponse       EventKind = "model_response_received"
-	EventUserMessageFlushed  EventKind = "user_message_flushed"
-	EventToolCallStarted     EventKind = "tool_call_started"
-	EventToolCallCompleted   EventKind = "tool_call_completed"
-	EventReviewerStarted     EventKind = "reviewer_started"
-	EventReviewerCompleted   EventKind = "reviewer_completed"
-	EventInFlightClearFailed EventKind = "in_flight_clear_failed"
-	EventCompactionStarted   EventKind = "context_compaction_started"
-	EventCompactionCompleted EventKind = "context_compaction_completed"
-	EventCompactionFailed    EventKind = "context_compaction_failed"
-	EventCacheWarning        EventKind = "cache_warning"
-	EventLocalEntryAdded     EventKind = "local_entry_added"
-	EventRunStateChanged     EventKind = "run_state_changed"
-	EventBackgroundUpdated   EventKind = "background_updated"
-	EventSleepGuardFailed    EventKind = "sleep_guard_failed"
-	EventGoalStatusUpdated   EventKind = "goal_status_updated"
+	EventConversationUpdated     EventKind = "conversation_updated"
+	EventAssistantDelta          EventKind = "assistant_delta"
+	EventAssistantDeltaReset     EventKind = "assistant_delta_reset"
+	EventOngoingErrorUpdated     EventKind = "ongoing_error_updated"
+	EventReasoningDelta          EventKind = "reasoning_delta"
+	EventReasoningDeltaReset     EventKind = "reasoning_delta_reset"
+	EventAssistantMessage        EventKind = "assistant_message"
+	EventModelResponse           EventKind = "model_response_received"
+	EventUserMessageFlushed      EventKind = "user_message_flushed"
+	EventToolCallStarted         EventKind = "tool_call_started"
+	EventToolCallCompleted       EventKind = "tool_call_completed"
+	EventReviewerStarted         EventKind = "reviewer_started"
+	EventReviewerCompleted       EventKind = "reviewer_completed"
+	EventInFlightClearFailed     EventKind = "in_flight_clear_failed"
+	EventCompactionStarted       EventKind = "context_compaction_started"
+	EventCompactionCompleted     EventKind = "context_compaction_completed"
+	EventCompactionFailed        EventKind = "context_compaction_failed"
+	EventCacheWarning            EventKind = "cache_warning"
+	EventLocalEntryAdded         EventKind = "local_entry_added"
+	EventRunStateChanged         EventKind = "run_state_changed"
+	EventBackgroundUpdated       EventKind = "background_updated"
+	EventSleepGuardFailed        EventKind = "sleep_guard_failed"
+	EventGoalStatusUpdated       EventKind = "goal_status_updated"
+	EventQueuedUserMessageStatus EventKind = "queued_user_message_status"
 )
+
+type QueuedUserMessageStatus string
+
+const (
+	QueuedUserMessageAccepted  QueuedUserMessageStatus = "accepted"
+	QueuedUserMessageSubmitted QueuedUserMessageStatus = "submitted"
+	QueuedUserMessageFailed    QueuedUserMessageStatus = "failed"
+	QueuedUserMessageDiscarded QueuedUserMessageStatus = "discarded"
+)
+
+type QueuedUserMessageFailureReason string
+
+const (
+	QueuedUserMessageFailureClosing                    QueuedUserMessageFailureReason = "closing"
+	QueuedUserMessageFailureTerminalWorkflowCompletion QueuedUserMessageFailureReason = "terminal_workflow_completion"
+	QueuedUserMessageFailureRuntimeUnavailable         QueuedUserMessageFailureReason = "runtime_unavailable"
+)
+
+type QueuedUserMessageStatusEvent struct {
+	SessionID       string
+	QueueItemID     string
+	ClientRequestID string
+	Status          QueuedUserMessageStatus
+	FailureReason   QueuedUserMessageFailureReason
+	RestoreText     string
+}
 
 type Event struct {
 	Kind                         EventKind
@@ -63,6 +90,7 @@ type Event struct {
 	ContextUsage                 *ContextUsage
 	Background                   *BackgroundShellEvent
 	GoalStatus                   *GoalStatusUpdate
+	QueuedUserMessageStatus      *QueuedUserMessageStatusEvent
 }
 
 type GoalStatusUpdate struct {

--- a/server/runtime/message_lifecycle.go
+++ b/server/runtime/message_lifecycle.go
@@ -249,16 +249,18 @@ func queuedUserSteeringIntentText(intent steeringIntent) string {
 	return strings.Join(parts, "\n\n")
 }
 
-func queuedUserMessageIDs(messages []queuedUserSteeringIntent) []string {
-	ids := make([]string, 0, len(messages))
+func queuedUserMessagesForFlush(messages []queuedUserSteeringIntent) []QueuedUserMessage {
+	items := make([]QueuedUserMessage, 0, len(messages))
 	for _, message := range messages {
-		id := strings.TrimSpace(message.message.ID)
-		if id == "" || queuedUserSteeringIntentText(message.intent) == "" {
+		item := message.message
+		item.ID = strings.TrimSpace(item.ID)
+		item.ClientRequestID = strings.TrimSpace(item.ClientRequestID)
+		if item.ID == "" || queuedUserSteeringIntentText(message.intent) == "" {
 			continue
 		}
-		ids = append(ids, id)
+		items = append(items, item)
 	}
-	return ids
+	return items
 }
 
 func (m *defaultMessageLifecycle) FlushPendingUserInjections(stepID string) (int, error) {
@@ -273,7 +275,8 @@ func (m *defaultMessageLifecycle) FlushPendingUserInjections(stepID string) (int
 	queuedMessages := normalizeQueuedUserMessages(pending)
 	if len(queuedMessages) > 0 {
 		joined := strings.Join(queuedMessages, "\n\n")
-		if err := e.steer(stepID, steerQueuedUserMessageFlushIntent(joined, queuedMessages, queuedUserMessageIDs(pending))); err != nil {
+		if err := e.steer(stepID, steerQueuedUserMessageFlushIntent(joined, queuedMessages, queuedUserMessagesForFlush(pending))); err != nil {
+			m.queue.RestoreFront(pending)
 			return flushed, err
 		}
 		flushed++
@@ -287,18 +290,30 @@ func (m *defaultMessageLifecycle) FlushPendingUserInjections(stepID string) (int
 	return flushed, nil
 }
 
-func (m *defaultMessageLifecycle) QueueUserMessage(text string) QueuedUserMessage {
+func (m *defaultMessageLifecycle) QueueUserMessage(text string, clientRequestID string) QueuedUserMessage {
 	if m == nil || m.queue == nil {
 		return QueuedUserMessage{}
 	}
-	return m.queue.Queue(text)
+	return m.queue.Queue(text, clientRequestID)
 }
 
-func (m *defaultMessageLifecycle) DiscardQueuedUserMessage(queueItemID string) bool {
+func (m *defaultMessageLifecycle) DrainPendingUserInjections() []QueuedUserMessage {
 	if m == nil || m.queue == nil {
-		return false
+		return nil
 	}
-	return m.queue.Discard(queueItemID)
+	pending := m.queue.Drain()
+	out := make([]QueuedUserMessage, 0, len(pending))
+	for _, item := range pending {
+		out = append(out, item.message)
+	}
+	return out
+}
+
+func (m *defaultMessageLifecycle) DiscardQueuedUserMessage(queueItemID string) (QueuedUserMessage, bool) {
+	if m == nil || m.queue == nil {
+		return QueuedUserMessage{}, false
+	}
+	return m.queue.DiscardItem(queueItemID)
 }
 
 func (m *defaultMessageLifecycle) HasPendingUserInjections() bool {

--- a/server/runtime/orchestration_collaborators.go
+++ b/server/runtime/orchestration_collaborators.go
@@ -67,8 +67,9 @@ type toolExecutor interface {
 type messageLifecycle interface {
 	RestoreMessages() error
 	FlushPendingUserInjections(stepID string) (int, error)
-	QueueUserMessage(text string) QueuedUserMessage
-	DiscardQueuedUserMessage(queueItemID string) bool
+	DrainPendingUserInjections() []QueuedUserMessage
+	QueueUserMessage(text string, clientRequestID string) QueuedUserMessage
+	DiscardQueuedUserMessage(queueItemID string) (QueuedUserMessage, bool)
 	HasPendingUserInjections() bool
 }
 

--- a/server/runtime/output_steering.go
+++ b/server/runtime/output_steering.go
@@ -73,9 +73,9 @@ type steeringCacheObservation struct {
 }
 
 type steeringQueuedUserMessageFlush struct {
-	text         string
-	batch        []string
-	queueItemIDs []string
+	text       string
+	batch      []string
+	queueItems []QueuedUserMessage
 }
 
 type steeringMessageEventPolicy uint8
@@ -134,13 +134,13 @@ func steerToolCompletionIntent(result tools.Result) steeringIntent {
 	}
 }
 
-func steerQueuedUserMessageFlushIntent(text string, batch []string, queueItemIDs []string) steeringIntent {
+func steerQueuedUserMessageFlushIntent(text string, batch []string, queueItems []QueuedUserMessage) steeringIntent {
 	return steeringIntent{
 		priority: steeringPriorityUser,
 		items: []steeringItem{{queuedFlush: &steeringQueuedUserMessageFlush{
-			text:         text,
-			batch:        append([]string(nil), batch...),
-			queueItemIDs: append([]string(nil), queueItemIDs...),
+			text:       text,
+			batch:      append([]string(nil), batch...),
+			queueItems: append([]QueuedUserMessage(nil), queueItems...),
 		}}},
 	}
 }
@@ -248,7 +248,7 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 		return nil
 	}
 	if item.queuedFlush != nil {
-		return e.appendQueuedUserMessageFlush(stepID, item.queuedFlush.text, item.queuedFlush.batch, item.queuedFlush.queueItemIDs)
+		return e.appendQueuedUserMessageFlush(stepID, item.queuedFlush.text, item.queuedFlush.batch, item.queuedFlush.queueItems)
 	}
 	if item.event != nil {
 		evt := *item.event

--- a/server/runtime/queued_user_messages.go
+++ b/server/runtime/queued_user_messages.go
@@ -22,8 +22,12 @@ func newQueuedUserMessageStore() *queuedUserMessageStore {
 	return &queuedUserMessageStore{}
 }
 
-func (s *queuedUserMessageStore) Queue(text string) QueuedUserMessage {
-	item := QueuedUserMessage{ID: uuid.NewString(), Text: text}
+func (s *queuedUserMessageStore) Queue(text string, clientRequestID ...string) QueuedUserMessage {
+	requestID := ""
+	if len(clientRequestID) > 0 {
+		requestID = clientRequestID[0]
+	}
+	item := QueuedUserMessage{ID: uuid.NewString(), Text: text, ClientRequestID: strings.TrimSpace(requestID)}
 	intent := steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventNone, true, []llm.Message{{Role: llm.RoleUser, Content: item.Text}})
 	s.mu.Lock()
 	s.pending = append(s.pending, queuedUserSteeringIntent{message: item, intent: intent})
@@ -32,23 +36,30 @@ func (s *queuedUserMessageStore) Queue(text string) QueuedUserMessage {
 }
 
 func (s *queuedUserMessageStore) Discard(queueItemID string) bool {
+	_, removed := s.DiscardItem(queueItemID)
+	return removed
+}
+
+func (s *queuedUserMessageStore) DiscardItem(queueItemID string) (QueuedUserMessage, bool) {
 	id := strings.TrimSpace(queueItemID)
 	if id == "" || s == nil {
-		return false
+		return QueuedUserMessage{}, false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	filtered := s.pending[:0]
 	removed := false
+	var item QueuedUserMessage
 	for _, pending := range s.pending {
 		if pending.message.ID == id {
 			removed = true
+			item = pending.message
 			continue
 		}
 		filtered = append(filtered, pending)
 	}
 	s.pending = filtered
-	return removed
+	return item, removed
 }
 
 func (s *queuedUserMessageStore) Drain() []queuedUserSteeringIntent {
@@ -60,6 +71,16 @@ func (s *queuedUserMessageStore) Drain() []queuedUserSteeringIntent {
 	s.pending = nil
 	s.mu.Unlock()
 	return pending
+}
+
+func (s *queuedUserMessageStore) RestoreFront(items []queuedUserSteeringIntent) {
+	if s == nil || len(items) == 0 {
+		return
+	}
+	restored := append([]queuedUserSteeringIntent(nil), items...)
+	s.mu.Lock()
+	s.pending = append(restored, s.pending...)
+	s.mu.Unlock()
 }
 
 func (s *queuedUserMessageStore) HasPending() bool {

--- a/server/runtime/step_executor.go
+++ b/server/runtime/step_executor.go
@@ -424,6 +424,7 @@ func (s *defaultStepExecutor) handleWorkflowAssistantWithoutTools(ctx context.Co
 			terminal, nudgeErr := s.appendWorkflowInvalidCompletionNudge(ctx, stepID, completeErr)
 			return true, terminal, nudgeErr
 		}
+		e.setWorkflowTerminalState(WorkflowCompletionSourceStructuredOutput)
 		return true, true, nil
 	}
 	if mode == workflowruntime.CompletionModeUnstructuredOutput && assistantMsg.Phase == llm.MessagePhaseFinal {
@@ -437,6 +438,7 @@ func (s *defaultStepExecutor) handleWorkflowAssistantWithoutTools(ctx context.Co
 			terminal, nudgeErr := s.appendWorkflowInvalidCompletionNudge(ctx, stepID, completeErr)
 			return true, terminal, nudgeErr
 		}
+		e.setWorkflowTerminalState(WorkflowCompletionSourceUnstructured)
 		return true, true, nil
 	}
 	if mode == workflowruntime.CompletionModeShellCommand && assistantMsg.Phase == llm.MessagePhaseFinal {

--- a/server/runtime/tool_executor.go
+++ b/server/runtime/tool_executor.go
@@ -192,6 +192,7 @@ func (t *defaultToolExecutor) executeCompleteNodeTool(ctx context.Context, stepI
 	if err != nil {
 		return e.workflowCompletionRejectedResult(ctx, result, err)
 	}
+	e.setWorkflowTerminalState(WorkflowCompletionSourceTool)
 	result.Output = workflowruntime.ToolSuccessPayload(completed)
 	result.Summary = "workflow node completed"
 	result.Terminal = true

--- a/server/runtime/workflow_completion.go
+++ b/server/runtime/workflow_completion.go
@@ -72,6 +72,9 @@ func (e *Engine) observeWorkflowDurableCompletion(ctx context.Context) (bool, er
 	if err != nil {
 		return false, err
 	}
+	if result.Completed {
+		e.setWorkflowTerminalState(WorkflowCompletionSourceObserved)
+	}
 	return result.Completed, nil
 }
 

--- a/server/runtime/workflow_completion_test.go
+++ b/server/runtime/workflow_completion_test.go
@@ -394,6 +394,24 @@ func TestWorkflowRuntimeRejectsUnresolvedCompletionMode(t *testing.T) {
 	}
 }
 
+func TestWorkflowCompletionRecordsTerminalStateForStructuredOutput(t *testing.T) {
+	store := mustCreateTestSession(t)
+	controller := &fakeWorkflowController{}
+	eng := mustNewWorkflowTestEngine(t, store, &fakeClient{responses: []llm.Response{
+		structuredFinalResponse(`{"commentary":"complete","summary":"done"}`),
+	}}, testWorkflowConfig(controller, config.WorkflowCompletionModeStructuredOutput), Config{
+		ProviderCapabilitiesOverride: &llm.ProviderCapabilities{SupportsResponsesAPI: true},
+	})
+
+	if _, err := eng.SubmitWorkflowTurn(context.Background()); err != nil {
+		t.Fatalf("SubmitWorkflowTurn: %v", err)
+	}
+	terminal := eng.WorkflowTerminalState()
+	if !terminal.Completed || terminal.RunID != "run-1" || terminal.Source != WorkflowCompletionSourceStructuredOutput {
+		t.Fatalf("terminal state = %+v, want structured completion", terminal)
+	}
+}
+
 func TestWorkflowRuntimeUsesPersistedStructuredOutputMode(t *testing.T) {
 	store := mustCreateTestSession(t)
 	client := &fakeClient{caps: llm.ProviderCapabilities{ProviderID: "legacy"}}
@@ -624,6 +642,80 @@ func TestWorkflowUnstructuredFinalAnswerCompletesRun(t *testing.T) {
 	}
 	if got := requests[0].Commentary; got != "complete" {
 		t.Fatalf("completion commentary = %q, want complete", got)
+	}
+	terminal := eng.WorkflowTerminalState()
+	if !terminal.Completed || terminal.Source != WorkflowCompletionSourceUnstructured || terminal.RunID != "run-1" {
+		t.Fatalf("terminal state = %+v, want unstructured completion", terminal)
+	}
+}
+
+func TestWorkflowUnstructuredTerminalCompletionFailsQueuedSteeringDuringCloseDrain(t *testing.T) {
+	store := mustCreateTestSession(t)
+	controller := &fakeWorkflowController{}
+	client := &fakeClient{responses: []llm.Response{
+		structuredFinalResponse(`{"commentary":"complete","summary":"done"}`),
+		structuredFinalResponse("unexpected queued turn"),
+	}}
+	var statuses []QueuedUserMessageStatusEvent
+	eng := mustNewWorkflowTestEngine(t, store, client, testWorkflowConfig(controller, config.WorkflowCompletionModeUnstructured), Config{
+		OnEvent: func(evt Event) {
+			if evt.QueuedUserMessageStatus != nil {
+				statuses = append(statuses, *evt.QueuedUserMessageStatus)
+			}
+		},
+	})
+	if _, err := eng.SubmitUserMessage(context.Background(), "run"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	queued := eng.QueueUserMessageWithClientRequestID("do not submit after completion", "req-after-complete")
+	if err := eng.DrainQueuedUserMessagesBeforeClose(context.Background()); err != nil {
+		t.Fatalf("DrainQueuedUserMessagesBeforeClose: %v", err)
+	}
+	assertModelCallCount(t, client, 1)
+	if len(statuses) != 2 || statuses[0].Status != QueuedUserMessageAccepted || statuses[1].Status != QueuedUserMessageFailed {
+		t.Fatalf("queued statuses = %+v, want accepted then failed", statuses)
+	}
+	if statuses[1].QueueItemID != queued.ID || statuses[1].ClientRequestID != "req-after-complete" || statuses[1].RestoreText != "do not submit after completion" || statuses[1].FailureReason != QueuedUserMessageFailureTerminalWorkflowCompletion {
+		t.Fatalf("failed queue status = %+v, want terminal completion failure for %q", statuses[1], queued.ID)
+	}
+}
+
+func TestWorkflowObservedDurableCompletionFailsQueuedSteeringDuringCloseDrain(t *testing.T) {
+	store := mustCreateTestSession(t)
+	controller := &fakeWorkflowController{}
+	controller.completedExternally.Store(true)
+	client := &fakeClient{responses: []llm.Response{
+		structuredFinalResponse("unexpected queued turn"),
+	}}
+	var statuses []QueuedUserMessageStatusEvent
+	eng := mustNewWorkflowTestEngine(t, store, client, testWorkflowConfig(controller, config.WorkflowCompletionModeShellCommand), Config{
+		OnEvent: func(evt Event) {
+			if evt.QueuedUserMessageStatus != nil {
+				statuses = append(statuses, *evt.QueuedUserMessageStatus)
+			}
+		},
+	})
+	queued := eng.QueueUserMessageWithClientRequestID("do not submit after observed completion", "req-observed-complete")
+	completed, err := eng.observeWorkflowDurableCompletion(context.Background())
+	if err != nil {
+		t.Fatalf("observeWorkflowDurableCompletion: %v", err)
+	}
+	if !completed {
+		t.Fatal("expected durable workflow completion observation")
+	}
+	terminal := eng.WorkflowTerminalState()
+	if !terminal.Completed || terminal.Source != WorkflowCompletionSourceObserved || terminal.RunID != "run-1" {
+		t.Fatalf("terminal state = %+v, want observed completion", terminal)
+	}
+	if err := eng.DrainQueuedUserMessagesBeforeClose(context.Background()); err != nil {
+		t.Fatalf("DrainQueuedUserMessagesBeforeClose: %v", err)
+	}
+	assertModelCallCount(t, client, 0)
+	if len(statuses) != 2 || statuses[0].Status != QueuedUserMessageAccepted || statuses[1].Status != QueuedUserMessageFailed {
+		t.Fatalf("queued statuses = %+v, want accepted then failed", statuses)
+	}
+	if statuses[1].QueueItemID != queued.ID || statuses[1].ClientRequestID != "req-observed-complete" || statuses[1].RestoreText != "do not submit after observed completion" || statuses[1].FailureReason != QueuedUserMessageFailureTerminalWorkflowCompletion {
+		t.Fatalf("failed queue status = %+v, want terminal completion failure for %q", statuses[1], queued.ID)
 	}
 }
 

--- a/server/runtime/workflow_terminal_state.go
+++ b/server/runtime/workflow_terminal_state.go
@@ -1,0 +1,78 @@
+package runtime
+
+import (
+	"strings"
+	"time"
+)
+
+type WorkflowCompletionSource string
+
+const (
+	WorkflowCompletionSourceTool             WorkflowCompletionSource = "tool"
+	WorkflowCompletionSourceStructuredOutput WorkflowCompletionSource = "structured_output"
+	WorkflowCompletionSourceUnstructured     WorkflowCompletionSource = "unstructured_output"
+	WorkflowCompletionSourceObserved         WorkflowCompletionSource = "observed"
+)
+
+type WorkflowTerminalState struct {
+	Completed   bool
+	RunID       string
+	Generation  int64
+	Source      WorkflowCompletionSource
+	CompletedAt time.Time
+}
+
+type WorkflowSessionState struct {
+	RunID      string
+	TaskID     string
+	WorkflowID string
+}
+
+func (e *Engine) WorkflowSessionState() WorkflowSessionState {
+	if e == nil {
+		return WorkflowSessionState{}
+	}
+	if e.workflowRunActive() {
+		return WorkflowSessionState{
+			RunID:      strings.TrimSpace(string(e.cfg.WorkflowRun.Contract.RunID)),
+			TaskID:     strings.TrimSpace(e.cfg.WorkflowRun.Instructions.TaskID),
+			WorkflowID: strings.TrimSpace(e.cfg.WorkflowRun.Instructions.WorkflowID),
+		}
+	}
+	if e.store == nil || e.store.Meta().WorkflowSession == nil {
+		return WorkflowSessionState{}
+	}
+	workflowSession := e.store.Meta().WorkflowSession
+	return WorkflowSessionState{
+		RunID:      strings.TrimSpace(workflowSession.RunID),
+		TaskID:     strings.TrimSpace(workflowSession.TaskID),
+		WorkflowID: strings.TrimSpace(workflowSession.WorkflowID),
+	}
+}
+
+func (e *Engine) WorkflowTerminalState() WorkflowTerminalState {
+	if e == nil {
+		return WorkflowTerminalState{}
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.workflowTerminal
+}
+
+func (e *Engine) setWorkflowTerminalState(source WorkflowCompletionSource) {
+	if e == nil || !e.workflowRunActive() {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.workflowTerminal.Completed {
+		return
+	}
+	e.workflowTerminal = WorkflowTerminalState{
+		Completed:   true,
+		RunID:       strings.TrimSpace(string(e.cfg.WorkflowRun.Contract.RunID)),
+		Generation:  e.cfg.WorkflowRun.Contract.ExpectedGeneration,
+		Source:      source,
+		CompletedAt: time.Now(),
+	}
+}

--- a/server/runtime/workflow_terminal_state.go
+++ b/server/runtime/workflow_terminal_state.go
@@ -39,10 +39,14 @@ func (e *Engine) WorkflowSessionState() WorkflowSessionState {
 			WorkflowID: strings.TrimSpace(e.cfg.WorkflowRun.Instructions.WorkflowID),
 		}
 	}
-	if e.store == nil || e.store.Meta().WorkflowSession == nil {
+	if e.store == nil {
 		return WorkflowSessionState{}
 	}
-	workflowSession := e.store.Meta().WorkflowSession
+	meta := e.store.Meta()
+	workflowSession := meta.WorkflowSession
+	if workflowSession == nil {
+		return WorkflowSessionState{}
+	}
 	return WorkflowSessionState{
 		RunID:      strings.TrimSpace(workflowSession.RunID),
 		TaskID:     strings.TrimSpace(workflowSession.TaskID),

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -21,6 +21,14 @@ type RuntimeResolver interface {
 	ResolveRuntime(ctx context.Context, sessionID string) (*runtime.Engine, error)
 }
 
+type CollaborativeRuntimeGuard interface {
+	Engine() *runtime.Engine
+}
+
+type CollaborativeRuntimeResolver interface {
+	WithCollaborativeRuntimeEngine(ctx context.Context, sessionID string, op serverapi.SessionRuntimeOperation, fn func(*runtime.Engine) error) error
+}
+
 type ControllerLeaseVerifier interface {
 	RequireControllerLease(ctx context.Context, sessionID string, leaseID string) error
 }
@@ -29,11 +37,17 @@ type PromptHistoryStore interface {
 	RecordPromptHistoryEntry(ctx context.Context, entry metadata.PromptHistoryEntry) (metadata.PromptHistoryRecord, bool, error)
 }
 
+type WorkflowSessionResolver interface {
+	ResolveSessionStore(ctx context.Context, sessionID string) (*session.Store, error)
+}
+
 type Service struct {
 	runtimes       RuntimeResolver
+	collaborative  CollaborativeRuntimeResolver
 	gate           primaryrun.Gate
 	control        ControllerLeaseVerifier
 	promptStore    PromptHistoryStore
+	workflowStates WorkflowSessionResolver
 	sessionNames   *requestmemo.Memo[sessionStringMemoRequest, struct{}]
 	thinkingLevels *requestmemo.Memo[sessionStringMemoRequest, struct{}]
 	fastModes      *requestmemo.Memo[sessionBoolMemoRequest, serverapi.RuntimeSetFastModeEnabledResponse]
@@ -153,6 +167,14 @@ func (s *Service) WithControllerLeaseVerifier(verifier ControllerLeaseVerifier) 
 	return s
 }
 
+func (s *Service) WithCollaborativeRuntimeResolver(resolver CollaborativeRuntimeResolver) *Service {
+	if s == nil {
+		return nil
+	}
+	s.collaborative = resolver
+	return s
+}
+
 func (s *Service) WithPromptHistoryStore(store PromptHistoryStore) *Service {
 	if s == nil {
 		return nil
@@ -161,11 +183,36 @@ func (s *Service) WithPromptHistoryStore(store PromptHistoryStore) *Service {
 	return s
 }
 
+func (s *Service) WithWorkflowSessionResolver(resolver WorkflowSessionResolver) *Service {
+	if s == nil {
+		return nil
+	}
+	s.workflowStates = resolver
+	return s
+}
+
 func (s *Service) requireControllerLease(ctx context.Context, sessionID string, leaseID string) error {
 	if s == nil || s.control == nil {
 		return nil
 	}
 	return s.control.RequireControllerLease(ctx, sessionID, leaseID)
+}
+
+func (s *Service) withRuntimeAccess(ctx context.Context, sessionID string, leaseID string, op serverapi.SessionRuntimeOperation, fn func(*runtime.Engine) error) error {
+	if strings.TrimSpace(leaseID) != "" {
+		if err := s.requireControllerLease(ctx, sessionID, leaseID); err != nil {
+			return err
+		}
+		engine, err := s.resolve(ctx, sessionID)
+		if err != nil {
+			return err
+		}
+		return fn(engine)
+	}
+	if s == nil || s.collaborative == nil {
+		return serverapi.ErrInvalidControllerLease
+	}
+	return s.collaborative.WithCollaborativeRuntimeEngine(ctx, sessionID, op, fn)
 }
 
 func (s *Service) resolve(ctx context.Context, sessionID string) (*runtime.Engine, error) {
@@ -188,14 +235,9 @@ func (s *Service) SetSessionName(ctx context.Context, req serverapi.RuntimeSetSe
 	}
 	memoReq := sessionStringMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Value: req.Name}
 	_, err := s.sessionNames.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameSessionStringMemoRequest, func(ctx context.Context) (struct{}, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return struct{}{}, err
-		}
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return struct{}{}, err
-		}
-		return struct{}{}, engine.SetSessionName(req.Name)
+		return struct{}{}, s.withRuntimeAccess(ctx, req.SessionID, req.ControllerLeaseID, serverapi.SessionRuntimeOperationSettingsSessionName, func(engine *runtime.Engine) error {
+			return engine.SetSessionName(req.Name)
+		})
 	})
 	return err
 }
@@ -206,14 +248,9 @@ func (s *Service) SetThinkingLevel(ctx context.Context, req serverapi.RuntimeSet
 	}
 	memoReq := sessionStringMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Value: req.Level}
 	_, err := s.thinkingLevels.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameSessionStringMemoRequest, func(ctx context.Context) (struct{}, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return struct{}{}, err
-		}
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return struct{}{}, err
-		}
-		return struct{}{}, engine.SetThinkingLevel(req.Level)
+		return struct{}{}, s.withRuntimeAccess(ctx, req.SessionID, req.ControllerLeaseID, serverapi.SessionRuntimeOperationSettingsThinkingLevel, func(engine *runtime.Engine) error {
+			return engine.SetThinkingLevel(req.Level)
+		})
 	})
 	return err
 }
@@ -224,20 +261,15 @@ func (s *Service) SetFastModeEnabled(ctx context.Context, req serverapi.RuntimeS
 	}
 	memoReq := sessionBoolMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Enabled: req.Enabled}
 	return s.fastModes.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameSessionBoolMemoRequest, func(ctx context.Context) (serverapi.RuntimeSetFastModeEnabledResponse, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return serverapi.RuntimeSetFastModeEnabledResponse{}, err
-		}
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return serverapi.RuntimeSetFastModeEnabledResponse{}, err
-		}
-		changed, err := engine.SetFastModeEnabledWithCommittedFeedback(req.Enabled, func(changed bool) string {
-			return serverapi.FastModeToggleStatusMessage(req.Enabled, changed)
+		var resp serverapi.RuntimeSetFastModeEnabledResponse
+		err := s.withRuntimeAccess(ctx, req.SessionID, req.ControllerLeaseID, serverapi.SessionRuntimeOperationSettingsFastMode, func(engine *runtime.Engine) error {
+			changed, err := engine.SetFastModeEnabledWithCommittedFeedback(req.Enabled, func(changed bool) string {
+				return serverapi.FastModeToggleStatusMessage(req.Enabled, changed)
+			})
+			resp = serverapi.RuntimeSetFastModeEnabledResponse{Changed: changed}
+			return err
 		})
-		if err != nil {
-			return serverapi.RuntimeSetFastModeEnabledResponse{}, err
-		}
-		return serverapi.RuntimeSetFastModeEnabledResponse{Changed: changed}, nil
+		return resp, err
 	})
 }
 
@@ -270,15 +302,18 @@ func (s *Service) SetAutoCompactionEnabled(ctx context.Context, req serverapi.Ru
 	}
 	memoReq := sessionBoolMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Enabled: req.Enabled}
 	return s.autoCompacts.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameSessionBoolMemoRequest, func(ctx context.Context) (serverapi.RuntimeSetAutoCompactionEnabledResponse, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return serverapi.RuntimeSetAutoCompactionEnabledResponse{}, err
-		}
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return serverapi.RuntimeSetAutoCompactionEnabledResponse{}, err
-		}
-		changed, enabled := engine.SetAutoCompactionEnabled(req.Enabled)
-		return serverapi.RuntimeSetAutoCompactionEnabledResponse{Changed: changed, Enabled: enabled}, nil
+		var resp serverapi.RuntimeSetAutoCompactionEnabledResponse
+		err := s.withRuntimeAccess(ctx, req.SessionID, req.ControllerLeaseID, serverapi.SessionRuntimeOperationSettingsAutoCompaction, func(engine *runtime.Engine) error {
+			if !req.Enabled {
+				if err := s.rejectWorkflowAutoCompactionDisable(ctx, req.SessionID, engine); err != nil {
+					return err
+				}
+			}
+			changed, enabled := engine.SetAutoCompactionEnabled(req.Enabled)
+			resp = serverapi.RuntimeSetAutoCompactionEnabledResponse{Changed: changed, Enabled: enabled}
+			return nil
+		})
+		return resp, err
 	})
 }
 
@@ -288,20 +323,15 @@ func (s *Service) SetQuestionsEnabled(ctx context.Context, req serverapi.Runtime
 	}
 	memoReq := sessionBoolMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Enabled: req.Enabled}
 	return s.questions.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameSessionBoolMemoRequest, func(ctx context.Context) (serverapi.RuntimeSetQuestionsEnabledResponse, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return serverapi.RuntimeSetQuestionsEnabledResponse{}, err
-		}
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return serverapi.RuntimeSetQuestionsEnabledResponse{}, err
-		}
-		changed, enabled, err := engine.SetQuestionsEnabledWithCommittedFeedback(req.Enabled, func(enabled bool, changed bool) string {
-			return serverapi.QuestionsToggleStatusMessage(enabled, changed)
+		var resp serverapi.RuntimeSetQuestionsEnabledResponse
+		err := s.withRuntimeAccess(ctx, req.SessionID, req.ControllerLeaseID, serverapi.SessionRuntimeOperationSettingsQuestions, func(engine *runtime.Engine) error {
+			changed, enabled, err := engine.SetQuestionsEnabledWithCommittedFeedback(req.Enabled, func(enabled bool, changed bool) string {
+				return serverapi.QuestionsToggleStatusMessage(enabled, changed)
+			})
+			resp = serverapi.RuntimeSetQuestionsEnabledResponse{Changed: changed, Enabled: enabled}
+			return err
 		})
-		if err != nil {
-			return serverapi.RuntimeSetQuestionsEnabledResponse{}, err
-		}
-		return serverapi.RuntimeSetQuestionsEnabledResponse{Changed: changed, Enabled: enabled}, nil
+		return resp, err
 	})
 }
 
@@ -432,18 +462,20 @@ func (s *Service) CompactContext(ctx context.Context, req serverapi.RuntimeCompa
 	}
 	memoReq := sessionStringMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Value: req.Args}
 	_, err := s.compactions.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameSessionStringMemoRequest, func(ctx context.Context) (struct{}, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return struct{}{}, err
-		}
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return struct{}{}, err
-		}
 		runCtx := context.Background()
 		if ctx != nil {
 			runCtx = context.WithoutCancel(ctx)
 		}
-		return struct{}{}, engine.CompactContext(runCtx, req.Args)
+		if strings.TrimSpace(req.ControllerLeaseID) == "" {
+			lease, err := s.acquirePrimaryRun(memoReq.SessionID)
+			if err != nil {
+				return struct{}{}, err
+			}
+			defer lease.Release()
+		}
+		return struct{}{}, s.withRuntimeAccess(ctx, req.SessionID, req.ControllerLeaseID, serverapi.SessionRuntimeOperationCompactManual, func(engine *runtime.Engine) error {
+			return engine.CompactContext(runCtx, req.Args)
+		})
 	})
 	return err
 }
@@ -454,18 +486,20 @@ func (s *Service) CompactContextForPreSubmit(ctx context.Context, req serverapi.
 	}
 	memoReq := sessionOnlyMemoRequest{SessionID: strings.TrimSpace(req.SessionID)}
 	_, err := s.preSubmitCompactions.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, func(a sessionOnlyMemoRequest, b sessionOnlyMemoRequest) bool { return a.SessionID == b.SessionID }, func(ctx context.Context) (struct{}, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return struct{}{}, err
-		}
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return struct{}{}, err
-		}
 		runCtx := context.Background()
 		if ctx != nil {
 			runCtx = context.WithoutCancel(ctx)
 		}
-		return struct{}{}, engine.CompactContextForPreSubmit(runCtx)
+		if strings.TrimSpace(req.ControllerLeaseID) == "" {
+			lease, err := s.acquirePrimaryRun(memoReq.SessionID)
+			if err != nil {
+				return struct{}{}, err
+			}
+			defer lease.Release()
+		}
+		return struct{}{}, s.withRuntimeAccess(ctx, req.SessionID, req.ControllerLeaseID, serverapi.SessionRuntimeOperationCompactPreSubmit, func(engine *runtime.Engine) error {
+			return engine.CompactContextForPreSubmit(runCtx)
+		})
 	})
 	return err
 }
@@ -487,27 +521,22 @@ func (s *Service) SubmitQueuedUserMessages(ctx context.Context, req serverapi.Ru
 	}
 	memoReq := sessionOnlyMemoRequest{SessionID: strings.TrimSpace(req.SessionID)}
 	return s.queuedSubmits.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, func(a sessionOnlyMemoRequest, b sessionOnlyMemoRequest) bool { return a.SessionID == b.SessionID }, func(ctx context.Context) (serverapi.RuntimeSubmitQueuedUserMessagesResponse, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return serverapi.RuntimeSubmitQueuedUserMessagesResponse{}, err
-		}
 		lease, err := s.acquirePrimaryRun(req.SessionID)
 		if err != nil {
 			return serverapi.RuntimeSubmitQueuedUserMessagesResponse{}, err
 		}
 		defer lease.Release()
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return serverapi.RuntimeSubmitQueuedUserMessagesResponse{}, err
-		}
 		runCtx := context.Background()
 		if ctx != nil {
 			runCtx = context.WithoutCancel(ctx)
 		}
-		msg, err := engine.SubmitQueuedUserMessages(runCtx)
-		if err != nil {
-			return serverapi.RuntimeSubmitQueuedUserMessagesResponse{}, err
-		}
-		return serverapi.RuntimeSubmitQueuedUserMessagesResponse{Message: msg.Content}, nil
+		var resp serverapi.RuntimeSubmitQueuedUserMessagesResponse
+		err = s.withRuntimeAccess(ctx, req.SessionID, req.ControllerLeaseID, serverapi.SessionRuntimeOperationSubmitQueuedUserMessages, func(engine *runtime.Engine) error {
+			msg, err := engine.SubmitQueuedUserMessages(runCtx)
+			resp = serverapi.RuntimeSubmitQueuedUserMessagesResponse{Message: msg.Content}
+			return err
+		})
+		return resp, err
 	})
 }
 
@@ -535,23 +564,21 @@ func (s *Service) QueueUserMessage(ctx context.Context, req serverapi.RuntimeQue
 	}
 	memoReq := sessionTextMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Text: req.Text}
 	return s.queues.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameSessionTextMemoRequest, func(ctx context.Context) (serverapi.RuntimeQueueUserMessageResponse, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return serverapi.RuntimeQueueUserMessageResponse{}, err
-		}
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return serverapi.RuntimeQueueUserMessageResponse{}, err
-		}
-		text := memoReq.Text
-		if s != nil && s.promptStore != nil {
-			record, _, err := s.recordPromptHistory(ctx, memoReq.SessionID, strings.TrimSpace(req.ClientRequestID), memoReq.Text)
-			if err != nil {
-				return serverapi.RuntimeQueueUserMessageResponse{}, err
+		var resp serverapi.RuntimeQueueUserMessageResponse
+		err := s.withRuntimeAccess(ctx, req.SessionID, req.ControllerLeaseID, serverapi.SessionRuntimeOperationQueueUserMessage, func(engine *runtime.Engine) error {
+			text := memoReq.Text
+			if s != nil && s.promptStore != nil {
+				record, _, err := s.recordPromptHistory(ctx, memoReq.SessionID, strings.TrimSpace(req.ClientRequestID), memoReq.Text)
+				if err != nil {
+					return err
+				}
+				text = record.Text
 			}
-			text = record.Text
-		}
-		item := engine.QueueUserMessage(text)
-		return serverapi.RuntimeQueueUserMessageResponse{QueueItemID: item.ID, Text: item.Text}, nil
+			item := engine.QueueUserMessageWithClientRequestID(text, strings.TrimSpace(req.ClientRequestID))
+			resp = serverapi.RuntimeQueueUserMessageResponse{QueueItemID: item.ID, Text: item.Text, ClientRequestID: item.ClientRequestID}
+			return nil
+		})
+		return resp, err
 	})
 }
 
@@ -561,15 +588,12 @@ func (s *Service) DiscardQueuedUserMessage(ctx context.Context, req serverapi.Ru
 	}
 	memoReq := queuedUserMessageMemoRequest{SessionID: strings.TrimSpace(req.SessionID), QueueItemID: strings.TrimSpace(req.QueueItemID)}
 	return s.queuedDiscards.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameQueuedUserMessageMemoRequest, func(ctx context.Context) (serverapi.RuntimeDiscardQueuedUserMessageResponse, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return serverapi.RuntimeDiscardQueuedUserMessageResponse{}, err
-		}
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return serverapi.RuntimeDiscardQueuedUserMessageResponse{}, err
-		}
-		discarded := engine.DiscardQueuedUserMessage(req.QueueItemID)
-		return serverapi.RuntimeDiscardQueuedUserMessageResponse{Discarded: discarded}, nil
+		var resp serverapi.RuntimeDiscardQueuedUserMessageResponse
+		err := s.withRuntimeAccess(ctx, req.SessionID, req.ControllerLeaseID, serverapi.SessionRuntimeOperationDiscardQueuedUserMessage, func(engine *runtime.Engine) error {
+			resp = serverapi.RuntimeDiscardQueuedUserMessageResponse{Discarded: engine.DiscardQueuedUserMessage(req.QueueItemID)}
+			return nil
+		})
+		return resp, err
 	})
 }
 
@@ -579,14 +603,10 @@ func (s *Service) RecordPromptHistory(ctx context.Context, req serverapi.Runtime
 	}
 	memoReq := sessionTextMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Text: req.Text}
 	_, err := s.promptHistory.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameSessionTextMemoRequest, func(ctx context.Context) (struct{}, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return struct{}{}, err
-		}
-		if _, err := s.resolve(ctx, req.SessionID); err != nil {
-			return struct{}{}, err
-		}
-		_, _, err := s.recordPromptHistory(ctx, memoReq.SessionID, strings.TrimSpace(req.ClientRequestID), memoReq.Text)
-		return struct{}{}, err
+		return struct{}{}, s.withRuntimeAccess(ctx, req.SessionID, req.ControllerLeaseID, serverapi.SessionRuntimeOperationRecordPromptHistory, func(*runtime.Engine) error {
+			_, _, err := s.recordPromptHistory(ctx, memoReq.SessionID, strings.TrimSpace(req.ClientRequestID), memoReq.Text)
+			return err
+		})
 	})
 	return err
 }
@@ -610,6 +630,9 @@ func (s *Service) ShowGoal(ctx context.Context, req serverapi.RuntimeGoalShowReq
 	if err != nil {
 		return serverapi.RuntimeGoalShowResponse{}, err
 	}
+	if err := s.rejectWorkflowGoalControl(ctx, req.SessionID, engine); err != nil {
+		return serverapi.RuntimeGoalShowResponse{}, err
+	}
 	goal := engine.Goal()
 	if goal == nil {
 		return serverapi.RuntimeGoalShowResponse{}, nil
@@ -631,41 +654,42 @@ func (s *Service) SetGoal(ctx context.Context, req serverapi.RuntimeGoalSetReque
 	trimmedObjective := strings.TrimSpace(req.Objective)
 	memoReq := goalSetMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Objective: trimmedObjective, Actor: strings.TrimSpace(req.Actor)}
 	return s.goals.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameGoalSetMemoRequest, func(ctx context.Context) (serverapi.RuntimeGoalShowResponse, error) {
-		if err := s.requireOptionalControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return serverapi.RuntimeGoalShowResponse{}, err
-		}
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return serverapi.RuntimeGoalShowResponse{}, err
-		}
-		if strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) {
-			currentGoal := engine.Goal()
-			if goalBlocksAgentSet(currentGoal) {
-				return serverapi.RuntimeGoalShowResponse{}, goalAgentOverwriteDeniedError{Objective: currentGoal.Objective, Status: string(currentGoal.Status)}
+		var response serverapi.RuntimeGoalShowResponse
+		err := s.withGoalMutationAccess(ctx, req.SessionID, req.ControllerLeaseID, func(engine *runtime.Engine) error {
+			if err := s.rejectWorkflowGoalControl(ctx, req.SessionID, engine); err != nil {
+				return err
 			}
-		}
-		if err := engine.RequireGoalLoopStartAllowed(); err != nil {
-			return serverapi.RuntimeGoalShowResponse{}, err
-		}
-		goal, err := engine.SetGoal(trimmedObjective, session.GoalActor(req.Actor))
-		if err != nil {
-			var blocked session.GoalAgentOverwriteBlockedError
-			if errors.As(err, &blocked) {
-				return serverapi.RuntimeGoalShowResponse{}, goalAgentOverwriteDeniedError{Objective: blocked.Goal.Objective, Status: string(blocked.Goal.Status)}
+			if strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) {
+				currentGoal := engine.Goal()
+				if goalBlocksAgentSet(currentGoal) {
+					return goalAgentOverwriteDeniedError{Objective: currentGoal.Objective, Status: string(currentGoal.Status)}
+				}
 			}
-			return serverapi.RuntimeGoalShowResponse{}, err
-		}
-		if err := engine.StartGoalLoop(); err != nil {
-			return serverapi.RuntimeGoalShowResponse{}, err
-		}
-		return serverapi.RuntimeGoalShowResponse{Goal: &serverapi.RuntimeGoal{
-			ID:        strings.TrimSpace(goal.ID),
-			Objective: goal.Objective,
-			Status:    strings.TrimSpace(string(goal.Status)),
-			Suspended: false,
-			CreatedAt: goal.CreatedAt,
-			UpdatedAt: goal.UpdatedAt,
-		}}, nil
+			if err := engine.RequireGoalLoopStartAllowed(); err != nil {
+				return err
+			}
+			goal, err := engine.SetGoal(trimmedObjective, session.GoalActor(req.Actor))
+			if err != nil {
+				var blocked session.GoalAgentOverwriteBlockedError
+				if errors.As(err, &blocked) {
+					return goalAgentOverwriteDeniedError{Objective: blocked.Goal.Objective, Status: string(blocked.Goal.Status)}
+				}
+				return err
+			}
+			if err := engine.StartGoalLoop(); err != nil {
+				return err
+			}
+			response = serverapi.RuntimeGoalShowResponse{Goal: &serverapi.RuntimeGoal{
+				ID:        strings.TrimSpace(goal.ID),
+				Objective: goal.Objective,
+				Status:    strings.TrimSpace(string(goal.Status)),
+				Suspended: false,
+				CreatedAt: goal.CreatedAt,
+				UpdatedAt: goal.UpdatedAt,
+			}}
+			return nil
+		})
+		return response, err
 	})
 }
 
@@ -704,48 +728,50 @@ func (s *Service) setGoalStatus(ctx context.Context, req serverapi.RuntimeGoalSt
 	}
 	memoReq := goalStatusMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Status: strings.TrimSpace(string(status)), Actor: strings.TrimSpace(req.Actor)}
 	return s.goalStatuses.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameGoalStatusMemoRequest, func(ctx context.Context) (serverapi.RuntimeGoalShowResponse, error) {
-		if err := s.requireOptionalControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return serverapi.RuntimeGoalShowResponse{}, err
-		}
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return serverapi.RuntimeGoalShowResponse{}, err
-		}
-		if status == session.GoalStatusComplete {
-			current := engine.Goal()
-			if current != nil && current.Status == session.GoalStatusComplete {
-				return serverapi.RuntimeGoalShowResponse{Goal: &serverapi.RuntimeGoal{
-					ID:        strings.TrimSpace(current.ID),
-					Objective: current.Objective,
-					Status:    strings.TrimSpace(string(current.Status)),
-					Suspended: false,
-					CreatedAt: current.CreatedAt,
-					UpdatedAt: current.UpdatedAt,
-				}}, nil
+		var response serverapi.RuntimeGoalShowResponse
+		err := s.withGoalMutationAccess(ctx, req.SessionID, req.ControllerLeaseID, func(engine *runtime.Engine) error {
+			if err := s.rejectWorkflowGoalControl(ctx, req.SessionID, engine); err != nil {
+				return err
 			}
-		}
-		if status == session.GoalStatusActive {
-			if err := engine.RequireGoalLoopStartAllowed(); err != nil {
-				return serverapi.RuntimeGoalShowResponse{}, err
+			if status == session.GoalStatusComplete {
+				current := engine.Goal()
+				if current != nil && current.Status == session.GoalStatusComplete {
+					response = serverapi.RuntimeGoalShowResponse{Goal: &serverapi.RuntimeGoal{
+						ID:        strings.TrimSpace(current.ID),
+						Objective: current.Objective,
+						Status:    strings.TrimSpace(string(current.Status)),
+						Suspended: false,
+						CreatedAt: current.CreatedAt,
+						UpdatedAt: current.UpdatedAt,
+					}}
+					return nil
+				}
 			}
-		}
-		goal, err := engine.SetGoalStatus(status, session.GoalActor(req.Actor))
-		if err != nil {
-			return serverapi.RuntimeGoalShowResponse{}, err
-		}
-		if status == session.GoalStatusActive {
-			if err := engine.StartGoalLoop(); err != nil {
-				return serverapi.RuntimeGoalShowResponse{}, err
+			if status == session.GoalStatusActive {
+				if err := engine.RequireGoalLoopStartAllowed(); err != nil {
+					return err
+				}
 			}
-		}
-		return serverapi.RuntimeGoalShowResponse{Goal: &serverapi.RuntimeGoal{
-			ID:        strings.TrimSpace(goal.ID),
-			Objective: goal.Objective,
-			Status:    strings.TrimSpace(string(goal.Status)),
-			Suspended: false,
-			CreatedAt: goal.CreatedAt,
-			UpdatedAt: goal.UpdatedAt,
-		}}, nil
+			goal, err := engine.SetGoalStatus(status, session.GoalActor(req.Actor))
+			if err != nil {
+				return err
+			}
+			if status == session.GoalStatusActive {
+				if err := engine.StartGoalLoop(); err != nil {
+					return err
+				}
+			}
+			response = serverapi.RuntimeGoalShowResponse{Goal: &serverapi.RuntimeGoal{
+				ID:        strings.TrimSpace(goal.ID),
+				Objective: goal.Objective,
+				Status:    strings.TrimSpace(string(goal.Status)),
+				Suspended: false,
+				CreatedAt: goal.CreatedAt,
+				UpdatedAt: goal.UpdatedAt,
+			}}
+			return nil
+		})
+		return response, err
 	})
 }
 
@@ -755,25 +781,69 @@ func (s *Service) ClearGoal(ctx context.Context, req serverapi.RuntimeGoalClearR
 	}
 	memoReq := goalClearMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Actor: strings.TrimSpace(req.Actor)}
 	return s.goalClears.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameGoalClearMemoRequest, func(ctx context.Context) (serverapi.RuntimeGoalShowResponse, error) {
-		if err := s.requireOptionalControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return serverapi.RuntimeGoalShowResponse{}, err
-		}
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return serverapi.RuntimeGoalShowResponse{}, err
-		}
-		if _, err := engine.ClearGoal(session.GoalActor(req.Actor)); err != nil {
-			return serverapi.RuntimeGoalShowResponse{}, err
-		}
-		return serverapi.RuntimeGoalShowResponse{}, nil
+		err := s.withGoalMutationAccess(ctx, req.SessionID, req.ControllerLeaseID, func(engine *runtime.Engine) error {
+			if err := s.rejectWorkflowGoalControl(ctx, req.SessionID, engine); err != nil {
+				return err
+			}
+			_, err := engine.ClearGoal(session.GoalActor(req.Actor))
+			return err
+		})
+		return serverapi.RuntimeGoalShowResponse{}, err
 	})
 }
 
-func (s *Service) requireOptionalControllerLease(ctx context.Context, sessionID string, leaseID string) error {
+func (s *Service) withGoalMutationAccess(ctx context.Context, sessionID string, leaseID string, fn func(*runtime.Engine) error) error {
+	var lease primaryrun.Lease
 	if strings.TrimSpace(leaseID) == "" {
-		return nil
+		if _, err := s.resolve(ctx, sessionID); err != nil {
+			return err
+		}
+		var err error
+		lease, err = s.acquirePrimaryRun(sessionID)
+		if err != nil {
+			return err
+		}
+		defer lease.Release()
 	}
-	return s.requireControllerLease(ctx, sessionID, leaseID)
+	return s.withRuntimeAccess(ctx, sessionID, leaseID, serverapi.SessionRuntimeOperationGoalManage, fn)
+}
+
+func (s *Service) rejectWorkflowGoalControl(ctx context.Context, sessionID string, engine *runtime.Engine) error {
+	workflowSession, err := s.workflowTaskSession(ctx, sessionID, engine)
+	if err != nil {
+		return err
+	}
+	if workflowSession {
+		return errors.New("goal control is unavailable for workflow task sessions")
+	}
+	return nil
+}
+
+func (s *Service) rejectWorkflowAutoCompactionDisable(ctx context.Context, sessionID string, engine *runtime.Engine) error {
+	workflowSession, err := s.workflowTaskSession(ctx, sessionID, engine)
+	if err != nil {
+		return err
+	}
+	if workflowSession {
+		return errors.New("auto-compaction cannot be disabled for workflow task sessions")
+	}
+	return nil
+}
+
+func (s *Service) workflowTaskSession(ctx context.Context, sessionID string, engine *runtime.Engine) (bool, error) {
+	if engine != nil && engine.WorkflowSessionState().RunID != "" {
+		return true, nil
+	}
+	if s != nil && s.workflowStates != nil {
+		store, err := s.workflowStates.ResolveSessionStore(ctx, sessionID)
+		if err != nil {
+			return false, err
+		}
+		if store != nil && store.Meta().WorkflowSession != nil {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (s *Service) acquirePrimaryRun(sessionID string) (primaryrun.Lease, error) {

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -41,6 +41,11 @@ type WorkflowSessionResolver interface {
 	ResolveSessionStore(ctx context.Context, sessionID string) (*session.Store, error)
 }
 
+var (
+	errWorkflowTaskSessionGoalControl           = errors.New("goal control is unavailable for workflow task sessions")
+	errWorkflowTaskSessionAutoCompactionDisable = errors.New("auto-compaction cannot be disabled for workflow task sessions")
+)
+
 type Service struct {
 	runtimes       RuntimeResolver
 	collaborative  CollaborativeRuntimeResolver
@@ -192,6 +197,9 @@ func (s *Service) WithWorkflowSessionResolver(resolver WorkflowSessionResolver) 
 }
 
 func (s *Service) requireControllerLease(ctx context.Context, sessionID string, leaseID string) error {
+	if strings.TrimSpace(leaseID) == "" {
+		return serverapi.ErrInvalidControllerLease
+	}
 	if s == nil || s.control == nil {
 		return nil
 	}
@@ -814,7 +822,7 @@ func (s *Service) rejectWorkflowGoalControl(ctx context.Context, sessionID strin
 		return err
 	}
 	if workflowSession {
-		return errors.New("goal control is unavailable for workflow task sessions")
+		return errWorkflowTaskSessionGoalControl
 	}
 	return nil
 }
@@ -825,7 +833,7 @@ func (s *Service) rejectWorkflowAutoCompactionDisable(ctx context.Context, sessi
 		return err
 	}
 	if workflowSession {
-		return errors.New("auto-compaction cannot be disabled for workflow task sessions")
+		return errWorkflowTaskSessionAutoCompactionDisable
 	}
 	return nil
 }

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -16,6 +17,8 @@ import (
 	"core/server/runtimeview"
 	"core/server/session"
 	"core/server/tools"
+	"core/server/workflow"
+	"core/server/workflowruntime"
 	"core/shared/serverapi"
 	"core/shared/toolspec"
 )
@@ -26,6 +29,24 @@ type stubRuntimeResolver struct {
 
 func (s stubRuntimeResolver) ResolveRuntime(context.Context, string) (*runtime.Engine, error) {
 	return s.engine, nil
+}
+
+type stubCollaborativeRuntimeResolver struct {
+	engine  *runtime.Engine
+	calls   int
+	session string
+	op      serverapi.SessionRuntimeOperation
+	err     error
+}
+
+func (s *stubCollaborativeRuntimeResolver) WithCollaborativeRuntimeEngine(ctx context.Context, sessionID string, op serverapi.SessionRuntimeOperation, fn func(*runtime.Engine) error) error {
+	s.calls++
+	s.session = sessionID
+	s.op = op
+	if s.err != nil {
+		return s.err
+	}
+	return fn(s.engine)
 }
 
 var runtimeControlPromptHistoryStores sync.Map
@@ -110,6 +131,14 @@ func (g *stubPrimaryRunGate) AcquirePrimaryRun(sessionID string) (primaryrun.Lea
 		return nil, g.err
 	}
 	return primaryrun.LeaseFunc(func() { g.release++ }), nil
+}
+
+type staticRuntimeControlSessionResolver struct {
+	store *session.Store
+}
+
+func (r staticRuntimeControlSessionResolver) ResolveSessionStore(context.Context, string) (*session.Store, error) {
+	return r.store, nil
 }
 
 type runtimeControlFakeClient struct {
@@ -204,7 +233,9 @@ func newRuntimeControlTestService(t *testing.T, client llm.Client, registry *too
 	t.Helper()
 	store, engine := newRuntimeControlTestEngine(t, client, registry, cfg, opts...)
 	history := newRuntimeControlPromptHistoryStore(store.Meta().SessionID)
-	return store, engine, NewService(stubRuntimeResolver{engine: engine}, nil).WithPromptHistoryStore(history)
+	service := NewService(stubRuntimeResolver{engine: engine}, nil).WithPromptHistoryStore(history)
+	service.WithCollaborativeRuntimeResolver(&stubCollaborativeRuntimeResolver{engine: engine})
+	return store, engine, service
 }
 
 func finalResponseRuntimeControlClient() *runtimeControlFakeClient {
@@ -318,16 +349,39 @@ func TestServiceSubmitUserMessageStillCancelsOnExplicitInterrupt(t *testing.T) {
 	}
 }
 
-func TestServiceGoalCommandsDoNotRequireControllerLease(t *testing.T) {
+func TestServiceGoalMutationsRequireRuntimeAccess(t *testing.T) {
 	store, engine := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
 	verifier := &stubRuntimeLeaseVerifier{err: serverapi.ErrInvalidControllerLease}
 	service := NewService(stubRuntimeResolver{engine: engine}, nil).WithControllerLeaseVerifier(verifier)
 
-	setResp, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
+	_, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
 		ClientRequestID: "goal-set-1",
 		SessionID:       store.Meta().SessionID,
 		Objective:       "ship goal mode",
 		Actor:           "user",
+	})
+	if !errors.Is(err, serverapi.ErrInvalidControllerLease) {
+		t.Fatalf("SetGoal without lease/collaborative access error = %v, want invalid controller lease", err)
+	}
+	if goal := engine.Goal(); goal != nil {
+		t.Fatalf("goal after rejected empty-lease mutation = %+v, want nil", goal)
+	}
+	if verifier.calls != 0 {
+		t.Fatalf("lease verifier calls = %d, want 0 for empty lease", verifier.calls)
+	}
+}
+
+func TestServiceGoalMutationsAllowControllerLease(t *testing.T) {
+	store, engine := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	verifier := &stubRuntimeLeaseVerifier{}
+	service := NewService(stubRuntimeResolver{engine: engine}, nil).WithControllerLeaseVerifier(verifier)
+
+	setResp, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
+		ClientRequestID:   "goal-set-1",
+		SessionID:         store.Meta().SessionID,
+		ControllerLeaseID: "lease-1",
+		Objective:         "ship goal mode",
+		Actor:             "user",
 	})
 	if err != nil {
 		t.Fatalf("SetGoal: %v", err)
@@ -343,9 +397,10 @@ func TestServiceGoalCommandsDoNotRequireControllerLease(t *testing.T) {
 		t.Fatalf("show goal response = %+v, want id %q", showResp.Goal, setResp.Goal.ID)
 	}
 	completeResp, err := service.CompleteGoal(context.Background(), serverapi.RuntimeGoalStatusRequest{
-		ClientRequestID: "goal-complete-1",
-		SessionID:       store.Meta().SessionID,
-		Actor:           "agent",
+		ClientRequestID:   "goal-complete-1",
+		SessionID:         store.Meta().SessionID,
+		ControllerLeaseID: "lease-1",
+		Actor:             "agent",
 	})
 	if err != nil {
 		t.Fatalf("CompleteGoal: %v", err)
@@ -353,8 +408,125 @@ func TestServiceGoalCommandsDoNotRequireControllerLease(t *testing.T) {
 	if completeResp.Goal == nil || completeResp.Goal.Status != "complete" {
 		t.Fatalf("complete goal response = %+v", completeResp.Goal)
 	}
-	if verifier.calls != 0 {
-		t.Fatalf("lease verifier calls = %d, want 0", verifier.calls)
+	if verifier.calls != 2 {
+		t.Fatalf("lease verifier calls = %d, want 2", verifier.calls)
+	}
+}
+
+func TestServiceGoalMutationsAllowCollaborativeGoalManageAccess(t *testing.T) {
+	store, engine, service := newRuntimeControlTestService(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	collaborative := &stubCollaborativeRuntimeResolver{engine: engine}
+	gate := &stubPrimaryRunGate{}
+	service.gate = gate
+	service.WithCollaborativeRuntimeResolver(collaborative)
+
+	setResp, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
+		ClientRequestID: "goal-set-collaborative",
+		SessionID:       store.Meta().SessionID,
+		Objective:       "ship collaborative goal",
+		Actor:           "user",
+	})
+	if err != nil {
+		t.Fatalf("SetGoal collaborative: %v", err)
+	}
+	if setResp.Goal == nil || setResp.Goal.Objective != "ship collaborative goal" {
+		t.Fatalf("set goal response = %+v", setResp.Goal)
+	}
+	if collaborative.calls != 1 || collaborative.op != serverapi.SessionRuntimeOperationGoalManage {
+		t.Fatalf("collaborative calls=%d op=%q, want goal.manage", collaborative.calls, collaborative.op)
+	}
+	if gate.acquire != 1 || gate.release != 1 {
+		t.Fatalf("gate acquire/release = %d/%d, want 1/1", gate.acquire, gate.release)
+	}
+}
+
+func TestServiceQueueUserMessageAllowsCollaborativeEmptyLease(t *testing.T) {
+	store, engine, service := newRuntimeControlTestService(t, nil, nil, runtime.Config{})
+	leaseVerifier := &stubRuntimeLeaseVerifier{err: errors.New("lease should not be required")}
+	collaborative := &stubCollaborativeRuntimeResolver{engine: engine}
+	service.WithControllerLeaseVerifier(leaseVerifier).WithCollaborativeRuntimeResolver(collaborative)
+
+	req := runtimeControlQueueUserMessageRequest(store, "req-collab-queue", "collaborative steer")
+	req.ControllerLeaseID = ""
+	resp, err := service.QueueUserMessage(context.Background(), req)
+	if err != nil {
+		t.Fatalf("QueueUserMessage: %v", err)
+	}
+	if resp.QueueItemID == "" || resp.Text != "collaborative steer" {
+		t.Fatalf("response = %+v, want queued collaborative steer", resp)
+	}
+	if leaseVerifier.calls != 0 {
+		t.Fatalf("lease verifier calls = %d, want none", leaseVerifier.calls)
+	}
+	if collaborative.calls != 1 || collaborative.op != serverapi.SessionRuntimeOperationQueueUserMessage {
+		t.Fatalf("collaborative calls=%d op=%q, want queue operation", collaborative.calls, collaborative.op)
+	}
+	if !engine.HasQueuedUserWork() {
+		t.Fatal("expected collaborative queue to enqueue on active runtime")
+	}
+}
+
+func TestRuntimeControlProtectedShellCommandStillRequiresLease(t *testing.T) {
+	if err := (serverapi.RuntimeSubmitUserShellCommandRequest{ClientRequestID: "req-shell", SessionID: "session-1", Command: "echo hi"}).Validate(); err == nil {
+		t.Fatal("expected shell command without controller lease to fail validation")
+	}
+}
+
+func TestServiceWorkflowRuntimeRejectsGoalControl(t *testing.T) {
+	store, _, service := newRuntimeControlTestService(t, nil, nil, runtime.Config{
+		WorkflowRun: &workflowruntime.Config{
+			Contract: workflowruntime.CompletionContract{RunID: workflow.RunID("run-1")},
+		},
+	})
+	_, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
+		ClientRequestID: "req-goal-workflow",
+		SessionID:       store.Meta().SessionID,
+		Objective:       "competing goal",
+		Actor:           "user",
+	})
+	if err == nil || !strings.Contains(err.Error(), "workflow task sessions") {
+		t.Fatalf("SetGoal error = %v, want workflow goal rejection", err)
+	}
+}
+
+func TestServiceDurableWorkflowSessionRejectsGoalControl(t *testing.T) {
+	store, _, service := newRuntimeControlTestService(t, nil, nil, runtime.Config{})
+	if err := store.SetWorkflowSessionState(&session.WorkflowSessionState{RunID: "run-1", TaskID: "task-1", WorkflowID: "workflow-1"}); err != nil {
+		t.Fatalf("SetWorkflowSessionState: %v", err)
+	}
+	service = service.WithWorkflowSessionResolver(staticRuntimeControlSessionResolver{store: store})
+	if _, err := service.ShowGoal(context.Background(), serverapi.RuntimeGoalShowRequest{SessionID: store.Meta().SessionID}); err == nil || !strings.Contains(err.Error(), "workflow task sessions") {
+		t.Fatalf("ShowGoal error = %v, want workflow goal rejection", err)
+	}
+	_, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
+		ClientRequestID: "req-goal-durable-workflow",
+		SessionID:       store.Meta().SessionID,
+		Objective:       "competing goal",
+		Actor:           "user",
+	})
+	if err == nil || !strings.Contains(err.Error(), "workflow task sessions") {
+		t.Fatalf("SetGoal error = %v, want workflow goal rejection", err)
+	}
+}
+
+func TestServiceDurableWorkflowSessionRejectsAutoCompactionDisable(t *testing.T) {
+	store, engine, service := newRuntimeControlTestService(t, nil, nil, runtime.Config{})
+	if err := store.SetWorkflowSessionState(&session.WorkflowSessionState{RunID: "run-1", TaskID: "task-1", WorkflowID: "workflow-1"}); err != nil {
+		t.Fatalf("SetWorkflowSessionState: %v", err)
+	}
+	service = service.WithWorkflowSessionResolver(staticRuntimeControlSessionResolver{store: store})
+
+	_, err := service.SetAutoCompactionEnabled(context.Background(), serverapi.RuntimeSetAutoCompactionEnabledRequest{
+		ClientRequestID:   "req-auto-off-durable-workflow",
+		SessionID:         store.Meta().SessionID,
+		ControllerLeaseID: "lease-1",
+		Enabled:           false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "workflow task sessions") {
+		t.Fatalf("SetAutoCompactionEnabled error = %v, want workflow auto-compaction rejection", err)
+	}
+	if !engine.AutoCompactionEnabled() {
+		t.Fatal("auto-compaction disabled despite durable workflow session marker")
 	}
 }
 
@@ -594,7 +766,7 @@ func TestServiceActiveGoalUpdatesEmitExactlyOneGoalStatusEventBeforeGoalLoopEven
 			if tt.prepare != nil {
 				tt.prepare(t, engine, resetEvents)
 			}
-			service := NewService(stubRuntimeResolver{engine: engine}, nil)
+			service := NewService(stubRuntimeResolver{engine: engine}, nil).WithCollaborativeRuntimeResolver(&stubCollaborativeRuntimeResolver{engine: engine})
 
 			if err := tt.call(context.Background(), service, store.Meta().SessionID); err != nil {
 				t.Fatalf("active goal update: %v", err)
@@ -661,12 +833,11 @@ func TestServiceResumeGoalPreflightFailureDoesNotMutateOrEmit(t *testing.T) {
 	}
 }
 
-func TestServiceActiveGoalUpdatesDoNotUsePrimaryRunGate(t *testing.T) {
+func TestServiceCollaborativeGoalMutationsRejectActivePrimaryRun(t *testing.T) {
 	tests := []struct {
-		name       string
-		prepare    func(t *testing.T, engine *runtime.Engine)
-		call       func(context.Context, *Service, string) error
-		assertGoal func(t *testing.T, goal *session.GoalState)
+		name    string
+		prepare func(t *testing.T, engine *runtime.Engine)
+		call    func(context.Context, *Service, string) error
 	}{
 		{
 			name: "set",
@@ -678,12 +849,6 @@ func TestServiceActiveGoalUpdatesDoNotUsePrimaryRunGate(t *testing.T) {
 					Actor:           "user",
 				})
 				return err
-			},
-			assertGoal: func(t *testing.T, goal *session.GoalState) {
-				t.Helper()
-				if goal == nil || goal.Status != session.GoalStatusActive || goal.Objective != "ship goal mode" {
-					t.Fatalf("goal after busy set = %+v, want active ship goal mode", goal)
-				}
 			},
 		},
 		{
@@ -705,12 +870,6 @@ func TestServiceActiveGoalUpdatesDoNotUsePrimaryRunGate(t *testing.T) {
 				})
 				return err
 			},
-			assertGoal: func(t *testing.T, goal *session.GoalState) {
-				t.Helper()
-				if goal == nil || goal.Status != session.GoalStatusActive {
-					t.Fatalf("goal after busy resume = %+v, want active", goal)
-				}
-			},
 		},
 	}
 
@@ -725,22 +884,25 @@ func TestServiceActiveGoalUpdatesDoNotUsePrimaryRunGate(t *testing.T) {
 				t.Fatalf("ReadEvents before: %v", err)
 			}
 			gate := &stubPrimaryRunGate{err: primaryrun.ErrActivePrimaryRun}
-			service := NewService(stubRuntimeResolver{engine: engine}, gate)
+			collaborative := &stubCollaborativeRuntimeResolver{engine: engine}
+			service := NewService(stubRuntimeResolver{engine: engine}, gate).WithCollaborativeRuntimeResolver(collaborative)
 
 			err = tt.call(context.Background(), service, store.Meta().SessionID)
-			if err != nil {
-				t.Fatalf("goal update while primary run active: %v", err)
+			if !errors.Is(err, primaryrun.ErrActivePrimaryRun) {
+				t.Fatalf("goal update while primary run active error = %v, want ErrActivePrimaryRun", err)
 			}
-			tt.assertGoal(t, store.Meta().Goal)
 			after, err := store.ReadEvents()
 			if err != nil {
 				t.Fatalf("ReadEvents after: %v", err)
 			}
-			if len(after) <= len(before) {
-				t.Fatalf("events after goal update = %d, want > %d", len(after), len(before))
+			if len(after) != len(before) {
+				t.Fatalf("events after rejected goal update = %d, want %d", len(after), len(before))
 			}
-			if gate.acquire != 0 || gate.release != 0 {
-				t.Fatalf("gate acquire/release = %d/%d, want 0/0", gate.acquire, gate.release)
+			if collaborative.calls != 0 {
+				t.Fatalf("collaborative calls = %d, want 0 when primary run is active", collaborative.calls)
+			}
+			if gate.acquire != 1 || gate.release != 0 {
+				t.Fatalf("gate acquire/release = %d/%d, want 1/0", gate.acquire, gate.release)
 			}
 		})
 	}
@@ -1129,6 +1291,24 @@ func TestServiceQueueUserMessageDoesNotEnqueueWhenPromptHistoryRecordFails(t *te
 	}
 	if engine.HasQueuedUserWork() {
 		t.Fatal("did not expect runtime queue mutation after prompt history record failure")
+	}
+}
+
+func TestServiceQueueUserMessageDoesNotRecordPromptHistoryWhenAccessRejected(t *testing.T) {
+	sessionStore, engine, service := newRuntimeControlTestService(t, finalResponseRuntimeControlClient(), nil, runtime.Config{})
+	verifier := &stubRuntimeLeaseVerifier{err: serverapi.ErrInvalidControllerLease}
+	service.WithControllerLeaseVerifier(verifier)
+	req := runtimeControlQueueUserMessageRequest(sessionStore, "req-invalid-lease", "rejected queue")
+	req.ControllerLeaseID = "invalid"
+
+	if _, err := service.QueueUserMessage(context.Background(), req); !errors.Is(err, serverapi.ErrInvalidControllerLease) {
+		t.Fatalf("QueueUserMessage error = %v, want invalid controller lease", err)
+	}
+	if engine.HasQueuedUserWork() {
+		t.Fatal("did not expect runtime queue mutation after access rejection")
+	}
+	if got := countPromptHistoryEvents(t, sessionStore, "rejected queue"); got != 0 {
+		t.Fatalf("prompt history event count = %d, want 0 after access rejection", got)
 	}
 }
 

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -484,7 +483,7 @@ func TestServiceWorkflowRuntimeRejectsGoalControl(t *testing.T) {
 		Objective:       "competing goal",
 		Actor:           "user",
 	})
-	if err == nil || !strings.Contains(err.Error(), "workflow task sessions") {
+	if !errors.Is(err, errWorkflowTaskSessionGoalControl) {
 		t.Fatalf("SetGoal error = %v, want workflow goal rejection", err)
 	}
 }
@@ -495,7 +494,7 @@ func TestServiceDurableWorkflowSessionRejectsGoalControl(t *testing.T) {
 		t.Fatalf("SetWorkflowSessionState: %v", err)
 	}
 	service = service.WithWorkflowSessionResolver(staticRuntimeControlSessionResolver{store: store})
-	if _, err := service.ShowGoal(context.Background(), serverapi.RuntimeGoalShowRequest{SessionID: store.Meta().SessionID}); err == nil || !strings.Contains(err.Error(), "workflow task sessions") {
+	if _, err := service.ShowGoal(context.Background(), serverapi.RuntimeGoalShowRequest{SessionID: store.Meta().SessionID}); !errors.Is(err, errWorkflowTaskSessionGoalControl) {
 		t.Fatalf("ShowGoal error = %v, want workflow goal rejection", err)
 	}
 	_, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
@@ -504,7 +503,7 @@ func TestServiceDurableWorkflowSessionRejectsGoalControl(t *testing.T) {
 		Objective:       "competing goal",
 		Actor:           "user",
 	})
-	if err == nil || !strings.Contains(err.Error(), "workflow task sessions") {
+	if !errors.Is(err, errWorkflowTaskSessionGoalControl) {
 		t.Fatalf("SetGoal error = %v, want workflow goal rejection", err)
 	}
 }
@@ -522,7 +521,7 @@ func TestServiceDurableWorkflowSessionRejectsAutoCompactionDisable(t *testing.T)
 		ControllerLeaseID: "lease-1",
 		Enabled:           false,
 	})
-	if err == nil || !strings.Contains(err.Error(), "workflow task sessions") {
+	if !errors.Is(err, errWorkflowTaskSessionAutoCompactionDisable) {
 		t.Fatalf("SetAutoCompactionEnabled error = %v, want workflow auto-compaction rejection", err)
 	}
 	if !engine.AutoCompactionEnabled() {

--- a/server/runtimecontrol/service_turn_submission.go
+++ b/server/runtimecontrol/service_turn_submission.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"core/server/runtime"
 	"core/shared/serverapi"
 )
 
@@ -13,40 +14,35 @@ func (s *Service) SubmitUserTurn(ctx context.Context, req serverapi.RuntimeSubmi
 	}
 	memoReq := turnSubmitMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Text: req.Text, PromptHistoryRecorded: req.PromptHistoryRecorded}
 	return s.turnSubmits.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameTurnSubmitMemoRequest, func(ctx context.Context) (serverapi.RuntimeSubmitUserTurnResponse, error) {
-		if err := s.requireControllerLease(ctx, req.SessionID, req.ControllerLeaseID); err != nil {
-			return serverapi.RuntimeSubmitUserTurnResponse{}, err
-		}
 		lease, err := s.acquirePrimaryRun(memoReq.SessionID)
 		if err != nil {
 			return serverapi.RuntimeSubmitUserTurnResponse{}, err
 		}
 		defer lease.Release()
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return serverapi.RuntimeSubmitUserTurnResponse{}, err
-		}
 		runCtx := context.Background()
 		if ctx != nil {
 			runCtx = context.WithoutCancel(ctx)
 		}
-		shouldCompact, err := engine.ShouldCompactBeforeUserMessage(runCtx, memoReq.Text)
-		if err != nil {
-			return serverapi.RuntimeSubmitUserTurnResponse{}, err
-		}
-		if shouldCompact {
-			if err := engine.CompactContextForPreSubmit(runCtx); err != nil {
-				return serverapi.RuntimeSubmitUserTurnResponse{}, err
+		var resp serverapi.RuntimeSubmitUserTurnResponse
+		err = s.withRuntimeAccess(ctx, req.SessionID, req.ControllerLeaseID, serverapi.SessionRuntimeOperationSubmitUserTurn, func(engine *runtime.Engine) error {
+			shouldCompact, err := engine.ShouldCompactBeforeUserMessage(runCtx, memoReq.Text)
+			if err != nil {
+				return err
 			}
-		}
-		if !req.PromptHistoryRecorded {
-			if _, _, err := s.recordPromptHistory(runCtx, memoReq.SessionID, strings.TrimSpace(req.ClientRequestID), memoReq.Text); err != nil {
-				return serverapi.RuntimeSubmitUserTurnResponse{}, err
+			if shouldCompact {
+				if err := engine.CompactContextForPreSubmit(runCtx); err != nil {
+					return err
+				}
 			}
-		}
-		msg, err := engine.SubmitUserMessage(runCtx, memoReq.Text)
-		if err != nil {
-			return serverapi.RuntimeSubmitUserTurnResponse{}, err
-		}
-		return serverapi.RuntimeSubmitUserTurnResponse{Message: msg.Content, Compacted: shouldCompact}, nil
+			if !req.PromptHistoryRecorded {
+				if _, _, err := s.recordPromptHistory(runCtx, memoReq.SessionID, strings.TrimSpace(req.ClientRequestID), memoReq.Text); err != nil {
+					return err
+				}
+			}
+			msg, err := engine.SubmitUserMessage(runCtx, memoReq.Text)
+			resp = serverapi.RuntimeSubmitUserTurnResponse{Message: msg.Content, Compacted: shouldCompact}
+			return err
+		})
+		return resp, err
 	})
 }

--- a/server/runtimeview/projection.go
+++ b/server/runtimeview/projection.go
@@ -30,7 +30,7 @@ func StatusFromRuntime(engine *runtime.Engine) clientui.RuntimeStatus {
 		return clientui.RuntimeStatus{}
 	}
 	usage := engine.ContextUsage()
-	return clientui.RuntimeStatus{
+	status := clientui.RuntimeStatus{
 		ReviewerFrequency:                 engine.ReviewerFrequency(),
 		ReviewerEnabled:                   engine.ReviewerEnabled(),
 		AutoCompactionEnabled:             engine.AutoCompactionEnabled(),
@@ -51,6 +51,15 @@ func StatusFromRuntime(engine *runtime.Engine) clientui.RuntimeStatus {
 		CompactionCount: engine.CompactionCount(),
 		Goal:            GoalFromSessionState(engine.Goal(), engine.GoalLoopSuspended()),
 	}
+	if workflowState := engine.WorkflowSessionState(); workflowState.RunID != "" {
+		status.WorkflowActive = engine.WorkflowRunConfigured() && !engine.WorkflowTerminalState().Completed
+		status.WorkflowSession = &clientui.WorkflowSessionStatus{
+			RunID:      workflowState.RunID,
+			TaskID:     workflowState.TaskID,
+			WorkflowID: workflowState.WorkflowID,
+		}
+	}
+	return status
 }
 
 func GoalFromSessionState(goal *session.GoalState, suspended bool) *clientui.RuntimeGoal {
@@ -162,6 +171,16 @@ func EventFromRuntime(evt runtime.Event) clientui.Event {
 		if evt.Background.ExitCode != nil {
 			exitCode := *evt.Background.ExitCode
 			view.Background.ExitCode = &exitCode
+		}
+	}
+	if evt.QueuedUserMessageStatus != nil {
+		view.QueuedUserMessageStatus = &clientui.QueuedUserMessageStatusEvent{
+			SessionID:       evt.QueuedUserMessageStatus.SessionID,
+			QueueItemID:     evt.QueuedUserMessageStatus.QueueItemID,
+			ClientRequestID: evt.QueuedUserMessageStatus.ClientRequestID,
+			Status:          clientui.QueuedUserMessageStatus(evt.QueuedUserMessageStatus.Status),
+			FailureReason:   clientui.QueuedUserMessageFailureReason(evt.QueuedUserMessageStatus.FailureReason),
+			RestoreText:     evt.QueuedUserMessageStatus.RestoreText,
 		}
 	}
 	return view

--- a/server/runtimeview/projection_test.go
+++ b/server/runtimeview/projection_test.go
@@ -11,6 +11,8 @@ import (
 	"core/server/runtime"
 	"core/server/session"
 	"core/server/tools"
+	"core/server/workflow"
+	"core/server/workflowruntime"
 	"core/shared/clientui"
 	"core/shared/transcript"
 	patchformat "core/shared/transcript/patchformat"
@@ -357,6 +359,45 @@ func TestMainViewFromRuntimeBundlesStatusAndSession(t *testing.T) {
 	}
 	if view.ActiveRun != nil {
 		t.Fatalf("expected no active run in idle main view, got %+v", view.ActiveRun)
+	}
+}
+
+func TestMainViewFromWorkflowRuntimeIncludesWorkflowStatus(t *testing.T) {
+	store := newRuntimeViewStore(t)
+	eng := newRuntimeViewEngine(t, store, projectionFastClient{}, runtime.Config{
+		Model: "gpt-5",
+		WorkflowRun: &workflowruntime.Config{
+			Contract: workflowruntime.CompletionContract{RunID: workflow.RunID("run-1")},
+			Instructions: workflowruntime.TaskInstructions{
+				TaskID:     "task-1",
+				WorkflowID: "workflow-1",
+			},
+		},
+	})
+	view := MainViewFromRuntime(eng)
+	if !view.Status.WorkflowActive || view.Status.WorkflowSession == nil {
+		t.Fatalf("workflow status = %+v, want active workflow session", view.Status)
+	}
+	if view.Status.WorkflowSession.RunID != "run-1" || view.Status.WorkflowSession.TaskID != "task-1" || view.Status.WorkflowSession.WorkflowID != "workflow-1" {
+		t.Fatalf("workflow session = %+v, want run/task/workflow ids", view.Status.WorkflowSession)
+	}
+}
+
+func TestMainViewFromReopenedWorkflowSessionIncludesDurableWorkflowStatus(t *testing.T) {
+	store := newRuntimeViewStore(t)
+	if err := store.SetWorkflowSessionState(&session.WorkflowSessionState{RunID: "run-1", TaskID: "task-1", WorkflowID: "workflow-1"}); err != nil {
+		t.Fatalf("SetWorkflowSessionState: %v", err)
+	}
+	eng := newRuntimeViewEngine(t, store, projectionFastClient{}, runtime.Config{Model: "gpt-5"})
+	view := MainViewFromRuntime(eng)
+	if view.Status.WorkflowActive {
+		t.Fatalf("workflow active = true, want false for reopened non-workflow runtime")
+	}
+	if view.Status.WorkflowSession == nil {
+		t.Fatalf("workflow session = nil, status=%+v", view.Status)
+	}
+	if view.Status.WorkflowSession.RunID != "run-1" || view.Status.WorkflowSession.TaskID != "task-1" || view.Status.WorkflowSession.WorkflowID != "workflow-1" {
+		t.Fatalf("workflow session = %+v, want run/task/workflow ids", view.Status.WorkflowSession)
 	}
 }
 

--- a/server/runtimewire/background_router.go
+++ b/server/runtimewire/background_router.go
@@ -42,14 +42,18 @@ func (r *BackgroundEventRouter) SetActiveSession(sessionID string, engine *runti
 	r.active[trimmedSessionID] = activeRuntime{engine: engine, activatedAt: time.Now().UTC()}
 }
 
-func (r *BackgroundEventRouter) ClearActiveSession(sessionID string) {
+func (r *BackgroundEventRouter) ClearActiveSession(sessionID string, engine *runtime.Engine) {
 	trimmedSessionID := strings.TrimSpace(sessionID)
-	if trimmedSessionID == "" {
+	if trimmedSessionID == "" || engine == nil {
 		return
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if len(r.active) == 0 {
+		return
+	}
+	active, ok := r.active[trimmedSessionID]
+	if !ok || active.engine != engine {
 		return
 	}
 	delete(r.active, trimmedSessionID)

--- a/server/runtimewire/runtime_registration.go
+++ b/server/runtimewire/runtime_registration.go
@@ -30,7 +30,6 @@ type RuntimeRegistration struct {
 	once    sync.Once
 	cleanup func()
 	drain   func(context.Context, func(context.Context) error) error
-	drainMu sync.Mutex
 }
 
 type RuntimeRegistrationOption func(*runtimeRegistrationOptions)

--- a/server/runtimewire/runtime_registration.go
+++ b/server/runtimewire/runtime_registration.go
@@ -1,6 +1,7 @@
 package runtimewire
 
 import (
+	"context"
 	"strings"
 	"sync"
 
@@ -12,40 +13,123 @@ type RuntimeRegistry interface {
 	Unregister(sessionID string, engine *runtime.Engine)
 }
 
+type RuntimeRegistryHookRegistrar interface {
+	RegisterRuntimeHooks(sessionID string, engine *runtime.Engine, rebind func(string) error)
+}
+
+type RuntimeRegistryCloseDrainer interface {
+	CloseRuntimeWithDrain(ctx context.Context, sessionID string, engine *runtime.Engine, drain func(context.Context) error) error
+}
+
 type BackgroundRouter interface {
 	SetActiveSession(sessionID string, engine *runtime.Engine)
-	ClearActiveSession(sessionID string)
+	ClearActiveSession(sessionID string, engine *runtime.Engine)
 }
 
 type RuntimeRegistration struct {
 	once    sync.Once
 	cleanup func()
+	drain   func(context.Context, func(context.Context) error) error
+	drainMu sync.Mutex
 }
 
-func RegisterSessionRuntime(sessionID string, engine *runtime.Engine, registry RuntimeRegistry, router BackgroundRouter) *RuntimeRegistration {
+type RuntimeRegistrationOption func(*runtimeRegistrationOptions)
+
+type runtimeRegistrationOptions struct {
+	rebind func(string) error
+}
+
+func WithRuntimeRebind(rebind func(string) error) RuntimeRegistrationOption {
+	return func(options *runtimeRegistrationOptions) {
+		if options != nil {
+			options.rebind = rebind
+		}
+	}
+}
+
+func RuntimeRebindFunc(localRebind func(string) error, engine *runtime.Engine) func(string) error {
+	return func(workdir string) error {
+		if localRebind != nil {
+			if err := localRebind(workdir); err != nil {
+				return err
+			}
+		}
+		if engine != nil {
+			engine.SetTranscriptWorkingDir(workdir)
+		}
+		return nil
+	}
+}
+
+func RegisterSessionRuntime(sessionID string, engine *runtime.Engine, registry RuntimeRegistry, router BackgroundRouter, opts ...RuntimeRegistrationOption) *RuntimeRegistration {
 	trimmedSessionID := strings.TrimSpace(sessionID)
 	if trimmedSessionID == "" || engine == nil {
 		return &RuntimeRegistration{}
 	}
+	options := runtimeRegistrationOptions{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
 	if registry != nil {
-		registry.Register(trimmedSessionID, engine)
+		if hookRegistry, ok := registry.(RuntimeRegistryHookRegistrar); ok {
+			hookRegistry.RegisterRuntimeHooks(trimmedSessionID, engine, options.rebind)
+		} else {
+			registry.Register(trimmedSessionID, engine)
+		}
 	}
 	if router != nil {
 		router.SetActiveSession(trimmedSessionID, engine)
 	}
-	return &RuntimeRegistration{cleanup: func() {
+	cleanup := func() {
 		if registry != nil {
 			registry.Unregister(trimmedSessionID, engine)
 		}
 		if router != nil {
-			router.ClearActiveSession(trimmedSessionID)
+			router.ClearActiveSession(trimmedSessionID, engine)
 		}
-	}}
+	}
+	drainClose := func(ctx context.Context, drain func(context.Context) error) error {
+		if drainer, ok := registry.(RuntimeRegistryCloseDrainer); ok {
+			err := drainer.CloseRuntimeWithDrain(ctx, trimmedSessionID, engine, drain)
+			if router != nil {
+				router.ClearActiveSession(trimmedSessionID, engine)
+			}
+			return err
+		}
+		if drain != nil {
+			if err := drain(ctx); err != nil {
+				cleanup()
+				return err
+			}
+		}
+		cleanup()
+		return nil
+	}
+	return &RuntimeRegistration{cleanup: cleanup, drain: drainClose}
 }
 
 func (r *RuntimeRegistration) Close() {
+	_ = r.CloseWithDrain(context.Background(), nil)
+}
+
+func (r *RuntimeRegistration) CloseWithDrain(ctx context.Context, drain func(context.Context) error) error {
 	if r == nil || r.cleanup == nil {
-		return
+		return nil
 	}
-	r.once.Do(r.cleanup)
+	var err error
+	r.once.Do(func() {
+		if r.drain != nil {
+			err = r.drain(ctx, drain)
+			return
+		}
+		if drain != nil {
+			err = drain(ctx)
+		}
+		if r.cleanup != nil {
+			r.cleanup()
+		}
+	})
+	return err
 }

--- a/server/runtimewire/runtime_registration_test.go
+++ b/server/runtimewire/runtime_registration_test.go
@@ -1,0 +1,73 @@
+package runtimewire
+
+import (
+	"context"
+	"testing"
+
+	"core/server/registry"
+	"core/server/runtime"
+)
+
+type recordingRuntimeRegistry struct {
+	registered   []string
+	unregistered []string
+}
+
+func (r *recordingRuntimeRegistry) Register(sessionID string, _ *runtime.Engine) {
+	r.registered = append(r.registered, sessionID)
+}
+
+func (r *recordingRuntimeRegistry) Unregister(sessionID string, _ *runtime.Engine) {
+	r.unregistered = append(r.unregistered, sessionID)
+}
+
+func TestRuntimeRegistrationCloseWithDrainRunsDrainBeforeUnregister(t *testing.T) {
+	registry := &recordingRuntimeRegistry{}
+	engine := &runtime.Engine{}
+	registration := RegisterSessionRuntime("session-1", engine, registry, nil)
+	var order []string
+	err := registration.CloseWithDrain(context.Background(), func(context.Context) error {
+		order = append(order, "drain")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("CloseWithDrain: %v", err)
+	}
+	order = append(order, "closed")
+	if len(registry.unregistered) != 1 || registry.unregistered[0] != "session-1" {
+		t.Fatalf("unregistered = %#v, want session-1 once", registry.unregistered)
+	}
+	if len(order) != 2 || order[0] != "drain" || order[1] != "closed" {
+		t.Fatalf("order = %#v, want drain before close", order)
+	}
+	registration.Close()
+	if len(registry.unregistered) != 1 {
+		t.Fatalf("unregistered after idempotent close = %#v, want once", registry.unregistered)
+	}
+}
+
+func TestRuntimeRegistrationCloseWithDrainRejectsNewGuardsBeforeDrain(t *testing.T) {
+	registry := registry.NewRuntimeRegistry()
+	engine := &runtime.Engine{}
+	registration := RegisterSessionRuntime("session-1", engine, registry, nil)
+
+	err := registration.CloseWithDrain(context.Background(), func(ctx context.Context) error {
+		if !registry.IsSessionRuntimeActive("session-1") {
+			t.Fatal("runtime should remain registered while drain runs")
+		}
+		guard, guardErr := registry.BeginRuntimeGuard(ctx, "session-1")
+		if guard != nil {
+			guard.Release()
+		}
+		if guardErr == nil {
+			t.Fatal("expected close barrier to reject new guarded collaborative access before drain")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("CloseWithDrain: %v", err)
+	}
+	if registry.IsSessionRuntimeActive("session-1") {
+		t.Fatal("runtime should be unregistered after close")
+	}
+}

--- a/server/runtimewire/runtime_registration_test.go
+++ b/server/runtimewire/runtime_registration_test.go
@@ -11,6 +11,7 @@ import (
 type recordingRuntimeRegistry struct {
 	registered   []string
 	unregistered []string
+	onUnregister func(string)
 }
 
 func (r *recordingRuntimeRegistry) Register(sessionID string, _ *runtime.Engine) {
@@ -19,13 +20,18 @@ func (r *recordingRuntimeRegistry) Register(sessionID string, _ *runtime.Engine)
 
 func (r *recordingRuntimeRegistry) Unregister(sessionID string, _ *runtime.Engine) {
 	r.unregistered = append(r.unregistered, sessionID)
+	if r.onUnregister != nil {
+		r.onUnregister(sessionID)
+	}
 }
 
 func TestRuntimeRegistrationCloseWithDrainRunsDrainBeforeUnregister(t *testing.T) {
-	registry := &recordingRuntimeRegistry{}
+	var order []string
+	registry := &recordingRuntimeRegistry{onUnregister: func(string) {
+		order = append(order, "unregister")
+	}}
 	engine := &runtime.Engine{}
 	registration := RegisterSessionRuntime("session-1", engine, registry, nil)
-	var order []string
 	err := registration.CloseWithDrain(context.Background(), func(context.Context) error {
 		order = append(order, "drain")
 		return nil
@@ -33,12 +39,12 @@ func TestRuntimeRegistrationCloseWithDrainRunsDrainBeforeUnregister(t *testing.T
 	if err != nil {
 		t.Fatalf("CloseWithDrain: %v", err)
 	}
-	order = append(order, "closed")
 	if len(registry.unregistered) != 1 || registry.unregistered[0] != "session-1" {
 		t.Fatalf("unregistered = %#v, want session-1 once", registry.unregistered)
 	}
-	if len(order) != 2 || order[0] != "drain" || order[1] != "closed" {
-		t.Fatalf("order = %#v, want drain before close", order)
+	order = append(order, "closed")
+	if len(order) != 3 || order[0] != "drain" || order[1] != "unregister" || order[2] != "closed" {
+		t.Fatalf("order = %#v, want drain before unregister before close", order)
 	}
 	registration.Close()
 	if len(registry.unregistered) != 1 {

--- a/server/runtimewire/runtimewire_test.go
+++ b/server/runtimewire/runtimewire_test.go
@@ -259,7 +259,7 @@ func TestBackgroundEventRouterClearActiveSessionDropsOnlyThatOwner(t *testing.T)
 	router := &BackgroundEventRouter{}
 	router.SetActiveSession(storeA.Meta().SessionID, engA)
 	router.SetActiveSession(storeB.Meta().SessionID, engB)
-	router.ClearActiveSession(storeA.Meta().SessionID)
+	router.ClearActiveSession(storeA.Meta().SessionID, engA)
 	router.Handle(shelltool.Event{Snapshot: shelltool.Snapshot{ID: "1003", OwnerSessionID: storeA.Meta().SessionID, State: "completed", Command: "kent run", Workdir: root, LogPath: filepath.Join(root, "1003.log")}, Type: shelltool.EventCompleted, Preview: "done"})
 	time.Sleep(150 * time.Millisecond)
 	if got := clientA.CallCount(); got != 0 {
@@ -276,6 +276,32 @@ func TestBackgroundEventRouterClearActiveSessionDropsOnlyThatOwner(t *testing.T)
 	}
 	if got := clientB.CallCount(); got == 0 {
 		t.Fatal("expected other active sessions to keep receiving their own completions after clearing a different owner")
+	}
+}
+
+func TestBackgroundEventRouterStaleClearKeepsReplacementForSameSession(t *testing.T) {
+	root := t.TempDir()
+	store := newRuntimeWireSession(t, root, "ws")
+	clientA := &busyToggleFakeClient{responses: []llm.Response{{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "a", Phase: llm.MessagePhaseFinal}, Usage: llm.Usage{WindowTokens: 200_000}}}}
+	clientB := &busyToggleFakeClient{responses: []llm.Response{{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "b", Phase: llm.MessagePhaseFinal}, Usage: llm.Usage{WindowTokens: 200_000}}}}
+	engA := newRuntimeWireEngine(t, store, clientA)
+	engB := newRuntimeWireEngine(t, store, clientB)
+
+	router := &BackgroundEventRouter{}
+	router.SetActiveSession(store.Meta().SessionID, engA)
+	router.SetActiveSession(store.Meta().SessionID, engB)
+	router.ClearActiveSession(store.Meta().SessionID, engA)
+	router.Handle(shelltool.Event{Snapshot: shelltool.Snapshot{ID: "1005", OwnerSessionID: store.Meta().SessionID, State: "completed", Command: "kent run", Workdir: root, LogPath: filepath.Join(root, "1005.log")}, Type: shelltool.EventCompleted, Preview: "done"})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for clientB.CallCount() == 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := clientB.CallCount(); got == 0 {
+		t.Fatal("expected replacement active session to receive completion after stale clear")
+	}
+	if got := clientA.CallCount(); got != 0 {
+		t.Fatalf("did not expect stale active session to receive completion, got %d", got)
 	}
 }
 

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -568,7 +568,11 @@ func (s *Store) SetWorkflowSessionState(state *WorkflowSessionState) error {
 			normalized.RunID = strings.TrimSpace(normalized.RunID)
 			normalized.TaskID = strings.TrimSpace(normalized.TaskID)
 			normalized.WorkflowID = strings.TrimSpace(normalized.WorkflowID)
-			s.meta.WorkflowSession = &normalized
+			if normalized.RunID == "" && normalized.TaskID == "" && normalized.WorkflowID == "" {
+				s.meta.WorkflowSession = nil
+			} else {
+				s.meta.WorkflowSession = &normalized
+			}
 		}
 		s.meta.UpdatedAt = time.Now().UTC()
 		return nil

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -559,6 +559,22 @@ func (s *Store) MarkGeneratedRecoveredWarningIssued() error {
 	})
 }
 
+func (s *Store) SetWorkflowSessionState(state *WorkflowSessionState) error {
+	return s.mutateAndPersist(func() error {
+		if state == nil {
+			s.meta.WorkflowSession = nil
+		} else {
+			normalized := *state
+			normalized.RunID = strings.TrimSpace(normalized.RunID)
+			normalized.TaskID = strings.TrimSpace(normalized.TaskID)
+			normalized.WorkflowID = strings.TrimSpace(normalized.WorkflowID)
+			s.meta.WorkflowSession = &normalized
+		}
+		s.meta.UpdatedAt = time.Now().UTC()
+		return nil
+	})
+}
+
 func (s *Store) MarkModelDispatchLocked(contract LockedContract) error {
 	return s.mutateAndPersist(func() error {
 		s.meta.ModelRequestCount++

--- a/server/session/store_test.go
+++ b/server/session/store_test.go
@@ -47,6 +47,21 @@ func TestBackfillLockedContextBudgetWithoutLockedContractDoesNotPersistLazyStore
 	}
 }
 
+func TestSetWorkflowSessionStateNormalizesEmptyStateToNil(t *testing.T) {
+	store := newSessionTestStore(t)
+
+	if err := store.SetWorkflowSessionState(&WorkflowSessionState{
+		RunID:      "   ",
+		TaskID:     "\t",
+		WorkflowID: "\n",
+	}); err != nil {
+		t.Fatalf("SetWorkflowSessionState: %v", err)
+	}
+	if store.Meta().WorkflowSession != nil {
+		t.Fatalf("workflow session = %+v, want nil", store.Meta().WorkflowSession)
+	}
+}
+
 func TestAppendEventMonotonicSequence(t *testing.T) {
 	store := newSessionTestStore(t)
 

--- a/server/session/types.go
+++ b/server/session/types.go
@@ -135,7 +135,14 @@ type Meta struct {
 	WorktreeReminder                *WorktreeReminderState `json:"worktree_reminder,omitempty"`
 	UsageState                      *UsageState            `json:"usage_state,omitempty"`
 	Goal                            *GoalState             `json:"goal,omitempty"`
+	WorkflowSession                 *WorkflowSessionState  `json:"workflow_session,omitempty"`
 	Locked                          *LockedContract        `json:"locked,omitempty"`
+}
+
+type WorkflowSessionState struct {
+	RunID      string `json:"run_id,omitempty"`
+	TaskID     string `json:"task_id,omitempty"`
+	WorkflowID string `json:"workflow_id,omitempty"`
 }
 
 type Event struct {

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -197,6 +197,7 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 			return serverapi.SessionRuntimeActivateResponse{
 				Mode:              serverapi.SessionRuntimeAttachModeCollaborative,
 				AllowedOperations: serverapi.CollaborativeSessionRuntimeOperations(workflowCollaborativeSession(engine)),
+				ReadOnly:          true,
 			}, nil
 		}
 		startupPrimaryLease = nil
@@ -224,6 +225,7 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 				return serverapi.SessionRuntimeActivateResponse{
 					Mode:              serverapi.SessionRuntimeAttachModeCollaborative,
 					AllowedOperations: serverapi.CollaborativeSessionRuntimeOperations(workflowCollaborativeSession(engine)),
+					ReadOnly:          true,
 				}, nil
 			}
 			handle, takeover, claim, err = s.claimNewActivation(sessionID, requestID, ownerID)

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -73,10 +73,17 @@ type runtimeIdleTimer struct {
 	timer      *time.Timer
 }
 
+type CollaborativeRuntimeGuard interface {
+	Engine() *runtime.Engine
+	Rebind(workdir string) error
+	Release()
+}
+
 const (
 	defaultRuntimeIdleUnloadDelay        = 5 * time.Second
 	defaultRunFinishedIdleUnloadDelay    = 3 * time.Minute
 	bestEffortRuntimeLeaseReleaseTimeout = 2 * time.Second
+	activationPrimaryRunRetryDelay       = 10 * time.Millisecond
 )
 
 type runtimeTakeover struct {
@@ -95,6 +102,7 @@ const (
 	activationClaimClosing
 	activationClaimTakeoverReuse
 	activationClaimTakeover
+	activationClaimMissing
 )
 
 func NewService(persistenceRoot string, metadataStore *metadata.Store, authManager *auth.Manager, fastModeState *runtime.FastModeState, background *shelltool.Manager, backgroundRouter *runtimewire.BackgroundEventRouter, runtimes *registry.RuntimeRegistry, sessionStores *registry.SessionStoreRegistry, storeOptions ...session.StoreOption) *Service {
@@ -182,17 +190,59 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 	var handle *runtimeHandle
 	var takeover *runtimeTakeover
 	var claim activationClaim
+	var startupPrimaryLease primaryrun.Lease
 	var err error
 	for {
-		if s.confirmExternalSessionRuntimeActive(ctx, sessionID) {
-			return serverapi.SessionRuntimeActivateResponse{ReadOnly: true}, nil
+		if engine, ok := s.confirmExternalSessionRuntimeActive(ctx, sessionID); ok {
+			return serverapi.SessionRuntimeActivateResponse{
+				Mode:              serverapi.SessionRuntimeAttachModeCollaborative,
+				AllowedOperations: serverapi.CollaborativeSessionRuntimeOperations(workflowCollaborativeSession(engine)),
+			}, nil
 		}
-		handle, takeover, claim, err = s.claimActivation(sessionID, requestID, ownerID)
+		startupPrimaryLease = nil
+		handle, takeover, claim, err = s.claimExistingActivation(sessionID, requestID, ownerID)
 		if err != nil {
 			return serverapi.SessionRuntimeActivateResponse{}, err
 		}
+		if claim == activationClaimMissing {
+			// Workflow/headless owners hold the primary-run gate before runtime
+			// registration, so a fresh controller must acquire the same gate
+			// before publishing a handle or wait for the owner to register.
+			startupPrimaryLease, err = s.acquirePrimaryRunLease(sessionID)
+			if errors.Is(err, primaryrun.ErrActivePrimaryRun) {
+				if waitErr := waitForActivationPrimaryRunRetry(ctx); waitErr != nil {
+					return serverapi.SessionRuntimeActivateResponse{}, waitErr
+				}
+				continue
+			}
+			if err != nil {
+				return serverapi.SessionRuntimeActivateResponse{}, err
+			}
+			if engine, ok := s.confirmExternalSessionRuntimeActive(ctx, sessionID); ok {
+				startupPrimaryLease.Release()
+				startupPrimaryLease = nil
+				return serverapi.SessionRuntimeActivateResponse{
+					Mode:              serverapi.SessionRuntimeAttachModeCollaborative,
+					AllowedOperations: serverapi.CollaborativeSessionRuntimeOperations(workflowCollaborativeSession(engine)),
+				}, nil
+			}
+			handle, takeover, claim, err = s.claimNewActivation(sessionID, requestID, ownerID)
+			if err != nil {
+				startupPrimaryLease.Release()
+				startupPrimaryLease = nil
+				return serverapi.SessionRuntimeActivateResponse{}, err
+			}
+			if claim != activationClaimOwner {
+				startupPrimaryLease.Release()
+				startupPrimaryLease = nil
+			}
+		}
 		if claim != activationClaimClosing {
 			break
+		}
+		if startupPrimaryLease != nil {
+			startupPrimaryLease.Release()
+			startupPrimaryLease = nil
 		}
 		if err := waitForRuntimeHandleClosed(ctx, handle); err != nil {
 			return serverapi.SessionRuntimeActivateResponse{}, err
@@ -225,6 +275,10 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 		}
 		if strings.TrimSpace(leaseID) != "" {
 			s.releaseRuntimeLeaseBestEffort(sessionID, leaseID)
+		}
+		if startupPrimaryLease != nil {
+			startupPrimaryLease.Release()
+			startupPrimaryLease = nil
 		}
 		s.failActivation(sessionID, handle, err)
 	}()
@@ -296,22 +350,25 @@ func (s *Service) ActivateSessionRuntime(ctx context.Context, req serverapi.Sess
 	if s.backgroundRouter != nil {
 		backgroundRouter = s.backgroundRouter
 	}
-	registration := runtimewire.RegisterSessionRuntime(sessionID, wiring.Engine, runtimeRegistry, backgroundRouter)
-	cleanup = func() {
-		registration.Close()
-		_ = wiring.Close()
-		_ = logger.Close()
-	}
-	handle.rebind = nil
 	var localRebind func(string) error
 	if wiring.LocalTools != nil {
 		localRebind = wiring.LocalTools.Rebind
 	}
 	handle.rebind = runtimeRebindFunc(localRebind, wiring.Engine)
+	registration := runtimewire.RegisterSessionRuntime(sessionID, wiring.Engine, runtimeRegistry, backgroundRouter, runtimewire.WithRuntimeRebind(handle.rebind))
+	cleanup = func() {
+		registration.Close()
+		_ = wiring.Close()
+		_ = logger.Close()
+	}
 	s.completeActivation(handle, leaseID, cleanup)
+	if startupPrimaryLease != nil {
+		startupPrimaryLease.Release()
+		startupPrimaryLease = nil
+	}
 	s.cancelScheduledIdleUnload(sessionID)
 	cleanup = nil
-	return serverapi.SessionRuntimeActivateResponse{LeaseID: leaseID}, nil
+	return serverapi.SessionRuntimeActivateResponse{LeaseID: leaseID, Mode: serverapi.SessionRuntimeAttachModeController}, nil
 }
 
 func (s *Service) externalSessionRuntimeActive(sessionID string) bool {
@@ -323,15 +380,95 @@ func (s *Service) externalSessionRuntimeActive(sessionID string) bool {
 	return s.handles[strings.TrimSpace(sessionID)] == nil
 }
 
-func (s *Service) confirmExternalSessionRuntimeActive(ctx context.Context, sessionID string) bool {
-	if !s.externalSessionRuntimeActive(sessionID) || s.runtimes == nil {
+func (s *Service) WithCollaborativeRuntime(ctx context.Context, sessionID string, op serverapi.SessionRuntimeOperation, fn func(CollaborativeRuntimeGuard) error) error {
+	if s == nil || s.runtimes == nil {
+		return fmt.Errorf("collaborative runtime %q is unavailable", strings.TrimSpace(sessionID))
+	}
+	id := strings.TrimSpace(sessionID)
+	if !s.externalSessionRuntimeActive(id) {
+		return fmt.Errorf("collaborative runtime %q is unavailable", id)
+	}
+	guard, err := s.runtimes.BeginRuntimeGuard(ctx, id)
+	if err != nil {
+		return err
+	}
+	defer guard.Release()
+	if !s.externalSessionRuntimeActive(id) {
+		return fmt.Errorf("collaborative runtime %q is unavailable", id)
+	}
+	if !collaborativeOperationAllowed(op, guard.Engine()) {
+		return fmt.Errorf("collaborative operation %q is unavailable for session %q", op, id)
+	}
+	return fn(guard)
+}
+
+func (s *Service) WithCollaborativeRuntimeEngine(ctx context.Context, sessionID string, op serverapi.SessionRuntimeOperation, fn func(*runtime.Engine) error) error {
+	return s.WithCollaborativeRuntime(ctx, sessionID, op, func(guard CollaborativeRuntimeGuard) error {
+		return fn(guard.Engine())
+	})
+}
+
+func (s *Service) BeginCollaborativeRuntimeGuard(ctx context.Context, sessionID string, op serverapi.SessionRuntimeOperation) (interface {
+	Release()
+	Rebind(workdir string) error
+}, error) {
+	if s == nil || s.runtimes == nil {
+		return nil, fmt.Errorf("collaborative runtime %q is unavailable", strings.TrimSpace(sessionID))
+	}
+	id := strings.TrimSpace(sessionID)
+	if !s.externalSessionRuntimeActive(id) {
+		return nil, fmt.Errorf("collaborative runtime %q is unavailable", id)
+	}
+	guard, err := s.runtimes.BeginRuntimeGuard(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !s.externalSessionRuntimeActive(id) {
+		guard.Release()
+		return nil, fmt.Errorf("collaborative runtime %q is unavailable", id)
+	}
+	if !collaborativeOperationAllowed(op, guard.Engine()) {
+		guard.Release()
+		return nil, fmt.Errorf("collaborative operation %q is unavailable for session %q", op, id)
+	}
+	return guard, nil
+}
+
+func (s *Service) WithCollaborativePromptResponder(ctx context.Context, sessionID string, op serverapi.SessionRuntimeOperation, fn func(registry.GuardedPromptResponder) error) error {
+	return s.WithCollaborativeRuntime(ctx, sessionID, op, func(guard CollaborativeRuntimeGuard) error {
+		responder, ok := guard.(registry.GuardedPromptResponder)
+		if !ok {
+			return fmt.Errorf("collaborative prompt responder for session %q is unavailable", strings.TrimSpace(sessionID))
+		}
+		return fn(responder)
+	})
+}
+
+func collaborativeOperationAllowed(op serverapi.SessionRuntimeOperation, engine *runtime.Engine) bool {
+	for _, allowed := range serverapi.CollaborativeSessionRuntimeOperations(workflowCollaborativeSession(engine)) {
+		if allowed == op {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowCollaborativeSession(engine *runtime.Engine) bool {
+	if engine == nil {
 		return false
+	}
+	return engine.WorkflowRunConfigured() || strings.TrimSpace(engine.WorkflowSessionState().RunID) != ""
+}
+
+func (s *Service) confirmExternalSessionRuntimeActive(ctx context.Context, sessionID string) (*runtime.Engine, bool) {
+	if !s.externalSessionRuntimeActive(sessionID) || s.runtimes == nil {
+		return nil, false
 	}
 	engine, err := s.runtimes.ResolveRuntime(ctx, sessionID)
 	if err != nil || engine == nil {
-		return false
+		return nil, false
 	}
-	return s.externalSessionRuntimeActive(sessionID)
+	return engine, s.externalSessionRuntimeActive(sessionID)
 }
 
 func runtimeRebindFunc(localRebind func(string) error, engine *runtime.Engine) func(string) error {
@@ -818,12 +955,33 @@ func (s *Service) SyncExecutionTarget(ctx context.Context, sessionID string, tar
 		return err
 	}
 	if handle == nil || handle.rebind == nil {
+		if s.externalSessionRuntimeActive(trimmedSessionID) {
+			if err := s.WithCollaborativeRuntime(ctx, trimmedSessionID, serverapi.SessionRuntimeOperationWorktreeManage, func(guard CollaborativeRuntimeGuard) error {
+				return guard.Rebind(trimmedWorkdir)
+			}); err != nil {
+				return err
+			}
+		}
 		return s.persistWorktreeReminderState(ctx, trimmedSessionID, normalizedReminder)
 	}
 	if err := handle.rebind(trimmedWorkdir); err != nil {
 		return err
 	}
 	return s.persistWorktreeReminderState(ctx, trimmedSessionID, normalizedReminder)
+}
+
+func (s *Service) PersistWorktreeReminderState(ctx context.Context, sessionID string, reminder *session.WorktreeReminderState) error {
+	if s == nil {
+		return errors.New("session runtime service is required")
+	}
+	if reminder == nil {
+		return nil
+	}
+	normalized, err := normalizeWorktreeReminderState(*reminder)
+	if err != nil {
+		return err
+	}
+	return s.persistWorktreeReminderState(ctx, strings.TrimSpace(sessionID), &normalized)
 }
 
 func (s *Service) persistWorktreeReminderState(ctx context.Context, sessionID string, reminder *session.WorktreeReminderState) error {
@@ -911,10 +1069,33 @@ func (s *Service) activeRuntimeHandle(ctx context.Context, sessionID string) (*r
 	return current, nil
 }
 
+func waitForActivationPrimaryRunRetry(ctx context.Context) error {
+	timer := time.NewTimer(activationPrimaryRunRetryDelay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *Service) claimExistingActivation(sessionID string, requestID string, ownerID string) (*runtimeHandle, *runtimeTakeover, activationClaim, error) {
+	return s.claimActivationWithCreate(sessionID, requestID, ownerID, false)
+}
+
+func (s *Service) claimNewActivation(sessionID string, requestID string, ownerID string) (*runtimeHandle, *runtimeTakeover, activationClaim, error) {
+	return s.claimActivationWithCreate(sessionID, requestID, ownerID, true)
+}
+
+func (s *Service) claimActivation(sessionID string, requestID string, ownerID string) (*runtimeHandle, *runtimeTakeover, activationClaim, error) {
+	return s.claimActivationWithCreate(sessionID, requestID, ownerID, true)
+}
+
 // Phase 2 temporarily allows many attached readers, but exactly one controlling
 // client per session. A second activation must fail explicitly instead of
 // joining the active runtime.
-func (s *Service) claimActivation(sessionID string, requestID string, ownerID string) (*runtimeHandle, *runtimeTakeover, activationClaim, error) {
+func (s *Service) claimActivationWithCreate(sessionID string, requestID string, ownerID string, allowCreate bool) (*runtimeHandle, *runtimeTakeover, activationClaim, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if current := s.handles[sessionID]; current != nil {
@@ -939,6 +1120,9 @@ func (s *Service) claimActivation(sessionID string, requestID string, ownerID st
 			return current, takeover, activationClaimTakeover, nil
 		}
 		return nil, nil, activationClaimOwner, errors.Join(serverapi.ErrSessionAlreadyControlled, fmt.Errorf("session %q is already controlled by another client", sessionID))
+	}
+	if !allowCreate {
+		return nil, nil, activationClaimMissing, nil
 	}
 	handle := newRuntimeHandle(requestID, ownerID)
 	s.handles[sessionID] = handle
@@ -988,7 +1172,7 @@ func (s *Service) takeOverActivation(ctx context.Context, sessionID string, requ
 		finishRuntimeTakeover(takeover, "", err)
 		return serverapi.SessionRuntimeActivateResponse{}, err
 	}
-	return serverapi.SessionRuntimeActivateResponse{LeaseID: leaseID}, nil
+	return serverapi.SessionRuntimeActivateResponse{LeaseID: leaseID, Mode: serverapi.SessionRuntimeAttachModeController}, nil
 }
 
 func runtimeHandleReady(handle *runtimeHandle) bool {
@@ -1208,7 +1392,7 @@ func activationResponseForHandle(handle *runtimeHandle) (serverapi.SessionRuntim
 	if leaseID == "" {
 		return serverapi.SessionRuntimeActivateResponse{}, fmt.Errorf("activate session runtime: controller lease is unavailable")
 	}
-	return serverapi.SessionRuntimeActivateResponse{LeaseID: leaseID}, nil
+	return serverapi.SessionRuntimeActivateResponse{LeaseID: leaseID, Mode: serverapi.SessionRuntimeAttachModeController}, nil
 }
 
 func activationResponseForTakeover(takeover *runtimeTakeover) (serverapi.SessionRuntimeActivateResponse, error) {

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -675,8 +675,8 @@ func TestActivateSessionRuntimeAttachesCollaborativelyToExternalActiveRuntime(t 
 	if err != nil {
 		t.Fatalf("ActivateSessionRuntime: %v", err)
 	}
-	if resp.Mode != serverapi.SessionRuntimeAttachModeCollaborative || resp.ReadOnly || strings.TrimSpace(resp.LeaseID) != "" {
-		t.Fatalf("response = %+v, want collaborative without lease/read-only", resp)
+	if resp.Mode != serverapi.SessionRuntimeAttachModeCollaborative || !resp.ReadOnly || strings.TrimSpace(resp.LeaseID) != "" {
+		t.Fatalf("response = %+v, want collaborative legacy read-only without lease", resp)
 	}
 	assertOperationsEqual(t, resp.AllowedOperations, serverapi.CollaborativeSessionRuntimeOperations(false))
 	if len(fixture.service.handles) != 0 {
@@ -736,8 +736,8 @@ func TestActivateSessionRuntimeWaitsForPendingExternalOwnerBeforeClaimingControl
 		if result.err != nil {
 			t.Fatalf("ActivateSessionRuntime: %v", result.err)
 		}
-		if result.resp.Mode != serverapi.SessionRuntimeAttachModeCollaborative || result.resp.ReadOnly || strings.TrimSpace(result.resp.LeaseID) != "" {
-			t.Fatalf("response = %+v, want collaborative without controller lease", result.resp)
+		if result.resp.Mode != serverapi.SessionRuntimeAttachModeCollaborative || !result.resp.ReadOnly || strings.TrimSpace(result.resp.LeaseID) != "" {
+			t.Fatalf("response = %+v, want collaborative legacy read-only without controller lease", result.resp)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for activation to attach to registered external runtime")
@@ -775,8 +775,8 @@ func TestActivateSessionRuntimeCollaborativeWorkflowRuntimeOmitsGoalManage(t *te
 	if err != nil {
 		t.Fatalf("ActivateSessionRuntime: %v", err)
 	}
-	if resp.Mode != serverapi.SessionRuntimeAttachModeCollaborative || resp.ReadOnly || strings.TrimSpace(resp.LeaseID) != "" {
-		t.Fatalf("response = %+v, want collaborative without lease/read-only", resp)
+	if resp.Mode != serverapi.SessionRuntimeAttachModeCollaborative || !resp.ReadOnly || strings.TrimSpace(resp.LeaseID) != "" {
+		t.Fatalf("response = %+v, want collaborative legacy read-only without lease", resp)
 	}
 	assertOperationsEqual(t, resp.AllowedOperations, serverapi.CollaborativeSessionRuntimeOperations(true))
 	if len(fixture.service.handles) != 0 {

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -678,12 +678,7 @@ func TestActivateSessionRuntimeAttachesCollaborativelyToExternalActiveRuntime(t 
 	if resp.Mode != serverapi.SessionRuntimeAttachModeCollaborative || resp.ReadOnly || strings.TrimSpace(resp.LeaseID) != "" {
 		t.Fatalf("response = %+v, want collaborative without lease/read-only", resp)
 	}
-	assertOperationPresent(t, resp.AllowedOperations, serverapi.SessionRuntimeOperationSubmitUserTurn)
-	assertOperationPresent(t, resp.AllowedOperations, serverapi.SessionRuntimeOperationQueueUserMessage)
-	assertOperationPresent(t, resp.AllowedOperations, serverapi.SessionRuntimeOperationGoalManage)
-	if len(resp.AllowedOperations) != len(serverapi.CollaborativeSessionRuntimeOperations(false)) {
-		t.Fatalf("allowed operations = %#v, want exact non-workflow collaborative allowlist", resp.AllowedOperations)
-	}
+	assertOperationsEqual(t, resp.AllowedOperations, serverapi.CollaborativeSessionRuntimeOperations(false))
 	if len(fixture.service.handles) != 0 {
 		t.Fatalf("external active runtime should not leave controller handles, got %+v", fixture.service.handles)
 	}
@@ -783,11 +778,7 @@ func TestActivateSessionRuntimeCollaborativeWorkflowRuntimeOmitsGoalManage(t *te
 	if resp.Mode != serverapi.SessionRuntimeAttachModeCollaborative || resp.ReadOnly || strings.TrimSpace(resp.LeaseID) != "" {
 		t.Fatalf("response = %+v, want collaborative without lease/read-only", resp)
 	}
-	assertOperationPresent(t, resp.AllowedOperations, serverapi.SessionRuntimeOperationSubmitUserTurn)
-	assertOperationAbsent(t, resp.AllowedOperations, serverapi.SessionRuntimeOperationGoalManage)
-	if len(resp.AllowedOperations) != len(serverapi.CollaborativeSessionRuntimeOperations(true)) {
-		t.Fatalf("allowed operations = %#v, want exact workflow collaborative allowlist", resp.AllowedOperations)
-	}
+	assertOperationsEqual(t, resp.AllowedOperations, serverapi.CollaborativeSessionRuntimeOperations(true))
 	if len(fixture.service.handles) != 0 {
 		t.Fatalf("external active runtime should not leave controller handles, got %+v", fixture.service.handles)
 	}
@@ -819,10 +810,7 @@ func TestActivateSessionRuntimeCollaborativeDurableWorkflowSessionOmitsGoalManag
 	if err != nil {
 		t.Fatalf("ActivateSessionRuntime: %v", err)
 	}
-	assertOperationAbsent(t, resp.AllowedOperations, serverapi.SessionRuntimeOperationGoalManage)
-	if len(resp.AllowedOperations) != len(serverapi.CollaborativeSessionRuntimeOperations(true)) {
-		t.Fatalf("allowed operations = %#v, want exact durable workflow collaborative allowlist", resp.AllowedOperations)
-	}
+	assertOperationsEqual(t, resp.AllowedOperations, serverapi.CollaborativeSessionRuntimeOperations(true))
 	err = fixture.service.WithCollaborativeRuntime(context.Background(), fixture.store.Meta().SessionID, serverapi.SessionRuntimeOperationGoalManage, func(CollaborativeRuntimeGuard) error {
 		t.Fatal("goal.manage callback should not run for durable workflow sessions")
 		return nil
@@ -2111,22 +2099,23 @@ func TestReleaseSessionRuntimeRejectsPathLikeSessionID(t *testing.T) {
 	}
 }
 
-func assertOperationPresent(t *testing.T, operations []serverapi.SessionRuntimeOperation, want serverapi.SessionRuntimeOperation) {
+func assertOperationsEqual(t *testing.T, got, want []serverapi.SessionRuntimeOperation) {
 	t.Helper()
-	for _, op := range operations {
-		if op == want {
-			return
-		}
+	if len(got) != len(want) {
+		t.Fatalf("allowed operations = %#v, want %#v", got, want)
 	}
-	t.Fatalf("operation %q missing from %#v", want, operations)
-}
-
-func assertOperationAbsent(t *testing.T, operations []serverapi.SessionRuntimeOperation, want serverapi.SessionRuntimeOperation) {
-	t.Helper()
-	for _, op := range operations {
-		if op == want {
-			t.Fatalf("operation %q unexpectedly present in %#v", want, operations)
+	remaining := make(map[serverapi.SessionRuntimeOperation]int, len(got))
+	for _, op := range got {
+		remaining[op]++
+	}
+	for _, op := range want {
+		if remaining[op] != 1 {
+			t.Fatalf("allowed operations = %#v, want %#v", got, want)
 		}
+		delete(remaining, op)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("allowed operations = %#v, want %#v", got, want)
 	}
 }
 

--- a/server/sessionruntime/service_test.go
+++ b/server/sessionruntime/service_test.go
@@ -19,6 +19,8 @@ import (
 	runtimepkg "core/server/runtime"
 	"core/server/session"
 	"core/server/tools"
+	"core/server/workflow"
+	"core/server/workflowruntime"
 	"core/shared/clientui"
 	"core/shared/config"
 	"core/shared/serverapi"
@@ -653,7 +655,7 @@ func TestActivateSessionRuntimeIgnoresRecoveredWarningProviderError(t *testing.T
 	}
 }
 
-func TestActivateSessionRuntimeAttachesReadOnlyToExternalActiveRuntime(t *testing.T) {
+func TestActivateSessionRuntimeAttachesCollaborativelyToExternalActiveRuntime(t *testing.T) {
 	fixture := newSessionRuntimeFixture(t)
 	runtimes := registry.NewRuntimeRegistry()
 	engine, err := runtimepkg.New(fixture.store, &sessionRuntimeTestLLMClient{}, tools.NewRegistry(), runtimepkg.Config{Model: "gpt-5"})
@@ -673,14 +675,197 @@ func TestActivateSessionRuntimeAttachesReadOnlyToExternalActiveRuntime(t *testin
 	if err != nil {
 		t.Fatalf("ActivateSessionRuntime: %v", err)
 	}
-	if !resp.ReadOnly || strings.TrimSpace(resp.LeaseID) != "" {
-		t.Fatalf("response = %+v, want read-only without lease", resp)
+	if resp.Mode != serverapi.SessionRuntimeAttachModeCollaborative || resp.ReadOnly || strings.TrimSpace(resp.LeaseID) != "" {
+		t.Fatalf("response = %+v, want collaborative without lease/read-only", resp)
+	}
+	assertOperationPresent(t, resp.AllowedOperations, serverapi.SessionRuntimeOperationSubmitUserTurn)
+	assertOperationPresent(t, resp.AllowedOperations, serverapi.SessionRuntimeOperationQueueUserMessage)
+	assertOperationPresent(t, resp.AllowedOperations, serverapi.SessionRuntimeOperationGoalManage)
+	if len(resp.AllowedOperations) != len(serverapi.CollaborativeSessionRuntimeOperations(false)) {
+		t.Fatalf("allowed operations = %#v, want exact non-workflow collaborative allowlist", resp.AllowedOperations)
 	}
 	if len(fixture.service.handles) != 0 {
 		t.Fatalf("external active runtime should not leave controller handles, got %+v", fixture.service.handles)
 	}
 	if !runtimes.IsSessionRuntimeActive(fixture.store.Meta().SessionID) {
 		t.Fatal("expected external runtime to remain registered")
+	}
+}
+
+func TestActivateSessionRuntimeWaitsForPendingExternalOwnerBeforeClaimingController(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	runtimes := registry.NewRuntimeRegistry()
+	fixture.service.runtimes = runtimes
+	ownerLease, err := runtimes.AcquirePrimaryRun(fixture.store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("AcquirePrimaryRun owner: %v", err)
+	}
+	defer ownerLease.Release()
+
+	type activationResult struct {
+		resp serverapi.SessionRuntimeActivateResponse
+		err  error
+	}
+	done := make(chan activationResult, 1)
+	go func() {
+		resp, err := fixture.service.ActivateSessionRuntime(context.Background(), serverapi.SessionRuntimeActivateRequest{
+			ClientRequestID: "req-pending-owner",
+			SessionID:       fixture.store.Meta().SessionID,
+			ActiveSettings:  config.Settings{Model: "gpt-5"},
+		})
+		done <- activationResult{resp: resp, err: err}
+	}()
+
+	select {
+	case result := <-done:
+		t.Fatalf("activation completed before external owner registration: resp=%+v err=%v", result.resp, result.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	fixture.service.mu.Lock()
+	handle := fixture.service.handles[fixture.store.Meta().SessionID]
+	fixture.service.mu.Unlock()
+	if handle != nil {
+		t.Fatalf("activation created controller handle while external owner primary-run lease was pending: %+v", handle)
+	}
+
+	engine, err := runtimepkg.New(fixture.store, &sessionRuntimeTestLLMClient{}, tools.NewRegistry(), runtimepkg.Config{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("runtime.New: %v", err)
+	}
+	defer func() { _ = engine.Close() }()
+	runtimes.Register(fixture.store.Meta().SessionID, engine)
+	t.Cleanup(func() { runtimes.Unregister(fixture.store.Meta().SessionID, engine) })
+
+	select {
+	case result := <-done:
+		if result.err != nil {
+			t.Fatalf("ActivateSessionRuntime: %v", result.err)
+		}
+		if result.resp.Mode != serverapi.SessionRuntimeAttachModeCollaborative || result.resp.ReadOnly || strings.TrimSpace(result.resp.LeaseID) != "" {
+			t.Fatalf("response = %+v, want collaborative without controller lease", result.resp)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for activation to attach to registered external runtime")
+	}
+	fixture.service.mu.Lock()
+	handle = fixture.service.handles[fixture.store.Meta().SessionID]
+	fixture.service.mu.Unlock()
+	if handle != nil {
+		t.Fatalf("collaborative activation left controller handle: %+v", handle)
+	}
+}
+
+func TestActivateSessionRuntimeCollaborativeWorkflowRuntimeOmitsGoalManage(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	runtimes := registry.NewRuntimeRegistry()
+	engine, err := runtimepkg.New(fixture.store, &sessionRuntimeTestLLMClient{}, tools.NewRegistry(), runtimepkg.Config{
+		Model: "gpt-5",
+		WorkflowRun: &workflowruntime.Config{
+			Contract: workflowruntime.CompletionContract{RunID: workflow.RunID("run-1")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runtime.New: %v", err)
+	}
+	defer func() { _ = engine.Close() }()
+	runtimes.Register(fixture.store.Meta().SessionID, engine)
+	t.Cleanup(func() { runtimes.Unregister(fixture.store.Meta().SessionID, engine) })
+	fixture.service.runtimes = runtimes
+
+	resp, err := fixture.service.ActivateSessionRuntime(context.Background(), serverapi.SessionRuntimeActivateRequest{
+		ClientRequestID: "req-external-workflow",
+		SessionID:       fixture.store.Meta().SessionID,
+		ActiveSettings:  config.Settings{Model: "gpt-5"},
+	})
+	if err != nil {
+		t.Fatalf("ActivateSessionRuntime: %v", err)
+	}
+	if resp.Mode != serverapi.SessionRuntimeAttachModeCollaborative || resp.ReadOnly || strings.TrimSpace(resp.LeaseID) != "" {
+		t.Fatalf("response = %+v, want collaborative without lease/read-only", resp)
+	}
+	assertOperationPresent(t, resp.AllowedOperations, serverapi.SessionRuntimeOperationSubmitUserTurn)
+	assertOperationAbsent(t, resp.AllowedOperations, serverapi.SessionRuntimeOperationGoalManage)
+	if len(resp.AllowedOperations) != len(serverapi.CollaborativeSessionRuntimeOperations(true)) {
+		t.Fatalf("allowed operations = %#v, want exact workflow collaborative allowlist", resp.AllowedOperations)
+	}
+	if len(fixture.service.handles) != 0 {
+		t.Fatalf("external active runtime should not leave controller handles, got %+v", fixture.service.handles)
+	}
+}
+
+func TestActivateSessionRuntimeCollaborativeDurableWorkflowSessionOmitsGoalManage(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	if err := fixture.store.SetWorkflowSessionState(&session.WorkflowSessionState{RunID: "run-1", TaskID: "task-1", WorkflowID: "workflow-1"}); err != nil {
+		t.Fatalf("SetWorkflowSessionState: %v", err)
+	}
+	runtimes := registry.NewRuntimeRegistry()
+	engine, err := runtimepkg.New(fixture.store, &sessionRuntimeTestLLMClient{}, tools.NewRegistry(), runtimepkg.Config{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("runtime.New: %v", err)
+	}
+	defer func() { _ = engine.Close() }()
+	if engine.WorkflowRunConfigured() {
+		t.Fatal("test requires a non-workflow-configured active runtime")
+	}
+	runtimes.Register(fixture.store.Meta().SessionID, engine)
+	t.Cleanup(func() { runtimes.Unregister(fixture.store.Meta().SessionID, engine) })
+	fixture.service.runtimes = runtimes
+
+	resp, err := fixture.service.ActivateSessionRuntime(context.Background(), serverapi.SessionRuntimeActivateRequest{
+		ClientRequestID: "req-external-durable-workflow",
+		SessionID:       fixture.store.Meta().SessionID,
+		ActiveSettings:  config.Settings{Model: "gpt-5"},
+	})
+	if err != nil {
+		t.Fatalf("ActivateSessionRuntime: %v", err)
+	}
+	assertOperationAbsent(t, resp.AllowedOperations, serverapi.SessionRuntimeOperationGoalManage)
+	if len(resp.AllowedOperations) != len(serverapi.CollaborativeSessionRuntimeOperations(true)) {
+		t.Fatalf("allowed operations = %#v, want exact durable workflow collaborative allowlist", resp.AllowedOperations)
+	}
+	err = fixture.service.WithCollaborativeRuntime(context.Background(), fixture.store.Meta().SessionID, serverapi.SessionRuntimeOperationGoalManage, func(CollaborativeRuntimeGuard) error {
+		t.Fatal("goal.manage callback should not run for durable workflow sessions")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected durable workflow collaborative goal.manage to be unavailable")
+	}
+}
+
+func TestWithCollaborativeRuntimeRequiresExternalActiveRuntime(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	runtimes := registry.NewRuntimeRegistry()
+	engine, err := runtimepkg.New(fixture.store, &sessionRuntimeTestLLMClient{}, tools.NewRegistry(), runtimepkg.Config{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("runtime.New: %v", err)
+	}
+	defer func() { _ = engine.Close() }()
+	runtimes.Register(fixture.store.Meta().SessionID, engine)
+	t.Cleanup(func() { runtimes.Unregister(fixture.store.Meta().SessionID, engine) })
+	fixture.service.runtimes = runtimes
+
+	called := false
+	err = fixture.service.WithCollaborativeRuntime(context.Background(), fixture.store.Meta().SessionID, serverapi.SessionRuntimeOperationQueueUserMessage, func(guard CollaborativeRuntimeGuard) error {
+		called = true
+		if guard.Engine() != engine {
+			t.Fatal("expected guarded active engine")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithCollaborativeRuntime: %v", err)
+	}
+	if !called {
+		t.Fatal("expected collaborative callback")
+	}
+
+	fixture.service.handles[fixture.store.Meta().SessionID] = &runtimeHandle{}
+	err = fixture.service.WithCollaborativeRuntime(context.Background(), fixture.store.Meta().SessionID, serverapi.SessionRuntimeOperationQueueUserMessage, func(CollaborativeRuntimeGuard) error {
+		t.Fatal("unexpected callback for controller-owned handle")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected controller-owned session to reject collaborative access")
 	}
 }
 
@@ -1722,6 +1907,29 @@ func TestSyncExecutionTargetRebindsActiveRuntime(t *testing.T) {
 	}
 }
 
+func TestSyncExecutionTargetRebindsExternalCollaborativeRuntime(t *testing.T) {
+	fixture := newSessionRuntimeFixture(t)
+	runtimes := registry.NewRuntimeRegistry()
+	fixture.service.runtimes = runtimes
+	reboundRoot := ""
+	engine := &runtimepkg.Engine{}
+	runtimes.RegisterRuntimeHooks(fixture.store.Meta().SessionID, engine, func(root string) error {
+		reboundRoot = root
+		return nil
+	})
+	t.Cleanup(func() { runtimes.Unregister(fixture.store.Meta().SessionID, engine) })
+
+	err := fixture.service.SyncExecutionTarget(context.Background(), fixture.store.Meta().SessionID, clientui.SessionExecutionTarget{
+		EffectiveWorkdir: " /tmp/collaborative-worktree ",
+	}, nil)
+	if err != nil {
+		t.Fatalf("SyncExecutionTarget: %v", err)
+	}
+	if reboundRoot != "/tmp/collaborative-worktree" {
+		t.Fatalf("rebound root = %q, want /tmp/collaborative-worktree", reboundRoot)
+	}
+}
+
 func TestSyncExecutionTargetUpdatesActiveRuntimePatchTranscriptWorkdir(t *testing.T) {
 	fixture := newSessionRuntimeFixture(t)
 	patchText := "*** Begin Patch\n*** Add File: probe.txt\n+hello\n*** End Patch\n"
@@ -1900,6 +2108,25 @@ func TestReleaseSessionRuntimeRejectsPathLikeSessionID(t *testing.T) {
 	})
 	if !errors.Is(err, serverapi.ErrSessionIDNotSingle) {
 		t.Fatalf("expected path-like session id rejection, got %v", err)
+	}
+}
+
+func assertOperationPresent(t *testing.T, operations []serverapi.SessionRuntimeOperation, want serverapi.SessionRuntimeOperation) {
+	t.Helper()
+	for _, op := range operations {
+		if op == want {
+			return
+		}
+	}
+	t.Fatalf("operation %q missing from %#v", want, operations)
+}
+
+func assertOperationAbsent(t *testing.T, operations []serverapi.SessionRuntimeOperation, want serverapi.SessionRuntimeOperation) {
+	t.Helper()
+	for _, op := range operations {
+		if op == want {
+			t.Fatalf("operation %q unexpectedly present in %#v", want, operations)
+		}
 	}
 }
 

--- a/server/sessionview/dormant_cache.go
+++ b/server/sessionview/dormant_cache.go
@@ -149,13 +149,21 @@ func buildDormantTranscriptCacheEntry(ctx context.Context, store *session.Store)
 }
 
 func (e dormantTranscriptCacheEntry) mainView(meta session.Meta, freshness clientui.ConversationFreshness) clientui.RuntimeMainView {
+	status := clientui.RuntimeStatus{
+		ConversationFreshness:             freshness,
+		ParentSessionID:                   meta.ParentSessionID,
+		LastCommittedAssistantFinalAnswer: e.lastCommittedAssistantAnswer,
+		Goal:                              runtimeview.GoalFromSessionState(meta.Goal, false),
+	}
+	if meta.WorkflowSession != nil {
+		status.WorkflowSession = &clientui.WorkflowSessionStatus{
+			RunID:      strings.TrimSpace(meta.WorkflowSession.RunID),
+			TaskID:     strings.TrimSpace(meta.WorkflowSession.TaskID),
+			WorkflowID: strings.TrimSpace(meta.WorkflowSession.WorkflowID),
+		}
+	}
 	return clientui.RuntimeMainView{
-		Status: clientui.RuntimeStatus{
-			ConversationFreshness:             freshness,
-			ParentSessionID:                   meta.ParentSessionID,
-			LastCommittedAssistantFinalAnswer: e.lastCommittedAssistantAnswer,
-			Goal:                              runtimeview.GoalFromSessionState(meta.Goal, false),
-		},
+		Status: status,
 		Session: clientui.RuntimeSessionView{
 			SessionID:             meta.SessionID,
 			SessionName:           meta.Name,

--- a/server/sessionview/service.go
+++ b/server/sessionview/service.go
@@ -24,6 +24,10 @@ type RuntimeResolver interface {
 	ResolveRuntime(ctx context.Context, sessionID string) (*runtime.Engine, error)
 }
 
+type ExternalRuntimeStatusResolver interface {
+	ExternalRuntimeStatus(sessionID string) clientui.ExternalRuntimeStatus
+}
+
 type ExecutionTargetResolver interface {
 	ResolveSessionExecutionTarget(ctx context.Context, sessionID string) (clientui.SessionExecutionTarget, error)
 }

--- a/server/sessionview/service_test.go
+++ b/server/sessionview/service_test.go
@@ -194,6 +194,57 @@ func TestServiceGetSessionMainViewFallsBackToDurableSessionState(t *testing.T) {
 	}
 }
 
+func TestServiceGetSessionMainViewFallsBackToDurableWorkflowSessionState(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	if err := store.SetWorkflowSessionState(&session.WorkflowSessionState{RunID: "run-1", TaskID: "task-1", WorkflowID: "workflow-1"}); err != nil {
+		t.Fatalf("SetWorkflowSessionState: %v", err)
+	}
+	svc := NewService(NewStaticSessionResolver(store), nil, nil)
+	resp, err := svc.GetSessionMainView(context.Background(), serverapi.SessionMainViewRequest{SessionID: store.Meta().SessionID})
+	if err != nil {
+		t.Fatalf("GetSessionMainView: %v", err)
+	}
+	if resp.MainView.Status.WorkflowSession == nil {
+		t.Fatalf("workflow session = nil, status=%+v", resp.MainView.Status)
+	}
+	if resp.MainView.Status.WorkflowActive {
+		t.Fatalf("workflow active = true, want false for reopened non-workflow runtime")
+	}
+	if resp.MainView.Status.WorkflowSession.RunID != "run-1" || resp.MainView.Status.WorkflowSession.TaskID != "task-1" || resp.MainView.Status.WorkflowSession.WorkflowID != "workflow-1" {
+		t.Fatalf("workflow session = %+v, want run/task/workflow ids", resp.MainView.Status.WorkflowSession)
+	}
+}
+
+func TestServiceGetSessionMainViewMergesDurableWorkflowSessionStateIntoLiveRuntime(t *testing.T) {
+	dir := t.TempDir()
+	store, err := session.Create(dir, "ws", dir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	if err := store.SetWorkflowSessionState(&session.WorkflowSessionState{RunID: "run-1", TaskID: "task-1", WorkflowID: "workflow-1"}); err != nil {
+		t.Fatalf("SetWorkflowSessionState: %v", err)
+	}
+	eng, err := runtime.New(store, &serviceFakeLLM{}, tools.NewRegistry(), runtime.Config{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	svc := NewService(NewStaticSessionResolver(store), NewStaticRuntimeResolver(eng), nil)
+	resp, err := svc.GetSessionMainView(context.Background(), serverapi.SessionMainViewRequest{SessionID: store.Meta().SessionID})
+	if err != nil {
+		t.Fatalf("GetSessionMainView: %v", err)
+	}
+	if resp.MainView.Status.WorkflowSession == nil {
+		t.Fatalf("workflow session = nil, status=%+v", resp.MainView.Status)
+	}
+	if resp.MainView.Status.WorkflowSession.RunID != "run-1" || resp.MainView.Status.WorkflowSession.TaskID != "task-1" || resp.MainView.Status.WorkflowSession.WorkflowID != "workflow-1" {
+		t.Fatalf("workflow session = %+v, want run/task/workflow ids", resp.MainView.Status.WorkflowSession)
+	}
+}
+
 func TestServiceGetSessionMainViewIncludesExecutionTarget(t *testing.T) {
 	dir := t.TempDir()
 	store, err := session.Create(dir, "ws", dir)

--- a/server/sessionview/snapshot.go
+++ b/server/sessionview/snapshot.go
@@ -214,10 +214,7 @@ func (s liveRuntimeSessionSnapshot) MainView(ctx context.Context) (clientui.Runt
 	}
 	if s.sessions != nil && view.Status.WorkflowSession == nil {
 		store, err := s.sessions.ResolveSessionStore(ctx, s.engine.SessionID())
-		if err != nil {
-			return clientui.RuntimeMainView{}, err
-		}
-		if store != nil {
+		if err == nil && store != nil {
 			if workflowSession := store.Meta().WorkflowSession; workflowSession != nil {
 				view.Status.WorkflowSession = &clientui.WorkflowSessionStatus{
 					RunID:      strings.TrimSpace(workflowSession.RunID),

--- a/server/sessionview/snapshot.go
+++ b/server/sessionview/snapshot.go
@@ -168,7 +168,11 @@ func (s *resolvedSessionSnapshotSource) ResolveSessionSnapshot(ctx context.Conte
 			return nil, err
 		}
 		if engine != nil {
-			return liveRuntimeSessionSnapshot{engine: engine, sessions: s.sessions}, nil
+			var external clientui.ExternalRuntimeStatus
+			if resolver, ok := s.runtimes.(ExternalRuntimeStatusResolver); ok {
+				external = resolver.ExternalRuntimeStatus(sessionID)
+			}
+			return liveRuntimeSessionSnapshot{engine: engine, sessions: s.sessions, external: external}, nil
 		}
 	}
 	if s.sessions == nil {
@@ -193,14 +197,37 @@ func (s *resolvedSessionSnapshotSource) ClearCaches() {
 type liveRuntimeSessionSnapshot struct {
 	engine   *runtime.Engine
 	sessions SessionStoreResolver
+	external clientui.ExternalRuntimeStatus
 }
 
 func (s liveRuntimeSessionSnapshot) Capabilities() SessionSnapshotCapabilities {
 	return coreSessionSnapshotCapabilities()
 }
 
-func (s liveRuntimeSessionSnapshot) MainView(context.Context) (clientui.RuntimeMainView, error) {
-	return runtimeview.MainViewFromRuntime(s.engine), nil
+func (s liveRuntimeSessionSnapshot) MainView(ctx context.Context) (clientui.RuntimeMainView, error) {
+	view := runtimeview.MainViewFromRuntime(s.engine)
+	if s.external.State != "" {
+		view.ExternalRuntime = &clientui.ExternalRuntimeStatus{
+			State:          s.external.State,
+			QueueAccepting: s.external.QueueAccepting,
+		}
+	}
+	if s.sessions != nil && view.Status.WorkflowSession == nil {
+		store, err := s.sessions.ResolveSessionStore(ctx, s.engine.SessionID())
+		if err != nil {
+			return clientui.RuntimeMainView{}, err
+		}
+		if store != nil {
+			if workflowSession := store.Meta().WorkflowSession; workflowSession != nil {
+				view.Status.WorkflowSession = &clientui.WorkflowSessionStatus{
+					RunID:      strings.TrimSpace(workflowSession.RunID),
+					TaskID:     strings.TrimSpace(workflowSession.TaskID),
+					WorkflowID: strings.TrimSpace(workflowSession.WorkflowID),
+				}
+			}
+		}
+	}
+	return view, nil
 }
 
 func (s liveRuntimeSessionSnapshot) TranscriptPage(_ context.Context, req clientui.TranscriptPageRequest) (clientui.TranscriptPage, error) {

--- a/server/sessionview/snapshot_capability_test.go
+++ b/server/sessionview/snapshot_capability_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSessionSnapshotCapabilitiesCoverReadModelFields(t *testing.T) {
 	covered := map[reflect.Type]map[string]struct{}{
-		reflect.TypeOf(clientui.RuntimeMainView{}): fieldSet("Status", "Session", "ActiveRun"),
+		reflect.TypeOf(clientui.RuntimeMainView{}): fieldSet("Status", "Session", "ActiveRun", "ExternalRuntime"),
 		reflect.TypeOf(clientui.RuntimeStatus{}): fieldSet(
 			"ReviewerFrequency",
 			"ReviewerEnabled",
@@ -26,12 +26,16 @@ func TestSessionSnapshotCapabilitiesCoverReadModelFields(t *testing.T) {
 			"ContextUsage",
 			"CompactionCount",
 			"Goal",
+			"WorkflowActive",
+			"WorkflowSession",
 			"Update",
 		),
-		reflect.TypeOf(clientui.RuntimeContextUsage{}): fieldSet("UsedTokens", "WindowTokens", "CacheHitPercent", "HasCacheHitPercentage"),
-		reflect.TypeOf(clientui.RuntimeGoal{}):         fieldSet("ID", "Objective", "Status", "Suspended"),
-		reflect.TypeOf(clientui.UpdateStatus{}):        fieldSet("Checked", "Available", "CurrentVersion", "LatestVersion"),
-		reflect.TypeOf(clientui.RuntimeSessionView{}):  fieldSet("SessionID", "SessionName", "ConversationFreshness", "ExecutionTarget", "Transcript", "Chat"),
+		reflect.TypeOf(clientui.WorkflowSessionStatus{}): fieldSet("RunID", "TaskID", "WorkflowID"),
+		reflect.TypeOf(clientui.ExternalRuntimeStatus{}): fieldSet("State", "QueueAccepting"),
+		reflect.TypeOf(clientui.RuntimeContextUsage{}):   fieldSet("UsedTokens", "WindowTokens", "CacheHitPercent", "HasCacheHitPercentage"),
+		reflect.TypeOf(clientui.RuntimeGoal{}):           fieldSet("ID", "Objective", "Status", "Suspended"),
+		reflect.TypeOf(clientui.UpdateStatus{}):          fieldSet("Checked", "Available", "CurrentVersion", "LatestVersion"),
+		reflect.TypeOf(clientui.RuntimeSessionView{}):    fieldSet("SessionID", "SessionName", "ConversationFreshness", "ExecutionTarget", "Transcript", "Chat"),
 		reflect.TypeOf(clientui.SessionExecutionTarget{}): fieldSet(
 			"WorkspaceID",
 			"WorkspaceName",

--- a/server/startup/embedded_server.go
+++ b/server/startup/embedded_server.go
@@ -33,7 +33,7 @@ type EmbeddedStartHooks struct {
 
 type BackgroundRouter interface {
 	SetActiveSession(sessionID string, engine *runtime.Engine)
-	ClearActiveSession(sessionID string)
+	ClearActiveSession(sessionID string, engine *runtime.Engine)
 }
 
 type EmbeddedServer struct {

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -360,6 +360,9 @@ func protocolError(err error) (int, string) {
 	if errors.Is(err, serverapi.ErrRuntimeUnavailable) {
 		return protocol.ErrCodeRuntimeUnavailable, message
 	}
+	if errors.Is(err, serverapi.ErrActivePrimaryRun) {
+		return protocol.ErrCodeActivePrimaryRun, message
+	}
 	if errors.Is(err, serverapi.ErrStreamUnavailable) {
 		return protocol.ErrCodeStreamUnavailable, message
 	}

--- a/server/transport/gateway_part2_test.go
+++ b/server/transport/gateway_part2_test.go
@@ -292,6 +292,16 @@ func TestGatewaySessionActivitySubscriptionStreamsEventsAndCompletion(t *testing
 	}
 
 	appCore.UnregisterRuntime(store.Meta().SessionID, engine)
+	var closing protocol.SessionActivityEventParams
+	receiveGatewayNotification(t, conn, protocol.MethodSessionActivityEvent, "closing external runtime", &closing)
+	if closing.Event.Kind != clientui.EventExternalRuntimeStatus || closing.Event.ExternalRuntimeStatus == nil || closing.Event.ExternalRuntimeStatus.State != clientui.ExternalRuntimeStateClosing {
+		t.Fatalf("unexpected closing external runtime event: %+v", closing.Event)
+	}
+	var closed protocol.SessionActivityEventParams
+	receiveGatewayNotification(t, conn, protocol.MethodSessionActivityEvent, "closed external runtime", &closed)
+	if closed.Event.Kind != clientui.EventExternalRuntimeStatus || closed.Event.ExternalRuntimeStatus == nil || closed.Event.ExternalRuntimeStatus.State != "" {
+		t.Fatalf("unexpected closed external runtime event: %+v", closed.Event)
+	}
 	var complete protocol.StreamCompleteParams
 	receiveGatewayNotification(t, conn, protocol.MethodSessionActivityComplete, "completion", &complete)
 	if complete.Code != 0 || complete.Message != "" {

--- a/server/transport/gateway_part2_test.go
+++ b/server/transport/gateway_part2_test.go
@@ -294,12 +294,18 @@ func TestGatewaySessionActivitySubscriptionStreamsEventsAndCompletion(t *testing
 	appCore.UnregisterRuntime(store.Meta().SessionID, engine)
 	var closing protocol.SessionActivityEventParams
 	receiveGatewayNotification(t, conn, protocol.MethodSessionActivityEvent, "closing external runtime", &closing)
-	if closing.Event.Kind != clientui.EventExternalRuntimeStatus || closing.Event.ExternalRuntimeStatus == nil || closing.Event.ExternalRuntimeStatus.State != clientui.ExternalRuntimeStateClosing {
+	if closing.Event.Kind != clientui.EventExternalRuntimeStatus ||
+		closing.Event.ExternalRuntimeStatus == nil ||
+		closing.Event.ExternalRuntimeStatus.State != clientui.ExternalRuntimeStateClosing ||
+		closing.Event.ExternalRuntimeStatus.QueueAccepting {
 		t.Fatalf("unexpected closing external runtime event: %+v", closing.Event)
 	}
 	var closed protocol.SessionActivityEventParams
 	receiveGatewayNotification(t, conn, protocol.MethodSessionActivityEvent, "closed external runtime", &closed)
-	if closed.Event.Kind != clientui.EventExternalRuntimeStatus || closed.Event.ExternalRuntimeStatus == nil || closed.Event.ExternalRuntimeStatus.State != "" {
+	if closed.Event.Kind != clientui.EventExternalRuntimeStatus ||
+		closed.Event.ExternalRuntimeStatus == nil ||
+		closed.Event.ExternalRuntimeStatus.State != "" ||
+		closed.Event.ExternalRuntimeStatus.QueueAccepting {
 		t.Fatalf("unexpected closed external runtime event: %+v", closed.Event)
 	}
 	var complete protocol.StreamCompleteParams

--- a/server/transport/gateway_test.go
+++ b/server/transport/gateway_test.go
@@ -459,7 +459,7 @@ func TestGatewayFailedActivationDoesNotRecordOwnedRuntimeLease(t *testing.T) {
 	}
 }
 
-func TestGatewayReadOnlyRuntimeActivationDoesNotRecordOwnedLease(t *testing.T) {
+func TestGatewayCollaborativeRuntimeActivationDoesNotRecordOwnedLease(t *testing.T) {
 	appCore, server := newGatewayTestServer(t)
 	defer func() { _ = appCore.Close() }()
 	defer server.Close()
@@ -473,8 +473,8 @@ func TestGatewayReadOnlyRuntimeActivationDoesNotRecordOwnedLease(t *testing.T) {
 	handshakeGateway(t, conn)
 	var activation serverapi.SessionRuntimeActivateResponse
 	callGateway(t, conn, "activate-runtime", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "activate-runtime"), &activation)
-	if !activation.ReadOnly || strings.TrimSpace(activation.LeaseID) != "" {
-		t.Fatalf("activation response = %+v, want read-only without lease", activation)
+	if activation.ReadOnly || activation.Mode != serverapi.SessionRuntimeAttachModeCollaborative || strings.TrimSpace(activation.LeaseID) != "" || len(activation.AllowedOperations) == 0 {
+		t.Fatalf("activation response = %+v, want collaborative without lease and with allowed operations", activation)
 	}
 	if err := conn.Close(); err != nil {
 		t.Fatalf("close gateway connection: %v", err)
@@ -484,8 +484,8 @@ func TestGatewayReadOnlyRuntimeActivationDoesNotRecordOwnedLease(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 	handshakeGateway(t, conn)
 	callGateway(t, conn, "activate-runtime-again", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "activate-runtime-again"), &activation)
-	if !activation.ReadOnly || strings.TrimSpace(activation.LeaseID) != "" {
-		t.Fatalf("activation after read-only disconnect = %+v, want read-only without lease", activation)
+	if activation.ReadOnly || activation.Mode != serverapi.SessionRuntimeAttachModeCollaborative || strings.TrimSpace(activation.LeaseID) != "" || len(activation.AllowedOperations) == 0 {
+		t.Fatalf("activation after collaborative disconnect = %+v, want collaborative without lease and with allowed operations", activation)
 	}
 }
 

--- a/server/transport/gateway_test.go
+++ b/server/transport/gateway_test.go
@@ -473,8 +473,8 @@ func TestGatewayCollaborativeRuntimeActivationDoesNotRecordOwnedLease(t *testing
 	handshakeGateway(t, conn)
 	var activation serverapi.SessionRuntimeActivateResponse
 	callGateway(t, conn, "activate-runtime", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "activate-runtime"), &activation)
-	if activation.ReadOnly || activation.Mode != serverapi.SessionRuntimeAttachModeCollaborative || strings.TrimSpace(activation.LeaseID) != "" || len(activation.AllowedOperations) == 0 {
-		t.Fatalf("activation response = %+v, want collaborative without lease and with allowed operations", activation)
+	if !activation.ReadOnly || activation.Mode != serverapi.SessionRuntimeAttachModeCollaborative || strings.TrimSpace(activation.LeaseID) != "" || len(activation.AllowedOperations) == 0 {
+		t.Fatalf("activation response = %+v, want collaborative legacy read-only without lease and with allowed operations", activation)
 	}
 	if err := conn.Close(); err != nil {
 		t.Fatalf("close gateway connection: %v", err)
@@ -484,8 +484,8 @@ func TestGatewayCollaborativeRuntimeActivationDoesNotRecordOwnedLease(t *testing
 	defer func() { _ = conn.Close() }()
 	handshakeGateway(t, conn)
 	callGateway(t, conn, "activate-runtime-again", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "activate-runtime-again"), &activation)
-	if activation.ReadOnly || activation.Mode != serverapi.SessionRuntimeAttachModeCollaborative || strings.TrimSpace(activation.LeaseID) != "" || len(activation.AllowedOperations) == 0 {
-		t.Fatalf("activation after collaborative disconnect = %+v, want collaborative without lease and with allowed operations", activation)
+	if !activation.ReadOnly || activation.Mode != serverapi.SessionRuntimeAttachModeCollaborative || strings.TrimSpace(activation.LeaseID) != "" || len(activation.AllowedOperations) == 0 {
+		t.Fatalf("activation after collaborative disconnect = %+v, want collaborative legacy read-only without lease and with allowed operations", activation)
 	}
 }
 

--- a/server/workflowrunner/starter.go
+++ b/server/workflowrunner/starter.go
@@ -17,6 +17,7 @@ import (
 	"core/server/launch"
 	"core/server/llm"
 	"core/server/metadata"
+	"core/server/primaryrun"
 	"core/server/runprompt"
 	"core/server/runtime"
 	"core/server/runtimeview"
@@ -59,6 +60,7 @@ type TaskWorktreeEnsurer interface {
 }
 
 type RuntimeEventRegistry interface {
+	primaryrun.Gate
 	runtimewire.RuntimeRegistry
 	PublishRuntimeEvent(sessionID string, evt runtime.Event)
 	AwaitPromptResponse(ctx context.Context, sessionID string, req askquestion.AskQuestionRequest) (askquestion.AskQuestionResponse, error)
@@ -202,6 +204,15 @@ func (s *Starter) StartWorkflowRun(ctx context.Context, req SchedulerStartRunReq
 		return errors.Join(err, cleanupSession())
 	}
 	if err := s.store.AttachRunSession(ctx, req.RunID, req.Generation, plan.Store.Meta().SessionID); err != nil {
+		cancel()
+		s.releaseRegisteredRun(req.RunID)
+		return errors.Join(err, cleanupSession())
+	}
+	if err := plan.Store.SetWorkflowSessionState(&session.WorkflowSessionState{
+		RunID:      string(req.RunID),
+		TaskID:     string(input.Task.ID),
+		WorkflowID: string(input.Task.WorkflowID),
+	}); err != nil {
 		cancel()
 		s.releaseRegisteredRun(req.RunID)
 		return errors.Join(err, cleanupSession())
@@ -658,8 +669,41 @@ func (s *Starter) run(ctx context.Context, req SchedulerStartRunRequest, input w
 			return askquestion.AskQuestionResponse{}, errors.New("workflow questions require runtime registry")
 		})
 	}
-	registration := runtimewire.RegisterSessionRuntime(plan.Store.Meta().SessionID, wiring.Engine, runtimeRegistry, s.backgroundRouter)
-	defer registration.Close()
+	var rebind func(string) error
+	if wiring.LocalTools != nil {
+		rebind = runtimewire.RuntimeRebindFunc(wiring.LocalTools.Rebind, wiring.Engine)
+	}
+	sessionID := plan.Store.Meta().SessionID
+	var workflowTurnLease primaryrun.Lease
+	workflowTurnLease, err = s.acquirePrimaryRun(sessionID)
+	if err != nil {
+		s.interrupt(context.Background(), req.RunID, req.Generation, ReasonRuntimeFailed, err)
+		return
+	}
+	workflowTurnLeaseHeld := true
+	failQueuedOnClose := false
+	registration := runtimewire.RegisterSessionRuntime(sessionID, wiring.Engine, runtimeRegistry, s.backgroundRouter, runtimewire.WithRuntimeRebind(rebind))
+	defer func() {
+		if workflowTurnLeaseHeld && workflowTurnLease != nil {
+			defer workflowTurnLease.Release()
+		}
+		_ = registration.CloseWithDrain(context.Background(), func(drainCtx context.Context) error {
+			if failQueuedOnClose {
+				wiring.Engine.FailQueuedUserMessages(runtime.QueuedUserMessageFailureClosing)
+				return nil
+			}
+			if workflowTurnLeaseHeld {
+				return wiring.Engine.DrainQueuedUserMessagesBeforeClose(drainCtx)
+			}
+			lease, err := s.acquirePrimaryRun(plan.Store.Meta().SessionID)
+			if err != nil {
+				wiring.Engine.FailQueuedUserMessages(runtime.QueuedUserMessageFailureClosing)
+				return err
+			}
+			defer lease.Release()
+			return wiring.Engine.DrainQueuedUserMessagesBeforeClose(drainCtx)
+		})
+	}()
 	// Compact exactly once per compact_and_continue handoff. The compaction's
 	// provenance is recorded atomically in its history_replaced event and rebuilt
 	// on restore, so the engine reports which run last compacted this session.
@@ -673,6 +717,7 @@ func (s *Starter) run(ctx context.Context, req SchedulerStartRunRequest, input w
 	if input.ContextMode == workflow.ContextModeCompactAndContinueSession &&
 		wiring.Engine.LastCompactionWorkflowRunID() != string(req.RunID) {
 		if err := wiring.Engine.CompactContext(ctx, ""); err != nil {
+			failQueuedOnClose = true
 			reason := ReasonRuntimeFailed
 			if errors.Is(err, context.Canceled) || ctx.Err() != nil {
 				reason = ReasonRuntimeCanceled
@@ -681,13 +726,22 @@ func (s *Starter) run(ctx context.Context, req SchedulerStartRunRequest, input w
 			return
 		}
 	}
-	if _, err := wiring.Engine.SubmitWorkflowTurn(ctx); err != nil {
+	_, err = wiring.Engine.SubmitWorkflowTurn(ctx)
+	if err != nil {
+		failQueuedOnClose = true
 		reason := ReasonRuntimeFailed
 		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
 			reason = ReasonRuntimeCanceled
 		}
 		s.interrupt(context.Background(), req.RunID, req.Generation, reason, err)
 	}
+}
+
+func (s *Starter) acquirePrimaryRun(sessionID string) (primaryrun.Lease, error) {
+	if s == nil || s.runtimes == nil {
+		return primaryrun.LeaseFunc(nil), nil
+	}
+	return s.runtimes.AcquirePrimaryRun(sessionID)
 }
 
 func (s *Starter) finish(runID workflow.RunID, generation int64) {

--- a/server/workflowrunner/starter.go
+++ b/server/workflowrunner/starter.go
@@ -203,10 +203,13 @@ func (s *Starter) StartWorkflowRun(ctx context.Context, req SchedulerStartRunReq
 		s.releaseRegisteredRun(req.RunID)
 		return errors.Join(err, cleanupSession())
 	}
-	if err := s.store.AttachRunSession(ctx, req.RunID, req.Generation, plan.Store.Meta().SessionID); err != nil {
-		cancel()
-		s.releaseRegisteredRun(req.RunID)
-		return errors.Join(err, cleanupSession())
+	var previousWorkflowSession *session.WorkflowSessionState
+	if workflowSession := plan.Store.Meta().WorkflowSession; workflowSession != nil {
+		snap := *workflowSession
+		previousWorkflowSession = &snap
+	}
+	restoreWorkflowSession := func() error {
+		return plan.Store.SetWorkflowSessionState(previousWorkflowSession)
 	}
 	if err := plan.Store.SetWorkflowSessionState(&session.WorkflowSessionState{
 		RunID:      string(req.RunID),
@@ -216,6 +219,11 @@ func (s *Starter) StartWorkflowRun(ctx context.Context, req SchedulerStartRunReq
 		cancel()
 		s.releaseRegisteredRun(req.RunID)
 		return errors.Join(err, cleanupSession())
+	}
+	if err := s.store.AttachRunSession(ctx, req.RunID, req.Generation, plan.Store.Meta().SessionID); err != nil {
+		cancel()
+		s.releaseRegisteredRun(req.RunID)
+		return errors.Join(err, restoreWorkflowSession(), cleanupSession())
 	}
 	go s.run(runCtx, req, input, plan, warnings, client, effectiveMode)
 	return nil

--- a/server/workflowrunner/starter_test.go
+++ b/server/workflowrunner/starter_test.go
@@ -15,7 +15,9 @@ import (
 	"core/server/launch"
 	"core/server/llm"
 	"core/server/metadata"
+	"core/server/primaryrun"
 	"core/server/registry"
+	"core/server/runtime"
 	"core/server/session"
 	askquestion "core/server/tools"
 	"core/server/workflow"
@@ -71,6 +73,27 @@ func TestSchedulerRunsNewSessionWorkflowNodeWithStructuredOutput(t *testing.T) {
 	fixture.assertRunSessionUsesTaskWorktree(t, runs[0].SessionID)
 	if scheduler.ActiveCount() != 0 {
 		t.Fatalf("scheduler active count = %d, want 0 after runtime finish", scheduler.ActiveCount())
+	}
+}
+
+func TestStarterHoldsPrimaryRunLeaseThroughWorkflowRuntimeCloseDrain(t *testing.T) {
+	fixture := newStarterFixture(t, config.WorkflowCompletionModeStructuredOutput, ScriptedFinalAnswer(`{"commentary":"finished structured"}`))
+	trackingRuntimes := &primaryRunAcquireTrackingRegistry{RuntimeRegistry: registry.NewRuntimeRegistry()}
+	fixture.runtimes = trackingRuntimes
+	fixture.rebuildStarter(t)
+	task := fixture.createStartedTask(t)
+	scheduler := fixture.scheduler(t)
+
+	if err := scheduler.Process(context.Background()); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	fixture.waitForCompletedRun(t, task.ID)
+
+	if got := trackingRuntimes.AcquireCount(); got != 1 {
+		t.Fatalf("primary-run acquisitions = %d, want only workflow owner acquisition before close drain", got)
+	}
+	if !trackingRuntimes.RegisterObservedOwnerLeaseBlock() {
+		t.Fatal("runtime registration did not observe workflow owner primary-run lease already held")
 	}
 }
 
@@ -1015,10 +1038,58 @@ type starterFixture struct {
 	worktrees     *metadataTaskWorktrees
 	client        *ScriptedClient
 	clientFactory func(SchedulerStartRunRequest) llm.Client
-	runtimes      *registry.RuntimeRegistry
+	runtimes      starterRuntimeRegistry
 	starter       *Starter
 	workflowID    workflow.WorkflowID
 	projectID     string
+}
+
+type primaryRunAcquireTrackingRegistry struct {
+	*registry.RuntimeRegistry
+	mu                              sync.Mutex
+	acquireCount                    int
+	registerObservedOwnerLeaseBlock bool
+}
+
+type starterRuntimeRegistry interface {
+	RuntimeEventRegistry
+	ListPendingPrompts(sessionID string) []registry.PendingPromptSnapshot
+	SubmitPromptResponse(sessionID string, resp askquestion.AskQuestionResponse, err error) error
+}
+
+func (r *primaryRunAcquireTrackingRegistry) AcquirePrimaryRun(sessionID string) (primaryrun.Lease, error) {
+	lease, err := r.RuntimeRegistry.AcquirePrimaryRun(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	r.mu.Lock()
+	r.acquireCount++
+	r.mu.Unlock()
+	return lease, nil
+}
+
+func (r *primaryRunAcquireTrackingRegistry) RegisterRuntimeHooks(sessionID string, engine *runtime.Engine, rebind func(string) error) {
+	lease, err := r.RuntimeRegistry.AcquirePrimaryRun(sessionID)
+	ownerLeaseHeld := errors.Is(err, primaryrun.ErrActivePrimaryRun)
+	if err == nil && lease != nil {
+		lease.Release()
+	}
+	r.mu.Lock()
+	r.registerObservedOwnerLeaseBlock = ownerLeaseHeld
+	r.mu.Unlock()
+	r.RuntimeRegistry.RegisterRuntimeHooks(sessionID, engine, rebind)
+}
+
+func (r *primaryRunAcquireTrackingRegistry) AcquireCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.acquireCount
+}
+
+func (r *primaryRunAcquireTrackingRegistry) RegisterObservedOwnerLeaseBlock() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.registerObservedOwnerLeaseBlock
 }
 
 func newStarterFixture(t *testing.T, mode config.WorkflowCompletionMode, steps ...ScriptedRuntimeStep) starterFixture {

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -890,15 +890,6 @@ func (s *Service) beginMutationRuntimeAccess(ctx context.Context, sessionID stri
 	return nil, errors.New("collaborative runtime guard is unavailable")
 }
 
-func (s *Service) authorizeMutationRuntime(ctx context.Context, sessionID string, leaseID string) error {
-	release, err := s.beginMutationRuntimeAccess(ctx, sessionID, leaseID)
-	if err != nil {
-		return err
-	}
-	release.Release()
-	return nil
-}
-
 func (s *Service) acquireWorkspaceMutationLock(workspaceID string) primaryrun.Lease {
 	trimmedWorkspaceID := strings.TrimSpace(workspaceID)
 	if s == nil || trimmedWorkspaceID == "" {

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -17,6 +17,7 @@ import (
 	"core/server/metadata"
 	"core/server/metadata/sqlitegen"
 	"core/server/primaryrun"
+	runtimepkg "core/server/runtime"
 	"core/server/session"
 	shelltool "core/server/tools/shell"
 	"core/shared/clientui"
@@ -34,6 +35,63 @@ type runtimeController interface {
 	RebindLocalTools(ctx context.Context, sessionID string, leaseID string, workspaceRoot string) error
 	RecordWorktreeTransition(ctx context.Context, sessionID string, leaseID string, state session.WorktreeReminderState) error
 	SyncExecutionTarget(ctx context.Context, sessionID string, target clientui.SessionExecutionTarget, reminder *session.WorktreeReminderState) error
+	PersistWorktreeReminderState(ctx context.Context, sessionID string, reminder *session.WorktreeReminderState) error
+}
+
+type collaborativeRuntimeController interface {
+	WithCollaborativeRuntimeEngine(ctx context.Context, sessionID string, op serverapi.SessionRuntimeOperation, fn func(*runtimepkg.Engine) error) error
+}
+
+type collaborativeRuntimeGuardController interface {
+	BeginCollaborativeRuntimeGuard(ctx context.Context, sessionID string, op serverapi.SessionRuntimeOperation) (interface {
+		Release()
+		Rebind(workdir string) error
+	}, error)
+}
+
+type collaborativeRuntimeAccess interface {
+	Release()
+	Rebind(workdir string) error
+}
+
+type mutationRuntimeAccess interface {
+	Release()
+	SyncExecutionTarget(ctx context.Context, sessionID string, target clientui.SessionExecutionTarget, reminder *session.WorktreeReminderState) error
+}
+
+type controllerMutationRuntimeAccess struct {
+	runtime runtimeController
+}
+
+func (a controllerMutationRuntimeAccess) Release() {}
+
+func (a controllerMutationRuntimeAccess) SyncExecutionTarget(ctx context.Context, sessionID string, target clientui.SessionExecutionTarget, reminder *session.WorktreeReminderState) error {
+	return a.runtime.SyncExecutionTarget(ctx, sessionID, target, reminder)
+}
+
+type collaborativeMutationRuntimeAccess struct {
+	runtime runtimeController
+	guard   collaborativeRuntimeAccess
+}
+
+func (a collaborativeMutationRuntimeAccess) Release() {
+	if a.guard != nil {
+		a.guard.Release()
+	}
+}
+
+func (a collaborativeMutationRuntimeAccess) SyncExecutionTarget(ctx context.Context, sessionID string, target clientui.SessionExecutionTarget, reminder *session.WorktreeReminderState) error {
+	trimmedWorkdir := strings.TrimSpace(target.EffectiveWorkdir)
+	if trimmedWorkdir == "" {
+		return errors.New("execution target effective workdir is required")
+	}
+	if a.guard == nil {
+		return errors.New("collaborative runtime guard is unavailable")
+	}
+	if err := a.guard.Rebind(trimmedWorkdir); err != nil {
+		return err
+	}
+	return a.runtime.PersistWorktreeReminderState(ctx, sessionID, reminder)
 }
 
 type activeRuntimeSource interface {
@@ -492,7 +550,7 @@ func (s *Service) ListWorktrees(ctx context.Context, req serverapi.WorktreeListR
 	if err := req.Validate(); err != nil {
 		return serverapi.WorktreeListResponse{}, err
 	}
-	release, workspaceCtx, err := s.beginMutation(ctx, req.SessionID, req.ControllerLeaseID)
+	release, workspaceCtx, _, err := s.beginMutation(ctx, req.SessionID, req.ControllerLeaseID)
 	if err != nil {
 		return serverapi.WorktreeListResponse{}, err
 	}
@@ -535,7 +593,7 @@ func (s *Service) CreateWorktree(ctx context.Context, req serverapi.WorktreeCrea
 	if err != nil {
 		return serverapi.WorktreeCreateResponse{}, err
 	}
-	release, workspaceCtx, err := s.beginMutation(ctx, req.SessionID, req.ControllerLeaseID)
+	release, workspaceCtx, runtimeAccess, err := s.beginMutation(ctx, req.SessionID, req.ControllerLeaseID)
 	if err != nil {
 		return serverapi.WorktreeCreateResponse{}, err
 	}
@@ -588,7 +646,7 @@ func (s *Service) CreateWorktree(ctx context.Context, req serverapi.WorktreeCrea
 		return serverapi.WorktreeCreateResponse{}, err
 	}
 	previous := currentSyncedWorktree(synced, workspaceCtx.target)
-	nextTarget, err := s.switchSessionTarget(ctx, workspaceCtx, req.ControllerLeaseID, previous, created)
+	nextTarget, err := s.switchSessionTarget(ctx, workspaceCtx, runtimeAccess, req.ControllerLeaseID, previous, created)
 	if err != nil {
 		return serverapi.WorktreeCreateResponse{}, err
 	}
@@ -660,7 +718,7 @@ func (s *Service) SwitchWorktree(ctx context.Context, req serverapi.WorktreeSwit
 	if err := req.Validate(); err != nil {
 		return serverapi.WorktreeSwitchResponse{}, err
 	}
-	release, workspaceCtx, err := s.beginMutation(ctx, req.SessionID, req.ControllerLeaseID)
+	release, workspaceCtx, runtimeAccess, err := s.beginMutation(ctx, req.SessionID, req.ControllerLeaseID)
 	if err != nil {
 		return serverapi.WorktreeSwitchResponse{}, err
 	}
@@ -674,7 +732,7 @@ func (s *Service) SwitchWorktree(ctx context.Context, req serverapi.WorktreeSwit
 		return serverapi.WorktreeSwitchResponse{}, serverapi.ErrWorktreeNotFound
 	}
 	previous := currentSyncedWorktree(synced, workspaceCtx.target)
-	nextTarget, err := s.switchSessionTarget(ctx, workspaceCtx, req.ControllerLeaseID, previous, targetWorktree)
+	nextTarget, err := s.switchSessionTarget(ctx, workspaceCtx, runtimeAccess, req.ControllerLeaseID, previous, targetWorktree)
 	if err != nil {
 		return serverapi.WorktreeSwitchResponse{}, err
 	}
@@ -685,7 +743,7 @@ func (s *Service) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDele
 	if err := req.Validate(); err != nil {
 		return serverapi.WorktreeDeleteResponse{}, err
 	}
-	release, workspaceCtx, err := s.beginMutation(ctx, req.SessionID, req.ControllerLeaseID)
+	release, workspaceCtx, runtimeAccess, err := s.beginMutation(ctx, req.SessionID, req.ControllerLeaseID)
 	if err != nil {
 		return serverapi.WorktreeDeleteResponse{}, err
 	}
@@ -711,7 +769,7 @@ func (s *Service) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDele
 		if !mainFound {
 			return serverapi.WorktreeDeleteResponse{}, fmt.Errorf("main worktree not found for workspace %q", workspaceCtx.workspaceID)
 		}
-		if _, err := s.switchSessionTarget(ctx, workspaceCtx, req.ControllerLeaseID, &targetWorktree, mainWorktree); err != nil {
+		if _, err := s.switchSessionTarget(ctx, workspaceCtx, runtimeAccess, req.ControllerLeaseID, &targetWorktree, mainWorktree); err != nil {
 			return serverapi.WorktreeDeleteResponse{}, err
 		}
 		workspaceCtx, err = s.resolveSessionWorkspaceContext(ctx, workspaceCtx.sessionID)
@@ -757,47 +815,88 @@ func (s *Service) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDele
 	return serverapi.WorktreeDeleteResponse{Target: finalTarget, Worktree: worktreeViewFromSynced(targetWorktree, finalTarget), BranchDeleted: branchDeleted, BranchCleanupMessage: branchCleanupMessage}, nil
 }
 
-func (s *Service) beginMutation(ctx context.Context, sessionID string, leaseID string) (primaryrun.Lease, sessionWorkspaceContext, error) {
+func (s *Service) beginMutation(ctx context.Context, sessionID string, leaseID string) (primaryrun.Lease, sessionWorkspaceContext, mutationRuntimeAccess, error) {
 	if s == nil || s.metadata == nil {
-		return nil, sessionWorkspaceContext{}, errors.New("worktree service metadata store is required")
+		return nil, sessionWorkspaceContext{}, nil, errors.New("worktree service metadata store is required")
 	}
 	if s.runtime == nil {
-		return nil, sessionWorkspaceContext{}, errors.New("worktree service runtime controller is required")
+		return nil, sessionWorkspaceContext{}, nil, errors.New("worktree service runtime controller is required")
 	}
 	if s.gate == nil {
-		return nil, sessionWorkspaceContext{}, errors.New("worktree service primary-run gate is required")
+		return nil, sessionWorkspaceContext{}, nil, errors.New("worktree service primary-run gate is required")
 	}
-	if err := s.runtime.RequireControllerLease(ctx, sessionID, leaseID); err != nil {
-		return nil, sessionWorkspaceContext{}, err
+	runtimeRelease, err := s.beginMutationRuntimeAccess(ctx, sessionID, leaseID)
+	if err != nil {
+		return nil, sessionWorkspaceContext{}, nil, err
 	}
 	release, err := s.gate.AcquirePrimaryRun(strings.TrimSpace(sessionID))
 	if err != nil {
+		runtimeRelease.Release()
 		if errors.Is(err, primaryrun.ErrActivePrimaryRun) {
-			return nil, sessionWorkspaceContext{}, errors.Join(serverapi.ErrWorktreeMutationRequiresIdle, err)
+			return nil, sessionWorkspaceContext{}, nil, errors.Join(serverapi.ErrWorktreeMutationRequiresIdle, err)
 		}
-		return nil, sessionWorkspaceContext{}, err
+		return nil, sessionWorkspaceContext{}, nil, err
 	}
 	for {
 		workspaceCtx, err := s.resolveSessionWorkspaceContext(ctx, sessionID)
 		if err != nil {
 			release.Release()
-			return nil, sessionWorkspaceContext{}, err
+			runtimeRelease.Release()
+			return nil, sessionWorkspaceContext{}, nil, err
 		}
 		workspaceLease := s.acquireWorkspaceMutationLock(workspaceCtx.workspaceID)
 		lockedWorkspaceCtx, err := s.resolveSessionWorkspaceContext(ctx, sessionID)
 		if err != nil {
 			workspaceLease.Release()
 			release.Release()
-			return nil, sessionWorkspaceContext{}, err
+			runtimeRelease.Release()
+			return nil, sessionWorkspaceContext{}, nil, err
 		}
 		if strings.TrimSpace(lockedWorkspaceCtx.workspaceID) == strings.TrimSpace(workspaceCtx.workspaceID) {
 			return primaryrun.LeaseFunc(func() {
 				workspaceLease.Release()
 				release.Release()
-			}), lockedWorkspaceCtx, nil
+				runtimeRelease.Release()
+			}), lockedWorkspaceCtx, runtimeRelease, nil
 		}
 		workspaceLease.Release()
 	}
+}
+
+func (s *Service) beginMutationRuntimeAccess(ctx context.Context, sessionID string, leaseID string) (mutationRuntimeAccess, error) {
+	if strings.TrimSpace(leaseID) != "" {
+		if err := s.runtime.RequireControllerLease(ctx, sessionID, leaseID); err != nil {
+			return nil, err
+		}
+		return controllerMutationRuntimeAccess{runtime: s.runtime}, nil
+	}
+	scoped, ok := s.runtime.(collaborativeRuntimeGuardController)
+	if ok {
+		guard, err := scoped.BeginCollaborativeRuntimeGuard(ctx, sessionID, serverapi.SessionRuntimeOperationWorktreeManage)
+		if err != nil {
+			return nil, err
+		}
+		return collaborativeMutationRuntimeAccess{runtime: s.runtime, guard: guard}, nil
+	}
+	collaborative, ok := s.runtime.(collaborativeRuntimeController)
+	if !ok {
+		return nil, serverapi.ErrInvalidControllerLease
+	}
+	if err := collaborative.WithCollaborativeRuntimeEngine(ctx, sessionID, serverapi.SessionRuntimeOperationWorktreeManage, func(*runtimepkg.Engine) error {
+		return errors.New("collaborative runtime guard is unavailable")
+	}); err != nil {
+		return nil, err
+	}
+	return nil, errors.New("collaborative runtime guard is unavailable")
+}
+
+func (s *Service) authorizeMutationRuntime(ctx context.Context, sessionID string, leaseID string) error {
+	release, err := s.beginMutationRuntimeAccess(ctx, sessionID, leaseID)
+	if err != nil {
+		return err
+	}
+	release.Release()
+	return nil
 }
 
 func (s *Service) acquireWorkspaceMutationLock(workspaceID string) primaryrun.Lease {
@@ -1088,7 +1187,7 @@ func worktreeHasStableIdentity(entry GitWorktree) bool {
 	return strings.TrimSpace(entry.BranchRef) != "" || strings.TrimSpace(entry.HeadOID) != "" || entry.Detached || entry.IsMain || entry.Bare
 }
 
-func (s *Service) switchSessionTarget(ctx context.Context, workspaceCtx sessionWorkspaceContext, leaseID string, previous *syncedWorktree, next syncedWorktree) (clientui.SessionExecutionTarget, error) {
+func (s *Service) switchSessionTarget(ctx context.Context, workspaceCtx sessionWorkspaceContext, runtimeAccess mutationRuntimeAccess, leaseID string, previous *syncedWorktree, next syncedWorktree) (clientui.SessionExecutionTarget, error) {
 	nextWorktreeID := strings.TrimSpace(next.record.ID)
 	nextBaseRoot := strings.TrimSpace(next.record.CanonicalRoot)
 	if next.git.IsMain {
@@ -1102,28 +1201,46 @@ func (s *Service) switchSessionTarget(ctx context.Context, workspaceCtx sessionW
 	}
 	nextTarget, err := s.metadata.ResolveSessionExecutionTarget(ctx, workspaceCtx.sessionID)
 	if err != nil {
-		s.rollbackSessionTarget(ctx, workspaceCtx, leaseID, previousTarget)
-		return clientui.SessionExecutionTarget{}, err
-	}
-	if err := s.runtime.RebindLocalTools(ctx, workspaceCtx.sessionID, leaseID, nextTarget.EffectiveWorkdir); err != nil {
-		s.rollbackSessionTarget(ctx, workspaceCtx, leaseID, previousTarget)
+		s.rollbackSessionTarget(ctx, workspaceCtx, runtimeAccess, leaseID, previousTarget)
 		return clientui.SessionExecutionTarget{}, err
 	}
 	if reminder, ok := worktreeReminderStateForTransition(previous, previousTarget, next, nextTarget); ok {
-		if err := s.runtime.RecordWorktreeTransition(ctx, workspaceCtx.sessionID, leaseID, reminder); err != nil {
-			s.rollbackSessionTarget(ctx, workspaceCtx, leaseID, previousTarget)
+		if err := s.applySessionTarget(ctx, workspaceCtx.sessionID, runtimeAccess, leaseID, nextTarget, &reminder); err != nil {
+			s.rollbackSessionTarget(ctx, workspaceCtx, runtimeAccess, leaseID, previousTarget)
 			return clientui.SessionExecutionTarget{}, err
 		}
+		return nextTarget, nil
+	}
+	if err := s.applySessionTarget(ctx, workspaceCtx.sessionID, runtimeAccess, leaseID, nextTarget, nil); err != nil {
+		s.rollbackSessionTarget(ctx, workspaceCtx, runtimeAccess, leaseID, previousTarget)
+		return clientui.SessionExecutionTarget{}, err
 	}
 	return nextTarget, nil
 }
 
-func (s *Service) rollbackSessionTarget(ctx context.Context, workspaceCtx sessionWorkspaceContext, leaseID string, previousTarget clientui.SessionExecutionTarget) {
+func (s *Service) applySessionTarget(ctx context.Context, sessionID string, runtimeAccess mutationRuntimeAccess, leaseID string, target clientui.SessionExecutionTarget, reminder *session.WorktreeReminderState) error {
+	if strings.TrimSpace(leaseID) == "" {
+		return runtimeAccess.SyncExecutionTarget(ctx, sessionID, target, reminder)
+	}
+	if err := s.runtime.RebindLocalTools(ctx, sessionID, leaseID, target.EffectiveWorkdir); err != nil {
+		return err
+	}
+	if reminder == nil {
+		return nil
+	}
+	return s.runtime.RecordWorktreeTransition(ctx, sessionID, leaseID, *reminder)
+}
+
+func (s *Service) rollbackSessionTarget(ctx context.Context, workspaceCtx sessionWorkspaceContext, runtimeAccess mutationRuntimeAccess, leaseID string, previousTarget clientui.SessionExecutionTarget) {
 	rollbackCtx, cancel := liveRollbackContext(ctx)
 	defer cancel()
 	_ = s.metadata.UpdateSessionExecutionTargetByID(rollbackCtx, workspaceCtx.sessionID, workspaceCtx.workspaceID, previousTarget.WorktreeID, previousTarget.CwdRelpath)
 	if strings.TrimSpace(previousTarget.EffectiveWorkdir) != "" {
-		_ = s.runtime.RebindLocalTools(rollbackCtx, workspaceCtx.sessionID, leaseID, previousTarget.EffectiveWorkdir)
+		if strings.TrimSpace(leaseID) == "" {
+			_ = runtimeAccess.SyncExecutionTarget(rollbackCtx, workspaceCtx.sessionID, previousTarget, nil)
+		} else {
+			_ = s.runtime.RebindLocalTools(rollbackCtx, workspaceCtx.sessionID, leaseID, previousTarget.EffectiveWorkdir)
+		}
 	}
 }
 

--- a/server/worktree/service_part2_test.go
+++ b/server/worktree/service_part2_test.go
@@ -70,7 +70,7 @@ func TestBeginMutationSerializesMutationsByWorkspace(t *testing.T) {
 	env := newServiceTestEnv(t)
 	otherSession := createServiceTestSession(t, env.store, env.cfg, env.binding)
 
-	firstRelease, _, err := env.service.beginMutation(env.ctx, env.session.Meta().SessionID, env.leaseID)
+	firstRelease, _, _, err := env.service.beginMutation(env.ctx, env.session.Meta().SessionID, env.leaseID)
 	if err != nil {
 		t.Fatalf("beginMutation first: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestBeginMutationSerializesMutationsByWorkspace(t *testing.T) {
 	}
 	resultCh := make(chan mutationResult, 1)
 	go func() {
-		release, _, err := env.service.beginMutation(env.ctx, otherSession.Meta().SessionID, "lease-2")
+		release, _, _, err := env.service.beginMutation(env.ctx, otherSession.Meta().SessionID, "lease-2")
 		resultCh <- mutationResult{release: release, err: err}
 	}()
 
@@ -115,6 +115,31 @@ func TestBeginMutationSerializesMutationsByWorkspace(t *testing.T) {
 		t.Fatal("expected second mutation lease")
 	}
 	result.release.Release()
+}
+
+func TestBeginMutationCollaborativeRuntimeGuardHeldUntilRelease(t *testing.T) {
+	env := newServiceTestEnv(t)
+	env.runtime.activeSessions[env.session.Meta().SessionID] = true
+
+	release, _, _, err := env.service.beginMutation(env.ctx, env.session.Meta().SessionID, "")
+	if err != nil {
+		t.Fatalf("beginMutation collaborative: %v", err)
+	}
+	env.runtime.mu.Lock()
+	activeGuards := env.runtime.activeGuards
+	releasedGuards := env.runtime.releasedGuards
+	env.runtime.mu.Unlock()
+	if activeGuards != 1 || releasedGuards != 0 {
+		t.Fatalf("guard counts before release active=%d released=%d, want active=1 released=0", activeGuards, releasedGuards)
+	}
+	release.Release()
+	env.runtime.mu.Lock()
+	activeGuards = env.runtime.activeGuards
+	releasedGuards = env.runtime.releasedGuards
+	env.runtime.mu.Unlock()
+	if activeGuards != 0 || releasedGuards != 1 {
+		t.Fatalf("guard counts after release active=%d released=%d, want active=0 released=1", activeGuards, releasedGuards)
+	}
 }
 
 func TestBeginMutationReacquiresWorkspaceLockWhenSessionWorkspaceChanges(t *testing.T) {
@@ -146,7 +171,7 @@ func TestBeginMutationReacquiresWorkspaceLockWhenSessionWorkspaceChanges(t *test
 	}
 	firstCh := make(chan mutationResult, 1)
 	go func() {
-		release, workspaceCtx, err := env.service.beginMutation(env.ctx, env.session.Meta().SessionID, env.leaseID)
+		release, workspaceCtx, _, err := env.service.beginMutation(env.ctx, env.session.Meta().SessionID, env.leaseID)
 		firstCh <- mutationResult{release: release, workspaceCtx: workspaceCtx, err: err}
 	}()
 
@@ -173,7 +198,7 @@ func TestBeginMutationReacquiresWorkspaceLockWhenSessionWorkspaceChanges(t *test
 
 	secondCh := make(chan mutationResult, 1)
 	go func() {
-		release, workspaceCtx, err := env.service.beginMutation(env.ctx, secondSession.Meta().SessionID, "lease-2")
+		release, workspaceCtx, _, err := env.service.beginMutation(env.ctx, secondSession.Meta().SessionID, "lease-2")
 		secondCh <- mutationResult{release: release, workspaceCtx: workspaceCtx, err: err}
 	}()
 	select {

--- a/server/worktree/service_test.go
+++ b/server/worktree/service_test.go
@@ -32,6 +32,8 @@ type serviceTestRuntime struct {
 	rebindHook      func(context.Context, string, string, string)
 	requireErr      error
 	controllerSeen  bool
+	activeGuards    int
+	releasedGuards  int
 }
 
 type serviceRuntimeCall struct {
@@ -69,23 +71,80 @@ func (r *serviceTestRuntime) RecordWorktreeTransition(_ context.Context, _ strin
 }
 
 func (r *serviceTestRuntime) SyncExecutionTarget(_ context.Context, sessionID string, target clientui.SessionExecutionTarget, reminder *session.WorktreeReminderState) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
 	trimmedSessionID := strings.TrimSpace(sessionID)
+	r.mu.Lock()
 	if reminder != nil {
 		r.reminderCalls = append(r.reminderCalls, *reminder)
 	}
 	if !r.activeSessions[trimmedSessionID] {
+		r.mu.Unlock()
 		return nil
 	}
-	r.rebindCalls = append(r.rebindCalls, serviceRuntimeCall{sessionID: sessionID, root: strings.TrimSpace(target.EffectiveWorkdir)})
 	if err := r.syncErrSessions[trimmedSessionID]; err != nil {
+		r.mu.Unlock()
 		return err
 	}
-	if r.rebindErr != nil && (strings.TrimSpace(r.rebindErrRoot) == "" || strings.TrimSpace(r.rebindErrRoot) == strings.TrimSpace(target.EffectiveWorkdir)) {
-		return r.rebindErr
+	r.mu.Unlock()
+	guard, err := r.BeginCollaborativeRuntimeGuard(context.Background(), sessionID, serverapi.SessionRuntimeOperationWorktreeManage)
+	if err != nil {
+		return err
+	}
+	defer guard.Release()
+	return guard.Rebind(strings.TrimSpace(target.EffectiveWorkdir))
+}
+
+func (r *serviceTestRuntime) PersistWorktreeReminderState(_ context.Context, _ string, reminder *session.WorktreeReminderState) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if reminder != nil {
+		r.reminderCalls = append(r.reminderCalls, *reminder)
 	}
 	return nil
+}
+
+func (r *serviceTestRuntime) BeginCollaborativeRuntimeGuard(_ context.Context, sessionID string, _ serverapi.SessionRuntimeOperation) (interface {
+	Release()
+	Rebind(workdir string) error
+}, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	trimmedSessionID := strings.TrimSpace(sessionID)
+	if r.activeSessions != nil && !r.activeSessions[trimmedSessionID] {
+		return nil, errors.New("collaborative runtime unavailable")
+	}
+	r.requireCalls = append(r.requireCalls, serviceRuntimeCall{sessionID: sessionID})
+	r.activeGuards++
+	return &serviceTestCollaborativeRuntimeAccess{runtime: r, sessionID: sessionID}, nil
+}
+
+func (r *serviceTestRuntime) WithCollaborativeRuntimeEngine(ctx context.Context, sessionID string, op serverapi.SessionRuntimeOperation, fn func(*runtimepkg.Engine) error) error {
+	lease, err := r.BeginCollaborativeRuntimeGuard(ctx, sessionID, op)
+	if err != nil {
+		return err
+	}
+	defer lease.Release()
+	return fn(&runtimepkg.Engine{})
+}
+
+type serviceTestCollaborativeRuntimeAccess struct {
+	runtime   *serviceTestRuntime
+	sessionID string
+	once      sync.Once
+}
+
+func (a *serviceTestCollaborativeRuntimeAccess) Rebind(workspaceRoot string) error {
+	return a.runtime.RebindLocalTools(context.Background(), a.sessionID, "", workspaceRoot)
+}
+
+func (a *serviceTestCollaborativeRuntimeAccess) Release() {
+	a.once.Do(func() {
+		a.runtime.mu.Lock()
+		defer a.runtime.mu.Unlock()
+		if a.runtime.activeGuards > 0 {
+			a.runtime.activeGuards--
+		}
+		a.runtime.releasedGuards++
+	})
 }
 
 func (r *serviceTestRuntime) IsSessionRuntimeActive(sessionID string) bool {
@@ -510,6 +569,42 @@ func TestSwitchWorktreeClampsCwdAndRecordsPendingReminder(t *testing.T) {
 	}
 	if finalTarget.WorktreeID != "" || finalTarget.CwdRelpath != "." {
 		t.Fatalf("unexpected final target after switch: %+v", finalTarget)
+	}
+}
+
+func TestSwitchWorktreeCollaborativeRuntimeReusesScopedGuardForRebind(t *testing.T) {
+	env := newServiceTestEnv(t)
+	created := mustCreateWorktree(t, env, "feature/collaborative-scoped-rebind")
+	env.runtime.mu.Lock()
+	env.runtime.activeSessions[env.session.Meta().SessionID] = true
+	env.runtime.requireCalls = nil
+	env.runtime.rebindCalls = nil
+	env.runtime.reminderCalls = nil
+	env.runtime.releasedGuards = 0
+	env.runtime.mu.Unlock()
+
+	_, err := env.service.SwitchWorktree(env.ctx, serverapi.WorktreeSwitchRequest{
+		ClientRequestID: "req-switch-collaborative-scoped-rebind",
+		SessionID:       env.session.Meta().SessionID,
+		WorktreeID:      created.WorktreeID,
+	})
+	if err != nil {
+		t.Fatalf("SwitchWorktree collaborative: %v", err)
+	}
+	env.runtime.mu.Lock()
+	requireCalls := append([]serviceRuntimeCall(nil), env.runtime.requireCalls...)
+	rebindCalls := append([]serviceRuntimeCall(nil), env.runtime.rebindCalls...)
+	activeGuards := env.runtime.activeGuards
+	releasedGuards := env.runtime.releasedGuards
+	env.runtime.mu.Unlock()
+	if len(requireCalls) != 1 {
+		t.Fatalf("collaborative guard acquisitions = %d, want 1; calls=%+v", len(requireCalls), requireCalls)
+	}
+	if len(rebindCalls) != 1 || rebindCalls[0].root != created.CanonicalRoot {
+		t.Fatalf("collaborative rebind calls = %+v, want one rebind to %q", rebindCalls, created.CanonicalRoot)
+	}
+	if activeGuards != 0 || releasedGuards != 1 {
+		t.Fatalf("collaborative guard counts active=%d released=%d, want active=0 released=1", activeGuards, releasedGuards)
 	}
 }
 

--- a/shared/client/remote_rpc.go
+++ b/shared/client/remote_rpc.go
@@ -456,6 +456,8 @@ func protocolError(resp *protocol.ResponseError) error {
 		return errors.Join(serverapi.ErrInvalidControllerLease, errors.New(message))
 	case protocol.ErrCodeRuntimeUnavailable:
 		return errors.Join(serverapi.ErrRuntimeUnavailable, errors.New(message))
+	case protocol.ErrCodeActivePrimaryRun:
+		return errors.Join(serverapi.ErrActivePrimaryRun, errors.New(message))
 	case protocol.ErrCodeStreamUnavailable:
 		return errors.Join(serverapi.ErrStreamUnavailable, errors.New(message))
 	case protocol.ErrCodeStreamFailed:

--- a/shared/clientui/runtime.go
+++ b/shared/clientui/runtime.go
@@ -54,7 +54,15 @@ type RuntimeStatus struct {
 	ContextUsage                      RuntimeContextUsage
 	CompactionCount                   int
 	Goal                              *RuntimeGoal
+	WorkflowActive                    bool
+	WorkflowSession                   *WorkflowSessionStatus
 	Update                            UpdateStatus
+}
+
+type WorkflowSessionStatus struct {
+	RunID      string
+	TaskID     string
+	WorkflowID string
 }
 
 type UpdateStatus struct {
@@ -83,15 +91,31 @@ type RunView struct {
 	FinishedAt time.Time
 }
 
+type ExternalRuntimeState string
+
+const (
+	ExternalRuntimeStateRegisteredIdle ExternalRuntimeState = "registered_idle"
+	ExternalRuntimeStateOwnerRunning   ExternalRuntimeState = "owner_running"
+	ExternalRuntimeStateDraining       ExternalRuntimeState = "draining"
+	ExternalRuntimeStateClosing        ExternalRuntimeState = "closing"
+)
+
+type ExternalRuntimeStatus struct {
+	State          ExternalRuntimeState
+	QueueAccepting bool
+}
+
 type RuntimeMainView struct {
-	Status    RuntimeStatus
-	Session   RuntimeSessionView
-	ActiveRun *RunView
+	Status          RuntimeStatus
+	Session         RuntimeSessionView
+	ActiveRun       *RunView
+	ExternalRuntime *ExternalRuntimeStatus
 }
 
 type QueuedUserMessage struct {
-	ID   string
-	Text string
+	ID              string
+	Text            string
+	ClientRequestID string
 }
 
 type TranscriptMetadata struct {

--- a/shared/clientui/types.go
+++ b/shared/clientui/types.go
@@ -11,30 +11,32 @@ type EventKind string
 type TranscriptRecoveryCause string
 
 const (
-	EventConversationUpdated EventKind = "conversation_updated"
-	EventStreamGap           EventKind = "stream_gap"
-	EventAssistantDelta      EventKind = "assistant_delta"
-	EventAssistantDeltaReset EventKind = "assistant_delta_reset"
-	EventOngoingErrorUpdated EventKind = "ongoing_error_updated"
-	EventReasoningDelta      EventKind = "reasoning_delta"
-	EventReasoningDeltaReset EventKind = "reasoning_delta_reset"
-	EventAssistantMessage    EventKind = "assistant_message"
-	EventModelResponse       EventKind = "model_response_received"
-	EventUserMessageFlushed  EventKind = "user_message_flushed"
-	EventToolCallStarted     EventKind = "tool_call_started"
-	EventToolCallCompleted   EventKind = "tool_call_completed"
-	EventReviewerStarted     EventKind = "reviewer_started"
-	EventReviewerCompleted   EventKind = "reviewer_completed"
-	EventInFlightClearFailed EventKind = "in_flight_clear_failed"
-	EventCompactionStarted   EventKind = "context_compaction_started"
-	EventCompactionCompleted EventKind = "context_compaction_completed"
-	EventCompactionFailed    EventKind = "context_compaction_failed"
-	EventCacheWarning        EventKind = "cache_warning"
-	EventLocalEntryAdded     EventKind = "local_entry_added"
-	EventRunStateChanged     EventKind = "run_state_changed"
-	EventBackgroundUpdated   EventKind = "background_updated"
-	EventSleepGuardFailed    EventKind = "sleep_guard_failed"
-	EventGoalStatusUpdated   EventKind = "goal_status_updated"
+	EventConversationUpdated     EventKind = "conversation_updated"
+	EventStreamGap               EventKind = "stream_gap"
+	EventAssistantDelta          EventKind = "assistant_delta"
+	EventAssistantDeltaReset     EventKind = "assistant_delta_reset"
+	EventOngoingErrorUpdated     EventKind = "ongoing_error_updated"
+	EventReasoningDelta          EventKind = "reasoning_delta"
+	EventReasoningDeltaReset     EventKind = "reasoning_delta_reset"
+	EventAssistantMessage        EventKind = "assistant_message"
+	EventModelResponse           EventKind = "model_response_received"
+	EventUserMessageFlushed      EventKind = "user_message_flushed"
+	EventToolCallStarted         EventKind = "tool_call_started"
+	EventToolCallCompleted       EventKind = "tool_call_completed"
+	EventReviewerStarted         EventKind = "reviewer_started"
+	EventReviewerCompleted       EventKind = "reviewer_completed"
+	EventInFlightClearFailed     EventKind = "in_flight_clear_failed"
+	EventCompactionStarted       EventKind = "context_compaction_started"
+	EventCompactionCompleted     EventKind = "context_compaction_completed"
+	EventCompactionFailed        EventKind = "context_compaction_failed"
+	EventCacheWarning            EventKind = "cache_warning"
+	EventLocalEntryAdded         EventKind = "local_entry_added"
+	EventRunStateChanged         EventKind = "run_state_changed"
+	EventBackgroundUpdated       EventKind = "background_updated"
+	EventSleepGuardFailed        EventKind = "sleep_guard_failed"
+	EventGoalStatusUpdated       EventKind = "goal_status_updated"
+	EventQueuedUserMessageStatus EventKind = "queued_user_message_status"
+	EventExternalRuntimeStatus   EventKind = "external_runtime_status"
 
 	TranscriptRecoveryCauseNone         TranscriptRecoveryCause = ""
 	TranscriptRecoveryCauseStreamGap    TranscriptRecoveryCause = "stream_gap"
@@ -65,6 +67,8 @@ type Event struct {
 	ContextUsage                 *RuntimeContextUsage
 	Background                   *BackgroundShellEvent
 	GoalStatus                   *RuntimeGoalStatusUpdate
+	QueuedUserMessageStatus      *QueuedUserMessageStatusEvent
+	ExternalRuntimeStatus        *ExternalRuntimeStatus
 }
 
 type RuntimeGoalStatusUpdate struct {
@@ -72,6 +76,32 @@ type RuntimeGoalStatusUpdate struct {
 	Objective string
 	Status    RuntimeGoalStatus
 	Cleared   bool
+}
+
+type QueuedUserMessageStatus string
+
+const (
+	QueuedUserMessageAccepted  QueuedUserMessageStatus = "accepted"
+	QueuedUserMessageSubmitted QueuedUserMessageStatus = "submitted"
+	QueuedUserMessageFailed    QueuedUserMessageStatus = "failed"
+	QueuedUserMessageDiscarded QueuedUserMessageStatus = "discarded"
+)
+
+type QueuedUserMessageFailureReason string
+
+const (
+	QueuedUserMessageFailureClosing                    QueuedUserMessageFailureReason = "closing"
+	QueuedUserMessageFailureTerminalWorkflowCompletion QueuedUserMessageFailureReason = "terminal_workflow_completion"
+	QueuedUserMessageFailureRuntimeUnavailable         QueuedUserMessageFailureReason = "runtime_unavailable"
+)
+
+type QueuedUserMessageStatusEvent struct {
+	SessionID       string
+	QueueItemID     string
+	ClientRequestID string
+	Status          QueuedUserMessageStatus
+	FailureReason   QueuedUserMessageFailureReason
+	RestoreText     string
 }
 
 type CompactionStatus struct {

--- a/shared/protocol/jsonrpc.go
+++ b/shared/protocol/jsonrpc.go
@@ -37,6 +37,7 @@ const (
 	ErrCodeProtocolVersionMismatch       = -32025
 	ErrCodeWorkflowTaskCompleteAmbiguous = -32026
 	ErrCodeWorkflowTaskCompleteNotFound  = -32027
+	ErrCodeActivePrimaryRun              = -32028
 )
 
 type Request struct {

--- a/shared/serverapi/prompt_control.go
+++ b/shared/serverapi/prompt_control.go
@@ -35,8 +35,10 @@ func (r AskAnswerRequest) Validate() error {
 	if err := validateRequiredSessionID(r.SessionID); err != nil {
 		return err
 	}
-	if err := validateControllerLeaseID(r.ControllerLeaseID); err != nil {
-		return err
+	if strings.TrimSpace(r.ControllerLeaseID) != "" {
+		if err := validateControllerLeaseID(r.ControllerLeaseID); err != nil {
+			return err
+		}
 	}
 	if strings.TrimSpace(r.AskID) == "" {
 		return errors.New("ask_id is required")
@@ -51,8 +53,10 @@ func (r ApprovalAnswerRequest) Validate() error {
 	if err := validateRequiredSessionID(r.SessionID); err != nil {
 		return err
 	}
-	if err := validateControllerLeaseID(r.ControllerLeaseID); err != nil {
-		return err
+	if strings.TrimSpace(r.ControllerLeaseID) != "" {
+		if err := validateControllerLeaseID(r.ControllerLeaseID); err != nil {
+			return err
+		}
 	}
 	if strings.TrimSpace(r.ApprovalID) == "" {
 		return errors.New("approval_id is required")

--- a/shared/serverapi/runtime_control.go
+++ b/shared/serverapi/runtime_control.go
@@ -164,8 +164,9 @@ type RuntimeQueueUserMessageRequest struct {
 }
 
 type RuntimeQueueUserMessageResponse struct {
-	QueueItemID string `json:"queue_item_id"`
-	Text        string `json:"text"`
+	QueueItemID     string `json:"queue_item_id"`
+	Text            string `json:"text"`
+	ClientRequestID string `json:"client_request_id"`
 }
 
 type RuntimeDiscardQueuedUserMessageRequest struct {
@@ -258,6 +259,19 @@ func validateRuntimeControllerRequest(clientRequestID string, sessionID string, 
 	return validateControllerLeaseID(controllerLeaseID)
 }
 
+func validateRuntimeControlRequest(clientRequestID string, sessionID string, controllerLeaseID string) error {
+	if err := validateClientRequestID(clientRequestID); err != nil {
+		return err
+	}
+	if err := validateRequiredSessionID(sessionID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(controllerLeaseID) != "" {
+		return validateControllerLeaseID(controllerLeaseID)
+	}
+	return nil
+}
+
 func validateRuntimeGoalActionRequest(clientRequestID string, sessionID string, actor string) error {
 	if err := validateClientRequestID(clientRequestID); err != nil {
 		return err
@@ -269,22 +283,22 @@ func validateRuntimeGoalActionRequest(clientRequestID string, sessionID string, 
 }
 
 func (r RuntimeSetSessionNameRequest) Validate() error {
-	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
+	return validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeSetThinkingLevelRequest) Validate() error {
-	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
+	return validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeSetFastModeEnabledRequest) Validate() error {
-	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
+	return validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeSetReviewerEnabledRequest) Validate() error {
 	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeSetAutoCompactionEnabledRequest) Validate() error {
-	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
+	return validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeSetQuestionsEnabledRequest) Validate() error {
-	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
+	return validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeAppendCommittedEntryRequest) Validate() error {
 	if err := validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID); err != nil {
@@ -302,31 +316,31 @@ func (r RuntimeSubmitUserMessageRequest) Validate() error {
 	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeSubmitUserTurnRequest) Validate() error {
-	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
+	return validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeSubmitUserShellCommandRequest) Validate() error {
 	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeCompactContextRequest) Validate() error {
-	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
+	return validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeCompactContextForPreSubmitRequest) Validate() error {
-	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
+	return validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeHasQueuedUserWorkRequest) Validate() error {
 	return validateRequiredSessionID(r.SessionID)
 }
 func (r RuntimeSubmitQueuedUserMessagesRequest) Validate() error {
-	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
+	return validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeInterruptRequest) Validate() error {
 	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeQueueUserMessageRequest) Validate() error {
-	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
+	return validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeDiscardQueuedUserMessageRequest) Validate() error {
-	if err := validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID); err != nil {
+	if err := validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID); err != nil {
 		return err
 	}
 	if strings.TrimSpace(r.QueueItemID) == "" {
@@ -335,16 +349,13 @@ func (r RuntimeDiscardQueuedUserMessageRequest) Validate() error {
 	return nil
 }
 func (r RuntimeRecordPromptHistoryRequest) Validate() error {
-	return validateRuntimeControllerRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
+	return validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID)
 }
 func (r RuntimeGoalShowRequest) Validate() error {
 	return validateRequiredSessionID(r.SessionID)
 }
 func (r RuntimeGoalSetRequest) Validate() error {
-	if err := validateClientRequestID(r.ClientRequestID); err != nil {
-		return err
-	}
-	if err := validateRequiredSessionID(r.SessionID); err != nil {
+	if err := validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID); err != nil {
 		return err
 	}
 	if strings.TrimSpace(r.Objective) == "" {
@@ -353,8 +364,14 @@ func (r RuntimeGoalSetRequest) Validate() error {
 	return validateGoalActor(r.Actor)
 }
 func (r RuntimeGoalStatusRequest) Validate() error {
-	return validateRuntimeGoalActionRequest(r.ClientRequestID, r.SessionID, r.Actor)
+	if err := validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID); err != nil {
+		return err
+	}
+	return validateGoalActor(r.Actor)
 }
 func (r RuntimeGoalClearRequest) Validate() error {
-	return validateRuntimeGoalActionRequest(r.ClientRequestID, r.SessionID, r.Actor)
+	if err := validateRuntimeControlRequest(r.ClientRequestID, r.SessionID, r.ControllerLeaseID); err != nil {
+		return err
+	}
+	return validateGoalActor(r.Actor)
 }

--- a/shared/serverapi/session_control_errors.go
+++ b/shared/serverapi/session_control_errors.go
@@ -5,3 +5,4 @@ import "errors"
 var ErrSessionAlreadyControlled = errors.New("session is already controlled by another client")
 var ErrInvalidControllerLease = errors.New("controller lease is invalid or expired")
 var ErrRuntimeUnavailable = errors.New("session runtime is unavailable")
+var ErrActivePrimaryRun = errors.New("session already has an active primary run")

--- a/shared/serverapi/session_runtime.go
+++ b/shared/serverapi/session_runtime.go
@@ -17,8 +17,63 @@ type SessionRuntimeActivateRequest struct {
 }
 
 type SessionRuntimeActivateResponse struct {
-	LeaseID  string `json:"lease_id"`
-	ReadOnly bool   `json:"read_only,omitempty"`
+	LeaseID           string                    `json:"lease_id"`
+	Mode              SessionRuntimeAttachMode  `json:"mode,omitempty"`
+	AllowedOperations []SessionRuntimeOperation `json:"allowed_operations,omitempty"`
+	ReadOnly          bool                      `json:"read_only,omitempty"`
+}
+
+type SessionRuntimeAttachMode string
+
+const (
+	SessionRuntimeAttachModeController    SessionRuntimeAttachMode = "controller"
+	SessionRuntimeAttachModeCollaborative SessionRuntimeAttachMode = "collaborative"
+	SessionRuntimeAttachModeNoControl     SessionRuntimeAttachMode = "no_control"
+)
+
+type SessionRuntimeOperation string
+
+const (
+	SessionRuntimeOperationSubmitUserTurn           SessionRuntimeOperation = "runtime.submit_user_turn"
+	SessionRuntimeOperationQueueUserMessage         SessionRuntimeOperation = "runtime.queue_user_message"
+	SessionRuntimeOperationSubmitQueuedUserMessages SessionRuntimeOperation = "runtime.submit_queued_user_messages"
+	SessionRuntimeOperationDiscardQueuedUserMessage SessionRuntimeOperation = "runtime.discard_queued_user_message"
+	SessionRuntimeOperationRecordPromptHistory      SessionRuntimeOperation = "runtime.record_prompt_history"
+	SessionRuntimeOperationPromptAnswer             SessionRuntimeOperation = "prompt.answer"
+	SessionRuntimeOperationSettingsSessionName      SessionRuntimeOperation = "settings.session_name"
+	SessionRuntimeOperationSettingsThinkingLevel    SessionRuntimeOperation = "settings.thinking_level"
+	SessionRuntimeOperationSettingsFastMode         SessionRuntimeOperation = "settings.fast_mode"
+	SessionRuntimeOperationSettingsQuestions        SessionRuntimeOperation = "settings.questions"
+	SessionRuntimeOperationSettingsAutoCompaction   SessionRuntimeOperation = "settings.auto_compaction"
+	SessionRuntimeOperationCompactManual            SessionRuntimeOperation = "runtime.compact_manual"
+	SessionRuntimeOperationCompactPreSubmit         SessionRuntimeOperation = "runtime.compact_pre_submit"
+	SessionRuntimeOperationWorktreeManage           SessionRuntimeOperation = "worktree.manage"
+	SessionRuntimeOperationProcessView              SessionRuntimeOperation = "process.view"
+	SessionRuntimeOperationGoalManage               SessionRuntimeOperation = "goal.manage"
+)
+
+func CollaborativeSessionRuntimeOperations(workflowSession bool) []SessionRuntimeOperation {
+	operations := []SessionRuntimeOperation{
+		SessionRuntimeOperationSubmitUserTurn,
+		SessionRuntimeOperationQueueUserMessage,
+		SessionRuntimeOperationSubmitQueuedUserMessages,
+		SessionRuntimeOperationDiscardQueuedUserMessage,
+		SessionRuntimeOperationRecordPromptHistory,
+		SessionRuntimeOperationPromptAnswer,
+		SessionRuntimeOperationSettingsSessionName,
+		SessionRuntimeOperationSettingsThinkingLevel,
+		SessionRuntimeOperationSettingsFastMode,
+		SessionRuntimeOperationSettingsQuestions,
+		SessionRuntimeOperationSettingsAutoCompaction,
+		SessionRuntimeOperationCompactManual,
+		SessionRuntimeOperationCompactPreSubmit,
+		SessionRuntimeOperationWorktreeManage,
+		SessionRuntimeOperationProcessView,
+	}
+	if !workflowSession {
+		operations = append(operations, SessionRuntimeOperationGoalManage)
+	}
+	return operations
 }
 
 type SessionRuntimeReleaseRequest struct {

--- a/shared/serverapi/worktree.go
+++ b/shared/serverapi/worktree.go
@@ -111,7 +111,7 @@ func (r WorktreeListRequest) Validate() error {
 	if err := validateRequiredSessionID(r.SessionID); err != nil {
 		return err
 	}
-	return validateControllerLeaseID(r.ControllerLeaseID)
+	return nil
 }
 
 func (r WorktreeCreateTargetResolveRequest) Validate() error {
@@ -129,9 +129,6 @@ func (r WorktreeCreateRequest) Validate() error {
 		return err
 	}
 	if err := validateRequiredSessionID(r.SessionID); err != nil {
-		return err
-	}
-	if err := validateControllerLeaseID(r.ControllerLeaseID); err != nil {
 		return err
 	}
 	if r.CreateBranch {
@@ -159,9 +156,6 @@ func (r WorktreeSwitchRequest) Validate() error {
 	if err := validateRequiredSessionID(r.SessionID); err != nil {
 		return err
 	}
-	if err := validateControllerLeaseID(r.ControllerLeaseID); err != nil {
-		return err
-	}
 	if strings.TrimSpace(r.WorktreeID) == "" {
 		return errors.New("worktree_id is required")
 	}
@@ -173,9 +167,6 @@ func (r WorktreeDeleteRequest) Validate() error {
 		return err
 	}
 	if err := validateRequiredSessionID(r.SessionID); err != nil {
-		return err
-	}
-	if err := validateControllerLeaseID(r.ControllerLeaseID); err != nil {
 		return err
 	}
 	if strings.TrimSpace(r.WorktreeID) == "" {


### PR DESCRIPTION
## Summary
- Adds collaborative attach mode for externally owned active runtimes so TUI operators can steer/queue messages, answer prompts, and use explicitly allowed controls without taking controller ownership.
- Preserves workflow completion authority and goal/autocompaction restrictions for workflow-marked sessions, including durable workflow state.
- Hardens runtime replacement/close-drain lifecycle, queued-message status correlation, external-owner busy fallback, primary-run owner serialization, prompt/worktree guarded access, and background router ownership cleanup.
- Updates BUI-17 specs in docs/dev/specs/core-runtime-tools.md and docs/dev/specs/workflow-orchestration.md.

## Verification
- ./scripts/test.sh ./shared/serverapi ./shared/clientui ./shared/client ./server/core ./server/registry ./server/runtimewire ./server/sessionruntime ./server/runtimecontrol ./server/promptcontrol ./server/runtime ./server/runprompt ./server/sessionview ./server/runtimeview ./server/worktree ./server/workflowrunner ./server/transport ./server/tools/shell ./server/tools/shell/postprocess ./cli/app ./cli/app/internal/runtimeattach ./cli/app/internal/runtimestate ./cli/app/internal/worktreeui
- ./scripts/test.sh
- ./scripts/build.sh --output ./bin/kent && ./bin/kent -version (2.0.0)
- Focused go test suites for collaborative attach/read-only/external-owner queueing/goal/prompt/workflow completion regressions
- pnpm --dir apps/desktop test -- WorkflowLibraryRoute.test.tsx
- pnpm --dir apps/desktop lint
- git diff --check && git diff --cached --check
- non-mutating TUI launch smoke against active workflow session

Closes #364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added collaborative runtime attachment mode enabling limited-control session access with permission-based operations
  * Extended queued message handling with client request tracking and status lifecycle (accepted/submitted/failed)
  * Added external runtime status visibility showing owner activity and queue state
  * Improved workflow session tracking with terminal completion state

* **Tests**
  * Expanded test coverage for collaborative runtime scenarios and queued message lifecycle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->