### PR TITLE
fix: restore /back parent composer prefill

### DIFF
--- a/cli/app/auth_gate_test.go
+++ b/cli/app/auth_gate_test.go
@@ -227,14 +227,11 @@ func TestResolveSessionActionLogoutUsesBootstrapAuthInteractor(t *testing.T) {
 	if pickerCalls != 1 {
 		t.Fatalf("expected auth picker to be called once, got %d", pickerCalls)
 	}
-	if !resolved.ShouldContinue {
-		t.Fatal("expected logout flow to continue after reauth")
+	if got := requireSessionOpenDestination(t, resolved); got != store.Meta().SessionID {
+		t.Fatalf("expected session to continue in place, got %q", got)
 	}
-	if resolved.NextSessionID != store.Meta().SessionID {
-		t.Fatalf("expected session to continue in place, got %q", resolved.NextSessionID)
-	}
-	if resolved.InitialPrompt != "" || resolved.InitialInput.TransitionInput != "" || resolved.ParentSessionID != "" || resolved.ForceNewSession {
-		t.Fatalf("unexpected logout transition values prompt=%q input=%q parent=%q forceNew=%t", resolved.InitialPrompt, resolved.InitialInput.TransitionInput, resolved.ParentSessionID, resolved.ForceNewSession)
+	if resolved.InitialPrompt != nil || resolved.InitialInput.TransitionInput != "" {
+		t.Fatalf("unexpected logout transition values prompt=%+v input=%q", resolved.InitialPrompt, resolved.InitialInput.TransitionInput)
 	}
 
 	state, err := mgr.Load(ctx)
@@ -282,12 +279,7 @@ func TestResolveSessionActionLogoutAllowsNilStore(t *testing.T) {
 	if pickerCalls != 1 {
 		t.Fatalf("expected auth picker to be called once, got %d", pickerCalls)
 	}
-	if !resolved.ShouldContinue {
-		t.Fatal("expected logout flow to continue after reauth")
-	}
-	if resolved.NextSessionID != "" {
-		t.Fatalf("expected no next session id without a current store, got %q", resolved.NextSessionID)
-	}
+	requireSessionPickerDestination(t, resolved)
 }
 
 func TestResolveSessionActionLogoutCancelPreservesStoredAuth(t *testing.T) {
@@ -394,7 +386,7 @@ func TestResolveSessionActionLogoutRetryPreservesStoredAuthUntilSuccess(t *testi
 	if err != nil {
 		t.Fatalf("resolve session action: %v", err)
 	}
-	if !resolved.ShouldContinue {
+	if resolved == nil {
 		t.Fatal("expected successful retry to continue session")
 	}
 	if pickCalls != 2 {
@@ -626,7 +618,7 @@ func TestResolveSessionActionLoginSkipClearsStoredAuthOnOptionalAuthSetup(t *tes
 	if err != nil {
 		t.Fatalf("resolve session action: %v", err)
 	}
-	if !resolved.ShouldContinue {
+	if resolved == nil {
 		t.Fatal("expected login skip flow to continue")
 	}
 

--- a/cli/app/auth_gate_test.go
+++ b/cli/app/auth_gate_test.go
@@ -233,8 +233,8 @@ func TestResolveSessionActionLogoutUsesBootstrapAuthInteractor(t *testing.T) {
 	if resolved.NextSessionID != store.Meta().SessionID {
 		t.Fatalf("expected session to continue in place, got %q", resolved.NextSessionID)
 	}
-	if resolved.InitialPrompt != "" || resolved.InitialInput != "" || resolved.ParentSessionID != "" || resolved.ForceNewSession {
-		t.Fatalf("unexpected logout transition values prompt=%q input=%q parent=%q forceNew=%t", resolved.InitialPrompt, resolved.InitialInput, resolved.ParentSessionID, resolved.ForceNewSession)
+	if resolved.InitialPrompt != "" || resolved.InitialInput.TransitionInput != "" || resolved.ParentSessionID != "" || resolved.ForceNewSession {
+		t.Fatalf("unexpected logout transition values prompt=%q input=%q parent=%q forceNew=%t", resolved.InitialPrompt, resolved.InitialInput.TransitionInput, resolved.ParentSessionID, resolved.ForceNewSession)
 	}
 
 	state, err := mgr.Load(ctx)

--- a/cli/app/back_parent_prefill_integration_test.go
+++ b/cli/app/back_parent_prefill_integration_test.go
@@ -219,8 +219,8 @@ func runBackParentPrefillScenario(t *testing.T, server backParentPrefillScenario
 
 			planner := newSessionLaunchPlanner(server)
 			parentPlan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{
-				Mode:              launchModeInteractive,
-				SelectedSessionID: parentSessionID,
+				Mode:        launchModeInteractive,
+				Destination: sessionOpenDestinationForTest(t, parentSessionID),
 			})
 			if err != nil {
 				t.Fatalf("plan parent session: %v", err)

--- a/cli/app/back_parent_prefill_integration_test.go
+++ b/cli/app/back_parent_prefill_integration_test.go
@@ -1,0 +1,285 @@
+package app
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"core/server/llm"
+	serverstartup "core/server/startup"
+	"core/shared/client"
+	"core/shared/clientui"
+	"core/shared/serverapi"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/google/uuid"
+)
+
+type backParentPrefillScenarioServer interface {
+	interactiveSessionServer
+	ProjectID() string
+	SessionViewClient() client.SessionViewClient
+}
+
+func TestBackParentPrefillTransportParity(t *testing.T) {
+	t.Run("embedded loopback", func(t *testing.T) {
+		_, workspace := newRegisteredAppWorkspace(t)
+		server, err := startEmbeddedServer(context.Background(), Options{
+			WorkspaceRoot:         workspace,
+			WorkspaceRootExplicit: true,
+			Model:                 "gpt-5",
+		}, readyMemoryAuthHandler(), false)
+		if err != nil {
+			t.Fatalf("start embedded server: %v", err)
+		}
+		defer func() { _ = server.Close() }()
+
+		runBackParentPrefillScenario(t, server)
+	})
+
+	t.Run("served remote", func(t *testing.T) {
+		_, workspace := newRegisteredAppWorkspace(t)
+		srv, err := serverstartup.StartServeServer(context.Background(), serverstartup.Request{
+			WorkspaceRoot:         workspace,
+			WorkspaceRootExplicit: true,
+			Model:                 "gpt-5",
+		}, apiKeyMemoryAuthHandler("test-key"), autoOnboarding)
+		if err != nil {
+			t.Fatalf("start served app server: %v", err)
+		}
+		defer func() { _ = srv.Close() }()
+
+		stopServing := serveAppServer(t, srv)
+		defer stopServing()
+		waitForConfiguredRemoteIdentity(t, workspace)
+
+		server, err := startSessionServer(
+			context.Background(),
+			Options{WorkspaceRoot: workspace, WorkspaceRootExplicit: true},
+			newHeadlessAuthInteractor(),
+			false,
+		)
+		if err != nil {
+			t.Fatalf("start remote session server: %v", err)
+		}
+		defer func() { _ = server.Close() }()
+		remote, ok := server.(*remoteAppServer)
+		if !ok {
+			t.Fatalf("session server = %T, want remote app server", server)
+		}
+		boundServer, err := ensureInteractiveProjectBinding(context.Background(), remote)
+		if err != nil {
+			t.Fatalf("bind remote server to project workspace: %v", err)
+		}
+		boundRemote, ok := boundServer.(*remoteAppServer)
+		if !ok {
+			t.Fatalf("bound session server = %T, want remote app server", boundServer)
+		}
+		defer func() { _ = boundRemote.Close() }()
+
+		runBackParentPrefillScenario(t, boundRemote)
+	})
+}
+
+func runBackParentPrefillScenario(t *testing.T, server backParentPrefillScenarioServer) {
+	t.Helper()
+
+	exactFinal := " \nExact café 👩🏽‍💻\n尾  "
+	tests := []struct {
+		name        string
+		finalAnswer *string
+	}{
+		{
+			name:        "exact durable final",
+			finalAnswer: &exactFinal,
+		},
+		{
+			name: "absent durable final",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := createAttachedAuthoritativeAppSession(t, server.Config().PersistenceRoot, server.ProjectID(), server.Config().WorkspaceRoot)
+			child := createAttachedAuthoritativeAppSession(t, server.Config().PersistenceRoot, server.ProjectID(), server.Config().WorkspaceRoot)
+			if err := child.SetParentSessionID(parent.Meta().SessionID); err != nil {
+				t.Fatalf("link child to parent: %v", err)
+			}
+			if _, _, err := child.AppendEvent("child-step", "message", llm.Message{
+				Role:    llm.RoleUser,
+				Content: "child task",
+			}); err != nil {
+				t.Fatalf("append child user message: %v", err)
+			}
+			if tt.finalAnswer != nil {
+				if _, _, err := child.AppendEvent("child-step", "message", llm.Message{
+					Role:    llm.RoleAssistant,
+					Phase:   llm.MessagePhaseFinal,
+					Content: *tt.finalAnswer,
+				}); err != nil {
+					t.Fatalf("append child final answer: %v", err)
+				}
+			}
+
+			_, err := server.SessionLifecycleClient().PersistInputDraft(
+				context.Background(),
+				serverapi.SessionPersistInputDraftRequest{
+					ClientRequestID: uuid.NewString(),
+					SessionID:       parent.Meta().SessionID,
+					Input:           "conflicting parent draft",
+					RecoveryBuffers: []serverapi.SessionDraftRecoveryBuffer{
+						{
+							Kind:            serverapi.SessionDraftRecoveryBufferPendingInjectedInput,
+							ID:              "pending-parent-input",
+							ClientRequestID: "pending-parent-request",
+							Text:            "conflicting pending input",
+						},
+						{
+							Kind: serverapi.SessionDraftRecoveryBufferQueuedInput,
+							ID:   "queued-parent-input",
+							Text: "conflicting queued input",
+						},
+					},
+				},
+			)
+			if err != nil {
+				t.Fatalf("persist conflicting parent draft: %v", err)
+			}
+
+			childView, err := server.SessionViewClient().GetSessionMainView(
+				context.Background(),
+				serverapi.SessionMainViewRequest{SessionID: child.Meta().SessionID},
+			)
+			if err != nil {
+				t.Fatalf("load child main view: %v", err)
+			}
+			childRuntime := &runtimeControlFakeClient{
+				mainView: clientui.RuntimeMainView{
+					Status:  childView.MainView.Status,
+					Session: childView.MainView.Session,
+				},
+			}
+			childModel := newProjectedClosedUIModel(childRuntime, WithUISessionID(child.Meta().SessionID))
+			childModel.statusConfig.SessionViews = server.SessionViewClient()
+
+			next, lookupCmd := childModel.inputController().handleBackCommand()
+			childModel = next.(*uiModel)
+			if lookupCmd == nil || childModel.finalAnswerOperation == nil {
+				t.Fatal("/back did not start the final-answer lookup")
+			}
+			lookupBatchMsg := lookupCmd()
+			batch, ok := lookupBatchMsg.(tea.BatchMsg)
+			if !ok || len(batch) == 0 {
+				t.Fatalf("/back command result = %T, want lookup batch", lookupBatchMsg)
+			}
+			firstLookupMsg := batch[0]()
+			lookupDone, ok := firstLookupMsg.(latestFinalAnswerDoneMsg)
+			if !ok {
+				t.Fatalf("first /back operation result = %T, want final-answer lookup result", firstLookupMsg)
+			}
+			next, quitCmd := childModel.Update(lookupDone)
+			childModel = next.(*uiModel)
+			if quitCmd == nil {
+				t.Fatal("successful /back lookup did not request child UI exit")
+			}
+			transition := childModel.Transition()
+			if transition.Action != UIActionOpenSession || transition.TargetSessionID != parent.Meta().SessionID {
+				t.Fatalf("/back transition = %+v, want open parent", transition)
+			}
+			wantInput := ""
+			if tt.finalAnswer != nil {
+				wantInput = *tt.finalAnswer
+			}
+			if transition.InitialInput != wantInput {
+				t.Fatalf("/back transition input = %q, want %q", transition.InitialInput, wantInput)
+			}
+
+			originReleased := false
+			handoff, err := resolveAndReleaseSessionHandoff(
+				context.Background(),
+				server,
+				nil,
+				child.Meta().SessionID,
+				transition,
+				&runtimeLaunchPlan{close: func() error {
+					originReleased = true
+					return nil
+				}},
+			)
+			if err != nil {
+				t.Fatalf("resolve and release child handoff: %v", err)
+			}
+			if !originReleased {
+				t.Fatal("child runtime was not released before parent launch")
+			}
+			if handoff.NextSessionID != parent.Meta().SessionID || handoff.InitialInput.TransitionInput != wantInput {
+				t.Fatalf("resolved handoff = %+v, want parent with exact transition input", handoff)
+			}
+
+			planner := newSessionLaunchPlanner(server)
+			parentPlan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{
+				Mode:              launchModeInteractive,
+				SelectedSessionID: handoff.NextSessionID,
+			})
+			if err != nil {
+				t.Fatalf("plan parent session: %v", err)
+			}
+			parentRuntimePlan, request, err := prepareSessionUIRun(
+				context.Background(),
+				server,
+				planner,
+				parentPlan,
+				handoff,
+				false,
+			)
+			if err != nil {
+				t.Fatalf("prepare parent UI: %v", err)
+			}
+			defer func() { _ = parentRuntimePlan.Close() }()
+
+			composition, err := composeUIProgram(request, io.Discard)
+			if err != nil {
+				t.Fatalf("compose parent UI: %v", err)
+			}
+			defer composition.close()
+			parentModel := composition.model
+
+			if parentModel.input != wantInput {
+				t.Fatalf("parent composer input = %q, want %q", parentModel.input, wantInput)
+			}
+			if parentModel.startupSubmit != "" || parentModel.activeSubmit.text != "" || parentModel.isBusy() {
+				t.Fatalf("parent prefill submitted on startup: startup=%q active=%+v busy=%t", parentModel.startupSubmit, parentModel.activeSubmit, parentModel.isBusy())
+			}
+			if len(parentModel.recoveredDraftBuffers) != 0 || len(parentModel.pendingInjected) != 0 || len(parentModel.queued) != 0 {
+				t.Fatalf("parent draft recovery leaked: recovered=%+v pending=%+v queued=%+v", parentModel.recoveredDraftBuffers, parentModel.pendingInjected, parentModel.queued)
+			}
+
+			beforeEdit, err := parentRuntimePlan.Wiring.runtimeClient.RefreshMainView()
+			if err != nil {
+				t.Fatalf("refresh parent runtime before edit: %v", err)
+			}
+			next, editCmd := parentModel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+			edited := next.(*uiModel)
+			if editCmd != nil {
+				t.Fatal("normal parent composer edit created a runtime command")
+			}
+			if edited.input != wantInput+"x" {
+				t.Fatalf("edited parent input = %q, want %q", edited.input, wantInput+"x")
+			}
+			afterEdit, err := parentRuntimePlan.Wiring.runtimeClient.RefreshMainView()
+			if err != nil {
+				t.Fatalf("refresh parent runtime after edit: %v", err)
+			}
+			if afterEdit.Activity != beforeEdit.Activity || afterEdit.Activity.State != clientui.RuntimeActivityRegisteredIdle {
+				t.Fatalf("normal edit changed parent runtime activity: before=%+v after=%+v", beforeEdit.Activity, afterEdit.Activity)
+			}
+			hasQueuedWork, err := parentRuntimePlan.Wiring.runtimeClient.HasQueuedUserWork()
+			if err != nil {
+				t.Fatalf("read parent queued work after edit: %v", err)
+			}
+			if hasQueuedWork {
+				t.Fatal("normal parent composer edit created queued runtime work")
+			}
+		})
+	}
+}

--- a/cli/app/back_parent_prefill_integration_test.go
+++ b/cli/app/back_parent_prefill_integration_test.go
@@ -212,14 +212,15 @@ func runBackParentPrefillScenario(t *testing.T, server backParentPrefillScenario
 			if !originReleased {
 				t.Fatal("child runtime was not released before parent launch")
 			}
-			if handoff.NextSessionID != parent.Meta().SessionID || handoff.InitialInput.TransitionInput != wantInput {
+			parentSessionID := requireSessionOpenDestination(t, handoff)
+			if parentSessionID != parent.Meta().SessionID || handoff.InitialInput.TransitionInput != wantInput {
 				t.Fatalf("resolved handoff = %+v, want parent with exact transition input", handoff)
 			}
 
 			planner := newSessionLaunchPlanner(server)
 			parentPlan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{
 				Mode:              launchModeInteractive,
-				SelectedSessionID: handoff.NextSessionID,
+				SelectedSessionID: parentSessionID,
 			})
 			if err != nil {
 				t.Fatalf("plan parent session: %v", err)
@@ -229,7 +230,7 @@ func runBackParentPrefillScenario(t *testing.T, server backParentPrefillScenario
 				server,
 				planner,
 				parentPlan,
-				handoff,
+				*handoff,
 				false,
 			)
 			if err != nil {

--- a/cli/app/embedded_server_part2_test.go
+++ b/cli/app/embedded_server_part2_test.go
@@ -26,7 +26,7 @@ func TestEmbeddedAppServerDeliversBackgroundCompletionWhileIdle(t *testing.T) {
 		t.Fatalf("start embedded server: %v", err)
 	}
 	defer func() { _ = server.Close() }()
-	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive}, io.Discard, "test background completion while idle")
+	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}}, io.Discard, "test background completion while idle")
 	defer runtimePlan.Close()
 
 	activity := server.inner.SessionActivityClient()
@@ -64,7 +64,7 @@ func TestPrepareRuntimeForwardsBackgroundCompletionIntoProjectedRuntimeEvents(t 
 	}
 	defer func() { _ = server.Close() }()
 
-	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive}, io.Discard, "test projected background completion while idle")
+	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}}, io.Discard, "test projected background completion while idle")
 	defer runtimePlan.Close()
 
 	processID := "bg-1001"
@@ -94,7 +94,7 @@ func TestEmbeddedAppServerPrepareRuntimeWiresProcessControlForUIActions(t *testi
 	}
 	defer func() { _ = server.Close() }()
 
-	_, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive}, io.Discard, "test prepare runtime process control")
+	_, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}}, io.Discard, "test prepare runtime process control")
 	defer runtimePlan.Close()
 	if runtimePlan.Wiring.processControls == nil {
 		t.Fatal("expected PrepareRuntime to wire process control client")
@@ -128,7 +128,7 @@ func TestEmbeddedAppServerPrepareRuntimeWiresProcessOutputClient(t *testing.T) {
 	}
 	defer func() { _ = server.Close() }()
 
-	_, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive}, io.Discard, "test prepare runtime process output")
+	_, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}}, io.Discard, "test prepare runtime process output")
 	defer runtimePlan.Close()
 	if runtimePlan.Wiring.processOutput == nil {
 		t.Fatal("expected PrepareRuntime to wire process output client")
@@ -144,7 +144,7 @@ func TestEmbeddedAppServerPromptActivityStreamsAndHydratesPendingResources(t *te
 	}
 	defer func() { _ = server.Close() }()
 
-	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, io.Discard, "test embedded prompt activity parity")
+	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}}, io.Discard, "test embedded prompt activity parity")
 	defer runtimePlan.Close()
 
 	askDone := make(chan struct {
@@ -228,7 +228,7 @@ func TestEmbeddedAppServerPendingPromptsKeepPromptActivityForAnsweringOnly(t *te
 	}
 	defer func() { _ = server.Close() }()
 
-	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, io.Discard, "test embedded ask notification")
+	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}}, io.Discard, "test embedded ask notification")
 	defer runtimePlan.Close()
 
 	model := newProjectedTestUIModel(runtimePlan.Wiring.runtimeClient, closedProjectedRuntimeEvents(), runtimePlan.Wiring.askEvents)
@@ -276,7 +276,7 @@ func TestEmbeddedAppServerProcessOutputStreamsAndInlineSnapshot(t *testing.T) {
 	defer func() { _ = server.Close() }()
 
 	planner := newSessionLaunchPlanner(server)
-	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true})
+	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}})
 	if err != nil {
 		t.Fatalf("plan session: %v", err)
 	}

--- a/cli/app/embedded_server_test.go
+++ b/cli/app/embedded_server_test.go
@@ -469,7 +469,7 @@ func TestEmbeddedAppServerPrepareRuntimeRegistersRuntimeForSessionViews(t *testi
 	}
 	defer func() { _ = server.Close() }()
 
-	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive}, io.Discard, "test prepare runtime")
+	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}}, io.Discard, "test prepare runtime")
 	defer runtimePlan.Close()
 	if err := runtimePlan.Wiring.runtimeControls.SetThinkingLevel(context.Background(), serverapi.RuntimeSetThinkingLevelRequest{ClientRequestID: uuid.NewString(), SessionID: plan.SessionID, Level: "high"}); err != nil {
 		t.Fatalf("set thinking level: %v", err)
@@ -496,7 +496,7 @@ func TestEmbeddedAppServerPrepareRuntimeWiresProcessReadsForUIHydration(t *testi
 	}
 	defer func() { _ = server.Close() }()
 
-	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive}, io.Discard, "test prepare runtime process reads")
+	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}}, io.Discard, "test prepare runtime process reads")
 	defer runtimePlan.Close()
 	if runtimePlan.Wiring.processViews == nil {
 		t.Fatal("expected PrepareRuntime to wire process view client")
@@ -550,7 +550,7 @@ func TestEmbeddedAppServerPrepareRuntimeExposesPendingAsksAndApprovals(t *testin
 	}
 	defer func() { _ = server.Close() }()
 
-	_, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive}, io.Discard, "test prepare runtime pending prompts")
+	_, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}}, io.Discard, "test prepare runtime pending prompts")
 	defer runtimePlan.Close()
 	if runtimePlan.Wiring.askViews == nil || runtimePlan.Wiring.approvalViews == nil || runtimePlan.Wiring.promptControl == nil {
 		t.Fatal("expected PrepareRuntime to wire shared prompt clients")
@@ -608,7 +608,7 @@ func TestEmbeddedAppServerPrepareRuntimeWiresSessionActivityForSharedClients(t *
 	}
 	defer func() { _ = server.Close() }()
 
-	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive}, io.Discard, "test prepare runtime session activity")
+	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}}, io.Discard, "test prepare runtime session activity")
 	defer runtimePlan.Close()
 
 	reads := server.SessionViewClient()
@@ -668,10 +668,10 @@ func TestEmbeddedAppServerPrepareRuntimeIsolatesSessionActivityBetweenSessions(t
 	}
 	defer func() { _ = server.Close() }()
 
-	planA, runtimePlanA := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive}, io.Discard, "test prepare runtime session activity A")
+	planA, runtimePlanA := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}}, io.Discard, "test prepare runtime session activity A")
 	defer runtimePlanA.Close()
 
-	planB, runtimePlanB := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive}, io.Discard, "test prepare runtime session activity B")
+	planB, runtimePlanB := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}}, io.Discard, "test prepare runtime session activity B")
 	defer runtimePlanB.Close()
 
 	activity := server.inner.SessionActivityClient()
@@ -734,10 +734,10 @@ func TestEmbeddedAppServerRoutesBackgroundCompletionToOwningSessionOnly(t *testi
 	}
 	defer func() { _ = server.Close() }()
 
-	planA, runtimePlanA := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive}, io.Discard, "test background completion isolation A")
+	planA, runtimePlanA := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}}, io.Discard, "test background completion isolation A")
 	defer runtimePlanA.Close()
 
-	planB, runtimePlanB := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive}, io.Discard, "test background completion isolation B")
+	planB, runtimePlanB := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}}, io.Discard, "test background completion isolation B")
 	defer runtimePlanB.Close()
 
 	activity := server.inner.SessionActivityClient()

--- a/cli/app/launch_planner.go
+++ b/cli/app/launch_planner.go
@@ -27,11 +27,9 @@ const (
 )
 
 type sessionLaunchRequest struct {
-	Mode              launchMode
-	SelectedSessionID string
-	ForceNewSession   bool
-	ParentSessionID   string
-	Overrides         serverapi.RunPromptOverrides
+	Mode        launchMode
+	Destination sessionLaunchDestination
+	Overrides   serverapi.RunPromptOverrides
 }
 
 type sessionLaunchPlan struct {
@@ -52,7 +50,8 @@ type sessionLaunchPlan struct {
 }
 
 type resolvedSessionPlanRequest struct {
-	request             serverapi.SessionPlanRequest
+	destination         sessionLaunchDestination
+	overrides           serverapi.RunPromptOverrides
 	selectedViaPicker   bool
 	sessionSummaries    []clientui.SessionSummary
 	hasSessionSummaries bool
@@ -135,7 +134,11 @@ func (p *launchPlanner) PlanSession(ctx context.Context, req sessionLaunchReques
 	if err != nil {
 		return sessionLaunchPlan{}, err
 	}
-	resp, err := p.server.SessionLaunchClient().PlanSession(ctx, resolved.request)
+	apiRequest, err := resolved.apiRequest(req.Mode)
+	if err != nil {
+		return sessionLaunchPlan{}, err
+	}
+	resp, err := p.server.SessionLaunchClient().PlanSession(ctx, apiRequest)
 	if err != nil {
 		return sessionLaunchPlan{}, err
 	}
@@ -222,19 +225,19 @@ func (p *launchPlanner) PrepareRuntime(ctx context.Context, plan sessionLaunchPl
 func (p *launchPlanner) resolvePlanRequest(ctx context.Context, req sessionLaunchRequest) (resolvedSessionPlanRequest, error) {
 	overrides := sessionPlanOverridesFromConfig(p.server.Config())
 	overrides = mergeSessionPlanOverrides(overrides, req.Overrides)
-	resolved := resolvedSessionPlanRequest{request: serverapi.SessionPlanRequest{
-		ClientRequestID:   uuid.NewString(),
-		Mode:              serverapi.SessionLaunchMode(req.Mode),
-		SelectedSessionID: strings.TrimSpace(req.SelectedSessionID),
-		ForceNewSession:   req.ForceNewSession,
-		ParentSessionID:   strings.TrimSpace(req.ParentSessionID),
-		Overrides:         overrides,
-	}}
-	if resolved.request.Mode == serverapi.SessionLaunchModeHeadless && resolved.request.SelectedSessionID == "" {
-		resolved.request.ForceNewSession = true
-		return resolved, nil
+	resolved := resolvedSessionPlanRequest{
+		destination: req.Destination,
+		overrides:   overrides,
 	}
-	if resolved.request.SelectedSessionID != "" || resolved.request.ForceNewSession {
+	switch req.Destination.(type) {
+	case sessionOpenDestination, sessionCreateDestination:
+		return resolved, nil
+	case sessionPickerDestination:
+	default:
+		return resolvedSessionPlanRequest{}, errors.New("session launch destination is required")
+	}
+	if req.Mode == launchModeHeadless {
+		resolved.destination = sessionCreateDestination{}
 		return resolved, nil
 	}
 	summaries, err := p.listSessionSummaries(ctx)
@@ -244,7 +247,7 @@ func (p *launchPlanner) resolvePlanRequest(ctx context.Context, req sessionLaunc
 	resolved.sessionSummaries = append([]clientui.SessionSummary(nil), summaries...)
 	resolved.hasSessionSummaries = true
 	if len(summaries) == 0 {
-		resolved.request.ForceNewSession = true
+		resolved.destination = sessionCreateDestination{}
 		return resolved, nil
 	}
 	if p.pickSession == nil {
@@ -259,15 +262,39 @@ func (p *launchPlanner) resolvePlanRequest(ctx context.Context, req sessionLaunc
 		return resolvedSessionPlanRequest{}, projectbinding.ErrStartupCanceledByUser
 	}
 	if picked.CreateNew {
-		resolved.request.ForceNewSession = true
+		resolved.destination = sessionCreateDestination{}
 		return resolved, nil
 	}
 	if picked.Session == nil {
 		return resolvedSessionPlanRequest{}, errors.New("no session selected")
 	}
-	resolved.request.SelectedSessionID = picked.Session.SessionID
+	destination, err := newSessionOpenDestination(picked.Session.SessionID)
+	if err != nil {
+		return resolvedSessionPlanRequest{}, err
+	}
+	resolved.destination = destination
 	resolved.selectedViaPicker = true
 	return resolved, nil
+}
+
+func (r resolvedSessionPlanRequest) apiRequest(mode launchMode) (serverapi.SessionPlanRequest, error) {
+	request := serverapi.SessionPlanRequest{
+		ClientRequestID: uuid.NewString(),
+		Mode:            serverapi.SessionLaunchMode(mode),
+		Overrides:       r.overrides,
+	}
+	switch destination := r.destination.(type) {
+	case sessionOpenDestination:
+		request.SelectedSessionID = destination.SessionID()
+	case sessionCreateDestination:
+		request.ForceNewSession = true
+		if destination.Parent != nil {
+			request.ParentSessionID = destination.Parent.SessionID()
+		}
+	default:
+		return serverapi.SessionPlanRequest{}, errors.New("resolved session launch destination is required")
+	}
+	return request, nil
 }
 
 func (p *launchPlanner) sessionPickerHeaderInfo(cfg config.App) sessionPickerHeaderInfo {

--- a/cli/app/launch_planner_destination_test.go
+++ b/cli/app/launch_planner_destination_test.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"testing"
+
+	"core/shared/serverapi"
+)
+
+func TestResolvedSessionPlanRequestConvertsTypedDestinationAtAPIClientBoundary(t *testing.T) {
+	openDestination := sessionOpenDestinationForTest(t, " session-1 ")
+	parent := sessionParentReferenceForTest(t, " parent-1 ")
+	tests := []struct {
+		name                string
+		destination         sessionLaunchDestination
+		wantSelectedSession string
+		wantForceNew        bool
+		wantParentSession   string
+	}{
+		{
+			name:                "existing session",
+			destination:         openDestination,
+			wantSelectedSession: "session-1",
+		},
+		{
+			name:              "new root session",
+			destination:       sessionCreateDestination{},
+			wantForceNew:      true,
+			wantParentSession: "",
+		},
+		{
+			name:              "new child session",
+			destination:       sessionCreateDestination{Parent: parent},
+			wantForceNew:      true,
+			wantParentSession: "parent-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request, err := (resolvedSessionPlanRequest{
+				destination: tt.destination,
+				overrides:   serverapi.RunPromptOverrides{Model: "gpt-5"},
+			}).apiRequest(launchModeInteractive)
+			if err != nil {
+				t.Fatalf("convert typed destination to API request: %v", err)
+			}
+			if request.SelectedSessionID != tt.wantSelectedSession ||
+				request.ForceNewSession != tt.wantForceNew ||
+				request.ParentSessionID != tt.wantParentSession {
+				t.Fatalf("API request destination = %+v", request)
+			}
+			if request.Overrides.Model != "gpt-5" {
+				t.Fatalf("API request overrides = %+v", request.Overrides)
+			}
+		})
+	}
+}

--- a/cli/app/pty_fixture_process_test.go
+++ b/cli/app/pty_fixture_process_test.go
@@ -119,9 +119,13 @@ func runPTYFixtureProcess(ctx context.Context, processConfig appfixture.ProcessC
 	server = boundServer
 
 	planner := newSessionLaunchPlanner(server)
+	destination, err := newSessionOpenDestination(sessionID)
+	if err != nil {
+		return err
+	}
 	plan, err := planner.PlanSession(ctx, sessionLaunchRequest{
-		Mode:              launchModeInteractive,
-		SelectedSessionID: sessionID,
+		Mode:        launchModeInteractive,
+		Destination: destination,
 	})
 	if err != nil {
 		return err

--- a/cli/app/pty_fixture_process_test.go
+++ b/cli/app/pty_fixture_process_test.go
@@ -126,7 +126,7 @@ func runPTYFixtureProcess(ctx context.Context, processConfig appfixture.ProcessC
 	if err != nil {
 		return err
 	}
-	runtimePlan, request, err := prepareSessionUIRun(ctx, server, planner, plan, resolvedSessionHandoff{}, true)
+	runtimePlan, request, err := prepareSessionUIRun(ctx, server, planner, plan, resolvedSessionHandoff{Destination: sessionPickerDestination{}}, true)
 	if err != nil {
 		return err
 	}

--- a/cli/app/pty_fixture_process_test.go
+++ b/cli/app/pty_fixture_process_test.go
@@ -126,7 +126,7 @@ func runPTYFixtureProcess(ctx context.Context, processConfig appfixture.ProcessC
 	if err != nil {
 		return err
 	}
-	runtimePlan, request, err := prepareSessionUIRun(ctx, server, planner, plan, "", false, "", false, true)
+	runtimePlan, request, err := prepareSessionUIRun(ctx, server, planner, plan, resolvedSessionHandoff{}, true)
 	if err != nil {
 		return err
 	}

--- a/cli/app/pty_fixture_process_test.go
+++ b/cli/app/pty_fixture_process_test.go
@@ -8,6 +8,7 @@ import (
 
 	checkpoint "core/internal/testharness/pty/analyzer"
 	"core/internal/testharness/pty/appfixture"
+	"core/shared/serverapi"
 )
 
 type ptyCheckpointTerminalFile struct {
@@ -119,18 +120,19 @@ func runPTYFixtureProcess(ctx context.Context, processConfig appfixture.ProcessC
 	server = boundServer
 
 	planner := newSessionLaunchPlanner(server)
-	destination, err := newSessionOpenDestination(sessionID)
+	handoff, err := initialSessionHandoff(sessionID, false)
 	if err != nil {
 		return err
 	}
-	plan, err := planner.PlanSession(ctx, sessionLaunchRequest{
-		Mode:        launchModeInteractive,
-		Destination: destination,
-	})
+	launchRequest, err := sessionLaunchRequestFromHandoff(handoff, serverapi.RunPromptOverrides{})
 	if err != nil {
 		return err
 	}
-	runtimePlan, request, err := prepareSessionUIRun(ctx, server, planner, plan, resolvedSessionHandoff{Destination: sessionPickerDestination{}}, true)
+	plan, err := planner.PlanSession(ctx, launchRequest)
+	if err != nil {
+		return err
+	}
+	runtimePlan, request, err := prepareSessionUIRun(ctx, server, planner, plan, handoff, true)
 	if err != nil {
 		return err
 	}

--- a/cli/app/session_launch_destination.go
+++ b/cli/app/session_launch_destination.go
@@ -1,0 +1,86 @@
+package app
+
+import (
+	"errors"
+	"strings"
+)
+
+type validatedSessionID struct {
+	value string
+}
+
+func newValidatedSessionID(raw string) (validatedSessionID, error) {
+	validated := optionalValidatedSessionID(raw)
+	if validated == nil {
+		return validatedSessionID{}, errors.New("session id is required")
+	}
+	return *validated, nil
+}
+
+func optionalValidatedSessionID(raw string) *validatedSessionID {
+	normalized := strings.TrimSpace(raw)
+	if normalized == "" {
+		return nil
+	}
+	return &validatedSessionID{value: normalized}
+}
+
+func (id validatedSessionID) String() string {
+	return id.value
+}
+
+type sessionLaunchDestination interface {
+	sessionLaunchDestination()
+}
+
+type sessionPickerDestination struct{}
+
+func (sessionPickerDestination) sessionLaunchDestination() {}
+
+type sessionOpenDestination struct {
+	sessionID validatedSessionID
+}
+
+func newSessionOpenDestination(sessionID string) (sessionOpenDestination, error) {
+	validated, err := newValidatedSessionID(sessionID)
+	if err != nil {
+		return sessionOpenDestination{}, err
+	}
+	return sessionOpenDestination{sessionID: validated}, nil
+}
+
+func (sessionOpenDestination) sessionLaunchDestination() {}
+
+func (d sessionOpenDestination) SessionID() string {
+	return d.sessionID.String()
+}
+
+type sessionParentReference struct {
+	sessionID validatedSessionID
+}
+
+func newSessionParentReference(sessionID string) (sessionParentReference, error) {
+	validated, err := newValidatedSessionID(sessionID)
+	if err != nil {
+		return sessionParentReference{}, err
+	}
+	return sessionParentReference{sessionID: validated}, nil
+}
+
+func (p sessionParentReference) SessionID() string {
+	return p.sessionID.String()
+}
+
+func optionalSessionParentReference(sessionID string) *sessionParentReference {
+	validated := optionalValidatedSessionID(sessionID)
+	if validated == nil {
+		return nil
+	}
+	return &sessionParentReference{sessionID: *validated}
+}
+
+type sessionCreateDestination struct {
+	Parent *sessionParentReference
+}
+
+func (sessionCreateDestination) sessionLaunchDestination() {}

--- a/cli/app/session_launch_destination_test_helpers_test.go
+++ b/cli/app/session_launch_destination_test_helpers_test.go
@@ -1,0 +1,21 @@
+package app
+
+import "testing"
+
+func sessionOpenDestinationForTest(t *testing.T, sessionID string) sessionOpenDestination {
+	t.Helper()
+	destination, err := newSessionOpenDestination(sessionID)
+	if err != nil {
+		t.Fatalf("new session-open destination: %v", err)
+	}
+	return destination
+}
+
+func sessionParentReferenceForTest(t *testing.T, sessionID string) *sessionParentReference {
+	t.Helper()
+	parent, err := newSessionParentReference(sessionID)
+	if err != nil {
+		t.Fatalf("new parent session reference: %v", err)
+	}
+	return &parent
+}

--- a/cli/app/session_lifecycle.go
+++ b/cli/app/session_lifecycle.go
@@ -83,28 +83,25 @@ func runSessionLifecycleWithOptions(ctx context.Context, server interactiveSessi
 	}
 	server = boundServer
 	planner := newSessionLaunchPlanner(server)
-	currentSessionID := strings.TrimSpace(initialSessionID)
-	nextSessionInitialPrompt := ""
-	nextSessionInitialPromptHistoryRecorded := false
-	nextSessionInitialInput := ""
-	nextSessionInitialInputOverride := false
-	nextSessionParentID := ""
-	forceNewSession := opts.ForceNewSession
+	handoff := resolvedSessionHandoff{
+		NextSessionID:   strings.TrimSpace(initialSessionID),
+		ForceNewSession: opts.ForceNewSession,
+	}
 	nextSessionOverrides := opts.Overrides
 	showStartupUpdateNotice := true
 	for {
 		plan, err := planner.PlanSession(ctx, sessionLaunchRequest{
 			Mode:              launchModeInteractive,
-			SelectedSessionID: currentSessionID,
-			ForceNewSession:   forceNewSession,
-			ParentSessionID:   nextSessionParentID,
+			SelectedSessionID: handoff.NextSessionID,
+			ForceNewSession:   handoff.ForceNewSession,
+			ParentSessionID:   handoff.ParentSessionID,
 			Overrides:         nextSessionOverrides,
 		})
 		if err != nil {
 			return err
 		}
-		forceNewSession = false
-		nextSessionParentID = ""
+		handoff.ForceNewSession = false
+		handoff.ParentSessionID = ""
 		nextSessionOverrides = serverapi.RunPromptOverrides{}
 		workspaceChangeAction, err := maybeHandlePickedSessionWorkspaceChange(ctx, server, plan)
 		if err != nil {
@@ -112,10 +109,10 @@ func runSessionLifecycleWithOptions(ctx context.Context, server interactiveSessi
 		}
 		switch workspaceChangeAction {
 		case sessionWorkspaceChangePickAgain:
-			currentSessionID = ""
+			handoff.NextSessionID = ""
 			continue
 		case sessionWorkspaceChangeReplanSelected:
-			currentSessionID = plan.SessionID
+			handoff.NextSessionID = plan.SessionID
 			continue
 		}
 		runtimePlan, request, err := prepareSessionUIRun(
@@ -123,10 +120,7 @@ func runSessionLifecycleWithOptions(ctx context.Context, server interactiveSessi
 			server,
 			planner,
 			plan,
-			nextSessionInitialPrompt,
-			nextSessionInitialPromptHistoryRecorded,
-			nextSessionInitialInput,
-			nextSessionInitialInputOverride,
+			handoff,
 			showStartupUpdateNotice,
 		)
 		if err != nil {
@@ -134,10 +128,6 @@ func runSessionLifecycleWithOptions(ctx context.Context, server interactiveSessi
 		}
 		finalModel, runErr := runUILoop(request)
 		showStartupUpdateNotice = shouldRetryStartupUpdateNotice(finalModel, showStartupUpdateNotice)
-		nextSessionInitialPrompt = ""
-		nextSessionInitialPromptHistoryRecorded = false
-		nextSessionInitialInput = ""
-		nextSessionInitialInputOverride = false
 		if runErr != nil {
 			if closeErr := runtimePlan.Close(); closeErr != nil {
 				return errors.Join(runErr, closeErr)
@@ -158,33 +148,30 @@ func runSessionLifecycleWithOptions(ctx context.Context, server interactiveSessi
 			}
 			return nil
 		}
-		resolved, err := resolveAndReleaseSessionAction(ctx, server, interactor, plan.SessionID, transition, runtimePlan)
+		resolved, err := resolveAndReleaseSessionHandoff(ctx, server, interactor, plan.SessionID, transition, runtimePlan)
 		if err != nil {
 			return err
 		}
 		if !resolved.ShouldContinue {
 			return nil
 		}
-		currentSessionID = resolved.NextSessionID
-		nextSessionInitialPrompt = resolved.InitialPrompt
-		nextSessionInitialPromptHistoryRecorded = resolved.InitialPromptHistoryRecorded
-		nextSessionInitialInput = resolved.InitialInput
-		nextSessionInitialInputOverride = transition.Action == UIActionOpenSession
-		nextSessionParentID = resolved.ParentSessionID
-		forceNewSession = resolved.ForceNewSession
+		handoff = resolved
 	}
 }
 
-func resolveAndReleaseSessionAction(ctx context.Context, server sessionTransitionServer, interactor authInteractor, sessionID string, transition UITransition, runtimePlan *runtimeLaunchPlan) (resolvedSessionAction, error) {
+func resolveAndReleaseSessionHandoff(ctx context.Context, server sessionTransitionServer, interactor authInteractor, sessionID string, transition UITransition, runtimePlan *runtimeLaunchPlan) (resolvedSessionHandoff, error) {
 	resolved, err := resolveSessionAction(ctx, server, interactor, sessionID, transition)
 	if err != nil {
 		if closeErr := runtimePlan.Close(); closeErr != nil {
-			return resolvedSessionAction{}, errors.Join(err, closeErr)
+			return resolvedSessionHandoff{}, errors.Join(err, closeErr)
 		}
-		return resolvedSessionAction{}, err
+		return resolvedSessionHandoff{}, err
 	}
 	if err := runtimePlan.Close(); err != nil {
-		return resolvedSessionAction{}, err
+		return resolvedSessionHandoff{}, err
+	}
+	if transition.Action == UIActionOpenSession {
+		resolved.InitialInput.Precedence = sessionInitialInputPreferTransition
 	}
 	return resolved, nil
 }
@@ -194,10 +181,7 @@ func prepareSessionUIRun(
 	server interactiveSessionServer,
 	planner *launchPlanner,
 	plan sessionLaunchPlan,
-	initialPrompt string,
-	initialPromptHistoryRecorded bool,
-	transitionInput string,
-	overrideStoredDraft bool,
+	handoff resolvedSessionHandoff,
 	startupUpdateNotice bool,
 ) (*runtimeLaunchPlan, uiLoopRequest, error) {
 	runtimePlan, err := planner.PrepareRuntime(ctx, plan, os.Stderr, "app.start session_id="+plan.SessionID+" workspace="+plan.WorkspaceRoot+" model="+plan.ActiveSettings.Model)
@@ -216,14 +200,14 @@ func prepareSessionUIRun(
 		}
 		return nil, uiLoopRequest{}, err
 	}
-	initialState := sessionLaunchInitialStateFromServer(ctx, server, plan.SessionID, transitionInput, overrideStoredDraft)
+	initialState := sessionLaunchInitialStateFromServer(ctx, server, plan.SessionID, handoff.InitialInput)
 	return runtimePlan, uiLoopRequest{
 		wiring:                       runtimePlan.Wiring,
 		active:                       plan.ActiveSettings,
 		logger:                       runtimePlan.Logger,
 		commandRegistry:              commandRegistry,
-		initialPrompt:                initialPrompt,
-		initialPromptHistoryRecorded: initialPromptHistoryRecorded,
+		initialPrompt:                handoff.InitialPrompt,
+		initialPromptHistoryRecorded: handoff.InitialPromptHistoryRecorded,
 		initialInput:                 initialState.Input,
 		recoveryBuffers:              initialState.RecoveryBuffers,
 		sessionName:                  plan.SessionName,
@@ -262,7 +246,10 @@ func shouldCloseReboundServer(original appServerCore, rebound appServerCore) boo
 }
 
 func sessionLaunchInitialInputFromServer(ctx context.Context, server sessionInitialInputServer, sessionID string, transitionInput string) string {
-	return sessionLaunchInitialStateFromServer(ctx, server, sessionID, transitionInput, false).Input
+	return sessionLaunchInitialStateFromServer(ctx, server, sessionID, sessionInitialInputDirective{
+		TransitionInput: transitionInput,
+		Precedence:      sessionInitialInputPreferStoredDraft,
+	}).Input
 }
 
 type sessionLaunchInitialState struct {
@@ -270,17 +257,17 @@ type sessionLaunchInitialState struct {
 	RecoveryBuffers []serverapi.SessionDraftRecoveryBuffer
 }
 
-func sessionLaunchInitialStateFromServer(ctx context.Context, server sessionInitialInputServer, sessionID string, transitionInput string, overrideStoredDraft bool) sessionLaunchInitialState {
+func sessionLaunchInitialStateFromServer(ctx context.Context, server sessionInitialInputServer, sessionID string, directive sessionInitialInputDirective) sessionLaunchInitialState {
 	if server == nil || server.SessionLifecycleClient() == nil {
-		return sessionLaunchInitialState{Input: transitionInput}
+		return sessionLaunchInitialState{Input: directive.TransitionInput}
 	}
 	resp, err := server.SessionLifecycleClient().GetInitialInput(ctx, serverapi.SessionInitialInputRequest{
 		SessionID:           strings.TrimSpace(sessionID),
-		TransitionInput:     transitionInput,
-		OverrideStoredDraft: overrideStoredDraft,
+		TransitionInput:     directive.TransitionInput,
+		OverrideStoredDraft: directive.Precedence == sessionInitialInputPreferTransition,
 	})
 	if err != nil {
-		return sessionLaunchInitialState{Input: transitionInput}
+		return sessionLaunchInitialState{Input: directive.TransitionInput}
 	}
 	return sessionLaunchInitialState{Input: resp.Input, RecoveryBuffers: resp.RecoveryBuffers}
 }
@@ -305,22 +292,34 @@ func persistSessionDraftToServer(ctx context.Context, server sessionDraftPersist
 	return err
 }
 
-type resolvedSessionAction struct {
+type sessionInitialInputPrecedence uint8
+
+const (
+	sessionInitialInputPreferStoredDraft sessionInitialInputPrecedence = iota
+	sessionInitialInputPreferTransition
+)
+
+type sessionInitialInputDirective struct {
+	TransitionInput string
+	Precedence      sessionInitialInputPrecedence
+}
+
+type resolvedSessionHandoff struct {
 	NextSessionID                string
 	InitialPrompt                string
 	InitialPromptHistoryRecorded bool
-	InitialInput                 string
+	InitialInput                 sessionInitialInputDirective
 	ParentSessionID              string
 	ForceNewSession              bool
 	ShouldContinue               bool
 }
 
-func resolveSessionAction(ctx context.Context, server sessionTransitionServer, interactor authInteractor, sessionID string, transition UITransition) (resolvedSessionAction, error) {
+func resolveSessionAction(ctx context.Context, server sessionTransitionServer, interactor authInteractor, sessionID string, transition UITransition) (resolvedSessionHandoff, error) {
 	if transition.Exit {
-		return resolvedSessionAction{}, nil
+		return resolvedSessionHandoff{}, nil
 	}
 	if server == nil || server.SessionLifecycleClient() == nil {
-		return resolvedSessionAction{}, errors.New("session lifecycle client is required")
+		return resolvedSessionHandoff{}, errors.New("session lifecycle client is required")
 	}
 	resolved, err := server.SessionLifecycleClient().ResolveTransition(ctx, serverapi.SessionResolveTransitionRequest{
 		ClientRequestID: uuid.NewString(),
@@ -336,20 +335,23 @@ func resolveSessionAction(ctx context.Context, server sessionTransitionServer, i
 		},
 	})
 	if err != nil {
-		return resolvedSessionAction{}, err
+		return resolvedSessionHandoff{}, err
 	}
 	if resolved.RequiresReauth {
 		if err := server.Reauthenticate(ctx, interactor, true); err != nil {
-			return resolvedSessionAction{}, err
+			return resolvedSessionHandoff{}, err
 		}
 	}
-	return resolvedSessionAction{
+	return resolvedSessionHandoff{
 		NextSessionID:                resolved.NextSessionID,
 		InitialPrompt:                resolved.InitialPrompt,
 		InitialPromptHistoryRecorded: resolved.InitialPromptHistoryRecorded,
-		InitialInput:                 resolved.InitialInput,
-		ParentSessionID:              resolved.ParentSessionID,
-		ForceNewSession:              resolved.ForceNewSession,
-		ShouldContinue:               resolved.ShouldContinue,
+		InitialInput: sessionInitialInputDirective{
+			TransitionInput: resolved.InitialInput,
+			Precedence:      sessionInitialInputPreferStoredDraft,
+		},
+		ParentSessionID: resolved.ParentSessionID,
+		ForceNewSession: resolved.ForceNewSession,
+		ShouldContinue:  resolved.ShouldContinue,
 	}, nil
 }

--- a/cli/app/session_lifecycle.go
+++ b/cli/app/session_lifecycle.go
@@ -304,30 +304,6 @@ type sessionInitialInputDirective struct {
 	Precedence      sessionInitialInputPrecedence
 }
 
-type sessionLaunchDestination interface {
-	sessionLaunchDestination()
-}
-
-type sessionPickerDestination struct{}
-
-func (sessionPickerDestination) sessionLaunchDestination() {}
-
-type sessionOpenDestination struct {
-	SessionID string
-}
-
-func (sessionOpenDestination) sessionLaunchDestination() {}
-
-type sessionParentReference struct {
-	SessionID string
-}
-
-type sessionCreateDestination struct {
-	Parent *sessionParentReference
-}
-
-func (sessionCreateDestination) sessionLaunchDestination() {}
-
 type sessionInitialPrompt struct {
 	Text            string
 	HistoryRecorded bool
@@ -340,9 +316,9 @@ type resolvedSessionHandoff struct {
 }
 
 func initialSessionHandoff(initialSessionID string, forceNewSession bool) (resolvedSessionHandoff, error) {
-	normalizedSessionID := strings.TrimSpace(initialSessionID)
+	validatedSessionID := optionalValidatedSessionID(initialSessionID)
 	if forceNewSession {
-		if normalizedSessionID != "" {
+		if validatedSessionID != nil {
 			return resolvedSessionHandoff{}, errors.New("initial session id cannot be combined with force-new session")
 		}
 		return resolvedSessionHandoff{
@@ -350,77 +326,26 @@ func initialSessionHandoff(initialSessionID string, forceNewSession bool) (resol
 			InitialInput: sessionInitialInputDirective{Precedence: sessionInitialInputPreferStoredDraft},
 		}, nil
 	}
-	if normalizedSessionID == "" {
+	if validatedSessionID == nil {
 		return resolvedSessionHandoff{
 			Destination:  sessionPickerDestination{},
 			InitialInput: sessionInitialInputDirective{Precedence: sessionInitialInputPreferStoredDraft},
 		}, nil
 	}
-	destination, err := newSessionOpenDestination(normalizedSessionID)
-	if err != nil {
-		return resolvedSessionHandoff{}, err
-	}
 	return resolvedSessionHandoff{
-		Destination:  destination,
+		Destination:  sessionOpenDestination{sessionID: *validatedSessionID},
 		InitialInput: sessionInitialInputDirective{Precedence: sessionInitialInputPreferStoredDraft},
 	}, nil
 }
 
-func newSessionOpenDestination(sessionID string) (sessionOpenDestination, error) {
-	normalized := strings.TrimSpace(sessionID)
-	if normalized == "" {
-		return sessionOpenDestination{}, errors.New("open-session destination requires a session id")
-	}
-	if normalized != sessionID {
-		return sessionOpenDestination{}, errors.New("open-session destination session id must be normalized")
-	}
-	return sessionOpenDestination{SessionID: normalized}, nil
-}
-
-func newSessionParentReference(sessionID string) (sessionParentReference, error) {
-	normalized := strings.TrimSpace(sessionID)
-	if normalized == "" {
-		return sessionParentReference{}, errors.New("parent session id is required")
-	}
-	if normalized != sessionID {
-		return sessionParentReference{}, errors.New("parent session id must be normalized")
-	}
-	return sessionParentReference{SessionID: normalized}, nil
-}
-
-func optionalSessionParentReference(sessionID string) (*sessionParentReference, error) {
-	if sessionID == "" {
-		return nil, nil
-	}
-	parent, err := newSessionParentReference(sessionID)
-	if err != nil {
-		return nil, err
-	}
-	return &parent, nil
-}
-
 func sessionLaunchRequestFromHandoff(handoff resolvedSessionHandoff, overrides serverapi.RunPromptOverrides) (sessionLaunchRequest, error) {
-	request := sessionLaunchRequest{Mode: launchModeInteractive, Overrides: overrides}
-	switch destination := handoff.Destination.(type) {
-	case sessionPickerDestination:
-		return request, nil
-	case sessionOpenDestination:
-		normalized, err := newSessionOpenDestination(destination.SessionID)
-		if err != nil {
-			return sessionLaunchRequest{}, err
-		}
-		request.SelectedSessionID = normalized.SessionID
-		return request, nil
-	case sessionCreateDestination:
-		request.ForceNewSession = true
-		if destination.Parent != nil {
-			parent, err := newSessionParentReference(destination.Parent.SessionID)
-			if err != nil {
-				return sessionLaunchRequest{}, err
-			}
-			request.ParentSessionID = parent.SessionID
-		}
-		return request, nil
+	switch handoff.Destination.(type) {
+	case sessionPickerDestination, sessionOpenDestination, sessionCreateDestination:
+		return sessionLaunchRequest{
+			Mode:        launchModeInteractive,
+			Destination: handoff.Destination,
+			Overrides:   overrides,
+		}, nil
 	default:
 		return sessionLaunchRequest{}, errors.New("session handoff destination is required")
 	}
@@ -461,11 +386,14 @@ func resolveSessionAction(ctx context.Context, server sessionTransitionServer, i
 			return nil, err
 		}
 	}
-	return resolvedSessionHandoffFromResponse(resolved)
+	return resolvedSessionHandoffFromResponse(transition.Action, resolved)
 }
 
-func resolvedSessionHandoffFromResponse(resolved serverapi.SessionResolveTransitionResponse) (*resolvedSessionHandoff, error) {
+func resolvedSessionHandoffFromResponse(action UIAction, resolved serverapi.SessionResolveTransitionResponse) (*resolvedSessionHandoff, error) {
 	if !resolved.ShouldContinue {
+		if transitionActionRequiresDestination(action) {
+			return nil, errors.New("session transition did not resolve a destination")
+		}
 		if resolved.NextSessionID != "" ||
 			resolved.InitialPrompt != "" ||
 			resolved.InitialPromptHistoryRecorded ||
@@ -479,6 +407,9 @@ func resolvedSessionHandoffFromResponse(resolved serverapi.SessionResolveTransit
 
 	destination, err := sessionLaunchDestinationFromResponse(resolved)
 	if err != nil {
+		return nil, err
+	}
+	if err := validateTransitionDestination(action, destination); err != nil {
 		return nil, err
 	}
 	var prompt *sessionInitialPrompt
@@ -501,15 +432,51 @@ func resolvedSessionHandoffFromResponse(resolved serverapi.SessionResolveTransit
 	}, nil
 }
 
+func transitionActionRequiresDestination(action UIAction) bool {
+	switch action {
+	case UIActionNewSession,
+		UIActionResume,
+		UIActionLogout,
+		UIActionForkRollback,
+		UIActionOpenSession:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateTransitionDestination(action UIAction, destination sessionLaunchDestination) error {
+	switch action {
+	case UIActionOpenSession, UIActionForkRollback:
+		if _, ok := destination.(sessionOpenDestination); !ok {
+			return errors.New("session transition requires an existing-session destination")
+		}
+	case UIActionNewSession:
+		if _, ok := destination.(sessionCreateDestination); !ok {
+			return errors.New("new-session transition requires a create-session destination")
+		}
+	case UIActionResume:
+		if _, ok := destination.(sessionPickerDestination); !ok {
+			return errors.New("resume transition requires a session-picker destination")
+		}
+	case UIActionLogout:
+		switch destination.(type) {
+		case sessionOpenDestination, sessionPickerDestination:
+		default:
+			return errors.New("logout transition requires an existing-session or session-picker destination")
+		}
+	default:
+		return errors.New("continuing session transition has unsupported action")
+	}
+	return nil
+}
+
 func sessionLaunchDestinationFromResponse(resolved serverapi.SessionResolveTransitionResponse) (sessionLaunchDestination, error) {
 	if resolved.ForceNewSession {
 		if resolved.NextSessionID != "" {
 			return nil, errors.New("force-new session transition cannot also select an existing session")
 		}
-		parent, err := optionalSessionParentReference(resolved.ParentSessionID)
-		if err != nil {
-			return nil, err
-		}
+		parent := optionalSessionParentReference(resolved.ParentSessionID)
 		return sessionCreateDestination{Parent: parent}, nil
 	}
 	if resolved.NextSessionID != "" {

--- a/cli/app/session_lifecycle.go
+++ b/cli/app/session_lifecycle.go
@@ -83,25 +83,21 @@ func runSessionLifecycleWithOptions(ctx context.Context, server interactiveSessi
 	}
 	server = boundServer
 	planner := newSessionLaunchPlanner(server)
-	handoff := resolvedSessionHandoff{
-		NextSessionID:   strings.TrimSpace(initialSessionID),
-		ForceNewSession: opts.ForceNewSession,
+	handoff, err := initialSessionHandoff(initialSessionID, opts.ForceNewSession)
+	if err != nil {
+		return err
 	}
 	nextSessionOverrides := opts.Overrides
 	showStartupUpdateNotice := true
 	for {
-		plan, err := planner.PlanSession(ctx, sessionLaunchRequest{
-			Mode:              launchModeInteractive,
-			SelectedSessionID: handoff.NextSessionID,
-			ForceNewSession:   handoff.ForceNewSession,
-			ParentSessionID:   handoff.ParentSessionID,
-			Overrides:         nextSessionOverrides,
-		})
+		launchRequest, err := sessionLaunchRequestFromHandoff(handoff, nextSessionOverrides)
 		if err != nil {
 			return err
 		}
-		handoff.ForceNewSession = false
-		handoff.ParentSessionID = ""
+		plan, err := planner.PlanSession(ctx, launchRequest)
+		if err != nil {
+			return err
+		}
 		nextSessionOverrides = serverapi.RunPromptOverrides{}
 		workspaceChangeAction, err := maybeHandlePickedSessionWorkspaceChange(ctx, server, plan)
 		if err != nil {
@@ -109,10 +105,14 @@ func runSessionLifecycleWithOptions(ctx context.Context, server interactiveSessi
 		}
 		switch workspaceChangeAction {
 		case sessionWorkspaceChangePickAgain:
-			handoff.NextSessionID = ""
+			handoff.Destination = sessionPickerDestination{}
 			continue
 		case sessionWorkspaceChangeReplanSelected:
-			handoff.NextSessionID = plan.SessionID
+			destination, err := newSessionOpenDestination(plan.SessionID)
+			if err != nil {
+				return err
+			}
+			handoff.Destination = destination
 			continue
 		}
 		runtimePlan, request, err := prepareSessionUIRun(
@@ -152,25 +152,25 @@ func runSessionLifecycleWithOptions(ctx context.Context, server interactiveSessi
 		if err != nil {
 			return err
 		}
-		if !resolved.ShouldContinue {
+		if resolved == nil {
 			return nil
 		}
-		handoff = resolved
+		handoff = *resolved
 	}
 }
 
-func resolveAndReleaseSessionHandoff(ctx context.Context, server sessionTransitionServer, interactor authInteractor, sessionID string, transition UITransition, runtimePlan *runtimeLaunchPlan) (resolvedSessionHandoff, error) {
+func resolveAndReleaseSessionHandoff(ctx context.Context, server sessionTransitionServer, interactor authInteractor, sessionID string, transition UITransition, runtimePlan *runtimeLaunchPlan) (*resolvedSessionHandoff, error) {
 	resolved, err := resolveSessionAction(ctx, server, interactor, sessionID, transition)
 	if err != nil {
 		if closeErr := runtimePlan.Close(); closeErr != nil {
-			return resolvedSessionHandoff{}, errors.Join(err, closeErr)
+			return nil, errors.Join(err, closeErr)
 		}
-		return resolvedSessionHandoff{}, err
+		return nil, err
 	}
 	if err := runtimePlan.Close(); err != nil {
-		return resolvedSessionHandoff{}, err
+		return nil, err
 	}
-	if transition.Action == UIActionOpenSession {
+	if resolved != nil && transition.Action == UIActionOpenSession {
 		resolved.InitialInput.Precedence = sessionInitialInputPreferTransition
 	}
 	return resolved, nil
@@ -190,24 +190,24 @@ func prepareSessionUIRun(
 	}
 	promptRoots, err := server.ClientPromptRoots()
 	if err != nil {
-		runtimePlan.Close()
-		return nil, uiLoopRequest{}, err
+		return nil, uiLoopRequest{}, closeRuntimePlanAfterPreparationFailure(runtimePlan, err)
 	}
 	commandRegistry, err := commands.NewDefaultRegistryWithClientPromptRoots(promptRoots)
 	if err != nil {
-		if closeErr := runtimePlan.Close(); closeErr != nil {
-			return nil, uiLoopRequest{}, errors.Join(err, closeErr)
-		}
-		return nil, uiLoopRequest{}, err
+		return nil, uiLoopRequest{}, closeRuntimePlanAfterPreparationFailure(runtimePlan, err)
 	}
-	initialState := sessionLaunchInitialStateFromServer(ctx, server, plan.SessionID, handoff.InitialInput)
+	initialState, err := sessionLaunchInitialStateFromServer(ctx, server, plan.SessionID, handoff.InitialInput)
+	if err != nil {
+		return nil, uiLoopRequest{}, closeRuntimePlanAfterPreparationFailure(runtimePlan, err)
+	}
+	initialPrompt, initialPromptHistoryRecorded := handoff.initialPromptFields()
 	return runtimePlan, uiLoopRequest{
 		wiring:                       runtimePlan.Wiring,
 		active:                       plan.ActiveSettings,
 		logger:                       runtimePlan.Logger,
 		commandRegistry:              commandRegistry,
-		initialPrompt:                handoff.InitialPrompt,
-		initialPromptHistoryRecorded: handoff.InitialPromptHistoryRecorded,
+		initialPrompt:                initialPrompt,
+		initialPromptHistoryRecorded: initialPromptHistoryRecorded,
 		initialInput:                 initialState.Input,
 		recoveryBuffers:              initialState.RecoveryBuffers,
 		sessionName:                  plan.SessionName,
@@ -216,6 +216,13 @@ func prepareSessionUIRun(
 		statusConfig:                 plan.StatusConfig,
 		startupUpdateNotice:          startupUpdateNotice,
 	}, nil
+}
+
+func closeRuntimePlanAfterPreparationFailure(runtimePlan *runtimeLaunchPlan, preparationErr error) error {
+	if closeErr := runtimePlan.Close(); closeErr != nil {
+		return errors.Join(preparationErr, closeErr)
+	}
+	return preparationErr
 }
 
 func closeRuntimePlanAfterUIExit(runtimePlan *runtimeLaunchPlan, finalModel any) error {
@@ -245,21 +252,14 @@ func shouldCloseReboundServer(original appServerCore, rebound appServerCore) boo
 	return true
 }
 
-func sessionLaunchInitialInputFromServer(ctx context.Context, server sessionInitialInputServer, sessionID string, transitionInput string) string {
-	return sessionLaunchInitialStateFromServer(ctx, server, sessionID, sessionInitialInputDirective{
-		TransitionInput: transitionInput,
-		Precedence:      sessionInitialInputPreferStoredDraft,
-	}).Input
-}
-
 type sessionLaunchInitialState struct {
 	Input           string
 	RecoveryBuffers []serverapi.SessionDraftRecoveryBuffer
 }
 
-func sessionLaunchInitialStateFromServer(ctx context.Context, server sessionInitialInputServer, sessionID string, directive sessionInitialInputDirective) sessionLaunchInitialState {
+func sessionLaunchInitialStateFromServer(ctx context.Context, server sessionInitialInputServer, sessionID string, directive sessionInitialInputDirective) (sessionLaunchInitialState, error) {
 	if server == nil || server.SessionLifecycleClient() == nil {
-		return sessionLaunchInitialState{Input: directive.TransitionInput}
+		return sessionLaunchInitialState{}, errors.New("session lifecycle client is required")
 	}
 	resp, err := server.SessionLifecycleClient().GetInitialInput(ctx, serverapi.SessionInitialInputRequest{
 		SessionID:           strings.TrimSpace(sessionID),
@@ -267,9 +267,9 @@ func sessionLaunchInitialStateFromServer(ctx context.Context, server sessionInit
 		OverrideStoredDraft: directive.Precedence == sessionInitialInputPreferTransition,
 	})
 	if err != nil {
-		return sessionLaunchInitialState{Input: directive.TransitionInput}
+		return sessionLaunchInitialState{}, err
 	}
-	return sessionLaunchInitialState{Input: resp.Input, RecoveryBuffers: resp.RecoveryBuffers}
+	return sessionLaunchInitialState{Input: resp.Input, RecoveryBuffers: resp.RecoveryBuffers}, nil
 }
 
 func persistSessionDraftToServer(ctx context.Context, server sessionDraftPersistenceServer, sessionID string, model any) error {
@@ -304,22 +304,141 @@ type sessionInitialInputDirective struct {
 	Precedence      sessionInitialInputPrecedence
 }
 
-type resolvedSessionHandoff struct {
-	NextSessionID                string
-	InitialPrompt                string
-	InitialPromptHistoryRecorded bool
-	InitialInput                 sessionInitialInputDirective
-	ParentSessionID              string
-	ForceNewSession              bool
-	ShouldContinue               bool
+type sessionLaunchDestination interface {
+	sessionLaunchDestination()
 }
 
-func resolveSessionAction(ctx context.Context, server sessionTransitionServer, interactor authInteractor, sessionID string, transition UITransition) (resolvedSessionHandoff, error) {
+type sessionPickerDestination struct{}
+
+func (sessionPickerDestination) sessionLaunchDestination() {}
+
+type sessionOpenDestination struct {
+	SessionID string
+}
+
+func (sessionOpenDestination) sessionLaunchDestination() {}
+
+type sessionParentReference struct {
+	SessionID string
+}
+
+type sessionCreateDestination struct {
+	Parent *sessionParentReference
+}
+
+func (sessionCreateDestination) sessionLaunchDestination() {}
+
+type sessionInitialPrompt struct {
+	Text            string
+	HistoryRecorded bool
+}
+
+type resolvedSessionHandoff struct {
+	Destination   sessionLaunchDestination
+	InitialPrompt *sessionInitialPrompt
+	InitialInput  sessionInitialInputDirective
+}
+
+func initialSessionHandoff(initialSessionID string, forceNewSession bool) (resolvedSessionHandoff, error) {
+	normalizedSessionID := strings.TrimSpace(initialSessionID)
+	if forceNewSession {
+		if normalizedSessionID != "" {
+			return resolvedSessionHandoff{}, errors.New("initial session id cannot be combined with force-new session")
+		}
+		return resolvedSessionHandoff{
+			Destination:  sessionCreateDestination{},
+			InitialInput: sessionInitialInputDirective{Precedence: sessionInitialInputPreferStoredDraft},
+		}, nil
+	}
+	if normalizedSessionID == "" {
+		return resolvedSessionHandoff{
+			Destination:  sessionPickerDestination{},
+			InitialInput: sessionInitialInputDirective{Precedence: sessionInitialInputPreferStoredDraft},
+		}, nil
+	}
+	destination, err := newSessionOpenDestination(normalizedSessionID)
+	if err != nil {
+		return resolvedSessionHandoff{}, err
+	}
+	return resolvedSessionHandoff{
+		Destination:  destination,
+		InitialInput: sessionInitialInputDirective{Precedence: sessionInitialInputPreferStoredDraft},
+	}, nil
+}
+
+func newSessionOpenDestination(sessionID string) (sessionOpenDestination, error) {
+	normalized := strings.TrimSpace(sessionID)
+	if normalized == "" {
+		return sessionOpenDestination{}, errors.New("open-session destination requires a session id")
+	}
+	if normalized != sessionID {
+		return sessionOpenDestination{}, errors.New("open-session destination session id must be normalized")
+	}
+	return sessionOpenDestination{SessionID: normalized}, nil
+}
+
+func newSessionParentReference(sessionID string) (sessionParentReference, error) {
+	normalized := strings.TrimSpace(sessionID)
+	if normalized == "" {
+		return sessionParentReference{}, errors.New("parent session id is required")
+	}
+	if normalized != sessionID {
+		return sessionParentReference{}, errors.New("parent session id must be normalized")
+	}
+	return sessionParentReference{SessionID: normalized}, nil
+}
+
+func optionalSessionParentReference(sessionID string) (*sessionParentReference, error) {
+	if sessionID == "" {
+		return nil, nil
+	}
+	parent, err := newSessionParentReference(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	return &parent, nil
+}
+
+func sessionLaunchRequestFromHandoff(handoff resolvedSessionHandoff, overrides serverapi.RunPromptOverrides) (sessionLaunchRequest, error) {
+	request := sessionLaunchRequest{Mode: launchModeInteractive, Overrides: overrides}
+	switch destination := handoff.Destination.(type) {
+	case sessionPickerDestination:
+		return request, nil
+	case sessionOpenDestination:
+		normalized, err := newSessionOpenDestination(destination.SessionID)
+		if err != nil {
+			return sessionLaunchRequest{}, err
+		}
+		request.SelectedSessionID = normalized.SessionID
+		return request, nil
+	case sessionCreateDestination:
+		request.ForceNewSession = true
+		if destination.Parent != nil {
+			parent, err := newSessionParentReference(destination.Parent.SessionID)
+			if err != nil {
+				return sessionLaunchRequest{}, err
+			}
+			request.ParentSessionID = parent.SessionID
+		}
+		return request, nil
+	default:
+		return sessionLaunchRequest{}, errors.New("session handoff destination is required")
+	}
+}
+
+func (h resolvedSessionHandoff) initialPromptFields() (string, bool) {
+	if h.InitialPrompt == nil {
+		return "", false
+	}
+	return h.InitialPrompt.Text, h.InitialPrompt.HistoryRecorded
+}
+
+func resolveSessionAction(ctx context.Context, server sessionTransitionServer, interactor authInteractor, sessionID string, transition UITransition) (*resolvedSessionHandoff, error) {
 	if transition.Exit {
-		return resolvedSessionHandoff{}, nil
+		return nil, nil
 	}
 	if server == nil || server.SessionLifecycleClient() == nil {
-		return resolvedSessionHandoff{}, errors.New("session lifecycle client is required")
+		return nil, errors.New("session lifecycle client is required")
 	}
 	resolved, err := server.SessionLifecycleClient().ResolveTransition(ctx, serverapi.SessionResolveTransitionRequest{
 		ClientRequestID: uuid.NewString(),
@@ -335,23 +454,76 @@ func resolveSessionAction(ctx context.Context, server sessionTransitionServer, i
 		},
 	})
 	if err != nil {
-		return resolvedSessionHandoff{}, err
+		return nil, err
 	}
 	if resolved.RequiresReauth {
 		if err := server.Reauthenticate(ctx, interactor, true); err != nil {
-			return resolvedSessionHandoff{}, err
+			return nil, err
 		}
 	}
-	return resolvedSessionHandoff{
-		NextSessionID:                resolved.NextSessionID,
-		InitialPrompt:                resolved.InitialPrompt,
-		InitialPromptHistoryRecorded: resolved.InitialPromptHistoryRecorded,
+	return resolvedSessionHandoffFromResponse(resolved)
+}
+
+func resolvedSessionHandoffFromResponse(resolved serverapi.SessionResolveTransitionResponse) (*resolvedSessionHandoff, error) {
+	if !resolved.ShouldContinue {
+		if resolved.NextSessionID != "" ||
+			resolved.InitialPrompt != "" ||
+			resolved.InitialPromptHistoryRecorded ||
+			resolved.InitialInput != "" ||
+			resolved.ParentSessionID != "" ||
+			resolved.ForceNewSession {
+			return nil, errors.New("non-continuing session transition returned continuation state")
+		}
+		return nil, nil
+	}
+
+	destination, err := sessionLaunchDestinationFromResponse(resolved)
+	if err != nil {
+		return nil, err
+	}
+	var prompt *sessionInitialPrompt
+	switch {
+	case resolved.InitialPrompt == "" && resolved.InitialPromptHistoryRecorded:
+		return nil, errors.New("initial prompt history cannot be recorded without an initial prompt")
+	case resolved.InitialPrompt != "":
+		prompt = &sessionInitialPrompt{
+			Text:            resolved.InitialPrompt,
+			HistoryRecorded: resolved.InitialPromptHistoryRecorded,
+		}
+	}
+	return &resolvedSessionHandoff{
+		Destination:   destination,
+		InitialPrompt: prompt,
 		InitialInput: sessionInitialInputDirective{
 			TransitionInput: resolved.InitialInput,
 			Precedence:      sessionInitialInputPreferStoredDraft,
 		},
-		ParentSessionID: resolved.ParentSessionID,
-		ForceNewSession: resolved.ForceNewSession,
-		ShouldContinue:  resolved.ShouldContinue,
 	}, nil
+}
+
+func sessionLaunchDestinationFromResponse(resolved serverapi.SessionResolveTransitionResponse) (sessionLaunchDestination, error) {
+	if resolved.ForceNewSession {
+		if resolved.NextSessionID != "" {
+			return nil, errors.New("force-new session transition cannot also select an existing session")
+		}
+		parent, err := optionalSessionParentReference(resolved.ParentSessionID)
+		if err != nil {
+			return nil, err
+		}
+		return sessionCreateDestination{Parent: parent}, nil
+	}
+	if resolved.NextSessionID != "" {
+		if resolved.ParentSessionID != "" {
+			return nil, errors.New("existing-session transition cannot also carry a parent session")
+		}
+		destination, err := newSessionOpenDestination(resolved.NextSessionID)
+		if err != nil {
+			return nil, err
+		}
+		return destination, nil
+	}
+	if resolved.ParentSessionID != "" {
+		return nil, errors.New("picker transition cannot carry a parent session")
+	}
+	return sessionPickerDestination{}, nil
 }

--- a/cli/app/session_lifecycle_failure_test.go
+++ b/cli/app/session_lifecycle_failure_test.go
@@ -1,0 +1,356 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"core/cli/app/commands"
+	"core/server/session"
+	"core/shared/config"
+	"core/shared/serverapi"
+)
+
+type clientPromptRootsFailureServer struct {
+	*testEmbeddedServer
+	err error
+}
+
+func (s clientPromptRootsFailureServer) ClientPromptRoots() (commands.ClientPromptRoots, error) {
+	return commands.ClientPromptRoots{}, s.err
+}
+
+func TestResolveAndReleaseSessionHandoffTransitionFailureLeavesChildReopenableWithoutDestination(t *testing.T) {
+	child := createAppRuntimeSession(t)
+	if err := child.EnsureDurable(); err != nil {
+		t.Fatalf("persist child session: %v", err)
+	}
+	resolveErr := errors.New("transition resolution failed")
+	releaseCalls := 0
+	server := narrowSessionLifecycleServer{
+		lifecycle: &recordingSessionLifecycleClient{
+			resolveTransition: func(context.Context, serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {
+				return serverapi.SessionResolveTransitionResponse{}, resolveErr
+			},
+		},
+	}
+
+	handoff, err := resolveAndReleaseSessionHandoff(
+		context.Background(),
+		server,
+		nil,
+		child.Meta().SessionID,
+		UITransition{Action: UIActionOpenSession, TargetSessionID: "parent-session"},
+		&runtimeLaunchPlan{close: func() error {
+			releaseCalls++
+			return nil
+		}},
+	)
+	if !errors.Is(err, resolveErr) {
+		t.Fatalf("handoff error = %v, want transition failure", err)
+	}
+	if handoff != nil {
+		t.Fatalf("transition failure returned destination handoff %+v", handoff)
+	}
+	if releaseCalls != 1 {
+		t.Fatalf("origin release calls = %d, want 1 after transition failure", releaseCalls)
+	}
+
+	reopened, err := session.Open(child.Dir())
+	if err != nil {
+		t.Fatalf("reopen child after transition failure: %v", err)
+	}
+	if reopened.Meta().SessionID != child.Meta().SessionID {
+		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
+	}
+}
+
+func TestResolveAndReleaseSessionHandoffReturnsReleaseFailureBeforeDestinationCanPlan(t *testing.T) {
+	child := createAppRuntimeSession(t)
+	if err := child.EnsureDurable(); err != nil {
+		t.Fatalf("persist child session: %v", err)
+	}
+	releaseErr := errors.New("release failed")
+	events := make([]string, 0, 2)
+	server := narrowSessionLifecycleServer{
+		lifecycle: &recordingSessionLifecycleClient{
+			resolveTransition: func(context.Context, serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {
+				events = append(events, "resolve")
+				return serverapi.SessionResolveTransitionResponse{ShouldContinue: true, NextSessionID: "destination"}, nil
+			},
+		},
+	}
+	plan := &runtimeLaunchPlan{close: func() error {
+		events = append(events, "release")
+		return releaseErr
+	}}
+
+	resolved, err := resolveAndReleaseSessionHandoff(context.Background(), server, nil, child.Meta().SessionID, UITransition{Action: UIActionResume}, plan)
+	if !errors.Is(err, releaseErr) {
+		t.Fatalf("error = %v, want release failure", err)
+	}
+	if resolved != nil {
+		t.Fatalf("release failure returned destination %+v", resolved)
+	}
+	if got := strings.Join(events, ","); got != "resolve,release" {
+		t.Fatalf("event order = %q, want resolve,release", got)
+	}
+	reopened, err := session.Open(child.Dir())
+	if err != nil {
+		t.Fatalf("reopen child after release failure: %v", err)
+	}
+	if reopened.Meta().SessionID != child.Meta().SessionID {
+		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
+	}
+}
+
+func TestDestinationPlanningFailureLeavesChildReopenableWithoutPreparation(t *testing.T) {
+	child := createAppRuntimeSession(t)
+	if err := child.EnsureDurable(); err != nil {
+		t.Fatalf("persist child session: %v", err)
+	}
+	planErr := errors.New("destination planning failed")
+	prepareCalls := 0
+	server := &testEmbeddedServer{
+		cfg: config.App{
+			WorkspaceRoot:   t.TempDir(),
+			PersistenceRoot: t.TempDir(),
+			Settings:        config.Settings{Theme: "dark"},
+		},
+		sessionLifecycle: &recordingSessionLifecycleClient{
+			resolveTransition: func(_ context.Context, req serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {
+				return serverapi.SessionResolveTransitionResponse{
+					NextSessionID:  req.Transition.TargetSessionID,
+					InitialInput:   req.Transition.InitialInput,
+					ShouldContinue: true,
+				}, nil
+			},
+		},
+		sessionLaunch: stubSessionLaunchClient{
+			planSession: func(context.Context, serverapi.SessionPlanRequest) (serverapi.SessionPlanResponse, error) {
+				return serverapi.SessionPlanResponse{}, planErr
+			},
+		},
+		prepareRuntime: func(context.Context, sessionLaunchPlan, io.Writer, string) (*runtimeLaunchPlan, error) {
+			prepareCalls++
+			return nil, errors.New("destination preparation must not start")
+		},
+	}
+
+	handoff, err := resolveAndReleaseSessionHandoff(
+		context.Background(),
+		server,
+		nil,
+		child.Meta().SessionID,
+		UITransition{Action: UIActionOpenSession, TargetSessionID: "parent-session", InitialInput: "child final"},
+		&runtimeLaunchPlan{close: func() error { return nil }},
+	)
+	if err != nil {
+		t.Fatalf("resolve destination handoff: %v", err)
+	}
+	parentSessionID := requireSessionOpenDestination(t, handoff)
+	planner := newSessionLaunchPlanner(server)
+	_, err = planner.PlanSession(context.Background(), sessionLaunchRequest{
+		Mode:              launchModeInteractive,
+		SelectedSessionID: parentSessionID,
+	})
+	if !errors.Is(err, planErr) {
+		t.Fatalf("destination planning error = %v, want %v", err, planErr)
+	}
+	if prepareCalls != 0 {
+		t.Fatalf("destination preparation calls = %d, want none after planning failure", prepareCalls)
+	}
+
+	reopened, err := session.Open(child.Dir())
+	if err != nil {
+		t.Fatalf("reopen child after destination planning failure: %v", err)
+	}
+	if reopened.Meta().SessionID != child.Meta().SessionID {
+		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
+	}
+}
+
+func TestDestinationPreparationFailureLeavesChildReopenableWithoutComposition(t *testing.T) {
+	child := createAppRuntimeSession(t)
+	if err := child.EnsureDurable(); err != nil {
+		t.Fatalf("persist child session: %v", err)
+	}
+	prepareErr := errors.New("destination runtime preparation failed")
+	initialInputCalls := 0
+	server := &testEmbeddedServer{
+		cfg: config.App{
+			WorkspaceRoot:   t.TempDir(),
+			PersistenceRoot: t.TempDir(),
+			Settings:        config.Settings{Theme: "dark"},
+		},
+		sessionLifecycle: &recordingSessionLifecycleClient{
+			getInitialInput: func(context.Context, serverapi.SessionInitialInputRequest) (serverapi.SessionInitialInputResponse, error) {
+				initialInputCalls++
+				return serverapi.SessionInitialInputResponse{}, errors.New("initial input must not load before runtime preparation")
+			},
+		},
+		prepareRuntime: func(context.Context, sessionLaunchPlan, io.Writer, string) (*runtimeLaunchPlan, error) {
+			return nil, prepareErr
+		},
+	}
+	planner := newSessionLaunchPlanner(server)
+
+	runtimePlan, request, err := prepareSessionUIRun(
+		context.Background(),
+		server,
+		planner,
+		sessionLaunchPlan{
+			SessionID:      "parent-session",
+			WorkspaceRoot:  server.cfg.WorkspaceRoot,
+			ActiveSettings: config.Settings{Model: "gpt-5", Theme: "dark"},
+		},
+		resolvedSessionHandoff{
+			Destination: sessionOpenDestination{SessionID: "parent-session"},
+			InitialInput: sessionInitialInputDirective{
+				TransitionInput: "child final",
+				Precedence:      sessionInitialInputPreferTransition,
+			},
+		},
+		false,
+	)
+	if !errors.Is(err, prepareErr) {
+		t.Fatalf("destination preparation error = %v, want %v", err, prepareErr)
+	}
+	if runtimePlan != nil || request.wiring != nil {
+		t.Fatalf("failed destination preparation returned composable state plan=%+v request=%+v", runtimePlan, request)
+	}
+	if initialInputCalls != 0 {
+		t.Fatalf("initial input calls = %d, want none before successful runtime preparation", initialInputCalls)
+	}
+
+	reopened, err := session.Open(child.Dir())
+	if err != nil {
+		t.Fatalf("reopen child after destination preparation failure: %v", err)
+	}
+	if reopened.Meta().SessionID != child.Meta().SessionID {
+		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
+	}
+}
+
+func TestDestinationInitialInputFailureClosesRuntimeAndLeavesChildReopenableWithoutComposition(t *testing.T) {
+	child := createAppRuntimeSession(t)
+	if err := child.EnsureDurable(); err != nil {
+		t.Fatalf("persist child session: %v", err)
+	}
+	lookupErr := errors.New("destination initial input failed")
+	closeErr := errors.New("destination runtime cleanup failed")
+	closeCalls := 0
+	server := &testEmbeddedServer{
+		cfg: config.App{
+			WorkspaceRoot:   t.TempDir(),
+			PersistenceRoot: t.TempDir(),
+			Settings:        config.Settings{Theme: "dark"},
+		},
+		sessionLifecycle: &recordingSessionLifecycleClient{
+			getInitialInput: func(context.Context, serverapi.SessionInitialInputRequest) (serverapi.SessionInitialInputResponse, error) {
+				return serverapi.SessionInitialInputResponse{}, lookupErr
+			},
+		},
+		prepareRuntime: func(context.Context, sessionLaunchPlan, io.Writer, string) (*runtimeLaunchPlan, error) {
+			return &runtimeLaunchPlan{close: func() error {
+				closeCalls++
+				return closeErr
+			}}, nil
+		},
+	}
+
+	runtimePlan, request, err := prepareSessionUIRun(
+		context.Background(),
+		server,
+		newSessionLaunchPlanner(server),
+		sessionLaunchPlan{
+			SessionID:      "parent-session",
+			WorkspaceRoot:  server.cfg.WorkspaceRoot,
+			ActiveSettings: config.Settings{Model: "gpt-5", Theme: "dark"},
+		},
+		resolvedSessionHandoff{
+			Destination: sessionOpenDestination{SessionID: "parent-session"},
+			InitialInput: sessionInitialInputDirective{
+				TransitionInput: "child final",
+				Precedence:      sessionInitialInputPreferTransition,
+			},
+		},
+		false,
+	)
+	if !errors.Is(err, lookupErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("destination initial-input error = %v, want lookup and cleanup failures", err)
+	}
+	if runtimePlan != nil || request.wiring != nil {
+		t.Fatalf("failed initial-input preparation returned composable state plan=%+v request=%+v", runtimePlan, request)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("runtime cleanup calls = %d, want 1", closeCalls)
+	}
+
+	reopened, err := session.Open(child.Dir())
+	if err != nil {
+		t.Fatalf("reopen child after destination initial-input failure: %v", err)
+	}
+	if reopened.Meta().SessionID != child.Meta().SessionID {
+		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
+	}
+}
+
+func TestDestinationClientPromptRootsFailureJoinsRuntimeCleanupFailure(t *testing.T) {
+	child := createAppRuntimeSession(t)
+	if err := child.EnsureDurable(); err != nil {
+		t.Fatalf("persist child session: %v", err)
+	}
+	promptRootsErr := errors.New("client prompt roots unavailable")
+	closeErr := errors.New("destination runtime cleanup failed")
+	closeCalls := 0
+	baseServer := &testEmbeddedServer{
+		cfg: config.App{
+			WorkspaceRoot:   t.TempDir(),
+			PersistenceRoot: t.TempDir(),
+			Settings:        config.Settings{Theme: "dark"},
+		},
+		prepareRuntime: func(context.Context, sessionLaunchPlan, io.Writer, string) (*runtimeLaunchPlan, error) {
+			return &runtimeLaunchPlan{close: func() error {
+				closeCalls++
+				return closeErr
+			}}, nil
+		},
+	}
+	server := clientPromptRootsFailureServer{testEmbeddedServer: baseServer, err: promptRootsErr}
+
+	runtimePlan, request, err := prepareSessionUIRun(
+		context.Background(),
+		server,
+		newSessionLaunchPlanner(server),
+		sessionLaunchPlan{
+			SessionID:      "parent-session",
+			WorkspaceRoot:  baseServer.cfg.WorkspaceRoot,
+			ActiveSettings: config.Settings{Model: "gpt-5", Theme: "dark"},
+		},
+		resolvedSessionHandoff{
+			Destination:  sessionOpenDestination{SessionID: "parent-session"},
+			InitialInput: sessionInitialInputDirective{Precedence: sessionInitialInputPreferTransition},
+		},
+		false,
+	)
+	if !errors.Is(err, promptRootsErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("client-prompt-root preparation error = %v, want prompt-root and cleanup failures", err)
+	}
+	if runtimePlan != nil || request.wiring != nil {
+		t.Fatalf("failed client-prompt-root preparation returned composable state plan=%+v request=%+v", runtimePlan, request)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("runtime cleanup calls = %d, want 1", closeCalls)
+	}
+
+	reopened, err := session.Open(child.Dir())
+	if err != nil {
+		t.Fatalf("reopen child after client-prompt-root failure: %v", err)
+	}
+	if reopened.Meta().SessionID != child.Meta().SessionID {
+		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
+	}
+}

--- a/cli/app/session_lifecycle_failure_test.go
+++ b/cli/app/session_lifecycle_failure_test.go
@@ -67,6 +67,50 @@ func TestResolveAndReleaseSessionHandoffTransitionFailureLeavesChildReopenableWi
 	}
 }
 
+func TestResolveAndReleaseSessionHandoffRejectsOpenSessionWithoutDestination(t *testing.T) {
+	child := createAppRuntimeSession(t)
+	if err := child.EnsureDurable(); err != nil {
+		t.Fatalf("persist child session: %v", err)
+	}
+	releaseCalls := 0
+	server := narrowSessionLifecycleServer{
+		lifecycle: &recordingSessionLifecycleClient{
+			resolveTransition: func(context.Context, serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {
+				return serverapi.SessionResolveTransitionResponse{ShouldContinue: true}, nil
+			},
+		},
+	}
+
+	handoff, err := resolveAndReleaseSessionHandoff(
+		context.Background(),
+		server,
+		nil,
+		child.Meta().SessionID,
+		UITransition{Action: UIActionOpenSession},
+		&runtimeLaunchPlan{close: func() error {
+			releaseCalls++
+			return nil
+		}},
+	)
+	if err == nil {
+		t.Fatal("open-session response without destination was accepted")
+	}
+	if handoff != nil {
+		t.Fatalf("open-session response without destination returned handoff %+v", handoff)
+	}
+	if releaseCalls != 1 {
+		t.Fatalf("origin cleanup calls = %d, want 1", releaseCalls)
+	}
+
+	reopened, err := session.Open(child.Dir())
+	if err != nil {
+		t.Fatalf("reopen child after invalid open-session response: %v", err)
+	}
+	if reopened.Meta().SessionID != child.Meta().SessionID {
+		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
+	}
+}
+
 func TestResolveAndReleaseSessionHandoffReturnsReleaseFailureBeforeDestinationCanPlan(t *testing.T) {
 	child := createAppRuntimeSession(t)
 	if err := child.EnsureDurable(); err != nil {
@@ -153,8 +197,8 @@ func TestDestinationPlanningFailureLeavesChildReopenableWithoutPreparation(t *te
 	parentSessionID := requireSessionOpenDestination(t, handoff)
 	planner := newSessionLaunchPlanner(server)
 	_, err = planner.PlanSession(context.Background(), sessionLaunchRequest{
-		Mode:              launchModeInteractive,
-		SelectedSessionID: parentSessionID,
+		Mode:        launchModeInteractive,
+		Destination: sessionOpenDestinationForTest(t, parentSessionID),
 	})
 	if !errors.Is(err, planErr) {
 		t.Fatalf("destination planning error = %v, want %v", err, planErr)
@@ -207,7 +251,7 @@ func TestDestinationPreparationFailureLeavesChildReopenableWithoutComposition(t 
 			ActiveSettings: config.Settings{Model: "gpt-5", Theme: "dark"},
 		},
 		resolvedSessionHandoff{
-			Destination: sessionOpenDestination{SessionID: "parent-session"},
+			Destination: sessionOpenDestinationForTest(t, "parent-session"),
 			InitialInput: sessionInitialInputDirective{
 				TransitionInput: "child final",
 				Precedence:      sessionInitialInputPreferTransition,
@@ -271,7 +315,7 @@ func TestDestinationInitialInputFailureClosesRuntimeAndLeavesChildReopenableWith
 			ActiveSettings: config.Settings{Model: "gpt-5", Theme: "dark"},
 		},
 		resolvedSessionHandoff{
-			Destination: sessionOpenDestination{SessionID: "parent-session"},
+			Destination: sessionOpenDestinationForTest(t, "parent-session"),
 			InitialInput: sessionInitialInputDirective{
 				TransitionInput: "child final",
 				Precedence:      sessionInitialInputPreferTransition,
@@ -331,7 +375,7 @@ func TestDestinationClientPromptRootsFailureJoinsRuntimeCleanupFailure(t *testin
 			ActiveSettings: config.Settings{Model: "gpt-5", Theme: "dark"},
 		},
 		resolvedSessionHandoff{
-			Destination:  sessionOpenDestination{SessionID: "parent-session"},
+			Destination:  sessionOpenDestinationForTest(t, "parent-session"),
 			InitialInput: sessionInitialInputDirective{Precedence: sessionInitialInputPreferTransition},
 		},
 		false,

--- a/cli/app/session_lifecycle_handoff_test.go
+++ b/cli/app/session_lifecycle_handoff_test.go
@@ -1,0 +1,279 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"core/shared/clientui"
+	"core/shared/config"
+	"core/shared/serverapi"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func requireResolvedSessionHandoff(t *testing.T, handoff *resolvedSessionHandoff) *resolvedSessionHandoff {
+	t.Helper()
+	if handoff == nil {
+		t.Fatal("expected session lifecycle to continue")
+	}
+	return handoff
+}
+
+func requireSessionPickerDestination(t *testing.T, handoff *resolvedSessionHandoff) {
+	t.Helper()
+	handoff = requireResolvedSessionHandoff(t, handoff)
+	if _, ok := handoff.Destination.(sessionPickerDestination); !ok {
+		t.Fatalf("destination = %T, want session picker", handoff.Destination)
+	}
+}
+
+func requireSessionOpenDestination(t *testing.T, handoff *resolvedSessionHandoff) string {
+	t.Helper()
+	handoff = requireResolvedSessionHandoff(t, handoff)
+	destination, ok := handoff.Destination.(sessionOpenDestination)
+	if !ok {
+		t.Fatalf("destination = %T, want existing session", handoff.Destination)
+	}
+	return destination.SessionID
+}
+
+func requireSessionCreateDestination(t *testing.T, handoff *resolvedSessionHandoff) *sessionParentReference {
+	t.Helper()
+	handoff = requireResolvedSessionHandoff(t, handoff)
+	destination, ok := handoff.Destination.(sessionCreateDestination)
+	if !ok {
+		t.Fatalf("destination = %T, want new session", handoff.Destination)
+	}
+	return destination.Parent
+}
+
+func TestResolveAndReleaseSessionHandoffOwnsInitialInputPrecedence(t *testing.T) {
+	tests := []struct {
+		name           string
+		action         UIAction
+		initialInput   string
+		wantPrecedence sessionInitialInputPrecedence
+	}{
+		{
+			name:           "open session preserves exact transition input",
+			action:         UIActionOpenSession,
+			initialInput:   " \nExact café 👩🏽‍💻\n尾  ",
+			wantPrecedence: sessionInitialInputPreferTransition,
+		},
+		{
+			name:           "open session preserves intentional empty transition input",
+			action:         UIActionOpenSession,
+			initialInput:   "",
+			wantPrecedence: sessionInitialInputPreferTransition,
+		},
+		{
+			name:           "other transitions prefer stored draft",
+			action:         UIActionResume,
+			initialInput:   "ordinary transition input",
+			wantPrecedence: sessionInitialInputPreferStoredDraft,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var initialInputRequest serverapi.SessionInitialInputRequest
+			lifecycle := &recordingSessionLifecycleClient{
+				resolveTransition: func(_ context.Context, req serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {
+					return serverapi.SessionResolveTransitionResponse{
+						NextSessionID:  "parent-session",
+						InitialInput:   req.Transition.InitialInput,
+						ShouldContinue: true,
+					}, nil
+				},
+				getInitialInput: func(_ context.Context, req serverapi.SessionInitialInputRequest) (serverapi.SessionInitialInputResponse, error) {
+					initialInputRequest = req
+					if req.OverrideStoredDraft {
+						return serverapi.SessionInitialInputResponse{Input: req.TransitionInput}, nil
+					}
+					return serverapi.SessionInitialInputResponse{
+						Input: "stored parent draft",
+						RecoveryBuffers: []serverapi.SessionDraftRecoveryBuffer{
+							{Kind: serverapi.SessionDraftRecoveryBufferQueuedInput, ID: "stale-parent-buffer", Text: "stale queued input"},
+						},
+					}, nil
+				},
+			}
+			server := narrowSessionLifecycleServer{lifecycle: lifecycle}
+
+			handoff, err := resolveAndReleaseSessionHandoff(
+				context.Background(),
+				server,
+				nil,
+				"child-session",
+				UITransition{Action: tt.action, InitialInput: tt.initialInput},
+				&runtimeLaunchPlan{close: func() error { return nil }},
+			)
+			if err != nil {
+				t.Fatalf("resolve and release handoff: %v", err)
+			}
+			handoff = requireResolvedSessionHandoff(t, handoff)
+			if handoff.InitialInput.TransitionInput != tt.initialInput {
+				t.Fatalf("transition input = %q, want %q", handoff.InitialInput.TransitionInput, tt.initialInput)
+			}
+			if handoff.InitialInput.Precedence != tt.wantPrecedence {
+				t.Fatalf("initial input precedence = %v, want %v", handoff.InitialInput.Precedence, tt.wantPrecedence)
+			}
+			if tt.action != UIActionOpenSession {
+				return
+			}
+			parentSessionID := requireSessionOpenDestination(t, handoff)
+
+			initialState, err := sessionLaunchInitialStateFromServer(
+				context.Background(),
+				server,
+				parentSessionID,
+				handoff.InitialInput,
+			)
+			if err != nil {
+				t.Fatalf("resolve next-launch initial state: %v", err)
+			}
+			if initialInputRequest.TransitionInput != tt.initialInput {
+				t.Fatalf("next-launch transition input = %q, want %q", initialInputRequest.TransitionInput, tt.initialInput)
+			}
+			if !initialInputRequest.OverrideStoredDraft {
+				t.Fatal("next-launch request did not apply transition-input precedence")
+			}
+			if initialState.Input != tt.initialInput {
+				t.Fatalf("resolved parent input = %q, want %q", initialState.Input, tt.initialInput)
+			}
+			if len(initialState.RecoveryBuffers) != 0 {
+				t.Fatalf("resolved parent recovery buffers = %+v, want none", initialState.RecoveryBuffers)
+			}
+
+			runtimeClient := &runtimeControlFakeClient{
+				mainView: clientui.RuntimeMainView{
+					Session: clientui.RuntimeSessionView{SessionID: parentSessionID},
+				},
+			}
+			initialPrompt, initialPromptHistoryRecorded := handoff.initialPromptFields()
+			composition, err := composeUIProgram(uiLoopRequest{
+				wiring: &runtimeWiring{
+					runtimeClient: runtimeClient,
+					runtimeEvents: closedProjectedRuntimeEvents(),
+					askEvents:     closedAskEvents(),
+				},
+				active:                       config.Settings{Theme: "dark"},
+				initialPrompt:                initialPrompt,
+				initialPromptHistoryRecorded: initialPromptHistoryRecorded,
+				initialInput:                 initialState.Input,
+				recoveryBuffers:              initialState.RecoveryBuffers,
+				statusConfig:                 uiStatusConfig{PersistenceRoot: t.TempDir()},
+			}, io.Discard)
+			if err != nil {
+				t.Fatalf("compose parent UI: %v", err)
+			}
+			defer composition.close()
+
+			model := composition.model
+			if model.input != tt.initialInput {
+				t.Fatalf("parent composer input = %q, want %q", model.input, tt.initialInput)
+			}
+			if model.startupSubmit != "" || model.activeSubmit.text != "" || model.isBusy() {
+				t.Fatalf("prefill must stay idle and unsent: startup=%q active=%+v busy=%t", model.startupSubmit, model.activeSubmit, model.isBusy())
+			}
+			if len(model.recoveredDraftBuffers) != 0 || len(model.pendingInjected) != 0 || len(model.queued) != 0 {
+				t.Fatalf("parent recovery state leaked: recovered=%+v pending=%+v queued=%+v", model.recoveredDraftBuffers, model.pendingInjected, model.queued)
+			}
+
+			next, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+			edited := next.(*uiModel)
+			if cmd != nil {
+				t.Fatal("normal composer edit created a command")
+			}
+			if edited.input != tt.initialInput+"x" {
+				t.Fatalf("edited parent input = %q, want %q", edited.input, tt.initialInput+"x")
+			}
+			if runtimeClient.submitText != "" || runtimeClient.queueUserMessageCalls != 0 || runtimeClient.submitQueuedCalls != 0 {
+				t.Fatalf("normal edit submitted runtime work: submit=%q queued=%d flushed=%d", runtimeClient.submitText, runtimeClient.queueUserMessageCalls, runtimeClient.submitQueuedCalls)
+			}
+		})
+	}
+}
+
+func TestResolvedSessionHandoffRejectsInvalidWireCombinations(t *testing.T) {
+	tests := []struct {
+		name     string
+		response serverapi.SessionResolveTransitionResponse
+	}{
+		{
+			name: "non-continuing response with destination",
+			response: serverapi.SessionResolveTransitionResponse{
+				ShouldContinue: false,
+				NextSessionID:  "session-1",
+			},
+		},
+		{
+			name: "force new with existing destination",
+			response: serverapi.SessionResolveTransitionResponse{
+				ShouldContinue:  true,
+				ForceNewSession: true,
+				NextSessionID:   "session-1",
+			},
+		},
+		{
+			name: "existing destination with parent",
+			response: serverapi.SessionResolveTransitionResponse{
+				ShouldContinue:  true,
+				NextSessionID:   "session-1",
+				ParentSessionID: "parent-1",
+			},
+		},
+		{
+			name: "picker destination with parent",
+			response: serverapi.SessionResolveTransitionResponse{
+				ShouldContinue:  true,
+				ParentSessionID: "parent-1",
+			},
+		},
+		{
+			name: "history flag without prompt",
+			response: serverapi.SessionResolveTransitionResponse{
+				ShouldContinue:               true,
+				InitialPromptHistoryRecorded: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handoff, err := resolvedSessionHandoffFromResponse(tt.response)
+			if err == nil {
+				t.Fatalf("invalid response produced handoff %+v", handoff)
+			}
+		})
+	}
+}
+
+func TestSessionLaunchInitialStateReturnsLifecycleError(t *testing.T) {
+	lookupErr := errors.New("initial input lookup failed")
+	server := narrowSessionLifecycleServer{
+		lifecycle: &recordingSessionLifecycleClient{
+			getInitialInput: func(context.Context, serverapi.SessionInitialInputRequest) (serverapi.SessionInitialInputResponse, error) {
+				return serverapi.SessionInitialInputResponse{}, lookupErr
+			},
+		},
+	}
+
+	state, err := sessionLaunchInitialStateFromServer(
+		context.Background(),
+		server,
+		"parent-session",
+		sessionInitialInputDirective{
+			TransitionInput: "child final",
+			Precedence:      sessionInitialInputPreferTransition,
+		},
+	)
+	if !errors.Is(err, lookupErr) {
+		t.Fatalf("initial state error = %v, want %v", err, lookupErr)
+	}
+	if state.Input != "" || len(state.RecoveryBuffers) != 0 {
+		t.Fatalf("failed initial state lookup returned state %+v", state)
+	}
+}

--- a/cli/app/session_lifecycle_handoff_test.go
+++ b/cli/app/session_lifecycle_handoff_test.go
@@ -36,7 +36,7 @@ func requireSessionOpenDestination(t *testing.T, handoff *resolvedSessionHandoff
 	if !ok {
 		t.Fatalf("destination = %T, want existing session", handoff.Destination)
 	}
-	return destination.SessionID
+	return destination.SessionID()
 }
 
 func requireSessionCreateDestination(t *testing.T, handoff *resolvedSessionHandoff) *sessionParentReference {
@@ -81,11 +81,14 @@ func TestResolveAndReleaseSessionHandoffOwnsInitialInputPrecedence(t *testing.T)
 			var initialInputRequest serverapi.SessionInitialInputRequest
 			lifecycle := &recordingSessionLifecycleClient{
 				resolveTransition: func(_ context.Context, req serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {
-					return serverapi.SessionResolveTransitionResponse{
-						NextSessionID:  "parent-session",
+					response := serverapi.SessionResolveTransitionResponse{
 						InitialInput:   req.Transition.InitialInput,
 						ShouldContinue: true,
-					}, nil
+					}
+					if req.Transition.Action == UIActionOpenSession {
+						response.NextSessionID = "parent-session"
+					}
+					return response, nil
 				},
 				getInitialInput: func(_ context.Context, req serverapi.SessionInitialInputRequest) (serverapi.SessionInitialInputResponse, error) {
 					initialInputRequest = req
@@ -200,17 +203,20 @@ func TestResolveAndReleaseSessionHandoffOwnsInitialInputPrecedence(t *testing.T)
 func TestResolvedSessionHandoffRejectsInvalidWireCombinations(t *testing.T) {
 	tests := []struct {
 		name     string
+		action   UIAction
 		response serverapi.SessionResolveTransitionResponse
 	}{
 		{
-			name: "non-continuing response with destination",
+			name:   "non-continuing response with destination",
+			action: UIActionNone,
 			response: serverapi.SessionResolveTransitionResponse{
 				ShouldContinue: false,
 				NextSessionID:  "session-1",
 			},
 		},
 		{
-			name: "force new with existing destination",
+			name:   "force new with existing destination",
+			action: UIActionNewSession,
 			response: serverapi.SessionResolveTransitionResponse{
 				ShouldContinue:  true,
 				ForceNewSession: true,
@@ -218,7 +224,8 @@ func TestResolvedSessionHandoffRejectsInvalidWireCombinations(t *testing.T) {
 			},
 		},
 		{
-			name: "existing destination with parent",
+			name:   "existing destination with parent",
+			action: UIActionOpenSession,
 			response: serverapi.SessionResolveTransitionResponse{
 				ShouldContinue:  true,
 				NextSessionID:   "session-1",
@@ -226,24 +233,48 @@ func TestResolvedSessionHandoffRejectsInvalidWireCombinations(t *testing.T) {
 			},
 		},
 		{
-			name: "picker destination with parent",
+			name:   "picker destination with parent",
+			action: UIActionResume,
 			response: serverapi.SessionResolveTransitionResponse{
 				ShouldContinue:  true,
 				ParentSessionID: "parent-1",
 			},
 		},
 		{
-			name: "history flag without prompt",
+			name:   "history flag without prompt",
+			action: UIActionResume,
 			response: serverapi.SessionResolveTransitionResponse{
 				ShouldContinue:               true,
 				InitialPromptHistoryRecorded: true,
+			},
+		},
+		{
+			name:   "open session with picker destination",
+			action: UIActionOpenSession,
+			response: serverapi.SessionResolveTransitionResponse{
+				ShouldContinue: true,
+			},
+		},
+		{
+			name:   "resume with existing destination",
+			action: UIActionResume,
+			response: serverapi.SessionResolveTransitionResponse{
+				ShouldContinue: true,
+				NextSessionID:  "session-1",
+			},
+		},
+		{
+			name:   "new session with picker destination",
+			action: UIActionNewSession,
+			response: serverapi.SessionResolveTransitionResponse{
+				ShouldContinue: true,
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handoff, err := resolvedSessionHandoffFromResponse(tt.response)
+			handoff, err := resolvedSessionHandoffFromResponse(tt.action, tt.response)
 			if err == nil {
 				t.Fatalf("invalid response produced handoff %+v", handoff)
 			}

--- a/cli/app/session_lifecycle_test.go
+++ b/cli/app/session_lifecycle_test.go
@@ -713,7 +713,7 @@ func TestResolveSessionActionNewSessionUsesForceNewFlow(t *testing.T) {
 		t.Fatalf("resolve session action: %v", err)
 	}
 	parent := requireSessionCreateDestination(t, resolved)
-	if parent == nil || parent.SessionID != "parent-1" {
+	if parent == nil || parent.SessionID() != "parent-1" {
 		t.Fatalf("expected parent session id passthrough, got %+v", parent)
 	}
 	if resolved.InitialPrompt == nil || resolved.InitialPrompt.Text != "hello" || resolved.InitialInput.TransitionInput != "" {
@@ -780,7 +780,7 @@ func TestNewSessionTransitionKeepsBackgroundProcessesAlive(t *testing.T) {
 		t.Fatalf("resolve session action: %v", err)
 	}
 	parent := requireSessionCreateDestination(t, resolved)
-	if parent == nil || parent.SessionID != "parent-1" {
+	if parent == nil || parent.SessionID() != "parent-1" {
 		t.Fatalf("expected new-session parent, got %+v", parent)
 	}
 	if resolved.InitialPrompt == nil || resolved.InitialPrompt.Text != "hello" || resolved.InitialInput.TransitionInput != "" {
@@ -1211,7 +1211,7 @@ func TestResumeReleaseCompletesBeforePickerAndPickerCancelDoesNotReleaseAgain(t 
 		t.Fatalf("resolve and release resume: %v", err)
 	}
 	requireSessionPickerDestination(t, resolved)
-	if _, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive}); !errors.Is(err, projectbinding.ErrStartupCanceledByUser) {
+	if _, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}}); !errors.Is(err, projectbinding.ErrStartupCanceledByUser) {
 		t.Fatalf("picker result error = %v, want cancellation", err)
 	}
 	if releaseCalls != 1 {

--- a/cli/app/session_lifecycle_test.go
+++ b/cli/app/session_lifecycle_test.go
@@ -692,8 +692,8 @@ func TestResolveSessionActionResumeReopensPicker(t *testing.T) {
 	if resolved.ParentSessionID != "" {
 		t.Fatalf("expected no parent session id on resume, got %q", resolved.ParentSessionID)
 	}
-	if resolved.InitialPrompt != "" || resolved.InitialInput != "" {
-		t.Fatalf("expected no initial payload on resume, got prompt=%q input=%q", resolved.InitialPrompt, resolved.InitialInput)
+	if resolved.InitialPrompt != "" || resolved.InitialInput.TransitionInput != "" {
+		t.Fatalf("expected no initial payload on resume, got prompt=%q input=%q", resolved.InitialPrompt, resolved.InitialInput.TransitionInput)
 	}
 }
 
@@ -736,8 +736,8 @@ func TestResolveSessionActionNewSessionUsesForceNewFlow(t *testing.T) {
 	if resolved.ParentSessionID != "parent-1" {
 		t.Fatalf("expected parent session id passthrough, got %q", resolved.ParentSessionID)
 	}
-	if resolved.InitialPrompt != "hello" || resolved.InitialInput != "" {
-		t.Fatalf("expected initial prompt passthrough, got prompt=%q input=%q", resolved.InitialPrompt, resolved.InitialInput)
+	if resolved.InitialPrompt != "hello" || resolved.InitialInput.TransitionInput != "" {
+		t.Fatalf("expected initial prompt passthrough, got prompt=%q input=%q", resolved.InitialPrompt, resolved.InitialInput.TransitionInput)
 	}
 }
 
@@ -802,8 +802,8 @@ func TestNewSessionTransitionKeepsBackgroundProcessesAlive(t *testing.T) {
 	if !resolved.ShouldContinue || !resolved.ForceNewSession {
 		t.Fatalf("expected new-session transition, shouldContinue=%t forceNew=%t", resolved.ShouldContinue, resolved.ForceNewSession)
 	}
-	if resolved.NextSessionID != "" || resolved.InitialPrompt != "hello" || resolved.InitialInput != "" {
-		t.Fatalf("unexpected transition payload nextSessionID=%q initialPrompt=%q initialInput=%q", resolved.NextSessionID, resolved.InitialPrompt, resolved.InitialInput)
+	if resolved.NextSessionID != "" || resolved.InitialPrompt != "hello" || resolved.InitialInput.TransitionInput != "" {
+		t.Fatalf("unexpected transition payload nextSessionID=%q initialPrompt=%q initialInput=%q", resolved.NextSessionID, resolved.InitialPrompt, resolved.InitialInput.TransitionInput)
 	}
 
 	testServer := &testEmbeddedServer{
@@ -972,14 +972,155 @@ func TestResolveSessionActionOpenSessionUsesTargetID(t *testing.T) {
 	if resolved.InitialPrompt != "" {
 		t.Fatalf("expected no initial prompt, got %q", resolved.InitialPrompt)
 	}
-	if resolved.InitialInput != "draft reply" {
-		t.Fatalf("expected initial input passthrough, got %q", resolved.InitialInput)
+	if resolved.InitialInput.TransitionInput != "draft reply" {
+		t.Fatalf("expected initial input passthrough, got %q", resolved.InitialInput.TransitionInput)
 	}
 	if resolved.ParentSessionID != "" {
 		t.Fatalf("expected no parent session id, got %q", resolved.ParentSessionID)
 	}
 	if resolved.ForceNewSession {
 		t.Fatal("did not expect force-new session")
+	}
+}
+
+func TestResolveAndReleaseSessionHandoffOwnsInitialInputPrecedence(t *testing.T) {
+	tests := []struct {
+		name           string
+		action         UIAction
+		initialInput   string
+		wantPrecedence sessionInitialInputPrecedence
+	}{
+		{
+			name:           "open session preserves exact transition input",
+			action:         UIActionOpenSession,
+			initialInput:   " \nExact café 👩🏽‍💻\n尾  ",
+			wantPrecedence: sessionInitialInputPreferTransition,
+		},
+		{
+			name:           "open session preserves intentional empty transition input",
+			action:         UIActionOpenSession,
+			initialInput:   "",
+			wantPrecedence: sessionInitialInputPreferTransition,
+		},
+		{
+			name:           "other transitions prefer stored draft",
+			action:         UIActionResume,
+			initialInput:   "ordinary transition input",
+			wantPrecedence: sessionInitialInputPreferStoredDraft,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var initialInputRequest serverapi.SessionInitialInputRequest
+			lifecycle := &recordingSessionLifecycleClient{
+				resolveTransition: func(_ context.Context, req serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {
+					return serverapi.SessionResolveTransitionResponse{
+						NextSessionID:  "parent-session",
+						InitialInput:   req.Transition.InitialInput,
+						ShouldContinue: true,
+					}, nil
+				},
+				getInitialInput: func(_ context.Context, req serverapi.SessionInitialInputRequest) (serverapi.SessionInitialInputResponse, error) {
+					initialInputRequest = req
+					if req.OverrideStoredDraft {
+						return serverapi.SessionInitialInputResponse{Input: req.TransitionInput}, nil
+					}
+					return serverapi.SessionInitialInputResponse{
+						Input: "stored parent draft",
+						RecoveryBuffers: []serverapi.SessionDraftRecoveryBuffer{
+							{Kind: serverapi.SessionDraftRecoveryBufferQueuedInput, ID: "stale-parent-buffer", Text: "stale queued input"},
+						},
+					}, nil
+				},
+			}
+			server := narrowSessionLifecycleServer{lifecycle: lifecycle}
+
+			handoff, err := resolveAndReleaseSessionHandoff(
+				context.Background(),
+				server,
+				nil,
+				"child-session",
+				UITransition{Action: tt.action, InitialInput: tt.initialInput},
+				&runtimeLaunchPlan{close: func() error { return nil }},
+			)
+			if err != nil {
+				t.Fatalf("resolve and release handoff: %v", err)
+			}
+			if handoff.InitialInput.TransitionInput != tt.initialInput {
+				t.Fatalf("transition input = %q, want %q", handoff.InitialInput.TransitionInput, tt.initialInput)
+			}
+			if handoff.InitialInput.Precedence != tt.wantPrecedence {
+				t.Fatalf("initial input precedence = %v, want %v", handoff.InitialInput.Precedence, tt.wantPrecedence)
+			}
+			if tt.action != UIActionOpenSession {
+				return
+			}
+
+			initialState := sessionLaunchInitialStateFromServer(
+				context.Background(),
+				server,
+				handoff.NextSessionID,
+				handoff.InitialInput,
+			)
+			if initialInputRequest.TransitionInput != tt.initialInput {
+				t.Fatalf("next-launch transition input = %q, want %q", initialInputRequest.TransitionInput, tt.initialInput)
+			}
+			if !initialInputRequest.OverrideStoredDraft {
+				t.Fatal("next-launch request did not apply transition-input precedence")
+			}
+			if initialState.Input != tt.initialInput {
+				t.Fatalf("resolved parent input = %q, want %q", initialState.Input, tt.initialInput)
+			}
+			if len(initialState.RecoveryBuffers) != 0 {
+				t.Fatalf("resolved parent recovery buffers = %+v, want none", initialState.RecoveryBuffers)
+			}
+
+			runtimeClient := &runtimeControlFakeClient{
+				mainView: clientui.RuntimeMainView{
+					Session: clientui.RuntimeSessionView{SessionID: handoff.NextSessionID},
+				},
+			}
+			composition, err := composeUIProgram(uiLoopRequest{
+				wiring: &runtimeWiring{
+					runtimeClient: runtimeClient,
+					runtimeEvents: closedProjectedRuntimeEvents(),
+					askEvents:     closedAskEvents(),
+				},
+				active:          config.Settings{Theme: "dark"},
+				initialPrompt:   handoff.InitialPrompt,
+				initialInput:    initialState.Input,
+				recoveryBuffers: initialState.RecoveryBuffers,
+				statusConfig:    uiStatusConfig{PersistenceRoot: t.TempDir()},
+			}, io.Discard)
+			if err != nil {
+				t.Fatalf("compose parent UI: %v", err)
+			}
+			defer composition.close()
+
+			model := composition.model
+			if model.input != tt.initialInput {
+				t.Fatalf("parent composer input = %q, want %q", model.input, tt.initialInput)
+			}
+			if model.startupSubmit != "" || model.activeSubmit.text != "" || model.isBusy() {
+				t.Fatalf("prefill must stay idle and unsent: startup=%q active=%+v busy=%t", model.startupSubmit, model.activeSubmit, model.isBusy())
+			}
+			if len(model.recoveredDraftBuffers) != 0 || len(model.pendingInjected) != 0 || len(model.queued) != 0 {
+				t.Fatalf("parent recovery state leaked: recovered=%+v pending=%+v queued=%+v", model.recoveredDraftBuffers, model.pendingInjected, model.queued)
+			}
+
+			next, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+			edited := next.(*uiModel)
+			if cmd != nil {
+				t.Fatal("normal composer edit created a command")
+			}
+			if edited.input != tt.initialInput+"x" {
+				t.Fatalf("edited parent input = %q, want %q", edited.input, tt.initialInput+"x")
+			}
+			if runtimeClient.submitText != "" || runtimeClient.queueUserMessageCalls != 0 || runtimeClient.submitQueuedCalls != 0 {
+				t.Fatalf("normal edit submitted runtime work: submit=%q queued=%d flushed=%d", runtimeClient.submitText, runtimeClient.queueUserMessageCalls, runtimeClient.submitQueuedCalls)
+			}
+		})
 	}
 }
 
@@ -1194,7 +1335,56 @@ func TestNormalExitUsesNormalRuntimePlanClose(t *testing.T) {
 	}
 }
 
-func TestResolveAndReleaseSessionActionReturnsReleaseFailureBeforeDestinationCanPlan(t *testing.T) {
+func TestResolveAndReleaseSessionHandoffTransitionFailureLeavesChildReopenableWithoutDestination(t *testing.T) {
+	child := createAppRuntimeSession(t)
+	if err := child.EnsureDurable(); err != nil {
+		t.Fatalf("persist child session: %v", err)
+	}
+	resolveErr := errors.New("transition resolution failed")
+	releaseCalls := 0
+	server := narrowSessionLifecycleServer{
+		lifecycle: &recordingSessionLifecycleClient{
+			resolveTransition: func(context.Context, serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {
+				return serverapi.SessionResolveTransitionResponse{}, resolveErr
+			},
+		},
+	}
+
+	handoff, err := resolveAndReleaseSessionHandoff(
+		context.Background(),
+		server,
+		nil,
+		child.Meta().SessionID,
+		UITransition{Action: UIActionOpenSession, TargetSessionID: "parent-session"},
+		&runtimeLaunchPlan{close: func() error {
+			releaseCalls++
+			return nil
+		}},
+	)
+	if !errors.Is(err, resolveErr) {
+		t.Fatalf("handoff error = %v, want transition failure", err)
+	}
+	if handoff.ShouldContinue || handoff.NextSessionID != "" {
+		t.Fatalf("transition failure returned destination handoff %+v", handoff)
+	}
+	if releaseCalls != 1 {
+		t.Fatalf("origin release calls = %d, want 1 after transition failure", releaseCalls)
+	}
+
+	reopened, err := session.Open(child.Dir())
+	if err != nil {
+		t.Fatalf("reopen child after transition failure: %v", err)
+	}
+	if reopened.Meta().SessionID != child.Meta().SessionID {
+		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
+	}
+}
+
+func TestResolveAndReleaseSessionHandoffReturnsReleaseFailureBeforeDestinationCanPlan(t *testing.T) {
+	child := createAppRuntimeSession(t)
+	if err := child.EnsureDurable(); err != nil {
+		t.Fatalf("persist child session: %v", err)
+	}
 	releaseErr := errors.New("release failed")
 	events := make([]string, 0, 2)
 	server := narrowSessionLifecycleServer{
@@ -1210,7 +1400,7 @@ func TestResolveAndReleaseSessionActionReturnsReleaseFailureBeforeDestinationCan
 		return releaseErr
 	}}
 
-	resolved, err := resolveAndReleaseSessionAction(context.Background(), server, nil, "origin", UITransition{Action: UIActionResume}, plan)
+	resolved, err := resolveAndReleaseSessionHandoff(context.Background(), server, nil, child.Meta().SessionID, UITransition{Action: UIActionResume}, plan)
 	if !errors.Is(err, releaseErr) {
 		t.Fatalf("error = %v, want release failure", err)
 	}
@@ -1219,6 +1409,140 @@ func TestResolveAndReleaseSessionActionReturnsReleaseFailureBeforeDestinationCan
 	}
 	if got := strings.Join(events, ","); got != "resolve,release" {
 		t.Fatalf("event order = %q, want resolve,release", got)
+	}
+	reopened, err := session.Open(child.Dir())
+	if err != nil {
+		t.Fatalf("reopen child after release failure: %v", err)
+	}
+	if reopened.Meta().SessionID != child.Meta().SessionID {
+		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
+	}
+}
+
+func TestDestinationPlanningFailureLeavesChildReopenableWithoutPreparation(t *testing.T) {
+	child := createAppRuntimeSession(t)
+	if err := child.EnsureDurable(); err != nil {
+		t.Fatalf("persist child session: %v", err)
+	}
+	planErr := errors.New("destination planning failed")
+	prepareCalls := 0
+	server := &testEmbeddedServer{
+		cfg: config.App{
+			WorkspaceRoot:   t.TempDir(),
+			PersistenceRoot: t.TempDir(),
+			Settings:        config.Settings{Theme: "dark"},
+		},
+		sessionLifecycle: &recordingSessionLifecycleClient{
+			resolveTransition: func(_ context.Context, req serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {
+				return serverapi.SessionResolveTransitionResponse{
+					NextSessionID:  req.Transition.TargetSessionID,
+					InitialInput:   req.Transition.InitialInput,
+					ShouldContinue: true,
+				}, nil
+			},
+		},
+		sessionLaunch: stubSessionLaunchClient{
+			planSession: func(context.Context, serverapi.SessionPlanRequest) (serverapi.SessionPlanResponse, error) {
+				return serverapi.SessionPlanResponse{}, planErr
+			},
+		},
+		prepareRuntime: func(context.Context, sessionLaunchPlan, io.Writer, string) (*runtimeLaunchPlan, error) {
+			prepareCalls++
+			return nil, errors.New("destination preparation must not start")
+		},
+	}
+
+	handoff, err := resolveAndReleaseSessionHandoff(
+		context.Background(),
+		server,
+		nil,
+		child.Meta().SessionID,
+		UITransition{Action: UIActionOpenSession, TargetSessionID: "parent-session", InitialInput: "child final"},
+		&runtimeLaunchPlan{close: func() error { return nil }},
+	)
+	if err != nil {
+		t.Fatalf("resolve destination handoff: %v", err)
+	}
+	planner := newSessionLaunchPlanner(server)
+	_, err = planner.PlanSession(context.Background(), sessionLaunchRequest{
+		Mode:              launchModeInteractive,
+		SelectedSessionID: handoff.NextSessionID,
+	})
+	if !errors.Is(err, planErr) {
+		t.Fatalf("destination planning error = %v, want %v", err, planErr)
+	}
+	if prepareCalls != 0 {
+		t.Fatalf("destination preparation calls = %d, want none after planning failure", prepareCalls)
+	}
+
+	reopened, err := session.Open(child.Dir())
+	if err != nil {
+		t.Fatalf("reopen child after destination planning failure: %v", err)
+	}
+	if reopened.Meta().SessionID != child.Meta().SessionID {
+		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
+	}
+}
+
+func TestDestinationPreparationFailureLeavesChildReopenableWithoutComposition(t *testing.T) {
+	child := createAppRuntimeSession(t)
+	if err := child.EnsureDurable(); err != nil {
+		t.Fatalf("persist child session: %v", err)
+	}
+	prepareErr := errors.New("destination runtime preparation failed")
+	initialInputCalls := 0
+	server := &testEmbeddedServer{
+		cfg: config.App{
+			WorkspaceRoot:   t.TempDir(),
+			PersistenceRoot: t.TempDir(),
+			Settings:        config.Settings{Theme: "dark"},
+		},
+		sessionLifecycle: &recordingSessionLifecycleClient{
+			getInitialInput: func(context.Context, serverapi.SessionInitialInputRequest) (serverapi.SessionInitialInputResponse, error) {
+				initialInputCalls++
+				return serverapi.SessionInitialInputResponse{}, errors.New("initial input must not load before runtime preparation")
+			},
+		},
+		prepareRuntime: func(context.Context, sessionLaunchPlan, io.Writer, string) (*runtimeLaunchPlan, error) {
+			return nil, prepareErr
+		},
+	}
+	planner := newSessionLaunchPlanner(server)
+
+	runtimePlan, request, err := prepareSessionUIRun(
+		context.Background(),
+		server,
+		planner,
+		sessionLaunchPlan{
+			SessionID:      "parent-session",
+			WorkspaceRoot:  server.cfg.WorkspaceRoot,
+			ActiveSettings: config.Settings{Model: "gpt-5", Theme: "dark"},
+		},
+		resolvedSessionHandoff{
+			NextSessionID: "parent-session",
+			InitialInput: sessionInitialInputDirective{
+				TransitionInput: "child final",
+				Precedence:      sessionInitialInputPreferTransition,
+			},
+		},
+		false,
+	)
+	if !errors.Is(err, prepareErr) {
+		t.Fatalf("destination preparation error = %v, want %v", err, prepareErr)
+	}
+	if runtimePlan != nil || request.wiring != nil {
+		t.Fatalf("failed destination preparation returned composable state plan=%+v request=%+v", runtimePlan, request)
+	}
+	if initialInputCalls != 0 {
+		t.Fatalf("initial input calls = %d, want none before successful runtime preparation", initialInputCalls)
+	}
+
+	reopened, err := session.Open(child.Dir())
+	if err != nil {
+		t.Fatalf("reopen child after destination preparation failure: %v", err)
+	}
+	if reopened.Meta().SessionID != child.Meta().SessionID {
+		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
 	}
 }
 
@@ -1261,7 +1585,7 @@ func TestResumeReleaseCompletesBeforePickerAndPickerCancelDoesNotReleaseAgain(t 
 		}
 		return sessionPickerResult{Canceled: true}, nil
 	}
-	resolved, err := resolveAndReleaseSessionAction(
+	resolved, err := resolveAndReleaseSessionHandoff(
 		context.Background(),
 		narrowSessionLifecycleServer{lifecycle: &recordingSessionLifecycleClient{
 			resolveTransition: func(context.Context, serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {

--- a/cli/app/session_lifecycle_test.go
+++ b/cli/app/session_lifecycle_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -680,20 +679,9 @@ func TestResolveSessionActionResumeReopensPicker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve session action: %v", err)
 	}
-	if !resolved.ShouldContinue {
-		t.Fatal("expected lifecycle to continue for resume action")
-	}
-	if resolved.NextSessionID != "" {
-		t.Fatalf("expected empty session id to force picker, got %q", resolved.NextSessionID)
-	}
-	if resolved.ForceNewSession {
-		t.Fatal("did not expect force-new for resume action")
-	}
-	if resolved.ParentSessionID != "" {
-		t.Fatalf("expected no parent session id on resume, got %q", resolved.ParentSessionID)
-	}
-	if resolved.InitialPrompt != "" || resolved.InitialInput.TransitionInput != "" {
-		t.Fatalf("expected no initial payload on resume, got prompt=%q input=%q", resolved.InitialPrompt, resolved.InitialInput.TransitionInput)
+	requireSessionPickerDestination(t, resolved)
+	if resolved.InitialPrompt != nil || resolved.InitialInput.TransitionInput != "" {
+		t.Fatalf("expected no initial payload on resume, got prompt=%+v input=%q", resolved.InitialPrompt, resolved.InitialInput.TransitionInput)
 	}
 }
 
@@ -708,7 +696,7 @@ func TestResolveSessionActionExitStaysClientLocal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve session action: %v", err)
 	}
-	if resolved.ShouldContinue {
+	if resolved != nil {
 		t.Fatal("expected exit transition not to continue")
 	}
 }
@@ -724,20 +712,12 @@ func TestResolveSessionActionNewSessionUsesForceNewFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve session action: %v", err)
 	}
-	if !resolved.ShouldContinue {
-		t.Fatal("expected lifecycle to continue for new session action")
+	parent := requireSessionCreateDestination(t, resolved)
+	if parent == nil || parent.SessionID != "parent-1" {
+		t.Fatalf("expected parent session id passthrough, got %+v", parent)
 	}
-	if !resolved.ForceNewSession {
-		t.Fatal("expected force-new session flow")
-	}
-	if resolved.NextSessionID != "" {
-		t.Fatalf("expected empty session id for force-new flow, got %q", resolved.NextSessionID)
-	}
-	if resolved.ParentSessionID != "parent-1" {
-		t.Fatalf("expected parent session id passthrough, got %q", resolved.ParentSessionID)
-	}
-	if resolved.InitialPrompt != "hello" || resolved.InitialInput.TransitionInput != "" {
-		t.Fatalf("expected initial prompt passthrough, got prompt=%q input=%q", resolved.InitialPrompt, resolved.InitialInput.TransitionInput)
+	if resolved.InitialPrompt == nil || resolved.InitialPrompt.Text != "hello" || resolved.InitialInput.TransitionInput != "" {
+		t.Fatalf("expected initial prompt passthrough, got prompt=%+v input=%q", resolved.InitialPrompt, resolved.InitialInput.TransitionInput)
 	}
 }
 
@@ -766,7 +746,7 @@ func TestResolveSessionActionPreservesInitialPromptHistoryRecorded(t *testing.T)
 	if err != nil {
 		t.Fatalf("resolve session action: %v", err)
 	}
-	if !resolved.InitialPromptHistoryRecorded {
+	if resolved == nil || resolved.InitialPrompt == nil || !resolved.InitialPrompt.HistoryRecorded {
 		t.Fatal("expected resolved transition to preserve initial prompt-history flag")
 	}
 }
@@ -799,11 +779,12 @@ func TestNewSessionTransitionKeepsBackgroundProcessesAlive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve session action: %v", err)
 	}
-	if !resolved.ShouldContinue || !resolved.ForceNewSession {
-		t.Fatalf("expected new-session transition, shouldContinue=%t forceNew=%t", resolved.ShouldContinue, resolved.ForceNewSession)
+	parent := requireSessionCreateDestination(t, resolved)
+	if parent == nil || parent.SessionID != "parent-1" {
+		t.Fatalf("expected new-session parent, got %+v", parent)
 	}
-	if resolved.NextSessionID != "" || resolved.InitialPrompt != "hello" || resolved.InitialInput.TransitionInput != "" {
-		t.Fatalf("unexpected transition payload nextSessionID=%q initialPrompt=%q initialInput=%q", resolved.NextSessionID, resolved.InitialPrompt, resolved.InitialInput.TransitionInput)
+	if resolved.InitialPrompt == nil || resolved.InitialPrompt.Text != "hello" || resolved.InitialInput.TransitionInput != "" {
+		t.Fatalf("unexpected transition payload initialPrompt=%+v initialInput=%q", resolved.InitialPrompt, resolved.InitialInput.TransitionInput)
 	}
 
 	testServer := &testEmbeddedServer{
@@ -815,12 +796,11 @@ func TestNewSessionTransitionKeepsBackgroundProcessesAlive(t *testing.T) {
 		containerDir: root,
 	}
 	planner := &launchPlanner{server: testServer}
-	storePlan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{
-		Mode:              launchModeInteractive,
-		SelectedSessionID: resolved.NextSessionID,
-		ForceNewSession:   resolved.ForceNewSession,
-		ParentSessionID:   resolved.ParentSessionID,
-	})
+	launchRequest, err := sessionLaunchRequestFromHandoff(*resolved, serverapi.RunPromptOverrides{})
+	if err != nil {
+		t.Fatalf("build next-session launch request: %v", err)
+	}
+	storePlan, err := planner.PlanSession(context.Background(), launchRequest)
 	if err != nil {
 		t.Fatalf("open or create next session: %v", err)
 	}
@@ -921,11 +901,11 @@ func TestReviewTeleportLifecyclePreservesParentWorktreeContext(t *testing.T) {
 		t.Fatalf("resolve session action: %v", err)
 	}
 	planner := newSessionLaunchPlanner(server)
-	plan, err := planner.PlanSession(ctx, sessionLaunchRequest{
-		Mode:            launchModeInteractive,
-		ForceNewSession: resolved.ForceNewSession,
-		ParentSessionID: resolved.ParentSessionID,
-	})
+	launchRequest, err := sessionLaunchRequestFromHandoff(*resolved, serverapi.RunPromptOverrides{})
+	if err != nil {
+		t.Fatalf("build child launch request: %v", err)
+	}
+	plan, err := planner.PlanSession(ctx, launchRequest)
 	if err != nil {
 		t.Fatalf("PlanSession child: %v", err)
 	}
@@ -963,176 +943,14 @@ func TestResolveSessionActionOpenSessionUsesTargetID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve session action: %v", err)
 	}
-	if !resolved.ShouldContinue {
-		t.Fatal("expected lifecycle to continue for open session action")
+	if got := requireSessionOpenDestination(t, resolved); got != "session-42" {
+		t.Fatalf("expected target session id passthrough, got %q", got)
 	}
-	if resolved.NextSessionID != "session-42" {
-		t.Fatalf("expected target session id passthrough, got %q", resolved.NextSessionID)
-	}
-	if resolved.InitialPrompt != "" {
-		t.Fatalf("expected no initial prompt, got %q", resolved.InitialPrompt)
+	if resolved.InitialPrompt != nil {
+		t.Fatalf("expected no initial prompt, got %+v", resolved.InitialPrompt)
 	}
 	if resolved.InitialInput.TransitionInput != "draft reply" {
 		t.Fatalf("expected initial input passthrough, got %q", resolved.InitialInput.TransitionInput)
-	}
-	if resolved.ParentSessionID != "" {
-		t.Fatalf("expected no parent session id, got %q", resolved.ParentSessionID)
-	}
-	if resolved.ForceNewSession {
-		t.Fatal("did not expect force-new session")
-	}
-}
-
-func TestResolveAndReleaseSessionHandoffOwnsInitialInputPrecedence(t *testing.T) {
-	tests := []struct {
-		name           string
-		action         UIAction
-		initialInput   string
-		wantPrecedence sessionInitialInputPrecedence
-	}{
-		{
-			name:           "open session preserves exact transition input",
-			action:         UIActionOpenSession,
-			initialInput:   " \nExact café 👩🏽‍💻\n尾  ",
-			wantPrecedence: sessionInitialInputPreferTransition,
-		},
-		{
-			name:           "open session preserves intentional empty transition input",
-			action:         UIActionOpenSession,
-			initialInput:   "",
-			wantPrecedence: sessionInitialInputPreferTransition,
-		},
-		{
-			name:           "other transitions prefer stored draft",
-			action:         UIActionResume,
-			initialInput:   "ordinary transition input",
-			wantPrecedence: sessionInitialInputPreferStoredDraft,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var initialInputRequest serverapi.SessionInitialInputRequest
-			lifecycle := &recordingSessionLifecycleClient{
-				resolveTransition: func(_ context.Context, req serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {
-					return serverapi.SessionResolveTransitionResponse{
-						NextSessionID:  "parent-session",
-						InitialInput:   req.Transition.InitialInput,
-						ShouldContinue: true,
-					}, nil
-				},
-				getInitialInput: func(_ context.Context, req serverapi.SessionInitialInputRequest) (serverapi.SessionInitialInputResponse, error) {
-					initialInputRequest = req
-					if req.OverrideStoredDraft {
-						return serverapi.SessionInitialInputResponse{Input: req.TransitionInput}, nil
-					}
-					return serverapi.SessionInitialInputResponse{
-						Input: "stored parent draft",
-						RecoveryBuffers: []serverapi.SessionDraftRecoveryBuffer{
-							{Kind: serverapi.SessionDraftRecoveryBufferQueuedInput, ID: "stale-parent-buffer", Text: "stale queued input"},
-						},
-					}, nil
-				},
-			}
-			server := narrowSessionLifecycleServer{lifecycle: lifecycle}
-
-			handoff, err := resolveAndReleaseSessionHandoff(
-				context.Background(),
-				server,
-				nil,
-				"child-session",
-				UITransition{Action: tt.action, InitialInput: tt.initialInput},
-				&runtimeLaunchPlan{close: func() error { return nil }},
-			)
-			if err != nil {
-				t.Fatalf("resolve and release handoff: %v", err)
-			}
-			if handoff.InitialInput.TransitionInput != tt.initialInput {
-				t.Fatalf("transition input = %q, want %q", handoff.InitialInput.TransitionInput, tt.initialInput)
-			}
-			if handoff.InitialInput.Precedence != tt.wantPrecedence {
-				t.Fatalf("initial input precedence = %v, want %v", handoff.InitialInput.Precedence, tt.wantPrecedence)
-			}
-			if tt.action != UIActionOpenSession {
-				return
-			}
-
-			initialState := sessionLaunchInitialStateFromServer(
-				context.Background(),
-				server,
-				handoff.NextSessionID,
-				handoff.InitialInput,
-			)
-			if initialInputRequest.TransitionInput != tt.initialInput {
-				t.Fatalf("next-launch transition input = %q, want %q", initialInputRequest.TransitionInput, tt.initialInput)
-			}
-			if !initialInputRequest.OverrideStoredDraft {
-				t.Fatal("next-launch request did not apply transition-input precedence")
-			}
-			if initialState.Input != tt.initialInput {
-				t.Fatalf("resolved parent input = %q, want %q", initialState.Input, tt.initialInput)
-			}
-			if len(initialState.RecoveryBuffers) != 0 {
-				t.Fatalf("resolved parent recovery buffers = %+v, want none", initialState.RecoveryBuffers)
-			}
-
-			runtimeClient := &runtimeControlFakeClient{
-				mainView: clientui.RuntimeMainView{
-					Session: clientui.RuntimeSessionView{SessionID: handoff.NextSessionID},
-				},
-			}
-			composition, err := composeUIProgram(uiLoopRequest{
-				wiring: &runtimeWiring{
-					runtimeClient: runtimeClient,
-					runtimeEvents: closedProjectedRuntimeEvents(),
-					askEvents:     closedAskEvents(),
-				},
-				active:          config.Settings{Theme: "dark"},
-				initialPrompt:   handoff.InitialPrompt,
-				initialInput:    initialState.Input,
-				recoveryBuffers: initialState.RecoveryBuffers,
-				statusConfig:    uiStatusConfig{PersistenceRoot: t.TempDir()},
-			}, io.Discard)
-			if err != nil {
-				t.Fatalf("compose parent UI: %v", err)
-			}
-			defer composition.close()
-
-			model := composition.model
-			if model.input != tt.initialInput {
-				t.Fatalf("parent composer input = %q, want %q", model.input, tt.initialInput)
-			}
-			if model.startupSubmit != "" || model.activeSubmit.text != "" || model.isBusy() {
-				t.Fatalf("prefill must stay idle and unsent: startup=%q active=%+v busy=%t", model.startupSubmit, model.activeSubmit, model.isBusy())
-			}
-			if len(model.recoveredDraftBuffers) != 0 || len(model.pendingInjected) != 0 || len(model.queued) != 0 {
-				t.Fatalf("parent recovery state leaked: recovered=%+v pending=%+v queued=%+v", model.recoveredDraftBuffers, model.pendingInjected, model.queued)
-			}
-
-			next, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
-			edited := next.(*uiModel)
-			if cmd != nil {
-				t.Fatal("normal composer edit created a command")
-			}
-			if edited.input != tt.initialInput+"x" {
-				t.Fatalf("edited parent input = %q, want %q", edited.input, tt.initialInput+"x")
-			}
-			if runtimeClient.submitText != "" || runtimeClient.queueUserMessageCalls != 0 || runtimeClient.submitQueuedCalls != 0 {
-				t.Fatalf("normal edit submitted runtime work: submit=%q queued=%d flushed=%d", runtimeClient.submitText, runtimeClient.queueUserMessageCalls, runtimeClient.submitQueuedCalls)
-			}
-		})
-	}
-}
-
-func TestSessionLaunchInitialInputUsesNarrowLifecycleClientFallback(t *testing.T) {
-	got := sessionLaunchInitialInputFromServer(
-		context.Background(),
-		narrowSessionLifecycleServer{},
-		"session-1",
-		"typed draft",
-	)
-	if got != "typed draft" {
-		t.Fatalf("initial input = %q, want fallback transition input", got)
 	}
 }
 
@@ -1196,7 +1014,7 @@ func TestResolveSessionActionReauthenticatesThroughNarrowServer(t *testing.T) {
 	if reauthCalls != 1 {
 		t.Fatalf("reauth calls = %d, want 1", reauthCalls)
 	}
-	if !resolved.ShouldContinue || resolved.NextSessionID != "next-1" {
+	if got := requireSessionOpenDestination(t, resolved); got != "next-1" {
 		t.Fatalf("resolved = %+v, want continue to next-1", resolved)
 	}
 }
@@ -1335,217 +1153,6 @@ func TestNormalExitUsesNormalRuntimePlanClose(t *testing.T) {
 	}
 }
 
-func TestResolveAndReleaseSessionHandoffTransitionFailureLeavesChildReopenableWithoutDestination(t *testing.T) {
-	child := createAppRuntimeSession(t)
-	if err := child.EnsureDurable(); err != nil {
-		t.Fatalf("persist child session: %v", err)
-	}
-	resolveErr := errors.New("transition resolution failed")
-	releaseCalls := 0
-	server := narrowSessionLifecycleServer{
-		lifecycle: &recordingSessionLifecycleClient{
-			resolveTransition: func(context.Context, serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {
-				return serverapi.SessionResolveTransitionResponse{}, resolveErr
-			},
-		},
-	}
-
-	handoff, err := resolveAndReleaseSessionHandoff(
-		context.Background(),
-		server,
-		nil,
-		child.Meta().SessionID,
-		UITransition{Action: UIActionOpenSession, TargetSessionID: "parent-session"},
-		&runtimeLaunchPlan{close: func() error {
-			releaseCalls++
-			return nil
-		}},
-	)
-	if !errors.Is(err, resolveErr) {
-		t.Fatalf("handoff error = %v, want transition failure", err)
-	}
-	if handoff.ShouldContinue || handoff.NextSessionID != "" {
-		t.Fatalf("transition failure returned destination handoff %+v", handoff)
-	}
-	if releaseCalls != 1 {
-		t.Fatalf("origin release calls = %d, want 1 after transition failure", releaseCalls)
-	}
-
-	reopened, err := session.Open(child.Dir())
-	if err != nil {
-		t.Fatalf("reopen child after transition failure: %v", err)
-	}
-	if reopened.Meta().SessionID != child.Meta().SessionID {
-		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
-	}
-}
-
-func TestResolveAndReleaseSessionHandoffReturnsReleaseFailureBeforeDestinationCanPlan(t *testing.T) {
-	child := createAppRuntimeSession(t)
-	if err := child.EnsureDurable(); err != nil {
-		t.Fatalf("persist child session: %v", err)
-	}
-	releaseErr := errors.New("release failed")
-	events := make([]string, 0, 2)
-	server := narrowSessionLifecycleServer{
-		lifecycle: &recordingSessionLifecycleClient{
-			resolveTransition: func(context.Context, serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {
-				events = append(events, "resolve")
-				return serverapi.SessionResolveTransitionResponse{ShouldContinue: true, NextSessionID: "destination"}, nil
-			},
-		},
-	}
-	plan := &runtimeLaunchPlan{close: func() error {
-		events = append(events, "release")
-		return releaseErr
-	}}
-
-	resolved, err := resolveAndReleaseSessionHandoff(context.Background(), server, nil, child.Meta().SessionID, UITransition{Action: UIActionResume}, plan)
-	if !errors.Is(err, releaseErr) {
-		t.Fatalf("error = %v, want release failure", err)
-	}
-	if resolved.ShouldContinue || resolved.NextSessionID != "" {
-		t.Fatalf("release failure returned destination %+v", resolved)
-	}
-	if got := strings.Join(events, ","); got != "resolve,release" {
-		t.Fatalf("event order = %q, want resolve,release", got)
-	}
-	reopened, err := session.Open(child.Dir())
-	if err != nil {
-		t.Fatalf("reopen child after release failure: %v", err)
-	}
-	if reopened.Meta().SessionID != child.Meta().SessionID {
-		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
-	}
-}
-
-func TestDestinationPlanningFailureLeavesChildReopenableWithoutPreparation(t *testing.T) {
-	child := createAppRuntimeSession(t)
-	if err := child.EnsureDurable(); err != nil {
-		t.Fatalf("persist child session: %v", err)
-	}
-	planErr := errors.New("destination planning failed")
-	prepareCalls := 0
-	server := &testEmbeddedServer{
-		cfg: config.App{
-			WorkspaceRoot:   t.TempDir(),
-			PersistenceRoot: t.TempDir(),
-			Settings:        config.Settings{Theme: "dark"},
-		},
-		sessionLifecycle: &recordingSessionLifecycleClient{
-			resolveTransition: func(_ context.Context, req serverapi.SessionResolveTransitionRequest) (serverapi.SessionResolveTransitionResponse, error) {
-				return serverapi.SessionResolveTransitionResponse{
-					NextSessionID:  req.Transition.TargetSessionID,
-					InitialInput:   req.Transition.InitialInput,
-					ShouldContinue: true,
-				}, nil
-			},
-		},
-		sessionLaunch: stubSessionLaunchClient{
-			planSession: func(context.Context, serverapi.SessionPlanRequest) (serverapi.SessionPlanResponse, error) {
-				return serverapi.SessionPlanResponse{}, planErr
-			},
-		},
-		prepareRuntime: func(context.Context, sessionLaunchPlan, io.Writer, string) (*runtimeLaunchPlan, error) {
-			prepareCalls++
-			return nil, errors.New("destination preparation must not start")
-		},
-	}
-
-	handoff, err := resolveAndReleaseSessionHandoff(
-		context.Background(),
-		server,
-		nil,
-		child.Meta().SessionID,
-		UITransition{Action: UIActionOpenSession, TargetSessionID: "parent-session", InitialInput: "child final"},
-		&runtimeLaunchPlan{close: func() error { return nil }},
-	)
-	if err != nil {
-		t.Fatalf("resolve destination handoff: %v", err)
-	}
-	planner := newSessionLaunchPlanner(server)
-	_, err = planner.PlanSession(context.Background(), sessionLaunchRequest{
-		Mode:              launchModeInteractive,
-		SelectedSessionID: handoff.NextSessionID,
-	})
-	if !errors.Is(err, planErr) {
-		t.Fatalf("destination planning error = %v, want %v", err, planErr)
-	}
-	if prepareCalls != 0 {
-		t.Fatalf("destination preparation calls = %d, want none after planning failure", prepareCalls)
-	}
-
-	reopened, err := session.Open(child.Dir())
-	if err != nil {
-		t.Fatalf("reopen child after destination planning failure: %v", err)
-	}
-	if reopened.Meta().SessionID != child.Meta().SessionID {
-		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
-	}
-}
-
-func TestDestinationPreparationFailureLeavesChildReopenableWithoutComposition(t *testing.T) {
-	child := createAppRuntimeSession(t)
-	if err := child.EnsureDurable(); err != nil {
-		t.Fatalf("persist child session: %v", err)
-	}
-	prepareErr := errors.New("destination runtime preparation failed")
-	initialInputCalls := 0
-	server := &testEmbeddedServer{
-		cfg: config.App{
-			WorkspaceRoot:   t.TempDir(),
-			PersistenceRoot: t.TempDir(),
-			Settings:        config.Settings{Theme: "dark"},
-		},
-		sessionLifecycle: &recordingSessionLifecycleClient{
-			getInitialInput: func(context.Context, serverapi.SessionInitialInputRequest) (serverapi.SessionInitialInputResponse, error) {
-				initialInputCalls++
-				return serverapi.SessionInitialInputResponse{}, errors.New("initial input must not load before runtime preparation")
-			},
-		},
-		prepareRuntime: func(context.Context, sessionLaunchPlan, io.Writer, string) (*runtimeLaunchPlan, error) {
-			return nil, prepareErr
-		},
-	}
-	planner := newSessionLaunchPlanner(server)
-
-	runtimePlan, request, err := prepareSessionUIRun(
-		context.Background(),
-		server,
-		planner,
-		sessionLaunchPlan{
-			SessionID:      "parent-session",
-			WorkspaceRoot:  server.cfg.WorkspaceRoot,
-			ActiveSettings: config.Settings{Model: "gpt-5", Theme: "dark"},
-		},
-		resolvedSessionHandoff{
-			NextSessionID: "parent-session",
-			InitialInput: sessionInitialInputDirective{
-				TransitionInput: "child final",
-				Precedence:      sessionInitialInputPreferTransition,
-			},
-		},
-		false,
-	)
-	if !errors.Is(err, prepareErr) {
-		t.Fatalf("destination preparation error = %v, want %v", err, prepareErr)
-	}
-	if runtimePlan != nil || request.wiring != nil {
-		t.Fatalf("failed destination preparation returned composable state plan=%+v request=%+v", runtimePlan, request)
-	}
-	if initialInputCalls != 0 {
-		t.Fatalf("initial input calls = %d, want none before successful runtime preparation", initialInputCalls)
-	}
-
-	reopened, err := session.Open(child.Dir())
-	if err != nil {
-		t.Fatalf("reopen child after destination preparation failure: %v", err)
-	}
-	if reopened.Meta().SessionID != child.Meta().SessionID {
-		t.Fatalf("reopened child id = %q, want %q", reopened.Meta().SessionID, child.Meta().SessionID)
-	}
-}
-
 func TestExitReleaseFailureReturnsAfterUILoopResult(t *testing.T) {
 	releaseErr := errors.New("release failed")
 	uiLoopReturned := false
@@ -1603,9 +1210,7 @@ func TestResumeReleaseCompletesBeforePickerAndPickerCancelDoesNotReleaseAgain(t 
 	if err != nil {
 		t.Fatalf("resolve and release resume: %v", err)
 	}
-	if !resolved.ShouldContinue || resolved.NextSessionID != "" {
-		t.Fatalf("resolved resume = %+v", resolved)
-	}
+	requireSessionPickerDestination(t, resolved)
 	if _, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive}); !errors.Is(err, projectbinding.ErrStartupCanceledByUser) {
 		t.Fatalf("picker result error = %v, want cancellation", err)
 	}

--- a/cli/app/session_server_target_part2_test.go
+++ b/cli/app/session_server_target_part2_test.go
@@ -76,7 +76,7 @@ func TestStartEmbeddedServerUnknownWorkspaceCreateProjectFlowCanPlanSession(t *t
 
 	t.Log("planning interactive session")
 	planner := newSessionLaunchPlanner(bound)
-	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive})
+	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionPickerDestination{}})
 	if err != nil {
 		t.Fatalf("PlanSession: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestRemoteNoAuthUnregisteredWorkspaceBindingCanPrepareRuntime(t *testing.T)
 	if err != nil {
 		t.Fatalf("ensureInteractiveProjectBinding: %v", err)
 	}
-	_, runtimePlan := prepareAppRuntimePlanWithOpenAIBaseURL(t, bound, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, fakeResponses.URL, io.Discard, "test remote no-auth rebound runtime")
+	_, runtimePlan := prepareAppRuntimePlanWithOpenAIBaseURL(t, bound, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}}, fakeResponses.URL, io.Discard, "test remote no-auth rebound runtime")
 	submission, err := submitRuntimeClientForTest(t, runtimePlan.Wiring.runtimeClient, "hello after rebound no auth")
 	if err != nil {
 		t.Fatalf("SubmitUserMessage: %v", err)
@@ -277,7 +277,7 @@ func TestRemoteSessionStatusDoesNotReuseLocalAuthState(t *testing.T) {
 	}
 
 	planner := newSessionLaunchPlanner(server)
-	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true})
+	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}})
 	if err != nil {
 		t.Fatalf("PlanSession: %v", err)
 	}
@@ -425,7 +425,7 @@ func TestStartSessionServerUsesInvocationOverridesWhenAttachingToDiscoveredDaemo
 	}
 	defer func() { _ = server.Close() }()
 
-	_, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, io.Discard, "test remote interactive runtime override")
+	_, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}}, io.Discard, "test remote interactive runtime override")
 	defer runtimePlan.Close()
 
 	submission, err := submitRuntimeClientForTest(t, runtimePlan.Wiring.runtimeClient, "hello through interactive override")
@@ -474,7 +474,7 @@ func TestStartSessionServerPreservesExplicitCLIToolsWithCLIModelOverride(t *test
 	defer func() { _ = server.Close() }()
 
 	planner := newSessionLaunchPlanner(server)
-	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true})
+	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}})
 	if err != nil {
 		t.Fatalf("PlanSession: %v", err)
 	}
@@ -511,7 +511,7 @@ func TestStartSessionServerUsesConfiguredDaemonForPromptRoundTrip(t *testing.T) 
 	defer func() { _ = server.Close() }()
 	promptViews := requirePromptViewServer(t, server)
 
-	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, io.Discard, "test remote prompt round trip")
+	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}}, io.Discard, "test remote prompt round trip")
 	defer runtimePlan.Close()
 
 	askDone := make(chan struct {

--- a/cli/app/session_server_target_part3_test.go
+++ b/cli/app/session_server_target_part3_test.go
@@ -49,8 +49,15 @@ func TestStartSessionServerUsesConfiguredDaemonForSessionLifecycleDraftPersisten
 	if _, err := server.SessionLifecycleClient().PersistInputDraft(context.Background(), serverapi.SessionPersistInputDraftRequest{ClientRequestID: uuid.NewString(), SessionID: plan.SessionID, Input: "saved draft"}); err != nil {
 		t.Fatalf("PersistInputDraft: %v", err)
 	}
-	if got := sessionLaunchInitialInputFromServer(context.Background(), server, plan.SessionID, "transition draft"); got != "saved draft" {
-		t.Fatalf("sessionLaunchInitialInputFromServer = %q, want saved draft", got)
+	initialState, err := sessionLaunchInitialStateFromServer(context.Background(), server, plan.SessionID, sessionInitialInputDirective{
+		TransitionInput: "transition draft",
+		Precedence:      sessionInitialInputPreferStoredDraft,
+	})
+	if err != nil {
+		t.Fatalf("sessionLaunchInitialStateFromServer: %v", err)
+	}
+	if initialState.Input != "saved draft" {
+		t.Fatalf("sessionLaunchInitialStateFromServer input = %q, want saved draft", initialState.Input)
 	}
 	resolved, err := server.SessionLifecycleClient().ResolveTransition(context.Background(), serverapi.SessionResolveTransitionRequest{
 		ClientRequestID: uuid.NewString(),
@@ -421,8 +428,15 @@ func runInteractiveWorkflowScenario(t *testing.T, server interactiveSessionServe
 	if _, err := server.SessionLifecycleClient().PersistInputDraft(context.Background(), serverapi.SessionPersistInputDraftRequest{ClientRequestID: uuid.NewString(), SessionID: plan.SessionID, Input: "workflow draft"}); err != nil {
 		t.Fatalf("PersistInputDraft: %v", err)
 	}
-	if got := sessionLaunchInitialInputFromServer(context.Background(), server, plan.SessionID, "transition draft"); got != "workflow draft" {
-		t.Fatalf("sessionLaunchInitialInputFromServer = %q, want workflow draft", got)
+	initialState, err := sessionLaunchInitialStateFromServer(context.Background(), server, plan.SessionID, sessionInitialInputDirective{
+		TransitionInput: "transition draft",
+		Precedence:      sessionInitialInputPreferStoredDraft,
+	})
+	if err != nil {
+		t.Fatalf("sessionLaunchInitialStateFromServer: %v", err)
+	}
+	if initialState.Input != "workflow draft" {
+		t.Fatalf("sessionLaunchInitialStateFromServer input = %q, want workflow draft", initialState.Input)
 	}
 }
 

--- a/cli/app/session_server_target_part3_test.go
+++ b/cli/app/session_server_target_part3_test.go
@@ -44,7 +44,7 @@ func TestStartSessionServerUsesConfiguredDaemonForSessionLifecycleDraftPersisten
 	}
 	defer func() { _ = server.Close() }()
 
-	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, io.Discard, "session lifecycle draft persistence")
+	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}}, io.Discard, "session lifecycle draft persistence")
 	defer runtimePlan.Close()
 	if _, err := server.SessionLifecycleClient().PersistInputDraft(context.Background(), serverapi.SessionPersistInputDraftRequest{ClientRequestID: uuid.NewString(), SessionID: plan.SessionID, Input: "saved draft"}); err != nil {
 		t.Fatalf("PersistInputDraft: %v", err)
@@ -104,7 +104,7 @@ func TestStartSessionServerListsPendingPromptSnapshotOverRemoteReads(t *testing.
 	}
 	promptViews := requirePromptViewServer(t, server)
 
-	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, io.Discard, "test remote prompt snapshot reads")
+	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}}, io.Discard, "test remote prompt snapshot reads")
 	defer runtimePlan.Close()
 
 	askDone := make(chan error, 1)
@@ -187,7 +187,7 @@ func TestStartSessionServerUsesConfiguredDaemonForProcessFlows(t *testing.T) {
 	processes := requireProcessServer(t, server)
 
 	planner := newSessionLaunchPlanner(server)
-	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true})
+	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}})
 	if err != nil {
 		t.Fatalf("PlanSession: %v", err)
 	}
@@ -414,7 +414,7 @@ func waitForRemoteInlineOutput(t *testing.T, controls client.ProcessControlClien
 
 func runInteractiveWorkflowScenario(t *testing.T, server interactiveSessionServer, wantReply string) {
 	t.Helper()
-	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, io.Discard, "workflow parity")
+	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}}, io.Discard, "workflow parity")
 	defer runtimePlan.Close()
 
 	submission, err := submitRuntimeClientForTest(t, runtimePlan.Wiring.runtimeClient, "hello parity")

--- a/cli/app/session_server_target_test.go
+++ b/cli/app/session_server_target_test.go
@@ -79,7 +79,7 @@ func TestStartSessionServerUsesConfiguredDaemonForInteractiveFlow(t *testing.T) 
 		t.Fatalf("expected remote app server, got %T", server)
 	}
 
-	_, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, io.Discard, "test remote interactive runtime")
+	_, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}}, io.Discard, "test remote interactive runtime")
 	defer runtimePlan.Close()
 
 	submission, err := submitRuntimeClientForTest(t, runtimePlan.Wiring.runtimeClient, "hello through interactive daemon")
@@ -134,7 +134,7 @@ func TestStartSessionServerConfiguredDaemonNoAuthSkipsLaterPrompt(t *testing.T) 
 	if err != nil {
 		t.Fatalf("first startSessionServer: %v", err)
 	}
-	_, firstRuntimePlan := prepareAppRuntimePlanWithOpenAIBaseURL(t, firstServer, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, fakeResponses.URL, io.Discard, "test remote no-auth runtime")
+	_, firstRuntimePlan := prepareAppRuntimePlanWithOpenAIBaseURL(t, firstServer, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}}, fakeResponses.URL, io.Discard, "test remote no-auth runtime")
 	firstSubmission, err := submitRuntimeClientForTest(t, firstRuntimePlan.Wiring.runtimeClient, "hello after no auth")
 	if err != nil {
 		t.Fatalf("first SubmitUserMessage: %v", err)
@@ -162,7 +162,7 @@ func TestStartSessionServerConfiguredDaemonNoAuthSkipsLaterPrompt(t *testing.T) 
 		t.Fatalf("second startSessionServer: %v", err)
 	}
 	defer func() { _ = secondServer.Close() }()
-	_, secondRuntimePlan := prepareAppRuntimePlanWithOpenAIBaseURL(t, secondServer, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, fakeResponses.URL, io.Discard, "test remote persisted no-auth runtime")
+	_, secondRuntimePlan := prepareAppRuntimePlanWithOpenAIBaseURL(t, secondServer, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}}, fakeResponses.URL, io.Discard, "test remote persisted no-auth runtime")
 	secondSubmission, err := submitRuntimeClientForTest(t, secondRuntimePlan.Wiring.runtimeClient, "hello after persisted no auth")
 	if err != nil {
 		t.Fatalf("second SubmitUserMessage: %v", err)
@@ -288,7 +288,7 @@ func TestConfiguredDaemonPlanSessionUsesSessionWorkspaceLocalConfig(t *testing.T
 	}
 	defer func() { _ = bound.Close() }()
 	planner := newSessionLaunchPlanner(bound)
-	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true})
+	plan, err := planner.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}})
 	if err != nil {
 		t.Fatalf("PlanSession: %v", err)
 	}
@@ -328,7 +328,7 @@ func TestConfiguredDaemonEnvironmentContextUsesSessionWorkspaceRootForCWD(t *tes
 	}
 	defer func() { _ = server.Close() }()
 
-	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, io.Discard, "test daemon environment cwd")
+	plan, runtimePlan := prepareAppRuntimePlan(t, server, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}}, io.Discard, "test daemon environment cwd")
 	defer runtimePlan.Close()
 
 	submission, err := submitRuntimeClientForTest(t, runtimePlan.Wiring.runtimeClient, "hello through interactive daemon")
@@ -654,10 +654,10 @@ func startRemoteMultiClientRuntimeFixture(t *testing.T, openAIBaseURL string) *r
 		t.Fatalf("expected distinct workspace roots across clients, both=%q", fixture.serverA.Config().WorkspaceRoot)
 	}
 
-	fixture.planA, fixture.runtimePlanA = prepareAppRuntimePlan(t, fixture.serverA, sessionLaunchRequest{Mode: launchModeInteractive, ForceNewSession: true}, io.Discard, "test remote multi-client runtime A")
+	fixture.planA, fixture.runtimePlanA = prepareAppRuntimePlan(t, fixture.serverA, sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionCreateDestination{}}, io.Discard, "test remote multi-client runtime A")
 
 	plannerB := newSessionLaunchPlanner(fixture.serverB)
-	fixture.planB, err = plannerB.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, SelectedSessionID: fixture.planA.SessionID})
+	fixture.planB, err = plannerB.PlanSession(context.Background(), sessionLaunchRequest{Mode: launchModeInteractive, Destination: sessionOpenDestinationForTest(t, fixture.planA.SessionID)})
 	if err != nil {
 		t.Fatalf("PlanSession B: %v", err)
 	}

--- a/cli/app/ui_final_answer_operation_test.go
+++ b/cli/app/ui_final_answer_operation_test.go
@@ -78,6 +78,7 @@ func TestCopyFinalAnswerOperationBlocksInputUntilClipboardCompletes(t *testing.T
 func TestFinalAnswerLookupTimeoutAndStaleResultDoNotNavigate(t *testing.T) {
 	m := newProjectedStaticUIModel(WithUISessionID("child-1"))
 	m.statusConfig.SessionViews = &countingSessionViewClient{}
+	m.input = "editable child draft"
 	_ = m.startFinalAnswerOperation(uiFinalAnswerOperationBack, "parent-1")
 	op := *m.finalAnswerOperation
 
@@ -86,11 +87,19 @@ func TestFinalAnswerLookupTimeoutAndStaleResultDoNotNavigate(t *testing.T) {
 	if m.finalAnswerOperation != nil {
 		t.Fatal("timeout must restore input ownership")
 	}
+	if m.input != "editable child draft" {
+		t.Fatalf("timeout child input = %q, want preserved draft", m.input)
+	}
 	answer := "late answer"
 	next, _ = m.Update(latestFinalAnswerDoneMsg{token: op.token, purpose: op.purpose, sessionID: op.sessionID, parentSessionID: op.parentSessionID, answer: &answer})
 	m = next.(*uiModel)
 	if m.exitAction != UIActionNone {
 		t.Fatalf("stale result transitioned with %q", m.exitAction)
+	}
+	next, editCmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = next.(*uiModel)
+	if editCmd != nil || m.input != "editable child draftx" {
+		t.Fatalf("child input after timeout edit = %q cmd=%v, want editable draft", m.input, editCmd)
 	}
 }
 
@@ -144,10 +153,40 @@ func TestBackFinalAnswerOperationAbsenceOpensParentWithEmptyPrefill(t *testing.T
 	}
 }
 
+func TestBackCommandMissingParentPreservesEditableChildWithoutLookupOrTransition(t *testing.T) {
+	m := newProjectedStaticUIModel(WithUISessionID("child-1"))
+	m.input = "editable child draft"
+
+	next, errorCmd := m.inputController().handleBackCommand()
+	m = next.(*uiModel)
+	if errorCmd == nil || m.transientStatus == "" {
+		t.Fatal("missing parent did not surface an operator-visible error")
+	}
+	if m.finalAnswerOperation != nil {
+		t.Fatalf("missing parent started final-answer operation %+v", m.finalAnswerOperation)
+	}
+	if transition := m.Transition(); transition.Action != UIActionNone || transition.Exit {
+		t.Fatalf("missing parent emitted transition %+v", transition)
+	}
+	if m.input != "editable child draft" {
+		t.Fatalf("child input = %q, want preserved draft", m.input)
+	}
+
+	next, editCmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = next.(*uiModel)
+	if editCmd != nil {
+		t.Fatal("normal child edit after missing parent created a command")
+	}
+	if m.input != "editable child draftx" {
+		t.Fatalf("edited child input = %q, want editable draft", m.input)
+	}
+}
+
 func TestFinalAnswerLookupErrorRestoresInputWithoutNavigation(t *testing.T) {
 	lookupErr := errors.New("durable lookup failed")
 	m := newProjectedStaticUIModel(WithUISessionID("child-1"))
 	m.statusConfig.SessionViews = &countingSessionViewClient{}
+	m.input = "editable child draft"
 	_ = m.startFinalAnswerOperation(uiFinalAnswerOperationBack, "parent-1")
 	op := *m.finalAnswerOperation
 
@@ -155,6 +194,14 @@ func TestFinalAnswerLookupErrorRestoresInputWithoutNavigation(t *testing.T) {
 	m = next.(*uiModel)
 	if m.finalAnswerOperation != nil || m.exitAction != UIActionNone || m.transientStatus == "" {
 		t.Fatalf("lookup failure state op=%+v transition=%+v status=%q", m.finalAnswerOperation, m.Transition(), m.transientStatus)
+	}
+	if m.input != "editable child draft" {
+		t.Fatalf("lookup failure child input = %q, want preserved draft", m.input)
+	}
+	next, editCmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = next.(*uiModel)
+	if editCmd != nil || m.input != "editable child draftx" {
+		t.Fatalf("child input after lookup failure edit = %q cmd=%v, want editable draft", m.input, editCmd)
 	}
 }
 

--- a/server/sessionservice/session_lifecycle_service_test.go
+++ b/server/sessionservice/session_lifecycle_service_test.go
@@ -421,6 +421,19 @@ func TestServiceResolveTransitionRejectsPathLikeSessionID(t *testing.T) {
 	}
 }
 
+func TestServiceResolveTransitionOpenSessionRequiresTarget(t *testing.T) {
+	service := newTestSessionLifecycleService(t.TempDir(), nil)
+	response, err := service.ResolveTransition(context.Background(), serverapi.SessionResolveTransitionRequest{
+		ClientRequestID: "open-session-without-target",
+		Transition: serverapi.SessionTransition{
+			Action: serverapi.SessionTransitionActionOpenSession,
+		},
+	})
+	if err == nil {
+		t.Fatalf("open-session transition without target resolved as %+v", response)
+	}
+}
+
 func TestServiceResolveTransitionForkRollbackCreatesFork(t *testing.T) {
 	_, containerDir, store := createPersistedSession(t)
 	if _, _, err := store.AppendEvent("step-1", "message", llm.Message{Role: llm.RoleUser, Content: "u1"}); err != nil {

--- a/server/sessionservice/session_lifecycle_service_test.go
+++ b/server/sessionservice/session_lifecycle_service_test.go
@@ -135,6 +135,68 @@ func TestServiceGetInitialInputPrefersStoredDraft(t *testing.T) {
 	}
 }
 
+func TestServiceGetInitialInputOverrideReturnsOnlyExactTransitionInput(t *testing.T) {
+	tests := []struct {
+		name            string
+		transitionInput string
+	}{
+		{
+			name:            "byte-sensitive input",
+			transitionInput: " \nExact café 👩🏽‍💻\n尾  ",
+		},
+		{
+			name:            "intentional empty input",
+			transitionInput: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, containerDir, store := createPersistedSession(t)
+			if err := store.SetName("parent session"); err != nil {
+				t.Fatalf("persist parent session: %v", err)
+			}
+			service := newTestSessionLifecycleService(containerDir, nil)
+			_, err := service.PersistInputDraft(context.Background(), serverapi.SessionPersistInputDraftRequest{
+				ClientRequestID: "persist-parent-draft",
+				SessionID:       store.Meta().SessionID,
+				Input:           "conflicting parent draft",
+				RecoveryBuffers: []serverapi.SessionDraftRecoveryBuffer{
+					{
+						Kind:            serverapi.SessionDraftRecoveryBufferPendingInjectedInput,
+						ID:              "pending-parent-input",
+						ClientRequestID: "pending-parent-request",
+						Text:            "conflicting pending input",
+					},
+					{
+						Kind: serverapi.SessionDraftRecoveryBufferQueuedInput,
+						ID:   "queued-parent-input",
+						Text: "conflicting queued input",
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("persist parent draft: %v", err)
+			}
+
+			resp, err := service.GetInitialInput(context.Background(), serverapi.SessionInitialInputRequest{
+				SessionID:           store.Meta().SessionID,
+				TransitionInput:     tt.transitionInput,
+				OverrideStoredDraft: true,
+			})
+			if err != nil {
+				t.Fatalf("GetInitialInput: %v", err)
+			}
+			if resp.Input != tt.transitionInput {
+				t.Fatalf("input = %q, want exact transition input %q", resp.Input, tt.transitionInput)
+			}
+			if len(resp.RecoveryBuffers) != 0 {
+				t.Fatalf("recovery buffers = %+v, want none from overridden parent draft", resp.RecoveryBuffers)
+			}
+		})
+	}
+}
+
 func TestServiceGetInitialInputAllowsEmptySessionID(t *testing.T) {
 	service := newTestSessionLifecycleService(t.TempDir(), nil)
 	resp, err := service.GetInitialInput(context.Background(), serverapi.SessionInitialInputRequest{

--- a/server/sessionservice/session_transition.go
+++ b/server/sessionservice/session_transition.go
@@ -112,8 +112,12 @@ func resolveSessionTransition(ctx context.Context, req sessionTransitionResolveR
 	case serverapi.SessionTransitionActionResume:
 		return resolvedSessionTransition{ShouldContinue: true}, nil
 	case serverapi.SessionTransitionActionOpenSession:
+		targetSessionID := strings.TrimSpace(req.Transition.TargetSessionID)
+		if targetSessionID == "" {
+			return resolvedSessionTransition{}, errors.New("open-session target session id is required")
+		}
 		return resolvedSessionTransition{
-			NextSessionID:  strings.TrimSpace(req.Transition.TargetSessionID),
+			NextSessionID:  targetSessionID,
 			InitialInput:   req.Transition.InitialInput,
 			ShouldContinue: true,
 		}, nil


### PR DESCRIPTION
## Summary
- carry `/back` through one typed session handoff so the parent composer receives the child session's newest durable committed non-noop final answer byte-for-byte
- preserve intentional empty input as an explicit parent-draft override while keeping the composer editable, idle, and unsent
- retain typed picker/open/create destinations through launch planning and reject missing or action-mismatched transition destinations
- propagate destination preparation failures with runtime cleanup, preserving durable child recovery
- cover embedded loopback and served remote clients with the same end-to-end scenario

## Verification
- `./scripts/test.sh ./cli/app ./server/runtime ./server/sessionview ./server/sessionservice ./server/core ./server/transport ./shared/client ./shared/apicontract ./shared/serverapi -count=1`
- `./scripts/test.sh ./cli/app ./server/sessionview ./server/sessionservice ./shared/client ./shared/serverapi -count=1` after rebasing onto `origin/main`
- `./scripts/build.sh --output ./bin/kent`
