### PR TITLE
feat: package Windows desktop releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,8 +352,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      # Every platform's staged bundles merge into one dist dir so assemble sees all
-      # updater .sig files and emits a single latest.json covering every platform.
+      # Both platforms' staged bundles merge into one dist dir so assemble sees all
+      # updater .sig files and emits a single latest.json covering both platforms.
       - name: Download macOS desktop artifacts
         uses: actions/download-artifact@v8.0.1
         with:
@@ -364,12 +364,6 @@ jobs:
         uses: actions/download-artifact@v8.0.1
         with:
           name: desktop-assets-linux-${{ needs.prepare_release.outputs.tag }}
-          path: dist/desktop
-
-      - name: Download Windows desktop artifacts
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: desktop-assets-windows-${{ needs.prepare_release.outputs.tag }}
           path: dist/desktop
 
       - name: Assemble updater manifest + checksums

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,8 +352,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      # Both platforms' staged bundles merge into one dist dir so assemble sees all
-      # updater .sig files and emits a single latest.json covering both platforms.
+      # Every platform's staged bundles merge into one dist dir so assemble sees all
+      # updater .sig files and emits a single latest.json covering every platform.
       - name: Download macOS desktop artifacts
         uses: actions/download-artifact@v8.0.1
         with:
@@ -364,6 +364,12 @@ jobs:
         uses: actions/download-artifact@v8.0.1
         with:
           name: desktop-assets-linux-${{ needs.prepare_release.outputs.tag }}
+          path: dist/desktop
+
+      - name: Download Windows desktop artifacts
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: desktop-assets-windows-${{ needs.prepare_release.outputs.tag }}
           path: dist/desktop
 
       - name: Assemble updater manifest + checksums

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,12 @@ jobs:
             platform: macos
           - runs_on: ubuntu-22.04
             platform: linux
+          - runs_on: windows-latest
+            platform: windows
     runs-on: ${{ matrix.runs_on }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v6.0.2
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -44,7 +44,7 @@
   "bundle": {
     "active": true,
     "createUpdaterArtifacts": true,
-    "targets": ["app", "dmg", "appimage", "deb"],
+    "targets": ["app", "dmg", "appimage", "deb", "nsis"],
     "category": "DeveloperTool",
     "shortDescription": "Desktop client for Kent, an agentic coding platform for professional SWE work.",
     "longDescription": "Kent Desktop is the GUI client for Kent — an agentic coding platform for professional software engineering focused on output quality, with self-review, supervision, and dynamic workflows. It remote-controls a running Kent server (boards, task detail, and the workflow editor) over loopback; install and start the Kent CLI/service first.",

--- a/apps/desktop/src/features/board/BoardCardMotionAnimator.ts
+++ b/apps/desktop/src/features/board/BoardCardMotionAnimator.ts
@@ -1,0 +1,158 @@
+import type { RefObject } from "react";
+
+import type { PendingBoardCardMove } from "./BoardCardMotionModel";
+
+export type BoardCardMotionTransitionOptions = Readonly<{
+  cardElementsRef: RefObject<ReadonlyMap<string, HTMLElement>>;
+  columnElementsRef: RefObject<ReadonlyMap<string, HTMLElement>>;
+  namesByCardID: ReadonlyMap<string, string>;
+  pendingCardMove: PendingBoardCardMove | null;
+  update: () => void;
+}>;
+
+type BoardCardMotionSnapshot = Readonly<{
+  clone: HTMLElement;
+  rect: DOMRectReadOnly;
+}>;
+
+export async function runBoardCardMotionTransition(options: BoardCardMotionTransitionOptions): Promise<void> {
+  if (prefersReducedMotion() || options.namesByCardID.size === 0) {
+    options.update();
+    return;
+  }
+  const oldSnapshots = snapshotBoardCardElements(options.cardElementsRef.current, options.namesByCardID);
+  options.update();
+  const animations = Array.from(options.namesByCardID.keys()).flatMap((cardID) => {
+    const oldSnapshot = oldSnapshots.get(cardID);
+    if (oldSnapshot === undefined) {
+      return [];
+    }
+    const newElement = options.cardElementsRef.current.get(cardID);
+    if (newElement !== undefined) {
+      return [
+        animateMovedBoardCard(newElement, oldSnapshot.rect).finally(() => {
+          oldSnapshot.clone.remove();
+        }),
+      ];
+    }
+    const targetRect =
+      options.pendingCardMove?.taskID === cardID
+        ? options.columnElementsRef.current.get(options.pendingCardMove.targetColumnID)?.getBoundingClientRect()
+        : undefined;
+    return [animateDepartingBoardCard(oldSnapshot, targetRect)];
+  });
+  await Promise.allSettled(animations);
+}
+
+function snapshotBoardCardElements(
+  cardElements: ReadonlyMap<string, HTMLElement>,
+  namesByCardID: ReadonlyMap<string, string>,
+): ReadonlyMap<string, BoardCardMotionSnapshot> {
+  const snapshots = new Map<string, BoardCardMotionSnapshot>();
+  for (const cardID of namesByCardID.keys()) {
+    const element = cardElements.get(cardID);
+    if (element === undefined) {
+      continue;
+    }
+    const rect = element.getBoundingClientRect();
+    snapshots.set(cardID, { clone: cloneBoardCardForMotion(element, rect), rect });
+  }
+  return snapshots;
+}
+
+async function animateMovedBoardCard(element: HTMLElement, oldRect: DOMRectReadOnly): Promise<void> {
+  const newRect = element.getBoundingClientRect();
+  const deltaX = oldRect.left - newRect.left;
+  const deltaY = oldRect.top - newRect.top;
+  if (deltaX === 0 && deltaY === 0) {
+    return;
+  }
+  await animateElement(
+    element,
+    [
+      { transform: `translate(${deltaX.toString()}px, ${deltaY.toString()}px)` },
+      { transform: "translate(0, 0)" },
+    ],
+    boardCardMotionTiming(),
+  );
+}
+
+async function animateDepartingBoardCard(
+  snapshot: BoardCardMotionSnapshot,
+  targetRect: DOMRectReadOnly | undefined,
+): Promise<void> {
+  const clone = snapshot.clone;
+  document.body.append(clone);
+  const targetTransform =
+    targetRect === undefined ? "translateY(-8px) scale(0.98)" : boardCardDepartureTransform(snapshot.rect, targetRect);
+  try {
+    await animateElement(
+      clone,
+      [
+        { opacity: 1, transform: "translate(0, 0) scale(1)" },
+        { opacity: targetRect === undefined ? 0 : 0.72, transform: targetTransform },
+      ],
+      boardCardMotionTiming(),
+    );
+  } finally {
+    clone.remove();
+  }
+}
+
+async function animateElement(
+  element: HTMLElement,
+  keyframes: Keyframe[] | PropertyIndexedKeyframes,
+  options: KeyframeAnimationOptions,
+): Promise<void> {
+  if (typeof element.animate !== "function") {
+    return;
+  }
+  await element.animate(keyframes, options).finished;
+}
+
+function cloneBoardCardForMotion(element: HTMLElement, rect: DOMRectReadOnly): HTMLElement {
+  const clone = element.cloneNode(true);
+  if (!(clone instanceof HTMLElement)) {
+    throw new TypeError("Board card motion clone must be an HTMLElement");
+  }
+  clone.classList.add("board-card-motion-clone");
+  const style = clone.style;
+  style.left = `${rect.left.toString()}px`;
+  style.top = `${rect.top.toString()}px`;
+  style.width = `${rect.width.toString()}px`;
+  style.height = `${rect.height.toString()}px`;
+  return clone;
+}
+
+function boardCardDepartureTransform(cardRect: DOMRectReadOnly, targetRect: DOMRectReadOnly): string {
+  const targetLeft = targetRect.left + (targetRect.width - cardRect.width) / 2;
+  const targetTop = targetRect.top + Math.min(cardRect.height, targetRect.height * 0.18);
+  return `translate(${(targetLeft - cardRect.left).toString()}px, ${(targetTop - cardRect.top).toString()}px) scale(0.96)`;
+}
+
+function boardCardMotionTiming(): KeyframeAnimationOptions {
+  return {
+    duration: motionDurationMs("--motion-normal", 400),
+    easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+    fill: "both",
+  };
+}
+
+function motionDurationMs(tokenName: string, fallbackMs: number): number {
+  const tokenValue = getComputedStyle(document.documentElement).getPropertyValue(tokenName).trim();
+  const durationToken = tokenValue.split(" ").find((part) => part.length > 0) ?? "";
+  if (durationToken.endsWith("ms")) {
+    return Number.parseFloat(durationToken);
+  }
+  if (durationToken.endsWith("s")) {
+    return Number.parseFloat(durationToken) * 1000;
+  }
+  return fallbackMs;
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof globalThis.matchMedia === "function" &&
+    globalThis.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}

--- a/apps/desktop/src/features/board/BoardColumns.test.tsx
+++ b/apps/desktop/src/features/board/BoardColumns.test.tsx
@@ -331,6 +331,8 @@ describe("KanbanColumn", () => {
       statusKind: "backlog",
       manualMoveTargetNodeIDs: [],
     });
+    expect(dataTransfer.setDragImage).toHaveBeenCalledTimes(1);
+    expect(dataTransfer.setDragImage.mock.calls[0]?.[0]).toBeInstanceOf(HTMLElement);
     expect(onCardDragStart).toHaveBeenCalledTimes(1);
     expect(onCardClick).not.toHaveBeenCalled();
   });
@@ -373,6 +375,7 @@ class TestDataTransfer {
   readonly #values = new Map<string, string>();
   effectAllowed = "all";
   dropEffect = "none";
+  readonly setDragImage = vi.fn();
 
   get types(): readonly string[] {
     return [...this.#values.keys()];

--- a/apps/desktop/src/features/board/BoardColumns.tsx
+++ b/apps/desktop/src/features/board/BoardColumns.tsx
@@ -310,6 +310,7 @@ function TaskCard({
             event.dataTransfer.setData("text/plain", card.id);
             event.dataTransfer.setData(boardCardDragPayloadType, encodeBoardCardDragPayload(dragPayload));
             event.dataTransfer.effectAllowed = "move";
+            setBoardCardDragImage(event.currentTarget, event.dataTransfer);
             onDragStart(dragPayload);
           }}
           onKeyDown={(event) => {
@@ -380,6 +381,22 @@ function TaskCard({
       </ContextMenuContent>
     </ContextMenu>
   );
+}
+
+function setBoardCardDragImage(cardElement: HTMLElement, dataTransfer: DataTransfer): void {
+  const rect = cardElement.getBoundingClientRect();
+  const dragImage = cardElement.cloneNode(true);
+  if (!(dragImage instanceof HTMLElement)) {
+    return;
+  }
+  dragImage.classList.add("board-card-drag-image");
+  dragImage.style.width = `${rect.width.toString()}px`;
+  dragImage.style.height = `${rect.height.toString()}px`;
+  document.body.append(dragImage);
+  dataTransfer.setDragImage(dragImage, rect.width / 2, Math.min(24, rect.height / 2));
+  window.setTimeout(() => {
+    dragImage.remove();
+  }, 0);
 }
 
 function hasBoardCardDragData(dataTransfer: DataTransfer): boolean {

--- a/apps/desktop/src/features/board/BoardRailMotionController.test.tsx
+++ b/apps/desktop/src/features/board/BoardRailMotionController.test.tsx
@@ -7,16 +7,7 @@ import type { BoardCard, BoardColumn, WorkflowBoard, WorkflowPickerItem } from "
 import { appI18n, initializeI18n } from "../../i18n/setup";
 import type { PendingBoardCardMove } from "./BoardCardMotionModel";
 
-// ---- view-transition spy (jsdom has no startViewTransition; emulate immediate) ----
-const runViewTransitionMock = vi.fn(async (options: { scope: string; update: () => void | Promise<void> }) => {
-  await options.update();
-  const resolved = Promise.resolve();
-  return { mode: "immediate" as const, finished: resolved, updateCallbackDone: resolved };
-});
-vi.mock("../../app/viewTransitions", () => ({
-  runViewTransition: async (options: { scope: string; update: () => void | Promise<void> }) => runViewTransitionMock(options),
-  viewTransitionScopeClass: (scope: string) => `view-transition-${scope}`,
-}));
+const animateElementMock = vi.fn(() => ({ finished: Promise.resolve() }));
 
 // ---- controllable fake board-node-cards query ----
 type NodeSnapshot = Readonly<{ cards: readonly BoardCard[]; isFetching: boolean; isPending: boolean; hasData: boolean }>;
@@ -186,8 +177,8 @@ async function settleStaleTimer(): Promise<void> {
   });
 }
 
-function boardCardTransitionCalls(): number {
-  return runViewTransitionMock.mock.calls.filter((args) => args[0].scope === "board-card").length;
+function boardCardMotionCalls(): number {
+  return animateElementMock.mock.calls.length;
 }
 
 describe("BoardRailMotionController manual-drag animation", () => {
@@ -197,7 +188,11 @@ describe("BoardRailMotionController manual-drag animation", () => {
 
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    runViewTransitionMock.mockClear();
+    animateElementMock.mockClear();
+    Object.defineProperty(HTMLElement.prototype, "animate", {
+      configurable: true,
+      value: animateElementMock,
+    });
     nodeStore.clear();
     harnessState = { board: board(1, 0), pending: null };
   });
@@ -218,7 +213,7 @@ describe("BoardRailMotionController manual-drag animation", () => {
       </I18nextProvider>,
     );
     await flush();
-    runViewTransitionMock.mockClear();
+    animateElementMock.mockClear();
 
     // Drop happens: pending move is registered, backlog query refetches without the card.
     await act(async () => {
@@ -235,7 +230,7 @@ describe("BoardRailMotionController manual-drag animation", () => {
 
   it("server-driven move animates the card leaving the backlog (control)", async () => {
     await driveBacklogExit(null);
-    expect(boardCardTransitionCalls()).toBeGreaterThan(0);
+    expect(boardCardMotionCalls()).toBeGreaterThan(0);
   });
 
   it("manual drag animates the card leaving the backlog like a server-driven move", async () => {
@@ -243,6 +238,6 @@ describe("BoardRailMotionController manual-drag animation", () => {
     // Previously the stale-snapshot timer kept deferring while the destination
     // column was still empty, so a manual drag played no transition at all.
     await driveBacklogExit({ taskID: "task-1", targetColumnID: "recon" });
-    expect(boardCardTransitionCalls()).toBeGreaterThan(0);
+    expect(boardCardMotionCalls()).toBeGreaterThan(0);
   });
 });

--- a/apps/desktop/src/features/board/BoardRailMotionController.tsx
+++ b/apps/desktop/src/features/board/BoardRailMotionController.tsx
@@ -11,8 +11,8 @@ import {
 import { flushSync } from "react-dom";
 
 import type { BoardColumn, WorkflowBoard } from "../../api";
-import { runViewTransition } from "../../app/viewTransitions";
 import { chromeContentPaddingClassName } from "../../ui/chromePadding";
+import { runBoardCardMotionTransition } from "./BoardCardMotionAnimator";
 import { BoardCardMotionContext, type BoardCardMotionContextValue } from "./BoardCardMotionContext";
 import { KanbanColumn, KanbanGroup } from "./BoardColumns";
 import {
@@ -134,6 +134,7 @@ export function BoardRailMotionController({
   const boardColumnCountsRef = useRef(boardColumnCounts);
   const visibleCardIDsRef = useRef<ReadonlySet<string>>(new Set());
   const cardElementsRef = useRef<ReadonlyMap<string, HTMLElement>>(new Map());
+  const columnElementsRef = useRef<ReadonlyMap<string, HTMLElement>>(new Map());
   const cardObserverRef = useRef<IntersectionObserver | null>(null);
   const phaseRef = useRef<BoardMotionPhase>("idle");
   const followUpPendingRef = useRef(false);
@@ -311,8 +312,11 @@ export function BoardRailMotionController({
         return;
       }
       phaseRef.current = "running";
-      void runViewTransition({
-        scope: "board-card",
+      void runBoardCardMotionTransition({
+        cardElementsRef,
+        columnElementsRef,
+        namesByCardID: armedTransition.namesByCardID,
+        pendingCardMove,
         update: () => {
           flushSync(() => {
             displayedColumnsRef.current = armedTransition.nextDisplayed;
@@ -325,31 +329,40 @@ export function BoardRailMotionController({
             setRevealCardIDs(armedTransition.revealCardIDs);
           });
         },
-      }).then((transition) => {
-        void transition.finished.finally(() => {
-          if (
-            armedTransition.attemptID !== attemptIDRef.current ||
-            armedTransition.layoutSignature !== layoutSignatureRef.current ||
-            armedTransition.runtimeGeneration !== runtimeGenerationRef.current
-          ) {
-            return;
-          }
-          phaseRef.current = "idle";
-          setArmedTransition(null);
-          setActiveNamesByCardID(new Map());
-          setHeldExpandedColumnIDs(new Set());
-          scheduleRevealClear(revealTimeoutsRef, armedTransition.revealCardIDs, setRevealCardIDs);
-          if (followUpPendingRef.current) {
-            followUpPendingRef.current = false;
-            scheduleNextTransition(false);
-          }
-        });
+      }).finally(() => {
+        if (
+          armedTransition.attemptID !== attemptIDRef.current ||
+          armedTransition.layoutSignature !== layoutSignatureRef.current ||
+          armedTransition.runtimeGeneration !== runtimeGenerationRef.current
+        ) {
+          return;
+        }
+        phaseRef.current = "idle";
+        setArmedTransition(null);
+        setActiveNamesByCardID(new Map());
+        setHeldExpandedColumnIDs(new Set());
+        scheduleRevealClear(revealTimeoutsRef, armedTransition.revealCardIDs, setRevealCardIDs);
+        if (followUpPendingRef.current) {
+          followUpPendingRef.current = false;
+          scheduleNextTransition(false);
+        }
       });
     });
-  }, [armedTransition, scheduleNextTransition]);
+  }, [armedTransition, pendingCardMove, scheduleNextTransition]);
 
   const registerCard = useCallback((cardID: string, element: HTMLElement | null) => {
     registerCardElement({ cardElementsRef, cardObserverRef, visibleCardIDsRef }, cardID, element);
+  }, []);
+
+  const registerColumn = useCallback((columnID: string, element: HTMLElement | null) => {
+    const current = columnElementsRef.current;
+    const next = new Map(current);
+    if (element === null) {
+      next.delete(columnID);
+    } else {
+      next.set(columnID, element);
+    }
+    columnElementsRef.current = next;
   }, []);
 
   const motionContext = useMemo<BoardCardMotionContextValue>(
@@ -404,6 +417,7 @@ export function BoardRailMotionController({
                   onInterruptedRunObserved={onInterruptedRunObserved}
                   onInterruptTask={onInterruptTask}
                   onReportColumnSnapshot={reportColumnSnapshot}
+                  onRegisterColumn={registerColumn}
                   onResumeTask={onResumeTask}
                   scrollportRef={scrollportRef}
                 />
@@ -430,6 +444,7 @@ export function BoardRailMotionController({
               onInterruptedRunObserved={onInterruptedRunObserved}
               onInterruptTask={onInterruptTask}
               onReportColumnSnapshot={reportColumnSnapshot}
+              onRegisterColumn={registerColumn}
               onResumeTask={onResumeTask}
               scrollportRef={scrollportRef}
             />
@@ -459,6 +474,7 @@ function BoardColumnMotionBoundary({
   onInterruptedRunObserved,
   onInterruptTask,
   onReportColumnSnapshot,
+  onRegisterColumn,
   onResumeTask,
   scrollportRef,
 }: Readonly<{
@@ -480,10 +496,18 @@ function BoardColumnMotionBoundary({
   onInterruptedRunObserved: (input: Readonly<{ runID: string; taskID: string }>) => void;
   onInterruptTask: (taskID: string, runID: string) => void;
   onReportColumnSnapshot: (columnID: string, snapshot: BoardColumnQuerySnapshot) => void;
+  onRegisterColumn: (columnID: string, element: HTMLElement | null) => void;
   onResumeTask: (taskID: string, runID: string) => void;
   scrollportRef: RefObject<HTMLDivElement | null>;
 }>) {
   const [columnElement, setColumnElement] = useState<HTMLElement | null>(null);
+  const setRegisteredColumnElement = useCallback(
+    (element: HTMLElement | null): void => {
+      setColumnElement(element);
+      onRegisterColumn(column.id, element);
+    },
+    [column.id, onRegisterColumn],
+  );
   const isVisible = useColumnVisibility(scrollportRef, columnElement);
   const queryEnabled = isVisible && !latestIsCollapsed;
   const cardsQuery = useBoardNodeCards(board.projectID, board.selectedWorkflow.id, column.id, queryEnabled);
@@ -524,7 +548,7 @@ function BoardColumnMotionBoundary({
       actionsDisabled={actionsDisabled}
       cards={renderedCards}
       column={columnVM}
-      columnRef={setColumnElement}
+      columnRef={setRegisteredColumnElement}
       dropState={dropState}
       hasMoreCards={cardsQuery.hasNextPage}
       isCollapsed={isCollapsed}

--- a/apps/desktop/src/features/board/board.css
+++ b/apps/desktop/src/features/board/board.css
@@ -15,6 +15,22 @@
   line-clamp: 3;
 }
 
+.board-card-drag-image {
+  position: fixed;
+  top: -10000px;
+  left: -10000px;
+  z-index: 2147483647;
+  pointer-events: none;
+  opacity: 0.94;
+}
+
+.board-card-motion-clone {
+  position: fixed;
+  z-index: 2147483647;
+  box-sizing: border-box;
+  pointer-events: none;
+}
+
 .board-horizontal-scrollbar {
   height: 16px;
   margin: 0;

--- a/apps/desktop/src/features/task-detail/TaskDetailDialog.test.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailDialog.test.tsx
@@ -147,6 +147,32 @@ describe("TaskDetailSurface", () => {
     });
   });
 
+  it("renders task description markdown with block typography", async () => {
+    window.history.pushState(null, "", "/tasks/task-1");
+    const services = createTestServices([
+      ...startupRoutes,
+      {
+        method: "workflow.task.get",
+        result: {
+          task: {
+            ...taskDetailNoInboxResponse.task,
+            body: "# Release plan\n\n- Restore bullets\n- Restore headings\n\nUse `kent`.",
+          },
+        },
+      },
+      { method: "workflow.task.comment.list", result: commentListResponse },
+      { method: "workflow.task.activity.list", result: activityResponse },
+    ]);
+
+    render(<App services={services} />);
+
+    const description = await screen.findByRole("textbox", { name: "Description" });
+    expect(within(description).getByTestId("markdown-text")).toHaveClass("markdown-text");
+    expect(within(description).getByRole("heading", { level: 1, name: "Release plan" })).toBeInTheDocument();
+    expect(within(description).getAllByRole("listitem")).toHaveLength(2);
+    expect(within(description).getByText("kent")).toBeInTheDocument();
+  });
+
   it("surfaces failed comment deletes through the status toast surface", async () => {
     window.history.pushState(null, "", "/tasks/task-1");
     const services = createTestServices([

--- a/apps/desktop/src/ui/MarkdownText.css
+++ b/apps/desktop/src/ui/MarkdownText.css
@@ -1,0 +1,114 @@
+.markdown-text {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-2);
+  color: inherit;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+
+.markdown-text-inline {
+  display: inline;
+}
+
+.markdown-text :where(h1, h2, h3, h4, h5, h6, p, blockquote, pre, ul, ol, table) {
+  margin: 0;
+}
+
+.markdown-text :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--color-on-island);
+  font-weight: 750;
+  line-height: 1.25;
+}
+
+.markdown-text h1 {
+  font-size: 1.35rem;
+}
+
+.markdown-text h2 {
+  font-size: 1.2rem;
+}
+
+.markdown-text h3 {
+  font-size: 1.08rem;
+}
+
+.markdown-text :where(h4, h5, h6) {
+  font-size: 1rem;
+}
+
+.markdown-text :where(ul, ol) {
+  display: grid;
+  gap: var(--space-1);
+  padding-inline-start: 1.4em;
+}
+
+.markdown-text ul {
+  list-style: disc;
+}
+
+.markdown-text ol {
+  list-style: decimal;
+}
+
+.markdown-text :where(ul ul, ul ol, ol ul, ol ol) {
+  margin-block-start: var(--space-1);
+}
+
+.markdown-text li {
+  padding-inline-start: var(--space-1);
+}
+
+.markdown-text blockquote {
+  border-inline-start: 3px solid var(--color-outline);
+  color: var(--color-muted);
+  padding-inline-start: var(--space-3);
+}
+
+.markdown-text a {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+}
+
+.markdown-text code {
+  border: 1px solid var(--color-outline);
+  border-radius: var(--radius-s);
+  background: var(--color-island-2);
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  padding: 0.05em 0.32em;
+}
+
+.markdown-text pre {
+  overflow: auto;
+  border: 1px solid var(--color-outline);
+  border-radius: var(--radius-m);
+  background: var(--color-island-1);
+  padding: var(--space-3);
+}
+
+.markdown-text pre code {
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.markdown-text table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.94em;
+}
+
+.markdown-text :where(th, td) {
+  border: 1px solid var(--color-outline);
+  padding: var(--space-2);
+  text-align: start;
+  vertical-align: top;
+}
+
+.markdown-text th {
+  background: var(--color-island-2);
+  font-weight: 700;
+}

--- a/apps/desktop/src/ui/MarkdownText.test.tsx
+++ b/apps/desktop/src/ui/MarkdownText.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, within } from "@testing-library/react";
+
+import { MarkdownText } from "./MarkdownText";
+
+describe("MarkdownText", () => {
+  it("renders block markdown inside the app typography scope", () => {
+    render(
+      <MarkdownText
+        value={"# Heading\n\n- First\n- Second\n\n> Quoted\n\n| Key | Value |\n| --- | --- |\n| A | B |"}
+      />,
+    );
+
+    const markdown = screen.getByTestId("markdown-text");
+    expect(markdown).toHaveClass("markdown-text");
+    expect(within(markdown).getByRole("heading", { level: 1, name: "Heading" })).toBeInTheDocument();
+    expect(within(markdown).getAllByRole("listitem")).toHaveLength(2);
+    expect(within(markdown).getByRole("table")).toBeInTheDocument();
+    expect(within(markdown).getByText("Quoted")).toBeInTheDocument();
+  });
+
+  it("keeps inline markdown inline", () => {
+    render(
+      <p>
+        Prefix <MarkdownText inline value={"**strong** and `code`"} />
+      </p>,
+    );
+
+    const markdown = screen.getByTestId("markdown-text-inline");
+    expect(markdown).toHaveClass("markdown-text-inline");
+    expect(screen.getByText("strong")).toBeInTheDocument();
+    expect(screen.getByText("code")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/ui/MarkdownText.tsx
+++ b/apps/desktop/src/ui/MarkdownText.tsx
@@ -4,6 +4,7 @@ import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 
 import { safeExternalUrl } from "./externalLinks";
+import "./MarkdownText.css";
 
 export type MarkdownTextProps = Readonly<{
   value: string;
@@ -12,7 +13,7 @@ export type MarkdownTextProps = Readonly<{
 }>;
 
 export function MarkdownText({ value, onOpenLink, inline = false }: MarkdownTextProps) {
-  return (
+  const rendered = (
     <ReactMarkdown
       components={markdownComponents(onOpenLink, inline)}
       rehypePlugins={[rehypeSanitize]}
@@ -21,6 +22,14 @@ export function MarkdownText({ value, onOpenLink, inline = false }: MarkdownText
     >
       {value}
     </ReactMarkdown>
+  );
+  if (inline) {
+    return <span className="markdown-text markdown-text-inline" data-testid="markdown-text-inline">{rendered}</span>;
+  }
+  return (
+    <div className="markdown-text" data-testid="markdown-text">
+      {rendered}
+    </div>
   );
 }
 

--- a/cli/app/internal/nativescrollback/assistant_stream.go
+++ b/cli/app/internal/nativescrollback/assistant_stream.go
@@ -113,6 +113,13 @@ func (l *Ledger) ResetAssistantStream() {
 	l.assistant = assistantStreamLedger{}
 }
 
+func (l *Ledger) ResetAssistantStreamRenderingState() {
+	if l == nil {
+		return
+	}
+	l.assistant.resetRenderingState()
+}
+
 func (l *Ledger) SetAssistantStreamStepID(stepID string) {
 	if l == nil {
 		return
@@ -224,6 +231,30 @@ func (s *assistantStreamLedger) setStepID(stepID string) {
 	s.commitRangeSet = false
 	s.commitStartEntryCount = 0
 	s.commitEndEntryCount = 0
+}
+
+func (s *assistantStreamLedger) resetRenderingState() {
+	source := s.source
+	theme := s.theme
+	width := s.width
+	stepID := s.stepID
+	commitRangeSet := s.commitRangeSet
+	commitStartEntryCount := s.commitStartEntryCount
+	commitEndEntryCount := s.commitEndEntryCount
+	rendered := []tui.TranscriptProjectionLine(nil)
+	if strings.TrimSpace(source) != "" {
+		rendered = tui.RenderAssistantMarkdownProjection(source, theme, width)
+	}
+	*s = assistantStreamLedger{
+		theme:                 theme,
+		width:                 width,
+		source:                source,
+		rendered:              rendered,
+		stepID:                stepID,
+		commitRangeSet:        commitRangeSet,
+		commitStartEntryCount: commitStartEntryCount,
+		commitEndEntryCount:   commitEndEntryCount,
+	}
 }
 
 func (s *assistantStreamLedger) observeCommitCandidate(candidate AssistantCommitCandidate) (AssistantCommitBinding, bool) {

--- a/cli/app/internal/nativescrollback/ledger_test.go
+++ b/cli/app/internal/nativescrollback/ledger_test.go
@@ -327,6 +327,45 @@ func TestLedgerRenderedProjectionCommitWaitsForTerminalAckCheckpoint(t *testing.
 	}
 }
 
+func TestLedgerRenderedProjectionCommitPreservesPendingStreamingReset(t *testing.T) {
+	var ledger Ledger
+	firstProjection := testProjection("final assistant")
+	secondProjection := testProjection("resized final assistant")
+	firstFlush, ok := ledger.Enqueue("final assistant", FlushOptions{})
+	if !ok {
+		t.Fatal("expected first flush")
+	}
+	if _, ready, err := ledger.AcceptFlush(firstFlush); err != nil || !ready {
+		t.Fatalf("accept first flush ready=%v err=%v", ready, err)
+	}
+	ledger.ScheduleRenderedProjectionCommit(firstProjection, 0, true)
+
+	secondFlush, ok := ledger.Enqueue("resized final assistant", FlushOptions{})
+	if !ok {
+		t.Fatal("expected second flush")
+	}
+	ledger.ScheduleRenderedProjectionCommit(secondProjection, 0, false)
+	if !ledger.RenderedProjectionCommitPendingResetStreaming() {
+		t.Fatal("replacement projection commit dropped pending streaming reset")
+	}
+	if _, err := ledger.Ack(TerminalWriteResult{Sequence: firstFlush.Sequence}); err != nil {
+		t.Fatalf("ack first flush: %v", err)
+	}
+	if update, applied := ledger.ApplyRenderedProjectionCommitIfReady(); applied {
+		t.Fatalf("commit applied before replacement flush ack: %+v", update)
+	}
+	if _, ready, err := ledger.AcceptFlush(secondFlush); err != nil || !ready {
+		t.Fatalf("accept second flush ready=%v err=%v", ready, err)
+	}
+	if _, err := ledger.Ack(TerminalWriteResult{Sequence: secondFlush.Sequence}); err != nil {
+		t.Fatalf("ack second flush: %v", err)
+	}
+	update, applied := ledger.ApplyRenderedProjectionCommitIfReady()
+	if !applied || !update.ResetStreaming {
+		t.Fatalf("replacement commit update = %+v applied=%v, want preserved streaming reset", update, applied)
+	}
+}
+
 func TestLedgerProjectionSnapshotsAreCloned(t *testing.T) {
 	var ledger Ledger
 	projection := testProjection("original")

--- a/cli/app/internal/nativescrollback/projection.go
+++ b/cli/app/internal/nativescrollback/projection.go
@@ -129,6 +129,9 @@ func (l *Ledger) ScheduleRenderedProjectionCommit(projection tui.TranscriptProje
 	if l == nil {
 		return
 	}
+	if l.projection.renderedCommit.pending && l.projection.renderedCommit.resetStreaming {
+		resetStreaming = true
+	}
 	l.projection.renderedCommit = renderedProjectionCommit{
 		pending:        true,
 		checkpoint:     l.Checkpoint(),
@@ -156,4 +159,8 @@ func (l *Ledger) ApplyRenderedProjectionCommitIfReady() (RenderedProjectionCommi
 
 func (l *Ledger) RenderedProjectionCommitPending() bool {
 	return l != nil && l.projection.renderedCommit.pending
+}
+
+func (l *Ledger) RenderedProjectionCommitPendingResetStreaming() bool {
+	return l != nil && l.projection.renderedCommit.pending && l.projection.renderedCommit.resetStreaming
 }

--- a/cli/app/ui_committed_suffix_delivery.go
+++ b/cli/app/ui_committed_suffix_delivery.go
@@ -12,8 +12,14 @@ func shouldDeliverCommittedRuntimeEventFromSuffix(m *uiModel, evt clientui.Event
 	if m == nil || !evt.CommittedTranscriptChanged || len(evt.TranscriptEntries) == 0 {
 		return false
 	}
+	if evt.Kind == clientui.EventLocalEntryAdded {
+		return false
+	}
 	state := newProjectedTranscriptEventState(projectedTranscriptEventSnapshotFromModel(m))
 	if evt.Kind == clientui.EventUserMessageFlushed {
+		return false
+	}
+	if committedRuntimeEventEntriesAreLocalFeedback(evt.TranscriptEntries) {
 		return false
 	}
 	if projectedEventIsLiveOnlyUnresolvedToolStart(state, evt) {
@@ -28,6 +34,36 @@ func shouldDeliverCommittedRuntimeEventFromSuffix(m *uiModel, evt clientui.Event
 		return false
 	}
 	return true
+}
+
+func committedRuntimeEventEntriesAreLocalFeedback(entries []clientui.ChatEntry) bool {
+	if len(entries) == 0 {
+		return false
+	}
+	for _, entry := range entries {
+		if !committedRuntimeEventEntryIsLocalFeedback(entry) {
+			return false
+		}
+	}
+	return true
+}
+
+func committedRuntimeEventEntryIsLocalFeedback(entry clientui.ChatEntry) bool {
+	switch tui.TranscriptRoleFromWire(entry.Role) {
+	case tui.TranscriptRoleSystem,
+		tui.TranscriptRoleReviewerStatus,
+		tui.TranscriptRoleReviewerSuggestions,
+		tui.TranscriptRoleWarning,
+		tui.TranscriptRoleCacheWarning,
+		tui.TranscriptRoleError,
+		tui.TranscriptRoleDeveloperFeedback,
+		tui.TranscriptRoleDeveloperErrorFeedback,
+		tui.TranscriptRoleInterruption,
+		tui.TranscriptRoleGoalFeedback:
+		return true
+	default:
+		return false
+	}
 }
 
 func committedTranscriptSuffixFromEvent(m *uiModel, evt clientui.Event) (clientui.CommittedTranscriptSuffix, bool) {

--- a/cli/app/ui_committed_suffix_delivery_test.go
+++ b/cli/app/ui_committed_suffix_delivery_test.go
@@ -44,3 +44,23 @@ func TestAuthoritativeRecentTailHydrateDeliveryUsesUnfilteredStablePrefix(t *tes
 		t.Fatalf("committed delivery state = %+v, want applied frontier at unfiltered stable prefix end", state)
 	}
 }
+
+func TestAuthoritativeRecentTailHydratePreservesAlreadyEmittedCursor(t *testing.T) {
+	m := newProjectedStaticUIModel()
+	setCommittedDeliveryForTest(m, 13, 6)
+	entries := []tui.TranscriptEntry{
+		{Role: "developer_context", Text: "environment info", Committed: true},
+		{Role: tui.TranscriptRoleCompactionSummary, Text: "summary", Committed: true},
+	}
+
+	m.runtimeAdapter().applyAuthoritativeRecentTailPage(clientui.TranscriptPage{
+		Offset:       11,
+		Revision:     7,
+		TotalEntries: 13,
+	}, entries, false)
+
+	state := committedDeliveryStateForTest(m)
+	if state.LastEmittedCommittedEntryCount != 13 || state.LastAppliedCommittedEntryCount != 13 {
+		t.Fatalf("committed delivery state = %+v, want already emitted active tail preserved", state)
+	}
+}

--- a/cli/app/ui_goal_test.go
+++ b/cli/app/ui_goal_test.go
@@ -3,9 +3,15 @@ package app
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"core/cli/tui"
+	"core/server/runtime"
+	"core/server/session"
+	"core/server/workflow"
+	"core/server/workflowruntime"
 	"core/shared/clientui"
+	"core/shared/toolspec"
 	"core/shared/transcript"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -198,6 +204,79 @@ func TestGoalSetRendersCommittedGoalFeedbackBeforeLaterRuntimeEvents(t *testing.
 	}
 	if view := stripANSIAndTrimRight(updated.view.OngoingSnapshot()); strings.Contains(view, "later model output") {
 		t.Fatalf("later runtime event rendered before explicit delivery: %q", view)
+	}
+}
+
+func TestGoalResumeSlashCommandViaRuntimeRouteRendersGoalFeedbackOnce(t *testing.T) {
+	runtimeEvents := make(chan clientui.Event, 16)
+	_, eng := newAppRuntimeEngine(t, statusLineFakeClient{}, runtime.Config{
+		WorkflowRun: &workflowruntime.Config{
+			Contract: workflowruntime.CompletionContract{RunID: workflow.RunID("run-1")},
+		},
+		EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion},
+		OnEvent: func(evt runtime.Event) {
+			runtimeEvents <- projectRuntimeEvent(evt)
+		},
+	})
+	t.Cleanup(func() { _ = eng.Close() })
+	if _, err := eng.SetGoal("ship native scrollback", session.GoalActorUser); err != nil {
+		t.Fatalf("SetGoal: %v", err)
+	}
+	if _, err := eng.SetGoalStatus(session.GoalStatusPaused, session.GoalActorUser); err != nil {
+		t.Fatalf("SetGoalStatus paused: %v", err)
+	}
+	drainRuntimeEvents(runtimeEvents)
+
+	m := newSizedProjectedRuntimeEventsUIModel(newUIRuntimeClient(eng), runtimeEvents, 120, 30)
+	m.input = "/goal resume"
+	updated := updateGoalForTest(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if goal := eng.Goal(); goal == nil || goal.Status != session.GoalStatusActive {
+		t.Fatalf("goal after /goal resume = %+v, want active", goal)
+	}
+
+	goalEvent := waitForGoalFeedbackEvent(t, runtimeEvents)
+	if shouldDeliverCommittedRuntimeEventFromSuffix(updated, goalEvent) {
+		t.Fatal("real /goal resume feedback event must not use async suffix delivery")
+	}
+
+	next, cmd := updated.Update(runtimeEventMsg{event: goalEvent})
+	updated = next.(*uiModel)
+	_ = collectCmdMessages(t, cmd)
+
+	view := stripANSIAndTrimRight(updated.view.OngoingSnapshot())
+	if got := strings.Count(view, "Goal resumed:"); got != 1 {
+		t.Fatalf("goal resumed feedback count = %d, want 1 in %q", got, view)
+	}
+	if !strings.Contains(view, `Goal resumed: "ship native scrollback"`) {
+		t.Fatalf("expected resumed goal feedback in ongoing transcript, got %q", view)
+	}
+}
+
+func drainRuntimeEvents(events <-chan clientui.Event) {
+	for {
+		select {
+		case <-events:
+		default:
+			return
+		}
+	}
+}
+
+func waitForGoalFeedbackEvent(t *testing.T, events <-chan clientui.Event) clientui.Event {
+	t.Helper()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case evt := <-events:
+			for _, entry := range evt.TranscriptEntries {
+				if entry.Role == string(transcript.EntryRoleGoalFeedback) && strings.Contains(entry.CondensedText, "Goal resumed:") {
+					return evt
+				}
+			}
+		case <-timer.C:
+			t.Fatal("timed out waiting for /goal resume goal_feedback event")
+		}
 	}
 }
 

--- a/cli/app/ui_input_resume.go
+++ b/cli/app/ui_input_resume.go
@@ -60,13 +60,16 @@ func (c uiInputController) handleQueuedRuntimeWorkCheckDone(msg queuedRuntimeWor
 		m.layout().syncViewport()
 		return m, tea.Batch(restoreCmd, appendCmd)
 	}
-	if !msg.hasWork || m.injectedQueueBlocksDrain() || m.isBusy() ||
-		m.isInputSubmitLocked() {
-		if !msg.hasWork {
-			c.notifyUserCompactionCompleted(compactionOrigin, true)
-		} else {
-			c.notifyUserCompactionCompleted(compactionOrigin, false)
+	blocked := m.injectedQueueBlocksDrain() || m.isBusy() || m.isInputSubmitLocked()
+	if !msg.hasWork {
+		c.notifyUserCompactionCompleted(compactionOrigin, true)
+		if blocked {
+			return m, nil
 		}
+		return m, c.requestIdleRuntimeControlCommittedTranscriptSync(compactionOrigin)
+	}
+	if blocked {
+		c.notifyUserCompactionCompleted(compactionOrigin, false)
 		return m, nil
 	}
 	c.notifyUserCompactionCompleted(compactionOrigin, false)
@@ -74,6 +77,14 @@ func (c uiInputController) handleQueuedRuntimeWorkCheckDone(msg queuedRuntimeWor
 	m.logf("step.resume_queued_injected pending_injected=%d", len(m.pendingInjected))
 	m.layout().syncViewport()
 	return m, tea.Batch(c.submitQueuedUserMessagesCmd(), c.model.reconcileSpinnerTicking(false))
+}
+
+func (c uiInputController) requestIdleRuntimeControlCommittedTranscriptSync(origin uiCompactionOrigin) tea.Cmd {
+	m := c.model
+	if m == nil || origin == uiCompactionOriginNone || !m.hasRuntimeClient() {
+		return nil
+	}
+	return m.requestRuntimeCommittedConversationSync()
 }
 
 func (c uiInputController) submitQueuedUserMessagesCmd() tea.Cmd {

--- a/cli/app/ui_native_history.go
+++ b/cli/app/ui_native_history.go
@@ -151,11 +151,11 @@ func (m *uiModel) reflowNativeHistoryForResize() tea.Cmd {
 	}
 	nativeCommittedEntries := committedNativeScrollbackEntriesForApp(m.transcriptEntries)
 	committedEntries := nativeCommittedEntries.Entries
-	m.resetNativeStreamingState()
+	m.resetNativeStreamingRenderStateForResize()
 	if len(committedEntries) == 0 {
 		m.rebaseNativeProjection(tui.TranscriptProjection{}, m.transcriptBaseOffset, 0)
 		m.scheduleNativeRenderedProjectionCommitAtBase(tui.TranscriptProjection{}, m.transcriptBaseOffset, false)
-		return sequenceCmds(m.emitNativeClearScreen(), m.syncNativeStreamingScrollback())
+		return sequenceCmds(m.emitNativeClearScreen(), m.syncNativeStreamingScrollbackAfterResize())
 	}
 	committedCount := len(committedEntries)
 	projection := m.nativeCommittedProjection(committedEntries)
@@ -163,11 +163,11 @@ func (m *uiModel) reflowNativeHistoryForResize() tea.Cmd {
 	styled := renderStyledNativeProjectionLines(projection.Lines(tui.TranscriptDivider), m.theme, m.nativeReplayRenderWidth())
 	if strings.TrimSpace(styled) == "" {
 		m.scheduleNativeRenderedProjectionCommitAtBase(projection, m.transcriptBaseOffset, false)
-		return sequenceCmds(m.emitNativeClearScreen(), m.syncNativeStreamingScrollback())
+		return sequenceCmds(m.emitNativeClearScreen(), m.syncNativeStreamingScrollbackAfterResize())
 	}
 	return sequenceCmds(
 		m.emitNativeRenderedTextAndCommitProjection(nativeClearScreenAndHomeSequence+styled, false, projection, m.transcriptBaseOffset, false),
-		m.syncNativeStreamingScrollback(),
+		m.syncNativeStreamingScrollbackAfterResize(),
 	)
 }
 
@@ -282,6 +282,18 @@ func (m *uiModel) resetNativeStreamingState() {
 	m.nativeScrollbackLedger.ResetAssistantStream()
 }
 
+func (m *uiModel) resetNativeStreamingRenderStateForResize() {
+	if m == nil {
+		return
+	}
+	m.nativeStreamingDividerFlushed = false
+	if m.nativeStreamingAwaitingCommit {
+		m.nativeScrollbackLedger.ResetAssistantStreamRenderingState()
+		return
+	}
+	m.nativeScrollbackLedger.ResetAssistantStream()
+}
+
 func (m *uiModel) syncNativeStreamingScrollback() tea.Cmd {
 	if m == nil || !m.shouldEmitNativeHistory() {
 		return nil
@@ -294,6 +306,40 @@ func (m *uiModel) syncNativeStreamingScrollback() tea.Cmd {
 		m.resetNativeStreamingState()
 		return nil
 	}
+	return m.syncNativeStreamingScrollbackText(streamText)
+}
+
+func (m *uiModel) syncNativeStreamingScrollbackAfterResize() tea.Cmd {
+	if m == nil || !m.shouldEmitNativeHistory() {
+		return nil
+	}
+	if streamText, ok := m.nativeStreamingResizeReplayText(); ok {
+		return m.syncNativeStreamingScrollbackText(streamText)
+	}
+	return m.syncNativeStreamingScrollback()
+}
+
+func (m *uiModel) nativeStreamingResizeReplayText() (string, bool) {
+	if m == nil || !m.nativeStreamingAwaitingCommit {
+		return "", false
+	}
+	if strings.TrimSpace(m.view.OngoingStreamingText()) != "" {
+		return "", false
+	}
+	if m.nativeScrollbackLedger.RenderedProjectionCommitPendingResetStreaming() {
+		return "", false
+	}
+	streamState := m.nativeScrollbackLedger.AssistantStreamState()
+	if strings.TrimSpace(streamState.Source) == "" ||
+		streamState.ScheduledStableLines != 0 ||
+		streamState.AckedStableLines != 0 ||
+		streamState.NeedsReplay {
+		return "", false
+	}
+	return streamState.Source, true
+}
+
+func (m *uiModel) syncNativeStreamingScrollbackText(streamText string) tea.Cmd {
 	width := m.nativeReplayRenderWidth()
 	update := m.nativeScrollbackLedger.ApplyAssistantStreamSource(nativescrollback.AssistantStreamInput{
 		Source: streamText,

--- a/cli/app/ui_native_history.go
+++ b/cli/app/ui_native_history.go
@@ -59,6 +59,18 @@ func (m *uiModel) syncNativeHistoryFromTranscript() tea.Cmd {
 	committedCount := len(committedEntries)
 	projection := m.nativeCommittedProjection(committedEntries)
 	if m.nativeCommittedEntryCount() < 0 || m.nativeCommittedEntryCount() > committedCount {
+		previousProjection := m.nativeCommittedHistoryDivergenceBaseline()
+		previousBaseOffset := m.nativeRenderedProjectionBaseOffset()
+		if previousBaseOffset < 0 {
+			previousBaseOffset = m.nativeCurrentProjectionBaseOffset()
+		}
+		if appendCmd, appended := m.emitNativeSlidingWindowAppend(projection, previousProjection, m.transcriptBaseOffset, previousBaseOffset); appended {
+			m.rebaseNativeProjection(projection, m.transcriptBaseOffset, committedCount)
+			if !m.shouldEmitNativeHistory() {
+				return sequenceCmds(nil, m.syncNativeStreamingScrollback())
+			}
+			return sequenceCmds(appendCmd, m.syncNativeStreamingScrollback())
+		}
 		if m.nativeHistoryReplayPermit == nativeHistoryReplayPermitContinuityRecovery {
 			previousProjection := m.nativeCommittedHistoryDivergenceBaseline()
 			m.rebaseNativeProjection(projection, m.transcriptBaseOffset, committedCount)
@@ -131,6 +143,32 @@ func (m *uiModel) syncNativeHistoryFromTranscriptAndTrackCommittedDelivery() tea
 		return cmd
 	}
 	return sequenceCmds(cmd, m.trackOngoingCommittedFrontierFlush(committedOngoingLocalFrontierEnd(m), m.transcriptRevision, beforeSequence))
+}
+
+func (m *uiModel) reflowNativeHistoryForResize() tea.Cmd {
+	if m == nil || !m.shouldEmitNativeHistory() {
+		return nil
+	}
+	nativeCommittedEntries := committedNativeScrollbackEntriesForApp(m.transcriptEntries)
+	committedEntries := nativeCommittedEntries.Entries
+	m.resetNativeStreamingState()
+	if len(committedEntries) == 0 {
+		m.rebaseNativeProjection(tui.TranscriptProjection{}, m.transcriptBaseOffset, 0)
+		m.scheduleNativeRenderedProjectionCommitAtBase(tui.TranscriptProjection{}, m.transcriptBaseOffset, false)
+		return sequenceCmds(m.emitNativeClearScreen(), m.syncNativeStreamingScrollback())
+	}
+	committedCount := len(committedEntries)
+	projection := m.nativeCommittedProjection(committedEntries)
+	m.rebaseNativeProjection(projection, m.transcriptBaseOffset, committedCount)
+	styled := renderStyledNativeProjectionLines(projection.Lines(tui.TranscriptDivider), m.theme, m.nativeReplayRenderWidth())
+	if strings.TrimSpace(styled) == "" {
+		m.scheduleNativeRenderedProjectionCommitAtBase(projection, m.transcriptBaseOffset, false)
+		return sequenceCmds(m.emitNativeClearScreen(), m.syncNativeStreamingScrollback())
+	}
+	return sequenceCmds(
+		m.emitNativeRenderedTextAndCommitProjection(nativeClearScreenAndHomeSequence+styled, false, projection, m.transcriptBaseOffset, false),
+		m.syncNativeStreamingScrollback(),
+	)
 }
 
 func (m *uiModel) nativeCommittedHistoryBaselineExists() bool {
@@ -574,6 +612,7 @@ func (m *uiModel) emitNativeSlidingWindowAppend(current tui.TranscriptProjection
 		return nil, false
 	}
 	if overlapBlocks >= len(current.Blocks) {
+		m.scheduleNativeRenderedProjectionCommitAtBase(current, currentBaseOffset, false)
 		return nil, true
 	}
 	styledDelta := renderStyledNativeProjectionLines(current.LinesFromBlock(overlapBlocks, tui.TranscriptDivider), m.theme, m.nativeReplayRenderWidth())

--- a/cli/app/ui_native_history_part3_test.go
+++ b/cli/app/ui_native_history_part3_test.go
@@ -564,7 +564,7 @@ func TestProjectedRuntimeAssistantFinalAfterPromotionDefersNormalScrollbackAppen
 	}
 }
 
-func TestNativeStreamingResizeKeepsPermanentPromotionWidthFrozen(t *testing.T) {
+func TestNativeStreamingResizeReflowsPermanentPromotionWidth(t *testing.T) {
 	m := newProjectedStaticUIModel(
 		WithUIInitialTranscript([]UITranscriptEntry{{Role: "user", Text: "try again"}}),
 	)
@@ -586,9 +586,9 @@ func TestNativeStreamingResizeKeepsPermanentPromotionWidthFrozen(t *testing.T) {
 
 	next, resizeCmd := m.Update(tea.WindowSizeMsg{Width: 16, Height: 8})
 	m = next.(*uiModel)
-	_ = resizeCmd
-	if got := m.nativeScrollbackLedger.AssistantStreamState().Width; got != 22 {
-		t.Fatalf("expected permanent stream ledger width to stay frozen at 22 after resize, got %d", got)
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, resizeCmd)
+	if got := m.nativeScrollbackLedger.AssistantStreamState().Width; got != 16 {
+		t.Fatalf("expected permanent stream ledger width to reflow at 16 after resize, got %d", got)
 	}
 
 	resizedCount := lineCount + 1
@@ -598,11 +598,11 @@ func TestNativeStreamingResizeKeepsPermanentPromotionWidthFrozen(t *testing.T) {
 
 	secondCmd := m.syncNativeHistoryFromTranscript()
 	secondFlush := collectNativeHistoryFlushText(collectCmdMessages(t, secondCmd))
-	if got := m.nativeScrollbackLedger.AssistantStreamState().Width; got != 22 {
-		t.Fatalf("expected stream tracking width to stay frozen at 22 after resize, got %d", got)
+	if got := m.nativeScrollbackLedger.AssistantStreamState().Width; got != 16 {
+		t.Fatalf("expected stream tracking width to stay at resized width 16, got %d", got)
 	}
-	if got := strings.Count(firstFlush+secondFlush, "line-01"); got != 1 {
-		t.Fatalf("expected resized stream not to duplicate earliest line, got %d in %q%q", got, firstFlush, secondFlush)
+	if got := strings.Count(firstFlush+secondFlush, "line-01"); got < 1 || got > 2 {
+		t.Fatalf("expected resized stream to reflow without unbounded duplication, got %d in %q%q", got, firstFlush, secondFlush)
 	}
 	view := stripANSIPreserve(m.View())
 	if !strings.Contains(view, fmt.Sprintf("line-%02d", resizedCount)) {
@@ -1058,6 +1058,65 @@ func TestNativeHistorySnapshotAppendsVisibleSuffixAfterHiddenRewriteWithoutRepla
 	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, cmd)
 	if got := m.nativeRenderedSnapshot(); got != m.nativeCurrentProjection().Render(tui.TranscriptDivider) {
 		t.Fatalf("expected rendered snapshot rebased to current projection, got %q", got)
+	}
+}
+
+func TestNativeHistoryRecentTailHydrateRebasesRenderedSuffixWithoutMismatch(t *testing.T) {
+	m := newProjectedStaticUIModel(
+		WithUIInitialTranscript([]UITranscriptEntry{
+			{Role: "assistant", Text: "before resident tail"},
+			{Role: "assistant", Text: "resident tail one"},
+			{Role: "assistant", Text: "resident tail two"},
+		}),
+	)
+	_, startupCmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 20})
+	if startupCmd == nil {
+		t.Fatal("expected startup replay command")
+	}
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, startupCmd)
+
+	hydrateCmd := m.runtimeAdapter().applyRuntimeTranscriptPageWithRecovery(clientui.TranscriptPageRequest{}, clientui.TranscriptPage{
+		SessionID:    "session-1",
+		Revision:     2,
+		Offset:       1,
+		TotalEntries: 3,
+		Entries: []clientui.ChatEntry{
+			{Role: "assistant", Text: "resident tail one"},
+			{Role: "assistant", Text: "resident tail two"},
+		},
+	}, clientui.TranscriptRecoveryCauseNone)
+	for _, msg := range collectCmdMessages(t, hydrateCmd) {
+		if flush, ok := msg.(nativeHistoryFlushMsg); ok {
+			t.Fatalf("did not expect active-tail hydrate to re-emit already rendered suffix, got %+v", flush)
+		}
+	}
+	if m.nativeScrollbackInvariantSet {
+		t.Fatalf("did not expect active-tail hydrate to record invariant: %+v current=%#v rendered=%#v", m.nativeScrollbackInvariant, m.nativeCurrentProjection().Blocks, m.nativeScheduledRenderedProjectionState().Projection.Blocks)
+	}
+	rendered := stripANSIText(m.nativeRenderedSnapshot())
+	if strings.Contains(rendered, "before resident tail") || !strings.Contains(rendered, "resident tail two") {
+		t.Fatalf("expected rendered projection ledger rebased to active suffix, got %q", rendered)
+	}
+
+	cmd, mutated, needsHydration := m.runtimeAdapter().applyProjectedTranscriptEntries(clientui.Event{
+		Kind:                       clientui.EventAssistantMessage,
+		CommittedTranscriptChanged: true,
+		TranscriptRevision:         3,
+		CommittedEntryStart:        3,
+		CommittedEntryStartSet:     true,
+		CommittedEntryCount:        4,
+		TranscriptEntries:          []clientui.ChatEntry{{Role: "assistant", Text: "answer after compaction"}},
+	}, true)
+	if !mutated || needsHydration {
+		t.Fatalf("expected post-hydrate assistant append, mutated=%t needsHydration=%t", mutated, needsHydration)
+	}
+	msg, ok := cmd().(nativeHistoryFlushMsg)
+	if !ok {
+		t.Fatalf("expected native append flush after active-tail hydrate, got %T", cmd())
+	}
+	plain := stripANSIText(msg.Text)
+	if !strings.Contains(plain, "answer after compaction") || strings.Contains(plain, "before resident tail") {
+		t.Fatalf("expected only new post-compaction answer to flush, got %q", plain)
 	}
 }
 

--- a/cli/app/ui_native_history_projection.go
+++ b/cli/app/ui_native_history_projection.go
@@ -9,6 +9,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+const nativeClearScreenAndHomeSequence = "\x1b[2J\x1b[H"
+
 func nativeProjectionRenderedFrontier(projection tui.TranscriptProjection) (int, bool) {
 	if len(projection.Blocks) == 0 {
 		return 0, false
@@ -90,6 +92,10 @@ func nativeRenderedDelta(previous, current string) (string, bool) {
 	delta := strings.TrimPrefix(current, previous)
 	delta = strings.TrimPrefix(delta, "\n")
 	return delta, true
+}
+
+func (m *uiModel) emitNativeClearScreen() tea.Cmd {
+	return m.emitNativeHistoryFlushWithOptions(nativeClearScreenAndHomeSequence, false, false)
 }
 
 func (m *uiModel) emitNativeRenderedTextWithOptions(rendered string, clearBelowBefore bool) tea.Cmd {

--- a/cli/app/ui_native_history_test.go
+++ b/cli/app/ui_native_history_test.go
@@ -457,7 +457,7 @@ func TestNativeScrollbackBlocksWhenNoSharedPrefixExists(t *testing.T) {
 	}
 }
 
-func TestNativeScrollbackResizeFreezesFormatterWidth(t *testing.T) {
+func TestNativeScrollbackResizeTracksFormatterWidth(t *testing.T) {
 	m := newProjectedStaticUIModel(
 		WithUIInitialTranscript([]UITranscriptEntry{{Role: "assistant", Text: "old line"}}),
 	)
@@ -470,9 +470,13 @@ func TestNativeScrollbackResizeFreezesFormatterWidth(t *testing.T) {
 		t.Fatalf("expected initial formatter width 40, got %d", m.nativeFormatterWidth)
 	}
 
-	_, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 20})
-	if m.nativeFormatterWidth != 40 {
-		t.Fatalf("expected formatter width to stay frozen at 40 after resize, got %d", m.nativeFormatterWidth)
+	_, resizeCmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 20})
+	if resizeCmd == nil {
+		t.Fatal("expected width resize to schedule resident native history reflow")
+	}
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, resizeCmd)
+	if m.nativeFormatterWidth != 100 {
+		t.Fatalf("expected formatter width to track resize at 100, got %d", m.nativeFormatterWidth)
 	}
 
 	m.forwardToView(tui.AppendTranscriptMsg{Role: "assistant", Text: "new line"})
@@ -494,7 +498,7 @@ func TestNativeScrollbackResizeFreezesFormatterWidth(t *testing.T) {
 	}
 }
 
-func TestNativeWidthResizeDoesNotScheduleReplayOrRebaseRenderedHistory(t *testing.T) {
+func TestNativeWidthResizeSchedulesResidentReflowAndRebasesRenderedHistory(t *testing.T) {
 	m := newProjectedStaticUIModel(
 		WithUIInitialTranscript([]UITranscriptEntry{{Role: "assistant", Text: "old line"}}),
 	)
@@ -504,18 +508,64 @@ func TestNativeWidthResizeDoesNotScheduleReplayOrRebaseRenderedHistory(t *testin
 	}
 	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, startupCmd)
 	renderedSnapshot := m.nativeRenderedSnapshot()
-	formatterWidth := m.nativeFormatterWidth
 
 	next, cmd := m.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
 	m = next.(*uiModel)
-	if cmd != nil {
-		t.Fatalf("expected width resize not to schedule native replay, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected width resize to schedule resident native history reflow")
 	}
-	if m.nativeRenderedSnapshot() != renderedSnapshot {
-		t.Fatalf("expected width resize not to mutate rendered native snapshot, got %q want %q", m.nativeRenderedSnapshot(), renderedSnapshot)
+	foundResidentHistory := false
+	for _, msg := range collectCmdMessagesApplyingNativeWriteResults(t, m, cmd) {
+		if flush, ok := msg.(nativeHistoryFlushMsg); ok && strings.Contains(stripANSIText(flush.Text), "old line") {
+			foundResidentHistory = true
+		}
 	}
-	if m.nativeFormatterWidth != formatterWidth {
-		t.Fatalf("expected width resize not to change frozen formatter width, got %d want %d", m.nativeFormatterWidth, formatterWidth)
+	if !foundResidentHistory {
+		t.Fatalf("expected width resize to re-emit resident native history, previous snapshot %q", renderedSnapshot)
+	}
+	if m.nativeFormatterWidth != 80 {
+		t.Fatalf("expected width resize to update formatter width, got %d", m.nativeFormatterWidth)
+	}
+}
+
+func TestNativeWidthResizeReflowUsesLedgerFlushWhileWriteInFlight(t *testing.T) {
+	m := newProjectedStaticUIModel(
+		WithUIInitialTranscript([]UITranscriptEntry{{Role: "assistant", Text: "old line"}}),
+	)
+	_, startupCmd := m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	if startupCmd == nil {
+		t.Fatal("expected startup replay command")
+	}
+	startupFlush, ok := startupCmd().(nativeHistoryFlushMsg)
+	if !ok {
+		t.Fatalf("expected nativeHistoryFlushMsg, got %T", startupCmd())
+	}
+	_ = collectCmdMessages(t, m.handleNativeHistoryFlush(startupFlush))
+
+	_, resizeCmd := m.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
+	if resizeCmd == nil {
+		t.Fatal("expected width resize to schedule resident native history reflow")
+	}
+	msgs := collectCmdMessages(t, resizeCmd)
+	var resizeFlush nativeHistoryFlushMsg
+	foundResizeFlush := false
+	for _, msg := range msgs {
+		if strings.Contains(fmt.Sprintf("%T", msg), "clearScreenMsg") {
+			t.Fatalf("resize reflow must be ledger-owned, got out-of-band clear screen msg %+v", msg)
+		}
+		if flush, ok := msg.(nativeHistoryFlushMsg); ok {
+			resizeFlush = flush
+			foundResizeFlush = true
+		}
+	}
+	if !foundResizeFlush {
+		t.Fatalf("expected resize reflow native flush, got %+v", msgs)
+	}
+	if !strings.HasPrefix(resizeFlush.Text, nativeClearScreenAndHomeSequence) {
+		t.Fatalf("resize reflow flush must include ordered clear-screen prefix, got %q", resizeFlush.Text)
+	}
+	if pendingMsgs := collectCmdMessages(t, m.handleNativeHistoryFlush(resizeFlush)); len(pendingMsgs) != 0 {
+		t.Fatalf("resize reflow should wait behind in-flight native write, got immediate messages %+v", pendingMsgs)
 	}
 }
 
@@ -535,7 +585,7 @@ func TestNativeHeightOnlyResizeDoesNotScheduleFullReplay(t *testing.T) {
 	}
 }
 
-func TestNativeWidthResizeAcrossModeSwitchDoesNotScheduleReplay(t *testing.T) {
+func TestNativeWidthResizeAcrossModeSwitchUsesResidentReflowOnlyOnce(t *testing.T) {
 	m := newProjectedStaticUIModel(
 		WithUIInitialTranscript([]UITranscriptEntry{{Role: "assistant", Text: "seed"}}),
 	)
@@ -546,9 +596,10 @@ func TestNativeWidthResizeAcrossModeSwitchDoesNotScheduleReplay(t *testing.T) {
 
 	next, resizeCmd := m.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
 	m = next.(*uiModel)
-	if resizeCmd != nil {
-		t.Fatalf("expected width resize not to schedule replay, got %T", resizeCmd)
+	if resizeCmd == nil {
+		t.Fatal("expected width resize to schedule resident native history reflow")
 	}
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, resizeCmd)
 
 	_ = m.toggleTranscriptModeWithNativeReplay(false)
 	if m.view.Mode() != tui.ModeDetail {

--- a/cli/app/ui_native_history_test.go
+++ b/cli/app/ui_native_history_test.go
@@ -1,8 +1,10 @@
 package app
 
 import (
+	"core/cli/app/internal/nativescrollback"
 	"core/cli/tui"
 	"core/server/runtime"
+	"core/shared/clientui"
 	"core/shared/transcript"
 	"fmt"
 	"strings"
@@ -39,6 +41,17 @@ func collectNativeHistoryFlushText(msgs []tea.Msg) string {
 		out.WriteByte('\n')
 	}
 	return out.String()
+}
+
+func firstNativeHistoryFlushForTest(t *testing.T, cmd tea.Cmd) (nativeHistoryFlushMsg, bool) {
+	t.Helper()
+	for _, msg := range collectCmdMessages(t, cmd) {
+		flush, ok := msg.(nativeHistoryFlushMsg)
+		if ok {
+			return flush, true
+		}
+	}
+	return nativeHistoryFlushMsg{}, false
 }
 
 func makeStreamingLines(count int) string {
@@ -566,6 +579,196 @@ func TestNativeWidthResizeReflowUsesLedgerFlushWhileWriteInFlight(t *testing.T) 
 	}
 	if pendingMsgs := collectCmdMessages(t, m.handleNativeHistoryFlush(resizeFlush)); len(pendingMsgs) != 0 {
 		t.Fatalf("resize reflow should wait behind in-flight native write, got immediate messages %+v", pendingMsgs)
+	}
+}
+
+func TestNativeWidthResizePreservesAwaitingAssistantCommitGate(t *testing.T) {
+	m := newProjectedStaticUIModel(
+		WithUIInitialTranscript([]UITranscriptEntry{{Role: "user", Text: "prompt"}}),
+	)
+	_, startupCmd := m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	if startupCmd == nil {
+		t.Fatal("expected startup replay command")
+	}
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, startupCmd)
+	seedNativeAssistantStreamForTest(m, "final answer")
+	m.nativeStreamingAwaitingCommit = true
+
+	_, resizeCmd := m.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
+	if resizeCmd == nil {
+		t.Fatal("expected width resize to schedule resident native history reflow")
+	}
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, resizeCmd)
+	if !m.nativeStreamingAwaitingCommit {
+		t.Fatal("resize reflow must preserve awaiting assistant commit gate")
+	}
+	if strings.TrimSpace(m.nativeScrollbackLedger.AssistantStreamState().Source) == "" {
+		t.Fatal("resize reflow must preserve assistant stream source while awaiting committed finalizer")
+	}
+
+	beforeSequence := m.nativeLastScheduledFlushSequence()
+	_, _ = m.handleRuntimeEventBatch([]clientui.Event{{
+		Kind:                       clientui.EventLocalEntryAdded,
+		StepID:                     "step-1",
+		CommittedTranscriptChanged: true,
+		CommittedEntryStart:        2,
+		CommittedEntryStartSet:     true,
+		CommittedEntryCount:        3,
+		TranscriptRevision:         3,
+		TranscriptEntries:          []clientui.ChatEntry{{Role: "system", Text: "local diagnostic"}},
+	}})
+	if got := len(m.transcriptEntries); got != 1 {
+		t.Fatalf("transcript entry count while awaiting commit = %d, want 1", got)
+	}
+	if got := len(m.deferredCommittedTail); got != 1 {
+		t.Fatalf("deferred committed tail count = %d, want 1", got)
+	}
+	if got := m.nativeLastScheduledFlushSequence(); got != beforeSequence {
+		t.Fatalf("local feedback scheduled native flush while awaiting commit: before=%d after=%d", beforeSequence, got)
+	}
+}
+
+func TestNativeWidthResizeResetsPromotedAssistantAccountingBeforeFinalCommit(t *testing.T) {
+	m := newProjectedStaticUIModel(
+		WithUIInitialTranscript([]UITranscriptEntry{{Role: "user", Text: "prompt"}}),
+	)
+	_, startupCmd := m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	if startupCmd == nil {
+		t.Fatal("expected startup replay command")
+	}
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, startupCmd)
+
+	streamText := "stable prefix\nstable body\n"
+	m.nativeScrollbackLedger.SetAssistantStreamStepID("step-resize-final")
+	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries, Ongoing: streamText})
+	streamCmd := m.syncNativeHistoryFromTranscript()
+	if streamCmd == nil {
+		t.Fatal("expected stable streaming promotion before resize")
+	}
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, streamCmd)
+	beforeResizeState := m.nativeScrollbackLedger.AssistantStreamState()
+	if beforeResizeState.AckedStableLines == 0 {
+		t.Fatalf("test setup did not ack promoted stable lines: %+v", beforeResizeState)
+	}
+
+	m.nativeStreamingAwaitingCommit = true
+	m.forwardToView(tui.ClearOngoingAssistantMsg{})
+	_, resizeCmd := m.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
+	if resizeCmd == nil {
+		t.Fatal("expected width resize to schedule resident native history reflow")
+	}
+	resizeMsgs := collectCmdMessagesApplyingNativeWriteResults(t, m, resizeCmd)
+	afterResizeState := m.nativeScrollbackLedger.AssistantStreamState()
+	if !m.nativeStreamingAwaitingCommit || strings.TrimSpace(afterResizeState.Source) == "" {
+		t.Fatalf("resize must preserve awaiting finalizer identity, awaiting=%t state=%+v", m.nativeStreamingAwaitingCommit, afterResizeState)
+	}
+	if afterResizeState.NeedsReplay || afterResizeState.Width != 80 {
+		t.Fatalf("resize replay must re-render assistant stream at the new width without stale replay state: %+v", afterResizeState)
+	}
+	if got := collectNativeHistoryFlushText(resizeMsgs); !strings.Contains(got, "stable prefix") {
+		t.Fatalf("resize while awaiting commit dropped visible assistant stream, got %q", got)
+	}
+
+	m.nativeScrollbackLedger.ObserveAssistantCommitCandidate(nativescrollback.AssistantCommitCandidate{
+		StepID:          "step-resize-final",
+		StartEntryCount: 1,
+		Entries: []nativescrollback.AssistantCommitEntry{
+			{Role: string(tui.TranscriptRoleAssistant), Text: streamText},
+		},
+	})
+	m.transcriptEntries = append(m.transcriptEntries, tui.TranscriptEntry{
+		Role:      tui.TranscriptRoleAssistant,
+		Text:      streamText,
+		Committed: true,
+	})
+	m.transcriptRevision = 2
+	m.transcriptTotalEntries = 2
+	finalCmd := m.syncNativeHistoryFromTranscript()
+	if finalCmd == nil {
+		t.Fatal("expected final assistant commit to schedule native finalizer flush")
+	}
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, finalCmd)
+	if m.nativeScrollbackInvariantSet {
+		t.Fatalf("final commit after resize reported native divergence: %+v", m.nativeScrollbackInvariant)
+	}
+	if m.nativeStreamingAwaitingCommit {
+		t.Fatal("final native write ack did not clear awaiting assistant commit gate")
+	}
+	if got := stripANSIText(m.nativeRenderedSnapshot()); !strings.Contains(got, "stable body") {
+		t.Fatalf("final assistant commit did not advance rendered projection, got %q", got)
+	}
+}
+
+func TestNativeWidthResizeBeforeFinalizerAckPreservesStreamingReset(t *testing.T) {
+	m := newProjectedStaticUIModel(
+		WithUIInitialTranscript([]UITranscriptEntry{{Role: "user", Text: "prompt"}}),
+	)
+	_, startupCmd := m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	if startupCmd == nil {
+		t.Fatal("expected startup replay command")
+	}
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, startupCmd)
+
+	streamText := "stable prefix\nstable body\n"
+	finalText := streamText + "final tail\n"
+	m.nativeScrollbackLedger.SetAssistantStreamStepID("step-resize-pending-reset")
+	m.forwardToView(tui.SetConversationMsg{Entries: m.transcriptEntries, Ongoing: streamText})
+	streamCmd := m.syncNativeHistoryFromTranscript()
+	if streamCmd == nil {
+		t.Fatal("expected stable streaming promotion before final commit")
+	}
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, streamCmd)
+	m.nativeStreamingAwaitingCommit = true
+	m.forwardToView(tui.ClearOngoingAssistantMsg{})
+	m.nativeScrollbackLedger.ObserveAssistantCommitCandidate(nativescrollback.AssistantCommitCandidate{
+		StepID:          "step-resize-pending-reset",
+		StartEntryCount: 1,
+		Entries: []nativescrollback.AssistantCommitEntry{
+			{Role: string(tui.TranscriptRoleAssistant), Text: finalText},
+		},
+	})
+	m.transcriptEntries = append(m.transcriptEntries, tui.TranscriptEntry{
+		Role:      tui.TranscriptRoleAssistant,
+		Text:      finalText,
+		Committed: true,
+	})
+	m.transcriptRevision = 2
+	m.transcriptTotalEntries = 2
+	finalCmd := m.syncNativeHistoryFromTranscript()
+	if finalCmd == nil {
+		t.Fatal("expected final assistant commit to schedule native finalizer flush")
+	}
+	finalFlush, ok := firstNativeHistoryFlushForTest(t, finalCmd)
+	if !ok {
+		t.Fatal("expected finalizer native flush")
+	}
+	if !m.nativeRenderedProjectionCommitPending() || !m.nativeScrollbackLedger.RenderedProjectionCommitPendingResetStreaming() {
+		t.Fatal("expected finalizer rendered projection reset to wait for native write ack")
+	}
+
+	_, resizeCmd := m.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
+	if resizeCmd == nil {
+		t.Fatal("expected width resize to schedule resident native history reflow")
+	}
+	resizeFlush, ok := firstNativeHistoryFlushForTest(t, resizeCmd)
+	if !ok {
+		t.Fatal("expected resize native flush")
+	}
+	if cmd := m.handleNativeHistoryFlush(resizeFlush); cmd != nil {
+		t.Fatalf("out-of-order resize flush should wait for finalizer write, got %T", cmd())
+	}
+	if !m.nativeScrollbackLedger.RenderedProjectionCommitPendingResetStreaming() {
+		t.Fatal("resize reflow replaced pending finalizer reset")
+	}
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, m.handleNativeHistoryFlush(finalFlush))
+	if m.nativeStreamingAwaitingCommit {
+		t.Fatal("resize ack after finalizer write did not clear awaiting assistant commit gate")
+	}
+	if state := m.nativeScrollbackLedger.AssistantStreamState(); strings.TrimSpace(state.Source) != "" {
+		t.Fatalf("assistant stream state was not reset after ordered finalizer/resize writes: %+v", state)
+	}
+	if got := stripANSIText(m.nativeRenderedSnapshot()); !strings.Contains(got, "final tail") {
+		t.Fatalf("final resized projection did not remain rendered, got %q", got)
 	}
 }
 

--- a/cli/app/ui_native_scrollback_integration_part5_test.go
+++ b/cli/app/ui_native_scrollback_integration_part5_test.go
@@ -6,6 +6,7 @@ import (
 	"core/server/llm"
 	"core/server/runtime"
 	"core/shared/clientui"
+	"core/shared/transcript"
 	"strings"
 	"testing"
 	"time"
@@ -164,6 +165,223 @@ func TestNativeStreamedMultilineMarkdownFinalThenCommitAppearsOnceInScrollback(t
 	}
 	if got := strings.Count(committed, "I opened it via the browser client"); got != 1 {
 		t.Fatalf("expected committed multiline final tail once, got %d in %q", got, committed)
+	}
+}
+
+func TestNativeGoalFeedbackBeforeStreamDoesNotReplayOrDuplicateFinal(t *testing.T) {
+	out := &bytes.Buffer{}
+	runtimeEvents := make(chan clientui.Event, 8)
+	model := newProjectedTestUIModel(nil, runtimeEvents, closedAskEvents())
+	program := startNativeProgram(t, model, out)
+	time.Sleep(30 * time.Millisecond)
+	program.Send(tea.WindowSizeMsg{Width: 120, Height: 30})
+
+	runtimeEvents <- clientui.Event{
+		Kind:                       clientui.EventLocalEntryAdded,
+		StepID:                     "step-1",
+		CommittedTranscriptChanged: true,
+		CommittedEntryStart:        0,
+		CommittedEntryStartSet:     true,
+		CommittedEntryCount:        1,
+		TranscriptRevision:         1,
+		TranscriptEntries: []clientui.ChatEntry{{
+			Role:          string(transcript.EntryRoleGoalFeedback),
+			Text:          "Goal resumed developer prompt detail",
+			CondensedText: `Goal resumed: "ship native scrollback"`,
+			Visibility:    clientui.EntryVisibilityAll,
+		}},
+	}
+	waitForTestCondition(t, 2*time.Second, "goal feedback visible before stream", func() bool {
+		return strings.Contains(normalizedOutput(out.String()), `Goal resumed: "ship native scrollback"`)
+	})
+
+	finalText := "Continuing the same pending-tool/native live-region flow family."
+	runtimeEvents <- clientui.Event{Kind: clientui.EventAssistantDelta, StepID: "step-1", AssistantDelta: finalText}
+	waitForTestCondition(t, 2*time.Second, "assistant stream visible after goal feedback", func() bool {
+		return strings.Contains(normalizedOutput(out.String()), finalText)
+	})
+	runtimeEvents <- clientui.Event{
+		Kind:                       clientui.EventAssistantMessage,
+		StepID:                     "step-1",
+		CommittedTranscriptChanged: true,
+		CommittedEntryStart:        1,
+		CommittedEntryStartSet:     true,
+		CommittedEntryCount:        2,
+		TranscriptRevision:         2,
+		TranscriptEntries: []clientui.ChatEntry{{
+			Role:  "assistant",
+			Text:  finalText,
+			Phase: string(llm.MessagePhaseFinal),
+		}},
+	}
+	waitForTestCondition(t, 2*time.Second, "stream committed after goal feedback", func() bool {
+		return strings.TrimSpace(model.view.OngoingStreamingText()) == "" &&
+			model.nativeAckedFlushSequence() >= model.nativeLastScheduledFlushSequence() &&
+			model.nativeScrollbackLedger.PendingCount() == 0
+	})
+
+	program.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
+	program.Wait(2 * time.Second)
+	finalTerminal := normalizedOutput(replayTerminalPlainText(out.String()))
+	if got := strings.Count(finalTerminal, `Goal resumed: "ship native scrollback"`); got != 1 {
+		t.Fatalf("expected goal feedback once, got %d in %q", got, finalTerminal)
+	}
+	if got := strings.Count(finalTerminal, finalText); got != 1 {
+		t.Fatalf("expected final answer once, got %d in %q", got, finalTerminal)
+	}
+	if !containsInOrder(finalTerminal, `Goal resumed: "ship native scrollback"`, finalText) {
+		t.Fatalf("expected goal feedback before final answer without replay, got %q", finalTerminal)
+	}
+}
+
+func TestNativeLocalEntryDuringStreamDefersUntilFinalWithoutDuplicatingStream(t *testing.T) {
+	out := &bytes.Buffer{}
+	runtimeEvents := make(chan clientui.Event, 8)
+	model := newProjectedTestUIModel(nil, runtimeEvents, closedAskEvents())
+	program := startNativeProgram(t, model, out)
+	time.Sleep(30 * time.Millisecond)
+	program.Send(tea.WindowSizeMsg{Width: 120, Height: 30})
+
+	finalText := "Current implementation is at 864 LOC diff."
+	runtimeEvents <- clientui.Event{Kind: clientui.EventAssistantDelta, StepID: "step-1", AssistantDelta: finalText}
+	waitForTestCondition(t, 2*time.Second, "assistant stream visible", func() bool {
+		return strings.Contains(normalizedOutput(out.String()), finalText)
+	})
+	runtimeEvents <- clientui.Event{
+		Kind:                       clientui.EventLocalEntryAdded,
+		StepID:                     "step-1",
+		CommittedTranscriptChanged: true,
+		CommittedEntryStart:        0,
+		CommittedEntryStartSet:     true,
+		CommittedEntryCount:        1,
+		TranscriptRevision:         1,
+		TranscriptEntries: []clientui.ChatEntry{{
+			Role:          string(transcript.EntryRoleGoalFeedback),
+			Text:          "Goal resumed developer prompt detail",
+			CondensedText: `Goal resumed: "ship native scrollback"`,
+			Visibility:    clientui.EntryVisibilityAll,
+		}},
+	}
+	time.Sleep(50 * time.Millisecond)
+	if strings.Contains(normalizedOutput(replayTerminalPlainText(out.String())), `Goal resumed: "ship native scrollback"`) {
+		t.Fatalf("local goal feedback reached native scrollback before stream finalization: %q", normalizedOutput(replayTerminalPlainText(out.String())))
+	}
+
+	runtimeEvents <- clientui.Event{
+		Kind:                       clientui.EventAssistantMessage,
+		StepID:                     "step-1",
+		CommittedTranscriptChanged: true,
+		CommittedEntryStart:        1,
+		CommittedEntryStartSet:     true,
+		CommittedEntryCount:        2,
+		TranscriptRevision:         2,
+		TranscriptEntries: []clientui.ChatEntry{{
+			Role:  "assistant",
+			Text:  finalText,
+			Phase: string(llm.MessagePhaseFinal),
+		}},
+	}
+	waitForTestCondition(t, 2*time.Second, "deferred local row drained after stream finalization", func() bool {
+		terminal := normalizedOutput(replayTerminalPlainText(out.String()))
+		return strings.TrimSpace(model.view.OngoingStreamingText()) == "" &&
+			model.nativeAckedFlushSequence() >= model.nativeLastScheduledFlushSequence() &&
+			model.nativeScrollbackLedger.PendingCount() == 0 &&
+			strings.Contains(terminal, finalText) &&
+			strings.Contains(terminal, `Goal resumed: "ship native scrollback"`)
+	})
+
+	program.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
+	program.Wait(2 * time.Second)
+	finalTerminal := normalizedOutput(replayTerminalPlainText(out.String()))
+	if got := strings.Count(finalTerminal, finalText); got != 1 {
+		t.Fatalf("expected stream/final text once, got %d in %q", got, finalTerminal)
+	}
+	if got := strings.Count(finalTerminal, `Goal resumed: "ship native scrollback"`); got != 1 {
+		t.Fatalf("expected deferred goal feedback once, got %d in %q", got, finalTerminal)
+	}
+	if !containsInOrder(finalTerminal, finalText, `Goal resumed: "ship native scrollback"`) {
+		t.Fatalf("expected stream finalization before deferred local feedback, got %q", finalTerminal)
+	}
+}
+
+func TestNativeReviewerEntriesAfterStreamFinalDoNotReplayFinalAnswer(t *testing.T) {
+	out := &bytes.Buffer{}
+	runtimeEvents := make(chan clientui.Event, 8)
+	model := newProjectedTestUIModel(nil, runtimeEvents, closedAskEvents())
+	program := startNativeProgram(t, model, out)
+	time.Sleep(30 * time.Millisecond)
+	program.Send(tea.WindowSizeMsg{Width: 120, Height: 30})
+
+	finalText := "Continuing into the worker projection bridge next."
+	runtimeEvents <- clientui.Event{Kind: clientui.EventAssistantDelta, StepID: "step-1", AssistantDelta: finalText}
+	waitForTestCondition(t, 2*time.Second, "assistant stream visible", func() bool {
+		return strings.Contains(normalizedOutput(out.String()), finalText)
+	})
+	runtimeEvents <- clientui.Event{
+		Kind:                       clientui.EventAssistantMessage,
+		StepID:                     "step-1",
+		CommittedTranscriptChanged: true,
+		CommittedEntryStart:        0,
+		CommittedEntryStartSet:     true,
+		CommittedEntryCount:        1,
+		TranscriptRevision:         1,
+		TranscriptEntries: []clientui.ChatEntry{{
+			Role:  "assistant",
+			Text:  finalText,
+			Phase: string(llm.MessagePhaseFinal),
+		}},
+	}
+	waitForTestCondition(t, 2*time.Second, "final answer committed before reviewer entries", func() bool {
+		return strings.TrimSpace(model.view.OngoingStreamingText()) == "" &&
+			model.nativeAckedFlushSequence() >= model.nativeLastScheduledFlushSequence() &&
+			model.nativeScrollbackLedger.PendingCount() == 0
+	})
+
+	runtimeEvents <- clientui.Event{
+		Kind:                       clientui.EventLocalEntryAdded,
+		StepID:                     "step-1",
+		CommittedTranscriptChanged: true,
+		CommittedEntryStart:        1,
+		CommittedEntryStartSet:     true,
+		CommittedEntryCount:        2,
+		TranscriptRevision:         2,
+		TranscriptEntries: []clientui.ChatEntry{{
+			Role:          "reviewer_suggestions",
+			Text:          "Supervisor suggested:\n1. Check final answer.",
+			CondensedText: "Supervisor suggested:\n1. Check final answer.",
+		}},
+	}
+	runtimeEvents <- clientui.Event{
+		Kind:                       clientui.EventLocalEntryAdded,
+		StepID:                     "step-1",
+		CommittedTranscriptChanged: true,
+		CommittedEntryStart:        2,
+		CommittedEntryStartSet:     true,
+		CommittedEntryCount:        3,
+		TranscriptRevision:         3,
+		TranscriptEntries: []clientui.ChatEntry{{
+			Role: "reviewer_status",
+			Text: "Supervisor ran: 1 suggestion, no changes applied.",
+		}},
+	}
+	waitForTestCondition(t, 2*time.Second, "reviewer entries appended after final answer", func() bool {
+		terminal := normalizedOutput(replayTerminalPlainText(out.String()))
+		return model.nativeAckedFlushSequence() >= model.nativeLastScheduledFlushSequence() &&
+			model.nativeScrollbackLedger.PendingCount() == 0 &&
+			containsInOrder(terminal, finalText, "Supervisor suggested:", "Supervisor ran: 1 suggestion")
+	})
+
+	program.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
+	program.Wait(2 * time.Second)
+	finalTerminal := normalizedOutput(replayTerminalPlainText(out.String()))
+	if got := strings.Count(finalTerminal, finalText); got != 1 {
+		t.Fatalf("expected final answer once after reviewer entries, got %d in %q", got, finalTerminal)
+	}
+	if got := strings.Count(finalTerminal, "Supervisor suggested:"); got != 1 {
+		t.Fatalf("expected reviewer suggestions once, got %d in %q", got, finalTerminal)
+	}
+	if got := strings.Count(finalTerminal, "Supervisor ran: 1 suggestion"); got != 1 {
+		t.Fatalf("expected reviewer status once, got %d in %q", got, finalTerminal)
 	}
 }
 

--- a/cli/app/ui_native_scrollback_integration_test.go
+++ b/cli/app/ui_native_scrollback_integration_test.go
@@ -647,7 +647,7 @@ func TestNativeScrollbackInitClearsOnEachProgramRun(t *testing.T) {
 	}
 }
 
-func TestNativeResizeDoesNotReplayOngoingScrollbackAfterRealResize(t *testing.T) {
+func TestNativeResizeReflowsOngoingScrollbackFromResidentHistory(t *testing.T) {
 	out := &bytes.Buffer{}
 	model := newProjectedTestUIModel(
 		nil,
@@ -673,12 +673,13 @@ func TestNativeResizeDoesNotReplayOngoingScrollbackAfterRealResize(t *testing.T)
 	program.QuitAndWaitAllowContextCanceled(2 * time.Second)
 
 	raw := out.String()
-	if count := strings.Count(raw, "\x1b[2J"); count != 1 {
-		t.Fatalf("expected only the startup clear-screen sequence after resize burst, got %d occurrences in %q", count, raw)
+	clearCount := strings.Count(raw, "\x1b[2J")
+	if clearCount < 2 || clearCount > 6 {
+		t.Fatalf("expected bounded clear-screen reflows after resize burst, got %d occurrences in %q", clearCount, raw)
 	}
 	plain := xansi.Strip(raw)
-	if count := strings.Count(normalizedOutput(raw), "seed replay line"); count != 1 {
-		t.Fatalf("expected committed history to remain emitted once after resize burst, got %q", normalizedOutput(raw))
+	if count := strings.Count(normalizedOutput(raw), "seed replay line"); count < 2 || count > 6 {
+		t.Fatalf("expected committed history to be re-emitted only for resident resize reflows, got %q", normalizedOutput(raw))
 	}
 	for _, line := range strings.Split(plain, "\n") {
 		if strings.Count(line, statusStateCircleGlyph+statusLineSpinnerSeparator) > 1 {

--- a/cli/app/ui_ongoing_committed_scrollback_gate.go
+++ b/cli/app/ui_ongoing_committed_scrollback_gate.go
@@ -16,6 +16,7 @@ func (m *uiModel) ongoingCommittedScrollbackGateActive() bool {
 	return strings.TrimSpace(m.view.OngoingStreamingText()) != "" ||
 		m.sawAssistantDelta ||
 		m.nativeStreamingActive ||
+		m.nativeStreamingAwaitingCommit ||
 		strings.TrimSpace(m.nativeScrollbackLedger.AssistantStreamState().Source) != ""
 }
 

--- a/cli/app/ui_ongoing_committed_scrollback_gate_test.go
+++ b/cli/app/ui_ongoing_committed_scrollback_gate_test.go
@@ -72,6 +72,47 @@ func TestCommittedSuffixFinalizerThatWouldRestructureEmittedBlockIsDeferred(t *t
 	}
 }
 
+func TestCommittedLocalEntryNeverUsesSuffixDelivery(t *testing.T) {
+	client := &runtimeClientWithoutCachedMainView{
+		mainView: clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{SessionID: "session-1"}},
+	}
+	m := newProjectedClosedUIModel(client)
+	m.windowSizeKnown = true
+	m.termWidth = 100
+	m.termHeight = 20
+
+	committedLocal := clientui.Event{
+		Kind:                       clientui.EventLocalEntryAdded,
+		CommittedTranscriptChanged: true,
+		CommittedEntryCount:        1,
+		CommittedEntryStart:        0,
+		CommittedEntryStartSet:     true,
+		TranscriptRevision:         1,
+		TranscriptEntries:          []clientui.ChatEntry{{Role: "system", Text: "local diagnostic"}},
+	}
+	if shouldDeliverCommittedRuntimeEventFromSuffix(m, committedLocal) {
+		t.Fatal("committed local row must use direct transcript application, not async suffix delivery")
+	}
+
+	committedGoalFeedback := clientui.Event{
+		Kind:                       clientui.EventConversationUpdated,
+		CommittedTranscriptChanged: true,
+		CommittedEntryCount:        1,
+		CommittedEntryStart:        0,
+		CommittedEntryStartSet:     true,
+		TranscriptRevision:         1,
+		TranscriptEntries: []clientui.ChatEntry{{
+			Role:          "goal_feedback",
+			Text:          "goal detail",
+			CondensedText: `Goal resumed: "ship feature"`,
+			Visibility:    clientui.EntryVisibilityAll,
+		}},
+	}
+	if shouldDeliverCommittedRuntimeEventFromSuffix(m, committedGoalFeedback) {
+		t.Fatal("committed goal_feedback conversation update must use direct transcript application, not async suffix delivery")
+	}
+}
+
 func TestCommittedLocalEntryWhileAssistantStreamingIsDeferredUntilFinalCommit(t *testing.T) {
 	m := newProjectedClosedUIModel(nil)
 	m.windowSizeKnown = true

--- a/cli/app/ui_part4_test.go
+++ b/cli/app/ui_part4_test.go
@@ -1524,6 +1524,54 @@ func TestCompactDoneSurfacesQueuedRuntimeWorkProbeFailure(t *testing.T) {
 	}
 }
 
+func TestIdleCompactDoneRefreshesCommittedSteeringOutput(t *testing.T) {
+	client := &runtimeControlFakeClient{
+		sessionView: clientui.RuntimeSessionView{SessionID: "session-1"},
+	}
+	m := newProjectedTestUIModel(client, closedProjectedRuntimeEvents(), closedAskEvents())
+	m.sessionID = "session-1"
+	_, startupCmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 20})
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, m, startupCmd)
+	m.compactionOrigin = uiCompactionOriginManual
+	m.setBusy(true)
+	m.setCompacting(true)
+	m.activity = uiActivityRunning
+
+	next, checkCmd := m.Update(compactDoneMsg{})
+	updated := next.(*uiModel)
+	client.transcript = clientui.TranscriptPage{
+		SessionID:    "session-1",
+		Offset:       0,
+		TotalEntries: 1,
+		Revision:     1,
+		NewerCursor:  1,
+		Entries: []clientui.ChatEntry{
+			{Role: "compaction_notice", Text: "context compacted for the 1st time"},
+		},
+	}
+	updated, syncCmd := applyQueuedRuntimeWorkCheckForTest(t, updated, checkCmd)
+	if syncCmd == nil {
+		t.Fatal("expected idle compaction completion to request committed transcript sync")
+	}
+	for _, msg := range collectCmdMessages(t, syncCmd) {
+		next, followCmd := updated.Update(msg)
+		updated = next.(*uiModel)
+		_ = collectCmdMessagesApplyingNativeWriteResults(t, updated, followCmd)
+	}
+	if client.hasQueuedUserWorkCalls != 1 {
+		t.Fatalf("HasQueuedUserWork calls = %d, want 1", client.hasQueuedUserWorkCalls)
+	}
+	if client.refreshTranscriptCalls != 1 {
+		t.Fatalf("RefreshTranscriptPage calls = %d, want 1", client.refreshTranscriptCalls)
+	}
+	if got := stripANSIText(updated.nativeRenderedSnapshot()); !strings.Contains(got, "context compacted") {
+		t.Fatalf("idle compaction did not flush committed steering output, rendered=%q", got)
+	}
+	if got := strings.Count(stripANSIText(updated.nativeRenderedSnapshot()), "context compacted"); got != 1 {
+		t.Fatalf("idle compaction rendered steering output %d times, want once", got)
+	}
+}
+
 func TestCompactDoneSuppressesQueuedRuntimeWorkProbeCancellation(t *testing.T) {
 	client := &runtimeControlFakeClient{hasQueuedUserWorkErr: context.Canceled}
 	m := newProjectedStaticUIModel()

--- a/cli/app/ui_runtime_adapter_test.go
+++ b/cli/app/ui_runtime_adapter_test.go
@@ -469,7 +469,7 @@ func TestOngoingReviewerEntriesAfterCommittedFinalKeepFinalVisibleWithoutHydrati
 	}
 
 	for _, evt := range events {
-		msgs := collectCmdMessages(t, m.runtimeAdapter().applyProjectedRuntimeEvent(evt, true).cmd)
+		msgs := collectCmdMessagesApplyingNativeWriteResults(t, m, m.runtimeAdapter().applyProjectedRuntimeEvent(evt, true).cmd)
 		for _, msg := range msgs {
 			if _, ok := msg.(runtimeTranscriptRefreshedMsg); ok {
 				t.Fatalf("did not expect reviewer sequence to trigger transcript hydration, event=%s msg=%+v", evt.Kind, msg)

--- a/cli/app/ui_runtime_client_test.go
+++ b/cli/app/ui_runtime_client_test.go
@@ -377,7 +377,7 @@ func TestStartupRuntimeTranscriptSeedsFromCommittedSuffix(t *testing.T) {
 	}
 }
 
-func TestWidthResizeDoesNotFetchCommittedSuffixOrReplay(t *testing.T) {
+func TestWidthResizeReflowsResidentHistoryWithoutFetchingCommittedSuffix(t *testing.T) {
 	reads := &countingSessionViewClient{
 		view: clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{
 			SessionID: "session-1",
@@ -420,9 +420,10 @@ func TestWidthResizeDoesNotFetchCommittedSuffixOrReplay(t *testing.T) {
 
 	next, resizeCmd := model.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
 	model = next.(*uiModel)
-	if resizeCmd != nil {
-		t.Fatalf("expected width resize not to schedule native replay or suffix fetch, got %T", resizeCmd)
+	if resizeCmd == nil {
+		t.Fatal("expected width resize to schedule resident native history reflow")
 	}
+	_ = collectCmdMessagesApplyingNativeWriteResults(t, model, resizeCmd)
 	if reads.lastSuffixReq.SessionID != "" {
 		t.Fatalf("expected width resize not to request committed suffix, got %+v", reads.lastSuffixReq)
 	}

--- a/cli/app/ui_transcript_event_snapshot.go
+++ b/cli/app/ui_transcript_event_snapshot.go
@@ -17,7 +17,7 @@ func projectedTranscriptEventSnapshotFromModel(m *uiModel) projectedTranscriptEv
 		revision:             m.transcriptRevision,
 		hasRuntimeClient:     m.hasRuntimeClient(),
 		busy:                 m.isBusy(),
-		liveAssistantPending: strings.TrimSpace(liveAssistantText) != "" || m.sawAssistantDelta,
+		liveAssistantPending: strings.TrimSpace(liveAssistantText) != "" || m.sawAssistantDelta || m.nativeStreamingAwaitingCommit,
 		liveAssistantText:    liveAssistantText,
 		liveAssistantStepID:  m.nativeScrollbackLedger.AssistantStreamState().StepID,
 	}

--- a/cli/app/ui_transcript_page_apply.go
+++ b/cli/app/ui_transcript_page_apply.go
@@ -220,7 +220,12 @@ func (a uiRuntimeAdapter) applyAuthoritativeRecentTailPage(page clientui.Transcr
 	m.transcriptTotalEntries = max(page.TotalEntries, page.Offset+len(entries))
 	m.transcriptRevision = max(m.transcriptRevision, page.Revision)
 	hydratedCommittedEnd := page.Offset + committedNativeScrollbackEntriesForApp(entries).PrefixEnd
-	m.nativeScrollbackLedger.ResetCommittedDeliveryAppliedRange(page.Offset, hydratedCommittedEnd, m.transcriptRevision)
+	emittedCommittedEnd := page.Offset
+	if state := m.nativeScrollbackLedger.CommittedDeliveryState(); state.Initialized && state.LastEmittedCommittedEntryCount <= hydratedCommittedEnd {
+		emittedCommittedEnd = max(emittedCommittedEnd, state.LastEmittedCommittedEntryCount)
+		hydratedCommittedEnd = max(hydratedCommittedEnd, state.LastAppliedCommittedEntryCount)
+	}
+	m.nativeScrollbackLedger.ResetCommittedDeliveryAppliedRange(emittedCommittedEnd, hydratedCommittedEnd, m.transcriptRevision)
 	m.transcriptLiveDirty = false
 	if !preserveLiveReasoning {
 		m.reasoningLiveDirty = false

--- a/cli/app/ui_transcript_runtime_state.go
+++ b/cli/app/ui_transcript_runtime_state.go
@@ -159,7 +159,9 @@ func (m *uiModel) clearAssistantStreamForCommittedAppend() {
 	if m == nil {
 		return
 	}
-	if strings.TrimSpace(m.nativeScrollbackLedger.AssistantStreamState().Source) == "" && strings.TrimSpace(m.view.OngoingStreamingText()) != "" {
+	if m.shouldEmitNativeHistory() &&
+		strings.TrimSpace(m.nativeScrollbackLedger.AssistantStreamState().Source) == "" &&
+		strings.TrimSpace(m.view.OngoingStreamingText()) != "" {
 		m.nativeStreamingAwaitingCommit = true
 	}
 	m.sawAssistantDelta = false

--- a/cli/app/ui_window_reducer.go
+++ b/cli/app/ui_window_reducer.go
@@ -14,12 +14,22 @@ func (r uiWindowFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 	m := r.model
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		previousWidth := m.termWidth
+		windowWasKnown := m.windowSizeKnown
+		historyWasReplayed := m.nativeHistoryReplayed()
 		m.termWidth = msg.Width
 		m.termHeight = msg.Height
 		m.windowSizeKnown = true
+		if msg.Width > 0 {
+			m.nativeReplayWidth = msg.Width
+			m.nativeFormatterWidth = msg.Width
+		}
 		m.layout().syncViewport()
 		if !m.nativeHistoryReplayed() {
 			return handledUIFeatureUpdate(m, m.syncNativeHistoryFromTranscriptAndTrackCommittedDelivery())
+		}
+		if historyWasReplayed && windowWasKnown && previousWidth > 0 && msg.Width > 0 && msg.Width != previousWidth {
+			return handledUIFeatureUpdate(m, m.reflowNativeHistoryForResize())
 		}
 	}
 	return uiFeatureUpdateResult{}

--- a/docs/dev/specs/release-distribution.md
+++ b/docs/dev/specs/release-distribution.md
@@ -39,18 +39,20 @@
 
 ## Desktop Bundle Artifacts
 
-- The desktop app ships arm64 macOS + x86_64 Linux only. Per-release assets, built
-  by `scripts/desktop-release.sh build` and published by the `release.yml`
-  `build_desktop` → `publish_desktop` jobs:
+- The desktop app ships arm64 macOS, x86_64 Linux, and x86_64 Windows bundles.
+  Per-release assets, built by `scripts/desktop-release.sh build` and published
+  by the `release.yml` `build_desktop` → `publish_desktop` jobs:
   - `Kent_<ver>_aarch64.dmg` (macOS installer),
   - `Kent_<ver>_aarch64.app.tar.gz` (+`.sig`) — macOS updater artifact (Tauri emits
     it as `Kent.app.tar.gz`; the build step renames it to this versioned asset),
   - `Kent_<ver>_amd64.AppImage` (+`.sig`) — Linux updater artifact,
-  - `Kent_<ver>_amd64.deb` (Linux, apt/manual updates).
+  - `Kent_<ver>_amd64.deb` (Linux, apt/manual updates),
+  - `Kent_<ver>_x64-setup.exe` (+`.sig`) — Windows NSIS installer and updater
+    artifact.
 - `latest.json` is the Tauri updater manifest (`scripts/desktop-release.sh assemble`
-  builds it from the `.sig` files), with `darwin-aarch64` and `linux-x86_64` entries
-  pointing at the `.app.tar.gz` / `.AppImage` updater artifacts. It is the
-  `plugins.updater` endpoint target.
+  builds it from the `.sig` files), with `darwin-aarch64`, `linux-x86_64`, and
+  `windows-x86_64` entries pointing at the `.app.tar.gz`, `.AppImage`, and NSIS
+  updater artifacts. It is the `plugins.updater` endpoint target.
 - `desktop-checksums.txt` carries sha256s for the distributable bundles.
 - macOS bundles are Developer ID signed in CI (`APPLE_CERTIFICATE`); notarization is
   off for v1 (Apple-side blocked), so v1 ships signed + un-notarized. The macOS

--- a/docs/dev/specs/release-distribution.md
+++ b/docs/dev/specs/release-distribution.md
@@ -39,20 +39,18 @@
 
 ## Desktop Bundle Artifacts
 
-- The desktop app ships arm64 macOS, x86_64 Linux, and x86_64 Windows bundles.
-  Per-release assets, built by `scripts/desktop-release.sh build` and published
-  by the `release.yml` `build_desktop` → `publish_desktop` jobs:
+- The desktop app ships arm64 macOS + x86_64 Linux only. Per-release assets, built
+  by `scripts/desktop-release.sh build` and published by the `release.yml`
+  `build_desktop` → `publish_desktop` jobs:
   - `Kent_<ver>_aarch64.dmg` (macOS installer),
   - `Kent_<ver>_aarch64.app.tar.gz` (+`.sig`) — macOS updater artifact (Tauri emits
     it as `Kent.app.tar.gz`; the build step renames it to this versioned asset),
   - `Kent_<ver>_amd64.AppImage` (+`.sig`) — Linux updater artifact,
-  - `Kent_<ver>_amd64.deb` (Linux, apt/manual updates),
-  - `Kent_<ver>_x64-setup.exe` (+`.sig`) — Windows NSIS installer and updater
-    artifact.
+  - `Kent_<ver>_amd64.deb` (Linux, apt/manual updates).
 - `latest.json` is the Tauri updater manifest (`scripts/desktop-release.sh assemble`
-  builds it from the `.sig` files), with `darwin-aarch64`, `linux-x86_64`, and
-  `windows-x86_64` entries pointing at the `.app.tar.gz`, `.AppImage`, and NSIS
-  updater artifacts. It is the `plugins.updater` endpoint target.
+  builds it from the `.sig` files), with `darwin-aarch64` and `linux-x86_64` entries
+  pointing at the `.app.tar.gz` / `.AppImage` updater artifacts. It is the
+  `plugins.updater` endpoint target.
 - `desktop-checksums.txt` carries sha256s for the distributable bundles.
 - macOS bundles are Developer ID signed in CI (`APPLE_CERTIFICATE`); notarization is
   off for v1 (Apple-side blocked), so v1 ships signed + un-notarized. The macOS

--- a/docs/dev/specs/tui-transcript.md
+++ b/docs/dev/specs/tui-transcript.md
@@ -14,6 +14,7 @@
 - Main UI startup stays in the normal buffer because ongoing-mode replay must remain visible in terminal scrollback.
 - **ongoing normal-buffer history is append-only.** 
 - **Once a transcript line is emitted into scrollback, it is immutable: no retroactive restyling, no in-place rewrites, no clear-and-replay, and no full-buffer re-emission to paper over same-session divergence.**
+- Terminal width resize is the only normal-buffer reflow exception: ongoing may clear and re-emit the resident active committed history at the new width, using in-memory active transcript state only.
 - Compaction is same-session committed transcript progression, not a same-session transcript rewrite.
 - User-visible transcript history is never truncated by compaction or handoff. It is durable on disk and served by streaming the persisted event log through a windowed projector (page or recent-tail), never by holding the full transcript in memory; the live conversation storage keeps only the bounded model working set.
 - Latest-compaction boundary/floor is tail/model metadata only; detail paging and rendering ignore it.

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -56,7 +56,7 @@ The desktop app lets you use Kent's [Workflows and Tasks](../workflows/) feature
 
 ### Manual Install
 
-Download the installer for your platform at [kent.sh/desktop](https://kent.sh/desktop) (currently MacOS and Linux), or install via Homebrew:
+Download the installer for your platform at [kent.sh/desktop](https://kent.sh/desktop) (macOS, Linux, and Windows), or install the macOS app via Homebrew:
 
 ```bash
 brew install --cask respawn-llc/tap/kent-desktop

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -56,7 +56,7 @@ The desktop app lets you use Kent's [Workflows and Tasks](../workflows/) feature
 
 ### Manual Install
 
-Download the installer for your platform at [kent.sh/desktop](https://kent.sh/desktop) (macOS, Linux, and Windows), or install the macOS app via Homebrew:
+Download the installer for your platform at [kent.sh/desktop](https://kent.sh/desktop) (currently MacOS and Linux), or install via Homebrew:
 
 ```bash
 brew install --cask respawn-llc/tap/kent-desktop

--- a/scripts/desktop-release.sh
+++ b/scripts/desktop-release.sh
@@ -20,11 +20,12 @@ Usage:
   scripts/desktop-release.sh assemble [--version X.Y.Z] [--dist-dir dist/desktop] [--base-url URL] [--pub-date RFC3339] [--notes TEXT]
   scripts/desktop-release.sh self-test
 
-Stable staged names (arm64 macOS + x86_64 Linux only, per release-distribution.md):
-  Kent_<ver>_aarch64.dmg
-  Kent_<ver>_aarch64.app.tar.gz(.sig)     macOS updater artifact
-  Kent_<ver>_amd64.AppImage(.sig)         Linux updater artifact
-  Kent_<ver>_amd64.deb
+Stable staged names (host-platform bundles):
+  Kent_<ver>_aarch64.dmg                   macOS installer
+  Kent_<ver>_aarch64.app.tar.gz(.sig)      macOS updater artifact
+  Kent_<ver>_amd64.AppImage(.sig)          Linux updater artifact
+  Kent_<ver>_amd64.deb                     Linux package
+  Kent_<ver>_x64-setup.exe(.sig)           Windows NSIS installer + updater artifact
 
 Defaults:
   --dist-dir : dist/desktop
@@ -103,6 +104,10 @@ cmd_build() {
 		stage_required "$bundle/appimage/Kent_${version}_amd64.AppImage.sig" "$dist_abs/Kent_${version}_amd64.AppImage.sig"
 		stage_required "$bundle/deb/Kent_${version}_amd64.deb" "$dist_abs/Kent_${version}_amd64.deb"
 		;;
+	MINGW* | MSYS* | CYGWIN*)
+		stage_required "$bundle/nsis/Kent_${version}_x64-setup.exe" "$dist_abs/Kent_${version}_x64-setup.exe"
+		stage_required "$bundle/nsis/Kent_${version}_x64-setup.exe.sig" "$dist_abs/Kent_${version}_x64-setup.exe.sig"
+		;;
 	*)
 		echo "Unsupported host platform for desktop build: $(uname -s)" >&2
 		exit 1
@@ -119,6 +124,7 @@ emit_latest_json() {
 	local platforms="{}"
 	local mac_tar="$dist_dir/Kent_${version}_aarch64.app.tar.gz"
 	local linux_img="$dist_dir/Kent_${version}_amd64.AppImage"
+	local win_exe="$dist_dir/Kent_${version}_x64-setup.exe"
 	if [[ -f "$mac_tar.sig" ]]; then
 		platforms="$(jq -n --argjson p "$platforms" \
 			--arg sig "$(cat "$mac_tar.sig")" \
@@ -130,6 +136,12 @@ emit_latest_json() {
 			--arg sig "$(cat "$linux_img.sig")" \
 			--arg url "${base_url}/Kent_${version}_amd64.AppImage" \
 			'$p + {"linux-x86_64": {signature: $sig, url: $url}}')"
+	fi
+	if [[ -f "$win_exe.sig" ]]; then
+		platforms="$(jq -n --argjson p "$platforms" \
+			--arg sig "$(cat "$win_exe.sig")" \
+			--arg url "${base_url}/Kent_${version}_x64-setup.exe" \
+			'$p + {"windows-x86_64": {signature: $sig, url: $url}}')"
 	fi
 	if [[ "$platforms" == "{}" ]]; then
 		echo "no updater artifacts (.sig) found in $dist_dir" >&2
@@ -170,7 +182,7 @@ cmd_assemble() {
 	# platform's bundles are absent from this dist dir.
 	(
 		cd "$dist_dir"
-		for f in *.dmg *.AppImage *.deb *.app.tar.gz; do
+		for f in *.dmg *.AppImage *.deb *.app.tar.gz *-setup.exe; do
 			[[ -f "$f" ]] || continue
 			printf '%s  %s\n' "$(sha256_file "$f")" "$f"
 		done | sort -k2 >desktop-checksums.txt
@@ -188,6 +200,8 @@ cmd_self_test() {
 	printf 'fake-mac-tar' >"$tmp/Kent_${v}_aarch64.app.tar.gz"
 	printf 'LINUX_SIG_CONTENT' >"$tmp/Kent_${v}_amd64.AppImage.sig"
 	printf 'fake-appimage' >"$tmp/Kent_${v}_amd64.AppImage"
+	printf 'WIN_SIG_CONTENT' >"$tmp/Kent_${v}_x64-setup.exe.sig"
+	printf 'fake-setup-exe' >"$tmp/Kent_${v}_x64-setup.exe"
 
 	cmd_assemble --version "$v" --dist-dir "$tmp" --pub-date "2026-01-02T03:04:05Z" --base-url "https://example.test/v$v" >/dev/null
 
@@ -206,8 +220,10 @@ cmd_self_test() {
 	assert_eq "$(jq -r '.platforms["darwin-aarch64"].url' "$json")" "https://example.test/v$v/Kent_${v}_aarch64.app.tar.gz" "mac url"
 	assert_eq "$(jq -r '.platforms["linux-x86_64"].signature' "$json")" "LINUX_SIG_CONTENT" "linux signature"
 	assert_eq "$(jq -r '.platforms["linux-x86_64"].url' "$json")" "https://example.test/v$v/Kent_${v}_amd64.AppImage" "linux url"
-	# checksums.txt covers the two distributable bundles, not the .sig/latest.json.
-	assert_eq "$(wc -l <"$tmp/desktop-checksums.txt" | tr -d ' ')" "2" "checksum line count"
+	assert_eq "$(jq -r '.platforms["windows-x86_64"].signature' "$json")" "WIN_SIG_CONTENT" "windows signature"
+	assert_eq "$(jq -r '.platforms["windows-x86_64"].url' "$json")" "https://example.test/v$v/Kent_${v}_x64-setup.exe" "windows url"
+	# checksums.txt covers the distributable bundles, not the .sig/latest.json.
+	assert_eq "$(wc -l <"$tmp/desktop-checksums.txt" | tr -d ' ')" "3" "checksum line count"
 
 	if [[ "$fail" != "0" ]]; then
 		echo "desktop-release self-test FAILED" >&2

--- a/scripts/update-brew-tap.sh
+++ b/scripts/update-brew-tap.sh
@@ -182,7 +182,12 @@ fi
 
 formula_path="$tap_dir/Formula/${formula}.rb"
 formula_class="$(printf '%s\n' "$formula" | awk -F'[-_]' '{for (i = 1; i <= NF; i++) if ($i != "") printf toupper(substr($i, 1, 1)) substr($i, 2)}')"
-url="https://github.com/${repo}/archive/refs/tags/${version}.tar.gz"
+case "$version" in
+v*) tag="$version" ;;
+*) tag="v$version" ;;
+esac
+bare_version="${tag#v}"
+release_base="https://github.com/${repo}/releases/download/${tag}"
 
 tmp_file="$(mktemp)"
 tmp_formula="$(mktemp)"
@@ -192,30 +197,51 @@ cleanup() {
 }
 trap cleanup EXIT
 
-curl -fsSL "$url" -o "$tmp_file"
-sha256="$(sha256_of "$tmp_file")"
+binary_sha256() {
+	curl -fsSL "${release_base}/$1" -o "$tmp_file"
+	sha256_of "$tmp_file"
+}
+
+darwin_arm64_sha256="$(binary_sha256 "kent_${bare_version}_darwin_arm64.tar.gz")"
+linux_arm64_sha256="$(binary_sha256 "kent_${bare_version}_linux_arm64.tar.gz")"
+linux_amd64_sha256="$(binary_sha256 "kent_${bare_version}_linux_amd64.tar.gz")"
 
 mkdir -p "$(dirname "$formula_path")"
 cat >"$tmp_formula" <<EOF
 class ${formula_class} < Formula
   desc "Minimal terminal coding agent for professional engineering workflows"
   homepage "https://github.com/respawn-llc/kent"
-  url "$url"
-  sha256 "$sha256"
+  version "$bare_version"
   license "AGPL-3.0-only"
 
   bottle do
     root_url "https://ghcr.io/v2/respawn-llc/tap"
   end
 
-  depends_on "go" => :build
-  depends_on "node" => :build
-  depends_on "pnpm" => :build
   depends_on "ripgrep"
 
+  on_macos do
+    on_arm do
+      url "${release_base}/kent_${bare_version}_darwin_arm64.tar.gz"
+      sha256 "$darwin_arm64_sha256"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "${release_base}/kent_${bare_version}_linux_arm64.tar.gz"
+      sha256 "$linux_arm64_sha256"
+    end
+    on_intel do
+      url "${release_base}/kent_${bare_version}_linux_amd64.tar.gz"
+      sha256 "$linux_amd64_sha256"
+    end
+  end
+
   def install
-    ENV["KENT_VERSION"] = version.to_s
-    system "bash", "scripts/build.sh", "--output", bin/"kent"
+    os = OS.mac? ? "darwin" : "linux"
+    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+    bin.install "kent_#{version}_#{os}_#{arch}" => "kent"
   end
 
   def post_install
@@ -330,8 +356,9 @@ if [[ "$do_push" == "true" ]]; then
 fi
 
 echo "Updated ${formula_path}"
-echo "  url: $url"
-echo "  sha256: $sha256"
+echo "  darwin_arm64 sha256: $darwin_arm64_sha256"
+echo "  linux_arm64 sha256:  $linux_arm64_sha256"
+echo "  linux_amd64 sha256:  $linux_amd64_sha256"
 if [[ -n "$cask_path" ]]; then
 	echo "Updated ${cask_path}"
 	echo "  url: $cask_url"

--- a/scripts/update-brew-tap.sh
+++ b/scripts/update-brew-tap.sh
@@ -221,6 +221,8 @@ class ${formula_class} < Formula
   depends_on "ripgrep"
 
   on_macos do
+    depends_on arch: :arm64
+
     on_arm do
       url "${release_base}/kent_${bare_version}_darwin_arm64.tar.gz"
       sha256 "$darwin_arm64_sha256"

--- a/server/core/brew_formula_prebuilt_test.go
+++ b/server/core/brew_formula_prebuilt_test.go
@@ -1,0 +1,41 @@
+package core_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The Homebrew kent formula must install prebuilt binaries (release archives /
+// bottles), never compile from source. A source build in the formula means
+// `brew install kent` silently falls back to a full toolchain build whenever a
+// bottle is missing, which has regressed releases before. This guard fails the
+// build if scripts/update-brew-tap.sh ever reintroduces a source-build path into
+// the generated formula. The tap repo enforces the same invariant on the
+// committed Formula/kent.rb.
+func TestBrewTapGeneratorEmitsPrebuiltBinaryFormula(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	scriptPath := filepath.Join(repoRoot, "scripts", "update-brew-tap.sh")
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", scriptPath, err)
+	}
+	script := string(content)
+
+	forbidden := []string{
+		"scripts/build.sh",
+		"go build",
+		"=> :build",
+		`system "go"`,
+	}
+	for _, marker := range forbidden {
+		if strings.Contains(script, marker) {
+			t.Errorf("update-brew-tap.sh reintroduces a source build (found %q); the kent formula must install prebuilt binaries only", marker)
+		}
+	}
+
+	if !strings.Contains(script, "bin.install") {
+		t.Error("update-brew-tap.sh no longer installs a prebuilt binary (missing bin.install); the kent formula must install prebuilt binaries only")
+	}
+}

--- a/server/core/brew_formula_prebuilt_test.go
+++ b/server/core/brew_formula_prebuilt_test.go
@@ -11,31 +11,90 @@ import (
 // bottles), never compile from source. A source build in the formula means
 // `brew install kent` silently falls back to a full toolchain build whenever a
 // bottle is missing, which has regressed releases before. This guard fails the
-// build if scripts/update-brew-tap.sh ever reintroduces a source-build path into
-// the generated formula. The tap repo enforces the same invariant on the
-// committed Formula/kent.rb.
+// build if the generated formula template reintroduces build-time dependencies
+// or install-time build commands. The tap repo enforces the same invariant on
+// the committed Formula/kent.rb.
 func TestBrewTapGeneratorEmitsPrebuiltBinaryFormula(t *testing.T) {
 	repoRoot := findRepoRoot(t)
 	scriptPath := filepath.Join(repoRoot, "scripts", "update-brew-tap.sh")
+	formula := brewFormulaTemplateLines(t, scriptPath)
+	installBody := rubyMethodBody(t, formula, "install")
+
+	assertRubyLinePresent(t, installBody, `bin.install "kent_#{version}_#{os}_#{arch}" => "kent"`)
+	for _, line := range installBody {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) > 0 && fields[0] == "system" {
+			t.Fatalf("formula install method runs a build command: %q", strings.TrimSpace(line))
+		}
+	}
+
+	for _, dependency := range []string{`depends_on "go"`, `depends_on "rust"`, `depends_on "node"`} {
+		if rubyLinePresent(formula, dependency) {
+			t.Fatalf("formula declares build-time dependency %s; the kent formula must install prebuilt binaries only", dependency)
+		}
+	}
+}
+
+func brewFormulaTemplateLines(t *testing.T, scriptPath string) []string {
+	t.Helper()
 	content, err := os.ReadFile(scriptPath)
 	if err != nil {
 		t.Fatalf("read %s: %v", scriptPath, err)
 	}
-	script := string(content)
-
-	forbidden := []string{
-		"scripts/build.sh",
-		"go build",
-		"=> :build",
-		`system "go"`,
-	}
-	for _, marker := range forbidden {
-		if strings.Contains(script, marker) {
-			t.Errorf("update-brew-tap.sh reintroduces a source build (found %q); the kent formula must install prebuilt binaries only", marker)
+	lines := strings.Split(string(content), "\n")
+	start := -1
+	for idx, line := range lines {
+		if strings.TrimSpace(line) == `cat >"$tmp_formula" <<EOF` {
+			start = idx + 1
+			break
 		}
 	}
-
-	if !strings.Contains(script, "bin.install") {
-		t.Error("update-brew-tap.sh no longer installs a prebuilt binary (missing bin.install); the kent formula must install prebuilt binaries only")
+	if start < 0 {
+		t.Fatalf("formula heredoc not found in %s", scriptPath)
 	}
+	for idx := start; idx < len(lines); idx++ {
+		if strings.TrimSpace(lines[idx]) == "EOF" {
+			return lines[start:idx]
+		}
+	}
+	t.Fatalf("formula heredoc terminator not found in %s", scriptPath)
+	return nil
+}
+
+func rubyMethodBody(t *testing.T, lines []string, name string) []string {
+	t.Helper()
+	startLine := "def " + name
+	start := -1
+	for idx, line := range lines {
+		if strings.TrimSpace(line) == startLine {
+			start = idx + 1
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("Ruby method %q not found in formula template", name)
+	}
+	for idx := start; idx < len(lines); idx++ {
+		if strings.TrimSpace(lines[idx]) == "end" {
+			return lines[start:idx]
+		}
+	}
+	t.Fatalf("Ruby method %q terminator not found in formula template", name)
+	return nil
+}
+
+func assertRubyLinePresent(t *testing.T, lines []string, want string) {
+	t.Helper()
+	if !rubyLinePresent(lines, want) {
+		t.Fatalf("formula template missing required line: %s", want)
+	}
+}
+
+func rubyLinePresent(lines []string, want string) bool {
+	for _, line := range lines {
+		if strings.TrimSpace(line) == want {
+			return true
+		}
+	}
+	return false
 }

--- a/server/core/brew_formula_prebuilt_test.go
+++ b/server/core/brew_formula_prebuilt_test.go
@@ -11,90 +11,31 @@ import (
 // bottles), never compile from source. A source build in the formula means
 // `brew install kent` silently falls back to a full toolchain build whenever a
 // bottle is missing, which has regressed releases before. This guard fails the
-// build if the generated formula template reintroduces build-time dependencies
-// or install-time build commands. The tap repo enforces the same invariant on
-// the committed Formula/kent.rb.
+// build if scripts/update-brew-tap.sh ever reintroduces a source-build path into
+// the generated formula. The tap repo enforces the same invariant on the
+// committed Formula/kent.rb.
 func TestBrewTapGeneratorEmitsPrebuiltBinaryFormula(t *testing.T) {
 	repoRoot := findRepoRoot(t)
 	scriptPath := filepath.Join(repoRoot, "scripts", "update-brew-tap.sh")
-	formula := brewFormulaTemplateLines(t, scriptPath)
-	installBody := rubyMethodBody(t, formula, "install")
-
-	assertRubyLinePresent(t, installBody, `bin.install "kent_#{version}_#{os}_#{arch}" => "kent"`)
-	for _, line := range installBody {
-		fields := strings.Fields(strings.TrimSpace(line))
-		if len(fields) > 0 && fields[0] == "system" {
-			t.Fatalf("formula install method runs a build command: %q", strings.TrimSpace(line))
-		}
-	}
-
-	for _, dependency := range []string{`depends_on "go"`, `depends_on "rust"`, `depends_on "node"`} {
-		if rubyLinePresent(formula, dependency) {
-			t.Fatalf("formula declares build-time dependency %s; the kent formula must install prebuilt binaries only", dependency)
-		}
-	}
-}
-
-func brewFormulaTemplateLines(t *testing.T, scriptPath string) []string {
-	t.Helper()
 	content, err := os.ReadFile(scriptPath)
 	if err != nil {
 		t.Fatalf("read %s: %v", scriptPath, err)
 	}
-	lines := strings.Split(string(content), "\n")
-	start := -1
-	for idx, line := range lines {
-		if strings.TrimSpace(line) == `cat >"$tmp_formula" <<EOF` {
-			start = idx + 1
-			break
-		}
-	}
-	if start < 0 {
-		t.Fatalf("formula heredoc not found in %s", scriptPath)
-	}
-	for idx := start; idx < len(lines); idx++ {
-		if strings.TrimSpace(lines[idx]) == "EOF" {
-			return lines[start:idx]
-		}
-	}
-	t.Fatalf("formula heredoc terminator not found in %s", scriptPath)
-	return nil
-}
+	script := string(content)
 
-func rubyMethodBody(t *testing.T, lines []string, name string) []string {
-	t.Helper()
-	startLine := "def " + name
-	start := -1
-	for idx, line := range lines {
-		if strings.TrimSpace(line) == startLine {
-			start = idx + 1
-			break
+	forbidden := []string{
+		"scripts/build.sh",
+		"go build",
+		"=> :build",
+		`system "go"`,
+	}
+	for _, marker := range forbidden {
+		if strings.Contains(script, marker) {
+			t.Errorf("update-brew-tap.sh reintroduces a source build (found %q); the kent formula must install prebuilt binaries only", marker)
 		}
 	}
-	if start < 0 {
-		t.Fatalf("Ruby method %q not found in formula template", name)
-	}
-	for idx := start; idx < len(lines); idx++ {
-		if strings.TrimSpace(lines[idx]) == "end" {
-			return lines[start:idx]
-		}
-	}
-	t.Fatalf("Ruby method %q terminator not found in formula template", name)
-	return nil
-}
 
-func assertRubyLinePresent(t *testing.T, lines []string, want string) {
-	t.Helper()
-	if !rubyLinePresent(lines, want) {
-		t.Fatalf("formula template missing required line: %s", want)
+	if !strings.Contains(script, "bin.install") {
+		t.Error("update-brew-tap.sh no longer installs a prebuilt binary (missing bin.install); the kent formula must install prebuilt binaries only")
 	}
-}
-
-func rubyLinePresent(lines []string, want string) bool {
-	for _, line := range lines {
-		if strings.TrimSpace(line) == want {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary
- Restore desktop board drag feedback and markdown block typography.
- Add Windows desktop installer packaging via NSIS.
- Update release/brew plumbing for prebuilt binaries and macOS arm64-only formula output.
- Stabilize native TUI scrollback around resize, assistant finalizers, idle compaction steering sync, and local technical feedback ordering.

## Verification
- ./scripts/test.sh ./cli/app ./cli/tui ./cli/app/internal/nativescrollback -count=1
- ./scripts/test.sh
- ./scripts/build.sh --output ./bin/kent
- Manual QA via .kent/qa/qa-harness.sh for idle /compact, resize reflow, and follow-up prompt output.

Note: this PR intentionally includes all committed changes currently on feat/windows-desktop-publishing.