### PR TITLE
Recover prompt answer delivery after timeouts

### DIFF
--- a/cli/app/session_server_target_part3_test.go
+++ b/cli/app/session_server_target_part3_test.go
@@ -266,9 +266,10 @@ func answerRemoteTranscriptPrompt(t *testing.T, answerer *transcriptPromptAnswer
 	if err != nil {
 		t.Fatalf("prepare transcript prompt answer: %v", err)
 	}
-	result, ok := cmd().(promptAnswerDeliveryResultMsg)
+	msg := cmd()
+	result, ok := msg.(promptAnswerDeliveryResultMsg)
 	if !ok {
-		t.Fatalf("transcript prompt answer result type = %T", cmd())
+		t.Fatalf("transcript prompt answer result type = %T", msg)
 	}
 	if result.err != nil {
 		t.Fatalf("deliver transcript prompt answer: %v", result.err)

--- a/cli/app/session_server_target_part3_test.go
+++ b/cli/app/session_server_target_part3_test.go
@@ -262,7 +262,17 @@ func answerRemoteTranscriptPrompt(t *testing.T, answerer *transcriptPromptAnswer
 	if answerer == nil {
 		t.Fatal("transcript prompt answerer is required")
 	}
-	answerer.event(prompt).reply <- askReply{response: answer}
+	_, cmd, err := answerer.delivery(prompt, answer, nil)
+	if err != nil {
+		t.Fatalf("prepare transcript prompt answer: %v", err)
+	}
+	result, ok := cmd().(promptAnswerDeliveryResultMsg)
+	if !ok {
+		t.Fatalf("transcript prompt answer result type = %T", cmd())
+	}
+	if result.err != nil {
+		t.Fatalf("deliver transcript prompt answer: %v", result.err)
+	}
 }
 
 func waitForRemoteProcess(t *testing.T, views apicontract.ProcessViewService, sessionID string, processID string) clientui.BackgroundProcess {

--- a/cli/app/transcript_prompt_answers.go
+++ b/cli/app/transcript_prompt_answers.go
@@ -48,8 +48,7 @@ func newTranscriptPromptAnswerer(ctx context.Context, control apicontract.Prompt
 		return nil
 	}
 	return &transcriptPromptAnswerer{
-		ctx:         ctx,
-		control:     control,
+		ctx: ctx, control: control,
 		retryDelays: transcriptPromptAnswerRetryDelays,
 		retryWait:   rpcwire.WaitForRetry,
 	}

--- a/cli/app/transcript_prompt_answers.go
+++ b/cli/app/transcript_prompt_answers.go
@@ -3,98 +3,214 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"core/shared/apicontract"
 	"core/shared/clientui"
+	"core/shared/rpcwire"
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
-const transcriptPromptAnswerRetryDelay = 250 * time.Millisecond
+var transcriptPromptAnswerRetryDelays = []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second, 16 * time.Second}
 
 type transcriptPromptAnswerer struct {
-	ctx     context.Context
-	control apicontract.PromptControlService
+	ctx                   context.Context
+	control               apicontract.PromptControlService
+	connectionOutcomeSink func(error)
+	retryDelays           []time.Duration
+	retryWait             func(context.Context, time.Duration) error
+}
+
+type transcriptPromptKey struct {
+	sessionID runtimeids.SessionID
+	promptID  clientui.PromptID
+}
+
+type activePromptAnswerDelivery struct {
+	key       transcriptPromptKey
+	requestID runtimeids.RuntimeClientRequestID
+	cancel    context.CancelFunc
+}
+
+type promptAnswerDeliveryResultMsg struct {
+	key       transcriptPromptKey
+	requestID runtimeids.RuntimeClientRequestID
+	err       error
 }
 
 func newTranscriptPromptAnswerer(ctx context.Context, control apicontract.PromptControlService) *transcriptPromptAnswerer {
 	if ctx == nil || control == nil {
 		return nil
 	}
-	return &transcriptPromptAnswerer{ctx: ctx, control: control}
+	return &transcriptPromptAnswerer{
+		ctx:         ctx,
+		control:     control,
+		retryDelays: transcriptPromptAnswerRetryDelays,
+		retryWait:   rpcwire.WaitForRetry,
+	}
+}
+
+func (a *transcriptPromptAnswerer) withConnectionOutcomeSink(sink func(error)) *transcriptPromptAnswerer {
+	if a == nil {
+		return nil
+	}
+	copy := *a
+	copy.connectionOutcomeSink = sink
+	return &copy
 }
 
 func (a *transcriptPromptAnswerer) event(prompt clientui.TranscriptPrompt) askEvent {
-	prompt = cloneTranscriptPromptForAsk(prompt)
-	reply := make(chan askReply, 1)
-	if a == nil || a.ctx == nil || a.control == nil {
-		return askEvent{prompt: prompt, reply: reply}
-	}
-	promptCtx, cancel := context.WithCancel(a.ctx)
-	go func() {
-		var result askReply
-		select {
-		case <-promptCtx.Done():
-			return
-		case result = <-reply:
-		}
-		if promptCtx.Err() != nil {
-			return
-		}
-		operationID := runtimeids.NewRuntimeClientRequestID()
-		if transcriptPromptIsApproval(prompt) {
-			request := serverapi.ApprovalAnswerRequest{
-				ClientRequestID: operationID.String(),
-				SessionID:       prompt.SessionID.String(),
-				ApprovalID:      string(prompt.PromptID),
-			}
-			if result.err != nil {
-				request.ErrorMessage = result.err.Error()
-			} else if result.response.Approval != nil {
-				request.Decision = result.response.Approval.Decision
-				request.Commentary = result.response.Approval.Commentary
-			} else {
-				request.ErrorMessage = "approval response is required"
-			}
-			retryTranscriptPromptAnswer(promptCtx, func() error {
-				return a.control.AnswerApproval(promptCtx, request)
-			})
-			return
-		}
-		request := serverapi.AskAnswerRequest{
-			ClientRequestID: operationID.String(),
-			SessionID:       prompt.SessionID.String(),
-			AskID:           string(prompt.PromptID),
-		}
-		if result.err != nil {
-			request.ErrorMessage = result.err.Error()
-		} else {
-			request.Answer = result.response.Answer
-			request.SelectedOptionNumber = result.response.SelectedOptionNumber
-			request.FreeformAnswer = result.response.FreeformAnswer
-		}
-		retryTranscriptPromptAnswer(promptCtx, func() error {
-			return a.control.AnswerAsk(promptCtx, request)
-		})
-	}()
-	return askEvent{prompt: prompt, reply: reply, cancel: cancel}
+	return askEvent{prompt: cloneTranscriptPromptForAsk(prompt)}
 }
 
-func retryTranscriptPromptAnswer(ctx context.Context, submit func() error) {
-	for {
-		err := submit()
-		if !shouldRetryTranscriptPromptAnswer(err) {
-			return
-		}
-		timer := time.NewTimer(transcriptPromptAnswerRetryDelay)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return
-		case <-timer.C:
-		}
+func (a *transcriptPromptAnswerer) delivery(
+	prompt clientui.TranscriptPrompt,
+	answer clientui.PromptAnswer,
+	answerErr error,
+) (*activePromptAnswerDelivery, tea.Cmd, error) {
+	if a == nil || a.ctx == nil || a.control == nil {
+		return nil, nil, errors.New("prompt answer delivery is unavailable")
 	}
+	key, err := newTranscriptPromptKey(prompt)
+	if err != nil {
+		return nil, nil, err
+	}
+	requestID := runtimeids.NewRuntimeClientRequestID()
+	deliveryCtx, cancel := context.WithCancel(a.ctx)
+	active, err := newActivePromptAnswerDelivery(key, requestID, cancel)
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+	submit, err := a.submitter(prompt, clonePromptAnswer(answer), answerErr, requestID)
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+	delays := append([]time.Duration(nil), a.retryDelays...)
+	wait := a.retryWait
+	return active, func() tea.Msg {
+		err := retryTranscriptPromptAnswer(deliveryCtx, delays, wait, func() error {
+			err := submit(deliveryCtx)
+			if a.connectionOutcomeSink != nil {
+				a.connectionOutcomeSink(err)
+			}
+			return err
+		})
+		return promptAnswerDeliveryResultMsg{key: key, requestID: requestID, err: err}
+	}, nil
+}
+
+func (a *transcriptPromptAnswerer) submitter(
+	prompt clientui.TranscriptPrompt,
+	answer clientui.PromptAnswer,
+	answerErr error,
+	requestID runtimeids.RuntimeClientRequestID,
+) (func(context.Context) error, error) {
+	if transcriptPromptIsApproval(prompt) {
+		request := serverapi.ApprovalAnswerRequest{
+			ClientRequestID: requestID.String(),
+			SessionID:       prompt.SessionID.String(),
+			ApprovalID:      string(prompt.PromptID),
+		}
+		switch {
+		case answerErr != nil:
+			request.ErrorMessage = answerErr.Error()
+		case answer.Approval != nil:
+			request.Decision = answer.Approval.Decision
+			request.Commentary = answer.Approval.Commentary
+		default:
+			return nil, errors.New("approval response is required")
+		}
+		if err := request.Validate(); err != nil {
+			return nil, fmt.Errorf("validate approval answer: %w", err)
+		}
+		return func(ctx context.Context) error {
+			return a.control.AnswerApproval(ctx, request)
+		}, nil
+	}
+	request := serverapi.AskAnswerRequest{
+		ClientRequestID:      requestID.String(),
+		SessionID:            prompt.SessionID.String(),
+		AskID:                string(prompt.PromptID),
+		Answer:               answer.Answer,
+		SelectedOptionNumber: answer.SelectedOptionNumber,
+		FreeformAnswer:       answer.FreeformAnswer,
+	}
+	if answerErr != nil {
+		request.ErrorMessage = answerErr.Error()
+		request.Answer = ""
+		request.SelectedOptionNumber = nil
+		request.FreeformAnswer = ""
+	}
+	if err := request.Validate(); err != nil {
+		return nil, fmt.Errorf("validate ask answer: %w", err)
+	}
+	return func(ctx context.Context) error {
+		return a.control.AnswerAsk(ctx, request)
+	}, nil
+}
+
+func newTranscriptPromptKey(prompt clientui.TranscriptPrompt) (transcriptPromptKey, error) {
+	if prompt.SessionID.IsZero() {
+		return transcriptPromptKey{}, errors.New("prompt answer session id is required")
+	}
+	rawPromptID := string(prompt.PromptID)
+	if strings.TrimSpace(rawPromptID) == "" || strings.TrimSpace(rawPromptID) != rawPromptID {
+		return transcriptPromptKey{}, errors.New("prompt answer prompt id is required without surrounding whitespace")
+	}
+	return transcriptPromptKey{sessionID: prompt.SessionID, promptID: prompt.PromptID}, nil
+}
+
+func newActivePromptAnswerDelivery(
+	key transcriptPromptKey,
+	requestID runtimeids.RuntimeClientRequestID,
+	cancel context.CancelFunc,
+) (*activePromptAnswerDelivery, error) {
+	if key.sessionID.IsZero() || strings.TrimSpace(string(key.promptID)) == "" {
+		return nil, errors.New("prompt answer delivery key is required")
+	}
+	if requestID.IsZero() {
+		return nil, errors.New("prompt answer delivery request id is required")
+	}
+	if cancel == nil {
+		return nil, errors.New("prompt answer delivery cancellation is required")
+	}
+	return &activePromptAnswerDelivery{key: key, requestID: requestID, cancel: cancel}, nil
+}
+
+func (d *activePromptAnswerDelivery) cancelPending() {
+	if d != nil {
+		d.cancel()
+	}
+}
+
+func (d *activePromptAnswerDelivery) matches(key transcriptPromptKey, requestID runtimeids.RuntimeClientRequestID) bool {
+	return d != nil && d.key == key && d.requestID == requestID
+}
+
+func retryTranscriptPromptAnswer(
+	ctx context.Context,
+	delays []time.Duration,
+	wait func(context.Context, time.Duration) error,
+	submit func() error,
+) error {
+	err := submit()
+	for _, delay := range delays {
+		if !shouldRetryTranscriptPromptAnswer(err) {
+			return err
+		}
+		if err := wait(ctx, delay); err != nil {
+			return err
+		}
+		err = submit()
+	}
+	return err
 }
 
 func shouldRetryTranscriptPromptAnswer(err error) bool {
@@ -106,6 +222,18 @@ func shouldRetryTranscriptPromptAnswer(err error) bool {
 		!errors.Is(err, serverapi.ErrPromptNotFound) &&
 		!errors.Is(err, serverapi.ErrPromptAlreadyResolved) &&
 		!errors.Is(err, serverapi.ErrPromptUnsupported)
+}
+
+func clonePromptAnswer(answer clientui.PromptAnswer) clientui.PromptAnswer {
+	if answer.SelectedOptionNumber != nil {
+		selected := *answer.SelectedOptionNumber
+		answer.SelectedOptionNumber = &selected
+	}
+	if answer.Approval != nil {
+		approval := *answer.Approval
+		answer.Approval = &approval
+	}
+	return answer
 }
 
 func cloneTranscriptPromptForAsk(prompt clientui.TranscriptPrompt) clientui.TranscriptPrompt {

--- a/cli/app/transcript_prompt_answers.go
+++ b/cli/app/transcript_prompt_answers.go
@@ -200,7 +200,13 @@ func retryTranscriptPromptAnswer(
 	wait func(context.Context, time.Duration) error,
 	submit func() error,
 ) error {
-	err := submit()
+	submitIfActive := func() error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return submit()
+	}
+	err := submitIfActive()
 	for _, delay := range delays {
 		if !shouldRetryTranscriptPromptAnswer(err) {
 			return err
@@ -208,7 +214,7 @@ func retryTranscriptPromptAnswer(
 		if err := wait(ctx, delay); err != nil {
 			return err
 		}
-		err = submit()
+		err = submitIfActive()
 	}
 	return err
 }

--- a/cli/app/transcript_prompt_answers_retry_test.go
+++ b/cli/app/transcript_prompt_answers_retry_test.go
@@ -77,6 +77,33 @@ func TestTranscriptPromptAnswerRetryStopsImmediatelyForTerminalErrors(t *testing
 	}
 }
 
+func TestTranscriptPromptAnswerRetryDoesNotSubmitWhenAlreadyCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	waits := 0
+
+	err := retryTranscriptPromptAnswer(
+		ctx,
+		transcriptPromptAnswerRetryDelays,
+		func(context.Context, time.Duration) error {
+			waits++
+			return nil
+		},
+		func() error {
+			calls++
+			return nil
+		},
+	)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("retry error = %v, want context canceled", err)
+	}
+	if calls != 0 || waits != 0 {
+		t.Fatalf("calls = %d waits = %d, want no service call or wait", calls, waits)
+	}
+}
+
 func TestTranscriptPromptAnswerRetryCancellationStopsBlockedBackoff(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	firstCall := make(chan struct{})

--- a/cli/app/transcript_prompt_answers_retry_test.go
+++ b/cli/app/transcript_prompt_answers_retry_test.go
@@ -1,0 +1,114 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"core/shared/serverapi"
+)
+
+func TestTranscriptPromptAnswerRetryPolicyIsBounded(t *testing.T) {
+	persistent := errors.New("persistent retryable failure")
+	var (
+		calls int
+		waits []time.Duration
+	)
+	err := retryTranscriptPromptAnswer(
+		context.Background(),
+		transcriptPromptAnswerRetryDelays,
+		func(_ context.Context, delay time.Duration) error {
+			waits = append(waits, delay)
+			return nil
+		},
+		func() error {
+			calls++
+			return persistent
+		},
+	)
+	if !errors.Is(err, persistent) {
+		t.Fatalf("retry error = %v, want persistent failure", err)
+	}
+	if calls != 6 {
+		t.Fatalf("service calls = %d, want 6", calls)
+	}
+	wantWaits := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second, 16 * time.Second}
+	if !reflect.DeepEqual(waits, wantWaits) {
+		t.Fatalf("retry waits = %v, want %v", waits, wantWaits)
+	}
+}
+
+func TestTranscriptPromptAnswerRetryStopsImmediatelyForTerminalErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "deadline", err: context.DeadlineExceeded},
+		{name: "canceled", err: context.Canceled},
+		{name: "not found", err: serverapi.ErrPromptNotFound},
+		{name: "already resolved", err: serverapi.ErrPromptAlreadyResolved},
+		{name: "unsupported", err: serverapi.ErrPromptUnsupported},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			waits := 0
+			err := retryTranscriptPromptAnswer(
+				context.Background(),
+				transcriptPromptAnswerRetryDelays,
+				func(context.Context, time.Duration) error {
+					waits++
+					return nil
+				},
+				func() error {
+					calls++
+					return test.err
+				},
+			)
+			if !errors.Is(err, test.err) {
+				t.Fatalf("retry error = %v, want %v", err, test.err)
+			}
+			if calls != 1 || waits != 0 {
+				t.Fatalf("calls = %d waits = %d, want one call and no wait", calls, waits)
+			}
+		})
+	}
+}
+
+func TestTranscriptPromptAnswerRetryCancellationStopsBlockedBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	firstCall := make(chan struct{})
+	waitStarted := make(chan struct{})
+	calls := 0
+	result := make(chan error, 1)
+	go func() {
+		result <- retryTranscriptPromptAnswer(
+			ctx,
+			transcriptPromptAnswerRetryDelays,
+			func(waitCtx context.Context, _ time.Duration) error {
+				close(waitStarted)
+				<-waitCtx.Done()
+				return waitCtx.Err()
+			},
+			func() error {
+				calls++
+				if calls == 1 {
+					close(firstCall)
+				}
+				return errors.New("retryable failure")
+			},
+		)
+	}()
+
+	<-firstCall
+	<-waitStarted
+	cancel()
+	if err := <-result; !errors.Is(err, context.Canceled) {
+		t.Fatalf("retry error = %v, want context canceled", err)
+	}
+	if calls != 1 {
+		t.Fatalf("service calls = %d, want no call after canceled backoff", calls)
+	}
+}

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -1,0 +1,651 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"core/server/runtime"
+	"core/shared/clientui"
+	"core/shared/runtimeids"
+	"core/shared/serverapi"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type deadlineThenSuccessPromptControl struct {
+	mu           sync.Mutex
+	askRequests  []serverapi.AskAnswerRequest
+	firstStarted chan struct{}
+	firstRelease chan struct{}
+}
+
+type scriptedAskPromptControl struct {
+	mu          sync.Mutex
+	results     []error
+	askRequests []serverapi.AskAnswerRequest
+}
+
+type deadlineThenSuccessApprovalControl struct {
+	mu               sync.Mutex
+	approvalRequests []serverapi.ApprovalAnswerRequest
+	firstStarted     chan struct{}
+	firstRelease     chan struct{}
+}
+
+func newDeadlineThenSuccessApprovalControl() *deadlineThenSuccessApprovalControl {
+	return &deadlineThenSuccessApprovalControl{
+		firstStarted: make(chan struct{}),
+		firstRelease: make(chan struct{}),
+	}
+}
+
+func (c *deadlineThenSuccessApprovalControl) AnswerAsk(context.Context, serverapi.AskAnswerRequest) error {
+	return errors.New("unexpected ask answer")
+}
+
+func (c *deadlineThenSuccessApprovalControl) AnswerApproval(ctx context.Context, request serverapi.ApprovalAnswerRequest) error {
+	c.mu.Lock()
+	call := len(c.approvalRequests)
+	c.approvalRequests = append(c.approvalRequests, request)
+	c.mu.Unlock()
+	if call != 0 {
+		return nil
+	}
+	close(c.firstStarted)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.firstRelease:
+		return context.DeadlineExceeded
+	}
+}
+
+func (c *deadlineThenSuccessApprovalControl) requests() []serverapi.ApprovalAnswerRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]serverapi.ApprovalAnswerRequest(nil), c.approvalRequests...)
+}
+
+func (c *scriptedAskPromptControl) AnswerAsk(_ context.Context, request serverapi.AskAnswerRequest) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	call := len(c.askRequests)
+	c.askRequests = append(c.askRequests, request)
+	if call < len(c.results) {
+		return c.results[call]
+	}
+	return nil
+}
+
+func (c *scriptedAskPromptControl) AnswerApproval(context.Context, serverapi.ApprovalAnswerRequest) error {
+	return errors.New("unexpected approval answer")
+}
+
+func (c *scriptedAskPromptControl) requests() []serverapi.AskAnswerRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]serverapi.AskAnswerRequest(nil), c.askRequests...)
+}
+
+func newDeadlineThenSuccessPromptControl() *deadlineThenSuccessPromptControl {
+	return &deadlineThenSuccessPromptControl{
+		firstStarted: make(chan struct{}),
+		firstRelease: make(chan struct{}),
+	}
+}
+
+func (c *deadlineThenSuccessPromptControl) AnswerAsk(ctx context.Context, request serverapi.AskAnswerRequest) error {
+	c.mu.Lock()
+	call := len(c.askRequests)
+	c.askRequests = append(c.askRequests, request)
+	c.mu.Unlock()
+	if call != 0 {
+		return nil
+	}
+	close(c.firstStarted)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.firstRelease:
+		return context.DeadlineExceeded
+	}
+}
+
+func (c *deadlineThenSuccessPromptControl) AnswerApproval(context.Context, serverapi.ApprovalAnswerRequest) error {
+	return errors.New("unexpected approval answer")
+}
+
+func (c *deadlineThenSuccessPromptControl) requests() []serverapi.AskAnswerRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]serverapi.AskAnswerRequest(nil), c.askRequests...)
+}
+
+func TestAskDeadlineKeepsEditedRetryDraftActionableUntilCanonicalResolution(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	control := newDeadlineThenSuccessPromptControl()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	model := newProjectedStaticUIModel()
+	model.promptAnswers = newTranscriptPromptAnswerer(ctx, control)
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testQuestionPrompt("ask-deadline", "How should I proceed?", "Use the draft", "Stop"),
+	)})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("original")})
+
+	next, firstDelivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	if firstDelivery == nil {
+		t.Fatal("submitting an answer did not return a stateless delivery command")
+	}
+	if !testPromptAnswerDeliveryActive(model) {
+		t.Fatal("answer delivery is not active after submission")
+	}
+
+	firstResult := make(chan tea.Msg, 1)
+	go func() {
+		firstResult <- firstDelivery()
+	}()
+	<-control.firstStarted
+
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(" edited")})
+	if got := testAskInput(model); got != "original edited" {
+		t.Fatalf("retry draft = %q, want edited draft while delivery is outstanding", got)
+	}
+	if got := testAskCursor(model); got != 0 {
+		t.Fatalf("selection = %d, want original selection retained", got)
+	}
+
+	close(control.firstRelease)
+	model = updateUIModel(t, model, <-firstResult)
+	if testPromptAnswerDeliveryActive(model) {
+		t.Fatal("deadline left answer delivery active")
+	}
+	if testActiveAsk(model) == nil {
+		t.Fatal("deadline locally resolved the prompt")
+	}
+	if got := testAskInput(model); got != "original edited" {
+		t.Fatalf("retry draft = %q after deadline, want edited draft preserved", got)
+	}
+	if model.transientStatusKind != uiStatusNoticeError || model.transientStatus == "" {
+		t.Fatalf("deadline notice = kind %d text %q, want visible error", model.transientStatusKind, model.transientStatus)
+	}
+
+	next, secondDelivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	if secondDelivery == nil {
+		t.Fatal("resubmitting the edited draft did not return a delivery command")
+	}
+	model = updateUIModel(t, model, secondDelivery())
+	if !testPromptAnswerDeliveryActive(model) {
+		t.Fatal("successful delivery stopped awaiting canonical prompt resolution")
+	}
+	if testActiveAsk(model) == nil {
+		t.Fatal("successful delivery locally resolved the prompt")
+	}
+
+	requests := control.requests()
+	if len(requests) != 2 {
+		t.Fatalf("ask requests = %d, want deadline attempt plus user resubmission", len(requests))
+	}
+	if requests[0].ClientRequestID == "" || requests[1].ClientRequestID == "" || requests[0].ClientRequestID == requests[1].ClientRequestID {
+		t.Fatalf("request IDs = %q, %q; want distinct non-empty IDs", requests[0].ClientRequestID, requests[1].ClientRequestID)
+	}
+	if requests[0].Answer != "original" || requests[0].FreeformAnswer != "original" {
+		t.Fatalf("first immutable request = %+v, want original draft", requests[0])
+	}
+	if requests[1].Answer != "original edited" || requests[1].FreeformAnswer != "original edited" {
+		t.Fatalf("resubmitted request = %+v, want edited retry draft", requests[1])
+	}
+
+	resolveAnsweredTestAskThroughTranscript(t, model)
+	if testActiveAsk(model) != nil {
+		t.Fatal("prompt remained after canonical transcript resolution")
+	}
+}
+
+func TestAskRepeatedEnterWhileDeliveryActiveDoesNotSubmitAgain(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	control := newDeadlineThenSuccessPromptControl()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	model := newProjectedStaticUIModel()
+	model.promptAnswers = newTranscriptPromptAnswerer(ctx, control)
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testQuestionPrompt("ask-duplicate", "Proceed?", "Yes", "No"),
+	)})
+
+	next, delivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	result := make(chan tea.Msg, 1)
+	go func() {
+		result <- delivery()
+	}()
+	<-control.firstStarted
+
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+	if len(control.requests()) != 1 {
+		t.Fatalf("ask requests = %d, want one while delivery is active", len(control.requests()))
+	}
+	if !testPromptAnswerDeliveryActive(model) {
+		t.Fatal("repeated Enter cleared the active delivery")
+	}
+	if model.transientStatusKind != uiStatusNoticeInfo || model.transientStatus == "" {
+		t.Fatalf("sending notice = kind %d text %q, want nonblocking info", model.transientStatusKind, model.transientStatus)
+	}
+
+	close(control.firstRelease)
+	model = updateUIModel(t, model, <-result)
+	if testPromptAnswerDeliveryActive(model) {
+		t.Fatal("deadline result left the delivery active")
+	}
+}
+
+func TestAskRetryThenSuccessKeepsOneRequestIDUntilCanonicalResolution(t *testing.T) {
+	control := &scriptedAskPromptControl{results: []error{
+		errors.New("retryable one"),
+		errors.New("retryable two"),
+		nil,
+	}}
+	answerer := newTranscriptPromptAnswerer(context.Background(), control)
+	answerer.retryWait = func(context.Context, time.Duration) error { return nil }
+
+	model := newProjectedStaticUIModel()
+	model.promptAnswers = answerer
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testQuestionPrompt("ask-retry-success", "Provide details"),
+	)})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("answer")})
+
+	next, delivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = runPromptDeliveryCommand(t, next.(*uiModel), delivery)
+	requests := control.requests()
+	if len(requests) != 3 {
+		t.Fatalf("ask requests = %d, want two retries then success", len(requests))
+	}
+	requestID := requests[0].ClientRequestID
+	for index, request := range requests {
+		if request.ClientRequestID != requestID {
+			t.Fatalf("request %d ID = %q, want stable %q", index, request.ClientRequestID, requestID)
+		}
+	}
+	if !testPromptAnswerDeliveryActive(model) || testActiveAsk(model) == nil {
+		t.Fatal("successful retry resolved the prompt before canonical transcript resolution")
+	}
+	resolveAnsweredTestAskThroughTranscript(t, model)
+	if testActiveAsk(model) != nil {
+		t.Fatal("prompt remained after canonical transcript resolution")
+	}
+}
+
+func TestAskPersistentRetryableFailureStopsAfterSixCallsAndRestoresActionability(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	persistent := errors.New("persistent retryable failure")
+	control := &scriptedAskPromptControl{results: []error{
+		persistent,
+		persistent,
+		persistent,
+		persistent,
+		persistent,
+		persistent,
+	}}
+	answerer := newTranscriptPromptAnswerer(context.Background(), control)
+	answerer.retryWait = func(context.Context, time.Duration) error { return nil }
+
+	model := newProjectedStaticUIModel()
+	model.promptAnswers = answerer
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testQuestionPrompt("ask-retry-exhausted", "Provide details"),
+	)})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("retry draft")})
+
+	next, delivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = runPromptDeliveryCommand(t, next.(*uiModel), delivery)
+	requests := control.requests()
+	if len(requests) != 6 {
+		t.Fatalf("ask requests = %d, want bounded six calls", len(requests))
+	}
+	requestID := requests[0].ClientRequestID
+	for index, request := range requests {
+		if request.ClientRequestID != requestID {
+			t.Fatalf("request %d ID = %q, want stable %q", index, request.ClientRequestID, requestID)
+		}
+	}
+	if testPromptAnswerDeliveryActive(model) {
+		t.Fatal("exhausted retry left answer delivery active")
+	}
+	if testActiveAsk(model) == nil || testAskInput(model) != "retry draft" {
+		t.Fatal("exhausted retry did not preserve the actionable prompt draft")
+	}
+	if model.transientStatusKind != uiStatusNoticeError || model.transientStatus == "" {
+		t.Fatalf("exhausted retry notice = kind %d text %q, want visible error", model.transientStatusKind, model.transientStatus)
+	}
+}
+
+func TestAskRetryReportsDisconnectAndReachabilityBeforeFinalDelivery(t *testing.T) {
+	control := &scriptedAskPromptControl{results: []error{io.EOF, nil}}
+	waitStarted := make(chan struct{})
+	releaseWait := make(chan struct{})
+	answerer := newTranscriptPromptAnswerer(context.Background(), control)
+	answerer.retryWait = func(waitCtx context.Context, _ time.Duration) error {
+		close(waitStarted)
+		select {
+		case <-waitCtx.Done():
+			return waitCtx.Err()
+		case <-releaseWait:
+			return nil
+		}
+	}
+
+	_, engine := newAppRuntimeEngine(t, statusLineFakeClient{}, runtime.Config{ContextWindowTokens: 400_000})
+	model := newProjectedEngineUIModel(engine)
+	if model.runtimeConnectionEvents == nil {
+		t.Fatal("projected runtime model did not create the global connection event channel")
+	}
+	model.promptAnswers = answerer.withConnectionOutcomeSink(func(err error) {
+		enqueueRuntimeConnectionStateChange(model.runtimeConnectionEvents, err)
+	})
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testQuestionPrompt("ask-connection-retry", "Proceed?", "Yes", "No"),
+	)})
+
+	next, delivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	finalResult := make(chan tea.Msg, 1)
+	go func() {
+		finalResult <- delivery()
+	}()
+	<-waitStarted
+
+	model = updateUIModel(t, model, <-model.runtimeConnectionEvents)
+	if !model.runtimeDisconnectStatusVisible() {
+		t.Fatal("disconnect was not visible while prompt delivery remained in backoff")
+	}
+	if !testPromptAnswerDeliveryActive(model) {
+		t.Fatal("connection failure prematurely cleared active delivery")
+	}
+	if model.transientStatus != "" {
+		t.Fatalf("connection failure created prompt-local notice %q", model.transientStatus)
+	}
+
+	close(releaseWait)
+	model = updateUIModel(t, model, <-model.runtimeConnectionEvents)
+	if model.runtimeDisconnectStatusVisible() {
+		t.Fatal("reachable retry did not clear the global disconnect state")
+	}
+	model = updateUIModel(t, model, <-finalResult)
+	if !testPromptAnswerDeliveryActive(model) || testActiveAsk(model) == nil {
+		t.Fatal("successful delivery stopped awaiting canonical prompt resolution")
+	}
+	requests := control.requests()
+	if len(requests) != 2 || requests[0].ClientRequestID != requests[1].ClientRequestID {
+		t.Fatalf("retry requests = %+v, want two calls with one stable request ID", requests)
+	}
+	resolveAnsweredTestAskThroughTranscript(t, model)
+}
+
+func TestAskSameKeyRefreshPreservesActiveDeliveryDraftAndSelection(t *testing.T) {
+	control := newDeadlineThenSuccessPromptControl()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	model := newProjectedStaticUIModel()
+	model.promptAnswers = newTranscriptPromptAnswerer(ctx, control)
+	prompt := testQuestionPrompt("ask-refresh", "Original question", "One", "Two")
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(prompt)})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("retry draft")})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyDown})
+
+	next, delivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	active := model.ask.activeDelivery
+	result := make(chan tea.Msg, 1)
+	go func() {
+		result <- delivery()
+	}()
+	<-control.firstStarted
+
+	refreshed := cloneTranscriptPromptForAsk(prompt)
+	refreshed.Question = "Refreshed question"
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(refreshed)})
+	if model.ask.activeDelivery != active {
+		t.Fatal("same-key refresh replaced active delivery ownership")
+	}
+	if testAskInput(model) != "retry draft" || testAskCursor(model) != 1 || testAskFreeform(model) {
+		t.Fatalf(
+			"same-key refresh changed draft/selection: draft=%q cursor=%d freeform=%t",
+			testAskInput(model),
+			testAskCursor(model),
+			testAskFreeform(model),
+		)
+	}
+	if testActiveAsk(model).prompt.Question != "Refreshed question" {
+		t.Fatalf("same-key refresh did not update prompt payload: %+v", testActiveAsk(model).prompt)
+	}
+
+	close(control.firstRelease)
+	model = updateUIModel(t, model, <-result)
+	if testPromptAnswerDeliveryActive(model) {
+		t.Fatal("deadline result left refreshed delivery active")
+	}
+}
+
+func TestAskResolutionCancelsConnectionBackoffWithoutFabricatingReachability(t *testing.T) {
+	control := &scriptedAskPromptControl{results: []error{io.EOF}}
+	waitStarted := make(chan struct{})
+	answerer := newTranscriptPromptAnswerer(context.Background(), control)
+	answerer.retryWait = func(waitCtx context.Context, _ time.Duration) error {
+		close(waitStarted)
+		<-waitCtx.Done()
+		return waitCtx.Err()
+	}
+
+	_, engine := newAppRuntimeEngine(t, statusLineFakeClient{}, runtime.Config{ContextWindowTokens: 400_000})
+	model := newProjectedEngineUIModel(engine)
+	model.promptAnswers = answerer.withConnectionOutcomeSink(func(err error) {
+		enqueueRuntimeConnectionStateChange(model.runtimeConnectionEvents, err)
+	})
+	first := testQuestionPrompt("ask-cancel-backoff", "First?", "Yes", "No")
+	second := testQuestionPrompt("ask-after-cancel", "Second?", "Continue", "Stop")
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(first)})
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(second)})
+
+	next, delivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	finalResult := make(chan tea.Msg, 1)
+	go func() {
+		finalResult <- delivery()
+	}()
+	<-waitStarted
+	model = updateUIModel(t, model, <-model.runtimeConnectionEvents)
+	if !model.runtimeDisconnectStatusVisible() {
+		t.Fatal("disconnect was not visible before cancellation")
+	}
+
+	resolveAnsweredTestAskThroughTranscript(t, model)
+	if active := testActiveAsk(model); active == nil || active.prompt.PromptID != second.PromptID {
+		t.Fatalf("authoritative resolution did not activate the next prompt: %+v", active)
+	}
+	model = updateUIModel(t, model, <-finalResult)
+	if active := testActiveAsk(model); active == nil || active.prompt.PromptID != second.PromptID {
+		t.Fatalf("stale canceled result changed the next prompt: %+v", active)
+	}
+	if len(control.requests()) != 1 {
+		t.Fatalf("service calls = %d, want no retry after cancellation", len(control.requests()))
+	}
+	select {
+	case outcome := <-model.runtimeConnectionEvents:
+		t.Fatalf("cancellation fabricated connection outcome %+v", outcome)
+	default:
+	}
+	if !model.runtimeDisconnectStatusVisible() {
+		t.Fatal("cancellation incorrectly cleared the global disconnect state")
+	}
+
+	enqueueRuntimeConnectionStateChange(model.runtimeConnectionEvents, nil)
+	model = updateUIModel(t, model, <-model.runtimeConnectionEvents)
+	if model.runtimeDisconnectStatusVisible() {
+		t.Fatal("a later real reachable outcome did not clear disconnect state")
+	}
+}
+
+func TestAskConnectionExhaustionUsesOnlyGlobalDisconnectNotice(t *testing.T) {
+	control := &scriptedAskPromptControl{results: []error{io.EOF, io.EOF, io.EOF, io.EOF, io.EOF, io.EOF}}
+	answerer := newTranscriptPromptAnswerer(context.Background(), control)
+	answerer.retryWait = func(context.Context, time.Duration) error { return nil }
+
+	_, engine := newAppRuntimeEngine(t, statusLineFakeClient{}, runtime.Config{ContextWindowTokens: 400_000})
+	model := newProjectedEngineUIModel(engine)
+	model.promptAnswers = answerer.withConnectionOutcomeSink(func(err error) {
+		enqueueRuntimeConnectionStateChange(model.runtimeConnectionEvents, err)
+	})
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testQuestionPrompt("ask-connection-exhausted", "Proceed?", "Yes", "No"),
+	)})
+
+	next, delivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	result := delivery()
+	model = updateUIModel(t, model, <-model.runtimeConnectionEvents)
+	model = updateUIModel(t, model, result)
+
+	if !model.runtimeDisconnectStatusVisible() {
+		t.Fatal("connection exhaustion did not leave the global disconnect visible")
+	}
+	if model.transientStatus != "" {
+		t.Fatalf("connection exhaustion created prompt-local notice %q", model.transientStatus)
+	}
+	if testPromptAnswerDeliveryActive(model) || testActiveAsk(model) == nil {
+		t.Fatal("connection exhaustion did not restore the unresolved prompt")
+	}
+	if len(control.requests()) != 6 {
+		t.Fatalf("service calls = %d, want bounded six calls", len(control.requests()))
+	}
+}
+
+func TestAskTypedTerminalFailureRestoresDraftAndShowsError(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	control := &scriptedAskPromptControl{results: []error{serverapi.ErrPromptNotFound}}
+	answerer := newTranscriptPromptAnswerer(context.Background(), control)
+
+	model := newProjectedStaticUIModel()
+	model.promptAnswers = answerer
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testQuestionPrompt("ask-terminal", "Provide details"),
+	)})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("retry draft")})
+
+	next, delivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = runPromptDeliveryCommand(t, next.(*uiModel), delivery)
+	if testPromptAnswerDeliveryActive(model) {
+		t.Fatal("typed terminal failure left answer delivery active")
+	}
+	if testActiveAsk(model) == nil || testAskInput(model) != "retry draft" {
+		t.Fatal("typed terminal failure did not preserve the actionable retry draft")
+	}
+	if model.transientStatusKind != uiStatusNoticeError || model.transientStatus == "" {
+		t.Fatalf("typed failure notice = kind %d text %q, want visible error", model.transientStatusKind, model.transientStatus)
+	}
+}
+
+func TestAskSessionReplacementCancelsDeliveryAndClearsOldPrompt(t *testing.T) {
+	control := newDeadlineThenSuccessPromptControl()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	model := newProjectedStaticUIModel()
+	model.promptAnswers = newTranscriptPromptAnswerer(ctx, control)
+	prompt := testQuestionPrompt("ask-old-session", "Proceed?", "Yes", "No")
+	model.sessionID = prompt.SessionID.String()
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(prompt)})
+
+	next, delivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	result := make(chan tea.Msg, 1)
+	go func() {
+		result <- delivery()
+	}()
+	<-control.firstStarted
+
+	model.applyTranscriptSessionIdentity(clientui.TranscriptSessionIdentity{
+		SessionID:             runtimeids.NewSessionID(),
+		ConversationFreshness: clientui.ConversationFreshnessFresh,
+	})
+	if testActiveAsk(model) != nil || testPromptAnswerDeliveryActive(model) {
+		t.Fatal("session replacement retained the old prompt delivery")
+	}
+	model = updateUIModel(t, model, <-result)
+	if testActiveAsk(model) != nil || testPromptAnswerDeliveryActive(model) {
+		t.Fatal("stale canceled result restored the old-session prompt")
+	}
+}
+
+func TestApprovalDeadlineKeepsEditedSelectionActionableUntilCanonicalResolution(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	control := newDeadlineThenSuccessApprovalControl()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	model := newProjectedStaticUIModel()
+	model.promptAnswers = newTranscriptPromptAnswerer(ctx, control)
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testApprovalPrompt(
+			"approval-deadline",
+			"Allow access?",
+			clientui.ApprovalDecisionAllowOnce,
+			clientui.ApprovalDecisionDeny,
+		),
+	)})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyDown})
+
+	next, firstDelivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	firstResult := make(chan tea.Msg, 1)
+	go func() {
+		firstResult <- firstDelivery()
+	}()
+	<-control.firstStarted
+
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyUp})
+	if testAskCursor(model) != 0 {
+		t.Fatalf("retry selection = %d, want edited allow selection", testAskCursor(model))
+	}
+	close(control.firstRelease)
+	model = updateUIModel(t, model, <-firstResult)
+	if testPromptAnswerDeliveryActive(model) || testActiveAsk(model) == nil {
+		t.Fatal("approval deadline did not restore the unresolved prompt")
+	}
+	if model.transientStatusKind != uiStatusNoticeError || model.transientStatus == "" {
+		t.Fatalf("approval deadline notice = kind %d text %q, want visible error", model.transientStatusKind, model.transientStatus)
+	}
+
+	next, secondDelivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = runPromptDeliveryCommand(t, next.(*uiModel), secondDelivery)
+	requests := control.requests()
+	if len(requests) != 2 {
+		t.Fatalf("approval requests = %d, want deadline plus user resubmission", len(requests))
+	}
+	if requests[0].Decision != clientui.ApprovalDecisionDeny || requests[1].Decision != clientui.ApprovalDecisionAllowOnce {
+		t.Fatalf("approval decisions = %q then %q, want immutable deny then edited allow", requests[0].Decision, requests[1].Decision)
+	}
+	if requests[0].ClientRequestID == requests[1].ClientRequestID {
+		t.Fatalf("approval resubmission reused request ID %q", requests[0].ClientRequestID)
+	}
+	if !testPromptAnswerDeliveryActive(model) || testActiveAsk(model) == nil {
+		t.Fatal("successful approval delivery stopped awaiting canonical resolution")
+	}
+	resolveAnsweredTestAskThroughTranscript(t, model)
+}
+
+func testPromptAnswerDeliveryActive(model *uiModel) bool {
+	return model != nil && model.ask.activeDelivery != nil
+}

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -810,8 +810,69 @@ func TestAllowCommentaryQueuesBeforeApprovalRetriesWithOneRequestID(t *testing.T
 			t.Fatalf("allow request %d = %+v, want stable immutable request ID %q", index, request, requestID)
 		}
 	}
-	if !testPromptAnswerDeliveryActive(model) || !model.ask.answerPending {
-		t.Fatal("successful allow delivery stopped awaiting canonical resolution")
+	if !testPromptAnswerDeliveryActive(model) || model.ask.answerPending {
+		t.Fatal("successful allow delivery did not remain active with the queue-stage lock released")
+	}
+	resolveAnsweredTestAskThroughTranscript(t, model)
+}
+
+func TestAllowCommentaryQueueUnlocksBeforeCancelableApprovalDelivery(t *testing.T) {
+	control := newDeadlineThenSuccessApprovalControl()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runtimeClient := &runtimeControlFakeClient{queueUserMessageID: "allow-commentary-queue"}
+	model := newProjectedTestUIModel(runtimeClient)
+	model.promptAnswers = newTranscriptPromptAnswerer(ctx, control)
+	model.setRuntimeActivityBusyForTest(true)
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testApprovalPrompt(
+			"allow-commentary-cancel",
+			"Allow access?",
+			clientui.ApprovalDecisionAllowOnce,
+			clientui.ApprovalDecisionDeny,
+		),
+	)})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("safe operation")})
+
+	next, queueCommand := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	if queueCommand == nil || !model.ask.answerPending {
+		t.Fatal("allow commentary did not enter the locked queue stage")
+	}
+	next, deliveryCommand := model.Update(queueCommand())
+	model = next.(*uiModel)
+	if deliveryCommand == nil || model.ask.answerPending {
+		t.Fatal("completed queue stage did not unlock the prompt before approval delivery")
+	}
+
+	firstResult := make(chan tea.Msg, 1)
+	go func() {
+		firstResult <- deliveryCommand()
+	}()
+	<-control.firstStarted
+
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(" edited")})
+	if testAskInput(model) != "safe operation edited" {
+		t.Fatalf("approval retry draft = %q, want responsive editing during delivery", testAskInput(model))
+	}
+	next, cancelDelivery := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	model = next.(*uiModel)
+	if cancelDelivery == nil || !testPromptAnswerDeliveryActive(model) {
+		t.Fatal("Esc did not replace the active approval delivery with a cancellation delivery")
+	}
+	model = updateUIModel(t, model, <-firstResult)
+	model = runPromptDeliveryCommand(t, model, cancelDelivery)
+
+	requests := control.requests()
+	if len(requests) != 2 {
+		t.Fatalf("approval requests = %d, want original allow plus cancellation", len(requests))
+	}
+	if requests[0].Decision != clientui.ApprovalDecisionAllowOnce || requests[0].Commentary != "safe operation" {
+		t.Fatalf("original immutable approval request = %+v", requests[0])
+	}
+	if requests[1].ErrorMessage == "" {
+		t.Fatalf("replacement approval request = %+v, want typed cancellation", requests[1])
 	}
 	resolveAnsweredTestAskThroughTranscript(t, model)
 }
@@ -874,8 +935,8 @@ func TestAllowCommentaryAnswerDeadlineRestoresFreshQueueAndAnswerResubmission(t 
 	if runtimeClient.queueUserMessageCalls != 2 {
 		t.Fatalf("allow commentary queue calls = %d, want one per user submission", runtimeClient.queueUserMessageCalls)
 	}
-	if !testPromptAnswerDeliveryActive(model) || !model.ask.answerPending {
-		t.Fatal("successful allow resubmission stopped awaiting canonical resolution")
+	if !testPromptAnswerDeliveryActive(model) || model.ask.answerPending {
+		t.Fatal("successful allow resubmission did not remain active with the queue-stage lock released")
 	}
 	resolveAnsweredTestAskThroughTranscript(t, model)
 }

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -29,6 +29,12 @@ type scriptedAskPromptControl struct {
 	askRequests []serverapi.AskAnswerRequest
 }
 
+type scriptedApprovalPromptControl struct {
+	mu               sync.Mutex
+	results          []error
+	approvalRequests []serverapi.ApprovalAnswerRequest
+}
+
 type deadlineThenSuccessApprovalControl struct {
 	mu               sync.Mutex
 	approvalRequests []serverapi.ApprovalAnswerRequest
@@ -89,6 +95,27 @@ func (c *scriptedAskPromptControl) requests() []serverapi.AskAnswerRequest {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([]serverapi.AskAnswerRequest(nil), c.askRequests...)
+}
+
+func (c *scriptedApprovalPromptControl) AnswerAsk(context.Context, serverapi.AskAnswerRequest) error {
+	return errors.New("unexpected ask answer")
+}
+
+func (c *scriptedApprovalPromptControl) AnswerApproval(_ context.Context, request serverapi.ApprovalAnswerRequest) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	call := len(c.approvalRequests)
+	c.approvalRequests = append(c.approvalRequests, request)
+	if call < len(c.results) {
+		return c.results[call]
+	}
+	return nil
+}
+
+func (c *scriptedApprovalPromptControl) requests() []serverapi.ApprovalAnswerRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]serverapi.ApprovalAnswerRequest(nil), c.approvalRequests...)
 }
 
 func newDeadlineThenSuccessPromptControl() *deadlineThenSuccessPromptControl {
@@ -589,7 +616,7 @@ func TestAskSessionReplacementCancelsDeliveryAndClearsOldPrompt(t *testing.T) {
 	}
 }
 
-func TestApprovalDeadlineKeepsEditedSelectionActionableUntilCanonicalResolution(t *testing.T) {
+func TestDenyCommentaryDeadlineKeepsEditedDraftActionableWithoutQueuedCopy(t *testing.T) {
 	disableTransientStatusClearForTest(t)
 	control := newDeadlineThenSuccessApprovalControl()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -599,15 +626,185 @@ func TestApprovalDeadlineKeepsEditedSelectionActionableUntilCanonicalResolution(
 	model.promptAnswers = newTranscriptPromptAnswerer(ctx, control)
 	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
 		testApprovalPrompt(
-			"approval-deadline",
+			"deny-commentary-deadline",
 			"Allow access?",
 			clientui.ApprovalDecisionAllowOnce,
 			clientui.ApprovalDecisionDeny,
 		),
 	)})
 	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyDown})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("original denial")})
 
 	next, firstDelivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	if firstDelivery == nil || len(model.pendingInjected) != 0 {
+		t.Fatalf("deny submission = command %v queued %+v, want direct delivery without queued commentary", firstDelivery, model.pendingInjected)
+	}
+	firstResult := make(chan tea.Msg, 1)
+	go func() {
+		firstResult <- firstDelivery()
+	}()
+	<-control.firstStarted
+
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(" edited")})
+	if testAskInput(model) != "original denial edited" {
+		t.Fatalf("retry commentary = %q, want edited draft", testAskInput(model))
+	}
+	close(control.firstRelease)
+	model = updateUIModel(t, model, <-firstResult)
+	if testPromptAnswerDeliveryActive(model) || testActiveAsk(model) == nil {
+		t.Fatal("denial deadline did not restore the unresolved prompt")
+	}
+	if model.transientStatusKind != uiStatusNoticeError || model.transientStatus == "" {
+		t.Fatalf("denial deadline notice = kind %d text %q, want visible error", model.transientStatusKind, model.transientStatus)
+	}
+
+	next, secondDelivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = runPromptDeliveryCommand(t, next.(*uiModel), secondDelivery)
+	requests := control.requests()
+	if len(requests) != 2 {
+		t.Fatalf("denial requests = %d, want deadline plus user resubmission", len(requests))
+	}
+	if requests[0].Decision != clientui.ApprovalDecisionDeny || requests[1].Decision != clientui.ApprovalDecisionDeny {
+		t.Fatalf("denial decisions = %q then %q, want deny", requests[0].Decision, requests[1].Decision)
+	}
+	if requests[0].Commentary != "original denial" || requests[1].Commentary != "original denial edited" {
+		t.Fatalf("denial commentary = %q then %q, want immutable submission then edited retry", requests[0].Commentary, requests[1].Commentary)
+	}
+	if requests[0].ClientRequestID == requests[1].ClientRequestID {
+		t.Fatalf("denial resubmission reused request ID %q", requests[0].ClientRequestID)
+	}
+	if len(model.pendingInjected) != 0 {
+		t.Fatalf("denial commentary created a queued copy: %+v", model.pendingInjected)
+	}
+	if !testPromptAnswerDeliveryActive(model) || testActiveAsk(model) == nil {
+		t.Fatal("successful denial delivery stopped awaiting canonical resolution")
+	}
+	resolveAnsweredTestAskThroughTranscript(t, model)
+}
+
+func TestDenyCommentaryAutomaticRetriesUseOneRequestIDAndStopAfterSixCalls(t *testing.T) {
+	persistent := errors.New("persistent approval failure")
+	control := &scriptedApprovalPromptControl{results: []error{
+		persistent,
+		persistent,
+		persistent,
+		persistent,
+		persistent,
+		persistent,
+	}}
+	answerer := newTranscriptPromptAnswerer(context.Background(), control)
+	answerer.retryWait = func(context.Context, time.Duration) error { return nil }
+
+	model := newProjectedStaticUIModel()
+	model.promptAnswers = answerer
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testApprovalPrompt(
+			"deny-commentary-exhausted",
+			"Allow access?",
+			clientui.ApprovalDecisionAllowOnce,
+			clientui.ApprovalDecisionDeny,
+		),
+	)})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyDown})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("blocked")})
+
+	next, delivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = runPromptDeliveryCommand(t, next.(*uiModel), delivery)
+	requests := control.requests()
+	if len(requests) != 6 {
+		t.Fatalf("denial requests = %d, want bounded six calls", len(requests))
+	}
+	requestID := requests[0].ClientRequestID
+	for index, request := range requests {
+		if request.ClientRequestID != requestID || request.Decision != clientui.ApprovalDecisionDeny || request.Commentary != "blocked" {
+			t.Fatalf("denial request %d = %+v, want stable immutable request ID %q", index, request, requestID)
+		}
+	}
+	if testPromptAnswerDeliveryActive(model) || testActiveAsk(model) == nil || testAskInput(model) != "blocked" {
+		t.Fatal("denial retry exhaustion did not preserve the actionable commentary draft")
+	}
+	if len(model.pendingInjected) != 0 {
+		t.Fatalf("denial retries created queued commentary: %+v", model.pendingInjected)
+	}
+}
+
+func TestAllowCommentaryQueuesBeforeApprovalRetriesWithOneRequestID(t *testing.T) {
+	control := &scriptedApprovalPromptControl{results: []error{
+		errors.New("retryable approval failure one"),
+		errors.New("retryable approval failure two"),
+		nil,
+	}}
+	answerer := newTranscriptPromptAnswerer(context.Background(), control)
+	answerer.retryWait = func(context.Context, time.Duration) error { return nil }
+	runtimeClient := &runtimeControlFakeClient{queueUserMessageID: "allow-commentary-queue"}
+	model := newProjectedTestUIModel(runtimeClient)
+	model.promptAnswers = answerer
+	model.setRuntimeActivityBusyForTest(true)
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testApprovalPrompt(
+			"allow-commentary-retry",
+			"Allow access?",
+			clientui.ApprovalDecisionAllowOnce,
+			clientui.ApprovalDecisionDeny,
+		),
+	)})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("safe operation")})
+
+	next, queueCommand := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	if queueCommand == nil || !model.ask.answerPending || runtimeClient.queueUserMessageCalls != 0 {
+		t.Fatalf("allow queue stage = command %v pending %t calls %d", queueCommand, model.ask.answerPending, runtimeClient.queueUserMessageCalls)
+	}
+	next, deliveryCommand := model.Update(queueCommand())
+	model = next.(*uiModel)
+	model = runPromptDeliveryCommand(t, model, deliveryCommand)
+
+	if runtimeClient.queueUserMessageCalls != 1 || runtimeClient.queuedText != "safe operation" {
+		t.Fatalf("allow commentary queue = calls %d text %q, want one queue before answer", runtimeClient.queueUserMessageCalls, runtimeClient.queuedText)
+	}
+	requests := control.requests()
+	if len(requests) != 3 {
+		t.Fatalf("allow approval requests = %d, want two retries then success", len(requests))
+	}
+	requestID := requests[0].ClientRequestID
+	for index, request := range requests {
+		if request.ClientRequestID != requestID || request.Decision != clientui.ApprovalDecisionAllowOnce || request.Commentary != "safe operation" {
+			t.Fatalf("allow request %d = %+v, want stable immutable request ID %q", index, request, requestID)
+		}
+	}
+	if !testPromptAnswerDeliveryActive(model) || !model.ask.answerPending {
+		t.Fatal("successful allow delivery stopped awaiting canonical resolution")
+	}
+	resolveAnsweredTestAskThroughTranscript(t, model)
+}
+
+func TestAllowCommentaryAnswerDeadlineRestoresFreshQueueAndAnswerResubmission(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	control := newDeadlineThenSuccessApprovalControl()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runtimeClient := &runtimeControlFakeClient{queueUserMessageID: "allow-commentary-queue"}
+	model := newProjectedTestUIModel(runtimeClient)
+	model.promptAnswers = newTranscriptPromptAnswerer(ctx, control)
+	model.setRuntimeActivityBusyForTest(true)
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testApprovalPrompt(
+			"allow-commentary-deadline",
+			"Allow access?",
+			clientui.ApprovalDecisionAllowOnce,
+			clientui.ApprovalDecisionDeny,
+		),
+	)})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("original allow")})
+
+	next, firstQueueCommand := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	next, firstDelivery := model.Update(firstQueueCommand())
 	model = next.(*uiModel)
 	firstResult := make(chan tea.Msg, 1)
 	go func() {
@@ -615,33 +812,36 @@ func TestApprovalDeadlineKeepsEditedSelectionActionableUntilCanonicalResolution(
 	}()
 	<-control.firstStarted
 
-	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyUp})
-	if testAskCursor(model) != 0 {
-		t.Fatalf("retry selection = %d, want edited allow selection", testAskCursor(model))
-	}
 	close(control.firstRelease)
 	model = updateUIModel(t, model, <-firstResult)
-	if testPromptAnswerDeliveryActive(model) || testActiveAsk(model) == nil {
-		t.Fatal("approval deadline did not restore the unresolved prompt")
+	if testPromptAnswerDeliveryActive(model) || model.ask.answerPending || testActiveAsk(model) == nil {
+		t.Fatal("allow answer deadline did not restore the unresolved prompt")
 	}
 	if model.transientStatusKind != uiStatusNoticeError || model.transientStatus == "" {
-		t.Fatalf("approval deadline notice = kind %d text %q, want visible error", model.transientStatusKind, model.transientStatus)
+		t.Fatalf("allow deadline notice = kind %d text %q, want visible error", model.transientStatusKind, model.transientStatus)
 	}
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(" edited")})
 
-	next, secondDelivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, secondQueueCommand := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	next, secondDelivery := model.Update(secondQueueCommand())
 	model = runPromptDeliveryCommand(t, next.(*uiModel), secondDelivery)
+
 	requests := control.requests()
 	if len(requests) != 2 {
-		t.Fatalf("approval requests = %d, want deadline plus user resubmission", len(requests))
+		t.Fatalf("allow requests = %d, want deadline plus user resubmission", len(requests))
 	}
-	if requests[0].Decision != clientui.ApprovalDecisionDeny || requests[1].Decision != clientui.ApprovalDecisionAllowOnce {
-		t.Fatalf("approval decisions = %q then %q, want immutable deny then edited allow", requests[0].Decision, requests[1].Decision)
+	if requests[0].Commentary != "original allow" || requests[1].Commentary != "original allow edited" {
+		t.Fatalf("allow commentary = %q then %q, want original then edited resubmission", requests[0].Commentary, requests[1].Commentary)
 	}
 	if requests[0].ClientRequestID == requests[1].ClientRequestID {
-		t.Fatalf("approval resubmission reused request ID %q", requests[0].ClientRequestID)
+		t.Fatalf("allow resubmission reused request ID %q", requests[0].ClientRequestID)
 	}
-	if !testPromptAnswerDeliveryActive(model) || testActiveAsk(model) == nil {
-		t.Fatal("successful approval delivery stopped awaiting canonical resolution")
+	if runtimeClient.queueUserMessageCalls != 2 {
+		t.Fatalf("allow commentary queue calls = %d, want one per user submission", runtimeClient.queueUserMessageCalls)
+	}
+	if !testPromptAnswerDeliveryActive(model) || !model.ask.answerPending {
+		t.Fatal("successful allow resubmission stopped awaiting canonical resolution")
 	}
 	resolveAnsweredTestAskThroughTranscript(t, model)
 }

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -616,6 +616,40 @@ func TestAskSessionReplacementCancelsDeliveryAndClearsOldPrompt(t *testing.T) {
 	}
 }
 
+func TestAskResolutionBeforeDeliveryCommandRunsDoesNotCallPromptControl(t *testing.T) {
+	control := &scriptedAskPromptControl{}
+	model := newProjectedStaticUIModel()
+	model.promptAnswers = newTranscriptPromptAnswerer(context.Background(), control)
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testQuestionPrompt("ask-resolved-before-command", "Proceed?", "Yes", "No"),
+	)})
+
+	next, delivery := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	if delivery == nil || !testPromptAnswerDeliveryActive(model) {
+		t.Fatal("submission did not create an active delivery command")
+	}
+	resolveAnsweredTestAskThroughTranscript(t, model)
+	if testActiveAsk(model) != nil || testPromptAnswerDeliveryActive(model) {
+		t.Fatal("canonical resolution did not cancel and remove the prompt")
+	}
+
+	result, ok := delivery().(promptAnswerDeliveryResultMsg)
+	if !ok {
+		t.Fatalf("delivery result = %T, want promptAnswerDeliveryResultMsg", result)
+	}
+	if !errors.Is(result.err, context.Canceled) {
+		t.Fatalf("delivery error = %v, want context canceled", result.err)
+	}
+	if len(control.requests()) != 0 {
+		t.Fatalf("prompt-control calls = %d, want zero after pre-execution resolution", len(control.requests()))
+	}
+	model = updateUIModel(t, model, result)
+	if testActiveAsk(model) != nil || testPromptAnswerDeliveryActive(model) {
+		t.Fatal("stale canceled result restored the resolved prompt")
+	}
+}
+
 func TestDenyCommentaryDeadlineKeepsEditedDraftActionableWithoutQueuedCopy(t *testing.T) {
 	disableTransientStatusClearForTest(t)
 	control := newDeadlineThenSuccessApprovalControl()

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -197,6 +197,9 @@ func TestAskDeadlineKeepsEditedRetryDraftActionableUntilCanonicalResolution(t *t
 	if testActiveAsk(model) == nil {
 		t.Fatal("deadline locally resolved the prompt")
 	}
+	if model.activity != uiActivityQuestion {
+		t.Fatalf("deadline activity = %d, want question", model.activity)
+	}
 	if got := testAskInput(model); got != "original edited" {
 		t.Fatalf("retry draft = %q after deadline, want edited draft preserved", got)
 	}
@@ -553,6 +556,9 @@ func TestAskConnectionExhaustionUsesOnlyGlobalDisconnectNotice(t *testing.T) {
 	}
 	if testPromptAnswerDeliveryActive(model) || testActiveAsk(model) == nil {
 		t.Fatal("connection exhaustion did not restore the unresolved prompt")
+	}
+	if model.activity != uiActivityQuestion {
+		t.Fatalf("connection exhaustion activity = %d, want question", model.activity)
 	}
 	if len(control.requests()) != 6 {
 		t.Fatalf("service calls = %d, want bounded six calls", len(control.requests()))

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -278,6 +278,31 @@ func TestAskRepeatedEnterWhileDeliveryActiveDoesNotSubmitAgain(t *testing.T) {
 	}
 }
 
+func TestAskDeliverySetupFailureKeepsQuestionActivity(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	model, control := newProjectedPromptTestUIModel(t)
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testQuestionPrompt("ask-empty-setup-failure", "Provide details"),
+	)})
+
+	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	if model.activity != uiActivityQuestion || testActiveAsk(model) == nil || testPromptAnswerDeliveryActive(model) {
+		t.Fatalf(
+			"setup failure state = activity %d prompt %v delivery %t, want actionable question",
+			model.activity,
+			testActiveAsk(model) != nil,
+			testPromptAnswerDeliveryActive(model),
+		)
+	}
+	if model.transientStatusKind != uiStatusNoticeError || model.transientStatus == "" {
+		t.Fatalf("setup failure notice = kind %d text %q, want visible error", model.transientStatusKind, model.transientStatus)
+	}
+	if len(control.askRequests) != 0 {
+		t.Fatalf("setup failure recorded %d ask requests, want zero", len(control.askRequests))
+	}
+}
+
 func TestAskRetryThenSuccessKeepsOneRequestIDUntilCanonicalResolution(t *testing.T) {
 	control := &scriptedAskPromptControl{results: []error{
 		errors.New("retryable one"),
@@ -881,6 +906,37 @@ func TestAllowCommentaryQueueUnlocksBeforeCancelableApprovalDelivery(t *testing.
 		t.Fatalf("replacement approval request = %+v, want typed cancellation", requests[1])
 	}
 	resolveAnsweredTestAskThroughTranscript(t, model)
+}
+
+func TestStaleQueuedApprovalCommentaryDoesNotUnlockCurrentPrompt(t *testing.T) {
+	model, _ := newProjectedPromptTestUIModel(t)
+	model = updateUIModel(t, model, askEventMsg{event: model.transcriptPromptEvent(
+		testApprovalPrompt(
+			"approval-current",
+			"Allow current operation?",
+			clientui.ApprovalDecisionAllowOnce,
+			clientui.ApprovalDecisionDeny,
+		),
+	)})
+	model.ask.answerPending = true
+
+	command := model.answerQueuedApprovalCommentary(clientui.PromptAnswer{
+		PromptID: "approval-stale",
+		Approval: &clientui.ApprovalPromptAnswer{
+			Decision:   clientui.ApprovalDecisionAllowOnce,
+			Commentary: "stale commentary",
+		},
+	})
+
+	if command != nil {
+		t.Fatal("stale queued approval commentary created a delivery command")
+	}
+	if !model.ask.answerPending {
+		t.Fatal("stale queued approval commentary unlocked the current prompt queue stage")
+	}
+	if testPromptAnswerDeliveryActive(model) {
+		t.Fatal("stale queued approval commentary created active delivery ownership")
+	}
 }
 
 func TestAllowCommentaryAnswerDeadlineRestoresFreshQueueAndAnswerResubmission(t *testing.T) {

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -514,6 +514,7 @@ func (c uiAskController) applyDeliveryResult(result promptAnswerDeliveryResultMs
 		return nil
 	}
 	c.cancelActiveDelivery()
+	m.activity = uiActivityQuestion
 	if errors.Is(result.err, context.Canceled) || runtimeattach.IsRuntimeConnectionError(result.err) {
 		return nil
 	}

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -513,6 +513,7 @@ func (c uiAskController) applyDeliveryResult(result promptAnswerDeliveryResultMs
 		return nil
 	}
 	c.cancelActiveDelivery()
+	m.ask.answerPending = false
 	if errors.Is(result.err, context.Canceled) || runtimeattach.IsRuntimeConnectionError(result.err) {
 		return nil
 	}

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -444,7 +444,7 @@ func (c uiAskController) answer(resp clientui.PromptAnswer, err error) (bool, bo
 	}
 	active, cmd, deliveryErr := m.promptAnswers.delivery(m.ask.current.prompt, resp, err)
 	if deliveryErr != nil {
-		return true, false, m.sendTransientStatusWithNoticeID(deliveryErr.Error(), uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, "")
+		return true, true, m.sendTransientStatusWithNoticeID(deliveryErr.Error(), uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, "")
 	}
 	m.ask.activeDelivery = active
 	return true, false, cmd
@@ -471,11 +471,11 @@ func (c uiAskController) resolveAnsweredPromptOptimistically() bool {
 }
 
 func (m *uiModel) answerQueuedApprovalCommentary(resp clientui.PromptAnswer) tea.Cmd {
-	m.ask.answerPending = false
 	accepted, hasNext, cmd := m.askController().answer(resp, nil)
 	if !accepted {
 		return nil
 	}
+	m.ask.answerPending = false
 	if hasNext {
 		m.activity = uiActivityQuestion
 	} else {

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+	"core/cli/app/internal/runtimeattach"
 	"core/cli/tui"
 	"core/shared/clientui"
 	"core/shared/textutil"
@@ -56,7 +58,6 @@ func (c uiAskController) acceptEvent(evt askEvent) {
 	incomingPromptID := strings.TrimSpace(string(evt.prompt.PromptID))
 	if incomingPromptID != "" && m.ask.hasCurrent() && strings.TrimSpace(string(m.ask.current.prompt.PromptID)) == incomingPromptID {
 		m.ask.current.prompt = evt.prompt
-		m.ask.answerPending = false
 		return
 	}
 	if !m.ask.hasCurrent() {
@@ -79,7 +80,6 @@ func (c uiAskController) resolvePrompt(promptID string) {
 	filteredQueue := m.ask.queue[:0]
 	for _, queued := range m.ask.queue {
 		if strings.TrimSpace(string(queued.prompt.PromptID)) == targetID {
-			queued.cancelPending()
 			continue
 		}
 		filteredQueue = append(filteredQueue, queued)
@@ -88,7 +88,7 @@ func (c uiAskController) resolvePrompt(promptID string) {
 	if !m.ask.hasCurrent() || strings.TrimSpace(string(m.ask.current.prompt.PromptID)) != targetID {
 		return
 	}
-	m.ask.current.cancelPending()
+	c.cancelActiveDelivery()
 	if len(m.ask.queue) > 0 {
 		next := m.ask.queue[0]
 		m.ask.queue = m.ask.queue[1:]
@@ -159,7 +159,8 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.Type {
 	case tea.KeyCtrlC:
-		_, hasNext := c.answer(clientui.PromptAnswer{}, errors.New("interrupted"))
+		c.cancelActiveDelivery()
+		_, hasNext, answerCmd := c.answer(clientui.PromptAnswer{}, errors.New("interrupted"))
 		interruptCmd := tea.Cmd(nil)
 		if m.blocksRuntimeInput() {
 			_, interruptCmd = m.inputController().handleRuntimeCtrlC(nil)
@@ -169,15 +170,16 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else {
 			m.activity = uiActivityInterrupted
 		}
-		return m, tea.Batch(interruptCmd, m.interruptedStatusNoticeCmd())
+		return m, tea.Batch(answerCmd, interruptCmd, m.interruptedStatusNoticeCmd())
 	case tea.KeyEsc:
-		_, hasNext := c.answer(clientui.PromptAnswer{}, errors.New("question canceled"))
+		c.cancelActiveDelivery()
+		_, hasNext, answerCmd := c.answer(clientui.PromptAnswer{}, errors.New("question canceled"))
 		if hasNext {
 			m.activity = uiActivityQuestion
 		} else {
 			m.activity = uiActivityIdle
 		}
-		return m, nil
+		return m, answerCmd
 	case tea.KeyTab:
 		if m.ask.freeform {
 			if !askSupportsDraftRoundTrip(req) {
@@ -193,6 +195,9 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case tea.KeyEnter:
+		if m.ask.activeDelivery != nil {
+			return m, m.sendTransientStatusWithNoticeID("Answer is already sending", uiStatusNoticeInfo, transientStatusDuration, uiStatusNoticeReplace, "")
+		}
 		m.inputController().normalizePendingCSIShiftEnterOnEnter()
 		if m.ask.freeform {
 			commentary := strings.TrimSpace(m.ask.input)
@@ -222,22 +227,22 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 							return m, queueCmd
 						}
 					}
-					_, hasNext := c.answer(resp, nil)
+					_, hasNext, answerCmd := c.answer(resp, nil)
 					if hasNext {
 						m.activity = uiActivityQuestion
 					} else {
 						m.activity = uiActivityRunning
 					}
-					return m, nil
+					return m, answerCmd
 				}
 			}
-			_, hasNext := c.answer(resp, nil)
+			_, hasNext, answerCmd := c.answer(resp, nil)
 			if hasNext {
 				m.activity = uiActivityQuestion
 			} else {
 				m.activity = uiActivityRunning
 			}
-			return m, nil
+			return m, answerCmd
 		}
 		optionCount := askOptionCount(req)
 		if optionCount == 0 {
@@ -250,13 +255,13 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.ask.freeform = true
 				return m, nil
 			}
-			_, hasNext := c.answer(clientui.PromptAnswer{Answer: commentary, FreeformAnswer: commentary}, nil)
+			_, hasNext, answerCmd := c.answer(clientui.PromptAnswer{Answer: commentary, FreeformAnswer: commentary}, nil)
 			if hasNext {
 				m.activity = uiActivityQuestion
 			} else {
 				m.activity = uiActivityRunning
 			}
-			return m, nil
+			return m, answerCmd
 		}
 		visibleOptions := askVisibleOptions(req)
 		if m.ask.cursor < 0 || m.ask.cursor >= len(visibleOptions) {
@@ -271,13 +276,13 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if transcriptPromptIsApproval(req) && m.ask.cursor < len(req.ApprovalOptions) {
 			resp = clientui.PromptAnswer{Approval: &clientui.ApprovalPromptAnswer{Decision: req.ApprovalOptions[m.ask.cursor]}}
 		}
-		_, hasNext := c.answer(resp, nil)
+		_, hasNext, answerCmd := c.answer(resp, nil)
 		if hasNext {
 			m.activity = uiActivityQuestion
 		} else {
 			m.activity = uiActivityRunning
 		}
-		return m, nil
+		return m, answerCmd
 	case tea.KeyUp:
 		if m.ask.freeform {
 			m.moveAskCursorUpLine()
@@ -419,32 +424,35 @@ func askQuestionPromptTextLines(question string) []askPromptLine {
 	return lines
 }
 
-func (c uiAskController) answer(resp clientui.PromptAnswer, err error) (bool, bool) {
+func (c uiAskController) answer(resp clientui.PromptAnswer, err error) (bool, bool, tea.Cmd) {
 	m := c.model
 	if !m.ask.hasCurrent() {
-		return false, false
+		return false, false, nil
 	}
 	currentPromptID := strings.TrimSpace(string(m.ask.current.prompt.PromptID))
 	answerPromptID := strings.TrimSpace(resp.PromptID)
 	if answerPromptID != "" && answerPromptID != currentPromptID {
-		return false, false
+		return false, false, nil
 	}
-	m.ask.answerPending = true
 	if answerPromptID == "" {
 		resp.PromptID = currentPromptID
 	} else {
 		resp.PromptID = answerPromptID
 	}
-	m.ask.current.reply <- askReply{response: resp, err: err}
-	if m.ask.current.prompt.SessionID.IsZero() || currentPromptID == "" {
-		return true, c.resolveAnsweredPromptOptimistically()
+	if m.promptAnswers == nil || m.ask.current.prompt.SessionID.IsZero() || currentPromptID == "" {
+		return true, c.resolveAnsweredPromptOptimistically(), nil
 	}
-	return true, false
+	active, cmd, deliveryErr := m.promptAnswers.delivery(m.ask.current.prompt, resp, err)
+	if deliveryErr != nil {
+		return true, false, m.sendTransientStatusWithNoticeID(deliveryErr.Error(), uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, "")
+	}
+	m.ask.activeDelivery = active
+	return true, false, cmd
 }
 
 func (c uiAskController) resolveAnsweredPromptOptimistically() bool {
 	m := c.model
-	m.ask.answerPending = false
+	c.cancelActiveDelivery()
 	if len(m.ask.queue) == 0 {
 		m.ask.current = nil
 		m.ask.currentToken = nextNonZeroToken(m.ask.currentToken)
@@ -463,7 +471,7 @@ func (c uiAskController) resolveAnsweredPromptOptimistically() bool {
 }
 
 func (m *uiModel) answerQueuedApprovalCommentary(resp clientui.PromptAnswer) tea.Cmd {
-	accepted, hasNext := m.askController().answer(resp, nil)
+	accepted, hasNext, cmd := m.askController().answer(resp, nil)
 	if !accepted {
 		return nil
 	}
@@ -472,11 +480,12 @@ func (m *uiModel) answerQueuedApprovalCommentary(resp clientui.PromptAnswer) tea
 	} else {
 		m.activity = uiActivityRunning
 	}
-	return nil
+	return cmd
 }
 
 func (c uiAskController) setActiveAsk(evt askEvent) {
 	m := c.model
+	c.cancelActiveDelivery()
 	current := evt
 	m.ask.currentToken = nextNonZeroToken(m.ask.currentToken)
 	m.ask.current = &current
@@ -485,6 +494,29 @@ func (c uiAskController) setActiveAsk(evt askEvent) {
 	m.clearAskInput()
 	m.ask.freeform = askOptionCount(current.prompt) == 0
 	m.ask.freeformMode = askFreeformModeGeneric
+}
+
+func (c uiAskController) cancelActiveDelivery() {
+	if c.model == nil || c.model.ask.activeDelivery == nil {
+		return
+	}
+	c.model.ask.activeDelivery.cancelPending()
+	c.model.ask.activeDelivery = nil
+}
+
+func (c uiAskController) applyDeliveryResult(result promptAnswerDeliveryResultMsg) tea.Cmd {
+	m := c.model
+	if m == nil || !m.ask.activeDelivery.matches(result.key, result.requestID) {
+		return nil
+	}
+	if result.err == nil {
+		return nil
+	}
+	c.cancelActiveDelivery()
+	if errors.Is(result.err, context.Canceled) || runtimeattach.IsRuntimeConnectionError(result.err) {
+		return nil
+	}
+	return m.sendTransientStatusWithNoticeID(result.err.Error(), uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, "")
 }
 
 func askVisibleOptions(req clientui.TranscriptPrompt) []string {

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -471,6 +471,7 @@ func (c uiAskController) resolveAnsweredPromptOptimistically() bool {
 }
 
 func (m *uiModel) answerQueuedApprovalCommentary(resp clientui.PromptAnswer) tea.Cmd {
+	m.ask.answerPending = false
 	accepted, hasNext, cmd := m.askController().answer(resp, nil)
 	if !accepted {
 		return nil
@@ -513,7 +514,6 @@ func (c uiAskController) applyDeliveryResult(result promptAnswerDeliveryResultMs
 		return nil
 	}
 	c.cancelActiveDelivery()
-	m.ask.answerPending = false
 	if errors.Is(result.err, context.Canceled) || runtimeattach.IsRuntimeConnectionError(result.err) {
 		return nil
 	}

--- a/cli/app/ui_ask_deferred_test.go
+++ b/cli/app/ui_ask_deferred_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestAskEventDefersWhileDetailModeActive(t *testing.T) {
-	reply := make(chan askReply, 1)
-	m := newProjectedStaticUIModel()
+	m, control := newProjectedPromptTestUIModel(t)
 	m.terminalGeometry = terminalGeometryKnown(90, 12)
 	m.input = "hidden draft"
 	m.layout().syncViewport()
@@ -20,7 +19,7 @@ func TestAskEventDefersWhileDetailModeActive(t *testing.T) {
 		t.Fatalf("expected detail mode, got %q", m.view.Mode())
 	}
 
-	m = updateUIModel(t, m, askEventMsg{event: testQuestionAskEvent("ask-1", "Proceed?", reply, "Yes", "No")})
+	m = updateUIModel(t, m, askEventMsg{event: testQuestionAskEvent("ask-1", "Proceed?", "Yes", "No")})
 	if got := m.inputMode(); got != uiInputModeMain {
 		t.Fatalf("expected detail mode to defer ask input, got %q", got)
 	}
@@ -32,10 +31,8 @@ func TestAskEventDefersWhileDetailModeActive(t *testing.T) {
 
 	m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyPgUp})
 
-	select {
-	case got := <-reply:
-		t.Fatalf("did not expect ask answered before leaving detail mode: %+v", got)
-	default:
+	if len(control.askRequests) != 0 {
+		t.Fatal("did not expect ask answered before leaving detail mode")
 	}
 
 	m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyShiftTab})
@@ -50,16 +47,16 @@ func TestAskEventDefersWhileDetailModeActive(t *testing.T) {
 		t.Fatalf("expected ask prompt visible after returning to ongoing mode, got %q", view)
 	}
 
-	m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyEnter})
-	resp := <-reply
-	if resp.response.SelectedOptionNumber == nil || *resp.response.SelectedOptionNumber != 1 {
-		t.Fatalf("expected first option selected by default, got %+v", resp.response)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = runPromptDeliveryCommand(t, next.(*uiModel), cmd)
+	request := <-control.askRequests
+	if request.SelectedOptionNumber == nil || *request.SelectedOptionNumber != 1 {
+		t.Fatalf("expected first option selected by default, got %+v", request)
 	}
 }
 
 func TestAskEventDefersWhileProcessListOverlayIsOpen(t *testing.T) {
-	reply := make(chan askReply, 1)
-	m := newProjectedStaticUIModel()
+	m, control := newProjectedPromptTestUIModel(t)
 	m.terminalGeometry = terminalGeometryKnown(100, 14)
 	m.input = "/ps"
 
@@ -68,15 +65,13 @@ func TestAskEventDefersWhileProcessListOverlayIsOpen(t *testing.T) {
 		t.Fatalf("expected process list surface open, visible=%t surface=%q", m.processList.open, m.surface())
 	}
 
-	m = updateUIModel(t, m, askEventMsg{event: testQuestionAskEvent("ask-1", "Pick one", reply, "a", "b")})
+	m = updateUIModel(t, m, askEventMsg{event: testQuestionAskEvent("ask-1", "Pick one", "a", "b")})
 	if got := m.inputMode(); got != uiInputModeProcessList {
 		t.Fatalf("expected process list to keep input focus while ask is pending, got %q", got)
 	}
 
-	select {
-	case got := <-reply:
-		t.Fatalf("did not expect ask answered while process list overlay was open: %+v", got)
-	default:
+	if len(control.askRequests) != 0 {
+		t.Fatal("did not expect ask answered while process list overlay was open")
 	}
 
 	m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyEsc})
@@ -94,10 +89,11 @@ func TestAskEventDefersWhileProcessListOverlayIsOpen(t *testing.T) {
 		t.Fatalf("expected deferred ask prompt visible after closing process list, got %q", view)
 	}
 
-	m = updateUIModel(t, m, tea.KeyMsg{Type: tea.KeyEnter})
-	resp := <-reply
-	if resp.response.SelectedOptionNumber == nil || *resp.response.SelectedOptionNumber != 1 {
-		t.Fatalf("expected first option selected by default, got %+v", resp.response)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = runPromptDeliveryCommand(t, next.(*uiModel), cmd)
+	request := <-control.askRequests
+	if request.SelectedOptionNumber == nil || *request.SelectedOptionNumber != 1 {
+		t.Fatalf("expected first option selected by default, got %+v", request)
 	}
 }
 

--- a/cli/app/ui_ask_deferred_test.go
+++ b/cli/app/ui_ask_deferred_test.go
@@ -49,7 +49,7 @@ func TestAskEventDefersWhileDetailModeActive(t *testing.T) {
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = runPromptDeliveryCommand(t, next.(*uiModel), cmd)
-	request := <-control.askRequests
+	request := requireAskRequest(t, control)
 	if request.SelectedOptionNumber == nil || *request.SelectedOptionNumber != 1 {
 		t.Fatalf("expected first option selected by default, got %+v", request)
 	}
@@ -91,7 +91,7 @@ func TestAskEventDefersWhileProcessListOverlayIsOpen(t *testing.T) {
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = runPromptDeliveryCommand(t, next.(*uiModel), cmd)
-	request := <-control.askRequests
+	request := requireAskRequest(t, control)
 	if request.SelectedOptionNumber == nil || *request.SelectedOptionNumber != 1 {
 		t.Fatalf("expected first option selected by default, got %+v", request)
 	}

--- a/cli/app/ui_clipboard_controller_test.go
+++ b/cli/app/ui_clipboard_controller_test.go
@@ -43,7 +43,6 @@ func setupClipboardTestInput(t *testing.T, m *uiModel, target clipboardTestInput
 		next, _ := m.Update(askEventMsg{event: testQuestionAskEvent(
 			"clipboard-ask",
 			"Provide details",
-			make(chan askReply, 1),
 		)})
 		updated := next.(*uiModel)
 		if !updated.ask.freeform {
@@ -192,7 +191,7 @@ func TestClipboardPasteDoneRejectsStaleTarget(t *testing.T) {
 	t.Run("replaced ask", func(t *testing.T) {
 		m := setupClipboardTestInput(t, newProjectedStaticUIModel(), clipboardTestInputAsk)
 		staleToken := m.ask.currentToken
-		replacement := testQuestionAskEvent("replacement-ask", "Replacement", make(chan askReply, 1))
+		replacement := testQuestionAskEvent("replacement-ask", "Replacement")
 		testSetActiveAsk(m, &replacement)
 		m.ask.freeform = true
 		m.ask.input = "replacement"
@@ -472,7 +471,6 @@ func TestClipboardPasteBindingLeavesNonFreeformAskUnchanged(t *testing.T) {
 	next, _ := m.Update(askEventMsg{event: testQuestionAskEvent(
 		"clipboard-choice",
 		"Choose one",
-		make(chan askReply, 1),
 		"first",
 		"second",
 	)})

--- a/cli/app/ui_event_reducers.go
+++ b/cli/app/ui_event_reducers.go
@@ -14,6 +14,10 @@ func (m *uiModel) reduceAskMessage(msg tea.Msg) uiFeatureUpdateResult {
 		m.askController().acceptEvent(msg.event)
 		m.layout().syncViewport()
 		return handledUIFeatureUpdate(m, nil)
+	case promptAnswerDeliveryResultMsg:
+		cmd := m.askController().applyDeliveryResult(msg)
+		m.layout().syncViewport()
+		return handledUIFeatureUpdate(m, cmd)
 	}
 	return uiFeatureUpdateResult{}
 }

--- a/cli/app/ui_input_mode.go
+++ b/cli/app/ui_input_mode.go
@@ -25,16 +25,17 @@ type uiInteractionState struct {
 }
 
 type uiAskState struct {
-	current       *askEvent
-	currentToken  uint64
-	queue         []askEvent
-	cursor        int
-	freeform      bool
-	freeformMode  askFreeformMode
-	answerPending bool
-	input         string
-	inputCursor   int
-	inputKill     string
+	current        *askEvent
+	currentToken   uint64
+	queue          []askEvent
+	cursor         int
+	freeform       bool
+	freeformMode   askFreeformMode
+	activeDelivery *activePromptAnswerDelivery
+	answerPending  bool
+	input          string
+	inputCursor    int
+	inputKill      string
 }
 
 type uiProcessListState struct {

--- a/cli/app/ui_input_movement_keys_test.go
+++ b/cli/app/ui_input_movement_keys_test.go
@@ -101,8 +101,7 @@ func TestMainComposerPreservesOtherRuneInput(t *testing.T) {
 
 func TestAskFreeformAltRuneWordNavigation(t *testing.T) {
 	model := newProjectedStaticUIModel()
-	reply := make(chan askReply, 1)
-	event := testQuestionAskEvent("ask-1", "Type answer", reply)
+	event := testQuestionAskEvent("ask-1", "Type answer")
 	updated := updateUIModel(t, model, askEventMsg{event: event})
 	updated.ask.input = "alpha beta gamma"
 	updated.ask.inputCursor = len([]rune(updated.ask.input))

--- a/cli/app/ui_loop.go
+++ b/cli/app/ui_loop.go
@@ -147,7 +147,9 @@ func composeUIProgram(request uiLoopRequest, output io.Writer) (*uiProgramCompos
 		}
 		return nil, errors.New("projected UI model has unexpected type")
 	}
-	model.promptAnswers = request.wiring.promptAnswers
+	model.promptAnswers = request.wiring.promptAnswers.withConnectionOutcomeSink(func(err error) {
+		enqueueRuntimeConnectionStateChange(model.runtimeConnectionEvents, err)
+	})
 	model.promptAttention = request.wiring.promptAttention
 	sessionClient, ok := runtimeClient.(*sessionRuntimeClient)
 	if !ok {

--- a/cli/app/ui_messages.go
+++ b/cli/app/ui_messages.go
@@ -227,8 +227,6 @@ type clipboardTextCopyDoneMsg struct {
 
 type askEvent struct {
 	prompt           clientui.TranscriptPrompt
-	reply            chan askReply
-	cancel           func()
 	resolvedPromptID clientui.PromptID
 }
 
@@ -241,17 +239,6 @@ func (e askEvent) promptID() string {
 
 func (e askEvent) isResolution() bool {
 	return strings.TrimSpace(string(e.resolvedPromptID)) != ""
-}
-
-func (e askEvent) cancelPending() {
-	if e.cancel != nil {
-		e.cancel()
-	}
-}
-
-type askReply struct {
-	response clientui.PromptAnswer
-	err      error
 }
 
 type askEventMsg struct {

--- a/cli/app/ui_ongoing_surface_test.go
+++ b/cli/app/ui_ongoing_surface_test.go
@@ -145,7 +145,6 @@ func TestOngoingTranscriptDeliveryKeepsCursorAbsentForAskOptionPicker(t *testing
 	next, _ := m.Update(askEventMsg{event: testQuestionAskEvent(
 		"ask-1",
 		"Choose an option",
-		make(chan askReply, 1),
 		"first",
 		"second",
 	)})

--- a/cli/app/ui_ongoing_transcript_state.go
+++ b/cli/app/ui_ongoing_transcript_state.go
@@ -208,6 +208,7 @@ func (m *uiModel) applyTranscriptSessionIdentity(identity clientui.TranscriptSes
 	if previousSessionID == "" || previousSessionID == nextSessionID {
 		return titleCmd
 	}
+	m.reconcileTranscriptPrompts(nil)
 	rollbackCmd := m.discardRollbackStateForSessionReplacement()
 	cancelCmd := m.cancelPendingDetailTranscriptRequest()
 	m.detailTranscript.reset()
@@ -329,7 +330,6 @@ func (m *uiModel) transcriptPromptEvent(prompt clientui.TranscriptPrompt) askEve
 	}
 	return askEvent{
 		prompt: cloneTranscriptPromptForAsk(prompt),
-		reply:  make(chan askReply, 1),
 	}
 }
 

--- a/cli/app/ui_projected_test_helpers_test.go
+++ b/cli/app/ui_projected_test_helpers_test.go
@@ -101,7 +101,29 @@ func submitAskPromptKey(t *testing.T, model *uiModel, control *recordingPromptCo
 	t.Helper()
 	next, command := model.Update(key)
 	updated := runPromptDeliveryCommand(t, next.(*uiModel), command)
-	return updated, <-control.askRequests
+	return updated, requireAskRequest(t, control)
+}
+
+func requireAskRequest(t *testing.T, control *recordingPromptControl) serverapi.AskAnswerRequest {
+	t.Helper()
+	select {
+	case request := <-control.askRequests:
+		return request
+	default:
+		t.Fatal("completed prompt delivery recorded no ask request")
+		return serverapi.AskAnswerRequest{}
+	}
+}
+
+func requireApprovalRequest(t *testing.T, control *recordingPromptControl) serverapi.ApprovalAnswerRequest {
+	t.Helper()
+	select {
+	case request := <-control.approvalRequests:
+		return request
+	default:
+		t.Fatal("completed prompt delivery recorded no approval request")
+		return serverapi.ApprovalAnswerRequest{}
+	}
 }
 
 func newProjectedEngineUIModel(engine *runtime.Engine, opts ...UIOption) *uiModel {

--- a/cli/app/ui_projected_test_helpers_test.go
+++ b/cli/app/ui_projected_test_helpers_test.go
@@ -12,6 +12,9 @@ import (
 	"core/server/sessionview"
 	"core/shared/apicontract"
 	"core/shared/clientui"
+	"core/shared/serverapi"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func waitForTestCondition(t *testing.T, timeout time.Duration, label string, condition func() bool) {
@@ -52,6 +55,53 @@ func sizedTestUIModel(m *uiModel, width, height int) *uiModel {
 
 func newProjectedStaticUIModel(opts ...UIOption) *uiModel {
 	return newProjectedTestUIModel(nil, opts...)
+}
+
+type recordingPromptControl struct {
+	askRequests      chan serverapi.AskAnswerRequest
+	approvalRequests chan serverapi.ApprovalAnswerRequest
+}
+
+func newRecordingPromptControl() *recordingPromptControl {
+	return &recordingPromptControl{
+		askRequests:      make(chan serverapi.AskAnswerRequest, 8),
+		approvalRequests: make(chan serverapi.ApprovalAnswerRequest, 8),
+	}
+}
+
+func (c *recordingPromptControl) AnswerAsk(_ context.Context, request serverapi.AskAnswerRequest) error {
+	c.askRequests <- request
+	return nil
+}
+
+func (c *recordingPromptControl) AnswerApproval(_ context.Context, request serverapi.ApprovalAnswerRequest) error {
+	c.approvalRequests <- request
+	return nil
+}
+
+func newProjectedPromptTestUIModel(t *testing.T, opts ...UIOption) (*uiModel, *recordingPromptControl) {
+	t.Helper()
+	control := newRecordingPromptControl()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	model := newProjectedStaticUIModel(opts...)
+	model.promptAnswers = newTranscriptPromptAnswerer(ctx, control)
+	return model, control
+}
+
+func runPromptDeliveryCommand(t *testing.T, model *uiModel, command tea.Cmd) *uiModel {
+	t.Helper()
+	if command == nil {
+		t.Fatal("expected prompt delivery command")
+	}
+	return updateUIModel(t, model, command())
+}
+
+func submitAskPromptKey(t *testing.T, model *uiModel, control *recordingPromptControl, key tea.KeyMsg) (*uiModel, serverapi.AskAnswerRequest) {
+	t.Helper()
+	next, command := model.Update(key)
+	updated := runPromptDeliveryCommand(t, next.(*uiModel), command)
+	return updated, <-control.askRequests
 }
 
 func newProjectedEngineUIModel(engine *runtime.Engine, opts ...UIOption) *uiModel {
@@ -122,15 +172,15 @@ func testApprovalPrompt(id, question string, decisions ...clientui.ApprovalDecis
 	}
 }
 
-func testQuestionAskEvent(id, question string, reply chan askReply, suggestions ...string) askEvent {
-	return askEvent{prompt: testQuestionPrompt(id, question, suggestions...), reply: reply}
+func testQuestionAskEvent(id, question string, suggestions ...string) askEvent {
+	return askEvent{prompt: testQuestionPrompt(id, question, suggestions...)}
 }
 
 func testQuestionAskEventPtr(id, question string, suggestions ...string) *askEvent {
-	event := testQuestionAskEvent(id, question, nil, suggestions...)
+	event := testQuestionAskEvent(id, question, suggestions...)
 	return &event
 }
 
-func testApprovalAskEvent(id, question string, reply chan askReply, decisions ...clientui.ApprovalDecision) askEvent {
-	return askEvent{prompt: testApprovalPrompt(id, question, decisions...), reply: reply}
+func testApprovalAskEvent(id, question string, decisions ...clientui.ApprovalDecision) askEvent {
+	return askEvent{prompt: testApprovalPrompt(id, question, decisions...)}
 }

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -39,7 +39,7 @@ type uiRuntimeFeatureState struct {
 	worktreeClient        apicontract.WorktreeService
 
 	pathReferenceEvents        <-chan uiPathReferenceSearchEvent
-	runtimeConnectionEvents    <-chan runtimeConnectionStateChangedMsg
+	runtimeConnectionEvents    chan runtimeConnectionStateChangedMsg
 	runtimeReconnectWarning    <-chan runtimeReconnectWarningMsg
 	runtimeContextUsage        clientui.RuntimeContextUsage
 	runtimeContextUsageSession string

--- a/cli/app/ui_state_test_helpers_test.go
+++ b/cli/app/ui_state_test_helpers_test.go
@@ -60,7 +60,7 @@ func resolveAnsweredTestAskThroughTranscript(t *testing.T, m *uiModel) {
 	if active == nil {
 		t.Fatal("answered ask was resolved before the canonical transcript resolution")
 	}
-	if !m.ask.answerPending {
+	if m.ask.activeDelivery == nil && !m.ask.answerPending {
 		t.Fatal("answered ask is not awaiting the canonical transcript resolution")
 	}
 	resolved := cloneTranscriptPromptForAsk(active.prompt)

--- a/cli/app/ui_state_test_helpers_test.go
+++ b/cli/app/ui_state_test_helpers_test.go
@@ -60,7 +60,7 @@ func resolveAnsweredTestAskThroughTranscript(t *testing.T, m *uiModel) {
 	if active == nil {
 		t.Fatal("answered ask was resolved before the canonical transcript resolution")
 	}
-	if m.ask.activeDelivery == nil && !m.ask.answerPending {
+	if m.ask.activeDelivery == nil {
 		t.Fatal("answered ask is not awaiting the canonical transcript resolution")
 	}
 	resolved := cloneTranscriptPromptForAsk(active.prompt)

--- a/cli/app/ui_terminal_cursor_test.go
+++ b/cli/app/ui_terminal_cursor_test.go
@@ -324,8 +324,7 @@ func TestInputCursorsUseSharedFieldDisplayWidth(t *testing.T) {
 			model := newProjectedStaticUIModel(WithUITerminalCursorState(state))
 			model.terminalGeometry = terminalGeometryKnown(12, 10)
 			if test.ask {
-				reply := make(chan askReply, 1)
-				event := testQuestionAskEvent("ask-1", "Question?", reply)
+				event := testQuestionAskEvent("ask-1", "Question?")
 				testSetActiveAsk(model, &event)
 				model.ask.input = "ab👍cd"
 				model.ask.inputCursor = 3

--- a/cli/app/ui_test.go
+++ b/cli/app/ui_test.go
@@ -522,7 +522,7 @@ func TestApprovalAskUsesSingleDenyOptionAndTabCommentary(t *testing.T) {
 		t.Fatal("deny commentary did not create a direct approval delivery command")
 	}
 	updated = runPromptDeliveryCommand(t, updated, cmd)
-	request := <-control.approvalRequests
+	request := requireApprovalRequest(t, control)
 	if request.Decision != clientui.ApprovalDecisionDeny || request.Commentary != "blocked by policy" {
 		t.Fatalf("unexpected approval request: %+v", request)
 	}

--- a/cli/app/ui_test.go
+++ b/cli/app/ui_test.go
@@ -4,7 +4,6 @@ import (
 	"core/cli/tui"
 	"core/cli/tui/transcriptrender"
 	tuitest "core/internal/testharness/pty"
-	"core/server/runtime"
 	"core/shared/clientui"
 	goruntime "runtime"
 	"strings"
@@ -176,9 +175,8 @@ func TestParseUserShellCommand(t *testing.T) {
 }
 
 func TestAskQuestionTabFreeformFlow(t *testing.T) {
-	m := newProjectedStaticUIModel()
-	reply := make(chan askReply, 1)
-	event := testQuestionAskEvent("ask-1", "Pick one", reply, "a", "b")
+	m, control := newProjectedPromptTestUIModel(t)
+	event := testQuestionAskEvent("ask-1", "Pick one", "a", "b")
 
 	next, _ := m.Update(askEventMsg{event: event})
 	updated := next.(*uiModel)
@@ -200,18 +198,15 @@ func TestAskQuestionTabFreeformFlow(t *testing.T) {
 
 	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("custom")})
 	updated = next.(*uiModel)
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated = next.(*uiModel)
-
-	resp := <-reply
-	if resp.response.Answer != "custom" {
-		t.Fatalf("unexpected answer: %q", resp.response.Answer)
+	updated, request := submitAskPromptKey(t, updated, control, tea.KeyMsg{Type: tea.KeyEnter})
+	if request.Answer != "custom" {
+		t.Fatalf("unexpected answer: %q", request.Answer)
 	}
-	if resp.response.FreeformAnswer != "custom" {
-		t.Fatalf("unexpected freeform answer: %q", resp.response.FreeformAnswer)
+	if request.FreeformAnswer != "custom" {
+		t.Fatalf("unexpected freeform answer: %q", request.FreeformAnswer)
 	}
-	if resp.response.SelectedOptionNumber == nil || *resp.response.SelectedOptionNumber != 1 {
-		t.Fatalf("expected selected option 1 preserved when switching to freeform, got %+v", resp.response)
+	if request.SelectedOptionNumber == nil || *request.SelectedOptionNumber != 1 {
+		t.Fatalf("expected selected option 1 preserved when switching to freeform, got %+v", request)
 	}
 	resolveAnsweredTestAskThroughTranscript(t, updated)
 	if testActiveAsk(updated) != nil {
@@ -220,9 +215,8 @@ func TestAskQuestionTabFreeformFlow(t *testing.T) {
 }
 
 func TestAskQuestionPickerSubmitPreservesPendingFreeformDraft(t *testing.T) {
-	m := newProjectedStaticUIModel()
-	reply := make(chan askReply, 1)
-	event := testQuestionAskEvent("ask-1", "Pick one", reply, "a", "b")
+	m, control := newProjectedPromptTestUIModel(t)
+	event := testQuestionAskEvent("ask-1", "Pick one", "a", "b")
 
 	next, _ := m.Update(askEventMsg{event: event})
 	updated := next.(*uiModel)
@@ -259,18 +253,15 @@ func TestAskQuestionPickerSubmitPreservesPendingFreeformDraft(t *testing.T) {
 
 	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyDown})
 	updated = next.(*uiModel)
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated = next.(*uiModel)
-
-	resp := <-reply
-	if resp.response.SelectedOptionNumber == nil || *resp.response.SelectedOptionNumber != 2 {
-		t.Fatalf("expected selected option number 2, got %+v", resp.response)
+	updated, request := submitAskPromptKey(t, updated, control, tea.KeyMsg{Type: tea.KeyEnter})
+	if request.SelectedOptionNumber == nil || *request.SelectedOptionNumber != 2 {
+		t.Fatalf("expected selected option number 2, got %+v", request)
 	}
-	if resp.response.Answer != "" {
-		t.Fatalf("expected structured picker response without raw answer text, got %+v", resp.response)
+	if request.Answer != "" {
+		t.Fatalf("expected structured picker response without raw answer text, got %+v", request)
 	}
-	if resp.response.FreeformAnswer != "custom" {
-		t.Fatalf("expected pending freeform draft submitted with picker answer, got %+v", resp.response)
+	if request.FreeformAnswer != "custom" {
+		t.Fatalf("expected pending freeform draft submitted with picker answer, got %+v", request)
 	}
 	resolveAnsweredTestAskThroughTranscript(t, updated)
 	if testActiveAsk(updated) != nil {
@@ -279,9 +270,8 @@ func TestAskQuestionPickerSubmitPreservesPendingFreeformDraft(t *testing.T) {
 }
 
 func TestAskQuestionTabRoundTripRestoresPendingFreeformDraftAndCursor(t *testing.T) {
-	m := newProjectedStaticUIModel()
-	reply := make(chan askReply, 1)
-	event := testQuestionAskEvent("ask-1", "Pick one", reply, "a", "b")
+	m, control := newProjectedPromptTestUIModel(t)
+	event := testQuestionAskEvent("ask-1", "Pick one", "a", "b")
 
 	next, _ := m.Update(askEventMsg{event: event})
 	updated := next.(*uiModel)
@@ -314,15 +304,12 @@ func TestAskQuestionTabRoundTripRestoresPendingFreeformDraftAndCursor(t *testing
 
 	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("X")})
 	updated = next.(*uiModel)
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated = next.(*uiModel)
-
-	resp := <-reply
-	if resp.response.SelectedOptionNumber == nil || *resp.response.SelectedOptionNumber != 2 {
-		t.Fatalf("expected selected option number 2 after round-trip, got %+v", resp.response)
+	updated, request := submitAskPromptKey(t, updated, control, tea.KeyMsg{Type: tea.KeyEnter})
+	if request.SelectedOptionNumber == nil || *request.SelectedOptionNumber != 2 {
+		t.Fatalf("expected selected option number 2 after round-trip, got %+v", request)
 	}
-	if resp.response.FreeformAnswer != "custoXm" {
-		t.Fatalf("expected restored draft to remain editable, got %+v", resp.response)
+	if request.FreeformAnswer != "custoXm" {
+		t.Fatalf("expected restored draft to remain editable, got %+v", request)
 	}
 	resolveAnsweredTestAskThroughTranscript(t, updated)
 	if testActiveAsk(updated) != nil {
@@ -332,8 +319,7 @@ func TestAskQuestionTabRoundTripRestoresPendingFreeformDraftAndCursor(t *testing
 
 func TestAskQuestionFreeformSelectionEnterDropsIntoFreeformWhenEmpty(t *testing.T) {
 	m := newProjectedStaticUIModel()
-	reply := make(chan askReply, 1)
-	event := testQuestionAskEvent("ask-1", "Pick one", reply, "a", "b")
+	event := testQuestionAskEvent("ask-1", "Pick one", "a", "b")
 
 	next, _ := m.Update(askEventMsg{event: event})
 	updated := next.(*uiModel)
@@ -356,17 +342,11 @@ func TestAskQuestionFreeformSelectionEnterDropsIntoFreeformWhenEmpty(t *testing.
 	if testActiveAsk(updated) == nil {
 		t.Fatal("expected ask to remain active after switching to freeform")
 	}
-	select {
-	case resp := <-reply:
-		t.Fatalf("did not expect reply while opening freeform, got %+v", resp)
-	default:
-	}
 }
 
 func TestAskQuestionFreeformSelectionEmptySubmitRequiresCommentary(t *testing.T) {
-	m := newProjectedStaticUIModel()
-	reply := make(chan askReply, 1)
-	event := testQuestionAskEvent("ask-1", "Pick one", reply, "a", "b")
+	m, control := newProjectedPromptTestUIModel(t)
+	event := testQuestionAskEvent("ask-1", "Pick one", "a", "b")
 
 	next, _ := m.Update(askEventMsg{event: event})
 	updated := next.(*uiModel)
@@ -392,16 +372,15 @@ func TestAskQuestionFreeformSelectionEmptySubmitRequiresCommentary(t *testing.T)
 		t.Fatal("expected ask to remain active after validation error")
 	}
 	select {
-	case resp := <-reply:
-		t.Fatalf("did not expect reply on validation error, got %+v", resp)
+	case request := <-control.askRequests:
+		t.Fatalf("did not expect request on validation error, got %+v", request)
 	default:
 	}
 }
 
 func TestAskQuestionFreeformSelectionSubmitsFreeformOnly(t *testing.T) {
-	m := newProjectedStaticUIModel()
-	reply := make(chan askReply, 1)
-	event := testQuestionAskEvent("ask-1", "Pick one", reply, "a", "b")
+	m, control := newProjectedPromptTestUIModel(t)
+	event := testQuestionAskEvent("ask-1", "Pick one", "a", "b")
 
 	next, _ := m.Update(askEventMsg{event: event})
 	updated := next.(*uiModel)
@@ -413,15 +392,12 @@ func TestAskQuestionFreeformSelectionSubmitsFreeformOnly(t *testing.T) {
 	updated = next.(*uiModel)
 	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("custom")})
 	updated = next.(*uiModel)
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated = next.(*uiModel)
-
-	resp := <-reply
-	if resp.response.SelectedOptionNumber != nil {
-		t.Fatalf("expected freeform selection to submit without selected option number, got %+v", resp.response)
+	updated, request := submitAskPromptKey(t, updated, control, tea.KeyMsg{Type: tea.KeyEnter})
+	if request.SelectedOptionNumber != nil {
+		t.Fatalf("expected freeform selection to submit without selected option number, got %+v", request)
 	}
-	if resp.response.Answer != "custom" || resp.response.FreeformAnswer != "custom" {
-		t.Fatalf("unexpected freeform selection response: %+v", resp.response)
+	if request.Answer != "custom" || request.FreeformAnswer != "custom" {
+		t.Fatalf("unexpected freeform selection response: %+v", request)
 	}
 	resolveAnsweredTestAskThroughTranscript(t, updated)
 	if testActiveAsk(updated) != nil {
@@ -430,9 +406,8 @@ func TestAskQuestionFreeformSelectionSubmitsFreeformOnly(t *testing.T) {
 }
 
 func TestAskFreeformUsesMainEditingStack(t *testing.T) {
-	m := newProjectedStaticUIModel()
-	reply := make(chan askReply, 1)
-	event := testQuestionAskEvent("ask-1", "Type answer", reply)
+	m, control := newProjectedPromptTestUIModel(t)
+	event := testQuestionAskEvent("ask-1", "Type answer")
 
 	next, _ := m.Update(askEventMsg{event: event})
 	updated := next.(*uiModel)
@@ -456,12 +431,9 @@ func TestAskFreeformUsesMainEditingStack(t *testing.T) {
 	updated = next.(*uiModel)
 	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyBackspace})
 	updated = next.(*uiModel)
-	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	updated = next.(*uiModel)
-
-	resp := <-reply
-	if resp.response.Answer != ">hello _worl" {
-		t.Fatalf("unexpected inline edit result: %q", resp.response.Answer)
+	updated, request := submitAskPromptKey(t, updated, control, tea.KeyMsg{Type: tea.KeyEnter})
+	if request.Answer != ">hello _worl" {
+		t.Fatalf("unexpected inline edit result: %q", request.Answer)
 	}
 	resolveAnsweredTestAskThroughTranscript(t, updated)
 	if testActiveAsk(updated) != nil {
@@ -471,8 +443,7 @@ func TestAskFreeformUsesMainEditingStack(t *testing.T) {
 
 func TestAskFreeformCtrlUEditingMatchesMainInput(t *testing.T) {
 	m := newProjectedStaticUIModel()
-	reply := make(chan askReply, 1)
-	event := testQuestionAskEvent("ask-1", "Type answer", reply)
+	event := testQuestionAskEvent("ask-1", "Type answer")
 
 	next, _ := m.Update(askEventMsg{event: event})
 	updated := next.(*uiModel)
@@ -500,14 +471,11 @@ func TestAskFreeformCtrlUEditingMatchesMainInput(t *testing.T) {
 }
 
 func TestApprovalAskUsesSingleDenyOptionAndTabCommentary(t *testing.T) {
-	_, eng := newAppRuntimeEngine(t, statusLineFakeClient{}, runtime.Config{ContextWindowTokens: 400_000})
-	m := newProjectedEngineUIModel(eng)
+	m, control := newProjectedPromptTestUIModel(t)
 	m.setRuntimeActivityBusyForTest(true)
-	reply := make(chan askReply, 1)
 	event := testApprovalAskEvent(
 		"approval-1",
 		"Approve?",
-		reply,
 		clientui.ApprovalDecisionAllowOnce,
 		clientui.ApprovalDecisionAllowSession,
 		clientui.ApprovalDecisionDeny,
@@ -546,26 +514,17 @@ func TestApprovalAskUsesSingleDenyOptionAndTabCommentary(t *testing.T) {
 	if len(promptLines) != 2 || promptLines[0].Kind != askPromptLineKindHint || promptLines[1].Kind != askPromptLineKindInput {
 		t.Fatalf("expected commentary prompt to collapse to hint+input, got %+v", promptLines)
 	}
-	select {
-	case <-reply:
-		t.Fatal("did not expect answer submission before commentary")
-	default:
-	}
-
 	next, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("blocked by policy")})
 	updated = next.(*uiModel)
 	next, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
-	if cmd != nil {
-		t.Fatal("deny commentary must not create a queued user-message command")
+	if cmd == nil {
+		t.Fatal("deny commentary did not create a direct approval delivery command")
 	}
-
-	resp := <-reply
-	if resp.response.Approval == nil {
-		t.Fatal("expected typed approval response")
-	}
-	if resp.response.Approval.Decision != clientui.ApprovalDecisionDeny || resp.response.Approval.Commentary != "blocked by policy" {
-		t.Fatalf("unexpected approval response: %+v", resp.response.Approval)
+	updated = runPromptDeliveryCommand(t, updated, cmd)
+	request := <-control.approvalRequests
+	if request.Decision != clientui.ApprovalDecisionDeny || request.Commentary != "blocked by policy" {
+		t.Fatalf("unexpected approval request: %+v", request)
 	}
 	if len(updated.pendingInjected) != 0 {
 		t.Fatalf("deny commentary created a duplicate queued user message: %+v", updated.pendingInjected)
@@ -663,7 +622,7 @@ func TestAskQuestionMarkdownPromptCursorTracksInputAfterExpandedQuestion(t *test
 	m := newProjectedStaticUIModel()
 	m.terminalGeometry = terminalGeometryKnown(72, 12)
 	m.layout().syncViewport()
-	event := testQuestionAskEvent("ask-1", question, make(chan askReply, 1))
+	event := testQuestionAskEvent("ask-1", question)
 	testSetActiveAsk(m, &event)
 	m.ask.input = "typed"
 	m.ask.inputCursor = len([]rune(m.ask.input))
@@ -712,7 +671,6 @@ func TestAskQuestionMarkdownLinksWrapIntoIndependentBoundedRows(t *testing.T) {
 			event := testQuestionAskEvent(
 				"ask-1",
 				"[PR #456](https://github.com/org/repo/pull/456)",
-				make(chan askReply, 1),
 			)
 			testSetActiveAsk(m, &event)
 			m.ask.input = "answer"
@@ -746,7 +704,7 @@ func TestAskQuestionMarkdownLinksWrapIntoIndependentBoundedRows(t *testing.T) {
 
 func TestAskQuestionPlainPRReferenceDoesNotCreateHyperlink(t *testing.T) {
 	m := newProjectedStaticUIModel()
-	event := testQuestionAskEvent("ask-1", "PR #456", make(chan askReply, 1))
+	event := testQuestionAskEvent("ask-1", "PR #456")
 	testSetActiveAsk(m, &event)
 
 	wrapped, _ := m.layout().wrappedAskPromptLines(12)
@@ -767,7 +725,6 @@ func TestAskQuestionViewportPrioritizesAnswerOptionsOverQuestionLines(t *testing
 	event := testQuestionAskEvent(
 		"ask-1",
 		strings.Repeat("Long **Markdown question** content. ", 8),
-		make(chan askReply, 1),
 		"First",
 		"Second",
 	)

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -114,7 +114,7 @@
 - Selecting freeform with empty input opens freeform editing; submitting from that path still requires non-empty commentary.
 - Returning to picker preserves a pending freeform draft as muted text.
 - Internal approval asks show only `Allow once`, `Allow for this session`, and `Deny`.
-- Internal approval commentary is injected through regular queued user-message steering; denial fails the guarded tool call authoritatively.
+- Internal approval commentary follows the selected decision: denial commentary accompanies only the typed approval answer, while allow commentary is queued as a regular user message before the approval answer. The allow queue and approval answer are separate operations; if the queue succeeds but its response is lost, a later submission can queue the commentary again. Denial fails the guarded tool call authoritatively.
 - Freeform ask input uses the same editor/cursor behavior as main input.
 - Source origin is not labeled in UI.
 - Answers are persisted as explicit summary text including selected option number and commentary.

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -118,7 +118,7 @@
 - Freeform ask input uses the same editor/cursor behavior as main input.
 - Source origin is not labeled in UI.
 - Answers are persisted as explicit summary text including selected option number and commentary.
-- Ask queue semantics are strict FIFO, in-memory only, and submitted answers are not editable.
+- Ask queue semantics are strict FIFO and in-memory only. Each submission snapshots an immutable answer payload. During delivery, the visible editor may hold a separate editable retry draft; changes apply only to a future submission after delivery fails, and canonical prompt resolution discards the draft.
 - Optional post-answer action binding uses typed registry with stable ID, payload schema, and handler.
 
 ## Sessions And Persistence

--- a/docs/dev/specs/ongoing-scrollback-buffer.md
+++ b/docs/dev/specs/ongoing-scrollback-buffer.md
@@ -47,7 +47,7 @@
   - The last received event sequence number: one integer.
   - The active assistant stream: source text, its stream/step identity, its rendered rows, and the promotion boundary within them.
   - Mutable-band frame state: pending tool-call rows, spinner/animation state, input field, status line.
-  - One temporary active prompt-answer delivery, including the immutable submitted answer and cancellation ownership. The visible prompt editor remains operator-owned draft state and may diverge from that submitted answer for a future retry.
+  - One temporary active prompt-answer delivery, including the immutable submitted answer and cancellation ownership. The visible prompt editor remains operator-owned draft state and may diverge from that submitted answer for a future retry. Approval commentary queued before an allow answer belongs to the operator-input queue; denial commentary does not enter that queue.
   - The arrival-order queue of received-but-unrendered typed events, used only while the surface does not own the normal buffer, plus its rehydration-required marker after overflow.
   - Operator-owned UI-local state: input draft, editor cursor state, and prompt history capped at the 100 most recent entries. Prompt history must never grow unbounded; entries beyond the cap are discarded oldest-first.
   - The group register: the group kind of the most recently promoted row. One enum value.

--- a/docs/dev/specs/ongoing-scrollback-buffer.md
+++ b/docs/dev/specs/ongoing-scrollback-buffer.md
@@ -47,6 +47,7 @@
   - The last received event sequence number: one integer.
   - The active assistant stream: source text, its stream/step identity, its rendered rows, and the promotion boundary within them.
   - Mutable-band frame state: pending tool-call rows, spinner/animation state, input field, status line.
+  - One temporary active prompt-answer delivery, including the immutable submitted answer and cancellation ownership. The visible prompt editor remains operator-owned draft state and may diverge from that submitted answer for a future retry.
   - The arrival-order queue of received-but-unrendered typed events, used only while the surface does not own the normal buffer, plus its rehydration-required marker after overflow.
   - Operator-owned UI-local state: input draft, editor cursor state, and prompt history capped at the 100 most recent entries. Prompt history must never grow unbounded; entries beyond the cap are discarded oldest-first.
   - The group register: the group kind of the most recently promoted row. One enum value.

--- a/docs/dev/specs/tui-ask-prompts.md
+++ b/docs/dev/specs/tui-ask-prompts.md
@@ -12,7 +12,7 @@ Bullets marked (owner: …) restate decisions owned by another spec for one-plac
 - The active question is Markdown-rendered and wraps within the live region. Answer options take viewport priority; question lines use the remaining capacity and follow the live region's existing collapse/truncation behavior. Pure freeform prompts retain the existing cursor-anchored viewport behavior.
 - Prompts queue FIFO: one active at a time; answering (or external resolution) activates the next. A prompt resolved from another attached client disappears here too — including from the queue. Updates to the active prompt (same prompt ID) refresh it in place. (multi-client consistency owner: terminology :: Equal Full-Control Attach)
 - Bell rings when a new prompt is shown; notification text is owned by tui-transcript :: Notifications.
-- Submitting an answer snapshots an immutable payload and never freezes input. The visible editor remains responsive and holds a separate editable retry draft; edits, cursor movement, option navigation, `Tab`, and paste affect only a future submission after delivery fails.
+- Submitting an answer snapshots an immutable payload. During answer delivery, the visible editor remains responsive and holds a separate editable retry draft; edits, cursor movement, option navigation, `Tab`, and paste affect only a future submission after delivery fails. Allow commentary has a preceding queued-input stage that temporarily locks the prompt until that queue operation finishes.
 - Repeated `Enter` during delivery does not submit another answer and surfaces a brief nonblocking sending notice. A terminal delivery failure keeps the prompt, selection, and retry draft actionable. A new submission snapshots that draft as a new payload. Canonical prompt resolution discards the draft.
 - Answer delivery retries non-terminal failures with finite exponential backoff while preserving one submission identity. A deadline is terminal immediately and returns the prompt to an actionable state; it is not retried automatically.
 - After the last prompt resolves, focus returns to the main composer and activity returns to running/idle.
@@ -22,7 +22,7 @@ Bullets marked (owner: …) restate decisions owned by another spec for one-plac
 
 - **Question with options**: numbered options plus an appended "Freeform answer" option. A recommended option is marked (star + recommended suffix) and the selection marker is distinct from the recommendation marker. Exact glyphs are presentation, not contract.
 - **Pure freeform question** (no options): goes straight to text entry.
-- **Approval prompt**: options carry typed approval decisions; no freeform-selection option; optional commentary attaches to the chosen decision. Approval answers submitted while the runtime is busy travel through the queued-input path, not a side channel.
+- **Approval prompt**: options carry typed approval decisions; no freeform-selection option; optional commentary attaches to the chosen decision. Denial commentary travels only with the approval answer; allow commentary is queued before the approval answer. (owner: core-runtime-tools :: Ask Question)
 
 ## Keys
 

--- a/docs/dev/specs/tui-ask-prompts.md
+++ b/docs/dev/specs/tui-ask-prompts.md
@@ -12,7 +12,10 @@ Bullets marked (owner: …) restate decisions owned by another spec for one-plac
 - The active question is Markdown-rendered and wraps within the live region. Answer options take viewport priority; question lines use the remaining capacity and follow the live region's existing collapse/truncation behavior. Pure freeform prompts retain the existing cursor-anchored viewport behavior.
 - Prompts queue FIFO: one active at a time; answering (or external resolution) activates the next. A prompt resolved from another attached client disappears here too — including from the queue. Updates to the active prompt (same prompt ID) refresh it in place. (multi-client consistency owner: terminology :: Equal Full-Control Attach)
 - Bell rings when a new prompt is shown; notification text is owned by tui-transcript :: Notifications.
-- Submitting an answer never freezes input: the UI stays responsive throughout answer delivery. After the last prompt resolves, focus returns to the main composer and activity returns to running/idle.
+- Submitting an answer snapshots an immutable payload and never freezes input. The visible editor remains responsive and holds a separate editable retry draft; edits, cursor movement, option navigation, `Tab`, and paste affect only a future submission after delivery fails.
+- Repeated `Enter` during delivery does not submit another answer and surfaces a brief nonblocking sending notice. A terminal delivery failure keeps the prompt, selection, and retry draft actionable. A new submission snapshots that draft as a new payload. Canonical prompt resolution discards the draft.
+- Answer delivery retries non-terminal failures with finite exponential backoff while preserving one submission identity. A deadline is terminal immediately and returns the prompt to an actionable state; it is not retried automatically.
+- After the last prompt resolves, focus returns to the main composer and activity returns to running/idle.
 - The status-line spinner pauses while a prompt waits. (owner: tui-status-line :: Activity Indicator)
 
 ## Prompt Kinds
@@ -27,9 +30,5 @@ Bullets marked (owner: …) restate decisions owned by another spec for one-plac
 - `Tab` toggles between the option picker and freeform text entry; for approvals, freeform is commentary for the currently selected decision. Toggling back preserves the typed draft (non-approval prompts), shown dimmed under the options.
 - Freeform entry uses the shared editing key set (owner: tui-chat-core :: Editing Model) and supports the shared clipboard-paste contract (owner: tui-chat-core :: Clipboard Paste).
 - Choosing the "Freeform answer" option with empty text enters freeform mode; submitting it with empty text is rejected with an error notice + bell.
-- `Esc` cancels the prompt (the agent receives a typed cancellation); `Ctrl+C` cancels it AND routes to global runtime Ctrl+C handling (interrupt while busy).
+- `Esc` cancels any active answer delivery, then cancels the prompt (the agent receives a typed cancellation); `Ctrl+C` cancels any active answer delivery and the prompt, then routes to global runtime Ctrl+C handling (interrupt while busy).
 - There is no digit-jump on prompt options.
-
-## Known Drift (Go TUI, frozen)
-
-- Go freezes prompt input while an answer is in flight (`answerPending`); spec is never-frozen input.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -30,7 +30,7 @@ Environment:
   KENT_TEST_TIMEOUT_SECONDS
             Server test wall-clock cap in seconds. Defaults to 120.
   KENT_TEST_GO_PACKAGE_PARALLELISM
-            Maximum Go test packages to execute concurrently. Defaults to 8.
+            Maximum Go test packages to execute concurrently. Defaults to 4.
   KENT_TEST_TUI_TIMEOUT_SECONDS
             TUI test wall-clock cap in seconds. Defaults to 600.
   -h, --help
@@ -117,7 +117,7 @@ case "$disable_wall_clock_cap" in
 esac
 
 timeout_seconds="${KENT_TEST_TIMEOUT_SECONDS:-120}"
-go_test_package_parallelism="${KENT_TEST_GO_PACKAGE_PARALLELISM:-8}"
+go_test_package_parallelism="${KENT_TEST_GO_PACKAGE_PARALLELISM:-4}"
 tui_timeout_seconds="${KENT_TEST_TUI_TIMEOUT_SECONDS:-600}"
 inside_tui_wall_clock_cap="${KENT_TEST_INSIDE_TUI_WALL_CLOCK_CAP:-0}"
 case "$go_test_package_parallelism" in

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -30,7 +30,7 @@ Environment:
   KENT_TEST_TIMEOUT_SECONDS
             Server test wall-clock cap in seconds. Defaults to 120.
   KENT_TEST_GO_PACKAGE_PARALLELISM
-            Maximum Go test packages to execute concurrently. Defaults to 4.
+            Maximum Go test packages to execute concurrently. Defaults to 8.
   KENT_TEST_TUI_TIMEOUT_SECONDS
             TUI test wall-clock cap in seconds. Defaults to 600.
   -h, --help
@@ -117,7 +117,7 @@ case "$disable_wall_clock_cap" in
 esac
 
 timeout_seconds="${KENT_TEST_TIMEOUT_SECONDS:-120}"
-go_test_package_parallelism="${KENT_TEST_GO_PACKAGE_PARALLELISM:-4}"
+go_test_package_parallelism="${KENT_TEST_GO_PACKAGE_PARALLELISM:-8}"
 tui_timeout_seconds="${KENT_TEST_TUI_TIMEOUT_SECONDS:-600}"
 inside_tui_wall_clock_cap="${KENT_TEST_INSIDE_TUI_WALL_CLOCK_CAP:-0}"
 case "$go_test_package_parallelism" in

--- a/server/runtime/compaction_executor.go
+++ b/server/runtime/compaction_executor.go
@@ -8,6 +8,7 @@ import (
 
 	"core/server/llm"
 	"core/server/session"
+	"core/shared/rpcwire"
 	"core/shared/textutil"
 	"core/shared/transcript"
 )
@@ -158,7 +159,7 @@ func (e *Engine) compactWithRetry(ctx context.Context, stepID string, client llm
 		if i == len(delays) {
 			break
 		}
-		if err := waitForRetryDelay(ctx, delays[i]); err != nil {
+		if err := rpcwire.WaitForRetry(ctx, delays[i]); err != nil {
 			return llm.CompactionResponse{}, err
 		}
 	}

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -16,6 +16,7 @@ import (
 	"core/server/workflowruntime"
 	"core/shared/clientui"
 	"core/shared/config"
+	"core/shared/rpcwire"
 	"core/shared/runtimeids"
 	"core/shared/toolspec"
 	"core/shared/transcript"
@@ -988,7 +989,7 @@ func (e *Engine) generateWithRetryClient(ctx context.Context, stepID string, cli
 		if i >= len(delays) {
 			break
 		}
-		if err := waitForRetryDelay(ctx, delays[i]); err != nil {
+		if err := rpcwire.WaitForRetry(ctx, delays[i]); err != nil {
 			return llm.Response{}, err
 		}
 	}

--- a/server/runtime/retry.go
+++ b/server/runtime/retry.go
@@ -1,29 +1,9 @@
 package runtime
 
 import (
-	"context"
 	"time"
 )
 
 var generateRetryDelays = []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second, 16 * time.Second}
 var idleStallRetryDelays = []time.Duration{1 * time.Second}
 var compactionRetryDelays = []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second}
-
-func waitForRetryDelay(ctx context.Context, delay time.Duration) error {
-	if delay <= 0 {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			return nil
-		}
-	}
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
-}

--- a/shared/rpcwire/retry.go
+++ b/shared/rpcwire/retry.go
@@ -1,0 +1,20 @@
+package rpcwire
+
+import (
+	"context"
+	"time"
+)
+
+func WaitForRetry(ctx context.Context, delay time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	timer := time.NewTimer(max(delay, 0))
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary

- Replace prompt-owned answer workers and reply channels with stateless Bubble Tea delivery commands carrying immutable prompt/answer snapshots.
- Treat `context.DeadlineExceeded` as terminal and actionable, while other retryable failures use bounded 1s/2s/4s/8s/16s backoff with one stable UUID-v4 request ID.
- Route every RPC outcome through the existing global runtime-connection reducer; preserve canonical server-owned prompt resolution and stale-result isolation.
- Preserve editable retry drafts and responsive ask input during answer delivery, suppress duplicate Enter submissions, and keep question activity/status aligned after terminal or setup failures.
- Lock approval commentary behavior: Deny is answer-only with no queued copy; Allow queues commentary before the approval answer, releases the queue-stage lock only after prompt-identity validation, then starts cancelable answer delivery.

## Verification

- `./scripts/test.sh ./cli/app ./server/promptcontrol ./server/registry ./shared/rpcwire ./server/runtime` — pass after rebase.
- `./scripts/test.sh ./cli/app` — pass after the latest review fixes.
- `./scripts/test.sh tui server` — pass after the latest review fixes using the repository default four-package parallelism.
- `./scripts/build.sh --output ./bin/kent` — pass after the latest review fixes.
- `git diff --check origin/main...HEAD` — pass.
- Prior QA also passed focused ask/approval deadline, bounded retry, connection-state, cancellation, refresh, stale-result, session-replacement, idempotency, prompt interaction, and PTY fixture coverage. An isolated `scripts/tui-qa.sh --client ./bin/kent --server ./bin/kent ...` smoke passed.

Evidence instruments: `scripts/test.sh`, `scripts/tui-qa.sh`, and `internal/testharness/pty/README.md`. The acceptance checklist is retained in the Kent KENT-269 workflow plan.

## Diff size

Compared with the PR merge base:

- Production code: **+299 / -136**, net **+163**, gross **435 LoC**.
- Test/generated code: **+1312 / -132**, net **+1180**, gross **1444 LoC**.
- Documentation/specs: **+9 / -9**, net **0**, gross **18 LoC**.
- Total: **+1620 / -277**, net **+1343**, gross **1897 LoC**.

## Caveats and follow-ups

- Allow commentary queueing and approval answering remain separate operations. If the queue commits but its response is lost, a fresh user submission may repeat commentary. Kent task **KENT-282** tracks an authoritative retry-safe transaction and removal of the remaining queue-stage input freeze.
- The interactive PTY harness cannot inject prompt-control deadline/retry outcomes into a live black-box flow; product-boundary tests provide deterministic evidence for those paths.
- The first post-rebase full-suite attempt reached the 120-second wall-clock cap under transient load; all reported packages passed, and an immediate unchanged rerun completed successfully in 35.0s.
- A compliance reviewer proposed redesigning the pre-existing prompt-answer wire union and bumping protocol version. The User rejected that as unrelated KENT-269 scope expansion, so this PR preserves the existing wire contract.

## Tracking

- Kent task: **KENT-269 — Recover prompt answer timeouts**
- Follow-up: **KENT-282 — Make approval commentary retry-safe**
- No separate GitHub issue is associated with this task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt answers now submit asynchronously, keeping the editor responsive during delivery and retries.
  * Edited drafts remain available after temporary failures, while submitted answers stay consistent across retries.
  * Esc and Ctrl+C can cancel active answer delivery.
  * Approval and denial commentary follow clearer queueing and submission behavior.

* **Bug Fixes**
  * Prevented duplicate submissions when Enter is pressed while an answer is sending.
  * Added bounded, cancellation-aware retries with clearer connection and delivery error feedback.
  * Improved prompt cleanup when sessions change or prompts resolve.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->