### PR TITLE
fix: request client-side decorations on Linux windows

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -116,6 +116,20 @@ pub fn run() {
                     eprintln!("Apply native window glass failed: {error}");
                 }
             }
+            // On Linux we paint our own window chrome (see `AppChrome`), so we
+            // request client-side decorations. This stops the compositor from
+            // drawing its own titlebar, and — critically for Wayland compositors
+            // such as Niri whose `draw-border-with-background` default fills a
+            // solid rectangle behind windows that omit CSD — keeps the focus
+            // ring/border from showing through our semi-transparent window as a
+            // full-window backdrop. The window stays transparent; only the
+            // decoration mode changes.
+            #[cfg(target_os = "linux")]
+            if let Some(window) = app.get_webview_window("main") {
+                if let Err(error) = window.set_decorations(false) {
+                    eprintln!("Disable Linux window decorations failed: {error}");
+                }
+            }
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![


### PR DESCRIPTION
## Problem

On Linux the desktop window never set `decorations: false`, so Tauri requested **server-side decorations** from the compositor. Reported by an Arch/Niri (Wayland) alpha tester as two symptoms:

1. **Duplicate titlebar** — the compositor drew its own titlebar on top of the chrome `AppChrome` already paints.
2. **Full-window green backdrop instead of a thin border** — per Niri's [`draw-border-with-background`](https://yalter.github.io/niri/Configuration%3A-Window-Rules.html#draw-border-with-background) default, the focus ring/border is drawn as a **solid rectangle behind** windows that omit client-side decorations. Our window is intentionally semi-transparent, so that rectangle showed through the whole surface (Niri docs: "focus ring and border with background will show through semitransparent windows").

Both stem from one root cause: we declared SSD while actually painting our own chrome.

## Fix

Request **client-side decorations on Linux** in `setup()` (`cfg(target_os = "linux")`). Niri then draws a real thin border (no backing rectangle) and no titlebar. The window stays `transparent: true` — glass/blur tint is unchanged. macOS (overlay titlebar + vibrancy) and Windows (native controls) paths are untouched.

## Testing

- `cargo check` passes on macOS (path is cfg-gated out there).
- Linux path compiled and packaged via the Arch `.pkg.tar.zst` build; delivered to the tester for on-device verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Disabled window decorations on Linux platforms for a cleaner, more streamlined application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->