### PR TITLE
fix: preserve executable modes in edit and patch

### DIFF
--- a/internal/testharness/filemode/assertions.go
+++ b/internal/testharness/filemode/assertions.go
@@ -1,0 +1,24 @@
+// Package filemode provides test-only filesystem permission assertions.
+package filemode
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+// AssertUnixPermissionMode asserts the complete Unix permission mode at path.
+// Windows does not represent Unix permission bits, so the assertion is skipped there.
+func AssertUnixPermissionMode(t testing.TB, path string, want os.FileMode) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode for %s = %04o, want %04o", path, got, want)
+	}
+}

--- a/server/core/small_package_guardrail_test.go
+++ b/server/core/small_package_guardrail_test.go
@@ -111,7 +111,7 @@ var allowedSmallPackages = map[string]string{
 	"cli/app/internal/runtimestate":               "DTO-only reducer boundary; package-level tests enforce stdlib plus shared/clientui imports only",
 	"cli/app/internal/startupconfig":              "narrow CLI startup config-resolution seam after absorbing serve-command env construction",
 	"internal/testharness/pty/blackbox/cmd/tuiqa": "test-tooling command boundary retained outside production CLI so arbitrary compiled clients can run strict black-box scenarios",
-	"internal/testharness/filemode":                "test-only cross-package Unix permission assertion kept out of production tool APIs so edit and patch behavior tests share one implementation",
+	"internal/testharness/filemode":               "test-only cross-package Unix permission assertion kept out of production tool APIs so edit and patch behavior tests share one implementation",
 	"internal/testharness/runtimewirefixture":     "shared runtimewire event fixture package used by app/runtimewire tests without duplicating router-facing event construction",
 	"server/bootstrap":                            "composition support boundary shared by core and startup; merging into startup creates a cycle",
 	"server/attentionnotify":                      "transient attention notification broker and batch tracker owner kept separate from registry/workflow packages to avoid making them notification state owners",

--- a/server/core/small_package_guardrail_test.go
+++ b/server/core/small_package_guardrail_test.go
@@ -111,6 +111,7 @@ var allowedSmallPackages = map[string]string{
 	"cli/app/internal/runtimestate":               "DTO-only reducer boundary; package-level tests enforce stdlib plus shared/clientui imports only",
 	"cli/app/internal/startupconfig":              "narrow CLI startup config-resolution seam after absorbing serve-command env construction",
 	"internal/testharness/pty/blackbox/cmd/tuiqa": "test-tooling command boundary retained outside production CLI so arbitrary compiled clients can run strict black-box scenarios",
+	"internal/testharness/filemode":                "test-only cross-package Unix permission assertion kept out of production tool APIs so edit and patch behavior tests share one implementation",
 	"internal/testharness/runtimewirefixture":     "shared runtimewire event fixture package used by app/runtimewire tests without duplicating router-facing event construction",
 	"server/bootstrap":                            "composition support boundary shared by core and startup; merging into startup creates a cycle",
 	"server/attentionnotify":                      "transient attention notification broker and batch tracker owner kept separate from registry/workflow packages to avoid making them notification state owners",

--- a/server/tools/edit/tool_test.go
+++ b/server/tools/edit/tool_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
+	"core/internal/testharness/filemode"
 	"core/server/tools"
 	"core/shared/toolspec"
 )
@@ -101,15 +101,7 @@ func TestEditReplacementPreservesExecutableMode(t *testing.T) {
 	if got, want := string(data), "#!/bin/sh\necho new\n"; got != want {
 		t.Fatalf("edited content = %q, want %q", got, want)
 	}
-	if runtime.GOOS != "windows" {
-		info, err := os.Stat(target)
-		if err != nil {
-			t.Fatalf("stat edited file: %v", err)
-		}
-		if got, want := info.Mode().Perm(), os.FileMode(0o755); got != want {
-			t.Fatalf("edited mode = %04o, want %04o", got, want)
-		}
-	}
+	filemode.AssertUnixPermissionMode(t, target, 0o755)
 }
 
 func TestInputAliasesAndConflicts(t *testing.T) {

--- a/server/tools/edit/tool_test.go
+++ b/server/tools/edit/tool_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -100,12 +101,14 @@ func TestEditReplacementPreservesExecutableMode(t *testing.T) {
 	if got, want := string(data), "#!/bin/sh\necho new\n"; got != want {
 		t.Fatalf("edited content = %q, want %q", got, want)
 	}
-	info, err := os.Stat(target)
-	if err != nil {
-		t.Fatalf("stat edited file: %v", err)
-	}
-	if got, want := info.Mode().Perm(), os.FileMode(0o755); got != want {
-		t.Fatalf("edited mode = %04o, want %04o", got, want)
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(target)
+		if err != nil {
+			t.Fatalf("stat edited file: %v", err)
+		}
+		if got, want := info.Mode().Perm(), os.FileMode(0o755); got != want {
+			t.Fatalf("edited mode = %04o, want %04o", got, want)
+		}
 	}
 }
 

--- a/server/tools/edit/tool_test.go
+++ b/server/tools/edit/tool_test.go
@@ -73,6 +73,42 @@ func TestExactReplaceAndReplaceAll(t *testing.T) {
 	}
 }
 
+func TestEditReplacementPreservesExecutableMode(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "script.sh")
+	if err := os.WriteFile(target, []byte("#!/bin/sh\necho old\n"), 0o755); err != nil {
+		t.Fatalf("seed executable file: %v", err)
+	}
+	if err := os.Chmod(target, 0o755); err != nil {
+		t.Fatalf("mark seed file executable: %v", err)
+	}
+	tool := newTestTool(t, dir)
+
+	result := callEdit(t, tool, map[string]any{
+		"path":       "script.sh",
+		"old_string": "echo old",
+		"new_string": "echo new",
+	})
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read edited file: %v", err)
+	}
+	if got, want := string(data), "#!/bin/sh\necho new\n"; got != want {
+		t.Fatalf("edited content = %q, want %q", got, want)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat edited file: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o755); got != want {
+		t.Fatalf("edited mode = %04o, want %04o", got, want)
+	}
+}
+
 func TestInputAliasesAndConflicts(t *testing.T) {
 	dir := t.TempDir()
 	tool := newTestTool(t, dir)

--- a/server/tools/patch/tool_commit.go
+++ b/server/tools/patch/tool_commit.go
@@ -12,6 +12,7 @@ import (
 type patchFileState struct {
 	Exists     bool
 	Content    []string
+	Mode       os.FileMode
 	NewPath    string
 	Original   string
 	StagedPath string
@@ -149,7 +150,7 @@ func commitStagedFiles(states []*patchFileState, deleteTargets map[string]struct
 	return nil
 }
 
-func createStagedFile(targetPath string, data []byte) (string, error) {
+func createStagedFile(targetPath string, data []byte, mode os.FileMode) (string, error) {
 	stageDir, err := nearestExistingDirectory(filepath.Dir(targetPath))
 	if err != nil {
 		return "", err
@@ -168,7 +169,7 @@ func createStagedFile(targetPath string, data []byte) (string, error) {
 		_ = os.Remove(path)
 		return "", err
 	}
-	if err := file.Chmod(0o644); err != nil {
+	if err := file.Chmod(mode); err != nil {
 		_ = file.Close()
 		_ = os.Remove(path)
 		return "", err

--- a/server/tools/patch/tool_state.go
+++ b/server/tools/patch/tool_state.go
@@ -113,7 +113,7 @@ func (s *applyState) getState(path string) (*patchFileState, error) {
 	if existing, ok := s.state[resolved]; ok {
 		return existing, nil
 	}
-	fileState := &patchFileState{NewPath: resolved, Original: resolved}
+	fileState := &patchFileState{Mode: 0o644, NewPath: resolved, Original: resolved}
 	snapshot, err := captureSnapshot(resolved)
 	if err == nil && snapshot.Exists {
 		fileState.Exists = true

--- a/server/tools/patch/tool_state.go
+++ b/server/tools/patch/tool_state.go
@@ -114,11 +114,12 @@ func (s *applyState) getState(path string) (*patchFileState, error) {
 		return existing, nil
 	}
 	fileState := &patchFileState{NewPath: resolved, Original: resolved}
-	data, err := os.ReadFile(resolved)
-	if err == nil {
+	snapshot, err := captureSnapshot(resolved)
+	if err == nil && snapshot.Exists {
 		fileState.Exists = true
-		fileState.Content = splitLines(string(data))
-	} else if !errors.Is(err, os.ErrNotExist) {
+		fileState.Content = splitLines(string(snapshot.Data))
+		fileState.Mode = snapshot.Mode
+	} else if err != nil {
 		return nil, internalFailure(path, fmt.Sprintf("read file failed: %v", err))
 	}
 	s.state[resolved] = fileState
@@ -147,6 +148,7 @@ func (s *applyState) addFile(op patchformat.AddFile) error {
 	s.state[target] = &patchFileState{
 		Exists:   true,
 		Content:  append([]string(nil), op.Content...),
+		Mode:     0o644,
 		NewPath:  target,
 		Original: target,
 	}
@@ -229,7 +231,7 @@ func (s *applyState) prepareCommitStates() ([]*patchFileState, error) {
 		if len(fileState.Content) > 0 && !strings.HasSuffix(text, "\n") {
 			text += "\n"
 		}
-		staged, err := createStagedFile(fileState.NewPath, []byte(text))
+		staged, err := createStagedFile(fileState.NewPath, []byte(text), fileState.Mode)
 		if err != nil {
 			return nil, internalFailure(fileState.NewPath, fmt.Sprintf("stage write failed: %v", err))
 		}

--- a/server/tools/patch/tool_test.go
+++ b/server/tools/patch/tool_test.go
@@ -2,14 +2,15 @@ package patch
 
 import (
 	"context"
-	patchformat "core/shared/transcript/patchformat"
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
+
+	"core/internal/testharness/filemode"
+	patchformat "core/shared/transcript/patchformat"
 )
 
 func TestDeleteFile(t *testing.T) {
@@ -237,7 +238,7 @@ func TestUpdateFilePreservesExecutableMode(t *testing.T) {
 	if got, want := string(data), "#!/bin/sh\necho new\n"; got != want {
 		t.Fatalf("updated content = %q, want %q", got, want)
 	}
-	assertUnixFileMode(t, target, 0o755)
+	filemode.AssertUnixPermissionMode(t, target, 0o755)
 }
 
 func TestUpdateAndMoveFilePreservesExecutableMode(t *testing.T) {
@@ -267,7 +268,7 @@ func TestUpdateAndMoveFilePreservesExecutableMode(t *testing.T) {
 	if got, want := string(data), "#!/bin/sh\necho new\n"; got != want {
 		t.Fatalf("moved content = %q, want %q", got, want)
 	}
-	assertUnixFileMode(t, destination, 0o755)
+	filemode.AssertUnixPermissionMode(t, destination, 0o755)
 }
 
 func TestUpdateFileUsesCodexStyleContextHeader(t *testing.T) {
@@ -464,21 +465,7 @@ func TestAddFileUsesDefaultNonExecutableMode(t *testing.T) {
 	if got, want := string(data), "#!/bin/sh\necho new\n"; got != want {
 		t.Fatalf("added content = %q, want %q", got, want)
 	}
-	assertUnixFileMode(t, target, 0o644)
-}
-
-func assertUnixFileMode(t *testing.T, path string, want os.FileMode) {
-	t.Helper()
-	if runtime.GOOS == "windows" {
-		return
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat %s: %v", path, err)
-	}
-	if got := info.Mode().Perm(); got != want {
-		t.Fatalf("mode for %s = %04o, want %04o", path, got, want)
-	}
+	filemode.AssertUnixPermissionMode(t, target, 0o644)
 }
 
 func TestUpdateAnchorsToHeaderInRepeatedBlocks(t *testing.T) {

--- a/server/tools/patch/tool_test.go
+++ b/server/tools/patch/tool_test.go
@@ -213,6 +213,74 @@ func TestAddUpdateMove(t *testing.T) {
 	}
 }
 
+func TestUpdateFilePreservesExecutableMode(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "script.sh")
+	if err := os.WriteFile(target, []byte("#!/bin/sh\necho old\n"), 0o755); err != nil {
+		t.Fatalf("seed executable file: %v", err)
+	}
+	if err := os.Chmod(target, 0o755); err != nil {
+		t.Fatalf("mark seed file executable: %v", err)
+	}
+	tool := newPatchTestTool(t, dir)
+
+	result := callPatch(t, tool, "preserve-executable-mode", "*** Begin Patch\n*** Update File: script.sh\n #!/bin/sh\n-echo old\n+echo new\n*** End Patch\n")
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read updated file: %v", err)
+	}
+	if got, want := string(data), "#!/bin/sh\necho new\n"; got != want {
+		t.Fatalf("updated content = %q, want %q", got, want)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat updated file: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o755); got != want {
+		t.Fatalf("updated mode = %04o, want %04o", got, want)
+	}
+}
+
+func TestUpdateAndMoveFilePreservesExecutableMode(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "script.sh")
+	destination := filepath.Join(dir, "bin", "script.sh")
+	if err := os.WriteFile(source, []byte("#!/bin/sh\necho old\n"), 0o755); err != nil {
+		t.Fatalf("seed executable file: %v", err)
+	}
+	if err := os.Chmod(source, 0o755); err != nil {
+		t.Fatalf("mark seed file executable: %v", err)
+	}
+	tool := newPatchTestTool(t, dir)
+
+	result := callPatch(t, tool, "move-preserve-executable-mode", "*** Begin Patch\n*** Update File: script.sh\n*** Move to: bin/script.sh\n #!/bin/sh\n-echo old\n+echo new\n*** End Patch\n")
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+	if _, err := os.Stat(source); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected source removed after move, stat err=%v", err)
+	}
+
+	data, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read moved file: %v", err)
+	}
+	if got, want := string(data), "#!/bin/sh\necho new\n"; got != want {
+		t.Fatalf("moved content = %q, want %q", got, want)
+	}
+	info, err := os.Stat(destination)
+	if err != nil {
+		t.Fatalf("stat moved file: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o755); got != want {
+		t.Fatalf("moved mode = %04o, want %04o", got, want)
+	}
+}
+
 func TestUpdateFileUsesCodexStyleContextHeader(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "a.go")
@@ -387,6 +455,32 @@ func TestAddFileInNewDirectory(t *testing.T) {
 	}
 	if string(data) != "hello\n" {
 		t.Fatalf("unexpected file content: %q", string(data))
+	}
+}
+
+func TestAddFileUsesDefaultNonExecutableMode(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "new-script.sh")
+	tool := newPatchTestTool(t, dir)
+
+	result := callPatch(t, tool, "add-default-mode", "*** Begin Patch\n*** Add File: new-script.sh\n+#!/bin/sh\n+echo new\n*** End Patch\n")
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read added file: %v", err)
+	}
+	if got, want := string(data), "#!/bin/sh\necho new\n"; got != want {
+		t.Fatalf("added content = %q, want %q", got, want)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat added file: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o644); got != want {
+		t.Fatalf("added mode = %04o, want %04o", got, want)
 	}
 }
 
@@ -577,12 +671,12 @@ func TestCommitStagedFilesRollsBackCommittedTargetsOnLaterFailure(t *testing.T) 
 		t.Fatalf("seed blocking dir: %v", err)
 	}
 
-	firstStage, err := createStagedFile(first, []byte("patched-first\n"))
+	firstStage, err := createStagedFile(first, []byte("patched-first\n"), 0o644)
 	if err != nil {
 		t.Fatalf("stage first file: %v", err)
 	}
 	defer func() { _ = os.Remove(firstStage) }()
-	secondStage, err := createStagedFile(blockingDir, []byte("patched-second\n"))
+	secondStage, err := createStagedFile(blockingDir, []byte("patched-second\n"), 0o644)
 	if err != nil {
 		t.Fatalf("stage second file: %v", err)
 	}

--- a/server/tools/patch/tool_test.go
+++ b/server/tools/patch/tool_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -236,13 +237,7 @@ func TestUpdateFilePreservesExecutableMode(t *testing.T) {
 	if got, want := string(data), "#!/bin/sh\necho new\n"; got != want {
 		t.Fatalf("updated content = %q, want %q", got, want)
 	}
-	info, err := os.Stat(target)
-	if err != nil {
-		t.Fatalf("stat updated file: %v", err)
-	}
-	if got, want := info.Mode().Perm(), os.FileMode(0o755); got != want {
-		t.Fatalf("updated mode = %04o, want %04o", got, want)
-	}
+	assertUnixFileMode(t, target, 0o755)
 }
 
 func TestUpdateAndMoveFilePreservesExecutableMode(t *testing.T) {
@@ -272,13 +267,7 @@ func TestUpdateAndMoveFilePreservesExecutableMode(t *testing.T) {
 	if got, want := string(data), "#!/bin/sh\necho new\n"; got != want {
 		t.Fatalf("moved content = %q, want %q", got, want)
 	}
-	info, err := os.Stat(destination)
-	if err != nil {
-		t.Fatalf("stat moved file: %v", err)
-	}
-	if got, want := info.Mode().Perm(), os.FileMode(0o755); got != want {
-		t.Fatalf("moved mode = %04o, want %04o", got, want)
-	}
+	assertUnixFileMode(t, destination, 0o755)
 }
 
 func TestUpdateFileUsesCodexStyleContextHeader(t *testing.T) {
@@ -475,12 +464,20 @@ func TestAddFileUsesDefaultNonExecutableMode(t *testing.T) {
 	if got, want := string(data), "#!/bin/sh\necho new\n"; got != want {
 		t.Fatalf("added content = %q, want %q", got, want)
 	}
-	info, err := os.Stat(target)
-	if err != nil {
-		t.Fatalf("stat added file: %v", err)
+	assertUnixFileMode(t, target, 0o644)
+}
+
+func assertUnixFileMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
 	}
-	if got, want := info.Mode().Perm(), os.FileMode(0o644); got != want {
-		t.Fatalf("added mode = %04o, want %04o", got, want)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode for %s = %04o, want %04o", path, got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Preserve the source permission mode when patch updates replace or move an existing file.
- Keep patch-added files at the explicit non-executable `0644` default.
- Add edit/patch regression coverage and centralize Unix-mode assertions in a test-only shared helper; Windows retains content/path coverage while skipping unsupported Unix mode checks.

## Verification
- `./scripts/test.sh ./server/tools/edit ./server/tools/patch`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/kent-edit-windows.test.exe ./server/tools/edit`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/kent-patch-windows.test.exe ./server/tools/patch`
- `./scripts/test.sh server`
- `./scripts/build.sh --output ./bin/kent`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File edits and updates now preserve existing Unix executable permissions.
  * File moves retain the source file’s permission mode.
  * Newly added files use non-executable permissions by default.

* **Tests**
  * Added coverage for permission preservation during edits, updates, moves, and staged operations.
  * Added cross-platform handling for Unix-specific permission checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->