### PR TITLE
fix: refresh launchd service restart

### DIFF
--- a/cli/kent/service_backend_darwin.go
+++ b/cli/kent/service_backend_darwin.go
@@ -65,23 +65,9 @@ func (launchdServiceBackend) Name() string {
 }
 
 func (launchdServiceBackend) Install(ctx context.Context, spec serviceSpec, force bool, start bool) error {
-	if err := ensureServiceLogDir(spec); err != nil {
-		return err
-	}
-	path, err := launchdPlistPath()
+	path, err := writeLaunchdServicePlist(spec, force)
 	if err != nil {
 		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create LaunchAgents dir: %w", err)
-	}
-	if !force {
-		if existing, err := os.ReadFile(path); err == nil && !bytes.Equal(existing, []byte(renderLaunchdPlist(spec))) {
-			return fmt.Errorf(brand.ServiceDisplayName+" is already installed at %s; use --force to rewrite it", path)
-		}
-	}
-	if err := os.WriteFile(path, []byte(renderLaunchdPlist(spec)), 0o644); err != nil {
-		return fmt.Errorf("write launchd plist: %w", err)
 	}
 	if start {
 		if err := reloadLaunchdService(ctx, spec, path); err != nil {
@@ -89,6 +75,28 @@ func (launchdServiceBackend) Install(ctx context.Context, spec serviceSpec, forc
 		}
 	}
 	return nil
+}
+
+func writeLaunchdServicePlist(spec serviceSpec, force bool) (string, error) {
+	if err := ensureServiceLogDir(spec); err != nil {
+		return "", err
+	}
+	path, err := launchdPlistPath()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("create LaunchAgents dir: %w", err)
+	}
+	if !force {
+		if existing, err := os.ReadFile(path); err == nil && !bytes.Equal(existing, []byte(renderLaunchdPlist(spec))) {
+			return "", fmt.Errorf(brand.ServiceDisplayName+" is already installed at %s; use --force to rewrite it", path)
+		}
+	}
+	if err := os.WriteFile(path, []byte(renderLaunchdPlist(spec)), 0o644); err != nil {
+		return "", fmt.Errorf("write launchd plist: %w", err)
+	}
+	return path, nil
 }
 
 func (launchdServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop bool) error {
@@ -142,8 +150,9 @@ func (launchdServiceBackend) Restart(ctx context.Context, spec serviceSpec) erro
 		}
 		return fmt.Errorf("stat launchd plist: %w", err)
 	}
-	if loaded, _ := launchdLoaded(ctx); !loaded {
-		return reloadLaunchdService(ctx, spec, path)
+	path, err = writeLaunchdServicePlist(spec, true)
+	if err != nil {
+		return err
 	}
 	return reloadLaunchdService(ctx, spec, path)
 }
@@ -179,7 +188,6 @@ func (launchdServiceBackend) Status(ctx context.Context, spec serviceSpec) (serv
 }
 
 func reloadLaunchdService(ctx context.Context, spec serviceSpec, path string) error {
-	verifyStartup := false
 	if loaded, _ := launchdLoaded(ctx); loaded {
 		if _, err := runServiceCommand(ctx, "launchctl", "bootout", fmt.Sprintf("gui/%d", os.Getuid())+"/"+serviceLaunchdLabel); err != nil {
 			return err
@@ -189,22 +197,19 @@ func reloadLaunchdService(ctx context.Context, spec serviceSpec, path string) er
 			if stopErr != nil {
 				return errors.Join(err, stopErr)
 			}
-			verifyStartup = stopped
+			if !stopped {
+				return err
+			}
 		}
 	} else {
-		stopped, err := stopHealthyServerBeforeLaunchdBootstrap(ctx, spec)
-		if err != nil {
+		if _, err := stopHealthyServerBeforeLaunchdBootstrap(ctx, spec); err != nil {
 			return err
 		}
-		verifyStartup = stopped
 	}
 	if err := bootstrapLaunchdService(ctx, spec, path); err != nil {
 		return err
 	}
-	if verifyStartup {
-		return waitForLaunchdServiceStartup(ctx, spec)
-	}
-	return nil
+	return waitForLaunchdServiceStartup(ctx, spec)
 }
 
 func stopHealthyServerBeforeLaunchdBootstrap(ctx context.Context, spec serviceSpec) (bool, error) {
@@ -274,12 +279,27 @@ func waitForLaunchdServiceStartup(ctx context.Context, spec serviceSpec) error {
 	for {
 		loaded, output := launchdLoaded(ctx)
 		launchdPID := launchdPID(output)
+		loadedCommand := parseLaunchdPrintProgramArguments(output)
 		healthStatus, healthPID := probeServiceHealth(ctx, spec)
-		healthOwnedByLaunchd := healthStatus == "ok" && (healthPID == 0 || healthPID == launchdPID)
-		if loaded && launchdPID > 0 && healthOwnedByLaunchd {
+		healthOwnedByLaunchd := healthStatus == "ok" && launchdPID > 0 && healthPID == launchdPID
+		commandVerified := commandArgsEqual(loadedCommand, serviceCommand(spec))
+		if loaded && launchdPID > 0 && healthOwnedByLaunchd && commandVerified {
 			return nil
 		}
-		lastDetail = fmt.Sprintf("launchd loaded=%t pid=%d state=%s health=%s health_pid=%d", loaded, launchdPID, launchdState(output), healthStatus, healthPID)
+		commandDetail := commandString(loadedCommand)
+		if len(loadedCommand) == 0 {
+			commandDetail = "<missing>"
+		}
+		lastDetail = fmt.Sprintf(
+			"launchd loaded=%t pid=%d state=%s command=%s expected_command=%s health=%s health_pid=%d",
+			loaded,
+			launchdPID,
+			launchdState(output),
+			commandDetail,
+			commandString(serviceCommand(spec)),
+			healthStatus,
+			healthPID,
+		)
 		if time.Now().After(deadline) {
 			return fmt.Errorf("%w: %s", errLaunchdServerNotHealthy, lastDetail)
 		}

--- a/cli/kent/service_backend_darwin.go
+++ b/cli/kent/service_backend_darwin.go
@@ -88,12 +88,20 @@ func writeLaunchdServicePlist(spec serviceSpec, force bool) (string, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", fmt.Errorf("create LaunchAgents dir: %w", err)
 	}
+	rendered := []byte(renderLaunchdPlist(spec))
 	if !force {
-		if existing, err := os.ReadFile(path); err == nil && !bytes.Equal(existing, []byte(renderLaunchdPlist(spec))) {
-			return "", fmt.Errorf(brand.ServiceDisplayName+" is already installed at %s; use --force to rewrite it", path)
+		existing, err := os.ReadFile(path)
+		switch {
+		case err == nil:
+			if !bytes.Equal(existing, rendered) {
+				return "", fmt.Errorf(brand.ServiceDisplayName+" is already installed at %s; use --force to rewrite it", path)
+			}
+		case errors.Is(err, os.ErrNotExist):
+		default:
+			return "", fmt.Errorf("read launchd plist: %w", err)
 		}
 	}
-	if err := os.WriteFile(path, []byte(renderLaunchdPlist(spec)), 0o644); err != nil {
+	if err := os.WriteFile(path, rendered, 0o644); err != nil {
 		return "", fmt.Errorf("write launchd plist: %w", err)
 	}
 	return path, nil

--- a/cli/kent/service_backend_darwin_restart_test.go
+++ b/cli/kent/service_backend_darwin_restart_test.go
@@ -1,0 +1,280 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLaunchdRestartRefreshesStaleLoadedCommandBeforeBootstrap(t *testing.T) {
+	withFastLaunchdShutdownPolling(t)
+	spec := newLaunchdTestSpec(t)
+	spec.Executable = "/new/kent"
+	bootstrapped := false
+	server := newLaunchdHealthTestServer(t, func() (string, int) {
+		if bootstrapped {
+			return `{"status":"ok","pid":77}`, http.StatusOK
+		}
+		return "stopped", http.StatusServiceUnavailable
+	})
+	spec.Endpoint = server.URL
+	oldCommand := append([]string{"/old/kent"}, spec.Arguments...)
+	path := writeLaunchdTestPlistWithCommand(t, spec, oldCommand)
+	var calls *[][]string
+	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch strings.Join(append([]string{name}, args...), "\x00") {
+		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			if bootstrapped {
+				return serviceCommandResult{Stdout: launchdPrintOutput(77, readLaunchdRegisteredCommand(path))}, nil
+			}
+			if countLaunchdCommand(*calls, "bootout") > 0 {
+				return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
+			}
+			return serviceCommandResult{Stdout: launchdPrintOutput(42, oldCommand)}, nil
+		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			return serviceCommandResult{}, nil
+		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
+			if command := readLaunchdRegisteredCommand(path); !reflect.DeepEqual(command, serviceCommand(spec)) {
+				t.Fatalf("bootstrap read command %#v, want refreshed %#v", command, serviceCommand(spec))
+			}
+			bootstrapped = true
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	if err := (launchdServiceBackend{}).Restart(context.Background(), spec); err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	status, err := (launchdServiceBackend{}).Status(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !reflect.DeepEqual(status.Command, serviceCommand(spec)) {
+		t.Fatalf("status command = %#v, want %#v", status.Command, serviceCommand(spec))
+	}
+	if countLaunchdCommand(*calls, "bootstrap") != 1 {
+		t.Fatalf("calls = %#v, want one bootstrap", *calls)
+	}
+}
+
+func TestLaunchdRestartIfInstalledRefreshesStaleLoadedCommandBeforeBootstrap(t *testing.T) {
+	withFastLaunchdShutdownPolling(t)
+	bootstrapped := false
+	server := newLaunchdHealthTestServer(t, func() (string, int) {
+		if bootstrapped {
+			return `{"status":"ok","pid":77}`, http.StatusOK
+		}
+		return "starting", http.StatusServiceUnavailable
+	})
+	spec := newLaunchdTestSpec(t)
+	spec.Executable = "/new/kent"
+	spec.Endpoint = server.URL
+	withLaunchdServiceCommandSpec(t, spec)
+	oldCommand := append([]string{"/old/kent"}, spec.Arguments...)
+	path := writeLaunchdTestPlistWithCommand(t, spec, oldCommand)
+	var calls *[][]string
+	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch strings.Join(append([]string{name}, args...), "\x00") {
+		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			if bootstrapped {
+				return serviceCommandResult{Stdout: launchdPrintOutput(77, readLaunchdRegisteredCommand(path))}, nil
+			}
+			if countLaunchdCommand(*calls, "bootout") > 0 {
+				return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
+			}
+			return serviceCommandResult{Stdout: launchdPrintOutput(42, oldCommand)}, nil
+		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			return serviceCommandResult{}, nil
+		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
+			if command := readLaunchdRegisteredCommand(path); !reflect.DeepEqual(command, serviceCommand(spec)) {
+				t.Fatalf("bootstrap read command %#v, want refreshed %#v", command, serviceCommand(spec))
+			}
+			bootstrapped = true
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	code := serviceSubcommand([]string{"restart", "--if-installed"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	status, err := (launchdServiceBackend{}).Status(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !reflect.DeepEqual(status.Command, serviceCommand(spec)) {
+		t.Fatalf("status command = %#v, want %#v", status.Command, serviceCommand(spec))
+	}
+	if countLaunchdCommand(*calls, "bootstrap") != 1 {
+		t.Fatalf("calls = %#v, want one bootstrap", *calls)
+	}
+	if !strings.Contains(stdout.String(), "Restarted "+serviceDisplayName) {
+		t.Fatalf("stdout = %q, want restart confirmation", stdout.String())
+	}
+}
+
+func TestLaunchdRestartRejectsLoadedCommandSkewAfterBootstrap(t *testing.T) {
+	withFastLaunchdShutdownPolling(t)
+	bootstrapped := false
+	server := newLaunchdHealthTestServer(t, func() (string, int) {
+		if bootstrapped {
+			return `{"status":"ok","pid":77}`, http.StatusOK
+		}
+		return "starting", http.StatusServiceUnavailable
+	})
+	spec := newLaunchdTestSpec(t)
+	spec.Executable = "/new/kent"
+	spec.Endpoint = server.URL
+	path := writeLaunchdTestPlist(t, spec)
+	oldCommand := append([]string{"/old/kent"}, spec.Arguments...)
+	var calls *[][]string
+	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch strings.Join(append([]string{name}, args...), "\x00") {
+		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			if bootstrapped {
+				return serviceCommandResult{Stdout: launchdPrintOutput(77, oldCommand)}, nil
+			}
+			if countLaunchdCommand(*calls, "bootout") > 0 {
+				return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
+			}
+			return serviceCommandResult{Stdout: launchdPrintOutput(42, oldCommand)}, nil
+		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			return serviceCommandResult{}, nil
+		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
+			bootstrapped = true
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	err := (launchdServiceBackend{}).Restart(context.Background(), spec)
+	if err == nil {
+		t.Fatal("expected restart to reject loaded command skew")
+	}
+	if !errors.Is(err, errLaunchdServerNotHealthy) {
+		t.Fatalf("error = %v, want startup verification failure", err)
+	}
+}
+
+func TestLaunchdRestartWaitsForHealthToBelongToNewLaunchdPID(t *testing.T) {
+	withFastLaunchdShutdownPolling(t)
+	bootout := false
+	bootstrapped := false
+	postBootstrapHealthRequests := 0
+	server := newLaunchdHealthTestServer(t, func() (string, int) {
+		switch {
+		case bootstrapped:
+			postBootstrapHealthRequests++
+			if postBootstrapHealthRequests == 1 {
+				return `{"status":"ok","pid":42}`, http.StatusOK
+			}
+			return `{"status":"ok","pid":77}`, http.StatusOK
+		case bootout:
+			return "stopped", http.StatusServiceUnavailable
+		default:
+			return `{"status":"ok","pid":42}`, http.StatusOK
+		}
+	})
+	spec := newLaunchdTestSpec(t)
+	spec.Endpoint = server.URL
+	path := writeLaunchdTestPlist(t, spec)
+	var calls *[][]string
+	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch strings.Join(append([]string{name}, args...), "\x00") {
+		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			if bootstrapped {
+				return serviceCommandResult{Stdout: launchdPrintOutput(77, serviceCommand(spec))}, nil
+			}
+			if bootout {
+				return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
+			}
+			return serviceCommandResult{Stdout: launchdPrintOutput(42, serviceCommand(spec))}, nil
+		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			bootout = true
+			return serviceCommandResult{}, nil
+		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
+			bootstrapped = true
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	if err := (launchdServiceBackend{}).Restart(context.Background(), spec); err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	if postBootstrapHealthRequests < 2 {
+		t.Fatalf("post-bootstrap health requests = %d, want retry until health pid belongs to launchd pid 77; calls=%#v", postBootstrapHealthRequests, *calls)
+	}
+}
+
+func TestLaunchdRestartRejectsOldHealthPIDAfterBootstrap(t *testing.T) {
+	originalTimeout := launchdServiceShutdownTimeout
+	originalInterval := launchdServiceShutdownPollInterval
+	launchdServiceShutdownTimeout = time.Millisecond
+	launchdServiceShutdownPollInterval = time.Millisecond
+	t.Cleanup(func() {
+		launchdServiceShutdownTimeout = originalTimeout
+		launchdServiceShutdownPollInterval = originalInterval
+	})
+	bootout := false
+	bootstrapped := false
+	server := newLaunchdHealthTestServer(t, func() (string, int) {
+		switch {
+		case bootstrapped:
+			return `{"status":"ok","pid":42}`, http.StatusOK
+		case bootout:
+			return "stopped", http.StatusServiceUnavailable
+		default:
+			return `{"status":"ok","pid":42}`, http.StatusOK
+		}
+	})
+	spec := newLaunchdTestSpec(t)
+	spec.Endpoint = server.URL
+	path := writeLaunchdTestPlist(t, spec)
+	var calls *[][]string
+	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch strings.Join(append([]string{name}, args...), "\x00") {
+		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			if bootstrapped {
+				return serviceCommandResult{Stdout: launchdPrintOutput(77, serviceCommand(spec))}, nil
+			}
+			if bootout {
+				return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
+			}
+			return serviceCommandResult{Stdout: launchdPrintOutput(42, serviceCommand(spec))}, nil
+		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			bootout = true
+			return serviceCommandResult{}, nil
+		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
+			bootstrapped = true
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	err := (launchdServiceBackend{}).Restart(context.Background(), spec)
+	if err == nil {
+		t.Fatal("expected restart to reject old endpoint owner")
+	}
+	if !errors.Is(err, errLaunchdServerNotHealthy) {
+		t.Fatalf("error = %v, want startup verification failure", err)
+	}
+	if countLaunchdCommand(*calls, "bootstrap") != 1 {
+		t.Fatalf("calls = %#v, want one bootstrap", *calls)
+	}
+}

--- a/cli/kent/service_backend_darwin_test.go
+++ b/cli/kent/service_backend_darwin_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -89,6 +90,36 @@ func TestLaunchdInstallReloadsLoadedServiceBeforeBootstrap(t *testing.T) {
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("calls = %#v, want %#v", *calls, want)
+	}
+}
+
+func TestLaunchdInstallFailsClosedWhenExistingPlistCannotBeRead(t *testing.T) {
+	spec := newLaunchdTestSpec(t)
+	path := mustLaunchdPlistPath(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir launch agents: %v", err)
+	}
+	original := []byte("unreadable existing plist")
+	if err := os.WriteFile(path, original, 0o200); err != nil {
+		t.Fatalf("write unreadable plist: %v", err)
+	}
+
+	err := (launchdServiceBackend{}).Install(context.Background(), spec, false, false)
+	if err == nil {
+		t.Fatal("expected install to fail when existing plist cannot be read")
+	}
+	if !strings.Contains(err.Error(), "read launchd plist") {
+		t.Fatalf("error = %v, want read failure", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatalf("restore plist permissions: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read preserved plist: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("plist was overwritten despite unreadable existing registration")
 	}
 }
 

--- a/cli/kent/service_backend_darwin_test.go
+++ b/cli/kent/service_backend_darwin_test.go
@@ -41,21 +41,35 @@ func newLaunchdHealthTestServer(t *testing.T, health func() (string, int)) *http
 func TestLaunchdInstallReloadsLoadedServiceBeforeBootstrap(t *testing.T) {
 	withFastLaunchdShutdownPolling(t)
 	spec := newLaunchdTestSpec(t)
+	bootout := false
+	bootstrapped := false
+	server := newLaunchdHealthTestServer(t, func() (string, int) {
+		if bootstrapped {
+			return `{"status":"ok","pid":77}`, http.StatusOK
+		}
+		return "stopped", http.StatusServiceUnavailable
+	})
+	spec.Endpoint = server.URL
 	var calls *[][]string
 	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
 		switch strings.Join(append([]string{name}, args...), "\x00") {
 		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
 			// launchd reports the job loaded until bootout has fully evicted it.
-			if countLaunchdCommand(*calls, "bootout") > 0 {
+			if bootstrapped {
+				return serviceCommandResult{Stdout: launchdPrintOutput(77, serviceCommand(spec))}, nil
+			}
+			if bootout {
 				return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
 			}
-			return serviceCommandResult{Stdout: "state = running\npid = 42\n"}, nil
+			return serviceCommandResult{Stdout: launchdPrintOutput(42, serviceCommand(spec))}, nil
 		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			bootout = true
 			return serviceCommandResult{}, nil
 		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + mustLaunchdPlistPath(t):
 			if countLaunchdCommand(*calls, "print") < 2 {
 				t.Fatalf("bootstrap happened before launchd evicted the old job, calls=%#v", *calls)
 			}
+			bootstrapped = true
 			return serviceCommandResult{}, nil
 		default:
 			return serviceCommandResult{}, errors.New("unexpected command")
@@ -71,6 +85,7 @@ func TestLaunchdInstallReloadsLoadedServiceBeforeBootstrap(t *testing.T) {
 		{"launchctl", "bootout", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 		{"launchctl", "bootstrap", "gui/" + currentUIDText(), mustLaunchdPlistPath(t)},
+		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("calls = %#v, want %#v", *calls, want)
@@ -108,6 +123,15 @@ func TestLaunchdStartBootstrapsUnloadedServiceWithoutKickstart(t *testing.T) {
 func TestLaunchdRestartReloadsLoadedServiceBeforeBootstrap(t *testing.T) {
 	withFastLaunchdShutdownPolling(t)
 	spec := newLaunchdTestSpec(t)
+	bootout := false
+	bootstrapped := false
+	server := newLaunchdHealthTestServer(t, func() (string, int) {
+		if bootstrapped {
+			return `{"status":"ok","pid":77}`, http.StatusOK
+		}
+		return "stopped", http.StatusServiceUnavailable
+	})
+	spec.Endpoint = server.URL
 	path := writeLaunchdTestPlist(t, spec)
 	var calls *[][]string
 	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
@@ -115,16 +139,21 @@ func TestLaunchdRestartReloadsLoadedServiceBeforeBootstrap(t *testing.T) {
 		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
 			// launchd keeps reporting the job loaded until bootout has fully
 			// evicted it; the reload must not bootstrap before that.
-			if countLaunchdCommand(*calls, "bootout") > 0 {
+			if bootstrapped {
+				return serviceCommandResult{Stdout: launchdPrintOutput(77, serviceCommand(spec))}, nil
+			}
+			if bootout {
 				return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
 			}
-			return serviceCommandResult{Stdout: "state = running\npid = 42\n"}, nil
+			return serviceCommandResult{Stdout: launchdPrintOutput(42, serviceCommand(spec))}, nil
 		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			bootout = true
 			return serviceCommandResult{}, nil
 		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
 			if countLaunchdCommand(*calls, "bootout") == 0 {
 				t.Fatalf("bootstrap happened before bootout, calls=%#v", *calls)
 			}
+			bootstrapped = true
 			return serviceCommandResult{}, nil
 		default:
 			return serviceCommandResult{}, errors.New("unexpected command")
@@ -137,10 +166,10 @@ func TestLaunchdRestartReloadsLoadedServiceBeforeBootstrap(t *testing.T) {
 
 	want := [][]string{
 		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
-		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 		{"launchctl", "bootout", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 		{"launchctl", "bootstrap", "gui/" + currentUIDText(), path},
+		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("calls = %#v, want %#v", *calls, want)
@@ -182,7 +211,7 @@ func TestLaunchdRestartReloadsUnloadedHealthyServerBeforeBootstrap(t *testing.T)
 		switch strings.Join(append([]string{name}, args...), "\x00") {
 		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
 			if countLaunchdCommand(*calls, "bootstrap") > 0 {
-				return serviceCommandResult{Stdout: "state = running\npid = 77\n"}, nil
+				return serviceCommandResult{Stdout: launchdPrintOutput(77, serviceCommand(spec))}, nil
 			}
 			return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
 		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
@@ -206,7 +235,6 @@ func TestLaunchdRestartReloadsUnloadedHealthyServerBeforeBootstrap(t *testing.T)
 	want := [][]string{
 		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
-		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 		{"launchctl", "bootstrap", "gui/" + currentUIDText(), path},
 		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 	}
@@ -217,6 +245,14 @@ func TestLaunchdRestartReloadsUnloadedHealthyServerBeforeBootstrap(t *testing.T)
 
 func TestLaunchdRestartIfInstalledReplacesStaleLoadedServiceAfterTransientBootstrapError(t *testing.T) {
 	spec := newLaunchdTestSpec(t)
+	bootstrapped := false
+	server := newLaunchdHealthTestServer(t, func() (string, int) {
+		if bootstrapped {
+			return `{"status":"ok","pid":77}`, http.StatusOK
+		}
+		return "stopped", http.StatusServiceUnavailable
+	})
+	spec.Endpoint = server.URL
 	withLaunchdServiceCommandSpec(t, spec)
 	path := writeLaunchdTestPlist(t, spec)
 	printCalls := 0
@@ -224,6 +260,9 @@ func TestLaunchdRestartIfInstalledReplacesStaleLoadedServiceAfterTransientBootst
 	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
 		switch strings.Join(append([]string{name}, args...), "\x00") {
 		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			if bootstrapped {
+				return serviceCommandResult{Stdout: launchdPrintOutput(77, serviceCommand(spec))}, nil
+			}
 			printCalls++
 			if printCalls <= 2 {
 				return serviceCommandResult{Stdout: "state = running\npid = 42\narguments = {\n\t/old/kent\n\tserve\n}\n"}, nil
@@ -233,6 +272,7 @@ func TestLaunchdRestartIfInstalledReplacesStaleLoadedServiceAfterTransientBootst
 			if countLaunchdCommand(*calls, "bootstrap") == 1 {
 				return serviceCommandResult{Stderr: "Bootstrap failed: 5: Input/output error", Code: 5}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "Bootstrap failed: 5: Input/output error", Code: 5}}
 			}
+			bootstrapped = true
 			return serviceCommandResult{}, nil
 		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
 			return serviceCommandResult{}, nil
@@ -256,6 +296,7 @@ func TestLaunchdRestartIfInstalledReplacesStaleLoadedServiceAfterTransientBootst
 		{"launchctl", "bootout", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 		{"launchctl", "bootstrap", "gui/" + currentUIDText(), path},
+		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("calls = %#v, want %#v", *calls, want)
@@ -346,7 +387,11 @@ func TestLaunchdRestartIfInstalledBootstrapRecoveryFailsWhenRetryBootstrapFails(
 func TestLaunchdReloadWaitsForOldServerBeforeBootstrap(t *testing.T) {
 	withFastLaunchdShutdownPolling(t)
 	serverRequests := 0
+	bootstrapped := false
 	server := newLaunchdHealthTestServer(t, func() (string, int) {
+		if bootstrapped {
+			return `{"status":"ok","pid":77}`, http.StatusOK
+		}
 		serverRequests++
 		if serverRequests == 1 {
 			return `{"status":"ok","pid":42}`, http.StatusOK
@@ -360,16 +405,20 @@ func TestLaunchdReloadWaitsForOldServerBeforeBootstrap(t *testing.T) {
 	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
 		switch strings.Join(append([]string{name}, args...), "\x00") {
 		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			if bootstrapped {
+				return serviceCommandResult{Stdout: launchdPrintOutput(77, serviceCommand(spec))}, nil
+			}
 			if countLaunchdCommand(*calls, "bootout") > 0 {
 				return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
 			}
-			return serviceCommandResult{Stdout: "state = running\npid = 42\n"}, nil
+			return serviceCommandResult{Stdout: launchdPrintOutput(42, serviceCommand(spec))}, nil
 		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
 			return serviceCommandResult{}, nil
 		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
 			if serverRequests < 2 {
 				t.Fatalf("bootstrap happened before old server health went down")
 			}
+			bootstrapped = true
 			return serviceCommandResult{}, nil
 		default:
 			return serviceCommandResult{}, errors.New("unexpected command")
@@ -386,6 +435,7 @@ func TestLaunchdReloadWaitsForOldServerBeforeBootstrap(t *testing.T) {
 		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 		{"launchctl", "bootstrap", "gui/" + currentUIDText(), path},
+		{"launchctl", "print", "gui/" + currentUIDText() + "/" + serviceLaunchdLabel},
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("calls = %#v, want %#v", *calls, want)
@@ -400,20 +450,31 @@ func TestLaunchdReloadWaitsForLaunchdEvictionBeforeBootstrap(t *testing.T) {
 	// launchd has evicted the label, no matter how fast health drops.
 	withFastLaunchdShutdownPolling(t)
 	spec := newLaunchdTestSpec(t)
+	bootstrapped := false
+	server := newLaunchdHealthTestServer(t, func() (string, int) {
+		if bootstrapped {
+			return `{"status":"ok","pid":77}`, http.StatusOK
+		}
+		return "stopped", http.StatusServiceUnavailable
+	})
+	spec.Endpoint = server.URL
 	path := writeLaunchdTestPlist(t, spec)
 	postBootoutPrints := 0
 	var calls *[][]string
 	calls = captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
 		switch strings.Join(append([]string{name}, args...), "\x00") {
 		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			if bootstrapped {
+				return serviceCommandResult{Stdout: launchdPrintOutput(77, serviceCommand(spec))}, nil
+			}
 			if countLaunchdCommand(*calls, "bootout") == 0 {
-				return serviceCommandResult{Stdout: "state = running\npid = 42\n"}, nil
+				return serviceCommandResult{Stdout: launchdPrintOutput(42, serviceCommand(spec))}, nil
 			}
 			// Stay "loaded" for the first few post-bootout polls to emulate a
 			// slow teardown, then report the label gone.
 			postBootoutPrints++
 			if postBootoutPrints <= 3 {
-				return serviceCommandResult{Stdout: "state = running\npid = 42\n"}, nil
+				return serviceCommandResult{Stdout: launchdPrintOutput(42, serviceCommand(spec))}, nil
 			}
 			return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
 		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
@@ -422,6 +483,7 @@ func TestLaunchdReloadWaitsForLaunchdEvictionBeforeBootstrap(t *testing.T) {
 			if postBootoutPrints <= 3 {
 				t.Fatalf("bootstrap ran while launchd still reported the label loaded (after %d post-bootout prints)", postBootoutPrints)
 			}
+			bootstrapped = true
 			return serviceCommandResult{}, nil
 		default:
 			return serviceCommandResult{}, errors.New("unexpected command")
@@ -433,6 +495,44 @@ func TestLaunchdReloadWaitsForLaunchdEvictionBeforeBootstrap(t *testing.T) {
 	}
 	if countLaunchdCommand(*calls, "bootstrap") != 1 {
 		t.Fatalf("expected exactly one bootstrap after eviction, calls=%#v", *calls)
+	}
+}
+
+func TestLaunchdReloadDoesNotBootstrapWhenLaunchdRemainsLoadedAfterHealthDrops(t *testing.T) {
+	originalTimeout := launchdServiceShutdownTimeout
+	originalInterval := launchdServiceShutdownPollInterval
+	launchdServiceShutdownTimeout = time.Millisecond
+	launchdServiceShutdownPollInterval = time.Millisecond
+	t.Cleanup(func() {
+		launchdServiceShutdownTimeout = originalTimeout
+		launchdServiceShutdownPollInterval = originalInterval
+	})
+	server := newLaunchdHealthTestServer(t, func() (string, int) {
+		return "stopped", http.StatusServiceUnavailable
+	})
+	spec := newLaunchdTestSpec(t)
+	spec.Endpoint = server.URL
+	path := writeLaunchdTestPlist(t, spec)
+	calls := captureLaunchdServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
+		switch strings.Join(append([]string{name}, args...), "\x00") {
+		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			return serviceCommandResult{Stdout: launchdPrintOutput(42, serviceCommand(spec))}, nil
+		case "launchctl\x00bootout\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
+			return serviceCommandResult{}, nil
+		default:
+			return serviceCommandResult{}, errors.New("unexpected command")
+		}
+	})
+
+	err := reloadLaunchdService(context.Background(), spec, path)
+	if err == nil {
+		t.Fatal("expected reload to fail while launchd still reports service loaded")
+	}
+	if !errors.Is(err, errLaunchdOldServerNotExited) {
+		t.Fatalf("error = %v, want launchd shutdown failure", err)
+	}
+	if countLaunchdCommand(*calls, "bootstrap") != 0 {
+		t.Fatalf("bootstrap should not run before launchd eviction, calls=%#v", *calls)
 	}
 }
 
@@ -471,7 +571,7 @@ func TestLaunchdReloadStopsUnloadedHealthyServerBeforeBootstrap(t *testing.T) {
 		switch strings.Join(append([]string{name}, args...), "\x00") {
 		case "launchctl\x00print\x00gui/" + currentUIDText() + "/" + serviceLaunchdLabel:
 			if countLaunchdCommand(*calls, "bootstrap") > 0 {
-				return serviceCommandResult{Stdout: "state = running\npid = 77\n"}, nil
+				return serviceCommandResult{Stdout: launchdPrintOutput(77, serviceCommand(spec))}, nil
 			}
 			return serviceCommandResult{Stderr: "not found", Code: 113}, serviceCommandError{Name: name, Args: args, Result: serviceCommandResult{Stderr: "not found", Code: 113}}
 		case "launchctl\x00bootstrap\x00gui/" + currentUIDText() + "\x00" + path:
@@ -763,14 +863,32 @@ func newLaunchdTestSpec(t *testing.T) serviceSpec {
 
 func writeLaunchdTestPlist(t *testing.T, spec serviceSpec) string {
 	t.Helper()
+	return writeLaunchdTestPlistWithCommand(t, spec, serviceCommand(spec))
+}
+
+func writeLaunchdTestPlistWithCommand(t *testing.T, spec serviceSpec, command []string) string {
+	t.Helper()
 	path := mustLaunchdPlistPath(t)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir launch agents: %v", err)
 	}
-	if err := os.WriteFile(path, []byte(renderLaunchdPlist(spec)), 0o644); err != nil {
+	plistSpec := spec
+	plistSpec.Executable = command[0]
+	plistSpec.Arguments = append([]string(nil), command[1:]...)
+	if err := os.WriteFile(path, []byte(renderLaunchdPlist(plistSpec)), 0o644); err != nil {
 		t.Fatalf("write plist: %v", err)
 	}
 	return path
+}
+
+func launchdPrintOutput(pid int, command []string) string {
+	var builder strings.Builder
+	_, _ = fmt.Fprintf(&builder, "state = running\npid = %d\narguments = {\n", pid)
+	for _, arg := range command {
+		_, _ = fmt.Fprintf(&builder, "\t%s\n", arg)
+	}
+	builder.WriteString("}\n")
+	return builder.String()
 }
 
 func testLaunchdServiceSpec(t *testing.T) serviceSpec {


### PR DESCRIPTION
## Summary
- refresh the macOS LaunchAgent plist during plain `kent service restart` before bootout/bootstrap so stale Homebrew commands are replaced
- verify post-bootstrap launchd startup by requiring a loaded PID, matching /healthz PID ownership, and loaded `ProgramArguments` equal to `serviceCommand(spec)`
- keep reload fail-closed when launchd has not evicted the old label, and add deterministic launchd restart/reload coverage for stale command, old PID ownership, and command skew

Closes #433

## Verification
- `./scripts/test.sh ./cli/kent -run 'TestLaunchd|TestServiceRestart'`
- `./scripts/test.sh ./cli/kent`
- `./scripts/build.sh --output ./bin/kent`
- `go test ./cli/kent -run 'TestLaunchd.*(Restart|Reload)' -count=1 -v` passed in QA, skipping only the opt-in real launchd integration
- `go test ./cli/kent -run TestServiceRestart -count=1 -v` passed in QA
- `./bin/kent service restart --help` exited 0 in QA without restarting the live service

Live service restart/stop/start was intentionally not executed per task comment: `Do NOT RESTART LIVE KENT SERVICE`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service restart and reload behavior on macOS so updates are applied more reliably.
  * Restart now better detects stale or mismatched service state and avoids leaving outdated versions running.
  * Health checks are now used more consistently during service startup, helping prevent false-ready states and failed restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->