### PR TITLE
Prevent zero runtime request IDs in draft recovery

### DIFF
--- a/cli/app/back_parent_prefill_integration_test.go
+++ b/cli/app/back_parent_prefill_integration_test.go
@@ -130,23 +130,12 @@ func runBackParentPrefillScenario(t *testing.T, server backParentPrefillScenario
 					Input:           "conflicting parent draft",
 					RecoveryBuffers: []serverapi.SessionDraftRecoveryBuffer{
 						{
-							Kind:            serverapi.SessionDraftRecoveryBufferPendingInjectedInput,
-							ID:              "pending-parent-input",
-							ClientRequestID: "pending-parent-request",
-							Text:            "conflicting pending input",
-							OperationRef: clientui.RuntimeOperationRef{
-								Kind:            clientui.RuntimeOperationKindQueuedMessage,
-								ClientRequestID: runtimeids.NewRuntimeClientRequestID(),
-							},
+							Kind: serverapi.SessionDraftRecoveryBufferPendingInjectedInput,
+							Text: "conflicting pending input",
 						},
 						{
 							Kind: serverapi.SessionDraftRecoveryBufferQueuedInput,
-							ID:   "queued-parent-input",
 							Text: "conflicting queued input",
-							OperationRef: clientui.RuntimeOperationRef{
-								Kind:            clientui.RuntimeOperationKindQueuedMessage,
-								ClientRequestID: runtimeids.NewRuntimeClientRequestID(),
-							},
 						},
 					},
 				},

--- a/cli/app/session_draft_recovery.go
+++ b/cli/app/session_draft_recovery.go
@@ -17,10 +17,8 @@ func (m *uiModel) sessionDraftRecoveryBuffers() []serverapi.SessionDraftRecovery
 			continue
 		}
 		buffers = append(buffers, serverapi.SessionDraftRecoveryBuffer{
-			Kind:            serverapi.SessionDraftRecoveryBufferPendingInjectedInput,
-			ID:              strings.TrimSpace(pending.ID),
-			ClientRequestID: strings.TrimSpace(pending.ClientRequestID),
-			Text:            pending.Text,
+			Kind: serverapi.SessionDraftRecoveryBufferPendingInjectedInput,
+			Text: pending.Text,
 		})
 	}
 	for _, queued := range m.queued {
@@ -30,7 +28,6 @@ func (m *uiModel) sessionDraftRecoveryBuffers() []serverapi.SessionDraftRecovery
 		}
 		buffers = append(buffers, serverapi.SessionDraftRecoveryBuffer{
 			Kind: serverapi.SessionDraftRecoveryBufferQueuedInput,
-			ID:   strings.TrimSpace(queued.ID),
 			Text: queued.Text,
 		})
 	}

--- a/cli/app/session_lifecycle_test.go
+++ b/cli/app/session_lifecycle_test.go
@@ -2,10 +2,12 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -1228,15 +1230,8 @@ func TestPersistSessionDraftIncludesStructuredRecoveryBuffers(t *testing.T) {
 	}
 	model := newUIModelDefaults(nil)
 	model.input = "visible draft"
-	model.activeSubmit = activeSubmitState{
-		text: "submitted before forced exit",
-		operationRef: clientui.RuntimeOperationRef{
-			Kind:            clientui.RuntimeOperationKindSubmit,
-			ClientRequestID: runtimeids.NewRuntimeClientRequestID(),
-		},
-	}
-	model.pendingInjected = queuedUserMessagesForTest("pending injected")
-	model.queued = queuedInputsForTest("queued later")
+	model.pendingInjected = queuedUserMessagesForTest("  pending injected\n")
+	model.queued = queuedInputsForTest("\tqueued later  ")
 
 	if err := persistSessionDraftToServer(context.Background(), narrowSessionLifecycleServer{lifecycle: client}, " session-1 ", model); err != nil {
 		t.Fatalf("persistSessionDraftToServer: %v", err)
@@ -1247,8 +1242,15 @@ func TestPersistSessionDraftIncludesStructuredRecoveryBuffers(t *testing.T) {
 	if len(captured.RecoveryBuffers) != 2 {
 		t.Fatalf("recovery buffers = %+v, want pending injected and queued", captured.RecoveryBuffers)
 	}
-	if captured.RecoveryBuffers[0].Kind != serverapi.SessionDraftRecoveryBufferPendingInjectedInput {
-		t.Fatalf("first recovery buffer = %+v, want pending injected input", captured.RecoveryBuffers[0])
+	want := []serverapi.SessionDraftRecoveryBuffer{
+		{Kind: serverapi.SessionDraftRecoveryBufferPendingInjectedInput, Text: "  pending injected\n"},
+		{Kind: serverapi.SessionDraftRecoveryBufferQueuedInput, Text: "\tqueued later  "},
+	}
+	if !reflect.DeepEqual(captured.RecoveryBuffers, want) {
+		t.Fatalf("recovery buffers = %+v, want ordered byte-preserved category/text %+v", captured.RecoveryBuffers, want)
+	}
+	if _, err := json.Marshal(captured); err != nil {
+		t.Fatalf("marshal captured draft request: %v", err)
 	}
 }
 
@@ -1257,8 +1259,8 @@ func TestInitialRecoveryBuffersRestoreRetryAffordancesWithoutStartupSubmit(t *te
 		WithUIInitialInput("visible draft"),
 		WithUIInitialRecoveryBuffers([]serverapi.SessionDraftRecoveryBuffer{
 			{Kind: serverapi.SessionDraftRecoveryBufferActiveSubmit, Text: "submitted before forced exit"},
-			{Kind: serverapi.SessionDraftRecoveryBufferPendingInjectedInput, ID: "server-1", ClientRequestID: "queue-1", Text: "pending steering"},
-			{Kind: serverapi.SessionDraftRecoveryBufferQueuedInput, ID: "queued-1", Text: "queued later"},
+			{Kind: serverapi.SessionDraftRecoveryBufferPendingInjectedInput, Text: "pending steering"},
+			{Kind: serverapi.SessionDraftRecoveryBufferQueuedInput, Text: "queued later"},
 		}),
 	).(*uiModel)
 

--- a/docs/dev/specs/terminology.md
+++ b/docs/dev/specs/terminology.md
@@ -276,11 +276,11 @@ A non-liveness session recovery marker used to repair model context after an int
 
 ### DraftRecoveryBuffer
 
-Structured persisted local input that should be recoverable after an early TUI exit, including active submitted text, queued messages, pending injected input, reviewer buffers, and related operation refs. It is a retry/recovery payload, not an instruction to auto-submit.
+An ordered persisted collection of inert local input entries recoverable after an early TUI exit. Each entry carries only its recovery category and original text; the collection carries no runtime operation, request, or queue identity. Opening a session restores eligible entry text to the editable composer and never resumes or automatically replays prior work.
 
 ### DraftInputBuffer
 
-A typed hidden/recoverable buffer entry inside `DraftRecoveryBuffer`, such as active submitted text, queued message, pending injected input, locked injected input, or reviewer buffer. The visible prompt text is the `VisibleInput` field on `DraftRecoveryBuffer`, not a `DraftInputBuffer`.
+A typed inert category-and-text entry inside `DraftRecoveryBuffer`, such as active submitted text, queued message, pending injected input, locked injected input, or reviewer buffer. Its category explains why the text was retained but carries no operation identity or delivery state. The visible prompt text remains separate from these entries.
 
 ### Forced Local Detach
 

--- a/docs/dev/specs/tui-chat-core.md
+++ b/docs/dev/specs/tui-chat-core.md
@@ -46,6 +46,9 @@ Bullets marked (owner: …) restate decisions owned by another spec for one-plac
 - The interrupt also drains pending messages: queued and steering queue contents populate the main input, so nothing typed is lost and the user can edit or resend.
 - `Ctrl+C` while idle exits the TUI.
 - Draft recovery does not depend on a graceful shutdown callback. Closing the terminal window or otherwise losing the TUI process preserves the current main-input draft; opening the session later seeds the input from that draft verbatim.
+- Structured draft-recovery entries preserve only their recovery category and text. They carry no runtime operation, request, or queue identity.
+- Recovered entries return as editable composer text and are never reconstructed into operational queues, resumed, or replayed automatically; sending them again requires an explicit user action.
+- Older recovery metadata that contains operation or queue identity remains readable. Kent ignores the obsolete identity while preserving the recovery category and text, without an upgrade warning.
 - Graceful TUI exit through Ctrl+C or `/exit` flushes the current main-input draft to the server before release. (owner: tui-startup.md :: Session Picker).
 - `/exit` is a client detach, not a runtime interrupt. An active server-owned run continues after this TUI releases its attachment.
 - Session-navigation commands persist the outgoing draft, resolve the typed transition, release the originating attachment, and only then plan or attach the destination. A release failure aborts navigation before destination attachment; an `/exit` release failure is reported after terminal teardown and exits nonzero.

--- a/server/metadata/store_test.go
+++ b/server/metadata/store_test.go
@@ -798,14 +798,8 @@ func TestResolvePersistedSessionRoundTripsRequiredStructuredMetadata(t *testing.
 	store, cfg, binding := newMetadataTestStore(t)
 	sess := createMetadataTestSession(t, store, cfg, binding)
 	buffers := []session.InputDraftRecoveryBuffer{{
-		Kind:                     "queued_input",
-		ID:                       "buffer-1",
-		ServerID:                 "server-1",
-		ClientRequestID:          "request-1",
-		Text:                     "recover this draft",
-		OperationClientRequestID: "operation-request-1",
-		OperationQueueItemID:     "queue-item-1",
-		OperationKind:            "steer",
+		Kind: "queued_input",
+		Text: "recover this draft",
 	}}
 	if err := sess.SetInputDraftRecovery("draft", buffers); err != nil {
 		t.Fatalf("SetInputDraftRecovery: %v", err)

--- a/server/processview/service_test.go
+++ b/server/processview/service_test.go
@@ -15,6 +15,8 @@ import (
 	"core/shared/toolspec"
 )
 
+const processViewTestWaitTimeout = 10 * time.Second
+
 func TestServiceListProcessesIncludesRunOwnership(t *testing.T) {
 	fixture := newProcessViewFixture(t)
 	result := fixture.startCommand(t, "call-1", "printf 'working\n'; sleep 30", "run-1", "step-1")
@@ -22,7 +24,7 @@ func TestServiceListProcessesIncludesRunOwnership(t *testing.T) {
 		t.Fatalf("expected successful tool result, got %+v", result)
 	}
 
-	waitForProcessSnapshot(t, 2*time.Second, func() (shelltool.Snapshot, bool) {
+	waitForProcessSnapshot(t, processViewTestWaitTimeout, func() (shelltool.Snapshot, bool) {
 		entries := fixture.manager.List()
 		if len(entries) != 1 {
 			return shelltool.Snapshot{}, false
@@ -128,7 +130,7 @@ func TestServiceGetInlineOutputReturnsManagerPreview(t *testing.T) {
 		t.Fatalf("expected successful tool result, got %+v", result)
 	}
 
-	waitForInlineOutput(t, 2*time.Second, func() (serverapi.ProcessInlineOutputResponse, error) {
+	waitForInlineOutput(t, processViewTestWaitTimeout, func() (serverapi.ProcessInlineOutputResponse, error) {
 		return fixture.service.GetInlineOutput(context.Background(), serverapi.ProcessInlineOutputRequest{ProcessID: "1000", MaxChars: 12_000})
 	}, func(resp serverapi.ProcessInlineOutputResponse) bool {
 		return resp.LogPath != "" && strings.Contains(resp.Output, "inline-preview")
@@ -229,7 +231,7 @@ func (s *stubKillProcessSource) InlineOutput(string, int) (string, string, error
 
 func waitForProcessCount(t *testing.T, manager *shelltool.Manager, count int) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(processViewTestWaitTimeout)
 	for time.Now().Before(deadline) {
 		if len(manager.List()) >= count {
 			return
@@ -241,7 +243,7 @@ func waitForProcessCount(t *testing.T, manager *shelltool.Manager, count int) {
 
 func waitForProcessKilled(t *testing.T, manager *shelltool.Manager, id string) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(processViewTestWaitTimeout)
 	for time.Now().Before(deadline) {
 		for _, entry := range manager.List() {
 			if entry.ID == id && (entry.KillRequested || !entry.Running) {

--- a/server/session/store_test.go
+++ b/server/session/store_test.go
@@ -216,11 +216,8 @@ func TestSetInputDraftClearsPersistedValue(t *testing.T) {
 func TestSetInputDraftRecoveryPersistsAcrossReopenAndClearsWithDraft(t *testing.T) {
 	store := newSessionTestLazyStore(t)
 	if err := store.SetInputDraftRecovery("visible", []InputDraftRecoveryBuffer{{
-		Kind:                     "active_submit",
-		ID:                       "queued-1",
-		Text:                     "submitted before forced exit",
-		OperationKind:            "submit",
-		OperationClientRequestID: "submit-1",
+		Kind: "active_submit",
+		Text: "submitted before forced exit",
 	}}); err != nil {
 		t.Fatalf("set input draft recovery: %v", err)
 	}
@@ -231,8 +228,9 @@ func TestSetInputDraftRecoveryPersistsAcrossReopenAndClearsWithDraft(t *testing.
 	if reopened.Meta().InputDraft != "visible" || len(reopened.Meta().InputDraftRecoveryBuffers) != 1 {
 		t.Fatalf("reopened draft metadata = %+v", reopened.Meta())
 	}
-	if reopened.Meta().InputDraftRecoveryBuffers[0].OperationClientRequestID != "submit-1" {
-		t.Fatalf("recovery buffer = %+v, want operation client request id", reopened.Meta().InputDraftRecoveryBuffers[0])
+	wantBuffer := InputDraftRecoveryBuffer{Kind: "active_submit", Text: "submitted before forced exit"}
+	if reopened.Meta().InputDraftRecoveryBuffers[0] != wantBuffer {
+		t.Fatalf("recovery buffer = %+v, want %+v", reopened.Meta().InputDraftRecoveryBuffers[0], wantBuffer)
 	}
 	if err := reopened.SetInputDraft(""); err != nil {
 		t.Fatalf("clear input draft: %v", err)

--- a/server/session/types.go
+++ b/server/session/types.go
@@ -220,14 +220,8 @@ type PendingModelRecovery struct {
 }
 
 type InputDraftRecoveryBuffer struct {
-	Kind                     string `json:"kind"`
-	ID                       string `json:"id,omitempty"`
-	ServerID                 string `json:"server_id,omitempty"`
-	ClientRequestID          string `json:"client_request_id,omitempty"`
-	Text                     string `json:"text,omitempty"`
-	OperationClientRequestID string `json:"operation_client_request_id,omitempty"`
-	OperationQueueItemID     string `json:"operation_queue_item_id,omitempty"`
-	OperationKind            string `json:"operation_kind,omitempty"`
+	Kind string `json:"kind"`
+	Text string `json:"text,omitempty"`
 }
 
 type WorkflowSessionState struct {

--- a/server/sessionservice/session_lifecycle_service.go
+++ b/server/sessionservice/session_lifecycle_service.go
@@ -86,13 +86,9 @@ func (s *SessionLifecycleService) GetInitialInput(_ context.Context, req servera
 		return serverapi.SessionInitialInputResponse{Input: req.TransitionInput}, nil
 	}
 	meta := store.Meta()
-	recoveryBuffers, err := sessionRecoveryBuffersToAPI(meta.InputDraftRecoveryBuffers)
-	if err != nil {
-		return serverapi.SessionInitialInputResponse{}, err
-	}
 	return serverapi.SessionInitialInputResponse{
 		Input:           initialSessionInput(store, req.TransitionInput),
-		RecoveryBuffers: recoveryBuffers,
+		RecoveryBuffers: sessionRecoveryBuffersToAPI(meta.InputDraftRecoveryBuffers),
 	}, nil
 }
 

--- a/server/sessionservice/session_lifecycle_service_test.go
+++ b/server/sessionservice/session_lifecycle_service_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -161,14 +162,11 @@ func TestServiceGetInitialInputOverrideReturnsOnlyExactTransitionInput(t *testin
 				Input:           "conflicting parent draft",
 				RecoveryBuffers: []serverapi.SessionDraftRecoveryBuffer{
 					{
-						Kind:            serverapi.SessionDraftRecoveryBufferPendingInjectedInput,
-						ID:              "pending-parent-input",
-						ClientRequestID: "pending-parent-request",
-						Text:            "conflicting pending input",
+						Kind: serverapi.SessionDraftRecoveryBufferPendingInjectedInput,
+						Text: "conflicting pending input",
 					},
 					{
 						Kind: serverapi.SessionDraftRecoveryBufferQueuedInput,
-						ID:   "queued-parent-input",
 						Text: "conflicting queued input",
 					},
 				},
@@ -249,11 +247,8 @@ func TestServicePersistInputDraftRoundTripsStructuredRecoveryBuffers(t *testing.
 	}
 	service := newTestSessionLifecycleService(containerDir, nil)
 	recovery := []serverapi.SessionDraftRecoveryBuffer{{
-		Kind:            serverapi.SessionDraftRecoveryBufferPendingInjectedInput,
-		ID:              "local-queue-1",
-		ServerID:        "server-queue-1",
-		ClientRequestID: "queue-create-1",
-		Text:            "queued steering before forced exit",
+		Kind: serverapi.SessionDraftRecoveryBufferPendingInjectedInput,
+		Text: "queued steering before forced exit",
 	}}
 	if _, err := service.PersistInputDraft(context.Background(), serverapi.SessionPersistInputDraftRequest{
 		ClientRequestID: "draft-recovery-1",
@@ -272,8 +267,104 @@ func TestServicePersistInputDraftRoundTripsStructuredRecoveryBuffers(t *testing.
 		t.Fatalf("initial input response = %+v, want visible draft and one recovery buffer", resp)
 	}
 	got := resp.RecoveryBuffers[0]
-	if got.Kind != recovery[0].Kind || got.ServerID != "server-queue-1" || got.ClientRequestID != "queue-create-1" || got.Text != recovery[0].Text {
+	if got != recovery[0] {
 		t.Fatalf("recovery buffer = %+v, want %+v", got, recovery[0])
+	}
+}
+
+func TestServiceRestoresLegacyDraftRecoveryAndOrdinaryWriteDropsIdentity(t *testing.T) {
+	cfg, metadataStore, _, sess := createAuthoritativeSessionLifecycleSession(t, t.TempDir())
+	legacyBuffers := []map[string]any{
+		{
+			"kind":                        "pending_injected_input",
+			"id":                          "legacy-local-1",
+			"server_id":                   "legacy-server-1",
+			"client_request_id":           "legacy-request-1",
+			"text":                        "first recovered draft",
+			"operation_client_request_id": "not-a-runtime-request-id",
+			"operation_queue_item_id":     "not-a-queue-item-id",
+			"operation_kind":              "queued_message",
+		},
+		{
+			"kind":                        "queued_input",
+			"id":                          "legacy-local-2",
+			"server_id":                   "legacy-server-2",
+			"client_request_id":           "legacy-request-2",
+			"text":                        "second recovered draft",
+			"operation_client_request_id": "also-invalid",
+			"operation_queue_item_id":     "also-invalid",
+			"operation_kind":              "submit",
+		},
+	}
+	legacyMetadata, err := json.Marshal(map[string]any{
+		"workspace_root":               cfg.WorkspaceRoot,
+		"workspace_container":          filepath.Base(cfg.WorkspaceRoot),
+		"input_draft_recovery_buffers": legacyBuffers,
+	})
+	if err != nil {
+		t.Fatalf("marshal legacy metadata: %v", err)
+	}
+	if _, err := metadataStore.DB().ExecContext(
+		t.Context(),
+		"UPDATE sessions SET input_draft = ?, metadata_json = ? WHERE id = ?",
+		"visible draft",
+		string(legacyMetadata),
+		sess.Meta().SessionID,
+	); err != nil {
+		t.Fatalf("seed legacy metadata: %v", err)
+	}
+
+	service := NewGlobalSessionLifecycleService(
+		cfg.PersistenceRoot,
+		nil,
+		nil,
+		metadataStore.AuthoritativeSessionStoreOptions()...,
+	)
+	resp, err := service.GetInitialInput(t.Context(), serverapi.SessionInitialInputRequest{
+		SessionID: sess.Meta().SessionID,
+	})
+	if err != nil {
+		t.Fatalf("GetInitialInput: %v", err)
+	}
+	wantRecovery := []serverapi.SessionDraftRecoveryBuffer{
+		{Kind: serverapi.SessionDraftRecoveryBufferPendingInjectedInput, Text: "first recovered draft"},
+		{Kind: serverapi.SessionDraftRecoveryBufferQueuedInput, Text: "second recovered draft"},
+	}
+	if resp.Input != "visible draft" || !reflect.DeepEqual(resp.RecoveryBuffers, wantRecovery) {
+		t.Fatalf("initial input response = %+v, want visible draft and ordered category/text %+v", resp, wantRecovery)
+	}
+
+	reopened, err := session.OpenByID(
+		cfg.PersistenceRoot,
+		sess.Meta().SessionID,
+		metadataStore.AuthoritativeSessionStoreOptions()...,
+	)
+	if err != nil {
+		t.Fatalf("open legacy session: %v", err)
+	}
+	if err := reopened.SetName("rewritten legacy recovery"); err != nil {
+		t.Fatalf("rewrite metadata through ordinary mutation: %v", err)
+	}
+	var rewrittenMetadata string
+	if err := metadataStore.DB().QueryRowContext(
+		t.Context(),
+		"SELECT metadata_json FROM sessions WHERE id = ?",
+		sess.Meta().SessionID,
+	).Scan(&rewrittenMetadata); err != nil {
+		t.Fatalf("read rewritten metadata: %v", err)
+	}
+	var rewritten struct {
+		RecoveryBuffers []map[string]any `json:"input_draft_recovery_buffers"`
+	}
+	if err := json.Unmarshal([]byte(rewrittenMetadata), &rewritten); err != nil {
+		t.Fatalf("decode rewritten metadata: %v", err)
+	}
+	wantBuffers := []map[string]any{
+		{"kind": "pending_injected_input", "text": "first recovered draft"},
+		{"kind": "queued_input", "text": "second recovered draft"},
+	}
+	if !reflect.DeepEqual(rewritten.RecoveryBuffers, wantBuffers) {
+		t.Fatalf("rewritten recovery buffers = %#v, want category/text only %#v", rewritten.RecoveryBuffers, wantBuffers)
 	}
 }
 

--- a/server/sessionservice/session_transition.go
+++ b/server/sessionservice/session_transition.go
@@ -3,12 +3,10 @@ package sessionservice
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 
 	"core/server/session"
-	"core/shared/clientui"
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
 	"core/shared/sessioncontract"
@@ -56,70 +54,26 @@ func sessionRecoveryBuffersFromAPI(buffers []serverapi.SessionDraftRecoveryBuffe
 	}
 	out := make([]session.InputDraftRecoveryBuffer, 0, len(buffers))
 	for _, buffer := range buffers {
-		operationQueueItemID := ""
-		if buffer.OperationRef.QueueItemID != nil {
-			operationQueueItemID = buffer.OperationRef.QueueItemID.String()
-		}
 		out = append(out, session.InputDraftRecoveryBuffer{
-			Kind:                     string(buffer.Kind),
-			ID:                       strings.TrimSpace(buffer.ID),
-			ServerID:                 strings.TrimSpace(buffer.ServerID),
-			ClientRequestID:          strings.TrimSpace(buffer.ClientRequestID),
-			Text:                     buffer.Text,
-			OperationClientRequestID: buffer.OperationRef.ClientRequestID.String(),
-			OperationQueueItemID:     operationQueueItemID,
-			OperationKind:            string(buffer.OperationRef.Kind),
+			Kind: string(buffer.Kind),
+			Text: buffer.Text,
 		})
 	}
 	return out
 }
 
-func sessionRecoveryBuffersToAPI(buffers []session.InputDraftRecoveryBuffer) ([]serverapi.SessionDraftRecoveryBuffer, error) {
+func sessionRecoveryBuffersToAPI(buffers []session.InputDraftRecoveryBuffer) []serverapi.SessionDraftRecoveryBuffer {
 	if len(buffers) == 0 {
-		return nil, nil
+		return nil
 	}
 	out := make([]serverapi.SessionDraftRecoveryBuffer, 0, len(buffers))
-	for index, buffer := range buffers {
-		operationRef, err := sessionRecoveryOperationRef(buffer)
-		if err != nil {
-			return nil, fmt.Errorf("restore session draft recovery operation %d: %w", index, err)
-		}
+	for _, buffer := range buffers {
 		out = append(out, serverapi.SessionDraftRecoveryBuffer{
-			Kind:            serverapi.SessionDraftRecoveryBufferKind(strings.TrimSpace(buffer.Kind)),
-			ID:              strings.TrimSpace(buffer.ID),
-			ServerID:        strings.TrimSpace(buffer.ServerID),
-			ClientRequestID: strings.TrimSpace(buffer.ClientRequestID),
-			Text:            buffer.Text,
-			OperationRef:    operationRef,
+			Kind: serverapi.SessionDraftRecoveryBufferKind(buffer.Kind),
+			Text: buffer.Text,
 		})
 	}
-	return out, nil
-}
-
-func sessionRecoveryOperationRef(buffer session.InputDraftRecoveryBuffer) (clientui.RuntimeOperationRef, error) {
-	kind := clientui.RuntimeOperationKind(strings.TrimSpace(buffer.OperationKind))
-	if kind == "" {
-		return clientui.RuntimeOperationRef{}, nil
-	}
-	clientRequestID, err := runtimeids.ParseRuntimeClientRequestID(strings.TrimSpace(buffer.OperationClientRequestID))
-	if err != nil {
-		return clientui.RuntimeOperationRef{}, err
-	}
-	ref := clientui.RuntimeOperationRef{
-		Kind:            kind,
-		ClientRequestID: clientRequestID,
-	}
-	if rawQueueItemID := strings.TrimSpace(buffer.OperationQueueItemID); rawQueueItemID != "" {
-		queueItemID, err := runtimeids.ParseQueueItemID(rawQueueItemID)
-		if err != nil {
-			return clientui.RuntimeOperationRef{}, err
-		}
-		ref.QueueItemID = &queueItemID
-	}
-	if err := ref.Validate(); err != nil {
-		return clientui.RuntimeOperationRef{}, err
-	}
-	return ref, nil
+	return out
 }
 
 func resolveSessionTransition(_ context.Context, req sessionTransitionResolveRequest) (serverapi.SessionDirective, error) {

--- a/server/transport/gateway_test.go
+++ b/server/transport/gateway_test.go
@@ -1107,6 +1107,53 @@ func TestGatewayAllowsOptionalSessionLifecycleRequestsWithoutSessionID(t *testin
 	}
 }
 
+func TestGatewayDraftRecoveryRoundTripKeepsServerAvailable(t *testing.T) {
+	appCore, server := newGatewayTestServer(t)
+	store := createGatewayAuthoritativeSession(t, appCore)
+
+	remote, err := remoteclient.DialRemoteURLForProject(
+		context.Background(),
+		"ws"+server.URL[len("http"):],
+		appCore.ProjectID(),
+	)
+	if err != nil {
+		t.Fatalf("DialRemoteURLForProject: %v", err)
+	}
+	defer func() { _ = remote.Close() }()
+
+	wantRecovery := []serverapi.SessionDraftRecoveryBuffer{
+		{Kind: serverapi.SessionDraftRecoveryBufferPendingInjectedInput, Text: "  pending steering\n"},
+		{Kind: serverapi.SessionDraftRecoveryBufferQueuedInput, Text: "\tqueued later  "},
+	}
+	if _, err := remote.PersistInputDraft(context.Background(), serverapi.SessionPersistInputDraftRequest{
+		ClientRequestID: "gateway-draft-recovery",
+		SessionID:       store.Meta().SessionID,
+		Input:           "visible draft",
+		RecoveryBuffers: wantRecovery,
+	}); err != nil {
+		t.Fatalf("PersistInputDraft: %v", err)
+	}
+	initialInput, err := remote.GetInitialInput(context.Background(), serverapi.SessionInitialInputRequest{
+		SessionID: store.Meta().SessionID,
+	})
+	if err != nil {
+		t.Fatalf("GetInitialInput: %v", err)
+	}
+	if initialInput.Input != "visible draft" ||
+		len(initialInput.RecoveryBuffers) != len(wantRecovery) ||
+		initialInput.RecoveryBuffers[0] != wantRecovery[0] ||
+		initialInput.RecoveryBuffers[1] != wantRecovery[1] {
+		t.Fatalf("initial input = %+v, want visible draft and ordered byte-preserved recovery %+v", initialInput, wantRecovery)
+	}
+	projects, err := remote.ListProjects(context.Background(), serverapi.ProjectListRequest{})
+	if err != nil {
+		t.Fatalf("follow-up ListProjects: %v", err)
+	}
+	if len(projects.Projects) == 0 {
+		t.Fatal("follow-up ListProjects returned no projects")
+	}
+}
+
 func TestGatewayProjectReattachClearsStaleSessionAttachment(t *testing.T) {
 	home := t.TempDir()
 	workspaceA := t.TempDir()

--- a/shared/client/remote_test.go
+++ b/shared/client/remote_test.go
@@ -77,6 +77,53 @@ func acceptRemoteHandshake(t *testing.T, ws *websocket.Conn) protocol.Request {
 	return req
 }
 
+func TestRemotePersistInputDraftSendsInertRecoveryBuffers(t *testing.T) {
+	server := newRemoteTestServer(t, func(ws *websocket.Conn) {
+		acceptRemoteHandshake(t, ws)
+		var request protocol.Request
+		if err := websocket.JSON.Receive(ws, &request); err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			t.Fatalf("receive persist input draft: %v", err)
+		}
+		if request.Method != protocol.MethodSessionPersistInputDraft {
+			t.Fatalf("method = %q, want %q", request.Method, protocol.MethodSessionPersistInputDraft)
+		}
+		var decoded serverapi.SessionPersistInputDraftRequest
+		if err := json.Unmarshal(request.Params, &decoded); err != nil {
+			t.Fatalf("decode persist input draft: %v", err)
+		}
+		want := []serverapi.SessionDraftRecoveryBuffer{{
+			Kind: serverapi.SessionDraftRecoveryBufferPendingInjectedInput,
+			Text: "pending steering",
+		}}
+		if !reflect.DeepEqual(decoded.RecoveryBuffers, want) {
+			t.Fatalf("recovery buffers = %+v, want %+v", decoded.RecoveryBuffers, want)
+		}
+		if err := websocket.JSON.Send(ws, protocol.NewSuccessResponse(request.ID, serverapi.SessionPersistInputDraftResponse{})); err != nil {
+			t.Fatalf("send persist input draft response: %v", err)
+		}
+	})
+	remote, err := DialRemoteURL(context.Background(), "ws"+server.URL[len("http"):])
+	if err != nil {
+		t.Fatalf("DialRemoteURL: %v", err)
+	}
+	defer func() { _ = remote.Close() }()
+	_, err = remote.PersistInputDraft(context.Background(), serverapi.SessionPersistInputDraftRequest{
+		ClientRequestID: "draft-1",
+		SessionID:       "session-1",
+		Input:           "visible draft",
+		RecoveryBuffers: []serverapi.SessionDraftRecoveryBuffer{{
+			Kind: serverapi.SessionDraftRecoveryBufferPendingInjectedInput,
+			Text: "pending steering",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("PersistInputDraft: %v", err)
+	}
+}
+
 func TestRemoteRunPromptPublishesProgressNotifications(t *testing.T) {
 	server := newRemoteTestServer(t, func(ws *websocket.Conn) {
 		req := acceptRemoteHandshake(t, ws)

--- a/shared/protocol/version.json
+++ b/shared/protocol/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "60"
+  "version": "61"
 }

--- a/shared/serverapi/session_lifecycle.go
+++ b/shared/serverapi/session_lifecycle.go
@@ -3,8 +3,6 @@ package serverapi
 import (
 	"errors"
 	"strings"
-
-	"core/shared/clientui"
 )
 
 // ErrClientRequestIDRequired is returned when a lifecycle request omits its
@@ -62,12 +60,8 @@ const (
 )
 
 type SessionDraftRecoveryBuffer struct {
-	Kind            SessionDraftRecoveryBufferKind `json:"kind"`
-	ID              string                         `json:"id,omitempty"`
-	ServerID        string                         `json:"server_id,omitempty"`
-	ClientRequestID string                         `json:"client_request_id,omitempty"`
-	Text            string                         `json:"text,omitempty"`
-	OperationRef    clientui.RuntimeOperationRef   `json:"operation_ref,omitempty"`
+	Kind SessionDraftRecoveryBufferKind `json:"kind"`
+	Text string                         `json:"text,omitempty"`
 }
 
 type SessionRetargetWorkspaceRequest struct {

--- a/shared/serverapi/session_lifecycle_test.go
+++ b/shared/serverapi/session_lifecycle_test.go
@@ -1,15 +1,13 @@
 package serverapi
 
 import (
+	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
-
-	"core/shared/clientui"
-	"core/shared/runtimeids"
 )
 
-func TestSessionPersistInputDraftAcceptsStructuredRecoveryBuffers(t *testing.T) {
-	submitID := runtimeids.NewRuntimeClientRequestID()
+func TestSessionPersistInputDraftMarshalsInertRecoveryBuffers(t *testing.T) {
 	req := SessionPersistInputDraftRequest{
 		ClientRequestID: "draft-1",
 		SessionID:       "session-1",
@@ -17,14 +15,33 @@ func TestSessionPersistInputDraftAcceptsStructuredRecoveryBuffers(t *testing.T) 
 		RecoveryBuffers: []SessionDraftRecoveryBuffer{{
 			Kind: SessionDraftRecoveryBufferActiveSubmit,
 			Text: "submitted before forced exit",
-			OperationRef: clientui.RuntimeOperationRef{
-				Kind:            clientui.RuntimeOperationKindSubmit,
-				ClientRequestID: submitID,
-			},
 		}},
 	}
 	if err := req.Validate(); err != nil {
 		t.Fatalf("Validate: %v", err)
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("Unmarshal payload: %v", err)
+	}
+	recoveryBuffers, ok := payload["recovery_buffers"].([]any)
+	if !ok || len(recoveryBuffers) != 1 {
+		t.Fatalf("recovery_buffers = %#v, want one entry", payload["recovery_buffers"])
+	}
+	got, ok := recoveryBuffers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("recovery buffer = %#v, want JSON object", recoveryBuffers[0])
+	}
+	want := map[string]any{
+		"kind": string(SessionDraftRecoveryBufferActiveSubmit),
+		"text": "submitted before forced exit",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("recovery buffer = %#v, want category/text only %#v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reduce draft-recovery wire and persisted records to ordered category/text entries, removing runtime, request, and queue identity from the recovery object graph.
- Preserve original text bytes and entry order while keeping recovery inert: restored text returns to the editable composer and is never resumed or replayed automatically.
- Keep legacy identity-bearing metadata readable; malformed obsolete operation identity is ignored, and the next ordinary metadata write emits only category/text.
- Increment the exact-match protocol version from 60 to 61 so fixed clients cannot attach to older servers that may reproduce the zero-ID serialization failure.
- Add wire, remote-client, TUI, authoritative-metadata, lifecycle, and real-gateway regression coverage, including a follow-up RPC availability check.
- Give asynchronous process-view assertions scheduler margin after the CI test job twice exposed the existing 2-second timeout under full-suite load.

## Verification

Passed on the branch rebased directly onto `origin/main`:

- `./scripts/test.sh ./shared/runtimeids ./shared/clientui ./shared/serverapi ./shared/client`
- `./scripts/test.sh ./server/session ./server/metadata ./server/sessionservice`
- `./scripts/test.sh ./server/transport ./cli/app`
- `./scripts/test.sh ./server/processview -count=20`
- `./scripts/build.sh --output ./bin/kent`
- `git diff --check`
- Structured/source audits confirming obsolete recovery identity fields and `sessionRecoveryOperationRef` are absent from production recovery paths.
- Scope audits confirming runtime-ID implementations and the KENT-250/KENT-271/KENT-272 ownership paths were unchanged.

The previous CI runs both failed only at `TestServiceGetInlineOutputReturnsManagerPreview`, whose 2-second asynchronous wait was insufficient under full-suite runner load. The scheduler-margin commit raises the shared process-view test wait to 10 seconds; the package passes 20 consecutive local runs. A local broad `./scripts/ci-check.sh test` attempt exceeded the repository's 120-second wall-clock cap after `server/processview` had passed, so it is not claimed as passing; fresh hosted CI is running on the latest commit.

### Completion evidence

- `.kent/plans/KENT-265.md` contains the accepted scope, TDD slices, and completion evidence. It is intentionally repository-ignored and therefore is not attached to this PR.
- `shared/protocol/version.json` records protocol version 61 on the actual `origin/main` base.
- Prior QA also reported focused verbose acceptance suites, `./bin/kent --version`, and `./bin/kent serve --help` passing.

## Diff size

| Category | Additions | Deletions | Gross LoC | Net LoC |
| --- | ---: | ---: | ---: | ---: |
| Production code, specs, and protocol data | 21 | 83 | 104 | -62 |
| Tests / generated code | 252 | 65 | 317 | +187 |
| **Total** | **273** | **148** | **421** | **+125** |

No generated files changed.

## Caveats and follow-ups

- This intentionally does not migrate metadata eagerly. Obsolete identity keys disappear on the next ordinary metadata write.
- Protocol 61 is an exact-version compatibility break by design.
- The process-view scheduler-margin change is test-only and addresses the readiness failure; production process behavior is unchanged.
- Approval-commentary delivery remains owned by KENT-250.
- Phantom no-runtime-client queue items remain tracked by KENT-271.
- Client-created queue-error transcript rows/status recovery remain tracked by KENT-272.
- Runtime operation constructors and UUIDv4 validation were deliberately left unchanged.

## Tracking

- Kent task: KENT-265 — Prevent zero runtime request IDs
- GitHub issue: none associated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Draft recovery now preserves only each entry’s category and text.
  * Recovered entries reopen as editable composer text and are not automatically resumed or replayed.
  * Legacy recovery data remains readable while obsolete operation details are removed during subsequent saves.
  * Draft recovery round-trips reliably across local and remote sessions.
* **Protocol**
  * Updated the communication protocol version to 61.
* **Documentation**
  * Clarified draft recovery behavior and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->