### PR TITLE
fix: block hallucinated web search queries

### DIFF
--- a/server/runtime/engine_part3_test.go
+++ b/server/runtime/engine_part3_test.go
@@ -16,6 +16,18 @@ import (
 	"core/shared/toolspec"
 )
 
+func openAIFirstPartyNativeWebSearchCaps() llm.ProviderCapabilities {
+	return llm.ProviderCapabilities{
+		ProviderID:                    "openai",
+		SupportsResponsesAPI:          true,
+		SupportsResponsesCompact:      true,
+		SupportsNativeWebSearch:       true,
+		SupportsReasoningEncrypted:    true,
+		SupportsServerSideContextEdit: true,
+		IsOpenAIFirstParty:            true,
+	}
+}
+
 func TestSetReviewerEnabledConcurrentWithBusyStep(t *testing.T) {
 	store := mustCreateTestSession(t)
 
@@ -220,6 +232,41 @@ func TestHostedWebSearchExecutionRejectsWhitespaceSearchQuery(t *testing.T) {
 	}
 }
 
+func TestHostedWebSearchExecutionRejectsHallucinatedSearchQuery(t *testing.T) {
+	item := llm.ResponseItem{
+		Type: llm.ResponseItemTypeOther,
+		Raw: json.RawMessage(`{
+			"type":"web_search_call",
+			"id":"ws_4",
+			"status":"completed",
+			"action":{"type":"search","query":"web search"}
+		}`),
+	}
+
+	executions := hostedToolExecutionsFromOutputItems([]llm.ResponseItem{item}, tools.DefinitionsFor([]toolspec.ID{toolspec.ToolWebSearch}))
+	if len(executions) != 1 {
+		t.Fatal("expected hosted web search execution")
+	}
+	execution := executions[0]
+	if !execution.Result.IsError {
+		t.Fatalf("expected hosted hallucinated query to fail, got %+v", execution.Result)
+	}
+	var output map[string]string
+	if err := json.Unmarshal(execution.Result.Output, &output); err != nil {
+		t.Fatalf("decode hosted output: %v", err)
+	}
+	if output["error"] != tools.InvalidWebSearchQueryMessage {
+		t.Fatalf("expected invalid query error, got %+v", output)
+	}
+	var input map[string]string
+	if err := json.Unmarshal(execution.Call.Input, &input); err != nil {
+		t.Fatalf("decode hosted input: %v", err)
+	}
+	if input["query"] != "web search" {
+		t.Fatalf("expected hosted input to preserve normalized query, got %+v", input)
+	}
+}
+
 func TestSubmitUserMessageContinuesAfterHostedToolOnlyTurn(t *testing.T) {
 	store := mustCreateTestSession(t)
 
@@ -239,15 +286,7 @@ func TestSubmitUserMessageContinuesAfterHostedToolOnlyTurn(t *testing.T) {
 			Usage:     llm.Usage{WindowTokens: 200000},
 		},
 	}}
-	client.caps = llm.ProviderCapabilities{
-		ProviderID:                    "openai",
-		SupportsResponsesAPI:          true,
-		SupportsResponsesCompact:      true,
-		SupportsNativeWebSearch:       true,
-		SupportsReasoningEncrypted:    true,
-		SupportsServerSideContextEdit: true,
-		IsOpenAIFirstParty:            true,
-	}
+	client.caps = openAIFirstPartyNativeWebSearchCaps()
 
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
 		Model:         "gpt-5",
@@ -307,6 +346,98 @@ func TestSubmitUserMessageContinuesAfterHostedToolOnlyTurn(t *testing.T) {
 	}
 }
 
+func TestSubmitUserMessageContinuesAfterInvalidHostedWebSearch(t *testing.T) {
+	store := mustCreateTestSession(t)
+
+	client := &fakeClient{responses: []llm.Response{
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: ""},
+			OutputItems: []llm.ResponseItem{
+				{
+					Type: llm.ResponseItemTypeOther,
+					Raw:  json.RawMessage(`{"type":"web_search_call","id":"ws_invalid","status":"completed","action":{"type":"search","query":"web search"}}`),
+				},
+			},
+			Usage: llm.Usage{WindowTokens: 200000},
+		},
+		{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done"},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		},
+	}}
+	client.caps = openAIFirstPartyNativeWebSearchCaps()
+
+	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
+		Model:         "gpt-5",
+		WebSearchMode: "native",
+		EnabledTools:  []toolspec.ID{toolspec.ToolWebSearch},
+	})
+
+	msg, err := eng.SubmitUserMessage(context.Background(), "find latest")
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if msg.Content != "done" {
+		t.Fatalf("assistant content = %q, want done", msg.Content)
+	}
+	if len(client.calls) != 2 {
+		t.Fatalf("expected 2 model calls, got %d", len(client.calls))
+	}
+	if !client.calls[0].EnableNativeWebSearch {
+		t.Fatalf("expected first request to enable native web search")
+	}
+
+	foundHostedOutput := false
+	for _, item := range client.calls[1].Items {
+		if item.Type != llm.ResponseItemTypeFunctionCallOutput || item.CallID != "ws_invalid" {
+			continue
+		}
+		foundHostedOutput = true
+		var output map[string]string
+		if err := json.Unmarshal(item.Output, &output); err != nil {
+			t.Fatalf("decode hosted tool output: %v", err)
+		}
+		if output["error"] != tools.InvalidWebSearchQueryMessage {
+			t.Fatalf("expected invalid query error in follow-up output, got %+v", output)
+		}
+	}
+	if !foundHostedOutput {
+		t.Fatalf("expected invalid hosted tool output item in follow-up request, got %+v", client.calls[1].Items)
+	}
+
+	events, err := sessiontest.CollectEvents(store)
+	if err != nil {
+		t.Fatalf("read events: %v", err)
+	}
+	foundPersistedError := false
+	for _, evt := range events {
+		if evt.Kind != "tool_completed" {
+			continue
+		}
+		var completion storedToolCompletion
+		if err := json.Unmarshal(evt.Payload, &completion); err != nil {
+			t.Fatalf("decode tool_completed payload: %v", err)
+		}
+		if completion.CallID != "ws_invalid" {
+			continue
+		}
+		foundPersistedError = true
+		if !completion.IsError {
+			t.Fatalf("expected persisted hosted completion to be error, got %+v", completion)
+		}
+		var output map[string]string
+		if err := json.Unmarshal(completion.Output, &output); err != nil {
+			t.Fatalf("decode persisted hosted output: %v", err)
+		}
+		if output["error"] != tools.InvalidWebSearchQueryMessage {
+			t.Fatalf("expected persisted invalid query error, got %+v", output)
+		}
+	}
+	if !foundPersistedError {
+		t.Fatalf("expected persisted hosted completion for ws_invalid")
+	}
+}
+
 func TestSubmitUserMessageFinalAnswerWithHostedToolCallMaterializesToolBeforeFinal(t *testing.T) {
 	store := mustCreateTestSession(t)
 
@@ -328,15 +459,7 @@ func TestSubmitUserMessageFinalAnswerWithHostedToolCallMaterializesToolBeforeFin
 			Usage: llm.Usage{WindowTokens: 200000},
 		},
 	}}
-	client.caps = llm.ProviderCapabilities{
-		ProviderID:                    "openai",
-		SupportsResponsesAPI:          true,
-		SupportsResponsesCompact:      true,
-		SupportsNativeWebSearch:       true,
-		SupportsReasoningEncrypted:    true,
-		SupportsServerSideContextEdit: true,
-		IsOpenAIFirstParty:            true,
-	}
+	client.caps = openAIFirstPartyNativeWebSearchCaps()
 
 	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
 		Model:         "gpt-5",

--- a/server/runtime/engine_part9_test.go
+++ b/server/runtime/engine_part9_test.go
@@ -15,6 +15,26 @@ import (
 	"time"
 )
 
+type webSearchProbeTool struct {
+	mu    sync.Mutex
+	calls int
+	name  toolspec.ID
+}
+
+func (t *webSearchProbeTool) Call(_ context.Context, c tools.Call) (tools.Result, error) {
+	t.mu.Lock()
+	t.calls++
+	t.mu.Unlock()
+	out, _ := json.Marshal(map[string]any{"tool": string(t.name)})
+	return tools.Result{CallID: c.ID, Name: c.Name, Output: out}, nil
+}
+
+func (t *webSearchProbeTool) Calls() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.calls
+}
+
 func TestMultiRowCompactionEmitsPerRowCommittedCounts(t *testing.T) {
 	store := mustCreateTestSession(t)
 	var (
@@ -73,6 +93,46 @@ func TestExecuteToolCallsRejectsWhitespaceWebSearchQuery(t *testing.T) {
 	}
 	if !results[0].IsError {
 		t.Fatalf("expected invalid web search query to fail, got %+v", results[0])
+	}
+	var output map[string]string
+	if err := json.Unmarshal(results[0].Output, &output); err != nil {
+		t.Fatalf("decode result output: %v", err)
+	}
+	if output["error"] != tools.InvalidWebSearchQueryMessage {
+		t.Fatalf("expected invalid query error, got %+v", output)
+	}
+	if completion, ok := eng.transcriptRuntimeState().ToolCompletionSnapshot("call-web"); !ok {
+		t.Fatal("expected tool completion to be recorded")
+	} else if !completion.IsError {
+		t.Fatalf("expected persisted completion to be error, got %+v", completion)
+	}
+}
+
+func TestExecuteToolCallsRejectsHallucinatedWebSearchQueryBeforeHandler(t *testing.T) {
+	store := mustCreateTestSession(t)
+
+	probe := &webSearchProbeTool{name: toolspec.ToolWebSearch}
+	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{
+		ID:      toolspec.ToolWebSearch,
+		Handler: probe,
+	}), Config{Model: "gpt-5"})
+
+	results, err := eng.executeToolCalls(context.Background(), "step", []llm.ToolCall{{
+		ID:    "call-web",
+		Name:  string(toolspec.ToolWebSearch),
+		Input: json.RawMessage(`{"query":"web search"}`),
+	}})
+	if err != nil {
+		t.Fatalf("execute tool calls: %v", err)
+	}
+	if probe.Calls() != 0 {
+		t.Fatalf("expected validation to reject before handler execution, got %d handler calls", probe.Calls())
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected one result, got %d", len(results))
+	}
+	if !results[0].IsError {
+		t.Fatalf("expected hallucinated web search query to fail, got %+v", results[0])
 	}
 	var output map[string]string
 	if err := json.Unmarshal(results[0].Output, &output); err != nil {

--- a/server/tools/web_search.go
+++ b/server/tools/web_search.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 )
 
-const InvalidWebSearchQueryMessage = "you provided an invalid search query"
+const (
+	InvalidWebSearchQueryMessage = "you provided an invalid search query"
+	blockedWebSearchQuery        = "web search"
+)
 
 // ErrInvalidWebSearchQuery is the sentinel for rejected web search queries.
 // Callers match it via errors.Is; the message wording lives in
@@ -29,10 +32,18 @@ func ParseWebSearchInput(raw json.RawMessage) (WebSearchInput, error) {
 }
 
 func ValidateWebSearchQuery(query string) error {
-	if strings.TrimSpace(query) == "" {
+	if !isValidWebSearchQuery(normalizeWebSearchQuery(query)) {
 		return ErrInvalidWebSearchQuery
 	}
 	return nil
+}
+
+func normalizeWebSearchQuery(query string) string {
+	return strings.TrimSpace(query)
+}
+
+func isValidWebSearchQuery(normalizedQuery string) bool {
+	return normalizedQuery != "" && normalizedQuery != blockedWebSearchQuery
 }
 
 func ValidateWebSearchInput(raw json.RawMessage) error {
@@ -44,8 +55,8 @@ func ValidateWebSearchInput(raw json.RawMessage) error {
 }
 
 func FormatWebSearchDisplayText(query string) string {
-	trimmed := strings.TrimSpace(query)
-	if trimmed == "" {
+	trimmed := normalizeWebSearchQuery(query)
+	if !isValidWebSearchQuery(trimmed) {
 		return "web search: invalid query"
 	}
 	return fmt.Sprintf("web search: %q", trimmed)

--- a/server/tools/web_search_test.go
+++ b/server/tools/web_search_test.go
@@ -6,12 +6,63 @@ import (
 	"testing"
 )
 
-func TestValidateWebSearchInputRejectsWhitespaceQuery(t *testing.T) {
-	err := ValidateWebSearchInput(json.RawMessage(`{"query":"   "}`))
-	if err == nil {
-		t.Fatal("expected whitespace-only query to be rejected")
+func TestValidateWebSearchInputRejectsInvalidQueries(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{name: "empty", query: ""},
+		{name: "whitespace", query: "   "},
+		{name: "hallucinated tool name", query: "web search"},
+		{name: "whitespace wrapped hallucinated tool name", query: " \tweb search\n"},
 	}
-	if !errors.Is(err, ErrInvalidWebSearchQuery) {
-		t.Fatalf("unexpected validation error: %v", err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := json.Marshal(WebSearchInput{Query: tt.query})
+			if err != nil {
+				t.Fatalf("marshal input: %v", err)
+			}
+			err = ValidateWebSearchInput(raw)
+			if err == nil {
+				t.Fatal("expected query to be rejected")
+			}
+			if !errors.Is(err, ErrInvalidWebSearchQuery) {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateWebSearchInputAllowsNearbyQueries(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{name: "case differs", query: "Web Search"},
+		{name: "hyphenated", query: "web-search"},
+		{name: "specific web search", query: "web search docs"},
+		{name: "word order differs", query: "search the web"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := json.Marshal(WebSearchInput{Query: tt.query})
+			if err != nil {
+				t.Fatalf("marshal input: %v", err)
+			}
+			if err := ValidateWebSearchInput(raw); err != nil {
+				t.Fatalf("expected query to be allowed, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateWebSearchDisplayTextUsesInvalidQueryDisplay(t *testing.T) {
+	if got := FormatWebSearchDisplayText("web search"); got != "web search: invalid query" {
+		t.Fatalf("display = %q, want invalid query display", got)
+	}
+	if got := FormatWebSearchDisplayText(" \tweb search\n"); got != "web search: invalid query" {
+		t.Fatalf("display = %q, want invalid query display", got)
 	}
 }


### PR DESCRIPTION
## Summary
- reject normalized exact `web search` queries through the shared web-search validator while preserving nearby valid queries
- route transcript display formatting through the same validation seam so invalid queries render as invalid
- cover local runtime rejection, hosted decoder rejection, and native hosted continuation error output

Closes #406.

## Verification
- `./scripts/test.sh ./server/tools ./server/runtime`
- `./scripts/test.sh ./server/tools -run TestValidateWebSearch`
- `./scripts/test.sh ./server/runtime -run 'TestExecuteToolCallsRejectsHallucinatedWebSearchQueryBeforeHandler|TestHostedWebSearchExecutionRejectsHallucinatedSearchQuery|TestSubmitUserMessageContinuesAfterInvalidHostedWebSearch'`\n- `./scripts/build.sh --output ./bin/kent`\n\n## Notes\n- Native OpenAI web search remains enabled per BUI-164 product decision; invalid hosted native output is projected into the model-facing follow-up tool error once Kent receives the hosted `web_search_call`.