### PR TITLE
feat: make worktree setup blocking

### DIFF
--- a/apps/desktop/src/api/attentionNotificationSubscription.ts
+++ b/apps/desktop/src/api/attentionNotificationSubscription.ts
@@ -1,0 +1,29 @@
+import type { AttentionNotificationEventHandler } from "./attentionNotifications";
+import { ContractError } from "./errors";
+import {
+  attentionNotificationEventParamsSchema,
+  isUnsupportedAttentionNotificationEventParams,
+} from "./schemas/attentionNotification";
+import type { RpcEventHandler } from "./transport";
+
+export function attentionNotificationRpcHandler(handler: AttentionNotificationEventHandler): RpcEventHandler {
+  return {
+    ...(handler.onOpen !== undefined ? { onOpen: handler.onOpen } : {}),
+    onComplete: handler.onComplete,
+    onError: handler.onError,
+    onEvent(method, params) {
+      if (method !== "attention.notification") {
+        return;
+      }
+      const parsed = attentionNotificationEventParamsSchema.safeParse(params);
+      if (parsed.success) {
+        handler.onEvent(parsed.data.event);
+        return;
+      }
+      if (isUnsupportedAttentionNotificationEventParams(params)) {
+        return;
+      }
+      handler.onError(new ContractError("attention.notification event did not match GUI contract."));
+    },
+  };
+}

--- a/apps/desktop/src/api/attentionNotifications.test.ts
+++ b/apps/desktop/src/api/attentionNotifications.test.ts
@@ -1,0 +1,161 @@
+import { ApiClient } from "./client";
+import type { AttentionNotificationEvent } from "./attentionNotifications";
+import { ContractError } from "./errors";
+import { FakeRpcTransport } from "./fakeTransport";
+
+describe("attention notification API", () => {
+  it("subscribes to typed attention notifications and rejects malformed events at the API boundary", () => {
+    const transport = new FakeRpcTransport([]);
+    const client = new ApiClient(transport);
+    const events: AttentionNotificationEvent[] = [];
+    const errors: Error[] = [];
+
+    client.subscribeAttentionNotifications({
+      onEvent(event) {
+        events.push(event);
+      },
+      onComplete() {
+        return;
+      },
+      onError(error) {
+        errors.push(error);
+      },
+    });
+
+    expect(transport.subscriptions).toContainEqual({
+      method: "attention.notification.subscribe",
+      params: {},
+    });
+    transport.emit("attention.notification", {
+      event: {
+        type: "pending",
+        sequence: 1,
+        source: "live",
+        pending: {
+          id: { kind: "question", uuid: "batch-1" },
+          kind: "question",
+          occurred_at: "2026-06-29T12:00:00Z",
+          revision: 1,
+          question: {
+            prepared_ask_ids: ["ask-1", "ask-2"],
+            materialized_ask_ids: ["ask-1"],
+            current_unresolved_ask_ids: ["ask-1"],
+            skipped_ask_ids: [],
+            preview: "question from agent",
+            display_count: 2,
+            materialized_count: 1,
+          },
+          target: {
+            kind: "workflow_task",
+            project_id: "project-1",
+            workflow_id: "workflow-1",
+            task_id: "task-1",
+            task_short_id: "KT-1",
+            task_title: "Needs answer",
+            session_id: "session-1",
+            run_id: "run-1",
+            focus: { kind: "question", ask_ids: ["ask-1", "ask-2"] },
+          },
+        },
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    if (event?.type !== "pending") {
+      throw new Error("Expected parsed attention pending event.");
+    }
+    expect(event.pending.id).toEqual({ kind: "question", uuid: "batch-1" });
+    expect(event.pending.question?.displayCount).toBe(2);
+    if (event.pending.target.kind !== "workflow_task") {
+      throw new Error("Expected workflow-task attention target.");
+    }
+    expect(event.pending.target.focus).toEqual({ kind: "question", askIDs: ["ask-1", "ask-2"] });
+
+    transport.emit("attention.notification", {
+      event: {
+        type: "pending",
+        sequence: 2,
+        source: "live",
+        pending: {
+          id: "broken",
+          kind: "question",
+          occurred_at: "2026-06-29T12:00:00Z",
+          revision: 1,
+          target: { kind: "workflow_task", task_id: "task-1" },
+        },
+      },
+    });
+
+    expect(errors[0]).toBeInstanceOf(ContractError);
+
+    transport.emit("attention.notification", {
+      event: {
+        type: "pending",
+        sequence: 3,
+        source: "live",
+        pending: {
+          id: { kind: "question", uuid: "future" },
+          kind: "future_attention",
+          occurred_at: "2026-06-29T12:00:00Z",
+          revision: 1,
+          target: { kind: "future_target" },
+        },
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+  });
+
+  it("parses interrupted-run attention notifications", () => {
+    const transport = new FakeRpcTransport([]);
+    const client = new ApiClient(transport);
+    const events: AttentionNotificationEvent[] = [];
+
+    client.subscribeAttentionNotifications({
+      onEvent(event) {
+        events.push(event);
+      },
+      onComplete() {
+        return;
+      },
+      onError(error) {
+        throw error;
+      },
+    });
+
+    transport.emit("attention.notification", {
+      event: {
+        type: "pending",
+        sequence: 1,
+        source: "live",
+        pending: {
+          id: { kind: "interrupted_run", uuid: "run-1" },
+          kind: "interrupted_run",
+          occurred_at: "2026-06-29T12:00:00Z",
+          revision: 1,
+          interrupted_run: {
+            run_id: "run-1",
+            message: "Run interrupted",
+            reason: "workflow_runtime_failed",
+          },
+          target: {
+            kind: "workflow_task",
+            task_id: "task-1",
+            run_id: "run-1",
+            focus: { kind: "interrupted_run", run_id: "run-1" },
+          },
+        },
+      },
+    });
+
+    const event = events[0];
+    if (event?.type !== "pending" || event.pending.target.kind !== "workflow_task") {
+      throw new Error("Expected parsed interrupted-run attention pending event.");
+    }
+    expect(event.pending.kind).toBe("interrupted_run");
+    expect(event.pending.question).toBeNull();
+    expect(event.pending.target.focus).toEqual({ kind: "interrupted_run", runID: "run-1" });
+  });
+});

--- a/apps/desktop/src/api/client.test.ts
+++ b/apps/desktop/src/api/client.test.ts
@@ -1,8 +1,14 @@
+import { z } from "zod";
+
 import { ApiClient } from "./client";
-import type { AttentionNotificationEvent } from "./attentionNotifications";
 import { ContractError } from "./errors";
 import { FakeRpcTransport } from "./fakeTransport";
 import { protocolVersion } from "./jsonRpcSocket";
+
+const startTaskParamsSchema = z.object({
+  task_id: z.literal("task-1"),
+  setup_operation_id: z.string(),
+});
 
 describe("ApiClient", () => {
   it("parses readiness and sends mutation params through typed method boundary", async () => {
@@ -33,7 +39,9 @@ describe("ApiClient", () => {
     });
     await client.startTask("task-1");
 
-    expect(transport.calls).toContainEqual({ method: "workflow.task.start", params: { task_id: "task-1" } });
+    const startCall = transport.calls.find((call) => call.method === "workflow.task.start");
+    expect(startCall?.options).toEqual({ timeoutMs: null });
+    expect(startTaskParamsSchema.parse(startCall?.params).task_id).toBe("task-1");
   });
 
   it("rejects server contract drift before feature code receives raw data", async () => {
@@ -42,150 +50,6 @@ describe("ApiClient", () => {
     );
 
     await expect(client.getReadiness()).rejects.toBeInstanceOf(ContractError);
-  });
-
-  it("subscribes to typed attention notifications and rejects malformed events at the API boundary", () => {
-    const transport = new FakeRpcTransport([]);
-    const client = new ApiClient(transport);
-    const events: AttentionNotificationEvent[] = [];
-    const errors: Error[] = [];
-
-    client.subscribeAttentionNotifications({
-      onEvent(event) {
-        events.push(event);
-      },
-      onComplete() {
-        return;
-      },
-      onError(error) {
-        errors.push(error);
-      },
-    });
-
-    expect(transport.subscriptions).toContainEqual({
-      method: "attention.notification.subscribe",
-      params: {},
-    });
-    transport.emit("attention.notification", {
-      event: {
-        type: "pending",
-        sequence: 1,
-        source: "live",
-        pending: {
-          id: { kind: "question", uuid: "batch-1" },
-          kind: "question",
-          occurred_at: "2026-06-29T12:00:00Z",
-          revision: 1,
-          question: {
-            prepared_ask_ids: ["ask-1", "ask-2"],
-            materialized_ask_ids: ["ask-1"],
-            current_unresolved_ask_ids: ["ask-1"],
-            skipped_ask_ids: [],
-            preview: "question from agent",
-            display_count: 2,
-            materialized_count: 1,
-          },
-          target: {
-            kind: "workflow_task",
-            project_id: "project-1",
-            workflow_id: "workflow-1",
-            task_id: "task-1",
-            task_short_id: "KT-1",
-            task_title: "Needs answer",
-            session_id: "session-1",
-            run_id: "run-1",
-            focus: { kind: "question", ask_ids: ["ask-1", "ask-2"] },
-          },
-        },
-      },
-    });
-
-    expect(events).toHaveLength(1);
-    const event = events[0];
-    if (event?.type !== "pending") {
-      throw new Error("Expected parsed attention pending event.");
-    }
-    expect(event.pending.id).toEqual({ kind: "question", uuid: "batch-1" });
-    expect(event.pending.question?.displayCount).toBe(2);
-    if (event.pending.target.kind !== "workflow_task") {
-      throw new Error("Expected workflow-task attention target.");
-    }
-    expect(event.pending.target.focus).toEqual({ kind: "question", askIDs: ["ask-1", "ask-2"] });
-
-    transport.emit("attention.notification", {
-      event: {
-        type: "pending",
-        sequence: 2,
-        source: "live",
-        pending: {
-          id: "broken",
-          kind: "question",
-          occurred_at: "2026-06-29T12:00:00Z",
-          revision: 1,
-          target: { kind: "workflow_task", task_id: "task-1" },
-        },
-      },
-    });
-
-    expect(errors[0]).toBeInstanceOf(ContractError);
-
-    transport.emit("attention.notification", {
-      event: { type: "pending", sequence: 3, source: "live", pending: { id: { kind: "question", uuid: "future" }, kind: "future_attention", occurred_at: "2026-06-29T12:00:00Z", revision: 1, target: { kind: "future_target" } } },
-    });
-
-    expect(events).toHaveLength(1);
-    expect(errors).toHaveLength(1);
-  });
-
-  it("parses interrupted-run attention notifications", () => {
-    const transport = new FakeRpcTransport([]);
-    const client = new ApiClient(transport);
-    const events: AttentionNotificationEvent[] = [];
-
-    client.subscribeAttentionNotifications({
-      onEvent(event) {
-        events.push(event);
-      },
-      onComplete() {
-        return;
-      },
-      onError(error) {
-        throw error;
-      },
-    });
-
-    transport.emit("attention.notification", {
-      event: {
-        type: "pending",
-        sequence: 1,
-        source: "live",
-        pending: {
-          id: { kind: "interrupted_run", uuid: "run-1" },
-          kind: "interrupted_run",
-          occurred_at: "2026-06-29T12:00:00Z",
-          revision: 1,
-          interrupted_run: {
-            run_id: "run-1",
-            message: "Run interrupted",
-            reason: "workflow_runtime_failed",
-          },
-          target: {
-            kind: "workflow_task",
-            task_id: "task-1",
-            run_id: "run-1",
-            focus: { kind: "interrupted_run", run_id: "run-1" },
-          },
-        },
-      },
-    });
-
-    const event = events[0];
-    if (event?.type !== "pending" || event.pending.target.kind !== "workflow_task") {
-      throw new Error("Expected parsed interrupted-run attention pending event.");
-    }
-    expect(event.pending.kind).toBe("interrupted_run");
-    expect(event.pending.question).toBeNull();
-    expect(event.pending.target.focus).toEqual({ kind: "interrupted_run", runID: "run-1" });
   });
 
   it("surfaces workflow move auto-approval failures returned in successful responses", async () => {

--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -1,6 +1,7 @@
-import { type z } from "zod";
-
 import type { AttentionNotificationEventHandler } from "./attentionNotifications";
+import { attentionNotificationRpcHandler } from "./attentionNotificationSubscription";
+import { parseRpcResponse as parse } from "./clientParse";
+import * as taskLifecycle from "./clientTaskLifecycle";
 import {
   workflowGraphDraftPayload,
   workflowGraphMetadataPayload,
@@ -22,8 +23,12 @@ import type {
   WorkflowListInput,
   WorkflowProjectLinkInput,
 } from "./clientInputs";
-import { ContractError } from "./errors";
 import { compactJsonObject, emptyJsonObject } from "./json";
+import type { SetupOperationID } from "./setupOperationID";
+import {
+  worktreeSetupRpcHandler,
+  type WorktreeSetupEventHandler,
+} from "./worktreeSetup";
 import type {
   ActivityPage,
   AttentionPage,
@@ -67,10 +72,6 @@ import {
 } from "./schemas/project";
 import { readinessSchema } from "./schemas/status";
 import {
-  attentionNotificationEventParamsSchema,
-  isUnsupportedAttentionNotificationEventParams,
-} from "./schemas/attentionNotification";
-import {
   activityPageSchema,
   attentionPageSchema,
   boardNodeCardsPageSchema,
@@ -79,7 +80,6 @@ import {
   pendingAskListSchema,
   projectWorkflowLinksSchema,
   taskCreateResponseSchema,
-  taskMoveResponseSchema,
   taskDetailSchema,
   taskUpdateResponseSchema,
   workflowBoardSchema,
@@ -512,29 +512,12 @@ export class ApiClient {
     return response.task.id;
   }
 
-  async startTask(taskID: string): Promise<void> {
-    await this.transport.call("workflow.task.start", { task_id: taskID });
+  async startTask(taskID: string, setupOperationID?: SetupOperationID): Promise<void> {
+    await taskLifecycle.startTask(this.transport, taskID, setupOperationID);
   }
 
   async moveTask(input: TaskMoveInput): Promise<TaskMoveResponse> {
-    const response = parse(
-      "workflow.task.move",
-      taskMoveResponseSchema,
-      await this.transport.call(
-        "workflow.task.move",
-        compactJsonObject({
-          task_id: input.taskID,
-          target_node_id: input.targetNodeID,
-          output_values: input.outputValues ?? {},
-          allow_missing_edge: input.allowMissingEdge,
-          auto_approve: input.autoApprove,
-        }),
-      ),
-    );
-    if (response.approvalError.length > 0) {
-      throw new Error(response.approvalError);
-    }
-    return response;
+    return taskLifecycle.moveTask(this.transport, input);
   }
 
   async interruptTask(taskID: string, sessionID?: string): Promise<void> {
@@ -548,8 +531,11 @@ export class ApiClient {
     await this.transport.call("workflow.task.resume", compactJsonObject({ task_id: taskID }));
   }
 
-  async approveTransition(taskTransitionID: string): Promise<void> {
-    await this.transport.call("workflow.task.approve", { task_transition_id: taskTransitionID });
+  async approveTransition(
+    taskTransitionID: string,
+    setupOperationID?: SetupOperationID,
+  ): Promise<void> {
+    await taskLifecycle.approveTransition(this.transport, taskTransitionID, setupOperationID);
   }
 
   async cancelTask(taskID: string): Promise<void> {
@@ -643,36 +629,18 @@ export class ApiClient {
   }
 
   subscribeAttentionNotifications(handler: AttentionNotificationEventHandler): RpcSubscription {
-    const rpcHandler = {
-      ...(handler.onOpen !== undefined ? { onOpen: handler.onOpen } : {}),
-      onComplete: handler.onComplete,
-      onError: handler.onError,
-      onEvent(method, params) {
-        if (method !== "attention.notification") {
-          return;
-        }
-        try {
-          handler.onEvent(
-            parse("attention.notification", attentionNotificationEventParamsSchema, params).event,
-          );
-        } catch (cause) {
-          if (isUnsupportedAttentionNotificationEventParams(params)) {
-            return;
-          }
-          handler.onError(
-            cause instanceof Error ? cause : new Error("Invalid attention notification event."),
-          );
-        }
-      },
-    } satisfies RpcEventHandler;
-    return this.transport.subscribe("attention.notification.subscribe", emptyJsonObject, rpcHandler);
+    return this.transport.subscribe(
+      "attention.notification.subscribe",
+      emptyJsonObject,
+      attentionNotificationRpcHandler(handler),
+    );
   }
-}
 
-function parse<T>(method: string, schema: z.ZodType<T>, value: unknown): T {
-  const result = schema.safeParse(value);
-  if (!result.success) {
-    throw new ContractError(`${method} response did not match GUI contract.`);
+  subscribeWorktreeSetup(setupOperationID: SetupOperationID, handler: WorktreeSetupEventHandler): RpcSubscription {
+    return this.transport.subscribe(
+      "worktree.setup.subscribe",
+      { setup_operation_id: setupOperationID.toJSONValue() },
+      worktreeSetupRpcHandler(handler),
+    );
   }
-  return result.data;
 }

--- a/apps/desktop/src/api/clientInputs.ts
+++ b/apps/desktop/src/api/clientInputs.ts
@@ -4,6 +4,7 @@ import type {
   WorkflowGraphSaveConfirmation,
   WorkflowValidationMode,
 } from "./models";
+import type { SetupOperationID } from "./setupOperationID";
 
 export type TaskMutationInput = Readonly<{
   projectID: string;
@@ -87,6 +88,7 @@ export type TaskMoveInput = Readonly<{
   outputValues?: Readonly<Record<string, string>>;
   allowMissingEdge?: boolean;
   autoApprove?: boolean;
+  setupOperationID?: SetupOperationID | undefined;
 }>;
 
 export type QuestionAnswerInput = Readonly<{

--- a/apps/desktop/src/api/clientParse.ts
+++ b/apps/desktop/src/api/clientParse.ts
@@ -1,0 +1,11 @@
+import { type z } from "zod";
+
+import { ContractError } from "./errors";
+
+export function parseRpcResponse<T>(method: string, schema: z.ZodType<T>, value: unknown): T {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    throw new ContractError(`${method} response did not match GUI contract.`);
+  }
+  return result.data;
+}

--- a/apps/desktop/src/api/clientTaskLifecycle.ts
+++ b/apps/desktop/src/api/clientTaskLifecycle.ts
@@ -1,0 +1,54 @@
+import type { TaskMoveInput } from "./clientInputs";
+import { parseRpcResponse } from "./clientParse";
+import { compactJsonObject } from "./json";
+import type { TaskMoveResponse } from "./models";
+import { taskMoveResponseSchema } from "./schemas/workflowBoard";
+import { newSetupOperationID, type SetupOperationID } from "./setupOperationID";
+import type { RpcTransport } from "./transport";
+
+export async function startTask(
+  transport: RpcTransport,
+  taskID: string,
+  setupOperationID: SetupOperationID = newSetupOperationID(),
+): Promise<void> {
+  await transport.call(
+    "workflow.task.start",
+    { task_id: taskID, setup_operation_id: setupOperationID.toJSONValue() },
+    { timeoutMs: null },
+  );
+}
+
+export async function moveTask(transport: RpcTransport, input: TaskMoveInput): Promise<TaskMoveResponse> {
+  const response = parseRpcResponse(
+    "workflow.task.move",
+    taskMoveResponseSchema,
+    await transport.call(
+      "workflow.task.move",
+      compactJsonObject({
+        task_id: input.taskID,
+        target_node_id: input.targetNodeID,
+        output_values: input.outputValues ?? {},
+        allow_missing_edge: input.allowMissingEdge,
+        auto_approve: input.autoApprove,
+        setup_operation_id: (input.setupOperationID ?? newSetupOperationID()).toJSONValue(),
+      }),
+      { timeoutMs: null },
+    ),
+  );
+  if (response.approvalError.length > 0) {
+    throw new Error(response.approvalError);
+  }
+  return response;
+}
+
+export async function approveTransition(
+  transport: RpcTransport,
+  taskTransitionID: string,
+  setupOperationID: SetupOperationID = newSetupOperationID(),
+): Promise<void> {
+  await transport.call(
+    "workflow.task.approve",
+    { task_transition_id: taskTransitionID, setup_operation_id: setupOperationID.toJSONValue() },
+    { timeoutMs: null },
+  );
+}

--- a/apps/desktop/src/api/fakeTransport.ts
+++ b/apps/desktop/src/api/fakeTransport.ts
@@ -1,6 +1,7 @@
 import { ConnectionStore } from "./connectionStore";
 import type { JsonValue } from "./json";
 import type { RpcEventHandler, RpcSubscription, RpcTransport } from "./transport";
+import type { RpcCallOptions } from "./transport";
 
 export type FakeRoute = Readonly<{
   method: string;
@@ -11,7 +12,7 @@ export type FakeRoute = Readonly<{
 
 export class FakeRpcTransport implements RpcTransport {
   readonly connection = new ConnectionStore();
-  readonly calls: Readonly<{ method: string; params: JsonValue }>[] = [];
+  readonly calls: Readonly<{ method: string; params: JsonValue; options?: RpcCallOptions }>[] = [];
   #routes = new Map<string, FakeRoute>();
   #callCounts = new Map<string, number>();
   #subscribers: Readonly<{ method: string; params: JsonValue; handler: RpcEventHandler }>[] = [];
@@ -23,8 +24,8 @@ export class FakeRpcTransport implements RpcTransport {
     this.connection.set("connected");
   }
 
-  async call(method: string, params: JsonValue): Promise<unknown> {
-    this.calls.push({ method, params });
+  async call(method: string, params: JsonValue, options?: RpcCallOptions): Promise<unknown> {
+    this.calls.push(options === undefined ? { method, params } : { method, params, options });
     const route = this.#routes.get(method);
     if (route === undefined) {
       throw new Error(`Missing fake route: ${method}`);

--- a/apps/desktop/src/api/jsonRpc.test.ts
+++ b/apps/desktop/src/api/jsonRpc.test.ts
@@ -55,6 +55,7 @@ describe("JsonRpcWebSocketTransport", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -140,6 +141,38 @@ describe("JsonRpcWebSocketTransport", () => {
     ack(socket, 1);
 
     await expect(readiness).resolves.toEqual({});
+  });
+
+  it("keeps no-timeout control calls pending past the generic request deadline", async () => {
+    vi.useFakeTimers();
+    const transport = createJsonRpcTransport("ws://127.0.0.1:53082/rpc");
+    const mutation = transport.call(
+      "workflow.task.start",
+      { task_id: "task-1" },
+      { timeoutMs: null },
+    );
+    let settled = false;
+    mutation.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    const socket = sockets[0] ?? failTest("control socket missing");
+
+    socket.open();
+    await waitForSent(socket, 1);
+    ack(socket, 0);
+    await waitForSent(socket, 2);
+    expect(frame(socket, 1)).toMatchObject({ method: "workflow.task.start" });
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    expect(settled).toBe(false);
+    ack(socket, 1);
+
+    await expect(mutation).resolves.toEqual({});
   });
 
   it("installs subscription event listener before subscribe ack can race with first event", async () => {

--- a/apps/desktop/src/api/jsonRpc.ts
+++ b/apps/desktop/src/api/jsonRpc.ts
@@ -18,7 +18,7 @@ import {
   subscriptionCompleteMethod,
   waitForSubscriptionEnd,
 } from "./jsonRpcSocket";
-import type { RpcEventHandler, RpcSubscription, RpcTransport } from "./transport";
+import type { RpcCallOptions, RpcEventHandler, RpcSubscription, RpcTransport } from "./transport";
 
 const socketOpenTimeoutMs = 10_000;
 const rpcRequestTimeoutMs = 30_000;
@@ -28,7 +28,7 @@ const textFrameSchema = z.string();
 
 type PendingRequest = Readonly<{
   method: string;
-  timeout: ReturnType<typeof setTimeout>;
+  timeout: ReturnType<typeof setTimeout> | null;
   resolve(value: unknown): void;
   reject(error: Error): void;
 }>;
@@ -51,9 +51,9 @@ class JsonRpcWebSocketTransport implements RpcTransport {
     this.#expectedRootId = expectedRootId;
   }
 
-  async call(method: string, params: JsonValue): Promise<unknown> {
+  async call(method: string, params: JsonValue, options?: RpcCallOptions): Promise<unknown> {
     const socket = await this.#open();
-    return this.#send(socket, method, params);
+    return this.#send(socket, method, params, options);
   }
 
   subscribe(method: string, params: JsonValue, handler: RpcEventHandler): RpcSubscription {
@@ -105,7 +105,7 @@ class JsonRpcWebSocketTransport implements RpcTransport {
     return socket;
   }
 
-  async #send(socket: WebSocket, method: string, params: JsonValue): Promise<unknown> {
+  async #send(socket: WebSocket, method: string, params: JsonValue, options?: RpcCallOptions): Promise<unknown> {
     if (socket.readyState !== WebSocket.OPEN) {
       return Promise.reject(new TransportError("WebSocket is not open."));
     }
@@ -113,17 +113,20 @@ class JsonRpcWebSocketTransport implements RpcTransport {
     this.#nextID += 1;
     const frame = JSON.stringify({ jsonrpc: jsonRpcVersion, id, method, params });
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
+      const timeoutMs = options?.timeoutMs === undefined ? rpcRequestTimeoutMs : options.timeoutMs;
+      const timeout = timeoutMs === null ? null : setTimeout(() => {
         if (!this.#pending.delete(id)) {
           return;
         }
         reject(new TransportError(`${method} request timed out.`));
-      }, rpcRequestTimeoutMs);
+      }, timeoutMs);
       this.#pending.set(id, { method, timeout, resolve, reject });
       try {
         socket.send(frame);
       } catch (error) {
-        clearTimeout(timeout);
+        if (timeout !== null) {
+          clearTimeout(timeout);
+        }
         this.#pending.delete(id);
         reject(error instanceof Error ? error : new TransportError(`${method} request failed to send.`));
       }
@@ -150,7 +153,9 @@ class JsonRpcWebSocketTransport implements RpcTransport {
       return;
     }
     this.#pending.delete(id);
-    clearTimeout(pending.timeout);
+    if (pending.timeout !== null) {
+      clearTimeout(pending.timeout);
+    }
     if (error !== undefined) {
       pending.reject(socketRequestError(pending.method, error));
       return;
@@ -174,7 +179,9 @@ class JsonRpcWebSocketTransport implements RpcTransport {
     const pending = [...this.#pending.values()];
     this.#pending.clear();
     for (const request of pending) {
-      clearTimeout(request.timeout);
+      if (request.timeout !== null) {
+        clearTimeout(request.timeout);
+      }
       request.reject(error);
     }
   }

--- a/apps/desktop/src/api/setupOperationID.ts
+++ b/apps/desktop/src/api/setupOperationID.ts
@@ -1,0 +1,60 @@
+export class SetupOperationID {
+  readonly #value: string;
+
+  private constructor(value: string) {
+    this.#value = value;
+  }
+
+  static parse(value: string): SetupOperationID {
+    if (!isSetupOperationID(value)) {
+      throw new Error("Setup operation id must be a UUID v4.");
+    }
+    return new SetupOperationID(value);
+  }
+
+  toJSONValue(): string {
+    return this.#value;
+  }
+}
+
+const uuidSectionLengths = [8, 4, 4, 4, 12] as const;
+const variantDigits = new Set(["8", "9", "a", "b"]);
+
+function isSetupOperationID(value: string): boolean {
+  const sections = value.split("-");
+  return (
+    sections.length === uuidSectionLengths.length &&
+    sections.every((section, index) => isHexSection(section, uuidSectionLengths[index] ?? 0)) &&
+    sections[2]?.charAt(0) === "4" &&
+    variantDigits.has(sections[3]?.charAt(0).toLowerCase() ?? "")
+  );
+}
+
+function isHexSection(section: string, expectedLength: number): boolean {
+  if (section.length !== expectedLength) {
+    return false;
+  }
+  for (const char of section) {
+    if (!isHexDigit(char)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isHexDigit(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 70) ||
+    (code >= 97 && code <= 102)
+  );
+}
+
+export function parseSetupOperationID(value: string): SetupOperationID {
+  return SetupOperationID.parse(value);
+}
+
+export function newSetupOperationID(): SetupOperationID {
+  return parseSetupOperationID(crypto.randomUUID());
+}

--- a/apps/desktop/src/api/transport.ts
+++ b/apps/desktop/src/api/transport.ts
@@ -12,8 +12,12 @@ export type RpcSubscription = Readonly<{
   close(): void;
 }>;
 
+export type RpcCallOptions = Readonly<{
+  timeoutMs?: number | null;
+}>;
+
 export type RpcTransport = Readonly<{
   connection: ConnectionStore;
-  call(method: string, params: JsonValue): Promise<unknown>;
+  call(method: string, params: JsonValue, options?: RpcCallOptions): Promise<unknown>;
   subscribe(method: string, params: JsonValue, handler: RpcEventHandler): RpcSubscription;
 }>;

--- a/apps/desktop/src/api/worktreeSetup.test.ts
+++ b/apps/desktop/src/api/worktreeSetup.test.ts
@@ -1,0 +1,150 @@
+import { z } from "zod";
+
+import { ApiClient } from "./client";
+import { ContractError } from "./errors";
+import { FakeRpcTransport } from "./fakeTransport";
+import { newSetupOperationID, parseSetupOperationID, type SetupOperationID } from "./setupOperationID";
+import type { WorktreeSetupEvent } from "./worktreeSetup";
+
+const setupOperationIDWireSchema = z.string().transform((value, ctx): SetupOperationID => {
+  try {
+    return parseSetupOperationID(value);
+  } catch {
+    ctx.addIssue({ code: "custom", message: "Expected setup operation id UUID v4." });
+    return z.NEVER;
+  }
+});
+
+const setupMutationParamsSchema = z.object({
+  setup_operation_id: setupOperationIDWireSchema,
+});
+
+function parseSetupMutationParams(value: unknown): Readonly<{ setupOperationID: SetupOperationID }> {
+  const parsed = setupMutationParamsSchema.parse(value);
+  return { setupOperationID: parsed.setup_operation_id };
+}
+
+describe("worktree setup API", () => {
+  it("rejects malformed setup operation ids before RPC submission can use them", () => {
+    expect(() => parseSetupOperationID("11111111-1111-1111-1111-111111111111")).toThrow(
+      "Setup operation id must be a UUID v4.",
+    );
+    expect(() => parseSetupOperationID("not-a-uuid")).toThrow("Setup operation id must be a UUID v4.");
+  });
+
+  it("uses caller-provided setup operation ids and disables generic timeouts for workflow lifecycle mutations", async () => {
+    const transport = new FakeRpcTransport([
+      { method: "workflow.task.start", result: {} },
+      {
+        method: "workflow.task.approve",
+        result: { transition_id: "transition-1", task_id: "task-1", state: "approved" },
+      },
+      {
+        method: "workflow.task.move",
+        result: { transition_id: "transition-1", state: "approved", run_ids: [] },
+      },
+    ]);
+    const client = new ApiClient(transport);
+    const startSetupID = newSetupOperationID();
+    const approveSetupID = newSetupOperationID();
+    const moveSetupID = newSetupOperationID();
+
+    client.subscribeWorktreeSetup(startSetupID, {
+      onEvent() {
+        return;
+      },
+      onComplete() {
+        return;
+      },
+      onError(error) {
+        throw error;
+      },
+    });
+    await client.startTask("task-1", startSetupID);
+    await client.approveTransition("transition-1", approveSetupID);
+    await client.moveTask({
+      taskID: "task-1",
+      targetNodeID: "node-1",
+      allowMissingEdge: true,
+      autoApprove: true,
+      setupOperationID: moveSetupID,
+    });
+
+    expect(transport.subscriptions).toContainEqual({
+      method: "worktree.setup.subscribe",
+      params: { setup_operation_id: startSetupID.toJSONValue() },
+    });
+    for (const [method, expectedSetupID] of [
+      ["workflow.task.start", startSetupID],
+      ["workflow.task.approve", approveSetupID],
+      ["workflow.task.move", moveSetupID],
+    ] as const) {
+      const call = transport.calls.find((entry) => entry.method === method);
+      expect(call?.options).toEqual({ timeoutMs: null });
+      expect(parseSetupMutationParams(call?.params).setupOperationID.toJSONValue()).toBe(
+        expectedSetupID.toJSONValue(),
+      );
+    }
+  });
+
+  it("subscribes to typed worktree setup events and rejects malformed setup ids", () => {
+    const transport = new FakeRpcTransport([]);
+    const client = new ApiClient(transport);
+    const setupOperationID = parseSetupOperationID("123e4567-e89b-42d3-a456-426614174000");
+    const events: WorktreeSetupEvent[] = [];
+    const errors: Error[] = [];
+
+    client.subscribeWorktreeSetup(setupOperationID, {
+      onEvent(event) {
+        events.push(event);
+      },
+      onComplete() {
+        return;
+      },
+      onError(error) {
+        errors.push(error);
+      },
+    });
+
+    expect(transport.subscriptions).toContainEqual({
+      method: "worktree.setup.subscribe",
+      params: { setup_operation_id: setupOperationID.toJSONValue() },
+    });
+    transport.emit("worktree.setup", {
+      event: {
+        setup_operation_id: setupOperationID.toJSONValue(),
+        source_workspace_root: "/src",
+        worktree_root: "/worktree",
+        script_path: "/src/setup.sh",
+        phase: "started",
+      },
+    });
+
+    expect(events).toEqual([
+      {
+        setupOperationID,
+        sourceWorkspaceRoot: "/src",
+        worktreeRoot: "/worktree",
+        scriptPath: "/src/setup.sh",
+        phase: "started",
+        timeout: false,
+        canceled: false,
+        stdout: "",
+        stderr: "",
+        error: "",
+      },
+    ]);
+
+    transport.emit("worktree.setup", {
+      event: {
+        setup_operation_id: "not-a-uuid",
+        source_workspace_root: "/src",
+        worktree_root: "/worktree",
+        script_path: "/src/setup.sh",
+        phase: "started",
+      },
+    });
+
+    expect(errors[0]).toBeInstanceOf(ContractError);
+  });
+});

--- a/apps/desktop/src/api/worktreeSetup.ts
+++ b/apps/desktop/src/api/worktreeSetup.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+
+import { ContractError } from "./errors";
+import { parseSetupOperationID, type SetupOperationID } from "./setupOperationID";
+import type { RpcEventHandler } from "./transport";
+
+export type WorktreeSetupPhase = "started" | "completed" | "failed";
+
+export type WorktreeSetupEvent = Readonly<{
+  setupOperationID: SetupOperationID;
+  sourceWorkspaceRoot: string;
+  worktreeRoot: string;
+  scriptPath: string;
+  phase: WorktreeSetupPhase;
+  timeout: boolean;
+  canceled: boolean;
+  exitCode?: number;
+  stdout: string;
+  stderr: string;
+  error: string;
+}>;
+
+export type WorktreeSetupEventHandler = Readonly<{
+  onOpen?(): void;
+  onEvent(event: WorktreeSetupEvent): void;
+  onComplete(code: number, message: string): void;
+  onError(error: Error): void;
+}>;
+
+function setupOperationID(value: string, ctx: z.RefinementCtx): SetupOperationID {
+  try {
+    return parseSetupOperationID(value);
+  } catch {
+    ctx.addIssue({ code: "custom", message: "Expected setup operation id UUID v4." });
+    return z.NEVER;
+  }
+}
+
+const setupEventWireSchema = z.object({
+  setup_operation_id: z.string().transform(setupOperationID),
+  source_workspace_root: z.string().min(1),
+  worktree_root: z.string().min(1),
+  script_path: z.string().min(1),
+  phase: z.enum(["started", "completed", "failed"]),
+  timeout: z.boolean().optional().default(false),
+  canceled: z.boolean().optional().default(false),
+  exit_code: z.number().int().optional(),
+  stdout: z.string().optional().default(""),
+  stderr: z.string().optional().default(""),
+  error: z.string().optional().default(""),
+});
+
+export const worktreeSetupEventParamsSchema = z
+  .object({
+    event: setupEventWireSchema,
+  })
+  .transform(({ event }): { event: WorktreeSetupEvent } => {
+    const parsedEvent: WorktreeSetupEvent = {
+      setupOperationID: event.setup_operation_id,
+      sourceWorkspaceRoot: event.source_workspace_root,
+      worktreeRoot: event.worktree_root,
+      scriptPath: event.script_path,
+      phase: event.phase,
+      timeout: event.timeout,
+      canceled: event.canceled,
+      stdout: event.stdout,
+      stderr: event.stderr,
+      error: event.error,
+    };
+    return {
+      event: {
+        ...parsedEvent,
+        ...(event.exit_code !== undefined ? { exitCode: event.exit_code } : {}),
+      },
+    };
+  });
+
+export function worktreeSetupRpcHandler(handler: WorktreeSetupEventHandler): RpcEventHandler {
+  return {
+    ...(handler.onOpen !== undefined ? { onOpen: handler.onOpen } : {}),
+    onComplete: handler.onComplete,
+    onError: handler.onError,
+    onEvent(method, params) {
+      if (method !== "worktree.setup") {
+        return;
+      }
+      try {
+        handler.onEvent(worktreeSetupEventParamsSchema.parse(params).event);
+      } catch {
+        handler.onError(new ContractError("worktree.setup event did not match GUI contract."));
+      }
+    },
+  };
+}

--- a/apps/desktop/src/features/task-detail/TaskDetailDialog.test.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailDialog.test.tsx
@@ -105,9 +105,10 @@ describe("TaskDetailSurface", () => {
     expect(screen.queryByRole("button", { name: "Reject" })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Approve" }));
     await waitFor(() => {
-      expect(services.transport.calls).toContainEqual({
-        method: "workflow.task.approve",
-        params: { task_transition_id: "transition-1" },
+      const params = callParams(services.transport.calls, "workflow.task.approve");
+      expect(params.task_transition_id).toBe("transition-1");
+      expect(services.transport.calls.find((call) => call.method === "workflow.task.approve")?.options).toEqual({
+        timeoutMs: null,
       });
     });
 

--- a/cli/app/internal/worktreeui/worktreemutation_service.go
+++ b/cli/app/internal/worktreeui/worktreemutation_service.go
@@ -60,7 +60,10 @@ func (s Service) ResolveCreateTarget(target string) (serverapi.WorktreeCreateTar
 
 func (s Service) Create(req serverapi.WorktreeCreateRequest) (serverapi.WorktreeCreateResponse, error) {
 	clientRequestID := s.clientRequestID()
-	return runMutation(s, func(ctx context.Context) (serverapi.WorktreeCreateResponse, error) {
+	if err := req.SetupOperationID.Validate(); err != nil {
+		req.SetupOperationID = serverapi.NewWorktreeSetupOperationID()
+	}
+	return runCreateMutation(s, func(ctx context.Context) (serverapi.WorktreeCreateResponse, error) {
 		req.ClientRequestID = clientRequestID
 		req.SessionID = s.SessionID
 		return s.Client.CreateWorktree(ctx, req)
@@ -96,6 +99,18 @@ func runMutation[T any](s Service, call func(context.Context) (T, error)) (T, er
 	if err != nil {
 		return zero, err
 	}
+	defer cancel()
+	return retryControlCall(ctx, s.Runtime.RecoverRuntimeConnection, s.Runtime.AppendRecoveryWarning, func() (T, error) {
+		return call(ctx)
+	})
+}
+
+func runCreateMutation[T any](s Service, call func(context.Context) (T, error)) (T, error) {
+	var zero T
+	if s.Client == nil {
+		return zero, ErrClientUnavailable
+	}
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	return retryControlCall(ctx, s.Runtime.RecoverRuntimeConnection, s.Runtime.AppendRecoveryWarning, func() (T, error) {
 		return call(ctx)

--- a/cli/app/internal/worktreeui/worktreemutation_service_test.go
+++ b/cli/app/internal/worktreeui/worktreemutation_service_test.go
@@ -2,6 +2,7 @@ package worktreeui
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
@@ -58,6 +59,21 @@ func (c *testWorktreeClient) DeleteWorktree(ctx context.Context, req serverapi.W
 	c.deleteRequests = append(c.deleteRequests, req)
 	return c.deleteResp, c.nextErr()
 }
+
+func (c *testWorktreeClient) SubscribeWorktreeSetup(ctx context.Context, req serverapi.WorktreeSetupSubscribeRequest) (serverapi.WorktreeSetupSubscription, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	return testNoopWorktreeSetupSubscription{}, nil
+}
+
+type testNoopWorktreeSetupSubscription struct{}
+
+func (testNoopWorktreeSetupSubscription) Next(ctx context.Context) (serverapi.WorktreeSetupEvent, error) {
+	return serverapi.WorktreeSetupEvent{}, io.EOF
+}
+
+func (testNoopWorktreeSetupSubscription) Close() error { return nil }
 
 func (c *testWorktreeClient) nextErr() error {
 	if len(c.errs) == 0 {
@@ -165,6 +181,24 @@ func TestMutationsUseDedicatedMutationContext(t *testing.T) {
 	remaining := time.Until(deadline)
 	if remaining <= 8*time.Second {
 		t.Fatalf("delete context remaining = %v, want dedicated mutation timeout", remaining)
+	}
+}
+
+func TestCreateDoesNotInstallFixedMutationDeadline(t *testing.T) {
+	client := &testWorktreeClient{}
+	service := newTestService(client)
+	service.Runtime.MutationContext = func() (context.Context, context.CancelFunc) {
+		return context.WithTimeout(context.Background(), 10*time.Millisecond)
+	}
+
+	if _, err := service.Create(serverapi.WorktreeCreateRequest{BaseRef: "HEAD", CreateBranch: true, BranchName: "feature/a"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if client.createCtx == nil {
+		t.Fatal("expected create context recorded")
+	}
+	if _, ok := client.createCtx.Deadline(); ok {
+		t.Fatal("create context has a deadline")
 	}
 }
 

--- a/cli/app/ui_worktree_create_controller_test.go
+++ b/cli/app/ui_worktree_create_controller_test.go
@@ -116,3 +116,28 @@ func TestWorktreeCreateControllerSubmitStartsResolution(t *testing.T) {
 		t.Fatalf("resolve requests = %+v, want feature/new", client.resolveRequests)
 	}
 }
+
+func TestWorktreeCreateSetupEventUpdatesPendingOperationState(t *testing.T) {
+	model := newWorktreeCreateControllerTestModel(t, &worktreeCommandTestClient{listResp: testMainWorktreeListResponse()})
+	model.worktrees.mutationToken = 7
+	model.worktrees.create.submitting = true
+	event := serverapi.WorktreeSetupEvent{
+		SetupOperationID:    serverapi.NewWorktreeSetupOperationID(),
+		SourceWorkspaceRoot: "/repo",
+		WorktreeRoot:        "/repo/.worktrees/feature",
+		ScriptPath:          "/repo/scripts/setup.sh",
+		Phase:               serverapi.WorktreeSetupPhaseStarted,
+	}
+
+	updated := model.worktreeReducer().Update(worktreeSetupEventMsg{token: 7, event: event}).model
+
+	if updated.worktrees.create.setupEvent == nil {
+		t.Fatal("setup event was not reduced into create state")
+	}
+	if updated.worktrees.create.setupEvent.ScriptPath != event.ScriptPath || updated.worktrees.create.setupEvent.WorktreeRoot != event.WorktreeRoot {
+		t.Fatalf("setup event state = %+v, want script/worktree paths", updated.worktrees.create.setupEvent)
+	}
+	if !updated.worktrees.create.submitting {
+		t.Fatal("create operation stopped submitting before create response")
+	}
+}

--- a/cli/app/ui_worktree_reducer.go
+++ b/cli/app/ui_worktree_reducer.go
@@ -3,6 +3,7 @@ package app
 import (
 	"core/cli/app/internal/runtimeattach"
 	"core/cli/app/internal/worktreeui"
+	"core/shared/serverapi"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -39,6 +40,10 @@ func (r uiWorktreeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, nil)
 		}
+		if m.worktrees.create.setupProgress != nil && m.worktrees.create.setupProgress.cancel != nil {
+			m.worktrees.create.setupProgress.cancel()
+		}
+		m.worktrees.create.setupProgress = nil
 		m.worktrees.create.submitting = false
 		if msg.err != nil {
 			if !m.worktrees.open {
@@ -56,12 +61,26 @@ func (r uiWorktreeFeatureReducer) Update(msg tea.Msg) uiFeatureUpdateResult {
 			m.closeWorktreeOverlay()
 		}
 		status := "Created worktree " + worktreeui.DisplayName(msg.resp.Worktree)
-		if msg.resp.SetupScheduled {
-			status += " and started setup"
-		}
 		feedbackCmd := m.sendTransientStatusWithNoticeID(status, uiStatusNoticeSuccess, transientStatusDuration, uiStatusNoticeReplace, "")
 		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, tea.Batch(overlayCmd, feedbackCmd, m.startRuntimeMainViewRefreshRequest(runtimeMainViewRefreshRequestForCause(runtimeMainViewRefreshCauseWorktreeMutation)).cmd, m.reconcileSpinnerTicking(false)))
+	case worktreeSetupEventMsg:
+		if msg.token != m.worktrees.mutationToken {
+			m.layout().syncViewport()
+			return handledUIFeatureUpdate(m, nil)
+		}
+		if msg.err != nil {
+			m.worktrees.create.errorText = runtimeattach.FormatSubmissionError(msg.err)
+			m.layout().syncViewport()
+			return handledUIFeatureUpdate(m, m.reconcileSpinnerTicking(false))
+		}
+		event := msg.event
+		m.worktrees.create.setupEvent = &event
+		m.layout().syncViewport()
+		if event.Phase == serverapi.WorktreeSetupPhaseCompleted || event.Phase == serverapi.WorktreeSetupPhaseFailed {
+			return handledUIFeatureUpdate(m, nil)
+		}
+		return handledUIFeatureUpdate(m, worktreeSetupEventCmd(msg.events))
 	case worktreeSwitchDoneMsg:
 		if msg.token != m.worktrees.switchToken {
 			m.layout().syncViewport()

--- a/cli/app/ui_worktree_render.go
+++ b/cli/app/ui_worktree_render.go
@@ -259,6 +259,12 @@ func (l uiViewLayout) renderWorktreeCreateDialog(width, height int, style uiStyl
 	footer := make([]string, 0, 3)
 	if dialog.submitting {
 		footer = append(footer, style.meta.Render(truncateQueuedMessageLine(pendingToolSpinnerFrame(m.spinnerFrame)+" Creating worktree...", width)))
+		if dialog.setupEvent != nil && dialog.setupEvent.Phase == serverapi.WorktreeSetupPhaseStarted {
+			footer = append(footer,
+				style.meta.Render(truncateQueuedMessageLine("Setup script: "+dialog.setupEvent.ScriptPath, width)),
+				style.meta.Render(truncateQueuedMessageLine("Setup worktree: "+dialog.setupEvent.WorktreeRoot, width)),
+			)
+		}
 	}
 	if trimmed := strings.TrimSpace(dialog.errorText); trimmed != "" {
 		footer = append(footer, renderWorktreeErrorLines(trimmed, width, lipgloss.NewStyle().Foreground(sharedtheme.DefaultPalette().Status.Error.Adaptive()).Bold(true), worktreeOverlayMaxErrorLines)...)

--- a/cli/app/ui_worktree_test_helpers_test.go
+++ b/cli/app/ui_worktree_test_helpers_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -81,6 +82,21 @@ func (c *worktreeCommandTestClient) DeleteWorktree(ctx context.Context, req serv
 	}
 	return c.deleteResp, c.deleteErr
 }
+
+func (c *worktreeCommandTestClient) SubscribeWorktreeSetup(ctx context.Context, req serverapi.WorktreeSetupSubscribeRequest) (serverapi.WorktreeSetupSubscription, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	return worktreeCommandNoopSetupSubscription{}, nil
+}
+
+type worktreeCommandNoopSetupSubscription struct{}
+
+func (worktreeCommandNoopSetupSubscription) Next(ctx context.Context) (serverapi.WorktreeSetupEvent, error) {
+	return serverapi.WorktreeSetupEvent{}, io.EOF
+}
+
+func (worktreeCommandNoopSetupSubscription) Close() error { return nil }
 
 func (c *worktreeCommandTestClient) consumeReconnectFailure(kind string) bool {
 	if c == nil || c.reconnectFailures == nil {

--- a/cli/app/ui_worktrees.go
+++ b/cli/app/ui_worktrees.go
@@ -2,11 +2,14 @@ package app
 
 import (
 	"context"
+	"errors"
+	"io"
 	"strings"
 
 	"core/cli/app/internal/runtimeattach"
 	"core/cli/app/internal/worktreeui"
 	tuiinput "core/cli/tui/input"
+	"core/shared/client"
 	"core/shared/clientui"
 	"core/shared/serverapi"
 
@@ -61,6 +64,12 @@ type uiWorktreeCreateDialogState struct {
 	submitPending bool
 	resolveToken  uint64
 	resolution    serverapi.WorktreeCreateTargetResolution
+	setupProgress *uiWorktreeSetupProgressState
+	setupEvent    *serverapi.WorktreeSetupEvent
+}
+
+type uiWorktreeSetupProgressState struct {
+	cancel context.CancelFunc
 }
 
 type uiWorktreeDeleteAction = worktreeui.DeleteAction
@@ -114,6 +123,13 @@ type worktreeCreateDoneMsg struct {
 	token uint64
 	resp  serverapi.WorktreeCreateResponse
 	err   error
+}
+
+type worktreeSetupEventMsg struct {
+	token  uint64
+	event  serverapi.WorktreeSetupEvent
+	err    error
+	events <-chan worktreeSetupEventMsg
 }
 
 type worktreeSwitchDoneMsg struct {
@@ -177,6 +193,9 @@ func (m *uiModel) closeWorktreeOverlay() {
 	if m.worktrees.switchPending {
 		return
 	}
+	if m.worktrees.create.setupProgress != nil && m.worktrees.create.setupProgress.cancel != nil {
+		m.worktrees.create.setupProgress.cancel()
+	}
 	m.worktrees = uiWorktreeOverlayState{}
 	m.restorePrimaryInputMode()
 }
@@ -220,6 +239,9 @@ func (m *uiModel) openDeleteWorktreeDialog(target serverapi.WorktreeView, prefer
 func (m *uiModel) closeWorktreeDialog() {
 	if m == nil {
 		return
+	}
+	if m.worktrees.create.setupProgress != nil && m.worktrees.create.setupProgress.cancel != nil {
+		m.worktrees.create.setupProgress.cancel()
 	}
 	m.worktrees.phase = uiWorktreeOverlayPhaseList
 	m.worktrees.create = uiWorktreeCreateDialogState{}
@@ -297,12 +319,70 @@ func (m *uiModel) worktreeCreateCmd(req serverapi.WorktreeCreateRequest) tea.Cmd
 	}
 	m.worktrees.mutationToken++
 	token := m.worktrees.mutationToken
+	if err := req.SetupOperationID.Validate(); err != nil {
+		req.SetupOperationID = serverapi.NewWorktreeSetupOperationID()
+	}
 	m.worktrees.create.errorText = ""
 	m.worktrees.create.submitting = true
+	m.worktrees.create.setupEvent = nil
+	setupCtx, cancel := context.WithCancel(context.Background())
+	m.worktrees.create.setupProgress = &uiWorktreeSetupProgressState{cancel: cancel}
+	setupReady := make(chan error, 1)
+	setupEvents := make(chan worktreeSetupEventMsg, 8)
+	subscribeCmd := func() tea.Msg {
+		go subscribeWorktreeSetupEvents(setupCtx, m.worktreeClient, token, req.SetupOperationID, setupReady, setupEvents)
+		return nil
+	}
 	service := m.worktreeMutationService()
-	return func() tea.Msg {
+	createCmd := func() tea.Msg {
+		if err := <-setupReady; err != nil {
+			return worktreeCreateDoneMsg{token: token, err: err}
+		}
 		resp, err := service.Create(req)
 		return worktreeCreateDoneMsg{token: token, resp: resp, err: err}
+	}
+	return tea.Batch(subscribeCmd, createCmd, worktreeSetupEventCmd(setupEvents))
+}
+
+func subscribeWorktreeSetupEvents(ctx context.Context, worktreeClient client.WorktreeClient, token uint64, setupOperationID serverapi.WorktreeSetupOperationID, ready chan<- error, events chan worktreeSetupEventMsg) {
+	defer close(events)
+	if worktreeClient == nil {
+		ready <- worktreeui.ErrClientUnavailable
+		return
+	}
+	subscription, err := worktreeClient.SubscribeWorktreeSetup(ctx, serverapi.WorktreeSetupSubscribeRequest{SetupOperationID: setupOperationID})
+	if err != nil {
+		ready <- err
+		return
+	}
+	defer func() { _ = subscription.Close() }()
+	ready <- nil
+	for {
+		event, err := subscription.Next(ctx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, io.EOF) {
+				return
+			}
+			events <- worktreeSetupEventMsg{token: token, err: err, events: events}
+			return
+		}
+		events <- worktreeSetupEventMsg{token: token, event: event, events: events}
+		if event.Phase == serverapi.WorktreeSetupPhaseCompleted || event.Phase == serverapi.WorktreeSetupPhaseFailed {
+			return
+		}
+	}
+}
+
+func worktreeSetupEventCmd(events <-chan worktreeSetupEventMsg) tea.Cmd {
+	if events == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		msg, ok := <-events
+		if !ok {
+			return nil
+		}
+		return msg
 	}
 }
 

--- a/cli/kent/task_complete_command_test.go
+++ b/cli/kent/task_complete_command_test.go
@@ -380,7 +380,7 @@ func TestTaskCompleteAgentCrossSessionSelectorUsesServiceOwnershipError(t *testi
 	if err != nil {
 		t.Fatalf("CreateWorkflowTask: %v", err)
 	}
-	started, err := remote.StartWorkflowTask(context.Background(), serverapi.WorkflowTaskStartRequest{TaskID: created.Task.ID})
+	started, err := remote.StartWorkflowTask(context.Background(), serverapi.WorkflowTaskStartRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: created.Task.ID})
 	if err != nil {
 		t.Fatalf("StartWorkflowTask: %v", err)
 	}

--- a/cli/kent/task_lifecycle_command.go
+++ b/cli/kent/task_lifecycle_command.go
@@ -210,9 +210,9 @@ func taskStartSubcommand(args []string, stdout io.Writer, stderr io.Writer) int 
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	resp, err := remote.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{TaskID: taskID})
+	resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskStartResponse, error) {
+		return remote.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{SetupOperationID: setupOperationID, TaskID: taskID})
+	})
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
@@ -372,9 +372,9 @@ func taskApproveSubcommand(args []string, stdout io.Writer, stderr io.Writer) in
 		return 1
 	}
 	defer func() { _ = remote.Close() }()
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	resp, err := remote.ApproveWorkflowTask(ctx, serverapi.WorkflowTaskApproveRequest{TransitionID: positionals[0]})
+	resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskApproveResponse, error) {
+		return remote.ApproveWorkflowTask(ctx, serverapi.WorkflowTaskApproveRequest{SetupOperationID: setupOperationID, TransitionID: positionals[0]})
+	})
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
@@ -421,9 +421,9 @@ func taskMoveSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	resp, err := remote.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{TaskID: taskID, TargetNodeID: positionals[1], OutputValues: outputs.values, Commentary: *commentary})
+	resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskMoveResponse, error) {
+		return remote.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: setupOperationID, TaskID: taskID, TargetNodeID: positionals[1], OutputValues: outputs.values, Commentary: *commentary})
+	})
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
@@ -435,6 +435,67 @@ func taskMoveSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 	writeTaskTransitionResult(stdout, "Moved task", detail, resp.TransitionID, resp.RunIDs)
 	return 0
+}
+
+type worktreeSetupProgressSubscriber interface {
+	SubscribeWorktreeSetup(context.Context, serverapi.WorktreeSetupSubscribeRequest) (serverapi.WorktreeSetupSubscription, error)
+}
+
+func runWorkflowMutationWithSetupProgress[T any](ctx context.Context, remote workflowCommandRemote, stderr io.Writer, mutate func(context.Context, serverapi.WorktreeSetupOperationID) (T, error)) (T, error) {
+	setupOperationID := serverapi.NewWorktreeSetupOperationID()
+	stopSetupProgress, err := subscribeWorktreeSetupProgress(ctx, remote, setupOperationID, stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "warning: worktree setup progress subscription unavailable: %v\n", err)
+		stopSetupProgress = func() error { return nil }
+	}
+	resp, mutateErr := mutate(ctx, setupOperationID)
+	if setupProgressErr := stopSetupProgress(); setupProgressErr != nil {
+		fmt.Fprintf(stderr, "warning: worktree setup progress stream ended unexpectedly: %v\n", setupProgressErr)
+	}
+	return resp, mutateErr
+}
+
+func subscribeWorktreeSetupProgress(ctx context.Context, remote workflowCommandRemote, setupOperationID serverapi.WorktreeSetupOperationID, stderr io.Writer) (func() error, error) {
+	subscriber, ok := remote.(worktreeSetupProgressSubscriber)
+	if !ok {
+		return nil, errors.New("worktree setup progress subscription is unavailable")
+	}
+	subscription, err := subscriber.SubscribeWorktreeSetup(ctx, serverapi.WorktreeSetupSubscribeRequest{SetupOperationID: setupOperationID})
+	if err != nil {
+		return nil, err
+	}
+	progressCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() {
+		defer func() { _ = subscription.Close() }()
+		for {
+			event, err := subscription.Next(progressCtx)
+			if err != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(progressCtx.Err(), context.Canceled) || errors.Is(err, io.EOF) {
+					done <- nil
+					return
+				}
+				done <- err
+				return
+			}
+			writeWorktreeSetupProgress(stderr, event)
+			if event.Phase == serverapi.WorktreeSetupPhaseCompleted || event.Phase == serverapi.WorktreeSetupPhaseFailed {
+				done <- nil
+				return
+			}
+		}
+	}()
+	return func() error {
+		cancel()
+		return <-done
+	}, nil
+}
+
+func writeWorktreeSetupProgress(stderr io.Writer, event serverapi.WorktreeSetupEvent) {
+	if event.Phase != serverapi.WorktreeSetupPhaseStarted {
+		return
+	}
+	fmt.Fprintf(stderr, "Waiting for worktree setup script %s in %s.\n", event.ScriptPath, event.WorktreeRoot)
 }
 
 type stringMapFlag struct {
@@ -482,8 +543,10 @@ func waitForWorkflowTaskRunSession(ctx context.Context, remote workflowCommandRe
 			}
 			return serverapi.WorkflowTaskDetail{}, fmt.Errorf("started task %s with run %s but failed to load task detail while waiting for session id: %w", taskID, trimmedRunID, err)
 		}
-		if run, ok := workflowTaskRunByID(detail, trimmedRunID); ok && strings.TrimSpace(run.SessionID) != "" {
-			return detail, nil
+		if run, ok := workflowTaskRunByID(detail, trimmedRunID); ok {
+			if workflowTaskRunDoesNotRequireSession(run) || strings.TrimSpace(run.SessionID) != "" {
+				return detail, nil
+			}
 		}
 		timer := time.NewTimer(interval)
 		select {
@@ -493,4 +556,8 @@ func waitForWorkflowTaskRunSession(ctx context.Context, remote workflowCommandRe
 		case <-timer.C:
 		}
 	}
+}
+
+func workflowTaskRunDoesNotRequireSession(run serverapi.WorkflowRun) bool {
+	return serverapi.WorkflowNodeKind(strings.TrimSpace(run.NodeKind)) == serverapi.WorkflowNodeKindScript
 }

--- a/cli/kent/task_lifecycle_command_test.go
+++ b/cli/kent/task_lifecycle_command_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -248,6 +249,28 @@ func TestTaskStartSessionPollingTimeoutReportsStartedTask(t *testing.T) {
 	}
 }
 
+func TestTaskStartSessionPollingDoesNotWaitForScriptRunSession(t *testing.T) {
+	remote := &taskSessionPollingRemote{task: serverapi.WorkflowTaskDetail{
+		Summary:  serverapi.WorkflowTaskSummary{ID: "task-1", ShortID: "BLD-1", Title: "Task"},
+		Workflow: serverapi.WorkflowPickerItem{WorkflowID: "workflow-1", DisplayName: "Workflow"},
+		Placements: []serverapi.WorkflowPlacement{
+			{ID: "placement-1", TaskID: "task-1", NodeID: "node-script", NodeKey: "script"},
+		},
+		Runs: []serverapi.WorkflowRun{
+			{ID: "run-1", TaskID: "task-1", PlacementID: "placement-1", NodeID: "node-script", NodeKind: "script"},
+		},
+	}}
+	detail, err := waitForWorkflowTaskRunSession(context.Background(), remote, "task-1", "run-1", time.Second, time.Millisecond)
+	if err != nil {
+		t.Fatalf("waitForWorkflowTaskRunSession: %v", err)
+	}
+	var stdout bytes.Buffer
+	writeTaskStartResult(&stdout, detail, serverapi.WorkflowTaskStartResponse{RunID: "run-1", PlacementID: "placement-1", TransitionID: "transition-start"})
+	if got, want := stdout.String(), "Started task BLD-1 using workflow \"Workflow\" (workflow-1).\nFirst node: script\n"; got != want {
+		t.Fatalf("start output = %q, want %q", got, want)
+	}
+}
+
 func TestTaskStartCommandPollsForSessionAndPrintsReadableOutput(t *testing.T) {
 	restorePolling := replaceTaskStartSessionPolling(t, 50*time.Millisecond, time.Millisecond)
 	defer restorePolling()
@@ -280,6 +303,109 @@ func TestTaskStartCommandPollsForSessionAndPrintsReadableOutput(t *testing.T) {
 	}
 	if remote.taskIDDetailCalls < 2 {
 		t.Fatalf("task detail calls = %d, want polling before session assignment", remote.taskIDDetailCalls)
+	}
+}
+
+func TestTaskLifecycleCommandsConsumeWorktreeSetupProgressWithoutMutationDeadline(t *testing.T) {
+	restorePolling := replaceTaskStartSessionPolling(t, 50*time.Millisecond, time.Millisecond)
+	defer restorePolling()
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "start", args: []string{"task", "start", "--project", "project-1", "BLD-1"}, want: "Started task BLD-1"},
+		{name: "approve", args: []string{"task", "approve", "transition-1"}, want: "Approved transition of BLD-1"},
+		{name: "move", args: []string{"task", "move", "--project", "project-1", "BLD-1", "node-1"}, want: "Moved task BLD-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.App{WorkspaceRoot: t.TempDir()}
+			remote := newSetupProgressLifecycleRemote()
+			restoreRemote := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
+			defer restoreRemote()
+
+			stdout, stderr, code := runWorkflowRootCommand(tc.args...)
+			if code != 0 {
+				t.Fatalf("command exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+			}
+			if !strings.HasPrefix(stdout, tc.want) {
+				t.Fatalf("stdout = %q, want lifecycle result prefix %q", stdout, tc.want)
+			}
+			assertSetupProgressOutputHasPaths(t, stderr, remote.scriptPath, remote.worktreeRoot)
+			if !remote.mutationCalled {
+				t.Fatal("workflow mutation was not called")
+			}
+		})
+	}
+}
+
+func TestTaskLifecycleCommandsWarnAndContinueWhenSetupProgressUnavailable(t *testing.T) {
+	restorePolling := replaceTaskStartSessionPolling(t, 50*time.Millisecond, time.Millisecond)
+	defer restorePolling()
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "start", args: []string{"task", "start", "--project", "project-1", "BLD-1"}, want: "Started task BLD-1"},
+		{name: "approve", args: []string{"task", "approve", "transition-1"}, want: "Approved transition of BLD-1"},
+		{name: "move", args: []string{"task", "move", "--project", "project-1", "BLD-1", "node-1"}, want: "Moved task BLD-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.App{WorkspaceRoot: t.TempDir()}
+			remote := newSetupProgressLifecycleRemote()
+			remote.subscribeErr = errors.New("setup subscription unavailable")
+			restoreRemote := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
+			defer restoreRemote()
+
+			stdout, stderr, code := runWorkflowRootCommand(tc.args...)
+			if code != 0 {
+				t.Fatalf("command exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+			}
+			if !strings.HasPrefix(stdout, tc.want) {
+				t.Fatalf("stdout = %q, want lifecycle result prefix %q", stdout, tc.want)
+			}
+			if !strings.Contains(stderr, "warning: worktree setup progress subscription unavailable") {
+				t.Fatalf("stderr = %q, want setup subscription warning", stderr)
+			}
+			if !remote.mutationCalled {
+				t.Fatal("workflow mutation was not called")
+			}
+		})
+	}
+}
+
+func TestTaskLifecycleCommandsWarnAndContinueWhenSetupProgressStreamFailsAfterMutation(t *testing.T) {
+	restorePolling := replaceTaskStartSessionPolling(t, 50*time.Millisecond, time.Millisecond)
+	defer restorePolling()
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "start", args: []string{"task", "start", "--project", "project-1", "BLD-1"}, want: "Started task BLD-1"},
+		{name: "approve", args: []string{"task", "approve", "transition-1"}, want: "Approved transition of BLD-1"},
+		{name: "move", args: []string{"task", "move", "--project", "project-1", "BLD-1", "node-1"}, want: "Moved task BLD-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.App{WorkspaceRoot: t.TempDir()}
+			remote := newSetupProgressLifecycleRemote()
+			remote.streamErrAfterEvent = errors.New("setup stream disconnected")
+			restoreRemote := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
+			defer restoreRemote()
+
+			stdout, stderr, code := runWorkflowRootCommand(tc.args...)
+			if code != 0 {
+				t.Fatalf("command exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+			}
+			if !strings.HasPrefix(stdout, tc.want) {
+				t.Fatalf("stdout = %q, want lifecycle result prefix %q", stdout, tc.want)
+			}
+			assertSetupProgressOutputHasPaths(t, stderr, remote.scriptPath, remote.worktreeRoot)
+			if !strings.Contains(stderr, "warning: worktree setup progress stream ended unexpectedly") {
+				t.Fatalf("stderr = %q, want setup stream warning", stderr)
+			}
+		})
 	}
 }
 
@@ -327,6 +453,13 @@ type taskStartPollingRemote struct {
 
 func (r *taskStartPollingRemote) Close() error { return nil }
 
+func (r *taskStartPollingRemote) SubscribeWorktreeSetup(ctx context.Context, req serverapi.WorktreeSetupSubscribeRequest) (serverapi.WorktreeSetupSubscription, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	return noopWorktreeSetupSubscription{}, nil
+}
+
 func (r *taskStartPollingRemote) ResolveProjectPath(context.Context, serverapi.ProjectResolvePathRequest) (serverapi.ProjectResolvePathResponse, error) {
 	return serverapi.ProjectResolvePathResponse{Binding: &serverapi.ProjectBinding{ProjectID: r.projectID}}, nil
 }
@@ -359,5 +492,204 @@ func (r *taskStartPollingRemote) taskDetail(sessionID string) serverapi.Workflow
 		Runs: []serverapi.WorkflowRun{
 			{ID: r.runID, TaskID: r.taskID, PlacementID: r.placementID, NodeID: r.nodeID, SessionID: sessionID},
 		},
+	}
+}
+
+type setupProgressLifecycleRemote struct {
+	client.WorkflowClient
+	projectID           string
+	taskID              string
+	shortID             string
+	workflowID          string
+	workflow            string
+	placementID         string
+	runID               string
+	sessionID           string
+	nodeID              string
+	nodeKey             string
+	transitionID        string
+	scriptPath          string
+	worktreeRoot        string
+	events              chan serverapi.WorktreeSetupEvent
+	eventConsumed       chan struct{}
+	subscribedID        serverapi.WorktreeSetupOperationID
+	mutationCalled      bool
+	subscribeErr        error
+	streamErrAfterEvent error
+}
+
+func newSetupProgressLifecycleRemote() *setupProgressLifecycleRemote {
+	return &setupProgressLifecycleRemote{
+		projectID:     "project-1",
+		taskID:        "task-1",
+		shortID:       "BLD-1",
+		workflowID:    "workflow-1",
+		workflow:      "Workflow",
+		placementID:   "placement-1",
+		runID:         "run-1",
+		sessionID:     "session-1",
+		nodeID:        "node-1",
+		nodeKey:       "implement",
+		transitionID:  "transition-1",
+		scriptPath:    "/tmp/kent-setup.sh",
+		worktreeRoot:  "/tmp/kent-worktree",
+		events:        make(chan serverapi.WorktreeSetupEvent, 1),
+		eventConsumed: make(chan struct{}, 1),
+	}
+}
+
+func (r *setupProgressLifecycleRemote) Close() error { return nil }
+
+func (r *setupProgressLifecycleRemote) SubscribeWorktreeSetup(_ context.Context, req serverapi.WorktreeSetupSubscribeRequest) (serverapi.WorktreeSetupSubscription, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	if r.subscribeErr != nil {
+		return nil, r.subscribeErr
+	}
+	r.subscribedID = req.SetupOperationID
+	return &setupProgressSubscription{events: r.events, consumed: r.eventConsumed, errAfterEvent: r.streamErrAfterEvent}, nil
+}
+
+func (r *setupProgressLifecycleRemote) ResolveProjectPath(context.Context, serverapi.ProjectResolvePathRequest) (serverapi.ProjectResolvePathResponse, error) {
+	return serverapi.ProjectResolvePathResponse{Binding: &serverapi.ProjectBinding{ProjectID: r.projectID}}, nil
+}
+
+func (r *setupProgressLifecycleRemote) GetWorkflowTask(_ context.Context, req serverapi.WorkflowTaskGetRequest) (serverapi.WorkflowTaskGetResponse, error) {
+	if req.ProjectID == r.projectID && req.ShortID == r.shortID {
+		return serverapi.WorkflowTaskGetResponse{Task: r.taskDetail("")}, nil
+	}
+	if req.TaskID == r.taskID {
+		return serverapi.WorkflowTaskGetResponse{Task: r.taskDetail(r.sessionID)}, nil
+	}
+	return serverapi.WorkflowTaskGetResponse{}, sql.ErrNoRows
+}
+
+func (r *setupProgressLifecycleRemote) StartWorkflowTask(ctx context.Context, req serverapi.WorkflowTaskStartRequest) (serverapi.WorkflowTaskStartResponse, error) {
+	if err := r.validateMutationContextAndSetupID(ctx, req.SetupOperationID); err != nil {
+		return serverapi.WorkflowTaskStartResponse{}, err
+	}
+	return serverapi.WorkflowTaskStartResponse{TransitionID: r.transitionID, PlacementID: r.placementID, RunID: r.runID}, nil
+}
+
+func (r *setupProgressLifecycleRemote) ApproveWorkflowTask(ctx context.Context, req serverapi.WorkflowTaskApproveRequest) (serverapi.WorkflowTaskApproveResponse, error) {
+	if err := r.validateMutationContextAndSetupID(ctx, req.SetupOperationID); err != nil {
+		return serverapi.WorkflowTaskApproveResponse{}, err
+	}
+	return serverapi.WorkflowTaskApproveResponse{TaskID: r.taskID, TransitionID: r.transitionID, RunIDs: []string{r.runID}}, nil
+}
+
+func (r *setupProgressLifecycleRemote) MoveWorkflowTask(ctx context.Context, req serverapi.WorkflowTaskMoveRequest) (serverapi.WorkflowTaskMoveResponse, error) {
+	if err := r.validateMutationContextAndSetupID(ctx, req.SetupOperationID); err != nil {
+		return serverapi.WorkflowTaskMoveResponse{}, err
+	}
+	return serverapi.WorkflowTaskMoveResponse{TransitionID: r.transitionID, RunIDs: []string{r.runID}}, nil
+}
+
+func (r *setupProgressLifecycleRemote) validateMutationContextAndSetupID(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) error {
+	r.mutationCalled = true
+	if _, ok := ctx.Deadline(); ok {
+		return errors.New("workflow lifecycle mutation context has a deadline")
+	}
+	if err := setupOperationID.Validate(); err != nil {
+		return err
+	}
+	if r.subscribedID.Validate() != nil {
+		return nil
+	}
+	if setupOperationID != r.subscribedID {
+		return errors.New("workflow lifecycle mutation used a different setup operation id than the subscription")
+	}
+	r.events <- serverapi.WorktreeSetupEvent{
+		SetupOperationID:    setupOperationID,
+		SourceWorkspaceRoot: "/tmp/source",
+		WorktreeRoot:        r.worktreeRoot,
+		ScriptPath:          r.scriptPath,
+		Phase:               serverapi.WorktreeSetupPhaseStarted,
+	}
+	select {
+	case <-r.eventConsumed:
+		return nil
+	case <-time.After(3 * time.Second):
+		return errors.New("setup progress event was not consumed while mutation was in flight")
+	}
+}
+
+func (r *setupProgressLifecycleRemote) taskDetail(sessionID string) serverapi.WorkflowTaskDetail {
+	return serverapi.WorkflowTaskDetail{
+		Summary:  serverapi.WorkflowTaskSummary{ID: r.taskID, ShortID: r.shortID, WorkflowID: r.workflowID, ProjectID: r.projectID, Title: "Task"},
+		Workflow: serverapi.WorkflowPickerItem{WorkflowID: r.workflowID, DisplayName: r.workflow},
+		Placements: []serverapi.WorkflowPlacement{
+			{ID: r.placementID, TaskID: r.taskID, NodeID: r.nodeID, NodeKey: r.nodeKey},
+		},
+		Runs: []serverapi.WorkflowRun{
+			{ID: r.runID, TaskID: r.taskID, PlacementID: r.placementID, NodeID: r.nodeID, SessionID: sessionID},
+		},
+		Transitions: []serverapi.WorkflowTaskTransition{
+			{
+				ID:            r.transitionID,
+				SourceNodeKey: r.nodeKey,
+				TransitionID:  "done",
+				Edges: []serverapi.WorkflowTransitionEdge{
+					{EdgeKey: "done", TargetNodeKey: "done", State: "applied"},
+				},
+			},
+		},
+	}
+}
+
+type setupProgressSubscription struct {
+	events        <-chan serverapi.WorktreeSetupEvent
+	consumed      chan<- struct{}
+	errAfterEvent error
+	delivered     bool
+}
+
+func (s *setupProgressSubscription) Next(ctx context.Context) (serverapi.WorktreeSetupEvent, error) {
+	if s.delivered && s.errAfterEvent != nil {
+		return serverapi.WorktreeSetupEvent{}, s.errAfterEvent
+	}
+	select {
+	case event := <-s.events:
+		s.delivered = true
+		select {
+		case s.consumed <- struct{}{}:
+		default:
+		}
+		return event, nil
+	case <-ctx.Done():
+		return serverapi.WorktreeSetupEvent{}, ctx.Err()
+	}
+}
+
+func (s *setupProgressSubscription) Close() error { return nil }
+
+type noopWorktreeSetupSubscription struct{}
+
+func (noopWorktreeSetupSubscription) Next(ctx context.Context) (serverapi.WorktreeSetupEvent, error) {
+	<-ctx.Done()
+	return serverapi.WorktreeSetupEvent{}, ctx.Err()
+}
+
+func (noopWorktreeSetupSubscription) Close() error { return nil }
+
+func assertSetupProgressOutputHasPaths(t *testing.T, output string, scriptPath string, worktreeRoot string) {
+	t.Helper()
+	fields := strings.Fields(output)
+	if len(fields) < 8 {
+		t.Fatalf("setup progress output fields = %v", fields)
+	}
+	scriptFound := false
+	worktreeFound := false
+	for _, field := range fields {
+		if field == scriptPath {
+			scriptFound = true
+		}
+		if strings.TrimSuffix(field, ".") == worktreeRoot {
+			worktreeFound = true
+		}
+	}
+	if !scriptFound || !worktreeFound {
+		t.Fatalf("setup progress output = %q, want script %q and worktree %q", output, scriptPath, worktreeRoot)
 	}
 }

--- a/cli/kent/task_output.go
+++ b/cli/kent/task_output.go
@@ -13,7 +13,11 @@ func writeTaskStartResult(stdout io.Writer, task serverapi.WorkflowTaskDetail, r
 	sessionID := strings.TrimSpace(run.SessionID)
 	placement, _ := workflowTaskPlacementByID(task, resp.PlacementID)
 	nodeKey := placementDisplayKey(placement, run.NodeID)
-	fmt.Fprintf(stdout, "Started task %s in session %s using workflow %q (%s).\n", taskDisplayID(task), sessionID, task.Workflow.DisplayName, task.Workflow.WorkflowID)
+	if sessionID == "" {
+		fmt.Fprintf(stdout, "Started task %s using workflow %q (%s).\n", taskDisplayID(task), task.Workflow.DisplayName, task.Workflow.WorkflowID)
+	} else {
+		fmt.Fprintf(stdout, "Started task %s in session %s using workflow %q (%s).\n", taskDisplayID(task), sessionID, task.Workflow.DisplayName, task.Workflow.WorkflowID)
+	}
 	fmt.Fprintf(stdout, "First node: %s\n", nodeKey)
 }
 

--- a/cli/kent/task_workflow_integration_test.go
+++ b/cli/kent/task_workflow_integration_test.go
@@ -75,7 +75,7 @@ func TestTaskCommandsUseWorkflowAPI(t *testing.T) {
 	}
 	runWorkflowRootCommandOK(t, "task", "comment", "delete", commentID)
 
-	startResp, err := remote.StartWorkflowTask(context.Background(), serverapi.WorkflowTaskStartRequest{TaskID: taskID})
+	startResp, err := remote.StartWorkflowTask(context.Background(), serverapi.WorkflowTaskStartRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: taskID})
 	if err != nil {
 		t.Fatalf("StartWorkflowTask for resume command: %v", err)
 	}

--- a/cli/kent/workflow_command_test.go
+++ b/cli/kent/workflow_command_test.go
@@ -34,6 +34,13 @@ type workflowCommandLoopbackRemote struct {
 
 func (r *workflowCommandLoopbackRemote) Close() error { return nil }
 
+func (r *workflowCommandLoopbackRemote) SubscribeWorktreeSetup(ctx context.Context, req serverapi.WorktreeSetupSubscribeRequest) (serverapi.WorktreeSetupSubscription, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	return noopWorktreeSetupSubscription{}, nil
+}
+
 func (r *workflowCommandLoopbackRemote) ResolveProjectPath(ctx context.Context, req serverapi.ProjectResolvePathRequest) (serverapi.ProjectResolvePathResponse, error) {
 	if binding, ok := r.projectBindingsByRoot[req.Path]; ok {
 		return serverapi.ProjectResolvePathResponse{CanonicalRoot: req.Path, Binding: &binding}, nil

--- a/docs/dev/specs/tui-transcript.md
+++ b/docs/dev/specs/tui-transcript.md
@@ -176,7 +176,10 @@
 - Branch cleanup is conservative/best-effort. Kent only auto-attempts branch deletion when provenance proves it created the branch. Force delete is not part of the first slice.
 - New worktrees default under `worktrees.base_dir`, rooted under Kent persistence state by default.
 - Live worktree retarget rebinds runtime-local tool handlers to the new effective root.
-- Optional post-create setup script is `worktrees.setup_script`, runs async only after new worktree creation, receives args/stdin JSON/env, and failures do not undo worktree/session switch.
+- Optional post-create setup script is `worktrees.setup_script`, runs as a blocking part of every new worktree creation path, and receives args/stdin JSON/env. Blocking setup prevents sessions and workflow runs from locking context before setup-provided local skills, docs, or other worktree files are present.
+- Worktree setup progress is live client operation state, not a model-visible transcript entry and not durable transcript history.
+- Manual worktree creation switches the current session to the new worktree only after setup succeeds. Setup failure leaves the session on its previous worktree, keeps the created worktree available for inspection or manual repair, and surfaces a foreground error.
+- Worktree setup timeout is configured by `worktrees.setup_timeout_seconds`. The default is 60 seconds. Unset timeout uses the default; a configured timeout of zero or less disables the timeout.
 
 ## Slash Commands
 

--- a/docs/dev/specs/workflow-orchestration.md
+++ b/docs/dev/specs/workflow-orchestration.md
@@ -186,7 +186,9 @@
 
 - A task owns one managed worktree by default.
 - All executable nodes require and reuse the task managed worktree.
-- Kent creates the managed worktree on task start before first executable run is scheduled.
+- Kent creates and, when configured, runs setup for the managed worktree on task start before first executable run is scheduled. Blocking setup prevents runs from locking context before setup-provided local skills, docs, or other worktree files are present.
+- Managed worktree setup failure fails task start without scheduling an executable run. The created worktree stays available for inspection or manual repair.
+- Starting the task again trusts an existing managed worktree as manually repaired. If the managed worktree was removed, task start recreates it and runs setup again.
 - Task worktree branch name is the task short ID.
 - Worktree creation reuses existing worktree branch/root collision handling.
 - Worktree deletion/retargeting treats non-terminal tasks referencing a managed worktree as blockers.

--- a/docs/src/content/docs/worktrees.md
+++ b/docs/src/content/docs/worktrees.md
@@ -3,7 +3,7 @@ title: Worktrees
 description: Create, switch, and delete git worktrees from Kent.
 ---
 
-Kent can manage git worktrees for you. Creating or switching a worktree moves that session into the selected checkout and gives the agent necessary context. Managed worktrees are created according to config.toml's `[worktrees].base_dir`, and Kent switches the session into the new worktree after create. Run `/wt` to get started. 
+Kent can manage git worktrees for you. Creating or switching a worktree moves that session into the selected checkout and gives the agent necessary context. Managed worktrees are created under `config.toml`'s `[worktrees].base_dir`, and Kent switches the session into the new worktree after creation and setup succeed. Run `/wt` to get started.
 
 ## Switch
 
@@ -25,22 +25,28 @@ If you delete the active worktree, Kent moves the session back to the main works
 
 ## Configuration
 
-Since worktrees are basically raw git checkouts, you can set-up a custom worktree creation script that will prepare newly created checkouts with local data like `.env`, encryption credentials, gradle wrappers, installed dependencies, local skills/config, etc.
+Since worktrees are raw git checkouts, you can set a custom worktree creation script that prepares newly created checkouts with local data such as `.env`, encryption credentials, Gradle wrappers, installed dependencies, local skills, docs, or config.
 
 ```toml
 [worktrees]
 base_dir = "~/.kent/worktrees"
 # setup_script = "scripts/setup-worktree.sh"
+# setup_timeout_seconds = 60
 ```
 
 - `base_dir` sets the root directory for Kent-managed worktrees.
-- `setup_script` runs after creating a worktree in the background. Relative paths resolve from the workspace root.
+- `setup_script` runs after Kent creates and records a new worktree, before Kent switches a session into it or starts a workflow run that uses it. Relative paths resolve from the source workspace root.
+- `setup_timeout_seconds` sets the setup script timeout. The default is `60`; `0` or a negative value disables the timeout.
+
+Setup is blocking because worktree-local context can change what the agent sees. Files created by setup, including local skills under `.kent/skills` and workspace-local docs, are present before Kent locks the new session or workflow run context.
+
+While setup is running, Kent reports live setup progress with the resolved script path and worktree path. If setup fails, times out, or is canceled, the foreground create/start operation fails and Kent does not switch the session or start the workflow run against that worktree. The created worktree and Kent metadata remain available so you can inspect, repair, or delete them.
 
 The script receives environment variables as input:
 
-- `KENT_WORKTREE_SOURCE_WORKSPACE_ROOT` - Original/main workspace root that created the worktree, e.g. `/Users/user/Developer/app` or `C:\Users\user\dev\app`.
+- `KENT_WORKTREE_SOURCE_WORKSPACE_ROOT` - Original/main workspace root that created the worktree, e.g. `/home/user/dev/app` or `C:\Users\user\dev\app`.
 - `KENT_WORKTREE_BRANCH_NAME` - Branch/ref name selected for the new worktree, e.g. `feature/search-fix`.
-- `KENT_WORKTREE_ROOT` - Filesystem path to the newly created worktree; setup script runs with this as cwd, e.g. `/Users/nek/.kent/worktrees/app/search-fix`.
+- `KENT_WORKTREE_ROOT` - Filesystem path to the newly created worktree; setup script runs with this as cwd, e.g. `/home/user/.kent/worktrees/app/search-fix`.
 - `KENT_WORKTREE_SESSION_ID` - Kent session id that requested the worktree, e.g. `b31234ab-78ce-43d1-8f4c-2d6c6d4adbc1`.
 - `KENT_WORKTREE_PROJECT_ID` - Kent project id for the workspace/project, e.g. `project-94b18685-19ed-4513-96bb-bcffa10410ff`.
 - `KENT_WORKTREE_WORKSPACE_ID` - Kent workspace binding id for the source workspace, e.g. `workspace-2f7b6d4a`.

--- a/server/core/composition.go
+++ b/server/core/composition.go
@@ -146,7 +146,7 @@ func NewWithContextOptions(ctx context.Context, cfg config.App, authSupport serv
 	runtimeRegistry.WithOperationCoordinator(runtimeOperations)
 	runtimeRegistry.WithExecutionTargetResolver(metadataStore.ResolveSessionExecutionTarget)
 	runtimeControlService := runtimecontrol.NewService(runtimeRegistry).WithOperationCoordinator(runtimeOperations).WithPromptHistoryStore(metadataStore).WithWorkflowSessionResolver(sessionStoreResolver)
-	worktreeService := worktree.NewService(metadataStore, nil, runtimeRegistry, sessionRuntimeService, runtimeSupport.Background, runtimeControlService, worktree.ServiceOptions{BaseDir: cfg.Settings.Worktrees.BaseDir, SetupScript: cfg.Settings.Worktrees.SetupScript})
+	worktreeService := worktree.NewService(metadataStore, nil, runtimeRegistry, sessionRuntimeService, runtimeSupport.Background, runtimeControlService, worktree.ServiceOptions{BaseDir: cfg.Settings.Worktrees.BaseDir, SetupScript: cfg.Settings.Worktrees.SetupScript, SetupTimeoutSeconds: cfg.Settings.Worktrees.SetupTimeoutSeconds})
 	projectViews := client.NewLoopbackProjectViewClient(projectService)
 	authBootstrapService := authservice.NewBootstrapService(authSupport.AuthManager, authSupport.OAuthOptions, cfg.Settings, rpccontract.AllowedPreAuthMethods())
 	authStatusService := authservice.NewStatusService(authSupport.AuthManager, cfg.Settings)
@@ -183,7 +183,7 @@ func NewWithContextOptions(ctx context.Context, cfg config.App, authSupport serv
 		return nil, fmt.Errorf("workflow bundle: view: %w", err)
 	}
 	workflowAttentionFinalizer := workflowattention.NewFinalizer(workflowApprovalProjection{store: workflowStore, view: workflowViewService, roleResolver: workflowRoleResolver}, attentionBroker)
-	workflowRuntimeStarter, err = workflowrunner.NewStarter(cfg, metadataStore, workflowStore, authSupport.AuthManager, runtimeSupport.Background, runtimeRegistry, workflowrunner.StarterOptions{RuntimeClientFactory: opts.RuntimeClientFactory, Worktrees: taskWorktreeEnsurer{service: worktreeService}, SessionRuntime: sessionRuntimeService, AttentionFinalizer: workflowAttentionFinalizer})
+	workflowRuntimeStarter, err = workflowrunner.NewStarter(cfg, metadataStore, workflowStore, authSupport.AuthManager, runtimeSupport.Background, runtimeRegistry, workflowrunner.StarterOptions{RuntimeClientFactory: opts.RuntimeClientFactory, Worktrees: runtimeTaskWorktreeEnsurer{service: worktreeService}, SessionRuntime: sessionRuntimeService, AttentionFinalizer: workflowAttentionFinalizer})
 	if err != nil {
 		cleanupNewFailure()
 		return nil, fmt.Errorf("workflow bundle: runtime starter: %w", err)
@@ -269,11 +269,23 @@ type taskWorktreeEnsurer struct {
 	service *worktree.Service
 }
 
-func (e taskWorktreeEnsurer) EnsureTaskWorktree(ctx context.Context, taskID string) error {
+func (e taskWorktreeEnsurer) EnsureTaskWorktree(ctx context.Context, req workflowsvc.TaskWorktreeEnsureRequest) error {
 	if e.service == nil {
 		return nil
 	}
-	_, err := e.service.EnsureTaskWorktree(ctx, worktree.EnsureTaskWorktreeRequest{TaskID: taskID})
+	_, err := e.service.EnsureTaskWorktree(ctx, worktree.EnsureTaskWorktreeRequest{TaskID: req.TaskID, SetupOperationID: req.SetupOperationID})
+	return err
+}
+
+type runtimeTaskWorktreeEnsurer struct {
+	service *worktree.Service
+}
+
+func (e runtimeTaskWorktreeEnsurer) EnsureTaskWorktree(ctx context.Context, req workflowrunner.TaskWorktreeEnsureRequest) error {
+	if e.service == nil {
+		return nil
+	}
+	_, err := e.service.EnsureTaskWorktree(ctx, worktree.EnsureTaskWorktreeRequest{TaskID: req.TaskID, SetupOperationID: req.SetupOperationID})
 	return err
 }
 

--- a/server/tools/shell/bounded_output.go
+++ b/server/tools/shell/bounded_output.go
@@ -1,0 +1,64 @@
+package shell
+
+import "bytes"
+
+type BoundedOutput struct {
+	limit    int
+	buf      bytes.Buffer
+	total    int
+	overflow bool
+}
+
+func NewBoundedOutput(limit int) *BoundedOutput {
+	return &BoundedOutput{limit: limit}
+}
+
+func (b *BoundedOutput) Write(p []byte) (int, error) {
+	if b == nil {
+		return len(p), nil
+	}
+	if b.limit <= 0 {
+		b.total += len(p)
+		if len(p) > 0 {
+			b.overflow = true
+		}
+		return len(p), nil
+	}
+	b.total += len(p)
+	remaining := b.limit - b.buf.Len()
+	if remaining > 0 {
+		if len(p) > remaining {
+			_, _ = b.buf.Write(p[:remaining])
+			b.overflow = true
+		} else {
+			_, _ = b.buf.Write(p)
+		}
+	} else if len(p) > 0 {
+		b.overflow = true
+	}
+	if b.total > b.limit {
+		b.overflow = true
+	}
+	return len(p), nil
+}
+
+func (b *BoundedOutput) Bytes() []byte {
+	if b == nil {
+		return nil
+	}
+	return append([]byte(nil), b.buf.Bytes()...)
+}
+
+func (b *BoundedOutput) String() string {
+	if b == nil {
+		return ""
+	}
+	return b.buf.String()
+}
+
+func (b *BoundedOutput) Overflow() bool {
+	if b == nil {
+		return false
+	}
+	return b.overflow
+}

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -175,6 +175,7 @@ var gatewaySubscriptionHandlerEntries = map[string]gatewaySubscriptionHandler{
 	protocol.MethodAttentionSessionNotificationSubscribe: (*Gateway).serveSessionAttentionNotificationSubscription,
 	protocol.MethodWorkflowSubscribe:                     (*Gateway).serveWorkflowSubscription,
 	protocol.MethodWorkflowSubscribeProject:              (*Gateway).serveWorkflowProjectSubscription,
+	protocol.MethodWorktreeSetupSubscribe:                (*Gateway).serveWorktreeSetupSubscription,
 }
 
 var gatewaySubscriptionHandlers = routeHandlersForKind(rpccontract.KindSubscription, gatewaySubscriptionHandlerEntries)

--- a/server/transport/gateway_stream_handlers.go
+++ b/server/transport/gateway_stream_handlers.go
@@ -193,6 +193,26 @@ func (g *Gateway) serveWorkflowSubscription(conn rpcwire.Conn, ctx context.Conte
 	serveGatewaySubscription(conn, ctx, route, req, g.deps.WorkflowClient().SubscribeWorkflow, workflowProjectEventParams)
 }
 
+func (g *Gateway) serveWorktreeSetupSubscription(conn rpcwire.Conn, ctx context.Context, _ *connectionState, route rpccontract.Route, req protocol.Request) {
+	serveGatewaySubscription(conn, ctx, route, req, g.deps.WorktreeClient().SubscribeWorktreeSetup, worktreeSetupEventParams)
+}
+
 func workflowProjectEventParams(evt serverapi.WorkflowProjectEvent) protocol.WorkflowProjectEventParams {
 	return protocol.WorkflowProjectEventParams{Event: protocol.WorkflowProjectEvent{ProjectID: evt.ProjectID, WorkflowID: evt.WorkflowID, Resource: evt.Resource, Action: evt.Action, ChangedIDs: evt.ChangedIDs, OccurredAtUnixMs: evt.OccurredAtUnixMs}}
+}
+
+func worktreeSetupEventParams(evt serverapi.WorktreeSetupEvent) protocol.WorktreeSetupEventParams {
+	return protocol.WorktreeSetupEventParams{Event: protocol.WorktreeSetupEvent{
+		SetupOperationID:    evt.SetupOperationID.String(),
+		SourceWorkspaceRoot: evt.SourceWorkspaceRoot,
+		WorktreeRoot:        evt.WorktreeRoot,
+		ScriptPath:          evt.ScriptPath,
+		Phase:               string(evt.Phase),
+		Timeout:             evt.Timeout,
+		Canceled:            evt.Canceled,
+		ExitCode:            evt.ExitCode,
+		Stdout:              evt.Stdout,
+		Stderr:              evt.Stderr,
+		Error:               evt.Error,
+	}}
 }

--- a/server/workflowrunner/script_runner.go
+++ b/server/workflowrunner/script_runner.go
@@ -1,7 +1,6 @@
 package workflowrunner
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -14,6 +13,7 @@ import (
 	"time"
 
 	tools "core/server/tools"
+	shelltool "core/server/tools/shell"
 	"core/server/workflow"
 	"core/server/workflowattention"
 	"core/server/workflowruntime"
@@ -170,7 +170,7 @@ func executeWorkflowScript(ctx context.Context, req SchedulerStartRunRequest, in
 	cmd := exec.Command(resolvedPath)
 	cmd.Dir = input.WorktreeRoot
 	cmd.Env = workflowScriptEnv(req, input)
-	cmd.Stdin = bytes.NewReader(stdin)
+	cmd.Stdin = strings.NewReader(string(stdin))
 	prepareScriptCommand(cmd)
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
@@ -183,8 +183,8 @@ func executeWorkflowScript(ctx context.Context, req SchedulerStartRunRequest, in
 	if err := cmd.Start(); err != nil {
 		return workflowScriptResult{ResolvedPath: resolvedPath}, workflowScriptError{Reason: ReasonScriptExecutionFailed, Err: err}
 	}
-	stdout := newBoundedOutput(scriptOutputLimitBytes)
-	stderr := newBoundedOutput(scriptOutputLimitBytes)
+	stdout := shelltool.NewBoundedOutput(scriptOutputLimitBytes)
+	stderr := shelltool.NewBoundedOutput(scriptOutputLimitBytes)
 	var copyWG sync.WaitGroup
 	copyWG.Add(2)
 	go func() {
@@ -270,44 +270,6 @@ func workflowScriptEnv(req SchedulerStartRunRequest, input workflowstore.RunStar
 		"KENT_WORKTREE_ROOT="+input.WorktreeRoot,
 	)
 	return env
-}
-
-type boundedOutput struct {
-	limit    int
-	buf      bytes.Buffer
-	total    int
-	overflow bool
-}
-
-func newBoundedOutput(limit int) *boundedOutput {
-	return &boundedOutput{limit: limit}
-}
-
-func (b *boundedOutput) Write(p []byte) (int, error) {
-	b.total += len(p)
-	remaining := b.limit - b.buf.Len()
-	if remaining > 0 {
-		if len(p) > remaining {
-			_, _ = b.buf.Write(p[:remaining])
-			b.overflow = true
-		} else {
-			_, _ = b.buf.Write(p)
-		}
-	} else if len(p) > 0 {
-		b.overflow = true
-	}
-	if b.total > b.limit {
-		b.overflow = true
-	}
-	return len(p), nil
-}
-
-func (b *boundedOutput) Bytes() []byte {
-	return append([]byte(nil), b.buf.Bytes()...)
-}
-
-func (b *boundedOutput) Overflow() bool {
-	return b.overflow
 }
 
 func scriptFailureDetailJSON(err error, result workflowScriptResult) string {

--- a/server/workflowrunner/starter.go
+++ b/server/workflowrunner/starter.go
@@ -61,7 +61,13 @@ type RuntimeStore interface {
 }
 
 type TaskWorktreeEnsurer interface {
-	EnsureTaskWorktree(ctx context.Context, taskID string) error
+	EnsureTaskWorktree(ctx context.Context, req TaskWorktreeEnsureRequest) error
+}
+
+type TaskWorktreeEnsureRequest struct {
+	TaskID           workflow.TaskID
+	RunID            workflow.RunID
+	SetupOperationID serverapi.WorktreeSetupOperationID
 }
 
 type RuntimeEventRegistry interface {
@@ -162,7 +168,7 @@ func (s *Starter) StartWorkflowRun(ctx context.Context, req SchedulerStartRunReq
 	}
 	s.mu.Unlock()
 	if s.worktrees != nil {
-		if err := s.worktrees.EnsureTaskWorktree(ctx, string(req.TaskID)); err != nil {
+		if err := s.worktrees.EnsureTaskWorktree(ctx, TaskWorktreeEnsureRequest{TaskID: req.TaskID, RunID: req.RunID, SetupOperationID: serverapi.NewWorktreeSetupOperationID()}); err != nil {
 			return err
 		}
 	}

--- a/server/workflowrunner/starter_test.go
+++ b/server/workflowrunner/starter_test.go
@@ -1684,7 +1684,7 @@ func TestWorkflowRuntimeStartFailsWhenTransitionPromptPreviewCannotRender(t *tes
 func TestWorkflowRuntimeResumeInterruptedRunUsesSameSession(t *testing.T) {
 	fixture := newStarterFixture(t, config.WorkflowCompletionModeStructuredOutput, ScriptedFinalAnswer(`{"commentary":"resumed"}`))
 	task := fixture.createStartedTask(t)
-	if err := fixture.worktrees.EnsureTaskWorktree(context.Background(), string(task.ID)); err != nil {
+	if err := fixture.worktrees.EnsureTaskWorktree(context.Background(), TaskWorktreeEnsureRequest{TaskID: task.ID}); err != nil {
 		t.Fatalf("EnsureTaskWorktree: %v", err)
 	}
 	def, _, err := fixture.store.GetDefinition(context.Background(), fixture.workflowID)
@@ -1751,6 +1751,91 @@ func TestWorkflowRuntimeResumeInterruptedRunUsesSameSession(t *testing.T) {
 	if meta.Name != "RUN-1: Backlog -> Agent" || meta.FirstPromptPreview != startEdgePrompt {
 		t.Fatalf("resumed session metadata = name %q preview %q, want accepted transition metadata", meta.Name, meta.FirstPromptPreview)
 	}
+}
+
+func TestStartWorkflowRunWaitsForTaskWorktreeEnsureBeforeRunContext(t *testing.T) {
+	ensureStarted := make(chan TaskWorktreeEnsureRequest, 1)
+	releaseEnsure := make(chan struct{})
+	ensureErr := errors.New("setup failed")
+	ensurer := blockingStarterTaskWorktreeEnsurer{started: ensureStarted, release: releaseEnsure, err: ensureErr}
+	starter := &Starter{store: &recordingRuntimeStore{}, worktrees: ensurer}
+	done := make(chan error, 1)
+	go func() {
+		done <- starter.StartWorkflowRun(context.Background(), SchedulerStartRunRequest{TaskID: "task-1", RunID: "run-1", Generation: 1})
+	}()
+	var req TaskWorktreeEnsureRequest
+	select {
+	case req = <-ensureStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for worktree ensure")
+	}
+	if req.TaskID != "task-1" || req.RunID != "run-1" {
+		t.Fatalf("ensure request = %+v", req)
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("StartWorkflowRun returned before ensure released: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseEnsure)
+	select {
+	case err := <-done:
+		if !errors.Is(err, ensureErr) {
+			t.Fatalf("StartWorkflowRun error = %v, want %v", err, ensureErr)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for StartWorkflowRun")
+	}
+}
+
+func TestStartWorkflowRunIncludesSetupCreatedSkillInFirstModelRequest(t *testing.T) {
+	fixture := newStarterFixture(t, config.WorkflowCompletionModeStructuredOutput, ScriptedFinalAnswer(`{"commentary":"done"}`))
+	const skillName = "setup-created-workflow-skill"
+	const skillDescription = "created before context lock"
+	var skillPath string
+	fixture.worktrees.afterCreate = func(worktreeRoot string) error {
+		skillDir := filepath.Join(worktreeRoot, config.ConfigDirName, "skills", skillName)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			return err
+		}
+		skillPath = filepath.Join(skillDir, "SKILL.md")
+		content := "---\nname: " + skillName + "\ndescription: " + skillDescription + "\n---\n\n# Setup skill\n"
+		if err := os.WriteFile(skillPath, []byte(content), 0o644); err != nil {
+			return err
+		}
+		canonicalPath, err := filepath.EvalSymlinks(skillPath)
+		if err == nil {
+			skillPath = canonicalPath
+		}
+		return nil
+	}
+	task := fixture.createStartedTask(t)
+
+	if err := fixture.scheduler(t).Process(context.Background()); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	fixture.waitForCompletedRun(t, task.ID)
+
+	reqs := fixture.client.Requests()
+	if len(reqs) == 0 {
+		t.Fatal("fake model was not called")
+	}
+	if skillPath == "" {
+		t.Fatal("task worktree setup hook did not create a skill")
+	}
+	assertRequestHasSkillEntry(t, reqs[0], skillName, skillPath, skillDescription)
+}
+
+type blockingStarterTaskWorktreeEnsurer struct {
+	started chan<- TaskWorktreeEnsureRequest
+	release <-chan struct{}
+	err     error
+}
+
+func (e blockingStarterTaskWorktreeEnsurer) EnsureTaskWorktree(_ context.Context, req TaskWorktreeEnsureRequest) error {
+	e.started <- req
+	<-e.release
+	return e.err
 }
 
 func TestRemoveFanoutCloneDeletesOrphanedClone(t *testing.T) {
@@ -1923,7 +2008,7 @@ func (f starterFixture) createStartedTask(t *testing.T) workflowstore.TaskRecord
 func (f starterFixture) claimPlannedRun(t *testing.T) (workflowstore.RunnableRunRecord, workflowstore.RunStartContext, launch.SessionPlan) {
 	t.Helper()
 	task := f.createStartedTask(t)
-	if err := f.worktrees.EnsureTaskWorktree(context.Background(), string(task.ID)); err != nil {
+	if err := f.worktrees.EnsureTaskWorktree(context.Background(), TaskWorktreeEnsureRequest{TaskID: task.ID}); err != nil {
 		t.Fatalf("EnsureTaskWorktree: %v", err)
 	}
 	runs, err := f.store.ListRuns(context.Background(), task.ID)
@@ -2480,12 +2565,14 @@ type metadataTaskWorktrees struct {
 	metadata    *metadata.Store
 	workspaceID string
 	root        string
+	afterCreate func(worktreeRoot string) error
 }
 
-func (e *metadataTaskWorktrees) EnsureTaskWorktree(ctx context.Context, taskID string) error {
+func (e *metadataTaskWorktrees) EnsureTaskWorktree(ctx context.Context, req TaskWorktreeEnsureRequest) error {
 	if e == nil || e.metadata == nil {
 		return nil
 	}
+	taskID := string(req.TaskID)
 	var shortID string
 	if err := e.metadata.DB().QueryRowContext(ctx, `SELECT short_id FROM tasks WHERE id = ?`, taskID).Scan(&shortID); err != nil {
 		return err
@@ -2494,6 +2581,11 @@ func (e *metadataTaskWorktrees) EnsureTaskWorktree(ctx context.Context, taskID s
 	worktreeRoot := filepath.Join(e.root, shortID)
 	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
 		return err
+	}
+	if e.afterCreate != nil {
+		if err := e.afterCreate(worktreeRoot); err != nil {
+			return err
+		}
 	}
 	if err := e.metadata.UpsertWorktreeRecord(ctx, metadata.WorktreeRecord{
 		ID:              worktreeID,
@@ -2777,6 +2869,23 @@ func requestPromptText(req llm.Request) string {
 		haystack.WriteString("\n")
 	}
 	return haystack.String()
+}
+
+func assertRequestHasSkillEntry(t *testing.T, req llm.Request, name string, skillPath string, description string) {
+	t.Helper()
+	wantLine := "- " + name + ": " + filepath.ToSlash(skillPath) + " . " + description
+	for _, item := range req.Items {
+		if item.Role != llm.RoleDeveloper || item.MessageType != llm.MessageTypeSkills {
+			continue
+		}
+		for _, line := range strings.Split(item.Content, "\n") {
+			if line == wantLine {
+				return
+			}
+		}
+		t.Fatalf("skills message missing setup-created skill entry %q: %q", wantLine, item.Content)
+	}
+	t.Fatalf("request missing structured skills message: %+v", req.Items)
 }
 
 func assertNoUserPrompt(t *testing.T, req llm.Request) {

--- a/server/workflowstore/transitions.go
+++ b/server/workflowstore/transitions.go
@@ -84,7 +84,7 @@ func (s *Store) PendingTransitionTargetsExecutableNode(ctx context.Context, tran
 		return false, err
 	}
 	for _, edge := range edges {
-		if edge.State == "pending" && executableNodeKind(workflow.NodeKind(edge.TargetNodeKind)) {
+		if executableNodeKind(workflow.NodeKind(edge.TargetNodeKind)) {
 			return true, nil
 		}
 	}

--- a/server/workflowsvc/service.go
+++ b/server/workflowsvc/service.go
@@ -37,7 +37,24 @@ type Service struct {
 }
 
 type taskWorktreeEnsurer interface {
-	EnsureTaskWorktree(ctx context.Context, taskID string) error
+	EnsureTaskWorktree(ctx context.Context, req TaskWorktreeEnsureRequest) error
+}
+
+type TaskWorktreeEnsureRequest struct {
+	TaskID           workflow.TaskID
+	SetupOperationID serverapi.WorktreeSetupOperationID
+}
+
+type taskWorktreeEnsureError struct {
+	err error
+}
+
+func (e taskWorktreeEnsureError) Error() string {
+	return e.err.Error()
+}
+
+func (e taskWorktreeEnsureError) Unwrap() error {
+	return e.err
 }
 
 type taskWorktreeDeleter interface {
@@ -593,7 +610,7 @@ func (s *Service) StartWorkflowTask(ctx context.Context, req serverapi.WorkflowT
 	if err := req.Validate(); err != nil {
 		return serverapi.WorkflowTaskStartResponse{}, err
 	}
-	started, err := s.StartTaskAutomation(ctx, req.TaskID)
+	started, err := s.startTaskAutomation(ctx, TaskAutomationStartRequest{TaskID: req.TaskID, SetupOperationID: req.SetupOperationID})
 	if err != nil {
 		return serverapi.WorkflowTaskStartResponse{}, err
 	}
@@ -669,12 +686,26 @@ func (s *Service) ResumeWorkflowTask(ctx context.Context, req serverapi.Workflow
 	return serverapi.WorkflowTaskResumeResponse{Runs: workflowTaskRunSummaries(resumed)}, nil
 }
 
+type TaskAutomationStartRequest struct {
+	TaskID           string
+	SetupOperationID serverapi.WorktreeSetupOperationID
+}
+
 func (s *Service) StartTaskAutomation(ctx context.Context, taskID string) (workflowstore.StartTaskResult, error) {
+	return s.startTaskAutomation(ctx, TaskAutomationStartRequest{TaskID: taskID, SetupOperationID: serverapi.NewWorktreeSetupOperationID()})
+}
+
+func (s *Service) StartTaskAutomationWithSetup(ctx context.Context, req TaskAutomationStartRequest) (workflowstore.StartTaskResult, error) {
+	return s.startTaskAutomation(ctx, req)
+}
+
+func (s *Service) startTaskAutomation(ctx context.Context, req TaskAutomationStartRequest) (workflowstore.StartTaskResult, error) {
+	taskID := strings.TrimSpace(req.TaskID)
 	if s.taskWorktrees != nil {
 		if err := s.store.ValidateTaskStart(ctx, workflow.TaskID(taskID)); err != nil {
 			return workflowstore.StartTaskResult{}, err
 		}
-		if err := s.taskWorktrees.EnsureTaskWorktree(ctx, taskID); err != nil {
+		if err := s.taskWorktrees.EnsureTaskWorktree(ctx, TaskWorktreeEnsureRequest{TaskID: workflow.TaskID(taskID), SetupOperationID: req.SetupOperationID}); err != nil {
 			return workflowstore.StartTaskResult{}, err
 		}
 	}
@@ -700,7 +731,7 @@ func (s *Service) ApproveWorkflowTask(ctx context.Context, req serverapi.Workflo
 	if err != nil {
 		return serverapi.WorkflowTaskApproveResponse{}, err
 	}
-	approved, err := s.approveTransition(ctx, workflow.TransitionID(transitionID), taskID)
+	approved, err := s.approveTransition(ctx, workflow.TransitionID(transitionID), taskID, req.SetupOperationID)
 	if err != nil {
 		return serverapi.WorkflowTaskApproveResponse{}, err
 	}
@@ -723,8 +754,12 @@ func (s *Service) MoveWorkflowTask(ctx context.Context, req serverapi.WorkflowTa
 	approvalError := ""
 	resolvedApprovals := append([]workflow.TransitionID(nil), moved.ResolvedApprovalTransitionIDs...)
 	if req.AutoApprove && moved.State == "pending_approval" && !moved.RequiresApproval {
-		approved, approveErr := s.approveTransition(ctx, moved.TransitionID, req.TaskID)
+		approved, approveErr := s.approveTransition(ctx, moved.TransitionID, req.TaskID, req.SetupOperationID)
 		if approveErr != nil {
+			var ensureErr taskWorktreeEnsureError
+			if errors.As(approveErr, &ensureErr) {
+				return serverapi.WorkflowTaskMoveResponse{}, approveErr
+			}
 			approvalError = approveErr.Error()
 		} else {
 			approved.ResolvedApprovalTransitionIDs = append(resolvedApprovals, approved.ResolvedApprovalTransitionIDs...)
@@ -741,7 +776,7 @@ func (s *Service) MoveWorkflowTask(ctx context.Context, req serverapi.WorkflowTa
 	return serverapi.WorkflowTaskMoveResponse{TransitionID: string(moved.TransitionID), State: moved.State, PlacementIDs: placementIDs(moved.PlacementIDs), RunIDs: runIDs(moved.RunIDs), ApprovalError: approvalError}, nil
 }
 
-func (s *Service) approveTransition(ctx context.Context, transitionID workflow.TransitionID, taskID string) (workflowstore.CompleteRunResult, error) {
+func (s *Service) approveTransition(ctx context.Context, transitionID workflow.TransitionID, taskID string, setupOperationID serverapi.WorktreeSetupOperationID) (workflowstore.CompleteRunResult, error) {
 	if s.taskWorktrees != nil {
 		requiresWorktree, err := s.store.PendingTransitionTargetsExecutableNode(ctx, transitionID)
 		if err != nil {
@@ -755,8 +790,8 @@ func (s *Service) approveTransition(ctx context.Context, transitionID workflow.T
 					return workflowstore.CompleteRunResult{}, err
 				}
 			}
-			if err := s.taskWorktrees.EnsureTaskWorktree(ctx, resolvedTaskID); err != nil {
-				return workflowstore.CompleteRunResult{}, err
+			if err := s.taskWorktrees.EnsureTaskWorktree(ctx, TaskWorktreeEnsureRequest{TaskID: workflow.TaskID(resolvedTaskID), SetupOperationID: setupOperationID}); err != nil {
+				return workflowstore.CompleteRunResult{}, taskWorktreeEnsureError{err: err}
 			}
 		}
 	}

--- a/server/workflowsvc/service_test.go
+++ b/server/workflowsvc/service_test.go
@@ -469,7 +469,7 @@ func TestServiceTaskStartValidatesCurrentGraph(t *testing.T) {
 	if _, err := service.AddWorkflowTransitionGroup(ctx, serverapi.WorkflowTransitionGroupAddRequest{WorkflowID: workflowID, GroupID: "group-invalid", SourceNodeID: doneID, TransitionID: "invalid", DisplayName: "Invalid"}); err != nil {
 		t.Fatalf("AddWorkflowTransitionGroup invalid: %v", err)
 	}
-	if _, err := service.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{TaskID: task.Task.ID}); err == nil {
+	if _, err := service.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: task.Task.ID}); err == nil {
 		t.Fatalf("expected current graph validation error, got %v", err)
 	} else {
 		var validationErr workflowstore.WorkflowValidationError
@@ -494,9 +494,15 @@ func TestServiceTaskStartEnsuresTaskWorktreeBeforeRun(t *testing.T) {
 		}
 	}}
 	service.taskWorktrees = ensurer
-	startWorkflowServiceTask(t, ctx, service, task.Task.ID)
+	setupID := serverapi.NewWorktreeSetupOperationID()
+	if _, err := service.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{SetupOperationID: setupID, TaskID: task.Task.ID}); err != nil {
+		t.Fatalf("StartWorkflowTask: %v", err)
+	}
 	if ensurer.taskID != task.Task.ID {
 		t.Fatalf("ensured task id = %q, want %q", ensurer.taskID, task.Task.ID)
+	}
+	if ensurer.setupOperationID != setupID {
+		t.Fatalf("ensured setup operation id = %s, want %s", ensurer.setupOperationID.String(), setupID.String())
 	}
 }
 
@@ -511,7 +517,7 @@ func TestServiceAllowsInvalidDefaultBacklogButRejectsUnlinkedWorkflow(t *testing
 	}
 	linkDefaultWorkflowServiceProject(t, ctx, service, binding.ProjectID, unlinked.Workflow.ID)
 	task := createDefaultWorkflowServiceTask(t, ctx, service, binding.ProjectID)
-	if _, err := service.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{TaskID: task.Task.ID}); !errors.Is(err, workflowstore.ErrWorkflowValidationFailed) {
+	if _, err := service.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: task.Task.ID}); !errors.Is(err, workflowstore.ErrWorkflowValidationFailed) {
 		t.Fatalf("expected invalid default workflow start error, got %v", err)
 	}
 }
@@ -590,7 +596,7 @@ func TestServiceMoveTaskRejectsMissingEdgeExecutableOverride(t *testing.T) {
 	}
 	implementID := workflowServiceNodeIDByKey(t, def.Definition, "implement")
 
-	_, err = service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{TaskID: task.Task.ID, TargetNodeID: implementID, AllowMissingEdge: true, AutoApprove: true, OutputValues: map[string]string{"prior_summary": "replacement"}})
+	_, err = service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: task.Task.ID, TargetNodeID: implementID, AllowMissingEdge: true, AutoApprove: true, OutputValues: map[string]string{"prior_summary": "replacement"}})
 	if !errors.Is(err, workflowstore.ErrManualMoveExecutableTargetNeedsEdge) {
 		t.Fatalf("MoveWorkflowTask error = %v, want executable edge requirement", err)
 	}
@@ -643,12 +649,16 @@ func TestServiceMoveTaskAutoApproveEnsuresWorktreeBeforeApprovingScript(t *testi
 	}}
 	service.taskWorktrees = ensurer
 
-	moved, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{TaskID: task.Task.ID, TargetNodeID: scriptID, AllowMissingEdge: true, AutoApprove: true})
+	setupID := serverapi.NewWorktreeSetupOperationID()
+	moved, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: setupID, TaskID: task.Task.ID, TargetNodeID: scriptID, AllowMissingEdge: true, AutoApprove: true})
 	if err != nil {
 		t.Fatalf("MoveWorkflowTask: %v", err)
 	}
 	if ensurer.taskID != task.Task.ID {
 		t.Fatalf("ensured task id = %q, want %q", ensurer.taskID, task.Task.ID)
+	}
+	if ensurer.setupOperationID != setupID {
+		t.Fatalf("ensured setup operation id = %s, want %s", ensurer.setupOperationID.String(), setupID.String())
 	}
 	if moved.State != "approved" || len(moved.PlacementIDs) != 1 || len(moved.RunIDs) != 1 || moved.ApprovalError != "" {
 		t.Fatalf("auto-approved script move = %+v, want approved placement and run", moved)
@@ -871,7 +881,7 @@ func TestServiceMoveTaskAutoApproveSurfacesCommittedPendingMoveWhenApprovalFails
 		return workflowstore.CompleteRunResult{}, errors.New("approval failed")
 	}
 
-	moved, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{TaskID: task.Task.ID, TargetNodeID: planID, AllowMissingEdge: true, AutoApprove: true})
+	moved, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: task.Task.ID, TargetNodeID: planID, AllowMissingEdge: true, AutoApprove: true})
 	if err != nil {
 		t.Fatalf("MoveWorkflowTask: %v", err)
 	}
@@ -890,6 +900,39 @@ func TestServiceMoveTaskAutoApproveSurfacesCommittedPendingMoveWhenApprovalFails
 	}
 }
 
+func TestServiceMoveTaskAutoApproveReturnsEnsureFailureAsForegroundError(t *testing.T) {
+	ctx, service, binding := newWorkflowServiceTestContext(t)
+	workflowID := createWorkflowServiceChainedWorkflow(t, ctx, service)
+	linkDefaultWorkflowServiceProject(t, ctx, service, binding.ProjectID, workflowID)
+	task := createDefaultWorkflowServiceTask(t, ctx, service, binding.ProjectID)
+	def, err := service.GetWorkflow(ctx, serverapi.WorkflowGetRequest{WorkflowID: workflowID})
+	if err != nil {
+		t.Fatalf("GetWorkflow: %v", err)
+	}
+	planID := workflowServiceNodeIDByKey(t, def.Definition, "plan")
+	setupErr := errors.New("setup failed")
+	service.taskWorktrees = &recordingTaskWorktreeEnsurer{err: setupErr}
+
+	_, err = service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: task.Task.ID, TargetNodeID: planID, AllowMissingEdge: true, AutoApprove: true})
+	if !errors.Is(err, setupErr) {
+		t.Fatalf("MoveWorkflowTask err = %v, want setup failure", err)
+	}
+	runs, listErr := service.store.ListRuns(ctx, workflow.TaskID(task.Task.ID))
+	if listErr != nil {
+		t.Fatalf("ListRuns: %v", listErr)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("runs = %+v, want no scheduled runs after setup failure", runs)
+	}
+	transitions, err := service.store.ListTransitions(ctx, workflow.TaskID(task.Task.ID))
+	if err != nil {
+		t.Fatalf("ListTransitions: %v", err)
+	}
+	if len(transitions) != 1 || transitions[0].State != "pending_approval" {
+		t.Fatalf("committed transition = %+v, want pending move kept for inspection", transitions)
+	}
+}
+
 func TestServiceMoveTaskAutoApprovedReplacementResolvesOldPendingApproval(t *testing.T) {
 	ctx, service, binding := newWorkflowServiceTestContext(t)
 	workflowID := createWorkflowServiceChainedWorkflow(t, ctx, service)
@@ -902,7 +945,7 @@ func TestServiceMoveTaskAutoApprovedReplacementResolvesOldPendingApproval(t *tes
 	planID := workflowServiceNodeIDByKey(t, def.Definition, "plan")
 	finalizer := &recordingWorkflowAttentionFinalizer{}
 	service.attentionFinalizer = finalizer
-	oldMove, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{TaskID: task.Task.ID, TargetNodeID: planID, AllowMissingEdge: true})
+	oldMove, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: task.Task.ID, TargetNodeID: planID, AllowMissingEdge: true})
 	if err != nil {
 		t.Fatalf("initial MoveWorkflowTask: %v", err)
 	}
@@ -910,7 +953,7 @@ func TestServiceMoveTaskAutoApprovedReplacementResolvesOldPendingApproval(t *tes
 		t.Fatalf("initial move = %+v, want pending approval", oldMove)
 	}
 
-	replacement, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{TaskID: task.Task.ID, TargetNodeID: planID, AllowMissingEdge: true, AutoApprove: true})
+	replacement, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: task.Task.ID, TargetNodeID: planID, AllowMissingEdge: true, AutoApprove: true})
 	if err != nil {
 		t.Fatalf("replacement MoveWorkflowTask: %v", err)
 	}
@@ -950,7 +993,7 @@ func TestServiceMoveTaskAutoApproveDoesNotBypassApprovalGatedEdge(t *testing.T) 
 		t.Fatalf("enable start edge approval: %v", err)
 	}
 
-	moved, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{TaskID: task.Task.ID, TargetNodeID: agentID, AllowMissingEdge: true, AutoApprove: true})
+	moved, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: task.Task.ID, TargetNodeID: agentID, AllowMissingEdge: true, AutoApprove: true})
 	if err != nil {
 		t.Fatalf("MoveWorkflowTask: %v", err)
 	}
@@ -993,12 +1036,53 @@ func TestServiceApproveTerminalTransitionDoesNotEnsureWorktree(t *testing.T) {
 		t.Fatalf("unexpected worktree ensure for terminal approval of task %s", taskID)
 	}}
 
-	approved, err := service.ApproveWorkflowTask(ctx, serverapi.WorkflowTaskApproveRequest{TaskTransitionID: string(completed.TransitionID)})
+	approved, err := service.ApproveWorkflowTask(ctx, serverapi.WorkflowTaskApproveRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskTransitionID: string(completed.TransitionID)})
 	if err != nil {
 		t.Fatalf("ApproveWorkflowTask: %v", err)
 	}
 	if approved.State != "approved" || len(approved.RunIDs) != 0 {
 		t.Fatalf("terminal approval = %+v, want approved without run", approved)
+	}
+}
+
+func TestServiceApproveExecutableTransitionForwardsSetupOperationID(t *testing.T) {
+	ctx, service, binding := newWorkflowServiceTestContext(t)
+	workflowID := createWorkflowServiceValidWorkflow(t, ctx, service)
+	linkDefaultWorkflowServiceProject(t, ctx, service, binding.ProjectID, workflowID)
+	task := createDefaultWorkflowServiceTask(t, ctx, service, binding.ProjectID)
+	def, err := service.GetWorkflow(ctx, serverapi.WorkflowGetRequest{WorkflowID: workflowID})
+	if err != nil {
+		t.Fatalf("GetWorkflow: %v", err)
+	}
+	var startEdge serverapi.WorkflowEdge
+	for _, edge := range def.Definition.Edges {
+		if edge.Key == "start" {
+			startEdge = edge
+			break
+		}
+	}
+	if startEdge.ID == "" {
+		t.Fatalf("missing start edge in %+v", def.Definition.Edges)
+	}
+	if _, err := service.store.UpdateEdge(ctx, workflowstore.EdgeRecord{ID: workflow.EdgeID(startEdge.ID), WorkflowID: workflow.WorkflowID(workflowID), TransitionGroupID: workflow.TransitionGroupID(startEdge.TransitionGroupID), Key: workflow.ModelKey(startEdge.Key), TargetNodeID: workflow.NodeID(startEdge.TargetNodeID), RequiresApproval: true, ContextMode: workflow.ContextMode(startEdge.ContextMode), ContextSource: workflow.CanonicalContextSource(workflow.ContextSource{Kind: workflow.ContextSourceKind(startEdge.ContextSource.Kind), NodeKey: workflow.ModelKey(startEdge.ContextSource.NodeKey)}), PromptTemplate: startEdge.PromptTemplate, Parameters: domainParameters(startEdge.Parameters)}); err != nil {
+		t.Fatalf("enable start edge approval: %v", err)
+	}
+	started, err := service.store.StartTask(ctx, workflow.TaskID(task.Task.ID))
+	if err != nil {
+		t.Fatalf("StartTask: %v", err)
+	}
+	ensurer := &recordingTaskWorktreeEnsurer{}
+	service.taskWorktrees = ensurer
+	setupID := serverapi.NewWorktreeSetupOperationID()
+	approved, err := service.ApproveWorkflowTask(ctx, serverapi.WorkflowTaskApproveRequest{SetupOperationID: setupID, TaskTransitionID: string(started.TransitionID)})
+	if err != nil {
+		t.Fatalf("ApproveWorkflowTask: %v", err)
+	}
+	if approved.State != "applied" {
+		t.Fatalf("approval = %+v, want applied", approved)
+	}
+	if ensurer.taskID != task.Task.ID || ensurer.setupOperationID != setupID {
+		t.Fatalf("ensurer = task %q setup %s, want task %q setup %s", ensurer.taskID, ensurer.setupOperationID.String(), task.Task.ID, setupID.String())
 	}
 }
 
@@ -1085,7 +1169,7 @@ func TestServiceCancelTaskResolvesPendingApprovalAttention(t *testing.T) {
 	planID := workflowServiceNodeIDByKey(t, def.Definition, "plan")
 	finalizer := &recordingWorkflowAttentionFinalizer{}
 	service.attentionFinalizer = finalizer
-	moved, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{TaskID: task.Task.ID, TargetNodeID: planID, AllowMissingEdge: true})
+	moved, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: task.Task.ID, TargetNodeID: planID, AllowMissingEdge: true})
 	if err != nil {
 		t.Fatalf("MoveWorkflowTask: %v", err)
 	}
@@ -1149,7 +1233,7 @@ func TestServiceDeleteTaskResolvesPendingApprovalAttention(t *testing.T) {
 	planID := workflowServiceNodeIDByKey(t, def.Definition, "plan")
 	finalizer := &recordingWorkflowAttentionFinalizer{}
 	service.attentionFinalizer = finalizer
-	moved, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{TaskID: task.Task.ID, TargetNodeID: planID, AllowMissingEdge: true})
+	moved, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: task.Task.ID, TargetNodeID: planID, AllowMissingEdge: true})
 	if err != nil {
 		t.Fatalf("MoveWorkflowTask: %v", err)
 	}
@@ -1177,7 +1261,7 @@ func TestServiceDeleteWorkflowResolvesPendingApprovalAttention(t *testing.T) {
 	planID := workflowServiceNodeIDByKey(t, def.Definition, "plan")
 	finalizer := &recordingWorkflowAttentionFinalizer{}
 	service.attentionFinalizer = finalizer
-	moved, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{TaskID: task.Task.ID, TargetNodeID: planID, AllowMissingEdge: true})
+	moved, err := service.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: task.Task.ID, TargetNodeID: planID, AllowMissingEdge: true})
 	if err != nil {
 		t.Fatalf("MoveWorkflowTask: %v", err)
 	}
@@ -1408,8 +1492,10 @@ func (c *recordingTaskRuntimeRunCancelRequester) RequestCancelRun(runID workflow
 }
 
 type recordingTaskWorktreeEnsurer struct {
-	taskID string
-	hook   func(string)
+	taskID           string
+	setupOperationID serverapi.WorktreeSetupOperationID
+	hook             func(string)
+	err              error
 }
 
 type recordingTaskWorktreeDeleter struct {
@@ -1441,12 +1527,13 @@ func (r *recordingPromptResponder) SubmitPromptResponse(sessionID string, resp a
 	return nil
 }
 
-func (e *recordingTaskWorktreeEnsurer) EnsureTaskWorktree(ctx context.Context, taskID string) error {
-	e.taskID = taskID
+func (e *recordingTaskWorktreeEnsurer) EnsureTaskWorktree(ctx context.Context, req TaskWorktreeEnsureRequest) error {
+	e.taskID = string(req.TaskID)
+	e.setupOperationID = req.SetupOperationID
 	if e.hook != nil {
-		e.hook(taskID)
+		e.hook(string(req.TaskID))
 	}
-	return nil
+	return e.err
 }
 
 func TestServiceDefaultWorkflowResolvesWithinProjectOnly(t *testing.T) {
@@ -2130,7 +2217,7 @@ func TestServiceWorkflowGraphSaveAllowsEmptyPromptButTaskStartRejects(t *testing
 	}
 
 	task := createDefaultWorkflowServiceTask(t, ctx, service, binding.ProjectID)
-	if _, err := service.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{TaskID: task.Task.ID}); err == nil {
+	if _, err := service.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: task.Task.ID}); err == nil {
 		t.Fatalf("StartWorkflowTask empty prompt error = %v, want transition prompt required", err)
 	} else {
 		var validationErr workflowstore.WorkflowValidationError
@@ -2245,7 +2332,7 @@ func createDefaultWorkflowServiceTask(t *testing.T, ctx context.Context, service
 
 func startWorkflowServiceTask(t *testing.T, ctx context.Context, service *Service, taskID string) serverapi.WorkflowTaskStartResponse {
 	t.Helper()
-	started, err := service.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{TaskID: taskID})
+	started, err := service.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: taskID})
 	if err != nil {
 		t.Fatalf("StartWorkflowTask: %v", err)
 	}

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -18,13 +18,14 @@ import (
 	"core/server/metadata/sqlitegen"
 	"core/server/session"
 	shelltool "core/server/tools/shell"
+	"core/server/workflow"
 	"core/shared/clientui"
 	"core/shared/config"
 	"core/shared/serverapi"
 	"github.com/google/uuid"
 )
 
-const setupScriptTimeout = 20 * time.Second
+const setupDiagnosticLimitBytes = 16 * 1024
 
 const rollbackSessionTargetTimeout = 5 * time.Second
 
@@ -49,19 +50,22 @@ type localEntryAppender interface {
 }
 
 type ServiceOptions struct {
-	BaseDir     string
-	SetupScript string
+	BaseDir             string
+	SetupScript         string
+	SetupTimeoutSeconds int
 }
 
 type Service struct {
-	metadata    *metadata.Store
-	git         *GitInspector
-	runtime     runtimeController
-	active      activeRuntimeSource
-	processes   processSource
-	localNotes  localEntryAppender
-	baseDir     string
-	setupScript string
+	metadata            *metadata.Store
+	git                 *GitInspector
+	runtime             runtimeController
+	active              activeRuntimeSource
+	processes           processSource
+	localNotes          localEntryAppender
+	baseDir             string
+	setupScript         string
+	setupTimeoutSeconds int
+	setupBroker         *setupEventBroker
 
 	workspaceMu    sync.Mutex
 	workspaceLocks map[string]*workspaceMutationLock
@@ -107,7 +111,8 @@ type setupScriptPayload struct {
 }
 
 type EnsureTaskWorktreeRequest struct {
-	TaskID string
+	TaskID           workflow.TaskID
+	SetupOperationID serverapi.WorktreeSetupOperationID
 }
 
 type EnsureTaskWorktreeResponse struct {
@@ -136,15 +141,17 @@ func NewService(metadataStore *metadata.Store, gitInspector *GitInspector, activ
 		}
 	}
 	return &Service{
-		metadata:       metadataStore,
-		git:            gitInspector,
-		runtime:        runtime,
-		active:         active,
-		processes:      processes,
-		localNotes:     localNotes,
-		baseDir:        strings.TrimSpace(opts.BaseDir),
-		setupScript:    strings.TrimSpace(opts.SetupScript),
-		workspaceLocks: make(map[string]*workspaceMutationLock),
+		metadata:            metadataStore,
+		git:                 gitInspector,
+		runtime:             runtime,
+		active:              active,
+		processes:           processes,
+		localNotes:          localNotes,
+		baseDir:             strings.TrimSpace(opts.BaseDir),
+		setupScript:         strings.TrimSpace(opts.SetupScript),
+		setupTimeoutSeconds: opts.SetupTimeoutSeconds,
+		setupBroker:         newSetupEventBroker(),
+		workspaceLocks:      make(map[string]*workspaceMutationLock),
 	}
 }
 
@@ -152,7 +159,7 @@ func (s *Service) EnsureTaskWorktree(ctx context.Context, req EnsureTaskWorktree
 	if s == nil || s.metadata == nil || s.git == nil {
 		return EnsureTaskWorktreeResponse{}, errors.New("worktree service dependencies are required")
 	}
-	taskID := strings.TrimSpace(req.TaskID)
+	taskID := strings.TrimSpace(string(req.TaskID))
 	if taskID == "" {
 		return EnsureTaskWorktreeResponse{}, errors.New("task_id is required")
 	}
@@ -162,10 +169,12 @@ func (s *Service) EnsureTaskWorktree(ctx context.Context, req EnsureTaskWorktree
 	}
 	if task.ManagedWorktreeID.Valid && strings.TrimSpace(task.ManagedWorktreeID.String) != "" {
 		view, err := s.taskManagedWorktreeView(ctx, strings.TrimSpace(task.ManagedWorktreeID.String))
-		if err != nil {
+		if err == nil {
+			return EnsureTaskWorktreeResponse{Worktree: view}, nil
+		}
+		if !errors.Is(err, serverapi.ErrWorktreeNotFound) {
 			return EnsureTaskWorktreeResponse{}, err
 		}
-		return EnsureTaskWorktreeResponse{Worktree: view}, nil
 	}
 	workspace, err := s.taskSourceWorkspace(ctx, task.ProjectID, task.SourceWorkspaceID.String)
 	if err != nil {
@@ -179,10 +188,15 @@ func (s *Service) EnsureTaskWorktree(ctx context.Context, req EnsureTaskWorktree
 	}
 	if task.ManagedWorktreeID.Valid && strings.TrimSpace(task.ManagedWorktreeID.String) != "" {
 		view, err := s.taskManagedWorktreeView(ctx, strings.TrimSpace(task.ManagedWorktreeID.String))
-		if err != nil {
+		if err == nil {
+			return EnsureTaskWorktreeResponse{Worktree: view}, nil
+		}
+		if !errors.Is(err, serverapi.ErrWorktreeNotFound) {
 			return EnsureTaskWorktreeResponse{}, err
 		}
-		return EnsureTaskWorktreeResponse{Worktree: view}, nil
+		if err := s.git.Prune(ctx, workspace.RootPath); err != nil {
+			return EnsureTaskWorktreeResponse{}, err
+		}
 	}
 	createSpec, err := normalizeCreateSpec(CreateSpec{BaseRef: "HEAD", CreateBranch: true, BranchName: task.ShortID})
 	if err != nil {
@@ -193,7 +207,14 @@ func (s *Service) EnsureTaskWorktree(ctx context.Context, req EnsureTaskWorktree
 		return EnsureTaskWorktreeResponse{}, err
 	}
 	if resolution.Kind != CreateTargetResolutionKindNewBranch {
-		return EnsureTaskWorktreeResponse{}, &TaskBranchCollisionError{BranchName: createSpec.BranchName, ResolvedRef: resolution.ResolvedRef}
+		if task.ManagedWorktreeID.Valid && strings.TrimSpace(task.ManagedWorktreeID.String) != "" && resolution.Kind == CreateTargetResolutionKindExistingBranch {
+			createSpec, err = normalizeCreateSpec(CreateSpec{BaseRef: createSpec.BranchName, CreateBranch: false})
+			if err != nil {
+				return EnsureTaskWorktreeResponse{}, err
+			}
+		} else {
+			return EnsureTaskWorktreeResponse{}, &TaskBranchCollisionError{BranchName: createSpec.BranchName, ResolvedRef: resolution.ResolvedRef}
+		}
 	}
 	worktreeRoot, err := s.resolveRequestedWorktreeRoot("", workspace.WorkspaceID, createSpec)
 	if err != nil {
@@ -205,7 +226,7 @@ func (s *Service) EnsureTaskWorktree(ctx context.Context, req EnsureTaskWorktree
 		workspaceRoot: workspace.RootPath,
 		worktreeRoot:  worktreeRoot,
 		branchName:    createSpec.BranchName,
-		createdBranch: true,
+		createdBranch: createSpec.CreateBranch,
 	}
 	defer func() {
 		if err == nil || !cleanup.active {
@@ -235,7 +256,7 @@ func (s *Service) EnsureTaskWorktree(ctx context.Context, req EnsureTaskWorktree
 		return EnsureTaskWorktreeResponse{}, fmt.Errorf("created task worktree %q was not discovered after git sync: %w", worktreeRoot, serverapi.ErrWorktreeNotFound)
 	}
 	created.record.Managed = true
-	created.record.CreatedBranch = createdBranch
+	created.record.CreatedBranch = createdBranch || (task.ManagedWorktreeID.Valid && strings.TrimSpace(task.ManagedWorktreeID.String) != "")
 	created.record.UpdatedAt = time.Now().UTC()
 	cleanup.worktreeID = strings.TrimSpace(created.record.ID)
 	if err := s.metadata.UpsertWorktreeRecord(ctx, created.record); err != nil {
@@ -247,6 +268,20 @@ func (s *Service) EnsureTaskWorktree(ctx context.Context, req EnsureTaskWorktree
 		return EnsureTaskWorktreeResponse{}, sql.ErrNoRows
 	}
 	cleanup.active = false
+	if err := s.runSetupForWorktree(ctx, setupExecutionRequest{
+		SetupOperationID:    req.SetupOperationID,
+		SourceWorkspaceRoot: workspace.RootPath,
+		BranchName:          strings.TrimSpace(created.git.BranchName),
+		WorktreeRoot:        created.record.CanonicalRoot,
+		ScriptPayload: setupScriptPayload{
+			ProjectID:   task.ProjectID,
+			WorkspaceID: workspace.WorkspaceID,
+			WorktreeID:  created.record.ID,
+		},
+		CreatedBranch: createdBranch,
+	}); err != nil {
+		return EnsureTaskWorktreeResponse{}, err
+	}
 	worktreeView, err := worktreeViewFromSynced(created, clientui.SessionExecutionTarget{})
 	if err != nil {
 		return EnsureTaskWorktreeResponse{}, err
@@ -470,6 +505,15 @@ func (s *Service) taskManagedWorktreeView(ctx context.Context, worktreeID string
 	if err != nil {
 		return serverapi.WorktreeView{}, err
 	}
+	if strings.TrimSpace(record.CanonicalRoot) == "" {
+		return serverapi.WorktreeView{}, fmt.Errorf("managed worktree %q has no canonical root: %w", worktreeID, serverapi.ErrWorktreeNotFound)
+	}
+	if _, err := os.Stat(record.CanonicalRoot); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return serverapi.WorktreeView{}, fmt.Errorf("managed worktree %q root %q is missing: %w", worktreeID, record.CanonicalRoot, serverapi.ErrWorktreeNotFound)
+		}
+		return serverapi.WorktreeView{}, err
+	}
 	gitMetadata, err := worktreeGitMetadataFromRecord(record)
 	if err != nil {
 		return serverapi.WorktreeView{}, err
@@ -580,6 +624,22 @@ func (s *Service) CreateWorktree(ctx context.Context, req serverapi.WorktreeCrea
 	if err := s.metadata.UpsertWorktreeRecord(ctx, created.record); err != nil {
 		return serverapi.WorktreeCreateResponse{}, err
 	}
+	cleanup.active = false
+	if err := s.runSetupForWorktree(ctx, setupExecutionRequest{
+		SetupOperationID:    req.SetupOperationID,
+		SourceWorkspaceRoot: workspaceCtx.workspaceRoot,
+		BranchName:          strings.TrimSpace(created.git.BranchName),
+		WorktreeRoot:        created.record.CanonicalRoot,
+		ScriptPayload: setupScriptPayload{
+			SessionID:   workspaceCtx.sessionID,
+			ProjectID:   workspaceCtx.projectID,
+			WorkspaceID: workspaceCtx.workspaceID,
+			WorktreeID:  created.record.ID,
+		},
+		CreatedBranch: createdBranch,
+	}); err != nil {
+		return serverapi.WorktreeCreateResponse{}, err
+	}
 	previous, err := currentSyncedWorktree(synced, workspaceCtx.target)
 	if err != nil {
 		return serverapi.WorktreeCreateResponse{}, err
@@ -588,7 +648,6 @@ func (s *Service) CreateWorktree(ctx context.Context, req serverapi.WorktreeCrea
 	if err != nil {
 		return serverapi.WorktreeCreateResponse{}, err
 	}
-	setupScheduled := s.scheduleSetupScript(workspaceCtx, created, strings.TrimSpace(created.git.BranchName), createdBranch)
 	createdView, err := worktreeViewFromSynced(created, nextTarget)
 	if err != nil {
 		return serverapi.WorktreeCreateResponse{}, err
@@ -596,8 +655,7 @@ func (s *Service) CreateWorktree(ctx context.Context, req serverapi.WorktreeCrea
 	createdView.Managed = true
 	createdView.CreatedBranch = createdBranch
 	createdView.OriginSessionID = workspaceCtx.sessionID
-	cleanup.active = false
-	return serverapi.WorktreeCreateResponse{Target: nextTarget, Worktree: createdView, CreatedBranch: createdBranch, SetupScheduled: setupScheduled}, nil
+	return serverapi.WorktreeCreateResponse{Target: nextTarget, Worktree: createdView, CreatedBranch: createdBranch}, nil
 }
 
 func (s *Service) cleanupFailedCreate(ctx context.Context, cleanup failedCreateCleanup) error {
@@ -1112,39 +1170,89 @@ func nextAvailableWorktreeRoot(baseRoot string) (string, error) {
 	return "", fmt.Errorf("no available worktree root under %q after %d attempts: %w", canonicalBase, maxCollisionSuffixAttempts, ErrWorktreeRootCollisionCap)
 }
 
-func (s *Service) scheduleSetupScript(workspaceCtx sessionWorkspaceContext, created syncedWorktree, branchName string, createdBranch bool) bool {
-	trimmedScript := strings.TrimSpace(s.setupScript)
-	if trimmedScript == "" {
-		return false
-	}
-	scriptPath, err := resolveSetupScriptPath(workspaceCtx.workspaceRoot, trimmedScript)
-	if err != nil {
-		s.appendLocalNote(context.Background(), workspaceCtx.sessionID, fmt.Sprintf("Worktree setup script skipped: %v", err))
-		return false
-	}
-	payload := setupScriptPayload{
-		SourceWorkspaceRoot: workspaceCtx.workspaceRoot,
-		BranchName:          strings.TrimSpace(branchName),
-		WorktreeRoot:        created.record.CanonicalRoot,
-		SessionID:           workspaceCtx.sessionID,
-		ProjectID:           workspaceCtx.projectID,
-		WorkspaceID:         workspaceCtx.workspaceID,
-		WorktreeID:          created.record.ID,
-		CreatedBranch:       createdBranch,
-	}
-	go s.runSetupScript(scriptPath, workspaceCtx.sessionID, payload)
-	return true
+type setupExecutionRequest struct {
+	SetupOperationID    serverapi.WorktreeSetupOperationID
+	SourceWorkspaceRoot string
+	BranchName          string
+	WorktreeRoot        string
+	ScriptPayload       setupScriptPayload
+	CreatedBranch       bool
 }
 
-func (s *Service) runSetupScript(scriptPath string, sessionID string, payload setupScriptPayload) {
-	ctx, cancel := context.WithTimeout(context.Background(), setupScriptTimeout)
-	defer cancel()
+func (s *Service) runSetupForWorktree(ctx context.Context, req setupExecutionRequest) error {
+	trimmedScript := strings.TrimSpace(s.setupScript)
+	if trimmedScript == "" {
+		return nil
+	}
+	operationID := req.SetupOperationID
+	if err := operationID.Validate(); err != nil {
+		operationID = serverapi.NewWorktreeSetupOperationID()
+	}
+	scriptPath, err := resolveSetupScriptPath(req.SourceWorkspaceRoot, trimmedScript)
+	if err != nil {
+		s.publishSetupEvent(serverapi.WorktreeSetupEvent{
+			SetupOperationID:    operationID,
+			SourceWorkspaceRoot: strings.TrimSpace(req.SourceWorkspaceRoot),
+			WorktreeRoot:        strings.TrimSpace(req.WorktreeRoot),
+			ScriptPath:          strings.TrimSpace(trimmedScript),
+			Phase:               serverapi.WorktreeSetupPhaseFailed,
+			Error:               err.Error(),
+		})
+		return fmt.Errorf("resolve worktree setup script: %w", err)
+	}
+	payload := setupScriptPayload{
+		SourceWorkspaceRoot: strings.TrimSpace(req.SourceWorkspaceRoot),
+		BranchName:          strings.TrimSpace(req.BranchName),
+		WorktreeRoot:        strings.TrimSpace(req.WorktreeRoot),
+		SessionID:           strings.TrimSpace(req.ScriptPayload.SessionID),
+		ProjectID:           strings.TrimSpace(req.ScriptPayload.ProjectID),
+		WorkspaceID:         strings.TrimSpace(req.ScriptPayload.WorkspaceID),
+		WorktreeID:          strings.TrimSpace(req.ScriptPayload.WorktreeID),
+		CreatedBranch:       req.CreatedBranch,
+	}
+	started := serverapi.WorktreeSetupEvent{
+		SetupOperationID:    operationID,
+		SourceWorkspaceRoot: payload.SourceWorkspaceRoot,
+		WorktreeRoot:        payload.WorktreeRoot,
+		ScriptPath:          scriptPath,
+		Phase:               serverapi.WorktreeSetupPhaseStarted,
+	}
+	s.publishSetupEvent(started)
+	if err := s.runSetupScript(ctx, scriptPath, payload); err != nil {
+		failure := started
+		failure.Phase = serverapi.WorktreeSetupPhaseFailed
+		var setupErr *setupScriptError
+		if errors.As(err, &setupErr) {
+			failure.Timeout = setupErr.Timeout
+			failure.Canceled = setupErr.Canceled
+			failure.ExitCode = setupErr.ExitCode
+			failure.Stdout = setupErr.Stdout
+			failure.Stderr = setupErr.Stderr
+			failure.Error = setupErr.Error()
+		} else {
+			failure.Error = err.Error()
+		}
+		s.publishSetupEvent(failure)
+		return err
+	}
+	completed := started
+	completed.Phase = serverapi.WorktreeSetupPhaseCompleted
+	s.publishSetupEvent(completed)
+	return nil
+}
+
+func (s *Service) runSetupScript(ctx context.Context, scriptPath string, payload setupScriptPayload) error {
+	setupCtx := ctx
+	var cancel context.CancelFunc
+	if s != nil && s.setupTimeoutSeconds > 0 {
+		setupCtx, cancel = context.WithTimeout(ctx, time.Duration(s.setupTimeoutSeconds)*time.Second)
+		defer cancel()
+	}
 	body, err := json.Marshal(payload)
 	if err != nil {
-		s.appendSessionNote(context.Background(), sessionID, fmt.Sprintf("Worktree setup script failed before start: %v", err))
-		return
+		return &setupScriptError{Message: fmt.Sprintf("marshal setup payload: %v", err)}
 	}
-	cmd := exec.CommandContext(ctx, scriptPath, payload.SourceWorkspaceRoot, payload.BranchName, payload.WorktreeRoot)
+	cmd := exec.CommandContext(setupCtx, scriptPath, payload.SourceWorkspaceRoot, payload.BranchName, payload.WorktreeRoot)
 	cmd.Dir = payload.WorktreeRoot
 	cmd.Stdin = strings.NewReader(string(body))
 	cmd.Env = append(os.Environ(),
@@ -1158,38 +1266,87 @@ func (s *Service) runSetupScript(scriptPath string, sessionID string, payload se
 		fmt.Sprintf("KENT_WORKTREE_CREATED_BRANCH=%t", payload.CreatedBranch),
 		"KENT_WORKTREE_PAYLOAD_JSON="+string(body),
 	)
-	output, err := cmd.CombinedOutput()
+	stdout := shelltool.NewBoundedOutput(setupDiagnosticLimitBytes)
+	stderr := shelltool.NewBoundedOutput(setupDiagnosticLimitBytes)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	configureSetupCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		return &setupScriptError{Message: err.Error(), ScriptPath: scriptPath, WorktreeRoot: payload.WorktreeRoot, Stdout: strings.TrimSpace(stdout.String()), Stderr: strings.TrimSpace(stderr.String())}
+	}
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+	select {
+	case err = <-waitCh:
+	case <-setupCtx.Done():
+		terminateSetupCommand(cmd)
+		err = <-waitCh
+	}
 	if err == nil {
-		return
+		return nil
 	}
-	detail := strings.TrimSpace(string(output))
-	if ctx.Err() != nil {
-		s.appendSessionNote(context.Background(), sessionID, fmt.Sprintf("Worktree setup timed out for %s", payload.WorktreeRoot))
-		return
+	setupErr := &setupScriptError{Message: err.Error(), ScriptPath: scriptPath, WorktreeRoot: payload.WorktreeRoot, Stdout: strings.TrimSpace(stdout.String()), Stderr: strings.TrimSpace(stderr.String())}
+	if setupCtx.Err() != nil {
+		setupErr.Timeout = errors.Is(setupCtx.Err(), context.DeadlineExceeded)
+		setupErr.Canceled = errors.Is(setupCtx.Err(), context.Canceled)
+		if setupErr.Timeout {
+			setupErr.TimeoutSeconds = s.setupTimeoutSeconds
+			setupErr.Message = fmt.Sprintf("timed out after %s", time.Duration(s.setupTimeoutSeconds)*time.Second)
+		} else {
+			setupErr.Message = setupCtx.Err().Error()
+		}
 	}
-	if detail == "" {
-		detail = err.Error()
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		exitCode := exitErr.ExitCode()
+		setupErr.ExitCode = &exitCode
 	}
-	s.appendSessionNote(context.Background(), sessionID, fmt.Sprintf("Worktree setup failed for %s: %s", payload.WorktreeRoot, detail))
+	return setupErr
 }
 
-func (s *Service) appendLocalNote(ctx context.Context, sessionID string, text string) {
-	trimmedText := strings.TrimSpace(text)
-	if s == nil || s.localNotes == nil || trimmedText == "" {
+func (s *Service) publishSetupEvent(evt serverapi.WorktreeSetupEvent) {
+	if s == nil || s.setupBroker == nil {
 		return
 	}
-	_ = s.localNotes.AppendCommittedEntry(ctx, serverapi.RuntimeAppendCommittedEntryRequest{
-		ClientRequestID: uuid.NewString(),
-		SessionID:       strings.TrimSpace(sessionID),
-		Role:            "system",
-		Text:            trimmedText,
-	})
+	s.setupBroker.Publish(evt)
 }
 
-func (s *Service) appendSessionNote(ctx context.Context, sessionID string, text string) {
-	trimmedText := strings.TrimSpace(text)
-	if s == nil || s.localNotes == nil || trimmedText == "" {
-		return
+type setupScriptError struct {
+	Message        string
+	ScriptPath     string
+	WorktreeRoot   string
+	Timeout        bool
+	TimeoutSeconds int
+	Canceled       bool
+	ExitCode       *int
+	Stdout         string
+	Stderr         string
+}
+
+func (e *setupScriptError) Error() string {
+	if e == nil {
+		return ""
 	}
-	_ = s.localNotes.AppendSessionEntry(ctx, strings.TrimSpace(sessionID), "system", trimmedText)
+	parts := []string{"worktree setup script failed"}
+	if strings.TrimSpace(e.Message) != "" {
+		parts = append(parts, e.Message)
+	}
+	if e.Timeout && e.TimeoutSeconds > 0 {
+		parts = append(parts, fmt.Sprintf("configured timeout %s", time.Duration(e.TimeoutSeconds)*time.Second))
+	}
+	if strings.TrimSpace(e.ScriptPath) != "" {
+		parts = append(parts, "script "+strings.TrimSpace(e.ScriptPath))
+	}
+	if strings.TrimSpace(e.WorktreeRoot) != "" {
+		parts = append(parts, "worktree "+strings.TrimSpace(e.WorktreeRoot))
+	}
+	if strings.TrimSpace(e.Stderr) != "" {
+		parts = append(parts, strings.TrimSpace(e.Stderr))
+	}
+	if strings.TrimSpace(e.Stdout) != "" {
+		parts = append(parts, strings.TrimSpace(e.Stdout))
+	}
+	return strings.Join(parts, ": ")
 }

--- a/server/worktree/service_part2_test.go
+++ b/server/worktree/service_part2_test.go
@@ -454,14 +454,41 @@ func waitForFileLines(t *testing.T, path string) []string {
 	return strings.Split(text, "\n")
 }
 
+func nextSetupTerminalEvent(t *testing.T, sub serverapi.WorktreeSetupSubscription) serverapi.WorktreeSetupEvent {
+	t.Helper()
+	deadline, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for {
+		evt, err := sub.Next(deadline)
+		if err != nil {
+			t.Fatalf("setup event: %v", err)
+		}
+		if evt.Phase == serverapi.WorktreeSetupPhaseCompleted || evt.Phase == serverapi.WorktreeSetupPhaseFailed {
+			return evt
+		}
+	}
+}
+
+func assertServiceTestSessionTarget(t *testing.T, env *serviceTestEnv, worktreeID string, workdir string) {
+	t.Helper()
+	target, err := env.store.ResolveSessionExecutionTarget(env.ctx, env.session.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("ResolveSessionExecutionTarget: %v", err)
+	}
+	if sessionTargetWorktreeID(target) != worktreeID || target.EffectiveWorkdir != workdir {
+		t.Fatalf("session target = %+v, want worktree_id=%q workdir=%q", target, worktreeID, workdir)
+	}
+}
+
 func mustCreateWorktree(t *testing.T, env *serviceTestEnv, branchName string) serverapi.WorktreeView {
 	t.Helper()
 	resp, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
-		ClientRequestID: "req-create-" + strings.ReplaceAll(branchName, "/", "-"),
-		SessionID:       env.session.Meta().SessionID,
-		BaseRef:         "HEAD",
-		CreateBranch:    true,
-		BranchName:      branchName,
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "req-create-" + strings.ReplaceAll(branchName, "/", "-"),
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "HEAD",
+		CreateBranch:     true,
+		BranchName:       branchName,
 	})
 	if err != nil {
 		t.Fatalf("CreateWorktree(%s): %v", branchName, err)

--- a/server/worktree/service_test.go
+++ b/server/worktree/service_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 type serviceTestRuntime struct {
@@ -226,20 +227,18 @@ func TestCreateWorktreeMarksProvenanceAndRunsSetupScriptWithProjectID(t *testing
 	env.service.setupScript = scriptRelpath
 
 	resp, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
-		ClientRequestID: "req-create",
-		SessionID:       env.session.Meta().SessionID,
-		BaseRef:         "HEAD",
-		CreateBranch:    true,
-		BranchName:      "feature/create-provenance",
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "req-create",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "HEAD",
+		CreateBranch:     true,
+		BranchName:       "feature/create-provenance",
 	})
 	if err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
 	if !resp.CreatedBranch {
 		t.Fatal("expected create to report created branch")
-	}
-	if !resp.SetupScheduled {
-		t.Fatal("expected setup script to be scheduled")
 	}
 	if !resp.Worktree.Managed {
 		t.Fatal("expected worktree managed=true")
@@ -304,13 +303,296 @@ func TestCreateWorktreeMarksProvenanceAndRunsSetupScriptWithProjectID(t *testing
 	}
 }
 
+func TestCreateWorktreeBlocksUntilSetupCompletesBeforeSessionSwitch(t *testing.T) {
+	env := newServiceTestEnv(t)
+	startedPath := filepath.Join(t.TempDir(), "started")
+	releasePath := filepath.Join(t.TempDir(), "release")
+	markerPath := filepath.Join(t.TempDir(), "marker")
+	scriptRelpath := filepath.Join("scripts", "blocking-setup.sh")
+	writeExecutableFile(t, filepath.Join(env.workspaceRoot, scriptRelpath), fmt.Sprintf("#!/bin/sh\nprintf started > %q\nwhile [ ! -f %q ]; do sleep 0.02; done\nprintf marker > %q\n", startedPath, releasePath, markerPath))
+	env.service.setupScript = scriptRelpath
+	setupID := serverapi.NewWorktreeSetupOperationID()
+	sub, err := env.service.SubscribeWorktreeSetup(env.ctx, serverapi.WorktreeSetupSubscribeRequest{SetupOperationID: setupID})
+	if err != nil {
+		t.Fatalf("SubscribeWorktreeSetup: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+	type createResult struct {
+		resp serverapi.WorktreeCreateResponse
+		err  error
+	}
+	resultCh := make(chan createResult, 1)
+	go func() {
+		resp, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+			SetupOperationID: setupID,
+			ClientRequestID:  "req-create-blocking",
+			SessionID:        env.session.Meta().SessionID,
+			BaseRef:          "HEAD",
+			CreateBranch:     true,
+			BranchName:       "feature/create-blocking",
+		})
+		resultCh <- createResult{resp: resp, err: err}
+	}()
+
+	started := waitForFileText(t, startedPath)
+	if started != "started" {
+		t.Fatalf("started marker = %q, want started", started)
+	}
+	evt, err := sub.Next(env.ctx)
+	if err != nil {
+		t.Fatalf("setup event: %v", err)
+	}
+	if evt.Phase != serverapi.WorktreeSetupPhaseStarted || evt.SetupOperationID != setupID || evt.ScriptPath == "" || evt.WorktreeRoot == "" {
+		t.Fatalf("started setup event = %+v", evt)
+	}
+	select {
+	case result := <-resultCh:
+		t.Fatalf("CreateWorktree returned before setup release: resp=%+v err=%v", result.resp, result.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	target, err := env.store.ResolveSessionExecutionTarget(env.ctx, env.session.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("ResolveSessionExecutionTarget: %v", err)
+	}
+	if sessionTargetWorktreeID(target) != "" || target.EffectiveWorkdir != env.workspaceRoot {
+		t.Fatalf("session target changed while setup blocked: %+v", target)
+	}
+	if err := os.WriteFile(releasePath, []byte("release"), 0o644); err != nil {
+		t.Fatalf("release setup: %v", err)
+	}
+	var result createResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for CreateWorktree")
+	}
+	if result.err != nil {
+		t.Fatalf("CreateWorktree: %v", result.err)
+	}
+	if got := waitForFileText(t, markerPath); got != "marker" {
+		t.Fatalf("setup marker = %q, want marker", got)
+	}
+	target, err = env.store.ResolveSessionExecutionTarget(env.ctx, env.session.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("ResolveSessionExecutionTarget after: %v", err)
+	}
+	if sessionTargetWorktreeID(target) != result.resp.Worktree.WorktreeID {
+		t.Fatalf("session target after setup = %+v, want worktree %q", target, result.resp.Worktree.WorktreeID)
+	}
+}
+
+func TestCreateWorktreeSetupFailureKeepsWorktreeAndSessionTarget(t *testing.T) {
+	env := newServiceTestEnv(t)
+	scriptRelpath := filepath.Join("scripts", "fails.sh")
+	longOutput := strings.Repeat("x", setupDiagnosticLimitBytes+128)
+	writeExecutableFile(t, filepath.Join(env.workspaceRoot, scriptRelpath), fmt.Sprintf("#!/bin/sh\nprintf '%%s' %q >&2\nexit 7\n", longOutput))
+	env.service.setupScript = scriptRelpath
+	setupID := serverapi.NewWorktreeSetupOperationID()
+	sub, err := env.service.SubscribeWorktreeSetup(env.ctx, serverapi.WorktreeSetupSubscribeRequest{SetupOperationID: setupID})
+	if err != nil {
+		t.Fatalf("SubscribeWorktreeSetup: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+	expectedRoot, err := env.service.resolveRequestedWorktreeRoot("", env.binding.WorkspaceID, CreateSpec{BaseRef: "HEAD", CreateBranch: true, BranchName: "feature/setup-fails"})
+	if err != nil {
+		t.Fatalf("resolveRequestedWorktreeRoot: %v", err)
+	}
+	_, err = env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+		SetupOperationID: setupID,
+		ClientRequestID:  "req-setup-fails",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "HEAD",
+		CreateBranch:     true,
+		BranchName:       "feature/setup-fails",
+	})
+	if err == nil {
+		t.Fatal("CreateWorktree succeeded, want setup failure")
+	}
+	if _, statErr := os.Stat(expectedRoot); statErr != nil {
+		t.Fatalf("expected setup-failed worktree kept, stat err=%v", statErr)
+	}
+	assertServiceTestSessionTarget(t, env, "", env.workspaceRoot)
+	evt := nextSetupTerminalEvent(t, sub)
+	if evt.Phase != serverapi.WorktreeSetupPhaseFailed || evt.ExitCode == nil || *evt.ExitCode != 7 {
+		t.Fatalf("failure setup event = %+v", evt)
+	}
+	if len(evt.Stderr) > setupDiagnosticLimitBytes {
+		t.Fatalf("stderr diagnostic length = %d, want <= %d", len(evt.Stderr), setupDiagnosticLimitBytes)
+	}
+}
+
+func TestCreateWorktreeSetupTimeoutKeepsWorktreeAndSessionTarget(t *testing.T) {
+	env := newServiceTestEnv(t)
+	scriptRelpath := filepath.Join("scripts", "timeout.sh")
+	writeExecutableFile(t, filepath.Join(env.workspaceRoot, scriptRelpath), "#!/bin/sh\nsleep 10\n")
+	env.service.setupScript = scriptRelpath
+	env.service.setupTimeoutSeconds = 1
+	setupID := serverapi.NewWorktreeSetupOperationID()
+	sub, err := env.service.SubscribeWorktreeSetup(env.ctx, serverapi.WorktreeSetupSubscribeRequest{SetupOperationID: setupID})
+	if err != nil {
+		t.Fatalf("SubscribeWorktreeSetup: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+	_, err = env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+		SetupOperationID: setupID,
+		ClientRequestID:  "req-setup-timeout",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "HEAD",
+		CreateBranch:     true,
+		BranchName:       "feature/setup-timeout",
+	})
+	if err == nil {
+		t.Fatal("CreateWorktree succeeded, want setup timeout")
+	}
+	expectedScript, canonicalErr := config.CanonicalWorkspaceRoot(filepath.Join(env.workspaceRoot, scriptRelpath))
+	if canonicalErr != nil {
+		t.Fatalf("canonical expected script: %v", canonicalErr)
+	}
+	var setupErr *setupScriptError
+	if !errors.As(err, &setupErr) {
+		t.Fatalf("timeout error = %#v, want setupScriptError", err)
+	}
+	if !setupErr.Timeout || setupErr.TimeoutSeconds != 1 || setupErr.ScriptPath != expectedScript || setupErr.WorktreeRoot == "" {
+		t.Fatalf("timeout setup error fields timeout=%t seconds=%d script=%q want=%q root=%q", setupErr.Timeout, setupErr.TimeoutSeconds, setupErr.ScriptPath, expectedScript, setupErr.WorktreeRoot)
+	}
+	if _, statErr := os.Stat(setupErr.WorktreeRoot); statErr != nil {
+		t.Fatalf("expected timed-out setup worktree kept, stat err=%v", statErr)
+	}
+	assertServiceTestSessionTarget(t, env, "", env.workspaceRoot)
+	evt := nextSetupTerminalEvent(t, sub)
+	if evt.Phase != serverapi.WorktreeSetupPhaseFailed || !evt.Timeout {
+		t.Fatalf("timeout setup event = %+v", evt)
+	}
+	if evt.ScriptPath != expectedScript || evt.WorktreeRoot != setupErr.WorktreeRoot || evt.Error != setupErr.Error() {
+		t.Fatalf("timeout setup event = %+v, want timeout/script/worktree context", evt)
+	}
+}
+
+func TestCreateWorktreeSetupCancellationKeepsWorktreeAndSessionTarget(t *testing.T) {
+	env := newServiceTestEnv(t)
+	startedPath := filepath.Join(t.TempDir(), "started")
+	scriptRelpath := filepath.Join("scripts", "cancel.sh")
+	writeExecutableFile(t, filepath.Join(env.workspaceRoot, scriptRelpath), fmt.Sprintf("#!/bin/sh\nprintf started > %q\nsleep 10\n", startedPath))
+	env.service.setupScript = scriptRelpath
+	setupID := serverapi.NewWorktreeSetupOperationID()
+	sub, err := env.service.SubscribeWorktreeSetup(env.ctx, serverapi.WorktreeSetupSubscribeRequest{SetupOperationID: setupID})
+	if err != nil {
+		t.Fatalf("SubscribeWorktreeSetup: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+	expectedRoot, err := env.service.resolveRequestedWorktreeRoot("", env.binding.WorkspaceID, CreateSpec{BaseRef: "HEAD", CreateBranch: true, BranchName: "feature/setup-cancel"})
+	if err != nil {
+		t.Fatalf("resolveRequestedWorktreeRoot: %v", err)
+	}
+	ctx, cancel := context.WithCancel(env.ctx)
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := env.service.CreateWorktree(ctx, serverapi.WorktreeCreateRequest{
+			SetupOperationID: setupID,
+			ClientRequestID:  "req-setup-cancel",
+			SessionID:        env.session.Meta().SessionID,
+			BaseRef:          "HEAD",
+			CreateBranch:     true,
+			BranchName:       "feature/setup-cancel",
+		})
+		resultCh <- err
+	}()
+	if got := waitForFileText(t, startedPath); got != "started" {
+		t.Fatalf("started marker = %q, want started", got)
+	}
+	cancel()
+	select {
+	case err = <-resultCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for canceled create")
+	}
+	if err == nil {
+		t.Fatal("CreateWorktree succeeded, want cancellation error")
+	}
+	if _, statErr := os.Stat(expectedRoot); statErr != nil {
+		t.Fatalf("expected canceled setup worktree kept, stat err=%v", statErr)
+	}
+	assertServiceTestSessionTarget(t, env, "", env.workspaceRoot)
+	evt := nextSetupTerminalEvent(t, sub)
+	if evt.Phase != serverapi.WorktreeSetupPhaseFailed || !evt.Canceled {
+		t.Fatalf("canceled setup event = %+v", evt)
+	}
+}
+
+func TestCreateWorktreeSetupDirectoryScriptKeepsWorktreeAndSessionTarget(t *testing.T) {
+	env := newServiceTestEnv(t)
+	scriptRelpath := filepath.Join("scripts", "directory")
+	if err := os.MkdirAll(filepath.Join(env.workspaceRoot, scriptRelpath), 0o755); err != nil {
+		t.Fatalf("MkdirAll script dir: %v", err)
+	}
+	env.service.setupScript = scriptRelpath
+	setupID := serverapi.NewWorktreeSetupOperationID()
+	sub, err := env.service.SubscribeWorktreeSetup(env.ctx, serverapi.WorktreeSetupSubscribeRequest{SetupOperationID: setupID})
+	if err != nil {
+		t.Fatalf("SubscribeWorktreeSetup: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+	_, err = env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+		SetupOperationID: setupID,
+		ClientRequestID:  "req-setup-directory",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "HEAD",
+		CreateBranch:     true,
+		BranchName:       "feature/setup-directory",
+	})
+	if err == nil {
+		t.Fatal("CreateWorktree succeeded, want directory setup script error")
+	}
+	assertServiceTestSessionTarget(t, env, "", env.workspaceRoot)
+	evt := nextSetupTerminalEvent(t, sub)
+	if evt.Phase != serverapi.WorktreeSetupPhaseFailed || strings.TrimSpace(evt.Error) == "" {
+		t.Fatalf("directory setup event = %+v", evt)
+	}
+}
+
+func TestCreateWorktreeMissingSetupScriptKeepsWorktreeAndSessionTarget(t *testing.T) {
+	env := newServiceTestEnv(t)
+	env.service.setupScript = filepath.Join("scripts", "missing.sh")
+	setupID := serverapi.NewWorktreeSetupOperationID()
+	sub, err := env.service.SubscribeWorktreeSetup(env.ctx, serverapi.WorktreeSetupSubscribeRequest{SetupOperationID: setupID})
+	if err != nil {
+		t.Fatalf("SubscribeWorktreeSetup: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+	expectedRoot, err := env.service.resolveRequestedWorktreeRoot("", env.binding.WorkspaceID, CreateSpec{BaseRef: "HEAD", CreateBranch: true, BranchName: "feature/setup-missing"})
+	if err != nil {
+		t.Fatalf("resolveRequestedWorktreeRoot: %v", err)
+	}
+	_, err = env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+		SetupOperationID: setupID,
+		ClientRequestID:  "req-setup-missing",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "HEAD",
+		CreateBranch:     true,
+		BranchName:       "feature/setup-missing",
+	})
+	if err == nil {
+		t.Fatal("CreateWorktree succeeded, want missing setup script error")
+	}
+	if _, statErr := os.Stat(expectedRoot); statErr != nil {
+		t.Fatalf("expected missing-setup worktree kept, stat err=%v", statErr)
+	}
+	assertServiceTestSessionTarget(t, env, "", env.workspaceRoot)
+	evt := nextSetupTerminalEvent(t, sub)
+	if evt.Phase != serverapi.WorktreeSetupPhaseFailed || strings.TrimSpace(evt.Error) == "" {
+		t.Fatalf("missing setup event = %+v", evt)
+	}
+}
+
 func TestRunSetupScriptDoesNotAppendSuccessNote(t *testing.T) {
 	notes := &serviceTestLocalNotes{}
 	service := &Service{localNotes: notes}
 	scriptPath := filepath.Join(t.TempDir(), "setup.sh")
 	writeExecutableFile(t, scriptPath, "#!/bin/sh\nexit 0\n")
 
-	service.runSetupScript(scriptPath, "session-1", setupScriptPayload{WorktreeRoot: t.TempDir()})
+	if err := service.runSetupScript(context.Background(), scriptPath, setupScriptPayload{WorktreeRoot: t.TempDir()}); err != nil {
+		t.Fatalf("runSetupScript: %v", err)
+	}
 
 	if got := notes.snapshot(); len(got) != 0 {
 		t.Fatalf("expected no setup success note, got %+v", got)
@@ -322,10 +604,11 @@ func TestCreateWorktreeAllowsExistingRefWithoutCreatingBranch(t *testing.T) {
 	runGit(t, env.workspaceRoot, "branch", "feature/existing-ref")
 
 	resp, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
-		ClientRequestID: "req-create-existing-ref",
-		SessionID:       env.session.Meta().SessionID,
-		BaseRef:         "feature/existing-ref",
-		CreateBranch:    false,
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "req-create-existing-ref",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "feature/existing-ref",
+		CreateBranch:     false,
 	})
 	if err != nil {
 		t.Fatalf("CreateWorktree existing ref: %v", err)
@@ -401,10 +684,11 @@ func TestDeleteWorktreeKeepsExistingBranchUnlessExplicitlyRequested(t *testing.T
 	env := newServiceTestEnv(t)
 	runGit(t, env.workspaceRoot, "branch", "feature/shared-branch")
 	resp, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
-		ClientRequestID: "req-create-shared-branch",
-		SessionID:       env.session.Meta().SessionID,
-		BaseRef:         "feature/shared-branch",
-		CreateBranch:    false,
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "req-create-shared-branch",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "feature/shared-branch",
+		CreateBranch:     false,
 	})
 	if err != nil {
 		t.Fatalf("CreateWorktree existing branch: %v", err)
@@ -434,10 +718,11 @@ func TestDeleteWorktreeDeletesExistingBranchWhenExplicitlyRequested(t *testing.T
 	env := newServiceTestEnv(t)
 	runGit(t, env.workspaceRoot, "branch", "feature/shared-branch")
 	resp, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
-		ClientRequestID: "req-create-shared-branch-explicit",
-		SessionID:       env.session.Meta().SessionID,
-		BaseRef:         "feature/shared-branch",
-		CreateBranch:    false,
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "req-create-shared-branch-explicit",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "feature/shared-branch",
+		CreateBranch:     false,
 	})
 	if err != nil {
 		t.Fatalf("CreateWorktree existing branch: %v", err)
@@ -724,7 +1009,7 @@ func TestSwitchWorktreeRollsBackExecutionTargetWhenRequestContextCancelsDuringRe
 	}
 }
 
-func TestCreateWorktreeCleansUpCreatedStateWhenPostCreateSwitchFails(t *testing.T) {
+func TestCreateWorktreeKeepsCreatedStateWhenPostSetupSwitchFails(t *testing.T) {
 	env := newServiceTestEnv(t)
 	expectedRoot, err := env.service.resolveRequestedWorktreeRoot("", env.binding.WorkspaceID, CreateSpec{BaseRef: "HEAD", CreateBranch: true, BranchName: "feature/create-rollback"})
 	if err != nil {
@@ -733,29 +1018,40 @@ func TestCreateWorktreeCleansUpCreatedStateWhenPostCreateSwitchFails(t *testing.
 	env.runtime.rebindErr = errors.New("boom")
 
 	_, err = env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
-		ClientRequestID: "req-create-rollback",
-		SessionID:       env.session.Meta().SessionID,
-		BaseRef:         "HEAD",
-		CreateBranch:    true,
-		BranchName:      "feature/create-rollback",
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "req-create-rollback",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "HEAD",
+		CreateBranch:     true,
+		BranchName:       "feature/create-rollback",
 	})
 	if err == nil || !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("CreateWorktree error = %v, want rebind failure", err)
 	}
-	if _, statErr := os.Stat(expectedRoot); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("expected failed create worktree root removed, stat err=%v", statErr)
+	if _, statErr := os.Stat(expectedRoot); statErr != nil {
+		t.Fatalf("expected failed create worktree root kept, stat err=%v", statErr)
+	}
+	expectedRoot, err = config.CanonicalWorkspaceRoot(expectedRoot)
+	if err != nil {
+		t.Fatalf("CanonicalWorkspaceRoot expected: %v", err)
 	}
 	if got := runGit(t, env.workspaceRoot, "branch", "--list", "feature/create-rollback"); strings.Contains(got, "feature/create-rollback") {
-		t.Fatalf("expected created branch cleaned up after failed create, got %q", got)
+		// Branch remains because setup has completed and the worktree is inspectable.
+	} else {
+		t.Fatalf("expected created branch kept after post-setup switch failure, got %q", got)
 	}
 	records, err := env.store.ListWorktreeRecordsByWorkspaceID(env.ctx, env.binding.WorkspaceID)
 	if err != nil {
 		t.Fatalf("ListWorktreeRecordsByWorkspaceID: %v", err)
 	}
+	recordKept := false
 	for _, record := range records {
 		if strings.TrimSpace(record.CanonicalRoot) == strings.TrimSpace(expectedRoot) {
-			t.Fatalf("expected failed create worktree record removed, got %+v", record)
+			recordKept = true
 		}
+	}
+	if !recordKept {
+		t.Fatalf("expected failed create worktree record kept for root %q", expectedRoot)
 	}
 	finalTarget, err := env.store.ResolveSessionExecutionTarget(env.ctx, env.session.Meta().SessionID)
 	if err != nil {

--- a/server/worktree/setup_events.go
+++ b/server/worktree/setup_events.go
@@ -1,0 +1,138 @@
+package worktree
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+
+	"core/shared/serverapi"
+)
+
+type setupEventBroker struct {
+	mu          sync.Mutex
+	subscribers map[serverapi.WorktreeSetupOperationID]map[*setupSubscription]struct{}
+}
+
+type setupSubscription struct {
+	broker *setupEventBroker
+	id     serverapi.WorktreeSetupOperationID
+	events chan serverapi.WorktreeSetupEvent
+	mu     sync.Mutex
+	closed bool
+}
+
+func newSetupEventBroker() *setupEventBroker {
+	return &setupEventBroker{subscribers: make(map[serverapi.WorktreeSetupOperationID]map[*setupSubscription]struct{})}
+}
+
+func (b *setupEventBroker) Subscribe(req serverapi.WorktreeSetupSubscribeRequest) (serverapi.WorktreeSetupSubscription, error) {
+	if b == nil {
+		return nil, errors.New("worktree setup broker is required")
+	}
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	id := req.SetupOperationID
+	sub := &setupSubscription{broker: b, id: id, events: make(chan serverapi.WorktreeSetupEvent, 16)}
+	b.mu.Lock()
+	if b.subscribers[id] == nil {
+		b.subscribers[id] = make(map[*setupSubscription]struct{})
+	}
+	b.subscribers[id][sub] = struct{}{}
+	b.mu.Unlock()
+	return sub, nil
+}
+
+func (b *setupEventBroker) Publish(evt serverapi.WorktreeSetupEvent) {
+	if b == nil || evt.SetupOperationID.Validate() != nil {
+		return
+	}
+	id := evt.SetupOperationID
+	b.mu.Lock()
+	subscribers := make([]*setupSubscription, 0, len(b.subscribers[id]))
+	for sub := range b.subscribers[id] {
+		subscribers = append(subscribers, sub)
+	}
+	if evt.Phase == serverapi.WorktreeSetupPhaseCompleted || evt.Phase == serverapi.WorktreeSetupPhaseFailed {
+		delete(b.subscribers, id)
+	}
+	b.mu.Unlock()
+	for _, sub := range subscribers {
+		sub.publish(evt)
+		if evt.Phase == serverapi.WorktreeSetupPhaseCompleted || evt.Phase == serverapi.WorktreeSetupPhaseFailed {
+			sub.Close()
+		}
+	}
+}
+
+func (s *setupSubscription) Next(ctx context.Context) (serverapi.WorktreeSetupEvent, error) {
+	if s == nil {
+		return serverapi.WorktreeSetupEvent{}, io.EOF
+	}
+	select {
+	case <-ctx.Done():
+		return serverapi.WorktreeSetupEvent{}, ctx.Err()
+	case evt, ok := <-s.events:
+		if !ok {
+			return serverapi.WorktreeSetupEvent{}, io.EOF
+		}
+		return evt, nil
+	}
+}
+
+func (s *setupSubscription) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	alreadyClosed := s.closed
+	if !s.closed {
+		s.closed = true
+		close(s.events)
+	}
+	s.mu.Unlock()
+	if !alreadyClosed {
+		s.removeFromBroker()
+	}
+	return nil
+}
+
+func (s *setupSubscription) publish(evt serverapi.WorktreeSetupEvent) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	select {
+	case s.events <- evt:
+	default:
+		s.closed = true
+		close(s.events)
+		s.removeFromBroker()
+	}
+}
+
+func (s *setupSubscription) removeFromBroker() {
+	if s == nil || s.broker == nil {
+		return
+	}
+	s.broker.mu.Lock()
+	if subscribers := s.broker.subscribers[s.id]; subscribers != nil {
+		delete(subscribers, s)
+		if len(subscribers) == 0 {
+			delete(s.broker.subscribers, s.id)
+		}
+	}
+	s.broker.mu.Unlock()
+}
+
+func (s *Service) SubscribeWorktreeSetup(_ context.Context, req serverapi.WorktreeSetupSubscribeRequest) (serverapi.WorktreeSetupSubscription, error) {
+	if s == nil || s.setupBroker == nil {
+		return nil, errors.New("worktree setup broker is required")
+	}
+	return s.setupBroker.Subscribe(req)
+}

--- a/server/worktree/setup_events_test.go
+++ b/server/worktree/setup_events_test.go
@@ -1,0 +1,70 @@
+package worktree
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"core/shared/serverapi"
+)
+
+func TestSetupEventBrokerPublishCloseConcurrent(t *testing.T) {
+	broker := newSetupEventBroker()
+	setupID := serverapi.NewWorktreeSetupOperationID()
+	const subscribers = 64
+	subs := make([]serverapi.WorktreeSetupSubscription, 0, subscribers)
+	for i := 0; i < subscribers; i++ {
+		sub, err := broker.Subscribe(serverapi.WorktreeSetupSubscribeRequest{SetupOperationID: setupID})
+		if err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+		subs = append(subs, sub)
+	}
+	evt := serverapi.WorktreeSetupEvent{
+		SetupOperationID:    setupID,
+		SourceWorkspaceRoot: "/source",
+		WorktreeRoot:        "/worktree",
+		ScriptPath:          "/source/setup.sh",
+		Phase:               serverapi.WorktreeSetupPhaseStarted,
+	}
+	var wg sync.WaitGroup
+	for _, sub := range subs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = sub.Close()
+		}()
+	}
+	for i := 0; i < subscribers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			broker.Publish(evt)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestSetupEventBrokerUsesTypedSetupOperationIDKey(t *testing.T) {
+	broker := newSetupEventBroker()
+	setupID := serverapi.NewWorktreeSetupOperationID()
+	sub, err := broker.Subscribe(serverapi.WorktreeSetupSubscribeRequest{SetupOperationID: setupID})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+	broker.Publish(serverapi.WorktreeSetupEvent{
+		SetupOperationID:    setupID,
+		SourceWorkspaceRoot: "/source",
+		WorktreeRoot:        "/worktree",
+		ScriptPath:          "/source/setup.sh",
+		Phase:               serverapi.WorktreeSetupPhaseStarted,
+	})
+	evt, err := sub.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if evt.SetupOperationID != setupID {
+		t.Fatalf("setup operation id = %s, want %s", evt.SetupOperationID, setupID)
+	}
+}

--- a/server/worktree/setup_process_other.go
+++ b/server/worktree/setup_process_other.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package worktree
+
+import (
+	"os/exec"
+	"strconv"
+)
+
+func configureSetupCommand(*exec.Cmd) {}
+
+func terminateSetupCommand(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid)).Run()
+	_ = cmd.Process.Kill()
+}

--- a/server/worktree/setup_process_unix.go
+++ b/server/worktree/setup_process_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package worktree
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureSetupCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func terminateSetupCommand(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	_ = cmd.Process.Kill()
+}

--- a/server/worktree/task_worktree_test.go
+++ b/server/worktree/task_worktree_test.go
@@ -2,10 +2,12 @@ package worktree
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"core/server/workflow"
 	"core/server/workflowstore"
@@ -16,7 +18,7 @@ func TestEnsureTaskWorktreeCreatesShortIDBranchWithoutControllerLease(t *testing
 	env := newServiceTestEnv(t)
 	task, _ := createTaskWorktreeTestTask(t, env)
 
-	resp, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: string(task.ID)})
+	resp, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: task.ID})
 	if err != nil {
 		t.Fatalf("EnsureTaskWorktree: %v", err)
 	}
@@ -44,15 +46,77 @@ func TestEnsureTaskWorktreeCreatesShortIDBranchWithoutControllerLease(t *testing
 	}
 }
 
+func TestEnsureTaskWorktreeRunsSetupAndPublishesProgressBeforeReturning(t *testing.T) {
+	env := newServiceTestEnv(t)
+	task, _ := createTaskWorktreeTestTask(t, env)
+	startedPath := filepath.Join(t.TempDir(), "started")
+	releasePath := filepath.Join(t.TempDir(), "release")
+	markerPath := filepath.Join(t.TempDir(), "marker")
+	payloadPath := filepath.Join(t.TempDir(), "payload.json")
+	scriptRelpath := filepath.Join("scripts", "task-setup.sh")
+	writeExecutableFile(t, filepath.Join(env.workspaceRoot, scriptRelpath), fmt.Sprintf("#!/bin/sh\nprintf started > %q\ncat > %q\nwhile [ ! -f %q ]; do sleep 0.02; done\nprintf marker > %q\n", startedPath, payloadPath, releasePath, markerPath))
+	env.service.setupScript = scriptRelpath
+	setupID := serverapi.NewWorktreeSetupOperationID()
+	sub, err := env.service.SubscribeWorktreeSetup(env.ctx, serverapi.WorktreeSetupSubscribeRequest{SetupOperationID: setupID})
+	if err != nil {
+		t.Fatalf("SubscribeWorktreeSetup: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+	type ensureResult struct {
+		resp EnsureTaskWorktreeResponse
+		err  error
+	}
+	resultCh := make(chan ensureResult, 1)
+	go func() {
+		resp, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: task.ID, SetupOperationID: setupID})
+		resultCh <- ensureResult{resp: resp, err: err}
+	}()
+
+	if got := waitForFileText(t, startedPath); got != "started" {
+		t.Fatalf("started marker = %q, want started", got)
+	}
+	evt, err := sub.Next(env.ctx)
+	if err != nil {
+		t.Fatalf("setup event: %v", err)
+	}
+	if evt.Phase != serverapi.WorktreeSetupPhaseStarted || evt.SetupOperationID != setupID || evt.ScriptPath == "" || evt.WorktreeRoot == "" {
+		t.Fatalf("started setup event = %+v", evt)
+	}
+	select {
+	case result := <-resultCh:
+		t.Fatalf("EnsureTaskWorktree returned before setup release: resp=%+v err=%v", result.resp, result.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := os.WriteFile(releasePath, []byte("release"), 0o644); err != nil {
+		t.Fatalf("release setup: %v", err)
+	}
+	var result ensureResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for EnsureTaskWorktree")
+	}
+	if result.err != nil {
+		t.Fatalf("EnsureTaskWorktree: %v", result.err)
+	}
+	if got := waitForFileText(t, markerPath); got != "marker" {
+		t.Fatalf("setup marker = %q, want marker", got)
+	}
+	payload := waitForSetupPayload(t, payloadPath)
+	if payload.SourceWorkspaceRoot != env.workspaceRoot || payload.WorktreeRoot != result.resp.Worktree.CanonicalRoot {
+		t.Fatalf("setup payload = %+v, want source %q worktree %q", payload, env.workspaceRoot, result.resp.Worktree.CanonicalRoot)
+	}
+}
+
 func TestEnsureTaskWorktreeReturnsExistingManagedWorktree(t *testing.T) {
 	env := newServiceTestEnv(t)
 	task, _ := createTaskWorktreeTestTask(t, env)
 
-	first, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: string(task.ID)})
+	first, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: task.ID})
 	if err != nil {
 		t.Fatalf("EnsureTaskWorktree first: %v", err)
 	}
-	second, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: string(task.ID)})
+	second, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: task.ID})
 	if err != nil {
 		t.Fatalf("EnsureTaskWorktree second: %v", err)
 	}
@@ -61,6 +125,62 @@ func TestEnsureTaskWorktreeReturnsExistingManagedWorktree(t *testing.T) {
 	}
 	if first.Worktree.WorktreeID != second.Worktree.WorktreeID {
 		t.Fatalf("second worktree id = %q, want %q", second.Worktree.WorktreeID, first.Worktree.WorktreeID)
+	}
+}
+
+func TestEnsureTaskWorktreeFailureRetryTrustsExistingWorktreeAndRecreatesRemovedRoot(t *testing.T) {
+	env := newServiceTestEnv(t)
+	task, _ := createTaskWorktreeTestTask(t, env)
+	countPath := filepath.Join(t.TempDir(), "count")
+	scriptRelpath := filepath.Join("scripts", "retry-setup.sh")
+	writeExecutableFile(t, filepath.Join(env.workspaceRoot, scriptRelpath), fmt.Sprintf("#!/bin/sh\ncount=0\nif [ -f %q ]; then count=$(cat %q); fi\ncount=$((count + 1))\nprintf '%%s' \"$count\" > %q\nif [ \"$count\" = \"1\" ]; then exit 3; fi\n", countPath, countPath, countPath))
+	env.service.setupScript = scriptRelpath
+
+	_, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: task.ID, SetupOperationID: serverapi.NewWorktreeSetupOperationID()})
+	if err == nil {
+		t.Fatal("first EnsureTaskWorktree succeeded, want setup failure")
+	}
+	row, err := env.store.Queries().GetTask(env.ctx, string(task.ID))
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if !row.ManagedWorktreeID.Valid || strings.TrimSpace(row.ManagedWorktreeID.String) == "" {
+		t.Fatalf("managed worktree not attached after setup failure: %+v", row.ManagedWorktreeID)
+	}
+	record, err := env.store.GetWorktreeRecordByID(env.ctx, row.ManagedWorktreeID.String)
+	if err != nil {
+		t.Fatalf("GetWorktreeRecordByID: %v", err)
+	}
+	if _, err := os.Stat(record.CanonicalRoot); err != nil {
+		t.Fatalf("failed setup worktree root unavailable: %v", err)
+	}
+	if got := waitForFileText(t, countPath); got != "1" {
+		t.Fatalf("setup run count after failure = %q, want 1", got)
+	}
+
+	second, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: task.ID, SetupOperationID: serverapi.NewWorktreeSetupOperationID()})
+	if err != nil {
+		t.Fatalf("second EnsureTaskWorktree should trust existing root: %v", err)
+	}
+	if second.Created {
+		t.Fatalf("second ensure created worktree, want existing trusted: %+v", second)
+	}
+	if got := waitForFileText(t, countPath); got != "1" {
+		t.Fatalf("setup reran for existing worktree, count=%q", got)
+	}
+
+	if err := env.service.git.Remove(env.ctx, env.workspaceRoot, record.CanonicalRoot, true); err != nil {
+		t.Fatalf("remove stale worktree root: %v", err)
+	}
+	third, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: task.ID, SetupOperationID: serverapi.NewWorktreeSetupOperationID()})
+	if err != nil {
+		t.Fatalf("third EnsureTaskWorktree should recreate removed root: %v", err)
+	}
+	if !third.Created {
+		t.Fatalf("third ensure did not recreate worktree: %+v", third)
+	}
+	if got := waitForFileText(t, countPath); got != "2" {
+		t.Fatalf("setup run count after recreate = %q, want 2", got)
 	}
 }
 
@@ -77,7 +197,7 @@ func TestEnsureTaskWorktreeUsesTaskSourceWorkspace(t *testing.T) {
 	}
 	task, _ := createTaskWorktreeTestTaskWithSource(t, env, source.WorkspaceID)
 
-	resp, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: string(task.ID)})
+	resp, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: task.ID})
 	if err != nil {
 		t.Fatalf("EnsureTaskWorktree: %v", err)
 	}
@@ -103,7 +223,7 @@ func TestEnsureTaskWorktreeHandlesRootCollisionAndReportsBranchCollision(t *test
 		t.Fatalf("MkdirAll collision root: %v", err)
 	}
 
-	resp, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: string(task.ID)})
+	resp, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: task.ID})
 	if err != nil {
 		t.Fatalf("EnsureTaskWorktree root collision: %v", err)
 	}
@@ -116,7 +236,7 @@ func TestEnsureTaskWorktreeHandlesRootCollisionAndReportsBranchCollision(t *test
 
 	otherTask, _ := createTaskWorktreeTestTask(t, env)
 	runGit(t, env.workspaceRoot, "branch", otherTask.ShortID)
-	_, err = env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: string(otherTask.ID)})
+	_, err = env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: otherTask.ID})
 	var branchCollision *TaskBranchCollisionError
 	if !errors.As(err, &branchCollision) || branchCollision.BranchName != otherTask.ShortID {
 		t.Fatalf("EnsureTaskWorktree branch collision error = %v, want task branch collision", err)
@@ -126,7 +246,7 @@ func TestEnsureTaskWorktreeHandlesRootCollisionAndReportsBranchCollision(t *test
 func TestDeleteWorktreeBlocksNonTerminalTaskManagedWorktree(t *testing.T) {
 	env := newServiceTestEnv(t)
 	task, _ := createTaskWorktreeTestTask(t, env)
-	created, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: string(task.ID)})
+	created, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: task.ID})
 	if err != nil {
 		t.Fatalf("EnsureTaskWorktree: %v", err)
 	}
@@ -144,7 +264,7 @@ func TestDeleteWorktreeBlocksNonTerminalTaskManagedWorktree(t *testing.T) {
 func TestDeleteWorktreeAllowsTerminalTaskManagedWorktree(t *testing.T) {
 	env := newServiceTestEnv(t)
 	task, workflowStore := createTaskWorktreeTestTask(t, env)
-	created, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: string(task.ID)})
+	created, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: task.ID})
 	if err != nil {
 		t.Fatalf("EnsureTaskWorktree: %v", err)
 	}
@@ -172,7 +292,7 @@ func TestDeleteWorktreeAllowsTerminalTaskManagedWorktree(t *testing.T) {
 func TestDeleteTaskWorktreeRemovesManagedWorktreeAndBranch(t *testing.T) {
 	env := newServiceTestEnv(t)
 	task, _ := createTaskWorktreeTestTask(t, env)
-	created, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: string(task.ID)})
+	created, err := env.service.EnsureTaskWorktree(env.ctx, EnsureTaskWorktreeRequest{TaskID: task.ID})
 	if err != nil {
 		t.Fatalf("EnsureTaskWorktree: %v", err)
 	}

--- a/shared/apicontract/rpc_routes.go
+++ b/shared/apicontract/rpc_routes.go
@@ -266,6 +266,7 @@ var routeContracts = []Route{
 	unary[serverapi.WorktreeCreateRequest, serverapi.WorktreeCreateResponse](protocol.MethodWorktreeCreate, AuthServer, ScopeSessionActiveProject, ConnectionControl, DependencyWorktree),
 	unary[serverapi.WorktreeSwitchRequest, serverapi.WorktreeSwitchResponse](protocol.MethodWorktreeSwitch, AuthServer, ScopeSessionActiveProject, ConnectionControl, DependencyWorktree),
 	unary[serverapi.WorktreeDeleteRequest, serverapi.WorktreeDeleteResponse](protocol.MethodWorktreeDelete, AuthServer, ScopeSessionActiveProject, ConnectionControl, DependencyWorktree),
+	subscription[serverapi.WorktreeSetupSubscribeRequest, protocol.WorktreeSetupEventParams](protocol.MethodWorktreeSetupSubscribe, AuthServer, ScopeNone, DependencyWorktree, protocol.MethodWorktreeSetupEvent, protocol.MethodWorktreeSetupComplete),
 	unary[serverapi.RuntimeSetSessionNameRequest, struct{}](protocol.MethodRuntimeSetSessionName, AuthServer, ScopeSessionActiveProject, ConnectionControl, DependencyRuntimeControl),
 	unary[serverapi.RuntimeSetThinkingLevelRequest, struct{}](protocol.MethodRuntimeSetThinkingLevel, AuthServer, ScopeSessionActiveProject, ConnectionControl, DependencyRuntimeControl),
 	unary[serverapi.RuntimeSetFastModeEnabledRequest, serverapi.RuntimeSetFastModeEnabledResponse](protocol.MethodRuntimeSetFastModeEnabled, AuthServer, ScopeSessionActiveProject, ConnectionControl, DependencyRuntimeControl),
@@ -327,6 +328,8 @@ var routeContracts = []Route{
 	notification[protocol.StreamCompleteParams](protocol.MethodWorkflowComplete),
 	notification[protocol.WorkflowProjectEventParams](protocol.MethodWorkflowProjectEvent),
 	notification[protocol.StreamCompleteParams](protocol.MethodWorkflowProjectComplete),
+	notification[protocol.WorktreeSetupEventParams](protocol.MethodWorktreeSetupEvent),
+	notification[protocol.StreamCompleteParams](protocol.MethodWorktreeSetupComplete),
 }
 
 func Routes() []Route {

--- a/shared/apicontract/service_contracts.go
+++ b/shared/apicontract/service_contracts.go
@@ -156,6 +156,7 @@ type WorktreeService interface {
 	CreateWorktree(ctx context.Context, req serverapi.WorktreeCreateRequest) (serverapi.WorktreeCreateResponse, error)
 	SwitchWorktree(ctx context.Context, req serverapi.WorktreeSwitchRequest) (serverapi.WorktreeSwitchResponse, error)
 	DeleteWorktree(ctx context.Context, req serverapi.WorktreeDeleteRequest) (serverapi.WorktreeDeleteResponse, error)
+	SubscribeWorktreeSetup(ctx context.Context, req serverapi.WorktreeSetupSubscribeRequest) (serverapi.WorktreeSetupSubscription, error)
 }
 
 type WorkflowService interface {

--- a/shared/client/remote_stream.go
+++ b/shared/client/remote_stream.go
@@ -19,7 +19,7 @@ import (
 type remoteSubscription[Wire any, Event any] struct {
 	conn  rpcwire.Conn
 	route rpccontract.Route
-	event func(Wire) Event
+	event func(Wire) (Event, error)
 	once  sync.Once
 }
 
@@ -145,6 +145,32 @@ func (c *Remote) SubscribeWorkflow(ctx context.Context, req serverapi.WorkflowSu
 	}), nil
 }
 
+func (c *Remote) SubscribeWorktreeSetup(ctx context.Context, req serverapi.WorktreeSetupSubscribeRequest) (serverapi.WorktreeSetupSubscription, error) {
+	conn, route, err := c.subscribeRPC(ctx, protocol.MethodWorktreeSetupSubscribe, "subscribe-worktree-setup", req, "", false)
+	if err != nil {
+		return nil, err
+	}
+	return newRemoteSubscriptionWithError(conn, route, func(params protocol.WorktreeSetupEventParams) (serverapi.WorktreeSetupEvent, error) {
+		id, err := serverapi.ParseWorktreeSetupOperationID(params.Event.SetupOperationID)
+		if err != nil {
+			return serverapi.WorktreeSetupEvent{}, err
+		}
+		return serverapi.WorktreeSetupEvent{
+			SetupOperationID:    id,
+			SourceWorkspaceRoot: params.Event.SourceWorkspaceRoot,
+			WorktreeRoot:        params.Event.WorktreeRoot,
+			ScriptPath:          params.Event.ScriptPath,
+			Phase:               serverapi.WorktreeSetupPhase(params.Event.Phase),
+			Timeout:             params.Event.Timeout,
+			Canceled:            params.Event.Canceled,
+			ExitCode:            params.Event.ExitCode,
+			Stdout:              params.Event.Stdout,
+			Stderr:              params.Event.Stderr,
+			Error:               params.Event.Error,
+		}, nil
+	}), nil
+}
+
 func (c *Remote) subscribeRPC(ctx context.Context, method string, requestID string, req any, sessionID string, attachSession bool) (rpcwire.Conn, rpccontract.Route, error) {
 	route := mustRemoteRoute(method)
 	conn, cleanup, err := c.openRPCConn(ctx)
@@ -166,6 +192,12 @@ func (c *Remote) subscribeRPC(ctx context.Context, method string, requestID stri
 }
 
 func newRemoteSubscription[Wire any, Event any](conn rpcwire.Conn, route rpccontract.Route, event func(Wire) Event) *remoteSubscription[Wire, Event] {
+	return newRemoteSubscriptionWithError(conn, route, func(wire Wire) (Event, error) {
+		return event(wire), nil
+	})
+}
+
+func newRemoteSubscriptionWithError[Wire any, Event any](conn rpcwire.Conn, route rpccontract.Route, event func(Wire) (Event, error)) *remoteSubscription[Wire, Event] {
 	return &remoteSubscription[Wire, Event]{conn: conn, route: route, event: event}
 }
 
@@ -190,7 +222,12 @@ func (s *remoteSubscription[Wire, Event]) Next(ctx context.Context) (Event, erro
 			var zero Event
 			return zero, errors.Join(serverapi.ErrStreamFailed, err)
 		}
-		return s.event(params), nil
+		event, err := s.event(params)
+		if err != nil {
+			var zero Event
+			return zero, errors.Join(serverapi.ErrStreamFailed, err)
+		}
+		return event, nil
 	case s.route.CompleteMethod:
 		var params protocol.StreamCompleteParams
 		if err := json.Unmarshal(frame.Params, &params); err != nil {

--- a/shared/client/worktree.go
+++ b/shared/client/worktree.go
@@ -36,3 +36,7 @@ func (c *loopbackWorktreeClient) SwitchWorktree(ctx context.Context, req servera
 func (c *loopbackWorktreeClient) DeleteWorktree(ctx context.Context, req serverapi.WorktreeDeleteRequest) (serverapi.WorktreeDeleteResponse, error) {
 	return callLoopbackClient(c, "worktree service is required", ctx, req, servicecontract.WorktreeService.DeleteWorktree)
 }
+
+func (c *loopbackWorktreeClient) SubscribeWorktreeSetup(ctx context.Context, req serverapi.WorktreeSetupSubscribeRequest) (serverapi.WorktreeSetupSubscription, error) {
+	return callLoopbackClient(c, "worktree service is required", ctx, req, servicecontract.WorktreeService.SubscribeWorktreeSetup)
+}

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -27,8 +27,9 @@ type WorkflowCompletionMode string
 type SleepPreventionMode string
 
 type WorktreeSettings struct {
-	BaseDir     string
-	SetupScript string
+	BaseDir             string
+	SetupScript         string
+	SetupTimeoutSeconds int
 }
 
 type WorkflowSettings struct {

--- a/shared/config/config_defaults.go
+++ b/shared/config/config_defaults.go
@@ -31,6 +31,7 @@ const (
 	defaultCompactionMode                = "local"
 	defaultServerHost                    = "127.0.0.1"
 	defaultServerPort                    = 53082
+	defaultWorktreeSetupTimeoutSeconds   = 60
 )
 
 func settingsTOMLForOnboarding(settings Settings, preservedDefaults map[string]bool) string {

--- a/shared/config/config_registry.go
+++ b/shared/config/config_registry.go
@@ -368,6 +368,12 @@ func newSettingsRegistry() settingsRegistry {
 			nil,
 			nil,
 			settingDocOptions{}),
+		newIntSetting("worktrees.setup_timeout_seconds", defaultWorktreeSetupTimeoutSeconds,
+			func(state *settingsState, value int) { state.Settings.Worktrees.SetupTimeoutSeconds = value },
+			func(state settingsState) int { return state.Settings.Worktrees.SetupTimeoutSeconds },
+			"",
+			nil,
+			settingDocOptions{}),
 		newStringSetting("workflow.completion_mode", defaultWorkflowCompletionMode,
 			func(state *settingsState, value WorkflowCompletionMode) {
 				state.Settings.Workflow.CompletionMode = value

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -148,6 +148,9 @@ func TestLoadUsesDefaultsWithoutCreatingConfigOnFirstUse(t *testing.T) {
 	if cfg.Settings.Worktrees.SetupScript != "" {
 		t.Fatalf("expected default worktrees.setup_script empty, got %q", cfg.Settings.Worktrees.SetupScript)
 	}
+	if cfg.Settings.Worktrees.SetupTimeoutSeconds != defaultWorktreeSetupTimeoutSeconds {
+		t.Fatalf("default worktrees.setup_timeout_seconds mismatch: %d", cfg.Settings.Worktrees.SetupTimeoutSeconds)
+	}
 	if cfg.Settings.Reviewer.Frequency != defaultReviewerFrequency {
 		t.Fatalf("expected default reviewer.frequency=%s, got %q", defaultReviewerFrequency, cfg.Settings.Reviewer.Frequency)
 	}
@@ -770,6 +773,37 @@ func TestLoadResolvesWorktreeBaseDirRelativeToPersistenceRoot(t *testing.T) {
 	}
 	if got := cfg.Settings.Worktrees.SetupScript; got != "scripts/setup-worktree.sh" {
 		t.Fatalf("worktrees.setup_script = %q, want scripts/setup-worktree.sh", got)
+	}
+}
+
+func TestLoadWorktreeSetupTimeoutSeconds(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{name: "default", content: "", want: defaultWorktreeSetupTimeoutSeconds},
+		{name: "positive", content: "[worktrees]\nsetup_timeout_seconds = 120\n", want: 120},
+		{name: "zero", content: "[worktrees]\nsetup_timeout_seconds = 0\n", want: 0},
+		{name: "negative", content: "[worktrees]\nsetup_timeout_seconds = -1\n", want: -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			workspace := t.TempDir()
+			if strings.TrimSpace(tt.content) != "" {
+				if err := os.WriteFile(filepath.Join(root, "config.toml"), []byte(tt.content), 0o644); err != nil {
+					t.Fatalf("write config: %v", err)
+				}
+			}
+			cfg, err := Load(workspace, LoadOptions{ConfigRoot: root})
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if got := cfg.Settings.Worktrees.SetupTimeoutSeconds; got != tt.want {
+				t.Fatalf("worktrees.setup_timeout_seconds = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/shared/protocol/handshake.go
+++ b/shared/protocol/handshake.go
@@ -100,6 +100,9 @@ const (
 	MethodWorktreeCreate                        = "worktree.create"
 	MethodWorktreeSwitch                        = "worktree.switch"
 	MethodWorktreeDelete                        = "worktree.delete"
+	MethodWorktreeSetupSubscribe                = "worktree.setup.subscribe"
+	MethodWorktreeSetupEvent                    = "worktree.setup"
+	MethodWorktreeSetupComplete                 = "worktree.setup.complete"
 	MethodRuntimeSetSessionName                 = "runtime.setSessionName"
 	MethodRuntimeSetThinkingLevel               = "runtime.setThinkingLevel"
 	MethodRuntimeSetFastModeEnabled             = "runtime.setFastModeEnabled"
@@ -209,6 +212,24 @@ type AttentionNotificationEventParams struct {
 
 type WorkflowProjectEventParams struct {
 	Event WorkflowProjectEvent `json:"event"`
+}
+
+type WorktreeSetupEventParams struct {
+	Event WorktreeSetupEvent `json:"event"`
+}
+
+type WorktreeSetupEvent struct {
+	SetupOperationID    string `json:"setup_operation_id"`
+	SourceWorkspaceRoot string `json:"source_workspace_root"`
+	WorktreeRoot        string `json:"worktree_root"`
+	ScriptPath          string `json:"script_path"`
+	Phase               string `json:"phase"`
+	Timeout             bool   `json:"timeout,omitempty"`
+	Canceled            bool   `json:"canceled,omitempty"`
+	ExitCode            *int   `json:"exit_code,omitempty"`
+	Stdout              string `json:"stdout,omitempty"`
+	Stderr              string `json:"stderr,omitempty"`
+	Error               string `json:"error,omitempty"`
 }
 
 type WorkflowProjectEvent struct {

--- a/shared/protocol/version.json
+++ b/shared/protocol/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "39"
+  "version": "40"
 }

--- a/shared/serverapi/workflow.go
+++ b/shared/serverapi/workflow.go
@@ -21,6 +21,16 @@ const WorkflowListMaxPageSize = 100
 const WorkflowTaskListMaxPageSize = 100
 const WorkflowTaskListMaxSortSelectors = 5
 
+type WorkflowNodeKind string
+
+const (
+	WorkflowNodeKindStart    WorkflowNodeKind = "start"
+	WorkflowNodeKindAgent    WorkflowNodeKind = "agent"
+	WorkflowNodeKindScript   WorkflowNodeKind = "script"
+	WorkflowNodeKindJoin     WorkflowNodeKind = "join"
+	WorkflowNodeKindTerminal WorkflowNodeKind = "terminal"
+)
+
 const (
 	WorkflowGraphDraftMaxNodeGroups       = 200
 	WorkflowGraphDraftMaxNodes            = 200
@@ -663,7 +673,8 @@ type WorkflowTaskUpdateResponse struct {
 }
 
 type WorkflowTaskStartRequest struct {
-	TaskID string `json:"task_id"`
+	TaskID           string                   `json:"task_id"`
+	SetupOperationID WorktreeSetupOperationID `json:"setup_operation_id"`
 }
 
 type WorkflowTaskStartResponse struct {
@@ -688,8 +699,9 @@ type WorkflowTaskResumeResponse struct {
 }
 
 type WorkflowTaskApproveRequest struct {
-	TaskTransitionID string `json:"task_transition_id,omitempty"`
-	TransitionID     string `json:"transition_id,omitempty"`
+	TaskTransitionID string                   `json:"task_transition_id,omitempty"`
+	TransitionID     string                   `json:"transition_id,omitempty"`
+	SetupOperationID WorktreeSetupOperationID `json:"setup_operation_id"`
 }
 
 type WorkflowTaskApproveResponse struct {
@@ -701,12 +713,13 @@ type WorkflowTaskApproveResponse struct {
 }
 
 type WorkflowTaskMoveRequest struct {
-	TaskID           string            `json:"task_id"`
-	TargetNodeID     string            `json:"target_node_id"`
-	OutputValues     map[string]string `json:"output_values,omitempty"`
-	Commentary       string            `json:"commentary,omitempty"`
-	AllowMissingEdge bool              `json:"allow_missing_edge,omitempty"`
-	AutoApprove      bool              `json:"auto_approve,omitempty"`
+	TaskID           string                   `json:"task_id"`
+	TargetNodeID     string                   `json:"target_node_id"`
+	OutputValues     map[string]string        `json:"output_values,omitempty"`
+	Commentary       string                   `json:"commentary,omitempty"`
+	AllowMissingEdge bool                     `json:"allow_missing_edge,omitempty"`
+	AutoApprove      bool                     `json:"auto_approve,omitempty"`
+	SetupOperationID WorktreeSetupOperationID `json:"setup_operation_id"`
 }
 
 type WorkflowTaskMoveResponse struct {
@@ -1668,7 +1681,10 @@ func (r WorkflowTaskUpdateRequest) Validate() error {
 }
 
 func (r WorkflowTaskStartRequest) Validate() error {
-	return validateRequired("task_id", r.TaskID)
+	if err := validateRequired("task_id", r.TaskID); err != nil {
+		return err
+	}
+	return r.SetupOperationID.Validate()
 }
 
 func (r WorkflowTaskResumeRequest) Validate() error {
@@ -1677,13 +1693,19 @@ func (r WorkflowTaskResumeRequest) Validate() error {
 
 func (r WorkflowTaskApproveRequest) Validate() error {
 	if strings.TrimSpace(r.TaskTransitionID) != "" {
-		return nil
+		return r.SetupOperationID.Validate()
 	}
-	return validateRequired("transition_id", r.TransitionID)
+	if err := validateRequired("transition_id", r.TransitionID); err != nil {
+		return err
+	}
+	return r.SetupOperationID.Validate()
 }
 
 func (r WorkflowTaskMoveRequest) Validate() error {
-	return validateRequiredFields(requiredField("task_id", r.TaskID), requiredField("target_node_id", r.TargetNodeID))
+	if err := validateRequiredFields(requiredField("task_id", r.TaskID), requiredField("target_node_id", r.TargetNodeID)); err != nil {
+		return err
+	}
+	return r.SetupOperationID.Validate()
 }
 
 func (r WorkflowTaskCompleteRequest) Validate() error {

--- a/shared/serverapi/workflow_test.go
+++ b/shared/serverapi/workflow_test.go
@@ -141,6 +141,7 @@ func TestWorkflowTransitionGroupDescriptionRequestValidation(t *testing.T) {
 }
 
 func TestWorkflowTaskAndCommentRequestValidation(t *testing.T) {
+	setupOperationID := NewWorktreeSetupOperationID()
 	if err := (WorkflowTaskCreateRequest{ProjectID: "project-1", Title: "Task"}).Validate(); err != nil {
 		t.Fatalf("valid task create rejected: %v", err)
 	}
@@ -158,7 +159,7 @@ func TestWorkflowTaskAndCommentRequestValidation(t *testing.T) {
 	if err := (WorkflowTaskUpdateRequest{TaskID: "task-1", Title: &blankTitle}).Validate(); !isWorkflowFieldError(err, "title", WorkflowRequestErrorRequired) {
 		t.Fatalf("empty update title error = %#v, want required on title", err)
 	}
-	if err := (WorkflowTaskStartRequest{TaskID: "task-1"}).Validate(); err != nil {
+	if err := (WorkflowTaskStartRequest{TaskID: "task-1", SetupOperationID: setupOperationID}).Validate(); err != nil {
 		t.Fatalf("valid task start rejected: %v", err)
 	}
 	if err := (WorkflowTaskGetRequest{ProjectID: "project-1", ShortID: "BLD-1"}).Validate(); err != nil {
@@ -182,7 +183,7 @@ func TestWorkflowTaskAndCommentRequestValidation(t *testing.T) {
 	if err := (WorkflowTaskInterruptRequest{TaskID: "task-1"}).Validate(); err != nil {
 		t.Fatalf("valid task interrupt rejected: %v", err)
 	}
-	if err := (WorkflowTaskApproveRequest{TaskTransitionID: "transition-1"}).Validate(); err != nil {
+	if err := (WorkflowTaskApproveRequest{TaskTransitionID: "transition-1", SetupOperationID: setupOperationID}).Validate(); err != nil {
 		t.Fatalf("valid task approval rejected: %v", err)
 	}
 	if err := (WorkflowTaskApproveRequest{}).Validate(); !isWorkflowFieldError(err, "transition_id", WorkflowRequestErrorRequired) {

--- a/shared/serverapi/worktree.go
+++ b/shared/serverapi/worktree.go
@@ -63,19 +63,19 @@ type WorktreeCreateTargetResolveResponse struct {
 }
 
 type WorktreeCreateRequest struct {
-	ClientRequestID string `json:"client_request_id"`
-	SessionID       string `json:"session_id"`
-	BaseRef         string `json:"base_ref,omitempty"`
-	CreateBranch    bool   `json:"create_branch,omitempty"`
-	BranchName      string `json:"branch_name,omitempty"`
-	RootPath        string `json:"root_path,omitempty"`
+	ClientRequestID  string                   `json:"client_request_id"`
+	SetupOperationID WorktreeSetupOperationID `json:"setup_operation_id"`
+	SessionID        string                   `json:"session_id"`
+	BaseRef          string                   `json:"base_ref,omitempty"`
+	CreateBranch     bool                     `json:"create_branch,omitempty"`
+	BranchName       string                   `json:"branch_name,omitempty"`
+	RootPath         string                   `json:"root_path,omitempty"`
 }
 
 type WorktreeCreateResponse struct {
-	Target         clientui.SessionExecutionTarget `json:"target"`
-	Worktree       WorktreeView                    `json:"worktree"`
-	CreatedBranch  bool                            `json:"created_branch"`
-	SetupScheduled bool                            `json:"setup_scheduled"`
+	Target        clientui.SessionExecutionTarget `json:"target"`
+	Worktree      WorktreeView                    `json:"worktree"`
+	CreatedBranch bool                            `json:"created_branch"`
 }
 
 type WorktreeSwitchRequest struct {
@@ -122,6 +122,9 @@ func (r WorktreeCreateTargetResolveRequest) Validate() error {
 
 func (r WorktreeCreateRequest) Validate() error {
 	if err := validateClientRequestID(r.ClientRequestID); err != nil {
+		return err
+	}
+	if err := r.SetupOperationID.Validate(); err != nil {
 		return err
 	}
 	if err := validateRequiredSessionID(r.SessionID); err != nil {

--- a/shared/serverapi/worktree_setup.go
+++ b/shared/serverapi/worktree_setup.go
@@ -1,0 +1,135 @@
+package serverapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+type WorktreeSetupOperationID uuid.UUID
+
+func NewWorktreeSetupOperationID() WorktreeSetupOperationID {
+	return WorktreeSetupOperationID(uuid.New())
+}
+
+func ParseWorktreeSetupOperationID(value string) (WorktreeSetupOperationID, error) {
+	parsed, err := uuid.Parse(strings.TrimSpace(value))
+	if err != nil {
+		return WorktreeSetupOperationID{}, fmt.Errorf("setup_operation_id must be a UUID v4: %w", err)
+	}
+	id := WorktreeSetupOperationID(parsed)
+	if err := id.Validate(); err != nil {
+		return WorktreeSetupOperationID{}, err
+	}
+	return id, nil
+}
+
+func (id WorktreeSetupOperationID) String() string {
+	value := uuid.UUID(id)
+	if value == uuid.Nil {
+		return ""
+	}
+	return value.String()
+}
+
+func (id WorktreeSetupOperationID) Validate() error {
+	value := uuid.UUID(id)
+	if value == uuid.Nil {
+		return errors.New("setup_operation_id is required")
+	}
+	if value.Version() != 4 {
+		return errors.New("setup_operation_id must be a UUID v4")
+	}
+	return nil
+}
+
+func (id WorktreeSetupOperationID) MarshalJSON() ([]byte, error) {
+	if err := id.Validate(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(id.String())
+}
+
+func (id *WorktreeSetupOperationID) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	parsed, err := ParseWorktreeSetupOperationID(raw)
+	if err != nil {
+		return err
+	}
+	*id = parsed
+	return nil
+}
+
+type WorktreeSetupPhase string
+
+const (
+	WorktreeSetupPhaseStarted   WorktreeSetupPhase = "started"
+	WorktreeSetupPhaseCompleted WorktreeSetupPhase = "completed"
+	WorktreeSetupPhaseFailed    WorktreeSetupPhase = "failed"
+)
+
+type WorktreeSetupEvent struct {
+	SetupOperationID    WorktreeSetupOperationID `json:"setup_operation_id"`
+	SourceWorkspaceRoot string                   `json:"source_workspace_root"`
+	WorktreeRoot        string                   `json:"worktree_root"`
+	ScriptPath          string                   `json:"script_path"`
+	Phase               WorktreeSetupPhase       `json:"phase"`
+	Timeout             bool                     `json:"timeout,omitempty"`
+	Canceled            bool                     `json:"canceled,omitempty"`
+	ExitCode            *int                     `json:"exit_code,omitempty"`
+	Stdout              string                   `json:"stdout,omitempty"`
+	Stderr              string                   `json:"stderr,omitempty"`
+	Error               string                   `json:"error,omitempty"`
+}
+
+func (e WorktreeSetupEvent) Validate() error {
+	if err := e.SetupOperationID.Validate(); err != nil {
+		return err
+	}
+	switch e.Phase {
+	case WorktreeSetupPhaseStarted:
+		if strings.TrimSpace(e.SourceWorkspaceRoot) == "" || strings.TrimSpace(e.WorktreeRoot) == "" || strings.TrimSpace(e.ScriptPath) == "" {
+			return errors.New("started setup event requires source_workspace_root, worktree_root, and script_path")
+		}
+		if e.Timeout || e.Canceled || e.ExitCode != nil || strings.TrimSpace(e.Error) != "" {
+			return errors.New("started setup event cannot contain terminal facts")
+		}
+	case WorktreeSetupPhaseCompleted:
+		if strings.TrimSpace(e.WorktreeRoot) == "" || strings.TrimSpace(e.ScriptPath) == "" {
+			return errors.New("completed setup event requires worktree_root and script_path")
+		}
+		if e.Timeout || e.Canceled || e.ExitCode != nil || strings.TrimSpace(e.Error) != "" || strings.TrimSpace(e.Stdout) != "" || strings.TrimSpace(e.Stderr) != "" {
+			return errors.New("completed setup event cannot contain failure facts")
+		}
+	case WorktreeSetupPhaseFailed:
+		if strings.TrimSpace(e.WorktreeRoot) == "" || strings.TrimSpace(e.ScriptPath) == "" {
+			return errors.New("failed setup event requires worktree_root and script_path")
+		}
+		if strings.TrimSpace(e.Error) == "" && strings.TrimSpace(e.Stdout) == "" && strings.TrimSpace(e.Stderr) == "" && e.ExitCode == nil && !e.Timeout && !e.Canceled {
+			return errors.New("failed setup event requires failure facts")
+		}
+	default:
+		return errors.New("setup phase is invalid")
+	}
+	return nil
+}
+
+type WorktreeSetupSubscribeRequest struct {
+	SetupOperationID WorktreeSetupOperationID `json:"setup_operation_id"`
+}
+
+func (r WorktreeSetupSubscribeRequest) Validate() error {
+	return r.SetupOperationID.Validate()
+}
+
+type WorktreeSetupSubscription interface {
+	Next(context.Context) (WorktreeSetupEvent, error)
+	Close() error
+}

--- a/shared/serverapi/worktree_setup_test.go
+++ b/shared/serverapi/worktree_setup_test.go
@@ -1,0 +1,81 @@
+package serverapi
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWorktreeSetupOperationIDRequiresUUIDV4(t *testing.T) {
+	id := NewWorktreeSetupOperationID()
+	if err := id.Validate(); err != nil {
+		t.Fatalf("generated setup operation id invalid: %v", err)
+	}
+	for _, raw := range []string{"", "not-a-uuid", "00000000-0000-0000-0000-000000000000", "11111111-1111-1111-1111-111111111111"} {
+		if _, err := ParseWorktreeSetupOperationID(raw); err == nil {
+			t.Fatalf("ParseWorktreeSetupOperationID(%q) succeeded, want error", raw)
+		}
+	}
+}
+
+func TestWorktreeSetupEventValidation(t *testing.T) {
+	id := NewWorktreeSetupOperationID()
+	started := WorktreeSetupEvent{
+		SetupOperationID:    id,
+		SourceWorkspaceRoot: "/source",
+		WorktreeRoot:        "/worktree",
+		ScriptPath:          "/source/scripts/setup.sh",
+		Phase:               WorktreeSetupPhaseStarted,
+	}
+	if err := started.Validate(); err != nil {
+		t.Fatalf("started setup event validate: %v", err)
+	}
+	invalidStarted := started
+	invalidStarted.ScriptPath = ""
+	if err := invalidStarted.Validate(); err == nil {
+		t.Fatal("started setup event without script path validated")
+	}
+	failed := started
+	failed.Phase = WorktreeSetupPhaseFailed
+	failed.Error = "exit status 1"
+	if err := failed.Validate(); err != nil {
+		t.Fatalf("failed setup event validate: %v", err)
+	}
+	invalidFailed := started
+	invalidFailed.Phase = WorktreeSetupPhaseFailed
+	if err := invalidFailed.Validate(); err == nil {
+		t.Fatal("failed setup event without terminal facts validated")
+	}
+}
+
+func TestWorktreeSetupOperationIDJSONRejectsNonV4(t *testing.T) {
+	var req WorktreeSetupSubscribeRequest
+	if err := json.Unmarshal([]byte(`{"setup_operation_id":"11111111-1111-1111-1111-111111111111"}`), &req); err == nil {
+		t.Fatal("expected non-v4 setup operation id to fail JSON decoding")
+	}
+}
+
+func TestForegroundSetupRequestsRequireSetupOperationID(t *testing.T) {
+	id := NewWorktreeSetupOperationID()
+	valid := []interface{ Validate() error }{
+		WorktreeCreateRequest{ClientRequestID: "req", SetupOperationID: id, SessionID: "session", BaseRef: "HEAD", CreateBranch: true, BranchName: "feature"},
+		WorkflowTaskStartRequest{TaskID: "task", SetupOperationID: id},
+		WorkflowTaskApproveRequest{TransitionID: "transition", SetupOperationID: id},
+		WorkflowTaskMoveRequest{TaskID: "task", TargetNodeID: "node", SetupOperationID: id},
+	}
+	for _, req := range valid {
+		if err := req.Validate(); err != nil {
+			t.Fatalf("%T Validate: %v", req, err)
+		}
+	}
+	invalid := []interface{ Validate() error }{
+		WorktreeCreateRequest{ClientRequestID: "req", SessionID: "session", BaseRef: "HEAD", CreateBranch: true, BranchName: "feature"},
+		WorkflowTaskStartRequest{TaskID: "task"},
+		WorkflowTaskApproveRequest{TransitionID: "transition"},
+		WorkflowTaskMoveRequest{TaskID: "task", TargetNodeID: "node"},
+	}
+	for _, req := range invalid {
+		if err := req.Validate(); err == nil {
+			t.Fatalf("%T Validate succeeded without setup operation id", req)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Runs configured `worktrees.setup_script` as a blocking step for newly created manual and workflow worktrees before session/run context can lock.
- Adds typed setup operation IDs, live setup progress subscriptions, path-bearing CLI/TUI progress, and desktop caller-provided setup IDs.
- Makes setup timeout/cancel/failure explicit, keeps failed worktrees inspectable, reuses one bounded process-output collector, and documents blocking setup behavior.

## Verification
- `./scripts/test.sh ./shared/config ./server/worktree ./server/workflowsvc ./server/workflowrunner ./shared/serverapi ./shared/client ./shared/apicontract ./server/transport ./cli/app ./cli/kent`
- `pnpm --dir apps/desktop exec vitest run src/api/client.test.ts src/api/jsonRpc.test.ts`
- `./scripts/build.sh --output ./bin/kent`
- `git diff --check`

## QA Evidence
Manual isolated QA passed before PR: workflow script-node start stayed pending while setup ran, setup-created marker/skill were visible to the first workflow executable, non-zero setup failures and timeouts prevented run scheduling while keeping worktrees inspectable, and cancellation terminated the setup process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added setup progress tracking for worktree creation and task lifecycle actions.
  * Users can now see live setup status, script path, and target worktree details while operations run.
  * Worktree setup subscriptions now stream structured progress events.

* **Behavior Changes**
  * Worktree creation and task start/approve/move now wait for setup to finish before completing.
  * On setup failure, the created worktree remains available for inspection instead of being immediately discarded.

* **Bug Fixes**
  * Improved timeout handling so setup operations can run without the generic request deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->