### PR TITLE
fix: support Responses SSE EOF without done sentinel

### DIFF
--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -239,3 +239,4 @@
 - JSON command mode for all TUI commands emits exactly one final object on stdout.
 
 - LLM provider wiring uses a provider-factory seam so runtime/app constructs clients via provider selection.
+- OpenAI-compatible Responses SSE streams accept either OpenAI's `data: [DONE]` sentinel or normal EOF after a valid `response.completed` event has been consumed. `response.failed`, `response.incomplete`, `error`, and caller cancellation are terminal failures. Streams that end before any terminal Responses event, including malformed SSE/JSON framing that prevents a terminal event from being consumed, surface provider-contract errors instead of partial model completion.

--- a/server/llm/errors_test.go
+++ b/server/llm/errors_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -41,7 +42,7 @@ func TestIsNonRetriableModelError(t *testing.T) {
 	if !IsNonRetriableModelError(&ProviderAPIError{ProviderID: "openai", StatusCode: 0, Code: UnifiedErrorCodeProviderContract, Message: "unknown provider contract"}) {
 		t.Fatal("expected provider contract error to be non-retriable")
 	}
-	if !IsNonRetriableModelError(&ProviderAPIError{ProviderID: "openai", StatusCode: 0, Code: UnifiedErrorCodeUnknown, ProviderType: "response.incomplete", ProviderCode: "max_output_tokens"}) {
+	if !IsNonRetriableModelError(&ProviderAPIError{ProviderID: "openai", StatusCode: http.StatusOK, Code: UnifiedErrorCodeUnknown, ProviderType: "response.incomplete", ProviderCode: "max_output_tokens"}) {
 		t.Fatal("expected response.incomplete terminal error to be non-retriable")
 	}
 	if !IsNonRetriableModelError(&AuthError{Err: errors.New("token refresh failed")}) {

--- a/server/llm/errors_test.go
+++ b/server/llm/errors_test.go
@@ -41,6 +41,9 @@ func TestIsNonRetriableModelError(t *testing.T) {
 	if !IsNonRetriableModelError(&ProviderAPIError{ProviderID: "openai", StatusCode: 0, Code: UnifiedErrorCodeProviderContract, Message: "unknown provider contract"}) {
 		t.Fatal("expected provider contract error to be non-retriable")
 	}
+	if !IsNonRetriableModelError(&ProviderAPIError{ProviderID: "openai", StatusCode: 0, Code: UnifiedErrorCodeUnknown, ProviderType: "response.incomplete", ProviderCode: "max_output_tokens"}) {
+		t.Fatal("expected response.incomplete terminal error to be non-retriable")
+	}
 	if !IsNonRetriableModelError(&AuthError{Err: errors.New("token refresh failed")}) {
 		t.Fatal("expected AuthError to be non-retriable")
 	}

--- a/server/llm/openai_error_reducer.go
+++ b/server/llm/openai_error_reducer.go
@@ -79,6 +79,18 @@ func mapOpenAIStreamErrorPayload(providerID string, data []byte, cause error) (*
 	if !ok {
 		return nil, false
 	}
+	if payload.Type == "response.incomplete" {
+		return &ProviderAPIError{
+			ProviderID:    providerID,
+			Code:          UnifiedErrorCodeProviderContract,
+			ProviderCode:  payload.Code,
+			ProviderType:  payload.Type,
+			ProviderParam: payload.Param,
+			Message:       payload.Message,
+			Raw:           string(data),
+			Err:           cause,
+		}, true
+	}
 	return mapOpenAIProviderErrorContract(
 		providerID,
 		0,

--- a/server/llm/openai_error_reducer.go
+++ b/server/llm/openai_error_reducer.go
@@ -29,7 +29,7 @@ func newOpaqueProviderErrorReducer(providerID string) ProviderErrorReducer {
 }
 
 func (r openAICompatibleErrorReducer) Reduce(err error, rawResp *http.Response) (*ProviderAPIError, bool) {
-	if reduced, ok := r.reduceFromStreamError(err, openAIResponseStatusCode(rawResp)); ok {
+	if reduced, ok := r.reduceFromStreamError(err, newOpenAIResponseStatus(rawResp)); ok {
 		return reduced, true
 	}
 	if reduced, ok := r.reduceFromSDK(err); ok {
@@ -59,15 +59,18 @@ func (r opaqueProviderErrorReducer) Reduce(err error, rawResp *http.Response) (*
 	return nil, false
 }
 
-func (r openAICompatibleErrorReducer) reduceFromStreamError(err error, statusCode int) (*ProviderAPIError, bool) {
+func (r openAICompatibleErrorReducer) reduceFromStreamError(err error, responseStatus *openAIResponseStatus) (*ProviderAPIError, bool) {
 	if err == nil {
+		return nil, false
+	}
+	if responseStatus == nil {
 		return nil, false
 	}
 	var streamErr *ssestream.StreamError
 	if !errors.As(err, &streamErr) {
 		return nil, false
 	}
-	reduced, ok := mapOpenAIStreamErrorPayload(r.providerID, streamErr.Event.Data, err, statusCode)
+	reduced, ok := mapOpenAIStreamErrorPayload(r.providerID, streamErr.Event.Data, err, responseStatus.Code)
 	if !ok {
 		return nil, false
 	}

--- a/server/llm/openai_error_reducer.go
+++ b/server/llm/openai_error_reducer.go
@@ -29,7 +29,7 @@ func newOpaqueProviderErrorReducer(providerID string) ProviderErrorReducer {
 }
 
 func (r openAICompatibleErrorReducer) Reduce(err error, rawResp *http.Response) (*ProviderAPIError, bool) {
-	if reduced, ok := r.reduceFromStreamError(err); ok {
+	if reduced, ok := r.reduceFromStreamError(err, openAIResponseStatusCode(rawResp)); ok {
 		return reduced, true
 	}
 	if reduced, ok := r.reduceFromSDK(err); ok {
@@ -59,7 +59,7 @@ func (r opaqueProviderErrorReducer) Reduce(err error, rawResp *http.Response) (*
 	return nil, false
 }
 
-func (r openAICompatibleErrorReducer) reduceFromStreamError(err error) (*ProviderAPIError, bool) {
+func (r openAICompatibleErrorReducer) reduceFromStreamError(err error, statusCode int) (*ProviderAPIError, bool) {
 	if err == nil {
 		return nil, false
 	}
@@ -67,21 +67,21 @@ func (r openAICompatibleErrorReducer) reduceFromStreamError(err error) (*Provide
 	if !errors.As(err, &streamErr) {
 		return nil, false
 	}
-	reduced, ok := mapOpenAIStreamErrorPayload(r.providerID, streamErr.Event.Data, err)
+	reduced, ok := mapOpenAIStreamErrorPayload(r.providerID, streamErr.Event.Data, err, statusCode)
 	if !ok {
 		return nil, false
 	}
 	return reduced, true
 }
 
-func mapOpenAIStreamErrorPayload(providerID string, data []byte, cause error) (*ProviderAPIError, bool) {
+func mapOpenAIStreamErrorPayload(providerID string, data []byte, cause error, statusCode int) (*ProviderAPIError, bool) {
 	payload, ok := decodeOpenAIStreamErrorPayload(data)
 	if !ok {
 		return nil, false
 	}
 	return mapOpenAIProviderErrorContract(
 		providerID,
-		0,
+		statusCode,
 		payload.Code,
 		payload.Type,
 		payload.Param,

--- a/server/llm/openai_error_reducer.go
+++ b/server/llm/openai_error_reducer.go
@@ -211,6 +211,9 @@ func decodeOpenAIStreamErrorPayload(data []byte) (openAIStreamErrorPayload, bool
 			Message string `json:"message"`
 		} `json:"error"`
 		Response struct {
+			IncompleteDetails struct {
+				Reason string `json:"reason"`
+			} `json:"incomplete_details"`
 			Error struct {
 				Type    string `json:"type"`
 				Code    string `json:"code"`
@@ -222,8 +225,9 @@ func decodeOpenAIStreamErrorPayload(data []byte) (openAIStreamErrorPayload, bool
 	if err := json.Unmarshal(data, &envelope); err != nil {
 		return openAIStreamErrorPayload{}, false
 	}
+	eventType := strings.TrimSpace(envelope.Type)
 	payload := openAIStreamErrorPayload{
-		Type:    strings.TrimSpace(envelope.Type),
+		Type:    eventType,
 		Code:    strings.TrimSpace(envelope.Code),
 		Param:   strings.TrimSpace(envelope.Param),
 		Message: strings.TrimSpace(envelope.Message),
@@ -242,6 +246,17 @@ func decodeOpenAIStreamErrorPayload(data []byte) (openAIStreamErrorPayload, bool
 			Code:    strings.TrimSpace(envelope.Response.Error.Code),
 			Param:   strings.TrimSpace(envelope.Response.Error.Param),
 			Message: strings.TrimSpace(envelope.Response.Error.Message),
+		}
+	}
+	if eventType == "response.incomplete" {
+		reason := strings.TrimSpace(envelope.Response.IncompleteDetails.Reason)
+		if reason != "" {
+			payload = openAIStreamErrorPayload{
+				Type:    eventType,
+				Code:    reason,
+				Param:   "response.incomplete_details.reason",
+				Message: "response incomplete: " + reason,
+			}
 		}
 	}
 	if payload.Code == "" && payload.Message == "" {

--- a/server/llm/openai_error_reducer.go
+++ b/server/llm/openai_error_reducer.go
@@ -79,18 +79,6 @@ func mapOpenAIStreamErrorPayload(providerID string, data []byte, cause error) (*
 	if !ok {
 		return nil, false
 	}
-	if payload.Type == "response.incomplete" {
-		return &ProviderAPIError{
-			ProviderID:    providerID,
-			Code:          UnifiedErrorCodeProviderContract,
-			ProviderCode:  payload.Code,
-			ProviderType:  payload.Type,
-			ProviderParam: payload.Param,
-			Message:       payload.Message,
-			Raw:           string(data),
-			Err:           cause,
-		}, true
-	}
 	return mapOpenAIProviderErrorContract(
 		providerID,
 		0,

--- a/server/llm/openai_http.go
+++ b/server/llm/openai_http.go
@@ -174,7 +174,7 @@ func (t *HTTPTransport) GenerateStreamWithEvents(ctx context.Context, request Op
 			callbacks.OnStreamActivity()
 		}
 		accumulator.Consume(stream.Current())
-		if err := accumulator.Err(providerCaps.ProviderID, openAIResponseStatusCode(rawResp)); err != nil {
+		if err := accumulator.Err(providerCaps.ProviderID, newOpenAIResponseStatus(rawResp)); err != nil {
 			return OpenAIResponse{}, newOpenAIRequestErrorMapper(providerCaps.ProviderID).Map(err, rawResp, "read responses stream events")
 		}
 	}
@@ -182,19 +182,24 @@ func (t *HTTPTransport) GenerateStreamWithEvents(ctx context.Context, request Op
 		if accumulator.hasCompleted() && !callerCanceledStreamRead(ctx) {
 			return accumulator.Response(), nil
 		}
-		if rawResp != nil && isOpenAIResponsesStreamFramingError(err) {
+		responseStatus := newOpenAIResponseStatus(rawResp)
+		if responseStatus != nil && isOpenAIResponsesStreamFramingError(err) {
 			return OpenAIResponse{}, fmt.Errorf("read responses stream events: %w", llmerrors.NewProviderContractError(
 				providerCaps.ProviderID,
-				openAIResponseStatusCode(rawResp),
+				responseStatus.Code,
 				fmt.Errorf("%s: %w", openAIResponsesStreamEndedBeforeTerminalMessage, err),
 			))
 		}
 		return OpenAIResponse{}, newOpenAIRequestErrorMapper(providerCaps.ProviderID).Map(err, rawResp, "read responses stream events")
 	}
 	if !accumulator.hasCompleted() {
+		responseStatus := newOpenAIResponseStatus(rawResp)
+		if responseStatus == nil {
+			return OpenAIResponse{}, fmt.Errorf("read responses stream events: %w", errors.New(openAIResponsesStreamEndedBeforeTerminalMessage))
+		}
 		return OpenAIResponse{}, fmt.Errorf("read responses stream events: %w", llmerrors.NewProviderContractError(
 			providerCaps.ProviderID,
-			openAIResponseStatusCode(rawResp),
+			responseStatus.Code,
 			errors.New(openAIResponsesStreamEndedBeforeTerminalMessage),
 		))
 	}
@@ -216,11 +221,15 @@ func isOpenAIResponsesStreamFramingError(err error) bool {
 	return errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF)
 }
 
-func openAIResponseStatusCode(rawResp *http.Response) int {
+type openAIResponseStatus struct {
+	Code int
+}
+
+func newOpenAIResponseStatus(rawResp *http.Response) *openAIResponseStatus {
 	if rawResp == nil {
-		return 0
+		return nil
 	}
-	return rawResp.StatusCode
+	return &openAIResponseStatus{Code: rawResp.StatusCode}
 }
 
 func callerCanceledStreamRead(ctx context.Context) bool {

--- a/server/llm/openai_http.go
+++ b/server/llm/openai_http.go
@@ -182,7 +182,7 @@ func (t *HTTPTransport) GenerateStreamWithEvents(ctx context.Context, request Op
 		if accumulator.hasCompleted() && !callerCanceledStreamRead(ctx) {
 			return accumulator.Response(), nil
 		}
-		if isOpenAIResponsesStreamFramingError(err) {
+		if rawResp != nil && isOpenAIResponsesStreamFramingError(err) {
 			return OpenAIResponse{}, fmt.Errorf("read responses stream events: %w", llmerrors.NewProviderContractError(
 				providerCaps.ProviderID,
 				openAIResponseStatusCode(rawResp),

--- a/server/llm/openai_http.go
+++ b/server/llm/openai_http.go
@@ -209,6 +209,10 @@ func isOpenAIResponsesStreamFramingError(err error) bool {
 	if errors.As(err, &syntaxErr) {
 		return true
 	}
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		return true
+	}
 	return errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF)
 }
 

--- a/server/llm/openai_http.go
+++ b/server/llm/openai_http.go
@@ -174,7 +174,7 @@ func (t *HTTPTransport) GenerateStreamWithEvents(ctx context.Context, request Op
 			callbacks.OnStreamActivity()
 		}
 		accumulator.Consume(stream.Current())
-		if err := accumulator.Err(providerCaps.ProviderID); err != nil {
+		if err := accumulator.Err(providerCaps.ProviderID, openAIResponseStatusCode(rawResp)); err != nil {
 			return OpenAIResponse{}, newOpenAIRequestErrorMapper(providerCaps.ProviderID).Map(err, rawResp, "read responses stream events")
 		}
 	}

--- a/server/llm/openai_http.go
+++ b/server/llm/openai_http.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"core/server/auth"
+	"core/shared/llmerrors"
 
 	openai "github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
@@ -28,6 +29,8 @@ const (
 	defaultUserAgent       = "kent/dev"
 	reasoningRoleSummary   = "reasoning"
 )
+
+const openAIResponsesStreamEndedBeforeTerminalMessage = "OpenAI-compatible Responses SSE stream ended before a terminal Responses event"
 
 type AuthHeaderProvider interface {
 	AuthorizationHeader(ctx context.Context) (string, error)
@@ -180,21 +183,19 @@ func (t *HTTPTransport) GenerateStreamWithEvents(ctx context.Context, request Op
 			return accumulator.Response(), nil
 		}
 		if isOpenAIResponsesStreamFramingError(err) {
-			return OpenAIResponse{}, fmt.Errorf("read responses stream events: %w", newOpenAIProviderContractError(
+			return OpenAIResponse{}, fmt.Errorf("read responses stream events: %w", llmerrors.NewProviderContractError(
 				providerCaps.ProviderID,
-				rawResp,
-				"OpenAI-compatible Responses SSE stream ended before a terminal Responses event",
-				err,
+				openAIResponseStatusCode(rawResp),
+				fmt.Errorf("%s: %w", openAIResponsesStreamEndedBeforeTerminalMessage, err),
 			))
 		}
 		return OpenAIResponse{}, newOpenAIRequestErrorMapper(providerCaps.ProviderID).Map(err, rawResp, "read responses stream events")
 	}
 	if !accumulator.hasCompleted() {
-		return OpenAIResponse{}, fmt.Errorf("read responses stream events: %w", newOpenAIProviderContractError(
+		return OpenAIResponse{}, fmt.Errorf("read responses stream events: %w", llmerrors.NewProviderContractError(
 			providerCaps.ProviderID,
-			rawResp,
-			"OpenAI-compatible Responses SSE stream ended before a terminal Responses event",
-			nil,
+			openAIResponseStatusCode(rawResp),
+			errors.New(openAIResponsesStreamEndedBeforeTerminalMessage),
 		))
 	}
 	return accumulator.Response(), nil
@@ -208,7 +209,14 @@ func isOpenAIResponsesStreamFramingError(err error) bool {
 	if errors.As(err, &syntaxErr) {
 		return true
 	}
-	return errors.Is(err, io.ErrUnexpectedEOF)
+	return errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF)
+}
+
+func openAIResponseStatusCode(rawResp *http.Response) int {
+	if rawResp == nil {
+		return 0
+	}
+	return rawResp.StatusCode
 }
 
 func callerCanceledStreamRead(ctx context.Context) bool {

--- a/server/llm/openai_http.go
+++ b/server/llm/openai_http.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -178,9 +179,36 @@ func (t *HTTPTransport) GenerateStreamWithEvents(ctx context.Context, request Op
 		if accumulator.hasCompleted() && !callerCanceledStreamRead(ctx) {
 			return accumulator.Response(), nil
 		}
+		if isOpenAIResponsesStreamFramingError(err) {
+			return OpenAIResponse{}, fmt.Errorf("read responses stream events: %w", newOpenAIProviderContractError(
+				providerCaps.ProviderID,
+				rawResp,
+				"OpenAI-compatible Responses SSE stream ended before a terminal Responses event",
+				err,
+			))
+		}
 		return OpenAIResponse{}, newOpenAIRequestErrorMapper(providerCaps.ProviderID).Map(err, rawResp, "read responses stream events")
 	}
+	if !accumulator.hasCompleted() {
+		return OpenAIResponse{}, fmt.Errorf("read responses stream events: %w", newOpenAIProviderContractError(
+			providerCaps.ProviderID,
+			rawResp,
+			"OpenAI-compatible Responses SSE stream ended before a terminal Responses event",
+			nil,
+		))
+	}
 	return accumulator.Response(), nil
+}
+
+func isOpenAIResponsesStreamFramingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return true
+	}
+	return errors.Is(err, io.ErrUnexpectedEOF)
 }
 
 func callerCanceledStreamRead(ctx context.Context) bool {

--- a/server/llm/openai_http_errors.go
+++ b/server/llm/openai_http_errors.go
@@ -16,21 +16,6 @@ func newOpenAIRequestErrorMapper(providerID string) openAIRequestErrorMapper {
 	return openAIRequestErrorMapper{providerID: providerID}
 }
 
-func newOpenAIProviderContractError(providerID string, rawResp *http.Response, message string, cause error) *ProviderAPIError {
-	statusCode := 0
-	if rawResp != nil {
-		statusCode = rawResp.StatusCode
-	}
-	return &ProviderAPIError{
-		ProviderID: providerID,
-		StatusCode: statusCode,
-		Code:       UnifiedErrorCodeProviderContract,
-		Message:    message,
-		Raw:        message,
-		Err:        cause,
-	}
-}
-
 func (m openAIRequestErrorMapper) Map(err error, rawResp *http.Response, prefix string) error {
 	reducer, reducerErr := providerErrorReducerForID(m.providerID)
 	if reducerErr != nil {

--- a/server/llm/openai_http_errors.go
+++ b/server/llm/openai_http_errors.go
@@ -16,6 +16,21 @@ func newOpenAIRequestErrorMapper(providerID string) openAIRequestErrorMapper {
 	return openAIRequestErrorMapper{providerID: providerID}
 }
 
+func newOpenAIProviderContractError(providerID string, rawResp *http.Response, message string, cause error) *ProviderAPIError {
+	statusCode := 0
+	if rawResp != nil {
+		statusCode = rawResp.StatusCode
+	}
+	return &ProviderAPIError{
+		ProviderID: providerID,
+		StatusCode: statusCode,
+		Code:       UnifiedErrorCodeProviderContract,
+		Message:    message,
+		Raw:        message,
+		Err:        cause,
+	}
+}
+
 func (m openAIRequestErrorMapper) Map(err error, rawResp *http.Response, prefix string) error {
 	reducer, reducerErr := providerErrorReducerForID(m.providerID)
 	if reducerErr != nil {

--- a/server/llm/openai_http_stream.go
+++ b/server/llm/openai_http_stream.go
@@ -87,7 +87,7 @@ func (a *responseStreamAccumulator) Consume(evt responses.ResponseStreamEventUni
 		a.emitReasoningSummaryDelta(key)
 	case "response.completed":
 		completedEvent := evt.AsResponseCompleted()
-		if !completedEvent.JSON.Response.Valid() || !completedEvent.Response.JSON.Output.Valid() {
+		if !responseCompletedEventHasValidPayload(completedEvent) {
 			a.responseError = &responseStreamError{
 				Raw: completedEvent.RawJSON(),
 				ProviderContract: &responseStreamProviderContract{
@@ -117,6 +117,17 @@ func (a *responseStreamAccumulator) Consume(evt responses.ResponseStreamEventUni
 	case "error":
 		a.responseError = &responseStreamError{Raw: evt.RawJSON()}
 	}
+}
+
+func responseCompletedEventHasValidPayload(evt responses.ResponseCompletedEvent) bool {
+	if !evt.JSON.Response.Valid() || !evt.Response.JSON.Output.Valid() {
+		return false
+	}
+	var output []json.RawMessage
+	if err := json.Unmarshal([]byte(evt.Response.JSON.Output.Raw()), &output); err != nil {
+		return false
+	}
+	return output != nil
 }
 
 func (a *responseStreamAccumulator) Err(providerID string, responseStatus *openAIResponseStatus) error {

--- a/server/llm/openai_http_stream.go
+++ b/server/llm/openai_http_stream.go
@@ -87,7 +87,7 @@ func (a *responseStreamAccumulator) Consume(evt responses.ResponseStreamEventUni
 		a.emitReasoningSummaryDelta(key)
 	case "response.completed":
 		completedEvent := evt.AsResponseCompleted()
-		if !completedEvent.JSON.Response.Valid() {
+		if !completedEvent.JSON.Response.Valid() || !completedEvent.Response.JSON.Output.Valid() {
 			a.responseError = &responseStreamError{
 				Raw: completedEvent.RawJSON(),
 				ProviderContract: &responseStreamProviderContract{

--- a/server/llm/openai_http_stream.go
+++ b/server/llm/openai_http_stream.go
@@ -2,9 +2,11 @@ package llm
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
+	"core/shared/llmerrors"
 	"core/shared/textutil"
 	"github.com/openai/openai-go/v3/responses"
 )
@@ -104,12 +106,7 @@ func (a *responseStreamAccumulator) Err(providerID string) error {
 	}
 	if a.responseError.ProviderContract {
 		message := "OpenAI-compatible Responses stream emitted response.incomplete without incomplete_details.reason"
-		return &ProviderAPIError{
-			ProviderID: providerID,
-			Code:       UnifiedErrorCodeProviderContract,
-			Message:    message,
-			Raw:        strings.TrimSpace(a.responseError.Raw),
-		}
+		return llmerrors.NewProviderContractError(providerID, 0, errors.New(message))
 	}
 	if err, ok := mapOpenAIStreamErrorPayload(providerID, []byte(a.responseError.Raw), nil); ok {
 		return err

--- a/server/llm/openai_http_stream.go
+++ b/server/llm/openai_http_stream.go
@@ -100,13 +100,13 @@ func (a *responseStreamAccumulator) Consume(evt responses.ResponseStreamEventUni
 	}
 }
 
-func (a *responseStreamAccumulator) Err(providerID string) error {
+func (a *responseStreamAccumulator) Err(providerID string, statusCode int) error {
 	if a == nil || a.responseError == nil {
 		return nil
 	}
 	if a.responseError.ProviderContract {
 		message := "OpenAI-compatible Responses stream emitted response.incomplete without incomplete_details.reason"
-		return llmerrors.NewProviderContractError(providerID, 0, errors.New(message))
+		return llmerrors.NewProviderContractError(providerID, statusCode, errors.New(message))
 	}
 	if err, ok := mapOpenAIStreamErrorPayload(providerID, []byte(a.responseError.Raw), nil); ok {
 		return err

--- a/server/llm/openai_http_stream.go
+++ b/server/llm/openai_http_stream.go
@@ -119,14 +119,24 @@ func (a *responseStreamAccumulator) Consume(evt responses.ResponseStreamEventUni
 	}
 }
 
-func (a *responseStreamAccumulator) Err(providerID string, statusCode int) error {
+func (a *responseStreamAccumulator) Err(providerID string, responseStatus *openAIResponseStatus) error {
 	if a == nil || a.responseError == nil {
 		return nil
 	}
-	if a.responseError.ProviderContract != nil {
-		return llmerrors.NewProviderContractError(providerID, statusCode, errors.New(a.responseError.ProviderContract.Message))
+	if responseStatus == nil {
+		message := strings.TrimSpace(a.responseError.Raw)
+		if a.responseError.ProviderContract != nil {
+			message = a.responseError.ProviderContract.Message
+		}
+		if message == "" {
+			message = "unrecognized stream error"
+		}
+		return errors.New(message)
 	}
-	if err, ok := mapOpenAIStreamErrorPayload(providerID, []byte(a.responseError.Raw), nil, statusCode); ok {
+	if a.responseError.ProviderContract != nil {
+		return llmerrors.NewProviderContractError(providerID, responseStatus.Code, errors.New(a.responseError.ProviderContract.Message))
+	}
+	if err, ok := mapOpenAIStreamErrorPayload(providerID, []byte(a.responseError.Raw), nil, responseStatus.Code); ok {
 		return err
 	}
 	message := strings.TrimSpace(a.responseError.Raw)
@@ -135,6 +145,7 @@ func (a *responseStreamAccumulator) Err(providerID string, statusCode int) error
 	}
 	return &ProviderAPIError{
 		ProviderID: providerID,
+		StatusCode: responseStatus.Code,
 		Code:       UnifiedErrorCodeUnknown,
 		Message:    message,
 		Raw:        message,

--- a/server/llm/openai_http_stream.go
+++ b/server/llm/openai_http_stream.go
@@ -126,7 +126,7 @@ func (a *responseStreamAccumulator) Err(providerID string, statusCode int) error
 	if a.responseError.ProviderContract != nil {
 		return llmerrors.NewProviderContractError(providerID, statusCode, errors.New(a.responseError.ProviderContract.Message))
 	}
-	if err, ok := mapOpenAIStreamErrorPayload(providerID, []byte(a.responseError.Raw), nil); ok {
+	if err, ok := mapOpenAIStreamErrorPayload(providerID, []byte(a.responseError.Raw), nil, statusCode); ok {
 		return err
 	}
 	message := strings.TrimSpace(a.responseError.Raw)

--- a/server/llm/openai_http_stream.go
+++ b/server/llm/openai_http_stream.go
@@ -22,10 +22,8 @@ type responseStreamAccumulator struct {
 }
 
 type responseStreamError struct {
-	Code    string
-	Param   string
-	Message string
-	Raw     string
+	Raw              string
+	ProviderContract bool
 }
 
 func newResponseStreamAccumulator(callbacks StreamCallbacks, windowTokens int) *responseStreamAccumulator {
@@ -87,20 +85,31 @@ func (a *responseStreamAccumulator) Consume(evt responses.ResponseStreamEventUni
 	case "response.failed":
 		failed := evt.AsResponseFailed()
 		a.responseError = &responseStreamError{Raw: failed.RawJSON()}
-	case "error":
-		errorEvent := evt.AsError()
-		a.responseError = &responseStreamError{
-			Code:    errorEvent.Code,
-			Param:   errorEvent.Param,
-			Message: errorEvent.Message,
-			Raw:     evt.RawJSON(),
+	case "response.incomplete":
+		incomplete := evt.AsResponseIncomplete()
+		raw := incomplete.RawJSON()
+		if strings.TrimSpace(incomplete.Response.IncompleteDetails.Reason) == "" {
+			a.responseError = &responseStreamError{Raw: raw, ProviderContract: true}
+			return
 		}
+		a.responseError = &responseStreamError{Raw: raw}
+	case "error":
+		a.responseError = &responseStreamError{Raw: evt.RawJSON()}
 	}
 }
 
 func (a *responseStreamAccumulator) Err(providerID string) error {
 	if a == nil || a.responseError == nil {
 		return nil
+	}
+	if a.responseError.ProviderContract {
+		message := "OpenAI-compatible Responses stream emitted response.incomplete without incomplete_details.reason"
+		return &ProviderAPIError{
+			ProviderID: providerID,
+			Code:       UnifiedErrorCodeProviderContract,
+			Message:    message,
+			Raw:        strings.TrimSpace(a.responseError.Raw),
+		}
 	}
 	if err, ok := mapOpenAIStreamErrorPayload(providerID, []byte(a.responseError.Raw), nil); ok {
 		return err

--- a/server/llm/openai_http_stream.go
+++ b/server/llm/openai_http_stream.go
@@ -25,7 +25,11 @@ type responseStreamAccumulator struct {
 
 type responseStreamError struct {
 	Raw              string
-	ProviderContract bool
+	ProviderContract *responseStreamProviderContract
+}
+
+type responseStreamProviderContract struct {
+	Message string
 }
 
 func newResponseStreamAccumulator(callbacks StreamCallbacks, windowTokens int) *responseStreamAccumulator {
@@ -82,7 +86,17 @@ func (a *responseStreamAccumulator) Consume(evt responses.ResponseStreamEventUni
 		a.reasoning.Set(reasoningRoleSummary, key, evt.Part.Text)
 		a.emitReasoningSummaryDelta(key)
 	case "response.completed":
-		completed := evt.AsResponseCompleted().Response
+		completedEvent := evt.AsResponseCompleted()
+		if !completedEvent.JSON.Response.Valid() {
+			a.responseError = &responseStreamError{
+				Raw: completedEvent.RawJSON(),
+				ProviderContract: &responseStreamProviderContract{
+					Message: "OpenAI-compatible Responses stream emitted response.completed without a valid response payload",
+				},
+			}
+			return
+		}
+		completed := completedEvent.Response
 		a.completed = &completed
 	case "response.failed":
 		failed := evt.AsResponseFailed()
@@ -91,7 +105,12 @@ func (a *responseStreamAccumulator) Consume(evt responses.ResponseStreamEventUni
 		incomplete := evt.AsResponseIncomplete()
 		raw := incomplete.RawJSON()
 		if strings.TrimSpace(incomplete.Response.IncompleteDetails.Reason) == "" {
-			a.responseError = &responseStreamError{Raw: raw, ProviderContract: true}
+			a.responseError = &responseStreamError{
+				Raw: raw,
+				ProviderContract: &responseStreamProviderContract{
+					Message: "OpenAI-compatible Responses stream emitted response.incomplete without incomplete_details.reason",
+				},
+			}
 			return
 		}
 		a.responseError = &responseStreamError{Raw: raw}
@@ -104,9 +123,8 @@ func (a *responseStreamAccumulator) Err(providerID string, statusCode int) error
 	if a == nil || a.responseError == nil {
 		return nil
 	}
-	if a.responseError.ProviderContract {
-		message := "OpenAI-compatible Responses stream emitted response.incomplete without incomplete_details.reason"
-		return llmerrors.NewProviderContractError(providerID, statusCode, errors.New(message))
+	if a.responseError.ProviderContract != nil {
+		return llmerrors.NewProviderContractError(providerID, statusCode, errors.New(a.responseError.ProviderContract.Message))
 	}
 	if err, ok := mapOpenAIStreamErrorPayload(providerID, []byte(a.responseError.Raw), nil); ok {
 		return err

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -179,6 +179,7 @@ func TestGenerateStream_RejectsCompletedEventWithoutResponsePayload(t *testing.T
 	}{
 		{name: "missing_response", data: `{"type":"response.completed","sequence_number":1}`},
 		{name: "empty_response", data: `{"type":"response.completed","sequence_number":1,"response":{}}`},
+		{name: "null_output", data: `{"type":"response.completed","sequence_number":1,"response":{"output":null}}`},
 	}
 
 	for _, tc := range cases {

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -18,15 +18,22 @@ func (staticAuthHeader) AuthorizationHeader(context.Context) (string, error) {
 
 func newOpenAIStreamTestServer(t *testing.T, events ...string) *httptest.Server {
 	t.Helper()
+	var stream strings.Builder
+	for _, event := range events {
+		_, _ = fmt.Fprintf(&stream, "data: %s\n\n", event)
+	}
+	return newOpenAIRawStreamTestServer(t, stream.String())
+}
+
+func newOpenAIRawStreamTestServer(t *testing.T, stream string) *httptest.Server {
+	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/responses" {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
-		for _, event := range events {
-			_, _ = fmt.Fprintf(w, "data: %s\n\n", event)
-		}
+		_, _ = w.Write([]byte(stream))
 	}))
 	t.Cleanup(server.Close)
 	return server
@@ -35,10 +42,20 @@ func newOpenAIStreamTestServer(t *testing.T, events ...string) *httptest.Server 
 func newOpenAIStreamTestTransport(t *testing.T, events ...string) *HTTPTransport {
 	t.Helper()
 	server := newOpenAIStreamTestServer(t, events...)
+	return newOpenAIStreamTestTransportForServer(server)
+}
+
+func newOpenAIStreamTestTransportForServer(server *httptest.Server) *HTTPTransport {
 	transport := NewHTTPTransport(staticAuthHeader{})
 	transport.BaseURL = server.URL
 	transport.Client = server.Client()
 	return transport
+}
+
+func newOpenAIRawStreamTestTransport(t *testing.T, stream string) *HTTPTransport {
+	t.Helper()
+	server := newOpenAIRawStreamTestServer(t, stream)
+	return newOpenAIStreamTestTransportForServer(server)
 }
 
 func joinedAssistantDeltas(deltas []AssistantDelta) string {
@@ -47,6 +64,140 @@ func joinedAssistantDeltas(deltas []AssistantDelta) string {
 		text.WriteString(delta.Text)
 	}
 	return text.String()
+}
+
+func TestGenerateStream_AcceptsCompletedResponseEOFWithoutDoneSentinel(t *testing.T) {
+	transport := newOpenAIRawStreamTestTransport(t, strings.Join([]string{
+		`event: response.completed`,
+		`data: {"type":"response.completed","sequence_number":1,"response":{"usage":{"input_tokens":11,"output_tokens":7,"total_tokens":18},"output":[{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Hello"}]}]}}`,
+		``,
+		``,
+	}, "\n"))
+
+	resp, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{Model: "gpt-5"}, StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("GenerateStream failed: %v", err)
+	}
+
+	if resp.AssistantText != "Hello" {
+		t.Fatalf("assistant text = %q, want Hello", resp.AssistantText)
+	}
+	if resp.Usage.InputTokens != 11 || resp.Usage.OutputTokens != 7 {
+		t.Fatalf("unexpected usage: %+v", resp.Usage)
+	}
+}
+
+func TestGenerateStream_SalvagesCompletedResponseBeforeTrailingMalformedEvent(t *testing.T) {
+	transport := newOpenAIRawStreamTestTransport(t, strings.Join([]string{
+		`event: response.completed`,
+		`data: {"type":"response.completed","sequence_number":1,"response":{"usage":{"input_tokens":3,"output_tokens":5,"total_tokens":8},"output":[{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Done"}]}]}}`,
+		``,
+		`event: response.completed`,
+		`data: `,
+		``,
+		``,
+	}, "\n"))
+
+	resp, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{Model: "gpt-5"}, StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("GenerateStream failed: %v", err)
+	}
+
+	if resp.AssistantText != "Done" {
+		t.Fatalf("assistant text = %q, want Done", resp.AssistantText)
+	}
+	if resp.Usage.InputTokens != 3 || resp.Usage.OutputTokens != 5 {
+		t.Fatalf("unexpected usage: %+v", resp.Usage)
+	}
+}
+
+func TestGenerateStream_MapsResponseIncompleteEventToProviderAPIError(t *testing.T) {
+	transport := newOpenAIRawStreamTestTransport(t, strings.Join([]string{
+		`event: response.output_text.delta`,
+		`data: {"type":"response.output_text.delta","output_index":0,"delta":"partial"}`,
+		``,
+		`event: response.incomplete`,
+		`data: {"type":"response.incomplete","sequence_number":2,"response":{"id":"resp_1","created_at":1,"incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"partial"}]}]}}`,
+		``,
+		``,
+	}, "\n"))
+
+	_, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{Model: "gpt-5"}, StreamCallbacks{})
+	if err == nil {
+		t.Fatal("expected response incomplete event")
+	}
+	var providerErr *ProviderAPIError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("expected ProviderAPIError, got %T", err)
+	}
+	if providerErr.ProviderType != "response.incomplete" {
+		t.Fatalf("provider type = %q, want response.incomplete", providerErr.ProviderType)
+	}
+	if providerErr.ProviderCode != "max_output_tokens" {
+		t.Fatalf("provider code = %q, want max_output_tokens", providerErr.ProviderCode)
+	}
+	if providerErr.ProviderParam != "response.incomplete_details.reason" {
+		t.Fatalf("provider param = %q, want response.incomplete_details.reason", providerErr.ProviderParam)
+	}
+}
+
+func TestGenerateStream_MapsResponseIncompleteWithoutReasonToProviderContractError(t *testing.T) {
+	transport := newOpenAIRawStreamTestTransport(t, strings.Join([]string{
+		`event: response.incomplete`,
+		`data: {"type":"response.incomplete","sequence_number":1,"response":{"id":"resp_1","created_at":1,"output":[]}}`,
+		``,
+		``,
+	}, "\n"))
+
+	_, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{Model: "gpt-5"}, StreamCallbacks{})
+	if err == nil {
+		t.Fatal("expected response incomplete event")
+	}
+	var providerErr *ProviderAPIError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("expected ProviderAPIError, got %T", err)
+	}
+	if providerErr.Code != UnifiedErrorCodeProviderContract {
+		t.Fatalf("provider code = %q, want %q", providerErr.Code, UnifiedErrorCodeProviderContract)
+	}
+}
+
+func TestGenerateStream_RejectsPreTerminalMalformedResponsesStream(t *testing.T) {
+	cases := map[string]string{
+		"eof_without_terminal": strings.Join([]string{
+			`event: response.output_text.delta`,
+			`data: {"type":"response.output_text.delta","output_index":0,"delta":"partial"}`,
+			``,
+			``,
+		}, "\n"),
+		"malformed_json_before_terminal": strings.Join([]string{
+			`event: response.output_text.delta`,
+			`data: {"type":`,
+			``,
+			``,
+		}, "\n"),
+	}
+
+	for name, stream := range cases {
+		t.Run(name, func(t *testing.T) {
+			transport := newOpenAIRawStreamTestTransport(t, stream)
+
+			_, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{Model: "gpt-5"}, StreamCallbacks{})
+			if err == nil {
+				t.Fatal("expected provider contract error")
+			}
+			var providerErr *ProviderAPIError
+			if !errors.As(err, &providerErr) {
+				t.Fatalf("expected ProviderAPIError, got %T", err)
+			}
+			if providerErr.Code != UnifiedErrorCodeProviderContract {
+				t.Fatalf("provider code = %q, want %q", providerErr.Code, UnifiedErrorCodeProviderContract)
+			}
+			if !IsNonRetriableModelError(err) {
+				t.Fatalf("expected provider-contract stream error to be non-retriable: %v", err)
+			}
+		})
+	}
 }
 
 func TestGenerateStream_EmitsAssistantDeltasAndToolCalls(t *testing.T) {

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -140,6 +140,9 @@ func TestGenerateStream_MapsResponseIncompleteEventToProviderAPIError(t *testing
 	if providerErr.ProviderParam != "response.incomplete_details.reason" {
 		t.Fatalf("provider param = %q, want response.incomplete_details.reason", providerErr.ProviderParam)
 	}
+	if providerErr.StatusCode != http.StatusOK {
+		t.Fatalf("provider status = %d, want %d", providerErr.StatusCode, http.StatusOK)
+	}
 	if !IsNonRetriableModelError(err) {
 		t.Fatalf("expected response.incomplete terminal error to be non-retriable: %v", err)
 	}

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -164,6 +164,9 @@ func TestGenerateStream_MapsResponseIncompleteWithoutReasonToProviderContractErr
 	if providerErr.Code != UnifiedErrorCodeProviderContract {
 		t.Fatalf("provider code = %q, want %q", providerErr.Code, UnifiedErrorCodeProviderContract)
 	}
+	if providerErr.StatusCode != http.StatusOK {
+		t.Fatalf("provider status = %d, want %d", providerErr.StatusCode, http.StatusOK)
+	}
 }
 
 func TestGenerateStream_RejectsPreTerminalMalformedResponsesStream(t *testing.T) {

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -205,6 +206,26 @@ func TestGenerateStream_RejectsPreTerminalMalformedResponsesStream(t *testing.T)
 				t.Fatalf("expected provider-contract stream error to be non-retriable: %v", err)
 			}
 		})
+	}
+}
+
+func TestGenerateStream_LeavesPreResponseEOFRetryable(t *testing.T) {
+	transport := NewHTTPTransport(staticAuthHeader{})
+	transport.BaseURL = "https://example.invalid"
+	transport.Client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, io.EOF
+	})}
+
+	_, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{Model: "gpt-5"}, StreamCallbacks{})
+	if err == nil {
+		t.Fatal("expected pre-response EOF")
+	}
+	var providerErr *ProviderAPIError
+	if errors.As(err, &providerErr) {
+		t.Fatalf("expected pre-response EOF to stay outside provider-contract classification, got %+v", providerErr)
+	}
+	if IsNonRetriableModelError(err) {
+		t.Fatalf("expected pre-response EOF to remain retryable: %v", err)
 	}
 }
 

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -139,6 +139,9 @@ func TestGenerateStream_MapsResponseIncompleteEventToProviderAPIError(t *testing
 	if providerErr.ProviderParam != "response.incomplete_details.reason" {
 		t.Fatalf("provider param = %q, want response.incomplete_details.reason", providerErr.ProviderParam)
 	}
+	if !IsNonRetriableModelError(err) {
+		t.Fatalf("expected response.incomplete terminal error to be non-retriable: %v", err)
+	}
 }
 
 func TestGenerateStream_MapsResponseIncompleteWithoutReasonToProviderContractError(t *testing.T) {
@@ -173,6 +176,11 @@ func TestGenerateStream_RejectsPreTerminalMalformedResponsesStream(t *testing.T)
 		"malformed_json_before_terminal": strings.Join([]string{
 			`event: response.output_text.delta`,
 			`data: {"type":`,
+			``,
+			``,
+		}, "\n"),
+		"empty_data_before_terminal": strings.Join([]string{
+			`data: `,
 			``,
 			``,
 		}, "\n"),

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -173,26 +173,38 @@ func TestGenerateStream_MapsResponseIncompleteWithoutReasonToProviderContractErr
 }
 
 func TestGenerateStream_RejectsCompletedEventWithoutResponsePayload(t *testing.T) {
-	transport := newOpenAIRawStreamTestTransport(t, strings.Join([]string{
-		`event: response.completed`,
-		`data: {"type":"response.completed","sequence_number":1}`,
-		``,
-		``,
-	}, "\n"))
+	cases := []struct {
+		name string
+		data string
+	}{
+		{name: "missing_response", data: `{"type":"response.completed","sequence_number":1}`},
+		{name: "empty_response", data: `{"type":"response.completed","sequence_number":1,"response":{}}`},
+	}
 
-	_, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{Model: "gpt-5"}, StreamCallbacks{})
-	if err == nil {
-		t.Fatal("expected provider contract error")
-	}
-	var providerErr *ProviderAPIError
-	if !errors.As(err, &providerErr) {
-		t.Fatalf("expected ProviderAPIError, got %T", err)
-	}
-	if providerErr.Code != UnifiedErrorCodeProviderContract {
-		t.Fatalf("provider code = %q, want %q", providerErr.Code, UnifiedErrorCodeProviderContract)
-	}
-	if providerErr.StatusCode != http.StatusOK {
-		t.Fatalf("provider status = %d, want %d", providerErr.StatusCode, http.StatusOK)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := newOpenAIRawStreamTestTransport(t, strings.Join([]string{
+				`event: response.completed`,
+				`data: ` + tc.data,
+				``,
+				``,
+			}, "\n"))
+
+			_, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{Model: "gpt-5"}, StreamCallbacks{})
+			if err == nil {
+				t.Fatal("expected provider contract error")
+			}
+			var providerErr *ProviderAPIError
+			if !errors.As(err, &providerErr) {
+				t.Fatalf("expected ProviderAPIError, got %T", err)
+			}
+			if providerErr.Code != UnifiedErrorCodeProviderContract {
+				t.Fatalf("provider code = %q, want %q", providerErr.Code, UnifiedErrorCodeProviderContract)
+			}
+			if providerErr.StatusCode != http.StatusOK {
+				t.Fatalf("provider status = %d, want %d", providerErr.StatusCode, http.StatusOK)
+			}
+		})
 	}
 }
 

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -169,6 +169,30 @@ func TestGenerateStream_MapsResponseIncompleteWithoutReasonToProviderContractErr
 	}
 }
 
+func TestGenerateStream_RejectsCompletedEventWithoutResponsePayload(t *testing.T) {
+	transport := newOpenAIRawStreamTestTransport(t, strings.Join([]string{
+		`event: response.completed`,
+		`data: {"type":"response.completed","sequence_number":1}`,
+		``,
+		``,
+	}, "\n"))
+
+	_, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{Model: "gpt-5"}, StreamCallbacks{})
+	if err == nil {
+		t.Fatal("expected provider contract error")
+	}
+	var providerErr *ProviderAPIError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("expected ProviderAPIError, got %T", err)
+	}
+	if providerErr.Code != UnifiedErrorCodeProviderContract {
+		t.Fatalf("provider code = %q, want %q", providerErr.Code, UnifiedErrorCodeProviderContract)
+	}
+	if providerErr.StatusCode != http.StatusOK {
+		t.Fatalf("provider status = %d, want %d", providerErr.StatusCode, http.StatusOK)
+	}
+}
+
 func TestGenerateStream_RejectsPreTerminalMalformedResponsesStream(t *testing.T) {
 	cases := map[string]string{
 		"eof_without_terminal": strings.Join([]string{

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -185,6 +185,11 @@ func TestGenerateStream_RejectsPreTerminalMalformedResponsesStream(t *testing.T)
 			``,
 			``,
 		}, "\n"),
+		"invalid_schema_before_terminal": strings.Join([]string{
+			`data: {"type":1}`,
+			``,
+			``,
+		}, "\n"),
 	}
 
 	for name, stream := range cases {

--- a/server/llm/openai_http_test.go
+++ b/server/llm/openai_http_test.go
@@ -335,7 +335,7 @@ func TestMapOpenAIStreamErrorPayload_UsesSharedStructuredDecoder(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err, ok := mapOpenAIStreamErrorPayload("openai", []byte(tc.body), nil)
+			err, ok := mapOpenAIStreamErrorPayload("openai", []byte(tc.body), nil, http.StatusOK)
 			if !ok {
 				t.Fatal("expected stream error payload to map")
 			}

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -981,12 +981,16 @@ func (e *Engine) generateWithRetryClient(ctx context.Context, stepID string, cli
 			}
 			return resp, nil
 		}
+		resetAttempt := func() {
+			if (attemptEmitted || reasoningEmitted) && onAttemptReset != nil {
+				onAttemptReset()
+			}
+		}
 		if llm.IsNonRetriableModelError(attemptErr) || llm.IsContextLengthOverflowError(attemptErr) {
+			resetAttempt()
 			return llm.Response{}, attemptErr
 		}
-		if (attemptEmitted || reasoningEmitted) && onAttemptReset != nil {
-			onAttemptReset()
-		}
+		resetAttempt()
 		lastErr = attemptErr
 		delays := generateRetryDelays
 		if errors.Is(attemptErr, llm.ErrModelStreamStalled) {

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -987,7 +987,9 @@ func (e *Engine) generateWithRetryClient(ctx context.Context, stepID string, cli
 			}
 		}
 		if llm.IsNonRetriableModelError(attemptErr) || llm.IsContextLengthOverflowError(attemptErr) {
-			resetAttempt()
+			if !llm.HasHTTPStatus(attemptErr, 400) {
+				resetAttempt()
+			}
 			return llm.Response{}, attemptErr
 		}
 		resetAttempt()

--- a/server/runtime/engine_part9_test.go
+++ b/server/runtime/engine_part9_test.go
@@ -579,24 +579,28 @@ func TestStreamingNonRetriableErrorResetsAttemptDeltas(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	delta := -1
-	reset := -1
+	var deltaIndex int
+	var hasDelta bool
+	var resetIndex int
+	var hasReset bool
 	for i, evt := range events {
-		if evt.Kind == EventAssistantDelta && evt.AssistantDelta == "partial" && delta == -1 {
-			delta = i
+		if evt.Kind == EventAssistantDelta && evt.AssistantDelta == "partial" && !hasDelta {
+			deltaIndex = i
+			hasDelta = true
 		}
-		if evt.Kind == EventAssistantDeltaReset && reset == -1 {
-			reset = i
+		if evt.Kind == EventAssistantDeltaReset && !hasReset {
+			resetIndex = i
+			hasReset = true
 		}
 	}
-	if delta == -1 {
+	if !hasDelta {
 		t.Fatalf("missing streamed delta before terminal error: %+v", events)
 	}
-	if reset == -1 {
+	if !hasReset {
 		t.Fatalf("missing reset after terminal error: %+v", events)
 	}
-	if delta > reset {
-		t.Fatalf("unexpected delta/reset ordering delta=%d reset=%d", delta, reset)
+	if deltaIndex > resetIndex {
+		t.Fatalf("unexpected delta/reset ordering delta=%d reset=%d", deltaIndex, resetIndex)
 	}
 }
 

--- a/server/runtime/engine_part9_test.go
+++ b/server/runtime/engine_part9_test.go
@@ -7,6 +7,7 @@ import (
 	"core/server/tools"
 	"core/shared/toolspec"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -534,6 +535,68 @@ func TestStreamingRetryResetsAttemptDeltas(t *testing.T) {
 	}
 	if !(firstDelta < reset && reset < secondDelta) {
 		t.Fatalf("unexpected delta/reset ordering first=%d reset=%d second=%d", firstDelta, reset, secondDelta)
+	}
+}
+
+type fakeNonRetriableStreamClient struct{}
+
+func (fakeNonRetriableStreamClient) Generate(_ context.Context, _ llm.Request) (llm.Response, error) {
+	return llm.Response{}, errors.New("not implemented")
+}
+
+func (fakeNonRetriableStreamClient) GenerateStream(_ context.Context, _ llm.Request, onDelta func(string)) (llm.Response, error) {
+	if onDelta != nil {
+		onDelta("partial")
+	}
+	return llm.Response{}, &llm.ProviderAPIError{
+		ProviderID: "openai-compatible",
+		Code:       llm.UnifiedErrorCodeProviderContract,
+		Message:    "stream ended before terminal event",
+	}
+}
+
+func TestStreamingNonRetriableErrorResetsAttemptDeltas(t *testing.T) {
+	store := mustCreateTestSession(t)
+
+	var (
+		mu     sync.Mutex
+		events []Event
+	)
+	eng := mustNewTestEngine(t, store, fakeNonRetriableStreamClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
+		Model: "gpt-5",
+		OnEvent: func(evt Event) {
+			mu.Lock()
+			events = append(events, evt)
+			mu.Unlock()
+		},
+	})
+
+	_, err := eng.SubmitUserMessage(context.Background(), "non-retriable stream")
+	if err == nil {
+		t.Fatal("expected non-retriable stream error")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	delta := -1
+	reset := -1
+	for i, evt := range events {
+		if evt.Kind == EventAssistantDelta && evt.AssistantDelta == "partial" && delta == -1 {
+			delta = i
+		}
+		if evt.Kind == EventAssistantDeltaReset && reset == -1 {
+			reset = i
+		}
+	}
+	if delta == -1 {
+		t.Fatalf("missing streamed delta before terminal error: %+v", events)
+	}
+	if reset == -1 {
+		t.Fatalf("missing reset after terminal error: %+v", events)
+	}
+	if delta > reset {
+		t.Fatalf("unexpected delta/reset ordering delta=%d reset=%d", delta, reset)
 	}
 }
 

--- a/shared/llmerrors/errors.go
+++ b/shared/llmerrors/errors.go
@@ -31,6 +31,8 @@ const (
 	UnifiedErrorCodeProviderContract      UnifiedErrorCode = "provider_contract_error"
 )
 
+const providerTypeResponseIncomplete = "response.incomplete"
+
 type ProviderAPIError struct {
 	ProviderID    string
 	StatusCode    int
@@ -154,6 +156,9 @@ func IsNonRetriableModelError(err error) bool {
 	}
 	var providerErr *ProviderAPIError
 	if errors.As(err, &providerErr) {
+		if providerErr.ProviderType == providerTypeResponseIncomplete {
+			return true
+		}
 		if providerErr.Code == UnifiedErrorCodeProviderContract {
 			return true
 		}


### PR DESCRIPTION
## Summary
- Accept OpenAI-compatible Responses SSE streams that close after a valid `response.completed` event without `data: [DONE]`.
- Treat `response.incomplete` as an explicit terminal provider failure and preserve provider fields for its reason.
- Return provider-contract errors for malformed or pre-terminal Responses streams instead of partial success or raw JSON EOF errors.
- Document the locked provider terminal contract in `docs/dev/specs/core-runtime-tools.md`.

## Verification
- `./scripts/test.sh server ./server/llm -run 'TestGenerateStream'`
- `./scripts/build.sh --output ./bin/kent`

Closes #504


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming responses now handle terminal and incomplete-ending cases more reliably, including EOF endings, malformed streams, and incomplete responses.
  * Partial output is preserved when a response completes successfully before a later stream error.
  * Incomplete responses are now surfaced with clearer error details and are treated as non-retriable when appropriate.
  * Retry behavior now better preserves streamed output and resets attempt state only when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->