### PR TITLE
fix: order board rework cycles structurally

### DIFF
--- a/docs/dev/specs/workflow-editor.md
+++ b/docs/dev/specs/workflow-editor.md
@@ -22,7 +22,7 @@
 - Runtime/task state remains in Kanban and task detail. The editor edits workflow definitions, not live task execution.
 - The canvas renders start/backlog, agent, join, terminal/done, disconnected nodes, and node groups.
 - Join nodes are inspectable internal merge plumbing. Board/Kanban read models still omit join columns.
-- Board/Kanban column order is derived from workflow graph structure. Persisted node list order is not a board-order source; structurally ambiguous non-terminal sibling branches are ordered by node key, and reachable terminal columns sort after reachable non-terminal columns when graph precedence does not decide their order.
+- Board/Kanban column order is derived from workflow graph structure. Persisted node list order is not a board-order source; structurally ambiguous non-terminal sibling branches are ordered by node key, and reachable terminal columns sort after reachable non-terminal columns when graph precedence does not decide their order. Visible cycles from backward/rework transitions are ordered from their structural entry and graph-discovery order, so downstream review or gate nodes do not move before the upstream family that leads to them.
 - GUI-authored node groups are execution-shaped parallel groups. A saved node group contains branch nodes and one join; its fan-out is represented by one fan-out transition.
 - One-node node groups may exist only as unsaved invalid drafts while the operator is building the parallel group.
 - Agent nodes show name plus assignee role. Non-agent/no-role nodes have blank role line.

--- a/server/workflowview/board_order.go
+++ b/server/workflowview/board_order.go
@@ -136,6 +136,9 @@ func (g boardColumnGraph) topologicalVisibleNodeIDs(reachableVisibleIDs []string
 			componentByNodeID[nodeID] = componentID
 		}
 	}
+	for componentID, component := range components {
+		components[componentID] = g.structurallyOrderedComponentMembers(component, componentByNodeID, precedence)
+	}
 	componentEdges := make(map[int]map[int]bool, len(components))
 	indegree := make(map[int]int, len(components))
 	for componentID := range components {
@@ -168,12 +171,7 @@ func (g boardColumnGraph) topologicalVisibleNodeIDs(reachableVisibleIDs []string
 	emitted := make(map[int]bool, len(components))
 	for len(available) > 0 {
 		sort.SliceStable(available, func(i, j int) bool {
-			leftTerminal := g.componentHasTerminalNode(components[available[i]])
-			rightTerminal := g.componentHasTerminalNode(components[available[j]])
-			if leftTerminal != rightTerminal {
-				return !leftTerminal
-			}
-			return workflowNodeKeyLess(g.nodesByID[components[available[i]][0]], g.nodesByID[components[available[j]][0]])
+			return g.boardOrderComponentLess(components[available[i]], components[available[j]])
 		})
 		componentID := available[0]
 		available = available[1:]
@@ -184,12 +182,7 @@ func (g boardColumnGraph) topologicalVisibleNodeIDs(reachableVisibleIDs []string
 		emitted[componentID] = true
 		targetComponentIDs := mapIntKeys(componentEdges[componentID])
 		sort.SliceStable(targetComponentIDs, func(i, j int) bool {
-			leftTerminal := g.componentHasTerminalNode(components[targetComponentIDs[i]])
-			rightTerminal := g.componentHasTerminalNode(components[targetComponentIDs[j]])
-			if leftTerminal != rightTerminal {
-				return !leftTerminal
-			}
-			return workflowNodeKeyLess(g.nodesByID[components[targetComponentIDs[i]][0]], g.nodesByID[components[targetComponentIDs[j]][0]])
+			return g.boardOrderComponentLess(components[targetComponentIDs[i]], components[targetComponentIDs[j]])
 		})
 		for _, targetComponentID := range targetComponentIDs {
 			indegree[targetComponentID]--
@@ -221,7 +214,7 @@ func (g boardColumnGraph) stronglyConnectedVisibleComponents(nodeIDs []string, p
 	components := make([][]string, 0)
 	orderedNodeIDs := append([]string(nil), nodeIDs...)
 	sort.SliceStable(orderedNodeIDs, func(i, j int) bool {
-		return workflowNodeKeyLess(g.nodesByID[orderedNodeIDs[i]], g.nodesByID[orderedNodeIDs[j]])
+		return g.boardOrderNodeIDLess(orderedNodeIDs[i], orderedNodeIDs[j])
 	})
 	var visit func(string)
 	visit = func(nodeID string) {
@@ -232,7 +225,7 @@ func (g boardColumnGraph) stronglyConnectedVisibleComponents(nodeIDs []string, p
 		onStack[nodeID] = true
 		targetIDs := mapKeys(precedence[nodeID])
 		sort.SliceStable(targetIDs, func(i, j int) bool {
-			return workflowNodeKeyLess(g.nodesByID[targetIDs[i]], g.nodesByID[targetIDs[j]])
+			return g.boardOrderNodeIDLess(targetIDs[i], targetIDs[j])
 		})
 		for _, targetID := range targetIDs {
 			if _, seen := indexByNodeID[targetID]; !seen {
@@ -258,7 +251,7 @@ func (g boardColumnGraph) stronglyConnectedVisibleComponents(nodeIDs []string, p
 			}
 		}
 		sort.SliceStable(component, func(i, j int) bool {
-			return workflowNodeKeyLess(g.nodesByID[component[i]], g.nodesByID[component[j]])
+			return g.boardOrderNodeIDLess(component[i], component[j])
 		})
 		components = append(components, component)
 	}
@@ -268,6 +261,110 @@ func (g boardColumnGraph) stronglyConnectedVisibleComponents(nodeIDs []string, p
 		}
 	}
 	return components
+}
+
+func (g boardColumnGraph) structurallyOrderedComponentMembers(component []string, componentByNodeID map[string]int, precedence map[string]map[string]bool) []string {
+	if len(component) < 2 {
+		return append([]string(nil), component...)
+	}
+	componentSet := make(map[string]bool, len(component))
+	for _, nodeID := range component {
+		componentSet[nodeID] = true
+	}
+	roots := g.componentEntryNodeIDs(componentSet, componentByNodeID, precedence)
+	if len(roots) == 0 {
+		for _, nodeID := range g.startNodeIDs {
+			if componentSet[nodeID] {
+				roots = append(roots, nodeID)
+			}
+		}
+	}
+	if len(roots) == 0 {
+		sorted := append([]string(nil), component...)
+		sort.SliceStable(sorted, func(i, j int) bool {
+			return g.boardOrderNodeIDLess(sorted[i], sorted[j])
+		})
+		roots = append(roots, sorted[0])
+	}
+	sort.SliceStable(roots, func(i, j int) bool {
+		return g.boardOrderNodeIDLess(roots[i], roots[j])
+	})
+
+	ordered := make([]string, 0, len(component))
+	queued := make(map[string]bool, len(component))
+	queue := make([]string, 0, len(component))
+	for _, root := range roots {
+		if queued[root] {
+			continue
+		}
+		queued[root] = true
+		queue = append(queue, root)
+	}
+	for len(queue) > 0 {
+		nodeID := queue[0]
+		queue = queue[1:]
+		ordered = append(ordered, nodeID)
+		targetIDs := mapKeys(precedence[nodeID])
+		sort.SliceStable(targetIDs, func(i, j int) bool {
+			return g.boardOrderNodeIDLess(targetIDs[i], targetIDs[j])
+		})
+		for _, targetID := range targetIDs {
+			if !componentSet[targetID] || queued[targetID] {
+				continue
+			}
+			queued[targetID] = true
+			queue = append(queue, targetID)
+		}
+	}
+
+	unvisited := make([]string, 0, len(component)-len(ordered))
+	for _, nodeID := range component {
+		if !queued[nodeID] {
+			unvisited = append(unvisited, nodeID)
+		}
+	}
+	sort.SliceStable(unvisited, func(i, j int) bool {
+		return g.boardOrderNodeIDLess(unvisited[i], unvisited[j])
+	})
+	return append(ordered, unvisited...)
+}
+
+func (g boardColumnGraph) componentEntryNodeIDs(componentSet map[string]bool, componentByNodeID map[string]int, precedence map[string]map[string]bool) []string {
+	entries := make([]string, 0)
+	for sourceID, targetIDs := range precedence {
+		sourceComponent, sourceKnown := componentByNodeID[sourceID]
+		for targetID := range targetIDs {
+			if !componentSet[targetID] {
+				continue
+			}
+			targetComponent, targetKnown := componentByNodeID[targetID]
+			if !sourceKnown || !targetKnown || sourceComponent == targetComponent {
+				continue
+			}
+			entries = append(entries, targetID)
+		}
+	}
+	return dedupeStrings(entries)
+}
+
+func (g boardColumnGraph) boardOrderComponentLess(left []string, right []string) bool {
+	leftTerminal := g.componentHasTerminalNode(left)
+	rightTerminal := g.componentHasTerminalNode(right)
+	if leftTerminal != rightTerminal {
+		return !leftTerminal
+	}
+	return g.boardOrderNodeIDLess(left[0], right[0])
+}
+
+func (g boardColumnGraph) boardOrderNodeIDLess(leftID string, rightID string) bool {
+	left := g.nodesByID[leftID]
+	right := g.nodesByID[rightID]
+	leftTerminal := workflow.NodeKind(left.Kind) == workflow.NodeKindTerminal
+	rightTerminal := workflow.NodeKind(right.Kind) == workflow.NodeKindTerminal
+	if leftTerminal != rightTerminal {
+		return !leftTerminal
+	}
+	return workflowNodeKeyLess(left, right)
 }
 
 func (g boardColumnGraph) componentHasTerminalNode(component []string) bool {

--- a/server/workflowview/board_order.go
+++ b/server/workflowview/board_order.go
@@ -213,9 +213,7 @@ func (g boardColumnGraph) stronglyConnectedVisibleComponents(nodeIDs []string, p
 	nextIndex := 0
 	components := make([][]string, 0)
 	orderedNodeIDs := append([]string(nil), nodeIDs...)
-	sort.SliceStable(orderedNodeIDs, func(i, j int) bool {
-		return g.boardOrderNodeIDLess(orderedNodeIDs[i], orderedNodeIDs[j])
-	})
+	g.sortNodeIDsByBoardOrder(orderedNodeIDs)
 	var visit func(string)
 	visit = func(nodeID string) {
 		indexByNodeID[nodeID] = nextIndex
@@ -224,9 +222,7 @@ func (g boardColumnGraph) stronglyConnectedVisibleComponents(nodeIDs []string, p
 		stack = append(stack, nodeID)
 		onStack[nodeID] = true
 		targetIDs := mapKeys(precedence[nodeID])
-		sort.SliceStable(targetIDs, func(i, j int) bool {
-			return g.boardOrderNodeIDLess(targetIDs[i], targetIDs[j])
-		})
+		g.sortNodeIDsByBoardOrder(targetIDs)
 		for _, targetID := range targetIDs {
 			if _, seen := indexByNodeID[targetID]; !seen {
 				visit(targetID)
@@ -250,9 +246,7 @@ func (g boardColumnGraph) stronglyConnectedVisibleComponents(nodeIDs []string, p
 				break
 			}
 		}
-		sort.SliceStable(component, func(i, j int) bool {
-			return g.boardOrderNodeIDLess(component[i], component[j])
-		})
+		g.sortNodeIDsByBoardOrder(component)
 		components = append(components, component)
 	}
 	for _, nodeID := range orderedNodeIDs {
@@ -281,14 +275,10 @@ func (g boardColumnGraph) structurallyOrderedComponentMembers(component []string
 	}
 	if len(roots) == 0 {
 		sorted := append([]string(nil), component...)
-		sort.SliceStable(sorted, func(i, j int) bool {
-			return g.boardOrderNodeIDLess(sorted[i], sorted[j])
-		})
+		g.sortNodeIDsByBoardOrder(sorted)
 		roots = append(roots, sorted[0])
 	}
-	sort.SliceStable(roots, func(i, j int) bool {
-		return g.boardOrderNodeIDLess(roots[i], roots[j])
-	})
+	g.sortNodeIDsByBoardOrder(roots)
 
 	ordered := make([]string, 0, len(component))
 	queued := make(map[string]bool, len(component))
@@ -305,9 +295,7 @@ func (g boardColumnGraph) structurallyOrderedComponentMembers(component []string
 		queue = queue[1:]
 		ordered = append(ordered, nodeID)
 		targetIDs := mapKeys(precedence[nodeID])
-		sort.SliceStable(targetIDs, func(i, j int) bool {
-			return g.boardOrderNodeIDLess(targetIDs[i], targetIDs[j])
-		})
+		g.sortNodeIDsByBoardOrder(targetIDs)
 		for _, targetID := range targetIDs {
 			if !componentSet[targetID] || queued[targetID] {
 				continue
@@ -323,9 +311,7 @@ func (g boardColumnGraph) structurallyOrderedComponentMembers(component []string
 			unvisited = append(unvisited, nodeID)
 		}
 	}
-	sort.SliceStable(unvisited, func(i, j int) bool {
-		return g.boardOrderNodeIDLess(unvisited[i], unvisited[j])
-	})
+	g.sortNodeIDsByBoardOrder(unvisited)
 	return append(ordered, unvisited...)
 }
 
@@ -365,6 +351,12 @@ func (g boardColumnGraph) boardOrderNodeIDLess(leftID string, rightID string) bo
 		return !leftTerminal
 	}
 	return workflowNodeKeyLess(left, right)
+}
+
+func (g boardColumnGraph) sortNodeIDsByBoardOrder(nodeIDs []string) {
+	sort.SliceStable(nodeIDs, func(i, j int) bool {
+		return g.boardOrderNodeIDLess(nodeIDs[i], nodeIDs[j])
+	})
 }
 
 func (g boardColumnGraph) componentHasTerminalNode(component []string) bool {

--- a/server/workflowview/board_order_test.go
+++ b/server/workflowview/board_order_test.go
@@ -1,0 +1,61 @@
+package workflowview
+
+import (
+	"strings"
+	"testing"
+
+	"core/server/workflow"
+	"core/shared/serverapi"
+)
+
+func TestBoardColumnsOrderVisibleReworkCycleByStructuralEntry(t *testing.T) {
+	def := serverapi.WorkflowDefinition{
+		Workflow: serverapi.WorkflowRecord{ID: "workflow-1"},
+		NodeGroups: []serverapi.WorkflowNodeGroup{
+			{GroupID: "group-code-review-parallel", GroupKey: "code_review_parallel", DisplayName: "Code Review Parallel"},
+		},
+		Nodes: []serverapi.WorkflowNode{
+			{ID: "node-backlog", Key: "backlog", Kind: string(workflow.NodeKindStart), DisplayName: "Backlog"},
+			{ID: "node-implementation", Key: "implementation", Kind: string(workflow.NodeKindAgent), DisplayName: "Implementation"},
+			{ID: "node-approval-gate", Key: "approval_gate", Kind: string(workflow.NodeKindAgent), DisplayName: "Approval gate"},
+			{ID: "node-code-review", Key: "code_review", Kind: string(workflow.NodeKindAgent), DisplayName: "Code Review", GroupID: "group-code-review-parallel"},
+			{ID: "node-qa", Key: "qa", Kind: string(workflow.NodeKindAgent), DisplayName: "QA", GroupID: "group-code-review-parallel"},
+			{ID: "node-code-review-join", Key: "code_review_parallel_join", Kind: string(workflow.NodeKindJoin), DisplayName: "Code Review Join", GroupID: "group-code-review-parallel"},
+			{ID: "node-pr-autoreview", Key: "pr_autoreview", Kind: string(workflow.NodeKindAgent), DisplayName: "PR Autoreview"},
+			{ID: "node-done", Key: "done", Kind: string(workflow.NodeKindTerminal), DisplayName: "Done"},
+		},
+		TransitionGroups: []serverapi.WorkflowTransitionGroup{
+			{ID: "transition-backlog", SourceNodeID: "node-backlog", TransitionID: "start"},
+			{ID: "transition-implementation", SourceNodeID: "node-implementation", TransitionID: "review"},
+			{ID: "transition-code-review", SourceNodeID: "node-code-review", TransitionID: "join"},
+			{ID: "transition-qa", SourceNodeID: "node-qa", TransitionID: "join"},
+			{ID: "transition-code-review-join", SourceNodeID: "node-code-review-join", TransitionID: "approval_gate"},
+			{ID: "transition-approval-approved", SourceNodeID: "node-approval-gate", TransitionID: "approved"},
+			{ID: "transition-approval-rejected", SourceNodeID: "node-approval-gate", TransitionID: "rejected"},
+			{ID: "transition-pr-autoreview", SourceNodeID: "node-pr-autoreview", TransitionID: "done"},
+		},
+		Edges: []serverapi.WorkflowEdge{
+			{ID: "edge-start", TransitionGroupID: "transition-backlog", Key: "start", TargetNodeID: "node-implementation"},
+			{ID: "edge-code-review", TransitionGroupID: "transition-implementation", Key: "code_review", TargetNodeID: "node-code-review"},
+			{ID: "edge-qa", TransitionGroupID: "transition-implementation", Key: "qa", TargetNodeID: "node-qa"},
+			{ID: "edge-code-review-join", TransitionGroupID: "transition-code-review", Key: "join", TargetNodeID: "node-code-review-join"},
+			{ID: "edge-qa-join", TransitionGroupID: "transition-qa", Key: "join", TargetNodeID: "node-code-review-join"},
+			{ID: "edge-approval-gate", TransitionGroupID: "transition-code-review-join", Key: "approval_gate", TargetNodeID: "node-approval-gate"},
+			{ID: "edge-approved", TransitionGroupID: "transition-approval-approved", Key: "approved", TargetNodeID: "node-pr-autoreview"},
+			{ID: "edge-rejected", TransitionGroupID: "transition-approval-rejected", Key: "rejected", TargetNodeID: "node-implementation"},
+			{ID: "edge-done", TransitionGroupID: "transition-pr-autoreview", Key: "done", TargetNodeID: "node-done"},
+		},
+	}
+
+	keys := workflowViewBoardColumnKeys(boardColumns(def))
+	wantKeys := []string{"backlog", "implementation", "code_review", "qa", "approval_gate", "pr_autoreview", "done"}
+	if strings.Join(keys, ",") != strings.Join(wantKeys, ",") {
+		t.Fatalf("board column keys = %+v, want structural rework-cycle order %+v", keys, wantKeys)
+	}
+
+	groups := boardGroups(def)
+	wantNodeIDs := []string{"node-code-review", "node-qa"}
+	if len(groups) != 1 || strings.Join(groups[0].NodeIDs, ",") != strings.Join(wantNodeIDs, ",") {
+		t.Fatalf("board groups = %+v, want visible group node ids %+v", groups, wantNodeIDs)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix workflow board column ordering for visible rework cycles that include grouped parallel review branches and a hidden join.
- Order visible SCC members from structural entry/discovery order so Implementation stays before Code Review/QA and Approval Gate.
- Add a focused backend regression test for the Main-SWE-shaped fan-out/join/rework workflow and document the cycle ordering contract.

## Verification
- `./scripts/test.sh ./server/workflowview -run TestBoardColumnsOrderVisibleReworkCycleByStructuralEntry`
- `./scripts/test.sh ./server/workflowview -run 'TestBoardColumns|TestBoardGroups'`
- `./scripts/test.sh ./server/workflowview`
- `./scripts/build.sh --output ./bin/kent`
- Code review subagent reported no issues.

## Additional QA Evidence
- `/tmp/bui171-53173-board-columns.json`: manual JSON-RPC `workflow.board.get` against the built worktree binary on isolated port 53173 returned columns `backlog -> implementation -> code_review -> qa -> approval_gate -> pr_autoreview -> done`; join node was omitted from columns.
- `/tmp/bui171-workflowview-go-test-json.log`: `go test -json ./server/workflowview -run "TestBoardColumnsOrderVisibleReworkCycleByStructuralEntry|TestBoardColumns|TestBoardGroups"` showed 8 relevant board ordering/grouping tests passed.
- `/tmp/bui171-boardmodel-test.log`: `pnpm --dir apps/desktop test -- BoardModel` completed with 81 files / 376 tests passed, including `apps/desktop/src/features/board/BoardModel.test.ts`.

Closes #452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved board column ordering for workflows with branching, terminal steps, and visible cycles so the display is more predictable and consistent.
  * Rework/cycle paths now follow a clearer structural order when shown on the board.

* **Documentation**
  * Updated the workflow editor specification to describe the new ordering rules more clearly.

* **Tests**
  * Added coverage for ordering behavior in visible rework-cycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->