### PR TITLE
fix: preserve no-auth remote acknowledgement

### DIFF
--- a/cli/app/auth_gate.go
+++ b/cli/app/auth_gate.go
@@ -122,6 +122,9 @@ func (i *interactiveAuthInteractor) Interact(ctx context.Context, req authIntera
 	if authui.NeedsAuthEnvConflictResolution(req) {
 		return authui.AuthInteractionOutcome{}, i.resolveEnvAPIKeyConflict(ctx, req)
 	}
+	if req.AuthRequired && req.State.IsNoAuthSelected() {
+		return authui.AuthInteractionOutcome{ProceedWithoutAuth: true}, nil
+	}
 
 	for {
 		choice, err := i.chooseMethod(req)

--- a/cli/app/auth_gate_test.go
+++ b/cli/app/auth_gate_test.go
@@ -151,6 +151,37 @@ func TestBootstrapAppNoAuthPreferenceDoesNotOpenAuthPicker(t *testing.T) {
 	}
 }
 
+func TestBootstrapAppRequiredNoAuthPreferenceDoesNotOpenAuthPicker(t *testing.T) {
+	home, workspace := newRegisteredAppWorkspace(t)
+	if err := os.MkdirAll(filepath.Join(home, config.ConfigDirName), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, config.ConfigDirName, "config.toml"), []byte("model = \"gpt-5\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg := loadAppTestConfig(t, workspace, config.LoadOptions{})
+	store := auth.NewFileStore(config.GlobalAuthConfigPath(cfg))
+	if err := store.Save(context.Background(), auth.State{
+		Scope:               auth.ScopeGlobal,
+		Method:              auth.Method{Type: auth.MethodNone},
+		EnvAPIKeyPreference: auth.EnvAPIKeyPreferencePreferSaved,
+	}); err != nil {
+		t.Fatalf("save no-auth state: %v", err)
+	}
+	interactor := &interactiveAuthInteractor{
+		pickMethod: func(authInteraction) (authMethodPickerResult, error) {
+			t.Fatal("persisted no-auth under required auth must not open auth picker")
+			return authMethodPickerResult{}, nil
+		},
+	}
+
+	boot, err := startEmbeddedServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true, Model: "gpt-5"}, interactor, true)
+	if err != nil {
+		t.Fatalf("bootstrap app: %v", err)
+	}
+	defer func() { _ = boot.Close() }()
+}
+
 func TestResolveSessionActionLogoutUsesBootstrapAuthInteractor(t *testing.T) {
 	ctx := context.Background()
 	mgr := auth.NewManager(auth.NewMemoryStore(auth.State{

--- a/cli/app/internal/remoteattach/remotebinding_binding.go
+++ b/cli/app/internal/remoteattach/remotebinding_binding.go
@@ -51,6 +51,12 @@ func BindProjectWorkspace(ctx context.Context, req ProjectWorkspaceBindingReques
 		_ = nextRemote.Close()
 		return ProjectWorkspaceBinding{}, err
 	}
+	if req.Current.NoAuthBootstrapAcknowledgementEnabled() {
+		if err := nextRemote.EnableNoAuthBootstrapAcknowledgement(ctx); err != nil {
+			_ = nextRemote.Close()
+			return ProjectWorkspaceBinding{}, err
+		}
+	}
 	_ = req.Current.Close()
 	var closeFn func() error
 	if req.OwnsServer && req.OwnedClose != nil {

--- a/cli/app/remote_auth_bootstrap.go
+++ b/cli/app/remote_auth_bootstrap.go
@@ -29,6 +29,7 @@ func ensureRemoteAuthReady(ctx context.Context, remote client.AuthBootstrapClien
 		return err
 	}
 	if status.AuthReady {
+		disableRemoteNoAuth(remote)
 		return nil
 	}
 	if interactor == nil {
@@ -38,6 +39,9 @@ func ensureRemoteAuthReady(ctx context.Context, remote client.AuthBootstrapClien
 		return nil
 	}
 	if interactive, ok := interactor.(*interactiveAuthInteractor); ok {
+		if status.NoAuthSelected {
+			return enableRemoteNoAuth(ctx, remote)
+		}
 		return interactive.completeRemoteAuthBootstrap(ctx, remote, settings, status, false)
 	}
 	apiKey := strings.TrimSpace(interactor.LookupEnv("OPENAI_API_KEY"))
@@ -54,6 +58,7 @@ func ensureRemoteAuthReady(ctx context.Context, remote client.AuthBootstrapClien
 	if !resp.AuthReady {
 		return serverapi.ErrServerAuthRequired
 	}
+	disableRemoteNoAuth(remote)
 	return nil
 }
 
@@ -83,12 +88,48 @@ func (i *interactiveAuthInteractor) completeRemoteAuthBootstrap(ctx context.Cont
 			req.FlowErr = err
 			continue
 		}
+		if completeReq.Mode == serverapi.AuthBootstrapModeNone && resp.NoAuthSelected {
+			if err := enableRemoteNoAuth(ctx, remote); err != nil {
+				return err
+			}
+			i.printAuthSection(req.Theme, "Server Auth Skipped", []string{lipgloss.NewStyle().Foreground(uiPalette(req.Theme).muted).Faint(true).Render("Kent will proceed without configured server auth.")})
+			return nil
+		}
 		if !resp.AuthReady {
 			req.FlowErr = serverapi.ErrServerAuthRequired
 			continue
 		}
+		disableRemoteNoAuth(remote)
 		i.printAuthSection(req.Theme, "Server Auth Ready", []string{lipgloss.NewStyle().Foreground(uiPalette(req.Theme).muted).Faint(true).Render("Kent configured auth on the server.")})
 		return nil
+	}
+}
+
+type remoteNoAuthAcknowledgementEnabler interface {
+	EnableNoAuthBootstrapAcknowledgement(context.Context) error
+}
+
+type remoteNoAuthAcknowledgementDisabler interface {
+	DisableNoAuthBootstrapAcknowledgement()
+}
+
+func enableRemoteNoAuth(ctx context.Context, remote client.AuthBootstrapClient) error {
+	if enabler, ok := remote.(remoteNoAuthAcknowledgementEnabler); ok {
+		return enabler.EnableNoAuthBootstrapAcknowledgement(ctx)
+	}
+	resp, err := remote.AcknowledgeNoAuth(ctx, serverapi.AuthAcknowledgeNoAuthRequest{})
+	if err != nil {
+		return err
+	}
+	if resp.NoAuthSelected || resp.AuthReady {
+		return nil
+	}
+	return serverapi.ErrServerAuthRequired
+}
+
+func disableRemoteNoAuth(remote client.AuthBootstrapClient) {
+	if disabler, ok := remote.(remoteNoAuthAcknowledgementDisabler); ok {
+		disabler.DisableNoAuthBootstrapAcknowledgement()
 	}
 }
 

--- a/cli/app/remote_auth_bootstrap_test.go
+++ b/cli/app/remote_auth_bootstrap_test.go
@@ -11,8 +11,14 @@ import (
 )
 
 type stubAuthBootstrapClient struct {
-	status      serverapi.AuthGetBootstrapStatusResponse
-	completeReq serverapi.AuthCompleteBootstrapRequest
+	status          serverapi.AuthGetBootstrapStatusResponse
+	completeReq     serverapi.AuthCompleteBootstrapRequest
+	completeCalls   int
+	completeResp    serverapi.AuthCompleteBootstrapResponse
+	acknowledgeReq  serverapi.AuthAcknowledgeNoAuthRequest
+	acknowledge     int
+	acknowledgeResp serverapi.AuthAcknowledgeNoAuthResponse
+	acknowledgeErr  error
 }
 
 func (c *stubAuthBootstrapClient) GetAuthBootstrapStatus(context.Context, serverapi.AuthGetBootstrapStatusRequest) (serverapi.AuthGetBootstrapStatusResponse, error) {
@@ -20,8 +26,24 @@ func (c *stubAuthBootstrapClient) GetAuthBootstrapStatus(context.Context, server
 }
 
 func (c *stubAuthBootstrapClient) CompleteAuthBootstrap(_ context.Context, req serverapi.AuthCompleteBootstrapRequest) (serverapi.AuthCompleteBootstrapResponse, error) {
+	c.completeCalls++
 	c.completeReq = req
+	if c.completeResp != (serverapi.AuthCompleteBootstrapResponse{}) {
+		return c.completeResp, nil
+	}
 	return serverapi.AuthCompleteBootstrapResponse{AuthReady: true, MethodType: "oauth"}, nil
+}
+
+func (c *stubAuthBootstrapClient) AcknowledgeNoAuth(_ context.Context, req serverapi.AuthAcknowledgeNoAuthRequest) (serverapi.AuthAcknowledgeNoAuthResponse, error) {
+	c.acknowledge++
+	c.acknowledgeReq = req
+	if c.acknowledgeErr != nil {
+		return serverapi.AuthAcknowledgeNoAuthResponse{}, c.acknowledgeErr
+	}
+	if c.acknowledgeResp != (serverapi.AuthAcknowledgeNoAuthResponse{}) {
+		return c.acknowledgeResp, nil
+	}
+	return serverapi.AuthAcknowledgeNoAuthResponse{AuthReady: true}, nil
 }
 
 func TestRemoteAuthBootstrapHybridBrowserAcceptsCallbackOrPaste(t *testing.T) {
@@ -154,5 +176,123 @@ func TestRemoteAuthBootstrapRejectsMismatchedOAuthState(t *testing.T) {
 	}
 	if flowErr == nil || !errors.Is(flowErr, ErrOAuthStateMismatch) {
 		t.Fatalf("flow error = %v, want oauth state mismatch", flowErr)
+	}
+}
+
+func TestRemoteAuthBootstrapNoAuthSelectionCompletesWithoutRePrompt(t *testing.T) {
+	remote := &stubAuthBootstrapClient{
+		status: serverapi.AuthGetBootstrapStatusResponse{
+			AuthReady:    false,
+			AuthRequired: true,
+			SupportedModes: []serverapi.AuthBootstrapMode{
+				serverapi.AuthBootstrapModeNone,
+			},
+		},
+		completeResp:    serverapi.AuthCompleteBootstrapResponse{AuthReady: false, NoAuthSelected: true},
+		acknowledgeResp: serverapi.AuthAcknowledgeNoAuthResponse{AuthReady: false, NoAuthSelected: true},
+	}
+	pickerCalls := 0
+	interactor := &interactiveAuthInteractor{
+		pickMethod: func(authInteraction) (authMethodPickerResult, error) {
+			pickerCalls++
+			if pickerCalls > 1 {
+				t.Fatal("no-auth completion must not re-enter the auth picker")
+			}
+			return authMethodPickerResult{Choice: authMethodChoiceSkip}, nil
+		},
+	}
+
+	if err := ensureRemoteAuthReady(context.Background(), remote, config.Settings{}, interactor, true); err != nil {
+		t.Fatalf("ensureRemoteAuthReady: %v", err)
+	}
+	if remote.completeReq.Mode != serverapi.AuthBootstrapModeNone {
+		t.Fatalf("complete mode = %q, want none", remote.completeReq.Mode)
+	}
+	if remote.acknowledge != 1 {
+		t.Fatalf("acknowledge calls = %d, want 1", remote.acknowledge)
+	}
+}
+
+func TestRemoteAuthBootstrapNoAuthSelectionPropagatesAcknowledgementError(t *testing.T) {
+	ackErr := errors.New("ack failed")
+	remote := &stubAuthBootstrapClient{
+		status: serverapi.AuthGetBootstrapStatusResponse{
+			AuthReady:      false,
+			AuthRequired:   true,
+			SupportedModes: []serverapi.AuthBootstrapMode{serverapi.AuthBootstrapModeNone},
+		},
+		completeResp:   serverapi.AuthCompleteBootstrapResponse{AuthReady: false, NoAuthSelected: true},
+		acknowledgeErr: ackErr,
+	}
+	pickerCalls := 0
+	interactor := &interactiveAuthInteractor{
+		pickMethod: func(authInteraction) (authMethodPickerResult, error) {
+			pickerCalls++
+			if pickerCalls > 1 {
+				t.Fatal("acknowledgement failure after persisted no-auth must not re-open the auth picker")
+			}
+			return authMethodPickerResult{Choice: authMethodChoiceSkip}, nil
+		},
+	}
+
+	err := ensureRemoteAuthReady(context.Background(), remote, config.Settings{}, interactor, true)
+	if !errors.Is(err, ackErr) {
+		t.Fatalf("ensureRemoteAuthReady error = %v, want ackErr", err)
+	}
+	if pickerCalls != 1 {
+		t.Fatalf("picker calls = %d, want 1", pickerCalls)
+	}
+}
+
+func TestRemoteAuthBootstrapPersistedNoAuthAcknowledgesWithoutPicker(t *testing.T) {
+	remote := &stubAuthBootstrapClient{
+		status: serverapi.AuthGetBootstrapStatusResponse{
+			AuthReady:      false,
+			AuthRequired:   true,
+			NoAuthSelected: true,
+			SupportedModes: []serverapi.AuthBootstrapMode{
+				serverapi.AuthBootstrapModeNone,
+			},
+		},
+		acknowledgeResp: serverapi.AuthAcknowledgeNoAuthResponse{AuthReady: false, NoAuthSelected: true},
+	}
+	interactor := &interactiveAuthInteractor{
+		pickMethod: func(authInteraction) (authMethodPickerResult, error) {
+			t.Fatal("persisted no-auth should not open auth picker")
+			return authMethodPickerResult{}, nil
+		},
+	}
+
+	if err := ensureRemoteAuthReady(context.Background(), remote, config.Settings{}, interactor, true); err != nil {
+		t.Fatalf("ensureRemoteAuthReady: %v", err)
+	}
+	if remote.acknowledge != 1 {
+		t.Fatalf("acknowledge calls = %d, want 1", remote.acknowledge)
+	}
+	if remote.completeCalls != 0 {
+		t.Fatalf("complete calls = %d, want 0", remote.completeCalls)
+	}
+}
+
+func TestRemoteAuthBootstrapHeadlessDoesNotAcknowledgePersistedNoAuth(t *testing.T) {
+	remote := &stubAuthBootstrapClient{
+		status: serverapi.AuthGetBootstrapStatusResponse{
+			AuthReady:      false,
+			AuthRequired:   true,
+			NoAuthSelected: true,
+			SupportedModes: []serverapi.AuthBootstrapMode{serverapi.AuthBootstrapModeNone},
+		},
+		acknowledgeResp: serverapi.AuthAcknowledgeNoAuthResponse{AuthReady: false, NoAuthSelected: true},
+	}
+
+	err := ensureRemoteAuthReady(context.Background(), remote, config.Settings{}, newHeadlessAuthInteractor(), false)
+	if !errors.Is(err, serverapi.ErrServerAuthRequired) {
+		t.Fatalf("ensureRemoteAuthReady error = %v, want ErrServerAuthRequired", err)
+	}
+	if remote.acknowledge != 0 {
+		t.Fatalf("acknowledge calls = %d, want 0", remote.acknowledge)
+	}
+	if remote.completeCalls != 0 {
+		t.Fatalf("complete calls = %d, want 0", remote.completeCalls)
 	}
 }

--- a/cli/app/run_prompt_part2_test.go
+++ b/cli/app/run_prompt_part2_test.go
@@ -409,6 +409,25 @@ func newFakeResponsesServer(t *testing.T, assistantReplies []string) (*httptest.
 	return server, &hits
 }
 
+func newNoAuthFakeResponsesServer(t *testing.T, assistantReplies []string) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if handleTestOpenAIInputTokenCount(w, r, 11) {
+			return
+		}
+		if r.URL.Path != "/responses" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		index := int(hits.Add(1)) - 1
+		if index >= len(assistantReplies) {
+			t.Fatalf("unexpected response request index %d", index)
+		}
+		writeTestOpenAICompletedResponseStream(w, assistantReplies[index], 11, 7)
+	}))
+	return server, &hits
+}
+
 func openAuthoritativeWorkspaceSessionStore(t *testing.T, workspaceRoot, openAIBaseURL, sessionID string) *session.Store {
 	t.Helper()
 	loadOpts := config.LoadOptions{}

--- a/cli/app/run_prompt_part2_test.go
+++ b/cli/app/run_prompt_part2_test.go
@@ -419,6 +419,9 @@ func newNoAuthFakeResponsesServer(t *testing.T, assistantReplies []string) (*htt
 		if r.URL.Path != "/responses" {
 			t.Fatalf("unexpected path %q", r.URL.Path)
 		}
+		if got := strings.TrimSpace(r.Header.Get("Authorization")); got != "" {
+			t.Fatalf("unexpected authorization header %q", got)
+		}
 		index := int(hits.Add(1)) - 1
 		if index >= len(assistantReplies) {
 			t.Fatalf("unexpected response request index %d", index)

--- a/cli/app/session_server_target_part2_test.go
+++ b/cli/app/session_server_target_part2_test.go
@@ -96,6 +96,71 @@ func TestStartEmbeddedServerUnknownWorkspaceCreateProjectFlowCanPlanSession(t *t
 	}
 }
 
+func TestRemoteNoAuthUnregisteredWorkspaceBindingCanPrepareRuntime(t *testing.T) {
+	newAppTestHome(t)
+	workspace := t.TempDir()
+	configureAppTestServerPort(t)
+	fakeResponses, hits := newNoAuthFakeResponsesServer(t, []string{"rebound no-auth reply"})
+	defer fakeResponses.Close()
+
+	srv, err := serverstartup.StartServeServer(context.Background(), serverstartup.Request{
+		Model:                "gpt-5",
+		AllowUnauthenticated: true,
+	}, memoryAuthHandler{}, autoOnboarding)
+	if err != nil {
+		t.Fatalf("serve.Start: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+	stopServing := serveAppServer(t, srv)
+	defer stopServing()
+	waitForConfiguredRunPromptDaemon(t, workspace)
+
+	originalPicker := runProjectBindingPickerFlow
+	originalPrompt := runProjectNamePromptFlow
+	t.Cleanup(func() {
+		runProjectBindingPickerFlow = originalPicker
+		runProjectNamePromptFlow = originalPrompt
+	})
+	runProjectBindingPickerFlow = func(projects []clientui.ProjectSummary, theme string) (projectBindingPickerResult, error) {
+		return projectBindingPickerResult{CreateNew: true}, nil
+	}
+	runProjectNamePromptFlow = func(defaultName string, theme string) (string, error) {
+		return "Remote No Auth Project", nil
+	}
+
+	authPickerCalls := 0
+	interactor := &interactiveAuthInteractor{
+		pickMethod: func(authInteraction) (authMethodPickerResult, error) {
+			authPickerCalls++
+			if authPickerCalls > 1 {
+				t.Fatal("remote no-auth binding flow must not re-enter auth picker")
+			}
+			return authMethodPickerResult{Choice: authMethodChoiceSkip}, nil
+		},
+	}
+	server, err := startSessionServer(context.Background(), Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true, Model: "gpt-5"}, interactor, true)
+	if err != nil {
+		t.Fatalf("startSessionServer: %v", err)
+	}
+	defer func() { _ = server.Close() }()
+	bound, err := ensureInteractiveProjectBinding(context.Background(), server)
+	if err != nil {
+		t.Fatalf("ensureInteractiveProjectBinding: %v", err)
+	}
+	_, runtimePlan := prepareAppRuntimePlanWithOpenAIBaseURL(t, bound, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, fakeResponses.URL, io.Discard, "test remote no-auth rebound runtime")
+	submission, err := runtimePlan.Wiring.runtimeClient.SubmitUserMessage(context.Background(), "hello after rebound no auth")
+	if err != nil {
+		t.Fatalf("SubmitUserMessage: %v", err)
+	}
+	if submission.Message != "rebound no-auth reply" {
+		t.Fatalf("assistant message = %q, want rebound no-auth reply", submission.Message)
+	}
+	runtimePlan.Close()
+	if hits.Load() != 1 {
+		t.Fatalf("expected fake LLM call once, got %d", hits.Load())
+	}
+}
+
 func TestStartSessionServerRejectsIncompatibleDiscoveredDaemonAndFallsBack(t *testing.T) {
 	_, workspace := newRegisteredAppWorkspace(t)
 

--- a/cli/app/session_server_target_test.go
+++ b/cli/app/session_server_target_test.go
@@ -104,6 +104,86 @@ func TestStartSessionServerUsesConfiguredDaemonForInteractiveFlow(t *testing.T) 
 
 }
 
+func TestStartSessionServerConfiguredDaemonNoAuthSkipsLaterPrompt(t *testing.T) {
+	_, workspace := newRegisteredAppWorkspace(t)
+	fakeResponses, hits := newNoAuthFakeResponsesServer(t, []string{"first no-auth reply", "second no-auth reply"})
+	defer fakeResponses.Close()
+
+	srv, err := serverstartup.StartServeServer(context.Background(), serverstartup.Request{
+		WorkspaceRoot:         workspace,
+		WorkspaceRootExplicit: true,
+		Model:                 "gpt-5",
+		AllowUnauthenticated:  true,
+	}, memoryAuthHandler{}, autoOnboarding)
+	if err != nil {
+		t.Fatalf("serve.Start: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	stopServing := serveAppServer(t, srv)
+	defer stopServing()
+	waitForConfiguredRemoteIdentity(t, workspace)
+
+	pickerCalls := 0
+	firstInteractor := &interactiveAuthInteractor{
+		pickMethod: func(authInteraction) (authMethodPickerResult, error) {
+			pickerCalls++
+			if pickerCalls > 1 {
+				t.Fatal("no-auth selection must not re-enter the auth picker")
+			}
+			return authMethodPickerResult{Choice: authMethodChoiceSkip}, nil
+		},
+	}
+	firstServer, err := startSessionServer(context.Background(), Options{
+		WorkspaceRoot:         workspace,
+		WorkspaceRootExplicit: true,
+		Model:                 "gpt-5",
+	}, firstInteractor, true)
+	if err != nil {
+		t.Fatalf("first startSessionServer: %v", err)
+	}
+	_, firstRuntimePlan := prepareAppRuntimePlanWithOpenAIBaseURL(t, firstServer, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, fakeResponses.URL, io.Discard, "test remote no-auth runtime")
+	firstSubmission, err := firstRuntimePlan.Wiring.runtimeClient.SubmitUserMessage(context.Background(), "hello after no auth")
+	if err != nil {
+		t.Fatalf("first SubmitUserMessage: %v", err)
+	}
+	if firstSubmission.Message != "first no-auth reply" {
+		t.Fatalf("first assistant message = %q, want first no-auth reply", firstSubmission.Message)
+	}
+	firstRuntimePlan.Close()
+	if err := firstServer.Close(); err != nil {
+		t.Fatalf("first server close: %v", err)
+	}
+
+	secondInteractor := &interactiveAuthInteractor{
+		pickMethod: func(authInteraction) (authMethodPickerResult, error) {
+			t.Fatal("persisted no-auth must not open the auth picker on a later launch")
+			return authMethodPickerResult{}, nil
+		},
+	}
+	secondServer, err := startSessionServer(context.Background(), Options{
+		WorkspaceRoot:         workspace,
+		WorkspaceRootExplicit: true,
+		Model:                 "gpt-5",
+	}, secondInteractor, true)
+	if err != nil {
+		t.Fatalf("second startSessionServer: %v", err)
+	}
+	defer func() { _ = secondServer.Close() }()
+	_, secondRuntimePlan := prepareAppRuntimePlanWithOpenAIBaseURL(t, secondServer, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, fakeResponses.URL, io.Discard, "test remote persisted no-auth runtime")
+	secondSubmission, err := secondRuntimePlan.Wiring.runtimeClient.SubmitUserMessage(context.Background(), "hello after persisted no auth")
+	if err != nil {
+		t.Fatalf("second SubmitUserMessage: %v", err)
+	}
+	if secondSubmission.Message != "second no-auth reply" {
+		t.Fatalf("second assistant message = %q, want second no-auth reply", secondSubmission.Message)
+	}
+	secondRuntimePlan.Close()
+	if hits.Load() != 2 {
+		t.Fatalf("expected fake LLM calls twice, got %d", hits.Load())
+	}
+}
+
 func TestConfiguredDaemonPlanSessionUsesSessionWorkspaceLocalConfig(t *testing.T) {
 	home := newAppTestHome(t)
 	workspace := t.TempDir()

--- a/cli/app/workspace_registration_test.go
+++ b/cli/app/workspace_registration_test.go
@@ -134,6 +134,21 @@ func prepareAppRuntimePlan(t *testing.T, server launchPlannerServer, req session
 	return plan, runtimePlan
 }
 
+func prepareAppRuntimePlanWithOpenAIBaseURL(t *testing.T, server launchPlannerServer, req sessionLaunchRequest, openAIBaseURL string, diagnosticWriter io.Writer, startLogLine string) (sessionLaunchPlan, *runtimeLaunchPlan) {
+	t.Helper()
+	planner := newSessionLaunchPlanner(server)
+	plan, err := planner.PlanSession(context.Background(), req)
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	plan.ActiveSettings.OpenAIBaseURL = openAIBaseURL
+	runtimePlan, err := planner.PrepareRuntime(context.Background(), plan, diagnosticWriter, startLogLine)
+	if err != nil {
+		t.Fatalf("PrepareRuntime: %v", err)
+	}
+	return plan, runtimePlan
+}
+
 func newAppRuntimeEngine(t *testing.T, client llm.Client, cfg runtime.Config, handlers ...tools.HandlerRegistration) (*session.Store, *runtime.Engine) {
 	t.Helper()
 	store := createAppRuntimeSession(t)

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -155,6 +155,11 @@
 - Startup auth failures and 401s surface as normal actionable UX.
 - Startup auth picker uses themed startup picker style and friendly titles with one-line explanations.
 - Picker exposes browser OAuth, device-code OAuth, `No auth`, and env-key adoption when available.
+- Choosing `No auth` persists the no-auth sentinel, clears active server auth, and disables env-key fallback. The sentinel does not satisfy raw startup auth readiness.
+- Interactive remote clients may acknowledge a persisted `No auth` choice per JSON-RPC connection to pass startup-owned `AuthServer` route checks while the sentinel remains selected.
+- Recurring no-auth acknowledgements are non-mutating. They must not clear real API-key or OAuth auth, and successful real-auth configuration revokes any client-side no-auth acknowledgement policy.
+- Remote client rebinding preserves and re-acknowledges the no-auth connection policy before the rebound client uses startup-owned server routes.
+- Headless clients, fresh external clients, and remote connections that have not explicitly acknowledged no-auth remain blocked when Kent-managed OpenAI auth is required and no real auth is configured.
 - Browser OAuth uses a hybrid callback flow accepting local callback or pasted callback URL/code.
 - OAuth issuer routing is not configurable in production. `KENT_OAUTH_ISSUER` is intentionally unsupported.
 - Interactive startup treats `OPENAI_API_KEY` as chooser-backed auth source, not unconditional override.

--- a/server/authservice/bootstrap_service.go
+++ b/server/authservice/bootstrap_service.go
@@ -40,9 +40,14 @@ func (s *BootstrapService) GetBootstrapStatus(ctx context.Context, _ serverapi.A
 	if err != nil {
 		return serverapi.AuthGetBootstrapStatusResponse{}, err
 	}
+	stored, err := s.storedState(ctx)
+	if err != nil {
+		return serverapi.AuthGetBootstrapStatusResponse{}, err
+	}
 	return serverapi.AuthGetBootstrapStatusResponse{
 		AuthReady:              ready,
 		AuthRequired:           s.authRequired,
+		NoAuthSelected:         stored.IsNoAuthSelected(),
 		AuthBootstrapSupported: true,
 		AllowedPreAuthMethods:  append([]string(nil), s.allowedPreAuth...),
 		SupportedModes:         append([]serverapi.AuthBootstrapMode(nil), s.supportedModes...),
@@ -51,6 +56,28 @@ func (s *BootstrapService) GetBootstrapStatus(ctx context.Context, _ serverapi.A
 			ClientID: strings.TrimSpace(s.oauthOptions.ClientID),
 		},
 	}, nil
+}
+
+func (s *BootstrapService) AcknowledgeNoAuth(ctx context.Context, _ serverapi.AuthAcknowledgeNoAuthRequest) (serverapi.AuthAcknowledgeNoAuthResponse, error) {
+	if s == nil || s.manager == nil {
+		return serverapi.AuthAcknowledgeNoAuthResponse{}, serverapi.ErrServerAuthRequired
+	}
+	stored, err := s.manager.StoredState(ctx)
+	if err != nil {
+		return serverapi.AuthAcknowledgeNoAuthResponse{}, err
+	}
+	current, err := s.manager.Load(ctx)
+	if err != nil {
+		return serverapi.AuthAcknowledgeNoAuthResponse{}, err
+	}
+	ready := !s.authRequired || auth.EvaluateStartupGate(current).Ready
+	if stored.IsNoAuthSelected() {
+		return serverapi.AuthAcknowledgeNoAuthResponse{AuthReady: ready, NoAuthSelected: true}, nil
+	}
+	if ready {
+		return serverapi.AuthAcknowledgeNoAuthResponse{AuthReady: true}, nil
+	}
+	return serverapi.AuthAcknowledgeNoAuthResponse{}, serverapi.ErrServerAuthRequired
 }
 
 func (s *BootstrapService) CompleteBootstrap(ctx context.Context, req serverapi.AuthCompleteBootstrapRequest) (serverapi.AuthCompleteBootstrapResponse, error) {
@@ -106,11 +133,21 @@ func (s *BootstrapService) authReady(ctx context.Context) (bool, error) {
 	if s == nil || s.manager == nil {
 		return false, nil
 	}
+	if !s.authRequired {
+		return true, nil
+	}
 	state, err := s.manager.Load(ctx)
 	if err != nil {
 		return false, err
 	}
 	return auth.EvaluateStartupGate(state).Ready, nil
+}
+
+func (s *BootstrapService) storedState(ctx context.Context) (auth.State, error) {
+	if s == nil || s.manager == nil {
+		return auth.EmptyState(), nil
+	}
+	return s.manager.StoredState(ctx)
 }
 
 func (s *BootstrapService) bootstrapResponseFromState(state auth.State) serverapi.AuthCompleteBootstrapResponse {
@@ -121,10 +158,11 @@ func (s *BootstrapService) bootstrapResponseFromState(state auth.State) serverap
 		email = strings.TrimSpace(state.Method.OAuth.Email)
 	}
 	return serverapi.AuthCompleteBootstrapResponse{
-		AuthReady:  !s.authRequired || auth.EvaluateStartupGate(state).Ready,
-		MethodType: strings.TrimSpace(string(state.Method.Type)),
-		AccountID:  accountID,
-		Email:      email,
+		AuthReady:      !s.authRequired || auth.EvaluateStartupGate(state).Ready,
+		NoAuthSelected: state.IsNoAuthSelected(),
+		MethodType:     strings.TrimSpace(string(state.Method.Type)),
+		AccountID:      accountID,
+		Email:          email,
 	}
 }
 

--- a/server/authservice/bootstrap_service_test.go
+++ b/server/authservice/bootstrap_service_test.go
@@ -2,6 +2,7 @@ package authservice
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -116,6 +117,94 @@ func TestCompleteBootstrapNoneSavesNoAuthPreferenceWhenAuthRequired(t *testing.T
 	}
 	if !state.IsNoAuthSelected() {
 		t.Fatalf("stored state = %+v, want no-auth preference", state)
+	}
+	if !resp.NoAuthSelected {
+		t.Fatalf("NoAuthSelected = false, want true")
+	}
+}
+
+func TestGetBootstrapStatusReportsPersistedNoAuthSelection(t *testing.T) {
+	service, _ := newTestAuthBootstrapService(auth.State{
+		Scope:               auth.ScopeGlobal,
+		Method:              auth.Method{Type: auth.MethodNone},
+		EnvAPIKeyPreference: auth.EnvAPIKeyPreferencePreferSaved,
+	})
+
+	resp, err := service.GetBootstrapStatus(context.Background(), serverapi.AuthGetBootstrapStatusRequest{})
+	if err != nil {
+		t.Fatalf("GetBootstrapStatus: %v", err)
+	}
+	if resp.AuthReady {
+		t.Fatal("did not expect no-auth selection to satisfy required startup readiness")
+	}
+	if !resp.NoAuthSelected {
+		t.Fatal("expected bootstrap status to report persisted no-auth selection")
+	}
+}
+
+func TestGetBootstrapStatusDoesNotReportEmptyStateAsNoAuthSelection(t *testing.T) {
+	service, _ := newTestAuthBootstrapService(auth.EmptyState())
+
+	resp, err := service.GetBootstrapStatus(context.Background(), serverapi.AuthGetBootstrapStatusRequest{})
+	if err != nil {
+		t.Fatalf("GetBootstrapStatus: %v", err)
+	}
+	if resp.NoAuthSelected {
+		t.Fatal("empty state must not be reported as explicit no-auth selection")
+	}
+}
+
+func TestAcknowledgeNoAuthIsNonMutating(t *testing.T) {
+	initial := auth.State{
+		Scope:               auth.ScopeGlobal,
+		Method:              auth.Method{Type: auth.MethodNone},
+		EnvAPIKeyPreference: auth.EnvAPIKeyPreferencePreferSaved,
+	}
+	service, store := newTestAuthBootstrapService(initial)
+
+	resp, err := service.AcknowledgeNoAuth(context.Background(), serverapi.AuthAcknowledgeNoAuthRequest{})
+	if err != nil {
+		t.Fatalf("AcknowledgeNoAuth: %v", err)
+	}
+	if resp.AuthReady {
+		t.Fatal("did not expect acknowledged no-auth to satisfy raw readiness")
+	}
+	if !resp.NoAuthSelected {
+		t.Fatal("expected no-auth acknowledgement response")
+	}
+	state, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if state != initial {
+		t.Fatalf("stored state mutated: %+v, want %+v", state, initial)
+	}
+}
+
+func TestAcknowledgeNoAuthReportsReadyRealAuthWithoutNoAuthSelection(t *testing.T) {
+	service, _ := newTestAuthBootstrapService(auth.State{
+		Scope: auth.ScopeGlobal,
+		Method: auth.Method{
+			Type:   auth.MethodAPIKey,
+			APIKey: &auth.APIKeyMethod{Key: "server-key"},
+		},
+	})
+
+	resp, err := service.AcknowledgeNoAuth(context.Background(), serverapi.AuthAcknowledgeNoAuthRequest{})
+	if err != nil {
+		t.Fatalf("AcknowledgeNoAuth: %v", err)
+	}
+	if !resp.AuthReady || resp.NoAuthSelected {
+		t.Fatalf("ack response = %+v, want real-auth ready without no-auth selection", resp)
+	}
+}
+
+func TestAcknowledgeNoAuthRejectsMissingAuthAndNoAuthSelection(t *testing.T) {
+	service, _ := newTestAuthBootstrapService(auth.EmptyState())
+
+	_, err := service.AcknowledgeNoAuth(context.Background(), serverapi.AuthAcknowledgeNoAuthRequest{})
+	if !errors.Is(err, serverapi.ErrServerAuthRequired) {
+		t.Fatalf("AcknowledgeNoAuth error = %v, want ErrServerAuthRequired", err)
 	}
 }
 

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -124,6 +124,7 @@ func protocolSubscriptionMethodSet() map[string]struct{} {
 
 type connectionState struct {
 	handshakeDone         bool
+	noAuthAccepted        bool
 	attachedProject       string
 	attachedWorkspaceID   string
 	attachedWorkspaceRoot string
@@ -262,7 +263,7 @@ func (g *Gateway) dispatch(ctx context.Context, state *connectionState, req prot
 	if req.Method != protocol.MethodHandshake && !state.handshakeDone {
 		return protocol.NewErrorResponse(req.ID, protocol.ErrCodeInvalidRequest, "handshake is required before other methods")
 	}
-	if err := newRoutePolicyExecutor(g).requireAuth(ctx, req.Method); err != nil {
+	if err := newRoutePolicyExecutor(g).requireAuth(ctx, state, req.Method); err != nil {
 		return responseForError(req.ID, err)
 	}
 	handler, ok := gatewayUnaryHandlers[req.Method]

--- a/server/transport/gateway_stream_handlers.go
+++ b/server/transport/gateway_stream_handlers.go
@@ -25,7 +25,7 @@ func (g *Gateway) serveRunPrompt(conn rpcwire.Conn, ctx context.Context, state *
 	if !state.handshakeDone {
 		return sendResponse(ctx, conn, protocol.NewErrorResponse(req.ID, protocol.ErrCodeInvalidRequest, "handshake is required before other methods"))
 	}
-	if err := newRoutePolicyExecutor(g).requireAuth(ctx, req.Method); err != nil {
+	if err := newRoutePolicyExecutor(g).requireAuth(ctx, state, req.Method); err != nil {
 		return sendResponse(ctx, conn, responseForError(req.ID, err))
 	}
 	decoded, preflightResp, failed := g.preflightRouteRequest(ctx, state, route, req)
@@ -73,7 +73,7 @@ func (g *Gateway) serveSubscription(conn rpcwire.Conn, ctx context.Context, stat
 		_ = sendResponse(ctx, conn, protocol.NewErrorResponse(req.ID, protocol.ErrCodeInvalidRequest, "handshake is required before other methods"))
 		return
 	}
-	if err := newRoutePolicyExecutor(g).requireAuth(ctx, req.Method); err != nil {
+	if err := newRoutePolicyExecutor(g).requireAuth(ctx, state, req.Method); err != nil {
 		_ = sendResponse(ctx, conn, responseForError(req.ID, err))
 		return
 	}

--- a/server/transport/gateway_test.go
+++ b/server/transport/gateway_test.go
@@ -589,6 +589,90 @@ func TestGatewayAuthBootstrapAPIKeyCompletionEnablesAuthRequiredMethods(t *testi
 	}
 }
 
+func TestGatewayAuthBootstrapNoneAuthorizesSameConnectionOnly(t *testing.T) {
+	appCore, server, _ := newGatewayTestServerWithAuth(t, false)
+	defer func() { _ = appCore.Close() }()
+	defer server.Close()
+
+	conn := dialGateway(t, server)
+	defer func() { _ = conn.Close() }()
+	handshakeGateway(t, conn)
+	callGateway(t, conn, "attach-project", protocol.MethodAttachProject, protocol.AttachProjectRequest{ProjectID: appCore.ProjectID()}, nil)
+	if respErr := callGatewayExpectError(t, conn, "plan-before-no-auth", protocol.MethodSessionPlan, gatewaySessionPlanRequest("plan-before-no-auth")); respErr.Code != protocol.ErrCodeAuthRequired {
+		t.Fatalf("session.plan before no-auth = %+v, want auth required", respErr)
+	}
+
+	var complete serverapi.AuthCompleteBootstrapResponse
+	callGateway(t, conn, "complete-no-auth", protocol.MethodAuthCompleteBootstrap, serverapi.AuthCompleteBootstrapRequest{Mode: serverapi.AuthBootstrapModeNone}, &complete)
+	if complete.AuthReady || !complete.NoAuthSelected {
+		t.Fatalf("auth.completeBootstrap none = %+v, want not ready and no-auth selected", complete)
+	}
+
+	var plan serverapi.SessionPlanResponse
+	callGateway(t, conn, "plan-after-no-auth", protocol.MethodSessionPlan, gatewaySessionPlanRequest("plan-after-no-auth"), &plan)
+	if strings.TrimSpace(plan.Plan.WorkspaceRoot) == "" {
+		t.Fatalf("session.plan after no-auth returned empty workspace root: %+v", plan)
+	}
+}
+
+func TestGatewayBootstrapStatusDoesNotAuthorizeNoAuthConnection(t *testing.T) {
+	appCore, server, authSupport := newGatewayTestServerWithAuth(t, false)
+	defer func() { _ = appCore.Close() }()
+	defer server.Close()
+	if _, err := authSupport.AuthManager.SwitchMethodAndSetEnvAPIKeyPreference(context.Background(), auth.Method{Type: auth.MethodNone}, auth.EnvAPIKeyPreferencePreferSaved, true, true); err != nil {
+		t.Fatalf("SwitchMethodAndSetEnvAPIKeyPreference: %v", err)
+	}
+
+	conn := dialGateway(t, server)
+	defer func() { _ = conn.Close() }()
+	handshakeGateway(t, conn)
+	callGateway(t, conn, "attach-project", protocol.MethodAttachProject, protocol.AttachProjectRequest{ProjectID: appCore.ProjectID()}, nil)
+
+	var status serverapi.AuthGetBootstrapStatusResponse
+	callGateway(t, conn, "status-no-auth", protocol.MethodAuthGetBootstrapStatus, serverapi.AuthGetBootstrapStatusRequest{}, &status)
+	if status.AuthReady || !status.NoAuthSelected {
+		t.Fatalf("bootstrap status = %+v, want no-auth selected but not ready", status)
+	}
+	if respErr := callGatewayExpectError(t, conn, "plan-after-status", protocol.MethodSessionPlan, gatewaySessionPlanRequest("plan-after-status")); respErr.Code != protocol.ErrCodeAuthRequired {
+		t.Fatalf("session.plan after status = %+v, want auth required", respErr)
+	}
+
+	var ack serverapi.AuthAcknowledgeNoAuthResponse
+	callGateway(t, conn, "ack-no-auth", protocol.MethodAuthAcknowledgeNoAuth, serverapi.AuthAcknowledgeNoAuthRequest{}, &ack)
+	if ack.AuthReady || !ack.NoAuthSelected {
+		t.Fatalf("auth.acknowledgeNoAuth = %+v, want no-auth selected but not ready", ack)
+	}
+	callGateway(t, conn, "plan-after-ack", protocol.MethodSessionPlan, gatewaySessionPlanRequest("plan-after-ack"), nil)
+}
+
+func TestGatewayPersistedNoAuthDoesNotAuthorizeFreshConnectionsWithoutAck(t *testing.T) {
+	appCore, server, authSupport := newGatewayTestServerWithAuth(t, false)
+	defer func() { _ = appCore.Close() }()
+	store := createGatewayAuthoritativeSession(t, appCore)
+	appCore.RegisterSessionStore(store)
+	defer server.Close()
+	if _, err := authSupport.AuthManager.SwitchMethodAndSetEnvAPIKeyPreference(context.Background(), auth.Method{Type: auth.MethodNone}, auth.EnvAPIKeyPreferencePreferSaved, true, true); err != nil {
+		t.Fatalf("SwitchMethodAndSetEnvAPIKeyPreference: %v", err)
+	}
+
+	control := dialGateway(t, server)
+	defer func() { _ = control.Close() }()
+	handshakeGateway(t, control)
+	callGateway(t, control, "attach-project", protocol.MethodAttachProject, protocol.AttachProjectRequest{ProjectID: appCore.ProjectID()}, nil)
+	if respErr := callGatewayExpectError(t, control, "plan-fresh-no-ack", protocol.MethodSessionPlan, gatewaySessionPlanRequest("plan-fresh-no-ack")); respErr.Code != protocol.ErrCodeAuthRequired {
+		t.Fatalf("fresh session.plan = %+v, want auth required", respErr)
+	}
+
+	subscription := dialGateway(t, server)
+	defer func() { _ = subscription.Close() }()
+	handshakeGateway(t, subscription)
+	callGateway(t, subscription, "attach-project", protocol.MethodAttachProject, protocol.AttachProjectRequest{ProjectID: appCore.ProjectID()}, nil)
+	callGateway(t, subscription, "attach-session", protocol.MethodAttachSession, protocol.AttachSessionRequest{SessionID: store.Meta().SessionID}, nil)
+	if respErr := callGatewayExpectError(t, subscription, "subscribe-fresh-no-ack", protocol.MethodSessionSubscribeActivity, serverapi.SessionActivitySubscribeRequest{SessionID: store.Meta().SessionID}); respErr.Code != protocol.ErrCodeAuthRequired {
+		t.Fatalf("fresh session activity subscribe = %+v, want auth required", respErr)
+	}
+}
+
 func TestGatewayRejectsProjectWorkspaceMutationBeforeServerAuthReady(t *testing.T) {
 	appCore, server, _ := newGatewayTestServerWithAuth(t, false)
 	defer func() { _ = appCore.Close() }()
@@ -629,6 +713,14 @@ func containsString(items []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func gatewaySessionPlanRequest(id string) serverapi.SessionPlanRequest {
+	return serverapi.SessionPlanRequest{
+		ClientRequestID: id,
+		Mode:            serverapi.SessionLaunchModeInteractive,
+		ForceNewSession: true,
+	}
 }
 
 func sameStringSet(left []string, right []string) bool {

--- a/server/transport/gateway_unary_handlers.go
+++ b/server/transport/gateway_unary_handlers.go
@@ -73,8 +73,8 @@ var gatewayUnaryHandlerEntries = map[string]gatewayUnaryHandler{
 				return serverapi.AuthCompleteBootstrapResponse{}, serverapi.ErrServerAuthRequired
 			}
 			resp, err := bootstrapClient.CompleteAuthBootstrap(ctx, params)
-			if err == nil && resp.NoAuthSelected {
-				state.noAuthAccepted = true
+			if err == nil {
+				state.noAuthAccepted = resp.NoAuthSelected
 			}
 			return resp, err
 		})
@@ -86,8 +86,8 @@ var gatewayUnaryHandlerEntries = map[string]gatewayUnaryHandler{
 				return serverapi.AuthAcknowledgeNoAuthResponse{}, serverapi.ErrServerAuthRequired
 			}
 			resp, err := bootstrapClient.AcknowledgeNoAuth(ctx, params)
-			if err == nil && resp.NoAuthSelected {
-				state.noAuthAccepted = true
+			if err == nil {
+				state.noAuthAccepted = resp.NoAuthSelected
 			}
 			return resp, err
 		})

--- a/server/transport/gateway_unary_handlers.go
+++ b/server/transport/gateway_unary_handlers.go
@@ -72,7 +72,24 @@ var gatewayUnaryHandlerEntries = map[string]gatewayUnaryHandler{
 			if bootstrapClient == nil {
 				return serverapi.AuthCompleteBootstrapResponse{}, serverapi.ErrServerAuthRequired
 			}
-			return bootstrapClient.CompleteAuthBootstrap(ctx, params)
+			resp, err := bootstrapClient.CompleteAuthBootstrap(ctx, params)
+			if err == nil && resp.NoAuthSelected {
+				state.noAuthAccepted = true
+			}
+			return resp, err
+		})
+	},
+	protocol.MethodAuthAcknowledgeNoAuth: func(g *Gateway, ctx context.Context, state *connectionState, req protocol.Request) protocol.Response {
+		return decodeAndHandle(req, func(params serverapi.AuthAcknowledgeNoAuthRequest) (serverapi.AuthAcknowledgeNoAuthResponse, error) {
+			bootstrapClient := g.deps.AuthBootstrapClient()
+			if bootstrapClient == nil {
+				return serverapi.AuthAcknowledgeNoAuthResponse{}, serverapi.ErrServerAuthRequired
+			}
+			resp, err := bootstrapClient.AcknowledgeNoAuth(ctx, params)
+			if err == nil && resp.NoAuthSelected {
+				state.noAuthAccepted = true
+			}
+			return resp, err
 		})
 	},
 	protocol.MethodAuthGetStatus: func(g *Gateway, ctx context.Context, state *connectionState, req protocol.Request) protocol.Response {

--- a/server/transport/route_policy.go
+++ b/server/transport/route_policy.go
@@ -80,11 +80,11 @@ func (e gatewayRouteError) Error() string {
 	return e.message
 }
 
-func (e routePolicyExecutor) requireAuth(ctx context.Context, method string) error {
+func (e routePolicyExecutor) requireAuth(ctx context.Context, state *connectionState, method string) error {
 	if !e.requiresServerAuth(method) {
 		return nil
 	}
-	ready, err := e.serverAuthReady(ctx)
+	ready, err := e.serverAuthReady(ctx, state)
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func (e routePolicyExecutor) requiresServerAuth(method string) bool {
 	}
 }
 
-func (e routePolicyExecutor) serverAuthReady(ctx context.Context) (bool, error) {
+func (e routePolicyExecutor) serverAuthReady(ctx context.Context, connection *connectionState) (bool, error) {
 	g := e.gateway
 	if g == nil || g.deps == nil {
 		return false, nil
@@ -126,7 +126,17 @@ func (e routePolicyExecutor) serverAuthReady(ctx context.Context) (bool, error) 
 	if err != nil {
 		return false, err
 	}
-	return auth.EvaluateStartupGate(state).Ready, nil
+	if auth.EvaluateStartupGate(state).Ready {
+		return true, nil
+	}
+	if connection != nil && connection.noAuthAccepted {
+		stored, err := g.deps.AuthManager().StoredState(ctx)
+		if err != nil {
+			return false, err
+		}
+		return stored.IsNoAuthSelected(), nil
+	}
+	return false, nil
 }
 
 func decodeRouteParams(route rpccontract.Route, raw json.RawMessage) (any, error) {

--- a/server/transport/route_policy_test.go
+++ b/server/transport/route_policy_test.go
@@ -146,16 +146,16 @@ func routeAccessorKindForScope(scope rpccontract.ScopePolicy) routeAccessorKind 
 
 func TestRoutePolicyAuthPolicyHandlesBlankAndUnknownMethods(t *testing.T) {
 	executor := newRoutePolicyExecutor(nil)
-	if err := executor.requireAuth(context.Background(), ""); err != nil {
+	if err := executor.requireAuth(context.Background(), nil, ""); err != nil {
 		t.Fatalf("blank method auth: %v", err)
 	}
-	if err := executor.requireAuth(context.Background(), protocol.MethodProjectList); err != nil {
+	if err := executor.requireAuth(context.Background(), nil, protocol.MethodProjectList); err != nil {
 		t.Fatalf("pre-auth method auth: %v", err)
 	}
-	if err := executor.requireAuth(context.Background(), protocol.MethodProjectAttachWorkspace); !errors.Is(err, serverapi.ErrServerAuthRequired) {
+	if err := executor.requireAuth(context.Background(), nil, protocol.MethodProjectAttachWorkspace); !errors.Is(err, serverapi.ErrServerAuthRequired) {
 		t.Fatalf("auth-required method error = %v, want server auth required", err)
 	}
-	if err := executor.requireAuth(context.Background(), "missing.method"); !errors.Is(err, serverapi.ErrServerAuthRequired) {
+	if err := executor.requireAuth(context.Background(), nil, "missing.method"); !errors.Is(err, serverapi.ErrServerAuthRequired) {
 		t.Fatalf("unknown method error = %v, want server auth required", err)
 	}
 }

--- a/shared/apicontract/rpc_routes.go
+++ b/shared/apicontract/rpc_routes.go
@@ -177,6 +177,7 @@ var routeContracts = []Route{
 	unary[serverapi.ServerReadinessRequest, serverapi.ServerReadinessResponse](protocol.MethodServerReadinessGet, AuthPreServerAuth, ScopeNone, ConnectionUnscoped, DependencyServerStatus),
 	unary[serverapi.AuthGetBootstrapStatusRequest, serverapi.AuthGetBootstrapStatusResponse](protocol.MethodAuthGetBootstrapStatus, AuthPreServerAuth, ScopeNone, ConnectionUnscoped, DependencyAuthBootstrap),
 	unary[serverapi.AuthCompleteBootstrapRequest, serverapi.AuthCompleteBootstrapResponse](protocol.MethodAuthCompleteBootstrap, AuthPreServerAuth, ScopeNone, ConnectionUnscoped, DependencyAuthBootstrap),
+	unary[serverapi.AuthAcknowledgeNoAuthRequest, serverapi.AuthAcknowledgeNoAuthResponse](protocol.MethodAuthAcknowledgeNoAuth, AuthPreServerAuth, ScopeNone, ConnectionUnscoped, DependencyAuthBootstrap),
 	unary[serverapi.AuthStatusRequest, serverapi.AuthStatusResponse](protocol.MethodAuthGetStatus, AuthPreServerAuth, ScopeNone, ConnectionUnscoped, DependencyAuthStatus),
 	unary[protocol.AttachProjectRequest, protocol.AttachResponse](protocol.MethodAttachProject, AuthPreServerAuth, ScopeAttachProject, ConnectionUnscoped, DependencyProtocol),
 	unary[protocol.AttachSessionRequest, protocol.AttachResponse](protocol.MethodAttachSession, AuthPreServerAuth, ScopeAttachSession, ConnectionUnscoped, DependencyProtocol),

--- a/shared/apicontract/service_contracts.go
+++ b/shared/apicontract/service_contracts.go
@@ -20,6 +20,7 @@ type AskViewService interface {
 type AuthBootstrapService interface {
 	GetBootstrapStatus(ctx context.Context, req serverapi.AuthGetBootstrapStatusRequest) (serverapi.AuthGetBootstrapStatusResponse, error)
 	CompleteBootstrap(ctx context.Context, req serverapi.AuthCompleteBootstrapRequest) (serverapi.AuthCompleteBootstrapResponse, error)
+	AcknowledgeNoAuth(ctx context.Context, req serverapi.AuthAcknowledgeNoAuthRequest) (serverapi.AuthAcknowledgeNoAuthResponse, error)
 }
 
 type AuthStatusService interface {

--- a/shared/client/auth_bootstrap.go
+++ b/shared/client/auth_bootstrap.go
@@ -10,6 +10,7 @@ import (
 type AuthBootstrapClient interface {
 	GetAuthBootstrapStatus(ctx context.Context, req serverapi.AuthGetBootstrapStatusRequest) (serverapi.AuthGetBootstrapStatusResponse, error)
 	CompleteAuthBootstrap(ctx context.Context, req serverapi.AuthCompleteBootstrapRequest) (serverapi.AuthCompleteBootstrapResponse, error)
+	AcknowledgeNoAuth(ctx context.Context, req serverapi.AuthAcknowledgeNoAuthRequest) (serverapi.AuthAcknowledgeNoAuthResponse, error)
 }
 
 type loopbackAuthBootstrapClient struct {
@@ -26,4 +27,8 @@ func (c *loopbackAuthBootstrapClient) GetAuthBootstrapStatus(ctx context.Context
 
 func (c *loopbackAuthBootstrapClient) CompleteAuthBootstrap(ctx context.Context, req serverapi.AuthCompleteBootstrapRequest) (serverapi.AuthCompleteBootstrapResponse, error) {
 	return callLoopbackClient(c, "auth bootstrap service is required", ctx, req, servicecontract.AuthBootstrapService.CompleteBootstrap)
+}
+
+func (c *loopbackAuthBootstrapClient) AcknowledgeNoAuth(ctx context.Context, req serverapi.AuthAcknowledgeNoAuthRequest) (serverapi.AuthAcknowledgeNoAuthResponse, error) {
+	return callLoopbackClient(c, "auth bootstrap service is required", ctx, req, servicecontract.AuthBootstrapService.AcknowledgeNoAuth)
 }

--- a/shared/client/remote.go
+++ b/shared/client/remote.go
@@ -23,6 +23,7 @@ type Remote struct {
 	workspaceID    string
 	workspaceRoot  string
 	expectedRootID atomic.Value // string; empty disables root validation
+	noAuthAck      atomic.Bool
 	closed         atomic.Bool
 }
 
@@ -101,6 +102,54 @@ func (c *Remote) rootID() string {
 	return ""
 }
 
+func (c *Remote) EnableNoAuthBootstrapAcknowledgement(ctx context.Context) error {
+	if c == nil {
+		return errors.New("remote client is required")
+	}
+	resp, err := c.AcknowledgeNoAuth(ctx, serverapi.AuthAcknowledgeNoAuthRequest{})
+	if err != nil {
+		c.noAuthAck.Store(false)
+		return err
+	}
+	if resp.NoAuthSelected {
+		c.noAuthAck.Store(true)
+		return nil
+	}
+	c.noAuthAck.Store(false)
+	if resp.AuthReady {
+		return nil
+	}
+	return serverapi.ErrServerAuthRequired
+}
+
+func (c *Remote) DisableNoAuthBootstrapAcknowledgement() {
+	if c != nil {
+		c.noAuthAck.Store(false)
+	}
+}
+
+func (c *Remote) NoAuthBootstrapAcknowledgementEnabled() bool {
+	return c != nil && c.noAuthAck.Load()
+}
+
+func (c *Remote) acknowledgeNoAuthOnConn(ctx context.Context, conn rpcwire.Conn) error {
+	if c == nil || !c.noAuthAck.Load() {
+		return nil
+	}
+	var resp serverapi.AuthAcknowledgeNoAuthResponse
+	if err := callRPC(ctx, conn, "auth-acknowledge-no-auth", protocol.MethodAuthAcknowledgeNoAuth, serverapi.AuthAcknowledgeNoAuthRequest{}, &resp); err != nil {
+		return err
+	}
+	if resp.NoAuthSelected {
+		return nil
+	}
+	c.noAuthAck.Store(false)
+	if resp.AuthReady {
+		return nil
+	}
+	return serverapi.ErrServerAuthRequired
+}
+
 func (c *Remote) GetServerReadiness(ctx context.Context, req serverapi.ServerReadinessRequest) (serverapi.ServerReadinessResponse, error) {
 	return callUnscopedRPC[serverapi.ServerReadinessRequest, serverapi.ServerReadinessResponse](c, ctx, protocol.MethodServerReadinessGet, req)
 }
@@ -146,7 +195,19 @@ func (c *Remote) GetAuthBootstrapStatus(ctx context.Context, req serverapi.AuthG
 }
 
 func (c *Remote) CompleteAuthBootstrap(ctx context.Context, req serverapi.AuthCompleteBootstrapRequest) (serverapi.AuthCompleteBootstrapResponse, error) {
-	return callUnscopedRPC[serverapi.AuthCompleteBootstrapRequest, serverapi.AuthCompleteBootstrapResponse](c, ctx, protocol.MethodAuthCompleteBootstrap, req)
+	resp, err := callUnscopedRPC[serverapi.AuthCompleteBootstrapRequest, serverapi.AuthCompleteBootstrapResponse](c, ctx, protocol.MethodAuthCompleteBootstrap, req)
+	if err == nil {
+		if resp.NoAuthSelected {
+			c.noAuthAck.Store(true)
+		} else if resp.AuthReady {
+			c.noAuthAck.Store(false)
+		}
+	}
+	return resp, err
+}
+
+func (c *Remote) AcknowledgeNoAuth(ctx context.Context, req serverapi.AuthAcknowledgeNoAuthRequest) (serverapi.AuthAcknowledgeNoAuthResponse, error) {
+	return callUnscopedRPC[serverapi.AuthAcknowledgeNoAuthRequest, serverapi.AuthAcknowledgeNoAuthResponse](c, ctx, protocol.MethodAuthAcknowledgeNoAuth, req)
 }
 
 func (c *Remote) GetAuthStatus(ctx context.Context, req serverapi.AuthStatusRequest) (serverapi.AuthStatusResponse, error) {
@@ -673,6 +734,10 @@ func (c *Remote) openControlRPCConn(ctx context.Context) (rpcwire.Conn, protocol
 		return nil, protocol.ServerIdentity{}, err
 	}
 	if err := validateIdentityRoot(c.rootID(), identity); err != nil {
+		cleanup()
+		return nil, protocol.ServerIdentity{}, err
+	}
+	if err := c.acknowledgeNoAuthOnConn(ctx, conn); err != nil {
 		cleanup()
 		return nil, protocol.ServerIdentity{}, err
 	}

--- a/shared/client/remote.go
+++ b/shared/client/remote.go
@@ -138,6 +138,9 @@ func (c *Remote) acknowledgeNoAuthOnConn(ctx context.Context, conn rpcwire.Conn)
 	}
 	var resp serverapi.AuthAcknowledgeNoAuthResponse
 	if err := callRPC(ctx, conn, "auth-acknowledge-no-auth", protocol.MethodAuthAcknowledgeNoAuth, serverapi.AuthAcknowledgeNoAuthRequest{}, &resp); err != nil {
+		if errors.Is(err, serverapi.ErrServerAuthRequired) {
+			c.noAuthAck.Store(false)
+		}
 		return err
 	}
 	if resp.NoAuthSelected {

--- a/shared/client/remote_noauth_transport_test.go
+++ b/shared/client/remote_noauth_transport_test.go
@@ -1,0 +1,324 @@
+package client
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"core/shared/protocol"
+	"core/shared/rpcwire"
+	"core/shared/serverapi"
+)
+
+func TestRemoteNoAuthAcknowledgementPropagatesToFreshConnectionStrategies(t *testing.T) {
+	var connectionCount atomic.Int32
+	var freshAckCount atomic.Int32
+	handlerErrs := make(chan error, 16)
+	server := httptest.NewServer(rpcwire.NewWebSocketTransport().Handler(func(ctx context.Context, conn rpcwire.Conn) {
+		connIndex := connectionCount.Add(1)
+		handshaken := false
+		attached := false
+		sawAck := false
+		for event := range conn.Events() {
+			if event.Err != nil {
+				return
+			}
+			req := event.Frame.Request()
+			if !handshaken {
+				if req.Method != protocol.MethodHandshake {
+					reportHandlerError(handlerErrs, "conn %d first method = %q, want handshake", connIndex, req.Method)
+					return
+				}
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, protocol.HandshakeResponse{Identity: protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"}}))); err != nil {
+					reportHandlerError(handlerErrs, "send handshake response: %w", err)
+					return
+				}
+				handshaken = true
+				continue
+			}
+			switch req.Method {
+			case protocol.MethodAuthAcknowledgeNoAuth:
+				sawAck = true
+				if connIndex > 1 {
+					freshAckCount.Add(1)
+				}
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, serverapi.AuthAcknowledgeNoAuthResponse{NoAuthSelected: true}))); err != nil {
+					reportHandlerError(handlerErrs, "send no-auth ack response: %w", err)
+				}
+			case protocol.MethodAttachProject:
+				if connIndex > 1 && !sawAck {
+					reportHandlerError(handlerErrs, "conn %d attached project before no-auth acknowledgement", connIndex)
+					return
+				}
+				attached = true
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, protocol.AttachResponse{Kind: "project", ProjectID: "project-1", WorkspaceRoot: "/tmp/workspace-a"}))); err != nil {
+					reportHandlerError(handlerErrs, "send attach response: %w", err)
+					return
+				}
+			case protocol.MethodAttachSession:
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, protocol.AttachResponse{Kind: "session", SessionID: "session-1"}))); err != nil {
+					reportHandlerError(handlerErrs, "send attach-session response: %w", err)
+					return
+				}
+			case protocol.MethodRuntimeSubmitUserTurn:
+				if !attached {
+					reportHandlerError(handlerErrs, "submit before project attach")
+					return
+				}
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, serverapi.RuntimeSubmitUserTurnResponse{Message: "ok"}))); err != nil {
+					reportHandlerError(handlerErrs, "send submit response: %w", err)
+				}
+				return
+			case protocol.MethodSessionSubscribeActivity:
+				if !attached {
+					reportHandlerError(handlerErrs, "subscribe before project attach")
+					return
+				}
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, protocol.SubscribeResponse{Stream: protocol.MethodSessionActivityEvent}))); err != nil {
+					reportHandlerError(handlerErrs, "send subscribe response: %w", err)
+				}
+				return
+			case protocol.MethodRunPrompt:
+				if !attached {
+					reportHandlerError(handlerErrs, "run.prompt before project attach")
+					return
+				}
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, serverapi.RunPromptResponse{}))); err != nil {
+					reportHandlerError(handlerErrs, "send run.prompt response: %w", err)
+				}
+				return
+			default:
+				reportHandlerError(handlerErrs, "unexpected method %q", req.Method)
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	remote, err := DialRemoteURLForProject(context.Background(), "ws"+server.URL[len("http"):], "project-1")
+	if err != nil {
+		t.Fatalf("DialRemoteURLForProject: %v", err)
+	}
+	defer func() { _ = remote.Close() }()
+	if err := remote.EnableNoAuthBootstrapAcknowledgement(context.Background()); err != nil {
+		t.Fatalf("EnableNoAuthBootstrapAcknowledgement: %v", err)
+	}
+	if _, err := remote.SubmitUserTurn(context.Background(), serverapi.RuntimeSubmitUserTurnRequest{ClientRequestID: "submit-1", SessionID: "session-1", Text: "hi"}); err != nil {
+		t.Fatalf("SubmitUserTurn: %v", err)
+	}
+	sub, err := remote.SubscribeSessionActivity(context.Background(), serverapi.SessionActivitySubscribeRequest{SessionID: "session-1"})
+	if err != nil {
+		t.Fatalf("SubscribeSessionActivity: %v", err)
+	}
+	_ = sub.Close()
+	if _, err := remote.RunPrompt(context.Background(), serverapi.RunPromptRequest{ClientRequestID: "run-1", Prompt: "hi"}, nil); err != nil {
+		t.Fatalf("RunPrompt: %v", err)
+	}
+	if got := freshAckCount.Load(); got != 3 {
+		t.Fatalf("fresh no-auth ack count = %d, want 3", got)
+	}
+	requireNoHandlerError(t, handlerErrs)
+}
+
+func TestRemoteNoAuthAcknowledgementDisabledWhenServerReportsRealAuthReady(t *testing.T) {
+	var connectionCount atomic.Int32
+	var ackCount atomic.Int32
+	handlerErrs := make(chan error, 8)
+	server := httptest.NewServer(rpcwire.NewWebSocketTransport().Handler(func(ctx context.Context, conn rpcwire.Conn) {
+		connIndex := connectionCount.Add(1)
+		handshaken := false
+		for event := range conn.Events() {
+			if event.Err != nil {
+				return
+			}
+			req := event.Frame.Request()
+			if !handshaken {
+				if req.Method != protocol.MethodHandshake {
+					reportHandlerError(handlerErrs, "conn %d first method = %q, want handshake", connIndex, req.Method)
+					return
+				}
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, protocol.HandshakeResponse{Identity: protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"}}))); err != nil {
+					reportHandlerError(handlerErrs, "send handshake response: %w", err)
+					return
+				}
+				handshaken = true
+				continue
+			}
+			switch req.Method {
+			case protocol.MethodAttachProject:
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, protocol.AttachResponse{Kind: "project", ProjectID: "project-1", WorkspaceRoot: "/tmp/workspace-a"}))); err != nil {
+					reportHandlerError(handlerErrs, "send attach response: %w", err)
+					return
+				}
+			case protocol.MethodAuthAcknowledgeNoAuth:
+				ackCount.Add(1)
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, serverapi.AuthAcknowledgeNoAuthResponse{AuthReady: true}))); err != nil {
+					reportHandlerError(handlerErrs, "send ack response: %w", err)
+					return
+				}
+			case protocol.MethodRuntimeSubmitUserTurn:
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, serverapi.RuntimeSubmitUserTurnResponse{Message: "ok"}))); err != nil {
+					reportHandlerError(handlerErrs, "send submit response: %w", err)
+				}
+				return
+			default:
+				reportHandlerError(handlerErrs, "unexpected method %q", req.Method)
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	remote, err := DialRemoteURLForProject(context.Background(), "ws"+server.URL[len("http"):], "project-1")
+	if err != nil {
+		t.Fatalf("DialRemoteURLForProject: %v", err)
+	}
+	defer func() { _ = remote.Close() }()
+	remote.noAuthAck.Store(true)
+	if _, err := remote.SubmitUserTurn(context.Background(), serverapi.RuntimeSubmitUserTurnRequest{ClientRequestID: "submit-1", SessionID: "session-1", Text: "hi"}); err != nil {
+		t.Fatalf("SubmitUserTurn: %v", err)
+	}
+	if got := ackCount.Load(); got != 1 {
+		t.Fatalf("ack count = %d, want 1", got)
+	}
+	if remote.NoAuthBootstrapAcknowledgementEnabled() {
+		t.Fatal("expected no-auth acknowledgement policy to be disabled after real auth ready response")
+	}
+	requireNoHandlerError(t, handlerErrs)
+}
+
+func TestRemoteRealAuthCompletionDisablesNoAuthAcknowledgementPolicy(t *testing.T) {
+	var connectionCount atomic.Int32
+	var ackCount atomic.Int32
+	handlerErrs := make(chan error, 8)
+	server := httptest.NewServer(rpcwire.NewWebSocketTransport().Handler(func(ctx context.Context, conn rpcwire.Conn) {
+		connIndex := connectionCount.Add(1)
+		handshaken := false
+		for event := range conn.Events() {
+			if event.Err != nil {
+				return
+			}
+			req := event.Frame.Request()
+			if !handshaken {
+				if req.Method != protocol.MethodHandshake {
+					reportHandlerError(handlerErrs, "conn %d first method = %q, want handshake", connIndex, req.Method)
+					return
+				}
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, protocol.HandshakeResponse{Identity: protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"}}))); err != nil {
+					reportHandlerError(handlerErrs, "send handshake response: %w", err)
+					return
+				}
+				handshaken = true
+				continue
+			}
+			switch req.Method {
+			case protocol.MethodAttachProject:
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, protocol.AttachResponse{Kind: "project", ProjectID: "project-1", WorkspaceRoot: "/tmp/workspace-a"}))); err != nil {
+					reportHandlerError(handlerErrs, "send attach response: %w", err)
+					return
+				}
+			case protocol.MethodAuthAcknowledgeNoAuth:
+				ackCount.Add(1)
+				if connIndex > 1 {
+					reportHandlerError(handlerErrs, "fresh connection sent stale no-auth acknowledgement after real auth")
+					return
+				}
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, serverapi.AuthAcknowledgeNoAuthResponse{NoAuthSelected: true}))); err != nil {
+					reportHandlerError(handlerErrs, "send no-auth ack response: %w", err)
+					return
+				}
+			case protocol.MethodAuthCompleteBootstrap:
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, serverapi.AuthCompleteBootstrapResponse{AuthReady: true, MethodType: "api_key"}))); err != nil {
+					reportHandlerError(handlerErrs, "send complete response: %w", err)
+					return
+				}
+			case protocol.MethodRuntimeSubmitUserTurn:
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, serverapi.RuntimeSubmitUserTurnResponse{Message: "ok"}))); err != nil {
+					reportHandlerError(handlerErrs, "send submit response: %w", err)
+				}
+				return
+			default:
+				reportHandlerError(handlerErrs, "unexpected method %q", req.Method)
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	remote, err := DialRemoteURLForProject(context.Background(), "ws"+server.URL[len("http"):], "project-1")
+	if err != nil {
+		t.Fatalf("DialRemoteURLForProject: %v", err)
+	}
+	defer func() { _ = remote.Close() }()
+	if err := remote.EnableNoAuthBootstrapAcknowledgement(context.Background()); err != nil {
+		t.Fatalf("EnableNoAuthBootstrapAcknowledgement: %v", err)
+	}
+	if _, err := remote.CompleteAuthBootstrap(context.Background(), serverapi.AuthCompleteBootstrapRequest{Mode: serverapi.AuthBootstrapModeAPIKey, APIKey: "real-key"}); err != nil {
+		t.Fatalf("CompleteAuthBootstrap: %v", err)
+	}
+	if remote.NoAuthBootstrapAcknowledgementEnabled() {
+		t.Fatal("expected real auth completion to disable no-auth acknowledgement policy")
+	}
+	if _, err := remote.SubmitUserTurn(context.Background(), serverapi.RuntimeSubmitUserTurnRequest{ClientRequestID: "submit-1", SessionID: "session-1", Text: "hi"}); err != nil {
+		t.Fatalf("SubmitUserTurn: %v", err)
+	}
+	if got := ackCount.Load(); got != 1 {
+		t.Fatalf("ack count = %d, want only initial enable acknowledgement", got)
+	}
+	requireNoHandlerError(t, handlerErrs)
+}
+
+func TestRemoteDoesNotAcknowledgeNoAuthWhenPolicyDisabled(t *testing.T) {
+	handlerErrs := make(chan error, 8)
+	server := httptest.NewServer(rpcwire.NewWebSocketTransport().Handler(func(ctx context.Context, conn rpcwire.Conn) {
+		handshaken := false
+		for event := range conn.Events() {
+			if event.Err != nil {
+				return
+			}
+			req := event.Frame.Request()
+			if !handshaken {
+				if req.Method != protocol.MethodHandshake {
+					reportHandlerError(handlerErrs, "first method = %q, want handshake", req.Method)
+					return
+				}
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, protocol.HandshakeResponse{Identity: protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"}}))); err != nil {
+					reportHandlerError(handlerErrs, "send handshake response: %w", err)
+					return
+				}
+				handshaken = true
+				continue
+			}
+			switch req.Method {
+			case protocol.MethodAttachProject:
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, protocol.AttachResponse{Kind: "project", ProjectID: "project-1", WorkspaceRoot: "/tmp/workspace-a"}))); err != nil {
+					reportHandlerError(handlerErrs, "send attach response: %w", err)
+					return
+				}
+			case protocol.MethodAuthAcknowledgeNoAuth:
+				reportHandlerError(handlerErrs, "unexpected no-auth acknowledgement while policy disabled")
+				return
+			case protocol.MethodRuntimeSubmitUserTurn:
+				if err := conn.Send(ctx, rpcwire.FrameFromResponse(protocol.NewSuccessResponse(req.ID, serverapi.RuntimeSubmitUserTurnResponse{Message: "ok"}))); err != nil {
+					reportHandlerError(handlerErrs, "send submit response: %w", err)
+				}
+				return
+			default:
+				reportHandlerError(handlerErrs, "unexpected method %q", req.Method)
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	remote, err := DialRemoteURLForProject(context.Background(), "ws"+server.URL[len("http"):], "project-1")
+	if err != nil {
+		t.Fatalf("DialRemoteURLForProject: %v", err)
+	}
+	defer func() { _ = remote.Close() }()
+	if _, err := remote.SubmitUserTurn(context.Background(), serverapi.RuntimeSubmitUserTurnRequest{ClientRequestID: "submit-1", SessionID: "session-1", Text: "hi"}); err != nil {
+		t.Fatalf("SubmitUserTurn: %v", err)
+	}
+	requireNoHandlerError(t, handlerErrs)
+}

--- a/shared/client/remote_rpc.go
+++ b/shared/client/remote_rpc.go
@@ -211,6 +211,10 @@ func (c *Remote) openRPCConn(ctx context.Context) (rpcwire.Conn, func(), error) 
 		cleanup()
 		return nil, nil, err
 	}
+	if err := c.acknowledgeNoAuthOnConn(ctx, conn); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
 	if err := attachProjectRPC(ctx, conn, c.projectID, c.workspaceID, c.workspaceRoot); err != nil {
 		cleanup()
 		return nil, nil, err

--- a/shared/protocol/handshake.go
+++ b/shared/protocol/handshake.go
@@ -12,6 +12,7 @@ const (
 	MethodServerReadinessGet                    = "server.readiness.get"
 	MethodAuthGetBootstrapStatus                = "auth.getBootstrapStatus"
 	MethodAuthCompleteBootstrap                 = "auth.completeBootstrap"
+	MethodAuthAcknowledgeNoAuth                 = "auth.acknowledgeNoAuth"
 	MethodAuthGetStatus                         = "auth.getStatus"
 	MethodAttachProject                         = "project.attach"
 	MethodAttachSession                         = "session.attach"

--- a/shared/protocol/version.json
+++ b/shared/protocol/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "18"
+  "version": "19"
 }

--- a/shared/serverapi/auth_bootstrap.go
+++ b/shared/serverapi/auth_bootstrap.go
@@ -33,10 +33,18 @@ type AuthGetBootstrapStatusRequest struct{}
 type AuthGetBootstrapStatusResponse struct {
 	AuthReady              bool                     `json:"auth_ready"`
 	AuthRequired           bool                     `json:"auth_required"`
+	NoAuthSelected         bool                     `json:"no_auth_selected,omitempty"`
 	AuthBootstrapSupported bool                     `json:"auth_bootstrap_supported"`
 	AllowedPreAuthMethods  []string                 `json:"allowed_pre_auth_methods,omitempty"`
 	SupportedModes         []AuthBootstrapMode      `json:"supported_modes,omitempty"`
 	OAuth                  AuthBootstrapOAuthConfig `json:"oauth,omitempty"`
+}
+
+type AuthAcknowledgeNoAuthRequest struct{}
+
+type AuthAcknowledgeNoAuthResponse struct {
+	AuthReady      bool `json:"auth_ready"`
+	NoAuthSelected bool `json:"no_auth_selected,omitempty"`
 }
 
 type AuthCompleteBootstrapRequest struct {
@@ -52,10 +60,11 @@ type AuthCompleteBootstrapRequest struct {
 }
 
 type AuthCompleteBootstrapResponse struct {
-	AuthReady  bool   `json:"auth_ready"`
-	MethodType string `json:"method_type,omitempty"`
-	AccountID  string `json:"account_id,omitempty"`
-	Email      string `json:"email,omitempty"`
+	AuthReady      bool   `json:"auth_ready"`
+	NoAuthSelected bool   `json:"no_auth_selected,omitempty"`
+	MethodType     string `json:"method_type,omitempty"`
+	AccountID      string `json:"account_id,omitempty"`
+	Email          string `json:"email,omitempty"`
 }
 
 func (r AuthCompleteBootstrapRequest) Validate() error {


### PR DESCRIPTION
## Summary
- Add a non-mutating no-auth acknowledgement RPC and protocol v19 route/client/server contracts.
- Allow acknowledged no-auth per gateway connection while preserving raw auth readiness semantics.
- Propagate no-auth acknowledgement across remote control, dedicated, subscription, progress, and rebound connections; keep headless/fresh clients blocked.
- Honor persisted local/remote no-auth without reopening the auth picker and revoke stale no-auth policy after real auth.
- Update the locked auth spec.

## Verification
- ./scripts/test.sh ./shared/protocol
- ./scripts/test.sh ./shared/apicontract
- ./scripts/test.sh ./shared/serverapi
- ./scripts/test.sh ./server/transport -run 'Gateway.*Auth|NoAuth|RoutePolicy'
- ./scripts/test.sh ./shared/client -run 'Remote.*Auth|NoAuth|Connection'
- ./scripts/test.sh ./cli/app -run 'RemoteAuth|RemoteAppServer.*Auth|StartSessionServer.*Auth|SessionServer.*Auth|RuntimeAttachment.*Auth|ProjectBinding.*Auth|Auth|BootstrapAppRequiredNoAuthPreferenceDoesNotOpenAuthPicker|RemoteNoAuthUnregisteredWorkspaceBinding'
- ./scripts/test.sh ./server/authservice
- ./scripts/test.sh ./cli/app/internal/remoteattach
- ./scripts/test.sh ./cli/app/internal/serverattach
- go test ./... -run '^$'
- ./scripts/build.sh --output ./bin/kent
- code_review follow-up: no findings

Plan/evidence path: .builder/plans/BUI-144-auth-no-auth-reprompt.md

Closes #443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting and persisting “no auth” during setup.
  * Introduced a new acknowledgment flow so authenticated clients can recognize that choice on reconnects.

* **Bug Fixes**
  * Prevents the auth picker from reopening when “no auth” is already selected.
  * Keeps session and workspace startup working correctly across reconnects and rebinding.

* **Documentation**
  * Updated the runtime auth spec to describe the new no-auth behavior and connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->