### PR TITLE
feat!: delete run role compat flag

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -13,7 +13,6 @@ type Options struct {
 	SessionID                 string
 	WorkspaceContextSessionID string
 	AgentRole                 string
-	AgentRoleSet              bool
 	Model                     string
 	ProviderOverride          string
 	ThinkingLevel             string

--- a/cli/app/run_prompt.go
+++ b/cli/app/run_prompt.go
@@ -55,7 +55,6 @@ func runPromptParentSessionID(opts Options, initialSessionID string) string {
 func runPromptOverridesFromOptions(opts Options) serverapi.RunPromptOverrides {
 	return serverapi.RunPromptOverrides{
 		AgentRole:           strings.TrimSpace(opts.AgentRole),
-		AgentRoleSet:        opts.AgentRoleSet,
 		Model:               strings.TrimSpace(opts.Model),
 		ProviderOverride:    strings.TrimSpace(opts.ProviderOverride),
 		ThinkingLevel:       strings.TrimSpace(opts.ThinkingLevel),

--- a/cli/app/run_prompt_target.go
+++ b/cli/app/run_prompt_target.go
@@ -14,6 +14,7 @@ import (
 	"core/shared/client"
 	"core/shared/config"
 	"core/shared/protocol"
+	"core/shared/serverapi"
 )
 
 var dialConfiguredRemote = client.DialConfiguredRemoteForProjectWorkspaceID
@@ -118,11 +119,11 @@ var (
 )
 
 func validateRunPromptAgentRole(settings config.Settings, rawRole string, kentSessionCaller bool, contextAgentRole string) error {
-	roleName := config.NormalizeSubagentSelector(rawRole)
-	if roleName == "" {
-		if strings.TrimSpace(rawRole) != "" && !config.IsReservedSubagentRoleName(rawRole) {
-			return errors.New("invalid agent role " + strconv.Quote(rawRole))
-		}
+	override, err := serverapi.RunPromptOverrides{AgentRole: rawRole}.AgentRoleOverride()
+	if err != nil {
+		return err
+	}
+	if !override.Present || override.Default {
 		if kentSessionCaller {
 			if err := validateContextAgentRoleCallable(settings, contextAgentRole); err != nil {
 				return err
@@ -130,6 +131,7 @@ func validateRunPromptAgentRole(settings config.Settings, rawRole string, kentSe
 		}
 		return nil
 	}
+	roleName := override.Role
 	role, exists := settings.Subagents[roleName]
 	if !exists && roleName != config.BuiltInSubagentRoleFast {
 		return fmt.Errorf("%w: %s. It may have been removed by the user during the session. Available roles: [%s]", errUnrecognizedSubagentRole, strconv.Quote(roleName), strings.Join(config.AvailableSubagentRoleNames(settings, kentSessionCaller), ", "))

--- a/cli/app/run_prompt_target_test.go
+++ b/cli/app/run_prompt_target_test.go
@@ -121,12 +121,19 @@ func TestStartRunPromptClientDefaultAliasBlocksNonCallableContextRole(t *testing
 	}
 }
 
-func TestValidateRunPromptAgentRoleAliasesDefaultSelectors(t *testing.T) {
+func TestValidateRunPromptAgentRoleAllowsDefaultSelector(t *testing.T) {
 	settings := config.Settings{Subagents: map[string]config.SubagentRole{}}
-	for _, alias := range []string{"default", "none", "self"} {
+	if err := validateRunPromptAgentRole(settings, "default", true, ""); err != nil {
+		t.Fatalf("validateRunPromptAgentRole(default): %v", err)
+	}
+}
+
+func TestValidateRunPromptAgentRoleRejectsRemovedDefaultAliases(t *testing.T) {
+	settings := config.Settings{Subagents: map[string]config.SubagentRole{}}
+	for _, alias := range []string{"none", "self"} {
 		t.Run(alias, func(t *testing.T) {
-			if err := validateRunPromptAgentRole(settings, alias, true, ""); err != nil {
-				t.Fatalf("validateRunPromptAgentRole(%q): %v", alias, err)
+			if err := validateRunPromptAgentRole(settings, alias, true, ""); err == nil {
+				t.Fatalf("expected validateRunPromptAgentRole(%q) to fail", alias)
 			}
 		})
 	}
@@ -136,7 +143,7 @@ func TestValidateRunPromptAgentRoleBlocksDefaultAliasFromNonCallableContextRole(
 	settings := config.Settings{Subagents: map[string]config.SubagentRole{
 		"blocked": {AgentCallable: false, AgentCallableSet: true, Sources: map[string]string{"model": "file"}},
 	}}
-	for _, rawRole := range []string{"", "default", "none", "self"} {
+	for _, rawRole := range []string{"", "default"} {
 		t.Run(rawRole, func(t *testing.T) {
 			err := validateRunPromptAgentRole(settings, rawRole, true, "blocked")
 			if err == nil {

--- a/cli/kent/help/run.txt
+++ b/cli/kent/help/run.txt
@@ -18,7 +18,9 @@ Session Selection:
 
 Subagents:
   `--agent <role>` selects a named role from `[subagents.<role>]` in `~/.kent/config.toml`.
+  `--agent default` clears a resumed role and uses the base/default settings.
   `--fast` is shorthand for the built-in `fast` role.
+  `none` and `self` are not valid run-agent selectors.
 
 Examples:
   kent run "summarize the unstaged changes"

--- a/cli/kent/main.go
+++ b/cli/kent/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -262,12 +263,15 @@ func runSubcommand(args []string) int {
 		emitRunUsageError(usageOutputMode, err.Error())
 		return 2
 	}
+	if flagExplicit(runFS, "agent") && strings.TrimSpace(*agentRoleRaw) == "" {
+		emitRunUsageError(outputMode, "invalid --agent value "+strconv.Quote(*agentRoleRaw))
+		return 2
+	}
 	agentRole, err := effectiveRunAgentRole(*agentRoleRaw, *fastRole)
 	if err != nil {
 		emitRunUsageError(outputMode, err.Error())
 		return 2
 	}
-	agentRoleSet := flagExplicit(runFS, "agent") || *fastRole
 
 	remaining := runFS.Args()
 	if len(remaining) == 0 {
@@ -304,7 +308,6 @@ func runSubcommand(args []string) int {
 		SessionID:                 sessionID,
 		WorkspaceContextSessionID: workspaceContextSessionID,
 		AgentRole:                 agentRole,
-		AgentRoleSet:              agentRoleSet,
 		Model:                     flags.Model,
 		ProviderOverride:          flags.ProviderOverride,
 		ThinkingLevel:             flags.ThinkingLevel,
@@ -562,9 +565,17 @@ func emitWarnings(w io.Writer, warnings []string) {
 
 func effectiveRunAgentRole(raw string, fast bool) (string, error) {
 	trimmed := strings.TrimSpace(raw)
-	normalized := config.NormalizeSubagentSelector(trimmed)
-	if trimmed != "" && normalized == "" && !config.IsReservedSubagentRoleName(trimmed) {
-		return "", fmt.Errorf("invalid --agent value %q", raw)
+	normalized := ""
+	if trimmed != "" {
+		lower := strings.ToLower(trimmed)
+		if lower == config.DefaultSubagentRole {
+			normalized = config.DefaultSubagentRole
+		} else {
+			normalized = config.NormalizeSubagentSelector(trimmed)
+			if normalized == "" {
+				return "", fmt.Errorf("invalid --agent value %q", raw)
+			}
+		}
 	}
 	if fast {
 		if normalized != "" && normalized != config.BuiltInSubagentRoleFast {

--- a/cli/kent/main_test.go
+++ b/cli/kent/main_test.go
@@ -630,59 +630,94 @@ func TestRunSubcommandDefaultAgentWithFastUsesFastRole(t *testing.T) {
 		_ = stderrFile.Close()
 	})
 
-	if code := rootCommand([]string{"run", "--agent=default", "--fast", "hello"}, strings.NewReader(""), io.Discard, io.Discard); code != 0 {
-		t.Fatalf("exit code = %d, want 0", code)
+	if code := rootCommand([]string{"run", "--agent=default", "--fast", "hello"}, strings.NewReader(""), io.Discard, io.Discard); code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
 	}
-	if gotOpts.AgentRole != config.BuiltInSubagentRoleFast {
-		t.Fatalf("agent role = %q, want fast", gotOpts.AgentRole)
+	if gotOpts.AgentRole != "" {
+		t.Fatalf("run prompt app should not be called, got agent role %q", gotOpts.AgentRole)
 	}
 }
 
-func TestRunSubcommandContinueDefaultAgentAliasesMarkExplicitRoleOverride(t *testing.T) {
-	for _, alias := range []string{"default", "none", "self"} {
+func TestRunSubcommandContinueDefaultAgentSendsDefaultRoleOverride(t *testing.T) {
+	original := runPromptApp
+	t.Cleanup(func() {
+		runPromptApp = original
+	})
+	var gotOpts app.Options
+	runPromptApp = func(ctx context.Context, opts app.Options, prompt string, timeout time.Duration, progress io.Writer) (app.RunPromptResult, error) {
+		gotOpts = opts
+		return app.RunPromptResult{Result: "done"}, nil
+	}
+
+	originalStdout := os.Stdout
+	originalStderr := os.Stderr
+	stdoutFile, err := os.CreateTemp(t.TempDir(), "stdout")
+	if err != nil {
+		t.Fatalf("create stdout temp file: %v", err)
+	}
+	stderrFile, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatalf("create stderr temp file: %v", err)
+	}
+	os.Stdout = stdoutFile
+	os.Stderr = stderrFile
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		os.Stderr = originalStderr
+		_ = stdoutFile.Close()
+		_ = stderrFile.Close()
+	})
+
+	if code := rootCommand([]string{"run", "--continue", "session-123", "--agent", "default", "hello"}, strings.NewReader(""), io.Discard, io.Discard); code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if gotOpts.SessionID != "session-123" {
+		t.Fatalf("session id = %q, want session-123", gotOpts.SessionID)
+	}
+	if gotOpts.AgentRole != config.DefaultSubagentRole {
+		t.Fatalf("agent role = %q, want default", gotOpts.AgentRole)
+	}
+}
+
+func TestRunSubcommandRejectsRemovedDefaultAgentAliases(t *testing.T) {
+	for _, alias := range []string{"none", "self"} {
 		t.Run(alias, func(t *testing.T) {
 			original := runPromptApp
 			t.Cleanup(func() {
 				runPromptApp = original
 			})
-			var gotOpts app.Options
-			runPromptApp = func(ctx context.Context, opts app.Options, prompt string, timeout time.Duration, progress io.Writer) (app.RunPromptResult, error) {
-				gotOpts = opts
-				return app.RunPromptResult{Result: "done"}, nil
+			called := false
+			runPromptApp = func(context.Context, app.Options, string, time.Duration, io.Writer) (app.RunPromptResult, error) {
+				called = true
+				return app.RunPromptResult{}, nil
 			}
 
-			originalStdout := os.Stdout
-			originalStderr := os.Stderr
-			stdoutFile, err := os.CreateTemp(t.TempDir(), "stdout")
-			if err != nil {
-				t.Fatalf("create stdout temp file: %v", err)
+			if code := rootCommand([]string{"run", "--agent", alias, "hello"}, strings.NewReader(""), io.Discard, io.Discard); code != 2 {
+				t.Fatalf("exit code = %d, want 2", code)
 			}
-			stderrFile, err := os.CreateTemp(t.TempDir(), "stderr")
-			if err != nil {
-				t.Fatalf("create stderr temp file: %v", err)
-			}
-			os.Stdout = stdoutFile
-			os.Stderr = stderrFile
-			t.Cleanup(func() {
-				os.Stdout = originalStdout
-				os.Stderr = originalStderr
-				_ = stdoutFile.Close()
-				_ = stderrFile.Close()
-			})
-
-			if code := rootCommand([]string{"run", "--continue", "session-123", "--agent", alias, "hello"}, strings.NewReader(""), io.Discard, io.Discard); code != 0 {
-				t.Fatalf("exit code = %d, want 0", code)
-			}
-			if gotOpts.SessionID != "session-123" {
-				t.Fatalf("session id = %q, want session-123", gotOpts.SessionID)
-			}
-			if gotOpts.AgentRole != "" {
-				t.Fatalf("agent role = %q, want empty default role", gotOpts.AgentRole)
-			}
-			if !gotOpts.AgentRoleSet {
-				t.Fatal("expected default alias to mark explicit role override")
+			if called {
+				t.Fatal("run prompt app should not be called for invalid role")
 			}
 		})
+	}
+}
+
+func TestRunSubcommandRejectsExplicitBlankAgentRole(t *testing.T) {
+	original := runPromptApp
+	t.Cleanup(func() {
+		runPromptApp = original
+	})
+	called := false
+	runPromptApp = func(context.Context, app.Options, string, time.Duration, io.Writer) (app.RunPromptResult, error) {
+		called = true
+		return app.RunPromptResult{}, nil
+	}
+
+	if code := rootCommand([]string{"run", "--continue", "session-123", "--agent=", "hello"}, strings.NewReader(""), io.Discard, io.Discard); code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if called {
+		t.Fatal("run prompt app should not be called for blank role")
 	}
 }
 
@@ -730,6 +765,9 @@ func TestEffectiveRunAgentRoleRejectsConflictingFastFlag(t *testing.T) {
 	if _, err := effectiveRunAgentRole("worker", true); err == nil {
 		t.Fatal("expected conflicting fast role error")
 	}
+	if _, err := effectiveRunAgentRole("default", true); err == nil {
+		t.Fatal("expected default role to conflict with fast flag")
+	}
 	role, err := effectiveRunAgentRole("fast", true)
 	if err != nil {
 		t.Fatalf("effectiveRunAgentRole: %v", err)
@@ -739,24 +777,20 @@ func TestEffectiveRunAgentRoleRejectsConflictingFastFlag(t *testing.T) {
 	}
 }
 
-func TestEffectiveRunAgentRoleAliasesDefaultSelectors(t *testing.T) {
-	for _, alias := range []string{"default", "none", "self"} {
+func TestEffectiveRunAgentRoleDefaultAndRemovedAliases(t *testing.T) {
+	role, err := effectiveRunAgentRole("default", false)
+	if err != nil {
+		t.Fatalf("effectiveRunAgentRole: %v", err)
+	}
+	if role != config.DefaultSubagentRole {
+		t.Fatalf("role = %q, want default", role)
+	}
+	for _, alias := range []string{"none", "self"} {
 		t.Run(alias, func(t *testing.T) {
-			role, err := effectiveRunAgentRole(alias, false)
-			if err != nil {
-				t.Fatalf("effectiveRunAgentRole: %v", err)
-			}
-			if role != "" {
-				t.Fatalf("role = %q, want empty", role)
+			if _, err := effectiveRunAgentRole(alias, false); err == nil {
+				t.Fatal("expected removed alias to be rejected")
 			}
 		})
-	}
-	role, err := effectiveRunAgentRole("default", true)
-	if err != nil {
-		t.Fatalf("effectiveRunAgentRole default+fast: %v", err)
-	}
-	if role != config.BuiltInSubagentRoleFast {
-		t.Fatalf("role = %q, want fast", role)
 	}
 }
 

--- a/docs/src/content/docs/headless.md
+++ b/docs/src/content/docs/headless.md
@@ -25,7 +25,7 @@ kent run --continue <session-id> "<follow-up>"
 
 Roles are needed to create specialized subagent types for different tasks. Treat them like different employees or specialists.
 
-`--agent <role>` selects a named subagent role from `[subagents.<role>]` in the local or global config file. To define a new role, edit the config:
+`--agent <role>` selects a named subagent role from `[subagents.<role>]` in the local or global config file. `--agent default` clears a resumed role and uses the base settings; `none` and `self` are not run-agent selectors. To define a new role, edit the config:
 
 ```toml
 [subagents.research]
@@ -114,5 +114,5 @@ Supported run-specific flags:
 | `--output-mode` | `final-text` or `json`. Default is `final-text`. |
 | `--progress-mode` | `quiet` or `stderr`. Default is `quiet`. |
 | `--continue` | Continue a previous session by id. |
-| `--agent` | Select a named subagent role from `config.toml`. |
+| `--agent` | Select a named subagent role from `config.toml`; use `default` for the base role. |
 | `--fast` | Shortcut for the built-in `fast` subagent role. |

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -282,19 +282,19 @@ func applyRunPromptOverridesWithBudgetApplier(plan SessionPlan, overrides server
 			AgentRole:     continuationAgentRole,
 		})
 	}
-	if trimmedRole := strings.TrimSpace(overrides.AgentRole); trimmedRole != "" && config.NormalizeSubagentSelector(trimmedRole) == "" && !config.IsReservedSubagentRoleName(trimmedRole) {
-		return SessionPlan{}, nil, fmt.Errorf("%w %q", errInvalidAgentRole, trimmedRole)
+	roleOverride, err := overrides.AgentRoleOverride()
+	if err != nil {
+		return SessionPlan{}, nil, fmt.Errorf("%w: %v", errInvalidAgentRole, err)
 	}
-	roleName := config.NormalizeSubagentSelector(overrides.AgentRole)
-	if overrides.AgentRoleSet || roleName != "" {
+	if roleOverride.Present {
 		shouldPersistContinuation = true
-		continuationAgentRole = roleName
+		continuationAgentRole = roleOverride.Role
 		next.ActiveSettings = cloneSettings(baseSettings)
 		next.Source = baseSource
 		if !plan.ModelContractLocked {
 			next.ConfiguredModelName = next.ActiveSettings.Model
 		}
-		if roleName == "" {
+		if roleOverride.Default {
 			enabledTools, err := ActiveToolIDsForPlan(next.ActiveSettings, next.Source, plan.Store.Meta().Locked)
 			if err != nil {
 				return SessionPlan{}, nil, err
@@ -302,7 +302,7 @@ func applyRunPromptOverridesWithBudgetApplier(plan SessionPlan, overrides server
 			next.EnabledTools = enabledTools
 		}
 	}
-	if roleName != "" {
+	if roleOverride.Role != "" {
 		providerBase := cloneSettings(baseSettings)
 		if value := strings.TrimSpace(overrides.ProviderOverride); value != "" {
 			providerBase.ProviderOverride = value
@@ -310,7 +310,7 @@ func applyRunPromptOverridesWithBudgetApplier(plan SessionPlan, overrides server
 		if value := strings.TrimSpace(overrides.OpenAIBaseURL); value != "" {
 			providerBase.OpenAIBaseURL = value
 		}
-		resolved, warning, err := resolveSubagentSettingsWithValidation(baseSettings, providerBase, baseSource.Sources, roleName, authState, !plan.ModelContractLocked, !overrides.HasConfigOverrides())
+		resolved, warning, err := resolveSubagentSettingsWithValidation(baseSettings, providerBase, baseSource.Sources, roleOverride.Role, authState, !plan.ModelContractLocked, !overrides.HasConfigOverrides())
 		if err != nil {
 			return SessionPlan{}, nil, err
 		}
@@ -318,7 +318,7 @@ func applyRunPromptOverridesWithBudgetApplier(plan SessionPlan, overrides server
 		if !plan.ModelContractLocked {
 			next.ConfiguredModelName = resolved.Model
 		}
-		roleSource := sourceReportWithSubagentRoleSources(baseSource, baseSettings, roleName, !plan.ModelContractLocked)
+		roleSource := sourceReportWithSubagentRoleSources(baseSource, baseSettings, roleOverride.Role, !plan.ModelContractLocked)
 		enabledTools, err := ActiveToolIDsForPlan(next.ActiveSettings, roleSource, plan.Store.Meta().Locked)
 		if err != nil {
 			return SessionPlan{}, nil, err

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -295,7 +295,7 @@ func TestPlannerKeepsRoleBaseURLOutOfBaseSettingsOnResume(t *testing.T) {
 		t.Fatalf("base settings url = %q, want base", plan.BaseSettings.OpenAIBaseURL)
 	}
 
-	cleared, warnings, err := ApplyRunPromptOverrides(plan, serverapi.RunPromptOverrides{AgentRoleSet: true}, auth.EmptyState())
+	cleared, warnings, err := ApplyRunPromptOverrides(plan, serverapi.RunPromptOverrides{AgentRole: config.DefaultSubagentRole}, auth.EmptyState())
 	if err != nil {
 		t.Fatalf("ApplyRunPromptOverrides clear: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestApplyRunPromptOverridesExplicitDefaultClearsPersistedRole(t *testing.T)
 		BaseSource:          config.SourceReport{Sources: map[string]string{"thinking_level": "file"}},
 	}
 
-	updated := applyRunPromptOverridesNoWarnings(t, plan, serverapi.RunPromptOverrides{AgentRoleSet: true}, auth.EmptyState())
+	updated := applyRunPromptOverridesNoWarnings(t, plan, serverapi.RunPromptOverrides{AgentRole: config.DefaultSubagentRole}, auth.EmptyState())
 	if updated.ActiveSettings.ThinkingLevel != "medium" {
 		t.Fatalf("thinking level = %q, want base config", updated.ActiveSettings.ThinkingLevel)
 	}
@@ -477,8 +477,8 @@ func TestApplyRunPromptOverridesResumedRoleMatrix(t *testing.T) {
 			wantAgentRole:    "worker",
 		},
 		{
-			name:             "default alias clears resumed role",
-			overrides:        serverapi.RunPromptOverrides{AgentRoleSet: true},
+			name:             "default clears resumed role",
+			overrides:        serverapi.RunPromptOverrides{AgentRole: config.DefaultSubagentRole},
 			wantModel:        "gpt-5.5",
 			wantThinking:     "medium",
 			wantPatchSetting: true,
@@ -1164,14 +1164,17 @@ func TestResolveSubagentSettingsRejectsRoleReviewerContextWindowBelowMinimum(t *
 func TestApplyRunPromptOverridesRejectsInvalidAgentRole(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	workspace := t.TempDir()
-	plan := newSettingsPlan(t, workspace, config.Settings{Model: "gpt-5.4"})
-
-	_, _, err := ApplyRunPromptOverrides(plan, serverapi.RunPromptOverrides{AgentRole: "fast!"}, auth.EmptyState())
-	if err == nil {
-		t.Fatal("expected invalid agent role to fail")
-	}
-	if !errors.Is(err, errInvalidAgentRole) {
-		t.Fatalf("unexpected error: %v", err)
+	for _, role := range []string{"fast!", "none", "self"} {
+		t.Run(role, func(t *testing.T) {
+			plan := newSettingsPlan(t, workspace, config.Settings{Model: "gpt-5.4"})
+			_, _, err := ApplyRunPromptOverrides(plan, serverapi.RunPromptOverrides{AgentRole: role}, auth.EmptyState())
+			if err == nil {
+				t.Fatal("expected invalid agent role to fail")
+			}
+			if !errors.Is(err, errInvalidAgentRole) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }
 

--- a/server/runprompt/prompt_service.go
+++ b/server/runprompt/prompt_service.go
@@ -63,6 +63,9 @@ func (s *PromptService) RunPrompt(ctx context.Context, req serverapi.RunPromptRe
 	if req.Prompt == "" {
 		return serverapi.RunPromptResponse{}, ErrPromptRequired
 	}
+	if err := req.Overrides.ValidateAgentRoleOverride(); err != nil {
+		return serverapi.RunPromptResponse{}, err
+	}
 
 	runtimeHandle, err := s.launcher.PrepareHeadlessPrompt(ctx, req, progress)
 	if err != nil {

--- a/server/runprompt/prompt_service_test.go
+++ b/server/runprompt/prompt_service_test.go
@@ -29,6 +29,27 @@ func TestPromptServiceRejectsMissingClientRequestID(t *testing.T) {
 	}
 }
 
+func TestPromptServiceRejectsInvalidAgentRoleBeforePreparingLauncher(t *testing.T) {
+	launcher := &stubHeadlessPromptLauncher{}
+	service := NewPromptService(launcher)
+
+	for _, role := range []string{"none", "self"} {
+		t.Run(role, func(t *testing.T) {
+			_, err := service.RunPrompt(context.Background(), serverapi.RunPromptRequest{
+				ClientRequestID: "req-1",
+				Prompt:          "hello",
+				Overrides:       serverapi.RunPromptOverrides{AgentRole: role},
+			}, nil)
+			if err == nil {
+				t.Fatal("expected invalid agent role error")
+			}
+			if launcher.lastRequest.ClientRequestID != "" {
+				t.Fatal("launcher should not be prepared for invalid role overrides")
+			}
+		})
+	}
+}
+
 func TestPromptServiceRunsPromptThroughPreparedRuntime(t *testing.T) {
 	launcher := &stubHeadlessPromptLauncher{
 		runtime: &stubPromptSessionRuntime{

--- a/server/sessionlaunch/service.go
+++ b/server/sessionlaunch/service.go
@@ -90,7 +90,7 @@ func (s *Service) PlanLaunchSession(ctx context.Context, req serverapi.SessionPl
 			SelectedSessionID:                   req.SelectedSessionID,
 			ForceNewSession:                     req.ForceNewSession,
 			ParentSessionID:                     req.ParentSessionID,
-			SkipContinuationAgentRoleValidation: req.Overrides.HasAny(),
+			SkipContinuationAgentRoleValidation: req.Overrides.HasAgentRoleOverride(),
 		})
 		if err != nil {
 			return PlanResult{}, err

--- a/server/sessionlaunch/service_test.go
+++ b/server/sessionlaunch/service_test.go
@@ -281,7 +281,7 @@ func TestServicePlanSessionDefaultRoleClearDoesNotRequireAuthState(t *testing.T)
 		ClientRequestID: "req-1",
 		Mode:            serverapi.SessionLaunchModeInteractive,
 		ForceNewSession: true,
-		Overrides:       serverapi.RunPromptOverrides{AgentRoleSet: true},
+		Overrides:       serverapi.RunPromptOverrides{AgentRole: config.DefaultSubagentRole},
 	}); err != nil {
 		t.Fatalf("PlanSession with default role clear should not read auth state: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestServicePlanSessionCanClearInvalidPersistedRoleBeforeValidation(t *testi
 		ClientRequestID:   "req-1",
 		Mode:              serverapi.SessionLaunchModeInteractive,
 		SelectedSessionID: store.Meta().SessionID,
-		Overrides:         serverapi.RunPromptOverrides{AgentRoleSet: true},
+		Overrides:         serverapi.RunPromptOverrides{AgentRole: config.DefaultSubagentRole},
 	})
 	if err != nil {
 		t.Fatalf("PlanSession: %v", err)
@@ -332,5 +332,91 @@ func TestServicePlanSessionCanClearInvalidPersistedRoleBeforeValidation(t *testi
 	}
 	if got := reopened.Meta().Continuation; got != nil && got.AgentRole != "" {
 		t.Fatalf("continuation = %+v, want cleared agent role", got)
+	}
+}
+
+func TestServicePlanSessionConfigOnlyOverrideDoesNotSkipInvalidPersistedRoleValidation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	workspace := t.TempDir()
+	persistenceRoot := t.TempDir()
+	containerDir := t.TempDir()
+	store, err := session.Create(containerDir, "workspace-a", workspace)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.SetContinuationContext(session.ContinuationContext{AgentRole: "worker"}); err != nil {
+		t.Fatalf("SetContinuationContext: %v", err)
+	}
+	cfg := loadSessionLaunchTestConfig(t, workspace, persistenceRoot)
+	roleSettings := cfg.Settings
+	roleSettings.Model = "gpt-5.3-codex-spark"
+	roleSettings.ContextCompactionThresholdTokens = 200_000
+	cfg.Settings.Subagents = map[string]config.SubagentRole{
+		"worker": {
+			Settings: roleSettings,
+			Sources:  map[string]string{"model": "file", "context_compaction_threshold_tokens": "file"},
+		},
+	}
+	service := NewService(launch.Planner{
+		Config:       cfg,
+		ContainerDir: containerDir,
+	}, registry.NewSessionStoreRegistry())
+
+	_, err = service.PlanSession(context.Background(), serverapi.SessionPlanRequest{
+		ClientRequestID:   "req-1",
+		Mode:              serverapi.SessionLaunchModeInteractive,
+		SelectedSessionID: store.Meta().SessionID,
+		Overrides:         serverapi.RunPromptOverrides{Model: "gpt-5.5"},
+	})
+	if err == nil {
+		t.Fatal("expected invalid persisted role validation to fail")
+	}
+	if errors.Is(err, serverapi.ErrInvalidRunPromptAgentRole) {
+		t.Fatalf("error = %v, want persisted role validation error", err)
+	}
+}
+
+func TestServicePlanSessionInvalidRoleOverridePrecedesPersistedRoleValidation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	workspace := t.TempDir()
+	persistenceRoot := t.TempDir()
+	containerDir := t.TempDir()
+	store, err := session.Create(containerDir, "workspace-a", workspace)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.SetContinuationContext(session.ContinuationContext{AgentRole: "worker"}); err != nil {
+		t.Fatalf("SetContinuationContext: %v", err)
+	}
+	cfg := loadSessionLaunchTestConfig(t, workspace, persistenceRoot)
+	roleSettings := cfg.Settings
+	roleSettings.Model = "gpt-5.3-codex-spark"
+	roleSettings.ContextCompactionThresholdTokens = 200_000
+	cfg.Settings.Subagents = map[string]config.SubagentRole{
+		"worker": {
+			Settings: roleSettings,
+			Sources:  map[string]string{"model": "file", "context_compaction_threshold_tokens": "file"},
+		},
+	}
+	service := NewService(launch.Planner{
+		Config:       cfg,
+		ContainerDir: containerDir,
+	}, registry.NewSessionStoreRegistry())
+
+	for _, role := range []string{"none", "self"} {
+		t.Run(role, func(t *testing.T) {
+			_, err := service.PlanSession(context.Background(), serverapi.SessionPlanRequest{
+				ClientRequestID:   "req-" + role,
+				Mode:              serverapi.SessionLaunchModeInteractive,
+				SelectedSessionID: store.Meta().SessionID,
+				Overrides:         serverapi.RunPromptOverrides{AgentRole: role},
+			})
+			if err == nil {
+				t.Fatal("expected invalid role override to fail")
+			}
+			if !errors.Is(err, serverapi.ErrInvalidRunPromptAgentRole) {
+				t.Fatalf("error = %v, want malformed role error before persisted role validation", err)
+			}
+		})
 	}
 }

--- a/server/workflow/types.go
+++ b/server/workflow/types.go
@@ -1,6 +1,10 @@
 package workflow
 
-import "strings"
+import (
+	"strings"
+
+	"core/shared/config"
+)
 
 type WorkflowID string
 type NodeID string
@@ -176,7 +180,7 @@ type RoleResolver interface {
 	RoleExists(role string) bool
 }
 
-const DefaultAgentRole = "default"
+const DefaultAgentRole = config.DefaultSubagentRole
 
 func IsDefaultAgentRole(role string) bool {
 	return strings.TrimSpace(role) == DefaultAgentRole

--- a/server/workflowrunner/starter.go
+++ b/server/workflowrunner/starter.go
@@ -610,7 +610,7 @@ func toolIDEnabled(enabled []toolspec.ID, want toolspec.ID) bool {
 
 func workflowRunPromptOverrides(role string) serverapi.RunPromptOverrides {
 	if workflow.IsDefaultAgentRole(role) {
-		return serverapi.RunPromptOverrides{AgentRoleSet: true}
+		return serverapi.RunPromptOverrides{AgentRole: workflow.DefaultAgentRole}
 	}
 	return serverapi.RunPromptOverrides{AgentRole: role}
 }

--- a/shared/config/subagents.go
+++ b/shared/config/subagents.go
@@ -8,12 +8,13 @@ import (
 )
 
 const BuiltInSubagentRoleFast = "fast"
+const DefaultSubagentRole = "default"
 const MaxSubagentDescriptionChars = 5000
 
 var reservedSubagentRoleNames = map[string]bool{
-	"default": true,
-	"none":    true,
-	"self":    true,
+	DefaultSubagentRole: true,
+	"none":              true,
+	"self":              true,
 }
 
 func NormalizeSubagentRole(raw string) string {

--- a/shared/protocol/version.json
+++ b/shared/protocol/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "15"
+  "version": "16"
 }

--- a/shared/serverapi/run_prompt.go
+++ b/shared/serverapi/run_prompt.go
@@ -1,6 +1,9 @@
 package serverapi
 
 import (
+	"errors"
+	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -16,9 +19,18 @@ type RunPromptRequest struct {
 	Overrides         RunPromptOverrides
 }
 
+func (r RunPromptRequest) Validate() error {
+	if strings.TrimSpace(r.ClientRequestID) == "" {
+		return errors.New("client_request_id is required")
+	}
+	if strings.TrimSpace(r.Prompt) == "" {
+		return errors.New("prompt is required")
+	}
+	return r.Overrides.ValidateAgentRoleOverride()
+}
+
 type RunPromptOverrides struct {
 	AgentRole           string
-	AgentRoleSet        bool
 	Model               string
 	ProviderOverride    string
 	ThinkingLevel       string
@@ -28,9 +40,44 @@ type RunPromptOverrides struct {
 	OpenAIBaseURL       string
 }
 
+var ErrInvalidRunPromptAgentRole = errors.New("invalid agent role")
+
+type RunPromptAgentRoleOverride struct {
+	Present bool
+	Default bool
+	Role    string
+}
+
+func (o RunPromptOverrides) AgentRoleOverride() (RunPromptAgentRoleOverride, error) {
+	raw := strings.TrimSpace(o.AgentRole)
+	if raw == "" {
+		return RunPromptAgentRoleOverride{}, nil
+	}
+	normalized := strings.ToLower(raw)
+	if normalized == config.DefaultSubagentRole {
+		return RunPromptAgentRoleOverride{Present: true, Default: true}, nil
+	}
+	if config.IsReservedSubagentRoleName(normalized) {
+		return RunPromptAgentRoleOverride{}, fmt.Errorf("%w %s", ErrInvalidRunPromptAgentRole, strconv.Quote(raw))
+	}
+	roleName := config.NormalizeSubagentSelector(raw)
+	if roleName == "" {
+		return RunPromptAgentRoleOverride{}, fmt.Errorf("%w %s", ErrInvalidRunPromptAgentRole, strconv.Quote(raw))
+	}
+	return RunPromptAgentRoleOverride{Present: true, Role: roleName}, nil
+}
+
+func (o RunPromptOverrides) ValidateAgentRoleOverride() error {
+	_, err := o.AgentRoleOverride()
+	return err
+}
+
+func (o RunPromptOverrides) HasAgentRoleOverride() bool {
+	return strings.TrimSpace(o.AgentRole) != ""
+}
+
 func (o RunPromptOverrides) HasAny() bool {
-	return o.AgentRoleSet ||
-		strings.TrimSpace(o.AgentRole) != "" ||
+	return strings.TrimSpace(o.AgentRole) != "" ||
 		strings.TrimSpace(o.Model) != "" ||
 		strings.TrimSpace(o.ProviderOverride) != "" ||
 		strings.TrimSpace(o.ThinkingLevel) != "" ||
@@ -51,7 +98,8 @@ func (o RunPromptOverrides) HasConfigOverrides() bool {
 }
 
 func (o RunPromptOverrides) NeedsAuthState() bool {
-	return config.NormalizeSubagentSelector(o.AgentRole) != ""
+	role, err := o.AgentRoleOverride()
+	return err == nil && role.Present && !role.Default
 }
 
 type RunPromptResponse struct {

--- a/shared/serverapi/run_prompt_test.go
+++ b/shared/serverapi/run_prompt_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 )
 
-func TestRunPromptOverridesAgentRoleSetJSONRoundTrip(t *testing.T) {
+func TestRunPromptOverridesAgentRoleJSONRoundTrip(t *testing.T) {
 	req := SessionPlanRequest{
 		ClientRequestID: "req-1",
 		Mode:            SessionLaunchModeHeadless,
 		ForceNewSession: true,
 		Overrides: RunPromptOverrides{
-			AgentRoleSet: true,
+			AgentRole: "default",
 		},
 	}
 	data, err := json.Marshal(req)
@@ -22,11 +22,11 @@ func TestRunPromptOverridesAgentRoleSetJSONRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if !got.Overrides.AgentRoleSet {
-		t.Fatalf("AgentRoleSet = false after round trip: %s", data)
+	if got.Overrides.AgentRole != "default" {
+		t.Fatalf("AgentRole = %q, want default after round trip: %s", got.Overrides.AgentRole, data)
 	}
-	if !got.Overrides.HasAny() {
-		t.Fatal("default-role override presence should count as an override")
+	if !got.Overrides.HasAgentRoleOverride() {
+		t.Fatal("default role should count as a role override")
 	}
 }
 
@@ -50,18 +50,66 @@ func TestRunPromptRequestParentSessionIDJSONRoundTrip(t *testing.T) {
 	}
 }
 
-func TestRunPromptOverridesAgentRoleCompatJSON(t *testing.T) {
+func TestRunPromptOverridesAgentRoleContract(t *testing.T) {
 	var got SessionPlanRequest
 	if err := json.Unmarshal([]byte(`{"ClientRequestID":"req-1","Mode":"headless","ForceNewSession":true,"Overrides":{"AgentRole":"worker"}}`), &got); err != nil {
-		t.Fatalf("Unmarshal legacy request: %v", err)
+		t.Fatalf("Unmarshal request: %v", err)
 	}
 	if got.Overrides.AgentRole != "worker" {
 		t.Fatalf("AgentRole = %q, want worker", got.Overrides.AgentRole)
 	}
-	if got.Overrides.AgentRoleSet {
-		t.Fatal("legacy JSON without AgentRoleSet should leave AgentRoleSet false")
-	}
 	if !got.Overrides.HasAny() {
-		t.Fatal("legacy AgentRole should still count as an override")
+		t.Fatal("AgentRole should count as an override")
+	}
+	if !got.Overrides.HasAgentRoleOverride() {
+		t.Fatal("AgentRole should count as a role override")
+	}
+}
+
+func TestRunPromptOverridesRolePresenceAndAuth(t *testing.T) {
+	tests := []struct {
+		name         string
+		overrides    RunPromptOverrides
+		wantAny      bool
+		wantRole     bool
+		wantAuth     bool
+		wantDefault  bool
+		wantRoleName string
+	}{
+		{name: "empty", overrides: RunPromptOverrides{}, wantAny: false, wantRole: false},
+		{name: "empty role", overrides: RunPromptOverrides{AgentRole: " "}, wantAny: false, wantRole: false},
+		{name: "config only", overrides: RunPromptOverrides{Model: "gpt-5.5"}, wantAny: true, wantRole: false},
+		{name: "default", overrides: RunPromptOverrides{AgentRole: "default"}, wantAny: true, wantRole: true, wantAuth: false, wantDefault: true},
+		{name: "named", overrides: RunPromptOverrides{AgentRole: " Worker "}, wantAny: true, wantRole: true, wantAuth: true, wantRoleName: "worker"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.overrides.HasAny(); got != tt.wantAny {
+				t.Fatalf("HasAny = %t, want %t", got, tt.wantAny)
+			}
+			if got := tt.overrides.HasAgentRoleOverride(); got != tt.wantRole {
+				t.Fatalf("HasAgentRoleOverride = %t, want %t", got, tt.wantRole)
+			}
+			if got := tt.overrides.NeedsAuthState(); got != tt.wantAuth {
+				t.Fatalf("NeedsAuthState = %t, want %t", got, tt.wantAuth)
+			}
+			role, err := tt.overrides.AgentRoleOverride()
+			if err != nil {
+				t.Fatalf("AgentRoleOverride: %v", err)
+			}
+			if role.Default != tt.wantDefault || role.Role != tt.wantRoleName {
+				t.Fatalf("AgentRoleOverride = %+v, want default=%t role=%q", role, tt.wantDefault, tt.wantRoleName)
+			}
+		})
+	}
+}
+
+func TestRunPromptOverridesRejectReservedNonDefaultRoles(t *testing.T) {
+	for _, role := range []string{"none", "self"} {
+		t.Run(role, func(t *testing.T) {
+			if err := (RunPromptOverrides{AgentRole: role}).ValidateAgentRoleOverride(); err == nil {
+				t.Fatal("expected reserved non-default role to be invalid")
+			}
+		})
 	}
 }

--- a/shared/serverapi/session_launch.go
+++ b/shared/serverapi/session_launch.go
@@ -54,5 +54,5 @@ func (r SessionPlanRequest) Validate() error {
 	if strings.TrimSpace(r.SelectedSessionID) == "" && !r.ForceNewSession {
 		return errors.New("selected_session_id or force_new_session is required")
 	}
-	return nil
+	return r.Overrides.ValidateAgentRoleOverride()
 }


### PR DESCRIPTION
## Summary
- Remove `RunPromptOverrides.AgentRoleSet` and use the retained `AgentRole` wire key as the single role override contract.
- Add `default` as the explicit base/default role reset selector, reject removed `none`/`self` run-agent aliases, and reject explicit blank `--agent` values.
- Bump the protocol version for the breaking wire change and update CLI/app/workflow/server validation, launch planning, help, and headless docs.

## Verification
- `rg "AgentRoleSet|legacy JSON without AgentRoleSet|RunPromptOverridesAgentRoleCompatJSON" shared server cli --glob "*.go"` returned no matches.
- `rg 'json:"agent_role"|"agent_role"' shared/serverapi cli server --glob "*.go"` returned no matches.
- `./scripts/test.sh ./shared/protocol/... ./server/transport/... ./cli/app/internal/serverattach/...`
- `./scripts/test.sh ./shared/serverapi/... ./server/launch/... ./server/sessionlaunch/... ./cli/kent/... ./cli/app/...`
- `./scripts/test.sh ./server/runprompt/... ./server/workflowrunner/... ./server/workflow/... ./shared/config/...`
- `./scripts/build.sh --output ./bin/kent`
- Code review subagent reported no findings after the explicit blank `--agent` fix.

Additional QA from the implementation pass:
- `./bin/kent run --help` showed `--agent default` as base/default reset and `none`/`self` as invalid.
- `docs/src/content/docs/headless.md` readback showed `--agent` documents `default` and `--fast` documents the built-in fast shortcut.
- Manual CLI probes verified `--agent none` and `--agent self` exit 2, `--agent default` passes selector validation, and `--fast --agent default` exits 2 with a conflict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `kent run --agent default` now clearly resets to the base/default role when resuming a session.
  * Help text and docs now explain supported agent selectors and call out invalid values.

* **Bug Fixes**
  * Invalid agent selectors like `none`, `self`, and blank values are now rejected earlier with clearer errors.
  * Agent-role handling now behaves consistently across run, continue, and headless prompt flows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->