### PR TITLE
fix: animate worktree deletion spinner

### DIFF
--- a/cli/app/ui_worktree_commands_test.go
+++ b/cli/app/ui_worktree_commands_test.go
@@ -687,6 +687,116 @@ func TestWorktreeCreateDialogSubmitResolvesTargetWithBoundedContext(t *testing.T
 	}
 }
 
+func TestWorktreeCreateTargetResolutionSubmitSchedulesSpinnerTick(t *testing.T) {
+	withDeterministicSpinnerClock(t)
+
+	client := &worktreeCommandTestClient{
+		listResp:   testMainWorktreeListResponse(),
+		createResp: serverapi.WorktreeCreateResponse{Target: clientui.SessionExecutionTarget{EffectiveWorkdir: "/repo"}, Worktree: serverapi.WorktreeView{WorktreeID: "wt-main", DisplayName: "main", CanonicalRoot: "/repo"}},
+	}
+	updated, cmd := submitWorktreeCreateAfterTargetResolution(t, client)
+	if !updated.worktrees.create.submitting {
+		t.Fatal("expected create submitting state")
+	}
+	if updated.spinnerTickToken == 0 {
+		t.Fatal("expected create submit to start spinner ticking")
+	}
+	if updated.spinnerTickDue.IsZero() {
+		t.Fatal("expected create submit to record spinner tick deadline")
+	}
+
+	msgs := collectCmdMessages(t, cmd)
+	sawCreateDone := false
+	sawSpinnerTick := false
+	for _, msg := range msgs {
+		switch typed := msg.(type) {
+		case worktreeCreateDoneMsg:
+			sawCreateDone = true
+		case spinnerTickMsg:
+			if typed.token != updated.spinnerTickToken {
+				t.Fatalf("spinner tick token = %d, want %d", typed.token, updated.spinnerTickToken)
+			}
+			sawSpinnerTick = true
+		}
+	}
+	if !sawCreateDone {
+		t.Fatalf("expected returned command to emit create completion, got %+v", msgs)
+	}
+	if !sawSpinnerTick {
+		t.Fatalf("expected returned command to emit spinner tick, got %+v", msgs)
+	}
+	if len(client.createRequests) != 1 {
+		t.Fatalf("expected one create request, got %+v", client.createRequests)
+	}
+}
+
+func TestWorktreeCreateCompletionStopsSpinnerAfterOverlayError(t *testing.T) {
+	withDeterministicSpinnerClock(t)
+
+	client := &worktreeCommandTestClient{
+		listResp:   testMainWorktreeListResponse(),
+		createErr:  errors.New("create failed"),
+		createResp: serverapi.WorktreeCreateResponse{Target: clientui.SessionExecutionTarget{EffectiveWorkdir: "/repo"}, Worktree: serverapi.WorktreeView{WorktreeID: "wt-main", DisplayName: "main", CanonicalRoot: "/repo"}},
+	}
+	updated, cmd := submitWorktreeCreateAfterTargetResolution(t, client)
+	if updated.spinnerTickToken == 0 {
+		t.Fatal("expected create submit to start spinner ticking")
+	}
+	var done worktreeCreateDoneMsg
+	foundDone := false
+	for _, msg := range collectCmdMessages(t, cmd) {
+		if typed, ok := msg.(worktreeCreateDoneMsg); ok {
+			done = typed
+			foundDone = true
+		}
+	}
+	if !foundDone {
+		t.Fatal("expected create completion from command")
+	}
+
+	next, _ := updated.Update(done)
+	completed := next.(*uiModel)
+	if completed.worktrees.create.submitting {
+		t.Fatal("expected create completion to clear submitting state")
+	}
+	if completed.spinnerTickToken != 0 {
+		t.Fatalf("expected create error completion to stop spinner ticking, got token %d", completed.spinnerTickToken)
+	}
+}
+
+func submitWorktreeCreateAfterTargetResolution(t *testing.T, client *worktreeCommandTestClient) (*uiModel, tea.Cmd) {
+	t.Helper()
+	m := newWorktreeTestModel(t, client)
+	m.input = "/worktree create"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := applyWorktreeCmdMessages(t, next.(*uiModel), cmd)
+	updated.worktrees.create.branchTarget.Replace(strings.NewReplacer("\r", "", "\n", "").Replace("main"))
+	updated.worktrees.create.focus = uiWorktreeCreateFieldActions
+	updated.worktrees.create.action = uiWorktreeCreateActionCreate
+	updated.worktrees.create.syncFocus()
+
+	next, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected create target resolution command")
+	}
+
+	next, cmd = updated.Update(worktreeCreateTargetResolveDoneMsg{
+		token: updated.worktrees.create.resolveToken,
+		query: "main",
+		resp: serverapi.WorktreeCreateTargetResolveResponse{Resolution: serverapi.WorktreeCreateTargetResolution{
+			Input: "main",
+			Kind:  serverapi.WorktreeCreateTargetResolutionKindExistingBranch,
+		}},
+	})
+	updated = next.(*uiModel)
+	if cmd == nil {
+		t.Fatal("expected create command after target resolution")
+	}
+	return updated, cmd
+}
+
 func TestWorktreeCreateDialogLayoutStaysStableAcrossResolutionStates(t *testing.T) {
 	client := &worktreeCommandTestClient{listResp: testMainWorktreeListResponse()}
 	m := newWorktreeTestModel(t, client)

--- a/cli/app/ui_worktree_delete_controller.go
+++ b/cli/app/ui_worktree_delete_controller.go
@@ -75,10 +75,12 @@ func (c uiInputController) handleWorktreeDeleteDialogKey(msg tea.KeyMsg) (tea.Mo
 		case uiWorktreeDeleteActionCancel:
 			m.closeWorktreeDialog()
 			return m, nil
-		case uiWorktreeDeleteActionDelete:
-			return m, m.worktreeDeleteCmd(dialog.target, false)
-		case uiWorktreeDeleteActionDeleteBranch:
-			return m, m.worktreeDeleteCmd(dialog.target, true)
+		case uiWorktreeDeleteActionDelete, uiWorktreeDeleteActionDeleteBranch:
+			deleteBranch := dialog.selectedAction == uiWorktreeDeleteActionDeleteBranch
+			deleteCmd := m.worktreeDeleteCmd(dialog.target, deleteBranch)
+			return m, tea.Batch(deleteCmd, m.reconcileSpinnerTicking(false))
+		default:
+			return m, nil
 		}
 	}
 	return m, nil

--- a/cli/app/ui_worktree_delete_controller_test.go
+++ b/cli/app/ui_worktree_delete_controller_test.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"core/shared/serverapi"
 
@@ -29,6 +31,19 @@ func newWorktreeDeleteControllerTestModel(t *testing.T, client *worktreeCommandT
 func applyWorktreeDeleteControllerKey(model *uiModel, key tea.KeyMsg) (*uiModel, tea.Cmd) {
 	next, cmd := uiInputController{model: model}.handleWorktreeDeleteDialogKey(key)
 	return next.(*uiModel), cmd
+}
+
+func withDeterministicSpinnerClock(t *testing.T) {
+	t.Helper()
+	oldNow := uiAnimationNow
+	oldInterval := spinnerTickInterval
+	anchor := time.Unix(1_700_010_000, 0)
+	uiAnimationNow = func() time.Time { return anchor }
+	spinnerTickInterval = time.Millisecond
+	t.Cleanup(func() {
+		uiAnimationNow = oldNow
+		spinnerTickInterval = oldInterval
+	})
 }
 
 func TestWorktreeDeleteControllerEscapeAndCancelCloseDialog(t *testing.T) {
@@ -70,7 +85,170 @@ func TestWorktreeDeleteControllerCyclesActions(t *testing.T) {
 	}
 }
 
+func TestWorktreeDeleteControllerSubmitSchedulesSpinnerTick(t *testing.T) {
+	withDeterministicSpinnerClock(t)
+
+	tests := []struct {
+		name         string
+		action       uiWorktreeDeleteAction
+		deleteBranch bool
+	}{
+		{name: "delete worktree", action: uiWorktreeDeleteActionDelete, deleteBranch: false},
+		{name: "delete worktree and branch", action: uiWorktreeDeleteActionDeleteBranch, deleteBranch: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &worktreeCommandTestClient{listResp: testMainWorktreeListResponse()}
+			model := newWorktreeDeleteControllerTestModel(t, client)
+			model.worktrees.deleteConfirm.selectedAction = tt.action
+
+			updated, cmd := applyWorktreeDeleteControllerKey(model, tea.KeyMsg{Type: tea.KeyEnter})
+			if cmd == nil {
+				t.Fatal("expected delete command")
+			}
+			if !updated.worktrees.deleteConfirm.submitting {
+				t.Fatal("expected delete submitting state")
+			}
+			if updated.spinnerTickToken == 0 {
+				t.Fatal("expected delete submit to start spinner ticking")
+			}
+			if updated.spinnerTickDue.IsZero() {
+				t.Fatal("expected delete submit to record spinner tick deadline")
+			}
+
+			msgs := collectCmdMessages(t, cmd)
+			sawDeleteDone := false
+			sawSpinnerTick := false
+			for _, msg := range msgs {
+				switch typed := msg.(type) {
+				case worktreeDeleteDoneMsg:
+					sawDeleteDone = true
+				case spinnerTickMsg:
+					if typed.token != updated.spinnerTickToken {
+						t.Fatalf("spinner tick token = %d, want %d", typed.token, updated.spinnerTickToken)
+					}
+					sawSpinnerTick = true
+				}
+			}
+			if !sawDeleteDone {
+				t.Fatalf("expected returned command to emit delete completion, got %+v", msgs)
+			}
+			if !sawSpinnerTick {
+				t.Fatalf("expected returned command to emit spinner tick, got %+v", msgs)
+			}
+			if len(client.deleteRequests) != 1 {
+				t.Fatalf("delete requests = %d, want 1", len(client.deleteRequests))
+			}
+			if got := client.deleteRequests[0]; got.WorktreeID != "wt-feature" || got.DeleteBranch != tt.deleteBranch {
+				t.Fatalf("delete request = %+v, want deleteBranch=%t for wt-feature", got, tt.deleteBranch)
+			}
+		})
+	}
+}
+
+func TestWorktreeDeleteControllerPendingSpinnerAdvancesFromReturnedTick(t *testing.T) {
+	oldNow := uiAnimationNow
+	oldInterval := spinnerTickInterval
+	spinnerTickInterval = 20 * time.Millisecond
+	uiAnimationNow = func() time.Time { return time.Now().Add(-3 * spinnerTickInterval) }
+	t.Cleanup(func() {
+		uiAnimationNow = oldNow
+		spinnerTickInterval = oldInterval
+	})
+
+	client := &worktreeCommandTestClient{listResp: testMainWorktreeListResponse()}
+	model := newWorktreeDeleteControllerTestModel(t, client)
+	model.worktrees.deleteConfirm.selectedAction = uiWorktreeDeleteActionDelete
+
+	updated, cmd := applyWorktreeDeleteControllerKey(model, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected delete command")
+	}
+	initialFrame := updated.spinnerFrame
+	var tick spinnerTickMsg
+	foundTick := false
+	for _, msg := range collectCmdMessages(t, cmd) {
+		if typed, ok := msg.(spinnerTickMsg); ok {
+			tick = typed
+			foundTick = true
+		}
+	}
+	if !foundTick {
+		t.Fatal("expected returned delete command to emit spinner tick")
+	}
+
+	next, _ := updated.Update(tick)
+	advanced := next.(*uiModel)
+	if !advanced.worktrees.deleteConfirm.submitting {
+		t.Fatal("expected delete to remain submitting after spinner tick")
+	}
+	if advanced.spinnerFrame == initialFrame {
+		t.Fatalf("expected spinner frame to advance from %d after returned tick", initialFrame)
+	}
+}
+
+func TestWorktreeDeleteCompletionStopsSpinnerAfterOverlayError(t *testing.T) {
+	withDeterministicSpinnerClock(t)
+
+	client := &worktreeCommandTestClient{
+		listResp:  testMainWorktreeListResponse(),
+		deleteErr: errors.New("delete failed"),
+	}
+	model := newWorktreeDeleteControllerTestModel(t, client)
+	model.worktrees.deleteConfirm.selectedAction = uiWorktreeDeleteActionDelete
+
+	updated, cmd := applyWorktreeDeleteControllerKey(model, tea.KeyMsg{Type: tea.KeyEnter})
+	if updated.spinnerTickToken == 0 {
+		t.Fatal("expected delete submit to start spinner ticking")
+	}
+	done, ok := findWorktreeDeleteDoneMsg(collectCmdMessages(t, cmd))
+	if !ok {
+		t.Fatal("expected delete completion from command")
+	}
+
+	next, _ := updated.Update(done)
+	completed := next.(*uiModel)
+	if completed.worktrees.deleteConfirm.submitting {
+		t.Fatal("expected delete completion to clear submitting state")
+	}
+	if completed.spinnerTickToken != 0 {
+		t.Fatalf("expected delete error completion to stop spinner ticking, got token %d", completed.spinnerTickToken)
+	}
+}
+
+func TestWorktreeDeleteCompletionPreservesSpinnerForFollowUpListLoading(t *testing.T) {
+	withDeterministicSpinnerClock(t)
+
+	client := &worktreeCommandTestClient{listResp: testMainWorktreeListResponse()}
+	model := newWorktreeDeleteControllerTestModel(t, client)
+	model.worktrees.deleteConfirm.selectedAction = uiWorktreeDeleteActionDelete
+
+	updated, cmd := applyWorktreeDeleteControllerKey(model, tea.KeyMsg{Type: tea.KeyEnter})
+	if updated.spinnerTickToken == 0 {
+		t.Fatal("expected delete submit to start spinner ticking")
+	}
+	done, ok := findWorktreeDeleteDoneMsg(collectCmdMessages(t, cmd))
+	if !ok {
+		t.Fatal("expected delete completion from command")
+	}
+
+	next, _ := updated.Update(done)
+	completed := next.(*uiModel)
+	if completed.worktrees.deleteConfirm.submitting {
+		t.Fatal("expected delete completion to clear submitting state")
+	}
+	if !completed.worktrees.loading {
+		t.Fatal("expected delete success in overlay to start follow-up list loading")
+	}
+	if completed.spinnerTickToken == 0 {
+		t.Fatal("expected spinner ticking to continue for follow-up list loading")
+	}
+}
+
 func TestWorktreeDeleteControllerSubmitsDelete(t *testing.T) {
+	withDeterministicSpinnerClock(t)
+
 	client := &worktreeCommandTestClient{listResp: testMainWorktreeListResponse()}
 	model := newWorktreeDeleteControllerTestModel(t, client)
 	model.worktrees.deleteConfirm.selectedAction = uiWorktreeDeleteActionDelete
@@ -82,9 +260,9 @@ func TestWorktreeDeleteControllerSubmitsDelete(t *testing.T) {
 	if !updated.worktrees.deleteConfirm.submitting {
 		t.Fatal("expected delete submitting state")
 	}
-	result := cmd()
-	if _, ok := result.(worktreeDeleteDoneMsg); !ok {
-		t.Fatalf("command message type = %T, want worktreeDeleteDoneMsg", result)
+	msgs := collectCmdMessages(t, cmd)
+	if !hasWorktreeDeleteDoneMsg(msgs) {
+		t.Fatalf("expected worktreeDeleteDoneMsg, got %+v", msgs)
 	}
 	if len(client.deleteRequests) != 1 {
 		t.Fatalf("delete requests = %d, want 1", len(client.deleteRequests))
@@ -95,6 +273,8 @@ func TestWorktreeDeleteControllerSubmitsDelete(t *testing.T) {
 }
 
 func TestWorktreeDeleteControllerSubmitsDeleteBranch(t *testing.T) {
+	withDeterministicSpinnerClock(t)
+
 	client := &worktreeCommandTestClient{listResp: testMainWorktreeListResponse()}
 	model := newWorktreeDeleteControllerTestModel(t, client)
 	model.worktrees.deleteConfirm.selectedAction = uiWorktreeDeleteActionDeleteBranch
@@ -103,7 +283,10 @@ func TestWorktreeDeleteControllerSubmitsDeleteBranch(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected delete-branch command")
 	}
-	_ = cmd()
+	msgs := collectCmdMessages(t, cmd)
+	if !hasWorktreeDeleteDoneMsg(msgs) {
+		t.Fatalf("expected worktreeDeleteDoneMsg, got %+v", msgs)
+	}
 	if len(client.deleteRequests) != 1 {
 		t.Fatalf("delete requests = %d, want 1", len(client.deleteRequests))
 	}
@@ -113,6 +296,8 @@ func TestWorktreeDeleteControllerSubmitsDeleteBranch(t *testing.T) {
 }
 
 func TestWorktreeDeleteControllerUpdateRoutesToDeleteDialog(t *testing.T) {
+	withDeterministicSpinnerClock(t)
+
 	client := &worktreeCommandTestClient{listResp: testMainWorktreeListResponse()}
 	model := newWorktreeDeleteControllerTestModel(t, client)
 	model.worktrees.deleteConfirm.selectedAction = uiWorktreeDeleteActionDelete
@@ -125,11 +310,25 @@ func TestWorktreeDeleteControllerUpdateRoutesToDeleteDialog(t *testing.T) {
 	if !updated.worktrees.deleteConfirm.submitting {
 		t.Fatal("expected submitting state through uiModel.Update")
 	}
-	result := cmd()
-	if _, ok := result.(worktreeDeleteDoneMsg); !ok {
-		t.Fatalf("command message type = %T, want worktreeDeleteDoneMsg", result)
+	msgs := collectCmdMessages(t, cmd)
+	if !hasWorktreeDeleteDoneMsg(msgs) {
+		t.Fatalf("expected worktreeDeleteDoneMsg, got %+v", msgs)
 	}
 	if len(client.deleteRequests) != 1 || client.deleteRequests[0].WorktreeID != "wt-feature" {
 		t.Fatalf("delete requests = %+v, want wt-feature delete", client.deleteRequests)
 	}
+}
+
+func hasWorktreeDeleteDoneMsg(msgs []tea.Msg) bool {
+	_, ok := findWorktreeDeleteDoneMsg(msgs)
+	return ok
+}
+
+func findWorktreeDeleteDoneMsg(msgs []tea.Msg) (worktreeDeleteDoneMsg, bool) {
+	for _, msg := range msgs {
+		if typed, ok := msg.(worktreeDeleteDoneMsg); ok {
+			return typed, true
+		}
+	}
+	return worktreeDeleteDoneMsg{}, false
 }

--- a/cli/app/ui_worktree_reducer.go
+++ b/cli/app/ui_worktree_reducer.go
@@ -154,7 +154,8 @@ func (r uiWorktreeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 				m.layout().syncViewport()
 				return handledUIFeatureUpdate(m, nil)
 			}
-			return handledUIFeatureUpdate(m, m.worktreeCreateCmd(req))
+			createCmd := m.worktreeCreateCmd(req)
+			return handledUIFeatureUpdate(m, tea.Batch(createCmd, m.reconcileSpinnerTicking(false)))
 		}
 		return handledUIFeatureUpdate(m, nil)
 	}


### PR DESCRIPTION
## Summary
- Batch worktree delete submissions with the existing global spinner tick reconciliation so delete and delete+branch pending states receive real spinner ticks.
- Apply the same mutation-start lifecycle fix to create submission after target resolution.
- Add focused tests for emitted spinnerTickMsg commands, visible frame advancement from the actual returned tick, batched delete request semantics, and completion stop/preserve behavior.

## Verification
- `./scripts/test.sh ./cli/app -run 'TestWorktreeDelete|Test.*Spinner|TestWorktreeCreateTargetResolutionSubmitSchedulesSpinnerTick|TestWorktreeCreateCompletionStopsSpinnerAfterOverlayError'`\n- `./scripts/test.sh ./cli/app`\n- `./scripts/build.sh --output ./bin/kent`\n- `git diff --check`\n\n## QA Evidence\n- Plan/acceptance criteria: `/Users/nek/.kent/worktrees/builder-cli-c2f75fc8-68f5-4deb-a23c-21cc5820436d/BUI-81/.builder/plans/BUI-81-worktree-delete-spinner.md`\n- Prior manual TUI run: `/var/folders/4y/3b8zshg92kn3ryxd1x2f1rs00000gn/T/kent-bg-shells-2825512374/1760.log` showed animated create/delete spinner frames and cleanup status.\n- Prior full test evidence: `/var/folders/4y/3b8zshg92kn3ryxd1x2f1rs00000gn/T/kent-bg-shells-2825512374/1830.log` and targeted rerun `/var/folders/4y/3b8zshg92kn3ryxd1x2f1rs00000gn/T/kent-bg-shells-2825512374/1870.log` documented an unrelated GUI timeout; this PR was verified with the Go package test and build commands above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spinner behavior and state management during worktree creation and deletion operations to ensure consistent UI feedback.
  * Fixed spinner tick scheduling and stopping logic when operations complete with errors.

* **Tests**
  * Added comprehensive test coverage for worktree operation workflows and spinner animation timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->