### PR TITLE
fix: recognize no-op configured subagent roles in workflows

### DIFF
--- a/cli/app/run_prompt_target.go
+++ b/cli/app/run_prompt_target.go
@@ -132,26 +132,25 @@ func validateRunPromptAgentRole(settings config.Settings, rawRole string, kentSe
 		return nil
 	}
 	roleName := override.Role
-	role, exists := settings.Subagents[roleName]
-	if !exists && roleName != config.BuiltInSubagentRoleFast {
+	lookup := config.LookupSubagentRole(settings, roleName)
+	if lookup.Status != config.SubagentRoleLookupPresent {
 		return fmt.Errorf("%w: %s. It may have been removed by the user during the session. Available roles: [%s]", errUnrecognizedSubagentRole, strconv.Quote(roleName), strings.Join(config.AvailableSubagentRoleNames(settings, kentSessionCaller), ", "))
 	}
-	if kentSessionCaller && !config.SubagentRoleCallable(role) {
+	if kentSessionCaller && !config.SubagentRoleCallable(lookup.Role) {
 		return errNonCallableSubagentRole
 	}
 	return nil
 }
 
 func validateContextAgentRoleCallable(settings config.Settings, rawRole string) error {
-	roleName := config.NormalizeSubagentSelector(rawRole)
-	if roleName == "" {
+	lookup := config.LookupSubagentRole(settings, rawRole)
+	if lookup.Status == config.SubagentRoleLookupInvalid {
 		return nil
 	}
-	role, exists := settings.Subagents[roleName]
-	if !exists && roleName != config.BuiltInSubagentRoleFast {
-		return fmt.Errorf("%w: %s. It may have been removed by the user during the session. Available roles: [%s]", errUnrecognizedSubagentRole, strconv.Quote(roleName), strings.Join(config.AvailableSubagentRoleNames(settings, true), ", "))
+	if lookup.Status == config.SubagentRoleLookupMissing {
+		return fmt.Errorf("%w: %s. It may have been removed by the user during the session. Available roles: [%s]", errUnrecognizedSubagentRole, strconv.Quote(*lookup.NormalizedSelector), strings.Join(config.AvailableSubagentRoleNames(settings, true), ", "))
 	}
-	if !config.SubagentRoleCallable(role) {
+	if !config.SubagentRoleCallable(lookup.Role) {
 		return errNonCallableSubagentRole
 	}
 	return nil

--- a/server/core/workflow_roles.go
+++ b/server/core/workflow_roles.go
@@ -19,10 +19,5 @@ func (r configRoleResolver) RoleExists(role string) bool {
 	if workflow.IsDefaultAgentRole(trimmed) {
 		return true
 	}
-	for _, available := range config.AvailableSubagentRoleNames(r.settings, false) {
-		if available == trimmed {
-			return true
-		}
-	}
-	return false
+	return config.LookupSubagentRole(r.settings, trimmed).Status == config.SubagentRoleLookupPresent
 }

--- a/server/core/workflow_roles_test.go
+++ b/server/core/workflow_roles_test.go
@@ -1,0 +1,158 @@
+package core
+
+import (
+	"slices"
+	"testing"
+
+	"core/server/workflow"
+	"core/shared/config"
+)
+
+func TestConfigRoleResolverUsesConfiguredRoleIdentity(t *testing.T) {
+	settings := config.Settings{
+		ThinkingLevel: "medium",
+		Subagents: map[string]config.SubagentRole{
+			"planner": {
+				Settings: config.Settings{ThinkingLevel: "medium"},
+				Sources:  map[string]string{"thinking_level": "file"},
+			},
+			"blocked": {
+				AgentCallable:    false,
+				AgentCallableSet: true,
+				Sources:          map[string]string{"agent_callable": "file"},
+			},
+		},
+	}
+	resolver := configRoleResolver{settings: settings}
+
+	tests := []struct {
+		name string
+		role string
+		want bool
+	}{
+		{name: "configured no-op role", role: " Planner ", want: true},
+		{name: "built-in fast role", role: config.BuiltInSubagentRoleFast, want: true},
+		{name: "configured non-callable role", role: "blocked", want: true},
+		{name: "workflow default role", role: workflow.DefaultAgentRole, want: true},
+		{name: "missing valid role", role: "missing", want: false},
+		{name: "reserved none role", role: "none", want: false},
+		{name: "reserved self role", role: "self", want: false},
+		{name: "invalid role", role: "plan/ner", want: false},
+		{name: "empty role", role: " \t ", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolver.RoleExists(tt.role); got != tt.want {
+				t.Fatalf("RoleExists(%q) = %v, want %v", tt.role, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkflowValidationUsesConfigRoleResolverIdentity(t *testing.T) {
+	settings := config.Settings{
+		ThinkingLevel: "medium",
+		Subagents: map[string]config.SubagentRole{
+			"planner": {
+				Settings: config.Settings{ThinkingLevel: "medium"},
+				Sources:  map[string]string{"thinking_level": "file"},
+			},
+		},
+	}
+
+	t.Run("configured no-op role", func(t *testing.T) {
+		result := workflow.ValidateDefinition(coreWorkflowValidationDefinition("planner"), workflow.ValidationOptions{
+			Context:      workflow.ValidationContextTaskCreation,
+			RoleResolver: configRoleResolver{settings: settings},
+		})
+
+		assertCoreWorkflowHasNoCode(t, result, workflow.CodeAgentRoleMissing)
+		if result.HasErrors() {
+			t.Fatalf("configured role workflow should validate, got errors: %+v", result.Errors)
+		}
+	})
+
+	for _, role := range []string{"missing", "plan/ner"} {
+		t.Run(role, func(t *testing.T) {
+			result := workflow.ValidateDefinition(coreWorkflowValidationDefinition(role), workflow.ValidationOptions{
+				Context:      workflow.ValidationContextTaskCreation,
+				RoleResolver: configRoleResolver{settings: settings},
+			})
+
+			assertCoreWorkflowHasCode(t, result, workflow.CodeAgentRoleMissing)
+		})
+	}
+}
+
+func coreWorkflowValidationDefinition(role string) workflow.Definition {
+	const (
+		workflowID        workflow.WorkflowID        = "0190f1aa-0000-7000-8000-000000000001"
+		startNodeID       workflow.NodeID            = "0190f1aa-0000-7000-8000-000000000002"
+		agentNodeID       workflow.NodeID            = "0190f1aa-0000-7000-8000-000000000003"
+		doneNodeID        workflow.NodeID            = "0190f1aa-0000-7000-8000-000000000004"
+		startGroupID      workflow.TransitionGroupID = "0190f1aa-0000-7000-8000-000000000005"
+		doneGroupID       workflow.TransitionGroupID = "0190f1aa-0000-7000-8000-000000000006"
+		startTransitionID workflow.TransitionID      = "start"
+		doneTransitionID  workflow.TransitionID      = "done"
+		startEdgeID       workflow.EdgeID            = "0190f1aa-0000-7000-8000-000000000009"
+		doneEdgeID        workflow.EdgeID            = "0190f1aa-0000-7000-8000-00000000000a"
+	)
+	return workflow.Definition{
+		ID:          workflowID,
+		DisplayName: "Config Roles",
+		Nodes: []workflow.Node{
+			coreWorkflowNode(workflowID, startNodeID, "start", "Start", workflow.NodeKindStart, workflow.NodeFields{}),
+			coreWorkflowNode(workflowID, agentNodeID, "agent", "Agent", workflow.NodeKindAgent, workflow.NodeFields{
+				SubagentRole:   role,
+				PromptTemplate: "Do work.",
+				OutputFields:   []workflow.OutputField{{Name: "summary", Description: "Summary of completed work."}},
+			}),
+			coreWorkflowNode(workflowID, doneNodeID, "done", "Done", workflow.NodeKindTerminal, workflow.NodeFields{}),
+		},
+		TransitionGroups: []workflow.TransitionGroup{
+			{WorkflowID: workflowID, ID: startGroupID, SourceNodeID: startNodeID, TransitionID: startTransitionID, DisplayName: "Start"},
+			{WorkflowID: workflowID, ID: doneGroupID, SourceNodeID: agentNodeID, TransitionID: doneTransitionID, DisplayName: "Done"},
+		},
+		Edges: []workflow.Edge{
+			{WorkflowID: workflowID, ID: startEdgeID, Key: "start", TransitionGroupID: startGroupID, TargetNodeID: agentNodeID, ContextMode: workflow.ContextModeNewSession, PromptTemplate: "Do work."},
+			{
+				WorkflowID:         workflowID,
+				ID:                 doneEdgeID,
+				Key:                "done",
+				TransitionGroupID:  doneGroupID,
+				TargetNodeID:       doneNodeID,
+				ContextMode:        workflow.ContextModeNewSession,
+				Parameters:         []workflow.Parameter{{Key: "summary", Description: "Summary of completed work."}},
+				OutputRequirements: []workflow.OutputRequirement{{FieldName: "summary"}},
+			},
+		},
+	}
+}
+
+func coreWorkflowNode(workflowID workflow.WorkflowID, id workflow.NodeID, key workflow.ModelKey, displayName string, kind workflow.NodeKind, fields workflow.NodeFields) workflow.Node {
+	node, err := workflow.NewNode(workflow.NodeIdentity{
+		WorkflowID:  workflowID,
+		ID:          id,
+		Key:         key,
+		DisplayName: displayName,
+	}, kind, fields)
+	if err != nil {
+		panic(err)
+	}
+	return node
+}
+
+func assertCoreWorkflowHasCode(t *testing.T, result workflow.ValidationResult, want workflow.ValidationErrorCode) {
+	t.Helper()
+	if !slices.Contains(result.Codes(), want) {
+		t.Fatalf("missing validation code %q in %v; errors: %+v", want, result.Codes(), result.Errors)
+	}
+}
+
+func assertCoreWorkflowHasNoCode(t *testing.T, result workflow.ValidationResult, code workflow.ValidationErrorCode) {
+	t.Helper()
+	if slices.Contains(result.Codes(), code) {
+		t.Fatalf("unexpected validation code %q in %v; errors: %+v", code, result.Codes(), result.Errors)
+	}
+}

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -201,17 +201,16 @@ func (p Planner) PlanSession(ctx context.Context, req SessionRequest) (SessionPl
 }
 
 func applyPersistedSubagentRoleSettings(base config.Settings, source config.SourceReport, roleName string, allowModelOverride bool, validate bool) (config.Settings, config.SourceReport, error) {
-	normalizedRole := config.NormalizeSubagentSelector(roleName)
-	if normalizedRole == "" {
+	lookup := config.LookupSubagentRole(base, roleName)
+	if lookup.Status == config.SubagentRoleLookupInvalid {
 		return base, source, nil
 	}
-	role, hasRole := base.Subagents[normalizedRole]
-	if !hasRole && normalizedRole != config.BuiltInSubagentRoleFast {
+	if lookup.Status == config.SubagentRoleLookupMissing {
 		return base, source, nil
 	}
 	providerSettings := cloneSettings(base)
-	applySubagentProviderOverrides(&providerSettings, role)
-	resolved, effectiveSource, _, err := resolveSubagentSettingsWithProviderID(base, source, normalizedRole, persistedRoleProviderID(providerSettings), allowModelOverride, validate)
+	applySubagentProviderOverrides(&providerSettings, lookup.Role)
+	resolved, effectiveSource, _, err := resolveSubagentSettingsWithProviderID(base, source, *lookup.NormalizedSelector, persistedRoleProviderID(providerSettings), allowModelOverride, validate)
 	if err != nil {
 		return config.Settings{}, config.SourceReport{}, err
 	}
@@ -219,15 +218,14 @@ func applyPersistedSubagentRoleSettings(base config.Settings, source config.Sour
 }
 
 func shouldApplyPersistedContinuationBaseURL(base config.Settings, roleName string) bool {
-	normalizedRole := config.NormalizeSubagentSelector(roleName)
-	if normalizedRole == "" {
+	lookup := config.LookupSubagentRole(base, roleName)
+	if lookup.Status == config.SubagentRoleLookupInvalid {
 		return true
 	}
-	role, hasRole := base.Subagents[normalizedRole]
-	if !hasRole && normalizedRole != config.BuiltInSubagentRoleFast {
+	if lookup.Status == config.SubagentRoleLookupMissing {
 		return false
 	}
-	_, hasRoleBaseURL := role.Sources["openai_base_url"]
+	_, hasRoleBaseURL := lookup.Role.Sources["openai_base_url"]
 	return !hasRoleBaseURL
 }
 
@@ -437,12 +435,8 @@ func mergeOverrideSources(base config.SourceReport, override config.SourceReport
 }
 
 func sourceReportWithSubagentRoleSources(base config.SourceReport, settings config.Settings, roleName string, allowModelOverride bool) config.SourceReport {
-	normalizedRole := config.NormalizeSubagentRole(roleName)
-	if normalizedRole == "" {
-		return base
-	}
-	role, ok := settings.Subagents[normalizedRole]
-	if !ok || len(role.Sources) == 0 {
+	lookup := config.LookupSubagentRole(settings, roleName)
+	if lookup.Status != config.SubagentRoleLookupPresent || len(lookup.Role.Sources) == 0 {
 		return base
 	}
 	next := base
@@ -450,7 +444,7 @@ func sourceReportWithSubagentRoleSources(base config.SourceReport, settings conf
 	if !allowModelOverride && strings.TrimSpace(next.Sources["model"]) == "default" {
 		next.Sources["model"] = "session"
 	}
-	for key := range role.Sources {
+	for key := range lookup.Role.Sources {
 		if key == "model" && !allowModelOverride {
 			continue
 		}

--- a/server/launch/subagents.go
+++ b/server/launch/subagents.go
@@ -14,17 +14,16 @@ import (
 const fastRoleSameAsMainWarning = "Warning: user configuration for fast agents is the same as for other agents. Consider asking the user to edit their config to pick a faster, smaller model at the end of your task. More info at " + config.DocsURL
 
 func resolveSubagentSettingsWithValidation(base config.Settings, providerBase config.Settings, baseSources map[string]string, roleName string, authState auth.State, allowModelOverride bool, validate bool) (config.Settings, string, error) {
-	normalizedRole := config.NormalizeSubagentSelector(roleName)
-	if normalizedRole == "" {
+	lookup := config.LookupSubagentRole(base, roleName)
+	switch lookup.Status {
+	case config.SubagentRoleLookupInvalid:
 		return config.Settings{}, "", fmt.Errorf("invalid subagent role %q", roleName)
-	}
-	role, hasRole := base.Subagents[normalizedRole]
-	if !hasRole && normalizedRole != config.BuiltInSubagentRoleFast {
-		return config.Settings{}, "", fmt.Errorf("Unrecognized role %q. It may have been removed by the user during the session. Available roles: [%s]", normalizedRole, strings.Join(config.AvailableSubagentRoleNames(base, false), ", "))
+	case config.SubagentRoleLookupMissing:
+		return config.Settings{}, "", fmt.Errorf("Unrecognized role %q. It may have been removed by the user during the session. Available roles: [%s]", *lookup.NormalizedSelector, strings.Join(config.AvailableSubagentRoleNames(base, false), ", "))
 	}
 	providerSettings := cloneSettings(providerBase)
 	providerSettings.Subagents = nil
-	applySubagentProviderOverrides(&providerSettings, role)
+	applySubagentProviderOverrides(&providerSettings, lookup.Role)
 	providerCaps, err := llm.ProviderCapabilitiesForSettings(authState, providerSettings)
 	if err != nil {
 		return config.Settings{}, "", err
@@ -32,7 +31,7 @@ func resolveSubagentSettingsWithValidation(base config.Settings, providerBase co
 	resolved, _, warning, err := resolveSubagentSettingsWithProviderID(
 		base,
 		config.SourceReport{Sources: baseSources},
-		normalizedRole,
+		*lookup.NormalizedSelector,
 		strings.TrimSpace(providerCaps.ProviderID),
 		allowModelOverride,
 		validate,
@@ -44,28 +43,27 @@ func resolveSubagentSettingsWithValidation(base config.Settings, providerBase co
 }
 
 func resolveSubagentSettingsWithProviderID(base config.Settings, baseSource config.SourceReport, roleName string, providerID string, allowModelOverride bool, validate bool) (config.Settings, config.SourceReport, string, error) {
-	normalizedRole := config.NormalizeSubagentSelector(roleName)
-	if normalizedRole == "" {
+	lookup := config.LookupSubagentRole(base, roleName)
+	switch lookup.Status {
+	case config.SubagentRoleLookupInvalid:
 		return config.Settings{}, config.SourceReport{}, "", fmt.Errorf("invalid subagent role %q", roleName)
-	}
-	role, hasRole := base.Subagents[normalizedRole]
-	if !hasRole && normalizedRole != config.BuiltInSubagentRoleFast {
-		return config.Settings{}, config.SourceReport{}, "", fmt.Errorf("Unrecognized role %q. It may have been removed by the user during the session. Available roles: [%s]", normalizedRole, strings.Join(config.AvailableSubagentRoleNames(base, false), ", "))
+	case config.SubagentRoleLookupMissing:
+		return config.Settings{}, config.SourceReport{}, "", fmt.Errorf("Unrecognized role %q. It may have been removed by the user during the session. Available roles: [%s]", *lookup.NormalizedSelector, strings.Join(config.AvailableSubagentRoleNames(base, false), ", "))
 	}
 	resolved := cloneSettings(base)
-	_ = applyBuiltInRoleHeuristics(&resolved, normalizedRole, strings.TrimSpace(providerID), allowModelOverride)
-	applySubagentRoleOverrides(&resolved, role, allowModelOverride)
-	effectiveSource := sourceReportWithSubagentRoleSources(baseSource, base, normalizedRole, allowModelOverride)
+	_ = applyBuiltInRoleHeuristics(&resolved, *lookup.NormalizedSelector, strings.TrimSpace(providerID), allowModelOverride)
+	applySubagentRoleOverrides(&resolved, lookup.Role, allowModelOverride)
+	effectiveSource := sourceReportWithSubagentRoleSources(baseSource, base, *lookup.NormalizedSelector, allowModelOverride)
 	effectiveSources := cloneStringMap(effectiveSource.Sources)
 	applyReviewerInheritance(&resolved, effectiveSources)
 	effectiveSource.Sources = effectiveSources
 	if validate {
 		if err := config.ValidateSettingsWithSources(resolved, effectiveSources); err != nil {
-			return config.Settings{}, config.SourceReport{}, "", fmt.Errorf("invalid subagent role %q: %w", normalizedRole, err)
+			return config.Settings{}, config.SourceReport{}, "", fmt.Errorf("invalid subagent role %q: %w", *lookup.NormalizedSelector, err)
 		}
 	}
 	warning := ""
-	if normalizedRole == config.BuiltInSubagentRoleFast && sameResolvedSubagentSettings(base, resolved) {
+	if *lookup.NormalizedSelector == config.BuiltInSubagentRoleFast && sameResolvedSubagentSettings(base, resolved) {
 		warning = fastRoleSameAsMainWarning
 	}
 	return resolved, effectiveSource, warning, nil

--- a/server/tools/ask_question_tool.go
+++ b/server/tools/ask_question_tool.go
@@ -18,18 +18,18 @@ import (
 // model-facing tool payload shape because internal approval workflows carry
 // fields that must never be exposed through the ask_question tool contract.
 type AskQuestionRequest struct {
-	ID                     string                                      `json:"-"`
-	Question               string                                      `json:"-"`
-	Suggestions            []string                                    `json:"-"`
-	RecommendedOptionIndex int                                         `json:"-"`
-	Approval               bool                                        `json:"-"`
-	ApprovalOptions        []AskQuestionApprovalOption                 `json:"-"`
-	Origin                 AskQuestionOrigin                           `json:"-"`
-	RunID                  string                                      `json:"-"`
-	StepID                 string                                      `json:"-"`
-	ToolCallID             string                                      `json:"-"`
-	QuestionBatch          *AskQuestionBatchMetadata                   `json:"-"`
-	AttentionTarget        *clientui.AttentionNotificationTarget       `json:"-"`
+	ID                     string                                `json:"-"`
+	Question               string                                `json:"-"`
+	Suggestions            []string                              `json:"-"`
+	RecommendedOptionIndex int                                   `json:"-"`
+	Approval               bool                                  `json:"-"`
+	ApprovalOptions        []AskQuestionApprovalOption           `json:"-"`
+	Origin                 AskQuestionOrigin                     `json:"-"`
+	RunID                  string                                `json:"-"`
+	StepID                 string                                `json:"-"`
+	ToolCallID             string                                `json:"-"`
+	QuestionBatch          *AskQuestionBatchMetadata             `json:"-"`
+	AttentionTarget        *clientui.AttentionNotificationTarget `json:"-"`
 }
 
 // AskQuestionToolRequest is the model-facing ask_question payload. Keep this limited to

--- a/server/workflowrunner/starter.go
+++ b/server/workflowrunner/starter.go
@@ -681,10 +681,8 @@ func (s *Starter) validateRole(role string) error {
 	if workflow.IsDefaultAgentRole(trimmed) {
 		return nil
 	}
-	for _, available := range config.AvailableSubagentRoleNames(s.cfg.Settings, false) {
-		if available == trimmed {
-			return nil
-		}
+	if config.LookupSubagentRole(s.cfg.Settings, trimmed).Status == config.SubagentRoleLookupPresent {
+		return nil
 	}
 	return fmt.Errorf("workflow validation failed: [%s]", workflow.CodeAgentRoleMissing)
 }

--- a/server/workflowrunner/starter_test.go
+++ b/server/workflowrunner/starter_test.go
@@ -1511,6 +1511,33 @@ func TestWorkflowRuntimeStartFailsWhenRoleDisappearedAfterTaskStart(t *testing.T
 	}
 }
 
+func TestWorkflowRuntimeStartsConfiguredNoOpRole(t *testing.T) {
+	fixture := newStarterFixture(t, config.WorkflowCompletionModeStructuredOutput,
+		ScriptedFinalAnswer(`{"commentary":"first comments","prior_summary":"first summary"}`),
+		ScriptedFinalAnswer(`{"commentary":"second done"}`),
+	)
+	fixture.cfg.Settings.Subagents["planner"] = config.SubagentRole{
+		Settings: config.Settings{ThinkingLevel: fixture.cfg.Settings.ThinkingLevel},
+		Sources:  map[string]string{"thinking_level": "test"},
+	}
+	fixture.rebuildStarter(t)
+	workflowID := createChainedStarterWorkflowWithContextMode(t, fixture.store, workflow.ContextModeNewSession, "planner")
+	if _, err := fixture.store.LinkWorkflow(context.Background(), fixture.projectID, workflowID, true); err != nil {
+		t.Fatalf("LinkWorkflow chained: %v", err)
+	}
+	task := fixture.createStartedTask(t)
+	scheduler := fixture.scheduler(t)
+
+	if err := scheduler.Process(context.Background()); err != nil {
+		t.Fatalf("first Process: %v", err)
+	}
+	fixture.waitForRunCount(t, task.ID, 2)
+	if err := scheduler.Process(context.Background()); err != nil {
+		t.Fatalf("second Process: %v", err)
+	}
+	fixture.waitForCompletedRunCount(t, task.ID, 2)
+}
+
 func TestWorkflowRuntimeStartFailsWhenTransitionPromptPreviewCannotRender(t *testing.T) {
 	fixture := newStarterFixture(t, config.WorkflowCompletionModeStructuredOutput, ScriptedFinalAnswer(`{"commentary":"should not run"}`))
 	finalizer := &recordingInterruptedRunFinalizer{}
@@ -1697,7 +1724,7 @@ func newStarterFixture(t *testing.T, mode config.WorkflowCompletionMode, steps .
 	if err := metadataStore.SetProjectKey(context.Background(), binding.ProjectID, "RUN"); err != nil {
 		t.Fatalf("SetProjectKey: %v", err)
 	}
-	store, err := workflowstore.New(metadataStore, workflowstore.WithRoleResolver(workflow.StaticRoleResolver{"coder": true, "reviewer": true}))
+	store, err := workflowstore.New(metadataStore, workflowstore.WithRoleResolver(workflow.StaticRoleResolver{"coder": true, "reviewer": true, "planner": true}))
 	if err != nil {
 		t.Fatalf("workflowstore.New: %v", err)
 	}

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -587,6 +587,89 @@ func TestSubagentRoleHasMeaningfulDiffComparesProviderReviewerAndTimeoutValues(t
 	}
 }
 
+func TestLookupSubagentRoleUsesConfiguredIdentity(t *testing.T) {
+	settings := Settings{
+		ThinkingLevel: "medium",
+		Subagents: map[string]SubagentRole{
+			"planner": {
+				Settings: Settings{ThinkingLevel: "medium"},
+				Sources:  map[string]string{"thinking_level": "file"},
+			},
+			"blocked": {
+				AgentCallable:    false,
+				AgentCallableSet: true,
+				Sources:          map[string]string{"agent_callable": "file"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		rawSelector    string
+		wantNormalized string
+		wantSelector   bool
+		wantStatus     SubagentRoleLookupStatus
+	}{
+		{name: "configured no-op role", rawSelector: " Planner ", wantNormalized: "planner", wantSelector: true, wantStatus: SubagentRoleLookupPresent},
+		{name: "configured non-callable role", rawSelector: "blocked", wantNormalized: "blocked", wantSelector: true, wantStatus: SubagentRoleLookupPresent},
+		{name: "built-in fast", rawSelector: BuiltInSubagentRoleFast, wantNormalized: BuiltInSubagentRoleFast, wantSelector: true, wantStatus: SubagentRoleLookupPresent},
+		{name: "missing valid role", rawSelector: "missing", wantNormalized: "missing", wantSelector: true, wantStatus: SubagentRoleLookupMissing},
+		{name: "reserved default", rawSelector: "default", wantStatus: SubagentRoleLookupInvalid},
+		{name: "reserved none", rawSelector: "none", wantStatus: SubagentRoleLookupInvalid},
+		{name: "reserved self", rawSelector: "self", wantStatus: SubagentRoleLookupInvalid},
+		{name: "empty after trim", rawSelector: " \t ", wantStatus: SubagentRoleLookupInvalid},
+		{name: "internal space", rawSelector: "plan ner", wantStatus: SubagentRoleLookupInvalid},
+		{name: "slash", rawSelector: "plan/ner", wantStatus: SubagentRoleLookupInvalid},
+		{name: "punctuation", rawSelector: "planner!", wantStatus: SubagentRoleLookupInvalid},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lookup := LookupSubagentRole(settings, tt.rawSelector)
+			if lookup.Status != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", lookup.Status, tt.wantStatus)
+			}
+			if got := lookup.NormalizedSelector != nil; got != tt.wantSelector {
+				t.Fatalf("normalized selector presence = %v, want %v", got, tt.wantSelector)
+			}
+			if tt.wantSelector && *lookup.NormalizedSelector != tt.wantNormalized {
+				t.Fatalf("normalized selector = %q, want %q", *lookup.NormalizedSelector, tt.wantNormalized)
+			}
+		})
+	}
+}
+
+func TestAvailableSubagentRoleNamesRemainsPresentationOnly(t *testing.T) {
+	settings := Settings{
+		ThinkingLevel: "medium",
+		Subagents: map[string]SubagentRole{
+			"planner": {
+				Settings: Settings{ThinkingLevel: "medium"},
+				Sources:  map[string]string{"thinking_level": "file"},
+			},
+			"callable": {
+				Settings: Settings{Model: "gpt-5.4-mini"},
+				Sources:  map[string]string{"model": "file"},
+			},
+			"blocked": {
+				Settings:         Settings{Model: "gpt-5.4-mini"},
+				Sources:          map[string]string{"model": "file"},
+				AgentCallable:    false,
+				AgentCallableSet: true,
+			},
+		},
+	}
+
+	all := strings.Join(AvailableSubagentRoleNames(settings, false), ",")
+	if all != "fast,blocked,callable" {
+		t.Fatalf("available presentation roles = %q, want no no-op role and all meaningful roles", all)
+	}
+	callable := strings.Join(AvailableSubagentRoleNames(settings, true), ",")
+	if callable != "fast,callable" {
+		t.Fatalf("callable presentation roles = %q, want no no-op or non-callable roles", callable)
+	}
+}
+
 func TestAppendSystemPromptFileFromConfigResolvesConfigRelativePath(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), ConfigDirName, "config.toml")
 	state := configRegistry.defaultState()

--- a/shared/config/subagents.go
+++ b/shared/config/subagents.go
@@ -80,6 +80,56 @@ func SubagentRoleCallable(role SubagentRole) bool {
 	return !role.AgentCallableSet || role.AgentCallable
 }
 
+type SubagentRoleLookupStatus string
+
+const (
+	SubagentRoleLookupInvalid SubagentRoleLookupStatus = "invalid"
+	SubagentRoleLookupMissing SubagentRoleLookupStatus = "missing"
+	SubagentRoleLookupPresent SubagentRoleLookupStatus = "present"
+)
+
+type SubagentRoleLookup struct {
+	Role               SubagentRole
+	NormalizedSelector *string
+	Status             SubagentRoleLookupStatus
+}
+
+// LookupSubagentRole resolves a subagent selector to configured role identity.
+// It treats built-in roles as present and does not apply presentation filters
+// such as meaningful-diff or callability checks.
+func LookupSubagentRole(settings Settings, rawSelector string) SubagentRoleLookup {
+	normalized := NormalizeSubagentSelector(rawSelector)
+	if normalized == "" {
+		return SubagentRoleLookup{Status: SubagentRoleLookupInvalid}
+	}
+	if normalized == BuiltInSubagentRoleFast {
+		return SubagentRoleLookup{
+			Role:               settings.Subagents[normalized],
+			NormalizedSelector: subagentRoleLookupSelector(normalized),
+			Status:             SubagentRoleLookupPresent,
+		}
+	}
+	role, ok := settings.Subagents[normalized]
+	if !ok {
+		return SubagentRoleLookup{
+			NormalizedSelector: subagentRoleLookupSelector(normalized),
+			Status:             SubagentRoleLookupMissing,
+		}
+	}
+	return SubagentRoleLookup{
+		Role:               role,
+		NormalizedSelector: subagentRoleLookupSelector(normalized),
+		Status:             SubagentRoleLookupPresent,
+	}
+}
+
+func subagentRoleLookupSelector(selector string) *string {
+	return &selector
+}
+
+// AvailableSubagentRoleNames returns presentation-ready role names. It filters
+// out configured roles that have no runtime diff from the base settings and can
+// optionally filter non-callable roles. Use LookupSubagentRole for existence.
 func AvailableSubagentRoleNames(settings Settings, agentCallableOnly bool) []string {
 	names := []string{}
 	if !agentCallableOnly || SubagentRoleCallable(settings.Subagents[BuiltInSubagentRoleFast]) {


### PR DESCRIPTION
## Summary
- Add canonical `shared/config` subagent role lookup with explicit invalid/missing/present states.
- Use configured role identity for workflow role resolution, so roles with `thinking_level = "medium"` are recognized even when that equals the base default.
- Consolidate launch and run-prompt role existence checks onto the canonical lookup while preserving callable/presentation filtering.
- Add regressions for no-op roles, non-callable roles, built-in `fast`, missing/reserved/invalid selectors, and workflow validation through `configRoleResolver`.

Closes #482.

## Verification
- `env -u KENT_PERSISTENCE_ROOT ./scripts/test.sh ./shared/config -run 'TestLookupSubagentRoleUsesConfiguredIdentity|TestAvailableSubagentRoleNamesRemainsPresentationOnly'`\n- `env -u KENT_PERSISTENCE_ROOT ./scripts/test.sh ./server/core -run 'TestConfigRoleResolverUsesConfiguredRoleIdentity|TestWorkflowValidationUsesConfigRoleResolverIdentity'`\n- `env -u KENT_PERSISTENCE_ROOT ./scripts/test.sh ./server/launch ./cli/app -run 'TestApplyRunPromptOverrides|TestPlanner|TestValidateRunPromptAgentRole|TestStartRunPromptClient'`\n- `./scripts/build.sh --output ./bin/kent`\n\nBroader focused package command still fails only on existing unrelated `TestSharedClientUIRemainsDTOOnly` / `AssistantStreamMetadata` allowlist issue in `shared/clientui`, which this PR does not touch.\n\n## QA Evidence\n- Manual QA used isolated `KENT_PERSISTENCE_ROOT=/tmp/kent-bui179-qa2.2GJoGw` and port `53180`.\n- Workflow validation succeeded for a no-op medium role and non-callable workflow assignee; missing/invalid roles still failed with `workflow.validation.agent_role_missing`; presentation lists still hid no-op/non-callable roles.\n- Transcript: `/var/folders/4y/3b8zshg92kn3ryxd1x2f1rs00000gn/T/kent-bg-shells-3580482598/1956.log`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved subagent role detection and validation, including clearer handling of built-in, configured, missing, and invalid roles.
  * Workflow role checks now more reliably recognize configured roles during validation and execution.

* **Bug Fixes**
  * Fixed cases where valid subagent roles could be treated as missing.
  * Improved error reporting for invalid or unrecognized roles.
  * Persisted subagent settings and continuation behavior now apply more consistently across role lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->