### PR TITLE
fix: load workflow worktree setup from source workspace

### DIFF
--- a/docs/dev/specs/workflow-orchestration.md
+++ b/docs/dev/specs/workflow-orchestration.md
@@ -228,7 +228,7 @@
 - A task locks target-selection provenance only when the initiating action successfully reaches its first executable placement. Later nodes and retries reuse the locked mode and managed requested/resolved facts despite workflow edits or Git ref movement.
 - Every pre-upgrade task with a recorded managed worktree and usable recorded HEAD metadata continues using that worktree after upgrade, regardless of whether it already has a run. Its observed commit is identified as legacy provenance and is not presented as a known original branch point.
 - Pre-upgrade tasks without a managed worktree remain unlocked and inherit their migrated workflow's source-`HEAD` policy.
-- Managed targets use the existing task-worktree creation, setup, and collision behavior. Before the first executable run is scheduled, setup either succeeds for the newly created candidate in that request or a later explicit request accepts the same available, base-compatible candidate as manually repaired.
+- Managed targets use the existing task-worktree creation, setup, and collision behavior. Before the first executable run is scheduled, Kent loads worktree setup settings from the task's source workspace; a configured setup script must succeed for the newly created candidate in that request.
 - Managed worktree setup failure leaves the initiating action unapplied and unscheduled. Any created worktree remains available for inspection or manual repair.
 - Setup runs only when the current request creates or recreates a worktree root. A later retry trusts an already-existing compatible root and does not rerun setup; no durable setup-readiness state exists.
 - Setup receives the source workspace root, branch name, and managed worktree root as stable positional inputs.

--- a/server/core/composition.go
+++ b/server/core/composition.go
@@ -146,7 +146,16 @@ func NewWithContextOptions(ctx context.Context, cfg config.App, authSupport serv
 	runtimeRegistry.WithExecutionTargetResolver(metadataStore.ResolveSessionExecutionTarget)
 	runtimeControlService := runtimecontrol.NewService(runtimeRegistry).WithOperationCoordinator(runtimeOperations).WithPromptHistoryStore(metadataStore).WithWorkflowSessionResolver(sessionStoreResolver)
 	gitInspector := worktree.NewGitInspector(nil)
-	worktreeService := worktree.NewService(metadataStore, gitInspector, runtimeRegistry, sessionRuntimeService, runtimeSupport.Background, worktree.ServiceOptions{BaseDir: cfg.Settings.Worktrees.BaseDir, SetupScript: cfg.Settings.Worktrees.SetupScript, SetupTimeoutSeconds: cfg.Settings.Worktrees.SetupTimeoutSeconds})
+	worktreeService := worktree.NewService(metadataStore, gitInspector, runtimeRegistry, sessionRuntimeService, runtimeSupport.Background, worktree.ServiceOptions{
+		BaseDir: cfg.Settings.Worktrees.BaseDir,
+		ResolveSetup: func(sourceWorkspaceRoot string) (config.WorktreeSettings, error) {
+			sourceConfig, err := config.Load(sourceWorkspaceRoot, config.LoadOptions{ConfigRoot: cfg.PersistenceRoot})
+			if err != nil {
+				return config.WorktreeSettings{}, err
+			}
+			return sourceConfig.Settings.Worktrees, nil
+		},
+	})
 	projectViews := projectService
 	authBootstrapService := authservice.NewBootstrapService(authSupport.AuthManager, authSupport.OAuthOptions, cfg.Settings, rpccontract.AllowedPreAuthMethods())
 	authStatusService := authservice.NewStatusService(authSupport.AuthManager, cfg.Settings)

--- a/server/core/composition.go
+++ b/server/core/composition.go
@@ -149,11 +149,7 @@ func NewWithContextOptions(ctx context.Context, cfg config.App, authSupport serv
 	worktreeService := worktree.NewService(metadataStore, gitInspector, runtimeRegistry, sessionRuntimeService, runtimeSupport.Background, worktree.ServiceOptions{
 		BaseDir: cfg.Settings.Worktrees.BaseDir,
 		ResolveSetup: func(sourceWorkspaceRoot string) (config.WorktreeSettings, error) {
-			sourceConfig, err := config.Load(sourceWorkspaceRoot, config.LoadOptions{ConfigRoot: cfg.PersistenceRoot})
-			if err != nil {
-				return config.WorktreeSettings{}, err
-			}
-			return sourceConfig.Settings.Worktrees, nil
+			return config.LoadWorktreeSetupSettings(sourceWorkspaceRoot, cfg.PersistenceRoot)
 		},
 	})
 	projectViews := projectService

--- a/server/core/composition_test.go
+++ b/server/core/composition_test.go
@@ -73,8 +73,9 @@ func TestComposedWorkflowTaskSetupPrecedesFirstModelRequest(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		t.Fatalf("create source workspace config directory: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte(fmt.Sprintf("[worktrees]\nsetup_script = %q\n", filepath.ToSlash(setupScript))), 0o644); err != nil {
-		t.Fatalf("write source workspace config: %v", err)
+	validSetupConfig := fmt.Sprintf("[worktrees]\nsetup_script = %q\n", filepath.ToSlash(setupScript))
+	if err := os.WriteFile(configPath, []byte("[worktrees]\nsetup_timeout_seconds = \"invalid\"\n"), 0o644); err != nil {
+		t.Fatalf("write invalid source workspace config: %v", err)
 	}
 	if resolved.Config.Settings.Worktrees.SetupScript != "" {
 		t.Fatalf("server startup config unexpectedly contains source workspace setup script")
@@ -123,6 +124,18 @@ func TestComposedWorkflowTaskSetupPrecedesFirstModelRequest(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("CreateWorkflowTask: %v", err)
+	}
+	if _, err := appCore.WorkflowClient().StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{
+		TaskID:           task.Task.ID,
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ExecutionTarget: &serverapi.WorkflowExecutionTargetSelection{
+			Mode: serverapi.WorkflowExecutionTargetModeHead,
+		},
+	}); err == nil {
+		t.Fatal("StartWorkflowTask accepted invalid source workspace setup configuration")
+	}
+	if err := os.WriteFile(configPath, []byte(validSetupConfig), 0o644); err != nil {
+		t.Fatalf("write corrected source workspace config: %v", err)
 	}
 	started, err := appCore.WorkflowClient().StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{
 		TaskID:           task.Task.ID,

--- a/server/core/composition_test.go
+++ b/server/core/composition_test.go
@@ -82,7 +82,7 @@ func TestComposedWorkflowTaskSetupPrecedesFirstModelRequest(t *testing.T) {
 		filepath.Join(blockedBase, "worktrees"),
 		filepath.ToSlash(setupScript),
 	)
-	if err := os.WriteFile(configPath, []byte("[worktrees]\nsetup_timeout_seconds = \"invalid\"\n"), 0o644); err != nil {
+	if err := os.WriteFile(configPath, []byte("[worktrees]\nsetup_scrip = \"scripts/misspelled.sh\"\n"), 0o644); err != nil {
 		t.Fatalf("write invalid source workspace config: %v", err)
 	}
 	if resolved.Config.Settings.Worktrees.SetupScript != "" {

--- a/server/core/composition_test.go
+++ b/server/core/composition_test.go
@@ -35,11 +35,13 @@ import (
 func TestComposedWorkflowTaskSetupPrecedesFirstModelRequest(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()
+	serverWorkspace := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("KENT_WORKTREE_SESSION_ID", "stale-parent-session")
+	testsetup.InitializeGitRepository(t, serverWorkspace)
 	testsetup.InitializeGitRepository(t, workspace)
-	resolved, err := serverbootstrap.ResolveConfig(serverbootstrap.Request{WorkspaceRoot: workspace})
+	resolved, err := serverbootstrap.ResolveConfig(serverbootstrap.Request{WorkspaceRoot: serverWorkspace})
 	if err != nil {
 		t.Fatalf("ResolveConfig: %v", err)
 	}
@@ -66,7 +68,17 @@ func TestComposedWorkflowTaskSetupPrecedesFirstModelRequest(t *testing.T) {
 			Description: skillDescription,
 		},
 	})
-	resolved.Config.Settings.Worktrees.SetupScript = setup.InstallInSourceWorkspace(t, workspace)
+	setupScript := setup.InstallInSourceWorkspace(t, workspace)
+	configPath := filepath.Join(workspace, config.ConfigDirName, "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create source workspace config directory: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(fmt.Sprintf("[worktrees]\nsetup_script = %q\n", filepath.ToSlash(setupScript))), 0o644); err != nil {
+		t.Fatalf("write source workspace config: %v", err)
+	}
+	if resolved.Config.Settings.Worktrees.SetupScript != "" {
+		t.Fatalf("server startup config unexpectedly contains source workspace setup script")
+	}
 	observerClient := &firstGenerateObserverClient{
 		delegate: scriptedllm.NewLegacyOnlyClient(
 			llm.ProviderCapabilities{ProviderID: "scripted-workflow", SupportsResponsesAPI: true},

--- a/server/core/composition_test.go
+++ b/server/core/composition_test.go
@@ -73,7 +73,15 @@ func TestComposedWorkflowTaskSetupPrecedesFirstModelRequest(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		t.Fatalf("create source workspace config directory: %v", err)
 	}
-	validSetupConfig := fmt.Sprintf("[worktrees]\nsetup_script = %q\n", filepath.ToSlash(setupScript))
+	blockedBase := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blockedBase, []byte("blocked"), 0o644); err != nil {
+		t.Fatalf("write blocked base path: %v", err)
+	}
+	validSetupConfig := fmt.Sprintf(
+		"[worktrees]\nbase_dir = %q\nsetup_script = %q\n",
+		filepath.Join(blockedBase, "worktrees"),
+		filepath.ToSlash(setupScript),
+	)
 	if err := os.WriteFile(configPath, []byte("[worktrees]\nsetup_timeout_seconds = \"invalid\"\n"), 0o644); err != nil {
 		t.Fatalf("write invalid source workspace config: %v", err)
 	}

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -55,6 +55,7 @@ type ServiceOptions struct {
 	BaseDir             string
 	SetupScript         string
 	SetupTimeoutSeconds int
+	ResolveSetup        func(sourceWorkspaceRoot string) (config.WorktreeSettings, error)
 }
 
 type Service struct {
@@ -66,6 +67,7 @@ type Service struct {
 	baseDir             string
 	setupScript         string
 	setupTimeoutSeconds int
+	resolveSetup        func(sourceWorkspaceRoot string) (config.WorktreeSettings, error)
 	setupBroker         *setupEventBroker
 
 	workspaceMu    sync.Mutex
@@ -221,6 +223,7 @@ func NewService(metadataStore *metadata.Store, gitInspector *GitInspector, activ
 		baseDir:             strings.TrimSpace(opts.BaseDir),
 		setupScript:         strings.TrimSpace(opts.SetupScript),
 		setupTimeoutSeconds: opts.SetupTimeoutSeconds,
+		resolveSetup:        opts.ResolveSetup,
 		setupBroker:         newSetupEventBroker(),
 		workspaceLocks:      make(map[string]*workspaceMutationLock),
 		transitionCtx:       transitionCtx,
@@ -1552,7 +1555,18 @@ type setupExecutionRequest struct {
 }
 
 func (s *Service) runSetupForWorktree(ctx context.Context, req setupExecutionRequest) error {
-	trimmedScript := strings.TrimSpace(s.setupScript)
+	settings := config.WorktreeSettings{
+		SetupScript:         s.setupScript,
+		SetupTimeoutSeconds: s.setupTimeoutSeconds,
+	}
+	if s.resolveSetup != nil {
+		resolved, err := s.resolveSetup(req.SourceWorkspaceRoot)
+		if err != nil {
+			return fmt.Errorf("resolve worktree setup settings: %w", err)
+		}
+		settings = resolved
+	}
+	trimmedScript := strings.TrimSpace(settings.SetupScript)
 	if trimmedScript == "" {
 		return nil
 	}
@@ -1594,7 +1608,7 @@ func (s *Service) runSetupForWorktree(ctx context.Context, req setupExecutionReq
 		Phase:               serverapi.WorktreeSetupPhaseStarted,
 	}
 	s.publishSetupEvent(started)
-	if err := s.runSetupScript(ctx, scriptPath, payload); err != nil {
+	if err := s.runSetupScript(ctx, scriptPath, payload, settings.SetupTimeoutSeconds); err != nil {
 		failure := started
 		failure.Phase = serverapi.WorktreeSetupPhaseFailed
 		var setupErr *setupScriptError
@@ -1617,11 +1631,11 @@ func (s *Service) runSetupForWorktree(ctx context.Context, req setupExecutionReq
 	return nil
 }
 
-func (s *Service) runSetupScript(ctx context.Context, scriptPath string, payload setupScriptPayload) error {
+func (s *Service) runSetupScript(ctx context.Context, scriptPath string, payload setupScriptPayload, timeoutSeconds int) error {
 	setupCtx := ctx
 	var cancel context.CancelFunc
-	if s != nil && s.setupTimeoutSeconds > 0 {
-		setupCtx, cancel = context.WithTimeout(ctx, time.Duration(s.setupTimeoutSeconds)*time.Second)
+	if timeoutSeconds > 0 {
+		setupCtx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 		defer cancel()
 	}
 	body, err := json.Marshal(payload)
@@ -1661,8 +1675,8 @@ func (s *Service) runSetupScript(ctx context.Context, scriptPath string, payload
 		setupErr.Timeout = errors.Is(setupCtx.Err(), context.DeadlineExceeded)
 		setupErr.Canceled = errors.Is(setupCtx.Err(), context.Canceled)
 		if setupErr.Timeout {
-			setupErr.TimeoutSeconds = s.setupTimeoutSeconds
-			setupErr.Message = fmt.Sprintf("timed out after %s", time.Duration(s.setupTimeoutSeconds)*time.Second)
+			setupErr.TimeoutSeconds = timeoutSeconds
+			setupErr.Message = fmt.Sprintf("timed out after %s", time.Duration(timeoutSeconds)*time.Second)
 		} else {
 			setupErr.Message = setupCtx.Err().Error()
 		}

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -566,6 +566,10 @@ func (s *Service) registeredWorktreeRoot(ctx context.Context, workspaceRoot stri
 }
 
 func (s *Service) createManagedTaskWorktree(ctx context.Context, req managedTaskWorktreeCreationRequest) (resp TaskWorktreeMaterialization, err error) {
+	setupSettings, err := s.worktreeSetupSettings(req.Workspace.RootPath)
+	if err != nil {
+		return TaskWorktreeMaterialization{}, err
+	}
 	createSpec, err := normalizeCreateSpec(req.CreateSpec)
 	if err != nil {
 		return TaskWorktreeMaterialization{}, err
@@ -658,6 +662,7 @@ func (s *Service) createManagedTaskWorktree(ctx context.Context, req managedTask
 	if err := s.runSetupForWorktree(ctx, setupExecutionRequest{
 		SetupOperationID:    req.SetupOperationID,
 		SourceWorkspaceRoot: req.Workspace.RootPath,
+		ResolvedSettings:    &setupSettings,
 		BranchName:          branchName,
 		WorktreeRoot:        created.record.CanonicalRoot,
 		ScriptPayload: setupScriptPayload{
@@ -1548,6 +1553,7 @@ func nextAvailableWorktreeRoot(baseRoot string) (string, error) {
 type setupExecutionRequest struct {
 	SetupOperationID    serverapi.WorktreeSetupOperationID
 	SourceWorkspaceRoot string
+	ResolvedSettings    *config.WorktreeSettings
 	BranchName          string
 	WorktreeRoot        string
 	ScriptPayload       setupScriptPayload
@@ -1555,16 +1561,13 @@ type setupExecutionRequest struct {
 }
 
 func (s *Service) runSetupForWorktree(ctx context.Context, req setupExecutionRequest) error {
-	settings := config.WorktreeSettings{
-		SetupScript:         s.setupScript,
-		SetupTimeoutSeconds: s.setupTimeoutSeconds,
-	}
-	if s.resolveSetup != nil {
-		resolved, err := s.resolveSetup(req.SourceWorkspaceRoot)
+	settings := req.ResolvedSettings
+	if settings == nil {
+		resolved, err := s.worktreeSetupSettings(req.SourceWorkspaceRoot)
 		if err != nil {
-			return fmt.Errorf("resolve worktree setup settings: %w", err)
+			return err
 		}
-		settings = resolved
+		settings = &resolved
 	}
 	trimmedScript := strings.TrimSpace(settings.SetupScript)
 	if trimmedScript == "" {
@@ -1629,6 +1632,20 @@ func (s *Service) runSetupForWorktree(ctx context.Context, req setupExecutionReq
 	completed.Phase = serverapi.WorktreeSetupPhaseCompleted
 	s.publishSetupEvent(completed)
 	return nil
+}
+
+func (s *Service) worktreeSetupSettings(sourceWorkspaceRoot string) (config.WorktreeSettings, error) {
+	if s.resolveSetup == nil {
+		return config.WorktreeSettings{
+			SetupScript:         s.setupScript,
+			SetupTimeoutSeconds: s.setupTimeoutSeconds,
+		}, nil
+	}
+	settings, err := s.resolveSetup(sourceWorkspaceRoot)
+	if err != nil {
+		return config.WorktreeSettings{}, fmt.Errorf("resolve worktree setup settings: %w", err)
+	}
+	return settings, nil
 }
 
 func (s *Service) runSetupScript(ctx context.Context, scriptPath string, payload setupScriptPayload, timeoutSeconds int) error {

--- a/shared/config/config_registry.go
+++ b/shared/config/config_registry.go
@@ -31,6 +31,10 @@ type registrySetting interface {
 	applyFile(settingsFile, string, *settingsState, map[string]string) error
 }
 
+type keyedRegistrySetting interface {
+	registryKey() string
+}
+
 type sourceInitializingSetting interface {
 	initSources(map[string]string)
 }
@@ -1022,6 +1026,10 @@ func newIntSetting(
 
 func (s scalarSetting[T]) applyDefault(state *settingsState) {
 	s.apply(state, s.defaultValue)
+}
+
+func (s scalarSetting[T]) registryKey() string {
+	return s.key
 }
 
 func (s scalarSetting[T]) initSources(sources map[string]string) {

--- a/shared/config/worktree_setup.go
+++ b/shared/config/worktree_setup.go
@@ -7,6 +7,7 @@ import (
 )
 
 const (
+	worktreeBaseDirKey      = "worktrees.base_dir"
 	worktreeSetupScriptKey  = "worktrees.setup_script"
 	worktreeSetupTimeoutKey = "worktrees.setup_timeout_seconds"
 )
@@ -28,6 +29,22 @@ func LoadWorktreeSetupSettings(workspaceRoot string, persistenceRoot string) (Wo
 	if err != nil {
 		return WorktreeSettings{}, err
 	}
+	worktreeSettings, err := configRegistry.settingsForKeys(
+		worktreeBaseDirKey,
+		worktreeSetupScriptKey,
+		worktreeSetupTimeoutKey,
+	)
+	if err != nil {
+		return WorktreeSettings{}, err
+	}
+	keyTree := newFileKeyTree()
+	for _, setting := range worktreeSettings {
+		fileSetting, ok := setting.(fileKeyRegisteringSetting)
+		if !ok {
+			return WorktreeSettings{}, errors.New("worktree setting cannot validate file keys")
+		}
+		fileSetting.registerFileKeys(keyTree)
+	}
 	state := settingsState{}
 	sources := map[string]string{}
 	for _, setting := range settings {
@@ -37,6 +54,11 @@ func LoadWorktreeSetupSettings(workspaceRoot string, persistenceRoot string) (Wo
 		file, err := readOptionalSettingsFile(path)
 		if err != nil {
 			return WorktreeSettings{}, err
+		}
+		if worktrees, exists := file["worktrees"]; exists {
+			if err := validateSettingsFileKeys(settingsFile{"worktrees": worktrees}, keyTree); err != nil {
+				return WorktreeSettings{}, err
+			}
 		}
 		for _, setting := range settings {
 			if err := setting.applyFile(file, path, &state, sources); err != nil {

--- a/shared/config/worktree_setup.go
+++ b/shared/config/worktree_setup.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	worktreeSetupScriptKey  = "worktrees.setup_script"
+	worktreeSetupTimeoutKey = "worktrees.setup_timeout_seconds"
+)
+
+// LoadWorktreeSetupSettings reads only the settings used by setup execution.
+func LoadWorktreeSetupSettings(workspaceRoot string, persistenceRoot string) (WorktreeSettings, error) {
+	if strings.TrimSpace(workspaceRoot) == "" {
+		return WorktreeSettings{}, errors.New("workspace root is required")
+	}
+	homePath, err := resolveSettingsFilePathInRoot(persistenceRoot)
+	if err != nil {
+		return WorktreeSettings{}, err
+	}
+	workspacePath, err := resolveWorkspaceSettingsFilePath(workspaceRoot)
+	if err != nil {
+		return WorktreeSettings{}, err
+	}
+	settings, err := configRegistry.settingsForKeys(worktreeSetupScriptKey, worktreeSetupTimeoutKey)
+	if err != nil {
+		return WorktreeSettings{}, err
+	}
+	state := settingsState{}
+	sources := map[string]string{}
+	for _, setting := range settings {
+		setting.applyDefault(&state)
+	}
+	for _, path := range []string{homePath, workspacePath} {
+		file, err := readOptionalSettingsFile(path)
+		if err != nil {
+			return WorktreeSettings{}, err
+		}
+		for _, setting := range settings {
+			if err := setting.applyFile(file, path, &state, sources); err != nil {
+				return WorktreeSettings{}, fmt.Errorf("apply settings file %s: %w", path, err)
+			}
+		}
+	}
+	return state.Settings.Worktrees, nil
+}
+
+func readOptionalSettingsFile(path string) (settingsFile, error) {
+	exists, err := settingsFileExists(path)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return settingsFile{}, nil
+	}
+	return readSettingsFile(path)
+}
+
+func (r settingsRegistry) settingsForKeys(keys ...string) ([]registrySetting, error) {
+	selected := make([]registrySetting, 0, len(keys))
+	for _, wanted := range keys {
+		found := false
+		for _, setting := range r.settings {
+			keyed, ok := setting.(keyedRegistrySetting)
+			if !ok || keyed.registryKey() != wanted {
+				continue
+			}
+			selected = append(selected, setting)
+			found = true
+			break
+		}
+		if !found {
+			return nil, fmt.Errorf("settings registry is missing %q", wanted)
+		}
+	}
+	return selected, nil
+}


### PR DESCRIPTION
## Summary

- load only `setup_script` and `setup_timeout_seconds` from each workflow task's source workspace instead of using the server startup workspace
- validate setup-key spelling and setup value types before creating or binding the managed worktree
- ignore unrelated source-workspace configuration such as `worktrees.base_dir`
- execute the configured setup script before the workflow action can schedule its first run or model request
- preserve the existing hard-failure behavior: setup errors retain the managed worktree and leave the initiating action unapplied

Closes #581

## Scope

This PR changes six files and has a net diff of 189 additions / 11 deletions. It adds one narrow, read-only setup-settings projection that reuses the existing registry definitions. It adds no persistence, protocol, CLI, Desktop, event-contract, layout, action-serialization, or retry-flow changes.

## Verification

- `./scripts/test.sh ./shared/config ./server/core ./server/worktree`
- `./scripts/test.sh server desktop`
- `./scripts/build.sh server desktop --output ./bin/kent`
- `./scripts/ci-check.sh all`
- `git diff --check origin/main...HEAD`