### PR TITLE
refactor!: remove Windows legacy service migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,9 +148,6 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Test Windows service package
-        run: go test ./cli/kent
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.9
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,9 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Test Windows service package
+        run: go test ./cli/kent
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.9
         with:

--- a/cli/kent/service_backend_windows.go
+++ b/cli/kent/service_backend_windows.go
@@ -30,11 +30,10 @@ func (scmServiceBackend) Name() string {
 
 var serviceRecoveryResetPeriod = uint32((24 * time.Hour).Seconds())
 
-func (scmServiceBackend) Install(ctx context.Context, spec serviceSpec, force bool, start bool) error {
+func (scmServiceBackend) Install(_ context.Context, spec serviceSpec, force bool, start bool) error {
 	if err := ensureServiceLogDir(spec); err != nil {
 		return err
 	}
-	removeLegacyWindowsRegistration(ctx, spec)
 
 	m, err := mgr.Connect()
 	if err != nil {
@@ -105,7 +104,7 @@ func configureCreatedService(service *mgr.Service, spec serviceSpec) error {
 	return nil
 }
 
-func (scmServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop bool) error {
+func (scmServiceBackend) Uninstall(_ context.Context, spec serviceSpec, stop bool) error {
 	m, err := mgr.Connect()
 	if err != nil {
 		return fmt.Errorf("connect to the service manager (uninstalling requires Administrator): %w", err)
@@ -117,28 +116,18 @@ func (scmServiceBackend) Uninstall(ctx context.Context, spec serviceSpec, stop b
 		if !errors.Is(err, windows.ERROR_SERVICE_DOES_NOT_EXIST) {
 			return fmt.Errorf("open service: %w", err)
 		}
+	} else {
+		defer func() { _ = service.Close() }()
 		if stop {
-			endLegacyWindowsTask(ctx)
+			if err := stopServiceAndWait(service); err != nil {
+				return fmt.Errorf("stop service before uninstall: %w", err)
+			}
 		}
-		removeLegacyWindowsRegistration(ctx, spec)
-		_ = os.Remove(windowsServerPIDPath(spec))
-		return nil
-	}
-	defer func() { _ = service.Close() }()
-
-	if stop {
-		if err := stopServiceAndWait(service); err != nil {
-			return fmt.Errorf("stop service before uninstall: %w", err)
+		if err := service.Delete(); err != nil {
+			return fmt.Errorf("delete service: %w", err)
 		}
-		endLegacyWindowsTask(ctx)
 	}
-	if err := service.Delete(); err != nil {
-		return fmt.Errorf("delete service: %w", err)
-	}
-	removeLegacyWindowsRegistration(ctx, spec)
-	_ = os.Remove(windowsServerPIDPath(spec))
-	_ = os.Remove(installUserSIDPath(spec))
-	return nil
+	return removeWindowsRuntimeMetadata(spec)
 }
 
 func (scmServiceBackend) Start(ctx context.Context, spec serviceSpec) error {
@@ -230,6 +219,24 @@ func readWindowsServerPID(spec serviceSpec) int {
 
 func installUserSIDPath(spec serviceSpec) string {
 	return filepath.Join(windowsServiceDir(spec), "install_user.sid")
+}
+
+func removeWindowsRuntimeMetadata(spec serviceSpec) error {
+	type metadataFile struct {
+		name string
+		path string
+	}
+	files := []metadataFile{
+		{name: "server PID", path: windowsServerPIDPath(spec)},
+		{name: "install user SID", path: installUserSIDPath(spec)},
+	}
+	errs := make([]error, 0, len(files))
+	for _, file := range files {
+		if err := os.Remove(file.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			errs = append(errs, fmt.Errorf("remove %s metadata: %w", file.name, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func persistInstallUser(spec serviceSpec) error {
@@ -426,26 +433,4 @@ func waitForServiceAbsent(m *mgr.Mgr, timeout time.Duration) error {
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
-}
-
-func (scmServiceBackend) stopLegacyServer(ctx context.Context, spec serviceSpec) {
-	endLegacyWindowsTask(ctx)
-}
-
-func endLegacyWindowsTask(ctx context.Context) {
-	_, _ = runServiceCommand(ctx, "schtasks", "/End", "/TN", serviceWindowsTaskName)
-}
-
-func removeLegacyWindowsRegistration(ctx context.Context, spec serviceSpec) {
-	_, _ = runServiceCommand(ctx, "schtasks", "/Delete", "/F", "/TN", serviceWindowsTaskName)
-	_ = os.Remove(legacyWindowsStartupItemPath())
-	_ = os.Remove(filepath.Join(windowsServiceDir(spec), "server.cmd"))
-}
-
-func legacyWindowsStartupItemPath() string {
-	base := strings.TrimSpace(os.Getenv("APPDATA"))
-	if base == "" {
-		base = filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Roaming")
-	}
-	return filepath.Join(base, "Microsoft", "Windows", "Start Menu", "Programs", "Startup", serviceWindowsTaskName+".cmd")
 }

--- a/cli/kent/service_backend_windows_test.go
+++ b/cli/kent/service_backend_windows_test.go
@@ -3,8 +3,6 @@
 package main
 
 import (
-	"errors"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -33,116 +31,5 @@ func TestWindowsServerPIDPathUnderServiceDir(t *testing.T) {
 	want := filepath.Join(`C:\Roots\kent`, "service", "server.pid")
 	if got != want {
 		t.Fatalf("windowsServerPIDPath = %q, want %q", got, want)
-	}
-}
-
-func TestRemoveWindowsRuntimeMetadata(t *testing.T) {
-	t.Run("removes both files", func(t *testing.T) {
-		spec := windowsMetadataTestSpec(t)
-		writeWindowsMetadataFile(t, windowsServerPIDPath(spec))
-		writeWindowsMetadataFile(t, installUserSIDPath(spec))
-
-		if err := removeWindowsRuntimeMetadata(spec); err != nil {
-			t.Fatalf("removeWindowsRuntimeMetadata: %v", err)
-		}
-		assertWindowsMetadataAbsent(t, windowsServerPIDPath(spec))
-		assertWindowsMetadataAbsent(t, installUserSIDPath(spec))
-	})
-
-	for _, metadataPath := range []struct {
-		name string
-		path func(serviceSpec) string
-	}{
-		{name: "server PID absent", path: windowsServerPIDPath},
-		{name: "install user SID absent", path: installUserSIDPath},
-	} {
-		t.Run(metadataPath.name, func(t *testing.T) {
-			spec := windowsMetadataTestSpec(t)
-			paths := []string{windowsServerPIDPath(spec), installUserSIDPath(spec)}
-			for _, path := range paths {
-				if path != metadataPath.path(spec) {
-					writeWindowsMetadataFile(t, path)
-				}
-			}
-
-			if err := removeWindowsRuntimeMetadata(spec); err != nil {
-				t.Fatalf("removeWindowsRuntimeMetadata: %v", err)
-			}
-			for _, path := range paths {
-				assertWindowsMetadataAbsent(t, path)
-			}
-		})
-	}
-
-	t.Run("non-removable server PID still removes install user SID", func(t *testing.T) {
-		spec := windowsMetadataTestSpec(t)
-		createNonEmptyWindowsMetadataDirectory(t, windowsServerPIDPath(spec))
-		writeWindowsMetadataFile(t, installUserSIDPath(spec))
-
-		if err := removeWindowsRuntimeMetadata(spec); err == nil {
-			t.Fatal("expected metadata cleanup error")
-		}
-		assertWindowsMetadataAbsent(t, installUserSIDPath(spec))
-	})
-
-	t.Run("non-removable install user SID still removes server PID", func(t *testing.T) {
-		spec := windowsMetadataTestSpec(t)
-		writeWindowsMetadataFile(t, windowsServerPIDPath(spec))
-		createNonEmptyWindowsMetadataDirectory(t, installUserSIDPath(spec))
-
-		if err := removeWindowsRuntimeMetadata(spec); err == nil {
-			t.Fatal("expected metadata cleanup error")
-		}
-		assertWindowsMetadataAbsent(t, windowsServerPIDPath(spec))
-	})
-
-	t.Run("joins simultaneous removal failures", func(t *testing.T) {
-		spec := windowsMetadataTestSpec(t)
-		createNonEmptyWindowsMetadataDirectory(t, windowsServerPIDPath(spec))
-		createNonEmptyWindowsMetadataDirectory(t, installUserSIDPath(spec))
-
-		err := removeWindowsRuntimeMetadata(spec)
-		if err == nil {
-			t.Fatal("expected metadata cleanup error")
-		}
-		joined, ok := err.(interface{ Unwrap() []error })
-		if !ok {
-			t.Fatalf("error %T does not expose joined failures", err)
-		}
-		if len(joined.Unwrap()) != 2 {
-			t.Fatalf("joined failures = %d, want 2", len(joined.Unwrap()))
-		}
-	})
-}
-
-func windowsMetadataTestSpec(t *testing.T) serviceSpec {
-	t.Helper()
-	return serviceSpec{Config: config.App{PersistenceRoot: t.TempDir()}}
-}
-
-func writeWindowsMetadataFile(t *testing.T, path string) {
-	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("create metadata directory: %v", err)
-	}
-	if err := os.WriteFile(path, []byte("metadata"), 0o644); err != nil {
-		t.Fatalf("write metadata file: %v", err)
-	}
-}
-
-func createNonEmptyWindowsMetadataDirectory(t *testing.T, path string) {
-	t.Helper()
-	if err := os.MkdirAll(path, 0o755); err != nil {
-		t.Fatalf("create non-empty metadata directory: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(path, "entry"), []byte("metadata"), 0o644); err != nil {
-		t.Fatalf("write non-empty metadata directory entry: %v", err)
-	}
-}
-
-func assertWindowsMetadataAbsent(t *testing.T, path string) {
-	t.Helper()
-	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("metadata path %q stat error = %v, want not exist", path, err)
 	}
 }

--- a/cli/kent/service_backend_windows_test.go
+++ b/cli/kent/service_backend_windows_test.go
@@ -3,281 +3,146 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"core/shared/config"
 )
 
-func TestWindowsInstallWithoutForceRejectsExistingDifferentScript(t *testing.T) {
-	spec := windowsServiceTestSpec(t)
-	if err := os.MkdirAll(filepath.Dir(windowsTaskScriptPath(spec)), 0o755); err != nil {
-		t.Fatalf("mkdir task script dir: %v", err)
-	}
-	if err := os.WriteFile(windowsTaskScriptPath(spec), []byte("old script"), 0o644); err != nil {
-		t.Fatalf("write existing task script: %v", err)
-	}
-	calls := captureWindowsServiceCommands(t, func(context.Context, string, ...string) (serviceCommandResult, error) {
-		return serviceCommandResult{}, errors.New("unexpected command")
-	})
-
-	err := (scheduledTaskServiceBackend{}).Install(context.Background(), spec, false, false)
-	if err == nil {
-		t.Fatal("expected existing script rejection")
-	}
-	if string(mustReadFile(t, windowsTaskScriptPath(spec))) != "old script" {
-		t.Fatal("expected existing script to remain unchanged")
-	}
-	if len(calls.commands()) != 0 {
-		t.Fatalf("commands = %+v, want none", calls.commands())
+func TestWindowsServiceRunArgumentsBakesRoot(t *testing.T) {
+	got := windowsServiceRunArguments(`C:\Roots\kent`)
+	want := []string{"service", "run", "--persistence-root", `C:\Roots\kent`}
+	if !commandArgsEqual(got, want) {
+		t.Fatalf("windowsServiceRunArguments = %#v, want %#v", got, want)
 	}
 }
 
-func TestWindowsInstallRewritesOrphanScriptAndRegistersTask(t *testing.T) {
-	spec := windowsServiceTestSpec(t)
-	if err := os.MkdirAll(filepath.Dir(windowsTaskScriptPath(spec)), 0o755); err != nil {
-		t.Fatalf("mkdir task script dir: %v", err)
-	}
-	if err := os.WriteFile(windowsTaskScriptPath(spec), []byte("old script"), 0o644); err != nil {
-		t.Fatalf("write existing task script: %v", err)
-	}
-	calls := captureWindowsServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
-		if name != "schtasks" {
-			return serviceCommandResult{}, errors.New("unexpected command")
-		}
-		if len(args) > 0 && args[0] == "/Query" {
-			return serviceCommandResult{}, errors.New("task missing")
-		}
-		return serviceCommandResult{}, nil
-	})
-
-	if err := (scheduledTaskServiceBackend{}).Install(context.Background(), spec, false, false); err != nil {
-		t.Fatalf("install with orphan script: %v", err)
-	}
-	if string(mustReadFile(t, windowsTaskScriptPath(spec))) == "old script" {
-		t.Fatal("expected orphan script to be rewritten")
-	}
-	if !calls.saw("schtasks", "/Create") {
-		t.Fatalf("commands = %+v, want scheduled task registration", calls.commands())
+func TestWindowsServiceRunArgumentsOmitsEmptyRoot(t *testing.T) {
+	got := windowsServiceRunArguments("   ")
+	want := []string{"service", "run"}
+	if !commandArgsEqual(got, want) {
+		t.Fatalf("windowsServiceRunArguments = %#v, want %#v", got, want)
 	}
 }
 
-func TestWindowsInstallRemovesStartupFallbackAfterScheduledTaskRegistration(t *testing.T) {
-	spec := windowsServiceTestSpec(t)
-	if err := os.MkdirAll(filepath.Dir(windowsStartupItemPath()), 0o755); err != nil {
-		t.Fatalf("mkdir startup dir: %v", err)
-	}
-	if err := os.WriteFile(windowsStartupItemPath(), []byte("fallback"), 0o644); err != nil {
-		t.Fatalf("write startup item: %v", err)
-	}
-	calls := captureWindowsServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
-		if name != "schtasks" {
-			return serviceCommandResult{}, errors.New("unexpected command")
-		}
-		if len(args) > 0 && args[0] == "/Query" {
-			return serviceCommandResult{}, errors.New("task missing")
-		}
-		return serviceCommandResult{}, nil
-	})
-
-	if err := (scheduledTaskServiceBackend{}).Install(context.Background(), spec, true, false); err != nil {
-		t.Fatalf("install: %v", err)
-	}
-	if _, err := os.Stat(windowsStartupItemPath()); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("startup fallback stat err = %v, want not exist", err)
-	}
-	if !calls.saw("schtasks", "/Create") {
-		t.Fatalf("commands = %+v, want scheduled task registration before fallback removal", calls.commands())
+func TestWindowsServerPIDPathUnderServiceDir(t *testing.T) {
+	spec := serviceSpec{Config: config.App{PersistenceRoot: `C:\Roots\kent`}}
+	got := windowsServerPIDPath(spec)
+	want := filepath.Join(`C:\Roots\kent`, "service", "server.pid")
+	if got != want {
+		t.Fatalf("windowsServerPIDPath = %q, want %q", got, want)
 	}
 }
 
-func TestWindowsStopStartupFallbackKillsTaskScriptProcess(t *testing.T) {
-	spec := windowsServiceTestSpec(t)
-	if err := os.MkdirAll(filepath.Dir(windowsStartupItemPath()), 0o755); err != nil {
-		t.Fatalf("mkdir startup dir: %v", err)
-	}
-	if err := os.WriteFile(windowsStartupItemPath(), []byte("launcher"), 0o644); err != nil {
-		t.Fatalf("write startup item: %v", err)
-	}
-	calls := captureWindowsServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
-		switch name {
-		case "schtasks":
-			return serviceCommandResult{}, errors.New("task missing")
-		case "powershell":
-			return serviceCommandResult{Stdout: "123\r\n"}, nil
-		case "taskkill":
-			return serviceCommandResult{}, nil
-		default:
-			return serviceCommandResult{}, errors.New("unexpected command")
+func TestRemoveWindowsRuntimeMetadata(t *testing.T) {
+	t.Run("removes both files", func(t *testing.T) {
+		spec := windowsMetadataTestSpec(t)
+		writeWindowsMetadataFile(t, windowsServerPIDPath(spec))
+		writeWindowsMetadataFile(t, installUserSIDPath(spec))
+
+		if err := removeWindowsRuntimeMetadata(spec); err != nil {
+			t.Fatalf("removeWindowsRuntimeMetadata: %v", err)
 		}
+		assertWindowsMetadataAbsent(t, windowsServerPIDPath(spec))
+		assertWindowsMetadataAbsent(t, installUserSIDPath(spec))
 	})
 
-	if err := (scheduledTaskServiceBackend{}).Stop(context.Background(), spec); err != nil {
-		t.Fatalf("stop fallback: %v", err)
-	}
-	if !calls.sawAll("taskkill", "/T", "/F", "/PID", "123") {
-		t.Fatalf("commands = %+v, want taskkill for fallback script pid", calls.commands())
-	}
-}
-
-func TestWindowsStatusReportsRegisteredServerPID(t *testing.T) {
-	spec := windowsServiceTestSpec(t)
-	if err := os.MkdirAll(filepath.Dir(windowsTaskScriptPath(spec)), 0o755); err != nil {
-		t.Fatalf("mkdir task script dir: %v", err)
-	}
-	if err := os.WriteFile(windowsTaskScriptPath(spec), []byte(renderWindowsTaskScript(spec)), 0o644); err != nil {
-		t.Fatalf("write task script: %v", err)
-	}
-	captureWindowsServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
-		switch name {
-		case "schtasks":
-			return serviceCommandResult{Stdout: "Status: Running\r\n"}, nil
-		case "powershell":
-			script := strings.Join(args, " ")
-			if strings.Contains(script, windowsTaskScriptPath(spec)) {
-				return serviceCommandResult{Stdout: "111\r\n"}, nil
+	for _, metadataPath := range []struct {
+		name string
+		path func(serviceSpec) string
+	}{
+		{name: "server PID absent", path: windowsServerPIDPath},
+		{name: "install user SID absent", path: installUserSIDPath},
+	} {
+		t.Run(metadataPath.name, func(t *testing.T) {
+			spec := windowsMetadataTestSpec(t)
+			paths := []string{windowsServerPIDPath(spec), installUserSIDPath(spec)}
+			for _, path := range paths {
+				if path != metadataPath.path(spec) {
+					writeWindowsMetadataFile(t, path)
+				}
 			}
-			if strings.Contains(script, spec.Executable) {
-				return serviceCommandResult{Stdout: "222\r\n"}, nil
+
+			if err := removeWindowsRuntimeMetadata(spec); err != nil {
+				t.Fatalf("removeWindowsRuntimeMetadata: %v", err)
 			}
-			return serviceCommandResult{}, nil
-		default:
-			return serviceCommandResult{}, errors.New("unexpected command")
+			for _, path := range paths {
+				assertWindowsMetadataAbsent(t, path)
+			}
+		})
+	}
+
+	t.Run("non-removable server PID still removes install user SID", func(t *testing.T) {
+		spec := windowsMetadataTestSpec(t)
+		createNonEmptyWindowsMetadataDirectory(t, windowsServerPIDPath(spec))
+		writeWindowsMetadataFile(t, installUserSIDPath(spec))
+
+		if err := removeWindowsRuntimeMetadata(spec); err == nil {
+			t.Fatal("expected metadata cleanup error")
 		}
+		assertWindowsMetadataAbsent(t, installUserSIDPath(spec))
 	})
 
-	status, err := (scheduledTaskServiceBackend{}).Status(context.Background(), spec)
-	if err != nil {
-		t.Fatalf("status: %v", err)
-	}
-	if !status.Installed || !status.Running || status.PID != 222 {
-		t.Fatalf("status = %+v, want running service with registered server PID 222", status)
-	}
-}
+	t.Run("non-removable install user SID still removes server PID", func(t *testing.T) {
+		spec := windowsMetadataTestSpec(t)
+		writeWindowsMetadataFile(t, windowsServerPIDPath(spec))
+		createNonEmptyWindowsMetadataDirectory(t, installUserSIDPath(spec))
 
-func TestWindowsStatusDoesNotTreatBareServerProcessAsServiceRunning(t *testing.T) {
-	spec := windowsServiceTestSpec(t)
-	if err := os.MkdirAll(filepath.Dir(windowsTaskScriptPath(spec)), 0o755); err != nil {
-		t.Fatalf("mkdir task script dir: %v", err)
-	}
-	if err := os.WriteFile(windowsTaskScriptPath(spec), []byte(renderWindowsTaskScript(spec)), 0o644); err != nil {
-		t.Fatalf("write task script: %v", err)
-	}
-	captureWindowsServiceCommands(t, func(_ context.Context, name string, args ...string) (serviceCommandResult, error) {
-		switch name {
-		case "schtasks":
-			return serviceCommandResult{Stdout: "Status: Ready\r\n"}, nil
-		case "powershell":
-			script := strings.Join(args, " ")
-			if strings.Contains(script, windowsTaskScriptPath(spec)) {
-				return serviceCommandResult{}, nil
-			}
-			if strings.Contains(script, spec.Executable) {
-				return serviceCommandResult{Stdout: "222\r\n"}, nil
-			}
-			return serviceCommandResult{}, nil
-		default:
-			return serviceCommandResult{}, errors.New("unexpected command")
+		if err := removeWindowsRuntimeMetadata(spec); err == nil {
+			t.Fatal("expected metadata cleanup error")
 		}
+		assertWindowsMetadataAbsent(t, windowsServerPIDPath(spec))
 	})
 
-	status, err := (scheduledTaskServiceBackend{}).Status(context.Background(), spec)
-	if err != nil {
-		t.Fatalf("status: %v", err)
-	}
-	if status.Running || status.PID != 0 {
-		t.Fatalf("status running=%v pid=%d, want stopped with no service PID", status.Running, status.PID)
-	}
+	t.Run("joins simultaneous removal failures", func(t *testing.T) {
+		spec := windowsMetadataTestSpec(t)
+		createNonEmptyWindowsMetadataDirectory(t, windowsServerPIDPath(spec))
+		createNonEmptyWindowsMetadataDirectory(t, installUserSIDPath(spec))
+
+		err := removeWindowsRuntimeMetadata(spec)
+		if err == nil {
+			t.Fatal("expected metadata cleanup error")
+		}
+		joined, ok := err.(interface{ Unwrap() []error })
+		if !ok {
+			t.Fatalf("error %T does not expose joined failures", err)
+		}
+		if len(joined.Unwrap()) != 2 {
+			t.Fatalf("joined failures = %d, want 2", len(joined.Unwrap()))
+		}
+	})
 }
 
-func TestParseWindowsCommandLinePreservesPathBackslashes(t *testing.T) {
-	got := parseWindowsCommandLine(`"C:\Users\Nek\AppData\Local\Kent\kent.exe" serve`)
-	want := []string{`C:\Users\Nek\AppData\Local\Kent\kent.exe`, "serve"}
-	if !windowsStringSlicesEqual(got, want) {
-		t.Fatalf("parseWindowsCommandLine = %#v, want %#v", got, want)
-	}
-}
-
-func windowsServiceTestSpec(t *testing.T) serviceSpec {
+func windowsMetadataTestSpec(t *testing.T) serviceSpec {
 	t.Helper()
-	temp := t.TempDir()
-	t.Setenv("APPDATA", filepath.Join(temp, "AppData", "Roaming"))
-	return serviceSpec{
-		Config:        config.App{PersistenceRoot: filepath.Join(temp, config.ConfigDirName)},
-		Executable:    filepath.Join(temp, "kent.exe"),
-		Arguments:     []string{"serve"},
-		LogDir:        filepath.Join(temp, config.ConfigDirName, "logs"),
-		StdoutLogPath: filepath.Join(temp, config.ConfigDirName, "logs", "server.log"),
-		StderrLogPath: filepath.Join(temp, config.ConfigDirName, "logs", "server.err.log"),
-		Endpoint:      "http://127.0.0.1:53082",
-	}
+	return serviceSpec{Config: config.App{PersistenceRoot: t.TempDir()}}
 }
 
-type windowsCommandRecorder struct {
-	calls []serviceCommandInvocation
-}
-
-type serviceCommandInvocation struct {
-	Name string
-	Args []string
-}
-
-func captureWindowsServiceCommands(t *testing.T, fn func(context.Context, string, ...string) (serviceCommandResult, error)) *windowsCommandRecorder {
+func writeWindowsMetadataFile(t *testing.T, path string) {
 	t.Helper()
-	original := runServiceCommand
-	recorder := &windowsCommandRecorder{}
-	runServiceCommand = func(ctx context.Context, name string, args ...string) (serviceCommandResult, error) {
-		recorder.calls = append(recorder.calls, serviceCommandInvocation{Name: name, Args: append([]string(nil), args...)})
-		return fn(ctx, name, args...)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create metadata directory: %v", err)
 	}
-	t.Cleanup(func() { runServiceCommand = original })
-	return recorder
+	if err := os.WriteFile(path, []byte("metadata"), 0o644); err != nil {
+		t.Fatalf("write metadata file: %v", err)
+	}
 }
 
-func (r *windowsCommandRecorder) commands() []serviceCommandInvocation {
-	return append([]serviceCommandInvocation(nil), r.calls...)
-}
-
-func (r *windowsCommandRecorder) saw(name string, firstArg string) bool {
-	for _, call := range r.calls {
-		if call.Name == name && len(call.Args) > 0 && call.Args[0] == firstArg {
-			return true
-		}
-	}
-	return false
-}
-
-func (r *windowsCommandRecorder) sawAll(values ...string) bool {
-	for _, call := range r.calls {
-		actual := append([]string{call.Name}, call.Args...)
-		if windowsStringSlicesEqual(actual, values) {
-			return true
-		}
-	}
-	return false
-}
-
-func windowsStringSlicesEqual(a []string, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func mustReadFile(t *testing.T, path string) []byte {
+func createNonEmptyWindowsMetadataDirectory(t *testing.T, path string) {
 	t.Helper()
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read file %s: %v", path, err)
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("create non-empty metadata directory: %v", err)
 	}
-	return data
+	if err := os.WriteFile(filepath.Join(path, "entry"), []byte("metadata"), 0o644); err != nil {
+		t.Fatalf("write non-empty metadata directory entry: %v", err)
+	}
+}
+
+func assertWindowsMetadataAbsent(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("metadata path %q stat error = %v, want not exist", path, err)
+	}
 }

--- a/cli/kent/service_command.go
+++ b/cli/kent/service_command.go
@@ -230,16 +230,6 @@ func serviceRunSubcommand(args []string, stdout io.Writer, stderr io.Writer) int
 	return serviceHostRun(spec, stdout, stderr)
 }
 
-type legacyServerStopper interface {
-	stopLegacyServer(ctx context.Context, spec serviceSpec)
-}
-
-func stopLegacyManagedServer(ctx context.Context, backend serviceBackend, spec serviceSpec) {
-	if stopper, ok := backend.(legacyServerStopper); ok {
-		stopper.stopLegacyServer(ctx, spec)
-	}
-}
-
 func runServiceCommandAction(ctx context.Context, action serviceAction, opts serviceCommandOptions, stdout io.Writer, stderr io.Writer) int {
 	if err := ensureServiceLifecycleAllowed(action, opts); err != nil {
 		fmt.Fprintln(stderr, err)
@@ -273,10 +263,6 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 		writeServiceStatus(stdout, status)
 		return 0
 	case serviceActionInstall:
-
-		if serviceLifecycleGuardApplies(serviceActionInstall, opts) {
-			stopLegacyManagedServer(ctx, backend, spec)
-		}
 		if err := ensureNoUnmanagedServerConflictForAction(ctx, backend, spec, serviceActionInstall); err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
@@ -344,7 +330,6 @@ func runServiceCommandAction(ctx context.Context, action serviceAction, opts ser
 			if code, handled := elevateServiceAction(serviceActionRestart); handled {
 				return code
 			}
-			stopLegacyManagedServer(ctx, backend, spec)
 			if err := ensureNoUnmanagedServerConflictForAction(ctx, backend, spec, action); err != nil {
 				fmt.Fprintln(stderr, err)
 				return 1

--- a/cli/kent/service_types.go
+++ b/cli/kent/service_types.go
@@ -20,7 +20,6 @@ const (
 	serviceDisplayName        = config.ServiceDisplayName
 	serviceLaunchdLabel       = config.ServiceLaunchdLabel
 	serviceSystemdUnitName    = config.ServiceSystemdUnitName
-	serviceWindowsTaskName    = config.ServiceWindowsTaskName
 	serviceWindowsServiceName = config.ServiceWindowsServiceName
 	serviceLogDirName         = "logs"
 	serviceStdoutLogName      = "server.log"

--- a/shared/config/brand.go
+++ b/shared/config/brand.go
@@ -50,9 +50,7 @@ const (
 	// ServiceLaunchdLabel is the macOS launchd label (and plist base name).
 	ServiceLaunchdLabel = "sh.kent.server"
 	// ServiceSystemdUnitName is the Linux systemd user-unit name.
-	ServiceSystemdUnitName = "kent.service"
-	ServiceWindowsTaskName = Product + " Server"
-
+	ServiceSystemdUnitName    = "kent.service"
 	ServiceWindowsServiceName = Product + "Server"
 )
 


### PR DESCRIPTION
## Summary
- Remove the Scheduled Task/Startup-folder migration path and legacy service preflight hooks.
- Keep SCM as the sole Windows service backend, including normalized cleanup of its current runtime metadata.
- Replace stale Scheduled Task tests with surviving Windows service argument/path contract coverage.

## Verification
- `./scripts/test.sh ./cli/kent`
- `GOOS=windows GOARCH=arm64 go test -exec /usr/bin/true ./cli/kent` (compile-only)
- `./scripts/build.sh --output ./bin/kent`
- `./scripts/ci-check.sh`

## Windows validation
Native Windows cleanup behavior is explicitly deferred to manual validation; this PR makes no CI workflow changes.

Closes #441