### PR TITLE
fix: keep missing inputs dialog usable

### DIFF
--- a/apps/desktop/src/features/board/BoardDropActions.test.ts
+++ b/apps/desktop/src/features/board/BoardDropActions.test.ts
@@ -38,6 +38,38 @@ describe("classifyDrop", () => {
       ),
     ).toEqual({ kind: "move" });
   });
+
+  it("moves terminal targets without collecting transition output values", () => {
+    expect(
+      classifyDrop(
+        {
+          ...baseColumn,
+          id: "node-terminal",
+          isDone: true,
+          kind: "terminal",
+          transitionOutputFields: [{ name: "summary", description: "Summary" }],
+        },
+        { ...baseDragPayload, manualMoveTargetNodeIDs: [] },
+        undefined,
+      ),
+    ).toEqual({ kind: "move", allowMissingEdge: true });
+  });
+
+  it("collects transition output values for non-terminal targets", () => {
+    expect(
+      classifyDrop(
+        {
+          ...baseColumn,
+          id: "node-review",
+          isDone: false,
+          kind: "agent",
+          transitionOutputFields: [{ name: "summary", description: "Summary" }],
+        },
+        { ...baseDragPayload, manualMoveTargetNodeIDs: [] },
+        undefined,
+      ),
+    ).toEqual({ kind: "missingInput" });
+  });
 });
 
 const baseDragPayload: BoardCardDragPayload = {

--- a/apps/desktop/src/features/board/BoardDropActions.ts
+++ b/apps/desktop/src/features/board/BoardDropActions.ts
@@ -40,6 +40,9 @@ export function classifyDrop(
   if (dragPayload.statusKind === "done" && column.kind === "agent") {
     return { kind: "confirmRollback" };
   }
+  if (isTerminalColumn(column)) {
+    return { kind: "move", allowMissingEdge: true };
+  }
   if (column.transitionOutputFields.length > 0) {
     return { kind: "missingInput" };
   }
@@ -51,4 +54,8 @@ export function classifyDrop(
 
 export function missingInputValues(fields: readonly WorkflowOutputField[]): Readonly<Record<string, string>> {
   return Object.fromEntries(fields.map((field) => [field.name, ""]));
+}
+
+function isTerminalColumn(column: BoardColumn): boolean {
+  return column.isDone || column.kind === "terminal";
 }

--- a/apps/desktop/src/features/board/BoardDropDialogs.test.tsx
+++ b/apps/desktop/src/features/board/BoardDropDialogs.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, within } from "@testing-library/react";
+import { I18nextProvider } from "react-i18next";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { appI18n, initializeI18n } from "../../i18n/setup";
+import type { PendingMissingInputDrop } from "./BoardDropActions";
+import { MissingInputsDialog } from "./BoardDropDialogs";
+
+describe("MissingInputsDialog", () => {
+  beforeAll(async () => {
+    await initializeI18n();
+  });
+
+  it("keeps many required fields in a bounded field list with reachable actions", () => {
+    render(
+      <I18nextProvider i18n={appI18n}>
+        <MissingInputsDialog
+          drop={missingInputDrop}
+          onClose={vi.fn()}
+          onSubmit={vi.fn()}
+          onValueChange={vi.fn()}
+        />
+      </I18nextProvider>,
+    );
+
+    const form = screen.getByTestId("missing-inputs-dialog-form");
+    const fieldList = screen.getByTestId("missing-inputs-field-list");
+    const actions = screen.getByTestId("missing-inputs-dialog-actions");
+    const textareas = within(fieldList).getAllByRole("textbox");
+
+    expect(textareas).toHaveLength(missingInputDrop.fields.length);
+    expect(textareas.every((textarea) => textarea.getAttribute("rows") === "2")).toBe(true);
+    expect(within(fieldList).queryAllByRole("button")).toHaveLength(0);
+    expect(within(actions).getAllByRole("button")).toHaveLength(2);
+    expect(form).toContainElement(fieldList);
+    expect(form).toContainElement(actions);
+  });
+});
+
+const fields = Array.from({ length: 12 }, (_, index) => {
+  const fieldNumber = String(index + 1);
+  return {
+    description: `Description ${fieldNumber}`,
+    name: `field_${fieldNumber}`,
+  };
+});
+
+const missingInputDrop: PendingMissingInputDrop = {
+  fields,
+  targetColumn: {
+    assigneeRole: "reviewer",
+    groupID: "",
+    id: "node-review",
+    isBacklog: false,
+    isDone: false,
+    key: "review",
+    kind: "agent",
+    name: "Review",
+    outputFields: [],
+    sortOrder: 1,
+    taskCount: 0,
+    transitionOutputFields: fields,
+  },
+  taskID: "task-1",
+  values: Object.fromEntries(fields.map((field) => [field.name, ""])),
+};

--- a/apps/desktop/src/features/board/BoardDropDialogs.tsx
+++ b/apps/desktop/src/features/board/BoardDropDialogs.tsx
@@ -49,21 +49,32 @@ export function MissingInputsDialog({
       title={t("board.missingInputsTitle")}
     >
       {drop === null ? null : (
-        <form className="grid gap-[var(--space-4)]" onSubmit={onSubmit}>
+        <form
+          className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] gap-[var(--space-4)]"
+          data-testid="missing-inputs-dialog-form"
+          onSubmit={onSubmit}
+        >
           <p className="m-0 text-[var(--color-muted)]">{t("board.missingInputsBody")}</p>
-          {drop.fields.map((field) => (
-            <TextArea
-              key={field.name}
-              label={field.name}
-              hint={field.description}
-              onChange={(event) => {
-                onValueChange(field.name, event.currentTarget.value);
-              }}
-              required
-              value={drop.values[field.name] ?? ""}
-            />
-          ))}
-          <div className="flex justify-end gap-[var(--space-2)]">
+          <div
+            className="grid min-h-0 gap-[var(--space-4)] overflow-auto pr-[var(--space-1)] hide-scrollbar"
+            data-testid="missing-inputs-field-list"
+          >
+            {drop.fields.map((field) => (
+              <TextArea
+                className="!min-h-16"
+                key={field.name}
+                label={field.name}
+                hint={field.description}
+                onChange={(event) => {
+                  onValueChange(field.name, event.currentTarget.value);
+                }}
+                required
+                rows={2}
+                value={drop.values[field.name] ?? ""}
+              />
+            ))}
+          </div>
+          <div className="flex justify-end gap-[var(--space-2)]" data-testid="missing-inputs-dialog-actions">
             <Button onClick={onClose}>{t("app.cancel")}</Button>
             <Button type="submit" variant="primary">
               {t("board.missingInputsConfirm")}

--- a/apps/desktop/src/ui/Dialog.test.tsx
+++ b/apps/desktop/src/ui/Dialog.test.tsx
@@ -46,6 +46,18 @@ describe("Dialog", () => {
     });
     expect(opener).toHaveFocus();
   });
+
+  it("preserves controlled textarea focus while the close callback identity changes", async () => {
+    const user = userEvent.setup();
+    render(<ControlledTextareaDialogHarness />);
+
+    const input = screen.getByRole("textbox", { name: "Missing value" });
+    await user.click(input);
+    await user.type(input, "abc");
+
+    expect(input).toHaveValue("abc");
+    expect(input).toHaveFocus();
+  });
 });
 
 function DialogHarness() {
@@ -72,5 +84,27 @@ function DialogHarness() {
         <button type="button">Delete</button>
       </Dialog>
     </>
+  );
+}
+
+function ControlledTextareaDialogHarness() {
+  const [value, setValue] = useState("");
+  return (
+    <Dialog
+      closeLabel="Close dialog"
+      onClose={() => {
+        setValue("");
+      }}
+      open
+      title="Controlled dialog"
+    >
+      <textarea
+        aria-label="Missing value"
+        onChange={(event) => {
+          setValue(event.currentTarget.value);
+        }}
+        value={value}
+      />
+    </Dialog>
   );
 }

--- a/apps/desktop/src/ui/Dialog.tsx
+++ b/apps/desktop/src/ui/Dialog.tsx
@@ -52,7 +52,7 @@ export function Dialog({
         aria-labelledby={titleId}
         aria-modal="true"
         className={cx(
-          "relative grid max-h-[calc(100vh-48px)] w-[min(720px,calc(100vw-32px))] gap-[var(--space-4)] overflow-hidden",
+          "relative grid max-h-[calc(100vh-48px)] w-[min(720px,calc(100vw-32px))] grid-rows-[auto_minmax(0,1fr)] gap-[var(--space-4)] overflow-hidden",
           surface === "island" && cx(islandSurfaceClassName(0), "rounded-[var(--radius-xl)] p-[var(--space-4)]"),
           surface === "transparent" && "bg-transparent p-0 shadow-none",
           className,
@@ -100,6 +100,11 @@ function useModalDialogKeyboard(
   dialogRef: RefObject<HTMLElement | null>,
   onClose: () => void,
 ): void {
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
   useEffect(() => {
     if (!open) {
       return undefined;
@@ -115,7 +120,7 @@ function useModalDialogKeyboard(
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
-        onClose();
+        onCloseRef.current();
         return;
       }
       if (event.key === "Tab") {
@@ -130,7 +135,7 @@ function useModalDialogKeyboard(
         previousFocus.focus();
       }
     };
-  }, [dialogRef, onClose, open]);
+  }, [dialogRef, onCloseRef, open]);
 }
 
 function trapTabFocus(event: KeyboardEvent, dialog: HTMLElement): void {


### PR DESCRIPTION
## Summary
- skip missing-input collection when dropping tasks into terminal/done board columns, even if the column reports transition output fields
- keep required transition input collection for non-terminal targets
- make the missing-input dialog viewport-contained with a scrollable field list, reachable actions, and compact two-row textarea starts
- stabilize shared dialog focus handling so controlled textarea rerenders do not steal focus after each character

Closes #376.

## Verification
- `pnpm --dir apps/desktop test -- BoardDropActions Dialog BoardDropDialogs`
- `pnpm --dir apps/desktop test`
- `pnpm --dir apps/desktop lint`
- `pnpm --dir apps/desktop typecheck`
- Firefox.app headless QA at 800x500 using a temporary Vite harness: 18 required fields, first textarea filled with `abc`, field list scroll-contained, footer reachable, and browser-bundled terminal/non-terminal classification showed `move/missingInput/pass`.
