### PR TITLE
Remove duplicate denial commentary steering

### DIFF
--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -216,9 +216,11 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 						PromptID: string(req.PromptID),
 						Approval: &clientui.ApprovalPromptAnswer{Decision: decision, Commentary: commentary},
 					}
-					if queueCmd := m.enqueueInjectedInputWithApprovalAnswer(commentary, &resp); queueCmd != nil {
-						m.ask.answerPending = true
-						return m, queueCmd
+					if decision != clientui.ApprovalDecisionDeny {
+						if queueCmd := m.enqueueInjectedInputWithApprovalAnswer(commentary, &resp); queueCmd != nil {
+							m.ask.answerPending = true
+							return m, queueCmd
+						}
 					}
 					_, hasNext := c.answer(resp, nil)
 					if hasNext {

--- a/cli/app/ui_test.go
+++ b/cli/app/ui_test.go
@@ -556,17 +556,8 @@ func TestApprovalAskUsesSingleDenyOptionAndTabCommentary(t *testing.T) {
 	updated = next.(*uiModel)
 	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
-	if cmd == nil {
-		t.Fatal("expected approval commentary queue command")
-	}
-	select {
-	case <-reply:
-		t.Fatal("did not expect approval answer before commentary queue command completes")
-	default:
-	}
-	for _, msg := range collectCmdMessages(t, cmd) {
-		next, cmd = updated.Update(msg)
-		updated = next.(*uiModel)
+	if cmd != nil {
+		t.Fatal("deny commentary must not create a queued user-message command")
 	}
 
 	resp := <-reply
@@ -576,8 +567,8 @@ func TestApprovalAskUsesSingleDenyOptionAndTabCommentary(t *testing.T) {
 	if resp.response.Approval.Decision != clientui.ApprovalDecisionDeny || resp.response.Approval.Commentary != "blocked by policy" {
 		t.Fatalf("unexpected approval response: %+v", resp.response.Approval)
 	}
-	if len(updated.pendingInjected) != 1 || updated.pendingInjected[0].Text != "blocked by policy" {
-		t.Fatalf("expected deny commentary injected into regular user-said flow, got %+v", updated.pendingInjected)
+	if len(updated.pendingInjected) != 0 {
+		t.Fatalf("deny commentary created a duplicate queued user message: %+v", updated.pendingInjected)
 	}
 	resolveAnsweredTestAskThroughTranscript(t, updated)
 	if testActiveAsk(updated) != nil {


### PR DESCRIPTION
## Summary

Removes the duplicate queued user-message path when an approval is denied with commentary. The commentary remains attached to the typed denial answer/tool error, so it appears once instead of being repeated as a separately steered reminder.

Allow decisions retain the existing queue-before-answer behavior.

## Scope

Exactly two files:

- `cli/app/ui_ask_controller.go`
- `cli/app/ui_test.go`

No protocol, API, server, desktop, workflow, persistence, documentation, or unrelated architecture changes.

## Verification

- Focused approval/ask UI tests passed.
- `./scripts/test.sh server` passed.
- `./scripts/test.sh tui desktop` passed.
- `./scripts/build.sh --output ./bin/kent` passed.
- `./scripts/ci-check.sh format` passed.
- `git diff --check` passed.

The first full server run was executed concurrently with another full suite and hit the repository's 120-second wall-clock cap despite all reported packages passing; rerunning `./scripts/test.sh server` alone passed.

## LoC report

Compared with `origin/main`:

- **Total:** -7 net / 25 gross (`+9`, `-16`)
- **Production:** +2 net / 8 gross (`+5`, `-3`)
- **Tests:** -9 net / 17 gross (`+4`, `-13`)

## Tracking

- Kent ticket: **KENT-250**
- GitHub issue: none linked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Denying an approval no longer queues an unnecessary user message or injected commentary.
  * Updated approval commentary behavior so denial submissions are handled without creating pending input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->