### PR TITLE
fix: harden native stream debug invariants

### DIFF
--- a/cli/app/ui_native_surface.go
+++ b/cli/app/ui_native_surface.go
@@ -61,6 +61,7 @@ func (s *uiNativeSurface) ensure(width int, height int) bool {
 		scrollback.WithNormalBufferAvailability(s.normalBufferAvailableForBuffer),
 		scrollback.WithDelayedWriteErrorListener(s.delayedWriteErrorListener),
 		scrollback.WithAssistantMarkdownRenderer(s.assistantMarkdownRenderer),
+		scrollback.WithAssistantStreamPromotion(false),
 		scrollback.WithNormalBufferPreparation(),
 	)
 	s.surface = s.buffer
@@ -924,6 +925,9 @@ func (intent nativeStableDeliveryIntent) allowActiveStreamFinalizeFromText() boo
 }
 
 func (m *uiModel) nativeStableProjectionDeliveryError(intent nativeStableDeliveryIntent, reason string, previous tui.TranscriptProjection, current tui.TranscriptProjection) error {
+	if m != nil && m.debugMode {
+		return m.nativeStableProjectionInvariantError(intent.operationLabel(), reason, previous, current)
+	}
 	if intent.debugInvariantViolation() {
 		return m.nativeStableProjectionInvariantError(intent.operationLabel(), reason, previous, current)
 	}

--- a/cli/app/ui_native_surface_test.go
+++ b/cli/app/ui_native_surface_test.go
@@ -492,7 +492,7 @@ func TestNativeFinalAssistantStreamingUsesMarkdownProjection(t *testing.T) {
 	}
 }
 
-func TestNativeFinalAssistantStreamingPromotesMarkdownAcrossDeltas(t *testing.T) {
+func TestNativeFinalAssistantStreamingRendersMarkdownAcrossDeltasInMutableTail(t *testing.T) {
 	var out bytes.Buffer
 	m := newNativeSurfaceTestModel(&out)
 	if rendered := m.View(); rendered != "" {
@@ -519,19 +519,16 @@ func TestNativeFinalAssistantStreamingPromotesMarkdownAcrossDeltas(t *testing.T)
 	})
 	_ = collectCmdMessages(t, second.cmd)
 	plain := stripANSIAndTrimRight(out.String())
-	if strings.Contains(plain, "**") {
-		t.Fatalf("native stable stream promotion exposed raw markdown markers: %q", plain)
-	}
-	if !strings.Contains(plain, "rendered first") {
-		t.Fatalf("native stable stream promotion skipped first rendered row: %q", plain)
+	if plain != "" {
+		t.Fatalf("assistant delta wrote stable output before finalization: %q", plain)
 	}
 	tail := xansi.Strip(strings.Join(m.nativeSurface.AssistantStreamTailLines(), ""))
-	if !strings.Contains(tail, "second row") {
-		t.Fatalf("native rendered tail skipped second row: %q", tail)
+	if strings.Contains(tail, "**") || !strings.Contains(tail, "rendered first") || !strings.Contains(tail, "second row") {
+		t.Fatalf("native rendered tail did not hold rendered Markdown until finalization: %q", tail)
 	}
 }
 
-func TestNativeFinalAssistantStreamingContinuesActiveParagraphAfterStableBlockPromotion(t *testing.T) {
+func TestNativeFinalAssistantStreamingContinuesActiveParagraphInMutableTail(t *testing.T) {
 	var out bytes.Buffer
 	m := newSizedProjectedClosedUIModel(nil, 157, 36, WithUINativeSurfaceWriter(&out))
 	if rendered := m.View(); rendered != "" {
@@ -546,8 +543,8 @@ func TestNativeFinalAssistantStreamingContinuesActiveParagraphAfterStableBlockPr
 		AssistantDeltaPhase: clientui.MessagePhaseFinal,
 	})
 	_ = collectCmdMessages(t, first.cmd)
-	if plain := stripANSIAndTrimRight(out.String()); !strings.Contains(plain, "Fixed and committed") {
-		t.Fatalf("completed first markdown block was not promoted after next block started: %q", plain)
+	if plain := stripANSIAndTrimRight(out.String()); plain != "" {
+		t.Fatalf("assistant delta wrote stable output before finalization: %q", plain)
 	}
 
 	continued := applyNativeSurfaceRuntimeEventForTest(t, m, clientui.Event{
@@ -558,7 +555,7 @@ func TestNativeFinalAssistantStreamingContinuesActiveParagraphAfterStableBlockPr
 	})
 	_ = collectCmdMessages(t, continued.cmd)
 	tail := xansi.Strip(strings.Join(m.nativeSurface.AssistantStreamTailLines(), ""))
-	if !strings.Contains(tail, "Whatever comes next") {
+	if !strings.Contains(tail, "Fixed and committed") || !strings.Contains(tail, "Whatever comes next") {
 		t.Fatalf("native rendered tail skipped continued active paragraph: %q", tail)
 	}
 }
@@ -723,9 +720,42 @@ func TestNativeFinalAssistantStreamingHoldsUnclosedFenceWithBlankLine(t *testing
 	})
 	_ = collectCmdMessages(t, close.cmd)
 	plain := stripANSIAndTrimRight(out.String())
-	if !strings.Contains(plain, "line1") || !strings.Contains(plain, "line2") {
-		t.Fatalf("native rendered code promotion skipped fenced content: %q", plain)
+	if plain != "" {
+		t.Fatalf("closed fenced code block wrote stable output before finalization: %q", plain)
 	}
+	tail := xansi.Strip(strings.Join(m.nativeSurface.AssistantStreamTailLines(), ""))
+	if !strings.Contains(tail, "line1") || !strings.Contains(tail, "line2") {
+		t.Fatalf("native rendered code tail skipped fenced content: %q", tail)
+	}
+}
+
+func TestNativeFinalAssistantStreamingDoesNotPromoteRowsChangedByLaterCodeFence(t *testing.T) {
+	var out bytes.Buffer
+	m := newNativeSurfaceTestModel(&out)
+	if rendered := m.View(); rendered != "" {
+		t.Fatalf("native ongoing View() returned %q, want empty renderer payload", rendered)
+	}
+	out.Reset()
+
+	first := "Yes, restart the Kent server too.\n\n" +
+		"This PR changes both CLI/TUI-side native scrollback handling and server/runtime transcript event metadata. Restarting only the TUI can leave it connected to an old server emitting the old event shape/behavior.\n\n" +
+		"Use whatever you normally use to stop/start the daemon, or from this repo:\n\n" +
+		"```sh\n"
+	open := applyNativeSurfaceRuntimeEventForTest(t, m, clientui.Event{
+		Kind:                clientui.EventAssistantDelta,
+		StepID:              "step-final",
+		AssistantDelta:      first,
+		AssistantDeltaPhase: clientui.MessagePhaseFinal,
+	})
+	_ = collectCmdMessages(t, open.cmd)
+
+	more := applyNativeSurfaceRuntimeEventForTest(t, m, clientui.Event{
+		Kind:                clientui.EventAssistantDelta,
+		StepID:              "step-final",
+		AssistantDelta:      "kent",
+		AssistantDeltaPhase: clientui.MessagePhaseFinal,
+	})
+	_ = collectCmdMessages(t, more.cmd)
 }
 
 func TestNativeFinalAssistantStreamingKeepsMismatchedFenceMarkerOpen(t *testing.T) {
@@ -1154,8 +1184,8 @@ func TestNativeSurfaceResizeDisablesActiveNativeAssistantStreamBeforeFinalizer(t
 	if m.nativeSurface == nil || !m.nativeSurface.AssistantStreaming() {
 		t.Fatal("expected assistant delta to start native assistant streaming")
 	}
-	if !strings.Contains(stripANSIAndTrimRight(out.String()), "promoted prefix") {
-		t.Fatalf("assistant stream did not write promoted prefix setup output: %q", out.String())
+	if got := stripANSIAndTrimRight(out.String()); got != "" {
+		t.Fatalf("assistant stream wrote stable setup output before finalization: %q", got)
 	}
 	out.Reset()
 
@@ -2013,13 +2043,28 @@ func TestNativeStableWriteErrorDisablesNativeSurface(t *testing.T) {
 	if rendered := m.View(); rendered != "" {
 		t.Fatalf("native ongoing View() returned %q, want empty renderer payload", rendered)
 	}
-	result := applyNativeSurfaceRuntimeEventForTest(t, m, clientui.Event{
+	streamed := applyNativeSurfaceRuntimeEventForTest(t, m, clientui.Event{
 		Kind:                clientui.EventAssistantDelta,
 		StepID:              "step-final",
 		AssistantDelta:      strings.Repeat("x", 120) + "\n\nnext\n",
 		AssistantDeltaPhase: clientui.MessagePhaseFinal,
 	})
-	_ = collectCmdMessages(t, result.cmd)
+	_ = collectCmdMessages(t, streamed.cmd)
+	committed := applyNativeSurfaceRuntimeEventForTest(t, m, clientui.Event{
+		Kind:                       clientui.EventAssistantMessage,
+		StepID:                     "step-final",
+		CommittedTranscriptChanged: true,
+		TranscriptRevision:         1,
+		CommittedEntryCount:        1,
+		CommittedEntryStart:        0,
+		CommittedEntryStartSet:     true,
+		TranscriptEntries: []clientui.ChatEntry{{
+			Role:  "assistant",
+			Text:  strings.Repeat("x", 120) + "\n\nnext\n",
+			Phase: string(clientui.MessagePhaseFinal),
+		}},
+	})
+	_ = collectCmdMessages(t, committed.cmd)
 
 	if m.nativeLiveAreaError == nil {
 		t.Fatal("expected native stable write error to be recorded")
@@ -2117,7 +2162,7 @@ func TestNativeRecentTailHydrateDeliversRecoveredCommittedRows(t *testing.T) {
 	}
 }
 
-func TestNativeTranscriptPageRecoveryDisablesInsertedCommittedToolBeforeDeliveredTail(t *testing.T) {
+func TestNativeTranscriptPageRecoveryPanicsForInsertedCommittedToolBeforeDeliveredTailInDebug(t *testing.T) {
 	var out bytes.Buffer
 	m := newSizedProjectedClosedUIModel(nil, 120, 30, WithUINativeSurfaceWriter(&out), WithUIDebug(true))
 	previousClientEntries := nativeShellClientEntriesForTest("call-continue", "kent run --continue \"ab410dc6\" \"Fixed remaining\"", "continued")
@@ -2137,23 +2182,19 @@ func TestNativeTranscriptPageRecoveryDisablesInsertedCommittedToolBeforeDelivere
 	recoveredEntries := append([]clientui.ChatEntry{}, nativeWidePatchSummaryClientEntriesForTest()...)
 	recoveredEntries = append(recoveredEntries, previousClientEntries...)
 	recoveredEntries = append(recoveredEntries, nativeShellClientEntriesForTest("call-complete", "kent task complete --commentary 'Revised plan'", "completed")...)
-	exitMainThread := m.enterUIMainThread("native recovery inserted committed tool app test")
-	cmd := m.runtimeAdapter().applyRuntimeTranscriptPageWithRecovery(clientui.TranscriptPageRequest{}, clientui.TranscriptPage{
-		SessionID: "session-1",
-		Revision:  2,
-		Entries:   recoveredEntries,
-	}, clientui.TranscriptRecoveryCauseStreamGap)
-	exitMainThread()
-	_ = collectCmdMessages(t, cmd)
-
-	if m.nativeSurface != nil {
-		t.Fatal("non-contiguous recovery page should disable native")
-	}
-	if m.nativeLiveAreaError == nil {
-		t.Fatal("non-contiguous recovery page did not surface native error")
-	}
-	if !strings.Contains(m.nativeLiveAreaError.Error(), nativeStableProjectionNonContiguousReason) {
-		t.Fatalf("native error = %v, want non-contiguous reason", m.nativeLiveAreaError)
+	panicText := captureNativeSurfacePanicText(t, func() {
+		exitMainThread := m.enterUIMainThread("native recovery inserted committed tool app test")
+		_ = m.runtimeAdapter().applyRuntimeTranscriptPageWithRecovery(clientui.TranscriptPageRequest{}, clientui.TranscriptPage{
+			SessionID: "session-1",
+			Revision:  2,
+			Entries:   recoveredEntries,
+		}, clientui.TranscriptRecoveryCauseStreamGap)
+		exitMainThread()
+	})
+	if !strings.Contains(panicText, "Native scrollback invariant violation") ||
+		!strings.Contains(panicText, nativeStableProjectionNonContiguousReason) ||
+		!strings.Contains(panicText, "operation=deliverNativeStableProjectionChange") {
+		t.Fatalf("panic = %q, want debug native stable invariant diagnostic", panicText)
 	}
 	plain := stripANSIAndTrimRight(out.String())
 	if strings.Contains(plain, nativeWidePatchSummaryPathForTest) || strings.Contains(plain, "kent task complete") {
@@ -3221,7 +3262,7 @@ func TestNativeStableAppendWithActiveStreamRejectsLaterMatchingFinalizer(t *test
 	}
 }
 
-func TestNativeStableAppendWithActiveStreamRecoveryMismatchReturnsErrorWithoutPanic(t *testing.T) {
+func TestNativeStableAppendWithActiveStreamRecoveryMismatchPanicsInDebug(t *testing.T) {
 	var out bytes.Buffer
 	m := newSizedProjectedClosedUIModel(nil, 120, 30, WithUINativeSurfaceWriter(&out), WithUIDebug(true))
 	if rendered := m.View(); rendered != "" {
@@ -3248,18 +3289,22 @@ func TestNativeStableAppendWithActiveStreamRecoveryMismatchReturnsErrorWithoutPa
 	}})
 	current.Blocks = append(current.Blocks, mismatched.Blocks[0])
 
-	exitMainThread := m.enterUIMainThread("native active stream recovery mismatch test")
-	err := m.deliverNativeStableProjectionChange(nativeStableRecoveryReconcileIntent("deliverNativeStableProjectionChange"), previous, current, true, true, false, "live active stream")
-	exitMainThread()
-	if err == nil {
-		t.Fatal("expected recovery mismatch to return an error")
+	panicText := captureNativeSurfacePanicText(t, func() {
+		exitMainThread := m.enterUIMainThread("native active stream recovery mismatch test")
+		_ = m.deliverNativeStableProjectionChange(nativeStableRecoveryReconcileIntent("deliverNativeStableProjectionChange"), previous, current, true, true, false, "live active stream")
+		exitMainThread()
+	})
+	if !strings.Contains(panicText, "Native scrollback invariant violation") ||
+		!strings.Contains(panicText, nativeStableProjectionActiveStreamMismatchReason) ||
+		!strings.Contains(panicText, "operation=deliverNativeStableProjectionChange") {
+		t.Fatalf("panic = %q, want debug native stable invariant diagnostic", panicText)
 	}
 	if got := out.String(); strings.Contains(got, "different committed assistant") {
 		t.Fatalf("recovery mismatch wrote committed assistant through native stable path: %q", got)
 	}
 }
 
-func TestNativeStableRecoveryReconcileReturnsErrorForInsertedCommittedToolBeforeDeliveredTailInDebug(t *testing.T) {
+func TestNativeStableRecoveryReconcilePanicsForInsertedCommittedToolBeforeDeliveredTailInDebug(t *testing.T) {
 	var out bytes.Buffer
 	m := newSizedProjectedClosedUIModel(nil, 120, 30, WithUINativeSurfaceWriter(&out), WithUIDebug(true))
 	if rendered := m.View(); rendered != "" {
@@ -3305,14 +3350,15 @@ func TestNativeStableRecoveryReconcileReturnsErrorForInsertedCommittedToolBefore
 		},
 	}}
 
-	exitMainThread := m.enterUIMainThread("native recovery inserted committed tool before delivered tail test")
-	err := m.deliverNativeStableProjectionChange(nativeStableRecoveryReconcileIntent("deliverNativeStableProjectionChange"), previous, current, true, false, false, "")
-	exitMainThread()
-	if err == nil {
-		t.Fatal("expected recovery reconcile to return an error")
-	}
-	if !strings.Contains(err.Error(), nativeStableProjectionNonContiguousReason) {
-		t.Fatalf("error = %v, want non-contiguous projection reason", err)
+	panicText := captureNativeSurfacePanicText(t, func() {
+		exitMainThread := m.enterUIMainThread("native recovery inserted committed tool before delivered tail test")
+		_ = m.deliverNativeStableProjectionChange(nativeStableRecoveryReconcileIntent("deliverNativeStableProjectionChange"), previous, current, true, false, false, "")
+		exitMainThread()
+	})
+	if !strings.Contains(panicText, "Native scrollback invariant violation") ||
+		!strings.Contains(panicText, nativeStableProjectionNonContiguousReason) ||
+		!strings.Contains(panicText, "operation=deliverNativeStableProjectionChange") {
+		t.Fatalf("panic = %q, want debug native stable invariant diagnostic", panicText)
 	}
 	if plain := stripANSIAndTrimRight(out.String()); strings.Contains(plain, "bui-142-queued-steering-compaction") || strings.Contains(plain, "kent task complete") {
 		t.Fatalf("recovery reconcile wrote non-contiguous committed rows into native scrollback: %q", plain)
@@ -3379,14 +3425,15 @@ func TestNativeStablePendingRecoveryIntentSurvivesLaterLiveAppendBeforeResizeSet
 		t.Fatalf("pending intent after later live append = %q, want recovery", m.nativePendingStableIntent.source)
 	}
 
-	exitMainThread = m.enterUIMainThread("native pending recovery resize settle")
-	err = m.deliverNativeStableProjectionChange(m.nativePendingStableIntent, previous, liveAfterRecovery, true, false, false, "")
-	exitMainThread()
-	if err == nil {
-		t.Fatal("expected recovery-shaped pending delivery to return non-contiguous error after resize settle")
-	}
-	if !strings.Contains(err.Error(), nativeStableProjectionNonContiguousReason) {
-		t.Fatalf("error = %v, want non-contiguous reason", err)
+	panicText := captureNativeSurfacePanicText(t, func() {
+		exitMainThread = m.enterUIMainThread("native pending recovery resize settle")
+		_ = m.deliverNativeStableProjectionChange(m.nativePendingStableIntent, previous, liveAfterRecovery, true, false, false, "")
+		exitMainThread()
+	})
+	if !strings.Contains(panicText, "Native scrollback invariant violation") ||
+		!strings.Contains(panicText, nativeStableProjectionNonContiguousReason) ||
+		!strings.Contains(panicText, "operation=deliverNativeStableProjectionChange") {
+		t.Fatalf("panic = %q, want debug native stable invariant diagnostic", panicText)
 	}
 	if plain := stripANSIAndTrimRight(out.String()); strings.Contains(plain, "bui-142-queued-steering-compaction") || strings.Contains(plain, "kent task complete") {
 		t.Fatalf("pending recovery wrote non-contiguous rows into native scrollback: %q", plain)
@@ -4151,7 +4198,7 @@ func TestNativeStableAppendsBackgroundNoticeAfterCompletedTurn(t *testing.T) {
 	}
 }
 
-func TestNativeStableTranscriptPageRecoveryDisablesActiveStreamMismatchWithoutPanic(t *testing.T) {
+func TestNativeStableTranscriptPageRecoveryPanicsOnActiveStreamMismatchInDebug(t *testing.T) {
 	var out bytes.Buffer
 	m := newSizedProjectedClosedUIModel(nil, 120, 30, WithUINativeSurfaceWriter(&out), WithUIDebug(true))
 	seedNativeSurfaceTranscript(m, []tui.TranscriptEntry{
@@ -4174,25 +4221,25 @@ func TestNativeStableTranscriptPageRecoveryDisablesActiveStreamMismatchWithoutPa
 	}
 	out.Reset()
 
-	exitMainThread := m.enterUIMainThread("native active stream mismatched page recovery test")
-	cmd := m.runtimeAdapter().applyRuntimeTranscriptPageWithRecovery(clientui.TranscriptPageRequest{}, clientui.TranscriptPage{
-		Revision: 2,
-		Entries: []clientui.ChatEntry{{
-			Role: "user",
-			Text: "prompt",
-		}, {
-			Role:  "assistant",
-			Text:  "corrected answer",
-			Phase: string(clientui.MessagePhaseFinal),
-		}},
-	}, clientui.TranscriptRecoveryCauseStreamGap)
-	exitMainThread()
-	_ = collectCmdMessages(t, cmd)
-	if m.nativeSurface != nil {
-		t.Fatal("mismatched page recovery should disable native")
-	}
-	if m.nativeLiveAreaError == nil {
-		t.Fatal("mismatched page recovery did not surface native error")
+	panicText := captureNativeSurfacePanicText(t, func() {
+		exitMainThread := m.enterUIMainThread("native active stream mismatched page recovery test")
+		_ = m.runtimeAdapter().applyRuntimeTranscriptPageWithRecovery(clientui.TranscriptPageRequest{}, clientui.TranscriptPage{
+			Revision: 2,
+			Entries: []clientui.ChatEntry{{
+				Role: "user",
+				Text: "prompt",
+			}, {
+				Role:  "assistant",
+				Text:  "corrected answer",
+				Phase: string(clientui.MessagePhaseFinal),
+			}},
+		}, clientui.TranscriptRecoveryCauseStreamGap)
+		exitMainThread()
+	})
+	if !strings.Contains(panicText, "Native scrollback invariant violation") ||
+		!strings.Contains(panicText, nativeStableProjectionActiveStreamMismatchReason) ||
+		!strings.Contains(panicText, "operation=deliverNativeStableProjectionChange") {
+		t.Fatalf("panic = %q, want debug native stable invariant diagnostic", panicText)
 	}
 	plain := stripANSIAndTrimRight(out.String())
 	if strings.Contains(plain, "draft answer") {

--- a/cli/tui/scrollback/ongoing_scrollback_buffer.go
+++ b/cli/tui/scrollback/ongoing_scrollback_buffer.go
@@ -29,6 +29,7 @@ type OngoingScrollbackBufferImpl struct {
 	isStreaming               bool
 	assistantMarkdownRenderer AssistantMarkdownRenderer
 	assistantStablePrefix     assistantStreamStablePrefixFunc
+	assistantStreamPromotion  bool
 	assistantStreamSource     string
 	assistantStreamPromoted   []assistantStreamPromotedRow
 	assistantStreamTail       []string
@@ -90,6 +91,12 @@ func WithAssistantMarkdownRenderer(renderer AssistantMarkdownRenderer) OngoingSc
 	}
 }
 
+func WithAssistantStreamPromotion(enabled bool) OngoingScrollbackBufferOption {
+	return func(buffer *OngoingScrollbackBufferImpl) {
+		buffer.assistantStreamPromotion = enabled
+	}
+}
+
 func WithNormalBufferPreparation() OngoingScrollbackBufferOption {
 	return func(buffer *OngoingScrollbackBufferImpl) {
 		buffer.prepareNormalBuffer = true
@@ -108,10 +115,11 @@ func NewOngoingScrollbackBufferImpl(ctx context.Context, terminalWidth int, term
 	}
 	watcherCtx, cancelWatcher := context.WithCancel(ctx)
 	buffer := &OngoingScrollbackBufferImpl{
-		cancelWatcher:  cancelWatcher,
-		stableWriter:   stableWriter,
-		terminalWidth:  terminalWidth,
-		terminalHeight: terminalHeight,
+		cancelWatcher:            cancelWatcher,
+		stableWriter:             stableWriter,
+		terminalWidth:            terminalWidth,
+		terminalHeight:           terminalHeight,
+		assistantStreamPromotion: true,
 	}
 	for _, option := range options {
 		if option != nil {
@@ -582,6 +590,9 @@ func (buffer *OngoingScrollbackBufferImpl) assistantStreamPromoteLimitLocked(row
 		return 0
 	}
 	promotedCount := len(buffer.assistantStreamPromoted)
+	if !buffer.assistantStreamPromotion {
+		return promotedCount
+	}
 	promoteLimit := 0
 	if prefix, ok := unstableAssistantMarkdownBlockStablePrefix(buffer.assistantStreamSource); ok {
 		if assistantMarkdownStablePrefixCanPromote(prefix) {

--- a/docs/dev/specs/ongoing-scrollback-buffer.md
+++ b/docs/dev/specs/ongoing-scrollback-buffer.md
@@ -61,11 +61,13 @@ All terminal buffer writes assert terminal-main-thread ownership. Blocking or no
 
 ## Assistant Streaming
 
-Assistant streaming is source-backed. `StreamMarkdownAssistantContent` appends incoming assistant content to the surface's active assistant stream state, renders the complete source through the assistant markdown projection for the active theme and terminal width, and promotes rendered projection rows into the stable zone through normal stable-write transactions. The mutable active rendered tail remains in surface state and is exposed as live-area tail lines for rendering with input, status, and pending chrome.
+Assistant streaming is source-backed. `StreamMarkdownAssistantContent` appends incoming assistant content to the surface's active assistant stream state, renders the complete source through the assistant markdown projection for the active theme and terminal width, and exposes the mutable active rendered tail as live-area tail lines for rendering with input, status, and pending chrome.
 
 The app keeps the active assistant stream source as transcript reconciliation state. Committed assistant finalization compares the authoritative committed projection against that source, not against live-area view text. Live-area text may be cleared or rehydrated independently; it must not decide whether a native active stream is the committed block being finalized.
 
 Partial assistant chunks must not be raw-written into normal-buffer scrollback. Stable stream rows are rendered markdown projection rows, not raw deltas or raw terminal wrapping. The active stream tail is the only mutable assistant stream content. `FinishAssistantStreaming` promotes the remaining rendered tail into the stable zone, flushes queued stable appends, clears active stream state, and restores the latest live area.
+
+Native streaming promotion is allowed only for renderers with a prefix-stability policy. A document-scoped Markdown renderer that can reinterpret earlier rows when later Markdown arrives keeps all assistant-stream rows in the mutable live tail until finalization.
 
 Already-promoted rendered stream rows are immutable. The immutability key is the canonical rendered terminal state for the row, including text, display width, per-cell style, per-cell hyperlinks, and final pen/link state after the row. Equivalent escape-sequence churn does not change the key. If re-rendering the source changes a promoted row's canonical terminal state, the surface fails fast instead of rewriting, restyling, clearing, or replaying stable scrollback content.
 
@@ -89,7 +91,7 @@ Native stable delivery uses explicit source policies:
 - Recovery reconcile: transcript page hydration, reconnect, and recent-tail recovery. A recovery page may append only a proven suffix or overlap and explicit local append-only rows. It must not start a compaction epoch, finalize an active native assistant stream, or write non-contiguous committed corrections into existing scrollback.
 - Geometry reproject: resize-only reconciliation of the delivered ledger. Geometry is not transcript authority and must not append transcript rows by itself.
 
-Runtime transcript reconciliation can produce an authoritative committed transcript replacement that is not appendable to already-emitted stable scrollback. In production and debug mode, recovery and geometry mismatches surface a native-surface error and disable native ongoing output so the standard renderer can continue from authoritative state; they do not append rewritten content, clear/replay history, or panic. In debug mode, live-append native scrollback developer errors and invariant violations fail fast with invariant diagnostics. Direct native stable append calls that violate the append-only contract remain invariant violations.
+Runtime transcript reconciliation can produce an authoritative committed transcript replacement that is not appendable to already-emitted stable scrollback. In production, recovery and geometry mismatches surface a native-surface error and disable native ongoing output so the standard renderer can continue from authoritative state. In debug mode, native projection mismatches fail fast with invariant diagnostics. They never append rewritten content or clear/replay history.
 
 Native committed-projection reconciliation compares terminal-visible block identity: render intent, divider group, rendered lines, and durable source identity. Source identity includes the committed entry range and payload identity so repeated committed rows with identical rendered text remain distinct across resize. UI-only metadata such as selection state, expanded state, and expandability does not affect native append or overlap detection because that metadata is not emitted to the terminal stable zone.
 


### PR DESCRIPTION
## Summary
- disable app-level mid-stream native stable promotion for the document-scoped Markdown renderer; assistant deltas stay in the mutable live tail until finalization
- make debug native recovery/geometry projection mismatches panic with invariant diagnostics instead of surfacing status-line fallback
- update native scrollback spec and regressions for the fenced-code crash and debug recovery behavior

## Verification
- ./scripts/test.sh ./cli/app -count=1
- ./scripts/test.sh ./cli/tui/scrollback ./cli/tui ./cli/app ./server/runtime
- ./scripts/build.sh --output ./bin/kent
- ./scripts/test.sh
- ./scripts/test.sh ./cli/app ./cli/tui/scrollback
- ./scripts/build.sh --output ./bin/kent