### PR TITLE
fix: correct goal status indicator and interrupts

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,1 +1,1 @@
-../.builder/skills
+../.kent/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,9 @@ Examples: `feat: add state recovery`, `feat!: change Saver API`
 If user asks you to fix a github issue and you commit the fix, use 'closes #xx' in description.
 
 ## Important rules:
-- All business logic covered by tests. Production code is written to be unit-testable.
+- Production API shape is dictated by product/domain seams, runtime contracts, and operator-visible behavior. Do not add or widen production APIs, exported hooks, global overrides, interfaces, or configuration only so tests can fake, mock, or inspect internals.
+- Tests must adapt to product shape. Prefer product-boundary tests, package-local tests, or harness-level verification when a unit test would require fake-only interfaces or test-only production hooks.
+- Delete or rewrite tests that only preserve implementation shape, fake call order, literal human-readable text, colors/styles, private route tables, file layout, or compatibility shims without a current product contract.
 - Use red/green TDD when developing new features.
 - Never write tests that assert literal prompt strings, log lines, colors, styles, or other textual/visual content. Such tests check the wording of an artifact rather than its behavior, break on every copy edit, and provide no signal — the prompt/log itself is the source of truth. Test behavior, parsing, structure, or invariants instead.
 - Before handing off to the user after Go code changes, rebuild via `./scripts/build.sh --output ./bin/kent`. Don't ask for confirmation to run/write tests and run checks.

--- a/cli/app/ui_goal.go
+++ b/cli/app/ui_goal.go
@@ -49,6 +49,18 @@ func goalIsActive(goal *clientui.RuntimeGoal) bool {
 	return goal != nil && goal.Status == clientui.RuntimeGoalStatusActive
 }
 
+func goalIsPresent(goal *clientui.RuntimeGoal) bool {
+	if goal == nil {
+		return false
+	}
+	switch goal.Status {
+	case clientui.RuntimeGoalStatusActive, clientui.RuntimeGoalStatusPaused:
+		return true
+	default:
+		return false
+	}
+}
+
 func goalRequiresClearConfirmation(goal *clientui.RuntimeGoal) bool {
 	return goalIsActive(goal) && !goal.Suspended
 }

--- a/cli/app/ui_layout_rendering_status.go
+++ b/cli/app/ui_layout_rendering_status.go
@@ -19,7 +19,7 @@ const (
 
 func (l uiViewLayout) renderStatusLine(width int, style uiStyles) string {
 	m := l.model
-	indicator := renderStatusIndicator(m.theme, m.statusLinePhase(), m.statusLineSpinning(), m.spinnerFrame)
+	indicator := renderStatusIndicator(m.theme, m.statusLinePhase(), m.statusLineSpinning(), m.spinnerFrame, m.statusLineLabel())
 	segments := make([]string, 0, 5)
 	if modeLabel := l.statusModeLabel(); modeLabel != "" {
 		segments = append(segments, style.meta.Render(modeLabel))
@@ -271,10 +271,14 @@ func statusContextZone(themeName string, percent int) sharedtheme.Color {
 
 const statusStateCircleGlyph = "●"
 
-func renderStatusIndicator(theme string, phase statusLinePhase, spinning bool, frame int) string {
+func renderStatusIndicator(theme string, phase statusLinePhase, spinning bool, frame int, label string) string {
 	glyph := statusStateCircleGlyph
 	if spinning {
 		glyph = pendingToolSpinnerFrame(frame)
+	}
+	label = strings.TrimSpace(label)
+	if label != "" {
+		glyph += " " + label
 	}
 	return lipgloss.NewStyle().Foreground(statusLinePhaseColor(theme, phase)).Render(glyph)
 }

--- a/cli/app/ui_layout_rendering_status.go
+++ b/cli/app/ui_layout_rendering_status.go
@@ -19,15 +19,7 @@ const (
 
 func (l uiViewLayout) renderStatusLine(width int, style uiStyles) string {
 	m := l.model
-	spin := renderStatusDot(m.theme, m.activity, m.spinnerFrame)
-	switch m.statusLineIndicator() {
-	case statusLineIndicatorReviewer:
-		spin = renderReviewerStatus(m.spinnerFrame)
-	case statusLineIndicatorCompaction:
-		spin = renderCompactionStatus(m.spinnerFrame)
-	case statusLineIndicatorGoal:
-		spin = renderGoalStatus(m.theme, m.spinnerFrame)
-	}
+	indicator := renderStatusIndicator(m.theme, m.statusLinePhase(), m.statusLineSpinning(), m.spinnerFrame)
 	segments := make([]string, 0, 5)
 	if modeLabel := l.statusModeLabel(); modeLabel != "" {
 		segments = append(segments, style.meta.Render(modeLabel))
@@ -43,7 +35,7 @@ func (l uiViewLayout) renderStatusLine(width int, style uiStyles) string {
 		segments = append(segments, serverOwnershipSection)
 	}
 	separator := style.meta.Render(statusLineSeparator)
-	left := renderStatusLineLeft(spin, segments, separator)
+	left := renderStatusLineLeft(indicator, segments, separator)
 	if lipgloss.Width(left) >= width {
 		return padANSIRight(truncateANSIRight(left, width), width)
 	}
@@ -279,37 +271,24 @@ func statusContextZone(themeName string, percent int) sharedtheme.Color {
 
 const statusStateCircleGlyph = "●"
 
-func renderStatusDot(theme string, activity uiActivity, frame int) string {
-	palette := uiPalette(theme)
-	switch activity {
-	case uiActivityRunning:
-		return lipgloss.NewStyle().Foreground(palette.primary).Render(pendingToolSpinnerFrame(frame))
-	case uiActivityQuestion:
-		return lipgloss.NewStyle().Foreground(palette.primary).Render(statusStateCircleGlyph)
-	default:
-		color := sharedtheme.DefaultPalette().Status.Success.Adaptive()
-		if activity == uiActivityError {
-			color = sharedtheme.DefaultPalette().Status.Error.Adaptive()
-		}
-		return lipgloss.NewStyle().Foreground(color).Render(statusStateCircleGlyph)
+func renderStatusIndicator(theme string, phase statusLinePhase, spinning bool, frame int) string {
+	glyph := statusStateCircleGlyph
+	if spinning {
+		glyph = pendingToolSpinnerFrame(frame)
 	}
+	return lipgloss.NewStyle().Foreground(statusLinePhaseColor(theme, phase)).Render(glyph)
 }
 
-func renderCompactionStatus(frame int) string {
-	indicator := lipgloss.NewStyle().Foreground(sharedtheme.DefaultPalette().Status.Warning.Adaptive()).Render(pendingToolSpinnerFrame(frame))
-	keyword := lipgloss.NewStyle().Foreground(sharedtheme.DefaultPalette().Status.Warning.Adaptive()).Bold(true).Render("compacting")
-	return indicator + " " + keyword
-}
-
-func renderReviewerStatus(frame int) string {
-	indicator := lipgloss.NewStyle().Foreground(sharedtheme.DefaultPalette().Status.Success.Adaptive()).Render(pendingToolSpinnerFrame(frame))
-	keyword := lipgloss.NewStyle().Foreground(sharedtheme.DefaultPalette().Status.Success.Adaptive()).Bold(true).Render("reviewing")
-	return indicator + " " + keyword
-}
-
-func renderGoalStatus(theme string, frame int) string {
-	color := uiPalette(theme).primary
-	indicator := lipgloss.NewStyle().Foreground(color).Render(pendingToolSpinnerFrame(frame))
-	keyword := lipgloss.NewStyle().Foreground(color).Bold(true).Render("goal")
-	return indicator + " " + keyword
+func statusLinePhaseColor(theme string, phase statusLinePhase) lipgloss.TerminalColor {
+	palette := uiPalette(theme)
+	switch phase {
+	case statusLinePhaseSecondary:
+		return palette.secondary
+	case statusLinePhaseSuccess:
+		return sharedtheme.DefaultPalette().Status.Success.Adaptive()
+	case statusLinePhaseError:
+		return sharedtheme.DefaultPalette().Status.Error.Adaptive()
+	default:
+		return palette.primary
+	}
 }

--- a/cli/app/ui_layout_rendering_status.go
+++ b/cli/app/ui_layout_rendering_status.go
@@ -167,6 +167,9 @@ func (l uiViewLayout) renderActivityStatus(available int, style uiStyles) string
 	if strings.TrimSpace(l.model.transientStatus) != "" {
 		return ""
 	}
+	if l.model.activity == uiActivityInterrupted {
+		return statusNoticeStyle(l.model.theme, uiStatusNoticeNeutral).Render(truncateQueuedMessageLine("interrupted", available))
+	}
 	if action, ok := l.model.view.DetailSelectedExpansionAction(); ok {
 		return style.meta.Render(truncateQueuedMessageLine("Enter to "+action, available))
 	}

--- a/cli/app/ui_layout_rendering_status.go
+++ b/cli/app/ui_layout_rendering_status.go
@@ -280,15 +280,15 @@ func renderStatusIndicator(theme string, phase statusLinePhase, spinning bool, f
 }
 
 func statusLinePhaseColor(theme string, phase statusLinePhase) lipgloss.TerminalColor {
-	palette := uiPalette(theme)
+	palette := sharedtheme.ResolvePalette(theme)
 	switch phase {
 	case statusLinePhaseSecondary:
-		return palette.secondary
+		return palette.App.Secondary.Lipgloss()
 	case statusLinePhaseSuccess:
-		return sharedtheme.DefaultPalette().Status.Success.Adaptive()
+		return palette.Status.Success.Lipgloss()
 	case statusLinePhaseError:
-		return sharedtheme.DefaultPalette().Status.Error.Adaptive()
+		return palette.Status.Error.Lipgloss()
 	default:
-		return palette.primary
+		return palette.App.Primary.Lipgloss()
 	}
 }

--- a/cli/app/ui_part3_test.go
+++ b/cli/app/ui_part3_test.go
@@ -663,7 +663,7 @@ func TestCtrlCWhileSubmitRestoresQueuedDraft(t *testing.T) {
 	}
 }
 
-func TestCtrlCWhileGoalRunReactsOnInterruptAcknowledgement(t *testing.T) {
+func TestCtrlCWhileGoalRunWaitsForInterruptedRunStateBeforeCleanup(t *testing.T) {
 	client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{
 		Goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
 	}}
@@ -688,8 +688,16 @@ func TestCtrlCWhileGoalRunReactsOnInterruptAcknowledgement(t *testing.T) {
 	if client.interruptCalls != 1 {
 		t.Fatalf("interrupt calls = %d, want 1", client.interruptCalls)
 	}
+	if !updated.isBusy() || !updated.hasPendingInterrupt() {
+		t.Fatalf("interrupt control acknowledgement must wait for run-state cleanup, busy=%t pending=%t", updated.isBusy(), updated.hasPendingInterrupt())
+	}
+	if updated.input != "" || len(updated.queued) != 1 {
+		t.Fatalf("interrupt control acknowledgement restored input before run-state event, input=%q queue=%+v", updated.input, updated.queued)
+	}
+
+	updated = applyInterruptedRunStateForTest(t, updated)
 	if updated.isBusy() || updated.hasPendingInterrupt() {
-		t.Fatalf("expected interrupt acknowledgement to unblock CLI, busy=%t pending=%t", updated.isBusy(), updated.hasPendingInterrupt())
+		t.Fatalf("expected interrupted run-state to unblock CLI, busy=%t pending=%t", updated.isBusy(), updated.hasPendingInterrupt())
 	}
 	if updated.activity != uiActivityInterrupted {
 		t.Fatalf("activity = %v, want interrupted", updated.activity)

--- a/cli/app/ui_part3_test.go
+++ b/cli/app/ui_part3_test.go
@@ -699,6 +699,41 @@ func TestCtrlCWhileGoalRunReactsOnInterruptAcknowledgement(t *testing.T) {
 	}
 }
 
+func TestCtrlCInterruptControlErrorKeepsPendingCleanupForLaterRunState(t *testing.T) {
+	client := &runtimeControlFakeClient{interruptErr: errors.New("interrupt transport failed")}
+	m := newProjectedStaticUIModel()
+	m.engine = client
+	m.setBusy(true)
+	m.queued = queuedInputsForTest("queued after delayed interrupt")
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	updated := next.(*uiModel)
+	for _, msg := range collectCmdMessages(t, cmd) {
+		if typed, ok := msg.(runtimeControlDoneMsg); ok {
+			next, _ = updated.Update(typed)
+			updated = next.(*uiModel)
+		}
+	}
+
+	if !updated.hasPendingInterrupt() {
+		t.Fatal("interrupt control error must keep pending cleanup for a later interrupted run-state event")
+	}
+	if !updated.isBusy() {
+		t.Fatal("failed interrupt control call must not locally mark the run idle")
+	}
+	if updated.input != "" || len(updated.queued) != 1 {
+		t.Fatalf("failed interrupt control call restored input early: input=%q queue=%+v", updated.input, updated.queued)
+	}
+
+	updated = applyInterruptedRunStateForTest(t, updated)
+	if updated.isBusy() || updated.hasPendingInterrupt() {
+		t.Fatalf("later interrupted run-state must finish cleanup, busy=%t pending=%t", updated.isBusy(), updated.hasPendingInterrupt())
+	}
+	if updated.input != "queued after delayed interrupt" || len(updated.queued) != 0 {
+		t.Fatalf("later interrupted run-state must restore queued input, input=%q queue=%+v", updated.input, updated.queued)
+	}
+}
+
 func TestActiveSubmitErrorRestoresQueuedSteeringInput(t *testing.T) {
 	_, eng := newAppRuntimeEngine(t, &runtimeAdapterFakeClient{}, runtime.Config{})
 

--- a/cli/app/ui_part3_test.go
+++ b/cli/app/ui_part3_test.go
@@ -663,6 +663,42 @@ func TestCtrlCWhileSubmitRestoresQueuedDraft(t *testing.T) {
 	}
 }
 
+func TestCtrlCWhileGoalRunReactsOnInterruptAcknowledgement(t *testing.T) {
+	client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{
+		Goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
+	}}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.setGoalRun(true)
+	m.activity = uiActivityRunning
+	m.queued = queuedInputsForTest("queued while goal runs")
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	updated := next.(*uiModel)
+	if !updated.isBusy() || !updated.hasPendingInterrupt() {
+		t.Fatal("expected ctrl+c to request an interrupt while goal run is busy")
+	}
+
+	for _, msg := range collectCmdMessages(t, cmd) {
+		if typed, ok := msg.(runtimeControlDoneMsg); ok {
+			next, _ = updated.Update(typed)
+			updated = next.(*uiModel)
+		}
+	}
+
+	if client.interruptCalls != 1 {
+		t.Fatalf("interrupt calls = %d, want 1", client.interruptCalls)
+	}
+	if updated.isBusy() || updated.hasPendingInterrupt() {
+		t.Fatalf("expected interrupt acknowledgement to unblock CLI, busy=%t pending=%t", updated.isBusy(), updated.hasPendingInterrupt())
+	}
+	if updated.activity != uiActivityInterrupted {
+		t.Fatalf("activity = %v, want interrupted", updated.activity)
+	}
+	if updated.input != "queued while goal runs" || len(updated.queued) != 0 {
+		t.Fatalf("expected queued goal draft restored into input, input=%q queue=%+v", updated.input, updated.queued)
+	}
+}
+
 func TestActiveSubmitErrorRestoresQueuedSteeringInput(t *testing.T) {
 	_, eng := newAppRuntimeEngine(t, &runtimeAdapterFakeClient{}, runtime.Config{})
 

--- a/cli/app/ui_runtime_control.go
+++ b/cli/app/ui_runtime_control.go
@@ -381,9 +381,6 @@ func (m *uiModel) applyRuntimeControlDone(msg runtimeControlDoneMsg) tea.Cmd {
 	}
 	m.observeRuntimeRequestResult(msg.err)
 	if msg.err != nil {
-		if msg.operation == runtimeControlInterrupt {
-			m.setPendingInterrupt(false)
-		}
 		m.clearRuntimeControlPending(msg.operation)
 		errText := runtimeattach.FormatSubmissionError(msg.err)
 		return sequenceCmds(

--- a/cli/app/ui_runtime_control.go
+++ b/cli/app/ui_runtime_control.go
@@ -438,7 +438,7 @@ func (m *uiModel) applyRuntimeControlDone(msg runtimeControlDoneMsg) tea.Cmd {
 		status := serverapi.QuestionsToggleStatusMessage(msg.enabled, msg.changed)
 		return sequenceCmds(m.sendTransientStatusWithNoticeID(status, uiStatusNoticeNeutral, transientStatusDuration, uiStatusNoticeReplace, ""), followUpCmd)
 	case runtimeControlInterrupt:
-		return sequenceCmds(m.acknowledgePendingInterrupt(), followUpCmd)
+		return followUpCmd
 	default:
 		return followUpCmd
 	}

--- a/cli/app/ui_runtime_control.go
+++ b/cli/app/ui_runtime_control.go
@@ -381,6 +381,9 @@ func (m *uiModel) applyRuntimeControlDone(msg runtimeControlDoneMsg) tea.Cmd {
 	}
 	m.observeRuntimeRequestResult(msg.err)
 	if msg.err != nil {
+		if msg.operation == runtimeControlInterrupt {
+			m.setPendingInterrupt(false)
+		}
 		m.clearRuntimeControlPending(msg.operation)
 		errText := runtimeattach.FormatSubmissionError(msg.err)
 		return sequenceCmds(
@@ -438,7 +441,7 @@ func (m *uiModel) applyRuntimeControlDone(msg runtimeControlDoneMsg) tea.Cmd {
 		status := serverapi.QuestionsToggleStatusMessage(msg.enabled, msg.changed)
 		return sequenceCmds(m.sendTransientStatusWithNoticeID(status, uiStatusNoticeNeutral, transientStatusDuration, uiStatusNoticeReplace, ""), followUpCmd)
 	case runtimeControlInterrupt:
-		return followUpCmd
+		return sequenceCmds(m.acknowledgePendingInterrupt(), followUpCmd)
 	default:
 		return followUpCmd
 	}

--- a/cli/app/ui_runtime_event_reduction.go
+++ b/cli/app/ui_runtime_event_reduction.go
@@ -120,18 +120,29 @@ func (a uiRuntimeAdapter) reconcileInterruptFromRunState(evt clientui.Event) tea
 		m.setPendingInterrupt(false)
 		return nil
 	}
-	var cmd tea.Cmd
 	if m.hasPendingInterrupt() {
-		if m.activeSubmit.restoreOnInterrupt && !m.activeSubmit.flushed {
-			c := uiInputController{model: m}
-			c.restoreSubmittedTextIntoInput(m.activeSubmit.text)
-		}
-		m.activeSubmit = activeSubmitState{}
-		c := uiInputController{model: m}
-		cmd = tea.Batch(c.releaseLockedInjectedInput(true), c.restorePendingInjectedIntoInput())
-		c.restoreQueuedMessagesIntoInput()
-		m.setPendingInterrupt(false)
+		return m.acknowledgePendingInterrupt()
 	}
+	m.activity = uiActivityInterrupted
+	m.clearReviewerState()
+	return nil
+}
+
+func (m *uiModel) acknowledgePendingInterrupt() tea.Cmd {
+	if m == nil || !m.hasPendingInterrupt() {
+		return nil
+	}
+	var cmd tea.Cmd
+	if m.activeSubmit.restoreOnInterrupt && !m.activeSubmit.flushed {
+		c := uiInputController{model: m}
+		c.restoreSubmittedTextIntoInput(m.activeSubmit.text)
+	}
+	m.activeSubmit = activeSubmitState{}
+	c := uiInputController{model: m}
+	cmd = tea.Batch(c.releaseLockedInjectedInput(true), c.restorePendingInjectedIntoInput())
+	c.restoreQueuedMessagesIntoInput()
+	m.setPendingInterrupt(false)
+	m.setBusy(false)
 	m.activity = uiActivityInterrupted
 	m.clearReviewerState()
 	return cmd

--- a/cli/app/ui_runtime_status.go
+++ b/cli/app/ui_runtime_status.go
@@ -144,6 +144,9 @@ func (m *uiModel) statusLineIndicator() statusLineIndicator {
 	if m.isCompacting() {
 		return statusLineIndicatorCompaction
 	}
+	if m.activity == uiActivityInterrupted {
+		return statusLineIndicatorActivity
+	}
 	if goalIsActive(m.cachedRuntimeStatus().Goal) {
 		return statusLineIndicatorGoal
 	}

--- a/cli/app/ui_runtime_status.go
+++ b/cli/app/ui_runtime_status.go
@@ -7,13 +7,13 @@ import (
 	"core/shared/clientui"
 )
 
-type statusLineIndicator uint8
+type statusLinePhase uint8
 
 const (
-	statusLineIndicatorActivity statusLineIndicator = iota
-	statusLineIndicatorReviewer
-	statusLineIndicatorCompaction
-	statusLineIndicatorGoal
+	statusLinePhasePrimary statusLinePhase = iota
+	statusLinePhaseSecondary
+	statusLinePhaseSuccess
+	statusLinePhaseError
 )
 
 func (m *uiModel) applyRuntimeMainViewState(view clientui.RuntimeMainView) {
@@ -134,23 +134,30 @@ func (m *uiModel) cachedRuntimeStatus() clientui.RuntimeStatus {
 	return status
 }
 
-func (m *uiModel) statusLineIndicator() statusLineIndicator {
+func (m *uiModel) statusLinePhase() statusLinePhase {
 	if m == nil {
-		return statusLineIndicatorActivity
-	}
-	if m.isReviewerRunning() {
-		return statusLineIndicatorReviewer
+		return statusLinePhasePrimary
 	}
 	if m.isCompacting() {
-		return statusLineIndicatorCompaction
+		return statusLinePhaseSecondary
 	}
-	if m.activity == uiActivityInterrupted {
-		return statusLineIndicatorActivity
+	if m.isReviewerRunning() {
+		return statusLinePhaseSuccess
 	}
 	if goalIsActive(m.cachedRuntimeStatus().Goal) {
-		return statusLineIndicatorGoal
+		return statusLinePhasePrimary
 	}
-	return statusLineIndicatorActivity
+	if m.activity == uiActivityError {
+		return statusLinePhaseError
+	}
+	return statusLinePhasePrimary
+}
+
+func (m *uiModel) statusLineSpinning() bool {
+	if m == nil {
+		return false
+	}
+	return m.isBusy() || m.isCompacting() || m.isReviewerRunning()
 }
 
 func (m *uiModel) refreshRuntimeStatus() clientui.RuntimeStatus {

--- a/cli/app/ui_runtime_status.go
+++ b/cli/app/ui_runtime_status.go
@@ -153,6 +153,25 @@ func (m *uiModel) statusLinePhase() statusLinePhase {
 	return statusLinePhasePrimary
 }
 
+func (m *uiModel) statusLineLabel() string {
+	if m == nil {
+		return ""
+	}
+	if m.isCompacting() {
+		return "compacting"
+	}
+	if m.isReviewerRunning() {
+		return "review"
+	}
+	if goalIsPresent(m.cachedRuntimeStatus().Goal) {
+		return "goal"
+	}
+	if m.activity == uiActivityError {
+		return "error"
+	}
+	return ""
+}
+
 func (m *uiModel) statusLineSpinning() bool {
 	if m == nil {
 		return false

--- a/cli/app/ui_runtime_status.go
+++ b/cli/app/ui_runtime_status.go
@@ -157,7 +157,9 @@ func (m *uiModel) statusLineSpinning() bool {
 	if m == nil {
 		return false
 	}
-	return m.isBusy() || m.isCompacting() || m.isReviewerRunning()
+	return (m.runtimeLifecycle.Run.IsRunning() && m.activity != uiActivityQuestion) ||
+		m.runtimeLifecycle.Compaction.IsRunning() ||
+		m.runtimeLifecycle.Reviewer.IsRunning()
 }
 
 func (m *uiModel) refreshRuntimeStatus() clientui.RuntimeStatus {

--- a/cli/app/ui_runtime_status_test.go
+++ b/cli/app/ui_runtime_status_test.go
@@ -114,36 +114,41 @@ func TestStaticLocalEntryAppendShowsStatusOnly(t *testing.T) {
 	}
 }
 
-func TestRuntimeStatusLineHidesGoalStatusText(t *testing.T) {
-	for _, goalStatus := range []clientui.RuntimeGoalStatus{clientui.RuntimeGoalStatusActive, clientui.RuntimeGoalStatusPaused, clientui.RuntimeGoalStatusComplete} {
+func TestRuntimeStatusLineGoalLabelUsesPresentGoalOnly(t *testing.T) {
+	for _, goalStatus := range []clientui.RuntimeGoalStatus{clientui.RuntimeGoalStatusActive, clientui.RuntimeGoalStatusPaused} {
 		client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{
 			Goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: goalStatus},
 		}}
 		m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
 
 		status := stripANSIAndTrimRight(m.layout().renderStatusLine(120, uiThemeStyles("dark")))
-		if strings.Contains(status, "goal active") || strings.Contains(status, "goal paused") || strings.Contains(status, "goal complete") {
-			t.Fatalf("did not expect status line to include goal status text for %s, got %q", goalStatus, status)
+		if !strings.HasPrefix(status, statusStateCircleGlyph+" goal ") {
+			t.Fatalf("expected present goal %s to render goal label, got %q", goalStatus, status)
 		}
+	}
+	client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{
+		Goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusComplete},
+	}}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	status := stripANSIAndTrimRight(m.layout().renderStatusLine(120, uiThemeStyles("dark")))
+	if strings.HasPrefix(status, statusStateCircleGlyph+" goal ") {
+		t.Fatalf("did not expect complete goal to render goal label, got %q", status)
 	}
 }
 
-func TestRuntimeStatusLineShowsIdleDotForIdleActiveGoal(t *testing.T) {
+func TestRuntimeStatusLineShowsIdleGoalDotForIdleActiveGoal(t *testing.T) {
 	client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{
 		Goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
 	}}
 	m := newSizedProjectedClosedUIModel(client, 100, 20)
 	status := stripANSIAndTrimRight(uiViewLayout{model: m}.renderStatusLine(100, uiThemeStyles(m.theme)))
 
-	if !strings.HasPrefix(status, statusStateCircleGlyph+" ") {
-		t.Fatalf("expected idle active goal to render a dot, got %q", status)
-	}
-	if strings.Contains(status, "goal") {
-		t.Fatalf("did not expect idle active goal to render goal indicator text, got %q", status)
+	if !strings.HasPrefix(status, statusStateCircleGlyph+" goal ") {
+		t.Fatalf("expected idle active goal to render a dot with goal label, got %q", status)
 	}
 }
 
-func TestRuntimeStatusLineShowsInterruptedInsteadOfGoalAfterInterrupt(t *testing.T) {
+func TestRuntimeStatusLineGoalLabelOverridesInterruptedActivity(t *testing.T) {
 	client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{
 		Goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
 	}}
@@ -151,8 +156,8 @@ func TestRuntimeStatusLineShowsInterruptedInsteadOfGoalAfterInterrupt(t *testing
 	m.activity = uiActivityInterrupted
 	status := stripANSIAndTrimRight(uiViewLayout{model: m}.renderStatusLine(100, uiThemeStyles(m.theme)))
 
-	if strings.Contains(status, "goal") {
-		t.Fatalf("did not expect active goal indicator after interrupt, got %q", status)
+	if !strings.HasPrefix(status, statusStateCircleGlyph+" goal ") {
+		t.Fatalf("expected active goal label after interrupt, got %q", status)
 	}
 	if !strings.Contains(status, "interrupted") {
 		t.Fatalf("expected interrupted status after interrupt, got %q", status)
@@ -298,6 +303,68 @@ func TestRuntimeStatusPhasePrecedence(t *testing.T) {
 	}
 }
 
+func TestRuntimeStatusLabelPrecedence(t *testing.T) {
+	tests := []struct {
+		name    string
+		goal    *clientui.RuntimeGoal
+		prepare func(*uiModel)
+		want    string
+	}{
+		{name: "idle", want: ""},
+		{
+			name: "last event error",
+			prepare: func(m *uiModel) {
+				m.activity = uiActivityError
+			},
+			want: "error",
+		},
+		{
+			name: "active goal overrides error",
+			goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
+			prepare: func(m *uiModel) {
+				m.activity = uiActivityError
+			},
+			want: "goal",
+		},
+		{
+			name: "paused goal",
+			goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusPaused},
+			want: "goal",
+		},
+		{
+			name: "complete goal omitted",
+			goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusComplete},
+			want: "",
+		},
+		{
+			name:    "review overrides active goal",
+			goal:    &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
+			prepare: func(m *uiModel) { m.setReviewerRunning(true) },
+			want:    "review",
+		},
+		{
+			name:    "compaction overrides active goal",
+			goal:    &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
+			prepare: func(m *uiModel) { m.setCompacting(true) },
+			want:    "compacting",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{Goal: tt.goal}}
+			m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+			if tt.prepare != nil {
+				tt.prepare(m)
+			}
+
+			if got := m.statusLineLabel(); got != tt.want {
+				t.Fatalf("label = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRuntimeStatusLineReopenActiveGoalFromStartupMainViewUsesIdleDot(t *testing.T) {
 	reads := &countingSessionViewClient{view: clientui.RuntimeMainView{
 		Session: clientui.RuntimeSessionView{SessionID: "session-1"},
@@ -316,11 +383,8 @@ func TestRuntimeStatusLineReopenActiveGoalFromStartupMainViewUsesIdleDot(t *test
 		t.Fatal("reopened active goal without active run must not spin")
 	}
 	status := stripANSIAndTrimRight(uiViewLayout{model: m}.renderStatusLine(100, uiThemeStyles(m.theme)))
-	if !strings.HasPrefix(status, statusStateCircleGlyph+" ") {
-		t.Fatalf("expected reopened active goal to render idle dot, got %q", status)
-	}
-	if strings.Contains(status, "goal") {
-		t.Fatalf("did not expect reopened active goal to render goal indicator text, got %q", status)
+	if !strings.HasPrefix(status, statusStateCircleGlyph+" goal ") {
+		t.Fatalf("expected reopened active goal to render idle dot with goal label, got %q", status)
 	}
 }
 

--- a/cli/app/ui_runtime_status_test.go
+++ b/cli/app/ui_runtime_status_test.go
@@ -196,6 +196,13 @@ func TestRuntimeStatusLineShapeUsesOnlyActiveWork(t *testing.T) {
 			spinning: true,
 		},
 		{
+			name: "waiting on question",
+			prepare: func(m *uiModel) {
+				m.setBusy(true)
+				m.activity = uiActivityQuestion
+			},
+		},
+		{
 			name:     "compaction",
 			prepare:  func(m *uiModel) { m.setCompacting(true) },
 			spinning: true,

--- a/cli/app/ui_runtime_status_test.go
+++ b/cli/app/ui_runtime_status_test.go
@@ -128,15 +128,18 @@ func TestRuntimeStatusLineHidesGoalStatusText(t *testing.T) {
 	}
 }
 
-func TestRuntimeStatusLineShowsGoalProgressWord(t *testing.T) {
+func TestRuntimeStatusLineShowsIdleDotForIdleActiveGoal(t *testing.T) {
 	client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{
 		Goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
 	}}
 	m := newSizedProjectedClosedUIModel(client, 100, 20)
-	status := uiViewLayout{model: m}.renderStatusLine(100, uiThemeStyles(m.theme))
+	status := stripANSIAndTrimRight(uiViewLayout{model: m}.renderStatusLine(100, uiThemeStyles(m.theme)))
 
-	if !strings.Contains(stripANSIAndTrimRight(status), "goal") {
-		t.Fatalf("expected status line to include goal progress word, got %q", status)
+	if !strings.HasPrefix(status, statusStateCircleGlyph+" ") {
+		t.Fatalf("expected idle active goal to render a dot, got %q", status)
+	}
+	if strings.Contains(status, "goal") {
+		t.Fatalf("did not expect idle active goal to render goal indicator text, got %q", status)
 	}
 }
 
@@ -156,64 +159,120 @@ func TestRuntimeStatusLineShowsInterruptedInsteadOfGoalAfterInterrupt(t *testing
 	}
 }
 
-func TestRuntimeStatusIndicatorSelectsActiveGoalFromCachedStatus(t *testing.T) {
+func TestRuntimeStatusLineShapeUsesOnlyActiveWork(t *testing.T) {
 	tests := []struct {
 		name     string
-		goal     *clientui.RuntimeGoal
 		prepare  func(*uiModel)
-		want     statusLineIndicator
-		wantGoal bool
+		spinning bool
 	}{
 		{
-			name:     "idle active goal",
-			goal:     &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
-			want:     statusLineIndicatorGoal,
-			wantGoal: true,
+			name: "idle active goal",
+			prepare: func(m *uiModel) {
+				m.engine = &runtimeControlFakeClient{status: clientui.RuntimeStatus{
+					Goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
+				}}
+			},
 		},
 		{
-			name:     "normal running turn active goal",
-			goal:     &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
-			prepare:  func(m *uiModel) { m.activity = uiActivityRunning; m.setBusy(true) },
-			want:     statusLineIndicatorGoal,
-			wantGoal: true,
+			name: "paused goal",
+			prepare: func(m *uiModel) {
+				m.engine = &runtimeControlFakeClient{status: clientui.RuntimeStatus{
+					Goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusPaused},
+				}}
+			},
 		},
 		{
-			name:     "suspended active goal",
-			goal:     &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive, Suspended: true},
-			want:     statusLineIndicatorGoal,
-			wantGoal: true,
+			name: "interrupted active goal",
+			prepare: func(m *uiModel) {
+				m.activity = uiActivityInterrupted
+				m.engine = &runtimeControlFakeClient{status: clientui.RuntimeStatus{
+					Goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
+				}}
+			},
 		},
 		{
-			name:    "interrupted overrides active goal",
-			goal:    &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
-			prepare: func(m *uiModel) { m.activity = uiActivityInterrupted },
-			want:    statusLineIndicatorActivity,
+			name:     "agent turn",
+			prepare:  func(m *uiModel) { m.setBusy(true) },
+			spinning: true,
+		},
+		{
+			name:     "compaction",
+			prepare:  func(m *uiModel) { m.setCompacting(true) },
+			spinning: true,
+		},
+		{
+			name:     "supervisor",
+			prepare:  func(m *uiModel) { m.setReviewerRunning(true) },
+			spinning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newProjectedStaticUIModel()
+			if tt.prepare != nil {
+				tt.prepare(m)
+			}
+
+			if got := m.statusLineSpinning(); got != tt.spinning {
+				t.Fatalf("spinning = %t, want %t", got, tt.spinning)
+			}
+			status := stripANSIAndTrimRight(uiViewLayout{model: m}.renderStatusLine(100, uiThemeStyles(m.theme)))
+			hasSpinner := !strings.HasPrefix(status, statusStateCircleGlyph+" ")
+			if hasSpinner != tt.spinning {
+				t.Fatalf("rendered spinning = %t, want %t, status=%q", hasSpinner, tt.spinning, status)
+			}
+		})
+	}
+}
+
+func TestRuntimeStatusPhasePrecedence(t *testing.T) {
+	tests := []struct {
+		name    string
+		goal    *clientui.RuntimeGoal
+		prepare func(*uiModel)
+		want    statusLinePhase
+	}{
+		{
+			name: "nil goal",
+			want: statusLinePhasePrimary,
+		},
+		{
+			name: "last event error",
+			prepare: func(m *uiModel) {
+				m.activity = uiActivityError
+			},
+			want: statusLinePhaseError,
+		},
+		{
+			name: "goal active overrides error",
+			goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
+			prepare: func(m *uiModel) {
+				m.activity = uiActivityError
+			},
+			want: statusLinePhasePrimary,
 		},
 		{
 			name: "paused goal",
 			goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusPaused},
-			want: statusLineIndicatorActivity,
+			want: statusLinePhasePrimary,
 		},
 		{
-			name: "completed goal",
-			goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusComplete},
-			want: statusLineIndicatorActivity,
+			name: "active goal",
+			goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
+			want: statusLinePhasePrimary,
 		},
 		{
-			name: "nil goal",
-			want: statusLineIndicatorActivity,
-		},
-		{
-			name:    "reviewer overrides active goal",
+			name:    "supervisor overrides active goal",
 			goal:    &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
 			prepare: func(m *uiModel) { m.setReviewerRunning(true) },
-			want:    statusLineIndicatorReviewer,
+			want:    statusLinePhaseSuccess,
 		},
 		{
 			name:    "compaction overrides active goal",
 			goal:    &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
 			prepare: func(m *uiModel) { m.setCompacting(true) },
-			want:    statusLineIndicatorCompaction,
+			want:    statusLinePhaseSecondary,
 		},
 	}
 
@@ -225,17 +284,14 @@ func TestRuntimeStatusIndicatorSelectsActiveGoalFromCachedStatus(t *testing.T) {
 				tt.prepare(m)
 			}
 
-			if got := m.statusLineIndicator(); got != tt.want {
-				t.Fatalf("indicator = %v, want %v", got, tt.want)
-			}
-			if tt.wantGoal && m.isGoalRun() {
-				t.Fatalf("test requires active goal indicator without goal-loop lifecycle")
+			if got := m.statusLinePhase(); got != tt.want {
+				t.Fatalf("phase = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestRuntimeStatusIndicatorUsesStartupMainViewGoalFromSessionRuntimeClient(t *testing.T) {
+func TestRuntimeStatusLineReopenActiveGoalFromStartupMainViewUsesIdleDot(t *testing.T) {
 	reads := &countingSessionViewClient{view: clientui.RuntimeMainView{
 		Session: clientui.RuntimeSessionView{SessionID: "session-1"},
 		Status: clientui.RuntimeStatus{
@@ -246,8 +302,18 @@ func TestRuntimeStatusIndicatorUsesStartupMainViewGoalFromSessionRuntimeClient(t
 
 	m := newProjectedTestUIModel(runtimeClient, closedProjectedRuntimeEvents(), closedAskEvents(), WithUISessionID("session-1"))
 
-	if got := m.statusLineIndicator(); got != statusLineIndicatorGoal {
-		t.Fatalf("indicator = %v, want active goal from startup main view", got)
+	if got := m.statusLinePhase(); got != statusLinePhasePrimary {
+		t.Fatalf("phase = %v, want primary active goal from startup main view", got)
+	}
+	if m.statusLineSpinning() {
+		t.Fatal("reopened active goal without active run must not spin")
+	}
+	status := stripANSIAndTrimRight(uiViewLayout{model: m}.renderStatusLine(100, uiThemeStyles(m.theme)))
+	if !strings.HasPrefix(status, statusStateCircleGlyph+" ") {
+		t.Fatalf("expected reopened active goal to render idle dot, got %q", status)
+	}
+	if strings.Contains(status, "goal") {
+		t.Fatalf("did not expect reopened active goal to render goal indicator text, got %q", status)
 	}
 }
 
@@ -447,7 +513,7 @@ func TestRuntimeStatusUsesLiveContextUsageFromRuntimeEvents(t *testing.T) {
 	}
 }
 
-func TestRuntimeGoalStatusEventUpdatesStatusIndicator(t *testing.T) {
+func TestRuntimeGoalStatusEventUpdatesCachedGoal(t *testing.T) {
 	runtimeClient := newTestSessionRuntimeClientWithControls(&leaseRetryRuntimeControlClient{})
 	runtimeClient.storeMainView(clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{SessionID: "session-1"}})
 	m := newProjectedTestUIModel(runtimeClient, closedProjectedRuntimeEvents(), closedAskEvents(), WithUISessionID("session-1"))
@@ -464,11 +530,8 @@ func TestRuntimeGoalStatusEventUpdatesStatusIndicator(t *testing.T) {
 	}})
 	updated := next.(*uiModel)
 	assertCachedRuntimeGoal(t, runtimeClient, &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive})
-	if got := updated.statusLineIndicator(); got != statusLineIndicatorGoal {
-		t.Fatalf("indicator = %v, want active goal", got)
-	}
 	if updated.isGoalRun() {
-		t.Fatalf("test requires active goal indicator without goal-loop lifecycle")
+		t.Fatalf("goal status update must not synthesize goal-loop lifecycle")
 	}
 
 	next, _ = updated.Update(runtimeEventMsg{event: clientui.Event{
@@ -481,9 +544,6 @@ func TestRuntimeGoalStatusEventUpdatesStatusIndicator(t *testing.T) {
 	}})
 	updated = next.(*uiModel)
 	assertCachedRuntimeGoal(t, runtimeClient, &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusPaused})
-	if got := updated.statusLineIndicator(); got == statusLineIndicatorGoal {
-		t.Fatalf("indicator = %v, want non-goal after pause", got)
-	}
 
 	next, _ = updated.Update(runtimeEventMsg{event: clientui.Event{
 		Kind: clientui.EventGoalStatusUpdated,
@@ -495,9 +555,6 @@ func TestRuntimeGoalStatusEventUpdatesStatusIndicator(t *testing.T) {
 	}})
 	updated = next.(*uiModel)
 	assertCachedRuntimeGoal(t, runtimeClient, &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusComplete})
-	if got := updated.statusLineIndicator(); got == statusLineIndicatorGoal {
-		t.Fatalf("indicator = %v, want non-goal after complete", got)
-	}
 
 	next, _ = updated.Update(runtimeEventMsg{event: clientui.Event{
 		Kind:       clientui.EventGoalStatusUpdated,
@@ -505,9 +562,6 @@ func TestRuntimeGoalStatusEventUpdatesStatusIndicator(t *testing.T) {
 	}})
 	updated = next.(*uiModel)
 	assertCachedRuntimeGoal(t, runtimeClient, nil)
-	if got := updated.statusLineIndicator(); got == statusLineIndicatorGoal {
-		t.Fatalf("indicator = %v, want non-goal after clear", got)
-	}
 }
 
 func assertCachedRuntimeGoal(t *testing.T, runtimeClient *sessionRuntimeClient, want *clientui.RuntimeGoal) {

--- a/cli/app/ui_runtime_status_test.go
+++ b/cli/app/ui_runtime_status_test.go
@@ -140,6 +140,22 @@ func TestRuntimeStatusLineShowsGoalProgressWord(t *testing.T) {
 	}
 }
 
+func TestRuntimeStatusLineShowsInterruptedInsteadOfGoalAfterInterrupt(t *testing.T) {
+	client := &runtimeControlFakeClient{status: clientui.RuntimeStatus{
+		Goal: &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
+	}}
+	m := newSizedProjectedClosedUIModel(client, 100, 20)
+	m.activity = uiActivityInterrupted
+	status := stripANSIAndTrimRight(uiViewLayout{model: m}.renderStatusLine(100, uiThemeStyles(m.theme)))
+
+	if strings.Contains(status, "goal") {
+		t.Fatalf("did not expect active goal indicator after interrupt, got %q", status)
+	}
+	if !strings.Contains(status, "interrupted") {
+		t.Fatalf("expected interrupted status after interrupt, got %q", status)
+	}
+}
+
 func TestRuntimeStatusIndicatorSelectsActiveGoalFromCachedStatus(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -166,6 +182,12 @@ func TestRuntimeStatusIndicatorSelectsActiveGoalFromCachedStatus(t *testing.T) {
 			goal:     &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive, Suspended: true},
 			want:     statusLineIndicatorGoal,
 			wantGoal: true,
+		},
+		{
+			name:    "interrupted overrides active goal",
+			goal:    &clientui.RuntimeGoal{ID: "goal-1", Objective: "ship feature", Status: clientui.RuntimeGoalStatusActive},
+			prepare: func(m *uiModel) { m.activity = uiActivityInterrupted },
+			want:    statusLineIndicatorActivity,
 		},
 		{
 			name: "paused goal",

--- a/cli/kent/goal_command.go
+++ b/cli/kent/goal_command.go
@@ -137,7 +137,8 @@ func goalSetSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 	if agent {
 		actor = "agent"
 	}
-	resp, err := remote.SetGoal(ctx, serverapi.RuntimeGoalSetRequest{ClientRequestID: uuid.NewString(), SessionID: target, Objective: objective, Actor: actor, ShellToken: goalCommandShellToken(agent)})
+	agentShell := goalCommandAgentShell(agent)
+	resp, err := remote.SetGoal(ctx, serverapi.RuntimeGoalSetRequest{ClientRequestID: uuid.NewString(), SessionID: target, Objective: objective, Actor: actor, ShellToken: agentShell.Token, ShellRunID: agentShell.RunID, ShellStepID: agentShell.StepID})
 	if err != nil {
 		fmt.Fprintln(stderr, formatGoalCommandError(err))
 		return 1
@@ -235,7 +236,8 @@ func goalCompleteSubcommand(args []string, stdout io.Writer, stderr io.Writer) i
 	}
 	completeCtx, completeCancel := context.WithTimeout(context.Background(), goalCommandTimeout)
 	defer completeCancel()
-	resp, err := remote.CompleteGoal(completeCtx, serverapi.RuntimeGoalStatusRequest{ClientRequestID: uuid.NewString(), SessionID: target, Actor: actor, ShellToken: goalCommandShellToken(agent)})
+	agentShell := goalCommandAgentShell(agent)
+	resp, err := remote.CompleteGoal(completeCtx, serverapi.RuntimeGoalStatusRequest{ClientRequestID: uuid.NewString(), SessionID: target, Actor: actor, ShellToken: agentShell.Token, ShellRunID: agentShell.RunID, ShellStepID: agentShell.StepID})
 	if err != nil {
 		fmt.Fprintln(stderr, formatGoalCommandError(err))
 		return 1
@@ -244,12 +246,20 @@ func goalCompleteSubcommand(args []string, stdout io.Writer, stderr io.Writer) i
 	return 0
 }
 
-func goalCommandShellToken(agent bool) string {
+type goalCommandAgentShellContext struct {
+	Token  string
+	RunID  string
+	StepID string
+}
+
+func goalCommandAgentShell(agent bool) goalCommandAgentShellContext {
 	if !agent {
-		return ""
+		return goalCommandAgentShellContext{}
 	}
 	token, _ := sessionenv.LookupShellToken(os.LookupEnv)
-	return token
+	runID, _ := sessionenv.LookupShellRunID(os.LookupEnv)
+	stepID, _ := sessionenv.LookupShellStepID(os.LookupEnv)
+	return goalCommandAgentShellContext{Token: token, RunID: runID, StepID: stepID}
 }
 
 func goalAlreadyComplete(goal *serverapi.RuntimeGoal) bool {

--- a/cli/kent/goal_command.go
+++ b/cli/kent/goal_command.go
@@ -137,7 +137,7 @@ func goalSetSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 	if agent {
 		actor = "agent"
 	}
-	resp, err := remote.SetGoal(ctx, serverapi.RuntimeGoalSetRequest{ClientRequestID: uuid.NewString(), SessionID: target, Objective: objective, Actor: actor})
+	resp, err := remote.SetGoal(ctx, serverapi.RuntimeGoalSetRequest{ClientRequestID: uuid.NewString(), SessionID: target, Objective: objective, Actor: actor, ShellToken: goalCommandShellToken(agent)})
 	if err != nil {
 		fmt.Fprintln(stderr, formatGoalCommandError(err))
 		return 1

--- a/cli/kent/goal_command_test.go
+++ b/cli/kent/goal_command_test.go
@@ -98,6 +98,7 @@ func TestGoalShowUsesSessionIDEnv(t *testing.T) {
 
 func TestGoalAgentEnvAllowsSetWithAgentActor(t *testing.T) {
 	t.Setenv(sessionenv.SessionIDEnv, "session-1")
+	t.Setenv(sessionenv.ShellTokenEnv, "shell-token-1")
 	remote := &recordingGoalRemote{goal: &serverapi.RuntimeGoal{ID: "goal-1", Objective: "new goal", Status: "active"}}
 	restore := replaceGoalCommandRemoteOpener(t, remote)
 	defer restore()
@@ -112,6 +113,9 @@ func TestGoalAgentEnvAllowsSetWithAgentActor(t *testing.T) {
 	}
 	if remote.setReq[0].SessionID != "session-1" || remote.setReq[0].Actor != "agent" || remote.setReq[0].Objective != "new goal" {
 		t.Fatalf("set request = %+v", remote.setReq[0])
+	}
+	if remote.setReq[0].ShellToken != "shell-token-1" {
+		t.Fatalf("set shell token = %q, want shell-token-1", remote.setReq[0].ShellToken)
 	}
 	if !strings.Contains(stdout.String(), "Goal: new goal") {
 		t.Fatalf("stdout = %q", stdout.String())

--- a/cli/kent/goal_command_test.go
+++ b/cli/kent/goal_command_test.go
@@ -99,6 +99,8 @@ func TestGoalShowUsesSessionIDEnv(t *testing.T) {
 func TestGoalAgentEnvAllowsSetWithAgentActor(t *testing.T) {
 	t.Setenv(sessionenv.SessionIDEnv, "session-1")
 	t.Setenv(sessionenv.ShellTokenEnv, "shell-token-1")
+	t.Setenv(sessionenv.ShellRunIDEnv, "run-1")
+	t.Setenv(sessionenv.ShellStepIDEnv, "step-1")
 	remote := &recordingGoalRemote{goal: &serverapi.RuntimeGoal{ID: "goal-1", Objective: "new goal", Status: "active"}}
 	restore := replaceGoalCommandRemoteOpener(t, remote)
 	defer restore()
@@ -116,6 +118,9 @@ func TestGoalAgentEnvAllowsSetWithAgentActor(t *testing.T) {
 	}
 	if remote.setReq[0].ShellToken != "shell-token-1" {
 		t.Fatalf("set shell token = %q, want shell-token-1", remote.setReq[0].ShellToken)
+	}
+	if remote.setReq[0].ShellRunID != "run-1" || remote.setReq[0].ShellStepID != "step-1" {
+		t.Fatalf("set shell run context = %q/%q, want run-1/step-1", remote.setReq[0].ShellRunID, remote.setReq[0].ShellStepID)
 	}
 	if !strings.Contains(stdout.String(), "Goal: new goal") {
 		t.Fatalf("stdout = %q", stdout.String())
@@ -213,6 +218,8 @@ func TestGoalAgentCompleteRequiresConfirmTripwire(t *testing.T) {
 	stdout := new(strings.Builder)
 	stderr.Reset()
 	t.Setenv(sessionenv.ShellTokenEnv, "shell-token-1")
+	t.Setenv(sessionenv.ShellRunIDEnv, "run-1")
+	t.Setenv(sessionenv.ShellStepIDEnv, "step-1")
 	if code := goalSubcommand([]string{"complete", "--confirm"}, stdout, stderr); code != 0 {
 		t.Fatalf("goal complete --confirm exit = %d stderr=%q", code, stderr.String())
 	}
@@ -224,6 +231,9 @@ func TestGoalAgentCompleteRequiresConfirmTripwire(t *testing.T) {
 	}
 	if remote.completeReq[0].ShellToken != "shell-token-1" {
 		t.Fatalf("complete shell token = %q, want shell-token-1", remote.completeReq[0].ShellToken)
+	}
+	if remote.completeReq[0].ShellRunID != "run-1" || remote.completeReq[0].ShellStepID != "step-1" {
+		t.Fatalf("complete shell run context = %q/%q, want run-1/step-1", remote.completeReq[0].ShellRunID, remote.completeReq[0].ShellStepID)
 	}
 }
 

--- a/server/runtime/background_test.go
+++ b/server/runtime/background_test.go
@@ -35,6 +35,9 @@ func (s *blockingBackgroundStepLifecycle) IsBusy() bool     { return false }
 func (s *blockingBackgroundStepLifecycle) Snapshot() *RunSnapshot {
 	return nil
 }
+func (s *blockingBackgroundStepLifecycle) WithActiveRun(string, string, func() error) (bool, error) {
+	return false, nil
+}
 
 func TestBackgroundNoticeSchedulerCancelsQueuedContinuationOnEngineClose(t *testing.T) {
 	steps := &blockingBackgroundStepLifecycle{

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -169,6 +169,8 @@ type Engine struct {
 	queuedUserWorkMu           sync.Mutex
 	queuedUserWorkScheduled    bool
 	queuedUserWorkAutoDrainIDs map[string]struct{}
+	activeRunGoalMutationsMu   sync.Mutex
+	activeRunGoalMutations     map[string][]activeRunGoalMutation
 	// userInjectionScopeMu guards activeUserInjectionScope, the queued
 	// user-injection IDs the in-flight top-level step should flush. The engine
 	// owns this scope so the step executor derives it directly and reviewer

--- a/server/runtime/exclusive_step.go
+++ b/server/runtime/exclusive_step.go
@@ -34,6 +34,7 @@ type exclusiveRunState struct {
 	cancel    context.CancelFunc
 	runID     string
 	stepID    string
+	closing   bool
 	startedAt time.Time
 }
 
@@ -73,6 +74,7 @@ func (s *defaultExclusiveStepLifecycle) Run(ctx context.Context, options exclusi
 	}
 	defer func() {
 		panicValue := recover()
+		s.closeActiveRunGate()
 		if panicValue == nil {
 			if drainErr := s.engine.drainActiveRunGoalMutations(stepID); drainErr != nil {
 				err = errors.Join(err, fmt.Errorf("drain active-run goal mutations: %w", drainErr))
@@ -179,10 +181,21 @@ func (s *defaultExclusiveStepLifecycle) WithActiveRun(runID string, stepID strin
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.active == nil || s.active.runID != runID || s.active.stepID != stepID {
+	if s.active == nil || s.active.closing || s.active.runID != runID || s.active.stepID != stepID {
 		return false, nil
 	}
 	return true, fn()
+}
+
+func (s *defaultExclusiveStepLifecycle) closeActiveRunGate() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.active != nil {
+		s.active.closing = true
+	}
 }
 
 func (s *defaultExclusiveStepLifecycle) begin(ctx context.Context, options exclusiveStepOptions) (context.Context, string, error) {

--- a/server/runtime/exclusive_step.go
+++ b/server/runtime/exclusive_step.go
@@ -75,7 +75,7 @@ func (s *defaultExclusiveStepLifecycle) Run(ctx context.Context, options exclusi
 	defer func() {
 		panicValue := recover()
 		s.closeActiveRunGate()
-		if panicValue == nil {
+		if panicValue == nil && err == nil {
 			if drainErr := s.engine.drainActiveRunGoalMutations(stepID); drainErr != nil {
 				err = errors.Join(err, fmt.Errorf("drain active-run goal mutations: %w", drainErr))
 			}

--- a/server/runtime/exclusive_step.go
+++ b/server/runtime/exclusive_step.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -72,6 +73,11 @@ func (s *defaultExclusiveStepLifecycle) Run(ctx context.Context, options exclusi
 	}
 	defer func() {
 		panicValue := recover()
+		if panicValue == nil {
+			if drainErr := s.engine.drainActiveRunGoalMutations(stepID); drainErr != nil {
+				err = errors.Join(err, fmt.Errorf("drain active-run goal mutations: %w", drainErr))
+			}
+		}
 		finishedAt := time.Now().UTC()
 		status := statusFromRunError(err)
 		if panicValue != nil {
@@ -160,6 +166,23 @@ func (s *defaultExclusiveStepLifecycle) Snapshot() *RunSnapshot {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return cloneRunSnapshot(s.snapshotLocked())
+}
+
+func (s *defaultExclusiveStepLifecycle) WithActiveRun(runID string, stepID string, fn func() error) (bool, error) {
+	if s == nil {
+		return false, nil
+	}
+	runID = strings.TrimSpace(runID)
+	stepID = strings.TrimSpace(stepID)
+	if runID == "" || stepID == "" || fn == nil {
+		return false, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.active == nil || s.active.runID != runID || s.active.stepID != stepID {
+		return false, nil
+	}
+	return true, fn()
 }
 
 func (s *defaultExclusiveStepLifecycle) begin(ctx context.Context, options exclusiveStepOptions) (context.Context, string, error) {

--- a/server/runtime/exclusive_step_test.go
+++ b/server/runtime/exclusive_step_test.go
@@ -62,6 +62,18 @@ func (s *stubExclusiveStepLifecycle) Snapshot() *RunSnapshot {
 	return cloneRunSnapshot(s.snapshot)
 }
 
+func (s *stubExclusiveStepLifecycle) WithActiveRun(runID string, stepID string, fn func() error) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.snapshot == nil || s.snapshot.RunID != runID || s.snapshot.StepID != stepID {
+		return false, nil
+	}
+	if fn == nil {
+		return true, nil
+	}
+	return true, fn()
+}
+
 func (s *stubExclusiveStepLifecycle) setBusy(busy bool) {
 	s.mu.Lock()
 	s.busy = busy

--- a/server/runtime/goal.go
+++ b/server/runtime/goal.go
@@ -104,6 +104,39 @@ func (e *Engine) setGoalStatusForStep(stepID string, status session.GoalStatus, 
 	return goal, nil
 }
 
+func (e *Engine) completeGoalIfActiveForStep(stepID string, goalID string, actor session.GoalActor) (session.GoalState, error) {
+	if e == nil || e.store == nil {
+		return session.GoalState{}, fmt.Errorf("runtime engine is required")
+	}
+	goalID = strings.TrimSpace(goalID)
+	if goalID == "" {
+		return session.GoalState{}, errors.New("goal id is required")
+	}
+	transcriptWorkingDir := e.transcriptWorkingDir()
+	var msg llm.Message
+	e.controlMutationMu.Lock()
+	defer e.controlMutationMu.Unlock()
+	goal, transitioned, err := e.store.CompleteGoalIfActive(goalID, actor, func(goal session.GoalState) ([]session.EventInput, error) {
+		msg = normalizeMessageForTranscript(llm.Message{
+			Role:           llm.RoleDeveloper,
+			MessageType:    llm.MessageTypeGoal,
+			Content:        goalStatusPrompt(goal),
+			CompactContent: goalStatusCompactText(goal),
+		}, transcriptWorkingDir)
+		return []session.EventInput{{Kind: "message", Payload: msg}}, nil
+	})
+	if err != nil {
+		return session.GoalState{}, err
+	}
+	if !transitioned {
+		return session.GoalState{}, nil
+	}
+	if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, false, []llm.Message{msg}), steerGoalStatusUpdateIntent(goalStatusUpdateFromState(goal))); err != nil {
+		return session.GoalState{}, err
+	}
+	return goal, nil
+}
+
 func (e *Engine) QueueAgentShellSetGoal(runID string, stepID string, objective string, actor session.GoalActor) (session.GoalState, bool, error) {
 	if e == nil || e.store == nil {
 		return session.GoalState{}, false, fmt.Errorf("runtime engine is required")
@@ -144,6 +177,7 @@ func (e *Engine) QueueAgentShellCompleteGoal(runID string, stepID string, actor 
 	}
 	queued, err := e.enqueueActiveRunGoalMutation(runID, stepID, activeRunGoalMutation{
 		kind:  activeRunGoalMutationComplete,
+		goal:  *current,
 		actor: actor,
 	})
 	if err != nil || !queued {
@@ -205,12 +239,15 @@ func (e *Engine) shiftActiveRunGoalMutation(stepID string) (activeRunGoalMutatio
 func (e *Engine) applyActiveRunGoalMutation(stepID string, mutation activeRunGoalMutation) error {
 	switch mutation.kind {
 	case activeRunGoalMutationSet:
+		if err := e.RequireGoalLoopStartAllowed(); err != nil {
+			return err
+		}
 		if _, err := e.setGoalStateForStep(stepID, mutation.goal, mutation.actor); err != nil {
 			return err
 		}
 		return e.StartGoalLoop()
 	case activeRunGoalMutationComplete:
-		_, err := e.setGoalStatusForStep(stepID, session.GoalStatusComplete, mutation.actor)
+		_, err := e.completeGoalIfActiveForStep(stepID, mutation.goal.ID, mutation.actor)
 		return err
 	default:
 		return fmt.Errorf("unsupported active-run goal mutation kind %d", mutation.kind)
@@ -453,6 +490,9 @@ func (e *Engine) RequireGoalLoopStartAllowed() error {
 }
 
 func (e *Engine) requireAskQuestionForGoalLoopStart() error {
+	if !e.QuestionsEnabled() {
+		return ErrGoalRequiresAskQuestion
+	}
 	shape, err := e.lockedRequestShape()
 	if err != nil {
 		return err

--- a/server/runtime/goal.go
+++ b/server/runtime/goal.go
@@ -156,10 +156,17 @@ func (e *Engine) QueueAgentShellSetGoal(runID string, stepID string, objective s
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
-	queued, err := e.enqueueActiveRunGoalMutation(runID, stepID, activeRunGoalMutation{
-		kind:  activeRunGoalMutationSet,
-		goal:  goal,
-		actor: actor,
+	queued, err := e.enqueueActiveRunGoalMutation(runID, stepID, func(stepID string) (activeRunGoalMutation, error) {
+		if actor == session.GoalActorAgent {
+			if current := e.effectiveActiveRunGoalForStepLocked(stepID); activeRunGoalBlocksAgentSet(current) {
+				return activeRunGoalMutation{}, session.GoalAgentOverwriteBlockedError{Goal: *current}
+			}
+		}
+		return activeRunGoalMutation{
+			kind:  activeRunGoalMutationSet,
+			goal:  goal,
+			actor: actor,
+		}, nil
 	})
 	if err != nil || !queued {
 		return session.GoalState{}, queued, err
@@ -171,37 +178,72 @@ func (e *Engine) QueueAgentShellCompleteGoal(runID string, stepID string, actor 
 	if e == nil || e.store == nil {
 		return session.GoalState{}, false, fmt.Errorf("runtime engine is required")
 	}
-	current := e.Goal()
-	if current == nil {
-		return session.GoalState{}, false, errors.New("goal is not set")
-	}
-	queued, err := e.enqueueActiveRunGoalMutation(runID, stepID, activeRunGoalMutation{
-		kind:  activeRunGoalMutationComplete,
-		goal:  *current,
-		actor: actor,
+	var accepted session.GoalState
+	queued, err := e.enqueueActiveRunGoalMutation(runID, stepID, func(stepID string) (activeRunGoalMutation, error) {
+		current := e.effectiveActiveRunGoalForStepLocked(stepID)
+		if current == nil {
+			return activeRunGoalMutation{}, errors.New("goal is not set")
+		}
+		accepted = *current
+		accepted.Status = session.GoalStatusComplete
+		accepted.UpdatedAt = time.Now().UTC()
+		return activeRunGoalMutation{
+			kind:  activeRunGoalMutationComplete,
+			goal:  *current,
+			actor: actor,
+		}, nil
 	})
 	if err != nil || !queued {
 		return session.GoalState{}, queued, err
 	}
-	accepted := *current
-	accepted.Status = session.GoalStatusComplete
-	accepted.UpdatedAt = time.Now().UTC()
 	return accepted, true, nil
 }
 
-func (e *Engine) enqueueActiveRunGoalMutation(runID string, stepID string, mutation activeRunGoalMutation) (bool, error) {
+func (e *Engine) enqueueActiveRunGoalMutation(runID string, stepID string, build func(stepID string) (activeRunGoalMutation, error)) (bool, error) {
 	if e == nil || e.stepLifecycle == nil {
 		return false, nil
 	}
+	stepID = strings.TrimSpace(stepID)
 	return e.stepLifecycle.WithActiveRun(runID, stepID, func() error {
 		e.activeRunGoalMutationsMu.Lock()
 		defer e.activeRunGoalMutationsMu.Unlock()
 		if e.activeRunGoalMutations == nil {
 			e.activeRunGoalMutations = make(map[string][]activeRunGoalMutation)
 		}
-		e.activeRunGoalMutations[strings.TrimSpace(stepID)] = append(e.activeRunGoalMutations[strings.TrimSpace(stepID)], mutation)
+		mutation, err := build(stepID)
+		if err != nil {
+			return err
+		}
+		e.activeRunGoalMutations[stepID] = append(e.activeRunGoalMutations[stepID], mutation)
 		return nil
 	})
+}
+
+func (e *Engine) effectiveActiveRunGoalForStepLocked(stepID string) *session.GoalState {
+	var effective *session.GoalState
+	if current := e.Goal(); current != nil {
+		clone := *current
+		effective = &clone
+	}
+	for _, mutation := range e.activeRunGoalMutations[strings.TrimSpace(stepID)] {
+		switch mutation.kind {
+		case activeRunGoalMutationSet:
+			clone := mutation.goal
+			effective = &clone
+		case activeRunGoalMutationComplete:
+			if effective != nil && strings.TrimSpace(effective.ID) == strings.TrimSpace(mutation.goal.ID) {
+				clone := *effective
+				clone.Status = session.GoalStatusComplete
+				clone.UpdatedAt = time.Now().UTC()
+				effective = &clone
+			}
+		}
+	}
+	return effective
+}
+
+func activeRunGoalBlocksAgentSet(goal *session.GoalState) bool {
+	return goal != nil && goal.Status != session.GoalStatusComplete
 }
 
 func (e *Engine) drainActiveRunGoalMutations(stepID string) error {
@@ -486,6 +528,9 @@ func (e *Engine) requireAskQuestionForActiveGoal() error {
 }
 
 func (e *Engine) RequireGoalLoopStartAllowed() error {
+	if e.workflowRunActive() {
+		return nil
+	}
 	return e.requireAskQuestionForGoalLoopStart()
 }
 

--- a/server/runtime/goal.go
+++ b/server/runtime/goal.go
@@ -12,6 +12,8 @@ import (
 	"core/server/session"
 	"core/shared/toolspec"
 	"core/shared/transcript"
+
+	"github.com/google/uuid"
 )
 
 const goalObjectivePreviewMaxRunes = 120
@@ -28,9 +30,9 @@ const (
 )
 
 type activeRunGoalMutation struct {
-	kind      activeRunGoalMutationKind
-	objective string
-	actor     session.GoalActor
+	kind  activeRunGoalMutationKind
+	goal  session.GoalState
+	actor session.GoalActor
 }
 
 func (e *Engine) Goal() *session.GoalState {
@@ -52,13 +54,17 @@ func (e *Engine) SetGoal(objective string, actor session.GoalActor) (session.Goa
 }
 
 func (e *Engine) setGoalForStep(stepID string, objective string, actor session.GoalActor) (session.GoalState, error) {
+	return e.setGoalStateForStep(stepID, session.GoalState{Objective: objective}, actor)
+}
+
+func (e *Engine) setGoalStateForStep(stepID string, goalState session.GoalState, actor session.GoalActor) (session.GoalState, error) {
 	if e == nil || e.store == nil {
 		return session.GoalState{}, fmt.Errorf("runtime engine is required")
 	}
-	msg := normalizeMessageForTranscript(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeGoal, Content: prompts.RenderGoalSetPrompt(strings.TrimSpace(objective)), CompactContent: goalSetCompactText(objective)}, e.transcriptWorkingDir())
+	msg := normalizeMessageForTranscript(llm.Message{Role: llm.RoleDeveloper, MessageType: llm.MessageTypeGoal, Content: prompts.RenderGoalSetPrompt(strings.TrimSpace(goalState.Objective)), CompactContent: goalSetCompactText(goalState.Objective)}, e.transcriptWorkingDir())
 	e.controlMutationMu.Lock()
 	defer e.controlMutationMu.Unlock()
-	goal, err := e.store.SetGoalWithEvents(objective, actor, []session.EventInput{{Kind: "message", Payload: msg}})
+	goal, err := e.store.SetActiveGoalWithEvents(goalState, actor, []session.EventInput{{Kind: "message", Payload: msg}})
 	if err != nil {
 		return session.GoalState{}, err
 	}
@@ -109,16 +115,23 @@ func (e *Engine) QueueAgentShellSetGoal(runID string, stepID string, objective s
 	if err := e.RequireGoalLoopStartAllowed(); err != nil {
 		return session.GoalState{}, false, err
 	}
+	now := time.Now().UTC()
+	goal := session.GoalState{
+		ID:        uuid.NewString(),
+		Objective: objective,
+		Status:    session.GoalStatusActive,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
 	queued, err := e.enqueueActiveRunGoalMutation(runID, stepID, activeRunGoalMutation{
-		kind:      activeRunGoalMutationSet,
-		objective: objective,
-		actor:     actor,
+		kind:  activeRunGoalMutationSet,
+		goal:  goal,
+		actor: actor,
 	})
 	if err != nil || !queued {
 		return session.GoalState{}, queued, err
 	}
-	now := time.Now().UTC()
-	return session.GoalState{Objective: objective, Status: session.GoalStatusActive, CreatedAt: now, UpdatedAt: now}, true, nil
+	return goal, true, nil
 }
 
 func (e *Engine) QueueAgentShellCompleteGoal(runID string, stepID string, actor session.GoalActor) (session.GoalState, bool, error) {
@@ -163,42 +176,36 @@ func (e *Engine) drainActiveRunGoalMutations(stepID string) error {
 		return nil
 	}
 	for {
-		mutation, ok := e.peekActiveRunGoalMutation(stepID)
+		mutation, ok := e.shiftActiveRunGoalMutation(stepID)
 		if !ok {
 			return nil
 		}
 		if err := e.applyActiveRunGoalMutation(stepID, mutation); err != nil {
 			return err
 		}
-		e.shiftActiveRunGoalMutation(stepID)
 	}
 }
 
-func (e *Engine) peekActiveRunGoalMutation(stepID string) (activeRunGoalMutation, bool) {
+func (e *Engine) shiftActiveRunGoalMutation(stepID string) (activeRunGoalMutation, bool) {
 	e.activeRunGoalMutationsMu.Lock()
 	defer e.activeRunGoalMutationsMu.Unlock()
 	pending := e.activeRunGoalMutations[stepID]
 	if len(pending) == 0 {
 		return activeRunGoalMutation{}, false
 	}
-	return pending[0], true
-}
-
-func (e *Engine) shiftActiveRunGoalMutation(stepID string) {
-	e.activeRunGoalMutationsMu.Lock()
-	defer e.activeRunGoalMutationsMu.Unlock()
-	pending := e.activeRunGoalMutations[stepID]
+	mutation := pending[0]
 	if len(pending) <= 1 {
 		delete(e.activeRunGoalMutations, stepID)
-		return
+		return mutation, true
 	}
 	e.activeRunGoalMutations[stepID] = pending[1:]
+	return mutation, true
 }
 
 func (e *Engine) applyActiveRunGoalMutation(stepID string, mutation activeRunGoalMutation) error {
 	switch mutation.kind {
 	case activeRunGoalMutationSet:
-		if _, err := e.setGoalForStep(stepID, mutation.objective, mutation.actor); err != nil {
+		if _, err := e.setGoalStateForStep(stepID, mutation.goal, mutation.actor); err != nil {
 			return err
 		}
 		return e.StartGoalLoop()

--- a/server/runtime/goal.go
+++ b/server/runtime/goal.go
@@ -20,6 +20,19 @@ const goalLoopBusyRetryDelay = 50 * time.Millisecond
 var ErrGoalRequiresAskQuestion = errors.New("active goal requires ask_question to be enabled; enable ask_question or pause/clear the goal")
 var errGoalLoopInactive = errors.New("goal loop inactive")
 
+type activeRunGoalMutationKind uint8
+
+const (
+	activeRunGoalMutationSet activeRunGoalMutationKind = iota
+	activeRunGoalMutationComplete
+)
+
+type activeRunGoalMutation struct {
+	kind      activeRunGoalMutationKind
+	objective string
+	actor     session.GoalActor
+}
+
 func (e *Engine) Goal() *session.GoalState {
 	if e == nil || e.store == nil {
 		return nil
@@ -35,6 +48,10 @@ func (e *Engine) GoalLoopSuspended() bool {
 }
 
 func (e *Engine) SetGoal(objective string, actor session.GoalActor) (session.GoalState, error) {
+	return e.setGoalForStep("", objective, actor)
+}
+
+func (e *Engine) setGoalForStep(stepID string, objective string, actor session.GoalActor) (session.GoalState, error) {
 	if e == nil || e.store == nil {
 		return session.GoalState{}, fmt.Errorf("runtime engine is required")
 	}
@@ -45,13 +62,17 @@ func (e *Engine) SetGoal(objective string, actor session.GoalActor) (session.Goa
 	if err != nil {
 		return session.GoalState{}, err
 	}
-	if err := e.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, false, []llm.Message{msg}), steerGoalStatusUpdateIntent(goalStatusUpdateFromState(goal))); err != nil {
+	if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, false, []llm.Message{msg}), steerGoalStatusUpdateIntent(goalStatusUpdateFromState(goal))); err != nil {
 		return session.GoalState{}, err
 	}
 	return goal, nil
 }
 
 func (e *Engine) SetGoalStatus(status session.GoalStatus, actor session.GoalActor) (session.GoalState, error) {
+	return e.setGoalStatusForStep("", status, actor)
+}
+
+func (e *Engine) setGoalStatusForStep(stepID string, status session.GoalStatus, actor session.GoalActor) (session.GoalState, error) {
 	if e == nil || e.store == nil {
 		return session.GoalState{}, fmt.Errorf("runtime engine is required")
 	}
@@ -71,10 +92,122 @@ func (e *Engine) SetGoalStatus(status session.GoalStatus, actor session.GoalActo
 	if err != nil {
 		return session.GoalState{}, err
 	}
-	if err := e.steer("", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, false, []llm.Message{msg}), steerGoalStatusUpdateIntent(goalStatusUpdateFromState(goal))); err != nil {
+	if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventDefault, false, []llm.Message{msg}), steerGoalStatusUpdateIntent(goalStatusUpdateFromState(goal))); err != nil {
 		return session.GoalState{}, err
 	}
 	return goal, nil
+}
+
+func (e *Engine) QueueAgentShellSetGoal(runID string, stepID string, objective string, actor session.GoalActor) (session.GoalState, bool, error) {
+	if e == nil || e.store == nil {
+		return session.GoalState{}, false, fmt.Errorf("runtime engine is required")
+	}
+	objective = strings.TrimSpace(objective)
+	if objective == "" {
+		return session.GoalState{}, false, errors.New("goal objective is required")
+	}
+	if err := e.RequireGoalLoopStartAllowed(); err != nil {
+		return session.GoalState{}, false, err
+	}
+	queued, err := e.enqueueActiveRunGoalMutation(runID, stepID, activeRunGoalMutation{
+		kind:      activeRunGoalMutationSet,
+		objective: objective,
+		actor:     actor,
+	})
+	if err != nil || !queued {
+		return session.GoalState{}, queued, err
+	}
+	now := time.Now().UTC()
+	return session.GoalState{Objective: objective, Status: session.GoalStatusActive, CreatedAt: now, UpdatedAt: now}, true, nil
+}
+
+func (e *Engine) QueueAgentShellCompleteGoal(runID string, stepID string, actor session.GoalActor) (session.GoalState, bool, error) {
+	if e == nil || e.store == nil {
+		return session.GoalState{}, false, fmt.Errorf("runtime engine is required")
+	}
+	current := e.Goal()
+	if current == nil {
+		return session.GoalState{}, false, errors.New("goal is not set")
+	}
+	queued, err := e.enqueueActiveRunGoalMutation(runID, stepID, activeRunGoalMutation{
+		kind:  activeRunGoalMutationComplete,
+		actor: actor,
+	})
+	if err != nil || !queued {
+		return session.GoalState{}, queued, err
+	}
+	accepted := *current
+	accepted.Status = session.GoalStatusComplete
+	accepted.UpdatedAt = time.Now().UTC()
+	return accepted, true, nil
+}
+
+func (e *Engine) enqueueActiveRunGoalMutation(runID string, stepID string, mutation activeRunGoalMutation) (bool, error) {
+	if e == nil || e.stepLifecycle == nil {
+		return false, nil
+	}
+	return e.stepLifecycle.WithActiveRun(runID, stepID, func() error {
+		e.activeRunGoalMutationsMu.Lock()
+		defer e.activeRunGoalMutationsMu.Unlock()
+		if e.activeRunGoalMutations == nil {
+			e.activeRunGoalMutations = make(map[string][]activeRunGoalMutation)
+		}
+		e.activeRunGoalMutations[strings.TrimSpace(stepID)] = append(e.activeRunGoalMutations[strings.TrimSpace(stepID)], mutation)
+		return nil
+	})
+}
+
+func (e *Engine) drainActiveRunGoalMutations(stepID string) error {
+	stepID = strings.TrimSpace(stepID)
+	if e == nil || stepID == "" {
+		return nil
+	}
+	for {
+		mutation, ok := e.peekActiveRunGoalMutation(stepID)
+		if !ok {
+			return nil
+		}
+		if err := e.applyActiveRunGoalMutation(stepID, mutation); err != nil {
+			return err
+		}
+		e.shiftActiveRunGoalMutation(stepID)
+	}
+}
+
+func (e *Engine) peekActiveRunGoalMutation(stepID string) (activeRunGoalMutation, bool) {
+	e.activeRunGoalMutationsMu.Lock()
+	defer e.activeRunGoalMutationsMu.Unlock()
+	pending := e.activeRunGoalMutations[stepID]
+	if len(pending) == 0 {
+		return activeRunGoalMutation{}, false
+	}
+	return pending[0], true
+}
+
+func (e *Engine) shiftActiveRunGoalMutation(stepID string) {
+	e.activeRunGoalMutationsMu.Lock()
+	defer e.activeRunGoalMutationsMu.Unlock()
+	pending := e.activeRunGoalMutations[stepID]
+	if len(pending) <= 1 {
+		delete(e.activeRunGoalMutations, stepID)
+		return
+	}
+	e.activeRunGoalMutations[stepID] = pending[1:]
+}
+
+func (e *Engine) applyActiveRunGoalMutation(stepID string, mutation activeRunGoalMutation) error {
+	switch mutation.kind {
+	case activeRunGoalMutationSet:
+		if _, err := e.setGoalForStep(stepID, mutation.objective, mutation.actor); err != nil {
+			return err
+		}
+		return e.StartGoalLoop()
+	case activeRunGoalMutationComplete:
+		_, err := e.setGoalStatusForStep(stepID, session.GoalStatusComplete, mutation.actor)
+		return err
+	default:
+		return fmt.Errorf("unsupported active-run goal mutation kind %d", mutation.kind)
+	}
 }
 
 func (e *Engine) ClearGoal(actor session.GoalActor) (session.GoalState, error) {

--- a/server/runtime/goal.go
+++ b/server/runtime/goal.go
@@ -524,6 +524,9 @@ func (e *Engine) requireAskQuestionForActiveGoal() error {
 	if goal == nil || goal.Status != session.GoalStatusActive {
 		return nil
 	}
+	if e.workflowRunActive() {
+		return nil
+	}
 	return e.requireAskQuestionForGoalLoopStart()
 }
 

--- a/server/runtime/goal_test.go
+++ b/server/runtime/goal_test.go
@@ -111,7 +111,8 @@ func TestQueuedAgentShellGoalSetDrainsAfterToolCompletion(t *testing.T) {
 	})
 	engine.stepLifecycle = &stubExclusiveStepLifecycle{snapshot: &RunSnapshot{RunID: "run-1", StepID: "step-1"}}
 
-	if _, queued, err := engine.QueueAgentShellSetGoal("run-1", "step-1", "queued goal", session.GoalActorAgent); err != nil || !queued {
+	queuedGoal, queued, err := engine.QueueAgentShellSetGoal("run-1", "step-1", "queued goal", session.GoalActorAgent)
+	if err != nil || !queued {
 		t.Fatalf("QueueAgentShellSetGoal queued=%t err=%v, want queued", queued, err)
 	}
 	assistant := llm.Message{
@@ -136,6 +137,9 @@ func TestQueuedAgentShellGoalSetDrainsAfterToolCompletion(t *testing.T) {
 	}
 	if err := engine.drainActiveRunGoalMutations("step-1"); err != nil {
 		t.Fatalf("drain goal mutations: %v", err)
+	}
+	if goal := engine.Goal(); goal == nil || goal.ID != queuedGoal.ID {
+		t.Fatalf("persisted goal id = %+v, want queued id %q", goal, queuedGoal.ID)
 	}
 
 	messages := engine.transcriptRuntimeState().SnapshotMessages()

--- a/server/runtime/goal_test.go
+++ b/server/runtime/goal_test.go
@@ -514,6 +514,22 @@ func TestActiveGoalRequiresAskQuestionBeforeModelTurn(t *testing.T) {
 	assertModelCallCount(t, client, 0)
 }
 
+func TestWorkflowActiveGoalSkipsAskQuestionBeforeModelTurn(t *testing.T) {
+	store := mustCreateNamedTestSession(t, "workspace-x", "/tmp/workspace-x")
+	engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{
+		EnabledTools: []toolspec.ID{toolspec.ToolExecCommand},
+		WorkflowRun:  &workflowruntime.Config{Contract: workflowruntime.CompletionContract{RunID: workflow.RunID("workflow-run-1")}},
+	})
+	engine.SetQuestionsEnabled(false)
+	if _, err := engine.SetGoal("ship workflow goal", session.GoalActorUser); err != nil {
+		t.Fatalf("SetGoal: %v", err)
+	}
+
+	if err := engine.requireAskQuestionForActiveGoal(); err != nil {
+		t.Fatalf("workflow active goal preflight with questions disabled: %v", err)
+	}
+}
+
 func TestActiveGoalAllowsModelTurnWithAskQuestionEnabled(t *testing.T) {
 	store := mustCreateNamedTestSession(t, "workspace-x", "/tmp/workspace-x")
 	client := &fakeClient{responses: []llm.Response{finalTextResponse("done")}}

--- a/server/runtime/goal_test.go
+++ b/server/runtime/goal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -160,6 +161,81 @@ func TestQueuedAgentShellGoalSetDrainsAfterToolCompletion(t *testing.T) {
 	}
 	if !(assistantIdx < toolIdx && toolIdx < goalIdx) {
 		t.Fatalf("message order assistant/tool/goal = %d/%d/%d, want tool result before goal mutation", assistantIdx, toolIdx, goalIdx)
+	}
+}
+
+func TestQueuedAgentShellGoalCompleteSkipsReplacedGoal(t *testing.T) {
+	store := mustCreateNamedTestSession(t, "workspace-x", "/tmp/workspace-x")
+	engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{})
+	engine.stepLifecycle = &stubExclusiveStepLifecycle{snapshot: &RunSnapshot{RunID: "run-1", StepID: "step-1"}}
+	accepted, err := engine.SetGoal("accepted goal", session.GoalActorUser)
+	if err != nil {
+		t.Fatalf("SetGoal accepted: %v", err)
+	}
+	if _, queued, err := engine.QueueAgentShellCompleteGoal("run-1", "step-1", session.GoalActorAgent); err != nil || !queued {
+		t.Fatalf("QueueAgentShellCompleteGoal queued=%t err=%v, want queued", queued, err)
+	}
+	replacement, err := engine.SetGoal("replacement goal", session.GoalActorUser)
+	if err != nil {
+		t.Fatalf("SetGoal replacement: %v", err)
+	}
+	if err := engine.drainActiveRunGoalMutations("step-1"); err != nil {
+		t.Fatalf("drain goal mutations: %v", err)
+	}
+	if goal := engine.Goal(); goal == nil || goal.ID != replacement.ID || goal.Status != session.GoalStatusActive {
+		t.Fatalf("goal after stale completion = %+v, want active replacement %+v", goal, replacement)
+	}
+	if accepted.ID == replacement.ID {
+		t.Fatalf("test setup reused goal id %q", accepted.ID)
+	}
+}
+
+func TestQueuedAgentShellGoalSetRechecksLoopPreflightBeforePersist(t *testing.T) {
+	store := mustCreateNamedTestSession(t, "workspace-x", "/tmp/workspace-x")
+	engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{
+		EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion},
+	})
+	engine.stepLifecycle = &stubExclusiveStepLifecycle{snapshot: &RunSnapshot{RunID: "run-1", StepID: "step-1"}}
+	if _, queued, err := engine.QueueAgentShellSetGoal("run-1", "step-1", "queued goal", session.GoalActorAgent); err != nil || !queued {
+		t.Fatalf("QueueAgentShellSetGoal queued=%t err=%v, want queued", queued, err)
+	}
+	engine.SetQuestionsEnabled(false)
+	if err := engine.drainActiveRunGoalMutations("step-1"); !errors.Is(err, ErrGoalRequiresAskQuestion) {
+		t.Fatalf("drain error = %v, want ErrGoalRequiresAskQuestion", err)
+	}
+	if goal := engine.Goal(); goal != nil {
+		t.Fatalf("goal after failed deferred preflight = %+v, want nil", goal)
+	}
+}
+
+type failingQueuedGoalTool struct {
+	engine *Engine
+}
+
+func (t failingQueuedGoalTool) Call(_ context.Context, call tools.Call) (tools.Result, error) {
+	if _, queued, err := t.engine.QueueAgentShellSetGoal(call.RunID, call.StepID, "queued goal", session.GoalActorAgent); err != nil || !queued {
+		return tools.Result{}, fmt.Errorf("queue goal queued=%t err=%w", queued, err)
+	}
+	return tools.Result{}, errors.New("tool failed after queuing goal")
+}
+
+func TestQueuedAgentShellGoalMutationDoesNotDrainAfterToolFailure(t *testing.T) {
+	store := mustCreateNamedTestSession(t, "workspace-x", "/tmp/workspace-x")
+	engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{
+		EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion},
+	})
+	engine.registry.ReplaceHandlers(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: failingQueuedGoalTool{engine: engine}})
+	engine.stepLifecycle = &stubExclusiveStepLifecycle{snapshot: &RunSnapshot{RunID: "run-1", StepID: "step-1"}}
+	executor := &defaultToolExecutor{engine: engine}
+	_, err := executor.ExecuteToolCalls(context.Background(), "step-1", []llm.ToolCall{{
+		ID:   "call-shell",
+		Name: string(toolspec.ToolExecCommand),
+	}})
+	if err == nil {
+		t.Fatal("ExecuteToolCalls error = nil, want tool failure")
+	}
+	if goal := engine.Goal(); goal != nil {
+		t.Fatalf("goal after failed tool = %+v, want nil", goal)
 	}
 }
 

--- a/server/runtime/goal_test.go
+++ b/server/runtime/goal_test.go
@@ -14,6 +14,8 @@ import (
 	"core/server/session"
 	"core/server/session/sessiontest"
 	"core/server/tools"
+	"core/server/workflow"
+	"core/server/workflowruntime"
 	"core/shared/toolspec"
 	"core/shared/transcript"
 )
@@ -98,6 +100,62 @@ func TestGoalSetEmitsCommittedGoalFeedbackEvent(t *testing.T) {
 	}
 	if statusEvt.GoalStatus.Cleared || statusEvt.GoalStatus.State.Objective != "ship goal mode" || statusEvt.GoalStatus.State.Status != session.GoalStatusActive {
 		t.Fatalf("status payload = %+v, want active goal", statusEvt.GoalStatus)
+	}
+}
+
+func TestQueuedAgentShellGoalSetDrainsAfterToolCompletion(t *testing.T) {
+	store := mustCreateNamedTestSession(t, "workspace-x", "/tmp/workspace-x")
+	engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{
+		EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion},
+		WorkflowRun:  &workflowruntime.Config{Contract: workflowruntime.CompletionContract{RunID: workflow.RunID("workflow-run-1")}},
+	})
+	engine.stepLifecycle = &stubExclusiveStepLifecycle{snapshot: &RunSnapshot{RunID: "run-1", StepID: "step-1"}}
+
+	if _, queued, err := engine.QueueAgentShellSetGoal("run-1", "step-1", "queued goal", session.GoalActorAgent); err != nil || !queued {
+		t.Fatalf("QueueAgentShellSetGoal queued=%t err=%v, want queued", queued, err)
+	}
+	assistant := llm.Message{
+		Role:  llm.RoleAssistant,
+		Phase: llm.MessagePhaseCommentary,
+		ToolCalls: []llm.ToolCall{{
+			ID:   "call-shell",
+			Name: string(toolspec.ToolExecCommand),
+		}},
+	}
+	if err := engine.steer("step-1", steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventNone, true, []llm.Message{assistant})); err != nil {
+		t.Fatalf("append assistant tool call: %v", err)
+	}
+	result := tools.Result{
+		CallID:  "call-shell",
+		Name:    toolspec.ToolExecCommand,
+		Output:  json.RawMessage(`{"output":"ok","exit_code":0,"truncated":false}`),
+		Summary: "ok",
+	}
+	if err := engine.steer("step-1", steerToolCompletionIntent(result)); err != nil {
+		t.Fatalf("append tool completion: %v", err)
+	}
+	if err := engine.drainActiveRunGoalMutations("step-1"); err != nil {
+		t.Fatalf("drain goal mutations: %v", err)
+	}
+
+	messages := engine.transcriptRuntimeState().SnapshotMessages()
+	assistantIdx, toolIdx, goalIdx := -1, -1, -1
+	for idx, msg := range messages {
+		if msg.Role == llm.RoleAssistant && len(msg.ToolCalls) == 1 && msg.ToolCalls[0].ID == "call-shell" {
+			assistantIdx = idx
+		}
+		if msg.Role == llm.RoleTool && msg.ToolCallID == "call-shell" {
+			toolIdx = idx
+		}
+		if msg.Role == llm.RoleDeveloper && msg.MessageType == llm.MessageTypeGoal {
+			goalIdx = idx
+		}
+	}
+	if assistantIdx < 0 || toolIdx < 0 || goalIdx < 0 {
+		t.Fatalf("message indexes assistant/tool/goal = %d/%d/%d, messages=%+v", assistantIdx, toolIdx, goalIdx, messages)
+	}
+	if !(assistantIdx < toolIdx && toolIdx < goalIdx) {
+		t.Fatalf("message order assistant/tool/goal = %d/%d/%d, want tool result before goal mutation", assistantIdx, toolIdx, goalIdx)
 	}
 }
 

--- a/server/runtime/orchestration_collaborators.go
+++ b/server/runtime/orchestration_collaborators.go
@@ -18,6 +18,7 @@ type exclusiveStepLifecycle interface {
 	Interrupt() error
 	IsBusy() bool
 	Snapshot() *RunSnapshot
+	WithActiveRun(runID string, stepID string, fn func() error) (bool, error)
 }
 
 type backgroundNoticeScheduler interface {

--- a/server/runtime/step_executor.go
+++ b/server/runtime/step_executor.go
@@ -35,6 +35,9 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 		if err := ctx.Err(); err != nil {
 			return stepLoopResult{}, err
 		}
+		if err := e.drainActiveRunGoalMutations(stepID); err != nil {
+			return stepLoopResult{}, err
+		}
 		if terminal, err := s.workflowDurableCompletionTerminal(ctx, stepID); err != nil {
 			return stepLoopResult{}, err
 		} else if terminal {
@@ -305,6 +308,9 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 					return stepLoopResult{}, err
 				}
 				_ = e.steer(stepID, steerEventIntent(Event{Kind: EventReviewerCompleted, StepID: stepID, Reviewer: reviewerCompletion}))
+			}
+			if err := e.drainActiveRunGoalMutations(stepID); err != nil {
+				return stepLoopResult{}, err
 			}
 			return stepLoopResult{Message: resolved, ExecutedToolCall: executedToolCall, AssistantCommittedStart: resolvedCommittedStart, AssistantCommittedStartSet: resolvedCommittedStartSet}, nil
 		}

--- a/server/runtime/tool_executor.go
+++ b/server/runtime/tool_executor.go
@@ -122,7 +122,9 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 	for _, err := range callErrs {
 		joined = errors.Join(joined, err)
 	}
-	joined = errors.Join(joined, e.drainActiveRunGoalMutations(stepID))
+	if joined == nil {
+		joined = errors.Join(joined, e.drainActiveRunGoalMutations(stepID))
+	}
 	if joined != nil {
 		return results, joined
 	}

--- a/server/runtime/tool_executor.go
+++ b/server/runtime/tool_executor.go
@@ -122,6 +122,7 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 	for _, err := range callErrs {
 		joined = errors.Join(joined, err)
 	}
+	joined = errors.Join(joined, e.drainActiveRunGoalMutations(stepID))
 	if joined != nil {
 		return results, joined
 	}

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -830,7 +830,7 @@ func (s *Service) withGoalMutationAccess(ctx context.Context, sessionID string, 
 }
 
 func (s *Service) withGoalSetMutationAccess(ctx context.Context, req serverapi.RuntimeGoalSetRequest, fn func(*runtime.Engine) error) error {
-	if s.agentGoalSetUsesLeaseFreeRuntimeAccess(req) {
+	if s.agentGoalSetUsesLeaseFreeRuntimeAccess(ctx, req) {
 		engine, err := s.resolve(ctx, req.SessionID)
 		if err != nil {
 			return err
@@ -841,7 +841,7 @@ func (s *Service) withGoalSetMutationAccess(ctx context.Context, req serverapi.R
 }
 
 func (s *Service) withGoalStatusMutationAccess(ctx context.Context, req serverapi.RuntimeGoalStatusRequest, status session.GoalStatus, fn func(*runtime.Engine) error) error {
-	if s.agentGoalCompletionUsesLeaseFreeRuntimeAccess(req, status) {
+	if s.agentGoalCompletionUsesLeaseFreeRuntimeAccess(ctx, req, status) {
 		engine, err := s.resolve(ctx, req.SessionID)
 		if err != nil {
 			return err
@@ -851,21 +851,37 @@ func (s *Service) withGoalStatusMutationAccess(ctx context.Context, req serverap
 	return s.withGoalMutationAccess(ctx, req.SessionID, req.ControllerLeaseID, fn)
 }
 
-func (s *Service) agentGoalSetUsesLeaseFreeRuntimeAccess(req serverapi.RuntimeGoalSetRequest) bool {
+func (s *Service) agentGoalSetUsesLeaseFreeRuntimeAccess(ctx context.Context, req serverapi.RuntimeGoalSetRequest) bool {
 	return strings.TrimSpace(req.ControllerLeaseID) == "" &&
 		strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) &&
 		s != nil &&
 		s.shellTokens != nil &&
-		s.shellTokens.VerifyShellToken(req.SessionID, req.ShellToken)
+		s.shellTokens.VerifyShellToken(req.SessionID, req.ShellToken) &&
+		agentShellOwnsActiveRun(ctx, s, req.SessionID, req.ShellRunID, req.ShellStepID)
 }
 
-func (s *Service) agentGoalCompletionUsesLeaseFreeRuntimeAccess(req serverapi.RuntimeGoalStatusRequest, status session.GoalStatus) bool {
+func (s *Service) agentGoalCompletionUsesLeaseFreeRuntimeAccess(ctx context.Context, req serverapi.RuntimeGoalStatusRequest, status session.GoalStatus) bool {
 	return strings.TrimSpace(req.ControllerLeaseID) == "" &&
 		strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) &&
 		status == session.GoalStatusComplete &&
 		s != nil &&
 		s.shellTokens != nil &&
-		s.shellTokens.VerifyShellToken(req.SessionID, req.ShellToken)
+		s.shellTokens.VerifyShellToken(req.SessionID, req.ShellToken) &&
+		agentShellOwnsActiveRun(ctx, s, req.SessionID, req.ShellRunID, req.ShellStepID)
+}
+
+func agentShellOwnsActiveRun(ctx context.Context, s *Service, sessionID string, shellRunID string, shellStepID string) bool {
+	shellRunID = strings.TrimSpace(shellRunID)
+	shellStepID = strings.TrimSpace(shellStepID)
+	if s == nil || shellRunID == "" || shellStepID == "" {
+		return false
+	}
+	engine, err := s.resolve(ctx, sessionID)
+	if err != nil {
+		return false
+	}
+	active := engine.ActiveRun()
+	return active != nil && active.RunID == shellRunID && active.StepID == shellStepID
 }
 
 func (s *Service) rejectWorkflowAutoCompactionDisable(ctx context.Context, sessionID string, engine *runtime.Engine) error {

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -684,6 +684,9 @@ func (s *Service) SetGoal(ctx context.Context, req serverapi.RuntimeGoalSetReque
 				return serverapi.RuntimeGoalShowResponse{}, goalAgentOverwriteDeniedError{Objective: currentGoal.Objective, Status: string(currentGoal.Status)}
 			}
 		}
+		if response, queued, err := s.queueAgentShellGoalSet(ctx, req, rejectEngine, trimmedObjective); err != nil || queued {
+			return response, err
+		}
 		err = s.withGoalSetMutationAccess(ctx, req, func(engine *runtime.Engine) error {
 			if strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) {
 				currentGoal := engine.Goal()
@@ -705,18 +708,37 @@ func (s *Service) SetGoal(ctx context.Context, req serverapi.RuntimeGoalSetReque
 			if err := engine.StartGoalLoop(); err != nil {
 				return err
 			}
-			response = serverapi.RuntimeGoalShowResponse{Goal: &serverapi.RuntimeGoal{
-				ID:        strings.TrimSpace(goal.ID),
-				Objective: goal.Objective,
-				Status:    strings.TrimSpace(string(goal.Status)),
-				Suspended: false,
-				CreatedAt: goal.CreatedAt,
-				UpdatedAt: goal.UpdatedAt,
-			}}
+			response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal, false)}
 			return nil
 		})
 		return response, err
 	})
+}
+
+func (s *Service) queueAgentShellGoalSet(ctx context.Context, req serverapi.RuntimeGoalSetRequest, engine *runtime.Engine, objective string) (serverapi.RuntimeGoalShowResponse, bool, error) {
+	if !s.agentGoalSetCanQueue(req) {
+		return serverapi.RuntimeGoalShowResponse{}, false, nil
+	}
+	if engine == nil {
+		var err error
+		engine, err = s.resolve(ctx, req.SessionID)
+		if err != nil {
+			return serverapi.RuntimeGoalShowResponse{}, false, err
+		}
+	}
+	goal, queued, err := engine.QueueAgentShellSetGoal(req.ShellRunID, req.ShellStepID, objective, session.GoalActor(req.Actor))
+	if err != nil || !queued {
+		return serverapi.RuntimeGoalShowResponse{}, queued, err
+	}
+	return serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal, false)}, true, nil
+}
+
+func (s *Service) agentGoalSetCanQueue(req serverapi.RuntimeGoalSetRequest) bool {
+	return strings.TrimSpace(req.ControllerLeaseID) == "" &&
+		strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) &&
+		s != nil &&
+		s.shellTokens != nil &&
+		s.shellTokens.VerifyShellToken(req.SessionID, req.ShellToken)
 }
 
 func goalBlocksAgentSet(goal *session.GoalState) bool {
@@ -755,18 +777,16 @@ func (s *Service) setGoalStatus(ctx context.Context, req serverapi.RuntimeGoalSt
 	memoReq := goalStatusMemoRequest{SessionID: strings.TrimSpace(req.SessionID), Status: strings.TrimSpace(string(status)), Actor: strings.TrimSpace(req.Actor)}
 	return s.goalStatuses.Do(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, sameGoalStatusMemoRequest, func(ctx context.Context) (serverapi.RuntimeGoalShowResponse, error) {
 		var response serverapi.RuntimeGoalShowResponse
+		if status == session.GoalStatusComplete {
+			if queuedResponse, queued, err := s.queueAgentShellGoalComplete(ctx, req); err != nil || queued {
+				return queuedResponse, err
+			}
+		}
 		err := s.withGoalStatusMutationAccess(ctx, req, status, func(engine *runtime.Engine) error {
 			if status == session.GoalStatusComplete {
 				current := engine.Goal()
 				if current != nil && current.Status == session.GoalStatusComplete {
-					response = serverapi.RuntimeGoalShowResponse{Goal: &serverapi.RuntimeGoal{
-						ID:        strings.TrimSpace(current.ID),
-						Objective: current.Objective,
-						Status:    strings.TrimSpace(string(current.Status)),
-						Suspended: false,
-						CreatedAt: current.CreatedAt,
-						UpdatedAt: current.UpdatedAt,
-					}}
+					response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(*current, false)}
 					return nil
 				}
 			}
@@ -784,18 +804,37 @@ func (s *Service) setGoalStatus(ctx context.Context, req serverapi.RuntimeGoalSt
 					return err
 				}
 			}
-			response = serverapi.RuntimeGoalShowResponse{Goal: &serverapi.RuntimeGoal{
-				ID:        strings.TrimSpace(goal.ID),
-				Objective: goal.Objective,
-				Status:    strings.TrimSpace(string(goal.Status)),
-				Suspended: false,
-				CreatedAt: goal.CreatedAt,
-				UpdatedAt: goal.UpdatedAt,
-			}}
+			response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal, false)}
 			return nil
 		})
 		return response, err
 	})
+}
+
+func (s *Service) queueAgentShellGoalComplete(ctx context.Context, req serverapi.RuntimeGoalStatusRequest) (serverapi.RuntimeGoalShowResponse, bool, error) {
+	if !s.agentGoalCompletionCanQueue(req) {
+		return serverapi.RuntimeGoalShowResponse{}, false, nil
+	}
+	engine, err := s.resolve(ctx, req.SessionID)
+	if err != nil {
+		return serverapi.RuntimeGoalShowResponse{}, false, err
+	}
+	if current := engine.Goal(); current != nil && current.Status == session.GoalStatusComplete {
+		return serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(*current, false)}, true, nil
+	}
+	goal, queued, err := engine.QueueAgentShellCompleteGoal(req.ShellRunID, req.ShellStepID, session.GoalActor(req.Actor))
+	if err != nil || !queued {
+		return serverapi.RuntimeGoalShowResponse{}, queued, err
+	}
+	return serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal, false)}, true, nil
+}
+
+func (s *Service) agentGoalCompletionCanQueue(req serverapi.RuntimeGoalStatusRequest) bool {
+	return strings.TrimSpace(req.ControllerLeaseID) == "" &&
+		strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) &&
+		s != nil &&
+		s.shellTokens != nil &&
+		s.shellTokens.VerifyShellToken(req.SessionID, req.ShellToken)
 }
 
 func (s *Service) ClearGoal(ctx context.Context, req serverapi.RuntimeGoalClearRequest) (serverapi.RuntimeGoalShowResponse, error) {
@@ -830,58 +869,22 @@ func (s *Service) withGoalMutationAccess(ctx context.Context, sessionID string, 
 }
 
 func (s *Service) withGoalSetMutationAccess(ctx context.Context, req serverapi.RuntimeGoalSetRequest, fn func(*runtime.Engine) error) error {
-	if s.agentGoalSetUsesLeaseFreeRuntimeAccess(ctx, req) {
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return err
-		}
-		return fn(engine)
-	}
 	return s.withGoalMutationAccess(ctx, req.SessionID, req.ControllerLeaseID, fn)
 }
 
 func (s *Service) withGoalStatusMutationAccess(ctx context.Context, req serverapi.RuntimeGoalStatusRequest, status session.GoalStatus, fn func(*runtime.Engine) error) error {
-	if s.agentGoalCompletionUsesLeaseFreeRuntimeAccess(ctx, req, status) {
-		engine, err := s.resolve(ctx, req.SessionID)
-		if err != nil {
-			return err
-		}
-		return fn(engine)
-	}
 	return s.withGoalMutationAccess(ctx, req.SessionID, req.ControllerLeaseID, fn)
 }
 
-func (s *Service) agentGoalSetUsesLeaseFreeRuntimeAccess(ctx context.Context, req serverapi.RuntimeGoalSetRequest) bool {
-	return strings.TrimSpace(req.ControllerLeaseID) == "" &&
-		strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) &&
-		s != nil &&
-		s.shellTokens != nil &&
-		s.shellTokens.VerifyShellToken(req.SessionID, req.ShellToken) &&
-		agentShellOwnsActiveRun(ctx, s, req.SessionID, req.ShellRunID, req.ShellStepID)
-}
-
-func (s *Service) agentGoalCompletionUsesLeaseFreeRuntimeAccess(ctx context.Context, req serverapi.RuntimeGoalStatusRequest, status session.GoalStatus) bool {
-	return strings.TrimSpace(req.ControllerLeaseID) == "" &&
-		strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) &&
-		status == session.GoalStatusComplete &&
-		s != nil &&
-		s.shellTokens != nil &&
-		s.shellTokens.VerifyShellToken(req.SessionID, req.ShellToken) &&
-		agentShellOwnsActiveRun(ctx, s, req.SessionID, req.ShellRunID, req.ShellStepID)
-}
-
-func agentShellOwnsActiveRun(ctx context.Context, s *Service, sessionID string, shellRunID string, shellStepID string) bool {
-	shellRunID = strings.TrimSpace(shellRunID)
-	shellStepID = strings.TrimSpace(shellStepID)
-	if s == nil || shellRunID == "" || shellStepID == "" {
-		return false
+func runtimeGoalFromSessionGoal(goal session.GoalState, suspended bool) *serverapi.RuntimeGoal {
+	return &serverapi.RuntimeGoal{
+		ID:        strings.TrimSpace(goal.ID),
+		Objective: goal.Objective,
+		Status:    strings.TrimSpace(string(goal.Status)),
+		Suspended: suspended,
+		CreatedAt: goal.CreatedAt,
+		UpdatedAt: goal.UpdatedAt,
 	}
-	engine, err := s.resolve(ctx, sessionID)
-	if err != nil {
-		return false
-	}
-	active := engine.ActiveRun()
-	return active != nil && active.RunID == shellRunID && active.StepID == shellStepID
 }
 
 func (s *Service) rejectWorkflowAutoCompactionDisable(ctx context.Context, sessionID string, engine *runtime.Engine) error {

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -679,13 +679,13 @@ func (s *Service) SetGoal(ctx context.Context, req serverapi.RuntimeGoalSetReque
 		if err != nil {
 			return serverapi.RuntimeGoalShowResponse{}, err
 		}
+		if response, queued, err := s.queueAgentShellGoalSet(ctx, req, rejectEngine, trimmedObjective); err != nil || queued {
+			return response, err
+		}
 		if strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) {
 			if currentGoal := rejectEngine.Goal(); goalBlocksAgentSet(currentGoal) {
 				return serverapi.RuntimeGoalShowResponse{}, goalAgentOverwriteDeniedError{Objective: currentGoal.Objective, Status: string(currentGoal.Status)}
 			}
-		}
-		if response, queued, err := s.queueAgentShellGoalSet(ctx, req, rejectEngine, trimmedObjective); err != nil || queued {
-			return response, err
 		}
 		err = s.withGoalSetMutationAccess(ctx, req, func(engine *runtime.Engine) error {
 			if strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) {
@@ -727,6 +727,12 @@ func (s *Service) queueAgentShellGoalSet(ctx context.Context, req serverapi.Runt
 		}
 	}
 	goal, queued, err := engine.QueueAgentShellSetGoal(req.ShellRunID, req.ShellStepID, objective, session.GoalActor(req.Actor))
+	if err != nil {
+		var blocked session.GoalAgentOverwriteBlockedError
+		if errors.As(err, &blocked) {
+			return serverapi.RuntimeGoalShowResponse{}, queued, goalAgentOverwriteDeniedError{Objective: blocked.Goal.Objective, Status: string(blocked.Goal.Status)}
+		}
+	}
 	if err != nil || !queued {
 		return serverapi.RuntimeGoalShowResponse{}, queued, err
 	}

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -684,7 +684,7 @@ func (s *Service) SetGoal(ctx context.Context, req serverapi.RuntimeGoalSetReque
 				return serverapi.RuntimeGoalShowResponse{}, goalAgentOverwriteDeniedError{Objective: currentGoal.Objective, Status: string(currentGoal.Status)}
 			}
 		}
-		err = s.withGoalMutationAccess(ctx, req.SessionID, req.ControllerLeaseID, func(engine *runtime.Engine) error {
+		err = s.withGoalSetMutationAccess(ctx, req, func(engine *runtime.Engine) error {
 			if strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) {
 				currentGoal := engine.Goal()
 				if goalBlocksAgentSet(currentGoal) {
@@ -829,6 +829,17 @@ func (s *Service) withGoalMutationAccess(ctx context.Context, sessionID string, 
 	return s.withRuntimeAccess(ctx, sessionID, leaseID, serverapi.SessionRuntimeOperationGoalManage, fn)
 }
 
+func (s *Service) withGoalSetMutationAccess(ctx context.Context, req serverapi.RuntimeGoalSetRequest, fn func(*runtime.Engine) error) error {
+	if s.agentGoalSetUsesLeaseFreeRuntimeAccess(req) {
+		engine, err := s.resolve(ctx, req.SessionID)
+		if err != nil {
+			return err
+		}
+		return fn(engine)
+	}
+	return s.withGoalMutationAccess(ctx, req.SessionID, req.ControllerLeaseID, fn)
+}
+
 func (s *Service) withGoalStatusMutationAccess(ctx context.Context, req serverapi.RuntimeGoalStatusRequest, status session.GoalStatus, fn func(*runtime.Engine) error) error {
 	if s.agentGoalCompletionUsesLeaseFreeRuntimeAccess(req, status) {
 		engine, err := s.resolve(ctx, req.SessionID)
@@ -838,6 +849,14 @@ func (s *Service) withGoalStatusMutationAccess(ctx context.Context, req serverap
 		return fn(engine)
 	}
 	return s.withGoalMutationAccess(ctx, req.SessionID, req.ControllerLeaseID, fn)
+}
+
+func (s *Service) agentGoalSetUsesLeaseFreeRuntimeAccess(req serverapi.RuntimeGoalSetRequest) bool {
+	return strings.TrimSpace(req.ControllerLeaseID) == "" &&
+		strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) &&
+		s != nil &&
+		s.shellTokens != nil &&
+		s.shellTokens.VerifyShellToken(req.SessionID, req.ShellToken)
 }
 
 func (s *Service) agentGoalCompletionUsesLeaseFreeRuntimeAccess(req serverapi.RuntimeGoalStatusRequest, status session.GoalStatus) bool {

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -173,6 +173,7 @@ type cancelObservingRuntimeControlClient struct {
 	started     chan struct{}
 	release     chan struct{}
 	ctxCanceled chan struct{}
+	cancelOnce  sync.Once
 }
 
 func newCancelObservingRuntimeControlClient() *cancelObservingRuntimeControlClient {
@@ -193,7 +194,7 @@ func (c *cancelObservingRuntimeControlClient) Generate(ctx context.Context, req 
 	if done := ctx.Done(); done != nil {
 		go func() {
 			<-done
-			close(c.ctxCanceled)
+			c.cancelOnce.Do(func() { close(c.ctxCanceled) })
 		}()
 	}
 	<-c.release
@@ -208,6 +209,45 @@ func (c *cancelObservingRuntimeControlClient) Generate(ctx context.Context, req 
 
 func (c *cancelObservingRuntimeControlClient) ProviderCapabilities(context.Context) (llm.ProviderCapabilities, error) {
 	return llm.ProviderCapabilities{}, nil
+}
+
+func startRuntimeControlActiveRun(t *testing.T, engine *runtime.Engine, client *cancelObservingRuntimeControlClient) *runtime.RunSnapshot {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		_, err := engine.SubmitUserMessage(context.Background(), "active run")
+		done <- err
+	}()
+	select {
+	case <-client.started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for active runtime run")
+	}
+	var snapshot *runtime.RunSnapshot
+	deadline := time.After(3 * time.Second)
+	for snapshot == nil {
+		snapshot = engine.ActiveRun()
+		if snapshot != nil {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for active runtime snapshot")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	t.Cleanup(func() {
+		close(client.release)
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("active run: %v", err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for active run cleanup")
+		}
+	})
+	return snapshot
 }
 
 type fakeShellHandler struct{}
@@ -451,10 +491,12 @@ func TestServiceGoalMutationsAllowCollaborativeGoalManageAccess(t *testing.T) {
 }
 
 func TestServiceAgentCompleteGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
-	store, engine := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	client := newCancelObservingRuntimeControlClient()
+	store, engine := newRuntimeControlTestEngine(t, client, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
 	if _, err := engine.SetGoal("ship goal mode", session.GoalActorUser); err != nil {
 		t.Fatalf("SetGoal: %v", err)
 	}
+	active := startRuntimeControlActiveRun(t, engine, client)
 	gate := &stubPrimaryRunGate{err: primaryrun.ErrActivePrimaryRun}
 	collaborative := &stubCollaborativeRuntimeResolver{engine: engine}
 	tokens := &stubShellTokenVerifier{valid: true}
@@ -464,6 +506,8 @@ func TestServiceAgentCompleteGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
 		ClientRequestID: "goal-complete-agent-current-turn",
 		SessionID:       store.Meta().SessionID,
 		ShellToken:      "shell-token",
+		ShellRunID:      active.RunID,
+		ShellStepID:     active.StepID,
 		Actor:           "agent",
 	})
 	if err != nil {
@@ -487,7 +531,9 @@ func TestServiceAgentCompleteGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
 }
 
 func TestServiceAgentSetGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
-	store, engine := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	client := newCancelObservingRuntimeControlClient()
+	store, engine := newRuntimeControlTestEngine(t, client, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	active := startRuntimeControlActiveRun(t, engine, client)
 	gate := &stubPrimaryRunGate{err: primaryrun.ErrActivePrimaryRun}
 	collaborative := &stubCollaborativeRuntimeResolver{engine: engine}
 	tokens := &stubShellTokenVerifier{valid: true}
@@ -497,6 +543,8 @@ func TestServiceAgentSetGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
 		ClientRequestID: "goal-set-agent-current-turn",
 		SessionID:       store.Meta().SessionID,
 		ShellToken:      "shell-token",
+		ShellRunID:      active.RunID,
+		ShellStepID:     active.StepID,
 		Objective:       "new current-turn goal",
 		Actor:           "agent",
 	})
@@ -511,6 +559,41 @@ func TestServiceAgentSetGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
 	}
 	if gate.acquire != 0 || gate.release != 0 {
 		t.Fatalf("gate acquire/release = %d/%d, want 0/0", gate.acquire, gate.release)
+	}
+	if collaborative.calls != 0 {
+		t.Fatalf("collaborative calls = %d, want 0", collaborative.calls)
+	}
+	if tokens.calls != 1 {
+		t.Fatalf("token verifier calls = %d, want 1", tokens.calls)
+	}
+}
+
+func TestServiceAgentSetGoalWithStaleShellRunKeepsPrimaryRunGate(t *testing.T) {
+	client := newCancelObservingRuntimeControlClient()
+	store, engine := newRuntimeControlTestEngine(t, client, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	active := startRuntimeControlActiveRun(t, engine, client)
+	gate := &stubPrimaryRunGate{err: primaryrun.ErrActivePrimaryRun}
+	collaborative := &stubCollaborativeRuntimeResolver{engine: engine}
+	tokens := &stubShellTokenVerifier{valid: true}
+	service := NewService(stubRuntimeResolver{engine: engine}, gate).WithCollaborativeRuntimeResolver(collaborative).WithShellTokenVerifier(tokens)
+
+	_, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
+		ClientRequestID: "goal-set-agent-stale-turn",
+		SessionID:       store.Meta().SessionID,
+		ShellToken:      "shell-token",
+		ShellRunID:      active.RunID + "-stale",
+		ShellStepID:     active.StepID,
+		Objective:       "blocked stale goal",
+		Actor:           "agent",
+	})
+	if !errors.Is(err, primaryrun.ErrActivePrimaryRun) {
+		t.Fatalf("SetGoal error = %v, want active primary run", err)
+	}
+	if goal := store.Meta().Goal; goal != nil {
+		t.Fatalf("persisted goal = %+v, want nil", goal)
+	}
+	if gate.acquire != 1 || gate.release != 0 {
+		t.Fatalf("gate acquire/release = %d/%d, want 1/0", gate.acquire, gate.release)
 	}
 	if collaborative.calls != 0 {
 		t.Fatalf("collaborative calls = %d, want 0", collaborative.calls)

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -486,6 +486,70 @@ func TestServiceAgentCompleteGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
 	}
 }
 
+func TestServiceAgentSetGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
+	store, engine := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	gate := &stubPrimaryRunGate{err: primaryrun.ErrActivePrimaryRun}
+	collaborative := &stubCollaborativeRuntimeResolver{engine: engine}
+	tokens := &stubShellTokenVerifier{valid: true}
+	service := NewService(stubRuntimeResolver{engine: engine}, gate).WithCollaborativeRuntimeResolver(collaborative).WithShellTokenVerifier(tokens)
+
+	resp, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
+		ClientRequestID: "goal-set-agent-current-turn",
+		SessionID:       store.Meta().SessionID,
+		ShellToken:      "shell-token",
+		Objective:       "new current-turn goal",
+		Actor:           "agent",
+	})
+	if err != nil {
+		t.Fatalf("SetGoal: %v", err)
+	}
+	if resp.Goal == nil || resp.Goal.Objective != "new current-turn goal" || resp.Goal.Status != string(session.GoalStatusActive) {
+		t.Fatalf("set response = %+v, want active current-turn goal", resp.Goal)
+	}
+	if goal := store.Meta().Goal; goal == nil || goal.Objective != "new current-turn goal" || goal.Status != session.GoalStatusActive {
+		t.Fatalf("persisted goal = %+v, want active current-turn goal", goal)
+	}
+	if gate.acquire != 0 || gate.release != 0 {
+		t.Fatalf("gate acquire/release = %d/%d, want 0/0", gate.acquire, gate.release)
+	}
+	if collaborative.calls != 0 {
+		t.Fatalf("collaborative calls = %d, want 0", collaborative.calls)
+	}
+	if tokens.calls != 1 {
+		t.Fatalf("token verifier calls = %d, want 1", tokens.calls)
+	}
+}
+
+func TestServiceAgentSetGoalWithoutShellTokenKeepsPrimaryRunGate(t *testing.T) {
+	store, engine := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	gate := &stubPrimaryRunGate{err: primaryrun.ErrActivePrimaryRun}
+	collaborative := &stubCollaborativeRuntimeResolver{engine: engine}
+	tokens := &stubShellTokenVerifier{valid: false}
+	service := NewService(stubRuntimeResolver{engine: engine}, gate).WithCollaborativeRuntimeResolver(collaborative).WithShellTokenVerifier(tokens)
+
+	_, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
+		ClientRequestID: "goal-set-agent-no-token",
+		SessionID:       store.Meta().SessionID,
+		Objective:       "blocked goal",
+		Actor:           "agent",
+	})
+	if !errors.Is(err, primaryrun.ErrActivePrimaryRun) {
+		t.Fatalf("SetGoal error = %v, want active primary run", err)
+	}
+	if goal := store.Meta().Goal; goal != nil {
+		t.Fatalf("persisted goal = %+v, want nil", goal)
+	}
+	if gate.acquire != 1 || gate.release != 0 {
+		t.Fatalf("gate acquire/release = %d/%d, want 1/0", gate.acquire, gate.release)
+	}
+	if collaborative.calls != 0 {
+		t.Fatalf("collaborative calls = %d, want 0", collaborative.calls)
+	}
+	if tokens.calls != 1 {
+		t.Fatalf("token verifier calls = %d, want 1", tokens.calls)
+	}
+}
+
 func TestServiceAgentCompleteGoalWithoutShellTokenKeepsPrimaryRunGate(t *testing.T) {
 	store, engine := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
 	if _, err := engine.SetGoal("ship goal mode", session.GoalActorUser); err != nil {

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -532,6 +532,8 @@ func TestServiceAgentCompleteGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
 	active.finish()
 	if goal := store.Meta().Goal; goal == nil || goal.Status != session.GoalStatusComplete {
 		t.Fatalf("persisted goal = %+v, want complete", goal)
+	} else if resp.Goal.ID != goal.ID {
+		t.Fatalf("complete response goal id = %q, want persisted id %q", resp.Goal.ID, goal.ID)
 	}
 	if gate.acquire != 0 || gate.release != 0 {
 		t.Fatalf("gate acquire/release = %d/%d, want 0/0", gate.acquire, gate.release)
@@ -571,6 +573,8 @@ func TestServiceAgentSetGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
 	active.finish()
 	if goal := store.Meta().Goal; goal == nil || goal.Objective != "new current-turn goal" || goal.Status != session.GoalStatusActive {
 		t.Fatalf("persisted goal = %+v, want active current-turn goal", goal)
+	} else if resp.Goal.ID != goal.ID {
+		t.Fatalf("set response goal id = %q, want persisted id %q", resp.Goal.ID, goal.ID)
 	}
 	if gate.acquire != 0 || gate.release != 0 {
 		t.Fatalf("gate acquire/release = %d/%d, want 0/0", gate.acquire, gate.release)

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -587,6 +587,64 @@ func TestServiceAgentSetGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
 	}
 }
 
+func TestServiceAgentShellCompleteThenSetGoalUsesQueuedEffectiveGoal(t *testing.T) {
+	client := newCancelObservingRuntimeControlClient()
+	store, engine := newRuntimeControlTestEngine(t, client, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	if _, err := engine.SetGoal("finished current goal", session.GoalActorUser); err != nil {
+		t.Fatalf("SetGoal initial: %v", err)
+	}
+	active := startRuntimeControlActiveRun(t, engine, client)
+	gate := &stubPrimaryRunGate{err: primaryrun.ErrActivePrimaryRun}
+	collaborative := &stubCollaborativeRuntimeResolver{engine: engine}
+	tokens := &stubShellTokenVerifier{valid: true}
+	service := NewService(stubRuntimeResolver{engine: engine}, gate).WithCollaborativeRuntimeResolver(collaborative).WithShellTokenVerifier(tokens)
+
+	complete, err := service.CompleteGoal(context.Background(), serverapi.RuntimeGoalStatusRequest{
+		ClientRequestID: "goal-complete-agent-current-turn-chain",
+		SessionID:       store.Meta().SessionID,
+		ShellToken:      "shell-token",
+		ShellRunID:      active.Snapshot.RunID,
+		ShellStepID:     active.Snapshot.StepID,
+		Actor:           "agent",
+	})
+	if err != nil {
+		t.Fatalf("CompleteGoal: %v", err)
+	}
+	if complete.Goal == nil || complete.Goal.Status != string(session.GoalStatusComplete) {
+		t.Fatalf("complete response = %+v, want completed queued goal", complete.Goal)
+	}
+	set, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
+		ClientRequestID: "goal-set-agent-current-turn-chain",
+		SessionID:       store.Meta().SessionID,
+		ShellToken:      "shell-token",
+		ShellRunID:      active.Snapshot.RunID,
+		ShellStepID:     active.Snapshot.StepID,
+		Objective:       "follow-up queued goal",
+		Actor:           "agent",
+	})
+	if err != nil {
+		t.Fatalf("SetGoal after queued complete: %v", err)
+	}
+	if set.Goal == nil || set.Goal.Objective != "follow-up queued goal" || set.Goal.Status != string(session.GoalStatusActive) {
+		t.Fatalf("set response = %+v, want follow-up active goal", set.Goal)
+	}
+	active.finish()
+	if goal := store.Meta().Goal; goal == nil || goal.Objective != "follow-up queued goal" || goal.Status != session.GoalStatusActive {
+		t.Fatalf("persisted goal = %+v, want follow-up active goal", goal)
+	} else if set.Goal.ID != goal.ID {
+		t.Fatalf("set response goal id = %q, want persisted id %q", set.Goal.ID, goal.ID)
+	}
+	if gate.acquire != 0 || gate.release != 0 {
+		t.Fatalf("gate acquire/release = %d/%d, want 0/0", gate.acquire, gate.release)
+	}
+	if collaborative.calls != 0 {
+		t.Fatalf("collaborative calls = %d, want 0", collaborative.calls)
+	}
+	if tokens.calls != 2 {
+		t.Fatalf("token verifier calls = %d, want 2", tokens.calls)
+	}
+}
+
 func TestServiceAgentSetGoalWithStaleShellRunKeepsPrimaryRunGate(t *testing.T) {
 	client := newCancelObservingRuntimeControlClient()
 	store, engine := newRuntimeControlTestEngine(t, client, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
@@ -723,6 +781,7 @@ func TestServiceWorkflowRuntimeAllowsGoalControl(t *testing.T) {
 		},
 		EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion},
 	})
+	engine.SetQuestionsEnabled(false)
 	resp, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
 		ClientRequestID: "req-goal-workflow",
 		SessionID:       store.Meta().SessionID,
@@ -785,6 +844,7 @@ func TestServiceWorkflowRuntimeAllowsGoalStatusTransitions(t *testing.T) {
 	if goal := engine.Goal(); goal == nil || goal.Status != session.GoalStatusPaused {
 		t.Fatalf("goal after pause = %+v, want paused", goal)
 	}
+	engine.SetQuestionsEnabled(false)
 	if _, err := service.ResumeGoal(context.Background(), serverapi.RuntimeGoalStatusRequest{ClientRequestID: "resume", SessionID: sessionID, Actor: "user"}); err != nil {
 		t.Fatalf("ResumeGoal: %v", err)
 	}

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -176,6 +176,11 @@ type cancelObservingRuntimeControlClient struct {
 	cancelOnce  sync.Once
 }
 
+type runtimeControlActiveRun struct {
+	Snapshot *runtime.RunSnapshot
+	finish   func()
+}
+
 func newCancelObservingRuntimeControlClient() *cancelObservingRuntimeControlClient {
 	return &cancelObservingRuntimeControlClient{
 		started:     make(chan struct{}),
@@ -211,7 +216,7 @@ func (c *cancelObservingRuntimeControlClient) ProviderCapabilities(context.Conte
 	return llm.ProviderCapabilities{}, nil
 }
 
-func startRuntimeControlActiveRun(t *testing.T, engine *runtime.Engine, client *cancelObservingRuntimeControlClient) *runtime.RunSnapshot {
+func startRuntimeControlActiveRun(t *testing.T, engine *runtime.Engine, client *cancelObservingRuntimeControlClient) runtimeControlActiveRun {
 	t.Helper()
 	done := make(chan error, 1)
 	go func() {
@@ -236,18 +241,26 @@ func startRuntimeControlActiveRun(t *testing.T, engine *runtime.Engine, client *
 		case <-time.After(10 * time.Millisecond):
 		}
 	}
-	t.Cleanup(func() {
-		close(client.release)
-		select {
-		case err := <-done:
-			if err != nil {
-				t.Fatalf("active run: %v", err)
+	var finishOnce sync.Once
+	finish := func() {
+		t.Helper()
+		finishOnce.Do(func() {
+			close(client.release)
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("active run: %v", err)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("timed out waiting for active run cleanup")
 			}
-		case <-time.After(3 * time.Second):
-			t.Fatal("timed out waiting for active run cleanup")
-		}
+		})
+	}
+	t.Cleanup(func() {
+		t.Helper()
+		finish()
 	})
-	return snapshot
+	return runtimeControlActiveRun{Snapshot: snapshot, finish: finish}
 }
 
 type fakeShellHandler struct{}
@@ -506,8 +519,8 @@ func TestServiceAgentCompleteGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
 		ClientRequestID: "goal-complete-agent-current-turn",
 		SessionID:       store.Meta().SessionID,
 		ShellToken:      "shell-token",
-		ShellRunID:      active.RunID,
-		ShellStepID:     active.StepID,
+		ShellRunID:      active.Snapshot.RunID,
+		ShellStepID:     active.Snapshot.StepID,
 		Actor:           "agent",
 	})
 	if err != nil {
@@ -516,6 +529,7 @@ func TestServiceAgentCompleteGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
 	if resp.Goal == nil || resp.Goal.Status != string(session.GoalStatusComplete) {
 		t.Fatalf("complete response = %+v, want complete goal", resp.Goal)
 	}
+	active.finish()
 	if goal := store.Meta().Goal; goal == nil || goal.Status != session.GoalStatusComplete {
 		t.Fatalf("persisted goal = %+v, want complete", goal)
 	}
@@ -543,8 +557,8 @@ func TestServiceAgentSetGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
 		ClientRequestID: "goal-set-agent-current-turn",
 		SessionID:       store.Meta().SessionID,
 		ShellToken:      "shell-token",
-		ShellRunID:      active.RunID,
-		ShellStepID:     active.StepID,
+		ShellRunID:      active.Snapshot.RunID,
+		ShellStepID:     active.Snapshot.StepID,
 		Objective:       "new current-turn goal",
 		Actor:           "agent",
 	})
@@ -554,6 +568,7 @@ func TestServiceAgentSetGoalAllowsCurrentTurnPrimaryRun(t *testing.T) {
 	if resp.Goal == nil || resp.Goal.Objective != "new current-turn goal" || resp.Goal.Status != string(session.GoalStatusActive) {
 		t.Fatalf("set response = %+v, want active current-turn goal", resp.Goal)
 	}
+	active.finish()
 	if goal := store.Meta().Goal; goal == nil || goal.Objective != "new current-turn goal" || goal.Status != session.GoalStatusActive {
 		t.Fatalf("persisted goal = %+v, want active current-turn goal", goal)
 	}
@@ -581,8 +596,8 @@ func TestServiceAgentSetGoalWithStaleShellRunKeepsPrimaryRunGate(t *testing.T) {
 		ClientRequestID: "goal-set-agent-stale-turn",
 		SessionID:       store.Meta().SessionID,
 		ShellToken:      "shell-token",
-		ShellRunID:      active.RunID + "-stale",
-		ShellStepID:     active.StepID,
+		ShellRunID:      active.Snapshot.RunID + "-stale",
+		ShellStepID:     active.Snapshot.StepID,
 		Objective:       "blocked stale goal",
 		Actor:           "agent",
 	})

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -416,16 +416,33 @@ func (s *Store) SetGoal(objective string, actor GoalActor) (GoalState, error) {
 }
 
 func (s *Store) SetGoalWithEvents(objective string, actor GoalActor, extraEvents []EventInput) (GoalState, error) {
-	trimmedObjective := strings.TrimSpace(objective)
-	if trimmedObjective == "" {
+	return s.SetActiveGoalWithEvents(GoalState{Objective: objective}, actor, extraEvents)
+}
+
+func (s *Store) SetActiveGoalWithEvents(goal GoalState, actor GoalActor, extraEvents []EventInput) (GoalState, error) {
+	goal.Objective = strings.TrimSpace(goal.Objective)
+	if goal.Objective == "" {
 		return GoalState{}, errors.New("goal objective is required")
 	}
+	goal.ID = strings.TrimSpace(goal.ID)
+	if goal.ID == "" {
+		goal.ID = uuid.NewString()
+	}
+	goal.Status = GoalStatusActive
 	normalizedActor, err := normalizeGoalActor(actor)
 	if err != nil {
 		return GoalState{}, err
 	}
 	s.mu.Lock()
 	now := storeTimestamp(s.options)
+	if goal.CreatedAt.IsZero() {
+		goal.CreatedAt = now
+	}
+	if goal.UpdatedAt.IsZero() {
+		goal.UpdatedAt = goal.CreatedAt
+	}
+	goal.CreatedAt = goal.CreatedAt.UTC().Round(0)
+	goal.UpdatedAt = goal.UpdatedAt.UTC().Round(0)
 	replacedGoalID := ""
 	previousGoal := cloneGoalState(s.meta.Goal)
 	if normalizedActor == GoalActorAgent && previousGoal != nil && previousGoal.Status != GoalStatusComplete {
@@ -434,13 +451,6 @@ func (s *Store) SetGoalWithEvents(objective string, actor GoalActor, extraEvents
 	}
 	if s.meta.Goal != nil {
 		replacedGoalID = strings.TrimSpace(s.meta.Goal.ID)
-	}
-	goal := GoalState{
-		ID:        uuid.NewString(),
-		Objective: trimmedObjective,
-		Status:    GoalStatusActive,
-		CreatedAt: now,
-		UpdatedAt: now,
 	}
 	events, err := s.buildGoalEventsLocked("goal_set", GoalSetEvent{Goal: goal, Actor: normalizedActor, ReplacedGoalID: replacedGoalID}, extraEvents, now)
 	if err != nil {

--- a/server/tools/shell/manager.go
+++ b/server/tools/shell/manager.go
@@ -134,7 +134,9 @@ func (m *Manager) Start(ctx context.Context, req ExecRequest) (ExecResult, error
 			return ExecResult{}, err
 		}
 	}
-	cmd.Env = tools.EnrichShellEnvForSessionToken(os.Environ(), ownerSessionID, shellToken)
+	ownerRunID := strings.TrimSpace(req.OwnerRunID)
+	ownerStepID := strings.TrimSpace(req.OwnerStepID)
+	cmd.Env = tools.EnrichShellEnvForSessionRunToken(os.Environ(), ownerSessionID, ownerRunID, ownerStepID, shellToken)
 	prepareManagedExec(cmd)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -148,8 +150,8 @@ func (m *Manager) Start(ctx context.Context, req ExecRequest) (ExecResult, error
 		id:             id,
 		ownerSessionID: ownerSessionID,
 		shellToken:     shellToken,
-		ownerRunID:     strings.TrimSpace(req.OwnerRunID),
-		ownerStepID:    strings.TrimSpace(req.OwnerStepID),
+		ownerRunID:     ownerRunID,
+		ownerStepID:    ownerStepID,
 		command:        strings.TrimSpace(req.DisplayCommand),
 		workdir:        workdir,
 		raw:            req.Raw,

--- a/server/tools/shell_env.go
+++ b/server/tools/shell_env.go
@@ -48,6 +48,10 @@ func EnrichShellEnvForSession(base []string, sessionID string) []string {
 }
 
 func EnrichShellEnvForSessionToken(base []string, sessionID string, shellToken string) []string {
+	return EnrichShellEnvForSessionRunToken(base, sessionID, "", "", shellToken)
+}
+
+func EnrichShellEnvForSessionRunToken(base []string, sessionID string, runID string, stepID string, shellToken string) []string {
 	env := make(map[string]string, len(base)+len(overrides))
 	order := make([]string, 0, len(base)+len(overrides))
 
@@ -84,6 +88,18 @@ func EnrichShellEnvForSessionToken(base []string, sessionID string, shellToken s
 			order = append(order, sessionenv.ShellTokenEnv)
 		}
 		env[sessionenv.ShellTokenEnv] = shellToken
+	}
+	if runID = strings.TrimSpace(runID); runID != "" {
+		if _, exists := env[sessionenv.ShellRunIDEnv]; !exists {
+			order = append(order, sessionenv.ShellRunIDEnv)
+		}
+		env[sessionenv.ShellRunIDEnv] = runID
+	}
+	if stepID = strings.TrimSpace(stepID); stepID != "" {
+		if _, exists := env[sessionenv.ShellStepIDEnv]; !exists {
+			order = append(order, sessionenv.ShellStepIDEnv)
+		}
+		env[sessionenv.ShellStepIDEnv] = stepID
 	}
 
 	if _, exists := env["RIPGREP_CONFIG_PATH"]; !exists {

--- a/server/tools/shell_env_test.go
+++ b/server/tools/shell_env_test.go
@@ -77,6 +77,22 @@ func TestEnrichForSessionTokenInjectsShellTokenEnv(t *testing.T) {
 	}
 }
 
+func TestEnrichForSessionRunTokenInjectsRunContextEnv(t *testing.T) {
+	env := envMap(t, EnrichShellEnvForSessionRunToken([]string{"PATH=/bin", "KEEP=1"}, " session-1 ", " run-1 ", " step-1 ", " token-1 "))
+	if got := env[sessionenv.SessionIDEnv]; got != "session-1" {
+		t.Fatalf("%s = %q, want session-1", sessionenv.SessionIDEnv, got)
+	}
+	if got := env[sessionenv.ShellTokenEnv]; got != "token-1" {
+		t.Fatalf("%s = %q, want token-1", sessionenv.ShellTokenEnv, got)
+	}
+	if got := env[sessionenv.ShellRunIDEnv]; got != "run-1" {
+		t.Fatalf("%s = %q, want run-1", sessionenv.ShellRunIDEnv, got)
+	}
+	if got := env[sessionenv.ShellStepIDEnv]; got != "step-1" {
+		t.Fatalf("%s = %q, want step-1", sessionenv.ShellStepIDEnv, got)
+	}
+}
+
 func TestEnrichForSessionOverridesExistingSessionIDEnv(t *testing.T) {
 	env := envMap(t, EnrichShellEnvForSession([]string{sessionenv.SessionIDEnv + "=old"}, "new"))
 	if got := env[sessionenv.SessionIDEnv]; got != "new" {

--- a/shared/serverapi/runtime_control.go
+++ b/shared/serverapi/runtime_control.go
@@ -208,6 +208,7 @@ type RuntimeGoalSetRequest struct {
 	ClientRequestID   string `json:"client_request_id"`
 	SessionID         string `json:"session_id"`
 	ControllerLeaseID string `json:"controller_lease_id,omitempty"`
+	ShellToken        string `json:"shell_token,omitempty"`
 	Objective         string `json:"objective"`
 	Actor             string `json:"actor"`
 }

--- a/shared/serverapi/runtime_control.go
+++ b/shared/serverapi/runtime_control.go
@@ -209,6 +209,8 @@ type RuntimeGoalSetRequest struct {
 	SessionID         string `json:"session_id"`
 	ControllerLeaseID string `json:"controller_lease_id,omitempty"`
 	ShellToken        string `json:"shell_token,omitempty"`
+	ShellRunID        string `json:"shell_run_id,omitempty"`
+	ShellStepID       string `json:"shell_step_id,omitempty"`
 	Objective         string `json:"objective"`
 	Actor             string `json:"actor"`
 }
@@ -218,6 +220,8 @@ type RuntimeGoalStatusRequest struct {
 	SessionID         string `json:"session_id"`
 	ControllerLeaseID string `json:"controller_lease_id,omitempty"`
 	ShellToken        string `json:"shell_token,omitempty"`
+	ShellRunID        string `json:"shell_run_id,omitempty"`
+	ShellStepID       string `json:"shell_step_id,omitempty"`
 	Actor             string `json:"actor"`
 }
 

--- a/shared/sessionenv/sessionenv.go
+++ b/shared/sessionenv/sessionenv.go
@@ -8,6 +8,8 @@ import (
 
 const SessionIDEnv = brand.SessionIDEnv
 const ShellTokenEnv = brand.EnvPrefix + "SHELL_TOKEN"
+const ShellRunIDEnv = brand.EnvPrefix + "SHELL_RUN_ID"
+const ShellStepIDEnv = brand.EnvPrefix + "SHELL_STEP_ID"
 
 func LookupSessionID(lookup func(string) (string, bool)) (string, bool) {
 	if lookup == nil {
@@ -29,6 +31,29 @@ func LookupShellToken(lookup func(string) (string, bool)) (string, bool) {
 		return "", false
 	}
 	value, ok := lookup(ShellTokenEnv)
+	if !ok {
+		return "", false
+	}
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", false
+	}
+	return trimmed, true
+}
+
+func LookupShellRunID(lookup func(string) (string, bool)) (string, bool) {
+	return lookupTrimmed(lookup, ShellRunIDEnv)
+}
+
+func LookupShellStepID(lookup func(string) (string, bool)) (string, bool) {
+	return lookupTrimmed(lookup, ShellStepIDEnv)
+}
+
+func lookupTrimmed(lookup func(string) (string, bool), key string) (string, bool) {
+	if lookup == nil {
+		return "", false
+	}
+	value, ok := lookup(key)
 	if !ok {
 		return "", false
 	}


### PR DESCRIPTION
## Summary
- unblock the CLI immediately after successful runtime interrupt acknowledgement
- render idle active goals as a dot instead of a frozen goal spinner
- centralize status indicator shape and phase logic

## Verification
- ./scripts/test.sh ./cli/app ./server/runtime ./server/runtimecontrol ./server/runtimeview
- ./scripts/build.sh --output ./bin/kent
- QA harness: seeded persisted active-goal session with no active run; reopened TUI rendered an idle dot before any prompt/goal-loop work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent goal actions now carry full shell context, improving continuity for goal set/complete flows.
  * The CLI status line now shows clearer phase-based indicators and better reflects active work, interruptions, and spinning state.

* **Bug Fixes**
  * Fixed Ctrl+C interruption handling so cleanup happens in the right order and queued input is restored reliably.
  * Improved goal updates and shell execution so active-run changes are applied at the correct time, with better consistency across runtime operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->