### PR TITLE
fix: expose silent shell completion

### DIFF
--- a/cli/app/embedded_server_part2_test.go
+++ b/cli/app/embedded_server_part2_test.go
@@ -38,6 +38,7 @@ func TestEmbeddedAppServerDeliversBackgroundCompletionWhileIdle(t *testing.T) {
 	defer func() { _ = sub.Close() }()
 
 	processID := "bg-1000"
+	exitCode := 0
 	server.inner.BackgroundRouter().Handle(shelltool.Event{
 		Type:             shelltool.EventCompleted,
 		NoticeSuppressed: true,
@@ -49,8 +50,8 @@ func TestEmbeddedAppServerDeliversBackgroundCompletionWhileIdle(t *testing.T) {
 			Command:        "sleep 1; printf done",
 			Workdir:        workspace,
 			LogPath:        "/tmp/bg-1000.log",
+			ExitCode:       &exitCode,
 		},
-		Preview: "done",
 	})
 
 	evt := waitForSessionActivityEvent(t, sub, 5*time.Second, func(evt clientui.Event) bool {
@@ -77,6 +78,7 @@ func TestPrepareRuntimeForwardsBackgroundCompletionIntoProjectedRuntimeEvents(t 
 	defer runtimePlan.Close()
 
 	processID := "bg-1001"
+	exitCode := 0
 	server.inner.BackgroundRouter().Handle(shelltool.Event{
 		Type:             shelltool.EventCompleted,
 		NoticeSuppressed: true,
@@ -88,8 +90,8 @@ func TestPrepareRuntimeForwardsBackgroundCompletionIntoProjectedRuntimeEvents(t 
 			Command:        "sleep 1; printf done",
 			Workdir:        workspace,
 			LogPath:        "/tmp/bg-1001.log",
+			ExitCode:       &exitCode,
 		},
-		Preview: "done",
 	})
 
 	select {

--- a/cli/app/embedded_server_part2_test.go
+++ b/cli/app/embedded_server_part2_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"core/internal/testharness/runtimewirefixture"
 	askquestion "core/server/tools"
 	shelltool "core/server/tools/shell"
 	"core/shared/clientui"
@@ -38,21 +39,9 @@ func TestEmbeddedAppServerDeliversBackgroundCompletionWhileIdle(t *testing.T) {
 	defer func() { _ = sub.Close() }()
 
 	processID := "bg-1000"
-	exitCode := 0
-	server.inner.BackgroundRouter().Handle(shelltool.Event{
-		Type:             shelltool.EventCompleted,
-		NoticeSuppressed: true,
-		Snapshot: shelltool.Snapshot{
-			ID:             processID,
-			ActivityID:     uuid.New(),
-			OwnerSessionID: plan.SessionID,
-			State:          "completed",
-			Command:        "sleep 1; printf done",
-			Workdir:        workspace,
-			LogPath:        "/tmp/bg-1000.log",
-			ExitCode:       &exitCode,
-		},
-	})
+	event := runtimewirefixture.BackgroundCompletionEvent(processID, plan.SessionID, workspace)
+	event.NoticeSuppressed = true
+	server.inner.BackgroundRouter().Handle(event)
 
 	evt := waitForSessionActivityEvent(t, sub, 5*time.Second, func(evt clientui.Event) bool {
 		return evt.Kind == clientui.EventBackgroundUpdated && evt.Background != nil && evt.Background.ID == processID && evt.Background.Type == "completed"
@@ -78,21 +67,9 @@ func TestPrepareRuntimeForwardsBackgroundCompletionIntoProjectedRuntimeEvents(t 
 	defer runtimePlan.Close()
 
 	processID := "bg-1001"
-	exitCode := 0
-	server.inner.BackgroundRouter().Handle(shelltool.Event{
-		Type:             shelltool.EventCompleted,
-		NoticeSuppressed: true,
-		Snapshot: shelltool.Snapshot{
-			ID:             processID,
-			ActivityID:     uuid.New(),
-			OwnerSessionID: plan.SessionID,
-			State:          "completed",
-			Command:        "sleep 1; printf done",
-			Workdir:        workspace,
-			LogPath:        "/tmp/bg-1001.log",
-			ExitCode:       &exitCode,
-		},
-	})
+	event := runtimewirefixture.BackgroundCompletionEvent(processID, plan.SessionID, workspace)
+	event.NoticeSuppressed = true
+	server.inner.BackgroundRouter().Handle(event)
 
 	select {
 	case evt := <-runtimePlan.Wiring.runtimeEvents:

--- a/cli/app/embedded_server_test.go
+++ b/cli/app/embedded_server_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"core/cli/app/internal/status"
+	"core/internal/testharness/runtimewirefixture"
 	"core/server/auth"
 	"core/server/authservice"
 	"core/server/launch"
@@ -748,21 +749,9 @@ func TestEmbeddedAppServerRoutesBackgroundCompletionToOwningSessionOnly(t *testi
 	defer func() { _ = subB.Close() }()
 
 	processID := "bg-owned-a"
-	exitCode := 0
-	server.inner.BackgroundRouter().Handle(shelltool.Event{
-		Type:             shelltool.EventCompleted,
-		NoticeSuppressed: true,
-		Snapshot: shelltool.Snapshot{
-			ID:             processID,
-			ActivityID:     uuid.New(),
-			OwnerSessionID: planA.SessionID,
-			State:          "completed",
-			Command:        "sleep 1; printf done",
-			Workdir:        workspace,
-			LogPath:        "/tmp/bg-owned-a.log",
-			ExitCode:       &exitCode,
-		},
-	})
+	event := runtimewirefixture.BackgroundCompletionEvent(processID, planA.SessionID, workspace)
+	event.NoticeSuppressed = true
+	server.inner.BackgroundRouter().Handle(event)
 
 	evtA := waitForSessionActivityEvent(t, subA, 5*time.Second, func(evt clientui.Event) bool {
 		return evt.Kind == clientui.EventBackgroundUpdated && evt.Background != nil && evt.Background.ID == processID && evt.Background.Type == "completed"

--- a/cli/app/embedded_server_test.go
+++ b/cli/app/embedded_server_test.go
@@ -748,6 +748,7 @@ func TestEmbeddedAppServerRoutesBackgroundCompletionToOwningSessionOnly(t *testi
 	defer func() { _ = subB.Close() }()
 
 	processID := "bg-owned-a"
+	exitCode := 0
 	server.inner.BackgroundRouter().Handle(shelltool.Event{
 		Type:             shelltool.EventCompleted,
 		NoticeSuppressed: true,
@@ -759,8 +760,8 @@ func TestEmbeddedAppServerRoutesBackgroundCompletionToOwningSessionOnly(t *testi
 			Command:        "sleep 1; printf done",
 			Workdir:        workspace,
 			LogPath:        "/tmp/bg-owned-a.log",
+			ExitCode:       &exitCode,
 		},
-		Preview: "done",
 	})
 
 	evtA := waitForSessionActivityEvent(t, subA, 5*time.Second, func(evt clientui.Event) bool {

--- a/cli/app/runtime_factory_test.go
+++ b/cli/app/runtime_factory_test.go
@@ -22,8 +22,6 @@ import (
 	shelltool "core/server/tools/shell"
 	"core/shared/config"
 	"core/shared/toolspec"
-
-	"github.com/google/uuid"
 )
 
 type stubTriggerHandoffController struct{}
@@ -495,18 +493,9 @@ func TestBackgroundEventRouterShapesBackgroundNoticeByOutputMode(t *testing.T) {
 
 			router := newBackgroundEventRouter(nil, tt.maxChars, tt.mode)
 			router.SetActiveSession(store.Meta().SessionID, eng)
-			router.handle(shelltool.Event{
-				Type:             shelltool.EventCompleted,
-				NoticeSuppressed: true,
-				Snapshot: shelltool.Snapshot{
-					ID:             "1000",
-					ActivityID:     uuid.New(),
-					OwnerSessionID: store.Meta().SessionID,
-					State:          "completed",
-					LogPath:        logPath,
-					ExitCode:       &tt.exitCode,
-				},
-			})
+			event := runtimewirefixture.BackgroundCompletionEventWithExit("1000", store.Meta().SessionID, root, tt.exitCode)
+			event.NoticeSuppressed = true
+			router.handle(event)
 
 			select {
 			case evt := <-events:
@@ -522,7 +511,7 @@ func TestBackgroundEventRouterShapesBackgroundNoticeByOutputMode(t *testing.T) {
 	}
 }
 
-func TestBackgroundEventRouterWhitespacePreviewUsesNoOutputLine(t *testing.T) {
+func TestBackgroundEventRouterRoutesValidCompletion(t *testing.T) {
 	root := t.TempDir()
 	store := createAppRuntimeSessionAt(t, root, "ws", root)
 	client := &busyToggleFakeClient{}
@@ -539,23 +528,15 @@ func TestBackgroundEventRouterWhitespacePreviewUsesNoOutputLine(t *testing.T) {
 	router := newBackgroundEventRouter(nil, 80, shelltool.BackgroundOutputDefault)
 	router.SetActiveSession(store.Meta().SessionID, eng)
 	exitCode := 0
-	router.handle(shelltool.Event{
-		Type:             shelltool.EventCompleted,
-		NoticeSuppressed: true,
-		Snapshot: shelltool.Snapshot{
-			ID:             "1000",
-			ActivityID:     uuid.New(),
-			OwnerSessionID: store.Meta().SessionID,
-			State:          "completed",
-			ExitCode:       &exitCode,
-		},
-	})
+	event := runtimewirefixture.BackgroundCompletionEvent("1000", store.Meta().SessionID, root)
+	event.NoticeSuppressed = true
+	router.handle(event)
 
 	select {
 	case evt := <-events:
 		if evt.Background == nil || evt.Background.ExitCode == nil || *evt.Background.ExitCode != exitCode ||
-			evt.Background.NoticeText == "" || evt.Background.CompactText == "" || evt.Background.Preview != "" {
-			t.Fatalf("blank-output background update = %+v", evt.Background)
+			evt.Background.NoticeText == "" || evt.Background.CompactText == "" || evt.Background.Preview == "" {
+			t.Fatalf("valid background completion update = %+v", evt.Background)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for background update event")
@@ -676,15 +657,7 @@ func TestBackgroundEventRouterDropsNoticeWhenNoSessionIsActive(t *testing.T) {
 	eng := newAppRuntimeEngineWithStore(t, store, client, runtime.Config{})
 	router.SetActiveSession(store.Meta().SessionID, eng)
 	router.ClearActiveSession(store.Meta().SessionID, eng)
-	router.handle(shelltool.Event{
-		Type: shelltool.EventCompleted,
-		Snapshot: shelltool.Snapshot{
-			ID:             "1002",
-			ActivityID:     uuid.New(),
-			OwnerSessionID: store.Meta().SessionID,
-			State:          "completed",
-		},
-	})
+	router.handle(runtimewirefixture.BackgroundCompletionEvent("1002", store.Meta().SessionID, root))
 	time.Sleep(50 * time.Millisecond)
 	if got := client.CallCount(); got != 0 {
 		t.Fatalf("expected no notice delivery while no session is active, got %d", got)

--- a/cli/app/runtime_factory_test.go
+++ b/cli/app/runtime_factory_test.go
@@ -510,18 +510,10 @@ func TestBackgroundEventRouterShapesBackgroundNoticeByOutputMode(t *testing.T) {
 
 			select {
 			case evt := <-events:
-				if evt.Background == nil {
-					t.Fatal("expected background payload")
-				}
-				for _, needle := range tt.wantContains {
-					if !strings.Contains(evt.Background.NoticeText, needle) {
-						t.Fatalf("expected notice to contain %q, got %q", needle, evt.Background.NoticeText)
-					}
-				}
-				for _, needle := range tt.wantNotContains {
-					if strings.Contains(evt.Background.NoticeText, needle) {
-						t.Fatalf("expected notice to omit %q, got %q", needle, evt.Background.NoticeText)
-					}
+				if evt.Background == nil ||
+					evt.Background.ExitCode == nil || *evt.Background.ExitCode != tt.exitCode ||
+					evt.Background.NoticeText == "" || evt.Background.CompactText == "" {
+					t.Fatalf("background update = %+v", evt.Background)
 				}
 			case <-time.After(time.Second):
 				t.Fatal("timed out waiting for background update event")
@@ -557,19 +549,13 @@ func TestBackgroundEventRouterWhitespacePreviewUsesNoOutputLine(t *testing.T) {
 			State:          "completed",
 			ExitCode:       &exitCode,
 		},
-		Preview: "  \n\t  ",
 	})
 
 	select {
 	case evt := <-events:
-		if evt.Background == nil {
-			t.Fatal("expected background payload")
-		}
-		if !strings.Contains(evt.Background.NoticeText, "\nNo output") {
-			t.Fatalf("expected no output line, got %q", evt.Background.NoticeText)
-		}
-		if strings.Contains(evt.Background.NoticeText, "Output:") {
-			t.Fatalf("did not expect output header for blank preview, got %q", evt.Background.NoticeText)
+		if evt.Background == nil || evt.Background.ExitCode == nil || *evt.Background.ExitCode != exitCode ||
+			evt.Background.NoticeText == "" || evt.Background.CompactText == "" || evt.Background.Preview != "" {
+			t.Fatalf("blank-output background update = %+v", evt.Background)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for background update event")
@@ -690,7 +676,15 @@ func TestBackgroundEventRouterDropsNoticeWhenNoSessionIsActive(t *testing.T) {
 	eng := newAppRuntimeEngineWithStore(t, store, client, runtime.Config{})
 	router.SetActiveSession(store.Meta().SessionID, eng)
 	router.ClearActiveSession(store.Meta().SessionID, eng)
-	router.handle(shelltool.Event{Snapshot: shelltool.Snapshot{ID: "1002", ActivityID: uuid.New(), OwnerSessionID: store.Meta().SessionID, State: "completed"}, Type: shelltool.EventCompleted, Preview: "done"})
+	router.handle(shelltool.Event{
+		Type: shelltool.EventCompleted,
+		Snapshot: shelltool.Snapshot{
+			ID:             "1002",
+			ActivityID:     uuid.New(),
+			OwnerSessionID: store.Meta().SessionID,
+			State:          "completed",
+		},
+	})
 	time.Sleep(50 * time.Millisecond)
 	if got := client.CallCount(); got != 0 {
 		t.Fatalf("expected no notice delivery while no session is active, got %d", got)

--- a/cli/app/runtime_factory_test.go
+++ b/cli/app/runtime_factory_test.go
@@ -405,69 +405,46 @@ func TestBackgroundEventRouterQueuesNoticeForActiveOwnerSession(t *testing.T) {
 
 func TestBackgroundEventRouterShapesBackgroundNoticeByOutputMode(t *testing.T) {
 	tests := []struct {
-		name            string
-		mode            shelltool.BackgroundOutputMode
-		exitCode        int
-		maxChars        int
-		content         string
-		wantContains    []string
-		wantNotContains []string
+		name              string
+		mode              shelltool.BackgroundOutputMode
+		exitCode          int
+		maxChars          int
+		content           string
+		wantInlinePreview bool
+		wantTruncated     bool
 	}{
 		{
-			name:     "concise success omits output section",
-			mode:     shelltool.BackgroundOutputConcise,
-			exitCode: 0,
-			maxChars: 16,
-			content:  "alpha\nbeta\ngamma\n",
-			wantContains: []string{
-				"Output file (3 lines):",
-			},
-			wantNotContains: []string{
-				"Output:",
-				"alpha",
-			},
+			name:              "concise success suppresses inline preview",
+			mode:              shelltool.BackgroundOutputConcise,
+			exitCode:          0,
+			maxChars:          16,
+			content:           "alpha\nbeta\ngamma\n",
+			wantInlinePreview: false,
 		},
 		{
-			name:     "verbose success keeps full output",
-			mode:     shelltool.BackgroundOutputVerbose,
-			exitCode: 0,
-			maxChars: 5,
-			content:  "alpha\nbeta\ngamma\n",
-			wantContains: []string{
-				"Output:",
-				"alpha\nbeta\ngamma",
-			},
-			wantNotContains: []string{
-				"omitted",
-			},
+			name:              "verbose success keeps inline preview",
+			mode:              shelltool.BackgroundOutputVerbose,
+			exitCode:          0,
+			maxChars:          5,
+			content:           "alpha\nbeta\ngamma\n",
+			wantInlinePreview: true,
 		},
 		{
-			name:     "concise non-zero falls back to default truncation",
-			mode:     shelltool.BackgroundOutputConcise,
-			exitCode: 17,
-			maxChars: 32,
-			content:  "alpha line\n" + strings.Repeat("middle-noise-", 40) + "\nomega line\n",
-			wantContains: []string{
-				"Output:",
-				"alpha line",
-				"omega line",
-				"Omitted ",
-				"read log file for details",
-			},
+			name:              "concise non-zero uses default preview",
+			mode:              shelltool.BackgroundOutputConcise,
+			exitCode:          17,
+			maxChars:          32,
+			content:           "alpha line\n" + strings.Repeat("middle-noise-", 40) + "\nomega line\n",
+			wantInlinePreview: true,
+			wantTruncated:     true,
 		},
 		{
-			name:     "verbose non-zero keeps full output",
-			mode:     shelltool.BackgroundOutputVerbose,
-			exitCode: 17,
-			maxChars: 5,
-			content:  "alpha\nbeta\ngamma\n",
-			wantContains: []string{
-				"Output:",
-				"alpha\nbeta\ngamma",
-			},
-			wantNotContains: []string{
-				"omitted",
-			},
+			name:              "verbose non-zero keeps inline preview",
+			mode:              shelltool.BackgroundOutputVerbose,
+			exitCode:          17,
+			maxChars:          5,
+			content:           "alpha\nbeta\ngamma\n",
+			wantInlinePreview: true,
 		},
 	}
 
@@ -486,14 +463,9 @@ func TestBackgroundEventRouterShapesBackgroundNoticeByOutputMode(t *testing.T) {
 			})
 			t.Cleanup(func() { _ = eng.Close() })
 
-			logPath := filepath.Join(root, "1000.log")
-			if err := os.WriteFile(logPath, []byte(tt.content), 0o644); err != nil {
-				t.Fatalf("write log: %v", err)
-			}
-
 			router := newBackgroundEventRouter(nil, tt.maxChars, tt.mode)
 			router.SetActiveSession(store.Meta().SessionID, eng)
-			event := runtimewirefixture.BackgroundCompletionEventWithExit("1000", store.Meta().SessionID, root, tt.exitCode)
+			event := runtimewirefixture.BackgroundCompletionEventWithOutput("1000", store.Meta().SessionID, root, tt.content, tt.exitCode)
 			event.NoticeSuppressed = true
 			router.handle(event)
 
@@ -503,6 +475,12 @@ func TestBackgroundEventRouterShapesBackgroundNoticeByOutputMode(t *testing.T) {
 					evt.Background.ExitCode == nil || *evt.Background.ExitCode != tt.exitCode ||
 					evt.Background.NoticeText == "" || evt.Background.CompactText == "" {
 					t.Fatalf("background update = %+v", evt.Background)
+				}
+				if got := evt.Background.Preview != ""; got != tt.wantInlinePreview {
+					t.Fatalf("inline preview = %t, want %t", got, tt.wantInlinePreview)
+				}
+				if got := evt.Background.PreviewRemoved > 0; got != tt.wantTruncated {
+					t.Fatalf("preview truncation = %t, want %t", got, tt.wantTruncated)
 				}
 			case <-time.After(time.Second):
 				t.Fatal("timed out waiting for background update event")

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -83,6 +83,15 @@
 
 - Large tool output is truncated for model consumption using standardized head/tail payloads with truncation metadata. Tool truncation threshold is not a tool post-processor, but a separate path that runs after the post-processor pipeline. 
 - Large output truncation threshold is configurable via a config file.
+- Foreground shell completion uses the final visible result after sanitization, postprocessing, warnings, truncation, and presentation trimming to determine whether output exists. Whitespace-only final content counts as no output.
+- A foreground shell command that exits successfully with output returns that output as plaintext without an exit-code header.
+- A foreground shell command that exits with no output returns exactly `Exit code N, no output.`, where `N` is its exit code.
+- A foreground shell command that exits unsuccessfully with output returns `Exit code N, output:` followed by the output.
+- A completed background shell always exposes its exit code in both polling results and automatic completion notices. When it has no output, its completion text is `Exit code N, no output.`
+- Background completion keeps shell identity and lifecycle state separate from its output summary. Polling retains its structured lifecycle fields.
+- Configured background-output verbosity continues to control inline previews. If concise presentation hides a preview for a command that produced output, completion still exposes the exit code and output-file location and does not claim that there was no output.
+- Recoverable shell-output warnings remain visible and count as output for completion wording. Background output-file metadata describes retained command output only; a warning does not add lines to or imply content in the command's log file.
+- An invalid internal background-completion event panics with diagnostic context in debug invariant mode. Production keeps the background-notice envelope and terminal process facts, records the invariant diagnostic, and presents an explicit internal error instead of fabricated successful or no-output content.
 - Model-step transient failures use exponential backoff retries with 5 attempts: `1s`, `2s`, `4s`, `8s`, `16s`.
 - Model/API errors in ongoing mode are shown as concise single-line errors; full details remain in detail/logs.
 - Kent implements tool repair infrastructure after a provider HTTP 400: Kent may repair tool calls that lack outputs (typically left dangling by an interruption) by appending a synthetic completion to each, then rebuilding the request and retrying. The repair is append-only: it never rewrites or removes persisted history, so the prompt-cache prefix through each repaired call stays intact, and the materialized output matches the original call kind. The synthetic result is an error stating the call was interrupted with no output, never a fabricated success. The repair defers to the resume path while interrupted calls still have pending re-execution starts, and no-ops when a 400 has no missing outputs (the original error then surfaces). Each repair appends one operator-only `developer_error_feedback` warning noting how many calls were closed.

--- a/docs/src/content/docs/command-postprocessing.md
+++ b/docs/src/content/docs/command-postprocessing.md
@@ -5,6 +5,8 @@ description: Configure Kent's shell command post-processing and ship your own ho
 
 Kent post-processes shell command output before it is shown to the model to normalize output, reduce command noise, and add useful execution context.
 
+Successful commands with visible output return that output. A completed command without visible output reports its exit code and explicit no-output completion.
+
 ## Config
 
 Configure command post-processing under `[shell]` in `~/.kent/config.toml`:

--- a/internal/testharness/runtimewirefixture/background.go
+++ b/internal/testharness/runtimewirefixture/background.go
@@ -9,9 +9,9 @@ import (
 )
 
 func BackgroundCompletionEvent(id string, ownerSessionID string, root string) shelltool.Event {
+	exitCode := 0
 	return shelltool.Event{
-		Type:    shelltool.EventCompleted,
-		Preview: "done",
+		Type: shelltool.EventCompleted,
 		Snapshot: shelltool.Snapshot{
 			ID:             id,
 			ActivityID:     uuid.New(),
@@ -20,6 +20,7 @@ func BackgroundCompletionEvent(id string, ownerSessionID string, root string) sh
 			Command:        "kent run",
 			Workdir:        root,
 			LogPath:        filepath.Join(root, id+".log"),
+			ExitCode:       &exitCode,
 		},
 	}
 }

--- a/internal/testharness/runtimewirefixture/background.go
+++ b/internal/testharness/runtimewirefixture/background.go
@@ -1,26 +1,48 @@
 package runtimewirefixture
 
 import (
-	"path/filepath"
+	"context"
+	"fmt"
+	"time"
 
 	shelltool "core/server/tools/shell"
-
-	"github.com/google/uuid"
 )
 
 func BackgroundCompletionEvent(id string, ownerSessionID string, root string) shelltool.Event {
-	exitCode := 0
-	return shelltool.Event{
-		Type: shelltool.EventCompleted,
-		Snapshot: shelltool.Snapshot{
-			ID:             id,
-			ActivityID:     uuid.New(),
-			OwnerSessionID: ownerSessionID,
-			State:          "completed",
-			Command:        "kent run",
-			Workdir:        root,
-			LogPath:        filepath.Join(root, id+".log"),
-			ExitCode:       &exitCode,
-		},
+	return BackgroundCompletionEventWithExit(id, ownerSessionID, root, 0)
+}
+
+func BackgroundCompletionEventWithExit(id string, ownerSessionID string, root string, exitCode int) shelltool.Event {
+	manager, err := shelltool.NewManager(shelltool.WithMinimumExecToBgTime(time.Millisecond))
+	if err != nil {
+		panic(fmt.Sprintf("create background shell manager fixture: %v", err))
+	}
+	defer func() { _ = manager.Close() }()
+
+	events := make(chan shelltool.Event, 1)
+	manager.SetEventHandler(func(event shelltool.Event) {
+		if event.Type == shelltool.EventCompleted || event.Type == shelltool.EventKilled {
+			events <- event
+		}
+	})
+	result, err := manager.Start(context.Background(), shelltool.ExecRequest{
+		Command:        []string{"/bin/sh", "-c", fmt.Sprintf("sleep 0.02; printf done; exit %d", exitCode)},
+		DisplayCommand: "fixture background completion",
+		OwnerSessionID: ownerSessionID,
+		Workdir:        root,
+		YieldTime:      time.Millisecond,
+	})
+	if err != nil {
+		panic(fmt.Sprintf("start background shell fixture: %v", err))
+	}
+	if !result.MovedToBackground {
+		panic("background shell fixture completed before background transition")
+	}
+	select {
+	case event := <-events:
+		event.Snapshot.ID = id
+		return event
+	case <-time.After(time.Second):
+		panic("timed out waiting for background shell fixture completion")
 	}
 }

--- a/internal/testharness/runtimewirefixture/background.go
+++ b/internal/testharness/runtimewirefixture/background.go
@@ -3,6 +3,8 @@ package runtimewirefixture
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	shelltool "core/server/tools/shell"
@@ -13,6 +15,14 @@ func BackgroundCompletionEvent(id string, ownerSessionID string, root string) sh
 }
 
 func BackgroundCompletionEventWithExit(id string, ownerSessionID string, root string, exitCode int) shelltool.Event {
+	return BackgroundCompletionEventWithOutput(id, ownerSessionID, root, "done", exitCode)
+}
+
+func BackgroundCompletionEventWithOutput(id string, ownerSessionID string, root string, output string, exitCode int) shelltool.Event {
+	sourcePath := filepath.Join(root, id+".fixture-output")
+	if err := os.WriteFile(sourcePath, []byte(output), 0o644); err != nil {
+		panic(fmt.Sprintf("write background shell fixture output: %v", err))
+	}
 	manager, err := shelltool.NewManager(shelltool.WithMinimumExecToBgTime(time.Millisecond))
 	if err != nil {
 		panic(fmt.Sprintf("create background shell manager fixture: %v", err))
@@ -26,7 +36,7 @@ func BackgroundCompletionEventWithExit(id string, ownerSessionID string, root st
 		}
 	})
 	result, err := manager.Start(context.Background(), shelltool.ExecRequest{
-		Command:        []string{"/bin/sh", "-c", fmt.Sprintf("sleep 0.02; printf done; exit %d", exitCode)},
+		Command:        []string{"/bin/sh", "-c", fmt.Sprintf("sleep 0.02; cat %q; exit %d", sourcePath, exitCode)},
 		DisplayCommand: "fixture background completion",
 		OwnerSessionID: ownerSessionID,
 		Workdir:        root,

--- a/server/runtime/engine_part7_test.go
+++ b/server/runtime/engine_part7_test.go
@@ -272,6 +272,12 @@ func TestFastExecCommandCompletionDoesNotQueueBackgroundNotice(t *testing.T) {
 	registry := tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: shelltool.NewExecCommandTool(dir, 16_000, manager, "")})
 	eng := mustNewTestEngine(t, store, client, registry, Config{Model: "gpt-5"})
 	manager.SetEventHandler(func(evt shelltool.Event) {
+		summary, summaryErr := shelltool.SummarizeBackgroundEvent(evt, shelltool.BackgroundNoticeOptions{MaxChars: 16_000, SuccessOutputMode: shelltool.BackgroundOutputDefault})
+		if summaryErr != nil {
+			t.Errorf("SummarizeBackgroundEvent: %v", summaryErr)
+			return
+		}
+		preview, previewRemoved := summary.RuntimePreview()
 		eng.HandleBackgroundShellUpdate(BackgroundShellEvent{
 			Type:           backgroundShellEventTypeForTest(evt.Type),
 			ID:             evt.Snapshot.ID,
@@ -279,8 +285,8 @@ func TestFastExecCommandCompletionDoesNotQueueBackgroundNotice(t *testing.T) {
 			Command:        evt.Snapshot.Command,
 			Workdir:        evt.Snapshot.Workdir,
 			LogPath:        evt.Snapshot.LogPath,
-			Preview:        evt.Preview,
-			PreviewRemoved: evt.Removed,
+			Preview:        preview,
+			PreviewRemoved: previewRemoved,
 			ExitCode: func() *int {
 				if evt.Snapshot.ExitCode == nil {
 					return nil

--- a/server/runtime/engine_part8_test.go
+++ b/server/runtime/engine_part8_test.go
@@ -153,6 +153,12 @@ func TestWriteStdinCompletionDoesNotQueueDuplicateBackgroundNotice(t *testing.T)
 	)
 	eng := mustNewTestEngine(t, store, client, registry, Config{Model: "gpt-5"})
 	manager.SetEventHandler(func(evt shelltool.Event) {
+		summary, summaryErr := shelltool.SummarizeBackgroundEvent(evt, shelltool.BackgroundNoticeOptions{MaxChars: 16_000, SuccessOutputMode: shelltool.BackgroundOutputDefault})
+		if summaryErr != nil {
+			t.Errorf("SummarizeBackgroundEvent: %v", summaryErr)
+			return
+		}
+		preview, previewRemoved := summary.RuntimePreview()
 		eng.HandleBackgroundShellUpdate(BackgroundShellEvent{
 			Type:           backgroundShellEventTypeForTest(evt.Type),
 			ID:             evt.Snapshot.ID,
@@ -160,8 +166,8 @@ func TestWriteStdinCompletionDoesNotQueueDuplicateBackgroundNotice(t *testing.T)
 			Command:        evt.Snapshot.Command,
 			Workdir:        evt.Snapshot.Workdir,
 			LogPath:        evt.Snapshot.LogPath,
-			Preview:        evt.Preview,
-			PreviewRemoved: evt.Removed,
+			Preview:        preview,
+			PreviewRemoved: previewRemoved,
 			ExitCode: func() *int {
 				if evt.Snapshot.ExitCode == nil {
 					return nil

--- a/server/runtimewire/background_router.go
+++ b/server/runtimewire/background_router.go
@@ -8,6 +8,7 @@ import (
 
 	"core/server/runtime"
 	shelltool "core/server/tools/shell"
+	"core/shared/invariant"
 	"core/shared/valuecopy"
 
 	"github.com/google/uuid"
@@ -18,6 +19,7 @@ type BackgroundEventRouter struct {
 	active      map[string]activeRuntime
 	outputLimit int
 	outputMode  shelltool.BackgroundOutputMode
+	policy      invariant.Policy
 }
 
 type activeRuntime struct {
@@ -26,7 +28,16 @@ type activeRuntime struct {
 }
 
 func NewBackgroundEventRouter(background *shelltool.Manager, outputLimit int, outputMode shelltool.BackgroundOutputMode) *BackgroundEventRouter {
-	router := &BackgroundEventRouter{active: make(map[string]activeRuntime), outputLimit: outputLimit, outputMode: outputMode}
+	return NewBackgroundEventRouterWithInvariantPolicy(background, outputLimit, outputMode, invariant.NewPolicy())
+}
+
+func NewBackgroundEventRouterWithInvariantPolicy(background *shelltool.Manager, outputLimit int, outputMode shelltool.BackgroundOutputMode, policy invariant.Policy) *BackgroundEventRouter {
+	router := &BackgroundEventRouter{
+		active:      make(map[string]activeRuntime),
+		outputLimit: outputLimit,
+		outputMode:  outputMode,
+		policy:      policy,
+	}
 	if background != nil {
 		background.SetEventHandler(router.handle)
 	}
@@ -81,10 +92,21 @@ func (r *BackgroundEventRouter) handle(evt shelltool.Event) {
 	}
 	summary := shelltool.BackgroundNoticeSummary{}
 	if evt.Type == shelltool.EventCompleted || evt.Type == shelltool.EventKilled {
-		summary = shelltool.SummarizeBackgroundEvent(evt, shelltool.BackgroundNoticeOptions{
+		var summaryErr error
+		summary, summaryErr = shelltool.SummarizeBackgroundEvent(evt, shelltool.BackgroundNoticeOptions{
 			MaxChars:          outputLimit,
 			SuccessOutputMode: outputMode,
 		})
+		if summaryErr != nil {
+			r.policy.Check(false, invariant.BackgroundEventDiagnostic(invariant.BackgroundEventDiagnosticInput{
+				Operation: "route_background_shell_event",
+				EventType: string(evt.Type),
+				ProcessID: evt.Snapshot.ID,
+				State:     evt.Snapshot.State,
+				Cause:     summaryErr.Error(),
+			}))
+			summary = shelltool.InvariantFailureBackgroundNotice(evt, summaryErr)
+		}
 	}
 	shouldNotify := !evt.NoticeSuppressed
 	if shouldNotify && !evt.Snapshot.FinishedAt.IsZero() && evt.Snapshot.FinishedAt.Before(activeRuntime.activatedAt) {
@@ -97,6 +119,7 @@ func (r *BackgroundEventRouter) handle(evt shelltool.Event) {
 	case shelltool.EventKilled:
 		eventType = runtime.BackgroundShellEventKilled
 	}
+	preview, previewRemoved := summary.RuntimePreview()
 	activeRuntime.engine.HandleBackgroundShellUpdate(runtime.BackgroundShellEvent{
 		Type:              eventType,
 		ID:                evt.Snapshot.ID,
@@ -107,8 +130,8 @@ func (r *BackgroundEventRouter) handle(evt shelltool.Event) {
 		LogPath:           evt.Snapshot.LogPath,
 		NoticeText:        summary.DetailText,
 		CompactText:       summary.CondensedText,
-		Preview:           evt.Preview,
-		PreviewRemoved:    evt.Removed,
+		Preview:           preview,
+		PreviewRemoved:    previewRemoved,
 		ExitCode:          valuecopy.Pointer(evt.Snapshot.ExitCode),
 		UserRequestedKill: evt.Snapshot.KillRequested,
 		NoticeSuppressed:  evt.NoticeSuppressed,

--- a/server/runtimewire/runtimewire_test.go
+++ b/server/runtimewire/runtimewire_test.go
@@ -22,8 +22,12 @@ import (
 	"core/server/tools"
 	askquestion "core/server/tools"
 	patchtool "core/server/tools/patch"
+	shelltool "core/server/tools/shell"
 	"core/shared/config"
+	"core/shared/invariant"
 	"core/shared/toolspec"
+
+	"github.com/google/uuid"
 )
 
 func TestBuildToolRegistryAllowsHostedWebSearchWithoutLocalRuntimeBuilder(t *testing.T) {
@@ -527,6 +531,116 @@ func TestBackgroundEventRouterQueuesNoticeForActiveOwnerSession(t *testing.T) {
 	}
 	if got := client.CallCount(); got == 0 {
 		t.Fatal("expected active owner completion to queue a model notice")
+	}
+}
+
+func TestBackgroundEventRouterDropsOrphanedTerminalEventBeforeInvariantHandling(t *testing.T) {
+	router := NewBackgroundEventRouterWithInvariantPolicy(nil, 16_000, shelltool.BackgroundOutputDefault, invariant.NewPolicy(invariant.WithMode(invariant.ModePanic)))
+	exitCode := 7
+	router.Handle(shelltool.Event{
+		Type: shelltool.EventCompleted,
+		Snapshot: shelltool.Snapshot{
+			ID:             "1000",
+			ActivityID:     uuid.New(),
+			OwnerSessionID: "inactive-owner",
+			State:          "completed",
+			ExitCode:       &exitCode,
+		},
+	})
+}
+
+func TestBackgroundEventRouterPanicsForInvalidTerminalEventInPanicMode(t *testing.T) {
+	root := t.TempDir()
+	store := newRuntimeWireSession(t, root, "panic")
+	router := NewBackgroundEventRouterWithInvariantPolicy(nil, 16_000, shelltool.BackgroundOutputDefault, invariant.NewPolicy(invariant.WithMode(invariant.ModePanic)))
+	router.SetActiveSession(store.Meta().SessionID, newRuntimeWireEngine(t, store, &busyToggleFakeClient{}))
+	exitCode := 7
+
+	defer func() {
+		recovered := recover()
+		diagnostic, ok := recovered.(invariant.Diagnostic)
+		if !ok {
+			t.Fatalf("panic = %#v, want invariant diagnostic", recovered)
+		}
+		if diagnostic.Scope != invariant.ScopeBackgroundEvent ||
+			diagnostic.Fields[invariant.FieldEventKind] != string(shelltool.EventCompleted) ||
+			diagnostic.Fields[invariant.FieldProcessID] != "1000" ||
+			diagnostic.Fields[invariant.FieldBackgroundState] != "completed" ||
+			diagnostic.Fields[invariant.FieldInvariantError] == "" ||
+			diagnostic.Stack == "" {
+			t.Fatalf("diagnostic = %+v", diagnostic)
+		}
+	}()
+
+	router.Handle(shelltool.Event{
+		Type: shelltool.EventCompleted,
+		Snapshot: shelltool.Snapshot{
+			ID:             "1000",
+			ActivityID:     uuid.New(),
+			OwnerSessionID: store.Meta().SessionID,
+			State:          "completed",
+			ExitCode:       &exitCode,
+		},
+	})
+}
+
+func TestBackgroundEventRouterRecoversInvalidTerminalEventInDiagnosticMode(t *testing.T) {
+	root := t.TempDir()
+	store := newRuntimeWireSession(t, root, "diagnostic")
+	client := &busyToggleFakeClient{responses: []llm.Response{{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "handled", Phase: llm.MessagePhaseFinal}, Usage: llm.Usage{WindowTokens: 200_000}}}}
+	var updates []runtime.BackgroundShellEvent
+	eng := newRuntimeWireEngine(t, store, client, runtime.Config{Model: "gpt-5", OnEvent: func(evt runtime.Event) {
+		if evt.Kind == runtime.EventBackgroundUpdated && evt.Background != nil {
+			updates = append(updates, *evt.Background)
+		}
+	}})
+	var diagnostics []invariant.Diagnostic
+	policy := invariant.NewPolicy(
+		invariant.WithMode(invariant.ModeDiagnostic),
+		invariant.WithSink(invariant.SinkFunc(func(d invariant.Diagnostic) {
+			diagnostics = append(diagnostics, d)
+		})),
+	)
+	router := NewBackgroundEventRouterWithInvariantPolicy(nil, 16_000, shelltool.BackgroundOutputDefault, policy)
+	router.SetActiveSession(store.Meta().SessionID, eng)
+	exitCode := 17
+	event := shelltool.Event{
+		Type: shelltool.EventCompleted,
+		Snapshot: shelltool.Snapshot{
+			ID:             "1000",
+			ActivityID:     uuid.New(),
+			OwnerSessionID: store.Meta().SessionID,
+			State:          "completed",
+			ExitCode:       &exitCode,
+			LogPath:        filepath.Join(root, "1000.log"),
+		},
+	}
+
+	router.Handle(event)
+
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diagnostics))
+	}
+	diagnostic := diagnostics[0]
+	if diagnostic.Scope != invariant.ScopeBackgroundEvent ||
+		diagnostic.Fields[invariant.FieldProcessID] != event.Snapshot.ID ||
+		diagnostic.Fields[invariant.FieldBackgroundState] != event.Snapshot.State ||
+		diagnostic.Fields[invariant.FieldInvariantError] == "" ||
+		diagnostic.Stack == "" {
+		t.Fatalf("diagnostic = %+v", diagnostic)
+	}
+	if len(updates) != 1 {
+		t.Fatalf("background updates = %d, want 1", len(updates))
+	}
+	update := updates[0]
+	if update.Type != runtime.BackgroundShellEventCompleted ||
+		update.ID != event.Snapshot.ID ||
+		update.State != event.Snapshot.State ||
+		update.ExitCode == nil || *update.ExitCode != exitCode ||
+		update.LogPath != event.Snapshot.LogPath ||
+		update.NoticeText == "" ||
+		update.CompactText == "" {
+		t.Fatalf("recovered background update = %+v", update)
 	}
 }
 

--- a/server/tools/shell/background_notice_test.go
+++ b/server/tools/shell/background_notice_test.go
@@ -1,72 +1,176 @@
 package shell
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"core/server/tools/shell/postprocess"
 )
 
-func TestSummarizeBackgroundEventDefaultDoesNotDuplicateShortLogAroundTruncationBoundary(t *testing.T) {
+func TestBackgroundEventCompletionOutputApplicability(t *testing.T) {
+	exitCode := 0
+	snapshot := Snapshot{ID: "1000", State: "completed", ExitCode: &exitCode}
+
+	backgrounded := newBackgroundedEvent(snapshot)
+	if backgrounded.completion != nil {
+		t.Fatal("background transition must not carry completion output")
+	}
+
+	finalized := newFinalizedBackgroundEvent(EventCompleted, snapshot, "", nil, false)
+	if finalized.completion == nil {
+		t.Fatal("completed event must carry completion output")
+	}
+	if finalized.completion.source != completionOutputFinalized {
+		t.Fatalf("finalized event source = %d", finalized.completion.source)
+	}
+
+	fallback := newFallbackBackgroundEvent(EventKilled, snapshot, "preview", nil, 1, false)
+	if fallback.completion == nil {
+		t.Fatal("killed event must carry completion output")
+	}
+	if fallback.completion.source != completionOutputFallback {
+		t.Fatalf("fallback event source = %d", fallback.completion.source)
+	}
+
+	_, err := SummarizeBackgroundEvent(Event{Type: EventCompleted, Snapshot: snapshot}, BackgroundNoticeOptions{})
+	var invalid *InvalidBackgroundEventError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("terminal event without completion output error = %v, want typed invalid event error", err)
+	}
+	if invalid.EventType != EventCompleted || invalid.ProcessID != snapshot.ID || invalid.State != snapshot.State {
+		t.Fatalf("invalid event error = %+v", invalid)
+	}
+}
+
+func TestBackgroundNoticeFinalizedOutputKeepsRetainedLogMetadata(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "1000.log")
-	content := strings.Repeat("x", 543)
-	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+	lines := strings.Repeat("line\n", 100)
+	if err := os.WriteFile(logPath, []byte(lines), 0o644); err != nil {
 		t.Fatalf("write log: %v", err)
 	}
+	exitCode := 0
+	event := newFinalizedBackgroundEvent(EventCompleted, Snapshot{
+		ID:       "1000",
+		State:    "completed",
+		LogPath:  logPath,
+		ExitCode: &exitCode,
+	}, "semantic replacement", nil, false)
+
+	summary, err := SummarizeBackgroundEvent(event, BackgroundNoticeOptions{MaxChars: 80, SuccessOutputMode: BackgroundOutputDefault})
+	if err != nil {
+		t.Fatalf("SummarizeBackgroundEvent: %v", err)
+	}
+	if summary.output.source != completionOutputFinalized {
+		t.Fatalf("notice output source = %d, want finalized", summary.output.source)
+	}
+	if summary.output.inlinePreview == nil {
+		t.Fatal("expected finalized output inline preview")
+	}
+	if !summary.output.retainedLogHasOutput {
+		t.Fatal("expected retained-log output")
+	}
+	if summary.output.logLineCount == nil || *summary.output.logLineCount != 100 {
+		t.Fatalf("retained log line count = %v, want 100", summary.output.logLineCount)
+	}
+	if summary.LineCount != 100 {
+		t.Fatalf("summary line count = %d, want 100", summary.LineCount)
+	}
+	if summary.Truncated {
+		t.Fatal("semantic replacement must not inherit retained-log truncation")
+	}
+
+	concise, err := SummarizeBackgroundEvent(event, BackgroundNoticeOptions{MaxChars: 80, SuccessOutputMode: BackgroundOutputConcise})
+	if err != nil {
+		t.Fatalf("SummarizeBackgroundEvent concise: %v", err)
+	}
+	if concise.output.inlinePreview != nil {
+		t.Fatal("concise mode must suppress only command inline preview")
+	}
+	if concise.output.logLineCount == nil || *concise.output.logLineCount != 100 {
+		t.Fatalf("concise retained log line count = %v, want 100", concise.output.logLineCount)
+	}
+}
+
+func TestBackgroundNoticeWarningOnlyOutputDoesNotClaimLogContent(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "1000.log")
+	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
+		t.Fatalf("write empty log: %v", err)
+	}
+	warning, err := postprocess.NewWarning("recoverable warning")
+	if err != nil {
+		t.Fatalf("NewWarning: %v", err)
+	}
+	exitCode := 0
+	event := newFinalizedBackgroundEvent(EventCompleted, Snapshot{
+		ID:       "1000",
+		State:    "completed",
+		LogPath:  logPath,
+		ExitCode: &exitCode,
+	}, "", warning, false)
+
+	summary, err := SummarizeBackgroundEvent(event, BackgroundNoticeOptions{SuccessOutputMode: BackgroundOutputConcise})
+	if err != nil {
+		t.Fatalf("SummarizeBackgroundEvent: %v", err)
+	}
+	if !summary.output.visible.HasVisibleContent() {
+		t.Fatal("warning-only completion must be visible output")
+	}
+	if summary.output.visible.Warning() == nil {
+		t.Fatal("warning-only completion must retain typed warning")
+	}
+	if summary.output.visible.HasCommandContent() {
+		t.Fatal("warning-only completion must not acquire command output")
+	}
+	if summary.output.retainedLogHasOutput || summary.output.logLineCount != nil {
+		t.Fatalf("warning-only completion must not claim retained log content: %+v", summary.output)
+	}
+}
+
+func TestBackgroundNoticeFallbackCarriesTruncationWithoutFinalizedState(t *testing.T) {
+	exitCode := 1
+	event := newFallbackBackgroundEvent(EventCompleted, Snapshot{
+		ID:       "1000",
+		State:    "completed",
+		ExitCode: &exitCode,
+	}, strings.Repeat("x", 200), nil, 1, false)
+
+	summary, err := SummarizeBackgroundEvent(event, BackgroundNoticeOptions{MaxChars: 80, SuccessOutputMode: BackgroundOutputDefault})
+	if err != nil {
+		t.Fatalf("SummarizeBackgroundEvent: %v", err)
+	}
+	if summary.output.source != completionOutputFallback {
+		t.Fatalf("notice output source = %d, want fallback", summary.output.source)
+	}
+	if summary.output.inlinePreview == nil {
+		t.Fatal("expected fallback inline preview")
+	}
+	if !summary.output.truncated || !summary.Truncated {
+		t.Fatal("expected fallback truncation")
+	}
+}
+
+func TestInvariantFailureBackgroundNoticeUsesDistinctTypedProjection(t *testing.T) {
 	exitCode := 17
-	summary := SummarizeBackgroundEvent(Event{
+	summary := InvariantFailureBackgroundNotice(Event{
 		Type: EventCompleted,
 		Snapshot: Snapshot{
 			ID:       "1000",
 			State:    "completed",
-			LogPath:  logPath,
 			ExitCode: &exitCode,
+			LogPath:  "/tmp/1000.log",
 		},
-	}, BackgroundNoticeOptions{MaxChars: 80, SuccessOutputMode: BackgroundOutputDefault})
+	}, errors.New("missing completion output"))
 
-	if !summary.Truncated {
-		t.Fatal("expected truncated summary")
+	if summary.output.kind != backgroundNoticeOutputInvariantFailure {
+		t.Fatalf("notice output kind = %d, want invariant failure", summary.output.kind)
 	}
-	if strings.Contains(summary.DetailText, "omitted -") {
-		t.Fatalf("did not expect negative omitted bytes, got %q", summary.DetailText)
+	if summary.output.invariantFailure == nil || summary.output.invariantFailure.message == "" {
+		t.Fatalf("invariant failure projection = %+v", summary.output.invariantFailure)
 	}
-	if strings.Count(summary.DetailText, content) > 0 {
-		t.Fatalf("did not expect full content duplicated in summary, got %q", summary.DetailText)
-	}
-	headLen, tailLen := truncationSegmentLengths(len(content), 80)
-	wantMax := headLen + tailLen + len(fmt.Sprintf(backgroundTruncationBannerTemplate, len(content)-headLen-tailLen))
-	_, preview, ok := strings.Cut(summary.DetailText, "Output:\n")
-	if !ok {
-		t.Fatalf("expected output section in summary, got %q", summary.DetailText)
-	}
-	if got := len(preview); got > wantMax {
-		t.Fatalf("expected bounded preview <= %d bytes, got %d", wantMax, got)
-	}
-	if len(preview) >= len(content) {
-		t.Fatalf("expected truncated preview smaller than content, got preview=%d content=%d", len(preview), len(content))
-	}
-}
-
-func TestSummarizeBackgroundEventPreservesRawAnsi(t *testing.T) {
-	logPath := filepath.Join(t.TempDir(), "1000.log")
-	content := "\x1b[31mred\x1b[0m\n"
-	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
-		t.Fatalf("write log: %v", err)
-	}
-	exitCode := 0
-	summary := SummarizeBackgroundEvent(Event{
-		Type: EventCompleted,
-		Snapshot: Snapshot{
-			ID:        "1000",
-			State:     "completed",
-			LogPath:   logPath,
-			ExitCode:  &exitCode,
-			RawOutput: true,
-		},
-	}, BackgroundNoticeOptions{MaxChars: 80, SuccessOutputMode: BackgroundOutputDefault})
-
-	if !strings.Contains(summary.DetailText, content) {
-		t.Fatalf("raw ANSI missing from summary: %q", summary.DetailText)
+	if summary.DetailText == "" || summary.CondensedText == "" {
+		t.Fatal("invariant failure notice must remain visible through the ordinary notice envelope")
 	}
 }

--- a/server/tools/shell/background_notice_test.go
+++ b/server/tools/shell/background_notice_test.go
@@ -129,6 +129,34 @@ func TestBackgroundNoticeWarningOnlyOutputDoesNotClaimLogContent(t *testing.T) {
 	}
 }
 
+func TestBackgroundNoticeWhitespaceLogRendersNoOutputCompletion(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "1000.log")
+	if err := os.WriteFile(logPath, []byte("\n"), 0o644); err != nil {
+		t.Fatalf("write whitespace log: %v", err)
+	}
+	exitCode := 0
+	event := newFinalizedBackgroundEvent(EventCompleted, Snapshot{
+		ID:       "1000",
+		State:    "completed",
+		LogPath:  logPath,
+		ExitCode: &exitCode,
+	}, "", nil, false)
+
+	summary, err := SummarizeBackgroundEvent(event, BackgroundNoticeOptions{SuccessOutputMode: BackgroundOutputDefault})
+	if err != nil {
+		t.Fatalf("SummarizeBackgroundEvent: %v", err)
+	}
+	if summary.output.logLineCount == nil || *summary.output.logLineCount != 1 {
+		t.Fatalf("whitespace log metadata = %+v, want one retained line", summary.output)
+	}
+	if !summary.output.shouldRenderNoOutputCompletion(&exitCode) {
+		t.Fatalf("whitespace-only completion must render explicit no-output state: %+v", summary.output)
+	}
+	if sections := len(strings.Split(summary.DetailText, "\n")); sections != 4 {
+		t.Fatalf("whitespace completion detail sections = %d, want 4", sections)
+	}
+}
+
 func TestBackgroundNoticeFallbackCarriesTruncationWithoutFinalizedState(t *testing.T) {
 	exitCode := 1
 	event := newFallbackBackgroundEvent(EventCompleted, Snapshot{

--- a/server/tools/shell/background_notice_test.go
+++ b/server/tools/shell/background_notice_test.go
@@ -157,6 +157,17 @@ func TestBackgroundNoticeWhitespaceLogRendersNoOutputCompletion(t *testing.T) {
 	}
 }
 
+func TestBackgroundPreviewOmitsTruncationForWhitespaceOnlyOutput(t *testing.T) {
+	builder := newBackgroundPreviewBuilder(80, BackgroundOutputDefault, false)
+	builder.WriteRaw([]byte(strings.Repeat(" ", 200)))
+	if !builder.Truncated() {
+		t.Fatal("expected whitespace-only preview source to be truncated")
+	}
+	if preview := builder.Preview(); preview != "" {
+		t.Fatalf("whitespace-only preview must not surface generated truncation content: %q", preview)
+	}
+}
+
 func TestBackgroundNoticeFallbackCarriesTruncationWithoutFinalizedState(t *testing.T) {
 	exitCode := 1
 	event := newFallbackBackgroundEvent(EventCompleted, Snapshot{

--- a/server/tools/shell/background_notice_test.go
+++ b/server/tools/shell/background_notice_test.go
@@ -180,6 +180,31 @@ func TestBackgroundNoticeFallbackCarriesTruncationWithoutFinalizedState(t *testi
 	}
 }
 
+func TestBackgroundNoticeConciseFallbackRetainsVisibleCompletion(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "1000.log")
+	if err := os.WriteFile(logPath, []byte("output\n"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	exitCode := 0
+	event := newFallbackBackgroundEvent(EventCompleted, Snapshot{
+		ID:       "1000",
+		State:    "completed",
+		LogPath:  logPath,
+		ExitCode: &exitCode,
+	}, "output", nil, 0, false)
+
+	summary, err := SummarizeBackgroundEvent(event, BackgroundNoticeOptions{SuccessOutputMode: BackgroundOutputConcise})
+	if err != nil {
+		t.Fatalf("SummarizeBackgroundEvent: %v", err)
+	}
+	if summary.output.inlinePreview != nil {
+		t.Fatal("concise mode must suppress the fallback inline preview")
+	}
+	if !summary.output.visible.HasCommandContent() || summary.output.shouldRenderNoOutputCompletion(&exitCode) {
+		t.Fatalf("concise fallback must retain semantic output while suppressing its preview: %+v", summary.output)
+	}
+}
+
 func TestInvariantFailureBackgroundNoticeUsesDistinctTypedProjection(t *testing.T) {
 	exitCode := 17
 	summary := InvariantFailureBackgroundNotice(Event{

--- a/server/tools/shell/exec_command_tool.go
+++ b/server/tools/shell/exec_command_tool.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"core/server/tools"
-	"core/server/tools/shell/postprocess"
 	"core/shared/transcript"
 )
 
@@ -106,7 +105,7 @@ func (t *ExecCommandTool) Call(ctx context.Context, c tools.Call) (tools.Result,
 		return tools.ErrorResultWith(c, formatToolCallError("exec_command", err), marshalNoHTMLEscape), nil
 	}
 	if strings.TrimSpace(result.ToolError) != "" {
-		return tools.ErrorResultWith(c, postprocess.JoinWarnings(result.Warning, result.ToolError), marshalNoHTMLEscape), nil
+		return tools.ErrorResultWith(c, formatToolError(result.Warning, result.ToolError), marshalNoHTMLEscape), nil
 	}
 	body, marshalErr := marshalNoHTMLEscape(formatExecResponse(result))
 	if marshalErr != nil {

--- a/server/tools/shell/manager.go
+++ b/server/tools/shell/manager.go
@@ -323,11 +323,15 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (ExecResult,
 	}
 	snapshot := entry.snapshot()
 	consumedCompletion := false
+	harvestingCompletion := snapshot.Backgrounded && snapshot.ExitCode != nil && !entry.completionNoticeConsumed()
+	if harvestingCompletion {
+		entry.markCompletionNoticeConsumed()
+	}
 	var warning postprocess.Warning
 	var warningErr error
 	sourceTruncated := false
 	var processed postprocess.Result
-	if snapshot.Backgrounded && snapshot.ExitCode != nil && !entry.completionNoticeConsumed() {
+	if harvestingCompletion {
 		fullOutput, readErr := readOutputFileLimited(snapshot.LogPath, maxFullLogPostprocessBytes)
 		if readErr == nil {
 			processed, err = m.applyPostprocessing(ctx, entry, fullOutput, snapshot.ExitCode, true, maxOutputChars)
@@ -361,9 +365,6 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (ExecResult,
 		}
 	}
 	display, displayTruncated, _ := truncateWithTemplate(processed.Output, maxOutputChars, backgroundTruncationBannerTemplate)
-	if snapshot.Backgrounded && snapshot.ExitCode != nil && consumedCompletion {
-		entry.markCompletionNoticeConsumed()
-	}
 	return ExecResult{
 		SessionID:          id,
 		WallTime:           time.Since(start),

--- a/server/tools/shell/manager.go
+++ b/server/tools/shell/manager.go
@@ -324,9 +324,6 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (ExecResult,
 	snapshot := entry.snapshot()
 	consumedCompletion := false
 	harvestingCompletion := snapshot.Backgrounded && snapshot.ExitCode != nil && !entry.completionNoticeConsumed()
-	if harvestingCompletion {
-		entry.markCompletionNoticeConsumed()
-	}
 	var warning postprocess.Warning
 	var warningErr error
 	sourceTruncated := false
@@ -357,6 +354,9 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (ExecResult,
 				}
 			}
 		}
+	}
+	if consumedCompletion {
+		entry.markCompletionNoticeConsumed()
 	}
 	if !consumedCompletion {
 		processed, err = m.applyPostprocessing(ctx, entry, string(output), snapshot.ExitCode, snapshot.Backgrounded, maxOutputChars)

--- a/server/tools/shell/manager.go
+++ b/server/tools/shell/manager.go
@@ -268,7 +268,7 @@ func (m *Manager) Start(ctx context.Context, req ExecRequest) (ExecResult, error
 	result.Truncated = truncated
 	result.Warning = processed.Warning
 	result.ToolError = processed.UnrecoverableError
-	m.emitEvent(Event{Type: EventBackgrounded, Snapshot: snapshot})
+	m.emitEvent(newBackgroundedEvent(snapshot))
 	return result, nil
 }
 
@@ -323,7 +323,8 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (ExecResult,
 	}
 	snapshot := entry.snapshot()
 	consumedCompletion := false
-	warning := ""
+	var warning postprocess.Warning
+	var warningErr error
 	sourceTruncated := false
 	var processed postprocess.Result
 	if snapshot.Backgrounded && snapshot.ExitCode != nil && !entry.completionNoticeConsumed() {
@@ -341,9 +342,15 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (ExecResult,
 				processed = postprocess.Result{Output: preview}
 				consumedCompletion = true
 				sourceTruncated = previewTruncated
-				warning = postprocess.JoinWarnings(warning, fmt.Sprintf("full output log skipped: %v", readErr))
+				warning, warningErr = mergeOperationalWarning(warning, fmt.Sprintf("full output log skipped: %v", readErr))
+				if warningErr != nil {
+					return ExecResult{}, warningErr
+				}
 			} else {
-				warning = postprocess.JoinWarnings(warning, fmt.Sprintf("failed to read full output log: %v", readErr))
+				warning, warningErr = mergeOperationalWarning(warning, fmt.Sprintf("failed to read full output log: %v", readErr))
+				if warningErr != nil {
+					return ExecResult{}, warningErr
+				}
 			}
 		}
 	}
@@ -360,7 +367,7 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (ExecResult,
 	return ExecResult{
 		SessionID:          id,
 		WallTime:           time.Since(start),
-		Warning:            postprocess.JoinWarnings(warning, processed.Warning),
+		Warning:            postprocess.MergeWarnings(warning, processed.Warning),
 		ToolError:          processed.UnrecoverableError,
 		Output:             display,
 		OutputPath:         snapshot.LogPath,

--- a/server/tools/shell/manager_notice.go
+++ b/server/tools/shell/manager_notice.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 	"unicode"
 
 	"core/server/tools/shell/postprocess"
@@ -14,6 +15,77 @@ import (
 )
 
 const noOutputText = "No output"
+
+type execPresentationKind uint8
+
+const (
+	execPresentationRunning execPresentationKind = iota
+	execPresentationForegroundCompleted
+	execPresentationBackgroundCompleted
+)
+
+type visibleShellOutput struct {
+	command string
+	warning postprocess.Warning
+}
+
+func newVisibleShellOutput(command string, warning postprocess.Warning) visibleShellOutput {
+	return visibleShellOutput{command: command, warning: warning}
+}
+
+func (o visibleShellOutput) Content() string {
+	sections := make([]string, 0, 2)
+	if o.warning != nil {
+		sections = append(sections, o.warning.Text())
+	}
+	if text := strings.TrimSpace(o.command); text != "" {
+		sections = append(sections, text)
+	}
+	return strings.Join(sections, "\n")
+}
+
+func (o visibleShellOutput) HasVisibleContent() bool {
+	return strings.TrimSpace(o.Content()) != ""
+}
+
+func (o visibleShellOutput) HasCommandContent() bool {
+	return strings.TrimSpace(o.command) != ""
+}
+
+func (o visibleShellOutput) Warning() postprocess.Warning {
+	return o.warning
+}
+
+type execPresentation struct {
+	kind              execPresentationKind
+	sessionID         string
+	wallTime          time.Duration
+	outputPath        string
+	output            visibleShellOutput
+	exitCode          int
+	movedToBackground bool
+}
+
+func projectExecResult(result ExecResult) execPresentation {
+	presentation := execPresentation{
+		sessionID:         strings.TrimSpace(result.SessionID),
+		wallTime:          result.WallTime,
+		outputPath:        strings.TrimSpace(result.OutputPath),
+		output:            newVisibleShellOutput(result.Output, result.Warning),
+		movedToBackground: result.MovedToBackground,
+	}
+	if result.ExitCode == nil {
+		presentation.kind = execPresentationRunning
+		return presentation
+	}
+	presentation.exitCode = *result.ExitCode
+	if result.Backgrounded {
+		presentation.kind = execPresentationBackgroundCompleted
+		return presentation
+	}
+	presentation.kind = execPresentationForegroundCompleted
+	return presentation
+}
 
 func NormalizeBackgroundOutputMode(raw string) BackgroundOutputMode {
 	switch BackgroundOutputMode(strings.ToLower(strings.TrimSpace(raw))) {
@@ -26,13 +98,67 @@ func NormalizeBackgroundOutputMode(raw string) BackgroundOutputMode {
 	}
 }
 
-func SummarizeBackgroundEvent(evt Event, opts BackgroundNoticeOptions) BackgroundNoticeSummary {
+type InvalidBackgroundEventError struct {
+	EventType EventType
+	ProcessID string
+	State     string
+}
+
+func (e *InvalidBackgroundEventError) Error() string {
+	return fmt.Sprintf("terminal background event %q for process %q in state %q is missing completion output", e.EventType, e.ProcessID, e.State)
+}
+
+type backgroundInlinePreview struct {
+	text string
+}
+
+type backgroundNoticeOutputKind uint8
+
+const (
+	backgroundNoticeOutputNormal backgroundNoticeOutputKind = iota + 1
+	backgroundNoticeOutputInvariantFailure
+)
+
+type invariantFailureNotice struct {
+	message string
+}
+
+type backgroundNoticeOutput struct {
+	kind                 backgroundNoticeOutputKind
+	source               completionOutputSource
+	visible              visibleShellOutput
+	inlinePreview        *backgroundInlinePreview
+	retainedLogHasOutput bool
+	logLineCount         *int
+	truncated            bool
+	previewRemoved       int
+	invariantFailure     *invariantFailureNotice
+}
+
+func (s BackgroundNoticeSummary) RuntimePreview() (string, int) {
+	if s.output.inlinePreview == nil {
+		return "", s.output.previewRemoved
+	}
+	return s.output.inlinePreview.text, s.output.previewRemoved
+}
+
+func SummarizeBackgroundEvent(evt Event, opts BackgroundNoticeOptions) (BackgroundNoticeSummary, error) {
+	if (evt.Type == EventCompleted || evt.Type == EventKilled) && evt.completion == nil {
+		return BackgroundNoticeSummary{}, &InvalidBackgroundEventError{
+			EventType: evt.Type,
+			ProcessID: evt.Snapshot.ID,
+			State:     evt.Snapshot.State,
+		}
+	}
 	maxChars := opts.MaxChars
 	if maxChars <= 0 {
 		maxChars = defaultOutputTokenCap * 4
 	}
 	mode := effectiveBackgroundOutputMode(evt.Snapshot.ExitCode, opts.SuccessOutputMode)
-	preview, lineCount, truncated := backgroundNoticePreview(evt, maxChars, mode)
+	output, err := projectBackgroundNoticeOutput(evt, maxChars, mode)
+	if err != nil {
+		return BackgroundNoticeSummary{}, err
+	}
 	state := strings.TrimSpace(evt.Snapshot.State)
 	if state == "" {
 		state = strings.TrimSpace(string(evt.Type))
@@ -44,20 +170,22 @@ func SummarizeBackgroundEvent(evt Event, opts BackgroundNoticeOptions) Backgroun
 	if evt.Snapshot.ExitCode != nil {
 		detail = append(detail, fmt.Sprintf("Exit code: %d", *evt.Snapshot.ExitCode))
 	}
-	if strings.TrimSpace(evt.Snapshot.LogPath) != "" && lineCount > 0 {
-		lineCountText := fmt.Sprintf("%d lines", lineCount)
-		if lineCount == 1 {
+	if strings.TrimSpace(evt.Snapshot.LogPath) != "" && output.logLineCount != nil {
+		lineCountText := fmt.Sprintf("%d lines", *output.logLineCount)
+		if *output.logLineCount == 1 {
 			lineCountText = "1 line"
 		}
 		detail = append(detail, fmt.Sprintf("Output file (%s): %s", lineCountText, evt.Snapshot.LogPath))
 	}
-	if mode != BackgroundOutputConcise {
-		if strings.TrimSpace(preview) == "" {
-			detail = append(detail, noOutputText)
-		} else {
-			detail = append(detail, "Output:")
-			detail = append(detail, preview)
-		}
+	if warning := output.visible.Warning(); warning != nil {
+		detail = append(detail, warning.Text())
+	}
+	if output.inlinePreview != nil {
+		detail = append(detail, "Output:")
+		detail = append(detail, output.inlinePreview.text)
+	}
+	if !output.visible.HasVisibleContent() && (output.source == completionOutputFinalized || !output.retainedLogHasOutput) && evt.Snapshot.ExitCode != nil {
+		detail = append(detail, fmt.Sprintf("Exit code %d, no output.", *evt.Snapshot.ExitCode))
 	}
 	summary := fmt.Sprintf("Background shell %s %s", evt.Snapshot.ID, state)
 	if evt.Snapshot.ExitCode != nil {
@@ -66,10 +194,11 @@ func SummarizeBackgroundEvent(evt Event, opts BackgroundNoticeOptions) Backgroun
 	return BackgroundNoticeSummary{
 		DetailText:    strings.Join(detail, "\n"),
 		CondensedText: summary,
-		LineCount:     lineCount,
-		Truncated:     truncated,
+		LineCount:     valueOrZero(output.logLineCount),
+		Truncated:     output.truncated,
 		LogPath:       evt.Snapshot.LogPath,
-	}
+		output:        output,
+	}, nil
 }
 
 func effectiveBackgroundOutputMode(exitCode *int, successMode BackgroundOutputMode) BackgroundOutputMode {
@@ -86,39 +215,98 @@ func effectiveBackgroundOutputMode(exitCode *int, successMode BackgroundOutputMo
 	return BackgroundOutputDefault
 }
 
-func backgroundNoticePreview(evt Event, maxChars int, mode BackgroundOutputMode) (string, int, bool) {
-	if evt.PreviewProcessed {
-		if mode == BackgroundOutputConcise {
-			return "", 0, false
-		}
-		preview := strings.TrimSpace(evt.Preview)
-		if preview == "" {
-			return "", 0, false
-		}
-		if mode == BackgroundOutputVerbose {
-			return preview, countOutputLines(preview), false
-		}
-		display, truncated, _ := truncateWithTemplate(preview, maxChars, backgroundTruncationBannerTemplate)
-		return display, countOutputLines(preview), truncated
+func projectBackgroundNoticeOutput(evt Event, maxChars int, mode BackgroundOutputMode) (backgroundNoticeOutput, error) {
+	if evt.completion == nil {
+		return backgroundNoticeOutput{}, nil
 	}
-	if strings.TrimSpace(evt.Snapshot.LogPath) != "" {
-		preview, lineCount, truncated, err := readBackgroundSummaryFromFile(evt.Snapshot.LogPath, maxChars, mode, !evt.Snapshot.RawOutput)
-		if err == nil {
-			return preview, lineCount, truncated
+	completion := evt.completion
+	output := backgroundNoticeOutput{
+		kind:           backgroundNoticeOutputNormal,
+		source:         completion.source,
+		visible:        completion.output,
+		truncated:      completion.removed > 0,
+		previewRemoved: completion.removed,
+	}
+	path := strings.TrimSpace(evt.Snapshot.LogPath)
+	if path != "" {
+		scanMode := mode
+		if completion.source == completionOutputFinalized {
+			scanMode = BackgroundOutputConcise
+		}
+		preview, lineCount, truncated, err := readBackgroundSummaryFromFile(path, maxChars, scanMode, !evt.Snapshot.RawOutput)
+		if err != nil {
+			warning, warningErr := postprocess.NewWarning(fmt.Sprintf("failed to read output preview: %v", err))
+			if warningErr != nil {
+				return backgroundNoticeOutput{}, warningErr
+			}
+			output.visible.warning = postprocess.MergeWarnings(output.visible.warning, warning)
+		} else {
+			if lineCount > 0 {
+				output.retainedLogHasOutput = true
+				output.logLineCount = &lineCount
+			}
+			if completion.source == completionOutputFallback {
+				output.visible.command = preview
+				output.truncated = output.truncated || truncated
+				if truncated && output.previewRemoved == 0 {
+					output.previewRemoved = 1
+				}
+			}
 		}
 	}
 	if mode == BackgroundOutputConcise {
-		return "", 0, false
+		return output, nil
 	}
-	preview := evt.Preview
-	if !evt.Snapshot.RawOutput {
-		preview = postprocess.SanitizeOutput(preview)
+	command := output.visible.command
+	if strings.TrimSpace(command) == "" {
+		return output, nil
 	}
-	truncated := evt.Removed > 0
-	if strings.TrimSpace(preview) == "" {
-		return "", 0, truncated
+	if mode == BackgroundOutputVerbose {
+		output.inlinePreview = &backgroundInlinePreview{text: strings.TrimSpace(command)}
+		return output, nil
 	}
-	return preview, countOutputLines(preview), truncated
+	preview, truncated, _ := truncateWithTemplate(strings.TrimSpace(command), maxChars, backgroundTruncationBannerTemplate)
+	output.inlinePreview = &backgroundInlinePreview{text: preview}
+	output.truncated = output.truncated || truncated
+	if truncated && output.previewRemoved == 0 {
+		output.previewRemoved = 1
+	}
+	return output, nil
+}
+
+func InvariantFailureBackgroundNotice(evt Event, cause error) BackgroundNoticeSummary {
+	state := strings.TrimSpace(evt.Snapshot.State)
+	if state == "" {
+		state = strings.TrimSpace(string(evt.Type))
+	}
+	message := fmt.Sprintf("Background shell completion internal error: %v", cause)
+	detail := []string{fmt.Sprintf("Background shell %s %s.", evt.Snapshot.ID, state)}
+	if evt.Snapshot.ExitCode != nil {
+		detail = append(detail, fmt.Sprintf("Exit code: %d", *evt.Snapshot.ExitCode))
+	}
+	detail = append(detail, message)
+	summary := fmt.Sprintf("Background shell %s %s", evt.Snapshot.ID, state)
+	if evt.Snapshot.ExitCode != nil {
+		summary = fmt.Sprintf("%s (exit %d)", summary, *evt.Snapshot.ExitCode)
+	}
+	return BackgroundNoticeSummary{
+		DetailText:    strings.Join(detail, "\n"),
+		CondensedText: summary,
+		LogPath:       evt.Snapshot.LogPath,
+		output: backgroundNoticeOutput{
+			kind: backgroundNoticeOutputInvariantFailure,
+			invariantFailure: &invariantFailureNotice{
+				message: message,
+			},
+		},
+	}
+}
+
+func valueOrZero(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
 }
 
 func readBackgroundSummaryFromFile(path string, maxChars int, mode BackgroundOutputMode, sanitize bool) (string, int, bool, error) {
@@ -330,29 +518,56 @@ func utf8EncodeRune(dst []byte, r rune) int {
 }
 
 func formatExecResponse(result ExecResult) string {
-	sections := make([]string, 0, 6)
-	output := strings.TrimSpace(result.Output)
-	if strings.TrimSpace(result.Warning) != "" {
-		sections = append(sections, result.Warning)
-	}
-	if result.MovedToBackground {
-		sections = append(sections, formatBackgroundTransitionLine(result.SessionID, output != ""))
-	}
-	if result.ExitCode != nil && *result.ExitCode != 0 {
-		sections = append(sections, fmt.Sprintf("Exit code %d, output:", *result.ExitCode))
-	} else if result.Running && strings.TrimSpace(result.SessionID) != "" && !result.MovedToBackground {
-		sections = append(sections, fmt.Sprintf("Process running with session ID %s", result.SessionID))
-	}
-	if result.Backgrounded && result.ExitCode != nil {
-		sections = append(sections, fmt.Sprintf("Wall time: %.4f seconds", result.WallTime.Seconds()))
-	}
-	if result.Backgrounded && result.ExitCode != nil && strings.TrimSpace(result.OutputPath) != "" {
-		sections = append(sections, fmt.Sprintf("Log file: %s", result.OutputPath))
-	}
-	if output == "" {
-		sections = append(sections, noOutputText)
-	} else {
+	return renderExecPresentation(projectExecResult(result))
+}
+
+func renderExecPresentation(presentation execPresentation) string {
+	output := presentation.output.Content()
+	switch presentation.kind {
+	case execPresentationRunning:
+		sections := make([]string, 0, 2)
+		if presentation.movedToBackground {
+			sections = append(sections, formatBackgroundTransitionLine(presentation.sessionID, presentation.output.HasCommandContent()))
+		} else if presentation.sessionID != "" {
+			sections = append(sections, fmt.Sprintf("Process running with session ID %s", presentation.sessionID))
+		}
+		if output == "" {
+			sections = append(sections, noOutputText)
+		} else {
+			sections = append(sections, output)
+		}
+		return strings.Join(sections, "\n")
+	case execPresentationForegroundCompleted:
+		if output == "" {
+			return fmt.Sprintf("Exit code %d, no output.", presentation.exitCode)
+		}
+		if presentation.exitCode == 0 {
+			return output
+		}
+		return fmt.Sprintf("Exit code %d, output:\n%s", presentation.exitCode, output)
+	case execPresentationBackgroundCompleted:
+		if output == "" {
+			return fmt.Sprintf("Exit code %d, no output.", presentation.exitCode)
+		}
+		sections := []string{fmt.Sprintf("Exit code %d, output:", presentation.exitCode)}
+		sections = append(sections, fmt.Sprintf("Wall time: %.4f seconds", presentation.wallTime.Seconds()))
+		if presentation.outputPath != "" {
+			sections = append(sections, fmt.Sprintf("Log file: %s", presentation.outputPath))
+		}
 		sections = append(sections, output)
+		return strings.Join(sections, "\n")
+	default:
+		panic(fmt.Sprintf("unknown exec presentation kind %d", presentation.kind))
+	}
+}
+
+func formatToolError(warning postprocess.Warning, toolError string) string {
+	sections := make([]string, 0, 2)
+	if warning != nil {
+		sections = append(sections, warning.Text())
+	}
+	if text := strings.TrimSpace(toolError); text != "" {
+		sections = append(sections, text)
 	}
 	return strings.Join(sections, "\n")
 }

--- a/server/tools/shell/manager_notice.go
+++ b/server/tools/shell/manager_notice.go
@@ -135,6 +135,10 @@ type backgroundNoticeOutput struct {
 	invariantFailure     *invariantFailureNotice
 }
 
+func (o backgroundNoticeOutput) shouldRenderNoOutputCompletion(exitCode *int) bool {
+	return exitCode != nil && !o.visible.HasVisibleContent()
+}
+
 func (s BackgroundNoticeSummary) RuntimePreview() (string, int) {
 	if s.output.inlinePreview == nil {
 		return "", s.output.previewRemoved
@@ -184,7 +188,7 @@ func SummarizeBackgroundEvent(evt Event, opts BackgroundNoticeOptions) (Backgrou
 		detail = append(detail, "Output:")
 		detail = append(detail, output.inlinePreview.text)
 	}
-	if !output.visible.HasVisibleContent() && (output.source == completionOutputFinalized || !output.retainedLogHasOutput) && evt.Snapshot.ExitCode != nil {
+	if output.shouldRenderNoOutputCompletion(evt.Snapshot.ExitCode) {
 		detail = append(detail, fmt.Sprintf("Exit code %d, no output.", *evt.Snapshot.ExitCode))
 	}
 	summary := fmt.Sprintf("Background shell %s %s", evt.Snapshot.ID, state)

--- a/server/tools/shell/manager_notice.go
+++ b/server/tools/shell/manager_notice.go
@@ -249,7 +249,7 @@ func projectBackgroundNoticeOutput(evt Event, maxChars int, mode BackgroundOutpu
 				output.retainedLogHasOutput = true
 				output.logLineCount = &lineCount
 			}
-			if completion.source == completionOutputFallback {
+			if completion.source == completionOutputFallback && mode != BackgroundOutputConcise {
 				output.visible.command = preview
 				output.truncated = output.truncated || truncated
 				if truncated && output.previewRemoved == 0 {

--- a/server/tools/shell/manager_notice.go
+++ b/server/tools/shell/manager_notice.go
@@ -338,19 +338,20 @@ func readBackgroundSummaryFromFile(path string, maxChars int, mode BackgroundOut
 }
 
 type backgroundPreviewBuilder struct {
-	maxChars    int
-	mode        BackgroundOutputMode
-	sanitize    bool
-	carry       []byte
-	prevCR      bool
-	totalBytes  int
-	lineCount   int
-	hasContent  bool
-	lastNewline bool
-	fullMode    bool
-	full        []byte
-	head        []byte
-	tail        []byte
+	maxChars          int
+	mode              BackgroundOutputMode
+	sanitize          bool
+	carry             []byte
+	prevCR            bool
+	totalBytes        int
+	lineCount         int
+	hasContent        bool
+	hasVisibleContent bool
+	lastNewline       bool
+	fullMode          bool
+	full              []byte
+	head              []byte
+	tail              []byte
 }
 
 func newBackgroundPreviewBuilder(maxChars int, mode BackgroundOutputMode, sanitize bool) *backgroundPreviewBuilder {
@@ -435,6 +436,9 @@ func (b *backgroundPreviewBuilder) emitBytes(data []byte) {
 		return
 	}
 	b.hasContent = true
+	if !b.hasVisibleContent && strings.TrimSpace(string(data)) != "" {
+		b.hasVisibleContent = true
+	}
 	b.totalBytes += len(data)
 	if b.fullMode {
 		b.full = append(b.full, data...)
@@ -468,6 +472,9 @@ func (b *backgroundPreviewBuilder) emitBytes(data []byte) {
 
 func (b *backgroundPreviewBuilder) Preview() string {
 	if b.mode == BackgroundOutputConcise {
+		return ""
+	}
+	if !b.hasVisibleContent {
 		return ""
 	}
 	if b.fullMode {

--- a/server/tools/shell/manager_notice_test.go
+++ b/server/tools/shell/manager_notice_test.go
@@ -1,0 +1,95 @@
+package shell
+
+import (
+	"testing"
+
+	"core/server/tools/shell/postprocess"
+)
+
+func TestProjectExecResultClassifiesTerminalVisibleOutput(t *testing.T) {
+	zero := 0
+	nonZero := 7
+	warning, err := postprocess.NewWarning("recoverable warning")
+	if err != nil {
+		t.Fatalf("NewWarning: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		result       ExecResult
+		wantKind     execPresentationKind
+		wantExitCode int
+		wantOutput   bool
+		wantWarning  bool
+	}{
+		{
+			name:         "zero exit whitespace command output",
+			result:       ExecResult{ExitCode: &zero, Output: " \t\n"},
+			wantKind:     execPresentationForegroundCompleted,
+			wantExitCode: 0,
+		},
+		{
+			name:         "non-zero exit whitespace command output",
+			result:       ExecResult{ExitCode: &nonZero, Output: "\n"},
+			wantKind:     execPresentationForegroundCompleted,
+			wantExitCode: 7,
+		},
+		{
+			name:         "warning-only success",
+			result:       ExecResult{ExitCode: &zero, Warning: warning},
+			wantKind:     execPresentationForegroundCompleted,
+			wantExitCode: 0,
+			wantOutput:   true,
+			wantWarning:  true,
+		},
+		{
+			name:         "postprocessor replacement with empty output",
+			result:       ExecResult{ExitCode: &zero, Output: ""},
+			wantKind:     execPresentationForegroundCompleted,
+			wantExitCode: 0,
+		},
+		{
+			name:         "non-empty command output",
+			result:       ExecResult{ExitCode: &zero, Output: "visible"},
+			wantKind:     execPresentationForegroundCompleted,
+			wantExitCode: 0,
+			wantOutput:   true,
+		},
+		{
+			name:         "completed background",
+			result:       ExecResult{ExitCode: &zero, Backgrounded: true},
+			wantKind:     execPresentationBackgroundCompleted,
+			wantExitCode: 0,
+		},
+		{
+			name:         "completed background non-zero output",
+			result:       ExecResult{ExitCode: &nonZero, Backgrounded: true, Output: "visible"},
+			wantKind:     execPresentationBackgroundCompleted,
+			wantExitCode: 7,
+			wantOutput:   true,
+		},
+		{
+			name:     "background transition",
+			result:   ExecResult{Running: true, Backgrounded: true, MovedToBackground: true, SessionID: "1000"},
+			wantKind: execPresentationRunning,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			presentation := projectExecResult(tt.result)
+			if presentation.kind != tt.wantKind {
+				t.Fatalf("presentation kind = %d, want %d", presentation.kind, tt.wantKind)
+			}
+			if tt.wantKind != execPresentationRunning && presentation.exitCode != tt.wantExitCode {
+				t.Fatalf("exit code = %d, want %d", presentation.exitCode, tt.wantExitCode)
+			}
+			if got := presentation.output.HasVisibleContent(); got != tt.wantOutput {
+				t.Fatalf("visible output = %t, want %t", got, tt.wantOutput)
+			}
+			if got := presentation.output.Warning() != nil; got != tt.wantWarning {
+				t.Fatalf("warning presence = %t, want %t", got, tt.wantWarning)
+			}
+		})
+	}
+}

--- a/server/tools/shell/manager_postprocess.go
+++ b/server/tools/shell/manager_postprocess.go
@@ -35,6 +35,14 @@ func (m *Manager) applyPostprocessing(ctx context.Context, entry *processEntry, 
 	})
 }
 
+func mergeOperationalWarning(existing postprocess.Warning, message string) (postprocess.Warning, error) {
+	warning, err := postprocess.NewWarning(message)
+	if err != nil {
+		return nil, err
+	}
+	return postprocess.MergeWarnings(existing, warning), nil
+}
+
 func readOutputFileLimited(path string, maxBytes int64) (string, error) {
 	trimmed := strings.TrimSpace(path)
 	if trimmed == "" {

--- a/server/tools/shell/manager_runtime.go
+++ b/server/tools/shell/manager_runtime.go
@@ -184,12 +184,7 @@ func (m *Manager) waitForExit(entry *processEntry) {
 				return
 			}
 		}
-		fallback, fallbackErr := m.fallbackBackgroundEvent(eventType, snapshot, warning, completionNoticeSuppressed(entry))
-		if fallbackErr != nil {
-			m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: completionNoticeSuppressed(entry)})
-		} else {
-			m.emitEvent(fallback)
-		}
+		m.emitFallbackBackgroundEvent(entry, eventType, snapshot, warning)
 		entry.finalizeClosedExit()
 		return
 	}
@@ -199,16 +194,21 @@ func (m *Manager) waitForExit(entry *processEntry) {
 		entry.finalizeClosedExit()
 		return
 	}
-	fallback, fallbackErr := m.fallbackBackgroundEvent(eventType, snapshot, warning, completionNoticeSuppressed(entry))
-	if fallbackErr != nil {
-		m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: completionNoticeSuppressed(entry)})
-	} else {
-		m.emitEvent(fallback)
-	}
+	m.emitFallbackBackgroundEvent(entry, eventType, snapshot, warning)
 	entry.finalizeClosedExit()
 }
 
-func (m *Manager) fallbackBackgroundEvent(eventType EventType, snapshot Snapshot, warning postprocess.Warning, noticeSuppressed bool) (Event, error) {
+func (m *Manager) emitFallbackBackgroundEvent(entry *processEntry, eventType EventType, snapshot Snapshot, warning postprocess.Warning) {
+	fallback, fallbackErr := m.fallbackBackgroundEvent(eventType, snapshot, warning)
+	if fallbackErr != nil {
+		m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: completionNoticeSuppressed(entry)})
+	} else {
+		fallback.NoticeSuppressed = completionNoticeSuppressed(entry)
+		m.emitEvent(fallback)
+	}
+}
+
+func (m *Manager) fallbackBackgroundEvent(eventType EventType, snapshot Snapshot, warning postprocess.Warning) (Event, error) {
 	preview, _, truncated, err := readBackgroundSummaryFromFile(snapshot.LogPath, defaultLimit, BackgroundOutputDefault, !snapshot.RawOutput)
 	if err != nil {
 		warning, err = mergeOperationalWarning(warning, fmt.Sprintf("failed to read output preview: %v", err))
@@ -221,7 +221,7 @@ func (m *Manager) fallbackBackgroundEvent(eventType EventType, snapshot Snapshot
 	if truncated {
 		removed = 1
 	}
-	return newFallbackBackgroundEvent(eventType, snapshot, preview, warning, removed, noticeSuppressed), nil
+	return newFallbackBackgroundEvent(eventType, snapshot, preview, warning, removed, false), nil
 }
 
 func completionNoticeSuppressed(entry *processEntry) bool {

--- a/server/tools/shell/manager_runtime.go
+++ b/server/tools/shell/manager_runtime.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"core/server/tools/shell/postprocess"
 )
 
 func (m *Manager) List() []Snapshot {
@@ -154,33 +156,6 @@ func (m *Manager) waitForExit(entry *processEntry) {
 		return
 	}
 	snapshot := entry.closeOnExit(exitCode, state)
-	preview := ""
-	removed := 0
-	previewProcessed := false
-	fullOutput, readErr := readOutputFileLimited(entry.logPath, maxFullLogPostprocessBytes)
-	if readErr == nil {
-		processed, err := m.applyPostprocessing(context.Background(), entry, fullOutput, snapshot.ExitCode, true, defaultLimit)
-		if err == nil && processed.Processed {
-			preview = processed.Output
-			previewProcessed = true
-		} else {
-			var truncated bool
-			preview, _, truncated, err = readBackgroundSummaryFromFile(entry.logPath, defaultLimit, BackgroundOutputDefault, !snapshot.RawOutput)
-			if err != nil {
-				preview = fmt.Sprintf("failed to read output preview: %v", err)
-			} else if truncated {
-				removed = 1
-			}
-		}
-	} else {
-		var truncated bool
-		preview, _, truncated, readErr = readBackgroundSummaryFromFile(entry.logPath, defaultLimit, BackgroundOutputDefault, !snapshot.RawOutput)
-		if readErr != nil {
-			preview = fmt.Sprintf("failed to read output preview: %v", readErr)
-		} else if truncated {
-			removed = 1
-		}
-	}
 	eventType := EventCompleted
 	if state == "killed" {
 		eventType = EventKilled
@@ -188,8 +163,69 @@ func (m *Manager) waitForExit(entry *processEntry) {
 	entry.interactMu.Lock()
 	noticeSuppressed := entry.completionNoticeConsumed()
 	entry.interactMu.Unlock()
-	m.emitEvent(Event{Type: eventType, Snapshot: snapshot, Preview: preview, PreviewProcessed: previewProcessed, Removed: removed, NoticeSuppressed: noticeSuppressed})
+
+	fullOutput, readErr := readOutputFileLimited(entry.logPath, maxFullLogPostprocessBytes)
+	if readErr == nil {
+		processed, postprocessErr := m.applyPostprocessing(context.Background(), entry, fullOutput, snapshot.ExitCode, true, defaultLimit)
+		if postprocessErr == nil && processed.Processed && strings.TrimSpace(processed.UnrecoverableError) == "" {
+			m.emitEvent(newFinalizedBackgroundEvent(eventType, snapshot, processed.Output, processed.Warning, noticeSuppressed))
+			entry.finalizeClosedExit()
+			return
+		}
+		warning := processed.Warning
+		if postprocessErr != nil {
+			warning, postprocessErr = mergeOperationalWarning(warning, fmt.Sprintf("background postprocess failed: %v", postprocessErr))
+			if postprocessErr != nil {
+				m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: noticeSuppressed})
+				entry.finalizeClosedExit()
+				return
+			}
+		} else if strings.TrimSpace(processed.UnrecoverableError) != "" {
+			warning, postprocessErr = mergeOperationalWarning(warning, processed.UnrecoverableError)
+			if postprocessErr != nil {
+				m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: noticeSuppressed})
+				entry.finalizeClosedExit()
+				return
+			}
+		}
+		fallback, fallbackErr := m.fallbackBackgroundEvent(eventType, snapshot, warning, noticeSuppressed)
+		if fallbackErr != nil {
+			m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: noticeSuppressed})
+		} else {
+			m.emitEvent(fallback)
+		}
+		entry.finalizeClosedExit()
+		return
+	}
+	warning, warningErr := mergeOperationalWarning(nil, fmt.Sprintf("full output log skipped: %v", readErr))
+	if warningErr != nil {
+		m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: noticeSuppressed})
+		entry.finalizeClosedExit()
+		return
+	}
+	fallback, fallbackErr := m.fallbackBackgroundEvent(eventType, snapshot, warning, noticeSuppressed)
+	if fallbackErr != nil {
+		m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: noticeSuppressed})
+	} else {
+		m.emitEvent(fallback)
+	}
 	entry.finalizeClosedExit()
+}
+
+func (m *Manager) fallbackBackgroundEvent(eventType EventType, snapshot Snapshot, warning postprocess.Warning, noticeSuppressed bool) (Event, error) {
+	preview, _, truncated, err := readBackgroundSummaryFromFile(snapshot.LogPath, defaultLimit, BackgroundOutputDefault, !snapshot.RawOutput)
+	if err != nil {
+		warning, err = mergeOperationalWarning(warning, fmt.Sprintf("failed to read output preview: %v", err))
+		if err != nil {
+			return Event{}, err
+		}
+		preview = ""
+	}
+	removed := 0
+	if truncated {
+		removed = 1
+	}
+	return newFallbackBackgroundEvent(eventType, snapshot, preview, warning, removed, noticeSuppressed), nil
 }
 
 func (m *Manager) collectUntil(ctx context.Context, entry *processEntry, deadline time.Time) ([]byte, error) {

--- a/server/tools/shell/manager_runtime.go
+++ b/server/tools/shell/manager_runtime.go
@@ -164,7 +164,7 @@ func (m *Manager) waitForExit(entry *processEntry) {
 	if readErr == nil {
 		processed, postprocessErr := m.applyPostprocessing(context.Background(), entry, fullOutput, snapshot.ExitCode, true, defaultLimit)
 		if postprocessErr == nil && processed.Processed && strings.TrimSpace(processed.UnrecoverableError) == "" {
-			m.emitEvent(newFinalizedBackgroundEvent(eventType, snapshot, processed.Output, processed.Warning, completionNoticeSuppressed(entry)))
+			m.emitCompletionEvent(entry, newFinalizedBackgroundEvent(eventType, snapshot, processed.Output, processed.Warning, false))
 			entry.finalizeClosedExit()
 			return
 		}
@@ -172,14 +172,14 @@ func (m *Manager) waitForExit(entry *processEntry) {
 		if postprocessErr != nil {
 			warning, postprocessErr = mergeOperationalWarning(warning, fmt.Sprintf("background postprocess failed: %v", postprocessErr))
 			if postprocessErr != nil {
-				m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: completionNoticeSuppressed(entry)})
+				m.emitCompletionEvent(entry, Event{Type: eventType, Snapshot: snapshot})
 				entry.finalizeClosedExit()
 				return
 			}
 		} else if strings.TrimSpace(processed.UnrecoverableError) != "" {
 			warning, postprocessErr = mergeOperationalWarning(warning, processed.UnrecoverableError)
 			if postprocessErr != nil {
-				m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: completionNoticeSuppressed(entry)})
+				m.emitCompletionEvent(entry, Event{Type: eventType, Snapshot: snapshot})
 				entry.finalizeClosedExit()
 				return
 			}
@@ -190,7 +190,7 @@ func (m *Manager) waitForExit(entry *processEntry) {
 	}
 	warning, warningErr := mergeOperationalWarning(nil, fmt.Sprintf("full output log skipped: %v", readErr))
 	if warningErr != nil {
-		m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: completionNoticeSuppressed(entry)})
+		m.emitCompletionEvent(entry, Event{Type: eventType, Snapshot: snapshot})
 		entry.finalizeClosedExit()
 		return
 	}
@@ -201,10 +201,9 @@ func (m *Manager) waitForExit(entry *processEntry) {
 func (m *Manager) emitFallbackBackgroundEvent(entry *processEntry, eventType EventType, snapshot Snapshot, warning postprocess.Warning) {
 	fallback, fallbackErr := m.fallbackBackgroundEvent(eventType, snapshot, warning)
 	if fallbackErr != nil {
-		m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: completionNoticeSuppressed(entry)})
+		m.emitCompletionEvent(entry, Event{Type: eventType, Snapshot: snapshot})
 	} else {
-		fallback.NoticeSuppressed = completionNoticeSuppressed(entry)
-		m.emitEvent(fallback)
+		m.emitCompletionEvent(entry, fallback)
 	}
 }
 
@@ -224,10 +223,11 @@ func (m *Manager) fallbackBackgroundEvent(eventType EventType, snapshot Snapshot
 	return newFallbackBackgroundEvent(eventType, snapshot, preview, warning, removed, false), nil
 }
 
-func completionNoticeSuppressed(entry *processEntry) bool {
+func (m *Manager) emitCompletionEvent(entry *processEntry, event Event) {
 	entry.interactMu.Lock()
 	defer entry.interactMu.Unlock()
-	return entry.completionNoticeConsumed()
+	event.NoticeSuppressed = entry.completionNoticeConsumed()
+	m.emitEvent(event)
 }
 
 func (m *Manager) collectUntil(ctx context.Context, entry *processEntry, deadline time.Time) ([]byte, error) {

--- a/server/tools/shell/manager_runtime.go
+++ b/server/tools/shell/manager_runtime.go
@@ -160,15 +160,11 @@ func (m *Manager) waitForExit(entry *processEntry) {
 	if state == "killed" {
 		eventType = EventKilled
 	}
-	entry.interactMu.Lock()
-	noticeSuppressed := entry.completionNoticeConsumed()
-	entry.interactMu.Unlock()
-
 	fullOutput, readErr := readOutputFileLimited(entry.logPath, maxFullLogPostprocessBytes)
 	if readErr == nil {
 		processed, postprocessErr := m.applyPostprocessing(context.Background(), entry, fullOutput, snapshot.ExitCode, true, defaultLimit)
 		if postprocessErr == nil && processed.Processed && strings.TrimSpace(processed.UnrecoverableError) == "" {
-			m.emitEvent(newFinalizedBackgroundEvent(eventType, snapshot, processed.Output, processed.Warning, noticeSuppressed))
+			m.emitEvent(newFinalizedBackgroundEvent(eventType, snapshot, processed.Output, processed.Warning, completionNoticeSuppressed(entry)))
 			entry.finalizeClosedExit()
 			return
 		}
@@ -176,21 +172,21 @@ func (m *Manager) waitForExit(entry *processEntry) {
 		if postprocessErr != nil {
 			warning, postprocessErr = mergeOperationalWarning(warning, fmt.Sprintf("background postprocess failed: %v", postprocessErr))
 			if postprocessErr != nil {
-				m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: noticeSuppressed})
+				m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: completionNoticeSuppressed(entry)})
 				entry.finalizeClosedExit()
 				return
 			}
 		} else if strings.TrimSpace(processed.UnrecoverableError) != "" {
 			warning, postprocessErr = mergeOperationalWarning(warning, processed.UnrecoverableError)
 			if postprocessErr != nil {
-				m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: noticeSuppressed})
+				m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: completionNoticeSuppressed(entry)})
 				entry.finalizeClosedExit()
 				return
 			}
 		}
-		fallback, fallbackErr := m.fallbackBackgroundEvent(eventType, snapshot, warning, noticeSuppressed)
+		fallback, fallbackErr := m.fallbackBackgroundEvent(eventType, snapshot, warning, completionNoticeSuppressed(entry))
 		if fallbackErr != nil {
-			m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: noticeSuppressed})
+			m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: completionNoticeSuppressed(entry)})
 		} else {
 			m.emitEvent(fallback)
 		}
@@ -199,13 +195,13 @@ func (m *Manager) waitForExit(entry *processEntry) {
 	}
 	warning, warningErr := mergeOperationalWarning(nil, fmt.Sprintf("full output log skipped: %v", readErr))
 	if warningErr != nil {
-		m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: noticeSuppressed})
+		m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: completionNoticeSuppressed(entry)})
 		entry.finalizeClosedExit()
 		return
 	}
-	fallback, fallbackErr := m.fallbackBackgroundEvent(eventType, snapshot, warning, noticeSuppressed)
+	fallback, fallbackErr := m.fallbackBackgroundEvent(eventType, snapshot, warning, completionNoticeSuppressed(entry))
 	if fallbackErr != nil {
-		m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: noticeSuppressed})
+		m.emitEvent(Event{Type: eventType, Snapshot: snapshot, NoticeSuppressed: completionNoticeSuppressed(entry)})
 	} else {
 		m.emitEvent(fallback)
 	}
@@ -226,6 +222,12 @@ func (m *Manager) fallbackBackgroundEvent(eventType EventType, snapshot Snapshot
 		removed = 1
 	}
 	return newFallbackBackgroundEvent(eventType, snapshot, preview, warning, removed, noticeSuppressed), nil
+}
+
+func completionNoticeSuppressed(entry *processEntry) bool {
+	entry.interactMu.Lock()
+	defer entry.interactMu.Unlock()
+	return entry.completionNoticeConsumed()
 }
 
 func (m *Manager) collectUntil(ctx context.Context, entry *processEntry, deadline time.Time) ([]byte, error) {

--- a/server/tools/shell/manager_types.go
+++ b/server/tools/shell/manager_types.go
@@ -41,10 +41,62 @@ const (
 type Event struct {
 	Type             EventType
 	Snapshot         Snapshot
-	Preview          string
-	PreviewProcessed bool
-	Removed          int
 	NoticeSuppressed bool
+	completion       *completionOutput
+}
+
+type completionOutputSource uint8
+
+const (
+	completionOutputFinalized completionOutputSource = iota + 1
+	completionOutputFallback
+)
+
+type completionOutput struct {
+	source  completionOutputSource
+	output  visibleShellOutput
+	removed int
+}
+
+func newBackgroundedEvent(snapshot Snapshot) Event {
+	return Event{Type: EventBackgrounded, Snapshot: snapshot}
+}
+
+func newFinalizedBackgroundEvent(eventType EventType, snapshot Snapshot, output string, warning postprocess.Warning, noticeSuppressed bool) Event {
+	return newTerminalBackgroundEvent(eventType, snapshot, completionOutput{
+		source: completionOutputFinalized,
+		output: newVisibleShellOutput(output, warning),
+	}, noticeSuppressed)
+}
+
+func newFallbackBackgroundEvent(eventType EventType, snapshot Snapshot, output string, warning postprocess.Warning, removed int, noticeSuppressed bool) Event {
+	if removed < 0 {
+		panic("background fallback removal count must not be negative")
+	}
+	return newTerminalBackgroundEvent(eventType, snapshot, completionOutput{
+		source:  completionOutputFallback,
+		output:  newVisibleShellOutput(output, warning),
+		removed: removed,
+	}, noticeSuppressed)
+}
+
+func newTerminalBackgroundEvent(eventType EventType, snapshot Snapshot, output completionOutput, noticeSuppressed bool) Event {
+	switch eventType {
+	case EventCompleted, EventKilled:
+	default:
+		panic(fmt.Sprintf("terminal background event requires completed or killed type, got %q", eventType))
+	}
+	switch output.source {
+	case completionOutputFinalized, completionOutputFallback:
+	default:
+		panic(fmt.Sprintf("terminal background event requires known output source, got %d", output.source))
+	}
+	return Event{
+		Type:             eventType,
+		Snapshot:         snapshot,
+		NoticeSuppressed: noticeSuppressed,
+		completion:       &output,
+	}
 }
 
 type Snapshot struct {
@@ -89,7 +141,7 @@ type ExecRequest struct {
 type ExecResult struct {
 	SessionID          string
 	WallTime           time.Duration
-	Warning            string
+	Warning            postprocess.Warning
 	ToolError          string
 	Output             string
 	OutputPath         string
@@ -107,6 +159,7 @@ type BackgroundNoticeSummary struct {
 	LineCount     int
 	Truncated     bool
 	LogPath       string
+	output        backgroundNoticeOutput
 }
 
 type OutputChunk struct {

--- a/server/tools/shell/postprocess/runner.go
+++ b/server/tools/shell/postprocess/runner.go
@@ -36,8 +36,83 @@ type Result struct {
 	Output             string
 	Processed          bool
 	ProcessorID        string
-	Warning            string
+	Warning            Warning
 	UnrecoverableError string
+}
+
+type warningMessage string
+
+// Warning is an opaque immutable aggregate of non-empty operational warnings.
+// Its unexported seal prevents callers outside this package from fabricating an
+// empty present warning.
+type Warning interface {
+	warningSeal()
+	Text() string
+}
+
+type warningAggregate struct {
+	messages []warningMessage
+}
+
+func NewWarning(message string) (Warning, error) {
+	normalized := strings.TrimSpace(message)
+	if normalized == "" {
+		return nil, errors.New("warning message is required")
+	}
+	return &warningAggregate{messages: []warningMessage{warningMessage(normalized)}}, nil
+}
+
+func (w *warningAggregate) warningSeal() {}
+
+func (w *warningAggregate) Text() string {
+	if w == nil || len(w.messages) == 0 {
+		panic("present warning aggregate has no messages")
+	}
+	values := make([]string, len(w.messages))
+	for index, message := range w.messages {
+		values[index] = string(message)
+	}
+	return strings.Join(values, "\n")
+}
+
+func MergeWarnings(existing Warning, next Warning) Warning {
+	if existing == nil {
+		return cloneWarning(next)
+	}
+	if next == nil {
+		return cloneWarning(existing)
+	}
+	existingAggregate := warningAggregateOf(existing)
+	nextAggregate := warningAggregateOf(next)
+	messages := make([]warningMessage, 0, len(existingAggregate.messages)+len(nextAggregate.messages))
+	messages = append(messages, existingAggregate.messages...)
+	messages = append(messages, nextAggregate.messages...)
+	return &warningAggregate{messages: messages}
+}
+
+func cloneWarning(warning Warning) Warning {
+	if warning == nil {
+		return nil
+	}
+	aggregate := warningAggregateOf(warning)
+	messages := append([]warningMessage(nil), aggregate.messages...)
+	return &warningAggregate{messages: messages}
+}
+
+func warningAggregateOf(warning Warning) *warningAggregate {
+	aggregate, ok := warning.(*warningAggregate)
+	if !ok || aggregate == nil || len(aggregate.messages) == 0 {
+		panic("present warning aggregate is invalid")
+	}
+	return aggregate
+}
+
+func mustWarning(message string) Warning {
+	warning, err := NewWarning(message)
+	if err != nil {
+		panic(err)
+	}
+	return warning
 }
 
 type Processor interface {
@@ -237,19 +312,6 @@ func resolveHookPath(raw string) (string, bool) {
 	return abs, true
 }
 
-func JoinWarnings(existing string, next string) string {
-	existing = strings.TrimSpace(existing)
-	next = strings.TrimSpace(next)
-	switch {
-	case existing == "":
-		return next
-	case next == "":
-		return existing
-	default:
-		return existing + "\n" + next
-	}
-}
-
 type Action string
 
 const (
@@ -262,7 +324,7 @@ type Envelope struct {
 	Request           Request
 	OriginalOutput    string
 	CurrentOutput     string
-	Warnings          []string
+	Warnings          []Warning
 	RecoverableErrors []ProcessorFailure
 }
 
@@ -280,9 +342,9 @@ func (e Envelope) WithOriginal(output string) Envelope {
 	return e
 }
 
-func (e Envelope) withWarning(warning string) Envelope {
-	if trimmed := strings.TrimSpace(warning); trimmed != "" {
-		e.Warnings = append(e.Warnings, trimmed)
+func (e Envelope) withWarning(warning Warning) Envelope {
+	if warning != nil {
+		e.Warnings = append(e.Warnings, cloneWarning(warning))
 	}
 	return e
 }
@@ -298,7 +360,7 @@ type Decision struct {
 	Action      Action
 	Next        Envelope
 	ProcessorID string
-	Warning     string
+	Warning     Warning
 	Failure     *ProcessorFailure
 }
 
@@ -464,12 +526,12 @@ func classifyProcessorFailure(processorID string, err error) ProcessorFailure {
 }
 
 func resultFromEnvelope(envelope Envelope, processed bool, processorID string, terminal ProcessorFailure) Result {
-	warning := ""
+	var warning Warning
 	for _, processorErr := range envelope.RecoverableErrors {
-		warning = JoinWarnings(warning, formatProcessorFailure(processorErr))
+		warning = MergeWarnings(warning, mustWarning(formatProcessorFailure(processorErr)))
 	}
 	for _, item := range envelope.Warnings {
-		warning = JoinWarnings(warning, item)
+		warning = MergeWarnings(warning, item)
 	}
 	result := Result{Output: envelope.CurrentOutput, Processed: processed, ProcessorID: processorID, Warning: warning}
 	if terminal.Severity == FailureUnrecoverable {

--- a/server/tools/shell/postprocess/runner_chain_test.go
+++ b/server/tools/shell/postprocess/runner_chain_test.go
@@ -66,11 +66,11 @@ func TestChainAccumulatesRecoverableProcessorErrors(t *testing.T) {
 		t.Fatalf("output = %q", decision.Next.CurrentOutput)
 	}
 	result := resultFromEnvelope(decision.Next, decision.Processed(), decision.ProcessorID, ProcessorFailure{})
-	if !strings.Contains(result.Warning, "Postprocess processor one failed: bad one") {
-		t.Fatalf("warning missing first error: %q", result.Warning)
+	if result.Warning == nil {
+		t.Fatal("expected recoverable failures to produce a warning")
 	}
-	if !strings.Contains(result.Warning, "Postprocess processor two failed: bad two") {
-		t.Fatalf("warning missing second error: %q", result.Warning)
+	if got := len(result.Warning.(*warningAggregate).messages); got != 2 {
+		t.Fatalf("warning count = %d, want 2", got)
 	}
 }
 

--- a/server/tools/shell/postprocess/runner_test.go
+++ b/server/tools/shell/postprocess/runner_test.go
@@ -15,6 +15,34 @@ import (
 	"core/shared/toolspec"
 )
 
+func TestWarningRejectsBlankMessageAndMergesImmutably(t *testing.T) {
+	if _, err := NewWarning(" \t\n "); err == nil {
+		t.Fatal("expected blank warning construction to fail")
+	}
+
+	first, err := NewWarning("first")
+	if err != nil {
+		t.Fatalf("NewWarning(first): %v", err)
+	}
+	second, err := NewWarning("second")
+	if err != nil {
+		t.Fatalf("NewWarning(second): %v", err)
+	}
+	merged := MergeWarnings(first, second)
+	if merged == nil {
+		t.Fatal("expected merged warning")
+	}
+	if got := len(merged.(*warningAggregate).messages); got != 2 {
+		t.Fatalf("merged warning count = %d, want 2", got)
+	}
+	if got := len(first.(*warningAggregate).messages); got != 1 {
+		t.Fatalf("first warning count mutated to %d", got)
+	}
+	if MergeWarnings(nil, nil) != nil {
+		t.Fatal("expected absent warnings to remain nil")
+	}
+}
+
 func TestRunnerBuiltinGoTestSuccessCollapsesToPass(t *testing.T) {
 	runner := NewRunner(Settings{Mode: config.ShellPostprocessingModeBuiltin})
 	exitCode := 0
@@ -544,11 +572,14 @@ func TestRunnerUserHookFailureWarningTruncatesStderr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
-	if !strings.Contains(result.Warning, "[hook output truncated]") {
-		t.Fatalf("expected truncated stderr marker, got %q", result.Warning)
+	if result.Warning == nil {
+		t.Fatal("expected hook failure warning")
 	}
-	if len(result.Warning) > maxHookOutputBytes+512 {
-		t.Fatalf("expected bounded warning length, got %d", len(result.Warning))
+	if len(result.Warning.(*warningAggregate).messages) != 1 {
+		t.Fatalf("warning count = %d, want 1", len(result.Warning.(*warningAggregate).messages))
+	}
+	if len(result.Warning.Text()) > maxHookOutputBytes+512 {
+		t.Fatalf("expected bounded warning length, got %d", len(result.Warning.Text()))
 	}
 }
 
@@ -609,8 +640,11 @@ func TestRunnerAllModeAccumulatesWarnings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
-	if !strings.Contains(result.Warning, "builtin warning") || !strings.Contains(result.Warning, "command postprocess hook failed:") {
-		t.Fatalf("warning = %q, want both warnings", result.Warning)
+	if result.Warning == nil {
+		t.Fatal("expected accumulated warnings")
+	}
+	if got := len(result.Warning.(*warningAggregate).messages); got != 2 {
+		t.Fatalf("warning count = %d, want 2", got)
 	}
 }
 
@@ -619,5 +653,9 @@ type warningProcessor struct{}
 func (warningProcessor) ID() string { return "test/warning" }
 
 func (warningProcessor) Process(_ context.Context, envelope Envelope) (Decision, error) {
-	return Decision{Action: ActionSkip, Next: envelope, Warning: "builtin warning"}, nil
+	warning, err := NewWarning("builtin warning")
+	if err != nil {
+		return Decision{}, err
+	}
+	return Decision{Action: ActionSkip, Next: envelope, Warning: warning}, nil
 }

--- a/server/tools/shell/tool.go
+++ b/server/tools/shell/tool.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -44,6 +45,9 @@ func cancellationMessage(err error) string {
 }
 
 func truncateWithTemplate(s string, maxLen int, bannerTemplate string) (string, bool, int) {
+	if strings.TrimSpace(s) == "" {
+		return "", false, 0
+	}
 	if len(s) <= maxLen {
 		return s, false, 0
 	}

--- a/server/tools/shell/tool_part2_test.go
+++ b/server/tools/shell/tool_part2_test.go
@@ -2,7 +2,7 @@ package shell
 
 import (
 	"context"
-	"strings"
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -72,21 +72,15 @@ func TestExecCommandClosesStdinForNonInteractiveProcess(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected exec_command error: %s", string(result.Output))
 	}
-	text := decodeStringToolOutput(t, result)
-	if strings.Contains(text, "Process moved to background.") {
-		t.Fatalf("expected immediate completion with closed stdin, got %q", text)
+	var output string
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("exec_command result must be a JSON string: %v", err)
 	}
-	if strings.Contains(text, "Wall time:") {
-		t.Fatalf("did not expect wall time for foreground shell, got %q", text)
+	if output == "" {
+		t.Fatal("foreground EOF completion must have non-empty output")
 	}
-	if strings.Contains(text, "Log file:") {
-		t.Fatalf("did not expect log file for foreground shell, got %q", text)
-	}
-	if strings.Contains(text, "Exit code 0, output:") {
-		t.Fatalf("did not expect zero exit code in output, got %q", text)
-	}
-	if !strings.Contains(text, "eof") {
-		t.Fatalf("expected EOF branch output, got %q", text)
+	if result.PresentationDelta != nil && result.PresentationDelta.MovedToBackground {
+		t.Fatalf("foreground EOF completion must not be backgrounded: %+v", result.PresentationDelta)
 	}
 	waitForManagerCount(t, manager, 0, 3*time.Second)
 	select {

--- a/server/tools/shell/tool_part2_test.go
+++ b/server/tools/shell/tool_part2_test.go
@@ -98,6 +98,68 @@ func TestWriteStdinSuppressesFallbackCompletionNoticeEvent(t *testing.T) {
 	waitForManagerCount(t, manager, 0, 3*time.Second)
 }
 
+func TestTerminalEventEmissionHoldsPollingInteractionLock(t *testing.T) {
+	workspace := t.TempDir()
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+	terminalHandlerStarted := make(chan struct{})
+	releaseTerminalHandler := make(chan struct{})
+	events := make(chan Event, 1)
+	manager.SetEventHandler(func(evt Event) {
+		if evt.Type != EventCompleted && evt.Type != EventKilled {
+			return
+		}
+		close(terminalHandlerStarted)
+		<-releaseTerminalHandler
+		events <- evt
+	})
+
+	result := callExecCommand(t, execTool, "bg-lock-1", map[string]any{
+		"cmd":           "sleep 0.3; echo done",
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 250,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected exec_command error: %s", string(result.Output))
+	}
+
+	select {
+	case <-terminalHandlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for terminal event handler")
+	}
+	pollDone := make(chan struct{})
+	go func() {
+		_, _ = manager.WriteStdin(context.Background(), WriteRequest{
+			SessionID:      "1000",
+			YieldTime:      250 * time.Millisecond,
+			MaxOutputChars: 16_000,
+		})
+		close(pollDone)
+	}()
+	select {
+	case <-pollDone:
+		t.Fatal("poll acquired the interaction lock while terminal event delivery was in progress")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseTerminalHandler)
+	select {
+	case evt := <-events:
+		if evt.NoticeSuppressed {
+			t.Fatalf("terminal event claimed notice suppression before polling could acquire the lock: %+v", evt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for terminal event")
+	}
+	select {
+	case <-pollDone:
+	case <-time.After(time.Second):
+		t.Fatal("poll did not complete after terminal event delivery")
+	}
+	waitForManagerCount(t, manager, 0, time.Second)
+}
+
 func TestExecCommandClosesStdinForNonInteractiveProcess(t *testing.T) {
 	workspace := t.TempDir()
 	manager := newBackgroundTestManager(t)

--- a/server/tools/shell/tool_part2_test.go
+++ b/server/tools/shell/tool_part2_test.go
@@ -51,6 +51,53 @@ func TestWriteStdinCompletionSuppressesBackgroundNoticeEvent(t *testing.T) {
 	waitForManagerCount(t, manager, 0, time.Second)
 }
 
+func TestWriteStdinSuppressesFallbackCompletionNoticeEvent(t *testing.T) {
+	workspace := t.TempDir()
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+	pollTool := NewWriteStdinTool(16_000, manager)
+	events := make(chan Event, 2)
+	manager.SetEventHandler(func(evt Event) {
+		if evt.Type == EventCompleted || evt.Type == EventKilled {
+			select {
+			case events <- evt:
+			default:
+			}
+		}
+	})
+
+	result := callExecCommand(t, execTool, "bg-large-1", map[string]any{
+		"cmd":           "sleep 0.3; dd if=/dev/zero bs=1048576 count=3 2>/dev/null | tr '\\000' x",
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 250,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected exec_command error: %s", string(result.Output))
+	}
+
+	pollResult := callWriteStdin(t, pollTool, "bg-large-2", map[string]any{
+		"session_id":    1000,
+		"yield_time_ms": 1_500,
+	})
+	if pollResult.IsError {
+		t.Fatalf("unexpected write_stdin error: %s", string(pollResult.Output))
+	}
+
+	select {
+	case evt := <-events:
+		if evt.completion == nil || evt.completion.source != completionOutputFallback {
+			t.Fatalf("expected fallback completion event, got %+v", evt)
+		}
+		if !evt.NoticeSuppressed {
+			t.Fatalf("expected fallback completion event notice to be suppressed after write_stdin harvest, got %+v", evt)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for fallback completion event")
+	}
+	waitForManagerCount(t, manager, 0, 3*time.Second)
+}
+
 func TestExecCommandClosesStdinForNonInteractiveProcess(t *testing.T) {
 	workspace := t.TempDir()
 	manager := newBackgroundTestManager(t)

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -306,6 +306,13 @@ func TestTruncateBannerUsesByteWording(t *testing.T) {
 	}
 }
 
+func TestTruncateWhitespaceOnlyOutputDoesNotCreateBanner(t *testing.T) {
+	output, truncated, removed := truncateWithTemplate(strings.Repeat(" ", 4096), 80, truncationBannerTemplate)
+	if output != "" || truncated || removed != 0 {
+		t.Fatalf("whitespace-only output truncation = (%q, %t, %d), want empty untruncated output", output, truncated, removed)
+	}
+}
+
 func TestManagerSubscribeOutputStreamsTailAndEndsAtEOF(t *testing.T) {
 	manager := newBackgroundTestManager(t)
 	workspace := t.TempDir()

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -58,6 +58,15 @@ func callWriteStdin(t *testing.T, tool *WriteStdinTool, id string, input map[str
 	return callShellTestTool(t, tool, id, toolspec.ToolWriteStdin, input)
 }
 
+func decodeWriteStdinToolOutput(t *testing.T, result tools.Result) writeStdinOutput {
+	t.Helper()
+	var output writeStdinOutput
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("decode write_stdin output: %v", err)
+	}
+	return output
+}
+
 func waitForManagerCount(t *testing.T, manager *Manager, want int, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
@@ -104,6 +113,33 @@ func newBackgroundTestManager(t *testing.T) *Manager {
 	}
 	t.Cleanup(func() { _ = manager.Close() })
 	return manager
+}
+
+func TestExecCommandSilentSuccessIsTerminalAndUnambiguous(t *testing.T) {
+	workspace := t.TempDir()
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+
+	result := callExecCommand(t, execTool, "silent-success", map[string]any{
+		"cmd":           "true",
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 1_000,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected exec_command error: %s", string(result.Output))
+	}
+	var rendered string
+	if err := json.Unmarshal(result.Output, &rendered); err != nil {
+		t.Fatalf("exec_command result must be a JSON string: %v", err)
+	}
+	if rendered == "" {
+		t.Fatal("silent terminal completion must render non-empty content")
+	}
+	if result.PresentationDelta != nil && result.PresentationDelta.MovedToBackground {
+		t.Fatalf("silent foreground completion must not be marked backgrounded: %+v", result.PresentationDelta)
+	}
+	waitForManagerCount(t, manager, 0, time.Second)
 }
 
 func envSliceToMap(t *testing.T, in []string) map[string]string {
@@ -539,6 +575,13 @@ func TestExecCommandMovesToBackgroundAndPollsToCompletion(t *testing.T) {
 	if result.PresentationDelta == nil || !result.PresentationDelta.MovedToBackground {
 		t.Fatalf("expected backgrounded presentation delta, got %+v", result.PresentationDelta)
 	}
+	snapshots := manager.List()
+	if len(snapshots) != 1 {
+		t.Fatalf("background snapshot count = %d, want 1", len(snapshots))
+	}
+	if _, err := manager.Snapshot(snapshots[0].ID); err != nil {
+		t.Fatalf("background session must be pollable: %v", err)
+	}
 
 	pollResult := callWriteStdin(t, pollTool, "bg-2", map[string]any{
 		"session_id":    1000,
@@ -547,20 +590,91 @@ func TestExecCommandMovesToBackgroundAndPollsToCompletion(t *testing.T) {
 	if pollResult.IsError {
 		t.Fatalf("unexpected write_stdin error: %s", string(pollResult.Output))
 	}
-	pollText := decodeStringToolOutput(t, pollResult)
-	if strings.Contains(pollText, "Exit code 0, output:") {
-		t.Fatalf("did not expect zero exit code in poll output, got %q", pollText)
+	pollOutput := decodeWriteStdinToolOutput(t, pollResult)
+	if pollOutput.BackgroundSessionID != 1000 {
+		t.Fatalf("background session ID = %d, want 1000", pollOutput.BackgroundSessionID)
 	}
-	if !strings.Contains(pollText, "Wall time:") {
-		t.Fatalf("expected wall time once backgrounded shell completed, got %q", pollText)
+	if pollOutput.BackgroundRunning {
+		t.Fatal("expected completed background process")
 	}
-	if !strings.Contains(pollText, "Log file:") {
-		t.Fatalf("expected log file once backgrounded shell completed, got %q", pollText)
+	if !pollOutput.Backgrounded {
+		t.Fatal("expected terminal polling result to retain background lifecycle")
 	}
-	if !strings.Contains(pollText, "done") {
-		t.Fatalf("expected command output in poll output, got %q", pollText)
+	if pollOutput.BackgroundExitCode == nil || *pollOutput.BackgroundExitCode != 0 {
+		t.Fatalf("background exit code = %v, want 0", pollOutput.BackgroundExitCode)
+	}
+	if pollOutput.Output == "" {
+		t.Fatal("completed polling output must be non-empty")
 	}
 	waitForManagerCount(t, manager, 0, time.Second)
+}
+
+func TestWriteStdinPollingPreservesTerminalLifecycleForAllCompletionShapes(t *testing.T) {
+	tests := []struct {
+		name         string
+		command      string
+		wantExitCode int
+	}{
+		{name: "zero silent", command: "sleep 0.3", wantExitCode: 0},
+		{name: "zero with output", command: "sleep 0.3; printf visible", wantExitCode: 0},
+		{name: "non-zero silent", command: "sleep 0.3; exit 7", wantExitCode: 7},
+		{name: "non-zero with output", command: "sleep 0.3; printf visible; exit 7", wantExitCode: 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			manager := newBackgroundTestManager(t)
+			execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+			pollTool := NewWriteStdinTool(16_000, manager)
+
+			start := callExecCommand(t, execTool, "poll-start", map[string]any{
+				"cmd":           tt.command,
+				"shell":         "/bin/sh",
+				"login":         false,
+				"yield_time_ms": 250,
+			})
+			if start.IsError {
+				t.Fatalf("unexpected exec_command error: %s", string(start.Output))
+			}
+			if start.PresentationDelta == nil || !start.PresentationDelta.MovedToBackground {
+				t.Fatalf("expected background transition, got %+v", start.PresentationDelta)
+			}
+			snapshots := manager.List()
+			if len(snapshots) != 1 {
+				t.Fatalf("background snapshot count = %d, want 1", len(snapshots))
+			}
+			sessionID, err := strconv.Atoi(snapshots[0].ID)
+			if err != nil {
+				t.Fatalf("background session ID must be numeric: %v", err)
+			}
+
+			poll := callWriteStdin(t, pollTool, "poll-complete", map[string]any{
+				"session_id":    sessionID,
+				"yield_time_ms": 800,
+			})
+			if poll.IsError {
+				t.Fatalf("unexpected write_stdin error: %s", string(poll.Output))
+			}
+			output := decodeWriteStdinToolOutput(t, poll)
+			if output.BackgroundSessionID != sessionID {
+				t.Fatalf("background session ID = %d, want %d", output.BackgroundSessionID, sessionID)
+			}
+			if output.BackgroundRunning {
+				t.Fatal("expected terminal polling response")
+			}
+			if !output.Backgrounded {
+				t.Fatal("expected terminal polling response to preserve backgrounded lifecycle")
+			}
+			if output.BackgroundExitCode == nil || *output.BackgroundExitCode != tt.wantExitCode {
+				t.Fatalf("background exit code = %v, want %d", output.BackgroundExitCode, tt.wantExitCode)
+			}
+			if output.Output == "" {
+				t.Fatal("terminal polling response must contain non-empty presentation")
+			}
+			waitForManagerCount(t, manager, 0, time.Second)
+		})
+	}
 }
 
 func TestWriteStdinCancellationReportsActiveProcess(t *testing.T) {
@@ -690,8 +804,8 @@ func TestExecCommandBackgroundProcessExportsAgentEnv(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected exec_command error: %s", string(result.Output))
 	}
-	if got := decodeStringToolOutput(t, result); !strings.Contains(got, "Process moved to background with ID 1000.") {
-		t.Fatalf("expected background transition, got %q", got)
+	if result.PresentationDelta == nil || !result.PresentationDelta.MovedToBackground {
+		t.Fatalf("expected background transition, got %+v", result.PresentationDelta)
 	}
 
 	pollResult := callWriteStdin(t, pollTool, "agent-env-bg-poll", map[string]any{
@@ -769,9 +883,6 @@ func TestExecCommandFileReadPostprocessorHandlesDirectCommandOnly(t *testing.T) 
 	if strings.Contains(pipelineOutput, "[Total line count:") {
 		t.Fatalf("pipeline output should not include file-read context marker, got %q", pipelineOutput)
 	}
-	if strings.Contains(pipelineOutput, "Exit code 0, output:") {
-		t.Fatalf("pipeline output should not include zero exit code header, got %q", pipelineOutput)
-	}
 	if !strings.Contains(pipelineOutput, "alpha") {
 		t.Fatalf("pipeline output missing command output, got %q", pipelineOutput)
 	}
@@ -791,12 +902,17 @@ func TestExecCommandReportsNonZeroExitCode(t *testing.T) {
 	if result.IsError {
 		t.Fatalf("unexpected exec_command error: %s", string(result.Output))
 	}
-	text := decodeStringToolOutput(t, result)
-	if !strings.Contains(text, "Exit code 7, output:") {
-		t.Fatalf("expected non-zero exit code in output, got %q", text)
+	var output string
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("exec_command result must be a JSON string: %v", err)
 	}
-	if !strings.Contains(text, "bad") {
-		t.Fatalf("expected command output, got %q", text)
+	if output == "" {
+		t.Fatal("non-zero completion with output must render non-empty content")
+	}
+	exitCode := 7
+	presentation := projectExecResult(ExecResult{ExitCode: &exitCode, Output: "bad"})
+	if presentation.kind != execPresentationForegroundCompleted || presentation.exitCode != exitCode || !presentation.output.HasVisibleContent() {
+		t.Fatalf("non-zero presentation = %+v", presentation)
 	}
 }
 
@@ -889,12 +1005,6 @@ func TestExecCommandClampsShortYieldTimeSilently(t *testing.T) {
 	text := decodeStringToolOutput(t, result)
 	if strings.Contains(text, "Warning: yield_time_ms below the minimum exec-to-background time") {
 		t.Fatalf("did not expect clamp warning, got %q", text)
-	}
-	if strings.Contains(text, "Process moved to background.") {
-		t.Fatalf("expected command to stay foreground after clamp, got %q", text)
-	}
-	if strings.Contains(text, "Exit code 0, output:") {
-		t.Fatalf("did not expect zero exit code in output, got %q", text)
 	}
 	if !strings.Contains(text, "done") {
 		t.Fatalf("expected command output, got %q", text)
@@ -1013,12 +1123,6 @@ func TestExecCommandForegroundTruncationUsesForegroundBanner(t *testing.T) {
 	if strings.Contains(text, "read log file for details") {
 		t.Fatalf("did not expect background truncation guidance in foreground output, got %q", text)
 	}
-	if strings.Contains(text, "Log file:") {
-		t.Fatalf("did not expect log file in foreground output, got %q", text)
-	}
-	if strings.Contains(text, "Process moved to background.") {
-		t.Fatalf("expected immediate completion, got %q", text)
-	}
 	if result.PresentationDelta == nil || !result.PresentationDelta.OutputTruncated {
 		t.Fatalf("expected foreground truncation presentation delta, got %+v", result.PresentationDelta)
 	}
@@ -1107,18 +1211,10 @@ func TestWriteStdinSendsInputToInteractiveProcess(t *testing.T) {
 	if stdinResult.IsError {
 		t.Fatalf("unexpected write_stdin error: %s", string(stdinResult.Output))
 	}
-	stdinText := decodeStringToolOutput(t, stdinResult)
-	if strings.Contains(stdinText, "Exit code 0, output:") {
-		t.Fatalf("did not expect zero exit code in stdin output, got %q", stdinText)
-	}
-	if !strings.Contains(stdinText, "Wall time:") {
-		t.Fatalf("expected wall time once interactive background shell completed, got %q", stdinText)
-	}
-	if !strings.Contains(stdinText, "Log file:") {
-		t.Fatalf("expected log file once interactive background shell completed, got %q", stdinText)
-	}
-	if !strings.Contains(stdinText, "hello app") {
-		t.Fatalf("expected echoed stdin in output, got %q", stdinText)
+	stdinOutput := decodeWriteStdinToolOutput(t, stdinResult)
+	if stdinOutput.BackgroundSessionID != 1000 || stdinOutput.BackgroundRunning || !stdinOutput.Backgrounded ||
+		stdinOutput.BackgroundExitCode == nil || *stdinOutput.BackgroundExitCode != 0 || stdinOutput.Output == "" {
+		t.Fatalf("completed interactive write_stdin output = %+v", stdinOutput)
 	}
 	waitForManagerCount(t, manager, 0, time.Second)
 }
@@ -1158,9 +1254,6 @@ func TestWriteStdinUsesBackgroundTruncationBannerOnCompletion(t *testing.T) {
 	}
 	if strings.Contains(stdinText, "Consider using more targeted commands") {
 		t.Fatalf("did not expect foreground truncation guidance in background output, got %q", stdinText)
-	}
-	if !strings.Contains(stdinText, "Log file:") {
-		t.Fatalf("expected completed background shell response to include log file, got %q", stdinText)
 	}
 	if stdinResult.PresentationDelta == nil || !stdinResult.PresentationDelta.OutputTruncated {
 		t.Fatalf("expected write_stdin truncation presentation delta, got %+v", stdinResult.PresentationDelta)

--- a/server/tools/shell/write_stdin_tool.go
+++ b/server/tools/shell/write_stdin_tool.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"core/server/tools"
-	"core/server/tools/shell/postprocess"
 	"core/shared/textutil"
 )
 
@@ -69,7 +68,7 @@ func (t *WriteStdinTool) Call(ctx context.Context, c tools.Call) (tools.Result, 
 		return tools.ErrorResultWith(c, formatToolCallError("write_stdin", err), marshalNoHTMLEscape), nil
 	}
 	if strings.TrimSpace(result.ToolError) != "" {
-		return tools.ErrorResultWith(c, postprocess.JoinWarnings(result.Warning, result.ToolError), marshalNoHTMLEscape), nil
+		return tools.ErrorResultWith(c, formatToolError(result.Warning, result.ToolError), marshalNoHTMLEscape), nil
 	}
 	body, marshalErr := marshalNoHTMLEscape(writeStdinOutput{
 		Output:              formatExecResponse(result),

--- a/shared/invariant/diagnostic.go
+++ b/shared/invariant/diagnostic.go
@@ -10,6 +10,7 @@ type Scope string
 const (
 	ScopeTUIProjection        Scope = "tui_projection"
 	ScopeReadModelPublication Scope = "read_model_publication"
+	ScopeBackgroundEvent      Scope = "background_event"
 )
 
 type Field string
@@ -43,6 +44,8 @@ const (
 	FieldTranscriptState          Field = "transcript_state"
 	FieldLiveState                Field = "live_state"
 	FieldProposedStepID           Field = "proposed_step_id"
+	FieldProcessID                Field = "process_id"
+	FieldBackgroundState          Field = "background_state"
 )
 
 type Diagnostic struct {
@@ -101,6 +104,27 @@ func ReadModelPublicationDiagnostic(input ReadModelPublicationDiagnosticInput) D
 			FieldCachedActivity:           input.CachedLastPublishedActivity,
 			FieldResolvedActivity:         input.ResolvedProposedActivity,
 			FieldProviderError:            input.ProviderError,
+		}),
+	}
+}
+
+type BackgroundEventDiagnosticInput struct {
+	Operation string
+	EventType string
+	ProcessID string
+	State     string
+	Cause     string
+}
+
+func BackgroundEventDiagnostic(input BackgroundEventDiagnosticInput) Diagnostic {
+	return Diagnostic{
+		Scope: ScopeBackgroundEvent,
+		Fields: fields(map[Field]string{
+			FieldOperation:       input.Operation,
+			FieldEventKind:       input.EventType,
+			FieldProcessID:       input.ProcessID,
+			FieldBackgroundState: input.State,
+			FieldInvariantError:  input.Cause,
 		}),
 	}
 }


### PR DESCRIPTION
## Summary
- make silent foreground and background shell completions explicit with exit status
- model warnings as opaque non-empty values and preserve background completion invariants
- route real manager completion events through output-mode regression coverage

## Verification
- `./scripts/test.sh ./... -count=1`
- `./scripts/ci-check.sh`
- `./scripts/build.sh --output ./bin/kent`
- `go run .kent/qa/KENT-206-shell-completion.go` (raw QA evidence retained locally under `.kent/qa`)

Manual QA covered foreground and polling zero/non-zero × silent/output, valid background transitions, default/concise/verbose notices, and silent automatic notices for exits 0 and 7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved shell command completion messages, including clearer handling of output, warnings, exit codes, truncation, and no-output results.
  * Background command notices now provide more consistent previews, retained-log details, and fallback information.
  * Added structured warning handling so multiple warnings are preserved and displayed reliably.
  * Invalid background completion events now produce controlled diagnostics instead of unreliable output.

* **Documentation**
  * Clarified foreground and background command output, failure, and post-processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->