### PR TITLE
fix: allow agent goal completion from shell

### DIFF
--- a/cli/kent/goal_command.go
+++ b/cli/kent/goal_command.go
@@ -235,13 +235,21 @@ func goalCompleteSubcommand(args []string, stdout io.Writer, stderr io.Writer) i
 	}
 	completeCtx, completeCancel := context.WithTimeout(context.Background(), goalCommandTimeout)
 	defer completeCancel()
-	resp, err := remote.CompleteGoal(completeCtx, serverapi.RuntimeGoalStatusRequest{ClientRequestID: uuid.NewString(), SessionID: target, Actor: actor})
+	resp, err := remote.CompleteGoal(completeCtx, serverapi.RuntimeGoalStatusRequest{ClientRequestID: uuid.NewString(), SessionID: target, Actor: actor, ShellToken: goalCommandShellToken(agent)})
 	if err != nil {
 		fmt.Fprintln(stderr, formatGoalCommandError(err))
 		return 1
 	}
 	writeGoalShowText(stdout, resp.Goal)
 	return 0
+}
+
+func goalCommandShellToken(agent bool) string {
+	if !agent {
+		return ""
+	}
+	token, _ := sessionenv.LookupShellToken(os.LookupEnv)
+	return token
 }
 
 func goalAlreadyComplete(goal *serverapi.RuntimeGoal) bool {

--- a/cli/kent/goal_command_test.go
+++ b/cli/kent/goal_command_test.go
@@ -208,6 +208,7 @@ func TestGoalAgentCompleteRequiresConfirmTripwire(t *testing.T) {
 
 	stdout := new(strings.Builder)
 	stderr.Reset()
+	t.Setenv(sessionenv.ShellTokenEnv, "shell-token-1")
 	if code := goalSubcommand([]string{"complete", "--confirm"}, stdout, stderr); code != 0 {
 		t.Fatalf("goal complete --confirm exit = %d stderr=%q", code, stderr.String())
 	}
@@ -216,6 +217,9 @@ func TestGoalAgentCompleteRequiresConfirmTripwire(t *testing.T) {
 	}
 	if remote.completeReq[0].SessionID != "session-1" || remote.completeReq[0].Actor != "agent" {
 		t.Fatalf("complete req = %+v", remote.completeReq[0])
+	}
+	if remote.completeReq[0].ShellToken != "shell-token-1" {
+		t.Fatalf("complete shell token = %q, want shell-token-1", remote.completeReq[0].ShellToken)
 	}
 }
 
@@ -388,27 +392,23 @@ func TestGoalCommandSubprocessTargetsLiveSessionFromUnboundWorktree(t *testing.T
 		t.Fatalf("persisted goal after rejected overwrite = %+v", goal)
 	}
 
-	completeOutput, completeErr, completeRunErr := runGoalCommandSubprocessRaw(t, kentPath, unboundWorktree, store.Meta().SessionID, "complete", "--confirm")
-	if completeRunErr == nil {
-		t.Fatalf("goal complete unexpectedly succeeded stdout=%q stderr=%q", completeOutput, completeErr)
-	}
-	if completeOutput != "" {
-		t.Fatalf("goal complete stdout = %q, want empty", completeOutput)
-	}
-
-	setOutput, setErr, setRunErr := runGoalCommandSubprocessRaw(t, kentPath, unboundWorktree, store.Meta().SessionID, "set", "follow-up live goal CLI")
-	if setRunErr == nil {
-		t.Fatalf("goal set after rejected complete unexpectedly succeeded stdout=%q stderr=%q", setOutput, setErr)
+	if err := remote.SubmitUserShellCommand(context.Background(), serverapi.RuntimeSubmitUserShellCommandRequest{
+		ClientRequestID:   "shell-goal-complete-e2e",
+		SessionID:         store.Meta().SessionID,
+		ControllerLeaseID: activateResp.LeaseID,
+		Command:           shellQuote(kentPath) + " goal complete --confirm",
+	}); err != nil {
+		t.Fatalf("shell goal complete: %v", err)
 	}
 	record, err = metadataStore.ResolvePersistedSession(context.Background(), store.Meta().SessionID)
 	if err != nil {
-		t.Fatalf("ResolvePersistedSession after rejected follow-up set: %v", err)
+		t.Fatalf("ResolvePersistedSession after complete: %v", err)
 	}
 	if record.Meta == nil {
-		t.Fatal("persisted metadata missing after rejected follow-up set")
+		t.Fatal("persisted metadata missing after complete")
 	}
-	if goal := record.Meta.Goal; goal == nil || goal.Objective != "exercise live goal CLI" || goal.Status != session.GoalStatusActive {
-		t.Fatalf("persisted goal after rejected follow-up set = %+v", goal)
+	if goal := record.Meta.Goal; goal == nil || goal.Objective != "exercise live goal CLI" || goal.Status != session.GoalStatusComplete {
+		t.Fatalf("persisted goal after complete = %+v", goal)
 	}
 }
 

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -236,6 +236,7 @@
 - Goal CLI never mutates session DB directly. It crosses live server/runtime RPC.
 - `kent service restart`, `kent service restart --if-installed`, `kent service install` without `--no-start`, `kent service start`, `kent service stop`, and `kent service uninstall` without `--keep-running` refuse to run from Kent shell commands when `KENT_SESSION_ID` is present, before backend stop/restart or installation-state mutation, because those commands can stop or restart the server hosting current agent work.
 - Standalone `kent goal` commands do not acquire controller leases; model-shell CLI has narrow lease-free authority for same-session show, first-time set, and confirm-gated complete.
+- Confirmed model-shell goal completion carries a Kent-managed shell token, resolves the current live runtime, and records the completion inside the active model turn instead of acquiring a competing primary-run lease.
 - While a model turn runs, TUI goal lifecycle accepts only pause and clear.
 - Ctrl+C during active goal work keeps persisted status `active` and creates runtime-local suspension only. The next user message auto-resumes the suspended goal loop after its turn completes (no `/goal resume` needed); an explicit `/goal pause` is still the hard pause. A user turn that is itself interrupted leaves the loop suspended.
 - The goal status-line indicator shows the animated spinner only while a goal run is executing; when the goal is `active` but idle (e.g. after Ctrl+C), it shows the idle status dot.

--- a/server/core/composition.go
+++ b/server/core/composition.go
@@ -114,7 +114,7 @@ func NewWithContext(ctx context.Context, cfg config.App, authSupport serverboots
 	sessionStoreResolver := registry.NewGlobalPersistenceSessionResolver(cfg.PersistenceRoot, storeOptions...)
 	promptControlService := promptcontrol.NewPromptControlService(runtimeRegistry).WithControllerLeaseVerifier(sessionRuntimeService).WithCollaborativeRuntimeResolver(sessionRuntimeService)
 	promptActivityService := promptcontrol.NewPromptActivityService(runtimeRegistry)
-	runtimeControlService := runtimecontrol.NewService(runtimeRegistry, runtimeRegistry).WithControllerLeaseVerifier(sessionRuntimeService).WithCollaborativeRuntimeResolver(sessionRuntimeService).WithPromptHistoryStore(metadataStore).WithWorkflowSessionResolver(sessionStoreResolver)
+	runtimeControlService := runtimecontrol.NewService(runtimeRegistry, runtimeRegistry).WithControllerLeaseVerifier(sessionRuntimeService).WithCollaborativeRuntimeResolver(sessionRuntimeService).WithPromptHistoryStore(metadataStore).WithWorkflowSessionResolver(sessionStoreResolver).WithShellTokenVerifier(runtimeSupport.Background)
 	worktreeService := worktree.NewService(metadataStore, nil, runtimeRegistry, sessionRuntimeService, runtimeSupport.Background, runtimeControlService, worktree.ServiceOptions{BaseDir: cfg.Settings.Worktrees.BaseDir, SetupScript: cfg.Settings.Worktrees.SetupScript})
 	projectViews := client.NewLoopbackProjectViewClient(projectService)
 	authBootstrapService := authservice.NewBootstrapService(authSupport.AuthManager, authSupport.OAuthOptions, cfg.Settings, rpccontract.AllowedPreAuthMethods())

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -41,6 +41,10 @@ type WorkflowSessionResolver interface {
 	ResolveSessionStore(ctx context.Context, sessionID string) (*session.Store, error)
 }
 
+type ShellTokenVerifier interface {
+	VerifyShellToken(sessionID string, token string) bool
+}
+
 var errWorkflowTaskSessionAutoCompactionDisable = errors.New("auto-compaction cannot be disabled for workflow task sessions")
 
 type Service struct {
@@ -50,6 +54,7 @@ type Service struct {
 	control        ControllerLeaseVerifier
 	promptStore    PromptHistoryStore
 	workflowStates WorkflowSessionResolver
+	shellTokens    ShellTokenVerifier
 	sessionNames   *requestmemo.Memo[sessionStringMemoRequest, struct{}]
 	thinkingLevels *requestmemo.Memo[sessionStringMemoRequest, struct{}]
 	fastModes      *requestmemo.Memo[sessionBoolMemoRequest, serverapi.RuntimeSetFastModeEnabledResponse]
@@ -190,6 +195,14 @@ func (s *Service) WithWorkflowSessionResolver(resolver WorkflowSessionResolver) 
 		return nil
 	}
 	s.workflowStates = resolver
+	return s
+}
+
+func (s *Service) WithShellTokenVerifier(verifier ShellTokenVerifier) *Service {
+	if s == nil {
+		return nil
+	}
+	s.shellTokens = verifier
 	return s
 }
 
@@ -742,7 +755,7 @@ func (s *Service) setGoalStatus(ctx context.Context, req serverapi.RuntimeGoalSt
 	memoReq := goalStatusMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Status: strings.TrimSpace(string(status)), Actor: strings.TrimSpace(req.Actor)}
 	return s.goalStatuses.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameGoalStatusMemoRequest, func(ctx context.Context) (serverapi.RuntimeGoalShowResponse, error) {
 		var response serverapi.RuntimeGoalShowResponse
-		err := s.withGoalMutationAccess(ctx, req.SessionID, req.ControllerLeaseID, func(engine *runtime.Engine) error {
+		err := s.withGoalStatusMutationAccess(ctx, req, status, func(engine *runtime.Engine) error {
 			if status == session.GoalStatusComplete {
 				current := engine.Goal()
 				if current != nil && current.Status == session.GoalStatusComplete {
@@ -814,6 +827,26 @@ func (s *Service) withGoalMutationAccess(ctx context.Context, sessionID string, 
 		}
 	}
 	return s.withRuntimeAccess(ctx, sessionID, leaseID, serverapi.SessionRuntimeOperationGoalManage, fn)
+}
+
+func (s *Service) withGoalStatusMutationAccess(ctx context.Context, req serverapi.RuntimeGoalStatusRequest, status session.GoalStatus, fn func(*runtime.Engine) error) error {
+	if s.agentGoalCompletionUsesLeaseFreeRuntimeAccess(req, status) {
+		engine, err := s.resolve(ctx, req.SessionID)
+		if err != nil {
+			return err
+		}
+		return fn(engine)
+	}
+	return s.withGoalMutationAccess(ctx, req.SessionID, req.ControllerLeaseID, fn)
+}
+
+func (s *Service) agentGoalCompletionUsesLeaseFreeRuntimeAccess(req serverapi.RuntimeGoalStatusRequest, status session.GoalStatus) bool {
+	return strings.TrimSpace(req.ControllerLeaseID) == "" &&
+		strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) &&
+		status == session.GoalStatusComplete &&
+		s != nil &&
+		s.shellTokens != nil &&
+		s.shellTokens.VerifyShellToken(req.SessionID, req.ShellToken)
 }
 
 func (s *Service) rejectWorkflowAutoCompactionDisable(ctx context.Context, sessionID string, engine *runtime.Engine) error {

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -124,6 +124,16 @@ type stubPrimaryRunGate struct {
 	sessions []string
 }
 
+type stubShellTokenVerifier struct {
+	valid bool
+	calls int
+}
+
+func (v *stubShellTokenVerifier) VerifyShellToken(string, string) bool {
+	v.calls++
+	return v.valid
+}
+
 func (g *stubPrimaryRunGate) AcquirePrimaryRun(sessionID string) (primaryrun.Lease, error) {
 	g.acquire++
 	g.sessions = append(g.sessions, sessionID)
@@ -437,6 +447,74 @@ func TestServiceGoalMutationsAllowCollaborativeGoalManageAccess(t *testing.T) {
 	}
 	if gate.acquire != 1 || gate.release != 1 {
 		t.Fatalf("gate acquire/release = %d/%d, want 1/1", gate.acquire, gate.release)
+	}
+}
+
+func TestServiceAgentCompleteGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
+	store, engine := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	if _, err := engine.SetGoal("ship goal mode", session.GoalActorUser); err != nil {
+		t.Fatalf("SetGoal: %v", err)
+	}
+	gate := &stubPrimaryRunGate{err: primaryrun.ErrActivePrimaryRun}
+	collaborative := &stubCollaborativeRuntimeResolver{engine: engine}
+	tokens := &stubShellTokenVerifier{valid: true}
+	service := NewService(stubRuntimeResolver{engine: engine}, gate).WithCollaborativeRuntimeResolver(collaborative).WithShellTokenVerifier(tokens)
+
+	resp, err := service.CompleteGoal(context.Background(), serverapi.RuntimeGoalStatusRequest{
+		ClientRequestID: "goal-complete-agent-current-turn",
+		SessionID:       store.Meta().SessionID,
+		ShellToken:      "shell-token",
+		Actor:           "agent",
+	})
+	if err != nil {
+		t.Fatalf("CompleteGoal: %v", err)
+	}
+	if resp.Goal == nil || resp.Goal.Status != string(session.GoalStatusComplete) {
+		t.Fatalf("complete response = %+v, want complete goal", resp.Goal)
+	}
+	if goal := store.Meta().Goal; goal == nil || goal.Status != session.GoalStatusComplete {
+		t.Fatalf("persisted goal = %+v, want complete", goal)
+	}
+	if gate.acquire != 0 || gate.release != 0 {
+		t.Fatalf("gate acquire/release = %d/%d, want 0/0", gate.acquire, gate.release)
+	}
+	if collaborative.calls != 0 {
+		t.Fatalf("collaborative calls = %d, want 0", collaborative.calls)
+	}
+	if tokens.calls != 1 {
+		t.Fatalf("token verifier calls = %d, want 1", tokens.calls)
+	}
+}
+
+func TestServiceAgentCompleteGoalWithoutShellTokenKeepsPrimaryRunGate(t *testing.T) {
+	store, engine := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	if _, err := engine.SetGoal("ship goal mode", session.GoalActorUser); err != nil {
+		t.Fatalf("SetGoal: %v", err)
+	}
+	gate := &stubPrimaryRunGate{err: primaryrun.ErrActivePrimaryRun}
+	collaborative := &stubCollaborativeRuntimeResolver{engine: engine}
+	tokens := &stubShellTokenVerifier{valid: false}
+	service := NewService(stubRuntimeResolver{engine: engine}, gate).WithCollaborativeRuntimeResolver(collaborative).WithShellTokenVerifier(tokens)
+
+	_, err := service.CompleteGoal(context.Background(), serverapi.RuntimeGoalStatusRequest{
+		ClientRequestID: "goal-complete-agent-no-token",
+		SessionID:       store.Meta().SessionID,
+		Actor:           "agent",
+	})
+	if !errors.Is(err, primaryrun.ErrActivePrimaryRun) {
+		t.Fatalf("CompleteGoal error = %v, want active primary run", err)
+	}
+	if goal := store.Meta().Goal; goal == nil || goal.Status != session.GoalStatusActive {
+		t.Fatalf("persisted goal = %+v, want active", goal)
+	}
+	if gate.acquire != 1 || gate.release != 0 {
+		t.Fatalf("gate acquire/release = %d/%d, want 1/0", gate.acquire, gate.release)
+	}
+	if collaborative.calls != 0 {
+		t.Fatalf("collaborative calls = %d, want 0", collaborative.calls)
+	}
+	if tokens.calls != 1 {
+		t.Fatalf("token verifier calls = %d, want 1", tokens.calls)
 	}
 }
 
@@ -929,6 +1007,23 @@ func TestServiceCollaborativeGoalMutationsRejectActivePrimaryRun(t *testing.T) {
 					ClientRequestID: "goal-set-busy",
 					SessionID:       sessionID,
 					Objective:       "ship goal mode",
+					Actor:           "user",
+				})
+				return err
+			},
+		},
+		{
+			name: "complete-user",
+			prepare: func(t *testing.T, engine *runtime.Engine) {
+				t.Helper()
+				if _, err := engine.SetGoal("ship goal mode", session.GoalActorUser); err != nil {
+					t.Fatalf("SetGoal: %v", err)
+				}
+			},
+			call: func(ctx context.Context, service *Service, sessionID string) error {
+				_, err := service.CompleteGoal(ctx, serverapi.RuntimeGoalStatusRequest{
+					ClientRequestID: "goal-complete-user-busy",
+					SessionID:       sessionID,
 					Actor:           "user",
 				})
 				return err

--- a/server/tools/shell/manager.go
+++ b/server/tools/shell/manager.go
@@ -20,6 +20,7 @@ type Manager struct {
 	mu                  sync.Mutex
 	nextID              int
 	entries             map[string]*processEntry
+	sessionTokens       map[string]map[string]int
 	tempDir             string
 	onEvent             func(Event)
 	minimumExecToBgTime time.Duration
@@ -64,6 +65,7 @@ func NewManager(opts ...ManagerOption) (*Manager, error) {
 	mgr := &Manager{
 		nextID:              initialProcessID,
 		entries:             make(map[string]*processEntry),
+		sessionTokens:       make(map[string]map[string]int),
 		tempDir:             tempDir,
 		minimumExecToBgTime: defaultMinimumExecToBgTime,
 		closeGracePeriod:    closeGracePeriod,
@@ -124,7 +126,15 @@ func (m *Manager) Start(ctx context.Context, req ExecRequest) (ExecResult, error
 	cmd := exec.CommandContext(context.Background(), req.Command[0], req.Command[1:]...)
 	cmd.Dir = workdir
 	ownerSessionID := strings.TrimSpace(req.OwnerSessionID)
-	cmd.Env = tools.EnrichShellEnvForSession(os.Environ(), ownerSessionID)
+	shellToken := ""
+	if ownerSessionID != "" {
+		shellToken, err = newShellToken()
+		if err != nil {
+			m.releaseEntry(id)
+			return ExecResult{}, err
+		}
+	}
+	cmd.Env = tools.EnrichShellEnvForSessionToken(os.Environ(), ownerSessionID, shellToken)
 	prepareManagedExec(cmd)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -137,6 +147,7 @@ func (m *Manager) Start(ctx context.Context, req ExecRequest) (ExecResult, error
 	entry := &processEntry{
 		id:             id,
 		ownerSessionID: ownerSessionID,
+		shellToken:     shellToken,
 		ownerRunID:     strings.TrimSpace(req.OwnerRunID),
 		ownerStepID:    strings.TrimSpace(req.OwnerStepID),
 		command:        strings.TrimSpace(req.DisplayCommand),
@@ -161,7 +172,26 @@ func (m *Manager) Start(ctx context.Context, req ExecRequest) (ExecResult, error
 	writer := &outputWriter{entry: entry}
 	cmd.Stdout = writer
 	cmd.Stderr = writer
+	m.mu.Lock()
+	if m.closed {
+		m.unregisterSessionTokenLocked(ownerSessionID, shellToken)
+		m.mu.Unlock()
+		entry.mu.Lock()
+		stdin, log := entry.detachResourcesLocked()
+		entry.mu.Unlock()
+		closeDetachedResources(stdin, log)
+		return ExecResult{}, errors.New("background shell manager is closed")
+	}
+	m.registerSessionTokenLocked(ownerSessionID, shellToken)
+	m.mu.Unlock()
+	tokenRegistered := true
+
 	if err := cmd.Start(); err != nil {
+		if tokenRegistered {
+			m.mu.Lock()
+			m.unregisterSessionTokenLocked(ownerSessionID, shellToken)
+			m.mu.Unlock()
+		}
 		entry.mu.Lock()
 		stdin, log := entry.detachResourcesLocked()
 		entry.mu.Unlock()
@@ -171,6 +201,12 @@ func (m *Manager) Start(ctx context.Context, req ExecRequest) (ExecResult, error
 	}
 	if !req.KeepStdinOpen {
 		if err := stdin.Close(); err != nil {
+			if tokenRegistered {
+				m.mu.Lock()
+				m.unregisterSessionTokenLocked(ownerSessionID, shellToken)
+				m.mu.Unlock()
+				tokenRegistered = false
+			}
 			_ = killManagedProcess(cmd.Process)
 			gracePeriod := m.closeGracePeriod
 			if gracePeriod <= 0 {
@@ -191,6 +227,12 @@ func (m *Manager) Start(ctx context.Context, req ExecRequest) (ExecResult, error
 	m.mu.Lock()
 	if m.closed {
 		m.mu.Unlock()
+		if tokenRegistered {
+			m.mu.Lock()
+			m.unregisterSessionTokenLocked(ownerSessionID, shellToken)
+			m.mu.Unlock()
+			tokenRegistered = false
+		}
 		_ = killManagedProcess(cmd.Process)
 		gracePeriod := m.closeGracePeriod
 		if gracePeriod <= 0 {

--- a/server/tools/shell/manager_output_test.go
+++ b/server/tools/shell/manager_output_test.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -39,5 +40,46 @@ func TestManagerSubscribeOutputWaitsForLogFlushNotification(t *testing.T) {
 	}
 	if !strings.Contains(chunk.Text, "flush-ready") {
 		t.Fatalf("expected flushed output, got %+v", chunk)
+	}
+}
+
+func TestManagerBackgroundShellTokenExpiresWhenProcessExits(t *testing.T) {
+	manager := newBackgroundTestManager(t)
+	workspace := t.TempDir()
+
+	result, err := manager.Start(context.Background(), ExecRequest{
+		Command:        []string{"sh", "-c", "sleep 0.3"},
+		DisplayCommand: "token-expiry",
+		OwnerSessionID: "session-token-expiry",
+		Workdir:        workspace,
+		YieldTime:      50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if !result.Backgrounded {
+		t.Fatalf("expected backgrounded process, got %+v", result)
+	}
+	entry, err := manager.entry(result.SessionID)
+	if err != nil {
+		t.Fatalf("entry: %v", err)
+	}
+	if !manager.VerifyShellToken("session-token-expiry", entry.shellToken) {
+		t.Fatalf("expected shell token to be valid while background process is running")
+	}
+
+	sub, err := manager.SubscribeOutput(context.Background(), result.SessionID, 0)
+	if err != nil {
+		t.Fatalf("SubscribeOutput: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+	if _, err := sub.Next(context.Background()); err != io.EOF {
+		t.Fatalf("expected EOF after process exit, got %v", err)
+	}
+	if manager.VerifyShellToken("session-token-expiry", entry.shellToken) {
+		t.Fatalf("shell token remained valid after background process exit")
+	}
+	if _, err := manager.Snapshot(result.SessionID); err != nil {
+		t.Fatalf("background entry should remain visible after token expiry: %v", err)
 	}
 }

--- a/server/tools/shell/manager_runtime.go
+++ b/server/tools/shell/manager_runtime.go
@@ -149,6 +149,7 @@ func (m *Manager) emitEvent(evt Event) {
 func (m *Manager) waitForExit(entry *processEntry) {
 	defer close(entry.done)
 	err := entry.cmd.Wait()
+	m.unregisterEntryShellToken(entry)
 	exitCode, state := processExitState(err)
 	if !entry.isBackgrounded() {
 		entry.setExited(exitCode, state)
@@ -240,6 +241,15 @@ func (m *Manager) releaseEntry(id string) {
 	if entry != nil {
 		m.unregisterSessionTokenLocked(entry.ownerSessionID, entry.shellToken)
 	}
+}
+
+func (m *Manager) unregisterEntryShellToken(entry *processEntry) {
+	if m == nil || entry == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.unregisterSessionTokenLocked(entry.ownerSessionID, entry.shellToken)
 }
 
 func (m *Manager) VerifyShellToken(sessionID string, token string) bool {

--- a/server/tools/shell/manager_runtime.go
+++ b/server/tools/shell/manager_runtime.go
@@ -3,6 +3,8 @@ package shell
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -233,7 +235,67 @@ func (m *Manager) allocateProcessSlot() (string, string, error) {
 func (m *Manager) releaseEntry(id string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	entry := m.entries[id]
 	delete(m.entries, id)
+	if entry != nil {
+		m.unregisterSessionTokenLocked(entry.ownerSessionID, entry.shellToken)
+	}
+}
+
+func (m *Manager) VerifyShellToken(sessionID string, token string) bool {
+	if m == nil {
+		return false
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	token = strings.TrimSpace(token)
+	if sessionID == "" || token == "" {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.sessionTokens[sessionID][token] > 0
+}
+
+func (m *Manager) registerSessionTokenLocked(sessionID string, token string) {
+	sessionID = strings.TrimSpace(sessionID)
+	token = strings.TrimSpace(token)
+	if sessionID == "" || token == "" {
+		return
+	}
+	tokens := m.sessionTokens[sessionID]
+	if tokens == nil {
+		tokens = make(map[string]int)
+		m.sessionTokens[sessionID] = tokens
+	}
+	tokens[token]++
+}
+
+func (m *Manager) unregisterSessionTokenLocked(sessionID string, token string) {
+	sessionID = strings.TrimSpace(sessionID)
+	token = strings.TrimSpace(token)
+	if sessionID == "" || token == "" {
+		return
+	}
+	tokens := m.sessionTokens[sessionID]
+	if tokens == nil {
+		return
+	}
+	if tokens[token] <= 1 {
+		delete(tokens, token)
+	} else {
+		tokens[token]--
+	}
+	if len(tokens) == 0 {
+		delete(m.sessionTokens, sessionID)
+	}
+}
+
+func newShellToken() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate shell token: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
 }
 
 func (m *Manager) normalizeExecYieldTime(value time.Duration) time.Duration {

--- a/server/tools/shell/manager_types.go
+++ b/server/tools/shell/manager_types.go
@@ -160,6 +160,7 @@ func (e *PollingCanceledError) Unwrap() error {
 type processEntry struct {
 	id             string
 	ownerSessionID string
+	shellToken     string
 	ownerRunID     string
 	ownerStepID    string
 	command        string

--- a/server/tools/shell_env.go
+++ b/server/tools/shell_env.go
@@ -44,6 +44,10 @@ func EnrichShellEnv(base []string) []string {
 }
 
 func EnrichShellEnvForSession(base []string, sessionID string) []string {
+	return EnrichShellEnvForSessionToken(base, sessionID, "")
+}
+
+func EnrichShellEnvForSessionToken(base []string, sessionID string, shellToken string) []string {
 	env := make(map[string]string, len(base)+len(overrides))
 	order := make([]string, 0, len(base)+len(overrides))
 
@@ -74,6 +78,12 @@ func EnrichShellEnvForSession(base []string, sessionID string) []string {
 			order = append(order, sessionenv.SessionIDEnv)
 		}
 		env[sessionenv.SessionIDEnv] = sessionID
+	}
+	if shellToken = strings.TrimSpace(shellToken); shellToken != "" {
+		if _, exists := env[sessionenv.ShellTokenEnv]; !exists {
+			order = append(order, sessionenv.ShellTokenEnv)
+		}
+		env[sessionenv.ShellTokenEnv] = shellToken
 	}
 
 	if _, exists := env["RIPGREP_CONFIG_PATH"]; !exists {

--- a/server/tools/shell_env_test.go
+++ b/server/tools/shell_env_test.go
@@ -67,6 +67,16 @@ func TestEnrichForSessionInjectsSessionIDEnv(t *testing.T) {
 	}
 }
 
+func TestEnrichForSessionTokenInjectsShellTokenEnv(t *testing.T) {
+	env := envMap(t, EnrichShellEnvForSessionToken([]string{"PATH=/bin", "KEEP=1"}, " session-1 ", " token-1 "))
+	if got := env[sessionenv.SessionIDEnv]; got != "session-1" {
+		t.Fatalf("%s = %q, want session-1", sessionenv.SessionIDEnv, got)
+	}
+	if got := env[sessionenv.ShellTokenEnv]; got != "token-1" {
+		t.Fatalf("%s = %q, want token-1", sessionenv.ShellTokenEnv, got)
+	}
+}
+
 func TestEnrichForSessionOverridesExistingSessionIDEnv(t *testing.T) {
 	env := envMap(t, EnrichShellEnvForSession([]string{sessionenv.SessionIDEnv + "=old"}, "new"))
 	if got := env[sessionenv.SessionIDEnv]; got != "new" {

--- a/shared/serverapi/runtime_control.go
+++ b/shared/serverapi/runtime_control.go
@@ -216,6 +216,7 @@ type RuntimeGoalStatusRequest struct {
 	ClientRequestID   string `json:"client_request_id"`
 	SessionID         string `json:"session_id"`
 	ControllerLeaseID string `json:"controller_lease_id,omitempty"`
+	ShellToken        string `json:"shell_token,omitempty"`
 	Actor             string `json:"actor"`
 }
 

--- a/shared/sessionenv/sessionenv.go
+++ b/shared/sessionenv/sessionenv.go
@@ -7,12 +7,28 @@ import (
 )
 
 const SessionIDEnv = brand.SessionIDEnv
+const ShellTokenEnv = brand.EnvPrefix + "SHELL_TOKEN"
 
 func LookupSessionID(lookup func(string) (string, bool)) (string, bool) {
 	if lookup == nil {
 		return "", false
 	}
 	value, ok := lookup(SessionIDEnv)
+	if !ok {
+		return "", false
+	}
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", false
+	}
+	return trimmed, true
+}
+
+func LookupShellToken(lookup func(string) (string, bool)) (string, bool) {
+	if lookup == nil {
+		return "", false
+	}
+	value, ok := lookup(ShellTokenEnv)
 	if !ok {
 		return "", false
 	}


### PR DESCRIPTION
## Summary
- add a Kent-managed shell token so same-session agent shell commands can prove they came from Kent's shell manager
- allow confirmed agent goal completion to update the live runtime without taking a competing primary-run lease
- keep untrusted agent-actor RPCs on the normal primary-run gate and cover the original nested CLI shell path

## Verification
- ./scripts/test.sh ./server/runtimecontrol ./cli/kent ./server/tools ./server/tools/shell ./shared/sessionenv
- ./scripts/build.sh --output ./bin/kent
- git diff --check