### PR TITLE
Preserve ongoing cursor projection during ask prompts

### DIFF
--- a/cli/app/ui_ongoing_frame_test.go
+++ b/cli/app/ui_ongoing_frame_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"core/cli/tui/ongoing"
@@ -99,6 +100,67 @@ func TestOngoingTranscriptControllerPlacesCursorAfterPrependedLiveSections(t *te
 	}
 	if got, want := frame.Cursor.Row, inputStart+1; got != want {
 		t.Fatalf("final frame cursor row = %d, want first framed input content row %d", got, want)
+	}
+}
+
+func TestOngoingTranscriptControllerPreservesWrappedDisplayCursorTargetWithPrependedSections(t *testing.T) {
+	const width = 24
+	m := sizedTestUIModel(newProjectedStaticUIModel(
+		WithUITerminalCursorState(newUITerminalCursorState()),
+	), width, 12)
+	m.input = strings.Repeat("界", 20) + " tail"
+	m.inputCursor = -1
+	projected := m.layout().inputPaneCursor(width)
+	if !projected.Visible {
+		t.Fatal("shared editor cursor projection is absent")
+	}
+
+	surface := &ongoingSurfaceSpy{}
+	controller := newOngoingTranscriptController(surface, m.ongoingFrameInput)
+	if _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+		t.Fatalf("accept hydration: %v", err)
+	}
+	if _, err := controller.Accept(clientui.TranscriptMessage{
+		Sequence: 2,
+		Kind:     clientui.TranscriptMessageQueuedOrSteeredMessageState,
+		QueuedOrSteeredMessageState: &clientui.TranscriptQueuedOrSteeredMessageState{
+			QueueItemID: "11111111-1111-4111-8111-111111111111",
+			Status:      clientui.QueuedUserMessageAccepted,
+			UserText:    "queued prompt",
+		},
+	}); err != nil {
+		t.Fatalf("accept queued message: %v", err)
+	}
+
+	frame := surface.calls[len(surface.calls)-1].frame
+	_, queuedEnd, ok := ongoingFrameSectionTerminalRows(frame, ongoing.FrameSectionQueuedOrSteered)
+	if !ok {
+		t.Fatal("prepended queued section missing from final ongoing frame")
+	}
+	inputStart, inputEnd, ok := ongoingFrameSectionTerminalRows(frame, ongoing.FrameSectionInput)
+	if !ok {
+		t.Fatal("input section missing from final ongoing frame")
+	}
+	if queuedEnd >= inputStart {
+		t.Fatalf("queued section ends at row %d, want before input start %d", queuedEnd, inputStart)
+	}
+	if frame.Cursor.Target == nil || frame.Cursor.Target.SectionKind != ongoing.FrameSectionInput {
+		t.Fatalf("frame cursor target = %+v, want input section", frame.Cursor.Target)
+	}
+	if got, want := frame.Cursor.Target.Row, projected.Row; got != want {
+		t.Fatalf("frame cursor target row = %d, want shared editor row %d", got, want)
+	}
+	if got, want := frame.Cursor.Column, projected.Col+1; got != want {
+		t.Fatalf("frame cursor column = %d, want shared editor column %d", got, want)
+	}
+	if frame.Cursor.Column < 1 || frame.Cursor.Column > frame.Size.Width {
+		t.Fatalf("frame cursor column %d outside width %d", frame.Cursor.Column, frame.Size.Width)
+	}
+	if got, want := frame.Cursor.Row, inputStart+projected.Row-1; got != want {
+		t.Fatalf("frame cursor row = %d, want targeted input row %d", got, want)
+	}
+	if frame.Cursor.Row < inputStart || frame.Cursor.Row > inputEnd {
+		t.Fatalf("frame cursor row %d outside input rows %d..%d", frame.Cursor.Row, inputStart, inputEnd)
 	}
 }
 

--- a/cli/app/ui_ongoing_frame_test.go
+++ b/cli/app/ui_ongoing_frame_test.go
@@ -115,11 +115,11 @@ func TestOngoingTranscriptControllerPreservesWrappedDisplayCursorTargetWithPrepe
 	}
 
 	surface := &ongoingSurfaceSpy{}
-	controller := newOngoingTranscriptController(surface, m.ongoingFrameInput)
+	controller := newTestOngoingTranscriptController(surface, m.ongoingFrameInput)
 	if _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
-	if _, _, err := controller.Accept(ongoingTranscriptMessage(2, clientui.TranscriptMessageQueuedMessageState)); err != nil {
+	if _, err := controller.Accept(ongoingTranscriptMessage(2, clientui.TranscriptMessageQueuedMessageState)); err != nil {
 		t.Fatalf("accept queued message: %v", err)
 	}
 

--- a/cli/app/ui_ongoing_frame_test.go
+++ b/cli/app/ui_ongoing_frame_test.go
@@ -85,7 +85,6 @@ func TestOngoingTranscriptControllerPlacesCursorAfterPrependedLiveSections(t *te
 	if _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
-
 	if _, err := controller.Accept(ongoingTranscriptMessage(2, clientui.TranscriptMessageQueuedMessageState)); err != nil {
 		t.Fatalf("accept queued message: %v", err)
 	}
@@ -120,15 +119,7 @@ func TestOngoingTranscriptControllerPreservesWrappedDisplayCursorTargetWithPrepe
 	if _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
-	if _, err := controller.Accept(clientui.TranscriptMessage{
-		Sequence: 2,
-		Kind:     clientui.TranscriptMessageQueuedOrSteeredMessageState,
-		QueuedOrSteeredMessageState: &clientui.TranscriptQueuedOrSteeredMessageState{
-			QueueItemID: "11111111-1111-4111-8111-111111111111",
-			Status:      clientui.QueuedUserMessageAccepted,
-			UserText:    "queued prompt",
-		},
-	}); err != nil {
+	if _, _, err := controller.Accept(ongoingTranscriptMessage(2, clientui.TranscriptMessageQueuedMessageState)); err != nil {
 		t.Fatalf("accept queued message: %v", err)
 	}
 

--- a/cli/app/ui_ongoing_surface.go
+++ b/cli/app/ui_ongoing_surface.go
@@ -214,30 +214,27 @@ func (m *uiModel) ongoingFrameInput() ongoing.FrameInput {
 		appendSection(ongoing.FrameSectionStatus, []string{statusLine})
 	}
 	cursor := layout.inputPaneCursor(width)
-	visible := cursor.Visible
-	column := cursor.Col + 1
-	cursorSectionRow := cursor.Row
-	if !visible {
-		visible = true
-		column = clampCursor(m.inputCursor, len([]rune(m.input))) + 1
-		cursorSectionRow = 1
+	frameCursor := ongoing.Cursor{}
+	if cursor.Visible {
+		frameCursor = ongoing.Cursor{
+			Visible: true,
+			Column:  cursor.Col + 1,
+			Target: &ongoing.CursorTarget{
+				SectionKind: ongoing.FrameSectionInput,
+				Row:         cursor.Row,
+			},
+		}
 	}
 	frame := ongoing.FrameInput{
 		Size:         ongoing.Size{Width: width, Height: height},
 		Theme:        m.theme,
 		SpinnerFrame: m.spinnerFrame,
 		Sections:     sections,
-		Cursor: ongoing.Cursor{
-			Visible: visible,
-			Row:     height,
-			Column:  column,
-			Target: &ongoing.CursorTarget{
-				SectionKind: ongoing.FrameSectionInput,
-				Row:         cursorSectionRow,
-			},
-		},
+		Cursor:       frameCursor,
 	}
-	frame.Cursor.Row = ongoingFrameInputCursorTerminalRow(frame, cursorSectionRow)
+	if cursor.Visible {
+		frame.Cursor.Row = ongoingFrameInputCursorTerminalRow(frame, cursor.Row)
+	}
 	return frame
 }
 

--- a/cli/app/ui_ongoing_surface_test.go
+++ b/cli/app/ui_ongoing_surface_test.go
@@ -10,6 +10,7 @@ import (
 	"core/shared/clientui"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/google/uuid"
 )
 
 func withUIOngoingTranscriptController(controller *ongoingTranscriptController) UIOption {
@@ -123,6 +124,60 @@ func TestOngoingTranscriptEventReachesNativeSurface(t *testing.T) {
 	}
 	if got := out.String(); !strings.Contains(got, "hydrated row") {
 		t.Fatalf("native surface output = %q, want hydrated row", got)
+	}
+}
+
+func TestOngoingTranscriptDeliveryKeepsCursorAbsentForAskOptionPicker(t *testing.T) {
+	var out bytes.Buffer
+	surface := ongoing.NewSurface(&out)
+	m := sizedTestUIModel(newProjectedStaticUIModel(
+		WithUIOngoingSurface(surface),
+		WithUITerminalCursorState(newUITerminalCursorState()),
+	), 77, 34)
+	m.input = strings.Repeat("x", 91)
+	m.inputCursor = -1
+	m.ongoingTranscript = newOngoingTranscriptController(surface, m.ongoingFrameInput)
+
+	if _, err := m.ongoingTranscript.Accept(ongoingHydrationMessage(1)); err != nil {
+		t.Fatalf("accept hydration: %v", err)
+	}
+	next, _ := m.Update(askEventMsg{event: askEvent{
+		req: clientui.PendingPromptEvent{
+			Type:        clientui.PendingPromptEventPending,
+			PromptID:    "ask-1",
+			Question:    "Choose an option",
+			Suggestions: []string{"first", "second"},
+		},
+		reply: make(chan askReply, 1),
+	}})
+	m = next.(*uiModel)
+
+	if got := m.surface(); got != uiSurfaceOngoingTranscript {
+		t.Fatalf("surface = %q, want ongoing transcript", got)
+	}
+	if !m.ongoingTranscript.normalOwned {
+		t.Fatal("ongoing transcript controller lost normal-buffer ownership")
+	}
+	if got := m.inputMode(); got != uiInputModeAsk {
+		t.Fatalf("input mode = %q, want ask", got)
+	}
+	if got := m.layout().inputPaneCursor(77); got.Visible {
+		t.Fatalf("ask option picker cursor = %+v, want absent", got)
+	}
+
+	if _, err := m.ongoingTranscript.Accept(clientui.TranscriptMessage{
+		Sequence: 2,
+		Kind:     clientui.TranscriptMessageAssistantDelta,
+		AssistantDelta: &clientui.TranscriptAssistantDelta{
+			StreamID: uuid.New(),
+			Delta:    "working",
+		},
+	}); err != nil {
+		t.Fatalf("accept assistant delta: %v", err)
+	}
+
+	if got := m.ongoingFrameInput().Cursor; !reflect.DeepEqual(got, ongoing.Cursor{}) {
+		t.Fatalf("ask option picker frame cursor = %+v, want absent zero value", got)
 	}
 }
 

--- a/cli/app/ui_ongoing_surface_test.go
+++ b/cli/app/ui_ongoing_surface_test.go
@@ -8,9 +8,10 @@ import (
 
 	"core/cli/tui/ongoing"
 	"core/shared/clientui"
+	"core/shared/runtimeids"
+	"core/shared/transcript"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/google/uuid"
 )
 
 func withUIOngoingTranscriptController(controller *ongoingTranscriptController) UIOption {
@@ -136,20 +137,18 @@ func TestOngoingTranscriptDeliveryKeepsCursorAbsentForAskOptionPicker(t *testing
 	), 77, 34)
 	m.input = strings.Repeat("x", 91)
 	m.inputCursor = -1
-	m.ongoingTranscript = newOngoingTranscriptController(surface, m.ongoingFrameInput)
+	m.ongoingTranscript = newNoopOngoingTranscriptController(surface, m.ongoingFrameInput)
 
-	if _, err := m.ongoingTranscript.Accept(ongoingHydrationMessage(1)); err != nil {
+	if _, _, err := m.ongoingTranscript.Accept(ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
-	next, _ := m.Update(askEventMsg{event: askEvent{
-		req: clientui.PendingPromptEvent{
-			Type:        clientui.PendingPromptEventPending,
-			PromptID:    "ask-1",
-			Question:    "Choose an option",
-			Suggestions: []string{"first", "second"},
-		},
-		reply: make(chan askReply, 1),
-	}})
+	next, _ := m.Update(askEventMsg{event: testQuestionAskEvent(
+		"ask-1",
+		"Choose an option",
+		make(chan askReply, 1),
+		"first",
+		"second",
+	)})
 	m = next.(*uiModel)
 
 	if got := m.surface(); got != uiSurfaceOngoingTranscript {
@@ -165,12 +164,16 @@ func TestOngoingTranscriptDeliveryKeepsCursorAbsentForAskOptionPicker(t *testing
 		t.Fatalf("ask option picker cursor = %+v, want absent", got)
 	}
 
-	if _, err := m.ongoingTranscript.Accept(clientui.TranscriptMessage{
+	if _, _, err := m.ongoingTranscript.Accept(clientui.TranscriptMessage{
 		Sequence: 2,
 		Kind:     clientui.TranscriptMessageAssistantDelta,
-		AssistantDelta: &clientui.TranscriptAssistantDelta{
-			StreamID: uuid.New(),
-			Delta:    "working",
+		Payload: clientui.TranscriptPayload{
+			AssistantDelta: &clientui.TranscriptAssistantDelta{
+				StepID:   ongoingTestStepID(),
+				StreamID: runtimeids.NewAssistantStreamID(),
+				Delta:    "working",
+				Phase:    transcript.AssistantPhaseCommentary,
+			},
 		},
 	}); err != nil {
 		t.Fatalf("accept assistant delta: %v", err)

--- a/server/runtimeview/transcript_subscription_test.go
+++ b/server/runtimeview/transcript_subscription_test.go
@@ -1,9 +1,12 @@
 package runtimeview
 
 import (
+	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
 
+	"core/internal/testharness/scriptedllm"
 	"core/server/llm"
 	"core/server/runtime"
 	"core/server/session"
@@ -72,6 +75,71 @@ func TestTranscriptCommittedRowsPreserveRuntimeVisibility(t *testing.T) {
 	}
 	if got := hydration.CommittedRows[0].Visibility; got != clientui.EntryVisibilityHidden {
 		t.Fatalf("hydration visibility = %q, want hidden", got)
+	}
+}
+
+func TestUnknownToolExecutionProjectsFinalizedFailedInput(t *testing.T) {
+	input := json.RawMessage(`{}`)
+	call := llm.ToolCall{
+		ID:    "call-unknown",
+		Name:  "final_answer",
+		Input: input,
+	}
+	client := scriptedllm.NewClient(scriptedllm.Script{
+		Steps: []scriptedllm.Step{
+			scriptedllm.ToolBatch("", call),
+			{
+				ExpectedToolResults: []scriptedllm.ExpectedToolResult{{
+					CallID: call.ID,
+					Name:   call.Name,
+				}},
+				Response: scriptedllm.FinalAnswer("done").Response,
+			},
+		},
+	})
+	store := newRuntimeViewStore(t)
+	var completion runtime.Event
+	engine := newRuntimeViewEngine(t, store, client, runtime.Config{
+		Model: "gpt-5",
+		OnEvent: func(evt runtime.Event) {
+			if evt.Kind == runtime.EventToolCallCompleted && evt.ToolResult != nil {
+				completion = evt
+			}
+		},
+	})
+	if _, err := engine.SubmitUserMessage(context.Background(), "exercise unknown tool"); err != nil {
+		t.Fatalf("submit user message: %v", err)
+	}
+	if completion.ToolResult == nil || !completion.ToolResult.IsError || completion.ToolResult.Presentation == nil {
+		t.Fatalf("emitted completion = %+v, want finalized failed result", completion.ToolResult)
+	}
+	if completion.ToolResult.Presentation.Command != string(input) ||
+		completion.ToolResult.Presentation.CompactText != string(input) {
+		t.Fatalf("emitted presentation = %+v, want original input preserved", completion.ToolResult.Presentation)
+	}
+
+	messages := TranscriptMessagesFromRuntimeEvent(completion)
+	var row *clientui.TranscriptCommittedRow
+	for _, message := range messages {
+		if message.Kind == clientui.TranscriptMessageCommittedRow &&
+			message.CommittedRow != nil &&
+			message.CommittedRow.Tool != nil {
+			if row != nil {
+				t.Fatalf("client transcript messages = %+v, want exactly one committed tool row", messages)
+			}
+			row = message.CommittedRow
+		}
+	}
+	if row == nil {
+		t.Fatalf("client transcript messages = %+v, want one committed tool row", messages)
+	}
+	if row.Kind != clientui.TranscriptRowTool || !row.Tool.IsError {
+		t.Fatalf("client transcript row = %+v, want failed tool row", row)
+	}
+	if row.Tool.ToolPresentation == nil ||
+		row.Tool.ToolPresentation.Command != string(input) ||
+		row.Tool.ToolPresentation.CompactText != string(input) {
+		t.Fatalf("projected tool presentation = %+v, want original input preserved", row.Tool.ToolPresentation)
 	}
 }
 

--- a/server/runtimeview/transcript_subscription_test.go
+++ b/server/runtimeview/transcript_subscription_test.go
@@ -110,6 +110,9 @@ func TestUnknownToolExecutionProjectsFinalizedFailedInput(t *testing.T) {
 	if _, err := engine.SubmitUserMessage(context.Background(), "exercise unknown tool"); err != nil {
 		t.Fatalf("submit user message: %v", err)
 	}
+	if remaining := client.RemainingSteps(); remaining != 0 {
+		t.Fatalf("scripted LLM steps remaining = %d, want continuation after tool result consumed", remaining)
+	}
 	if completion.ToolResult == nil || !completion.ToolResult.IsError || completion.ToolResult.Presentation == nil {
 		t.Fatalf("emitted completion = %+v, want finalized failed result", completion.ToolResult)
 	}

--- a/server/runtimeview/transcript_subscription_test.go
+++ b/server/runtimeview/transcript_subscription_test.go
@@ -125,12 +125,12 @@ func TestUnknownToolExecutionProjectsFinalizedFailedInput(t *testing.T) {
 	var row *clientui.TranscriptCommittedRow
 	for _, message := range messages {
 		if message.Kind == clientui.TranscriptMessageCommittedRow &&
-			message.CommittedRow != nil &&
-			message.CommittedRow.Tool != nil {
+			message.Payload.CommittedRow != nil &&
+			message.Payload.CommittedRow.Tool != nil {
 			if row != nil {
 				t.Fatalf("client transcript messages = %+v, want exactly one committed tool row", messages)
 			}
-			row = message.CommittedRow
+			row = message.Payload.CommittedRow
 		}
 	}
 	if row == nil {
@@ -139,10 +139,10 @@ func TestUnknownToolExecutionProjectsFinalizedFailedInput(t *testing.T) {
 	if row.Kind != clientui.TranscriptRowTool || !row.Tool.IsError {
 		t.Fatalf("client transcript row = %+v, want failed tool row", row)
 	}
-	if row.Tool.ToolPresentation == nil ||
-		row.Tool.ToolPresentation.Command != string(input) ||
-		row.Tool.ToolPresentation.CompactText != string(input) {
-		t.Fatalf("projected tool presentation = %+v, want original input preserved", row.Tool.ToolPresentation)
+	if row.Tool.Presentation == nil ||
+		row.Tool.Presentation.Command != string(input) ||
+		row.Tool.Presentation.CompactText != string(input) {
+		t.Fatalf("projected tool presentation = %+v, want original input preserved", row.Tool.Presentation)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Make the shared editor cursor projection the sole source for ongoing-frame cursor coordinates.
- Leave the ongoing cursor absent when ask pickers or other modes expose no editable input cursor.
- Add regression coverage for the reported 77x34 ask-picker delivery path, wrapped wide-character input with prepended live sections, and finalized unknown-tool input metadata.

## Verification

- `./scripts/test.sh ./cli/app ./cli/tui/ongoing`
- `./scripts/test.sh ./server/runtimeview ./server/runtime ./cli/app ./cli/tui/ongoing ./cli/tui/transcriptrender ./server/tools`
- `go test -v ./... -run ^TestUnknownToolExecutionProjectsFinalizedFailedInput$`
- `./scripts/ci-check.sh`
- `./scripts/build.sh --output ./bin/kent`
- `./bin/kent -version` → `2.3.0`

Manual QA used an isolated repo-local server at `127.0.0.1:53090`:

- At 77x34, typed a 100-character draft while model work opened a two-option ask picker.
- Selected an answer without an `invalid_cursor` panic.
- Confirmed the retained draft remained editable and wrapped cleanly after resizing to 24x12.
- Confirmed the failed unknown-tool path retained its exact structured input per the locked input-first transcript contract.

## Diff report

- Total: **+179 net LoC**, **215 gross LoC** (`197 additions`, `18 deletions`)
- Production, non-generated: **-3 net LoC**, **31 gross LoC** (`14 additions`, `17 deletions`)
- Tests: **+182 net LoC**, **184 gross LoC** (`183 additions`, `1 deletion`)
- Generated: **0 LoC**

## Notes and tradeoffs

- `uiViewLayout.inputPaneCursor` remains the authoritative logical-editor-to-terminal-cell projection.
- Surface validation remains fail-fast; this change does not clamp invalid producer output or move validation later.
- Failed tool rows intentionally remain input-first. An unknown tool with empty-object input may display that input with the typed error symbol; changing that behavior requires an explicit transcript-spec decision.
- No production API was widened for tests.

## Technical debt / follow-up

- None required for KENT-251. A broader redesign of unknown-tool presentation, if desired, should be handled as a separate product/spec decision.

## Tracking

- Kent ticket: `KENT-251`
- GitHub issue: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cursor positioning in the ongoing transcript when new content is prepended above the input, preserving correct wrapped cursor targets and row/column mapping.
  * Ensured the ask-option picker keeps the main input cursor absent/invisible during the ask flow.
  * Preserved original input details for tool execution failures and corrected the projected client transcript so failed tool rows render consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
