### PR TITLE
Report logical line counts for whole-file deletions

### DIFF
--- a/.kent/evidence/BUI-23-exact-delete-capture.txt
+++ b/.kent/evidence/BUI-23-exact-delete-capture.txt
@@ -1,0 +1,22 @@
+BUI-23 deterministic exact Delete File capture
+workspace: /var/folders/4y/3b8zshg92kn3ryxd1x2f1rs00000gn/T/bui23-exact-delete-1330433650
+--- pending ---
+*** Begin Patch
+*** Delete File: pending.txt
+*** End Patch
+source_exists_after_capture: true
+tui: ⇄ ./pending.txt
+--- positive ---
+*** Begin Patch
+*** Delete File: populated.txt
+*** End Patch
+source_exists_after_capture: false
+deletion_facts: [{{0} 3}]
+tui: ⇄ ./populated.txt -3
+--- known-zero ---
+*** Begin Patch
+*** Delete File: empty.txt
+*** End Patch
+source_exists_after_capture: false
+deletion_facts: [{{0} 0}]
+tui: ⇄ ./empty.txt -0

--- a/cli/app/session_transcript_controller.go
+++ b/cli/app/session_transcript_controller.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"runtime/debug"
 	"strings"
 
 	"core/cli/tui/ongoing"
@@ -35,12 +36,24 @@ type ongoingTranscriptController struct {
 	queueOverflowed bool
 	renderPending   bool
 	liveReadModel   ongoingTranscriptReadModel
+	debug           bool
+	logf            func(string, ...any)
+}
+
+type ongoingTranscriptControllerOption func(*ongoingTranscriptController)
+
+func withOngoingTranscriptDeveloperDiagnostics(debugMode bool, logf func(string, ...any)) ongoingTranscriptControllerOption {
+	return func(controller *ongoingTranscriptController) {
+		controller.debug = debugMode
+		controller.logf = logf
+	}
 }
 
 func newOngoingTranscriptController(
 	surface ongoingTranscriptSurface,
 	frameProvider ongoingFrameProvider,
 	stateObserver ongoingTranscriptStateObserver,
+	options ...ongoingTranscriptControllerOption,
 ) *ongoingTranscriptController {
 	if frameProvider == nil {
 		panic("ongoing transcript controller requires frame provider")
@@ -48,13 +61,19 @@ func newOngoingTranscriptController(
 	if stateObserver == nil {
 		panic("ongoing transcript controller requires state observer")
 	}
-	return &ongoingTranscriptController{
+	controller := &ongoingTranscriptController{
 		surface:       surface,
 		frameProvider: frameProvider,
 		stateObserver: stateObserver,
 		normalOwned:   true,
 		liveReadModel: newOngoingTranscriptReadModel(),
 	}
+	for _, option := range options {
+		if option != nil {
+			option(controller)
+		}
+	}
+	return controller
 }
 
 func (c *ongoingTranscriptController) Accept(message clientui.TranscriptMessage) (ongoing.Result, tea.Cmd, error) {
@@ -175,17 +194,31 @@ func (c *ongoingTranscriptController) drainQueued() (ongoing.Result, error) {
 			return ongoing.Result{}, err
 		}
 	}
+	diagnostic := developerDiagnosticFromTranscriptMessages(queued)
 	if needsRender {
-		return c.surface.Render(c.frameInput())
+		result, err := c.surface.Render(c.frameInput())
+		if err != nil {
+			return ongoing.Result{}, err
+		}
+		c.consumeDeveloperDiagnostic(diagnostic)
+		return result, nil
 	}
+	c.consumeDeveloperDiagnostic(diagnostic)
 	return ongoing.Result{}, nil
 }
 
 func (c *ongoingTranscriptController) applyNow(message clientui.TranscriptMessage, stateChanged bool) (ongoing.Result, error) {
+	diagnostic := developerDiagnosticFromTranscriptMessage(message)
 	if isAppOwnedOngoingMessage(message.Kind) {
 		if stateChanged {
-			return c.surface.Render(c.frameInput())
+			result, err := c.surface.Render(c.frameInput())
+			if err != nil {
+				return ongoing.Result{}, err
+			}
+			c.consumeDeveloperDiagnostic(diagnostic)
+			return result, nil
 		}
+		c.consumeDeveloperDiagnostic(diagnostic)
 		return ongoing.Result{}, nil
 	}
 	if message.Kind == clientui.TranscriptMessageHydration {
@@ -194,11 +227,99 @@ func (c *ongoingTranscriptController) applyNow(message clientui.TranscriptMessag
 			return ongoing.Result{}, err
 		}
 		if stateChanged && hydrationHasNoTerminalRows(message.Payload.Hydration) {
-			return c.surface.Render(c.frameInput())
+			result, err = c.surface.Render(c.frameInput())
+			if err != nil {
+				return ongoing.Result{}, err
+			}
 		}
+		c.consumeDeveloperDiagnostic(diagnostic)
 		return result, nil
 	}
-	return c.surface.ApplyTerminalMessage(message, c.frameInput())
+	result, err := c.surface.ApplyTerminalMessage(message, c.frameInput())
+	if err != nil {
+		return ongoing.Result{}, err
+	}
+	c.consumeDeveloperDiagnostic(diagnostic)
+	return result, nil
+}
+
+type ongoingTranscriptDeveloperDiagnosticError struct {
+	Diagnostic transcript.DeveloperDiagnostic
+	Stack      string
+}
+
+func (e ongoingTranscriptDeveloperDiagnosticError) Error() string {
+	context := e.Diagnostic.DeletionFactMismatch
+	if context == nil {
+		return fmt.Sprintf(
+			"ongoing transcript developer diagnostic: kind=%s detail=%q\n%s",
+			e.Diagnostic.Kind(),
+			transcript.DeveloperDiagnosticText(e.Diagnostic),
+			e.Stack,
+		)
+	}
+	return fmt.Sprintf(
+		"ongoing transcript developer diagnostic: kind=%s call_id=%q hunk_ordinal=%d mismatch=%s detail=%q\n%s",
+		e.Diagnostic.Kind(),
+		context.CallID,
+		context.OperationID.HunkOrdinal,
+		context.MismatchKind,
+		transcript.DeveloperDiagnosticText(e.Diagnostic),
+		e.Stack,
+	)
+}
+
+func (c *ongoingTranscriptController) consumeDeveloperDiagnostic(diagnostic *transcript.DeveloperDiagnostic) {
+	if diagnostic == nil {
+		return
+	}
+	err := ongoingTranscriptDeveloperDiagnosticError{
+		Diagnostic: *transcript.CloneDeveloperDiagnostic(diagnostic),
+		Stack:      string(debug.Stack()),
+	}
+	if c.logf != nil {
+		c.logf("%s", err.Error())
+	}
+	if c.debug {
+		panic(err)
+	}
+}
+
+func developerDiagnosticFromTranscriptMessages(messages []clientui.TranscriptMessage) *transcript.DeveloperDiagnostic {
+	for _, message := range messages {
+		if diagnostic := developerDiagnosticFromTranscriptMessage(message); diagnostic != nil {
+			return diagnostic
+		}
+	}
+	return nil
+}
+
+func developerDiagnosticFromTranscriptMessage(message clientui.TranscriptMessage) *transcript.DeveloperDiagnostic {
+	if message.Kind == clientui.TranscriptMessageCommittedRow {
+		return developerDiagnosticFromCommittedRow(message.Payload.CommittedRow)
+	}
+	if message.Kind != clientui.TranscriptMessageHydration || message.Payload.Hydration == nil {
+		return nil
+	}
+	for index := range message.Payload.Hydration.CommittedRows {
+		if diagnostic := developerDiagnosticFromCommittedRow(&message.Payload.Hydration.CommittedRows[index]); diagnostic != nil {
+			return diagnostic
+		}
+	}
+	return nil
+}
+
+func developerDiagnosticFromCommittedRow(row *clientui.TranscriptCommittedRow) *transcript.DeveloperDiagnostic {
+	if row == nil || row.Notice == nil || row.Notice.Diagnostic == nil {
+		return nil
+	}
+	diagnostic := row.Notice.Diagnostic.Developer
+	if diagnostic == nil ||
+		diagnostic.Kind() != transcript.DeveloperDiagnosticDeletionFactMismatch ||
+		diagnostic.Validate() != nil {
+		return nil
+	}
+	return transcript.CloneDeveloperDiagnostic(diagnostic)
 }
 
 func (c *ongoingTranscriptController) applyState(message clientui.TranscriptMessage) bool {

--- a/cli/app/session_transcript_controller.go
+++ b/cli/app/session_transcript_controller.go
@@ -194,31 +194,31 @@ func (c *ongoingTranscriptController) drainQueued() (ongoing.Result, error) {
 			return ongoing.Result{}, err
 		}
 	}
-	diagnostic := developerDiagnosticFromTranscriptMessages(queued)
+	diagnostics := developerDiagnosticsFromTranscriptMessages(queued)
 	if needsRender {
 		result, err := c.surface.Render(c.frameInput())
 		if err != nil {
 			return ongoing.Result{}, err
 		}
-		c.consumeDeveloperDiagnostic(diagnostic)
+		c.consumeDeveloperDiagnostics(diagnostics)
 		return result, nil
 	}
-	c.consumeDeveloperDiagnostic(diagnostic)
+	c.consumeDeveloperDiagnostics(diagnostics)
 	return ongoing.Result{}, nil
 }
 
 func (c *ongoingTranscriptController) applyNow(message clientui.TranscriptMessage, stateChanged bool) (ongoing.Result, error) {
-	diagnostic := developerDiagnosticFromTranscriptMessage(message)
+	diagnostics := developerDiagnosticsFromTranscriptMessage(message)
 	if isAppOwnedOngoingMessage(message.Kind) {
 		if stateChanged {
 			result, err := c.surface.Render(c.frameInput())
 			if err != nil {
 				return ongoing.Result{}, err
 			}
-			c.consumeDeveloperDiagnostic(diagnostic)
+			c.consumeDeveloperDiagnostics(diagnostics)
 			return result, nil
 		}
-		c.consumeDeveloperDiagnostic(diagnostic)
+		c.consumeDeveloperDiagnostics(diagnostics)
 		return ongoing.Result{}, nil
 	}
 	if message.Kind == clientui.TranscriptMessageHydration {
@@ -232,14 +232,14 @@ func (c *ongoingTranscriptController) applyNow(message clientui.TranscriptMessag
 				return ongoing.Result{}, err
 			}
 		}
-		c.consumeDeveloperDiagnostic(diagnostic)
+		c.consumeDeveloperDiagnostics(diagnostics)
 		return result, nil
 	}
 	result, err := c.surface.ApplyTerminalMessage(message, c.frameInput())
 	if err != nil {
 		return ongoing.Result{}, err
 	}
-	c.consumeDeveloperDiagnostic(diagnostic)
+	c.consumeDeveloperDiagnostics(diagnostics)
 	return result, nil
 }
 
@@ -249,18 +249,26 @@ type ongoingTranscriptDeveloperDiagnosticError struct {
 }
 
 func (e ongoingTranscriptDeveloperDiagnosticError) Error() string {
+	kind, present := e.Diagnostic.Kind()
+	if !present {
+		return fmt.Sprintf(
+			"ongoing transcript developer diagnostic: invalid variant detail=%q\n%s",
+			transcript.DeveloperDiagnosticText(e.Diagnostic),
+			e.Stack,
+		)
+	}
 	context := e.Diagnostic.DeletionFactMismatch
 	if context == nil {
 		return fmt.Sprintf(
 			"ongoing transcript developer diagnostic: kind=%s detail=%q\n%s",
-			e.Diagnostic.Kind(),
+			kind,
 			transcript.DeveloperDiagnosticText(e.Diagnostic),
 			e.Stack,
 		)
 	}
 	return fmt.Sprintf(
 		"ongoing transcript developer diagnostic: kind=%s call_id=%q hunk_ordinal=%d mismatch=%s detail=%q\n%s",
-		e.Diagnostic.Kind(),
+		kind,
 		context.CallID,
 		context.OperationID.HunkOrdinal,
 		context.MismatchKind,
@@ -269,44 +277,50 @@ func (e ongoingTranscriptDeveloperDiagnosticError) Error() string {
 	)
 }
 
-func (c *ongoingTranscriptController) consumeDeveloperDiagnostic(diagnostic *transcript.DeveloperDiagnostic) {
-	if diagnostic == nil {
-		return
-	}
-	err := ongoingTranscriptDeveloperDiagnosticError{
-		Diagnostic: *transcript.CloneDeveloperDiagnostic(diagnostic),
-		Stack:      string(debug.Stack()),
-	}
-	if c.logf != nil {
-		c.logf("%s", err.Error())
-	}
-	if c.debug {
-		panic(err)
-	}
-}
-
-func developerDiagnosticFromTranscriptMessages(messages []clientui.TranscriptMessage) *transcript.DeveloperDiagnostic {
-	for _, message := range messages {
-		if diagnostic := developerDiagnosticFromTranscriptMessage(message); diagnostic != nil {
-			return diagnostic
+func (c *ongoingTranscriptController) consumeDeveloperDiagnostics(diagnostics []transcript.DeveloperDiagnostic) {
+	var panicError *ongoingTranscriptDeveloperDiagnosticError
+	for index := range diagnostics {
+		err := ongoingTranscriptDeveloperDiagnosticError{
+			Diagnostic: *transcript.CloneDeveloperDiagnostic(&diagnostics[index]),
+			Stack:      string(debug.Stack()),
+		}
+		if c.logf != nil {
+			c.logf("%s", err.Error())
+		}
+		if panicError == nil {
+			panicError = &err
 		}
 	}
-	return nil
+	if c.debug && panicError != nil {
+		panic(*panicError)
+	}
 }
 
-func developerDiagnosticFromTranscriptMessage(message clientui.TranscriptMessage) *transcript.DeveloperDiagnostic {
+func developerDiagnosticsFromTranscriptMessages(messages []clientui.TranscriptMessage) []transcript.DeveloperDiagnostic {
+	var diagnostics []transcript.DeveloperDiagnostic
+	for _, message := range messages {
+		diagnostics = append(diagnostics, developerDiagnosticsFromTranscriptMessage(message)...)
+	}
+	return diagnostics
+}
+
+func developerDiagnosticsFromTranscriptMessage(message clientui.TranscriptMessage) []transcript.DeveloperDiagnostic {
 	if message.Kind == clientui.TranscriptMessageCommittedRow {
-		return developerDiagnosticFromCommittedRow(message.Payload.CommittedRow)
+		if diagnostic := developerDiagnosticFromCommittedRow(message.Payload.CommittedRow); diagnostic != nil {
+			return []transcript.DeveloperDiagnostic{*diagnostic}
+		}
+		return nil
 	}
 	if message.Kind != clientui.TranscriptMessageHydration || message.Payload.Hydration == nil {
 		return nil
 	}
+	var diagnostics []transcript.DeveloperDiagnostic
 	for index := range message.Payload.Hydration.CommittedRows {
 		if diagnostic := developerDiagnosticFromCommittedRow(&message.Payload.Hydration.CommittedRows[index]); diagnostic != nil {
-			return diagnostic
+			diagnostics = append(diagnostics, *diagnostic)
 		}
 	}
-	return nil
+	return diagnostics
 }
 
 func developerDiagnosticFromCommittedRow(row *clientui.TranscriptCommittedRow) *transcript.DeveloperDiagnostic {
@@ -314,9 +328,11 @@ func developerDiagnosticFromCommittedRow(row *clientui.TranscriptCommittedRow) *
 		return nil
 	}
 	diagnostic := row.Notice.Diagnostic.Developer
-	if diagnostic == nil ||
-		diagnostic.Kind() != transcript.DeveloperDiagnosticDeletionFactMismatch ||
-		diagnostic.Validate() != nil {
+	if diagnostic == nil || diagnostic.Validate() != nil {
+		return nil
+	}
+	kind, present := diagnostic.Kind()
+	if !present || kind != transcript.DeveloperDiagnosticDeletionFactMismatch {
 		return nil
 	}
 	return transcript.CloneDeveloperDiagnostic(diagnostic)

--- a/cli/app/session_transcript_controller_test.go
+++ b/cli/app/session_transcript_controller_test.go
@@ -605,9 +605,11 @@ func ongoingDeveloperDiagnosticMessageForCall(sequence uint64, callID string, hu
 		Integrity:  transcript.RowIntegrityValid,
 		Kind:       clientui.TranscriptRowNotice,
 		Notice: &clientui.TranscriptNoticeRow{
-			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
-			Severity:   clientui.TranscriptNoticeError,
-			Diagnostic: clientui.NewDeveloperTranscriptDiagnostic(diagnostic),
+			Reason:   clientui.TranscriptNoticeRuntimeDiagnostic,
+			Severity: clientui.TranscriptNoticeError,
+			Diagnostic: &clientui.TranscriptDiagnostic{
+				Developer: transcript.CloneDeveloperDiagnostic(&diagnostic),
+			},
 		},
 	}
 	return clientui.TranscriptMessage{

--- a/cli/app/session_transcript_controller_test.go
+++ b/cli/app/session_transcript_controller_test.go
@@ -253,6 +253,136 @@ func TestOngoingTranscriptControllerDebugPanicsForQueuedDeveloperDiagnosticAfter
 	_, _ = controller.SetNormalBufferOwned(true)
 }
 
+func TestOngoingTranscriptControllerConsumesEveryHydratedAndQueuedDeveloperDiagnostic(t *testing.T) {
+	t.Run("hydration", func(t *testing.T) {
+		surface := &ongoingSurfaceSpy{}
+		loggedAfterApply := 0
+		controller := newOngoingTranscriptController(
+			surface,
+			ongoingTestFrameProvider,
+			func(clientui.TranscriptMessage) tea.Cmd { return nil },
+			withOngoingTranscriptDeveloperDiagnostics(false, func(string, ...any) {
+				if got := surface.callKinds(); reflect.DeepEqual(got, []string{"apply"}) {
+					loggedAfterApply++
+				}
+			}),
+		)
+		hydration := ongoingHydrationMessage(1)
+		hydration.Payload.Hydration.CommittedRows = []clientui.TranscriptCommittedRow{
+			*ongoingDeveloperDiagnosticMessageForCall(1, "call-1", 0).Payload.CommittedRow,
+			*ongoingDeveloperDiagnosticMessageForCall(1, "call-2", 1).Payload.CommittedRow,
+		}
+
+		if _, _, err := controller.Accept(hydration); err != nil {
+			t.Fatalf("accept hydration: %v", err)
+		}
+		if loggedAfterApply != 2 {
+			t.Fatalf("diagnostics logged after terminal apply = %d, want 2", loggedAfterApply)
+		}
+	})
+
+	t.Run("queue", func(t *testing.T) {
+		surface := &ongoingSurfaceSpy{}
+		loggedAfterApply := 0
+		controller := newOngoingTranscriptController(
+			surface,
+			ongoingTestFrameProvider,
+			func(clientui.TranscriptMessage) tea.Cmd { return nil },
+			withOngoingTranscriptDeveloperDiagnostics(false, func(string, ...any) {
+				if got := surface.callKinds(); reflect.DeepEqual(got, []string{"apply", "apply"}) {
+					loggedAfterApply++
+				}
+			}),
+		)
+		if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+			t.Fatalf("accept hydration: %v", err)
+		}
+		surface.calls = nil
+		if _, err := controller.SetNormalBufferOwned(false); err != nil {
+			t.Fatalf("mark unowned: %v", err)
+		}
+		for sequence, callID := range []string{"call-1", "call-2"} {
+			message := ongoingDeveloperDiagnosticMessageForCall(uint64(sequence+2), callID, sequence)
+			if _, _, err := controller.Accept(message); err != nil {
+				t.Fatalf("queue diagnostic %d: %v", sequence, err)
+			}
+		}
+
+		if _, err := controller.SetNormalBufferOwned(true); err != nil {
+			t.Fatalf("restore ownership: %v", err)
+		}
+		if loggedAfterApply != 2 {
+			t.Fatalf("queued diagnostics logged after terminal apply = %d, want 2", loggedAfterApply)
+		}
+	})
+}
+
+func TestOngoingTranscriptControllerDebugLogsEveryDiagnosticBeforePanicking(t *testing.T) {
+	tests := []struct {
+		name           string
+		wantApplyCalls int
+		apply          func(*testing.T, *ongoingTranscriptController)
+	}{
+		{
+			name:           "hydration",
+			wantApplyCalls: 1,
+			apply: func(t *testing.T, controller *ongoingTranscriptController) {
+				hydration := ongoingHydrationMessage(1)
+				hydration.Payload.Hydration.CommittedRows = []clientui.TranscriptCommittedRow{
+					*ongoingDeveloperDiagnosticMessageForCall(1, "call-1", 0).Payload.CommittedRow,
+					*ongoingDeveloperDiagnosticMessageForCall(1, "call-2", 1).Payload.CommittedRow,
+				}
+				_, _, _ = controller.Accept(hydration)
+			},
+		},
+		{
+			name:           "queue",
+			wantApplyCalls: 3,
+			apply: func(t *testing.T, controller *ongoingTranscriptController) {
+				if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+					t.Fatalf("accept hydration: %v", err)
+				}
+				if _, err := controller.SetNormalBufferOwned(false); err != nil {
+					t.Fatalf("mark unowned: %v", err)
+				}
+				for sequence, callID := range []string{"call-1", "call-2"} {
+					message := ongoingDeveloperDiagnosticMessageForCall(uint64(sequence+2), callID, sequence)
+					if _, _, err := controller.Accept(message); err != nil {
+						t.Fatalf("queue diagnostic %d: %v", sequence, err)
+					}
+				}
+				_, _ = controller.SetNormalBufferOwned(true)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			surface := &ongoingSurfaceSpy{}
+			logCount := 0
+			controller := newOngoingTranscriptController(
+				surface,
+				ongoingTestFrameProvider,
+				func(clientui.TranscriptMessage) tea.Cmd { return nil },
+				withOngoingTranscriptDeveloperDiagnostics(true, func(string, ...any) {
+					logCount++
+				}),
+			)
+			defer func() {
+				if _, ok := recover().(ongoingTranscriptDeveloperDiagnosticError); !ok {
+					t.Fatal("multiple diagnostics did not panic with typed context")
+				}
+				if logCount != 2 {
+					t.Fatalf("diagnostics logged before panic = %d, want 2", logCount)
+				}
+				if got := len(surface.callKinds()); got != test.wantApplyCalls {
+					t.Fatalf("surface apply calls before panic = %d, want %d", got, test.wantApplyCalls)
+				}
+			}()
+			test.apply(t, controller)
+		})
+	}
+}
+
 func TestOngoingTranscriptControllerDrainsQueuedAssistantFinalizationAfterDetail(t *testing.T) {
 	surface := &ongoingSurfaceSpy{}
 	controller := newTestOngoingTranscriptController(surface, ongoingTestFrameProvider)
@@ -459,11 +589,15 @@ func newNoopOngoingTranscriptController(surface ongoingTranscriptSurface, frameP
 }
 
 func ongoingDeveloperDiagnosticMessage(sequence uint64) clientui.TranscriptMessage {
+	return ongoingDeveloperDiagnosticMessageForCall(sequence, "call-1", 0)
+}
+
+func ongoingDeveloperDiagnosticMessageForCall(sequence uint64, callID string, hunkOrdinal int) clientui.TranscriptMessage {
 	diagnostic := transcript.NewDeletionFactMismatchDeveloperDiagnostic(
-		"call-1",
+		callID,
 		patchformat.WholeFileDeletionFactMismatchError{
 			Kind: patchformat.WholeFileDeletionFactMismatchMissing,
-			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: hunkOrdinal},
 		},
 	)
 	row := clientui.TranscriptCommittedRow{
@@ -473,7 +607,7 @@ func ongoingDeveloperDiagnosticMessage(sequence uint64) clientui.TranscriptMessa
 		Notice: &clientui.TranscriptNoticeRow{
 			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:   clientui.TranscriptNoticeError,
-			Diagnostic: &clientui.TranscriptDiagnostic{Developer: &diagnostic},
+			Diagnostic: clientui.NewDeveloperTranscriptDiagnostic(diagnostic),
 		},
 	}
 	return clientui.TranscriptMessage{

--- a/cli/app/session_transcript_controller_test.go
+++ b/cli/app/session_transcript_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"core/shared/clientui"
 	"core/shared/runtimeids"
 	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -139,6 +140,117 @@ func TestOngoingTranscriptControllerLeavesUserMessageFlushPresentationToStateObs
 	if got, want := surface.callKinds(), []string{"render"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("surface calls = %v, want %v", got, want)
 	}
+}
+
+func TestOngoingTranscriptControllerLogsDeveloperDiagnosticAfterTerminalApply(t *testing.T) {
+	surface := &ongoingSurfaceSpy{}
+	loggedAfterApply := false
+	controller := newOngoingTranscriptController(
+		surface,
+		ongoingTestFrameProvider,
+		func(clientui.TranscriptMessage) tea.Cmd { return nil },
+		withOngoingTranscriptDeveloperDiagnostics(false, func(string, ...any) {
+			loggedAfterApply = reflect.DeepEqual(surface.callKinds(), []string{"apply"})
+		}),
+	)
+	if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+		t.Fatalf("accept hydration: %v", err)
+	}
+	surface.calls = nil
+	if _, _, err := controller.Accept(ongoingDeveloperDiagnosticMessage(2)); err != nil {
+		t.Fatalf("accept developer diagnostic: %v", err)
+	}
+	if !loggedAfterApply {
+		t.Fatal("developer diagnostic was not logged after terminal application")
+	}
+}
+
+func TestOngoingTranscriptControllerDebugPanicsForDeveloperDiagnosticAfterTerminalApply(t *testing.T) {
+	surface := &ongoingSurfaceSpy{}
+	controller := newOngoingTranscriptController(
+		surface,
+		ongoingTestFrameProvider,
+		func(clientui.TranscriptMessage) tea.Cmd { return nil },
+		withOngoingTranscriptDeveloperDiagnostics(true, func(string, ...any) {}),
+	)
+	if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+		t.Fatalf("accept hydration: %v", err)
+	}
+	surface.calls = nil
+	defer func() {
+		if _, ok := recover().(ongoingTranscriptDeveloperDiagnosticError); !ok {
+			t.Fatal("developer diagnostic did not panic with typed context in debug mode")
+		}
+		if got := surface.callKinds(); !reflect.DeepEqual(got, []string{"apply"}) {
+			t.Fatalf("surface calls = %v, want terminal application before panic", got)
+		}
+	}()
+	_, _, _ = controller.Accept(ongoingDeveloperDiagnosticMessage(2))
+}
+
+func TestOngoingTranscriptControllerDebugPanicsForHydratedDeveloperDiagnosticAfterTerminalApply(t *testing.T) {
+	surface := &ongoingSurfaceSpy{}
+	controller := newOngoingTranscriptController(
+		surface,
+		ongoingTestFrameProvider,
+		func(clientui.TranscriptMessage) tea.Cmd { return nil },
+		withOngoingTranscriptDeveloperDiagnostics(true, func(string, ...any) {}),
+	)
+	hydration := ongoingHydrationMessage(1)
+	hydration.Payload.Hydration.CommittedRows = []clientui.TranscriptCommittedRow{
+		*ongoingDeveloperDiagnosticMessage(1).Payload.CommittedRow,
+		*ongoingTranscriptMessage(2, clientui.TranscriptMessageCommittedRow).Payload.CommittedRow,
+	}
+
+	defer func() {
+		if _, ok := recover().(ongoingTranscriptDeveloperDiagnosticError); !ok {
+			t.Fatal("hydrated developer diagnostic did not panic with typed context in debug mode")
+		}
+		if got := surface.callKinds(); !reflect.DeepEqual(got, []string{"apply"}) {
+			t.Fatalf("surface calls = %v, want terminal application before panic", got)
+		}
+		rows := surface.calls[0].message.Payload.Hydration.CommittedRows
+		if len(rows) != 2 || rows[1].Kind != clientui.TranscriptRowUser {
+			t.Fatalf("applied hydration rows = %+v, want diagnostic followed by user row", rows)
+		}
+	}()
+	_, _, _ = controller.Accept(hydration)
+}
+
+func TestOngoingTranscriptControllerDebugPanicsForQueuedDeveloperDiagnosticAfterTerminalApply(t *testing.T) {
+	surface := &ongoingSurfaceSpy{}
+	controller := newOngoingTranscriptController(
+		surface,
+		ongoingTestFrameProvider,
+		func(clientui.TranscriptMessage) tea.Cmd { return nil },
+		withOngoingTranscriptDeveloperDiagnostics(true, func(string, ...any) {}),
+	)
+	if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+		t.Fatalf("accept hydration: %v", err)
+	}
+	surface.calls = nil
+	if _, err := controller.SetNormalBufferOwned(false); err != nil {
+		t.Fatalf("mark unowned: %v", err)
+	}
+	if _, _, err := controller.Accept(ongoingDeveloperDiagnosticMessage(2)); err != nil {
+		t.Fatalf("queue developer diagnostic: %v", err)
+	}
+	if _, _, err := controller.Accept(ongoingTranscriptMessage(3, clientui.TranscriptMessageCommittedRow)); err != nil {
+		t.Fatalf("queue trailing terminal row: %v", err)
+	}
+
+	defer func() {
+		if _, ok := recover().(ongoingTranscriptDeveloperDiagnosticError); !ok {
+			t.Fatal("queued developer diagnostic did not panic with typed context in debug mode")
+		}
+		if got := surface.callKinds(); !reflect.DeepEqual(got, []string{"apply", "apply"}) {
+			t.Fatalf("surface calls = %v, want all queued terminal applications before panic", got)
+		}
+		if row := surface.calls[1].message.Payload.CommittedRow; row == nil || row.Kind != clientui.TranscriptRowUser {
+			t.Fatalf("trailing terminal row = %+v, want user row", row)
+		}
+	}()
+	_, _ = controller.SetNormalBufferOwned(true)
 }
 
 func TestOngoingTranscriptControllerDrainsQueuedAssistantFinalizationAfterDetail(t *testing.T) {
@@ -344,6 +456,31 @@ func newNoopOngoingTranscriptController(surface ongoingTranscriptSurface, frameP
 	return newOngoingTranscriptController(surface, frameProvider, func(clientui.TranscriptMessage) tea.Cmd {
 		return nil
 	})
+}
+
+func ongoingDeveloperDiagnosticMessage(sequence uint64) clientui.TranscriptMessage {
+	diagnostic := transcript.NewDeletionFactMismatchDeveloperDiagnostic(
+		"call-1",
+		patchformat.WholeFileDeletionFactMismatchError{
+			Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+		},
+	)
+	row := clientui.TranscriptCommittedRow{
+		Visibility: transcript.EntryVisibilityOngoing,
+		Integrity:  transcript.RowIntegrityValid,
+		Kind:       clientui.TranscriptRowNotice,
+		Notice: &clientui.TranscriptNoticeRow{
+			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
+			Severity:   clientui.TranscriptNoticeError,
+			Diagnostic: &clientui.TranscriptDiagnostic{Developer: &diagnostic},
+		},
+	}
+	return clientui.TranscriptMessage{
+		Sequence: sequence,
+		Kind:     clientui.TranscriptMessageCommittedRow,
+		Payload:  clientui.TranscriptPayload{CommittedRow: &row},
+	}
 }
 
 func (c *testOngoingTranscriptController) Accept(message clientui.TranscriptMessage) (ongoing.Result, error) {

--- a/cli/app/ui_loop.go
+++ b/cli/app/ui_loop.go
@@ -153,6 +153,7 @@ func composeUIProgram(request uiLoopRequest, output io.Writer) (*uiProgramCompos
 		ongoingSurface,
 		model.ongoingFrameInput,
 		model.applyTranscriptMessageState,
+		withOngoingTranscriptDeveloperDiagnostics(model.debugMode, model.logf),
 	)
 	return &uiProgramComposition{
 		model:   model,

--- a/cli/app/ui_worktree_reducer.go
+++ b/cli/app/ui_worktree_reducer.go
@@ -18,12 +18,11 @@ func (m *uiModel) reconcileTranscriptWorktreeTransitionOutcome(outcome clientui.
 	}
 	var statusCmd tea.Cmd
 	if outcome.State == clientui.WorktreeTransitionFailed {
-		_, diagnostic, legacy := outcome.Failure.Legacy()
-		if !legacy {
+		if outcome.Failure == nil || outcome.Failure.Detail == nil {
 			panic("failed worktree transition is missing its legacy diagnostic")
 		}
 		statusCmd = m.sendTransientStatusWithNoticeID(
-			diagnostic,
+			*outcome.Failure.Detail,
 			uiStatusNoticeError,
 			transientStatusDuration,
 			uiStatusNoticeReplace,

--- a/cli/app/ui_worktree_reducer.go
+++ b/cli/app/ui_worktree_reducer.go
@@ -18,8 +18,12 @@ func (m *uiModel) reconcileTranscriptWorktreeTransitionOutcome(outcome clientui.
 	}
 	var statusCmd tea.Cmd
 	if outcome.State == clientui.WorktreeTransitionFailed {
+		_, diagnostic, legacy := outcome.Failure.Legacy()
+		if !legacy {
+			panic("failed worktree transition is missing its legacy diagnostic")
+		}
 		statusCmd = m.sendTransientStatusWithNoticeID(
-			outcome.Failure.Detail,
+			diagnostic,
 			uiStatusNoticeError,
 			transientStatusDuration,
 			uiStatusNoticeReplace,

--- a/cli/tui/model_detail_performance_test.go
+++ b/cli/tui/model_detail_performance_test.go
@@ -302,12 +302,12 @@ func detailPerformanceVisibleTail() []clientui.TranscriptCommittedRow {
 		detailNotice(clientui.TranscriptNoticeRow{
 			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:   clientui.TranscriptNoticeInfo,
-			Diagnostic: &clientui.TranscriptDiagnostic{Detail: "tail diagnostic one"},
+			Diagnostic: clientui.NewLegacyTranscriptDiagnostic("tail_diagnostic", "tail diagnostic one"),
 		}),
 		detailNotice(clientui.TranscriptNoticeRow{
 			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:   clientui.TranscriptNoticeInfo,
-			Diagnostic: &clientui.TranscriptDiagnostic{Detail: "tail diagnostic two"},
+			Diagnostic: clientui.NewLegacyTranscriptDiagnostic("tail_diagnostic", "tail diagnostic two"),
 		}),
 		{
 			Visibility: clientui.EntryVisibilityOngoing,

--- a/cli/tui/model_detail_performance_test.go
+++ b/cli/tui/model_detail_performance_test.go
@@ -302,12 +302,12 @@ func detailPerformanceVisibleTail() []clientui.TranscriptCommittedRow {
 		detailNotice(clientui.TranscriptNoticeRow{
 			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:   clientui.TranscriptNoticeInfo,
-			Diagnostic: clientui.NewLegacyTranscriptDiagnostic("tail_diagnostic", "tail diagnostic one"),
+			Diagnostic: legacyTranscriptDiagnosticForTest("tail_diagnostic", "tail diagnostic one"),
 		}),
 		detailNotice(clientui.TranscriptNoticeRow{
 			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:   clientui.TranscriptNoticeInfo,
-			Diagnostic: clientui.NewLegacyTranscriptDiagnostic("tail_diagnostic", "tail diagnostic two"),
+			Diagnostic: legacyTranscriptDiagnosticForTest("tail_diagnostic", "tail diagnostic two"),
 		}),
 		{
 			Visibility: clientui.EntryVisibilityOngoing,

--- a/cli/tui/model_detail_performance_test.go
+++ b/cli/tui/model_detail_performance_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"core/internal/testharness/clientuitest"
+	"core/internal/testharness/testsetup"
 	"core/shared/clientui"
 	"core/shared/transcript"
 	patchformat "core/shared/transcript/patchformat"
@@ -303,12 +303,12 @@ func detailPerformanceVisibleTail() []clientui.TranscriptCommittedRow {
 		detailNotice(clientui.TranscriptNoticeRow{
 			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:   clientui.TranscriptNoticeInfo,
-			Diagnostic: clientuitest.LegacyTranscriptDiagnostic("tail_diagnostic", "tail diagnostic one"),
+			Diagnostic: testsetup.LegacyTranscriptDiagnostic("tail_diagnostic", "tail diagnostic one"),
 		}),
 		detailNotice(clientui.TranscriptNoticeRow{
 			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:   clientui.TranscriptNoticeInfo,
-			Diagnostic: clientuitest.LegacyTranscriptDiagnostic("tail_diagnostic", "tail diagnostic two"),
+			Diagnostic: testsetup.LegacyTranscriptDiagnostic("tail_diagnostic", "tail diagnostic two"),
 		}),
 		{
 			Visibility: clientui.EntryVisibilityOngoing,

--- a/cli/tui/model_detail_performance_test.go
+++ b/cli/tui/model_detail_performance_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"core/internal/testharness/clientuitest"
 	"core/shared/clientui"
 	"core/shared/transcript"
 	patchformat "core/shared/transcript/patchformat"
@@ -302,12 +303,12 @@ func detailPerformanceVisibleTail() []clientui.TranscriptCommittedRow {
 		detailNotice(clientui.TranscriptNoticeRow{
 			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:   clientui.TranscriptNoticeInfo,
-			Diagnostic: legacyTranscriptDiagnosticForTest("tail_diagnostic", "tail diagnostic one"),
+			Diagnostic: clientuitest.LegacyTranscriptDiagnostic("tail_diagnostic", "tail diagnostic one"),
 		}),
 		detailNotice(clientui.TranscriptNoticeRow{
 			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:   clientui.TranscriptNoticeInfo,
-			Diagnostic: legacyTranscriptDiagnosticForTest("tail_diagnostic", "tail diagnostic two"),
+			Diagnostic: clientuitest.LegacyTranscriptDiagnostic("tail_diagnostic", "tail diagnostic two"),
 		}),
 		{
 			Visibility: clientui.EntryVisibilityOngoing,

--- a/cli/tui/model_detail_test.go
+++ b/cli/tui/model_detail_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"core/cli/tui/transcriptrender"
-	"core/internal/testharness/clientuitest"
+	"core/internal/testharness/testsetup"
 	"core/shared/clientui"
 	"core/shared/rollbacktarget"
 	"core/shared/transcript"
@@ -265,7 +265,7 @@ func TestDetailModeCachedRowsPreserveVisibility(t *testing.T) {
 		Reason:       clientui.TranscriptNoticeRuntimeDiagnostic,
 		Severity:     clientui.TranscriptNoticeInfo,
 		CompactLabel: &compactNotice,
-		Diagnostic: clientuitest.LegacyTranscriptDiagnostic(
+		Diagnostic: testsetup.LegacyTranscriptDiagnostic(
 			"detail_cache_test",
 			"diagnostic detail",
 		),
@@ -540,7 +540,7 @@ func TestDetailReviewerRowsPreserveDiagnosticCodes(t *testing.T) {
 				Severity:     clientui.TranscriptNoticeInfo,
 				MessageType:  &messageType,
 				CompactLabel: &compactLabel,
-				Diagnostic: clientuitest.LegacyTranscriptDiagnostic(
+				Diagnostic: testsetup.LegacyTranscriptDiagnostic(
 					clientui.TranscriptDiagnosticCode(role),
 					"review result",
 				),

--- a/cli/tui/model_detail_test.go
+++ b/cli/tui/model_detail_test.go
@@ -264,7 +264,7 @@ func TestDetailModeCachedRowsPreserveVisibility(t *testing.T) {
 		Reason:       clientui.TranscriptNoticeRuntimeDiagnostic,
 		Severity:     clientui.TranscriptNoticeInfo,
 		CompactLabel: &compactNotice,
-		Diagnostic: clientui.NewLegacyTranscriptDiagnostic(
+		Diagnostic: legacyTranscriptDiagnosticForTest(
 			"detail_cache_test",
 			"diagnostic detail",
 		),
@@ -539,7 +539,7 @@ func TestDetailReviewerRowsPreserveDiagnosticCodes(t *testing.T) {
 				Severity:     clientui.TranscriptNoticeInfo,
 				MessageType:  &messageType,
 				CompactLabel: &compactLabel,
-				Diagnostic: clientui.NewLegacyTranscriptDiagnostic(
+				Diagnostic: legacyTranscriptDiagnosticForTest(
 					clientui.TranscriptDiagnosticCode(role),
 					"review result",
 				),
@@ -551,10 +551,14 @@ func TestDetailReviewerRowsPreserveDiagnosticCodes(t *testing.T) {
 			if row.Notice == nil || row.Notice.Diagnostic == nil {
 				t.Fatalf("reviewer row = %+v", row)
 			}
-			code, _, legacy := row.Notice.Diagnostic.Legacy()
-			if !legacy || code != clientui.TranscriptDiagnosticCode(role) {
-				t.Fatalf("reviewer diagnostic code = %q legacy=%t, want %q", code, legacy, role)
+			if row.Notice.Diagnostic.Code == nil ||
+				*row.Notice.Diagnostic.Code != clientui.TranscriptDiagnosticCode(role) {
+				t.Fatalf("reviewer diagnostic = %+v, want code %q", row.Notice.Diagnostic, role)
 			}
 		})
 	}
+}
+
+func legacyTranscriptDiagnosticForTest(code clientui.TranscriptDiagnosticCode, detail string) *clientui.TranscriptDiagnostic {
+	return &clientui.TranscriptDiagnostic{Code: &code, Detail: &detail}
 }

--- a/cli/tui/model_detail_test.go
+++ b/cli/tui/model_detail_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"core/cli/tui/transcriptrender"
+	"core/internal/testharness/clientuitest"
 	"core/shared/clientui"
 	"core/shared/rollbacktarget"
 	"core/shared/transcript"
@@ -264,7 +265,7 @@ func TestDetailModeCachedRowsPreserveVisibility(t *testing.T) {
 		Reason:       clientui.TranscriptNoticeRuntimeDiagnostic,
 		Severity:     clientui.TranscriptNoticeInfo,
 		CompactLabel: &compactNotice,
-		Diagnostic: legacyTranscriptDiagnosticForTest(
+		Diagnostic: clientuitest.LegacyTranscriptDiagnostic(
 			"detail_cache_test",
 			"diagnostic detail",
 		),
@@ -539,7 +540,7 @@ func TestDetailReviewerRowsPreserveDiagnosticCodes(t *testing.T) {
 				Severity:     clientui.TranscriptNoticeInfo,
 				MessageType:  &messageType,
 				CompactLabel: &compactLabel,
-				Diagnostic: legacyTranscriptDiagnosticForTest(
+				Diagnostic: clientuitest.LegacyTranscriptDiagnostic(
 					clientui.TranscriptDiagnosticCode(role),
 					"review result",
 				),
@@ -557,8 +558,4 @@ func TestDetailReviewerRowsPreserveDiagnosticCodes(t *testing.T) {
 			}
 		})
 	}
-}
-
-func legacyTranscriptDiagnosticForTest(code clientui.TranscriptDiagnosticCode, detail string) *clientui.TranscriptDiagnostic {
-	return &clientui.TranscriptDiagnostic{Code: &code, Detail: &detail}
 }

--- a/cli/tui/model_detail_test.go
+++ b/cli/tui/model_detail_test.go
@@ -264,10 +264,10 @@ func TestDetailModeCachedRowsPreserveVisibility(t *testing.T) {
 		Reason:       clientui.TranscriptNoticeRuntimeDiagnostic,
 		Severity:     clientui.TranscriptNoticeInfo,
 		CompactLabel: &compactNotice,
-		Diagnostic: &clientui.TranscriptDiagnostic{
-			Code:   "detail_cache_test",
-			Detail: "diagnostic detail",
-		},
+		Diagnostic: clientui.NewLegacyTranscriptDiagnostic(
+			"detail_cache_test",
+			"diagnostic detail",
+		),
 	})
 	cached.Visibility = clientui.EntryVisibilityOngoingCollapsed
 	next, _ := model.Update(SetDetailTranscriptPageMsg{Page: clientui.TranscriptPage{
@@ -539,10 +539,10 @@ func TestDetailReviewerRowsPreserveDiagnosticCodes(t *testing.T) {
 				Severity:     clientui.TranscriptNoticeInfo,
 				MessageType:  &messageType,
 				CompactLabel: &compactLabel,
-				Diagnostic: &clientui.TranscriptDiagnostic{
-					Code:   clientui.TranscriptDiagnosticCode(role),
-					Detail: "review result",
-				},
+				Diagnostic: clientui.NewLegacyTranscriptDiagnostic(
+					clientui.TranscriptDiagnosticCode(role),
+					"review result",
+				),
 			}))
 			if !ok {
 				t.Fatal("reviewer row was dropped")
@@ -551,8 +551,9 @@ func TestDetailReviewerRowsPreserveDiagnosticCodes(t *testing.T) {
 			if row.Notice == nil || row.Notice.Diagnostic == nil {
 				t.Fatalf("reviewer row = %+v", row)
 			}
-			if row.Notice.Diagnostic.Code != clientui.TranscriptDiagnosticCode(role) {
-				t.Fatalf("reviewer diagnostic code = %q, want %q", row.Notice.Diagnostic.Code, role)
+			code, _, legacy := row.Notice.Diagnostic.Legacy()
+			if !legacy || code != clientui.TranscriptDiagnosticCode(role) {
+				t.Fatalf("reviewer diagnostic code = %q legacy=%t, want %q", code, legacy, role)
 			}
 		})
 	}

--- a/cli/tui/transcript_row_equal.go
+++ b/cli/tui/transcript_row_equal.go
@@ -75,8 +75,11 @@ func transcriptDiagnosticEqual(left, right *clientui.TranscriptDiagnostic) bool 
 	if left == nil || right == nil {
 		return left == right
 	}
-	return left.Code == right.Code &&
-		left.Detail == right.Detail &&
+	leftCode, leftDetail, leftLegacy := left.Legacy()
+	rightCode, rightDetail, rightLegacy := right.Legacy()
+	return leftLegacy == rightLegacy &&
+		leftCode == rightCode &&
+		leftDetail == rightDetail &&
 		transcript.DeveloperDiagnosticEqual(left.Developer, right.Developer)
 }
 

--- a/cli/tui/transcript_row_equal.go
+++ b/cli/tui/transcript_row_equal.go
@@ -65,10 +65,19 @@ func transcriptNoticeRowEqual(left, right *clientui.TranscriptNoticeRow) bool {
 		pointersEqual(left.SourcePath, right.SourcePath) &&
 		transcriptWorktreeContextEqual(left.Worktree, right.Worktree) &&
 		pointersEqual(left.CacheWarning, right.CacheWarning) &&
-		pointersEqual(left.Diagnostic, right.Diagnostic) &&
+		transcriptDiagnosticEqual(left.Diagnostic, right.Diagnostic) &&
 		pointersEqual(left.Background, right.Background) &&
 		pointersEqual(left.CondensedText, right.CondensedText) &&
 		pointersEqual(left.CompactLabel, right.CompactLabel)
+}
+
+func transcriptDiagnosticEqual(left, right *clientui.TranscriptDiagnostic) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.Code == right.Code &&
+		left.Detail == right.Detail &&
+		transcript.DeveloperDiagnosticEqual(left.Developer, right.Developer)
 }
 
 func transcriptWorktreeContextEqual(left, right *clientui.TranscriptWorktreeContext) bool {

--- a/cli/tui/transcript_row_equal.go
+++ b/cli/tui/transcript_row_equal.go
@@ -75,11 +75,8 @@ func transcriptDiagnosticEqual(left, right *clientui.TranscriptDiagnostic) bool 
 	if left == nil || right == nil {
 		return left == right
 	}
-	leftCode, leftDetail, leftLegacy := left.Legacy()
-	rightCode, rightDetail, rightLegacy := right.Legacy()
-	return leftLegacy == rightLegacy &&
-		leftCode == rightCode &&
-		leftDetail == rightDetail &&
+	return pointersEqual(left.Code, right.Code) &&
+		pointersEqual(left.Detail, right.Detail) &&
 		transcript.DeveloperDiagnosticEqual(left.Developer, right.Developer)
 }
 

--- a/cli/tui/transcriptrender/render.go
+++ b/cli/tui/transcriptrender/render.go
@@ -539,11 +539,18 @@ func noticeRoleAndText(row *clientui.TranscriptNoticeRow, visibility clientui.En
 		if row.Diagnostic.Developer != nil {
 			developerText = transcript.DeveloperDiagnosticText(*row.Diagnostic.Developer)
 		}
-		legacyCode, legacyDetail, _ := row.Diagnostic.Legacy()
+		legacyCode := ""
+		if row.Diagnostic.Code != nil {
+			legacyCode = string(*row.Diagnostic.Code)
+		}
+		legacyDetail := ""
+		if row.Diagnostic.Detail != nil {
+			legacyDetail = *row.Diagnostic.Detail
+		}
 		text = firstNonEmpty(
 			developerText,
 			legacyDetail,
-			string(legacyCode),
+			legacyCode,
 			text,
 		)
 	}
@@ -631,8 +638,8 @@ func noticeDiagnosticHasReviewerRole(row *clientui.TranscriptNoticeRow) bool {
 	if row == nil || row.Diagnostic == nil {
 		return false
 	}
-	code, _, legacy := row.Diagnostic.Legacy()
-	return legacy && transcript.IsReviewerEntryRole(strings.TrimSpace(string(code)))
+	return row.Diagnostic.Code != nil &&
+		transcript.IsReviewerEntryRole(strings.TrimSpace(string(*row.Diagnostic.Code)))
 }
 
 func noticeLegacyText(row *clientui.TranscriptNoticeRow) string {

--- a/cli/tui/transcriptrender/render.go
+++ b/cli/tui/transcriptrender/render.go
@@ -535,7 +535,16 @@ func noticeRoleAndText(row *clientui.TranscriptNoticeRow, visibility clientui.En
 		}
 	}
 	if row.Diagnostic != nil && (mode == ModeDetailExpanded || typedCompactText == "") {
-		text = firstNonEmpty(row.Diagnostic.Detail, string(row.Diagnostic.Code), text)
+		developerText := ""
+		if row.Diagnostic.Developer != nil {
+			developerText = transcript.DeveloperDiagnosticText(*row.Diagnostic.Developer)
+		}
+		text = firstNonEmpty(
+			developerText,
+			row.Diagnostic.Detail,
+			string(row.Diagnostic.Code),
+			text,
+		)
 	}
 	return noticeStyleRole(row), text
 }

--- a/cli/tui/transcriptrender/render.go
+++ b/cli/tui/transcriptrender/render.go
@@ -539,10 +539,11 @@ func noticeRoleAndText(row *clientui.TranscriptNoticeRow, visibility clientui.En
 		if row.Diagnostic.Developer != nil {
 			developerText = transcript.DeveloperDiagnosticText(*row.Diagnostic.Developer)
 		}
+		legacyCode, legacyDetail, _ := row.Diagnostic.Legacy()
 		text = firstNonEmpty(
 			developerText,
-			row.Diagnostic.Detail,
-			string(row.Diagnostic.Code),
+			legacyDetail,
+			string(legacyCode),
 			text,
 		)
 	}
@@ -630,7 +631,8 @@ func noticeDiagnosticHasReviewerRole(row *clientui.TranscriptNoticeRow) bool {
 	if row == nil || row.Diagnostic == nil {
 		return false
 	}
-	return transcript.IsReviewerEntryRole(strings.TrimSpace(string(row.Diagnostic.Code)))
+	code, _, legacy := row.Diagnostic.Legacy()
+	return legacy && transcript.IsReviewerEntryRole(strings.TrimSpace(string(code)))
 }
 
 func noticeLegacyText(row *clientui.TranscriptNoticeRow) string {

--- a/cli/tui/transcriptrender/render_test.go
+++ b/cli/tui/transcriptrender/render_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"unicode"
 
+	"core/internal/testharness/clientuitest"
 	"core/shared/clientui"
 	"core/shared/runtimeids"
 	"core/shared/transcript"
@@ -430,7 +431,7 @@ func TestBackgroundNoticeUsesPrimaryInfoSymbolAndFullStrengthBody(t *testing.T) 
 			Severity:     clientui.TranscriptNoticeInfo,
 			MessageType:  &messageType,
 			CompactLabel: &compactLabel,
-			Diagnostic:   legacyTranscriptDiagnosticForTest("background_completion", compactLabel),
+			Diagnostic:   clientuitest.LegacyTranscriptDiagnostic("background_completion", compactLabel),
 			Background: &clientui.TranscriptBackgroundNoticeIdentity{
 				ActivityID: runtimeids.NewBackgroundActivityID(),
 				ProcessID:  "background-process",
@@ -479,7 +480,7 @@ func TestWorktreeNoticeRendersTypedClientContext(t *testing.T) {
 				WorkspaceRoot: "/tmp/workspace",
 				EffectiveCwd:  effectiveCWD,
 			},
-			Diagnostic: legacyTranscriptDiagnosticForTest(
+			Diagnostic: clientuitest.LegacyTranscriptDiagnostic(
 				"worktree_transition",
 				"model-only instructions",
 			),
@@ -1600,7 +1601,7 @@ func TestBackgroundExitStatusDoesNotOverridePrimaryNoticeSymbol(t *testing.T) {
 				Severity:     clientui.TranscriptNoticeInfo,
 				MessageType:  &messageType,
 				CompactLabel: &compactLabel,
-				Diagnostic:   legacyTranscriptDiagnosticForTest("background_completion", compactLabel),
+				Diagnostic:   clientuitest.LegacyTranscriptDiagnostic("background_completion", compactLabel),
 				Background: &clientui.TranscriptBackgroundNoticeIdentity{
 					ActivityID: runtimeids.NewBackgroundActivityID(),
 					ProcessID:  "background-process",
@@ -1821,7 +1822,7 @@ func TestCollapsedDiagnosticNoticeUsesCompactLabelForDetailVisibility(t *testing
 			Reason:       clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:     clientui.TranscriptNoticeInfo,
 			CompactLabel: &compactLabel,
-			Diagnostic:   legacyTranscriptDiagnosticForTest("agents_context", "raw diagnostic body"),
+			Diagnostic:   clientuitest.LegacyTranscriptDiagnostic("agents_context", "raw diagnostic body"),
 		},
 	}, 80, "", ModeDetailCollapsed)
 
@@ -1836,7 +1837,7 @@ func TestCollapsedDiagnosticNoticeUsesCompactLabelForDetailVisibility(t *testing
 			Reason:       clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:     clientui.TranscriptNoticeInfo,
 			CompactLabel: &compactLabel,
-			Diagnostic:   legacyTranscriptDiagnosticForTest("agents_context", "raw diagnostic body"),
+			Diagnostic:   clientuitest.LegacyTranscriptDiagnostic("agents_context", "raw diagnostic body"),
 		},
 	}, 80, "", ModeDetailExpanded)
 	if got, want := expanded.Lines[0].Plain(), "ℹ raw diagnostic body"; got != want {
@@ -1915,7 +1916,7 @@ func TestReviewerNoticeRendersReviewerGlyph(t *testing.T) {
 			Severity:     clientui.TranscriptNoticeInfo,
 			MessageType:  &messageType,
 			CompactLabel: &compactLabel,
-			Diagnostic: legacyTranscriptDiagnosticForTest(
+			Diagnostic: clientuitest.LegacyTranscriptDiagnostic(
 				clientui.TranscriptDiagnosticCode(transcript.EntryRoleReviewerSuggestions),
 				compactLabel,
 			),
@@ -1931,10 +1932,6 @@ func TestReviewerNoticeRendersReviewerGlyph(t *testing.T) {
 			t.Fatalf("mode %v reviewer line = %q, want reviewer glyph", mode, got)
 		}
 	}
-}
-
-func legacyTranscriptDiagnosticForTest(code clientui.TranscriptDiagnosticCode, detail string) *clientui.TranscriptDiagnostic {
-	return &clientui.TranscriptDiagnostic{Code: &code, Detail: &detail}
 }
 
 func toolRow(name string, presentation transcript.ToolPresentationKind, text string, isError bool) clientui.TranscriptCommittedRow {

--- a/cli/tui/transcriptrender/render_test.go
+++ b/cli/tui/transcriptrender/render_test.go
@@ -430,7 +430,7 @@ func TestBackgroundNoticeUsesPrimaryInfoSymbolAndFullStrengthBody(t *testing.T) 
 			Severity:     clientui.TranscriptNoticeInfo,
 			MessageType:  &messageType,
 			CompactLabel: &compactLabel,
-			Diagnostic:   clientui.NewLegacyTranscriptDiagnostic("background_completion", compactLabel),
+			Diagnostic:   legacyTranscriptDiagnosticForTest("background_completion", compactLabel),
 			Background: &clientui.TranscriptBackgroundNoticeIdentity{
 				ActivityID: runtimeids.NewBackgroundActivityID(),
 				ProcessID:  "background-process",
@@ -479,7 +479,7 @@ func TestWorktreeNoticeRendersTypedClientContext(t *testing.T) {
 				WorkspaceRoot: "/tmp/workspace",
 				EffectiveCwd:  effectiveCWD,
 			},
-			Diagnostic: clientui.NewLegacyTranscriptDiagnostic(
+			Diagnostic: legacyTranscriptDiagnosticForTest(
 				"worktree_transition",
 				"model-only instructions",
 			),
@@ -495,7 +495,7 @@ func TestWorktreeNoticeRendersTypedClientContext(t *testing.T) {
 		if !strings.Contains(text, branch) || !strings.Contains(text, effectiveCWD) {
 			t.Fatalf("mode %v rendered worktree facts = %q, want branch and effective cwd", mode, text)
 		}
-		_, diagnosticDetail, _ := row.Notice.Diagnostic.Legacy()
+		diagnosticDetail := *row.Notice.Diagnostic.Detail
 		if strings.Contains(text, diagnosticDetail) {
 			t.Fatalf("mode %v rendered model instructions instead of client presentation: %q", mode, text)
 		}
@@ -1600,7 +1600,7 @@ func TestBackgroundExitStatusDoesNotOverridePrimaryNoticeSymbol(t *testing.T) {
 				Severity:     clientui.TranscriptNoticeInfo,
 				MessageType:  &messageType,
 				CompactLabel: &compactLabel,
-				Diagnostic:   clientui.NewLegacyTranscriptDiagnostic("background_completion", compactLabel),
+				Diagnostic:   legacyTranscriptDiagnosticForTest("background_completion", compactLabel),
 				Background: &clientui.TranscriptBackgroundNoticeIdentity{
 					ActivityID: runtimeids.NewBackgroundActivityID(),
 					ProcessID:  "background-process",
@@ -1821,7 +1821,7 @@ func TestCollapsedDiagnosticNoticeUsesCompactLabelForDetailVisibility(t *testing
 			Reason:       clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:     clientui.TranscriptNoticeInfo,
 			CompactLabel: &compactLabel,
-			Diagnostic:   clientui.NewLegacyTranscriptDiagnostic("agents_context", "raw diagnostic body"),
+			Diagnostic:   legacyTranscriptDiagnosticForTest("agents_context", "raw diagnostic body"),
 		},
 	}, 80, "", ModeDetailCollapsed)
 
@@ -1836,7 +1836,7 @@ func TestCollapsedDiagnosticNoticeUsesCompactLabelForDetailVisibility(t *testing
 			Reason:       clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:     clientui.TranscriptNoticeInfo,
 			CompactLabel: &compactLabel,
-			Diagnostic:   clientui.NewLegacyTranscriptDiagnostic("agents_context", "raw diagnostic body"),
+			Diagnostic:   legacyTranscriptDiagnosticForTest("agents_context", "raw diagnostic body"),
 		},
 	}, 80, "", ModeDetailExpanded)
 	if got, want := expanded.Lines[0].Plain(), "ℹ raw diagnostic body"; got != want {
@@ -1855,9 +1855,11 @@ func TestDeveloperDiagnosticNoticeRendersTypedContext(t *testing.T) {
 	rendered := RenderCommittedRow(clientui.TranscriptCommittedRow{
 		Kind: clientui.TranscriptRowNotice,
 		Notice: &clientui.TranscriptNoticeRow{
-			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
-			Severity:   clientui.TranscriptNoticeError,
-			Diagnostic: clientui.NewDeveloperTranscriptDiagnostic(diagnostic),
+			Reason:   clientui.TranscriptNoticeRuntimeDiagnostic,
+			Severity: clientui.TranscriptNoticeError,
+			Diagnostic: &clientui.TranscriptDiagnostic{
+				Developer: transcript.CloneDeveloperDiagnostic(&diagnostic),
+			},
 		},
 	}, 120, "", ModeDetailExpanded)
 	if got, want := rendered.Lines[0].Plain(), transcript.DeveloperDiagnosticText(diagnostic); !strings.Contains(got, want) {
@@ -1913,7 +1915,7 @@ func TestReviewerNoticeRendersReviewerGlyph(t *testing.T) {
 			Severity:     clientui.TranscriptNoticeInfo,
 			MessageType:  &messageType,
 			CompactLabel: &compactLabel,
-			Diagnostic: clientui.NewLegacyTranscriptDiagnostic(
+			Diagnostic: legacyTranscriptDiagnosticForTest(
 				clientui.TranscriptDiagnosticCode(transcript.EntryRoleReviewerSuggestions),
 				compactLabel,
 			),
@@ -1929,6 +1931,10 @@ func TestReviewerNoticeRendersReviewerGlyph(t *testing.T) {
 			t.Fatalf("mode %v reviewer line = %q, want reviewer glyph", mode, got)
 		}
 	}
+}
+
+func legacyTranscriptDiagnosticForTest(code clientui.TranscriptDiagnosticCode, detail string) *clientui.TranscriptDiagnostic {
+	return &clientui.TranscriptDiagnostic{Code: &code, Detail: &detail}
 }
 
 func toolRow(name string, presentation transcript.ToolPresentationKind, text string, isError bool) clientui.TranscriptCommittedRow {

--- a/cli/tui/transcriptrender/render_test.go
+++ b/cli/tui/transcriptrender/render_test.go
@@ -1855,6 +1855,27 @@ func TestCollapsedDiagnosticNoticeUsesCompactLabelForDetailVisibility(t *testing
 	}
 }
 
+func TestDeveloperDiagnosticNoticeRendersTypedContext(t *testing.T) {
+	diagnostic := transcript.NewDeletionFactMismatchDeveloperDiagnostic(
+		"call-1",
+		patchformat.WholeFileDeletionFactMismatchError{
+			Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 2},
+		},
+	)
+	rendered := RenderCommittedRow(clientui.TranscriptCommittedRow{
+		Kind: clientui.TranscriptRowNotice,
+		Notice: &clientui.TranscriptNoticeRow{
+			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
+			Severity:   clientui.TranscriptNoticeError,
+			Diagnostic: &clientui.TranscriptDiagnostic{Developer: &diagnostic},
+		},
+	}, 120, "", ModeDetailExpanded)
+	if got, want := rendered.Lines[0].Plain(), transcript.DeveloperDiagnosticText(diagnostic); !strings.Contains(got, want) {
+		t.Fatalf("developer diagnostic render = %q, want %q", got, want)
+	}
+}
+
 // Spec tui-transcript.md: collapsed detail + ongoing use compact text, expansion
 // reveals full entry content verbatim. For user/assistant, the compact form is
 // the server-provided CondensedText when present (else first non-empty line).

--- a/cli/tui/transcriptrender/render_test.go
+++ b/cli/tui/transcriptrender/render_test.go
@@ -430,10 +430,7 @@ func TestBackgroundNoticeUsesPrimaryInfoSymbolAndFullStrengthBody(t *testing.T) 
 			Severity:     clientui.TranscriptNoticeInfo,
 			MessageType:  &messageType,
 			CompactLabel: &compactLabel,
-			Diagnostic: &clientui.TranscriptDiagnostic{
-				Code:   "background_completion",
-				Detail: compactLabel,
-			},
+			Diagnostic:   clientui.NewLegacyTranscriptDiagnostic("background_completion", compactLabel),
 			Background: &clientui.TranscriptBackgroundNoticeIdentity{
 				ActivityID: runtimeids.NewBackgroundActivityID(),
 				ProcessID:  "background-process",
@@ -482,10 +479,10 @@ func TestWorktreeNoticeRendersTypedClientContext(t *testing.T) {
 				WorkspaceRoot: "/tmp/workspace",
 				EffectiveCwd:  effectiveCWD,
 			},
-			Diagnostic: &clientui.TranscriptDiagnostic{
-				Code:   "worktree_transition",
-				Detail: "model-only instructions",
-			},
+			Diagnostic: clientui.NewLegacyTranscriptDiagnostic(
+				"worktree_transition",
+				"model-only instructions",
+			),
 		},
 	}
 
@@ -498,7 +495,8 @@ func TestWorktreeNoticeRendersTypedClientContext(t *testing.T) {
 		if !strings.Contains(text, branch) || !strings.Contains(text, effectiveCWD) {
 			t.Fatalf("mode %v rendered worktree facts = %q, want branch and effective cwd", mode, text)
 		}
-		if strings.Contains(text, row.Notice.Diagnostic.Detail) {
+		_, diagnosticDetail, _ := row.Notice.Diagnostic.Legacy()
+		if strings.Contains(text, diagnosticDetail) {
 			t.Fatalf("mode %v rendered model instructions instead of client presentation: %q", mode, text)
 		}
 	}
@@ -1602,10 +1600,7 @@ func TestBackgroundExitStatusDoesNotOverridePrimaryNoticeSymbol(t *testing.T) {
 				Severity:     clientui.TranscriptNoticeInfo,
 				MessageType:  &messageType,
 				CompactLabel: &compactLabel,
-				Diagnostic: &clientui.TranscriptDiagnostic{
-					Code:   "background_completion",
-					Detail: compactLabel,
-				},
+				Diagnostic:   clientui.NewLegacyTranscriptDiagnostic("background_completion", compactLabel),
 				Background: &clientui.TranscriptBackgroundNoticeIdentity{
 					ActivityID: runtimeids.NewBackgroundActivityID(),
 					ProcessID:  "background-process",
@@ -1826,10 +1821,7 @@ func TestCollapsedDiagnosticNoticeUsesCompactLabelForDetailVisibility(t *testing
 			Reason:       clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:     clientui.TranscriptNoticeInfo,
 			CompactLabel: &compactLabel,
-			Diagnostic: &clientui.TranscriptDiagnostic{
-				Code:   "agents_context",
-				Detail: "raw diagnostic body",
-			},
+			Diagnostic:   clientui.NewLegacyTranscriptDiagnostic("agents_context", "raw diagnostic body"),
 		},
 	}, 80, "", ModeDetailCollapsed)
 
@@ -1844,10 +1836,7 @@ func TestCollapsedDiagnosticNoticeUsesCompactLabelForDetailVisibility(t *testing
 			Reason:       clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:     clientui.TranscriptNoticeInfo,
 			CompactLabel: &compactLabel,
-			Diagnostic: &clientui.TranscriptDiagnostic{
-				Code:   "agents_context",
-				Detail: "raw diagnostic body",
-			},
+			Diagnostic:   clientui.NewLegacyTranscriptDiagnostic("agents_context", "raw diagnostic body"),
 		},
 	}, 80, "", ModeDetailExpanded)
 	if got, want := expanded.Lines[0].Plain(), "ℹ raw diagnostic body"; got != want {
@@ -1868,7 +1857,7 @@ func TestDeveloperDiagnosticNoticeRendersTypedContext(t *testing.T) {
 		Notice: &clientui.TranscriptNoticeRow{
 			Reason:     clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:   clientui.TranscriptNoticeError,
-			Diagnostic: &clientui.TranscriptDiagnostic{Developer: &diagnostic},
+			Diagnostic: clientui.NewDeveloperTranscriptDiagnostic(diagnostic),
 		},
 	}, 120, "", ModeDetailExpanded)
 	if got, want := rendered.Lines[0].Plain(), transcript.DeveloperDiagnosticText(diagnostic); !strings.Contains(got, want) {
@@ -1924,10 +1913,10 @@ func TestReviewerNoticeRendersReviewerGlyph(t *testing.T) {
 			Severity:     clientui.TranscriptNoticeInfo,
 			MessageType:  &messageType,
 			CompactLabel: &compactLabel,
-			Diagnostic: &clientui.TranscriptDiagnostic{
-				Code:   clientui.TranscriptDiagnosticCode(transcript.EntryRoleReviewerSuggestions),
-				Detail: compactLabel,
-			},
+			Diagnostic: clientui.NewLegacyTranscriptDiagnostic(
+				clientui.TranscriptDiagnosticCode(transcript.EntryRoleReviewerSuggestions),
+				compactLabel,
+			),
 		},
 	}
 

--- a/cli/tui/transcriptrender/render_test.go
+++ b/cli/tui/transcriptrender/render_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"unicode"
 
-	"core/internal/testharness/clientuitest"
+	"core/internal/testharness/testsetup"
 	"core/shared/clientui"
 	"core/shared/runtimeids"
 	"core/shared/transcript"
@@ -431,7 +431,7 @@ func TestBackgroundNoticeUsesPrimaryInfoSymbolAndFullStrengthBody(t *testing.T) 
 			Severity:     clientui.TranscriptNoticeInfo,
 			MessageType:  &messageType,
 			CompactLabel: &compactLabel,
-			Diagnostic:   clientuitest.LegacyTranscriptDiagnostic("background_completion", compactLabel),
+			Diagnostic:   testsetup.LegacyTranscriptDiagnostic("background_completion", compactLabel),
 			Background: &clientui.TranscriptBackgroundNoticeIdentity{
 				ActivityID: runtimeids.NewBackgroundActivityID(),
 				ProcessID:  "background-process",
@@ -480,7 +480,7 @@ func TestWorktreeNoticeRendersTypedClientContext(t *testing.T) {
 				WorkspaceRoot: "/tmp/workspace",
 				EffectiveCwd:  effectiveCWD,
 			},
-			Diagnostic: clientuitest.LegacyTranscriptDiagnostic(
+			Diagnostic: testsetup.LegacyTranscriptDiagnostic(
 				"worktree_transition",
 				"model-only instructions",
 			),
@@ -1601,7 +1601,7 @@ func TestBackgroundExitStatusDoesNotOverridePrimaryNoticeSymbol(t *testing.T) {
 				Severity:     clientui.TranscriptNoticeInfo,
 				MessageType:  &messageType,
 				CompactLabel: &compactLabel,
-				Diagnostic:   clientuitest.LegacyTranscriptDiagnostic("background_completion", compactLabel),
+				Diagnostic:   testsetup.LegacyTranscriptDiagnostic("background_completion", compactLabel),
 				Background: &clientui.TranscriptBackgroundNoticeIdentity{
 					ActivityID: runtimeids.NewBackgroundActivityID(),
 					ProcessID:  "background-process",
@@ -1822,7 +1822,7 @@ func TestCollapsedDiagnosticNoticeUsesCompactLabelForDetailVisibility(t *testing
 			Reason:       clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:     clientui.TranscriptNoticeInfo,
 			CompactLabel: &compactLabel,
-			Diagnostic:   clientuitest.LegacyTranscriptDiagnostic("agents_context", "raw diagnostic body"),
+			Diagnostic:   testsetup.LegacyTranscriptDiagnostic("agents_context", "raw diagnostic body"),
 		},
 	}, 80, "", ModeDetailCollapsed)
 
@@ -1837,7 +1837,7 @@ func TestCollapsedDiagnosticNoticeUsesCompactLabelForDetailVisibility(t *testing
 			Reason:       clientui.TranscriptNoticeRuntimeDiagnostic,
 			Severity:     clientui.TranscriptNoticeInfo,
 			CompactLabel: &compactLabel,
-			Diagnostic:   clientuitest.LegacyTranscriptDiagnostic("agents_context", "raw diagnostic body"),
+			Diagnostic:   testsetup.LegacyTranscriptDiagnostic("agents_context", "raw diagnostic body"),
 		},
 	}, 80, "", ModeDetailExpanded)
 	if got, want := expanded.Lines[0].Plain(), "ℹ raw diagnostic body"; got != want {
@@ -1916,7 +1916,7 @@ func TestReviewerNoticeRendersReviewerGlyph(t *testing.T) {
 			Severity:     clientui.TranscriptNoticeInfo,
 			MessageType:  &messageType,
 			CompactLabel: &compactLabel,
-			Diagnostic: clientuitest.LegacyTranscriptDiagnostic(
+			Diagnostic: testsetup.LegacyTranscriptDiagnostic(
 				clientui.TranscriptDiagnosticCode(transcript.EntryRoleReviewerSuggestions),
 				compactLabel,
 			),

--- a/cli/tui/transcriptrender/tool.go
+++ b/cli/tui/transcriptrender/tool.go
@@ -351,7 +351,7 @@ func renderPatchTool(
 		}
 		var spans []Span
 		spans = append(spans, roleSpan(path, role))
-		if file.Removed > 0 {
+		if patchformat.ShowsRemovedCount(file) {
 			spans = append(spans, roleSpan(" ", role))
 			spans = append(spans, SemanticSpan(fmt.Sprintf("-%d", file.Removed), StyleRoleToolError))
 		}

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -73,8 +73,10 @@
 - `patch` apply is atomic: malformed/conflicting patches make no file changes.
 - `patch` supports add, update, move, and delete.
 - Patch targets are validated with real-path resolution.
+- A second whole-file deletion that resolves to the same canonical target as an earlier deletion in the patch is malformed, including when distinct requested paths are symlink aliases. The patch makes no file changes.
 - `patch` has no timeout and no automatic retries.
 - Patch success persistence includes patch input plus apply-result metadata.
+- If deletion-count result metadata cannot be matched to the successful patch presentation, Kent preserves the successful patch completion with its original uncounted presentation, fabricates no count, and appends exactly one typed `developer_error_feedback` operator diagnostic. The server does not panic for this presentation failure.
 - Outside-workspace edits are approval-gated unless explicitly enabled. `allow_non_cwd_edits=false` by default.
 - If outside-workspace approval is denied, Kent returns to the model an explicit non-circumvention tool error instructing manual user edits when essential.
 - `view_image` path resolution uses absolute and canonical real paths before access checks.

--- a/docs/dev/specs/tui-transcript.md
+++ b/docs/dev/specs/tui-transcript.md
@@ -32,6 +32,8 @@
 - **Pending tool-call previews in live region use the same rendering/layout as committed tool-call previews, with no pending-only labels.**
 - A pending question's live row shows only the question text; it does not append the internal tool name or prompt kind.
 - **Tool completion appends exactly one final committed line in server emission order. Ongoing never recolors/mutates an earlier emitted tool line.**
+- A pending or failed whole-file deletion keeps its path visible without a removal-count badge while the count is unavailable. A successful whole-file deletion shows its logical removed-line count, including a known count of zero.
+- A typed deletion-count presentation diagnostic is consumed and rendered through the ordinary committed-row path. Release mode continues after rendering it; debug mode fails fast in the frontend only after the committed diagnostic row is consumed, while the server remains running.
 - **A shell invocation that moves to the background renders both its committed tool row and volatile background-activity row with a secondary `$`, faint foreground command, and `· backgrounded` suffix. The command truncates before the suffix so the complete suffix remains visible whenever the terminal can fit it; these rows never label the state as `running`.**
 - **Parallel tool calls commit in server emission order with no ordering guarantee among concurrent calls.**
 - **In main-input mode, `Up`/`Down` are reserved for prompt-history recall at whole-buffer boundaries or multiline cursor movement. They do not scroll ongoing transcript.**

--- a/internal/testharness/clientuitest/diagnostic.go
+++ b/internal/testharness/clientuitest/diagnostic.go
@@ -1,0 +1,7 @@
+package clientuitest
+
+import "core/shared/clientui"
+
+func LegacyTranscriptDiagnostic(code clientui.TranscriptDiagnosticCode, detail string) *clientui.TranscriptDiagnostic {
+	return &clientui.TranscriptDiagnostic{Code: &code, Detail: &detail}
+}

--- a/internal/testharness/pty/driver/driver_test.go
+++ b/internal/testharness/pty/driver/driver_test.go
@@ -437,6 +437,7 @@ func TestSessionChildReceivesOnlyDeclaredEnvironment(t *testing.T) {
 	}
 	for range session.Events() {
 	}
+	<-session.Done()
 	capture, err := session.Capture()
 	if err != nil {
 		t.Fatalf("Capture: %v", err)

--- a/internal/testharness/testsetup/transcript_diagnostic.go
+++ b/internal/testharness/testsetup/transcript_diagnostic.go
@@ -1,4 +1,4 @@
-package clientuitest
+package testsetup
 
 import "core/shared/clientui"
 

--- a/server/processview/service_test.go
+++ b/server/processview/service_test.go
@@ -15,6 +15,8 @@ import (
 	"core/shared/toolspec"
 )
 
+const processViewTestWaitTimeout = 10 * time.Second
+
 func TestServiceListProcessesIncludesRunOwnership(t *testing.T) {
 	fixture := newProcessViewFixture(t)
 	result := fixture.startCommand(t, "call-1", "printf 'working\n'; sleep 30", "run-1", "step-1")
@@ -22,7 +24,7 @@ func TestServiceListProcessesIncludesRunOwnership(t *testing.T) {
 		t.Fatalf("expected successful tool result, got %+v", result)
 	}
 
-	waitForProcessSnapshot(t, 2*time.Second, func() (shelltool.Snapshot, bool) {
+	waitForProcessSnapshot(t, processViewTestWaitTimeout, func() (shelltool.Snapshot, bool) {
 		entries := fixture.manager.List()
 		if len(entries) != 1 {
 			return shelltool.Snapshot{}, false
@@ -128,7 +130,7 @@ func TestServiceGetInlineOutputReturnsManagerPreview(t *testing.T) {
 		t.Fatalf("expected successful tool result, got %+v", result)
 	}
 
-	waitForInlineOutput(t, 2*time.Second, func() (serverapi.ProcessInlineOutputResponse, error) {
+	waitForInlineOutput(t, processViewTestWaitTimeout, func() (serverapi.ProcessInlineOutputResponse, error) {
 		return fixture.service.GetInlineOutput(context.Background(), serverapi.ProcessInlineOutputRequest{ProcessID: "1000", MaxChars: 12_000})
 	}, func(resp serverapi.ProcessInlineOutputResponse) bool {
 		return resp.LogPath != "" && strings.Contains(resp.Output, "inline-preview")
@@ -229,7 +231,7 @@ func (s *stubKillProcessSource) InlineOutput(string, int) (string, string, error
 
 func waitForProcessCount(t *testing.T, manager *shelltool.Manager, count int) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(processViewTestWaitTimeout)
 	for time.Now().Before(deadline) {
 		if len(manager.List()) >= count {
 			return
@@ -241,7 +243,7 @@ func waitForProcessCount(t *testing.T, manager *shelltool.Manager, count int) {
 
 func waitForProcessKilled(t *testing.T, manager *shelltool.Manager, id string) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(processViewTestWaitTimeout)
 	for time.Now().Before(deadline) {
 		for _, entry := range manager.List() {
 			if entry.ID == id && (entry.KillRequested || !entry.Running) {

--- a/server/registry/runtime_registry.go
+++ b/server/registry/runtime_registry.go
@@ -781,10 +781,12 @@ func (r *RuntimeRegistry) PublishWorktreeTransitionOutcome(sessionID string, out
 		State:       outcome.State,
 	}
 	if outcome.Failure != nil {
-		transcriptOutcome.Failure = clientui.NewLegacyTranscriptDiagnostic(
-			clientui.TranscriptDiagnosticCode("worktree_transition_failed"),
-			outcome.Failure.Diagnostic,
-		)
+		code := clientui.TranscriptDiagnosticCode("worktree_transition_failed")
+		detail := outcome.Failure.Diagnostic
+		transcriptOutcome.Failure = &clientui.TranscriptDiagnostic{
+			Code:   &code,
+			Detail: &detail,
+		}
 	}
 	entry.sessionFeed.Publish([]clientui.TranscriptMessage{{
 		Kind:    clientui.TranscriptMessageWorktreeTransitionOutcome,

--- a/server/registry/runtime_registry.go
+++ b/server/registry/runtime_registry.go
@@ -781,10 +781,10 @@ func (r *RuntimeRegistry) PublishWorktreeTransitionOutcome(sessionID string, out
 		State:       outcome.State,
 	}
 	if outcome.Failure != nil {
-		transcriptOutcome.Failure = &clientui.TranscriptDiagnostic{
-			Code:   clientui.TranscriptDiagnosticCode("worktree_transition_failed"),
-			Detail: outcome.Failure.Diagnostic,
-		}
+		transcriptOutcome.Failure = clientui.NewLegacyTranscriptDiagnostic(
+			clientui.TranscriptDiagnosticCode("worktree_transition_failed"),
+			outcome.Failure.Diagnostic,
+		)
 	}
 	entry.sessionFeed.Publish([]clientui.TranscriptMessage{{
 		Kind:    clientui.TranscriptMessageWorktreeTransitionOutcome,

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -7,6 +7,7 @@ import (
 	"core/shared/toolspec"
 	"core/shared/transcript"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -34,6 +35,7 @@ type ChatEntry struct {
 	BackgroundProcessID  string
 	BackgroundExitCode   *int
 	ToolCall             *transcript.ToolCallMeta
+	DeveloperDiagnostic  *transcript.DeveloperDiagnostic
 }
 
 type ChatSnapshot struct {
@@ -56,14 +58,44 @@ type TranscriptWindowSnapshot struct {
 }
 
 type storedToolCompletion struct {
-	CallID        string                   `json:"call_id"`
-	Name          string                   `json:"name"`
-	IsError       bool                     `json:"is_error"`
-	Output        json.RawMessage          `json:"output"`
-	Summary       string                   `json:"summary,omitempty"`
-	CondensedText string                   `json:"condensed_text,omitempty"`
-	Presentation  *transcript.ToolCallMeta `json:"presentation,omitempty"`
-	ProviderItems []llm.ResponseItem       `json:"provider_items,omitempty"`
+	CallID        string                          `json:"call_id"`
+	Name          string                          `json:"name"`
+	IsError       bool                            `json:"is_error"`
+	Output        json.RawMessage                 `json:"output"`
+	Summary       string                          `json:"summary,omitempty"`
+	CondensedText string                          `json:"condensed_text,omitempty"`
+	Presentation  *transcript.ToolCallMeta        `json:"presentation,omitempty"`
+	ProviderItems []llm.ResponseItem              `json:"provider_items,omitempty"`
+	Diagnostic    *transcript.DeveloperDiagnostic `json:"diagnostic,omitempty"`
+}
+
+func toolCompletionDiagnosticChatEntry(diagnostic transcript.DeveloperDiagnostic) ChatEntry {
+	return ChatEntry{
+		Visibility:          transcript.EntryVisibilityOngoing,
+		Role:                string(transcript.EntryRoleDeveloperErrorFeedback),
+		DeveloperDiagnostic: transcript.CloneDeveloperDiagnostic(&diagnostic),
+	}
+}
+
+func validateStoredToolCompletionDiagnostic(completion storedToolCompletion) error {
+	if completion.Diagnostic == nil {
+		return nil
+	}
+	if err := completion.Diagnostic.Validate(); err != nil {
+		return fmt.Errorf("tool completion diagnostic: %w", err)
+	}
+	context := completion.Diagnostic.DeletionFactMismatch
+	if context == nil {
+		return errors.New("tool completion diagnostic requires a deletion fact mismatch context")
+	}
+	if strings.TrimSpace(context.CallID) != strings.TrimSpace(completion.CallID) {
+		return fmt.Errorf(
+			"tool completion diagnostic call id %q does not match completion call id %q",
+			context.CallID,
+			completion.CallID,
+		)
+	}
+	return nil
 }
 
 type chatStore struct {
@@ -74,19 +106,21 @@ type chatStore struct {
 	compact        *compactionCheckpoint
 	local          []localChatEntry
 
-	toolCompletions                   map[string]tools.Result
-	toolCompletionProviderItems       map[string][]llm.ResponseItem
-	assistantToolCalls                map[string]struct{}
-	materializedToolResults           map[string]struct{}
-	synthesizedToolResults            map[string]struct{}
-	assistantStreamIDsByEntry         map[int]uuid.UUID
-	activeSegmentEntryStart           int
-	streaming                         *assistantStreamingState
-	streamingError                    string
-	cwd                               string
-	lastCommittedAssistantFinalAnswer string
-	messageCount                      int
-	transcriptEntryCount              int
+	toolCompletions                    map[string]tools.Result
+	toolCompletionProviderItems        map[string][]llm.ResponseItem
+	toolCompletionDiagnostics          map[string]*transcript.DeveloperDiagnostic
+	assistantToolCalls                 map[string]struct{}
+	materializedToolResults            map[string]struct{}
+	synthesizedToolResults             map[string]struct{}
+	projectedToolCompletionDiagnostics map[string]struct{}
+	assistantStreamIDsByEntry          map[int]uuid.UUID
+	activeSegmentEntryStart            int
+	streaming                          *assistantStreamingState
+	streamingError                     string
+	cwd                                string
+	lastCommittedAssistantFinalAnswer  string
+	messageCount                       int
+	transcriptEntryCount               int
 
 	providerTokenEstimate      int
 	providerTokenEstimateDirty bool
@@ -120,13 +154,15 @@ func newChatStore() *chatStore {
 
 func newChatStoreWithCWD(cwd string) *chatStore {
 	return &chatStore{
-		toolCompletions:             make(map[string]tools.Result, 16),
-		toolCompletionProviderItems: make(map[string][]llm.ResponseItem, 16),
-		assistantToolCalls:          make(map[string]struct{}, 16),
-		materializedToolResults:     make(map[string]struct{}, 16),
-		synthesizedToolResults:      make(map[string]struct{}, 16),
-		cwd:                         strings.TrimSpace(cwd),
-		providerTokenEstimateDirty:  true,
+		toolCompletions:                    make(map[string]tools.Result, 16),
+		toolCompletionProviderItems:        make(map[string][]llm.ResponseItem, 16),
+		toolCompletionDiagnostics:          make(map[string]*transcript.DeveloperDiagnostic, 16),
+		assistantToolCalls:                 make(map[string]struct{}, 16),
+		materializedToolResults:            make(map[string]struct{}, 16),
+		synthesizedToolResults:             make(map[string]struct{}, 16),
+		projectedToolCompletionDiagnostics: make(map[string]struct{}, 16),
+		cwd:                                strings.TrimSpace(cwd),
+		providerTokenEstimateDirty:         true,
 	}
 }
 
@@ -190,9 +226,11 @@ func (s *chatStore) pruneAssistantStreamIDsBeforeLocked(activeSegmentEntryStart 
 func (s *chatStore) pruneToolCompletionsToWorkingSetLocked() {
 	if len(s.toolCompletions) == 0 &&
 		len(s.toolCompletionProviderItems) == 0 &&
+		len(s.toolCompletionDiagnostics) == 0 &&
 		len(s.assistantToolCalls) == 0 &&
 		len(s.materializedToolResults) == 0 &&
-		len(s.synthesizedToolResults) == 0 {
+		len(s.synthesizedToolResults) == 0 &&
+		len(s.projectedToolCompletionDiagnostics) == 0 {
 		return
 	}
 	referenced := make(map[string]struct{}, len(s.toolCompletions))
@@ -210,9 +248,11 @@ func (s *chatStore) pruneToolCompletionsToWorkingSetLocked() {
 	}
 	pruneCallIDMapToReferenced(s.toolCompletions, referenced)
 	pruneCallIDMapToReferenced(s.toolCompletionProviderItems, referenced)
+	pruneCallIDMapToReferenced(s.toolCompletionDiagnostics, referenced)
 	pruneCallIDMapToReferenced(s.assistantToolCalls, referenced)
 	pruneCallIDMapToReferenced(s.materializedToolResults, referenced)
 	pruneCallIDMapToReferenced(s.synthesizedToolResults, referenced)
+	pruneCallIDMapToReferenced(s.projectedToolCompletionDiagnostics, referenced)
 }
 
 func pruneCallIDMapToReferenced[V any](m map[string]V, referenced map[string]struct{}) {
@@ -295,7 +335,15 @@ func (s *chatStore) restoreToolCompletionPayload(payload []byte) error {
 	if err := json.Unmarshal(payload, &completion); err != nil {
 		return fmt.Errorf("decode tool_completed event: %w", err)
 	}
-	s.recordToolCompletionWithProviderItems(tools.Result{
+	if err := validateStoredToolCompletionDiagnostic(completion); err != nil {
+		return fmt.Errorf("decode tool_completed event: %w", err)
+	}
+	s.recordStoredToolCompletion(completion)
+	return nil
+}
+
+func (s *chatStore) recordStoredToolCompletion(completion storedToolCompletion) {
+	s.recordToolCompletionWithDiagnostic(tools.Result{
 		CallID:        completion.CallID,
 		Name:          toolspec.ID(completion.Name),
 		IsError:       completion.IsError,
@@ -303,11 +351,14 @@ func (s *chatStore) restoreToolCompletionPayload(payload []byte) error {
 		Summary:       completion.Summary,
 		CondensedText: completion.CondensedText,
 		Presentation:  completion.Presentation,
-	}, completion.ProviderItems)
-	return nil
+	}, completion.ProviderItems, completion.Diagnostic)
 }
 
 func (s *chatStore) recordToolCompletionWithProviderItems(res tools.Result, providerItems []llm.ResponseItem) {
+	s.recordToolCompletionWithDiagnostic(res, providerItems, nil)
+}
+
+func (s *chatStore) recordToolCompletionWithDiagnostic(res tools.Result, providerItems []llm.ResponseItem, diagnostic *transcript.DeveloperDiagnostic) {
 	callID := strings.TrimSpace(res.CallID)
 	if callID == "" {
 		return
@@ -320,15 +371,36 @@ func (s *chatStore) recordToolCompletionWithProviderItems(res tools.Result, prov
 	} else {
 		delete(s.toolCompletionProviderItems, callID)
 	}
+	if diagnostic == nil {
+		delete(s.toolCompletionDiagnostics, callID)
+	} else {
+		s.toolCompletionDiagnostics[callID] = transcript.CloneDeveloperDiagnostic(diagnostic)
+	}
 	s.providerTokenEstimateDirty = true
-	if _, ok := s.assistantToolCalls[callID]; ok {
-		if _, materialized := s.materializedToolResults[callID]; !materialized {
-			if _, synthesized := s.synthesizedToolResults[callID]; !synthesized {
-				s.synthesizedToolResults[callID] = struct{}{}
-				s.transcriptEntryCount++
-			}
+	s.transcriptEntryCount += s.projectToolCompletionLocked(callID)
+}
+
+func (s *chatStore) projectToolCompletionLocked(callID string) int {
+	if _, ok := s.assistantToolCalls[callID]; !ok {
+		return 0
+	}
+	if _, ok := s.toolCompletions[callID]; !ok {
+		return 0
+	}
+	added := 0
+	if _, materialized := s.materializedToolResults[callID]; !materialized {
+		if _, synthesized := s.synthesizedToolResults[callID]; !synthesized {
+			s.synthesizedToolResults[callID] = struct{}{}
+			added++
 		}
 	}
+	if s.toolCompletionDiagnostics[callID] != nil {
+		if _, projected := s.projectedToolCompletionDiagnostics[callID]; !projected {
+			s.projectedToolCompletionDiagnostics[callID] = struct{}{}
+			added++
+		}
+	}
+	return added
 }
 
 func (s *chatStore) appendStreamingDelta(stepID string, baseRevision int64, baseCommittedEntryCount int, delta string, phase llm.MessagePhase) (*AssistantStreamMetadata, *uuid.UUID) {
@@ -660,16 +732,7 @@ func (s *chatStore) applyMessageStatsLocked(msg llm.Message) {
 				continue
 			}
 			s.assistantToolCalls[callID] = struct{}{}
-			if _, materialized := s.materializedToolResults[callID]; materialized {
-				continue
-			}
-			if _, synthesized := s.synthesizedToolResults[callID]; synthesized {
-				continue
-			}
-			if _, completed := s.toolCompletions[callID]; completed {
-				s.synthesizedToolResults[callID] = struct{}{}
-				delta++
-			}
+			delta += s.projectToolCompletionLocked(callID)
 		}
 	case llm.RoleTool:
 		callID := strings.TrimSpace(msg.ToolCallID)
@@ -713,15 +776,28 @@ type transcriptDeliverySnapshot struct {
 }
 
 type transcriptDeliveryFactScan struct {
-	rows                  []TranscriptCommittedRowFact
-	toolCompletions       map[string]tools.Result
-	materializedToolCalls map[string]struct{}
-	streamIDsByEntry      map[int]uuid.UUID
-	currentEntryIndex     int
+	rows                      []TranscriptCommittedRowFact
+	toolCompletions           map[string]tools.Result
+	materializedToolCalls     map[string]struct{}
+	toolCompletionDiagnostics map[string]*transcript.DeveloperDiagnostic
+	streamIDsByEntry          map[int]uuid.UUID
+	currentEntryIndex         int
 }
 
-func newTranscriptDeliveryFactScan(completions map[string]tools.Result, materializedToolCalls map[string]struct{}, streamIDsByEntry map[int]uuid.UUID, currentEntryIndex int) *transcriptDeliveryFactScan {
-	return &transcriptDeliveryFactScan{toolCompletions: completions, materializedToolCalls: materializedToolCalls, streamIDsByEntry: streamIDsByEntry, currentEntryIndex: currentEntryIndex}
+func newTranscriptDeliveryFactScan(
+	completions map[string]tools.Result,
+	materializedToolCalls map[string]struct{},
+	diagnostics map[string]*transcript.DeveloperDiagnostic,
+	streamIDsByEntry map[int]uuid.UUID,
+	currentEntryIndex int,
+) *transcriptDeliveryFactScan {
+	return &transcriptDeliveryFactScan{
+		toolCompletions:           completions,
+		materializedToolCalls:     materializedToolCalls,
+		toolCompletionDiagnostics: diagnostics,
+		streamIDsByEntry:          streamIDsByEntry,
+		currentEntryIndex:         currentEntryIndex,
+	}
 }
 
 func (s *transcriptDeliveryFactScan) ApplyMessage(stepID string, msg llm.Message) {
@@ -734,10 +810,21 @@ func (s *transcriptDeliveryFactScan) ApplyMessage(stepID string, msg llm.Message
 	}
 	facts := transcriptCommittedRowFactsForStep(
 		stepID,
-		transcriptCommittedRowFactsFromMessage(msg, streamID, s.toolCompletions, s.materializedToolCalls),
+		transcriptCommittedRowFactsWithToolCompletionDiagnostics(
+			msg,
+			streamID,
+			s.toolCompletions,
+			s.materializedToolCalls,
+			s.toolCompletionDiagnostics,
+		),
 	)
 	s.rows = append(s.rows, facts...)
-	s.currentEntryIndex += transcriptCommittedEntryCountFromMessage(msg, s.toolCompletions, s.materializedToolCalls)
+	s.currentEntryIndex += transcriptCommittedEntryCountWithToolCompletionDiagnostics(
+		msg,
+		s.toolCompletions,
+		s.materializedToolCalls,
+		s.toolCompletionDiagnostics,
+	)
 }
 
 func (s *transcriptDeliveryFactScan) ApplyLocalEntry(entry ChatEntry, projected bool) {
@@ -823,7 +910,13 @@ func (s *chatStore) deliverySnapshot() transcriptDeliverySnapshot {
 	for entryIndex, streamID := range s.assistantStreamIDsByEntry {
 		streamIDsByEntry[entryIndex] = streamID
 	}
-	scan := newTranscriptDeliveryFactScan(s.toolCompletions, materializedToolResults, streamIDsByEntry, s.activeSegmentEntryStart)
+	scan := newTranscriptDeliveryFactScan(
+		s.toolCompletions,
+		materializedToolResults,
+		s.toolCompletionDiagnostics,
+		streamIDsByEntry,
+		s.activeSegmentEntryStart,
+	)
 	s.walkProjectionLocked(
 		scan.ApplyMessage,
 		func(local localChatEntry) {

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -81,6 +81,9 @@ func validateStoredToolCompletionDiagnostic(completion storedToolCompletion) err
 	if completion.Diagnostic == nil {
 		return nil
 	}
+	if completion.IsError {
+		return errors.New("failed tool completion cannot carry a developer diagnostic")
+	}
 	if err := completion.Diagnostic.Validate(); err != nil {
 		return fmt.Errorf("tool completion diagnostic: %w", err)
 	}

--- a/server/runtime/committed_transcript_events_test.go
+++ b/server/runtime/committed_transcript_events_test.go
@@ -497,7 +497,7 @@ func TestStepLoopPersistsReasoningProgressAsDetailOnly(t *testing.T) {
 			t.Fatalf("hydrate transcript: %v", err)
 		}
 		for _, row := range hydration.CommittedRows {
-			if row.Notice != nil && row.Notice.DiagnosticCode == "reasoning" {
+			if row.Notice != nil && row.Notice.DiagnosticCode != nil && *row.Notice.DiagnosticCode == "reasoning" {
 				if row.Visibility != transcript.EntryVisibilityDetail ||
 					row.Integrity != transcript.RowIntegrityValid {
 					t.Fatalf("hydrated reasoning row = %+v, want valid detail-only row", row)

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -20,7 +20,8 @@ import (
 	"github.com/google/uuid"
 )
 
-func (e *Engine) persistToolCompletionRaw(stepID string, r tools.Result) (session.CommitReceipt, error) {
+func (e *Engine) persistToolCompletionRaw(stepID string, finalization toolCompletionFinalization) (session.CommitReceipt, error) {
+	r := finalization.Result
 	if r.PresentationDelta != nil {
 		panic(fmt.Sprintf(
 			"tool result presentation invariant violated: unconsumed presentation delta reached persistence (call_id=%q tool=%q)",
@@ -45,6 +46,10 @@ func (e *Engine) persistToolCompletionRaw(stepID string, r tools.Result) (sessio
 		CondensedText: r.CondensedText,
 		Presentation:  r.Presentation,
 		ProviderItems: e.providerItemsForToolCompletion(r),
+		Diagnostic:    transcript.CloneDeveloperDiagnostic(finalization.Diagnostic),
+	}
+	if err := validateStoredToolCompletionDiagnostic(payload); err != nil {
+		return session.CommitReceipt{}, err
 	}
 	_, receipt, err := e.store.AppendEvent(stepID, "tool_completed", payload)
 	if receipt.Committed {

--- a/server/runtime/events.go
+++ b/server/runtime/events.go
@@ -117,6 +117,7 @@ type Event struct {
 	ModelResponse                *ModelResponseTrace
 	ToolCall                     *llm.ToolCall
 	ToolResult                   *tools.Result
+	ToolCompletionDiagnostic     *transcript.DeveloperDiagnostic
 	ToolAbortReason              string
 	Reviewer                     *ReviewerStatus
 	Compaction                   *CompactionStatus

--- a/server/runtime/output_steering.go
+++ b/server/runtime/output_steering.go
@@ -421,13 +421,19 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 		return err
 	}
 	if item.toolCompletion != nil {
-		result := e.finalizeLiveToolCompletion(*item.toolCompletion)
-		receipt, err := e.persistToolCompletionRaw(stepID, result)
+		finalization := e.finalizeLiveToolCompletion(*item.toolCompletion)
+		receipt, err := e.persistToolCompletionRaw(stepID, finalization)
 		item.recordCommitReceipt(receipt)
 		if receipt.Committed {
-			result = cloneToolResult(result)
+			result := cloneToolResult(finalization.Result)
 			e.transcriptRuntimeState().CompleteLiveTool(result.CallID)
-			e.emitRaw(Event{Kind: EventToolCallCompleted, StepID: stepID, ToolResult: &result, CommittedTranscriptChanged: true})
+			e.emitRaw(Event{
+				Kind:                       EventToolCallCompleted,
+				StepID:                     stepID,
+				ToolResult:                 &result,
+				ToolCompletionDiagnostic:   transcript.CloneDeveloperDiagnostic(finalization.Diagnostic),
+				CommittedTranscriptChanged: true,
+			})
 		}
 		return err
 	}

--- a/server/runtime/persisted_transcript_scan.go
+++ b/server/runtime/persisted_transcript_scan.go
@@ -108,6 +108,7 @@ func clonePersistedChatEntry(entry ChatEntry) ChatEntry {
 	copyEntry.BackgroundExitCode = textutil.Pointer(entry.BackgroundExitCode)
 	copyEntry.WorktreeContext = session.CloneWorktreeContext(entry.WorktreeContext)
 	copyEntry.ToolCall = clonePersistedToolCallMeta(entry.ToolCall)
+	copyEntry.DeveloperDiagnostic = transcript.CloneDeveloperDiagnostic(entry.DeveloperDiagnostic)
 	return copyEntry
 }
 

--- a/server/runtime/streaming_transcript_scan.go
+++ b/server/runtime/streaming_transcript_scan.go
@@ -30,6 +30,7 @@ type streamingTranscriptScan struct {
 	scan             *inMemoryTranscriptScan
 	completions      map[string]tools.Result
 	materialized     map[string]struct{}
+	diagnostics      map[string]*transcript.DeveloperDiagnostic
 	cacheWarningMode config.CacheWarningMode
 
 	turn turnBuffer
@@ -48,10 +49,12 @@ type turnBuffer struct {
 func newStreamingTranscriptScan(req inMemoryTranscriptScanRequest, cacheWarningMode config.CacheWarningMode) *streamingTranscriptScan {
 	completions := make(map[string]tools.Result)
 	materialized := make(map[string]struct{})
+	diagnostics := make(map[string]*transcript.DeveloperDiagnostic)
 	return &streamingTranscriptScan{
-		scan:             newInMemoryTranscriptScan(req, completions, materialized),
+		scan:             newInMemoryTranscriptScan(req, completions, materialized, diagnostics),
 		completions:      completions,
 		materialized:     materialized,
+		diagnostics:      diagnostics,
 		cacheWarningMode: cacheWarningMode,
 	}
 }
@@ -74,6 +77,9 @@ func (s *streamingTranscriptScan) ApplyPersistedEvent(evt session.Event) error {
 		if err := json.Unmarshal(evt.Payload, &completion); err != nil {
 			return fmt.Errorf("decode tool_completed event: %w", err)
 		}
+		if err := validateStoredToolCompletionDiagnostic(completion); err != nil {
+			return fmt.Errorf("decode tool_completed event: %w", err)
+		}
 		callID := strings.TrimSpace(completion.CallID)
 		if callID == "" {
 			return nil
@@ -86,6 +92,9 @@ func (s *streamingTranscriptScan) ApplyPersistedEvent(evt session.Event) error {
 			Summary:       completion.Summary,
 			CondensedText: completion.CondensedText,
 			Presentation:  completion.Presentation,
+		}
+		if completion.Diagnostic != nil {
+			s.diagnostics[callID] = transcript.CloneDeveloperDiagnostic(completion.Diagnostic)
 		}
 	case "local_entry":
 		s.closeTurn()
@@ -198,6 +207,7 @@ func (s *streamingTranscriptScan) closeTurn() {
 	for _, callID := range callIDs {
 		delete(s.completions, callID)
 		delete(s.materialized, callID)
+		delete(s.diagnostics, callID)
 	}
 	s.turn = turnBuffer{
 		callIDs:           callIDs[:0],

--- a/server/runtime/tool_completion_diagnostic.go
+++ b/server/runtime/tool_completion_diagnostic.go
@@ -1,0 +1,15 @@
+package runtime
+
+import "core/shared/transcript"
+
+func toolCompletionDiagnosticFact(diagnostic transcript.DeveloperDiagnostic) TranscriptCommittedRowFact {
+	return TranscriptCommittedRowFact{
+		Kind:       TranscriptCommittedRowFactNotice,
+		Visibility: transcript.EntryVisibilityOngoing,
+		Notice: &TranscriptNoticeRowFact{
+			Reason:              transcript.NoticeReasonRuntimeDiagnostic,
+			Severity:            transcript.NoticeSeverityError,
+			DeveloperDiagnostic: transcript.CloneDeveloperDiagnostic(&diagnostic),
+		},
+	}
+}

--- a/server/runtime/tool_completion_presentation.go
+++ b/server/runtime/tool_completion_presentation.go
@@ -8,7 +8,12 @@ import (
 	"core/shared/transcript"
 )
 
-func (e *Engine) finalizeLiveToolCompletion(result tools.Result) tools.Result {
+type toolCompletionFinalization struct {
+	tools.Result
+	Diagnostic *transcript.DeveloperDiagnostic
+}
+
+func (e *Engine) finalizeLiveToolCompletion(result tools.Result) toolCompletionFinalization {
 	if result.Presentation != nil {
 		panic(fmt.Sprintf(
 			"tool result presentation invariant violated: live completion already has finalized presentation (call_id=%q tool=%q)",
@@ -27,7 +32,7 @@ func (e *Engine) finalizeLiveToolCompletion(result tools.Result) tools.Result {
 	return toolResultWithTranscriptPresentation(result, call, e.transcriptWorkingDir())
 }
 
-func toolResultWithTranscriptPresentation(result tools.Result, call llm.ToolCall, workingDir string) tools.Result {
+func toolResultWithTranscriptPresentation(result tools.Result, call llm.ToolCall, workingDir string) toolCompletionFinalization {
 	callMeta := transcriptToolCallMeta(call, workingDir)
 	if callMeta == nil {
 		panic(fmt.Sprintf(
@@ -36,8 +41,18 @@ func toolResultWithTranscriptPresentation(result tools.Result, call llm.ToolCall
 			result.Name,
 		))
 	}
-	finalized := transcript.ApplyToolResultPresentationDelta(*callMeta, result.PresentationDelta)
+	outcome := transcript.ToolResultPresentationOutcomeSuccessful
+	if result.IsError {
+		outcome = transcript.ToolResultPresentationOutcomeFailed
+	}
+	finalized, err := transcript.ApplyToolResultPresentationDelta(*callMeta, result.PresentationDelta, outcome)
 	result.PresentationDelta = nil
+	if err != nil {
+		finalized = transcript.NormalizeToolCallMeta(*callMeta)
+		diagnostic := transcript.NewDeletionFactMismatchDeveloperDiagnostic(result.CallID, *err)
+		result.Presentation = &finalized
+		return toolCompletionFinalization{Result: result, Diagnostic: &diagnostic}
+	}
 	result.Presentation = &finalized
-	return result
+	return toolCompletionFinalization{Result: result}
 }

--- a/server/runtime/tool_completion_presentation_test.go
+++ b/server/runtime/tool_completion_presentation_test.go
@@ -1,0 +1,341 @@
+package runtime
+
+import (
+	"encoding/json"
+	"testing"
+
+	"core/server/llm"
+	"core/server/session/sessiontest"
+	"core/server/tools"
+	"core/shared/toolspec"
+	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
+)
+
+func TestLiveToolCompletionPersistsAndProjectsDeletionMismatchDiagnosticAfterResult(t *testing.T) {
+	store := mustCreateTestSession(t)
+	emitted := make([]Event, 0, 1)
+	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{
+		OnEvent: func(event Event) {
+			emitted = append(emitted, event)
+		},
+	})
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	call := llm.ToolCall{
+		ID:   "call-live",
+		Name: string(toolspec.ToolPatch),
+		Presentation: transcript.EncodeToolCallMeta(transcript.ToolCallMeta{
+			ToolName:    string(toolspec.ToolPatch),
+			PatchRender: &rendered,
+		}),
+	}
+	receipt, err := eng.appendMessageRaw(
+		"step",
+		llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{call}},
+		steeringMessageEventNone,
+		true,
+	)
+	if err != nil || !receipt.Committed {
+		t.Fatalf("persist tool call: receipt=%+v error=%v", receipt, err)
+	}
+	receipt, err = eng.steerWithCommitReceipt("step", steerToolCompletionIntent(tools.Result{
+		CallID: call.ID,
+		Name:   toolspec.ToolPatch,
+		Output: json.RawMessage(`{"ok":true}`),
+		PresentationDelta: &transcript.ToolResultPresentationDelta{
+			WholeFileDeletionFacts: []patchformat.WholeFileDeletionFact{{
+				ID:      patchformat.WholeFileDeletionOperationID{HunkOrdinal: 1},
+				Removed: 3,
+			}},
+		},
+	}))
+	if err != nil || !receipt.Committed {
+		t.Fatalf("persist mismatched tool completion: receipt=%+v error=%v", receipt, err)
+	}
+
+	var completionEvent *Event
+	for index := range emitted {
+		if emitted[index].Kind == EventToolCallCompleted {
+			completionEvent = &emitted[index]
+		}
+	}
+	if completionEvent == nil || completionEvent.ToolResult == nil ||
+		completionEvent.ToolResult.IsError ||
+		completionEvent.ToolCompletionDiagnostic == nil {
+		t.Fatalf("completion event = %+v, want successful result plus diagnostic", completionEvent)
+	}
+	facts := TranscriptCommittedRowFactsFromEvent(*completionEvent)
+	if len(facts) != 2 ||
+		facts[0].Kind != TranscriptCommittedRowFactTool ||
+		facts[1].Kind != TranscriptCommittedRowFactNotice ||
+		facts[1].Notice == nil ||
+		!transcript.DeveloperDiagnosticEqual(facts[1].Notice.DeveloperDiagnostic, completionEvent.ToolCompletionDiagnostic) {
+		t.Fatalf("completion facts = %+v, want result followed by typed diagnostic notice", facts)
+	}
+	var hydration TranscriptHydrationSnapshot
+	if err := eng.WithTranscriptHydrationSnapshot(func(snapshot TranscriptHydrationSnapshot) error {
+		hydration = snapshot
+		return nil
+	}); err != nil {
+		t.Fatalf("hydrate live transcript: %v", err)
+	}
+	if len(hydration.CommittedRows) != 2 ||
+		hydration.CommittedRows[0].Kind != TranscriptCommittedRowFactTool ||
+		hydration.CommittedRows[1].Kind != TranscriptCommittedRowFactNotice ||
+		hydration.CommittedRows[1].Notice == nil ||
+		!transcript.DeveloperDiagnosticEqual(
+			hydration.CommittedRows[1].Notice.DeveloperDiagnostic,
+			completionEvent.ToolCompletionDiagnostic,
+		) {
+		t.Fatalf("live hydration rows = %+v, want result followed by typed diagnostic notice", hydration.CommittedRows)
+	}
+
+	persisted, err := sessiontest.CollectEvents(store)
+	if err != nil {
+		t.Fatalf("collect events: %v", err)
+	}
+	var stored storedToolCompletion
+	for _, event := range persisted {
+		if event.Kind == "tool_completed" {
+			if err := json.Unmarshal(event.Payload, &stored); err != nil {
+				t.Fatalf("decode persisted completion: %v", err)
+			}
+		}
+	}
+	if stored.Diagnostic == nil ||
+		!transcript.DeveloperDiagnosticEqual(stored.Diagnostic, completionEvent.ToolCompletionDiagnostic) {
+		t.Fatalf("persisted completion diagnostic = %+v, want %+v", stored.Diagnostic, completionEvent.ToolCompletionDiagnostic)
+	}
+
+	page, err := eng.TranscriptNewestSegmentPage()
+	if err != nil {
+		t.Fatalf("newest segment page: %v", err)
+	}
+	if len(page.Snapshot.Entries) != 3 ||
+		page.Snapshot.Entries[1].Role != "tool_result_ok" ||
+		page.Snapshot.Entries[2].Role != string(transcript.EntryRoleDeveloperErrorFeedback) ||
+		!transcript.DeveloperDiagnosticEqual(page.Snapshot.Entries[2].DeveloperDiagnostic, stored.Diagnostic) {
+		t.Fatalf("persisted page entries = %+v, want call, result, diagnostic", page.Snapshot.Entries)
+	}
+}
+
+func TestToolCompletionDiagnosticRejectsMismatchedCompletionCallID(t *testing.T) {
+	diagnostic := transcript.NewDeletionFactMismatchDeveloperDiagnostic(
+		"call-diagnostic",
+		patchformat.WholeFileDeletionFactMismatchError{
+			Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+		},
+	)
+	payload, err := json.Marshal(storedToolCompletion{
+		CallID:       "call-completion",
+		Name:         string(toolspec.ToolPatch),
+		Output:       json.RawMessage(`{"ok":true}`),
+		Presentation: deletionDiagnosticTestPresentation(),
+		Diagnostic:   &diagnostic,
+	})
+	if err != nil {
+		t.Fatalf("marshal completion payload: %v", err)
+	}
+	chat := newChatStore()
+	if err := chat.restoreToolCompletionPayload(payload); err == nil {
+		t.Fatal("restore accepted a diagnostic for another tool completion")
+	}
+	if len(chat.toolCompletions) != 0 {
+		t.Fatalf("rejected completion mutated runtime state: completions=%d", len(chat.toolCompletions))
+	}
+
+	store := mustCreateTestSession(t)
+	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{})
+	receipt, err := eng.persistToolCompletionRaw("step", toolCompletionFinalization{
+		Result: tools.Result{
+			CallID:       "call-completion",
+			Name:         toolspec.ToolPatch,
+			Output:       json.RawMessage(`{"ok":true}`),
+			Presentation: deletionDiagnosticTestPresentation(),
+		},
+		Diagnostic: &diagnostic,
+	})
+	if err == nil || receipt.Committed {
+		t.Fatalf("persist accepted mismatched diagnostic: receipt=%+v error=%v", receipt, err)
+	}
+}
+
+func deletionDiagnosticTestPresentation() *transcript.ToolCallMeta {
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	return &transcript.ToolCallMeta{
+		ToolName:    string(toolspec.ToolPatch),
+		PatchRender: &rendered,
+	}
+}
+
+func TestFailedToolCompletionDoesNotCreateDeletionMismatchDiagnostic(t *testing.T) {
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	finalization := toolResultWithTranscriptPresentation(tools.Result{
+		CallID:  "call-failed",
+		Name:    toolspec.ToolPatch,
+		IsError: true,
+		PresentationDelta: &transcript.ToolResultPresentationDelta{
+			WholeFileDeletionFacts: []patchformat.WholeFileDeletionFact{{
+				ID:      patchformat.WholeFileDeletionOperationID{HunkOrdinal: 99},
+				Removed: 1,
+			}},
+		},
+	}, llm.ToolCall{
+		ID:   "call-failed",
+		Name: string(toolspec.ToolPatch),
+		Presentation: transcript.EncodeToolCallMeta(transcript.ToolCallMeta{
+			ToolName:    string(toolspec.ToolPatch),
+			PatchRender: &rendered,
+		}),
+	}, "/workspace")
+	if finalization.Diagnostic != nil {
+		t.Fatalf("failed completion created deletion mismatch diagnostic: %+v", finalization.Diagnostic)
+	}
+}
+
+func TestToolResultPresentationMismatchPreservesSuccessfulUncountedCompletion(t *testing.T) {
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	call := llm.ToolCall{
+		ID:   "call-1",
+		Name: string(toolspec.ToolPatch),
+		Presentation: transcript.EncodeToolCallMeta(transcript.ToolCallMeta{
+			ToolName:    string(toolspec.ToolPatch),
+			PatchRender: &rendered,
+		}),
+	}
+	result := tools.Result{
+		CallID:  call.ID,
+		Name:    toolspec.ToolPatch,
+		Output:  json.RawMessage(`{"ok":true}`),
+		IsError: false,
+		PresentationDelta: &transcript.ToolResultPresentationDelta{
+			WholeFileDeletionFacts: []patchformat.WholeFileDeletionFact{{
+				ID:      patchformat.WholeFileDeletionOperationID{HunkOrdinal: 99},
+				Removed: 3,
+			}},
+		},
+	}
+
+	finalization := toolResultWithTranscriptPresentation(result, call, "/workspace")
+
+	if finalization.IsError {
+		t.Fatal("presentation mismatch changed successful tool completion into an error")
+	}
+	if finalization.PresentationDelta != nil {
+		t.Fatalf("presentation delta was not consumed: %+v", finalization.PresentationDelta)
+	}
+	if finalization.Presentation == nil ||
+		finalization.Presentation.PatchRender == nil ||
+		finalization.Presentation.PatchRender.Files[0].Removed != 0 ||
+		finalization.Presentation.PatchRender.Files[0].WholeFileDeletions[0].CountKnown {
+		t.Fatalf("completion did not preserve original uncounted presentation: %+v", finalization.Presentation)
+	}
+	if finalization.Diagnostic == nil ||
+		finalization.Diagnostic.Kind() != transcript.DeveloperDiagnosticDeletionFactMismatch ||
+		finalization.Diagnostic.DeletionFactMismatch == nil ||
+		finalization.Diagnostic.DeletionFactMismatch.CallID != call.ID ||
+		finalization.Diagnostic.DeletionFactMismatch.MismatchKind != patchformat.WholeFileDeletionFactMismatchUnmatched {
+		t.Fatalf("typed mismatch diagnostic = %+v", finalization.Diagnostic)
+	}
+}
+
+func TestToolResultPresentationMissingFactsPreserveSuccessfulUncountedCompletion(t *testing.T) {
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: first.txt\n*** Delete File: second.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	call := llm.ToolCall{
+		ID:   "call-missing",
+		Name: string(toolspec.ToolPatch),
+		Presentation: transcript.EncodeToolCallMeta(transcript.ToolCallMeta{
+			ToolName:    string(toolspec.ToolPatch),
+			PatchRender: &rendered,
+		}),
+	}
+	firstFact := patchformat.WholeFileDeletionFact{
+		ID:      patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+		Removed: 2,
+	}
+	tests := []struct {
+		name  string
+		delta *transcript.ToolResultPresentationDelta
+	}{
+		{name: "nil"},
+		{name: "empty", delta: &transcript.ToolResultPresentationDelta{}},
+		{name: "partial", delta: &transcript.ToolResultPresentationDelta{WholeFileDeletionFacts: []patchformat.WholeFileDeletionFact{firstFact}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			finalization := toolResultWithTranscriptPresentation(tools.Result{
+				CallID:            call.ID,
+				Name:              toolspec.ToolPatch,
+				Output:            json.RawMessage(`{"ok":true}`),
+				PresentationDelta: test.delta,
+			}, call, "/workspace")
+
+			if finalization.IsError || finalization.PresentationDelta != nil {
+				t.Fatalf("successful completion changed on missing fact: %+v", finalization.Result)
+			}
+			for _, file := range finalization.Presentation.PatchRender.Files {
+				if file.Removed != 0 || file.WholeFileDeletions[0].CountKnown {
+					t.Fatalf("missing fact fabricated count: %+v", finalization.Presentation.PatchRender)
+				}
+			}
+			context := finalization.Diagnostic.DeletionFactMismatch
+			if context == nil ||
+				context.MismatchKind != patchformat.WholeFileDeletionFactMismatchMissing {
+				t.Fatalf("missing-fact diagnostic = %+v", finalization.Diagnostic)
+			}
+		})
+	}
+}
+
+func TestToolResultPresentationNegativeFactPreservesSuccessfulUncountedCompletion(t *testing.T) {
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	call := llm.ToolCall{
+		ID:   "call-negative",
+		Name: string(toolspec.ToolPatch),
+		Presentation: transcript.EncodeToolCallMeta(transcript.ToolCallMeta{
+			ToolName:    string(toolspec.ToolPatch),
+			PatchRender: &rendered,
+		}),
+	}
+	finalization := toolResultWithTranscriptPresentation(tools.Result{
+		CallID: call.ID,
+		Name:   toolspec.ToolPatch,
+		Output: json.RawMessage(`{"ok":true}`),
+		PresentationDelta: &transcript.ToolResultPresentationDelta{
+			WholeFileDeletionFacts: []patchformat.WholeFileDeletionFact{{
+				ID:      patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+				Removed: -1,
+			}},
+		},
+	}, call, "/workspace")
+
+	if finalization.IsError ||
+		finalization.Presentation.PatchRender.Files[0].Removed != 0 ||
+		finalization.Presentation.PatchRender.Files[0].WholeFileDeletions[0].CountKnown {
+		t.Fatalf("negative fact changed successful uncounted completion: %+v", finalization)
+	}
+	context := finalization.Diagnostic.DeletionFactMismatch
+	if context == nil ||
+		context.MismatchKind != patchformat.WholeFileDeletionFactMismatchInvalidCount {
+		t.Fatalf("negative-fact diagnostic = %+v", finalization.Diagnostic)
+	}
+}

--- a/server/runtime/tool_completion_presentation_test.go
+++ b/server/runtime/tool_completion_presentation_test.go
@@ -7,6 +7,7 @@ import (
 	"core/server/llm"
 	"core/server/session/sessiontest"
 	"core/server/tools"
+	"core/shared/config"
 	"core/shared/toolspec"
 	"core/shared/transcript"
 	patchformat "core/shared/transcript/patchformat"
@@ -164,6 +165,56 @@ func TestToolCompletionDiagnosticRejectsMismatchedCompletionCallID(t *testing.T)
 	}
 }
 
+func TestToolCompletionDiagnosticRejectsFailedCompletionWithoutMutatingRestoreOrScanState(t *testing.T) {
+	diagnostic := transcript.NewDeletionFactMismatchDeveloperDiagnostic(
+		"call-failed",
+		patchformat.WholeFileDeletionFactMismatchError{
+			Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+		},
+	)
+	completion := storedToolCompletion{
+		CallID:       "call-failed",
+		Name:         string(toolspec.ToolPatch),
+		IsError:      true,
+		Output:       json.RawMessage(`{"error":"failed"}`),
+		Presentation: deletionDiagnosticTestPresentation(),
+		Diagnostic:   &diagnostic,
+	}
+	payload, err := json.Marshal(completion)
+	if err != nil {
+		t.Fatalf("marshal completion payload: %v", err)
+	}
+
+	chat := newChatStore()
+	if err := chat.restoreToolCompletionPayload(payload); err == nil {
+		t.Fatal("restore accepted a diagnostic on a failed completion")
+	}
+	if len(chat.toolCompletions) != 0 || len(chat.toolCompletionDiagnostics) != 0 {
+		t.Fatalf(
+			"rejected restore mutated state: completions=%d diagnostics=%d",
+			len(chat.toolCompletions),
+			len(chat.toolCompletionDiagnostics),
+		)
+	}
+
+	scan := newStreamingTranscriptScan(
+		inMemoryTranscriptScanRequest{Offset: 0, Limit: 0},
+		config.CacheWarningModeDefault,
+	)
+	if err := scan.ApplyPersistedEvent(streamScanTestEvent(t, "tool_completed", completion)); err == nil {
+		t.Fatal("streaming scan accepted a diagnostic on a failed completion")
+	}
+	if len(scan.completions) != 0 || len(scan.diagnostics) != 0 || scan.scan.totalEntries != 0 {
+		t.Fatalf(
+			"rejected scan mutated state: completions=%d diagnostics=%d entries=%d",
+			len(scan.completions),
+			len(scan.diagnostics),
+			scan.scan.totalEntries,
+		)
+	}
+}
+
 func deletionDiagnosticTestPresentation() *transcript.ToolCallMeta {
 	rendered := patchformat.Render(
 		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
@@ -243,8 +294,12 @@ func TestToolResultPresentationMismatchPreservesSuccessfulUncountedCompletion(t 
 		finalization.Presentation.PatchRender.Files[0].WholeFileDeletions[0].CountKnown {
 		t.Fatalf("completion did not preserve original uncounted presentation: %+v", finalization.Presentation)
 	}
-	if finalization.Diagnostic == nil ||
-		finalization.Diagnostic.Kind() != transcript.DeveloperDiagnosticDeletionFactMismatch ||
+	if finalization.Diagnostic == nil {
+		t.Fatal("typed mismatch diagnostic is missing")
+	}
+	diagnosticKind, diagnosticKindPresent := finalization.Diagnostic.Kind()
+	if !diagnosticKindPresent ||
+		diagnosticKind != transcript.DeveloperDiagnosticDeletionFactMismatch ||
 		finalization.Diagnostic.DeletionFactMismatch == nil ||
 		finalization.Diagnostic.DeletionFactMismatch.CallID != call.ID ||
 		finalization.Diagnostic.DeletionFactMismatch.MismatchKind != patchformat.WholeFileDeletionFactMismatchUnmatched {

--- a/server/runtime/transcript_delivery_facts.go
+++ b/server/runtime/transcript_delivery_facts.go
@@ -68,8 +68,9 @@ type TranscriptNoticeRowFact struct {
 	BackgroundActivityID string
 	BackgroundProcessID  string
 	BackgroundExitCode   *int
-	DiagnosticCode       string
-	DiagnosticDetail     string
+	DiagnosticCode       *string
+	DiagnosticDetail     *string
+	DeveloperDiagnostic  *transcript.DeveloperDiagnostic
 	CacheWarning         *TranscriptCacheWarningFact
 }
 
@@ -95,6 +96,9 @@ func TranscriptCommittedRowFactsFromEvent(evt Event) []TranscriptCommittedRowFac
 			return nil
 		}
 		facts = []TranscriptCommittedRowFact{transcriptToolRowFactFromResult(*evt.ToolResult)}
+		if evt.ToolCompletionDiagnostic != nil {
+			facts = append(facts, toolCompletionDiagnosticFact(*evt.ToolCompletionDiagnostic))
+		}
 	case EventCacheWarning:
 		if evt.CacheWarning == nil {
 			return nil
@@ -175,6 +179,16 @@ func TranscriptToolStartFactsFromEvent(evt Event) []TranscriptLiveToolStart {
 }
 
 func transcriptCommittedRowFactsFromMessage(msg llm.Message, streamID *uuid.UUID, completions map[string]tools.Result, materializedToolCalls map[string]struct{}) []TranscriptCommittedRowFact {
+	return transcriptCommittedRowFactsWithToolCompletionDiagnostics(msg, streamID, completions, materializedToolCalls, nil)
+}
+
+func transcriptCommittedRowFactsWithToolCompletionDiagnostics(
+	msg llm.Message,
+	streamID *uuid.UUID,
+	completions map[string]tools.Result,
+	materializedToolCalls map[string]struct{},
+	diagnostics map[string]*transcript.DeveloperDiagnostic,
+) []TranscriptCommittedRowFact {
 	switch msg.Role {
 	case llm.RoleUser:
 		if msg.MessageType == llm.MessageTypeCompactionSummary {
@@ -195,12 +209,12 @@ func transcriptCommittedRowFactsFromMessage(msg llm.Message, streamID *uuid.UUID
 		}
 		for _, call := range msg.ToolCalls {
 			if result, ok := synthesizedToolResultForCall(call, completions, materializedToolCalls); ok {
-				out = append(out, transcriptToolRowFactFromResult(result))
+				out = appendToolCompletionFacts(out, result, diagnostics)
 			}
 		}
 		return out
 	case llm.RoleTool:
-		return []TranscriptCommittedRowFact{transcriptToolRowFactFromResult(resolvedToolResultForMessage(msg, completions))}
+		return appendToolCompletionFacts(nil, resolvedToolResultForMessage(msg, completions), diagnostics)
 	case llm.RoleDeveloper:
 		if msg.MessageType == llm.MessageTypeReviewerFeedback {
 			return nil
@@ -218,7 +232,36 @@ func transcriptCommittedRowFactsFromMessage(msg llm.Message, streamID *uuid.UUID
 }
 
 func transcriptCommittedEntryCountFromMessage(msg llm.Message, completions map[string]tools.Result, materializedToolCalls map[string]struct{}) int {
-	return len(visibleChatEntriesFromMessage(msg, completions, materializedToolCalls))
+	return transcriptCommittedEntryCountWithToolCompletionDiagnostics(msg, completions, materializedToolCalls, nil)
+}
+
+func transcriptCommittedEntryCountWithToolCompletionDiagnostics(
+	msg llm.Message,
+	completions map[string]tools.Result,
+	materializedToolCalls map[string]struct{},
+	diagnostics map[string]*transcript.DeveloperDiagnostic,
+) int {
+	entries := visibleChatEntriesFromMessage(msg, completions, materializedToolCalls)
+	count := len(entries)
+	for _, entry := range entries {
+		if (entry.Role == "tool_result_ok" || entry.Role == "tool_result_error") &&
+			diagnostics[strings.TrimSpace(entry.ToolCallID)] != nil {
+			count++
+		}
+	}
+	return count
+}
+
+func appendToolCompletionFacts(
+	facts []TranscriptCommittedRowFact,
+	result tools.Result,
+	diagnostics map[string]*transcript.DeveloperDiagnostic,
+) []TranscriptCommittedRowFact {
+	facts = append(facts, transcriptToolRowFactFromResult(result))
+	if diagnostic := diagnostics[strings.TrimSpace(result.CallID)]; diagnostic != nil {
+		facts = append(facts, toolCompletionDiagnosticFact(*diagnostic))
+	}
+	return facts
 }
 
 func transcriptCommittedRowFactFromChatEntry(entry ChatEntry) (TranscriptCommittedRowFact, bool) {
@@ -351,6 +394,12 @@ func transcriptToolEntryHasRecoverableText(entry ChatEntry) bool {
 }
 
 func transcriptNoticeEntryIntegrity(entry ChatEntry) transcript.RowIntegrity {
+	if entry.DeveloperDiagnostic != nil {
+		if err := entry.DeveloperDiagnostic.Validate(); err != nil {
+			return transcript.RowIntegrityUnrecoverableMalformed
+		}
+		return transcript.RowIntegrityValid
+	}
 	if firstNonBlankTranscriptValue(entry.Text, entry.CondensedText, entry.CompactLabel, entry.SourcePath) == "" {
 		return transcript.RowIntegrityUnrecoverableMalformed
 	}
@@ -522,12 +571,17 @@ func runtimeNoticeFactFromMessage(msg llm.Message, severity string) TranscriptCo
 		BackgroundActivityID: strings.TrimSpace(msg.BackgroundActivityID),
 		BackgroundProcessID:  strings.TrimSpace(msg.Name),
 		BackgroundExitCode:   textutil.Pointer(msg.BackgroundExitCode),
-		DiagnosticCode:       code,
-		DiagnosticDetail:     msg.Content,
+		DiagnosticCode:       optionalDiagnosticString(code),
+		DiagnosticDetail:     optionalDiagnosticString(msg.Content),
 	}}
 }
 
 func runtimeNoticeFactFromLocalEntry(entry ChatEntry) TranscriptCommittedRowFact {
+	if entry.DeveloperDiagnostic != nil {
+		fact := toolCompletionDiagnosticFact(*entry.DeveloperDiagnostic)
+		fact.Visibility = normalizeRuntimeEntryVisibility(entry.Visibility)
+		return fact
+	}
 	noticeID := strings.TrimSpace(entry.NoticeID)
 	var noticeIDPtr *string
 	if noticeID != "" {
@@ -551,8 +605,8 @@ func runtimeNoticeFactFromLocalEntry(entry ChatEntry) TranscriptCommittedRowFact
 		BackgroundActivityID: strings.TrimSpace(entry.BackgroundActivityID),
 		BackgroundProcessID:  strings.TrimSpace(entry.BackgroundProcessID),
 		BackgroundExitCode:   textutil.Pointer(entry.BackgroundExitCode),
-		DiagnosticCode:       role,
-		DiagnosticDetail:     detail,
+		DiagnosticCode:       optionalDiagnosticString(role),
+		DiagnosticDetail:     optionalDiagnosticString(detail),
 	}}
 }
 
@@ -564,8 +618,8 @@ func emptyDeveloperMessageDiagnosticFact(msg llm.Message) TranscriptCommittedRow
 		MessageType:      msg.MessageType,
 		SourcePath:       strings.TrimSpace(msg.SourcePath),
 		CompactLabel:     compactLabelForMessage(msg),
-		DiagnosticCode:   code,
-		DiagnosticDetail: "empty developer message",
+		DiagnosticCode:   optionalDiagnosticString(code),
+		DiagnosticDetail: optionalDiagnosticString("empty developer message"),
 	}}
 }
 
@@ -577,9 +631,17 @@ func runtimeDiagnosticNoticeFact(code string, severity string, detail string) Tr
 	return TranscriptCommittedRowFact{Kind: TranscriptCommittedRowFactNotice, Visibility: transcript.EntryVisibilityOngoing, Notice: &TranscriptNoticeRowFact{
 		Reason:           transcript.NoticeReasonRuntimeDiagnostic,
 		Severity:         normalizeTranscriptNoticeSeverity(severity),
-		DiagnosticCode:   code,
-		DiagnosticDetail: detail,
+		DiagnosticCode:   optionalDiagnosticString(code),
+		DiagnosticDetail: optionalDiagnosticString(detail),
 	}}
+}
+
+func optionalDiagnosticString(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return &value
 }
 
 func normalizeTranscriptNoticeSeverity(severity string) string {

--- a/server/runtime/transcript_delivery_facts.go
+++ b/server/runtime/transcript_delivery_facts.go
@@ -241,11 +241,11 @@ func transcriptCommittedEntryCountWithToolCompletionDiagnostics(
 	materializedToolCalls map[string]struct{},
 	diagnostics map[string]*transcript.DeveloperDiagnostic,
 ) int {
-	entries := visibleChatEntriesFromMessage(msg, completions, materializedToolCalls)
-	count := len(entries)
-	for _, entry := range entries {
-		if (entry.Role == "tool_result_ok" || entry.Role == "tool_result_error") &&
-			diagnostics[strings.TrimSpace(entry.ToolCallID)] != nil {
+	projections := visibleChatEntryProjectionsFromMessage(msg, completions, materializedToolCalls)
+	count := len(projections)
+	for _, projection := range projections {
+		if projection.ToolCompletion != nil &&
+			diagnostics[strings.TrimSpace(projection.ToolCompletion.CallID)] != nil {
 			count++
 		}
 	}

--- a/server/runtime/transcript_event_entries.go
+++ b/server/runtime/transcript_event_entries.go
@@ -12,36 +12,54 @@ import (
 )
 
 func VisibleChatEntriesFromMessage(msg llm.Message) []ChatEntry {
-	return visibleChatEntriesFromMessage(msg, nil, nil)
+	projections := visibleChatEntryProjectionsFromMessage(msg, nil, nil)
+	entries := make([]ChatEntry, 0, len(projections))
+	for _, projection := range projections {
+		entries = append(entries, projection.Entry)
+	}
+	return entries
 }
 
-func visibleChatEntriesFromMessage(msg llm.Message, completions map[string]tools.Result, materializedToolCalls map[string]struct{}) []ChatEntry {
-	entries := make([]ChatEntry, 0, 1+len(msg.ToolCalls))
+type visibleChatEntryProjection struct {
+	Entry          ChatEntry
+	ToolCompletion *tools.Result
+}
+
+func visibleChatEntryProjectionsFromMessage(msg llm.Message, completions map[string]tools.Result, materializedToolCalls map[string]struct{}) []visibleChatEntryProjection {
+	entries := make([]visibleChatEntryProjection, 0, 1+len(msg.ToolCalls))
 	switch msg.Role {
 	case llm.RoleUser:
 		if entry, ok := visibleUserTranscriptEntry(msg); ok {
-			entries = append(entries, entry)
+			entries = append(entries, visibleChatEntryProjection{Entry: entry})
 		}
 	case llm.RoleAssistant:
 		if strings.TrimSpace(msg.Content) != "" && !isNoopFinalAnswer(msg) {
-			entries = append(entries, ChatEntry{
+			entries = append(entries, visibleChatEntryProjection{Entry: ChatEntry{
 				Visibility: assistantTranscriptVisibility(msg.Phase),
 				Role:       "assistant",
 				Text:       msg.Content,
 				Phase:      msg.Phase,
-			})
+			}})
 		}
 		for _, call := range msg.ToolCalls {
-			entries = append(entries, formatPersistedToolCall(call))
+			entries = append(entries, visibleChatEntryProjection{Entry: formatPersistedToolCall(call)})
 			if result, ok := synthesizedToolResultForCall(call, completions, materializedToolCalls); ok {
-				entries = append(entries, toolResultChatEntry(result))
+				resultCopy := result
+				entries = append(entries, visibleChatEntryProjection{
+					Entry:          toolResultChatEntry(result),
+					ToolCompletion: &resultCopy,
+				})
 			}
 		}
 	case llm.RoleTool:
-		entries = append(entries, toolResultChatEntry(resolvedToolResultForMessage(msg, completions)))
+		result := resolvedToolResultForMessage(msg, completions)
+		entries = append(entries, visibleChatEntryProjection{
+			Entry:          toolResultChatEntry(result),
+			ToolCompletion: &result,
+		})
 	case llm.RoleDeveloper:
 		if entry, ok := visibleDeveloperChatEntry(msg); ok {
-			entries = append(entries, entry)
+			entries = append(entries, visibleChatEntryProjection{Entry: entry})
 		}
 	}
 	return entries

--- a/server/runtime/transcript_event_entries.go
+++ b/server/runtime/transcript_event_entries.go
@@ -93,6 +93,9 @@ func TranscriptEntriesFromEvent(evt Event) []ChatEntry {
 			return nil
 		}
 		entries = []ChatEntry{toolResultChatEntry(*evt.ToolResult)}
+		if evt.ToolCompletionDiagnostic != nil {
+			entries = append(entries, toolCompletionDiagnosticChatEntry(*evt.ToolCompletionDiagnostic))
+		}
 	case EventReviewerCompleted:
 		// Reviewer completion remains a runtime-status event only.
 		// Persisted reviewer terminal rows must arrive through local_entry_added

--- a/server/runtime/transcript_message_visibility_test.go
+++ b/server/runtime/transcript_message_visibility_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"strings"
 	"testing"
 
 	"core/server/llm"
@@ -61,7 +62,7 @@ func TestAssistantCommentaryIsDetailOnlyWhileFinalAnswersRemainOngoing(t *testin
 			if len(facts) != 1 || facts[0].Visibility != test.want {
 				t.Fatalf("assistant facts = %+v, want one %q row", facts, test.want)
 			}
-			scan := newInMemoryTranscriptScan(inMemoryTranscriptScanRequest{Limit: 1}, nil, nil)
+			scan := newInMemoryTranscriptScan(inMemoryTranscriptScanRequest{Limit: 1}, nil, nil, nil)
 			scan.ApplyMessage(llm.Message{
 				Role:    llm.RoleAssistant,
 				Phase:   test.phase,
@@ -102,7 +103,8 @@ func TestEmptyUnknownDeveloperMessageProjectsDetailDiagnosticFact(t *testing.T) 
 		t.Fatalf("empty unknown developer facts = %+v, want one detail diagnostic notice", facts)
 	}
 	notice := facts[0].Notice
-	if notice.DiagnosticCode != string(unknownType) || notice.DiagnosticDetail == "" {
+	if notice.DiagnosticCode == nil || *notice.DiagnosticCode != string(unknownType) ||
+		notice.DiagnosticDetail == nil || strings.TrimSpace(*notice.DiagnosticDetail) == "" {
 		t.Fatalf("diagnostic notice = %+v, want unknown type code and non-empty detail", notice)
 	}
 }

--- a/server/runtime/transcript_projector_test.go
+++ b/server/runtime/transcript_projector_test.go
@@ -6,6 +6,7 @@ import (
 
 	"core/server/llm"
 	"core/server/session"
+	"core/server/tools"
 	"core/shared/toolspec"
 	"core/shared/transcript"
 	patchformat "core/shared/transcript/patchformat"
@@ -101,12 +102,42 @@ func TestPersistedTranscriptScanRestoresToolCompletionDiagnosticAfterResult(t *t
 	if len(entries) != 4 {
 		t.Fatalf("entry count = %d, want tool call, result, diagnostic, final", len(entries))
 	}
+	if entries[2].DeveloperDiagnostic == nil {
+		t.Fatalf("completion diagnostic is missing: %+v", entries)
+	}
+	diagnosticKind, diagnosticKindPresent := entries[2].DeveloperDiagnostic.Kind()
 	if entries[1].Role != "tool_result_ok" ||
 		entries[2].Role != string(transcript.EntryRoleDeveloperErrorFeedback) ||
 		entries[1].StepID != entries[2].StepID ||
-		entries[2].DeveloperDiagnostic == nil ||
-		entries[2].DeveloperDiagnostic.Kind() != transcript.DeveloperDiagnosticDeletionFactMismatch {
+		!diagnosticKindPresent ||
+		diagnosticKind != transcript.DeveloperDiagnosticDeletionFactMismatch {
 		t.Fatalf("completion/diagnostic adjacency was not restored: %+v", entries)
+	}
+}
+
+func TestToolCompletionProjectionCarriesTypedResultAuthority(t *testing.T) {
+	message := llm.Message{
+		Role:       llm.RoleTool,
+		ToolCallID: "call-1",
+		Name:       string(toolspec.ToolPatch),
+		Content:    `{"ok":true}`,
+	}
+	completions := map[string]tools.Result{
+		"call-1": {
+			CallID:  "call-1",
+			Name:    toolspec.ToolPatch,
+			IsError: false,
+			Output:  json.RawMessage(`{"ok":true}`),
+		},
+	}
+
+	projections := visibleChatEntryProjectionsFromMessage(message, completions, nil)
+	if len(projections) != 1 || projections[0].ToolCompletion == nil {
+		t.Fatalf("tool result projection = %+v, want one typed completion", projections)
+	}
+	if projections[0].ToolCompletion.CallID != "call-1" ||
+		projections[0].ToolCompletion.IsError {
+		t.Fatalf("typed completion authority = %+v", projections[0].ToolCompletion)
 	}
 }
 

--- a/server/runtime/transcript_projector_test.go
+++ b/server/runtime/transcript_projector_test.go
@@ -7,6 +7,8 @@ import (
 	"core/server/llm"
 	"core/server/session"
 	"core/shared/toolspec"
+	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
 )
 
 func applyPersistedScanEvents(t *testing.T, scan *PersistedTranscriptScan, events []session.Event) {
@@ -47,6 +49,95 @@ func TestPersistedTranscriptScanReconstructsPersistedTranscript(t *testing.T) {
 	}
 	if got := scan.LastCommittedAssistantFinalAnswer(); got != "final answer" {
 		t.Fatalf("LastCommittedAssistantFinalAnswer() = %q, want final answer", got)
+	}
+}
+
+func TestPersistedTranscriptScanRestoresToolCompletionDiagnosticAfterResult(t *testing.T) {
+	diagnostic := transcript.NewDeletionFactMismatchDeveloperDiagnostic(
+		"call-1",
+		patchformat.WholeFileDeletionFactMismatchError{
+			Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 1},
+		},
+	)
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	scan := NewPersistedTranscriptScan(PersistedTranscriptScanRequest{})
+	applyPersistedScanEvents(t, scan, []session.Event{
+		mustPersistedEvent(t, "message", llm.Message{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:    "call-1",
+				Name:  string(toolspec.ToolPatch),
+				Input: json.RawMessage(`{"patch":"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n"}`),
+			}},
+		}),
+		mustPersistedEvent(t, "tool_completed", storedToolCompletion{
+			CallID: "call-1",
+			Name:   string(toolspec.ToolPatch),
+			Output: json.RawMessage(`{"ok":true}`),
+			Presentation: &transcript.ToolCallMeta{
+				ToolName:    string(toolspec.ToolPatch),
+				PatchRender: &rendered,
+			},
+			Diagnostic: &diagnostic,
+		}),
+		mustPersistedEvent(t, "message", llm.Message{
+			Role:       llm.RoleTool,
+			ToolCallID: "call-1",
+			Name:       string(toolspec.ToolPatch),
+			Content:    `{"ok":true}`,
+		}),
+		mustPersistedEvent(t, "message", llm.Message{
+			Role:    llm.RoleAssistant,
+			Content: "done",
+			Phase:   llm.MessagePhaseFinal,
+		}),
+	})
+
+	entries := scan.CollectedPageSnapshot().Entries
+	if len(entries) != 4 {
+		t.Fatalf("entry count = %d, want tool call, result, diagnostic, final", len(entries))
+	}
+	if entries[1].Role != "tool_result_ok" ||
+		entries[2].Role != string(transcript.EntryRoleDeveloperErrorFeedback) ||
+		entries[1].StepID != entries[2].StepID ||
+		entries[2].DeveloperDiagnostic == nil ||
+		entries[2].DeveloperDiagnostic.Kind() != transcript.DeveloperDiagnosticDeletionFactMismatch {
+		t.Fatalf("completion/diagnostic adjacency was not restored: %+v", entries)
+	}
+}
+
+func TestPersistedTranscriptScanRejectsDiagnosticForDifferentToolCompletion(t *testing.T) {
+	diagnostic := transcript.NewDeletionFactMismatchDeveloperDiagnostic(
+		"call-b",
+		patchformat.WholeFileDeletionFactMismatchError{
+			Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+		},
+	)
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	scan := NewPersistedTranscriptScan(PersistedTranscriptScanRequest{})
+	err := scan.ApplyPersistedEvent(mustPersistedEvent(t, "tool_completed", storedToolCompletion{
+		CallID: "call-a",
+		Name:   string(toolspec.ToolPatch),
+		Output: json.RawMessage(`{"ok":true}`),
+		Presentation: &transcript.ToolCallMeta{
+			ToolName:    string(toolspec.ToolPatch),
+			PatchRender: &rendered,
+		},
+		Diagnostic: &diagnostic,
+	}))
+	if err == nil {
+		t.Fatal("streaming scan accepted diagnostic for a different tool completion")
+	}
+	if got := scan.TotalEntries(); got != 0 {
+		t.Fatalf("rejected completion projected %d entries", got)
 	}
 }
 

--- a/server/runtime/transcript_runtime_state.go
+++ b/server/runtime/transcript_runtime_state.go
@@ -11,7 +11,6 @@ import (
 	"core/shared/config"
 	"core/shared/rollbacktarget"
 	"core/shared/textutil"
-	"core/shared/toolspec"
 	"core/shared/transcript"
 
 	"github.com/google/uuid"
@@ -230,15 +229,7 @@ func (s *transcriptRuntimeState) RecordAssistantStreamFinalization(committedEntr
 }
 
 func (s *transcriptRuntimeState) RecordStoredToolCompletion(completion storedToolCompletion) {
-	s.chatProjection().recordToolCompletionWithProviderItems(tools.Result{
-		CallID:        completion.CallID,
-		Name:          toolspec.ID(completion.Name),
-		IsError:       completion.IsError,
-		Output:        completion.Output,
-		Summary:       completion.Summary,
-		CondensedText: completion.CondensedText,
-		Presentation:  completion.Presentation,
-	}, completion.ProviderItems)
+	s.chatProjection().recordStoredToolCompletion(completion)
 }
 
 func (s *transcriptRuntimeState) RestoreToolCompletionPayload(payload []byte) error {

--- a/server/runtime/transcript_scan.go
+++ b/server/runtime/transcript_scan.go
@@ -9,6 +9,7 @@ import (
 	"core/server/tools"
 	"core/shared/rollbacktarget"
 	"core/shared/textutil"
+	"core/shared/transcript"
 )
 
 type transcriptPageSnapshot struct {
@@ -36,11 +37,17 @@ type inMemoryTranscriptScan struct {
 	compactionEntryStart    int
 	hasCompactionCheckpoint bool
 
-	toolCompletions       map[string]tools.Result
-	materializedToolCalls map[string]struct{}
+	toolCompletions           map[string]tools.Result
+	materializedToolCalls     map[string]struct{}
+	toolCompletionDiagnostics map[string]*transcript.DeveloperDiagnostic
 }
 
-func newInMemoryTranscriptScan(req inMemoryTranscriptScanRequest, completions map[string]tools.Result, materializedToolCalls map[string]struct{}) *inMemoryTranscriptScan {
+func newInMemoryTranscriptScan(
+	req inMemoryTranscriptScanRequest,
+	completions map[string]tools.Result,
+	materializedToolCalls map[string]struct{},
+	diagnostics map[string]*transcript.DeveloperDiagnostic,
+) *inMemoryTranscriptScan {
 	if req.Offset < 0 {
 		req.Offset = 0
 	}
@@ -51,10 +58,11 @@ func newInMemoryTranscriptScan(req inMemoryTranscriptScanRequest, completions ma
 		req.TailLimit = 0
 	}
 	return &inMemoryTranscriptScan{
-		request:               req,
-		compactionEntryStart:  -1,
-		toolCompletions:       completions,
-		materializedToolCalls: materializedToolCalls,
+		request:                   req,
+		compactionEntryStart:      -1,
+		toolCompletions:           completions,
+		materializedToolCalls:     materializedToolCalls,
+		toolCompletionDiagnostics: diagnostics,
 	}
 }
 
@@ -69,6 +77,12 @@ func (s *inMemoryTranscriptScan) ApplyMessage(msg llm.Message, seq int64, stepID
 		}
 		entry.StepID = strings.TrimSpace(stepID)
 		s.appendEntry(entry)
+		if (entry.Role == "tool_result_ok" || entry.Role == "tool_result_error") &&
+			s.toolCompletionDiagnostics[strings.TrimSpace(entry.ToolCallID)] != nil {
+			diagnostic := toolCompletionDiagnosticChatEntry(*s.toolCompletionDiagnostics[strings.TrimSpace(entry.ToolCallID)])
+			diagnostic.StepID = strings.TrimSpace(stepID)
+			s.appendEntry(diagnostic)
+		}
 	}
 }
 

--- a/server/runtime/transcript_scan.go
+++ b/server/runtime/transcript_scan.go
@@ -70,16 +70,17 @@ func (s *inMemoryTranscriptScan) ApplyMessage(msg llm.Message, seq int64, stepID
 	if s == nil {
 		return
 	}
-	for _, entry := range visibleChatEntriesFromMessage(msg, s.toolCompletions, s.materializedToolCalls) {
+	for _, projection := range visibleChatEntryProjectionsFromMessage(msg, s.toolCompletions, s.materializedToolCalls) {
+		entry := projection.Entry
 		if strings.TrimSpace(entry.Role) == "user" && seq > 0 {
 			targetID := rollbacktarget.EncodeUserMessageSeq(seq)
 			entry.RollbackTargetID = &targetID
 		}
 		entry.StepID = strings.TrimSpace(stepID)
 		s.appendEntry(entry)
-		if (entry.Role == "tool_result_ok" || entry.Role == "tool_result_error") &&
-			s.toolCompletionDiagnostics[strings.TrimSpace(entry.ToolCallID)] != nil {
-			diagnostic := toolCompletionDiagnosticChatEntry(*s.toolCompletionDiagnostics[strings.TrimSpace(entry.ToolCallID)])
+		if projection.ToolCompletion != nil &&
+			s.toolCompletionDiagnostics[strings.TrimSpace(projection.ToolCompletion.CallID)] != nil {
+			diagnostic := toolCompletionDiagnosticChatEntry(*s.toolCompletionDiagnostics[strings.TrimSpace(projection.ToolCompletion.CallID)])
 			diagnostic.StepID = strings.TrimSpace(stepID)
 			s.appendEntry(diagnostic)
 		}

--- a/server/runtime/transcript_segment_page_test.go
+++ b/server/runtime/transcript_segment_page_test.go
@@ -1,12 +1,16 @@
 package runtime
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"core/server/llm"
 	"core/server/session"
 	"core/server/tools"
+	"core/shared/toolspec"
+	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
 )
 
 func appendSegmentTestMessage(t *testing.T, store *session.Store, role llm.Role, content string) {
@@ -156,5 +160,76 @@ func TestEngineTranscriptSegmentPageSingleSegment(t *testing.T) {
 	texts := segmentEntryTexts(page)
 	if !containsText(texts, "only") || !containsText(texts, "answer") {
 		t.Fatalf("single segment must contain all turns, got %v", texts)
+	}
+}
+
+func TestEngineTranscriptSegmentPageRestoresToolCompletionDiagnosticAfterResult(t *testing.T) {
+	store := mustCreateTestSession(t)
+	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{})
+	diagnostic := transcript.NewDeletionFactMismatchDeveloperDiagnostic(
+		"call-1",
+		patchformat.WholeFileDeletionFactMismatchError{
+			Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+		},
+	)
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	events := []struct {
+		kind    string
+		payload any
+	}{
+		{
+			kind: "message",
+			payload: llm.Message{
+				Role: llm.RoleAssistant,
+				ToolCalls: []llm.ToolCall{{
+					ID:    "call-1",
+					Name:  string(toolspec.ToolPatch),
+					Input: json.RawMessage(`{"patch":"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n"}`),
+				}},
+			},
+		},
+		{
+			kind: "tool_completed",
+			payload: storedToolCompletion{
+				CallID: "call-1",
+				Name:   string(toolspec.ToolPatch),
+				Output: json.RawMessage(`{"ok":true}`),
+				Presentation: &transcript.ToolCallMeta{
+					ToolName:    string(toolspec.ToolPatch),
+					PatchRender: &rendered,
+				},
+				Diagnostic: &diagnostic,
+			},
+		},
+		{
+			kind: "message",
+			payload: llm.Message{
+				Role:       llm.RoleTool,
+				ToolCallID: "call-1",
+				Name:       string(toolspec.ToolPatch),
+				Content:    `{"ok":true}`,
+			},
+		},
+	}
+	for _, event := range events {
+		if _, _, err := store.AppendEvent("step", event.kind, event.payload); err != nil {
+			t.Fatalf("append %s: %v", event.kind, err)
+		}
+	}
+
+	entries := mustEngineNewestSegmentPage(t, eng).Snapshot.Entries
+	if len(entries) != 3 {
+		t.Fatalf("entry count = %d, want tool call, result, diagnostic", len(entries))
+	}
+	if entries[1].Role != "tool_result_ok" ||
+		entries[2].Role != string(transcript.EntryRoleDeveloperErrorFeedback) ||
+		entries[1].StepID != entries[2].StepID ||
+		entries[2].StepID != "step" ||
+		!transcript.DeveloperDiagnosticEqual(entries[2].DeveloperDiagnostic, &diagnostic) {
+		t.Fatalf("segment completion/diagnostic adjacency = %+v", entries)
 	}
 }

--- a/server/runtimeview/transcript_subscription.go
+++ b/server/runtimeview/transcript_subscription.go
@@ -514,20 +514,38 @@ func transcriptNoticeFromFact(stepID string, fact *runtime.TranscriptNoticeRowFa
 			Visibility:      fact.CacheWarning.Visibility,
 		}
 	}
-	diagnosticCode := strings.TrimSpace(fact.DiagnosticCode)
-	diagnosticDetail := fact.DiagnosticDetail
-	if diagnosticCode != "" || strings.TrimSpace(diagnosticDetail) != "" {
-		if diagnosticCode == "" || strings.TrimSpace(diagnosticDetail) == "" {
+	hasLegacyDiagnostic := fact.DiagnosticCode != nil || fact.DiagnosticDetail != nil
+	hasDeveloperDiagnostic := fact.DeveloperDiagnostic != nil
+	if hasLegacyDiagnostic && hasDeveloperDiagnostic {
+		panic(fmt.Sprintf(
+			"runtime transcript notice has both legacy and developer diagnostic facts: code=%v detail=%v reason=%q",
+			fact.DiagnosticCode,
+			fact.DiagnosticDetail,
+			fact.Reason,
+		))
+	}
+	if hasLegacyDiagnostic {
+		if fact.DiagnosticCode == nil || fact.DiagnosticDetail == nil ||
+			strings.TrimSpace(*fact.DiagnosticCode) == "" ||
+			strings.TrimSpace(*fact.DiagnosticDetail) == "" {
 			panic(fmt.Sprintf(
-				"runtime transcript notice has partial diagnostic facts: code=%q detail_present=%t reason=%q",
-				diagnosticCode,
-				diagnosticDetail != "",
+				"runtime transcript notice has partial diagnostic facts: code=%v detail=%v reason=%q",
+				fact.DiagnosticCode,
+				fact.DiagnosticDetail,
 				fact.Reason,
 			))
 		}
 		notice.Diagnostic = &clientui.TranscriptDiagnostic{
-			Code:   clientui.TranscriptDiagnosticCode(diagnosticCode),
-			Detail: diagnosticDetail,
+			Code:   clientui.TranscriptDiagnosticCode(strings.TrimSpace(*fact.DiagnosticCode)),
+			Detail: *fact.DiagnosticDetail,
+		}
+	}
+	if hasDeveloperDiagnostic {
+		if err := fact.DeveloperDiagnostic.Validate(); err != nil {
+			panic(fmt.Sprintf("runtime transcript notice has invalid developer diagnostic: %v", err))
+		}
+		notice.Diagnostic = &clientui.TranscriptDiagnostic{
+			Developer: transcript.CloneDeveloperDiagnostic(fact.DeveloperDiagnostic),
 		}
 	}
 	activityID := strings.TrimSpace(fact.BackgroundActivityID)

--- a/server/runtimeview/transcript_subscription.go
+++ b/server/runtimeview/transcript_subscription.go
@@ -167,10 +167,9 @@ func transcriptCompactionStatus(evt runtime.Event) clientui.TranscriptCompaction
 		status.State = clientui.CompactionCompleted
 	case runtime.EventCompactionFailed:
 		status.State = clientui.CompactionFailed
-		status.Diagnostic = clientui.NewLegacyTranscriptDiagnostic(
-			clientui.TranscriptDiagnosticCode("compaction_failed"),
-			strings.TrimSpace(evt.Compaction.Error),
-		)
+		code := clientui.TranscriptDiagnosticCode("compaction_failed")
+		detail := strings.TrimSpace(evt.Compaction.Error)
+		status.Diagnostic = &clientui.TranscriptDiagnostic{Code: &code, Detail: &detail}
 	default:
 		panic(fmt.Sprintf("runtime event %q carries compaction facts outside the compaction lifecycle", evt.Kind))
 	}
@@ -304,10 +303,9 @@ func transcriptToolAbortMessages(evt runtime.Event) []clientui.TranscriptMessage
 		Reason:     reason,
 	}
 	if reason == clientui.ToolAbortFailed {
-		abort.Diagnostic = clientui.NewLegacyTranscriptDiagnostic(
-			clientui.TranscriptDiagnosticCode("tool_failed"),
-			strings.TrimSpace(evt.Error),
-		)
+		code := clientui.TranscriptDiagnosticCode("tool_failed")
+		detail := strings.TrimSpace(evt.Error)
+		abort.Diagnostic = &clientui.TranscriptDiagnostic{Code: &code, Detail: &detail}
 	}
 	return []clientui.TranscriptMessage{transcriptMessage(
 		clientui.TranscriptMessageToolAbort,
@@ -535,16 +533,17 @@ func transcriptNoticeFromFact(stepID string, fact *runtime.TranscriptNoticeRowFa
 				fact.Reason,
 			))
 		}
-		notice.Diagnostic = clientui.NewLegacyTranscriptDiagnostic(
-			clientui.TranscriptDiagnosticCode(strings.TrimSpace(*fact.DiagnosticCode)),
-			*fact.DiagnosticDetail,
-		)
+		code := clientui.TranscriptDiagnosticCode(strings.TrimSpace(*fact.DiagnosticCode))
+		detail := *fact.DiagnosticDetail
+		notice.Diagnostic = &clientui.TranscriptDiagnostic{Code: &code, Detail: &detail}
 	}
 	if hasDeveloperDiagnostic {
 		if err := fact.DeveloperDiagnostic.Validate(); err != nil {
 			panic(fmt.Sprintf("runtime transcript notice has invalid developer diagnostic: %v", err))
 		}
-		notice.Diagnostic = clientui.NewDeveloperTranscriptDiagnostic(*fact.DeveloperDiagnostic)
+		notice.Diagnostic = &clientui.TranscriptDiagnostic{
+			Developer: transcript.CloneDeveloperDiagnostic(fact.DeveloperDiagnostic),
+		}
 	}
 	activityID := strings.TrimSpace(fact.BackgroundActivityID)
 	processID := strings.TrimSpace(fact.BackgroundProcessID)

--- a/server/runtimeview/transcript_subscription.go
+++ b/server/runtimeview/transcript_subscription.go
@@ -167,10 +167,10 @@ func transcriptCompactionStatus(evt runtime.Event) clientui.TranscriptCompaction
 		status.State = clientui.CompactionCompleted
 	case runtime.EventCompactionFailed:
 		status.State = clientui.CompactionFailed
-		status.Diagnostic = &clientui.TranscriptDiagnostic{
-			Code:   clientui.TranscriptDiagnosticCode("compaction_failed"),
-			Detail: strings.TrimSpace(evt.Compaction.Error),
-		}
+		status.Diagnostic = clientui.NewLegacyTranscriptDiagnostic(
+			clientui.TranscriptDiagnosticCode("compaction_failed"),
+			strings.TrimSpace(evt.Compaction.Error),
+		)
 	default:
 		panic(fmt.Sprintf("runtime event %q carries compaction facts outside the compaction lifecycle", evt.Kind))
 	}
@@ -304,10 +304,10 @@ func transcriptToolAbortMessages(evt runtime.Event) []clientui.TranscriptMessage
 		Reason:     reason,
 	}
 	if reason == clientui.ToolAbortFailed {
-		abort.Diagnostic = &clientui.TranscriptDiagnostic{
-			Code:   clientui.TranscriptDiagnosticCode("tool_failed"),
-			Detail: strings.TrimSpace(evt.Error),
-		}
+		abort.Diagnostic = clientui.NewLegacyTranscriptDiagnostic(
+			clientui.TranscriptDiagnosticCode("tool_failed"),
+			strings.TrimSpace(evt.Error),
+		)
 	}
 	return []clientui.TranscriptMessage{transcriptMessage(
 		clientui.TranscriptMessageToolAbort,
@@ -535,18 +535,16 @@ func transcriptNoticeFromFact(stepID string, fact *runtime.TranscriptNoticeRowFa
 				fact.Reason,
 			))
 		}
-		notice.Diagnostic = &clientui.TranscriptDiagnostic{
-			Code:   clientui.TranscriptDiagnosticCode(strings.TrimSpace(*fact.DiagnosticCode)),
-			Detail: *fact.DiagnosticDetail,
-		}
+		notice.Diagnostic = clientui.NewLegacyTranscriptDiagnostic(
+			clientui.TranscriptDiagnosticCode(strings.TrimSpace(*fact.DiagnosticCode)),
+			*fact.DiagnosticDetail,
+		)
 	}
 	if hasDeveloperDiagnostic {
 		if err := fact.DeveloperDiagnostic.Validate(); err != nil {
 			panic(fmt.Sprintf("runtime transcript notice has invalid developer diagnostic: %v", err))
 		}
-		notice.Diagnostic = &clientui.TranscriptDiagnostic{
-			Developer: transcript.CloneDeveloperDiagnostic(fact.DeveloperDiagnostic),
-		}
+		notice.Diagnostic = clientui.NewDeveloperTranscriptDiagnostic(*fact.DeveloperDiagnostic)
 	}
 	activityID := strings.TrimSpace(fact.BackgroundActivityID)
 	processID := strings.TrimSpace(fact.BackgroundProcessID)

--- a/server/runtimeview/transcript_subscription_test.go
+++ b/server/runtimeview/transcript_subscription_test.go
@@ -99,7 +99,7 @@ func TestTranscriptNoticeProjectionCarriesTypedDeveloperDiagnostic(t *testing.T)
 	if row.Notice == nil || row.Notice.Diagnostic == nil || row.Notice.Diagnostic.Developer == nil {
 		t.Fatalf("projected developer diagnostic = %+v", row.Notice)
 	}
-	if row.Notice.Diagnostic.Code != "" || row.Notice.Diagnostic.Detail != "" {
+	if row.Notice.Diagnostic.Code != nil || row.Notice.Diagnostic.Detail != nil {
 		t.Fatalf("developer diagnostic leaked legacy fields: %+v", row.Notice.Diagnostic)
 	}
 	if !transcript.DeveloperDiagnosticEqual(row.Notice.Diagnostic.Developer, &diagnostic) {

--- a/server/runtimeview/transcript_subscription_test.go
+++ b/server/runtimeview/transcript_subscription_test.go
@@ -13,6 +13,7 @@ import (
 	"core/shared/clientui"
 	"core/shared/rollbacktarget"
 	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
 
 	"github.com/google/uuid"
 )
@@ -75,6 +76,34 @@ func TestTranscriptCommittedRowsPreserveRuntimeVisibility(t *testing.T) {
 	}
 	if got := hydration.CommittedRows[0].Visibility; got != clientui.EntryVisibilityHidden {
 		t.Fatalf("hydration visibility = %q, want hidden", got)
+	}
+}
+
+func TestTranscriptNoticeProjectionCarriesTypedDeveloperDiagnostic(t *testing.T) {
+	diagnostic := transcript.NewDeletionFactMismatchDeveloperDiagnostic(
+		"call-1",
+		patchformat.WholeFileDeletionFactMismatchError{
+			Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 2},
+		},
+	)
+	row := transcriptRowFromFact(runtime.TranscriptCommittedRowFact{
+		Visibility: transcript.EntryVisibilityOngoing,
+		Kind:       runtime.TranscriptCommittedRowFactNotice,
+		Notice: &runtime.TranscriptNoticeRowFact{
+			Reason:              transcript.NoticeReasonRuntimeDiagnostic,
+			Severity:            transcript.NoticeSeverityError,
+			DeveloperDiagnostic: &diagnostic,
+		},
+	})
+	if row.Notice == nil || row.Notice.Diagnostic == nil || row.Notice.Diagnostic.Developer == nil {
+		t.Fatalf("projected developer diagnostic = %+v", row.Notice)
+	}
+	if row.Notice.Diagnostic.Code != "" || row.Notice.Diagnostic.Detail != "" {
+		t.Fatalf("developer diagnostic leaked legacy fields: %+v", row.Notice.Diagnostic)
+	}
+	if !transcript.DeveloperDiagnosticEqual(row.Notice.Diagnostic.Developer, &diagnostic) {
+		t.Fatalf("projected developer diagnostic = %+v, want %+v", row.Notice.Diagnostic.Developer, diagnostic)
 	}
 }
 

--- a/server/session/store.go
+++ b/server/session/store.go
@@ -152,19 +152,26 @@ func OpenByID(persistenceRoot, sessionID string, options ...StoreOption) (*Store
 }
 
 func openPersistedSessionWithReconciliationRefresh(storeOpts storeOptions, resolve func() (PersistedSessionRecord, error)) (*Store, error) {
-	record, err := resolve()
-	if err != nil {
-		return nil, err
+	var conflict error
+	for attempt := 0; attempt < maxEventLogReconciliationOpenAttempts; attempt++ {
+		record, err := resolve()
+		if err != nil {
+			if conflict != nil {
+				return nil, errors.Join(conflict, fmt.Errorf("refresh session metadata after event-log reconciliation conflict: %w", err))
+			}
+			return nil, err
+		}
+		opened, err := openPersistedSession(record.SessionDir, record.Meta, storeOpts)
+		if !errors.Is(err, ErrEventLogReconciliationConflict) {
+			return opened, err
+		}
+		conflict = err
 	}
-	opened, err := openPersistedSession(record.SessionDir, record.Meta, storeOpts)
-	if !errors.Is(err, ErrEventLogReconciliationConflict) {
-		return opened, err
-	}
-	refreshed, refreshErr := resolve()
-	if refreshErr != nil {
-		return nil, errors.Join(err, fmt.Errorf("refresh session metadata after event-log reconciliation conflict: %w", refreshErr))
-	}
-	return openPersistedSession(refreshed.SessionDir, refreshed.Meta, storeOpts)
+	return nil, fmt.Errorf(
+		"open persisted session did not converge after %d event-log reconciliation attempts: %w",
+		maxEventLogReconciliationOpenAttempts,
+		conflict,
+	)
 }
 
 func openPersistedSession(sessionDir string, resolvedMeta *Meta, storeOpts storeOptions) (*Store, error) {

--- a/server/session/store_options.go
+++ b/server/session/store_options.go
@@ -14,9 +14,10 @@ const (
 )
 
 const (
-	defaultEventLogFSyncPolicy         = EventLogFSyncPeriodic
-	defaultEventLogFSyncIntervalWrites = 16
-	defaultPersistenceObserverTimeout  = 2 * time.Second
+	defaultEventLogFSyncPolicy            = EventLogFSyncPeriodic
+	defaultEventLogFSyncIntervalWrites    = 16
+	defaultPersistenceObserverTimeout     = 2 * time.Second
+	maxEventLogReconciliationOpenAttempts = 8
 )
 
 type StoreOption func(*storeOptions)

--- a/server/session/store_part2_test.go
+++ b/server/session/store_part2_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -473,6 +474,95 @@ func TestOpenReconcilesMetaLastSequenceFromEventLog(t *testing.T) {
 	}
 	if next.Seq != 3 {
 		t.Fatalf("expected seq=3 after reopen reconciliation, got %d", next.Seq)
+	}
+}
+
+type conflictingReconciliationObserver struct {
+	record             PersistedSessionRecord
+	conflictsRemaining int
+	resolveCalls       int
+	reconcileCalls     int
+}
+
+func (o *conflictingReconciliationObserver) ObservePersistedStore(_ context.Context, snapshot PersistedStoreSnapshot) error {
+	o.record = PersistedSessionRecord{SessionDir: snapshot.SessionDir, Meta: ptrMeta(snapshot.Meta)}
+	return nil
+}
+
+func (o *conflictingReconciliationObserver) ObserveEventLogReconciliation(_ context.Context, reconciliation PersistedEventLogReconciliation) error {
+	o.reconcileCalls++
+	if o.conflictsRemaining > 0 {
+		o.conflictsRemaining--
+		return EventLogReconciliationConflictError{
+			SessionID:            reconciliation.SessionID,
+			ObservedLastSequence: reconciliation.ObservedLastSequence,
+			CurrentLastSequence:  reconciliation.ObservedLastSequence + 1,
+		}
+	}
+	return nil
+}
+
+func (o *conflictingReconciliationObserver) ResolvePersistedSession(_ context.Context, _ string) (PersistedSessionRecord, error) {
+	o.resolveCalls++
+	return cloneTestPersistedSessionRecord(o.record), nil
+}
+
+func TestOpenRetriesEventLogReconciliationUntilMetadataConverges(t *testing.T) {
+	store := newSessionTestStore(t)
+	if _, _, err := store.AppendEvent("s1", "message", map[string]any{"role": "user", "content": "u1"}); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	meta := store.Meta()
+	meta.LastSequence = 0
+	observer := &conflictingReconciliationObserver{
+		record:             PersistedSessionRecord{SessionDir: store.Dir(), Meta: &meta},
+		conflictsRemaining: 2,
+	}
+
+	reopened, err := Open(
+		store.Dir(),
+		WithPersistedSessionResolver(observer),
+		WithPersistenceObserver(observer),
+	)
+	if err != nil {
+		t.Fatalf("open store after conflicts: %v", err)
+	}
+	if reopened.Meta().LastSequence != 1 {
+		t.Fatalf("reconciled last sequence = %d, want 1", reopened.Meta().LastSequence)
+	}
+	if observer.resolveCalls != 3 || observer.reconcileCalls != 3 {
+		t.Fatalf("retry calls = {resolve:%d reconcile:%d}, want 3 each", observer.resolveCalls, observer.reconcileCalls)
+	}
+}
+
+func TestOpenBoundsPersistentEventLogReconciliationConflicts(t *testing.T) {
+	store := newSessionTestStore(t)
+	if _, _, err := store.AppendEvent("s1", "message", map[string]any{"role": "user", "content": "u1"}); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	meta := store.Meta()
+	meta.LastSequence = 0
+	observer := &conflictingReconciliationObserver{
+		record:             PersistedSessionRecord{SessionDir: store.Dir(), Meta: &meta},
+		conflictsRemaining: maxEventLogReconciliationOpenAttempts,
+	}
+
+	_, err := Open(
+		store.Dir(),
+		WithPersistedSessionResolver(observer),
+		WithPersistenceObserver(observer),
+	)
+	if !errors.Is(err, ErrEventLogReconciliationConflict) {
+		t.Fatalf("open error = %v, want reconciliation conflict", err)
+	}
+	if observer.resolveCalls != maxEventLogReconciliationOpenAttempts ||
+		observer.reconcileCalls != maxEventLogReconciliationOpenAttempts {
+		t.Fatalf(
+			"bounded retry calls = {resolve:%d reconcile:%d}, want %d each",
+			observer.resolveCalls,
+			observer.reconcileCalls,
+			maxEventLogReconciliationOpenAttempts,
+		)
 	}
 }
 

--- a/server/tools/patch/tool.go
+++ b/server/tools/patch/tool.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"core/server/tools"
+	"core/shared/transcript"
 	patchformat "core/shared/transcript/patchformat"
 )
 
@@ -73,7 +74,8 @@ func (t *Tool) Call(ctx context.Context, c tools.Call) (tools.Result, error) {
 			return json.Marshal(errorPayload(patchErr))
 		}), nil
 	}
-	if err := t.apply(ctx, doc); err != nil {
+	deletionFacts, err := t.apply(ctx, doc)
+	if err != nil {
 		return tools.ErrorResultWith(c, err.Error(), func(any) (json.RawMessage, error) {
 			return json.Marshal(errorPayload(err))
 		}), nil
@@ -83,38 +85,45 @@ func (t *Tool) Call(ctx context.Context, c tools.Call) (tools.Result, error) {
 		"ok":         true,
 		"operations": len(doc.Hunks),
 	})
-	return tools.Result{CallID: c.ID, Name: c.Name, Output: body}, nil
+	result := tools.Result{CallID: c.ID, Name: c.Name, Output: body}
+	if len(deletionFacts) > 0 {
+		result.PresentationDelta = &transcript.ToolResultPresentationDelta{
+			WholeFileDeletionFacts: deletionFacts,
+		}
+	}
+	return result, nil
 }
 
-func (t *Tool) apply(ctx context.Context, doc patchformat.Document) error {
+func (t *Tool) apply(ctx context.Context, doc patchformat.Document) ([]patchformat.WholeFileDeletionFact, error) {
 	state := newApplyState(t, ctx)
 	unlock, err := state.lockDocumentPaths(doc)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer unlock()
-	for _, h := range doc.Hunks {
+	for ordinal, h := range doc.Hunks {
 		switch op := h.(type) {
 		case patchformat.AddFile:
 			if err := state.addFile(op); err != nil {
-				return err
+				return nil, err
 			}
 		case patchformat.DeleteFile:
-			if err := state.deleteFile(op); err != nil {
-				return err
+			operationID := patchformat.WholeFileDeletionOperationID{HunkOrdinal: ordinal}
+			if err := state.deleteFile(op, operationID); err != nil {
+				return nil, err
 			}
 		case patchformat.UpdateFile:
 			if err := state.updateFile(op); err != nil {
-				return err
+				return nil, err
 			}
 		default:
-			return fmt.Errorf("unsupported patch hunk: %T", h)
+			return nil, fmt.Errorf("unsupported patch hunk: %T", h)
 		}
 	}
 
 	states, err := state.prepareCommitStates()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer cleanupStagedFiles(states)
 	return commitStagedFiles(states, state.deleteTargets)

--- a/server/tools/patch/tool_commit.go
+++ b/server/tools/patch/tool_commit.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	patchformat "core/shared/transcript/patchformat"
 )
 
 type patchFileState struct {
@@ -54,10 +56,14 @@ func cleanupStagedFiles(states []*patchFileState) {
 	}
 }
 
-func commitStagedFiles(states []*patchFileState, deleteTargets map[string]struct{}) error {
+func commitStagedFiles(
+	states []*patchFileState,
+	deleteTargets map[string]patchformat.WholeFileDeletionOperationID,
+) ([]patchformat.WholeFileDeletionFact, error) {
 	committed := make([]committedWrite, 0, len(states))
 	removed := make([]removedSource, 0, len(states)*2)
 	removedPaths := make(map[string]struct{}, len(deleteTargets)+len(states))
+	deletionFacts := make([]patchformat.WholeFileDeletionFact, 0, len(deleteTargets))
 	rollback := func() error {
 		var rollbackErr error
 		for i := len(committed) - 1; i >= 0; i-- {
@@ -99,6 +105,12 @@ func commitStagedFiles(states []*patchFileState, deleteTargets map[string]struct
 			return primary
 		}
 		removed = append(removed, removedSource{Path: path, Before: before})
+		if operationID, explicitDelete := deleteTargets[path]; explicitDelete {
+			deletionFacts = append(deletionFacts, patchformat.WholeFileDeletionFact{
+				ID:      operationID,
+				Removed: len(splitLines(string(before.Data))),
+			})
+		}
 		return nil
 	}
 
@@ -109,14 +121,14 @@ func commitStagedFiles(states []*patchFileState, deleteTargets map[string]struct
 	sort.Strings(deletePaths)
 	for _, path := range deletePaths {
 		if err := removePath(path, "delete target"); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	for _, s := range states {
 		if s.NewPath != s.Original {
 			if err := removePath(s.Original, "moved source"); err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
@@ -125,29 +137,32 @@ func commitStagedFiles(states []*patchFileState, deleteTargets map[string]struct
 		if err := os.MkdirAll(filepath.Dir(s.NewPath), 0o755); err != nil {
 			primary := fmt.Errorf("create parent dir for %s: %w", s.NewPath, err)
 			if rollbackErr := rollback(); rollbackErr != nil {
-				return errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
+				return nil, errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
 			}
-			return primary
+			return nil, primary
 		}
 		before, err := captureSnapshot(s.NewPath)
 		if err != nil {
 			primary := fmt.Errorf("snapshot target %s: %w", s.NewPath, err)
 			if rollbackErr := rollback(); rollbackErr != nil {
-				return errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
+				return nil, errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
 			}
-			return primary
+			return nil, primary
 		}
 		if err := os.Rename(s.StagedPath, s.NewPath); err != nil {
 			primary := fmt.Errorf("commit write %s: %w", s.NewPath, err)
 			if rollbackErr := rollback(); rollbackErr != nil {
-				return errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
+				return nil, errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
 			}
-			return primary
+			return nil, primary
 		}
 		committed = append(committed, committedWrite{Path: s.NewPath, Before: before})
 	}
 
-	return nil
+	sort.Slice(deletionFacts, func(i, j int) bool {
+		return deletionFacts[i].ID.HunkOrdinal < deletionFacts[j].ID.HunkOrdinal
+	})
+	return deletionFacts, nil
 }
 
 func createStagedFile(targetPath string, data []byte, mode os.FileMode) (string, error) {

--- a/server/tools/patch/tool_deletion_facts_test.go
+++ b/server/tools/patch/tool_deletion_facts_test.go
@@ -1,0 +1,253 @@
+package patch
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"core/server/tools"
+	patchformat "core/shared/transcript/patchformat"
+)
+
+func TestDeleteFileReturnsLogicalLineCountFacts(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantRemoved int
+	}{
+		{name: "multi line", content: "first\r\nsecond\r\n", wantRemoved: 2},
+		{name: "empty", content: "", wantRemoved: 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			target := filepath.Join(workspace, "delete.txt")
+			if err := os.WriteFile(target, []byte(test.content), 0o644); err != nil {
+				t.Fatalf("seed delete target: %v", err)
+			}
+
+			result := callPatch(
+				t,
+				newPatchTestTool(t, workspace),
+				"delete-count",
+				"*** Begin Patch\n*** Delete File: delete.txt\n*** End Patch\n",
+			)
+			if result.IsError {
+				t.Fatalf("delete failed: %s", string(result.Output))
+			}
+			if _, err := os.Stat(target); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("delete target remains, stat err=%v", err)
+			}
+			facts := result.PresentationDelta.WholeFileDeletionFacts
+			if len(facts) != 1 {
+				t.Fatalf("deletion facts = %d, want one", len(facts))
+			}
+			wantID := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0}
+			if facts[0].ID != wantID || facts[0].Removed != test.wantRemoved {
+				t.Fatalf("deletion fact = %+v, want identity %+v and removed %d", facts[0], wantID, test.wantRemoved)
+			}
+		})
+	}
+}
+
+func TestCommitStagedFilesCountsTheSnapshotItRemoves(t *testing.T) {
+	workspace := t.TempDir()
+	target := filepath.Join(workspace, "delete.txt")
+	if err := os.WriteFile(target, []byte("validated earlier\n"), 0o644); err != nil {
+		t.Fatalf("seed delete target: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("commit\nsnapshot\ncontent\n"), 0o644); err != nil {
+		t.Fatalf("change target before commit: %v", err)
+	}
+	operationID := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 4}
+
+	facts, err := commitStagedFiles(nil, map[string]patchformat.WholeFileDeletionOperationID{
+		target: operationID,
+	})
+	if err != nil {
+		t.Fatalf("commit deletion: %v", err)
+	}
+	if len(facts) != 1 || facts[0].ID != operationID || facts[0].Removed != 3 {
+		t.Fatalf("commit deletion facts = %+v, want later three-line snapshot", facts)
+	}
+	if _, err := os.Stat(target); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("delete target remains, stat err=%v", err)
+	}
+}
+
+func TestFailedDeleteOperationsReturnNoCountFacts(t *testing.T) {
+	t.Run("path denied", func(t *testing.T) {
+		workspace := t.TempDir()
+		target := filepath.Join(workspace, "denied.txt")
+		if err := os.WriteFile(target, []byte("keep\n"), 0o644); err != nil {
+			t.Fatalf("seed denied target: %v", err)
+		}
+		result := callPatch(
+			t,
+			newPatchTestTool(t, workspace, WithPathDenyPolicy(
+				compileLiteralTreeDenyPolicy(t, target, "deny deletion"),
+			)),
+			"delete-denied",
+			"*** Begin Patch\n*** Delete File: denied.txt\n*** End Patch\n",
+		)
+		if !result.IsError {
+			t.Fatal("path-denied deletion succeeded")
+		}
+		assertNoWholeFileDeletionFacts(t, result)
+		assertPatchFileContent(t, target, "keep\n")
+	})
+
+	t.Run("outside approval denied", func(t *testing.T) {
+		workspace := t.TempDir()
+		outsideRoot := outsideNonTempDir(t)
+		target := filepath.Join(outsideRoot, "outside.txt")
+		if err := os.WriteFile(target, []byte("keep\n"), 0o644); err != nil {
+			t.Fatalf("seed outside target: %v", err)
+		}
+		result := callPatch(
+			t,
+			newPatchTestTool(t, workspace, WithOutsideWorkspaceApprover(
+				func(context.Context, OutsideWorkspaceRequest) (OutsideWorkspaceApproval, error) {
+					return OutsideWorkspaceApproval{Decision: OutsideWorkspaceDecisionDeny}, nil
+				},
+			)),
+			"delete-outside-denied",
+			"*** Begin Patch\n*** Delete File: "+target+"\n*** End Patch\n",
+		)
+		if !result.IsError {
+			t.Fatal("unapproved outside deletion succeeded")
+		}
+		assertNoWholeFileDeletionFacts(t, result)
+		assertPatchFileContent(t, target, "keep\n")
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		workspace := t.TempDir()
+		result := callPatch(
+			t,
+			newPatchTestTool(t, workspace),
+			"delete-missing",
+			"*** Begin Patch\n*** Delete File: missing.txt\n*** End Patch\n",
+		)
+		if !result.IsError {
+			t.Fatal("missing deletion succeeded")
+		}
+		assertNoWholeFileDeletionFacts(t, result)
+	})
+
+	t.Run("non regular", func(t *testing.T) {
+		workspace := t.TempDir()
+		target := filepath.Join(workspace, "directory")
+		if err := os.Mkdir(target, 0o755); err != nil {
+			t.Fatalf("seed directory target: %v", err)
+		}
+		result := callPatch(
+			t,
+			newPatchTestTool(t, workspace),
+			"delete-directory",
+			"*** Begin Patch\n*** Delete File: directory\n*** End Patch\n",
+		)
+		if !result.IsError {
+			t.Fatal("non-regular deletion succeeded")
+		}
+		assertNoWholeFileDeletionFacts(t, result)
+		info, err := os.Stat(target)
+		if err != nil || !info.IsDir() {
+			t.Fatalf("directory target changed, info=%v err=%v", info, err)
+		}
+	})
+}
+
+func TestRolledBackDeletionReturnsNoCountFacts(t *testing.T) {
+	workspace := t.TempDir()
+	deleteTarget := filepath.Join(workspace, "delete.txt")
+	if err := os.WriteFile(deleteTarget, []byte("restore\nme\n"), 0o644); err != nil {
+		t.Fatalf("seed delete target: %v", err)
+	}
+	blockingDirectory := filepath.Join(workspace, "blocking")
+	if err := os.Mkdir(blockingDirectory, 0o755); err != nil {
+		t.Fatalf("seed blocking directory: %v", err)
+	}
+	stage, err := createStagedFile(blockingDirectory, []byte("cannot commit\n"), 0o644)
+	if err != nil {
+		t.Fatalf("stage failing write: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(stage) })
+
+	facts, err := commitStagedFiles(
+		[]*patchFileState{{
+			Exists:     true,
+			NewPath:    blockingDirectory,
+			Original:   blockingDirectory,
+			StagedPath: stage,
+		}},
+		map[string]patchformat.WholeFileDeletionOperationID{
+			deleteTarget: {HunkOrdinal: 0},
+		},
+	)
+	if err == nil {
+		t.Fatal("expected commit failure")
+	}
+	if len(facts) != 0 {
+		t.Fatalf("rolled-back deletion returned facts: %+v", facts)
+	}
+	assertPatchFileContent(t, deleteTarget, "restore\nme\n")
+}
+
+func TestDuplicateCanonicalDeleteTargetsAreRejectedBeforeCommit(t *testing.T) {
+	tests := []struct {
+		name       string
+		secondPath func(*testing.T, string, string) string
+	}{
+		{
+			name: "same path",
+			secondPath: func(_ *testing.T, _ string, _ string) string {
+				return "target.txt"
+			},
+		},
+		{
+			name: "symlink alias",
+			secondPath: func(t *testing.T, workspace, target string) string {
+				alias := filepath.Join(workspace, "alias.txt")
+				if err := os.Symlink(target, alias); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+				return "alias.txt"
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			target := filepath.Join(workspace, "target.txt")
+			if err := os.WriteFile(target, []byte("keep\n"), 0o644); err != nil {
+				t.Fatalf("seed duplicate target: %v", err)
+			}
+			secondPath := test.secondPath(t, workspace, target)
+			result := callPatch(
+				t,
+				newPatchTestTool(t, workspace),
+				"duplicate-delete",
+				"*** Begin Patch\n*** Delete File: target.txt\n*** Delete File: "+secondPath+"\n*** End Patch\n",
+			)
+			if !result.IsError {
+				t.Fatal("duplicate canonical deletion succeeded")
+			}
+			if payload := toolFailurePayload(t, result); payload.Kind != string(failureKindMalformedSyntax) {
+				t.Fatalf("duplicate canonical deletion kind = %q, want malformed", payload.Kind)
+			}
+			assertNoWholeFileDeletionFacts(t, result)
+			assertPatchFileContent(t, target, "keep\n")
+		})
+	}
+}
+
+func assertNoWholeFileDeletionFacts(t *testing.T, result tools.Result) {
+	t.Helper()
+	if result.PresentationDelta != nil &&
+		len(result.PresentationDelta.WholeFileDeletionFacts) != 0 {
+		t.Fatalf("failed deletion returned facts: %+v", result.PresentationDelta.WholeFileDeletionFacts)
+	}
+}

--- a/server/tools/patch/tool_deletion_facts_test.go
+++ b/server/tools/patch/tool_deletion_facts_test.go
@@ -18,6 +18,7 @@ func TestDeleteFileReturnsLogicalLineCountFacts(t *testing.T) {
 		wantRemoved int
 	}{
 		{name: "multi line", content: "first\r\nsecond\r\n", wantRemoved: 2},
+		{name: "one line without final newline", content: "only line", wantRemoved: 1},
 		{name: "empty", content: "", wantRemoved: 0},
 	}
 	for _, test := range tests {

--- a/server/tools/patch/tool_state.go
+++ b/server/tools/patch/tool_state.go
@@ -16,7 +16,7 @@ type applyState struct {
 	tool            *Tool
 	ctx             context.Context
 	state           map[string]*patchFileState
-	deleteTargets   map[string]struct{}
+	deleteTargets   map[string]patchformat.WholeFileDeletionOperationID
 	approvedOutside map[string]bool
 }
 
@@ -25,7 +25,7 @@ func newApplyState(tool *Tool, ctx context.Context) *applyState {
 		tool:            tool,
 		ctx:             ctx,
 		state:           map[string]*patchFileState{},
-		deleteTargets:   map[string]struct{}{},
+		deleteTargets:   map[string]patchformat.WholeFileDeletionOperationID{},
 		approvedOutside: map[string]bool{},
 	}
 }
@@ -155,12 +155,15 @@ func (s *applyState) addFile(op patchformat.AddFile) error {
 	return nil
 }
 
-func (s *applyState) deleteFile(op patchformat.DeleteFile) error {
+func (s *applyState) deleteFile(op patchformat.DeleteFile, operationID patchformat.WholeFileDeletionOperationID) error {
 	target, err := s.tool.resolvePath(s.ctx, op.Path, true, s.approvedOutside)
 	if err != nil {
 		return err
 	}
 	if _, exists := s.state[target]; exists {
+		return malformedFailure(fmt.Sprintf("delete target already referenced: %s", op.Path))
+	}
+	if _, exists := s.deleteTargets[target]; exists {
 		return malformedFailure(fmt.Sprintf("delete target already referenced: %s", op.Path))
 	}
 	snapshot, err := captureSnapshot(target)
@@ -170,7 +173,7 @@ func (s *applyState) deleteFile(op patchformat.DeleteFile) error {
 	if !snapshot.Exists {
 		return targetMissingFailure(op.Path, "cannot delete a file that does not exist")
 	}
-	s.deleteTargets[target] = struct{}{}
+	s.deleteTargets[target] = operationID
 	return nil
 }
 

--- a/server/tools/patch/tool_test.go
+++ b/server/tools/patch/tool_test.go
@@ -671,7 +671,7 @@ func TestCommitStagedFilesRollsBackCommittedTargetsOnLaterFailure(t *testing.T) 
 		{Exists: true, NewPath: blockingDir, Original: blockingDir, StagedPath: secondStage},
 	}
 
-	err = commitStagedFiles(states, nil)
+	_, err = commitStagedFiles(states, nil)
 	if err == nil {
 		t.Fatal("expected transactional commit failure")
 	}

--- a/server/tools/transcript_contracts_test.go
+++ b/server/tools/transcript_contracts_test.go
@@ -1,6 +1,13 @@
 package tools
 
-import "testing"
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"core/shared/toolspec"
+	patchformat "core/shared/transcript/patchformat"
+)
 
 func TestFormatAskQuestionToolOutputRejectsPresentZeroSelection(t *testing.T) {
 	if formatted, ok := formatAskQuestionToolOutput([]byte(`{"selected_option_number":0,"freeform_answer":"typed"}`)); ok || formatted != "" {
@@ -12,5 +19,80 @@ func TestFormatAskQuestionToolOutputAcceptsLegacyOmittedSelection(t *testing.T) 
 	formatted, ok := formatAskQuestionToolOutput([]byte(`{"freeform_answer":"typed"}`))
 	if !ok || formatted == "" {
 		t.Fatalf("legacy omitted selection formatted as %q, %t; want freeform answer", formatted, ok)
+	}
+}
+
+func TestPatchToolCallMetaUsesOneRawFallbackForSupportedInvocationShapes(t *testing.T) {
+	patch, ok := DefinitionFor(toolspec.ToolPatch)
+	if !ok {
+		t.Fatalf("expected %s definition", toolspec.ToolPatch)
+	}
+	input := "not a structured patch\nsecond raw line"
+	oracle := patchformat.Raw(input)
+	stringShape, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshal string shape: %v", err)
+	}
+	objectShape, err := json.Marshal(struct {
+		Patch string `json:"patch"`
+	}{Patch: input})
+	if err != nil {
+		t.Fatalf("marshal object shape: %v", err)
+	}
+
+	var metas []struct {
+		detail  string
+		compact string
+		render  *patchformat.RenderedPatch
+	}
+	for _, raw := range []json.RawMessage{stringShape, objectShape} {
+		meta := patch.BuildToolCallMeta(ToolCallContext{WorkingDir: "/workspace"}, raw)
+		if meta.PatchRender == nil {
+			t.Fatalf("supported malformed patch shape used default metadata: %+v", meta)
+		}
+		if len(meta.PatchRender.Files) != 0 {
+			t.Fatalf("raw fallback exposed structured files: %+v", meta.PatchRender.Files)
+		}
+		if !reflect.DeepEqual(*meta.PatchRender, oracle) {
+			t.Fatalf("raw fallback = %+v, want oracle %+v", *meta.PatchRender, oracle)
+		}
+		if meta.Command != meta.PatchDetail || meta.CompactText != meta.PatchSummary {
+			t.Fatalf("raw fallback aliases are inconsistent: %+v", meta)
+		}
+		metas = append(metas, struct {
+			detail  string
+			compact string
+			render  *patchformat.RenderedPatch
+		}{
+			detail:  meta.PatchDetail,
+			compact: meta.PatchSummary,
+			render:  meta.PatchRender,
+		})
+	}
+	if !reflect.DeepEqual(metas[0], metas[1]) {
+		t.Fatalf("supported invocation shapes produced different raw metadata: left=%+v right=%+v", metas[0], metas[1])
+	}
+}
+
+func TestPatchToolCallMetaReservesDefaultFallbackForMalformedOrBlankInvocation(t *testing.T) {
+	patch, ok := DefinitionFor(toolspec.ToolPatch)
+	if !ok {
+		t.Fatalf("expected %s definition", toolspec.ToolPatch)
+	}
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+	}{
+		{name: "malformed JSON", raw: json.RawMessage(`{`)},
+		{name: "blank string", raw: json.RawMessage(`"   "`)},
+		{name: "blank object", raw: json.RawMessage(`{"patch":"\n\t"}`)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			meta := patch.BuildToolCallMeta(ToolCallContext{WorkingDir: "/workspace"}, test.raw)
+			if meta.PatchRender != nil {
+				t.Fatalf("default fallback unexpectedly carried a patch render: %+v", meta.PatchRender)
+			}
+		})
 	}
 }

--- a/shared/clientui/transcript_assistant_test.go
+++ b/shared/clientui/transcript_assistant_test.go
@@ -96,10 +96,10 @@ func TestTranscriptAssistantAbortRequiresTypedFailureDiagnostic(t *testing.T) {
 	if err := abort.Validate(); err == nil {
 		t.Fatal("accepted failed assistant abort without diagnostic")
 	}
-	abort.Diagnostic = &TranscriptDiagnostic{
-		Code:   TranscriptDiagnosticCode("assistant_stream_failed"),
-		Detail: "provider stream failed",
-	}
+	abort.Diagnostic = NewLegacyTranscriptDiagnostic(
+		TranscriptDiagnosticCode("assistant_stream_failed"),
+		"provider stream failed",
+	)
 	if err := abort.Validate(); err != nil {
 		t.Fatalf("validate failed assistant abort: %v", err)
 	}

--- a/shared/clientui/transcript_assistant_test.go
+++ b/shared/clientui/transcript_assistant_test.go
@@ -96,10 +96,9 @@ func TestTranscriptAssistantAbortRequiresTypedFailureDiagnostic(t *testing.T) {
 	if err := abort.Validate(); err == nil {
 		t.Fatal("accepted failed assistant abort without diagnostic")
 	}
-	abort.Diagnostic = legacyTranscriptDiagnosticForTest(
-		TranscriptDiagnosticCode("assistant_stream_failed"),
-		"provider stream failed",
-	)
+	code := TranscriptDiagnosticCode("assistant_stream_failed")
+	detail := "provider stream failed"
+	abort.Diagnostic = &TranscriptDiagnostic{Code: &code, Detail: &detail}
 	if err := abort.Validate(); err != nil {
 		t.Fatalf("validate failed assistant abort: %v", err)
 	}

--- a/shared/clientui/transcript_assistant_test.go
+++ b/shared/clientui/transcript_assistant_test.go
@@ -96,7 +96,7 @@ func TestTranscriptAssistantAbortRequiresTypedFailureDiagnostic(t *testing.T) {
 	if err := abort.Validate(); err == nil {
 		t.Fatal("accepted failed assistant abort without diagnostic")
 	}
-	abort.Diagnostic = NewLegacyTranscriptDiagnostic(
+	abort.Diagnostic = legacyTranscriptDiagnosticForTest(
 		TranscriptDiagnosticCode("assistant_stream_failed"),
 		"provider stream failed",
 	)

--- a/shared/clientui/transcript_diagnostic.go
+++ b/shared/clientui/transcript_diagnostic.go
@@ -1,7 +1,6 @@
 package clientui
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -14,21 +13,6 @@ type TranscriptDiagnostic struct {
 	Code      *TranscriptDiagnosticCode
 	Detail    *string
 	Developer *transcript.DeveloperDiagnostic
-}
-
-func NewLegacyTranscriptDiagnostic(code TranscriptDiagnosticCode, detail string) *TranscriptDiagnostic {
-	return &TranscriptDiagnostic{Code: &code, Detail: &detail}
-}
-
-func NewDeveloperTranscriptDiagnostic(diagnostic transcript.DeveloperDiagnostic) *TranscriptDiagnostic {
-	return &TranscriptDiagnostic{Developer: transcript.CloneDeveloperDiagnostic(&diagnostic)}
-}
-
-func (d TranscriptDiagnostic) Legacy() (TranscriptDiagnosticCode, string, bool) {
-	if d.Code == nil || d.Detail == nil {
-		return "", "", false
-	}
-	return *d.Code, *d.Detail, true
 }
 
 func (d TranscriptDiagnostic) Validate() error {
@@ -51,38 +35,4 @@ func (d TranscriptDiagnostic) Validate() error {
 		}
 	}
 	return nil
-}
-
-func (d TranscriptDiagnostic) MarshalJSON() ([]byte, error) {
-	if err := d.Validate(); err != nil {
-		return nil, err
-	}
-	return json.Marshal(transcriptDiagnosticWire{
-		Code:      d.Code,
-		Detail:    d.Detail,
-		Developer: d.Developer,
-	})
-}
-
-func (d *TranscriptDiagnostic) UnmarshalJSON(data []byte) error {
-	var wire transcriptDiagnosticWire
-	if err := json.Unmarshal(data, &wire); err != nil {
-		return err
-	}
-	decoded := TranscriptDiagnostic{
-		Code:      wire.Code,
-		Detail:    wire.Detail,
-		Developer: wire.Developer,
-	}
-	if err := decoded.Validate(); err != nil {
-		return err
-	}
-	*d = decoded
-	return nil
-}
-
-type transcriptDiagnosticWire struct {
-	Code      *TranscriptDiagnosticCode       `json:"Code"`
-	Detail    *string                         `json:"Detail"`
-	Developer *transcript.DeveloperDiagnostic `json:"Developer"`
 }

--- a/shared/clientui/transcript_diagnostic.go
+++ b/shared/clientui/transcript_diagnostic.go
@@ -3,21 +3,36 @@ package clientui
 import (
 	"fmt"
 	"strings"
+
+	"core/shared/transcript"
 )
 
 type TranscriptDiagnosticCode string
 
 type TranscriptDiagnostic struct {
-	Code   TranscriptDiagnosticCode
-	Detail string
+	Code      TranscriptDiagnosticCode
+	Detail    string
+	Developer *transcript.DeveloperDiagnostic
 }
 
 func (d TranscriptDiagnostic) Validate() error {
-	if strings.TrimSpace(string(d.Code)) == "" {
-		return fmt.Errorf("transcript diagnostic code is required")
+	hasLegacy := strings.TrimSpace(string(d.Code)) != "" || strings.TrimSpace(d.Detail) != ""
+	hasDeveloper := d.Developer != nil
+	if hasLegacy == hasDeveloper {
+		return fmt.Errorf("transcript diagnostic must contain exactly one legacy or developer variant")
 	}
-	if strings.TrimSpace(d.Detail) == "" {
-		return fmt.Errorf("transcript diagnostic detail is required")
+	if hasLegacy {
+		if strings.TrimSpace(string(d.Code)) == "" {
+			return fmt.Errorf("transcript diagnostic legacy code is required")
+		}
+		if strings.TrimSpace(d.Detail) == "" {
+			return fmt.Errorf("transcript diagnostic legacy detail is required")
+		}
+	}
+	if d.Developer != nil {
+		if err := d.Developer.Validate(); err != nil {
+			return fmt.Errorf("transcript developer diagnostic: %w", err)
+		}
 	}
 	return nil
 }

--- a/shared/clientui/transcript_diagnostic.go
+++ b/shared/clientui/transcript_diagnostic.go
@@ -1,6 +1,7 @@
 package clientui
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -10,22 +11,37 @@ import (
 type TranscriptDiagnosticCode string
 
 type TranscriptDiagnostic struct {
-	Code      TranscriptDiagnosticCode
-	Detail    string
+	Code      *TranscriptDiagnosticCode
+	Detail    *string
 	Developer *transcript.DeveloperDiagnostic
 }
 
+func NewLegacyTranscriptDiagnostic(code TranscriptDiagnosticCode, detail string) *TranscriptDiagnostic {
+	return &TranscriptDiagnostic{Code: &code, Detail: &detail}
+}
+
+func NewDeveloperTranscriptDiagnostic(diagnostic transcript.DeveloperDiagnostic) *TranscriptDiagnostic {
+	return &TranscriptDiagnostic{Developer: transcript.CloneDeveloperDiagnostic(&diagnostic)}
+}
+
+func (d TranscriptDiagnostic) Legacy() (TranscriptDiagnosticCode, string, bool) {
+	if d.Code == nil || d.Detail == nil {
+		return "", "", false
+	}
+	return *d.Code, *d.Detail, true
+}
+
 func (d TranscriptDiagnostic) Validate() error {
-	hasLegacy := strings.TrimSpace(string(d.Code)) != "" || strings.TrimSpace(d.Detail) != ""
+	hasLegacy := d.Code != nil || d.Detail != nil
 	hasDeveloper := d.Developer != nil
 	if hasLegacy == hasDeveloper {
 		return fmt.Errorf("transcript diagnostic must contain exactly one legacy or developer variant")
 	}
 	if hasLegacy {
-		if strings.TrimSpace(string(d.Code)) == "" {
+		if d.Code == nil || strings.TrimSpace(string(*d.Code)) == "" {
 			return fmt.Errorf("transcript diagnostic legacy code is required")
 		}
-		if strings.TrimSpace(d.Detail) == "" {
+		if d.Detail == nil || strings.TrimSpace(*d.Detail) == "" {
 			return fmt.Errorf("transcript diagnostic legacy detail is required")
 		}
 	}
@@ -35,4 +51,38 @@ func (d TranscriptDiagnostic) Validate() error {
 		}
 	}
 	return nil
+}
+
+func (d TranscriptDiagnostic) MarshalJSON() ([]byte, error) {
+	if err := d.Validate(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(transcriptDiagnosticWire{
+		Code:      d.Code,
+		Detail:    d.Detail,
+		Developer: d.Developer,
+	})
+}
+
+func (d *TranscriptDiagnostic) UnmarshalJSON(data []byte) error {
+	var wire transcriptDiagnosticWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	decoded := TranscriptDiagnostic{
+		Code:      wire.Code,
+		Detail:    wire.Detail,
+		Developer: wire.Developer,
+	}
+	if err := decoded.Validate(); err != nil {
+		return err
+	}
+	*d = decoded
+	return nil
+}
+
+type transcriptDiagnosticWire struct {
+	Code      *TranscriptDiagnosticCode       `json:"Code"`
+	Detail    *string                         `json:"Detail"`
+	Developer *transcript.DeveloperDiagnostic `json:"Developer"`
 }

--- a/shared/clientui/transcript_diagnostic_test.go
+++ b/shared/clientui/transcript_diagnostic_test.go
@@ -1,0 +1,73 @@
+package clientui
+
+import (
+	"encoding/json"
+	"testing"
+
+	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
+)
+
+func TestTranscriptDiagnosticJSONUsesNullableInactiveVariantFields(t *testing.T) {
+	legacyJSON, err := json.Marshal(NewLegacyTranscriptDiagnostic("legacy_code", "legacy detail"))
+	if err != nil {
+		t.Fatalf("marshal legacy diagnostic: %v", err)
+	}
+	if string(legacyJSON) != `{"Code":"legacy_code","Detail":"legacy detail","Developer":null}` {
+		t.Fatalf("legacy diagnostic JSON = %s", legacyJSON)
+	}
+
+	developer := transcript.NewDeletionFactMismatchDeveloperDiagnostic(
+		"call-1",
+		patchformat.WholeFileDeletionFactMismatchError{
+			Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+		},
+	)
+	developerJSON, err := json.Marshal(NewDeveloperTranscriptDiagnostic(developer))
+	if err != nil {
+		t.Fatalf("marshal developer diagnostic: %v", err)
+	}
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(developerJSON, &wire); err != nil {
+		t.Fatalf("decode developer wire shape: %v", err)
+	}
+	if string(wire["Code"]) != "null" || string(wire["Detail"]) != "null" {
+		t.Fatalf("developer diagnostic leaked legacy fields: %s", developerJSON)
+	}
+}
+
+func TestTranscriptDiagnosticJSONRejectsMissingPartialBlankAndMixedVariants(t *testing.T) {
+	developer := transcript.NewDeletionFactMismatchDeveloperDiagnostic(
+		"call-1",
+		patchformat.WholeFileDeletionFactMismatchError{
+			Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+		},
+	)
+	for _, payload := range []string{
+		`{"Code":null,"Detail":null,"Developer":null}`,
+		`{"Code":"legacy","Detail":null,"Developer":null}`,
+		`{"Code":null,"Detail":"detail","Developer":null}`,
+		`{"Code":"","Detail":"","Developer":null}`,
+		`{"Code":"legacy","Detail":"detail","Developer":{"deletion_fact_mismatch":{"call_id":"call-1","operation_id":{"HunkOrdinal":0},"mismatch_kind":"missing"}}}`,
+	} {
+		var diagnostic TranscriptDiagnostic
+		if err := json.Unmarshal([]byte(payload), &diagnostic); err == nil {
+			t.Fatalf("decoded invalid diagnostic payload: %s", payload)
+		}
+	}
+
+	blank := NewLegacyTranscriptDiagnostic(" ", "detail")
+	if _, err := json.Marshal(blank); err == nil {
+		t.Fatal("encoded blank legacy diagnostic")
+	}
+	mixed := NewDeveloperTranscriptDiagnostic(developer)
+	code := TranscriptDiagnosticCode("legacy")
+	detail := "detail"
+	mixed.Code = &code
+	mixed.Detail = &detail
+	if _, err := json.Marshal(mixed); err == nil {
+		t.Fatal("encoded mixed legacy and developer diagnostic")
+	}
+}

--- a/shared/clientui/transcript_diagnostic_test.go
+++ b/shared/clientui/transcript_diagnostic_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestTranscriptDiagnosticJSONUsesNullableInactiveVariantFields(t *testing.T) {
-	legacy := legacyTranscriptDiagnosticForTest("legacy_code", "legacy detail")
+	legacyCode := TranscriptDiagnosticCode("legacy_code")
+	legacyDetail := "legacy detail"
+	legacy := &TranscriptDiagnostic{Code: &legacyCode, Detail: &legacyDetail}
 	legacyJSON, err := json.Marshal(legacy)
 	if err != nil {
 		t.Fatalf("marshal legacy diagnostic: %v", err)
@@ -25,7 +27,9 @@ func TestTranscriptDiagnosticJSONUsesNullableInactiveVariantFields(t *testing.T)
 			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
 		},
 	)
-	developerJSON, err := json.Marshal(developerTranscriptDiagnosticForTest(developer))
+	developerJSON, err := json.Marshal(&TranscriptDiagnostic{
+		Developer: transcript.CloneDeveloperDiagnostic(&developer),
+	})
 	if err != nil {
 		t.Fatalf("marshal developer diagnostic: %v", err)
 	}
@@ -62,11 +66,13 @@ func TestTranscriptDiagnosticJSONRejectsMissingPartialBlankAndMixedVariants(t *t
 		}
 	}
 
-	blank := legacyTranscriptDiagnosticForTest(" ", "detail")
+	blankCode := TranscriptDiagnosticCode(" ")
+	blankDetail := "detail"
+	blank := &TranscriptDiagnostic{Code: &blankCode, Detail: &blankDetail}
 	if err := blank.Validate(); err == nil {
 		t.Fatal("validated blank legacy diagnostic")
 	}
-	mixed := developerTranscriptDiagnosticForTest(developer)
+	mixed := &TranscriptDiagnostic{Developer: transcript.CloneDeveloperDiagnostic(&developer)}
 	code := TranscriptDiagnosticCode("legacy")
 	detail := "detail"
 	mixed.Code = &code
@@ -74,12 +80,4 @@ func TestTranscriptDiagnosticJSONRejectsMissingPartialBlankAndMixedVariants(t *t
 	if err := mixed.Validate(); err == nil {
 		t.Fatal("validated mixed legacy and developer diagnostic")
 	}
-}
-
-func legacyTranscriptDiagnosticForTest(code TranscriptDiagnosticCode, detail string) *TranscriptDiagnostic {
-	return &TranscriptDiagnostic{Code: &code, Detail: &detail}
-}
-
-func developerTranscriptDiagnosticForTest(diagnostic transcript.DeveloperDiagnostic) *TranscriptDiagnostic {
-	return &TranscriptDiagnostic{Developer: transcript.CloneDeveloperDiagnostic(&diagnostic)}
 }

--- a/shared/clientui/transcript_diagnostic_test.go
+++ b/shared/clientui/transcript_diagnostic_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestTranscriptDiagnosticJSONUsesNullableInactiveVariantFields(t *testing.T) {
-	legacyJSON, err := json.Marshal(NewLegacyTranscriptDiagnostic("legacy_code", "legacy detail"))
+	legacy := legacyTranscriptDiagnosticForTest("legacy_code", "legacy detail")
+	legacyJSON, err := json.Marshal(legacy)
 	if err != nil {
 		t.Fatalf("marshal legacy diagnostic: %v", err)
 	}
@@ -24,7 +25,7 @@ func TestTranscriptDiagnosticJSONUsesNullableInactiveVariantFields(t *testing.T)
 			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
 		},
 	)
-	developerJSON, err := json.Marshal(NewDeveloperTranscriptDiagnostic(developer))
+	developerJSON, err := json.Marshal(developerTranscriptDiagnosticForTest(developer))
 	if err != nil {
 		t.Fatalf("marshal developer diagnostic: %v", err)
 	}
@@ -53,21 +54,32 @@ func TestTranscriptDiagnosticJSONRejectsMissingPartialBlankAndMixedVariants(t *t
 		`{"Code":"legacy","Detail":"detail","Developer":{"deletion_fact_mismatch":{"call_id":"call-1","operation_id":{"HunkOrdinal":0},"mismatch_kind":"missing"}}}`,
 	} {
 		var diagnostic TranscriptDiagnostic
-		if err := json.Unmarshal([]byte(payload), &diagnostic); err == nil {
-			t.Fatalf("decoded invalid diagnostic payload: %s", payload)
+		if err := json.Unmarshal([]byte(payload), &diagnostic); err != nil {
+			t.Fatalf("decode diagnostic payload for validation: %v", err)
+		}
+		if err := diagnostic.Validate(); err == nil {
+			t.Fatalf("validated invalid diagnostic payload: %s", payload)
 		}
 	}
 
-	blank := NewLegacyTranscriptDiagnostic(" ", "detail")
-	if _, err := json.Marshal(blank); err == nil {
-		t.Fatal("encoded blank legacy diagnostic")
+	blank := legacyTranscriptDiagnosticForTest(" ", "detail")
+	if err := blank.Validate(); err == nil {
+		t.Fatal("validated blank legacy diagnostic")
 	}
-	mixed := NewDeveloperTranscriptDiagnostic(developer)
+	mixed := developerTranscriptDiagnosticForTest(developer)
 	code := TranscriptDiagnosticCode("legacy")
 	detail := "detail"
 	mixed.Code = &code
 	mixed.Detail = &detail
-	if _, err := json.Marshal(mixed); err == nil {
-		t.Fatal("encoded mixed legacy and developer diagnostic")
+	if err := mixed.Validate(); err == nil {
+		t.Fatal("validated mixed legacy and developer diagnostic")
 	}
+}
+
+func legacyTranscriptDiagnosticForTest(code TranscriptDiagnosticCode, detail string) *TranscriptDiagnostic {
+	return &TranscriptDiagnostic{Code: &code, Detail: &detail}
+}
+
+func developerTranscriptDiagnosticForTest(diagnostic transcript.DeveloperDiagnostic) *TranscriptDiagnostic {
+	return &TranscriptDiagnostic{Developer: transcript.CloneDeveloperDiagnostic(&diagnostic)}
 }

--- a/shared/clientui/transcript_operation.go
+++ b/shared/clientui/transcript_operation.go
@@ -48,6 +48,9 @@ func (o TranscriptWorktreeTransitionOutcome) Validate() error {
 		if o.Failure == nil {
 			return fmt.Errorf("failed worktree transition requires failure diagnostic")
 		}
+		if o.Failure.Developer != nil {
+			return fmt.Errorf("failed worktree transition requires legacy failure diagnostic")
+		}
 		return o.Failure.Validate()
 	default:
 		return fmt.Errorf("unknown worktree transition state %q", o.State)

--- a/shared/clientui/transcript_operation_test.go
+++ b/shared/clientui/transcript_operation_test.go
@@ -2,6 +2,9 @@ package clientui
 
 import (
 	"testing"
+
+	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
 )
 
 func TestTranscriptWorktreeAndOperationalOutcomesStayTyped(t *testing.T) {
@@ -31,6 +34,18 @@ func TestTranscriptOperationOutcomesRejectUntypedFailure(t *testing.T) {
 	}
 	if err := worktree.Validate(); err == nil {
 		t.Fatal("accepted failed worktree transition without diagnostic")
+	}
+
+	developer := transcript.NewDeletionFactMismatchDeveloperDiagnostic(
+		"call-1",
+		patchformat.WholeFileDeletionFactMismatchError{
+			Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+		},
+	)
+	worktree.Failure = &TranscriptDiagnostic{Developer: &developer}
+	if err := worktree.Validate(); err == nil {
+		t.Fatal("accepted developer diagnostic for worktree transition failure")
 	}
 
 	diagnostic := TranscriptOperationalDiagnostic{

--- a/shared/clientui/transcript_row_test.go
+++ b/shared/clientui/transcript_row_test.go
@@ -110,7 +110,7 @@ func TestTranscriptNoticeRowRejectsReasonPayloadMismatch(t *testing.T) {
 				Reason:     "cache_miss",
 				Visibility: transcript.EntryVisibilityOngoing,
 			},
-			Diagnostic: NewLegacyTranscriptDiagnostic(
+			Diagnostic: legacyTranscriptDiagnosticForTest(
 				TranscriptDiagnosticCode("runtime"),
 				"contradictory",
 			),
@@ -123,7 +123,7 @@ func TestTranscriptNoticeRowRejectsReasonPayloadMismatch(t *testing.T) {
 				Reason:     "cache_miss",
 				Visibility: transcript.EntryVisibilityOngoing,
 			},
-			Diagnostic: NewLegacyTranscriptDiagnostic(
+			Diagnostic: legacyTranscriptDiagnosticForTest(
 				TranscriptDiagnosticCode("runtime"),
 				"failed",
 			),
@@ -132,7 +132,7 @@ func TestTranscriptNoticeRowRejectsReasonPayloadMismatch(t *testing.T) {
 			Reason:     TranscriptNoticeLegacyUntypedNotice,
 			Severity:   TranscriptNoticeInfo,
 			LegacyText: &legacyText,
-			Diagnostic: NewLegacyTranscriptDiagnostic(
+			Diagnostic: legacyTranscriptDiagnosticForTest(
 				TranscriptDiagnosticCode("runtime"),
 				"contradictory",
 			),
@@ -156,7 +156,7 @@ func TestTranscriptNoticeRowCarriesTypedDeveloperDiagnosticWithoutLegacyFields(t
 	notice := TranscriptNoticeRow{
 		Reason:     TranscriptNoticeRuntimeDiagnostic,
 		Severity:   TranscriptNoticeError,
-		Diagnostic: NewDeveloperTranscriptDiagnostic(diagnostic),
+		Diagnostic: developerTranscriptDiagnosticForTest(diagnostic),
 	}
 	if err := notice.Validate(); err != nil {
 		t.Fatalf("validate typed developer diagnostic notice: %v", err)

--- a/shared/clientui/transcript_row_test.go
+++ b/shared/clientui/transcript_row_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
 )
 
 func TestTranscriptCommittedAssistantRowCarriesStepAndOptionalStreamIdentity(t *testing.T) {
@@ -141,5 +142,31 @@ func TestTranscriptNoticeRowRejectsReasonPayloadMismatch(t *testing.T) {
 		if err := notice.Validate(); err == nil {
 			t.Fatalf("accepted notice without required typed payload: %+v", notice)
 		}
+	}
+}
+
+func TestTranscriptNoticeRowCarriesTypedDeveloperDiagnosticWithoutLegacyFields(t *testing.T) {
+	diagnostic := transcript.NewDeletionFactMismatchDeveloperDiagnostic(
+		"call-1",
+		patchformat.WholeFileDeletionFactMismatchError{
+			Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+			ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+		},
+	)
+	notice := TranscriptNoticeRow{
+		Reason:   TranscriptNoticeRuntimeDiagnostic,
+		Severity: TranscriptNoticeError,
+		Diagnostic: &TranscriptDiagnostic{
+			Developer: &diagnostic,
+		},
+	}
+	if err := notice.Validate(); err != nil {
+		t.Fatalf("validate typed developer diagnostic notice: %v", err)
+	}
+
+	notice.Diagnostic.Code = "legacy"
+	notice.Diagnostic.Detail = "must not coexist"
+	if err := notice.Validate(); err == nil {
+		t.Fatal("accepted developer diagnostic with legacy code and detail")
 	}
 }

--- a/shared/clientui/transcript_row_test.go
+++ b/shared/clientui/transcript_row_test.go
@@ -89,6 +89,9 @@ func TestTranscriptNoticeRowCarriesTypedCacheWarningFacts(t *testing.T) {
 
 func TestTranscriptNoticeRowRejectsReasonPayloadMismatch(t *testing.T) {
 	legacyText := "legacy notice"
+	runtimeCode := TranscriptDiagnosticCode("runtime")
+	contradictory := "contradictory"
+	failed := "failed"
 	tests := []TranscriptNoticeRow{
 		{
 			Reason:   TranscriptNoticeCacheWarning,
@@ -110,10 +113,7 @@ func TestTranscriptNoticeRowRejectsReasonPayloadMismatch(t *testing.T) {
 				Reason:     "cache_miss",
 				Visibility: transcript.EntryVisibilityOngoing,
 			},
-			Diagnostic: legacyTranscriptDiagnosticForTest(
-				TranscriptDiagnosticCode("runtime"),
-				"contradictory",
-			),
+			Diagnostic: &TranscriptDiagnostic{Code: &runtimeCode, Detail: &contradictory},
 		},
 		{
 			Reason:   TranscriptNoticeRuntimeDiagnostic,
@@ -123,19 +123,13 @@ func TestTranscriptNoticeRowRejectsReasonPayloadMismatch(t *testing.T) {
 				Reason:     "cache_miss",
 				Visibility: transcript.EntryVisibilityOngoing,
 			},
-			Diagnostic: legacyTranscriptDiagnosticForTest(
-				TranscriptDiagnosticCode("runtime"),
-				"failed",
-			),
+			Diagnostic: &TranscriptDiagnostic{Code: &runtimeCode, Detail: &failed},
 		},
 		{
 			Reason:     TranscriptNoticeLegacyUntypedNotice,
 			Severity:   TranscriptNoticeInfo,
 			LegacyText: &legacyText,
-			Diagnostic: legacyTranscriptDiagnosticForTest(
-				TranscriptDiagnosticCode("runtime"),
-				"contradictory",
-			),
+			Diagnostic: &TranscriptDiagnostic{Code: &runtimeCode, Detail: &contradictory},
 		},
 	}
 	for _, notice := range tests {
@@ -156,7 +150,7 @@ func TestTranscriptNoticeRowCarriesTypedDeveloperDiagnosticWithoutLegacyFields(t
 	notice := TranscriptNoticeRow{
 		Reason:     TranscriptNoticeRuntimeDiagnostic,
 		Severity:   TranscriptNoticeError,
-		Diagnostic: developerTranscriptDiagnosticForTest(diagnostic),
+		Diagnostic: &TranscriptDiagnostic{Developer: transcript.CloneDeveloperDiagnostic(&diagnostic)},
 	}
 	if err := notice.Validate(); err != nil {
 		t.Fatalf("validate typed developer diagnostic notice: %v", err)

--- a/shared/clientui/transcript_row_test.go
+++ b/shared/clientui/transcript_row_test.go
@@ -110,10 +110,10 @@ func TestTranscriptNoticeRowRejectsReasonPayloadMismatch(t *testing.T) {
 				Reason:     "cache_miss",
 				Visibility: transcript.EntryVisibilityOngoing,
 			},
-			Diagnostic: &TranscriptDiagnostic{
-				Code:   TranscriptDiagnosticCode("runtime"),
-				Detail: "contradictory",
-			},
+			Diagnostic: NewLegacyTranscriptDiagnostic(
+				TranscriptDiagnosticCode("runtime"),
+				"contradictory",
+			),
 		},
 		{
 			Reason:   TranscriptNoticeRuntimeDiagnostic,
@@ -123,19 +123,19 @@ func TestTranscriptNoticeRowRejectsReasonPayloadMismatch(t *testing.T) {
 				Reason:     "cache_miss",
 				Visibility: transcript.EntryVisibilityOngoing,
 			},
-			Diagnostic: &TranscriptDiagnostic{
-				Code:   TranscriptDiagnosticCode("runtime"),
-				Detail: "failed",
-			},
+			Diagnostic: NewLegacyTranscriptDiagnostic(
+				TranscriptDiagnosticCode("runtime"),
+				"failed",
+			),
 		},
 		{
 			Reason:     TranscriptNoticeLegacyUntypedNotice,
 			Severity:   TranscriptNoticeInfo,
 			LegacyText: &legacyText,
-			Diagnostic: &TranscriptDiagnostic{
-				Code:   TranscriptDiagnosticCode("runtime"),
-				Detail: "contradictory",
-			},
+			Diagnostic: NewLegacyTranscriptDiagnostic(
+				TranscriptDiagnosticCode("runtime"),
+				"contradictory",
+			),
 		},
 	}
 	for _, notice := range tests {
@@ -154,18 +154,18 @@ func TestTranscriptNoticeRowCarriesTypedDeveloperDiagnosticWithoutLegacyFields(t
 		},
 	)
 	notice := TranscriptNoticeRow{
-		Reason:   TranscriptNoticeRuntimeDiagnostic,
-		Severity: TranscriptNoticeError,
-		Diagnostic: &TranscriptDiagnostic{
-			Developer: &diagnostic,
-		},
+		Reason:     TranscriptNoticeRuntimeDiagnostic,
+		Severity:   TranscriptNoticeError,
+		Diagnostic: NewDeveloperTranscriptDiagnostic(diagnostic),
 	}
 	if err := notice.Validate(); err != nil {
 		t.Fatalf("validate typed developer diagnostic notice: %v", err)
 	}
 
-	notice.Diagnostic.Code = "legacy"
-	notice.Diagnostic.Detail = "must not coexist"
+	legacyCode := TranscriptDiagnosticCode("legacy")
+	legacyDetail := "must not coexist"
+	notice.Diagnostic.Code = &legacyCode
+	notice.Diagnostic.Detail = &legacyDetail
 	if err := notice.Validate(); err == nil {
 		t.Fatal("accepted developer diagnostic with legacy code and detail")
 	}

--- a/shared/protocol/version.json
+++ b/shared/protocol/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "60"
+  "version": "61"
 }

--- a/shared/transcript/developer_diagnostic.go
+++ b/shared/transcript/developer_diagnostic.go
@@ -1,0 +1,105 @@
+package transcript
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	patchformat "core/shared/transcript/patchformat"
+)
+
+type DeveloperDiagnosticKind string
+
+const (
+	DeveloperDiagnosticDeletionFactMismatch DeveloperDiagnosticKind = "deletion_fact_mismatch"
+)
+
+type DeveloperDiagnostic struct {
+	DeletionFactMismatch *DeletionFactMismatchDeveloperDiagnostic `json:"deletion_fact_mismatch,omitempty"`
+}
+
+type DeletionFactMismatchDeveloperDiagnostic struct {
+	CallID       string                                        `json:"call_id"`
+	OperationID  patchformat.WholeFileDeletionOperationID      `json:"operation_id"`
+	MismatchKind patchformat.WholeFileDeletionFactMismatchKind `json:"mismatch_kind"`
+}
+
+func NewDeletionFactMismatchDeveloperDiagnostic(
+	callID string,
+	mismatch patchformat.WholeFileDeletionFactMismatchError,
+) DeveloperDiagnostic {
+	return DeveloperDiagnostic{
+		DeletionFactMismatch: &DeletionFactMismatchDeveloperDiagnostic{
+			CallID:       strings.TrimSpace(callID),
+			OperationID:  mismatch.ID,
+			MismatchKind: mismatch.Kind,
+		},
+	}
+}
+
+func (d DeveloperDiagnostic) Kind() DeveloperDiagnosticKind {
+	if d.DeletionFactMismatch != nil {
+		return DeveloperDiagnosticDeletionFactMismatch
+	}
+	return DeveloperDiagnosticKind("")
+}
+
+func (d DeveloperDiagnostic) Validate() error {
+	context := d.DeletionFactMismatch
+	if context == nil {
+		return errors.New("developer diagnostic variant is required")
+	}
+	if strings.TrimSpace(context.CallID) == "" {
+		return errors.New("deletion fact mismatch diagnostic call id is required")
+	}
+	if context.OperationID.HunkOrdinal < 0 {
+		return errors.New("deletion fact mismatch diagnostic hunk ordinal must be non-negative")
+	}
+	switch context.MismatchKind {
+	case patchformat.WholeFileDeletionFactMismatchDuplicate,
+		patchformat.WholeFileDeletionFactMismatchUnmatched,
+		patchformat.WholeFileDeletionFactMismatchMissing,
+		patchformat.WholeFileDeletionFactMismatchInvalidCount:
+		return nil
+	default:
+		return errors.New("deletion fact mismatch diagnostic kind is invalid")
+	}
+}
+
+func DeveloperDiagnosticText(d DeveloperDiagnostic) string {
+	context := d.DeletionFactMismatch
+	if context == nil {
+		return "developer diagnostic"
+	}
+	return fmt.Sprintf(
+		"whole-file deletion count presentation mismatch: %s (call %s, hunk %d)",
+		context.MismatchKind,
+		context.CallID,
+		context.OperationID.HunkOrdinal,
+	)
+}
+
+func DeveloperDiagnosticEqual(left, right *DeveloperDiagnostic) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	if left.Kind() != right.Kind() {
+		return false
+	}
+	if left.DeletionFactMismatch == nil || right.DeletionFactMismatch == nil {
+		return left.DeletionFactMismatch == right.DeletionFactMismatch
+	}
+	return *left.DeletionFactMismatch == *right.DeletionFactMismatch
+}
+
+func CloneDeveloperDiagnostic(in *DeveloperDiagnostic) *DeveloperDiagnostic {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.DeletionFactMismatch != nil {
+		context := *in.DeletionFactMismatch
+		out.DeletionFactMismatch = &context
+	}
+	return &out
+}

--- a/shared/transcript/developer_diagnostic.go
+++ b/shared/transcript/developer_diagnostic.go
@@ -1,6 +1,7 @@
 package transcript
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -22,6 +23,28 @@ type DeletionFactMismatchDeveloperDiagnostic struct {
 	CallID       string                                        `json:"call_id"`
 	OperationID  patchformat.WholeFileDeletionOperationID      `json:"operation_id"`
 	MismatchKind patchformat.WholeFileDeletionFactMismatchKind `json:"mismatch_kind"`
+}
+
+func (d *DeletionFactMismatchDeveloperDiagnostic) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		CallID      string `json:"call_id"`
+		OperationID *struct {
+			HunkOrdinal *int `json:"HunkOrdinal"`
+		} `json:"operation_id"`
+		MismatchKind patchformat.WholeFileDeletionFactMismatchKind `json:"mismatch_kind"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	if wire.OperationID == nil || wire.OperationID.HunkOrdinal == nil {
+		return errors.New("deletion fact mismatch diagnostic hunk ordinal is required")
+	}
+	*d = DeletionFactMismatchDeveloperDiagnostic{
+		CallID:       wire.CallID,
+		OperationID:  patchformat.WholeFileDeletionOperationID{HunkOrdinal: *wire.OperationID.HunkOrdinal},
+		MismatchKind: wire.MismatchKind,
+	}
+	return nil
 }
 
 func NewDeletionFactMismatchDeveloperDiagnostic(

--- a/shared/transcript/developer_diagnostic.go
+++ b/shared/transcript/developer_diagnostic.go
@@ -27,21 +27,19 @@ type DeletionFactMismatchDeveloperDiagnostic struct {
 
 func (d *DeletionFactMismatchDeveloperDiagnostic) UnmarshalJSON(data []byte) error {
 	var wire struct {
-		CallID      string `json:"call_id"`
-		OperationID *struct {
-			HunkOrdinal *int `json:"HunkOrdinal"`
-		} `json:"operation_id"`
+		CallID       string                                        `json:"call_id"`
+		OperationID  *patchformat.WholeFileDeletionOperationID     `json:"operation_id"`
 		MismatchKind patchformat.WholeFileDeletionFactMismatchKind `json:"mismatch_kind"`
 	}
 	if err := json.Unmarshal(data, &wire); err != nil {
 		return err
 	}
-	if wire.OperationID == nil || wire.OperationID.HunkOrdinal == nil {
+	if wire.OperationID == nil {
 		return errors.New("deletion fact mismatch diagnostic hunk ordinal is required")
 	}
 	*d = DeletionFactMismatchDeveloperDiagnostic{
 		CallID:       wire.CallID,
-		OperationID:  patchformat.WholeFileDeletionOperationID{HunkOrdinal: *wire.OperationID.HunkOrdinal},
+		OperationID:  *wire.OperationID,
 		MismatchKind: wire.MismatchKind,
 	}
 	return nil

--- a/shared/transcript/developer_diagnostic.go
+++ b/shared/transcript/developer_diagnostic.go
@@ -37,11 +37,11 @@ func NewDeletionFactMismatchDeveloperDiagnostic(
 	}
 }
 
-func (d DeveloperDiagnostic) Kind() DeveloperDiagnosticKind {
+func (d DeveloperDiagnostic) Kind() (DeveloperDiagnosticKind, bool) {
 	if d.DeletionFactMismatch != nil {
-		return DeveloperDiagnosticDeletionFactMismatch
+		return DeveloperDiagnosticDeletionFactMismatch, true
 	}
-	return DeveloperDiagnosticKind("")
+	return "", false
 }
 
 func (d DeveloperDiagnostic) Validate() error {
@@ -83,7 +83,9 @@ func DeveloperDiagnosticEqual(left, right *DeveloperDiagnostic) bool {
 	if left == nil || right == nil {
 		return left == right
 	}
-	if left.Kind() != right.Kind() {
+	leftKind, leftPresent := left.Kind()
+	rightKind, rightPresent := right.Kind()
+	if leftPresent != rightPresent || leftKind != rightKind {
 		return false
 	}
 	if left.DeletionFactMismatch == nil || right.DeletionFactMismatch == nil {

--- a/shared/transcript/developer_diagnostic_test.go
+++ b/shared/transcript/developer_diagnostic_test.go
@@ -1,6 +1,7 @@
 package transcript
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -58,6 +59,19 @@ func TestDeveloperDiagnosticRejectsMissingOrInvalidVariantContext(t *testing.T) 
 	for index, diagnostic := range tests {
 		if err := diagnostic.Validate(); err == nil {
 			t.Fatalf("diagnostic %d unexpectedly validated: %+v", index, diagnostic)
+		}
+	}
+}
+
+func TestDeveloperDiagnosticJSONRejectsAbsentHunkOrdinal(t *testing.T) {
+	for _, payload := range []string{
+		`{"deletion_fact_mismatch":{"call_id":"call-1","operation_id":{},"mismatch_kind":"missing"}}`,
+		`{"deletion_fact_mismatch":{"call_id":"call-1","operation_id":{"HunkOrdinal":null},"mismatch_kind":"missing"}}`,
+		`{"deletion_fact_mismatch":{"call_id":"call-1","operation_id":null,"mismatch_kind":"missing"}}`,
+	} {
+		var diagnostic DeveloperDiagnostic
+		if err := json.Unmarshal([]byte(payload), &diagnostic); err == nil {
+			t.Fatalf("decoded diagnostic without hunk ordinal: %s", payload)
 		}
 	}
 }

--- a/shared/transcript/developer_diagnostic_test.go
+++ b/shared/transcript/developer_diagnostic_test.go
@@ -17,8 +17,9 @@ func TestDeletionFactMismatchDeveloperDiagnosticOwnsRequiredTypedContext(t *test
 	if err := diagnostic.Validate(); err != nil {
 		t.Fatalf("validate diagnostic: %v", err)
 	}
-	if diagnostic.Kind() != DeveloperDiagnosticDeletionFactMismatch {
-		t.Fatalf("diagnostic kind = %q", diagnostic.Kind())
+	kind, present := diagnostic.Kind()
+	if !present || kind != DeveloperDiagnosticDeletionFactMismatch {
+		t.Fatalf("diagnostic kind = %q present=%t", kind, present)
 	}
 	context := diagnostic.DeletionFactMismatch
 	if context == nil ||
@@ -29,6 +30,13 @@ func TestDeletionFactMismatchDeveloperDiagnosticOwnsRequiredTypedContext(t *test
 	}
 	if DeveloperDiagnosticText(diagnostic) == "" {
 		t.Fatal("typed diagnostic did not derive display text")
+	}
+}
+
+func TestDeveloperDiagnosticKindReportsMissingVariantExplicitly(t *testing.T) {
+	kind, present := (DeveloperDiagnostic{}).Kind()
+	if present {
+		t.Fatalf("missing diagnostic variant reported kind %q", kind)
 	}
 }
 

--- a/shared/transcript/developer_diagnostic_test.go
+++ b/shared/transcript/developer_diagnostic_test.go
@@ -1,0 +1,80 @@
+package transcript
+
+import (
+	"reflect"
+	"testing"
+
+	patchformat "core/shared/transcript/patchformat"
+)
+
+func TestDeletionFactMismatchDeveloperDiagnosticOwnsRequiredTypedContext(t *testing.T) {
+	mismatch := &patchformat.WholeFileDeletionFactMismatchError{
+		Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+		ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 2},
+	}
+	diagnostic := NewDeletionFactMismatchDeveloperDiagnostic("call-1", *mismatch)
+
+	if err := diagnostic.Validate(); err != nil {
+		t.Fatalf("validate diagnostic: %v", err)
+	}
+	if diagnostic.Kind() != DeveloperDiagnosticDeletionFactMismatch {
+		t.Fatalf("diagnostic kind = %q", diagnostic.Kind())
+	}
+	context := diagnostic.DeletionFactMismatch
+	if context == nil ||
+		context.CallID != "call-1" ||
+		context.OperationID != mismatch.ID ||
+		context.MismatchKind != mismatch.Kind {
+		t.Fatalf("diagnostic context = %+v, want mismatch %+v", context, mismatch)
+	}
+	if DeveloperDiagnosticText(diagnostic) == "" {
+		t.Fatal("typed diagnostic did not derive display text")
+	}
+}
+
+func TestDeveloperDiagnosticRejectsMissingOrInvalidVariantContext(t *testing.T) {
+	tests := []DeveloperDiagnostic{
+		{},
+		{DeletionFactMismatch: &DeletionFactMismatchDeveloperDiagnostic{}},
+		{DeletionFactMismatch: &DeletionFactMismatchDeveloperDiagnostic{
+			CallID:       "call-1",
+			OperationID:  patchformat.WholeFileDeletionOperationID{HunkOrdinal: -1},
+			MismatchKind: patchformat.WholeFileDeletionFactMismatchMissing,
+		}},
+		{DeletionFactMismatch: &DeletionFactMismatchDeveloperDiagnostic{
+			CallID:       "call-1",
+			OperationID:  patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+			MismatchKind: patchformat.WholeFileDeletionFactMismatchKind("invalid"),
+		}},
+	}
+	for index, diagnostic := range tests {
+		if err := diagnostic.Validate(); err == nil {
+			t.Fatalf("diagnostic %d unexpectedly validated: %+v", index, diagnostic)
+		}
+	}
+}
+
+func TestDeveloperDiagnosticDoesNotDuplicateTypedFactsAsParallelFields(t *testing.T) {
+	typ := reflect.TypeFor[DeveloperDiagnostic]()
+	for _, field := range []string{"CallID", "OperationID", "MismatchKind", "Detail"} {
+		if _, exists := typ.FieldByName(field); exists {
+			t.Fatalf("developer diagnostic duplicates variant fact in field %q", field)
+		}
+	}
+}
+
+func TestDeveloperDiagnosticEqualityUsesVariantValues(t *testing.T) {
+	mismatch := &patchformat.WholeFileDeletionFactMismatchError{
+		Kind: patchformat.WholeFileDeletionFactMismatchMissing,
+		ID:   patchformat.WholeFileDeletionOperationID{HunkOrdinal: 2},
+	}
+	left := NewDeletionFactMismatchDeveloperDiagnostic("call-1", *mismatch)
+	right := NewDeletionFactMismatchDeveloperDiagnostic("call-1", *mismatch)
+	if !DeveloperDiagnosticEqual(&left, &right) {
+		t.Fatal("equal diagnostic variants were not equal")
+	}
+	right.DeletionFactMismatch.CallID = "call-2"
+	if DeveloperDiagnosticEqual(&left, &right) {
+		t.Fatal("different diagnostic variants were equal")
+	}
+}

--- a/shared/transcript/entry_compare.go
+++ b/shared/transcript/entry_compare.go
@@ -138,7 +138,8 @@ func renderedPatchesEqual(left, right *patchformat.RenderedPatch) bool {
 			a.RelPath == b.RelPath &&
 			a.Added == b.Added &&
 			a.Removed == b.Removed &&
-			slices.Equal(a.Diff, b.Diff)
+			slices.Equal(a.Diff, b.Diff) &&
+			slices.Equal(a.WholeFileDeletions, b.WholeFileDeletions)
 	}) &&
 		slices.EqualFunc(left.SummaryLines, right.SummaryLines, func(a, b patchformat.RenderedLine) bool {
 			return a.Kind == b.Kind &&

--- a/shared/transcript/entry_compare_test.go
+++ b/shared/transcript/entry_compare_test.go
@@ -80,3 +80,25 @@ func TestEntryPayloadEqualIncludesPatchRenderMetadata(t *testing.T) {
 		t.Fatal("expected patch render summary change to make entries different")
 	}
 }
+
+func TestEntryPayloadEqualIncludesWholeFileDeletionMetadata(t *testing.T) {
+	leftRender := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: a.go\n*** End Patch\n",
+		"/workspace",
+	)
+	rightRender := patchformat.Clone(&leftRender)
+	rightRender.Files[0].WholeFileDeletions[0].CountKnown = true
+
+	left := EntryPayload{
+		Role:       "tool_call",
+		Text:       "patch",
+		ToolCallID: "call-1",
+		ToolCall:   &ToolCallMeta{ToolName: "patch", PatchRender: &leftRender},
+	}
+	right := left
+	right.ToolCall = &ToolCallMeta{ToolName: "patch", PatchRender: rightRender}
+
+	if EntryPayloadEqual(left, right) {
+		t.Fatal("expected whole-file deletion metadata change to make entries different")
+	}
+}

--- a/shared/transcript/patchformat/render.go
+++ b/shared/transcript/patchformat/render.go
@@ -74,6 +74,10 @@ func Raw(src string) RenderedPatch {
 
 func Format(doc Document, cwd string) RenderedPatch {
 	files := buildRenderedFiles(doc, cwd)
+	return renderFiles(files)
+}
+
+func renderFiles(files []RenderedFile) RenderedPatch {
 	if len(files) == 0 {
 		return RenderedPatch{}
 	}
@@ -145,7 +149,7 @@ func buildRenderedFiles(doc Document, cwd string) []RenderedFile {
 		return &files[idx]
 	}
 
-	for _, hunk := range doc.Hunks {
+	for ordinal, hunk := range doc.Hunks {
 		switch op := hunk.(type) {
 		case AddFile:
 			file := getFile(op.Path)
@@ -179,7 +183,9 @@ func buildRenderedFiles(doc Document, cwd string) []RenderedFile {
 			if file == nil {
 				continue
 			}
-			file.Removed++
+			file.WholeFileDeletions = append(file.WholeFileDeletions, WholeFileDeletionOperation{
+				ID: WholeFileDeletionOperationID{HunkOrdinal: ordinal},
+			})
 			file.Diff = append(file.Diff, "-<deleted file>")
 		}
 	}
@@ -205,10 +211,93 @@ func summaryLine(file RenderedFile) string {
 	if file.Added > 0 {
 		line += fmt.Sprintf(" +%d", file.Added)
 	}
-	if file.Removed > 0 {
+	if ShowsRemovedCount(file) {
 		line += fmt.Sprintf(" -%d", file.Removed)
 	}
 	return line
+}
+
+func ShowsRemovedCount(file RenderedFile) bool {
+	if file.Removed > 0 {
+		return true
+	}
+	for _, operation := range file.WholeFileDeletions {
+		if operation.CountKnown {
+			return true
+		}
+	}
+	return false
+}
+
+func ApplyWholeFileDeletionFacts(
+	rendered RenderedPatch,
+	facts []WholeFileDeletionFact,
+) (RenderedPatch, *WholeFileDeletionFactMismatchError) {
+	out := Clone(&rendered)
+	type operationLocation struct {
+		fileIndex      int
+		operationIndex int
+	}
+	locations := make(map[WholeFileDeletionOperationID]operationLocation)
+	for fileIndex := range out.Files {
+		for operationIndex, operation := range out.Files[fileIndex].WholeFileDeletions {
+			if _, duplicate := locations[operation.ID]; duplicate {
+				return RenderedPatch{}, &WholeFileDeletionFactMismatchError{
+					Kind: WholeFileDeletionFactMismatchDuplicate,
+					ID:   operation.ID,
+				}
+			}
+			locations[operation.ID] = operationLocation{
+				fileIndex:      fileIndex,
+				operationIndex: operationIndex,
+			}
+		}
+	}
+
+	seenFacts := make(map[WholeFileDeletionOperationID]struct{}, len(facts))
+	for _, fact := range facts {
+		if _, duplicate := seenFacts[fact.ID]; duplicate {
+			return RenderedPatch{}, &WholeFileDeletionFactMismatchError{
+				Kind: WholeFileDeletionFactMismatchDuplicate,
+				ID:   fact.ID,
+			}
+		}
+		seenFacts[fact.ID] = struct{}{}
+		location, matched := locations[fact.ID]
+		if !matched {
+			return RenderedPatch{}, &WholeFileDeletionFactMismatchError{
+				Kind: WholeFileDeletionFactMismatchUnmatched,
+				ID:   fact.ID,
+			}
+		}
+		if fact.Removed < 0 {
+			return RenderedPatch{}, &WholeFileDeletionFactMismatchError{
+				Kind: WholeFileDeletionFactMismatchInvalidCount,
+				ID:   fact.ID,
+			}
+		}
+		file := &out.Files[location.fileIndex]
+		operation := &file.WholeFileDeletions[location.operationIndex]
+		if operation.CountKnown {
+			return RenderedPatch{}, &WholeFileDeletionFactMismatchError{
+				Kind: WholeFileDeletionFactMismatchDuplicate,
+				ID:   fact.ID,
+			}
+		}
+		operation.CountKnown = true
+		file.Removed += fact.Removed
+	}
+	for fileIndex := range out.Files {
+		for _, operation := range out.Files[fileIndex].WholeFileDeletions {
+			if !operation.CountKnown {
+				return RenderedPatch{}, &WholeFileDeletionFactMismatchError{
+					Kind: WholeFileDeletionFactMismatchMissing,
+					ID:   operation.ID,
+				}
+			}
+		}
+	}
+	return renderFiles(out.Files), nil
 }
 
 func detailHeader(file RenderedFile) string {

--- a/shared/transcript/patchformat/render_test.go
+++ b/shared/transcript/patchformat/render_test.go
@@ -2,7 +2,6 @@ package patchformat
 
 import (
 	"errors"
-	"reflect"
 	"testing"
 )
 
@@ -177,12 +176,6 @@ func TestApplyWholeFileDeletionFactsExposesPositiveAndKnownZeroCounts(t *testing
 		if !ShowsRemovedCount(file) {
 			t.Fatalf("file %d did not expose its known removal-count fact", index)
 		}
-	}
-}
-
-func TestWholeFileDeletionOperationDoesNotDuplicateRemovedCount(t *testing.T) {
-	if _, exists := reflect.TypeFor[WholeFileDeletionOperation]().FieldByName("Removed"); exists {
-		t.Fatal("whole-file deletion operation duplicates the rendered file removal count")
 	}
 }
 

--- a/shared/transcript/patchformat/render_test.go
+++ b/shared/transcript/patchformat/render_test.go
@@ -1,6 +1,7 @@
 package patchformat
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 )
@@ -175,6 +176,20 @@ func TestApplyWholeFileDeletionFactsExposesPositiveAndKnownZeroCounts(t *testing
 		}
 		if !ShowsRemovedCount(file) {
 			t.Fatalf("file %d did not expose its known removal-count fact", index)
+		}
+	}
+}
+
+func TestWholeFileDeletionOperationJSONRejectsAbsentIdentity(t *testing.T) {
+	for _, payload := range []string{
+		`{"CountKnown":true}`,
+		`{"ID":null,"CountKnown":true}`,
+		`{"ID":{},"CountKnown":true}`,
+		`{"ID":{"HunkOrdinal":null},"CountKnown":true}`,
+	} {
+		var operation WholeFileDeletionOperation
+		if err := json.Unmarshal([]byte(payload), &operation); err == nil {
+			t.Fatalf("decoded whole-file deletion operation without identity: %s", payload)
 		}
 	}
 }

--- a/shared/transcript/patchformat/render_test.go
+++ b/shared/transcript/patchformat/render_test.go
@@ -1,6 +1,10 @@
 package patchformat
 
-import "testing"
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
 
 func TestRenderFormatsSummaryAndDetailFromParsedPatch(t *testing.T) {
 	patchText := "*** Begin Patch\n*** Update File: dir/a.go\n-old\n+new\n*** Add File: b.go\n+hello\n*** End Patch\n"
@@ -102,5 +106,142 @@ func TestFormatPreservesRelativeOutsideWorkspacePath(t *testing.T) {
 	}
 	if got := rendered.SummaryText(); got != "../outside.go +1" {
 		t.Fatalf("unexpected summary: %q", got)
+	}
+}
+
+func TestRenderWholeFileDeletionsTrackUnknownOperationsByHunkOrdinal(t *testing.T) {
+	rendered := Render(
+		"*** Begin Patch\n*** Delete File: duplicate.txt\n*** Delete File: duplicate.txt\n*** End Patch\n",
+		"/workspace",
+	)
+
+	if len(rendered.Files) != 1 {
+		t.Fatalf("rendered files = %d, want one lexical file", len(rendered.Files))
+	}
+	file := rendered.Files[0]
+	if file.Removed != 0 {
+		t.Fatalf("pending whole-file removal aggregate = %d, want unknown count omitted", file.Removed)
+	}
+	if len(file.WholeFileDeletions) != 2 {
+		t.Fatalf("whole-file deletion operations = %d, want two", len(file.WholeFileDeletions))
+	}
+	for ordinal, operation := range file.WholeFileDeletions {
+		wantID := WholeFileDeletionOperationID{HunkOrdinal: ordinal}
+		if operation.ID != wantID {
+			t.Fatalf("operation %d identity = %+v, want %+v", ordinal, operation.ID, wantID)
+		}
+		if operation.CountKnown {
+			t.Fatalf("operation %d count unexpectedly known: %+v", ordinal, operation)
+		}
+	}
+	if ShowsRemovedCount(file) {
+		t.Fatal("pending whole-file deletion exposed a removal-count fact")
+	}
+	if len(rendered.DetailLines) != 3 ||
+		rendered.DetailLines[0].Kind != RenderedLineKindFile ||
+		rendered.DetailLines[1].Kind != RenderedLineKindDiff ||
+		rendered.DetailLines[2].Kind != RenderedLineKindDiff {
+		t.Fatalf("whole-file deletion detail structure changed: %+v", rendered.DetailLines)
+	}
+}
+
+func TestApplyWholeFileDeletionFactsExposesPositiveAndKnownZeroCounts(t *testing.T) {
+	rendered := Render(
+		"*** Begin Patch\n*** Delete File: populated.txt\n*** Delete File: empty.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	facts := []WholeFileDeletionFact{
+		{ID: WholeFileDeletionOperationID{HunkOrdinal: 0}, Removed: 3},
+		{ID: WholeFileDeletionOperationID{HunkOrdinal: 1}, Removed: 0},
+	}
+
+	applied, err := ApplyWholeFileDeletionFacts(rendered, facts)
+	if err != nil {
+		t.Fatalf("apply deletion facts: %v", err)
+	}
+	if len(applied.Files) != 2 {
+		t.Fatalf("rendered files = %d, want two", len(applied.Files))
+	}
+	for index, wantRemoved := range []int{3, 0} {
+		file := applied.Files[index]
+		if file.Removed != wantRemoved {
+			t.Fatalf("file %d removed = %d, want %d", index, file.Removed, wantRemoved)
+		}
+		if len(file.WholeFileDeletions) != 1 {
+			t.Fatalf("file %d operations = %d, want one", index, len(file.WholeFileDeletions))
+		}
+		operation := file.WholeFileDeletions[0]
+		if operation.ID != facts[index].ID || !operation.CountKnown {
+			t.Fatalf("file %d operation = %+v, want fact %+v marked known", index, operation, facts[index])
+		}
+		if !ShowsRemovedCount(file) {
+			t.Fatalf("file %d did not expose its known removal-count fact", index)
+		}
+	}
+}
+
+func TestWholeFileDeletionOperationDoesNotDuplicateRemovedCount(t *testing.T) {
+	if _, exists := reflect.TypeFor[WholeFileDeletionOperation]().FieldByName("Removed"); exists {
+		t.Fatal("whole-file deletion operation duplicates the rendered file removal count")
+	}
+}
+
+func TestApplyWholeFileDeletionFactsRejectsDuplicateUnmatchedAndMissingIdentities(t *testing.T) {
+	rendered := Render(
+		"*** Begin Patch\n*** Delete File: first.txt\n*** Delete File: second.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	matchedID := WholeFileDeletionOperationID{HunkOrdinal: 0}
+
+	tests := []struct {
+		name     string
+		facts    []WholeFileDeletionFact
+		wantKind WholeFileDeletionFactMismatchKind
+		wantID   WholeFileDeletionOperationID
+	}{
+		{
+			name: "duplicate",
+			facts: []WholeFileDeletionFact{
+				{ID: matchedID, Removed: 1},
+				{ID: matchedID, Removed: 1},
+			},
+			wantKind: WholeFileDeletionFactMismatchDuplicate,
+			wantID:   matchedID,
+		},
+		{
+			name:     "unmatched",
+			facts:    []WholeFileDeletionFact{{ID: WholeFileDeletionOperationID{HunkOrdinal: 99}, Removed: 1}},
+			wantKind: WholeFileDeletionFactMismatchUnmatched,
+			wantID:   WholeFileDeletionOperationID{HunkOrdinal: 99},
+		},
+		{
+			name:     "empty",
+			wantKind: WholeFileDeletionFactMismatchMissing,
+			wantID:   matchedID,
+		},
+		{
+			name:     "partial",
+			facts:    []WholeFileDeletionFact{{ID: matchedID, Removed: 1}},
+			wantKind: WholeFileDeletionFactMismatchMissing,
+			wantID:   WholeFileDeletionOperationID{HunkOrdinal: 1},
+		},
+		{
+			name:     "negative count",
+			facts:    []WholeFileDeletionFact{{ID: matchedID, Removed: -1}},
+			wantKind: WholeFileDeletionFactMismatchInvalidCount,
+			wantID:   matchedID,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ApplyWholeFileDeletionFacts(rendered, test.facts)
+			var mismatch *WholeFileDeletionFactMismatchError
+			if !errors.As(err, &mismatch) {
+				t.Fatalf("error = %v, want typed whole-file deletion fact mismatch", err)
+			}
+			if mismatch.Kind != test.wantKind || mismatch.ID != test.wantID {
+				t.Fatalf("mismatch = %+v, want kind=%q id=%+v", mismatch, test.wantKind, test.wantID)
+			}
+		})
 	}
 }

--- a/shared/transcript/patchformat/types.go
+++ b/shared/transcript/patchformat/types.go
@@ -15,6 +15,38 @@ type DeleteFile struct {
 	Path string
 }
 
+type WholeFileDeletionOperationID struct {
+	HunkOrdinal int
+}
+
+type WholeFileDeletionFact struct {
+	ID      WholeFileDeletionOperationID
+	Removed int
+}
+
+type WholeFileDeletionOperation struct {
+	ID         WholeFileDeletionOperationID
+	CountKnown bool
+}
+
+type WholeFileDeletionFactMismatchKind string
+
+const (
+	WholeFileDeletionFactMismatchDuplicate    WholeFileDeletionFactMismatchKind = "duplicate"
+	WholeFileDeletionFactMismatchUnmatched    WholeFileDeletionFactMismatchKind = "unmatched"
+	WholeFileDeletionFactMismatchMissing      WholeFileDeletionFactMismatchKind = "missing"
+	WholeFileDeletionFactMismatchInvalidCount WholeFileDeletionFactMismatchKind = "invalid_count"
+)
+
+type WholeFileDeletionFactMismatchError struct {
+	Kind WholeFileDeletionFactMismatchKind
+	ID   WholeFileDeletionOperationID
+}
+
+func (e *WholeFileDeletionFactMismatchError) Error() string {
+	return "whole-file deletion fact mismatch: " + string(e.Kind)
+}
+
 type UpdateFile struct {
 	Path    string
 	MoveTo  string
@@ -44,11 +76,12 @@ type RenderedLine struct {
 }
 
 type RenderedFile struct {
-	AbsPath string
-	RelPath string
-	Added   int
-	Removed int
-	Diff    []string
+	AbsPath            string
+	RelPath            string
+	Added              int
+	Removed            int
+	Diff               []string
+	WholeFileDeletions []WholeFileDeletionOperation
 }
 
 type RenderedPatch struct {
@@ -67,6 +100,10 @@ func Clone(in *RenderedPatch) *RenderedPatch {
 		for _, file := range in.Files {
 			copyFile := file
 			copyFile.Diff = append([]string(nil), file.Diff...)
+			copyFile.WholeFileDeletions = append(
+				[]WholeFileDeletionOperation(nil),
+				file.WholeFileDeletions...,
+			)
 			out.Files = append(out.Files, copyFile)
 		}
 	}

--- a/shared/transcript/patchformat/types.go
+++ b/shared/transcript/patchformat/types.go
@@ -1,6 +1,10 @@
 package patchformat
 
-import "strings"
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+)
 
 type Document struct {
 	Hunks []any
@@ -19,6 +23,20 @@ type WholeFileDeletionOperationID struct {
 	HunkOrdinal int
 }
 
+func (id *WholeFileDeletionOperationID) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		HunkOrdinal *int `json:"HunkOrdinal"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	if wire.HunkOrdinal == nil {
+		return errors.New("whole-file deletion operation hunk ordinal is required")
+	}
+	id.HunkOrdinal = *wire.HunkOrdinal
+	return nil
+}
+
 type WholeFileDeletionFact struct {
 	ID      WholeFileDeletionOperationID
 	Removed int
@@ -27,6 +45,22 @@ type WholeFileDeletionFact struct {
 type WholeFileDeletionOperation struct {
 	ID         WholeFileDeletionOperationID
 	CountKnown bool
+}
+
+func (operation *WholeFileDeletionOperation) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		ID         *WholeFileDeletionOperationID `json:"ID"`
+		CountKnown bool                          `json:"CountKnown"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	if wire.ID == nil {
+		return errors.New("whole-file deletion operation id is required")
+	}
+	operation.ID = *wire.ID
+	operation.CountKnown = wire.CountKnown
+	return nil
 }
 
 type WholeFileDeletionFactMismatchKind string

--- a/shared/transcript/tool_codec_test.go
+++ b/shared/transcript/tool_codec_test.go
@@ -3,6 +3,8 @@ package transcript
 import (
 	"encoding/json"
 	"testing"
+
+	patchformat "core/shared/transcript/patchformat"
 )
 
 func TestDecodeToolCallMetaTreatsEmptyObjectAsAbsent(t *testing.T) {
@@ -61,5 +63,34 @@ func TestEncodeDecodeToolCallMetaRoundTripsShellOutputStatus(t *testing.T) {
 	if !meta.RawOutputRequested || !meta.OutputTruncated || !meta.MovedToBackground ||
 		meta.ShellExitCode == nil || *meta.ShellExitCode != 7 {
 		t.Fatalf("expected shell output status to round-trip, got %+v", meta)
+	}
+}
+
+func TestEncodeDecodeToolCallMetaRoundTripsKnownZeroDeletionCount(t *testing.T) {
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: empty.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	rendered, err := patchformat.ApplyWholeFileDeletionFacts(
+		rendered,
+		[]patchformat.WholeFileDeletionFact{{
+			ID: patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+		}},
+	)
+	if err != nil {
+		t.Fatalf("apply known-zero deletion fact: %v", err)
+	}
+
+	raw := EncodeToolCallMeta(ToolCallMeta{ToolName: "patch", PatchRender: &rendered})
+	meta, ok := DecodeToolCallMeta(raw)
+	if !ok || meta.PatchRender == nil || len(meta.PatchRender.Files) != 1 {
+		t.Fatalf("decoded patch metadata = %+v, want one file", meta)
+	}
+	file := meta.PatchRender.Files[0]
+	if file.Removed != 0 ||
+		len(file.WholeFileDeletions) != 1 ||
+		!file.WholeFileDeletions[0].CountKnown ||
+		!patchformat.ShowsRemovedCount(file) {
+		t.Fatalf("known-zero deletion did not round-trip: %+v", file)
 	}
 }

--- a/shared/transcript/types.go
+++ b/shared/transcript/types.go
@@ -73,24 +73,74 @@ type ToolCallMeta struct {
 // tool result. Tool-call input metadata remains authoritative for every other
 // presentation field.
 type ToolResultPresentationDelta struct {
-	RawOutputRequested bool
-	OutputTruncated    bool
-	MovedToBackground  bool
-	ShellExitCode      *int
+	RawOutputRequested     bool
+	OutputTruncated        bool
+	MovedToBackground      bool
+	ShellExitCode          *int
+	WholeFileDeletionFacts []patchformat.WholeFileDeletionFact
 }
 
-func ApplyToolResultPresentationDelta(meta ToolCallMeta, delta *ToolResultPresentationDelta) ToolCallMeta {
-	if delta == nil {
-		return NormalizeToolCallMeta(meta)
+type ToolResultPresentationOutcome uint8
+
+const (
+	ToolResultPresentationOutcomeSuccessful ToolResultPresentationOutcome = iota + 1
+	ToolResultPresentationOutcomeFailed
+)
+
+func ApplyToolResultPresentationDelta(
+	meta ToolCallMeta,
+	delta *ToolResultPresentationDelta,
+	outcome ToolResultPresentationOutcome,
+) (ToolCallMeta, *patchformat.WholeFileDeletionFactMismatchError) {
+	switch outcome {
+	case ToolResultPresentationOutcomeSuccessful, ToolResultPresentationOutcomeFailed:
+	default:
+		panic("tool result presentation outcome is invalid")
 	}
-	meta.RawOutputRequested = meta.RawOutputRequested || delta.RawOutputRequested
-	meta.OutputTruncated = meta.OutputTruncated || delta.OutputTruncated
-	meta.MovedToBackground = meta.MovedToBackground || delta.MovedToBackground
-	if delta.ShellExitCode != nil {
-		exitCode := *delta.ShellExitCode
-		meta.ShellExitCode = &exitCode
+	if delta != nil {
+		meta.RawOutputRequested = meta.RawOutputRequested || delta.RawOutputRequested
+		meta.OutputTruncated = meta.OutputTruncated || delta.OutputTruncated
+		meta.MovedToBackground = meta.MovedToBackground || delta.MovedToBackground
+		if delta.ShellExitCode != nil {
+			exitCode := *delta.ShellExitCode
+			meta.ShellExitCode = &exitCode
+		}
 	}
-	return NormalizeToolCallMeta(meta)
+	if outcome == ToolResultPresentationOutcomeSuccessful && renderedPatchHasWholeFileDeletions(meta.PatchRender) {
+		rendered := patchformat.RenderedPatch{}
+		if meta.PatchRender != nil {
+			rendered = *meta.PatchRender
+		}
+		var facts []patchformat.WholeFileDeletionFact
+		if delta != nil {
+			facts = delta.WholeFileDeletionFacts
+		}
+		finalized, err := patchformat.ApplyWholeFileDeletionFacts(
+			rendered,
+			facts,
+		)
+		if err != nil {
+			return NormalizeToolCallMeta(meta), err
+		}
+		meta.PatchRender = &finalized
+		meta.PatchSummary = strings.TrimSpace(finalized.SummaryText())
+		meta.PatchDetail = strings.TrimSpace(finalized.DetailText())
+		meta.CompactText = meta.PatchSummary
+		meta.Command = meta.PatchDetail
+	}
+	return NormalizeToolCallMeta(meta), nil
+}
+
+func renderedPatchHasWholeFileDeletions(rendered *patchformat.RenderedPatch) bool {
+	if rendered == nil {
+		return false
+	}
+	for _, file := range rendered.Files {
+		if len(file.WholeFileDeletions) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func NormalizeToolCallMeta(in ToolCallMeta) ToolCallMeta {

--- a/shared/transcript/types_test.go
+++ b/shared/transcript/types_test.go
@@ -1,6 +1,11 @@
 package transcript
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	patchformat "core/shared/transcript/patchformat"
+)
 
 func TestNormalizeToolCallMetaRecoversKnownShellToolsWithoutPresentationMetadata(t *testing.T) {
 	tests := []struct {
@@ -105,13 +110,114 @@ func TestApplyToolResultPresentationDeltaCopiesShellExitCode(t *testing.T) {
 	exitCode := 7
 	delta := &ToolResultPresentationDelta{ShellExitCode: &exitCode}
 
-	applied := ApplyToolResultPresentationDelta(ToolCallMeta{
+	applied, err := ApplyToolResultPresentationDelta(ToolCallMeta{
 		ToolName: "exec_command",
 		IsShell:  true,
-	}, delta)
+	}, delta, ToolResultPresentationOutcomeSuccessful)
+	if err != nil {
+		t.Fatalf("apply shell presentation delta: %v", err)
+	}
 	exitCode = 9
 
 	if applied.ShellExitCode == nil || *applied.ShellExitCode != 7 {
 		t.Fatalf("applied shell exit code = %v, want copied 7", applied.ShellExitCode)
+	}
+}
+
+func TestApplyToolResultPresentationDeltaFinalizesDeletionFactsOnceWithoutMutatingCallMetadata(t *testing.T) {
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	meta := ToolCallMeta{
+		ToolName:     "patch",
+		Command:      rendered.DetailText(),
+		CompactText:  rendered.SummaryText(),
+		PatchDetail:  rendered.DetailText(),
+		PatchSummary: rendered.SummaryText(),
+		PatchRender:  &rendered,
+	}
+	delta := &ToolResultPresentationDelta{
+		WholeFileDeletionFacts: []patchformat.WholeFileDeletionFact{{
+			ID:      patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+			Removed: 3,
+		}},
+	}
+
+	applied, err := ApplyToolResultPresentationDelta(meta, delta, ToolResultPresentationOutcomeSuccessful)
+	if err != nil {
+		t.Fatalf("apply deletion presentation delta: %v", err)
+	}
+	if applied.PatchRender == nil || len(applied.PatchRender.Files) != 1 {
+		t.Fatalf("finalized patch render = %+v, want one file", applied.PatchRender)
+	}
+	file := applied.PatchRender.Files[0]
+	if file.Removed != 3 ||
+		len(file.WholeFileDeletions) != 1 ||
+		!file.WholeFileDeletions[0].CountKnown {
+		t.Fatalf("finalized deletion metadata = %+v", file)
+	}
+	if applied.Command != applied.PatchDetail ||
+		applied.CompactText != applied.PatchSummary ||
+		applied.PatchDetail != applied.PatchRender.DetailText() ||
+		applied.PatchSummary != applied.PatchRender.SummaryText() {
+		t.Fatalf("finalized patch aliases are stale: %+v", applied)
+	}
+	if meta.PatchRender.Files[0].Removed != 0 ||
+		meta.PatchRender.Files[0].WholeFileDeletions[0].CountKnown {
+		t.Fatalf("authoritative call metadata was mutated: %+v", meta.PatchRender.Files[0])
+	}
+
+	_, err = ApplyToolResultPresentationDelta(applied, delta, ToolResultPresentationOutcomeSuccessful)
+	var mismatch *patchformat.WholeFileDeletionFactMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("reapplied deletion delta error = %v, want typed mismatch", err)
+	}
+}
+
+func TestApplyToolResultPresentationDeltaRequiresEverySuccessfulDeletionFact(t *testing.T) {
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: first.txt\n*** Delete File: second.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	meta := ToolCallMeta{ToolName: "patch", PatchRender: &rendered}
+	firstFact := patchformat.WholeFileDeletionFact{
+		ID:      patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+		Removed: 1,
+	}
+
+	tests := []struct {
+		name  string
+		delta *ToolResultPresentationDelta
+	}{
+		{name: "nil delta"},
+		{name: "empty delta", delta: &ToolResultPresentationDelta{}},
+		{name: "partial delta", delta: &ToolResultPresentationDelta{WholeFileDeletionFacts: []patchformat.WholeFileDeletionFact{firstFact}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ApplyToolResultPresentationDelta(meta, test.delta, ToolResultPresentationOutcomeSuccessful)
+			if err == nil || err.Kind != patchformat.WholeFileDeletionFactMismatchMissing {
+				t.Fatalf("error = %v, want typed missing deletion fact", err)
+			}
+		})
+	}
+}
+
+func TestApplyToolResultPresentationDeltaPreservesUnknownCountsForFailedDeletion(t *testing.T) {
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	meta := ToolCallMeta{ToolName: "patch", PatchRender: &rendered}
+
+	applied, err := ApplyToolResultPresentationDelta(meta, nil, ToolResultPresentationOutcomeFailed)
+	if err != nil {
+		t.Fatalf("apply failed deletion presentation: %v", err)
+	}
+	if applied.PatchRender == nil ||
+		applied.PatchRender.Files[0].Removed != 0 ||
+		applied.PatchRender.Files[0].WholeFileDeletions[0].CountKnown {
+		t.Fatalf("failed deletion presentation fabricated a count: %+v", applied.PatchRender)
 	}
 }

--- a/tui-rs/crates/client-contracts/src/clientui.rs
+++ b/tui-rs/crates/client-contracts/src/clientui.rs
@@ -373,6 +373,20 @@ pub struct RenderedFile {
     pub removed: i32,
     #[serde(rename = "Diff", default, deserialize_with = "null_to_default")]
     pub diff: Vec<String>,
+    #[serde(
+        rename = "WholeFileDeletions",
+        default,
+        deserialize_with = "null_to_default"
+    )]
+    pub whole_file_deletions: Vec<WholeFileDeletionOperation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct WholeFileDeletionOperation {
+    #[serde(rename = "ID")]
+    pub id: WholeFileDeletionOperationId,
+    #[serde(rename = "CountKnown")]
+    pub count_known: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/tui-rs/crates/client-contracts/src/clientui.rs
+++ b/tui-rs/crates/client-contracts/src/clientui.rs
@@ -4,8 +4,10 @@ use uuid::Uuid;
 use crate::config::null_to_default;
 
 pub mod main_view;
+mod transcript_diagnostic;
 
 pub use main_view::*;
+pub use transcript_diagnostic::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct RunState {
@@ -285,14 +287,6 @@ pub struct TranscriptCacheWarning {
     pub lost_input_tokens: i32,
     #[serde(rename = "Visibility")]
     pub visibility: EntryVisibility,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
-pub struct TranscriptDiagnostic {
-    #[serde(rename = "Code")]
-    pub code: String,
-    #[serde(rename = "Detail")]
-    pub detail: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/tui-rs/crates/client-contracts/src/clientui/transcript_diagnostic.rs
+++ b/tui-rs/crates/client-contracts/src/clientui/transcript_diagnostic.rs
@@ -4,29 +4,9 @@ use serde::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TranscriptDiagnostic {
-    pub code: String,
-    pub detail: String,
-    pub developer: Option<DeveloperDiagnostic>,
-}
-
-impl TranscriptDiagnostic {
-    fn validate(&self) -> Result<(), &'static str> {
-        let has_legacy = !self.code.trim().is_empty() || !self.detail.trim().is_empty();
-        let has_developer = self.developer.is_some();
-        if has_legacy == has_developer {
-            return Err(
-                "transcript diagnostic must contain exactly one legacy or developer variant",
-            );
-        }
-        if has_legacy && (self.code.trim().is_empty() || self.detail.trim().is_empty()) {
-            return Err("transcript diagnostic legacy code and detail are both required");
-        }
-        if let Some(developer) = &self.developer {
-            developer.validate()?;
-        }
-        Ok(())
-    }
+pub enum TranscriptDiagnostic {
+    Legacy { code: String, detail: String },
+    Developer(DeveloperDiagnostic),
 }
 
 impl Serialize for TranscriptDiagnostic {
@@ -34,11 +14,20 @@ impl Serialize for TranscriptDiagnostic {
     where
         S: Serializer,
     {
-        self.validate().map_err(S::Error::custom)?;
         let mut state = serializer.serialize_struct("TranscriptDiagnostic", 3)?;
-        state.serialize_field("Code", &self.code)?;
-        state.serialize_field("Detail", &self.detail)?;
-        state.serialize_field("Developer", &self.developer)?;
+        match self {
+            Self::Legacy { code, detail } => {
+                validate_legacy(code, detail).map_err(S::Error::custom)?;
+                state.serialize_field("Code", &Some(code))?;
+                state.serialize_field("Detail", &Some(detail))?;
+                state.serialize_field("Developer", &Option::<&DeveloperDiagnostic>::None)?;
+            }
+            Self::Developer(developer) => {
+                state.serialize_field("Code", &Option::<&String>::None)?;
+                state.serialize_field("Detail", &Option::<&String>::None)?;
+                state.serialize_field("Developer", &Some(developer))?;
+            }
+        }
         state.end()
     }
 }
@@ -51,37 +40,30 @@ impl<'de> Deserialize<'de> for TranscriptDiagnostic {
         #[derive(Deserialize)]
         struct WireDiagnostic {
             #[serde(rename = "Code")]
-            code: String,
+            code: Option<String>,
             #[serde(rename = "Detail")]
-            detail: String,
+            detail: Option<String>,
             #[serde(rename = "Developer", default)]
             developer: Option<DeveloperDiagnostic>,
         }
 
         let wire = WireDiagnostic::deserialize(deserializer)?;
-        let diagnostic = Self {
-            code: wire.code,
-            detail: wire.detail,
-            developer: wire.developer,
-        };
-        diagnostic.validate().map_err(D::Error::custom)?;
-        Ok(diagnostic)
+        match (wire.code, wire.detail, wire.developer) {
+            (Some(code), Some(detail), None) => {
+                validate_legacy(&code, &detail).map_err(D::Error::custom)?;
+                Ok(Self::Legacy { code, detail })
+            }
+            (None, None, Some(developer)) => Ok(Self::Developer(developer)),
+            _ => Err(D::Error::custom(
+                "transcript diagnostic must contain exactly one complete legacy or developer variant",
+            )),
+        }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DeveloperDiagnostic {
-    pub deletion_fact_mismatch: Option<DeletionFactMismatchDeveloperDiagnostic>,
-}
-
-impl DeveloperDiagnostic {
-    fn validate(&self) -> Result<(), &'static str> {
-        let mismatch = self
-            .deletion_fact_mismatch
-            .as_ref()
-            .ok_or("developer diagnostic variant is required")?;
-        mismatch.validate()
-    }
+pub enum DeveloperDiagnostic {
+    DeletionFactMismatch(DeletionFactMismatchDeveloperDiagnostic),
 }
 
 impl Serialize for DeveloperDiagnostic {
@@ -89,9 +71,13 @@ impl Serialize for DeveloperDiagnostic {
     where
         S: Serializer,
     {
-        self.validate().map_err(S::Error::custom)?;
         let mut state = serializer.serialize_struct("DeveloperDiagnostic", 1)?;
-        state.serialize_field("deletion_fact_mismatch", &self.deletion_fact_mismatch)?;
+        match self {
+            Self::DeletionFactMismatch(mismatch) => {
+                mismatch.validate().map_err(S::Error::custom)?;
+                state.serialize_field("deletion_fact_mismatch", mismatch)?;
+            }
+        }
         state.end()
     }
 }
@@ -108,12 +94,18 @@ impl<'de> Deserialize<'de> for DeveloperDiagnostic {
         }
 
         let wire = WireDeveloperDiagnostic::deserialize(deserializer)?;
-        let diagnostic = Self {
-            deletion_fact_mismatch: wire.deletion_fact_mismatch,
-        };
-        diagnostic.validate().map_err(D::Error::custom)?;
-        Ok(diagnostic)
+        let mismatch = wire
+            .deletion_fact_mismatch
+            .ok_or_else(|| D::Error::custom("developer diagnostic variant is required"))?;
+        Ok(Self::DeletionFactMismatch(mismatch))
     }
+}
+
+fn validate_legacy(code: &str, detail: &str) -> Result<(), &'static str> {
+    if code.trim().is_empty() || detail.trim().is_empty() {
+        return Err("transcript diagnostic legacy code and detail are both required");
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tui-rs/crates/client-contracts/src/clientui/transcript_diagnostic.rs
+++ b/tui-rs/crates/client-contracts/src/clientui/transcript_diagnostic.rs
@@ -1,0 +1,192 @@
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer, de::Error as _, ser::Error as _,
+    ser::SerializeStruct,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranscriptDiagnostic {
+    pub code: String,
+    pub detail: String,
+    pub developer: Option<DeveloperDiagnostic>,
+}
+
+impl TranscriptDiagnostic {
+    fn validate(&self) -> Result<(), &'static str> {
+        let has_legacy = !self.code.trim().is_empty() || !self.detail.trim().is_empty();
+        let has_developer = self.developer.is_some();
+        if has_legacy == has_developer {
+            return Err(
+                "transcript diagnostic must contain exactly one legacy or developer variant",
+            );
+        }
+        if has_legacy && (self.code.trim().is_empty() || self.detail.trim().is_empty()) {
+            return Err("transcript diagnostic legacy code and detail are both required");
+        }
+        if let Some(developer) = &self.developer {
+            developer.validate()?;
+        }
+        Ok(())
+    }
+}
+
+impl Serialize for TranscriptDiagnostic {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.validate().map_err(S::Error::custom)?;
+        let mut state = serializer.serialize_struct("TranscriptDiagnostic", 3)?;
+        state.serialize_field("Code", &self.code)?;
+        state.serialize_field("Detail", &self.detail)?;
+        state.serialize_field("Developer", &self.developer)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for TranscriptDiagnostic {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireDiagnostic {
+            #[serde(rename = "Code")]
+            code: String,
+            #[serde(rename = "Detail")]
+            detail: String,
+            #[serde(rename = "Developer", default)]
+            developer: Option<DeveloperDiagnostic>,
+        }
+
+        let wire = WireDiagnostic::deserialize(deserializer)?;
+        let diagnostic = Self {
+            code: wire.code,
+            detail: wire.detail,
+            developer: wire.developer,
+        };
+        diagnostic.validate().map_err(D::Error::custom)?;
+        Ok(diagnostic)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeveloperDiagnostic {
+    pub deletion_fact_mismatch: Option<DeletionFactMismatchDeveloperDiagnostic>,
+}
+
+impl DeveloperDiagnostic {
+    fn validate(&self) -> Result<(), &'static str> {
+        let mismatch = self
+            .deletion_fact_mismatch
+            .as_ref()
+            .ok_or("developer diagnostic variant is required")?;
+        mismatch.validate()
+    }
+}
+
+impl Serialize for DeveloperDiagnostic {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.validate().map_err(S::Error::custom)?;
+        let mut state = serializer.serialize_struct("DeveloperDiagnostic", 1)?;
+        state.serialize_field("deletion_fact_mismatch", &self.deletion_fact_mismatch)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for DeveloperDiagnostic {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireDeveloperDiagnostic {
+            #[serde(rename = "deletion_fact_mismatch", default)]
+            deletion_fact_mismatch: Option<DeletionFactMismatchDeveloperDiagnostic>,
+        }
+
+        let wire = WireDeveloperDiagnostic::deserialize(deserializer)?;
+        let diagnostic = Self {
+            deletion_fact_mismatch: wire.deletion_fact_mismatch,
+        };
+        diagnostic.validate().map_err(D::Error::custom)?;
+        Ok(diagnostic)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeletionFactMismatchDeveloperDiagnostic {
+    pub call_id: String,
+    pub operation_id: WholeFileDeletionOperationId,
+    pub mismatch_kind: DeletionFactMismatchKind,
+}
+
+impl DeletionFactMismatchDeveloperDiagnostic {
+    fn validate(&self) -> Result<(), &'static str> {
+        if self.call_id.trim().is_empty() {
+            return Err("deletion fact mismatch diagnostic call id is required");
+        }
+        if self.operation_id.hunk_ordinal < 0 {
+            return Err("deletion fact mismatch diagnostic hunk ordinal must be non-negative");
+        }
+        Ok(())
+    }
+}
+
+impl Serialize for DeletionFactMismatchDeveloperDiagnostic {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.validate().map_err(S::Error::custom)?;
+        let mut state =
+            serializer.serialize_struct("DeletionFactMismatchDeveloperDiagnostic", 3)?;
+        state.serialize_field("call_id", &self.call_id)?;
+        state.serialize_field("operation_id", &self.operation_id)?;
+        state.serialize_field("mismatch_kind", &self.mismatch_kind)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for DeletionFactMismatchDeveloperDiagnostic {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireMismatch {
+            call_id: String,
+            operation_id: WholeFileDeletionOperationId,
+            mismatch_kind: DeletionFactMismatchKind,
+        }
+
+        let wire = WireMismatch::deserialize(deserializer)?;
+        let mismatch = Self {
+            call_id: wire.call_id,
+            operation_id: wire.operation_id,
+            mismatch_kind: wire.mismatch_kind,
+        };
+        mismatch.validate().map_err(D::Error::custom)?;
+        Ok(mismatch)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct WholeFileDeletionOperationId {
+    #[serde(rename = "HunkOrdinal")]
+    pub hunk_ordinal: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+pub enum DeletionFactMismatchKind {
+    #[serde(rename = "duplicate")]
+    Duplicate,
+    #[serde(rename = "unmatched")]
+    Unmatched,
+    #[serde(rename = "missing")]
+    Missing,
+    #[serde(rename = "invalid_count")]
+    InvalidCount,
+}

--- a/tui-rs/crates/client-contracts/tests/rendered_file_contract.rs
+++ b/tui-rs/crates/client-contracts/tests/rendered_file_contract.rs
@@ -1,0 +1,42 @@
+#![forbid(unsafe_code)]
+
+use client_contracts::clientui::RenderedFile;
+use serde_json::json;
+
+#[test]
+fn rendered_file_preserves_whole_file_deletion_count_presence() {
+    let file: RenderedFile = serde_json::from_value(json!({
+        "AbsPath": "/workspace/empty.txt",
+        "RelPath": "./empty.txt",
+        "Added": 0,
+        "Removed": 0,
+        "Diff": ["*** Delete File: empty.txt"],
+        "WholeFileDeletions": [{
+            "ID": {"HunkOrdinal": 3},
+            "CountKnown": true
+        }]
+    }))
+    .expect("server rendered file must decode");
+
+    assert_eq!(file.whole_file_deletions.len(), 1);
+    let deletion = &file.whole_file_deletions[0];
+    assert_eq!(deletion.id.hunk_ordinal, 3);
+    assert!(deletion.count_known);
+
+    let encoded = serde_json::to_value(file).expect("rendered file must encode");
+    assert_eq!(encoded["WholeFileDeletions"][0]["CountKnown"], true);
+}
+
+#[test]
+fn rendered_file_defaults_legacy_missing_deletion_metadata_to_empty() {
+    let file: RenderedFile = serde_json::from_value(json!({
+        "AbsPath": "/workspace/file.txt",
+        "RelPath": "./file.txt",
+        "Added": 1,
+        "Removed": 0,
+        "Diff": ["+content"]
+    }))
+    .expect("legacy rendered file must decode");
+
+    assert!(file.whole_file_deletions.is_empty());
+}

--- a/tui-rs/crates/client-contracts/tests/transcript_diagnostic_contract.rs
+++ b/tui-rs/crates/client-contracts/tests/transcript_diagnostic_contract.rs
@@ -1,23 +1,35 @@
+#![forbid(unsafe_code)]
+
 use client_contracts::clientui::{
     DeletionFactMismatchDeveloperDiagnostic, DeletionFactMismatchKind, DeveloperDiagnostic,
     TranscriptDiagnostic, TranscriptNoticeRow, WholeFileDeletionOperationId,
 };
 use serde_json::json;
 
+fn valid_mismatch() -> DeletionFactMismatchDeveloperDiagnostic {
+    DeletionFactMismatchDeveloperDiagnostic {
+        call_id: "call-1".to_owned(),
+        operation_id: WholeFileDeletionOperationId { hunk_ordinal: 2 },
+        mismatch_kind: DeletionFactMismatchKind::Missing,
+    }
+}
+
+fn valid_developer_diagnostic() -> DeveloperDiagnostic {
+    DeveloperDiagnostic::DeletionFactMismatch(valid_mismatch())
+}
+
 #[test]
-fn typed_deletion_diagnostic_decodes_server_payload_without_legacy_strings() {
+fn typed_deletion_diagnostic_decodes_nullable_server_payload() {
     let notice: TranscriptNoticeRow = serde_json::from_value(json!({
         "Reason": "runtime_diagnostic",
         "Severity": "error",
         "Diagnostic": {
-            "Code": "",
-            "Detail": "",
+            "Code": null,
+            "Detail": null,
             "Developer": {
                 "deletion_fact_mismatch": {
                     "call_id": "call-1",
-                    "operation_id": {
-                        "HunkOrdinal": 2
-                    },
+                    "operation_id": {"HunkOrdinal": 2},
                     "mismatch_kind": "missing"
                 }
             }
@@ -28,63 +40,56 @@ fn typed_deletion_diagnostic_decodes_server_payload_without_legacy_strings() {
     let diagnostic = notice
         .diagnostic
         .expect("typed transcript diagnostic must be present");
-    assert!(diagnostic.code.is_empty());
-    assert!(diagnostic.detail.is_empty());
-    let mismatch = diagnostic
-        .developer
-        .expect("typed developer diagnostic must be present")
-        .deletion_fact_mismatch
-        .expect("deletion mismatch context must be present");
+    let TranscriptDiagnostic::Developer(DeveloperDiagnostic::DeletionFactMismatch(mismatch)) =
+        diagnostic
+    else {
+        panic!("expected typed deletion mismatch diagnostic");
+    };
     assert_eq!(mismatch.call_id, "call-1");
     assert_eq!(mismatch.operation_id.hunk_ordinal, 2);
     assert_eq!(mismatch.mismatch_kind, DeletionFactMismatchKind::Missing);
 }
 
 #[test]
-fn legacy_diagnostic_decodes_without_developer_variant() {
-    let diagnostic: TranscriptDiagnostic = serde_json::from_value(json!({
-        "Code": "legacy_code",
-        "Detail": "legacy detail"
-    }))
-    .expect("legacy diagnostic must decode without a developer variant");
+fn diagnostic_variants_encode_with_nullable_inactive_wire_fields() {
+    let legacy = serde_json::to_value(TranscriptDiagnostic::Legacy {
+        code: "legacy_code".to_owned(),
+        detail: "legacy detail".to_owned(),
+    })
+    .expect("legacy diagnostic must encode");
+    assert_eq!(
+        legacy,
+        json!({
+            "Code": "legacy_code",
+            "Detail": "legacy detail",
+            "Developer": null
+        })
+    );
 
-    assert_eq!(diagnostic.code, "legacy_code");
-    assert_eq!(diagnostic.detail, "legacy detail");
-    assert!(diagnostic.developer.is_none());
+    let developer =
+        serde_json::to_value(TranscriptDiagnostic::Developer(valid_developer_diagnostic()))
+            .expect("developer diagnostic must encode");
+    assert_eq!(developer["Code"], json!(null));
+    assert_eq!(developer["Detail"], json!(null));
+    assert!(developer["Developer"]["deletion_fact_mismatch"].is_object());
 }
 
 #[test]
-fn blank_present_legacy_diagnostic_fields_are_rejected() {
-    for payload in [
-        json!({"Code": " ", "Detail": ""}),
-        json!({"Code": "", "Detail": "\t"}),
-    ] {
-        let result = serde_json::from_value::<TranscriptDiagnostic>(payload);
-        assert!(
-            result.is_err(),
-            "blank present legacy field must not decode"
-        );
-    }
+fn legacy_diagnostic_decodes_without_developer_variant() {
+    let diagnostic: TranscriptDiagnostic = serde_json::from_value(json!({
+        "Code": "legacy_code",
+        "Detail": "legacy detail",
+        "Developer": null
+    }))
+    .expect("legacy diagnostic must decode");
 
-    let invalid = TranscriptDiagnostic {
-        code: " ".to_owned(),
-        detail: String::new(),
-        developer: None,
-    };
-    assert!(
-        serde_json::to_value(invalid).is_err(),
-        "blank present legacy field must not encode"
+    assert_eq!(
+        diagnostic,
+        TranscriptDiagnostic::Legacy {
+            code: "legacy_code".to_owned(),
+            detail: "legacy detail".to_owned(),
+        }
     );
-}
-
-fn valid_developer_diagnostic() -> DeveloperDiagnostic {
-    DeveloperDiagnostic {
-        deletion_fact_mismatch: Some(DeletionFactMismatchDeveloperDiagnostic {
-            call_id: "call-1".to_owned(),
-            operation_id: WholeFileDeletionOperationId { hunk_ordinal: 2 },
-            mismatch_kind: DeletionFactMismatchKind::Missing,
-        }),
-    }
 }
 
 #[test]
@@ -97,12 +102,15 @@ fn invalid_diagnostic_variants_are_rejected_on_decode() {
         }
     });
     for payload in [
+        json!({"Code": null, "Detail": null, "Developer": null}),
+        json!({"Code": "legacy", "Detail": null, "Developer": null}),
+        json!({"Code": null, "Detail": "detail", "Developer": null}),
         json!({"Code": "", "Detail": "", "Developer": null}),
         json!({"Code": "legacy", "Detail": "detail", "Developer": valid_developer}),
-        json!({"Code": "", "Detail": "", "Developer": {}}),
+        json!({"Code": null, "Detail": null, "Developer": {}}),
         json!({
-            "Code": "",
-            "Detail": "",
+            "Code": null,
+            "Detail": null,
             "Developer": {
                 "deletion_fact_mismatch": {
                     "call_id": " ",
@@ -112,8 +120,8 @@ fn invalid_diagnostic_variants_are_rejected_on_decode() {
             }
         }),
         json!({
-            "Code": "",
-            "Detail": "",
+            "Code": null,
+            "Detail": null,
             "Developer": {
                 "deletion_fact_mismatch": {
                     "call_id": "call-1",
@@ -123,72 +131,40 @@ fn invalid_diagnostic_variants_are_rejected_on_decode() {
             }
         }),
     ] {
-        let result = serde_json::from_value::<TranscriptDiagnostic>(payload);
-        assert!(result.is_err(), "invalid diagnostic must not decode");
+        assert!(
+            serde_json::from_value::<TranscriptDiagnostic>(payload).is_err(),
+            "invalid diagnostic must not decode"
+        );
     }
-
-    assert!(
-        serde_json::from_value::<DeveloperDiagnostic>(json!({})).is_err(),
-        "developer diagnostic without a known variant must not decode"
-    );
 }
 
 #[test]
 fn invalid_diagnostic_variants_are_rejected_on_encode() {
-    let valid_developer = valid_developer_diagnostic();
-    let invalid_diagnostics = [
-        TranscriptDiagnostic {
-            code: String::new(),
-            detail: String::new(),
-            developer: None,
-        },
-        TranscriptDiagnostic {
-            code: "legacy".to_owned(),
+    for diagnostic in [
+        TranscriptDiagnostic::Legacy {
+            code: " ".to_owned(),
             detail: "detail".to_owned(),
-            developer: Some(valid_developer),
         },
-        TranscriptDiagnostic {
-            code: String::new(),
-            detail: String::new(),
-            developer: Some(DeveloperDiagnostic {
-                deletion_fact_mismatch: None,
-            }),
+        TranscriptDiagnostic::Legacy {
+            code: "legacy".to_owned(),
+            detail: "\t".to_owned(),
         },
-        TranscriptDiagnostic {
-            code: String::new(),
-            detail: String::new(),
-            developer: Some(DeveloperDiagnostic {
-                deletion_fact_mismatch: Some(DeletionFactMismatchDeveloperDiagnostic {
-                    call_id: " ".to_owned(),
-                    operation_id: WholeFileDeletionOperationId { hunk_ordinal: 2 },
-                    mismatch_kind: DeletionFactMismatchKind::Missing,
-                }),
-            }),
-        },
-        TranscriptDiagnostic {
-            code: String::new(),
-            detail: String::new(),
-            developer: Some(DeveloperDiagnostic {
-                deletion_fact_mismatch: Some(DeletionFactMismatchDeveloperDiagnostic {
-                    call_id: "call-1".to_owned(),
-                    operation_id: WholeFileDeletionOperationId { hunk_ordinal: -1 },
-                    mismatch_kind: DeletionFactMismatchKind::Missing,
-                }),
-            }),
-        },
-    ];
-    for diagnostic in invalid_diagnostics {
+        TranscriptDiagnostic::Developer(DeveloperDiagnostic::DeletionFactMismatch(
+            DeletionFactMismatchDeveloperDiagnostic {
+                call_id: " ".to_owned(),
+                ..valid_mismatch()
+            },
+        )),
+        TranscriptDiagnostic::Developer(DeveloperDiagnostic::DeletionFactMismatch(
+            DeletionFactMismatchDeveloperDiagnostic {
+                operation_id: WholeFileDeletionOperationId { hunk_ordinal: -1 },
+                ..valid_mismatch()
+            },
+        )),
+    ] {
         assert!(
             serde_json::to_value(diagnostic).is_err(),
             "invalid diagnostic must not encode"
         );
     }
-
-    assert!(
-        serde_json::to_value(DeveloperDiagnostic {
-            deletion_fact_mismatch: None
-        })
-        .is_err(),
-        "developer diagnostic without a known variant must not encode"
-    );
 }

--- a/tui-rs/crates/client-contracts/tests/transcript_diagnostic_contract.rs
+++ b/tui-rs/crates/client-contracts/tests/transcript_diagnostic_contract.rs
@@ -1,0 +1,194 @@
+use client_contracts::clientui::{
+    DeletionFactMismatchDeveloperDiagnostic, DeletionFactMismatchKind, DeveloperDiagnostic,
+    TranscriptDiagnostic, TranscriptNoticeRow, WholeFileDeletionOperationId,
+};
+use serde_json::json;
+
+#[test]
+fn typed_deletion_diagnostic_decodes_server_payload_without_legacy_strings() {
+    let notice: TranscriptNoticeRow = serde_json::from_value(json!({
+        "Reason": "runtime_diagnostic",
+        "Severity": "error",
+        "Diagnostic": {
+            "Code": "",
+            "Detail": "",
+            "Developer": {
+                "deletion_fact_mismatch": {
+                    "call_id": "call-1",
+                    "operation_id": {
+                        "HunkOrdinal": 2
+                    },
+                    "mismatch_kind": "missing"
+                }
+            }
+        }
+    }))
+    .expect("server-emitted typed diagnostic notice must decode");
+
+    let diagnostic = notice
+        .diagnostic
+        .expect("typed transcript diagnostic must be present");
+    assert!(diagnostic.code.is_empty());
+    assert!(diagnostic.detail.is_empty());
+    let mismatch = diagnostic
+        .developer
+        .expect("typed developer diagnostic must be present")
+        .deletion_fact_mismatch
+        .expect("deletion mismatch context must be present");
+    assert_eq!(mismatch.call_id, "call-1");
+    assert_eq!(mismatch.operation_id.hunk_ordinal, 2);
+    assert_eq!(mismatch.mismatch_kind, DeletionFactMismatchKind::Missing);
+}
+
+#[test]
+fn legacy_diagnostic_decodes_without_developer_variant() {
+    let diagnostic: TranscriptDiagnostic = serde_json::from_value(json!({
+        "Code": "legacy_code",
+        "Detail": "legacy detail"
+    }))
+    .expect("legacy diagnostic must decode without a developer variant");
+
+    assert_eq!(diagnostic.code, "legacy_code");
+    assert_eq!(diagnostic.detail, "legacy detail");
+    assert!(diagnostic.developer.is_none());
+}
+
+#[test]
+fn blank_present_legacy_diagnostic_fields_are_rejected() {
+    for payload in [
+        json!({"Code": " ", "Detail": ""}),
+        json!({"Code": "", "Detail": "\t"}),
+    ] {
+        let result = serde_json::from_value::<TranscriptDiagnostic>(payload);
+        assert!(
+            result.is_err(),
+            "blank present legacy field must not decode"
+        );
+    }
+
+    let invalid = TranscriptDiagnostic {
+        code: " ".to_owned(),
+        detail: String::new(),
+        developer: None,
+    };
+    assert!(
+        serde_json::to_value(invalid).is_err(),
+        "blank present legacy field must not encode"
+    );
+}
+
+fn valid_developer_diagnostic() -> DeveloperDiagnostic {
+    DeveloperDiagnostic {
+        deletion_fact_mismatch: Some(DeletionFactMismatchDeveloperDiagnostic {
+            call_id: "call-1".to_owned(),
+            operation_id: WholeFileDeletionOperationId { hunk_ordinal: 2 },
+            mismatch_kind: DeletionFactMismatchKind::Missing,
+        }),
+    }
+}
+
+#[test]
+fn invalid_diagnostic_variants_are_rejected_on_decode() {
+    let valid_developer = json!({
+        "deletion_fact_mismatch": {
+            "call_id": "call-1",
+            "operation_id": {"HunkOrdinal": 2},
+            "mismatch_kind": "missing"
+        }
+    });
+    for payload in [
+        json!({"Code": "", "Detail": "", "Developer": null}),
+        json!({"Code": "legacy", "Detail": "detail", "Developer": valid_developer}),
+        json!({"Code": "", "Detail": "", "Developer": {}}),
+        json!({
+            "Code": "",
+            "Detail": "",
+            "Developer": {
+                "deletion_fact_mismatch": {
+                    "call_id": " ",
+                    "operation_id": {"HunkOrdinal": 2},
+                    "mismatch_kind": "missing"
+                }
+            }
+        }),
+        json!({
+            "Code": "",
+            "Detail": "",
+            "Developer": {
+                "deletion_fact_mismatch": {
+                    "call_id": "call-1",
+                    "operation_id": {"HunkOrdinal": -1},
+                    "mismatch_kind": "missing"
+                }
+            }
+        }),
+    ] {
+        let result = serde_json::from_value::<TranscriptDiagnostic>(payload);
+        assert!(result.is_err(), "invalid diagnostic must not decode");
+    }
+
+    assert!(
+        serde_json::from_value::<DeveloperDiagnostic>(json!({})).is_err(),
+        "developer diagnostic without a known variant must not decode"
+    );
+}
+
+#[test]
+fn invalid_diagnostic_variants_are_rejected_on_encode() {
+    let valid_developer = valid_developer_diagnostic();
+    let invalid_diagnostics = [
+        TranscriptDiagnostic {
+            code: String::new(),
+            detail: String::new(),
+            developer: None,
+        },
+        TranscriptDiagnostic {
+            code: "legacy".to_owned(),
+            detail: "detail".to_owned(),
+            developer: Some(valid_developer),
+        },
+        TranscriptDiagnostic {
+            code: String::new(),
+            detail: String::new(),
+            developer: Some(DeveloperDiagnostic {
+                deletion_fact_mismatch: None,
+            }),
+        },
+        TranscriptDiagnostic {
+            code: String::new(),
+            detail: String::new(),
+            developer: Some(DeveloperDiagnostic {
+                deletion_fact_mismatch: Some(DeletionFactMismatchDeveloperDiagnostic {
+                    call_id: " ".to_owned(),
+                    operation_id: WholeFileDeletionOperationId { hunk_ordinal: 2 },
+                    mismatch_kind: DeletionFactMismatchKind::Missing,
+                }),
+            }),
+        },
+        TranscriptDiagnostic {
+            code: String::new(),
+            detail: String::new(),
+            developer: Some(DeveloperDiagnostic {
+                deletion_fact_mismatch: Some(DeletionFactMismatchDeveloperDiagnostic {
+                    call_id: "call-1".to_owned(),
+                    operation_id: WholeFileDeletionOperationId { hunk_ordinal: -1 },
+                    mismatch_kind: DeletionFactMismatchKind::Missing,
+                }),
+            }),
+        },
+    ];
+    for diagnostic in invalid_diagnostics {
+        assert!(
+            serde_json::to_value(diagnostic).is_err(),
+            "invalid diagnostic must not encode"
+        );
+    }
+
+    assert!(
+        serde_json::to_value(DeveloperDiagnostic {
+            deletion_fact_mismatch: None
+        })
+        .is_err(),
+        "developer diagnostic without a known variant must not encode"
+    );
+}


### PR DESCRIPTION
## Summary

- report whole-file deletion counts from the exact locked source snapshot removed by the patch tool
- preserve known zero (`-0`) for successful empty-file deletions while pending/failed deletions remain path-only
- reject duplicate canonical deletion targets before commit, including symlink aliases
- persist typed deletion-fact mismatch diagnostics without changing successful tool completion, with release/debug TUI handling
- validate the protocol-61 diagnostic union consistently in Go and Rust

Closes #349. Kent ticket: `BUI-23`.

## Evidence

- Committed exact Delete File capture: [`.kent/evidence/BUI-23-exact-delete-capture.txt`](https://github.com/respawn-llc/kent/blob/BUI-23/.kent/evidence/BUI-23-exact-delete-capture.txt)
  - pending deletion: path only; source remains intact
  - populated deletion: source removed; renders `-3`
  - empty deletion: source removed; renders known-zero `-0`
- Acceptance and review checklist is maintained in `.kent/plans/BUI-23.md` (workflow-local, intentionally not committed).

GitHub CLI does not support uploading arbitrary PR attachments, so the text evidence is committed and linked above.

## Verification

After rebasing onto `origin/main`:

- `./scripts/test.sh server ./shared/transcript/patchformat ./server/tools/patch ./server/runtime ./server/runtimeview ./shared/clientui ./shared/protocol ./cli/tui ./cli/tui/transcriptrender ./cli/app -count=1`
- `./scripts/test.sh server ./server/transport ./server/startup -count=1`
- `./scripts/test.sh tui`
- `./scripts/build.sh server --output ./bin/kent`
- `./scripts/build.sh tui`
- `./scripts/test.sh server ./server/processview -count=20`

All passed. The last stress run verifies the scheduler-margin correction for two unrelated async process-view tests that timed out under CI load.

## LoC report vs `origin/main`

- Production, non-test, non-generated: **+1,226 / -219**, net **+1,007**, gross **1,445**
- Tests and generated: **+2,155 / -66**, net **+2,089**, gross **2,221**
- Docs and committed evidence: **+26 / -0**, net/gross **26**
- Total: **+3,407 / -285**, net **+3,122**, gross **3,692**

No generated files changed.

## Caveats and tradeoffs

- The removal count is captured at patch commit time and consumed as typed presentation metadata; formatters do not read the filesystem.
- Successful fact mismatches preserve the already-applied completion with uncounted presentation and one durable typed diagnostic; no count is fabricated.
- Rebase onto current `main` crossed the unified runtime-feed refactor. The old recent-tail cache path no longer exists on `main`, so the final branch integrates with the current feed/read-model architecture rather than restoring deleted cache code.
- Protocol remains **61** because this contract correction is still unreleased.
- The Rust client is currently a user-confirmed stub; its contract and build are covered, but it is not treated as a manual product surface.
- CI initially exposed two pre-existing process-view polling tests with a 2-second scheduler deadline. Their common deadline is now 10 seconds; behavior and polling cadence are unchanged, and 20 uncached repetitions pass.

## Follow-up / technical debt

No follow-up is required for the deletion-count behavior. Future protocol diagnostic variants must extend the validated Go/Rust union together and bump the protocol when released compatibility requires it.
