### PR TITLE
feat!: replace Windows scheduled-task service with real SCM service

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,6 +1,3 @@
-// In release builds, use the Windows GUI subsystem so launching the desktop app
-// never allocates/flashes a console window. Debug builds keep the console for
-// log visibility.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,3 +1,8 @@
+// In release builds, use the Windows GUI subsystem so launching the desktop app
+// never allocates/flashes a console window. Debug builds keep the console for
+// log visibility.
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 fn main() {
     app_desktop_lib::run()
 }

--- a/cli/app/ui_terminal_cursor_test.go
+++ b/cli/app/ui_terminal_cursor_test.go
@@ -737,10 +737,6 @@ func TestTerminalCursorProgramStartupReplayAfterClearScreenKeepsOngoingOutputVis
 	}
 }
 
-// terminalCursorOutputContains reads the program output buffer under the same
-// lock the cursor writer holds while writing, so a test can synchronize on bytes
-// Bubble Tea flushes asynchronously through its command pipeline without racing
-// concurrent writes.
 func terminalCursorOutputContains(state *uiTerminalCursorState, out *bytes.Buffer, want string) bool {
 	state.writeMu.Lock()
 	defer state.writeMu.Unlock()

--- a/cli/app/ui_terminal_cursor_test.go
+++ b/cli/app/ui_terminal_cursor_test.go
@@ -737,6 +737,16 @@ func TestTerminalCursorProgramStartupReplayAfterClearScreenKeepsOngoingOutputVis
 	}
 }
 
+// terminalCursorOutputContains reads the program output buffer under the same
+// lock the cursor writer holds while writing, so a test can synchronize on bytes
+// Bubble Tea flushes asynchronously through its command pipeline without racing
+// concurrent writes.
+func terminalCursorOutputContains(state *uiTerminalCursorState, out *bytes.Buffer, want string) bool {
+	state.writeMu.Lock()
+	defer state.writeMu.Unlock()
+	return strings.Contains(out.String(), want)
+}
+
 func terminalOutputAfterLastClearScreen(output string) string {
 	index := strings.LastIndex(output, xansi.EraseEntireScreen)
 	if index < 0 {
@@ -774,12 +784,12 @@ func TestTerminalCursorProgramSurvivesAltScreenTransitionAfterPlacement(t *testi
 		return ok
 	})
 	program.Send(tea.KeyMsg{Type: tea.KeyShiftTab})
-	waitForTestCondition(t, 2*time.Second, "detail alt-screen active", func() bool {
-		return model.view.Mode() == "detail" && model.altScreenActive
+	waitForTestCondition(t, 2*time.Second, "alt-screen enter flushed to output", func() bool {
+		return terminalCursorOutputContains(state, &out, "\x1b[?1049h")
 	})
 	program.Send(tea.KeyMsg{Type: tea.KeyShiftTab})
-	waitForTestCondition(t, 2*time.Second, "ongoing mode restored", func() bool {
-		return model.view.Mode() == "ongoing" && !model.altScreenActive
+	waitForTestCondition(t, 2*time.Second, "alt-screen exit flushed to output", func() bool {
+		return terminalCursorOutputContains(state, &out, "\x1b[?1049l")
 	})
 	program.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
 	select {

--- a/cli/kent/help/service.txt
+++ b/cli/kent/help/service.txt
@@ -15,11 +15,15 @@ What This Does:
 Backends:
   macOS: launchd LaunchAgent.
   Linux/WSL2: systemd --user unit.
-  Windows: Scheduled Task, with Startup folder fallback when needed.
+  Windows: Windows Service (SCM), supervising `kent serve` in your session as you (no stored password).
 
 macOS Notes:
   `restart --if-installed` rewrites the LaunchAgent, unloads the loaded job, and bootstraps it again.
   `start` bootstraps an unloaded LaunchAgent; launchd starts it through RunAtLoad.
+
+Windows Notes:
+  `install`/`uninstall` require Administrator and prompt for elevation automatically.
+  `status`/`start`/`stop`/`restart` run without elevation.
 
 Examples:
   kent service status

--- a/cli/kent/help/service.txt
+++ b/cli/kent/help/service.txt
@@ -10,13 +10,5 @@ What This Does:
   Run one shared local `kent serve` as a background service that starts at login.
   Lifecycle commands that stop or restart the service are refused inside Kent shell commands; use `install --no-start` or `uninstall --keep-running` for registration-only changes there.
 
-Platforms:
-  macOS, Linux/WSL2, and Windows.
-
 Windows Notes:
   `install` and `uninstall` prompt for Administrator elevation; other commands need no elevation.
-
-Examples:
-  kent service status
-  kent service install
-  kent service restart

--- a/cli/kent/help/service.txt
+++ b/cli/kent/help/service.txt
@@ -12,3 +12,4 @@ What This Does:
 
 Windows Notes:
   `install` and `uninstall` prompt for Administrator elevation; other commands need no elevation.
+  `uninstall --keep-running` is not supported; the server is bound to the service and stops with it.

--- a/cli/kent/help/service.txt
+++ b/cli/kent/help/service.txt
@@ -7,23 +7,14 @@ Usage of kent service:
   kent service restart [--if-installed]
 
 What This Does:
-  Manage the Kent server background service for one shared local `kent serve`.
-  The service starts at login and is supervised by the OS.
-  Lifecycle commands that can stop or restart the service are refused inside Kent shell commands.
-  Use `install --no-start` or `uninstall --keep-running` for registration-only changes from a Kent shell.
+  Run one shared local `kent serve` as a background service that starts at login.
+  Lifecycle commands that stop or restart the service are refused inside Kent shell commands; use `install --no-start` or `uninstall --keep-running` for registration-only changes there.
 
-Backends:
-  macOS: launchd LaunchAgent.
-  Linux/WSL2: systemd --user unit.
-  Windows: Windows Service (SCM), supervising `kent serve` in your session as you (no stored password).
-
-macOS Notes:
-  `restart --if-installed` rewrites the LaunchAgent, unloads the loaded job, and bootstraps it again.
-  `start` bootstraps an unloaded LaunchAgent; launchd starts it through RunAtLoad.
+Platforms:
+  macOS, Linux/WSL2, and Windows.
 
 Windows Notes:
-  `install`/`uninstall` require Administrator and prompt for elevation automatically.
-  `status`/`start`/`stop`/`restart` run without elevation.
+  `install` and `uninstall` prompt for Administrator elevation; other commands need no elevation.
 
 Examples:
   kent service status

--- a/cli/kent/main.go
+++ b/cli/kent/main.go
@@ -72,6 +72,7 @@ var runInteractiveApp = app.Run
 var runPromptApp = app.RunPrompt
 
 func main() {
+	redirectServiceLogs()
 	if exitCode := rootCommand(os.Args[1:], os.Stdin, os.Stdout, os.Stderr); exitCode != 0 {
 		os.Exit(exitCode)
 	}

--- a/cli/kent/serve.go
+++ b/cli/kent/serve.go
@@ -45,6 +45,7 @@ func serveSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	ctx = installServiceShutdownTrigger(ctx)
 	authHandler, onboardingHandler := newServeStartupHandlers()
 	server, err := startServeServer(ctx, serverstartup.Request{
 		AllowUnauthenticated: true,

--- a/cli/kent/service_backend_windows.go
+++ b/cli/kent/service_backend_windows.go
@@ -64,7 +64,10 @@ func (scmServiceBackend) Install(ctx context.Context, spec serviceSpec, force bo
 			return errors.New(brand.ServiceDisplayName + " is already installed; use --force to rewrite it")
 		}
 		if _, err := existing.Control(svc.Stop); err == nil {
-			_ = waitForServiceState(existing, svc.Stopped, serviceStopWindow)
+			if werr := waitForServiceState(existing, svc.Stopped, serviceStopWindow); werr != nil {
+				_ = existing.Close()
+				return fmt.Errorf("stop existing service before reinstall: %w", werr)
+			}
 		}
 		deleteErr := existing.Delete()
 		_ = existing.Close()
@@ -165,6 +168,9 @@ func (scmServiceBackend) Stop(ctx context.Context, spec serviceSpec) error {
 	}
 	defer cleanup()
 	if _, err := service.Control(svc.Stop); err != nil {
+		if errors.Is(err, windows.ERROR_SERVICE_NOT_ACTIVE) {
+			return nil
+		}
 		return fmt.Errorf("stop service: %w", err)
 	}
 	if err := waitForServiceState(service, svc.Stopped, serviceStopWindow); err != nil {
@@ -431,9 +437,17 @@ func waitForServiceAbsent(m *mgr.Mgr, timeout time.Duration) error {
 	}
 }
 
+// stopLegacyServer ends any still-running pre-SCM scheduled-task server so the
+// unmanaged-server preflight does not block migration. The registration itself
+// is removed by removeLegacyWindowsRegistration during install/uninstall.
+func (scmServiceBackend) stopLegacyServer(ctx context.Context, spec serviceSpec) {
+	_, _ = runServiceCommand(ctx, "schtasks", "/End", "/TN", serviceWindowsTaskName)
+}
+
 // removeLegacyWindowsRegistration tears down the pre-SCM scheduled task and
 // Startup-folder launcher so upgraders stop getting the old console windows.
 func removeLegacyWindowsRegistration(ctx context.Context, spec serviceSpec) {
+	_, _ = runServiceCommand(ctx, "schtasks", "/End", "/TN", serviceWindowsTaskName)
 	_, _ = runServiceCommand(ctx, "schtasks", "/Delete", "/F", "/TN", serviceWindowsTaskName)
 	_ = os.Remove(legacyWindowsStartupItemPath())
 	_ = os.Remove(filepath.Join(windowsServiceDir(spec), "server.cmd"))

--- a/cli/kent/service_backend_windows.go
+++ b/cli/kent/service_backend_windows.go
@@ -11,10 +11,22 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
+)
+
+var (
+	wtsapi32DLL                    = windows.NewLazySystemDLL("wtsapi32.dll")
+	procWTSQuerySessionInformation = wtsapi32DLL.NewProc("WTSQuerySessionInformationW")
+	procWTSFreeMemory              = wtsapi32DLL.NewProc("WTSFreeMemory")
+)
+
+const (
+	wtsInfoUserName   = 5 // WTSUserName
+	wtsInfoDomainName = 7 // WTSDomainName
 )
 
 // scmServiceBackend registers the background server as a Windows Service Control
@@ -266,18 +278,9 @@ func openServiceWithAccess(access uint32) (*mgr.Service, func(), error) {
 	return service, cleanup, nil
 }
 
-// grantUserServiceAccess adds an ACE granting the installing user start/stop/query
-// on the service so lifecycle commands work without elevation.
+// grantUserServiceAccess adds an ACE granting the interactive user
+// start/stop/query on the service so lifecycle commands work without elevation.
 func grantUserServiceAccess(service *mgr.Service) error {
-	token, err := windows.OpenCurrentProcessToken()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = token.Close() }()
-	user, err := token.GetTokenUser()
-	if err != nil {
-		return err
-	}
 	descriptor, err := windows.GetSecurityInfo(service.Handle, windows.SE_SERVICE, windows.DACL_SECURITY_INFORMATION)
 	if err != nil {
 		return err
@@ -286,6 +289,22 @@ func grantUserServiceAccess(service *mgr.Service) error {
 	if err != nil {
 		return err
 	}
+	sid, err := interactiveUserSID()
+	if err != nil {
+		// Fall back to the elevated process's own user. For an admin-approval-mode
+		// UAC install (the common case) this is the same console user; only a
+		// credential-prompt install under a different admin loses the grant here.
+		token, terr := windows.OpenCurrentProcessToken()
+		if terr != nil {
+			return terr
+		}
+		defer func() { _ = token.Close() }()
+		user, uerr := token.GetTokenUser()
+		if uerr != nil {
+			return uerr
+		}
+		sid = user.User.Sid
+	}
 	entry := windows.EXPLICIT_ACCESS{
 		AccessPermissions: windows.SERVICE_START | windows.SERVICE_STOP | windows.SERVICE_QUERY_STATUS | windows.SERVICE_QUERY_CONFIG | windows.READ_CONTROL,
 		AccessMode:        windows.GRANT_ACCESS,
@@ -293,7 +312,7 @@ func grantUserServiceAccess(service *mgr.Service) error {
 		Trustee: windows.TRUSTEE{
 			TrusteeForm:  windows.TRUSTEE_IS_SID,
 			TrusteeType:  windows.TRUSTEE_IS_USER,
-			TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
+			TrusteeValue: windows.TrusteeValueFromSID(sid),
 		},
 	}
 	merged, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{entry}, existing)
@@ -301,6 +320,53 @@ func grantUserServiceAccess(service *mgr.Service) error {
 		return err
 	}
 	return windows.SetSecurityInfo(service.Handle, windows.SE_SERVICE, windows.DACL_SECURITY_INFORMATION, nil, nil, merged, nil)
+}
+
+// interactiveUserSID resolves the SID of the user owning the active console
+// session, so a credential-prompt UAC install run under a different admin still
+// grants service lifecycle rights to the person who will run start/stop/status.
+func interactiveUserSID() (*windows.SID, error) {
+	session := windows.WTSGetActiveConsoleSessionId()
+	if session == 0xFFFFFFFF {
+		return nil, errors.New("no active console session")
+	}
+	user, err := wtsSessionString(session, wtsInfoUserName)
+	if err != nil {
+		return nil, err
+	}
+	if user == "" {
+		return nil, errors.New("active console session has no user")
+	}
+	domain, err := wtsSessionString(session, wtsInfoDomainName)
+	if err != nil {
+		return nil, err
+	}
+	account := user
+	if domain != "" {
+		account = domain + `\` + user
+	}
+	sid, _, _, err := windows.LookupSID("", account)
+	if err != nil {
+		return nil, fmt.Errorf("resolve interactive user %q: %w", account, err)
+	}
+	return sid, nil
+}
+
+func wtsSessionString(session uint32, infoClass uint32) (string, error) {
+	var buffer *uint16
+	var bytesReturned uint32
+	ret, _, callErr := procWTSQuerySessionInformation.Call(
+		0, // WTS_CURRENT_SERVER_HANDLE
+		uintptr(session),
+		uintptr(infoClass),
+		uintptr(unsafe.Pointer(&buffer)),
+		uintptr(unsafe.Pointer(&bytesReturned)),
+	)
+	if ret == 0 {
+		return "", fmt.Errorf("WTSQuerySessionInformation: %w", callErr)
+	}
+	defer procWTSFreeMemory.Call(uintptr(unsafe.Pointer(buffer)))
+	return windows.UTF16PtrToString(buffer), nil
 }
 
 func waitForServiceState(service *mgr.Service, state svc.State, timeout time.Duration) error {

--- a/cli/kent/service_backend_windows.go
+++ b/cli/kent/service_backend_windows.go
@@ -51,8 +51,9 @@ func (scmServiceBackend) Install(ctx context.Context, spec serviceSpec, force bo
 			_ = existing.Close()
 			return errors.New(brand.ServiceDisplayName + " is already installed; use --force to rewrite it")
 		}
-		_, _ = existing.Control(svc.Stop)
-		waitForServiceState(existing, svc.Stopped, 5*time.Second)
+		if _, err := existing.Control(svc.Stop); err == nil {
+			_ = waitForServiceState(existing, svc.Stopped, serviceStopWindow)
+		}
 		deleteErr := existing.Delete()
 		_ = existing.Close()
 		if deleteErr != nil {
@@ -107,6 +108,9 @@ func (scmServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop b
 
 	service, err := m.OpenService(serviceWindowsServiceName)
 	if err != nil {
+		if !errors.Is(err, windows.ERROR_SERVICE_DOES_NOT_EXIST) {
+			return fmt.Errorf("open service: %w", err)
+		}
 		// Not installed: clean up any leftover legacy registration and pid file.
 		removeLegacyWindowsRegistration(ctx, spec)
 		_ = os.Remove(windowsServerPIDPath(spec))
@@ -115,8 +119,9 @@ func (scmServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop b
 	defer func() { _ = service.Close() }()
 
 	if stop {
-		_, _ = service.Control(svc.Stop)
-		waitForServiceState(service, svc.Stopped, 5*time.Second)
+		if _, err := service.Control(svc.Stop); err == nil {
+			_ = waitForServiceState(service, svc.Stopped, serviceStopWindow)
+		}
 	}
 	if err := service.Delete(); err != nil {
 		return fmt.Errorf("delete service: %w", err)
@@ -147,7 +152,9 @@ func (scmServiceBackend) Stop(ctx context.Context, spec serviceSpec) error {
 	if _, err := service.Control(svc.Stop); err != nil {
 		return fmt.Errorf("stop service: %w", err)
 	}
-	waitForServiceState(service, svc.Stopped, 5*time.Second)
+	if err := waitForServiceState(service, svc.Stopped, serviceStopWindow); err != nil {
+		return fmt.Errorf("stop service: %w", err)
+	}
 	return nil
 }
 
@@ -158,7 +165,9 @@ func (scmServiceBackend) Restart(ctx context.Context, spec serviceSpec) error {
 	}
 	defer cleanup()
 	if _, err := service.Control(svc.Stop); err == nil {
-		waitForServiceState(service, svc.Stopped, 5*time.Second)
+		if err := waitForServiceState(service, svc.Stopped, serviceStopWindow); err != nil {
+			return fmt.Errorf("wait for service to stop before restart: %w", err)
+		}
 	}
 	if err := service.Start(); err != nil {
 		return fmt.Errorf("start service: %w", err)
@@ -278,7 +287,7 @@ func grantUserServiceAccess(service *mgr.Service) error {
 		return err
 	}
 	entry := windows.EXPLICIT_ACCESS{
-		AccessPermissions: windows.SERVICE_START | windows.SERVICE_STOP | windows.SERVICE_QUERY_STATUS | windows.READ_CONTROL,
+		AccessPermissions: windows.SERVICE_START | windows.SERVICE_STOP | windows.SERVICE_QUERY_STATUS | windows.SERVICE_QUERY_CONFIG | windows.READ_CONTROL,
 		AccessMode:        windows.GRANT_ACCESS,
 		Inheritance:       windows.NO_INHERITANCE,
 		Trustee: windows.TRUSTEE{
@@ -294,12 +303,18 @@ func grantUserServiceAccess(service *mgr.Service) error {
 	return windows.SetSecurityInfo(service.Handle, windows.SE_SERVICE, windows.DACL_SECURITY_INFORMATION, nil, nil, merged, nil)
 }
 
-func waitForServiceState(service *mgr.Service, state svc.State, timeout time.Duration) {
+func waitForServiceState(service *mgr.Service, state svc.State, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	for {
 		status, err := service.Query()
-		if err != nil || status.State == state {
-			return
+		if err != nil {
+			return fmt.Errorf("query service state: %w", err)
+		}
+		if status.State == state {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for service to reach state %d", state)
 		}
 		time.Sleep(200 * time.Millisecond)
 	}

--- a/cli/kent/service_backend_windows.go
+++ b/cli/kent/service_backend_windows.go
@@ -73,8 +73,22 @@ func (scmServiceBackend) Install(ctx context.Context, spec serviceSpec, force bo
 	if err != nil {
 		return fmt.Errorf("create service: %w", err)
 	}
+	if err := configureCreatedService(service, spec); err != nil {
+		_ = service.Delete()
+		_ = service.Close()
+		return err
+	}
 	defer func() { _ = service.Close() }()
 
+	if start {
+		if err := service.Start(); err != nil {
+			return fmt.Errorf("start service: %w", err)
+		}
+	}
+	return nil
+}
+
+func configureCreatedService(service *mgr.Service, spec serviceSpec) error {
 	if err := service.SetRecoveryActions([]mgr.RecoveryAction{
 		{Type: mgr.ServiceRestart, Delay: 2 * time.Second},
 		{Type: mgr.ServiceRestart, Delay: 5 * time.Second},
@@ -82,17 +96,11 @@ func (scmServiceBackend) Install(ctx context.Context, spec serviceSpec, force bo
 	}, serviceRecoveryResetPeriod); err != nil {
 		return fmt.Errorf("configure restart-on-failure: %w", err)
 	}
-
 	if err := grantUserServiceAccess(service); err != nil {
 		return fmt.Errorf("grant service control to the installing user: %w", err)
 	}
-
-	persistInstallUser(spec)
-
-	if start {
-		if err := service.Start(); err != nil {
-			return fmt.Errorf("start service: %w", err)
-		}
+	if err := persistInstallUser(spec); err != nil {
+		return err
 	}
 	return nil
 }
@@ -224,13 +232,18 @@ func installUserSIDPath(spec serviceSpec) string {
 	return filepath.Join(windowsServiceDir(spec), "install_user.sid")
 }
 
-func persistInstallUser(spec serviceSpec) {
+func persistInstallUser(spec serviceSpec) error {
 	sid, err := interactiveUserSID()
 	if err != nil {
-		return
+		return fmt.Errorf("resolve installing user: %w", err)
 	}
-	_ = os.MkdirAll(windowsServiceDir(spec), 0o755)
-	_ = os.WriteFile(installUserSIDPath(spec), []byte(sid.String()), 0o644)
+	if err := os.MkdirAll(windowsServiceDir(spec), 0o755); err != nil {
+		return fmt.Errorf("create service directory: %w", err)
+	}
+	if err := os.WriteFile(installUserSIDPath(spec), []byte(sid.String()), 0o644); err != nil {
+		return fmt.Errorf("persist installing user: %w", err)
+	}
+	return nil
 }
 
 func readInstallUserSID(spec serviceSpec) string {

--- a/cli/kent/service_backend_windows.go
+++ b/cli/kent/service_backend_windows.go
@@ -11,23 +11,10 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-	"unsafe"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
-)
-
-var (
-	wtsapi32DLL                    = windows.NewLazySystemDLL("wtsapi32.dll")
-	procWTSQuerySessionInformation = wtsapi32DLL.NewProc("WTSQuerySessionInformationW")
-	procWTSFreeMemory              = wtsapi32DLL.NewProc("WTSFreeMemory")
-)
-
-const (
-	wtsInfoUserName     = 5
-	wtsInfoDomainName   = 7
-	wtsInvalidSessionID = 0xFFFFFFFF
 )
 
 type scmServiceBackend struct{}
@@ -59,11 +46,14 @@ func (scmServiceBackend) Install(ctx context.Context, spec serviceSpec, force bo
 			_ = existing.Close()
 			return errors.New(brand.ServiceDisplayName + " is already installed; use --force to rewrite it")
 		}
-		if _, err := existing.Control(svc.Stop); err == nil {
-			if werr := waitForServiceState(existing, svc.Stopped, serviceStopWindow); werr != nil {
+		if _, err := existing.Control(svc.Stop); err != nil {
+			if !errors.Is(err, windows.ERROR_SERVICE_NOT_ACTIVE) {
 				_ = existing.Close()
-				return fmt.Errorf("stop existing service before reinstall: %w", werr)
+				return fmt.Errorf("stop existing service before reinstall: %w", err)
 			}
+		} else if werr := waitForServiceState(existing, svc.Stopped, serviceStopWindow); werr != nil {
+			_ = existing.Close()
+			return fmt.Errorf("stop existing service before reinstall: %w", werr)
 		}
 		deleteErr := existing.Delete()
 		_ = existing.Close()
@@ -133,10 +123,12 @@ func (scmServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop b
 	defer func() { _ = service.Close() }()
 
 	if stop {
-		if _, err := service.Control(svc.Stop); err == nil {
-			if werr := waitForServiceState(service, svc.Stopped, serviceStopWindow); werr != nil {
-				return fmt.Errorf("stop service before uninstall: %w", werr)
+		if _, err := service.Control(svc.Stop); err != nil {
+			if !errors.Is(err, windows.ERROR_SERVICE_NOT_ACTIVE) {
+				return fmt.Errorf("stop service before uninstall: %w", err)
 			}
+		} else if werr := waitForServiceState(service, svc.Stopped, serviceStopWindow); werr != nil {
+			return fmt.Errorf("stop service before uninstall: %w", werr)
 		}
 		endLegacyWindowsTask(ctx)
 	}
@@ -341,47 +333,23 @@ func grantUserServiceAccess(service *mgr.Service) error {
 }
 
 func interactiveUserSID() (*windows.SID, error) {
-	session := windows.WTSGetActiveConsoleSessionId()
-	if session == wtsInvalidSessionID {
-		return nil, errors.New("no active console session")
+	var session uint32
+	if err := windows.ProcessIdToSessionId(windows.GetCurrentProcessId(), &session); err != nil {
+		return nil, fmt.Errorf("resolve install session: %w", err)
 	}
-	user, err := wtsSessionString(session, wtsInfoUserName)
+	if session == 0 {
+		return nil, errors.New("install is not running in an interactive session")
+	}
+	var token windows.Token
+	if err := windows.WTSQueryUserToken(session, &token); err != nil {
+		return nil, fmt.Errorf("query install session user token: %w", err)
+	}
+	defer func() { _ = token.Close() }()
+	user, err := token.GetTokenUser()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get install session user: %w", err)
 	}
-	if user == "" {
-		return nil, errors.New("active console session has no user")
-	}
-	domain, err := wtsSessionString(session, wtsInfoDomainName)
-	if err != nil {
-		return nil, err
-	}
-	account := user
-	if domain != "" {
-		account = domain + `\` + user
-	}
-	sid, _, _, err := windows.LookupSID("", account)
-	if err != nil {
-		return nil, fmt.Errorf("resolve interactive user %q: %w", account, err)
-	}
-	return sid, nil
-}
-
-func wtsSessionString(session uint32, infoClass uint32) (string, error) {
-	var buffer *uint16
-	var bytesReturned uint32
-	ret, _, callErr := procWTSQuerySessionInformation.Call(
-		0,
-		uintptr(session),
-		uintptr(infoClass),
-		uintptr(unsafe.Pointer(&buffer)),
-		uintptr(unsafe.Pointer(&bytesReturned)),
-	)
-	if ret == 0 {
-		return "", fmt.Errorf("WTSQuerySessionInformation: %w", callErr)
-	}
-	defer procWTSFreeMemory.Call(uintptr(unsafe.Pointer(buffer)))
-	return windows.UTF16PtrToString(buffer), nil
+	return user.User.Sid, nil
 }
 
 func waitForServiceState(service *mgr.Service, state svc.State, timeout time.Duration) error {

--- a/cli/kent/service_backend_windows.go
+++ b/cli/kent/service_backend_windows.go
@@ -4,352 +4,334 @@ package main
 
 import (
 	"context"
+	brand "core/shared/config"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
-	brand "core/shared/config"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
 )
 
-type scheduledTaskServiceBackend struct{}
+// scmServiceBackend registers the background server as a Windows Service Control
+// Manager service. The service runs as LocalSystem (no stored password) and acts
+// as a supervisor that launches `kent serve` in the logged-in user's session via
+// the user's primary token (see service_supervisor_windows.go), so the server
+// keeps the user's full identity while no console window is ever shown.
+type scmServiceBackend struct{}
 
 func currentServiceBackend() serviceBackend {
-	return scheduledTaskServiceBackend{}
+	return scmServiceBackend{}
 }
 
-func (scheduledTaskServiceBackend) Name() string {
-	return "schtasks"
+func (scmServiceBackend) Name() string {
+	return "scm"
 }
 
-func (scheduledTaskServiceBackend) Install(ctx context.Context, spec serviceSpec, force bool, start bool) error {
+var serviceRecoveryResetPeriod = uint32((24 * time.Hour).Seconds())
+
+func (scmServiceBackend) Install(ctx context.Context, spec serviceSpec, force bool, start bool) error {
 	if err := ensureServiceLogDir(spec); err != nil {
 		return err
 	}
-	scriptPath := windowsTaskScriptPath(spec)
-	nextScript := renderWindowsTaskScript(spec)
-	installed, _ := windowsScheduledTaskInstalled(ctx)
-	startupInstalled := windowsStartupItemInstalled()
-	existingScript, scriptErr := os.ReadFile(scriptPath)
-	scriptExists := scriptErr == nil
-	if !force && (installed || startupInstalled) {
-		if !scriptExists || string(existingScript) != nextScript {
-			return fmt.Errorf(brand.ServiceDisplayName + " is already installed; use --force to rewrite it")
+	removeLegacyWindowsRegistration(ctx, spec)
+
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("connect to the service manager (installing requires Administrator): %w", err)
+	}
+	defer func() { _ = m.Disconnect() }()
+
+	if existing, openErr := m.OpenService(serviceWindowsServiceName); openErr == nil {
+		if !force {
+			_ = existing.Close()
+			return errors.New(brand.ServiceDisplayName + " is already installed; use --force to rewrite it")
 		}
-		if start {
-			return scheduledTaskServiceBackend{}.Start(ctx, spec)
+		_, _ = existing.Control(svc.Stop)
+		waitForServiceState(existing, svc.Stopped, 5*time.Second)
+		deleteErr := existing.Delete()
+		_ = existing.Close()
+		if deleteErr != nil {
+			return fmt.Errorf("remove existing service before reinstall: %w", deleteErr)
 		}
-		return nil
-	}
-	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
-		return fmt.Errorf("create task script dir: %w", err)
-	}
-	if err := os.WriteFile(scriptPath, []byte(nextScript), 0o644); err != nil {
-		return fmt.Errorf("write task script: %w", err)
-	}
-	createArgs := []string{"/Create"}
-	if force {
-		createArgs = append(createArgs, "/F")
-	}
-	createArgs = append(createArgs, "/SC", "ONLOGON", "/RL", "LIMITED", "/TN", serviceWindowsTaskName, "/TR", scriptPath)
-	if _, err := runServiceCommand(ctx, "schtasks", createArgs...); err != nil {
-		if fallbackErr := installWindowsStartupItem(ctx, spec, start); fallbackErr != nil {
-			return errors.Join(err, fmt.Errorf("startup fallback failed: %w", fallbackErr))
-		}
-		return nil
-	}
-	if err := os.Remove(windowsStartupItemPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove Startup folder fallback after scheduled task registration: %w", err)
-	}
-	if start {
-		if _, err := runServiceCommand(ctx, "schtasks", "/Run", "/TN", serviceWindowsTaskName); err != nil {
+		if err := waitForServiceAbsent(m, 5*time.Second); err != nil {
 			return err
 		}
 	}
+
+	config := mgr.Config{
+		ServiceType:      windows.SERVICE_WIN32_OWN_PROCESS,
+		StartType:        windows.SERVICE_AUTO_START,
+		ErrorControl:     windows.SERVICE_ERROR_NORMAL,
+		DisplayName:      brand.ServiceDisplayName,
+		Description:      brand.Product + " background server. Runs as the logged-in user with no console window.",
+		ServiceStartName: "LocalSystem",
+	}
+	service, err := m.CreateService(serviceWindowsServiceName, spec.Executable, config, windowsServiceRunArguments(spec.Config.PersistenceRoot)...)
+	if err != nil {
+		return fmt.Errorf("create service: %w", err)
+	}
+	defer func() { _ = service.Close() }()
+
+	if err := service.SetRecoveryActions([]mgr.RecoveryAction{
+		{Type: mgr.ServiceRestart, Delay: 2 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 5 * time.Second},
+		{Type: mgr.ServiceRestart, Delay: 10 * time.Second},
+	}, serviceRecoveryResetPeriod); err != nil {
+		return fmt.Errorf("configure restart-on-failure: %w", err)
+	}
+
+	// Best-effort: grant the installing user start/stop/query so lifecycle
+	// commands do not need elevation. A failure here only means those commands
+	// will require Administrator, so it must not fail the install.
+	_ = grantUserServiceAccess(service)
+
+	if start {
+		if err := service.Start(); err != nil {
+			return fmt.Errorf("start service: %w", err)
+		}
+	}
 	return nil
 }
 
-func (scheduledTaskServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop bool) error {
+func (scmServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop bool) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("connect to the service manager (uninstalling requires Administrator): %w", err)
+	}
+	defer func() { _ = m.Disconnect() }()
+
+	service, err := m.OpenService(serviceWindowsServiceName)
+	if err != nil {
+		// Not installed: clean up any leftover legacy registration and pid file.
+		removeLegacyWindowsRegistration(ctx, spec)
+		_ = os.Remove(windowsServerPIDPath(spec))
+		return nil
+	}
+	defer func() { _ = service.Close() }()
+
 	if stop {
-		_ = scheduledTaskServiceBackend{}.Stop(ctx, spec)
+		_, _ = service.Control(svc.Stop)
+		waitForServiceState(service, svc.Stopped, 5*time.Second)
 	}
-	_, _ = runServiceCommand(ctx, "schtasks", "/Delete", "/F", "/TN", serviceWindowsTaskName)
-	if err := os.Remove(windowsStartupItemPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove Startup folder item: %w", err)
+	if err := service.Delete(); err != nil {
+		return fmt.Errorf("delete service: %w", err)
 	}
-	if err := os.Remove(windowsTaskScriptPath(spec)); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove task script: %w", err)
-	}
+	removeLegacyWindowsRegistration(ctx, spec)
+	_ = os.Remove(windowsServerPIDPath(spec))
 	return nil
 }
 
-func (scheduledTaskServiceBackend) Start(ctx context.Context, spec serviceSpec) error {
-	if installed, _ := windowsScheduledTaskInstalled(ctx); installed {
-		_, err := runServiceCommand(ctx, "schtasks", "/Run", "/TN", serviceWindowsTaskName)
+func (scmServiceBackend) Start(ctx context.Context, spec serviceSpec) error {
+	service, cleanup, err := openServiceWithAccess(windows.SERVICE_START | windows.SERVICE_QUERY_STATUS)
+	if err != nil {
 		return err
 	}
-	if _, err := os.Stat(windowsStartupItemPath()); err == nil {
-		return launchWindowsTaskScript(ctx, spec)
+	defer cleanup()
+	if err := service.Start(); err != nil {
+		return fmt.Errorf("start service: %w", err)
 	}
-	return errors.New(brand.ServiceDisplayName + " is not installed; run `" + brand.Command + " service install`")
-}
-
-func (scheduledTaskServiceBackend) Stop(ctx context.Context, spec serviceSpec) error {
-	if installed, _ := windowsScheduledTaskInstalled(ctx); installed {
-		_, _ = runServiceCommand(ctx, "schtasks", "/End", "/TN", serviceWindowsTaskName)
-		_ = stopWindowsTaskScriptProcess(ctx, spec)
-		return nil
-	}
-	if windowsStartupItemInstalled() {
-		return stopWindowsTaskScriptProcess(ctx, spec)
-	}
-	_ = stopWindowsTaskScriptProcess(ctx, spec)
 	return nil
 }
 
-func (scheduledTaskServiceBackend) Restart(ctx context.Context, spec serviceSpec) error {
-	_ = scheduledTaskServiceBackend{}.Stop(ctx, spec)
-	return scheduledTaskServiceBackend{}.Start(ctx, spec)
+func (scmServiceBackend) Stop(ctx context.Context, spec serviceSpec) error {
+	service, cleanup, err := openServiceWithAccess(windows.SERVICE_STOP | windows.SERVICE_QUERY_STATUS)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if _, err := service.Control(svc.Stop); err != nil {
+		return fmt.Errorf("stop service: %w", err)
+	}
+	waitForServiceState(service, svc.Stopped, 5*time.Second)
+	return nil
 }
 
-func (scheduledTaskServiceBackend) Status(ctx context.Context, spec serviceSpec) (serviceStatus, error) {
-	taskInstalled, taskOutput := windowsScheduledTaskInstalled(ctx)
-	startupInstalled, err := windowsStartupItemInstalledChecked()
+func (scmServiceBackend) Restart(ctx context.Context, spec serviceSpec) error {
+	service, cleanup, err := openServiceWithAccess(windows.SERVICE_START | windows.SERVICE_STOP | windows.SERVICE_QUERY_STATUS)
 	if err != nil {
-		return serviceStatus{}, fmt.Errorf("stat Startup folder item: %w", err)
+		return err
 	}
-	taskScriptPIDs := windowsTaskScriptPIDs(ctx, spec)
-	serverPIDs := windowsRegisteredCommandPIDs(ctx, spec)
-	running := len(taskScriptPIDs) > 0
-	pid := 0
-	if running && len(serverPIDs) > 0 {
-		pid = serverPIDs[0]
+	defer cleanup()
+	if _, err := service.Control(svc.Stop); err == nil {
+		waitForServiceState(service, svc.Stopped, 5*time.Second)
 	}
-	return serviceStatus{
-		Backend:     "schtasks",
-		Installed:   taskInstalled || startupInstalled,
-		Loaded:      taskInstalled || startupInstalled,
-		Running:     running,
-		PID:         pid,
-		Command:     readWindowsRegisteredCommand(taskOutput),
+	if err := service.Start(); err != nil {
+		return fmt.Errorf("start service: %w", err)
+	}
+	return nil
+}
+
+func (scmServiceBackend) Status(ctx context.Context, spec serviceSpec) (serviceStatus, error) {
+	status := serviceStatus{
+		Backend:     "scm",
 		Endpoint:    spec.Endpoint,
 		Logs:        []string{spec.StdoutLogPath, spec.StderrLogPath},
-		InstallPath: windowsTaskScriptPath(spec),
-		Detail:      strings.TrimSpace(taskOutput),
-	}, nil
-}
-
-// readWindowsRegisteredCommand resolves the argv of the installed service from
-// the authoritative OS registration only: the scheduled task action path, or the
-// script path embedded in the Startup-folder launcher. It never derives the
-// command from a path under the requested persistence root, because lifecycle
-// actions target the single global registration -- guessing a requested-root
-// command would either fabricate a false root match or mask a real cross-root
-// mismatch (the rootMismatchError guard relies on this). It returns nil when no
-// authoritative registration path is available, which the guard treats as an
-// indeterminate (fail-open) root rather than a false match against the request.
-func readWindowsRegisteredCommand(taskQueryOutput string) []string {
-	scriptPath, ok := windowsRegisteredScriptPath(taskQueryOutput, readWindowsStartupLauncher())
-	if !ok {
-		return nil
+		InstallPath: spec.Executable,
 	}
-	return readWindowsScriptCommand(scriptPath)
-}
-
-func readWindowsStartupLauncher() string {
-	data, err := os.ReadFile(windowsStartupItemPath())
+	service, cleanup, err := openServiceWithAccess(windows.SERVICE_QUERY_STATUS | windows.SERVICE_QUERY_CONFIG)
 	if err != nil {
-		return ""
+		if errors.Is(err, windows.ERROR_SERVICE_DOES_NOT_EXIST) {
+			return status, nil
+		}
+		return serviceStatus{}, err
 	}
-	return string(data)
+	defer cleanup()
+	status.Installed = true
+	status.Loaded = true
+	if query, err := service.Query(); err == nil {
+		status.Running = query.State == svc.Running || query.State == svc.StartPending
+	}
+	if cfg, err := service.Config(); err == nil {
+		if command, err := windows.DecomposeCommandLine(cfg.BinaryPathName); err == nil {
+			status.Command = command
+		}
+	}
+	status.PID = readWindowsServerPID(spec)
+	return status, nil
 }
 
-func readWindowsScriptCommand(scriptPath string) []string {
-	data, err := os.ReadFile(scriptPath)
+// windowsServiceDir is the per-root directory holding service runtime state.
+func windowsServiceDir(spec serviceSpec) string {
+	return filepath.Join(spec.Config.PersistenceRoot, "service")
+}
+
+// windowsServerPIDPath is where the supervisor records the launched server's
+// PID. Status reads it so ownership checks compare against the actual server
+// process (the SCM-reported PID is the supervisor, not the server).
+func windowsServerPIDPath(spec serviceSpec) string {
+	return filepath.Join(windowsServiceDir(spec), "server.pid")
+}
+
+func readWindowsServerPID(spec serviceSpec) int {
+	data, err := os.ReadFile(windowsServerPIDPath(spec))
 	if err != nil {
-		return nil
+		return 0
 	}
-	for _, rawLine := range strings.Split(string(data), "\n") {
-		line := strings.TrimSpace(rawLine)
-		lower := strings.ToLower(line)
-		if line == "" || strings.HasPrefix(lower, "@echo") || strings.HasPrefix(lower, "rem ") || strings.HasPrefix(lower, "cd /d ") {
-			continue
-		}
-		if before, _, ok := strings.Cut(line, " 1>>"); ok {
-			line = before
-		}
-		return parseWindowsCommandLine(line)
-	}
-	return nil
+	return parsePositiveInt(string(data))
 }
 
-func parseWindowsCommandLine(value string) []string {
-	args := []string{}
-	var builder strings.Builder
-	inQuote := false
-	flush := func() {
-		if builder.Len() == 0 {
-			return
-		}
-		args = append(args, builder.String())
-		builder.Reset()
+// windowsServiceRunArguments are the arguments baked into the registered service
+// command: `service run --persistence-root <root>`. The supervisor re-derives the
+// server command (`serve --persistence-root <root>`) from the same root.
+func windowsServiceRunArguments(persistenceRoot string) []string {
+	args := []string{string(serviceActionRun)}
+	args = append([]string{"service"}, args...)
+	if trimmed := strings.TrimSpace(persistenceRoot); trimmed != "" {
+		args = append(args, "--persistence-root", trimmed)
 	}
-	for _, r := range value {
-		switch r {
-		case '"':
-			inQuote = !inQuote
-		case ' ', '\t':
-			if inQuote {
-				builder.WriteRune(r)
-			} else {
-				flush()
-			}
-		default:
-			builder.WriteRune(r)
-		}
-	}
-	flush()
 	return args
 }
 
-func windowsScheduledTaskInstalled(ctx context.Context) (bool, string) {
-	result, err := runServiceCommand(ctx, "schtasks", "/Query", "/TN", serviceWindowsTaskName, "/V", "/FO", "LIST")
+// openServiceWithAccess opens the service through a low-privilege SCM connection
+// (SC_MANAGER_CONNECT, available to all users) requesting only the given service
+// rights. Combined with the install-time DACL grant, this lets start/stop/status
+// run without elevation.
+func openServiceWithAccess(access uint32) (*mgr.Service, func(), error) {
+	scm, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_CONNECT)
 	if err != nil {
-		return false, strings.TrimSpace(strings.Join([]string{result.Stdout, result.Stderr}, "\n"))
+		return nil, nil, fmt.Errorf("connect to the service manager: %w", err)
 	}
-	return true, strings.TrimSpace(strings.Join([]string{result.Stdout, result.Stderr}, "\n"))
-}
-
-func windowsStartupItemInstalled() bool {
-	installed, _ := windowsStartupItemInstalledChecked()
-	return installed
-}
-
-func windowsStartupItemInstalledChecked() (bool, error) {
-	if _, err := os.Stat(windowsStartupItemPath()); err == nil {
-		return true, nil
-	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return false, err
+	namePtr, err := windows.UTF16PtrFromString(serviceWindowsServiceName)
+	if err != nil {
+		_ = windows.CloseServiceHandle(scm)
+		return nil, nil, err
 	}
-	return false, nil
+	handle, err := windows.OpenService(scm, namePtr, access)
+	if err != nil {
+		_ = windows.CloseServiceHandle(scm)
+		if errors.Is(err, windows.ERROR_SERVICE_DOES_NOT_EXIST) {
+			return nil, nil, windows.ERROR_SERVICE_DOES_NOT_EXIST
+		}
+		return nil, nil, fmt.Errorf("open service (is it installed? run `%s service install`): %w", brand.Command, err)
+	}
+	service := &mgr.Service{Name: serviceWindowsServiceName, Handle: handle}
+	cleanup := func() {
+		_ = windows.CloseServiceHandle(handle)
+		_ = windows.CloseServiceHandle(scm)
+	}
+	return service, cleanup, nil
 }
 
-func windowsTaskScriptPath(spec serviceSpec) string {
-	return filepath.Join(spec.Config.PersistenceRoot, "service", "server.cmd")
+// grantUserServiceAccess adds an ACE granting the installing user start/stop/query
+// on the service so lifecycle commands work without elevation.
+func grantUserServiceAccess(service *mgr.Service) error {
+	token, err := windows.OpenCurrentProcessToken()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = token.Close() }()
+	user, err := token.GetTokenUser()
+	if err != nil {
+		return err
+	}
+	descriptor, err := windows.GetSecurityInfo(service.Handle, windows.SE_SERVICE, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return err
+	}
+	existing, _, err := descriptor.DACL()
+	if err != nil {
+		return err
+	}
+	entry := windows.EXPLICIT_ACCESS{
+		AccessPermissions: windows.SERVICE_START | windows.SERVICE_STOP | windows.SERVICE_QUERY_STATUS | windows.READ_CONTROL,
+		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       windows.NO_INHERITANCE,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_USER,
+			TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
+		},
+	}
+	merged, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{entry}, existing)
+	if err != nil {
+		return err
+	}
+	return windows.SetSecurityInfo(service.Handle, windows.SE_SERVICE, windows.DACL_SECURITY_INFORMATION, nil, nil, merged, nil)
 }
 
-func windowsStartupItemPath() string {
+func waitForServiceState(service *mgr.Service, state svc.State, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		status, err := service.Query()
+		if err != nil || status.State == state {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func waitForServiceAbsent(m *mgr.Mgr, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		service, err := m.OpenService(serviceWindowsServiceName)
+		if err != nil {
+			return nil
+		}
+		_ = service.Close()
+		if time.Now().After(deadline) {
+			return errors.New("existing service still registered after delete; reboot or stop dependent processes and retry")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// removeLegacyWindowsRegistration tears down the pre-SCM scheduled task and
+// Startup-folder launcher so upgraders stop getting the old console windows.
+func removeLegacyWindowsRegistration(ctx context.Context, spec serviceSpec) {
+	_, _ = runServiceCommand(ctx, "schtasks", "/Delete", "/F", "/TN", serviceWindowsTaskName)
+	_ = os.Remove(legacyWindowsStartupItemPath())
+	_ = os.Remove(filepath.Join(windowsServiceDir(spec), "server.cmd"))
+}
+
+func legacyWindowsStartupItemPath() string {
 	base := strings.TrimSpace(os.Getenv("APPDATA"))
 	if base == "" {
 		base = filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Roaming")
 	}
 	return filepath.Join(base, "Microsoft", "Windows", "Start Menu", "Programs", "Startup", serviceWindowsTaskName+".cmd")
-}
-
-func installWindowsStartupItem(ctx context.Context, spec serviceSpec, start bool) error {
-	path := windowsStartupItemPath()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create Startup folder: %w", err)
-	}
-	contents := "@echo off\r\nstart \"\" /min cmd.exe /d /c " + windowsCmdQuote(windowsTaskScriptPath(spec)) + "\r\n"
-	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
-		return fmt.Errorf("write Startup folder item: %w", err)
-	}
-	if start {
-		return launchWindowsTaskScript(ctx, spec)
-	}
-	return nil
-}
-
-func launchWindowsTaskScript(ctx context.Context, spec serviceSpec) error {
-	_, err := runServiceCommand(ctx, "cmd.exe", "/d", "/c", "start", "", "/min", "cmd.exe", "/d", "/c", windowsTaskScriptPath(spec))
-	return err
-}
-
-func stopWindowsTaskScriptProcess(ctx context.Context, spec serviceSpec) error {
-	for _, pid := range windowsTaskScriptPIDs(ctx, spec) {
-		if pid <= 0 {
-			continue
-		}
-		_, _ = runServiceCommand(ctx, "taskkill", "/T", "/F", "/PID", fmt.Sprintf("%d", pid))
-	}
-	return nil
-}
-
-func windowsTaskScriptPIDs(ctx context.Context, spec serviceSpec) []int {
-	needle := strings.ReplaceAll(windowsTaskScriptPath(spec), "/", "\\")
-	return windowsProcessPIDsMatchingAll(ctx, []string{needle})
-}
-
-func windowsRegisteredCommandPIDs(ctx context.Context, spec serviceSpec) []int {
-	// PID matching is scoped to the requested root's server script (the running/PID
-	// display is per requested root), which is a deliberately different concern
-	// from which root owns the global registration. Read the requested-root script
-	// directly here rather than the authoritative registration.
-	command := readWindowsScriptCommand(windowsTaskScriptPath(spec))
-	if len(command) == 0 {
-		return nil
-	}
-	return windowsProcessPIDsMatchingAll(ctx, command)
-}
-
-func windowsProcessPIDsMatchingAll(ctx context.Context, needles []string) []int {
-	filteredNeedles := make([]string, 0, len(needles))
-	for _, needle := range needles {
-		trimmed := strings.TrimSpace(strings.ReplaceAll(needle, "/", "\\"))
-		if trimmed != "" {
-			filteredNeedles = append(filteredNeedles, trimmed)
-		}
-	}
-	if len(filteredNeedles) == 0 {
-		return nil
-	}
-	var script strings.Builder
-	script.WriteString("$self = $PID; $needles = @(")
-	for i, needle := range filteredNeedles {
-		if i > 0 {
-			script.WriteString(", ")
-		}
-		script.WriteString(windowsPowerShellSingleQuote(needle))
-	}
-	script.WriteString("); Get-CimInstance Win32_Process | Where-Object { $_.ProcessId -ne $self -and $_.CommandLine } | Where-Object { $cmd = ($_.CommandLine -replace '/', '\\'); $ok = $true; foreach ($needle in $needles) { if ($cmd.IndexOf($needle, [StringComparison]::OrdinalIgnoreCase) -lt 0) { $ok = $false; break } }; $ok } | ForEach-Object { $_.ProcessId }")
-	result, err := runServiceCommand(ctx, "powershell", "-NoProfile", "-Command", script.String())
-	if err != nil {
-		return nil
-	}
-	pids := []int{}
-	for _, line := range strings.Split(result.Stdout, "\n") {
-		if pid := parsePositiveInt(line); pid > 0 {
-			pids = append(pids, pid)
-		}
-	}
-	return pids
-}
-
-func windowsPowerShellSingleQuote(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
-}
-
-func renderWindowsTaskScript(spec serviceSpec) string {
-	lines := []string{"@echo off"}
-	lines = append(lines, "cd /d "+windowsCmdQuote(spec.Config.PersistenceRoot))
-	lines = append(lines, serviceCommandLineWindows(serviceCommand(spec))+" 1>>"+windowsCmdQuote(spec.StdoutLogPath)+" 2>>"+windowsCmdQuote(spec.StderrLogPath))
-	return strings.Join(lines, "\r\n") + "\r\n"
-}
-
-func serviceCommandLineWindows(args []string) string {
-	parts := make([]string, 0, len(args))
-	for _, arg := range args {
-		parts = append(parts, windowsCmdQuote(arg))
-	}
-	return strings.Join(parts, " ")
-}
-
-func windowsCmdQuote(value string) string {
-	escaped := strings.ReplaceAll(value, `"`, `\"`)
-	if escaped == "" || strings.ContainsAny(escaped, " \t&()[]{}^=;!'+,`~") {
-		return `"` + escaped + `"`
-	}
-	return escaped
 }

--- a/cli/kent/service_backend_windows.go
+++ b/cli/kent/service_backend_windows.go
@@ -137,7 +137,9 @@ func (scmServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop b
 
 	if stop {
 		if _, err := service.Control(svc.Stop); err == nil {
-			_ = waitForServiceState(service, svc.Stopped, serviceStopWindow)
+			if werr := waitForServiceState(service, svc.Stopped, serviceStopWindow); werr != nil {
+				return fmt.Errorf("stop service before uninstall: %w", werr)
+			}
 		}
 	}
 	if err := service.Delete(); err != nil {
@@ -156,6 +158,9 @@ func (scmServiceBackend) Start(ctx context.Context, spec serviceSpec) error {
 	}
 	defer cleanup()
 	if err := service.Start(); err != nil {
+		if errors.Is(err, windows.ERROR_SERVICE_ALREADY_RUNNING) {
+			return nil
+		}
 		return fmt.Errorf("start service: %w", err)
 	}
 	return nil

--- a/cli/kent/service_backend_windows.go
+++ b/cli/kent/service_backend_windows.go
@@ -25,15 +25,11 @@ var (
 )
 
 const (
-	wtsInfoUserName   = 5 // WTSUserName
-	wtsInfoDomainName = 7 // WTSDomainName
+	wtsInfoUserName     = 5
+	wtsInfoDomainName   = 7
+	wtsInvalidSessionID = 0xFFFFFFFF
 )
 
-// scmServiceBackend registers the background server as a Windows Service Control
-// Manager service. The service runs as LocalSystem (no stored password) and acts
-// as a supervisor that launches `kent serve` in the logged-in user's session via
-// the user's primary token (see service_supervisor_windows.go), so the server
-// keeps the user's full identity while no console window is ever shown.
 type scmServiceBackend struct{}
 
 func currentServiceBackend() serviceBackend {
@@ -84,7 +80,7 @@ func (scmServiceBackend) Install(ctx context.Context, spec serviceSpec, force bo
 		StartType:        windows.SERVICE_AUTO_START,
 		ErrorControl:     windows.SERVICE_ERROR_NORMAL,
 		DisplayName:      brand.ServiceDisplayName,
-		Description:      brand.Product + " background server. Runs as the logged-in user with no console window.",
+		Description:      brand.Product + " background server.",
 		ServiceStartName: "LocalSystem",
 	}
 	service, err := m.CreateService(serviceWindowsServiceName, spec.Executable, config, windowsServiceRunArguments(spec.Config.PersistenceRoot)...)
@@ -101,10 +97,9 @@ func (scmServiceBackend) Install(ctx context.Context, spec serviceSpec, force bo
 		return fmt.Errorf("configure restart-on-failure: %w", err)
 	}
 
-	// Best-effort: grant the installing user start/stop/query so lifecycle
-	// commands do not need elevation. A failure here only means those commands
-	// will require Administrator, so it must not fail the install.
-	_ = grantUserServiceAccess(service)
+	if err := grantUserServiceAccess(service); err != nil {
+		return fmt.Errorf("grant service control to the installing user: %w", err)
+	}
 
 	persistInstallUser(spec)
 
@@ -128,7 +123,9 @@ func (scmServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop b
 		if !errors.Is(err, windows.ERROR_SERVICE_DOES_NOT_EXIST) {
 			return fmt.Errorf("open service: %w", err)
 		}
-		// Not installed: clean up any leftover legacy registration and pid file.
+		if stop {
+			endLegacyWindowsTask(ctx)
+		}
 		removeLegacyWindowsRegistration(ctx, spec)
 		_ = os.Remove(windowsServerPIDPath(spec))
 		return nil
@@ -141,6 +138,7 @@ func (scmServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop b
 				return fmt.Errorf("stop service before uninstall: %w", werr)
 			}
 		}
+		endLegacyWindowsTask(ctx)
 	}
 	if err := service.Delete(); err != nil {
 		return fmt.Errorf("delete service: %w", err)
@@ -230,14 +228,10 @@ func (scmServiceBackend) Status(ctx context.Context, spec serviceSpec) (serviceS
 	return status, nil
 }
 
-// windowsServiceDir is the per-root directory holding service runtime state.
 func windowsServiceDir(spec serviceSpec) string {
 	return filepath.Join(spec.Config.PersistenceRoot, "service")
 }
 
-// windowsServerPIDPath is where the supervisor records the launched server's
-// PID. Status reads it so ownership checks compare against the actual server
-// process (the SCM-reported PID is the supervisor, not the server).
 func windowsServerPIDPath(spec serviceSpec) string {
 	return filepath.Join(windowsServiceDir(spec), "server.pid")
 }
@@ -250,16 +244,10 @@ func readWindowsServerPID(spec serviceSpec) int {
 	return parsePositiveInt(string(data))
 }
 
-// installUserSIDPath records the SID of the user the service was installed for,
-// so the supervisor launches the server only for that user's console session and
-// never for a different user against the installer's baked persistence root.
 func installUserSIDPath(spec serviceSpec) string {
 	return filepath.Join(windowsServiceDir(spec), "install_user.sid")
 }
 
-// persistInstallUser records the interactive user's SID at install time. It is
-// best-effort: when the SID cannot be resolved the supervisor falls back to
-// serving whichever user holds the console.
 func persistInstallUser(spec serviceSpec) {
 	sid, err := interactiveUserSID()
 	if err != nil {
@@ -277,9 +265,6 @@ func readInstallUserSID(spec serviceSpec) string {
 	return strings.TrimSpace(string(data))
 }
 
-// windowsServiceRunArguments are the arguments baked into the registered service
-// command: `service run --persistence-root <root>`. The supervisor re-derives the
-// server command (`serve --persistence-root <root>`) from the same root.
 func windowsServiceRunArguments(persistenceRoot string) []string {
 	args := []string{string(serviceActionRun)}
 	args = append([]string{"service"}, args...)
@@ -289,10 +274,6 @@ func windowsServiceRunArguments(persistenceRoot string) []string {
 	return args
 }
 
-// openServiceWithAccess opens the service through a low-privilege SCM connection
-// (SC_MANAGER_CONNECT, available to all users) requesting only the given service
-// rights. Combined with the install-time DACL grant, this lets start/stop/status
-// run without elevation.
 func openServiceWithAccess(access uint32) (*mgr.Service, func(), error) {
 	scm, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_CONNECT)
 	if err != nil {
@@ -319,8 +300,6 @@ func openServiceWithAccess(access uint32) (*mgr.Service, func(), error) {
 	return service, cleanup, nil
 }
 
-// grantUserServiceAccess adds an ACE granting the interactive user
-// start/stop/query on the service so lifecycle commands work without elevation.
 func grantUserServiceAccess(service *mgr.Service) error {
 	descriptor, err := windows.GetSecurityInfo(service.Handle, windows.SE_SERVICE, windows.DACL_SECURITY_INFORMATION)
 	if err != nil {
@@ -332,9 +311,7 @@ func grantUserServiceAccess(service *mgr.Service) error {
 	}
 	sid, err := interactiveUserSID()
 	if err != nil {
-		// Fall back to the elevated process's own user. For an admin-approval-mode
-		// UAC install (the common case) this is the same console user; only a
-		// credential-prompt install under a different admin loses the grant here.
+
 		token, terr := windows.OpenCurrentProcessToken()
 		if terr != nil {
 			return terr
@@ -363,12 +340,9 @@ func grantUserServiceAccess(service *mgr.Service) error {
 	return windows.SetSecurityInfo(service.Handle, windows.SE_SERVICE, windows.DACL_SECURITY_INFORMATION, nil, nil, merged, nil)
 }
 
-// interactiveUserSID resolves the SID of the user owning the active console
-// session, so a credential-prompt UAC install run under a different admin still
-// grants service lifecycle rights to the person who will run start/stop/status.
 func interactiveUserSID() (*windows.SID, error) {
 	session := windows.WTSGetActiveConsoleSessionId()
-	if session == 0xFFFFFFFF {
+	if session == wtsInvalidSessionID {
 		return nil, errors.New("no active console session")
 	}
 	user, err := wtsSessionString(session, wtsInfoUserName)
@@ -397,7 +371,7 @@ func wtsSessionString(session uint32, infoClass uint32) (string, error) {
 	var buffer *uint16
 	var bytesReturned uint32
 	ret, _, callErr := procWTSQuerySessionInformation.Call(
-		0, // WTS_CURRENT_SERVER_HANDLE
+		0,
 		uintptr(session),
 		uintptr(infoClass),
 		uintptr(unsafe.Pointer(&buffer)),
@@ -442,17 +416,15 @@ func waitForServiceAbsent(m *mgr.Mgr, timeout time.Duration) error {
 	}
 }
 
-// stopLegacyServer ends any still-running pre-SCM scheduled-task server so the
-// unmanaged-server preflight does not block migration. The registration itself
-// is removed by removeLegacyWindowsRegistration during install/uninstall.
 func (scmServiceBackend) stopLegacyServer(ctx context.Context, spec serviceSpec) {
+	endLegacyWindowsTask(ctx)
+}
+
+func endLegacyWindowsTask(ctx context.Context) {
 	_, _ = runServiceCommand(ctx, "schtasks", "/End", "/TN", serviceWindowsTaskName)
 }
 
-// removeLegacyWindowsRegistration tears down the pre-SCM scheduled task and
-// Startup-folder launcher so upgraders stop getting the old console windows.
 func removeLegacyWindowsRegistration(ctx context.Context, spec serviceSpec) {
-	_, _ = runServiceCommand(ctx, "schtasks", "/End", "/TN", serviceWindowsTaskName)
 	_, _ = runServiceCommand(ctx, "schtasks", "/Delete", "/F", "/TN", serviceWindowsTaskName)
 	_ = os.Remove(legacyWindowsStartupItemPath())
 	_ = os.Remove(filepath.Join(windowsServiceDir(spec), "server.cmd"))

--- a/cli/kent/service_backend_windows.go
+++ b/cli/kent/service_backend_windows.go
@@ -103,6 +103,8 @@ func (scmServiceBackend) Install(ctx context.Context, spec serviceSpec, force bo
 	// will require Administrator, so it must not fail the install.
 	_ = grantUserServiceAccess(service)
 
+	persistInstallUser(spec)
+
 	if start {
 		if err := service.Start(); err != nil {
 			return fmt.Errorf("start service: %w", err)
@@ -140,6 +142,7 @@ func (scmServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop b
 	}
 	removeLegacyWindowsRegistration(ctx, spec)
 	_ = os.Remove(windowsServerPIDPath(spec))
+	_ = os.Remove(installUserSIDPath(spec))
 	return nil
 }
 
@@ -234,6 +237,33 @@ func readWindowsServerPID(spec serviceSpec) int {
 		return 0
 	}
 	return parsePositiveInt(string(data))
+}
+
+// installUserSIDPath records the SID of the user the service was installed for,
+// so the supervisor launches the server only for that user's console session and
+// never for a different user against the installer's baked persistence root.
+func installUserSIDPath(spec serviceSpec) string {
+	return filepath.Join(windowsServiceDir(spec), "install_user.sid")
+}
+
+// persistInstallUser records the interactive user's SID at install time. It is
+// best-effort: when the SID cannot be resolved the supervisor falls back to
+// serving whichever user holds the console.
+func persistInstallUser(spec serviceSpec) {
+	sid, err := interactiveUserSID()
+	if err != nil {
+		return
+	}
+	_ = os.MkdirAll(windowsServiceDir(spec), 0o755)
+	_ = os.WriteFile(installUserSIDPath(spec), []byte(sid.String()), 0o644)
+}
+
+func readInstallUserSID(spec serviceSpec) string {
+	data, err := os.ReadFile(installUserSIDPath(spec))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }
 
 // windowsServiceRunArguments are the arguments baked into the registered service

--- a/cli/kent/service_backend_windows.go
+++ b/cli/kent/service_backend_windows.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
@@ -46,14 +47,9 @@ func (scmServiceBackend) Install(ctx context.Context, spec serviceSpec, force bo
 			_ = existing.Close()
 			return errors.New(brand.ServiceDisplayName + " is already installed; use --force to rewrite it")
 		}
-		if _, err := existing.Control(svc.Stop); err != nil {
-			if !errors.Is(err, windows.ERROR_SERVICE_NOT_ACTIVE) {
-				_ = existing.Close()
-				return fmt.Errorf("stop existing service before reinstall: %w", err)
-			}
-		} else if werr := waitForServiceState(existing, svc.Stopped, serviceStopWindow); werr != nil {
+		if err := stopServiceAndWait(existing); err != nil {
 			_ = existing.Close()
-			return fmt.Errorf("stop existing service before reinstall: %w", werr)
+			return fmt.Errorf("stop existing service before reinstall: %w", err)
 		}
 		deleteErr := existing.Delete()
 		_ = existing.Close()
@@ -123,12 +119,8 @@ func (scmServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop b
 	defer func() { _ = service.Close() }()
 
 	if stop {
-		if _, err := service.Control(svc.Stop); err != nil {
-			if !errors.Is(err, windows.ERROR_SERVICE_NOT_ACTIVE) {
-				return fmt.Errorf("stop service before uninstall: %w", err)
-			}
-		} else if werr := waitForServiceState(service, svc.Stopped, serviceStopWindow); werr != nil {
-			return fmt.Errorf("stop service before uninstall: %w", werr)
+		if err := stopServiceAndWait(service); err != nil {
+			return fmt.Errorf("stop service before uninstall: %w", err)
 		}
 		endLegacyWindowsTask(ctx)
 	}
@@ -162,13 +154,7 @@ func (scmServiceBackend) Stop(ctx context.Context, spec serviceSpec) error {
 		return err
 	}
 	defer cleanup()
-	if _, err := service.Control(svc.Stop); err != nil {
-		if errors.Is(err, windows.ERROR_SERVICE_NOT_ACTIVE) {
-			return nil
-		}
-		return fmt.Errorf("stop service: %w", err)
-	}
-	if err := waitForServiceState(service, svc.Stopped, serviceStopWindow); err != nil {
+	if err := stopServiceAndWait(service); err != nil {
 		return fmt.Errorf("stop service: %w", err)
 	}
 	return nil
@@ -180,10 +166,8 @@ func (scmServiceBackend) Restart(ctx context.Context, spec serviceSpec) error {
 		return err
 	}
 	defer cleanup()
-	if _, err := service.Control(svc.Stop); err == nil {
-		if err := waitForServiceState(service, svc.Stopped, serviceStopWindow); err != nil {
-			return fmt.Errorf("wait for service to stop before restart: %w", err)
-		}
+	if err := stopServiceAndWait(service); err != nil {
+		return fmt.Errorf("stop service before restart: %w", err)
 	}
 	if err := service.Start(); err != nil {
 		return fmt.Errorf("start service: %w", err)
@@ -332,6 +316,16 @@ func grantUserServiceAccess(service *mgr.Service) error {
 	return windows.SetSecurityInfo(service.Handle, windows.SE_SERVICE, windows.DACL_SECURITY_INFORMATION, nil, nil, merged, nil)
 }
 
+var (
+	wtsapi32DLL                    = windows.NewLazySystemDLL("wtsapi32.dll")
+	procWTSQuerySessionInformation = wtsapi32DLL.NewProc("WTSQuerySessionInformationW")
+)
+
+const (
+	wtsInfoUserName   = 5
+	wtsInfoDomainName = 7
+)
+
 func interactiveUserSID() (*windows.SID, error) {
 	var session uint32
 	if err := windows.ProcessIdToSessionId(windows.GetCurrentProcessId(), &session); err != nil {
@@ -340,16 +334,53 @@ func interactiveUserSID() (*windows.SID, error) {
 	if session == 0 {
 		return nil, errors.New("install is not running in an interactive session")
 	}
-	var token windows.Token
-	if err := windows.WTSQueryUserToken(session, &token); err != nil {
-		return nil, fmt.Errorf("query install session user token: %w", err)
-	}
-	defer func() { _ = token.Close() }()
-	user, err := token.GetTokenUser()
+	user, err := wtsSessionString(session, wtsInfoUserName)
 	if err != nil {
-		return nil, fmt.Errorf("get install session user: %w", err)
+		return nil, err
 	}
-	return user.User.Sid, nil
+	if user == "" {
+		return nil, errors.New("install session has no user")
+	}
+	domain, err := wtsSessionString(session, wtsInfoDomainName)
+	if err != nil {
+		return nil, err
+	}
+	account := user
+	if domain != "" {
+		account = domain + `\` + user
+	}
+	sid, _, _, err := windows.LookupSID("", account)
+	if err != nil {
+		return nil, fmt.Errorf("resolve install user %q: %w", account, err)
+	}
+	return sid, nil
+}
+
+func wtsSessionString(session uint32, infoClass uint32) (string, error) {
+	var buffer *uint16
+	var bytesReturned uint32
+	ret, _, callErr := procWTSQuerySessionInformation.Call(
+		0,
+		uintptr(session),
+		uintptr(infoClass),
+		uintptr(unsafe.Pointer(&buffer)),
+		uintptr(unsafe.Pointer(&bytesReturned)),
+	)
+	if ret == 0 {
+		return "", fmt.Errorf("WTSQuerySessionInformation: %w", callErr)
+	}
+	defer windows.WTSFreeMemory(uintptr(unsafe.Pointer(buffer)))
+	return windows.UTF16PtrToString(buffer), nil
+}
+
+func stopServiceAndWait(service *mgr.Service) error {
+	if _, err := service.Control(svc.Stop); err != nil {
+		if errors.Is(err, windows.ERROR_SERVICE_NOT_ACTIVE) {
+			return nil
+		}
+		return err
+	}
+	return waitForServiceState(service, svc.Stopped, serviceStopWindow)
 }
 
 func waitForServiceState(service *mgr.Service, state svc.State, timeout time.Duration) error {

--- a/cli/kent/service_backend_windows_test.go
+++ b/cli/kent/service_backend_windows_test.go
@@ -3,242 +3,32 @@
 package main
 
 import (
-	"context"
 	"core/shared/config"
-	"errors"
-	"os"
 	"path/filepath"
-	"reflect"
-	"strings"
 	"testing"
 )
 
-func TestWindowsInstallWithoutForceRejectsExistingDifferentScript(t *testing.T) {
-	spec := windowsServiceTestSpec(t)
-	if err := os.MkdirAll(filepath.Dir(windowsTaskScriptPath(spec)), 0o755); err != nil {
-		t.Fatalf("mkdir task script dir: %v", err)
-	}
-	if err := os.WriteFile(windowsTaskScriptPath(spec), []byte("old script"), 0o644); err != nil {
-		t.Fatalf("write existing task script: %v", err)
-	}
-	calls := captureWindowsServiceCommands(t, func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
-		return serviceCommandResult{}, errors.New("unexpected command")
-	})
-
-	err := (scheduledTaskServiceBackend{}).Install(context.Background(), spec, false, false)
-	if err == nil {
-		t.Fatal("expected existing script rejection")
-	}
-	if string(mustReadFile(t, windowsTaskScriptPath(spec))) != "old script" {
-		t.Fatal("expected existing script to remain unchanged")
-	}
-	if len(*calls) != 0 {
-		t.Fatalf("commands = %+v, want none", *calls)
+func TestWindowsServiceRunArgumentsBakesRoot(t *testing.T) {
+	got := windowsServiceRunArguments(`C:\Roots\kent`)
+	want := []string{"service", "run", "--persistence-root", `C:\Roots\kent`}
+	if !commandArgsEqual(got, want) {
+		t.Fatalf("windowsServiceRunArguments = %#v, want %#v", got, want)
 	}
 }
 
-func TestWindowsInstallWithoutForceReRegistersOrphanScript(t *testing.T) {
-	spec := windowsServiceTestSpec(t)
-	if err := os.MkdirAll(filepath.Dir(windowsTaskScriptPath(spec)), 0o755); err != nil {
-		t.Fatalf("mkdir task script dir: %v", err)
-	}
-	if err := os.WriteFile(windowsTaskScriptPath(spec), []byte("old script"), 0o644); err != nil {
-		t.Fatalf("write existing task script: %v", err)
-	}
-	calls := captureWindowsServiceCommands(t, func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
-		switch name {
-		case "schtasks":
-			if len(args) > 0 && args[0] == "/Query" {
-				return serviceCommandResult{}, errors.New("task missing")
-			}
-			return serviceCommandResult{}, nil
-		default:
-			return serviceCommandResult{}, errors.New("unexpected command")
-		}
-	})
-
-	if err := (scheduledTaskServiceBackend{}).Install(context.Background(), spec, false, false); err != nil {
-		t.Fatalf("install with orphan script: %v", err)
-	}
-	if string(mustReadFile(t, windowsTaskScriptPath(spec))) == "old script" {
-		t.Fatal("expected orphan script to be rewritten")
-	}
-	if len(*calls) != 2 || (*calls)[1][0] != "schtasks" || (*calls)[1][1] != "/Create" {
-		t.Fatalf("calls = %+v, want query then create", *calls)
+func TestWindowsServiceRunArgumentsOmitsEmptyRoot(t *testing.T) {
+	got := windowsServiceRunArguments("   ")
+	want := []string{"service", "run"}
+	if !commandArgsEqual(got, want) {
+		t.Fatalf("windowsServiceRunArguments = %#v, want %#v", got, want)
 	}
 }
 
-func TestWindowsInstallRemovesStartupFallbackAfterScheduledTaskRegistration(t *testing.T) {
-	spec := windowsServiceTestSpec(t)
-	if err := os.MkdirAll(filepath.Dir(windowsStartupItemPath()), 0o755); err != nil {
-		t.Fatalf("mkdir startup dir: %v", err)
+func TestWindowsServerPIDPathUnderServiceDir(t *testing.T) {
+	spec := serviceSpec{Config: config.App{PersistenceRoot: `C:\Roots\kent`}}
+	got := windowsServerPIDPath(spec)
+	want := filepath.Join(`C:\Roots\kent`, "service", "server.pid")
+	if got != want {
+		t.Fatalf("windowsServerPIDPath = %q, want %q", got, want)
 	}
-	if err := os.WriteFile(windowsStartupItemPath(), []byte("fallback"), 0o644); err != nil {
-		t.Fatalf("write startup item: %v", err)
-	}
-	calls := captureWindowsServiceCommands(t, func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
-		switch name {
-		case "schtasks":
-			if len(args) > 0 && args[0] == "/Query" {
-				return serviceCommandResult{}, errors.New("task missing")
-			}
-			return serviceCommandResult{}, nil
-		default:
-			return serviceCommandResult{}, errors.New("unexpected command")
-		}
-	})
-
-	if err := (scheduledTaskServiceBackend{}).Install(context.Background(), spec, true, false); err != nil {
-		t.Fatalf("install: %v", err)
-	}
-	if _, err := os.Stat(windowsStartupItemPath()); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("startup fallback stat err = %v, want not exist", err)
-	}
-	if len(*calls) != 2 || (*calls)[1][0] != "schtasks" || (*calls)[1][1] != "/Create" {
-		t.Fatalf("calls = %+v, want query then create", *calls)
-	}
-}
-
-func TestWindowsStopStartupFallbackKillsTaskScriptProcess(t *testing.T) {
-	spec := windowsServiceTestSpec(t)
-	if err := os.MkdirAll(filepath.Dir(windowsStartupItemPath()), 0o755); err != nil {
-		t.Fatalf("mkdir startup dir: %v", err)
-	}
-	if err := os.WriteFile(windowsStartupItemPath(), []byte("launcher"), 0o644); err != nil {
-		t.Fatalf("write startup item: %v", err)
-	}
-	calls := captureWindowsServiceCommands(t, func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
-		switch name {
-		case "schtasks":
-			return serviceCommandResult{}, errors.New("task missing")
-		case "powershell":
-			return serviceCommandResult{Stdout: "123\r\n"}, nil
-		case "taskkill":
-			return serviceCommandResult{}, nil
-		default:
-			return serviceCommandResult{}, errors.New("unexpected command")
-		}
-	})
-
-	if err := (scheduledTaskServiceBackend{}).Stop(context.Background(), spec); err != nil {
-		t.Fatalf("stop fallback: %v", err)
-	}
-	want := []string{"taskkill", "/T", "/F", "/PID", "123"}
-	if len(*calls) != 3 || !reflect.DeepEqual((*calls)[2], want) {
-		t.Fatalf("calls = %+v, want final %v", *calls, want)
-	}
-}
-
-func TestWindowsStatusReportsRegisteredServerPID(t *testing.T) {
-	spec := windowsServiceTestSpec(t)
-	if err := os.MkdirAll(filepath.Dir(windowsTaskScriptPath(spec)), 0o755); err != nil {
-		t.Fatalf("mkdir task script dir: %v", err)
-	}
-	if err := os.WriteFile(windowsTaskScriptPath(spec), []byte(renderWindowsTaskScript(spec)), 0o644); err != nil {
-		t.Fatalf("write task script: %v", err)
-	}
-	captureWindowsServiceCommands(t, func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
-		switch name {
-		case "schtasks":
-			return serviceCommandResult{Stdout: "Status: Running\r\n"}, nil
-		case "powershell":
-			script := strings.Join(args, " ")
-			if strings.Contains(script, windowsTaskScriptPath(spec)) {
-				return serviceCommandResult{Stdout: "111\r\n"}, nil
-			}
-			if strings.Contains(script, spec.Executable) {
-				return serviceCommandResult{Stdout: "222\r\n"}, nil
-			}
-			return serviceCommandResult{}, nil
-		default:
-			return serviceCommandResult{}, errors.New("unexpected command")
-		}
-	})
-
-	status, err := (scheduledTaskServiceBackend{}).Status(context.Background(), spec)
-	if err != nil {
-		t.Fatalf("status: %v", err)
-	}
-	if status.PID != 222 {
-		t.Fatalf("status PID = %d, want registered server PID 222", status.PID)
-	}
-}
-
-func TestWindowsStatusDoesNotTreatBareServerProcessAsServiceRunning(t *testing.T) {
-	spec := windowsServiceTestSpec(t)
-	if err := os.MkdirAll(filepath.Dir(windowsTaskScriptPath(spec)), 0o755); err != nil {
-		t.Fatalf("mkdir task script dir: %v", err)
-	}
-	if err := os.WriteFile(windowsTaskScriptPath(spec), []byte(renderWindowsTaskScript(spec)), 0o644); err != nil {
-		t.Fatalf("write task script: %v", err)
-	}
-	captureWindowsServiceCommands(t, func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
-		switch name {
-		case "schtasks":
-			return serviceCommandResult{Stdout: "Status: Ready\r\n"}, nil
-		case "powershell":
-			script := strings.Join(args, " ")
-			if strings.Contains(script, windowsTaskScriptPath(spec)) {
-				return serviceCommandResult{}, nil
-			}
-			if strings.Contains(script, spec.Executable) {
-				return serviceCommandResult{Stdout: "222\r\n"}, nil
-			}
-			return serviceCommandResult{}, nil
-		default:
-			return serviceCommandResult{}, errors.New("unexpected command")
-		}
-	})
-
-	status, err := (scheduledTaskServiceBackend{}).Status(context.Background(), spec)
-	if err != nil {
-		t.Fatalf("status: %v", err)
-	}
-	if status.Running || status.PID != 0 {
-		t.Fatalf("status running=%v pid=%d, want stopped with no service PID", status.Running, status.PID)
-	}
-}
-
-func TestParseWindowsCommandLinePreservesPathBackslashes(t *testing.T) {
-	got := parseWindowsCommandLine(`"C:\Users\Nek\AppData\Local\Kent\kent.exe" serve`)
-	want := []string{`C:\Users\Nek\AppData\Local\Kent\kent.exe`, "serve"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("parseWindowsCommandLine = %#v, want %#v", got, want)
-	}
-}
-
-func windowsServiceTestSpec(t *testing.T) serviceSpec {
-	t.Helper()
-	temp := t.TempDir()
-	t.Setenv("APPDATA", filepath.Join(temp, "AppData", "Roaming"))
-	return serviceSpec{
-		Config:        config.App{PersistenceRoot: filepath.Join(temp, config.ConfigDirName)},
-		Executable:    filepath.Join(temp, "kent.exe"),
-		Arguments:     []string{"serve"},
-		LogDir:        filepath.Join(temp, config.ConfigDirName, "logs"),
-		StdoutLogPath: filepath.Join(temp, config.ConfigDirName, "logs", "server.log"),
-		StderrLogPath: filepath.Join(temp, config.ConfigDirName, "logs", "server.err.log"),
-		Endpoint:      "http://127.0.0.1:53082",
-	}
-}
-
-func captureWindowsServiceCommands(t *testing.T, fn func(context.Context, string, ...string) (serviceCommandResult, error)) *[][]string {
-	t.Helper()
-	original := runServiceCommand
-	calls := [][]string{}
-	runServiceCommand = func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
-		calls = append(calls, append([]string{name}, args...))
-		return fn(ctx, name, args...)
-	}
-	t.Cleanup(func() { runServiceCommand = original })
-	return &calls
-}
-
-func mustReadFile(t *testing.T, path string) []byte {
-	t.Helper()
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read file %s: %v", path, err)
-	}
-	return data
 }

--- a/cli/kent/service_command.go
+++ b/cli/kent/service_command.go
@@ -208,14 +208,6 @@ func serviceRestartSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 	if code, blocked := guardBeforeElevation(serviceActionRestart, opts, stderr); blocked {
 		return code
 	}
-	// `restart --if-installed` rewrites the registration (reinstall), which needs
-	// Administrator on Windows; plain restart only stops/starts via the granted
-	// DACL and stays unprivileged. Elevate just the reinstall path.
-	if *ifInstalled {
-		if code, handled := elevateServiceAction(serviceActionRestart); handled {
-			return code
-		}
-	}
 	return runServiceCommandAction(context.Background(), serviceActionRestart, opts, stdout, stderr)
 }
 
@@ -245,6 +237,23 @@ func serviceRunSubcommand(args []string, stdout io.Writer, stderr io.Writer) int
 		return 1
 	}
 	return serviceHostRun(spec, stdout, stderr)
+}
+
+// legacyServerStopper is implemented by backends whose previous-generation
+// registration may have a still-running server that would otherwise trip the
+// unmanaged-server preflight during migration.
+type legacyServerStopper interface {
+	stopLegacyServer(ctx context.Context, spec serviceSpec)
+}
+
+// stopLegacyManagedServer best-effort stops a previous-generation server (e.g.
+// the Windows scheduled-task launcher) before the install/restart preflight, so
+// upgrading from an older Kent does not require manually killing the old server
+// first. A no-op on backends without a legacy generation.
+func stopLegacyManagedServer(ctx context.Context, backend serviceBackend, spec serviceSpec) {
+	if stopper, ok := backend.(legacyServerStopper); ok {
+		stopper.stopLegacyServer(ctx, spec)
+	}
 }
 
 func runServiceCommandAction(ctx context.Context, action serviceAction, opts serviceCommandOptions, stdout io.Writer, stderr io.Writer) int {
@@ -280,6 +289,7 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 		writeServiceStatus(stdout, status)
 		return 0
 	case serviceActionInstall:
+		stopLegacyManagedServer(ctx, backend, spec)
 		if err := ensureNoUnmanagedServerConflictForAction(ctx, backend, spec, serviceActionInstall); err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
@@ -344,6 +354,13 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 			if rootMismatchError(status, spec) != nil {
 				return 0
 			}
+			// Reinstall rewrites the registration (admin-only on Windows). Elevate
+			// only now that a matching installation is confirmed, so a not-installed
+			// or root-mismatch no-op above never triggers an unnecessary UAC prompt.
+			if code, handled := elevateServiceAction(serviceActionRestart); handled {
+				return code
+			}
+			stopLegacyManagedServer(ctx, backend, spec)
 			if err := ensureNoUnmanagedServerConflictForAction(ctx, backend, spec, action); err != nil {
 				fmt.Fprintln(stderr, err)
 				return 1

--- a/cli/kent/service_command.go
+++ b/cli/kent/service_command.go
@@ -204,11 +204,10 @@ func serviceRestartSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 	if code, ok := commitServicePersistenceRoot(*persistenceRoot, stderr); !ok {
 		return code
 	}
-	opts := serviceCommandOptions{IfInstalled: *ifInstalled}
-	if code, blocked := guardBeforeElevation(serviceActionRestart, opts, stderr); blocked {
-		return code
-	}
-	return runServiceCommandAction(context.Background(), serviceActionRestart, opts, stdout, stderr)
+	// The session guard and elevation for restart are applied inside
+	// runServiceCommandAction, after confirming a matching installation exists,
+	// so `restart --if-installed` can still no-op from inside a Kent session.
+	return runServiceCommandAction(context.Background(), serviceActionRestart, serviceCommandOptions{IfInstalled: *ifInstalled}, stdout, stderr)
 }
 
 // serviceRunSubcommand is the internal entry the OS service manager invokes via
@@ -289,7 +288,12 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 		writeServiceStatus(stdout, status)
 		return 0
 	case serviceActionInstall:
-		stopLegacyManagedServer(ctx, backend, spec)
+		// Only end the legacy server on paths allowed to stop the service, so a
+		// registration-only install (--no-start without --force) never halts a
+		// session hosted by the old launcher.
+		if serviceLifecycleGuardApplies(serviceActionInstall, opts) {
+			stopLegacyManagedServer(ctx, backend, spec)
+		}
 		if err := ensureNoUnmanagedServerConflictForAction(ctx, backend, spec, serviceActionInstall); err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
@@ -509,7 +513,9 @@ func serviceLifecycleGuardApplies(action serviceAction, opts serviceCommandOptio
 	case serviceActionRestart:
 		return true
 	case serviceActionInstall:
-		return !opts.NoStart
+		// --force rewrites (stops, deletes, recreates) an existing service, so it
+		// can halt the session even with --no-start; guard it regardless.
+		return !opts.NoStart || opts.Force
 	case serviceActionUninstall:
 		return !opts.KeepRunning
 	case serviceActionStart:

--- a/cli/kent/service_command.go
+++ b/cli/kent/service_command.go
@@ -183,6 +183,14 @@ func serviceRestartSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 	if code, ok := commitServicePersistenceRoot(*persistenceRoot, stderr); !ok {
 		return code
 	}
+	// `restart --if-installed` rewrites the registration (reinstall), which needs
+	// Administrator on Windows; plain restart only stops/starts via the granted
+	// DACL and stays unprivileged. Elevate just the reinstall path.
+	if *ifInstalled {
+		if code, handled := elevateServiceAction(serviceActionRestart); handled {
+			return code
+		}
+	}
 	return runServiceCommandAction(context.Background(), serviceActionRestart, serviceCommandOptions{IfInstalled: *ifInstalled}, stdout, stderr)
 }
 

--- a/cli/kent/service_command.go
+++ b/cli/kent/service_command.go
@@ -391,6 +391,22 @@ func rootMismatchError(status serviceStatus, spec serviceSpec) error {
 	return fmt.Errorf("no %s is installed for persistence root %s; the installed service targets %s. Reinstall with `%s service install --persistence-root %s` or manage the matching root instead", serviceDisplayName, spec.Config.PersistenceRoot, installedRoot, config.Command, spec.Config.PersistenceRoot)
 }
 
+func argsWithoutPersistenceRoot(args []string) []string {
+	const flag = "--persistence-root"
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		if args[i] == flag {
+			i++
+			continue
+		}
+		if _, ok := strings.CutPrefix(args[i], flag+"="); ok {
+			continue
+		}
+		out = append(out, args[i])
+	}
+	return out
+}
+
 func persistenceRootFromServiceCommand(command []string) (string, bool) {
 	const flag = "--persistence-root"
 	for i, arg := range command {

--- a/cli/kent/service_command.go
+++ b/cli/kent/service_command.go
@@ -151,6 +151,10 @@ func serviceUninstallSubcommand(args []string, stdout io.Writer, stderr io.Write
 		return code
 	}
 	opts := serviceCommandOptions{KeepRunning: *keepRunning}
+	if opts.KeepRunning && !keepRunningUninstallSupported() {
+		fmt.Fprintln(stderr, "uninstall --keep-running is not supported on Windows: the background server runs as a child of the service and cannot be kept running while the service is removed")
+		return 2
+	}
 	if code, blocked := guardBeforeElevation(serviceActionUninstall, opts, stderr); blocked {
 		return code
 	}

--- a/cli/kent/service_command.go
+++ b/cli/kent/service_command.go
@@ -109,6 +109,19 @@ func serviceStatusSubcommand(args []string, stdout io.Writer, stderr io.Writer) 
 	return runServiceCommandAction(context.Background(), serviceActionStatus, serviceCommandOptions{JSON: *jsonOut}, stdout, stderr)
 }
 
+// guardBeforeElevation evaluates the current-session lifecycle guard before any
+// UAC relaunch. The elevated child does not inherit KENT_SESSION_ID, so without
+// this the guard (enforced later in runServiceCommandAction) would pass in the
+// elevated process and let a user reinstall/stop the service hosting their own
+// active session. Returns (code, true) when the caller should stop.
+func guardBeforeElevation(action serviceAction, opts serviceCommandOptions, stderr io.Writer) (int, bool) {
+	if err := ensureServiceLifecycleAllowed(action, opts); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1, true
+	}
+	return 0, false
+}
+
 func serviceInstallSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 	fs := newCommandFlagSet(config.Command+" service install", stderr, serviceInstallUsage)
 	force := fs.Bool("force", false, "rewrite existing service registration")
@@ -124,10 +137,14 @@ func serviceInstallSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 	if code, ok := commitServicePersistenceRoot(*persistenceRoot, stderr); !ok {
 		return code
 	}
+	opts := serviceCommandOptions{Force: *force, NoStart: *noStart}
+	if code, blocked := guardBeforeElevation(serviceActionInstall, opts, stderr); blocked {
+		return code
+	}
 	if code, handled := elevateServiceAction(serviceActionInstall); handled {
 		return code
 	}
-	return runServiceCommandAction(context.Background(), serviceActionInstall, serviceCommandOptions{Force: *force, NoStart: *noStart}, stdout, stderr)
+	return runServiceCommandAction(context.Background(), serviceActionInstall, opts, stdout, stderr)
 }
 
 func serviceUninstallSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -144,10 +161,14 @@ func serviceUninstallSubcommand(args []string, stdout io.Writer, stderr io.Write
 	if code, ok := commitServicePersistenceRoot(*persistenceRoot, stderr); !ok {
 		return code
 	}
+	opts := serviceCommandOptions{KeepRunning: *keepRunning}
+	if code, blocked := guardBeforeElevation(serviceActionUninstall, opts, stderr); blocked {
+		return code
+	}
 	if code, handled := elevateServiceAction(serviceActionUninstall); handled {
 		return code
 	}
-	return runServiceCommandAction(context.Background(), serviceActionUninstall, serviceCommandOptions{KeepRunning: *keepRunning}, stdout, stderr)
+	return runServiceCommandAction(context.Background(), serviceActionUninstall, opts, stdout, stderr)
 }
 
 func serviceLifecycleSubcommand(action serviceAction, args []string, stdout io.Writer, stderr io.Writer) int {
@@ -183,6 +204,10 @@ func serviceRestartSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 	if code, ok := commitServicePersistenceRoot(*persistenceRoot, stderr); !ok {
 		return code
 	}
+	opts := serviceCommandOptions{IfInstalled: *ifInstalled}
+	if code, blocked := guardBeforeElevation(serviceActionRestart, opts, stderr); blocked {
+		return code
+	}
 	// `restart --if-installed` rewrites the registration (reinstall), which needs
 	// Administrator on Windows; plain restart only stops/starts via the granted
 	// DACL and stays unprivileged. Elevate just the reinstall path.
@@ -191,7 +216,7 @@ func serviceRestartSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 			return code
 		}
 	}
-	return runServiceCommandAction(context.Background(), serviceActionRestart, serviceCommandOptions{IfInstalled: *ifInstalled}, stdout, stderr)
+	return runServiceCommandAction(context.Background(), serviceActionRestart, opts, stdout, stderr)
 }
 
 // serviceRunSubcommand is the internal entry the OS service manager invokes via

--- a/cli/kent/service_command.go
+++ b/cli/kent/service_command.go
@@ -25,9 +25,7 @@ const (
 	serviceActionStart     serviceAction = "start"
 	serviceActionStop      serviceAction = "stop"
 	serviceActionRestart   serviceAction = "restart"
-	// serviceActionRun is the internal entry the OS service manager invokes to
-	// host the background service in-process. It is not advertised in usage and
-	// is only meaningful on platforms with an SCM-style host (Windows).
+
 	serviceActionRun serviceAction = "run"
 )
 
@@ -41,10 +39,6 @@ type serviceCommandOptions struct {
 
 const servicePersistenceRootFlagUsage = "config and data root directory (overrides KENT_PERSISTENCE_ROOT and the default ~/.kent)"
 
-// commitServicePersistenceRoot publishes a --persistence-root flag value to
-// KENT_PERSISTENCE_ROOT so every service operation resolves the same config+data
-// root (install bakes it into the launched unit; status/start/stop target the
-// matching instance). It returns (exitCode, false) when the value is invalid.
 func commitServicePersistenceRoot(value string, stderr io.Writer) (int, bool) {
 	if err := publishPersistenceRootEnv(value); err != nil {
 		fmt.Fprintln(stderr, err)
@@ -109,11 +103,6 @@ func serviceStatusSubcommand(args []string, stdout io.Writer, stderr io.Writer) 
 	return runServiceCommandAction(context.Background(), serviceActionStatus, serviceCommandOptions{JSON: *jsonOut}, stdout, stderr)
 }
 
-// guardBeforeElevation evaluates the current-session lifecycle guard before any
-// UAC relaunch. The elevated child does not inherit KENT_SESSION_ID, so without
-// this the guard (enforced later in runServiceCommandAction) would pass in the
-// elevated process and let a user reinstall/stop the service hosting their own
-// active session. Returns (code, true) when the caller should stop.
 func guardBeforeElevation(action serviceAction, opts serviceCommandOptions, stderr io.Writer) (int, bool) {
 	if err := ensureServiceLifecycleAllowed(action, opts); err != nil {
 		fmt.Fprintln(stderr, err)
@@ -204,16 +193,10 @@ func serviceRestartSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 	if code, ok := commitServicePersistenceRoot(*persistenceRoot, stderr); !ok {
 		return code
 	}
-	// The session guard and elevation for restart are applied inside
-	// runServiceCommandAction, after confirming a matching installation exists,
-	// so `restart --if-installed` can still no-op from inside a Kent session.
+
 	return runServiceCommandAction(context.Background(), serviceActionRestart, serviceCommandOptions{IfInstalled: *ifInstalled}, stdout, stderr)
 }
 
-// serviceRunSubcommand is the internal entry the OS service manager invokes via
-// the registered command (`<exe> service run --persistence-root <root>`). It
-// resolves the spec for the baked root and hands off to the platform host, which
-// supervises the background server. It is not a user-facing command.
 func serviceRunSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 	fs := newCommandFlagSet(config.Command+" service run", stderr, commandUsage{
 		title: "Usage of " + config.Command + " service run:",
@@ -238,17 +221,10 @@ func serviceRunSubcommand(args []string, stdout io.Writer, stderr io.Writer) int
 	return serviceHostRun(spec, stdout, stderr)
 }
 
-// legacyServerStopper is implemented by backends whose previous-generation
-// registration may have a still-running server that would otherwise trip the
-// unmanaged-server preflight during migration.
 type legacyServerStopper interface {
 	stopLegacyServer(ctx context.Context, spec serviceSpec)
 }
 
-// stopLegacyManagedServer best-effort stops a previous-generation server (e.g.
-// the Windows scheduled-task launcher) before the install/restart preflight, so
-// upgrading from an older Kent does not require manually killing the old server
-// first. A no-op on backends without a legacy generation.
 func stopLegacyManagedServer(ctx context.Context, backend serviceBackend, spec serviceSpec) {
 	if stopper, ok := backend.(legacyServerStopper); ok {
 		stopper.stopLegacyServer(ctx, spec)
@@ -288,9 +264,7 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 		writeServiceStatus(stdout, status)
 		return 0
 	case serviceActionInstall:
-		// Only end the legacy server on paths allowed to stop the service, so a
-		// registration-only install (--no-start without --force) never halts a
-		// session hosted by the old launcher.
+
 		if serviceLifecycleGuardApplies(serviceActionInstall, opts) {
 			stopLegacyManagedServer(ctx, backend, spec)
 		}
@@ -353,14 +327,11 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 			if !status.Installed {
 				return 0
 			}
-			// A registration for a different root is "not installed" from this
-			// invocation's perspective, so --if-installed exits as a quiet no-op.
+
 			if rootMismatchError(status, spec) != nil {
 				return 0
 			}
-			// Reinstall rewrites the registration (admin-only on Windows). Elevate
-			// only now that a matching installation is confirmed, so a not-installed
-			// or root-mismatch no-op above never triggers an unnecessary UAC prompt.
+
 			if code, handled := elevateServiceAction(serviceActionRestart); handled {
 				return code
 			}
@@ -386,13 +357,6 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 	return 0
 }
 
-// ensureServiceRootMatch reads the current registration and returns an error
-// when the installed service serves a different config+data root than the
-// resolved spec (or when the status read itself fails). It returns nil when
-// there is no conflict (or the installed root cannot be determined). Used by
-// stop/uninstall, which otherwise do not read status; start/restart reuse the
-// status fetched by ensureNoUnmanagedServerConflictForAction instead of paying a
-// second read.
 func ensureServiceRootMatch(ctx context.Context, backend serviceBackend, spec serviceSpec) error {
 	status, err := backend.Status(ctx, spec)
 	if err != nil {
@@ -401,32 +365,13 @@ func ensureServiceRootMatch(ctx context.Context, backend serviceBackend, spec se
 	return rootMismatchError(status, spec)
 }
 
-// rootMismatchError compares the persistence root baked into an installed
-// registration's command against the resolved spec root. Lifecycle actions
-// target the single global OS registration, so acting on a registration that
-// serves a different root is a cross-root footgun. It returns nil when they
-// match, when nothing is installed, or when the requested root is the default
-// and the installed registration's root cannot be confirmed (a legitimate
-// default-root service). Every service this binary installs now bakes
-// --persistence-root, and backends report the actual registration command (the
-// Windows backend resolves it from the registered scheduled-task action or the
-// Startup-folder launcher, never a path under the requested root), so the real
-// cross-root footguns — a default/other-root registration targeted with a
-// different --persistence-root, or an unpinned/unreadable legacy/manual
-// registration targeted with an explicit non-default root — are caught.
 func rootMismatchError(status serviceStatus, spec serviceSpec) error {
 	if !status.Installed {
 		return nil
 	}
 	installedRoot, ok := persistenceRootFromServiceCommand(status.Command)
 	if !ok {
-		// The registration's root cannot be confirmed: either the backend could
-		// not read/parse its command (empty command — e.g. a malformed plist or
-		// unit), or the command carries no --persistence-root (predates root
-		// isolation or was installed by hand). Both are indeterminate and treated
-		// as the default/global root. Acting on such a registration for an explicit
-		// non-default root would target the wrong (single, global) registration, so
-		// refuse unless the requested root is itself the default.
+
 		requestedIsDefault, err := config.IsDefaultPersistenceRoot(spec.Config.PersistenceRoot)
 		if err != nil {
 			return err
@@ -442,10 +387,6 @@ func rootMismatchError(status serviceStatus, spec serviceSpec) error {
 	return fmt.Errorf("no %s is installed for persistence root %s; the installed service targets %s. Reinstall with `%s service install --persistence-root %s` or manage the matching root instead", serviceDisplayName, spec.Config.PersistenceRoot, installedRoot, config.Command, spec.Config.PersistenceRoot)
 }
 
-// persistenceRootFromServiceCommand extracts the --persistence-root value baked
-// into an installed service command. It scans structured argv tokens (both the
-// "--persistence-root <root>" and "--persistence-root=<root>" forms) rather than
-// matching substrings.
 func persistenceRootFromServiceCommand(command []string) (string, bool) {
 	const flag = "--persistence-root"
 	for i, arg := range command {
@@ -467,8 +408,7 @@ func ensureNoUnmanagedServerConflictForAction(ctx context.Context, backend servi
 	if err != nil {
 		return err
 	}
-	// start/restart must not act on a registration installed for a different
-	// root. install (re)writes the registration, so it is exempt.
+
 	if action == serviceActionStart || action == serviceActionRestart {
 		if mismatch := rootMismatchError(status, spec); mismatch != nil {
 			return mismatch
@@ -513,8 +453,7 @@ func serviceLifecycleGuardApplies(action serviceAction, opts serviceCommandOptio
 	case serviceActionRestart:
 		return true
 	case serviceActionInstall:
-		// --force rewrites (stops, deletes, recreates) an existing service, so it
-		// can halt the session even with --no-start; guard it regardless.
+
 		return !opts.NoStart || opts.Force
 	case serviceActionUninstall:
 		return !opts.KeepRunning
@@ -542,9 +481,7 @@ func readServiceStatus(ctx context.Context, backend serviceBackend, spec service
 	if err != nil {
 		return serviceStatus{}, err
 	}
-	// Evaluate the root match against the raw registration command before the
-	// substitution below replaces an empty command with the requested-root one,
-	// which would otherwise mask a registration that serves a different root.
+
 	mismatched := rootMismatchError(status, spec) != nil
 	status.Backend = backend.Name()
 	status.Endpoint = spec.Endpoint
@@ -553,9 +490,7 @@ func readServiceStatus(ctx context.Context, backend serviceBackend, spec service
 		status.Command = serviceCommand(spec)
 	}
 	if mismatched {
-		// A registration for a different (or unconfirmable) root is "not
-		// installed" from the requested root's perspective, so status never
-		// reports another root's service as installed/running for this one.
+
 		status.Installed = false
 		status.Loaded = false
 		status.Running = false

--- a/cli/kent/service_command.go
+++ b/cli/kent/service_command.go
@@ -25,6 +25,10 @@ const (
 	serviceActionStart     serviceAction = "start"
 	serviceActionStop      serviceAction = "stop"
 	serviceActionRestart   serviceAction = "restart"
+	// serviceActionRun is the internal entry the OS service manager invokes to
+	// host the background service in-process. It is not advertised in usage and
+	// is only meaningful on platforms with an SCM-style host (Windows).
+	serviceActionRun serviceAction = "run"
 )
 
 type serviceCommandOptions struct {
@@ -78,6 +82,8 @@ func serviceSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		return serviceLifecycleSubcommand(action, args[1:], stdout, stderr)
 	case serviceActionRestart:
 		return serviceRestartSubcommand(args[1:], stdout, stderr)
+	case serviceActionRun:
+		return serviceRunSubcommand(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown service command: %s\n\n", args[0])
 		fs := newCommandFlagSet(config.Command+" service", stderr, serviceUsage)
@@ -118,6 +124,9 @@ func serviceInstallSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 	if code, ok := commitServicePersistenceRoot(*persistenceRoot, stderr); !ok {
 		return code
 	}
+	if code, handled := elevateServiceAction(serviceActionInstall); handled {
+		return code
+	}
 	return runServiceCommandAction(context.Background(), serviceActionInstall, serviceCommandOptions{Force: *force, NoStart: *noStart}, stdout, stderr)
 }
 
@@ -133,6 +142,9 @@ func serviceUninstallSubcommand(args []string, stdout io.Writer, stderr io.Write
 		return 2
 	}
 	if code, ok := commitServicePersistenceRoot(*persistenceRoot, stderr); !ok {
+		return code
+	}
+	if code, handled := elevateServiceAction(serviceActionUninstall); handled {
 		return code
 	}
 	return runServiceCommandAction(context.Background(), serviceActionUninstall, serviceCommandOptions{KeepRunning: *keepRunning}, stdout, stderr)
@@ -172,6 +184,34 @@ func serviceRestartSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 		return code
 	}
 	return runServiceCommandAction(context.Background(), serviceActionRestart, serviceCommandOptions{IfInstalled: *ifInstalled}, stdout, stderr)
+}
+
+// serviceRunSubcommand is the internal entry the OS service manager invokes via
+// the registered command (`<exe> service run --persistence-root <root>`). It
+// resolves the spec for the baked root and hands off to the platform host, which
+// supervises the background server. It is not a user-facing command.
+func serviceRunSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
+	fs := newCommandFlagSet(config.Command+" service run", stderr, commandUsage{
+		title: "Usage of " + config.Command + " service run:",
+		lines: []string{"  " + config.Command + " service run  (internal: hosted by the OS service manager)"},
+	})
+	persistenceRoot := fs.String("persistence-root", "", servicePersistenceRootFlagUsage)
+	if ok, exitCode := parseCommandFlags(fs, args); !ok {
+		return exitCode
+	}
+	if len(fs.Args()) != 0 {
+		fmt.Fprintln(stderr, "service run does not accept positional arguments")
+		return 2
+	}
+	if code, ok := commitServicePersistenceRoot(*persistenceRoot, stderr); !ok {
+		return code
+	}
+	spec, err := loadServiceSpec()
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return serviceHostRun(spec, stdout, stderr)
 }
 
 func runServiceCommandAction(ctx context.Context, action serviceAction, opts serviceCommandOptions, stdout io.Writer, stderr io.Writer) int {
@@ -364,68 +404,6 @@ func persistenceRootFromServiceCommand(command []string) (string, bool) {
 		if value, ok := strings.CutPrefix(arg, flag+"="); ok {
 			return value, true
 		}
-	}
-	return "", false
-}
-
-// windowsRegisteredTaskRunPath extracts the action path registered for the
-// scheduled task from `schtasks /Query /V /FO LIST` output (its "Task To Run"
-// field). That value reflects the actual global registration regardless of the
-// requested persistence root, so the resolved command can be compared against
-// the requested root instead of trusting a script path under it. Defined here
-// rather than in the build-tagged Windows backend so the parsing is unit-testable
-// on every platform.
-func windowsRegisteredTaskRunPath(taskQueryOutput string) (string, bool) {
-	const field = "task to run:"
-	for _, raw := range strings.Split(taskQueryOutput, "\n") {
-		line := strings.TrimSpace(raw)
-		if !strings.HasPrefix(strings.ToLower(line), field) {
-			continue
-		}
-		value := strings.Trim(strings.TrimSpace(line[len(field):]), "\"")
-		if value == "" {
-			return "", false
-		}
-		return value, true
-	}
-	return "", false
-}
-
-// windowsRegisteredScriptPath resolves the server.cmd path the OS actually has
-// registered, independent of any requested persistence root. It prefers the
-// scheduled task action ("Task To Run") and falls back to the script path
-// embedded in the Startup-folder launcher. It returns false when neither source
-// carries a path, in which case the installed root is indeterminate and callers
-// must not substitute a path derived from the requested root: lifecycle actions
-// target the single global registration, so a requested-root guess would either
-// fabricate a false root match or mask a real cross-root mismatch. Defined here
-// rather than in the build-tagged Windows backend so the parsing is unit-testable
-// on every platform.
-func windowsRegisteredScriptPath(taskQueryOutput string, startupLauncher string) (string, bool) {
-	if path, ok := windowsRegisteredTaskRunPath(taskQueryOutput); ok {
-		return path, true
-	}
-	return windowsStartupItemScriptPath(startupLauncher)
-}
-
-// windowsStartupItemScriptPath extracts the server.cmd path the Windows
-// Startup-folder fallback launcher invokes. The launcher line has the shape
-// `start "" /min cmd.exe /d /c "<script path>"`; the script path is the final
-// token after the `/d /c ` marker, optionally quoted. It returns false when no
-// launcher line is present, mirroring an absent scheduled-task action.
-func windowsStartupItemScriptPath(startupLauncher string) (string, bool) {
-	const marker = "/d /c "
-	for _, raw := range strings.Split(startupLauncher, "\n") {
-		line := strings.TrimSpace(raw)
-		idx := strings.LastIndex(strings.ToLower(line), marker)
-		if idx < 0 {
-			continue
-		}
-		candidate := strings.Trim(strings.TrimSpace(line[idx+len(marker):]), "\"")
-		if candidate == "" {
-			continue
-		}
-		return candidate, true
 	}
 	return "", false
 }

--- a/cli/kent/service_command_test.go
+++ b/cli/kent/service_command_test.go
@@ -120,10 +120,7 @@ func withServiceCommandTestBackendEndpoint(t *testing.T, backend *stubServiceBac
 	loadServiceSpec = func() (serviceSpec, error) {
 		host, portText, _ := net.SplitHostPort(strings.TrimPrefix(endpoint, "http://"))
 		port := parsePositiveInt(portText)
-		// These cases pass no --persistence-root, so the resolved root is the
-		// default; an unpinned `serve` registration is the default-root service and
-		// must not trip the cross-root guard. Explicit-root cases use
-		// withServiceCommandTestSpecRoot, which bakes a matching --persistence-root.
+
 		return serviceSpec{
 			Config:        config.App{PersistenceRoot: config.DefaultPersistence, Settings: config.Settings{ServerHost: host, ServerPort: port}},
 			Executable:    "/usr/local/bin/kent",
@@ -227,7 +224,7 @@ func TestServiceUninstallKeepRunning(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit code = %d, want 0; stderr=%q", code, stderr.String())
 	}
-	// uninstall first reads status to verify the registration targets this root.
+
 	want := []serviceAction{serviceActionStatus, serviceActionUninstall}
 	if strings.Join(actionsToStrings(backend.calls), ",") != strings.Join(actionsToStrings(want), ",") {
 		t.Fatalf("calls = %+v, want %+v", backend.calls, want)
@@ -261,8 +258,7 @@ func TestServiceUninstallRejectsKentShellSession(t *testing.T) {
 
 func withServiceCommandTestSpecRoot(t *testing.T, root string) {
 	t.Helper()
-	// `serviceSubcommand(... --persistence-root ...)` publishes KENT_PERSISTENCE_ROOT
-	// process-wide; register it so it is restored and does not leak into later tests.
+
 	t.Setenv(config.PersistenceRootEnvName, "")
 	original := loadServiceSpec
 	t.Cleanup(func() { loadServiceSpec = original })
@@ -361,9 +357,7 @@ func TestServiceRestartIfInstalledTreatsRootMismatchAsNoOp(t *testing.T) {
 }
 
 func TestRootMismatchErrorRejectsUnpinnedRegistrationForExplicitRoot(t *testing.T) {
-	// A registration with no --persistence-root (a pre-isolation or hand-installed
-	// service) is the single global default-root service; targeting it with an
-	// explicit non-default root must be refused rather than acting on the wrong one.
+
 	explicitRoot := filepath.Join(t.TempDir(), "iso")
 	status := serviceStatus{Installed: true, Command: []string{"/usr/local/bin/kent", "serve"}}
 	spec := serviceSpec{Config: config.App{PersistenceRoot: explicitRoot}}
@@ -385,10 +379,7 @@ func TestRootMismatchErrorAllowsUnpinnedRegistrationForDefaultRoot(t *testing.T)
 }
 
 func TestRootMismatchErrorRejectsUnreadableRegistrationForExplicitRoot(t *testing.T) {
-	// An installed service whose registered command the backend could not
-	// read/parse (empty command — e.g. a malformed plist or unit) is a root that
-	// cannot be confirmed; targeting it with an explicit non-default root must be
-	// refused rather than acting on the single global registration.
+
 	explicitRoot := filepath.Join(t.TempDir(), "iso")
 	status := serviceStatus{Installed: true, Command: nil}
 	spec := serviceSpec{Config: config.App{PersistenceRoot: explicitRoot}}
@@ -410,9 +401,7 @@ func TestRootMismatchErrorAllowsUnreadableRegistrationForDefaultRoot(t *testing.
 }
 
 func TestServiceStatusReportsNotInstalledForForeignRoot(t *testing.T) {
-	// A registration whose command targets a different root must be reported as
-	// not installed for the requested root, so `service status --persistence-root`
-	// never presents another root's service as installed/running for this one.
+
 	requestedRoot := filepath.Join(t.TempDir(), "requested")
 	installedRoot := filepath.Join(t.TempDir(), "installed")
 	backend := &stubServiceBackend{status: serviceStatus{

--- a/cli/kent/service_command_test.go
+++ b/cli/kent/service_command_test.go
@@ -161,7 +161,6 @@ func newServiceHealthTestServer(t *testing.T, body string, statusCode ...int) *h
 }
 
 func TestServiceInstallNoStartAndForce(t *testing.T) {
-	t.Setenv(sessionenv.SessionIDEnv, "session-123")
 	backend := &stubServiceBackend{}
 	withServiceCommandTestBackend(t, backend)
 
@@ -174,8 +173,24 @@ func TestServiceInstallNoStartAndForce(t *testing.T) {
 	if !backend.installForce || backend.installStart {
 		t.Fatalf("install flags force=%v start=%v, want force true start false", backend.installForce, backend.installStart)
 	}
-	if !strings.Contains(stdout.String(), "Started: no") {
-		t.Fatalf("stdout = %q, want Started: no", stdout.String())
+}
+
+func TestServiceInstallForceNoStartRejectsKentShellSession(t *testing.T) {
+	t.Setenv(sessionenv.SessionIDEnv, "session-123")
+	backend := &stubServiceBackend{}
+	withServiceCommandTestBackend(t, backend)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := serviceSubcommand([]string{"install", "--force", "--no-start"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if len(backend.calls) != 0 {
+		t.Fatalf("calls = %+v, want no service backend calls", backend.calls)
+	}
+	if got := strings.TrimSpace(stderr.String()); got != serviceLifecycleCurrentSessionError {
+		t.Fatalf("stderr = %q, want current session lifecycle guard", stderr.String())
 	}
 }
 

--- a/cli/kent/service_command_test.go
+++ b/cli/kent/service_command_test.go
@@ -345,66 +345,6 @@ func TestServiceRestartIfInstalledTreatsRootMismatchAsNoOp(t *testing.T) {
 	}
 }
 
-func TestWindowsRegisteredTaskRunPathParsesListOutput(t *testing.T) {
-	output := strings.Join([]string{
-		"Folder: \\",
-		"HostName:                             DESKTOP",
-		"TaskName:                             \\Kent",
-		"Task To Run:                          C:\\OtherRoot\\service\\server.cmd",
-		"Start In:                             N/A",
-	}, "\n")
-	got, ok := windowsRegisteredTaskRunPath(output)
-	if !ok || got != "C:\\OtherRoot\\service\\server.cmd" {
-		t.Fatalf("windowsRegisteredTaskRunPath = (%q, %v), want the registered Task To Run path", got, ok)
-	}
-}
-
-func TestWindowsRegisteredTaskRunPathAbsentReturnsFalse(t *testing.T) {
-	if got, ok := windowsRegisteredTaskRunPath("ERROR: The system cannot find the file specified."); ok {
-		t.Fatalf("windowsRegisteredTaskRunPath = (%q, true), want not found when no Task To Run field is present", got)
-	}
-}
-
-func TestWindowsStartupItemScriptPathParsesLauncher(t *testing.T) {
-	launcher := "@echo off\r\nstart \"\" /min cmd.exe /d /c \"C:\\OtherRoot\\service\\server.cmd\"\r\n"
-	got, ok := windowsStartupItemScriptPath(launcher)
-	if !ok || got != "C:\\OtherRoot\\service\\server.cmd" {
-		t.Fatalf("windowsStartupItemScriptPath = (%q, %v), want the launcher's embedded script path", got, ok)
-	}
-}
-
-func TestWindowsStartupItemScriptPathAbsentReturnsFalse(t *testing.T) {
-	if got, ok := windowsStartupItemScriptPath("@echo off\r\n"); ok {
-		t.Fatalf("windowsStartupItemScriptPath = (%q, true), want not found when no launcher line is present", got)
-	}
-}
-
-func TestWindowsRegisteredScriptPathPrefersTaskActionOverStartupLauncher(t *testing.T) {
-	taskOutput := "Task To Run:                          C:\\TaskRoot\\service\\server.cmd"
-	startupLauncher := "start \"\" /min cmd.exe /d /c \"C:\\StartupRoot\\service\\server.cmd\""
-	got, ok := windowsRegisteredScriptPath(taskOutput, startupLauncher)
-	if !ok || got != "C:\\TaskRoot\\service\\server.cmd" {
-		t.Fatalf("windowsRegisteredScriptPath = (%q, %v), want the scheduled-task action path", got, ok)
-	}
-}
-
-func TestWindowsRegisteredScriptPathFallsBackToStartupLauncher(t *testing.T) {
-	startupLauncher := "start \"\" /min cmd.exe /d /c \"C:\\StartupRoot\\service\\server.cmd\""
-	got, ok := windowsRegisteredScriptPath("ERROR: no such task", startupLauncher)
-	if !ok || got != "C:\\StartupRoot\\service\\server.cmd" {
-		t.Fatalf("windowsRegisteredScriptPath = (%q, %v), want the Startup launcher path when no task action exists", got, ok)
-	}
-}
-
-func TestWindowsRegisteredScriptPathAbsentReturnsFalse(t *testing.T) {
-	// With neither an authoritative task action nor a Startup launcher, the
-	// installed root is indeterminate and callers must not substitute a
-	// requested-root path.
-	if got, ok := windowsRegisteredScriptPath("", ""); ok {
-		t.Fatalf("windowsRegisteredScriptPath = (%q, true), want indeterminate when no registration path exists", got)
-	}
-}
-
 func TestRootMismatchErrorRejectsUnpinnedRegistrationForExplicitRoot(t *testing.T) {
 	// A registration with no --persistence-root (a pre-isolation or hand-installed
 	// service) is the single global default-root service; targeting it with an

--- a/cli/kent/service_elevate_other.go
+++ b/cli/kent/service_elevate_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+// elevateServiceAction is a no-op off Windows; launchd/systemd installs run as
+// the user with no elevation step.
+func elevateServiceAction(_ serviceAction) (int, bool) {
+	return 0, false
+}

--- a/cli/kent/service_elevate_other.go
+++ b/cli/kent/service_elevate_other.go
@@ -5,3 +5,7 @@ package main
 func elevateServiceAction(_ serviceAction) (int, bool) {
 	return 0, false
 }
+
+func keepRunningUninstallSupported() bool {
+	return true
+}

--- a/cli/kent/service_elevate_other.go
+++ b/cli/kent/service_elevate_other.go
@@ -2,8 +2,6 @@
 
 package main
 
-// elevateServiceAction is a no-op off Windows; launchd/systemd installs run as
-// the user with no elevation step.
 func elevateServiceAction(_ serviceAction) (int, bool) {
 	return 0, false
 }

--- a/cli/kent/service_elevate_windows.go
+++ b/cli/kent/service_elevate_windows.go
@@ -1,0 +1,106 @@
+//go:build windows
+
+package main
+
+import (
+	brand "core/shared/config"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	shell32DLL         = windows.NewLazySystemDLL("shell32.dll")
+	procShellExecuteEx = shell32DLL.NewProc("ShellExecuteExW")
+)
+
+const (
+	seeMaskNoCloseProcess = 0x00000040
+	swShowNormal          = 1
+)
+
+// shellExecuteInfo mirrors SHELLEXECUTEINFOW; ShellExecuteEx writes the launched
+// process handle into the trailing process field when SEE_MASK_NOCLOSEPROCESS is
+// set.
+type shellExecuteInfo struct {
+	cbSize        uint32
+	mask          uint32
+	hwnd          uintptr
+	verb          *uint16
+	file          *uint16
+	parameters    *uint16
+	directory     *uint16
+	show          int32
+	instApp       uintptr
+	idList        uintptr
+	class         *uint16
+	hkeyClass     uintptr
+	hotKey        uint32
+	iconOrMonitor uintptr
+	process       windows.Handle
+}
+
+// elevateServiceAction re-launches the current command elevated when the action
+// requires Administrator (install/uninstall) and this process is not elevated.
+// It returns (exitCode, true) when an elevated child handled the action, or
+// (0, false) when the caller should proceed in-process (already elevated, or the
+// action needs no elevation). Start/stop/restart/status are never elevated: the
+// install grants the user a service DACL so they run unprivileged.
+func elevateServiceAction(action serviceAction) (int, bool) {
+	if action != serviceActionInstall && action != serviceActionUninstall {
+		return 0, false
+	}
+	if windows.GetCurrentProcessToken().IsElevated() {
+		return 0, false
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1, true
+	}
+	verbPtr, err := windows.UTF16PtrFromString("runas")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1, true
+	}
+	exePtr, err := windows.UTF16PtrFromString(exe)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1, true
+	}
+	paramsPtr, err := windows.UTF16PtrFromString(windows.ComposeCommandLine(os.Args[1:]))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1, true
+	}
+	info := shellExecuteInfo{
+		mask:       seeMaskNoCloseProcess,
+		verb:       verbPtr,
+		file:       exePtr,
+		parameters: paramsPtr,
+		show:       swShowNormal,
+	}
+	info.cbSize = uint32(unsafe.Sizeof(info))
+
+	ret, _, callErr := procShellExecuteEx.Call(uintptr(unsafe.Pointer(&info)))
+	if ret == 0 {
+		fmt.Fprintf(os.Stderr, "elevation was declined or failed; run `%s service %s` from an Administrator terminal: %v\n", brand.Command, action, callErr)
+		return 1, true
+	}
+	if info.process == 0 {
+		return 0, true
+	}
+	defer func() { _ = windows.CloseHandle(info.process) }()
+	if _, err := windows.WaitForSingleObject(info.process, windows.INFINITE); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1, true
+	}
+	var code uint32
+	if err := windows.GetExitCodeProcess(info.process, &code); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1, true
+	}
+	return int(code), true
+}

--- a/cli/kent/service_elevate_windows.go
+++ b/cli/kent/service_elevate_windows.go
@@ -113,5 +113,5 @@ func elevatedServiceParams() []string {
 	if err != nil {
 		return args
 	}
-	return append(append([]string{}, args...), "--persistence-root", abs)
+	return append(argsWithoutPersistenceRoot(args), "--persistence-root", abs)
 }

--- a/cli/kent/service_elevate_windows.go
+++ b/cli/kent/service_elevate_windows.go
@@ -22,9 +22,6 @@ const (
 	swShowNormal          = 1
 )
 
-// shellExecuteInfo mirrors SHELLEXECUTEINFOW; ShellExecuteEx writes the launched
-// process handle into the trailing process field when SEE_MASK_NOCLOSEPROCESS is
-// set.
 type shellExecuteInfo struct {
 	cbSize        uint32
 	mask          uint32
@@ -43,12 +40,6 @@ type shellExecuteInfo struct {
 	process       windows.Handle
 }
 
-// elevateServiceAction re-launches the current command elevated when the action
-// requires Administrator (install/uninstall) and this process is not elevated.
-// It returns (exitCode, true) when an elevated child handled the action, or
-// (0, false) when the caller should proceed in-process (already elevated, or the
-// action needs no elevation). Start/stop/restart/status are never elevated: the
-// install grants the user a service DACL so they run unprivileged.
 func elevateServiceAction(action serviceAction) (int, bool) {
 	switch action {
 	case serviceActionInstall, serviceActionUninstall, serviceActionRestart:
@@ -108,13 +99,6 @@ func elevateServiceAction(action serviceAction) (int, bool) {
 	return int(code), true
 }
 
-// elevatedServiceParams forwards this invocation's arguments to the elevated
-// child, pinning the persistence root to the absolute value resolved for the
-// current interactive user. UAC may run the child under a different administrator
-// whose default root differs, and the elevated process does not inherit this
-// process's environment, so without an explicit root the registered service
-// would point at the wrong profile. The appended flag wins via last-flag-wins
-// parsing, so any relative or omitted root is overridden.
 func elevatedServiceParams() []string {
 	args := os.Args[1:]
 	cfg, err := brand.LoadGlobal(brand.LoadOptions{})

--- a/cli/kent/service_elevate_windows.go
+++ b/cli/kent/service_elevate_windows.go
@@ -40,6 +40,10 @@ type shellExecuteInfo struct {
 	process       windows.Handle
 }
 
+func keepRunningUninstallSupported() bool {
+	return false
+}
+
 func elevateServiceAction(action serviceAction) (int, bool) {
 	switch action {
 	case serviceActionInstall, serviceActionUninstall, serviceActionRestart:

--- a/cli/kent/service_elevate_windows.go
+++ b/cli/kent/service_elevate_windows.go
@@ -6,6 +6,7 @@ import (
 	brand "core/shared/config"
 	"fmt"
 	"os"
+	"strings"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -49,7 +50,9 @@ type shellExecuteInfo struct {
 // action needs no elevation). Start/stop/restart/status are never elevated: the
 // install grants the user a service DACL so they run unprivileged.
 func elevateServiceAction(action serviceAction) (int, bool) {
-	if action != serviceActionInstall && action != serviceActionUninstall {
+	switch action {
+	case serviceActionInstall, serviceActionUninstall, serviceActionRestart:
+	default:
 		return 0, false
 	}
 	if windows.GetCurrentProcessToken().IsElevated() {
@@ -70,7 +73,7 @@ func elevateServiceAction(action serviceAction) (int, bool) {
 		fmt.Fprintln(os.Stderr, err)
 		return 1, true
 	}
-	paramsPtr, err := windows.UTF16PtrFromString(windows.ComposeCommandLine(os.Args[1:]))
+	paramsPtr, err := windows.UTF16PtrFromString(windows.ComposeCommandLine(elevatedServiceParams()))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1, true
@@ -103,4 +106,20 @@ func elevateServiceAction(action serviceAction) (int, bool) {
 		return 1, true
 	}
 	return int(code), true
+}
+
+// elevatedServiceParams forwards this invocation's arguments to the elevated
+// child, pinning the persistence root to the absolute value resolved for the
+// current interactive user. UAC may run the child under a different administrator
+// whose default root differs, and the elevated process does not inherit this
+// process's environment, so without an explicit root the registered service
+// would point at the wrong profile. The appended flag wins via last-flag-wins
+// parsing, so any relative or omitted root is overridden.
+func elevatedServiceParams() []string {
+	args := os.Args[1:]
+	cfg, err := brand.LoadGlobal(brand.LoadOptions{})
+	if err != nil || strings.TrimSpace(cfg.PersistenceRoot) == "" {
+		return args
+	}
+	return append(append([]string{}, args...), "--persistence-root", cfg.PersistenceRoot)
 }

--- a/cli/kent/service_elevate_windows.go
+++ b/cli/kent/service_elevate_windows.go
@@ -105,9 +105,13 @@ func elevateServiceAction(action serviceAction) (int, bool) {
 
 func elevatedServiceParams() []string {
 	args := os.Args[1:]
-	cfg, err := brand.LoadGlobal(brand.LoadOptions{})
-	if err != nil || strings.TrimSpace(cfg.PersistenceRoot) == "" {
+	root := strings.TrimSpace(os.Getenv(brand.PersistenceRootEnvName))
+	if root == "" {
+		root = brand.DefaultPersistence
+	}
+	abs, err := brand.NormalizePersistenceRoot(root)
+	if err != nil {
 		return args
 	}
-	return append(append([]string{}, args...), "--persistence-root", cfg.PersistenceRoot)
+	return append(append([]string{}, args...), "--persistence-root", abs)
 }

--- a/cli/kent/service_host_other.go
+++ b/cli/kent/service_host_other.go
@@ -8,10 +8,6 @@ import (
 	"io"
 )
 
-// serviceHostRun is the in-process service host entry. Only Windows installs an
-// SCM-style service that re-invokes the binary to host itself; on every other
-// platform the OS manager (launchd/systemd) runs `serve` directly, so this entry
-// is never registered and is rejected if invoked by hand.
 func serviceHostRun(_ serviceSpec, _ io.Writer, stderr io.Writer) int {
 	fmt.Fprintln(stderr, brand.Command+" service run is only supported on Windows; on this platform the service manager runs `"+brand.Command+" serve` directly")
 	return 2

--- a/cli/kent/service_host_other.go
+++ b/cli/kent/service_host_other.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package main
+
+import (
+	brand "core/shared/config"
+	"fmt"
+	"io"
+)
+
+// serviceHostRun is the in-process service host entry. Only Windows installs an
+// SCM-style service that re-invokes the binary to host itself; on every other
+// platform the OS manager (launchd/systemd) runs `serve` directly, so this entry
+// is never registered and is rejected if invoked by hand.
+func serviceHostRun(_ serviceSpec, _ io.Writer, stderr io.Writer) int {
+	fmt.Fprintln(stderr, brand.Command+" service run is only supported on Windows; on this platform the service manager runs `"+brand.Command+" serve` directly")
+	return 2
+}

--- a/cli/kent/service_host_windows.go
+++ b/cli/kent/service_host_windows.go
@@ -12,11 +12,6 @@ import (
 	"golang.org/x/sys/windows/svc"
 )
 
-// serviceHostRun is the SCM entry point. The service manager launches the
-// registered command (`kent service run --persistence-root <root>`); svc.Run
-// connects this process to the service control dispatcher and drives the
-// supervisor until the SCM stops it. Invoked by hand it reports that it is not
-// running under the SCM.
 func serviceHostRun(spec serviceSpec, _ io.Writer, stderr io.Writer) int {
 	isService, err := svc.IsWindowsService()
 	if err != nil {
@@ -34,11 +29,6 @@ func serviceHostRun(spec serviceSpec, _ io.Writer, stderr io.Writer) int {
 	return 0
 }
 
-// serviceStopWindow is the single source of truth for how long a stop may take:
-// the graceful server shutdown (event signal + grace period + hard-terminate
-// fallback) plus SCM dispatch overhead. The SCM WaitHint advertises it so the
-// SCM waits instead of killing the supervisor (which would orphan the server),
-// and the lifecycle commands wait this long for a stop to complete.
 const (
 	serviceStopWindow         = 30 * time.Second
 	serviceStopWaitHintMillis = uint32(serviceStopWindow / time.Millisecond)
@@ -81,9 +71,7 @@ func (h *windowsServiceHandler) Execute(_ []string, r <-chan svc.ChangeRequest, 
 				changes <- svc.Status{State: svc.Stopped}
 				return false, 0
 			case svc.SessionChange:
-				// Any logon/logoff/lock change: recompute the target interactive
-				// session (0 when no matching user is logged in) and let the
-				// supervisor relaunch or stop the server accordingly.
+
 				supervisor.setWanted(supervisor.targetSession())
 			}
 		}

--- a/cli/kent/service_host_windows.go
+++ b/cli/kent/service_host_windows.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"time"
 
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 )
 
@@ -59,7 +60,8 @@ func (h *windowsServiceHandler) Execute(_ []string, r <-chan svc.ChangeRequest, 
 	for {
 		select {
 		case <-done:
-			return false, 0
+			changes <- svc.Status{State: svc.Stopped}
+			return false, uint32(windows.ERROR_PROCESS_ABORTED)
 		case request := <-r:
 			switch request.Cmd {
 			case svc.Interrogate:

--- a/cli/kent/service_host_windows.go
+++ b/cli/kent/service_host_windows.go
@@ -1,0 +1,86 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	brand "core/shared/config"
+	"fmt"
+	"io"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+// serviceHostRun is the SCM entry point. The service manager launches the
+// registered command (`kent service run --persistence-root <root>`); svc.Run
+// connects this process to the service control dispatcher and drives the
+// supervisor until the SCM stops it. Invoked by hand it reports that it is not
+// running under the SCM.
+func serviceHostRun(spec serviceSpec, _ io.Writer, stderr io.Writer) int {
+	isService, err := svc.IsWindowsService()
+	if err != nil {
+		fmt.Fprintf(stderr, "determine service context: %v\n", err)
+		return 1
+	}
+	if !isService {
+		fmt.Fprintf(stderr, "%s service run is an internal entry invoked by the Windows service manager; use `%s service start` instead\n", brand.Command, brand.Command)
+		return 2
+	}
+	if err := svc.Run(serviceWindowsServiceName, &windowsServiceHandler{spec: spec}); err != nil {
+		fmt.Fprintf(stderr, "service run: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// serviceStopWaitHintMillis tells the SCM how long the service may take to stop
+// so it waits for the graceful server shutdown (event signal + grace period +
+// hard-terminate fallback) instead of killing the supervisor, which would orphan
+// the server.
+const serviceStopWaitHintMillis = 30000
+
+type windowsServiceHandler struct {
+	spec serviceSpec
+}
+
+func (h *windowsServiceHandler) Execute(_ []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
+	const accepts = svc.AcceptStop | svc.AcceptShutdown | svc.AcceptSessionChange
+
+	changes <- svc.Status{State: svc.StartPending}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	supervisor := newServerSupervisor(h.spec)
+	supervisor.setWanted(activeUserSession())
+
+	done := make(chan struct{})
+	go func() {
+		supervisor.run(ctx)
+		close(done)
+	}()
+
+	changes <- svc.Status{State: svc.Running, Accepts: accepts}
+
+	for {
+		select {
+		case <-done:
+			return false, 0
+		case request := <-r:
+			switch request.Cmd {
+			case svc.Interrogate:
+				changes <- request.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				changes <- svc.Status{State: svc.StopPending, WaitHint: serviceStopWaitHintMillis}
+				cancel()
+				<-done
+				changes <- svc.Status{State: svc.Stopped}
+				return false, 0
+			case svc.SessionChange:
+				// Any logon/logoff/lock change: recompute the target interactive
+				// session (0 when no user is logged in) and let the supervisor
+				// relaunch or stop the server accordingly.
+				supervisor.setWanted(activeUserSession())
+			}
+		}
+	}
+}

--- a/cli/kent/service_host_windows.go
+++ b/cli/kent/service_host_windows.go
@@ -7,6 +7,7 @@ import (
 	brand "core/shared/config"
 	"fmt"
 	"io"
+	"time"
 
 	"golang.org/x/sys/windows/svc"
 )
@@ -33,11 +34,15 @@ func serviceHostRun(spec serviceSpec, _ io.Writer, stderr io.Writer) int {
 	return 0
 }
 
-// serviceStopWaitHintMillis tells the SCM how long the service may take to stop
-// so it waits for the graceful server shutdown (event signal + grace period +
-// hard-terminate fallback) instead of killing the supervisor, which would orphan
-// the server.
-const serviceStopWaitHintMillis = 30000
+// serviceStopWindow is the single source of truth for how long a stop may take:
+// the graceful server shutdown (event signal + grace period + hard-terminate
+// fallback) plus SCM dispatch overhead. The SCM WaitHint advertises it so the
+// SCM waits instead of killing the supervisor (which would orphan the server),
+// and the lifecycle commands wait this long for a stop to complete.
+const (
+	serviceStopWindow         = 30 * time.Second
+	serviceStopWaitHintMillis = uint32(serviceStopWindow / time.Millisecond)
+)
 
 type windowsServiceHandler struct {
 	spec serviceSpec

--- a/cli/kent/service_host_windows.go
+++ b/cli/kent/service_host_windows.go
@@ -56,7 +56,7 @@ func (h *windowsServiceHandler) Execute(_ []string, r <-chan svc.ChangeRequest, 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	supervisor := newServerSupervisor(h.spec)
-	supervisor.setWanted(activeUserSession())
+	supervisor.setWanted(supervisor.targetSession())
 
 	done := make(chan struct{})
 	go func() {
@@ -82,9 +82,9 @@ func (h *windowsServiceHandler) Execute(_ []string, r <-chan svc.ChangeRequest, 
 				return false, 0
 			case svc.SessionChange:
 				// Any logon/logoff/lock change: recompute the target interactive
-				// session (0 when no user is logged in) and let the supervisor
-				// relaunch or stop the server accordingly.
-				supervisor.setWanted(activeUserSession())
+				// session (0 when no matching user is logged in) and let the
+				// supervisor relaunch or stop the server accordingly.
+				supervisor.setWanted(supervisor.targetSession())
 			}
 		}
 	}

--- a/cli/kent/service_logredirect_other.go
+++ b/cli/kent/service_logredirect_other.go
@@ -2,7 +2,4 @@
 
 package main
 
-// redirectServiceLogs is a no-op off Windows; launchd/systemd redirect the
-// server's stdout/stderr to log files directly, and process launches stay within
-// one session so handle inheritance is unaffected.
 func redirectServiceLogs() {}

--- a/cli/kent/service_logredirect_other.go
+++ b/cli/kent/service_logredirect_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package main
+
+// redirectServiceLogs is a no-op off Windows; launchd/systemd redirect the
+// server's stdout/stderr to log files directly, and process launches stay within
+// one session so handle inheritance is unaffected.
+func redirectServiceLogs() {}

--- a/cli/kent/service_logredirect_windows.go
+++ b/cli/kent/service_logredirect_windows.go
@@ -9,22 +9,11 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// stdoutLogEnvVar and stderrLogEnvVar carry the service log file paths from the
-// supervisor to the server it launches. CreateProcessAsUser cannot inherit std
-// handles across Terminal Services sessions (the supervisor runs in session 0,
-// the server in the user's console session), so instead of redirecting via
-// inherited handles the server opens these files itself. They are set only on
-// the supervised child's environment.
 const (
 	stdoutLogEnvVar = brand.EnvPrefix + "SERVICE_STDOUT_LOG"
 	stderrLogEnvVar = brand.EnvPrefix + "SERVICE_STDERR_LOG"
 )
 
-// redirectServiceLogs points this process's stdout/stderr at the service log
-// files when launched by the service supervisor (the env vars are set). It runs
-// before the command dispatcher reads os.Stdout/os.Stderr, and also updates the
-// OS std handles so raw writes and child processes (shell tools) are captured.
-// A no-op for a normally-run process where the env vars are unset.
 func redirectServiceLogs() {
 	redirectStdStream(stdoutLogEnvVar, &os.Stdout, windows.STD_OUTPUT_HANDLE)
 	redirectStdStream(stderrLogEnvVar, &os.Stderr, windows.STD_ERROR_HANDLE)
@@ -32,9 +21,7 @@ func redirectServiceLogs() {
 
 func redirectStdStream(envVar string, target **os.File, stdHandle uint32) {
 	path := os.Getenv(envVar)
-	// Consume the variable so user/model commands spawned by shell tools (which
-	// build their environment from os.Environ()) do not inherit it and redirect
-	// their own output into the service logs.
+
 	_ = os.Unsetenv(envVar)
 	if path == "" {
 		return

--- a/cli/kent/service_logredirect_windows.go
+++ b/cli/kent/service_logredirect_windows.go
@@ -32,6 +32,10 @@ func redirectServiceLogs() {
 
 func redirectStdStream(envVar string, target **os.File, stdHandle uint32) {
 	path := os.Getenv(envVar)
+	// Consume the variable so user/model commands spawned by shell tools (which
+	// build their environment from os.Environ()) do not inherit it and redirect
+	// their own output into the service logs.
+	_ = os.Unsetenv(envVar)
 	if path == "" {
 		return
 	}

--- a/cli/kent/service_logredirect_windows.go
+++ b/cli/kent/service_logredirect_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package main
+
+import (
+	brand "core/shared/config"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// stdoutLogEnvVar and stderrLogEnvVar carry the service log file paths from the
+// supervisor to the server it launches. CreateProcessAsUser cannot inherit std
+// handles across Terminal Services sessions (the supervisor runs in session 0,
+// the server in the user's console session), so instead of redirecting via
+// inherited handles the server opens these files itself. They are set only on
+// the supervised child's environment.
+const (
+	stdoutLogEnvVar = brand.EnvPrefix + "SERVICE_STDOUT_LOG"
+	stderrLogEnvVar = brand.EnvPrefix + "SERVICE_STDERR_LOG"
+)
+
+// redirectServiceLogs points this process's stdout/stderr at the service log
+// files when launched by the service supervisor (the env vars are set). It runs
+// before the command dispatcher reads os.Stdout/os.Stderr, and also updates the
+// OS std handles so raw writes and child processes (shell tools) are captured.
+// A no-op for a normally-run process where the env vars are unset.
+func redirectServiceLogs() {
+	redirectStdStream(stdoutLogEnvVar, &os.Stdout, windows.STD_OUTPUT_HANDLE)
+	redirectStdStream(stderrLogEnvVar, &os.Stderr, windows.STD_ERROR_HANDLE)
+}
+
+func redirectStdStream(envVar string, target **os.File, stdHandle uint32) {
+	path := os.Getenv(envVar)
+	if path == "" {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	*target = f
+	_ = windows.SetStdHandle(stdHandle, windows.Handle(f.Fd()))
+}

--- a/cli/kent/service_proc_other.go
+++ b/cli/kent/service_proc_other.go
@@ -4,6 +4,4 @@ package main
 
 import "os/exec"
 
-// configureNoWindow is a no-op off Windows; only Windows console subprocesses
-// would otherwise flash a window.
 func configureNoWindow(_ *exec.Cmd) {}

--- a/cli/kent/service_proc_other.go
+++ b/cli/kent/service_proc_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+import "os/exec"
+
+// configureNoWindow is a no-op off Windows; only Windows console subprocesses
+// would otherwise flash a window.
+func configureNoWindow(_ *exec.Cmd) {}

--- a/cli/kent/service_proc_windows.go
+++ b/cli/kent/service_proc_windows.go
@@ -9,8 +9,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// configureNoWindow makes a service helper subprocess (e.g. the legacy schtasks
-// teardown) run without allocating a console window.
 func configureNoWindow(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}

--- a/cli/kent/service_proc_windows.go
+++ b/cli/kent/service_proc_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// configureNoWindow makes a service helper subprocess (e.g. the legacy schtasks
+// teardown) run without allocating a console window.
+func configureNoWindow(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NO_WINDOW
+}

--- a/cli/kent/service_shutdown_other.go
+++ b/cli/kent/service_shutdown_other.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package main
+
+import "context"
+
+// installServiceShutdownTrigger is a no-op off Windows; launchd/systemd stop the
+// server with SIGTERM directly, which the signal context already handles.
+func installServiceShutdownTrigger(ctx context.Context) context.Context {
+	return ctx
+}

--- a/cli/kent/service_shutdown_other.go
+++ b/cli/kent/service_shutdown_other.go
@@ -4,8 +4,6 @@ package main
 
 import "context"
 
-// installServiceShutdownTrigger is a no-op off Windows; launchd/systemd stop the
-// server with SIGTERM directly, which the signal context already handles.
 func installServiceShutdownTrigger(ctx context.Context) context.Context {
 	return ctx
 }

--- a/cli/kent/service_shutdown_windows.go
+++ b/cli/kent/service_shutdown_windows.go
@@ -25,6 +25,9 @@ const shutdownEventEnvVar = brand.EnvPrefix + "SERVICE_SHUTDOWN_EVENT"
 // opened) the original context is returned unchanged.
 func installServiceShutdownTrigger(ctx context.Context) context.Context {
 	name := os.Getenv(shutdownEventEnvVar)
+	// Consume the variable so commands spawned by shell tools (which build their
+	// environment from os.Environ()) do not inherit this service-only marker.
+	_ = os.Unsetenv(shutdownEventEnvVar)
 	if name == "" {
 		return ctx
 	}

--- a/cli/kent/service_shutdown_windows.go
+++ b/cli/kent/service_shutdown_windows.go
@@ -10,23 +10,11 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// shutdownEventEnvVar carries the name of the graceful-stop event from the
-// service supervisor to the server it launches. It is set only on the supervised
-// child's environment, so a normally-run `serve` never sees it.
 const shutdownEventEnvVar = brand.EnvPrefix + "SERVICE_SHUTDOWN_EVENT"
 
-// installServiceShutdownTrigger lets the LocalSystem service supervisor stop this
-// server gracefully across the session boundary. A session-0 service cannot send
-// a console Ctrl event to the windowless server in the user session, so instead
-// the supervisor signals a named event (created by it, opened here) whose name it
-// passes in shutdownEventEnvVar. When the event fires the returned context is
-// cancelled, driving the exact same graceful shutdown path as an interrupt. When
-// the server is not run by the supervisor (env var unset or the event cannot be
-// opened) the original context is returned unchanged.
 func installServiceShutdownTrigger(ctx context.Context) context.Context {
 	name := os.Getenv(shutdownEventEnvVar)
-	// Consume the variable so commands spawned by shell tools (which build their
-	// environment from os.Environ()) do not inherit this service-only marker.
+
 	_ = os.Unsetenv(shutdownEventEnvVar)
 	if name == "" {
 		return ctx

--- a/cli/kent/service_shutdown_windows.go
+++ b/cli/kent/service_shutdown_windows.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	brand "core/shared/config"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// shutdownEventEnvVar carries the name of the graceful-stop event from the
+// service supervisor to the server it launches. It is set only on the supervised
+// child's environment, so a normally-run `serve` never sees it.
+const shutdownEventEnvVar = brand.EnvPrefix + "SERVICE_SHUTDOWN_EVENT"
+
+// installServiceShutdownTrigger lets the LocalSystem service supervisor stop this
+// server gracefully across the session boundary. A session-0 service cannot send
+// a console Ctrl event to the windowless server in the user session, so instead
+// the supervisor signals a named event (created by it, opened here) whose name it
+// passes in shutdownEventEnvVar. When the event fires the returned context is
+// cancelled, driving the exact same graceful shutdown path as an interrupt. When
+// the server is not run by the supervisor (env var unset or the event cannot be
+// opened) the original context is returned unchanged.
+func installServiceShutdownTrigger(ctx context.Context) context.Context {
+	name := os.Getenv(shutdownEventEnvVar)
+	if name == "" {
+		return ctx
+	}
+	namePtr, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		return ctx
+	}
+	event, err := windows.OpenEvent(windows.SYNCHRONIZE, false, namePtr)
+	if err != nil {
+		return ctx
+	}
+	derived, cancel := context.WithCancel(ctx)
+	go func() {
+		_, _ = windows.WaitForSingleObject(event, windows.INFINITE)
+		cancel()
+	}()
+	return derived
+}

--- a/cli/kent/service_supervisor_windows.go
+++ b/cli/kent/service_supervisor_windows.go
@@ -39,15 +39,24 @@ const (
 // has the user's full identity (profile, DPAPI, Credential Manager, git/ssh),
 // and with CREATE_NO_WINDOW so no console window appears.
 type serverSupervisor struct {
-	spec   serviceSpec
-	wanted atomic.Uint32 // target interactive session id; 0 = no user session
-	wake   chan struct{}
-	mu     sync.Mutex
-	child  *managedChild
+	spec      serviceSpec
+	installer string        // SID the service was installed for; "" serves any console user
+	wanted    atomic.Uint32 // target interactive session id; 0 = no user session
+	wake      chan struct{}
+	mu        sync.Mutex
+	child     *managedChild
 }
 
 func newServerSupervisor(spec serviceSpec) *serverSupervisor {
-	return &serverSupervisor{spec: spec, wake: make(chan struct{}, 1)}
+	return &serverSupervisor{spec: spec, installer: readInstallUserSID(spec), wake: make(chan struct{}, 1)}
+}
+
+// targetSession is the console session the server should run in: the active
+// console session when it belongs to the install-time user (or when no installer
+// SID was recorded), else 0 so the supervisor does not launch the server for a
+// different user against the installer's persistence root.
+func (s *serverSupervisor) targetSession() uint32 {
+	return activeUserSessionForSID(s.installer)
 }
 
 // setWanted records the session the server should run in and nudges the run loop.
@@ -188,10 +197,11 @@ func growBackoff(current time.Duration) time.Duration {
 	return next
 }
 
-// activeUserSession returns the interactive console session id when a user is
-// logged in and a primary token can be obtained, else 0 (session 0 is the
-// non-interactive services session and is never a target).
-func activeUserSession() uint32 {
+// activeUserSessionForSID returns the interactive console session id when a user
+// is logged in, a primary token can be obtained, and (when wantSID is non-empty)
+// that user matches the install-time user, else 0. Session 0 is the
+// non-interactive services session and is never a target.
+func activeUserSessionForSID(wantSID string) uint32 {
 	session := windows.WTSGetActiveConsoleSessionId()
 	if session == 0xFFFFFFFF || session == 0 {
 		return 0
@@ -200,13 +210,19 @@ func activeUserSession() uint32 {
 	if err := windows.WTSQueryUserToken(session, &token); err != nil {
 		return 0
 	}
-	_ = token.Close()
+	defer func() { _ = token.Close() }()
+	if wantSID == "" {
+		return session
+	}
+	user, err := token.GetTokenUser()
+	if err != nil || user.User.Sid.String() != wantSID {
+		return 0
+	}
 	return session
 }
 
-// managedChild is a launched server process plus the user resources that must be
-// released when it exits (logon token, loaded profile, environment block, log
-// file handles).
+// managedChild is a launched server process plus the resources that must be
+// released when it exits (logon token, loaded profile, shutdown event, job).
 type managedChild struct {
 	session  uint32
 	pid      uint32
@@ -215,7 +231,6 @@ type managedChild struct {
 	profile  windows.Handle
 	shutdown windows.Handle
 	job      windows.Handle
-	logs     []windows.Handle
 	exited   chan struct{}
 	released sync.Once
 }
@@ -256,9 +271,6 @@ func (c *managedChild) terminate() {
 
 func (c *managedChild) release() {
 	c.released.Do(func() {
-		for _, h := range c.logs {
-			_ = windows.CloseHandle(h)
-		}
 		if c.shutdown != 0 {
 			_ = windows.CloseHandle(c.shutdown)
 		}
@@ -316,43 +328,26 @@ func launchServerAsUser(spec serviceSpec, session uint32) (child *managedChild, 
 		}
 	}()
 
-	env, err := userEnvironment(token, shutdownEventEnvVar, shutdownName)
-	if err != nil {
-		return nil, err
-	}
-
 	if err := ensureServiceLogDir(spec); err != nil {
 		return nil, err
 	}
-	stdout, err := openInheritableAppendFile(spec.StdoutLogPath)
+	// CreateProcessAsUser cannot inherit handles across sessions, so the server
+	// opens its own log files from these paths (see redirectServiceLogs) instead
+	// of receiving inherited std handles.
+	env, err := userEnvironment(token, map[string]string{
+		shutdownEventEnvVar: shutdownName,
+		stdoutLogEnvVar:     spec.StdoutLogPath,
+		stderrLogEnvVar:     spec.StderrLogPath,
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if !committed {
-			_ = windows.CloseHandle(stdout)
-		}
-	}()
-	stderr, err := openInheritableAppendFile(spec.StderrLogPath)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if !committed {
-			_ = windows.CloseHandle(stderr)
-		}
-	}()
 
 	desktop, err := windows.UTF16PtrFromString(`winsta0\default`)
 	if err != nil {
 		return nil, err
 	}
-	si := windows.StartupInfo{
-		Desktop:   desktop,
-		Flags:     windows.STARTF_USESTDHANDLES,
-		StdOutput: stdout,
-		StdErr:    stderr,
-	}
+	si := windows.StartupInfo{Desktop: desktop}
 	si.Cb = uint32(unsafe.Sizeof(si))
 
 	appName, err := windows.UTF16PtrFromString(spec.Executable)
@@ -372,7 +367,7 @@ func launchServerAsUser(spec serviceSpec, session uint32) (child *managedChild, 
 
 	var pi windows.ProcessInformation
 	flags := uint32(windows.CREATE_NO_WINDOW | windows.CREATE_UNICODE_ENVIRONMENT)
-	err = windows.CreateProcessAsUser(token, appName, cmdLine, nil, nil, true, flags, &env[0], cwd, &si, &pi)
+	err = windows.CreateProcessAsUser(token, appName, cmdLine, nil, nil, false, flags, &env[0], cwd, &si, &pi)
 	runtime.KeepAlive(env)
 	if err != nil {
 		return nil, fmt.Errorf("launch server as user in session %d: %w", session, err)
@@ -395,7 +390,6 @@ func launchServerAsUser(spec serviceSpec, session uint32) (child *managedChild, 
 		profile:  profile,
 		shutdown: shutdown,
 		job:      job,
-		logs:     []windows.Handle{stdout, stderr},
 		exited:   make(chan struct{}),
 	}
 	go c.watch()
@@ -447,13 +441,16 @@ func createShutdownEvent() (windows.Handle, string, error) {
 // profile environment with one extra variable set, returning a Go-owned block
 // the caller keeps alive across CreateProcessAsUser. The extra var carries the
 // graceful-stop event name only to the supervised child.
-func userEnvironment(token windows.Token, key string, value string) ([]uint16, error) {
+func userEnvironment(token windows.Token, extra map[string]string) ([]uint16, error) {
 	var block *uint16
 	if err := windows.CreateEnvironmentBlock(&block, token, false); err != nil {
 		return nil, fmt.Errorf("create environment block: %w", err)
 	}
 	defer func() { _ = windows.DestroyEnvironmentBlock(block) }()
-	entries := append(splitEnvironmentBlock(block), key+"="+value)
+	entries := splitEnvironmentBlock(block)
+	for key, value := range extra {
+		entries = append(entries, key+"="+value)
+	}
 	return buildEnvironmentBlock(entries)
 }
 
@@ -518,26 +515,4 @@ func assignProcessToKillJob(process windows.Handle) (windows.Handle, error) {
 		return 0, fmt.Errorf("assign server to job: %w", err)
 	}
 	return job, nil
-}
-
-func openInheritableAppendFile(path string) (windows.Handle, error) {
-	namePtr, err := windows.UTF16PtrFromString(path)
-	if err != nil {
-		return 0, err
-	}
-	sa := windows.SecurityAttributes{InheritHandle: 1}
-	sa.Length = uint32(unsafe.Sizeof(sa))
-	handle, err := windows.CreateFile(
-		namePtr,
-		windows.FILE_APPEND_DATA,
-		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
-		&sa,
-		windows.OPEN_ALWAYS,
-		windows.FILE_ATTRIBUTE_NORMAL,
-		0,
-	)
-	if err != nil {
-		return 0, fmt.Errorf("open log file %s: %w", path, err)
-	}
-	return handle, nil
 }

--- a/cli/kent/service_supervisor_windows.go
+++ b/cli/kent/service_supervisor_windows.go
@@ -1,0 +1,543 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	brand "core/shared/config"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	supervisorInitialBackoff = 1 * time.Second
+	supervisorMaxBackoff     = 30 * time.Second
+	stillActiveExitCode      = 259 // STILL_ACTIVE
+	// supervisorStopGracePeriod is how long a graceful stop waits for the server
+	// to exit after its shutdown event is signalled before falling back to a hard
+	// terminate. Kept well under the service stop WaitHint so the SCM never kills
+	// the supervisor (which would orphan the server) mid-shutdown.
+	supervisorStopGracePeriod = 15 * time.Second
+	// shutdownEventSDDL grants the supervisor (LocalSystem) and Administrators full
+	// control of the graceful-stop event and the interactive user wait access, so
+	// the server launched under the user token can open and wait on it.
+	shutdownEventSDDL = "D:(A;;GA;;;SY)(A;;GA;;;BA)(A;;0x00100000;;;IU)"
+)
+
+// serverSupervisor runs inside the LocalSystem service process and keeps a
+// `kent serve` child alive in the interactive user's session. The child is
+// launched with the logged-in user's primary token (no stored password), so it
+// has the user's full identity (profile, DPAPI, Credential Manager, git/ssh),
+// and with CREATE_NO_WINDOW so no console window appears.
+type serverSupervisor struct {
+	spec   serviceSpec
+	wanted atomic.Uint32 // target interactive session id; 0 = no user session
+	wake   chan struct{}
+	mu     sync.Mutex
+	child  *managedChild
+}
+
+func newServerSupervisor(spec serviceSpec) *serverSupervisor {
+	return &serverSupervisor{spec: spec, wake: make(chan struct{}, 1)}
+}
+
+// setWanted records the session the server should run in and nudges the run loop.
+func (s *serverSupervisor) setWanted(session uint32) {
+	s.wanted.Store(session)
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+// run is the supervision loop. It launches the child in the wanted session,
+// restarts it with backoff if it exits unexpectedly, relaunches it when the
+// interactive session changes, and tears it down when the context is cancelled.
+func (s *serverSupervisor) run(ctx context.Context) {
+	backoff := supervisorInitialBackoff
+	for {
+		if ctx.Err() != nil {
+			s.stopChild()
+			return
+		}
+		session := s.wanted.Load()
+		if session == 0 {
+			s.stopChild()
+			select {
+			case <-ctx.Done():
+				return
+			case <-s.wake:
+				continue
+			}
+		}
+		s.mu.Lock()
+		needLaunch := s.child == nil || s.child.session != session || !s.child.alive()
+		s.mu.Unlock()
+		if needLaunch {
+			s.stopChild()
+			child, err := launchServerAsUser(s.spec, session)
+			if err != nil {
+				s.logf("launch failed for session %d: %v", session, err)
+				if !s.sleep(ctx, backoff) {
+					return
+				}
+				backoff = growBackoff(backoff)
+				continue
+			}
+			s.mu.Lock()
+			s.child = child
+			s.mu.Unlock()
+			s.writePID(child.pid)
+			backoff = supervisorInitialBackoff
+		}
+		s.mu.Lock()
+		child := s.child
+		s.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			s.stopChild()
+			return
+		case <-s.wake:
+			continue
+		case <-child.exited:
+			child.release()
+			s.mu.Lock()
+			if s.child == child {
+				s.child = nil
+			}
+			s.mu.Unlock()
+			s.clearPID()
+			if ctx.Err() != nil {
+				return
+			}
+			if !s.sleep(ctx, backoff) {
+				return
+			}
+			backoff = growBackoff(backoff)
+		}
+	}
+}
+
+// sleep waits for the duration, an early wake, or context cancellation. It
+// returns false when the context was cancelled (caller should exit).
+func (s *serverSupervisor) sleep(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-s.wake:
+		return true
+	case <-timer.C:
+		return true
+	}
+}
+
+func (s *serverSupervisor) stopChild() {
+	s.mu.Lock()
+	child := s.child
+	s.child = nil
+	s.mu.Unlock()
+	if child != nil {
+		child.terminate()
+	}
+	s.clearPID()
+}
+
+func (s *serverSupervisor) writePID(pid uint32) {
+	_ = os.MkdirAll(windowsServiceDir(s.spec), 0o755)
+	_ = os.WriteFile(windowsServerPIDPath(s.spec), []byte(fmt.Sprintf("%d", pid)), 0o644)
+}
+
+func (s *serverSupervisor) clearPID() {
+	_ = os.Remove(windowsServerPIDPath(s.spec))
+}
+
+// logf appends a supervisor diagnostic to the service error log so launch
+// failures are observable even though the supervisor has no console.
+func (s *serverSupervisor) logf(format string, args ...any) {
+	appendServiceLog(s.spec, format, args...)
+}
+
+func appendServiceLog(spec serviceSpec, format string, args ...any) {
+	if err := ensureServiceLogDir(spec); err != nil {
+		return
+	}
+	f, err := os.OpenFile(spec.StderrLogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintf(f, "[%s supervisor] %s\n", time.Now().Format(time.RFC3339), fmt.Sprintf(format, args...))
+}
+
+func growBackoff(current time.Duration) time.Duration {
+	next := current * 2
+	if next > supervisorMaxBackoff {
+		return supervisorMaxBackoff
+	}
+	return next
+}
+
+// activeUserSession returns the interactive console session id when a user is
+// logged in and a primary token can be obtained, else 0 (session 0 is the
+// non-interactive services session and is never a target).
+func activeUserSession() uint32 {
+	session := windows.WTSGetActiveConsoleSessionId()
+	if session == 0xFFFFFFFF || session == 0 {
+		return 0
+	}
+	var token windows.Token
+	if err := windows.WTSQueryUserToken(session, &token); err != nil {
+		return 0
+	}
+	_ = token.Close()
+	return session
+}
+
+// managedChild is a launched server process plus the user resources that must be
+// released when it exits (logon token, loaded profile, environment block, log
+// file handles).
+type managedChild struct {
+	session  uint32
+	pid      uint32
+	process  windows.Handle
+	token    windows.Token
+	profile  windows.Handle
+	shutdown windows.Handle
+	job      windows.Handle
+	logs     []windows.Handle
+	exited   chan struct{}
+	released sync.Once
+}
+
+func (c *managedChild) watch() {
+	_, _ = windows.WaitForSingleObject(c.process, windows.INFINITE)
+	close(c.exited)
+}
+
+func (c *managedChild) alive() bool {
+	var code uint32
+	if err := windows.GetExitCodeProcess(c.process, &code); err != nil {
+		return false
+	}
+	return code == stillActiveExitCode
+}
+
+// terminate stops the server, preferring a graceful shutdown: it signals the
+// server's shutdown event (equivalent to Ctrl+C) and waits up to the grace
+// period for a clean exit, falling back to a hard TerminateProcess only if the
+// server does not exit in time or no shutdown event is available.
+func (c *managedChild) terminate() {
+	if c.shutdown != 0 && windows.SetEvent(c.shutdown) == nil {
+		select {
+		case <-c.exited:
+			c.release()
+			return
+		case <-time.After(supervisorStopGracePeriod):
+		}
+	}
+	_ = windows.TerminateProcess(c.process, 1)
+	select {
+	case <-c.exited:
+	case <-time.After(5 * time.Second):
+	}
+	c.release()
+}
+
+func (c *managedChild) release() {
+	c.released.Do(func() {
+		for _, h := range c.logs {
+			_ = windows.CloseHandle(h)
+		}
+		if c.shutdown != 0 {
+			_ = windows.CloseHandle(c.shutdown)
+		}
+		if c.job != 0 {
+			_ = windows.CloseHandle(c.job)
+		}
+		if c.profile != 0 {
+			_ = unloadUserProfile(c.token, c.profile)
+		}
+		if c.token != 0 {
+			_ = c.token.Close()
+		}
+		if c.process != 0 {
+			_ = windows.CloseHandle(c.process)
+		}
+	})
+}
+
+// launchServerAsUser starts `kent serve` in the given interactive session as the
+// logged-in user, with the user's profile/environment loaded and stdout/stderr
+// redirected to the service log files. No console window is created.
+func launchServerAsUser(spec serviceSpec, session uint32) (child *managedChild, err error) {
+	var token windows.Token
+	if err := windows.WTSQueryUserToken(session, &token); err != nil {
+		return nil, fmt.Errorf("query user token for session %d: %w", session, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = token.Close()
+		}
+	}()
+
+	username, err := tokenUserName(token)
+	if err != nil {
+		return nil, err
+	}
+	profile, err := loadUserProfile(token, username)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if !committed {
+			_ = unloadUserProfile(token, profile)
+		}
+	}()
+
+	shutdown, shutdownName, err := createShutdownEvent()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if !committed {
+			_ = windows.CloseHandle(shutdown)
+		}
+	}()
+
+	env, err := userEnvironment(token, shutdownEventEnvVar, shutdownName)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ensureServiceLogDir(spec); err != nil {
+		return nil, err
+	}
+	stdout, err := openInheritableAppendFile(spec.StdoutLogPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if !committed {
+			_ = windows.CloseHandle(stdout)
+		}
+	}()
+	stderr, err := openInheritableAppendFile(spec.StderrLogPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if !committed {
+			_ = windows.CloseHandle(stderr)
+		}
+	}()
+
+	desktop, err := windows.UTF16PtrFromString(`winsta0\default`)
+	if err != nil {
+		return nil, err
+	}
+	si := windows.StartupInfo{
+		Desktop:   desktop,
+		Flags:     windows.STARTF_USESTDHANDLES,
+		StdOutput: stdout,
+		StdErr:    stderr,
+	}
+	si.Cb = uint32(unsafe.Sizeof(si))
+
+	appName, err := windows.UTF16PtrFromString(spec.Executable)
+	if err != nil {
+		return nil, err
+	}
+	cmdLine, err := windows.UTF16PtrFromString(windows.ComposeCommandLine(serviceCommand(spec)))
+	if err != nil {
+		return nil, err
+	}
+	var cwd *uint16
+	if root := spec.Config.PersistenceRoot; root != "" {
+		if cwd, err = windows.UTF16PtrFromString(root); err != nil {
+			return nil, err
+		}
+	}
+
+	var pi windows.ProcessInformation
+	flags := uint32(windows.CREATE_NO_WINDOW | windows.CREATE_UNICODE_ENVIRONMENT)
+	err = windows.CreateProcessAsUser(token, appName, cmdLine, nil, nil, true, flags, &env[0], cwd, &si, &pi)
+	runtime.KeepAlive(env)
+	if err != nil {
+		return nil, fmt.Errorf("launch server as user in session %d: %w", session, err)
+	}
+	_ = windows.CloseHandle(pi.Thread)
+
+	// Best-effort: jobbing the server so a supervisor crash cannot leave it
+	// orphaned (which the SCM restart would then duplicate). A failure here only
+	// loses that safety net; graceful stop and normal teardown still work.
+	job, jobErr := assignProcessToKillJob(pi.Process)
+	if jobErr != nil {
+		appendServiceLog(spec, "kill-on-crash job unavailable for session %d: %v", session, jobErr)
+	}
+
+	c := &managedChild{
+		session:  session,
+		pid:      pi.ProcessId,
+		process:  pi.Process,
+		token:    token,
+		profile:  profile,
+		shutdown: shutdown,
+		job:      job,
+		logs:     []windows.Handle{stdout, stderr},
+		exited:   make(chan struct{}),
+	}
+	go c.watch()
+	committed = true
+	return c, nil
+}
+
+func tokenUserName(token windows.Token) (string, error) {
+	user, err := token.GetTokenUser()
+	if err != nil {
+		return "", fmt.Errorf("get token user: %w", err)
+	}
+	account, _, _, err := user.User.Sid.LookupAccount("")
+	if err != nil {
+		return "", fmt.Errorf("resolve token user name: %w", err)
+	}
+	return account, nil
+}
+
+// createShutdownEvent creates the per-server manual-reset event the supervisor
+// signals for a graceful stop. It lives in the Global namespace (the supervisor
+// has SeCreateGlobalPrivilege; the server, running as the user, only opens it)
+// with a DACL granting the interactive user wait access. The unique random name
+// is passed to the server so multiple installs never collide.
+func createShutdownEvent() (windows.Handle, string, error) {
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return 0, "", fmt.Errorf("generate shutdown event name: %w", err)
+	}
+	name := fmt.Sprintf(`Global\%s-svc-shutdown-%s`, brand.Product, hex.EncodeToString(nonce[:]))
+	namePtr, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		return 0, "", err
+	}
+	sd, err := windows.SecurityDescriptorFromString(shutdownEventSDDL)
+	if err != nil {
+		return 0, "", fmt.Errorf("build shutdown event security descriptor: %w", err)
+	}
+	sa := windows.SecurityAttributes{SecurityDescriptor: sd}
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	event, err := windows.CreateEvent(&sa, 1, 0, namePtr)
+	if err != nil {
+		return 0, "", fmt.Errorf("create shutdown event: %w", err)
+	}
+	return event, name, nil
+}
+
+// userEnvironment builds the environment block for the server from the user's
+// profile environment with one extra variable set, returning a Go-owned block
+// the caller keeps alive across CreateProcessAsUser. The extra var carries the
+// graceful-stop event name only to the supervised child.
+func userEnvironment(token windows.Token, key string, value string) ([]uint16, error) {
+	var block *uint16
+	if err := windows.CreateEnvironmentBlock(&block, token, false); err != nil {
+		return nil, fmt.Errorf("create environment block: %w", err)
+	}
+	defer func() { _ = windows.DestroyEnvironmentBlock(block) }()
+	entries := append(splitEnvironmentBlock(block), key+"="+value)
+	return buildEnvironmentBlock(entries)
+}
+
+// splitEnvironmentBlock decodes a double-null-terminated UTF-16 environment block
+// into its "KEY=VALUE" entries.
+func splitEnvironmentBlock(block *uint16) []string {
+	if block == nil {
+		return nil
+	}
+	var entries []string
+	for p := block; ; {
+		n := 0
+		for *(*uint16)(unsafe.Add(unsafe.Pointer(p), uintptr(n)*2)) != 0 {
+			n++
+		}
+		if n == 0 {
+			break
+		}
+		entries = append(entries, windows.UTF16ToString(unsafe.Slice(p, n)))
+		p = (*uint16)(unsafe.Add(unsafe.Pointer(p), uintptr(n+1)*2))
+	}
+	return entries
+}
+
+// buildEnvironmentBlock encodes "KEY=VALUE" entries into a double-null-terminated
+// UTF-16 environment block.
+func buildEnvironmentBlock(entries []string) ([]uint16, error) {
+	var block []uint16
+	for _, entry := range entries {
+		encoded, err := windows.UTF16FromString(entry)
+		if err != nil {
+			return nil, fmt.Errorf("encode environment entry: %w", err)
+		}
+		block = append(block, encoded...)
+	}
+	if len(block) == 0 {
+		block = append(block, 0)
+	}
+	block = append(block, 0)
+	return block, nil
+}
+
+// assignProcessToKillJob puts the server in a job that kills it when the job
+// handle closes, so an abnormal supervisor exit terminates the server with it
+// instead of orphaning it.
+func assignProcessToKillJob(process windows.Handle) (windows.Handle, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return 0, fmt.Errorf("create job object: %w", err)
+	}
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(job, windows.JobObjectExtendedLimitInformation, uintptr(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info))); err != nil {
+		_ = windows.CloseHandle(job)
+		return 0, fmt.Errorf("configure kill-on-close job: %w", err)
+	}
+	if err := windows.AssignProcessToJobObject(job, process); err != nil {
+		_ = windows.CloseHandle(job)
+		return 0, fmt.Errorf("assign server to job: %w", err)
+	}
+	return job, nil
+}
+
+func openInheritableAppendFile(path string) (windows.Handle, error) {
+	namePtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	sa := windows.SecurityAttributes{InheritHandle: 1}
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	handle, err := windows.CreateFile(
+		namePtr,
+		windows.FILE_APPEND_DATA,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		&sa,
+		windows.OPEN_ALWAYS,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("open log file %s: %w", path, err)
+	}
+	return handle, nil
+}

--- a/cli/kent/service_supervisor_windows.go
+++ b/cli/kent/service_supervisor_windows.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -447,11 +448,36 @@ func userEnvironment(token windows.Token, extra map[string]string) ([]uint16, er
 		return nil, fmt.Errorf("create environment block: %w", err)
 	}
 	defer func() { _ = windows.DestroyEnvironmentBlock(block) }()
-	entries := splitEnvironmentBlock(block)
-	for key, value := range extra {
-		entries = append(entries, key+"="+value)
+	return buildEnvironmentBlock(upsertEnvironmentEntries(splitEnvironmentBlock(block), extra))
+}
+
+// upsertEnvironmentEntries appends extra KEY=VALUE entries after removing any
+// existing entries with a matching name. Windows environment names are
+// case-insensitive and the first match in the block wins, so a preexisting
+// same-name entry would otherwise shadow the supervisor's value.
+func upsertEnvironmentEntries(entries []string, extra map[string]string) []string {
+	if len(extra) == 0 {
+		return entries
 	}
-	return buildEnvironmentBlock(entries)
+	replaced := make(map[string]struct{}, len(extra))
+	for key := range extra {
+		replaced[strings.ToLower(key)] = struct{}{}
+	}
+	result := make([]string, 0, len(entries)+len(extra))
+	for _, entry := range entries {
+		name := entry
+		if i := strings.IndexByte(entry, '='); i >= 0 {
+			name = entry[:i]
+		}
+		if _, dup := replaced[strings.ToLower(name)]; dup {
+			continue
+		}
+		result = append(result, entry)
+	}
+	for key, value := range extra {
+		result = append(result, key+"="+value)
+	}
+	return result
 }
 
 // splitEnvironmentBlock decodes a double-null-terminated UTF-16 environment block

--- a/cli/kent/service_supervisor_windows.go
+++ b/cli/kent/service_supervisor_windows.go
@@ -189,7 +189,11 @@ func activeUserSessionForSID(wantSID string) uint32 {
 	var consoleFallback uint32
 	for i := range sessions {
 		id := sessions[i].SessionID
-		if sessions[i].State != windows.WTSActive || id == 0 {
+		state := sessions[i].State
+		if id == 0 {
+			continue
+		}
+		if state != windows.WTSActive && state != windows.WTSDisconnected {
 			continue
 		}
 		sid, err := sessionUserSID(id)
@@ -200,6 +204,9 @@ func activeUserSessionForSID(wantSID string) uint32 {
 			if sid == wantSID {
 				return id
 			}
+			continue
+		}
+		if state != windows.WTSActive {
 			continue
 		}
 		if id == console {

--- a/cli/kent/service_supervisor_windows.go
+++ b/cli/kent/service_supervisor_windows.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -22,27 +23,17 @@ import (
 const (
 	supervisorInitialBackoff = 1 * time.Second
 	supervisorMaxBackoff     = 30 * time.Second
-	stillActiveExitCode      = 259 // STILL_ACTIVE
-	// supervisorStopGracePeriod is how long a graceful stop waits for the server
-	// to exit after its shutdown event is signalled before falling back to a hard
-	// terminate. Kept well under the service stop WaitHint so the SCM never kills
-	// the supervisor (which would orphan the server) mid-shutdown.
+	stillActiveExitCode      = 259
+
 	supervisorStopGracePeriod = 15 * time.Second
-	// shutdownEventSDDL grants the supervisor (LocalSystem) and Administrators full
-	// control of the graceful-stop event and the interactive user wait access, so
-	// the server launched under the user token can open and wait on it.
+
 	shutdownEventSDDL = "D:(A;;GA;;;SY)(A;;GA;;;BA)(A;;0x00100000;;;IU)"
 )
 
-// serverSupervisor runs inside the LocalSystem service process and keeps a
-// `kent serve` child alive in the interactive user's session. The child is
-// launched with the logged-in user's primary token (no stored password), so it
-// has the user's full identity (profile, DPAPI, Credential Manager, git/ssh),
-// and with CREATE_NO_WINDOW so no console window appears.
 type serverSupervisor struct {
 	spec      serviceSpec
-	installer string        // SID the service was installed for; "" serves any console user
-	wanted    atomic.Uint32 // target interactive session id; 0 = no user session
+	installer string
+	wanted    atomic.Uint32
 	wake      chan struct{}
 	mu        sync.Mutex
 	child     *managedChild
@@ -52,15 +43,10 @@ func newServerSupervisor(spec serviceSpec) *serverSupervisor {
 	return &serverSupervisor{spec: spec, installer: readInstallUserSID(spec), wake: make(chan struct{}, 1)}
 }
 
-// targetSession is the console session the server should run in: the active
-// console session when it belongs to the install-time user (or when no installer
-// SID was recorded), else 0 so the supervisor does not launch the server for a
-// different user against the installer's persistence root.
 func (s *serverSupervisor) targetSession() uint32 {
 	return activeUserSessionForSID(s.installer)
 }
 
-// setWanted records the session the server should run in and nudges the run loop.
 func (s *serverSupervisor) setWanted(session uint32) {
 	s.wanted.Store(session)
 	select {
@@ -69,9 +55,6 @@ func (s *serverSupervisor) setWanted(session uint32) {
 	}
 }
 
-// run is the supervision loop. It launches the child in the wanted session,
-// restarts it with backoff if it exits unexpectedly, relaunches it when the
-// interactive session changes, and tears it down when the context is cancelled.
 func (s *serverSupervisor) run(ctx context.Context) {
 	backoff := supervisorInitialBackoff
 	for {
@@ -137,8 +120,6 @@ func (s *serverSupervisor) run(ctx context.Context) {
 	}
 }
 
-// sleep waits for the duration, an early wake, or context cancellation. It
-// returns false when the context was cancelled (caller should exit).
 func (s *serverSupervisor) sleep(ctx context.Context, d time.Duration) bool {
 	timer := time.NewTimer(d)
 	defer timer.Stop()
@@ -172,8 +153,6 @@ func (s *serverSupervisor) clearPID() {
 	_ = os.Remove(windowsServerPIDPath(s.spec))
 }
 
-// logf appends a supervisor diagnostic to the service error log so launch
-// failures are observable even though the supervisor has no console.
 func (s *serverSupervisor) logf(format string, args ...any) {
 	appendServiceLog(s.spec, format, args...)
 }
@@ -198,32 +177,57 @@ func growBackoff(current time.Duration) time.Duration {
 	return next
 }
 
-// activeUserSessionForSID returns the interactive console session id when a user
-// is logged in, a primary token can be obtained, and (when wantSID is non-empty)
-// that user matches the install-time user, else 0. Session 0 is the
-// non-interactive services session and is never a target.
 func activeUserSessionForSID(wantSID string) uint32 {
-	session := windows.WTSGetActiveConsoleSessionId()
-	if session == 0xFFFFFFFF || session == 0 {
+	var infos *windows.WTS_SESSION_INFO
+	var count uint32
+	if err := windows.WTSEnumerateSessions(0, 0, 1, &infos, &count); err != nil {
 		return 0
 	}
-	var token windows.Token
-	if err := windows.WTSQueryUserToken(session, &token); err != nil {
-		return 0
+	defer windows.WTSFreeMemory(uintptr(unsafe.Pointer(infos)))
+	sessions := unsafe.Slice(infos, count)
+	console := windows.WTSGetActiveConsoleSessionId()
+	var consoleFallback uint32
+	for i := range sessions {
+		id := sessions[i].SessionID
+		if sessions[i].State != windows.WTSActive || id == 0 {
+			continue
+		}
+		sid, err := sessionUserSID(id)
+		if err != nil {
+			continue
+		}
+		if wantSID != "" {
+			if sid == wantSID {
+				return id
+			}
+			continue
+		}
+		if id == console {
+			return id
+		}
+		if consoleFallback == 0 {
+			consoleFallback = id
+		}
 	}
-	defer func() { _ = token.Close() }()
 	if wantSID == "" {
-		return session
+		return consoleFallback
 	}
-	user, err := token.GetTokenUser()
-	if err != nil || user.User.Sid.String() != wantSID {
-		return 0
-	}
-	return session
+	return 0
 }
 
-// managedChild is a launched server process plus the resources that must be
-// released when it exits (logon token, loaded profile, shutdown event, job).
+func sessionUserSID(session uint32) (string, error) {
+	var token windows.Token
+	if err := windows.WTSQueryUserToken(session, &token); err != nil {
+		return "", err
+	}
+	defer func() { _ = token.Close() }()
+	user, err := token.GetTokenUser()
+	if err != nil {
+		return "", err
+	}
+	return user.User.Sid.String(), nil
+}
+
 type managedChild struct {
 	session  uint32
 	pid      uint32
@@ -249,10 +253,6 @@ func (c *managedChild) alive() bool {
 	return code == stillActiveExitCode
 }
 
-// terminate stops the server, preferring a graceful shutdown: it signals the
-// server's shutdown event (equivalent to Ctrl+C) and waits up to the grace
-// period for a clean exit, falling back to a hard TerminateProcess only if the
-// server does not exit in time or no shutdown event is available.
 func (c *managedChild) terminate() {
 	if c.shutdown != 0 && windows.SetEvent(c.shutdown) == nil {
 		select {
@@ -290,9 +290,6 @@ func (c *managedChild) release() {
 	})
 }
 
-// launchServerAsUser starts `kent serve` in the given interactive session as the
-// logged-in user, with the user's profile/environment loaded and stdout/stderr
-// redirected to the service log files. No console window is created.
 func launchServerAsUser(spec serviceSpec, session uint32) (child *managedChild, err error) {
 	var token windows.Token
 	if err := windows.WTSQueryUserToken(session, &token); err != nil {
@@ -332,9 +329,7 @@ func launchServerAsUser(spec serviceSpec, session uint32) (child *managedChild, 
 	if err := ensureServiceLogDir(spec); err != nil {
 		return nil, err
 	}
-	// CreateProcessAsUser cannot inherit handles across sessions, so the server
-	// opens its own log files from these paths (see redirectServiceLogs) instead
-	// of receiving inherited std handles.
+
 	env, err := userEnvironment(token, map[string]string{
 		shutdownEventEnvVar: shutdownName,
 		stdoutLogEnvVar:     spec.StdoutLogPath,
@@ -375,9 +370,6 @@ func launchServerAsUser(spec serviceSpec, session uint32) (child *managedChild, 
 	}
 	_ = windows.CloseHandle(pi.Thread)
 
-	// Best-effort: jobbing the server so a supervisor crash cannot leave it
-	// orphaned (which the SCM restart would then duplicate). A failure here only
-	// loses that safety net; graceful stop and normal teardown still work.
 	job, jobErr := assignProcessToKillJob(pi.Process)
 	if jobErr != nil {
 		appendServiceLog(spec, "kill-on-crash job unavailable for session %d: %v", session, jobErr)
@@ -410,11 +402,6 @@ func tokenUserName(token windows.Token) (string, error) {
 	return account, nil
 }
 
-// createShutdownEvent creates the per-server manual-reset event the supervisor
-// signals for a graceful stop. It lives in the Global namespace (the supervisor
-// has SeCreateGlobalPrivilege; the server, running as the user, only opens it)
-// with a DACL granting the interactive user wait access. The unique random name
-// is passed to the server so multiple installs never collide.
 func createShutdownEvent() (windows.Handle, string, error) {
 	var nonce [16]byte
 	if _, err := rand.Read(nonce[:]); err != nil {
@@ -438,23 +425,19 @@ func createShutdownEvent() (windows.Handle, string, error) {
 	return event, name, nil
 }
 
-// userEnvironment builds the environment block for the server from the user's
-// profile environment with one extra variable set, returning a Go-owned block
-// the caller keeps alive across CreateProcessAsUser. The extra var carries the
-// graceful-stop event name only to the supervised child.
 func userEnvironment(token windows.Token, extra map[string]string) ([]uint16, error) {
 	var block *uint16
 	if err := windows.CreateEnvironmentBlock(&block, token, false); err != nil {
 		return nil, fmt.Errorf("create environment block: %w", err)
 	}
 	defer func() { _ = windows.DestroyEnvironmentBlock(block) }()
-	return buildEnvironmentBlock(upsertEnvironmentEntries(splitEnvironmentBlock(block), extra))
+	entries := upsertEnvironmentEntries(splitEnvironmentBlock(block), extra)
+	sort.Slice(entries, func(i, j int) bool {
+		return strings.ToLower(entries[i]) < strings.ToLower(entries[j])
+	})
+	return buildEnvironmentBlock(entries)
 }
 
-// upsertEnvironmentEntries appends extra KEY=VALUE entries after removing any
-// existing entries with a matching name. Windows environment names are
-// case-insensitive and the first match in the block wins, so a preexisting
-// same-name entry would otherwise shadow the supervisor's value.
 func upsertEnvironmentEntries(entries []string, extra map[string]string) []string {
 	if len(extra) == 0 {
 		return entries
@@ -480,8 +463,6 @@ func upsertEnvironmentEntries(entries []string, extra map[string]string) []strin
 	return result
 }
 
-// splitEnvironmentBlock decodes a double-null-terminated UTF-16 environment block
-// into its "KEY=VALUE" entries.
 func splitEnvironmentBlock(block *uint16) []string {
 	if block == nil {
 		return nil
@@ -501,8 +482,6 @@ func splitEnvironmentBlock(block *uint16) []string {
 	return entries
 }
 
-// buildEnvironmentBlock encodes "KEY=VALUE" entries into a double-null-terminated
-// UTF-16 environment block.
 func buildEnvironmentBlock(entries []string) ([]uint16, error) {
 	var block []uint16
 	for _, entry := range entries {
@@ -519,9 +498,6 @@ func buildEnvironmentBlock(entries []string) ([]uint16, error) {
 	return block, nil
 }
 
-// assignProcessToKillJob puts the server in a job that kills it when the job
-// handle closes, so an abnormal supervisor exit terminates the server with it
-// instead of orphaning it.
 func assignProcessToKillJob(process windows.Handle) (windows.Handle, error) {
 	job, err := windows.CreateJobObject(nil, nil)
 	if err != nil {

--- a/cli/kent/service_types.go
+++ b/cli/kent/service_types.go
@@ -17,13 +17,14 @@ import (
 )
 
 const (
-	serviceDisplayName     = config.ServiceDisplayName
-	serviceLaunchdLabel    = config.ServiceLaunchdLabel
-	serviceSystemdUnitName = config.ServiceSystemdUnitName
-	serviceWindowsTaskName = config.ServiceWindowsTaskName
-	serviceLogDirName      = "logs"
-	serviceStdoutLogName   = "server.log"
-	serviceStderrLogName   = "server.err.log"
+	serviceDisplayName        = config.ServiceDisplayName
+	serviceLaunchdLabel       = config.ServiceLaunchdLabel
+	serviceSystemdUnitName    = config.ServiceSystemdUnitName
+	serviceWindowsTaskName    = config.ServiceWindowsTaskName
+	serviceWindowsServiceName = config.ServiceWindowsServiceName
+	serviceLogDirName         = "logs"
+	serviceStdoutLogName      = "server.log"
+	serviceStderrLogName      = "server.err.log"
 )
 
 type serviceSpec struct {
@@ -84,6 +85,7 @@ func (e serviceCommandError) Error() string {
 
 var runServiceCommand = func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
+	configureNoWindow(cmd)
 	stdout, err := cmd.Output()
 	result := serviceCommandResult{Stdout: string(stdout)}
 	if err == nil {

--- a/cli/kent/service_types.go
+++ b/cli/kent/service_types.go
@@ -127,10 +127,6 @@ func defaultLoadServiceSpec() (serviceSpec, error) {
 	}, nil
 }
 
-// serviceServeArguments builds the `serve` arguments for an installed service.
-// The resolved config+data root is baked in as --persistence-root so the
-// launched service uses the same root the operator installed with, rather than
-// re-resolving ~/.kent under whatever user/HOME the service manager runs as.
 func serviceServeArguments(persistenceRoot string) []string {
 	args := []string{"serve"}
 	if trimmed := strings.TrimSpace(persistenceRoot); trimmed != "" {

--- a/cli/kent/service_userenv_windows.go
+++ b/cli/kent/service_userenv_windows.go
@@ -9,18 +9,12 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// userenv.dll wrappers that x/sys/windows does not vendor. The supervisor loads
-// the target user's profile before launching the server so that HKCU, DPAPI,
-// the Windows Credential Manager, and %USERPROFILE%-relative config (.gitconfig,
-// .ssh) resolve exactly as they do for an interactive logon.
 var (
 	userenvDLL            = windows.NewLazySystemDLL("userenv.dll")
 	procLoadUserProfile   = userenvDLL.NewProc("LoadUserProfileW")
 	procUnloadUserProfile = userenvDLL.NewProc("UnloadUserProfile")
 )
 
-// profileInfo mirrors PROFILEINFOW. hProfile is an output handle that must be
-// passed back to UnloadUserProfile.
 type profileInfo struct {
 	Size        uint32
 	Flags       uint32
@@ -32,10 +26,8 @@ type profileInfo struct {
 	Profile     windows.Handle
 }
 
-const piNoUI = 0x00000001 // PI_NOUI: do not display a progress UI
+const piNoUI = 0x00000001
 
-// loadUserProfile mounts the user's registry hive/profile for the logon token,
-// returning the profile handle to unload on shutdown.
 func loadUserProfile(token windows.Token, username string) (windows.Handle, error) {
 	namePtr, err := windows.UTF16PtrFromString(username)
 	if err != nil {
@@ -53,7 +45,6 @@ func loadUserProfile(token windows.Token, username string) (windows.Handle, erro
 	return info.Profile, nil
 }
 
-// unloadUserProfile releases a profile handle returned by loadUserProfile.
 func unloadUserProfile(token windows.Token, profile windows.Handle) error {
 	if profile == 0 {
 		return nil

--- a/cli/kent/service_userenv_windows.go
+++ b/cli/kent/service_userenv_windows.go
@@ -1,0 +1,66 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// userenv.dll wrappers that x/sys/windows does not vendor. The supervisor loads
+// the target user's profile before launching the server so that HKCU, DPAPI,
+// the Windows Credential Manager, and %USERPROFILE%-relative config (.gitconfig,
+// .ssh) resolve exactly as they do for an interactive logon.
+var (
+	userenvDLL            = windows.NewLazySystemDLL("userenv.dll")
+	procLoadUserProfile   = userenvDLL.NewProc("LoadUserProfileW")
+	procUnloadUserProfile = userenvDLL.NewProc("UnloadUserProfile")
+)
+
+// profileInfo mirrors PROFILEINFOW. hProfile is an output handle that must be
+// passed back to UnloadUserProfile.
+type profileInfo struct {
+	Size        uint32
+	Flags       uint32
+	UserName    *uint16
+	ProfilePath *uint16
+	DefaultPath *uint16
+	ServerName  *uint16
+	PolicyPath  *uint16
+	Profile     windows.Handle
+}
+
+const piNoUI = 0x00000001 // PI_NOUI: do not display a progress UI
+
+// loadUserProfile mounts the user's registry hive/profile for the logon token,
+// returning the profile handle to unload on shutdown.
+func loadUserProfile(token windows.Token, username string) (windows.Handle, error) {
+	namePtr, err := windows.UTF16PtrFromString(username)
+	if err != nil {
+		return 0, fmt.Errorf("encode profile user name: %w", err)
+	}
+	info := profileInfo{
+		Flags:    piNoUI,
+		UserName: namePtr,
+	}
+	info.Size = uint32(unsafe.Sizeof(info))
+	ret, _, callErr := procLoadUserProfile.Call(uintptr(token), uintptr(unsafe.Pointer(&info)))
+	if ret == 0 {
+		return 0, fmt.Errorf("LoadUserProfile: %w", callErr)
+	}
+	return info.Profile, nil
+}
+
+// unloadUserProfile releases a profile handle returned by loadUserProfile.
+func unloadUserProfile(token windows.Token, profile windows.Handle) error {
+	if profile == 0 {
+		return nil
+	}
+	ret, _, callErr := procUnloadUserProfile.Call(uintptr(token), uintptr(profile))
+	if ret == 0 {
+		return fmt.Errorf("UnloadUserProfile: %w", callErr)
+	}
+	return nil
+}

--- a/docs/src/content/docs/server.md
+++ b/docs/src/content/docs/server.md
@@ -34,25 +34,22 @@ kent service start
 kent service uninstall
 ```
 
-All service commands accept `--persistence-root` (and honor `KENT_PERSISTENCE_ROOT`). The root you install with is baked into the generated registration (bound to `--persistence-root <root>`), so the supervised service uses the same config+data root rather than re-resolving `~/.kent` under whatever user the supervisor runs as. Use the same root on `status`/`start`/`stop`/`restart`/`uninstall` to target that instance.
+All service commands accept `--persistence-root` and honor `KENT_PERSISTENCE_ROOT`. The root you install with is remembered, so pass the same root on `status`/`start`/`stop`/`restart`/`uninstall` to target that instance.
 
 ## Backends
 
-| OS | Supervisor |
+| OS | Service |
 | --- | --- |
 | macOS | LaunchAgent |
 | Linux / WSL2 | `systemd --user` |
-| Windows | Windows Service (SCM), runs as the logged-in user |
+| Windows | Windows Service |
 
 ### Windows
 
-On Windows the background service is a real Service Control Manager service that starts at boot and restarts on failure. The service itself runs as `LocalSystem`, but it is only a supervisor: it launches `kent serve` **in your interactive session, as you**, using your logon token — so the server keeps your full identity (`%USERPROFILE%`, git config, SSH keys, Windows Credential Manager) with **no password stored anywhere**. The server runs with no console window, and starts as soon as you log in.
+The background server runs as you, in your session, with your full environment (`%USERPROFILE%`, git config, SSH keys, Windows Credential Manager) and no console window. It starts when you log in and restarts on failure.
 
-- `install` / `uninstall` need Administrator and prompt for elevation (UAC) automatically.
-- `status` / `start` / `stop` / `restart` run without elevation — install grants your account start/stop rights on the service.
-- `stop` (and a service restart or system shutdown) shuts the server down gracefully — the supervisor signals it to exit cleanly, exactly as `Ctrl+C` would, and only force-kills it if it does not exit within the stop window.
-- Installing or uninstalling also removes any leftover registration from older Kent versions (the previous logon scheduled task and Startup-folder launcher), which is what caused stray console windows.
-
+- `install` and `uninstall` prompt for Administrator elevation (UAC). `status`, `start`, `stop`, and `restart` run without elevation.
+- `stop`, a service restart, and system shutdown stop the server gracefully, force-killing it only if it does not exit within the stop window.
 
 Linux headless machines may need lingering enabled so the server survives logout:
 

--- a/docs/src/content/docs/server.md
+++ b/docs/src/content/docs/server.md
@@ -52,7 +52,6 @@ On Windows the background service is a real Service Control Manager service that
 - `status` / `start` / `stop` / `restart` run without elevation — install grants your account start/stop rights on the service.
 - `stop` (and a service restart or system shutdown) shuts the server down gracefully — the supervisor signals it to exit cleanly, exactly as `Ctrl+C` would, and only force-kills it if it does not exit within the stop window.
 - Installing or uninstalling also removes any leftover registration from older Kent versions (the previous logon scheduled task and Startup-folder launcher), which is what caused stray console windows.
-- **Upgrading from an older Kent is a one-time migration**: updating the binary alone keeps the old scheduled-task registration. Run `kent service install` once to switch to the SCM service — it removes the legacy registration automatically.
 
 
 Linux headless machines may need lingering enabled so the server survives logout:

--- a/docs/src/content/docs/server.md
+++ b/docs/src/content/docs/server.md
@@ -52,6 +52,7 @@ On Windows the background service is a real Service Control Manager service that
 - `status` / `start` / `stop` / `restart` run without elevation — install grants your account start/stop rights on the service.
 - `stop` (and a service restart or system shutdown) shuts the server down gracefully — the supervisor signals it to exit cleanly, exactly as `Ctrl+C` would, and only force-kills it if it does not exit within the stop window.
 - Installing or uninstalling also removes any leftover registration from older Kent versions (the previous logon scheduled task and Startup-folder launcher), which is what caused stray console windows.
+- **Upgrading from an older Kent is a one-time migration**: updating the binary alone keeps the old scheduled-task registration. Run `kent service install` once to switch to the SCM service — it removes the legacy registration automatically.
 
 
 Linux headless machines may need lingering enabled so the server survives logout:

--- a/docs/src/content/docs/server.md
+++ b/docs/src/content/docs/server.md
@@ -16,12 +16,7 @@ While annoying at times, this:
 
 ## Background Service
 
-`kent service` installs and manages a supervised background `kent serve` process.
-The service starts at login and keeps the local server always available.
-
-```bash
-kent service install
-```
+`kent service` runs a local `kent serve` as a background service that starts at login.
 
 ## Commands
 
@@ -46,10 +41,10 @@ All service commands accept `--persistence-root` and honor `KENT_PERSISTENCE_ROO
 
 ### Windows
 
-The background server runs as you, in your session, with your full environment (`%USERPROFILE%`, git config, SSH keys, Windows Credential Manager) and no console window. It starts when you log in and restarts on failure.
+The background server runs as you, with your user environment, and starts when you log in.
 
-- `install` and `uninstall` prompt for Administrator elevation (UAC). `status`, `start`, `stop`, and `restart` run without elevation.
-- `stop`, a service restart, and system shutdown stop the server gracefully, force-killing it only if it does not exit within the stop window.
+- `install` and `uninstall` prompt for Administrator elevation (UAC). Other commands run without elevation.
+- `stop`, a service restart, and system shutdown shut the server down gracefully.
 
 Linux headless machines may need lingering enabled so the server survives logout:
 
@@ -60,7 +55,7 @@ loginctl enable-linger "$USER"
 ## Port Conflicts
 
 Service install/start commands refuse to change the service when Kent's configured server endpoint is already owned by a manual `kent serve` process or by a non-Kent listener.
-If the service is installed but unloaded, `restart` can stop a healthy Kent listener on the configured endpoint and attach that endpoint back to the background service.
+When the service is installed, `restart` reclaims the configured endpoint from a healthy Kent listener and attaches it back to the service.
 If you started `kent serve` manually, stop that process before installing or starting the background service.
 
 Running another server on a different configured port is fine. Kent only checks the endpoint resolved from `server_host` and `server_port`.

--- a/docs/src/content/docs/server.md
+++ b/docs/src/content/docs/server.md
@@ -34,7 +34,7 @@ kent service start
 kent service uninstall
 ```
 
-All service commands accept `--persistence-root` (and honor `KENT_PERSISTENCE_ROOT`). The root you install with is baked into the generated registration as `kent serve --persistence-root <root>`, so the supervised service uses the same config+data root rather than re-resolving `~/.kent` under whatever user the supervisor runs as. Use the same root on `status`/`start`/`stop`/`restart`/`uninstall` to target that instance.
+All service commands accept `--persistence-root` (and honor `KENT_PERSISTENCE_ROOT`). The root you install with is baked into the generated registration (bound to `--persistence-root <root>`), so the supervised service uses the same config+data root rather than re-resolving `~/.kent` under whatever user the supervisor runs as. Use the same root on `status`/`start`/`stop`/`restart`/`uninstall` to target that instance.
 
 ## Backends
 
@@ -42,7 +42,16 @@ All service commands accept `--persistence-root` (and honor `KENT_PERSISTENCE_RO
 | --- | --- |
 | macOS | LaunchAgent |
 | Linux / WSL2 | `systemd --user` |
-| Windows | Scheduled Task at logon, with Startup folder fallback |
+| Windows | Windows Service (SCM), runs as the logged-in user |
+
+### Windows
+
+On Windows the background service is a real Service Control Manager service that starts at boot and restarts on failure. The service itself runs as `LocalSystem`, but it is only a supervisor: it launches `kent serve` **in your interactive session, as you**, using your logon token — so the server keeps your full identity (`%USERPROFILE%`, git config, SSH keys, Windows Credential Manager) with **no password stored anywhere**. The server runs with no console window, and starts as soon as you log in.
+
+- `install` / `uninstall` need Administrator and prompt for elevation (UAC) automatically.
+- `status` / `start` / `stop` / `restart` run without elevation — install grants your account start/stop rights on the service.
+- `stop` (and a service restart or system shutdown) shuts the server down gracefully — the supervisor signals it to exit cleanly, exactly as `Ctrl+C` would, and only force-kills it if it does not exit within the stop window.
+- Installing or uninstalling also removes any leftover registration from older Kent versions (the previous logon scheduled task and Startup-folder launcher), which is what caused stray console windows.
 
 
 Linux headless machines may need lingering enabled so the server survives logout:

--- a/docs/src/content/docs/server.md
+++ b/docs/src/content/docs/server.md
@@ -45,6 +45,7 @@ The background server runs as you, with your user environment, and starts when y
 
 - `install` and `uninstall` prompt for Administrator elevation (UAC). Other commands run without elevation.
 - `stop`, a service restart, and system shutdown shut the server down gracefully.
+- `uninstall --keep-running` is not supported; the server is bound to the service and stops with it.
 
 Linux headless machines may need lingering enabled so the server survives logout:
 

--- a/shared/client/workflow_remote_test.go
+++ b/shared/client/workflow_remote_test.go
@@ -42,6 +42,7 @@ func TestRemoteWorkflowListRoute(t *testing.T) {
 			return
 		}
 		handlerErr <- nil
+		_ = websocket.JSON.Receive(ws, &req)
 	}))
 	defer server.Close()
 

--- a/shared/client/workflow_remote_test.go
+++ b/shared/client/workflow_remote_test.go
@@ -41,8 +41,11 @@ func TestRemoteWorkflowListRoute(t *testing.T) {
 			handlerErr <- fmt.Errorf("send workflow list response: %w", err)
 			return
 		}
+		if err := websocket.JSON.Receive(ws, &req); err == nil {
+			handlerErr <- fmt.Errorf("unexpected request after workflow list: method = %q", req.Method)
+			return
+		}
 		handlerErr <- nil
-		_ = websocket.JSON.Receive(ws, &req)
 	}))
 	defer server.Close()
 
@@ -50,14 +53,16 @@ func TestRemoteWorkflowListRoute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DialRemoteURL: %v", err)
 	}
-	defer func() { _ = remote.Close() }()
 	resp, err := remote.ListWorkflows(context.Background(), serverapi.WorkflowListRequest{})
 	if err != nil {
+		_ = remote.Close()
 		t.Fatalf("ListWorkflows: %v", err)
 	}
 	if len(resp.Workflows) != 1 || resp.Workflows[0].ID != "workflow-1" {
+		_ = remote.Close()
 		t.Fatalf("response = %+v", resp)
 	}
+	_ = remote.Close()
 	if err := <-handlerErr; err != nil {
 		t.Fatal(err)
 	}

--- a/shared/config/brand.go
+++ b/shared/config/brand.go
@@ -51,11 +51,8 @@ const (
 	ServiceLaunchdLabel = "sh.kent.server"
 	// ServiceSystemdUnitName is the Linux systemd user-unit name.
 	ServiceSystemdUnitName = "kent.service"
-	// ServiceWindowsTaskName is the legacy Windows Scheduled Task name, retained
-	// only so installs can tear down the pre-SCM scheduled task / Startup item.
 	ServiceWindowsTaskName = Product + " Server"
-	// ServiceWindowsServiceName is the Windows Service Control Manager service
-	// name for the SCM-backed background service.
+
 	ServiceWindowsServiceName = Product + "Server"
 )
 

--- a/shared/config/brand.go
+++ b/shared/config/brand.go
@@ -51,8 +51,12 @@ const (
 	ServiceLaunchdLabel = "sh.kent.server"
 	// ServiceSystemdUnitName is the Linux systemd user-unit name.
 	ServiceSystemdUnitName = "kent.service"
-	// ServiceWindowsTaskName is the Windows Scheduled Task name.
+	// ServiceWindowsTaskName is the legacy Windows Scheduled Task name, retained
+	// only so installs can tear down the pre-SCM scheduled task / Startup item.
 	ServiceWindowsTaskName = Product + " Server"
+	// ServiceWindowsServiceName is the Windows Service Control Manager service
+	// name for the SCM-backed background service.
+	ServiceWindowsServiceName = Product + "Server"
 )
 
 // Distribution identity. Repository, docs, and package-manager coordinates.


### PR DESCRIPTION
Closes #429.

## Problem
On Windows the background service was a logon **scheduled task** with a Startup-folder fallback. Every `kent service` operation (and logon) flashed blank `cmd.exe`/console windows.

## Change
Replace it with a real **Service Control Manager** service. The service runs as `LocalSystem` but is only a **supervisor**: it launches `kent serve` **in the interactive console session, as the logged-in user**, via `WTSQueryUserToken` + `CreateProcessAsUserW`. The server keeps the user's full identity (`%USERPROFILE%`, DPAPI, Credential Manager, git/SSH) with **no stored password**, and `CREATE_NO_WINDOW` means no console ever appears.

### Highlights
- **LocalSystem supervisor**: `SERVICE_AUTO_START`, `SERVICE_FAILURE_ACTIONS` restart-on-crash, recomputes the target session on logon/logoff.
- **Unprivileged lifecycle**: install grants the user a service DACL (start/stop/query), so `status`/`start`/`stop`/`restart` need no elevation. `install`/`uninstall` self-elevate via UAC.
- **Graceful stop across the session boundary**: a session-0 service can't send a console Ctrl event to a windowless child in the user session, so the supervisor signals a named event the server waits on — same path as Ctrl+C — and force-kills only as a fallback. `StopPending` carries a `WaitHint` so the SCM waits; a `KILL_ON_JOB_CLOSE` job object prevents an orphaned server if the supervisor crashes.
- **Status accuracy**: child-PID file so status reflects the server, not the supervisor.
- **Legacy cleanup**: install/uninstall remove the old scheduled task + Startup-folder launcher (the source of the stray windows).
- **Desktop**: release builds use `windows_subsystem = "windows"` to drop the console window.

## Migration (breaking)
Reinstall the service (`kent service install`) to move off the old scheduled-task registration; install/uninstall clean it up automatically.

## Verification
Built and vetted on host **and** `GOOS=windows` cross-compile; `go vet` clean (incl. `_test.go`); host + `shared/config` tests pass; `gofmt` clean.

⚠️ **Not runtime-tested** — all SCM / `CreateProcessAsUser` / named-event / job behavior needs a real Windows 11 desktop to validate; it cannot run on the macOS dev host.

## Known scope limits (by design, v1)
- Targets the **single active console session** — not Fast-User-Switching background sessions or RDP sessions (one server for the user at the physical console).
- Graceful stop relies on the user being able to open the supervisor-created `Global\` event (DACL grants Interactive); falls back to a hard kill if not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows `kent service` now uses an SCM-backed Windows Service (runs in the logged-in user session without opening a console window) to supervise `kent serve`.
  * Added a `kent service run` flow (Windows-only) to host the service entrypoint.
* **Bug Fixes**
  * Improved elevation and lifecycle guarding for service `install`/`uninstall` (Administrator prompts) and safer stop/restart/shutdown timing.
  * Service stdout/stderr are redirected to configured log files.
* **Documentation**
  * Updated Windows service, persistence-root, and port-conflict restart behavior in the server docs/help.
* **Tests**
  * Trimmed Windows service backend tests to core argument/path cases; updated a few unrelated test assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->