### PR TITLE
Add deterministic metadata schema dump command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Prefer using scripts provided in `./scripts/` over raw commands like `cargo buil
 
 - build.sh - Prefer to build executables. Pass 0 or more args: `tui`, `server`, `desktop` to pick what to build. 0 args builds all. e.g. `./scripts/build.sh tui desktop`. Before handing off to the user after code changes, rebuild relevant targets so they can test/use them right away.
 - test.sh - runs test suites. pass 0 or more of: `tui`, `server`, `desktop` to specify the target to run tests for; any other argument is forwarded to `go test` (packages, `-run`, ...) and implies the server target. If the script fails with time-outs, speeding up / fixing the hangs in the test suite execution becomes in the scope of the current task, bypasses are not allowed. Don't ask for confirmation to run/write tests and run checks, just do it proactively.
+- dump-metadata-schema.sh - prints executable DDL for the latest effective metadata schema from an isolated migrated SQLite database.
 
 - ci-check.sh - run CI-like extensive check setup needed to open PRs.
 - install.sh/install.ps1 - production, user-facing installer scripts of the product. Not for development.

--- a/cmd/dumpmetadataschema/main.go
+++ b/cmd/dumpmetadataschema/main.go
@@ -23,18 +23,27 @@ func main() {
 func run(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("dumpmetadataschema", flag.ContinueOnError)
 	fs.SetOutput(stderr)
+	var usageWriteErr error
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "usage: dumpmetadataschema")
+		_, usageWriteErr = fmt.Fprintln(stderr, "usage: dumpmetadataschema")
 	}
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
+			if usageWriteErr != nil {
+				return 1
+			}
 			return 0
 		}
 		return 2
 	}
 	if fs.NArg() != 0 {
-		fmt.Fprintln(stderr, "dumpmetadataschema does not accept arguments")
+		if _, err := fmt.Fprintln(stderr, "dumpmetadataschema does not accept arguments"); err != nil {
+			return 1
+		}
 		fs.Usage()
+		if usageWriteErr != nil {
+			return 1
+		}
 		return 2
 	}
 

--- a/cmd/dumpmetadataschema/main.go
+++ b/cmd/dumpmetadataschema/main.go
@@ -1,0 +1,142 @@
+// Command dumpmetadataschema prints the effective metadata SQLite schema after
+// applying Kent's authoritative embedded migrations to an isolated database.
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"core/server/metadata"
+	"core/server/metadata/sqlitegen"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("dumpmetadataschema", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: dumpmetadataschema")
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "dumpmetadataschema does not accept arguments")
+		fs.Usage()
+		return 2
+	}
+
+	dump, err := buildSchemaDump(context.Background())
+	if err != nil {
+		fmt.Fprintf(stderr, "dumpmetadataschema: %v\n", err)
+		return 1
+	}
+	written, err := stdout.Write(dump)
+	if err == nil && written != len(dump) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "dumpmetadataschema: write stdout: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func buildSchemaDump(ctx context.Context) ([]byte, error) {
+	root, err := os.MkdirTemp("", "kent-metadata-schema-")
+	if err != nil {
+		return nil, fmt.Errorf("create temporary metadata root: %w", err)
+	}
+
+	store, openErr := metadata.Open(root)
+	if openErr != nil {
+		return nil, errors.Join(
+			fmt.Errorf("open temporary metadata store: %w", openErr),
+			removeTemporaryRoot(root),
+		)
+	}
+
+	dump, dumpErr := loadSchemaDump(ctx, store)
+	err = errors.Join(
+		dumpErr,
+		wrapOperationalError("close temporary metadata store", store.Close()),
+		removeTemporaryRoot(root),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return dump, nil
+}
+
+func loadSchemaDump(ctx context.Context, store *metadata.Store) ([]byte, error) {
+	rows, err := store.Queries().ListMetadataSchemaDefinitions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list metadata schema definitions: %w", err)
+	}
+	return renderSchemaDefinitions(rows)
+}
+
+type schemaObjectKind uint8
+
+const (
+	schemaObjectTable schemaObjectKind = iota
+	schemaObjectView
+	schemaObjectIndex
+	schemaObjectTrigger
+)
+
+func renderSchemaDefinitions(rows []sqlitegen.ListMetadataSchemaDefinitionsRow) ([]byte, error) {
+	var buffer bytes.Buffer
+	for index, row := range rows {
+		if _, err := parseSchemaObjectKind(row.ObjectKind); err != nil {
+			return nil, fmt.Errorf("validate metadata schema object %q: %w", row.ObjectName, err)
+		}
+		if strings.TrimSpace(row.Ddl) == "" {
+			return nil, fmt.Errorf("metadata schema object %q has empty DDL", row.ObjectName)
+		}
+		if index > 0 {
+			buffer.WriteByte('\n')
+		}
+		buffer.WriteString(row.Ddl)
+		buffer.WriteString(";\n")
+	}
+	return buffer.Bytes(), nil
+}
+
+func parseSchemaObjectKind(value string) (schemaObjectKind, error) {
+	switch value {
+	case "table":
+		return schemaObjectTable, nil
+	case "view":
+		return schemaObjectView, nil
+	case "index":
+		return schemaObjectIndex, nil
+	case "trigger":
+		return schemaObjectTrigger, nil
+	default:
+		return 0, fmt.Errorf("unknown metadata schema object kind %q", value)
+	}
+}
+
+func removeTemporaryRoot(root string) error {
+	return wrapOperationalError("remove temporary metadata root", os.RemoveAll(root))
+}
+
+func wrapOperationalError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", operation, err)
+}

--- a/cmd/dumpmetadataschema/main_test.go
+++ b/cmd/dumpmetadataschema/main_test.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"core/server/metadata/sqlitegen"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestRunDumpsLatestMetadataSchemaWithoutTouchingConfiguredPersistence(t *testing.T) {
+	tempBase := t.TempDir()
+	t.Setenv("TMPDIR", tempBase)
+
+	configuredRoot := t.TempDir()
+	configuredDatabasePath := filepath.Join(configuredRoot, "db", "main.sqlite3")
+	if err := os.MkdirAll(filepath.Dir(configuredDatabasePath), 0o755); err != nil {
+		t.Fatalf("create configured database directory: %v", err)
+	}
+	configuredDatabase := []byte("configured metadata database sentinel")
+	if err := os.WriteFile(configuredDatabasePath, configuredDatabase, 0o600); err != nil {
+		t.Fatalf("write configured database sentinel: %v", err)
+	}
+	t.Setenv("KENT_PERSISTENCE_ROOT", configuredRoot)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if exitCode := run(nil, &stdout, &stderr); exitCode != 0 {
+		t.Fatalf("run exit code = %d, stderr = %q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	if stdout.Len() == 0 {
+		t.Fatal("stdout is empty")
+	}
+
+	gotConfiguredDatabase, err := os.ReadFile(configuredDatabasePath)
+	if err != nil {
+		t.Fatalf("read configured database sentinel: %v", err)
+	}
+	if !bytes.Equal(gotConfiguredDatabase, configuredDatabase) {
+		t.Fatal("configured metadata database changed")
+	}
+	tempArtifacts, err := os.ReadDir(tempBase)
+	if err != nil {
+		t.Fatalf("read isolated temporary base: %v", err)
+	}
+	if len(tempArtifacts) != 0 {
+		t.Fatalf("temporary artifacts remain: %v", tempArtifacts)
+	}
+
+	assertExecutableMetadataSchemaDump(t, stdout.Bytes())
+}
+
+func assertExecutableMetadataSchemaDump(t *testing.T, dump []byte) {
+	t.Helper()
+
+	reconstructed, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "reconstructed.sqlite3"))
+	if err != nil {
+		t.Fatalf("open reconstructed database: %v", err)
+	}
+	t.Cleanup(func() { _ = reconstructed.Close() })
+	if _, err := reconstructed.Exec(string(dump)); err != nil {
+		t.Fatalf("execute schema dump: %v", err)
+	}
+
+	rows, err := reconstructed.Query(`
+		SELECT type, name
+		FROM sqlite_schema
+		WHERE sql IS NOT NULL
+	`)
+	if err != nil {
+		t.Fatalf("query reconstructed catalog: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	foundKinds := map[string]bool{}
+	foundGooseVersionTable := false
+	for rows.Next() {
+		var kind string
+		var name string
+		if err := rows.Scan(&kind, &name); err != nil {
+			t.Fatalf("scan reconstructed catalog: %v", err)
+		}
+		foundKinds[kind] = true
+		if kind == "table" && name == "goose_db_version" {
+			foundGooseVersionTable = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate reconstructed catalog: %v", err)
+	}
+	for _, kind := range []string{"table", "view", "index", "trigger"} {
+		if !foundKinds[kind] {
+			t.Errorf("reconstructed catalog does not contain %s definitions", kind)
+		}
+	}
+	if !foundGooseVersionTable {
+		t.Error("reconstructed catalog does not contain goose_db_version")
+	}
+}
+
+func TestRunProducesByteIdenticalIndependentDumps(t *testing.T) {
+	tempBase := t.TempDir()
+	t.Setenv("TMPDIR", tempBase)
+
+	var firstStdout bytes.Buffer
+	var firstStderr bytes.Buffer
+	if exitCode := run(nil, &firstStdout, &firstStderr); exitCode != 0 {
+		t.Fatalf("first run exit code = %d, stderr = %q", exitCode, firstStderr.String())
+	}
+
+	var secondStdout bytes.Buffer
+	var secondStderr bytes.Buffer
+	if exitCode := run(nil, &secondStdout, &secondStderr); exitCode != 0 {
+		t.Fatalf("second run exit code = %d, stderr = %q", exitCode, secondStderr.String())
+	}
+
+	if !bytes.Equal(firstStdout.Bytes(), secondStdout.Bytes()) {
+		t.Fatal("independent schema dumps differ")
+	}
+}
+
+func TestRenderSchemaDefinitionsRejectsUnknownObjectKind(t *testing.T) {
+	_, err := renderSchemaDefinitions([]sqlitegen.ListMetadataSchemaDefinitionsRow{{
+		ObjectKind: "virtual-table",
+		ObjectName: "unexpected",
+		Ddl:        "CREATE TABLE unexpected (id INTEGER)",
+	}})
+	if err == nil {
+		t.Fatal("expected unknown object kind error")
+	}
+}
+
+func TestRenderSchemaDefinitionsRejectsEmptyDDL(t *testing.T) {
+	_, err := renderSchemaDefinitions([]sqlitegen.ListMetadataSchemaDefinitionsRow{{
+		ObjectKind: "table",
+		ObjectName: "missing_definition",
+		Ddl:        "",
+	}})
+	if err == nil {
+		t.Fatal("expected empty DDL error")
+	}
+}
+
+func TestRunHelpSucceedsWithoutCreatingTemporaryDatabase(t *testing.T) {
+	tempBase := t.TempDir()
+	t.Setenv("TMPDIR", tempBase)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if exitCode := run([]string{"--help"}, &stdout, &stderr); exitCode != 0 {
+		t.Fatalf("run help exit code = %d", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("help stdout is not schema-only: %q", stdout.String())
+	}
+	if stderr.Len() == 0 {
+		t.Fatal("help did not write usage")
+	}
+	tempArtifacts, err := os.ReadDir(tempBase)
+	if err != nil {
+		t.Fatalf("read isolated temporary base: %v", err)
+	}
+	if len(tempArtifacts) != 0 {
+		t.Fatalf("help created temporary artifacts: %v", tempArtifacts)
+	}
+}
+
+func TestRunRejectsArgumentsWithoutCreatingTemporaryDatabase(t *testing.T) {
+	for _, args := range [][]string{
+		{"database.sqlite3"},
+		{"--output", "schema.sql"},
+	} {
+		t.Run(args[0], func(t *testing.T) {
+			tempBase := t.TempDir()
+			t.Setenv("TMPDIR", tempBase)
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			if exitCode := run(args, &stdout, &stderr); exitCode != 2 {
+				t.Fatalf("run exit code = %d, want 2", exitCode)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout is not schema-only: %q", stdout.String())
+			}
+			if stderr.Len() == 0 {
+				t.Fatal("argument rejection did not write usage or an error")
+			}
+			tempArtifacts, err := os.ReadDir(tempBase)
+			if err != nil {
+				t.Fatalf("read isolated temporary base: %v", err)
+			}
+			if len(tempArtifacts) != 0 {
+				t.Fatalf("argument rejection created temporary artifacts: %v", tempArtifacts)
+			}
+		})
+	}
+}
+
+func TestRunReportsStdoutFailureAfterCleaningTemporaryDatabase(t *testing.T) {
+	tempBase := t.TempDir()
+	t.Setenv("TMPDIR", tempBase)
+
+	writeCalled := false
+	var artifactsAtWrite []os.DirEntry
+	var readAtWriteErr error
+	stdout := writerFunc(func(_ []byte) (int, error) {
+		writeCalled = true
+		artifactsAtWrite, readAtWriteErr = os.ReadDir(tempBase)
+		return 0, nil
+	})
+	var stderr bytes.Buffer
+	if exitCode := run(nil, stdout, &stderr); exitCode == 0 {
+		t.Fatal("run succeeded after a short stdout write")
+	}
+	if !writeCalled {
+		t.Fatal("stdout writer was not called")
+	}
+	if readAtWriteErr != nil {
+		t.Fatalf("read isolated temporary base during stdout write: %v", readAtWriteErr)
+	}
+	if len(artifactsAtWrite) != 0 {
+		t.Fatalf("temporary artifacts existed during stdout write: %v", artifactsAtWrite)
+	}
+	if stderr.Len() == 0 {
+		t.Fatal("stdout failure did not write an error")
+	}
+	tempArtifacts, err := os.ReadDir(tempBase)
+	if err != nil {
+		t.Fatalf("read isolated temporary base after stdout write: %v", err)
+	}
+	if len(tempArtifacts) != 0 {
+		t.Fatalf("temporary artifacts remain after stdout failure: %v", tempArtifacts)
+	}
+}
+
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) {
+	return f(p)
+}
+
+func TestMetadataSchemaDumpScriptWorksOutsideRepository(t *testing.T) {
+	repositoryRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	scriptPath := filepath.Join(repositoryRoot, "scripts", "dump-metadata-schema.sh")
+
+	shadowBin := t.TempDir()
+	shadowSQLite := filepath.Join(shadowBin, "sqlite3")
+	if err := os.WriteFile(shadowSQLite, []byte("#!/bin/sh\nexit 97\n"), 0o755); err != nil {
+		t.Fatalf("write sqlite3 shadow: %v", err)
+	}
+
+	command := exec.Command(scriptPath)
+	command.Dir = t.TempDir()
+	command.Env = append(os.Environ(), "PATH="+shadowBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		t.Fatalf("run metadata schema dump script: %v, stderr = %q", err, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("script stderr = %q, want empty", stderr.String())
+	}
+	if stdout.Len() == 0 {
+		t.Fatal("script stdout is empty")
+	}
+	assertExecutableMetadataSchemaDump(t, stdout.Bytes())
+}

--- a/cmd/dumpmetadataschema/main_test.go
+++ b/cmd/dumpmetadataschema/main_test.go
@@ -248,21 +248,7 @@ func (f writerFunc) Write(p []byte) (int, error) {
 }
 
 func TestMetadataSchemaDumpScriptWorksOutsideRepository(t *testing.T) {
-	repositoryRoot, err := filepath.Abs(filepath.Join("..", ".."))
-	if err != nil {
-		t.Fatalf("resolve repository root: %v", err)
-	}
-	scriptPath := filepath.Join(repositoryRoot, "scripts", "dump-metadata-schema.sh")
-
-	shadowBin := t.TempDir()
-	shadowSQLite := filepath.Join(shadowBin, "sqlite3")
-	if err := os.WriteFile(shadowSQLite, []byte("#!/bin/sh\nexit 97\n"), 0o755); err != nil {
-		t.Fatalf("write sqlite3 shadow: %v", err)
-	}
-
-	command := exec.Command(scriptPath)
-	command.Dir = t.TempDir()
-	command.Env = append(os.Environ(), "PATH="+shadowBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	command, temporaryBase := metadataSchemaDumpScriptCommand(t)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	command.Stdout = &stdout
@@ -276,5 +262,67 @@ func TestMetadataSchemaDumpScriptWorksOutsideRepository(t *testing.T) {
 	if stdout.Len() == 0 {
 		t.Fatal("script stdout is empty")
 	}
+	assertDirectoryEmpty(t, temporaryBase)
 	assertExecutableMetadataSchemaDump(t, stdout.Bytes())
+}
+
+func TestMetadataSchemaDumpScriptPreservesUsageExitStatus(t *testing.T) {
+	command, temporaryBase := metadataSchemaDumpScriptCommand(t, "--output", "schema.sql")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err := command.Run()
+	exitError, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("script error = %v, want process exit error", err)
+	}
+	if exitCode := exitError.ExitCode(); exitCode != 2 {
+		t.Fatalf("script exit code = %d, want 2", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("script stdout = %q, want empty", stdout.String())
+	}
+	if stderr.Len() == 0 {
+		t.Fatal("script did not write usage or an error")
+	}
+	assertDirectoryEmpty(t, temporaryBase)
+}
+
+func metadataSchemaDumpScriptCommand(t *testing.T, args ...string) (*exec.Cmd, string) {
+	t.Helper()
+
+	repositoryRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	scriptPath := filepath.Join(repositoryRoot, "scripts", "dump-metadata-schema.sh")
+
+	shadowBin := t.TempDir()
+	shadowSQLite := filepath.Join(shadowBin, "sqlite3")
+	if err := os.WriteFile(shadowSQLite, []byte("#!/bin/sh\nexit 97\n"), 0o755); err != nil {
+		t.Fatalf("write sqlite3 shadow: %v", err)
+	}
+
+	command := exec.Command(scriptPath, args...)
+	command.Dir = t.TempDir()
+	temporaryBase := t.TempDir()
+	command.Env = append(
+		os.Environ(),
+		"PATH="+shadowBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"TMPDIR="+temporaryBase,
+	)
+	return command, temporaryBase
+}
+
+func assertDirectoryEmpty(t *testing.T, path string) {
+	t.Helper()
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		t.Fatalf("read temporary base: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("temporary artifacts remain: %v", entries)
+	}
 }

--- a/cmd/dumpmetadataschema/main_test.go
+++ b/cmd/dumpmetadataschema/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"database/sql"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -170,6 +171,19 @@ func TestRunHelpSucceedsWithoutCreatingTemporaryDatabase(t *testing.T) {
 	}
 	if len(tempArtifacts) != 0 {
 		t.Fatalf("help created temporary artifacts: %v", tempArtifacts)
+	}
+}
+
+func TestRunReportsHelpOutputFailure(t *testing.T) {
+	var stdout bytes.Buffer
+	stderr := writerFunc(func(_ []byte) (int, error) {
+		return 0, io.ErrClosedPipe
+	})
+	if exitCode := run([]string{"--help"}, &stdout, stderr); exitCode == 0 {
+		t.Fatal("run succeeded after help output failed")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("help stdout is not schema-only: %q", stdout.String())
 	}
 }
 

--- a/scripts/dump-metadata-schema.sh
+++ b/scripts/dump-metadata-schema.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# dump-metadata-schema.sh — print the latest effective Kent metadata SQLite DDL.
+#
+# Usage:
+#   ./scripts/dump-metadata-schema.sh
+#
+# The command migrates an isolated temporary database through the application's
+# authoritative metadata path and writes executable schema-only SQL to stdout.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+go run ./cmd/dumpmetadataschema "$@"

--- a/scripts/dump-metadata-schema.sh
+++ b/scripts/dump-metadata-schema.sh
@@ -12,4 +12,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-go run ./cmd/dumpmetadataschema "$@"
+BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kent-dump-metadata-schema.XXXXXX")"
+cleanup() {
+  local command_status=$?
+  trap - EXIT
+  if ! find "$BUILD_DIR" -depth -delete; then
+    printf 'dump-metadata-schema.sh: remove temporary build directory: %s\n' "$BUILD_DIR" >&2
+    if [[ $command_status -eq 0 ]]; then
+      command_status=1
+    fi
+  fi
+  exit "$command_status"
+}
+trap cleanup EXIT
+
+go build -o "$BUILD_DIR/dumpmetadataschema" ./cmd/dumpmetadataschema
+"$BUILD_DIR/dumpmetadataschema" "$@"

--- a/scripts/dump-metadata-schema.sh
+++ b/scripts/dump-metadata-schema.sh
@@ -12,6 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Execute a built binary so command exit statuses pass through unchanged.
 BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kent-dump-metadata-schema.XXXXXX")"
 cleanup() {
   local command_status=$?

--- a/server/core/small_package_guardrail_test.go
+++ b/server/core/small_package_guardrail_test.go
@@ -101,6 +101,7 @@ func listRepoPackages(t *testing.T, repoRoot string) []smallPackageInfo {
 }
 
 var allowedSmallPackages = map[string]string{
+	"cmd/dumpmetadataschema":                      "narrow developer-only metadata schema audit command that reuses the authoritative metadata migration and generated-query paths",
 	"cmd/dumpmodelrequest":                        "temporary standalone model-request inspector command that keeps diagnostic request serialization out of production server startup paths",
 	"cli/app/internal/daemonlaunch":               "narrow process helper that intentionally isolates daemon process ownership and termination behavior from attachment policy",
 	"cli/app/internal/embeddedattach":             "narrow embedded-server attachment seam after absorbing embedded binding/startup helpers",

--- a/server/metadata/catalog_test.go
+++ b/server/metadata/catalog_test.go
@@ -1,0 +1,51 @@
+package metadata
+
+import (
+	"context"
+	"testing"
+)
+
+func TestListMetadataSchemaDefinitionsUsesDependencyOrder(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("open metadata store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	rows, err := store.Queries().ListMetadataSchemaDefinitions(context.Background())
+	if err != nil {
+		t.Fatalf("list metadata schema definitions: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("metadata schema definitions are empty")
+	}
+
+	kindRank := map[string]int{
+		"table":   0,
+		"view":    1,
+		"index":   2,
+		"trigger": 3,
+	}
+	previousRank := -1
+	previousName := ""
+	for _, row := range rows {
+		if row.ObjectName == "sqlite_sequence" {
+			t.Fatal("sqlite_sequence was included in metadata schema definitions")
+		}
+		rank, ok := kindRank[row.ObjectKind]
+		if !ok {
+			t.Fatalf("unexpected schema object kind %q", row.ObjectKind)
+		}
+		if rank < previousRank || (rank == previousRank && row.ObjectName < previousName) {
+			t.Fatalf(
+				"schema definitions are not ordered by kind and name: %s/%s follows rank=%d name=%q",
+				row.ObjectKind,
+				row.ObjectName,
+				previousRank,
+				previousName,
+			)
+		}
+		previousRank = rank
+		previousName = row.ObjectName
+	}
+}

--- a/server/metadata/catalog_test.go
+++ b/server/metadata/catalog_test.go
@@ -26,8 +26,11 @@ func TestListMetadataSchemaDefinitionsUsesDependencyOrder(t *testing.T) {
 		"index":   2,
 		"trigger": 3,
 	}
-	previousRank := -1
-	previousName := ""
+	type catalogPosition struct {
+		rank int
+		name string
+	}
+	var previous *catalogPosition
 	for _, row := range rows {
 		if row.ObjectName == "sqlite_sequence" {
 			t.Fatal("sqlite_sequence was included in metadata schema definitions")
@@ -36,16 +39,16 @@ func TestListMetadataSchemaDefinitionsUsesDependencyOrder(t *testing.T) {
 		if !ok {
 			t.Fatalf("unexpected schema object kind %q", row.ObjectKind)
 		}
-		if rank < previousRank || (rank == previousRank && row.ObjectName < previousName) {
+		current := catalogPosition{rank: rank, name: row.ObjectName}
+		if previous != nil && (current.rank < previous.rank || (current.rank == previous.rank && current.name < previous.name)) {
 			t.Fatalf(
 				"schema definitions are not ordered by kind and name: %s/%s follows rank=%d name=%q",
 				row.ObjectKind,
 				row.ObjectName,
-				previousRank,
-				previousName,
+				previous.rank,
+				previous.name,
 			)
 		}
-		previousRank = rank
-		previousName = row.ObjectName
+		previous = &current
 	}
 }

--- a/server/metadata/queries.sql
+++ b/server/metadata/queries.sql
@@ -4360,3 +4360,20 @@ ORDER BY r.started_at_unix_ms DESC, (
     FROM task_runs storage
     WHERE storage.id = r.id
 ) DESC;
+
+-- name: ListMetadataSchemaDefinitions :many
+SELECT
+    type AS object_kind,
+    name AS object_name,
+    CAST(sql AS TEXT) AS ddl
+FROM sqlite_schema
+WHERE sql IS NOT NULL
+  AND name != 'sqlite_sequence'
+ORDER BY
+    CASE type
+        WHEN 'table' THEN 0
+        WHEN 'view' THEN 1
+        WHEN 'index' THEN 2
+        WHEN 'trigger' THEN 3
+    END,
+    name;

--- a/server/metadata/sqlc/sqlite_schema.sql
+++ b/server/metadata/sqlc/sqlite_schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE sqlite_schema (
+    type TEXT NOT NULL,
+    name TEXT NOT NULL,
+    sql TEXT
+);

--- a/server/metadata/sqlitegen/models.go
+++ b/server/metadata/sqlitegen/models.go
@@ -47,6 +47,7 @@ type Session struct {
 	FirstPromptPreview string
 	InputDraft         string
 	ParentSessionID    sql.NullString
+	Category           sql.NullString
 	CreatedAtUnixMs    int64
 	UpdatedAtUnixMs    int64
 	LastSequence       int64
@@ -57,7 +58,6 @@ type Session struct {
 	LockedJson         string
 	UsageStateJson     string
 	MetadataJson       string
-	Category           sql.NullString
 }
 
 type SessionPromptHistoryEntry struct {
@@ -66,6 +66,12 @@ type SessionPromptHistoryEntry struct {
 	SourceID        string
 	Text            string
 	CreatedAtUnixMs int64
+}
+
+type SqliteSchema struct {
+	Type string
+	Name string
+	Sql  sql.NullString
 }
 
 type Task struct {

--- a/server/metadata/sqlitegen/queries.sql.go
+++ b/server/metadata/sqlitegen/queries.sql.go
@@ -4269,6 +4269,53 @@ func (q *Queries) ListJoinExpectedBranches(ctx context.Context, batchID string) 
 	return items, nil
 }
 
+const listMetadataSchemaDefinitions = `-- name: ListMetadataSchemaDefinitions :many
+SELECT
+    type AS object_kind,
+    name AS object_name,
+    CAST(sql AS TEXT) AS ddl
+FROM sqlite_schema
+WHERE sql IS NOT NULL
+  AND name != 'sqlite_sequence'
+ORDER BY
+    CASE type
+        WHEN 'table' THEN 0
+        WHEN 'view' THEN 1
+        WHEN 'index' THEN 2
+        WHEN 'trigger' THEN 3
+    END,
+    name
+`
+
+type ListMetadataSchemaDefinitionsRow struct {
+	ObjectKind string
+	ObjectName string
+	Ddl        string
+}
+
+func (q *Queries) ListMetadataSchemaDefinitions(ctx context.Context) ([]ListMetadataSchemaDefinitionsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listMetadataSchemaDefinitions)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListMetadataSchemaDefinitionsRow
+	for rows.Next() {
+		var i ListMetadataSchemaDefinitionsRow
+		if err := rows.Scan(&i.ObjectKind, &i.ObjectName, &i.Ddl); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listNewerSessionPage = `-- name: ListNewerSessionPage :many
 SELECT
     id,

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -3,6 +3,7 @@ sql:
   - engine: "sqlite"
     schema:
       - "server/metadata/migrations/*.up.sql"
+      - "server/metadata/sqlc/*.sql"
     queries:
       - "server/metadata/queries.sql"
     gen:


### PR DESCRIPTION
## Summary

- Add the canonical `./scripts/dump-metadata-schema.sh` developer command.
- Create and migrate an isolated temporary metadata database through `metadata.Open`, then read effective DDL through a generated `sqlite_schema` query.
- Emit deterministic executable SQL for tables, views, indexes, and triggers, including `goose_db_version`, only after database close and temporary cleanup succeed.
- Preserve conventional command exit statuses through an isolated temporary build/direct-execution wrapper, with no runtime `sqlite3` dependency.

## Verification

- `./scripts/test.sh ./cmd/dumpmetadataschema ./server/metadata ./server/core`
- `./scripts/test.sh server`
- `./scripts/build.sh --output ./bin/kent`
- Ran the canonical wrapper twice from outside the repository and confirmed byte-identical output.
- Executed the redirected dump into an empty SQLite database: 19 tables (including `goose_db_version`), 11 views, 37 indexes, and 40 triggers.
- Verified invalid canonical-wrapper arguments exit exactly `2`, write usage/errors only to stderr, and leave stdout empty.
- Verified help-output write failures return nonzero rather than being swallowed.
- Verified the wrapper succeeds with a failing `sqlite3` shadow in `PATH` and leaves no temporary artifacts.
- Workflow acceptance and QA coverage evidence: `.kent/plans/BUI-40-metadata-schema-dump.md`.

## Diff report

Compared with `origin/main` after rebase:

- Total: **+656 net LoC**, **658 gross LoC** (657 additions, 1 deletion).
- Non-test, non-generated implementation/tooling/docs: **+206 net LoC**, **206 gross LoC**.
- Tests and generated code: **+450 net LoC**, **452 gross LoC** (451 additions, 1 deletion).

## Caveats and tradeoffs

- The wrapper builds a temporary executable rather than using `go run` because `go run` collapses every non-zero child status to `1`; direct execution preserves the command contract, including usage status `2`. This mechanism was explicitly approved during implementation review.
- The output is a schema-audit artifact, not a backup: it contains no application rows or Goose migration-version rows.
- SQLite-reported DDL is preserved without formatting; the tool only adds statement terminators and spacing.

## Technical debt / follow-up

- No follow-up is required for schema evolution: future embedded up-migrations are picked up automatically through the authoritative metadata migration path.

## Tracking

Closes #282

Kent ticket: BUI-40