### PR TITLE
api!: remove board workflow absence sentinels

### DIFF
--- a/apps/desktop/src/api/client.test.ts
+++ b/apps/desktop/src/api/client.test.ts
@@ -68,19 +68,28 @@ describe("ApiClient", () => {
     await expect(client.getReadiness()).rejects.toBeInstanceOf(ContractError);
   });
 
-  it("normalizes empty workflow board metadata and node-card slices returned as null by Go JSON", async () => {
+  it("preserves optional board workflow selectors and normalizes empty slices", async () => {
     const transport = new FakeRpcTransport([
+      { method: "workflow.board.get", result: emptyBoardResponse },
       { method: "workflow.board.get", result: emptyBoardResponse },
       { method: "workflow.board.nodeCards.list", result: emptyBoardNodeCardsResponse },
     ]);
     const client = new ApiClient(transport);
 
-    await expect(client.getBoard("project-1", "")).resolves.toMatchObject({
+    await expect(client.getBoard("project-1", undefined)).resolves.toMatchObject({
       projectID: "project-1",
+      selectedWorkflow: null,
       workflows: [],
       groups: [],
       columns: [],
     });
+    await expect(client.getBoard("project-1", " ")).resolves.toMatchObject({
+      selectedWorkflow: null,
+    });
+    expect(transport.calls.slice(0, 2)).toEqual([
+      { method: "workflow.board.get", params: { project_id: "project-1" } },
+      { method: "workflow.board.get", params: { project_id: "project-1", workflow_id: " " } },
+    ]);
     await expect(client.listBoardNodeCards("project-1", "workflow-1", "node-1")).resolves.toMatchObject({
       projectID: "project-1",
       workflowID: "workflow-1",
@@ -679,16 +688,6 @@ describe("ApiClient", () => {
   });
 });
 
-const emptyWorkflow = {
-  workflow_id: "",
-  display_name: "",
-  description: "",
-  version: 0,
-  is_project_default: false,
-  valid_for_task_creation: false,
-  validation_errors: null,
-};
-
 const emptyBoardResponse = {
   board: {
     project_id: "project-1",
@@ -698,7 +697,6 @@ const emptyBoardResponse = {
       default_workspace_id: "workspace-1",
       attached_workspace_count: 1,
     },
-    selected_workflow: emptyWorkflow,
     workflows: null,
     groups: null,
     columns: null,
@@ -709,6 +707,15 @@ const emptyBoardResponse = {
 const boardWithJoinResponse = {
   board: {
     ...emptyBoardResponse.board,
+    selected_workflow: {
+      workflow_id: "workflow-1",
+      display_name: "Workflow",
+      description: "",
+      version: 1,
+      is_project_default: true,
+      valid_for_task_creation: true,
+      validation_errors: [],
+    },
     groups: [
       {
         group_id: "group-1",

--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -230,7 +230,7 @@ export class ApiClient {
     );
   }
 
-  async getBoard(projectID: string, workflowID: string): Promise<WorkflowBoard> {
+  async getBoard(projectID: string, workflowID: string | undefined): Promise<WorkflowBoard> {
     return parse(
       "workflow.board.get",
       workflowBoardSchema,
@@ -238,7 +238,7 @@ export class ApiClient {
         "workflow.board.get",
         compactJsonObject({
           project_id: projectID,
-          workflow_id: workflowID.length > 0 ? workflowID : undefined,
+          workflow_id: workflowID,
         }),
       ),
     );

--- a/apps/desktop/src/api/index.ts
+++ b/apps/desktop/src/api/index.ts
@@ -16,7 +16,7 @@ export type {
   AttentionNotificationTaskDetailFocus,
   AttentionNotificationWorkflowTaskTarget,
 } from "./attentionNotifications";
-export { defaultWorkflowExecutionTargetPolicy, emptyWorkflowDerivedWiring } from "./models";
+export { defaultWorkflowExecutionTargetPolicy, emptyWorkflowDerivedWiring, hasSelectedWorkflow } from "./models";
 export { createJsonRpcTransport } from "./jsonRpc";
 export type {
   ActivityItem,
@@ -36,6 +36,7 @@ export type {
   ProjectMutationResponse,
   ProjectWorkflowLink,
   ProjectSummary,
+  SelectedWorkflowBoard,
   ServerReadiness,
   TaskComment,
   TaskDetail,

--- a/apps/desktop/src/api/models.ts
+++ b/apps/desktop/src/api/models.ts
@@ -555,12 +555,19 @@ export type WorkflowBoard = Readonly<{
   projectName: string;
   defaultWorkspaceID: string;
   attachedWorkspaceCount: number;
-  selectedWorkflow: WorkflowPickerItem;
+  selectedWorkflow: WorkflowPickerItem | null;
   workflows: readonly WorkflowPickerItem[];
   groups: readonly BoardGroup[];
   columns: readonly BoardColumn[];
   generatedAt: number;
 }>;
+
+export type SelectedWorkflowBoard = Omit<WorkflowBoard, "selectedWorkflow"> &
+  Readonly<{ selectedWorkflow: WorkflowPickerItem }>;
+
+export function hasSelectedWorkflow(board: WorkflowBoard): board is SelectedWorkflowBoard {
+  return board.selectedWorkflow !== null;
+}
 
 export type BoardNodeCardsPage = Readonly<{
   projectID: string;

--- a/apps/desktop/src/api/schemas/common.ts
+++ b/apps/desktop/src/api/schemas/common.ts
@@ -172,7 +172,7 @@ export const workflowParameterSchema: z.ZodType<WorkflowParameter> = z
 
 export const workflowPickerItemSchema: z.ZodType<WorkflowPickerItem> = z
   .object({
-    workflow_id: z.string(),
+    workflow_id: z.string().min(1).refine((value) => value.trim() === value),
     display_name: z.string(),
     description: emptyString,
     version: z.number(),

--- a/apps/desktop/src/api/schemas/workflowBoard.test.ts
+++ b/apps/desktop/src/api/schemas/workflowBoard.test.ts
@@ -86,6 +86,37 @@ describe("workflow board schemas", () => {
     ).toThrow();
   });
 
+  it("decodes omitted and null board workflow selection as absence", () => {
+    const omittedSelection = structuredClone(boardResponse);
+    Reflect.deleteProperty(omittedSelection.board, "selected_workflow");
+    expect(workflowBoardSchema.parse(omittedSelection)).toMatchObject({
+      selectedWorkflow: null,
+    });
+
+    expect(
+      workflowBoardSchema.parse({
+        board: {
+          ...boardResponse.board,
+          selected_workflow: null,
+        },
+      }),
+    ).toMatchObject({ selectedWorkflow: null });
+  });
+
+  it("rejects a present board workflow selection with a blank ID", () => {
+    expect(() =>
+      workflowBoardSchema.parse({
+        board: {
+          ...boardResponse.board,
+          selected_workflow: {
+            ...selectedWorkflow,
+            workflow_id: " ",
+          },
+        },
+      }),
+    ).toThrow();
+  });
+
   it("rejects missing or invalid parent workspace facts", () => {
     const projectWithoutDefaultWorkspaceID = {
       project_key: boardResponse.board.project.project_key,

--- a/apps/desktop/src/api/schemas/workflowBoard.ts
+++ b/apps/desktop/src/api/schemas/workflowBoard.ts
@@ -230,7 +230,9 @@ export const workflowBoardSchema: z.ZodType<WorkflowBoard> = z
             attached_workspace_count: z.number().int().positive(),
           })
           .strict(),
-        selected_workflow: workflowPickerItemSchema,
+        selected_workflow: workflowPickerItemSchema
+          .nullish()
+          .transform((value) => value ?? null),
         workflows: workflowPickerSchema,
         groups: boardGroupsSchema,
         columns: boardColumnsSchema,

--- a/apps/desktop/src/app/RouteTransitionFrame.tsx
+++ b/apps/desktop/src/app/RouteTransitionFrame.tsx
@@ -22,8 +22,8 @@ export function RouteTransitionFrame() {
 
 function routeTransitionKey(pathname: string, searchStr: string): string {
   if (pathname.startsWith("/projects/")) {
-    const workflowID = new URLSearchParams(searchStr).get("workflowId") ?? "";
-    return `${pathname}?workflowId=${workflowID}`;
+    const workflowID = new URLSearchParams(searchStr).get("workflowId");
+    return workflowID === null ? `${pathname}?` : `${pathname}?workflowId=${workflowID}`;
   }
   return `${pathname}?${searchStr}`;
 }

--- a/apps/desktop/src/app/navigation.test.ts
+++ b/apps/desktop/src/app/navigation.test.ts
@@ -153,6 +153,10 @@ describe("navigation stack state", () => {
     });
     expectRoute(router, "/projects/project-1", { taskId: "", workflowId: "workflow-1" });
     await act(async () => {
+      await navigation.openProject("project-unscoped");
+    });
+    expectRoute(router, "/projects/project-unscoped", { taskId: "" });
+    await act(async () => {
       await navigation.openProjectTask("project-1", "workflow-1", "task-1");
     });
     expectRoute(router, "/projects/project-1", {
@@ -168,7 +172,7 @@ describe("navigation stack state", () => {
     });
     expectRoute(router, "/", {});
 
-    expect(startViewTransition).toHaveBeenCalledTimes(5);
+    expect(startViewTransition).toHaveBeenCalledTimes(6);
   });
 });
 

--- a/apps/desktop/src/app/navigation.test.ts
+++ b/apps/desktop/src/app/navigation.test.ts
@@ -168,6 +168,10 @@ describe("navigation stack state", () => {
     });
     expectRoute(router, "/projects/project-1", { taskId: "", workflowId: "workflow-1" });
     await act(async () => {
+      await navigation.closeProjectTask("project-unscoped");
+    });
+    expectRoute(router, "/projects/project-unscoped", { taskId: "" });
+    await act(async () => {
       await navigation.openHome();
     });
     expectRoute(router, "/", {});

--- a/apps/desktop/src/app/navigation.ts
+++ b/apps/desktop/src/app/navigation.ts
@@ -16,7 +16,7 @@ export type AppNavigation = Readonly<{
   openWorkflowLibrary(): Promise<void>;
   openTask(taskID: string): Promise<void>;
   openProjectTask(projectID: string, workflowID: string, taskID: string): Promise<void>;
-  closeProjectTask(projectID: string, workflowID: string): Promise<void>;
+  closeProjectTask(projectID: string, workflowID?: string): Promise<void>;
 }>;
 
 export type NavigationStackState = Readonly<{

--- a/apps/desktop/src/app/navigation.ts
+++ b/apps/desktop/src/app/navigation.ts
@@ -66,7 +66,7 @@ export function useAppNavigation(): AppNavigation {
           await navigate({ to: "/" });
         });
       },
-      async openProject(projectID, workflowID = "") {
+      async openProject(projectID, workflowID) {
         await runNavigation(async () => {
           await navigate({
             to: "/projects/$projectId",

--- a/apps/desktop/src/app/projectRoutePersistence.test.ts
+++ b/apps/desktop/src/app/projectRoutePersistence.test.ts
@@ -1,0 +1,18 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { installTestStorage } from "../testSupport/storage";
+import { readLastProjectRoute, writeLastProjectRoute } from "./projectRoutePersistence";
+
+describe("project route persistence", () => {
+  beforeEach(() => {
+    installTestStorage("localStorage");
+  });
+
+  it("preserves omitted and explicitly empty workflow selectors", () => {
+    writeLastProjectRoute({ projectId: "project-unscoped" });
+    expect(readLastProjectRoute()).toEqual({ projectId: "project-unscoped" });
+
+    writeLastProjectRoute({ projectId: "project-empty", workflowId: "" });
+    expect(readLastProjectRoute()).toEqual({ projectId: "project-empty", workflowId: "" });
+  });
+});

--- a/apps/desktop/src/app/projectRoutePersistence.ts
+++ b/apps/desktop/src/app/projectRoutePersistence.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 const lastProjectRouteStorageKey = "desktop.lastProjectRoute";
 const storedProjectRouteSchema = z.object({
   projectId: z.string(),
-  workflowId: z.string(),
+  workflowId: z.string().optional(),
 });
 type StoredProjectRoute = z.output<typeof storedProjectRouteSchema>;
 

--- a/apps/desktop/src/app/queryKeys.ts
+++ b/apps/desktop/src/app/queryKeys.ts
@@ -18,7 +18,7 @@ export const queryKeys = {
   allActivity: ["activity"],
   allComments: ["comments"],
   allPendingAsks: ["pending-asks"],
-  board: (projectID: string, workflowID: string) => ["board", projectID, workflowID],
+  board: (projectID: string, workflowID: string | undefined) => ["board", projectID, workflowID],
   workflows: (query: string) => ["workflow", query],
   workflowDefinition: (workflowID: string) => ["workflow-definition", workflowID],
   workflowDraftValidation: (

--- a/apps/desktop/src/app/routeComponents.tsx
+++ b/apps/desktop/src/app/routeComponents.tsx
@@ -60,7 +60,7 @@ function RoutePersistence() {
   const isHomeRoute = useMatch({ from: "/", shouldThrow: false }) !== undefined;
   const projectMatch = useMatch({ from: "/projects/$projectId", shouldThrow: false });
   const projectId = projectMatch?.params.projectId ?? null;
-  const workflowId = projectMatch?.search.workflowId ?? "";
+  const workflowId = projectMatch?.search.workflowId;
 
   useEffect(() => {
     if (claimRouteRestoreCheck()) {
@@ -117,7 +117,7 @@ export function ProjectRoute() {
     <BoardRoute
       projectId={params.projectId}
       selectedTaskId={search.taskId}
-      workflowId={search.workflowId.length === 0 ? undefined : search.workflowId}
+      workflowId={search.workflowId}
     />
   );
 }

--- a/apps/desktop/src/app/routeComponents.tsx
+++ b/apps/desktop/src/app/routeComponents.tsx
@@ -117,7 +117,7 @@ export function ProjectRoute() {
     <BoardRoute
       projectId={params.projectId}
       selectedTaskId={search.taskId}
-      workflowId={search.workflowId}
+      workflowId={search.workflowId.length === 0 ? undefined : search.workflowId}
     />
   );
 }

--- a/apps/desktop/src/app/routes.tsx
+++ b/apps/desktop/src/app/routes.tsx
@@ -17,9 +17,10 @@ import {
 import { createWorkflowDeleteWindowRoute } from "./workflowDeleteRoute";
 
 const optionalSearchString = z.string().catch("");
+const optionalWorkflowSelector = z.string().optional().catch(undefined);
 
 const projectSearchSchema = z.object({
-  workflowId: optionalSearchString,
+  workflowId: optionalWorkflowSelector,
   taskId: optionalSearchString,
 });
 

--- a/apps/desktop/src/app/sidebarContext.ts
+++ b/apps/desktop/src/app/sidebarContext.ts
@@ -51,7 +51,7 @@ export type SidebarDestination =
   | Readonly<{
       kind: "newTask";
       mode?: SidebarMode;
-      boardQueryWorkflowID: string;
+      boardQueryWorkflowID: string | undefined;
       projectID: string;
       workflowID: string;
     }>

--- a/apps/desktop/src/dev-showcase/mockData.ts
+++ b/apps/desktop/src/dev-showcase/mockData.ts
@@ -4,7 +4,7 @@ import type {
   BoardGroup,
   TaskActions,
   TaskStatus,
-  WorkflowBoard,
+  SelectedWorkflowBoard,
   WorkflowPickerItem,
   WorkspaceSummary,
   WorkspaceUnlinkBlocker,
@@ -346,7 +346,7 @@ export const mockBoardNodeCards: Readonly<Record<string, readonly BoardCard[]>> 
   "node-done": mockCards.filter((card) => card.activeNodeIDs.includes("node-done")),
 };
 
-export const mockBoard: WorkflowBoard = {
+export const mockBoard: SelectedWorkflowBoard = {
   columns: mockColumns,
   generatedAt: now,
   groups: mockGroups,

--- a/apps/desktop/src/features/board/BoardCardMotionModel.ts
+++ b/apps/desktop/src/features/board/BoardCardMotionModel.ts
@@ -1,4 +1,4 @@
-import type { BoardColumn, WorkflowBoard } from "../../api";
+import type { BoardColumn, SelectedWorkflowBoard } from "../../api";
 import type { KanbanCardVM } from "./BoardColumnViewModel";
 import type { BoardSection } from "./BoardModel";
 
@@ -113,7 +113,7 @@ export function boardCardColumnIDsWithCards(snapshot: BoardCardColumnsSnapshot):
 }
 
 export function boardRailLayoutSignature(
-  board: WorkflowBoard,
+  board: SelectedWorkflowBoard,
   sections: readonly BoardSection[],
   firstActiveID: string | undefined,
 ): string {

--- a/apps/desktop/src/features/board/BoardColumnDataOwner.tsx
+++ b/apps/desktop/src/features/board/BoardColumnDataOwner.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { BoardColumn, WorkflowBoard } from "../../api";
+import type { BoardColumn, SelectedWorkflowBoard } from "../../api";
 import { errorMessage } from "../../api/errors";
 import type { VirtualizedInfiniteListBoundaryState } from "../../ui";
 import { cardBelongsToColumn } from "./BoardCardMotionModel";
@@ -49,7 +49,7 @@ export function BoardColumnDataOwner({
   onInterruptedRunObserved,
   onReportColumnSnapshot,
 }: Readonly<{
-  board: WorkflowBoard;
+  board: SelectedWorkflowBoard;
   column: BoardColumn;
   onCardsLoadError: (error: unknown) => void;
   onDataViewChange: (view: BoardColumnDataView) => void;

--- a/apps/desktop/src/features/board/BoardColumnMotionBoundary.tsx
+++ b/apps/desktop/src/features/board/BoardColumnMotionBoundary.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { BoardColumn, WorkflowBoard } from "../../api";
+import type { BoardColumn, SelectedWorkflowBoard } from "../../api";
 import { useStableCallback, type VirtualizedInfiniteListBoundaryState } from "../../ui";
 import {
   BoardColumnDataOwner,
@@ -27,7 +27,7 @@ import { useColumnVisibility } from "./useColumnVisibility";
 export type BoardColumnMotionBoundaryProps = Readonly<{
   activeDrag: ActiveBoardCardDrag | null;
   actionsDisabled: boolean;
-  board: WorkflowBoard;
+  board: SelectedWorkflowBoard;
   displayedCards: readonly KanbanCardVM[] | undefined;
   column: BoardColumn;
   dropState: BoardColumnDropState;

--- a/apps/desktop/src/features/board/BoardHoverMenu.tsx
+++ b/apps/desktop/src/features/board/BoardHoverMenu.tsx
@@ -2,14 +2,14 @@ import { Pencil, Plus } from "lucide-react";
 import { useEffect, useRef, useState, type FocusEvent, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { WorkflowBoard, WorkflowPickerItem } from "../../api";
+import type { SelectedWorkflowBoard, WorkflowPickerItem } from "../../api";
 import { Item, ItemContent, ItemGroup, ItemTitle } from "../../ui";
 import { cx } from "../../ui/classes";
 
 const collapseDelayMs = 500;
 
 export type BoardHoverMenuProps = Readonly<{
-    board: WorkflowBoard;
+    board: SelectedWorkflowBoard;
     canCreateTask: boolean;
     onNewTask: () => void;
     onWorkflowEdit: (workflowID: string) => void;

--- a/apps/desktop/src/features/board/BoardRailMotionController.test.tsx
+++ b/apps/desktop/src/features/board/BoardRailMotionController.test.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useSyncExternalStore } from "react";
 import { I18nextProvider } from "react-i18next";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { BoardCard, BoardColumn, WorkflowBoard, WorkflowPickerItem } from "../../api";
+import type { BoardCard, BoardColumn, SelectedWorkflowBoard, WorkflowPickerItem } from "../../api";
 import { appI18n, initializeI18n } from "../../i18n/setup";
 import { TestDataTransfer } from "../../test-support/board/TestDataTransfer";
 import type { PendingBoardCardMove } from "./BoardCardMotionModel";
@@ -125,7 +125,7 @@ function column(over: Partial<BoardColumn>): BoardColumn {
   };
 }
 
-function board(backlogCount: number, reconCount: number): WorkflowBoard {
+function board(backlogCount: number, reconCount: number): SelectedWorkflowBoard {
   return {
     projectID: "p1",
     projectKey: "P",
@@ -211,7 +211,7 @@ type ActiveDragState = Readonly<{
 
 type HarnessState = Readonly<{
   activeDrag: ActiveDragState | null;
-  board: WorkflowBoard;
+  board: SelectedWorkflowBoard;
   collapsedColumnIDs: ReadonlySet<string>;
   pending: PendingBoardCardMove | null;
 }>;

--- a/apps/desktop/src/features/board/BoardRailMotionController.tsx
+++ b/apps/desktop/src/features/board/BoardRailMotionController.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import { flushSync } from "react-dom";
 
-import type { BoardColumn, WorkflowBoard } from "../../api";
+import type { BoardColumn, SelectedWorkflowBoard } from "../../api";
 import { chromeContentPaddingClassName } from "../../ui/chromePadding";
 import { type BoardColumnQueryDataSnapshot, type BoardColumnQuerySnapshot } from "./BoardColumnDataOwner";
 import { BoardColumnMotionBoundary } from "./BoardColumnMotionBoundary";
@@ -56,7 +56,7 @@ type DisplayedSnapshot = Readonly<{
 export type BoardRailMotionControllerProps = Readonly<{
   activeDrag: ActiveBoardCardDrag | null;
   actionsDisabled: boolean;
-  board: WorkflowBoard;
+  board: SelectedWorkflowBoard;
   columnDropState: (column: BoardColumn) => BoardColumnDropState;
   columnIsCollapsed: (column: BoardColumn) => boolean;
   firstActiveID: string | undefined;

--- a/apps/desktop/src/features/board/BoardRoute.test.tsx
+++ b/apps/desktop/src/features/board/BoardRoute.test.tsx
@@ -90,9 +90,6 @@ const boardWithoutWorkflowResponse = {
     workflows: [],
     groups: [],
     columns: [],
-    cards: [],
-    done_preview: [],
-    next_page_token: "",
     generated_at_unix_ms: 1,
   },
 };

--- a/apps/desktop/src/features/board/BoardRoute.test.tsx
+++ b/apps/desktop/src/features/board/BoardRoute.test.tsx
@@ -73,6 +73,51 @@ describe("BoardRoute live refresh", () => {
     ).toEqual([]);
   });
 
+  it("closes a deleted task route while workflow selection is still loading", async () => {
+    window.history.pushState(
+      null,
+      "",
+      "/projects/project-1?workflowId=workflow-1&taskId=task-1",
+    );
+    const pendingBoard = new Promise<unknown>(() => {
+      // Keep selection pending until the project event exercises route cleanup.
+    });
+    const services = createTestServices([
+      ...startupRoutes,
+      {
+        method: "workflow.board.get",
+        result: pendingBoard,
+      },
+    ]);
+
+    render(<App services={services} />);
+
+    await waitFor(() => {
+      expect(services.transport.subscriptions).toContainEqual({
+        method: "workflow.subscribeProject",
+        params: { project_id: "project-1" },
+      });
+    });
+
+    act(() => {
+      services.transport.emit("workflow.event", {
+        event: {
+          action: "deleted",
+          changed_ids: ["task-1"],
+          project_id: "project-1",
+          resource: "task",
+          workflow_id: "workflow-1",
+        },
+      });
+    });
+
+    await waitFor(() => {
+      const search = new URLSearchParams(window.location.search);
+      expect(search.get("workflowId")).toBe("workflow-1");
+      expect(search.get("taskId")).not.toBe("task-1");
+    });
+  });
+
   it("mounts board content only when the server selects a workflow", async () => {
     window.history.pushState(null, "", "/projects/project-1");
     const services = createTestServices([

--- a/apps/desktop/src/features/board/BoardRoute.test.tsx
+++ b/apps/desktop/src/features/board/BoardRoute.test.tsx
@@ -7,6 +7,26 @@ import { createTestServices, startupRoutes } from "../../testSupport/appServices
 void initializeI18n();
 
 describe("BoardRoute live refresh", () => {
+  it("preserves an explicitly empty route selector at the transport boundary", async () => {
+    window.history.pushState(null, "", "/projects/project-1?workflowId=");
+    const services = createTestServices([
+      ...startupRoutes,
+      {
+        method: "workflow.board.get",
+        result: boardWithoutWorkflowResponse,
+      },
+    ]);
+
+    render(<App services={services} />);
+
+    await waitFor(() => {
+      expect(boardCalls(services)).toContainEqual({
+        method: "workflow.board.get",
+        params: { project_id: "project-1", workflow_id: "" },
+      });
+    });
+  });
+
   it("refreshes a board without a selected workflow after a workflow-link event", async () => {
     window.history.pushState(null, "", "/projects/project-1");
     const services = createTestServices([

--- a/apps/desktop/src/features/board/BoardRoute.test.tsx
+++ b/apps/desktop/src/features/board/BoardRoute.test.tsx
@@ -1,0 +1,122 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+
+import { App } from "../../App";
+import { appI18n, initializeI18n } from "../../i18n/setup";
+import { createTestServices, startupRoutes } from "../../testSupport/appServices";
+
+void initializeI18n();
+
+describe("BoardRoute live refresh", () => {
+  it("refreshes a board without a selected workflow after a workflow-link event", async () => {
+    window.history.pushState(null, "", "/projects/project-1");
+    const services = createTestServices([
+      ...startupRoutes,
+      {
+        method: "workflow.board.get",
+        result: boardWithoutWorkflowResponse,
+      },
+    ]);
+
+    render(<App services={services} />);
+
+    await waitFor(() => {
+      expect(boardCalls(services).length).toBe(1);
+      expect(services.transport.subscriptions).toContainEqual({
+        method: "workflow.subscribeProject",
+        params: { project_id: "project-1" },
+      });
+    });
+    expect(
+      await screen.findByRole("button", { name: appI18n.t("workflowLibrary.linkWorkflow") }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: appI18n.t("workflowLibrary.createWorkflow") }),
+    ).toBeEnabled();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: appI18n.t("board.newTask") }),
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      services.transport.emit("workflow.event", {
+        event: {
+          action: "linked",
+          changed_ids: ["workflow-link-1"],
+          resource: "workflow_link",
+          workflow_id: "workflow-1",
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(boardCalls(services).length).toBe(2);
+    });
+    expect(
+      services.transport.calls.filter((call) => call.method === "workflow.board.nodeCards.list"),
+    ).toEqual([]);
+  });
+
+  it("mounts board content only when the server selects a workflow", async () => {
+    window.history.pushState(null, "", "/projects/project-1");
+    const services = createTestServices([
+      ...startupRoutes,
+      {
+        method: "workflow.board.get",
+        result: boardWithWorkflowResponse,
+      },
+    ]);
+
+    render(<App services={services} />);
+
+    expect(await screen.findByRole("list")).toBeInTheDocument();
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: appI18n.t("board.newTask") }),
+    ).toBeEnabled();
+    expect(
+      screen.queryByRole("button", { name: appI18n.t("workflowLibrary.createWorkflow") }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+function boardCalls(services: ReturnType<typeof createTestServices>) {
+  return services.transport.calls.filter((call) => call.method === "workflow.board.get");
+}
+
+const boardWithoutWorkflowResponse = {
+  board: {
+    project_id: "project-1",
+    project: {
+      project_key: "PRO",
+      display_name: "Project",
+      default_workspace_id: "workspace-1",
+      attached_workspace_count: 1,
+    },
+    workflows: [],
+    groups: [],
+    columns: [],
+    cards: [],
+    done_preview: [],
+    next_page_token: "",
+    generated_at_unix_ms: 1,
+  },
+};
+
+const selectedWorkflow = {
+  workflow_id: "workflow-1",
+  display_name: "Workflow",
+  description: "",
+  version: 1,
+  is_project_default: true,
+  valid_for_task_creation: true,
+  validation_errors: [],
+};
+
+const boardWithWorkflowResponse = {
+  board: {
+    ...boardWithoutWorkflowResponse.board,
+    selected_workflow: selectedWorkflow,
+    workflows: [selectedWorkflow],
+  },
+};

--- a/apps/desktop/src/features/board/BoardRoute.test.tsx
+++ b/apps/desktop/src/features/board/BoardRoute.test.tsx
@@ -29,14 +29,10 @@ describe("BoardRoute live refresh", () => {
     expect(
       await screen.findByRole("button", { name: appI18n.t("workflowLibrary.linkWorkflow") }),
     ).toBeEnabled();
-    expect(
-      screen.getByRole("button", { name: appI18n.t("workflowLibrary.createWorkflow") }),
-    ).toBeEnabled();
+    expect(screen.getByRole("button", { name: appI18n.t("workflowLibrary.createWorkflow") })).toBeEnabled();
     expect(screen.queryByRole("list")).not.toBeInTheDocument();
     expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: appI18n.t("board.newTask") }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: appI18n.t("board.newTask") })).not.toBeInTheDocument();
 
     act(() => {
       services.transport.emit("workflow.event", {
@@ -71,9 +67,7 @@ describe("BoardRoute live refresh", () => {
 
     expect(await screen.findByRole("list")).toBeInTheDocument();
     expect(screen.getByRole("navigation")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: appI18n.t("board.newTask") }),
-    ).toBeEnabled();
+    expect(screen.getByRole("button", { name: appI18n.t("board.newTask") })).toBeEnabled();
     expect(
       screen.queryByRole("button", { name: appI18n.t("workflowLibrary.createWorkflow") }),
     ).not.toBeInTheDocument();

--- a/apps/desktop/src/features/board/BoardRoute.tsx
+++ b/apps/desktop/src/features/board/BoardRoute.tsx
@@ -2,7 +2,7 @@ import type { DragEvent, SyntheticEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { BoardColumn, WorkflowBoard } from "../../api";
+import { hasSelectedWorkflow, type BoardColumn, type SelectedWorkflowBoard } from "../../api";
 import { errorMessage } from "../../api/errors";
 import { useAppNavigation } from "../../app/navigation";
 import { useConnectionSnapshot } from "../../app/useConnectionSnapshot";
@@ -49,7 +49,7 @@ import { useBoard, useBoardTaskActions, useProjectBoardSubscription } from "./us
 
 export type BoardRouteProps = Readonly<{
   projectId: string;
-  workflowId: string;
+  workflowId: string | undefined;
   selectedTaskId: string;
 }>;
 
@@ -86,6 +86,7 @@ export function BoardRoute({ projectId, workflowId, selectedTaskId }: BoardRoute
   );
   const boardQuery = useBoard(projectId, workflowId);
   const board = boardQuery.data;
+  const selectedWorkflowID = board?.selectedWorkflow?.id;
   const handleSelectedTaskDeleted = useCallback(() => {
     // The task detail sidebar is opened independently of the route, so closing
     // the route task alone would leave it mounted and refetching the now-deleted
@@ -93,24 +94,25 @@ export function BoardRoute({ projectId, workflowId, selectedTaskId }: BoardRoute
     if (activeDestination?.kind === "taskDetail" && activeDestination.taskID === selectedTaskId) {
       closeSidebar();
     }
-    void navigation
-      .closeProjectTask(projectId, board?.selectedWorkflow.id ?? workflowId)
-      .catch(reportBoardNavigationError);
+    if (selectedWorkflowID !== undefined) {
+      void navigation
+        .closeProjectTask(projectId, selectedWorkflowID)
+        .catch(reportBoardNavigationError);
+    }
   }, [
     activeDestination,
-    board?.selectedWorkflow.id,
     closeSidebar,
     navigation,
     projectId,
     reportBoardNavigationError,
+    selectedWorkflowID,
     selectedTaskId,
-    workflowId,
   ]);
   useProjectBoardSubscription(projectId, workflowId, {
     onBackgroundError: reportBoardLoadError,
     onSelectedTaskDeleted: handleSelectedTaskDeleted,
     selectedTaskID: selectedTaskId,
-    selectedWorkflowID: board?.selectedWorkflow.id ?? workflowId,
+    selectedWorkflowID,
   });
 
   if (boardQuery.isPending) {
@@ -128,7 +130,7 @@ export function BoardRoute({ projectId, workflowId, selectedTaskId }: BoardRoute
       />
     );
   }
-  if (board === undefined || board.workflows.length === 0) {
+  if (board === undefined || !hasSelectedWorkflow(board)) {
     return <BoardNoWorkflowState projectID={projectId} />;
   }
 
@@ -140,8 +142,8 @@ function BoardContent({
   boardQueryWorkflowID,
   selectedTaskId,
 }: Readonly<{
-  board: WorkflowBoard;
-  boardQueryWorkflowID: string;
+  board: SelectedWorkflowBoard;
+  boardQueryWorkflowID: string | undefined;
   selectedTaskId: string;
 }>) {
   const { t } = useTranslation();

--- a/apps/desktop/src/features/board/BoardRoute.tsx
+++ b/apps/desktop/src/features/board/BoardRoute.tsx
@@ -94,19 +94,15 @@ export function BoardRoute({ projectId, workflowId, selectedTaskId }: BoardRoute
     if (activeDestination?.kind === "taskDetail" && activeDestination.taskID === selectedTaskId) {
       closeSidebar();
     }
-    if (selectedWorkflowID !== undefined) {
-      void navigation
-        .closeProjectTask(projectId, selectedWorkflowID)
-        .catch(reportBoardNavigationError);
-    }
+    void navigation.closeProjectTask(projectId, workflowId).catch(reportBoardNavigationError);
   }, [
     activeDestination,
     closeSidebar,
     navigation,
     projectId,
     reportBoardNavigationError,
-    selectedWorkflowID,
     selectedTaskId,
+    workflowId,
   ]);
   useProjectBoardSubscription(projectId, workflowId, {
     onBackgroundError: reportBoardLoadError,

--- a/apps/desktop/src/features/board/useBoardData.test.ts
+++ b/apps/desktop/src/features/board/useBoardData.test.ts
@@ -41,6 +41,22 @@ describe("shouldRefreshBoardFromProjectEvent", () => {
     ).toBe(true);
     expect(shouldRefreshBoardFromProjectEvent({}, "workflow-route", "workflow-active")).toBe(true);
   });
+  it("refreshes workflow links without a selected workflow and skips unrelated task events", () => {
+    expect(
+      shouldRefreshBoardFromProjectEvent(
+        eventParams({ resource: "workflow_link", workflow_id: "workflow-new" }),
+        undefined,
+        undefined,
+      ),
+    ).toBe(true);
+    expect(
+      shouldRefreshBoardFromProjectEvent(
+        eventParams({ resource: "task", workflow_id: "workflow-other" }),
+        undefined,
+        undefined,
+      ),
+    ).toBe(false);
+  });
 
   it("retains three bidirectional pages and releases them when the column owner unmounts", async () => {
     const pages = [

--- a/apps/desktop/src/features/board/useBoardData.ts
+++ b/apps/desktop/src/features/board/useBoardData.ts
@@ -13,7 +13,7 @@ import { useAppServices } from "../../app/useAppServices";
 import { useConnectionSnapshot } from "../../app/useConnectionSnapshot";
 import { workflowProjectEvent, workflowProjectQuestionTaskID } from "../../app/workflowProjectEvents";
 
-export function useBoard(projectID: string, workflowID: string) {
+export function useBoard(projectID: string, workflowID: string | undefined) {
   const { api } = useAppServices();
   return useQuery({
     queryKey: queryKeys.board(projectID, workflowID),
@@ -44,9 +44,9 @@ export function useBoardNodeCards(projectID: string, workflowID: string, nodeID:
 
 export function useProjectBoardSubscription(
   projectID: string,
-  boardQueryWorkflowID: string,
+  boardQueryWorkflowID: string | undefined,
   input: Readonly<{
-    selectedWorkflowID: string;
+    selectedWorkflowID: string | undefined;
     selectedTaskID?: string;
     onBackgroundError?: (error: unknown) => void;
     onSelectedTaskDeleted?: () => void;
@@ -69,12 +69,14 @@ export function useProjectBoardSubscription(
     }
     async function refresh(): Promise<void> {
       await queryClient.invalidateQueries({ queryKey: queryKeys.board(projectID, boardQueryWorkflowID) });
-      if (selectedWorkflowID !== boardQueryWorkflowID) {
+      if (selectedWorkflowID !== undefined && selectedWorkflowID !== boardQueryWorkflowID) {
         await queryClient.invalidateQueries({ queryKey: queryKeys.board(projectID, selectedWorkflowID) });
       }
-      await queryClient.invalidateQueries({
-        queryKey: queryKeys.boardNodeCardsRoot(projectID, selectedWorkflowID),
-      });
+      if (selectedWorkflowID !== undefined) {
+        await queryClient.invalidateQueries({
+          queryKey: queryKeys.boardNodeCardsRoot(projectID, selectedWorkflowID),
+        });
+      }
       await queryClient.invalidateQueries({ queryKey: queryKeys.attention("") });
       await queryClient.invalidateQueries({ queryKey: queryKeys.attention(projectID) });
     }
@@ -138,8 +140,8 @@ function isDeletedTaskEvent(params: unknown, taskID: string): boolean {
 
 export function shouldRefreshBoardFromProjectEvent(
   params: unknown,
-  boardQueryWorkflowID: string,
-  selectedWorkflowID: string,
+  boardQueryWorkflowID: string | undefined,
+  selectedWorkflowID: string | undefined,
 ): boolean {
   const event = workflowProjectEvent(params);
   if (event === null) {
@@ -160,7 +162,7 @@ export function shouldRefreshBoardFromProjectEvent(
 
 export function useBoardTaskActions(
   projectID: string,
-  boardQueryWorkflowID: string,
+  boardQueryWorkflowID: string | undefined,
   selectedWorkflowID: string,
 ) {
   const { api } = useAppServices();

--- a/apps/desktop/src/features/home/HomeRoute.test.tsx
+++ b/apps/desktop/src/features/home/HomeRoute.test.tsx
@@ -5,13 +5,14 @@ import { z } from "zod";
 import type { JsonValue } from "../../api/json";
 import { App } from "../../App";
 import { createTestServices, startupRoutes } from "../../testSupport/appServices";
+import { installTestStorage } from "../../testSupport/storage";
 
 const jsonRecordSchema = z.record(z.string(), z.unknown());
 
 describe("HomeRoute", () => {
   beforeEach(() => {
-    installStorage("localStorage");
-    installStorage("sessionStorage");
+    installTestStorage("localStorage");
+    installTestStorage("sessionStorage");
     window.history.pushState(null, "", "/");
   });
 
@@ -346,27 +347,6 @@ function workspaceSummary(workspaceID: string, rootPath: string, updatedAtUnixMs
     is_primary: true,
     updated_at_unix_ms: updatedAtUnixMs,
   };
-}
-
-function installStorage(name: "localStorage" | "sessionStorage"): void {
-  const values = new Map<string, string>();
-  Object.defineProperty(globalThis, name, {
-    configurable: true,
-    value: {
-      clear() {
-        values.clear();
-      },
-      getItem(key: string) {
-        return values.get(key) ?? null;
-      },
-      removeItem(key: string) {
-        values.delete(key);
-      },
-      setItem(key: string, value: string) {
-        values.set(key, value);
-      },
-    },
-  });
 }
 
 function attentionItem({

--- a/apps/desktop/src/features/home/ProjectRow.tsx
+++ b/apps/desktop/src/features/home/ProjectRow.tsx
@@ -35,7 +35,7 @@ export function ProjectRow({ project }: Readonly<{ project: ProjectSummary }>) {
       }
       ariaLabel={`${project.name} ${workspacePathLabel}`}
       onClick={() => {
-        void navigation.openProject(project.id, project.defaultWorkflowID);
+        void navigation.openProject(project.id);
       }}
       title={project.primaryWorkspace.rootPath}
     >

--- a/apps/desktop/src/features/tasks/NewTaskDialog.tsx
+++ b/apps/desktop/src/features/tasks/NewTaskDialog.tsx
@@ -22,7 +22,7 @@ const newTaskSchema = z.object({
 type NewTaskFormValues = z.output<typeof newTaskSchema>;
 
 export type NewTaskFallbackDialogProps = Readonly<{
-  boardQueryWorkflowID: string;
+  boardQueryWorkflowID: string | undefined;
   projectID: string;
   workflowID: string;
   onClose: () => void;
@@ -91,7 +91,7 @@ export function NewTaskForm({
   projectID,
   workflowID,
 }: Readonly<{
-  boardQueryWorkflowID: string;
+  boardQueryWorkflowID: string | undefined;
   className?: string;
   onSubmitted: () => void;
   projectID: string;

--- a/apps/desktop/src/features/tasks/useTaskMutations.ts
+++ b/apps/desktop/src/features/tasks/useTaskMutations.ts
@@ -13,7 +13,11 @@ export function useWorkspaces(projectID: string) {
   });
 }
 
-export function useCreateTask(projectID: string, boardQueryWorkflowID: string, selectedWorkflowID: string) {
+export function useCreateTask(
+  projectID: string,
+  boardQueryWorkflowID: string | undefined,
+  selectedWorkflowID: string,
+) {
   const { api } = useAppServices();
   const queryClient = useQueryClient();
   return useMutation({

--- a/apps/desktop/src/testSupport/storage.ts
+++ b/apps/desktop/src/testSupport/storage.ts
@@ -1,0 +1,20 @@
+export function installTestStorage(name: "localStorage" | "sessionStorage"): void {
+  const values = new Map<string, string>();
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    value: {
+      clear() {
+        values.clear();
+      },
+      getItem(key: string) {
+        return values.get(key) ?? null;
+      },
+      removeItem(key: string) {
+        values.delete(key);
+      },
+      setItem(key: string, value: string) {
+        values.set(key, value);
+      },
+    },
+  });
+}

--- a/server/workflowsvc/service_test.go
+++ b/server/workflowsvc/service_test.go
@@ -2395,7 +2395,7 @@ func TestServiceWorkflowProjectSubscriptionEmitsLiveEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetWorkflowBoard: %v", err)
 	}
-	if board.Board.SelectedWorkflow.WorkflowID != created.Workflow.ID {
+	if board.Board.SelectedWorkflow == nil || board.Board.SelectedWorkflow.WorkflowID != created.Workflow.ID {
 		t.Fatalf("board selected workflow = %+v, want linked workflow", board.Board.SelectedWorkflow)
 	}
 }
@@ -2422,7 +2422,7 @@ func TestServiceWorkflowProjectSubscriptionEmitsRunCompletionEvent(t *testing.T)
 	if !sameStringSet(event.ChangedIDs, []string{task.Task.ID, string(completed.TransitionID), started.RunID}) {
 		t.Fatalf("changed IDs = %+v", event.ChangedIDs)
 	}
-	boardAfter, err := service.GetWorkflowBoard(ctx, serverapi.WorkflowBoardRequest{ProjectID: binding.ProjectID, WorkflowID: workflowID})
+	boardAfter, err := service.GetWorkflowBoard(ctx, serverapi.WorkflowBoardRequest{ProjectID: binding.ProjectID, WorkflowID: &workflowID})
 	if err != nil {
 		t.Fatalf("GetWorkflowBoard after completion: %v", err)
 	}

--- a/server/workflowview/service.go
+++ b/server/workflowview/service.go
@@ -356,20 +356,17 @@ func (s *Service) workflowSelectionInputs(ctx context.Context, projectID string,
 		return nil, nil, nil, err
 	}
 	workflowIDs := make([]string, 0, len(links))
-	seen := map[string]bool{}
 	linkByWorkflowID := map[string]sqlitegen.ProjectWorkflowLinkRecord{}
 	for _, link := range links {
-		if linkByWorkflowID[link.WorkflowID].ID == "" {
-			linkByWorkflowID[link.WorkflowID] = link
+		if _, exists := linkByWorkflowID[link.WorkflowID]; exists {
+			continue
 		}
-		if !seen[link.WorkflowID] {
-			workflowIDs = append(workflowIDs, link.WorkflowID)
-			seen[link.WorkflowID] = true
-		}
+		linkByWorkflowID[link.WorkflowID] = link
+		workflowIDs = append(workflowIDs, link.WorkflowID)
 	}
 	activityByWorkflowID := map[string]int64{}
 	for _, activity := range taskActivityRows {
-		if seen[activity.WorkflowID] {
+		if _, linked := linkByWorkflowID[activity.WorkflowID]; linked {
 			activityByWorkflowID[activity.WorkflowID] = activity.LatestUpdatedAtUnixMs
 		}
 	}
@@ -383,15 +380,18 @@ func (s *Service) workflowSelectionInputs(ctx context.Context, projectID string,
 		}
 		definitions[workflowID] = def
 		nodeKindsByWorkflowID[workflowID] = nodeKinds
-		link := linkByWorkflowID[workflowID]
+		link, linked := linkByWorkflowID[workflowID]
+		if !linked {
+			return nil, nil, nil, fmt.Errorf("workflow selection invariant violated: active link missing for project_id=%q workflow_id=%q", projectID, workflowID)
+		}
 		validation := definitionExecutionValidation(def, roleResolver)
 		picker = append(picker, serverapi.WorkflowPickerItem{
 			WorkflowID:           workflowID,
 			DisplayName:          def.Workflow.Name,
 			Description:          def.Workflow.Description,
 			Version:              def.Workflow.Version,
-			IsProjectDefault:     link.ID != "" && link.IsDefault != 0,
-			ValidForTaskCreation: !validation.HasBlockingErrors() && link.ID != "",
+			IsProjectDefault:     link.IsDefault != 0,
+			ValidForTaskCreation: !validation.HasBlockingErrors(),
 			ValidationErrors:     ValidationErrors(def.Workflow.ID, validation.Errors),
 		})
 	}

--- a/server/workflowview/service.go
+++ b/server/workflowview/service.go
@@ -134,11 +134,8 @@ func (s *Service) GetBoard(ctx context.Context, req serverapi.WorkflowBoardReque
 		return serverapi.WorkflowBoard{}, err
 	}
 	workspaceContext := boardProjectWorkspaceContext(project)
-	requestedWorkflowID := ""
-	if req.WorkflowID != nil {
-		requestedWorkflowID = *req.WorkflowID
-	}
-	selected := selectWorkflow(picker, requestedWorkflowID, false)
+	selector := workflowBoardSelectorFromRequest(req)
+	selected := selector.selectFrom(picker)
 	if selected == nil {
 		return serverapi.WorkflowBoard{ProjectID: projectID, Project: projectBoardProject(project, workspaceContext), WorkflowPicker: picker, GeneratedAtUnixMs: time.Now().UTC().UnixMilli()}, nil
 	}
@@ -2116,17 +2113,44 @@ func scriptPathDefinitionValidationErrors(def workflow.Definition, rootPath *str
 	return out
 }
 
-func selectWorkflow(picker []serverapi.WorkflowPickerItem, requested string, requireExact bool) *serverapi.WorkflowPickerItem {
-	if requested != "" {
-		for index := range picker {
-			if picker[index].WorkflowID == requested {
-				return &picker[index]
-			}
-		}
-		if requireExact {
-			return nil
+type workflowBoardSelector interface {
+	selectFrom(picker []serverapi.WorkflowPickerItem) *serverapi.WorkflowPickerItem
+}
+
+type workflowBoardDefaultSelector struct{}
+
+func (workflowBoardDefaultSelector) selectFrom(picker []serverapi.WorkflowPickerItem) *serverapi.WorkflowPickerItem {
+	return defaultWorkflowBoardSelection(picker)
+}
+
+type workflowBoardExplicitSelector struct {
+	workflowID string
+}
+
+func (s workflowBoardExplicitSelector) selectFrom(picker []serverapi.WorkflowPickerItem) *serverapi.WorkflowPickerItem {
+	if selected := exactWorkflowBoardSelection(picker, s.workflowID); selected != nil {
+		return selected
+	}
+	return defaultWorkflowBoardSelection(picker)
+}
+
+func workflowBoardSelectorFromRequest(req serverapi.WorkflowBoardRequest) workflowBoardSelector {
+	if req.WorkflowID != nil {
+		return workflowBoardExplicitSelector{workflowID: *req.WorkflowID}
+	}
+	return workflowBoardDefaultSelector{}
+}
+
+func exactWorkflowBoardSelection(picker []serverapi.WorkflowPickerItem, workflowID string) *serverapi.WorkflowPickerItem {
+	for index := range picker {
+		if picker[index].WorkflowID == workflowID {
+			return &picker[index]
 		}
 	}
+	return nil
+}
+
+func defaultWorkflowBoardSelection(picker []serverapi.WorkflowPickerItem) *serverapi.WorkflowPickerItem {
 	for index := range picker {
 		if picker[index].IsProjectDefault {
 			return &picker[index]

--- a/server/workflowview/service.go
+++ b/server/workflowview/service.go
@@ -134,9 +134,12 @@ func (s *Service) GetBoard(ctx context.Context, req serverapi.WorkflowBoardReque
 		return serverapi.WorkflowBoard{}, err
 	}
 	workspaceContext := boardProjectWorkspaceContext(project)
-	requestedWorkflowID := strings.TrimSpace(req.WorkflowID)
-	selected := selectWorkflow(picker, requestedWorkflowID)
-	if selected.WorkflowID == "" {
+	requestedWorkflowID := ""
+	if req.WorkflowID != nil {
+		requestedWorkflowID = *req.WorkflowID
+	}
+	selected := selectWorkflow(picker, requestedWorkflowID, false)
+	if selected == nil {
 		return serverapi.WorkflowBoard{ProjectID: projectID, Project: projectBoardProject(project, workspaceContext), WorkflowPicker: picker, GeneratedAtUnixMs: time.Now().UTC().UnixMilli()}, nil
 	}
 	def := definitions[selected.WorkflowID]
@@ -355,7 +358,7 @@ func (s *Service) workflowSelectionInputs(ctx context.Context, projectID string,
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	workflowIDs := make([]string, 0, len(links)+len(taskActivityRows))
+	workflowIDs := make([]string, 0, len(links))
 	seen := map[string]bool{}
 	linkByWorkflowID := map[string]sqlitegen.ProjectWorkflowLinkRecord{}
 	for _, link := range links {
@@ -369,10 +372,8 @@ func (s *Service) workflowSelectionInputs(ctx context.Context, projectID string,
 	}
 	activityByWorkflowID := map[string]int64{}
 	for _, activity := range taskActivityRows {
-		activityByWorkflowID[activity.WorkflowID] = activity.LatestUpdatedAtUnixMs
-		if !seen[activity.WorkflowID] {
-			workflowIDs = append(workflowIDs, activity.WorkflowID)
-			seen[activity.WorkflowID] = true
+		if seen[activity.WorkflowID] {
+			activityByWorkflowID[activity.WorkflowID] = activity.LatestUpdatedAtUnixMs
 		}
 	}
 	definitions := make(map[string]serverapi.WorkflowDefinition, len(workflowIDs))
@@ -2115,24 +2116,26 @@ func scriptPathDefinitionValidationErrors(def workflow.Definition, rootPath *str
 	return out
 }
 
-func selectWorkflow(picker []serverapi.WorkflowPickerItem, requested string) serverapi.WorkflowPickerItem {
-	trimmed := strings.TrimSpace(requested)
-	if trimmed != "" {
-		for _, item := range picker {
-			if item.WorkflowID == trimmed {
-				return item
+func selectWorkflow(picker []serverapi.WorkflowPickerItem, requested string, requireExact bool) *serverapi.WorkflowPickerItem {
+	if requested != "" {
+		for index := range picker {
+			if picker[index].WorkflowID == requested {
+				return &picker[index]
 			}
 		}
+		if requireExact {
+			return nil
+		}
 	}
-	for _, item := range picker {
-		if item.IsProjectDefault {
-			return item
+	for index := range picker {
+		if picker[index].IsProjectDefault {
+			return &picker[index]
 		}
 	}
 	if len(picker) == 0 {
-		return serverapi.WorkflowPickerItem{}
+		return nil
 	}
-	return picker[0]
+	return &picker[0]
 }
 
 func boardGroups(def serverapi.WorkflowDefinition) []serverapi.WorkflowBoardGroup {

--- a/server/workflowview/service_test.go
+++ b/server/workflowview/service_test.go
@@ -1055,11 +1055,12 @@ func TestBoardSelectsWorkflowAndReturnsPickerAndGroups(t *testing.T) {
 		t.Fatalf("CreateTask selected: %v", err)
 	}
 
-	board, err := view.GetBoard(ctx, serverapi.WorkflowBoardRequest{ProjectID: binding.ProjectID, WorkflowID: string(selected.ID)}, workflow.StaticRoleResolver{"coder": true})
+	selectedWorkflowID := string(selected.ID)
+	board, err := view.GetBoard(ctx, serverapi.WorkflowBoardRequest{ProjectID: binding.ProjectID, WorkflowID: &selectedWorkflowID}, workflow.StaticRoleResolver{"coder": true})
 	if err != nil {
 		t.Fatalf("GetBoard: %v", err)
 	}
-	if board.SelectedWorkflow.WorkflowID != string(selected.ID) {
+	if board.SelectedWorkflow == nil || board.SelectedWorkflow.WorkflowID != string(selected.ID) {
 		t.Fatalf("selected workflow = %+v, want %s", board.SelectedWorkflow, selected.ID)
 	}
 	if len(board.WorkflowPicker) != 2 || !board.WorkflowPicker[0].IsProjectDefault {
@@ -1078,6 +1079,129 @@ func TestBoardSelectsWorkflowAndReturnsPickerAndGroups(t *testing.T) {
 	}
 	if board.Project.ProjectKey != "WOR" || board.GeneratedAtUnixMs == 0 {
 		t.Fatalf("project/generated fields missing: %+v", board)
+	}
+}
+
+func TestBoardOmittedSelectorChoosesActiveDefault(t *testing.T) {
+	ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+	firstWorkflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, firstWorkflowID, false); err != nil {
+		t.Fatalf("LinkWorkflow first: %v", err)
+	}
+	defaultWorkflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, defaultWorkflowID, true); err != nil {
+		t.Fatalf("LinkWorkflow default: %v", err)
+	}
+
+	board, err := view.GetBoard(ctx, serverapi.WorkflowBoardRequest{ProjectID: binding.ProjectID}, workflow.StaticRoleResolver{"coder": true})
+	if err != nil {
+		t.Fatalf("GetBoard: %v", err)
+	}
+	if board.SelectedWorkflow == nil || board.SelectedWorkflow.WorkflowID != string(defaultWorkflowID) {
+		t.Fatalf("selected workflow = %+v, want active default %s", board.SelectedWorkflow, defaultWorkflowID)
+	}
+}
+
+func TestBoardOmittedSelectorChoosesFirstActiveLinkWithoutDefault(t *testing.T) {
+	ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+	workflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, workflowID, false); err != nil {
+		t.Fatalf("LinkWorkflow: %v", err)
+	}
+
+	board, err := view.GetBoard(ctx, serverapi.WorkflowBoardRequest{ProjectID: binding.ProjectID}, workflow.StaticRoleResolver{"coder": true})
+	if err != nil {
+		t.Fatalf("GetBoard: %v", err)
+	}
+	if board.SelectedWorkflow == nil || board.SelectedWorkflow.WorkflowID != string(workflowID) {
+		t.Fatalf("selected workflow = %+v, want first active link %s", board.SelectedWorkflow, workflowID)
+	}
+}
+
+func TestBoardOmittedSelectorKeepsBlockingLinkedWorkflowEligible(t *testing.T) {
+	ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+	workflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, workflowID, true); err != nil {
+		t.Fatalf("LinkWorkflow: %v", err)
+	}
+
+	board, err := view.GetBoard(ctx, serverapi.WorkflowBoardRequest{ProjectID: binding.ProjectID}, workflow.StaticRoleResolver{})
+	if err != nil {
+		t.Fatalf("GetBoard: %v", err)
+	}
+	if board.SelectedWorkflow == nil || board.SelectedWorkflow.WorkflowID != string(workflowID) {
+		t.Fatalf("selected workflow = %+v, want linked workflow %s", board.SelectedWorkflow, workflowID)
+	}
+	if board.SelectedWorkflow.ValidForTaskCreation {
+		t.Fatalf("selected workflow = %+v, want blocking validation without losing link eligibility", board.SelectedWorkflow)
+	}
+}
+
+func TestBoardWithoutActiveLinksReturnsNoSelectionOrContent(t *testing.T) {
+	ctx, _, _, binding, view := newWorkflowViewTestContextService(t)
+
+	board, err := view.GetBoard(ctx, serverapi.WorkflowBoardRequest{ProjectID: binding.ProjectID}, workflow.StaticRoleResolver{"coder": true})
+	if err != nil {
+		t.Fatalf("GetBoard: %v", err)
+	}
+	if board.SelectedWorkflow != nil {
+		t.Fatalf("selected workflow = %+v, want nil", board.SelectedWorkflow)
+	}
+	if len(board.WorkflowPicker) != 0 || len(board.Groups) != 0 || len(board.Columns) != 0 {
+		t.Fatalf("board content = picker:%+v groups:%+v columns:%+v, want empty", board.WorkflowPicker, board.Groups, board.Columns)
+	}
+}
+
+func TestBoardUnknownExplicitSelectorFallsBackToActiveSelection(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+		firstWorkflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+		if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, firstWorkflowID, false); err != nil {
+			t.Fatalf("LinkWorkflow first: %v", err)
+		}
+		defaultWorkflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+		if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, defaultWorkflowID, true); err != nil {
+			t.Fatalf("LinkWorkflow default: %v", err)
+		}
+		unknownWorkflowID := "workflow-unknown"
+
+		board, err := view.GetBoard(ctx, serverapi.WorkflowBoardRequest{ProjectID: binding.ProjectID, WorkflowID: &unknownWorkflowID}, workflow.StaticRoleResolver{"coder": true})
+		if err != nil {
+			t.Fatalf("GetBoard: %v", err)
+		}
+		if board.SelectedWorkflow == nil || board.SelectedWorkflow.WorkflowID != string(defaultWorkflowID) {
+			t.Fatalf("selected workflow = %+v, want active default %s", board.SelectedWorkflow, defaultWorkflowID)
+		}
+	})
+
+	t.Run("first active link", func(t *testing.T) {
+		ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+		workflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+		if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, workflowID, false); err != nil {
+			t.Fatalf("LinkWorkflow: %v", err)
+		}
+		unknownWorkflowID := "workflow-unknown"
+
+		board, err := view.GetBoard(ctx, serverapi.WorkflowBoardRequest{ProjectID: binding.ProjectID, WorkflowID: &unknownWorkflowID}, workflow.StaticRoleResolver{"coder": true})
+		if err != nil {
+			t.Fatalf("GetBoard: %v", err)
+		}
+		if board.SelectedWorkflow == nil || board.SelectedWorkflow.WorkflowID != string(workflowID) {
+			t.Fatalf("selected workflow = %+v, want first active link %s", board.SelectedWorkflow, workflowID)
+		}
+	})
+}
+
+func TestBoardUnknownExplicitSelectorWithoutLinksReturnsNoSelection(t *testing.T) {
+	ctx, _, _, binding, view := newWorkflowViewTestContextService(t)
+	unknownWorkflowID := "workflow-unknown"
+
+	board, err := view.GetBoard(ctx, serverapi.WorkflowBoardRequest{ProjectID: binding.ProjectID, WorkflowID: &unknownWorkflowID}, workflow.StaticRoleResolver{"coder": true})
+	if err != nil {
+		t.Fatalf("GetBoard: %v", err)
+	}
+	if board.SelectedWorkflow != nil || len(board.WorkflowPicker) != 0 {
+		t.Fatalf("selection = %+v picker = %+v, want no active selection", board.SelectedWorkflow, board.WorkflowPicker)
 	}
 }
 

--- a/shared/protocol/version.json
+++ b/shared/protocol/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "52"
+  "version": "53"
 }

--- a/shared/protocol/version_test.go
+++ b/shared/protocol/version_test.go
@@ -26,9 +26,9 @@ func TestProtocolVersionLoadsFromEmbeddedDefinition(t *testing.T) {
 	}
 }
 
-func TestProtocolVersionIncludesMetadataOnlyBoardContract(t *testing.T) {
-	const want = "52"
+func TestProtocolVersionIncludesMetadataOnlyBoardAndNullableWorkflowSelectionContract(t *testing.T) {
+	const want = "53"
 	if Version != want {
-		t.Fatalf("protocol version = %q, want %q for metadata-only board contract", Version, want)
+		t.Fatalf("protocol version = %q, want %q for metadata-only board and nullable workflow selection contract", Version, want)
 	}
 }

--- a/shared/serverapi/workflow.go
+++ b/shared/serverapi/workflow.go
@@ -926,8 +926,8 @@ type WorkflowTaskCommentDeleteRequest struct {
 }
 
 type WorkflowBoardRequest struct {
-	ProjectID  string `json:"project_id"`
-	WorkflowID string `json:"workflow_id,omitempty"`
+	ProjectID  string  `json:"project_id"`
+	WorkflowID *string `json:"workflow_id,omitempty"`
 }
 
 type WorkflowTaskStatusKind string
@@ -1143,7 +1143,7 @@ type WorkflowBoardNodeCardsListResponse struct {
 type WorkflowBoard struct {
 	ProjectID         string                `json:"project_id"`
 	Project           ProjectBoardProject   `json:"project"`
-	SelectedWorkflow  WorkflowPickerItem    `json:"selected_workflow"`
+	SelectedWorkflow  *WorkflowPickerItem   `json:"selected_workflow,omitempty"`
 	WorkflowPicker    []WorkflowPickerItem  `json:"workflows"`
 	Groups            []WorkflowBoardGroup  `json:"groups"`
 	Columns           []WorkflowBoardColumn `json:"columns"`
@@ -2087,7 +2087,10 @@ func (r WorkflowTaskCommentDeleteRequest) Validate() error {
 }
 
 func (r WorkflowBoardRequest) Validate() error {
-	return validateRequired("project_id", r.ProjectID)
+	if err := validateRequired("project_id", r.ProjectID); err != nil {
+		return err
+	}
+	return validateOptionalNonBlank("workflow_id", r.WorkflowID)
 }
 
 func (r WorkflowTaskListRequest) Validate() error {
@@ -2101,14 +2104,8 @@ func (r WorkflowTaskListRequest) Validate() error {
 		{field: "project_id", value: r.ProjectID},
 		{field: "workflow_id", value: r.WorkflowID},
 	} {
-		if scope.value == nil {
-			continue
-		}
-		if strings.TrimSpace(*scope.value) == "" {
-			return workflowRequestError(WorkflowRequestErrorRequired, scope.field, scope.field+" must not be blank")
-		}
-		if strings.TrimSpace(*scope.value) != *scope.value {
-			return workflowRequestError(WorkflowRequestErrorInvalidValue, scope.field, scope.field+" must not have leading or trailing whitespace")
+		if err := validateOptionalNonBlank(scope.field, scope.value); err != nil {
+			return err
 		}
 	}
 	if r.PageSize < 0 {
@@ -2231,6 +2228,19 @@ func (r WorkflowTaskActivityListRequest) Validate() error {
 func validateRequired(name string, value string) error {
 	if strings.TrimSpace(value) == "" {
 		return workflowRequestError(WorkflowRequestErrorRequired, name, name+" is required")
+	}
+	return nil
+}
+
+func validateOptionalNonBlank(name string, value *string) error {
+	if value == nil {
+		return nil
+	}
+	if strings.TrimSpace(*value) == "" {
+		return workflowRequestError(WorkflowRequestErrorRequired, name, name+" must not be blank")
+	}
+	if strings.TrimSpace(*value) != *value {
+		return workflowRequestError(WorkflowRequestErrorInvalidValue, name, name+" must not have leading or trailing whitespace")
 	}
 	return nil
 }

--- a/shared/serverapi/workflow_test.go
+++ b/shared/serverapi/workflow_test.go
@@ -502,6 +502,96 @@ func TestWorkflowBoardNodeCardsRequestCapsPageSizeAt25(t *testing.T) {
 	}
 }
 
+func TestWorkflowBoardRequestOptionalWorkflowSelectionJSONAndValidation(t *testing.T) {
+	omitted := WorkflowBoardRequest{ProjectID: "project-1"}
+	raw, err := json.Marshal(omitted)
+	if err != nil {
+		t.Fatalf("marshal omitted workflow selection: %v", err)
+	}
+	var omittedShape map[string]any
+	if err := json.Unmarshal(raw, &omittedShape); err != nil {
+		t.Fatalf("unmarshal omitted workflow selection: %v", err)
+	}
+	if _, ok := omittedShape["workflow_id"]; ok {
+		t.Fatalf("omitted workflow_id present in request JSON: %s", raw)
+	}
+	if err := omitted.Validate(); err != nil {
+		t.Fatalf("omitted workflow selection rejected: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name  string
+		value string
+		code  string
+	}{
+		{name: "empty", value: "", code: WorkflowRequestErrorRequired},
+		{name: "whitespace only", value: " \t", code: WorkflowRequestErrorRequired},
+		{name: "leading whitespace", value: " workflow-1", code: WorkflowRequestErrorInvalidValue},
+		{name: "trailing whitespace", value: "workflow-1 ", code: WorkflowRequestErrorInvalidValue},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			request := WorkflowBoardRequest{ProjectID: "project-1", WorkflowID: &tt.value}
+			if err := request.Validate(); !isWorkflowFieldError(err, "workflow_id", tt.code) {
+				t.Fatalf("validation error = %#v, want %s on workflow_id", err, tt.code)
+			}
+		})
+	}
+
+	workflowID := "workflow-1"
+	selected := WorkflowBoardRequest{ProjectID: "project-1", WorkflowID: &workflowID}
+	raw, err = json.Marshal(selected)
+	if err != nil {
+		t.Fatalf("marshal selected workflow: %v", err)
+	}
+	var selectedShape map[string]any
+	if err := json.Unmarshal(raw, &selectedShape); err != nil {
+		t.Fatalf("unmarshal selected workflow: %v", err)
+	}
+	if selectedShape["workflow_id"] != workflowID {
+		t.Fatalf("workflow_id = %#v, want %q", selectedShape["workflow_id"], workflowID)
+	}
+	if err := selected.Validate(); err != nil {
+		t.Fatalf("selected workflow rejected: %v", err)
+	}
+}
+
+func TestWorkflowBoardSelectedWorkflowJSONRepresentsAbsence(t *testing.T) {
+	selection := &WorkflowPickerItem{
+		WorkflowID:  "workflow-1",
+		DisplayName: "Main",
+		Version:     3,
+	}
+	selected := WorkflowBoard{ProjectID: "project-1", SelectedWorkflow: selection}
+	raw, err := json.Marshal(selected)
+	if err != nil {
+		t.Fatalf("marshal selected board: %v", err)
+	}
+	var selectedShape map[string]any
+	if err := json.Unmarshal(raw, &selectedShape); err != nil {
+		t.Fatalf("unmarshal selected board: %v", err)
+	}
+	selectedWorkflow, ok := selectedShape["selected_workflow"].(map[string]any)
+	if !ok {
+		t.Fatalf("selected_workflow = %#v, want object", selectedShape["selected_workflow"])
+	}
+	if selectedWorkflow["workflow_id"] != "workflow-1" {
+		t.Fatalf("selected workflow_id = %#v, want workflow-1", selectedWorkflow["workflow_id"])
+	}
+
+	absent := WorkflowBoard{ProjectID: "project-1"}
+	raw, err = json.Marshal(absent)
+	if err != nil {
+		t.Fatalf("marshal board without selection: %v", err)
+	}
+	var absentShape map[string]any
+	if err := json.Unmarshal(raw, &absentShape); err != nil {
+		t.Fatalf("unmarshal board without selection: %v", err)
+	}
+	if _, ok := absentShape["selected_workflow"]; ok {
+		t.Fatalf("selected_workflow present in board without selection: %s", raw)
+	}
+}
+
 func TestAskAnswerRequestValidatesNullableSelectedOption(t *testing.T) {
 	base := AskAnswerRequest{ClientRequestID: "req-1", SessionID: "session-1", AskID: "ask-1"}
 	freeform := base


### PR DESCRIPTION
## Summary

- model omitted board workflow selectors and no selected workflow as typed optional/null values across the Go API and Desktop client
- keep workflow selection server-owned and active-link gated, including default/fallback and no-workflow behavior
- preserve KENT-229 metadata-only boards and nullable bidirectional node-card pagination while removing the remaining active-link map sentinel
- bump the shared protocol once from 52 to 53

## Verification

- `pnpm --dir apps install --frozen-lockfile`
- `pnpm --dir apps lint`
- `pnpm --dir apps typecheck`
- `pnpm --dir apps test` (106 files, 550 tests)
- `./scripts/test.sh server`
- `./scripts/test.sh ./shared/serverapi ./server/workflowview ./shared/protocol -count=1`
- focused Desktop API/schema/board-route/persistence/navigation tests (32 tests)
- `./scripts/build.sh --output ./bin/kent`
- `./scripts/build.sh desktop`
- protocol 52→53 and KENT-229 pagination-contract audits
- authenticated browser QA covered omitted selection, explicit blank validation, and the zero-link no-workflow state

Desktop tests retain pre-existing non-fatal React test-harness diagnostics.