### PR TITLE
fix: normalize Option word navigation

### DIFF
--- a/cli/app/onboarding_model.go
+++ b/cli/app/onboarding_model.go
@@ -166,11 +166,11 @@ func (m *onboardingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case tea.KeyLeft:
-			if m.currentScreen.Kind != onboardingScreenInput {
+			if !typed.Alt {
 				return m.goBack()
 			}
 		case tea.KeyRight:
-			if m.currentScreen.Kind != onboardingScreenInput {
+			if !typed.Alt {
 				return m.submitCurrentScreen()
 			}
 		case tea.KeyEnter:

--- a/cli/app/onboarding_model.go
+++ b/cli/app/onboarding_model.go
@@ -166,9 +166,13 @@ func (m *onboardingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case tea.KeyLeft:
-			return m.goBack()
+			if m.currentScreen.Kind != onboardingScreenInput {
+				return m.goBack()
+			}
 		case tea.KeyRight:
-			return m.submitCurrentScreen()
+			if m.currentScreen.Kind != onboardingScreenInput {
+				return m.submitCurrentScreen()
+			}
 		case tea.KeyEnter:
 			return m.submitCurrentScreen()
 		case tea.KeySpace:

--- a/cli/app/onboarding_part2_test.go
+++ b/cli/app/onboarding_part2_test.go
@@ -148,6 +148,83 @@ func TestOnboardingEditorFieldDeleteCurrentLineUsesAppKeyAdapter(t *testing.T) {
 	}
 }
 
+func TestOnboardingInputWordNavigationStaysInField(t *testing.T) {
+	cases := []struct {
+		name          string
+		key           tea.KeyMsg
+		initialCursor func(string) int
+		wantCursor    func(string, int) int
+	}{
+		{
+			name:          "alt-left",
+			key:           tea.KeyMsg{Type: tea.KeyLeft, Alt: true},
+			initialCursor: func(text string) int { return len([]rune(text)) },
+			wantCursor:    moveBufferCursorWordLeft,
+		},
+		{
+			name:          "alt-right",
+			key:           tea.KeyMsg{Type: tea.KeyRight, Alt: true},
+			initialCursor: func(string) int { return 0 },
+			wantCursor:    moveBufferCursorWordRight,
+		},
+		{
+			name:          "alt-b",
+			key:           tea.KeyMsg{Type: tea.KeyRunes, Alt: true, Runes: []rune{'b'}},
+			initialCursor: func(text string) int { return len([]rune(text)) },
+			wantCursor:    moveBufferCursorWordLeft,
+		},
+		{
+			name:          "alt-f",
+			key:           tea.KeyMsg{Type: tea.KeyRunes, Alt: true, Runes: []rune{'f'}},
+			initialCursor: func(string) int { return 0 },
+			wantCursor:    moveBufferCursorWordRight,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			model := newOnboardingModelForWorkspace(t.TempDir(), "", onboardingFlowState{
+				settings: config.Settings{Model: "gpt-5.6-sol"},
+				theme:    "dark",
+			})
+			steps := model.workflow.visibleSteps(&model.state)
+			modelStepIndex := -1
+			for index, step := range steps {
+				if step.id == "model" {
+					modelStepIndex = index
+					break
+				}
+			}
+			if modelStepIndex < 1 {
+				t.Fatalf("model input step index = %d, want non-initial input step", modelStepIndex)
+			}
+			model.stepIndex = modelStepIndex
+			model.syncScreen(true)
+			if model.currentScreen.Kind != onboardingScreenInput {
+				t.Fatalf("screen kind = %q, want input", model.currentScreen.Kind)
+			}
+
+			const input = "alpha beta gamma"
+			model.input = newSingleLineEditor(input)
+			initialCursor := tt.initialCursor(input)
+			model.input.SetCursor(byteOffsetForRuneCursor(input, initialCursor))
+			screenID := model.currentScreen.ID
+
+			next, _ := model.Update(tt.key)
+			updated := next.(*onboardingModel)
+			if got := updated.currentScreen.ID; got != screenID {
+				t.Fatalf("screen after %s = %q, want %q", tt.name, got, screenID)
+			}
+			if got := updated.input.Text(); got != input {
+				t.Fatalf("input after %s = %q, want %q", tt.name, got, input)
+			}
+			if got, want := runeOffsetForByteCursor(updated.input.Text(), updated.input.Cursor()), tt.wantCursor(input, initialCursor); got != want {
+				t.Fatalf("cursor after %s = %d, want %d", tt.name, got, want)
+			}
+		})
+	}
+}
+
 func TestOnboardingSpinnerTickDoesNotRescheduleOutsideLoadingOrFinalize(t *testing.T) {
 	model := newOnboardingModelForWorkspace(t.TempDir(), "", onboardingFlowState{theme: "dark"})
 	model.state.imports.pending = false

--- a/cli/app/onboarding_part2_test.go
+++ b/cli/app/onboarding_part2_test.go
@@ -148,6 +148,31 @@ func TestOnboardingEditorFieldDeleteCurrentLineUsesAppKeyAdapter(t *testing.T) {
 	}
 }
 
+func newOnboardingModelAtModelInput(t *testing.T) *onboardingModel {
+	t.Helper()
+	model := newOnboardingModelForWorkspace(t.TempDir(), "", onboardingFlowState{
+		settings: config.Settings{Model: "gpt-5.6-sol"},
+		theme:    "dark",
+	})
+	steps := model.workflow.visibleSteps(&model.state)
+	modelStepIndex := -1
+	for index, step := range steps {
+		if step.id == "model" {
+			modelStepIndex = index
+			break
+		}
+	}
+	if modelStepIndex < 1 {
+		t.Fatalf("model input step index = %d, want non-initial input step", modelStepIndex)
+	}
+	model.stepIndex = modelStepIndex
+	model.syncScreen(true)
+	if model.currentScreen.Kind != onboardingScreenInput {
+		t.Fatalf("screen kind = %q, want input", model.currentScreen.Kind)
+	}
+	return model
+}
+
 func TestOnboardingInputWordNavigationStaysInField(t *testing.T) {
 	cases := []struct {
 		name          string
@@ -183,27 +208,7 @@ func TestOnboardingInputWordNavigationStaysInField(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			model := newOnboardingModelForWorkspace(t.TempDir(), "", onboardingFlowState{
-				settings: config.Settings{Model: "gpt-5.6-sol"},
-				theme:    "dark",
-			})
-			steps := model.workflow.visibleSteps(&model.state)
-			modelStepIndex := -1
-			for index, step := range steps {
-				if step.id == "model" {
-					modelStepIndex = index
-					break
-				}
-			}
-			if modelStepIndex < 1 {
-				t.Fatalf("model input step index = %d, want non-initial input step", modelStepIndex)
-			}
-			model.stepIndex = modelStepIndex
-			model.syncScreen(true)
-			if model.currentScreen.Kind != onboardingScreenInput {
-				t.Fatalf("screen kind = %q, want input", model.currentScreen.Kind)
-			}
-
+			model := newOnboardingModelAtModelInput(t)
 			const input = "alpha beta gamma"
 			model.input = newSingleLineEditor(input)
 			initialCursor := tt.initialCursor(input)
@@ -220,6 +225,29 @@ func TestOnboardingInputWordNavigationStaysInField(t *testing.T) {
 			}
 			if got, want := runeOffsetForByteCursor(updated.input.Text(), updated.input.Cursor()), tt.wantCursor(input, initialCursor); got != want {
 				t.Fatalf("cursor after %s = %d, want %d", tt.name, got, want)
+			}
+		})
+	}
+}
+
+func TestOnboardingInputPlainArrowsKeepStepNavigation(t *testing.T) {
+	cases := []struct {
+		name      string
+		key       tea.KeyMsg
+		stepDelta int
+	}{
+		{name: "left", key: tea.KeyMsg{Type: tea.KeyLeft}, stepDelta: -1},
+		{name: "right", key: tea.KeyMsg{Type: tea.KeyRight}, stepDelta: 1},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			model := newOnboardingModelAtModelInput(t)
+			initialStepIndex := model.stepIndex
+
+			next, _ := model.Update(tt.key)
+			updated := next.(*onboardingModel)
+			if got, want := updated.stepIndex, initialStepIndex+tt.stepDelta; got != want {
+				t.Fatalf("step index after plain %s = %d, want %d", tt.name, got, want)
 			}
 		})
 	}

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -139,6 +139,22 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}, runtime.GOOS) {
 		return m, nil
 	}
+	if m.ask.freeform && handleSharedInputMovementKey(msg, uiSharedInputMovementActions{
+		MoveLeft: func() {
+			m.ask.inputCursor = moveBufferCursorLeft(m.ask.input, m.ask.inputCursor)
+		},
+		MoveRight: func() {
+			m.ask.inputCursor = moveBufferCursorRight(m.ask.input, m.ask.inputCursor)
+		},
+		MoveWordLeft: func() {
+			m.ask.inputCursor = moveBufferCursorWordLeft(m.ask.input, m.ask.inputCursor)
+		},
+		MoveWordRight: func() {
+			m.ask.inputCursor = moveBufferCursorWordRight(m.ask.input, m.ask.inputCursor)
+		},
+	}) {
+		return m, nil
+	}
 
 	switch msg.Type {
 	case tea.KeyCtrlC:
@@ -289,26 +305,6 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.insertAskInputRunes([]rune{' '})
 		}
 		return m, nil
-	case tea.KeyLeft:
-		if !m.ask.freeform {
-			return m, nil
-		}
-		if msg.Alt {
-			m.ask.inputCursor = moveBufferCursorWordLeft(m.ask.input, m.ask.inputCursor)
-			return m, nil
-		}
-		m.ask.inputCursor = moveBufferCursorLeft(m.ask.input, m.ask.inputCursor)
-		return m, nil
-	case tea.KeyRight:
-		if !m.ask.freeform {
-			return m, nil
-		}
-		if msg.Alt {
-			m.ask.inputCursor = moveBufferCursorWordRight(m.ask.input, m.ask.inputCursor)
-			return m, nil
-		}
-		m.ask.inputCursor = moveBufferCursorRight(m.ask.input, m.ask.inputCursor)
-		return m, nil
 	case tea.KeyHome, tea.KeyCtrlA:
 		if m.ask.freeform {
 			m.ask.inputCursor = 0
@@ -317,16 +313,6 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyEnd, tea.KeyCtrlE, tea.KeyCtrlEnd:
 		if m.ask.freeform {
 			m.ask.inputCursor = -1
-		}
-		return m, nil
-	case tea.KeyCtrlLeft:
-		if m.ask.freeform {
-			m.ask.inputCursor = moveBufferCursorWordLeft(m.ask.input, m.ask.inputCursor)
-		}
-		return m, nil
-	case tea.KeyCtrlRight:
-		if m.ask.freeform {
-			m.ask.inputCursor = moveBufferCursorWordRight(m.ask.input, m.ask.inputCursor)
 		}
 		return m, nil
 	default:

--- a/cli/app/ui_input_controller_keys.go
+++ b/cli/app/ui_input_controller_keys.go
@@ -134,6 +134,14 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if isClipboardImagePasteKey(msg) {
 		return m, m.pasteClipboardImageCmd(uiClipboardPasteTargetMain)
 	}
+	if handleSharedInputMovementKey(msg, uiSharedInputMovementActions{
+		MoveLeft:      m.moveCursorLeft,
+		MoveRight:     m.moveCursorRight,
+		MoveWordLeft:  m.moveCursorWordLeft,
+		MoveWordRight: m.moveCursorWordRight,
+	}) {
+		return m, nil
+	}
 
 	switch msg.Type {
 	case tea.KeyCtrlC:
@@ -214,31 +222,11 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeySpace:
 		m.insertInputRunes([]rune{' '})
 		return m, nil
-	case tea.KeyLeft:
-		if msg.Alt {
-			m.moveCursorWordLeft()
-			return m, nil
-		}
-		m.moveCursorLeft()
-		return m, nil
-	case tea.KeyRight:
-		if msg.Alt {
-			m.moveCursorWordRight()
-			return m, nil
-		}
-		m.moveCursorRight()
-		return m, nil
 	case tea.KeyHome, tea.KeyCtrlA:
 		m.moveCursorStart()
 		return m, nil
 	case tea.KeyEnd, tea.KeyCtrlE, tea.KeyCtrlEnd:
 		m.moveCursorEnd()
-		return m, nil
-	case tea.KeyCtrlLeft:
-		m.moveCursorWordLeft()
-		return m, nil
-	case tea.KeyCtrlRight:
-		m.moveCursorWordRight()
 		return m, nil
 	case tea.KeyUp:
 		m.moveCursorUpLine()

--- a/cli/app/ui_input_movement_keys.go
+++ b/cli/app/ui_input_movement_keys.go
@@ -1,0 +1,57 @@
+package app
+
+import tea "github.com/charmbracelet/bubbletea"
+
+type uiSharedInputMovementActions struct {
+	MoveLeft      func()
+	MoveRight     func()
+	MoveWordLeft  func()
+	MoveWordRight func()
+}
+
+func handleSharedInputMovementKey(msg tea.KeyMsg, actions uiSharedInputMovementActions) bool {
+	switch msg.Type {
+	case tea.KeyLeft:
+		if msg.Alt {
+			runInputMovementAction(actions.MoveWordLeft)
+		} else {
+			runInputMovementAction(actions.MoveLeft)
+		}
+		return true
+	case tea.KeyRight:
+		if msg.Alt {
+			runInputMovementAction(actions.MoveWordRight)
+		} else {
+			runInputMovementAction(actions.MoveRight)
+		}
+		return true
+	case tea.KeyCtrlLeft:
+		runInputMovementAction(actions.MoveWordLeft)
+		return true
+	case tea.KeyCtrlRight:
+		runInputMovementAction(actions.MoveWordRight)
+		return true
+	case tea.KeyRunes:
+		if !msg.Alt || len(msg.Runes) != 1 {
+			return false
+		}
+		switch msg.Runes[0] {
+		case 'b':
+			runInputMovementAction(actions.MoveWordLeft)
+			return true
+		case 'f':
+			runInputMovementAction(actions.MoveWordRight)
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}
+
+func runInputMovementAction(action func()) {
+	if action != nil {
+		action()
+	}
+}

--- a/cli/app/ui_input_movement_keys_test.go
+++ b/cli/app/ui_input_movement_keys_test.go
@@ -1,0 +1,148 @@
+package app
+
+import (
+	"slices"
+	"testing"
+
+	"core/shared/clientui"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestSharedInputMovementKeyMapsNavigationAliases(t *testing.T) {
+	cases := []struct {
+		name   string
+		key    tea.KeyMsg
+		action string
+	}{
+		{name: "left", key: tea.KeyMsg{Type: tea.KeyLeft}, action: "left"},
+		{name: "right", key: tea.KeyMsg{Type: tea.KeyRight}, action: "right"},
+		{name: "alt-left", key: tea.KeyMsg{Type: tea.KeyLeft, Alt: true}, action: "word-left"},
+		{name: "alt-right", key: tea.KeyMsg{Type: tea.KeyRight, Alt: true}, action: "word-right"},
+		{name: "ctrl-left", key: tea.KeyMsg{Type: tea.KeyCtrlLeft}, action: "word-left"},
+		{name: "ctrl-right", key: tea.KeyMsg{Type: tea.KeyCtrlRight}, action: "word-right"},
+		{name: "alt-b", key: tea.KeyMsg{Type: tea.KeyRunes, Alt: true, Runes: []rune{'b'}}, action: "word-left"},
+		{name: "alt-f", key: tea.KeyMsg{Type: tea.KeyRunes, Alt: true, Runes: []rune{'f'}}, action: "word-right"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var actions []string
+			handled := handleSharedInputMovementKey(tt.key, uiSharedInputMovementActions{
+				MoveLeft:      func() { actions = append(actions, "left") },
+				MoveRight:     func() { actions = append(actions, "right") },
+				MoveWordLeft:  func() { actions = append(actions, "word-left") },
+				MoveWordRight: func() { actions = append(actions, "word-right") },
+			})
+			if !handled {
+				t.Fatal("expected movement key to be handled")
+			}
+			if got, want := actions, []string{tt.action}; !slices.Equal(got, want) {
+				t.Fatalf("actions = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestSharedInputMovementKeyPreservesOtherRuneInput(t *testing.T) {
+	cases := []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune{'b'}},
+		{Type: tea.KeyRunes, Runes: []rune{'f'}},
+		{Type: tea.KeyRunes, Alt: true, Runes: []rune("bf")},
+		{Type: tea.KeyRunes, Alt: true, Runes: []rune{'x'}},
+	}
+	for _, key := range cases {
+		if handleSharedInputMovementKey(key, uiSharedInputMovementActions{}) {
+			t.Fatalf("unexpectedly handled %q", key.String())
+		}
+	}
+}
+
+func TestMainComposerAltRuneWordNavigation(t *testing.T) {
+	model := newProjectedStaticUIModel()
+	model.input = "alpha beta gamma"
+	model.inputCursor = len([]rune(model.input))
+
+	updated := updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Alt: true, Runes: []rune{'b'}})
+	if got, want := updated.input, "alpha beta gamma"; got != want {
+		t.Fatalf("input after alt+b = %q, want %q", got, want)
+	}
+	if got, want := updated.inputCursor, moveBufferCursorWordLeft(updated.input, len([]rune(updated.input))); got != want {
+		t.Fatalf("cursor after alt+b = %d, want %d", got, want)
+	}
+
+	updated = updateUIModel(t, updated, tea.KeyMsg{Type: tea.KeyRunes, Alt: true, Runes: []rune{'f'}})
+	if got, want := updated.input, "alpha beta gamma"; got != want {
+		t.Fatalf("input after alt+f = %q, want %q", got, want)
+	}
+	if got, want := updated.inputCursor, len([]rune(updated.input)); got != want {
+		t.Fatalf("cursor after alt+f = %d, want %d", got, want)
+	}
+}
+
+func TestMainComposerPreservesOtherRuneInput(t *testing.T) {
+	cases := []struct {
+		name string
+		key  tea.KeyMsg
+		want string
+	}{
+		{name: "plain-b", key: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}}, want: "b"},
+		{name: "plain-f", key: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}}, want: "f"},
+		{name: "alt-multi-rune", key: tea.KeyMsg{Type: tea.KeyRunes, Alt: true, Runes: []rune("bf")}, want: "bf"},
+		{name: "unrelated-alt-rune", key: tea.KeyMsg{Type: tea.KeyRunes, Alt: true, Runes: []rune{'x'}}, want: "x"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			updated := updateUIModel(t, newProjectedStaticUIModel(), tt.key)
+			if got := updated.input; got != tt.want {
+				t.Fatalf("input = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAskFreeformAltRuneWordNavigation(t *testing.T) {
+	model := newProjectedStaticUIModel()
+	reply := make(chan askReply, 1)
+	event := askEvent{req: clientui.PendingPromptEvent{Question: "Type answer"}, reply: reply}
+	updated := updateUIModel(t, model, askEventMsg{event: event})
+	updated.ask.input = "alpha beta gamma"
+	updated.ask.inputCursor = len([]rune(updated.ask.input))
+
+	updated = updateUIModel(t, updated, tea.KeyMsg{Type: tea.KeyRunes, Alt: true, Runes: []rune{'b'}})
+	if got, want := updated.ask.input, "alpha beta gamma"; got != want {
+		t.Fatalf("ask input after alt+b = %q, want %q", got, want)
+	}
+	if got, want := updated.ask.inputCursor, moveBufferCursorWordLeft(updated.ask.input, len([]rune(updated.ask.input))); got != want {
+		t.Fatalf("ask cursor after alt+b = %d, want %d", got, want)
+	}
+
+	updated = updateUIModel(t, updated, tea.KeyMsg{Type: tea.KeyRunes, Alt: true, Runes: []rune{'f'}})
+	if got, want := updated.ask.input, "alpha beta gamma"; got != want {
+		t.Fatalf("ask input after alt+f = %q, want %q", got, want)
+	}
+	if got, want := updated.ask.inputCursor, len([]rune(updated.ask.input)); got != want {
+		t.Fatalf("ask cursor after alt+f = %d, want %d", got, want)
+	}
+}
+
+func TestSingleLineEditorAltRuneWordNavigation(t *testing.T) {
+	editor := newSingleLineEditor("alpha beta gamma")
+	editor.SetCursor(len(editor.Text()))
+
+	updateSingleLineEditorWithAppKeys(&editor, tea.KeyMsg{Type: tea.KeyRunes, Alt: true, Runes: []rune{'b'}})
+	if got, want := editor.Text(), "alpha beta gamma"; got != want {
+		t.Fatalf("editor text after alt+b = %q, want %q", got, want)
+	}
+	if got, want := editor.Cursor(), byteOffsetForRuneCursor(editor.Text(), moveBufferCursorWordLeft(editor.Text(), len([]rune(editor.Text())))); got != want {
+		t.Fatalf("editor cursor after alt+b = %d, want %d", got, want)
+	}
+
+	updateSingleLineEditorWithAppKeys(&editor, tea.KeyMsg{Type: tea.KeyRunes, Alt: true, Runes: []rune{'f'}})
+	if got, want := editor.Text(), "alpha beta gamma"; got != want {
+		t.Fatalf("editor text after alt+f = %q, want %q", got, want)
+	}
+	if got, want := editor.Cursor(), len(editor.Text()); got != want {
+		t.Fatalf("editor cursor after alt+f = %d, want %d", got, want)
+	}
+}

--- a/cli/app/ui_text_editor.go
+++ b/cli/app/ui_text_editor.go
@@ -100,32 +100,32 @@ func updateSingleLineEditorWithAppKeys(editor *tuiinput.Editor, msg tea.Msg) tea
 	}, runtime.GOOS) {
 		return nil
 	}
+	if handleSharedInputMovementKey(key, uiSharedInputMovementActions{
+		MoveLeft: func() {
+			editor.SetCursor(byteOffsetForRuneCursor(text, moveBufferCursorLeft(text, cursor)))
+		},
+		MoveRight: func() {
+			editor.SetCursor(byteOffsetForRuneCursor(text, moveBufferCursorRight(text, cursor)))
+		},
+		MoveWordLeft: func() {
+			editor.SetCursor(byteOffsetForRuneCursor(text, moveBufferCursorWordLeft(text, cursor)))
+		},
+		MoveWordRight: func() {
+			editor.SetCursor(byteOffsetForRuneCursor(text, moveBufferCursorWordRight(text, cursor)))
+		},
+	}) {
+		return nil
+	}
 	switch key.Type {
 	case tea.KeySpace:
 		updated, nextCursor, changed := insertBufferRunes(text, cursor, []rune{' '})
 		if changed {
 			apply(updated, nextCursor, killBuffer)
 		}
-	case tea.KeyLeft:
-		if key.Alt {
-			editor.SetCursor(byteOffsetForRuneCursor(editor.Text(), moveBufferCursorWordLeft(text, cursor)))
-		} else {
-			editor.SetCursor(byteOffsetForRuneCursor(editor.Text(), moveBufferCursorLeft(text, cursor)))
-		}
-	case tea.KeyRight:
-		if key.Alt {
-			editor.SetCursor(byteOffsetForRuneCursor(editor.Text(), moveBufferCursorWordRight(text, cursor)))
-		} else {
-			editor.SetCursor(byteOffsetForRuneCursor(editor.Text(), moveBufferCursorRight(text, cursor)))
-		}
 	case tea.KeyHome, tea.KeyCtrlA:
 		editor.SetCursor(byteOffsetForRuneCursor(editor.Text(), 0))
 	case tea.KeyEnd, tea.KeyCtrlE, tea.KeyCtrlEnd:
 		editor.SetCursor(len(editor.Text()))
-	case tea.KeyCtrlLeft:
-		editor.SetCursor(byteOffsetForRuneCursor(editor.Text(), moveBufferCursorWordLeft(text, cursor)))
-	case tea.KeyCtrlRight:
-		editor.SetCursor(byteOffsetForRuneCursor(editor.Text(), moveBufferCursorWordRight(text, cursor)))
 	case tea.KeyRunes:
 		updated, nextCursor, changed := insertBufferRunes(text, cursor, singleLineRunes(key.Runes))
 		if changed {

--- a/docs/dev/specs/tui-chat-core.md
+++ b/docs/dev/specs/tui-chat-core.md
@@ -14,7 +14,7 @@ Bullets marked (owner: …) restate decisions owned by another spec for one-plac
 
 ## Editing Model
 
-- Movement: `Left`/`Right` by grapheme cluster; `Ctrl+Left`/`Ctrl+Right` by word; `Home`/`Ctrl+A` to line start; `End`/`Ctrl+E`/`Ctrl+End` to line end. `Up`/`Down` move across wrapped/multiline content when the cursor is not at a whole-buffer boundary (boundary behavior is prompt history, below).
+- Movement: `Left`/`Right` by grapheme cluster; `Ctrl+Left`/`Ctrl+Right` and `Option+Left`/`Option+Right` by word; `Home`/`Ctrl+A` to line start; `End`/`Ctrl+E`/`Ctrl+End` to line end. At the typed terminal-input boundary, an Alt-modified single-rune `b`/`f` event is a compatibility encoding for previous-word/next-word movement rather than inserted text. `Up`/`Down` move across wrapped/multiline content when the cursor is not at a whole-buffer boundary (boundary behavior is prompt history, below).
 - Deletion: `Backspace`/`Ctrl+H` deletes backward; `Delete` deletes forward; `Ctrl+W` deletes the previous word.
 - Kill/yank: `Ctrl+K` kills to line end; `Ctrl+U` kills to line start (macOS: `Ctrl+U` deletes the current line); `Ctrl+Y` yanks the last killed text. One editor-local kill buffer.
 - `Shift+Enter` inserts a newline; known Shift+Enter/Ctrl+Enter CSI encodings normalize to their canonical actions (owner: tui-transcript :: Input And Queueing). `Ctrl+J` always inserts a newline as a universal fallback. Shift+Enter recognition follows the codex reference implementation; the Go TUI's recognition is known-broken drift.


### PR DESCRIPTION
## Summary
- Normalize exact Alt+b/Alt+f compatibility events with Option-arrow and Ctrl-arrow word movement across text-entry surfaces.
- Keep onboarding Left/Right in the reusable editor so Option-arrow navigation cannot leave or submit an input step.
- Record the approved editing-model contract and add regression coverage for composer, freeform ask, reusable fields, and onboarding.

## Verification
- `./scripts/test.sh server ./cli/app -count=1`
- `./scripts/test.sh tui`
- `go vet ./cli/app`
- `./scripts/tui-qa.sh --client ./bin/kent`
- `./scripts/build.sh --output ./bin/kent`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved left/right cursor navigation while entering onboarding responses.
  - Prevented navigation shortcuts from leaving the current input field.
  - Standardized character and word movement across prompts, editors, and composer inputs.
  - Preserved typed text when using word-navigation shortcuts.

- **Documentation**
  - Clarified terminal key behavior for previous- and next-word navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->