### PR TITLE
fix: reload prompt snapshots after compaction

### DIFF
--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -141,8 +141,10 @@
 - Workspace relocation/rebinding is explicit user action; Kent does not infer auto-rebinds.
 - Session metadata authority lives in SQLite. `session.json` is removed from authoritative layout.
 - Interactive session creation is lazily durable.
-- Session start/setup becomes immutable at first model request dispatch, except thinking level can change on resume.
-- Lock covers model, core generation params, enabled tools, tool schema/description snapshot, and system prompt snapshot.
+- Session start/setup becomes immutable at first model request dispatch, except thinking level can change on resume and system/reviewer prompt snapshots can refresh after successful compaction.
+- Lock covers model, core generation params, enabled tool IDs, native web-search mode, and system/reviewer prompt snapshots. Model/core generation fields, active enabled tool IDs, and native web-search mode remain locked for the session lifetime; system/reviewer prompt snapshot fields are locked per compaction generation. Developer meta context messages are transcript entries, not lazy-refreshed lock snapshots. Tool declarations for locked tool IDs are runtime-defined and are not persisted as session snapshots.
+- Locked enabled tool IDs distinguish explicit empty tool sets from legacy missing metadata with a presence field; explicit empty sets are authoritative.
+- Legacy request-shape locks that lack enabled-tool presence or native web-search mode are backfilled before use; failed backfill blocks request/launch planning instead of using mutable config fallback.
 - Transcript message order is immutable for cache stability.
 - Canonical model context/history is stored as Responses API input items; message-only chat is UI projection.
 - `events.jsonl` is append-only on normal writes; periodic compaction rewrites canonical JSONL to control growth.
@@ -202,6 +204,9 @@
 - Main-agent OpenAI `session_id` remains the persisted Kent session ID for the conversation lifetime.
 - Prompt-cache lineage rotates by compaction generation: base `<session_id>`, then `<session_id>/compact-N`.
 - Supervisor/reviewer cache lineage uses `<session_id>/supervisor` with the same compaction generation counter.
+- After successful history replacement, Kent clears stale system/reviewer prompt snapshots from the locked contract. The next model request lazily reloads effective config, preserves locked model/provider/generation fields and active enabled tool IDs, refreshes system/reviewer prompt snapshots, then persists the refreshed lock for the new generation. The no-marker design accepts the existing file-store crash window where `history_replaced` can be durable before prompt snapshot clearing is durable.
+- The compaction request itself uses the stored pre-compaction contract when one exists. Refreshed system/reviewer prompt snapshots apply only to ordinary requests sent after successful history replacement. A repeat compaction before lazy refresh starts from the cleared prompt snapshot state and uses a non-mutating prompt resolver rather than preserving or persisting the previous prompt.
+- If lazy snapshot refresh fails, Kent blocks the model request with a clear error, leaves the pre-refresh lock state unchanged, and retries refresh on a later request after configuration is fixed.
 - Local compaction instructions are final `developer` messages. Runtime rejects any tool calls returned by local compaction.
 - Local compaction summary generation reuses the normal main-agent request envelope and changes only request items by appending compaction instructions.
 - If native or local compaction exceeds provider context length, Kent retries by collapsing supported historical tool payloads in the compaction request only. The four total attempts are the original request, then cumulative collapse targets of 10%, 20%, and 40% of the model context window. Shell outputs, including `exec_command` and `write_stdin` outputs, and patch inputs collapse to exact text `<collapsed>`; tool calls and call/output relationships remain present. Reasoning items and unsupported tool payloads are not removed or collapsed. Successful repaired compaction persists an operator-visible diagnostic with collapse counts and estimated omitted tokens.

--- a/docs/dev/specs/terminology.md
+++ b/docs/dev/specs/terminology.md
@@ -130,7 +130,7 @@ A run stopped before producing a valid transition result. Its session and worktr
 
 ### Session Contract
 
-The immutable execution setup captured by a Kent session after its first model request: model/provider setup, generation parameters, tool schema snapshot, and system/developer prompt snapshot.
+The execution setup captured by a Kent session for one compaction generation. Model/provider setup, generation parameters, active enabled tool IDs, and native web-search mode stay locked for the session lifetime. System and reviewer prompt snapshots are immutable within a generation and can be lazily refreshed from current config/source truth after successful compaction. Developer meta context messages are transcript entries, not lazy-refreshed session-contract snapshots. Tool declarations for locked tool IDs are runtime-defined and are not persisted as session snapshots.
 
 ### Runtime Parameter Contract
 

--- a/docs/src/content/docs/prompts.md
+++ b/docs/src/content/docs/prompts.md
@@ -23,7 +23,7 @@ System prompt files replace Kent's built-in default "product engineer" / SWE-foc
 
 `system_prompt_file` paths are resolved relative to the containing `config.toml` directory unless absolute.
 
-The system prompt is snapshot and cannot be changed after the session starts to prevent cache invalidation and misbehaving models. Start a new session for changes to take effect.
+Kent snapshots the rendered system prompt for each compaction generation. Edits to system prompt files take effect after a successful compaction and the next model request. Model/provider settings, enabled tool IDs, and native web search mode stay locked for the session.
 
 ## Placeholders
 
@@ -62,4 +62,4 @@ Additionally, if `tool_preambles = true` in the [config](../config/), another bl
 - `~/.kent/config.toml`
 - `<workspace-root>/.kent/config.toml`
 
-The workspace config value takes priority. Editing the file affects only sessions that have not run the supervisor with that override yet.
+The workspace config value takes priority. Kent snapshots the rendered supervisor prompt independently when a supervisor request is built; edits take effect for supervisor requests after successful compaction. Developer context already written into the transcript is not reloaded by prompt snapshot refresh.

--- a/server/launch/edit_tools_test.go
+++ b/server/launch/edit_tools_test.go
@@ -62,6 +62,32 @@ func TestActiveToolIDsLockedSessionPreservesPatchAndEdit(t *testing.T) {
 	}
 }
 
+func TestActiveToolIDsLockedSessionPreservesExplicitZeroTools(t *testing.T) {
+	settings := validLaunchSettings("gpt-5.5")
+	locked := &session.LockedContract{HasEnabledTools: true}
+
+	ids, err := ActiveToolIDsForPlan(settings, defaultToolSources(), locked)
+	if err != nil {
+		t.Fatalf("ActiveToolIDsForPlan: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("enabled tools = %+v, want explicit zero-tool lock", ids)
+	}
+}
+
+func TestActiveToolIDsLegacyMissingLockUsesEffectiveConfig(t *testing.T) {
+	settings := validLaunchSettings("gpt-5.5")
+	locked := &session.LockedContract{}
+
+	ids, err := ActiveToolIDsForPlan(settings, defaultToolSources(), locked)
+	if err != nil {
+		t.Fatalf("ActiveToolIDsForPlan: %v", err)
+	}
+	if !containsTool(ids, toolspec.ToolPatch) {
+		t.Fatalf("enabled tools = %+v, want effective config fallback for legacy missing lock", ids)
+	}
+}
+
 func TestApplyRunPromptOverridesSubagentExplicitEditToolWins(t *testing.T) {
 	store := createTestSession(t, t.TempDir())
 	settings := validLaunchSettings("gpt-5.5")

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -72,6 +72,56 @@ type SessionPlan struct {
 	BaseSource          config.SourceReport
 }
 
+type PromptFacingSnapshotResolution struct {
+	Settings      config.Settings
+	Source        config.SourceReport
+	ActiveToolIDs []toolspec.ID
+	WebSearchMode string
+}
+
+func ResolvePromptFacingSnapshotConfig(app config.App, store *session.Store, skipContinuationAgentRoleValidation bool) (PromptFacingSnapshotResolution, error) {
+	if store == nil {
+		return PromptFacingSnapshotResolution{}, errors.New("session store is required")
+	}
+	meta := store.Meta()
+	baseActive := EffectiveSettings(app.Settings, meta.Locked)
+	baseSource := app.Source
+	active, source := baseActive, baseSource
+	if meta.Continuation != nil {
+		role := strings.TrimSpace(meta.Continuation.AgentRole)
+		var err error
+		active, source, err = applyPersistedSubagentRoleSettings(baseActive, baseSource, role, meta.Locked == nil, !skipContinuationAgentRoleValidation)
+		if err != nil {
+			return PromptFacingSnapshotResolution{}, err
+		}
+		if shouldApplyPersistedContinuationBaseURL(baseActive, role) {
+			if baseURL := strings.TrimSpace(meta.Continuation.OpenAIBaseURL); baseURL != "" {
+				active.OpenAIBaseURL = baseURL
+			}
+		}
+	}
+	enabledTools, err := ActiveToolIDsForPlan(active, source, meta.Locked)
+	if err != nil {
+		return PromptFacingSnapshotResolution{}, err
+	}
+	if meta.Locked != nil && (!meta.Locked.HasEnabledTools || strings.TrimSpace(meta.Locked.WebSearchMode) == "") {
+		backfill, backfillErr := store.BackfillLockedRequestShape(session.LockedRequestShapeBackfill{
+			EnabledTools:    toolIDNames(enabledTools),
+			HasEnabledTools: true,
+			WebSearchMode:   strings.TrimSpace(active.WebSearch),
+		})
+		if backfillErr != nil && !backfill.Committed {
+			return PromptFacingSnapshotResolution{}, backfillErr
+		}
+	}
+	return PromptFacingSnapshotResolution{
+		Settings:      active,
+		Source:        source,
+		ActiveToolIDs: enabledTools,
+		WebSearchMode: strings.TrimSpace(active.WebSearch),
+	}, nil
+}
+
 func (p Planner) PlanSession(ctx context.Context, req SessionRequest) (SessionPlan, error) {
 	if p.ReloadConfig != nil {
 		cfg, err := p.ReloadConfig()
@@ -118,6 +168,19 @@ func (p Planner) PlanSession(ctx context.Context, req SessionRequest) (SessionPl
 	enabledTools, err := ActiveToolIDsForPlan(active, source, meta.Locked)
 	if err != nil {
 		return SessionPlan{}, err
+	}
+	if meta.Locked != nil && (!meta.Locked.HasEnabledTools || strings.TrimSpace(meta.Locked.WebSearchMode) == "") {
+		backfill, backfillErr := store.BackfillLockedRequestShape(session.LockedRequestShapeBackfill{
+			EnabledTools:    toolIDNames(enabledTools),
+			HasEnabledTools: true,
+			WebSearchMode:   strings.TrimSpace(active.WebSearch),
+		})
+		if backfillErr != nil && !backfill.Committed {
+			return SessionPlan{}, backfillErr
+		}
+		if backfill.Committed && backfill.Locked != nil {
+			meta.Locked = backfill.Locked
+		}
 	}
 	configuredModelName := p.Config.Settings.Model
 	if meta.Locked == nil {
@@ -589,7 +652,7 @@ func EffectiveSettings(base config.Settings, locked *session.LockedContract) con
 }
 
 func ActiveToolIDsForPlan(settings config.Settings, source config.SourceReport, locked *session.LockedContract) ([]toolspec.ID, error) {
-	if locked != nil {
+	if locked != nil && (locked.HasEnabledTools || len(locked.EnabledTools) > 0) {
 		ids := make([]toolspec.ID, 0, len(locked.EnabledTools))
 		for _, raw := range locked.EnabledTools {
 			if id, ok := toolspec.ParseID(raw); ok {
@@ -612,6 +675,17 @@ func ActiveToolIDsForPlan(settings config.Settings, source config.SourceReport, 
 		return nil, ErrPatchEditToolsConflict
 	}
 	return DedupeSortToolIDs(enabledToolIDs(enabled)), nil
+}
+
+func toolIDNames(ids []toolspec.ID) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		out = append(out, string(id))
+	}
+	return out
 }
 
 func bothEditToolSourcesDefault(source config.SourceReport) bool {

--- a/server/runtime/compaction.go
+++ b/server/runtime/compaction.go
@@ -284,6 +284,52 @@ func (e *Engine) currentInputTokensPrecisely(ctx context.Context) (int, bool) {
 	return e.requestInputTokensPreciselyTracked(ctx, req, true)
 }
 
+func (e *Engine) currentInputTokensPreciselyWithoutPromptRefresh(ctx context.Context) (int, bool) {
+	req, err := e.buildRequestWithoutPromptRefresh(ctx)
+	if err != nil {
+		return 0, false
+	}
+	return e.requestInputTokensPreciselyTracked(ctx, req, true)
+}
+
+func (e *Engine) buildRequestWithoutPromptRefresh(ctx context.Context) (llm.Request, error) {
+	locked, err := e.ensureLocked()
+	if err != nil {
+		return llm.Request{}, err
+	}
+	workflowMode, err := e.workflowCompletionMode(ctx)
+	if err != nil {
+		return llm.Request{}, err
+	}
+	requestTools, err := e.requestTools(ctx, workflowMode)
+	if err != nil {
+		return llm.Request{}, err
+	}
+	systemPrompt, err := e.systemPromptWithoutBackfill(locked)
+	if err != nil {
+		return llm.Request{}, err
+	}
+	req, err := llm.RequestFromLockedContract(locked, systemPrompt, e.transcriptRuntimeState().SnapshotItems(), requestTools)
+	if err != nil {
+		return llm.Request{}, err
+	}
+	req.ReasoningEffort = e.ThinkingLevel()
+	req.FastMode = e.FastModeEnabled()
+	req.SessionID = e.SessionID()
+	if e.supportsPromptCacheKey(ctx) {
+		if cacheKey := conversationPromptCacheKey(e.SessionID(), e.compactionRuntimeState().Count()); cacheKey != "" {
+			req.PromptCacheKey = cacheKey
+			req.PromptCacheScope = transcript.CacheWarningScopeConversation
+		}
+	}
+	nativeWebSearch, nativeErr := e.enableNativeWebSearch(ctx)
+	if nativeErr != nil {
+		return llm.Request{}, nativeErr
+	}
+	req.EnableNativeWebSearch = nativeWebSearch
+	return req, nil
+}
+
 func (e *Engine) currentInputTokensPreciselyIfDueWithPriority(ctx context.Context, limit int, critical bool) (int, bool) {
 	if precise, ok := e.lookupCurrentPreciseInputTokens(); ok {
 		if !e.shouldRefreshCurrentPreciseInputTokens(limit, critical) {
@@ -590,7 +636,7 @@ func (e *Engine) compactNow(ctx context.Context, stepID string, mode compactionM
 		windowTokens = e.compactionPlannerState().contextWindowTokens(e.compactionPlanningSnapshot())
 	}
 	inputTokens := estimateItemsTokens(e.transcriptRuntimeState().SnapshotItems())
-	if preciseInput, ok := e.currentInputTokensPrecisely(ctx); ok {
+	if preciseInput, ok := e.currentInputTokensPreciselyWithoutPromptRefresh(ctx); ok {
 		inputTokens = preciseInput
 	}
 	if err := e.recordLastUsage(llm.Usage{
@@ -599,6 +645,14 @@ func (e *Engine) compactNow(ctx context.Context, stepID string, mode compactionM
 		WindowTokens: windowTokens,
 	}); err != nil {
 		return compactionResult{}, err
+	}
+	staleResult, staleErr := e.store.MarkLockedPromptFacingSnapshotsStale()
+	if staleResult.Committed && staleResult.Locked != nil {
+		e.lockedContractState().Set(*staleResult.Locked)
+	}
+	if staleErr != nil && !staleResult.Committed {
+		statusErr := newCompactionPersistence(e).emitStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, compactionNumber, staleErr.Error())
+		return compactionResult{}, errors.Join(staleErr, statusErr)
 	}
 
 	if err := newCompactionPersistence(e).emitStatus(stepID, EventCompactionCompleted, mode, result.engine, providerID, result.trimmedItemsCount, compactionNumber, ""); err != nil {

--- a/server/runtime/compaction_executor.go
+++ b/server/runtime/compaction_executor.go
@@ -188,7 +188,7 @@ func (e *Engine) compactionCacheObservationRequest(ctx context.Context, request 
 		return llm.Request{}, false, err
 	}
 	items := compactionConversationWithPromptItems(request.InputItems, request.Instructions)
-	systemPrompt, err := e.systemPrompt(locked)
+	systemPrompt, err := e.systemPromptWithoutBackfill(locked)
 	if err != nil {
 		return llm.Request{}, false, err
 	}
@@ -196,7 +196,11 @@ func (e *Engine) compactionCacheObservationRequest(ctx context.Context, request 
 	if err != nil {
 		return llm.Request{}, false, err
 	}
-	req, err := llm.RequestFromLockedContract(locked, systemPrompt, items, e.requestTools(ctx, workflowMode))
+	requestTools, err := e.requestTools(ctx, workflowMode)
+	if err != nil {
+		return llm.Request{}, false, err
+	}
+	req, err := llm.RequestFromLockedContract(locked, systemPrompt, items, requestTools)
 	if err != nil {
 		return llm.Request{}, false, err
 	}
@@ -245,7 +249,7 @@ func (e *Engine) localCompactionSummaryWithRepair(ctx context.Context, input []l
 	if err != nil {
 		return "", compactionOverflowRepairStats{}, err
 	}
-	systemPrompt, err := e.systemPrompt(locked)
+	systemPrompt, err := e.systemPromptWithoutBackfill(locked)
 	if err != nil {
 		return "", compactionOverflowRepairStats{}, err
 	}
@@ -253,7 +257,10 @@ func (e *Engine) localCompactionSummaryWithRepair(ctx context.Context, input []l
 	if err != nil {
 		return "", compactionOverflowRepairStats{}, err
 	}
-	requestTools := e.requestTools(ctx, workflowMode)
+	requestTools, err := e.requestTools(ctx, workflowMode)
+	if err != nil {
+		return "", compactionOverflowRepairStats{}, err
+	}
 	window := localCompactionWindow(input)
 	repairStats := compactionOverflowRepairStats{}
 	contextWindowTokens := e.compactionPlannerState().contextWindowTokens(e.compactionPlanningSnapshot())

--- a/server/runtime/compaction_reminder.go
+++ b/server/runtime/compaction_reminder.go
@@ -69,7 +69,11 @@ func (e *Engine) persistCompactionSoonReminderIssued(issued bool) error {
 }
 
 func (e *Engine) triggerHandoffConfigured() bool {
-	for _, id := range e.cfg.EnabledTools {
+	shape, err := e.lockedRequestShape()
+	if err != nil {
+		return false
+	}
+	for _, id := range shape.EnabledTools {
 		if id == toolspec.ToolTriggerHandoff {
 			return true
 		}

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -98,6 +98,7 @@ type Config struct {
 	FastModeEnabled               bool
 	FastModeState                 *FastModeState
 	WebSearchMode                 string
+	PromptFacingSnapshotReloader  PromptFacingSnapshotReloader
 	ProviderCapabilitiesOverride  *llm.ProviderCapabilities
 	EnabledTools                  []toolspec.ID
 	DisabledSkills                map[string]bool
@@ -569,6 +570,7 @@ func (e *Engine) ensureLocked() (session.LockedContract, error) {
 		ContextWindow:     contextBudget.window,
 		ContextPercent:    contextBudget.percent,
 		EnabledTools:      toToolNames(e.cfg.EnabledTools),
+		WebSearchMode:     strings.TrimSpace(e.cfg.WebSearchMode),
 		ModelCapabilities: e.cfg.ModelCapabilities,
 		ToolPreambles: func() *bool {
 			enabled := !e.cfg.HeadlessMode && e.cfg.ToolPreambles

--- a/server/runtime/engine_part5_test.go
+++ b/server/runtime/engine_part5_test.go
@@ -115,6 +115,57 @@ func TestReviewerSystemPromptFileIsLazyLockedAndReused(t *testing.T) {
 	}
 }
 
+func TestReviewerSystemPromptRefreshesIndependentlyAfterCompaction(t *testing.T) {
+	workspace := t.TempDir()
+	reviewerPromptPath := filepath.Join(workspace, "reviewer.md")
+	writeTestFile(t, reviewerPromptPath, "reviewer A")
+	autoCompactionEnabled := false
+	store := mustCreateTestSession(t, workspace)
+	mainClient := &fakeClient{responses: []llm.Response{
+		{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "ok"}, Usage: llm.Usage{WindowTokens: 200000}},
+		{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "summary"}, Usage: llm.Usage{WindowTokens: 200000}},
+	}}
+	reviewerClient := &fakeClient{}
+	eng := mustNewExecTestEngine(t, store, mainClient, Config{
+		CompactionMode:        "local",
+		AutoCompactionEnabled: &autoCompactionEnabled,
+		Reviewer: ReviewerConfig{
+			Frequency:        "all",
+			Model:            "gpt-5",
+			SystemPromptFile: reviewerPromptPath,
+			Client:           reviewerClient,
+		},
+	})
+	if _, err := eng.SubmitUserMessage(context.Background(), "hello"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	reviewerReq, err := eng.buildReviewerRequest(context.Background(), reviewerClient)
+	if err != nil {
+		t.Fatalf("build reviewer before compaction: %v", err)
+	}
+	if reviewerReq.SystemPrompt != "reviewer A" {
+		t.Fatalf("reviewer before compaction = %q, want reviewer A", reviewerReq.SystemPrompt)
+	}
+	writeTestFile(t, reviewerPromptPath, "reviewer B")
+	if err := eng.CompactContext(context.Background(), ""); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	mainLocked := store.Meta().Locked
+	if mainLocked == nil || mainLocked.HasSystemPrompt || mainLocked.HasReviewerPrompt {
+		t.Fatalf("locked prompts after compaction = %+v, want both stale", mainLocked)
+	}
+	reviewerReq, err = eng.buildReviewerRequest(context.Background(), reviewerClient)
+	if err != nil {
+		t.Fatalf("build reviewer after compaction: %v", err)
+	}
+	if reviewerReq.SystemPrompt != "reviewer B" {
+		t.Fatalf("reviewer after compaction = %q, want reviewer B", reviewerReq.SystemPrompt)
+	}
+	if locked := store.Meta().Locked; locked == nil || locked.SystemPrompt != "" || !locked.HasReviewerPrompt || locked.ReviewerPrompt != "reviewer B" {
+		t.Fatalf("locked prompts after reviewer refresh = %+v", locked)
+	}
+}
+
 func TestReviewerSystemPromptFileResolvesTilde(t *testing.T) {
 	home := t.TempDir()
 	dir := t.TempDir()

--- a/server/runtime/engine_part9_test.go
+++ b/server/runtime/engine_part9_test.go
@@ -177,7 +177,10 @@ func TestRequestToolsExposePatchAsCustomToolOnlyForFirstPartyResponsesProvider(t
 				t.Fatalf("ensureLocked: %v", err)
 			}
 
-			requestTools := eng.requestTools(context.Background(), "")
+			requestTools, err := eng.requestTools(context.Background(), "")
+			if err != nil {
+				t.Fatalf("requestTools: %v", err)
+			}
 			if len(requestTools) != 1 {
 				t.Fatalf("request tools = %+v, want one patch tool", requestTools)
 			}
@@ -213,7 +216,10 @@ func TestRequestToolsUseActiveProviderCapsForCustomPatchTool(t *testing.T) {
 		ProviderCapabilitiesOverride: &activeCaps,
 	})
 
-	requestTools := eng.requestTools(context.Background(), "")
+	requestTools, err := eng.requestTools(context.Background(), "")
+	if err != nil {
+		t.Fatalf("requestTools: %v", err)
+	}
 	if len(requestTools) != 1 {
 		t.Fatalf("request tools = %+v, want one patch tool", requestTools)
 	}

--- a/server/runtime/engine_request.go
+++ b/server/runtime/engine_request.go
@@ -40,6 +40,13 @@ func (e *Engine) buildRequestPlanWithExtraItems(ctx context.Context, stepID stri
 	if err != nil {
 		return requestBuildPlan{}, err
 	}
+	if _, err := e.lockedRequestShape(); err != nil {
+		return requestBuildPlan{}, err
+	}
+	locked, err = e.ensureMainPromptFacingContractFresh(ctx, locked)
+	if err != nil {
+		return requestBuildPlan{}, err
+	}
 
 	var workflowMode workflowruntime.CompletionMode
 	if e.workflowRunActive() {
@@ -51,7 +58,10 @@ func (e *Engine) buildRequestPlanWithExtraItems(ctx context.Context, stepID stri
 	}
 	var requestTools []llm.Tool
 	if allowTools {
-		requestTools = e.requestTools(ctx, workflowMode)
+		requestTools, err = e.requestTools(ctx, workflowMode)
+		if err != nil {
+			return requestBuildPlan{}, err
+		}
 	} else {
 		requestTools = []llm.Tool{}
 	}
@@ -123,7 +133,11 @@ func supportsPromptCacheKeyForClient(ctx context.Context, client llm.Client) boo
 }
 
 func (e *Engine) enableNativeWebSearch(ctx context.Context) (bool, error) {
-	if !tools.NeedsNativeWebSearch(e.cfg.EnabledTools, e.cfg.WebSearchMode) {
+	shape, err := e.lockedRequestShape()
+	if err != nil {
+		return false, err
+	}
+	if !tools.NeedsNativeWebSearch(shape.EnabledTools, shape.WebSearchMode) {
 		return false, nil
 	}
 	caps, err := e.providerCapabilities(ctx)
@@ -170,6 +184,16 @@ func (e *Engine) systemPrompt(locked session.LockedContract) (string, error) {
 	return prompt, nil
 }
 
+func (e *Engine) systemPromptWithoutBackfill(locked session.LockedContract) (string, error) {
+	if locked.HasSystemPrompt {
+		return strings.TrimSpace(locked.SystemPrompt), nil
+	}
+	if prompt := strings.TrimSpace(locked.SystemPrompt); prompt != "" {
+		return prompt, nil
+	}
+	return e.buildSystemPromptSnapshotForRoot(locked, e.systemPromptWorkspaceRoot())
+}
+
 func (e *Engine) estimatedToolCallsForLockedContext(locked session.LockedContract) int {
 	budget := e.promptContextBudget(locked)
 	return compactionutil.EstimatedToolCallsForContextWindow(budget.window, budget.percent)
@@ -181,6 +205,9 @@ type promptContextBudget struct {
 }
 
 func (e *Engine) promptContextBudget(locked session.LockedContract) promptContextBudget {
+	if locked.ContextWindow > 0 && locked.ContextPercent > 0 {
+		return promptContextBudget{window: locked.ContextWindow, percent: locked.ContextPercent}
+	}
 	budget := e.promptContextBudgetFromConfig()
 	if locked.ContextWindow > 0 {
 		budget.window = locked.ContextWindow
@@ -247,20 +274,24 @@ func hostedToolExecutionsFromOutputItems(items []llm.ResponseItem, defs []tools.
 	return out
 }
 
-func (e *Engine) requestTools(ctx context.Context, workflowMode workflowruntime.CompletionMode) []llm.Tool {
+func (e *Engine) requestTools(ctx context.Context, workflowMode workflowruntime.CompletionMode) ([]llm.Tool, error) {
 	workflowToolMode := workflowMode == workflowruntime.CompletionModeTool
+	shape, err := e.lockedRequestShape()
+	if err != nil {
+		return nil, err
+	}
 	exposure := tools.RequestExposureContext{
 		SupportsVision:     llm.LockedContractSupportsVisionInputs(e.store.Meta().Locked, e.cfg.Model),
 		WorkflowCompletion: workflowToolMode,
 	}
-	defs := tools.RequestExposedDefinitionsForSession(e.cfg.EnabledTools, e.registry.Definitions(), exposure)
+	defs := tools.RequestExposedDefinitionsForSession(shape.EnabledTools, e.registry.Definitions(), exposure)
 	if workflowToolMode {
 		if def, ok := tools.DefinitionFor(toolspec.ToolCompleteNode); ok && !definitionListContains(defs, toolspec.ToolCompleteNode) {
 			defs = append(defs, def)
 		}
 	}
 	if len(defs) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]llm.Tool, 0, len(defs))
 	customPatchSupported := e.supportsCustomPatchTool(ctx)
@@ -279,7 +310,7 @@ func (e *Engine) requestTools(ctx context.Context, workflowMode workflowruntime.
 		}
 		out = append(out, tool)
 	}
-	return out
+	return out, nil
 }
 
 func definitionListContains(defs []tools.Definition, id toolspec.ID) bool {

--- a/server/runtime/engine_test.go
+++ b/server/runtime/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"core/server/llm"
 	"core/server/session"
 	"core/server/tools"
+	"core/shared/config"
 	"core/shared/toolspec"
 	"encoding/json"
 	"errors"
@@ -861,6 +862,220 @@ func TestSystemPromptSnapshotUsesLocalFileAndSurvivesMidSessionFileChanges(t *te
 	}
 	if got := reopened.Meta().Locked.SystemPrompt; got != firstPrompt {
 		t.Fatalf("locked system prompt mismatch\ngot: %q\nwant: %q", got, firstPrompt)
+	}
+}
+
+func TestSystemPromptSnapshotRefreshesAfterCompaction(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	systemDir := filepath.Join(workspace, agentsGlobalDirName)
+	if err := os.MkdirAll(systemDir, 0o755); err != nil {
+		t.Fatalf("mkdir system dir: %v", err)
+	}
+	systemPath := filepath.Join(systemDir, systemPromptFileName)
+	writeTestFile(t, systemPath, "prompt A")
+	autoCompactionEnabled := false
+	store := mustCreateNamedTestSession(t, "ws", workspace)
+	client := &fakeClient{responses: []llm.Response{
+		{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "first"}, Usage: llm.Usage{WindowTokens: 200000}},
+		{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "second"}, Usage: llm.Usage{WindowTokens: 200000}},
+		{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "summary"}, Usage: llm.Usage{WindowTokens: 200000}},
+		{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "third"}, Usage: llm.Usage{WindowTokens: 200000}},
+	}}
+	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
+		Model:                 "gpt-5",
+		EnabledTools:          []toolspec.ID{toolspec.ToolExecCommand},
+		CompactionMode:        "local",
+		AutoCompactionEnabled: &autoCompactionEnabled,
+		ToolPreambles:         false,
+		TranscriptWorkingDir:  workspace,
+	})
+	if _, err := eng.SubmitUserMessage(context.Background(), "first"); err != nil {
+		t.Fatalf("submit first: %v", err)
+	}
+	if got := client.calls[0].SystemPrompt; got != "prompt A" {
+		t.Fatalf("first system prompt = %q, want prompt A", got)
+	}
+	firstCacheKey := client.calls[0].PromptCacheKey
+	writeTestFile(t, systemPath, "prompt B")
+	if _, err := eng.SubmitUserMessage(context.Background(), "second"); err != nil {
+		t.Fatalf("submit second: %v", err)
+	}
+	if got := client.calls[1].SystemPrompt; got != "prompt A" {
+		t.Fatalf("pre-compaction system prompt = %q, want prompt A", got)
+	}
+	if err := eng.CompactContext(context.Background(), ""); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	if got := client.calls[2].SystemPrompt; got != "prompt A" {
+		t.Fatalf("compaction system prompt = %q, want prompt A", got)
+	}
+	if _, err := eng.SubmitUserMessage(context.Background(), "third"); err != nil {
+		t.Fatalf("submit third: %v", err)
+	}
+	if got := client.calls[3].SystemPrompt; got != "prompt B" {
+		t.Fatalf("post-compaction system prompt = %q, want prompt B", got)
+	}
+	if got := client.calls[3].PromptCacheKey; got == "" || got == firstCacheKey {
+		t.Fatalf("post-compaction cache key = %q, want rotated from %q", got, firstCacheKey)
+	}
+	if locked := store.Meta().Locked; locked == nil || !locked.HasSystemPrompt || locked.SystemPrompt != "prompt B" {
+		t.Fatalf("locked prompt after refresh = %+v, want prompt B", locked)
+	}
+}
+
+func TestSystemPromptRefreshFailureKeepsStaleLockAndRetries(t *testing.T) {
+	workspace := t.TempDir()
+	systemPath := filepath.Join(workspace, "system.md")
+	writeTestFile(t, systemPath, "prompt A")
+	autoCompactionEnabled := false
+	store := mustCreateTestSession(t, workspace)
+	client := &fakeClient{responses: []llm.Response{
+		{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "first"}, Usage: llm.Usage{WindowTokens: 200000}},
+		{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "summary"}, Usage: llm.Usage{WindowTokens: 200000}},
+		{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "second"}, Usage: llm.Usage{WindowTokens: 200000}},
+	}}
+	eng := mustNewExecTestEngine(t, store, client, Config{
+		CompactionMode:        "local",
+		AutoCompactionEnabled: &autoCompactionEnabled,
+		ToolPreambles:         false,
+		SystemPromptFiles: []config.SystemPromptFile{
+			{Path: systemPath, Scope: config.SystemPromptFileScopeWorkspaceConfig},
+		},
+	})
+	if _, err := eng.SubmitUserMessage(context.Background(), "first"); err != nil {
+		t.Fatalf("submit first: %v", err)
+	}
+	writeTestFile(t, systemPath, "prompt B {{")
+	if err := eng.CompactContext(context.Background(), ""); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	if _, err := eng.SubmitUserMessage(context.Background(), "fails"); err == nil {
+		t.Fatal("expected invalid prompt refresh to fail")
+	}
+	if locked := store.Meta().Locked; locked == nil || locked.HasSystemPrompt || strings.TrimSpace(locked.SystemPrompt) != "" {
+		t.Fatalf("locked prompt after failed refresh = %+v, want stale cleared lock", locked)
+	}
+	writeTestFile(t, systemPath, "prompt B")
+	if _, err := eng.SubmitUserMessage(context.Background(), "second"); err != nil {
+		t.Fatalf("submit after prompt fix: %v", err)
+	}
+	if got := client.calls[len(client.calls)-1].SystemPrompt; got != "prompt B" {
+		t.Fatalf("system prompt after retry = %q, want prompt B", got)
+	}
+}
+
+func TestPendingSystemPromptRefreshRunsAfterReopen(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	systemDir := filepath.Join(workspace, agentsGlobalDirName)
+	if err := os.MkdirAll(systemDir, 0o755); err != nil {
+		t.Fatalf("mkdir system dir: %v", err)
+	}
+	systemPath := filepath.Join(systemDir, systemPromptFileName)
+	writeTestFile(t, systemPath, "prompt A")
+	autoCompactionEnabled := false
+	store := mustCreateTestSession(t, workspace)
+	client := &fakeClient{responses: []llm.Response{
+		{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "first"}, Usage: llm.Usage{WindowTokens: 200000}},
+		{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "summary"}, Usage: llm.Usage{WindowTokens: 200000}},
+	}}
+	eng := mustNewExecTestEngine(t, store, client, Config{
+		CompactionMode:        "local",
+		AutoCompactionEnabled: &autoCompactionEnabled,
+		ToolPreambles:         false,
+		TranscriptWorkingDir:  workspace,
+	})
+	if _, err := eng.SubmitUserMessage(context.Background(), "first"); err != nil {
+		t.Fatalf("submit first: %v", err)
+	}
+	writeTestFile(t, systemPath, "prompt B")
+	if err := eng.CompactContext(context.Background(), ""); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	if locked := store.Meta().Locked; locked == nil || locked.HasSystemPrompt || locked.SystemPrompt != "" {
+		t.Fatalf("locked prompt after compaction = %+v, want stale", locked)
+	}
+	if err := eng.Close(); err != nil {
+		t.Fatalf("close engine: %v", err)
+	}
+	reopenedStore, err := session.Open(store.Dir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	reopenedClient := &fakeClient{responses: []llm.Response{{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "second"}, Usage: llm.Usage{WindowTokens: 200000}}}}
+	reopened := mustNewExecTestEngine(t, reopenedStore, reopenedClient, Config{
+		ToolPreambles:        false,
+		TranscriptWorkingDir: workspace,
+	})
+	if _, err := reopened.SubmitUserMessage(context.Background(), "second"); err != nil {
+		t.Fatalf("submit after reopen: %v", err)
+	}
+	if got := reopenedClient.calls[0].SystemPrompt; got != "prompt B" {
+		t.Fatalf("reopened system prompt = %q, want prompt B", got)
+	}
+	if got, want := reopenedClient.calls[0].PromptCacheKey, conversationPromptCacheKey(reopened.SessionID(), 1); got != want {
+		t.Fatalf("reopened cache key = %q, want %q", got, want)
+	}
+}
+
+func TestLegacyNonBooleanSystemPromptSnapshotIsNotRefreshed(t *testing.T) {
+	store := mustCreateTestSession(t)
+	if err := store.MarkModelDispatchLocked(session.LockedContract{
+		Model:           "gpt-5",
+		SystemPrompt:    "legacy prompt",
+		HasSystemPrompt: false,
+	}); err != nil {
+		t.Fatalf("mark locked: %v", err)
+	}
+	client := &fakeClient{responses: []llm.Response{{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "ok"}, Usage: llm.Usage{WindowTokens: 200000}}}}
+	eng := mustNewExecTestEngine(t, store, client, Config{SystemPromptFiles: []config.SystemPromptFile{{Path: filepath.Join(t.TempDir(), "new.md"), Scope: config.SystemPromptFileScopeWorkspaceConfig}}})
+	if _, err := eng.SubmitUserMessage(context.Background(), "hello"); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if got := client.calls[0].SystemPrompt; got != "legacy prompt" {
+		t.Fatalf("system prompt = %q, want legacy prompt", got)
+	}
+}
+
+func TestLockedRequestShapeSurvivesRuntimeConfigToolAndWebSearchToggles(t *testing.T) {
+	store := mustCreateTestSession(t)
+	client := &fakeClient{}
+	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(
+		tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}},
+		tools.HandlerRegistration{ID: toolspec.ToolAskQuestion, Handler: fakeTool{name: toolspec.ToolAskQuestion}},
+		tools.HandlerRegistration{ID: toolspec.ToolWebSearch, Handler: fakeTool{name: toolspec.ToolWebSearch}},
+	), Config{
+		Model:         "gpt-5",
+		EnabledTools:  []toolspec.ID{toolspec.ToolExecCommand, toolspec.ToolWebSearch},
+		WebSearchMode: "native",
+		ToolPreambles: false,
+	})
+	if _, err := eng.ensureLocked(); err != nil {
+		t.Fatalf("ensureLocked: %v", err)
+	}
+	eng.cfg.EnabledTools = []toolspec.ID{toolspec.ToolAskQuestion}
+	eng.cfg.WebSearchMode = "off"
+
+	requestTools, err := eng.requestTools(context.Background(), "")
+	if err != nil {
+		t.Fatalf("requestTools: %v", err)
+	}
+	names := make([]string, 0, len(requestTools))
+	for _, tool := range requestTools {
+		names = append(names, tool.Name)
+	}
+	if strings.Join(names, ",") != string(toolspec.ToolExecCommand) {
+		t.Fatalf("request tool names = %v, want locked exec_command only", names)
+	}
+	native, err := eng.enableNativeWebSearch(context.Background())
+	if err != nil {
+		t.Fatalf("enable native web search: %v", err)
+	}
+	if !native {
+		t.Fatal("expected locked native web search to remain enabled")
 	}
 }
 

--- a/server/runtime/goal.go
+++ b/server/runtime/goal.go
@@ -260,7 +260,11 @@ func (e *Engine) RequireGoalLoopStartAllowed() error {
 }
 
 func (e *Engine) requireAskQuestionForGoalLoopStart() error {
-	for _, id := range e.cfg.EnabledTools {
+	shape, err := e.lockedRequestShape()
+	if err != nil {
+		return err
+	}
+	for _, id := range shape.EnabledTools {
 		if id == toolspec.ToolAskQuestion {
 			return nil
 		}

--- a/server/runtime/locked_contract_refresh.go
+++ b/server/runtime/locked_contract_refresh.go
@@ -1,0 +1,138 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+
+	"core/prompts"
+	"core/server/session"
+	"core/shared/config"
+	"core/shared/toolspec"
+)
+
+type PromptFacingSnapshotReloader interface {
+	ReloadPromptFacingSnapshotConfig(ctx context.Context, sessionID string) (PromptFacingSnapshotConfig, error)
+}
+
+type PromptFacingSnapshotConfig struct {
+	Settings      config.Settings
+	Source        config.SourceReport
+	ActiveToolIDs []toolspec.ID
+	WebSearchMode string
+}
+
+func (e *Engine) ensureMainPromptFacingContractFresh(ctx context.Context, locked session.LockedContract) (session.LockedContract, error) {
+	if locked.HasSystemPrompt || strings.TrimSpace(locked.SystemPrompt) != "" {
+		return locked, nil
+	}
+	reloaded, err := e.reloadPromptFacingSnapshotConfig(ctx)
+	if err != nil {
+		return session.LockedContract{}, err
+	}
+	next := locked
+	next.ToolPreambles = e.promptRefreshToolPreambles(reloaded.Settings.ToolPreambles)
+	if reloaded.Settings.ModelContextWindow > 0 {
+		next.ContextWindow = reloaded.Settings.ModelContextWindow
+	}
+	if next.ContextPercent <= 0 {
+		next.ContextPercent = e.cfg.EffectiveContextWindowPercent
+	}
+	if next.ContextWindow <= 0 {
+		next.ContextWindow = e.cfg.ContextWindowTokens
+	}
+	prompt, err := e.buildSystemPromptSnapshotFromConfig(next, e.systemPromptWorkspaceRoot(), systemPromptSnapshotOptions{
+		WorkspaceRoot:     e.systemPromptWorkspaceRoot(),
+		GlobalConfigDir:   e.cfg.GlobalConfigDir,
+		SystemPromptFiles: reloaded.Settings.SystemPromptFiles,
+	}, reloaded.ActiveToolIDs)
+	if err != nil {
+		return session.LockedContract{}, err
+	}
+	result, err := e.store.RefreshLockedMainPromptSnapshot(session.LockedMainPromptSnapshot{
+		SystemPrompt:    prompt,
+		HasSystemPrompt: true,
+		ToolPreambles:   next.ToolPreambles,
+		ContextWindow:   next.ContextWindow,
+		ContextPercent:  next.ContextPercent,
+	})
+	if commitErr := e.applyLockedContractMutationResult(result, err); commitErr != nil {
+		return session.LockedContract{}, commitErr
+	}
+	if result.Committed && result.Locked != nil {
+		return *result.Locked, nil
+	}
+	if err != nil {
+		return session.LockedContract{}, err
+	}
+	return session.LockedContract{}, nil
+}
+
+func (e *Engine) ensureReviewerPromptFresh(ctx context.Context) (string, bool, error) {
+	if prompt, ok := e.lockedReviewerPromptSnapshot(); ok || strings.TrimSpace(prompt) != "" {
+		return "", false, nil
+	}
+	reloaded, err := e.reloadPromptFacingSnapshotConfig(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	path := strings.TrimSpace(reloaded.Settings.Reviewer.SystemPromptFile)
+	if path == "" {
+		return prompts.ReviewerSystemPrompt, true, nil
+	}
+	prompt, err := buildReviewerPromptSnapshotFromFile(path)
+	if err != nil {
+		return "", false, err
+	}
+	result, err := e.store.RefreshLockedReviewerPromptSnapshot(session.LockedReviewerPromptSnapshot{
+		ReviewerPrompt:    prompt,
+		HasReviewerPrompt: true,
+	})
+	if commitErr := e.applyLockedContractMutationResult(result, err); commitErr != nil {
+		return "", false, commitErr
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return prompt, true, nil
+}
+
+func (e *Engine) reloadPromptFacingSnapshotConfig(ctx context.Context) (PromptFacingSnapshotConfig, error) {
+	if e.cfg.PromptFacingSnapshotReloader != nil {
+		return e.cfg.PromptFacingSnapshotReloader.ReloadPromptFacingSnapshotConfig(ctx, e.SessionID())
+	}
+	return PromptFacingSnapshotConfig{
+		Settings: config.Settings{
+			SystemPromptFiles:  e.cfg.SystemPromptFiles,
+			ToolPreambles:      e.cfg.ToolPreambles,
+			ModelContextWindow: e.cfg.ContextWindowTokens,
+			Reviewer: config.ReviewerSettings{
+				SystemPromptFile: e.cfg.Reviewer.SystemPromptFile,
+			},
+		},
+		ActiveToolIDs: e.lockedToolIDsFromConfigFallback(),
+		WebSearchMode: e.cfg.WebSearchMode,
+	}, nil
+}
+
+func (e *Engine) promptRefreshToolPreambles(enabled bool) *bool {
+	value := !e.cfg.HeadlessMode && enabled
+	return &value
+}
+
+func (e *Engine) lockedToolIDsFromConfigFallback() []toolspec.ID {
+	if locked, ok := e.lockedContractState().Snapshot(); ok {
+		ids := toolIDsFromNames(locked.EnabledTools)
+		if locked.HasEnabledTools || len(ids) > 0 {
+			return ids
+		}
+	}
+	return append([]toolspec.ID(nil), e.cfg.EnabledTools...)
+}
+
+func (e *Engine) applyLockedContractMutationResult(result session.LockedContractMutationResult, err error) error {
+	if result.Committed && result.Locked != nil {
+		e.lockedContractState().Set(*result.Locked)
+		return nil
+	}
+	return err
+}

--- a/server/runtime/locked_contract_refresh.go
+++ b/server/runtime/locked_contract_refresh.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"core/prompts"
@@ -64,7 +65,7 @@ func (e *Engine) ensureMainPromptFacingContractFresh(ctx context.Context, locked
 	if err != nil {
 		return session.LockedContract{}, err
 	}
-	return session.LockedContract{}, nil
+	return session.LockedContract{}, errors.New("locked main prompt snapshot refresh did not commit")
 }
 
 func (e *Engine) ensureReviewerPromptFresh(ctx context.Context) (string, bool, error) {

--- a/server/runtime/locked_request_shape.go
+++ b/server/runtime/locked_request_shape.go
@@ -1,0 +1,74 @@
+package runtime
+
+import (
+	"strings"
+
+	"core/server/session"
+	"core/shared/toolspec"
+)
+
+type lockedRequestShape struct {
+	EnabledTools  []toolspec.ID
+	WebSearchMode string
+}
+
+func (e *Engine) lockedRequestShape() (lockedRequestShape, error) {
+	locked, ok := e.lockedContractState().Snapshot()
+	if !ok {
+		return lockedRequestShape{
+			EnabledTools:  append([]toolspec.ID(nil), e.cfg.EnabledTools...),
+			WebSearchMode: strings.TrimSpace(e.cfg.WebSearchMode),
+		}, nil
+	}
+	ids := toolIDsFromNames(locked.EnabledTools)
+	hasEnabled := locked.HasEnabledTools || len(ids) > 0
+	webSearchMode := strings.TrimSpace(locked.WebSearchMode)
+	if hasEnabled && webSearchMode != "" && locked.HasEnabledTools {
+		return lockedRequestShape{EnabledTools: ids, WebSearchMode: webSearchMode}, nil
+	}
+	if hasEnabled && webSearchMode != "" && !locked.HasEnabledTools {
+		result, err := e.store.BackfillLockedRequestShape(session.LockedRequestShapeBackfill{
+			EnabledTools:    toToolNames(ids),
+			HasEnabledTools: true,
+			WebSearchMode:   webSearchMode,
+		})
+		if commitErr := e.applyLockedContractMutationResult(result, err); commitErr != nil {
+			return lockedRequestShape{}, commitErr
+		}
+		if result.Committed && result.Locked != nil {
+			ids = toolIDsFromNames(result.Locked.EnabledTools)
+			webSearchMode = strings.TrimSpace(result.Locked.WebSearchMode)
+		}
+		return lockedRequestShape{EnabledTools: ids, WebSearchMode: webSearchMode}, nil
+	}
+	fallbackIDs := append([]toolspec.ID(nil), e.cfg.EnabledTools...)
+	if hasEnabled {
+		fallbackIDs = ids
+	}
+	if webSearchMode == "" {
+		webSearchMode = strings.TrimSpace(e.cfg.WebSearchMode)
+	}
+	result, err := e.store.BackfillLockedRequestShape(session.LockedRequestShapeBackfill{
+		EnabledTools:    toToolNames(fallbackIDs),
+		HasEnabledTools: true,
+		WebSearchMode:   webSearchMode,
+	})
+	if commitErr := e.applyLockedContractMutationResult(result, err); commitErr != nil {
+		return lockedRequestShape{}, commitErr
+	}
+	if result.Committed && result.Locked != nil {
+		fallbackIDs = toolIDsFromNames(result.Locked.EnabledTools)
+		webSearchMode = strings.TrimSpace(result.Locked.WebSearchMode)
+	}
+	return lockedRequestShape{EnabledTools: fallbackIDs, WebSearchMode: webSearchMode}, nil
+}
+
+func toolIDsFromNames(names []string) []toolspec.ID {
+	out := make([]toolspec.ID, 0, len(names))
+	for _, raw := range names {
+		if id, ok := toolspec.ParseID(raw); ok {
+			out = append(out, id)
+		}
+	}
+	return out
+}

--- a/server/runtime/reviewer_request_builder.go
+++ b/server/runtime/reviewer_request_builder.go
@@ -33,7 +33,7 @@ func (e *Engine) buildReviewerRequest(ctx context.Context, reviewerClient llm.Cl
 	if err != nil {
 		return llm.Request{}, err
 	}
-	systemPrompt, err := e.reviewerSystemPrompt()
+	systemPrompt, err := e.reviewerSystemPrompt(ctx)
 	if err != nil {
 		return llm.Request{}, err
 	}

--- a/server/runtime/step_executor.go
+++ b/server/runtime/step_executor.go
@@ -70,7 +70,11 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 		}
 
 		localToolCalls := append([]llm.ToolCall(nil), resp.ToolCalls...)
-		hostedToolExecutions := hostedToolExecutionsFromOutputItems(resp.OutputItems, tools.DefinitionsFor(e.cfg.EnabledTools))
+		shape, shapeErr := e.lockedRequestShape()
+		if shapeErr != nil {
+			return stepLoopResult{}, shapeErr
+		}
+		hostedToolExecutions := hostedToolExecutionsFromOutputItems(resp.OutputItems, tools.DefinitionsFor(shape.EnabledTools))
 		if len(localToolCalls) > 0 || len(hostedToolExecutions) > 0 {
 			executedToolCall = true
 		}

--- a/server/runtime/system_prompt_snapshot.go
+++ b/server/runtime/system_prompt_snapshot.go
@@ -53,9 +53,6 @@ func buildSystemPromptSnapshotFromConfig(locked session.LockedContract, workspac
 		return "", err
 	}
 	if hasCustom {
-		if !strings.Contains(template, "{{") {
-			return prompts.WithToolPreambles(template, includeToolPreambles), nil
-		}
 		rendered, err := prompts.RenderCustomSystemPrompt(template, includeToolPreambles, args)
 		if err != nil {
 			return "", fmt.Errorf("render system prompt file %q: %w", sourcePath, err)

--- a/server/runtime/system_prompt_snapshot.go
+++ b/server/runtime/system_prompt_snapshot.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -20,23 +21,41 @@ type systemPromptSnapshotOptions struct {
 }
 
 func (e *Engine) buildSystemPromptSnapshotForRoot(locked session.LockedContract, workspaceRoot string) (string, error) {
+	fallback := promptContextBudget{window: e.cfg.ContextWindowTokens, percent: e.cfg.EffectiveContextWindowPercent}
+	enabledTools := toolIDsFromNames(locked.EnabledTools)
+	if len(enabledTools) == 0 && !locked.HasEnabledTools {
+		enabledTools = e.cfg.EnabledTools
+	}
+	return buildSystemPromptSnapshotFromConfig(locked, workspaceRoot, systemPromptSnapshotOptions{
+		WorkspaceRoot:     workspaceRoot,
+		GlobalConfigDir:   e.cfg.GlobalConfigDir,
+		SystemPromptFiles: e.cfg.SystemPromptFiles,
+	}, enabledTools, fallback)
+}
+
+func (e *Engine) buildSystemPromptSnapshotFromConfig(locked session.LockedContract, workspaceRoot string, opts systemPromptSnapshotOptions, enabledTools []toolspec.ID) (string, error) {
+	fallback := promptContextBudget{window: e.cfg.ContextWindowTokens, percent: e.cfg.EffectiveContextWindowPercent}
+	return buildSystemPromptSnapshotFromConfig(locked, workspaceRoot, opts, enabledTools, fallback)
+}
+
+func buildSystemPromptSnapshotFromConfig(locked session.LockedContract, workspaceRoot string, opts systemPromptSnapshotOptions, enabledTools []toolspec.ID, fallback promptContextBudget) (string, error) {
 	includeToolPreambles := true
 	if locked.ToolPreambles != nil {
 		includeToolPreambles = *locked.ToolPreambles
 	}
 	args := prompts.SystemPromptTemplateArgs{
-		EstimatedToolCallsForContext: e.estimatedToolCallsForLockedContext(locked),
-		EditingToolName:              editingToolName(e.cfg.EnabledTools),
+		EstimatedToolCallsForContext: estimatedToolCallsForLockedContextWithFallback(locked, fallback),
+		EditingToolName:              editingToolName(enabledTools),
 	}
-	template, sourcePath, hasCustom, err := readSystemPromptTemplate(systemPromptSnapshotOptions{
-		WorkspaceRoot:     workspaceRoot,
-		GlobalConfigDir:   e.cfg.GlobalConfigDir,
-		SystemPromptFiles: e.cfg.SystemPromptFiles,
-	})
+	opts.WorkspaceRoot = workspaceRoot
+	template, sourcePath, hasCustom, err := readSystemPromptTemplate(opts)
 	if err != nil {
 		return "", err
 	}
 	if hasCustom {
+		if !strings.Contains(template, "{{") {
+			return prompts.WithToolPreambles(template, includeToolPreambles), nil
+		}
 		rendered, err := prompts.RenderCustomSystemPrompt(template, includeToolPreambles, args)
 		if err != nil {
 			return "", fmt.Errorf("render system prompt file %q: %w", sourcePath, err)
@@ -44,6 +63,18 @@ func (e *Engine) buildSystemPromptSnapshotForRoot(locked session.LockedContract,
 		return rendered, nil
 	}
 	return prompts.WithToolPreambles(prompts.BaseSystemPrompt(args), includeToolPreambles), nil
+}
+
+func estimatedToolCallsForLockedContextWithFallback(locked session.LockedContract, fallback promptContextBudget) int {
+	window := fallback.window
+	percent := fallback.percent
+	if locked.ContextWindow > 0 {
+		window = locked.ContextWindow
+	}
+	if locked.ContextPercent > 0 {
+		percent = locked.ContextPercent
+	}
+	return config.EstimatedToolCallsForContextWindow(window, percent)
 }
 
 func editingToolName(enabled []toolspec.ID) string {
@@ -159,7 +190,12 @@ func pathWithinRoot(path string, root string) bool {
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
-func (e *Engine) reviewerSystemPrompt() (string, error) {
+func (e *Engine) reviewerSystemPrompt(ctx context.Context) (string, error) {
+	if prompt, ok, err := e.ensureReviewerPromptFresh(ctx); err != nil {
+		return "", err
+	} else if ok {
+		return prompt, nil
+	}
 	if prompt, ok := e.lockedReviewerPromptSnapshot(); ok {
 		return prompt, nil
 	}
@@ -203,6 +239,10 @@ func (e *Engine) buildReviewerPromptSnapshot() (string, error) {
 	if path == "" {
 		return prompts.ReviewerSystemPrompt, nil
 	}
+	return buildReviewerPromptSnapshotFromFile(path)
+}
+
+func buildReviewerPromptSnapshotFromFile(path string) (string, error) {
 	resolved, err := resolveConfiguredPromptFile(path)
 	if err != nil {
 		return "", fmt.Errorf("resolve reviewer.system_prompt_file %q: %w", path, err)

--- a/server/runtimewire/runtimewire_test.go
+++ b/server/runtimewire/runtimewire_test.go
@@ -40,6 +40,46 @@ func TestBuildToolRegistryAllowsHostedWebSearchWithoutLocalRuntimeBuilder(t *tes
 	}
 }
 
+func TestPromptFacingSnapshotReloaderUsesActiveWorkspaceRoot(t *testing.T) {
+	configRoot := t.TempDir()
+	originalWorkspace := t.TempDir()
+	activeWorkspace := t.TempDir()
+	for _, workspace := range []string{originalWorkspace, activeWorkspace} {
+		configDir := filepath.Join(workspace, config.ConfigDirName)
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatalf("mkdir workspace config: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("system_prompt_file = \"system.md\"\n"), 0o644); err != nil {
+			t.Fatalf("write workspace config: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(configDir, "system.md"), []byte(filepath.Base(workspace)), 0o644); err != nil {
+			t.Fatalf("write system prompt: %v", err)
+		}
+	}
+	store, err := session.Create(t.TempDir(), "ws", originalWorkspace)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	reloader := launchPromptFacingSnapshotReloader{
+		store:         store,
+		workspaceRoot: activeWorkspace,
+		configRoot:    configRoot,
+	}
+
+	reloaded, err := reloader.ReloadPromptFacingSnapshotConfig(context.Background(), store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("reload prompt-facing config: %v", err)
+	}
+	if len(reloaded.Settings.SystemPromptFiles) == 0 {
+		t.Fatal("expected system prompt files from active workspace config")
+	}
+	got := reloaded.Settings.SystemPromptFiles[len(reloaded.Settings.SystemPromptFiles)-1].Path
+	want := filepath.Join(activeWorkspace, config.ConfigDirName, "system.md")
+	if got != want {
+		t.Fatalf("system prompt path = %q, want active workspace path %q", got, want)
+	}
+}
+
 func TestBuildToolRegistryViewImageApprovedOutsidePathIsLogged(t *testing.T) {
 	workspace := t.TempDir()
 	outsideFile := filepath.Join(outsideNonTempDir(t), "doc.pdf")

--- a/server/runtimewire/wiring.go
+++ b/server/runtimewire/wiring.go
@@ -1,10 +1,12 @@
 package runtimewire
 
 import (
+	"context"
 	"strings"
 	"time"
 
 	"core/server/auth"
+	"core/server/launch"
 	"core/server/llm"
 	"core/server/runtime"
 	"core/server/session"
@@ -33,12 +35,14 @@ func (w *RuntimeWiring) Close() error {
 }
 
 type RuntimeWiringOptions struct {
-	OnEvent     func(evt runtime.Event)
-	Headless    bool
-	FastMode    *runtime.FastModeState
-	Sources     map[string]string
-	Client      llm.Client
-	WorkflowRun *workflowruntime.Config
+	OnEvent                             func(evt runtime.Event)
+	Headless                            bool
+	FastMode                            *runtime.FastModeState
+	Sources                             map[string]string
+	Client                              llm.Client
+	WorkflowRun                         *workflowruntime.Config
+	PromptFacingSnapshotReloader        runtime.PromptFacingSnapshotReloader
+	SkipContinuationAgentRoleValidation bool
 	// GlobalConfigDir is the absolute persistence root that owns model-visible
 	// global context (AGENTS.md, system prompt, skills). Empty falls back to
 	// ~/.kent inside the runtime resolvers.
@@ -134,6 +138,15 @@ func NewRuntimeWiringWithBackground(store *session.Store, active config.Settings
 			logger.Logf("runtime.event.drop count=%d kind=%s step_id=%s", total, evt.Kind, evt.StepID)
 		}
 	})
+	promptReloader := opts.PromptFacingSnapshotReloader
+	if promptReloader == nil {
+		promptReloader = launchPromptFacingSnapshotReloader{
+			store:                               store,
+			workspaceRoot:                       workspaceRoot,
+			configRoot:                          opts.GlobalConfigDir,
+			skipContinuationAgentRoleValidation: opts.SkipContinuationAgentRoleValidation,
+		}
+	}
 	eng, err = runtime.New(store, client, toolRegistry, runtime.Config{
 		Model:                         active.Model,
 		Temperature:                   1,
@@ -143,6 +156,7 @@ func NewRuntimeWiringWithBackground(store *session.Store, active config.Settings
 		FastModeEnabled:               active.PriorityRequestMode,
 		FastModeState:                 opts.FastMode,
 		WebSearchMode:                 active.WebSearch,
+		PromptFacingSnapshotReloader:  promptReloader,
 		ProviderCapabilitiesOverride:  mainProvider.ProviderCapabilitiesOverride,
 		EnabledTools:                  enabledTools,
 		DisabledSkills:                config.DisabledSkillToggles(active),
@@ -188,6 +202,30 @@ func NewRuntimeWiringWithBackground(store *session.Store, active config.Settings
 		EventBridge: eventBridge,
 		Background:  background,
 		LocalTools:  localTools,
+	}, nil
+}
+
+type launchPromptFacingSnapshotReloader struct {
+	store                               *session.Store
+	workspaceRoot                       string
+	configRoot                          string
+	skipContinuationAgentRoleValidation bool
+}
+
+func (r launchPromptFacingSnapshotReloader) ReloadPromptFacingSnapshotConfig(context.Context, string) (runtime.PromptFacingSnapshotConfig, error) {
+	app, err := config.Load(r.workspaceRoot, config.LoadOptions{ConfigRoot: r.configRoot})
+	if err != nil {
+		return runtime.PromptFacingSnapshotConfig{}, err
+	}
+	resolved, err := launch.ResolvePromptFacingSnapshotConfig(app, r.store, r.skipContinuationAgentRoleValidation)
+	if err != nil {
+		return runtime.PromptFacingSnapshotConfig{}, err
+	}
+	return runtime.PromptFacingSnapshotConfig{
+		Settings:      resolved.Settings,
+		Source:        resolved.Source,
+		ActiveToolIDs: append([]toolspec.ID(nil), resolved.ActiveToolIDs...),
+		WebSearchMode: resolved.WebSearchMode,
 	}, nil
 }
 

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -272,6 +272,45 @@ func (s *Store) unlockAndObservePersistence(observation *persistenceObservation,
 	return s.observePersistence(observation)
 }
 
+func (s *Store) mutateLockedContractWithCommitStatus(mutator func(*LockedContract)) (LockedContractMutationResult, error) {
+	if mutator == nil {
+		return LockedContractMutationResult{}, nil
+	}
+	s.mu.Lock()
+	if s.meta.Locked == nil {
+		s.mu.Unlock()
+		return LockedContractMutationResult{}, nil
+	}
+	previousMeta := s.meta
+	previousMetadataVersion := s.metadataVersion
+	previousPersistedMetaVersion := s.persistedMetaVersion
+	next := *s.meta.Locked
+	mutator(&next)
+	s.meta.Locked = &next
+	s.meta.UpdatedAt = time.Now().UTC()
+	observation, persistErr := s.persistMetaLocked()
+	if persistErr != nil {
+		s.meta = previousMeta
+		s.metadataVersion = previousMetadataVersion
+		s.persistedMetaVersion = previousPersistedMetaVersion
+		s.mu.Unlock()
+		return LockedContractMutationResult{Committed: false, Locked: cloneLockedContract(previousMeta.Locked)}, persistErr
+	}
+	committed := cloneLockedContract(s.meta.Locked)
+	fileless := s.options.filelessMeta
+	s.mu.Unlock()
+	observeErr := s.observePersistence(observation)
+	if observeErr != nil && fileless {
+		s.mu.Lock()
+		s.meta = previousMeta
+		s.metadataVersion = previousMetadataVersion
+		s.persistedMetaVersion = previousPersistedMetaVersion
+		s.mu.Unlock()
+		return LockedContractMutationResult{Committed: false, Locked: cloneLockedContract(previousMeta.Locked)}, observeErr
+	}
+	return LockedContractMutationResult{Committed: true, Locked: committed}, observeErr
+}
+
 func (s *Store) EnsureDurable() error {
 	return s.mutateAndPersist(func() error { return nil })
 }
@@ -592,6 +631,8 @@ func (s *Store) MarkModelDispatchLocked(contract LockedContract) error {
 	return s.mutateAndPersist(func() error {
 		s.meta.ModelRequestCount++
 		if s.meta.Locked == nil {
+			contract.EnabledTools = append([]string(nil), contract.EnabledTools...)
+			contract.HasEnabledTools = true
 			contract.LockedAt = time.Now().UTC()
 			s.meta.Locked = &contract
 		}
@@ -664,6 +705,52 @@ func (s *Store) BackfillLockedReviewerPrompt(reviewerPrompt string) error {
 	s.meta.Locked.HasReviewerPrompt = true
 	s.meta.UpdatedAt = time.Now().UTC()
 	return s.unlockAndObservePersistence(s.persistMetaLocked())
+}
+
+func (s *Store) MarkLockedPromptFacingSnapshotsStale() (LockedContractMutationResult, error) {
+	return s.mutateLockedContractWithCommitStatus(func(locked *LockedContract) {
+		locked.SystemPrompt = ""
+		locked.HasSystemPrompt = false
+		locked.ReviewerPrompt = ""
+		locked.HasReviewerPrompt = false
+	})
+}
+
+func (s *Store) RefreshLockedMainPromptSnapshot(snapshot LockedMainPromptSnapshot) (LockedContractMutationResult, error) {
+	return s.mutateLockedContractWithCommitStatus(func(locked *LockedContract) {
+		locked.SystemPrompt = strings.TrimSpace(snapshot.SystemPrompt)
+		locked.HasSystemPrompt = snapshot.HasSystemPrompt
+		locked.ToolPreambles = cloneBoolPtr(snapshot.ToolPreambles)
+		if snapshot.ContextWindow > 0 {
+			locked.ContextWindow = snapshot.ContextWindow
+		}
+		if snapshot.ContextPercent > 0 {
+			locked.ContextPercent = snapshot.ContextPercent
+		}
+	})
+}
+
+func (s *Store) RefreshLockedReviewerPromptSnapshot(snapshot LockedReviewerPromptSnapshot) (LockedContractMutationResult, error) {
+	return s.mutateLockedContractWithCommitStatus(func(locked *LockedContract) {
+		locked.ReviewerPrompt = strings.TrimSpace(snapshot.ReviewerPrompt)
+		locked.HasReviewerPrompt = snapshot.HasReviewerPrompt
+	})
+}
+
+func (s *Store) BackfillLockedRequestShape(fields LockedRequestShapeBackfill) (LockedContractMutationResult, error) {
+	return s.mutateLockedContractWithCommitStatus(func(locked *LockedContract) {
+		locked.EnabledTools = append([]string(nil), fields.EnabledTools...)
+		locked.HasEnabledTools = fields.HasEnabledTools
+		locked.WebSearchMode = strings.TrimSpace(fields.WebSearchMode)
+	})
+}
+
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	copyValue := *value
+	return &copyValue
 }
 
 func (s *Store) AppendEvent(stepID, kind string, payload any) (Event, bool, error) {

--- a/server/session/store_test.go
+++ b/server/session/store_test.go
@@ -207,6 +207,144 @@ func TestLockedContractPersistenceIncludesSystemPromptButNotToolSchema(t *testin
 	}
 }
 
+func TestLockedContractPersistenceIncludesExplicitZeroToolsAndWebSearchMode(t *testing.T) {
+	store := newSessionTestStore(t)
+	if err := store.MarkModelDispatchLocked(LockedContract{
+		Model:             "gpt-5",
+		SystemPrompt:      "prompt",
+		HasSystemPrompt:   true,
+		EnabledTools:      nil,
+		HasEnabledTools:   true,
+		WebSearchMode:     "native",
+		ReviewerPrompt:    "reviewer",
+		HasReviewerPrompt: true,
+	}); err != nil {
+		t.Fatalf("mark model dispatch locked: %v", err)
+	}
+	opened, err := Open(store.Dir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	locked := opened.Meta().Locked
+	if locked == nil || !locked.HasEnabledTools || len(locked.EnabledTools) != 0 || locked.WebSearchMode != "native" {
+		t.Fatalf("locked request shape = %+v, want explicit zero tools and native web search", locked)
+	}
+}
+
+func TestLockedPromptFacingMutationsPreserveLifetimeFields(t *testing.T) {
+	store := newSessionTestStore(t)
+	toolPreambles := true
+	lockedAt := store.Meta().CreatedAt
+	if err := store.MarkModelDispatchLocked(LockedContract{
+		Model:             "gpt-5",
+		Temperature:       0.7,
+		MaxOutputToken:    1000,
+		SystemPrompt:      "prompt A",
+		HasSystemPrompt:   true,
+		ReviewerPrompt:    "reviewer A",
+		HasReviewerPrompt: true,
+		ContextWindow:     100,
+		ContextPercent:    50,
+		EnabledTools:      []string{"shell"},
+		HasEnabledTools:   true,
+		WebSearchMode:     "native",
+		ToolPreambles:     &toolPreambles,
+		LockedAt:          lockedAt,
+	}); err != nil {
+		t.Fatalf("mark model dispatch locked: %v", err)
+	}
+	stale, err := store.MarkLockedPromptFacingSnapshotsStale()
+	if err != nil {
+		t.Fatalf("mark stale: %v", err)
+	}
+	if !stale.Committed || stale.Locked == nil {
+		t.Fatalf("stale result = %+v, want committed lock", stale)
+	}
+	if stale.Locked.SystemPrompt != "" || stale.Locked.HasSystemPrompt || stale.Locked.ReviewerPrompt != "" || stale.Locked.HasReviewerPrompt {
+		t.Fatalf("stale locked prompts = %+v, want cleared", stale.Locked)
+	}
+	if stale.Locked.Model != "gpt-5" || stale.Locked.WebSearchMode != "native" || len(stale.Locked.EnabledTools) != 1 || !stale.Locked.HasEnabledTools {
+		t.Fatalf("stale lifetime fields = %+v", stale.Locked)
+	}
+	refreshed, err := store.RefreshLockedMainPromptSnapshot(LockedMainPromptSnapshot{
+		SystemPrompt:    "prompt B",
+		HasSystemPrompt: true,
+		ToolPreambles:   &toolPreambles,
+		ContextWindow:   200,
+		ContextPercent:  60,
+	})
+	if err != nil {
+		t.Fatalf("refresh main: %v", err)
+	}
+	if refreshed.Locked.SystemPrompt != "prompt B" || !refreshed.Locked.HasSystemPrompt || refreshed.Locked.ReviewerPrompt != "" {
+		t.Fatalf("main refresh lock = %+v", refreshed.Locked)
+	}
+	reviewer, err := store.RefreshLockedReviewerPromptSnapshot(LockedReviewerPromptSnapshot{ReviewerPrompt: "reviewer B", HasReviewerPrompt: true})
+	if err != nil {
+		t.Fatalf("refresh reviewer: %v", err)
+	}
+	if reviewer.Locked.ReviewerPrompt != "reviewer B" || !reviewer.Locked.HasReviewerPrompt || reviewer.Locked.SystemPrompt != "prompt B" {
+		t.Fatalf("reviewer refresh lock = %+v", reviewer.Locked)
+	}
+}
+
+func TestLockedRequestShapeBackfillPersistsTogether(t *testing.T) {
+	store := newSessionTestStore(t)
+	if err := store.MarkModelDispatchLocked(LockedContract{Model: "gpt-5", SystemPrompt: "prompt", HasSystemPrompt: true}); err != nil {
+		t.Fatalf("mark model dispatch locked: %v", err)
+	}
+	result, err := store.BackfillLockedRequestShape(LockedRequestShapeBackfill{
+		EnabledTools:    []string{"shell", "patch"},
+		HasEnabledTools: true,
+		WebSearchMode:   "native",
+	})
+	if err != nil {
+		t.Fatalf("backfill request shape: %v", err)
+	}
+	if !result.Committed || result.Locked == nil || !result.Locked.HasEnabledTools || strings.Join(result.Locked.EnabledTools, ",") != "shell,patch" || result.Locked.WebSearchMode != "native" {
+		t.Fatalf("request shape result = %+v", result)
+	}
+	opened, err := Open(store.Dir())
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if locked := opened.Meta().Locked; locked == nil || !locked.HasEnabledTools || locked.WebSearchMode != "native" || len(locked.EnabledTools) != 2 {
+		t.Fatalf("persisted request shape = %+v", locked)
+	}
+}
+
+func TestLockedContractMutationObserverCommitSemantics(t *testing.T) {
+	fileObserver := &recordingPersistenceObserver{err: os.ErrPermission}
+	fileStore, err := Create(t.TempDir(), "ws", t.TempDir(), WithPersistenceObserver(fileObserver))
+	if err != nil {
+		t.Fatalf("create file store: %v", err)
+	}
+	if err := fileStore.MarkModelDispatchLocked(LockedContract{Model: "gpt-5", SystemPrompt: "prompt A", HasSystemPrompt: true}); err == nil {
+		t.Fatal("expected observer error on initial lock")
+	}
+	result, err := fileStore.MarkLockedPromptFacingSnapshotsStale()
+	if err == nil || !result.Committed || result.Locked == nil || result.Locked.HasSystemPrompt {
+		t.Fatalf("file-backed observer result=%+v err=%v, want committed observer warning", result, err)
+	}
+
+	filelessObserver := &recordingPersistenceObserver{err: os.ErrPermission}
+	filelessStore, err := Create(t.TempDir(), "ws", t.TempDir(), WithFilelessMetadataPersistence(), WithPersistenceObserver(filelessObserver))
+	if err != nil {
+		t.Fatalf("create fileless store: %v", err)
+	}
+	if err := filelessStore.MarkModelDispatchLocked(LockedContract{Model: "gpt-5", SystemPrompt: "prompt A", HasSystemPrompt: true}); err == nil {
+		t.Fatal("expected observer error on initial fileless lock")
+	}
+	before := filelessStore.Meta().Locked
+	result, err = filelessStore.MarkLockedPromptFacingSnapshotsStale()
+	if err == nil || result.Committed {
+		t.Fatalf("fileless observer result=%+v err=%v, want uncommitted failure", result, err)
+	}
+	if after := filelessStore.Meta().Locked; before == nil || after == nil || after.SystemPrompt != before.SystemPrompt || !after.HasSystemPrompt {
+		t.Fatalf("fileless lock after failed mutation = %+v, before %+v", after, before)
+	}
+}
+
 func TestReadEventsHandlesLargeJSONLines(t *testing.T) {
 	store := newSessionTestStore(t)
 

--- a/server/session/types.go
+++ b/server/session/types.go
@@ -16,10 +16,36 @@ type LockedContract struct {
 	ContextWindow     int                        `json:"context_window,omitempty"`
 	ContextPercent    int                        `json:"context_percent,omitempty"`
 	EnabledTools      []string                   `json:"enabled_tools,omitempty"`
+	HasEnabledTools   bool                       `json:"has_enabled_tools,omitempty"`
+	WebSearchMode     string                     `json:"web_search_mode,omitempty"`
 	ToolPreambles     *bool                      `json:"tool_preambles,omitempty"`
 	ModelCapabilities LockedModelCapabilities    `json:"model_capabilities,omitempty"`
 	ProviderContract  LockedProviderCapabilities `json:"provider_contract,omitempty"`
 	LockedAt          time.Time                  `json:"locked_at"`
+}
+
+type LockedMainPromptSnapshot struct {
+	SystemPrompt    string
+	HasSystemPrompt bool
+	ToolPreambles   *bool
+	ContextWindow   int
+	ContextPercent  int
+}
+
+type LockedReviewerPromptSnapshot struct {
+	ReviewerPrompt    string
+	HasReviewerPrompt bool
+}
+
+type LockedRequestShapeBackfill struct {
+	EnabledTools    []string
+	HasEnabledTools bool
+	WebSearchMode   string
+}
+
+type LockedContractMutationResult struct {
+	Committed bool
+	Locked    *LockedContract
 }
 
 type LockedModelCapabilities struct {


### PR DESCRIPTION
## Summary
- Clear locked main/reviewer prompt snapshots after successful compaction and lazily refresh them on the next ordinary request from the launch/config reload path.
- Preserve session-lifetime request-shape locks for enabled tool IDs and native web search, with committed-state legacy backfill and explicit zero-tool support.
- Keep compaction summary/cache-observation paths non-mutating while updating public/internal docs for compaction-generation prompt snapshots.

## Verification
- `./scripts/test.sh ./server/runtimewire -run 'TestPromptFacingSnapshotReloaderUsesActiveWorkspaceRoot'`\n- `./scripts/test.sh ./server/session ./server/runtime ./server/launch ./server/runtimewire`\n- `./scripts/test.sh ./server/session ./server/runtime ./server/launch ./server/runtimewire ./server/sessionruntime ./server/runprompt ./server/workflowrunner`\n- `./scripts/build.sh --output ./bin/kent`\n\nAdditional QA from workflow review included targeted prompt/compaction/request-shape tests, full repository `./scripts/test.sh`, and `./bin/kent --version` reporting `2.1.0`.\n\nCloses #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for system and supervisor prompt behavior, clarifying that edits take effect after successful context compaction rather than requiring a new session.

* **Improvements**
  * Enhanced system and supervisor prompt snapshot handling to refresh independently after context compaction while preserving locked session parameters across compaction generations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->