### PR TITLE
fix: add stream idle watchdog and surface dropped run failures

### DIFF
--- a/cli/app/internal/runtimeattach/submission_error_test.go
+++ b/cli/app/internal/runtimeattach/submission_error_test.go
@@ -1,0 +1,26 @@
+package runtimeattach
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"core/shared/llmerrors"
+)
+
+func TestFormatSubmissionErrorSurfacesStall(t *testing.T) {
+	stall := fmt.Errorf("model generation failed after retries: %w", llmerrors.ErrModelStreamStalled)
+	if got := FormatSubmissionError(stall); got == "" {
+		t.Fatal("expected stall error to format a non-empty submission message")
+	}
+}
+
+func TestFormatSubmissionErrorSuppressesCancellation(t *testing.T) {
+	if got := FormatSubmissionError(context.Canceled); got != "" {
+		t.Fatalf("cancellation should not surface a submission error, got %q", got)
+	}
+	if got := FormatSubmissionError(errors.Join(ErrSubmissionInterrupted, errors.New("noise"))); got != "" {
+		t.Fatalf("interrupt should not surface a submission error, got %q", got)
+	}
+}

--- a/cli/app/internal/runtimeattach/submission_error_test.go
+++ b/cli/app/internal/runtimeattach/submission_error_test.go
@@ -11,8 +11,12 @@ import (
 
 func TestFormatSubmissionErrorSurfacesStall(t *testing.T) {
 	stall := fmt.Errorf("model generation failed after retries: %w", llmerrors.ErrModelStreamStalled)
-	if got := FormatSubmissionError(stall); got == "" {
-		t.Fatal("expected stall error to format a non-empty submission message")
+	want := llmerrors.UserFacingError(stall)
+	if want == "" {
+		t.Fatal("expected stall error to have a mapped user-facing message")
+	}
+	if got := FormatSubmissionError(stall); got != want {
+		t.Fatalf("FormatSubmissionError(stall) = %q, want %q", got, want)
 	}
 }
 

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -227,7 +227,6 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 	if msg.token != 0 && m.activeSubmit.flushed {
 		restoreSubmittedText = false
 	}
-	runReachedEngine := strings.TrimSpace(m.activeSubmit.stepID) != ""
 	activeQueuedID := m.activeSubmit.queuedID
 	m.activeSubmit = activeSubmitState{}
 	c.finishBusyActivity(false)
@@ -252,11 +251,8 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 		m.activity = uiActivityError
 		m.logf("step.error err=%q", detailErr)
 		m.layout().syncViewport()
-		if runReachedEngine {
-			return m, tea.Batch(unlockCmd, restoreInjectedCmd)
-		}
-		appendCmd := m.appendLocalEntryWithNoticeID(operatorErrorFeedbackRole, detailErr, "")
-		return m, tea.Batch(unlockCmd, restoreInjectedCmd, appendCmd)
+		statusCmd := m.sendTransientStatusWithNoticeID(detailErr, uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, "")
+		return m, tea.Batch(unlockCmd, restoreInjectedCmd, statusCmd)
 	}
 
 	m.activity = uiActivityIdle

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -227,6 +227,7 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 	if msg.token != 0 && m.activeSubmit.flushed {
 		restoreSubmittedText = false
 	}
+	runReachedEngine := strings.TrimSpace(m.activeSubmit.stepID) != ""
 	activeQueuedID := m.activeSubmit.queuedID
 	m.activeSubmit = activeSubmitState{}
 	c.finishBusyActivity(false)
@@ -249,9 +250,12 @@ func (c uiInputController) handleSubmitDone(msg submitDoneMsg) (tea.Model, tea.C
 		}
 		detailErr := runtimeattach.FormatSubmissionError(msg.err)
 		m.activity = uiActivityError
-		appendCmd := m.appendLocalEntryWithNoticeID(operatorErrorFeedbackRole, detailErr, "")
 		m.logf("step.error err=%q", detailErr)
 		m.layout().syncViewport()
+		if runReachedEngine {
+			return m, tea.Batch(unlockCmd, restoreInjectedCmd)
+		}
+		appendCmd := m.appendLocalEntryWithNoticeID(operatorErrorFeedbackRole, detailErr, "")
 		return m, tea.Batch(unlockCmd, restoreInjectedCmd, appendCmd)
 	}
 

--- a/cli/app/ui_runtime_control_test.go
+++ b/cli/app/ui_runtime_control_test.go
@@ -8,9 +8,12 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"core/server/llm"
 	"core/shared/clientui"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 type runtimeControlFakeClient struct {
@@ -475,12 +478,16 @@ func TestRuntimeControlHelpersFallbackWithoutRuntimeClient(t *testing.T) {
 		t.Fatalf("record runtime prompt history without client: %v", err)
 	}
 }
-func TestSubmitErrorShowsStatusOnlyWhenRuntimeAppendFails(t *testing.T) {
-	client := &runtimeControlFakeClient{appendErr: errors.New("append failed")}
+func TestSubmitErrorShowsTransientStatusWithoutPersisting(t *testing.T) {
+	originalClear := scheduleTransientStatusClear
+	scheduleTransientStatusClear = func(time.Duration, uint64) tea.Cmd { return nil }
+	defer func() { scheduleTransientStatusClear = originalClear }()
+
+	client := &runtimeControlFakeClient{}
 	m := newProjectedStaticUIModel()
 	m.engine = client
 	m.setBusy(true)
-	m.activeSubmit = activeSubmitState{token: 1, text: "prompt"}
+	m.activeSubmit = activeSubmitState{token: 1, text: "prompt", stepID: "step-1"}
 
 	next, cmd := m.Update(submitDoneMsg{token: 1, submittedText: "prompt", err: errors.New("submit failed")})
 	updated := next.(*uiModel)
@@ -492,38 +499,14 @@ func TestSubmitErrorShowsStatusOnlyWhenRuntimeAppendFails(t *testing.T) {
 		next, _ = updated.Update(msg)
 		updated = next.(*uiModel)
 	}
-	if len(updated.transcriptEntries) != 0 {
-		t.Fatalf("runtime append failure must not create local transcript entries: %+v", updated.transcriptEntries)
-	}
-	if committed := committedTranscriptEntriesForApp(updated.transcriptEntries); len(committed) != 0 {
-		t.Fatalf("runtime append failure advanced committed transcript entries: %+v", committed)
-	}
-	if updated.transientStatus != "append failed" || updated.transientStatusKind != uiStatusNoticeError {
-		t.Fatalf("expected append failure status, got status=%q kind=%v", updated.transientStatus, updated.transientStatusKind)
-	}
-}
-
-func TestSubmitErrorSuppressesClientAppendWhenRunReachedEngine(t *testing.T) {
-	client := &runtimeControlFakeClient{}
-	m := newProjectedStaticUIModel()
-	m.engine = client
-	m.setBusy(true)
-	m.activeSubmit = activeSubmitState{token: 1, text: "prompt", stepID: "step-1"}
-
-	next, cmd := m.Update(submitDoneMsg{token: 1, submittedText: "prompt", err: errors.New("model generation failed after retries")})
-	updated := next.(*uiModel)
-	if updated.activity != uiActivityError {
-		t.Fatalf("expected error activity, got %v", updated.activity)
-	}
-	for _, msg := range collectCmdMessages(t, cmd) {
-		next, _ = updated.Update(msg)
-		updated = next.(*uiModel)
-	}
 	if client.appendedRole != "" || client.appendedText != "" {
-		t.Fatalf("run reached engine: client must not persist a duplicate entry, got role=%q text=%q", client.appendedRole, client.appendedText)
+		t.Fatalf("engine is sole persister: client must not persist a run-error entry, got role=%q text=%q", client.appendedRole, client.appendedText)
 	}
 	if committed := committedTranscriptEntriesForApp(updated.transcriptEntries); len(committed) != 0 {
-		t.Fatalf("run reached engine: client must not advance committed transcript, got %+v", committed)
+		t.Fatalf("client must not advance committed transcript on submit error: %+v", committed)
+	}
+	if updated.transientStatus == "" || updated.transientStatusKind != uiStatusNoticeError {
+		t.Fatalf("expected a transient error status for a submit failure, got status=%q kind=%v", updated.transientStatus, updated.transientStatusKind)
 	}
 }
 

--- a/cli/app/ui_runtime_control_test.go
+++ b/cli/app/ui_runtime_control_test.go
@@ -503,6 +503,30 @@ func TestSubmitErrorShowsStatusOnlyWhenRuntimeAppendFails(t *testing.T) {
 	}
 }
 
+func TestSubmitErrorSuppressesClientAppendWhenRunReachedEngine(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	m := newProjectedStaticUIModel()
+	m.engine = client
+	m.setBusy(true)
+	m.activeSubmit = activeSubmitState{token: 1, text: "prompt", stepID: "step-1"}
+
+	next, cmd := m.Update(submitDoneMsg{token: 1, submittedText: "prompt", err: errors.New("model generation failed after retries")})
+	updated := next.(*uiModel)
+	if updated.activity != uiActivityError {
+		t.Fatalf("expected error activity, got %v", updated.activity)
+	}
+	for _, msg := range collectCmdMessages(t, cmd) {
+		next, _ = updated.Update(msg)
+		updated = next.(*uiModel)
+	}
+	if client.appendedRole != "" || client.appendedText != "" {
+		t.Fatalf("run reached engine: client must not persist a duplicate entry, got role=%q text=%q", client.appendedRole, client.appendedText)
+	}
+	if committed := committedTranscriptEntriesForApp(updated.transcriptEntries); len(committed) != 0 {
+		t.Fatalf("run reached engine: client must not advance committed transcript, got %+v", committed)
+	}
+}
+
 func TestRuntimeControlMarksDisconnectOnTransportError(t *testing.T) {
 	client := &runtimeControlFakeClient{submitErr: io.EOF}
 	m := newProjectedTestUIModel(client, nil, nil)

--- a/cli/kent/main.go
+++ b/cli/kent/main.go
@@ -17,6 +17,7 @@ import (
 	"core/cli/app"
 	"core/prompts"
 	"core/shared/config"
+	"core/shared/llmerrors"
 	"core/shared/sessionenv"
 	"golang.org/x/term"
 )
@@ -342,12 +343,12 @@ func runSubcommand(args []string) int {
 				DurationMS:  result.Duration.Milliseconds(),
 				Error: &runJSONError{
 					Code:    code,
-					Message: runErr.Error(),
+					Message: runErrorMessage(runErr),
 				},
 			})
 		} else {
 			emitWarnings(os.Stderr, result.Warnings)
-			fmt.Fprintln(os.Stderr, runErr)
+			fmt.Fprintln(os.Stderr, runErrorMessage(runErr))
 			if continueHint != "" {
 				fmt.Fprintln(os.Stderr)
 				fmt.Fprintln(os.Stderr, continueHint)
@@ -499,6 +500,13 @@ func parseRunProgressMode(raw string) (runProgressMode, error) {
 	default:
 		return "", fmt.Errorf("invalid --progress-mode value %q", raw)
 	}
+}
+
+func runErrorMessage(err error) string {
+	if message := llmerrors.UserFacingError(err); message != "" {
+		return message
+	}
+	return err.Error()
 }
 
 func runErrorCode(err error) string {

--- a/cli/kent/main_test.go
+++ b/cli/kent/main_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"core/cli/app"
 	serverstartup "core/server/startup"
 	"core/shared/config"
+	"core/shared/llmerrors"
 	"core/shared/sessionenv"
 )
 
@@ -493,6 +495,24 @@ func TestRunErrorCode(t *testing.T) {
 	}
 	if got := runErrorCode(errors.New("boom")); got != "runtime" {
 		t.Fatalf("run error code = %q, want runtime", got)
+	}
+}
+
+func TestRunErrorMessageRoutesStallThroughUserFacingError(t *testing.T) {
+	stall := fmt.Errorf("model generation failed after retries: %w", llmerrors.ErrModelStreamStalled)
+	want := llmerrors.UserFacingError(stall)
+	if want == "" {
+		t.Fatal("expected a stall to have a user-facing message")
+	}
+	if got := runErrorMessage(stall); got != want {
+		t.Fatalf("run error message = %q, want user-facing message %q", got, want)
+	}
+}
+
+func TestRunErrorMessageFallsBackToRawErrorWhenUnmapped(t *testing.T) {
+	raw := errors.New("boom")
+	if got := runErrorMessage(raw); got != raw.Error() {
+		t.Fatalf("run error message = %q, want raw error %q", got, raw.Error())
 	}
 }
 

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -137,7 +137,7 @@ verbose_output = false # show supervisor suggestions in ongoing transcript
 | `shell.postprocessing_mode` | string | `builtin` | `KENT_SHELL_POSTPROCESSING_MODE` |  | Semantic post-processing mode for `exec_command`. Allowed: `none`, `builtin`, `user`, `all`. `builtin` enables Kent processors only. `all` runs Kent processors first, then your hook. |
 | `shell.postprocess_hook` | string | `""` | `KENT_SHELL_POSTPROCESS_HOOK` |  | Optional executable/script path for a single local command post-processing hook. Kent sends JSON on stdin and expects JSON on stdout. |
 | `prevent_sleep` | string | `active` | `KENT_PREVENT_SLEEP` |  | Prevent system sleep while Kent is running. Allowed: `always` (while the server process is live), `active` (while any agent is working, plus up to one minute of idle-confirmation grace), `never` (disabled). Only system sleep is inhibited; screensaver and display sleep are unaffected. |
-| `timeouts.model_request_seconds` | int | `400` | `KENT_TIMEOUTS_MODEL_REQUEST_SECONDS` | `kent run --model-timeout-seconds` | HTTP timeout for model requests. Must be `> 0`. |
+| `timeouts.model_request_seconds` | int | `400` | `KENT_TIMEOUTS_MODEL_REQUEST_SECONDS` | `kent run --model-timeout-seconds` | Model request timeout. Must be `> 0`. For non-streaming requests it bounds the whole request. For streaming responses it is a per-event idle window: the request is only aborted when no streaming activity arrives within this duration (measured from dispatch, so it also bounds time-to-first-event), letting a healthy long generation stream past it while a dead stream fails fast. |
 
 
 ### Workflow

--- a/server/llm/errors.go
+++ b/server/llm/errors.go
@@ -2,6 +2,8 @@ package llm
 
 import "core/shared/llmerrors"
 
+var ErrModelStreamStalled = llmerrors.ErrModelStreamStalled
+
 type APIStatusError = llmerrors.APIStatusError
 type UnifiedErrorCode = llmerrors.UnifiedErrorCode
 type ProviderAPIError = llmerrors.ProviderAPIError

--- a/server/llm/openai_http.go
+++ b/server/llm/openai_http.go
@@ -154,7 +154,7 @@ func (t *HTTPTransport) GenerateStreamWithEvents(ctx context.Context, request Op
 
 	service := responses.NewResponseService(
 		option.WithBaseURL(t.serviceBaseURL(mode)),
-		option.WithHTTPClient(t.Client),
+		option.WithHTTPClient(t.streamingHTTPClient()),
 		option.WithMaxRetries(0),
 	)
 	reqOpts := t.buildRequestOptions(authHeader, mode, request.SessionID)
@@ -166,15 +166,29 @@ func (t *HTTPTransport) GenerateStreamWithEvents(ctx context.Context, request Op
 
 	accumulator := newResponseStreamAccumulator(callbacks, windowTokens)
 	for stream.Next() {
+		if callbacks.OnStreamActivity != nil {
+			callbacks.OnStreamActivity()
+		}
 		accumulator.Consume(stream.Current())
 		if err := accumulator.Err(providerCaps.ProviderID); err != nil {
 			return OpenAIResponse{}, newOpenAIRequestErrorMapper(providerCaps.ProviderID).Map(err, rawResp, "read responses stream events")
 		}
 	}
 	if err := stream.Err(); err != nil {
+		if accumulator.hasCompleted() {
+			return accumulator.Response(), nil
+		}
 		return OpenAIResponse{}, newOpenAIRequestErrorMapper(providerCaps.ProviderID).Map(err, rawResp, "read responses stream events")
 	}
 	return accumulator.Response(), nil
+}
+
+func (t *HTTPTransport) streamingHTTPClient() *http.Client {
+	transport := t.Client.Transport
+	if transport == nil {
+		transport = sharedHTTPTransport
+	}
+	return &http.Client{Transport: transport}
 }
 
 func (t *HTTPTransport) Compact(ctx context.Context, request OpenAICompactionRequest) (OpenAICompactionResponse, error) {

--- a/server/llm/openai_http.go
+++ b/server/llm/openai_http.go
@@ -175,12 +175,19 @@ func (t *HTTPTransport) GenerateStreamWithEvents(ctx context.Context, request Op
 		}
 	}
 	if err := stream.Err(); err != nil {
-		if accumulator.hasCompleted() {
+		if accumulator.hasCompleted() && !callerCanceledStreamRead(ctx) {
 			return accumulator.Response(), nil
 		}
 		return OpenAIResponse{}, newOpenAIRequestErrorMapper(providerCaps.ProviderID).Map(err, rawResp, "read responses stream events")
 	}
 	return accumulator.Response(), nil
+}
+
+func callerCanceledStreamRead(ctx context.Context) bool {
+	if ctx.Err() == nil {
+		return false
+	}
+	return !errors.Is(context.Cause(ctx), ErrModelStreamStalled)
 }
 
 func (t *HTTPTransport) streamingHTTPClient() *http.Client {

--- a/server/llm/openai_http_idle_test.go
+++ b/server/llm/openai_http_idle_test.go
@@ -148,6 +148,29 @@ func TestGenerateStream_StallAfterCompletedSalvagesResponse(t *testing.T) {
 	}
 }
 
+func TestGenerateStream_CallerCancelAfterCompletedIsNotSalvaged(t *testing.T) {
+	client := newPacedWatchdogClient(t, 5*time.Second,
+		pacedStreamEvent{delay: 20 * time.Millisecond, data: `{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","phase":"final_answer","content":[]}}`},
+		pacedStreamEvent{delay: 20 * time.Millisecond, data: `{"type":"response.output_text.delta","delta":"Done"}`},
+		completedStreamEvent(20*time.Millisecond),
+		pacedStreamEvent{delay: 5 * time.Second, data: `[DONE]`},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(120 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := client.GenerateStreamWithEvents(ctx, Request{Model: "gpt-5"}, StreamCallbacks{})
+	if err == nil {
+		t.Fatal("caller cancellation after a completed event must not be salvaged into a successful response")
+	}
+	if errors.Is(err, ErrModelStreamStalled) {
+		t.Fatalf("caller cancel must not be classified as a stall: %v", err)
+	}
+}
+
 func TestGenerateStream_TransportEmitsActivityHeartbeatPerEvent(t *testing.T) {
 	transport := newOpenAIStreamTestTransport(t,
 		`{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","phase":"final_answer","content":[]}}`,

--- a/server/llm/openai_http_idle_test.go
+++ b/server/llm/openai_http_idle_test.go
@@ -1,0 +1,168 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type pacedStreamEvent struct {
+	delay time.Duration
+	data  string
+}
+
+func newPacedStreamTransport(t *testing.T, events ...pacedStreamEvent) *HTTPTransport {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("response writer is not a flusher")
+			return
+		}
+		flusher.Flush()
+		for _, event := range events {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(event.delay):
+			}
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", event.data); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	transport := NewHTTPTransport(staticAuthHeader{})
+	transport.BaseURL = server.URL
+	transport.Client = server.Client()
+	return transport
+}
+
+func newPacedWatchdogClient(t *testing.T, idle time.Duration, events ...pacedStreamEvent) *idleWatchdogClient {
+	t.Helper()
+	return newIdleWatchdogClient(NewOpenAIClient(newPacedStreamTransport(t, events...)), idle)
+}
+
+func completedStreamEvent(delay time.Duration) pacedStreamEvent {
+	return pacedStreamEvent{delay: delay, data: `{"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2},"output":[{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Done"}]}]}}`}
+}
+
+func TestGenerateStream_HealthyLongStreamSurvivesTotalWallClockBeyondIdle(t *testing.T) {
+	idle := 500 * time.Millisecond
+	gap := 80 * time.Millisecond
+	client := newPacedWatchdogClient(t, idle,
+		pacedStreamEvent{delay: gap, data: `{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","phase":"final_answer","content":[]}}`},
+		pacedStreamEvent{delay: gap, data: `{"type":"response.output_text.delta","delta":"Do"}`},
+		pacedStreamEvent{delay: gap, data: `{"type":"response.output_text.delta","delta":"ne"}`},
+		pacedStreamEvent{delay: gap, data: `{"type":"response.output_text.delta","delta":"!"}`},
+		pacedStreamEvent{delay: gap, data: `{"type":"response.output_text.delta","delta":"!"}`},
+		pacedStreamEvent{delay: gap, data: `{"type":"response.output_text.delta","delta":"!"}`},
+		pacedStreamEvent{delay: gap, data: `{"type":"response.output_text.delta","delta":"!"}`},
+		completedStreamEvent(gap),
+		pacedStreamEvent{delay: 0, data: `[DONE]`},
+	)
+
+	resp, err := client.GenerateStreamWithEvents(context.Background(), Request{Model: "gpt-5"}, StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("healthy long stream failed: %v", err)
+	}
+	if resp.Assistant.Content != "Done" {
+		t.Fatalf("assistant text = %q, want Done", resp.Assistant.Content)
+	}
+}
+
+func TestGenerateStream_StalledStreamReturnsStallSentinel(t *testing.T) {
+	client := newPacedWatchdogClient(t, 120*time.Millisecond,
+		pacedStreamEvent{delay: 20 * time.Millisecond, data: `{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","phase":"final_answer","content":[]}}`},
+		completedStreamEvent(5*time.Second),
+		pacedStreamEvent{delay: 0, data: `[DONE]`},
+	)
+
+	ctx := context.Background()
+	_, err := client.GenerateStreamWithEvents(ctx, Request{Model: "gpt-5"}, StreamCallbacks{})
+	if err == nil {
+		t.Fatal("expected stall error")
+	}
+	if !errors.Is(err, ErrModelStreamStalled) {
+		t.Fatalf("err = %v, want ErrModelStreamStalled", err)
+	}
+	if errors.Is(err, context.Canceled) {
+		t.Fatalf("stall error must not wrap context.Canceled: %v", err)
+	}
+	if IsNonRetriableModelError(err) {
+		t.Fatalf("stall error should be retriable")
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("parent context must remain live after a stall, got %v", ctx.Err())
+	}
+}
+
+func TestGenerateStream_ParentCancelIsDistinguishableFromStall(t *testing.T) {
+	client := newPacedWatchdogClient(t, 5*time.Second,
+		pacedStreamEvent{delay: 20 * time.Millisecond, data: `{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","phase":"final_answer","content":[]}}`},
+		completedStreamEvent(5*time.Second),
+		pacedStreamEvent{delay: 0, data: `[DONE]`},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := client.GenerateStreamWithEvents(ctx, Request{Model: "gpt-5"}, StreamCallbacks{})
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+	if errors.Is(err, ErrModelStreamStalled) {
+		t.Fatalf("parent cancel must not classify as stall: %v", err)
+	}
+}
+
+func TestGenerateStream_StallAfterCompletedSalvagesResponse(t *testing.T) {
+	client := newPacedWatchdogClient(t, 120*time.Millisecond,
+		pacedStreamEvent{delay: 20 * time.Millisecond, data: `{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","phase":"final_answer","content":[]}}`},
+		pacedStreamEvent{delay: 20 * time.Millisecond, data: `{"type":"response.output_text.delta","delta":"Done"}`},
+		completedStreamEvent(20*time.Millisecond),
+		pacedStreamEvent{delay: 5 * time.Second, data: `[DONE]`},
+	)
+
+	resp, err := client.GenerateStreamWithEvents(context.Background(), Request{Model: "gpt-5"}, StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("a fully-received response must not be discarded as a stall: %v", err)
+	}
+	if resp.Assistant.Content != "Done" {
+		t.Fatalf("assistant text = %q, want Done", resp.Assistant.Content)
+	}
+}
+
+func TestGenerateStream_TransportEmitsActivityHeartbeatPerEvent(t *testing.T) {
+	transport := newOpenAIStreamTestTransport(t,
+		`{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","phase":"final_answer","content":[]}}`,
+		`{"type":"response.output_text.delta","delta":"Done"}`,
+		`{"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2},"output":[{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Done"}]}]}}`,
+		`[DONE]`,
+	)
+
+	var beats atomic.Int32
+	if _, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{Model: "gpt-5"}, StreamCallbacks{
+		OnStreamActivity: func() { beats.Add(1) },
+	}); err != nil {
+		t.Fatalf("GenerateStreamWithEvents failed: %v", err)
+	}
+	if got := beats.Load(); got != 3 {
+		t.Fatalf("activity beats = %d, want one per streamed event (3)", got)
+	}
+}

--- a/server/llm/openai_http_stream.go
+++ b/server/llm/openai_http_stream.go
@@ -39,6 +39,10 @@ func newResponseStreamAccumulator(callbacks StreamCallbacks, windowTokens int) *
 	}
 }
 
+func (a *responseStreamAccumulator) hasCompleted() bool {
+	return a != nil && a.completed != nil
+}
+
 func (a *responseStreamAccumulator) Consume(evt responses.ResponseStreamEventUnion) {
 	switch evt.Type {
 	case "response.output_text.delta":

--- a/server/llm/openai_http_test.go
+++ b/server/llm/openai_http_test.go
@@ -645,10 +645,7 @@ func TestNewOpenAIProviderClientCanonicalizesBareDefaultOpenAIBaseURL(t *testing
 	if err != nil {
 		t.Fatalf("new openai provider client: %v", err)
 	}
-	openAIClient, ok := client.(*OpenAIClient)
-	if !ok {
-		t.Fatalf("expected *OpenAIClient, got %T", client)
-	}
+	openAIClient := openAIClientFromProvider(t, client)
 	transport, ok := openAIClient.transport.(*HTTPTransport)
 	if !ok {
 		t.Fatalf("expected *HTTPTransport, got %T", openAIClient.transport)

--- a/server/llm/provider_factory.go
+++ b/server/llm/provider_factory.go
@@ -258,7 +258,7 @@ func newOpenAIProviderClient(opts ProviderClientOptions) (Client, error) {
 		transport.ProviderCapabilitiesOverride = &caps
 	}
 	transport.Store = opts.Store
-	return NewOpenAIClient(transport), nil
+	return newIdleWatchdogClient(NewOpenAIClient(transport), transport.Client.Timeout), nil
 }
 
 func allowsAnonymousOpenAIBaseURL(baseURL string) bool {

--- a/server/llm/provider_factory_test.go
+++ b/server/llm/provider_factory_test.go
@@ -10,6 +10,18 @@ import (
 	"core/server/auth"
 )
 
+func openAIClientFromProvider(t *testing.T, client Client) *OpenAIClient {
+	t.Helper()
+	if watchdog, ok := client.(*idleWatchdogClient); ok {
+		client = watchdog.streamingModelClient
+	}
+	openAIClient, ok := client.(*OpenAIClient)
+	if !ok {
+		t.Fatalf("expected *OpenAIClient, got %T", client)
+	}
+	return openAIClient
+}
+
 type providerTestAuth struct{}
 
 func (providerTestAuth) AuthorizationHeader(context.Context) (string, error) {
@@ -53,10 +65,7 @@ func TestNewProviderClient_OpenAI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new provider client: %v", err)
 	}
-	openAIClient, ok := client.(*OpenAIClient)
-	if !ok {
-		t.Fatalf("expected *OpenAIClient, got %T", client)
-	}
+	openAIClient := openAIClientFromProvider(t, client)
 	transport, ok := openAIClient.transport.(*HTTPTransport)
 	if !ok {
 		t.Fatalf("expected *HTTPTransport, got %T", openAIClient.transport)
@@ -80,10 +89,7 @@ func TestNewProviderClient_CodexSparkUsesSparkMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new provider client: %v", err)
 	}
-	openAIClient, ok := client.(*OpenAIClient)
-	if !ok {
-		t.Fatalf("expected *OpenAIClient, got %T", client)
-	}
+	openAIClient := openAIClientFromProvider(t, client)
 	transport, ok := openAIClient.transport.(*HTTPTransport)
 	if !ok {
 		t.Fatalf("expected *HTTPTransport, got %T", openAIClient.transport)
@@ -113,10 +119,7 @@ func TestNewProviderClient_ExplicitProviderOverrideAllowsCustomModelAlias(t *tes
 		t.Fatalf("new provider client: %v", err)
 	}
 
-	openAIClient, ok := client.(*OpenAIClient)
-	if !ok {
-		t.Fatalf("expected *OpenAIClient, got %T", client)
-	}
+	openAIClient := openAIClientFromProvider(t, client)
 	providerCaps, err := openAIClient.ProviderCapabilities(context.Background())
 	if err != nil {
 		t.Fatalf("provider capabilities: %v", err)
@@ -151,10 +154,7 @@ func TestNewProviderClient_RemoteOpenAICompatibleBaseURLAllowsCustomModelFamily(
 		t.Fatalf("new provider client: %v", err)
 	}
 
-	openAIClient, ok := client.(*OpenAIClient)
-	if !ok {
-		t.Fatalf("expected *OpenAIClient, got %T", client)
-	}
+	openAIClient := openAIClientFromProvider(t, client)
 
 	transport, ok := openAIClient.transport.(*HTTPTransport)
 	if !ok {
@@ -195,10 +195,7 @@ func TestNewProviderClient_RemoteOpenAICompatibleBaseURLAllowsAnonymousCapabilit
 		t.Fatalf("new provider client: %v", err)
 	}
 
-	openAIClient, ok := client.(*OpenAIClient)
-	if !ok {
-		t.Fatalf("expected *OpenAIClient, got %T", client)
-	}
+	openAIClient := openAIClientFromProvider(t, client)
 
 	providerCaps, err := openAIClient.ProviderCapabilities(context.Background())
 	if err != nil {
@@ -218,10 +215,7 @@ func TestNewProviderClient_DefaultOpenAIBaseURLDoesNotStayExplicit(t *testing.T)
 	if err != nil {
 		t.Fatalf("new provider client: %v", err)
 	}
-	openAIClient, ok := client.(*OpenAIClient)
-	if !ok {
-		t.Fatalf("expected *OpenAIClient, got %T", client)
-	}
+	openAIClient := openAIClientFromProvider(t, client)
 	transport, ok := openAIClient.transport.(*HTTPTransport)
 	if !ok {
 		t.Fatalf("expected *HTTPTransport, got %T", openAIClient.transport)

--- a/server/llm/stream_idle.go
+++ b/server/llm/stream_idle.go
@@ -43,10 +43,10 @@ func (c *idleWatchdogClient) GenerateStreamWithEvents(ctx context.Context, reque
 
 	previousActivity := callbacks.OnStreamActivity
 	callbacks.OnStreamActivity = func() {
+		watchdog.ping()
 		if previousActivity != nil {
 			previousActivity()
 		}
-		watchdog.ping()
 	}
 
 	resp, err := c.streamingModelClient.GenerateStreamWithEvents(watchdog.ctx, request, callbacks)

--- a/server/llm/stream_idle.go
+++ b/server/llm/stream_idle.go
@@ -1,0 +1,111 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+type streamingModelClient interface {
+	Client
+	StreamClient
+	StreamEventsClient
+	CompactionClient
+	ProviderCapabilitiesClient
+	RequestInputTokenCountClient
+	RequestInputTokenCountSupportClient
+	ModelContextWindowClient
+}
+
+type idleWatchdogClient struct {
+	streamingModelClient
+	idle time.Duration
+}
+
+func newIdleWatchdogClient(inner streamingModelClient, idle time.Duration) *idleWatchdogClient {
+	return &idleWatchdogClient{streamingModelClient: inner, idle: idle}
+}
+
+func (c *idleWatchdogClient) GenerateStream(ctx context.Context, request Request, onDelta func(text string)) (Response, error) {
+	var callback func(AssistantDelta)
+	if onDelta != nil {
+		callback = func(delta AssistantDelta) {
+			onDelta(delta.Text)
+		}
+	}
+	return c.GenerateStreamWithEvents(ctx, request, StreamCallbacks{OnAssistantDelta: callback})
+}
+
+func (c *idleWatchdogClient) GenerateStreamWithEvents(ctx context.Context, request Request, callbacks StreamCallbacks) (Response, error) {
+	watchdog := newStreamIdleWatchdog(ctx, c.idle)
+	defer watchdog.stop()
+
+	previousActivity := callbacks.OnStreamActivity
+	callbacks.OnStreamActivity = func() {
+		if previousActivity != nil {
+			previousActivity()
+		}
+		watchdog.ping()
+	}
+
+	resp, err := c.streamingModelClient.GenerateStreamWithEvents(watchdog.ctx, request, callbacks)
+	if err != nil && errors.Is(context.Cause(watchdog.ctx), ErrModelStreamStalled) {
+		return Response{}, fmt.Errorf("model stream stalled: %w", ErrModelStreamStalled)
+	}
+	return resp, err
+}
+
+type streamIdleWatchdog struct {
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+	pings  chan struct{}
+	done   chan struct{}
+}
+
+func newStreamIdleWatchdog(parent context.Context, idle time.Duration) *streamIdleWatchdog {
+	ctx, cancel := context.WithCancelCause(parent)
+	w := &streamIdleWatchdog{ctx: ctx, cancel: cancel}
+	if idle <= 0 {
+		return w
+	}
+	w.pings = make(chan struct{}, 1)
+	w.done = make(chan struct{})
+	go w.run(idle)
+	return w
+}
+
+func (w *streamIdleWatchdog) run(idle time.Duration) {
+	defer close(w.done)
+	timer := time.NewTimer(idle)
+	defer timer.Stop()
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		case <-w.pings:
+			timer.Stop()
+			timer.Reset(idle)
+		case <-timer.C:
+			w.cancel(ErrModelStreamStalled)
+			return
+		}
+	}
+}
+
+func (w *streamIdleWatchdog) ping() {
+	if w.pings == nil {
+		return
+	}
+	select {
+	case w.pings <- struct{}{}:
+	default:
+	}
+}
+
+func (w *streamIdleWatchdog) stop() {
+	w.cancel(nil)
+	if w.done != nil {
+		<-w.done
+	}
+}

--- a/server/llm/stream_idle_test.go
+++ b/server/llm/stream_idle_test.go
@@ -65,7 +65,11 @@ func TestStreamIdleWatchdogPassthroughWhenIdleNonPositive(t *testing.T) {
 
 func TestStreamIdleWatchdogStopDoesNotOverrideStallCause(t *testing.T) {
 	w := newStreamIdleWatchdog(context.Background(), 20*time.Millisecond)
-	<-w.ctx.Done()
+	select {
+	case <-w.ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not fire after idle window")
+	}
 	w.stop()
 	if !errors.Is(context.Cause(w.ctx), ErrModelStreamStalled) {
 		t.Fatalf("stop overrode stall cause: %v", context.Cause(w.ctx))

--- a/server/llm/stream_idle_test.go
+++ b/server/llm/stream_idle_test.go
@@ -1,0 +1,73 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestStreamIdleWatchdogFiresAfterIdleSilence(t *testing.T) {
+	w := newStreamIdleWatchdog(context.Background(), 30*time.Millisecond)
+	defer w.stop()
+
+	select {
+	case <-w.ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not fire after idle window")
+	}
+	if !errors.Is(context.Cause(w.ctx), ErrModelStreamStalled) {
+		t.Fatalf("cause = %v, want ErrModelStreamStalled", context.Cause(w.ctx))
+	}
+}
+
+func TestStreamIdleWatchdogPingResetsTimer(t *testing.T) {
+	w := newStreamIdleWatchdog(context.Background(), 60*time.Millisecond)
+	defer w.stop()
+
+	deadline := time.After(300 * time.Millisecond)
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			if w.ctx.Err() != nil {
+				t.Fatalf("watchdog fired despite regular pings: %v", context.Cause(w.ctx))
+			}
+			return
+		case <-ticker.C:
+			w.ping()
+		case <-w.ctx.Done():
+			t.Fatalf("watchdog fired despite regular pings: %v", context.Cause(w.ctx))
+		}
+	}
+}
+
+func TestStreamIdleWatchdogStopIsCleanAndIdempotent(t *testing.T) {
+	w := newStreamIdleWatchdog(context.Background(), 50*time.Millisecond)
+	w.stop()
+	w.stop()
+	if w.ctx.Err() == nil {
+		t.Fatal("expected context canceled after stop")
+	}
+}
+
+func TestStreamIdleWatchdogPassthroughWhenIdleNonPositive(t *testing.T) {
+	w := newStreamIdleWatchdog(context.Background(), 0)
+	defer w.stop()
+	w.ping()
+	select {
+	case <-w.ctx.Done():
+		t.Fatal("passthrough watchdog should not cancel on its own")
+	case <-time.After(80 * time.Millisecond):
+	}
+}
+
+func TestStreamIdleWatchdogStopDoesNotOverrideStallCause(t *testing.T) {
+	w := newStreamIdleWatchdog(context.Background(), 20*time.Millisecond)
+	<-w.ctx.Done()
+	w.stop()
+	if !errors.Is(context.Cause(w.ctx), ErrModelStreamStalled) {
+		t.Fatalf("stop overrode stall cause: %v", context.Cause(w.ctx))
+	}
+}

--- a/server/llm/types.go
+++ b/server/llm/types.go
@@ -600,6 +600,7 @@ type ReasoningSummaryDelta struct {
 type StreamCallbacks struct {
 	OnAssistantDelta        func(delta AssistantDelta)
 	OnReasoningSummaryDelta func(delta ReasoningSummaryDelta)
+	OnStreamActivity        func()
 }
 
 type StreamEventsClient interface {

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -475,6 +475,7 @@ func (e *Engine) SubmitUserMessage(ctx context.Context, text string) (assistant 
 		assistant = msg
 		return runErr
 	})
+	e.surfaceRunError(err)
 	return assistant, err
 }
 
@@ -495,6 +496,7 @@ func (e *Engine) SubmitWorkflowTurn(ctx context.Context) (assistant llm.Message,
 		assistant = msg
 		return runErr
 	})
+	e.surfaceRunError(err)
 	return assistant, err
 }
 
@@ -689,9 +691,8 @@ func (e *Engine) generateWithRetryClient(ctx context.Context, stepID string, cli
 	if err := e.observePromptCacheRequest(stepID, prepared); err != nil {
 		return llm.Response{}, err
 	}
-	delays := generateRetryDelays
 	var lastErr error
-	for i := 0; i <= len(delays); i++ {
+	for i := 0; ; i++ {
 		var (
 			resp                    llm.Response
 			attemptErr              error
@@ -761,7 +762,11 @@ func (e *Engine) generateWithRetryClient(ctx context.Context, stepID string, cli
 			onAttemptReset()
 		}
 		lastErr = attemptErr
-		if i == len(delays) {
+		delays := generateRetryDelays
+		if errors.Is(attemptErr, llm.ErrModelStreamStalled) {
+			delays = idleStallRetryDelays
+		}
+		if i >= len(delays) {
 			break
 		}
 		if err := waitForRetryDelay(ctx, delays[i]); err != nil {

--- a/server/runtime/engine_queue_submission.go
+++ b/server/runtime/engine_queue_submission.go
@@ -44,7 +44,9 @@ func (e *Engine) RunWhenIdleBeforeQueuedUserWork(ctx context.Context, fn func() 
 // messages or background notices. This is used when a non-turn busy operation
 // (for example manual compaction) completes while queued steering is waiting.
 func (e *Engine) SubmitQueuedUserMessages(ctx context.Context) (assistant llm.Message, err error) {
-	return e.submitQueuedUserMessages(ctx, nil)
+	assistant, err = e.submitQueuedUserMessages(ctx, nil)
+	e.surfaceRunError(err)
+	return assistant, err
 }
 
 func (e *Engine) submitQueuedUserMessages(ctx context.Context, queueItemIDs map[string]struct{}) (assistant llm.Message, err error) {

--- a/server/runtime/engine_queue_submission.go
+++ b/server/runtime/engine_queue_submission.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -226,10 +225,7 @@ func (e *Engine) processQueuedUserWork(ctx context.Context) {
 	}
 	ids := e.queuedUserAutoDrainIDSnapshot()
 	if _, err := e.submitQueuedUserMessages(ctx, ids); err != nil {
-		if errors.Is(err, context.Canceled) {
-			return
-		}
-		e.AppendCommittedEntry("error", fmt.Sprintf("queued steering continuation failed: %v", err))
+		e.surfaceRunError(err)
 		return
 	}
 	completed = true

--- a/server/runtime/engine_queue_submission_test.go
+++ b/server/runtime/engine_queue_submission_test.go
@@ -9,6 +9,7 @@ import (
 
 	"core/server/llm"
 	"core/server/tools"
+	"core/shared/transcript"
 )
 
 func TestSubmitQueuedUserMessagesStartsTurnFromQueuedInjection(t *testing.T) {
@@ -57,6 +58,37 @@ func TestSubmitQueuedUserMessagesStartsTurnFromQueuedInjection(t *testing.T) {
 	}
 	if !hasQueuedUser {
 		t.Fatalf("expected first request to include queued user message, got %+v", requestMessages(client.calls[0]))
+	}
+}
+
+func TestSubmitQueuedUserMessagesSurfacesRunError(t *testing.T) {
+	store := mustCreateTestSession(t)
+
+	client := &fakeClient{errors: []error{&llm.ProviderAPIError{
+		ProviderID: "openai",
+		Code:       llm.UnifiedErrorCodeProviderContract,
+		Message:    "provider down",
+	}}}
+	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(), Config{Model: "gpt-5"})
+
+	eng.QueueUserMessage("steer now")
+
+	if _, err := eng.SubmitQueuedUserMessages(context.Background()); err == nil {
+		t.Fatal("expected explicit queued submission to surface the model failure")
+	}
+
+	snapshot := eng.ChatSnapshot()
+	found := false
+	for _, entry := range snapshot.Entries {
+		if entry.Role == string(transcript.EntryRoleDeveloperErrorFeedback) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected explicit queued-drain failure to persist a developer error entry, got %+v", snapshot.Entries)
+	}
+	if snapshot.StreamingError == "" {
+		t.Fatal("expected explicit queued-drain failure to set the streaming error banner")
 	}
 }
 

--- a/server/runtime/goal.go
+++ b/server/runtime/goal.go
@@ -512,7 +512,7 @@ func (e *Engine) runGoalLoop(ctx context.Context, firstTurnAlreadyPrompted bool)
 				}
 				continue
 			}
-			e.recordGoalLoopError(err)
+			e.surfaceRunError(err)
 			return
 		}
 		appendNudge = true
@@ -555,11 +555,18 @@ func (e *Engine) waitBeforeGoalLoopBusyRetry(ctx context.Context) bool {
 	}
 }
 
-func (e *Engine) recordGoalLoopError(err error) {
-	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, errGoalLoopInactive) {
+func (e *Engine) surfaceRunError(err error) {
+	if err == nil ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, ErrAgentBusy) ||
+		errors.Is(err, errGoalLoopInactive) ||
+		errors.Is(err, ErrEngineClosed) {
 		return
 	}
-	message := "Goal loop stopped: " + err.Error()
+	message := llm.UserFacingError(err)
+	if message == "" {
+		message = err.Error()
+	}
 	if appendErr := e.steer("", steerLocalEntryIntent(storedLocalEntry{
 		Visibility: transcript.EntryVisibilityAuto,
 		Role:       string(transcript.EntryRoleDeveloperErrorFeedback),
@@ -568,7 +575,7 @@ func (e *Engine) recordGoalLoopError(err error) {
 		_ = e.steer("", steerLocalEntryIntent(storedLocalEntry{
 			Visibility: transcript.EntryVisibilityAuto,
 			Role:       string(transcript.EntryRoleDeveloperErrorFeedback),
-			Text:       "Failed to persist goal loop error: " + appendErr.Error(),
+			Text:       "Failed to persist run error: " + appendErr.Error(),
 		}))
 	}
 	e.SetStreamingError(message)

--- a/server/runtime/goal_test.go
+++ b/server/runtime/goal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -767,24 +768,69 @@ func TestGoalDeveloperMessageVisibleInOngoingWithDetailPrompt(t *testing.T) {
 	}
 }
 
-func TestRecordGoalLoopErrorPersistsOperatorFeedback(t *testing.T) {
+func TestSurfaceRunErrorPersistsOperatorFeedback(t *testing.T) {
 	store := mustCreateNamedTestSession(t, "workspace-x", "/tmp/workspace-x")
 	engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
 	if _, err := engine.SetGoal("ship goal mode", session.GoalActorUser); err != nil {
 		t.Fatalf("SetGoal: %v", err)
 	}
 
-	engine.recordGoalLoopError(errors.New("provider down"))
+	runErr := errors.New("provider down")
+	engine.surfaceRunError(runErr)
 
 	snapshot := engine.ChatSnapshot()
 	found := false
 	for _, entry := range snapshot.Entries {
-		if entry.Role == "developer_error_feedback" && strings.Contains(entry.Text, "Goal loop stopped: provider down") {
+		if entry.Role == string(transcript.EntryRoleDeveloperErrorFeedback) && entry.Text == runErr.Error() {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatalf("expected goal loop error entry, got %+v", snapshot.Entries)
+		t.Fatalf("expected surfaced run error entry, got %+v", snapshot.Entries)
+	}
+	if snapshot.StreamingError == "" {
+		t.Fatal("expected streaming error banner to be set")
+	}
+}
+
+func TestSurfaceRunErrorIgnoresBenignTerminations(t *testing.T) {
+	store := mustCreateNamedTestSession(t, "workspace-x", "/tmp/workspace-x")
+	engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+
+	for _, benign := range []error{nil, context.Canceled, ErrAgentBusy, errGoalLoopInactive, ErrEngineClosed} {
+		engine.surfaceRunError(benign)
+	}
+
+	snapshot := engine.ChatSnapshot()
+	for _, entry := range snapshot.Entries {
+		if entry.Role == string(transcript.EntryRoleDeveloperErrorFeedback) {
+			t.Fatalf("benign termination surfaced an error entry: %+v", entry)
+		}
+	}
+	if snapshot.StreamingError != "" {
+		t.Fatalf("benign termination set a streaming error banner: %q", snapshot.StreamingError)
+	}
+}
+
+func TestSurfaceRunErrorPrefersUserFacingMessageForStall(t *testing.T) {
+	store := mustCreateNamedTestSession(t, "workspace-x", "/tmp/workspace-x")
+	engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+
+	engine.surfaceRunError(fmt.Errorf("model generation failed after retries: %w", llm.ErrModelStreamStalled))
+
+	snapshot := engine.ChatSnapshot()
+	want := llm.UserFacingError(llm.ErrModelStreamStalled)
+	if want == "" {
+		t.Fatal("expected stall sentinel to have a user-facing message")
+	}
+	found := false
+	for _, entry := range snapshot.Entries {
+		if entry.Role == string(transcript.EntryRoleDeveloperErrorFeedback) && entry.Text == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected user-facing stall message entry, got %+v", snapshot.Entries)
 	}
 }
 

--- a/server/runtime/retry.go
+++ b/server/runtime/retry.go
@@ -6,6 +6,7 @@ import (
 )
 
 var generateRetryDelays = []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second, 16 * time.Second}
+var idleStallRetryDelays = []time.Duration{1 * time.Second}
 var compactionRetryDelays = []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second}
 
 func waitForRetryDelay(ctx context.Context, delay time.Duration) error {

--- a/server/runtime/retry_test.go
+++ b/server/runtime/retry_test.go
@@ -14,6 +14,15 @@ func withGenerateRetryDelays(t *testing.T, delays []time.Duration) {
 	})
 }
 
+func withIdleStallRetryDelays(t *testing.T, delays []time.Duration) {
+	t.Helper()
+	previous := idleStallRetryDelays
+	idleStallRetryDelays = append([]time.Duration(nil), delays...)
+	t.Cleanup(func() {
+		idleStallRetryDelays = previous
+	})
+}
+
 func withCompactionRetryDelays(t *testing.T, delays []time.Duration) {
 	t.Helper()
 	previous := compactionRetryDelays

--- a/server/runtime/stream_stall_retry_test.go
+++ b/server/runtime/stream_stall_retry_test.go
@@ -1,0 +1,66 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"core/server/llm"
+	"core/server/tools"
+)
+
+type countingFailingStreamClient struct {
+	calls atomic.Int32
+	err   error
+}
+
+func (c *countingFailingStreamClient) Generate(context.Context, llm.Request) (llm.Response, error) {
+	c.calls.Add(1)
+	return llm.Response{}, c.err
+}
+
+func (c *countingFailingStreamClient) GenerateStreamWithEvents(context.Context, llm.Request, llm.StreamCallbacks) (llm.Response, error) {
+	c.calls.Add(1)
+	return llm.Response{}, c.err
+}
+
+func TestGenerateWithRetryStalledStreamUsesReducedRetryBudget(t *testing.T) {
+	withGenerateRetryDelays(t, []time.Duration{0, 0, 0, 0, 0})
+	withIdleStallRetryDelays(t, []time.Duration{0})
+
+	store := mustCreateTestSession(t)
+	stall := &countingFailingStreamClient{err: fmt.Errorf("model stream stalled: %w", llm.ErrModelStreamStalled)}
+	eng := mustNewTestEngine(t, store, stall, tools.NewRegistry(), Config{Model: "gpt-5"})
+
+	if _, err := eng.generateWithRetryClient(context.Background(), "step-1", stall, llm.Request{Model: "gpt-5"}, nil, nil, nil); err == nil {
+		t.Fatal("expected stall failure after reduced retries")
+	}
+	if got := stall.calls.Load(); got != int32(len(idleStallRetryDelays)+1) {
+		t.Fatalf("stall attempts = %d, want %d", got, len(idleStallRetryDelays)+1)
+	}
+}
+
+func TestGenerateWithRetryGenericRetriableUsesFullRetryBudget(t *testing.T) {
+	withGenerateRetryDelays(t, []time.Duration{0, 0, 0, 0, 0})
+	withIdleStallRetryDelays(t, []time.Duration{0})
+
+	store := mustCreateTestSession(t)
+	retriable := &countingFailingStreamClient{err: &llm.APIStatusError{StatusCode: 503, Body: "overloaded"}}
+	eng := mustNewTestEngine(t, store, retriable, tools.NewRegistry(), Config{Model: "gpt-5"})
+
+	if _, err := eng.generateWithRetryClient(context.Background(), "step-1", retriable, llm.Request{Model: "gpt-5"}, nil, nil, nil); err == nil {
+		t.Fatal("expected failure after full retries")
+	}
+	if got := retriable.calls.Load(); got != int32(len(generateRetryDelays)+1) {
+		t.Fatalf("generic retriable attempts = %d, want %d", got, len(generateRetryDelays)+1)
+	}
+}
+
+func TestStatusFromRunErrorClassifiesStallAsFailed(t *testing.T) {
+	stall := fmt.Errorf("model generation failed after retries: %w", llm.ErrModelStreamStalled)
+	if status := statusFromRunError(stall); status != RunStatusFailed {
+		t.Fatalf("statusFromRunError(stall) = %v, want RunStatusFailed", status)
+	}
+}

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -15,6 +15,7 @@ import (
 	"core/server/metadata"
 	rpccontract "core/shared/apicontract"
 	"core/shared/client"
+	"core/shared/llmerrors"
 	"core/shared/protocol"
 	"core/shared/rpcwire"
 	"core/shared/serverapi"
@@ -333,6 +334,9 @@ func protocolError(err error) (int, string) {
 			message = canceledByClientMessage
 		}
 		return protocol.ErrCodeRequestCanceled, message
+	}
+	if errors.Is(err, llmerrors.ErrModelStreamStalled) {
+		return protocol.ErrCodeModelStreamStalled, message
 	}
 	if errors.Is(err, serverapi.ErrStreamGap) {
 		return protocol.ErrCodeStreamGap, message

--- a/server/transport/gateway_test.go
+++ b/server/transport/gateway_test.go
@@ -10,6 +10,7 @@ import (
 	shelltool "core/server/tools/shell"
 	rpccontract "core/shared/apicontract"
 	remoteclient "core/shared/client"
+	"core/shared/llmerrors"
 	"core/shared/protocol"
 	"core/shared/rpcwire"
 	"core/shared/serverapi"
@@ -69,6 +70,13 @@ func TestProtocolErrorMapsWorkflowTaskNotFound(t *testing.T) {
 	code, _ := protocolError(serverapi.ErrWorkflowTaskNotFound)
 	if code != protocol.ErrCodeWorkflowTaskNotFound {
 		t.Fatalf("protocol error code = %d, want %d", code, protocol.ErrCodeWorkflowTaskNotFound)
+	}
+}
+
+func TestProtocolErrorMapsModelStreamStalled(t *testing.T) {
+	code, _ := protocolError(fmt.Errorf("model generation failed after retries: %w", llmerrors.ErrModelStreamStalled))
+	if code != protocol.ErrCodeModelStreamStalled {
+		t.Fatalf("protocol error code = %d, want %d", code, protocol.ErrCodeModelStreamStalled)
 	}
 }
 

--- a/shared/client/remote_rpc.go
+++ b/shared/client/remote_rpc.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"core/shared/config"
+	"core/shared/llmerrors"
 	"core/shared/protocol"
 	"core/shared/rpcwire"
 	"core/shared/serverapi"
@@ -471,6 +472,8 @@ func protocolError(resp *protocol.ResponseError) error {
 			return serverapi.ErrServerAuthRequired
 		}
 		return errors.Join(serverapi.ErrServerAuthRequired, errors.New(message))
+	case protocol.ErrCodeModelStreamStalled:
+		return errors.Join(llmerrors.ErrModelStreamStalled, errors.New(message))
 	case protocol.ErrCodeStreamGap:
 		return errors.Join(serverapi.ErrStreamGap, errors.New(message))
 	case protocol.ErrCodeWorkspaceNotRegistered:

--- a/shared/client/remote_test.go
+++ b/shared/client/remote_test.go
@@ -11,10 +11,21 @@ import (
 	"time"
 
 	"core/shared/clientui"
+	"core/shared/llmerrors"
 	"core/shared/protocol"
 	"core/shared/serverapi"
 	"golang.org/x/net/websocket"
 )
+
+func TestProtocolErrorReconstructsModelStreamStalled(t *testing.T) {
+	err := protocolError(&protocol.ResponseError{Code: protocol.ErrCodeModelStreamStalled, Message: "model generation failed after retries: model stream stalled"})
+	if !errors.Is(err, llmerrors.ErrModelStreamStalled) {
+		t.Fatalf("reconstructed error = %v, want errors.Is ErrModelStreamStalled", err)
+	}
+	if llmerrors.UserFacingError(err) == "" {
+		t.Fatal("expected reconstructed stall error to map to a user-facing message")
+	}
+}
 
 func newRemoteTestServer(t *testing.T, handle func(*websocket.Conn)) *httptest.Server {
 	t.Helper()

--- a/shared/llmerrors/errors.go
+++ b/shared/llmerrors/errors.go
@@ -8,6 +8,8 @@ import (
 	"core/shared/auth"
 )
 
+var ErrModelStreamStalled = errors.New("model stream stalled")
+
 type APIStatusError struct {
 	StatusCode int
 	Body       string
@@ -202,6 +204,9 @@ func HasHTTPStatus(err error, statusCode int) bool {
 func UserFacingError(err error) string {
 	if err == nil {
 		return ""
+	}
+	if errors.Is(err, ErrModelStreamStalled) {
+		return "The model request stalled: no streaming activity within the timeout window (timeouts.model_request_seconds). The model may be overloaded; retry, or raise the timeout."
 	}
 	var providerSelectionErr *ProviderSelectionError
 	if errors.As(err, &providerSelectionErr) {

--- a/shared/protocol/jsonrpc.go
+++ b/shared/protocol/jsonrpc.go
@@ -35,6 +35,7 @@ const (
 	ErrCodeProtocolVersionMismatch       = -32025
 	ErrCodeWorkflowTaskCompleteAmbiguous = -32026
 	ErrCodeWorkflowTaskCompleteNotFound  = -32027
+	ErrCodeModelStreamStalled            = -32028
 )
 
 type Request struct {


### PR DESCRIPTION
## Problem
Streaming model requests shared the non-streaming **total** wall-clock timeout (`timeouts.model_request_seconds`, default 400s). A healthy long generation streaming continuously past it was guillotined mid-stream, `generateWithRetryClient` retried into the same wall (~40min), then the run failed. Worse, the failure ran under a detached context and was **never surfaced** to attached clients — it looked silently stuck.

## Part A — provider-agnostic stream idle watchdog
- `StreamCallbacks.OnStreamActivity func()` — each transport fires it on every raw stream event.
- A generic `idleWatchdogClient` **decorator** (`server/llm/stream_idle.go`) wraps any streaming client and is applied once at the provider factory, so it is not hardcoded into the OpenAI provider — any future provider gets it for free by firing the heartbeat. It owns a `context.WithCancelCause` child that cancels with the **retriable** `ErrModelStreamStalled` sentinel after an idle window with no activity; `ping()` resets the timer, `stop()` joins the goroutine.
- For streaming, the timeout is now a **per-event idle window** (measured from dispatch, so it also bounds time-to-first-event), letting a healthy long stream run past it while a dead stream fails fast. Non-streaming requests keep the total bound. No config key change, no value migration.
- A response that completes before the connection's EOF/`[DONE]` is **salvaged** rather than discarded as a stall.
- Genuine stalls fast-fail via a reduced retry budget (`idleStallRetryDelays`).

## Part B — surface dropped run failures
- `surfaceRunError(err)` persists an operator-facing error-feedback transcript entry **and** sets an ephemeral streaming-error banner for all non-interrupt run failures, across every model-driving entry point (goal loop, `SubmitUserMessage`, `SubmitWorkflowTurn`, the queued-drain path). Benign terminations (`context.Canceled`, `ErrAgentBusy`, `errGoalLoopInactive`, `ErrEngineClosed`) are excluded.
- The headless `kent run` printer now routes errors through `UserFacingError` (both the stderr text and the JSON `error.Message`), so a headless stall shows actionable guidance instead of the raw wrapped error.

## Tests
- Deterministic paced-SSE integration tests: healthy-long stream survives total wall-clock beyond idle; stall returns the retriable sentinel with parent ctx still live; parent-cancel stays distinguishable from a stall; completed-response salvage; per-event activity heartbeat.
- Watchdog unit tests (ping reset, fire-after-idle, idempotent stop, stop-does-not-override-stall-cause).
- Retry-classification, surfacing (emits banner + one entry, not on interrupt, no double-surface), and `runErrorMessage` routing/fallback tests.
- `./scripts/build.sh` + `./scripts/test.sh` on affected packages green; independent adversarial review found no correctness bugs.

## Notes
- Docs: `config.md` updated to describe the dual (streaming idle vs. non-streaming total) semantics of `model_request_seconds`.
- Live omlx manual QA was not run; coverage rests on the deterministic SSE/timing tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer handling for stalled AI streams, including a user-facing stall message and improved retry behavior.
  * Streaming responses now show activity updates so long-running requests are monitored more reliably.

* **Bug Fixes**
  * Prevented completed streamed responses from being discarded when a stall is detected late.
  * Improved error display in the CLI and runtime so users see more helpful messages instead of raw technical errors.

* **Documentation**
  * Clarified request timeout behavior for both standard and streaming model requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->