### PR TITLE
Read session goals without requiring a live runtime

### DIFF
--- a/cli/app/ui_runtime_client_control.go
+++ b/cli/app/ui_runtime_client_control.go
@@ -105,7 +105,7 @@ func (c *sessionRuntimeClient) ShowGoal() (*clientui.RuntimeGoal, error) {
 	if err != nil {
 		return nil, err
 	}
-	return c.applyGoalResponse(resp), nil
+	return runtimeGoalFromAPI(resp.Goal), nil
 }
 
 func (c *sessionRuntimeClient) SetGoal(objective string) (*clientui.RuntimeGoal, error) {
@@ -172,7 +172,6 @@ func runtimeGoalFromAPI(goal *serverapi.RuntimeGoal) *clientui.RuntimeGoal {
 		ID:        goal.ID,
 		Objective: goal.Objective,
 		Status:    clientui.RuntimeGoalStatus(strings.TrimSpace(goal.Status)),
-		Suspended: goal.Suspended,
 	}
 }
 

--- a/cli/app/ui_runtime_client_part2_test.go
+++ b/cli/app/ui_runtime_client_part2_test.go
@@ -237,14 +237,74 @@ func (c *reconnectRetryRuntimeControlClient) ClearGoal(context.Context, serverap
 	return c.clearGoalResp, nil
 }
 
-func TestRuntimeClientGoalMethodsPatchCachedMainView(t *testing.T) {
-	showGoal := &serverapi.RuntimeGoal{ID: "goal-show", Objective: "show goal", Status: "paused", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+func TestRuntimeClientShowGoalDoesNotOverwriteAcceptedPendingGoal(t *testing.T) {
+	pending := &serverapi.RuntimeGoal{ID: "goal-pending", Objective: "accepted pending goal", Status: "active"}
+	committed := &serverapi.RuntimeGoal{ID: "goal-committed", Objective: "prior committed goal", Status: "paused"}
+	controls := &reconnectRetryRuntimeControlClient{
+		setGoalResp:  serverapi.RuntimeGoalShowResponse{Goal: pending},
+		showGoalResp: serverapi.RuntimeGoalShowResponse{Goal: committed},
+	}
+	runtimeClient := newTestSessionRuntimeClientWithControls(controls)
+
+	accepted, err := runtimeClient.SetGoal(pending.Objective)
+	if err != nil {
+		t.Fatalf("SetGoal: %v", err)
+	}
+	assertRuntimeClientGoalCached(t, runtimeClient, accepted, runtimeGoalFromAPI(pending))
+
+	shown, err := runtimeClient.ShowGoal()
+	if err != nil {
+		t.Fatalf("ShowGoal: %v", err)
+	}
+	if !reflect.DeepEqual(shown, runtimeGoalFromAPI(committed)) {
+		t.Fatalf("shown goal = %+v, want committed goal %+v", shown, committed)
+	}
+	view, ok := runtimeClient.CachedMainView()
+	if !ok {
+		t.Fatal("expected cached main view")
+	}
+	if !reflect.DeepEqual(view.Status.Goal, runtimeGoalFromAPI(pending)) {
+		t.Fatalf("cached goal = %+v, want accepted pending goal %+v", view.Status.Goal, pending)
+	}
+}
+
+func TestRuntimeClientShowGoalPreservesSuspendedLiveStatus(t *testing.T) {
+	committed := &serverapi.RuntimeGoal{ID: "goal-committed", Objective: "committed goal", Status: "active"}
+	controls := &reconnectRetryRuntimeControlClient{showGoalResp: serverapi.RuntimeGoalShowResponse{Goal: committed}}
+	runtimeClient := newTestSessionRuntimeClientWithControls(controls)
+	liveGoal := &clientui.RuntimeGoal{
+		ID:        committed.ID,
+		Objective: committed.Objective,
+		Status:    clientui.RuntimeGoalStatusActive,
+		Suspended: true,
+	}
+	runtimeClient.storeMainView(clientui.RuntimeMainView{
+		Session: clientui.RuntimeSessionView{SessionID: "session-1"},
+		Status:  clientui.RuntimeStatus{Goal: liveGoal},
+	})
+
+	shown, err := runtimeClient.ShowGoal()
+	if err != nil {
+		t.Fatalf("ShowGoal: %v", err)
+	}
+	if !reflect.DeepEqual(shown, runtimeGoalFromAPI(committed)) {
+		t.Fatalf("shown goal = %+v, want committed goal %+v", shown, committed)
+	}
+	view, ok := runtimeClient.CachedMainView()
+	if !ok {
+		t.Fatal("expected cached main view")
+	}
+	if !reflect.DeepEqual(view.Status.Goal, liveGoal) {
+		t.Fatalf("cached goal = %+v, want suspended live goal %+v", view.Status.Goal, liveGoal)
+	}
+}
+
+func TestRuntimeClientGoalMutationMethodsPatchCachedMainView(t *testing.T) {
 	setGoal := &serverapi.RuntimeGoal{ID: "goal-set", Objective: "set goal", Status: "active", CreatedAt: time.Now(), UpdatedAt: time.Now()}
 	pauseGoal := &serverapi.RuntimeGoal{ID: "goal-pause", Objective: "pause goal", Status: "paused", CreatedAt: time.Now(), UpdatedAt: time.Now()}
 	resumeGoal := &serverapi.RuntimeGoal{ID: "goal-resume", Objective: "resume goal", Status: "active", CreatedAt: time.Now(), UpdatedAt: time.Now()}
 	completeGoal := &serverapi.RuntimeGoal{ID: "goal-complete", Objective: "complete goal", Status: "complete", CreatedAt: time.Now(), UpdatedAt: time.Now()}
 	controls := &reconnectRetryRuntimeControlClient{
-		showGoalResp:     serverapi.RuntimeGoalShowResponse{Goal: showGoal},
 		setGoalResp:      serverapi.RuntimeGoalShowResponse{Goal: setGoal},
 		pauseGoalResp:    serverapi.RuntimeGoalShowResponse{Goal: pauseGoal},
 		resumeGoalResp:   serverapi.RuntimeGoalShowResponse{Goal: resumeGoal},
@@ -255,13 +315,6 @@ func TestRuntimeClientGoalMethodsPatchCachedMainView(t *testing.T) {
 	reactivator := newRuntimeReactivator()
 	reactivator.SetReactivateFunc(func(context.Context) error { return nil })
 	runtimeClient.SetRuntimeReactivator(reactivator)
-
-	goal, err := runtimeClient.ShowGoal()
-	if err != nil {
-		t.Fatalf("ShowGoal: %v", err)
-	}
-	assertRuntimeClientGoalCached(t, runtimeClient, goal, runtimeGoalFromAPI(showGoal))
-	assertRuntimeGoalConversionDropsAPITimestamps(t, goal, showGoal)
 
 	for _, tt := range []struct {
 		name string
@@ -280,6 +333,9 @@ func TestRuntimeClientGoalMethodsPatchCachedMainView(t *testing.T) {
 				t.Fatalf("%s goal: %v", tt.name, err)
 			}
 			assertRuntimeClientGoalCached(t, runtimeClient, goal, runtimeGoalFromAPI(tt.want))
+			if tt.want != nil {
+				assertRuntimeGoalConversionDropsAPITimestamps(t, goal, tt.want)
+			}
 		})
 	}
 }
@@ -426,7 +482,7 @@ func assertRuntimeGoalConversionDropsAPITimestamps(t *testing.T, got *clientui.R
 	if source == nil || source.CreatedAt.IsZero() || source.UpdatedAt.IsZero() {
 		t.Fatal("test source goal must include timestamps")
 	}
-	if got == nil || got.ID != source.ID || got.Objective != source.Objective || string(got.Status) != source.Status || got.Suspended != source.Suspended {
+	if got == nil || got.ID != source.ID || got.Objective != source.Objective || string(got.Status) != source.Status {
 		t.Fatalf("converted goal = %+v, source = %+v", got, source)
 	}
 }

--- a/cli/kent/goal_command.go
+++ b/cli/kent/goal_command.go
@@ -19,6 +19,17 @@ import (
 
 const goalCommandTimeout = 5 * time.Second
 
+type goalRuntimeUnavailablePresentationError struct {
+	SessionID string
+}
+
+func (e goalRuntimeUnavailablePresentationError) Error() string {
+	return fmt.Sprintf(
+		"No session is currently running under that goal, and updating it without an active run can make the model confused. Please start session %s.",
+		e.SessionID,
+	)
+}
+
 type goalCommandRemote interface {
 	ShowGoal(context.Context, serverapi.RuntimeGoalShowRequest) (serverapi.RuntimeGoalShowResponse, error)
 	SetGoal(context.Context, serverapi.RuntimeGoalSetRequest) (serverapi.RuntimeGoalShowResponse, error)
@@ -99,7 +110,7 @@ func goalShowSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		defer cancel()
 		resp, err := remote.ShowGoal(ctx, serverapi.RuntimeGoalShowRequest{SessionID: target})
 		if err != nil {
-			fmt.Fprintln(stderr, formatGoalCommandError(err))
+			fmt.Fprintln(stderr, err)
 			return 1
 		}
 		if *jsonOut {
@@ -137,7 +148,7 @@ func goalSetSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		defer cancel()
 		resp, err := remote.SetGoal(ctx, serverapi.RuntimeGoalSetRequest{ClientRequestID: uuid.NewString(), SessionID: target, Objective: objective, Actor: actor, RunID: runID, StepID: stepID})
 		if err != nil {
-			fmt.Fprintln(stderr, formatGoalCommandError(err))
+			fmt.Fprintln(stderr, goalMutationCommandError(target, err))
 			return 1
 		}
 		writeGoalShowText(stdout, resp.Goal)
@@ -182,7 +193,7 @@ func goalStatusSubcommand(action string, args []string, stdout io.Writer, stderr
 			resp, callErr = remote.ResumeGoal(ctx, req)
 		}
 		if callErr != nil {
-			fmt.Fprintln(stderr, formatGoalCommandError(callErr))
+			fmt.Fprintln(stderr, goalMutationCommandError(target, callErr))
 			return 1
 		}
 		writeGoalShowText(stdout, resp.Goal)
@@ -211,7 +222,7 @@ func goalCompleteSubcommand(args []string, stdout io.Writer, stderr io.Writer) i
 		current, err := remote.ShowGoal(showCtx, serverapi.RuntimeGoalShowRequest{SessionID: target})
 		showCancel()
 		if err != nil {
-			fmt.Fprintln(stderr, formatGoalCommandError(err))
+			fmt.Fprintln(stderr, err)
 			return 1
 		}
 		if goalAlreadyComplete(current.Goal) {
@@ -236,7 +247,7 @@ func goalCompleteSubcommand(args []string, stdout io.Writer, stderr io.Writer) i
 		defer completeCancel()
 		resp, err := remote.CompleteGoal(completeCtx, serverapi.RuntimeGoalStatusRequest{ClientRequestID: uuid.NewString(), SessionID: target, Actor: actor, RunID: runID, StepID: stepID})
 		if err != nil {
-			fmt.Fprintln(stderr, formatGoalCommandError(err))
+			fmt.Fprintln(stderr, goalMutationCommandError(target, err))
 			return 1
 		}
 		writeGoalShowText(stdout, resp.Goal)
@@ -271,7 +282,7 @@ func goalClearSubcommand(args []string, stdout io.Writer, stderr io.Writer) int 
 		ctx, cancel := context.WithTimeout(context.Background(), goalCommandTimeout)
 		defer cancel()
 		if _, err := remote.ClearGoal(ctx, serverapi.RuntimeGoalClearRequest{ClientRequestID: uuid.NewString(), SessionID: target, Actor: "user"}); err != nil {
-			fmt.Fprintln(stderr, formatGoalCommandError(err))
+			fmt.Fprintln(stderr, goalMutationCommandError(target, err))
 			return 1
 		}
 		fmt.Fprintln(stdout, "Goal cleared")
@@ -319,9 +330,9 @@ func writeGoalShowText(stdout io.Writer, goal *serverapi.RuntimeGoal) {
 	fmt.Fprintf(stdout, "Goal: %s\nStatus: %s\n", goal.Objective, goal.Status)
 }
 
-func formatGoalCommandError(err error) string {
+func goalMutationCommandError(sessionID string, err error) error {
 	if errors.Is(err, serverapi.ErrRuntimeUnavailable) {
-		return "live-runtime-unavailable: " + err.Error()
+		return goalRuntimeUnavailablePresentationError{SessionID: strings.TrimSpace(sessionID)}
 	}
-	return err.Error()
+	return err
 }

--- a/cli/kent/goal_command_test.go
+++ b/cli/kent/goal_command_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -28,9 +29,16 @@ import (
 type recordingGoalRemote struct {
 	showReq          []serverapi.RuntimeGoalShowRequest
 	setReq           []serverapi.RuntimeGoalSetRequest
+	pauseReq         []serverapi.RuntimeGoalStatusRequest
+	resumeReq        []serverapi.RuntimeGoalStatusRequest
 	completeReq      []serverapi.RuntimeGoalStatusRequest
+	clearReq         []serverapi.RuntimeGoalClearRequest
 	goal             *serverapi.RuntimeGoal
 	setErr           error
+	pauseErr         error
+	resumeErr        error
+	completeErr      error
+	clearErr         error
 	showDeadline     time.Time
 	completeDeadline time.Time
 }
@@ -53,12 +61,14 @@ func (r *recordingGoalRemote) SetGoal(_ context.Context, req serverapi.RuntimeGo
 	return serverapi.RuntimeGoalShowResponse{Goal: r.goal}, nil
 }
 
-func (r *recordingGoalRemote) PauseGoal(context.Context, serverapi.RuntimeGoalStatusRequest) (serverapi.RuntimeGoalShowResponse, error) {
-	return serverapi.RuntimeGoalShowResponse{}, nil
+func (r *recordingGoalRemote) PauseGoal(_ context.Context, req serverapi.RuntimeGoalStatusRequest) (serverapi.RuntimeGoalShowResponse, error) {
+	r.pauseReq = append(r.pauseReq, req)
+	return serverapi.RuntimeGoalShowResponse{}, r.pauseErr
 }
 
-func (r *recordingGoalRemote) ResumeGoal(context.Context, serverapi.RuntimeGoalStatusRequest) (serverapi.RuntimeGoalShowResponse, error) {
-	return serverapi.RuntimeGoalShowResponse{}, nil
+func (r *recordingGoalRemote) ResumeGoal(_ context.Context, req serverapi.RuntimeGoalStatusRequest) (serverapi.RuntimeGoalShowResponse, error) {
+	r.resumeReq = append(r.resumeReq, req)
+	return serverapi.RuntimeGoalShowResponse{}, r.resumeErr
 }
 
 func (r *recordingGoalRemote) CompleteGoal(ctx context.Context, req serverapi.RuntimeGoalStatusRequest) (serverapi.RuntimeGoalShowResponse, error) {
@@ -66,11 +76,115 @@ func (r *recordingGoalRemote) CompleteGoal(ctx context.Context, req serverapi.Ru
 	if deadline, ok := ctx.Deadline(); ok {
 		r.completeDeadline = deadline
 	}
+	if r.completeErr != nil {
+		return serverapi.RuntimeGoalShowResponse{}, r.completeErr
+	}
 	return serverapi.RuntimeGoalShowResponse{Goal: r.goal}, nil
 }
 
-func (r *recordingGoalRemote) ClearGoal(context.Context, serverapi.RuntimeGoalClearRequest) (serverapi.RuntimeGoalShowResponse, error) {
-	return serverapi.RuntimeGoalShowResponse{}, nil
+func (r *recordingGoalRemote) ClearGoal(_ context.Context, req serverapi.RuntimeGoalClearRequest) (serverapi.RuntimeGoalShowResponse, error) {
+	r.clearReq = append(r.clearReq, req)
+	return serverapi.RuntimeGoalShowResponse{}, r.clearErr
+}
+
+func TestGoalMutationRuntimeUnavailableMapsToTypedPresentationError(t *testing.T) {
+	const sessionID = "cc948e1e-17e5-4213-87d5-4793ebe18a55"
+	transportErr := errors.Join(serverapi.ErrRuntimeUnavailable, errors.New("transport detail that must not be rendered"))
+
+	err := goalMutationCommandError(sessionID, transportErr)
+	var presentationErr goalRuntimeUnavailablePresentationError
+	if !errors.As(err, &presentationErr) {
+		t.Fatalf("goalMutationCommandError type = %T, want goalRuntimeUnavailablePresentationError", err)
+	}
+	if presentationErr.SessionID != sessionID {
+		t.Fatalf("presentation session id = %q, want %q", presentationErr.SessionID, sessionID)
+	}
+	if errors.Is(err, transportErr) {
+		t.Fatal("presentation error must discard the joined transport error")
+	}
+	ordinaryErr := errors.New("ordinary mutation failure")
+	if got := goalMutationCommandError(sessionID, ordinaryErr); got != ordinaryErr {
+		t.Fatalf("ordinary error = %v, want original error identity", got)
+	}
+}
+
+func TestGoalRuntimeBackedMutationsPresentRuntimeUnavailableForResolvedSession(t *testing.T) {
+	t.Setenv(sessionenv.SessionIDEnv, "")
+	const sessionID = "cc948e1e-17e5-4213-87d5-4793ebe18a55"
+	runtimeErr := errors.Join(serverapi.ErrRuntimeUnavailable, errors.New("joined transport detail"))
+	tests := []struct {
+		name       string
+		args       []string
+		goalStatus string
+		configure  func(*recordingGoalRemote)
+		callCount  func(*recordingGoalRemote) int
+	}{
+		{
+			name:      "set",
+			args:      []string{"set", "--session", sessionID, "replacement goal"},
+			configure: func(remote *recordingGoalRemote) { remote.setErr = runtimeErr },
+			callCount: func(remote *recordingGoalRemote) int { return len(remote.setReq) },
+		},
+		{
+			name:      "pause",
+			args:      []string{"pause", "--session", sessionID},
+			configure: func(remote *recordingGoalRemote) { remote.pauseErr = runtimeErr },
+			callCount: func(remote *recordingGoalRemote) int { return len(remote.pauseReq) },
+		},
+		{
+			name:      "resume",
+			args:      []string{"resume", "--session", sessionID},
+			configure: func(remote *recordingGoalRemote) { remote.resumeErr = runtimeErr },
+			callCount: func(remote *recordingGoalRemote) int { return len(remote.resumeReq) },
+		},
+		{
+			name:       "complete active",
+			args:       []string{"complete", "--session", sessionID},
+			goalStatus: string(session.GoalStatusActive),
+			configure:  func(remote *recordingGoalRemote) { remote.completeErr = runtimeErr },
+			callCount:  func(remote *recordingGoalRemote) int { return len(remote.completeReq) },
+		},
+		{
+			name:       "complete paused",
+			args:       []string{"complete", "--session", sessionID},
+			goalStatus: string(session.GoalStatusPaused),
+			configure:  func(remote *recordingGoalRemote) { remote.completeErr = runtimeErr },
+			callCount:  func(remote *recordingGoalRemote) int { return len(remote.completeReq) },
+		},
+		{
+			name:      "clear",
+			args:      []string{"clear", "--session", sessionID},
+			configure: func(remote *recordingGoalRemote) { remote.clearErr = runtimeErr },
+			callCount: func(remote *recordingGoalRemote) int { return len(remote.clearReq) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			remote := &recordingGoalRemote{}
+			if tt.goalStatus != "" {
+				remote.goal = &serverapi.RuntimeGoal{ID: "goal-1", Objective: "dormant goal", Status: tt.goalStatus}
+			}
+			tt.configure(remote)
+			restore := replaceGoalCommandRemoteOpener(t, remote)
+			defer restore()
+
+			stdout := new(strings.Builder)
+			stderr := new(strings.Builder)
+			if code := goalSubcommand(tt.args, stdout, stderr); code != 1 {
+				t.Fatalf("goal mutation exit = %d, want 1", code)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+			if strings.TrimSpace(stderr.String()) == "" {
+				t.Fatal("stderr is empty, want presentation error")
+			}
+			if got := tt.callCount(remote); got != 1 {
+				t.Fatalf("mutation RPC calls = %d, want 1", got)
+			}
+		})
+	}
 }
 
 func TestGoalShowUsesSessionIDEnv(t *testing.T) {
@@ -218,7 +332,10 @@ func TestGoalCompleteAlreadyCompletePrintsAlreadyCompletePrompt(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(sessionenv.SessionIDEnv, "session-1")
-			remote := &recordingGoalRemote{goal: &serverapi.RuntimeGoal{ID: "goal-1", Objective: "ship goal mode", Status: "complete"}}
+			remote := &recordingGoalRemote{
+				goal:        &serverapi.RuntimeGoal{ID: "goal-1", Objective: "ship goal mode", Status: "complete"},
+				completeErr: errors.Join(serverapi.ErrRuntimeUnavailable, errors.New("dormant runtime")),
+			}
 			restore := replaceGoalCommandRemoteOpener(t, remote)
 			defer restore()
 
@@ -262,7 +379,7 @@ func TestGoalCompleteUsesFreshTimeoutForCompletionRPC(t *testing.T) {
 	}
 }
 
-func TestGoalCommandSubprocessTargetsLiveSessionFromUnboundWorktree(t *testing.T) {
+func TestGoalCommandSubprocessReadsDormantAndMutatesLiveSessionFromUnboundWorktree(t *testing.T) {
 	kentPath := filepath.Join(t.TempDir(), "kent")
 	buildCmd := exec.Command("go", "build", "-o", kentPath, ".")
 	if output, err := buildCmd.CombinedOutput(); err != nil {
@@ -313,6 +430,57 @@ func TestGoalCommandSubprocessTargetsLiveSessionFromUnboundWorktree(t *testing.T
 
 	cleanup := startBindingCommandServer(t, unboundWorktree)
 	defer cleanup()
+	t.Setenv(sessionenv.SessionIDEnv, store.Meta().SessionID)
+
+	assertGoalCommandSubprocessShow := func(want *session.GoalState) {
+		t.Helper()
+		showOutput, showErr := runGoalCommandSubprocess(t, kentPath, unboundWorktree, store.Meta().SessionID, "show", "--json")
+		if showErr != "" {
+			t.Fatalf("goal show stderr = %q", showErr)
+		}
+		var show serverapi.RuntimeGoalShowResponse
+		if err := json.Unmarshal([]byte(showOutput), &show); err != nil {
+			t.Fatalf("decode show json: %v output=%q", err, showOutput)
+		}
+		if show.Goal == nil ||
+			show.Goal.ID != want.ID ||
+			show.Goal.Status != string(want.Status) ||
+			show.Goal.Objective != want.Objective ||
+			!show.Goal.CreatedAt.Equal(want.CreatedAt) ||
+			!show.Goal.UpdatedAt.Equal(want.UpdatedAt) {
+			t.Fatalf("show goal = %+v, want %+v", show.Goal, want)
+		}
+		var payload struct {
+			Goal map[string]json.RawMessage `json:"goal"`
+		}
+		if err := json.Unmarshal([]byte(showOutput), &payload); err != nil {
+			t.Fatalf("decode show shape: %v output=%q", err, showOutput)
+		}
+		if _, exists := payload.Goal["suspended"]; exists {
+			t.Fatalf("goal show JSON unexpectedly contains runtime-local suspension: %q", showOutput)
+		}
+	}
+
+	assertGoalCommandSubprocessShow(record.Meta.Goal)
+
+	dormantOutput, dormantErr, dormantRunErr := runGoalCommandSubprocessRaw(t, kentPath, unboundWorktree, store.Meta().SessionID, "set", "replacement dormant goal CLI")
+	if dormantRunErr == nil {
+		t.Fatal("dormant goal mutation unexpectedly succeeded")
+	}
+	if dormantOutput != "" {
+		t.Fatalf("dormant goal mutation stdout = %q, want empty", dormantOutput)
+	}
+	if got := nonEmptyLineCount(t, dormantErr); got != 1 {
+		t.Fatalf("dormant goal mutation stderr lines = %d, want 1", got)
+	}
+	record, err = metadataStore.ResolvePersistedSession(context.Background(), store.Meta().SessionID)
+	if err != nil {
+		t.Fatalf("ResolvePersistedSession after dormant mutation: %v", err)
+	}
+	if goal := record.Meta.Goal; goal == nil || goal.Objective != "exercise live goal CLI" || goal.Status != session.GoalStatusActive {
+		t.Fatalf("persisted goal after dormant mutation = %+v", goal)
+	}
+
 	remote, err := client.DialConfiguredRemoteForProjectWorkspace(context.Background(), cfg, binding.ProjectID, cfg.WorkspaceRoot)
 	if err != nil {
 		t.Fatalf("DialConfiguredRemoteForProjectWorkspace: %v", err)
@@ -330,25 +498,7 @@ func TestGoalCommandSubprocessTargetsLiveSessionFromUnboundWorktree(t *testing.T
 	}); err != nil {
 		t.Fatalf("ActivateSessionRuntime: %v", err)
 	}
-	defer func() {
-		_, _ = remote.ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
-			ClientRequestID: "release-goal-cli-e2e",
-			SessionID:       store.Meta().SessionID,
-		})
-	}()
-
-	t.Setenv(sessionenv.SessionIDEnv, store.Meta().SessionID)
-	showOutput, showErr := runGoalCommandSubprocess(t, kentPath, unboundWorktree, store.Meta().SessionID, "show", "--json")
-	if showErr != "" {
-		t.Fatalf("goal show stderr = %q", showErr)
-	}
-	var show serverapi.RuntimeGoalShowResponse
-	if err := json.Unmarshal([]byte(showOutput), &show); err != nil {
-		t.Fatalf("decode show json: %v output=%q", err, showOutput)
-	}
-	if show.Goal == nil || show.Goal.Status != "active" || show.Goal.Objective != "exercise live goal CLI" {
-		t.Fatalf("show goal = %+v", show.Goal)
-	}
+	assertGoalCommandSubprocessShow(record.Meta.Goal)
 
 	overwriteOutput, overwriteErr, overwriteRunErr := runGoalCommandSubprocessRaw(t, kentPath, unboundWorktree, store.Meta().SessionID, "set", "replacement live goal CLI")
 	if overwriteRunErr == nil {
@@ -387,6 +537,28 @@ func TestGoalCommandSubprocessTargetsLiveSessionFromUnboundWorktree(t *testing.T
 	if goal := record.Meta.Goal; goal == nil || goal.Objective != "exercise live goal CLI" || goal.Status != session.GoalStatusComplete {
 		t.Fatalf("persisted goal after complete = %+v", goal)
 	}
+	if _, err := remote.ReleaseSessionRuntime(context.Background(), serverapi.SessionRuntimeReleaseRequest{
+		ClientRequestID: "release-goal-cli-e2e",
+		SessionID:       store.Meta().SessionID,
+	}); err != nil {
+		t.Fatalf("ReleaseSessionRuntime: %v", err)
+	}
+	assertGoalCommandSubprocessShow(record.Meta.Goal)
+}
+
+func nonEmptyLineCount(t *testing.T, text string) int {
+	t.Helper()
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	count := 0
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) != "" {
+			count++
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan process output lines: %v", err)
+	}
+	return count
 }
 
 func runGoalCommandSubprocess(t *testing.T, kentPath string, workdir string, sessionID string, args ...string) (stdout string, stderr string) {

--- a/cli/kent/goal_command_test.go
+++ b/cli/kent/goal_command_test.go
@@ -113,11 +113,11 @@ func TestGoalRuntimeBackedMutationsPresentRuntimeUnavailableForResolvedSession(t
 	const sessionID = "cc948e1e-17e5-4213-87d5-4793ebe18a55"
 	runtimeErr := errors.Join(serverapi.ErrRuntimeUnavailable, errors.New("joined transport detail"))
 	tests := []struct {
-		name       string
-		args       []string
-		goalStatus string
-		configure  func(*recordingGoalRemote)
-		callCount  func(*recordingGoalRemote) int
+		name      string
+		args      []string
+		goal      *serverapi.RuntimeGoal
+		configure func(*recordingGoalRemote)
+		callCount func(*recordingGoalRemote) int
 	}{
 		{
 			name:      "set",
@@ -138,18 +138,18 @@ func TestGoalRuntimeBackedMutationsPresentRuntimeUnavailableForResolvedSession(t
 			callCount: func(remote *recordingGoalRemote) int { return len(remote.resumeReq) },
 		},
 		{
-			name:       "complete active",
-			args:       []string{"complete", "--session", sessionID},
-			goalStatus: string(session.GoalStatusActive),
-			configure:  func(remote *recordingGoalRemote) { remote.completeErr = runtimeErr },
-			callCount:  func(remote *recordingGoalRemote) int { return len(remote.completeReq) },
+			name:      "complete active",
+			args:      []string{"complete", "--session", sessionID},
+			goal:      &serverapi.RuntimeGoal{ID: "goal-active", Objective: "dormant goal", Status: string(session.GoalStatusActive)},
+			configure: func(remote *recordingGoalRemote) { remote.completeErr = runtimeErr },
+			callCount: func(remote *recordingGoalRemote) int { return len(remote.completeReq) },
 		},
 		{
-			name:       "complete paused",
-			args:       []string{"complete", "--session", sessionID},
-			goalStatus: string(session.GoalStatusPaused),
-			configure:  func(remote *recordingGoalRemote) { remote.completeErr = runtimeErr },
-			callCount:  func(remote *recordingGoalRemote) int { return len(remote.completeReq) },
+			name:      "complete paused",
+			args:      []string{"complete", "--session", sessionID},
+			goal:      &serverapi.RuntimeGoal{ID: "goal-paused", Objective: "dormant goal", Status: string(session.GoalStatusPaused)},
+			configure: func(remote *recordingGoalRemote) { remote.completeErr = runtimeErr },
+			callCount: func(remote *recordingGoalRemote) int { return len(remote.completeReq) },
 		},
 		{
 			name:      "clear",
@@ -161,10 +161,7 @@ func TestGoalRuntimeBackedMutationsPresentRuntimeUnavailableForResolvedSession(t
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			remote := &recordingGoalRemote{}
-			if tt.goalStatus != "" {
-				remote.goal = &serverapi.RuntimeGoal{ID: "goal-1", Objective: "dormant goal", Status: tt.goalStatus}
-			}
+			remote := &recordingGoalRemote{goal: tt.goal}
 			tt.configure(remote)
 			restore := replaceGoalCommandRemoteOpener(t, remote)
 			defer restore()

--- a/cli/kent/worktree_command_test.go
+++ b/cli/kent/worktree_command_test.go
@@ -331,7 +331,21 @@ func TestWorktreeEnterRejectsPartialRuntimeOriginBeforeRPC(t *testing.T) {
 	replaceWorktreeCommandRemote(t, remote)
 	t.Setenv("KENT_SESSION_ID", "shell-session")
 	t.Setenv(sessionenv.RunIDEnv, "018fdd67-89ab-4cde-8123-456789abc001")
-	t.Setenv(sessionenv.StepIDEnv, "")
+	previousStepID, hadStepID := os.LookupEnv(sessionenv.StepIDEnv)
+	if err := os.Unsetenv(sessionenv.StepIDEnv); err != nil {
+		t.Fatalf("unset %s: %v", sessionenv.StepIDEnv, err)
+	}
+	t.Cleanup(func() {
+		var err error
+		if hadStepID {
+			err = os.Setenv(sessionenv.StepIDEnv, previousStepID)
+		} else {
+			err = os.Unsetenv(sessionenv.StepIDEnv)
+		}
+		if err != nil {
+			t.Errorf("restore %s: %v", sessionenv.StepIDEnv, err)
+		}
+	})
 
 	var stdout, stderr bytes.Buffer
 	if exitCode := rootCommand([]string{"worktree", "enter", "feature/a"}, strings.NewReader(""), &stdout, &stderr); exitCode != 2 {

--- a/cli/kent/worktree_command_test.go
+++ b/cli/kent/worktree_command_test.go
@@ -331,6 +331,7 @@ func TestWorktreeEnterRejectsPartialRuntimeOriginBeforeRPC(t *testing.T) {
 	replaceWorktreeCommandRemote(t, remote)
 	t.Setenv("KENT_SESSION_ID", "shell-session")
 	t.Setenv(sessionenv.RunIDEnv, "018fdd67-89ab-4cde-8123-456789abc001")
+	t.Setenv(sessionenv.StepIDEnv, "")
 
 	var stdout, stderr bytes.Buffer
 	if exitCode := rootCommand([]string{"worktree", "enter", "feature/a"}, strings.NewReader(""), &stdout, &stderr); exitCode != 2 {

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -235,6 +235,8 @@
 
 - Models may use normal shell commands `kent goal show`, `kent goal complete`, and first-time `kent goal set <objective>` for the current session, but other goal commands detect invocation by the agent and refuse it.
 -  `goal set` by agents is allowed only when no active or paused goal exists. Completed goals do not block the next agent-set goal.
+- Goal inspection reads the durable session goal and does not require an Active Session Runtime. Running and dormant sessions return the same goal result; a valid session with no goal returns no goal, while unknown or inaccessible sessions remain errors.
+- Goal inspection excludes runtime-local goal-loop suspension. Live clients derive suspension from runtime status.
 - Successful goal mutations emit typed runtime status updates carrying the projected goal status state so frontends can update from goal SSOT instead of inferring status from transcript feedback or run lifecycle. Set, pause, resume, complete, and clear emit updates; show/read-only operations do not.
 - `/goal <objective>` (TUI slash command or GUI path) immediately sets/replaces the session goal and starts a model turn. It must be allowed even while the model turn is running, and the new notice is steered as usual.
 - `/goal resume` on a completed goal reopens it as active.

--- a/server/core/composition.go
+++ b/server/core/composition.go
@@ -143,7 +143,11 @@ func NewWithContextOptions(ctx context.Context, cfg config.App, authSupport serv
 	runtimeOperations := runtimeops.NewCoordinator()
 	runtimeRegistry.WithOperationCoordinator(runtimeOperations)
 	runtimeRegistry.WithExecutionTargetResolver(metadataStore.ResolveSessionExecutionTarget)
-	runtimeControlService := runtimecontrol.NewService(runtimeRegistry).WithOperationCoordinator(runtimeOperations).WithPromptHistoryStore(metadataStore).WithWorkflowSessionResolver(sessionStoreResolver)
+	runtimeControlService := runtimecontrol.NewService(runtimeRegistry).
+		WithOperationCoordinator(runtimeOperations).
+		WithPromptHistoryStore(metadataStore).
+		WithWorkflowSessionResolver(sessionStoreResolver).
+		WithPersistedSessionResolver(metadataStore)
 	gitInspector := worktree.NewGitInspector(nil)
 	worktreeService := worktree.NewService(metadataStore, gitInspector, runtimeRegistry, sessionRuntimeService, runtimeSupport.Background, worktree.ServiceOptions{
 		BaseDir: cfg.Settings.Worktrees.BaseDir,

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -119,6 +119,7 @@ type Service struct {
 	activity       RuntimeActivityResolver
 	promptStore    PromptHistoryStore
 	workflowStates WorkflowSessionResolver
+	persisted      session.PersistedSessionResolver
 	operations     *runtimeops.Coordinator
 	sessionNames   *requestmemo.Memo[sessionStringMemoRequest, struct{}]
 	thinkingLevels *requestmemo.Memo[sessionStringMemoRequest, struct{}]
@@ -284,6 +285,14 @@ func (s *Service) WithWorkflowSessionResolver(resolver WorkflowSessionResolver) 
 		return nil
 	}
 	s.workflowStates = resolver
+	return s
+}
+
+func (s *Service) WithPersistedSessionResolver(resolver session.PersistedSessionResolver) *Service {
+	if s == nil {
+		return nil
+	}
+	s.persisted = resolver
 	return s
 }
 

--- a/server/runtimecontrol/service_goal.go
+++ b/server/runtimecontrol/service_goal.go
@@ -3,6 +3,7 @@ package runtimecontrol
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"core/prompts"
@@ -15,22 +16,22 @@ func (s *Service) ShowGoal(ctx context.Context, req serverapi.RuntimeGoalShowReq
 	if err := req.Validate(); err != nil {
 		return serverapi.RuntimeGoalShowResponse{}, err
 	}
-	engine, err := s.resolve(ctx, req.SessionID)
-	if err != nil {
-		return serverapi.RuntimeGoalShowResponse{}, err
+	if s == nil || s.persisted == nil {
+		return serverapi.RuntimeGoalShowResponse{}, errors.New("persisted session resolver is required")
 	}
-	goal := engine.Goal()
+	sessionID := strings.TrimSpace(req.SessionID)
+	record, err := s.persisted.ResolvePersistedSession(ctx, sessionID)
+	if err != nil {
+		return serverapi.RuntimeGoalShowResponse{}, fmt.Errorf("resolve persisted session %q: %w", sessionID, err)
+	}
+	if record.Meta == nil {
+		return serverapi.RuntimeGoalShowResponse{}, fmt.Errorf("persisted session %q metadata is required", sessionID)
+	}
+	goal := record.Meta.Goal
 	if goal == nil {
 		return serverapi.RuntimeGoalShowResponse{}, nil
 	}
-	return serverapi.RuntimeGoalShowResponse{Goal: &serverapi.RuntimeGoal{
-		ID:        strings.TrimSpace(goal.ID),
-		Objective: goal.Objective,
-		Status:    strings.TrimSpace(string(goal.Status)),
-		Suspended: engine.GoalLoopSuspended(),
-		CreatedAt: goal.CreatedAt,
-		UpdatedAt: goal.UpdatedAt,
-	}}, nil
+	return serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(*goal)}, nil
 }
 
 func (s *Service) SetGoal(ctx context.Context, req serverapi.RuntimeGoalSetRequest) (serverapi.RuntimeGoalShowResponse, error) {
@@ -51,7 +52,7 @@ func (s *Service) SetGoal(ctx context.Context, req serverapi.RuntimeGoalSetReque
 					}
 					return err
 				}
-				response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal, false)}
+				response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal)}
 				return nil
 			}
 			goal, queued, qErr := queueGoalSetForRequest(engine, req, trimmedObjective)
@@ -63,7 +64,7 @@ func (s *Service) SetGoal(ctx context.Context, req serverapi.RuntimeGoalSetReque
 				return qErr
 			}
 			if queued {
-				response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal, false)}
+				response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal)}
 				return nil
 			}
 			if strings.TrimSpace(req.Actor) == string(session.GoalActorAgent) {
@@ -86,7 +87,7 @@ func (s *Service) SetGoal(ctx context.Context, req serverapi.RuntimeGoalSetReque
 			if err := engine.StartGoalLoop(); err != nil {
 				return err
 			}
-			response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal, false)}
+			response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal)}
 			return nil
 		})
 		return response, err
@@ -129,18 +130,18 @@ func (s *Service) setGoalStatus(ctx context.Context, req serverapi.RuntimeGoalSt
 			if engine.WorkflowRunConfigured() && !requestOriginatesFromAgentStep(req.Actor, req.StepID) {
 				current := engine.Goal()
 				if status == session.GoalStatusActive && current != nil && current.Status == session.GoalStatusActive {
-					response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(*current, false)}
+					response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(*current)}
 					return nil
 				}
 				if status == session.GoalStatusComplete && current != nil && current.Status == session.GoalStatusComplete {
-					response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(*current, false)}
+					response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(*current)}
 					return nil
 				}
 				goal, err := engine.SetGoalStatusWithoutGoalLoopStart(status, session.GoalActor(req.Actor))
 				if err != nil {
 					return err
 				}
-				response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal, false)}
+				response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal)}
 				return nil
 			}
 			goal, queued, qErr := queueGoalStatusForRequest(engine, req, status)
@@ -148,20 +149,20 @@ func (s *Service) setGoalStatus(ctx context.Context, req serverapi.RuntimeGoalSt
 				return qErr
 			}
 			if queued {
-				response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal, false)}
+				response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal)}
 				return nil
 			}
 			if status == session.GoalStatusActive {
 				current := engine.Goal()
 				if current != nil && current.Status == session.GoalStatusActive && engine.GoalLoopContinuationEnforced() {
-					response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(*current, false)}
+					response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(*current)}
 					return nil
 				}
 			}
 			if status == session.GoalStatusComplete {
 				current := engine.Goal()
 				if current != nil && current.Status == session.GoalStatusComplete {
-					response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(*current, false)}
+					response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(*current)}
 					return nil
 				}
 			}
@@ -179,7 +180,7 @@ func (s *Service) setGoalStatus(ctx context.Context, req serverapi.RuntimeGoalSt
 					return err
 				}
 			}
-			response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal, false)}
+			response = serverapi.RuntimeGoalShowResponse{Goal: runtimeGoalFromSessionGoal(goal)}
 			return nil
 		})
 		return response, err
@@ -231,12 +232,11 @@ func requestOriginatesFromAgentStep(actor string, stepID string) bool {
 	return strings.TrimSpace(actor) == string(session.GoalActorAgent) && strings.TrimSpace(stepID) != ""
 }
 
-func runtimeGoalFromSessionGoal(goal session.GoalState, suspended bool) *serverapi.RuntimeGoal {
+func runtimeGoalFromSessionGoal(goal session.GoalState) *serverapi.RuntimeGoal {
 	return &serverapi.RuntimeGoal{
 		ID:        strings.TrimSpace(goal.ID),
 		Objective: goal.Objective,
 		Status:    strings.TrimSpace(string(goal.Status)),
-		Suspended: suspended,
 		CreatedAt: goal.CreatedAt,
 		UpdatedAt: goal.UpdatedAt,
 	}

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -84,13 +84,10 @@ func (r runtimeResolverMustNotBeCalled) SessionRunsBlocked(string) bool {
 	return false
 }
 
-type staticPersistedSessionResolver struct {
-	record session.PersistedSessionRecord
-	err    error
-}
+type missingMetadataPersistedSessionResolver struct{}
 
-func (r staticPersistedSessionResolver) ResolvePersistedSession(context.Context, string) (session.PersistedSessionRecord, error) {
-	return r.record, r.err
+func (missingMetadataPersistedSessionResolver) ResolvePersistedSession(context.Context, string) (session.PersistedSessionRecord, error) {
+	return session.PersistedSessionRecord{SessionDir: "/tmp/session"}, nil
 }
 
 type countingBeginRuntimeResolver struct {
@@ -693,25 +690,17 @@ func TestServiceGoalMutationsSetShowComplete(t *testing.T) {
 }
 
 func TestServiceShowGoalReturnsPersistedGoalWithoutRuntime(t *testing.T) {
-	createdAt := time.Date(2026, time.July, 16, 10, 11, 12, 0, time.UTC)
-	updatedAt := createdAt.Add(2 * time.Hour)
-	const sessionID = "cc948e1e-17e5-4213-87d5-4793ebe18a55"
-	goal := session.GoalState{
-		ID:        "ecdf563d-22b4-4a93-b587-3cfcc294b413",
-		Objective: "inspect dormant goals",
-		Status:    session.GoalStatusPaused,
-		CreatedAt: createdAt,
-		UpdatedAt: updatedAt,
+	store, _ := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	goal, err := store.SetGoal("inspect dormant goals", session.GoalActorUser)
+	if err != nil {
+		t.Fatalf("SetGoal: %v", err)
 	}
-	service := NewService(runtimeResolverMustNotBeCalled{t: t}).WithPersistedSessionResolver(staticPersistedSessionResolver{
-		record: session.PersistedSessionRecord{
-			SessionDir: "/tmp/session",
-			Meta: &session.Meta{
-				SessionID: sessionID,
-				Goal:      &goal,
-			},
-		},
-	})
+	goal, err = store.SetGoalStatus(session.GoalStatusPaused, session.GoalActorUser)
+	if err != nil {
+		t.Fatalf("SetGoalStatus: %v", err)
+	}
+	sessionID := store.Meta().SessionID
+	service := NewService(runtimeResolverMustNotBeCalled{t: t}).WithPersistedSessionResolver(runtimeControlTestSessionPersistence)
 
 	resp, err := service.ShowGoal(context.Background(), serverapi.RuntimeGoalShowRequest{SessionID: sessionID})
 	if err != nil {
@@ -730,24 +719,21 @@ func TestServiceShowGoalReturnsPersistedGoalWithoutRuntime(t *testing.T) {
 }
 
 func TestServiceShowGoalPrefersPersistedGoalOverLiveRuntime(t *testing.T) {
-	_, engine := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
-	if _, err := engine.SetGoal("live preview must not win", session.GoalActorUser); err != nil {
+	_, liveEngine := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	if _, err := liveEngine.SetGoal("live preview must not win", session.GoalActorUser); err != nil {
 		t.Fatalf("SetGoal: %v", err)
 	}
-	const sessionID = "2ff5dc20-31e4-49bd-aad2-90019e5e1fa2"
-	persistedGoal := session.GoalState{
-		ID:        "b5e80dc5-8c29-4635-9fc1-d4c7b3508428",
-		Objective: "return committed metadata",
-		Status:    session.GoalStatusPaused,
-		CreatedAt: time.Date(2026, time.July, 15, 8, 30, 0, 0, time.UTC),
-		UpdatedAt: time.Date(2026, time.July, 16, 9, 45, 0, 0, time.UTC),
+	persistedStore, _ := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	persistedGoal, err := persistedStore.SetGoal("return committed metadata", session.GoalActorUser)
+	if err != nil {
+		t.Fatalf("SetGoal persisted: %v", err)
 	}
-	service := NewService(stubRuntimeResolver{engine: engine}).WithPersistedSessionResolver(staticPersistedSessionResolver{
-		record: session.PersistedSessionRecord{
-			SessionDir: "/tmp/session",
-			Meta:       &session.Meta{SessionID: sessionID, Goal: &persistedGoal},
-		},
-	})
+	persistedGoal, err = persistedStore.SetGoalStatus(session.GoalStatusPaused, session.GoalActorUser)
+	if err != nil {
+		t.Fatalf("SetGoalStatus persisted: %v", err)
+	}
+	sessionID := persistedStore.Meta().SessionID
+	service := NewService(stubRuntimeResolver{engine: liveEngine}).WithPersistedSessionResolver(runtimeControlTestSessionPersistence)
 
 	resp, err := service.ShowGoal(context.Background(), serverapi.RuntimeGoalShowRequest{SessionID: sessionID})
 	if err != nil {
@@ -759,13 +745,9 @@ func TestServiceShowGoalPrefersPersistedGoalOverLiveRuntime(t *testing.T) {
 }
 
 func TestServiceShowGoalReturnsEmptyResponseForPersistedSessionWithoutGoal(t *testing.T) {
-	const sessionID = "5a1191c5-0ead-4aa8-93f0-cce6cc99aeeb"
-	service := NewService(runtimeResolverMustNotBeCalled{t: t}).WithPersistedSessionResolver(staticPersistedSessionResolver{
-		record: session.PersistedSessionRecord{
-			SessionDir: "/tmp/session",
-			Meta:       &session.Meta{SessionID: sessionID},
-		},
-	})
+	store, _ := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{})
+	sessionID := store.Meta().SessionID
+	service := NewService(runtimeResolverMustNotBeCalled{t: t}).WithPersistedSessionResolver(runtimeControlTestSessionPersistence)
 
 	resp, err := service.ShowGoal(context.Background(), serverapi.RuntimeGoalShowRequest{SessionID: sessionID})
 	if err != nil {
@@ -778,7 +760,6 @@ func TestServiceShowGoalReturnsEmptyResponseForPersistedSessionWithoutGoal(t *te
 
 func TestServiceShowGoalReturnsPersistedSessionResolutionFailures(t *testing.T) {
 	const sessionID = "64ee658a-138d-47d6-8624-e25aebcb7a5a"
-	resolutionErr := errors.New("metadata store unavailable")
 	tests := []struct {
 		name    string
 		service *Service
@@ -790,16 +771,14 @@ func TestServiceShowGoalReturnsPersistedSessionResolutionFailures(t *testing.T) 
 		},
 		{
 			name: "resolver failure",
-			service: NewService(runtimeResolverMustNotBeCalled{t: t}).WithPersistedSessionResolver(staticPersistedSessionResolver{
-				err: resolutionErr,
-			}),
-			wantIs: resolutionErr,
+			service: NewService(runtimeResolverMustNotBeCalled{t: t}).
+				WithPersistedSessionResolver(runtimeControlTestSessionPersistence),
+			wantIs: session.ErrSessionNotFound,
 		},
 		{
 			name: "metadata required",
-			service: NewService(runtimeResolverMustNotBeCalled{t: t}).WithPersistedSessionResolver(staticPersistedSessionResolver{
-				record: session.PersistedSessionRecord{SessionDir: "/tmp/session"},
-			}),
+			service: NewService(runtimeResolverMustNotBeCalled{t: t}).
+				WithPersistedSessionResolver(missingMetadataPersistedSessionResolver{}),
 		},
 	}
 

--- a/server/runtimecontrol/service_test.go
+++ b/server/runtimecontrol/service_test.go
@@ -50,6 +50,49 @@ func (s stubRuntimeResolver) BeginCancellableSessionRun(string) (context.Context
 
 func (s stubRuntimeResolver) SessionRunsBlocked(string) bool { return false }
 
+type runtimeResolverMustNotBeCalled struct {
+	t *testing.T
+}
+
+func (r runtimeResolverMustNotBeCalled) ResolveRuntime(context.Context, string) (*runtime.Engine, error) {
+	r.t.Helper()
+	r.t.Fatal("ResolveRuntime must not be called for persisted goal inspection")
+	return nil, nil
+}
+
+func (r runtimeResolverMustNotBeCalled) WithGuardedRuntime(context.Context, string, func(*runtime.Engine) error) (bool, error) {
+	r.t.Helper()
+	r.t.Fatal("WithGuardedRuntime must not be called for persisted goal inspection")
+	return false, nil
+}
+
+func (r runtimeResolverMustNotBeCalled) BeginSessionRun(string) (func(), bool) {
+	r.t.Helper()
+	r.t.Fatal("BeginSessionRun must not be called for persisted goal inspection")
+	return nil, false
+}
+
+func (r runtimeResolverMustNotBeCalled) BeginCancellableSessionRun(string) (context.Context, func(), bool) {
+	r.t.Helper()
+	r.t.Fatal("BeginCancellableSessionRun must not be called for persisted goal inspection")
+	return nil, nil, false
+}
+
+func (r runtimeResolverMustNotBeCalled) SessionRunsBlocked(string) bool {
+	r.t.Helper()
+	r.t.Fatal("SessionRunsBlocked must not be called for persisted goal inspection")
+	return false
+}
+
+type staticPersistedSessionResolver struct {
+	record session.PersistedSessionRecord
+	err    error
+}
+
+func (r staticPersistedSessionResolver) ResolvePersistedSession(context.Context, string) (session.PersistedSessionRecord, error) {
+	return r.record, r.err
+}
+
 type countingBeginRuntimeResolver struct {
 	stubRuntimeResolver
 	beginCount atomic.Int32
@@ -365,7 +408,9 @@ func newRuntimeControlTestService(t *testing.T, client llm.Client, registry *too
 	t.Helper()
 	store, engine := newRuntimeControlTestEngine(t, client, registry, cfg, opts...)
 	history := newRuntimeControlPromptHistoryStore(store.Meta().SessionID)
-	service := NewService(stubRuntimeResolver{engine: engine}).WithPromptHistoryStore(history)
+	service := NewService(stubRuntimeResolver{engine: engine}).
+		WithPromptHistoryStore(history).
+		WithPersistedSessionResolver(runtimeControlTestSessionPersistence)
 	return store, engine, service
 }
 
@@ -613,7 +658,7 @@ func TestServiceInterruptReturnsCurrentActivitySnapshot(t *testing.T) {
 
 func TestServiceGoalMutationsSetShowComplete(t *testing.T) {
 	store, engine := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
-	service := NewService(stubRuntimeResolver{engine: engine})
+	service := NewService(stubRuntimeResolver{engine: engine}).WithPersistedSessionResolver(runtimeControlTestSessionPersistence)
 
 	setResp, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
 		ClientRequestID: "goal-set-1",
@@ -644,6 +689,205 @@ func TestServiceGoalMutationsSetShowComplete(t *testing.T) {
 	}
 	if completeResp.Goal == nil || completeResp.Goal.Status != "complete" {
 		t.Fatalf("complete goal response = %+v", completeResp.Goal)
+	}
+}
+
+func TestServiceShowGoalReturnsPersistedGoalWithoutRuntime(t *testing.T) {
+	createdAt := time.Date(2026, time.July, 16, 10, 11, 12, 0, time.UTC)
+	updatedAt := createdAt.Add(2 * time.Hour)
+	const sessionID = "cc948e1e-17e5-4213-87d5-4793ebe18a55"
+	goal := session.GoalState{
+		ID:        "ecdf563d-22b4-4a93-b587-3cfcc294b413",
+		Objective: "inspect dormant goals",
+		Status:    session.GoalStatusPaused,
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}
+	service := NewService(runtimeResolverMustNotBeCalled{t: t}).WithPersistedSessionResolver(staticPersistedSessionResolver{
+		record: session.PersistedSessionRecord{
+			SessionDir: "/tmp/session",
+			Meta: &session.Meta{
+				SessionID: sessionID,
+				Goal:      &goal,
+			},
+		},
+	})
+
+	resp, err := service.ShowGoal(context.Background(), serverapi.RuntimeGoalShowRequest{SessionID: sessionID})
+	if err != nil {
+		t.Fatalf("ShowGoal: %v", err)
+	}
+	if resp.Goal == nil {
+		t.Fatal("ShowGoal goal = nil, want persisted goal")
+	}
+	if resp.Goal.ID != goal.ID ||
+		resp.Goal.Objective != goal.Objective ||
+		resp.Goal.Status != string(goal.Status) ||
+		!resp.Goal.CreatedAt.Equal(goal.CreatedAt) ||
+		!resp.Goal.UpdatedAt.Equal(goal.UpdatedAt) {
+		t.Fatalf("ShowGoal goal = %+v, want %+v", resp.Goal, goal)
+	}
+}
+
+func TestServiceShowGoalPrefersPersistedGoalOverLiveRuntime(t *testing.T) {
+	_, engine := newRuntimeControlTestEngine(t, nil, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	if _, err := engine.SetGoal("live preview must not win", session.GoalActorUser); err != nil {
+		t.Fatalf("SetGoal: %v", err)
+	}
+	const sessionID = "2ff5dc20-31e4-49bd-aad2-90019e5e1fa2"
+	persistedGoal := session.GoalState{
+		ID:        "b5e80dc5-8c29-4635-9fc1-d4c7b3508428",
+		Objective: "return committed metadata",
+		Status:    session.GoalStatusPaused,
+		CreatedAt: time.Date(2026, time.July, 15, 8, 30, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, time.July, 16, 9, 45, 0, 0, time.UTC),
+	}
+	service := NewService(stubRuntimeResolver{engine: engine}).WithPersistedSessionResolver(staticPersistedSessionResolver{
+		record: session.PersistedSessionRecord{
+			SessionDir: "/tmp/session",
+			Meta:       &session.Meta{SessionID: sessionID, Goal: &persistedGoal},
+		},
+	})
+
+	resp, err := service.ShowGoal(context.Background(), serverapi.RuntimeGoalShowRequest{SessionID: sessionID})
+	if err != nil {
+		t.Fatalf("ShowGoal: %v", err)
+	}
+	if resp.Goal == nil || resp.Goal.ID != persistedGoal.ID || resp.Goal.Objective != persistedGoal.Objective || resp.Goal.Status != string(persistedGoal.Status) {
+		t.Fatalf("ShowGoal goal = %+v, want persisted goal %+v", resp.Goal, persistedGoal)
+	}
+}
+
+func TestServiceShowGoalReturnsEmptyResponseForPersistedSessionWithoutGoal(t *testing.T) {
+	const sessionID = "5a1191c5-0ead-4aa8-93f0-cce6cc99aeeb"
+	service := NewService(runtimeResolverMustNotBeCalled{t: t}).WithPersistedSessionResolver(staticPersistedSessionResolver{
+		record: session.PersistedSessionRecord{
+			SessionDir: "/tmp/session",
+			Meta:       &session.Meta{SessionID: sessionID},
+		},
+	})
+
+	resp, err := service.ShowGoal(context.Background(), serverapi.RuntimeGoalShowRequest{SessionID: sessionID})
+	if err != nil {
+		t.Fatalf("ShowGoal: %v", err)
+	}
+	if resp.Goal != nil {
+		t.Fatalf("ShowGoal goal = %+v, want nil", resp.Goal)
+	}
+}
+
+func TestServiceShowGoalReturnsPersistedSessionResolutionFailures(t *testing.T) {
+	const sessionID = "64ee658a-138d-47d6-8624-e25aebcb7a5a"
+	resolutionErr := errors.New("metadata store unavailable")
+	tests := []struct {
+		name    string
+		service *Service
+		wantIs  error
+	}{
+		{
+			name:    "resolver required",
+			service: NewService(runtimeResolverMustNotBeCalled{t: t}),
+		},
+		{
+			name: "resolver failure",
+			service: NewService(runtimeResolverMustNotBeCalled{t: t}).WithPersistedSessionResolver(staticPersistedSessionResolver{
+				err: resolutionErr,
+			}),
+			wantIs: resolutionErr,
+		},
+		{
+			name: "metadata required",
+			service: NewService(runtimeResolverMustNotBeCalled{t: t}).WithPersistedSessionResolver(staticPersistedSessionResolver{
+				record: session.PersistedSessionRecord{SessionDir: "/tmp/session"},
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := tt.service.ShowGoal(context.Background(), serverapi.RuntimeGoalShowRequest{SessionID: sessionID})
+			if err == nil {
+				t.Fatal("ShowGoal error = nil, want failure")
+			}
+			if tt.wantIs != nil && !errors.Is(err, tt.wantIs) {
+				t.Fatalf("ShowGoal error = %v, want wrapping %v", err, tt.wantIs)
+			}
+			if resp.Goal != nil {
+				t.Fatalf("ShowGoal goal = %+v, want nil on failure", resp.Goal)
+			}
+		})
+	}
+}
+
+func TestServiceShowGoalReturnsCommittedStateAroundQueuedGoalDrain(t *testing.T) {
+	client := newCancelObservingRuntimeControlClient()
+	store, engine := newRuntimeControlTestEngine(t, client, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
+	initialGoal, err := engine.SetGoal("committed before active step", session.GoalActorUser)
+	if err != nil {
+		t.Fatalf("SetGoal: %v", err)
+	}
+	service := NewService(stubRuntimeResolver{engine: engine}).
+		WithPromptHistoryStore(newRuntimeControlPromptHistoryStore(store.Meta().SessionID)).
+		WithPersistedSessionResolver(runtimeControlTestSessionPersistence)
+	turnDone := make(chan error, 1)
+	go func() {
+		_, submitErr := service.SubmitUserTurn(context.Background(), runtimeControlUserTurnRequest(store, "turn-1", "work"))
+		turnDone <- submitErr
+	}()
+	released := false
+	defer func() {
+		if !released {
+			close(client.release)
+		}
+		select {
+		case <-turnDone:
+		case <-time.After(3 * time.Second):
+		}
+	}()
+	select {
+	case <-client.started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for active model step")
+	}
+
+	accepted, err := service.SetGoal(context.Background(), serverapi.RuntimeGoalSetRequest{
+		ClientRequestID: "goal-set-queued",
+		SessionID:       store.Meta().SessionID,
+		Objective:       "accepted pending goal",
+		Actor:           string(session.GoalActorUser),
+	})
+	if err != nil {
+		t.Fatalf("SetGoal queued mutation: %v", err)
+	}
+	if accepted.Goal == nil || accepted.Goal.Objective != "accepted pending goal" || accepted.Goal.Status != string(session.GoalStatusActive) {
+		t.Fatalf("SetGoal accepted response = %+v, want active pending goal", accepted.Goal)
+	}
+
+	beforeDrain, err := service.ShowGoal(context.Background(), serverapi.RuntimeGoalShowRequest{SessionID: store.Meta().SessionID})
+	if err != nil {
+		t.Fatalf("ShowGoal before drain: %v", err)
+	}
+	if beforeDrain.Goal == nil || beforeDrain.Goal.ID != initialGoal.ID || beforeDrain.Goal.Objective != initialGoal.Objective {
+		t.Fatalf("ShowGoal before drain = %+v, want prior committed goal %+v", beforeDrain.Goal, initialGoal)
+	}
+
+	close(client.release)
+	released = true
+	select {
+	case err := <-turnDone:
+		if err != nil {
+			t.Fatalf("SubmitUserTurn: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for active step drain")
+	}
+
+	afterDrain, err := service.ShowGoal(context.Background(), serverapi.RuntimeGoalShowRequest{SessionID: store.Meta().SessionID})
+	if err != nil {
+		t.Fatalf("ShowGoal after drain: %v", err)
+	}
+	if afterDrain.Goal == nil || afterDrain.Goal.Objective != accepted.Goal.Objective || afterDrain.Goal.Status != accepted.Goal.Status {
+		t.Fatalf("ShowGoal after drain = %+v, want committed accepted goal %+v", afterDrain.Goal, accepted.Goal)
 	}
 }
 
@@ -1010,37 +1254,6 @@ func TestServiceResumeGoalPreflightFailureDoesNotMutateOrEmit(t *testing.T) {
 	}
 	if len(events) != 0 {
 		t.Fatalf("live events emitted after failed resume preflight: %+v", events)
-	}
-}
-
-func TestServiceShowGoalReportsRuntimeSuspension(t *testing.T) {
-	client := newCancelObservingRuntimeControlClient()
-	store, engine := newRuntimeControlTestEngine(t, client, nil, runtime.Config{EnabledTools: []toolspec.ID{toolspec.ToolAskQuestion}})
-	if _, err := engine.SetGoal("ship goal mode", session.GoalActorUser); err != nil {
-		t.Fatalf("SetGoal: %v", err)
-	}
-	if err := engine.StartGoalLoop(); err != nil {
-		t.Fatalf("StartGoalLoop: %v", err)
-	}
-	select {
-	case <-client.started:
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for goal loop to start")
-	}
-	if err := engine.Interrupt(); err != nil {
-		t.Fatalf("Interrupt: %v", err)
-	}
-	defer func() {
-		close(client.release)
-	}()
-	service := NewService(stubRuntimeResolver{engine: engine})
-
-	resp, err := service.ShowGoal(context.Background(), serverapi.RuntimeGoalShowRequest{SessionID: store.Meta().SessionID})
-	if err != nil {
-		t.Fatalf("ShowGoal: %v", err)
-	}
-	if resp.Goal == nil || !resp.Goal.Suspended {
-		t.Fatalf("goal response = %+v, want suspended", resp.Goal)
 	}
 }
 

--- a/server/transport/gateway_part3_test.go
+++ b/server/transport/gateway_part3_test.go
@@ -369,7 +369,7 @@ func receiveGatewayNotification(t *testing.T, conn *websocket.Conn, method strin
 	}
 }
 
-func TestGatewayGoalRPCDoesNotRequireProjectAttachment(t *testing.T) {
+func TestGatewayGoalRPCWithoutProjectAttachmentReturnsServiceErrors(t *testing.T) {
 	_, server := newUnboundGatewayTestServer(t)
 	defer server.Close()
 	conn := dialGateway(t, server)
@@ -380,20 +380,18 @@ func TestGatewayGoalRPCDoesNotRequireProjectAttachment(t *testing.T) {
 		name   string
 		method string
 		params any
+		code   int
 	}{
-		{name: "show", method: protocol.MethodRuntimeGoalShow, params: serverapi.RuntimeGoalShowRequest{SessionID: "missing-session"}},
-		{name: "set", method: protocol.MethodRuntimeGoalSet, params: serverapi.RuntimeGoalSetRequest{ClientRequestID: "goal-set", SessionID: "missing-session", Objective: "ship", Actor: "user"}},
-		{name: "pause", method: protocol.MethodRuntimeGoalPause, params: serverapi.RuntimeGoalStatusRequest{ClientRequestID: "goal-pause", SessionID: "missing-session", Actor: "user"}},
-		{name: "resume", method: protocol.MethodRuntimeGoalResume, params: serverapi.RuntimeGoalStatusRequest{ClientRequestID: "goal-resume", SessionID: "missing-session", Actor: "user"}},
-		{name: "complete", method: protocol.MethodRuntimeGoalComplete, params: serverapi.RuntimeGoalStatusRequest{ClientRequestID: "goal-complete", SessionID: "missing-session", Actor: "agent"}},
-		{name: "clear", method: protocol.MethodRuntimeGoalClear, params: serverapi.RuntimeGoalClearRequest{ClientRequestID: "goal-clear", SessionID: "missing-session", Actor: "user"}},
+		{name: "show", method: protocol.MethodRuntimeGoalShow, params: serverapi.RuntimeGoalShowRequest{SessionID: "missing-session"}, code: protocol.ErrCodeInternalError},
+		{name: "set", method: protocol.MethodRuntimeGoalSet, params: serverapi.RuntimeGoalSetRequest{ClientRequestID: "goal-set", SessionID: "missing-session", Objective: "ship", Actor: "user"}, code: protocol.ErrCodeRuntimeUnavailable},
+		{name: "pause", method: protocol.MethodRuntimeGoalPause, params: serverapi.RuntimeGoalStatusRequest{ClientRequestID: "goal-pause", SessionID: "missing-session", Actor: "user"}, code: protocol.ErrCodeRuntimeUnavailable},
+		{name: "resume", method: protocol.MethodRuntimeGoalResume, params: serverapi.RuntimeGoalStatusRequest{ClientRequestID: "goal-resume", SessionID: "missing-session", Actor: "user"}, code: protocol.ErrCodeRuntimeUnavailable},
+		{name: "complete", method: protocol.MethodRuntimeGoalComplete, params: serverapi.RuntimeGoalStatusRequest{ClientRequestID: "goal-complete", SessionID: "missing-session", Actor: "agent"}, code: protocol.ErrCodeRuntimeUnavailable},
+		{name: "clear", method: protocol.MethodRuntimeGoalClear, params: serverapi.RuntimeGoalClearRequest{ClientRequestID: "goal-clear", SessionID: "missing-session", Actor: "user"}, code: protocol.ErrCodeRuntimeUnavailable},
 	} {
 		err := callGatewayExpectError(t, conn, "goal-"+tc.name, tc.method, tc.params)
-		if err.Code != protocol.ErrCodeRuntimeUnavailable {
-			t.Fatalf("%s error code = %d message=%q, want runtime unavailable", tc.name, err.Code, err.Message)
-		}
-		if err.Message == "project attachment is required" {
-			t.Fatalf("%s required project attachment", tc.name)
+		if err.Code != tc.code {
+			t.Fatalf("%s error code = %d, want %d", tc.name, err.Code, tc.code)
 		}
 	}
 }

--- a/shared/protocol/version.json
+++ b/shared/protocol/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "62"
+  "version": "63"
 }

--- a/shared/serverapi/runtime_control.go
+++ b/shared/serverapi/runtime_control.go
@@ -233,7 +233,6 @@ type RuntimeGoal struct {
 	ID        string    `json:"id"`
 	Objective string    `json:"objective"`
 	Status    string    `json:"status"`
-	Suspended bool      `json:"suspended,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/tui-rs/crates/rpc-client/tests/websocket_factory.rs
+++ b/tui-rs/crates/rpc-client/tests/websocket_factory.rs
@@ -13,7 +13,7 @@ use tungstenite::Message;
 
 #[test]
 fn rust_protocol_version_matches_attachment_contract() {
-    assert_eq!(PROTOCOL_VERSION, "62");
+    assert_eq!(PROTOCOL_VERSION, "63");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Make `kent goal show` read the authoritative persisted session goal, so dormant and running sessions expose the same committed state.
- Keep runtime-local goal-loop suspension in live runtime status only; remove it from the durable goal RPC and advance protocol version 62 → 63.
- Preserve accepted pending goal previews in the TUI cache when a durable read returns older committed metadata.
- Replace duplicated runtime-unavailable mutation output with one typed CLI presentation error carrying the resolved session ID.
- Cover dormant reads before activation and after release, queued mutation drain semantics, mutation error presentation, and protocol/TUI ownership.

## Verification and completion evidence

Passed on the latest pushed branch:

- `cargo test --manifest-path tui-rs/Cargo.toml -p rpc-client --test integration websocket_factory::rust_protocol_version_matches_attachment_contract`
- `./scripts/ci-check.sh test`
- `./scripts/test.sh server`
- `./scripts/build.sh --output ./bin/kent`
- `git diff --check origin/main...HEAD`

Prior QA also passed:

- isolated real CLI/server subprocess verification for dormant reads, live mutation behavior, release, durable timestamps, and omission of the `suspended` JSON member
- uncached `cli/kent` tests
- focused runtime-control goal and queued-goal tests
- `cli/app`, `server/runtimeview`, `shared/serverapi`, and `shared/protocol` suites
- manual CLI help and validation checks

Workflow acceptance evidence is recorded in `.kent/plans/KENT-275.md`. This is a workflow-local ignored artifact; GitHub CLI does not support attaching local files to pull-request bodies.

One cold post-rebase server-suite attempt exceeded the repository 120-second wall-clock cap; the immediate documented rerun passed in 39.4 seconds, and the required build passed afterward.

## Diff size

| Category | Additions | Deletions | Net | Gross |
|---|---:|---:|---:|---:|
| Production/source/docs | 61 | 37 | +24 | 98 |
| Tests/generated | 514 | 84 | +430 | 598 |
| **Total** | **575** | **121** | **+454** | **696** |

Generated files: none.

## Caveats, tradeoffs, and follow-up

- `ShowGoal` intentionally returns the latest committed metadata snapshot. A goal mutation accepted during an active model step remains a transient preview until the runtime drains and persists it.
- Goal mutations still require a live runtime. KENT-284 tracks durable dormant-session mutations and transcript reminder persistence.
- Removing `suspended` from the goal RPC is a breaking wire-contract change, hence protocol version 63.
- The QA-discovered partial-runtime-origin test now explicitly unsets and restores `KENT_STEP_ID`, making the suite independent of inherited Kent workflow environment.
- CI initially exposed a stale Rust protocol-contract assertion at version 62. The latest commit aligns that guard to version 63; the focused Rust test and the repository CI test command pass locally.

## Tracking

- Kent task: `KENT-275`
- GitHub issue: none associated with this ticket.
