### PR TITLE
feat: add chrome contrast gradient, drop workflow-editor blur

### DIFF
--- a/apps/desktop/src/app/AppChrome.tsx
+++ b/apps/desktop/src/app/AppChrome.tsx
@@ -6,6 +6,8 @@ import { useTranslation } from "react-i18next";
 
 import { toggleInMemoryThemeOverride } from "../appEnvironment";
 import {
+  appChromeContrastScrimClassNames,
+  appChromeContrastScrimStyle,
   appChromeInlineTitleClassNames,
   appChromeTitleClassNames,
   appChromeTitlePlacementClassNames,
@@ -35,6 +37,14 @@ export function AppChrome({ children }: AppChromeProps) {
 
   return (
     <main className="window-glass-fill grid h-screen w-screen overflow-hidden pt-[var(--native-titlebar-height)]">
+      {macOS ? null : (
+        <div
+          aria-hidden="true"
+          className={appChromeContrastScrimClassNames.join(" ")}
+          data-testid="app-chrome-contrast-scrim"
+          style={appChromeContrastScrimStyle}
+        />
+      )}
       <div
         className="app-region-drag fixed inset-x-0 top-0 z-20 h-[var(--native-titlebar-height)]"
         data-tauri-drag-region

--- a/apps/desktop/src/app/AppChrome.tsx
+++ b/apps/desktop/src/app/AppChrome.tsx
@@ -37,14 +37,12 @@ export function AppChrome({ children }: AppChromeProps) {
 
   return (
     <main className="window-glass-fill grid h-screen w-screen overflow-hidden pt-[var(--native-titlebar-height)]">
-      {macOS ? null : (
-        <div
-          aria-hidden="true"
-          className={appChromeContrastScrimClassNames.join(" ")}
-          data-testid="app-chrome-contrast-scrim"
-          style={appChromeContrastScrimStyle}
-        />
-      )}
+      <div
+        aria-hidden="true"
+        className={appChromeContrastScrimClassNames.join(" ")}
+        data-testid="app-chrome-contrast-scrim"
+        style={appChromeContrastScrimStyle}
+      />
       <div
         className="app-region-drag fixed inset-x-0 top-0 z-20 h-[var(--native-titlebar-height)]"
         data-tauri-drag-region

--- a/apps/desktop/src/app/appChromeStyles.ts
+++ b/apps/desktop/src/app/appChromeStyles.ts
@@ -11,12 +11,15 @@ export const appChromeContrastScrimClassNames = [
     "inset-x-0",
     "top-0",
     "z-10",
-    "h-[calc(var(--native-titlebar-height)*2)]",
+    "h-[calc(var(--native-titlebar-height)*1.5)]",
 ] as const;
 
+// The bare `66%` between the two color stops is a color interpolation hint: it
+// places the 50% midpoint of the fade at 66% of the height, so the alpha follows
+// a smooth non-linear (power) curve rather than a straight linear ramp.
 export const appChromeContrastScrimStyle = {
     background:
-        "linear-gradient(to bottom, color-mix(in srgb, var(--background) 55%, transparent) 0%, transparent 100%)",
+        "linear-gradient(to bottom, color-mix(in srgb, var(--background) 50%, transparent) 0%, 66%, transparent 100%)",
 } satisfies CSSProperties;
 
 export const appChromeTitleClassNames = [

--- a/apps/desktop/src/app/appChromeStyles.ts
+++ b/apps/desktop/src/app/appChromeStyles.ts
@@ -1,3 +1,24 @@
+import type { CSSProperties } from "react";
+
+// Contrast scrim behind the top window chrome. On macOS the chrome reads against
+// the native window glass (blur+tint); platforms without that glass (Linux,
+// Windows, browser) get this gradient instead so the chrome controls/title stay
+// legible over arbitrary content scrolling beneath them. Starts at a partial
+// background-token fill at the very top and fades to transparent over the chrome.
+export const appChromeContrastScrimClassNames = [
+    "pointer-events-none",
+    "fixed",
+    "inset-x-0",
+    "top-0",
+    "z-10",
+    "h-[calc(var(--native-titlebar-height)*2)]",
+] as const;
+
+export const appChromeContrastScrimStyle = {
+    background:
+        "linear-gradient(to bottom, color-mix(in srgb, var(--background) 55%, transparent) 0%, transparent 100%)",
+} satisfies CSSProperties;
+
 export const appChromeTitleClassNames = [
     "pointer-events-none",
     "fixed",

--- a/apps/desktop/src/features/workflow-editor/WorkflowEditorEmbeddedInspector.tsx
+++ b/apps/desktop/src/features/workflow-editor/WorkflowEditorEmbeddedInspector.tsx
@@ -1,29 +1,9 @@
-import { type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import { X } from "lucide-react";
 
 import type { WorkflowInspectorSelection } from "../../app/sidebarContext";
 import { Button, IslandSurface } from "../../ui";
 import { WorkflowInspectorSidebar } from "./WorkflowInspectorSidebar";
-
-export function WorkflowEditorTopChromeBlur() {
-  return (
-    <div
-      aria-hidden="true"
-      className="pointer-events-none fixed inset-x-0 top-0 z-10 h-[calc(var(--native-titlebar-height)*2)]"
-      data-testid="workflow-editor-top-chrome-blur"
-      style={workflowEditorTopChromeBlurStyle}
-    />
-  );
-}
-
-const workflowEditorTopChromeBlurStyle = {
-  WebkitBackdropFilter: "blur(16px) saturate(0.8) brightness(0.78)",
-  WebkitMaskImage: "linear-gradient(to bottom, black 0%, black 30%, transparent 100%)",
-  background: "color-mix(in srgb, var(--window-glass-tint) 65%, transparent)",
-  backdropFilter: "blur(16px) saturate(0.8) brightness(0.78)",
-  maskImage: "linear-gradient(to bottom, black 0%, black 30%, transparent 100%)",
-} satisfies CSSProperties;
 
 export function WorkflowEditorEmbeddedInspector({
   onClose,

--- a/apps/desktop/src/features/workflow-editor/WorkflowEditorRoute.tsx
+++ b/apps/desktop/src/features/workflow-editor/WorkflowEditorRoute.tsx
@@ -30,10 +30,7 @@ import { useWorkflowEditorGraphState } from "./useWorkflowEditorGraphState";
 import { useWorkflowEditorSave, type WorkflowEditorSave } from "./useWorkflowEditorSave";
 import { useWorkflowGraphDeleteConfirmation } from "./useWorkflowGraphDeleteConfirmation";
 import { WorkflowEditorCanvas } from "./WorkflowEditorCanvas";
-import {
-  WorkflowEditorEmbeddedInspector,
-  WorkflowEditorTopChromeBlur,
-} from "./WorkflowEditorEmbeddedInspector";
+import { WorkflowEditorEmbeddedInspector } from "./WorkflowEditorEmbeddedInspector";
 import { WorkflowEditorLegendIsland } from "./WorkflowEditorLegendIsland";
 import { WorkflowEditorStatusIsland } from "./WorkflowEditorStatusIsland";
 import type { WorkflowGraphSelection } from "./workflowGraphSelection";
@@ -264,7 +261,6 @@ function WorkflowEditorReadyView(props: WorkflowEditorReadyViewProps) {
       )}
       data-testid="workflow-editor-route"
     >
-      {surface === "route" ? <WorkflowEditorTopChromeBlur /> : null}
       <WorkflowEditorCanvas
         closeDeletedNodeInspector={closeDeletedNodeInspector}
         deleteRequestIndexRef={deleteRequestIndexRef}


### PR DESCRIPTION
## Why

The top window chrome (home/back/forward + title) reads against the **native window glass** (blur+tint) on macOS. That glass blurs the *desktop behind the window*, not in-app content scrolled under the chrome — so the controls/title could wash out over boards/workflows beneath them. A per-route backdrop **blur** in the workflow editor (`WorkflowEditorTopChromeBlur`) was a stopgap for this.

## What

- **New global contrast scrim in `AppChrome`**, rendered on **all platforms** (on macOS it layers over the glass). `pointer-events-none`, `z-10` (above content, below the chrome controls/drag region).
- **Real eased curve, not a linear ramp or stepped stops:** a CSS color interpolation hint puts the fade's 50% midpoint at 66% of the height, giving a smooth non-linear alpha falloff. Max **50%** of the `--background` token at the top → transparent at the bottom, over **1.5×** the chrome height.
- **Removed the workflow-editor blur** — now subsumed by the global scrim.

Uses a theme token (light/dark aware), not literal black.

## Testing

`pnpm` (in `apps/`): typecheck ✓, lint + policy checks ✓, 343 tests ✓, build ✓. Previewed live in the native macOS desktop app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a contrast scrim overlay to the desktop application's title bar area to ensure window controls remain visible and legible, regardless of the background content.

* **Style**
  * Removed the blur effect from the workflow editor's top chrome interface, providing a cleaner visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->