### PR TITLE
feat: add Windows acrylic window backdrop

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -136,7 +136,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", windows))]
             if let Some(window) = app.get_webview_window("main") {
                 if let Err(error) = native_glass::apply_to_window_now(&window) {
                     eprintln!("Apply native window glass failed: {error}");

--- a/apps/desktop/src-tauri/src/native_glass.rs
+++ b/apps/desktop/src-tauri/src/native_glass.rs
@@ -327,7 +327,99 @@ mod platform {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(windows)]
+mod platform {
+    use tauri::window::{Color, Effect, EffectsBuilder};
+    use tauri::{Manager, Runtime, WebviewWindow};
+
+    const ACRYLIC_EFFECT_NAME: &str = "windowEffect.acrylic";
+
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase", tag = "status")]
+    pub enum NativeGlassStatus {
+        Applied { effect: &'static str },
+    }
+
+    #[derive(Clone, Copy, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct NativeGlassTint {
+        red: f64,
+        green: f64,
+        blue: f64,
+        alpha: f64,
+    }
+
+    pub async fn apply_to_label<R: Runtime>(
+        app: tauri::AppHandle<R>,
+        label: String,
+    ) -> Result<NativeGlassStatus, String> {
+        let window = app
+            .get_webview_window(&label)
+            .ok_or_else(|| format!("Window '{label}' was not found."))?;
+        apply_acrylic(&window, None)
+    }
+
+    pub async fn set_tint_for_label<R: Runtime>(
+        app: tauri::AppHandle<R>,
+        label: String,
+        tint: Option<NativeGlassTint>,
+    ) -> Result<NativeGlassStatus, String> {
+        let window = app
+            .get_webview_window(&label)
+            .ok_or_else(|| format!("Window '{label}' was not found."))?;
+        apply_acrylic(&window, tint)
+    }
+
+    pub fn apply_to_window_now<R: Runtime>(
+        window: &WebviewWindow<R>,
+    ) -> Result<NativeGlassStatus, String> {
+        apply_acrylic(window, None)
+    }
+
+    fn apply_acrylic<R: Runtime>(
+        window: &WebviewWindow<R>,
+        tint: Option<NativeGlassTint>,
+    ) -> Result<NativeGlassStatus, String> {
+        let mut effects = EffectsBuilder::new().effect(Effect::Acrylic);
+        if let Some(tint) = tint {
+            effects = effects.color(native_acrylic_color(tint));
+        }
+        window
+            .set_effects(effects.build())
+            .map_err(|error| format!("Apply Windows acrylic failed: {error}"))?;
+        Ok(NativeGlassStatus::Applied {
+            effect: ACRYLIC_EFFECT_NAME,
+        })
+    }
+
+    fn native_acrylic_color(tint: NativeGlassTint) -> Color {
+        Color(
+            channel_to_u8(tint.red),
+            channel_to_u8(tint.green),
+            channel_to_u8(tint.blue),
+            channel_to_u8(tint.alpha),
+        )
+    }
+
+    fn channel_to_u8(value: f64) -> u8 {
+        (value.clamp(0.0, 1.0) * 255.0).round() as u8
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn maps_tint_channels_to_bytes() {
+            assert_eq!(channel_to_u8(-1.0), 0);
+            assert_eq!(channel_to_u8(0.0), 0);
+            assert_eq!(channel_to_u8(1.0), 255);
+            assert_eq!(channel_to_u8(2.0), 255);
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", windows)))]
 mod platform {
     use tauri::Runtime;
 
@@ -355,7 +447,7 @@ mod platform {
         _label: String,
     ) -> Result<NativeGlassStatus, String> {
         Ok(NativeGlassStatus::Unsupported {
-            reason: "Native Liquid Glass is only available on macOS.",
+            reason: "Native window blur is unavailable on this platform.",
         })
     }
 
@@ -365,11 +457,11 @@ mod platform {
         _tint: Option<NativeGlassTint>,
     ) -> Result<NativeGlassStatus, String> {
         Ok(NativeGlassStatus::Unsupported {
-            reason: "Native Liquid Glass is only available on macOS.",
+            reason: "Native window blur is unavailable on this platform.",
         })
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", windows))]
 pub use platform::apply_to_window_now;
 pub use platform::{apply_to_label, set_tint_for_label, NativeGlassStatus, NativeGlassTint};

--- a/apps/desktop/src/app/nativeWindowGlassTint.tsx
+++ b/apps/desktop/src/app/nativeWindowGlassTint.tsx
@@ -8,7 +8,8 @@ const windowGlassFillClassName = "window-glass-fill";
 
 export function useNativeWindowGlassTintSync(nativeBridge: NativeBridge): void {
   useEffect(() => {
-    if (nativeBridge.capabilities.platform !== "macos" || typeof document === "undefined") {
+    const platform = nativeBridge.capabilities.platform;
+    if ((platform !== "macos" && platform !== "windows") || typeof document === "undefined") {
       return;
     }
 


### PR DESCRIPTION
Closes #428 (BUI-135).

## Problem
On Windows the desktop window rendered fully transparent — it showed the desktop straight through. Root cause: the window is forced `transparent: true` on every platform, but the only code that supplies a native backdrop (`native_glass.rs`) was `#[cfg(target_os = "macos")]` only; the non-macOS branch was an `Unsupported` no-op. CSS `backdrop-filter` can't fill a transparent OS window — that needs the compositor.

## Change
- `native_glass.rs`: new `#[cfg(windows)]` branch that applies a native Windows acrylic backdrop via Tauri's built-in `WebviewWindow::set_effects(EffectsBuilder::new().effect(Effect::Acrylic).color(..))`. No new dependency — uses the `window-vibrancy` that Tauri already vendors, reached through Tauri's own API. The old non-macOS stub is narrowed to `not(any(macos, windows))` (Linux/other, where the compositor owns blur).
- `lib.rs`: the startup backdrop hook now runs on `any(macos, windows)`, so Windows gets acrylic at launch (no transparent flash).
- `nativeWindowGlassTint.tsx`: the theme-aware tint-sync hook (was macOS-only) now also runs on Windows, re-applying the acrylic tint on light/dark switch via the existing `set_native_window_glass_tint` path.

The CSS prerequisites Tauri requires (`transparent: true`, `html, body, #root { background: transparent }`) were already in place.

## Verification
- Host `cargo check`, frontend typecheck, `pnpm lint`, unit tests, and `pnpm build` all pass; `Cargo.toml`/`Cargo.lock` untouched.
- The `#[cfg(windows)]` module could **not** be compiled on the dev machine (macOS, Homebrew Rust, no Windows target). It's written against the verified Tauri 2.11 API but **needs a Windows 11 build to confirm visually**.

Out of scope: the separate Windows titlebar discussion — left unchanged.