### PR TITLE
fix: clear stale worktree target on rebind

### DIFF
--- a/cli/app/internal/status/status.go
+++ b/cli/app/internal/status/status.go
@@ -335,8 +335,10 @@ func ExecutionTarget(req Request) clientui.SessionExecutionTarget {
 }
 
 func EnvironmentRoot(workspaceRoot string, target clientui.SessionExecutionTarget) string {
-	if worktreeRoot := strings.TrimSpace(target.WorktreeRoot); worktreeRoot != "" {
-		return worktreeRoot
+	if target.Worktree != nil {
+		if worktreeRoot := strings.TrimSpace(target.Worktree.Root); worktreeRoot != "" {
+			return worktreeRoot
+		}
 	}
 	if registeredWorkspaceRoot := strings.TrimSpace(target.WorkspaceRoot); registeredWorkspaceRoot != "" {
 		return registeredWorkspaceRoot
@@ -360,8 +362,11 @@ func Workdir(workspaceRoot string, target clientui.SessionExecutionTarget) strin
 
 func GitRoot(req Request) string {
 	target := ExecutionTarget(req)
-	if worktreeRoot := strings.TrimSpace(target.WorktreeRoot); worktreeRoot != "" {
-		return worktreeRoot
+	if target.Worktree != nil {
+		worktreeRoot := strings.TrimSpace(target.Worktree.Root)
+		if worktreeRoot != "" {
+			return worktreeRoot
+		}
 	}
 	if workspaceRoot := strings.TrimSpace(req.WorkspaceRoot); workspaceRoot != "" {
 		return workspaceRoot

--- a/cli/app/run_prompt_part2_test.go
+++ b/cli/app/run_prompt_part2_test.go
@@ -143,8 +143,8 @@ func TestRunPromptWorkspaceContextCreatesChildWithParentWorktreeContext(t *testi
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := metadataStore.UpdateSessionExecutionTargetByID(ctx, parent.Meta().SessionID, binding.WorkspaceID, "worktree-feature", "pkg"); err != nil {
-		t.Fatalf("UpdateSessionExecutionTargetByID parent: %v", err)
+	if err := metadataStore.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{SessionID: parent.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "worktree-feature"}, CwdRelpath: "pkg"}); err != nil {
+		t.Fatalf("UpdateSessionExecutionTarget parent: %v", err)
 	}
 	if err := parent.SetWorktreeReminderState(&session.WorktreeReminderState{
 		Mode:                  session.WorktreeReminderModeEnter,

--- a/cli/app/run_prompt_part2_test.go
+++ b/cli/app/run_prompt_part2_test.go
@@ -143,7 +143,7 @@ func TestRunPromptWorkspaceContextCreatesChildWithParentWorktreeContext(t *testi
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := metadataStore.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{SessionID: parent.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "worktree-feature"}, CwdRelpath: "pkg"}); err != nil {
+	if err := metadataStore.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{SessionID: parent.Meta().SessionID, Workspace: &metadata.SessionExecutionTargetUpdateWorkspace{ID: binding.WorkspaceID}, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "worktree-feature"}, CwdRelpath: "pkg"}); err != nil {
 		t.Fatalf("UpdateSessionExecutionTarget parent: %v", err)
 	}
 	if err := parent.SetWorktreeReminderState(&session.WorktreeReminderState{

--- a/cli/app/session_lifecycle_test.go
+++ b/cli/app/session_lifecycle_test.go
@@ -895,7 +895,7 @@ func TestReviewTeleportLifecyclePreservesParentWorktreeContext(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := metadataStore.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{SessionID: parent.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "worktree-review-lifecycle"}, CwdRelpath: "pkg"}); err != nil {
+	if err := metadataStore.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{SessionID: parent.Meta().SessionID, Workspace: &metadata.SessionExecutionTargetUpdateWorkspace{ID: binding.WorkspaceID}, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "worktree-review-lifecycle"}, CwdRelpath: "pkg"}); err != nil {
 		t.Fatalf("UpdateSessionExecutionTarget parent: %v", err)
 	}
 

--- a/cli/app/session_lifecycle_test.go
+++ b/cli/app/session_lifecycle_test.go
@@ -895,8 +895,8 @@ func TestReviewTeleportLifecyclePreservesParentWorktreeContext(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := metadataStore.UpdateSessionExecutionTargetByID(ctx, parent.Meta().SessionID, binding.WorkspaceID, "worktree-review-lifecycle", "pkg"); err != nil {
-		t.Fatalf("UpdateSessionExecutionTargetByID parent: %v", err)
+	if err := metadataStore.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{SessionID: parent.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "worktree-review-lifecycle"}, CwdRelpath: "pkg"}); err != nil {
+		t.Fatalf("UpdateSessionExecutionTarget parent: %v", err)
 	}
 
 	model := newProjectedStaticUIModel(
@@ -942,7 +942,7 @@ func TestReviewTeleportLifecyclePreservesParentWorktreeContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget child: %v", err)
 	}
-	if target.WorktreeID != "worktree-review-lifecycle" || target.CwdRelpath != "pkg" {
+	if target.Worktree == nil || target.Worktree.ID != "worktree-review-lifecycle" || target.CwdRelpath != "pkg" {
 		t.Fatalf("child target = %+v, want parent worktree target", target)
 	}
 	if target.EffectiveWorkdir != filepath.Join(canonicalWorktreeRoot, "pkg") {

--- a/cli/app/ui_status_part2_test.go
+++ b/cli/app/ui_status_part2_test.go
@@ -44,7 +44,7 @@ func TestStatusLineGitStartupUsesRuntimeWorktreeRootBranch(t *testing.T) {
 	runtimeClient := &runtimeControlFakeClient{sessionView: clientui.RuntimeSessionView{
 		ExecutionTarget: clientui.SessionExecutionTarget{
 			WorkspaceRoot:    workspaceRoot,
-			WorktreeRoot:     worktreeRoot,
+			Worktree:         &clientui.SessionExecutionWorktreeTarget{ID: "worktree-1", Root: worktreeRoot},
 			EffectiveWorkdir: processRoot,
 		},
 	}}

--- a/cli/app/ui_worktree_test_helpers_test.go
+++ b/cli/app/ui_worktree_test_helpers_test.go
@@ -166,8 +166,7 @@ func worktreeListResponseForRoots(mainRoot string, featureRoot string) serverapi
 		}},
 	}
 	if strings.TrimSpace(featureRoot) != "" {
-		resp.Target.WorktreeID = "wt-feature"
-		resp.Target.WorktreeRoot = featureRoot
+		resp.Target.Worktree = &clientui.SessionExecutionWorktreeTarget{ID: "wt-feature", Root: featureRoot}
 		resp.Target.EffectiveWorkdir = featureRoot
 		resp.Worktrees[0].IsCurrent = false
 		resp.Worktrees = append(resp.Worktrees, serverapi.WorktreeView{
@@ -189,8 +188,7 @@ func testLinkedWorktreeListResponse() serverapi.WorktreeListResponse {
 		Target: clientui.SessionExecutionTarget{
 			WorkspaceID:      "workspace-1",
 			WorkspaceRoot:    "/repo",
-			WorktreeID:       "wt-feature",
-			WorktreeRoot:     "/wt/feature-a",
+			Worktree:         &clientui.SessionExecutionWorktreeTarget{ID: "wt-feature", Root: "/wt/feature-a"},
 			EffectiveWorkdir: "/wt/feature-a/pkg",
 		},
 		Worktrees: []serverapi.WorktreeView{

--- a/server/core/repo_boundary_test.go
+++ b/server/core/repo_boundary_test.go
@@ -130,6 +130,7 @@ func TestSharedClientUIRemainsDTOOnly(t *testing.T) {
 		"RuntimeSubmitRequest":                     {},
 		"ReadModelVersion":                         {},
 		"SessionExecutionTarget":                   {},
+		"SessionExecutionWorktreeTarget":           {},
 		"SessionSummary":                           {},
 		"ToolCallMeta":                             {},
 		"ToolCallRenderBehavior":                   {},

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -34,7 +34,7 @@ const (
 // session execution target into a newly created child session.
 type MetadataExecutionTargetStore interface {
 	ResolveSessionExecutionTarget(ctx context.Context, sessionID string) (clientui.SessionExecutionTarget, error)
-	UpdateSessionExecutionTargetByID(ctx context.Context, sessionID string, workspaceID string, worktreeID string, cwdRelpath string) error
+	UpdateSessionExecutionTarget(ctx context.Context, update metadata.SessionExecutionTargetUpdate) error
 	DeleteSessionRecordByID(ctx context.Context, sessionID string) error
 	Close() error
 }
@@ -618,7 +618,7 @@ func (p Planner) updateChildExecutionTarget(ctx context.Context, childSessionID 
 		return err
 	}
 	defer func() { _ = store.Close() }()
-	return store.UpdateSessionExecutionTargetByID(ctx, childSessionID, target.WorkspaceID, target.WorktreeID, target.CwdRelpath)
+	return store.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdateFromReadModel(childSessionID, target))
 }
 
 func (p Planner) rollbackChildSession(child *session.Store) error {

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -780,7 +780,7 @@ func TestPlannerNewChildSessionPreservesParentWorktreeContext(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := metadataStore.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{SessionID: parent.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "worktree-review"}, CwdRelpath: "pkg"}); err != nil {
+	if err := metadataStore.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{SessionID: parent.Meta().SessionID, Workspace: &metadata.SessionExecutionTargetUpdateWorkspace{ID: binding.WorkspaceID}, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "worktree-review"}, CwdRelpath: "pkg"}); err != nil {
 		t.Fatalf("UpdateSessionExecutionTarget parent: %v", err)
 	}
 	if err := parent.SetWorktreeReminderState(&session.WorktreeReminderState{
@@ -1051,7 +1051,7 @@ func TestPlannerNewChildSessionRollsBackDurableChildWhenExecutionTargetCopyFails
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := metadataStore.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{SessionID: parent.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "worktree-review"}, CwdRelpath: "."}); err != nil {
+	if err := metadataStore.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{SessionID: parent.Meta().SessionID, Workspace: &metadata.SessionExecutionTargetUpdateWorkspace{ID: binding.WorkspaceID}, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "worktree-review"}, CwdRelpath: "."}); err != nil {
 		t.Fatalf("UpdateSessionExecutionTarget parent: %v", err)
 	}
 	beforeEntries, err := os.ReadDir(containerDir)

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -28,8 +28,8 @@ func (s *failingUpdateMetadataExecutionTargetStore) ResolveSessionExecutionTarge
 	return s.base.ResolveSessionExecutionTarget(ctx, sessionID)
 }
 
-func (s *failingUpdateMetadataExecutionTargetStore) UpdateSessionExecutionTargetByID(_ context.Context, sessionID string, _ string, _ string, _ string) error {
-	s.updatedSessionID = sessionID
+func (s *failingUpdateMetadataExecutionTargetStore) UpdateSessionExecutionTarget(_ context.Context, update metadata.SessionExecutionTargetUpdate) error {
+	s.updatedSessionID = update.SessionID
 	return s.updateErr
 }
 
@@ -780,8 +780,8 @@ func TestPlannerNewChildSessionPreservesParentWorktreeContext(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := metadataStore.UpdateSessionExecutionTargetByID(ctx, parent.Meta().SessionID, binding.WorkspaceID, "worktree-review", "pkg"); err != nil {
-		t.Fatalf("UpdateSessionExecutionTargetByID parent: %v", err)
+	if err := metadataStore.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{SessionID: parent.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "worktree-review"}, CwdRelpath: "pkg"}); err != nil {
+		t.Fatalf("UpdateSessionExecutionTarget parent: %v", err)
 	}
 	if err := parent.SetWorktreeReminderState(&session.WorktreeReminderState{
 		Mode:                  session.WorktreeReminderModeEnter,
@@ -843,8 +843,8 @@ func TestPlannerNewChildSessionPreservesParentWorktreeContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget child: %v", err)
 	}
-	if target.WorktreeID != "worktree-review" {
-		t.Fatalf("child worktree id = %q, want worktree-review", target.WorktreeID)
+	if target.Worktree == nil || target.Worktree.ID != "worktree-review" {
+		t.Fatalf("child worktree = %+v, want worktree-review", target.Worktree)
 	}
 	if target.CwdRelpath != "pkg" {
 		t.Fatalf("child cwd relpath = %q, want pkg", target.CwdRelpath)
@@ -1051,8 +1051,8 @@ func TestPlannerNewChildSessionRollsBackDurableChildWhenExecutionTargetCopyFails
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := metadataStore.UpdateSessionExecutionTargetByID(ctx, parent.Meta().SessionID, binding.WorkspaceID, "worktree-review", "."); err != nil {
-		t.Fatalf("UpdateSessionExecutionTargetByID parent: %v", err)
+	if err := metadataStore.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{SessionID: parent.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "worktree-review"}, CwdRelpath: "."}); err != nil {
+		t.Fatalf("UpdateSessionExecutionTarget parent: %v", err)
 	}
 	beforeEntries, err := os.ReadDir(containerDir)
 	if err != nil {

--- a/server/metadata/queries.sql
+++ b/server/metadata/queries.sql
@@ -3168,7 +3168,7 @@ SELECT
     CAST(COALESCE(json_extract(s.metadata_json, '$.workspace_container'), '') AS TEXT) AS workspace_snapshot_name,
     COALESCE(w.canonical_root_path, json_extract(s.metadata_json, '$.workspace_root'), '') AS workspace_root,
     s.worktree_id,
-    COALESCE(wt.canonical_root_path, '') AS worktree_root,
+    wt.canonical_root_path AS worktree_root,
     s.cwd_relpath
 FROM sessions s
 LEFT JOIN workspaces w ON w.id = s.workspace_id

--- a/server/metadata/sqlitegen/queries.sql.go
+++ b/server/metadata/sqlitegen/queries.sql.go
@@ -1768,7 +1768,7 @@ SELECT
     CAST(COALESCE(json_extract(s.metadata_json, '$.workspace_container'), '') AS TEXT) AS workspace_snapshot_name,
     COALESCE(w.canonical_root_path, json_extract(s.metadata_json, '$.workspace_root'), '') AS workspace_root,
     s.worktree_id,
-    COALESCE(wt.canonical_root_path, '') AS worktree_root,
+    wt.canonical_root_path AS worktree_root,
     s.cwd_relpath
 FROM sessions s
 LEFT JOIN workspaces w ON w.id = s.workspace_id
@@ -1784,7 +1784,7 @@ type GetSessionExecutionTargetByIDRow struct {
 	WorkspaceSnapshotName string
 	WorkspaceRoot         string
 	WorktreeID            sql.NullString
-	WorktreeRoot          string
+	WorktreeRoot          sql.NullString
 	CwdRelpath            string
 }
 

--- a/server/metadata/store.go
+++ b/server/metadata/store.go
@@ -97,10 +97,14 @@ func (e *WorktreeWorkspaceMismatchError) Error() string {
 }
 
 type SessionExecutionTargetUpdate struct {
-	SessionID   string
-	WorkspaceID string
-	Worktree    *SessionExecutionTargetUpdateWorktree
-	CwdRelpath  string
+	SessionID  string
+	Workspace  *SessionExecutionTargetUpdateWorkspace
+	Worktree   *SessionExecutionTargetUpdateWorktree
+	CwdRelpath string
+}
+
+type SessionExecutionTargetUpdateWorkspace struct {
+	ID string
 }
 
 type SessionExecutionTargetUpdateWorktree struct {
@@ -108,15 +112,19 @@ type SessionExecutionTargetUpdateWorktree struct {
 }
 
 func SessionExecutionTargetUpdateFromReadModel(sessionID string, target clientui.SessionExecutionTarget) SessionExecutionTargetUpdate {
+	var workspace *SessionExecutionTargetUpdateWorkspace
+	if strings.TrimSpace(target.WorkspaceID) != "" {
+		workspace = &SessionExecutionTargetUpdateWorkspace{ID: target.WorkspaceID}
+	}
 	var worktree *SessionExecutionTargetUpdateWorktree
 	if target.Worktree != nil {
 		worktree = &SessionExecutionTargetUpdateWorktree{ID: target.Worktree.ID}
 	}
 	return SessionExecutionTargetUpdate{
-		SessionID:   sessionID,
-		WorkspaceID: target.WorkspaceID,
-		Worktree:    worktree,
-		CwdRelpath:  target.CwdRelpath,
+		SessionID:  sessionID,
+		Workspace:  workspace,
+		Worktree:   worktree,
+		CwdRelpath: target.CwdRelpath,
 	}
 }
 
@@ -405,12 +413,19 @@ func (s *Store) UpdateSessionExecutionTarget(ctx context.Context, update Session
 	if trimmedSessionID == "" {
 		return errors.New("session id is required")
 	}
-	trimmedWorkspaceID := strings.TrimSpace(update.WorkspaceID)
-	if trimmedWorkspaceID == "" {
-		return errors.New("workspace id is required")
+	workspaceID := sql.NullString{}
+	if update.Workspace != nil {
+		trimmedWorkspaceID := strings.TrimSpace(update.Workspace.ID)
+		if trimmedWorkspaceID == "" {
+			return errors.New("workspace id is required")
+		}
+		workspaceID = sql.NullString{String: trimmedWorkspaceID, Valid: true}
 	}
 	worktreeID := sql.NullString{}
 	if update.Worktree != nil {
+		if !workspaceID.Valid {
+			return errors.New("workspace id is required when worktree is selected")
+		}
 		trimmedWorktreeID := strings.TrimSpace(update.Worktree.ID)
 		if trimmedWorktreeID == "" {
 			return ErrWorktreeIDRequired
@@ -419,13 +434,13 @@ func (s *Store) UpdateSessionExecutionTarget(ctx context.Context, update Session
 		if err != nil {
 			return err
 		}
-		if strings.TrimSpace(record.WorkspaceID) != trimmedWorkspaceID {
-			return &WorktreeWorkspaceMismatchError{WorktreeID: trimmedWorktreeID, WorkspaceID: trimmedWorkspaceID}
+		if strings.TrimSpace(record.WorkspaceID) != workspaceID.String {
+			return &WorktreeWorkspaceMismatchError{WorktreeID: trimmedWorktreeID, WorkspaceID: workspaceID.String}
 		}
 		worktreeID = sql.NullString{String: trimmedWorktreeID, Valid: true}
 	}
 	params := sqlitegen.UpdateSessionExecutionTargetByIDParams{
-		WorkspaceID:     sql.NullString{String: trimmedWorkspaceID, Valid: true},
+		WorkspaceID:     workspaceID,
 		WorktreeID:      worktreeID,
 		CwdRelpath:      normalizeSessionCwdRelpath(update.CwdRelpath),
 		UpdatedAtUnixMs: time.Now().UTC().UnixMilli(),
@@ -1119,10 +1134,10 @@ func (s *Store) RetargetSessionWorkspace(ctx context.Context, sessionID string, 
 		return Binding{}, err
 	}
 	if err := s.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdate{
-		SessionID:   trimmedSessionID,
-		WorkspaceID: binding.WorkspaceID,
-		Worktree:    nil,
-		CwdRelpath:  ".",
+		SessionID:  trimmedSessionID,
+		Workspace:  &SessionExecutionTargetUpdateWorkspace{ID: binding.WorkspaceID},
+		Worktree:   nil,
+		CwdRelpath: ".",
 	}); err != nil {
 		return Binding{}, err
 	}

--- a/server/metadata/store.go
+++ b/server/metadata/store.go
@@ -96,6 +96,30 @@ func (e *WorktreeWorkspaceMismatchError) Error() string {
 	return fmt.Sprintf("worktree %q does not belong to workspace %q", e.WorktreeID, e.WorkspaceID)
 }
 
+type SessionExecutionTargetUpdate struct {
+	SessionID   string
+	WorkspaceID string
+	Worktree    *SessionExecutionTargetUpdateWorktree
+	CwdRelpath  string
+}
+
+type SessionExecutionTargetUpdateWorktree struct {
+	ID string
+}
+
+func SessionExecutionTargetUpdateFromReadModel(sessionID string, target clientui.SessionExecutionTarget) SessionExecutionTargetUpdate {
+	var worktree *SessionExecutionTargetUpdateWorktree
+	if target.Worktree != nil {
+		worktree = &SessionExecutionTargetUpdateWorktree{ID: target.Worktree.ID}
+	}
+	return SessionExecutionTargetUpdate{
+		SessionID:   sessionID,
+		WorkspaceID: target.WorkspaceID,
+		Worktree:    worktree,
+		CwdRelpath:  target.CwdRelpath,
+	}
+}
+
 func (s *Store) PersistenceRoot() string {
 	if s == nil {
 		return ""
@@ -373,13 +397,24 @@ func (s *Store) DeleteWorktreeRecordByID(ctx context.Context, worktreeID string)
 	return nil
 }
 
-func (s *Store) UpdateSessionExecutionTargetByID(ctx context.Context, sessionID string, workspaceID string, worktreeID string, cwdRelpath string) error {
+func (s *Store) UpdateSessionExecutionTarget(ctx context.Context, update SessionExecutionTargetUpdate) error {
 	if s == nil || s.queries == nil {
 		return errors.New("metadata store is required")
 	}
-	trimmedWorkspaceID := strings.TrimSpace(workspaceID)
-	trimmedWorktreeID := strings.TrimSpace(worktreeID)
-	if trimmedWorktreeID != "" {
+	trimmedSessionID := strings.TrimSpace(update.SessionID)
+	if trimmedSessionID == "" {
+		return errors.New("session id is required")
+	}
+	trimmedWorkspaceID := strings.TrimSpace(update.WorkspaceID)
+	if trimmedWorkspaceID == "" {
+		return errors.New("workspace id is required")
+	}
+	worktreeID := sql.NullString{}
+	if update.Worktree != nil {
+		trimmedWorktreeID := strings.TrimSpace(update.Worktree.ID)
+		if trimmedWorktreeID == "" {
+			return ErrWorktreeIDRequired
+		}
 		record, err := s.GetWorktreeRecordByID(ctx, trimmedWorktreeID)
 		if err != nil {
 			return err
@@ -387,13 +422,14 @@ func (s *Store) UpdateSessionExecutionTargetByID(ctx context.Context, sessionID 
 		if strings.TrimSpace(record.WorkspaceID) != trimmedWorkspaceID {
 			return &WorktreeWorkspaceMismatchError{WorktreeID: trimmedWorktreeID, WorkspaceID: trimmedWorkspaceID}
 		}
+		worktreeID = sql.NullString{String: trimmedWorktreeID, Valid: true}
 	}
 	params := sqlitegen.UpdateSessionExecutionTargetByIDParams{
-		WorkspaceID:     sql.NullString{String: trimmedWorkspaceID, Valid: trimmedWorkspaceID != ""},
-		WorktreeID:      sql.NullString{String: trimmedWorktreeID, Valid: trimmedWorktreeID != ""},
-		CwdRelpath:      normalizeSessionCwdRelpath(cwdRelpath),
+		WorkspaceID:     sql.NullString{String: trimmedWorkspaceID, Valid: true},
+		WorktreeID:      worktreeID,
+		CwdRelpath:      normalizeSessionCwdRelpath(update.CwdRelpath),
 		UpdatedAtUnixMs: time.Now().UTC().UnixMilli(),
-		SessionID:       strings.TrimSpace(sessionID),
+		SessionID:       trimmedSessionID,
 	}
 	rows, err := s.queries.UpdateSessionExecutionTargetByID(ctx, params)
 	if err != nil {
@@ -1077,6 +1113,17 @@ func (s *Store) RetargetSessionWorkspace(ctx context.Context, sessionID string, 
 		return Binding{}, err
 	}
 	if err := opened.SetWorkspaceRoot(binding.CanonicalRoot); err != nil {
+		return Binding{}, err
+	}
+	if err := opened.SetWorktreeReminderState(nil); err != nil {
+		return Binding{}, err
+	}
+	if err := s.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdate{
+		SessionID:   trimmedSessionID,
+		WorkspaceID: binding.WorkspaceID,
+		Worktree:    nil,
+		CwdRelpath:  ".",
+	}); err != nil {
 		return Binding{}, err
 	}
 	return binding, nil
@@ -2049,17 +2096,26 @@ func projectHomeSummaryFromRow(row sqlitegen.ListProjectHomeSummariesRow) server
 }
 
 func sessionExecutionTargetFromRow(row sqlitegen.GetSessionExecutionTargetByIDRow) clientui.SessionExecutionTarget {
-	worktreeID := ""
-	if row.WorktreeID.Valid {
-		worktreeID = row.WorktreeID.String
-	}
 	workspaceName := displayNameForPath(row.WorkspaceRoot)
 	if strings.TrimSpace(row.WorkspaceID) == "" && strings.TrimSpace(row.WorkspaceSnapshotName) != "" {
 		workspaceName = strings.TrimSpace(row.WorkspaceSnapshotName)
 	}
 	baseRoot := strings.TrimSpace(row.WorkspaceRoot)
-	if strings.TrimSpace(row.WorktreeRoot) != "" {
-		baseRoot = strings.TrimSpace(row.WorktreeRoot)
+	var worktree *clientui.SessionExecutionWorktreeTarget
+	if row.WorktreeID.Valid {
+		worktreeRoot := ""
+		if row.WorktreeRoot.Valid {
+			worktreeRoot = row.WorktreeRoot.String
+		}
+		worktree = &clientui.SessionExecutionWorktreeTarget{
+			ID:           row.WorktreeID.String,
+			Name:         displayNameForPath(worktreeRoot),
+			Root:         worktreeRoot,
+			Availability: availabilityForOptionalPath(worktreeRoot),
+		}
+		if strings.TrimSpace(worktreeRoot) != "" {
+			baseRoot = strings.TrimSpace(worktreeRoot)
+		}
 	}
 	cwdRelpath := normalizeSessionCwdRelpath(row.CwdRelpath)
 	effectiveWorkdir := effectiveWorkdirWithinRoot(baseRoot, cwdRelpath)
@@ -2068,10 +2124,7 @@ func sessionExecutionTargetFromRow(row sqlitegen.GetSessionExecutionTargetByIDRo
 		WorkspaceName:         workspaceName,
 		WorkspaceRoot:         row.WorkspaceRoot,
 		WorkspaceAvailability: availabilityForOptionalPath(row.WorkspaceRoot),
-		WorktreeID:            worktreeID,
-		WorktreeName:          displayNameForPath(row.WorktreeRoot),
-		WorktreeRoot:          row.WorktreeRoot,
-		WorktreeAvailability:  availabilityForOptionalPath(row.WorktreeRoot),
+		Worktree:              worktree,
 		CwdRelpath:            cwdRelpath,
 		EffectiveWorkdir:      effectiveWorkdir,
 	}

--- a/server/metadata/store_part2_test.go
+++ b/server/metadata/store_part2_test.go
@@ -112,7 +112,7 @@ func TestObservedSessionMetadataPersistencePreservesExecutionTarget(t *testing.T
 		t.Fatalf("MkdirAll worktreeSubdir: %v", err)
 	}
 	sess := createMetadataTestSession(t, store, cfg, binding)
-	if err := store.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &SessionExecutionTargetUpdateWorktree{ID: "worktree-a"}, CwdRelpath: "pkg"}); err != nil {
+	if err := store.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, Workspace: &SessionExecutionTargetUpdateWorkspace{ID: binding.WorkspaceID}, Worktree: &SessionExecutionTargetUpdateWorktree{ID: "worktree-a"}, CwdRelpath: "pkg"}); err != nil {
 		t.Fatalf("UpdateSessionExecutionTarget: %v", err)
 	}
 	reopened, err := session.OpenByID(cfg.PersistenceRoot, sess.Meta().SessionID, store.AuthoritativeSessionStoreOptions()...)
@@ -164,10 +164,37 @@ func TestUpdateSessionExecutionTargetRejectsCrossWorkspaceWorktree(t *testing.T)
 	worktreeRoot := filepath.Join(cfgB.WorkspaceRoot, "wt-b")
 	createMetadataTestWorktree(t, ctx, store, bindingB.WorkspaceID, "worktree-b", worktreeRoot)
 
-	err = store.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, WorkspaceID: bindingA.WorkspaceID, Worktree: &SessionExecutionTargetUpdateWorktree{ID: "worktree-b"}, CwdRelpath: "."})
+	err = store.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, Workspace: &SessionExecutionTargetUpdateWorkspace{ID: bindingA.WorkspaceID}, Worktree: &SessionExecutionTargetUpdateWorktree{ID: "worktree-b"}, CwdRelpath: "."})
 	var mismatch *WorktreeWorkspaceMismatchError
 	if !errors.As(err, &mismatch) || mismatch.WorktreeID != "worktree-b" || mismatch.WorkspaceID != bindingA.WorkspaceID {
 		t.Fatalf("UpdateSessionExecutionTarget error = %v", err)
+	}
+}
+
+func TestUpdateSessionExecutionTargetAllowsNullableWorkspaceTargetFromReadModel(t *testing.T) {
+	ctx := context.Background()
+	store, cfg, binding := newMetadataTestStore(t)
+	sess := createMetadataTestSession(t, store, cfg, binding)
+	if _, err := store.db.ExecContext(ctx, "UPDATE sessions SET workspace_id = NULL, worktree_id = NULL, cwd_relpath = 'pkg' WHERE id = ?", sess.Meta().SessionID); err != nil {
+		t.Fatalf("clear session workspace target: %v", err)
+	}
+	target, err := store.ResolveSessionExecutionTarget(ctx, sess.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("ResolveSessionExecutionTarget: %v", err)
+	}
+	if target.WorkspaceID != "" || target.Worktree != nil {
+		t.Fatalf("target = %+v, want nullable workspace root snapshot target", target)
+	}
+
+	if err := store.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdateFromReadModel(sess.Meta().SessionID, target)); err != nil {
+		t.Fatalf("UpdateSessionExecutionTarget nullable workspace: %v", err)
+	}
+	var storedWorkspaceID sql.NullString
+	if err := store.db.QueryRowContext(ctx, "SELECT workspace_id FROM sessions WHERE id = ?", sess.Meta().SessionID).Scan(&storedWorkspaceID); err != nil {
+		t.Fatalf("scan workspace_id: %v", err)
+	}
+	if storedWorkspaceID.Valid {
+		t.Fatalf("stored workspace_id = %+v, want SQL NULL", storedWorkspaceID)
 	}
 }
 

--- a/server/metadata/store_part2_test.go
+++ b/server/metadata/store_part2_test.go
@@ -51,7 +51,6 @@ func TestSessionExecutionTargetClampsEscapingCwdRelpath(t *testing.T) {
 	target := sessionExecutionTargetFromRow(sqlitegen.GetSessionExecutionTargetByIDRow{
 		WorkspaceID:   "workspace-1",
 		WorkspaceRoot: "/tmp/workspace",
-		WorktreeRoot:  "",
 		CwdRelpath:    "../../other-project",
 	})
 	if target.CwdRelpath != "." {
@@ -64,7 +63,8 @@ func TestSessionExecutionTargetClampsEscapingCwdRelpath(t *testing.T) {
 	target = sessionExecutionTargetFromRow(sqlitegen.GetSessionExecutionTargetByIDRow{
 		WorkspaceID:   "workspace-1",
 		WorkspaceRoot: "/tmp/workspace",
-		WorktreeRoot:  "/tmp/workspace/worktree-a",
+		WorktreeID:    sql.NullString{String: "worktree-a", Valid: true},
+		WorktreeRoot:  sql.NullString{String: "/tmp/workspace/worktree-a", Valid: true},
 		CwdRelpath:    "/tmp/absolute",
 	})
 	if target.CwdRelpath != "." {
@@ -112,8 +112,8 @@ func TestObservedSessionMetadataPersistencePreservesExecutionTarget(t *testing.T
 		t.Fatalf("MkdirAll worktreeSubdir: %v", err)
 	}
 	sess := createMetadataTestSession(t, store, cfg, binding)
-	if err := store.UpdateSessionExecutionTargetByID(ctx, sess.Meta().SessionID, binding.WorkspaceID, "worktree-a", "pkg"); err != nil {
-		t.Fatalf("UpdateSessionExecutionTargetByID: %v", err)
+	if err := store.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &SessionExecutionTargetUpdateWorktree{ID: "worktree-a"}, CwdRelpath: "pkg"}); err != nil {
+		t.Fatalf("UpdateSessionExecutionTarget: %v", err)
 	}
 	reopened, err := session.OpenByID(cfg.PersistenceRoot, sess.Meta().SessionID, store.AuthoritativeSessionStoreOptions()...)
 	if err != nil {
@@ -126,11 +126,11 @@ func TestObservedSessionMetadataPersistencePreservesExecutionTarget(t *testing.T
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget: %v", err)
 	}
-	if target.WorktreeID != "worktree-a" {
-		t.Fatalf("worktree id = %q, want worktree-a", target.WorktreeID)
+	if target.Worktree == nil || target.Worktree.ID != "worktree-a" {
+		t.Fatalf("worktree = %+v, want worktree-a", target.Worktree)
 	}
-	if target.WorktreeRoot != canonicalWorktreeRoot {
-		t.Fatalf("worktree root = %q, want %q", target.WorktreeRoot, canonicalWorktreeRoot)
+	if target.Worktree == nil || target.Worktree.Root != canonicalWorktreeRoot {
+		t.Fatalf("worktree root = %+v, want %q", target.Worktree, canonicalWorktreeRoot)
 	}
 	if target.CwdRelpath != "pkg" {
 		t.Fatalf("cwd relpath = %q, want pkg", target.CwdRelpath)
@@ -144,7 +144,7 @@ func TestObservedSessionMetadataPersistencePreservesExecutionTarget(t *testing.T
 	}
 }
 
-func TestUpdateSessionExecutionTargetByIDRejectsCrossWorkspaceWorktree(t *testing.T) {
+func TestUpdateSessionExecutionTargetRejectsCrossWorkspaceWorktree(t *testing.T) {
 	ctx := context.Background()
 	store, cfgA, bindingA := newMetadataTestStore(t)
 	workspaceB := t.TempDir()
@@ -164,10 +164,10 @@ func TestUpdateSessionExecutionTargetByIDRejectsCrossWorkspaceWorktree(t *testin
 	worktreeRoot := filepath.Join(cfgB.WorkspaceRoot, "wt-b")
 	createMetadataTestWorktree(t, ctx, store, bindingB.WorkspaceID, "worktree-b", worktreeRoot)
 
-	err = store.UpdateSessionExecutionTargetByID(ctx, sess.Meta().SessionID, bindingA.WorkspaceID, "worktree-b", ".")
+	err = store.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, WorkspaceID: bindingA.WorkspaceID, Worktree: &SessionExecutionTargetUpdateWorktree{ID: "worktree-b"}, CwdRelpath: "."})
 	var mismatch *WorktreeWorkspaceMismatchError
 	if !errors.As(err, &mismatch) || mismatch.WorktreeID != "worktree-b" || mismatch.WorkspaceID != bindingA.WorkspaceID {
-		t.Fatalf("UpdateSessionExecutionTargetByID error = %v", err)
+		t.Fatalf("UpdateSessionExecutionTarget error = %v", err)
 	}
 }
 

--- a/server/metadata/store_test.go
+++ b/server/metadata/store_test.go
@@ -526,8 +526,8 @@ func TestRetargetSessionWorkspaceAttachesTargetAndUpdatesSession(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := store.UpdateSessionExecutionTargetByID(ctx, sess.Meta().SessionID, bindingA.WorkspaceID, "worktree-a", "pkg"); err != nil {
-		t.Fatalf("UpdateSessionExecutionTargetByID before retarget: %v", err)
+	if err := store.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, WorkspaceID: bindingA.WorkspaceID, Worktree: &SessionExecutionTargetUpdateWorktree{ID: "worktree-a"}, CwdRelpath: "pkg"}); err != nil {
+		t.Fatalf("UpdateSessionExecutionTarget before retarget: %v", err)
 	}
 	if err := sess.SetWorktreeReminderState(&session.WorktreeReminderState{
 		Mode:          session.WorktreeReminderModeEnter,
@@ -572,14 +572,11 @@ func TestRetargetSessionWorkspaceAttachesTargetAndUpdatesSession(t *testing.T) {
 	if target.WorkspaceRoot != canonicalWorkspaceB {
 		t.Fatalf("target workspace root = %q, want %q", target.WorkspaceRoot, canonicalWorkspaceB)
 	}
-	if target.WorktreeID != "" {
-		t.Fatalf("target worktree id = %q, want empty after workspace retarget", target.WorktreeID)
+	if target.Worktree != nil {
+		t.Fatalf("target worktree = %+v, want nil after workspace retarget", target.Worktree)
 	}
 	if target.CwdRelpath != "." {
 		t.Fatalf("target cwd relpath = %q, want . after workspace retarget", target.CwdRelpath)
-	}
-	if target.WorktreeRoot != "" {
-		t.Fatalf("target worktree root = %q, want empty after workspace retarget", target.WorktreeRoot)
 	}
 	if target.EffectiveWorkdir != canonicalWorkspaceB {
 		t.Fatalf("target effective workdir = %q, want %q", target.EffectiveWorkdir, canonicalWorkspaceB)
@@ -597,6 +594,79 @@ func TestRetargetSessionWorkspaceAttachesTargetAndUpdatesSession(t *testing.T) {
 	}
 	if reopened.Meta().WorktreeReminder != nil {
 		t.Fatalf("expected stale worktree reminder cleared after workspace retarget, got %+v", reopened.Meta().WorktreeReminder)
+	}
+}
+
+func TestRetargetSessionWorkspaceClearsSameWorkspaceStaleWorktreeTarget(t *testing.T) {
+	ctx := context.Background()
+	store, cfg, binding := newMetadataTestStore(t)
+	sess := createMetadataTestSession(t, store, cfg, binding)
+	if err := sess.SetName("stale worktree recovery"); err != nil {
+		t.Fatalf("SetName: %v", err)
+	}
+	worktreeRoot := filepath.Join(cfg.WorkspaceRoot, "deleted-task-worktree")
+	worktreeSubdir := filepath.Join(worktreeRoot, "pkg")
+	if err := os.MkdirAll(worktreeSubdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll worktree subdir: %v", err)
+	}
+	canonicalWorktreeRoot := createMetadataTestWorktree(t, ctx, store, binding.WorkspaceID, "worktree-stale", worktreeRoot)
+	if err := store.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdate{
+		SessionID:   sess.Meta().SessionID,
+		WorkspaceID: binding.WorkspaceID,
+		Worktree:    &SessionExecutionTargetUpdateWorktree{ID: "worktree-stale"},
+		CwdRelpath:  "pkg",
+	}); err != nil {
+		t.Fatalf("UpdateSessionExecutionTarget before retarget: %v", err)
+	}
+	if err := sess.SetWorktreeReminderState(&session.WorktreeReminderState{
+		Mode:          session.WorktreeReminderModeEnter,
+		Branch:        "task/stale",
+		WorktreePath:  canonicalWorktreeRoot,
+		WorkspaceRoot: cfg.WorkspaceRoot,
+		EffectiveCwd:  filepath.Join(canonicalWorktreeRoot, "pkg"),
+	}); err != nil {
+		t.Fatalf("SetWorktreeReminderState before retarget: %v", err)
+	}
+	if err := os.RemoveAll(canonicalWorktreeRoot); err != nil {
+		t.Fatalf("RemoveAll stale worktree root: %v", err)
+	}
+
+	retargeted, err := store.RetargetSessionWorkspace(ctx, sess.Meta().SessionID, cfg.WorkspaceRoot)
+	if err != nil {
+		t.Fatalf("RetargetSessionWorkspace: %v", err)
+	}
+	if retargeted.WorkspaceID != binding.WorkspaceID {
+		t.Fatalf("retargeted workspace id = %q, want %q", retargeted.WorkspaceID, binding.WorkspaceID)
+	}
+	var storedWorktreeID sql.NullString
+	if err := store.db.QueryRowContext(ctx, "SELECT worktree_id FROM sessions WHERE id = ?", sess.Meta().SessionID).Scan(&storedWorktreeID); err != nil {
+		t.Fatalf("scan session worktree_id: %v", err)
+	}
+	if storedWorktreeID.Valid {
+		t.Fatalf("stored worktree_id = %+v, want SQL NULL", storedWorktreeID)
+	}
+	target, err := store.ResolveSessionExecutionTarget(ctx, sess.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("ResolveSessionExecutionTarget: %v", err)
+	}
+	if target.Worktree != nil {
+		t.Fatalf("target worktree = %+v, want nil", target.Worktree)
+	}
+	if target.CwdRelpath != "." {
+		t.Fatalf("target cwd_relpath = %q, want .", target.CwdRelpath)
+	}
+	if target.EffectiveWorkdir != retargeted.CanonicalRoot {
+		t.Fatalf("target effective workdir = %q, want %q", target.EffectiveWorkdir, retargeted.CanonicalRoot)
+	}
+	reopened, err := session.OpenByID(cfg.PersistenceRoot, sess.Meta().SessionID, store.AuthoritativeSessionStoreOptions()...)
+	if err != nil {
+		t.Fatalf("session.OpenByID: %v", err)
+	}
+	if reopened.Meta().WorkspaceRoot != retargeted.CanonicalRoot {
+		t.Fatalf("reopened workspace root = %q, want %q", reopened.Meta().WorkspaceRoot, retargeted.CanonicalRoot)
+	}
+	if reopened.Meta().WorktreeReminder != nil {
+		t.Fatalf("reopened worktree reminder = %+v, want nil", reopened.Meta().WorktreeReminder)
 	}
 }
 
@@ -733,11 +803,11 @@ func TestRebindWorkspaceRetargetsDescendantWorktrees(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget: %v", err)
 	}
-	if target.WorktreeID != worktreeID {
-		t.Fatalf("target worktree id = %q, want %q", target.WorktreeID, worktreeID)
+	if target.Worktree == nil || target.Worktree.ID != worktreeID {
+		t.Fatalf("target worktree = %+v, want %q", target.Worktree, worktreeID)
 	}
-	if target.WorktreeRoot != canonicalNewWorktree {
-		t.Fatalf("target worktree root = %q, want %q", target.WorktreeRoot, canonicalNewWorktree)
+	if target.Worktree == nil || target.Worktree.Root != canonicalNewWorktree {
+		t.Fatalf("target worktree root = %+v, want %q", target.Worktree, canonicalNewWorktree)
 	}
 	if target.EffectiveWorkdir != canonicalNewWorktree {
 		t.Fatalf("effective workdir = %q, want %q", target.EffectiveWorkdir, canonicalNewWorktree)

--- a/server/metadata/store_test.go
+++ b/server/metadata/store_test.go
@@ -526,7 +526,7 @@ func TestRetargetSessionWorkspaceAttachesTargetAndUpdatesSession(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := store.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, WorkspaceID: bindingA.WorkspaceID, Worktree: &SessionExecutionTargetUpdateWorktree{ID: "worktree-a"}, CwdRelpath: "pkg"}); err != nil {
+	if err := store.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, Workspace: &SessionExecutionTargetUpdateWorkspace{ID: bindingA.WorkspaceID}, Worktree: &SessionExecutionTargetUpdateWorktree{ID: "worktree-a"}, CwdRelpath: "pkg"}); err != nil {
 		t.Fatalf("UpdateSessionExecutionTarget before retarget: %v", err)
 	}
 	if err := sess.SetWorktreeReminderState(&session.WorktreeReminderState{
@@ -611,10 +611,10 @@ func TestRetargetSessionWorkspaceClearsSameWorkspaceStaleWorktreeTarget(t *testi
 	}
 	canonicalWorktreeRoot := createMetadataTestWorktree(t, ctx, store, binding.WorkspaceID, "worktree-stale", worktreeRoot)
 	if err := store.UpdateSessionExecutionTarget(ctx, SessionExecutionTargetUpdate{
-		SessionID:   sess.Meta().SessionID,
-		WorkspaceID: binding.WorkspaceID,
-		Worktree:    &SessionExecutionTargetUpdateWorktree{ID: "worktree-stale"},
-		CwdRelpath:  "pkg",
+		SessionID:  sess.Meta().SessionID,
+		Workspace:  &SessionExecutionTargetUpdateWorkspace{ID: binding.WorkspaceID},
+		Worktree:   &SessionExecutionTargetUpdateWorktree{ID: "worktree-stale"},
+		CwdRelpath: "pkg",
 	}); err != nil {
 		t.Fatalf("UpdateSessionExecutionTarget before retarget: %v", err)
 	}

--- a/server/registry/transcript_subscription_test.go
+++ b/server/registry/transcript_subscription_test.go
@@ -231,7 +231,7 @@ func TestSessionTranscriptSessionIdentityHydratesAndPublishesExecutionTarget(t *
 		t.Fatalf("hydration execution target = %+v, want %+v", hydration.Hydration.SessionIdentity.ExecutionTarget, target)
 	}
 
-	nextTarget := clientui.SessionExecutionTarget{WorkspaceID: "workspace-1", WorkspaceRoot: "/workspace", WorktreeID: "worktree-1", WorktreeRoot: "/workspace/wt", EffectiveWorkdir: "/workspace/wt"}
+	nextTarget := clientui.SessionExecutionTarget{WorkspaceID: "workspace-1", WorkspaceRoot: "/workspace", Worktree: &clientui.SessionExecutionWorktreeTarget{ID: "worktree-1", Root: "/workspace/wt"}, EffectiveWorkdir: "/workspace/wt"}
 	registry.PublishSessionIdentity(engine.SessionID(), &nextTarget)
 	live := nextTranscriptMessage(t, sub)
 	if live.Sequence != 2 || live.Kind != clientui.TranscriptMessageSessionIdentity || live.SessionIdentity == nil {

--- a/server/runtime/transcript_delivery_facts.go
+++ b/server/runtime/transcript_delivery_facts.go
@@ -255,7 +255,6 @@ func localEntryNoticeFact(entry ChatEntry) TranscriptCommittedRowFact {
 	return runtimeNoticeFactFromLocalEntry(entry)
 }
 
-
 func synthesizedTranscriptToolResultFact(call llm.ToolCall, completions map[string]tools.Result, materializedToolCalls map[string]struct{}) (TranscriptCommittedRowFact, bool) {
 	callID := strings.TrimSpace(call.ID)
 	if callID == "" {

--- a/server/sessionservice/session_lifecycle_service.go
+++ b/server/sessionservice/session_lifecycle_service.go
@@ -316,7 +316,7 @@ func (s *SessionLifecycleService) preserveForkExecutionTarget(ctx context.Contex
 		}
 		return err
 	}
-	return metadataStore.UpdateSessionExecutionTargetByID(ctx, trimmedChildID, target.WorkspaceID, target.WorktreeID, target.CwdRelpath)
+	return metadataStore.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdateFromReadModel(trimmedChildID, target))
 }
 
 func (s *SessionLifecycleService) openStore(sessionID string) (*session.Store, error) {

--- a/server/sessionservice/session_lifecycle_service_test.go
+++ b/server/sessionservice/session_lifecycle_service_test.go
@@ -467,7 +467,7 @@ func TestServiceResolveTransitionForkRollbackPreservesExecutionTarget(t *testing
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := metadataStore.UpdateSessionExecutionTarget(context.Background(), metadata.SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "wt-1"}, CwdRelpath: "pkg"}); err != nil {
+	if err := metadataStore.UpdateSessionExecutionTarget(context.Background(), metadata.SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, Workspace: &metadata.SessionExecutionTargetUpdateWorkspace{ID: binding.WorkspaceID}, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "wt-1"}, CwdRelpath: "pkg"}); err != nil {
 		t.Fatalf("UpdateSessionExecutionTarget: %v", err)
 	}
 
@@ -537,7 +537,7 @@ func TestServiceResolveTransitionForkRollbackActivatesChildInPreservedWorktree(t
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := metadataStore.UpdateSessionExecutionTarget(context.Background(), metadata.SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "wt-1"}, CwdRelpath: "pkg"}); err != nil {
+	if err := metadataStore.UpdateSessionExecutionTarget(context.Background(), metadata.SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, Workspace: &metadata.SessionExecutionTargetUpdateWorkspace{ID: binding.WorkspaceID}, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "wt-1"}, CwdRelpath: "pkg"}); err != nil {
 		t.Fatalf("UpdateSessionExecutionTarget: %v", err)
 	}
 

--- a/server/sessionservice/session_lifecycle_service_test.go
+++ b/server/sessionservice/session_lifecycle_service_test.go
@@ -467,8 +467,8 @@ func TestServiceResolveTransitionForkRollbackPreservesExecutionTarget(t *testing
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := metadataStore.UpdateSessionExecutionTargetByID(context.Background(), sess.Meta().SessionID, binding.WorkspaceID, "wt-1", "pkg"); err != nil {
-		t.Fatalf("UpdateSessionExecutionTargetByID: %v", err)
+	if err := metadataStore.UpdateSessionExecutionTarget(context.Background(), metadata.SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "wt-1"}, CwdRelpath: "pkg"}); err != nil {
+		t.Fatalf("UpdateSessionExecutionTarget: %v", err)
 	}
 
 	service := NewGlobalSessionLifecycleService(cfg.PersistenceRoot, nil, nil, metadataStore.AuthoritativeSessionStoreOptions()...)
@@ -493,11 +493,11 @@ func TestServiceResolveTransitionForkRollbackPreservesExecutionTarget(t *testing
 	if err != nil {
 		t.Fatalf("CanonicalWorkspaceRoot: %v", err)
 	}
-	if target.WorktreeID != "wt-1" {
-		t.Fatalf("fork target worktree id = %q, want wt-1", target.WorktreeID)
+	if target.Worktree == nil || target.Worktree.ID != "wt-1" {
+		t.Fatalf("fork target worktree = %+v, want wt-1", target.Worktree)
 	}
-	if target.WorktreeRoot != canonicalWorktreeRoot {
-		t.Fatalf("fork target worktree root = %q, want %q", target.WorktreeRoot, canonicalWorktreeRoot)
+	if target.Worktree == nil || target.Worktree.Root != canonicalWorktreeRoot {
+		t.Fatalf("fork target worktree root = %+v, want %q", target.Worktree, canonicalWorktreeRoot)
 	}
 	if target.CwdRelpath != "pkg" {
 		t.Fatalf("fork target cwd_relpath = %q, want pkg", target.CwdRelpath)
@@ -537,8 +537,8 @@ func TestServiceResolveTransitionForkRollbackActivatesChildInPreservedWorktree(t
 	}); err != nil {
 		t.Fatalf("UpsertWorktreeRecord: %v", err)
 	}
-	if err := metadataStore.UpdateSessionExecutionTargetByID(context.Background(), sess.Meta().SessionID, binding.WorkspaceID, "wt-1", "pkg"); err != nil {
-		t.Fatalf("UpdateSessionExecutionTargetByID: %v", err)
+	if err := metadataStore.UpdateSessionExecutionTarget(context.Background(), metadata.SessionExecutionTargetUpdate{SessionID: sess.Meta().SessionID, WorkspaceID: binding.WorkspaceID, Worktree: &metadata.SessionExecutionTargetUpdateWorktree{ID: "wt-1"}, CwdRelpath: "pkg"}); err != nil {
+		t.Fatalf("UpdateSessionExecutionTarget: %v", err)
 	}
 
 	lifecycle := NewGlobalSessionLifecycleService(cfg.PersistenceRoot, nil, nil, metadataStore.AuthoritativeSessionStoreOptions()...)

--- a/server/workflowrunner/starter.go
+++ b/server/workflowrunner/starter.go
@@ -242,7 +242,12 @@ func (s *Starter) StartWorkflowRun(ctx context.Context, req SchedulerStartRunReq
 		cancel()
 		return errors.Join(errors.New("workflow runtime starter closed"), cleanupSession())
 	}
-	if err := s.metadata.UpdateSessionExecutionTargetByID(ctx, plan.Store.Meta().SessionID, input.WorkspaceID, input.WorktreeID, "."); err != nil {
+	if err := s.metadata.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{
+		SessionID:   plan.Store.Meta().SessionID,
+		WorkspaceID: input.WorkspaceID,
+		Worktree:    &metadata.SessionExecutionTargetUpdateWorktree{ID: input.WorktreeID},
+		CwdRelpath:  ".",
+	}); err != nil {
 		cancel()
 		s.releaseRegisteredRun(req.RunID)
 		return errors.Join(err, cleanupSession())

--- a/server/workflowrunner/starter.go
+++ b/server/workflowrunner/starter.go
@@ -243,10 +243,10 @@ func (s *Starter) StartWorkflowRun(ctx context.Context, req SchedulerStartRunReq
 		return errors.Join(errors.New("workflow runtime starter closed"), cleanupSession())
 	}
 	if err := s.metadata.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{
-		SessionID:   plan.Store.Meta().SessionID,
-		WorkspaceID: input.WorkspaceID,
-		Worktree:    &metadata.SessionExecutionTargetUpdateWorktree{ID: input.WorktreeID},
-		CwdRelpath:  ".",
+		SessionID:  plan.Store.Meta().SessionID,
+		Workspace:  &metadata.SessionExecutionTargetUpdateWorkspace{ID: input.WorkspaceID},
+		Worktree:   &metadata.SessionExecutionTargetUpdateWorktree{ID: input.WorktreeID},
+		CwdRelpath: ".",
 	}); err != nil {
 		cancel()
 		s.releaseRegisteredRun(req.RunID)

--- a/server/workflowrunner/starter_test.go
+++ b/server/workflowrunner/starter_test.go
@@ -2371,7 +2371,7 @@ func (f starterFixture) assertRunSessionUsesTaskWorktree(t *testing.T, sessionID
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget: %v", err)
 	}
-	if strings.TrimSpace(target.WorktreeID) == "" || !strings.HasSuffix(target.EffectiveWorkdir, string(filepath.Separator)+"RUN-1") {
+	if target.Worktree == nil || strings.TrimSpace(target.Worktree.ID) == "" || !strings.HasSuffix(target.EffectiveWorkdir, string(filepath.Separator)+"RUN-1") {
 		t.Fatalf("session target = %+v, want task worktree", target)
 	}
 	return target.EffectiveWorkdir

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -247,7 +247,11 @@ func (s *Service) EnsureTaskWorktree(ctx context.Context, req EnsureTaskWorktree
 		return EnsureTaskWorktreeResponse{}, sql.ErrNoRows
 	}
 	cleanup.active = false
-	return EnsureTaskWorktreeResponse{Worktree: worktreeViewFromSynced(created, clientui.SessionExecutionTarget{}), Created: true, CreatedBranch: createdBranch}, nil
+	worktreeView, err := worktreeViewFromSynced(created, clientui.SessionExecutionTarget{})
+	if err != nil {
+		return EnsureTaskWorktreeResponse{}, err
+	}
+	return EnsureTaskWorktreeResponse{Worktree: worktreeView, Created: true, CreatedBranch: createdBranch}, nil
 }
 
 func (s *Service) DeleteTaskWorktree(ctx context.Context, req DeleteTaskWorktreeRequest) (DeleteTaskWorktreeResponse, error) {
@@ -470,7 +474,7 @@ func (s *Service) taskManagedWorktreeView(ctx context.Context, worktreeID string
 	if err != nil {
 		return serverapi.WorktreeView{}, err
 	}
-	return worktreeViewFromSynced(syncedWorktree{record: record, git: gitMetadata}, clientui.SessionExecutionTarget{}), nil
+	return worktreeViewFromSynced(syncedWorktree{record: record, git: gitMetadata}, clientui.SessionExecutionTarget{})
 }
 
 func (s *Service) ListWorktrees(ctx context.Context, req serverapi.WorktreeListRequest) (serverapi.WorktreeListResponse, error) {
@@ -490,7 +494,11 @@ func (s *Service) ListWorktrees(ctx context.Context, req serverapi.WorktreeListR
 	if err != nil {
 		return serverapi.WorktreeListResponse{}, err
 	}
-	return serverapi.WorktreeListResponse{Target: workspaceCtx.target, Worktrees: mapSyncedWorktrees(synced, workspaceCtx.target)}, nil
+	views, err := mapSyncedWorktrees(synced, workspaceCtx.target)
+	if err != nil {
+		return serverapi.WorktreeListResponse{}, err
+	}
+	return serverapi.WorktreeListResponse{Target: workspaceCtx.target, Worktrees: views}, nil
 }
 
 func (s *Service) ResolveWorktreeCreateTarget(ctx context.Context, req serverapi.WorktreeCreateTargetResolveRequest) (serverapi.WorktreeCreateTargetResolveResponse, error) {
@@ -572,13 +580,19 @@ func (s *Service) CreateWorktree(ctx context.Context, req serverapi.WorktreeCrea
 	if err := s.metadata.UpsertWorktreeRecord(ctx, created.record); err != nil {
 		return serverapi.WorktreeCreateResponse{}, err
 	}
-	previous := currentSyncedWorktree(synced, workspaceCtx.target)
+	previous, err := currentSyncedWorktree(synced, workspaceCtx.target)
+	if err != nil {
+		return serverapi.WorktreeCreateResponse{}, err
+	}
 	nextTarget, err := s.switchSessionTarget(ctx, workspaceCtx, previous, created)
 	if err != nil {
 		return serverapi.WorktreeCreateResponse{}, err
 	}
 	setupScheduled := s.scheduleSetupScript(workspaceCtx, created, strings.TrimSpace(created.git.BranchName), createdBranch)
-	createdView := worktreeViewFromSynced(created, nextTarget)
+	createdView, err := worktreeViewFromSynced(created, nextTarget)
+	if err != nil {
+		return serverapi.WorktreeCreateResponse{}, err
+	}
 	createdView.Managed = true
 	createdView.CreatedBranch = createdBranch
 	createdView.OriginSessionID = workspaceCtx.sessionID
@@ -658,12 +672,19 @@ func (s *Service) SwitchWorktree(ctx context.Context, req serverapi.WorktreeSwit
 	if !ok {
 		return serverapi.WorktreeSwitchResponse{}, serverapi.ErrWorktreeNotFound
 	}
-	previous := currentSyncedWorktree(synced, workspaceCtx.target)
+	previous, err := currentSyncedWorktree(synced, workspaceCtx.target)
+	if err != nil {
+		return serverapi.WorktreeSwitchResponse{}, err
+	}
 	nextTarget, err := s.switchSessionTarget(ctx, workspaceCtx, previous, targetWorktree)
 	if err != nil {
 		return serverapi.WorktreeSwitchResponse{}, err
 	}
-	return serverapi.WorktreeSwitchResponse{Target: nextTarget, Worktree: worktreeViewFromSynced(targetWorktree, nextTarget)}, nil
+	view, err := worktreeViewFromSynced(targetWorktree, nextTarget)
+	if err != nil {
+		return serverapi.WorktreeSwitchResponse{}, err
+	}
+	return serverapi.WorktreeSwitchResponse{Target: nextTarget, Worktree: view}, nil
 }
 
 func (s *Service) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDeleteRequest) (serverapi.WorktreeDeleteResponse, error) {
@@ -691,7 +712,7 @@ func (s *Service) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDele
 		return serverapi.WorktreeDeleteResponse{}, err
 	}
 	defer releaseDeletionSessionLeases()
-	if workspaceCtx.target.WorktreeID == targetWorktree.record.ID {
+	if workspaceCtx.target.Worktree != nil && workspaceCtx.target.Worktree.ID == targetWorktree.record.ID {
 		mainWorktree, mainFound := findMainWorktree(synced)
 		if !mainFound {
 			return serverapi.WorktreeDeleteResponse{}, fmt.Errorf("main worktree not found for workspace %q", workspaceCtx.workspaceID)
@@ -739,7 +760,11 @@ func (s *Service) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDele
 	if err != nil {
 		return serverapi.WorktreeDeleteResponse{}, err
 	}
-	return serverapi.WorktreeDeleteResponse{Target: finalTarget, Worktree: worktreeViewFromSynced(targetWorktree, finalTarget), BranchDeleted: branchDeleted, BranchCleanupMessage: branchCleanupMessage}, nil
+	view, err := worktreeViewFromSynced(targetWorktree, finalTarget)
+	if err != nil {
+		return serverapi.WorktreeDeleteResponse{}, err
+	}
+	return serverapi.WorktreeDeleteResponse{Target: finalTarget, Worktree: view, BranchDeleted: branchDeleted, BranchCleanupMessage: branchCleanupMessage}, nil
 }
 
 func (s *Service) beginMutation(ctx context.Context, sessionID string) (func(), sessionWorkspaceContext, error) {

--- a/server/worktree/service_part2_test.go
+++ b/server/worktree/service_part2_test.go
@@ -42,7 +42,7 @@ func TestDeleteWorktreeRebindsCurrentSessionToMainBeforeRemoval(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteWorktree: %v", err)
 	}
-	if resp.Target.WorktreeID != "" || resp.Target.EffectiveWorkdir != env.workspaceRoot {
+	if sessionTargetWorktreeID(resp.Target) != "" || resp.Target.EffectiveWorkdir != env.workspaceRoot {
 		t.Fatalf("unexpected final delete target: %+v", resp.Target)
 	}
 	if len(env.runtime.rebindCalls) < 2 {
@@ -232,14 +232,14 @@ func TestRetargetSessionsFromMissingWorktreeRollsBackActiveSessionMetadataOnRunt
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget active after: %v", err)
 	}
-	if activeTargetAfter.WorktreeID != activeTargetBefore.WorktreeID || activeTargetAfter.EffectiveWorkdir != activeTargetBefore.EffectiveWorkdir {
+	if sessionTargetWorktreeID(activeTargetAfter) != sessionTargetWorktreeID(activeTargetBefore) || activeTargetAfter.EffectiveWorkdir != activeTargetBefore.EffectiveWorkdir {
 		t.Fatalf("expected active session target rolled back after runtime failure, before=%+v after=%+v", activeTargetBefore, activeTargetAfter)
 	}
 	otherTarget, err := env.store.ResolveSessionExecutionTarget(env.ctx, otherSession.Meta().SessionID)
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget other session: %v", err)
 	}
-	if otherTarget.WorktreeID != "" || otherTarget.EffectiveWorkdir != env.workspaceRoot {
+	if sessionTargetWorktreeID(otherTarget) != "" || otherTarget.EffectiveWorkdir != env.workspaceRoot {
 		t.Fatalf("expected inactive session retargeted to main workspace, got %+v", otherTarget)
 	}
 	if len(env.runtime.rebindCalls) != 1 {
@@ -487,8 +487,12 @@ func worktreeDeleteRequest(env *serviceTestEnv, clientRequestID string, worktree
 
 func updateServiceTestSessionTarget(t *testing.T, env *serviceTestEnv, sessionID, workspaceID, worktreeID, cwdRelpath string) {
 	t.Helper()
-	if err := env.store.UpdateSessionExecutionTargetByID(env.ctx, sessionID, workspaceID, worktreeID, cwdRelpath); err != nil {
-		t.Fatalf("UpdateSessionExecutionTargetByID %s: %v", sessionID, err)
+	var worktree *metadata.SessionExecutionTargetUpdateWorktree
+	if strings.TrimSpace(worktreeID) != "" {
+		worktree = &metadata.SessionExecutionTargetUpdateWorktree{ID: worktreeID}
+	}
+	if err := env.store.UpdateSessionExecutionTarget(env.ctx, metadata.SessionExecutionTargetUpdate{SessionID: sessionID, WorkspaceID: workspaceID, Worktree: worktree, CwdRelpath: cwdRelpath}); err != nil {
+		t.Fatalf("UpdateSessionExecutionTarget %s: %v", sessionID, err)
 	}
 }
 

--- a/server/worktree/service_part2_test.go
+++ b/server/worktree/service_part2_test.go
@@ -491,7 +491,7 @@ func updateServiceTestSessionTarget(t *testing.T, env *serviceTestEnv, sessionID
 	if strings.TrimSpace(worktreeID) != "" {
 		worktree = &metadata.SessionExecutionTargetUpdateWorktree{ID: worktreeID}
 	}
-	if err := env.store.UpdateSessionExecutionTarget(env.ctx, metadata.SessionExecutionTargetUpdate{SessionID: sessionID, WorkspaceID: workspaceID, Worktree: worktree, CwdRelpath: cwdRelpath}); err != nil {
+	if err := env.store.UpdateSessionExecutionTarget(env.ctx, metadata.SessionExecutionTargetUpdate{SessionID: sessionID, Workspace: &metadata.SessionExecutionTargetUpdateWorkspace{ID: workspaceID}, Worktree: worktree, CwdRelpath: cwdRelpath}); err != nil {
 		t.Fatalf("UpdateSessionExecutionTarget %s: %v", sessionID, err)
 	}
 }

--- a/server/worktree/service_test.go
+++ b/server/worktree/service_test.go
@@ -33,6 +33,20 @@ type serviceTestRuntime struct {
 	rebindHook            func(context.Context, string, string, string)
 }
 
+func sessionTargetWorktreeID(target clientui.SessionExecutionTarget) string {
+	if target.Worktree == nil {
+		return ""
+	}
+	return strings.TrimSpace(target.Worktree.ID)
+}
+
+func sessionTargetWorktreeRoot(target clientui.SessionExecutionTarget) string {
+	if target.Worktree == nil {
+		return ""
+	}
+	return strings.TrimSpace(target.Worktree.Root)
+}
+
 func (r *serviceTestRuntime) blockedRunCount(sessionID string) int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -230,8 +244,8 @@ func TestCreateWorktreeMarksProvenanceAndRunsSetupScriptWithProjectID(t *testing
 	if !resp.Worktree.Managed {
 		t.Fatal("expected worktree managed=true")
 	}
-	if resp.Target.WorktreeID != resp.Worktree.WorktreeID {
-		t.Fatalf("create target worktree id = %q, want %q", resp.Target.WorktreeID, resp.Worktree.WorktreeID)
+	if sessionTargetWorktreeID(resp.Target) != resp.Worktree.WorktreeID {
+		t.Fatalf("create target worktree id = %q, want %q", sessionTargetWorktreeID(resp.Target), resp.Worktree.WorktreeID)
 	}
 	if resp.Target.EffectiveWorkdir != resp.Worktree.CanonicalRoot {
 		t.Fatalf("create effective workdir = %q, want %q", resp.Target.EffectiveWorkdir, resp.Worktree.CanonicalRoot)
@@ -494,8 +508,8 @@ func TestSwitchWorktreeClampsCwdAndRecordsPendingReminder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SwitchWorktree: %v", err)
 	}
-	if resp.Target.WorktreeID != "" {
-		t.Fatalf("target worktree id = %q, want main workspace", resp.Target.WorktreeID)
+	if sessionTargetWorktreeID(resp.Target) != "" {
+		t.Fatalf("target worktree id = %q, want main workspace", sessionTargetWorktreeID(resp.Target))
 	}
 	if resp.Target.CwdRelpath != "." {
 		t.Fatalf("target cwd_relpath = %q, want .", resp.Target.CwdRelpath)
@@ -520,7 +534,7 @@ func TestSwitchWorktreeClampsCwdAndRecordsPendingReminder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget: %v", err)
 	}
-	if finalTarget.WorktreeID != "" || finalTarget.CwdRelpath != "." {
+	if sessionTargetWorktreeID(finalTarget) != "" || finalTarget.CwdRelpath != "." {
 		t.Fatalf("unexpected final target after switch: %+v", finalTarget)
 	}
 }
@@ -542,8 +556,8 @@ func TestListWorktreesRetargetsMissingCurrentWorktreeBeforePruning(t *testing.T)
 	if err != nil {
 		t.Fatalf("ListWorktrees: %v", err)
 	}
-	if resp.Target.WorktreeID != "" {
-		t.Fatalf("response target worktree id = %q, want main workspace", resp.Target.WorktreeID)
+	if sessionTargetWorktreeID(resp.Target) != "" {
+		t.Fatalf("response target worktree id = %q, want main workspace", sessionTargetWorktreeID(resp.Target))
 	}
 	if resp.Target.CwdRelpath != "." {
 		t.Fatalf("response target cwd_relpath = %q, want .", resp.Target.CwdRelpath)
@@ -560,11 +574,11 @@ func TestListWorktreesRetargetsMissingCurrentWorktreeBeforePruning(t *testing.T)
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget: %v", err)
 	}
-	if resolved.WorktreeID != "" {
-		t.Fatalf("stored target worktree id = %q, want main workspace", resolved.WorktreeID)
+	if sessionTargetWorktreeID(resolved) != "" {
+		t.Fatalf("stored target worktree id = %q, want main workspace", sessionTargetWorktreeID(resolved))
 	}
-	if resolved.WorktreeRoot != "" {
-		t.Fatalf("stored target worktree root = %q, want empty", resolved.WorktreeRoot)
+	if sessionTargetWorktreeRoot(resolved) != "" {
+		t.Fatalf("stored target worktree root = %q, want empty", sessionTargetWorktreeRoot(resolved))
 	}
 	if resolved.CwdRelpath != "." {
 		t.Fatalf("stored target cwd_relpath = %q, want .", resolved.CwdRelpath)
@@ -576,7 +590,7 @@ func TestListWorktreesRetargetsMissingCurrentWorktreeBeforePruning(t *testing.T)
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget other session: %v", err)
 	}
-	if otherTarget.WorktreeID != "" || otherTarget.EffectiveWorkdir != env.workspaceRoot {
+	if sessionTargetWorktreeID(otherTarget) != "" || otherTarget.EffectiveWorkdir != env.workspaceRoot {
 		t.Fatalf("expected other session retargeted to main workspace, got %+v", otherTarget)
 	}
 	if len(env.runtime.rebindCalls) != 1 {
@@ -621,11 +635,48 @@ func TestSwitchWorktreeRollsBackExecutionTargetWhenRebindFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget: %v", err)
 	}
-	if finalTarget.WorktreeID != "" || finalTarget.EffectiveWorkdir != env.workspaceRoot {
+	if sessionTargetWorktreeID(finalTarget) != "" || finalTarget.EffectiveWorkdir != env.workspaceRoot {
 		t.Fatalf("expected execution target rollback to main workspace, got %+v", finalTarget)
 	}
 	if notes := env.localNotes.snapshot(); len(notes) != 0 {
 		t.Fatalf("expected no local notes on failed switch, got %+v", notes)
+	}
+}
+
+func TestSwitchSessionTargetRejectsInvalidPreviousTargetBeforeMetadataMutation(t *testing.T) {
+	env := newServiceTestEnv(t)
+	invalidPrevious := clientui.SessionExecutionTarget{
+		WorkspaceID:      env.binding.WorkspaceID,
+		WorkspaceRoot:    env.workspaceRoot,
+		Worktree:         &clientui.SessionExecutionWorktreeTarget{},
+		CwdRelpath:       ".",
+		EffectiveWorkdir: env.workspaceRoot,
+	}
+	workspaceCtx := sessionWorkspaceContext{
+		sessionID:     env.session.Meta().SessionID,
+		workspaceID:   env.binding.WorkspaceID,
+		workspaceRoot: env.workspaceRoot,
+		target:        invalidPrevious,
+		projectID:     env.binding.ProjectID,
+	}
+	next := syncedWorktree{
+		record: metadata.WorktreeRecord{
+			ID:            "worktree-next",
+			WorkspaceID:   env.binding.WorkspaceID,
+			CanonicalRoot: filepath.Join(env.workspaceRoot, "next"),
+		},
+		git: GitWorktree{},
+	}
+
+	if _, err := env.service.switchSessionTarget(env.ctx, workspaceCtx, nil, next); err == nil {
+		t.Fatal("expected switchSessionTarget to reject previous target with present empty worktree id")
+	}
+	target, err := env.store.ResolveSessionExecutionTarget(env.ctx, env.session.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("ResolveSessionExecutionTarget: %v", err)
+	}
+	if sessionTargetWorktreeID(target) != "" || target.EffectiveWorkdir != env.workspaceRoot {
+		t.Fatalf("execution target mutated despite invalid previous target: %+v", target)
 	}
 }
 
@@ -659,7 +710,7 @@ func TestSwitchWorktreeRollsBackExecutionTargetWhenRequestContextCancelsDuringRe
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget: %v", err)
 	}
-	if finalTarget.WorktreeID != "" || finalTarget.EffectiveWorkdir != env.workspaceRoot {
+	if sessionTargetWorktreeID(finalTarget) != "" || finalTarget.EffectiveWorkdir != env.workspaceRoot {
 		t.Fatalf("expected execution target rollback to main workspace, got %+v", finalTarget)
 	}
 	if got := env.runtime.rebindCalls[len(env.runtime.rebindCalls)-1].root; got != env.workspaceRoot {
@@ -710,7 +761,7 @@ func TestCreateWorktreeCleansUpCreatedStateWhenPostCreateSwitchFails(t *testing.
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget: %v", err)
 	}
-	if finalTarget.WorktreeID != "" || finalTarget.EffectiveWorkdir != env.workspaceRoot {
+	if sessionTargetWorktreeID(finalTarget) != "" || finalTarget.EffectiveWorkdir != env.workspaceRoot {
 		t.Fatalf("expected session target unchanged after failed create, got %+v", finalTarget)
 	}
 }
@@ -746,14 +797,14 @@ func TestDeleteWorktreeRetargetsActiveIdleSessionsTargetingIt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget other session: %v", err)
 	}
-	if target.WorktreeID != "" || target.EffectiveWorkdir != env.workspaceRoot {
+	if sessionTargetWorktreeID(target) != "" || target.EffectiveWorkdir != env.workspaceRoot {
 		t.Fatalf("expected active idle session retargeted to main workspace, got %+v", target)
 	}
 	dormantTarget, err := env.store.ResolveSessionExecutionTarget(env.ctx, dormantSession.Meta().SessionID)
 	if err != nil {
 		t.Fatalf("ResolveSessionExecutionTarget dormant session: %v", err)
 	}
-	if dormantTarget.WorktreeID != "" || dormantTarget.EffectiveWorkdir != env.workspaceRoot {
+	if sessionTargetWorktreeID(dormantTarget) != "" || dormantTarget.EffectiveWorkdir != env.workspaceRoot {
 		t.Fatalf("expected dormant stale session retargeted by worktree deletion cleanup, got %+v", dormantTarget)
 	}
 	foundRebind := false
@@ -787,7 +838,7 @@ func TestDeleteWorktreeRollsBackActiveIdleSessionRetargetsOnRuntimeSyncError(t *
 		if err != nil {
 			t.Fatalf("ResolveSessionExecutionTarget %s: %v", sess.Meta().SessionID, err)
 		}
-		if target.WorktreeID != created.WorktreeID || target.EffectiveWorkdir != created.CanonicalRoot {
+		if sessionTargetWorktreeID(target) != created.WorktreeID || target.EffectiveWorkdir != created.CanonicalRoot {
 			t.Fatalf("expected %s target rolled back to worktree, got %+v", sess.Meta().SessionID, target)
 		}
 	}

--- a/server/worktree/worktree_helpers.go
+++ b/server/worktree/worktree_helpers.go
@@ -13,18 +13,26 @@ import (
 	"core/shared/serverapi"
 )
 
-func mapSyncedWorktrees(items []syncedWorktree, target clientui.SessionExecutionTarget) []serverapi.WorktreeView {
+func mapSyncedWorktrees(items []syncedWorktree, target clientui.SessionExecutionTarget) ([]serverapi.WorktreeView, error) {
 	out := make([]serverapi.WorktreeView, 0, len(items))
 	for _, item := range items {
-		out = append(out, worktreeViewFromSynced(item, target))
+		view, err := worktreeViewFromSynced(item, target)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, view)
 	}
-	return out
+	return out, nil
 }
 
-func worktreeViewFromSynced(item syncedWorktree, target clientui.SessionExecutionTarget) serverapi.WorktreeView {
-	isCurrent := strings.TrimSpace(target.WorktreeID) == strings.TrimSpace(item.record.ID)
-	if strings.TrimSpace(target.WorktreeID) == "" && item.git.IsMain {
-		isCurrent = true
+func worktreeViewFromSynced(item syncedWorktree, target clientui.SessionExecutionTarget) (serverapi.WorktreeView, error) {
+	if err := validatePresentExecutionTargetWorktreeID(target); err != nil {
+		return serverapi.WorktreeView{}, err
+	}
+	isCurrent := item.git.IsMain && target.Worktree == nil
+	if target.Worktree != nil {
+		targetWorktreeID := strings.TrimSpace(target.Worktree.ID)
+		isCurrent = targetWorktreeID == strings.TrimSpace(item.record.ID)
 	}
 	return serverapi.WorktreeView{
 		WorktreeID:      item.record.ID,
@@ -42,7 +50,7 @@ func worktreeViewFromSynced(item syncedWorktree, target clientui.SessionExecutio
 		Managed:         item.record.Managed,
 		CreatedBranch:   item.record.CreatedBranch,
 		OriginSessionID: item.record.OriginSessionID,
-	}
+	}, nil
 }
 
 func findSyncedWorktreeByID(items []syncedWorktree, worktreeID string) (syncedWorktree, bool) {
@@ -74,15 +82,28 @@ func findMainWorktree(items []syncedWorktree) (syncedWorktree, bool) {
 	return syncedWorktree{}, false
 }
 
-func currentSyncedWorktree(items []syncedWorktree, target clientui.SessionExecutionTarget) *syncedWorktree {
-	trimmedID := strings.TrimSpace(target.WorktreeID)
-	if trimmedID == "" {
-		return nil
+func currentSyncedWorktree(items []syncedWorktree, target clientui.SessionExecutionTarget) (*syncedWorktree, error) {
+	if err := validatePresentExecutionTargetWorktreeID(target); err != nil {
+		return nil, err
 	}
+	if target.Worktree == nil {
+		return nil, nil
+	}
+	trimmedID := strings.TrimSpace(target.Worktree.ID)
 	for idx := range items {
 		if strings.TrimSpace(items[idx].record.ID) == trimmedID {
-			return &items[idx]
+			return &items[idx], nil
 		}
+	}
+	return nil, nil
+}
+
+func validatePresentExecutionTargetWorktreeID(target clientui.SessionExecutionTarget) error {
+	if target.Worktree == nil {
+		return nil
+	}
+	if strings.TrimSpace(target.Worktree.ID) == "" {
+		return errors.New("session execution target worktree id is required")
 	}
 	return nil
 }

--- a/server/worktree/worktree_helpers_test.go
+++ b/server/worktree/worktree_helpers_test.go
@@ -1,0 +1,72 @@
+package worktree
+
+import (
+	"testing"
+
+	"core/server/metadata"
+	"core/shared/clientui"
+)
+
+func TestWorktreeHelpersRejectPresentTargetWithEmptyWorktreeID(t *testing.T) {
+	item := syncedWorktree{
+		record: metadata.WorktreeRecord{ID: "worktree-1"},
+		git:    GitWorktree{},
+	}
+	target := clientui.SessionExecutionTarget{Worktree: &clientui.SessionExecutionWorktreeTarget{}}
+
+	if _, err := worktreeViewFromSynced(item, target); err == nil {
+		t.Fatal("expected worktree view to reject present worktree target without id")
+	}
+	if _, err := currentSyncedWorktree([]syncedWorktree{item}, target); err == nil {
+		t.Fatal("expected current worktree lookup to reject present worktree target without id")
+	}
+}
+
+func TestWorktreeViewFromSyncedUsesNilWorktreeAsMainWorkspaceTarget(t *testing.T) {
+	main := syncedWorktree{
+		record: metadata.WorktreeRecord{ID: "worktree-main"},
+		git:    GitWorktree{IsMain: true},
+	}
+	linked := syncedWorktree{
+		record: metadata.WorktreeRecord{ID: "worktree-linked"},
+		git:    GitWorktree{IsMain: false},
+	}
+
+	mainView, err := worktreeViewFromSynced(main, clientui.SessionExecutionTarget{})
+	if err != nil {
+		t.Fatalf("main worktree view: %v", err)
+	}
+	linkedView, err := worktreeViewFromSynced(linked, clientui.SessionExecutionTarget{})
+	if err != nil {
+		t.Fatalf("linked worktree view: %v", err)
+	}
+	if !mainView.IsCurrent {
+		t.Fatal("expected main worktree current when target has nil worktree")
+	}
+	if linkedView.IsCurrent {
+		t.Fatal("expected linked worktree not current when target has nil worktree")
+	}
+}
+
+func TestWorktreeReminderTransitionRejectsPresentPreviousTargetWithEmptyWorktreeID(t *testing.T) {
+	previous := &syncedWorktree{
+		record: metadata.WorktreeRecord{CanonicalRoot: "/repo/worktree"},
+		git:    GitWorktree{IsMain: false},
+	}
+	next := syncedWorktree{
+		record: metadata.WorktreeRecord{CanonicalRoot: "/repo"},
+		git:    GitWorktree{IsMain: true},
+	}
+	previousTarget := clientui.SessionExecutionTarget{
+		WorkspaceRoot: "/repo",
+		Worktree:      &clientui.SessionExecutionWorktreeTarget{},
+	}
+	nextTarget := clientui.SessionExecutionTarget{
+		WorkspaceRoot:    "/repo",
+		EffectiveWorkdir: "/repo",
+	}
+
+	if _, _, err := worktreeReminderStateForTransition(previous, previousTarget, next, nextTarget); err == nil {
+		t.Fatal("expected transition reminder to reject present previous worktree target without id")
+	}
+}

--- a/server/worktree/worktree_retarget.go
+++ b/server/worktree/worktree_retarget.go
@@ -92,10 +92,10 @@ func (s *Service) retargetSessionsFromWorktree(ctx context.Context, workspaceID 
 		}
 		cwdRelpath := clampCwdRelpath(previousTarget.CwdRelpath, trimmedWorkspaceRoot)
 		if err := s.metadata.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{
-			SessionID:   blocker.SessionID,
-			WorkspaceID: trimmedWorkspaceID,
-			Worktree:    nil,
-			CwdRelpath:  cwdRelpath,
+			SessionID:  blocker.SessionID,
+			Workspace:  &metadata.SessionExecutionTargetUpdateWorkspace{ID: trimmedWorkspaceID},
+			Worktree:   nil,
+			CwdRelpath: cwdRelpath,
 		}); err != nil {
 			appendErr(blocker.SessionID, err)
 			if options.rollbackOnError {
@@ -212,10 +212,10 @@ func (s *Service) switchSessionTarget(ctx context.Context, workspaceCtx sessionW
 	}
 	cwdRelpath := clampCwdRelpath(previousTarget.CwdRelpath, nextBaseRoot)
 	if err := s.metadata.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{
-		SessionID:   workspaceCtx.sessionID,
-		WorkspaceID: workspaceCtx.workspaceID,
-		Worktree:    nextWorktree,
-		CwdRelpath:  cwdRelpath,
+		SessionID:  workspaceCtx.sessionID,
+		Workspace:  &metadata.SessionExecutionTargetUpdateWorkspace{ID: workspaceCtx.workspaceID},
+		Worktree:   nextWorktree,
+		CwdRelpath: cwdRelpath,
 	}); err != nil {
 		return clientui.SessionExecutionTarget{}, err
 	}

--- a/server/worktree/worktree_retarget.go
+++ b/server/worktree/worktree_retarget.go
@@ -91,10 +91,15 @@ func (s *Service) retargetSessionsFromWorktree(ctx context.Context, workspaceID 
 			continue
 		}
 		cwdRelpath := clampCwdRelpath(previousTarget.CwdRelpath, trimmedWorkspaceRoot)
-		if err := s.metadata.UpdateSessionExecutionTargetByID(ctx, blocker.SessionID, trimmedWorkspaceID, "", cwdRelpath); err != nil {
+		if err := s.metadata.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{
+			SessionID:   blocker.SessionID,
+			WorkspaceID: trimmedWorkspaceID,
+			Worktree:    nil,
+			CwdRelpath:  cwdRelpath,
+		}); err != nil {
 			appendErr(blocker.SessionID, err)
 			if options.rollbackOnError {
-				return errors.Join(errors.Join(collected...), s.rollbackRetargetedSessions(ctx, trimmedWorkspaceID, pending))
+				return errors.Join(errors.Join(collected...), s.rollbackRetargetedSessions(ctx, pending))
 			}
 			continue
 		}
@@ -105,7 +110,7 @@ func (s *Service) retargetSessionsFromWorktree(ctx context.Context, workspaceID 
 		if err != nil {
 			appendErr(item.sessionID, err)
 			if options.rollbackOnError {
-				return errors.Join(errors.Join(collected...), s.rollbackRetargetedSessions(ctx, trimmedWorkspaceID, pending))
+				return errors.Join(errors.Join(collected...), s.rollbackRetargetedSessions(ctx, pending))
 			}
 			continue
 		}
@@ -113,17 +118,17 @@ func (s *Service) retargetSessionsFromWorktree(ctx context.Context, workspaceID 
 		if err != nil {
 			appendErr(item.sessionID, err)
 			if options.rollbackOnError {
-				return errors.Join(errors.Join(collected...), s.rollbackRetargetedSessions(ctx, trimmedWorkspaceID, pending))
+				return errors.Join(errors.Join(collected...), s.rollbackRetargetedSessions(ctx, pending))
 			}
 			continue
 		}
 		if err := s.runtime.SyncExecutionTarget(ctx, item.sessionID, nextTarget, &reminder); err != nil {
 			appendErr(item.sessionID, err)
 			if options.rollbackOnError {
-				return errors.Join(errors.Join(collected...), s.rollbackRetargetedSessions(ctx, trimmedWorkspaceID, pending))
+				return errors.Join(errors.Join(collected...), s.rollbackRetargetedSessions(ctx, pending))
 			}
 			rollbackCtx, cancel := liveRollbackContext(ctx)
-			rollbackErr := s.metadata.UpdateSessionExecutionTargetByID(rollbackCtx, item.sessionID, trimmedWorkspaceID, item.previousTarget.WorktreeID, item.previousTarget.CwdRelpath)
+			rollbackErr := s.metadata.UpdateSessionExecutionTarget(rollbackCtx, metadata.SessionExecutionTargetUpdateFromReadModel(item.sessionID, item.previousTarget))
 			cancel()
 			if rollbackErr != nil {
 				appendErr(item.sessionID, errors.Join(err, fmt.Errorf("rollback execution target after runtime sync failure: %w", rollbackErr)))
@@ -135,7 +140,7 @@ func (s *Service) retargetSessionsFromWorktree(ctx context.Context, workspaceID 
 	return errors.Join(collected...)
 }
 
-func (s *Service) rollbackRetargetedSessions(ctx context.Context, workspaceID string, pending []pendingWorktreeSessionRetarget) error {
+func (s *Service) rollbackRetargetedSessions(ctx context.Context, pending []pendingWorktreeSessionRetarget) error {
 	if len(pending) == 0 {
 		return nil
 	}
@@ -144,7 +149,7 @@ func (s *Service) rollbackRetargetedSessions(ctx context.Context, workspaceID st
 		item := pending[i]
 		sessionID := strings.TrimSpace(item.sessionID)
 		rollbackCtx, cancel := liveRollbackContext(ctx)
-		if err := s.metadata.UpdateSessionExecutionTargetByID(rollbackCtx, sessionID, workspaceID, item.previousTarget.WorktreeID, item.previousTarget.CwdRelpath); err != nil {
+		if err := s.metadata.UpdateSessionExecutionTarget(rollbackCtx, metadata.SessionExecutionTargetUpdateFromReadModel(sessionID, item.previousTarget)); err != nil {
 			collected = append(collected, fmt.Errorf("rollback session %q execution target: %w", sessionID, err))
 			cancel()
 			continue
@@ -195,13 +200,23 @@ func (s *Service) switchSessionTarget(ctx context.Context, workspaceCtx sessionW
 	}
 	nextWorktreeID := strings.TrimSpace(next.record.ID)
 	nextBaseRoot := strings.TrimSpace(next.record.CanonicalRoot)
+	var nextWorktree *metadata.SessionExecutionTargetUpdateWorktree
 	if next.git.IsMain {
-		nextWorktreeID = ""
 		nextBaseRoot = workspaceCtx.workspaceRoot
+	} else {
+		nextWorktree = &metadata.SessionExecutionTargetUpdateWorktree{ID: nextWorktreeID}
 	}
 	previousTarget := workspaceCtx.target
+	if err := validatePresentExecutionTargetWorktreeID(previousTarget); err != nil {
+		return clientui.SessionExecutionTarget{}, err
+	}
 	cwdRelpath := clampCwdRelpath(previousTarget.CwdRelpath, nextBaseRoot)
-	if err := s.metadata.UpdateSessionExecutionTargetByID(ctx, workspaceCtx.sessionID, workspaceCtx.workspaceID, nextWorktreeID, cwdRelpath); err != nil {
+	if err := s.metadata.UpdateSessionExecutionTarget(ctx, metadata.SessionExecutionTargetUpdate{
+		SessionID:   workspaceCtx.sessionID,
+		WorkspaceID: workspaceCtx.workspaceID,
+		Worktree:    nextWorktree,
+		CwdRelpath:  cwdRelpath,
+	}); err != nil {
 		return clientui.SessionExecutionTarget{}, err
 	}
 	nextTarget, err := s.metadata.ResolveSessionExecutionTarget(ctx, workspaceCtx.sessionID)
@@ -209,7 +224,12 @@ func (s *Service) switchSessionTarget(ctx context.Context, workspaceCtx sessionW
 		s.rollbackSessionTarget(ctx, workspaceCtx, previousTarget)
 		return clientui.SessionExecutionTarget{}, err
 	}
-	if reminder, ok := worktreeReminderStateForTransition(previous, previousTarget, next, nextTarget); ok {
+	reminder, ok, err := worktreeReminderStateForTransition(previous, previousTarget, next, nextTarget)
+	if err != nil {
+		s.rollbackSessionTarget(ctx, workspaceCtx, previousTarget)
+		return clientui.SessionExecutionTarget{}, err
+	}
+	if ok {
 		if err := s.applySessionTarget(ctx, workspaceCtx.sessionID, nextTarget, &reminder); err != nil {
 			s.rollbackSessionTarget(ctx, workspaceCtx, previousTarget)
 			return clientui.SessionExecutionTarget{}, err
@@ -230,7 +250,7 @@ func (s *Service) applySessionTarget(ctx context.Context, sessionID string, targ
 func (s *Service) rollbackSessionTarget(ctx context.Context, workspaceCtx sessionWorkspaceContext, previousTarget clientui.SessionExecutionTarget) {
 	rollbackCtx, cancel := liveRollbackContext(ctx)
 	defer cancel()
-	_ = s.metadata.UpdateSessionExecutionTargetByID(rollbackCtx, workspaceCtx.sessionID, workspaceCtx.workspaceID, previousTarget.WorktreeID, previousTarget.CwdRelpath)
+	_ = s.metadata.UpdateSessionExecutionTarget(rollbackCtx, metadata.SessionExecutionTargetUpdateFromReadModel(workspaceCtx.sessionID, previousTarget))
 	_ = s.runtime.ClearWorktreeReminder(rollbackCtx, workspaceCtx.sessionID)
 	if strings.TrimSpace(previousTarget.EffectiveWorkdir) != "" {
 		_ = s.runtime.SyncExecutionTarget(rollbackCtx, workspaceCtx.sessionID, previousTarget, nil)
@@ -244,10 +264,13 @@ func liveRollbackContext(ctx context.Context) (context.Context, context.CancelFu
 	return context.WithTimeout(context.WithoutCancel(ctx), rollbackSessionTargetTimeout)
 }
 
-func worktreeReminderStateForTransition(previous *syncedWorktree, previousTarget clientui.SessionExecutionTarget, next syncedWorktree, nextTarget clientui.SessionExecutionTarget) (session.WorktreeReminderState, bool) {
+func worktreeReminderStateForTransition(previous *syncedWorktree, previousTarget clientui.SessionExecutionTarget, next syncedWorktree, nextTarget clientui.SessionExecutionTarget) (session.WorktreeReminderState, bool, error) {
+	if err := validatePresentExecutionTargetWorktreeID(previousTarget); err != nil {
+		return session.WorktreeReminderState{}, false, err
+	}
 	if next.git.IsMain {
-		if previous == nil || strings.TrimSpace(previousTarget.WorktreeID) == "" || previous.git.IsMain {
-			return session.WorktreeReminderState{}, false
+		if previous == nil || previousTarget.Worktree == nil || previous.git.IsMain {
+			return session.WorktreeReminderState{}, false, nil
 		}
 		return session.WorktreeReminderState{
 			Mode:          session.WorktreeReminderModeExit,
@@ -255,7 +278,7 @@ func worktreeReminderStateForTransition(previous *syncedWorktree, previousTarget
 			WorktreePath:  strings.TrimSpace(previous.record.CanonicalRoot),
 			WorkspaceRoot: strings.TrimSpace(nextTarget.WorkspaceRoot),
 			EffectiveCwd:  strings.TrimSpace(nextTarget.EffectiveWorkdir),
-		}, true
+		}, true, nil
 	}
 	return session.WorktreeReminderState{
 		Mode:          session.WorktreeReminderModeEnter,
@@ -263,7 +286,7 @@ func worktreeReminderStateForTransition(previous *syncedWorktree, previousTarget
 		WorktreePath:  strings.TrimSpace(next.record.CanonicalRoot),
 		WorkspaceRoot: strings.TrimSpace(nextTarget.WorkspaceRoot),
 		EffectiveCwd:  strings.TrimSpace(nextTarget.EffectiveWorkdir),
-	}, true
+	}, true, nil
 }
 
 func worktreeReminderStateForExitedWorktree(worktree metadata.WorktreeRecord, nextTarget clientui.SessionExecutionTarget) (session.WorktreeReminderState, error) {

--- a/shared/clientui/runtime.go
+++ b/shared/clientui/runtime.go
@@ -104,35 +104,67 @@ type SessionExecutionTarget struct {
 	WorkspaceName         string
 	WorkspaceRoot         string
 	WorkspaceAvailability string
-	WorktreeID            string
-	WorktreeName          string
-	WorktreeRoot          string
-	WorktreeAvailability  string
+	Worktree              *SessionExecutionWorktreeTarget
 	CwdRelpath            string
 	EffectiveWorkdir      string
 }
 
+type SessionExecutionWorktreeTarget struct {
+	ID           string
+	Name         string
+	Root         string
+	Availability string
+}
+
 func NormalizeSessionExecutionTarget(target SessionExecutionTarget) SessionExecutionTarget {
+	var worktree *SessionExecutionWorktreeTarget
+	if target.Worktree != nil {
+		worktree = &SessionExecutionWorktreeTarget{
+			ID:           strings.TrimSpace(target.Worktree.ID),
+			Name:         strings.TrimSpace(target.Worktree.Name),
+			Root:         strings.TrimSpace(target.Worktree.Root),
+			Availability: strings.TrimSpace(target.Worktree.Availability),
+		}
+	}
 	return SessionExecutionTarget{
 		WorkspaceID:           strings.TrimSpace(target.WorkspaceID),
 		WorkspaceName:         strings.TrimSpace(target.WorkspaceName),
 		WorkspaceRoot:         strings.TrimSpace(target.WorkspaceRoot),
 		WorkspaceAvailability: strings.TrimSpace(target.WorkspaceAvailability),
-		WorktreeID:            strings.TrimSpace(target.WorktreeID),
-		WorktreeName:          strings.TrimSpace(target.WorktreeName),
-		WorktreeRoot:          strings.TrimSpace(target.WorktreeRoot),
-		WorktreeAvailability:  strings.TrimSpace(target.WorktreeAvailability),
+		Worktree:              worktree,
 		CwdRelpath:            strings.TrimSpace(target.CwdRelpath),
 		EffectiveWorkdir:      strings.TrimSpace(target.EffectiveWorkdir),
 	}
 }
 
 func SessionExecutionTargetIsZero(target SessionExecutionTarget) bool {
-	return NormalizeSessionExecutionTarget(target) == SessionExecutionTarget{}
+	normalized := NormalizeSessionExecutionTarget(target)
+	return normalized.WorkspaceID == "" &&
+		normalized.WorkspaceName == "" &&
+		normalized.WorkspaceRoot == "" &&
+		normalized.WorkspaceAvailability == "" &&
+		normalized.Worktree == nil &&
+		normalized.CwdRelpath == "" &&
+		normalized.EffectiveWorkdir == ""
 }
 
 func SessionExecutionTargetsEqual(a SessionExecutionTarget, b SessionExecutionTarget) bool {
-	return NormalizeSessionExecutionTarget(a) == NormalizeSessionExecutionTarget(b)
+	normalizedA := NormalizeSessionExecutionTarget(a)
+	normalizedB := NormalizeSessionExecutionTarget(b)
+	worktreesEqual := normalizedA.Worktree == normalizedB.Worktree
+	if normalizedA.Worktree != nil && normalizedB.Worktree != nil {
+		worktreesEqual = normalizedA.Worktree.ID == normalizedB.Worktree.ID &&
+			normalizedA.Worktree.Name == normalizedB.Worktree.Name &&
+			normalizedA.Worktree.Root == normalizedB.Worktree.Root &&
+			normalizedA.Worktree.Availability == normalizedB.Worktree.Availability
+	}
+	return normalizedA.WorkspaceID == normalizedB.WorkspaceID &&
+		normalizedA.WorkspaceName == normalizedB.WorkspaceName &&
+		normalizedA.WorkspaceRoot == normalizedB.WorkspaceRoot &&
+		normalizedA.WorkspaceAvailability == normalizedB.WorkspaceAvailability &&
+		worktreesEqual &&
+		normalizedA.CwdRelpath == normalizedB.CwdRelpath &&
+		normalizedA.EffectiveWorkdir == normalizedB.EffectiveWorkdir
 }
 
 type RuntimeSessionView struct {

--- a/shared/clientui/runtime_execution_target_test.go
+++ b/shared/clientui/runtime_execution_target_test.go
@@ -1,0 +1,89 @@
+package clientui
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestSessionExecutionTargetWorkspaceRootSerializesNilWorktree(t *testing.T) {
+	target := SessionExecutionTarget{
+		WorkspaceID:           "workspace-1",
+		WorkspaceName:         "Workspace",
+		WorkspaceRoot:         "/repo",
+		WorkspaceAvailability: "available",
+		Worktree:              nil,
+		CwdRelpath:            ".",
+		EffectiveWorkdir:      "/repo",
+	}
+
+	encoded, err := json.Marshal(target)
+	if err != nil {
+		t.Fatalf("marshal execution target: %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatalf("unmarshal encoded execution target: %v", err)
+	}
+	worktree, ok := fields["Worktree"]
+	if !ok {
+		t.Fatalf("encoded execution target = %s, want explicit worktree field", encoded)
+	}
+	if !bytes.Equal(worktree, []byte("null")) {
+		t.Fatalf("encoded worktree JSON = %s, want null", worktree)
+	}
+}
+
+func TestNormalizeSessionExecutionTargetPreservesNilWorktreeAbsence(t *testing.T) {
+	target := NormalizeSessionExecutionTarget(SessionExecutionTarget{
+		WorkspaceID:           " workspace-1 ",
+		WorkspaceName:         " Workspace ",
+		WorkspaceRoot:         " /repo ",
+		WorkspaceAvailability: " available ",
+		Worktree:              nil,
+		CwdRelpath:            " . ",
+		EffectiveWorkdir:      " /repo ",
+	})
+
+	if target.Worktree != nil {
+		t.Fatalf("normalized workspace-root target worktree = %+v, want nil", target.Worktree)
+	}
+	if target.WorkspaceID != "workspace-1" || target.CwdRelpath != "." || target.EffectiveWorkdir != "/repo" {
+		t.Fatalf("normalized target = %+v, want trimmed workspace-root fields", target)
+	}
+}
+
+func TestSessionExecutionTargetsEqualNormalizesPresentWorktree(t *testing.T) {
+	left := SessionExecutionTarget{
+		WorkspaceID:           "workspace-1",
+		WorkspaceName:         "Workspace",
+		WorkspaceRoot:         "/repo",
+		WorkspaceAvailability: "available",
+		Worktree: &SessionExecutionWorktreeTarget{
+			ID:           " worktree-1 ",
+			Name:         " Task worktree ",
+			Root:         " /repo/.kent-worktree ",
+			Availability: " missing ",
+		},
+		CwdRelpath:       " subdir ",
+		EffectiveWorkdir: " /repo/.kent-worktree/subdir ",
+	}
+	right := SessionExecutionTarget{
+		WorkspaceID:           "workspace-1",
+		WorkspaceName:         "Workspace",
+		WorkspaceRoot:         "/repo",
+		WorkspaceAvailability: "available",
+		Worktree: &SessionExecutionWorktreeTarget{
+			ID:           "worktree-1",
+			Name:         "Task worktree",
+			Root:         "/repo/.kent-worktree",
+			Availability: "missing",
+		},
+		CwdRelpath:       "subdir",
+		EffectiveWorkdir: "/repo/.kent-worktree/subdir",
+	}
+
+	if !SessionExecutionTargetsEqual(left, right) {
+		t.Fatalf("targets should compare equal after normalization:\nleft=%+v\nright=%+v", left, right)
+	}
+}

--- a/shared/protocol/version.json
+++ b/shared/protocol/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "37"
+  "version": "38"
 }


### PR DESCRIPTION
## Summary
- Make explicit `kent rebind` reset the authoritative execution target to the workspace root, clearing stale worktree state and worktree reminders.
- Replace execution-target worktree absence in the shared read model with nullable `Worktree` state and a typed metadata update boundary.
- Add same-workspace stale-worktree regression coverage plus worktree transition validation for invalid present-empty worktree targets.

## Verification
- `./scripts/test.sh ./server/metadata ./server/worktree ./server/workflowrunner ./server/launch ./server/sessionservice ./shared/clientui ./cli/app ./cli/kent` (after rebase: one workflowrunner timeout in `TestExecuteWorkflowScriptCancelKillsTermIgnoringProcess`; immediate focused rerun passed)
- `./scripts/test.sh ./server/workflowrunner --run TestExecuteWorkflowScriptCancelKillsTermIgnoringProcess`
- `./scripts/build.sh --output ./bin/kent`

## QA Evidence
- Manual QA report: `.kent/qa/KENT-195-manual-qa.md`
- Isolated runtime QA verified same-workspace stale `sessions.worktree_id` is set to SQL NULL, `cwd_relpath` resets to `.`, stale worktree rows remain harmlessly present, and effective target resolves to the canonical workspace root.

Closes #474