### PR TITLE
test: keep session parent setup out of production

### DIFF
--- a/cli/app/session_launch_destination.go
+++ b/cli/app/session_launch_destination.go
@@ -59,14 +59,6 @@ type sessionParentReference struct {
 	sessionID validatedSessionID
 }
 
-func newSessionParentReference(sessionID string) (sessionParentReference, error) {
-	validated, err := newValidatedSessionID(sessionID)
-	if err != nil {
-		return sessionParentReference{}, err
-	}
-	return sessionParentReference{sessionID: validated}, nil
-}
-
 func (p sessionParentReference) SessionID() string {
 	return p.sessionID.String()
 }

--- a/cli/app/session_launch_destination_test_helpers_test.go
+++ b/cli/app/session_launch_destination_test_helpers_test.go
@@ -13,9 +13,9 @@ func sessionOpenDestinationForTest(t *testing.T, sessionID string) sessionOpenDe
 
 func sessionParentReferenceForTest(t *testing.T, sessionID string) *sessionParentReference {
 	t.Helper()
-	parent, err := newSessionParentReference(sessionID)
+	validated, err := newValidatedSessionID(sessionID)
 	if err != nil {
-		t.Fatalf("new parent session reference: %v", err)
+		t.Fatalf("validate parent session id: %v", err)
 	}
-	return &parent
+	return &sessionParentReference{sessionID: validated}
 }


### PR DESCRIPTION
## Summary
- remove the parent-reference constructor that was used only by tests
- construct the validated parent reference inside the `_test.go` helper instead
- preserve the single production session-ID validation path without a test-only production API

## Verification
- `./scripts/test.sh ./cli/app -run 'TestResolvedSessionPlanRequestConvertsTypedDestinationAtAPIClientBoundary|TestBackParentPrefillTransportParity' -count=1`
- `git diff --check`

Follow-up to #556 for its resolved automated review finding.
