### PR TITLE
Unify task workflow selectors across CLI and server

### DIFF
--- a/apps/desktop/src/api/client.test.ts
+++ b/apps/desktop/src/api/client.test.ts
@@ -355,6 +355,7 @@ describe("ApiClient", () => {
       {
         method: "workflow.list",
         result: {
+          project_id: "project-1",
           workflows: [
             {
               id: "workflow-1",
@@ -362,6 +363,7 @@ describe("ApiClient", () => {
               description: "Ship",
               version: 4,
               execution_target_policy: { mode: "custom_ref", custom_ref: "release/v1" },
+              project_link: { default: true },
             },
           ],
           next_page_token: "cursor-2",

--- a/cli/app/onboarding_imports.go
+++ b/cli/app/onboarding_imports.go
@@ -243,20 +243,9 @@ func importSelectionsEqual(left, right onboardingImportSelection) bool {
 
 func importChoiceRefsEqual(left, right serverapi.ImportChoiceRef) bool {
 	return left.Mode == right.Mode &&
-		ptrStringEqual(left.SourceKind, right.SourceKind) &&
-		ptrStringEqual(left.ImportProviderID, right.ImportProviderID) &&
-		ptrStringEqual(left.SourceRootPath, right.SourceRootPath)
-}
-
-func ptrEqual[T comparable](left, right *T) bool {
-	if left == nil || right == nil {
-		return left == right
-	}
-	return *left == *right
-}
-
-func ptrStringEqual(left, right *string) bool {
-	return ptrEqual(left, right)
+		textutil.EqualOptional(left.SourceKind, right.SourceKind) &&
+		textutil.EqualOptional(left.ImportProviderID, right.ImportProviderID) &&
+		textutil.EqualOptional(left.SourceRootPath, right.SourceRootPath)
 }
 
 func applyImportChoice(selection *onboardingImportSelection, choiceID string, choices []onboardingImportChoice) error {

--- a/cli/app/ui_detail_transcript_window.go
+++ b/cli/app/ui_detail_transcript_window.go
@@ -256,8 +256,8 @@ func (w uiDetailTranscriptWindow) hasSegment(page clientui.TranscriptPage) bool 
 func segmentBoundaryEqual(seg residentSegmentMeta, page clientui.TranscriptPage) bool {
 	return seg.hasMoreAbove == page.HasMoreAbove &&
 		seg.hasMoreBelow == page.HasMoreBelow &&
-		int64PointerEqual(seg.olderCursor, page.OlderCursor) &&
-		int64PointerEqual(seg.newerCursor, page.NewerCursor)
+		textutil.EqualOptional(seg.olderCursor, page.OlderCursor) &&
+		textutil.EqualOptional(seg.newerCursor, page.NewerCursor)
 }
 
 func (w *uiDetailTranscriptWindow) trimToSegments(anchorLocal int) []clientui.TranscriptCommittedRow {
@@ -328,7 +328,7 @@ func (w uiDetailTranscriptWindow) pageAfter() (clientui.TranscriptPageRequest, b
 }
 
 func pageRequestEqual(a, b clientui.TranscriptPageRequest) bool {
-	return int64PointerEqual(a.Cursor, b.Cursor) && int64PointerEqual(a.NewerCursor, b.NewerCursor)
+	return textutil.EqualOptional(a.Cursor, b.Cursor) && textutil.EqualOptional(a.NewerCursor, b.NewerCursor)
 }
 
 func cloneTranscriptPageRequest(request clientui.TranscriptPageRequest) clientui.TranscriptPageRequest {
@@ -405,8 +405,4 @@ func cloneDetailTranscriptNotice(notice *clientui.TranscriptNoticeRow) *clientui
 	copyNotice.CondensedText = textutil.Pointer(notice.CondensedText)
 	copyNotice.CompactLabel = textutil.Pointer(notice.CompactLabel)
 	return &copyNotice
-}
-
-func int64PointerEqual(left, right *int64) bool {
-	return ptrEqual(left, right)
 }

--- a/cli/kent/help.go
+++ b/cli/kent/help.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"time"
 
 	"core/shared/config"
 )
@@ -61,15 +62,52 @@ func writeCommandFlagDefaults(fs *flag.FlagSet) {
 			flagName += " " + valueName
 		}
 		_, _ = fmt.Fprintf(fs.Output(), "  %s\n    \t%s", flagName, usage)
-		defaultValue := definition.DefValue
-		if defaultValue != "" && defaultValue != "false" && defaultValue != "0" {
-			if valueName == "string" {
+		if metadata := commandFlagDefaultMetadataFor(definition); metadata.Visible {
+			defaultValue := metadata.Value
+			if metadata.Quote {
 				defaultValue = strconv.Quote(defaultValue)
 			}
 			_, _ = fmt.Fprintf(fs.Output(), " (default %s)", defaultValue)
 		}
 		_, _ = fmt.Fprintln(fs.Output())
 	})
+}
+
+type commandFlagDefaultMetadata struct {
+	Value   string
+	Visible bool
+	Quote   bool
+}
+
+func commandFlagDefaultMetadataFor(definition *flag.Flag) commandFlagDefaultMetadata {
+	metadata := commandFlagDefaultMetadata{Value: definition.DefValue}
+	getter, ok := definition.Value.(flag.Getter)
+	if !ok {
+		metadata.Visible = metadata.Value != ""
+		return metadata
+	}
+	switch value := getter.Get().(type) {
+	case string:
+		metadata.Visible = value != ""
+		metadata.Quote = true
+	case bool:
+		metadata.Visible = value
+	case int:
+		metadata.Visible = value != 0
+	case int64:
+		metadata.Visible = value != 0
+	case time.Duration:
+		metadata.Visible = value != 0
+	case uint:
+		metadata.Visible = value != 0
+	case uint64:
+		metadata.Visible = value != 0
+	case float64:
+		metadata.Visible = value != 0
+	default:
+		metadata.Visible = metadata.Value != ""
+	}
+	return metadata
 }
 
 func flagSetHasDefinitions(fs *flag.FlagSet) bool {

--- a/cli/kent/help.go
+++ b/cli/kent/help.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"strconv"
 
 	"core/shared/config"
 )
@@ -22,7 +23,7 @@ func writeEmbeddedUsage(fs *flag.FlagSet, name string, includeFlags bool) {
 	}
 	_, _ = io.WriteString(fs.Output(), string(data))
 	if includeFlags {
-		fs.PrintDefaults()
+		writeCommandFlagDefaults(fs)
 	}
 }
 
@@ -45,8 +46,30 @@ func (u commandUsage) write(fs *flag.FlagSet) {
 	}
 	if u.includeCommandFlags && flagSetHasDefinitions(fs) {
 		writeHelpSection(fs.Output(), "Flags:")
-		fs.PrintDefaults()
+		writeCommandFlagDefaults(fs)
 	}
+}
+
+func writeCommandFlagDefaults(fs *flag.FlagSet) {
+	if fs == nil {
+		return
+	}
+	fs.VisitAll(func(definition *flag.Flag) {
+		flagName := "--" + definition.Name
+		valueName, usage := flag.UnquoteUsage(definition)
+		if valueName != "" {
+			flagName += " " + valueName
+		}
+		_, _ = fmt.Fprintf(fs.Output(), "  %s\n    \t%s", flagName, usage)
+		defaultValue := definition.DefValue
+		if defaultValue != "" && defaultValue != "false" && defaultValue != "0" {
+			if valueName == "string" {
+				defaultValue = strconv.Quote(defaultValue)
+			}
+			_, _ = fmt.Fprintf(fs.Output(), " (default %s)", defaultValue)
+		}
+		_, _ = fmt.Fprintln(fs.Output())
+	})
 }
 
 func flagSetHasDefinitions(fs *flag.FlagSet) bool {
@@ -100,7 +123,7 @@ var (
 	worktreeDeleteUsage     = leafCommandUsage(config.Command+" worktree delete [--session <id>] [--force] [--delete-branch] [--json] <selector>", "Delete a worktree; agent shell commands always retain branches.")
 	workflowUsage           = commandUsage{helpFile: "workflow.txt"}
 	workflowCreateUsage     = leafCommandUsage(config.Command+" workflow create [--description <text>] [--json] <name>", "Create a workflow with `backlog` start and `done` terminal nodes.")
-	workflowListUsage       = leafCommandUsage(config.Command+" workflow list [--page-size <n>] [--page-token <token>] [--json]", "List workflow definitions.")
+	workflowListUsage       = leafCommandUsage(config.Command+" workflow list [--project <path-or-id>] [--page-size <n>] [--page-token <token>] [--json]", "List workflow definitions.")
 	workflowNodeUsage       = leafCommandUsage(config.Command+" workflow node <add|update> ...", "Add or change workflow nodes.")
 	workflowNodeAddUsage    = leafCommandUsage(config.Command+" workflow node add <workflow> --key <key> --kind <kind> [flags]", "Add a node to a workflow.")
 	workflowNodeUpdateUsage = leafCommandUsage(config.Command+" workflow node update <workflow> <node-key> [flags]", "Change a workflow node.")
@@ -111,7 +134,7 @@ var (
 	workflowUnlinkUsage     = leafCommandUsage(config.Command+" workflow unlink <project> <workflow> [--json]", "Remove a workflow from a project.")
 	workflowDefaultUsage    = leafCommandUsage(config.Command+" workflow default <project> <workflow> [--json]", "Choose the workflow used when a project task omits `--workflow`.")
 	workflowValidateUsage   = leafCommandUsage(config.Command+" workflow validate <workflow> [--mode <mode>] [--json]", "Check whether a workflow is valid for draft editing, task creation, or execution.")
-	workflowInspectUsage    = leafCommandUsage(config.Command+" workflow inspect <workflow> [--json]", "Show a workflow's nodes, transitions, and configuration.")
+	workflowInspectUsage    = leafCommandUsage(config.Command+" workflow inspect <workflow> [--summary] [--json]", "Inspect a workflow graph or metadata summary.")
 	taskUsage               = commandUsage{helpFile: "task.txt"}
 	taskCreateUsage         = leafCommandUsage(config.Command+" task create --title <title> (--body <body>|--body-file <path>) [flags]", "Create a task in a project.")
 	taskEditUsage           = leafCommandUsage(config.Command+" task edit <task> [flags]", "Change a task's title, body, or source workspace.")

--- a/cli/kent/help/task.txt
+++ b/cli/kent/help/task.txt
@@ -1,5 +1,5 @@
 Usage of kent task:
-  kent task create --title <title> (--body <body>|--body-file <path>) [--workflow <workflow>] [--project <project>] [--source-url <url>] [--source-workspace <id-or-path>] [--json]
+  kent task create --title <title> (--body <body>|--body-file <path>) [--workflow <uuid>] [--project <project>] [--source-url <url>] [--source-workspace <id-or-path>] [--json]
   kent task edit <short-id-or-task-id> [--title <title>] [--body <body>|--body-file <path>] [--source-workspace <id-or-path>] [--project <project>] [--json]
   kent task start <short-id-or-task-id> [--project <project>] [--execution-target none|head|default-branch|ref:<revision>] [--json]
   kent task resume <short-id-or-task-id> [--project <project>]
@@ -24,6 +24,12 @@ Task references:
   Short IDs use the project selected by `--project`, which defaults to the
   project attached to the current workspace.
 
+Workflow selection:
+  Workflow selectors are bare canonical UUIDv4 values. Workflow names and
+  persisted `workflow-...` IDs are not accepted.
+  Task creation uses `--workflow` when supplied. Otherwise it uses the project
+  default, or the lone linked workflow when the project has no default.
+
 Selecting an execution target:
   Task start, approve, and move never prompt. If a workflow requires target
   selection, rerun the action with
@@ -37,11 +43,14 @@ If you are an agent, refer to the developer guidance you received for how to mar
 Subcommands `resume`, `approve`, `move`, `cancel`, `delete` are only available to humans. Do not try to circumvent this restriction, and give the user the commands they have to run instead.
 
 Listing tasks:
+  Task listing is always project-scoped. `--project` defaults to the project
+  attached to the current workspace. Without `--workflow`, the list spans all
+  workflows linked to that project; `--workflow <uuid>` narrows the result.
   `--status` filters primary typed task status; `--attention` filters current
   question, approval, or interruption attention; `--column` filters workflow
   node keys.
-  Supply either `--project` or `--workflow` only when its active link is unique,
-  or both to select an exact project/workflow link.
+  `--column` and `--sort column` require `--workflow` because column keys and
+  positions belong to one workflow.
   `--sort` accepts `created`, `updated`, `status`, `column`, `run_count`, or `title`
   followed by `:asc` or `:desc`.
   The default order is `status:asc,updated:desc`.

--- a/cli/kent/help/workflow.txt
+++ b/cli/kent/help/workflow.txt
@@ -1,7 +1,7 @@
 Usage of kent workflow:
   kent workflow create [--description <text>] [--json] <name>
   kent workflow update <workflow> [--name <name>] [--description <text>] [--execution-target ask-on-first-execution|none|head|default-branch|ref:<revision>] [--json]
-  kent workflow list [--page-size <n>] [--page-token <token>] [--json]
+  kent workflow list [--project <path-or-id>] [--page-size <n>] [--page-token <token>] [--json]
   kent workflow node add <workflow> --key <node-key> --kind start|agent|script|join|terminal [--display-name <name>] [--prompt <text>] [--agent <role>] [--completion-mode auto|structured_output|tool|shell_command|unstructured_output] [--script-path <path>] [--json]
   kent workflow node update <workflow> <node-key> [--key <node-key>] [--kind start|agent|script|join|terminal] [--display-name <name>] [--prompt <text>] [--agent <role>] [--completion-mode auto|structured_output|tool|shell_command|unstructured_output] [--script-path <path>] [--json]
   kent workflow edge add <workflow> --from <source-node-key> --transition <transition-key> --edge-key <edge-key> --to <target-node-key> --context new_session|continue_session|compact_and_continue_session [--requires-approval] [--context-source immediate_source|previous_target|previous_target_or_new|node:<node-key>] [--prompt <text>] [--transition-description <text>] [--param <key>=<description> ...] [--json]
@@ -10,7 +10,7 @@ Usage of kent workflow:
   kent workflow unlink <project> <workflow> [--json]
   kent workflow default <project> <workflow> [--json]
   kent workflow validate <workflow> [--mode draft|task_creation|execution] [--json]
-  kent workflow inspect <workflow> [--json]
+  kent workflow inspect <workflow> [--summary] [--json]
 
 Create reusable task workflows and link them to projects.
 
@@ -24,6 +24,10 @@ Typical setup:
   4. Link it to a project.
   5. Create and start tasks with `kent task`.
 
-Workflow references accept a workflow ID or exact name.
+Workflow references accept only a bare canonical workflow UUID. Workflow names and
+persisted `workflow-...` IDs are not selectors.
+Project filters accept a project path or project ID. Project-filtered results show the
+default workflow first and include link metadata.
+Use `workflow inspect --summary` to read workflow metadata without loading its graph.
 For edge updates, use either `--param` or `--clear-params`, not both.
 Use `--json` when consuming command output from scripts.

--- a/cli/kent/help_test.go
+++ b/cli/kent/help_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestWriteCommandFlagDefaultsUsesDoubleDashLongFlags(t *testing.T) {
+	var output bytes.Buffer
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(&output)
+	fs.Bool("json", false, "write JSON")
+	fs.String("page-size", "", "page size")
+
+	writeCommandFlagDefaults(fs)
+
+	rendered := output.String()
+	if !strings.Contains(rendered, "--json") || !strings.Contains(rendered, "--page-size") {
+		t.Fatalf("help = %q, want double-dash long flags", rendered)
+	}
+	if strings.Contains(rendered, "\n  -json") || strings.Contains(rendered, "\n  -page-size") {
+		t.Fatalf("help = %q, contains single-dash rendered long flags", rendered)
+	}
+}

--- a/cli/kent/help_test.go
+++ b/cli/kent/help_test.go
@@ -1,26 +1,28 @@
 package main
 
 import (
-	"bytes"
 	"flag"
-	"strings"
 	"testing"
 )
 
-func TestWriteCommandFlagDefaultsUsesDoubleDashLongFlags(t *testing.T) {
-	var output bytes.Buffer
+func TestCommandFlagDefaultMetadataUsesTypedGetterValues(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	fs.SetOutput(&output)
-	fs.Bool("json", false, "write JSON")
-	fs.String("page-size", "", "page size")
+	fs.String("path", "release/v1", "`ref` custom reference")
+	fs.String("zero-string", "0", "string")
+	fs.String("empty-string", "", "string")
+	fs.Bool("false", false, "false")
+	fs.Int("zero-int", 0, "zero")
 
-	writeCommandFlagDefaults(fs)
-
-	rendered := output.String()
-	if !strings.Contains(rendered, "--json") || !strings.Contains(rendered, "--page-size") {
-		t.Fatalf("help = %q, want double-dash long flags", rendered)
+	tests := map[string]commandFlagDefaultMetadata{
+		"path":         {Value: "release/v1", Visible: true, Quote: true},
+		"zero-string":  {Value: "0", Visible: true, Quote: true},
+		"empty-string": {Value: "", Visible: false, Quote: true},
+		"false":        {Value: "false", Visible: false},
+		"zero-int":     {Value: "0", Visible: false},
 	}
-	if strings.Contains(rendered, "\n  -json") || strings.Contains(rendered, "\n  -page-size") {
-		t.Fatalf("help = %q, contains single-dash rendered long flags", rendered)
+	for name, want := range tests {
+		if got := commandFlagDefaultMetadataFor(fs.Lookup(name)); got != want {
+			t.Fatalf("metadata for %q = %+v, want %+v", name, got, want)
+		}
 	}
 }

--- a/cli/kent/task_complete_command_test.go
+++ b/cli/kent/task_complete_command_test.go
@@ -374,7 +374,8 @@ func TestTaskCompleteAgentCrossSessionSelectorUsesServiceOwnershipError(t *testi
 	if _, linkErr, code := runWorkflowRootCommand("workflow", "link", binding.ProjectID, workflowID, "--default"); code != 0 {
 		t.Fatalf("workflow link exit=%d stderr=%q", code, linkErr)
 	}
-	created, err := remote.CreateWorkflowTask(context.Background(), serverapi.WorkflowTaskCreateRequest{ProjectID: binding.ProjectID, WorkflowID: workflowID, Title: "Task", Body: "Body"})
+	persistedWorkflowID := workflowPersistedIDForTest(t, workflowID)
+	created, err := remote.CreateWorkflowTask(context.Background(), serverapi.WorkflowTaskCreateRequest{ProjectID: binding.ProjectID, WorkflowID: &persistedWorkflowID, Title: "Task", Body: "Body"})
 	if err != nil {
 		t.Fatalf("CreateWorkflowTask: %v", err)
 	}

--- a/cli/kent/task_lifecycle_command.go
+++ b/cli/kent/task_lifecycle_command.go
@@ -49,69 +49,66 @@ func taskCreateSubcommand(args []string, stdout io.Writer, stderr io.Writer) int
 		}
 		selectedWorkflow = &selector
 	}
-	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, *projectRef)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	var workflowID *string
-	if selectedWorkflow != nil {
-		value := selectedWorkflow.PersistedID()
-		workflowID = &value
-	}
-	sourceWorkspaceID := ""
-	if strings.TrimSpace(*sourceWorkspace) != "" {
-		sourceWorkspaceID, err = resolveWorkflowSourceWorkspaceID(context.Background(), cfg, remote, *sourceWorkspace)
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, *projectRef)
 		if err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	resp, err := remote.CreateWorkflowTask(ctx, serverapi.WorkflowTaskCreateRequest{ProjectID: projectID, WorkflowID: workflowID, Title: *title, Body: taskBody, SourceURL: *sourceURL, SourceWorkspaceID: sourceWorkspaceID})
-	if err != nil {
-		var selectedWorkflowID *string
+		var workflowID *string
 		if selectedWorkflow != nil {
-			value := selectedWorkflow.String()
-			selectedWorkflowID = &value
+			value := selectedWorkflow.PersistedID()
+			workflowID = &value
 		}
-		writeTaskCreateError(stderr, err, taskCreateCommandContext{
-			ProjectRef:         *projectRef,
-			ResolvedProjectID:  projectID,
-			SelectedWorkflowID: selectedWorkflowID,
-			Title:              *title,
-			Body:               *body,
-			BodyFile:           *bodyFile,
-			SourceURL:          *sourceURL,
-			SourceWorkspace:    *sourceWorkspace,
-			JSON:               *jsonOut,
-		})
-		return 1
-	}
-	task, err := getWorkflowTaskByID(context.Background(), remote, resp.Task.ID)
-	if err != nil {
-		fmt.Fprintf(stderr, "created task %s but failed to load task detail for output: %v\n", resp.Task.ID, err)
-		return 1
-	}
-	task, err = workflowTaskDetailForCLI(task)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		return writeCommandJSON(stdout, stderr, taskShowOutputFromDetail(task))
-	}
-	if err := writeTaskDetail(stdout, task); err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	return 0
+		sourceWorkspaceID := ""
+		if strings.TrimSpace(*sourceWorkspace) != "" {
+			sourceWorkspaceID, err = resolveWorkflowSourceWorkspaceID(context.Background(), cfg, remote, *sourceWorkspace)
+			if err != nil {
+				fmt.Fprintln(stderr, err)
+				return 1
+			}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		resp, err := remote.CreateWorkflowTask(ctx, serverapi.WorkflowTaskCreateRequest{ProjectID: projectID, WorkflowID: workflowID, Title: *title, Body: taskBody, SourceURL: *sourceURL, SourceWorkspaceID: sourceWorkspaceID})
+		if err != nil {
+			var selectedWorkflowID *string
+			if selectedWorkflow != nil {
+				value := selectedWorkflow.String()
+				selectedWorkflowID = &value
+			}
+			writeTaskCreateError(stderr, err, taskCreateCommandContext{
+				ProjectRef:         *projectRef,
+				ResolvedProjectID:  projectID,
+				SelectedWorkflowID: selectedWorkflowID,
+				Title:              *title,
+				Body:               *body,
+				BodyFile:           *bodyFile,
+				SourceURL:          *sourceURL,
+				SourceWorkspace:    *sourceWorkspace,
+				JSON:               *jsonOut,
+			})
+			return 1
+		}
+		task, err := getWorkflowTaskByID(context.Background(), remote, resp.Task.ID)
+		if err != nil {
+			fmt.Fprintf(stderr, "created task %s but failed to load task detail for output: %v\n", resp.Task.ID, err)
+			return 1
+		}
+		task, err = workflowTaskDetailForCLI(task)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if *jsonOut {
+			return writeCommandJSON(stdout, stderr, taskShowOutputFromDetail(task))
+		}
+		if err := writeTaskDetail(stdout, task); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	})
 }
 
 func writeTaskCreateError(stderr io.Writer, err error, commandContext taskCreateCommandContext) {
@@ -184,55 +181,52 @@ func taskEditSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "--body cannot be combined with --body-file")
 		return 2
 	}
-	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	// Send title only when provided; omitting it leaves the persisted title unchanged.
-	req := serverapi.WorkflowTaskUpdateRequest{TaskID: taskID}
-	if titleProvided {
-		req.Title = title
-	}
-	if bodyProvided || bodyFileProvided {
-		newBody, err := readTaskEditBody(*body, *bodyFile, bodyFileProvided)
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 2
-		}
-		req.Body = &newBody
-	}
-	if workspaceProvided {
-		workspaceID, err := resolveWorkflowSourceWorkspaceID(context.Background(), cfg, remote, *sourceWorkspace)
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
 		if err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		req.SourceWorkspaceID = workspaceID
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	resp, err := remote.UpdateWorkflowTask(ctx, req)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		projected, projectionErr := workflowTaskSummaryForCLI(resp.Task)
-		if projectionErr != nil {
-			fmt.Fprintln(stderr, projectionErr)
+		// Send title only when provided; omitting it leaves the persisted title unchanged.
+		req := serverapi.WorkflowTaskUpdateRequest{TaskID: taskID}
+		if titleProvided {
+			req.Title = title
+		}
+		if bodyProvided || bodyFileProvided {
+			newBody, err := readTaskEditBody(*body, *bodyFile, bodyFileProvided)
+			if err != nil {
+				fmt.Fprintln(stderr, err)
+				return 2
+			}
+			req.Body = &newBody
+		}
+		if workspaceProvided {
+			workspaceID, err := resolveWorkflowSourceWorkspaceID(context.Background(), cfg, remote, *sourceWorkspace)
+			if err != nil {
+				fmt.Fprintln(stderr, err)
+				return 1
+			}
+			req.SourceWorkspaceID = workspaceID
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		resp, err := remote.UpdateWorkflowTask(ctx, req)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		resp.Task = projected
-		return writeCommandJSON(stdout, stderr, resp)
-	}
-	fmt.Fprintf(stdout, "Edited task %s.\n", taskSummaryDisplayID(resp.Task))
-	return 0
+		if *jsonOut {
+			projected, projectionErr := workflowTaskSummaryForCLI(resp.Task)
+			if projectionErr != nil {
+				fmt.Fprintln(stderr, projectionErr)
+				return 1
+			}
+			resp.Task = projected
+			return writeCommandJSON(stdout, stderr, resp)
+		}
+		fmt.Fprintf(stdout, "Edited task %s.\n", taskSummaryDisplayID(resp.Task))
+		return 0
+	})
 }
 
 // readTaskEditBody reads the replacement body for task edit. Unlike task create,
@@ -271,57 +265,54 @@ func taskStartSubcommand(args []string, stdout io.Writer, stderr io.Writer) int 
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskStartResponse, error) {
-		return remote.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{SetupOperationID: setupOperationID, TaskID: taskID, ExecutionTarget: executionTarget})
-	})
-	if err != nil {
-		if !writeWorkflowExecutionTargetError(stderr, err) {
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
+		if err != nil {
 			fmt.Fprintln(stderr, err)
+			return 1
 		}
-		return 1
-	}
-	if err := resp.Validate(); err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if resp.Outcome == serverapi.WorkflowExecutionTargetActionOutcomeSelectionRequired {
+		resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskStartResponse, error) {
+			return remote.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{SetupOperationID: setupOperationID, TaskID: taskID, ExecutionTarget: executionTarget})
+		})
+		if err != nil {
+			if !writeWorkflowExecutionTargetError(stderr, err) {
+				fmt.Fprintln(stderr, err)
+			}
+			return 1
+		}
+		if err := resp.Validate(); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if resp.Outcome == serverapi.WorkflowExecutionTargetActionOutcomeSelectionRequired {
+			if *jsonOut {
+				_ = writeCommandJSON(stdout, stderr, resp)
+			} else {
+				writeWorkflowExecutionTargetSelectionRequired(stderr, resp.SelectionRequired)
+			}
+			return 1
+		}
+		applied, err := requireAppliedWorkflowAction(resp.Outcome, resp.Applied)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
 		if *jsonOut {
-			_ = writeCommandJSON(stdout, stderr, resp)
-		} else {
-			writeWorkflowExecutionTargetSelectionRequired(stderr, resp.SelectionRequired)
+			return writeCommandJSON(stdout, stderr, resp)
 		}
-		return 1
-	}
-	applied, err := requireAppliedWorkflowAction(resp.Outcome, resp.Applied)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		return writeCommandJSON(stdout, stderr, resp)
-	}
-	detail, err := waitForWorkflowTaskRunSession(context.Background(), remote, taskID, applied.RunID, taskStartSessionPollTimeout, taskStartSessionPollInterval)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	detail, err = workflowTaskDetailForCLI(detail)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	writeTaskStartResult(stdout, detail, *applied)
-	return 0
+		detail, err := waitForWorkflowTaskRunSession(context.Background(), remote, taskID, applied.RunID, taskStartSessionPollTimeout, taskStartSessionPollInterval)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		detail, err = workflowTaskDetailForCLI(detail)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		writeTaskStartResult(stdout, detail, *applied)
+		return 0
+	})
 }
 
 func writeWorkflowExecutionTargetSelectionRequired(stderr io.Writer, requirement *serverapi.WorkflowExecutionTargetSelectionRequirement) {
@@ -386,29 +377,26 @@ func taskCancelSubcommand(args []string, stdout io.Writer, stderr io.Writer) int
 	if denyAgentHumanOnlyTaskAction(stderr) {
 		return 1
 	}
-	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	if err := remote.CancelWorkflowTask(ctx, serverapi.WorkflowTaskCancelRequest{TaskID: taskID, Reason: *reason}); err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	detail, err := getWorkflowTaskByID(context.Background(), remote, taskID)
-	if err != nil {
-		fmt.Fprintf(stderr, "canceled task %s but failed to load task detail for output: %v\n", taskID, err)
-		return 1
-	}
-	fmt.Fprintf(stdout, "Canceled task %s.\n", taskDisplayID(detail))
-	return 0
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		if err := remote.CancelWorkflowTask(ctx, serverapi.WorkflowTaskCancelRequest{TaskID: taskID, Reason: *reason}); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		detail, err := getWorkflowTaskByID(context.Background(), remote, taskID)
+		if err != nil {
+			fmt.Fprintf(stderr, "canceled task %s but failed to load task detail for output: %v\n", taskID, err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "Canceled task %s.\n", taskDisplayID(detail))
+		return 0
+	})
 }
 
 func taskDeleteSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -426,30 +414,27 @@ func taskDeleteSubcommand(args []string, stdout io.Writer, stderr io.Writer) int
 	if denyAgentHumanOnlyTaskAction(stderr) {
 		return 1
 	}
-	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	// Load the task detail before deletion so we can report a stable display id;
-	// the task no longer exists once the delete RPC succeeds.
-	displayID := taskID
-	if detail, err := getWorkflowTaskByID(context.Background(), remote, taskID); err == nil {
-		displayID = taskDisplayID(detail)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	if err := remote.DeleteWorkflowTask(ctx, serverapi.WorkflowTaskDeleteRequest{TaskID: taskID}); err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	fmt.Fprintf(stdout, "Deleted task %s.\n", displayID)
-	return 0
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		// Load the task detail before deletion so we can report a stable display id;
+		// the task no longer exists once the delete RPC succeeds.
+		displayID := taskID
+		if detail, err := getWorkflowTaskByID(context.Background(), remote, taskID); err == nil {
+			displayID = taskDisplayID(detail)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		if err := remote.DeleteWorkflowTask(ctx, serverapi.WorkflowTaskDeleteRequest{TaskID: taskID}); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "Deleted task %s.\n", displayID)
+		return 0
+	})
 }
 
 func taskResumeSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -467,30 +452,27 @@ func taskResumeSubcommand(args []string, stdout io.Writer, stderr io.Writer) int
 	if denyAgentHumanOnlyTaskAction(stderr) {
 		return 1
 	}
-	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	resp, err := remote.ResumeWorkflowTask(ctx, serverapi.WorkflowTaskResumeRequest{TaskID: taskID})
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	detail, err := getWorkflowTaskByID(context.Background(), remote, taskID)
-	if err != nil {
-		fmt.Fprintf(stderr, "resumed task %s but failed to load task detail for output: %v\n", taskID, err)
-		return 1
-	}
-	writeTaskResumeResult(stdout, detail, resp)
-	return 0
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		resp, err := remote.ResumeWorkflowTask(ctx, serverapi.WorkflowTaskResumeRequest{TaskID: taskID})
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		detail, err := getWorkflowTaskByID(context.Background(), remote, taskID)
+		if err != nil {
+			fmt.Fprintf(stderr, "resumed task %s but failed to load task detail for output: %v\n", taskID, err)
+			return 1
+		}
+		writeTaskResumeResult(stdout, detail, resp)
+		return 0
+	})
 }
 
 func taskApproveSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -513,43 +495,40 @@ func taskApproveSubcommand(args []string, stdout io.Writer, stderr io.Writer) in
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskApproveResponse, error) {
-		return remote.ApproveWorkflowTask(ctx, serverapi.WorkflowTaskApproveRequest{SetupOperationID: setupOperationID, TransitionID: positionals[0], ExecutionTarget: executionTarget})
-	})
-	if err != nil {
-		if !writeWorkflowExecutionTargetError(stderr, err) {
-			fmt.Fprintln(stderr, err)
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskApproveResponse, error) {
+			return remote.ApproveWorkflowTask(ctx, serverapi.WorkflowTaskApproveRequest{SetupOperationID: setupOperationID, TransitionID: positionals[0], ExecutionTarget: executionTarget})
+		})
+		if err != nil {
+			if !writeWorkflowExecutionTargetError(stderr, err) {
+				fmt.Fprintln(stderr, err)
+			}
+			return 1
 		}
-		return 1
-	}
-	if err := resp.Validate(); err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if workflowActionRequiresExecutionTargetSelection(stderr, resp.Outcome, resp.SelectionRequired) {
-		return 1
-	}
-	applied, err := requireAppliedWorkflowAction(resp.Outcome, resp.Applied)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if strings.TrimSpace(applied.TaskID) == "" {
-		fmt.Fprintf(stderr, "approved transition %s but response did not include task id for output\n", applied.TransitionID)
-		return 1
-	}
-	detail, err := getWorkflowTaskByID(context.Background(), remote, applied.TaskID)
-	if err != nil {
-		fmt.Fprintf(stderr, "approved transition %s but failed to load task detail for output: %v\n", applied.TransitionID, err)
-		return 1
-	}
-	writeTaskTransitionResult(stdout, "Approved transition of", detail, applied.TransitionID, applied.RunIDs)
-	return 0
+		if err := resp.Validate(); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if workflowActionRequiresExecutionTargetSelection(stderr, resp.Outcome, resp.SelectionRequired) {
+			return 1
+		}
+		applied, err := requireAppliedWorkflowAction(resp.Outcome, resp.Applied)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if strings.TrimSpace(applied.TaskID) == "" {
+			fmt.Fprintf(stderr, "approved transition %s but response did not include task id for output\n", applied.TransitionID)
+			return 1
+		}
+		detail, err := getWorkflowTaskByID(context.Background(), remote, applied.TaskID)
+		if err != nil {
+			fmt.Fprintf(stderr, "approved transition %s but failed to load task detail for output: %v\n", applied.TransitionID, err)
+			return 1
+		}
+		writeTaskTransitionResult(stdout, "Approved transition of", detail, applied.TransitionID, applied.RunIDs)
+		return 0
+	})
 }
 
 func taskMoveSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -576,44 +555,41 @@ func taskMoveSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskMoveResponse, error) {
-		return remote.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: setupOperationID, TaskID: taskID, TargetNodeID: positionals[1], OutputValues: outputs.values, Commentary: *commentary, ExecutionTarget: executionTarget})
-	})
-	if err != nil {
-		if !writeWorkflowExecutionTargetError(stderr, err) {
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
+		if err != nil {
 			fmt.Fprintln(stderr, err)
+			return 1
 		}
-		return 1
-	}
-	if err := resp.Validate(); err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if workflowActionRequiresExecutionTargetSelection(stderr, resp.Outcome, resp.SelectionRequired) {
-		return 1
-	}
-	applied, err := requireAppliedWorkflowAction(resp.Outcome, resp.Applied)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	detail, err := getWorkflowTaskByID(context.Background(), remote, taskID)
-	if err != nil {
-		fmt.Fprintf(stderr, "moved task %s but failed to load task detail for output: %v\n", taskID, err)
-		return 1
-	}
-	writeTaskTransitionResult(stdout, "Moved task", detail, applied.TransitionID, applied.RunIDs)
-	return 0
+		resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskMoveResponse, error) {
+			return remote.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: setupOperationID, TaskID: taskID, TargetNodeID: positionals[1], OutputValues: outputs.values, Commentary: *commentary, ExecutionTarget: executionTarget})
+		})
+		if err != nil {
+			if !writeWorkflowExecutionTargetError(stderr, err) {
+				fmt.Fprintln(stderr, err)
+			}
+			return 1
+		}
+		if err := resp.Validate(); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if workflowActionRequiresExecutionTargetSelection(stderr, resp.Outcome, resp.SelectionRequired) {
+			return 1
+		}
+		applied, err := requireAppliedWorkflowAction(resp.Outcome, resp.Applied)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		detail, err := getWorkflowTaskByID(context.Background(), remote, taskID)
+		if err != nil {
+			fmt.Fprintf(stderr, "moved task %s but failed to load task detail for output: %v\n", taskID, err)
+			return 1
+		}
+		writeTaskTransitionResult(stdout, "Moved task", detail, applied.TransitionID, applied.RunIDs)
+		return 0
+	})
 }
 
 func workflowActionRequiresExecutionTargetSelection(

--- a/cli/kent/task_lifecycle_command.go
+++ b/cli/kent/task_lifecycle_command.go
@@ -115,6 +115,18 @@ func taskCreateSubcommand(args []string, stdout io.Writer, stderr io.Writer) int
 }
 
 func writeTaskCreateError(stderr io.Writer, err error, commandContext taskCreateCommandContext) {
+	var conflictErr *serverapi.WorkflowTaskCreateConflictError
+	if errors.As(err, &conflictErr) {
+		switch conflictErr.Reason {
+		case serverapi.WorkflowTaskCreateConflictReasonSerialization:
+			retryCommand := taskCreateRetryCommandArgs(commandContext, commandContext.SelectedWorkflowID)
+			fmt.Fprintln(stderr, "Task creation conflicted with a concurrent update. This failure is retryable; no task was created.")
+			fmt.Fprintf(stderr, "  %s\n", commandString(retryCommand))
+		default:
+			fmt.Fprintln(stderr, err)
+		}
+		return
+	}
 	var selectionErr *serverapi.WorkflowTaskCreateSelectionError
 	if !errors.As(err, &selectionErr) {
 		fmt.Fprintln(stderr, err)

--- a/cli/kent/task_lifecycle_command.go
+++ b/cli/kent/task_lifecycle_command.go
@@ -495,7 +495,7 @@ func taskApproveSubcommand(args []string, stdout io.Writer, stderr io.Writer) in
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
 		resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskApproveResponse, error) {
 			return remote.ApproveWorkflowTask(ctx, serverapi.WorkflowTaskApproveRequest{SetupOperationID: setupOperationID, TransitionID: positionals[0], ExecutionTarget: executionTarget})
 		})

--- a/cli/kent/task_lifecycle_command.go
+++ b/cli/kent/task_lifecycle_command.go
@@ -23,7 +23,7 @@ func taskCreateSubcommand(args []string, stdout io.Writer, stderr io.Writer) int
 	title := fs.String("title", "", "task title")
 	body := fs.String("body", "", "task body")
 	bodyFile := fs.String("body-file", "", "read the task body from this file")
-	workflowRef := fs.String("workflow", "", "workflow ID or exact name; defaults to the project's default workflow")
+	workflowRef := fs.String("workflow", "", "workflow UUID; defaults to the project's default workflow")
 	projectRef := fs.String("project", ".", "project ID or attached workspace path")
 	sourceURL := fs.String("source-url", "", "URL of the issue or document that originated the task")
 	sourceWorkspace := fs.String("source-workspace", "", "workspace ID or path used as the task's source checkout")
@@ -40,49 +40,107 @@ func taskCreateSubcommand(args []string, stdout io.Writer, stderr io.Writer) int
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
-		projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, *projectRef)
+	var selectedWorkflow *workflowSelector
+	if flagWasProvided(fs, "workflow") {
+		selector, parseErr := parseWorkflowSelector(*workflowRef)
+		if parseErr != nil {
+			fmt.Fprintln(stderr, parseErr)
+			return 2
+		}
+		selectedWorkflow = &selector
+	}
+	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, *projectRef)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	var workflowID *string
+	if selectedWorkflow != nil {
+		value := selectedWorkflow.PersistedID()
+		workflowID = &value
+	}
+	sourceWorkspaceID := ""
+	if strings.TrimSpace(*sourceWorkspace) != "" {
+		sourceWorkspaceID, err = resolveWorkflowSourceWorkspaceID(context.Background(), cfg, remote, *sourceWorkspace)
 		if err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		workflowID := ""
-		if strings.TrimSpace(*workflowRef) != "" {
-			workflowID, err = resolveWorkflowID(context.Background(), remote, *workflowRef)
-			if err != nil {
-				fmt.Fprintln(stderr, err)
-				return 1
-			}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	resp, err := remote.CreateWorkflowTask(ctx, serverapi.WorkflowTaskCreateRequest{ProjectID: projectID, WorkflowID: workflowID, Title: *title, Body: taskBody, SourceURL: *sourceURL, SourceWorkspaceID: sourceWorkspaceID})
+	if err != nil {
+		var selectedWorkflowID *string
+		if selectedWorkflow != nil {
+			value := selectedWorkflow.String()
+			selectedWorkflowID = &value
 		}
-		sourceWorkspaceID := ""
-		if strings.TrimSpace(*sourceWorkspace) != "" {
-			sourceWorkspaceID, err = resolveWorkflowSourceWorkspaceID(context.Background(), cfg, remote, *sourceWorkspace)
-			if err != nil {
-				fmt.Fprintln(stderr, err)
-				return 1
-			}
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		resp, err := remote.CreateWorkflowTask(ctx, serverapi.WorkflowTaskCreateRequest{ProjectID: projectID, WorkflowID: workflowID, Title: *title, Body: taskBody, SourceURL: *sourceURL, SourceWorkspaceID: sourceWorkspaceID})
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		task, err := getWorkflowTaskByID(context.Background(), remote, resp.Task.ID)
-		if err != nil {
-			fmt.Fprintf(stderr, "created task %s but failed to load task detail for output: %v\n", resp.Task.ID, err)
-			return 1
-		}
-		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, taskShowOutputFromDetail(task))
-		}
-		if err := writeTaskDetail(stdout, task); err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		return 0
-	})
+		writeTaskCreateError(stderr, err, taskCreateCommandContext{
+			ProjectRef:         *projectRef,
+			ResolvedProjectID:  projectID,
+			SelectedWorkflowID: selectedWorkflowID,
+			Title:              *title,
+			Body:               *body,
+			BodyFile:           *bodyFile,
+			SourceURL:          *sourceURL,
+			SourceWorkspace:    *sourceWorkspace,
+			JSON:               *jsonOut,
+		})
+		return 1
+	}
+	task, err := getWorkflowTaskByID(context.Background(), remote, resp.Task.ID)
+	if err != nil {
+		fmt.Fprintf(stderr, "created task %s but failed to load task detail for output: %v\n", resp.Task.ID, err)
+		return 1
+	}
+	task, err = workflowTaskDetailForCLI(task)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		return writeCommandJSON(stdout, stderr, taskShowOutputFromDetail(task))
+	}
+	if err := writeTaskDetail(stdout, task); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func writeTaskCreateError(stderr io.Writer, err error, commandContext taskCreateCommandContext) {
+	var selectionErr *serverapi.WorkflowTaskCreateSelectionError
+	if !errors.As(err, &selectionErr) {
+		fmt.Fprintln(stderr, err)
+		return
+	}
+	recovery, projectionErr := taskCreateRecoveryForSelectionError(selectionErr, commandContext)
+	if projectionErr != nil {
+		fmt.Fprintln(stderr, projectionErr)
+		return
+	}
+	switch recovery.Kind {
+	case taskWorkflowRecoveryNoLinkedWorkflows:
+		fmt.Fprintln(stderr, "This project doesn't have any linked workflows yet. First, create a workflow or link an existing one, then retry.")
+	case taskWorkflowRecoveryWorkflowNotLinked:
+		fmt.Fprintln(stderr, "The selected workflow isn't linked to this project.")
+	case taskWorkflowRecoveryAmbiguousWithoutDefault:
+		fmt.Fprintf(
+			stderr,
+			"Tasks need both a project and a workflow binding, but your input leaves workflow choice ambiguous. Run `%s`, then retry with `--workflow <uuid>` or set a default with `%s`.\n",
+			commandString(recovery.Commands[0].Args),
+			commandString(recovery.Commands[2].Args),
+		)
+	}
+	for _, command := range recovery.Commands {
+		fmt.Fprintf(stderr, "  %s\n", commandString(command.Args))
+	}
 }
 
 func taskEditSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -114,46 +172,55 @@ func taskEditSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "--body cannot be combined with --body-file")
 		return 2
 	}
-	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
-		taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
+	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	// Send title only when provided; omitting it leaves the persisted title unchanged.
+	req := serverapi.WorkflowTaskUpdateRequest{TaskID: taskID}
+	if titleProvided {
+		req.Title = title
+	}
+	if bodyProvided || bodyFileProvided {
+		newBody, err := readTaskEditBody(*body, *bodyFile, bodyFileProvided)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 2
+		}
+		req.Body = &newBody
+	}
+	if workspaceProvided {
+		workspaceID, err := resolveWorkflowSourceWorkspaceID(context.Background(), cfg, remote, *sourceWorkspace)
 		if err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		// Send title only when provided; omitting it leaves the persisted title unchanged.
-		req := serverapi.WorkflowTaskUpdateRequest{TaskID: taskID}
-		if titleProvided {
-			req.Title = title
-		}
-		if bodyProvided || bodyFileProvided {
-			newBody, err := readTaskEditBody(*body, *bodyFile, bodyFileProvided)
-			if err != nil {
-				fmt.Fprintln(stderr, err)
-				return 2
-			}
-			req.Body = &newBody
-		}
-		if workspaceProvided {
-			workspaceID, err := resolveWorkflowSourceWorkspaceID(context.Background(), cfg, remote, *sourceWorkspace)
-			if err != nil {
-				fmt.Fprintln(stderr, err)
-				return 1
-			}
-			req.SourceWorkspaceID = workspaceID
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		resp, err := remote.UpdateWorkflowTask(ctx, req)
-		if err != nil {
-			fmt.Fprintln(stderr, err)
+		req.SourceWorkspaceID = workspaceID
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	resp, err := remote.UpdateWorkflowTask(ctx, req)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		projected, projectionErr := workflowTaskSummaryForCLI(resp.Task)
+		if projectionErr != nil {
+			fmt.Fprintln(stderr, projectionErr)
 			return 1
 		}
-		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, resp)
-		}
-		fmt.Fprintf(stdout, "Edited task %s.\n", taskSummaryDisplayID(resp.Task))
-		return 0
-	})
+		resp.Task = projected
+		return writeCommandJSON(stdout, stderr, resp)
+	}
+	fmt.Fprintf(stdout, "Edited task %s.\n", taskSummaryDisplayID(resp.Task))
+	return 0
 }
 
 // readTaskEditBody reads the replacement body for task edit. Unlike task create,
@@ -192,49 +259,57 @@ func taskStartSubcommand(args []string, stdout io.Writer, stderr io.Writer) int 
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
-		taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskStartResponse, error) {
-			return remote.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{SetupOperationID: setupOperationID, TaskID: taskID, ExecutionTarget: executionTarget})
-		})
-		if err != nil {
-			if !writeWorkflowExecutionTargetError(stderr, err) {
-				fmt.Fprintln(stderr, err)
-			}
-			return 1
-		}
-		if err := resp.Validate(); err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if resp.Outcome == serverapi.WorkflowExecutionTargetActionOutcomeSelectionRequired {
-			if *jsonOut {
-				_ = writeCommandJSON(stdout, stderr, resp)
-			} else {
-				writeWorkflowExecutionTargetSelectionRequired(stderr, resp.SelectionRequired)
-			}
-			return 1
-		}
-		applied, err := requireAppliedWorkflowAction(resp.Outcome, resp.Applied)
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, resp)
-		}
-		detail, err := waitForWorkflowTaskRunSession(context.Background(), remote, taskID, applied.RunID, taskStartSessionPollTimeout, taskStartSessionPollInterval)
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		writeTaskStartResult(stdout, detail, *applied)
-		return 0
+	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskStartResponse, error) {
+		return remote.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{SetupOperationID: setupOperationID, TaskID: taskID, ExecutionTarget: executionTarget})
 	})
+	if err != nil {
+		if !writeWorkflowExecutionTargetError(stderr, err) {
+			fmt.Fprintln(stderr, err)
+		}
+		return 1
+	}
+	if err := resp.Validate(); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if resp.Outcome == serverapi.WorkflowExecutionTargetActionOutcomeSelectionRequired {
+		if *jsonOut {
+			_ = writeCommandJSON(stdout, stderr, resp)
+		} else {
+			writeWorkflowExecutionTargetSelectionRequired(stderr, resp.SelectionRequired)
+		}
+		return 1
+	}
+	applied, err := requireAppliedWorkflowAction(resp.Outcome, resp.Applied)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		return writeCommandJSON(stdout, stderr, resp)
+	}
+	detail, err := waitForWorkflowTaskRunSession(context.Background(), remote, taskID, applied.RunID, taskStartSessionPollTimeout, taskStartSessionPollInterval)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	detail, err = workflowTaskDetailForCLI(detail)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	writeTaskStartResult(stdout, detail, *applied)
+	return 0
 }
 
 func writeWorkflowExecutionTargetSelectionRequired(stderr io.Writer, requirement *serverapi.WorkflowExecutionTargetSelectionRequirement) {
@@ -299,26 +374,29 @@ func taskCancelSubcommand(args []string, stdout io.Writer, stderr io.Writer) int
 	if denyAgentHumanOnlyTaskAction(stderr) {
 		return 1
 	}
-	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
-		taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		if err := remote.CancelWorkflowTask(ctx, serverapi.WorkflowTaskCancelRequest{TaskID: taskID, Reason: *reason}); err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		detail, err := getWorkflowTaskByID(context.Background(), remote, taskID)
-		if err != nil {
-			fmt.Fprintf(stderr, "canceled task %s but failed to load task detail for output: %v\n", taskID, err)
-			return 1
-		}
-		fmt.Fprintf(stdout, "Canceled task %s.\n", taskDisplayID(detail))
-		return 0
-	})
+	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	if err := remote.CancelWorkflowTask(ctx, serverapi.WorkflowTaskCancelRequest{TaskID: taskID, Reason: *reason}); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	detail, err := getWorkflowTaskByID(context.Background(), remote, taskID)
+	if err != nil {
+		fmt.Fprintf(stderr, "canceled task %s but failed to load task detail for output: %v\n", taskID, err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Canceled task %s.\n", taskDisplayID(detail))
+	return 0
 }
 
 func taskDeleteSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -336,27 +414,30 @@ func taskDeleteSubcommand(args []string, stdout io.Writer, stderr io.Writer) int
 	if denyAgentHumanOnlyTaskAction(stderr) {
 		return 1
 	}
-	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
-		taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		// Load the task detail before deletion so we can report a stable display id;
-		// the task no longer exists once the delete RPC succeeds.
-		displayID := taskID
-		if detail, err := getWorkflowTaskByID(context.Background(), remote, taskID); err == nil {
-			displayID = taskDisplayID(detail)
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		if err := remote.DeleteWorkflowTask(ctx, serverapi.WorkflowTaskDeleteRequest{TaskID: taskID}); err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		fmt.Fprintf(stdout, "Deleted task %s.\n", displayID)
-		return 0
-	})
+	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	// Load the task detail before deletion so we can report a stable display id;
+	// the task no longer exists once the delete RPC succeeds.
+	displayID := taskID
+	if detail, err := getWorkflowTaskByID(context.Background(), remote, taskID); err == nil {
+		displayID = taskDisplayID(detail)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	if err := remote.DeleteWorkflowTask(ctx, serverapi.WorkflowTaskDeleteRequest{TaskID: taskID}); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Deleted task %s.\n", displayID)
+	return 0
 }
 
 func taskResumeSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -374,27 +455,30 @@ func taskResumeSubcommand(args []string, stdout io.Writer, stderr io.Writer) int
 	if denyAgentHumanOnlyTaskAction(stderr) {
 		return 1
 	}
-	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
-		taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		resp, err := remote.ResumeWorkflowTask(ctx, serverapi.WorkflowTaskResumeRequest{TaskID: taskID})
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		detail, err := getWorkflowTaskByID(context.Background(), remote, taskID)
-		if err != nil {
-			fmt.Fprintf(stderr, "resumed task %s but failed to load task detail for output: %v\n", taskID, err)
-			return 1
-		}
-		writeTaskResumeResult(stdout, detail, resp)
-		return 0
-	})
+	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	resp, err := remote.ResumeWorkflowTask(ctx, serverapi.WorkflowTaskResumeRequest{TaskID: taskID})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	detail, err := getWorkflowTaskByID(context.Background(), remote, taskID)
+	if err != nil {
+		fmt.Fprintf(stderr, "resumed task %s but failed to load task detail for output: %v\n", taskID, err)
+		return 1
+	}
+	writeTaskResumeResult(stdout, detail, resp)
+	return 0
 }
 
 func taskApproveSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -417,40 +501,43 @@ func taskApproveSubcommand(args []string, stdout io.Writer, stderr io.Writer) in
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
-		resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskApproveResponse, error) {
-			return remote.ApproveWorkflowTask(ctx, serverapi.WorkflowTaskApproveRequest{SetupOperationID: setupOperationID, TransitionID: positionals[0], ExecutionTarget: executionTarget})
-		})
-		if err != nil {
-			if !writeWorkflowExecutionTargetError(stderr, err) {
-				fmt.Fprintln(stderr, err)
-			}
-			return 1
-		}
-		if err := resp.Validate(); err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if workflowActionRequiresExecutionTargetSelection(stderr, resp.Outcome, resp.SelectionRequired) {
-			return 1
-		}
-		applied, err := requireAppliedWorkflowAction(resp.Outcome, resp.Applied)
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if strings.TrimSpace(applied.TaskID) == "" {
-			fmt.Fprintf(stderr, "approved transition %s but response did not include task id for output\n", applied.TransitionID)
-			return 1
-		}
-		detail, err := getWorkflowTaskByID(context.Background(), remote, applied.TaskID)
-		if err != nil {
-			fmt.Fprintf(stderr, "approved transition %s but failed to load task detail for output: %v\n", applied.TransitionID, err)
-			return 1
-		}
-		writeTaskTransitionResult(stdout, "Approved transition of", detail, applied.TransitionID, applied.RunIDs)
-		return 0
+	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskApproveResponse, error) {
+		return remote.ApproveWorkflowTask(ctx, serverapi.WorkflowTaskApproveRequest{SetupOperationID: setupOperationID, TransitionID: positionals[0], ExecutionTarget: executionTarget})
 	})
+	if err != nil {
+		if !writeWorkflowExecutionTargetError(stderr, err) {
+			fmt.Fprintln(stderr, err)
+		}
+		return 1
+	}
+	if err := resp.Validate(); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if workflowActionRequiresExecutionTargetSelection(stderr, resp.Outcome, resp.SelectionRequired) {
+		return 1
+	}
+	applied, err := requireAppliedWorkflowAction(resp.Outcome, resp.Applied)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if strings.TrimSpace(applied.TaskID) == "" {
+		fmt.Fprintf(stderr, "approved transition %s but response did not include task id for output\n", applied.TransitionID)
+		return 1
+	}
+	detail, err := getWorkflowTaskByID(context.Background(), remote, applied.TaskID)
+	if err != nil {
+		fmt.Fprintf(stderr, "approved transition %s but failed to load task detail for output: %v\n", applied.TransitionID, err)
+		return 1
+	}
+	writeTaskTransitionResult(stdout, "Approved transition of", detail, applied.TransitionID, applied.RunIDs)
+	return 0
 }
 
 func taskMoveSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -477,41 +564,44 @@ func taskMoveSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
-		taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskMoveResponse, error) {
-			return remote.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: setupOperationID, TaskID: taskID, TargetNodeID: positionals[1], OutputValues: outputs.values, Commentary: *commentary, ExecutionTarget: executionTarget})
-		})
-		if err != nil {
-			if !writeWorkflowExecutionTargetError(stderr, err) {
-				fmt.Fprintln(stderr, err)
-			}
-			return 1
-		}
-		if err := resp.Validate(); err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if workflowActionRequiresExecutionTargetSelection(stderr, resp.Outcome, resp.SelectionRequired) {
-			return 1
-		}
-		applied, err := requireAppliedWorkflowAction(resp.Outcome, resp.Applied)
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		detail, err := getWorkflowTaskByID(context.Background(), remote, taskID)
-		if err != nil {
-			fmt.Fprintf(stderr, "moved task %s but failed to load task detail for output: %v\n", taskID, err)
-			return 1
-		}
-		writeTaskTransitionResult(stdout, "Moved task", detail, applied.TransitionID, applied.RunIDs)
-		return 0
+	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	taskID, err := resolveWorkflowTaskID(context.Background(), cfg, remote, *projectRef, positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	resp, err := runWorkflowMutationWithSetupProgress(context.Background(), remote, stderr, func(ctx context.Context, setupOperationID serverapi.WorktreeSetupOperationID) (serverapi.WorkflowTaskMoveResponse, error) {
+		return remote.MoveWorkflowTask(ctx, serverapi.WorkflowTaskMoveRequest{SetupOperationID: setupOperationID, TaskID: taskID, TargetNodeID: positionals[1], OutputValues: outputs.values, Commentary: *commentary, ExecutionTarget: executionTarget})
 	})
+	if err != nil {
+		if !writeWorkflowExecutionTargetError(stderr, err) {
+			fmt.Fprintln(stderr, err)
+		}
+		return 1
+	}
+	if err := resp.Validate(); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if workflowActionRequiresExecutionTargetSelection(stderr, resp.Outcome, resp.SelectionRequired) {
+		return 1
+	}
+	applied, err := requireAppliedWorkflowAction(resp.Outcome, resp.Applied)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	detail, err := getWorkflowTaskByID(context.Background(), remote, taskID)
+	if err != nil {
+		fmt.Fprintf(stderr, "moved task %s but failed to load task detail for output: %v\n", taskID, err)
+		return 1
+	}
+	writeTaskTransitionResult(stdout, "Moved task", detail, applied.TransitionID, applied.RunIDs)
+	return 0
 }
 
 func workflowActionRequiresExecutionTargetSelection(

--- a/cli/kent/task_lifecycle_command_test.go
+++ b/cli/kent/task_lifecycle_command_test.go
@@ -643,10 +643,6 @@ func TestTaskStartCommandPollsForSessionAndPrintsReadableOutput(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("task start exit=%d stdout=%q stderr=%q", code, stdout, stderr)
 	}
-	want := "Started task BLD-1 in session session-1 using workflow \"Workflow\" (" + workflowSelectorTestUUID + ").\nFirst node: implement\n"
-	if stdout != want {
-		t.Fatalf("task start stdout = %q, want %q", stdout, want)
-	}
 	if stderr != "" {
 		t.Fatalf("task start stderr = %q, want empty", stderr)
 	}

--- a/cli/kent/task_lifecycle_command_test.go
+++ b/cli/kent/task_lifecycle_command_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,190 @@ import (
 	"core/shared/serverapi"
 	"core/shared/sessionenv"
 )
+
+func TestTaskCreateRecoveryProjectionBuildsLockedCommandMatrix(t *testing.T) {
+	projectID := "project-1"
+	selectedWorkflowID := workflowSelectorTestUUID
+	persistedSelectedWorkflowID := "workflow-" + selectedWorkflowID
+	for _, testCase := range []struct {
+		name      string
+		createErr *serverapi.WorkflowTaskCreateSelectionError
+		context   taskCreateCommandContext
+		want      taskWorkflowRecovery
+	}{
+		{
+			name: "no linked workflows preserves dot and create options",
+			createErr: &serverapi.WorkflowTaskCreateSelectionError{
+				Reason:    serverapi.WorkflowTaskCreateSelectionReasonNoLinkedWorkflows,
+				ProjectID: projectID,
+			},
+			context: taskCreateCommandContext{
+				ProjectRef:        ".",
+				ResolvedProjectID: projectID,
+				Title:             "Task",
+				Body:              "Body",
+				SourceURL:         "https://example.test/issue/1",
+				SourceWorkspace:   "./workspace",
+				JSON:              true,
+			},
+			want: taskWorkflowRecovery{
+				Kind:       taskWorkflowRecoveryNoLinkedWorkflows,
+				ProjectRef: ".",
+				Commands: []taskWorkflowRecoveryCommand{
+					{Kind: taskWorkflowRecoveryCommandCreateWorkflow, Args: []string{config.Command, "workflow", "create", "<name>"}},
+					{Kind: taskWorkflowRecoveryCommandLinkCreatedWorkflow, Args: []string{config.Command, "workflow", "link", ".", "<created-uuid>"}},
+					{Kind: taskWorkflowRecoveryCommandListWorkflows, Args: []string{config.Command, "workflow", "list"}},
+					{Kind: taskWorkflowRecoveryCommandLinkExistingWorkflow, Args: []string{config.Command, "workflow", "link", ".", "<uuid>"}},
+					{Kind: taskWorkflowRecoveryCommandRetryTaskCreate, Args: []string{config.Command, "task", "create", "--project", ".", "--title", "Task", "--body", "Body", "--source-url", "https://example.test/issue/1", "--source-workspace", "./workspace", "--json"}},
+				},
+			},
+		},
+		{
+			name: "explicit not linked preserves path and selected workflow",
+			createErr: &serverapi.WorkflowTaskCreateSelectionError{
+				Reason:     serverapi.WorkflowTaskCreateSelectionReasonWorkflowNotLinked,
+				ProjectID:  projectID,
+				WorkflowID: &persistedSelectedWorkflowID,
+			},
+			context: taskCreateCommandContext{
+				ProjectRef:         "/tmp/my project",
+				ResolvedProjectID:  projectID,
+				SelectedWorkflowID: &selectedWorkflowID,
+				Title:              "Task",
+				Body:               "Body",
+			},
+			want: taskWorkflowRecovery{
+				Kind:               taskWorkflowRecoveryWorkflowNotLinked,
+				ProjectRef:         "/tmp/my project",
+				SelectedWorkflowID: &selectedWorkflowID,
+				Commands: []taskWorkflowRecoveryCommand{
+					{Kind: taskWorkflowRecoveryCommandListProjectWorkflows, Args: []string{config.Command, "workflow", "list", "--project", "/tmp/my project"}},
+					{Kind: taskWorkflowRecoveryCommandRetryTaskCreate, Args: []string{config.Command, "task", "create", "--project", "/tmp/my project", "--workflow", "<uuid>", "--title", "Task", "--body", "Body"}},
+					{Kind: taskWorkflowRecoveryCommandLinkSelectedWorkflow, Args: []string{config.Command, "workflow", "link", "/tmp/my project", selectedWorkflowID}},
+				},
+			},
+		},
+		{
+			name: "ambiguous selection preserves project id",
+			createErr: &serverapi.WorkflowTaskCreateSelectionError{
+				Reason:    serverapi.WorkflowTaskCreateSelectionReasonAmbiguousWithoutDefault,
+				ProjectID: projectID,
+			},
+			context: taskCreateCommandContext{
+				ProjectRef:        "project-selector",
+				ResolvedProjectID: projectID,
+				Title:             "Task",
+				BodyFile:          "/tmp/task body.md",
+			},
+			want: taskWorkflowRecovery{
+				Kind:       taskWorkflowRecoveryAmbiguousWithoutDefault,
+				ProjectRef: "project-selector",
+				Commands: []taskWorkflowRecoveryCommand{
+					{Kind: taskWorkflowRecoveryCommandListProjectWorkflows, Args: []string{config.Command, "workflow", "list", "--project", "project-selector"}},
+					{Kind: taskWorkflowRecoveryCommandRetryTaskCreate, Args: []string{config.Command, "task", "create", "--project", "project-selector", "--workflow", "<uuid>", "--title", "Task", "--body-file", "/tmp/task body.md"}},
+					{Kind: taskWorkflowRecoveryCommandSetDefaultWorkflow, Args: []string{config.Command, "workflow", "default", "project-selector", "<uuid>"}},
+				},
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := taskCreateRecoveryForSelectionError(testCase.createErr, testCase.context)
+			if err != nil {
+				t.Fatalf("taskCreateRecoveryForSelectionError: %v", err)
+			}
+			if !reflect.DeepEqual(got, testCase.want) {
+				t.Fatalf("recovery = %+v, want %+v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestTaskCreateTypedSelectionErrorsUseResolvedCommandContext(t *testing.T) {
+	cfg, binding, loopback := newWorkflowCommandLoopback(t)
+	pathRef := t.TempDir()
+	loopback.projectBindingsByRoot[pathRef] = serverapi.ProjectBinding{
+		ProjectID:     binding.ProjectID,
+		WorkspaceID:   binding.WorkspaceID,
+		CanonicalRoot: pathRef,
+	}
+	selectedWorkflowID := workflowSelectorTestUUID
+	persistedSelectedWorkflowID := "workflow-" + selectedWorkflowID
+	for _, testCase := range []struct {
+		name       string
+		projectRef string
+		workflowID string
+		createErr  *serverapi.WorkflowTaskCreateSelectionError
+	}{
+		{
+			name:       "dot no links",
+			projectRef: ".",
+			createErr: &serverapi.WorkflowTaskCreateSelectionError{
+				Reason:    serverapi.WorkflowTaskCreateSelectionReasonNoLinkedWorkflows,
+				ProjectID: binding.ProjectID,
+			},
+		},
+		{
+			name:       "path explicit not linked",
+			projectRef: pathRef,
+			workflowID: selectedWorkflowID,
+			createErr: &serverapi.WorkflowTaskCreateSelectionError{
+				Reason:     serverapi.WorkflowTaskCreateSelectionReasonWorkflowNotLinked,
+				ProjectID:  binding.ProjectID,
+				WorkflowID: &persistedSelectedWorkflowID,
+			},
+		},
+		{
+			name:       "project id ambiguous",
+			projectRef: binding.ProjectID,
+			createErr: &serverapi.WorkflowTaskCreateSelectionError{
+				Reason:    serverapi.WorkflowTaskCreateSelectionReasonAmbiguousWithoutDefault,
+				ProjectID: binding.ProjectID,
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			remote := &taskCreateSelectionErrorRemote{
+				workflowCommandRemote: loopback,
+				createErr:             testCase.createErr,
+			}
+			restore := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
+			defer restore()
+			args := []string{"task", "create", "--project", testCase.projectRef, "--title", "Task", "--body", "Body"}
+			if testCase.workflowID != "" {
+				args = append(args, "--workflow", testCase.workflowID)
+			}
+			stdout, _, code := runWorkflowRootCommand(args...)
+			if code != 1 || stdout != "" {
+				t.Fatalf("task create exit=%d stdout=%q, want typed selection failure", code, stdout)
+			}
+			if len(remote.requests) != 1 {
+				t.Fatalf("CreateWorkflowTask calls = %d, want 1", len(remote.requests))
+			}
+			request := remote.requests[0]
+			if request.ProjectID != binding.ProjectID {
+				t.Fatalf("request project = %q, want resolved %q", request.ProjectID, binding.ProjectID)
+			}
+			var wantWorkflowID *string
+			if testCase.workflowID != "" {
+				wantWorkflowID = &persistedSelectedWorkflowID
+			}
+			if !reflect.DeepEqual(request.WorkflowID, wantWorkflowID) {
+				t.Fatalf("request workflow = %v, want %v", request.WorkflowID, wantWorkflowID)
+			}
+		})
+	}
+}
+
+type taskCreateSelectionErrorRemote struct {
+	workflowCommandRemote
+	createErr error
+	requests  []serverapi.WorkflowTaskCreateRequest
+}
+
+func (r *taskCreateSelectionErrorRemote) CreateWorkflowTask(_ context.Context, req serverapi.WorkflowTaskCreateRequest) (serverapi.WorkflowTaskCreateResponse, error) {
+	r.requests = append(r.requests, req)
+	return serverapi.WorkflowTaskCreateResponse{}, r.createErr
+}
 
 func TestTaskCreateAcceptsSourceWorkspace(t *testing.T) {
 	cfg, binding, remote := newWorkflowCommandLoopback(t)
@@ -151,7 +336,7 @@ func TestTaskStartExecutionTargetOverrideAndSelectionRequiredOutput(t *testing.T
 		projectID:   "project-1",
 		taskID:      "task-1",
 		shortID:     "BLD-1",
-		workflowID:  "workflow-1",
+		workflowID:  "workflow-" + workflowSelectorTestUUID,
 		workflow:    "Workflow",
 		placementID: "placement-1",
 		runID:       "run-1",
@@ -407,7 +592,7 @@ func TestTaskStartCommandPollsForSessionAndPrintsReadableOutput(t *testing.T) {
 		projectID:   "project-1",
 		taskID:      "task-1",
 		shortID:     "BLD-1",
-		workflowID:  "workflow-1",
+		workflowID:  "workflow-" + workflowSelectorTestUUID,
 		workflow:    "Workflow",
 		placementID: "placement-1",
 		runID:       "run-1",
@@ -422,7 +607,7 @@ func TestTaskStartCommandPollsForSessionAndPrintsReadableOutput(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("task start exit=%d stdout=%q stderr=%q", code, stdout, stderr)
 	}
-	want := "Started task BLD-1 in session session-1 using workflow \"Workflow\" (workflow-1).\nFirst node: implement\n"
+	want := "Started task BLD-1 in session session-1 using workflow \"Workflow\" (" + workflowSelectorTestUUID + ").\nFirst node: implement\n"
 	if stdout != want {
 		t.Fatalf("task start stdout = %q, want %q", stdout, want)
 	}
@@ -664,7 +849,7 @@ func newSetupProgressLifecycleRemote() *setupProgressLifecycleRemote {
 		projectID:     "project-1",
 		taskID:        "task-1",
 		shortID:       "BLD-1",
-		workflowID:    "workflow-1",
+		workflowID:    "workflow-" + workflowSelectorTestUUID,
 		workflow:      "Workflow",
 		placementID:   "placement-1",
 		runID:         "run-1",

--- a/cli/kent/task_lifecycle_command_test.go
+++ b/cli/kent/task_lifecycle_command_test.go
@@ -190,6 +190,42 @@ func TestTaskCreateTypedSelectionErrorsUseResolvedCommandContext(t *testing.T) {
 	}
 }
 
+func TestTaskCreateSerializationConflictPrintsRetryCommand(t *testing.T) {
+	cfg, binding, loopback := newWorkflowCommandLoopback(t)
+	remote := &taskCreateSelectionErrorRemote{
+		workflowCommandRemote: loopback,
+		createErr: &serverapi.WorkflowTaskCreateConflictError{
+			Reason: serverapi.WorkflowTaskCreateConflictReasonSerialization,
+		},
+	}
+	restore := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
+	defer restore()
+
+	stdout, stderr, code := runWorkflowRootCommand(
+		"task", "create",
+		"--project", binding.ProjectID,
+		"--title", "Concurrent task",
+		"--body", "Body",
+		"--json",
+	)
+	if code != 1 || stdout != "" {
+		t.Fatalf("task create conflict exit=%d stdout=%q, want retryable failure", code, stdout)
+	}
+	retryCommand := commandString(taskCreateRetryCommandArgs(taskCreateCommandContext{
+		ProjectRef:        binding.ProjectID,
+		ResolvedProjectID: binding.ProjectID,
+		Title:             "Concurrent task",
+		Body:              "Body",
+		JSON:              true,
+	}, nil))
+	if !strings.Contains(stderr, retryCommand) {
+		t.Fatalf("task create conflict stderr = %q, want retry command %q", stderr, retryCommand)
+	}
+	if strings.Contains(stderr, string(serverapi.WorkflowTaskCreateConflictReasonSerialization)) {
+		t.Fatalf("task create conflict stderr = %q, want operator guidance without raw reason code", stderr)
+	}
+}
+
 type taskCreateSelectionErrorRemote struct {
 	workflowCommandRemote
 	createErr error

--- a/cli/kent/task_list_command.go
+++ b/cli/kent/task_list_command.go
@@ -106,10 +106,14 @@ func taskListSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 			})
 			return 1
 		}
-		return writeTaskListResponse(stdout, stderr, resp, taskListExpectedScope{
+		expectedScope := taskListExpectedScope{
 			ProjectID:  projectID,
 			WorkflowID: selectedWorkflowID,
-		}, *jsonOut)
+		}
+		if selectedWorkflowID == nil && strings.TrimSpace(*pageToken) != "" {
+			expectedScope.WorkflowOwner = taskListExpectedWorkflowFromToken
+		}
+		return writeTaskListResponse(stdout, stderr, resp, expectedScope, *jsonOut)
 	})
 }
 
@@ -136,8 +140,8 @@ func writeTaskListResponse(stdout io.Writer, stderr io.Writer, resp serverapi.Wo
 			fmt.Fprintf(stdout, "Columns: %s\n", taskListColumnKeysText(*row.Item.ColumnKeys))
 		}
 	}
-	if strings.TrimSpace(resp.NextPageToken) != "" {
-		fmt.Fprintf(stderr, "Next page token: `%s`\n", resp.NextPageToken)
+	if resp.NextPageToken != nil {
+		fmt.Fprintf(stderr, "Next page token: `%s`\n", *resp.NextPageToken)
 	}
 	return 0
 }

--- a/cli/kent/task_list_command.go
+++ b/cli/kent/task_list_command.go
@@ -74,46 +74,43 @@ func taskListSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		selectorValue := selector.String()
 		selectedWorkflowSelector = &selectorValue
 	}
-	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, *projectRef)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	request := serverapi.WorkflowTaskListRequest{
-		ProjectID:      &projectID,
-		WorkflowID:     selectedWorkflowID,
-		ColumnKeys:     columnKeys,
-		StatusKinds:    statusKinds,
-		AttentionKinds: attentionKinds,
-		Sort:           sortSelectors,
-		PageSize:       *pageSize,
-		PageToken:      *pageToken,
-	}
-	resp, err := workflowTaskList(context.Background(), remote, request)
-	if err != nil {
-		writeTaskListError(stderr, err, taskListCommandContext{
-			ProjectRef:         *projectRef,
-			ResolvedProjectID:  projectID,
-			SelectedWorkflowID: selectedWorkflowSelector,
-			ColumnKeys:         columnKeys,
-			StatusKinds:        statusKinds,
-			AttentionKinds:     attentionKinds,
-			Sort:               sortSelectors,
-			PageSize:           *pageSize,
-			PageToken:          *pageToken,
-			JSON:               *jsonOut,
-		})
-		return 1
-	}
-	return writeTaskListResponse(stdout, stderr, resp, taskListExpectedScope{
-		ProjectID:  projectID,
-		WorkflowID: selectedWorkflowID,
-	}, *jsonOut)
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, *projectRef)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		request := serverapi.WorkflowTaskListRequest{
+			ProjectID:      &projectID,
+			WorkflowID:     selectedWorkflowID,
+			ColumnKeys:     columnKeys,
+			StatusKinds:    statusKinds,
+			AttentionKinds: attentionKinds,
+			Sort:           sortSelectors,
+			PageSize:       *pageSize,
+			PageToken:      *pageToken,
+		}
+		resp, err := workflowTaskList(context.Background(), remote, request)
+		if err != nil {
+			writeTaskListError(stderr, err, taskListCommandContext{
+				ProjectRef:         *projectRef,
+				ResolvedProjectID:  projectID,
+				SelectedWorkflowID: selectedWorkflowSelector,
+				ColumnKeys:         columnKeys,
+				StatusKinds:        statusKinds,
+				AttentionKinds:     attentionKinds,
+				Sort:               sortSelectors,
+				PageSize:           *pageSize,
+				PageToken:          *pageToken,
+				JSON:               *jsonOut,
+			})
+			return 1
+		}
+		return writeTaskListResponse(stdout, stderr, resp, taskListExpectedScope{
+			ProjectID:  projectID,
+			WorkflowID: selectedWorkflowID,
+		}, *jsonOut)
+	})
 }
 
 func writeTaskListResponse(stdout io.Writer, stderr io.Writer, resp serverapi.WorkflowTaskListResponse, expectedScope taskListExpectedScope, jsonOut bool) int {

--- a/cli/kent/task_list_command.go
+++ b/cli/kent/task_list_command.go
@@ -8,30 +8,10 @@ import (
 	"strings"
 
 	"core/shared/config"
-	"core/shared/runtimeids"
 	"core/shared/serverapi"
 )
 
 const taskListDefaultPageSize = 100
-
-type taskListOutput struct {
-	ProjectID     string         `json:"project_id"`
-	WorkflowID    string         `json:"workflow_id"`
-	NextPageToken string         `json:"next_page_token,omitempty"`
-	Tasks         []taskListItem `json:"tasks"`
-}
-
-type taskListItem struct {
-	ShortID         string                       `json:"short_id"`
-	TaskID          string                       `json:"task_id"`
-	WorkflowID      string                       `json:"workflow_id"`
-	Status          serverapi.WorkflowTaskStatus `json:"status"`
-	ColumnKeys      []string                     `json:"column_keys"`
-	Title           string                       `json:"title"`
-	CreatedAtUnixMs int64                        `json:"created_at_unix_ms"`
-	UpdatedAtUnixMs int64                        `json:"updated_at_unix_ms"`
-	RunCount        int                          `json:"run_count"`
-}
 
 func taskListSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 	fs := newCommandFlagSet(config.Command+" task list", stderr, taskListUsage)
@@ -79,52 +59,85 @@ func taskListSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	projectProvided := flagWasProvided(fs, "project")
 	workflowProvided := flagWasProvided(fs, "workflow")
 	var selectedWorkflowID *string
+	var selectedWorkflowSelector *string
 	if workflowProvided {
-		selectedWorkflowID, err = workflowPointer(*workflowID)
+		selector, parseErr := parseWorkflowSelector(*workflowID)
+		err = parseErr
 		if err != nil {
 			fmt.Fprintln(stderr, err)
 			return 2
 		}
+		persistedID := selector.PersistedID()
+		selectedWorkflowID = &persistedID
+		selectorValue := selector.String()
+		selectedWorkflowSelector = &selectorValue
 	}
-	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
-		request := serverapi.WorkflowTaskListRequest{
-			WorkflowID:     selectedWorkflowID,
-			ColumnKeys:     columnKeys,
-			StatusKinds:    statusKinds,
-			AttentionKinds: attentionKinds,
-			Sort:           sortSelectors,
-			PageSize:       *pageSize,
-			PageToken:      *pageToken,
-		}
-		var resp serverapi.WorkflowTaskListResponse
-		if projectProvided || (!workflowProvided && strings.TrimSpace(*pageToken) == "") {
-			resp, err = workflowTaskListForProject(context.Background(), cfg, remote, *projectRef, request)
-		} else {
-			resp, err = workflowTaskList(context.Background(), remote, request)
-		}
-		if err != nil {
-			writeTaskListError(stderr, err)
-			return 1
-		}
-		return writeTaskListResponse(stdout, stderr, resp, *jsonOut)
-	})
+	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, *projectRef)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	request := serverapi.WorkflowTaskListRequest{
+		ProjectID:      &projectID,
+		WorkflowID:     selectedWorkflowID,
+		ColumnKeys:     columnKeys,
+		StatusKinds:    statusKinds,
+		AttentionKinds: attentionKinds,
+		Sort:           sortSelectors,
+		PageSize:       *pageSize,
+		PageToken:      *pageToken,
+	}
+	resp, err := workflowTaskList(context.Background(), remote, request)
+	if err != nil {
+		writeTaskListError(stderr, err, taskListCommandContext{
+			ProjectRef:         *projectRef,
+			ResolvedProjectID:  projectID,
+			SelectedWorkflowID: selectedWorkflowSelector,
+			ColumnKeys:         columnKeys,
+			StatusKinds:        statusKinds,
+			AttentionKinds:     attentionKinds,
+			Sort:               sortSelectors,
+			PageSize:           *pageSize,
+			PageToken:          *pageToken,
+			JSON:               *jsonOut,
+		})
+		return 1
+	}
+	return writeTaskListResponse(stdout, stderr, resp, taskListExpectedScope{
+		ProjectID:  projectID,
+		WorkflowID: selectedWorkflowID,
+	}, *jsonOut)
 }
 
-func writeTaskListResponse(stdout io.Writer, stderr io.Writer, resp serverapi.WorkflowTaskListResponse, jsonOut bool) int {
-	items := taskListItemsFromResponse(resp.Tasks)
-	if jsonOut {
-		return writeCommandJSON(stdout, stderr, taskListOutput{ProjectID: resp.ProjectID, WorkflowID: resp.WorkflowID, NextPageToken: resp.NextPageToken, Tasks: items})
+func writeTaskListResponse(stdout io.Writer, stderr io.Writer, resp serverapi.WorkflowTaskListResponse, expectedScope taskListExpectedScope, jsonOut bool) int {
+	projection, err := taskListProjectionFromResponse(resp, expectedScope)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
 	}
-	for _, item := range items {
-		statusText, err := taskStatusText(item.Status)
+	if jsonOut {
+		return writeCommandJSON(stdout, stderr, projection.Output)
+	}
+	for _, row := range projection.Rows {
+		statusText, err := taskStatusText(row.Item.Status)
 		if err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		fmt.Fprintf(stdout, "%s: %s.\nStatus: %s\nColumns: %s\n", item.ShortID, item.Title, statusText, taskListColumnKeysText(item.ColumnKeys))
+		fmt.Fprintf(stdout, "%s: %s.\nStatus: %s\n", row.Item.ShortID, row.Item.Title, statusText)
+		if row.ShowWorkflow {
+			fmt.Fprintf(stdout, "Workflow: %s\n", row.WorkflowName)
+		}
+		if row.ShowColumns {
+			fmt.Fprintf(stdout, "Columns: %s\n", taskListColumnKeysText(*row.Item.ColumnKeys))
+		}
 	}
 	if strings.TrimSpace(resp.NextPageToken) != "" {
 		fmt.Fprintf(stderr, "Next page token: `%s`\n", resp.NextPageToken)
@@ -132,54 +145,28 @@ func writeTaskListResponse(stdout io.Writer, stderr io.Writer, resp serverapi.Wo
 	return 0
 }
 
-func writeTaskListError(stderr io.Writer, err error) {
+func writeTaskListError(stderr io.Writer, err error, commandContext taskListCommandContext) {
 	var scopeErr *serverapi.WorkflowTaskListScopeError
 	if !errors.As(err, &scopeErr) {
 		fmt.Fprintln(stderr, err)
 		return
 	}
-	switch scopeErr.Kind {
-	case serverapi.WorkflowTaskListScopeErrorKindAmbiguous:
-		fmt.Fprint(stderr, "Task list scope is ambiguous.")
-	case serverapi.WorkflowTaskListScopeErrorKindNotLinked:
-		fmt.Fprint(stderr, "Task list scope has no active project/workflow link.")
-	default:
-		fmt.Fprintln(stderr, err)
+	recovery, projectionErr := taskListRecoveryForScopeError(scopeErr, commandContext)
+	if projectionErr != nil {
+		fmt.Fprintln(stderr, projectionErr)
 		return
 	}
-	if scopeErr.MissingScope != nil {
-		switch *scopeErr.MissingScope {
-		case serverapi.WorkflowTaskListScopeDimensionProject:
-			fmt.Fprint(stderr, " Specify --project <project>.")
-		case serverapi.WorkflowTaskListScopeDimensionWorkflow:
-			fmt.Fprint(stderr, " Specify --workflow <uuid>.")
-		}
+	switch recovery.Kind {
+	case taskWorkflowRecoveryNoLinkedWorkflows:
+		fmt.Fprintln(stderr, "This project doesn't have any linked workflows yet. First, create a workflow or link an existing one, then retry.")
+	case taskWorkflowRecoveryWorkflowNotLinked:
+		fmt.Fprintln(stderr, "The selected workflow isn't linked to this project.")
+	case taskWorkflowRecoveryWorkflowRequiredColumns:
+		fmt.Fprintln(stderr, "Column filters and column sorting require an explicit workflow.")
 	}
-	if len(scopeErr.ProjectIDs) > 0 {
-		fmt.Fprintf(stderr, " Available project UUIDs: %s.", strings.Join(scopeErr.ProjectIDs, ", "))
+	for _, command := range recovery.Commands {
+		fmt.Fprintf(stderr, "  %s\n", commandString(command.Args))
 	}
-	if len(scopeErr.WorkflowIDs) > 0 {
-		fmt.Fprintf(stderr, " Available workflow UUIDs: %s.", strings.Join(workflowSelectorsForDisplay(scopeErr.WorkflowIDs), ", "))
-	}
-	fmt.Fprintln(stderr)
-}
-
-func workflowSelectorsForDisplay(workflowIDs []string) []string {
-	selectors := make([]string, 0, len(workflowIDs))
-	for _, workflowID := range workflowIDs {
-		selector, hasPrefix := strings.CutPrefix(workflowID, "workflow-")
-		if !hasPrefix {
-			selectors = append(selectors, workflowID)
-			continue
-		}
-		parsed, err := runtimeids.ParseCanonicalUUIDv4(selector, "workflow id")
-		if err != nil {
-			selectors = append(selectors, workflowID)
-			continue
-		}
-		selectors = append(selectors, parsed.String())
-	}
-	return selectors
 }
 
 func taskListColumnKeysText(columnKeys []string) string {
@@ -187,24 +174,6 @@ func taskListColumnKeysText(columnKeys []string) string {
 		return "(none)"
 	}
 	return strings.Join(columnKeys, ", ")
-}
-
-func taskListItemsFromResponse(tasks []serverapi.WorkflowTaskListItem) []taskListItem {
-	items := make([]taskListItem, 0, len(tasks))
-	for _, task := range tasks {
-		items = append(items, taskListItem{
-			ShortID:         task.ShortID,
-			TaskID:          task.TaskID,
-			WorkflowID:      task.WorkflowID,
-			Status:          task.Status,
-			ColumnKeys:      append([]string(nil), task.ColumnKeys...),
-			Title:           task.Title,
-			CreatedAtUnixMs: task.CreatedAtUnixMs,
-			UpdatedAtUnixMs: task.UpdatedAtUnixMs,
-			RunCount:        task.RunCount,
-		})
-	}
-	return items
 }
 
 func parseTaskListFilterValues(raw []string, name string) ([]string, error) {
@@ -259,15 +228,6 @@ func parseTaskListAttentionKinds(raw []string) ([]serverapi.WorkflowTaskAttentio
 		}
 	}
 	return out, nil
-}
-
-func workflowPointer(value string) (*string, error) {
-	selector, err := runtimeids.ParseCanonicalUUIDv4(value, "workflow selector")
-	if err != nil {
-		return nil, err
-	}
-	workflowID := "workflow-" + selector.String()
-	return &workflowID, nil
 }
 
 func parseTaskListSortSelectors(raw []string) ([]serverapi.WorkflowTaskListSort, error) {

--- a/cli/kent/task_list_command_test.go
+++ b/cli/kent/task_list_command_test.go
@@ -30,7 +30,7 @@ const taskListSecondWorkflowID = "workflow-" + taskListSecondWorkflowSelector
 
 func TestTaskListSendsTypedFiltersAndSorts(t *testing.T) {
 	remote := &capturingTaskListRemote{response: serverapi.WorkflowTaskListResponse{
-		Scope:                       taskListResponseScope("project-1", taskListWorkflowID),
+		Scope:                       taskListResponseScope("project-1", stringPointerForTaskListTest(taskListWorkflowID)),
 		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone,
 	}}
 	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: t.TempDir()}, remote)
@@ -80,7 +80,7 @@ func TestTaskListSendsTypedFiltersAndSorts(t *testing.T) {
 
 func TestTaskListLeavesDefaultSortToServer(t *testing.T) {
 	remote := &capturingTaskListRemote{response: serverapi.WorkflowTaskListResponse{
-		Scope:                       taskListResponseScope("project-1", ""),
+		Scope:                       taskListResponseScope("project-1", nil),
 		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone,
 	}}
 	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: t.TempDir()}, remote)
@@ -98,10 +98,10 @@ func TestTaskListLeavesDefaultSortToServer(t *testing.T) {
 func TestTaskListWorkflowOnlyResolvesCurrentProject(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	remote := &capturingTaskListRemote{response: serverapi.WorkflowTaskListResponse{
-		Scope:                       taskListResponseScope("project-current", taskListWorkflowID),
+		Scope:                       taskListResponseScope("project-current", stringPointerForTaskListTest(taskListWorkflowID)),
 		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone,
 	}}
-	remote.resolvedProjectID = "project-current"
+	remote.resolvedProjectID = stringPointerForTaskListTest("project-current")
 	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: workspaceRoot}, remote)
 	defer restore()
 
@@ -120,10 +120,10 @@ func TestTaskListWorkflowOnlyResolvesCurrentProject(t *testing.T) {
 func TestTaskListTokenContinuationResolvesCurrentProject(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	remote := &capturingTaskListRemote{response: serverapi.WorkflowTaskListResponse{
-		Scope:                       taskListResponseScope("project-current", ""),
+		Scope:                       taskListResponseScope("project-current", nil),
 		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
 	}}
-	remote.resolvedProjectID = "project-current"
+	remote.resolvedProjectID = stringPointerForTaskListTest("project-current")
 	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: workspaceRoot}, remote)
 	defer restore()
 
@@ -139,9 +139,35 @@ func TestTaskListTokenContinuationResolvesCurrentProject(t *testing.T) {
 	}
 }
 
+func TestTaskListTokenContinuationAcceptsServerRestoredWorkflowScope(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	remote := &capturingTaskListRemote{response: serverapi.WorkflowTaskListResponse{
+		Scope:                       taskListResponseScope("project-current", stringPointerForTaskListTest(taskListWorkflowID)),
+		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone,
+	}}
+	remote.resolvedProjectID = stringPointerForTaskListTest("project-current")
+	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: workspaceRoot}, remote)
+	defer restore()
+
+	stdout, stderr, code := runWorkflowRootCommand("task", "list", "--page-token", "narrowed-token", "--json")
+	if code != 0 {
+		t.Fatalf("task list exit=%d stderr=%q", code, stderr)
+	}
+	if len(remote.requests) != 1 || remote.requests[0].WorkflowID != nil || remote.requests[0].PageToken != "narrowed-token" {
+		t.Fatalf("requests = %+v, want token-owned workflow scope", remote.requests)
+	}
+	var output taskListOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("task list JSON = %q: %v", stdout, err)
+	}
+	if output.WorkflowID == nil || *output.WorkflowID != taskListWorkflowSelector {
+		t.Fatalf("task list workflow = %v, want restored bare selector %q", output.WorkflowID, taskListWorkflowSelector)
+	}
+}
+
 func TestTaskListRejectsUnknownResponseStatus(t *testing.T) {
 	remote := &capturingTaskListRemote{response: serverapi.WorkflowTaskListResponse{
-		Scope:                       taskListResponseScope("project-1", taskListWorkflowID),
+		Scope:                       taskListResponseScope("project-1", stringPointerForTaskListTest(taskListWorkflowID)),
 		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
 		Tasks: []serverapi.WorkflowTaskListItem{{
 			TaskID:     "task-1",
@@ -178,20 +204,12 @@ func TestTaskListRejectsInvalidFlagsBeforeOpeningRemote(t *testing.T) {
 	}
 }
 
-func taskListResponseScope(projectID string, workflowID string) serverapi.WorkflowTaskListScope {
-	scope := serverapi.WorkflowTaskListScope{ProjectID: projectID}
-	if workflowID != "" {
-		scope.WorkflowID = &workflowID
-	}
-	return scope
+func taskListResponseScope(projectID string, workflowID *string) serverapi.WorkflowTaskListScope {
+	return serverapi.WorkflowTaskListScope{ProjectID: projectID, WorkflowID: workflowID}
 }
 
-func taskListExpectedScopeForTest(projectID string, workflowID string) taskListExpectedScope {
-	scope := taskListExpectedScope{ProjectID: projectID}
-	if workflowID != "" {
-		scope.WorkflowID = &workflowID
-	}
-	return scope
+func taskListExpectedScopeForTest(projectID string, workflowID *string) taskListExpectedScope {
+	return taskListExpectedScope{ProjectID: projectID, WorkflowID: workflowID}
 }
 
 func TestTaskListRejectsBlankWorkflowBeforeOpeningRemote(t *testing.T) {
@@ -244,7 +262,7 @@ type capturingTaskListRemote struct {
 	apicontract.WorkflowService
 	requests          []serverapi.WorkflowTaskListRequest
 	resolveRequests   []serverapi.ProjectResolvePathRequest
-	resolvedProjectID string
+	resolvedProjectID *string
 	response          serverapi.WorkflowTaskListResponse
 	err               error
 }
@@ -253,12 +271,12 @@ func (r *capturingTaskListRemote) Close() error { return nil }
 
 func (r *capturingTaskListRemote) ResolveProjectPath(_ context.Context, request serverapi.ProjectResolvePathRequest) (serverapi.ProjectResolvePathResponse, error) {
 	r.resolveRequests = append(r.resolveRequests, request)
-	if r.resolvedProjectID == "" {
+	if r.resolvedProjectID == nil {
 		return serverapi.ProjectResolvePathResponse{}, errors.New("unexpected project path resolution")
 	}
 	return serverapi.ProjectResolvePathResponse{
 		Binding: &serverapi.ProjectBinding{
-			ProjectID:     r.resolvedProjectID,
+			ProjectID:     *r.resolvedProjectID,
 			CanonicalRoot: request.Path,
 		},
 	}, nil
@@ -274,7 +292,7 @@ func (r *capturingTaskListRemote) ListWorkflowTasks(_ context.Context, request s
 
 func TestTaskListJSONUsesTypedStatusObject(t *testing.T) {
 	remote := &capturingTaskListRemote{response: serverapi.WorkflowTaskListResponse{
-		Scope:                       taskListResponseScope("project-1", taskListWorkflowID),
+		Scope:                       taskListResponseScope("project-1", stringPointerForTaskListTest(taskListWorkflowID)),
 		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
 		Tasks: []serverapi.WorkflowTaskListItem{{
 			TaskID:     "task-1",
@@ -304,25 +322,27 @@ func TestTaskListJSONUsesTypedStatusObject(t *testing.T) {
 
 func TestTaskListProjectionUsesFrozenCardinalityAndNormalizesWorkflowIDs(t *testing.T) {
 	projectWide, err := taskListProjectionFromResponse(serverapi.WorkflowTaskListResponse{
-		Scope:                       taskListResponseScope("project-1", ""),
+		Scope:                       taskListResponseScope("project-1", nil),
 		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple,
 		Tasks: []serverapi.WorkflowTaskListItem{
 			{
 				TaskID:       "task-1",
 				ShortID:      "KENT-1",
 				WorkflowID:   taskListWorkflowID,
-				WorkflowName: "First",
+				WorkflowName: stringPointerForTaskListTest("First"),
 				Title:        "First task",
+				Status:       serverapi.WorkflowTaskStatus{Kind: serverapi.WorkflowTaskStatusKindQueued, NativeState: "queued"},
 			},
 			{
 				TaskID:       "task-2",
 				ShortID:      "KENT-2",
 				WorkflowID:   taskListSecondWorkflowID,
-				WorkflowName: "Second",
+				WorkflowName: stringPointerForTaskListTest("Second"),
 				Title:        "Second task",
+				Status:       serverapi.WorkflowTaskStatus{Kind: serverapi.WorkflowTaskStatusKindQueued, NativeState: "queued"},
 			},
 		},
-	}, taskListExpectedScopeForTest("project-1", ""))
+	}, taskListExpectedScopeForTest("project-1", nil))
 	if err != nil {
 		t.Fatalf("taskListProjectionFromResponse project-wide: %v", err)
 	}
@@ -342,17 +362,17 @@ func TestTaskListProjectionUsesFrozenCardinalityAndNormalizesWorkflowIDs(t *test
 	}
 
 	narrowed, err := taskListProjectionFromResponse(serverapi.WorkflowTaskListResponse{
-		Scope:                       taskListResponseScope("project-1", taskListWorkflowID),
+		Scope:                       taskListResponseScope("project-1", stringPointerForTaskListTest(taskListWorkflowID)),
 		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
 		Tasks: []serverapi.WorkflowTaskListItem{{
-			TaskID:       "task-1",
-			ShortID:      "KENT-1",
-			WorkflowID:   taskListWorkflowID,
-			WorkflowName: "First",
-			ColumnKeys:   stringSlicePointerForTest("plan"),
-			Title:        "First task",
+			TaskID:     "task-1",
+			ShortID:    "KENT-1",
+			WorkflowID: taskListWorkflowID,
+			ColumnKeys: stringSlicePointerForTest("plan"),
+			Title:      "First task",
+			Status:     serverapi.WorkflowTaskStatus{Kind: serverapi.WorkflowTaskStatusKindQueued, NativeState: "queued"},
 		}},
-	}, taskListExpectedScopeForTest("project-1", taskListWorkflowID))
+	}, taskListExpectedScopeForTest("project-1", stringPointerForTaskListTest(taskListWorkflowID)))
 	if err != nil {
 		t.Fatalf("taskListProjectionFromResponse narrowed: %v", err)
 	}
@@ -370,16 +390,17 @@ func TestTaskListProjectWideJSONOmitsWorkflowAndColumnSentinels(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	code := writeTaskListResponse(&stdout, &stderr, serverapi.WorkflowTaskListResponse{
-		Scope:                       taskListResponseScope("project-1", ""),
+		Scope:                       taskListResponseScope("project-1", nil),
 		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple,
 		Tasks: []serverapi.WorkflowTaskListItem{{
 			TaskID:       "task-1",
 			ShortID:      "KENT-1",
 			WorkflowID:   taskListWorkflowID,
-			WorkflowName: "First",
+			WorkflowName: stringPointerForTaskListTest("First"),
 			Title:        "Task",
+			Status:       serverapi.WorkflowTaskStatus{Kind: serverapi.WorkflowTaskStatusKindQueued, NativeState: "queued"},
 		}},
-	}, taskListExpectedScopeForTest("project-1", ""), true)
+	}, taskListExpectedScopeForTest("project-1", nil), true)
 	if code != 0 || stderr.Len() != 0 {
 		t.Fatalf("writeTaskListResponse exit=%d stderr=%q", code, stderr.String())
 	}
@@ -410,26 +431,26 @@ func TestTaskListProjectWideJSONOmitsWorkflowAndColumnSentinels(t *testing.T) {
 func TestTaskListProjectionRejectsMalformedOrImpossibleWorkflowScope(t *testing.T) {
 	for name, response := range map[string]serverapi.WorkflowTaskListResponse{
 		"malformed selected workflow": {
-			Scope:                       taskListResponseScope("project-1", "workflow-not-a-uuid"),
+			Scope:                       taskListResponseScope("project-1", stringPointerForTaskListTest("workflow-not-a-uuid")),
 			MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone,
 		},
 		"malformed task workflow": {
-			Scope:                       taskListResponseScope("project-1", ""),
+			Scope:                       taskListResponseScope("project-1", nil),
 			MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
 			Tasks:                       []serverapi.WorkflowTaskListItem{{TaskID: "task-1", WorkflowID: "workflow-not-a-uuid"}},
 		},
 		"project-wide columns": {
-			Scope:                       taskListResponseScope("project-1", ""),
+			Scope:                       taskListResponseScope("project-1", nil),
 			MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
 			Tasks:                       []serverapi.WorkflowTaskListItem{{TaskID: "task-1", WorkflowID: taskListWorkflowID, ColumnKeys: stringSlicePointerForTest("plan")}},
 		},
 		"narrowed multiple cardinality": {
-			Scope:                       taskListResponseScope("project-1", taskListWorkflowID),
+			Scope:                       taskListResponseScope("project-1", stringPointerForTaskListTest(taskListWorkflowID)),
 			MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			expectedScope := taskListExpectedScopeForTest(response.Scope.ProjectID, "")
+			expectedScope := taskListExpectedScopeForTest(response.Scope.ProjectID, nil)
 			if response.Scope.WorkflowID != nil {
 				expectedScope.WorkflowID = response.Scope.WorkflowID
 			}
@@ -446,25 +467,55 @@ func TestTaskListProjectionRejectsResponseScopeMismatch(t *testing.T) {
 		expected taskListExpectedScope
 	}{
 		"project mismatch": {
-			response: serverapi.WorkflowTaskListResponse{Scope: taskListResponseScope("project-other", "")},
-			expected: taskListExpectedScopeForTest("project-1", ""),
+			response: serverapi.WorkflowTaskListResponse{Scope: taskListResponseScope("project-other", nil)},
+			expected: taskListExpectedScopeForTest("project-1", nil),
 		},
 		"unexpected narrowed workflow": {
-			response: serverapi.WorkflowTaskListResponse{Scope: taskListResponseScope("project-1", taskListWorkflowID)},
-			expected: taskListExpectedScopeForTest("project-1", ""),
+			response: serverapi.WorkflowTaskListResponse{Scope: taskListResponseScope("project-1", stringPointerForTaskListTest(taskListWorkflowID))},
+			expected: taskListExpectedScopeForTest("project-1", nil),
 		},
 		"missing narrowed workflow": {
-			response: serverapi.WorkflowTaskListResponse{Scope: taskListResponseScope("project-1", "")},
-			expected: taskListExpectedScopeForTest("project-1", taskListWorkflowID),
+			response: serverapi.WorkflowTaskListResponse{Scope: taskListResponseScope("project-1", nil)},
+			expected: taskListExpectedScopeForTest("project-1", stringPointerForTaskListTest(taskListWorkflowID)),
 		},
 		"workflow mismatch": {
-			response: serverapi.WorkflowTaskListResponse{Scope: taskListResponseScope("project-1", taskListSecondWorkflowID)},
-			expected: taskListExpectedScopeForTest("project-1", taskListWorkflowID),
+			response: serverapi.WorkflowTaskListResponse{Scope: taskListResponseScope("project-1", stringPointerForTaskListTest(taskListSecondWorkflowID))},
+			expected: taskListExpectedScopeForTest("project-1", stringPointerForTaskListTest(taskListWorkflowID)),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if _, err := taskListProjectionFromResponse(testCase.response, testCase.expected); err == nil {
 				t.Fatalf("taskListProjectionFromResponse(%s) accepted mismatched response scope", name)
+			}
+		})
+	}
+}
+
+func TestTaskListProjectionAcceptsTokenOwnedWorkflowScope(t *testing.T) {
+	for name, response := range map[string]serverapi.WorkflowTaskListResponse{
+		"project wide": {
+			Scope:                       taskListResponseScope("project-1", nil),
+			MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone,
+		},
+		"narrowed": {
+			Scope:                       taskListResponseScope("project-1", stringPointerForTaskListTest(taskListWorkflowID)),
+			MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			projection, err := taskListProjectionFromResponse(response, taskListExpectedScope{
+				ProjectID:     "project-1",
+				WorkflowOwner: taskListExpectedWorkflowFromToken,
+			})
+			if err != nil {
+				t.Fatalf("taskListProjectionFromResponse(%s): %v", name, err)
+			}
+			if name == "narrowed" {
+				if projection.Output.WorkflowID == nil || *projection.Output.WorkflowID != taskListWorkflowSelector {
+					t.Fatalf("narrowed output workflow = %v, want %q", projection.Output.WorkflowID, taskListWorkflowSelector)
+				}
+			} else if projection.Output.WorkflowID != nil {
+				t.Fatalf("project-wide output workflow = %v, want nil", projection.Output.WorkflowID)
 			}
 		})
 	}
@@ -669,11 +720,11 @@ func TestTaskListLoopbackValidatesExactPairAndContinuesFromToken(t *testing.T) {
 	if err := json.Unmarshal([]byte(firstJSON), &first); err != nil {
 		t.Fatalf("first list JSON = %q: %v", firstJSON, err)
 	}
-	if first.ProjectID != binding.ProjectID || first.WorkflowID != nil || len(first.Tasks) != 1 || first.NextPageToken == "" {
+	if first.ProjectID != binding.ProjectID || first.WorkflowID != nil || len(first.Tasks) != 1 || first.NextPageToken == nil {
 		t.Fatalf("first page = %+v, want project-wide scope and continuation", first)
 	}
 
-	secondJSON, secondErr, code := runWorkflowRootCommand("task", "list", "--page-token", first.NextPageToken, "--page-size", "1", "--json")
+	secondJSON, secondErr, code := runWorkflowRootCommand("task", "list", "--page-token", *first.NextPageToken, "--page-size", "1", "--json")
 	if code != 0 {
 		t.Fatalf("continuation exit=%d stderr=%q", code, secondErr)
 	}

--- a/cli/kent/task_list_command_test.go
+++ b/cli/kent/task_list_command_test.go
@@ -15,13 +15,23 @@ import (
 	"core/shared/serverapi"
 )
 
+func stringSlicePointerForTest(values ...string) *[]string {
+	return &values
+}
+
+func stringPointerForTaskListTest(value string) *string {
+	return &value
+}
+
 const taskListWorkflowSelector = "7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
 const taskListWorkflowID = "workflow-" + taskListWorkflowSelector
+const taskListSecondWorkflowSelector = "8e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
+const taskListSecondWorkflowID = "workflow-" + taskListSecondWorkflowSelector
 
 func TestTaskListSendsTypedFiltersAndSorts(t *testing.T) {
 	remote := &capturingTaskListRemote{response: serverapi.WorkflowTaskListResponse{
-		ProjectID:  "project-1",
-		WorkflowID: taskListWorkflowID,
+		Scope:                       taskListResponseScope("project-1", taskListWorkflowID),
+		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone,
 	}}
 	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: t.TempDir()}, remote)
 	defer restore()
@@ -70,8 +80,8 @@ func TestTaskListSendsTypedFiltersAndSorts(t *testing.T) {
 
 func TestTaskListLeavesDefaultSortToServer(t *testing.T) {
 	remote := &capturingTaskListRemote{response: serverapi.WorkflowTaskListResponse{
-		ProjectID:  "project-1",
-		WorkflowID: taskListWorkflowID,
+		Scope:                       taskListResponseScope("project-1", ""),
+		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone,
 	}}
 	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: t.TempDir()}, remote)
 	defer restore()
@@ -85,47 +95,58 @@ func TestTaskListLeavesDefaultSortToServer(t *testing.T) {
 	}
 }
 
-func TestTaskListWorkflowOnlyLeavesProjectScopeAbsent(t *testing.T) {
+func TestTaskListWorkflowOnlyResolvesCurrentProject(t *testing.T) {
+	workspaceRoot := t.TempDir()
 	remote := &capturingTaskListRemote{response: serverapi.WorkflowTaskListResponse{
-		ProjectID:  "project-1",
-		WorkflowID: taskListWorkflowID,
+		Scope:                       taskListResponseScope("project-current", taskListWorkflowID),
+		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone,
 	}}
-	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: t.TempDir()}, remote)
+	remote.resolvedProjectID = "project-current"
+	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: workspaceRoot}, remote)
 	defer restore()
 
 	_, stderr, code := runWorkflowRootCommand("task", "list", "--workflow", taskListWorkflowSelector)
 	if code != 0 {
 		t.Fatalf("task list exit=%d stderr=%q", code, stderr)
 	}
-	if len(remote.requests) != 1 || remote.requests[0].ProjectID != nil || remote.requests[0].WorkflowID == nil || *remote.requests[0].WorkflowID != taskListWorkflowID {
-		t.Fatalf("requests = %+v, want workflow-only scope", remote.requests)
+	if len(remote.resolveRequests) != 1 || remote.resolveRequests[0].Path != workspaceRoot {
+		t.Fatalf("project resolutions = %+v, want current workspace", remote.resolveRequests)
+	}
+	if len(remote.requests) != 1 || remote.requests[0].ProjectID == nil || *remote.requests[0].ProjectID != "project-current" || remote.requests[0].WorkflowID == nil || *remote.requests[0].WorkflowID != taskListWorkflowID {
+		t.Fatalf("requests = %+v, want current project narrowed by workflow", remote.requests)
 	}
 }
 
-func TestTaskListTokenContinuationLeavesScopeAbsent(t *testing.T) {
+func TestTaskListTokenContinuationResolvesCurrentProject(t *testing.T) {
+	workspaceRoot := t.TempDir()
 	remote := &capturingTaskListRemote{response: serverapi.WorkflowTaskListResponse{
-		ProjectID:  "project-1",
-		WorkflowID: "workflow-1",
+		Scope:                       taskListResponseScope("project-current", ""),
+		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
 	}}
-	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: t.TempDir()}, remote)
+	remote.resolvedProjectID = "project-current"
+	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: workspaceRoot}, remote)
 	defer restore()
 
 	_, stderr, code := runWorkflowRootCommand("task", "list", "--page-token", "opaque-token")
 	if code != 0 {
 		t.Fatalf("task list exit=%d stderr=%q", code, stderr)
 	}
-	if len(remote.requests) != 1 || remote.requests[0].ProjectID != nil || remote.requests[0].WorkflowID != nil || remote.requests[0].PageToken != "opaque-token" {
-		t.Fatalf("requests = %+v, want token-only scope", remote.requests)
+	if len(remote.resolveRequests) != 1 || remote.resolveRequests[0].Path != workspaceRoot {
+		t.Fatalf("project resolutions = %+v, want current workspace", remote.resolveRequests)
+	}
+	if len(remote.requests) != 1 || remote.requests[0].ProjectID == nil || *remote.requests[0].ProjectID != "project-current" || remote.requests[0].WorkflowID != nil || remote.requests[0].PageToken != "opaque-token" {
+		t.Fatalf("requests = %+v, want current project with token continuation", remote.requests)
 	}
 }
 
 func TestTaskListRejectsUnknownResponseStatus(t *testing.T) {
 	remote := &capturingTaskListRemote{response: serverapi.WorkflowTaskListResponse{
-		ProjectID:  "project-1",
-		WorkflowID: "workflow-1",
+		Scope:                       taskListResponseScope("project-1", taskListWorkflowID),
+		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
 		Tasks: []serverapi.WorkflowTaskListItem{{
-			TaskID: "task-1",
-			Status: serverapi.WorkflowTaskStatus{Kind: "future_status"},
+			TaskID:     "task-1",
+			WorkflowID: taskListWorkflowID,
+			Status:     serverapi.WorkflowTaskStatus{Kind: "future_status"},
 		}},
 	}}
 	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: t.TempDir()}, remote)
@@ -157,6 +178,22 @@ func TestTaskListRejectsInvalidFlagsBeforeOpeningRemote(t *testing.T) {
 	}
 }
 
+func taskListResponseScope(projectID string, workflowID string) serverapi.WorkflowTaskListScope {
+	scope := serverapi.WorkflowTaskListScope{ProjectID: projectID}
+	if workflowID != "" {
+		scope.WorkflowID = &workflowID
+	}
+	return scope
+}
+
+func taskListExpectedScopeForTest(projectID string, workflowID string) taskListExpectedScope {
+	scope := taskListExpectedScope{ProjectID: projectID}
+	if workflowID != "" {
+		scope.WorkflowID = &workflowID
+	}
+	return scope
+}
+
 func TestTaskListRejectsBlankWorkflowBeforeOpeningRemote(t *testing.T) {
 	called := false
 	original := workflowCommandRemoteOpener
@@ -178,13 +215,13 @@ func TestTaskListRejectsBlankWorkflowBeforeOpeningRemote(t *testing.T) {
 }
 
 func TestTaskListWorkflowSelectorRequiresV4UUID(t *testing.T) {
-	value, err := workflowPointer(taskListWorkflowSelector)
-	if err != nil || value == nil || *value != taskListWorkflowID {
-		t.Fatalf("workflowPointer valid selector = %v, %v", value, err)
+	value, err := parseWorkflowSelector(taskListWorkflowSelector)
+	if err != nil || value.PersistedID() != taskListWorkflowID {
+		t.Fatalf("parseWorkflowSelector valid selector = %v, %v", value, err)
 	}
 	for _, invalid := range []string{"", " ", "7e8d24d2-8a98-1dcf-a197-6214db1cb3c0", "not-a-uuid", taskListWorkflowID} {
-		if _, err := workflowPointer(invalid); err == nil {
-			t.Fatalf("workflowPointer(%q) succeeded", invalid)
+		if _, err := parseWorkflowSelector(invalid); err == nil {
+			t.Fatalf("parseWorkflowSelector(%q) succeeded", invalid)
 		}
 	}
 }
@@ -205,15 +242,26 @@ func TestTaskListParsesTypedStatusFilters(t *testing.T) {
 
 type capturingTaskListRemote struct {
 	apicontract.WorkflowService
-	requests []serverapi.WorkflowTaskListRequest
-	response serverapi.WorkflowTaskListResponse
-	err      error
+	requests          []serverapi.WorkflowTaskListRequest
+	resolveRequests   []serverapi.ProjectResolvePathRequest
+	resolvedProjectID string
+	response          serverapi.WorkflowTaskListResponse
+	err               error
 }
 
 func (r *capturingTaskListRemote) Close() error { return nil }
 
-func (r *capturingTaskListRemote) ResolveProjectPath(context.Context, serverapi.ProjectResolvePathRequest) (serverapi.ProjectResolvePathResponse, error) {
-	return serverapi.ProjectResolvePathResponse{}, errors.New("unexpected project path resolution")
+func (r *capturingTaskListRemote) ResolveProjectPath(_ context.Context, request serverapi.ProjectResolvePathRequest) (serverapi.ProjectResolvePathResponse, error) {
+	r.resolveRequests = append(r.resolveRequests, request)
+	if r.resolvedProjectID == "" {
+		return serverapi.ProjectResolvePathResponse{}, errors.New("unexpected project path resolution")
+	}
+	return serverapi.ProjectResolvePathResponse{
+		Binding: &serverapi.ProjectBinding{
+			ProjectID:     r.resolvedProjectID,
+			CanonicalRoot: request.Path,
+		},
+	}, nil
 }
 
 func (r *capturingTaskListRemote) ListWorkflowTasks(_ context.Context, request serverapi.WorkflowTaskListRequest) (serverapi.WorkflowTaskListResponse, error) {
@@ -226,21 +274,22 @@ func (r *capturingTaskListRemote) ListWorkflowTasks(_ context.Context, request s
 
 func TestTaskListJSONUsesTypedStatusObject(t *testing.T) {
 	remote := &capturingTaskListRemote{response: serverapi.WorkflowTaskListResponse{
-		ProjectID:  "project-1",
-		WorkflowID: "workflow-1",
+		Scope:                       taskListResponseScope("project-1", taskListWorkflowID),
+		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
 		Tasks: []serverapi.WorkflowTaskListItem{{
-			TaskID: "task-1",
+			TaskID:     "task-1",
+			WorkflowID: taskListWorkflowID,
 			Status: serverapi.WorkflowTaskStatus{
 				Kind:        serverapi.WorkflowTaskStatusKindQueued,
 				NativeState: "queued",
 			},
-			ColumnKeys: []string{"plan"},
+			ColumnKeys: stringSlicePointerForTest("plan"),
 		}},
 	}}
 	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: t.TempDir()}, remote)
 	defer restore()
 
-	stdout, stderr, code := runWorkflowRootCommand("task", "list", "--project", "project-1", "--json")
+	stdout, stderr, code := runWorkflowRootCommand("task", "list", "--project", "project-1", "--workflow", taskListWorkflowSelector, "--json")
 	if code != 0 || stderr != "" {
 		t.Fatalf("task list exit=%d stderr=%q", code, stderr)
 	}
@@ -253,7 +302,302 @@ func TestTaskListJSONUsesTypedStatusObject(t *testing.T) {
 	}
 }
 
-func TestTaskListLoopbackResolvesUniqueProjectAndWorkflowScopes(t *testing.T) {
+func TestTaskListProjectionUsesFrozenCardinalityAndNormalizesWorkflowIDs(t *testing.T) {
+	projectWide, err := taskListProjectionFromResponse(serverapi.WorkflowTaskListResponse{
+		Scope:                       taskListResponseScope("project-1", ""),
+		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple,
+		Tasks: []serverapi.WorkflowTaskListItem{
+			{
+				TaskID:       "task-1",
+				ShortID:      "KENT-1",
+				WorkflowID:   taskListWorkflowID,
+				WorkflowName: "First",
+				Title:        "First task",
+			},
+			{
+				TaskID:       "task-2",
+				ShortID:      "KENT-2",
+				WorkflowID:   taskListSecondWorkflowID,
+				WorkflowName: "Second",
+				Title:        "Second task",
+			},
+		},
+	}, taskListExpectedScopeForTest("project-1", ""))
+	if err != nil {
+		t.Fatalf("taskListProjectionFromResponse project-wide: %v", err)
+	}
+	if projectWide.Output.WorkflowID != nil ||
+		projectWide.Output.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple ||
+		len(projectWide.Rows) != 2 {
+		t.Fatalf("project-wide projection = %+v", projectWide)
+	}
+	for index, workflowID := range []string{taskListWorkflowSelector, taskListSecondWorkflowSelector} {
+		if projectWide.Output.Tasks[index].WorkflowID != workflowID ||
+			projectWide.Output.Tasks[index].ColumnKeys != nil ||
+			!projectWide.Rows[index].ShowWorkflow ||
+			projectWide.Rows[index].ShowColumns ||
+			projectWide.Rows[index].WorkflowName == "" {
+			t.Fatalf("project-wide row %d = %+v/%+v", index, projectWide.Output.Tasks[index], projectWide.Rows[index])
+		}
+	}
+
+	narrowed, err := taskListProjectionFromResponse(serverapi.WorkflowTaskListResponse{
+		Scope:                       taskListResponseScope("project-1", taskListWorkflowID),
+		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
+		Tasks: []serverapi.WorkflowTaskListItem{{
+			TaskID:       "task-1",
+			ShortID:      "KENT-1",
+			WorkflowID:   taskListWorkflowID,
+			WorkflowName: "First",
+			ColumnKeys:   stringSlicePointerForTest("plan"),
+			Title:        "First task",
+		}},
+	}, taskListExpectedScopeForTest("project-1", taskListWorkflowID))
+	if err != nil {
+		t.Fatalf("taskListProjectionFromResponse narrowed: %v", err)
+	}
+	if narrowed.Output.WorkflowID == nil || *narrowed.Output.WorkflowID != taskListWorkflowSelector ||
+		len(narrowed.Rows) != 1 ||
+		narrowed.Rows[0].ShowWorkflow ||
+		!narrowed.Rows[0].ShowColumns ||
+		narrowed.Output.Tasks[0].ColumnKeys == nil ||
+		!reflect.DeepEqual(*narrowed.Output.Tasks[0].ColumnKeys, []string{"plan"}) {
+		t.Fatalf("narrowed projection = %+v", narrowed)
+	}
+}
+
+func TestTaskListProjectWideJSONOmitsWorkflowAndColumnSentinels(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := writeTaskListResponse(&stdout, &stderr, serverapi.WorkflowTaskListResponse{
+		Scope:                       taskListResponseScope("project-1", ""),
+		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple,
+		Tasks: []serverapi.WorkflowTaskListItem{{
+			TaskID:       "task-1",
+			ShortID:      "KENT-1",
+			WorkflowID:   taskListWorkflowID,
+			WorkflowName: "First",
+			Title:        "Task",
+		}},
+	}, taskListExpectedScopeForTest("project-1", ""), true)
+	if code != 0 || stderr.Len() != 0 {
+		t.Fatalf("writeTaskListResponse exit=%d stderr=%q", code, stderr.String())
+	}
+	var payload struct {
+		WorkflowID *json.RawMessage             `json:"workflow_id"`
+		Tasks      []map[string]json.RawMessage `json:"tasks"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("task list JSON = %q: %v", stdout.String(), err)
+	}
+	if payload.WorkflowID != nil {
+		t.Fatalf("task list JSON = %q, want omitted workflow_id", stdout.String())
+	}
+	if len(payload.Tasks) != 1 {
+		t.Fatalf("task list JSON tasks = %+v", payload.Tasks)
+	}
+	for _, omitted := range []string{"column_keys", "workflow_name"} {
+		if _, exists := payload.Tasks[0][omitted]; exists {
+			t.Fatalf("task list JSON = %q, want omitted %s", stdout.String(), omitted)
+		}
+	}
+	var workflowID string
+	if err := json.Unmarshal(payload.Tasks[0]["workflow_id"], &workflowID); err != nil || workflowID != taskListWorkflowSelector {
+		t.Fatalf("task workflow_id = %q/%v, want bare selector", workflowID, err)
+	}
+}
+
+func TestTaskListProjectionRejectsMalformedOrImpossibleWorkflowScope(t *testing.T) {
+	for name, response := range map[string]serverapi.WorkflowTaskListResponse{
+		"malformed selected workflow": {
+			Scope:                       taskListResponseScope("project-1", "workflow-not-a-uuid"),
+			MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone,
+		},
+		"malformed task workflow": {
+			Scope:                       taskListResponseScope("project-1", ""),
+			MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
+			Tasks:                       []serverapi.WorkflowTaskListItem{{TaskID: "task-1", WorkflowID: "workflow-not-a-uuid"}},
+		},
+		"project-wide columns": {
+			Scope:                       taskListResponseScope("project-1", ""),
+			MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
+			Tasks:                       []serverapi.WorkflowTaskListItem{{TaskID: "task-1", WorkflowID: taskListWorkflowID, ColumnKeys: stringSlicePointerForTest("plan")}},
+		},
+		"narrowed multiple cardinality": {
+			Scope:                       taskListResponseScope("project-1", taskListWorkflowID),
+			MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			expectedScope := taskListExpectedScopeForTest(response.Scope.ProjectID, "")
+			if response.Scope.WorkflowID != nil {
+				expectedScope.WorkflowID = response.Scope.WorkflowID
+			}
+			if _, err := taskListProjectionFromResponse(response, expectedScope); err == nil {
+				t.Fatalf("taskListProjectionFromResponse(%s) succeeded", name)
+			}
+		})
+	}
+}
+
+func TestTaskListProjectionRejectsResponseScopeMismatch(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		response serverapi.WorkflowTaskListResponse
+		expected taskListExpectedScope
+	}{
+		"project mismatch": {
+			response: serverapi.WorkflowTaskListResponse{Scope: taskListResponseScope("project-other", "")},
+			expected: taskListExpectedScopeForTest("project-1", ""),
+		},
+		"unexpected narrowed workflow": {
+			response: serverapi.WorkflowTaskListResponse{Scope: taskListResponseScope("project-1", taskListWorkflowID)},
+			expected: taskListExpectedScopeForTest("project-1", ""),
+		},
+		"missing narrowed workflow": {
+			response: serverapi.WorkflowTaskListResponse{Scope: taskListResponseScope("project-1", "")},
+			expected: taskListExpectedScopeForTest("project-1", taskListWorkflowID),
+		},
+		"workflow mismatch": {
+			response: serverapi.WorkflowTaskListResponse{Scope: taskListResponseScope("project-1", taskListSecondWorkflowID)},
+			expected: taskListExpectedScopeForTest("project-1", taskListWorkflowID),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := taskListProjectionFromResponse(testCase.response, testCase.expected); err == nil {
+				t.Fatalf("taskListProjectionFromResponse(%s) accepted mismatched response scope", name)
+			}
+		})
+	}
+}
+
+func TestTaskListRecoveryProjectionBuildsLockedCommandMatrix(t *testing.T) {
+	projectID := "project-1"
+	selectedWorkflowID := taskListWorkflowID
+	for _, testCase := range []struct {
+		name     string
+		scopeErr *serverapi.WorkflowTaskListScopeError
+		context  taskListCommandContext
+		want     taskWorkflowRecovery
+	}{
+		{
+			name: "no linked workflows preserves dot",
+			scopeErr: &serverapi.WorkflowTaskListScopeError{
+				Reason:    serverapi.WorkflowTaskListScopeReasonNoLinkedWorkflows,
+				ProjectID: &projectID,
+			},
+			context: taskListCommandContext{
+				ProjectRef:        ".",
+				ResolvedProjectID: projectID,
+				StatusKinds:       []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindRunning},
+				PageSize:          50,
+				JSON:              true,
+			},
+			want: taskWorkflowRecovery{
+				Kind:       taskWorkflowRecoveryNoLinkedWorkflows,
+				ProjectRef: ".",
+				Commands: []taskWorkflowRecoveryCommand{
+					{Kind: taskWorkflowRecoveryCommandCreateWorkflow, Args: []string{config.Command, "workflow", "create", "<name>"}},
+					{Kind: taskWorkflowRecoveryCommandLinkCreatedWorkflow, Args: []string{config.Command, "workflow", "link", ".", "<created-uuid>"}},
+					{Kind: taskWorkflowRecoveryCommandListWorkflows, Args: []string{config.Command, "workflow", "list"}},
+					{Kind: taskWorkflowRecoveryCommandLinkExistingWorkflow, Args: []string{config.Command, "workflow", "link", ".", "<uuid>"}},
+					{Kind: taskWorkflowRecoveryCommandRetryTaskList, Args: []string{config.Command, "task", "list", "--project", ".", "--status", "running", "--page-size", "50", "--json"}},
+				},
+			},
+		},
+		{
+			name: "not linked preserves path and selected workflow",
+			scopeErr: &serverapi.WorkflowTaskListScopeError{
+				Reason:     serverapi.WorkflowTaskListScopeReasonWorkflowNotLinked,
+				ProjectID:  &projectID,
+				WorkflowID: &selectedWorkflowID,
+			},
+			context: taskListCommandContext{
+				ProjectRef:         "/tmp/my project",
+				ResolvedProjectID:  projectID,
+				SelectedWorkflowID: stringPointerForTaskListTest(taskListWorkflowSelector),
+				AttentionKinds:     []serverapi.WorkflowTaskAttentionKind{serverapi.WorkflowTaskAttentionKindApproval},
+				PageSize:           100,
+				PageToken:          "discard-me",
+			},
+			want: taskWorkflowRecovery{
+				Kind:               taskWorkflowRecoveryWorkflowNotLinked,
+				ProjectRef:         "/tmp/my project",
+				SelectedWorkflowID: stringPointerForTaskListTest(taskListWorkflowSelector),
+				Commands: []taskWorkflowRecoveryCommand{
+					{Kind: taskWorkflowRecoveryCommandListProjectWorkflows, Args: []string{config.Command, "workflow", "list", "--project", "/tmp/my project"}},
+					{Kind: taskWorkflowRecoveryCommandRetryTaskList, Args: []string{config.Command, "task", "list", "--project", "/tmp/my project", "--workflow", "<uuid>", "--attention", "approval", "--page-size", "100"}},
+					{Kind: taskWorkflowRecoveryCommandLinkSelectedWorkflow, Args: []string{config.Command, "workflow", "link", "/tmp/my project", taskListWorkflowSelector}},
+				},
+			},
+		},
+		{
+			name: "column filter preserves compatible options",
+			scopeErr: &serverapi.WorkflowTaskListScopeError{
+				Reason:    serverapi.WorkflowTaskListScopeReasonWorkflowRequiredColumns,
+				ProjectID: &projectID,
+			},
+			context: taskListCommandContext{
+				ProjectRef:        "project-selector",
+				ResolvedProjectID: projectID,
+				StatusKinds:       []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindRunning},
+				AttentionKinds:    []serverapi.WorkflowTaskAttentionKind{serverapi.WorkflowTaskAttentionKindQuestion},
+				ColumnKeys:        []string{"plan"},
+				Sort: []serverapi.WorkflowTaskListSort{{
+					Field:     serverapi.WorkflowTaskListSortFieldUpdated,
+					Direction: serverapi.WorkflowTaskListSortDirectionDesc,
+				}},
+				PageSize:  25,
+				PageToken: "discard-me",
+				JSON:      true,
+			},
+			want: taskWorkflowRecovery{
+				Kind:       taskWorkflowRecoveryWorkflowRequiredColumns,
+				ProjectRef: "project-selector",
+				Commands: []taskWorkflowRecoveryCommand{
+					{Kind: taskWorkflowRecoveryCommandListProjectWorkflows, Args: []string{config.Command, "workflow", "list", "--project", "project-selector"}},
+					{Kind: taskWorkflowRecoveryCommandRetryTaskList, Args: []string{config.Command, "task", "list", "--project", "project-selector", "--workflow", "<uuid>", "--status", "running", "--attention", "question", "--column", "plan", "--sort", "updated:desc", "--page-size", "25", "--json"}},
+				},
+			},
+		},
+		{
+			name: "column sort requires workflow and discards token",
+			scopeErr: &serverapi.WorkflowTaskListScopeError{
+				Reason:    serverapi.WorkflowTaskListScopeReasonWorkflowRequiredColumns,
+				ProjectID: &projectID,
+			},
+			context: taskListCommandContext{
+				ProjectRef:        ".",
+				ResolvedProjectID: projectID,
+				Sort: []serverapi.WorkflowTaskListSort{{
+					Field:     serverapi.WorkflowTaskListSortFieldColumn,
+					Direction: serverapi.WorkflowTaskListSortDirectionAsc,
+				}},
+				PageSize:  75,
+				PageToken: "discard-me",
+			},
+			want: taskWorkflowRecovery{
+				Kind:       taskWorkflowRecoveryWorkflowRequiredColumns,
+				ProjectRef: ".",
+				Commands: []taskWorkflowRecoveryCommand{
+					{Kind: taskWorkflowRecoveryCommandListProjectWorkflows, Args: []string{config.Command, "workflow", "list", "--project", "."}},
+					{Kind: taskWorkflowRecoveryCommandRetryTaskList, Args: []string{config.Command, "task", "list", "--project", ".", "--workflow", "<uuid>", "--sort", "column:asc", "--page-size", "75"}},
+				},
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := taskListRecoveryForScopeError(testCase.scopeErr, testCase.context)
+			if err != nil {
+				t.Fatalf("taskListRecoveryForScopeError: %v", err)
+			}
+			if !reflect.DeepEqual(got, testCase.want) {
+				t.Fatalf("recovery = %+v, want %+v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestTaskListLoopbackKeepsProjectOnlyScopeWithOneWorkflow(t *testing.T) {
 	ctx := context.Background()
 	cfg, binding, remote := newWorkflowCommandLoopback(t)
 	restore := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
@@ -272,22 +616,39 @@ func TestTaskListLoopbackResolvesUniqueProjectAndWorkflowScopes(t *testing.T) {
 		if err := json.Unmarshal([]byte(stdout), &response); err != nil {
 			t.Fatalf("%v JSON = %q: %v", args, stdout, err)
 		}
-		if response.ProjectID != binding.ProjectID || response.WorkflowID != workflowID || len(response.Tasks) != 1 || response.Tasks[0].TaskID != string(task.ID) {
-			t.Fatalf("%v response = %+v, want exact resolved scope and task", args, response)
+		if response.ProjectID != binding.ProjectID || response.WorkflowID != nil || len(response.Tasks) != 1 || response.Tasks[0].TaskID != string(task.ID) || response.Tasks[0].WorkflowID != workflowID {
+			t.Fatalf("%v response = %+v, want project-wide scope and normalized task workflow", args, response)
 		}
 	}
 }
 
-func TestTaskListLoopbackRejectsAmbiguousWorkflowScope(t *testing.T) {
+func TestTaskListLoopbackProjectScopeSpansLinkedWorkflows(t *testing.T) {
+	ctx := context.Background()
 	cfg, binding, remote := newWorkflowCommandLoopback(t)
 	restore := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
 	defer restore()
-	setupLinkedWorkflow(t, binding.ProjectID, "First Workflow")
-	setupLinkedWorkflow(t, binding.ProjectID, "Second Workflow")
+	firstWorkflowID := setupLinkedWorkflow(t, binding.ProjectID, "First Workflow")
+	secondWorkflowID := setupLinkedWorkflow(t, binding.ProjectID, "Second Workflow")
+	firstTask := createTaskForListCommandTest(t, ctx, remote, binding.ProjectID, firstWorkflowID, "First")
+	secondTask := createTaskForListCommandTest(t, ctx, remote, binding.ProjectID, secondWorkflowID, "Second")
 
-	_, stderr, code := runWorkflowRootCommand("task", "list", "--project", binding.ProjectID)
-	if code != 1 {
-		t.Fatalf("task list exit=%d stderr=%q, want ambiguity failure", code, stderr)
+	stdout, stderr, code := runWorkflowRootCommand("task", "list", "--project", binding.ProjectID, "--json")
+	if code != 0 {
+		t.Fatalf("task list exit=%d stderr=%q", code, stderr)
+	}
+	var response taskListOutput
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("task list JSON = %q: %v", stdout, err)
+	}
+	if response.WorkflowID != nil || response.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple || len(response.Tasks) != 2 {
+		t.Fatalf("task list response = %+v, want project-wide multiple-workflow page", response)
+	}
+	seen := map[string]string{}
+	for _, task := range response.Tasks {
+		seen[task.TaskID] = task.WorkflowID
+	}
+	if seen[string(firstTask.ID)] != firstWorkflowID || seen[string(secondTask.ID)] != secondWorkflowID {
+		t.Fatalf("task list workflows = %+v, want normalized linked workflow IDs", seen)
 	}
 }
 
@@ -308,8 +669,8 @@ func TestTaskListLoopbackValidatesExactPairAndContinuesFromToken(t *testing.T) {
 	if err := json.Unmarshal([]byte(firstJSON), &first); err != nil {
 		t.Fatalf("first list JSON = %q: %v", firstJSON, err)
 	}
-	if first.ProjectID != binding.ProjectID || first.WorkflowID != workflowID || len(first.Tasks) != 1 || first.NextPageToken == "" {
-		t.Fatalf("first page = %+v, want exact scope and continuation", first)
+	if first.ProjectID != binding.ProjectID || first.WorkflowID != nil || len(first.Tasks) != 1 || first.NextPageToken == "" {
+		t.Fatalf("first page = %+v, want project-wide scope and continuation", first)
 	}
 
 	secondJSON, secondErr, code := runWorkflowRootCommand("task", "list", "--page-token", first.NextPageToken, "--page-size", "1", "--json")
@@ -320,7 +681,7 @@ func TestTaskListLoopbackValidatesExactPairAndContinuesFromToken(t *testing.T) {
 	if err := json.Unmarshal([]byte(secondJSON), &second); err != nil {
 		t.Fatalf("continuation JSON = %q: %v", secondJSON, err)
 	}
-	if second.ProjectID != binding.ProjectID || second.WorkflowID != workflowID || len(second.Tasks) != 1 || second.Tasks[0].TaskID == first.Tasks[0].TaskID {
+	if second.ProjectID != binding.ProjectID || second.WorkflowID != nil || len(second.Tasks) != 1 || second.Tasks[0].TaskID == first.Tasks[0].TaskID {
 		t.Fatalf("continuation = %+v, want distinct next task in exact token scope", second)
 	}
 
@@ -332,9 +693,10 @@ func TestTaskListLoopbackValidatesExactPairAndContinuesFromToken(t *testing.T) {
 
 func createTaskForListCommandTest(t *testing.T, ctx context.Context, remote *workflowCommandLoopbackRemote, projectID string, workflowID string, title string) workflowstore.TaskRecord {
 	t.Helper()
+	persistedWorkflowID := workflow.WorkflowID(workflowPersistedIDForTest(t, workflowID))
 	task, err := remote.store.CreateTask(ctx, workflowstore.CreateTaskRequest{
 		ProjectID:  projectID,
-		WorkflowID: workflow.WorkflowID(workflowID),
+		WorkflowID: &persistedWorkflowID,
 		Title:      title,
 		Body:       "Body",
 	})

--- a/cli/kent/task_list_command_test.go
+++ b/cli/kent/task_list_command_test.go
@@ -521,6 +521,39 @@ func TestTaskListProjectionAcceptsTokenOwnedWorkflowScope(t *testing.T) {
 	}
 }
 
+func TestTaskListProjectionAcceptsLiveMixedTokenContinuationWithFrozenOneCardinality(t *testing.T) {
+	response := serverapi.WorkflowTaskListResponse{
+		Scope:                       taskListResponseScope("project-1", nil),
+		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
+		Tasks: []serverapi.WorkflowTaskListItem{
+			{
+				TaskID:     "task-1",
+				WorkflowID: taskListWorkflowID,
+				Status:     serverapi.WorkflowTaskStatus{Kind: serverapi.WorkflowTaskStatusKindQueued, NativeState: "queued"},
+			},
+			{
+				TaskID:     "task-2",
+				WorkflowID: taskListSecondWorkflowID,
+				Status:     serverapi.WorkflowTaskStatus{Kind: serverapi.WorkflowTaskStatusKindQueued, NativeState: "queued"},
+			},
+		},
+	}
+
+	projection, err := taskListProjectionFromResponse(response, taskListExpectedScope{
+		ProjectID:     "project-1",
+		WorkflowOwner: taskListExpectedWorkflowFromToken,
+	})
+	if err != nil {
+		t.Fatalf("taskListProjectionFromResponse: %v", err)
+	}
+	if len(projection.Rows) != 2 ||
+		projection.Rows[0].ShowWorkflow ||
+		projection.Rows[1].ShowWorkflow ||
+		projection.Output.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne {
+		t.Fatalf("projection = %+v, want live mixed rows with frozen no-label display", projection)
+	}
+}
+
 func TestTaskListRecoveryProjectionBuildsLockedCommandMatrix(t *testing.T) {
 	projectID := "project-1"
 	selectedWorkflowID := taskListWorkflowID

--- a/cli/kent/task_list_projection.go
+++ b/cli/kent/task_list_projection.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"core/shared/serverapi"
+)
+
+type taskListOutput struct {
+	ProjectID                   string                                                `json:"project_id"`
+	WorkflowID                  *string                                               `json:"workflow_id,omitempty"`
+	MatchingWorkflowCardinality serverapi.WorkflowTaskListMatchingWorkflowCardinality `json:"matching_workflow_cardinality"`
+	NextPageToken               string                                                `json:"next_page_token,omitempty"`
+	Tasks                       []taskListItem                                        `json:"tasks"`
+}
+
+type taskListItem struct {
+	ShortID         string                       `json:"short_id"`
+	TaskID          string                       `json:"task_id"`
+	WorkflowID      string                       `json:"workflow_id"`
+	Status          serverapi.WorkflowTaskStatus `json:"status"`
+	ColumnKeys      *[]string                    `json:"column_keys,omitempty"`
+	Title           string                       `json:"title"`
+	CreatedAtUnixMs int64                        `json:"created_at_unix_ms"`
+	UpdatedAtUnixMs int64                        `json:"updated_at_unix_ms"`
+	RunCount        int                          `json:"run_count"`
+}
+
+type taskListProjection struct {
+	Output taskListOutput
+	Rows   []taskListRenderItem
+}
+
+type taskListRenderItem struct {
+	Item         taskListItem
+	WorkflowName string
+	ShowWorkflow bool
+	ShowColumns  bool
+}
+
+type taskListExpectedScope struct {
+	ProjectID  string
+	WorkflowID *string
+}
+
+func taskListProjectionFromResponse(resp serverapi.WorkflowTaskListResponse, expectedScope taskListExpectedScope) (taskListProjection, error) {
+	if strings.TrimSpace(expectedScope.ProjectID) == "" || strings.TrimSpace(expectedScope.ProjectID) != expectedScope.ProjectID {
+		return taskListProjection{}, errors.New("task list request scope is missing project_id")
+	}
+	if strings.TrimSpace(resp.Scope.ProjectID) == "" || strings.TrimSpace(resp.Scope.ProjectID) != resp.Scope.ProjectID {
+		return taskListProjection{}, errors.New("task list response scope is missing project_id")
+	}
+	if resp.Scope.ProjectID != expectedScope.ProjectID {
+		return taskListProjection{}, fmt.Errorf("task list response project %q does not match requested project %q", resp.Scope.ProjectID, expectedScope.ProjectID)
+	}
+	if (resp.Scope.WorkflowID == nil) != (expectedScope.WorkflowID == nil) {
+		return taskListProjection{}, errors.New("task list response workflow scope does not match requested scope")
+	}
+	if resp.Scope.WorkflowID != nil && *resp.Scope.WorkflowID != *expectedScope.WorkflowID {
+		return taskListProjection{}, fmt.Errorf("task list response workflow %q does not match requested workflow %q", *resp.Scope.WorkflowID, *expectedScope.WorkflowID)
+	}
+	switch resp.MatchingWorkflowCardinality {
+	case serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone,
+		serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
+		serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple:
+	default:
+		return taskListProjection{}, fmt.Errorf("task list response has invalid matching_workflow_cardinality %q", resp.MatchingWorkflowCardinality)
+	}
+	if resp.MatchingWorkflowCardinality == serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone && len(resp.Tasks) != 0 {
+		return taskListProjection{}, errors.New("task list response with no matching workflows cannot contain tasks")
+	}
+	var selectedWorkflowID *string
+	if resp.Scope.WorkflowID != nil {
+		workflowID, err := workflowIDForCLI(*resp.Scope.WorkflowID)
+		if err != nil {
+			return taskListProjection{}, err
+		}
+		selectedWorkflowID = &workflowID
+		if resp.MatchingWorkflowCardinality == serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple {
+			return taskListProjection{}, errors.New("task list response narrowed to one workflow cannot have multiple matching workflows")
+		}
+	}
+	showWorkflow := resp.MatchingWorkflowCardinality == serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple
+	showColumns := selectedWorkflowID != nil
+	items := make([]taskListItem, 0, len(resp.Tasks))
+	rows := make([]taskListRenderItem, 0, len(resp.Tasks))
+	for _, task := range resp.Tasks {
+		workflowID, err := workflowIDForCLI(task.WorkflowID)
+		if err != nil {
+			return taskListProjection{}, err
+		}
+		if selectedWorkflowID != nil && workflowID != *selectedWorkflowID {
+			return taskListProjection{}, fmt.Errorf("task list response task %q workflow %q does not match selected workflow %q", task.TaskID, workflowID, *selectedWorkflowID)
+		}
+		var columnKeys *[]string
+		if showColumns {
+			if task.ColumnKeys == nil {
+				return taskListProjection{}, fmt.Errorf("narrowed task list response task %q is missing workflow-relative columns", task.TaskID)
+			}
+			values := append([]string(nil), (*task.ColumnKeys)...)
+			columnKeys = &values
+		} else if task.ColumnKeys != nil {
+			return taskListProjection{}, fmt.Errorf("project-wide task list response task %q contains workflow-relative columns", task.TaskID)
+		}
+		if showWorkflow && strings.TrimSpace(task.WorkflowName) == "" {
+			return taskListProjection{}, fmt.Errorf("task list response task %q is missing workflow_name for multiple-workflow rendering", task.TaskID)
+		}
+		item := taskListItem{
+			ShortID:         task.ShortID,
+			TaskID:          task.TaskID,
+			WorkflowID:      workflowID,
+			Status:          task.Status,
+			ColumnKeys:      columnKeys,
+			Title:           task.Title,
+			CreatedAtUnixMs: task.CreatedAtUnixMs,
+			UpdatedAtUnixMs: task.UpdatedAtUnixMs,
+			RunCount:        task.RunCount,
+		}
+		items = append(items, item)
+		rows = append(rows, taskListRenderItem{
+			Item:         item,
+			WorkflowName: task.WorkflowName,
+			ShowWorkflow: showWorkflow,
+			ShowColumns:  showColumns,
+		})
+	}
+	return taskListProjection{
+		Output: taskListOutput{
+			ProjectID:                   resp.Scope.ProjectID,
+			WorkflowID:                  selectedWorkflowID,
+			MatchingWorkflowCardinality: resp.MatchingWorkflowCardinality,
+			NextPageToken:               resp.NextPageToken,
+			Tasks:                       items,
+		},
+		Rows: rows,
+	}, nil
+}

--- a/cli/kent/task_list_projection.go
+++ b/cli/kent/task_list_projection.go
@@ -113,7 +113,8 @@ func taskListProjectionFromResponse(resp serverapi.WorkflowTaskListResponse, exp
 		if selectedWorkflowID != nil && workflowID != *selectedWorkflowID {
 			return taskListProjection{}, fmt.Errorf("task list response task %q workflow %q does not match selected workflow %q", task.TaskID, workflowID, *selectedWorkflowID)
 		}
-		if resp.MatchingWorkflowCardinality == serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne {
+		if resp.MatchingWorkflowCardinality == serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne &&
+			expectedScope.WorkflowOwner == taskListExpectedWorkflowFromRequest {
 			if soleWorkflowID == nil {
 				value := workflowID
 				soleWorkflowID = &value

--- a/cli/kent/task_list_projection.go
+++ b/cli/kent/task_list_projection.go
@@ -6,13 +6,14 @@ import (
 	"strings"
 
 	"core/shared/serverapi"
+	"core/shared/textutil"
 )
 
 type taskListOutput struct {
 	ProjectID                   string                                                `json:"project_id"`
 	WorkflowID                  *string                                               `json:"workflow_id,omitempty"`
 	MatchingWorkflowCardinality serverapi.WorkflowTaskListMatchingWorkflowCardinality `json:"matching_workflow_cardinality"`
-	NextPageToken               string                                                `json:"next_page_token,omitempty"`
+	NextPageToken               *string                                               `json:"next_page_token,omitempty"`
 	Tasks                       []taskListItem                                        `json:"tasks"`
 }
 
@@ -41,9 +42,17 @@ type taskListRenderItem struct {
 }
 
 type taskListExpectedScope struct {
-	ProjectID  string
-	WorkflowID *string
+	ProjectID     string
+	WorkflowID    *string
+	WorkflowOwner taskListExpectedWorkflowOwner
 }
+
+type taskListExpectedWorkflowOwner uint8
+
+const (
+	taskListExpectedWorkflowFromRequest taskListExpectedWorkflowOwner = iota
+	taskListExpectedWorkflowFromToken
+)
 
 func taskListProjectionFromResponse(resp serverapi.WorkflowTaskListResponse, expectedScope taskListExpectedScope) (taskListProjection, error) {
 	if strings.TrimSpace(expectedScope.ProjectID) == "" || strings.TrimSpace(expectedScope.ProjectID) != expectedScope.ProjectID {
@@ -55,11 +64,20 @@ func taskListProjectionFromResponse(resp serverapi.WorkflowTaskListResponse, exp
 	if resp.Scope.ProjectID != expectedScope.ProjectID {
 		return taskListProjection{}, fmt.Errorf("task list response project %q does not match requested project %q", resp.Scope.ProjectID, expectedScope.ProjectID)
 	}
-	if (resp.Scope.WorkflowID == nil) != (expectedScope.WorkflowID == nil) {
-		return taskListProjection{}, errors.New("task list response workflow scope does not match requested scope")
-	}
-	if resp.Scope.WorkflowID != nil && *resp.Scope.WorkflowID != *expectedScope.WorkflowID {
-		return taskListProjection{}, fmt.Errorf("task list response workflow %q does not match requested workflow %q", *resp.Scope.WorkflowID, *expectedScope.WorkflowID)
+	switch expectedScope.WorkflowOwner {
+	case taskListExpectedWorkflowFromRequest:
+		if (resp.Scope.WorkflowID == nil) != (expectedScope.WorkflowID == nil) {
+			return taskListProjection{}, errors.New("task list response workflow scope does not match requested scope")
+		}
+		if resp.Scope.WorkflowID != nil && *resp.Scope.WorkflowID != *expectedScope.WorkflowID {
+			return taskListProjection{}, fmt.Errorf("task list response workflow %q does not match requested workflow %q", *resp.Scope.WorkflowID, *expectedScope.WorkflowID)
+		}
+	case taskListExpectedWorkflowFromToken:
+		if expectedScope.WorkflowID != nil {
+			return taskListProjection{}, errors.New("task list token-owned workflow scope cannot include an explicit workflow_id")
+		}
+	default:
+		return taskListProjection{}, errors.New("task list request has invalid workflow scope ownership")
 	}
 	switch resp.MatchingWorkflowCardinality {
 	case serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone,
@@ -86,6 +104,7 @@ func taskListProjectionFromResponse(resp serverapi.WorkflowTaskListResponse, exp
 	showColumns := selectedWorkflowID != nil
 	items := make([]taskListItem, 0, len(resp.Tasks))
 	rows := make([]taskListRenderItem, 0, len(resp.Tasks))
+	var soleWorkflowID *string
 	for _, task := range resp.Tasks {
 		workflowID, err := workflowIDForCLI(task.WorkflowID)
 		if err != nil {
@@ -93,6 +112,18 @@ func taskListProjectionFromResponse(resp serverapi.WorkflowTaskListResponse, exp
 		}
 		if selectedWorkflowID != nil && workflowID != *selectedWorkflowID {
 			return taskListProjection{}, fmt.Errorf("task list response task %q workflow %q does not match selected workflow %q", task.TaskID, workflowID, *selectedWorkflowID)
+		}
+		if resp.MatchingWorkflowCardinality == serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne {
+			if soleWorkflowID == nil {
+				value := workflowID
+				soleWorkflowID = &value
+			} else if workflowID != *soleWorkflowID {
+				return taskListProjection{}, fmt.Errorf("single-workflow task list response mixes workflows %q and %q", *soleWorkflowID, workflowID)
+			}
+		}
+		expectedNativeState, validStatus := task.Status.Kind.NativeState()
+		if !validStatus || task.Status.NativeState != expectedNativeState {
+			return taskListProjection{}, fmt.Errorf("task list response task %q has invalid status %q/%q", task.TaskID, task.Status.Kind, task.Status.NativeState)
 		}
 		var columnKeys *[]string
 		if showColumns {
@@ -104,8 +135,14 @@ func taskListProjectionFromResponse(resp serverapi.WorkflowTaskListResponse, exp
 		} else if task.ColumnKeys != nil {
 			return taskListProjection{}, fmt.Errorf("project-wide task list response task %q contains workflow-relative columns", task.TaskID)
 		}
-		if showWorkflow && strings.TrimSpace(task.WorkflowName) == "" {
-			return taskListProjection{}, fmt.Errorf("task list response task %q is missing workflow_name for multiple-workflow rendering", task.TaskID)
+		workflowName := ""
+		if showWorkflow {
+			if task.WorkflowName == nil || strings.TrimSpace(*task.WorkflowName) == "" || strings.TrimSpace(*task.WorkflowName) != *task.WorkflowName {
+				return taskListProjection{}, fmt.Errorf("task list response task %q is missing an exact workflow_name for multiple-workflow rendering", task.TaskID)
+			}
+			workflowName = *task.WorkflowName
+		} else if task.WorkflowName != nil {
+			return taskListProjection{}, fmt.Errorf("task list response task %q contains workflow_name when workflow labels are hidden", task.TaskID)
 		}
 		item := taskListItem{
 			ShortID:         task.ShortID,
@@ -121,7 +158,7 @@ func taskListProjectionFromResponse(resp serverapi.WorkflowTaskListResponse, exp
 		items = append(items, item)
 		rows = append(rows, taskListRenderItem{
 			Item:         item,
-			WorkflowName: task.WorkflowName,
+			WorkflowName: workflowName,
 			ShowWorkflow: showWorkflow,
 			ShowColumns:  showColumns,
 		})
@@ -131,7 +168,7 @@ func taskListProjectionFromResponse(resp serverapi.WorkflowTaskListResponse, exp
 			ProjectID:                   resp.Scope.ProjectID,
 			WorkflowID:                  selectedWorkflowID,
 			MatchingWorkflowCardinality: resp.MatchingWorkflowCardinality,
-			NextPageToken:               resp.NextPageToken,
+			NextPageToken:               textutil.Pointer(resp.NextPageToken),
 			Tasks:                       items,
 		},
 		Rows: rows,

--- a/cli/kent/task_resolution.go
+++ b/cli/kent/task_resolution.go
@@ -11,17 +11,6 @@ import (
 	"core/shared/serverapi"
 )
 
-func workflowTaskListForProject(ctx context.Context, cfg config.App, remote workflowCommandRemote, projectRef string, req serverapi.WorkflowTaskListRequest) (serverapi.WorkflowTaskListResponse, error) {
-	projectID, err := resolveWorkflowProjectID(ctx, cfg, remote, projectRef)
-	if err != nil {
-		return serverapi.WorkflowTaskListResponse{}, err
-	}
-	req.ProjectID = &projectID
-	rpcCtx, cancel := context.WithTimeout(ctx, workflowCommandTimeout)
-	defer cancel()
-	return remote.ListWorkflowTasks(rpcCtx, req)
-}
-
 func workflowTaskList(ctx context.Context, remote workflowCommandRemote, req serverapi.WorkflowTaskListRequest) (serverapi.WorkflowTaskListResponse, error) {
 	rpcCtx, cancel := context.WithTimeout(ctx, workflowCommandTimeout)
 	defer cancel()

--- a/cli/kent/task_show_command.go
+++ b/cli/kent/task_show_command.go
@@ -42,28 +42,36 @@ func taskShowSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "task show requires <short-id-or-task-id>")
 		return 2
 	}
-	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
-		requestedProjectID, task, err := getWorkflowTaskForShow(context.Background(), cfg, remote, *projectRef, positionals[0])
-		if err != nil {
+	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	requestedProjectID, task, err := getWorkflowTaskForShow(context.Background(), cfg, remote, *projectRef, positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if requestedProjectID != "" && task.Summary.ProjectID != "" && task.Summary.ProjectID != requestedProjectID && task.Project.ProjectKey != "" {
+		fmt.Fprintf(stderr, "Note: This task belongs to another project %s\n", task.Project.ProjectKey)
+	}
+	task, err = workflowTaskDetailForCLI(task)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		if _, err := taskStatusText(task.Status); err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		if requestedProjectID != "" && task.Summary.ProjectID != "" && task.Summary.ProjectID != requestedProjectID && task.Project.ProjectKey != "" {
-			fmt.Fprintf(stderr, "Note: This task belongs to another project %s\n", task.Project.ProjectKey)
-		}
-		if *jsonOut {
-			if _, err := taskStatusText(task.Status); err != nil {
-				fmt.Fprintln(stderr, err)
-				return 1
-			}
-			return writeCommandJSON(stdout, stderr, taskShowOutputFromDetail(task))
-		}
-		if err := writeTaskDetail(stdout, task); err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		return 0
-	})
+		return writeCommandJSON(stdout, stderr, taskShowOutputFromDetail(task))
+	}
+	if err := writeTaskDetail(stdout, task); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
 }
 
 func taskShowOutputFromDetail(task serverapi.WorkflowTaskDetail) taskShowOutput {

--- a/cli/kent/task_show_command.go
+++ b/cli/kent/task_show_command.go
@@ -42,36 +42,33 @@ func taskShowSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "task show requires <short-id-or-task-id>")
 		return 2
 	}
-	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	requestedProjectID, task, err := getWorkflowTaskForShow(context.Background(), cfg, remote, *projectRef, positionals[0])
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if requestedProjectID != "" && task.Summary.ProjectID != "" && task.Summary.ProjectID != requestedProjectID && task.Project.ProjectKey != "" {
-		fmt.Fprintf(stderr, "Note: This task belongs to another project %s\n", task.Project.ProjectKey)
-	}
-	task, err = workflowTaskDetailForCLI(task)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		if _, err := taskStatusText(task.Status); err != nil {
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		requestedProjectID, task, err := getWorkflowTaskForShow(context.Background(), cfg, remote, *projectRef, positionals[0])
+		if err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		return writeCommandJSON(stdout, stderr, taskShowOutputFromDetail(task))
-	}
-	if err := writeTaskDetail(stdout, task); err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	return 0
+		if requestedProjectID != "" && task.Summary.ProjectID != "" && task.Summary.ProjectID != requestedProjectID && task.Project.ProjectKey != "" {
+			fmt.Fprintf(stderr, "Note: This task belongs to another project %s\n", task.Project.ProjectKey)
+		}
+		task, err = workflowTaskDetailForCLI(task)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if *jsonOut {
+			if _, err := taskStatusText(task.Status); err != nil {
+				fmt.Fprintln(stderr, err)
+				return 1
+			}
+			return writeCommandJSON(stdout, stderr, taskShowOutputFromDetail(task))
+		}
+		if err := writeTaskDetail(stdout, task); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	})
 }
 
 func taskShowOutputFromDetail(task serverapi.WorkflowTaskDetail) taskShowOutput {

--- a/cli/kent/task_show_command_test.go
+++ b/cli/kent/task_show_command_test.go
@@ -236,9 +236,10 @@ func (r *crossProjectTaskShowRemote) GetWorkflowTask(_ context.Context, req serv
 			return serverapi.WorkflowTaskGetResponse{}, r.unscopedErr
 		}
 		return serverapi.WorkflowTaskGetResponse{Task: serverapi.WorkflowTaskDetail{
-			Summary: serverapi.WorkflowTaskSummary{ID: "task-other", ProjectID: "project-other", WorkflowID: "workflow-other", ShortID: "OTH-1", Title: "Other Task"},
-			Project: serverapi.ProjectBoardProject{ProjectKey: "OTH", DisplayName: "Other"},
-			Status:  serverapi.WorkflowTaskStatus{Kind: serverapi.WorkflowTaskStatusKindBacklog},
+			Summary:  serverapi.WorkflowTaskSummary{ID: "task-other", ProjectID: "project-other", WorkflowID: "workflow-" + workflowSelectorTestUUID, ShortID: "OTH-1", Title: "Other Task"},
+			Project:  serverapi.ProjectBoardProject{ProjectKey: "OTH", DisplayName: "Other"},
+			Workflow: serverapi.WorkflowPickerItem{WorkflowID: "workflow-" + workflowSelectorTestUUID, DisplayName: "Workflow"},
+			Status:   serverapi.WorkflowTaskStatus{Kind: serverapi.WorkflowTaskStatusKindBacklog},
 		}}, nil
 	}
 	return serverapi.WorkflowTaskGetResponse{}, sql.ErrNoRows

--- a/cli/kent/task_workflow_integration_test.go
+++ b/cli/kent/task_workflow_integration_test.go
@@ -29,8 +29,8 @@ func TestTaskCommandsUseWorkflowAPI(t *testing.T) {
 	taskID := taskResp.Task.Summary.ID
 
 	taskListOut, _ := runWorkflowRootCommandOK(t, "task", "list", "--project", binding.ProjectID)
-	if !strings.Contains(taskListOut, shortID+": Task.") || !strings.Contains(taskListOut, "Status: backlog") || !strings.Contains(taskListOut, "Columns: backlog") {
-		t.Fatalf("task list output = %q, want short id, typed status, and column", taskListOut)
+	if !strings.Contains(taskListOut, shortID+": Task.") || !strings.Contains(taskListOut, "Status: backlog") || strings.Contains(taskListOut, "Columns:") {
+		t.Fatalf("task list output = %q, want project-wide short id and typed status without workflow-relative columns", taskListOut)
 	}
 	taskListJSONOut, _ := runWorkflowRootCommandOK(t, "task", "list", "--project", binding.ProjectID, "--json")
 	if !strings.Contains(taskListJSONOut, shortID) || !strings.Contains(taskListJSONOut, taskID) {

--- a/cli/kent/task_workflow_integration_test.go
+++ b/cli/kent/task_workflow_integration_test.go
@@ -28,13 +28,19 @@ func TestTaskCommandsUseWorkflowAPI(t *testing.T) {
 	}
 	taskID := taskResp.Task.Summary.ID
 
-	taskListOut, _ := runWorkflowRootCommandOK(t, "task", "list", "--project", binding.ProjectID)
-	if !strings.Contains(taskListOut, shortID+": Task.") || !strings.Contains(taskListOut, "Status: backlog") || strings.Contains(taskListOut, "Columns:") {
-		t.Fatalf("task list output = %q, want project-wide short id and typed status without workflow-relative columns", taskListOut)
-	}
 	taskListJSONOut, _ := runWorkflowRootCommandOK(t, "task", "list", "--project", binding.ProjectID, "--json")
-	if !strings.Contains(taskListJSONOut, shortID) || !strings.Contains(taskListJSONOut, taskID) {
-		t.Fatalf("task list json output = %q, want ids", taskListJSONOut)
+	var taskList taskListOutput
+	if err := json.Unmarshal([]byte(taskListJSONOut), &taskList); err != nil {
+		t.Fatalf("task list JSON output = %q: %v", taskListJSONOut, err)
+	}
+	if taskList.ProjectID != binding.ProjectID ||
+		taskList.WorkflowID != nil ||
+		len(taskList.Tasks) != 1 ||
+		taskList.Tasks[0].TaskID != taskID ||
+		taskList.Tasks[0].ShortID != shortID ||
+		taskList.Tasks[0].Status.Kind != serverapi.WorkflowTaskStatusKindBacklog ||
+		taskList.Tasks[0].ColumnKeys != nil {
+		t.Fatalf("task list projection = %+v, want project-wide task without workflow-relative columns", taskList)
 	}
 
 	taskShowOut, _ := runWorkflowRootCommandOK(t, "task", "show", "--project", binding.ProjectID, shortID)

--- a/cli/kent/task_workflow_recovery.go
+++ b/cli/kent/task_workflow_recovery.go
@@ -34,13 +34,13 @@ type taskCreateCommandContext struct {
 	JSON               bool
 }
 
-type taskWorkflowRecoveryKind string
+type taskWorkflowRecoveryKind uint8
 
 const (
-	taskWorkflowRecoveryNoLinkedWorkflows       taskWorkflowRecoveryKind = taskWorkflowRecoveryKind(serverapi.WorkflowTaskListScopeReasonNoLinkedWorkflows)
-	taskWorkflowRecoveryWorkflowNotLinked       taskWorkflowRecoveryKind = taskWorkflowRecoveryKind(serverapi.WorkflowTaskListScopeReasonWorkflowNotLinked)
-	taskWorkflowRecoveryWorkflowRequiredColumns taskWorkflowRecoveryKind = taskWorkflowRecoveryKind(serverapi.WorkflowTaskListScopeReasonWorkflowRequiredColumns)
-	taskWorkflowRecoveryAmbiguousWithoutDefault taskWorkflowRecoveryKind = taskWorkflowRecoveryKind(serverapi.WorkflowTaskCreateSelectionReasonAmbiguousWithoutDefault)
+	taskWorkflowRecoveryNoLinkedWorkflows taskWorkflowRecoveryKind = iota + 1
+	taskWorkflowRecoveryWorkflowNotLinked
+	taskWorkflowRecoveryWorkflowRequiredColumns
+	taskWorkflowRecoveryAmbiguousWithoutDefault
 )
 
 type taskWorkflowRecoveryCommandKind string
@@ -87,8 +87,12 @@ func taskListRecoveryForScopeError(scopeErr *serverapi.WorkflowTaskListScopeErro
 	if scopeErr == nil || scopeErr.ProjectID == nil {
 		return taskWorkflowRecovery{}, errors.New("task list scope error with project context is required")
 	}
+	kind, err := taskListRecoveryKind(scopeErr.Reason)
+	if err != nil {
+		return taskWorkflowRecovery{}, err
+	}
 	failure := taskWorkflowRecoveryFailure{
-		kind:       taskWorkflowRecoveryKind(scopeErr.Reason),
+		kind:       kind,
 		projectID:  *scopeErr.ProjectID,
 		workflowID: scopeErr.WorkflowID,
 	}
@@ -104,8 +108,12 @@ func taskCreateRecoveryForSelectionError(createErr *serverapi.WorkflowTaskCreate
 	if createErr == nil {
 		return taskWorkflowRecovery{}, errors.New("task create selection error is required")
 	}
+	kind, err := taskCreateRecoveryKind(createErr.Reason)
+	if err != nil {
+		return taskWorkflowRecovery{}, err
+	}
 	failure := taskWorkflowRecoveryFailure{
-		kind:       taskWorkflowRecoveryKind(createErr.Reason),
+		kind:       kind,
 		projectID:  createErr.ProjectID,
 		workflowID: createErr.WorkflowID,
 	}
@@ -115,6 +123,32 @@ func taskCreateRecoveryForSelectionError(createErr *serverapi.WorkflowTaskCreate
 		selectedWorkflowID: commandContext.SelectedWorkflowID,
 		create:             &commandContext,
 	})
+}
+
+func taskListRecoveryKind(reason serverapi.WorkflowTaskListScopeErrorReason) (taskWorkflowRecoveryKind, error) {
+	switch reason {
+	case serverapi.WorkflowTaskListScopeReasonNoLinkedWorkflows:
+		return taskWorkflowRecoveryNoLinkedWorkflows, nil
+	case serverapi.WorkflowTaskListScopeReasonWorkflowNotLinked:
+		return taskWorkflowRecoveryWorkflowNotLinked, nil
+	case serverapi.WorkflowTaskListScopeReasonWorkflowRequiredColumns:
+		return taskWorkflowRecoveryWorkflowRequiredColumns, nil
+	default:
+		return 0, fmt.Errorf("unsupported task-list workflow recovery reason %q", reason)
+	}
+}
+
+func taskCreateRecoveryKind(reason serverapi.WorkflowTaskCreateSelectionReason) (taskWorkflowRecoveryKind, error) {
+	switch reason {
+	case serverapi.WorkflowTaskCreateSelectionReasonNoLinkedWorkflows:
+		return taskWorkflowRecoveryNoLinkedWorkflows, nil
+	case serverapi.WorkflowTaskCreateSelectionReasonWorkflowNotLinked:
+		return taskWorkflowRecoveryWorkflowNotLinked, nil
+	case serverapi.WorkflowTaskCreateSelectionReasonAmbiguousWithoutDefault:
+		return taskWorkflowRecoveryAmbiguousWithoutDefault, nil
+	default:
+		return 0, fmt.Errorf("unsupported task-create workflow recovery reason %q", reason)
+	}
 }
 
 func taskWorkflowRecoveryForFailure(failure taskWorkflowRecoveryFailure, commandContext taskWorkflowRecoveryContext) (taskWorkflowRecovery, error) {
@@ -184,7 +218,7 @@ func taskWorkflowRecoveryForFailure(failure taskWorkflowRecoveryFailure, command
 			{Kind: taskWorkflowRecoveryCommandSetDefaultWorkflow, Args: []string{config.Command, "workflow", "default", commandContext.projectRef, "<uuid>"}},
 		}
 	default:
-		return taskWorkflowRecovery{}, fmt.Errorf("unsupported task workflow recovery reason %q", failure.kind)
+		return taskWorkflowRecovery{}, fmt.Errorf("unsupported task workflow recovery kind %d", failure.kind)
 	}
 	return recovery, nil
 }

--- a/cli/kent/task_workflow_recovery.go
+++ b/cli/kent/task_workflow_recovery.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"core/shared/config"
+	"core/shared/serverapi"
+)
+
+type taskListCommandContext struct {
+	ProjectRef         string
+	ResolvedProjectID  string
+	SelectedWorkflowID *string
+	ColumnKeys         []string
+	StatusKinds        []serverapi.WorkflowTaskStatusKind
+	AttentionKinds     []serverapi.WorkflowTaskAttentionKind
+	Sort               []serverapi.WorkflowTaskListSort
+	PageSize           int
+	PageToken          string
+	JSON               bool
+}
+
+type taskCreateCommandContext struct {
+	ProjectRef         string
+	ResolvedProjectID  string
+	SelectedWorkflowID *string
+	Title              string
+	Body               string
+	BodyFile           string
+	SourceURL          string
+	SourceWorkspace    string
+	JSON               bool
+}
+
+type taskWorkflowRecoveryKind string
+
+const (
+	taskWorkflowRecoveryNoLinkedWorkflows       taskWorkflowRecoveryKind = taskWorkflowRecoveryKind(serverapi.WorkflowTaskListScopeReasonNoLinkedWorkflows)
+	taskWorkflowRecoveryWorkflowNotLinked       taskWorkflowRecoveryKind = taskWorkflowRecoveryKind(serverapi.WorkflowTaskListScopeReasonWorkflowNotLinked)
+	taskWorkflowRecoveryWorkflowRequiredColumns taskWorkflowRecoveryKind = taskWorkflowRecoveryKind(serverapi.WorkflowTaskListScopeReasonWorkflowRequiredColumns)
+	taskWorkflowRecoveryAmbiguousWithoutDefault taskWorkflowRecoveryKind = taskWorkflowRecoveryKind(serverapi.WorkflowTaskCreateSelectionReasonAmbiguousWithoutDefault)
+)
+
+type taskWorkflowRecoveryCommandKind string
+
+const (
+	taskWorkflowRecoveryCommandCreateWorkflow       taskWorkflowRecoveryCommandKind = "create_workflow"
+	taskWorkflowRecoveryCommandLinkCreatedWorkflow  taskWorkflowRecoveryCommandKind = "link_created_workflow"
+	taskWorkflowRecoveryCommandListWorkflows        taskWorkflowRecoveryCommandKind = "list_workflows"
+	taskWorkflowRecoveryCommandLinkExistingWorkflow taskWorkflowRecoveryCommandKind = "link_existing_workflow"
+	taskWorkflowRecoveryCommandListProjectWorkflows taskWorkflowRecoveryCommandKind = "list_project_workflows"
+	taskWorkflowRecoveryCommandRetryTaskList        taskWorkflowRecoveryCommandKind = "retry_task_list"
+	taskWorkflowRecoveryCommandRetryTaskCreate      taskWorkflowRecoveryCommandKind = "retry_task_create"
+	taskWorkflowRecoveryCommandLinkSelectedWorkflow taskWorkflowRecoveryCommandKind = "link_selected_workflow"
+	taskWorkflowRecoveryCommandSetDefaultWorkflow   taskWorkflowRecoveryCommandKind = "set_default_workflow"
+)
+
+type taskWorkflowRecoveryCommand struct {
+	Kind taskWorkflowRecoveryCommandKind
+	Args []string
+}
+
+type taskWorkflowRecovery struct {
+	Kind               taskWorkflowRecoveryKind
+	ProjectRef         string
+	SelectedWorkflowID *string
+	Commands           []taskWorkflowRecoveryCommand
+}
+
+type taskWorkflowRecoveryFailure struct {
+	kind       taskWorkflowRecoveryKind
+	projectID  string
+	workflowID *string
+}
+
+type taskWorkflowRecoveryContext struct {
+	projectRef         string
+	resolvedProjectID  string
+	selectedWorkflowID *string
+	list               *taskListCommandContext
+	create             *taskCreateCommandContext
+}
+
+func taskListRecoveryForScopeError(scopeErr *serverapi.WorkflowTaskListScopeError, commandContext taskListCommandContext) (taskWorkflowRecovery, error) {
+	if scopeErr == nil || scopeErr.ProjectID == nil {
+		return taskWorkflowRecovery{}, errors.New("task list scope error with project context is required")
+	}
+	failure := taskWorkflowRecoveryFailure{
+		kind:       taskWorkflowRecoveryKind(scopeErr.Reason),
+		projectID:  *scopeErr.ProjectID,
+		workflowID: scopeErr.WorkflowID,
+	}
+	return taskWorkflowRecoveryForFailure(failure, taskWorkflowRecoveryContext{
+		projectRef:         commandContext.ProjectRef,
+		resolvedProjectID:  commandContext.ResolvedProjectID,
+		selectedWorkflowID: commandContext.SelectedWorkflowID,
+		list:               &commandContext,
+	})
+}
+
+func taskCreateRecoveryForSelectionError(createErr *serverapi.WorkflowTaskCreateSelectionError, commandContext taskCreateCommandContext) (taskWorkflowRecovery, error) {
+	if createErr == nil {
+		return taskWorkflowRecovery{}, errors.New("task create selection error is required")
+	}
+	failure := taskWorkflowRecoveryFailure{
+		kind:       taskWorkflowRecoveryKind(createErr.Reason),
+		projectID:  createErr.ProjectID,
+		workflowID: createErr.WorkflowID,
+	}
+	return taskWorkflowRecoveryForFailure(failure, taskWorkflowRecoveryContext{
+		projectRef:         commandContext.ProjectRef,
+		resolvedProjectID:  commandContext.ResolvedProjectID,
+		selectedWorkflowID: commandContext.SelectedWorkflowID,
+		create:             &commandContext,
+	})
+}
+
+func taskWorkflowRecoveryForFailure(failure taskWorkflowRecoveryFailure, commandContext taskWorkflowRecoveryContext) (taskWorkflowRecovery, error) {
+	if strings.TrimSpace(commandContext.projectRef) == "" || strings.TrimSpace(commandContext.resolvedProjectID) == "" {
+		return taskWorkflowRecovery{}, errors.New("task workflow recovery requires project context")
+	}
+	if (commandContext.list == nil) == (commandContext.create == nil) {
+		return taskWorkflowRecovery{}, errors.New("task workflow recovery requires exactly one command context")
+	}
+	if failure.projectID != commandContext.resolvedProjectID {
+		return taskWorkflowRecovery{}, fmt.Errorf("task workflow recovery project %q does not match resolved project %q", failure.projectID, commandContext.resolvedProjectID)
+	}
+	var selectedWorkflowID *string
+	if commandContext.selectedWorkflowID != nil {
+		value := *commandContext.selectedWorkflowID
+		selectedWorkflowID = &value
+	}
+	recovery := taskWorkflowRecovery{
+		Kind:               failure.kind,
+		ProjectRef:         commandContext.projectRef,
+		SelectedWorkflowID: selectedWorkflowID,
+	}
+	listProjectWorkflows := taskWorkflowListProjectCommand(commandContext.projectRef)
+	switch failure.kind {
+	case taskWorkflowRecoveryNoLinkedWorkflows:
+		if failure.workflowID != nil || selectedWorkflowID != nil {
+			return taskWorkflowRecovery{}, errors.New("no-linked-workflows recovery cannot select a workflow")
+		}
+		recovery.Commands = append(
+			taskWorkflowNoLinksPreparationCommands(commandContext.projectRef),
+			commandContext.retryCommand(nil, true),
+		)
+	case taskWorkflowRecoveryWorkflowNotLinked:
+		if selectedWorkflowID == nil || failure.workflowID == nil {
+			return taskWorkflowRecovery{}, errors.New("workflow-not-linked recovery requires a selected workflow")
+		}
+		selected, err := workflowIDForCLI(*failure.workflowID)
+		if err != nil {
+			return taskWorkflowRecovery{}, err
+		}
+		if selected != *selectedWorkflowID {
+			return taskWorkflowRecovery{}, fmt.Errorf("task workflow recovery workflow %q does not match selected workflow %q", selected, *selectedWorkflowID)
+		}
+		workflowPlaceholder := "<uuid>"
+		recovery.Commands = []taskWorkflowRecoveryCommand{
+			listProjectWorkflows,
+			commandContext.retryCommand(&workflowPlaceholder, false),
+			{Kind: taskWorkflowRecoveryCommandLinkSelectedWorkflow, Args: []string{config.Command, "workflow", "link", commandContext.projectRef, selected}},
+		}
+	case taskWorkflowRecoveryWorkflowRequiredColumns:
+		if commandContext.list == nil || failure.workflowID != nil || selectedWorkflowID != nil {
+			return taskWorkflowRecovery{}, errors.New("workflow-required-for-columns recovery requires project-wide task list context")
+		}
+		workflowPlaceholder := "<uuid>"
+		recovery.Commands = []taskWorkflowRecoveryCommand{
+			listProjectWorkflows,
+			commandContext.retryCommand(&workflowPlaceholder, false),
+		}
+	case taskWorkflowRecoveryAmbiguousWithoutDefault:
+		if commandContext.create == nil || failure.workflowID != nil || selectedWorkflowID != nil {
+			return taskWorkflowRecovery{}, errors.New("ambiguous recovery requires task create context without a selected workflow")
+		}
+		workflowPlaceholder := "<uuid>"
+		recovery.Commands = []taskWorkflowRecoveryCommand{
+			listProjectWorkflows,
+			commandContext.retryCommand(&workflowPlaceholder, false),
+			{Kind: taskWorkflowRecoveryCommandSetDefaultWorkflow, Args: []string{config.Command, "workflow", "default", commandContext.projectRef, "<uuid>"}},
+		}
+	default:
+		return taskWorkflowRecovery{}, fmt.Errorf("unsupported task workflow recovery reason %q", failure.kind)
+	}
+	return recovery, nil
+}
+
+func (c taskWorkflowRecoveryContext) retryCommand(workflowID *string, preservePageToken bool) taskWorkflowRecoveryCommand {
+	if c.list != nil {
+		return taskWorkflowRecoveryCommand{
+			Kind: taskWorkflowRecoveryCommandRetryTaskList,
+			Args: taskListRetryCommandArgs(*c.list, workflowID, preservePageToken),
+		}
+	}
+	return taskWorkflowRecoveryCommand{
+		Kind: taskWorkflowRecoveryCommandRetryTaskCreate,
+		Args: taskCreateRetryCommandArgs(*c.create, workflowID),
+	}
+}
+
+func taskWorkflowNoLinksPreparationCommands(projectRef string) []taskWorkflowRecoveryCommand {
+	return []taskWorkflowRecoveryCommand{
+		{Kind: taskWorkflowRecoveryCommandCreateWorkflow, Args: []string{config.Command, "workflow", "create", "<name>"}},
+		{Kind: taskWorkflowRecoveryCommandLinkCreatedWorkflow, Args: []string{config.Command, "workflow", "link", projectRef, "<created-uuid>"}},
+		{Kind: taskWorkflowRecoveryCommandListWorkflows, Args: []string{config.Command, "workflow", "list"}},
+		{Kind: taskWorkflowRecoveryCommandLinkExistingWorkflow, Args: []string{config.Command, "workflow", "link", projectRef, "<uuid>"}},
+	}
+}
+
+func taskWorkflowListProjectCommand(projectRef string) taskWorkflowRecoveryCommand {
+	return taskWorkflowRecoveryCommand{
+		Kind: taskWorkflowRecoveryCommandListProjectWorkflows,
+		Args: []string{config.Command, "workflow", "list", "--project", projectRef},
+	}
+}
+
+func taskCreateRetryCommandArgs(commandContext taskCreateCommandContext, workflowID *string) []string {
+	args := []string{config.Command, "task", "create", "--project", commandContext.ProjectRef}
+	if workflowID != nil {
+		args = append(args, "--workflow", *workflowID)
+	}
+	args = append(args, "--title", commandContext.Title)
+	if strings.TrimSpace(commandContext.BodyFile) != "" {
+		args = append(args, "--body-file", commandContext.BodyFile)
+	} else {
+		args = append(args, "--body", commandContext.Body)
+	}
+	if strings.TrimSpace(commandContext.SourceURL) != "" {
+		args = append(args, "--source-url", commandContext.SourceURL)
+	}
+	if strings.TrimSpace(commandContext.SourceWorkspace) != "" {
+		args = append(args, "--source-workspace", commandContext.SourceWorkspace)
+	}
+	if commandContext.JSON {
+		args = append(args, "--json")
+	}
+	return args
+}
+
+func taskListRetryCommandArgs(commandContext taskListCommandContext, workflowID *string, preservePageToken bool) []string {
+	args := []string{config.Command, "task", "list", "--project", commandContext.ProjectRef}
+	if workflowID != nil {
+		args = append(args, "--workflow", *workflowID)
+	}
+	for _, status := range commandContext.StatusKinds {
+		args = append(args, "--status", string(status))
+	}
+	for _, attention := range commandContext.AttentionKinds {
+		args = append(args, "--attention", string(attention))
+	}
+	for _, columnKey := range commandContext.ColumnKeys {
+		args = append(args, "--column", columnKey)
+	}
+	for _, sortSelector := range commandContext.Sort {
+		args = append(args, "--sort", string(sortSelector.Field)+":"+string(sortSelector.Direction))
+	}
+	args = append(args, "--page-size", fmt.Sprintf("%d", commandContext.PageSize))
+	if preservePageToken && strings.TrimSpace(commandContext.PageToken) != "" {
+		args = append(args, "--page-token", commandContext.PageToken)
+	}
+	if commandContext.JSON {
+		args = append(args, "--json")
+	}
+	return args
+}

--- a/cli/kent/workflow_command.go
+++ b/cli/kent/workflow_command.go
@@ -27,6 +27,7 @@ const (
 // workflowListOutput is the machine-readable shape of `workflow list --json`.
 type workflowListOutput struct {
 	Workflows     []serverapi.WorkflowRecord `json:"workflows"`
+	ProjectID     *string                    `json:"project_id,omitempty"`
 	NextPageToken string                     `json:"next_page_token,omitempty"`
 }
 
@@ -61,6 +62,19 @@ var workflowCommandRemoteOpener func(context.Context, string) (config.App, workf
 	return cfg, remote, err
 }
 
+func openWorkflowCommandSession(stderr io.Writer, path string) (config.App, workflowCommandRemote, func(), bool) {
+	cfg, remote, err := workflowCommandRemoteOpener(context.Background(), path)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return config.App{}, nil, nil, false
+	}
+	return cfg, remote, func() {
+		if err := remote.Close(); err != nil {
+			fmt.Fprintf(stderr, "close workflow command session: %v\n", err)
+		}
+	}, true
+}
+
 func runWorkflowCommandSession(stderr io.Writer, run func(config.App, workflowCommandRemote) int) int {
 	cfg, remote, err := workflowCommandRemoteOpener(context.Background(), ".")
 	if err != nil {
@@ -76,22 +90,47 @@ func runWorkflowCommandSession(stderr io.Writer, run func(config.App, workflowCo
 }
 
 func workflowSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
-	return dispatchCommandGroup(args, stdout, stderr, commandGroup{
-		path:  "workflow",
-		usage: workflowUsage,
-		routes: map[string]commandHandler{
-			"create":   workflowCreateSubcommand,
-			"update":   workflowUpdateSubcommand,
-			"list":     workflowListSubcommand,
-			"node":     workflowNodeSubcommand,
-			"edge":     workflowEdgeSubcommand,
-			"link":     workflowLinkSubcommand,
-			"unlink":   workflowUnlinkSubcommand,
-			"default":  workflowDefaultSubcommand,
-			"validate": workflowValidateSubcommand,
-			"inspect":  workflowInspectSubcommand,
-		},
-	})
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		fs := newCommandFlagSet(config.Command+" workflow", stderr, workflowUsage)
+		fs.Usage()
+		if len(args) == 0 {
+			return 2
+		}
+		return 0
+	}
+	switch args[0] {
+	case "create":
+		return workflowCreateSubcommand(args[1:], stdout, stderr)
+	case "update":
+		return workflowUpdateSubcommand(args[1:], stdout, stderr)
+	case "list":
+		return workflowListSubcommand(args[1:], stdout, stderr)
+	case "node":
+		return workflowNodeSubcommand(args[1:], stdout, stderr)
+	case "edge":
+		return workflowEdgeSubcommand(args[1:], stdout, stderr)
+	case "link":
+		return workflowLinkSubcommand(args[1:], stdout, stderr)
+	case "unlink":
+		return workflowUnlinkSubcommand(args[1:], stdout, stderr)
+	case "default":
+		return workflowDefaultSubcommand(args[1:], stdout, stderr)
+	case "validate":
+		return workflowValidateSubcommand(args[1:], stdout, stderr)
+	case "inspect":
+		return workflowInspectSubcommand(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown workflow command: %s\n\n", args[0])
+		fs := newCommandFlagSet(config.Command+" workflow", stderr, workflowUsage)
+		workflowUsage.write(fs)
+		return 2
+	}
 }
 
 func workflowUpdateSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -117,48 +156,61 @@ func workflowUpdateSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 		}
 		targetPolicy = &parsed
 	}
-	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
-		def, err := resolveWorkflowDefinition(context.Background(), remote, positionals[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		metadata := serverapi.WorkflowGraphMetadata{
-			Name:                  def.Workflow.Name,
-			Description:           def.Workflow.Description,
-			ExecutionTargetPolicy: targetPolicy,
-		}
-		if flagWasProvided(fs, "name") {
-			metadata.Name = strings.TrimSpace(*name)
-		}
-		if flagWasProvided(fs, "description") {
-			metadata.Description = strings.TrimSpace(*description)
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		resp, err := remote.SaveWorkflowGraph(ctx, serverapi.WorkflowGraphSaveRequest{
-			WorkflowID:      def.Workflow.ID,
-			ExpectedVersion: def.Workflow.Version,
-			Metadata:        &metadata,
-			Graph:           workflowGraphDraftFromDefinition(def),
-		})
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if !resp.Saved || resp.Definition == nil {
-			fmt.Fprintf(stderr, "workflow update was not saved at version %d\n", resp.CurrentVersion)
-			for _, blocker := range resp.Blockers {
-				fmt.Fprintf(stderr, "- [%s] %s\n", blocker.Code, blocker.Message)
-			}
-			return 1
-		}
-		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, resp.Definition.Workflow)
-		}
-		fmt.Fprintf(stdout, "Updated workflow %q (%s) to version %d.\n", resp.Definition.Workflow.Name, resp.Definition.Workflow.ID, resp.Definition.Workflow.Version)
-		return 0
+	selector, err := parseWorkflowSelector(positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	metadata := serverapi.WorkflowGraphMetadata{
+		Name:                  def.Workflow.Name,
+		Description:           def.Workflow.Description,
+		ExecutionTargetPolicy: targetPolicy,
+	}
+	if flagWasProvided(fs, "name") {
+		metadata.Name = strings.TrimSpace(*name)
+	}
+	if flagWasProvided(fs, "description") {
+		metadata.Description = strings.TrimSpace(*description)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	resp, err := remote.SaveWorkflowGraph(ctx, serverapi.WorkflowGraphSaveRequest{
+		WorkflowID:      def.Workflow.ID,
+		ExpectedVersion: def.Workflow.Version,
+		Metadata:        &metadata,
+		Graph:           workflowGraphDraftFromDefinition(def),
 	})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if !resp.Saved || resp.Definition == nil {
+		fmt.Fprintf(stderr, "workflow update was not saved at version %d\n", resp.CurrentVersion)
+		for _, blocker := range resp.Blockers {
+			fmt.Fprintf(stderr, "- [%s] %s\n", blocker.Code, blocker.Message)
+		}
+		return 1
+	}
+	projected, err := workflowRecordForCLI(resp.Definition.Workflow)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		return writeCommandJSON(stdout, stderr, projected)
+	}
+	fmt.Fprintf(stdout, "Updated workflow %q (%s) to version %d.\n", projected.Name, projected.ID, projected.Version)
+	return 0
 }
 
 func workflowCreateSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -174,26 +226,35 @@ func workflowCreateSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 		fmt.Fprintln(stderr, "workflow create requires <name>")
 		return 2
 	}
-	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		resp, err := remote.CreateWorkflow(ctx, serverapi.WorkflowCreateRequest{Name: name, Description: *description})
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, resp.Workflow)
-		}
-		fmt.Fprintf(stdout, "Created workflow %q (%s).\n", resp.Workflow.Name, resp.Workflow.ID)
-		return 0
-	})
+	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	resp, err := remote.CreateWorkflow(ctx, serverapi.WorkflowCreateRequest{Name: name, Description: *description})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	projected, err := workflowRecordForCLI(resp.Workflow)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		return writeCommandJSON(stdout, stderr, projected)
+	}
+	fmt.Fprintf(stdout, "Created workflow %q (%s).\n", projected.Name, projected.ID)
+	return 0
 }
 
 func workflowListSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 	fs := newCommandFlagSet(config.Command+" workflow list", stderr, workflowListUsage)
 	pageSize := fs.Int("page-size", workflowCommandWorkflowListPageSize, "maximum number of workflows to return")
 	pageToken := fs.String("page-token", "", "continue from a previous list response")
+	project := fs.String("project", "", "project path or ID to list linked workflows for")
 	jsonOut := fs.Bool("json", false, "write workflows and the next page token as JSON")
 	if ok, exitCode := parseCommandFlags(fs, args); !ok {
 		return exitCode
@@ -202,34 +263,106 @@ func workflowListSubcommand(args []string, stdout io.Writer, stderr io.Writer) i
 		fmt.Fprintln(stderr, "workflow list does not accept positional arguments")
 		return 2
 	}
-	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
-		workflows, nextPageToken, err := listWorkflowPage(context.Background(), remote, serverapi.WorkflowListRequest{PageSize: *pageSize, PageToken: *pageToken})
+	projectProvided := flagWasProvided(fs, "project")
+	if projectProvided && strings.TrimSpace(*project) == "" {
+		fmt.Fprintln(stderr, "workflow list --project requires a non-blank value")
+		return 2
+	}
+	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	var projectID *string
+	if projectProvided {
+		resolved, err := resolveWorkflowProjectID(context.Background(), cfg, remote, *project)
 		if err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, workflowListOutput{Workflows: workflows, NextPageToken: nextPageToken})
+		projectID = &resolved
+	}
+	response, err := listWorkflowPage(context.Background(), remote, serverapi.WorkflowListRequest{PageSize: *pageSize, PageToken: *pageToken, ProjectID: projectID})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	workflows, err := workflowRecordsForCLI(response.Workflows)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if err := validateWorkflowListProjectMetadata(projectID, response.ProjectID, workflows); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		return writeCommandJSON(stdout, stderr, workflowListOutput{Workflows: workflows, ProjectID: response.ProjectID, NextPageToken: response.NextPageToken})
+	}
+	for _, workflow := range workflows {
+		if response.ProjectID != nil {
+			fmt.Fprintf(stdout, "%s: %s (v%d; %s; target %s)\n", workflow.ID, workflow.Name, workflow.Version, workflowProjectLinkState(workflow.ProjectLink), workflowExecutionTargetPolicySelector(workflow.ExecutionTargetPolicy))
+			continue
+		}
+		fmt.Fprintf(stdout, "%s: %s (v%d)\n", workflow.ID, workflow.Name, workflow.Version)
+	}
+	if strings.TrimSpace(response.NextPageToken) != "" {
+		fmt.Fprintf(stderr, "Next page token: `%s`\n", response.NextPageToken)
+	}
+	return 0
+}
+
+func validateWorkflowListProjectMetadata(expectedProjectID *string, responseProjectID *string, workflows []serverapi.WorkflowRecord) error {
+	if expectedProjectID == nil {
+		if responseProjectID != nil {
+			return fmt.Errorf("global workflow list response unexpectedly contains project_id %q", *responseProjectID)
 		}
 		for _, workflow := range workflows {
-			fmt.Fprintf(stdout, "%s: %s (v%d)\n", workflow.ID, workflow.Name, workflow.Version)
+			if workflow.ProjectLink != nil {
+				return fmt.Errorf("global workflow list response workflow %q contains project_link metadata", workflow.ID)
+			}
 		}
-		if strings.TrimSpace(nextPageToken) != "" {
-			fmt.Fprintf(stderr, "Next page token: `%s`\n", nextPageToken)
+		return nil
+	}
+	if responseProjectID == nil || strings.TrimSpace(*responseProjectID) == "" {
+		return errors.New("project workflow list response is missing project_id")
+	}
+	if *responseProjectID != *expectedProjectID {
+		return fmt.Errorf("project workflow list response project %q does not match requested project %q", *responseProjectID, *expectedProjectID)
+	}
+	for _, workflow := range workflows {
+		if workflow.ProjectLink == nil {
+			return fmt.Errorf("project workflow list response workflow %q is missing project_link metadata", workflow.ID)
 		}
-		return 0
-	})
+	}
+	return nil
+}
+
+func workflowProjectLinkState(link *serverapi.WorkflowListProjectLink) string {
+	if link.Default {
+		return "default"
+	}
+	return "linked"
 }
 
 func workflowNodeSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
-	return dispatchCommandGroup(args, stdout, stderr, commandGroup{
-		path:  "workflow node",
-		usage: workflowNodeUsage,
-		routes: map[string]commandHandler{
-			"add":    workflowNodeAddSubcommand,
-			"update": workflowNodeUpdateSubcommand,
-		},
-	})
+	if len(args) > 0 && args[0] == "add" {
+		return workflowNodeAddSubcommand(args[1:], stdout, stderr)
+	}
+	if len(args) > 0 && args[0] == "update" {
+		return workflowNodeUpdateSubcommand(args[1:], stdout, stderr)
+	}
+	fs := newCommandFlagSet(config.Command+" workflow node", stderr, workflowNodeUsage)
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		fs.Usage()
+		if len(args) == 0 {
+			return 2
+		}
+		return 0
+	}
+	fmt.Fprintf(stderr, "unknown workflow node command: %s\n\n", args[0])
+	fs.Usage()
+	return 2
 }
 
 func workflowNodeAddSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -253,27 +386,31 @@ func workflowNodeAddSubcommand(args []string, stdout io.Writer, stderr io.Writer
 	if *displayName == "" {
 		*displayName = workflowDisplayNameFromKey(*key)
 	}
+	selector, err := parseWorkflowSelector(workflowRef[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
 	nodeID := "node-" + uuid.NewString()
-	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
-		workflowID, err := resolveWorkflowID(context.Background(), remote, workflowRef[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		req := serverapi.WorkflowNodeAddRequest{WorkflowID: workflowID, NodeID: nodeID, Key: *key, Kind: *kind, DisplayName: *displayName, SubagentRole: *agent, PromptTemplate: *prompt, CompletionMode: *completionMode, ScriptPath: workflowScriptPathFlagValue(fs, "script-path", *scriptPath)}
-		resp, err := remote.AddWorkflowNode(ctx, req)
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, workflowNodeOutput{WorkflowID: workflowID, NodeID: nodeID, Key: *key, Kind: *kind, ScriptPath: req.ScriptPath, Version: resp.Version})
-		}
-		fmt.Fprintf(stdout, "Added %s node `%s` (%s).\n", *kind, *key, nodeID)
-		return 0
-	})
+	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	workflowID := selector.PersistedID()
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	req := serverapi.WorkflowNodeAddRequest{WorkflowID: workflowID, NodeID: nodeID, Key: *key, Kind: *kind, DisplayName: *displayName, SubagentRole: *agent, PromptTemplate: *prompt, CompletionMode: *completionMode, ScriptPath: workflowScriptPathFlagValue(fs, "script-path", *scriptPath)}
+	resp, err := remote.AddWorkflowNode(ctx, req)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		return writeCommandJSON(stdout, stderr, workflowNodeOutput{WorkflowID: selector.String(), NodeID: nodeID, Key: *key, Kind: *kind, ScriptPath: req.ScriptPath, Version: resp.Version})
+	}
+	fmt.Fprintf(stdout, "Added %s node `%s` (%s).\n", *kind, *key, nodeID)
+	return 0
 }
 
 func workflowNodeUpdateSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -290,65 +427,73 @@ func workflowNodeUpdateSubcommand(args []string, stdout io.Writer, stderr io.Wri
 	if !ok {
 		return exitCode
 	}
-	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
-		def, err := resolveWorkflowDefinition(context.Background(), remote, positionals[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		node, err := workflowNodeByKey(def, positionals[1])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		updated := node
-		if strings.TrimSpace(*key) != "" {
-			updated.Key = strings.TrimSpace(*key)
-		}
-		if strings.TrimSpace(*kind) != "" {
-			updated.Kind = strings.TrimSpace(*kind)
-		}
-		if strings.TrimSpace(*displayName) != "" {
-			updated.DisplayName = strings.TrimSpace(*displayName)
-		}
-		if fs.Lookup("prompt") != nil && flagWasProvided(fs, "prompt") {
-			updated.PromptTemplate = *prompt
-		}
-		if fs.Lookup("agent") != nil && flagWasProvided(fs, "agent") {
-			updated.SubagentRole = *agent
-		}
-		if flagWasProvided(fs, "completion-mode") {
-			updated.CompletionMode = strings.TrimSpace(*completionMode)
-		}
-		if flagWasProvided(fs, "script-path") {
-			updated.ScriptPath = workflowScriptPathFlagValue(fs, "script-path", *scriptPath)
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		resp, err := remote.UpdateWorkflowNode(ctx, serverapi.WorkflowNodeUpdateRequest{
-			WorkflowID:         def.Workflow.ID,
-			NodeID:             updated.ID,
-			Key:                updated.Key,
-			Kind:               updated.Kind,
-			DisplayName:        updated.DisplayName,
-			GroupKey:           updated.GroupKey,
-			SubagentRole:       updated.SubagentRole,
-			PromptTemplate:     updated.PromptTemplate,
-			CompletionMode:     updated.CompletionMode,
-			ScriptPath:         updated.ScriptPath,
-			InputFields:        updated.InputFields,
-			JoinInputProviders: updated.JoinInputProviders,
-		})
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, workflowNodeOutput{WorkflowID: def.Workflow.ID, NodeID: updated.ID, Key: updated.Key, Kind: updated.Kind, ScriptPath: updated.ScriptPath, Version: resp.Version})
-		}
-		fmt.Fprintf(stdout, "Updated node `%s`.\n", updated.Key)
-		return 0
+	selector, err := parseWorkflowSelector(positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	node, err := workflowNodeByKey(def, positionals[1])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	updated := node
+	if strings.TrimSpace(*key) != "" {
+		updated.Key = strings.TrimSpace(*key)
+	}
+	if strings.TrimSpace(*kind) != "" {
+		updated.Kind = strings.TrimSpace(*kind)
+	}
+	if strings.TrimSpace(*displayName) != "" {
+		updated.DisplayName = strings.TrimSpace(*displayName)
+	}
+	if fs.Lookup("prompt") != nil && flagWasProvided(fs, "prompt") {
+		updated.PromptTemplate = *prompt
+	}
+	if fs.Lookup("agent") != nil && flagWasProvided(fs, "agent") {
+		updated.SubagentRole = *agent
+	}
+	if flagWasProvided(fs, "completion-mode") {
+		updated.CompletionMode = strings.TrimSpace(*completionMode)
+	}
+	if flagWasProvided(fs, "script-path") {
+		updated.ScriptPath = workflowScriptPathFlagValue(fs, "script-path", *scriptPath)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	resp, err := remote.UpdateWorkflowNode(ctx, serverapi.WorkflowNodeUpdateRequest{
+		WorkflowID:         def.Workflow.ID,
+		NodeID:             updated.ID,
+		Key:                updated.Key,
+		Kind:               updated.Kind,
+		DisplayName:        updated.DisplayName,
+		GroupKey:           updated.GroupKey,
+		SubagentRole:       updated.SubagentRole,
+		PromptTemplate:     updated.PromptTemplate,
+		CompletionMode:     updated.CompletionMode,
+		ScriptPath:         updated.ScriptPath,
+		InputFields:        updated.InputFields,
+		JoinInputProviders: updated.JoinInputProviders,
 	})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		return writeCommandJSON(stdout, stderr, workflowNodeOutput{WorkflowID: selector.String(), NodeID: updated.ID, Key: updated.Key, Kind: updated.Kind, ScriptPath: updated.ScriptPath, Version: resp.Version})
+	}
+	fmt.Fprintf(stdout, "Updated node `%s`.\n", updated.Key)
+	return 0
 }
 
 func workflowScriptPathFlagValue(fs *flag.FlagSet, name string, value string) *string {
@@ -363,14 +508,23 @@ func workflowScriptPathFlagValue(fs *flag.FlagSet, name string, value string) *s
 }
 
 func workflowEdgeSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
-	return dispatchCommandGroup(args, stdout, stderr, commandGroup{
-		path:  "workflow edge",
-		usage: workflowEdgeUsage,
-		routes: map[string]commandHandler{
-			"add":    workflowEdgeAddSubcommand,
-			"update": workflowEdgeUpdateSubcommand,
-		},
-	})
+	if len(args) > 0 && args[0] == "add" {
+		return workflowEdgeAddSubcommand(args[1:], stdout, stderr)
+	}
+	if len(args) > 0 && args[0] == "update" {
+		return workflowEdgeUpdateSubcommand(args[1:], stdout, stderr)
+	}
+	fs := newCommandFlagSet(config.Command+" workflow edge", stderr, workflowEdgeUsage)
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		fs.Usage()
+		if len(args) == 0 {
+			return 2
+		}
+		return 0
+	}
+	fmt.Fprintf(stderr, "unknown workflow edge command: %s\n\n", args[0])
+	fs.Usage()
+	return 2
 }
 
 func workflowEdgeAddSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -405,81 +559,89 @@ func workflowEdgeAddSubcommand(args []string, stdout io.Writer, stderr io.Writer
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
-		def, err := resolveWorkflowDefinition(context.Background(), remote, workflowRef[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
+	selector, err := parseWorkflowSelector(workflowRef[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	source, err := workflowNodeByKey(def, *fromKey)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	target, err := workflowNodeByKey(def, *toKey)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	groupID := ""
+	var existingGroup *serverapi.WorkflowTransitionGroup
+	for i := range def.TransitionGroups {
+		group := def.TransitionGroups[i]
+		if group.SourceNodeID == source.ID && group.TransitionID == strings.TrimSpace(*transitionID) {
+			groupID = group.ID
+			existingGroup = &group
+			break
 		}
-		source, err := workflowNodeByKey(def, *fromKey)
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		target, err := workflowNodeByKey(def, *toKey)
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		groupID := ""
-		var existingGroup *serverapi.WorkflowTransitionGroup
-		for i := range def.TransitionGroups {
-			group := def.TransitionGroups[i]
-			if group.SourceNodeID == source.ID && group.TransitionID == strings.TrimSpace(*transitionID) {
-				groupID = group.ID
-				existingGroup = &group
-				break
-			}
-		}
-		trimmedDescription := strings.TrimSpace(*transitionDescription)
-		if groupID == "" {
-			groupID = "group-" + uuid.NewString()
-			ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-			resp, addErr := remote.AddWorkflowTransitionGroup(ctx, serverapi.WorkflowTransitionGroupAddRequest{WorkflowID: def.Workflow.ID, GroupID: groupID, SourceNodeID: source.ID, TransitionID: *transitionID, DisplayName: workflowDisplayNameFromKey(*transitionID), Description: trimmedDescription})
-			cancel()
-			if addErr != nil {
-				fmt.Fprintln(stderr, addErr)
-				return 1
-			}
-			_ = resp
-		}
-		descriptionRollback := func() {}
-		if groupID != "" && flagWasProvided(fs, "transition-description") && existingGroup != nil {
-			previousGroup := *existingGroup
-			ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-			resp, updateErr := remote.UpdateWorkflowTransitionGroup(ctx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: existingGroup.ID, SourceNodeID: existingGroup.SourceNodeID, TransitionID: existingGroup.TransitionID, DisplayName: existingGroup.DisplayName, Description: trimmedDescription})
-			cancel()
-			if updateErr != nil {
-				fmt.Fprintln(stderr, updateErr)
-				return 1
-			}
-			_ = resp
-			// Restore the prior description if a later step fails so a non-zero exit
-			// never leaves the transition group description partially mutated.
-			descriptionRollback = func() {
-				rbCtx, rbCancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-				_, rbErr := remote.UpdateWorkflowTransitionGroup(rbCtx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: previousGroup.ID, SourceNodeID: previousGroup.SourceNodeID, TransitionID: previousGroup.TransitionID, DisplayName: previousGroup.DisplayName, Description: previousGroup.Description})
-				rbCancel()
-				if rbErr != nil {
-					fmt.Fprintf(stderr, "rollback transition group %s description failed: %v\n", previousGroup.ID, rbErr)
-				}
-			}
-		}
-		edgeID := "edge-" + uuid.NewString()
+	}
+	trimmedDescription := strings.TrimSpace(*transitionDescription)
+	if groupID == "" {
+		groupID = "group-" + uuid.NewString()
 		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		resp, err := remote.AddWorkflowEdge(ctx, serverapi.WorkflowEdgeAddRequest{WorkflowID: def.Workflow.ID, EdgeID: edgeID, TransitionGroupID: groupID, Key: *edgeKey, TargetNodeID: target.ID, ContextMode: *contextMode, ContextSource: parsedContextSource, RequiresApproval: *requiresApproval, PromptTemplate: *prompt, Parameters: parsedParameters})
+		resp, addErr := remote.AddWorkflowTransitionGroup(ctx, serverapi.WorkflowTransitionGroupAddRequest{WorkflowID: def.Workflow.ID, GroupID: groupID, SourceNodeID: source.ID, TransitionID: *transitionID, DisplayName: workflowDisplayNameFromKey(*transitionID), Description: trimmedDescription})
 		cancel()
-		if err != nil {
-			descriptionRollback()
-			fmt.Fprintln(stderr, err)
+		if addErr != nil {
+			fmt.Fprintln(stderr, addErr)
 			return 1
 		}
-		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, workflowEdgeOutput{WorkflowID: def.Workflow.ID, EdgeID: edgeID, TransitionGroupID: groupID, Key: *edgeKey, TransitionID: *transitionID, Version: resp.Version})
+		_ = resp
+	}
+	descriptionRollback := func() {}
+	if groupID != "" && flagWasProvided(fs, "transition-description") && existingGroup != nil {
+		previousGroup := *existingGroup
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		resp, updateErr := remote.UpdateWorkflowTransitionGroup(ctx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: existingGroup.ID, SourceNodeID: existingGroup.SourceNodeID, TransitionID: existingGroup.TransitionID, DisplayName: existingGroup.DisplayName, Description: trimmedDescription})
+		cancel()
+		if updateErr != nil {
+			fmt.Fprintln(stderr, updateErr)
+			return 1
 		}
-		fmt.Fprintf(stdout, "Added edge `%s` (%s) on transition `%s`: `%s` → `%s` (%s).\n", *edgeKey, edgeID, *transitionID, *fromKey, *toKey, workflowEdgeContextDetail(*contextMode, *requiresApproval, parsedContextSource))
-		return 0
-	})
+		_ = resp
+		// Restore the prior description if a later step fails so a non-zero exit
+		// never leaves the transition group description partially mutated.
+		descriptionRollback = func() {
+			rbCtx, rbCancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+			_, rbErr := remote.UpdateWorkflowTransitionGroup(rbCtx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: previousGroup.ID, SourceNodeID: previousGroup.SourceNodeID, TransitionID: previousGroup.TransitionID, DisplayName: previousGroup.DisplayName, Description: previousGroup.Description})
+			rbCancel()
+			if rbErr != nil {
+				fmt.Fprintf(stderr, "rollback transition group %s description failed: %v\n", previousGroup.ID, rbErr)
+			}
+		}
+	}
+	edgeID := "edge-" + uuid.NewString()
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	resp, err := remote.AddWorkflowEdge(ctx, serverapi.WorkflowEdgeAddRequest{WorkflowID: def.Workflow.ID, EdgeID: edgeID, TransitionGroupID: groupID, Key: *edgeKey, TargetNodeID: target.ID, ContextMode: *contextMode, ContextSource: parsedContextSource, RequiresApproval: *requiresApproval, PromptTemplate: *prompt, Parameters: parsedParameters})
+	cancel()
+	if err != nil {
+		descriptionRollback()
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		return writeCommandJSON(stdout, stderr, workflowEdgeOutput{WorkflowID: selector.String(), EdgeID: edgeID, TransitionGroupID: groupID, Key: *edgeKey, TransitionID: *transitionID, Version: resp.Version})
+	}
+	fmt.Fprintf(stdout, "Added edge `%s` (%s) on transition `%s`: `%s` → `%s` (%s).\n", *edgeKey, edgeID, *transitionID, *fromKey, *toKey, workflowEdgeContextDetail(*contextMode, *requiresApproval, parsedContextSource))
+	return 0
 }
 
 func workflowEdgeUpdateSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -501,112 +663,120 @@ func workflowEdgeUpdateSubcommand(args []string, stdout io.Writer, stderr io.Wri
 	if !ok {
 		return exitCode
 	}
-	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
-		def, err := resolveWorkflowDefinition(context.Background(), remote, positionals[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
+	selector, err := parseWorkflowSelector(positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	edge, err := workflowEdgeByID(def, positionals[1])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	group, err := workflowTransitionGroupByID(def, edge.TransitionGroupID)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	updatedGroup := group
+	if strings.TrimSpace(*transitionID) != "" {
+		updatedGroup.TransitionID = strings.TrimSpace(*transitionID)
+	}
+	if strings.TrimSpace(*transitionDisplayName) != "" {
+		updatedGroup.DisplayName = strings.TrimSpace(*transitionDisplayName)
+	} else if strings.TrimSpace(*transitionID) != "" {
+		updatedGroup.DisplayName = workflowDisplayNameFromKey(*transitionID)
+	}
+	if flagWasProvided(fs, "transition-description") {
+		updatedGroup.Description = strings.TrimSpace(*transitionDescription)
+	}
+	updatedEdge := edge
+	if strings.TrimSpace(*edgeKey) != "" {
+		updatedEdge.Key = strings.TrimSpace(*edgeKey)
+	}
+	if strings.TrimSpace(*toKey) != "" {
+		target, targetErr := workflowNodeByKey(def, *toKey)
+		if targetErr != nil {
+			fmt.Fprintln(stderr, targetErr)
 			return 1
 		}
-		edge, err := workflowEdgeByID(def, positionals[1])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		group, err := workflowTransitionGroupByID(def, edge.TransitionGroupID)
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		updatedGroup := group
-		if strings.TrimSpace(*transitionID) != "" {
-			updatedGroup.TransitionID = strings.TrimSpace(*transitionID)
-		}
-		if strings.TrimSpace(*transitionDisplayName) != "" {
-			updatedGroup.DisplayName = strings.TrimSpace(*transitionDisplayName)
-		} else if strings.TrimSpace(*transitionID) != "" {
-			updatedGroup.DisplayName = workflowDisplayNameFromKey(*transitionID)
-		}
-		if flagWasProvided(fs, "transition-description") {
-			updatedGroup.Description = strings.TrimSpace(*transitionDescription)
-		}
-		updatedEdge := edge
-		if strings.TrimSpace(*edgeKey) != "" {
-			updatedEdge.Key = strings.TrimSpace(*edgeKey)
-		}
-		if strings.TrimSpace(*toKey) != "" {
-			target, targetErr := workflowNodeByKey(def, *toKey)
-			if targetErr != nil {
-				fmt.Fprintln(stderr, targetErr)
-				return 1
-			}
-			updatedEdge.TargetNodeID = target.ID
-		}
-		if strings.TrimSpace(*contextMode) != "" {
-			updatedEdge.ContextMode = strings.TrimSpace(*contextMode)
-		}
-		if strings.TrimSpace(*contextSource) != "" {
-			parsedContextSource, parseErr := parseWorkflowContextSourceSelector(*contextSource)
-			if parseErr != nil {
-				fmt.Fprintln(stderr, parseErr)
-				return 2
-			}
-			updatedEdge.ContextSource = parsedContextSource
-		}
-		if flagWasProvided(fs, "requires-approval") {
-			updatedEdge.RequiresApproval = *requiresApproval
-		}
-		if flagWasProvided(fs, "prompt") {
-			updatedEdge.PromptTemplate = *prompt
-		}
-		if *clearParams && flagWasProvided(fs, "param") {
-			fmt.Fprintln(stderr, "use either --param or --clear-params, not both")
+		updatedEdge.TargetNodeID = target.ID
+	}
+	if strings.TrimSpace(*contextMode) != "" {
+		updatedEdge.ContextMode = strings.TrimSpace(*contextMode)
+	}
+	if strings.TrimSpace(*contextSource) != "" {
+		parsedContextSource, parseErr := parseWorkflowContextSourceSelector(*contextSource)
+		if parseErr != nil {
+			fmt.Fprintln(stderr, parseErr)
 			return 2
 		}
-		if *clearParams {
-			updatedEdge.Parameters = nil
-		} else if flagWasProvided(fs, "param") {
-			parsedParameters, parseErr := parseWorkflowParameters(params)
-			if parseErr != nil {
-				fmt.Fprintln(stderr, parseErr)
-				return 2
-			}
-			updatedEdge.Parameters = parsedParameters
+		updatedEdge.ContextSource = parsedContextSource
+	}
+	if flagWasProvided(fs, "requires-approval") {
+		updatedEdge.RequiresApproval = *requiresApproval
+	}
+	if flagWasProvided(fs, "prompt") {
+		updatedEdge.PromptTemplate = *prompt
+	}
+	if *clearParams && flagWasProvided(fs, "param") {
+		fmt.Fprintln(stderr, "use either --param or --clear-params, not both")
+		return 2
+	}
+	if *clearParams {
+		updatedEdge.Parameters = nil
+	} else if flagWasProvided(fs, "param") {
+		parsedParameters, parseErr := parseWorkflowParameters(params)
+		if parseErr != nil {
+			fmt.Fprintln(stderr, parseErr)
+			return 2
 		}
-		// Commit the transition group change only after every edge flag has parsed, so
-		// a malformed --param or --context-source can never leave the group mutated
-		// while the command exits non-zero before touching the edge.
-		if updatedGroup != group {
-			groupCtx, groupCancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-			groupResp, updateErr := remote.UpdateWorkflowTransitionGroup(groupCtx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: updatedGroup.ID, SourceNodeID: updatedGroup.SourceNodeID, TransitionID: updatedGroup.TransitionID, DisplayName: updatedGroup.DisplayName, Description: updatedGroup.Description})
-			groupCancel()
-			if updateErr != nil {
-				fmt.Fprintln(stderr, updateErr)
-				return 1
-			}
-			_ = groupResp
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		resp, err := remote.UpdateWorkflowEdge(ctx, serverapi.WorkflowEdgeUpdateRequest{WorkflowID: def.Workflow.ID, EdgeID: updatedEdge.ID, TransitionGroupID: updatedEdge.TransitionGroupID, Key: updatedEdge.Key, TargetNodeID: updatedEdge.TargetNodeID, ContextMode: updatedEdge.ContextMode, ContextSource: updatedEdge.ContextSource, RequiresApproval: updatedEdge.RequiresApproval, PromptTemplate: updatedEdge.PromptTemplate, Parameters: updatedEdge.Parameters})
-		if err != nil {
-			if updatedGroup != group {
-				rollbackCtx, rollbackCancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-				_, rollbackErr := remote.UpdateWorkflowTransitionGroup(rollbackCtx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: group.ID, SourceNodeID: group.SourceNodeID, TransitionID: group.TransitionID, DisplayName: group.DisplayName, Description: group.Description})
-				rollbackCancel()
-				if rollbackErr != nil {
-					fmt.Fprintf(stderr, "%v; rollback transition group %s failed: %v\n", err, group.ID, rollbackErr)
-					return 1
-				}
-			}
-			fmt.Fprintln(stderr, err)
+		updatedEdge.Parameters = parsedParameters
+	}
+	// Commit the transition group change only after every edge flag has parsed, so
+	// a malformed --param or --context-source can never leave the group mutated
+	// while the command exits non-zero before touching the edge.
+	if updatedGroup != group {
+		groupCtx, groupCancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		groupResp, updateErr := remote.UpdateWorkflowTransitionGroup(groupCtx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: updatedGroup.ID, SourceNodeID: updatedGroup.SourceNodeID, TransitionID: updatedGroup.TransitionID, DisplayName: updatedGroup.DisplayName, Description: updatedGroup.Description})
+		groupCancel()
+		if updateErr != nil {
+			fmt.Fprintln(stderr, updateErr)
 			return 1
 		}
-		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, workflowEdgeOutput{WorkflowID: def.Workflow.ID, EdgeID: updatedEdge.ID, TransitionGroupID: updatedEdge.TransitionGroupID, Key: updatedEdge.Key, TransitionID: updatedGroup.TransitionID, Version: resp.Version})
+		_ = groupResp
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	resp, err := remote.UpdateWorkflowEdge(ctx, serverapi.WorkflowEdgeUpdateRequest{WorkflowID: def.Workflow.ID, EdgeID: updatedEdge.ID, TransitionGroupID: updatedEdge.TransitionGroupID, Key: updatedEdge.Key, TargetNodeID: updatedEdge.TargetNodeID, ContextMode: updatedEdge.ContextMode, ContextSource: updatedEdge.ContextSource, RequiresApproval: updatedEdge.RequiresApproval, PromptTemplate: updatedEdge.PromptTemplate, Parameters: updatedEdge.Parameters})
+	if err != nil {
+		if updatedGroup != group {
+			rollbackCtx, rollbackCancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+			_, rollbackErr := remote.UpdateWorkflowTransitionGroup(rollbackCtx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: group.ID, SourceNodeID: group.SourceNodeID, TransitionID: group.TransitionID, DisplayName: group.DisplayName, Description: group.Description})
+			rollbackCancel()
+			if rollbackErr != nil {
+				fmt.Fprintf(stderr, "%v; rollback transition group %s failed: %v\n", err, group.ID, rollbackErr)
+				return 1
+			}
 		}
-		fmt.Fprintf(stdout, "Updated edge `%s`: `%s` → `%s` (%s).\n", updatedEdge.Key, updatedGroup.TransitionID, workflowNodeKeyOrID(workflowNodeKeyByID(def), updatedEdge.TargetNodeID), workflowEdgeContextDetail(updatedEdge.ContextMode, updatedEdge.RequiresApproval, updatedEdge.ContextSource))
-		return 0
-	})
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		return writeCommandJSON(stdout, stderr, workflowEdgeOutput{WorkflowID: selector.String(), EdgeID: updatedEdge.ID, TransitionGroupID: updatedEdge.TransitionGroupID, Key: updatedEdge.Key, TransitionID: updatedGroup.TransitionID, Version: resp.Version})
+	}
+	fmt.Fprintf(stdout, "Updated edge `%s`: `%s` → `%s` (%s).\n", updatedEdge.Key, updatedGroup.TransitionID, workflowNodeKeyOrID(workflowNodeKeyByID(def), updatedEdge.TargetNodeID), workflowEdgeContextDetail(updatedEdge.ContextMode, updatedEdge.RequiresApproval, updatedEdge.ContextSource))
+	return 0
 }
 
 func workflowLinkSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -617,42 +787,51 @@ func workflowLinkSubcommand(args []string, stdout io.Writer, stderr io.Writer) i
 	if !ok {
 		return exitCode
 	}
-	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
-		projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, positionals[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		workflowID, err := resolveWorkflowID(context.Background(), remote, positionals[1])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		defaultPolicy := serverapi.WorkflowProjectLinkDefaultNever
-		if *defaultLink {
-			defaultPolicy = serverapi.WorkflowProjectLinkDefaultAlways
-		}
-		resp, err := remote.LinkWorkflowToProject(ctx, serverapi.WorkflowLinkProjectRequest{
-			ProjectID:     projectID,
-			WorkflowID:    workflowID,
-			DefaultPolicy: defaultPolicy,
-		})
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, resp.Link)
-		}
-		suffix := ""
-		if resp.Link.Default {
-			suffix = " as the default workflow"
-		}
-		fmt.Fprintf(stdout, "Linked workflow %s to project %s%s.\n", positionals[1], positionals[0], suffix)
-		return 0
+	selector, err := parseWorkflowSelector(positionals[1])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	workflowID := selector.PersistedID()
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	defaultPolicy := serverapi.WorkflowProjectLinkDefaultNever
+	if *defaultLink {
+		defaultPolicy = serverapi.WorkflowProjectLinkDefaultAlways
+	}
+	resp, err := remote.LinkWorkflowToProject(ctx, serverapi.WorkflowLinkProjectRequest{
+		ProjectID:     projectID,
+		WorkflowID:    workflowID,
+		DefaultPolicy: defaultPolicy,
 	})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		projected, projectionErr := projectWorkflowLinkForCLI(resp.Link)
+		if projectionErr != nil {
+			fmt.Fprintln(stderr, projectionErr)
+			return 1
+		}
+		return writeCommandJSON(stdout, stderr, projected)
+	}
+	suffix := ""
+	if resp.Link.Default {
+		suffix = " as the default workflow"
+	}
+	fmt.Fprintf(stdout, "Linked workflow %s to project %s%s.\n", positionals[1], positionals[0], suffix)
+	return 0
 }
 
 func workflowUnlinkSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -662,33 +841,41 @@ func workflowUnlinkSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 	if !ok {
 		return exitCode
 	}
-	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
-		link, err := resolveWorkflowProjectLink(context.Background(), cfg, remote, positionals[0], positionals[1])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		resp, err := remote.UnlinkWorkflowFromProject(ctx, serverapi.WorkflowUnlinkProjectRequest{LinkID: link.ID})
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if !resp.Unlinked {
-			if *jsonOut {
-				writeCommandJSON(stdout, stderr, resp)
-				return 1
-			}
-			writeWorkflowUnlinkBlockers(stderr, resp.Blockers)
-			return 1
-		}
+	selector, err := parseWorkflowSelector(positionals[1])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	link, err := resolveWorkflowProjectLink(context.Background(), cfg, remote, positionals[0], selector)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	resp, err := remote.UnlinkWorkflowFromProject(ctx, serverapi.WorkflowUnlinkProjectRequest{LinkID: link.ID})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if !resp.Unlinked {
 		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, resp)
+			writeCommandJSON(stdout, stderr, resp)
+			return 1
 		}
-		fmt.Fprintf(stdout, "Unlinked workflow %s from project %s.\n", positionals[1], positionals[0])
-		return 0
-	})
+		writeWorkflowUnlinkBlockers(stderr, resp.Blockers)
+		return 1
+	}
+	if *jsonOut {
+		return writeCommandJSON(stdout, stderr, resp)
+	}
+	fmt.Fprintf(stdout, "Unlinked workflow %s from project %s.\n", positionals[1], positionals[0])
+	return 0
 }
 
 func workflowDefaultSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -698,30 +885,39 @@ func workflowDefaultSubcommand(args []string, stdout io.Writer, stderr io.Writer
 	if !ok {
 		return exitCode
 	}
-	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
-		projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, positionals[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
+	selector, err := parseWorkflowSelector(positionals[1])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	workflowID := selector.PersistedID()
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	resp, err := remote.SetDefaultProjectWorkflowLink(ctx, serverapi.WorkflowSetDefaultProjectLinkRequest{ProjectID: projectID, WorkflowID: workflowID})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		projected, projectionErr := projectWorkflowLinkForCLI(resp.Link)
+		if projectionErr != nil {
+			fmt.Fprintln(stderr, projectionErr)
 			return 1
 		}
-		workflowID, err := resolveWorkflowID(context.Background(), remote, positionals[1])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		resp, err := remote.SetDefaultProjectWorkflowLink(ctx, serverapi.WorkflowSetDefaultProjectLinkRequest{ProjectID: projectID, WorkflowID: workflowID})
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, resp.Link)
-		}
-		fmt.Fprintf(stdout, "Set workflow %s as the default for project %s.\n", positionals[1], positionals[0])
-		return 0
-	})
+		return writeCommandJSON(stdout, stderr, projected)
+	}
+	fmt.Fprintf(stdout, "Set workflow %s as the default for project %s.\n", positionals[1], positionals[0])
+	return 0
 }
 
 func workflowValidateSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -732,43 +928,52 @@ func workflowValidateSubcommand(args []string, stdout io.Writer, stderr io.Write
 	if !ok {
 		return exitCode
 	}
-	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
-		workflowID, err := resolveWorkflowID(context.Background(), remote, positionals[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
+	selector, err := parseWorkflowSelector(positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	workflowID := selector.PersistedID()
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	resp, err := remote.ValidateWorkflow(ctx, serverapi.WorkflowValidateRequest{WorkflowID: workflowID, Mode: serverapi.WorkflowValidationMode(*mode)})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	resp, err = workflowValidationForCLI(resp)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		exit := writeCommandJSON(stdout, stderr, resp)
+		if exit == 0 && !resp.Valid {
 			return 1
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		defer cancel()
-		resp, err := remote.ValidateWorkflow(ctx, serverapi.WorkflowValidateRequest{WorkflowID: workflowID, Mode: serverapi.WorkflowValidationMode(*mode)})
-		if err != nil {
-			fmt.Fprintln(stderr, err)
-			return 1
-		}
-		if *jsonOut {
-			exit := writeCommandJSON(stdout, stderr, resp)
-			if exit == 0 && !resp.Valid {
-				return 1
-			}
-			return exit
-		}
-		if resp.Valid {
-			if len(resp.Errors) == 0 {
-				fmt.Fprintf(stdout, "Workflow %s is valid in %s mode.\n", workflowID, *mode)
-				return 0
-			}
-			fmt.Fprintf(stdout, "Workflow %s is valid in %s mode with %d diagnostic(s).\n", workflowID, *mode, len(resp.Errors))
-			for _, validationErr := range resp.Errors {
-				writeWorkflowValidationError(stdout, validationErr)
-			}
+		return exit
+	}
+	if resp.Valid {
+		if len(resp.Errors) == 0 {
+			fmt.Fprintf(stdout, "Workflow %s is valid in %s mode.\n", selector.String(), *mode)
 			return 0
 		}
-		fmt.Fprintf(stdout, "Workflow %s is invalid in %s mode: %d error(s).\n", workflowID, *mode, len(resp.Errors))
+		fmt.Fprintf(stdout, "Workflow %s is valid in %s mode with %d diagnostic(s).\n", selector.String(), *mode, len(resp.Errors))
 		for _, validationErr := range resp.Errors {
 			writeWorkflowValidationError(stdout, validationErr)
 		}
-		return 1
-	})
+		return 0
+	}
+	fmt.Fprintf(stdout, "Workflow %s is invalid in %s mode: %d error(s).\n", selector.String(), *mode, len(resp.Errors))
+	for _, validationErr := range resp.Errors {
+		writeWorkflowValidationError(stdout, validationErr)
+	}
+	return 1
 }
 
 func writeWorkflowValidationError(stdout io.Writer, err serverapi.WorkflowValidationError) {
@@ -798,32 +1003,89 @@ func workflowValidationErrorLocation(err serverapi.WorkflowValidationError) stri
 func workflowInspectSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 	fs := newCommandFlagSet(config.Command+" workflow inspect", stderr, workflowInspectUsage)
 	jsonOut := fs.Bool("json", false, "write the complete workflow definition as JSON")
+	summary := fs.Bool("summary", false, "write workflow metadata without loading the graph")
 	positionals, ok, exitCode := parseWorkflowPositionals(fs, args, 1, stderr, "workflow inspect requires <workflow>")
 	if !ok {
 		return exitCode
 	}
-	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
-		def, err := resolveWorkflowDefinition(context.Background(), remote, positionals[0])
-		if err != nil {
-			fmt.Fprintln(stderr, err)
+	selector, err := parseWorkflowSelector(positionals[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
+	if !opened {
+		return 1
+	}
+	defer closeRemote()
+	if *summary {
+		persistedWorkflowID := selector.PersistedID()
+		response, listErr := listWorkflowPage(context.Background(), remote, serverapi.WorkflowListRequest{
+			PageSize:   1,
+			WorkflowID: &persistedWorkflowID,
+		})
+		if listErr != nil {
+			fmt.Fprintln(stderr, listErr)
 			return 1
 		}
-		if *jsonOut {
-			return writeCommandJSON(stdout, stderr, def)
+		workflows, projectionErr := workflowRecordsForCLI(response.Workflows)
+		if projectionErr != nil {
+			fmt.Fprintln(stderr, projectionErr)
+			return 1
 		}
-		writeWorkflowDefinition(stdout, def)
+		if scopeErr := validateWorkflowListProjectMetadata(nil, response.ProjectID, workflows); scopeErr != nil {
+			fmt.Fprintln(stderr, scopeErr)
+			return 1
+		}
+		if len(workflows) == 0 {
+			fmt.Fprintf(stderr, "workflow %s not found\n", selector.String())
+			return 1
+		}
+		if len(workflows) != 1 || workflows[0].ID != selector.String() {
+			fmt.Fprintln(stderr, "workflow summary response does not match the requested workflow")
+			return 1
+		}
+		projected := workflows[0]
+		if *jsonOut {
+			return writeCommandJSON(stdout, stderr, projected)
+		}
+		writeWorkflowSummary(stdout, projected)
 		return 0
-	})
+	}
+	def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *jsonOut {
+		projected, projectionErr := workflowDefinitionForCLI(def)
+		if projectionErr != nil {
+			fmt.Fprintln(stderr, projectionErr)
+			return 1
+		}
+		return writeCommandJSON(stdout, stderr, projected)
+	}
+	projected, err := workflowDefinitionForCLI(def)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	writeWorkflowDefinition(stdout, projected)
+	return 0
 }
 
 func writeWorkflowDefinition(stdout io.Writer, def serverapi.WorkflowDefinition) {
-	fmt.Fprintf(stdout, "Workflow %q (%s), version %d.\n", def.Workflow.Name, def.Workflow.ID, def.Workflow.Version)
-	if description := strings.TrimSpace(def.Workflow.Description); description != "" {
-		fmt.Fprintf(stdout, "Description: %s\n", description)
-	}
-	fmt.Fprintf(stdout, "Execution target: %s\n", workflowExecutionTargetPolicySelector(def.Workflow.ExecutionTargetPolicy))
+	writeWorkflowSummary(stdout, def.Workflow)
 	writeWorkflowDefinitionNodes(stdout, def.Nodes)
 	writeWorkflowDefinitionTransitions(stdout, def)
+}
+
+func writeWorkflowSummary(stdout io.Writer, workflow serverapi.WorkflowRecord) {
+	fmt.Fprintf(stdout, "Workflow %q (%s), version %d.\n", workflow.Name, workflow.ID, workflow.Version)
+	if description := strings.TrimSpace(workflow.Description); description != "" {
+		fmt.Fprintf(stdout, "Description: %s\n", description)
+	}
+	fmt.Fprintf(stdout, "Execution target: %s\n", workflowExecutionTargetPolicySelector(workflow.ExecutionTargetPolicy))
 }
 
 func workflowGraphDraftFromDefinition(def serverapi.WorkflowDefinition) serverapi.WorkflowGraphDraft {
@@ -1045,52 +1307,25 @@ func canonicalAPIContextSource(source serverapi.WorkflowContextSource) serverapi
 	return source
 }
 
-func resolveWorkflowID(ctx context.Context, remote workflowCommandRemote, ref string) (string, error) {
-	def, err := resolveWorkflowDefinition(ctx, remote, ref)
-	if err != nil {
-		return "", err
-	}
-	return def.Workflow.ID, nil
-}
-
-func resolveWorkflowDefinition(ctx context.Context, remote workflowCommandRemote, ref string) (serverapi.WorkflowDefinition, error) {
-	trimmed := strings.TrimSpace(ref)
-	if trimmed == "" {
-		return serverapi.WorkflowDefinition{}, errors.New("workflow is required")
-	}
+func resolveWorkflowDefinition(ctx context.Context, remote workflowCommandRemote, selector workflowSelector) (serverapi.WorkflowDefinition, error) {
 	getCtx, getCancel := context.WithTimeout(ctx, workflowCommandTimeout)
 	defer getCancel()
-	resp, err := remote.GetWorkflow(getCtx, serverapi.WorkflowGetRequest{WorkflowID: trimmed})
-	if err == nil {
-		return resp.Definition, nil
-	}
-	nameMatches, _, listErr := listWorkflowPage(ctx, remote, serverapi.WorkflowListRequest{PageSize: 2, ExactName: trimmed})
-	if listErr != nil {
-		return serverapi.WorkflowDefinition{}, listErr
-	}
-	if len(nameMatches) == 0 {
-		return serverapi.WorkflowDefinition{}, fmt.Errorf("workflow %q not found", trimmed)
-	}
-	if len(nameMatches) > 1 {
-		return serverapi.WorkflowDefinition{}, fmt.Errorf("workflow %q is ambiguous; use workflow id", trimmed)
-	}
-	nameGetCtx, nameGetCancel := context.WithTimeout(ctx, workflowCommandTimeout)
-	defer nameGetCancel()
-	nameResp, err := remote.GetWorkflow(nameGetCtx, serverapi.WorkflowGetRequest{WorkflowID: nameMatches[0].ID})
+	resp, err := remote.GetWorkflow(getCtx, serverapi.WorkflowGetRequest{WorkflowID: selector.PersistedID()})
 	if err != nil {
 		return serverapi.WorkflowDefinition{}, err
 	}
-	return nameResp.Definition, nil
+	return resp.Definition, nil
 }
 
-func listWorkflowPage(ctx context.Context, remote workflowCommandRemote, req serverapi.WorkflowListRequest) ([]serverapi.WorkflowRecord, string, error) {
+func listWorkflowPage(ctx context.Context, remote workflowCommandRemote, req serverapi.WorkflowListRequest) (serverapi.WorkflowListResponse, error) {
 	rpcCtx, cancel := context.WithTimeout(ctx, workflowCommandTimeout)
 	defer cancel()
 	resp, err := remote.ListWorkflows(rpcCtx, req)
 	if err != nil {
-		return nil, "", err
+		return serverapi.WorkflowListResponse{}, err
 	}
-	return resp.Workflows, strings.TrimSpace(resp.NextPageToken), nil
+	resp.NextPageToken = strings.TrimSpace(resp.NextPageToken)
+	return resp, nil
 }
 
 func workflowNodeByKey(def serverapi.WorkflowDefinition, key string) (serverapi.WorkflowNode, error) {
@@ -1193,15 +1428,12 @@ func resolveWorkflowSourceWorkspaceID(ctx context.Context, cfg config.App, remot
 	return trimmed, nil
 }
 
-func resolveWorkflowProjectLink(ctx context.Context, cfg config.App, remote workflowCommandRemote, projectRef string, workflowRef string) (serverapi.ProjectWorkflowLink, error) {
+func resolveWorkflowProjectLink(ctx context.Context, cfg config.App, remote workflowCommandRemote, projectRef string, selector workflowSelector) (serverapi.ProjectWorkflowLink, error) {
 	projectID, err := resolveWorkflowProjectID(ctx, cfg, remote, projectRef)
 	if err != nil {
 		return serverapi.ProjectWorkflowLink{}, err
 	}
-	workflowID, err := resolveWorkflowID(ctx, remote, workflowRef)
-	if err != nil {
-		return serverapi.ProjectWorkflowLink{}, err
-	}
+	workflowID := selector.PersistedID()
 	rpcCtx, cancel := context.WithTimeout(ctx, workflowCommandTimeout)
 	defer cancel()
 	resp, err := remote.ListProjectWorkflowLinks(rpcCtx, serverapi.WorkflowListProjectLinksRequest{ProjectID: projectID})

--- a/cli/kent/workflow_command.go
+++ b/cli/kent/workflow_command.go
@@ -1005,6 +1005,10 @@ func workflowInspectSubcommand(args []string, stdout io.Writer, stderr io.Writer
 				fmt.Fprintln(stderr, listErr)
 				return 1
 			}
+			if response.NextPageToken != "" {
+				fmt.Fprintln(stderr, "workflow summary response contains a continuation token")
+				return 1
+			}
 			workflows, projectionErr := workflowRecordsForCLI(response.Workflows)
 			if projectionErr != nil {
 				fmt.Fprintln(stderr, projectionErr)
@@ -1291,6 +1295,13 @@ func resolveWorkflowDefinition(ctx context.Context, remote workflowCommandRemote
 	resp, err := remote.GetWorkflow(getCtx, serverapi.WorkflowGetRequest{WorkflowID: selector.PersistedID()})
 	if err != nil {
 		return serverapi.WorkflowDefinition{}, err
+	}
+	if resp.Definition.Workflow.ID != selector.PersistedID() {
+		return serverapi.WorkflowDefinition{}, fmt.Errorf(
+			"workflow response identity %q does not match requested workflow %q",
+			resp.Definition.Workflow.ID,
+			selector.PersistedID(),
+		)
 	}
 	return resp.Definition, nil
 }

--- a/cli/kent/workflow_command.go
+++ b/cli/kent/workflow_command.go
@@ -62,19 +62,6 @@ var workflowCommandRemoteOpener func(context.Context, string) (config.App, workf
 	return cfg, remote, err
 }
 
-func openWorkflowCommandSession(stderr io.Writer, path string) (config.App, workflowCommandRemote, func(), bool) {
-	cfg, remote, err := workflowCommandRemoteOpener(context.Background(), path)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return config.App{}, nil, nil, false
-	}
-	return cfg, remote, func() {
-		if err := remote.Close(); err != nil {
-			fmt.Fprintf(stderr, "close workflow command session: %v\n", err)
-		}
-	}, true
-}
-
 func runWorkflowCommandSession(stderr io.Writer, run func(config.App, workflowCommandRemote) int) int {
 	cfg, remote, err := workflowCommandRemoteOpener(context.Background(), ".")
 	if err != nil {
@@ -161,56 +148,53 @@ func workflowUpdateSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	metadata := serverapi.WorkflowGraphMetadata{
-		Name:                  def.Workflow.Name,
-		Description:           def.Workflow.Description,
-		ExecutionTargetPolicy: targetPolicy,
-	}
-	if flagWasProvided(fs, "name") {
-		metadata.Name = strings.TrimSpace(*name)
-	}
-	if flagWasProvided(fs, "description") {
-		metadata.Description = strings.TrimSpace(*description)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	resp, err := remote.SaveWorkflowGraph(ctx, serverapi.WorkflowGraphSaveRequest{
-		WorkflowID:      def.Workflow.ID,
-		ExpectedVersion: def.Workflow.Version,
-		Metadata:        &metadata,
-		Graph:           workflowGraphDraftFromDefinition(def),
-	})
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if !resp.Saved || resp.Definition == nil {
-		fmt.Fprintf(stderr, "workflow update was not saved at version %d\n", resp.CurrentVersion)
-		for _, blocker := range resp.Blockers {
-			fmt.Fprintf(stderr, "- [%s] %s\n", blocker.Code, blocker.Message)
+	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
+		def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
 		}
-		return 1
-	}
-	projected, err := workflowRecordForCLI(resp.Definition.Workflow)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		return writeCommandJSON(stdout, stderr, projected)
-	}
-	fmt.Fprintf(stdout, "Updated workflow %q (%s) to version %d.\n", projected.Name, projected.ID, projected.Version)
-	return 0
+		metadata := serverapi.WorkflowGraphMetadata{
+			Name:                  def.Workflow.Name,
+			Description:           def.Workflow.Description,
+			ExecutionTargetPolicy: targetPolicy,
+		}
+		if flagWasProvided(fs, "name") {
+			metadata.Name = strings.TrimSpace(*name)
+		}
+		if flagWasProvided(fs, "description") {
+			metadata.Description = strings.TrimSpace(*description)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		resp, err := remote.SaveWorkflowGraph(ctx, serverapi.WorkflowGraphSaveRequest{
+			WorkflowID:      def.Workflow.ID,
+			ExpectedVersion: def.Workflow.Version,
+			Metadata:        &metadata,
+			Graph:           workflowGraphDraftFromDefinition(def),
+		})
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if !resp.Saved || resp.Definition == nil {
+			fmt.Fprintf(stderr, "workflow update was not saved at version %d\n", resp.CurrentVersion)
+			for _, blocker := range resp.Blockers {
+				fmt.Fprintf(stderr, "- [%s] %s\n", blocker.Code, blocker.Message)
+			}
+			return 1
+		}
+		projected, err := workflowRecordForCLI(resp.Definition.Workflow)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if *jsonOut {
+			return writeCommandJSON(stdout, stderr, projected)
+		}
+		fmt.Fprintf(stdout, "Updated workflow %q (%s) to version %d.\n", projected.Name, projected.ID, projected.Version)
+		return 0
+	})
 }
 
 func workflowCreateSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -226,28 +210,25 @@ func workflowCreateSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 		fmt.Fprintln(stderr, "workflow create requires <name>")
 		return 2
 	}
-	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	resp, err := remote.CreateWorkflow(ctx, serverapi.WorkflowCreateRequest{Name: name, Description: *description})
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	projected, err := workflowRecordForCLI(resp.Workflow)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		return writeCommandJSON(stdout, stderr, projected)
-	}
-	fmt.Fprintf(stdout, "Created workflow %q (%s).\n", projected.Name, projected.ID)
-	return 0
+	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		resp, err := remote.CreateWorkflow(ctx, serverapi.WorkflowCreateRequest{Name: name, Description: *description})
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		projected, err := workflowRecordForCLI(resp.Workflow)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if *jsonOut {
+			return writeCommandJSON(stdout, stderr, projected)
+		}
+		fmt.Fprintf(stdout, "Created workflow %q (%s).\n", projected.Name, projected.ID)
+		return 0
+	})
 }
 
 func workflowListSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -268,51 +249,48 @@ func workflowListSubcommand(args []string, stdout io.Writer, stderr io.Writer) i
 		fmt.Fprintln(stderr, "workflow list --project requires a non-blank value")
 		return 2
 	}
-	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	var projectID *string
-	if projectProvided {
-		resolved, err := resolveWorkflowProjectID(context.Background(), cfg, remote, *project)
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		var projectID *string
+		if projectProvided {
+			resolved, err := resolveWorkflowProjectID(context.Background(), cfg, remote, *project)
+			if err != nil {
+				fmt.Fprintln(stderr, err)
+				return 1
+			}
+			projectID = &resolved
+		}
+		response, err := listWorkflowPage(context.Background(), remote, serverapi.WorkflowListRequest{PageSize: *pageSize, PageToken: *pageToken, ProjectID: projectID})
 		if err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		projectID = &resolved
-	}
-	response, err := listWorkflowPage(context.Background(), remote, serverapi.WorkflowListRequest{PageSize: *pageSize, PageToken: *pageToken, ProjectID: projectID})
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	workflows, err := workflowRecordsForCLI(response.Workflows)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if err := validateWorkflowListProjectMetadata(workflowListExpectedScope{
-		ProjectID:      projectID,
-		TokenOwnsScope: projectID == nil && strings.TrimSpace(*pageToken) != "",
-	}, response.ProjectID, workflows); err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		return writeCommandJSON(stdout, stderr, workflowListOutput{Workflows: workflows, ProjectID: response.ProjectID, NextPageToken: response.NextPageToken})
-	}
-	for _, workflow := range workflows {
-		if response.ProjectID != nil {
-			fmt.Fprintf(stdout, "%s: %s (v%d; %s; target %s)\n", workflow.ID, workflow.Name, workflow.Version, workflowProjectLinkState(workflow.ProjectLink), workflowExecutionTargetPolicySelector(workflow.ExecutionTargetPolicy))
-			continue
+		workflows, err := workflowRecordsForCLI(response.Workflows)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
 		}
-		fmt.Fprintf(stdout, "%s: %s (v%d)\n", workflow.ID, workflow.Name, workflow.Version)
-	}
-	if strings.TrimSpace(response.NextPageToken) != "" {
-		fmt.Fprintf(stderr, "Next page token: `%s`\n", response.NextPageToken)
-	}
-	return 0
+		if err := validateWorkflowListProjectMetadata(workflowListExpectedScope{
+			ProjectID:      projectID,
+			TokenOwnsScope: projectID == nil && strings.TrimSpace(*pageToken) != "",
+		}, response.ProjectID, workflows); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if *jsonOut {
+			return writeCommandJSON(stdout, stderr, workflowListOutput{Workflows: workflows, ProjectID: response.ProjectID, NextPageToken: response.NextPageToken})
+		}
+		for _, workflow := range workflows {
+			if response.ProjectID != nil {
+				fmt.Fprintf(stdout, "%s: %s (v%d; %s; target %s)\n", workflow.ID, workflow.Name, workflow.Version, workflowProjectLinkState(workflow.ProjectLink), workflowExecutionTargetPolicySelector(workflow.ExecutionTargetPolicy))
+				continue
+			}
+			fmt.Fprintf(stdout, "%s: %s (v%d)\n", workflow.ID, workflow.Name, workflow.Version)
+		}
+		if strings.TrimSpace(response.NextPageToken) != "" {
+			fmt.Fprintf(stderr, "Next page token: `%s`\n", response.NextPageToken)
+		}
+		return 0
+	})
 }
 
 type workflowListExpectedScope struct {
@@ -419,25 +397,22 @@ func workflowNodeAddSubcommand(args []string, stdout io.Writer, stderr io.Writer
 		return 2
 	}
 	nodeID := "node-" + uuid.NewString()
-	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	workflowID := selector.PersistedID()
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	req := serverapi.WorkflowNodeAddRequest{WorkflowID: workflowID, NodeID: nodeID, Key: *key, Kind: *kind, DisplayName: *displayName, SubagentRole: *agent, PromptTemplate: *prompt, CompletionMode: *completionMode, ScriptPath: workflowScriptPathFlagValue(fs, "script-path", *scriptPath)}
-	resp, err := remote.AddWorkflowNode(ctx, req)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		return writeCommandJSON(stdout, stderr, workflowNodeOutput{WorkflowID: selector.String(), NodeID: nodeID, Key: *key, Kind: *kind, ScriptPath: req.ScriptPath, Version: resp.Version})
-	}
-	fmt.Fprintf(stdout, "Added %s node `%s` (%s).\n", *kind, *key, nodeID)
-	return 0
+	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
+		workflowID := selector.PersistedID()
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		req := serverapi.WorkflowNodeAddRequest{WorkflowID: workflowID, NodeID: nodeID, Key: *key, Kind: *kind, DisplayName: *displayName, SubagentRole: *agent, PromptTemplate: *prompt, CompletionMode: *completionMode, ScriptPath: workflowScriptPathFlagValue(fs, "script-path", *scriptPath)}
+		resp, err := remote.AddWorkflowNode(ctx, req)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if *jsonOut {
+			return writeCommandJSON(stdout, stderr, workflowNodeOutput{WorkflowID: selector.String(), NodeID: nodeID, Key: *key, Kind: *kind, ScriptPath: req.ScriptPath, Version: resp.Version})
+		}
+		fmt.Fprintf(stdout, "Added %s node `%s` (%s).\n", *kind, *key, nodeID)
+		return 0
+	})
 }
 
 func workflowNodeUpdateSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -459,68 +434,65 @@ func workflowNodeUpdateSubcommand(args []string, stdout io.Writer, stderr io.Wri
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	node, err := workflowNodeByKey(def, positionals[1])
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	updated := node
-	if strings.TrimSpace(*key) != "" {
-		updated.Key = strings.TrimSpace(*key)
-	}
-	if strings.TrimSpace(*kind) != "" {
-		updated.Kind = strings.TrimSpace(*kind)
-	}
-	if strings.TrimSpace(*displayName) != "" {
-		updated.DisplayName = strings.TrimSpace(*displayName)
-	}
-	if fs.Lookup("prompt") != nil && flagWasProvided(fs, "prompt") {
-		updated.PromptTemplate = *prompt
-	}
-	if fs.Lookup("agent") != nil && flagWasProvided(fs, "agent") {
-		updated.SubagentRole = *agent
-	}
-	if flagWasProvided(fs, "completion-mode") {
-		updated.CompletionMode = strings.TrimSpace(*completionMode)
-	}
-	if flagWasProvided(fs, "script-path") {
-		updated.ScriptPath = workflowScriptPathFlagValue(fs, "script-path", *scriptPath)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	resp, err := remote.UpdateWorkflowNode(ctx, serverapi.WorkflowNodeUpdateRequest{
-		WorkflowID:         def.Workflow.ID,
-		NodeID:             updated.ID,
-		Key:                updated.Key,
-		Kind:               updated.Kind,
-		DisplayName:        updated.DisplayName,
-		GroupKey:           updated.GroupKey,
-		SubagentRole:       updated.SubagentRole,
-		PromptTemplate:     updated.PromptTemplate,
-		CompletionMode:     updated.CompletionMode,
-		ScriptPath:         updated.ScriptPath,
-		InputFields:        updated.InputFields,
-		JoinInputProviders: updated.JoinInputProviders,
+	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
+		def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		node, err := workflowNodeByKey(def, positionals[1])
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		updated := node
+		if strings.TrimSpace(*key) != "" {
+			updated.Key = strings.TrimSpace(*key)
+		}
+		if strings.TrimSpace(*kind) != "" {
+			updated.Kind = strings.TrimSpace(*kind)
+		}
+		if strings.TrimSpace(*displayName) != "" {
+			updated.DisplayName = strings.TrimSpace(*displayName)
+		}
+		if fs.Lookup("prompt") != nil && flagWasProvided(fs, "prompt") {
+			updated.PromptTemplate = *prompt
+		}
+		if fs.Lookup("agent") != nil && flagWasProvided(fs, "agent") {
+			updated.SubagentRole = *agent
+		}
+		if flagWasProvided(fs, "completion-mode") {
+			updated.CompletionMode = strings.TrimSpace(*completionMode)
+		}
+		if flagWasProvided(fs, "script-path") {
+			updated.ScriptPath = workflowScriptPathFlagValue(fs, "script-path", *scriptPath)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		resp, err := remote.UpdateWorkflowNode(ctx, serverapi.WorkflowNodeUpdateRequest{
+			WorkflowID:         def.Workflow.ID,
+			NodeID:             updated.ID,
+			Key:                updated.Key,
+			Kind:               updated.Kind,
+			DisplayName:        updated.DisplayName,
+			GroupKey:           updated.GroupKey,
+			SubagentRole:       updated.SubagentRole,
+			PromptTemplate:     updated.PromptTemplate,
+			CompletionMode:     updated.CompletionMode,
+			ScriptPath:         updated.ScriptPath,
+			InputFields:        updated.InputFields,
+			JoinInputProviders: updated.JoinInputProviders,
+		})
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if *jsonOut {
+			return writeCommandJSON(stdout, stderr, workflowNodeOutput{WorkflowID: selector.String(), NodeID: updated.ID, Key: updated.Key, Kind: updated.Kind, ScriptPath: updated.ScriptPath, Version: resp.Version})
+		}
+		fmt.Fprintf(stdout, "Updated node `%s`.\n", updated.Key)
+		return 0
 	})
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		return writeCommandJSON(stdout, stderr, workflowNodeOutput{WorkflowID: selector.String(), NodeID: updated.ID, Key: updated.Key, Kind: updated.Kind, ScriptPath: updated.ScriptPath, Version: resp.Version})
-	}
-	fmt.Fprintf(stdout, "Updated node `%s`.\n", updated.Key)
-	return 0
 }
 
 func workflowScriptPathFlagValue(fs *flag.FlagSet, name string, value string) *string {
@@ -591,84 +563,81 @@ func workflowEdgeAddSubcommand(args []string, stdout io.Writer, stderr io.Writer
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	source, err := workflowNodeByKey(def, *fromKey)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	target, err := workflowNodeByKey(def, *toKey)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	groupID := ""
-	var existingGroup *serverapi.WorkflowTransitionGroup
-	for i := range def.TransitionGroups {
-		group := def.TransitionGroups[i]
-		if group.SourceNodeID == source.ID && group.TransitionID == strings.TrimSpace(*transitionID) {
-			groupID = group.ID
-			existingGroup = &group
-			break
-		}
-	}
-	trimmedDescription := strings.TrimSpace(*transitionDescription)
-	if groupID == "" {
-		groupID = "group-" + uuid.NewString()
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		resp, addErr := remote.AddWorkflowTransitionGroup(ctx, serverapi.WorkflowTransitionGroupAddRequest{WorkflowID: def.Workflow.ID, GroupID: groupID, SourceNodeID: source.ID, TransitionID: *transitionID, DisplayName: workflowDisplayNameFromKey(*transitionID), Description: trimmedDescription})
-		cancel()
-		if addErr != nil {
-			fmt.Fprintln(stderr, addErr)
+	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
+		def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		_ = resp
-	}
-	descriptionRollback := func() {}
-	if groupID != "" && flagWasProvided(fs, "transition-description") && existingGroup != nil {
-		previousGroup := *existingGroup
-		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		resp, updateErr := remote.UpdateWorkflowTransitionGroup(ctx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: existingGroup.ID, SourceNodeID: existingGroup.SourceNodeID, TransitionID: existingGroup.TransitionID, DisplayName: existingGroup.DisplayName, Description: trimmedDescription})
-		cancel()
-		if updateErr != nil {
-			fmt.Fprintln(stderr, updateErr)
+		source, err := workflowNodeByKey(def, *fromKey)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		_ = resp
-		// Restore the prior description if a later step fails so a non-zero exit
-		// never leaves the transition group description partially mutated.
-		descriptionRollback = func() {
-			rbCtx, rbCancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-			_, rbErr := remote.UpdateWorkflowTransitionGroup(rbCtx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: previousGroup.ID, SourceNodeID: previousGroup.SourceNodeID, TransitionID: previousGroup.TransitionID, DisplayName: previousGroup.DisplayName, Description: previousGroup.Description})
-			rbCancel()
-			if rbErr != nil {
-				fmt.Fprintf(stderr, "rollback transition group %s description failed: %v\n", previousGroup.ID, rbErr)
+		target, err := workflowNodeByKey(def, *toKey)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		groupID := ""
+		var existingGroup *serverapi.WorkflowTransitionGroup
+		for i := range def.TransitionGroups {
+			group := def.TransitionGroups[i]
+			if group.SourceNodeID == source.ID && group.TransitionID == strings.TrimSpace(*transitionID) {
+				groupID = group.ID
+				existingGroup = &group
+				break
 			}
 		}
-	}
-	edgeID := "edge-" + uuid.NewString()
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	resp, err := remote.AddWorkflowEdge(ctx, serverapi.WorkflowEdgeAddRequest{WorkflowID: def.Workflow.ID, EdgeID: edgeID, TransitionGroupID: groupID, Key: *edgeKey, TargetNodeID: target.ID, ContextMode: *contextMode, ContextSource: parsedContextSource, RequiresApproval: *requiresApproval, PromptTemplate: *prompt, Parameters: parsedParameters})
-	cancel()
-	if err != nil {
-		descriptionRollback()
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		return writeCommandJSON(stdout, stderr, workflowEdgeOutput{WorkflowID: selector.String(), EdgeID: edgeID, TransitionGroupID: groupID, Key: *edgeKey, TransitionID: *transitionID, Version: resp.Version})
-	}
-	fmt.Fprintf(stdout, "Added edge `%s` (%s) on transition `%s`: `%s` → `%s` (%s).\n", *edgeKey, edgeID, *transitionID, *fromKey, *toKey, workflowEdgeContextDetail(*contextMode, *requiresApproval, parsedContextSource))
-	return 0
+		trimmedDescription := strings.TrimSpace(*transitionDescription)
+		if groupID == "" {
+			groupID = "group-" + uuid.NewString()
+			ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+			resp, addErr := remote.AddWorkflowTransitionGroup(ctx, serverapi.WorkflowTransitionGroupAddRequest{WorkflowID: def.Workflow.ID, GroupID: groupID, SourceNodeID: source.ID, TransitionID: *transitionID, DisplayName: workflowDisplayNameFromKey(*transitionID), Description: trimmedDescription})
+			cancel()
+			if addErr != nil {
+				fmt.Fprintln(stderr, addErr)
+				return 1
+			}
+			_ = resp
+		}
+		descriptionRollback := func() {}
+		if groupID != "" && flagWasProvided(fs, "transition-description") && existingGroup != nil {
+			previousGroup := *existingGroup
+			ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+			resp, updateErr := remote.UpdateWorkflowTransitionGroup(ctx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: existingGroup.ID, SourceNodeID: existingGroup.SourceNodeID, TransitionID: existingGroup.TransitionID, DisplayName: existingGroup.DisplayName, Description: trimmedDescription})
+			cancel()
+			if updateErr != nil {
+				fmt.Fprintln(stderr, updateErr)
+				return 1
+			}
+			_ = resp
+			// Restore the prior description if a later step fails so a non-zero exit
+			// never leaves the transition group description partially mutated.
+			descriptionRollback = func() {
+				rbCtx, rbCancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+				_, rbErr := remote.UpdateWorkflowTransitionGroup(rbCtx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: previousGroup.ID, SourceNodeID: previousGroup.SourceNodeID, TransitionID: previousGroup.TransitionID, DisplayName: previousGroup.DisplayName, Description: previousGroup.Description})
+				rbCancel()
+				if rbErr != nil {
+					fmt.Fprintf(stderr, "rollback transition group %s description failed: %v\n", previousGroup.ID, rbErr)
+				}
+			}
+		}
+		edgeID := "edge-" + uuid.NewString()
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		resp, err := remote.AddWorkflowEdge(ctx, serverapi.WorkflowEdgeAddRequest{WorkflowID: def.Workflow.ID, EdgeID: edgeID, TransitionGroupID: groupID, Key: *edgeKey, TargetNodeID: target.ID, ContextMode: *contextMode, ContextSource: parsedContextSource, RequiresApproval: *requiresApproval, PromptTemplate: *prompt, Parameters: parsedParameters})
+		cancel()
+		if err != nil {
+			descriptionRollback()
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if *jsonOut {
+			return writeCommandJSON(stdout, stderr, workflowEdgeOutput{WorkflowID: selector.String(), EdgeID: edgeID, TransitionGroupID: groupID, Key: *edgeKey, TransitionID: *transitionID, Version: resp.Version})
+		}
+		fmt.Fprintf(stdout, "Added edge `%s` (%s) on transition `%s`: `%s` → `%s` (%s).\n", *edgeKey, edgeID, *transitionID, *fromKey, *toKey, workflowEdgeContextDetail(*contextMode, *requiresApproval, parsedContextSource))
+		return 0
+	})
 }
 
 func workflowEdgeUpdateSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -695,115 +664,112 @@ func workflowEdgeUpdateSubcommand(args []string, stdout io.Writer, stderr io.Wri
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	edge, err := workflowEdgeByID(def, positionals[1])
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	group, err := workflowTransitionGroupByID(def, edge.TransitionGroupID)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	updatedGroup := group
-	if strings.TrimSpace(*transitionID) != "" {
-		updatedGroup.TransitionID = strings.TrimSpace(*transitionID)
-	}
-	if strings.TrimSpace(*transitionDisplayName) != "" {
-		updatedGroup.DisplayName = strings.TrimSpace(*transitionDisplayName)
-	} else if strings.TrimSpace(*transitionID) != "" {
-		updatedGroup.DisplayName = workflowDisplayNameFromKey(*transitionID)
-	}
-	if flagWasProvided(fs, "transition-description") {
-		updatedGroup.Description = strings.TrimSpace(*transitionDescription)
-	}
-	updatedEdge := edge
-	if strings.TrimSpace(*edgeKey) != "" {
-		updatedEdge.Key = strings.TrimSpace(*edgeKey)
-	}
-	if strings.TrimSpace(*toKey) != "" {
-		target, targetErr := workflowNodeByKey(def, *toKey)
-		if targetErr != nil {
-			fmt.Fprintln(stderr, targetErr)
+	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
+		def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		updatedEdge.TargetNodeID = target.ID
-	}
-	if strings.TrimSpace(*contextMode) != "" {
-		updatedEdge.ContextMode = strings.TrimSpace(*contextMode)
-	}
-	if strings.TrimSpace(*contextSource) != "" {
-		parsedContextSource, parseErr := parseWorkflowContextSourceSelector(*contextSource)
-		if parseErr != nil {
-			fmt.Fprintln(stderr, parseErr)
-			return 2
-		}
-		updatedEdge.ContextSource = parsedContextSource
-	}
-	if flagWasProvided(fs, "requires-approval") {
-		updatedEdge.RequiresApproval = *requiresApproval
-	}
-	if flagWasProvided(fs, "prompt") {
-		updatedEdge.PromptTemplate = *prompt
-	}
-	if *clearParams && flagWasProvided(fs, "param") {
-		fmt.Fprintln(stderr, "use either --param or --clear-params, not both")
-		return 2
-	}
-	if *clearParams {
-		updatedEdge.Parameters = nil
-	} else if flagWasProvided(fs, "param") {
-		parsedParameters, parseErr := parseWorkflowParameters(params)
-		if parseErr != nil {
-			fmt.Fprintln(stderr, parseErr)
-			return 2
-		}
-		updatedEdge.Parameters = parsedParameters
-	}
-	// Commit the transition group change only after every edge flag has parsed, so
-	// a malformed --param or --context-source can never leave the group mutated
-	// while the command exits non-zero before touching the edge.
-	if updatedGroup != group {
-		groupCtx, groupCancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-		groupResp, updateErr := remote.UpdateWorkflowTransitionGroup(groupCtx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: updatedGroup.ID, SourceNodeID: updatedGroup.SourceNodeID, TransitionID: updatedGroup.TransitionID, DisplayName: updatedGroup.DisplayName, Description: updatedGroup.Description})
-		groupCancel()
-		if updateErr != nil {
-			fmt.Fprintln(stderr, updateErr)
+		edge, err := workflowEdgeByID(def, positionals[1])
+		if err != nil {
+			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		_ = groupResp
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	resp, err := remote.UpdateWorkflowEdge(ctx, serverapi.WorkflowEdgeUpdateRequest{WorkflowID: def.Workflow.ID, EdgeID: updatedEdge.ID, TransitionGroupID: updatedEdge.TransitionGroupID, Key: updatedEdge.Key, TargetNodeID: updatedEdge.TargetNodeID, ContextMode: updatedEdge.ContextMode, ContextSource: updatedEdge.ContextSource, RequiresApproval: updatedEdge.RequiresApproval, PromptTemplate: updatedEdge.PromptTemplate, Parameters: updatedEdge.Parameters})
-	if err != nil {
-		if updatedGroup != group {
-			rollbackCtx, rollbackCancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-			_, rollbackErr := remote.UpdateWorkflowTransitionGroup(rollbackCtx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: group.ID, SourceNodeID: group.SourceNodeID, TransitionID: group.TransitionID, DisplayName: group.DisplayName, Description: group.Description})
-			rollbackCancel()
-			if rollbackErr != nil {
-				fmt.Fprintf(stderr, "%v; rollback transition group %s failed: %v\n", err, group.ID, rollbackErr)
+		group, err := workflowTransitionGroupByID(def, edge.TransitionGroupID)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		updatedGroup := group
+		if strings.TrimSpace(*transitionID) != "" {
+			updatedGroup.TransitionID = strings.TrimSpace(*transitionID)
+		}
+		if strings.TrimSpace(*transitionDisplayName) != "" {
+			updatedGroup.DisplayName = strings.TrimSpace(*transitionDisplayName)
+		} else if strings.TrimSpace(*transitionID) != "" {
+			updatedGroup.DisplayName = workflowDisplayNameFromKey(*transitionID)
+		}
+		if flagWasProvided(fs, "transition-description") {
+			updatedGroup.Description = strings.TrimSpace(*transitionDescription)
+		}
+		updatedEdge := edge
+		if strings.TrimSpace(*edgeKey) != "" {
+			updatedEdge.Key = strings.TrimSpace(*edgeKey)
+		}
+		if strings.TrimSpace(*toKey) != "" {
+			target, targetErr := workflowNodeByKey(def, *toKey)
+			if targetErr != nil {
+				fmt.Fprintln(stderr, targetErr)
 				return 1
 			}
+			updatedEdge.TargetNodeID = target.ID
 		}
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		return writeCommandJSON(stdout, stderr, workflowEdgeOutput{WorkflowID: selector.String(), EdgeID: updatedEdge.ID, TransitionGroupID: updatedEdge.TransitionGroupID, Key: updatedEdge.Key, TransitionID: updatedGroup.TransitionID, Version: resp.Version})
-	}
-	fmt.Fprintf(stdout, "Updated edge `%s`: `%s` → `%s` (%s).\n", updatedEdge.Key, updatedGroup.TransitionID, workflowNodeKeyOrID(workflowNodeKeyByID(def), updatedEdge.TargetNodeID), workflowEdgeContextDetail(updatedEdge.ContextMode, updatedEdge.RequiresApproval, updatedEdge.ContextSource))
-	return 0
+		if strings.TrimSpace(*contextMode) != "" {
+			updatedEdge.ContextMode = strings.TrimSpace(*contextMode)
+		}
+		if strings.TrimSpace(*contextSource) != "" {
+			parsedContextSource, parseErr := parseWorkflowContextSourceSelector(*contextSource)
+			if parseErr != nil {
+				fmt.Fprintln(stderr, parseErr)
+				return 2
+			}
+			updatedEdge.ContextSource = parsedContextSource
+		}
+		if flagWasProvided(fs, "requires-approval") {
+			updatedEdge.RequiresApproval = *requiresApproval
+		}
+		if flagWasProvided(fs, "prompt") {
+			updatedEdge.PromptTemplate = *prompt
+		}
+		if *clearParams && flagWasProvided(fs, "param") {
+			fmt.Fprintln(stderr, "use either --param or --clear-params, not both")
+			return 2
+		}
+		if *clearParams {
+			updatedEdge.Parameters = nil
+		} else if flagWasProvided(fs, "param") {
+			parsedParameters, parseErr := parseWorkflowParameters(params)
+			if parseErr != nil {
+				fmt.Fprintln(stderr, parseErr)
+				return 2
+			}
+			updatedEdge.Parameters = parsedParameters
+		}
+		// Commit the transition group change only after every edge flag has parsed, so
+		// a malformed --param or --context-source can never leave the group mutated
+		// while the command exits non-zero before touching the edge.
+		if updatedGroup != group {
+			groupCtx, groupCancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+			groupResp, updateErr := remote.UpdateWorkflowTransitionGroup(groupCtx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: updatedGroup.ID, SourceNodeID: updatedGroup.SourceNodeID, TransitionID: updatedGroup.TransitionID, DisplayName: updatedGroup.DisplayName, Description: updatedGroup.Description})
+			groupCancel()
+			if updateErr != nil {
+				fmt.Fprintln(stderr, updateErr)
+				return 1
+			}
+			_ = groupResp
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		resp, err := remote.UpdateWorkflowEdge(ctx, serverapi.WorkflowEdgeUpdateRequest{WorkflowID: def.Workflow.ID, EdgeID: updatedEdge.ID, TransitionGroupID: updatedEdge.TransitionGroupID, Key: updatedEdge.Key, TargetNodeID: updatedEdge.TargetNodeID, ContextMode: updatedEdge.ContextMode, ContextSource: updatedEdge.ContextSource, RequiresApproval: updatedEdge.RequiresApproval, PromptTemplate: updatedEdge.PromptTemplate, Parameters: updatedEdge.Parameters})
+		if err != nil {
+			if updatedGroup != group {
+				rollbackCtx, rollbackCancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+				_, rollbackErr := remote.UpdateWorkflowTransitionGroup(rollbackCtx, serverapi.WorkflowTransitionGroupUpdateRequest{WorkflowID: def.Workflow.ID, GroupID: group.ID, SourceNodeID: group.SourceNodeID, TransitionID: group.TransitionID, DisplayName: group.DisplayName, Description: group.Description})
+				rollbackCancel()
+				if rollbackErr != nil {
+					fmt.Fprintf(stderr, "%v; rollback transition group %s failed: %v\n", err, group.ID, rollbackErr)
+					return 1
+				}
+			}
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if *jsonOut {
+			return writeCommandJSON(stdout, stderr, workflowEdgeOutput{WorkflowID: selector.String(), EdgeID: updatedEdge.ID, TransitionGroupID: updatedEdge.TransitionGroupID, Key: updatedEdge.Key, TransitionID: updatedGroup.TransitionID, Version: resp.Version})
+		}
+		fmt.Fprintf(stdout, "Updated edge `%s`: `%s` → `%s` (%s).\n", updatedEdge.Key, updatedGroup.TransitionID, workflowNodeKeyOrID(workflowNodeKeyByID(def), updatedEdge.TargetNodeID), workflowEdgeContextDetail(updatedEdge.ContextMode, updatedEdge.RequiresApproval, updatedEdge.ContextSource))
+		return 0
+	})
 }
 
 func workflowLinkSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -819,46 +785,43 @@ func workflowLinkSubcommand(args []string, stdout io.Writer, stderr io.Writer) i
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, positionals[0])
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	workflowID := selector.PersistedID()
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	defaultPolicy := serverapi.WorkflowProjectLinkDefaultNever
-	if *defaultLink {
-		defaultPolicy = serverapi.WorkflowProjectLinkDefaultAlways
-	}
-	resp, err := remote.LinkWorkflowToProject(ctx, serverapi.WorkflowLinkProjectRequest{
-		ProjectID:     projectID,
-		WorkflowID:    workflowID,
-		DefaultPolicy: defaultPolicy,
-	})
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		projected, projectionErr := projectWorkflowLinkForCLI(resp.Link)
-		if projectionErr != nil {
-			fmt.Fprintln(stderr, projectionErr)
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, positionals[0])
+		if err != nil {
+			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		return writeCommandJSON(stdout, stderr, projected)
-	}
-	suffix := ""
-	if resp.Link.Default {
-		suffix = " as the default workflow"
-	}
-	fmt.Fprintf(stdout, "Linked workflow %s to project %s%s.\n", positionals[1], positionals[0], suffix)
-	return 0
+		workflowID := selector.PersistedID()
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		defaultPolicy := serverapi.WorkflowProjectLinkDefaultNever
+		if *defaultLink {
+			defaultPolicy = serverapi.WorkflowProjectLinkDefaultAlways
+		}
+		resp, err := remote.LinkWorkflowToProject(ctx, serverapi.WorkflowLinkProjectRequest{
+			ProjectID:     projectID,
+			WorkflowID:    workflowID,
+			DefaultPolicy: defaultPolicy,
+		})
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if *jsonOut {
+			projected, projectionErr := projectWorkflowLinkForCLI(resp.Link)
+			if projectionErr != nil {
+				fmt.Fprintln(stderr, projectionErr)
+				return 1
+			}
+			return writeCommandJSON(stdout, stderr, projected)
+		}
+		suffix := ""
+		if resp.Link.Default {
+			suffix = " as the default workflow"
+		}
+		fmt.Fprintf(stdout, "Linked workflow %s to project %s%s.\n", positionals[1], positionals[0], suffix)
+		return 0
+	})
 }
 
 func workflowUnlinkSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -873,36 +836,33 @@ func workflowUnlinkSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	link, err := resolveWorkflowProjectLink(context.Background(), cfg, remote, positionals[0], selector)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	resp, err := remote.UnlinkWorkflowFromProject(ctx, serverapi.WorkflowUnlinkProjectRequest{LinkID: link.ID})
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if !resp.Unlinked {
-		if *jsonOut {
-			writeCommandJSON(stdout, stderr, resp)
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		link, err := resolveWorkflowProjectLink(context.Background(), cfg, remote, positionals[0], selector)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		writeWorkflowUnlinkBlockers(stderr, resp.Blockers)
-		return 1
-	}
-	if *jsonOut {
-		return writeCommandJSON(stdout, stderr, resp)
-	}
-	fmt.Fprintf(stdout, "Unlinked workflow %s from project %s.\n", positionals[1], positionals[0])
-	return 0
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		resp, err := remote.UnlinkWorkflowFromProject(ctx, serverapi.WorkflowUnlinkProjectRequest{LinkID: link.ID})
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if !resp.Unlinked {
+			if *jsonOut {
+				writeCommandJSON(stdout, stderr, resp)
+				return 1
+			}
+			writeWorkflowUnlinkBlockers(stderr, resp.Blockers)
+			return 1
+		}
+		if *jsonOut {
+			return writeCommandJSON(stdout, stderr, resp)
+		}
+		fmt.Fprintf(stdout, "Unlinked workflow %s from project %s.\n", positionals[1], positionals[0])
+		return 0
+	})
 }
 
 func workflowDefaultSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -917,34 +877,31 @@ func workflowDefaultSubcommand(args []string, stdout io.Writer, stderr io.Writer
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	cfg, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, positionals[0])
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	workflowID := selector.PersistedID()
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	resp, err := remote.SetDefaultProjectWorkflowLink(ctx, serverapi.WorkflowSetDefaultProjectLinkRequest{ProjectID: projectID, WorkflowID: workflowID})
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		projected, projectionErr := projectWorkflowLinkForCLI(resp.Link)
-		if projectionErr != nil {
-			fmt.Fprintln(stderr, projectionErr)
+	return runWorkflowCommandSession(stderr, func(cfg config.App, remote workflowCommandRemote) int {
+		projectID, err := resolveWorkflowProjectID(context.Background(), cfg, remote, positionals[0])
+		if err != nil {
+			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		return writeCommandJSON(stdout, stderr, projected)
-	}
-	fmt.Fprintf(stdout, "Set workflow %s as the default for project %s.\n", positionals[1], positionals[0])
-	return 0
+		workflowID := selector.PersistedID()
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		resp, err := remote.SetDefaultProjectWorkflowLink(ctx, serverapi.WorkflowSetDefaultProjectLinkRequest{ProjectID: projectID, WorkflowID: workflowID})
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if *jsonOut {
+			projected, projectionErr := projectWorkflowLinkForCLI(resp.Link)
+			if projectionErr != nil {
+				fmt.Fprintln(stderr, projectionErr)
+				return 1
+			}
+			return writeCommandJSON(stdout, stderr, projected)
+		}
+		fmt.Fprintf(stdout, "Set workflow %s as the default for project %s.\n", positionals[1], positionals[0])
+		return 0
+	})
 }
 
 func workflowValidateSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -960,47 +917,44 @@ func workflowValidateSubcommand(args []string, stdout io.Writer, stderr io.Write
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	workflowID := selector.PersistedID()
-	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
-	defer cancel()
-	resp, err := remote.ValidateWorkflow(ctx, serverapi.WorkflowValidateRequest{WorkflowID: workflowID, Mode: serverapi.WorkflowValidationMode(*mode)})
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	resp, err = workflowValidationForCLI(resp)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		exit := writeCommandJSON(stdout, stderr, resp)
-		if exit == 0 && !resp.Valid {
+	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
+		workflowID := selector.PersistedID()
+		ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+		defer cancel()
+		resp, err := remote.ValidateWorkflow(ctx, serverapi.WorkflowValidateRequest{WorkflowID: workflowID, Mode: serverapi.WorkflowValidationMode(*mode)})
+		if err != nil {
+			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		return exit
-	}
-	if resp.Valid {
-		if len(resp.Errors) == 0 {
-			fmt.Fprintf(stdout, "Workflow %s is valid in %s mode.\n", selector.String(), *mode)
+		resp, err = workflowValidationForCLI(resp)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if *jsonOut {
+			exit := writeCommandJSON(stdout, stderr, resp)
+			if exit == 0 && !resp.Valid {
+				return 1
+			}
+			return exit
+		}
+		if resp.Valid {
+			if len(resp.Errors) == 0 {
+				fmt.Fprintf(stdout, "Workflow %s is valid in %s mode.\n", selector.String(), *mode)
+				return 0
+			}
+			fmt.Fprintf(stdout, "Workflow %s is valid in %s mode with %d diagnostic(s).\n", selector.String(), *mode, len(resp.Errors))
+			for _, validationErr := range resp.Errors {
+				writeWorkflowValidationError(stdout, validationErr)
+			}
 			return 0
 		}
-		fmt.Fprintf(stdout, "Workflow %s is valid in %s mode with %d diagnostic(s).\n", selector.String(), *mode, len(resp.Errors))
+		fmt.Fprintf(stdout, "Workflow %s is invalid in %s mode: %d error(s).\n", selector.String(), *mode, len(resp.Errors))
 		for _, validationErr := range resp.Errors {
 			writeWorkflowValidationError(stdout, validationErr)
 		}
-		return 0
-	}
-	fmt.Fprintf(stdout, "Workflow %s is invalid in %s mode: %d error(s).\n", selector.String(), *mode, len(resp.Errors))
-	for _, validationErr := range resp.Errors {
-		writeWorkflowValidationError(stdout, validationErr)
-	}
-	return 1
+		return 1
+	})
 }
 
 func writeWorkflowValidationError(stdout io.Writer, err serverapi.WorkflowValidationError) {
@@ -1040,65 +994,62 @@ func workflowInspectSubcommand(args []string, stdout io.Writer, stderr io.Writer
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
-	_, remote, closeRemote, opened := openWorkflowCommandSession(stderr, ".")
-	if !opened {
-		return 1
-	}
-	defer closeRemote()
-	if *summary {
-		persistedWorkflowID := selector.PersistedID()
-		response, listErr := listWorkflowPage(context.Background(), remote, serverapi.WorkflowListRequest{
-			PageSize:   1,
-			WorkflowID: &persistedWorkflowID,
-		})
-		if listErr != nil {
-			fmt.Fprintln(stderr, listErr)
+	return runWorkflowCommandSession(stderr, func(_ config.App, remote workflowCommandRemote) int {
+		if *summary {
+			persistedWorkflowID := selector.PersistedID()
+			response, listErr := listWorkflowPage(context.Background(), remote, serverapi.WorkflowListRequest{
+				PageSize:   1,
+				WorkflowID: &persistedWorkflowID,
+			})
+			if listErr != nil {
+				fmt.Fprintln(stderr, listErr)
+				return 1
+			}
+			workflows, projectionErr := workflowRecordsForCLI(response.Workflows)
+			if projectionErr != nil {
+				fmt.Fprintln(stderr, projectionErr)
+				return 1
+			}
+			if scopeErr := validateWorkflowListProjectMetadata(workflowListExpectedScope{}, response.ProjectID, workflows); scopeErr != nil {
+				fmt.Fprintln(stderr, scopeErr)
+				return 1
+			}
+			if len(workflows) == 0 {
+				fmt.Fprintf(stderr, "workflow %s not found\n", selector.String())
+				return 1
+			}
+			if len(workflows) != 1 || workflows[0].ID != selector.String() {
+				fmt.Fprintln(stderr, "workflow summary response does not match the requested workflow")
+				return 1
+			}
+			projected := workflows[0]
+			if *jsonOut {
+				return writeCommandJSON(stdout, stderr, projected)
+			}
+			writeWorkflowSummary(stdout, projected)
+			return 0
+		}
+		def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		workflows, projectionErr := workflowRecordsForCLI(response.Workflows)
-		if projectionErr != nil {
-			fmt.Fprintln(stderr, projectionErr)
-			return 1
-		}
-		if scopeErr := validateWorkflowListProjectMetadata(workflowListExpectedScope{}, response.ProjectID, workflows); scopeErr != nil {
-			fmt.Fprintln(stderr, scopeErr)
-			return 1
-		}
-		if len(workflows) == 0 {
-			fmt.Fprintf(stderr, "workflow %s not found\n", selector.String())
-			return 1
-		}
-		if len(workflows) != 1 || workflows[0].ID != selector.String() {
-			fmt.Fprintln(stderr, "workflow summary response does not match the requested workflow")
-			return 1
-		}
-		projected := workflows[0]
 		if *jsonOut {
+			projected, projectionErr := workflowDefinitionForCLI(def)
+			if projectionErr != nil {
+				fmt.Fprintln(stderr, projectionErr)
+				return 1
+			}
 			return writeCommandJSON(stdout, stderr, projected)
 		}
-		writeWorkflowSummary(stdout, projected)
-		return 0
-	}
-	def, err := resolveWorkflowDefinition(context.Background(), remote, selector)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	if *jsonOut {
-		projected, projectionErr := workflowDefinitionForCLI(def)
-		if projectionErr != nil {
-			fmt.Fprintln(stderr, projectionErr)
+		projected, err := workflowDefinitionForCLI(def)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
 			return 1
 		}
-		return writeCommandJSON(stdout, stderr, projected)
-	}
-	projected, err := workflowDefinitionForCLI(def)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	writeWorkflowDefinition(stdout, projected)
-	return 0
+		writeWorkflowDefinition(stdout, projected)
+		return 0
+	})
 }
 
 func writeWorkflowDefinition(stdout io.Writer, def serverapi.WorkflowDefinition) {

--- a/cli/kent/workflow_command.go
+++ b/cli/kent/workflow_command.go
@@ -292,7 +292,10 @@ func workflowListSubcommand(args []string, stdout io.Writer, stderr io.Writer) i
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
-	if err := validateWorkflowListProjectMetadata(projectID, response.ProjectID, workflows); err != nil {
+	if err := validateWorkflowListProjectMetadata(workflowListExpectedScope{
+		ProjectID:      projectID,
+		TokenOwnsScope: projectID == nil && strings.TrimSpace(*pageToken) != "",
+	}, response.ProjectID, workflows); err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
@@ -312,8 +315,13 @@ func workflowListSubcommand(args []string, stdout io.Writer, stderr io.Writer) i
 	return 0
 }
 
-func validateWorkflowListProjectMetadata(expectedProjectID *string, responseProjectID *string, workflows []serverapi.WorkflowRecord) error {
-	if expectedProjectID == nil {
+type workflowListExpectedScope struct {
+	ProjectID      *string
+	TokenOwnsScope bool
+}
+
+func validateWorkflowListProjectMetadata(expected workflowListExpectedScope, responseProjectID *string, workflows []serverapi.WorkflowRecord) error {
+	if expected.ProjectID == nil && !expected.TokenOwnsScope {
 		if responseProjectID != nil {
 			return fmt.Errorf("global workflow list response unexpectedly contains project_id %q", *responseProjectID)
 		}
@@ -324,11 +332,30 @@ func validateWorkflowListProjectMetadata(expectedProjectID *string, responseProj
 		}
 		return nil
 	}
+	if expected.ProjectID == nil {
+		if responseProjectID == nil {
+			for _, workflow := range workflows {
+				if workflow.ProjectLink != nil {
+					return fmt.Errorf("global workflow list continuation workflow %q contains project_link metadata", workflow.ID)
+				}
+			}
+			return nil
+		}
+		if strings.TrimSpace(*responseProjectID) == "" {
+			return errors.New("project workflow list continuation response has blank project_id")
+		}
+		for _, workflow := range workflows {
+			if workflow.ProjectLink == nil {
+				return fmt.Errorf("project workflow list continuation workflow %q is missing project_link metadata", workflow.ID)
+			}
+		}
+		return nil
+	}
 	if responseProjectID == nil || strings.TrimSpace(*responseProjectID) == "" {
 		return errors.New("project workflow list response is missing project_id")
 	}
-	if *responseProjectID != *expectedProjectID {
-		return fmt.Errorf("project workflow list response project %q does not match requested project %q", *responseProjectID, *expectedProjectID)
+	if *responseProjectID != *expected.ProjectID {
+		return fmt.Errorf("project workflow list response project %q does not match requested project %q", *responseProjectID, *expected.ProjectID)
 	}
 	for _, workflow := range workflows {
 		if workflow.ProjectLink == nil {
@@ -1033,7 +1060,7 @@ func workflowInspectSubcommand(args []string, stdout io.Writer, stderr io.Writer
 			fmt.Fprintln(stderr, projectionErr)
 			return 1
 		}
-		if scopeErr := validateWorkflowListProjectMetadata(nil, response.ProjectID, workflows); scopeErr != nil {
+		if scopeErr := validateWorkflowListProjectMetadata(workflowListExpectedScope{}, response.ProjectID, workflows); scopeErr != nil {
 			fmt.Fprintln(stderr, scopeErr)
 			return 1
 		}

--- a/cli/kent/workflow_command_test.go
+++ b/cli/kent/workflow_command_test.go
@@ -25,6 +25,8 @@ import (
 	"core/shared/sessionenv"
 )
 
+const workflowMismatchedSelectorTestUUID = "8e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
+
 type workflowCommandLoopbackRemote struct {
 	apicontract.WorkflowService
 	cfg                   config.App
@@ -188,10 +190,6 @@ func TestWorkflowUpdateRoundTripsExecutionTargetPolicies(t *testing.T) {
 		}
 	}
 
-	human, _ := runWorkflowRootCommandOK(t, "workflow", "inspect", workflowID)
-	if !strings.Contains(human, "ask-on-first-execution") {
-		t.Fatalf("workflow inspect omitted execution target policy: %s", human)
-	}
 }
 
 func TestWorkflowEditCommandsPersistNodeAndEdgeMetadata(t *testing.T) {
@@ -337,9 +335,9 @@ func TestWorkflowNodeScriptPathAddUpdateAndInspect(t *testing.T) {
 	}
 
 	runWorkflowRootCommandOK(t, "workflow", "node", "update", workflowID, "script", "--json", "--script-path", "scripts/fixed")
-	inspectOut, _ := runWorkflowRootCommandOK(t, "workflow", "inspect", workflowID)
-	if !strings.Contains(inspectOut, "- script (script): Renamed Script  [script: scripts/fixed]") {
-		t.Fatalf("workflow inspect output = %q, want script path node line", inspectOut)
+	node = workflowNodeByIDForTest(t, workflowInspectDefinitionForTest(t, workflowID), added.NodeID)
+	if node.ScriptPath == nil || *node.ScriptPath != "scripts/fixed" || node.DisplayName != "Renamed Script" {
+		t.Fatalf("updated script node = %+v, want preserved display name and fixed script path", node)
 	}
 }
 
@@ -555,7 +553,7 @@ func TestWorkflowHelpSmoke(t *testing.T) {
 }
 
 func TestWorkflowValidateRejectsRemovedProjectFlag(t *testing.T) {
-	_, _, code := runWorkflowRootCommand("workflow", "validate", "workflow-id", "--project", "project-id")
+	_, _, code := runWorkflowRootCommand("workflow", "validate", workflowSelectorTestUUID, "--project", "project-id")
 	if code != 2 {
 		t.Fatalf("workflow validate with removed --project exit=%d, want 2", code)
 	}
@@ -857,6 +855,41 @@ func TestWorkflowInspectSummaryRejectsMismatchedResponseScope(t *testing.T) {
 				t.Fatalf("workflow inspect summary mismatch exit=%d stdout=%q", code, stdout)
 			}
 		})
+	}
+}
+
+func TestWorkflowInspectSummaryRejectsContinuationToken(t *testing.T) {
+	const workflowID = "workflow-" + workflowSelectorTestUUID
+	remote := &pagedWorkflowListRemote{
+		pages: map[string]serverapi.WorkflowListResponse{
+			"": {
+				Workflows:     []serverapi.WorkflowRecord{{ID: workflowID}},
+				NextPageToken: "unexpected",
+			},
+		},
+	}
+	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: t.TempDir()}, remote)
+	defer restore()
+
+	stdout, _, code := runWorkflowRootCommand("workflow", "inspect", workflowSelectorTestUUID, "--summary")
+	if code != 1 || stdout != "" {
+		t.Fatalf("workflow inspect summary exit=%d stdout=%q, want rejected continuation", code, stdout)
+	}
+}
+
+func TestWorkflowUpdateRejectsMismatchedGetWorkflowIdentity(t *testing.T) {
+	remote := &preservingNodeUpdateRemote{
+		definitionWorkflowID: "workflow-" + workflowMismatchedSelectorTestUUID,
+	}
+	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: t.TempDir()}, remote)
+	defer restore()
+
+	stdout, _, code := runWorkflowRootCommand("workflow", "update", workflowSelectorTestUUID, "--name", "Updated")
+	if code != 1 || stdout != "" {
+		t.Fatalf("workflow update exit=%d stdout=%q, want rejected mismatched identity", code, stdout)
+	}
+	if remote.saveCalls != 0 {
+		t.Fatalf("SaveWorkflowGraph calls = %d, want no mutation after mismatched identity", remote.saveCalls)
 	}
 }
 
@@ -1195,7 +1228,9 @@ func (r *workflowCommandLoopbackRemote) ListRequests() []serverapi.WorkflowListR
 
 type preservingNodeUpdateRemote struct {
 	apicontract.WorkflowService
-	updateReq serverapi.WorkflowNodeUpdateRequest
+	updateReq            serverapi.WorkflowNodeUpdateRequest
+	definitionWorkflowID string
+	saveCalls            int
 }
 
 func (r *preservingNodeUpdateRemote) Close() error { return nil }
@@ -1209,8 +1244,12 @@ func (r *preservingNodeUpdateRemote) ListWorkflows(context.Context, serverapi.Wo
 }
 
 func (r *preservingNodeUpdateRemote) GetWorkflow(context.Context, serverapi.WorkflowGetRequest) (serverapi.WorkflowGetResponse, error) {
+	workflowID := r.definitionWorkflowID
+	if workflowID == "" {
+		workflowID = "workflow-" + workflowSelectorTestUUID
+	}
 	return serverapi.WorkflowGetResponse{Definition: serverapi.WorkflowDefinition{
-		Workflow: serverapi.WorkflowRecord{ID: "workflow-" + workflowSelectorTestUUID, Name: "Workflow"},
+		Workflow: serverapi.WorkflowRecord{ID: workflowID, Name: "Workflow"},
 		Nodes: []serverapi.WorkflowNode{{
 			ID:          "node-join",
 			WorkflowID:  "workflow-" + workflowSelectorTestUUID,
@@ -1227,6 +1266,11 @@ func (r *preservingNodeUpdateRemote) GetWorkflow(context.Context, serverapi.Work
 			}},
 		}},
 	}}, nil
+}
+
+func (r *preservingNodeUpdateRemote) SaveWorkflowGraph(context.Context, serverapi.WorkflowGraphSaveRequest) (serverapi.WorkflowGraphSaveResponse, error) {
+	r.saveCalls++
+	return serverapi.WorkflowGraphSaveResponse{}, nil
 }
 
 func (r *preservingNodeUpdateRemote) UpdateWorkflowNode(_ context.Context, req serverapi.WorkflowNodeUpdateRequest) (serverapi.WorkflowNodeUpdateResponse, error) {

--- a/cli/kent/workflow_command_test.go
+++ b/cli/kent/workflow_command_test.go
@@ -749,7 +749,7 @@ func TestWorkflowListRejectsResponseScopeMismatch(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if err := validateWorkflowListProjectMetadata(testCase.expected, testCase.response, testCase.records); err == nil {
+			if err := validateWorkflowListProjectMetadata(workflowListExpectedScope{ProjectID: testCase.expected}, testCase.response, testCase.records); err == nil {
 				t.Fatalf("validateWorkflowListProjectMetadata(%s) accepted mismatched response scope", name)
 			}
 		})
@@ -774,7 +774,7 @@ func TestWorkflowListProjectContinuationPreservesScopeAndJSONShape(t *testing.T)
 	if first.ProjectID == nil || first.NextPageToken == "" || len(first.Workflows) != 1 {
 		t.Fatalf("first project page = %+v, want one row and continuation", first)
 	}
-	secondOut, secondErr, code := runWorkflowRootCommand("workflow", "list", "--project", binding.ProjectID, "--page-size", "1", "--page-token", first.NextPageToken, "--json")
+	secondOut, secondErr, code := runWorkflowRootCommand("workflow", "list", "--page-size", "1", "--page-token", first.NextPageToken, "--json")
 	if code != 0 {
 		t.Fatalf("workflow list second project page exit=%d stderr=%q", code, secondErr)
 	}
@@ -786,8 +786,8 @@ func TestWorkflowListProjectContinuationPreservesScopeAndJSONShape(t *testing.T)
 		t.Fatalf("second project page = %+v, want restored project context", second)
 	}
 	requests := remote.ListRequests()
-	if len(requests) != 2 || requests[1].PageToken != first.NextPageToken || requests[1].ProjectID == nil || *requests[1].ProjectID != binding.ProjectID {
-		t.Fatalf("continuation requests = %+v, want project-bound token replay", requests)
+	if len(requests) != 2 || requests[1].PageToken != first.NextPageToken || requests[1].ProjectID != nil {
+		t.Fatalf("continuation requests = %+v, want token-owned project scope", requests)
 	}
 }
 

--- a/cli/kent/workflow_command_test.go
+++ b/cli/kent/workflow_command_test.go
@@ -34,11 +34,17 @@ type workflowCommandLoopbackRemote struct {
 	store                 *workflowstore.Store
 	closeErr              error
 	closeCalls            int
+	listRequests          []serverapi.WorkflowListRequest
 }
 
 func (r *workflowCommandLoopbackRemote) Close() error {
 	r.closeCalls++
 	return r.closeErr
+}
+
+func (r *workflowCommandLoopbackRemote) ListWorkflows(ctx context.Context, req serverapi.WorkflowListRequest) (serverapi.WorkflowListResponse, error) {
+	r.listRequests = append(r.listRequests, req)
+	return r.WorkflowService.ListWorkflows(ctx, req)
 }
 
 func (r *workflowCommandLoopbackRemote) SubscribeWorktreeSetup(ctx context.Context, req serverapi.WorktreeSetupSubscribeRequest) (serverapi.WorktreeSetupSubscription, error) {
@@ -106,6 +112,21 @@ func TestWorkflowCommandsExposeJSONAndPersistGraphState(t *testing.T) {
 	}
 }
 
+func TestWorkflowNodeAddRejectsSecondStart(t *testing.T) {
+	cfg, _, remote := newWorkflowCommandLoopback(t)
+	restore := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
+	defer restore()
+	workflowID := workflowCreateForTest(t, "Duplicate Start").ID
+
+	_, stderr, code := runWorkflowRootCommand(
+		"workflow", "node", "add", workflowID,
+		"--key", "second_start", "--kind", "start",
+	)
+	if code == 0 || strings.TrimSpace(stderr) == "" {
+		t.Fatalf("second Start exit=%d stderr_present=%t, want actionable command failure", code, strings.TrimSpace(stderr) != "")
+	}
+}
+
 func TestWorkflowJSONFlagPlacementCompatibility(t *testing.T) {
 	cfg, _, remote := newWorkflowCommandLoopback(t)
 	restore := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
@@ -122,8 +143,12 @@ func TestWorkflowJSONFlagPlacementCompatibility(t *testing.T) {
 	if record.Name != "Trailing Flag Flow" {
 		t.Fatalf("workflow name = %q, want trailing flag name", record.Name)
 	}
+	selector, err := parseWorkflowSelector(record.ID)
+	if err != nil {
+		t.Fatalf("created workflow id %q: %v", record.ID, err)
+	}
 
-	nodeOut, _, code := runWorkflowRootCommand("workflow", "node", "add", "--json", record.ID, "--key", "implement", "--kind", "agent", "--agent", "workflow-test", "--prompt", "Do work")
+	nodeOut, _, code := runWorkflowRootCommand("workflow", "node", "add", "--json", selector.String(), "--key", "implement", "--kind", "agent", "--agent", "workflow-test", "--prompt", "Do work")
 	if code != 0 {
 		t.Fatalf("workflow node add leading --json exit=%d", code)
 	}
@@ -163,6 +188,10 @@ func TestWorkflowUpdateRoundTripsExecutionTargetPolicies(t *testing.T) {
 		}
 	}
 
+	human, _ := runWorkflowRootCommandOK(t, "workflow", "inspect", workflowID)
+	if !strings.Contains(human, "ask-on-first-execution") {
+		t.Fatalf("workflow inspect omitted execution target policy: %s", human)
+	}
 }
 
 func TestWorkflowEditCommandsPersistNodeAndEdgeMetadata(t *testing.T) {
@@ -308,9 +337,9 @@ func TestWorkflowNodeScriptPathAddUpdateAndInspect(t *testing.T) {
 	}
 
 	runWorkflowRootCommandOK(t, "workflow", "node", "update", workflowID, "script", "--json", "--script-path", "scripts/fixed")
-	node = workflowNodeByIDForTest(t, workflowInspectDefinitionForTest(t, workflowID), added.NodeID)
-	if node.ScriptPath == nil || *node.ScriptPath != "scripts/fixed" {
-		t.Fatalf("script path after update = %+v, want scripts/fixed", node.ScriptPath)
+	inspectOut, _ := runWorkflowRootCommandOK(t, "workflow", "inspect", workflowID)
+	if !strings.Contains(inspectOut, "- script (script): Renamed Script  [script: scripts/fixed]") {
+		t.Fatalf("workflow inspect output = %q, want script path node line", inspectOut)
 	}
 }
 
@@ -320,7 +349,7 @@ func TestWorkflowNodeUpdatePreservesCanonicalWiringFields(t *testing.T) {
 	restore := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
 	defer restore()
 
-	_, stderr, code := runWorkflowRootCommand("workflow", "node", "update", "workflow-1", "join", "--json", "--display-name", "Updated Join")
+	_, stderr, code := runWorkflowRootCommand("workflow", "node", "update", workflowSelectorTestUUID, "join", "--json", "--display-name", "Updated Join")
 	if code != 0 {
 		t.Fatalf("workflow node update exit=%d stderr=%q", code, stderr)
 	}
@@ -380,7 +409,7 @@ func TestWorkflowEdgeUpdateRollsBackTransitionGroupWhenEdgeUpdateFails(t *testin
 	if _, _, code := runWorkflowRootCommand("workflow", "edge", "update", workflowID, edgeID, "--transition", "changed"); code == 0 {
 		t.Fatal("workflow edge update succeeded despite injected edge update failure")
 	}
-	def, _, err := loopback.store.GetDefinition(context.Background(), workflow.WorkflowID(workflowID))
+	def, _, err := loopback.store.GetDefinition(context.Background(), workflow.WorkflowID(workflowPersistedIDForTest(t, workflowID)))
 	if err != nil {
 		t.Fatalf("GetDefinition: %v", err)
 	}
@@ -409,7 +438,7 @@ func TestTaskCommandsExposeJSONAndPersistState(t *testing.T) {
 	if err := json.Unmarshal([]byte(createOut), &created); err != nil {
 		t.Fatalf("task create --json = %q, want JSON: %v", createOut, err)
 	}
-	if created.Summary.ID == "" || created.Summary.ShortID == "" || created.Body != "Body" || created.Workflow.WorkflowID != workflowID {
+	if created.Summary.ID == "" || created.Summary.ShortID == "" || created.Body != "Body" || created.Workflow.WorkflowID != workflowID || created.Summary.WorkflowID != workflowID {
 		t.Fatalf("task create --json = %+v, want created task detail", created)
 	}
 
@@ -436,7 +465,12 @@ func TestTaskCommandsExposeJSONAndPersistState(t *testing.T) {
 	if err := json.Unmarshal([]byte(showOut), &shown); err != nil {
 		t.Fatalf("task show --json = %q, want JSON: %v", showOut, err)
 	}
-	if shown.Summary.ID != created.Summary.ID || shown.Summary.Title != "Updated" || shown.Body != "Updated body" || shown.Summary.SourceWorkspaceID != binding.WorkspaceID {
+	if shown.Summary.ID != created.Summary.ID ||
+		shown.Summary.Title != "Updated" ||
+		shown.Body != "Updated body" ||
+		shown.Summary.SourceWorkspaceID != binding.WorkspaceID ||
+		shown.Summary.WorkflowID != workflowID ||
+		shown.Workflow.WorkflowID != workflowID {
 		t.Fatalf("task show --json = %+v, want updated task detail", shown)
 	}
 	var shownFields map[string]json.RawMessage
@@ -510,6 +544,23 @@ func TestTaskCommentAuthorForAddBoundaryCases(t *testing.T) {
 	}
 }
 
+func TestWorkflowHelpSmoke(t *testing.T) {
+	_, stderr, code := runWorkflowRootCommand("workflow", "--help")
+	if code != 0 {
+		t.Fatalf("workflow --help exit=%d, want 0", code)
+	}
+	if strings.TrimSpace(stderr) == "" {
+		t.Fatal("workflow --help output is empty")
+	}
+}
+
+func TestWorkflowValidateRejectsRemovedProjectFlag(t *testing.T) {
+	_, _, code := runWorkflowRootCommand("workflow", "validate", "workflow-id", "--project", "project-id")
+	if code != 2 {
+		t.Fatalf("workflow validate with removed --project exit=%d, want 2", code)
+	}
+}
+
 func TestWorkflowCommandValidationErrorsAreExitTwo(t *testing.T) {
 	for _, args := range [][]string{
 		{"workflow", "create"},
@@ -547,25 +598,23 @@ func TestParseWorkflowParameters(t *testing.T) {
 	}
 }
 
-func TestWorkflowListPaginatesAndResolutionDoesNotDrainPages(t *testing.T) {
+func TestWorkflowListPaginatesWithoutSelectorLookup(t *testing.T) {
+	const secondWorkflowSelector = "8e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
 	cfg := config.App{WorkspaceRoot: t.TempDir()}
 	remote := &pagedWorkflowListRemote{
 		delayAfterFirstPage: true,
 		pages: map[string]serverapi.WorkflowListResponse{
 			"": {
 				Workflows: []serverapi.WorkflowRecord{
-					{ID: "workflow-1", Name: "First", Version: 1},
+					{ID: "workflow-" + workflowSelectorTestUUID, Name: "First", Version: 1},
 				},
 				NextPageToken: "next",
 			},
 			"next": {
 				Workflows: []serverapi.WorkflowRecord{
-					{ID: "workflow-2", Name: "Second", Version: 2},
+					{ID: "workflow-" + secondWorkflowSelector, Name: "Second", Version: 2},
 				},
 			},
-		},
-		definitions: map[string]serverapi.WorkflowDefinition{
-			"workflow-2": {Workflow: serverapi.WorkflowRecord{ID: "workflow-2", Name: "Second", Version: 2}},
 		},
 	}
 	restore := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
@@ -579,60 +628,235 @@ func TestWorkflowListPaginatesAndResolutionDoesNotDrainPages(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &listed); err != nil {
 		t.Fatalf("workflow list --json = %q, want JSON: %v", stdout, err)
 	}
-	if len(listed.Workflows) != 1 || listed.Workflows[0].ID != "workflow-1" || listed.NextPageToken != "next" {
+	if len(listed.Workflows) != 1 || listed.Workflows[0].ID != workflowSelectorTestUUID || listed.NextPageToken != "next" {
 		t.Fatalf("workflow list --json = %+v, want first page plus token", listed)
 	}
 	if len(remote.requests) != 1 || remote.requests[0].PageToken != "" || remote.requests[0].PageSize != serverapi.WorkflowListMaxPageSize {
 		t.Fatalf("workflow list requests = %+v, want single default-sized first page", remote.requests)
 	}
 
-	remote.requests = nil
-	remote.deadlines = nil
-	resolved, err := resolveWorkflowID(context.Background(), remote, "Second")
-	if err != nil {
-		t.Fatalf("resolveWorkflowID: %v", err)
-	}
-	if resolved != "workflow-2" {
-		t.Fatalf("resolveWorkflowID = %q, want workflow-2", resolved)
-	}
-	if len(remote.requests) != 1 || remote.requests[0].ExactName != "Second" || remote.requests[0].PageSize != 2 || remote.requests[0].PageToken != "" {
-		t.Fatalf("resolve requests = %+v, want bounded exact-name lookup", remote.requests)
-	}
-	if len(remote.deadlines) != 3 {
-		t.Fatalf("resolve deadlines = %+v, want id get plus exact-name list plus name get deadlines", remote.deadlines)
+	if len(remote.deadlines) != 1 {
+		t.Fatalf("list deadlines = %+v, want one bounded list call", remote.deadlines)
 	}
 }
 
-func TestRunWorkflowCommandSessionReportsCloseFailureWithoutChangingExitCode(t *testing.T) {
-	for _, wantCode := range []int{0, 1, 2} {
-		remote := &workflowCommandLoopbackRemote{closeErr: errors.New("close failed")}
-		restore := replaceWorkflowCommandRemoteOpener(t, config.App{}, remote)
-		stderr := new(strings.Builder)
-		got := runWorkflowCommandSession(stderr, func(config.App, workflowCommandRemote) int { return wantCode })
-		restore()
-		if got != wantCode {
-			t.Fatalf("exit code = %d, want %d", got, wantCode)
-		}
-		if remote.closeCalls != 1 {
-			t.Fatalf("remote close calls = %d, want 1", remote.closeCalls)
-		}
-		if strings.TrimSpace(stderr.String()) == "" {
-			t.Fatal("remote close failure was not reported")
-		}
+func TestWorkflowListProjectScopeResolvesPathAndIDAndProjectsMetadata(t *testing.T) {
+	cfg, binding, remote := newWorkflowCommandLoopback(t)
+	restore := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
+	defer restore()
+
+	workflowID := setupLinkedWorkflow(t, binding.ProjectID, "Project Workflow")
+	out, _, code := runWorkflowRootCommand("workflow", "list", "--project", binding.ProjectID, "--json")
+	if code != 0 {
+		t.Fatalf("workflow list project id exit=%d", code)
+	}
+	var byID workflowListOutput
+	if err := json.Unmarshal([]byte(out), &byID); err != nil {
+		t.Fatalf("decode project-id workflow list: %v", err)
+	}
+	if byID.ProjectID == nil || *byID.ProjectID != binding.ProjectID || !workflowListContains(byID.Workflows, workflowID) {
+		t.Fatalf("project-id response = %+v, want project context and workflow", byID)
+	}
+	if len(byID.Workflows) != 1 || byID.Workflows[0].ProjectLink == nil {
+		t.Fatalf("project-id workflow metadata = %+v, want project link metadata", byID.Workflows)
 	}
 
-	original := workflowCommandRemoteOpener
-	defer func() { workflowCommandRemoteOpener = original }()
-	workflowCommandRemoteOpener = func(context.Context, string) (config.App, workflowCommandRemote, error) {
-		return config.App{}, nil, errors.New("open failed")
+	out, _, code = runWorkflowRootCommand("workflow", "list", "--project", cfg.WorkspaceRoot, "--json")
+	if code != 0 {
+		t.Fatalf("workflow list project path exit=%d", code)
 	}
-	called := false
-	stderr := new(strings.Builder)
-	if got := runWorkflowCommandSession(stderr, func(config.App, workflowCommandRemote) int {
-		called = true
-		return 0
-	}); got != 1 || called || strings.TrimSpace(stderr.String()) == "" {
-		t.Fatalf("open failure exit=%d callback=%t stderr=%q", got, called, stderr.String())
+	var byPath workflowListOutput
+	if err := json.Unmarshal([]byte(out), &byPath); err != nil {
+		t.Fatalf("decode project-path workflow list: %v", err)
+	}
+	if byPath.ProjectID == nil || *byPath.ProjectID != binding.ProjectID || !workflowListContains(byPath.Workflows, workflowID) {
+		t.Fatalf("project-path response = %+v, want same project discovery", byPath)
+	}
+	if len(remote.ListRequests()) != 2 {
+		t.Fatalf("workflow list requests = %+v, want one request per scope", remote.ListRequests())
+	}
+	for _, req := range remote.ListRequests() {
+		if req.ProjectID == nil || *req.ProjectID != binding.ProjectID {
+			t.Fatalf("workflow list request = %+v, want resolved project id", req)
+		}
+	}
+}
+
+func TestWorkflowListRejectsExplicitBlankProjectBeforeOpeningRemote(t *testing.T) {
+	opened := false
+	original := workflowCommandRemoteOpener
+	workflowCommandRemoteOpener = func(context.Context, string) (config.App, workflowCommandRemote, error) {
+		opened = true
+		return config.App{}, nil, nil
+	}
+	defer func() { workflowCommandRemoteOpener = original }()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := workflowListSubcommand([]string{"--project", ""}, &stdout, &stderr)
+	if code != 2 || opened || stdout.Len() != 0 || stderr.Len() == 0 {
+		t.Fatalf("workflow list blank project exit=%d opened=%v stdout=%q stderr=%q", code, opened, stdout.String(), stderr.String())
+	}
+}
+
+func TestWorkflowListProjectResponseRequiresProjectLinkMetadata(t *testing.T) {
+	projectID := "project-1"
+	remote := &pagedWorkflowListRemote{
+		pages: map[string]serverapi.WorkflowListResponse{
+			"": {
+				ProjectID: &projectID,
+				Workflows: []serverapi.WorkflowRecord{{
+					ID:                    "workflow-" + workflowSelectorTestUUID,
+					Name:                  "Workflow",
+					Version:               1,
+					ExecutionTargetPolicy: serverapi.WorkflowExecutionTargetConfiguration{Mode: serverapi.WorkflowExecutionTargetModeNone},
+				}},
+			},
+		},
+	}
+	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: "."}, remote)
+	defer restore()
+
+	stdout, _, code := runWorkflowRootCommand("workflow", "list", "--project", projectID)
+	if code != 1 || stdout != "" {
+		t.Fatalf("workflow list exit=%d stdout=%q, want impossible project-link response failure", code, stdout)
+	}
+}
+
+func TestWorkflowListRejectsResponseScopeMismatch(t *testing.T) {
+	requestedProjectID := "project-1"
+	otherProjectID := "project-2"
+	projectWorkflow := serverapi.WorkflowRecord{
+		ID:                    "workflow-" + workflowSelectorTestUUID,
+		ProjectLink:           &serverapi.WorkflowListProjectLink{},
+		ExecutionTargetPolicy: serverapi.WorkflowExecutionTargetConfiguration{Mode: serverapi.WorkflowExecutionTargetModeNone},
+	}
+	for name, testCase := range map[string]struct {
+		expected *string
+		response *string
+		records  []serverapi.WorkflowRecord
+	}{
+		"global response unexpectedly scoped": {
+			response: &otherProjectID,
+		},
+		"project response missing scope": {
+			expected: &requestedProjectID,
+		},
+		"project response mismatches scope": {
+			expected: &requestedProjectID,
+			response: &otherProjectID,
+			records:  []serverapi.WorkflowRecord{projectWorkflow},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateWorkflowListProjectMetadata(testCase.expected, testCase.response, testCase.records); err == nil {
+				t.Fatalf("validateWorkflowListProjectMetadata(%s) accepted mismatched response scope", name)
+			}
+		})
+	}
+}
+
+func TestWorkflowListProjectContinuationPreservesScopeAndJSONShape(t *testing.T) {
+	cfg, binding, remote := newWorkflowCommandLoopback(t)
+	restore := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
+	defer restore()
+
+	setupLinkedWorkflow(t, binding.ProjectID, "First Project Workflow")
+	setupLinkedWorkflow(t, binding.ProjectID, "Second Project Workflow")
+	firstOut, firstErr, code := runWorkflowRootCommand("workflow", "list", "--project", binding.ProjectID, "--page-size", "1", "--json")
+	if code != 0 {
+		t.Fatalf("workflow list first project page exit=%d stderr=%q", code, firstErr)
+	}
+	var first workflowListOutput
+	if err := json.Unmarshal([]byte(firstOut), &first); err != nil {
+		t.Fatalf("decode first project page: %v", err)
+	}
+	if first.ProjectID == nil || first.NextPageToken == "" || len(first.Workflows) != 1 {
+		t.Fatalf("first project page = %+v, want one row and continuation", first)
+	}
+	secondOut, secondErr, code := runWorkflowRootCommand("workflow", "list", "--project", binding.ProjectID, "--page-size", "1", "--page-token", first.NextPageToken, "--json")
+	if code != 0 {
+		t.Fatalf("workflow list second project page exit=%d stderr=%q", code, secondErr)
+	}
+	var second workflowListOutput
+	if err := json.Unmarshal([]byte(secondOut), &second); err != nil {
+		t.Fatalf("decode second project page: %v", err)
+	}
+	if second.ProjectID == nil || *second.ProjectID != binding.ProjectID || len(second.Workflows) != 1 {
+		t.Fatalf("second project page = %+v, want restored project context", second)
+	}
+	requests := remote.ListRequests()
+	if len(requests) != 2 || requests[1].PageToken != first.NextPageToken || requests[1].ProjectID == nil || *requests[1].ProjectID != binding.ProjectID {
+		t.Fatalf("continuation requests = %+v, want project-bound token replay", requests)
+	}
+}
+
+func TestWorkflowInspectSummaryUsesMetadataListWithoutDefinitionRead(t *testing.T) {
+	cfg := config.App{WorkspaceRoot: t.TempDir()}
+	const workflowID = "workflow-" + workflowSelectorTestUUID
+	remote := &pagedWorkflowListRemote{
+		pages: map[string]serverapi.WorkflowListResponse{
+			"": {Workflows: []serverapi.WorkflowRecord{{
+				ID:                    workflowID,
+				Name:                  "Summary Workflow",
+				Description:           "Metadata only",
+				Version:               7,
+				ExecutionTargetPolicy: serverapi.WorkflowExecutionTargetConfiguration{Mode: "head"},
+			}}},
+		},
+		definitions: map[string]serverapi.WorkflowDefinition{},
+	}
+	restore := replaceWorkflowCommandRemoteOpener(t, cfg, remote)
+	defer restore()
+
+	out, _, code := runWorkflowRootCommand("workflow", "inspect", workflowSelectorTestUUID, "--summary", "--json")
+	if code != 0 {
+		t.Fatalf("workflow inspect summary exit=%d", code)
+	}
+	var summary serverapi.WorkflowRecord
+	if err := json.Unmarshal([]byte(out), &summary); err != nil {
+		t.Fatalf("decode workflow inspect summary: %v", err)
+	}
+	if summary.ID != workflowSelectorTestUUID || summary.Name != "Summary Workflow" || summary.Version != 7 {
+		t.Fatalf("summary = %+v, want projected metadata record", summary)
+	}
+	if len(remote.requests) != 1 || remote.requests[0].WorkflowID == nil || *remote.requests[0].WorkflowID != workflowID || remote.requests[0].PageSize != 1 {
+		t.Fatalf("summary list requests = %+v, want exact one-row metadata request", remote.requests)
+	}
+	if remote.getWorkflowCalls != 0 {
+		t.Fatalf("summary GetWorkflow calls = %d, want metadata-only path", remote.getWorkflowCalls)
+	}
+}
+
+func TestWorkflowInspectSummaryRejectsMismatchedResponseScope(t *testing.T) {
+	const requestedWorkflowID = "workflow-" + workflowSelectorTestUUID
+	const otherWorkflowID = "workflow-8e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
+	projectID := "project-1"
+	for name, response := range map[string]serverapi.WorkflowListResponse{
+		"unexpected project scope": {
+			ProjectID: &projectID,
+			Workflows: []serverapi.WorkflowRecord{{
+				ID:          requestedWorkflowID,
+				ProjectLink: &serverapi.WorkflowListProjectLink{},
+			}},
+		},
+		"wrong workflow": {
+			Workflows: []serverapi.WorkflowRecord{{ID: otherWorkflowID}},
+		},
+		"multiple workflows": {
+			Workflows: []serverapi.WorkflowRecord{{ID: requestedWorkflowID}, {ID: otherWorkflowID}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			remote := &pagedWorkflowListRemote{pages: map[string]serverapi.WorkflowListResponse{"": response}}
+			restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: t.TempDir()}, remote)
+			defer restore()
+
+			stdout, _, code := runWorkflowRootCommand("workflow", "inspect", workflowSelectorTestUUID, "--summary")
+			if code != 1 || stdout != "" {
+				t.Fatalf("workflow inspect summary mismatch exit=%d stdout=%q", code, stdout)
+			}
+		})
 	}
 }
 
@@ -790,7 +1014,19 @@ func workflowCreateForTest(t *testing.T, args ...string) serverapi.WorkflowRecor
 	if err := json.Unmarshal([]byte(out), &record); err != nil {
 		t.Fatalf("decode workflow create json %q: %v", out, err)
 	}
+	if _, err := parseWorkflowSelector(record.ID); err != nil {
+		t.Fatalf("created workflow id %q: %v", record.ID, err)
+	}
 	return record
+}
+
+func workflowPersistedIDForTest(t *testing.T, selector string) string {
+	t.Helper()
+	parsed, err := parseWorkflowSelector(selector)
+	if err != nil {
+		t.Fatalf("workflow selector %q: %v", selector, err)
+	}
+	return parsed.PersistedID()
 }
 
 func workflowNodeAddForTest(t *testing.T, args ...string) workflowNodeOutput {
@@ -900,7 +1136,7 @@ func workflowTransitionGroupForID(def serverapi.WorkflowDefinition, groupID stri
 
 func workflowCommandStoredEdgeByID(t *testing.T, ctx context.Context, store *workflowstore.Store, workflowID string, edgeID string) workflow.Edge {
 	t.Helper()
-	def, _, err := store.GetDefinition(ctx, workflow.WorkflowID(workflowID))
+	def, _, err := store.GetDefinition(ctx, workflow.WorkflowID(workflowPersistedIDForTest(t, workflowID)))
 	if err != nil {
 		t.Fatalf("GetDefinition: %v", err)
 	}
@@ -919,6 +1155,7 @@ type pagedWorkflowListRemote struct {
 	pages               map[string]serverapi.WorkflowListResponse
 	requests            []serverapi.WorkflowListRequest
 	deadlines           []time.Time
+	getWorkflowCalls    int
 	delayAfterFirstPage bool
 }
 
@@ -937,24 +1174,11 @@ func (r *pagedWorkflowListRemote) ListWorkflows(ctx context.Context, req servera
 	if r.delayAfterFirstPage && callIndex == 0 {
 		time.Sleep(5 * time.Millisecond)
 	}
-	if strings.TrimSpace(req.ExactName) != "" {
-		matches := []serverapi.WorkflowRecord{}
-		for _, page := range r.pages {
-			for _, record := range page.Workflows {
-				if record.Name == req.ExactName {
-					matches = append(matches, record)
-				}
-			}
-		}
-		if len(matches) > req.PageSize {
-			return serverapi.WorkflowListResponse{Workflows: matches[:req.PageSize], NextPageToken: "more"}, nil
-		}
-		return serverapi.WorkflowListResponse{Workflows: matches}, nil
-	}
 	return r.pages[req.PageToken], nil
 }
 
 func (r *pagedWorkflowListRemote) GetWorkflow(ctx context.Context, req serverapi.WorkflowGetRequest) (serverapi.WorkflowGetResponse, error) {
+	r.getWorkflowCalls++
 	if deadline, ok := ctx.Deadline(); ok {
 		r.deadlines = append(r.deadlines, deadline)
 	}
@@ -963,6 +1187,10 @@ func (r *pagedWorkflowListRemote) GetWorkflow(ctx context.Context, req serverapi
 		return serverapi.WorkflowGetResponse{}, sql.ErrNoRows
 	}
 	return serverapi.WorkflowGetResponse{Definition: def}, nil
+}
+
+func (r *workflowCommandLoopbackRemote) ListRequests() []serverapi.WorkflowListRequest {
+	return append([]serverapi.WorkflowListRequest(nil), r.listRequests...)
 }
 
 type preservingNodeUpdateRemote struct {
@@ -982,10 +1210,10 @@ func (r *preservingNodeUpdateRemote) ListWorkflows(context.Context, serverapi.Wo
 
 func (r *preservingNodeUpdateRemote) GetWorkflow(context.Context, serverapi.WorkflowGetRequest) (serverapi.WorkflowGetResponse, error) {
 	return serverapi.WorkflowGetResponse{Definition: serverapi.WorkflowDefinition{
-		Workflow: serverapi.WorkflowRecord{ID: "workflow-1", Name: "Workflow"},
+		Workflow: serverapi.WorkflowRecord{ID: "workflow-" + workflowSelectorTestUUID, Name: "Workflow"},
 		Nodes: []serverapi.WorkflowNode{{
 			ID:          "node-join",
-			WorkflowID:  "workflow-1",
+			WorkflowID:  "workflow-" + workflowSelectorTestUUID,
 			Key:         "join",
 			Kind:        "join",
 			DisplayName: "Join",

--- a/cli/kent/workflow_projection.go
+++ b/cli/kent/workflow_projection.go
@@ -107,14 +107,14 @@ func workflowValidationForCLI(response serverapi.WorkflowValidateResponse) (serv
 func workflowValidationErrorsForCLI(errors []serverapi.WorkflowValidationError) ([]serverapi.WorkflowValidationError, error) {
 	projected := append([]serverapi.WorkflowValidationError(nil), errors...)
 	for i := range projected {
-		if projected[i].WorkflowID == "" {
+		if projected[i].WorkflowID == nil {
 			continue
 		}
-		workflowID, err := workflowIDForCLI(projected[i].WorkflowID)
+		workflowID, err := workflowIDForCLI(*projected[i].WorkflowID)
 		if err != nil {
 			return nil, err
 		}
-		projected[i].WorkflowID = workflowID
+		projected[i].WorkflowID = &workflowID
 	}
 	return projected, nil
 }
@@ -136,13 +136,15 @@ func workflowTaskDetailForCLI(detail serverapi.WorkflowTaskDetail) (serverapi.Wo
 	}
 	projected.Attention = append([]serverapi.WorkflowAttentionItem(nil), detail.Attention...)
 	for i := range projected.Attention {
-		if projected.Attention[i].WorkflowID == "" {
+		if projected.Attention[i].WorkflowID == nil {
 			continue
 		}
-		projected.Attention[i].WorkflowID, err = workflowIDForCLI(projected.Attention[i].WorkflowID)
+		workflowID, projectionErr := workflowIDForCLI(*projected.Attention[i].WorkflowID)
+		err = projectionErr
 		if err != nil {
 			return serverapi.WorkflowTaskDetail{}, err
 		}
+		projected.Attention[i].WorkflowID = &workflowID
 	}
 	return projected, nil
 }

--- a/cli/kent/workflow_projection.go
+++ b/cli/kent/workflow_projection.go
@@ -1,0 +1,148 @@
+package main
+
+import "core/shared/serverapi"
+
+func workflowRecordForCLI(record serverapi.WorkflowRecord) (serverapi.WorkflowRecord, error) {
+	selector, err := workflowSelectorFromPersistedID(record.ID)
+	if err != nil {
+		return serverapi.WorkflowRecord{}, err
+	}
+	projected := record
+	projected.ID = selector.String()
+	return projected, nil
+}
+
+func workflowRecordsForCLI(records []serverapi.WorkflowRecord) ([]serverapi.WorkflowRecord, error) {
+	projected := make([]serverapi.WorkflowRecord, len(records))
+	for i := range records {
+		record, err := workflowRecordForCLI(records[i])
+		if err != nil {
+			return nil, err
+		}
+		projected[i] = record
+	}
+	return projected, nil
+}
+
+func workflowTaskSummaryForCLI(summary serverapi.WorkflowTaskSummary) (serverapi.WorkflowTaskSummary, error) {
+	workflowID, err := workflowIDForCLI(summary.WorkflowID)
+	if err != nil {
+		return serverapi.WorkflowTaskSummary{}, err
+	}
+	projected := summary
+	projected.WorkflowID = workflowID
+	return projected, nil
+}
+
+func workflowDefinitionForCLI(definition serverapi.WorkflowDefinition) (serverapi.WorkflowDefinition, error) {
+	workflow, err := workflowRecordForCLI(definition.Workflow)
+	if err != nil {
+		return serverapi.WorkflowDefinition{}, err
+	}
+	projected := definition
+	projected.Workflow = workflow
+	projected.NodeGroups = append([]serverapi.WorkflowNodeGroup(nil), definition.NodeGroups...)
+	for i := range projected.NodeGroups {
+		projected.NodeGroups[i].WorkflowID, err = workflowIDForCLI(projected.NodeGroups[i].WorkflowID)
+		if err != nil {
+			return serverapi.WorkflowDefinition{}, err
+		}
+	}
+	projected.Nodes = append([]serverapi.WorkflowNode(nil), definition.Nodes...)
+	for i := range projected.Nodes {
+		projected.Nodes[i].WorkflowID, err = workflowIDForCLI(projected.Nodes[i].WorkflowID)
+		if err != nil {
+			return serverapi.WorkflowDefinition{}, err
+		}
+	}
+	projected.TransitionGroups = append([]serverapi.WorkflowTransitionGroup(nil), definition.TransitionGroups...)
+	for i := range projected.TransitionGroups {
+		projected.TransitionGroups[i].WorkflowID, err = workflowIDForCLI(projected.TransitionGroups[i].WorkflowID)
+		if err != nil {
+			return serverapi.WorkflowDefinition{}, err
+		}
+	}
+	projected.Edges = append([]serverapi.WorkflowEdge(nil), definition.Edges...)
+	for i := range projected.Edges {
+		projected.Edges[i].WorkflowID, err = workflowIDForCLI(projected.Edges[i].WorkflowID)
+		if err != nil {
+			return serverapi.WorkflowDefinition{}, err
+		}
+	}
+	projected.DerivedWiring.Diagnostics, err = workflowValidationErrorsForCLI(definition.DerivedWiring.Diagnostics)
+	if err != nil {
+		return serverapi.WorkflowDefinition{}, err
+	}
+	return projected, nil
+}
+
+func workflowIDForCLI(persistedID string) (string, error) {
+	selector, err := workflowSelectorFromPersistedID(persistedID)
+	if err != nil {
+		return "", err
+	}
+	return selector.String(), nil
+}
+
+func projectWorkflowLinkForCLI(link serverapi.ProjectWorkflowLink) (serverapi.ProjectWorkflowLink, error) {
+	workflowID, err := workflowIDForCLI(link.WorkflowID)
+	if err != nil {
+		return serverapi.ProjectWorkflowLink{}, err
+	}
+	projected := link
+	projected.WorkflowID = workflowID
+	return projected, nil
+}
+
+func workflowValidationForCLI(response serverapi.WorkflowValidateResponse) (serverapi.WorkflowValidateResponse, error) {
+	projected := response
+	errors, err := workflowValidationErrorsForCLI(response.Errors)
+	if err != nil {
+		return serverapi.WorkflowValidateResponse{}, err
+	}
+	projected.Errors = errors
+	return projected, nil
+}
+
+func workflowValidationErrorsForCLI(errors []serverapi.WorkflowValidationError) ([]serverapi.WorkflowValidationError, error) {
+	projected := append([]serverapi.WorkflowValidationError(nil), errors...)
+	for i := range projected {
+		if projected[i].WorkflowID == "" {
+			continue
+		}
+		workflowID, err := workflowIDForCLI(projected[i].WorkflowID)
+		if err != nil {
+			return nil, err
+		}
+		projected[i].WorkflowID = workflowID
+	}
+	return projected, nil
+}
+
+func workflowTaskDetailForCLI(detail serverapi.WorkflowTaskDetail) (serverapi.WorkflowTaskDetail, error) {
+	projected := detail
+	summary, err := workflowTaskSummaryForCLI(detail.Summary)
+	if err != nil {
+		return serverapi.WorkflowTaskDetail{}, err
+	}
+	projected.Summary = summary
+	projected.Workflow.WorkflowID, err = workflowIDForCLI(detail.Workflow.WorkflowID)
+	if err != nil {
+		return serverapi.WorkflowTaskDetail{}, err
+	}
+	projected.Workflow.ValidationErrors, err = workflowValidationErrorsForCLI(detail.Workflow.ValidationErrors)
+	if err != nil {
+		return serverapi.WorkflowTaskDetail{}, err
+	}
+	projected.Attention = append([]serverapi.WorkflowAttentionItem(nil), detail.Attention...)
+	for i := range projected.Attention {
+		if projected.Attention[i].WorkflowID == "" {
+			continue
+		}
+		projected.Attention[i].WorkflowID, err = workflowIDForCLI(projected.Attention[i].WorkflowID)
+		if err != nil {
+			return serverapi.WorkflowTaskDetail{}, err
+		}
+	}
+	return projected, nil
+}

--- a/cli/kent/workflow_selector.go
+++ b/cli/kent/workflow_selector.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"core/shared/runtimeids"
+
+	"github.com/google/uuid"
+)
+
+const persistedWorkflowIDPrefix = "workflow-"
+
+type workflowSelector struct {
+	value uuid.UUID
+}
+
+func parseWorkflowSelector(raw string) (workflowSelector, error) {
+	value, err := runtimeids.ParseCanonicalUUIDv4(raw, "workflow selector")
+	if err != nil {
+		return workflowSelector{}, err
+	}
+	return workflowSelector{value: value}, nil
+}
+
+func workflowSelectorFromPersistedID(raw string) (workflowSelector, error) {
+	value, err := runtimeids.ParseCanonicalPrefixedUUIDv4(raw, persistedWorkflowIDPrefix, "workflow id")
+	if err != nil {
+		return workflowSelector{}, err
+	}
+	return workflowSelector{value: value}, nil
+}
+
+func (s workflowSelector) String() string {
+	return s.value.String()
+}
+
+func (s workflowSelector) PersistedID() string {
+	return persistedWorkflowIDPrefix + s.String()
+}

--- a/cli/kent/workflow_selector_test.go
+++ b/cli/kent/workflow_selector_test.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"core/shared/apicontract"
+	"core/shared/config"
+	"core/shared/serverapi"
+)
+
+const workflowSelectorTestUUID = "7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
+
+func TestParseWorkflowSelectorConvertsCanonicalUUIDv4ToPersistedID(t *testing.T) {
+	selector, err := parseWorkflowSelector(workflowSelectorTestUUID)
+	if err != nil {
+		t.Fatalf("parseWorkflowSelector: %v", err)
+	}
+	if got := selector.PersistedID(); got != "workflow-"+workflowSelectorTestUUID {
+		t.Fatalf("PersistedID = %q, want workflow-prefixed selector", got)
+	}
+}
+
+func TestParseWorkflowSelectorRejectsEveryNonCanonicalPublicForm(t *testing.T) {
+	for _, raw := range []string{
+		"",
+		" ",
+		"workflow-" + workflowSelectorTestUUID,
+		"Workflow Name",
+		" " + workflowSelectorTestUUID,
+		workflowSelectorTestUUID + " ",
+		"7E8D24D2-8A98-4DCF-A197-6214DB1CB3C0",
+		"7e8d24d2-8a98-1dcf-a197-6214db1cb3c0",
+	} {
+		if _, err := parseWorkflowSelector(raw); err == nil {
+			t.Fatalf("parseWorkflowSelector(%q) succeeded", raw)
+		}
+	}
+}
+
+func TestWorkflowRecordForCLIProjectsBareIDWithoutMutatingServerRecord(t *testing.T) {
+	serverRecord := serverapi.WorkflowRecord{
+		ID:      "workflow-" + workflowSelectorTestUUID,
+		Name:    "Workflow",
+		Version: 3,
+	}
+	projected, err := workflowRecordForCLI(serverRecord)
+	if err != nil {
+		t.Fatalf("workflowRecordForCLI: %v", err)
+	}
+	if projected.ID != workflowSelectorTestUUID {
+		t.Fatalf("projected id = %q, want bare UUID", projected.ID)
+	}
+	if serverRecord.ID != "workflow-"+workflowSelectorTestUUID {
+		t.Fatalf("server record mutated to %q", serverRecord.ID)
+	}
+}
+
+func TestWorkflowRecordForCLIFailsMalformedPersistedID(t *testing.T) {
+	if _, err := workflowRecordForCLI(serverapi.WorkflowRecord{ID: workflowSelectorTestUUID}); err == nil {
+		t.Fatal("workflowRecordForCLI accepted a bare server workflow id")
+	}
+}
+
+func TestWorkflowDefinitionForCLIProjectsEveryWorkflowIdentity(t *testing.T) {
+	persistedID := "workflow-" + workflowSelectorTestUUID
+	serverDefinition := serverapi.WorkflowDefinition{
+		Workflow:         serverapi.WorkflowRecord{ID: persistedID},
+		NodeGroups:       []serverapi.WorkflowNodeGroup{{WorkflowID: persistedID}},
+		Nodes:            []serverapi.WorkflowNode{{WorkflowID: persistedID}},
+		TransitionGroups: []serverapi.WorkflowTransitionGroup{{WorkflowID: persistedID}},
+		Edges:            []serverapi.WorkflowEdge{{WorkflowID: persistedID}},
+		DerivedWiring: serverapi.WorkflowDerivedWiring{
+			Diagnostics: []serverapi.WorkflowValidationError{{WorkflowID: persistedID}},
+		},
+	}
+	projected, err := workflowDefinitionForCLI(serverDefinition)
+	if err != nil {
+		t.Fatalf("workflowDefinitionForCLI: %v", err)
+	}
+	for label, got := range map[string]string{
+		"record":           projected.Workflow.ID,
+		"node group":       projected.NodeGroups[0].WorkflowID,
+		"node":             projected.Nodes[0].WorkflowID,
+		"transition group": projected.TransitionGroups[0].WorkflowID,
+		"edge":             projected.Edges[0].WorkflowID,
+		"diagnostic":       projected.DerivedWiring.Diagnostics[0].WorkflowID,
+	} {
+		if got != workflowSelectorTestUUID {
+			t.Fatalf("%s workflow id = %q, want bare UUID", label, got)
+		}
+	}
+	if serverDefinition.Nodes[0].WorkflowID != persistedID {
+		t.Fatal("workflowDefinitionForCLI mutated server definition")
+	}
+}
+
+func TestProjectWorkflowLinkForCLIProjectsBareWorkflowID(t *testing.T) {
+	serverLink := serverapi.ProjectWorkflowLink{
+		ID:         "link-1",
+		ProjectID:  "project-1",
+		WorkflowID: "workflow-" + workflowSelectorTestUUID,
+		Default:    true,
+	}
+	projected, err := projectWorkflowLinkForCLI(serverLink)
+	if err != nil {
+		t.Fatalf("projectWorkflowLinkForCLI: %v", err)
+	}
+	if projected.WorkflowID != workflowSelectorTestUUID {
+		t.Fatalf("projected workflow id = %q, want bare UUID", projected.WorkflowID)
+	}
+	if serverLink.WorkflowID != "workflow-"+workflowSelectorTestUUID {
+		t.Fatal("projectWorkflowLinkForCLI mutated server link")
+	}
+}
+
+func TestWorkflowValidationForCLIProjectsWorkflowIDs(t *testing.T) {
+	persistedID := "workflow-" + workflowSelectorTestUUID
+	serverResponse := serverapi.WorkflowValidateResponse{
+		Errors: []serverapi.WorkflowValidationError{{WorkflowID: persistedID}},
+	}
+	projected, err := workflowValidationForCLI(serverResponse)
+	if err != nil {
+		t.Fatalf("workflowValidationForCLI: %v", err)
+	}
+	if projected.Errors[0].WorkflowID != workflowSelectorTestUUID {
+		t.Fatalf("projected workflow id = %q, want bare UUID", projected.Errors[0].WorkflowID)
+	}
+	if serverResponse.Errors[0].WorkflowID != persistedID {
+		t.Fatal("workflowValidationForCLI mutated server response")
+	}
+}
+
+func TestWorkflowTaskDetailForCLIProjectsSummaryPickerAndAttentionWorkflowIDs(t *testing.T) {
+	persistedID := "workflow-" + workflowSelectorTestUUID
+	serverDetail := serverapi.WorkflowTaskDetail{
+		Summary: serverapi.WorkflowTaskSummary{WorkflowID: persistedID},
+		Workflow: serverapi.WorkflowPickerItem{
+			WorkflowID:       persistedID,
+			ValidationErrors: []serverapi.WorkflowValidationError{{WorkflowID: persistedID}},
+		},
+		Attention: []serverapi.WorkflowAttentionItem{{WorkflowID: persistedID}},
+	}
+	projected, err := workflowTaskDetailForCLI(serverDetail)
+	if err != nil {
+		t.Fatalf("workflowTaskDetailForCLI: %v", err)
+	}
+	for label, got := range map[string]string{
+		"summary":    projected.Summary.WorkflowID,
+		"picker":     projected.Workflow.WorkflowID,
+		"validation": projected.Workflow.ValidationErrors[0].WorkflowID,
+		"attention":  projected.Attention[0].WorkflowID,
+	} {
+		if got != workflowSelectorTestUUID {
+			t.Fatalf("%s workflow id = %q, want bare UUID", label, got)
+		}
+	}
+	if serverDetail.Summary.WorkflowID != persistedID {
+		t.Fatal("workflowTaskDetailForCLI mutated server detail")
+	}
+}
+
+func TestTaskCreateRejectsInvalidWorkflowSelectorBeforeOpeningRemote(t *testing.T) {
+	called := false
+	original := workflowCommandRemoteOpener
+	workflowCommandRemoteOpener = func(context.Context, string) (config.App, workflowCommandRemote, error) {
+		called = true
+		return config.App{}, nil, nil
+	}
+	defer func() { workflowCommandRemoteOpener = original }()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := taskCreateSubcommand([]string{
+		"--project", "project-1",
+		"--workflow", "workflow-" + workflowSelectorTestUUID,
+		"--title", "Task",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("task create code=%d stderr=%q, want usage failure", code, stderr.String())
+	}
+	if called {
+		t.Fatal("task create opened remote for invalid workflow selector")
+	}
+}
+
+func TestWorkflowValidateConvertsSelectorBeforeRemoteCall(t *testing.T) {
+	remote := &selectorCapturingRemote{}
+	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: t.TempDir()}, remote)
+	defer restore()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := workflowValidateSubcommand([]string{workflowSelectorTestUUID}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("workflow validate code=%d stderr=%q", code, stderr.String())
+	}
+	if remote.validateCalls != 1 || remote.workflowID != "workflow-"+workflowSelectorTestUUID {
+		t.Fatalf("validate calls=%d workflowID=%q", remote.validateCalls, remote.workflowID)
+	}
+}
+
+func TestWorkflowCommandRejectsInvalidSelectorBeforeOpeningRemote(t *testing.T) {
+	called := false
+	original := workflowCommandRemoteOpener
+	workflowCommandRemoteOpener = func(context.Context, string) (config.App, workflowCommandRemote, error) {
+		called = true
+		return config.App{}, nil, nil
+	}
+	defer func() { workflowCommandRemoteOpener = original }()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := workflowValidateSubcommand([]string{"Workflow Name"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("workflow validate code=%d stderr=%q, want usage failure", code, stderr.String())
+	}
+	if called {
+		t.Fatal("workflow validate opened remote for invalid workflow selector")
+	}
+}
+
+func TestWorkflowListFailsMalformedServerWorkflowID(t *testing.T) {
+	remote := &pagedWorkflowListRemote{
+		pages: map[string]serverapi.WorkflowListResponse{
+			"": {Workflows: []serverapi.WorkflowRecord{{ID: "workflow-malformed"}}},
+		},
+	}
+	restore := replaceWorkflowCommandRemoteOpener(t, config.App{WorkspaceRoot: t.TempDir()}, remote)
+	defer restore()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := workflowListSubcommand([]string{"--json"}, &stdout, &stderr)
+	if code != 1 || stdout.Len() != 0 {
+		t.Fatalf("workflow list code=%d stdout=%q stderr=%q, want operator-visible projection failure", code, stdout.String(), stderr.String())
+	}
+}
+
+type selectorCapturingRemote struct {
+	apicontract.WorkflowService
+	validateCalls int
+	workflowID    string
+}
+
+func (r *selectorCapturingRemote) Close() error { return nil }
+
+func (r *selectorCapturingRemote) ResolveProjectPath(context.Context, serverapi.ProjectResolvePathRequest) (serverapi.ProjectResolvePathResponse, error) {
+	return serverapi.ProjectResolvePathResponse{}, nil
+}
+
+func (r *selectorCapturingRemote) ValidateWorkflow(_ context.Context, req serverapi.WorkflowValidateRequest) (serverapi.WorkflowValidateResponse, error) {
+	r.validateCalls++
+	r.workflowID = req.WorkflowID
+	return serverapi.WorkflowValidateResponse{Valid: true}, nil
+}

--- a/cli/kent/workflow_selector_test.go
+++ b/cli/kent/workflow_selector_test.go
@@ -72,12 +72,15 @@ func TestWorkflowDefinitionForCLIProjectsEveryWorkflowIdentity(t *testing.T) {
 		TransitionGroups: []serverapi.WorkflowTransitionGroup{{WorkflowID: persistedID}},
 		Edges:            []serverapi.WorkflowEdge{{WorkflowID: persistedID}},
 		DerivedWiring: serverapi.WorkflowDerivedWiring{
-			Diagnostics: []serverapi.WorkflowValidationError{{WorkflowID: persistedID}},
+			Diagnostics: []serverapi.WorkflowValidationError{{WorkflowID: &persistedID}},
 		},
 	}
 	projected, err := workflowDefinitionForCLI(serverDefinition)
 	if err != nil {
 		t.Fatalf("workflowDefinitionForCLI: %v", err)
+	}
+	if projected.DerivedWiring.Diagnostics[0].WorkflowID == nil {
+		t.Fatal("projected diagnostic workflow id is absent")
 	}
 	for label, got := range map[string]string{
 		"record":           projected.Workflow.ID,
@@ -85,7 +88,7 @@ func TestWorkflowDefinitionForCLIProjectsEveryWorkflowIdentity(t *testing.T) {
 		"node":             projected.Nodes[0].WorkflowID,
 		"transition group": projected.TransitionGroups[0].WorkflowID,
 		"edge":             projected.Edges[0].WorkflowID,
-		"diagnostic":       projected.DerivedWiring.Diagnostics[0].WorkflowID,
+		"diagnostic":       *projected.DerivedWiring.Diagnostics[0].WorkflowID,
 	} {
 		if got != workflowSelectorTestUUID {
 			t.Fatalf("%s workflow id = %q, want bare UUID", label, got)
@@ -118,17 +121,20 @@ func TestProjectWorkflowLinkForCLIProjectsBareWorkflowID(t *testing.T) {
 func TestWorkflowValidationForCLIProjectsWorkflowIDs(t *testing.T) {
 	persistedID := "workflow-" + workflowSelectorTestUUID
 	serverResponse := serverapi.WorkflowValidateResponse{
-		Errors: []serverapi.WorkflowValidationError{{WorkflowID: persistedID}},
+		Errors: []serverapi.WorkflowValidationError{{WorkflowID: &persistedID}, {}},
 	}
 	projected, err := workflowValidationForCLI(serverResponse)
 	if err != nil {
 		t.Fatalf("workflowValidationForCLI: %v", err)
 	}
-	if projected.Errors[0].WorkflowID != workflowSelectorTestUUID {
-		t.Fatalf("projected workflow id = %q, want bare UUID", projected.Errors[0].WorkflowID)
+	if projected.Errors[0].WorkflowID == nil || *projected.Errors[0].WorkflowID != workflowSelectorTestUUID {
+		t.Fatalf("projected workflow id = %v, want bare UUID", projected.Errors[0].WorkflowID)
 	}
-	if serverResponse.Errors[0].WorkflowID != persistedID {
+	if serverResponse.Errors[0].WorkflowID == nil || *serverResponse.Errors[0].WorkflowID != persistedID {
 		t.Fatal("workflowValidationForCLI mutated server response")
+	}
+	if projected.Errors[1].WorkflowID != nil {
+		t.Fatalf("absent projected workflow id = %v, want nil", projected.Errors[1].WorkflowID)
 	}
 }
 
@@ -138,19 +144,22 @@ func TestWorkflowTaskDetailForCLIProjectsSummaryPickerAndAttentionWorkflowIDs(t 
 		Summary: serverapi.WorkflowTaskSummary{WorkflowID: persistedID},
 		Workflow: serverapi.WorkflowPickerItem{
 			WorkflowID:       persistedID,
-			ValidationErrors: []serverapi.WorkflowValidationError{{WorkflowID: persistedID}},
+			ValidationErrors: []serverapi.WorkflowValidationError{{WorkflowID: &persistedID}, {}},
 		},
-		Attention: []serverapi.WorkflowAttentionItem{{WorkflowID: persistedID}},
+		Attention: []serverapi.WorkflowAttentionItem{{WorkflowID: &persistedID}, {}},
 	}
 	projected, err := workflowTaskDetailForCLI(serverDetail)
 	if err != nil {
 		t.Fatalf("workflowTaskDetailForCLI: %v", err)
 	}
+	if projected.Workflow.ValidationErrors[0].WorkflowID == nil || projected.Attention[0].WorkflowID == nil {
+		t.Fatal("projected optional workflow identity is absent")
+	}
 	for label, got := range map[string]string{
 		"summary":    projected.Summary.WorkflowID,
 		"picker":     projected.Workflow.WorkflowID,
-		"validation": projected.Workflow.ValidationErrors[0].WorkflowID,
-		"attention":  projected.Attention[0].WorkflowID,
+		"validation": *projected.Workflow.ValidationErrors[0].WorkflowID,
+		"attention":  *projected.Attention[0].WorkflowID,
 	} {
 		if got != workflowSelectorTestUUID {
 			t.Fatalf("%s workflow id = %q, want bare UUID", label, got)
@@ -158,6 +167,25 @@ func TestWorkflowTaskDetailForCLIProjectsSummaryPickerAndAttentionWorkflowIDs(t 
 	}
 	if serverDetail.Summary.WorkflowID != persistedID {
 		t.Fatal("workflowTaskDetailForCLI mutated server detail")
+	}
+	if projected.Workflow.ValidationErrors[1].WorkflowID != nil || projected.Attention[1].WorkflowID != nil {
+		t.Fatal("absent optional workflow identities became present")
+	}
+}
+
+func TestWorkflowProjectionRejectsPresentBlankOptionalWorkflowIdentity(t *testing.T) {
+	blank := ""
+	if _, err := workflowValidationForCLI(serverapi.WorkflowValidateResponse{
+		Errors: []serverapi.WorkflowValidationError{{WorkflowID: &blank}},
+	}); err == nil {
+		t.Fatal("workflowValidationForCLI accepted a present blank workflow identity")
+	}
+	if _, err := workflowTaskDetailForCLI(serverapi.WorkflowTaskDetail{
+		Summary:   serverapi.WorkflowTaskSummary{WorkflowID: "workflow-" + workflowSelectorTestUUID},
+		Workflow:  serverapi.WorkflowPickerItem{WorkflowID: "workflow-" + workflowSelectorTestUUID},
+		Attention: []serverapi.WorkflowAttentionItem{{WorkflowID: &blank}},
+	}); err == nil {
+		t.Fatal("workflowTaskDetailForCLI accepted a present blank attention workflow identity")
 	}
 }
 

--- a/cli/tui/transcript_row_equal.go
+++ b/cli/tui/transcript_row_equal.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"core/shared/clientui"
+	"core/shared/textutil"
 	"core/shared/transcript"
 )
 
@@ -22,8 +23,8 @@ func transcriptUserRowEqual(left, right *clientui.TranscriptUserRow) bool {
 		return left == right
 	}
 	return left.Text == right.Text &&
-		pointersEqual(left.CondensedText, right.CondensedText) &&
-		pointersEqual(left.RollbackTargetID, right.RollbackTargetID)
+		textutil.EqualOptional(left.CondensedText, right.CondensedText) &&
+		textutil.EqualOptional(left.RollbackTargetID, right.RollbackTargetID)
 }
 
 func transcriptAssistantRowEqual(left, right *clientui.TranscriptAssistantRow) bool {
@@ -31,9 +32,9 @@ func transcriptAssistantRowEqual(left, right *clientui.TranscriptAssistantRow) b
 		return left == right
 	}
 	return left.Text == right.Text &&
-		pointersEqual(left.CondensedText, right.CondensedText) &&
+		textutil.EqualOptional(left.CondensedText, right.CondensedText) &&
 		left.Phase == right.Phase &&
-		pointersEqual(left.StreamID, right.StreamID)
+		textutil.EqualOptional(left.StreamID, right.StreamID)
 }
 
 func transcriptToolRowEqual(left, right *clientui.TranscriptToolRow) bool {
@@ -44,8 +45,8 @@ func transcriptToolRowEqual(left, right *clientui.TranscriptToolRow) bool {
 		left.ToolName == right.ToolName &&
 		left.Text == right.Text &&
 		left.IsError == right.IsError &&
-		pointersEqual(left.ResultSummary, right.ResultSummary) &&
-		pointersEqual(left.CondensedText, right.CondensedText) &&
+		textutil.EqualOptional(left.ResultSummary, right.ResultSummary) &&
+		textutil.EqualOptional(left.CondensedText, right.CondensedText) &&
 		transcript.ToolCallMetaEqual(
 			left.Presentation,
 			right.Presentation,
@@ -58,32 +59,25 @@ func transcriptNoticeRowEqual(left, right *clientui.TranscriptNoticeRow) bool {
 	}
 	return left.Reason == right.Reason &&
 		left.Severity == right.Severity &&
-		pointersEqual(left.StepID, right.StepID) &&
-		pointersEqual(left.MessageType, right.MessageType) &&
-		pointersEqual(left.LegacyText, right.LegacyText) &&
-		pointersEqual(left.NoticeID, right.NoticeID) &&
-		pointersEqual(left.SourcePath, right.SourcePath) &&
+		textutil.EqualOptional(left.StepID, right.StepID) &&
+		textutil.EqualOptional(left.MessageType, right.MessageType) &&
+		textutil.EqualOptional(left.LegacyText, right.LegacyText) &&
+		textutil.EqualOptional(left.NoticeID, right.NoticeID) &&
+		textutil.EqualOptional(left.SourcePath, right.SourcePath) &&
 		transcriptWorktreeContextEqual(left.Worktree, right.Worktree) &&
-		pointersEqual(left.CacheWarning, right.CacheWarning) &&
-		pointersEqual(left.Diagnostic, right.Diagnostic) &&
-		pointersEqual(left.Background, right.Background) &&
-		pointersEqual(left.CondensedText, right.CondensedText) &&
-		pointersEqual(left.CompactLabel, right.CompactLabel)
+		textutil.EqualOptional(left.CacheWarning, right.CacheWarning) &&
+		textutil.EqualOptional(left.Diagnostic, right.Diagnostic) &&
+		textutil.EqualOptional(left.Background, right.Background) &&
+		textutil.EqualOptional(left.CondensedText, right.CondensedText) &&
+		textutil.EqualOptional(left.CompactLabel, right.CompactLabel)
 }
 
 func transcriptWorktreeContextEqual(left, right *clientui.TranscriptWorktreeContext) bool {
 	if left == nil || right == nil {
 		return left == right
 	}
-	return pointersEqual(left.Branch, right.Branch) &&
+	return textutil.EqualOptional(left.Branch, right.Branch) &&
 		left.WorktreePath == right.WorktreePath &&
 		left.WorkspaceRoot == right.WorkspaceRoot &&
 		left.EffectiveCwd == right.EffectiveCwd
-}
-
-func pointersEqual[T comparable](left, right *T) bool {
-	if left == nil || right == nil {
-		return left == right
-	}
-	return *left == *right
 }

--- a/docs/dev/specs/workflow-orchestration.md
+++ b/docs/dev/specs/workflow-orchestration.md
@@ -43,6 +43,21 @@
 - Tasks, runs, transitions, approvals, and edge snapshots store observed workflow version where historical traceability is required.
 - Run-start snapshots and transition/approval/fan-out edge snapshots keep using their snapshot unless a node-specific runtime contract says otherwise. Script nodes live-load their current `script_path` and completion contract from the workflow graph when the run executes/completes.
 
+## CLI Workflow Selection And Discovery
+
+- CLI workflow selectors are bare canonical UUIDv4 values. Workflow display names and prefixed persistence identifiers are not selectors.
+- Every CLI command that accepts a workflow selector uses one shared parser and emits copyable bare UUIDs in human and JSON output. This CLI boundary does not change persisted or server-facing workflow identifiers.
+- Long flags are rendered with double dashes in help, examples, and Kent-authored diagnostics. Single-dash long flags remain accepted for compatibility; standard-library parser failures retain their native formatting.
+- `kent workflow list` is paginated. `--project <path-or-id>` filters the existing workflow list to workflows linked to the resolved project.
+- Project-filtered workflow discovery is served by one paginated database query. It does not load or validate workflow graphs.
+- Project-filtered workflow results are ordered with the project default first, then by project-local task activity, then by workflow name.
+- Project-filtered human results preserve the global one-line format and append default/link status plus execution-target policy. JSON includes the resolved project ID once and adds only the default-link fact to each workflow record.
+- `kent workflow inspect <uuid> --summary` returns only global workflow metadata: name, bare UUID, description, version, and execution-target policy. It does not accept project context; full inspect retains the workflow graph.
+- `kent task show` does not accept a workflow selector. It reports the selected task's actual workflow with a bare UUID.
+- Task creation without an explicit workflow uses the project default. If no default exists and exactly one workflow is linked, Kent uses that workflow.
+- Task creation with no linked workflows explains that a workflow must be created or linked before retrying.
+- Task creation with several linked workflows and no default does not enumerate candidates. It directs the operator to paginated project workflow discovery, an explicit `--workflow <uuid>` retry, or default selection.
+
 ## Nodes, Edges, And Validation
 
 - Nodes configure workflow states and executable behavior. Agent nodes configure subagent role, completion mode, and worktree/session execution policy. Script nodes configure an executable script path.
@@ -210,10 +225,18 @@
 - The status projection preserves all applicable typed attention kinds and run references even when parallel branches have different conditions.
 - Workflow validity is workflow-level state and is not a task status.
 - Task lists expose typed task status and attention filters. They do not expose a separate coarse run status.
-- CLI `--status` filters typed task status, `--column` filters workflow node keys, and `--attention` filters attention kinds.
-- Either project or workflow task-list scope may be inferred only when exactly one active link is possible. Zero links return a typed not-linked error; multiple links return a typed ambiguity error with the available choices.
-- Explicit workflow selectors are workflow UUIDs. When both project and workflow are supplied, Kent validates their active link.
-- Task-list status sorting follows primary typed-status precedence; column sorting follows workflow column position.
+- Task lists are project-scoped. The CLI defaults to the project attached to the current workspace, including when `--workflow` is supplied.
+- A project-only task list spans every workflow linked to that project. An explicit workflow selector narrows the list and must identify an active link in that project.
+- CLI `--status` filters typed task status and `--attention` filters attention kinds across project-wide results. Created, updated, status, run-count, and title sorting are also workflow-neutral.
+- `--column` and column sorting require an explicit workflow because node keys and column positions are workflow-relative.
+- Project-wide human task rows omit column output, and project-wide JSON task items omit `column_keys`. Workflow-narrowed lists retain board-ordered column output.
+- The first project-wide task-list page derives a filtered matching-workflow cardinality of none, one, or multiple and freezes that first-page display decision in continuation tokens. Task membership remains live, so concurrent mutations may make workflow-name visibility stale on later pages.
+- Human task-list rows include workflow names only when the filtered query can return tasks from multiple workflows. JSON task items always include their bare workflow UUID.
+- A project with no linked workflows, an explicitly selected workflow that is not linked to the project, and workflow-relative operations without a workflow selector return distinct typed actionable errors.
+- No-linked-workflow recovery directs the operator to create and link a workflow or list and link an existing workflow before retrying.
+- Explicit not-linked recovery offers project workflow discovery and retry with a linked workflow, or linking the selected workflow to the project.
+- Workflow-relative column recovery offers project workflow discovery and a task-list retry with an explicit workflow while preserving the parsed filters.
+- Task-list status sorting follows primary typed-status precedence; workflow-narrowed column sorting follows workflow column position.
 
 ## Execution Targets And Worktrees
 

--- a/docs/src/content/docs/workflows.md
+++ b/docs/src/content/docs/workflows.md
@@ -270,6 +270,30 @@ Choose the source workspace before starting automation. Agents run in the enviro
 
 ![Kent Desktop task board and task detail view showing task actions, comments, and a pending question.](/desktop/desktop-workflow-tasks.webp)
 
+### CLI Workflow And Task Scope
+
+CLI workflow selectors are bare canonical UUIDv4 values. Copy them from `kent workflow list` or `kent workflow inspect --summary`; workflow names and persisted `workflow-...` IDs are not selectors.
+
+```bash
+kent workflow list --project .
+workflow_uuid="<uuid-from-workflow-list>"
+kent workflow inspect "$workflow_uuid" --summary
+```
+
+Project-filtered workflow listing returns the default first, followed by project activity and name. Task creation uses an explicit linked `--workflow` when supplied, otherwise the project default, or the lone linked workflow when no default exists. Several links without a default require an explicit selector.
+
+```bash
+kent task create --project . --title "Fix flaky tests" --body "Investigate and repair the failure."
+kent task create --project . --workflow "$workflow_uuid" --title "Fix flaky tests" --body "Investigate and repair the failure."
+```
+
+Task listing is always project-scoped. Omitting `--workflow` lists tasks across every workflow linked to the project; supplying it narrows the result. Project-wide rows omit workflow columns. `--column` and `--sort column` require explicit workflow narrowing.
+
+```bash
+kent task list --project .
+kent task list --project . --workflow "$workflow_uuid" --column review
+```
+
 ### Choose The Execution Target
 
 The workflow's execution-target policy chooses where executable agent and script nodes run:

--- a/prompts/skills/kent-tasks/SKILL.md
+++ b/prompts/skills/kent-tasks/SKILL.md
@@ -32,15 +32,19 @@ Authoritative command details are always the live CLI:
 kent task --help
 ```
 
-Args marked with `[]` are optional and will attempt to auto-resolve - current cwd's project, default workflow for that project, current session ID.
+Args marked with `[]` are optional and attempt to resolve the current directory's project, that project's task workflow, or the current session ID as appropriate.
 
 Create task records against a linked/default workflow and project, then inspect them:
 
 ```bash
-kent task create [--project "path or id"] [--workflow "id"] --title "Fix flaky workflow tests" --body ".md content"
-kent task list [--project]
+kent workflow list --project .
+kent task create --project . [--workflow "<uuid>"] --title "Fix flaky workflow tests" --body ".md content"
+kent task list --project .
+kent task list --project . --workflow "<uuid>"
 kent task show <short-id-or-task-id>
 ```
+
+Workflow selectors are bare canonical UUIDv4 values copied from CLI workflow output. Names and `workflow-...` persistence IDs are not accepted. Task creation uses the project default when present, otherwise a lone linked workflow; several links without a default require `--workflow`. Project-only task listing spans every linked workflow. Column filters and `--sort column` require explicit workflow narrowing.
 
 ## Execution targets
 `kent task show` always reports the source workspace. After target lock it also reports the target mode and execution root; managed targets include requested revision, resolved commit, current named branch when available, and managed worktree.

--- a/prompts/skills/kent-workflows/SKILL.md
+++ b/prompts/skills/kent-workflows/SKILL.md
@@ -26,17 +26,19 @@ The CLI authoring path is: create a workflow, add or update nodes, add or update
 
 ```bash
 kent workflow create --description "Implement and review changes" "Implementation Review"
-kent workflow inspect "Implementation Review"
+kent workflow list
+workflow_uuid="<uuid-from-workflow-list>"
+kent workflow inspect "$workflow_uuid"
 
-kent workflow node add "Implementation Review" --key implement --kind agent --agent <implementer-role>
-kent workflow node add "Implementation Review" --key review --kind agent --agent <reviewer-role>
+kent workflow node add "$workflow_uuid" --key implement --kind agent --agent <implementer-role>
+kent workflow node add "$workflow_uuid" --key review --kind agent --agent <reviewer-role>
 
-kent workflow edge add "Implementation Review" --from backlog --transition start --edge-key start --to implement --context new_session --prompt "Implement the task."
-kent workflow edge add "Implementation Review" --from implement --transition review --edge-key review --to review --context new_session --prompt "Review the implementation."
-kent workflow edge add "Implementation Review" --from review --transition done --edge-key done --to done --context new_session
+kent workflow edge add "$workflow_uuid" --from backlog --transition start --edge-key start --to implement --context new_session --prompt "Implement the task."
+kent workflow edge add "$workflow_uuid" --from implement --transition review --edge-key review --to review --context new_session --prompt "Review the implementation."
+kent workflow edge add "$workflow_uuid" --from review --transition done --edge-key done --to done --context new_session
 
-kent workflow link . "Implementation Review" --default
-kent workflow validate "Implementation Review" --mode execution
+kent workflow link . "$workflow_uuid" --default
+kent workflow validate "$workflow_uuid" --mode execution
 ```
 
 For validation modes, use `draft` while authoring, `task_creation` before creating tasks, and `execution` for final handoff to the user. Draft workflows can be saved and linked while semantic validation fails. Validate before task creation as a best practice.
@@ -46,7 +48,8 @@ To understand what `--agent` roles are available (the reminder in your memory mi
 Important CLI behavior:
 - Every `workflow` command supports verbose `--json` for scripting, automation, and richer technical context.
 - `workflow create` auto-creates the initial backlog/start and done/terminal shape; inspect after create before adding duplicate start or terminal nodes.
-- Workflow references can be exact workflow IDs or exact workflow names. Prefer IDs in scripts and exact names in interactive work.
+- Workflow selectors use bare canonical UUIDv4 values emitted by the CLI. Names and `workflow-...` persistence IDs are rejected.
+- `workflow list --project <path-or-id>` discovers linked workflows with the default first. `workflow inspect <uuid> --summary` reads metadata without loading the graph.
 - Agent-targeting edges require `--prompt <text>`. Omit `--prompt` for edges targeting `start`, `join`, or `terminal` nodes, as there's nobody to prompt.
 - Script nodes use `--kind script --script-path <path>` and can appear anywhere an agent node can appear. Absolute paths resolve on the Kent server; relative paths resolve against the task managed worktree when the script runs.
 - Link, unlink, and set project defaults with `kent workflow link`, `kent workflow unlink`, and `kent workflow default`. This sets up bindings between a project (repo, workspace) and a workflow, and enables sharing of workflows.
@@ -58,8 +61,8 @@ Important CLI behavior:
 Use a script node when a workflow step should run a deterministic executable on the Kent server instead of starting an agent session. This saves tokens and eliminates the non-deterministic aspect of LLMs.
 
 ```bash
-kent workflow node add "Implementation Review" --key release_notes --kind script --script-path scripts/release-notes
-kent workflow edge add "Implementation Review" --from implement --transition release_notes --edge-key release_notes --to release_notes --context new_session
+kent workflow node add "$workflow_uuid" --key release_notes --kind script --script-path scripts/release-notes
+kent workflow edge add "$workflow_uuid" --from implement --transition release_notes --edge-key release_notes --to release_notes --context new_session
 ```
 
 Kent executes the script directly, without a shell wrapper. Stdin is one JSON object: incoming workflow parameter values are top-level properties, and `_kent` contains runtime identifiers such as `run_id` and `placement_id`. Prefer placing scripts in the repository main workspace (checked into VCS or not depends on user choice) for workflows that are tailored to a project, and at `~/.kent/scripts` or similar generic directory for reusable workflows, unless the user gives guidance.
@@ -82,8 +85,8 @@ Execution validation and task start require the selected script path to exist on
 Use the edge/node CRUD commands to manage the workflow:
 
 ```sh
-kent workflow node update "Implementation Review" implement --agent <implementer-role>
-kent workflow edge update "Implementation Review" edge-abc123 --transition needs_review --transition-display-name "Needs Review" --edge-key review --to review --context compact_and_continue_session --prompt "Review the implementation."
+kent workflow node update "$workflow_uuid" implement --agent <implementer-role>
+kent workflow edge update "$workflow_uuid" edge-abc123 --transition needs_review --transition-display-name "Needs Review" --edge-key review --to review --context compact_and_continue_session --prompt "Review the implementation."
 ```
 
 Node update flags are partial: omitted scalar fields keep current values. Edge update flags are partial; provided `--prompt` replaces the branch prompt. Validate the workflow with `kent workflow validate` each meaningful graph change.
@@ -109,11 +112,11 @@ Continuation modes also have a context source. Use `--context-source <source>` o
 Examples:
 
 ```bash
-kent workflow edge update "Implementation Review" edge-review \
+kent workflow edge update "$workflow_uuid" edge-review \
   --context continue_session \
   --context-source previous_target_or_new
 
-kent workflow edge update "Implementation Review" edge-rework \
+kent workflow edge update "$workflow_uuid" edge-rework \
   --context compact_and_continue_session \
   --context-source previous_target
 ```
@@ -144,7 +147,7 @@ Set it per node with `--completion-mode <mode>` on `node add` or `node update`. 
 The transition prompt is the task the target agent runs; parameters are the typed outputs the source agent must produce to carry context across the edge.
 
 ```bash
-kent workflow edge update "Implementation Review" edge-abc123 \
+kent workflow edge update "$workflow_uuid" edge-abc123 \
   --transition-description "Implementation is complete; send for review." \
   --param "plan_file_path=Path to the plan document the implementer followed." \
   --prompt "Review the changes against the plan at {{.Params.plan_file_path}}."

--- a/server/core/composition.go
+++ b/server/core/composition.go
@@ -399,10 +399,13 @@ func (p workflowApprovalProjection) ApprovalProjection(ctx context.Context, tran
 		if strings.TrimSpace(item.RunID) == "" || strings.TrimSpace(item.SessionID) == "" {
 			break
 		}
+		if item.WorkflowID == nil {
+			break
+		}
 		return workflowattention.ApprovalProjection{
 			TransitionID:     transitionID,
 			ProjectID:        item.ProjectID,
-			WorkflowID:       item.WorkflowID,
+			WorkflowID:       *item.WorkflowID,
 			TaskID:           workflow.TaskID(item.TaskID),
 			TaskShortID:      item.TaskShortID,
 			TaskTitle:        item.TaskTitle,
@@ -470,9 +473,12 @@ func (p workflowApprovalProjection) interruptedRunAttentionProjection(ctx contex
 		if item.Kind != "interrupted_run" || item.RunID != string(run.ID) {
 			continue
 		}
+		if item.WorkflowID == nil {
+			continue
+		}
 		return workflowattention.InterruptedRunProjection{
 			ProjectID:        item.ProjectID,
-			WorkflowID:       item.WorkflowID,
+			WorkflowID:       *item.WorkflowID,
 			TaskID:           workflow.TaskID(item.TaskID),
 			TaskShortID:      item.TaskShortID,
 			TaskTitle:        item.TaskTitle,

--- a/server/core/composition_test.go
+++ b/server/core/composition_test.go
@@ -124,9 +124,10 @@ func TestComposedWorkflowTaskSetupPrecedesFirstModelRequest(t *testing.T) {
 	if _, err := workflowStore.LinkWorkflow(ctx, project.Binding.ProjectID, workflowID, true); err != nil {
 		t.Fatalf("LinkWorkflow: %v", err)
 	}
+	persistedWorkflowID := string(workflowID)
 	task, err := appCore.WorkflowClient().CreateWorkflowTask(ctx, serverapi.WorkflowTaskCreateRequest{
 		ProjectID:         project.Binding.ProjectID,
-		WorkflowID:        string(workflowID),
+		WorkflowID:        &persistedWorkflowID,
 		Title:             "Provision task worktree",
 		SourceWorkspaceID: project.Binding.WorkspaceID,
 	})

--- a/server/launch/planner.go
+++ b/server/launch/planner.go
@@ -19,6 +19,7 @@ import (
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
 	"core/shared/sessioncontract"
+	"core/shared/textutil"
 	"core/shared/toolspec"
 )
 
@@ -625,10 +626,10 @@ func applyPreparedRunPromptOverridesWithBudgetApplier(plan SessionPlan, override
 	if roleOverride.Present && !roleOverride.Default {
 		requestedContinuationRole = cloneContinuationRole(&roleOverride.Role)
 	}
-	if roleOverride.Present && plan.ModelContractLocked && !sameContinuationRole(continuationAgentRole, requestedContinuationRole) && !options.AllowLockedAgentRoleChange {
+	if roleOverride.Present && plan.ModelContractLocked && !textutil.EqualOptional(continuationAgentRole, requestedContinuationRole) && !options.AllowLockedAgentRoleChange {
 		return SessionPlan{}, nil, fmt.Errorf("%w: current=%q requested=%q", ErrLockedAgentRoleChange, continuationRoleDisplay(continuationAgentRole), roleOverride.Role)
 	}
-	if roleOverride.Present && plan.ModelContractLocked && !sameContinuationRole(continuationAgentRole, requestedContinuationRole) && options.AllowLockedAgentRoleChange {
+	if roleOverride.Present && plan.ModelContractLocked && !textutil.EqualOptional(continuationAgentRole, requestedContinuationRole) && options.AllowLockedAgentRoleChange {
 		staleLockedPromptFacingContract = true
 	}
 	if roleOverride.Present {
@@ -749,13 +750,6 @@ func cloneContinuationRole(role *string) *string {
 	}
 	copyRole := *role
 	return &copyRole
-}
-
-func sameContinuationRole(left, right *string) bool {
-	if left == nil || right == nil {
-		return left == nil && right == nil
-	}
-	return *left == *right
 }
 
 func validateRunPromptOverrideSettings(settings config.Settings, source config.SourceReport) (config.Settings, error) {

--- a/server/launch/planner_test.go
+++ b/server/launch/planner_test.go
@@ -10,6 +10,7 @@ import (
 	"core/shared/config"
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
+	"core/shared/textutil"
 	"core/shared/toolspec"
 	"database/sql"
 	"encoding/json"
@@ -141,7 +142,7 @@ func TestPlannerReappliesPersistedSubagentRoleSettingsOnResume(t *testing.T) {
 	if plan.Source.Sources["thinking_level"] != "subagent" || plan.Source.Sources["tools.patch"] != "subagent" {
 		t.Fatalf("source report did not mark role overrides as subagent: %+v", plan.Source.Sources)
 	}
-	if got := plan.Store.Meta().Continuation; got == nil || !sessiontest.SameAgentRole(got.AgentRole, sessiontest.AgentRole("smart_reviewer")) {
+	if got := plan.Store.Meta().Continuation; got == nil || !textutil.EqualOptional(got.AgentRole, sessiontest.AgentRole("smart_reviewer")) {
 		t.Fatalf("continuation = %+v, want smart_reviewer preserved", got)
 	}
 }
@@ -212,7 +213,7 @@ func TestPlannerIgnoresMissingPersistedSubagentRoleOnResume(t *testing.T) {
 	if plan.ActiveSettings.ThinkingLevel != "medium" {
 		t.Fatalf("thinking level = %q, want base config when role is missing", plan.ActiveSettings.ThinkingLevel)
 	}
-	if got := plan.Store.Meta().Continuation; got == nil || !sessiontest.SameAgentRole(got.AgentRole, sessiontest.AgentRole("deleted_role")) {
+	if got := plan.Store.Meta().Continuation; got == nil || !textutil.EqualOptional(got.AgentRole, sessiontest.AgentRole("deleted_role")) {
 		t.Fatalf("continuation = %+v, want missing role preserved", got)
 	}
 }
@@ -318,7 +319,7 @@ func TestApplyRunPromptOverridesDefaultCannotClearLockedRoleAfterSkippingPersist
 	if !errors.Is(err, ErrLockedAgentRoleChange) {
 		t.Fatalf("default locked-role clear error = %v, want %v", err, ErrLockedAgentRoleChange)
 	}
-	if got := plan.Store.Meta().Continuation; got == nil || !sessiontest.SameAgentRole(got.AgentRole, sessiontest.AgentRole("worker")) {
+	if got := plan.Store.Meta().Continuation; got == nil || !textutil.EqualOptional(got.AgentRole, sessiontest.AgentRole("worker")) {
 		t.Fatalf("locked continuation changed after rejected clear: %+v", got)
 	}
 }
@@ -379,7 +380,7 @@ func TestApplyRunPromptOverridesAllowsSameAgentRoleForLockedSession(t *testing.T
 		EnabledTools: []string{"shell"},
 	})
 	updated := applyRunPromptOverridesNoWarnings(t, plan, serverapi.RunPromptOverrides{AgentRole: launchTestStringPtr("worker")}, auth.EmptyState())
-	if got := updated.Store.Meta().Continuation; got == nil || !sessiontest.SameAgentRole(got.AgentRole, sessiontest.AgentRole("worker")) {
+	if got := updated.Store.Meta().Continuation; got == nil || !textutil.EqualOptional(got.AgentRole, sessiontest.AgentRole("worker")) {
 		t.Fatalf("continuation = %+v, want worker", got)
 	}
 	if updated.ActiveSettings.Model != "locked-model" {
@@ -414,7 +415,7 @@ func TestApplyRunPromptOverridesOptionAllowsAgentRoleChangeForLockedSession(t *t
 	if err != nil {
 		t.Fatalf("ApplyRunPromptOverridesWithOptions: %v", err)
 	}
-	if got := updated.Store.Meta().Continuation; got == nil || !sessiontest.SameAgentRole(got.AgentRole, sessiontest.AgentRole("worker")) {
+	if got := updated.Store.Meta().Continuation; got == nil || !textutil.EqualOptional(got.AgentRole, sessiontest.AgentRole("worker")) {
 		t.Fatalf("continuation = %+v, want worker", got)
 	}
 	if updated.ActiveSettings.Model != "locked-model" {
@@ -680,7 +681,7 @@ func TestPlannerHeadlessChildWithRoleUsesFreshSystemPromptSnapshot(t *testing.T)
 	if len(updated.ActiveSettings.SystemPromptFiles) != 1 || updated.ActiveSettings.SystemPromptFiles[0].Path != rolePrompt {
 		t.Fatalf("active system prompt files = %+v, want role prompt %q", updated.ActiveSettings.SystemPromptFiles, rolePrompt)
 	}
-	if got := updated.Store.Meta().Continuation; got == nil || !sessiontest.SameAgentRole(got.AgentRole, sessiontest.AgentRole("code_review")) {
+	if got := updated.Store.Meta().Continuation; got == nil || !textutil.EqualOptional(got.AgentRole, sessiontest.AgentRole("code_review")) {
 		t.Fatalf("child continuation = %+v, want only selected role persisted", got)
 	}
 }
@@ -1385,7 +1386,7 @@ func TestApplyRunPromptOverridesRoleOnlyOverridePersistsContinuation(t *testing.
 		t.Fatalf("openai base url = %q, want worker override", updated.ActiveSettings.OpenAIBaseURL)
 	}
 	got := plan.Store.Meta().Continuation
-	if got == nil || got.OpenAIBaseURL != "https://worker.example/v1" || !sessiontest.SameAgentRole(got.AgentRole, sessiontest.AgentRole("worker")) {
+	if got == nil || got.OpenAIBaseURL != "https://worker.example/v1" || !textutil.EqualOptional(got.AgentRole, sessiontest.AgentRole("worker")) {
 		t.Fatalf("continuation = %+v, want worker base url and agent role", got)
 	}
 }

--- a/server/metadata/queries.sql
+++ b/server/metadata/queries.sql
@@ -214,6 +214,7 @@ SELECT
               AND project_workflow_link_records.workflow_id = workflows.id
         )
     END AS project_link_default
+    , lower(workflows.name) AS project_name_order_key
 FROM workflows
 WHERE (sqlc.narg(workflow_id) IS NULL OR workflows.id = sqlc.narg(workflow_id))
   AND (
@@ -1450,17 +1451,17 @@ WITH effective_board_placements AS (
       AND (
           t.canceled_at_unix_ms IS NULL
           OR n.kind = 'terminal'
-          OR trim(sqlc.arg(canceled_terminal_node_id)) = ''
+          OR sqlc.narg(canceled_terminal_node_id) IS NULL
       )
     UNION
     SELECT
         t.id AS task_id,
-        sqlc.arg(canceled_terminal_node_id) AS node_id
+        sqlc.narg(canceled_terminal_node_id) AS node_id
     FROM task_records t
     WHERE t.project_id = sqlc.arg(project_id)
       AND t.workflow_id = sqlc.arg(workflow_id)
       AND t.canceled_at_unix_ms IS NOT NULL
-      AND trim(sqlc.arg(canceled_terminal_node_id)) != ''
+      AND sqlc.narg(canceled_terminal_node_id) IS NOT NULL
       AND NOT EXISTS (
           SELECT 1
           FROM task_node_placements p
@@ -1480,7 +1481,7 @@ WITH effective_board_placements AS (
       AND t.workflow_id = sqlc.arg(workflow_id)
       AND (
           t.canceled_at_unix_ms IS NULL
-          OR trim(sqlc.arg(canceled_terminal_node_id)) = ''
+          OR sqlc.narg(canceled_terminal_node_id) IS NULL
       )
       AND trim(tt.source_node_id) != ''
 )

--- a/server/metadata/queries.sql
+++ b/server/metadata/queries.sql
@@ -178,52 +178,63 @@ FROM workflows
 ORDER BY updated_at_unix_ms DESC, rowid DESC;
 
 -- name: ListWorkflowRecordsPage :many
-WITH workflow_list(
-    id,
-    name,
-    description,
-    version,
-    execution_target_policy,
-    execution_target_custom_ref,
-    created_at_unix_ms,
-    updated_at_unix_ms,
-    activity_at_unix_ms
-) AS (
-    SELECT
-        workflows.id,
-        workflows.name,
-        workflows.description,
-        workflows.version,
-        workflows.execution_target_policy,
-        workflows.execution_target_custom_ref,
-        workflows.created_at_unix_ms,
-        workflows.updated_at_unix_ms,
-        CAST(MAX(
-            workflows.updated_at_unix_ms,
-            COALESCE((
+SELECT
+    workflows.id,
+    workflows.name,
+    workflows.description,
+    workflows.version,
+    workflows.execution_target_policy,
+    workflows.execution_target_custom_ref,
+    workflows.created_at_unix_ms,
+    workflows.updated_at_unix_ms,
+    CAST(
+        CASE
+            WHEN sqlc.narg(project_id) IS NULL THEN MAX(
+                workflows.updated_at_unix_ms,
+                COALESCE((
+                    SELECT MAX(task_records.updated_at_unix_ms)
+                    FROM task_records
+                    WHERE task_records.workflow_id = workflows.id
+                ), 0)
+            )
+            ELSE COALESCE((
                 SELECT MAX(task_records.updated_at_unix_ms)
                 FROM task_records
                 WHERE task_records.workflow_id = workflows.id
+                  AND task_records.project_id = sqlc.narg(project_id)
             ), 0)
-        ) AS INTEGER) AS activity_at_unix_ms
-    FROM workflows
-    WHERE (sqlc.arg(exact_name) = '' OR workflows.name = sqlc.arg(exact_name))
-      AND (
-          sqlc.arg(search_query) = ''
-          OR lower(workflows.name) LIKE '%' || lower(sqlc.arg(search_query)) || '%'
-          OR lower(workflows.description) LIKE '%' || lower(sqlc.arg(search_query)) || '%'
+        END
+    AS INTEGER) AS activity_at_unix_ms,
+    CASE
+        WHEN sqlc.narg(project_id) IS NULL THEN NULL
+        ELSE (
+            SELECT project_workflow_link_records.is_default
+            FROM project_workflow_link_records
+            WHERE project_workflow_link_records.project_id = sqlc.narg(project_id)
+              AND project_workflow_link_records.workflow_id = workflows.id
+        )
+    END AS project_link_default
+FROM workflows
+WHERE (sqlc.narg(workflow_id) IS NULL OR workflows.id = sqlc.narg(workflow_id))
+  AND (
+      sqlc.arg(search_query) = ''
+      OR lower(workflows.name) LIKE '%' || lower(sqlc.arg(search_query)) || '%'
+      OR lower(workflows.description) LIKE '%' || lower(sqlc.arg(search_query)) || '%'
+  )
+  AND (
+      sqlc.narg(project_id) IS NULL
+      OR EXISTS (
+          SELECT 1
+          FROM project_workflow_link_records
+          WHERE project_workflow_link_records.project_id = sqlc.narg(project_id)
+            AND project_workflow_link_records.workflow_id = workflows.id
       )
-      AND (
-          sqlc.arg(cursor_active) = 0
-          OR MAX(
-              workflows.updated_at_unix_ms,
-              COALESCE((
-                  SELECT MAX(task_records.updated_at_unix_ms)
-                  FROM task_records
-                  WHERE task_records.workflow_id = workflows.id
-              ), 0)
-          ) < sqlc.arg(cursor_activity_at_unix_ms)
-          OR (
+  )
+  AND (
+      sqlc.arg(cursor_active) = 0
+      OR (
+          sqlc.narg(project_id) IS NULL
+          AND (
               MAX(
                   workflows.updated_at_unix_ms,
                   COALESCE((
@@ -231,23 +242,83 @@ WITH workflow_list(
                       FROM task_records
                       WHERE task_records.workflow_id = workflows.id
                   ), 0)
-              ) = sqlc.arg(cursor_activity_at_unix_ms)
-              AND workflows.id < sqlc.arg(cursor_workflow_id)
+              ) < sqlc.arg(cursor_activity_at_unix_ms)
+              OR (
+                  MAX(
+                      workflows.updated_at_unix_ms,
+                      COALESCE((
+                          SELECT MAX(task_records.updated_at_unix_ms)
+                          FROM task_records
+                          WHERE task_records.workflow_id = workflows.id
+                      ), 0)
+                  ) = sqlc.arg(cursor_activity_at_unix_ms)
+                  AND workflows.id < sqlc.arg(cursor_workflow_id)
+              )
           )
       )
-)
-SELECT
-    id,
-    name,
-    description,
-    version,
-    execution_target_policy,
-    execution_target_custom_ref,
-    created_at_unix_ms,
-    updated_at_unix_ms,
-    activity_at_unix_ms
-FROM workflow_list
-ORDER BY activity_at_unix_ms DESC, id DESC
+      OR (
+          sqlc.narg(project_id) IS NOT NULL
+          AND (
+              COALESCE((
+                  SELECT project_workflow_link_records.is_default
+                  FROM project_workflow_link_records
+                  WHERE project_workflow_link_records.project_id = sqlc.narg(project_id)
+                    AND project_workflow_link_records.workflow_id = workflows.id
+              ), 0) < sqlc.narg(cursor_project_default)
+              OR (
+                  COALESCE((
+                      SELECT project_workflow_link_records.is_default
+                      FROM project_workflow_link_records
+                      WHERE project_workflow_link_records.project_id = sqlc.narg(project_id)
+                        AND project_workflow_link_records.workflow_id = workflows.id
+                  ), 0) = sqlc.narg(cursor_project_default)
+                  AND COALESCE((
+                      SELECT MAX(task_records.updated_at_unix_ms)
+                      FROM task_records
+                      WHERE task_records.workflow_id = workflows.id
+                        AND task_records.project_id = sqlc.narg(project_id)
+                  ), 0) < sqlc.arg(cursor_activity_at_unix_ms)
+              )
+              OR (
+                  COALESCE((
+                      SELECT project_workflow_link_records.is_default
+                      FROM project_workflow_link_records
+                      WHERE project_workflow_link_records.project_id = sqlc.narg(project_id)
+                        AND project_workflow_link_records.workflow_id = workflows.id
+                  ), 0) = sqlc.narg(cursor_project_default)
+                  AND COALESCE((
+                      SELECT MAX(task_records.updated_at_unix_ms)
+                      FROM task_records
+                      WHERE task_records.workflow_id = workflows.id
+                        AND task_records.project_id = sqlc.narg(project_id)
+                  ), 0) = sqlc.arg(cursor_activity_at_unix_ms)
+                  AND lower(workflows.name) > sqlc.narg(cursor_project_name)
+              )
+              OR (
+                  COALESCE((
+                      SELECT project_workflow_link_records.is_default
+                      FROM project_workflow_link_records
+                      WHERE project_workflow_link_records.project_id = sqlc.narg(project_id)
+                        AND project_workflow_link_records.workflow_id = workflows.id
+                  ), 0) = sqlc.narg(cursor_project_default)
+                  AND COALESCE((
+                      SELECT MAX(task_records.updated_at_unix_ms)
+                      FROM task_records
+                      WHERE task_records.workflow_id = workflows.id
+                        AND task_records.project_id = sqlc.narg(project_id)
+                  ), 0) = sqlc.arg(cursor_activity_at_unix_ms)
+                  AND lower(workflows.name) = sqlc.narg(cursor_project_name)
+                  AND workflows.id > sqlc.arg(cursor_workflow_id)
+              )
+          )
+      )
+  )
+ORDER BY
+    project_link_default DESC,
+    activity_at_unix_ms DESC,
+    CASE WHEN project_link_default IS NOT NULL THEN lower(workflows.name) END ASC,
+    CASE WHEN project_link_default IS NULL THEN workflows.id END DESC,
+    CASE WHEN project_link_default IS NOT NULL THEN workflows.id END ASC
 LIMIT sqlc.arg(page_limit);
 
 -- name: InsertWorkflowNode :exec
@@ -769,6 +840,19 @@ FROM project_workflow_link_records
 WHERE project_id = sqlc.arg(project_id)
   AND workflow_id = sqlc.arg(workflow_id)
 LIMIT 1;
+
+-- name: ListProjectWorkflowLinksForTaskSelection :many
+SELECT
+    id,
+    project_id,
+    workflow_id,
+    is_default,
+    created_at_unix_ms,
+    updated_at_unix_ms
+FROM project_workflow_link_records
+WHERE project_id = sqlc.arg(project_id)
+ORDER BY created_at_unix_ms ASC, id ASC
+LIMIT 2;
 
 -- name: ListProjectWorkflowLinks :many
 SELECT
@@ -1412,11 +1496,11 @@ WITH
 args AS (
     SELECT
         CAST(sqlc.arg(project_id) AS TEXT) AS project_id,
-        CAST(sqlc.arg(workflow_id) AS TEXT) AS workflow_id,
-        CAST(sqlc.arg(canceled_terminal_node_id) AS TEXT) AS canceled_terminal_node_id,
-        CAST(sqlc.arg(visible_columns_json) AS TEXT) AS visible_columns_json,
+        CAST(sqlc.narg(workflow_id) AS TEXT) AS workflow_id,
+        CAST(sqlc.narg(canceled_terminal_node_id) AS TEXT) AS canceled_terminal_node_id,
+        CAST(sqlc.narg(visible_columns_json) AS TEXT) AS visible_columns_json,
         CAST(sqlc.arg(column_filter_set) AS INTEGER) AS column_filter_set,
-        CAST(sqlc.arg(column_keys_json) AS TEXT) AS column_keys_json,
+        CAST(sqlc.narg(column_keys_json) AS TEXT) AS column_keys_json,
         CAST(sqlc.arg(status_filter_set) AS INTEGER) AS status_filter_set,
         CAST(sqlc.arg(status_kinds_json) AS TEXT) AS status_kinds_json,
         CAST(sqlc.arg(attention_filter_set) AS INTEGER) AS attention_filter_set,
@@ -1425,7 +1509,7 @@ args AS (
         CAST(sqlc.arg(cursor_created_at_unix_ms) AS INTEGER) AS cursor_created_at_unix_ms,
         CAST(sqlc.arg(cursor_updated_at_unix_ms) AS INTEGER) AS cursor_updated_at_unix_ms,
         CAST(sqlc.arg(cursor_primary_status_rank) AS INTEGER) AS cursor_primary_status_rank,
-        CAST(sqlc.arg(cursor_column_rank) AS INTEGER) AS cursor_column_rank,
+        CAST(sqlc.narg(cursor_column_rank) AS INTEGER) AS cursor_column_rank,
         CAST(sqlc.arg(cursor_run_count) AS INTEGER) AS cursor_run_count,
         CAST(sqlc.arg(cursor_title_sort) AS TEXT) AS cursor_title_sort,
         CAST(sqlc.arg(cursor_task_id) AS TEXT) AS cursor_task_id,
@@ -1451,13 +1535,15 @@ visible_columns AS (
 ),
 current_positions AS (
     SELECT p.task_id, p.node_id
-    FROM task_node_placements p
-    JOIN task_records t ON t.id = p.task_id
+    FROM args
+    CROSS JOIN project_workflow_links task_link
+    CROSS JOIN tasks t INDEXED BY tasks_project_workflow_link_idx
+    JOIN task_node_placements p ON p.task_id = t.id
     JOIN workflow_nodes n ON n.id = p.node_id
-    CROSS JOIN args
-    WHERE p.state IN ('active', 'waiting_approval')
-      AND t.project_id = args.project_id
-      AND t.workflow_id = args.workflow_id
+    WHERE task_link.project_id = args.project_id
+      AND (args.workflow_id IS NULL OR task_link.workflow_id = args.workflow_id)
+      AND t.project_workflow_link_id = task_link.id
+      AND p.state IN ('active', 'waiting_approval')
       AND (
           t.canceled_at_unix_ms IS NULL
           OR n.kind = 'terminal'
@@ -1466,25 +1552,29 @@ current_positions AS (
     UNION
 
     SELECT tt.task_id, tt.source_node_id
-    FROM task_transition_records tt
-    JOIN task_records t ON t.id = tt.task_id
-    CROSS JOIN args
-    WHERE tt.state = 'pending_approval'
+    FROM args
+    CROSS JOIN project_workflow_links task_link
+    CROSS JOIN tasks t INDEXED BY tasks_project_workflow_link_idx
+    JOIN task_transition_records tt ON tt.task_id = t.id
+    WHERE task_link.project_id = args.project_id
+      AND (args.workflow_id IS NULL OR task_link.workflow_id = args.workflow_id)
+      AND t.project_workflow_link_id = task_link.id
+      AND tt.state = 'pending_approval'
       AND tt.source_node_id IS NOT NULL
       AND trim(tt.source_node_id) != ''
-      AND t.project_id = args.project_id
-      AND t.workflow_id = args.workflow_id
       AND t.canceled_at_unix_ms IS NULL
 
     UNION
 
     SELECT t.id, args.canceled_terminal_node_id AS node_id
-    FROM task_records t
-    CROSS JOIN args
-    WHERE t.project_id = args.project_id
-      AND t.workflow_id = args.workflow_id
+    FROM args
+    CROSS JOIN project_workflow_links task_link
+    CROSS JOIN tasks t INDEXED BY tasks_project_workflow_link_idx
+    WHERE task_link.project_id = args.project_id
+      AND (args.workflow_id IS NULL OR task_link.workflow_id = args.workflow_id)
+      AND t.project_workflow_link_id = task_link.id
       AND t.canceled_at_unix_ms IS NOT NULL
-      AND trim(args.canceled_terminal_node_id) != ''
+      AND args.canceled_terminal_node_id IS NOT NULL
       AND NOT EXISTS (
           SELECT 1
           FROM task_node_placements p
@@ -1513,19 +1603,22 @@ column_facts AS (
 ),
 run_counts AS (
     SELECT r.task_id, CAST(COUNT(*) AS INTEGER) AS run_count
-    FROM task_run_records r
-    JOIN task_records t ON t.id = r.task_id
-    CROSS JOIN args
-    WHERE t.project_id = args.project_id
-      AND t.workflow_id = args.workflow_id
+    FROM args
+    CROSS JOIN project_workflow_links task_link
+    CROSS JOIN tasks t INDEXED BY tasks_project_workflow_link_idx
+    JOIN task_run_records r ON r.task_id = t.id
+    WHERE task_link.project_id = args.project_id
+      AND (args.workflow_id IS NULL OR task_link.workflow_id = args.workflow_id)
+      AND t.project_workflow_link_id = task_link.id
     GROUP BY r.task_id
 ),
 selected_rows AS (
     SELECT
         t.id,
-        t.project_id,
+        pwl.project_id,
         t.project_workflow_link_id,
-        t.workflow_id,
+        pwl.workflow_id,
+        w.name AS workflow_name,
         t.workflow_revision_seen,
         t.task_seq,
         t.short_id,
@@ -1544,7 +1637,7 @@ selected_rows AS (
         t.created_at_unix_ms,
         t.updated_at_unix_ms,
         t.metadata_json,
-        CAST(column_facts.column_rank AS INTEGER) AS column_rank,
+        column_facts.column_rank,
         column_facts.column_keys_json,
         status.kind,
         CAST(status.primary_status_rank AS INTEGER) AS primary_status_rank,
@@ -1598,13 +1691,18 @@ selected_rows AS (
             WHEN 'title' THEN LOWER(t.title)
             ELSE ''
         END AS sort_5_value
-    FROM task_records t
-    CROSS JOIN args
+    FROM args
+    CROSS JOIN project_workflow_links pwl
+    CROSS JOIN tasks t INDEXED BY tasks_project_workflow_link_idx
+    JOIN workflows w ON w.id = pwl.workflow_id
     JOIN workflow_task_status_records status ON status.task_id = t.id
-    JOIN column_facts ON column_facts.task_id = t.id
+    LEFT JOIN column_facts
+        ON args.workflow_id IS NOT NULL
+       AND column_facts.task_id = t.id
     LEFT JOIN run_counts ON run_counts.task_id = t.id
-    WHERE t.project_id = args.project_id
-      AND t.workflow_id = args.workflow_id
+    WHERE pwl.project_id = args.project_id
+      AND (args.workflow_id IS NULL OR pwl.workflow_id = args.workflow_id)
+      AND t.project_workflow_link_id = pwl.id
       AND (
           args.column_filter_set = 0
           OR EXISTS (
@@ -1625,6 +1723,12 @@ selected_rows AS (
               JOIN json_each(status.attention_types_json) task_attention ON task_attention.value = filter_attention.value
           )
       )
+),
+matching_workflows AS (
+    SELECT workflow_id
+    FROM selected_rows
+    GROUP BY workflow_id
+    LIMIT 2
 ),
 cursor_values AS (
     SELECT
@@ -1680,6 +1784,7 @@ SELECT
     rows.project_id,
     rows.project_workflow_link_id,
     rows.workflow_id,
+    rows.workflow_name,
     rows.workflow_revision_seen,
     rows.task_seq,
     rows.short_id,
@@ -1706,7 +1811,8 @@ SELECT
     rows.run_ids_json,
     rows.attention_types_json,
     rows.run_count,
-    rows.title_sort
+    rows.title_sort,
+    CAST((SELECT COUNT(*) FROM matching_workflows) AS INTEGER) AS matching_workflow_count
 FROM selected_rows rows
 CROSS JOIN args
 CROSS JOIN cursor_values cursor

--- a/server/metadata/queries.sql
+++ b/server/metadata/queries.sql
@@ -1703,30 +1703,8 @@ matching_workflows AS (
       AND (args.workflow_id IS NULL OR task_link.workflow_id = args.workflow_id)
       AND EXISTS (
           SELECT 1
-          FROM tasks t INDEXED BY tasks_project_workflow_link_idx
-          JOIN workflow_task_status_records status ON status.task_id = t.id
-          LEFT JOIN column_facts ON column_facts.task_id = t.id
-          WHERE t.project_workflow_link_id = task_link.id
-            AND (
-                args.column_filter_set = 0
-                OR EXISTS (
-                    SELECT 1
-                    FROM json_each(args.column_keys_json) filter_key
-                    JOIN json_each(column_facts.column_keys_json) task_key ON task_key.value = filter_key.value
-                )
-            )
-            AND (
-                args.status_filter_set = 0
-                OR status.kind IN (SELECT value FROM json_each(args.status_kinds_json))
-            )
-            AND (
-                args.attention_filter_set = 0
-                OR EXISTS (
-                    SELECT 1
-                    FROM json_each(args.attention_kinds_json) filter_attention
-                    JOIN json_each(status.attention_types_json) task_attention ON task_attention.value = filter_attention.value
-                )
-            )
+          FROM selected_rows eligible
+          WHERE eligible.project_workflow_link_id = task_link.id
           LIMIT 1
       )
     LIMIT 2

--- a/server/metadata/queries.sql
+++ b/server/metadata/queries.sql
@@ -187,35 +187,29 @@ SELECT
     workflows.execution_target_custom_ref,
     workflows.created_at_unix_ms,
     workflows.updated_at_unix_ms,
-    CAST(
-        CASE
-            WHEN sqlc.narg(project_id) IS NULL THEN MAX(
-                workflows.updated_at_unix_ms,
-                COALESCE((
-                    SELECT MAX(task_records.updated_at_unix_ms)
-                    FROM task_records
-                    WHERE task_records.workflow_id = workflows.id
-                ), 0)
-            )
-            ELSE COALESCE((
-                SELECT MAX(task_records.updated_at_unix_ms)
-                FROM task_records
-                WHERE task_records.workflow_id = workflows.id
-                  AND task_records.project_id = sqlc.narg(project_id)
-            ), 0)
-        END
-    AS INTEGER) AS activity_at_unix_ms,
-    CASE
-        WHEN sqlc.narg(project_id) IS NULL THEN NULL
-        ELSE (
-            SELECT project_workflow_link_records.is_default
-            FROM project_workflow_link_records
-            WHERE project_workflow_link_records.project_id = sqlc.narg(project_id)
-              AND project_workflow_link_records.workflow_id = workflows.id
-        )
-    END AS project_link_default
-    , lower(workflows.name) AS project_name_order_key
+    CAST(MAX(
+        workflows.updated_at_unix_ms,
+        COALESCE((
+            SELECT MAX(task_records.updated_at_unix_ms)
+            FROM task_records
+            WHERE task_records.workflow_id = workflows.id
+        ), workflows.updated_at_unix_ms)
+    ) AS INTEGER) AS global_activity_at_unix_ms,
+    project_latest_task.updated_at_unix_ms AS project_activity_at_unix_ms,
+    project_link.is_default AS project_link_default,
+    lower(workflows.name) AS project_name_order_key
 FROM workflows
+LEFT JOIN project_workflow_link_records project_link
+    ON project_link.project_id = sqlc.narg(project_id)
+   AND project_link.workflow_id = workflows.id
+LEFT JOIN tasks project_latest_task
+    ON project_latest_task.id = (
+        SELECT latest_task.id
+        FROM tasks latest_task INDEXED BY tasks_project_workflow_link_updated_idx
+        WHERE latest_task.project_workflow_link_id = project_link.id
+        ORDER BY latest_task.updated_at_unix_ms DESC, latest_task.id DESC
+        LIMIT 1
+    )
 WHERE (sqlc.narg(workflow_id) IS NULL OR workflows.id = sqlc.narg(workflow_id))
   AND (
       sqlc.arg(search_query) = ''
@@ -224,12 +218,7 @@ WHERE (sqlc.narg(workflow_id) IS NULL OR workflows.id = sqlc.narg(workflow_id))
   )
   AND (
       sqlc.narg(project_id) IS NULL
-      OR EXISTS (
-          SELECT 1
-          FROM project_workflow_link_records
-          WHERE project_workflow_link_records.project_id = sqlc.narg(project_id)
-            AND project_workflow_link_records.workflow_id = workflows.id
-      )
+      OR project_link.id IS NOT NULL
   )
   AND (
       sqlc.arg(cursor_active) = 0
@@ -242,8 +231,8 @@ WHERE (sqlc.narg(workflow_id) IS NULL OR workflows.id = sqlc.narg(workflow_id))
                       SELECT MAX(task_records.updated_at_unix_ms)
                       FROM task_records
                       WHERE task_records.workflow_id = workflows.id
-                  ), 0)
-              ) < sqlc.arg(cursor_activity_at_unix_ms)
+                  ), workflows.updated_at_unix_ms)
+              ) < sqlc.narg(cursor_activity_at_unix_ms)
               OR (
                   MAX(
                       workflows.updated_at_unix_ms,
@@ -251,8 +240,8 @@ WHERE (sqlc.narg(workflow_id) IS NULL OR workflows.id = sqlc.narg(workflow_id))
                           SELECT MAX(task_records.updated_at_unix_ms)
                           FROM task_records
                           WHERE task_records.workflow_id = workflows.id
-                      ), 0)
-                  ) = sqlc.arg(cursor_activity_at_unix_ms)
+                      ), workflows.updated_at_unix_ms)
+                  ) = sqlc.narg(cursor_activity_at_unix_ms)
                   AND workflows.id < sqlc.arg(cursor_workflow_id)
               )
           )
@@ -260,63 +249,44 @@ WHERE (sqlc.narg(workflow_id) IS NULL OR workflows.id = sqlc.narg(workflow_id))
       OR (
           sqlc.narg(project_id) IS NOT NULL
           AND (
-              COALESCE((
-                  SELECT project_workflow_link_records.is_default
-                  FROM project_workflow_link_records
-                  WHERE project_workflow_link_records.project_id = sqlc.narg(project_id)
-                    AND project_workflow_link_records.workflow_id = workflows.id
-              ), 0) < sqlc.narg(cursor_project_default)
+              project_link.is_default < sqlc.narg(cursor_project_default)
               OR (
-                  COALESCE((
-                      SELECT project_workflow_link_records.is_default
-                      FROM project_workflow_link_records
-                      WHERE project_workflow_link_records.project_id = sqlc.narg(project_id)
-                        AND project_workflow_link_records.workflow_id = workflows.id
-                  ), 0) = sqlc.narg(cursor_project_default)
-                  AND COALESCE((
-                      SELECT MAX(task_records.updated_at_unix_ms)
-                      FROM task_records
-                      WHERE task_records.workflow_id = workflows.id
-                        AND task_records.project_id = sqlc.narg(project_id)
-                  ), 0) < sqlc.arg(cursor_activity_at_unix_ms)
-              )
-              OR (
-                  COALESCE((
-                      SELECT project_workflow_link_records.is_default
-                      FROM project_workflow_link_records
-                      WHERE project_workflow_link_records.project_id = sqlc.narg(project_id)
-                        AND project_workflow_link_records.workflow_id = workflows.id
-                  ), 0) = sqlc.narg(cursor_project_default)
-                  AND COALESCE((
-                      SELECT MAX(task_records.updated_at_unix_ms)
-                      FROM task_records
-                      WHERE task_records.workflow_id = workflows.id
-                        AND task_records.project_id = sqlc.narg(project_id)
-                  ), 0) = sqlc.arg(cursor_activity_at_unix_ms)
-                  AND lower(workflows.name) > sqlc.narg(cursor_project_name)
-              )
-              OR (
-                  COALESCE((
-                      SELECT project_workflow_link_records.is_default
-                      FROM project_workflow_link_records
-                      WHERE project_workflow_link_records.project_id = sqlc.narg(project_id)
-                        AND project_workflow_link_records.workflow_id = workflows.id
-                  ), 0) = sqlc.narg(cursor_project_default)
-                  AND COALESCE((
-                      SELECT MAX(task_records.updated_at_unix_ms)
-                      FROM task_records
-                      WHERE task_records.workflow_id = workflows.id
-                        AND task_records.project_id = sqlc.narg(project_id)
-                  ), 0) = sqlc.arg(cursor_activity_at_unix_ms)
-                  AND lower(workflows.name) = sqlc.narg(cursor_project_name)
-                  AND workflows.id > sqlc.arg(cursor_workflow_id)
+                  project_link.is_default = sqlc.narg(cursor_project_default)
+                  AND (
+                      (
+                          sqlc.narg(cursor_activity_at_unix_ms) IS NOT NULL
+                          AND (
+                              project_latest_task.updated_at_unix_ms IS NULL
+                              OR project_latest_task.updated_at_unix_ms < sqlc.narg(cursor_activity_at_unix_ms)
+                          )
+                      )
+                      OR (
+                          (
+                              project_latest_task.updated_at_unix_ms = sqlc.narg(cursor_activity_at_unix_ms)
+                              OR (
+                                  project_latest_task.updated_at_unix_ms IS NULL
+                                  AND sqlc.narg(cursor_activity_at_unix_ms) IS NULL
+                              )
+                          )
+                          AND (
+                              lower(workflows.name) > sqlc.narg(cursor_project_name)
+                              OR (
+                                  lower(workflows.name) = sqlc.narg(cursor_project_name)
+                                  AND workflows.id > sqlc.arg(cursor_workflow_id)
+                              )
+                          )
+                      )
+                  )
               )
           )
       )
   )
 ORDER BY
     project_link_default DESC,
-    activity_at_unix_ms DESC,
+    CASE
+        WHEN project_link_default IS NULL THEN global_activity_at_unix_ms
+        ELSE project_activity_at_unix_ms
+    END DESC,
     CASE WHEN project_link_default IS NOT NULL THEN lower(workflows.name) END ASC,
     CASE WHEN project_link_default IS NULL THEN workflows.id END DESC,
     CASE WHEN project_link_default IS NOT NULL THEN workflows.id END ASC
@@ -1726,9 +1696,39 @@ selected_rows AS (
       )
 ),
 matching_workflows AS (
-    SELECT workflow_id
-    FROM selected_rows
-    GROUP BY workflow_id
+    SELECT task_link.workflow_id
+    FROM args
+    CROSS JOIN project_workflow_links task_link
+    WHERE task_link.project_id = args.project_id
+      AND (args.workflow_id IS NULL OR task_link.workflow_id = args.workflow_id)
+      AND EXISTS (
+          SELECT 1
+          FROM tasks t INDEXED BY tasks_project_workflow_link_idx
+          JOIN workflow_task_status_records status ON status.task_id = t.id
+          LEFT JOIN column_facts ON column_facts.task_id = t.id
+          WHERE t.project_workflow_link_id = task_link.id
+            AND (
+                args.column_filter_set = 0
+                OR EXISTS (
+                    SELECT 1
+                    FROM json_each(args.column_keys_json) filter_key
+                    JOIN json_each(column_facts.column_keys_json) task_key ON task_key.value = filter_key.value
+                )
+            )
+            AND (
+                args.status_filter_set = 0
+                OR status.kind IN (SELECT value FROM json_each(args.status_kinds_json))
+            )
+            AND (
+                args.attention_filter_set = 0
+                OR EXISTS (
+                    SELECT 1
+                    FROM json_each(args.attention_kinds_json) filter_attention
+                    JOIN json_each(status.attention_types_json) task_attention ON task_attention.value = filter_attention.value
+                )
+            )
+          LIMIT 1
+      )
     LIMIT 2
 ),
 cursor_values AS (

--- a/server/metadata/sqlitegen/queries.sql.go
+++ b/server/metadata/sqlitegen/queries.sql.go
@@ -5018,6 +5018,50 @@ func (q *Queries) ListProjectWorkflowLinks(ctx context.Context, projectID string
 	return items, nil
 }
 
+const listProjectWorkflowLinksForTaskSelection = `-- name: ListProjectWorkflowLinksForTaskSelection :many
+SELECT
+    id,
+    project_id,
+    workflow_id,
+    is_default,
+    created_at_unix_ms,
+    updated_at_unix_ms
+FROM project_workflow_link_records
+WHERE project_id = ?1
+ORDER BY created_at_unix_ms ASC, id ASC
+LIMIT 2
+`
+
+func (q *Queries) ListProjectWorkflowLinksForTaskSelection(ctx context.Context, projectID string) ([]ProjectWorkflowLinkRecord, error) {
+	rows, err := q.db.QueryContext(ctx, listProjectWorkflowLinksForTaskSelection, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ProjectWorkflowLinkRecord
+	for rows.Next() {
+		var i ProjectWorkflowLinkRecord
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.WorkflowID,
+			&i.IsDefault,
+			&i.CreatedAtUnixMs,
+			&i.UpdatedAtUnixMs,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listProjectWorkflowTaskActivity = `-- name: ListProjectWorkflowTaskActivity :many
 SELECT
     workflow_id,
@@ -7330,52 +7374,63 @@ func (q *Queries) ListWorkflowQuestionAttentionItems(ctx context.Context, arg Li
 }
 
 const listWorkflowRecordsPage = `-- name: ListWorkflowRecordsPage :many
-WITH workflow_list(
-    id,
-    name,
-    description,
-    version,
-    execution_target_policy,
-    execution_target_custom_ref,
-    created_at_unix_ms,
-    updated_at_unix_ms,
-    activity_at_unix_ms
-) AS (
-    SELECT
-        workflows.id,
-        workflows.name,
-        workflows.description,
-        workflows.version,
-        workflows.execution_target_policy,
-        workflows.execution_target_custom_ref,
-        workflows.created_at_unix_ms,
-        workflows.updated_at_unix_ms,
-        CAST(MAX(
-            workflows.updated_at_unix_ms,
-            COALESCE((
+SELECT
+    workflows.id,
+    workflows.name,
+    workflows.description,
+    workflows.version,
+    workflows.execution_target_policy,
+    workflows.execution_target_custom_ref,
+    workflows.created_at_unix_ms,
+    workflows.updated_at_unix_ms,
+    CAST(
+        CASE
+            WHEN ?1 IS NULL THEN MAX(
+                workflows.updated_at_unix_ms,
+                COALESCE((
+                    SELECT MAX(task_records.updated_at_unix_ms)
+                    FROM task_records
+                    WHERE task_records.workflow_id = workflows.id
+                ), 0)
+            )
+            ELSE COALESCE((
                 SELECT MAX(task_records.updated_at_unix_ms)
                 FROM task_records
                 WHERE task_records.workflow_id = workflows.id
+                  AND task_records.project_id = ?1
             ), 0)
-        ) AS INTEGER) AS activity_at_unix_ms
-    FROM workflows
-    WHERE (?2 = '' OR workflows.name = ?2)
-      AND (
-          ?3 = ''
-          OR lower(workflows.name) LIKE '%' || lower(?3) || '%'
-          OR lower(workflows.description) LIKE '%' || lower(?3) || '%'
+        END
+    AS INTEGER) AS activity_at_unix_ms,
+    CASE
+        WHEN ?1 IS NULL THEN NULL
+        ELSE (
+            SELECT project_workflow_link_records.is_default
+            FROM project_workflow_link_records
+            WHERE project_workflow_link_records.project_id = ?1
+              AND project_workflow_link_records.workflow_id = workflows.id
+        )
+    END AS project_link_default
+FROM workflows
+WHERE (?2 IS NULL OR workflows.id = ?2)
+  AND (
+      ?3 = ''
+      OR lower(workflows.name) LIKE '%' || lower(?3) || '%'
+      OR lower(workflows.description) LIKE '%' || lower(?3) || '%'
+  )
+  AND (
+      ?1 IS NULL
+      OR EXISTS (
+          SELECT 1
+          FROM project_workflow_link_records
+          WHERE project_workflow_link_records.project_id = ?1
+            AND project_workflow_link_records.workflow_id = workflows.id
       )
-      AND (
-          ?4 = 0
-          OR MAX(
-              workflows.updated_at_unix_ms,
-              COALESCE((
-                  SELECT MAX(task_records.updated_at_unix_ms)
-                  FROM task_records
-                  WHERE task_records.workflow_id = workflows.id
-              ), 0)
-          ) < ?5
-          OR (
+  )
+  AND (
+      ?4 = 0
+      OR (
+          ?1 IS NULL
+          AND (
               MAX(
                   workflows.updated_at_unix_ms,
                   COALESCE((
@@ -7383,33 +7438,96 @@ WITH workflow_list(
                       FROM task_records
                       WHERE task_records.workflow_id = workflows.id
                   ), 0)
-              ) = ?5
-              AND workflows.id < ?6
+              ) < ?5
+              OR (
+                  MAX(
+                      workflows.updated_at_unix_ms,
+                      COALESCE((
+                          SELECT MAX(task_records.updated_at_unix_ms)
+                          FROM task_records
+                          WHERE task_records.workflow_id = workflows.id
+                      ), 0)
+                  ) = ?5
+                  AND workflows.id < ?6
+              )
           )
       )
-)
-SELECT
-    id,
-    name,
-    description,
-    version,
-    execution_target_policy,
-    execution_target_custom_ref,
-    created_at_unix_ms,
-    updated_at_unix_ms,
-    activity_at_unix_ms
-FROM workflow_list
-ORDER BY activity_at_unix_ms DESC, id DESC
-LIMIT ?1
+      OR (
+          ?1 IS NOT NULL
+          AND (
+              COALESCE((
+                  SELECT project_workflow_link_records.is_default
+                  FROM project_workflow_link_records
+                  WHERE project_workflow_link_records.project_id = ?1
+                    AND project_workflow_link_records.workflow_id = workflows.id
+              ), 0) < ?7
+              OR (
+                  COALESCE((
+                      SELECT project_workflow_link_records.is_default
+                      FROM project_workflow_link_records
+                      WHERE project_workflow_link_records.project_id = ?1
+                        AND project_workflow_link_records.workflow_id = workflows.id
+                  ), 0) = ?7
+                  AND COALESCE((
+                      SELECT MAX(task_records.updated_at_unix_ms)
+                      FROM task_records
+                      WHERE task_records.workflow_id = workflows.id
+                        AND task_records.project_id = ?1
+                  ), 0) < ?5
+              )
+              OR (
+                  COALESCE((
+                      SELECT project_workflow_link_records.is_default
+                      FROM project_workflow_link_records
+                      WHERE project_workflow_link_records.project_id = ?1
+                        AND project_workflow_link_records.workflow_id = workflows.id
+                  ), 0) = ?7
+                  AND COALESCE((
+                      SELECT MAX(task_records.updated_at_unix_ms)
+                      FROM task_records
+                      WHERE task_records.workflow_id = workflows.id
+                        AND task_records.project_id = ?1
+                  ), 0) = ?5
+                  AND lower(workflows.name) > ?8
+              )
+              OR (
+                  COALESCE((
+                      SELECT project_workflow_link_records.is_default
+                      FROM project_workflow_link_records
+                      WHERE project_workflow_link_records.project_id = ?1
+                        AND project_workflow_link_records.workflow_id = workflows.id
+                  ), 0) = ?7
+                  AND COALESCE((
+                      SELECT MAX(task_records.updated_at_unix_ms)
+                      FROM task_records
+                      WHERE task_records.workflow_id = workflows.id
+                        AND task_records.project_id = ?1
+                  ), 0) = ?5
+                  AND lower(workflows.name) = ?8
+                  AND workflows.id > ?6
+              )
+          )
+      )
+  )
+ORDER BY
+    project_link_default DESC,
+    activity_at_unix_ms DESC,
+    CASE WHEN project_link_default IS NOT NULL THEN lower(workflows.name) END ASC,
+    CASE WHEN project_link_default IS NULL THEN workflows.id END DESC,
+    CASE WHEN project_link_default IS NOT NULL THEN workflows.id END ASC
+LIMIT ?9
 `
 
 type ListWorkflowRecordsPageParams struct {
-	PageLimit              int64
-	ExactName              interface{}
+	ProjectID              interface{}
+	WorkflowID             interface{}
 	SearchQuery            interface{}
 	CursorActive           interface{}
 	CursorActivityAtUnixMs int64
 	CursorWorkflowID       string
+	CursorProjectDefault   sql.NullInt64
+	CursorProjectName      sql.NullString
+	PageLimit              int64
 }
 
 type ListWorkflowRecordsPageRow struct {
@@ -7422,16 +7540,20 @@ type ListWorkflowRecordsPageRow struct {
 	CreatedAtUnixMs          int64
 	UpdatedAtUnixMs          int64
 	ActivityAtUnixMs         int64
+	ProjectLinkDefault       interface{}
 }
 
 func (q *Queries) ListWorkflowRecordsPage(ctx context.Context, arg ListWorkflowRecordsPageParams) ([]ListWorkflowRecordsPageRow, error) {
 	rows, err := q.db.QueryContext(ctx, listWorkflowRecordsPage,
-		arg.PageLimit,
-		arg.ExactName,
+		arg.ProjectID,
+		arg.WorkflowID,
 		arg.SearchQuery,
 		arg.CursorActive,
 		arg.CursorActivityAtUnixMs,
 		arg.CursorWorkflowID,
+		arg.CursorProjectDefault,
+		arg.CursorProjectName,
+		arg.PageLimit,
 	)
 	if err != nil {
 		return nil, err
@@ -7450,6 +7572,7 @@ func (q *Queries) ListWorkflowRecordsPage(ctx context.Context, arg ListWorkflowR
 			&i.CreatedAtUnixMs,
 			&i.UpdatedAtUnixMs,
 			&i.ActivityAtUnixMs,
+			&i.ProjectLinkDefault,
 		); err != nil {
 			return nil, err
 		}
@@ -7709,13 +7832,15 @@ visible_columns AS (
 ),
 current_positions AS (
     SELECT p.task_id, p.node_id
-    FROM task_node_placements p
-    JOIN task_records t ON t.id = p.task_id
+    FROM args
+    CROSS JOIN project_workflow_links task_link
+    CROSS JOIN tasks t INDEXED BY tasks_project_workflow_link_idx
+    JOIN task_node_placements p ON p.task_id = t.id
     JOIN workflow_nodes n ON n.id = p.node_id
-    CROSS JOIN args
-    WHERE p.state IN ('active', 'waiting_approval')
-      AND t.project_id = args.project_id
-      AND t.workflow_id = args.workflow_id
+    WHERE task_link.project_id = args.project_id
+      AND (args.workflow_id IS NULL OR task_link.workflow_id = args.workflow_id)
+      AND t.project_workflow_link_id = task_link.id
+      AND p.state IN ('active', 'waiting_approval')
       AND (
           t.canceled_at_unix_ms IS NULL
           OR n.kind = 'terminal'
@@ -7724,25 +7849,29 @@ current_positions AS (
     UNION
 
     SELECT tt.task_id, tt.source_node_id
-    FROM task_transition_records tt
-    JOIN task_records t ON t.id = tt.task_id
-    CROSS JOIN args
-    WHERE tt.state = 'pending_approval'
+    FROM args
+    CROSS JOIN project_workflow_links task_link
+    CROSS JOIN tasks t INDEXED BY tasks_project_workflow_link_idx
+    JOIN task_transition_records tt ON tt.task_id = t.id
+    WHERE task_link.project_id = args.project_id
+      AND (args.workflow_id IS NULL OR task_link.workflow_id = args.workflow_id)
+      AND t.project_workflow_link_id = task_link.id
+      AND tt.state = 'pending_approval'
       AND tt.source_node_id IS NOT NULL
       AND trim(tt.source_node_id) != ''
-      AND t.project_id = args.project_id
-      AND t.workflow_id = args.workflow_id
       AND t.canceled_at_unix_ms IS NULL
 
     UNION
 
     SELECT t.id, args.canceled_terminal_node_id AS node_id
-    FROM task_records t
-    CROSS JOIN args
-    WHERE t.project_id = args.project_id
-      AND t.workflow_id = args.workflow_id
+    FROM args
+    CROSS JOIN project_workflow_links task_link
+    CROSS JOIN tasks t INDEXED BY tasks_project_workflow_link_idx
+    WHERE task_link.project_id = args.project_id
+      AND (args.workflow_id IS NULL OR task_link.workflow_id = args.workflow_id)
+      AND t.project_workflow_link_id = task_link.id
       AND t.canceled_at_unix_ms IS NOT NULL
-      AND trim(args.canceled_terminal_node_id) != ''
+      AND args.canceled_terminal_node_id IS NOT NULL
       AND NOT EXISTS (
           SELECT 1
           FROM task_node_placements p
@@ -7771,19 +7900,22 @@ column_facts AS (
 ),
 run_counts AS (
     SELECT r.task_id, CAST(COUNT(*) AS INTEGER) AS run_count
-    FROM task_run_records r
-    JOIN task_records t ON t.id = r.task_id
-    CROSS JOIN args
-    WHERE t.project_id = args.project_id
-      AND t.workflow_id = args.workflow_id
+    FROM args
+    CROSS JOIN project_workflow_links task_link
+    CROSS JOIN tasks t INDEXED BY tasks_project_workflow_link_idx
+    JOIN task_run_records r ON r.task_id = t.id
+    WHERE task_link.project_id = args.project_id
+      AND (args.workflow_id IS NULL OR task_link.workflow_id = args.workflow_id)
+      AND t.project_workflow_link_id = task_link.id
     GROUP BY r.task_id
 ),
 selected_rows AS (
     SELECT
         t.id,
-        t.project_id,
+        pwl.project_id,
         t.project_workflow_link_id,
-        t.workflow_id,
+        pwl.workflow_id,
+        w.name AS workflow_name,
         t.workflow_revision_seen,
         t.task_seq,
         t.short_id,
@@ -7802,7 +7934,7 @@ selected_rows AS (
         t.created_at_unix_ms,
         t.updated_at_unix_ms,
         t.metadata_json,
-        CAST(column_facts.column_rank AS INTEGER) AS column_rank,
+        column_facts.column_rank,
         column_facts.column_keys_json,
         status.kind,
         CAST(status.primary_status_rank AS INTEGER) AS primary_status_rank,
@@ -7856,13 +7988,18 @@ selected_rows AS (
             WHEN 'title' THEN LOWER(t.title)
             ELSE ''
         END AS sort_5_value
-    FROM task_records t
-    CROSS JOIN args
+    FROM args
+    CROSS JOIN project_workflow_links pwl
+    CROSS JOIN tasks t INDEXED BY tasks_project_workflow_link_idx
+    JOIN workflows w ON w.id = pwl.workflow_id
     JOIN workflow_task_status_records status ON status.task_id = t.id
-    JOIN column_facts ON column_facts.task_id = t.id
+    LEFT JOIN column_facts
+        ON args.workflow_id IS NOT NULL
+       AND column_facts.task_id = t.id
     LEFT JOIN run_counts ON run_counts.task_id = t.id
-    WHERE t.project_id = args.project_id
-      AND t.workflow_id = args.workflow_id
+    WHERE pwl.project_id = args.project_id
+      AND (args.workflow_id IS NULL OR pwl.workflow_id = args.workflow_id)
+      AND t.project_workflow_link_id = pwl.id
       AND (
           args.column_filter_set = 0
           OR EXISTS (
@@ -7883,6 +8020,12 @@ selected_rows AS (
               JOIN json_each(status.attention_types_json) task_attention ON task_attention.value = filter_attention.value
           )
       )
+),
+matching_workflows AS (
+    SELECT workflow_id
+    FROM selected_rows
+    GROUP BY workflow_id
+    LIMIT 2
 ),
 cursor_values AS (
     SELECT
@@ -7938,6 +8081,7 @@ SELECT
     rows.project_id,
     rows.project_workflow_link_id,
     rows.workflow_id,
+    rows.workflow_name,
     rows.workflow_revision_seen,
     rows.task_seq,
     rows.short_id,
@@ -7964,7 +8108,8 @@ SELECT
     rows.run_ids_json,
     rows.attention_types_json,
     rows.run_count,
-    rows.title_sort
+    rows.title_sort,
+    CAST((SELECT COUNT(*) FROM matching_workflows) AS INTEGER) AS matching_workflow_count
 FROM selected_rows rows
 CROSS JOIN args
 CROSS JOIN cursor_values cursor
@@ -7994,11 +8139,11 @@ LIMIT (SELECT limit_rows FROM args)
 
 type ListWorkflowTaskListRowsParams struct {
 	ProjectID               string
-	WorkflowID              string
-	CanceledTerminalNodeID  string
-	VisibleColumnsJson      string
+	WorkflowID              sql.NullString
+	CanceledTerminalNodeID  sql.NullString
+	VisibleColumnsJson      sql.NullString
 	ColumnFilterSet         int64
-	ColumnKeysJson          string
+	ColumnKeysJson          sql.NullString
 	StatusFilterSet         int64
 	StatusKindsJson         string
 	AttentionFilterSet      int64
@@ -8007,7 +8152,7 @@ type ListWorkflowTaskListRowsParams struct {
 	CursorCreatedAtUnixMs   int64
 	CursorUpdatedAtUnixMs   int64
 	CursorPrimaryStatusRank int64
-	CursorColumnRank        int64
+	CursorColumnRank        sql.NullInt64
 	CursorRunCount          int64
 	CursorTitleSort         string
 	CursorTaskID            string
@@ -8029,6 +8174,7 @@ type ListWorkflowTaskListRowsRow struct {
 	ProjectID                   string
 	ProjectWorkflowLinkID       string
 	WorkflowID                  string
+	WorkflowName                string
 	WorkflowRevisionSeen        int64
 	TaskSeq                     int64
 	ShortID                     string
@@ -8047,8 +8193,8 @@ type ListWorkflowTaskListRowsRow struct {
 	CreatedAtUnixMs             int64
 	UpdatedAtUnixMs             int64
 	MetadataJson                string
-	ColumnRank                  int64
-	ColumnKeysJson              string
+	ColumnRank                  sql.NullInt64
+	ColumnKeysJson              sql.NullString
 	Kind                        string
 	PrimaryStatusRank           int64
 	NodeIdsJson                 string
@@ -8056,6 +8202,7 @@ type ListWorkflowTaskListRowsRow struct {
 	AttentionTypesJson          string
 	RunCount                    int64
 	TitleSort                   string
+	MatchingWorkflowCount       int64
 }
 
 func (q *Queries) ListWorkflowTaskListRows(ctx context.Context, arg ListWorkflowTaskListRowsParams) ([]ListWorkflowTaskListRowsRow, error) {
@@ -8102,6 +8249,7 @@ func (q *Queries) ListWorkflowTaskListRows(ctx context.Context, arg ListWorkflow
 			&i.ProjectID,
 			&i.ProjectWorkflowLinkID,
 			&i.WorkflowID,
+			&i.WorkflowName,
 			&i.WorkflowRevisionSeen,
 			&i.TaskSeq,
 			&i.ShortID,
@@ -8129,6 +8277,7 @@ func (q *Queries) ListWorkflowTaskListRows(ctx context.Context, arg ListWorkflow
 			&i.AttentionTypesJson,
 			&i.RunCount,
 			&i.TitleSort,
+			&i.MatchingWorkflowCount,
 		); err != nil {
 			return nil, err
 		}

--- a/server/metadata/sqlitegen/queries.sql.go
+++ b/server/metadata/sqlitegen/queries.sql.go
@@ -3845,7 +3845,7 @@ WITH effective_board_placements AS (
       AND (
           t.canceled_at_unix_ms IS NULL
           OR n.kind = 'terminal'
-          OR trim(?3) = ''
+          OR ?3 IS NULL
       )
     UNION
     SELECT
@@ -3855,7 +3855,7 @@ WITH effective_board_placements AS (
     WHERE t.project_id = ?1
       AND t.workflow_id = ?2
       AND t.canceled_at_unix_ms IS NOT NULL
-      AND trim(?3) != ''
+      AND ?3 IS NOT NULL
       AND NOT EXISTS (
           SELECT 1
           FROM task_node_placements p
@@ -3875,7 +3875,7 @@ WITH effective_board_placements AS (
       AND t.workflow_id = ?2
       AND (
           t.canceled_at_unix_ms IS NULL
-          OR trim(?3) = ''
+          OR ?3 IS NULL
       )
       AND trim(tt.source_node_id) != ''
 )
@@ -3890,7 +3890,7 @@ ORDER BY node_id ASC
 type ListBoardColumnTaskCountsParams struct {
 	ProjectID              string
 	WorkflowID             string
-	CanceledTerminalNodeID string
+	CanceledTerminalNodeID interface{}
 }
 
 type ListBoardColumnTaskCountsRow struct {
@@ -7410,6 +7410,7 @@ SELECT
               AND project_workflow_link_records.workflow_id = workflows.id
         )
     END AS project_link_default
+    , lower(workflows.name) AS project_name_order_key
 FROM workflows
 WHERE (?2 IS NULL OR workflows.id = ?2)
   AND (
@@ -7541,6 +7542,7 @@ type ListWorkflowRecordsPageRow struct {
 	UpdatedAtUnixMs          int64
 	ActivityAtUnixMs         int64
 	ProjectLinkDefault       interface{}
+	ProjectNameOrderKey      string
 }
 
 func (q *Queries) ListWorkflowRecordsPage(ctx context.Context, arg ListWorkflowRecordsPageParams) ([]ListWorkflowRecordsPageRow, error) {
@@ -7573,6 +7575,7 @@ func (q *Queries) ListWorkflowRecordsPage(ctx context.Context, arg ListWorkflowR
 			&i.UpdatedAtUnixMs,
 			&i.ActivityAtUnixMs,
 			&i.ProjectLinkDefault,
+			&i.ProjectNameOrderKey,
 		); err != nil {
 			return nil, err
 		}

--- a/server/metadata/sqlitegen/queries.sql.go
+++ b/server/metadata/sqlitegen/queries.sql.go
@@ -7383,35 +7383,29 @@ SELECT
     workflows.execution_target_custom_ref,
     workflows.created_at_unix_ms,
     workflows.updated_at_unix_ms,
-    CAST(
-        CASE
-            WHEN ?1 IS NULL THEN MAX(
-                workflows.updated_at_unix_ms,
-                COALESCE((
-                    SELECT MAX(task_records.updated_at_unix_ms)
-                    FROM task_records
-                    WHERE task_records.workflow_id = workflows.id
-                ), 0)
-            )
-            ELSE COALESCE((
-                SELECT MAX(task_records.updated_at_unix_ms)
-                FROM task_records
-                WHERE task_records.workflow_id = workflows.id
-                  AND task_records.project_id = ?1
-            ), 0)
-        END
-    AS INTEGER) AS activity_at_unix_ms,
-    CASE
-        WHEN ?1 IS NULL THEN NULL
-        ELSE (
-            SELECT project_workflow_link_records.is_default
-            FROM project_workflow_link_records
-            WHERE project_workflow_link_records.project_id = ?1
-              AND project_workflow_link_records.workflow_id = workflows.id
-        )
-    END AS project_link_default
-    , lower(workflows.name) AS project_name_order_key
+    CAST(MAX(
+        workflows.updated_at_unix_ms,
+        COALESCE((
+            SELECT MAX(task_records.updated_at_unix_ms)
+            FROM task_records
+            WHERE task_records.workflow_id = workflows.id
+        ), workflows.updated_at_unix_ms)
+    ) AS INTEGER) AS global_activity_at_unix_ms,
+    project_latest_task.updated_at_unix_ms AS project_activity_at_unix_ms,
+    project_link.is_default AS project_link_default,
+    lower(workflows.name) AS project_name_order_key
 FROM workflows
+LEFT JOIN project_workflow_link_records project_link
+    ON project_link.project_id = ?1
+   AND project_link.workflow_id = workflows.id
+LEFT JOIN tasks project_latest_task
+    ON project_latest_task.id = (
+        SELECT latest_task.id
+        FROM tasks latest_task INDEXED BY tasks_project_workflow_link_updated_idx
+        WHERE latest_task.project_workflow_link_id = project_link.id
+        ORDER BY latest_task.updated_at_unix_ms DESC, latest_task.id DESC
+        LIMIT 1
+    )
 WHERE (?2 IS NULL OR workflows.id = ?2)
   AND (
       ?3 = ''
@@ -7420,12 +7414,7 @@ WHERE (?2 IS NULL OR workflows.id = ?2)
   )
   AND (
       ?1 IS NULL
-      OR EXISTS (
-          SELECT 1
-          FROM project_workflow_link_records
-          WHERE project_workflow_link_records.project_id = ?1
-            AND project_workflow_link_records.workflow_id = workflows.id
-      )
+      OR project_link.id IS NOT NULL
   )
   AND (
       ?4 = 0
@@ -7438,7 +7427,7 @@ WHERE (?2 IS NULL OR workflows.id = ?2)
                       SELECT MAX(task_records.updated_at_unix_ms)
                       FROM task_records
                       WHERE task_records.workflow_id = workflows.id
-                  ), 0)
+                  ), workflows.updated_at_unix_ms)
               ) < ?5
               OR (
                   MAX(
@@ -7447,7 +7436,7 @@ WHERE (?2 IS NULL OR workflows.id = ?2)
                           SELECT MAX(task_records.updated_at_unix_ms)
                           FROM task_records
                           WHERE task_records.workflow_id = workflows.id
-                      ), 0)
+                      ), workflows.updated_at_unix_ms)
                   ) = ?5
                   AND workflows.id < ?6
               )
@@ -7456,63 +7445,44 @@ WHERE (?2 IS NULL OR workflows.id = ?2)
       OR (
           ?1 IS NOT NULL
           AND (
-              COALESCE((
-                  SELECT project_workflow_link_records.is_default
-                  FROM project_workflow_link_records
-                  WHERE project_workflow_link_records.project_id = ?1
-                    AND project_workflow_link_records.workflow_id = workflows.id
-              ), 0) < ?7
+              project_link.is_default < ?7
               OR (
-                  COALESCE((
-                      SELECT project_workflow_link_records.is_default
-                      FROM project_workflow_link_records
-                      WHERE project_workflow_link_records.project_id = ?1
-                        AND project_workflow_link_records.workflow_id = workflows.id
-                  ), 0) = ?7
-                  AND COALESCE((
-                      SELECT MAX(task_records.updated_at_unix_ms)
-                      FROM task_records
-                      WHERE task_records.workflow_id = workflows.id
-                        AND task_records.project_id = ?1
-                  ), 0) < ?5
-              )
-              OR (
-                  COALESCE((
-                      SELECT project_workflow_link_records.is_default
-                      FROM project_workflow_link_records
-                      WHERE project_workflow_link_records.project_id = ?1
-                        AND project_workflow_link_records.workflow_id = workflows.id
-                  ), 0) = ?7
-                  AND COALESCE((
-                      SELECT MAX(task_records.updated_at_unix_ms)
-                      FROM task_records
-                      WHERE task_records.workflow_id = workflows.id
-                        AND task_records.project_id = ?1
-                  ), 0) = ?5
-                  AND lower(workflows.name) > ?8
-              )
-              OR (
-                  COALESCE((
-                      SELECT project_workflow_link_records.is_default
-                      FROM project_workflow_link_records
-                      WHERE project_workflow_link_records.project_id = ?1
-                        AND project_workflow_link_records.workflow_id = workflows.id
-                  ), 0) = ?7
-                  AND COALESCE((
-                      SELECT MAX(task_records.updated_at_unix_ms)
-                      FROM task_records
-                      WHERE task_records.workflow_id = workflows.id
-                        AND task_records.project_id = ?1
-                  ), 0) = ?5
-                  AND lower(workflows.name) = ?8
-                  AND workflows.id > ?6
+                  project_link.is_default = ?7
+                  AND (
+                      (
+                          ?5 IS NOT NULL
+                          AND (
+                              project_latest_task.updated_at_unix_ms IS NULL
+                              OR project_latest_task.updated_at_unix_ms < ?5
+                          )
+                      )
+                      OR (
+                          (
+                              project_latest_task.updated_at_unix_ms = ?5
+                              OR (
+                                  project_latest_task.updated_at_unix_ms IS NULL
+                                  AND ?5 IS NULL
+                              )
+                          )
+                          AND (
+                              lower(workflows.name) > ?8
+                              OR (
+                                  lower(workflows.name) = ?8
+                                  AND workflows.id > ?6
+                              )
+                          )
+                      )
+                  )
               )
           )
       )
   )
 ORDER BY
     project_link_default DESC,
-    activity_at_unix_ms DESC,
+    CASE
+        WHEN project_link_default IS NULL THEN global_activity_at_unix_ms
+        ELSE project_activity_at_unix_ms
+    END DESC,
     CASE WHEN project_link_default IS NOT NULL THEN lower(workflows.name) END ASC,
     CASE WHEN project_link_default IS NULL THEN workflows.id END DESC,
     CASE WHEN project_link_default IS NOT NULL THEN workflows.id END ASC
@@ -7520,11 +7490,11 @@ LIMIT ?9
 `
 
 type ListWorkflowRecordsPageParams struct {
-	ProjectID              interface{}
+	ProjectID              sql.NullString
 	WorkflowID             interface{}
 	SearchQuery            interface{}
 	CursorActive           interface{}
-	CursorActivityAtUnixMs int64
+	CursorActivityAtUnixMs sql.NullInt64
 	CursorWorkflowID       string
 	CursorProjectDefault   sql.NullInt64
 	CursorProjectName      sql.NullString
@@ -7540,8 +7510,9 @@ type ListWorkflowRecordsPageRow struct {
 	ExecutionTargetCustomRef sql.NullString
 	CreatedAtUnixMs          int64
 	UpdatedAtUnixMs          int64
-	ActivityAtUnixMs         int64
-	ProjectLinkDefault       interface{}
+	GlobalActivityAtUnixMs   int64
+	ProjectActivityAtUnixMs  sql.NullInt64
+	ProjectLinkDefault       sql.NullInt64
 	ProjectNameOrderKey      string
 }
 
@@ -7573,7 +7544,8 @@ func (q *Queries) ListWorkflowRecordsPage(ctx context.Context, arg ListWorkflowR
 			&i.ExecutionTargetCustomRef,
 			&i.CreatedAtUnixMs,
 			&i.UpdatedAtUnixMs,
-			&i.ActivityAtUnixMs,
+			&i.GlobalActivityAtUnixMs,
+			&i.ProjectActivityAtUnixMs,
 			&i.ProjectLinkDefault,
 			&i.ProjectNameOrderKey,
 		); err != nil {
@@ -8025,9 +7997,39 @@ selected_rows AS (
       )
 ),
 matching_workflows AS (
-    SELECT workflow_id
-    FROM selected_rows
-    GROUP BY workflow_id
+    SELECT task_link.workflow_id
+    FROM args
+    CROSS JOIN project_workflow_links task_link
+    WHERE task_link.project_id = args.project_id
+      AND (args.workflow_id IS NULL OR task_link.workflow_id = args.workflow_id)
+      AND EXISTS (
+          SELECT 1
+          FROM tasks t INDEXED BY tasks_project_workflow_link_idx
+          JOIN workflow_task_status_records status ON status.task_id = t.id
+          LEFT JOIN column_facts ON column_facts.task_id = t.id
+          WHERE t.project_workflow_link_id = task_link.id
+            AND (
+                args.column_filter_set = 0
+                OR EXISTS (
+                    SELECT 1
+                    FROM json_each(args.column_keys_json) filter_key
+                    JOIN json_each(column_facts.column_keys_json) task_key ON task_key.value = filter_key.value
+                )
+            )
+            AND (
+                args.status_filter_set = 0
+                OR status.kind IN (SELECT value FROM json_each(args.status_kinds_json))
+            )
+            AND (
+                args.attention_filter_set = 0
+                OR EXISTS (
+                    SELECT 1
+                    FROM json_each(args.attention_kinds_json) filter_attention
+                    JOIN json_each(status.attention_types_json) task_attention ON task_attention.value = filter_attention.value
+                )
+            )
+          LIMIT 1
+      )
     LIMIT 2
 ),
 cursor_values AS (

--- a/server/metadata/sqlitegen/queries.sql.go
+++ b/server/metadata/sqlitegen/queries.sql.go
@@ -8004,30 +8004,8 @@ matching_workflows AS (
       AND (args.workflow_id IS NULL OR task_link.workflow_id = args.workflow_id)
       AND EXISTS (
           SELECT 1
-          FROM tasks t INDEXED BY tasks_project_workflow_link_idx
-          JOIN workflow_task_status_records status ON status.task_id = t.id
-          LEFT JOIN column_facts ON column_facts.task_id = t.id
-          WHERE t.project_workflow_link_id = task_link.id
-            AND (
-                args.column_filter_set = 0
-                OR EXISTS (
-                    SELECT 1
-                    FROM json_each(args.column_keys_json) filter_key
-                    JOIN json_each(column_facts.column_keys_json) task_key ON task_key.value = filter_key.value
-                )
-            )
-            AND (
-                args.status_filter_set = 0
-                OR status.kind IN (SELECT value FROM json_each(args.status_kinds_json))
-            )
-            AND (
-                args.attention_filter_set = 0
-                OR EXISTS (
-                    SELECT 1
-                    FROM json_each(args.attention_kinds_json) filter_attention
-                    JOIN json_each(status.attention_types_json) task_attention ON task_attention.value = filter_attention.value
-                )
-            )
+          FROM selected_rows eligible
+          WHERE eligible.project_workflow_link_id = task_link.id
           LIMIT 1
       )
     LIMIT 2

--- a/server/metadata/sqlitegen/query_program_test.go
+++ b/server/metadata/sqlitegen/query_program_test.go
@@ -22,6 +22,56 @@ type sqliteInstruction struct {
 
 func requireQueryUsesIndexWithoutSort(t *testing.T, db *sql.DB, query string, indexName string, args ...any) {
 	t.Helper()
+	instructions := queryProgram(t, db, query, args...)
+	requireQueryProgramOpensIndex(t, db, instructions, indexName)
+	for _, instruction := range instructions {
+		switch instruction.Opcode {
+		case sqliteOpcodeOpenEphemeral, sqliteOpcodeSorterOpen, sqliteOpcodeSort, sqliteOpcodeSorterSort:
+			t.Fatalf("query program opened a temporary sort structure: %+v", instructions)
+		}
+	}
+}
+
+func requireQueryUsesIndex(t *testing.T, db *sql.DB, query string, indexName string, args ...any) {
+	t.Helper()
+	requireQueryProgramOpensIndex(t, db, queryProgram(t, db, query, args...), indexName)
+}
+
+func requireQueryUsesAnyTableIndex(t *testing.T, db *sql.DB, query string, tableName string, args ...any) {
+	t.Helper()
+	instructions := queryProgram(t, db, query, args...)
+	rows, err := db.Query(
+		`SELECT rootpage FROM sqlite_schema WHERE type = 'index' AND tbl_name = ?`,
+		tableName,
+	)
+	if err != nil {
+		t.Fatalf("resolve indexes for table %q: %v", tableName, err)
+	}
+	defer rows.Close()
+	rootPages := map[int64]bool{}
+	for rows.Next() {
+		var rootPage int64
+		if err := rows.Scan(&rootPage); err != nil {
+			t.Fatalf("scan index root page for table %q: %v", tableName, err)
+		}
+		rootPages[rootPage] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate indexes for table %q: %v", tableName, err)
+	}
+	if len(rootPages) == 0 {
+		t.Fatalf("table %q has no indexes", tableName)
+	}
+	for _, instruction := range instructions {
+		if instruction.Opcode == sqliteOpcodeOpenRead && rootPages[instruction.P2] {
+			return
+		}
+	}
+	t.Fatalf("query program did not open an index for table %q at root pages %v: %+v", tableName, rootPages, instructions)
+}
+
+func queryProgram(t *testing.T, db *sql.DB, query string, args ...any) []sqliteInstruction {
+	t.Helper()
 	rows, err := db.Query("EXPLAIN "+query, args...)
 	if err != nil {
 		t.Fatalf("explain query program: %v", err)
@@ -40,7 +90,11 @@ func requireQueryUsesIndexWithoutSort(t *testing.T, db *sql.DB, query string, in
 	if err := rows.Err(); err != nil {
 		t.Fatalf("iterate query program: %v", err)
 	}
+	return instructions
+}
 
+func requireQueryProgramOpensIndex(t *testing.T, db *sql.DB, instructions []sqliteInstruction, indexName string) {
+	t.Helper()
 	var indexRootPage int64
 	if err := db.QueryRow(
 		`SELECT rootpage FROM sqlite_schema WHERE type = 'index' AND name = ?`,
@@ -52,10 +106,6 @@ func requireQueryUsesIndexWithoutSort(t *testing.T, db *sql.DB, query string, in
 	for _, instruction := range instructions {
 		if instruction.Opcode == sqliteOpcodeOpenRead && instruction.P2 == indexRootPage {
 			indexOpened = true
-		}
-		switch instruction.Opcode {
-		case sqliteOpcodeOpenEphemeral, sqliteOpcodeSorterOpen, sqliteOpcodeSort, sqliteOpcodeSorterSort:
-			t.Fatalf("query program opened a temporary sort structure: %+v", instructions)
 		}
 	}
 	if !indexOpened {

--- a/server/metadata/sqlitegen/query_program_test.go
+++ b/server/metadata/sqlitegen/query_program_test.go
@@ -47,7 +47,7 @@ func requireQueryUsesAnyTableIndex(t *testing.T, db *sql.DB, query string, table
 	if err != nil {
 		t.Fatalf("resolve indexes for table %q: %v", tableName, err)
 	}
-	defer rows.Close()
+	defer closeQueryRows(t, rows)
 	rootPages := map[int64]bool{}
 	for rows.Next() {
 		var rootPage int64
@@ -76,7 +76,7 @@ func queryProgram(t *testing.T, db *sql.DB, query string, args ...any) []sqliteI
 	if err != nil {
 		t.Fatalf("explain query program: %v", err)
 	}
-	defer rows.Close()
+	defer closeQueryRows(t, rows)
 	var instructions []sqliteInstruction
 	for rows.Next() {
 		var address, p1, p2, p3, p5 int64
@@ -91,6 +91,13 @@ func queryProgram(t *testing.T, db *sql.DB, query string, args ...any) []sqliteI
 		t.Fatalf("iterate query program: %v", err)
 	}
 	return instructions
+}
+
+func closeQueryRows(t *testing.T, rows *sql.Rows) {
+	t.Helper()
+	if err := rows.Close(); err != nil {
+		t.Fatalf("close query rows: %v", err)
+	}
 }
 
 func requireQueryProgramOpensIndex(t *testing.T, db *sql.DB, instructions []sqliteInstruction, indexName string) {

--- a/server/metadata/sqlitegen/task_list_query_plan_test.go
+++ b/server/metadata/sqlitegen/task_list_query_plan_test.go
@@ -135,4 +135,31 @@ CREATE TABLE task_run_records (
 	}
 	requireQueryUsesAnyTableIndex(t, db, listWorkflowTaskListRows, "project_workflow_links", args...)
 	requireQueryUsesIndex(t, db, listWorkflowTaskListRows, "tasks_project_workflow_link_idx", args...)
+	requireQueryPlanDoesNotGroupIntoTemporaryTree(t, db, listWorkflowTaskListRows, args...)
+}
+
+func requireQueryPlanDoesNotGroupIntoTemporaryTree(t *testing.T, db *sql.DB, query string, args ...any) {
+	t.Helper()
+	rows, err := db.Query("EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		t.Fatalf("explain query plan: %v", err)
+	}
+	defer rows.Close()
+	groupingStructures := 0
+	for rows.Next() {
+		var id, parent, unused int64
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		if detail == "USE TEMP B-TREE FOR GROUP BY" {
+			groupingStructures++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate query plan: %v", err)
+	}
+	if groupingStructures > 1 {
+		t.Fatalf("task-list cardinality introduced an extra unbounded grouping structure: count=%d", groupingStructures)
+	}
 }

--- a/server/metadata/sqlitegen/task_list_query_plan_test.go
+++ b/server/metadata/sqlitegen/task_list_query_plan_test.go
@@ -1,0 +1,138 @@
+package sqlitegen
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestListWorkflowTaskListRowsUsesProjectLinkAndTaskIndexes(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`
+CREATE TABLE workflows (
+	id TEXT PRIMARY KEY,
+	name TEXT NOT NULL
+);
+CREATE TABLE project_workflow_links (
+	id TEXT PRIMARY KEY,
+	project_id TEXT NOT NULL,
+	workflow_id TEXT NOT NULL,
+	UNIQUE (project_id, workflow_id)
+);
+CREATE TABLE tasks (
+	id TEXT PRIMARY KEY,
+	project_workflow_link_id TEXT NOT NULL,
+	workflow_revision_seen INTEGER NOT NULL,
+	task_seq INTEGER NOT NULL,
+	short_id TEXT NOT NULL,
+	title TEXT NOT NULL,
+	body TEXT NOT NULL,
+	source_url TEXT NOT NULL,
+	source_workspace_id TEXT,
+	managed_worktree_id TEXT,
+	execution_target_mode TEXT,
+	execution_target_requested_ref TEXT,
+	execution_target_resolved_ref TEXT,
+	execution_target_commit_oid TEXT,
+	execution_target_provenance TEXT,
+	canceled_at_unix_ms INTEGER,
+	cancellation_reason TEXT,
+	created_at_unix_ms INTEGER NOT NULL,
+	updated_at_unix_ms INTEGER NOT NULL,
+	metadata_json TEXT NOT NULL
+);
+CREATE INDEX tasks_project_workflow_link_idx
+	ON tasks(project_workflow_link_id);
+CREATE VIEW task_records AS
+SELECT
+	t.id,
+	pwl.project_id,
+	t.project_workflow_link_id,
+	pwl.workflow_id,
+	t.workflow_revision_seen,
+	t.task_seq,
+	t.short_id,
+	t.title,
+	t.body,
+	t.source_url,
+	t.source_workspace_id,
+	t.managed_worktree_id,
+	t.execution_target_mode,
+	t.execution_target_requested_ref,
+	t.execution_target_resolved_ref,
+	t.execution_target_commit_oid,
+	t.execution_target_provenance,
+	t.canceled_at_unix_ms,
+	t.cancellation_reason,
+	t.created_at_unix_ms,
+	t.updated_at_unix_ms,
+	t.metadata_json
+FROM tasks t
+JOIN project_workflow_links pwl ON pwl.id = t.project_workflow_link_id;
+CREATE TABLE workflow_task_status_records (
+	task_id TEXT PRIMARY KEY,
+	kind TEXT NOT NULL,
+	primary_status_rank INTEGER NOT NULL,
+	node_ids_json TEXT NOT NULL,
+	run_ids_json TEXT NOT NULL,
+	attention_types_json TEXT NOT NULL
+);
+CREATE TABLE task_node_placements (
+	task_id TEXT NOT NULL,
+	node_id TEXT,
+	state TEXT NOT NULL
+);
+CREATE TABLE workflow_nodes (
+	id TEXT PRIMARY KEY,
+	kind TEXT NOT NULL
+);
+CREATE TABLE task_transition_records (
+	task_id TEXT NOT NULL,
+	source_node_id TEXT,
+	state TEXT NOT NULL
+);
+CREATE TABLE task_run_records (
+	task_id TEXT NOT NULL
+);`); err != nil {
+		t.Fatalf("create query-plan fixture: %v", err)
+	}
+
+	args := []any{
+		"project-1",
+		nil,
+		nil,
+		nil,
+		int64(0),
+		nil,
+		nil,
+		"[]",
+		int64(0),
+		"[]",
+		int64(0),
+		int64(0),
+		int64(0),
+		int64(0),
+		int64(0),
+		int64(0),
+		"",
+		"",
+		"updated",
+		int64(1),
+		"title",
+		int64(0),
+		"",
+		int64(0),
+		"",
+		int64(0),
+		"",
+		int64(0),
+		int64(101),
+	}
+	requireQueryUsesAnyTableIndex(t, db, listWorkflowTaskListRows, "project_workflow_links", args...)
+	requireQueryUsesIndex(t, db, listWorkflowTaskListRows, "tasks_project_workflow_link_idx", args...)
+}

--- a/server/metadata/sqlitegen/task_list_query_plan_test.go
+++ b/server/metadata/sqlitegen/task_list_query_plan_test.go
@@ -155,6 +155,9 @@ func requireQueryPlanDoesNotGroupIntoTemporaryTree(t *testing.T, db *sql.DB, que
 		if detail == "USE TEMP B-TREE FOR GROUP BY" {
 			groupingStructures++
 		}
+		if detail == "MATERIALIZE selected_rows" {
+			t.Fatalf("task-list eligibility authority was materialized before pagination")
+		}
 	}
 	if err := rows.Err(); err != nil {
 		t.Fatalf("iterate query plan: %v", err)

--- a/server/metadata/sqlitegen/task_list_query_plan_test.go
+++ b/server/metadata/sqlitegen/task_list_query_plan_test.go
@@ -144,7 +144,7 @@ func requireQueryPlanDoesNotGroupIntoTemporaryTree(t *testing.T, db *sql.DB, que
 	if err != nil {
 		t.Fatalf("explain query plan: %v", err)
 	}
-	defer rows.Close()
+	defer closeQueryRows(t, rows)
 	groupingStructures := 0
 	for rows.Next() {
 		var id, parent, unused int64

--- a/server/onboardingimports/imports.go
+++ b/server/onboardingimports/imports.go
@@ -13,6 +13,7 @@ import (
 
 	"core/server/skillcatalog"
 	brand "core/shared/config"
+	"core/shared/textutil"
 )
 
 type ProviderID string
@@ -561,22 +562,11 @@ func itemKindPointer(value ItemKind) *ItemKind {
 }
 
 func choiceRefEqual(left, right ChoiceRef) bool {
-	return left.Mode == right.Mode && ptrEqual(left.ProviderID, right.ProviderID) && ptrStringEqual(left.SourceRoot, right.SourceRoot)
+	return left.Mode == right.Mode && textutil.EqualOptional(left.ProviderID, right.ProviderID) && textutil.EqualOptional(left.SourceRoot, right.SourceRoot)
 }
 
 func choiceItemEqual(left, right ItemRef) bool {
-	return left.ItemKind == right.ItemKind && left.SourceKind == right.SourceKind && ptrEqual(left.ProviderID, right.ProviderID) && ptrStringEqual(left.SourcePath, right.SourcePath)
-}
-
-func ptrEqual[T comparable](left, right *T) bool {
-	if left == nil || right == nil {
-		return left == right
-	}
-	return *left == *right
-}
-
-func ptrStringEqual(left, right *string) bool {
-	return ptrEqual(left, right)
+	return left.ItemKind == right.ItemKind && left.SourceKind == right.SourceKind && textutil.EqualOptional(left.ProviderID, right.ProviderID) && textutil.EqualOptional(left.SourcePath, right.SourcePath)
 }
 
 func providerRank(provider ProviderID) int {

--- a/server/runtime/tool_executor_batch_test.go
+++ b/server/runtime/tool_executor_batch_test.go
@@ -7,6 +7,7 @@ import (
 
 	"core/server/llm"
 	"core/server/tools"
+	"core/shared/textutil"
 	"core/shared/toolspec"
 	"core/shared/transcript"
 )
@@ -200,18 +201,11 @@ func TestToolResultWithTranscriptPresentationKeepsTypedInput(t *testing.T) {
 			if result.Presentation.MovedToBackground != tt.wantMovedToBackground {
 				t.Fatalf("backgrounded = %t, want %t", result.Presentation.MovedToBackground, tt.wantMovedToBackground)
 			}
-			if !optionalIntEqual(result.Presentation.ShellExitCode, tt.wantShellExitCode) {
+			if !textutil.EqualOptional(result.Presentation.ShellExitCode, tt.wantShellExitCode) {
 				t.Fatalf("shell exit code = %v, want %v", result.Presentation.ShellExitCode, tt.wantShellExitCode)
 			}
 		})
 	}
-}
-
-func optionalIntEqual(left, right *int) bool {
-	if left == nil || right == nil {
-		return left == right
-	}
-	return *left == *right
 }
 
 func TestLiveToolCompletionBoundaryRejectsHandlerFinalizedPresentation(t *testing.T) {

--- a/server/session/sessiontest/sessiontest.go
+++ b/server/session/sessiontest/sessiontest.go
@@ -110,14 +110,6 @@ func AgentRole(value string) *string {
 	return &value
 }
 
-// SameAgentRole compares optional continuation agent-role fixtures. Test-only.
-func SameAgentRole(left, right *string) bool {
-	if left == nil || right == nil {
-		return left == nil && right == nil
-	}
-	return *left == *right
-}
-
 // Snapshot mirrors the durable session state a test commonly asserts against:
 // metadata, the full event history, and conversation freshness.
 type Snapshot struct {

--- a/server/session/worktree_context.go
+++ b/server/session/worktree_context.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"strings"
 
+	"core/shared/textutil"
+
 	"github.com/google/uuid"
 )
 
@@ -82,8 +84,8 @@ func CloneWorktreeReminderState(state *WorktreeReminderState) *WorktreeReminderS
 }
 
 func WorktreeContextEqual(left, right WorktreeContext) bool {
-	return optionalUUIDEqual(left.ContextID, right.ContextID) &&
-		optionalStringEqual(left.Branch, right.Branch) &&
+	return textutil.EqualOptional(left.ContextID, right.ContextID) &&
+		textutil.EqualOptional(left.Branch, right.Branch) &&
 		left.WorktreePath == right.WorktreePath &&
 		left.WorkspaceRoot == right.WorkspaceRoot &&
 		left.EffectiveCwd == right.EffectiveCwd
@@ -97,20 +99,6 @@ func WorktreeReminderTargetEqual(left, right WorktreeReminderState) bool {
 
 func WorktreeReminderStateEqual(left, right WorktreeReminderState) bool {
 	return left.Mode == right.Mode && WorktreeContextEqual(left.WorktreeContext, right.WorktreeContext)
-}
-
-func optionalUUIDEqual(left, right *uuid.UUID) bool {
-	if left == nil || right == nil {
-		return left == right
-	}
-	return *left == *right
-}
-
-func optionalStringEqual(left, right *string) bool {
-	if left == nil || right == nil {
-		return left == right
-	}
-	return *left == *right
 }
 
 func cloneUUID(value *uuid.UUID) *uuid.UUID {

--- a/server/transport/gateway_part3_test.go
+++ b/server/transport/gateway_part3_test.go
@@ -293,7 +293,7 @@ func TestDecodeAndHandlePreservesWorkflowTaskListScopeError(t *testing.T) {
 }
 
 func TestDecodeAndHandlePreservesWorkflowTaskCreateSelectionError(t *testing.T) {
-	workflowID := "workflow-1"
+	workflowID := "workflow-7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
 	source := &serverapi.WorkflowTaskCreateSelectionError{
 		Reason:     serverapi.WorkflowTaskCreateSelectionReasonWorkflowNotLinked,
 		ProjectID:  "project-1",

--- a/server/transport/gateway_part3_test.go
+++ b/server/transport/gateway_part3_test.go
@@ -271,12 +271,11 @@ func TestGatewayRunPromptRejectsMixedTypedAndLegacyLaunchFields(t *testing.T) {
 
 func TestDecodeAndHandlePreservesWorkflowTaskListScopeError(t *testing.T) {
 	projectID := "project-1"
-	missing := serverapi.WorkflowTaskListScopeDimensionWorkflow
+	workflowID := "workflow-7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
 	source := &serverapi.WorkflowTaskListScopeError{
-		Kind:         serverapi.WorkflowTaskListScopeErrorKindAmbiguous,
-		MissingScope: &missing,
-		ProjectIDs:   []string{projectID},
-		WorkflowIDs:  []string{"workflow-1", "workflow-2"},
+		Reason:     serverapi.WorkflowTaskListScopeReasonWorkflowNotLinked,
+		ProjectID:  &projectID,
+		WorkflowID: &workflowID,
 	}
 	response := decodeAndHandle[serverapi.WorkflowTaskListRequest, struct{}](
 		protocol.Request{ID: "scope-error", Params: mustJSON(t, serverapi.WorkflowTaskListRequest{ProjectID: &projectID})},
@@ -288,8 +287,53 @@ func TestDecodeAndHandlePreservesWorkflowTaskListScopeError(t *testing.T) {
 		t.Fatalf("response error = %+v, want task-list scope code", response.Error)
 	}
 	decoded, ok := serverapi.DecodeWorkflowTaskListScopeError(response.Error.Data, response.Error.Message).(*serverapi.WorkflowTaskListScopeError)
-	if !ok || decoded.Kind != source.Kind || decoded.MissingScope == nil || *decoded.MissingScope != missing || len(decoded.WorkflowIDs) != 2 {
+	if !ok || decoded.Reason != source.Reason || decoded.ProjectID == nil || *decoded.ProjectID != projectID || decoded.WorkflowID == nil || *decoded.WorkflowID != workflowID {
 		t.Fatalf("decoded scope error = %+v, want %+v", decoded, source)
+	}
+}
+
+func TestDecodeAndHandlePreservesWorkflowTaskCreateSelectionError(t *testing.T) {
+	workflowID := "workflow-1"
+	source := &serverapi.WorkflowTaskCreateSelectionError{
+		Reason:     serverapi.WorkflowTaskCreateSelectionReasonWorkflowNotLinked,
+		ProjectID:  "project-1",
+		WorkflowID: &workflowID,
+	}
+	response := decodeAndHandle[serverapi.WorkflowTaskCreateRequest, struct{}](
+		protocol.Request{ID: "selection-error", Params: mustJSON(t, serverapi.WorkflowTaskCreateRequest{ProjectID: "project-1", Title: "Task"})},
+		func(serverapi.WorkflowTaskCreateRequest) (struct{}, error) {
+			return struct{}{}, source
+		},
+	)
+	if response.Error == nil || response.Error.Code != protocol.ErrCodeWorkflowTaskCreateSelection {
+		t.Fatalf("response error = %+v, want task-create selection code", response.Error)
+	}
+	decoded, ok := serverapi.DecodeWorkflowTaskCreateSelectionError(response.Error.Data, response.Error.Message).(*serverapi.WorkflowTaskCreateSelectionError)
+	if !ok ||
+		decoded.Reason != source.Reason ||
+		decoded.ProjectID != source.ProjectID ||
+		decoded.WorkflowID == nil ||
+		*decoded.WorkflowID != *source.WorkflowID {
+		t.Fatalf("decoded selection error = %+v, want %+v", decoded, source)
+	}
+}
+
+func TestDecodeAndHandlePreservesWorkflowTaskCreateConflictError(t *testing.T) {
+	source := &serverapi.WorkflowTaskCreateConflictError{
+		Reason: serverapi.WorkflowTaskCreateConflictReasonSerialization,
+	}
+	response := decodeAndHandle[serverapi.WorkflowTaskCreateRequest, struct{}](
+		protocol.Request{ID: "create-conflict", Params: mustJSON(t, serverapi.WorkflowTaskCreateRequest{ProjectID: "project-1", Title: "Task"})},
+		func(serverapi.WorkflowTaskCreateRequest) (struct{}, error) {
+			return struct{}{}, source
+		},
+	)
+	if response.Error == nil || response.Error.Code != protocol.ErrCodeWorkflowTaskCreateConflict {
+		t.Fatalf("response error = %+v, want task-create conflict code", response.Error)
+	}
+	decoded, ok := serverapi.DecodeWorkflowTaskCreateConflictError(response.Error.Data, response.Error.Message).(*serverapi.WorkflowTaskCreateConflictError)
+	if !ok || decoded.Reason != source.Reason {
+		t.Fatalf("decoded conflict error = %+v, want %+v", decoded, source)
 	}
 }
 

--- a/server/transport/gateway_test.go
+++ b/server/transport/gateway_test.go
@@ -485,6 +485,19 @@ func TestGatewayHandshakeRejectsProtocolVersionMismatch(t *testing.T) {
 	}
 }
 
+func TestGatewayHandshakeRejectsPreviousProtocolGeneration(t *testing.T) {
+	_, server := newGatewayTestServer(t)
+	defer server.Close()
+
+	conn := dialGateway(t, server)
+	defer func() { _ = conn.Close() }()
+
+	respErr := callGatewayExpectError(t, conn, "1", protocol.MethodHandshake, protocol.HandshakeRequest{ProtocolVersion: "62"})
+	if respErr.Code != protocol.ErrCodeProtocolVersionMismatch {
+		t.Fatalf("expected previous protocol generation rejection, got %+v", respErr)
+	}
+}
+
 func TestGatewayRejectsMethodsBeforeHandshake(t *testing.T) {
 	_, server := newGatewayTestServer(t)
 	defer server.Close()

--- a/server/workflowrunner/starter_test.go
+++ b/server/workflowrunner/starter_test.go
@@ -38,6 +38,7 @@ import (
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
 	"core/shared/sessioncontract"
+	"core/shared/textutil"
 	"core/shared/toolspec"
 )
 
@@ -1211,7 +1212,7 @@ func TestWorkflowRuntimeCompactAndContinueAllowsCrossRole(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open source session: %v", err)
 	}
-	if got := sourceStore.Meta().Continuation; got == nil || !sessiontest.SameAgentRole(got.AgentRole, sessiontest.AgentRole("reviewer")) {
+	if got := sourceStore.Meta().Continuation; got == nil || !textutil.EqualOptional(got.AgentRole, sessiontest.AgentRole("reviewer")) {
 		t.Fatalf("continuation role = %+v, want reviewer", got)
 	}
 	if got := sourceStore.Meta().PromptCacheLineageGeneration; got != 1 {
@@ -1396,7 +1397,7 @@ func TestWorkflowRuntimeLockedBaseSessionAcceptsTargetRole(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open source session: %v", err)
 	}
-	if got := reopened.Meta().Continuation; got == nil || !sessiontest.SameAgentRole(got.AgentRole, sessiontest.AgentRole("coder")) {
+	if got := reopened.Meta().Continuation; got == nil || !textutil.EqualOptional(got.AgentRole, sessiontest.AgentRole("coder")) {
 		t.Fatalf("continuation = %+v, want coder role persisted", got)
 	}
 }

--- a/server/workflowstore/deletion_test.go
+++ b/server/workflowstore/deletion_test.go
@@ -51,14 +51,14 @@ func TestTaskCreateAllowsInvalidWorkflowBacklogButRejectsUnlinkedWorkflow(t *tes
 	}
 	valid := createValidWorkflow(t, ctx, store)
 	linkWorkflow(t, ctx, store, binding.ProjectID, valid, false)
-	if task := createTask(t, ctx, store, CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: valid, Title: "Explicit", Body: "Body"}); !strings.HasPrefix(task.ShortID, "WOR-2") {
+	if task := createTask(t, ctx, store, CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: &valid, Title: "Explicit", Body: "Body"}); !strings.HasPrefix(task.ShortID, "WOR-2") {
 		t.Fatalf("explicit task short id = %q, want WOR-2", task.ShortID)
 	}
 	unlinked, err := store.CreateWorkflow(ctx, CreateWorkflowRequest{Name: "Unlinked"})
 	if err != nil {
 		t.Fatalf("CreateWorkflow unlinked: %v", err)
 	}
-	if _, err := store.CreateTask(ctx, CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: unlinked.ID, Title: "Task", Body: "Body"}); err == nil {
+	if _, err := store.CreateTask(ctx, CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: &unlinked.ID, Title: "Task", Body: "Body"}); err == nil {
 		t.Fatalf("expected unlinked workflow task creation to fail")
 	}
 }
@@ -235,7 +235,7 @@ func TestWorkflowDeleteBlocksDefaultReplacementAndDetectsImpactChanges(t *testin
 
 	staleWorkflowID, _ := f.linkedWorkflow(t, false)
 	staleImpact := f.preview(t, staleWorkflowID)
-	createTask(t, f.ctx, f.store, CreateTaskRequest{ProjectID: f.projectID, WorkflowID: staleWorkflowID, Title: "Stale", Body: "Body"})
+	createTask(t, f.ctx, f.store, CreateTaskRequest{ProjectID: f.projectID, WorkflowID: &staleWorkflowID, Title: "Stale", Body: "Body"})
 	staleDelete := f.confirmDelete(t, staleImpact, false)
 	if staleDelete.Deleted || !hasWorkflowDeleteBlocker(staleDelete.Blockers, "impact_changed", 1) || staleDelete.Impact.TaskCount != 1 {
 		t.Fatalf("stale delete result = %+v, want impact_changed with refreshed task count", staleDelete)

--- a/server/workflowstore/errors.go
+++ b/server/workflowstore/errors.go
@@ -6,7 +6,62 @@ import (
 	"strings"
 
 	"core/server/workflow"
+	sqlitedriver "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
 )
+
+type TaskWorkflowSelectionReason string
+
+const (
+	TaskWorkflowSelectionNoLinkedWorkflows       TaskWorkflowSelectionReason = "no_linked_workflows"
+	TaskWorkflowSelectionAmbiguousWithoutDefault TaskWorkflowSelectionReason = "ambiguous_without_default"
+	TaskWorkflowSelectionWorkflowNotLinked       TaskWorkflowSelectionReason = "workflow_not_linked"
+)
+
+type TaskWorkflowSelectionError struct {
+	Reason     TaskWorkflowSelectionReason
+	ProjectID  string
+	WorkflowID *workflow.WorkflowID
+}
+
+func (e TaskWorkflowSelectionError) Error() string {
+	return fmt.Sprintf("task workflow selection failed for project %q: %s", e.ProjectID, e.Reason)
+}
+
+type TaskCreateConflictReason string
+
+const (
+	TaskCreateConflictSerialization TaskCreateConflictReason = "serialization_conflict"
+)
+
+type TaskCreateConflictError struct {
+	Reason TaskCreateConflictReason
+	Cause  error
+}
+
+func (e TaskCreateConflictError) Error() string {
+	return fmt.Sprintf("task create conflict: %s", e.Reason)
+}
+
+func (e TaskCreateConflictError) Unwrap() error {
+	return e.Cause
+}
+
+func taskCreateStoreError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var sqliteErr *sqlitedriver.Error
+	if !errors.As(err, &sqliteErr) {
+		return err
+	}
+	switch sqliteErr.Code() & 0xff {
+	case sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED:
+		return TaskCreateConflictError{Reason: TaskCreateConflictSerialization, Cause: err}
+	default:
+		return err
+	}
+}
 
 // Sentinel errors returned by the workflow store. Callers (including tests)
 // must match these with errors.Is/errors.As rather than comparing the rendered

--- a/server/workflowstore/graph_test.go
+++ b/server/workflowstore/graph_test.go
@@ -385,13 +385,17 @@ func TestWorkflowListPageTokenRejectsMalformedOptionalScope(t *testing.T) {
 	projectName := "workflow"
 	validProjectID := "project-1"
 	validFilterWorkflowID := "workflow-8e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
+	activityAtUnixMs := int64(1)
 	base := workflowListPageTokenPayload{
-		Version:           2,
-		ActivityAtUnixMs:  1,
+		Version:           workflowListPageTokenVersion,
+		ActivityAtUnixMs:  &activityAtUnixMs,
 		WorkflowID:        cursorWorkflowID,
 		FilterFingerprint: "fingerprint",
 	}
 	for name, mutate := range map[string]func(*workflowListPageTokenPayload){
+		"global missing activity": func(payload *workflowListPageTokenPayload) {
+			payload.ActivityAtUnixMs = nil
+		},
 		"malformed cursor workflow": func(payload *workflowListPageTokenPayload) {
 			payload.WorkflowID = "workflow-1"
 		},
@@ -462,6 +466,15 @@ func TestWorkflowListPageTokenRejectsMalformedOptionalScope(t *testing.T) {
 	}
 	if _, err := parseWorkflowListPageToken(base64.RawURLEncoding.EncodeToString(encoded)); err != nil {
 		t.Fatalf("parseWorkflowListPageToken rejected valid optional scope: %v", err)
+	}
+
+	valid.ActivityAtUnixMs = nil
+	encoded, err = json.Marshal(valid)
+	if err != nil {
+		t.Fatalf("marshal valid project token without activity: %v", err)
+	}
+	if _, err := parseWorkflowListPageToken(base64.RawURLEncoding.EncodeToString(encoded)); err != nil {
+		t.Fatalf("parseWorkflowListPageToken rejected absent project activity: %v", err)
 	}
 }
 
@@ -557,6 +570,68 @@ func TestWorkflowListProjectScopeUsesSQLiteUnicodeOrderKeyAcrossPages(t *testing
 	}
 	if len(second.Workflows) != 1 || second.Workflows[0].ID == first.Workflows[0].ID {
 		t.Fatalf("paginated workflows first=%+v second=%+v, want distinct complete rows", first.Workflows, second.Workflows)
+	}
+}
+
+func TestWorkflowListProjectScopePreservesAbsentActivityAfterEpoch(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	created := map[string]WorkflowRecord{}
+	for _, name := range []string{"Epoch", "Alpha", "Beta"} {
+		record, err := store.CreateWorkflow(ctx, CreateWorkflowRequest{Name: name})
+		if err != nil {
+			t.Fatalf("CreateWorkflow %q: %v", name, err)
+		}
+		linkWorkflow(t, ctx, store, binding.ProjectID, record.ID, false)
+		created[name] = record
+	}
+	epochWorkflowID := created["Epoch"].ID
+	task := createTask(t, ctx, store, CreateTaskRequest{
+		ProjectID:  binding.ProjectID,
+		WorkflowID: &epochWorkflowID,
+		Title:      "Epoch activity",
+		Body:       "Body",
+	})
+	if _, err := store.db.ExecContext(ctx, `UPDATE tasks SET updated_at_unix_ms = 0 WHERE id = ?`, string(task.ID)); err != nil {
+		t.Fatalf("force epoch task timestamp: %v", err)
+	}
+
+	projectID := binding.ProjectID
+	first, err := store.ListWorkflows(ctx, ListWorkflowsRequest{ProjectID: &projectID, PageSize: 1})
+	if err != nil {
+		t.Fatalf("ListWorkflows first page: %v", err)
+	}
+	if len(first.Workflows) != 1 || first.Workflows[0].ID != epochWorkflowID || first.NextPageToken == "" {
+		t.Fatalf("first page = %+v, want epoch activity workflow and continuation", first)
+	}
+	firstCursor, err := parseWorkflowListPageToken(first.NextPageToken)
+	if err != nil {
+		t.Fatalf("parse first page token: %v", err)
+	}
+	if firstCursor.activityAtUnixMs == nil || *firstCursor.activityAtUnixMs != 0 {
+		t.Fatalf("first cursor activity = %v, want present Unix epoch", firstCursor.activityAtUnixMs)
+	}
+
+	second, err := store.ListWorkflows(ctx, ListWorkflowsRequest{PageToken: first.NextPageToken, PageSize: 1})
+	if err != nil {
+		t.Fatalf("ListWorkflows second page: %v", err)
+	}
+	if len(second.Workflows) != 1 || second.Workflows[0].ID != created["Alpha"].ID || second.NextPageToken == "" {
+		t.Fatalf("second page = %+v, want alpha no-activity workflow and continuation", second)
+	}
+	secondCursor, err := parseWorkflowListPageToken(second.NextPageToken)
+	if err != nil {
+		t.Fatalf("parse second page token: %v", err)
+	}
+	if secondCursor.activityAtUnixMs != nil {
+		t.Fatalf("second cursor activity = %v, want typed absence", secondCursor.activityAtUnixMs)
+	}
+
+	third, err := store.ListWorkflows(ctx, ListWorkflowsRequest{PageToken: second.NextPageToken, PageSize: 1})
+	if err != nil {
+		t.Fatalf("ListWorkflows third page: %v", err)
+	}
+	if len(third.Workflows) != 1 || third.Workflows[0].ID != created["Beta"].ID || third.NextPageToken != "" {
+		t.Fatalf("third page = %+v, want beta final row", third)
 	}
 }
 

--- a/server/workflowstore/graph_test.go
+++ b/server/workflowstore/graph_test.go
@@ -379,6 +379,31 @@ func TestWorkflowListPaginatesWithMostRecentOrderAndFilters(t *testing.T) {
 	}
 }
 
+func TestWorkflowListRejectsInvalidPresentScopes(t *testing.T) {
+	ctx, store, _ := newTestStoreContext(t)
+	validProjectID := "project-1"
+	paddedProjectID := " project-1 "
+	blankProjectID := " "
+	malformedWorkflowID := workflow.WorkflowID("workflow-1")
+	paddedWorkflowID := workflow.WorkflowID(" workflow-7e8d24d2-8a98-4dcf-a197-6214db1cb3c0 ")
+	tests := []struct {
+		name string
+		req  ListWorkflowsRequest
+	}{
+		{name: "blank project", req: ListWorkflowsRequest{ProjectID: &blankProjectID}},
+		{name: "padded project", req: ListWorkflowsRequest{ProjectID: &paddedProjectID}},
+		{name: "malformed workflow", req: ListWorkflowsRequest{ProjectID: &validProjectID, WorkflowID: &malformedWorkflowID}},
+		{name: "padded workflow", req: ListWorkflowsRequest{ProjectID: &validProjectID, WorkflowID: &paddedWorkflowID}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := store.ListWorkflows(ctx, test.req); err == nil {
+				t.Fatalf("ListWorkflows accepted invalid scope: %+v", test.req)
+			}
+		})
+	}
+}
+
 func TestWorkflowListPageTokenRejectsMalformedOptionalScope(t *testing.T) {
 	const cursorWorkflowID = "workflow-7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
 	projectDefault := int64(0)

--- a/server/workflowstore/graph_test.go
+++ b/server/workflowstore/graph_test.go
@@ -2,6 +2,8 @@ package workflowstore
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -339,7 +341,8 @@ func TestWorkflowListPaginatesWithMostRecentOrderAndFilters(t *testing.T) {
 	if len(filtered.Workflows) != 1 || filtered.Workflows[0].ID != created["Beta Searchable"] {
 		t.Fatalf("filtered = %+v", filtered.Workflows)
 	}
-	exact, err := store.ListWorkflows(ctx, ListWorkflowsRequest{PageSize: 10, ExactName: "Beta"})
+	exactWorkflowID := created["Beta"]
+	exact, err := store.ListWorkflows(ctx, ListWorkflowsRequest{PageSize: 10, WorkflowID: &exactWorkflowID})
 	if err != nil {
 		t.Fatalf("ListWorkflows exact: %v", err)
 	}
@@ -373,6 +376,143 @@ func TestWorkflowListPaginatesWithMostRecentOrderAndFilters(t *testing.T) {
 	}
 	if filteredPage2.Workflows[0].ID != created["Beta"] {
 		t.Fatalf("filtered page2 order = %+v", filteredPage2.Workflows)
+	}
+}
+
+func TestWorkflowListPageTokenRejectsMalformedOptionalScope(t *testing.T) {
+	const cursorWorkflowID = "workflow-7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
+	projectDefault := int64(0)
+	projectName := "workflow"
+	validProjectID := "project-1"
+	validFilterWorkflowID := "workflow-8e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
+	base := workflowListPageTokenPayload{
+		Version:           2,
+		ActivityAtUnixMs:  1,
+		WorkflowID:        cursorWorkflowID,
+		FilterFingerprint: "fingerprint",
+	}
+	for name, mutate := range map[string]func(*workflowListPageTokenPayload){
+		"malformed cursor workflow": func(payload *workflowListPageTokenPayload) {
+			payload.WorkflowID = "workflow-1"
+		},
+		"blank project": func(payload *workflowListPageTokenPayload) {
+			value := ""
+			payload.ProjectID = &value
+			payload.ProjectDefault = &projectDefault
+			payload.ProjectName = &projectName
+		},
+		"padded project": func(payload *workflowListPageTokenPayload) {
+			value := " project-1"
+			payload.ProjectID = &value
+			payload.ProjectDefault = &projectDefault
+			payload.ProjectName = &projectName
+		},
+		"blank exact workflow filter": func(payload *workflowListPageTokenPayload) {
+			value := ""
+			payload.FilterWorkflowID = &value
+		},
+		"padded exact workflow filter": func(payload *workflowListPageTokenPayload) {
+			value := " " + validFilterWorkflowID
+			payload.FilterWorkflowID = &value
+		},
+		"malformed exact workflow filter": func(payload *workflowListPageTokenPayload) {
+			value := "workflow-1"
+			payload.FilterWorkflowID = &value
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			payload := base
+			mutate(&payload)
+			encoded, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("marshal token payload: %v", err)
+			}
+			if _, err := parseWorkflowListPageToken(base64.RawURLEncoding.EncodeToString(encoded)); err == nil {
+				t.Fatalf("parseWorkflowListPageToken accepted %s", name)
+			}
+		})
+	}
+
+	valid := base
+	valid.ProjectID = &validProjectID
+	valid.ProjectDefault = &projectDefault
+	valid.ProjectName = &projectName
+	valid.FilterWorkflowID = &validFilterWorkflowID
+	encoded, err := json.Marshal(valid)
+	if err != nil {
+		t.Fatalf("marshal valid token payload: %v", err)
+	}
+	if _, err := parseWorkflowListPageToken(base64.RawURLEncoding.EncodeToString(encoded)); err != nil {
+		t.Fatalf("parseWorkflowListPageToken rejected valid optional scope: %v", err)
+	}
+}
+
+func TestWorkflowListProjectScopeOrdersDefaultActivityAndName(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	defaultWorkflow, err := store.CreateWorkflow(ctx, CreateWorkflowRequest{Name: "Default"})
+	if err != nil {
+		t.Fatalf("CreateWorkflow default: %v", err)
+	}
+	activeWorkflow, err := store.CreateWorkflow(ctx, CreateWorkflowRequest{Name: "Zulu Active"})
+	if err != nil {
+		t.Fatalf("CreateWorkflow active: %v", err)
+	}
+	alphaWorkflow, err := store.CreateWorkflow(ctx, CreateWorkflowRequest{Name: "Alpha"})
+	if err != nil {
+		t.Fatalf("CreateWorkflow alpha: %v", err)
+	}
+	unlinkedWorkflow, err := store.CreateWorkflow(ctx, CreateWorkflowRequest{Name: "Unlinked"})
+	if err != nil {
+		t.Fatalf("CreateWorkflow unlinked: %v", err)
+	}
+	linkWorkflow(t, ctx, store, binding.ProjectID, defaultWorkflow.ID, true)
+	linkWorkflow(t, ctx, store, binding.ProjectID, activeWorkflow.ID, false)
+	linkWorkflow(t, ctx, store, binding.ProjectID, alphaWorkflow.ID, false)
+	task := createTask(t, ctx, store, CreateTaskRequest{
+		ProjectID:  binding.ProjectID,
+		WorkflowID: &activeWorkflow.ID,
+		Title:      "Active",
+		Body:       "Body",
+	})
+	for _, workflowID := range []workflow.WorkflowID{defaultWorkflow.ID, activeWorkflow.ID, alphaWorkflow.ID, unlinkedWorkflow.ID} {
+		if _, err := store.db.ExecContext(ctx, `UPDATE workflows SET updated_at_unix_ms = 10 WHERE id = ?`, string(workflowID)); err != nil {
+			t.Fatalf("force workflow timestamp: %v", err)
+		}
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE tasks SET updated_at_unix_ms = 100 WHERE id = ?`, string(task.ID)); err != nil {
+		t.Fatalf("force task timestamp: %v", err)
+	}
+
+	projectID := binding.ProjectID
+	page1, err := store.ListWorkflows(ctx, ListWorkflowsRequest{ProjectID: &projectID, PageSize: 2})
+	if err != nil {
+		t.Fatalf("ListWorkflows project page1: %v", err)
+	}
+	if len(page1.Workflows) != 2 || page1.NextPageToken == "" {
+		t.Fatalf("project page1 = %+v, want two workflows and token", page1)
+	}
+	if page1.Workflows[0].ID != defaultWorkflow.ID || page1.Workflows[0].ProjectLink == nil || !page1.Workflows[0].ProjectLink.Default {
+		t.Fatalf("project default row = %+v", page1.Workflows[0])
+	}
+	if page1.Workflows[1].ID != activeWorkflow.ID || page1.Workflows[1].ProjectLink == nil || page1.Workflows[1].ProjectLink.Default {
+		t.Fatalf("project active row = %+v", page1.Workflows[1])
+	}
+	page2, err := store.ListWorkflows(ctx, ListWorkflowsRequest{PageToken: page1.NextPageToken})
+	if err != nil {
+		t.Fatalf("ListWorkflows restored project page2: %v", err)
+	}
+	if len(page2.Workflows) != 1 || page2.Workflows[0].ID != alphaWorkflow.ID || page2.NextPageToken != "" {
+		t.Fatalf("project page2 = %+v, want alpha final row", page2)
+	}
+	for _, record := range append(page1.Workflows, page2.Workflows...) {
+		if record.ID == unlinkedWorkflow.ID {
+			t.Fatalf("project discovery included unlinked workflow: %+v", record)
+		}
+	}
+
+	otherProject := "project-other"
+	if _, err := store.ListWorkflows(ctx, ListWorkflowsRequest{ProjectID: &otherProject, PageToken: page1.NextPageToken}); err == nil {
+		t.Fatal("project cursor accepted conflicting project filter")
 	}
 }
 

--- a/server/workflowstore/graph_test.go
+++ b/server/workflowstore/graph_test.go
@@ -407,6 +407,24 @@ func TestWorkflowListPageTokenRejectsMalformedOptionalScope(t *testing.T) {
 			payload.ProjectDefault = &projectDefault
 			payload.ProjectName = &projectName
 		},
+		"padded project name": func(payload *workflowListPageTokenPayload) {
+			payload.ProjectID = &validProjectID
+			payload.ProjectDefault = &projectDefault
+			value := " workflow"
+			payload.ProjectName = &value
+		},
+		"non-canonical project name": func(payload *workflowListPageTokenPayload) {
+			payload.ProjectID = &validProjectID
+			payload.ProjectDefault = &projectDefault
+			value := "Workflow"
+			payload.ProjectName = &value
+		},
+		"padded search query": func(payload *workflowListPageTokenPayload) {
+			payload.SearchQuery = " workflow "
+		},
+		"non-canonical search query": func(payload *workflowListPageTokenPayload) {
+			payload.SearchQuery = "Workflow"
+		},
 		"blank exact workflow filter": func(payload *workflowListPageTokenPayload) {
 			value := ""
 			payload.FilterWorkflowID = &value
@@ -513,6 +531,32 @@ func TestWorkflowListProjectScopeOrdersDefaultActivityAndName(t *testing.T) {
 	otherProject := "project-other"
 	if _, err := store.ListWorkflows(ctx, ListWorkflowsRequest{ProjectID: &otherProject, PageToken: page1.NextPageToken}); err == nil {
 		t.Fatal("project cursor accepted conflicting project filter")
+	}
+}
+
+func TestWorkflowListProjectScopeUsesSQLiteUnicodeOrderKeyAcrossPages(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	for _, name := range []string{"Äworkflow", "Öworkflow"} {
+		record, err := store.CreateWorkflow(ctx, CreateWorkflowRequest{Name: name})
+		if err != nil {
+			t.Fatalf("CreateWorkflow %q: %v", name, err)
+		}
+		linkWorkflow(t, ctx, store, binding.ProjectID, record.ID, false)
+	}
+	projectID := binding.ProjectID
+	first, err := store.ListWorkflows(ctx, ListWorkflowsRequest{ProjectID: &projectID, PageSize: 1})
+	if err != nil {
+		t.Fatalf("ListWorkflows first page: %v", err)
+	}
+	if len(first.Workflows) != 1 || first.NextPageToken == "" {
+		t.Fatalf("first page = %+v, want one row and continuation", first)
+	}
+	second, err := store.ListWorkflows(ctx, ListWorkflowsRequest{PageToken: first.NextPageToken, PageSize: 1})
+	if err != nil {
+		t.Fatalf("ListWorkflows second page: %v", err)
+	}
+	if len(second.Workflows) != 1 || second.Workflows[0].ID == first.Workflows[0].ID {
+		t.Fatalf("paginated workflows first=%+v second=%+v, want distinct complete rows", first.Workflows, second.Workflows)
 	}
 }
 

--- a/server/workflowstore/project_workflow_links.go
+++ b/server/workflowstore/project_workflow_links.go
@@ -252,11 +252,42 @@ func (s *Store) UnlinkProjectWorkflow(ctx context.Context, linkID string, replac
 	return result, nil
 }
 
-func (s *Store) resolveTaskWorkflowLink(ctx context.Context, projectID string, workflowID workflow.WorkflowID) (sqlitegen.ProjectWorkflowLinkRecord, error) {
-	if strings.TrimSpace(string(workflowID)) == "" {
-		return s.queries.GetDefaultProjectWorkflowLink(ctx, projectID)
+func resolveTaskWorkflowLinkWithQueries(ctx context.Context, q *sqlitegen.Queries, projectID string, workflowID *workflow.WorkflowID) (sqlitegen.ProjectWorkflowLinkRecord, error) {
+	if workflowID == nil {
+		link, err := q.GetDefaultProjectWorkflowLink(ctx, projectID)
+		if err == nil {
+			return link, nil
+		}
+		if err != sql.ErrNoRows {
+			return sqlitegen.ProjectWorkflowLinkRecord{}, err
+		}
+		links, err := q.ListProjectWorkflowLinksForTaskSelection(ctx, projectID)
+		if err != nil {
+			return sqlitegen.ProjectWorkflowLinkRecord{}, err
+		}
+		if len(links) == 1 {
+			return links[0], nil
+		}
+		if len(links) == 0 {
+			return sqlitegen.ProjectWorkflowLinkRecord{}, TaskWorkflowSelectionError{
+				Reason:    TaskWorkflowSelectionNoLinkedWorkflows,
+				ProjectID: projectID,
+			}
+		}
+		return sqlitegen.ProjectWorkflowLinkRecord{}, TaskWorkflowSelectionError{
+			Reason:    TaskWorkflowSelectionAmbiguousWithoutDefault,
+			ProjectID: projectID,
+		}
 	}
-	return s.queries.GetActiveProjectWorkflowLinkByWorkflow(ctx, sqlitegen.GetActiveProjectWorkflowLinkByWorkflowParams{ProjectID: projectID, WorkflowID: string(workflowID)})
+	link, err := q.GetActiveProjectWorkflowLinkByWorkflow(ctx, sqlitegen.GetActiveProjectWorkflowLinkByWorkflowParams{ProjectID: projectID, WorkflowID: string(*workflowID)})
+	if err == sql.ErrNoRows {
+		return sqlitegen.ProjectWorkflowLinkRecord{}, TaskWorkflowSelectionError{
+			Reason:     TaskWorkflowSelectionWorkflowNotLinked,
+			ProjectID:  projectID,
+			WorkflowID: workflowID,
+		}
+	}
+	return link, err
 }
 
 func linkRecordFromRow(row sqlitegen.ProjectWorkflowLinkRecord) ProjectWorkflowLinkRecord {

--- a/server/workflowstore/store.go
+++ b/server/workflowstore/store.go
@@ -536,6 +536,9 @@ func (s *Store) ListWorkflows(ctx context.Context, req ListWorkflowsRequest) (Li
 	projectID := req.ProjectID
 	workflowID := workflowIDString(req.WorkflowID)
 	query := sqliteLowerASCII(strings.TrimSpace(req.Query))
+	if err := validateWorkflowListScopes(projectID, workflowID); err != nil {
+		return ListWorkflowsResult{}, err
+	}
 	if cursor.hasValue {
 		if projectID != nil && !textutil.EqualOptional(projectID, cursor.projectID) {
 			return ListWorkflowsResult{}, errors.New("workflow list page token project scope conflict")
@@ -627,6 +630,19 @@ func (s *Store) ListWorkflows(ctx context.Context, req ListWorkflowsRequest) (Li
 		responseProjectID = &value
 	}
 	return ListWorkflowsResult{Workflows: out, ProjectID: responseProjectID, NextPageToken: nextPageToken}, nil
+}
+
+func validateWorkflowListScopes(projectID *string, workflowID *string) error {
+	if projectID != nil &&
+		(strings.TrimSpace(*projectID) == "" || strings.TrimSpace(*projectID) != *projectID) {
+		return errors.New("workflow list project scope must be non-blank and unpadded")
+	}
+	if workflowID != nil {
+		if _, err := runtimeids.ParseCanonicalPrefixedUUIDv4(*workflowID, "workflow-", "workflow id"); err != nil {
+			return fmt.Errorf("invalid workflow list workflow scope: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *Store) AddNode(ctx context.Context, node NodeRecord) (int64, error) {

--- a/server/workflowstore/store.go
+++ b/server/workflowstore/store.go
@@ -533,7 +533,7 @@ func (s *Store) ListWorkflows(ctx context.Context, req ListWorkflowsRequest) (Li
 	}
 	projectID := req.ProjectID
 	workflowID := workflowIDString(req.WorkflowID)
-	query := strings.TrimSpace(req.Query)
+	query := sqliteLowerASCII(strings.TrimSpace(req.Query))
 	if cursor.hasValue {
 		if projectID != nil && !optionalStringEqual(projectID, cursor.projectID) {
 			return ListWorkflowsResult{}, errors.New("workflow list page token project scope conflict")
@@ -600,6 +600,7 @@ func (s *Store) ListWorkflows(ctx context.Context, req ListWorkflowsRequest) (Li
 			UpdatedAtUnixMs:          row.UpdatedAtUnixMs,
 			ActivityAtUnixMs:         row.ActivityAtUnixMs,
 			ProjectLinkDefault:       row.ProjectLinkDefault,
+			ProjectNameOrderKey:      row.ProjectNameOrderKey,
 		})
 	}
 	nextPageToken := ""
@@ -1117,6 +1118,7 @@ type workflowRecordRow struct {
 	UpdatedAtUnixMs          int64
 	ActivityAtUnixMs         int64
 	ProjectLinkDefault       interface{}
+	ProjectNameOrderKey      string
 }
 
 func workflowRecordFromRow(row workflowRecordRow) WorkflowRecord {
@@ -1168,7 +1170,9 @@ func parseWorkflowListPageToken(token string) (workflowListPageCursor, error) {
 			*payload.ProjectDefault < 0 ||
 			*payload.ProjectDefault > 1 ||
 			payload.ProjectName == nil ||
-			strings.TrimSpace(*payload.ProjectName) == "" {
+			strings.TrimSpace(*payload.ProjectName) == "" ||
+			strings.TrimSpace(*payload.ProjectName) != *payload.ProjectName ||
+			sqliteLowerASCII(*payload.ProjectName) != *payload.ProjectName {
 			return workflowListPageCursor{}, fmt.Errorf("invalid workflow list page token")
 		}
 	}
@@ -1176,6 +1180,10 @@ func parseWorkflowListPageToken(token string) (workflowListPageCursor, error) {
 		if _, err := runtimeids.ParseCanonicalPrefixedUUIDv4(*payload.FilterWorkflowID, "workflow-", "workflow id"); err != nil {
 			return workflowListPageCursor{}, fmt.Errorf("invalid workflow list page token")
 		}
+	}
+	if strings.TrimSpace(payload.SearchQuery) != payload.SearchQuery ||
+		sqliteLowerASCII(payload.SearchQuery) != payload.SearchQuery {
+		return workflowListPageCursor{}, fmt.Errorf("invalid workflow list page token")
 	}
 	return workflowListPageCursor{
 		activityAtUnixMs:  payload.ActivityAtUnixMs,
@@ -1210,7 +1218,10 @@ func workflowListPageToken(row workflowRecordRow, projectID *string, workflowID 
 			return "", fmt.Errorf("workflow list project default has unexpected type %T for workflow %q", row.ProjectLinkDefault, row.ID)
 		}
 		payload.ProjectDefault = &projectDefault
-		projectName := strings.ToLower(row.Name)
+		projectName := row.ProjectNameOrderKey
+		if strings.TrimSpace(projectName) == "" {
+			return "", fmt.Errorf("workflow list project ordering key is missing for workflow %q", row.ID)
+		}
 		payload.ProjectName = &projectName
 	}
 	encoded, err := json.Marshal(payload)
@@ -1228,7 +1239,7 @@ func workflowListFilterFingerprint(projectID *string, workflowID *string, query 
 	}{
 		ProjectID:  projectID,
 		WorkflowID: workflowID,
-		Query:      strings.ToLower(strings.TrimSpace(query)),
+		Query:      sqliteLowerASCII(strings.TrimSpace(query)),
 	}
 	encoded, err := json.Marshal(scope)
 	if err != nil {
@@ -1236,6 +1247,16 @@ func workflowListFilterFingerprint(projectID *string, workflowID *string, query 
 	}
 	sum := sha256.Sum256(encoded)
 	return fmt.Sprintf("%x", sum[:]), nil
+}
+
+func sqliteLowerASCII(value string) string {
+	bytes := []byte(value)
+	for index, current := range bytes {
+		if current >= 'A' && current <= 'Z' {
+			bytes[index] = current + ('a' - 'A')
+		}
+	}
+	return string(bytes)
 }
 
 func workflowIDString(id *workflow.WorkflowID) *string {

--- a/server/workflowstore/store.go
+++ b/server/workflowstore/store.go
@@ -2,6 +2,7 @@ package workflowstore
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
@@ -14,6 +15,7 @@ import (
 	"core/server/metadata"
 	"core/server/metadata/sqlitegen"
 	"core/server/workflow"
+	"core/shared/runtimeids"
 	"github.com/google/uuid"
 )
 
@@ -105,6 +107,11 @@ type WorkflowRecord struct {
 	Description           string
 	Version               int64
 	ExecutionTargetPolicy workflow.ExecutionTargetPolicy
+	ProjectLink           *WorkflowListProjectLink
+}
+
+type WorkflowListProjectLink struct {
+	Default bool
 }
 
 type NodeRecord struct {
@@ -381,27 +388,41 @@ const (
 )
 
 type ListWorkflowsRequest struct {
-	PageSize  int
-	PageToken string
-	Query     string
-	ExactName string
+	PageSize   int
+	PageToken  string
+	Query      string
+	ProjectID  *string
+	WorkflowID *workflow.WorkflowID
 }
 
 type ListWorkflowsResult struct {
 	Workflows     []WorkflowRecord
+	ProjectID     *string
 	NextPageToken string
 }
 
 type workflowListPageCursor struct {
-	activityAtUnixMs int64
-	workflowID       string
-	hasValue         bool
+	activityAtUnixMs  int64
+	workflowID        string
+	projectDefault    *int64
+	projectName       *string
+	projectID         *string
+	filterWorkflowID  *string
+	searchQuery       string
+	filterFingerprint string
+	hasValue          bool
 }
 
 type workflowListPageTokenPayload struct {
-	Version          int    `json:"version"`
-	ActivityAtUnixMs int64  `json:"activity_at_unix_ms"`
-	WorkflowID       string `json:"workflow_id"`
+	Version           int     `json:"version"`
+	ActivityAtUnixMs  int64   `json:"activity_at_unix_ms"`
+	WorkflowID        string  `json:"workflow_id"`
+	ProjectDefault    *int64  `json:"project_default,omitempty"`
+	ProjectName       *string `json:"project_name,omitempty"`
+	ProjectID         *string `json:"project_id,omitempty"`
+	FilterWorkflowID  *string `json:"filter_workflow_id,omitempty"`
+	SearchQuery       string  `json:"search_query"`
+	FilterFingerprint string  `json:"filter_fingerprint"`
 }
 
 const (
@@ -510,17 +531,58 @@ func (s *Store) ListWorkflows(ctx context.Context, req ListWorkflowsRequest) (Li
 	if err != nil {
 		return ListWorkflowsResult{}, err
 	}
+	projectID := req.ProjectID
+	workflowID := workflowIDString(req.WorkflowID)
+	query := strings.TrimSpace(req.Query)
+	if cursor.hasValue {
+		if projectID != nil && !optionalStringEqual(projectID, cursor.projectID) {
+			return ListWorkflowsResult{}, errors.New("workflow list page token project scope conflict")
+		}
+		if workflowID != nil && !optionalStringEqual(workflowID, cursor.filterWorkflowID) {
+			return ListWorkflowsResult{}, errors.New("workflow list page token workflow scope conflict")
+		}
+		if query != "" && query != cursor.searchQuery {
+			return ListWorkflowsResult{}, errors.New("workflow list page token search scope conflict")
+		}
+		if projectID == nil {
+			projectID = cursor.projectID
+		}
+		if workflowID == nil {
+			workflowID = cursor.filterWorkflowID
+		}
+		if query == "" {
+			query = cursor.searchQuery
+		}
+		fingerprint, fingerprintErr := workflowListFilterFingerprint(projectID, workflowID, query)
+		if fingerprintErr != nil {
+			return ListWorkflowsResult{}, fingerprintErr
+		}
+		if fingerprint != cursor.filterFingerprint {
+			return ListWorkflowsResult{}, errors.New("workflow list page token filter fingerprint conflict")
+		}
+	}
 	cursorActive := int64(0)
 	if cursor.hasValue {
 		cursorActive = 1
 	}
+	cursorProjectDefault := sql.NullInt64{}
+	if cursor.projectDefault != nil {
+		cursorProjectDefault = sql.NullInt64{Int64: *cursor.projectDefault, Valid: true}
+	}
+	cursorProjectName := sql.NullString{}
+	if cursor.projectName != nil {
+		cursorProjectName = sql.NullString{String: *cursor.projectName, Valid: true}
+	}
 	rows, err := s.queries.ListWorkflowRecordsPage(ctx, sqlitegen.ListWorkflowRecordsPageParams{
 		PageLimit:              int64(pageSize + 1),
-		ExactName:              strings.TrimSpace(req.ExactName),
-		SearchQuery:            strings.TrimSpace(req.Query),
+		ProjectID:              nullableWorkflowFilter(projectID),
+		WorkflowID:             nullableWorkflowFilter(workflowID),
+		SearchQuery:            query,
 		CursorActive:           cursorActive,
 		CursorActivityAtUnixMs: cursor.activityAtUnixMs,
 		CursorWorkflowID:       cursor.workflowID,
+		CursorProjectDefault:   cursorProjectDefault,
+		CursorProjectName:      cursorProjectName,
 	})
 	if err != nil {
 		return ListWorkflowsResult{}, err
@@ -537,18 +599,27 @@ func (s *Store) ListWorkflows(ctx context.Context, req ListWorkflowsRequest) (Li
 			CreatedAtUnixMs:          row.CreatedAtUnixMs,
 			UpdatedAtUnixMs:          row.UpdatedAtUnixMs,
 			ActivityAtUnixMs:         row.ActivityAtUnixMs,
+			ProjectLinkDefault:       row.ProjectLinkDefault,
 		})
 	}
 	nextPageToken := ""
 	if len(rowsOut) > pageSize {
-		nextPageToken = workflowListPageToken(rowsOut[pageSize-1])
+		nextPageToken, err = workflowListPageToken(rowsOut[pageSize-1], projectID, workflowID, query)
+		if err != nil {
+			return ListWorkflowsResult{}, err
+		}
 		rowsOut = rowsOut[:pageSize]
 	}
 	out := make([]WorkflowRecord, 0, len(rowsOut))
 	for _, row := range rowsOut {
 		out = append(out, workflowRecordFromRow(row))
 	}
-	return ListWorkflowsResult{Workflows: out, NextPageToken: nextPageToken}, nil
+	var responseProjectID *string
+	if projectID != nil {
+		value := *projectID
+		responseProjectID = &value
+	}
+	return ListWorkflowsResult{Workflows: out, ProjectID: responseProjectID, NextPageToken: nextPageToken}, nil
 }
 
 func (s *Store) AddNode(ctx context.Context, node NodeRecord) (int64, error) {
@@ -930,23 +1001,27 @@ func (s *Store) DeleteEdge(ctx context.Context, edgeID workflow.EdgeID) error {
 }
 
 func (s *Store) GetDefinition(ctx context.Context, workflowID workflow.WorkflowID) (workflow.Definition, WorkflowRecord, error) {
-	row, err := s.queries.GetWorkflow(ctx, string(workflowID))
+	return workflowDefinitionFromQueries(ctx, s.queries, workflowID)
+}
+
+func workflowDefinitionFromQueries(ctx context.Context, q *sqlitegen.Queries, workflowID workflow.WorkflowID) (workflow.Definition, WorkflowRecord, error) {
+	row, err := q.GetWorkflow(ctx, string(workflowID))
 	if err != nil {
 		return workflow.Definition{}, WorkflowRecord{}, err
 	}
-	nodes, err := s.queries.ListWorkflowNodes(ctx, string(workflowID))
+	nodes, err := q.ListWorkflowNodes(ctx, string(workflowID))
 	if err != nil {
 		return workflow.Definition{}, WorkflowRecord{}, err
 	}
-	nodeGroups, err := s.queries.ListWorkflowNodeGroups(ctx, string(workflowID))
+	nodeGroups, err := q.ListWorkflowNodeGroups(ctx, string(workflowID))
 	if err != nil {
 		return workflow.Definition{}, WorkflowRecord{}, err
 	}
-	groups, err := s.queries.ListWorkflowTransitionGroups(ctx, string(workflowID))
+	groups, err := q.ListWorkflowTransitionGroups(ctx, string(workflowID))
 	if err != nil {
 		return workflow.Definition{}, WorkflowRecord{}, err
 	}
-	edges, err := s.queries.ListWorkflowEdges(ctx, string(workflowID))
+	edges, err := q.ListWorkflowEdges(ctx, string(workflowID))
 	if err != nil {
 		return workflow.Definition{}, WorkflowRecord{}, err
 	}
@@ -1041,10 +1116,11 @@ type workflowRecordRow struct {
 	CreatedAtUnixMs          int64
 	UpdatedAtUnixMs          int64
 	ActivityAtUnixMs         int64
+	ProjectLinkDefault       interface{}
 }
 
 func workflowRecordFromRow(row workflowRecordRow) WorkflowRecord {
-	return WorkflowRecord{
+	record := WorkflowRecord{
 		ID:          workflow.WorkflowID(row.ID),
 		Name:        row.Name,
 		Description: row.Description,
@@ -1054,6 +1130,14 @@ func workflowRecordFromRow(row workflowRecordRow) WorkflowRecord {
 			CustomRef: metadata.OptionalString(row.ExecutionTargetCustomRef),
 		}.Canonical(),
 	}
+	if row.ProjectLinkDefault != nil {
+		defaultValue, ok := row.ProjectLinkDefault.(int64)
+		if !ok {
+			panic(fmt.Sprintf("workflow list returned project_link_default with unexpected type %T for workflow %q", row.ProjectLinkDefault, row.ID))
+		}
+		record.ProjectLink = &WorkflowListProjectLink{Default: defaultValue != 0}
+	}
+	return record
 }
 
 func parseWorkflowListPageToken(token string) (workflowListPageCursor, error) {
@@ -1068,19 +1152,112 @@ func parseWorkflowListPageToken(token string) (workflowListPageCursor, error) {
 	if err := json.Unmarshal(decoded, &payload); err != nil {
 		return workflowListPageCursor{}, fmt.Errorf("invalid workflow list page token")
 	}
-	if payload.Version != 1 || payload.ActivityAtUnixMs < 0 || strings.TrimSpace(payload.WorkflowID) == "" {
+	if payload.Version != 2 || payload.ActivityAtUnixMs < 0 || strings.TrimSpace(payload.FilterFingerprint) == "" {
 		return workflowListPageCursor{}, fmt.Errorf("invalid workflow list page token")
 	}
-	return workflowListPageCursor{activityAtUnixMs: payload.ActivityAtUnixMs, workflowID: payload.WorkflowID, hasValue: true}, nil
+	if _, err := runtimeids.ParseCanonicalPrefixedUUIDv4(payload.WorkflowID, "workflow-", "workflow id"); err != nil {
+		return workflowListPageCursor{}, fmt.Errorf("invalid workflow list page token")
+	}
+	if payload.ProjectID == nil && (payload.ProjectDefault != nil || payload.ProjectName != nil) {
+		return workflowListPageCursor{}, fmt.Errorf("invalid workflow list page token")
+	}
+	if payload.ProjectID != nil {
+		if strings.TrimSpace(*payload.ProjectID) == "" ||
+			strings.TrimSpace(*payload.ProjectID) != *payload.ProjectID ||
+			payload.ProjectDefault == nil ||
+			*payload.ProjectDefault < 0 ||
+			*payload.ProjectDefault > 1 ||
+			payload.ProjectName == nil ||
+			strings.TrimSpace(*payload.ProjectName) == "" {
+			return workflowListPageCursor{}, fmt.Errorf("invalid workflow list page token")
+		}
+	}
+	if payload.FilterWorkflowID != nil {
+		if _, err := runtimeids.ParseCanonicalPrefixedUUIDv4(*payload.FilterWorkflowID, "workflow-", "workflow id"); err != nil {
+			return workflowListPageCursor{}, fmt.Errorf("invalid workflow list page token")
+		}
+	}
+	return workflowListPageCursor{
+		activityAtUnixMs:  payload.ActivityAtUnixMs,
+		workflowID:        payload.WorkflowID,
+		projectDefault:    payload.ProjectDefault,
+		projectName:       payload.ProjectName,
+		projectID:         payload.ProjectID,
+		filterWorkflowID:  payload.FilterWorkflowID,
+		searchQuery:       payload.SearchQuery,
+		filterFingerprint: payload.FilterFingerprint,
+		hasValue:          true,
+	}, nil
 }
 
-func workflowListPageToken(row workflowRecordRow) string {
-	payload := workflowListPageTokenPayload{Version: 1, ActivityAtUnixMs: row.ActivityAtUnixMs, WorkflowID: row.ID}
+func workflowListPageToken(row workflowRecordRow, projectID *string, workflowID *string, query string) (string, error) {
+	payload := workflowListPageTokenPayload{
+		Version:          2,
+		ActivityAtUnixMs: row.ActivityAtUnixMs,
+		WorkflowID:       row.ID,
+		ProjectID:        projectID,
+		FilterWorkflowID: workflowID,
+		SearchQuery:      query,
+	}
+	fingerprint, err := workflowListFilterFingerprint(projectID, workflowID, query)
+	if err != nil {
+		return "", err
+	}
+	payload.FilterFingerprint = fingerprint
+	if projectID != nil {
+		projectDefault, ok := row.ProjectLinkDefault.(int64)
+		if !ok {
+			return "", fmt.Errorf("workflow list project default has unexpected type %T for workflow %q", row.ProjectLinkDefault, row.ID)
+		}
+		payload.ProjectDefault = &projectDefault
+		projectName := strings.ToLower(row.Name)
+		payload.ProjectName = &projectName
+	}
 	encoded, err := json.Marshal(payload)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("marshal workflow list page token: %w", err)
 	}
-	return base64.RawURLEncoding.EncodeToString(encoded)
+	return base64.RawURLEncoding.EncodeToString(encoded), nil
+}
+
+func workflowListFilterFingerprint(projectID *string, workflowID *string, query string) (string, error) {
+	scope := struct {
+		ProjectID  *string `json:"project_id,omitempty"`
+		WorkflowID *string `json:"workflow_id,omitempty"`
+		Query      string  `json:"query"`
+	}{
+		ProjectID:  projectID,
+		WorkflowID: workflowID,
+		Query:      strings.ToLower(strings.TrimSpace(query)),
+	}
+	encoded, err := json.Marshal(scope)
+	if err != nil {
+		return "", fmt.Errorf("marshal workflow list filter scope: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return fmt.Sprintf("%x", sum[:]), nil
+}
+
+func workflowIDString(id *workflow.WorkflowID) *string {
+	if id == nil {
+		return nil
+	}
+	value := string(*id)
+	return &value
+}
+
+func nullableWorkflowFilter(value *string) interface{} {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func optionalStringEqual(left *string, right *string) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
 }
 
 func resolveWorkflowNodeGroupID(ctx context.Context, q *sqlitegen.Queries, workflowID string, groupID string, groupKey string) (string, error) {

--- a/server/workflowstore/store.go
+++ b/server/workflowstore/store.go
@@ -16,6 +16,7 @@ import (
 	"core/server/metadata/sqlitegen"
 	"core/server/workflow"
 	"core/shared/runtimeids"
+	"core/shared/textutil"
 	"github.com/google/uuid"
 )
 
@@ -402,7 +403,7 @@ type ListWorkflowsResult struct {
 }
 
 type workflowListPageCursor struct {
-	activityAtUnixMs  int64
+	activityAtUnixMs  *int64
 	workflowID        string
 	projectDefault    *int64
 	projectName       *string
@@ -415,7 +416,7 @@ type workflowListPageCursor struct {
 
 type workflowListPageTokenPayload struct {
 	Version           int     `json:"version"`
-	ActivityAtUnixMs  int64   `json:"activity_at_unix_ms"`
+	ActivityAtUnixMs  *int64  `json:"activity_at_unix_ms,omitempty"`
 	WorkflowID        string  `json:"workflow_id"`
 	ProjectDefault    *int64  `json:"project_default,omitempty"`
 	ProjectName       *string `json:"project_name,omitempty"`
@@ -426,8 +427,9 @@ type workflowListPageTokenPayload struct {
 }
 
 const (
-	defaultWorkflowListPageSize = 50
-	maxWorkflowListPageSize     = 100
+	workflowListPageTokenVersion = 3
+	defaultWorkflowListPageSize  = 50
+	maxWorkflowListPageSize      = 100
 )
 
 func (s *Store) CreateWorkflow(ctx context.Context, req CreateWorkflowRequest) (WorkflowRecord, error) {
@@ -535,10 +537,10 @@ func (s *Store) ListWorkflows(ctx context.Context, req ListWorkflowsRequest) (Li
 	workflowID := workflowIDString(req.WorkflowID)
 	query := sqliteLowerASCII(strings.TrimSpace(req.Query))
 	if cursor.hasValue {
-		if projectID != nil && !optionalStringEqual(projectID, cursor.projectID) {
+		if projectID != nil && !textutil.EqualOptional(projectID, cursor.projectID) {
 			return ListWorkflowsResult{}, errors.New("workflow list page token project scope conflict")
 		}
-		if workflowID != nil && !optionalStringEqual(workflowID, cursor.filterWorkflowID) {
+		if workflowID != nil && !textutil.EqualOptional(workflowID, cursor.filterWorkflowID) {
 			return ListWorkflowsResult{}, errors.New("workflow list page token workflow scope conflict")
 		}
 		if query != "" && query != cursor.searchQuery {
@@ -573,13 +575,17 @@ func (s *Store) ListWorkflows(ctx context.Context, req ListWorkflowsRequest) (Li
 	if cursor.projectName != nil {
 		cursorProjectName = sql.NullString{String: *cursor.projectName, Valid: true}
 	}
+	cursorActivityAtUnixMs := sql.NullInt64{}
+	if cursor.activityAtUnixMs != nil {
+		cursorActivityAtUnixMs = sql.NullInt64{Int64: *cursor.activityAtUnixMs, Valid: true}
+	}
 	rows, err := s.queries.ListWorkflowRecordsPage(ctx, sqlitegen.ListWorkflowRecordsPageParams{
 		PageLimit:              int64(pageSize + 1),
-		ProjectID:              nullableWorkflowFilter(projectID),
+		ProjectID:              nullableStringPointer(projectID),
 		WorkflowID:             nullableWorkflowFilter(workflowID),
 		SearchQuery:            query,
 		CursorActive:           cursorActive,
-		CursorActivityAtUnixMs: cursor.activityAtUnixMs,
+		CursorActivityAtUnixMs: cursorActivityAtUnixMs,
 		CursorWorkflowID:       cursor.workflowID,
 		CursorProjectDefault:   cursorProjectDefault,
 		CursorProjectName:      cursorProjectName,
@@ -598,7 +604,7 @@ func (s *Store) ListWorkflows(ctx context.Context, req ListWorkflowsRequest) (Li
 			ExecutionTargetCustomRef: row.ExecutionTargetCustomRef,
 			CreatedAtUnixMs:          row.CreatedAtUnixMs,
 			UpdatedAtUnixMs:          row.UpdatedAtUnixMs,
-			ActivityAtUnixMs:         row.ActivityAtUnixMs,
+			ActivityAtUnixMs:         workflowListActivityAtUnixMs(projectID, row.GlobalActivityAtUnixMs, row.ProjectActivityAtUnixMs),
 			ProjectLinkDefault:       row.ProjectLinkDefault,
 			ProjectNameOrderKey:      row.ProjectNameOrderKey,
 		})
@@ -1116,9 +1122,17 @@ type workflowRecordRow struct {
 	ExecutionTargetCustomRef sql.NullString
 	CreatedAtUnixMs          int64
 	UpdatedAtUnixMs          int64
-	ActivityAtUnixMs         int64
-	ProjectLinkDefault       interface{}
+	ActivityAtUnixMs         *int64
+	ProjectLinkDefault       sql.NullInt64
 	ProjectNameOrderKey      string
+}
+
+func workflowListActivityAtUnixMs(projectID *string, globalActivity int64, projectActivity sql.NullInt64) *int64 {
+	if projectID != nil {
+		return metadata.OptionalInt64(projectActivity)
+	}
+	value := globalActivity
+	return &value
 }
 
 func workflowRecordFromRow(row workflowRecordRow) WorkflowRecord {
@@ -1132,12 +1146,8 @@ func workflowRecordFromRow(row workflowRecordRow) WorkflowRecord {
 			CustomRef: metadata.OptionalString(row.ExecutionTargetCustomRef),
 		}.Canonical(),
 	}
-	if row.ProjectLinkDefault != nil {
-		defaultValue, ok := row.ProjectLinkDefault.(int64)
-		if !ok {
-			panic(fmt.Sprintf("workflow list returned project_link_default with unexpected type %T for workflow %q", row.ProjectLinkDefault, row.ID))
-		}
-		record.ProjectLink = &WorkflowListProjectLink{Default: defaultValue != 0}
+	if row.ProjectLinkDefault.Valid {
+		record.ProjectLink = &WorkflowListProjectLink{Default: row.ProjectLinkDefault.Int64 != 0}
 	}
 	return record
 }
@@ -1154,13 +1164,15 @@ func parseWorkflowListPageToken(token string) (workflowListPageCursor, error) {
 	if err := json.Unmarshal(decoded, &payload); err != nil {
 		return workflowListPageCursor{}, fmt.Errorf("invalid workflow list page token")
 	}
-	if payload.Version != 2 || payload.ActivityAtUnixMs < 0 || strings.TrimSpace(payload.FilterFingerprint) == "" {
+	if payload.Version != workflowListPageTokenVersion ||
+		(payload.ActivityAtUnixMs != nil && *payload.ActivityAtUnixMs < 0) ||
+		strings.TrimSpace(payload.FilterFingerprint) == "" {
 		return workflowListPageCursor{}, fmt.Errorf("invalid workflow list page token")
 	}
 	if _, err := runtimeids.ParseCanonicalPrefixedUUIDv4(payload.WorkflowID, "workflow-", "workflow id"); err != nil {
 		return workflowListPageCursor{}, fmt.Errorf("invalid workflow list page token")
 	}
-	if payload.ProjectID == nil && (payload.ProjectDefault != nil || payload.ProjectName != nil) {
+	if payload.ProjectID == nil && (payload.ActivityAtUnixMs == nil || payload.ProjectDefault != nil || payload.ProjectName != nil) {
 		return workflowListPageCursor{}, fmt.Errorf("invalid workflow list page token")
 	}
 	if payload.ProjectID != nil {
@@ -1200,7 +1212,7 @@ func parseWorkflowListPageToken(token string) (workflowListPageCursor, error) {
 
 func workflowListPageToken(row workflowRecordRow, projectID *string, workflowID *string, query string) (string, error) {
 	payload := workflowListPageTokenPayload{
-		Version:          2,
+		Version:          workflowListPageTokenVersion,
 		ActivityAtUnixMs: row.ActivityAtUnixMs,
 		WorkflowID:       row.ID,
 		ProjectID:        projectID,
@@ -1213,16 +1225,18 @@ func workflowListPageToken(row workflowRecordRow, projectID *string, workflowID 
 	}
 	payload.FilterFingerprint = fingerprint
 	if projectID != nil {
-		projectDefault, ok := row.ProjectLinkDefault.(int64)
-		if !ok {
-			return "", fmt.Errorf("workflow list project default has unexpected type %T for workflow %q", row.ProjectLinkDefault, row.ID)
+		if !row.ProjectLinkDefault.Valid {
+			return "", fmt.Errorf("workflow list project default is missing for workflow %q", row.ID)
 		}
+		projectDefault := row.ProjectLinkDefault.Int64
 		payload.ProjectDefault = &projectDefault
 		projectName := row.ProjectNameOrderKey
 		if strings.TrimSpace(projectName) == "" {
 			return "", fmt.Errorf("workflow list project ordering key is missing for workflow %q", row.ID)
 		}
 		payload.ProjectName = &projectName
+	} else if row.ActivityAtUnixMs == nil {
+		return "", fmt.Errorf("global workflow list activity is missing for workflow %q", row.ID)
 	}
 	encoded, err := json.Marshal(payload)
 	if err != nil {
@@ -1272,13 +1286,6 @@ func nullableWorkflowFilter(value *string) interface{} {
 		return nil
 	}
 	return *value
-}
-
-func optionalStringEqual(left *string, right *string) bool {
-	if left == nil || right == nil {
-		return left == nil && right == nil
-	}
-	return *left == *right
 }
 
 func resolveWorkflowNodeGroupID(ctx context.Context, q *sqlitegen.Queries, workflowID string, groupID string, groupKey string) (string, error) {

--- a/server/workflowstore/task_test.go
+++ b/server/workflowstore/task_test.go
@@ -189,6 +189,23 @@ func TestTaskCreateRejectsPresentBlankWorkflowWithoutMutation(t *testing.T) {
 	assertTaskCreationUnchanged(t, ctx, store, binding.ProjectID, beforeSequence)
 }
 
+func TestTaskCreateRejectsBlankProjectWithoutMutation(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	beforeSequence := projectNextTaskSequence(t, ctx, store, binding.ProjectID)
+	for _, projectID := range []string{"", " ", "\t\n"} {
+		t.Run(fmt.Sprintf("%q", projectID), func(t *testing.T) {
+			if _, err := store.CreateTask(ctx, CreateTaskRequest{
+				ProjectID: projectID,
+				Title:     "Blank project",
+				Body:      "Body",
+			}); err == nil {
+				t.Fatal("CreateTask accepted a blank project id")
+			}
+			assertTaskCreationUnchanged(t, ctx, store, binding.ProjectID, beforeSequence)
+		})
+	}
+}
+
 func TestTaskCreateMapsSQLiteBusyToTypedConflictWithoutMutation(t *testing.T) {
 	ctx, fixtureStore, binding, cfg := newTestStoreWithConfigContext(t)
 	createLinkedValidWorkflow(t, ctx, fixtureStore, binding.ProjectID)

--- a/server/workflowstore/task_test.go
+++ b/server/workflowstore/task_test.go
@@ -1,8 +1,10 @@
 package workflowstore
 
 import (
+	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -10,6 +12,9 @@ import (
 	"core/server/metadata"
 	"core/server/workflow"
 	"core/server/workflowscript"
+	"core/shared/config"
+	sqlitedriver "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
 )
 
 func TestTaskCreateStartCancelAndComments(t *testing.T) {
@@ -122,6 +127,527 @@ func TestTaskCreateStartCancelAndComments(t *testing.T) {
 	}
 	if !activeDone || activeNonTerminal {
 		t.Fatalf("placements after cancel = %+v, want active Done sink and no active non-terminal placement", placements)
+	}
+}
+
+func TestTaskCreateInfersLoneLinkedWorkflowWithoutDefault(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	workflowID := createValidWorkflow(t, ctx, store)
+	linkWorkflow(t, ctx, store, binding.ProjectID, workflowID, false)
+
+	task, err := store.CreateTask(ctx, CreateTaskRequest{
+		ProjectID: binding.ProjectID,
+		Title:     "Lone workflow",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask lone linked workflow: %v", err)
+	}
+	if task.WorkflowID != workflowID {
+		t.Fatalf("task workflow = %q, want lone linked workflow %q", task.WorkflowID, workflowID)
+	}
+	link, err := store.GetProjectWorkflowLink(ctx, task.LinkID)
+	if err != nil {
+		t.Fatalf("GetProjectWorkflowLink selected link: %v", err)
+	}
+	if link.ProjectID != binding.ProjectID || link.WorkflowID != workflowID {
+		t.Fatalf("persisted task link = %+v, want project %q workflow %q", link, binding.ProjectID, workflowID)
+	}
+}
+
+func TestTaskCreateWithoutLinkedWorkflowsReturnsTypedErrorWithoutMutation(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	beforeSequence := projectNextTaskSequence(t, ctx, store, binding.ProjectID)
+
+	_, err := store.CreateTask(ctx, CreateTaskRequest{
+		ProjectID: binding.ProjectID,
+		Title:     "No workflow",
+	})
+	var selectionErr TaskWorkflowSelectionError
+	if !errors.As(err, &selectionErr) {
+		t.Fatalf("CreateTask error = %v, want TaskWorkflowSelectionError", err)
+	}
+	if selectionErr.Reason != TaskWorkflowSelectionNoLinkedWorkflows ||
+		selectionErr.ProjectID != binding.ProjectID ||
+		selectionErr.WorkflowID != nil {
+		t.Fatalf("selection error = %+v", selectionErr)
+	}
+	assertTaskCreationUnchanged(t, ctx, store, binding.ProjectID, beforeSequence)
+}
+
+func TestTaskCreateRejectsPresentBlankWorkflowWithoutMutation(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	beforeSequence := projectNextTaskSequence(t, ctx, store, binding.ProjectID)
+	blankWorkflowID := workflow.WorkflowID(" ")
+
+	if _, err := store.CreateTask(ctx, CreateTaskRequest{
+		ProjectID:  binding.ProjectID,
+		WorkflowID: &blankWorkflowID,
+		Title:      "Blank workflow",
+	}); err == nil {
+		t.Fatal("CreateTask accepted a present blank workflow id")
+	}
+	assertTaskCreationUnchanged(t, ctx, store, binding.ProjectID, beforeSequence)
+}
+
+func TestTaskCreateMapsSQLiteBusyToTypedConflictWithoutMutation(t *testing.T) {
+	ctx, fixtureStore, binding, cfg := newTestStoreWithConfigContext(t)
+	createLinkedValidWorkflow(t, ctx, fixtureStore, binding.ProjectID)
+	createStore, lockStore := openConcurrentWorkflowStores(t, cfg)
+	if _, err := createStore.db.ExecContext(ctx, `PRAGMA busy_timeout = 0`); err != nil {
+		t.Fatalf("disable create-store busy timeout: %v", err)
+	}
+	beforeSequence := projectNextTaskSequence(t, ctx, createStore, binding.ProjectID)
+	lockTx, err := lockStore.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin lock transaction: %v", err)
+	}
+	defer func() { _ = lockTx.Rollback() }()
+	if _, err := lockTx.ExecContext(ctx, `UPDATE projects SET updated_at_unix_ms = updated_at_unix_ms WHERE id = ?`, binding.ProjectID); err != nil {
+		t.Fatalf("acquire project write lock: %v", err)
+	}
+
+	_, err = createStore.CreateTask(ctx, CreateTaskRequest{
+		ProjectID: binding.ProjectID,
+		Title:     "Conflicted task",
+	})
+	var conflictErr TaskCreateConflictError
+	if !errors.As(err, &conflictErr) || conflictErr.Reason != TaskCreateConflictSerialization {
+		t.Fatalf("CreateTask error = %T %v, want typed serialization conflict", err, err)
+	}
+	if err := lockTx.Rollback(); err != nil {
+		t.Fatalf("rollback lock transaction: %v", err)
+	}
+	assertTaskCreationUnchanged(t, ctx, createStore, binding.ProjectID, beforeSequence)
+}
+
+func TestTaskCreateWithSeveralLinksAndNoDefaultReturnsTypedErrorWithoutMutation(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	firstWorkflowID := createValidWorkflow(t, ctx, store)
+	secondWorkflowID := createValidWorkflow(t, ctx, store)
+	linkWorkflow(t, ctx, store, binding.ProjectID, firstWorkflowID, false)
+	linkWorkflow(t, ctx, store, binding.ProjectID, secondWorkflowID, false)
+	beforeSequence := projectNextTaskSequence(t, ctx, store, binding.ProjectID)
+
+	_, err := store.CreateTask(ctx, CreateTaskRequest{
+		ProjectID: binding.ProjectID,
+		Title:     "Ambiguous workflow",
+	})
+	var selectionErr TaskWorkflowSelectionError
+	if !errors.As(err, &selectionErr) {
+		t.Fatalf("CreateTask error = %v, want TaskWorkflowSelectionError", err)
+	}
+	if selectionErr.Reason != TaskWorkflowSelectionAmbiguousWithoutDefault ||
+		selectionErr.ProjectID != binding.ProjectID ||
+		selectionErr.WorkflowID != nil {
+		t.Fatalf("selection error = %+v", selectionErr)
+	}
+	assertTaskCreationUnchanged(t, ctx, store, binding.ProjectID, beforeSequence)
+}
+
+func TestTaskCreateWithExplicitUnlinkedWorkflowReturnsTypedErrorWithoutMutation(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	linkedWorkflowID := createValidWorkflow(t, ctx, store)
+	unlinkedWorkflowID := createValidWorkflow(t, ctx, store)
+	linkWorkflow(t, ctx, store, binding.ProjectID, linkedWorkflowID, true)
+	beforeSequence := projectNextTaskSequence(t, ctx, store, binding.ProjectID)
+
+	_, err := store.CreateTask(ctx, CreateTaskRequest{
+		ProjectID:  binding.ProjectID,
+		WorkflowID: &unlinkedWorkflowID,
+		Title:      "Unlinked workflow",
+	})
+	var selectionErr TaskWorkflowSelectionError
+	if !errors.As(err, &selectionErr) {
+		t.Fatalf("CreateTask error = %v, want TaskWorkflowSelectionError", err)
+	}
+	if selectionErr.Reason != TaskWorkflowSelectionWorkflowNotLinked ||
+		selectionErr.ProjectID != binding.ProjectID ||
+		selectionErr.WorkflowID == nil ||
+		*selectionErr.WorkflowID != unlinkedWorkflowID {
+		t.Fatalf("selection error = %+v", selectionErr)
+	}
+	assertTaskCreationUnchanged(t, ctx, store, binding.ProjectID, beforeSequence)
+}
+
+func TestTaskCreateWithExplicitLinkedWorkflowPersistsSelectedLink(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	defaultWorkflowID := createValidWorkflow(t, ctx, store)
+	selectedWorkflowID := createValidWorkflow(t, ctx, store)
+	defaultLink, err := store.LinkWorkflow(ctx, binding.ProjectID, defaultWorkflowID, true)
+	if err != nil {
+		t.Fatalf("LinkWorkflow default: %v", err)
+	}
+	selectedLink, err := store.LinkWorkflow(ctx, binding.ProjectID, selectedWorkflowID, false)
+	if err != nil {
+		t.Fatalf("LinkWorkflow selected: %v", err)
+	}
+
+	task, err := store.CreateTask(ctx, CreateTaskRequest{
+		ProjectID:  binding.ProjectID,
+		WorkflowID: &selectedWorkflowID,
+		Title:      "Explicit workflow",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask explicit linked workflow: %v", err)
+	}
+	if task.WorkflowID != selectedWorkflowID || task.LinkID != selectedLink.ID {
+		t.Fatalf("task selection = %+v, want workflow %q link %q", task, selectedWorkflowID, selectedLink.ID)
+	}
+	if task.LinkID == defaultLink.ID {
+		t.Fatalf("task used default link %q instead of explicit link %q", defaultLink.ID, selectedLink.ID)
+	}
+	persisted, err := store.queries.GetTask(ctx, string(task.ID))
+	if err != nil {
+		t.Fatalf("GetTask persisted selection: %v", err)
+	}
+	if persisted.ProjectWorkflowLinkID != selectedLink.ID ||
+		persisted.WorkflowID != string(selectedWorkflowID) {
+		t.Fatalf("persisted task selection = %+v, want workflow %q link %q", persisted, selectedWorkflowID, selectedLink.ID)
+	}
+}
+
+func TestTaskCreateUsesDefaultWorkflowWhenSeveralAreLinked(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	defaultWorkflowID := createValidWorkflow(t, ctx, store)
+	otherWorkflowID := createValidWorkflow(t, ctx, store)
+	defaultLink, err := store.LinkWorkflow(ctx, binding.ProjectID, defaultWorkflowID, true)
+	if err != nil {
+		t.Fatalf("LinkWorkflow default: %v", err)
+	}
+	if _, err := store.LinkWorkflow(ctx, binding.ProjectID, otherWorkflowID, false); err != nil {
+		t.Fatalf("LinkWorkflow other: %v", err)
+	}
+
+	task, err := store.CreateTask(ctx, CreateTaskRequest{
+		ProjectID: binding.ProjectID,
+		Title:     "Default workflow",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask default workflow: %v", err)
+	}
+	if task.WorkflowID != defaultWorkflowID || task.LinkID != defaultLink.ID {
+		t.Fatalf("task selection = %+v, want default workflow %q link %q", task, defaultWorkflowID, defaultLink.ID)
+	}
+}
+
+func TestTaskCreateConcurrentSelectionMutationsRemainSnapshotConsistent(t *testing.T) {
+	t.Run("default mutation", func(t *testing.T) {
+		ctx, fixtureStore, binding, cfg := newTestStoreWithConfigContext(t)
+		firstWorkflowID := createValidWorkflow(t, ctx, fixtureStore)
+		secondWorkflowID := createValidWorkflow(t, ctx, fixtureStore)
+		firstLink, err := fixtureStore.LinkWorkflow(ctx, binding.ProjectID, firstWorkflowID, true)
+		if err != nil {
+			t.Fatalf("LinkWorkflow first default: %v", err)
+		}
+		secondLink, err := fixtureStore.LinkWorkflow(ctx, binding.ProjectID, secondWorkflowID, false)
+		if err != nil {
+			t.Fatalf("LinkWorkflow second: %v", err)
+		}
+		createStore, mutationStore := openConcurrentWorkflowStores(t, cfg)
+		beforeSequence := projectNextTaskSequence(t, ctx, createStore, binding.ProjectID)
+
+		task, createErr, mutationErr := raceTaskCreateWithMutation(
+			ctx,
+			createStore,
+			CreateTaskRequest{ProjectID: binding.ProjectID, Title: "Concurrent default"},
+			func() error {
+				_, err := mutationStore.SetDefaultProjectWorkflowLink(ctx, binding.ProjectID, secondWorkflowID)
+				return err
+			},
+		)
+		assertConcurrentTaskCreateOutcome(
+			t,
+			ctx,
+			createStore,
+			binding.ProjectID,
+			beforeSequence,
+			task,
+			createErr,
+			mutationErr,
+			map[workflow.WorkflowID]string{
+				firstWorkflowID:  firstLink.ID,
+				secondWorkflowID: secondLink.ID,
+			},
+		)
+	})
+
+	t.Run("selected link unlink", func(t *testing.T) {
+		ctx, fixtureStore, binding, cfg := newTestStoreWithConfigContext(t)
+		selectedWorkflowID := createValidWorkflow(t, ctx, fixtureStore)
+		selectedLink, err := fixtureStore.LinkWorkflow(ctx, binding.ProjectID, selectedWorkflowID, false)
+		if err != nil {
+			t.Fatalf("LinkWorkflow selected: %v", err)
+		}
+		createStore, mutationStore := openConcurrentWorkflowStores(t, cfg)
+		beforeSequence := projectNextTaskSequence(t, ctx, createStore, binding.ProjectID)
+		var unlinkResult ProjectWorkflowUnlinkResult
+
+		task, createErr, mutationErr := raceTaskCreateWithMutation(
+			ctx,
+			createStore,
+			CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: &selectedWorkflowID, Title: "Concurrent unlink"},
+			func() error {
+				result, err := mutationStore.UnlinkProjectWorkflow(ctx, selectedLink.ID, "")
+				unlinkResult = result
+				return err
+			},
+		)
+		if createErr != nil {
+			var selectionErr TaskWorkflowSelectionError
+			if !isRetryableSQLiteConflict(createErr) &&
+				(!errors.As(createErr, &selectionErr) ||
+					selectionErr.Reason != TaskWorkflowSelectionWorkflowNotLinked ||
+					selectionErr.WorkflowID == nil ||
+					*selectionErr.WorkflowID != selectedWorkflowID) {
+				t.Fatalf("CreateTask concurrent unlink error = %v, want not-linked or retryable conflict", createErr)
+			}
+			if mutationErr != nil && !isRetryableSQLiteConflict(mutationErr) {
+				t.Fatalf("concurrent unlink error = %v, want success or retryable conflict", mutationErr)
+			}
+			if errors.As(createErr, &selectionErr) && (mutationErr != nil || !unlinkResult.Unlinked) {
+				t.Fatalf("not-linked create outcome requires committed unlink, result=%+v err=%v", unlinkResult, mutationErr)
+			}
+			assertTaskCreationUnchanged(t, ctx, createStore, binding.ProjectID, beforeSequence)
+			return
+		}
+		assertConcurrentTaskCreateOutcome(
+			t,
+			ctx,
+			createStore,
+			binding.ProjectID,
+			beforeSequence,
+			task,
+			createErr,
+			mutationErr,
+			map[workflow.WorkflowID]string{selectedWorkflowID: selectedLink.ID},
+		)
+		if mutationErr == nil && (unlinkResult.Unlinked || !hasProjectWorkflowUnlinkBlocker(unlinkResult.Blockers, "task_references", 1)) {
+			t.Fatalf("unlink after committed create = %+v, want task-reference blocker", unlinkResult)
+		}
+	})
+
+	t.Run("selected definition revision", func(t *testing.T) {
+		ctx, fixtureStore, binding, cfg := newTestStoreWithConfigContext(t)
+		selectedWorkflowID := createValidWorkflow(t, ctx, fixtureStore)
+		selectedLink, err := fixtureStore.LinkWorkflow(ctx, binding.ProjectID, selectedWorkflowID, false)
+		if err != nil {
+			t.Fatalf("LinkWorkflow selected: %v", err)
+		}
+		definition, record, err := fixtureStore.GetDefinition(ctx, selectedWorkflowID)
+		if err != nil {
+			t.Fatalf("GetDefinition selected: %v", err)
+		}
+		start, err := startNode(definition)
+		if err != nil {
+			t.Fatalf("startNode selected: %v", err)
+		}
+		revisionRequest := workflowGraphSaveRequestFromDefinition(selectedWorkflowID, record.Version, false, definition)
+		revisionRequest.Edges[0].PromptTemplate += " Concurrent revision."
+		createStore, mutationStore := openConcurrentWorkflowStores(t, cfg)
+		beforeSequence := projectNextTaskSequence(t, ctx, createStore, binding.ProjectID)
+
+		task, createErr, mutationErr := raceTaskCreateWithMutation(
+			ctx,
+			createStore,
+			CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: &selectedWorkflowID, Title: "Concurrent definition"},
+			func() error {
+				result, err := mutationStore.SaveWorkflowGraph(ctx, revisionRequest)
+				if err != nil {
+					return err
+				}
+				if !result.Saved || !result.Changed || result.Version != record.Version+1 {
+					return fmt.Errorf("concurrent definition revision was not saved: %+v", result)
+				}
+				return nil
+			},
+		)
+		assertConcurrentTaskCreateOutcome(
+			t,
+			ctx,
+			createStore,
+			binding.ProjectID,
+			beforeSequence,
+			task,
+			createErr,
+			mutationErr,
+			map[workflow.WorkflowID]string{selectedWorkflowID: selectedLink.ID},
+		)
+		if createErr == nil {
+			if task.Version != record.Version && task.Version != record.Version+1 {
+				t.Fatalf("created task workflow version = %d, want exact pre/post revision %d or %d", task.Version, record.Version, record.Version+1)
+			}
+			placements, err := createStore.ListPlacements(ctx, task.ID)
+			if err != nil {
+				t.Fatalf("ListPlacements concurrent definition: %v", err)
+			}
+			if len(placements) != 1 || placements[0].NodeID != workflow.NodeIDOf(start) {
+				t.Fatalf("created task placements = %+v, want immutable start node %q", placements, workflow.NodeIDOf(start))
+			}
+		}
+		_, current, err := createStore.GetDefinition(ctx, selectedWorkflowID)
+		if err != nil {
+			t.Fatalf("GetDefinition after concurrent revision: %v", err)
+		}
+		if mutationErr == nil && current.Version != record.Version+1 {
+			t.Fatalf("workflow version after committed revision = %d, want %d", current.Version, record.Version+1)
+		}
+		if mutationErr != nil && current.Version != record.Version {
+			t.Fatalf("workflow version after rejected revision = %d, want %d", current.Version, record.Version)
+		}
+	})
+}
+
+func openConcurrentWorkflowStores(t *testing.T, cfg config.App) (*Store, *Store) {
+	t.Helper()
+	open := func() *Store {
+		metadataStore, err := metadata.Open(cfg.PersistenceRoot)
+		if err != nil {
+			t.Fatalf("metadata.Open concurrent store: %v", err)
+		}
+		t.Cleanup(func() {
+			if err := metadataStore.Close(); err != nil {
+				t.Errorf("close concurrent metadata store: %v", err)
+			}
+		})
+		store, err := New(metadataStore)
+		if err != nil {
+			t.Fatalf("workflowstore.New concurrent store: %v", err)
+		}
+		return store
+	}
+	return open(), open()
+}
+
+func raceTaskCreateWithMutation(
+	ctx context.Context,
+	createStore *Store,
+	req CreateTaskRequest,
+	mutate func() error,
+) (TaskRecord, error, error) {
+	start := make(chan struct{})
+	type createResult struct {
+		task TaskRecord
+		err  error
+	}
+	createResults := make(chan createResult, 1)
+	mutationResults := make(chan error, 1)
+	go func() {
+		<-start
+		task, err := createStore.CreateTask(ctx, req)
+		createResults <- createResult{task: task, err: err}
+	}()
+	go func() {
+		<-start
+		mutationResults <- mutate()
+	}()
+	close(start)
+	created := <-createResults
+	return created.task, created.err, <-mutationResults
+}
+
+func assertConcurrentTaskCreateOutcome(
+	t *testing.T,
+	ctx context.Context,
+	store *Store,
+	projectID string,
+	beforeSequence int64,
+	task TaskRecord,
+	createErr error,
+	mutationErr error,
+	allowedLinks map[workflow.WorkflowID]string,
+) {
+	t.Helper()
+	if mutationErr != nil && !isRetryableSQLiteConflict(mutationErr) {
+		t.Fatalf("concurrent mutation error = %v, want success or retryable SQLite conflict", mutationErr)
+	}
+	if createErr != nil {
+		if !isRetryableSQLiteConflict(createErr) {
+			t.Fatalf("CreateTask concurrent error = %v, want retryable SQLite conflict", createErr)
+		}
+		assertTaskCreationUnchanged(t, ctx, store, projectID, beforeSequence)
+		return
+	}
+	wantLinkID, ok := allowedLinks[task.WorkflowID]
+	if !ok || task.LinkID != wantLinkID {
+		t.Fatalf("created task selection = %+v, allowed links = %+v", task, allowedLinks)
+	}
+	link, err := store.GetProjectWorkflowLink(ctx, task.LinkID)
+	if err != nil {
+		t.Fatalf("GetProjectWorkflowLink created task: %v", err)
+	}
+	if link.ProjectID != projectID || link.WorkflowID != task.WorkflowID {
+		t.Fatalf("created task link = %+v, task = %+v", link, task)
+	}
+	def, record, err := store.GetDefinition(ctx, task.WorkflowID)
+	if err != nil {
+		t.Fatalf("GetDefinition created task workflow: %v", err)
+	}
+	if task.Version <= 0 || task.Version > record.Version {
+		t.Fatalf("created task workflow version = %d, current workflow version = %d", task.Version, record.Version)
+	}
+	start, err := startNode(def)
+	if err != nil {
+		t.Fatalf("startNode created task workflow: %v", err)
+	}
+	placements, err := store.ListPlacements(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("ListPlacements created task: %v", err)
+	}
+	if len(placements) != 1 ||
+		placements[0].TaskID != task.ID ||
+		placements[0].NodeID != workflow.NodeIDOf(start) ||
+		placements[0].State != "active" {
+		t.Fatalf("created task placements = %+v, want one active placement at %q", placements, workflow.NodeIDOf(start))
+	}
+	if got := projectNextTaskSequence(t, ctx, store, projectID); got != beforeSequence+1 {
+		t.Fatalf("project next task sequence = %d, want %d after committed create", got, beforeSequence+1)
+	}
+}
+
+func isRetryableSQLiteConflict(err error) bool {
+	var sqliteErr *sqlitedriver.Error
+	if !errors.As(err, &sqliteErr) {
+		return false
+	}
+	switch sqliteErr.Code() & 0xff {
+	case sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED:
+		return true
+	default:
+		return false
+	}
+}
+
+func projectNextTaskSequence(t *testing.T, ctx context.Context, store *Store, projectID string) int64 {
+	t.Helper()
+	var sequence int64
+	if err := store.db.QueryRowContext(ctx, `SELECT next_task_seq FROM projects WHERE id = ?`, projectID).Scan(&sequence); err != nil {
+		t.Fatalf("query project next task sequence: %v", err)
+	}
+	return sequence
+}
+
+func assertTaskCreationUnchanged(t *testing.T, ctx context.Context, store *Store, projectID string, wantSequence int64) {
+	t.Helper()
+	if got := projectNextTaskSequence(t, ctx, store, projectID); got != wantSequence {
+		t.Fatalf("project next task sequence = %d, want unchanged %d", got, wantSequence)
+	}
+	var taskCount int64
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM task_records WHERE project_id = ?`, projectID).Scan(&taskCount); err != nil {
+		t.Fatalf("count project tasks: %v", err)
+	}
+	if taskCount != 0 {
+		t.Fatalf("project task count = %d, want 0", taskCount)
+	}
+	var placementCount int64
+	if err := store.db.QueryRowContext(ctx, `
+SELECT COUNT(*)
+FROM task_node_placements placement
+JOIN task_records task ON task.id = placement.task_id
+WHERE task.project_id = ?`, projectID).Scan(&placementCount); err != nil {
+		t.Fatalf("count project task placements: %v", err)
+	}
+	if placementCount != 0 {
+		t.Fatalf("project task placement count = %d, want 0", placementCount)
 	}
 }
 

--- a/server/workflowstore/tasks.go
+++ b/server/workflowstore/tasks.go
@@ -14,11 +14,23 @@ import (
 
 type CreateTaskRequest struct {
 	ProjectID         string
-	WorkflowID        workflow.WorkflowID
+	WorkflowID        *workflow.WorkflowID
 	Title             string
 	Body              string
 	SourceURL         string
 	SourceWorkspaceID string
+}
+
+type preparedTaskCreate struct {
+	projectID         string
+	workflowID        *workflow.WorkflowID
+	title             string
+	body              string
+	sourceURL         string
+	sourceWorkspaceID string
+	taskID            string
+	placementID       string
+	nowUnixMs         int64
 }
 
 type UpdateTaskRequest struct {
@@ -119,20 +131,54 @@ type ManualMoveRequest struct {
 type ManualMoveResult = CompleteRunResult
 
 func (s *Store) CreateTask(ctx context.Context, req CreateTaskRequest) (TaskRecord, error) {
-	title := strings.TrimSpace(req.Title)
-	body := strings.TrimSpace(req.Body)
-	if title == "" {
+	var workflowID *workflow.WorkflowID
+	if req.WorkflowID != nil {
+		if strings.TrimSpace(string(*req.WorkflowID)) == "" {
+			return TaskRecord{}, errors.New("workflow id is required when provided")
+		}
+		value := *req.WorkflowID
+		workflowID = &value
+	}
+	prepared := preparedTaskCreate{
+		projectID:         strings.TrimSpace(req.ProjectID),
+		workflowID:        workflowID,
+		title:             strings.TrimSpace(req.Title),
+		body:              strings.TrimSpace(req.Body),
+		sourceURL:         strings.TrimSpace(req.SourceURL),
+		sourceWorkspaceID: strings.TrimSpace(req.SourceWorkspaceID),
+		taskID:            prefixedID("task"),
+		placementID:       prefixedID("placement"),
+		nowUnixMs:         s.now().UnixMilli(),
+	}
+	if prepared.title == "" {
 		return TaskRecord{}, errors.New("task title is required")
 	}
-	link, err := s.resolveTaskWorkflowLink(ctx, req.ProjectID, req.WorkflowID)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return TaskRecord{}, taskCreateStoreError(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	q := s.queries.WithTx(tx)
+	task, err := createTaskWithQueries(ctx, q, prepared)
+	if err != nil {
+		return TaskRecord{}, taskCreateStoreError(err)
+	}
+	if err := tx.Commit(); err != nil {
+		return TaskRecord{}, taskCreateStoreError(err)
+	}
+	return task, nil
+}
+
+func createTaskWithQueries(ctx context.Context, q *sqlitegen.Queries, prepared preparedTaskCreate) (TaskRecord, error) {
+	link, err := resolveTaskWorkflowLinkWithQueries(ctx, q, prepared.projectID, prepared.workflowID)
 	if err != nil {
 		return TaskRecord{}, err
 	}
-	sourceWorkspaceID, err := s.resolveTaskSourceWorkspace(ctx, req.ProjectID, req.SourceWorkspaceID)
+	sourceWorkspaceID, err := resolveTaskSourceWorkspaceWithQueries(ctx, q, prepared.projectID, prepared.sourceWorkspaceID)
 	if err != nil {
 		return TaskRecord{}, err
 	}
-	def, wf, err := s.GetDefinition(ctx, workflow.WorkflowID(link.WorkflowID))
+	def, wf, err := workflowDefinitionFromQueries(ctx, q, workflow.WorkflowID(link.WorkflowID))
 	if err != nil {
 		return TaskRecord{}, err
 	}
@@ -140,16 +186,7 @@ func (s *Store) CreateTask(ctx context.Context, req CreateTaskRequest) (TaskReco
 	if err != nil {
 		return TaskRecord{}, err
 	}
-	now := s.now().UnixMilli()
-	taskID := prefixedID("task")
-	placementID := prefixedID("placement")
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return TaskRecord{}, err
-	}
-	defer func() { _ = tx.Rollback() }()
-	q := s.queries.WithTx(tx)
-	allocated, err := q.AllocateProjectTaskSequence(ctx, sqlitegen.AllocateProjectTaskSequenceParams{ProjectID: req.ProjectID, UpdatedAtUnixMs: now})
+	allocated, err := q.AllocateProjectTaskSequence(ctx, sqlitegen.AllocateProjectTaskSequenceParams{ProjectID: prepared.projectID, UpdatedAtUnixMs: prepared.nowUnixMs})
 	if err != nil {
 		return TaskRecord{}, fmt.Errorf("allocate task sequence: %w", err)
 	}
@@ -159,16 +196,13 @@ func (s *Store) CreateTask(ctx context.Context, req CreateTaskRequest) (TaskReco
 	if err != nil {
 		return TaskRecord{}, err
 	}
-	if err := q.InsertTask(ctx, sqlitegen.InsertTaskParams{ID: taskID, ProjectWorkflowLinkID: link.ID, WorkflowRevisionSeen: wf.Version, TaskSeq: seq, ShortID: shortID, Title: title, Body: body, SourceUrl: strings.TrimSpace(req.SourceURL), SourceWorkspaceID: sql.NullString{String: sourceWorkspaceID, Valid: sourceWorkspaceID != ""}, ManagedWorktreeID: sql.NullString{}, CreatedAtUnixMs: now, UpdatedAtUnixMs: now, MetadataJson: metadataJSON}); err != nil {
+	if err := q.InsertTask(ctx, sqlitegen.InsertTaskParams{ID: prepared.taskID, ProjectWorkflowLinkID: link.ID, WorkflowRevisionSeen: wf.Version, TaskSeq: seq, ShortID: shortID, Title: prepared.title, Body: prepared.body, SourceUrl: prepared.sourceURL, SourceWorkspaceID: sql.NullString{String: sourceWorkspaceID, Valid: sourceWorkspaceID != ""}, ManagedWorktreeID: sql.NullString{}, CreatedAtUnixMs: prepared.nowUnixMs, UpdatedAtUnixMs: prepared.nowUnixMs, MetadataJson: metadataJSON}); err != nil {
 		return TaskRecord{}, fmt.Errorf("insert task: %w", err)
 	}
-	if err := q.InsertTaskNodePlacement(ctx, sqlitegen.InsertTaskNodePlacementParams{ID: placementID, TaskID: taskID, NodeID: nullableString(string(workflow.NodeIDOf(startNode))), State: "active", CreatedAtUnixMs: now, UpdatedAtUnixMs: now}); err != nil {
+	if err := q.InsertTaskNodePlacement(ctx, sqlitegen.InsertTaskNodePlacementParams{ID: prepared.placementID, TaskID: prepared.taskID, NodeID: nullableString(string(workflow.NodeIDOf(startNode))), State: "active", CreatedAtUnixMs: prepared.nowUnixMs, UpdatedAtUnixMs: prepared.nowUnixMs}); err != nil {
 		return TaskRecord{}, fmt.Errorf("insert start placement: %w", err)
 	}
-	if err := tx.Commit(); err != nil {
-		return TaskRecord{}, err
-	}
-	return TaskRecord{ID: workflow.TaskID(taskID), ProjectID: req.ProjectID, WorkflowID: workflow.WorkflowID(link.WorkflowID), LinkID: link.ID, ShortID: shortID, Title: title, Body: body, SourceURL: strings.TrimSpace(req.SourceURL), SourceWorkspaceID: sourceWorkspaceID, Version: wf.Version}, nil
+	return TaskRecord{ID: workflow.TaskID(prepared.taskID), ProjectID: prepared.projectID, WorkflowID: workflow.WorkflowID(link.WorkflowID), LinkID: link.ID, ShortID: shortID, Title: prepared.title, Body: prepared.body, SourceURL: prepared.sourceURL, SourceWorkspaceID: sourceWorkspaceID, Version: wf.Version}, nil
 }
 
 func (s *Store) UpdateTask(ctx context.Context, req UpdateTaskRequest) (TaskRecord, error) {
@@ -306,39 +340,6 @@ func deleteTaskScopedChildren(ctx context.Context, q *sqlitegen.Queries, taskID 
 		return err
 	}
 	return nil
-}
-
-func (s *Store) resolveTaskSourceWorkspace(ctx context.Context, projectID string, workspaceID string) (string, error) {
-	trimmedProjectID := strings.TrimSpace(projectID)
-	trimmedWorkspaceID := strings.TrimSpace(workspaceID)
-	if trimmedProjectID == "" {
-		return "", errors.New("project id is required")
-	}
-	if trimmedWorkspaceID != "" {
-		workspace, err := s.metadata.GetWorkspaceByID(ctx, trimmedWorkspaceID)
-		if err != nil {
-			return "", fmt.Errorf("source workspace %q: %w", trimmedWorkspaceID, err)
-		}
-		if strings.TrimSpace(workspace.ProjectID) != trimmedProjectID {
-			return "", fmt.Errorf("source workspace %q does not belong to project %q: %w", trimmedWorkspaceID, trimmedProjectID, ErrSourceWorkspaceNotInProject)
-		}
-		return trimmedWorkspaceID, nil
-	}
-	workspaces, err := s.metadata.ListProjectWorkspaces(ctx, trimmedProjectID)
-	if err != nil {
-		return "", err
-	}
-	for _, workspace := range workspaces {
-		if workspace.IsPrimary && strings.TrimSpace(workspace.WorkspaceID) != "" {
-			return strings.TrimSpace(workspace.WorkspaceID), nil
-		}
-	}
-	for _, workspace := range workspaces {
-		if strings.TrimSpace(workspace.WorkspaceID) != "" {
-			return strings.TrimSpace(workspace.WorkspaceID), nil
-		}
-	}
-	return "", fmt.Errorf("project %q has no source workspace", trimmedProjectID)
 }
 
 func resolveTaskSourceWorkspaceWithQueries(ctx context.Context, q *sqlitegen.Queries, projectID string, workspaceID string) (string, error) {

--- a/server/workflowstore/tasks.go
+++ b/server/workflowstore/tasks.go
@@ -131,6 +131,10 @@ type ManualMoveRequest struct {
 type ManualMoveResult = CompleteRunResult
 
 func (s *Store) CreateTask(ctx context.Context, req CreateTaskRequest) (TaskRecord, error) {
+	projectID := strings.TrimSpace(req.ProjectID)
+	if projectID == "" {
+		return TaskRecord{}, errors.New("project id is required")
+	}
 	var workflowID *workflow.WorkflowID
 	if req.WorkflowID != nil {
 		if strings.TrimSpace(string(*req.WorkflowID)) == "" {
@@ -140,7 +144,7 @@ func (s *Store) CreateTask(ctx context.Context, req CreateTaskRequest) (TaskReco
 		workflowID = &value
 	}
 	prepared := preparedTaskCreate{
-		projectID:         strings.TrimSpace(req.ProjectID),
+		projectID:         projectID,
 		workflowID:        workflowID,
 		title:             strings.TrimSpace(req.Title),
 		body:              strings.TrimSpace(req.Body),

--- a/server/workflowstore/test_helpers_runs_test.go
+++ b/server/workflowstore/test_helpers_runs_test.go
@@ -216,7 +216,7 @@ func createFanoutJoinWorkflow(t *testing.T, ctx context.Context, store *Store) w
 
 func startFanoutTask(t *testing.T, ctx context.Context, store *Store, projectID string, workflowID workflow.WorkflowID) (TaskRecord, map[workflow.NodeID]workflow.RunID) {
 	t.Helper()
-	task, err := store.CreateTask(ctx, CreateTaskRequest{ProjectID: projectID, WorkflowID: workflowID, Title: "Task", Body: "Body"})
+	task, err := store.CreateTask(ctx, CreateTaskRequest{ProjectID: projectID, WorkflowID: &workflowID, Title: "Task", Body: "Body"})
 	if err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}

--- a/server/workflowsvc/service.go
+++ b/server/workflowsvc/service.go
@@ -1362,7 +1362,7 @@ func (s *Service) workflowInterruptedRunAttentionIDsByWorkflow(ctx context.Conte
 			}
 			for _, item := range attention.Items {
 				runID := strings.TrimSpace(item.RunID)
-				if item.Kind == "interrupted_run" && item.WorkflowID == workflowID && runID != "" && !seenRuns[runID] {
+				if item.Kind == "interrupted_run" && item.WorkflowID != nil && *item.WorkflowID == workflowID && runID != "" && !seenRuns[runID] {
 					seenRuns[runID] = true
 					runIDs = append(runIDs, workflow.RunID(runID))
 				}
@@ -1789,10 +1789,11 @@ func scriptPathValidationErrors(def workflow.Definition, rootPath *string) []ser
 }
 
 func scriptPathValidationError(workflowID workflow.WorkflowID, nodeID workflow.NodeID, diagnostic workflowscript.Diagnostic) serverapi.WorkflowValidationError {
+	workflowIDValue := string(workflowID)
 	return serverapi.WorkflowValidationError{
 		Code:          diagnostic.Code,
 		Message:       diagnostic.Message,
-		WorkflowID:    string(workflowID),
+		WorkflowID:    &workflowIDValue,
 		NodeID:        string(nodeID),
 		BlocksContext: diagnostic.Blocking,
 	}

--- a/server/workflowsvc/service.go
+++ b/server/workflowsvc/service.go
@@ -247,7 +247,18 @@ func (s *Service) ListWorkflows(ctx context.Context, req serverapi.WorkflowListR
 	if err := req.Validate(); err != nil {
 		return serverapi.WorkflowListResponse{}, err
 	}
-	rows, err := s.store.ListWorkflows(ctx, workflowstore.ListWorkflowsRequest{PageSize: req.PageSize, PageToken: req.PageToken, Query: req.Query, ExactName: req.ExactName})
+	var workflowID *workflow.WorkflowID
+	if req.WorkflowID != nil {
+		value := workflow.WorkflowID(*req.WorkflowID)
+		workflowID = &value
+	}
+	rows, err := s.store.ListWorkflows(ctx, workflowstore.ListWorkflowsRequest{
+		PageSize:   req.PageSize,
+		PageToken:  req.PageToken,
+		Query:      req.Query,
+		ProjectID:  req.ProjectID,
+		WorkflowID: workflowID,
+	})
 	if err != nil {
 		return serverapi.WorkflowListResponse{}, err
 	}
@@ -255,7 +266,7 @@ func (s *Service) ListWorkflows(ctx context.Context, req serverapi.WorkflowListR
 	for _, row := range rows.Workflows {
 		out = append(out, workflowRecord(row))
 	}
-	return serverapi.WorkflowListResponse{Workflows: out, NextPageToken: rows.NextPageToken}, nil
+	return serverapi.WorkflowListResponse{Workflows: out, ProjectID: rows.ProjectID, NextPageToken: rows.NextPageToken}, nil
 }
 
 func (s *Service) GetWorkflow(ctx context.Context, req serverapi.WorkflowGetRequest) (serverapi.WorkflowGetResponse, error) {
@@ -598,9 +609,14 @@ func (s *Service) CreateWorkflowTask(ctx context.Context, req serverapi.Workflow
 	if err := req.Validate(); err != nil {
 		return serverapi.WorkflowTaskCreateResponse{}, err
 	}
-	task, err := s.store.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: req.ProjectID, WorkflowID: workflow.WorkflowID(req.WorkflowID), Title: req.Title, Body: req.Body, SourceURL: req.SourceURL, SourceWorkspaceID: req.SourceWorkspaceID})
+	var workflowID *workflow.WorkflowID
+	if req.WorkflowID != nil {
+		value := workflow.WorkflowID(*req.WorkflowID)
+		workflowID = &value
+	}
+	task, err := s.store.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: req.ProjectID, WorkflowID: workflowID, Title: req.Title, Body: req.Body, SourceURL: req.SourceURL, SourceWorkspaceID: req.SourceWorkspaceID})
 	if err != nil {
-		return serverapi.WorkflowTaskCreateResponse{}, err
+		return serverapi.WorkflowTaskCreateResponse{}, workflowTaskCreateError(err)
 	}
 	s.publishWorkflowEvent(ctx, task.ProjectID, string(task.WorkflowID), "task", "created", string(task.ID))
 	detail, err := s.view.GetTask(ctx, string(task.ID))
@@ -608,6 +624,40 @@ func (s *Service) CreateWorkflowTask(ctx context.Context, req serverapi.Workflow
 		return serverapi.WorkflowTaskCreateResponse{}, err
 	}
 	return serverapi.WorkflowTaskCreateResponse{Task: detail.Summary}, nil
+}
+
+func workflowTaskCreateError(err error) error {
+	var selectionErr workflowstore.TaskWorkflowSelectionError
+	if errors.As(err, &selectionErr) {
+		var reason serverapi.WorkflowTaskCreateSelectionReason
+		switch selectionErr.Reason {
+		case workflowstore.TaskWorkflowSelectionNoLinkedWorkflows:
+			reason = serverapi.WorkflowTaskCreateSelectionReasonNoLinkedWorkflows
+		case workflowstore.TaskWorkflowSelectionWorkflowNotLinked:
+			reason = serverapi.WorkflowTaskCreateSelectionReasonWorkflowNotLinked
+		case workflowstore.TaskWorkflowSelectionAmbiguousWithoutDefault:
+			reason = serverapi.WorkflowTaskCreateSelectionReasonAmbiguousWithoutDefault
+		default:
+			return err
+		}
+		var workflowID *string
+		if selectionErr.WorkflowID != nil {
+			value := string(*selectionErr.WorkflowID)
+			workflowID = &value
+		}
+		return &serverapi.WorkflowTaskCreateSelectionError{
+			Reason:     reason,
+			ProjectID:  selectionErr.ProjectID,
+			WorkflowID: workflowID,
+		}
+	}
+	var conflictErr workflowstore.TaskCreateConflictError
+	if errors.As(err, &conflictErr) && conflictErr.Reason == workflowstore.TaskCreateConflictSerialization {
+		return &serverapi.WorkflowTaskCreateConflictError{
+			Reason: serverapi.WorkflowTaskCreateConflictReasonSerialization,
+		}
+	}
+	return err
 }
 
 func (s *Service) UpdateWorkflowTask(ctx context.Context, req serverapi.WorkflowTaskUpdateRequest) (serverapi.WorkflowTaskUpdateResponse, error) {
@@ -1632,13 +1682,17 @@ func (s *Service) GetWorkflowTask(ctx context.Context, req serverapi.WorkflowTas
 }
 
 func workflowRecord(row workflowstore.WorkflowRecord) serverapi.WorkflowRecord {
-	return serverapi.WorkflowRecord{
+	record := serverapi.WorkflowRecord{
 		ID:                    string(row.ID),
 		Name:                  row.Name,
 		Description:           row.Description,
 		Version:               row.Version,
 		ExecutionTargetPolicy: workflowExecutionTargetPolicyToAPI(row.ExecutionTargetPolicy),
 	}
+	if row.ProjectLink != nil {
+		record.ProjectLink = &serverapi.WorkflowListProjectLink{Default: row.ProjectLink.Default}
+	}
+	return record
 }
 
 func workflowNodeGroup(row workflowstore.NodeGroupRecord) serverapi.WorkflowNodeGroup {

--- a/server/workflowsvc/service_test.go
+++ b/server/workflowsvc/service_test.go
@@ -132,7 +132,7 @@ func TestServiceValidateWorkflowScriptPathReportsMissingPath(t *testing.T) {
 		t.Fatalf("validation = %+v, want one blocking missing-path diagnostic", validated)
 	}
 	got := validated.Errors[0]
-	if got.Code != workflowscript.CodeMissingPath || got.WorkflowID != workflowID || got.NodeID != "node-script" || !got.BlocksContext {
+	if got.Code != workflowscript.CodeMissingPath || got.WorkflowID == nil || *got.WorkflowID != workflowID || got.NodeID != "node-script" || !got.BlocksContext {
 		t.Fatalf("validation error = %+v, want blocking missing-path diagnostic scoped to script node", got)
 	}
 }

--- a/server/workflowsvc/service_test.go
+++ b/server/workflowsvc/service_test.go
@@ -147,11 +147,14 @@ func TestServiceListWorkflowTasksValidatesAndDelegates(t *testing.T) {
 	if _, err := service.ListWorkflowTasks(ctx, serverapi.WorkflowTaskListRequest{ProjectID: &blankProjectID}); !isWorkflowServiceRequestFieldError(err, "project_id") {
 		t.Fatalf("blank project error = %#v, want project_id validation", err)
 	}
-	resp, err := service.ListWorkflowTasks(ctx, serverapi.WorkflowTaskListRequest{ProjectID: &binding.ProjectID})
+	resp, err := service.ListWorkflowTasks(ctx, serverapi.WorkflowTaskListRequest{
+		ProjectID:  &binding.ProjectID,
+		WorkflowID: &workflowID,
+	})
 	if err != nil {
 		t.Fatalf("ListWorkflowTasks: %v", err)
 	}
-	if resp.WorkflowID != workflowID || len(resp.Tasks) != 1 || resp.Tasks[0].TaskID != task.Task.ID {
+	if resp.Scope.WorkflowID == nil || *resp.Scope.WorkflowID != workflowID || len(resp.Tasks) != 1 || resp.Tasks[0].TaskID != task.Task.ID {
 		t.Fatalf("task list response = %+v, want workflow %s task %s", resp, workflowID, task.Task.ID)
 	}
 }
@@ -638,13 +641,94 @@ func TestServiceAllowsInvalidDefaultBacklogButRejectsUnlinkedWorkflow(t *testing
 	if err != nil {
 		t.Fatalf("CreateWorkflow unlinked: %v", err)
 	}
-	if _, err := service.CreateWorkflowTask(ctx, serverapi.WorkflowTaskCreateRequest{ProjectID: binding.ProjectID, WorkflowID: unlinked.Workflow.ID, Title: "Task", Body: "Body"}); err == nil {
+	unlinkedWorkflowID := unlinked.Workflow.ID
+	if _, err := service.CreateWorkflowTask(ctx, serverapi.WorkflowTaskCreateRequest{ProjectID: binding.ProjectID, WorkflowID: &unlinkedWorkflowID, Title: "Task", Body: "Body"}); err == nil {
 		t.Fatalf("expected unlinked workflow task create to fail")
 	}
 	linkDefaultWorkflowServiceProject(t, ctx, service, binding.ProjectID, unlinked.Workflow.ID)
 	task := createDefaultWorkflowServiceTask(t, ctx, service, binding.ProjectID)
 	if _, err := service.StartWorkflowTask(ctx, serverapi.WorkflowTaskStartRequest{SetupOperationID: serverapi.NewWorktreeSetupOperationID(), TaskID: task.Task.ID}); !errors.Is(err, workflowstore.ErrWorkflowValidationFailed) {
 		t.Fatalf("expected invalid default workflow start error, got %v", err)
+	}
+}
+
+func TestServiceTaskCreateMapsNoLinkedWorkflowsSelectionError(t *testing.T) {
+	ctx, service, binding := newWorkflowServiceTestContext(t)
+
+	_, err := service.CreateWorkflowTask(ctx, serverapi.WorkflowTaskCreateRequest{
+		ProjectID: binding.ProjectID,
+		Title:     "No workflow",
+	})
+	var selectionErr *serverapi.WorkflowTaskCreateSelectionError
+	if !errors.As(err, &selectionErr) {
+		t.Fatalf("CreateWorkflowTask error = %v, want WorkflowTaskCreateSelectionError", err)
+	}
+	if selectionErr.Reason != serverapi.WorkflowTaskCreateSelectionReasonNoLinkedWorkflows ||
+		selectionErr.ProjectID != binding.ProjectID ||
+		selectionErr.WorkflowID != nil {
+		t.Fatalf("selection error = %+v", selectionErr)
+	}
+}
+
+func TestServiceTaskCreateMapsExplicitWorkflowNotLinkedSelectionError(t *testing.T) {
+	ctx, service, binding := newWorkflowServiceTestContext(t)
+	workflowID := createWorkflowServiceValidWorkflow(t, ctx, service)
+
+	_, err := service.CreateWorkflowTask(ctx, serverapi.WorkflowTaskCreateRequest{
+		ProjectID:  binding.ProjectID,
+		WorkflowID: &workflowID,
+		Title:      "Unlinked workflow",
+	})
+	var selectionErr *serverapi.WorkflowTaskCreateSelectionError
+	if !errors.As(err, &selectionErr) {
+		t.Fatalf("CreateWorkflowTask error = %v, want WorkflowTaskCreateSelectionError", err)
+	}
+	if selectionErr.Reason != serverapi.WorkflowTaskCreateSelectionReasonWorkflowNotLinked ||
+		selectionErr.ProjectID != binding.ProjectID ||
+		selectionErr.WorkflowID == nil ||
+		*selectionErr.WorkflowID != workflowID {
+		t.Fatalf("selection error = %+v", selectionErr)
+	}
+}
+
+func TestServiceTaskCreateMapsAmbiguousWorkflowSelectionError(t *testing.T) {
+	ctx, service, binding := newWorkflowServiceTestContext(t)
+	firstWorkflowID := createWorkflowServiceValidWorkflow(t, ctx, service)
+	secondWorkflowID := createWorkflowServiceValidWorkflow(t, ctx, service)
+	linkWorkflowServiceProject(t, ctx, service, serverapi.WorkflowLinkProjectRequest{
+		ProjectID:     binding.ProjectID,
+		WorkflowID:    firstWorkflowID,
+		DefaultPolicy: serverapi.WorkflowProjectLinkDefaultNever,
+	})
+	linkWorkflowServiceProject(t, ctx, service, serverapi.WorkflowLinkProjectRequest{
+		ProjectID:     binding.ProjectID,
+		WorkflowID:    secondWorkflowID,
+		DefaultPolicy: serverapi.WorkflowProjectLinkDefaultNever,
+	})
+
+	_, err := service.CreateWorkflowTask(ctx, serverapi.WorkflowTaskCreateRequest{
+		ProjectID: binding.ProjectID,
+		Title:     "Ambiguous workflow",
+	})
+	var selectionErr *serverapi.WorkflowTaskCreateSelectionError
+	if !errors.As(err, &selectionErr) {
+		t.Fatalf("CreateWorkflowTask error = %v, want WorkflowTaskCreateSelectionError", err)
+	}
+	if selectionErr.Reason != serverapi.WorkflowTaskCreateSelectionReasonAmbiguousWithoutDefault ||
+		selectionErr.ProjectID != binding.ProjectID ||
+		selectionErr.WorkflowID != nil {
+		t.Fatalf("selection error = %+v", selectionErr)
+	}
+}
+
+func TestServiceTaskCreateMapsRetryableStoreConflict(t *testing.T) {
+	err := workflowTaskCreateError(workflowstore.TaskCreateConflictError{
+		Reason: workflowstore.TaskCreateConflictSerialization,
+		Cause:  errors.New("database locked"),
+	})
+	var conflictErr *serverapi.WorkflowTaskCreateConflictError
+	if !errors.As(err, &conflictErr) || conflictErr.Reason != serverapi.WorkflowTaskCreateConflictReasonSerialization {
+		t.Fatalf("workflowTaskCreateError = %T %v, want typed serialization conflict", err, err)
 	}
 }
 
@@ -1661,6 +1745,25 @@ func TestServiceWorkflowListPaginatesAndCreateLinkIsAtomic(t *testing.T) {
 	}
 	if created.Workflow.ID == "" || created.Link.WorkflowID != created.Workflow.ID || !created.Link.Default {
 		t.Fatalf("created = %+v, want first default link", created)
+	}
+	projectID := binding.ProjectID
+	projectPage, err := service.ListWorkflows(ctx, serverapi.WorkflowListRequest{ProjectID: &projectID, PageSize: 10})
+	if err != nil {
+		t.Fatalf("project ListWorkflows: %v", err)
+	}
+	if projectPage.ProjectID == nil || *projectPage.ProjectID != projectID || len(projectPage.Workflows) != 1 {
+		t.Fatalf("project page = %+v, want one project-scoped workflow", projectPage)
+	}
+	if projectPage.Workflows[0].ProjectLink == nil || !projectPage.Workflows[0].ProjectLink.Default {
+		t.Fatalf("project workflow = %+v, want default project metadata", projectPage.Workflows[0])
+	}
+	exactWorkflowID := created.Workflow.ID
+	exactPage, err := service.ListWorkflows(ctx, serverapi.WorkflowListRequest{WorkflowID: &exactWorkflowID, PageSize: 10})
+	if err != nil {
+		t.Fatalf("exact ListWorkflows: %v", err)
+	}
+	if len(exactPage.Workflows) != 1 || exactPage.Workflows[0].ID != exactWorkflowID {
+		t.Fatalf("exact page = %+v, want selected workflow", exactPage)
 	}
 	if _, err := service.CreateAndLinkWorkflowToProject(ctx, serverapi.WorkflowCreateAndLinkProjectRequest{
 		Name:          "Broken",

--- a/server/workflowview/service.go
+++ b/server/workflowview/service.go
@@ -182,59 +182,87 @@ func (s *Service) ListTasks(ctx context.Context, req serverapi.WorkflowTaskListR
 	if _, err := s.metadata.GetProjectOverview(ctx, projectID); err != nil {
 		return serverapi.WorkflowTaskListResponse{}, err
 	}
-	definitions, _, picker, err := s.workflowSelectionInputs(ctx, projectID, roleResolver)
-	if err != nil {
-		return serverapi.WorkflowTaskListResponse{}, err
-	}
-	var selected serverapi.WorkflowPickerItem
-	for _, candidate := range picker {
-		if candidate.WorkflowID == workflowID {
-			selected = candidate
-			break
+	var def serverapi.WorkflowDefinition
+	var columns []serverapi.WorkflowBoardColumn
+	if workflowID == nil {
+		if len(req.ColumnKeys) > 0 || workflowTaskListSortUsesColumn(req.Sort) {
+			errorProjectID := projectID
+			return serverapi.WorkflowTaskListResponse{}, &serverapi.WorkflowTaskListScopeError{
+				Reason:    serverapi.WorkflowTaskListScopeReasonWorkflowRequiredColumns,
+				ProjectID: &errorProjectID,
+			}
 		}
-	}
-	if selected.WorkflowID == "" {
-		return serverapi.WorkflowTaskListResponse{}, serverapi.WorkflowRequestValidationError{
-			Code:    serverapi.WorkflowRequestErrorInvalidValue,
-			Field:   "workflow_id",
-			Message: fmt.Sprintf("unknown workflow %q for project %s", workflowID, projectID),
+	} else {
+		def, _, err = s.definition(ctx, *workflowID)
+		if err != nil {
+			return serverapi.WorkflowTaskListResponse{}, err
 		}
-	}
-	def := definitions[selected.WorkflowID]
-	columns := boardColumns(def)
-	if err := validateWorkflowTaskListColumnKeys(req.ColumnKeys, columns); err != nil {
-		return serverapi.WorkflowTaskListResponse{}, err
+		columns = boardColumns(def)
+		if err := validateWorkflowTaskListColumnKeys(req.ColumnKeys, columns); err != nil {
+			return serverapi.WorkflowTaskListResponse{}, err
+		}
 	}
 	sortSelectors := normalizeWorkflowTaskListSort(req.Sort)
-	columnStructureHash := workflowTaskListColumnStructureHash(def, columns)
+	columnStructureHash := ""
+	if workflowID != nil {
+		columnStructureHash = workflowTaskListColumnStructureHash(def, columns)
+	}
 	fingerprint := workflowTaskListRequestFingerprint(req, sortSelectors, columnStructureHash)
 	cursor := workflowTaskListCursor{}
+	matchingWorkflowCardinality := serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone
 	if hasPageToken {
-		if pageToken.ProjectID != projectID ||
-			pageToken.WorkflowID != selected.WorkflowID ||
-			pageToken.WorkflowVersion != def.Workflow.Version ||
-			pageToken.ColumnStructureHash != columnStructureHash ||
+		if pageToken.Scope.ProjectID != projectID ||
 			pageToken.StatusModelVersion != workflowTaskStatusModelVersion ||
 			pageToken.Fingerprint != fingerprint {
 			return serverapi.WorkflowTaskListResponse{}, ErrInvalidPageToken
 		}
+		if workflowID == nil {
+			if pageToken.Scope.ProjectWide == nil {
+				return serverapi.WorkflowTaskListResponse{}, ErrInvalidPageToken
+			}
+		} else {
+			narrowed := pageToken.Scope.Narrowed
+			if narrowed == nil ||
+				narrowed.WorkflowID != *workflowID ||
+				narrowed.WorkflowVersion != def.Workflow.Version ||
+				narrowed.ColumnStructureHash != columnStructureHash {
+				return serverapi.WorkflowTaskListResponse{}, ErrInvalidPageToken
+			}
+		}
 		cursor = pageToken.Cursor
+		matchingWorkflowCardinality = pageToken.MatchingWorkflowCardinality
+	}
+	var narrowedQuery *workflowTaskListNarrowedQueryFacts
+	if workflowID != nil {
+		var canceledTerminalNodeID *string
+		if value := canceledBoardTerminalNodeID(def); value != "" {
+			canceledTerminalNodeID = &value
+		}
+		narrowedQuery = &workflowTaskListNarrowedQueryFacts{
+			workflowID:             *workflowID,
+			canceledTerminalNodeID: canceledTerminalNodeID,
+			columns:                columns,
+			columnKeys:             req.ColumnKeys,
+		}
 	}
 	rows, err := s.listWorkflowTaskListRows(ctx, workflowTaskListQueryRequest{
-		projectID:              projectID,
-		workflowID:             selected.WorkflowID,
-		canceledTerminalNodeID: canceledBoardTerminalNodeID(def),
-		columns:                columns,
-		columnKeys:             req.ColumnKeys,
-		statusKinds:            req.StatusKinds,
-		attentionKinds:         req.AttentionKinds,
-		sortSelectors:          sortSelectors,
-		cursor:                 cursor,
-		cursorSet:              hasPageToken,
-		limit:                  pageSize + 1,
+		projectID:      projectID,
+		narrowed:       narrowedQuery,
+		statusKinds:    req.StatusKinds,
+		attentionKinds: req.AttentionKinds,
+		sortSelectors:  sortSelectors,
+		cursor:         cursor,
+		cursorSet:      hasPageToken,
+		limit:          pageSize + 1,
 	})
 	if err != nil {
 		return serverapi.WorkflowTaskListResponse{}, err
+	}
+	if !hasPageToken {
+		matchingWorkflowCardinality, err = workflowTaskListMatchingWorkflowCardinality(rows)
+		if err != nil {
+			return serverapi.WorkflowTaskListResponse{}, err
+		}
 	}
 	pageItems := rows
 	hasNext := len(pageItems) > pageSize
@@ -247,85 +275,78 @@ func (s *Service) ListTasks(ctx context.Context, req serverapi.WorkflowTaskListR
 	}
 	nextPageToken := ""
 	if hasNext && len(pageItems) > 0 {
+		tokenScope := workflowTaskListPageTokenScope{ProjectID: projectID}
+		if workflowID == nil {
+			tokenScope.ProjectWide = &workflowTaskListProjectWidePageTokenInvariants{}
+		} else {
+			tokenScope.Narrowed = &workflowTaskListNarrowedPageTokenInvariants{
+				WorkflowID:          *workflowID,
+				WorkflowVersion:     def.Workflow.Version,
+				ColumnStructureHash: columnStructureHash,
+			}
+		}
 		nextPageToken = workflowTaskListPageToken(workflowTaskListPageTokenPayload{
-			Version:             workflowTaskListPageTokenVersion,
-			ProjectID:           projectID,
-			WorkflowID:          selected.WorkflowID,
-			WorkflowVersion:     def.Workflow.Version,
-			ColumnStructureHash: columnStructureHash,
-			StatusModelVersion:  workflowTaskStatusModelVersion,
-			Fingerprint:         fingerprint,
-			Cursor:              workflowTaskListCursorFromRow(pageItems[len(pageItems)-1]),
+			Version:                     workflowTaskListPageTokenVersion,
+			Scope:                       tokenScope,
+			MatchingWorkflowCardinality: matchingWorkflowCardinality,
+			StatusModelVersion:          workflowTaskStatusModelVersion,
+			Fingerprint:                 fingerprint,
+			Cursor:                      workflowTaskListCursorFromRow(pageItems[len(pageItems)-1]),
 		})
 	}
-	selectedCopy := selected
 	return serverapi.WorkflowTaskListResponse{
-		ProjectID:         projectID,
-		WorkflowID:        selected.WorkflowID,
-		SelectedWorkflow:  &selectedCopy,
-		NextPageToken:     nextPageToken,
-		GeneratedAtUnixMs: time.Now().UTC().UnixMilli(),
-		Tasks:             responseItems,
+		Scope: serverapi.WorkflowTaskListScope{
+			ProjectID:  projectID,
+			WorkflowID: workflowID,
+		},
+		MatchingWorkflowCardinality: matchingWorkflowCardinality,
+		NextPageToken:               nextPageToken,
+		GeneratedAtUnixMs:           time.Now().UTC().UnixMilli(),
+		Tasks:                       responseItems,
 	}, nil
 }
 
-func (s *Service) resolveWorkflowTaskListScope(ctx context.Context, projectIDValue *string, workflowIDValue *string, token *workflowTaskListPageTokenPayload) (string, string, error) {
+func (s *Service) resolveWorkflowTaskListScope(ctx context.Context, projectIDValue *string, workflowIDValue *string, token *workflowTaskListPageTokenPayload) (string, *string, error) {
 	if token != nil {
-		if projectIDValue != nil && *projectIDValue != token.ProjectID {
-			return "", "", ErrInvalidPageToken
+		if projectIDValue != nil && *projectIDValue != token.Scope.ProjectID {
+			return "", nil, ErrInvalidPageToken
 		}
-		if workflowIDValue != nil && *workflowIDValue != token.WorkflowID {
-			return "", "", ErrInvalidPageToken
+		var tokenWorkflowID *string
+		if token.Scope.Narrowed != nil {
+			tokenWorkflowID = &token.Scope.Narrowed.WorkflowID
 		}
-		projectIDValue = &token.ProjectID
-		workflowIDValue = &token.WorkflowID
+		if workflowIDValue != nil {
+			if tokenWorkflowID == nil || *workflowIDValue != *tokenWorkflowID {
+				return "", nil, ErrInvalidPageToken
+			}
+		}
+		projectIDValue = &token.Scope.ProjectID
+		workflowIDValue = tokenWorkflowID
 	}
 	if projectIDValue != nil && workflowIDValue != nil {
 		if _, err := s.queries.GetActiveProjectWorkflowLinkByWorkflow(ctx, sqlitegen.GetActiveProjectWorkflowLinkByWorkflowParams{ProjectID: *projectIDValue, WorkflowID: *workflowIDValue}); err == nil {
-			return *projectIDValue, *workflowIDValue, nil
+			workflowID := *workflowIDValue
+			return *projectIDValue, &workflowID, nil
 		} else if errors.Is(err, sql.ErrNoRows) {
-			return "", "", &serverapi.WorkflowTaskListScopeError{Kind: serverapi.WorkflowTaskListScopeErrorKindNotLinked, ProjectIDs: []string{*projectIDValue}, WorkflowIDs: []string{*workflowIDValue}}
+			errorProjectID := *projectIDValue
+			errorWorkflowID := *workflowIDValue
+			return "", nil, &serverapi.WorkflowTaskListScopeError{Reason: serverapi.WorkflowTaskListScopeReasonWorkflowNotLinked, ProjectID: &errorProjectID, WorkflowID: &errorWorkflowID}
 		} else {
-			return "", "", err
+			return "", nil, err
 		}
 	}
 	if projectIDValue != nil {
-		links, err := s.queries.ListProjectWorkflowLinks(ctx, *projectIDValue)
+		linkCount, err := s.queries.CountActiveProjectWorkflowLinks(ctx, *projectIDValue)
 		if err != nil {
-			return "", "", err
+			return "", nil, err
 		}
-		if len(links) == 1 {
-			return *projectIDValue, links[0].WorkflowID, nil
+		if linkCount == 0 {
+			errorProjectID := *projectIDValue
+			return "", nil, &serverapi.WorkflowTaskListScopeError{Reason: serverapi.WorkflowTaskListScopeReasonNoLinkedWorkflows, ProjectID: &errorProjectID}
 		}
-		candidates := make([]string, 0, len(links))
-		for _, link := range links {
-			candidates = append(candidates, link.WorkflowID)
-		}
-		if len(candidates) == 0 {
-			return "", "", &serverapi.WorkflowTaskListScopeError{Kind: serverapi.WorkflowTaskListScopeErrorKindNotLinked, ProjectIDs: []string{*projectIDValue}}
-		}
-		missing := serverapi.WorkflowTaskListScopeDimensionWorkflow
-		return "", "", &serverapi.WorkflowTaskListScopeError{Kind: serverapi.WorkflowTaskListScopeErrorKindAmbiguous, MissingScope: &missing, ProjectIDs: []string{*projectIDValue}, WorkflowIDs: candidates}
+		return *projectIDValue, nil, nil
 	}
-	if workflowIDValue != nil {
-		links, err := s.queries.ListWorkflowProjectLinks(ctx, *workflowIDValue)
-		if err != nil {
-			return "", "", err
-		}
-		if len(links) == 1 {
-			return links[0].ProjectID, *workflowIDValue, nil
-		}
-		candidates := make([]string, 0, len(links))
-		for _, link := range links {
-			candidates = append(candidates, link.ProjectID)
-		}
-		if len(candidates) == 0 {
-			return "", "", &serverapi.WorkflowTaskListScopeError{Kind: serverapi.WorkflowTaskListScopeErrorKindNotLinked, WorkflowIDs: []string{*workflowIDValue}}
-		}
-		missing := serverapi.WorkflowTaskListScopeDimensionProject
-		return "", "", &serverapi.WorkflowTaskListScopeError{Kind: serverapi.WorkflowTaskListScopeErrorKindAmbiguous, MissingScope: &missing, ProjectIDs: candidates, WorkflowIDs: []string{*workflowIDValue}}
-	}
-	return "", "", &serverapi.WorkflowTaskListScopeError{Kind: serverapi.WorkflowTaskListScopeErrorKindNotLinked}
+	return "", nil, &serverapi.WorkflowTaskListScopeError{Reason: serverapi.WorkflowTaskListScopeReasonNoLinkedWorkflows}
 }
 
 func validateWorkflowTaskListColumnKeys(columnKeys []string, columns []serverapi.WorkflowBoardColumn) error {

--- a/server/workflowview/service.go
+++ b/server/workflowview/service.go
@@ -203,11 +203,24 @@ func (s *Service) ListTasks(ctx context.Context, req serverapi.WorkflowTaskListR
 		}
 	}
 	sortSelectors := normalizeWorkflowTaskListSort(req.Sort)
-	columnStructureHash := ""
-	if workflowID != nil {
-		columnStructureHash = workflowTaskListColumnStructureHash(def, columns)
+	fingerprintScope := workflowTaskListFingerprintScope{
+		ProjectWide: &workflowTaskListProjectWideFingerprintInvariants{},
 	}
-	fingerprint := workflowTaskListRequestFingerprint(req, sortSelectors, columnStructureHash)
+	var columnStructureHash *string
+	if workflowID != nil {
+		value, hashErr := workflowTaskListColumnStructureHash(def, columns)
+		if hashErr != nil {
+			return serverapi.WorkflowTaskListResponse{}, hashErr
+		}
+		columnStructureHash = &value
+		fingerprintScope = workflowTaskListFingerprintScope{
+			Narrowed: &workflowTaskListNarrowedFingerprintInvariants{ColumnStructureHash: value},
+		}
+	}
+	fingerprint, err := workflowTaskListRequestFingerprint(req, sortSelectors, fingerprintScope)
+	if err != nil {
+		return serverapi.WorkflowTaskListResponse{}, err
+	}
 	cursor := workflowTaskListCursor{}
 	matchingWorkflowCardinality := serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone
 	if hasPageToken {
@@ -225,7 +238,8 @@ func (s *Service) ListTasks(ctx context.Context, req serverapi.WorkflowTaskListR
 			if narrowed == nil ||
 				narrowed.WorkflowID != *workflowID ||
 				narrowed.WorkflowVersion != def.Workflow.Version ||
-				narrowed.ColumnStructureHash != columnStructureHash {
+				columnStructureHash == nil ||
+				narrowed.ColumnStructureHash != *columnStructureHash {
 				return serverapi.WorkflowTaskListResponse{}, ErrInvalidPageToken
 			}
 		}
@@ -234,13 +248,9 @@ func (s *Service) ListTasks(ctx context.Context, req serverapi.WorkflowTaskListR
 	}
 	var narrowedQuery *workflowTaskListNarrowedQueryFacts
 	if workflowID != nil {
-		var canceledTerminalNodeID *string
-		if value := canceledBoardTerminalNodeID(def); value != "" {
-			canceledTerminalNodeID = &value
-		}
 		narrowedQuery = &workflowTaskListNarrowedQueryFacts{
 			workflowID:             *workflowID,
-			canceledTerminalNodeID: canceledTerminalNodeID,
+			canceledTerminalNodeID: canceledBoardTerminalNodeID(def),
 			columns:                columns,
 			columnKeys:             req.ColumnKeys,
 		}
@@ -282,10 +292,10 @@ func (s *Service) ListTasks(ctx context.Context, req serverapi.WorkflowTaskListR
 			tokenScope.Narrowed = &workflowTaskListNarrowedPageTokenInvariants{
 				WorkflowID:          *workflowID,
 				WorkflowVersion:     def.Workflow.Version,
-				ColumnStructureHash: columnStructureHash,
+				ColumnStructureHash: *columnStructureHash,
 			}
 		}
-		nextPageToken = workflowTaskListPageToken(workflowTaskListPageTokenPayload{
+		nextPageToken, err = workflowTaskListPageToken(workflowTaskListPageTokenPayload{
 			Version:                     workflowTaskListPageTokenVersion,
 			Scope:                       tokenScope,
 			MatchingWorkflowCardinality: matchingWorkflowCardinality,
@@ -293,6 +303,9 @@ func (s *Service) ListTasks(ctx context.Context, req serverapi.WorkflowTaskListR
 			Fingerprint:                 fingerprint,
 			Cursor:                      workflowTaskListCursorFromRow(pageItems[len(pageItems)-1]),
 		})
+		if err != nil {
+			return serverapi.WorkflowTaskListResponse{}, err
+		}
 	}
 	return serverapi.WorkflowTaskListResponse{
 		Scope: serverapi.WorkflowTaskListScope{
@@ -465,7 +478,7 @@ func (s *Service) ListBoardNodeCards(ctx context.Context, req serverapi.Workflow
 		CursorUpdatedAtUnixMs:  cursorUpdatedAtUnixMs,
 		CursorTaskID:           cursorTaskID,
 		NodeID:                 sql.NullString{String: nodeID, Valid: true},
-		CanceledTerminalNodeID: canceledBoardTerminalNodeID(def),
+		CanceledTerminalNodeID: nullableWorkflowViewString(canceledBoardTerminalNodeID(def)),
 		LimitRows:              int64(pageSize + 1),
 	})
 	if err != nil {
@@ -2357,11 +2370,11 @@ func workflowDerivedEdgeWiringByID(derived serverapi.WorkflowDerivedWiring) map[
 	return byID
 }
 
-func (s *Service) applyBoardColumnTaskCounts(ctx context.Context, columns []serverapi.WorkflowBoardColumn, projectID string, workflowID string, canceledTerminalNodeID string) error {
+func (s *Service) applyBoardColumnTaskCounts(ctx context.Context, columns []serverapi.WorkflowBoardColumn, projectID string, workflowID string, canceledTerminalNodeID *string) error {
 	rows, err := s.queries.ListBoardColumnTaskCounts(ctx, sqlitegen.ListBoardColumnTaskCountsParams{
 		ProjectID:              projectID,
 		WorkflowID:             workflowID,
-		CanceledTerminalNodeID: canceledTerminalNodeID,
+		CanceledTerminalNodeID: nullableWorkflowViewString(canceledTerminalNodeID),
 	})
 	if err != nil {
 		return err
@@ -2380,6 +2393,13 @@ func (s *Service) applyBoardColumnTaskCounts(ctx context.Context, columns []serv
 		}
 	}
 	return nil
+}
+
+func nullableWorkflowViewString(value *string) sql.NullString {
+	if value == nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: *value, Valid: true}
 }
 
 func effectiveBoardPlacements(placements []sqlitegen.TaskNodePlacementRecord, nodeKinds map[string]workflow.NodeKind) []sqlitegen.TaskNodePlacementRecord {
@@ -2409,7 +2429,7 @@ func effectiveBoardPlacementsForTask(task sqlitegen.TaskRecord, placements []sql
 		return active
 	}
 	terminalNodeID := canceledBoardTerminalNodeID(def)
-	if terminalNodeID == "" {
+	if terminalNodeID == nil {
 		return active
 	}
 	terminalPlacements := make([]sqlitegen.TaskNodePlacementRecord, 0, len(active))
@@ -2425,24 +2445,26 @@ func effectiveBoardPlacementsForTask(task sqlitegen.TaskRecord, placements []sql
 	return []sqlitegen.TaskNodePlacementRecord{{
 		ID:              "",
 		TaskID:          task.ID,
-		NodeID:          sql.NullString{String: terminalNodeID, Valid: true},
+		NodeID:          sql.NullString{String: *terminalNodeID, Valid: true},
 		State:           "active",
 		CreatedAtUnixMs: task.UpdatedAtUnixMs,
 		UpdatedAtUnixMs: task.UpdatedAtUnixMs,
 	}}
 }
 
-func canceledBoardTerminalNodeID(def serverapi.WorkflowDefinition) string {
-	fallback := ""
+func canceledBoardTerminalNodeID(def serverapi.WorkflowDefinition) *string {
+	var fallback *string
 	for _, node := range def.Nodes {
 		if workflow.NodeKind(node.Kind) != workflow.NodeKindTerminal {
 			continue
 		}
-		if fallback == "" {
-			fallback = node.ID
+		if fallback == nil {
+			value := node.ID
+			fallback = &value
 		}
 		if node.Key == "done" {
-			return node.ID
+			value := node.ID
+			return &value
 		}
 	}
 	return fallback

--- a/server/workflowview/service.go
+++ b/server/workflowview/service.go
@@ -281,9 +281,13 @@ func (s *Service) ListTasks(ctx context.Context, req serverapi.WorkflowTaskListR
 	}
 	responseItems := make([]serverapi.WorkflowTaskListItem, 0, len(pageItems))
 	for _, item := range pageItems {
-		responseItems = append(responseItems, item.item)
+		responseItem := item.item
+		if matchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple {
+			responseItem.WorkflowName = nil
+		}
+		responseItems = append(responseItems, responseItem)
 	}
-	nextPageToken := ""
+	var nextPageToken *string
 	if hasNext && len(pageItems) > 0 {
 		tokenScope := workflowTaskListPageTokenScope{ProjectID: projectID}
 		if workflowID == nil {
@@ -295,7 +299,7 @@ func (s *Service) ListTasks(ctx context.Context, req serverapi.WorkflowTaskListR
 				ColumnStructureHash: *columnStructureHash,
 			}
 		}
-		nextPageToken, err = workflowTaskListPageToken(workflowTaskListPageTokenPayload{
+		encodedToken, encodeErr := workflowTaskListPageToken(workflowTaskListPageTokenPayload{
 			Version:                     workflowTaskListPageTokenVersion,
 			Scope:                       tokenScope,
 			MatchingWorkflowCardinality: matchingWorkflowCardinality,
@@ -303,9 +307,10 @@ func (s *Service) ListTasks(ctx context.Context, req serverapi.WorkflowTaskListR
 			Fingerprint:                 fingerprint,
 			Cursor:                      workflowTaskListCursorFromRow(pageItems[len(pageItems)-1]),
 		})
-		if err != nil {
-			return serverapi.WorkflowTaskListResponse{}, err
+		if encodeErr != nil {
+			return serverapi.WorkflowTaskListResponse{}, encodeErr
 		}
+		nextPageToken = &encodedToken
 	}
 	return serverapi.WorkflowTaskListResponse{
 		Scope: serverapi.WorkflowTaskListScope{
@@ -1096,9 +1101,10 @@ func (s *Service) attentionItemCandidates(ctx context.Context, projectID string,
 }
 
 func (s *Service) attentionItemFromCandidate(ctx context.Context, row attentionCandidateRow, roleResolver workflow.RoleResolver, questions *pendingQuestionResolver) (serverapi.WorkflowAttentionItem, bool, error) {
+	workflowID := row.workflowID
 	switch row.kind {
 	case "approval":
-		return serverapi.WorkflowAttentionItem{ID: row.id, Kind: "approval", ProjectID: row.projectID, WorkflowID: row.workflowID, TaskID: row.taskID, TaskShortID: row.shortID, TaskTitle: row.title, TaskTransitionID: row.taskTransitionID, Message: "Approval required", OccurredAtUnixMs: row.occurredAtUnixMs}, true, nil
+		return serverapi.WorkflowAttentionItem{ID: row.id, Kind: "approval", ProjectID: row.projectID, WorkflowID: &workflowID, TaskID: row.taskID, TaskShortID: row.shortID, TaskTitle: row.title, TaskTransitionID: row.taskTransitionID, Message: "Approval required", OccurredAtUnixMs: row.occurredAtUnixMs}, true, nil
 	case "question":
 		question, err := questions.Question(ctx, row.sessionID, row.askID)
 		if err != nil {
@@ -1106,7 +1112,7 @@ func (s *Service) attentionItemFromCandidate(ctx context.Context, row attentionC
 		}
 		return workflowQuestionAttentionItem(row.id, row.projectID, row.workflowID, row.taskID, row.shortID, row.title, row.runID, row.sessionID, row.askID, question, row.occurredAtUnixMs), true, nil
 	case attentionKindInterruptedRun:
-		return serverapi.WorkflowAttentionItem{ID: row.id, Kind: attentionKindInterruptedRun, ProjectID: row.projectID, WorkflowID: row.workflowID, TaskID: row.taskID, TaskShortID: row.shortID, TaskTitle: row.title, RunID: row.runID, SessionID: row.sessionID, Message: interruptedRunMessage(row.interruptionReason, row.interruptionDetailJSON), DetailJSON: row.interruptionDetailJSON, OccurredAtUnixMs: row.occurredAtUnixMs}, true, nil
+		return serverapi.WorkflowAttentionItem{ID: row.id, Kind: attentionKindInterruptedRun, ProjectID: row.projectID, WorkflowID: &workflowID, TaskID: row.taskID, TaskShortID: row.shortID, TaskTitle: row.title, RunID: row.runID, SessionID: row.sessionID, Message: interruptedRunMessage(row.interruptionReason, row.interruptionDetailJSON), DetailJSON: row.interruptionDetailJSON, OccurredAtUnixMs: row.occurredAtUnixMs}, true, nil
 	case "validation_blocker":
 		def, _, err := s.definition(ctx, row.workflowID)
 		if err != nil {
@@ -1116,7 +1122,7 @@ func (s *Service) attentionItemFromCandidate(ctx context.Context, row attentionC
 		if !validation.HasBlockingErrors() {
 			return serverapi.WorkflowAttentionItem{}, false, nil
 		}
-		return serverapi.WorkflowAttentionItem{ID: row.id, Kind: "validation_blocker", ProjectID: row.projectID, WorkflowID: row.workflowID, Message: fmt.Sprintf("Workflow %q is invalid for task start", def.Workflow.Name), OccurredAtUnixMs: row.occurredAtUnixMs}, true, nil
+		return serverapi.WorkflowAttentionItem{ID: row.id, Kind: "validation_blocker", ProjectID: row.projectID, WorkflowID: &workflowID, Message: fmt.Sprintf("Workflow %q is invalid for task start", def.Workflow.Name), OccurredAtUnixMs: row.occurredAtUnixMs}, true, nil
 	default:
 		return serverapi.WorkflowAttentionItem{}, false, fmt.Errorf("unknown attention item kind %q", row.kind)
 	}
@@ -1392,7 +1398,8 @@ func (s *Service) activityItemsFromRows(task sqlitegen.TaskRecord, rows []taskAc
 				item.Summary = "Run completed"
 			case "run_interrupted":
 				item.Summary = interruptedRunMessage(metadata.OptionalString(run.InterruptionReason), run.InterruptionDetailJson)
-				attention := serverapi.WorkflowAttentionItem{ID: attentionKindInterruptedRun + ":" + run.ID, Kind: attentionKindInterruptedRun, ProjectID: task.ProjectID, WorkflowID: task.WorkflowID, TaskID: task.ID, TaskShortID: task.ShortID, TaskTitle: task.Title, RunID: run.ID, SessionID: run.SessionID.String, Message: item.Summary, DetailJSON: run.InterruptionDetailJson, OccurredAtUnixMs: run.InterruptedAtUnixMs.Int64}
+				workflowID := task.WorkflowID
+				attention := serverapi.WorkflowAttentionItem{ID: attentionKindInterruptedRun + ":" + run.ID, Kind: attentionKindInterruptedRun, ProjectID: task.ProjectID, WorkflowID: &workflowID, TaskID: task.ID, TaskShortID: task.ShortID, TaskTitle: task.Title, RunID: run.ID, SessionID: run.SessionID.String, Message: item.Summary, DetailJSON: run.InterruptionDetailJson, OccurredAtUnixMs: run.InterruptedAtUnixMs.Int64}
 				item.Attention = &attention
 			}
 		case "task_canceled":
@@ -1685,7 +1692,8 @@ func (s *Service) approvalAttentionItems(ctx context.Context, projectID string, 
 	}
 	items := make([]serverapi.WorkflowAttentionItem, 0, len(rows))
 	for _, row := range rows {
-		items = append(items, serverapi.WorkflowAttentionItem{ID: "approval:" + row.TaskTransitionID, Kind: "approval", ProjectID: row.ProjectID, WorkflowID: row.WorkflowID, TaskID: row.TaskID, TaskShortID: row.ShortID, TaskTitle: row.Title, TaskTransitionID: row.TaskTransitionID, Message: "Approval required", OccurredAtUnixMs: row.CreatedAtUnixMs})
+		workflowID := row.WorkflowID
+		items = append(items, serverapi.WorkflowAttentionItem{ID: "approval:" + row.TaskTransitionID, Kind: "approval", ProjectID: row.ProjectID, WorkflowID: &workflowID, TaskID: row.TaskID, TaskShortID: row.ShortID, TaskTitle: row.Title, TaskTransitionID: row.TaskTransitionID, Message: "Approval required", OccurredAtUnixMs: row.CreatedAtUnixMs})
 	}
 	return items, nil
 }
@@ -1723,7 +1731,8 @@ func requiredWaitingAskID(value sql.NullString, runID string) (string, error) {
 }
 
 func workflowQuestionAttentionItem(id string, projectID string, workflowID string, taskID string, shortID string, title string, runID string, sessionID string, askID string, question pendingQuestion, occurredAtUnixMs int64) serverapi.WorkflowAttentionItem {
-	return serverapi.WorkflowAttentionItem{ID: id, Kind: "question", ProjectID: projectID, WorkflowID: workflowID, TaskID: taskID, TaskShortID: shortID, TaskTitle: title, RunID: runID, SessionID: sessionID, AskID: askID, Message: question.message, Suggestions: question.suggestions, RecommendedOptionIndex: question.recommendedOptionIndex, Question: question.prompt, OccurredAtUnixMs: occurredAtUnixMs}
+	workflowIDValue := workflowID
+	return serverapi.WorkflowAttentionItem{ID: id, Kind: "question", ProjectID: projectID, WorkflowID: &workflowIDValue, TaskID: taskID, TaskShortID: shortID, TaskTitle: title, RunID: runID, SessionID: sessionID, AskID: askID, Message: question.message, Suggestions: question.suggestions, RecommendedOptionIndex: question.recommendedOptionIndex, Question: question.prompt, OccurredAtUnixMs: occurredAtUnixMs}
 }
 
 const pendingQuestionFallbackMessage = "Question pending; open the task to answer."
@@ -1859,7 +1868,8 @@ func (s *Service) interruptedRunAttentionItems(ctx context.Context, projectID st
 	}
 	items := make([]serverapi.WorkflowAttentionItem, 0, len(rows))
 	for _, row := range rows {
-		items = append(items, serverapi.WorkflowAttentionItem{ID: attentionKindInterruptedRun + ":" + row.RunID, Kind: attentionKindInterruptedRun, ProjectID: row.ProjectID, WorkflowID: row.WorkflowID, TaskID: row.TaskID, TaskShortID: row.ShortID, TaskTitle: row.Title, RunID: row.RunID, SessionID: row.SessionID, Message: interruptedRunMessage(metadata.OptionalString(row.InterruptionReason), row.InterruptionDetailJson), DetailJSON: row.InterruptionDetailJson, OccurredAtUnixMs: row.InterruptedAtUnixMs.Int64})
+		workflowID := row.WorkflowID
+		items = append(items, serverapi.WorkflowAttentionItem{ID: attentionKindInterruptedRun + ":" + row.RunID, Kind: attentionKindInterruptedRun, ProjectID: row.ProjectID, WorkflowID: &workflowID, TaskID: row.TaskID, TaskShortID: row.ShortID, TaskTitle: row.Title, RunID: row.RunID, SessionID: row.SessionID, Message: interruptedRunMessage(metadata.OptionalString(row.InterruptionReason), row.InterruptionDetailJson), DetailJSON: row.InterruptionDetailJson, OccurredAtUnixMs: row.InterruptedAtUnixMs.Int64})
 	}
 	return items, nil
 }
@@ -1924,7 +1934,8 @@ func (s *Service) validationAttentionItems(ctx context.Context, projectID string
 		if !validation.HasBlockingErrors() {
 			continue
 		}
-		items = append(items, serverapi.WorkflowAttentionItem{ID: "validation_blocker:" + link.projectID + ":" + link.workflowID, Kind: "validation_blocker", ProjectID: link.projectID, WorkflowID: link.workflowID, Message: fmt.Sprintf("Workflow %q is invalid for task start", def.Workflow.Name), OccurredAtUnixMs: link.occurredAt})
+		workflowID := link.workflowID
+		items = append(items, serverapi.WorkflowAttentionItem{ID: "validation_blocker:" + link.projectID + ":" + link.workflowID, Kind: "validation_blocker", ProjectID: link.projectID, WorkflowID: &workflowID, Message: fmt.Sprintf("Workflow %q is invalid for task start", def.Workflow.Name), OccurredAtUnixMs: link.occurredAt})
 	}
 	return items, nil
 }

--- a/server/workflowview/service_test.go
+++ b/server/workflowview/service_test.go
@@ -264,7 +264,7 @@ func TestBoardNodeCardsProjectBoundedUnicodeMarkdownPreview(t *testing.T) {
 	for _, testCase := range cases {
 		if _, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
 			ProjectID:  binding.ProjectID,
-			WorkflowID: workflowID,
+			WorkflowID: workflowIDPointerForTest(workflowID),
 			Title:      testCase.title,
 			Body:       testCase.body,
 		}); err != nil {
@@ -333,7 +333,7 @@ func TestBoardNodeCardsDefaultPageSizeIs25(t *testing.T) {
 	for index := 0; index < 26; index++ {
 		if _, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
 			ProjectID:  binding.ProjectID,
-			WorkflowID: workflowID,
+			WorkflowID: workflowIDPointerForTest(workflowID),
 			Title:      "Task " + strconv.Itoa(index),
 			Body:       "Body",
 		}); err != nil {
@@ -929,11 +929,11 @@ func TestBoardSelectsWorkflowAndReturnsPickerAndGroups(t *testing.T) {
 	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, selected.ID, false); err != nil {
 		t.Fatalf("LinkWorkflow selected: %v", err)
 	}
-	defaultTask, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: defaultWorkflowID, Title: "Default task", Body: "Body"})
+	defaultTask, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowIDPointerForTest(defaultWorkflowID), Title: "Default task", Body: "Body"})
 	if err != nil {
 		t.Fatalf("CreateTask default: %v", err)
 	}
-	selectedTask, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: selected.ID, Title: "Selected task", Body: "Body"})
+	selectedTask, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowIDPointerForTest(selected.ID), Title: "Selected task", Body: "Body"})
 	if err != nil {
 		t.Fatalf("CreateTask selected: %v", err)
 	}
@@ -1031,7 +1031,7 @@ func TestTaskDetailPrefersActiveWorkflowLink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LinkWorkflow: %v", err)
 	}
-	task, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowID, Title: "Historical", Body: "Body"})
+	task, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowIDPointerForTest(workflowID), Title: "Historical", Body: "Body"})
 	if err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
@@ -1060,7 +1060,7 @@ func TestBoardColumnTaskCountsUseFullSelectedWorkflow(t *testing.T) {
 	}
 	taskIDs := []string{}
 	for _, title := range []string{"Task A", "Task B"} {
-		task, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowID, Title: title, Body: "Body"})
+		task, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowIDPointerForTest(workflowID), Title: title, Body: "Body"})
 		if err != nil {
 			t.Fatalf("CreateTask %s: %v", title, err)
 		}
@@ -1121,7 +1121,7 @@ func TestBoardNodeCardsBidirectionalPaginationRoundTripsWithoutGaps(t *testing.T
 	for index := 0; index < 126; index++ {
 		task, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
 			ProjectID:  binding.ProjectID,
-			WorkflowID: workflowID,
+			WorkflowID: workflowIDPointerForTest(workflowID),
 			Title:      "Paged task " + strconv.Itoa(index),
 			Body:       "Body",
 		})
@@ -1245,7 +1245,7 @@ func TestBoardNodeCardsArchiveCanceledTaskInDoneNode(t *testing.T) {
 	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, workflowID, true); err != nil {
 		t.Fatalf("LinkWorkflow: %v", err)
 	}
-	task, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowID, Title: "Canceled backlog", Body: "Body"})
+	task, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowIDPointerForTest(workflowID), Title: "Canceled backlog", Body: "Body"})
 	if err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
@@ -1287,7 +1287,7 @@ func TestBoardNodeCardsAllowRestartAfterDoneTaskResetToBacklog(t *testing.T) {
 	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, workflowID, true); err != nil {
 		t.Fatalf("LinkWorkflow: %v", err)
 	}
-	task, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowID, Title: "Restart", Body: "Body"})
+	task, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowIDPointerForTest(workflowID), Title: "Restart", Body: "Body"})
 	if err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
@@ -1329,7 +1329,7 @@ func TestBoardNodeCardsIgnoreInterruptedRunsFromCompletedPlacementsAfterResetToB
 	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, workflowID, true); err != nil {
 		t.Fatalf("LinkWorkflow: %v", err)
 	}
-	task, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowID, Title: "Restart", Body: "Body"})
+	task, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowIDPointerForTest(workflowID), Title: "Restart", Body: "Body"})
 	if err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
@@ -1392,7 +1392,7 @@ func TestBoardNodeCardsDoNotArchiveCanceledTaskInAlternateTerminalNode(t *testin
 	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, workflowID, true); err != nil {
 		t.Fatalf("LinkWorkflow: %v", err)
 	}
-	task, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowID, Title: "Canceled backlog", Body: "Body"})
+	task, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, WorkflowID: workflowIDPointerForTest(workflowID), Title: "Canceled backlog", Body: "Body"})
 	if err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}

--- a/server/workflowview/service_test.go
+++ b/server/workflowview/service_test.go
@@ -186,7 +186,7 @@ func TestWorkflowPickerAndAttentionIncludeScriptPathDiagnostics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListAttention: %v", err)
 	}
-	if len(attention.Items) != 1 || attention.Items[0].Kind != "validation_blocker" || attention.Items[0].WorkflowID != string(created.ID) {
+	if len(attention.Items) != 1 || attention.Items[0].Kind != "validation_blocker" || attention.Items[0].WorkflowID == nil || *attention.Items[0].WorkflowID != string(created.ID) {
 		t.Fatalf("attention items = %+v, want workflow validation blocker", attention.Items)
 	}
 }

--- a/server/workflowview/task_list_query.go
+++ b/server/workflowview/task_list_query.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -111,15 +112,34 @@ func workflowTaskListContinuationCardinalityValid(cardinality serverapi.Workflow
 		cardinality == serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple
 }
 
-func workflowTaskListPageToken(payload workflowTaskListPageTokenPayload) string {
+func workflowTaskListPageToken(payload workflowTaskListPageTokenPayload) (string, error) {
 	raw, err := json.Marshal(payload)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("marshal task list page token: %w", err)
 	}
-	return base64.RawURLEncoding.EncodeToString(raw)
+	return base64.RawURLEncoding.EncodeToString(raw), nil
 }
 
-func workflowTaskListRequestFingerprint(req serverapi.WorkflowTaskListRequest, sortSelectors []serverapi.WorkflowTaskListSort, columnStructureHash string) string {
+type workflowTaskListProjectWideFingerprintInvariants struct{}
+
+type workflowTaskListNarrowedFingerprintInvariants struct {
+	ColumnStructureHash string `json:"column_structure_hash"`
+}
+
+type workflowTaskListFingerprintScope struct {
+	ProjectWide *workflowTaskListProjectWideFingerprintInvariants `json:"project_wide,omitempty"`
+	Narrowed    *workflowTaskListNarrowedFingerprintInvariants    `json:"narrowed,omitempty"`
+}
+
+func workflowTaskListRequestFingerprint(req serverapi.WorkflowTaskListRequest, sortSelectors []serverapi.WorkflowTaskListSort, scope workflowTaskListFingerprintScope) (string, error) {
+	if (scope.ProjectWide == nil) == (scope.Narrowed == nil) {
+		return "", errors.New("task list fingerprint requires exactly one scope mode")
+	}
+	if scope.Narrowed != nil &&
+		(strings.TrimSpace(scope.Narrowed.ColumnStructureHash) == "" ||
+			strings.TrimSpace(scope.Narrowed.ColumnStructureHash) != scope.Narrowed.ColumnStructureHash) {
+		return "", errors.New("task list narrowed fingerprint requires column structure hash")
+	}
 	statusKinds := make([]string, 0, len(req.StatusKinds))
 	for _, kind := range req.StatusKinds {
 		statusKinds = append(statusKinds, string(kind))
@@ -129,34 +149,48 @@ func workflowTaskListRequestFingerprint(req serverapi.WorkflowTaskListRequest, s
 		attentionKinds = append(attentionKinds, string(kind))
 	}
 	payload := struct {
-		ColumnKeys          []string                         `json:"column_keys"`
-		StatusKinds         []string                         `json:"status_kinds"`
-		AttentionKinds      []string                         `json:"attention_kinds"`
-		Sort                []serverapi.WorkflowTaskListSort `json:"sort"`
-		ColumnStructureHash string                           `json:"column_structure_hash"`
-		StatusModelVersion  int                              `json:"status_model_version"`
+		ColumnKeys         []string                         `json:"column_keys"`
+		StatusKinds        []string                         `json:"status_kinds"`
+		AttentionKinds     []string                         `json:"attention_kinds"`
+		Sort               []serverapi.WorkflowTaskListSort `json:"sort"`
+		Scope              workflowTaskListFingerprintScope `json:"scope"`
+		StatusModelVersion int                              `json:"status_model_version"`
 	}{
-		ColumnKeys:          dedupeSortedStrings(req.ColumnKeys),
-		StatusKinds:         dedupeSortedStrings(statusKinds),
-		AttentionKinds:      dedupeSortedStrings(attentionKinds),
-		Sort:                sortSelectors,
-		ColumnStructureHash: columnStructureHash,
-		StatusModelVersion:  workflowTaskStatusModelVersion,
+		ColumnKeys:         dedupeSortedStrings(req.ColumnKeys),
+		StatusKinds:        dedupeSortedStrings(statusKinds),
+		AttentionKinds:     dedupeSortedStrings(attentionKinds),
+		Sort:               sortSelectors,
+		Scope:              scope,
+		StatusModelVersion: workflowTaskStatusModelVersion,
 	}
-	raw, _ := json.Marshal(payload)
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal task list fingerprint: %w", err)
+	}
 	sum := sha256.Sum256(raw)
-	return base64.RawURLEncoding.EncodeToString(sum[:])
+	return base64.RawURLEncoding.EncodeToString(sum[:]), nil
 }
 
-func workflowTaskListColumnStructureHash(def serverapi.WorkflowDefinition, columns []serverapi.WorkflowBoardColumn) string {
-	parts := make([]string, 0, len(columns)+1)
+func workflowTaskListColumnStructureHash(def serverapi.WorkflowDefinition, columns []serverapi.WorkflowBoardColumn) (string, error) {
+	columnFacts := make([]string, 0, len(columns))
 	for _, column := range columns {
-		parts = append(parts, strings.Join([]string{column.Node.NodeID, column.Node.Key, column.Node.Kind, strconv.Itoa(column.SortOrder), strconv.FormatBool(column.IsBacklog), strconv.FormatBool(column.IsDone)}, "\x00"))
+		columnFacts = append(columnFacts, strings.Join([]string{column.Node.NodeID, column.Node.Key, column.Node.Kind, strconv.Itoa(column.SortOrder), strconv.FormatBool(column.IsBacklog), strconv.FormatBool(column.IsDone)}, "\x00"))
 	}
-	parts = append(parts, "status-model:"+strconv.Itoa(workflowTaskStatusModelVersion))
-	parts = append(parts, "canceled:"+canceledBoardTerminalNodeID(def))
-	sum := sha256.Sum256([]byte(strings.Join(parts, "\x01")))
-	return base64.RawURLEncoding.EncodeToString(sum[:])
+	payload := struct {
+		Columns                []string `json:"columns"`
+		StatusModelVersion     int      `json:"status_model_version"`
+		CanceledTerminalNodeID *string  `json:"canceled_terminal_node_id"`
+	}{
+		Columns:                columnFacts,
+		StatusModelVersion:     workflowTaskStatusModelVersion,
+		CanceledTerminalNodeID: canceledBoardTerminalNodeID(def),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal task list column structure: %w", err)
+	}
+	sum := sha256.Sum256(raw)
+	return base64.RawURLEncoding.EncodeToString(sum[:]), nil
 }
 
 func dedupeSortedStrings(values []string) []string {

--- a/server/workflowview/task_list_query.go
+++ b/server/workflowview/task_list_query.go
@@ -3,6 +3,7 @@ package workflowview
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -11,11 +12,12 @@ import (
 	"strings"
 
 	"core/server/metadata/sqlitegen"
+	"core/shared/runtimeids"
 	"core/shared/serverapi"
 )
 
 const (
-	workflowTaskListPageTokenVersion = 2
+	workflowTaskListPageTokenVersion = 3
 	workflowTaskStatusModelVersion   = 1
 )
 
@@ -29,15 +31,36 @@ func normalizeWorkflowTaskListSort(sortSelectors []serverapi.WorkflowTaskListSor
 	return append([]serverapi.WorkflowTaskListSort(nil), sortSelectors...)
 }
 
+func workflowTaskListSortUsesColumn(sortSelectors []serverapi.WorkflowTaskListSort) bool {
+	for _, selector := range sortSelectors {
+		if selector.Field == serverapi.WorkflowTaskListSortFieldColumn {
+			return true
+		}
+	}
+	return false
+}
+
 type workflowTaskListPageTokenPayload struct {
-	Version             int                    `json:"version"`
-	ProjectID           string                 `json:"project_id"`
-	WorkflowID          string                 `json:"workflow_id"`
-	WorkflowVersion     int64                  `json:"workflow_version"`
-	ColumnStructureHash string                 `json:"column_structure_hash"`
-	StatusModelVersion  int                    `json:"status_model_version"`
-	Fingerprint         string                 `json:"fingerprint"`
-	Cursor              workflowTaskListCursor `json:"cursor"`
+	Version                     int                                                   `json:"version"`
+	Scope                       workflowTaskListPageTokenScope                        `json:"scope"`
+	MatchingWorkflowCardinality serverapi.WorkflowTaskListMatchingWorkflowCardinality `json:"matching_workflow_cardinality"`
+	StatusModelVersion          int                                                   `json:"status_model_version"`
+	Fingerprint                 string                                                `json:"fingerprint"`
+	Cursor                      workflowTaskListCursor                                `json:"cursor"`
+}
+
+type workflowTaskListPageTokenScope struct {
+	ProjectID   string                                          `json:"project_id"`
+	ProjectWide *workflowTaskListProjectWidePageTokenInvariants `json:"project_wide,omitempty"`
+	Narrowed    *workflowTaskListNarrowedPageTokenInvariants    `json:"narrowed,omitempty"`
+}
+
+type workflowTaskListProjectWidePageTokenInvariants struct{}
+
+type workflowTaskListNarrowedPageTokenInvariants struct {
+	WorkflowID          string `json:"workflow_id"`
+	WorkflowVersion     int64  `json:"workflow_version"`
+	ColumnStructureHash string `json:"column_structure_hash"`
 }
 
 type workflowTaskListCursor struct {
@@ -45,7 +68,7 @@ type workflowTaskListCursor struct {
 	CreatedAtUnixMs   int64  `json:"created_at_unix_ms"`
 	UpdatedAtUnixMs   int64  `json:"updated_at_unix_ms"`
 	PrimaryStatusRank int    `json:"primary_status_rank"`
-	ColumnRank        int    `json:"column_rank"`
+	ColumnRank        *int   `json:"column_rank,omitempty"`
 	RunCount          int    `json:"run_count"`
 	TitleSort         string `json:"title_sort"`
 }
@@ -62,10 +85,30 @@ func parseWorkflowTaskListPageToken(raw string) (workflowTaskListPageTokenPayloa
 	if err := json.Unmarshal(decoded, &payload); err != nil {
 		return workflowTaskListPageTokenPayload{}, false, ErrInvalidPageToken
 	}
-	if payload.Version != workflowTaskListPageTokenVersion || strings.TrimSpace(payload.ProjectID) == "" || strings.TrimSpace(payload.WorkflowID) == "" || payload.WorkflowVersion < 1 || strings.TrimSpace(payload.ColumnStructureHash) == "" || payload.StatusModelVersion != workflowTaskStatusModelVersion || strings.TrimSpace(payload.Cursor.TaskID) == "" || strings.TrimSpace(payload.Fingerprint) == "" {
+	if payload.Version != workflowTaskListPageTokenVersion ||
+		strings.TrimSpace(payload.Scope.ProjectID) == "" ||
+		strings.TrimSpace(payload.Scope.ProjectID) != payload.Scope.ProjectID ||
+		(payload.Scope.ProjectWide == nil) == (payload.Scope.Narrowed == nil) ||
+		!workflowTaskListContinuationCardinalityValid(payload.MatchingWorkflowCardinality) ||
+		payload.StatusModelVersion != workflowTaskStatusModelVersion ||
+		strings.TrimSpace(payload.Cursor.TaskID) == "" ||
+		strings.TrimSpace(payload.Fingerprint) == "" {
 		return workflowTaskListPageTokenPayload{}, false, ErrInvalidPageToken
 	}
+	if narrowed := payload.Scope.Narrowed; narrowed != nil {
+		if _, err := runtimeids.ParseCanonicalPrefixedUUIDv4(narrowed.WorkflowID, "workflow-", "workflow id"); err != nil ||
+			narrowed.WorkflowVersion < 1 ||
+			strings.TrimSpace(narrowed.ColumnStructureHash) == "" ||
+			strings.TrimSpace(narrowed.ColumnStructureHash) != narrowed.ColumnStructureHash {
+			return workflowTaskListPageTokenPayload{}, false, ErrInvalidPageToken
+		}
+	}
 	return payload, true, nil
+}
+
+func workflowTaskListContinuationCardinalityValid(cardinality serverapi.WorkflowTaskListMatchingWorkflowCardinality) bool {
+	return cardinality == serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne ||
+		cardinality == serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple
 }
 
 func workflowTaskListPageToken(payload workflowTaskListPageTokenPayload) string {
@@ -132,37 +175,53 @@ func dedupeSortedStrings(values []string) []string {
 }
 
 type workflowTaskListQueryRequest struct {
-	projectID              string
+	projectID      string
+	narrowed       *workflowTaskListNarrowedQueryFacts
+	statusKinds    []serverapi.WorkflowTaskStatusKind
+	attentionKinds []serverapi.WorkflowTaskAttentionKind
+	sortSelectors  []serverapi.WorkflowTaskListSort
+	cursor         workflowTaskListCursor
+	cursorSet      bool
+	limit          int
+}
+
+type workflowTaskListNarrowedQueryFacts struct {
 	workflowID             string
-	canceledTerminalNodeID string
+	canceledTerminalNodeID *string
 	columns                []serverapi.WorkflowBoardColumn
 	columnKeys             []string
-	statusKinds            []serverapi.WorkflowTaskStatusKind
-	attentionKinds         []serverapi.WorkflowTaskAttentionKind
-	sortSelectors          []serverapi.WorkflowTaskListSort
-	cursor                 workflowTaskListCursor
-	cursorSet              bool
-	limit                  int
 }
 
 type workflowTaskListRow struct {
-	item              serverapi.WorkflowTaskListItem
-	titleSort         string
-	primaryStatusRank int
-	columnRank        int
+	item                  serverapi.WorkflowTaskListItem
+	titleSort             string
+	primaryStatusRank     int
+	columnRank            *int
+	matchingWorkflowCount int
 }
 
 func (s *Service) listWorkflowTaskListRows(ctx context.Context, req workflowTaskListQueryRequest) ([]workflowTaskListRow, error) {
-	if len(req.columns) == 0 {
-		return []workflowTaskListRow{}, nil
-	}
-	visibleColumnsJSON, err := workflowTaskListVisibleColumnsJSON(req.columns)
-	if err != nil {
-		return nil, err
-	}
-	columnKeysJSON, err := json.Marshal(req.columnKeys)
-	if err != nil {
-		return nil, err
+	workflowFilter := sql.NullString{}
+	canceledTerminalNodeID := sql.NullString{}
+	visibleColumnsJSON := sql.NullString{}
+	columnKeysJSON := sql.NullString{}
+	columnFilterSet := false
+	if req.narrowed != nil {
+		workflowFilter = sql.NullString{String: req.narrowed.workflowID, Valid: true}
+		if req.narrowed.canceledTerminalNodeID != nil {
+			canceledTerminalNodeID = sql.NullString{String: *req.narrowed.canceledTerminalNodeID, Valid: true}
+		}
+		encodedColumns, err := workflowTaskListVisibleColumnsJSON(req.narrowed.columns)
+		if err != nil {
+			return nil, err
+		}
+		visibleColumnsJSON = sql.NullString{String: encodedColumns, Valid: true}
+		encodedColumnKeys, err := json.Marshal(req.narrowed.columnKeys)
+		if err != nil {
+			return nil, err
+		}
+		columnKeysJSON = sql.NullString{String: string(encodedColumnKeys), Valid: true}
+		columnFilterSet = len(req.narrowed.columnKeys) > 0
 	}
 	statusKinds := make([]string, 0, len(req.statusKinds))
 	for _, kind := range req.statusKinds {
@@ -180,13 +239,17 @@ func (s *Service) listWorkflowTaskListRows(ctx context.Context, req workflowTask
 	if err != nil {
 		return nil, err
 	}
+	cursorColumnRank := sql.NullInt64{}
+	if req.cursor.ColumnRank != nil {
+		cursorColumnRank = sql.NullInt64{Int64: int64(*req.cursor.ColumnRank), Valid: true}
+	}
 	rows, err := s.queries.ListWorkflowTaskListRows(ctx, sqlitegen.ListWorkflowTaskListRowsParams{
 		ProjectID:               req.projectID,
-		WorkflowID:              req.workflowID,
-		CanceledTerminalNodeID:  req.canceledTerminalNodeID,
+		WorkflowID:              workflowFilter,
+		CanceledTerminalNodeID:  canceledTerminalNodeID,
 		VisibleColumnsJson:      visibleColumnsJSON,
-		ColumnFilterSet:         boolInt64(len(req.columnKeys) > 0),
-		ColumnKeysJson:          string(columnKeysJSON),
+		ColumnFilterSet:         boolInt64(columnFilterSet),
+		ColumnKeysJson:          columnKeysJSON,
 		StatusFilterSet:         boolInt64(len(req.statusKinds) > 0),
 		StatusKindsJson:         string(statusKindsJSON),
 		AttentionFilterSet:      boolInt64(len(req.attentionKinds) > 0),
@@ -195,7 +258,7 @@ func (s *Service) listWorkflowTaskListRows(ctx context.Context, req workflowTask
 		CursorCreatedAtUnixMs:   req.cursor.CreatedAtUnixMs,
 		CursorUpdatedAtUnixMs:   req.cursor.UpdatedAtUnixMs,
 		CursorPrimaryStatusRank: int64(req.cursor.PrimaryStatusRank),
-		CursorColumnRank:        int64(req.cursor.ColumnRank),
+		CursorColumnRank:        cursorColumnRank,
 		CursorRunCount:          int64(req.cursor.RunCount),
 		CursorTitleSort:         req.cursor.TitleSort,
 		CursorTaskID:            req.cursor.TaskID,
@@ -220,15 +283,28 @@ func (s *Service) listWorkflowTaskListRows(ctx context.Context, req workflowTask
 		if err != nil {
 			return nil, err
 		}
-		columnKeys, err := workflowTaskListColumnKeys(row.ID, row.ColumnKeysJson)
-		if err != nil {
-			return nil, err
+		var columnKeys *[]string
+		if req.narrowed != nil {
+			values := []string{}
+			if row.ColumnKeysJson.Valid {
+				var err error
+				values, err = workflowTaskListColumnKeys(row.ID, row.ColumnKeysJson.String)
+				if err != nil {
+					return nil, err
+				}
+			}
+			columnKeys = &values
+		}
+		columnRank := nullableInt(row.ColumnRank)
+		if workflowTaskListSortUsesColumn(req.sortSelectors) && columnRank == nil {
+			return nil, fmt.Errorf("workflow task list record for task %q is missing a column rank required by column sorting", row.ID)
 		}
 		out = append(out, workflowTaskListRow{
 			item: serverapi.WorkflowTaskListItem{
 				TaskID:          row.ID,
 				ShortID:         row.ShortID,
 				WorkflowID:      row.WorkflowID,
+				WorkflowName:    row.WorkflowName,
 				Title:           row.Title,
 				CreatedAtUnixMs: row.CreatedAtUnixMs,
 				UpdatedAtUnixMs: row.UpdatedAtUnixMs,
@@ -236,12 +312,33 @@ func (s *Service) listWorkflowTaskListRows(ctx context.Context, req workflowTask
 				Status:          status,
 				RunCount:        int(row.RunCount),
 			},
-			titleSort:         row.TitleSort,
-			primaryStatusRank: int(row.PrimaryStatusRank),
-			columnRank:        int(row.ColumnRank),
+			titleSort:             row.TitleSort,
+			primaryStatusRank:     int(row.PrimaryStatusRank),
+			columnRank:            columnRank,
+			matchingWorkflowCount: int(row.MatchingWorkflowCount),
 		})
 	}
 	return out, nil
+}
+
+func workflowTaskListMatchingWorkflowCardinality(rows []workflowTaskListRow) (serverapi.WorkflowTaskListMatchingWorkflowCardinality, error) {
+	if len(rows) == 0 {
+		return serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone, nil
+	}
+	count := rows[0].matchingWorkflowCount
+	for _, row := range rows[1:] {
+		if row.matchingWorkflowCount != count {
+			return "", fmt.Errorf("workflow task list query returned inconsistent matching workflow counts: first=%d task_id=%q count=%d", count, row.item.TaskID, row.matchingWorkflowCount)
+		}
+	}
+	switch count {
+	case 1:
+		return serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne, nil
+	case 2:
+		return serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple, nil
+	default:
+		return "", fmt.Errorf("workflow task list query returned invalid matching workflow count %d", count)
+	}
 }
 
 func workflowTaskListColumnKeys(taskID string, encoded string) ([]string, error) {
@@ -260,6 +357,14 @@ func workflowTaskListColumnKeys(taskID string, encoded string) ([]string, error)
 		seen[value] = struct{}{}
 	}
 	return values, nil
+}
+
+func nullableInt(value sql.NullInt64) *int {
+	if !value.Valid {
+		return nil
+	}
+	converted := int(value.Int64)
+	return &converted
 }
 
 func workflowTaskListSortSelector(sortSelectors []serverapi.WorkflowTaskListSort, index int) serverapi.WorkflowTaskListSort {

--- a/server/workflowview/task_list_query.go
+++ b/server/workflowview/task_list_query.go
@@ -333,12 +333,20 @@ func (s *Service) listWorkflowTaskListRows(ctx context.Context, req workflowTask
 		if workflowTaskListSortUsesColumn(req.sortSelectors) && columnRank == nil {
 			return nil, fmt.Errorf("workflow task list record for task %q is missing a column rank required by column sorting", row.ID)
 		}
+		var workflowName *string
+		if req.narrowed == nil {
+			if strings.TrimSpace(row.WorkflowName) == "" {
+				return nil, fmt.Errorf("project-wide workflow task list record for task %q is missing workflow name", row.ID)
+			}
+			value := row.WorkflowName
+			workflowName = &value
+		}
 		out = append(out, workflowTaskListRow{
 			item: serverapi.WorkflowTaskListItem{
 				TaskID:          row.ID,
 				ShortID:         row.ShortID,
 				WorkflowID:      row.WorkflowID,
-				WorkflowName:    row.WorkflowName,
+				WorkflowName:    workflowName,
 				Title:           row.Title,
 				CreatedAtUnixMs: row.CreatedAtUnixMs,
 				UpdatedAtUnixMs: row.UpdatedAtUnixMs,

--- a/server/workflowview/task_list_service_test.go
+++ b/server/workflowview/task_list_service_test.go
@@ -143,7 +143,7 @@ func TestListTasksUsesBoardCanceledTerminalNode(t *testing.T) {
 		t.Fatalf("GetDefinition: %v", err)
 	}
 	boardTerminalNodeID := canceledBoardTerminalNodeID(def)
-	if boardTerminalNodeID == "" {
+	if boardTerminalNodeID == nil {
 		t.Fatal("workflow must have a board canceled-terminal node")
 	}
 	extraTerminalNodeID := workflow.NodeID("node-extra-terminal-" + string(workflowID))
@@ -164,7 +164,7 @@ func TestListTasksUsesBoardCanceledTerminalNode(t *testing.T) {
 	boardTerminalIndex, extraTerminalIndex := -1, -1
 	for index, column := range columns {
 		switch column.Node.NodeID {
-		case boardTerminalNodeID:
+		case *boardTerminalNodeID:
 			boardTerminalIndex = index
 		case string(extraTerminalNodeID):
 			extraTerminalIndex = index
@@ -189,7 +189,7 @@ func TestListTasksUsesBoardCanceledTerminalNode(t *testing.T) {
 		projectID: binding.ProjectID,
 		narrowed: &workflowTaskListNarrowedQueryFacts{
 			workflowID:             string(workflowID),
-			canceledTerminalNodeID: &boardTerminalNodeID,
+			canceledTerminalNodeID: boardTerminalNodeID,
 			columns:                columns,
 		},
 		limit: 2,
@@ -201,7 +201,7 @@ func TestListTasksUsesBoardCanceledTerminalNode(t *testing.T) {
 		t.Fatalf("canceled task rows = %+v", rows)
 	}
 	for _, column := range columns {
-		if column.Node.NodeID == boardTerminalNodeID && (*rows[0].item.ColumnKeys)[0] != column.Node.Key {
+		if column.Node.NodeID == *boardTerminalNodeID && (*rows[0].item.ColumnKeys)[0] != column.Node.Key {
 			t.Fatalf("canceled task column key = %q, want board terminal %q", (*rows[0].item.ColumnKeys)[0], column.Node.Key)
 		}
 	}
@@ -624,13 +624,13 @@ func TestListTasksSortAndCursorPagination(t *testing.T) {
 	changedProjectToken := token
 	changedProjectToken.Scope.ProjectID = "project-conflict"
 	invalidRequests := []serverapi.WorkflowTaskListRequest{
-		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(invalidVersionToken)},
+		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageTokenForTest(t, invalidVersionToken)},
 		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: firstPage.NextPageToken, StatusKinds: []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindBacklog}},
 		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: firstPage.NextPageToken, Sort: []serverapi.WorkflowTaskListSort{{Field: serverapi.WorkflowTaskListSortFieldColumn, Direction: serverapi.WorkflowTaskListSortDirectionAsc}}},
-		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(changedWorkflowVersionToken)},
-		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(changedColumnStructureToken)},
-		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(changedStatusModelToken)},
-		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(changedProjectToken)},
+		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageTokenForTest(t, changedWorkflowVersionToken)},
+		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageTokenForTest(t, changedColumnStructureToken)},
+		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageTokenForTest(t, changedStatusModelToken)},
+		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageTokenForTest(t, changedProjectToken)},
 	}
 	for _, request := range invalidRequests {
 		_, err := view.ListTasks(ctx, request, testsetup.QuestionsEnabled("coder"))
@@ -1127,7 +1127,7 @@ func TestWorkflowTaskListPageTokenUsesTypedModeInvariants(t *testing.T) {
 		ProjectID:   "project-1",
 		ProjectWide: &workflowTaskListProjectWidePageTokenInvariants{},
 	}
-	parsed, ok, err := parseWorkflowTaskListPageToken(workflowTaskListPageToken(projectWide))
+	parsed, ok, err := parseWorkflowTaskListPageToken(workflowTaskListPageTokenForTest(t, projectWide))
 	if err != nil || !ok || parsed.Scope.ProjectWide == nil || parsed.Scope.Narrowed != nil {
 		t.Fatalf("parse project-wide token = %+v/%t/%v", parsed, ok, err)
 	}
@@ -1155,7 +1155,7 @@ func TestWorkflowTaskListPageTokenUsesTypedModeInvariants(t *testing.T) {
 			ColumnStructureHash: "columns",
 		},
 	}
-	parsed, ok, err = parseWorkflowTaskListPageToken(workflowTaskListPageToken(narrowed))
+	parsed, ok, err = parseWorkflowTaskListPageToken(workflowTaskListPageTokenForTest(t, narrowed))
 	if err != nil || !ok || parsed.Scope.ProjectWide != nil || parsed.Scope.Narrowed == nil {
 		t.Fatalf("parse narrowed token = %+v/%t/%v", parsed, ok, err)
 	}
@@ -1235,29 +1235,83 @@ func TestWorkflowTaskListPageTokenRejectsMalformedModeAndCardinality(t *testing.
 		"malformed workflow id":    malformedWorkflowID,
 	} {
 		t.Run(name, func(t *testing.T) {
-			if _, _, err := parseWorkflowTaskListPageToken(workflowTaskListPageToken(payload)); !errors.Is(err, ErrInvalidPageToken) {
+			if _, _, err := parseWorkflowTaskListPageToken(workflowTaskListPageTokenForTest(t, payload)); !errors.Is(err, ErrInvalidPageToken) {
 				t.Fatalf("parse malformed token error = %v, want ErrInvalidPageToken", err)
 			}
 		})
 	}
 }
 
+func workflowTaskListPageTokenForTest(t *testing.T, payload workflowTaskListPageTokenPayload) string {
+	t.Helper()
+	token, err := workflowTaskListPageToken(payload)
+	if err != nil {
+		t.Fatalf("workflowTaskListPageToken: %v", err)
+	}
+	return token
+}
+
 func TestWorkflowTaskListRequestFingerprintCanonicalizesSetFilters(t *testing.T) {
 	sortSelectors := []serverapi.WorkflowTaskListSort{
 		{Field: serverapi.WorkflowTaskListSortFieldStatus, Direction: serverapi.WorkflowTaskListSortDirectionAsc},
 	}
-	first := workflowTaskListRequestFingerprint(serverapi.WorkflowTaskListRequest{
+	first, err := workflowTaskListRequestFingerprint(serverapi.WorkflowTaskListRequest{
 		ColumnKeys:     []string{"done", "backlog", "done"},
 		StatusKinds:    []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindRunning, serverapi.WorkflowTaskStatusKindBacklog, serverapi.WorkflowTaskStatusKindRunning},
 		AttentionKinds: []serverapi.WorkflowTaskAttentionKind{serverapi.WorkflowTaskAttentionKindQuestion, serverapi.WorkflowTaskAttentionKindApproval},
-	}, sortSelectors, "columns")
-	second := workflowTaskListRequestFingerprint(serverapi.WorkflowTaskListRequest{
+	}, sortSelectors, workflowTaskListFingerprintScope{
+		Narrowed: &workflowTaskListNarrowedFingerprintInvariants{ColumnStructureHash: "columns"},
+	})
+	if err != nil {
+		t.Fatalf("first fingerprint: %v", err)
+	}
+	second, err := workflowTaskListRequestFingerprint(serverapi.WorkflowTaskListRequest{
 		ColumnKeys:     []string{"backlog", "done"},
 		StatusKinds:    []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindBacklog, serverapi.WorkflowTaskStatusKindRunning},
 		AttentionKinds: []serverapi.WorkflowTaskAttentionKind{serverapi.WorkflowTaskAttentionKindApproval, serverapi.WorkflowTaskAttentionKindQuestion},
-	}, sortSelectors, "columns")
+	}, sortSelectors, workflowTaskListFingerprintScope{
+		Narrowed: &workflowTaskListNarrowedFingerprintInvariants{ColumnStructureHash: "columns"},
+	})
+	if err != nil {
+		t.Fatalf("second fingerprint: %v", err)
+	}
 	if first != second {
 		t.Fatalf("canonical fingerprints differ: %q != %q", first, second)
+	}
+}
+
+func TestWorkflowTaskListRequestFingerprintRequiresOneTypedScope(t *testing.T) {
+	request := serverapi.WorkflowTaskListRequest{}
+	sortSelectors := normalizeWorkflowTaskListSort(nil)
+	for name, scope := range map[string]workflowTaskListFingerprintScope{
+		"missing mode": {},
+		"both modes": {
+			ProjectWide: &workflowTaskListProjectWideFingerprintInvariants{},
+			Narrowed:    &workflowTaskListNarrowedFingerprintInvariants{ColumnStructureHash: "columns"},
+		},
+		"blank narrowed hash": {
+			Narrowed: &workflowTaskListNarrowedFingerprintInvariants{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := workflowTaskListRequestFingerprint(request, sortSelectors, scope); err == nil {
+				t.Fatalf("workflowTaskListRequestFingerprint accepted %s", name)
+			}
+		})
+	}
+}
+
+func TestCanceledBoardTerminalNodeIDUsesTypedAbsence(t *testing.T) {
+	if got := canceledBoardTerminalNodeID(serverapi.WorkflowDefinition{}); got != nil {
+		t.Fatalf("canceledBoardTerminalNodeID without terminal = %v, want nil", got)
+	}
+	def := serverapi.WorkflowDefinition{Nodes: []serverapi.WorkflowNode{
+		{ID: "node-terminal", Key: "archive", Kind: string(workflow.NodeKindTerminal)},
+		{ID: "node-done", Key: "done", Kind: string(workflow.NodeKindTerminal)},
+	}}
+	got := canceledBoardTerminalNodeID(def)
+	if got == nil || *got != "node-done" {
+		t.Fatalf("canceledBoardTerminalNodeID = %v, want done terminal", got)
 	}
 }
 

--- a/server/workflowview/task_list_service_test.go
+++ b/server/workflowview/task_list_service_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 
 	"core/internal/testharness/testsetup"
@@ -536,10 +537,10 @@ func TestListTasksSortAndCursorPagination(t *testing.T) {
 				seen[item.TaskID] = true
 				items = append(items, item)
 			}
-			if response.NextPageToken == "" {
+			if response.NextPageToken == nil {
 				return items
 			}
-			request.PageToken = response.NextPageToken
+			request.PageToken = *response.NextPageToken
 		}
 	}
 	sortedRequest := func(field serverapi.WorkflowTaskListSortField, direction serverapi.WorkflowTaskListSortDirection) serverapi.WorkflowTaskListRequest {
@@ -602,10 +603,10 @@ func TestListTasksSortAndCursorPagination(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTasks first page: %v", err)
 	}
-	if firstPage.NextPageToken == "" {
+	if firstPage.NextPageToken == nil {
 		t.Fatal("first page must produce a continuation token")
 	}
-	token, ok, err := parseWorkflowTaskListPageToken(firstPage.NextPageToken)
+	token, ok, err := parseWorkflowTaskListPageToken(*firstPage.NextPageToken)
 	if err != nil || !ok {
 		t.Fatalf("parse page token = %+v/%t/%v", token, ok, err)
 	}
@@ -625,8 +626,8 @@ func TestListTasksSortAndCursorPagination(t *testing.T) {
 	changedProjectToken.Scope.ProjectID = "project-conflict"
 	invalidRequests := []serverapi.WorkflowTaskListRequest{
 		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageTokenForTest(t, invalidVersionToken)},
-		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: firstPage.NextPageToken, StatusKinds: []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindBacklog}},
-		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: firstPage.NextPageToken, Sort: []serverapi.WorkflowTaskListSort{{Field: serverapi.WorkflowTaskListSortFieldColumn, Direction: serverapi.WorkflowTaskListSortDirectionAsc}}},
+		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: *firstPage.NextPageToken, StatusKinds: []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindBacklog}},
+		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: *firstPage.NextPageToken, Sort: []serverapi.WorkflowTaskListSort{{Field: serverapi.WorkflowTaskListSortFieldColumn, Direction: serverapi.WorkflowTaskListSortDirectionAsc}}},
 		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageTokenForTest(t, changedWorkflowVersionToken)},
 		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageTokenForTest(t, changedColumnStructureToken)},
 		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageTokenForTest(t, changedStatusModelToken)},
@@ -708,7 +709,7 @@ func TestTaskListProjectScopeSpansLinkedWorkflowsWithoutColumns(t *testing.T) {
 		if task.ColumnKeys != nil {
 			t.Fatalf("project-wide task columns = %+v, want omitted", task.ColumnKeys)
 		}
-		if task.WorkflowName == "" {
+		if task.WorkflowName == nil || strings.TrimSpace(*task.WorkflowName) == "" {
 			t.Fatalf("project-wide task = %+v, want workflow name", task)
 		}
 	}
@@ -983,7 +984,7 @@ func TestTaskListMatchingWorkflowCardinalityUsesFullFilteredSet(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ListTasks: %v", err)
 		}
-		if response.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple || len(response.Tasks) != 1 || response.NextPageToken == "" {
+		if response.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple || len(response.Tasks) != 1 || response.NextPageToken == nil {
 			t.Fatalf("first page = %+v, want multiple cardinality and continuation", response)
 		}
 	})
@@ -1013,11 +1014,11 @@ func TestTaskListProjectWidePaginationFreezesCardinalityWhileRowsRemainLive(t *t
 		if err != nil {
 			t.Fatalf("ListTasks first page: %v", err)
 		}
-		if firstPage.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne || firstPage.NextPageToken == "" {
+		if firstPage.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne || firstPage.NextPageToken == nil {
 			t.Fatalf("first page = %+v, want one and continuation", firstPage)
 		}
 		if _, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
-			PageToken:   firstPage.NextPageToken,
+			PageToken:   *firstPage.NextPageToken,
 			StatusKinds: []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindDone},
 			Sort:        sortByTitle,
 		}, nil); !errors.Is(err, ErrInvalidPageToken) {
@@ -1026,7 +1027,7 @@ func TestTaskListProjectWidePaginationFreezesCardinalityWhileRowsRemainLive(t *t
 		selectedWorkflowID := string(secondWorkflowID)
 		if _, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
 			WorkflowID: &selectedWorkflowID,
-			PageToken:  firstPage.NextPageToken,
+			PageToken:  *firstPage.NextPageToken,
 			Sort:       sortByTitle,
 		}, nil); !errors.Is(err, ErrInvalidPageToken) {
 			t.Fatalf("conflicting continuation scope error = %v, want ErrInvalidPageToken", err)
@@ -1040,7 +1041,7 @@ func TestTaskListProjectWidePaginationFreezesCardinalityWhileRowsRemainLive(t *t
 			t.Fatalf("CreateTask Zulu: %v", err)
 		}
 		nextPage, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
-			PageToken: firstPage.NextPageToken,
+			PageToken: *firstPage.NextPageToken,
 			PageSize:  10,
 			Sort:      sortByTitle,
 		}, nil)
@@ -1090,7 +1091,7 @@ func TestTaskListProjectWidePaginationFreezesCardinalityWhileRowsRemainLive(t *t
 		if err != nil {
 			t.Fatalf("ListTasks first page: %v", err)
 		}
-		if firstPage.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple || firstPage.NextPageToken == "" {
+		if firstPage.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple || firstPage.NextPageToken == nil {
 			t.Fatalf("first page = %+v, want multiple and continuation", firstPage)
 		}
 		if _, err := workflowStore.StartTask(ctx, zulu.ID); err != nil {
@@ -1098,7 +1099,7 @@ func TestTaskListProjectWidePaginationFreezesCardinalityWhileRowsRemainLive(t *t
 		}
 		nextPage, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
 			StatusKinds: statusFilter,
-			PageToken:   firstPage.NextPageToken,
+			PageToken:   *firstPage.NextPageToken,
 			PageSize:    10,
 			Sort:        sortByTitle,
 		}, nil)
@@ -1331,10 +1332,10 @@ func TestTaskListInfersScopeFromContinuationToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTasks first page: %v", err)
 	}
-	if firstPage.NextPageToken == "" {
+	if firstPage.NextPageToken == nil {
 		t.Fatal("expected continuation token")
 	}
-	nextPage, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{PageToken: firstPage.NextPageToken, PageSize: 1}, testsetup.QuestionsEnabled("coder"))
+	nextPage, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{PageToken: *firstPage.NextPageToken, PageSize: 1}, testsetup.QuestionsEnabled("coder"))
 	if err != nil {
 		t.Fatalf("ListTasks token-only continuation: %v", err)
 	}
@@ -1342,7 +1343,7 @@ func TestTaskListInfersScopeFromContinuationToken(t *testing.T) {
 		t.Fatalf("token-only continuation = %+v, want resolved second page", nextPage)
 	}
 	otherProjectID := "project-conflict"
-	_, err = view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{ProjectID: &otherProjectID, PageToken: firstPage.NextPageToken, PageSize: 1}, testsetup.QuestionsEnabled("coder"))
+	_, err = view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{ProjectID: &otherProjectID, PageToken: *firstPage.NextPageToken, PageSize: 1}, testsetup.QuestionsEnabled("coder"))
 	if !errors.Is(err, ErrInvalidPageToken) {
 		t.Fatalf("ListTasks conflicting token scope error = %v, want ErrInvalidPageToken", err)
 	}

--- a/server/workflowview/task_list_service_test.go
+++ b/server/workflowview/task_list_service_test.go
@@ -2,17 +2,21 @@ package workflowview
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"slices"
 	"testing"
 
 	"core/internal/testharness/testsetup"
-	"core/server/metadata"
 	"core/server/workflow"
 	"core/server/workflowstore"
 	"core/shared/serverapi"
 )
+
+func workflowIDPointerForTest(value workflow.WorkflowID) *workflow.WorkflowID {
+	return &value
+}
 
 func TestListTasksUsesCanonicalStatusProjection(t *testing.T) {
 	ctx, store, workflowStore, binding, view := newWorkflowViewTestContextService(t)
@@ -182,22 +186,74 @@ func TestListTasksUsesBoardCanceledTerminalNode(t *testing.T) {
 		t.Fatalf("CancelTask: %v", err)
 	}
 	rows, err := view.listWorkflowTaskListRows(ctx, workflowTaskListQueryRequest{
-		projectID:              binding.ProjectID,
-		workflowID:             string(workflowID),
-		canceledTerminalNodeID: boardTerminalNodeID,
-		columns:                columns,
-		limit:                  2,
+		projectID: binding.ProjectID,
+		narrowed: &workflowTaskListNarrowedQueryFacts{
+			workflowID:             string(workflowID),
+			canceledTerminalNodeID: &boardTerminalNodeID,
+			columns:                columns,
+		},
+		limit: 2,
 	})
 	if err != nil {
 		t.Fatalf("listWorkflowTaskListRows: %v", err)
 	}
-	if len(rows) != 1 || len(rows[0].item.ColumnKeys) != 1 {
+	if len(rows) != 1 || rows[0].item.ColumnKeys == nil || len(*rows[0].item.ColumnKeys) != 1 {
 		t.Fatalf("canceled task rows = %+v", rows)
 	}
 	for _, column := range columns {
-		if column.Node.NodeID == boardTerminalNodeID && rows[0].item.ColumnKeys[0] != column.Node.Key {
-			t.Fatalf("canceled task column key = %q, want board terminal %q", rows[0].item.ColumnKeys[0], column.Node.Key)
+		if column.Node.NodeID == boardTerminalNodeID && (*rows[0].item.ColumnKeys)[0] != column.Node.Key {
+			t.Fatalf("canceled task column key = %q, want board terminal %q", (*rows[0].item.ColumnKeys)[0], column.Node.Key)
 		}
+	}
+}
+
+func TestListTasksFiltersTypedStatusAndColumn(t *testing.T) {
+	ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+	workflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, workflowID, true); err != nil {
+		t.Fatalf("LinkWorkflow: %v", err)
+	}
+	backlog, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, Title: "Backlog", Body: "Body"})
+	if err != nil {
+		t.Fatalf("CreateTask backlog: %v", err)
+	}
+	running, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{ProjectID: binding.ProjectID, Title: "Running", Body: "Body"})
+	if err != nil {
+		t.Fatalf("CreateTask running: %v", err)
+	}
+	started, err := workflowStore.StartTask(ctx, running.ID)
+	if err != nil {
+		t.Fatalf("StartTask: %v", err)
+	}
+	if _, err := workflowStore.ClaimRun(ctx, started.RunID, 0); err != nil {
+		t.Fatalf("ClaimRun: %v", err)
+	}
+
+	projectID, workflowIDString := binding.ProjectID, string(workflowID)
+	backlogResp, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+		ProjectID:   &projectID,
+		WorkflowID:  &workflowIDString,
+		ColumnKeys:  []string{"backlog"},
+		StatusKinds: []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindBacklog},
+	}, testsetup.QuestionsEnabled("coder"))
+	if err != nil {
+		t.Fatalf("ListTasks backlog: %v", err)
+	}
+	if len(backlogResp.Tasks) != 1 || backlogResp.Tasks[0].TaskID != string(backlog.ID) {
+		t.Fatalf("backlog tasks = %+v", backlogResp.Tasks)
+	}
+
+	runningResp, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+		ProjectID:   &projectID,
+		WorkflowID:  &workflowIDString,
+		ColumnKeys:  []string{"agent"},
+		StatusKinds: []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindRunning},
+	}, testsetup.QuestionsEnabled("coder"))
+	if err != nil {
+		t.Fatalf("ListTasks running: %v", err)
+	}
+	if len(runningResp.Tasks) != 1 || runningResp.Tasks[0].TaskID != string(running.ID) {
+		t.Fatalf("running tasks = %+v", runningResp.Tasks)
 	}
 }
 
@@ -290,7 +346,7 @@ func TestListTasksStatusAndFiltersMatchCanonicalDetail(t *testing.T) {
 	}
 	forceCanceledBacklogPlacementWithoutTerminal(t, ctx, store, canceled.ID, workflowID)
 
-	projectID := binding.ProjectID
+	projectID, workflowIDString := binding.ProjectID, string(workflowID)
 	list := func(request serverapi.WorkflowTaskListRequest) serverapi.WorkflowTaskListResponse {
 		t.Helper()
 		request.ProjectID = &projectID
@@ -349,7 +405,10 @@ func TestListTasksStatusAndFiltersMatchCanonicalDetail(t *testing.T) {
 		"backlog": {string(backlog.ID): true},
 		"done":    {string(done.ID): true, string(canceled.ID): true},
 	} {
-		response := list(serverapi.WorkflowTaskListRequest{ColumnKeys: []string{columnKey}})
+		response := list(serverapi.WorkflowTaskListRequest{
+			WorkflowID: &workflowIDString,
+			ColumnKeys: []string{columnKey},
+		})
 		if len(response.Tasks) != len(taskIDs) {
 			t.Fatalf("column filter %q = %+v, want task IDs %v", columnKey, response.Tasks, taskIDs)
 		}
@@ -367,7 +426,7 @@ func TestListTasksStatusAndFiltersMatchCanonicalDetail(t *testing.T) {
 	for _, request := range []serverapi.WorkflowTaskListRequest{
 		{StatusKinds: []serverapi.WorkflowTaskStatusKind{"invalid"}},
 		{AttentionKinds: []serverapi.WorkflowTaskAttentionKind{"invalid"}},
-		{ColumnKeys: []string{"missing"}},
+		{WorkflowID: &workflowIDString, ColumnKeys: []string{"missing"}},
 	} {
 		request.ProjectID = &projectID
 		_, err := view.ListTasks(ctx, request, testsetup.QuestionsEnabled("coder"))
@@ -456,7 +515,7 @@ func TestListTasksSortAndCursorPagination(t *testing.T) {
 		t.Fatalf("CompleteRun done: %v", err)
 	}
 
-	projectID := binding.ProjectID
+	projectID, workflowIDString := binding.ProjectID, string(workflowID)
 	baseRequest := serverapi.WorkflowTaskListRequest{ProjectID: &projectID, PageSize: 2}
 	listAllPages := func(request serverapi.WorkflowTaskListRequest) []serverapi.WorkflowTaskListItem {
 		t.Helper()
@@ -484,11 +543,15 @@ func TestListTasksSortAndCursorPagination(t *testing.T) {
 		}
 	}
 	sortedRequest := func(field serverapi.WorkflowTaskListSortField, direction serverapi.WorkflowTaskListSortDirection) serverapi.WorkflowTaskListRequest {
-		return serverapi.WorkflowTaskListRequest{
+		request := serverapi.WorkflowTaskListRequest{
 			ProjectID: baseRequest.ProjectID,
 			PageSize:  baseRequest.PageSize,
 			Sort:      []serverapi.WorkflowTaskListSort{{Field: field, Direction: direction}},
 		}
+		if field == serverapi.WorkflowTaskListSortFieldColumn {
+			request.WorkflowID = &workflowIDString
+		}
+		return request
 	}
 	for _, tt := range []struct {
 		name      string
@@ -529,9 +592,11 @@ func TestListTasksSortAndCursorPagination(t *testing.T) {
 		})
 	}
 
+	firstPageRequest := sortedRequest(serverapi.WorkflowTaskListSortFieldStatus, serverapi.WorkflowTaskListSortDirectionAsc)
+	firstPageRequest.WorkflowID = &workflowIDString
 	firstPage, err := view.ListTasks(
 		ctx,
-		sortedRequest(serverapi.WorkflowTaskListSortFieldStatus, serverapi.WorkflowTaskListSortDirectionAsc),
+		firstPageRequest,
 		testsetup.QuestionsEnabled("coder"),
 	)
 	if err != nil {
@@ -544,14 +609,28 @@ func TestListTasksSortAndCursorPagination(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("parse page token = %+v/%t/%v", token, ok, err)
 	}
+	invalidVersionToken := token
+	invalidVersionToken.Version = 1
+	changedWorkflowVersionToken := token
+	changedWorkflowVersionInvariants := *token.Scope.Narrowed
+	changedWorkflowVersionInvariants.WorkflowVersion++
+	changedWorkflowVersionToken.Scope.Narrowed = &changedWorkflowVersionInvariants
+	changedColumnStructureToken := token
+	changedColumnStructureInvariants := *token.Scope.Narrowed
+	changedColumnStructureInvariants.ColumnStructureHash = "changed"
+	changedColumnStructureToken.Scope.Narrowed = &changedColumnStructureInvariants
+	changedStatusModelToken := token
+	changedStatusModelToken.StatusModelVersion++
+	changedProjectToken := token
+	changedProjectToken.Scope.ProjectID = "project-conflict"
 	invalidRequests := []serverapi.WorkflowTaskListRequest{
-		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(workflowTaskListPageTokenPayload{Version: 1, ProjectID: token.ProjectID, WorkflowID: token.WorkflowID, WorkflowVersion: token.WorkflowVersion, ColumnStructureHash: token.ColumnStructureHash, StatusModelVersion: token.StatusModelVersion, Fingerprint: token.Fingerprint, Cursor: token.Cursor})},
+		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(invalidVersionToken)},
 		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: firstPage.NextPageToken, StatusKinds: []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindBacklog}},
 		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: firstPage.NextPageToken, Sort: []serverapi.WorkflowTaskListSort{{Field: serverapi.WorkflowTaskListSortFieldColumn, Direction: serverapi.WorkflowTaskListSortDirectionAsc}}},
-		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(workflowTaskListPageTokenPayload{Version: token.Version, ProjectID: token.ProjectID, WorkflowID: token.WorkflowID, WorkflowVersion: token.WorkflowVersion + 1, ColumnStructureHash: token.ColumnStructureHash, StatusModelVersion: token.StatusModelVersion, Fingerprint: token.Fingerprint, Cursor: token.Cursor})},
-		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(workflowTaskListPageTokenPayload{Version: token.Version, ProjectID: token.ProjectID, WorkflowID: token.WorkflowID, WorkflowVersion: token.WorkflowVersion, ColumnStructureHash: "changed", StatusModelVersion: token.StatusModelVersion, Fingerprint: token.Fingerprint, Cursor: token.Cursor})},
-		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(workflowTaskListPageTokenPayload{Version: token.Version, ProjectID: token.ProjectID, WorkflowID: token.WorkflowID, WorkflowVersion: token.WorkflowVersion, ColumnStructureHash: token.ColumnStructureHash, StatusModelVersion: token.StatusModelVersion + 1, Fingerprint: token.Fingerprint, Cursor: token.Cursor})},
-		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(workflowTaskListPageTokenPayload{Version: token.Version, ProjectID: "project-conflict", WorkflowID: token.WorkflowID, WorkflowVersion: token.WorkflowVersion, ColumnStructureHash: token.ColumnStructureHash, StatusModelVersion: token.StatusModelVersion, Fingerprint: token.Fingerprint, Cursor: token.Cursor})},
+		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(changedWorkflowVersionToken)},
+		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(changedColumnStructureToken)},
+		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(changedStatusModelToken)},
+		{ProjectID: baseRequest.ProjectID, PageSize: baseRequest.PageSize, PageToken: workflowTaskListPageToken(changedProjectToken)},
 	}
 	for _, request := range invalidRequests {
 		_, err := view.ListTasks(ctx, request, testsetup.QuestionsEnabled("coder"))
@@ -561,134 +640,624 @@ func TestListTasksSortAndCursorPagination(t *testing.T) {
 	}
 }
 
-func TestTaskListResolvesExactProjectWorkflowScope(t *testing.T) {
-	type scopeExpectation struct {
-		kind         serverapi.WorkflowTaskListScopeErrorKind
-		missingScope *serverapi.WorkflowTaskListScopeDimension
-		projectIDs   map[string]bool
-		workflowIDs  map[string]bool
+func TestTaskListUsesTypedProjectWorkflowScope(t *testing.T) {
+	ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+	workflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, workflowID, true); err != nil {
+		t.Fatalf("LinkWorkflow: %v", err)
 	}
-	for _, testCase := range []struct {
-		name  string
-		setup func(t *testing.T, ctx context.Context, store *metadata.Store, workflowStore *workflowstore.Store, binding metadata.Binding, firstWorkflowID workflow.WorkflowID, secondWorkflowID workflow.WorkflowID) (serverapi.WorkflowTaskListRequest, string, string, *scopeExpectation)
-	}{
-		{
-			name: "exact pair",
-			setup: func(t *testing.T, ctx context.Context, _ *metadata.Store, workflowStore *workflowstore.Store, binding metadata.Binding, firstWorkflowID workflow.WorkflowID, _ workflow.WorkflowID) (serverapi.WorkflowTaskListRequest, string, string, *scopeExpectation) {
-				if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, firstWorkflowID, true); err != nil {
-					t.Fatalf("LinkWorkflow: %v", err)
-				}
-				projectID, workflowID := binding.ProjectID, string(firstWorkflowID)
-				return serverapi.WorkflowTaskListRequest{ProjectID: &projectID, WorkflowID: &workflowID}, projectID, workflowID, nil
-			},
+	projectID, selectedWorkflowID := binding.ProjectID, string(workflowID)
+	response, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+		ProjectID:  &projectID,
+		WorkflowID: &selectedWorkflowID,
+	}, testsetup.QuestionsEnabled("coder"))
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if response.Scope.ProjectID != projectID || response.Scope.WorkflowID == nil || *response.Scope.WorkflowID != selectedWorkflowID {
+		t.Fatalf("response scope = %+v, want project/workflow scope", response.Scope)
+	}
+	if response.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone {
+		t.Fatalf("matching workflow cardinality = %q, want none", response.MatchingWorkflowCardinality)
+	}
+}
+
+func TestTaskListProjectScopeSpansLinkedWorkflowsWithoutColumns(t *testing.T) {
+	ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+	firstWorkflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+	secondWorkflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, firstWorkflowID, true); err != nil {
+		t.Fatalf("LinkWorkflow first: %v", err)
+	}
+	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, secondWorkflowID, false); err != nil {
+		t.Fatalf("LinkWorkflow second: %v", err)
+	}
+	firstTask, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
+		ProjectID:  binding.ProjectID,
+		WorkflowID: workflowIDPointerForTest(firstWorkflowID),
+		Title:      "First",
+		Body:       "Body",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask first: %v", err)
+	}
+	secondTask, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
+		ProjectID:  binding.ProjectID,
+		WorkflowID: workflowIDPointerForTest(secondWorkflowID),
+		Title:      "Second",
+		Body:       "Body",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask second: %v", err)
+	}
+
+	projectID := binding.ProjectID
+	projectWide, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{ProjectID: &projectID}, nil)
+	if err != nil {
+		t.Fatalf("ListTasks project-wide: %v", err)
+	}
+	if projectWide.Scope.ProjectID != projectID || projectWide.Scope.WorkflowID != nil {
+		t.Fatalf("project-wide scope = %+v, want project-only", projectWide.Scope)
+	}
+	if len(projectWide.Tasks) != 2 {
+		t.Fatalf("project-wide tasks = %+v, want both linked workflows", projectWide.Tasks)
+	}
+	seen := map[string]bool{}
+	for _, task := range projectWide.Tasks {
+		seen[task.TaskID] = true
+		if task.ColumnKeys != nil {
+			t.Fatalf("project-wide task columns = %+v, want omitted", task.ColumnKeys)
+		}
+		if task.WorkflowName == "" {
+			t.Fatalf("project-wide task = %+v, want workflow name", task)
+		}
+	}
+	if !seen[string(firstTask.ID)] || !seen[string(secondTask.ID)] {
+		t.Fatalf("project-wide task IDs = %+v, want %s and %s", seen, firstTask.ID, secondTask.ID)
+	}
+
+	selectedWorkflowID := string(secondWorkflowID)
+	narrowed, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+		ProjectID:  &projectID,
+		WorkflowID: &selectedWorkflowID,
+	}, testsetup.QuestionsEnabled("coder"))
+	if err != nil {
+		t.Fatalf("ListTasks narrowed: %v", err)
+	}
+	if len(narrowed.Tasks) != 1 || narrowed.Tasks[0].TaskID != string(secondTask.ID) || narrowed.Tasks[0].ColumnKeys == nil || len(*narrowed.Tasks[0].ColumnKeys) == 0 {
+		t.Fatalf("narrowed tasks = %+v, want second workflow with columns", narrowed.Tasks)
+	}
+}
+
+func TestTaskListProjectScopeFiltersSortsAndBoundsAcrossLinkedWorkflows(t *testing.T) {
+	ctx, store, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+	firstWorkflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+	secondWorkflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, firstWorkflowID, true); err != nil {
+		t.Fatalf("LinkWorkflow first: %v", err)
+	}
+	if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, secondWorkflowID, false); err != nil {
+		t.Fatalf("LinkWorkflow second: %v", err)
+	}
+	alpha, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
+		ProjectID:  binding.ProjectID,
+		WorkflowID: workflowIDPointerForTest(firstWorkflowID),
+		Title:      "Alpha",
+		Body:       "Body",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask alpha: %v", err)
+	}
+	zulu, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
+		ProjectID:  binding.ProjectID,
+		WorkflowID: workflowIDPointerForTest(secondWorkflowID),
+		Title:      "Zulu",
+		Body:       "Body",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask zulu: %v", err)
+	}
+	zuluStarted, err := workflowStore.StartTask(ctx, zulu.ID)
+	if err != nil {
+		t.Fatalf("StartTask zulu: %v", err)
+	}
+	zuluClaimed, err := workflowStore.ClaimRun(ctx, zuluStarted.RunID, 0)
+	if err != nil {
+		t.Fatalf("ClaimRun zulu: %v", err)
+	}
+	if err := workflowStore.SetRunWaitingAsk(ctx, zuluStarted.RunID, zuluClaimed.Generation, "ask-project-wide"); err != nil {
+		t.Fatalf("SetRunWaitingAsk zulu: %v", err)
+	}
+	if _, err := store.DB().ExecContext(ctx, `
+UPDATE tasks
+SET created_at_unix_ms = CASE id WHEN ? THEN 100 ELSE 200 END,
+    updated_at_unix_ms = CASE id WHEN ? THEN 300 ELSE 100 END
+WHERE id IN (?, ?)`, string(alpha.ID), string(alpha.ID), string(alpha.ID), string(zulu.ID)); err != nil {
+		t.Fatalf("set deterministic task times: %v", err)
+	}
+
+	projectID := binding.ProjectID
+	list := func(request serverapi.WorkflowTaskListRequest) []serverapi.WorkflowTaskListItem {
+		t.Helper()
+		request.ProjectID = &projectID
+		response, err := view.ListTasks(ctx, request, nil)
+		if err != nil {
+			t.Fatalf("ListTasks %+v: %v", request, err)
+		}
+		for _, task := range response.Tasks {
+			if task.ColumnKeys != nil {
+				t.Fatalf("project-wide task columns = %+v, want omitted", task.ColumnKeys)
+			}
+		}
+		return response.Tasks
+	}
+	statusFiltered := list(serverapi.WorkflowTaskListRequest{
+		StatusKinds: []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindBacklog},
+	})
+	if len(statusFiltered) != 1 || statusFiltered[0].TaskID != string(alpha.ID) {
+		t.Fatalf("backlog project-wide tasks = %+v, want alpha", statusFiltered)
+	}
+	attentionFiltered := list(serverapi.WorkflowTaskListRequest{
+		AttentionKinds: []serverapi.WorkflowTaskAttentionKind{serverapi.WorkflowTaskAttentionKindQuestion},
+	})
+	if len(attentionFiltered) != 1 || attentionFiltered[0].TaskID != string(zulu.ID) {
+		t.Fatalf("question project-wide tasks = %+v, want zulu", attentionFiltered)
+	}
+
+	assertOrder := func(field serverapi.WorkflowTaskListSortField, direction serverapi.WorkflowTaskListSortDirection, want ...workflow.TaskID) {
+		t.Helper()
+		items := list(serverapi.WorkflowTaskListRequest{
+			Sort: []serverapi.WorkflowTaskListSort{{Field: field, Direction: direction}},
+		})
+		got := make([]string, 0, len(items))
+		for _, item := range items {
+			got = append(got, item.TaskID)
+		}
+		wantStrings := make([]string, 0, len(want))
+		for _, taskID := range want {
+			wantStrings = append(wantStrings, string(taskID))
+		}
+		if !reflect.DeepEqual(got, wantStrings) {
+			t.Fatalf("%s %s order = %v, want %v", field, direction, got, wantStrings)
+		}
+	}
+	assertOrder(serverapi.WorkflowTaskListSortFieldCreated, serverapi.WorkflowTaskListSortDirectionAsc, alpha.ID, zulu.ID)
+	assertOrder(serverapi.WorkflowTaskListSortFieldUpdated, serverapi.WorkflowTaskListSortDirectionAsc, zulu.ID, alpha.ID)
+	assertOrder(serverapi.WorkflowTaskListSortFieldRunCount, serverapi.WorkflowTaskListSortDirectionAsc, alpha.ID, zulu.ID)
+	assertOrder(serverapi.WorkflowTaskListSortFieldTitle, serverapi.WorkflowTaskListSortDirectionAsc, alpha.ID, zulu.ID)
+
+	statusAscending := list(serverapi.WorkflowTaskListRequest{
+		Sort: []serverapi.WorkflowTaskListSort{{Field: serverapi.WorkflowTaskListSortFieldStatus, Direction: serverapi.WorkflowTaskListSortDirectionAsc}},
+	})
+	statusDescending := list(serverapi.WorkflowTaskListRequest{
+		Sort: []serverapi.WorkflowTaskListSort{{Field: serverapi.WorkflowTaskListSortFieldStatus, Direction: serverapi.WorkflowTaskListSortDirectionDesc}},
+	})
+	if len(statusAscending) != 2 || len(statusDescending) != 2 ||
+		statusAscending[0].TaskID != statusDescending[1].TaskID ||
+		statusAscending[1].TaskID != statusDescending[0].TaskID {
+		t.Fatalf("status orders = asc %+v desc %+v, want reversed tasks", statusAscending, statusDescending)
+	}
+
+	bounded := list(serverapi.WorkflowTaskListRequest{PageSize: 1})
+	if len(bounded) != 1 {
+		t.Fatalf("bounded project-wide tasks = %+v, want one row", bounded)
+	}
+}
+
+func TestTaskListProjectScopeFailuresAreTyped(t *testing.T) {
+	t.Run("no linked workflows", func(t *testing.T) {
+		ctx, _, _, binding, view := newWorkflowViewTestContextService(t)
+		projectID := binding.ProjectID
+		_, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{ProjectID: &projectID}, nil)
+		var scopeErr *serverapi.WorkflowTaskListScopeError
+		if !errors.As(err, &scopeErr) ||
+			scopeErr.Reason != serverapi.WorkflowTaskListScopeReasonNoLinkedWorkflows ||
+			scopeErr.ProjectID == nil || *scopeErr.ProjectID != projectID ||
+			scopeErr.WorkflowID != nil {
+			t.Fatalf("ListTasks error = %+v, want typed no-links error for %q", err, projectID)
+		}
+	})
+
+	t.Run("explicit workflow is not linked", func(t *testing.T) {
+		ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+		linkedWorkflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+		unlinkedWorkflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+		if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, linkedWorkflowID, true); err != nil {
+			t.Fatalf("LinkWorkflow: %v", err)
+		}
+		projectID, workflowID := binding.ProjectID, string(unlinkedWorkflowID)
+		_, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+			ProjectID:  &projectID,
+			WorkflowID: &workflowID,
+		}, nil)
+		var scopeErr *serverapi.WorkflowTaskListScopeError
+		if !errors.As(err, &scopeErr) ||
+			scopeErr.Reason != serverapi.WorkflowTaskListScopeReasonWorkflowNotLinked ||
+			scopeErr.ProjectID == nil || *scopeErr.ProjectID != projectID ||
+			scopeErr.WorkflowID == nil || *scopeErr.WorkflowID != workflowID {
+			t.Fatalf("ListTasks error = %+v, want typed not-linked error for %q/%q", err, projectID, workflowID)
+		}
+	})
+
+	t.Run("column operation requires workflow", func(t *testing.T) {
+		ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+		workflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
+		if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, workflowID, true); err != nil {
+			t.Fatalf("LinkWorkflow: %v", err)
+		}
+		projectID := binding.ProjectID
+		_, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+			ProjectID:  &projectID,
+			ColumnKeys: []string{"backlog"},
+		}, nil)
+		var scopeErr *serverapi.WorkflowTaskListScopeError
+		if !errors.As(err, &scopeErr) ||
+			scopeErr.Reason != serverapi.WorkflowTaskListScopeReasonWorkflowRequiredColumns ||
+			scopeErr.ProjectID == nil || *scopeErr.ProjectID != projectID ||
+			scopeErr.WorkflowID != nil {
+			t.Fatalf("ListTasks error = %+v, want typed workflow-required error for %q", err, projectID)
+		}
+	})
+}
+
+func TestTaskListMatchingWorkflowCardinalityUsesFullFilteredSet(t *testing.T) {
+	t.Run("none", func(t *testing.T) {
+		ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+		createTwoLinkedWorkflowViewWorkflows(t, ctx, workflowStore, binding.ProjectID)
+		projectID := binding.ProjectID
+		response, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{ProjectID: &projectID}, nil)
+		if err != nil {
+			t.Fatalf("ListTasks: %v", err)
+		}
+		if response.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone || len(response.Tasks) != 0 {
+			t.Fatalf("empty filtered response = %+v, want none", response)
+		}
+	})
+
+	t.Run("one after filtering", func(t *testing.T) {
+		ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+		firstWorkflowID, secondWorkflowID := createTwoLinkedWorkflowViewWorkflows(t, ctx, workflowStore, binding.ProjectID)
+		if _, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
+			ProjectID:  binding.ProjectID,
+			WorkflowID: workflowIDPointerForTest(firstWorkflowID),
+			Title:      "Backlog",
+			Body:       "Body",
+		}); err != nil {
+			t.Fatalf("CreateTask backlog: %v", err)
+		}
+		running, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
+			ProjectID:  binding.ProjectID,
+			WorkflowID: workflowIDPointerForTest(secondWorkflowID),
+			Title:      "Running",
+			Body:       "Body",
+		})
+		if err != nil {
+			t.Fatalf("CreateTask running: %v", err)
+		}
+		started, err := workflowStore.StartTask(ctx, running.ID)
+		if err != nil {
+			t.Fatalf("StartTask: %v", err)
+		}
+		if _, err := workflowStore.ClaimRun(ctx, started.RunID, 0); err != nil {
+			t.Fatalf("ClaimRun: %v", err)
+		}
+
+		projectID := binding.ProjectID
+		response, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+			ProjectID:   &projectID,
+			StatusKinds: []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindBacklog},
+		}, nil)
+		if err != nil {
+			t.Fatalf("ListTasks: %v", err)
+		}
+		if response.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne || len(response.Tasks) != 1 || response.Tasks[0].WorkflowID != string(firstWorkflowID) {
+			t.Fatalf("filtered response = %+v, want one matching workflow", response)
+		}
+	})
+
+	t.Run("multiple beyond first page", func(t *testing.T) {
+		ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+		firstWorkflowID, secondWorkflowID := createTwoLinkedWorkflowViewWorkflows(t, ctx, workflowStore, binding.ProjectID)
+		for _, task := range []struct {
+			workflowID workflow.WorkflowID
+			title      string
+		}{
+			{workflowID: firstWorkflowID, title: "Alpha"},
+			{workflowID: secondWorkflowID, title: "Zulu"},
+		} {
+			if _, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
+				ProjectID:  binding.ProjectID,
+				WorkflowID: workflowIDPointerForTest(task.workflowID),
+				Title:      task.title,
+				Body:       "Body",
+			}); err != nil {
+				t.Fatalf("CreateTask %s: %v", task.title, err)
+			}
+		}
+		projectID := binding.ProjectID
+		response, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+			ProjectID: &projectID,
+			PageSize:  1,
+			Sort:      []serverapi.WorkflowTaskListSort{{Field: serverapi.WorkflowTaskListSortFieldTitle, Direction: serverapi.WorkflowTaskListSortDirectionAsc}},
+		}, nil)
+		if err != nil {
+			t.Fatalf("ListTasks: %v", err)
+		}
+		if response.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple || len(response.Tasks) != 1 || response.NextPageToken == "" {
+			t.Fatalf("first page = %+v, want multiple cardinality and continuation", response)
+		}
+	})
+}
+
+func TestTaskListProjectWidePaginationFreezesCardinalityWhileRowsRemainLive(t *testing.T) {
+	t.Run("one remains frozen after another workflow gains a match", func(t *testing.T) {
+		ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+		firstWorkflowID, secondWorkflowID := createTwoLinkedWorkflowViewWorkflows(t, ctx, workflowStore, binding.ProjectID)
+		for _, title := range []string{"Alpha", "Bravo"} {
+			if _, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
+				ProjectID:  binding.ProjectID,
+				WorkflowID: workflowIDPointerForTest(firstWorkflowID),
+				Title:      title,
+				Body:       "Body",
+			}); err != nil {
+				t.Fatalf("CreateTask %s: %v", title, err)
+			}
+		}
+		projectID := binding.ProjectID
+		sortByTitle := []serverapi.WorkflowTaskListSort{{Field: serverapi.WorkflowTaskListSortFieldTitle, Direction: serverapi.WorkflowTaskListSortDirectionAsc}}
+		firstPage, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+			ProjectID: &projectID,
+			PageSize:  1,
+			Sort:      sortByTitle,
+		}, nil)
+		if err != nil {
+			t.Fatalf("ListTasks first page: %v", err)
+		}
+		if firstPage.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne || firstPage.NextPageToken == "" {
+			t.Fatalf("first page = %+v, want one and continuation", firstPage)
+		}
+		if _, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+			PageToken:   firstPage.NextPageToken,
+			StatusKinds: []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindDone},
+			Sort:        sortByTitle,
+		}, nil); !errors.Is(err, ErrInvalidPageToken) {
+			t.Fatalf("conflicting continuation error = %v, want ErrInvalidPageToken", err)
+		}
+		selectedWorkflowID := string(secondWorkflowID)
+		if _, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+			WorkflowID: &selectedWorkflowID,
+			PageToken:  firstPage.NextPageToken,
+			Sort:       sortByTitle,
+		}, nil); !errors.Is(err, ErrInvalidPageToken) {
+			t.Fatalf("conflicting continuation scope error = %v, want ErrInvalidPageToken", err)
+		}
+		if _, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
+			ProjectID:  binding.ProjectID,
+			WorkflowID: workflowIDPointerForTest(secondWorkflowID),
+			Title:      "Zulu",
+			Body:       "Body",
+		}); err != nil {
+			t.Fatalf("CreateTask Zulu: %v", err)
+		}
+		nextPage, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+			PageToken: firstPage.NextPageToken,
+			PageSize:  10,
+			Sort:      sortByTitle,
+		}, nil)
+		if err != nil {
+			t.Fatalf("ListTasks continuation: %v", err)
+		}
+		if nextPage.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne ||
+			nextPage.Scope.WorkflowID != nil ||
+			len(nextPage.Tasks) != 2 ||
+			nextPage.Tasks[0].Title != "Bravo" ||
+			nextPage.Tasks[1].Title != "Zulu" {
+			t.Fatalf("live continuation = %+v, want frozen one with Bravo and Zulu", nextPage)
+		}
+	})
+
+	t.Run("multiple remains frozen after one workflow loses all matches", func(t *testing.T) {
+		ctx, _, workflowStore, binding, view := newWorkflowViewTestContextService(t)
+		firstWorkflowID, secondWorkflowID := createTwoLinkedWorkflowViewWorkflows(t, ctx, workflowStore, binding.ProjectID)
+		for _, title := range []string{"Alpha", "Bravo"} {
+			if _, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
+				ProjectID:  binding.ProjectID,
+				WorkflowID: workflowIDPointerForTest(firstWorkflowID),
+				Title:      title,
+				Body:       "Body",
+			}); err != nil {
+				t.Fatalf("CreateTask %s: %v", title, err)
+			}
+		}
+		zulu, err := workflowStore.CreateTask(ctx, workflowstore.CreateTaskRequest{
+			ProjectID:  binding.ProjectID,
+			WorkflowID: workflowIDPointerForTest(secondWorkflowID),
+			Title:      "Zulu",
+			Body:       "Body",
+		})
+		if err != nil {
+			t.Fatalf("CreateTask Zulu: %v", err)
+		}
+		projectID := binding.ProjectID
+		sortByTitle := []serverapi.WorkflowTaskListSort{{Field: serverapi.WorkflowTaskListSortFieldTitle, Direction: serverapi.WorkflowTaskListSortDirectionAsc}}
+		statusFilter := []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindBacklog}
+		firstPage, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+			ProjectID:   &projectID,
+			StatusKinds: statusFilter,
+			PageSize:    1,
+			Sort:        sortByTitle,
+		}, nil)
+		if err != nil {
+			t.Fatalf("ListTasks first page: %v", err)
+		}
+		if firstPage.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple || firstPage.NextPageToken == "" {
+			t.Fatalf("first page = %+v, want multiple and continuation", firstPage)
+		}
+		if _, err := workflowStore.StartTask(ctx, zulu.ID); err != nil {
+			t.Fatalf("StartTask Zulu: %v", err)
+		}
+		nextPage, err := view.ListTasks(ctx, serverapi.WorkflowTaskListRequest{
+			StatusKinds: statusFilter,
+			PageToken:   firstPage.NextPageToken,
+			PageSize:    10,
+			Sort:        sortByTitle,
+		}, nil)
+		if err != nil {
+			t.Fatalf("ListTasks continuation: %v", err)
+		}
+		if nextPage.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple ||
+			len(nextPage.Tasks) != 1 ||
+			nextPage.Tasks[0].Title != "Bravo" {
+			t.Fatalf("live continuation = %+v, want frozen multiple with only Bravo", nextPage)
+		}
+	})
+}
+
+func TestWorkflowTaskListPageTokenUsesTypedModeInvariants(t *testing.T) {
+	const tokenWorkflowID = "workflow-7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
+	base := workflowTaskListPageTokenPayload{
+		Version:                     workflowTaskListPageTokenVersion,
+		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityMultiple,
+		StatusModelVersion:          workflowTaskStatusModelVersion,
+		Fingerprint:                 "fingerprint",
+		Cursor:                      workflowTaskListCursor{TaskID: "task-1"},
+	}
+	projectWide := base
+	projectWide.Scope = workflowTaskListPageTokenScope{
+		ProjectID:   "project-1",
+		ProjectWide: &workflowTaskListProjectWidePageTokenInvariants{},
+	}
+	parsed, ok, err := parseWorkflowTaskListPageToken(workflowTaskListPageToken(projectWide))
+	if err != nil || !ok || parsed.Scope.ProjectWide == nil || parsed.Scope.Narrowed != nil {
+		t.Fatalf("parse project-wide token = %+v/%t/%v", parsed, ok, err)
+	}
+	raw, err := json.Marshal(projectWide)
+	if err != nil {
+		t.Fatalf("marshal project-wide token: %v", err)
+	}
+	var envelope struct {
+		Scope map[string]json.RawMessage `json:"scope"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("decode project-wide token shape: %v", err)
+	}
+	if _, exists := envelope.Scope["narrowed"]; exists {
+		t.Fatalf("project-wide token scope = %s, want no narrowed invariant block", raw)
+	}
+
+	narrowed := base
+	narrowed.MatchingWorkflowCardinality = serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne
+	narrowed.Scope = workflowTaskListPageTokenScope{
+		ProjectID: "project-1",
+		Narrowed: &workflowTaskListNarrowedPageTokenInvariants{
+			WorkflowID:          tokenWorkflowID,
+			WorkflowVersion:     2,
+			ColumnStructureHash: "columns",
 		},
-		{
-			name: "unique project inference",
-			setup: func(t *testing.T, ctx context.Context, _ *metadata.Store, workflowStore *workflowstore.Store, binding metadata.Binding, firstWorkflowID workflow.WorkflowID, _ workflow.WorkflowID) (serverapi.WorkflowTaskListRequest, string, string, *scopeExpectation) {
-				if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, firstWorkflowID, true); err != nil {
-					t.Fatalf("LinkWorkflow: %v", err)
-				}
-				projectID := binding.ProjectID
-				return serverapi.WorkflowTaskListRequest{ProjectID: &projectID}, projectID, string(firstWorkflowID), nil
-			},
+	}
+	parsed, ok, err = parseWorkflowTaskListPageToken(workflowTaskListPageToken(narrowed))
+	if err != nil || !ok || parsed.Scope.ProjectWide != nil || parsed.Scope.Narrowed == nil {
+		t.Fatalf("parse narrowed token = %+v/%t/%v", parsed, ok, err)
+	}
+	raw, err = json.Marshal(narrowed)
+	if err != nil {
+		t.Fatalf("marshal narrowed token: %v", err)
+	}
+	envelope = struct {
+		Scope map[string]json.RawMessage `json:"scope"`
+	}{}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("decode narrowed token shape: %v", err)
+	}
+	if _, exists := envelope.Scope["project_wide"]; exists {
+		t.Fatalf("narrowed token scope = %s, want no project-wide invariant block", raw)
+	}
+}
+
+func TestWorkflowTaskListPageTokenRejectsMalformedModeAndCardinality(t *testing.T) {
+	const tokenWorkflowID = "workflow-7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
+	valid := workflowTaskListPageTokenPayload{
+		Version: workflowTaskListPageTokenVersion,
+		Scope: workflowTaskListPageTokenScope{
+			ProjectID:   "project-1",
+			ProjectWide: &workflowTaskListProjectWidePageTokenInvariants{},
 		},
-		{
-			name: "unique workflow inference",
-			setup: func(t *testing.T, ctx context.Context, _ *metadata.Store, workflowStore *workflowstore.Store, binding metadata.Binding, firstWorkflowID workflow.WorkflowID, _ workflow.WorkflowID) (serverapi.WorkflowTaskListRequest, string, string, *scopeExpectation) {
-				if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, firstWorkflowID, true); err != nil {
-					t.Fatalf("LinkWorkflow: %v", err)
-				}
-				workflowID := string(firstWorkflowID)
-				return serverapi.WorkflowTaskListRequest{WorkflowID: &workflowID}, binding.ProjectID, workflowID, nil
-			},
-		},
-		{
-			name: "project has no links",
-			setup: func(_ *testing.T, _ context.Context, _ *metadata.Store, _ *workflowstore.Store, _ metadata.Binding, _ workflow.WorkflowID, _ workflow.WorkflowID) (serverapi.WorkflowTaskListRequest, string, string, *scopeExpectation) {
-				projectID := "project-unlinked"
-				return serverapi.WorkflowTaskListRequest{ProjectID: &projectID}, "", "", &scopeExpectation{kind: serverapi.WorkflowTaskListScopeErrorKindNotLinked, projectIDs: map[string]bool{projectID: true}}
-			},
-		},
-		{
-			name: "workflow has no links",
-			setup: func(_ *testing.T, _ context.Context, _ *metadata.Store, _ *workflowstore.Store, _ metadata.Binding, _ workflow.WorkflowID, _ workflow.WorkflowID) (serverapi.WorkflowTaskListRequest, string, string, *scopeExpectation) {
-				workflowID := "workflow-unlinked"
-				return serverapi.WorkflowTaskListRequest{WorkflowID: &workflowID}, "", "", &scopeExpectation{kind: serverapi.WorkflowTaskListScopeErrorKindNotLinked, workflowIDs: map[string]bool{workflowID: true}}
-			},
-		},
-		{
-			name: "project inference is ambiguous",
-			setup: func(t *testing.T, ctx context.Context, _ *metadata.Store, workflowStore *workflowstore.Store, binding metadata.Binding, firstWorkflowID workflow.WorkflowID, secondWorkflowID workflow.WorkflowID) (serverapi.WorkflowTaskListRequest, string, string, *scopeExpectation) {
-				if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, firstWorkflowID, true); err != nil {
-					t.Fatalf("LinkWorkflow first: %v", err)
-				}
-				if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, secondWorkflowID, false); err != nil {
-					t.Fatalf("LinkWorkflow second: %v", err)
-				}
-				projectID := binding.ProjectID
-				missing := serverapi.WorkflowTaskListScopeDimensionWorkflow
-				return serverapi.WorkflowTaskListRequest{ProjectID: &projectID}, "", "", &scopeExpectation{kind: serverapi.WorkflowTaskListScopeErrorKindAmbiguous, missingScope: &missing, projectIDs: map[string]bool{projectID: true}, workflowIDs: map[string]bool{string(firstWorkflowID): true, string(secondWorkflowID): true}}
-			},
-		},
-		{
-			name: "workflow inference is ambiguous",
-			setup: func(t *testing.T, ctx context.Context, store *metadata.Store, workflowStore *workflowstore.Store, binding metadata.Binding, firstWorkflowID workflow.WorkflowID, _ workflow.WorkflowID) (serverapi.WorkflowTaskListRequest, string, string, *scopeExpectation) {
-				if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, firstWorkflowID, true); err != nil {
-					t.Fatalf("LinkWorkflow first project: %v", err)
-				}
-				otherBinding, err := store.CreateProjectForWorkspace(ctx, t.TempDir(), "Other")
-				if err != nil {
-					t.Fatalf("CreateProjectForWorkspace: %v", err)
-				}
-				if _, err := workflowStore.LinkWorkflow(ctx, otherBinding.ProjectID, firstWorkflowID, true); err != nil {
-					t.Fatalf("LinkWorkflow second project: %v", err)
-				}
-				workflowID := string(firstWorkflowID)
-				missing := serverapi.WorkflowTaskListScopeDimensionProject
-				return serverapi.WorkflowTaskListRequest{WorkflowID: &workflowID}, "", "", &scopeExpectation{kind: serverapi.WorkflowTaskListScopeErrorKindAmbiguous, missingScope: &missing, projectIDs: map[string]bool{binding.ProjectID: true, otherBinding.ProjectID: true}, workflowIDs: map[string]bool{workflowID: true}}
-			},
-		},
-		{
-			name: "explicit pair is not linked",
-			setup: func(t *testing.T, ctx context.Context, _ *metadata.Store, workflowStore *workflowstore.Store, binding metadata.Binding, firstWorkflowID workflow.WorkflowID, secondWorkflowID workflow.WorkflowID) (serverapi.WorkflowTaskListRequest, string, string, *scopeExpectation) {
-				if _, err := workflowStore.LinkWorkflow(ctx, binding.ProjectID, firstWorkflowID, true); err != nil {
-					t.Fatalf("LinkWorkflow: %v", err)
-				}
-				projectID, workflowID := binding.ProjectID, string(secondWorkflowID)
-				return serverapi.WorkflowTaskListRequest{ProjectID: &projectID, WorkflowID: &workflowID}, "", "", &scopeExpectation{kind: serverapi.WorkflowTaskListScopeErrorKindNotLinked, projectIDs: map[string]bool{projectID: true}, workflowIDs: map[string]bool{workflowID: true}}
-			},
-		},
+		MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
+		StatusModelVersion:          workflowTaskStatusModelVersion,
+		Fingerprint:                 "fingerprint",
+		Cursor:                      workflowTaskListCursor{TaskID: "task-1"},
+	}
+	neitherMode := valid
+	neitherMode.Scope.ProjectWide = nil
+	bothModes := valid
+	bothModes.Scope.Narrowed = &workflowTaskListNarrowedPageTokenInvariants{
+		WorkflowID:          tokenWorkflowID,
+		WorkflowVersion:     1,
+		ColumnStructureHash: "columns",
+	}
+	invalidCardinality := valid
+	invalidCardinality.MatchingWorkflowCardinality = serverapi.WorkflowTaskListMatchingWorkflowCardinalityNone
+	missingWorkflowID := valid
+	missingWorkflowID.Scope.ProjectWide = nil
+	missingWorkflowID.Scope.Narrowed = &workflowTaskListNarrowedPageTokenInvariants{
+		WorkflowVersion:     1,
+		ColumnStructureHash: "columns",
+	}
+	missingWorkflowVersion := valid
+	missingWorkflowVersion.Scope.ProjectWide = nil
+	missingWorkflowVersion.Scope.Narrowed = &workflowTaskListNarrowedPageTokenInvariants{
+		WorkflowID:          tokenWorkflowID,
+		ColumnStructureHash: "columns",
+	}
+	missingColumnStructure := valid
+	missingColumnStructure.Scope.ProjectWide = nil
+	missingColumnStructure.Scope.Narrowed = &workflowTaskListNarrowedPageTokenInvariants{
+		WorkflowID:      tokenWorkflowID,
+		WorkflowVersion: 1,
+	}
+	paddedProjectID := valid
+	paddedProjectID.Scope.ProjectID = " project-1"
+	malformedWorkflowID := valid
+	malformedWorkflowID.Scope.ProjectWide = nil
+	malformedWorkflowID.Scope.Narrowed = &workflowTaskListNarrowedPageTokenInvariants{
+		WorkflowID:          "workflow-1",
+		WorkflowVersion:     1,
+		ColumnStructureHash: "columns",
+	}
+	for name, payload := range map[string]workflowTaskListPageTokenPayload{
+		"neither mode":             neitherMode,
+		"both modes":               bothModes,
+		"none cardinality":         invalidCardinality,
+		"missing workflow id":      missingWorkflowID,
+		"missing workflow version": missingWorkflowVersion,
+		"missing column structure": missingColumnStructure,
+		"padded project id":        paddedProjectID,
+		"malformed workflow id":    malformedWorkflowID,
 	} {
-		t.Run(testCase.name, func(t *testing.T) {
-			ctx, store, workflowStore, binding, view := newWorkflowViewTestContextService(t)
-			firstWorkflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
-			secondWorkflowID := createWorkflowViewValidWorkflow(t, ctx, workflowStore)
-			request, wantProjectID, wantWorkflowID, scopeErrWant := testCase.setup(t, ctx, store, workflowStore, binding, firstWorkflowID, secondWorkflowID)
-			response, err := view.ListTasks(ctx, request, testsetup.QuestionsEnabled("coder"))
-			if scopeErrWant == nil {
-				if err != nil {
-					t.Fatalf("ListTasks: %v", err)
-				}
-				if response.ProjectID != wantProjectID || response.WorkflowID != wantWorkflowID {
-					t.Fatalf("resolved scope = project %q workflow %q, want %q/%q", response.ProjectID, response.WorkflowID, wantProjectID, wantWorkflowID)
-				}
-				return
-			}
-			var scopeErr *serverapi.WorkflowTaskListScopeError
-			if !errors.As(err, &scopeErr) {
-				t.Fatalf("ListTasks error = %T %v, want scope error", err, err)
-			}
-			if scopeErr.Kind != scopeErrWant.kind || !reflect.DeepEqual(scopeIDSet(scopeErr.ProjectIDs), scopeErrWant.projectIDs) || !reflect.DeepEqual(scopeIDSet(scopeErr.WorkflowIDs), scopeErrWant.workflowIDs) {
-				t.Fatalf("scope error = %+v, want %+v", scopeErr, scopeErrWant)
-			}
-			if scopeErrWant.missingScope == nil {
-				if scopeErr.MissingScope != nil {
-					t.Fatalf("scope error missing scope = %q, want nil", *scopeErr.MissingScope)
-				}
-			} else if scopeErr.MissingScope == nil || *scopeErr.MissingScope != *scopeErrWant.missingScope {
-				t.Fatalf("scope error missing scope = %+v, want %q", scopeErr.MissingScope, *scopeErrWant.missingScope)
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := parseWorkflowTaskListPageToken(workflowTaskListPageToken(payload)); !errors.Is(err, ErrInvalidPageToken) {
+				t.Fatalf("parse malformed token error = %v, want ErrInvalidPageToken", err)
 			}
 		})
+	}
+}
+
+func TestWorkflowTaskListRequestFingerprintCanonicalizesSetFilters(t *testing.T) {
+	sortSelectors := []serverapi.WorkflowTaskListSort{
+		{Field: serverapi.WorkflowTaskListSortFieldStatus, Direction: serverapi.WorkflowTaskListSortDirectionAsc},
+	}
+	first := workflowTaskListRequestFingerprint(serverapi.WorkflowTaskListRequest{
+		ColumnKeys:     []string{"done", "backlog", "done"},
+		StatusKinds:    []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindRunning, serverapi.WorkflowTaskStatusKindBacklog, serverapi.WorkflowTaskStatusKindRunning},
+		AttentionKinds: []serverapi.WorkflowTaskAttentionKind{serverapi.WorkflowTaskAttentionKindQuestion, serverapi.WorkflowTaskAttentionKindApproval},
+	}, sortSelectors, "columns")
+	second := workflowTaskListRequestFingerprint(serverapi.WorkflowTaskListRequest{
+		ColumnKeys:     []string{"backlog", "done"},
+		StatusKinds:    []serverapi.WorkflowTaskStatusKind{serverapi.WorkflowTaskStatusKindBacklog, serverapi.WorkflowTaskStatusKindRunning},
+		AttentionKinds: []serverapi.WorkflowTaskAttentionKind{serverapi.WorkflowTaskAttentionKindApproval, serverapi.WorkflowTaskAttentionKindQuestion},
+	}, sortSelectors, "columns")
+	if first != second {
+		t.Fatalf("canonical fingerprints differ: %q != %q", first, second)
 	}
 }
 
@@ -715,7 +1284,7 @@ func TestTaskListInfersScopeFromContinuationToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTasks token-only continuation: %v", err)
 	}
-	if nextPage.ProjectID != binding.ProjectID || nextPage.WorkflowID != string(workflowID) || len(nextPage.Tasks) != 1 || nextPage.Tasks[0].TaskID == firstPage.Tasks[0].TaskID {
+	if nextPage.Scope.ProjectID != binding.ProjectID || nextPage.Scope.WorkflowID == nil || *nextPage.Scope.WorkflowID != string(workflowID) || len(nextPage.Tasks) != 1 || nextPage.Tasks[0].TaskID == firstPage.Tasks[0].TaskID {
 		t.Fatalf("token-only continuation = %+v, want resolved second page", nextPage)
 	}
 	otherProjectID := "project-conflict"
@@ -723,6 +1292,19 @@ func TestTaskListInfersScopeFromContinuationToken(t *testing.T) {
 	if !errors.Is(err, ErrInvalidPageToken) {
 		t.Fatalf("ListTasks conflicting token scope error = %v, want ErrInvalidPageToken", err)
 	}
+}
+
+func createTwoLinkedWorkflowViewWorkflows(t *testing.T, ctx context.Context, store *workflowstore.Store, projectID string) (workflow.WorkflowID, workflow.WorkflowID) {
+	t.Helper()
+	firstWorkflowID := createWorkflowViewValidWorkflow(t, ctx, store)
+	secondWorkflowID := createWorkflowViewValidWorkflow(t, ctx, store)
+	if _, err := store.LinkWorkflow(ctx, projectID, firstWorkflowID, true); err != nil {
+		t.Fatalf("LinkWorkflow first: %v", err)
+	}
+	if _, err := store.LinkWorkflow(ctx, projectID, secondWorkflowID, false); err != nil {
+		t.Fatalf("LinkWorkflow second: %v", err)
+	}
+	return firstWorkflowID, secondWorkflowID
 }
 
 func scopeIDSet(values []string) map[string]bool {

--- a/server/workflowview/workflow_api_projection.go
+++ b/server/workflowview/workflow_api_projection.go
@@ -42,17 +42,20 @@ func ValidationErrors(workflowID string, errs []workflow.ValidationError) []serv
 		if errorWorkflowID == "" {
 			errorWorkflowID = workflowID
 		}
-		out = append(out, serverapi.WorkflowValidationError{
+		projected := serverapi.WorkflowValidationError{
 			Code:              string(err.Code),
 			Message:           err.Message,
-			WorkflowID:        errorWorkflowID,
 			NodeID:            string(err.NodeID),
 			TransitionGroupID: string(err.TransitionGroupID),
 			EdgeID:            string(err.EdgeID),
 			Details:           validationErrorDetails(err),
 			RelatedIDs:        err.RelatedIDs,
 			BlocksContext:     err.BlocksContext,
-		})
+		}
+		if errorWorkflowID != "" {
+			projected.WorkflowID = &errorWorkflowID
+		}
+		out = append(out, projected)
 	}
 	return out
 }

--- a/server/workflowview/workflow_api_projection_test.go
+++ b/server/workflowview/workflow_api_projection_test.go
@@ -31,3 +31,14 @@ func TestValidationErrorsIncludesStructuredDetails(t *testing.T) {
 		t.Fatalf("details = %+v", details)
 	}
 }
+
+func TestValidationErrorsPreservesAbsentWorkflowIdentity(t *testing.T) {
+	errors := ValidationErrors("", []workflow.ValidationError{{
+		Code:    workflow.CodeInvalidTemplatePlaceholder,
+		Message: "invalid",
+	}})
+
+	if len(errors) != 1 || errors[0].WorkflowID != nil {
+		t.Fatalf("errors = %+v, want absent workflow identity", errors)
+	}
+}

--- a/shared/client/remote_rpc.go
+++ b/shared/client/remote_rpc.go
@@ -510,6 +510,12 @@ func protocolError(resp *protocol.ResponseError) error {
 	if resp.Code == protocol.ErrCodeWorkflowTaskListScope && len(resp.Data) > 0 {
 		return serverapi.DecodeWorkflowTaskListScopeError(resp.Data, message)
 	}
+	if resp.Code == protocol.ErrCodeWorkflowTaskCreateSelection && len(resp.Data) > 0 {
+		return serverapi.DecodeWorkflowTaskCreateSelectionError(resp.Data, message)
+	}
+	if resp.Code == protocol.ErrCodeWorkflowTaskCreateConflict && len(resp.Data) > 0 {
+		return serverapi.DecodeWorkflowTaskCreateConflictError(resp.Data, message)
+	}
 	if resp.Code == protocol.ErrCodeSubagentLaunchDenied && len(resp.Data) > 0 {
 		return serverapi.DecodeSubagentLaunchDeniedError(resp.Data, message)
 	}

--- a/shared/client/remote_test.go
+++ b/shared/client/remote_test.go
@@ -1029,11 +1029,12 @@ func TestProtocolErrorMapsSentinelCodes(t *testing.T) {
 }
 
 func TestProtocolErrorDecodesWorkflowTaskListScopeError(t *testing.T) {
-	missing := serverapi.WorkflowTaskListScopeDimensionProject
+	projectID := "project-1"
+	workflowID := "workflow-7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
 	source := &serverapi.WorkflowTaskListScopeError{
-		Kind:         serverapi.WorkflowTaskListScopeErrorKindAmbiguous,
-		MissingScope: &missing,
-		ProjectIDs:   []string{"project-1", "project-2"},
+		Reason:     serverapi.WorkflowTaskListScopeReasonWorkflowNotLinked,
+		ProjectID:  &projectID,
+		WorkflowID: &workflowID,
 	}
 	err := protocolError(&protocol.ResponseError{
 		Code:    protocol.ErrCodeWorkflowTaskListScope,
@@ -1044,9 +1045,67 @@ func TestProtocolErrorDecodesWorkflowTaskListScopeError(t *testing.T) {
 	if !errors.As(err, &decoded) {
 		t.Fatalf("decoded error = %T %v, want WorkflowTaskListScopeError", err, err)
 	}
-	if decoded.Kind != source.Kind || decoded.MissingScope == nil || *decoded.MissingScope != missing || len(decoded.ProjectIDs) != 2 || decoded.ProjectIDs[0] != "project-1" || decoded.ProjectIDs[1] != "project-2" {
+	if decoded.Reason != source.Reason || decoded.ProjectID == nil || *decoded.ProjectID != "project-1" || decoded.WorkflowID == nil || *decoded.WorkflowID != workflowID {
 		t.Fatalf("decoded scope error = %+v, want %+v", decoded, source)
 	}
+}
+
+func TestProtocolErrorDecodesWorkflowTaskCreateSelectionError(t *testing.T) {
+	workflowID := "workflow-1"
+	source := &serverapi.WorkflowTaskCreateSelectionError{
+		Reason:     serverapi.WorkflowTaskCreateSelectionReasonWorkflowNotLinked,
+		ProjectID:  "project-1",
+		WorkflowID: &workflowID,
+	}
+	err := protocolError(&protocol.ResponseError{
+		Code:    protocol.ErrCodeWorkflowTaskCreateSelection,
+		Message: "selection failed",
+		Data:    source.RPCErrorData(),
+	})
+	var decoded *serverapi.WorkflowTaskCreateSelectionError
+	if !errors.As(err, &decoded) {
+		t.Fatalf("decoded error = %T %v, want WorkflowTaskCreateSelectionError", err, err)
+	}
+	if decoded.Reason != source.Reason ||
+		decoded.ProjectID != source.ProjectID ||
+		decoded.WorkflowID == nil ||
+		*decoded.WorkflowID != workflowID {
+		t.Fatalf("decoded selection error = %+v, want %+v", decoded, source)
+	}
+}
+
+func TestProtocolErrorDecodesWorkflowTaskCreateConflictError(t *testing.T) {
+	source := &serverapi.WorkflowTaskCreateConflictError{
+		Reason: serverapi.WorkflowTaskCreateConflictReasonSerialization,
+	}
+	err := protocolError(&protocol.ResponseError{
+		Code:    protocol.ErrCodeWorkflowTaskCreateConflict,
+		Message: "task create conflicted",
+		Data:    source.RPCErrorData(),
+	})
+	var decoded *serverapi.WorkflowTaskCreateConflictError
+	if !errors.As(err, &decoded) || decoded.Reason != source.Reason {
+		t.Fatalf("decoded error = %T %v, want WorkflowTaskCreateConflictError", err, err)
+	}
+}
+
+func TestProtocolErrorDecodesSessionRetargetError(t *testing.T) {
+	source := &serverapi.SessionRetargetError{
+		Reason:        serverapi.SessionRetargetTargetProjectRequired,
+		SessionID:     "session-1",
+		SourceProject: serverapi.ProjectReference{ID: "project-source", Name: "Source"},
+		TargetRoot:    "/work/target",
+		CandidateProjects: []serverapi.ProjectReference{{
+			ID:   "project-target",
+			Name: "Target",
+		}},
+	}
+	err := protocolError(&protocol.ResponseError{
+		Code:    protocol.ErrCodeSessionRetarget,
+		Message: source.Error(),
+		Data:    source.RPCErrorData(),
+	})
+	assertRemoteSessionRetargetError(t, err, source)
 }
 
 func TestRemoteSessionRetargetErrorRoundTrip(t *testing.T) {

--- a/shared/client/remote_test.go
+++ b/shared/client/remote_test.go
@@ -1051,7 +1051,7 @@ func TestProtocolErrorDecodesWorkflowTaskListScopeError(t *testing.T) {
 }
 
 func TestProtocolErrorDecodesWorkflowTaskCreateSelectionError(t *testing.T) {
-	workflowID := "workflow-1"
+	workflowID := "workflow-7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
 	source := &serverapi.WorkflowTaskCreateSelectionError{
 		Reason:     serverapi.WorkflowTaskCreateSelectionReasonWorkflowNotLinked,
 		ProjectID:  "project-1",
@@ -1071,6 +1071,14 @@ func TestProtocolErrorDecodesWorkflowTaskCreateSelectionError(t *testing.T) {
 		decoded.WorkflowID == nil ||
 		*decoded.WorkflowID != workflowID {
 		t.Fatalf("decoded selection error = %+v, want %+v", decoded, source)
+	}
+	malformed := protocolError(&protocol.ResponseError{
+		Code:    protocol.ErrCodeWorkflowTaskCreateSelection,
+		Message: "selection failed",
+		Data:    json.RawMessage(`{"type":"workflow_task_create_selection_error","reason":"workflow_not_linked","project_id":"project-1","workflow_id":"workflow-1"}`),
+	})
+	if errors.As(malformed, &decoded) {
+		t.Fatalf("malformed selection payload decoded as typed error: %+v", decoded)
 	}
 }
 

--- a/shared/client/workflow_remote_test.go
+++ b/shared/client/workflow_remote_test.go
@@ -68,6 +68,62 @@ func TestRemoteWorkflowListRoute(t *testing.T) {
 	}
 }
 
+func TestRemoteWorkflowTaskListRoundTripsTypedScope(t *testing.T) {
+	handlerErr := make(chan error, 1)
+	projectID := "project-1"
+	workflowID := "workflow-1"
+	server := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {
+		defer func() { _ = ws.Close() }()
+		var req protocol.Request
+		if err := websocket.JSON.Receive(ws, &req); err != nil {
+			handlerErr <- fmt.Errorf("receive handshake: %w", err)
+			return
+		}
+		if err := websocket.JSON.Send(ws, protocol.NewSuccessResponse(req.ID, protocol.HandshakeResponse{Identity: protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"}})); err != nil {
+			handlerErr <- fmt.Errorf("send handshake response: %w", err)
+			return
+		}
+		if err := websocket.JSON.Receive(ws, &req); err != nil {
+			handlerErr <- fmt.Errorf("receive task list: %w", err)
+			return
+		}
+		if req.Method != protocol.MethodWorkflowTaskList {
+			handlerErr <- fmt.Errorf("task list method = %q", req.Method)
+			return
+		}
+		response := serverapi.WorkflowTaskListResponse{
+			Scope:                       serverapi.WorkflowTaskListScope{ProjectID: projectID, WorkflowID: &workflowID},
+			MatchingWorkflowCardinality: serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne,
+			Tasks:                       []serverapi.WorkflowTaskListItem{{TaskID: "task-1", WorkflowID: workflowID}},
+		}
+		if err := websocket.JSON.Send(ws, protocol.NewSuccessResponse(req.ID, response)); err != nil {
+			handlerErr <- fmt.Errorf("send task list response: %w", err)
+			return
+		}
+		handlerErr <- nil
+	}))
+	defer server.Close()
+
+	remote, err := DialRemoteURL(context.Background(), "ws"+server.URL[len("http"):])
+	if err != nil {
+		t.Fatalf("DialRemoteURL: %v", err)
+	}
+	defer func() { _ = remote.Close() }()
+	response, err := remote.ListWorkflowTasks(context.Background(), serverapi.WorkflowTaskListRequest{ProjectID: &projectID, WorkflowID: &workflowID})
+	if err != nil {
+		t.Fatalf("ListWorkflowTasks: %v", err)
+	}
+	if response.Scope.ProjectID != projectID || response.Scope.WorkflowID == nil || *response.Scope.WorkflowID != workflowID || response.MatchingWorkflowCardinality != serverapi.WorkflowTaskListMatchingWorkflowCardinalityOne {
+		t.Fatalf("response scope = %+v, want typed project/workflow scope", response)
+	}
+	if len(response.Tasks) != 1 || response.Tasks[0].WorkflowID != workflowID {
+		t.Fatalf("response tasks = %+v, want one workflow task", response.Tasks)
+	}
+	if err := <-handlerErr; err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRemoteWorkflowStartRejectsInvalidResponse(t *testing.T) {
 	handlerErr := make(chan error, 1)
 	server := httptest.NewServer(websocket.Handler(func(ws *websocket.Conn) {

--- a/shared/protocol/jsonrpc.go
+++ b/shared/protocol/jsonrpc.go
@@ -52,6 +52,8 @@ const (
 	ErrCodeWorktreeImmediateTransition       = -32042
 	ErrCodeSubagentLaunchDenied              = -32043
 	ErrCodeSubagentLaunchPolicy              = -32044
+	ErrCodeWorkflowTaskCreateSelection       = -32045
+	ErrCodeWorkflowTaskCreateConflict        = -32046
 )
 
 type Request struct {

--- a/shared/protocol/version.json
+++ b/shared/protocol/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "62"
+  "version": "63"
 }

--- a/shared/runtimeids/ids.go
+++ b/shared/runtimeids/ids.go
@@ -49,6 +49,26 @@ func ParseCanonicalUUIDv4(raw string, field string) (uuid.UUID, error) {
 	return parsed, nil
 }
 
+func ParseCanonicalPrefixedUUIDv4(raw string, prefix string, field string) (uuid.UUID, error) {
+	const canonicalUUIDTextLength = 36
+	if prefix == "" {
+		return uuid.Nil, fmt.Errorf("%s prefix is required", field)
+	}
+	if len(raw) != len(prefix)+canonicalUUIDTextLength {
+		return uuid.Nil, fmt.Errorf("%s must use the %q prefix followed by a canonical UUIDv4", field, prefix)
+	}
+	for index := range prefix {
+		if raw[index] != prefix[index] {
+			return uuid.Nil, fmt.Errorf("%s must use the %q prefix followed by a canonical UUIDv4", field, prefix)
+		}
+	}
+	var uuidText [canonicalUUIDTextLength]byte
+	for index := range uuidText {
+		uuidText[index] = raw[len(prefix)+index]
+	}
+	return ParseCanonicalUUIDv4(string(uuidText[:]), field)
+}
+
 func newUUIDv4Value() uuidv4Value {
 	return uuidv4Value{value: uuid.New()}
 }

--- a/shared/runtimeids/ids.go
+++ b/shared/runtimeids/ids.go
@@ -57,7 +57,7 @@ func ParseCanonicalPrefixedUUIDv4(raw string, prefix string, field string) (uuid
 	if len(raw) != len(prefix)+canonicalUUIDTextLength {
 		return uuid.Nil, fmt.Errorf("%s must use the %q prefix followed by a canonical UUIDv4", field, prefix)
 	}
-	for index := range prefix {
+	for index := 0; index < len(prefix); index++ {
 		if raw[index] != prefix[index] {
 			return uuid.Nil, fmt.Errorf("%s must use the %q prefix followed by a canonical UUIDv4", field, prefix)
 		}

--- a/shared/runtimeids/ids_test.go
+++ b/shared/runtimeids/ids_test.go
@@ -35,6 +35,13 @@ func TestParseCanonicalPrefixedUUIDv4RequiresExactPrefixAndCanonicalValue(t *tes
 	}
 }
 
+func TestParseCanonicalPrefixedUUIDv4ComparesEveryPrefixByte(t *testing.T) {
+	const canonical = "7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
+	if _, err := ParseCanonicalPrefixedUUIDv4("ê-"+canonical, "é-", "workflow id"); err == nil {
+		t.Fatal("ParseCanonicalPrefixedUUIDv4 accepted a changed UTF-8 continuation byte")
+	}
+}
+
 func TestParseSessionIDAcceptsCanonicalUUIDv4AndSupportedLegacyIDs(t *testing.T) {
 	for _, raw := range []string{
 		"7fd3bc93-f11c-4814-87d0-b60f10e6dd5c",

--- a/shared/runtimeids/ids_test.go
+++ b/shared/runtimeids/ids_test.go
@@ -13,6 +13,28 @@ func TestParseCanonicalUUIDv4RejectsNonRFCVariant(t *testing.T) {
 	}
 }
 
+func TestParseCanonicalPrefixedUUIDv4RequiresExactPrefixAndCanonicalValue(t *testing.T) {
+	const canonical = "7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
+	parsed, err := ParseCanonicalPrefixedUUIDv4("workflow-"+canonical, "workflow-", "workflow id")
+	if err != nil {
+		t.Fatalf("ParseCanonicalPrefixedUUIDv4 valid id: %v", err)
+	}
+	if parsed.String() != canonical {
+		t.Fatalf("parsed id = %q, want %q", parsed, canonical)
+	}
+	for _, raw := range []string{
+		canonical,
+		"workflowx" + canonical,
+		"workflow--" + canonical,
+		"workflow-" + canonical + "-extra",
+		"workflow-7E8D24D2-8A98-4DCF-A197-6214DB1CB3C0",
+	} {
+		if _, err := ParseCanonicalPrefixedUUIDv4(raw, "workflow-", "workflow id"); err == nil {
+			t.Fatalf("ParseCanonicalPrefixedUUIDv4(%q) succeeded", raw)
+		}
+	}
+}
+
 func TestParseSessionIDAcceptsCanonicalUUIDv4AndSupportedLegacyIDs(t *testing.T) {
 	for _, raw := range []string{
 		"7fd3bc93-f11c-4814-87d0-b60f10e6dd5c",

--- a/shared/serverapi/workflow.go
+++ b/shared/serverapi/workflow.go
@@ -9,6 +9,7 @@ import (
 
 	"core/shared/clientui"
 	"core/shared/protocol"
+	"core/shared/runtimeids"
 	"core/shared/workflowkey"
 )
 
@@ -78,6 +79,11 @@ type WorkflowRecord struct {
 	Description           string                               `json:"description"`
 	Version               int64                                `json:"version"`
 	ExecutionTargetPolicy WorkflowExecutionTargetConfiguration `json:"execution_target_policy"`
+	ProjectLink           *WorkflowListProjectLink             `json:"project_link,omitempty"`
+}
+
+type WorkflowListProjectLink struct {
+	Default bool `json:"default"`
 }
 
 type WorkflowNode struct {
@@ -376,14 +382,16 @@ type WorkflowUpdateRequest struct {
 }
 
 type WorkflowListRequest struct {
-	PageSize  int    `json:"page_size,omitempty"`
-	PageToken string `json:"page_token,omitempty"`
-	Query     string `json:"query,omitempty"`
-	ExactName string `json:"exact_name,omitempty"`
+	PageSize   int     `json:"page_size,omitempty"`
+	PageToken  string  `json:"page_token,omitempty"`
+	Query      string  `json:"query,omitempty"`
+	ProjectID  *string `json:"project_id,omitempty"`
+	WorkflowID *string `json:"workflow_id,omitempty"`
 }
 
 type WorkflowListResponse struct {
 	Workflows     []WorkflowRecord `json:"workflows"`
+	ProjectID     *string          `json:"project_id,omitempty"`
 	NextPageToken string           `json:"next_page_token,omitempty"`
 }
 
@@ -657,16 +665,137 @@ type WorkflowValidationErrorDetails struct {
 }
 
 type WorkflowTaskCreateRequest struct {
-	ProjectID         string `json:"project_id"`
-	WorkflowID        string `json:"workflow_id,omitempty"`
-	Title             string `json:"title"`
-	Body              string `json:"body,omitempty"`
-	SourceURL         string `json:"source_url,omitempty"`
-	SourceWorkspaceID string `json:"source_workspace_id,omitempty"`
+	ProjectID         string  `json:"project_id"`
+	WorkflowID        *string `json:"workflow_id,omitempty"`
+	Title             string  `json:"title"`
+	Body              string  `json:"body,omitempty"`
+	SourceURL         string  `json:"source_url,omitempty"`
+	SourceWorkspaceID string  `json:"source_workspace_id,omitempty"`
 }
 
 type WorkflowTaskCreateResponse struct {
 	Task WorkflowTaskSummary `json:"task"`
+}
+
+type WorkflowTaskCreateSelectionReason string
+
+const (
+	WorkflowTaskCreateSelectionReasonNoLinkedWorkflows       WorkflowTaskCreateSelectionReason = "no_linked_workflows"
+	WorkflowTaskCreateSelectionReasonWorkflowNotLinked       WorkflowTaskCreateSelectionReason = "workflow_not_linked"
+	WorkflowTaskCreateSelectionReasonAmbiguousWithoutDefault WorkflowTaskCreateSelectionReason = "ambiguous_without_default"
+)
+
+type WorkflowTaskCreateSelectionError struct {
+	Reason     WorkflowTaskCreateSelectionReason
+	ProjectID  string
+	WorkflowID *string
+}
+
+func (e *WorkflowTaskCreateSelectionError) Error() string {
+	if e == nil {
+		return "workflow task create selection error"
+	}
+	return "workflow task create selection error: " + string(e.Reason)
+}
+
+func (e *WorkflowTaskCreateSelectionError) RPCErrorCode() int {
+	return protocol.ErrCodeWorkflowTaskCreateSelection
+}
+
+func (e *WorkflowTaskCreateSelectionError) RPCErrorData() json.RawMessage {
+	if e == nil {
+		return nil
+	}
+	return marshalRPCErrorData(struct {
+		Type       string                            `json:"type"`
+		Reason     WorkflowTaskCreateSelectionReason `json:"reason"`
+		ProjectID  string                            `json:"project_id"`
+		WorkflowID *string                           `json:"workflow_id,omitempty"`
+	}{
+		Type:       "workflow_task_create_selection_error",
+		Reason:     e.Reason,
+		ProjectID:  e.ProjectID,
+		WorkflowID: e.WorkflowID,
+	})
+}
+
+func DecodeWorkflowTaskCreateSelectionError(data json.RawMessage, message string) error {
+	var envelope struct {
+		Type       string                            `json:"type"`
+		Reason     WorkflowTaskCreateSelectionReason `json:"reason"`
+		ProjectID  string                            `json:"project_id"`
+		WorkflowID *string                           `json:"workflow_id,omitempty"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil ||
+		envelope.Type != "workflow_task_create_selection_error" ||
+		strings.TrimSpace(envelope.ProjectID) == "" ||
+		!validWorkflowTaskCreateSelectionError(envelope.Reason, envelope.WorkflowID) {
+		return errors.New(strings.TrimSpace(message))
+	}
+	return &WorkflowTaskCreateSelectionError{
+		Reason:     envelope.Reason,
+		ProjectID:  envelope.ProjectID,
+		WorkflowID: envelope.WorkflowID,
+	}
+}
+
+func validWorkflowTaskCreateSelectionError(reason WorkflowTaskCreateSelectionReason, workflowID *string) bool {
+	switch reason {
+	case WorkflowTaskCreateSelectionReasonNoLinkedWorkflows,
+		WorkflowTaskCreateSelectionReasonAmbiguousWithoutDefault:
+		return workflowID == nil
+	case WorkflowTaskCreateSelectionReasonWorkflowNotLinked:
+		return workflowID != nil && strings.TrimSpace(*workflowID) != ""
+	default:
+		return false
+	}
+}
+
+type WorkflowTaskCreateConflictReason string
+
+const (
+	WorkflowTaskCreateConflictReasonSerialization WorkflowTaskCreateConflictReason = "serialization_conflict"
+)
+
+type WorkflowTaskCreateConflictError struct {
+	Reason WorkflowTaskCreateConflictReason
+}
+
+func (e *WorkflowTaskCreateConflictError) Error() string {
+	if e == nil {
+		return "workflow task create conflict"
+	}
+	return "workflow task create conflict: " + string(e.Reason)
+}
+
+func (e *WorkflowTaskCreateConflictError) RPCErrorCode() int {
+	return protocol.ErrCodeWorkflowTaskCreateConflict
+}
+
+func (e *WorkflowTaskCreateConflictError) RPCErrorData() json.RawMessage {
+	if e == nil {
+		return nil
+	}
+	return marshalRPCErrorData(struct {
+		Type   string                           `json:"type"`
+		Reason WorkflowTaskCreateConflictReason `json:"reason"`
+	}{
+		Type:   "workflow_task_create_conflict_error",
+		Reason: e.Reason,
+	})
+}
+
+func DecodeWorkflowTaskCreateConflictError(data json.RawMessage, message string) error {
+	var envelope struct {
+		Type   string                           `json:"type"`
+		Reason WorkflowTaskCreateConflictReason `json:"reason"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil ||
+		envelope.Type != "workflow_task_create_conflict_error" ||
+		envelope.Reason != WorkflowTaskCreateConflictReasonSerialization {
+		return errors.New(strings.TrimSpace(message))
+	}
+	return &WorkflowTaskCreateConflictError{Reason: envelope.Reason}
 }
 
 type WorkflowTaskUpdateRequest struct {
@@ -1025,53 +1154,59 @@ type WorkflowTaskListRequest struct {
 	PageToken      string                      `json:"page_token,omitempty"`
 }
 
+type WorkflowTaskListScope struct {
+	ProjectID  string  `json:"project_id"`
+	WorkflowID *string `json:"workflow_id,omitempty"`
+}
+
+type WorkflowTaskListMatchingWorkflowCardinality string
+
+const (
+	WorkflowTaskListMatchingWorkflowCardinalityNone     WorkflowTaskListMatchingWorkflowCardinality = "none"
+	WorkflowTaskListMatchingWorkflowCardinalityOne      WorkflowTaskListMatchingWorkflowCardinality = "one"
+	WorkflowTaskListMatchingWorkflowCardinalityMultiple WorkflowTaskListMatchingWorkflowCardinality = "multiple"
+)
+
 type WorkflowTaskListResponse struct {
-	ProjectID         string                 `json:"project_id"`
-	WorkflowID        string                 `json:"workflow_id"`
-	SelectedWorkflow  *WorkflowPickerItem    `json:"selected_workflow,omitempty"`
-	NextPageToken     string                 `json:"next_page_token,omitempty"`
-	GeneratedAtUnixMs int64                  `json:"generated_at_unix_ms"`
-	Tasks             []WorkflowTaskListItem `json:"tasks"`
+	Scope                       WorkflowTaskListScope                       `json:"scope"`
+	MatchingWorkflowCardinality WorkflowTaskListMatchingWorkflowCardinality `json:"matching_workflow_cardinality"`
+	NextPageToken               string                                      `json:"next_page_token,omitempty"`
+	GeneratedAtUnixMs           int64                                       `json:"generated_at_unix_ms"`
+	Tasks                       []WorkflowTaskListItem                      `json:"tasks"`
 }
 
 type WorkflowTaskListItem struct {
 	TaskID          string             `json:"task_id"`
 	ShortID         string             `json:"short_id"`
 	WorkflowID      string             `json:"workflow_id"`
+	WorkflowName    string             `json:"workflow_name,omitempty"`
 	Title           string             `json:"title"`
 	CreatedAtUnixMs int64              `json:"created_at_unix_ms"`
 	UpdatedAtUnixMs int64              `json:"updated_at_unix_ms"`
-	ColumnKeys      []string           `json:"column_keys"`
+	ColumnKeys      *[]string          `json:"column_keys,omitempty"`
 	Status          WorkflowTaskStatus `json:"status"`
 	RunCount        int                `json:"run_count"`
 }
 
-type WorkflowTaskListScopeErrorKind string
+type WorkflowTaskListScopeErrorReason string
 
 const (
-	WorkflowTaskListScopeErrorKindNotLinked WorkflowTaskListScopeErrorKind = "not_linked"
-	WorkflowTaskListScopeErrorKindAmbiguous WorkflowTaskListScopeErrorKind = "ambiguous"
-)
-
-type WorkflowTaskListScopeDimension string
-
-const (
-	WorkflowTaskListScopeDimensionProject  WorkflowTaskListScopeDimension = "project"
-	WorkflowTaskListScopeDimensionWorkflow WorkflowTaskListScopeDimension = "workflow"
+	WorkflowTaskListScopeReasonNoLinkedWorkflows       WorkflowTaskListScopeErrorReason = "no_linked_workflows"
+	WorkflowTaskListScopeReasonWorkflowNotLinked       WorkflowTaskListScopeErrorReason = "workflow_not_linked"
+	WorkflowTaskListScopeReasonWorkflowRequiredColumns WorkflowTaskListScopeErrorReason = "workflow_required_for_columns"
 )
 
 type WorkflowTaskListScopeError struct {
-	Kind         WorkflowTaskListScopeErrorKind
-	MissingScope *WorkflowTaskListScopeDimension
-	ProjectIDs   []string
-	WorkflowIDs  []string
+	Reason     WorkflowTaskListScopeErrorReason
+	ProjectID  *string
+	WorkflowID *string
 }
 
 func (e *WorkflowTaskListScopeError) Error() string {
 	if e == nil {
 		return "workflow task list scope error"
 	}
-	return "workflow task list scope error: " + string(e.Kind)
+	return "workflow task list scope error: " + string(e.Reason)
 }
 
 func (e *WorkflowTaskListScopeError) RPCErrorCode() int {
@@ -1083,41 +1218,60 @@ func (e *WorkflowTaskListScopeError) RPCErrorData() json.RawMessage {
 		return nil
 	}
 	return marshalRPCErrorData(struct {
-		Type         string                          `json:"type"`
-		Kind         WorkflowTaskListScopeErrorKind  `json:"kind"`
-		MissingScope *WorkflowTaskListScopeDimension `json:"missing_scope,omitempty"`
-		ProjectIDs   []string                        `json:"project_ids,omitempty"`
-		WorkflowIDs  []string                        `json:"workflow_ids,omitempty"`
+		Type       string                           `json:"type"`
+		Reason     WorkflowTaskListScopeErrorReason `json:"reason"`
+		ProjectID  *string                          `json:"project_id,omitempty"`
+		WorkflowID *string                          `json:"workflow_id,omitempty"`
 	}{
-		Type:         "workflow_task_list_scope_error",
-		Kind:         e.Kind,
-		MissingScope: e.MissingScope,
-		ProjectIDs:   e.ProjectIDs,
-		WorkflowIDs:  e.WorkflowIDs,
+		Type:       "workflow_task_list_scope_error",
+		Reason:     e.Reason,
+		ProjectID:  e.ProjectID,
+		WorkflowID: e.WorkflowID,
 	})
 }
 
 func DecodeWorkflowTaskListScopeError(data json.RawMessage, message string) error {
 	var envelope struct {
-		Type         string                          `json:"type"`
-		Kind         WorkflowTaskListScopeErrorKind  `json:"kind"`
-		MissingScope *WorkflowTaskListScopeDimension `json:"missing_scope,omitempty"`
-		ProjectIDs   []string                        `json:"project_ids,omitempty"`
-		WorkflowIDs  []string                        `json:"workflow_ids,omitempty"`
+		Type       string                           `json:"type"`
+		Reason     WorkflowTaskListScopeErrorReason `json:"reason"`
+		ProjectID  *string                          `json:"project_id,omitempty"`
+		WorkflowID *string                          `json:"workflow_id,omitempty"`
 	}
 	if err := json.Unmarshal(data, &envelope); err != nil ||
-		envelope.Type != "workflow_task_list_scope_error" ||
-		(envelope.Kind != WorkflowTaskListScopeErrorKindNotLinked && envelope.Kind != WorkflowTaskListScopeErrorKindAmbiguous) ||
-		(envelope.MissingScope != nil && *envelope.MissingScope != WorkflowTaskListScopeDimensionProject && *envelope.MissingScope != WorkflowTaskListScopeDimensionWorkflow) ||
-		(envelope.Kind == WorkflowTaskListScopeErrorKindAmbiguous && envelope.MissingScope == nil) {
+		envelope.Type != "workflow_task_list_scope_error" {
 		return errors.New(strings.TrimSpace(message))
 	}
-	return &WorkflowTaskListScopeError{
-		Kind:         envelope.Kind,
-		MissingScope: envelope.MissingScope,
-		ProjectIDs:   envelope.ProjectIDs,
-		WorkflowIDs:  envelope.WorkflowIDs,
+	scopeErr := &WorkflowTaskListScopeError{
+		Reason:     envelope.Reason,
+		ProjectID:  envelope.ProjectID,
+		WorkflowID: envelope.WorkflowID,
 	}
+	if err := scopeErr.validate(); err != nil {
+		return errors.New(strings.TrimSpace(message))
+	}
+	return scopeErr
+}
+
+func (e *WorkflowTaskListScopeError) validate() error {
+	if e == nil || e.ProjectID == nil || strings.TrimSpace(*e.ProjectID) == "" || strings.TrimSpace(*e.ProjectID) != *e.ProjectID {
+		return errors.New("workflow task list scope error requires an exact project id")
+	}
+	switch e.Reason {
+	case WorkflowTaskListScopeReasonNoLinkedWorkflows, WorkflowTaskListScopeReasonWorkflowRequiredColumns:
+		if e.WorkflowID != nil {
+			return errors.New("workflow task list scope error reason forbids workflow id")
+		}
+	case WorkflowTaskListScopeReasonWorkflowNotLinked:
+		if e.WorkflowID == nil {
+			return errors.New("workflow-not-linked task list scope error requires workflow id")
+		}
+		if _, err := runtimeids.ParseCanonicalPrefixedUUIDv4(*e.WorkflowID, "workflow-", "workflow id"); err != nil {
+			return err
+		}
+	default:
+		return errors.New("workflow task list scope error reason is invalid")
+	}
+	return nil
 }
 
 type WorkflowBoardResponse struct {
@@ -1435,6 +1589,16 @@ func (r WorkflowListRequest) Validate() error {
 	}
 	if r.PageToken != strings.TrimSpace(r.PageToken) {
 		return workflowRequestError(WorkflowRequestErrorInvalidMode, "page_token", "page_token must not have leading or trailing whitespace")
+	}
+	if r.ProjectID != nil {
+		if err := validateRequired("project_id", *r.ProjectID); err != nil {
+			return err
+		}
+	}
+	if r.WorkflowID != nil {
+		if err := validateRequired("workflow_id", *r.WorkflowID); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -1846,7 +2010,13 @@ func validateWorkflowGraphDraftEnvelope(graph WorkflowGraphDraft) error {
 }
 
 func (r WorkflowTaskCreateRequest) Validate() error {
-	return validateRequiredFields(requiredField("project_id", r.ProjectID), requiredField("title", r.Title))
+	if err := validateRequiredFields(requiredField("project_id", r.ProjectID), requiredField("title", r.Title)); err != nil {
+		return err
+	}
+	if r.WorkflowID != nil {
+		return validateRequired("workflow_id", *r.WorkflowID)
+	}
+	return nil
 }
 
 func (r WorkflowTaskUpdateRequest) Validate() error {
@@ -2095,8 +2265,12 @@ func (r WorkflowBoardRequest) Validate() error {
 }
 
 func (r WorkflowTaskListRequest) Validate() error {
-	if r.ProjectID == nil && r.WorkflowID == nil && strings.TrimSpace(r.PageToken) == "" {
-		return workflowRequestError(WorkflowRequestErrorRequired, "scope", "project_id, workflow_id, or page_token is required")
+	if r.ProjectID == nil && strings.TrimSpace(r.PageToken) == "" {
+		message := "project_id is required on the first page"
+		if r.WorkflowID != nil {
+			message = "project_id is required when workflow_id is selected"
+		}
+		return workflowRequestError(WorkflowRequestErrorRequired, "project_id", message)
 	}
 	for _, scope := range []struct {
 		field string

--- a/shared/serverapi/workflow.go
+++ b/shared/serverapi/workflow.go
@@ -646,7 +646,7 @@ type WorkflowValidateResponse struct {
 type WorkflowValidationError struct {
 	Code              string                          `json:"code"`
 	Message           string                          `json:"message"`
-	WorkflowID        string                          `json:"workflow_id,omitempty"`
+	WorkflowID        *string                         `json:"workflow_id,omitempty"`
 	NodeID            string                          `json:"node_id,omitempty"`
 	TransitionGroupID string                          `json:"transition_group_id,omitempty"`
 	EdgeID            string                          `json:"edge_id,omitempty"`
@@ -729,6 +729,7 @@ func DecodeWorkflowTaskCreateSelectionError(data json.RawMessage, message string
 	if err := json.Unmarshal(data, &envelope); err != nil ||
 		envelope.Type != "workflow_task_create_selection_error" ||
 		strings.TrimSpace(envelope.ProjectID) == "" ||
+		strings.TrimSpace(envelope.ProjectID) != envelope.ProjectID ||
 		!validWorkflowTaskCreateSelectionError(envelope.Reason, envelope.WorkflowID) {
 		return errors.New(strings.TrimSpace(message))
 	}
@@ -745,7 +746,11 @@ func validWorkflowTaskCreateSelectionError(reason WorkflowTaskCreateSelectionRea
 		WorkflowTaskCreateSelectionReasonAmbiguousWithoutDefault:
 		return workflowID == nil
 	case WorkflowTaskCreateSelectionReasonWorkflowNotLinked:
-		return workflowID != nil && strings.TrimSpace(*workflowID) != ""
+		if workflowID == nil {
+			return false
+		}
+		_, err := runtimeids.ParseCanonicalPrefixedUUIDv4(*workflowID, "workflow-", "workflow id")
+		return err == nil
 	default:
 		return false
 	}
@@ -978,7 +983,7 @@ type WorkflowAttentionItem struct {
 	ID                     string                           `json:"id"`
 	Kind                   string                           `json:"kind"`
 	ProjectID              string                           `json:"project_id,omitempty"`
-	WorkflowID             string                           `json:"workflow_id,omitempty"`
+	WorkflowID             *string                          `json:"workflow_id,omitempty"`
 	TaskID                 string                           `json:"task_id,omitempty"`
 	TaskShortID            string                           `json:"task_short_id,omitempty"`
 	TaskTitle              string                           `json:"task_title,omitempty"`
@@ -1170,7 +1175,7 @@ const (
 type WorkflowTaskListResponse struct {
 	Scope                       WorkflowTaskListScope                       `json:"scope"`
 	MatchingWorkflowCardinality WorkflowTaskListMatchingWorkflowCardinality `json:"matching_workflow_cardinality"`
-	NextPageToken               string                                      `json:"next_page_token,omitempty"`
+	NextPageToken               *string                                     `json:"next_page_token,omitempty"`
 	GeneratedAtUnixMs           int64                                       `json:"generated_at_unix_ms"`
 	Tasks                       []WorkflowTaskListItem                      `json:"tasks"`
 }
@@ -1179,7 +1184,7 @@ type WorkflowTaskListItem struct {
 	TaskID          string             `json:"task_id"`
 	ShortID         string             `json:"short_id"`
 	WorkflowID      string             `json:"workflow_id"`
-	WorkflowName    string             `json:"workflow_name,omitempty"`
+	WorkflowName    *string            `json:"workflow_name,omitempty"`
 	Title           string             `json:"title"`
 	CreatedAtUnixMs int64              `json:"created_at_unix_ms"`
 	UpdatedAtUnixMs int64              `json:"updated_at_unix_ms"`

--- a/shared/serverapi/workflow_test.go
+++ b/shared/serverapi/workflow_test.go
@@ -9,6 +9,7 @@ import (
 
 	"core/shared/clientui"
 	"core/shared/protocol"
+	"core/shared/textutil"
 )
 
 type workflowRequestValidator interface {
@@ -130,6 +131,16 @@ func TestWorkflowTransitionGroupDescriptionRequestValidation(t *testing.T) {
 
 func TestWorkflowTaskAndCommentRequestValidation(t *testing.T) {
 	setupOperationID := NewWorktreeSetupOperationID()
+	if err := (WorkflowTaskCreateRequest{ProjectID: "project-1", Title: "Task"}).Validate(); err != nil {
+		t.Fatalf("valid task create rejected: %v", err)
+	}
+	blankWorkflowID := " "
+	if err := (WorkflowTaskCreateRequest{ProjectID: "project-1", WorkflowID: &blankWorkflowID, Title: "Task"}).Validate(); !isWorkflowFieldError(err, "workflow_id", WorkflowRequestErrorRequired) {
+		t.Fatalf("blank present workflow id error = %#v, want required on workflow_id", err)
+	}
+	if err := (WorkflowTaskCreateRequest{ProjectID: "project-1", Title: "", Body: "Body"}).Validate(); !isWorkflowFieldError(err, "title", WorkflowRequestErrorRequired) {
+		t.Fatalf("empty title error = %#v, want required on title", err)
+	}
 	updateTitle := "Task"
 	blankTitle := " "
 	selectedOption := 1
@@ -569,7 +580,8 @@ func TestWorkflowTaskListRequestValidation(t *testing.T) {
 	}
 
 	testWorkflowFieldErrors(t, []workflowFieldErrorCase{
-		{name: "scope required without continuation token", request: WorkflowTaskListRequest{}, field: "scope", code: WorkflowRequestErrorRequired},
+		{name: "project scope required without continuation token", request: WorkflowTaskListRequest{}, field: "project_id", code: WorkflowRequestErrorRequired},
+		{name: "workflow requires project on first page", request: WorkflowTaskListRequest{WorkflowID: &workflowID}, field: "project_id", code: WorkflowRequestErrorRequired},
 		{name: "negative page size", request: WorkflowTaskListRequest{ProjectID: &projectID, PageSize: -1}, field: "page_size", code: WorkflowRequestErrorInvalidMode},
 		{name: "oversized page size", request: WorkflowTaskListRequest{ProjectID: &projectID, PageSize: WorkflowTaskListMaxPageSize + 1}, field: "page_size", code: WorkflowRequestErrorInvalidMode},
 		{name: "page token whitespace", request: WorkflowTaskListRequest{ProjectID: &projectID, PageToken: " token"}, field: "page_token", code: WorkflowRequestErrorInvalidMode},
@@ -585,12 +597,15 @@ func TestWorkflowTaskListRequestValidation(t *testing.T) {
 }
 
 func TestWorkflowTaskListResponseJSONShape(t *testing.T) {
+	selectedColumnKeys := []string{"plan", "qa"}
 	selected := WorkflowTaskListResponse{
-		ProjectID:         "project-1",
-		WorkflowID:        "workflow-1",
-		NextPageToken:     "next",
-		SelectedWorkflow:  &WorkflowPickerItem{WorkflowID: "workflow-1", DisplayName: "Main", Version: 3},
-		GeneratedAtUnixMs: 10,
+		Scope: WorkflowTaskListScope{
+			ProjectID:  "project-1",
+			WorkflowID: stringPointerForTest("workflow-1"),
+		},
+		MatchingWorkflowCardinality: WorkflowTaskListMatchingWorkflowCardinalityOne,
+		NextPageToken:               "next",
+		GeneratedAtUnixMs:           10,
 		Tasks: []WorkflowTaskListItem{{
 			TaskID:          "task-1",
 			ShortID:         "BLD-1",
@@ -598,17 +613,25 @@ func TestWorkflowTaskListResponseJSONShape(t *testing.T) {
 			Title:           "Task",
 			CreatedAtUnixMs: 11,
 			UpdatedAtUnixMs: 12,
-			ColumnKeys:      []string{"plan", "qa"},
+			ColumnKeys:      &selectedColumnKeys,
 			Status:          WorkflowTaskStatus{Kind: WorkflowTaskStatusKindQueued, NativeState: "active", NodeIDs: []string{"node-1"}, RunIDs: []string{"run-1"}, AttentionTypes: []WorkflowTaskAttentionKind{WorkflowTaskAttentionKindApproval}},
 			RunCount:        2,
 		}},
 	}
-	raw, selectedShape := marshalWorkflowJSON[map[string]any](t, selected)
-	if got := selectedShape["workflow_id"]; got != "workflow-1" {
-		t.Fatalf("workflow_id = %#v, want workflow-1", got)
+	raw, err := json.Marshal(selected)
+	if err != nil {
+		t.Fatalf("marshal selected response: %v", err)
 	}
-	if _, ok := selectedShape["selected_workflow"]; !ok {
-		t.Fatalf("selected_workflow missing from selected response JSON: %s", raw)
+	var selectedShape map[string]any
+	if err := json.Unmarshal(raw, &selectedShape); err != nil {
+		t.Fatalf("unmarshal selected response: %v", err)
+	}
+	scope, ok := selectedShape["scope"].(map[string]any)
+	if !ok || scope["project_id"] != "project-1" || scope["workflow_id"] != "workflow-1" {
+		t.Fatalf("scope = %#v, want project and selected workflow", selectedShape["scope"])
+	}
+	if selectedShape["matching_workflow_cardinality"] != string(WorkflowTaskListMatchingWorkflowCardinalityOne) {
+		t.Fatalf("matching workflow cardinality = %#v", selectedShape["matching_workflow_cardinality"])
 	}
 	tasks, ok := selectedShape["tasks"].([]any)
 	if !ok || len(tasks) != 1 {
@@ -636,14 +659,87 @@ func TestWorkflowTaskListResponseJSONShape(t *testing.T) {
 		t.Fatalf("task status JSON unexpectedly contains label: %s", raw)
 	}
 
-	empty := WorkflowTaskListResponse{ProjectID: "project-1", WorkflowID: "", Tasks: []WorkflowTaskListItem{}}
-	raw, emptyShape := marshalWorkflowJSON[map[string]any](t, empty)
-	if got, ok := emptyShape["workflow_id"]; !ok || got != "" {
-		t.Fatalf("empty workflow_id = %#v present=%v, want present empty string", got, ok)
+	empty := WorkflowTaskListResponse{
+		Scope:                       WorkflowTaskListScope{ProjectID: "project-1"},
+		MatchingWorkflowCardinality: WorkflowTaskListMatchingWorkflowCardinalityNone,
+		Tasks:                       []WorkflowTaskListItem{},
 	}
-	if _, ok := emptyShape["selected_workflow"]; ok {
-		t.Fatalf("selected_workflow present in no-selected-workflow response JSON: %s", raw)
+	raw, err = json.Marshal(empty)
+	if err != nil {
+		t.Fatalf("marshal empty response: %v", err)
 	}
+	var emptyShape map[string]any
+	if err := json.Unmarshal(raw, &emptyShape); err != nil {
+		t.Fatalf("unmarshal empty response: %v", err)
+	}
+	emptyScope, ok := emptyShape["scope"].(map[string]any)
+	if !ok || emptyScope["project_id"] != "project-1" {
+		t.Fatalf("empty scope = %#v, want project-only scope", emptyShape["scope"])
+	}
+	if _, ok := emptyScope["workflow_id"]; ok {
+		t.Fatalf("workflow_id present in project-only scope JSON: %s", raw)
+	}
+	projectWide := WorkflowTaskListResponse{
+		Scope:                       WorkflowTaskListScope{ProjectID: "project-1"},
+		MatchingWorkflowCardinality: WorkflowTaskListMatchingWorkflowCardinalityMultiple,
+		Tasks:                       []WorkflowTaskListItem{{TaskID: "task-1", WorkflowID: "workflow-1"}},
+	}
+	raw, err = json.Marshal(projectWide)
+	if err != nil {
+		t.Fatalf("marshal project-wide response: %v", err)
+	}
+	var projectWideShape map[string]any
+	if err := json.Unmarshal(raw, &projectWideShape); err != nil {
+		t.Fatalf("unmarshal project-wide response: %v", err)
+	}
+	tasks, ok = projectWideShape["tasks"].([]any)
+	if !ok || len(tasks) != 1 {
+		t.Fatalf("project-wide tasks shape = %#v", projectWideShape["tasks"])
+	}
+	projectWideTask, ok := tasks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("project-wide task shape = %#v", tasks[0])
+	}
+	if _, ok := projectWideTask["column_keys"]; ok {
+		t.Fatalf("project-wide task unexpectedly contains column_keys: %s", raw)
+	}
+	emptyColumns := []string{}
+	narrowed := WorkflowTaskListResponse{
+		Scope:                       WorkflowTaskListScope{ProjectID: "project-1", WorkflowID: stringPointerForTest("workflow-1")},
+		MatchingWorkflowCardinality: WorkflowTaskListMatchingWorkflowCardinalityOne,
+		Tasks:                       []WorkflowTaskListItem{{TaskID: "task-1", WorkflowID: "workflow-1", ColumnKeys: &emptyColumns}},
+	}
+	raw, err = json.Marshal(narrowed)
+	if err != nil {
+		t.Fatalf("marshal narrowed response: %v", err)
+	}
+	var narrowedShape map[string]any
+	if err := json.Unmarshal(raw, &narrowedShape); err != nil {
+		t.Fatalf("unmarshal narrowed response: %v", err)
+	}
+	narrowedTasks, ok := narrowedShape["tasks"].([]any)
+	if !ok || len(narrowedTasks) != 1 {
+		t.Fatalf("narrowed tasks shape = %#v", narrowedShape["tasks"])
+	}
+	narrowedTask, ok := narrowedTasks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("narrowed task shape = %#v", narrowedTasks[0])
+	}
+	if columnKeys, present := narrowedTask["column_keys"]; !present || !equalJSONArrays(columnKeys.([]any), []any{}) {
+		t.Fatalf("narrowed empty column_keys = %#v, want present empty array", narrowedTask["column_keys"])
+	}
+}
+
+func equalJSONArrays(got []any, want []any) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for index := range got {
+		if got[index] != want[index] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestWorkflowLifecycleJSONOmitsAbsentFacts(t *testing.T) {
@@ -700,15 +796,20 @@ func TestWorkflowLifecycleJSONOmitsAbsentFacts(t *testing.T) {
 }
 
 func TestWorkflowTaskListScopeErrorRoundTrip(t *testing.T) {
+	canonicalWorkflowID := "workflow-7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
 	for _, original := range []*WorkflowTaskListScopeError{
 		{
-			Kind:         WorkflowTaskListScopeErrorKindNotLinked,
-			MissingScope: workflowTaskListScopeDimensionPointer(WorkflowTaskListScopeDimensionWorkflow),
+			Reason:    WorkflowTaskListScopeReasonNoLinkedWorkflows,
+			ProjectID: stringPointerForTest("project-1"),
 		},
 		{
-			Kind:         WorkflowTaskListScopeErrorKindAmbiguous,
-			MissingScope: workflowTaskListScopeDimensionPointer(WorkflowTaskListScopeDimensionWorkflow),
-			WorkflowIDs:  []string{"workflow-1", "workflow-2"},
+			Reason:     WorkflowTaskListScopeReasonWorkflowNotLinked,
+			ProjectID:  stringPointerForTest("project-1"),
+			WorkflowID: &canonicalWorkflowID,
+		},
+		{
+			Reason:    WorkflowTaskListScopeReasonWorkflowRequiredColumns,
+			ProjectID: stringPointerForTest("project-1"),
 		},
 	} {
 		decoded := DecodeWorkflowTaskListScopeError(original.RPCErrorData(), original.Error())
@@ -716,16 +817,72 @@ func TestWorkflowTaskListScopeErrorRoundTrip(t *testing.T) {
 		if !errors.As(decoded, &scopeErr) {
 			t.Fatalf("decoded scope error = %T %v, want WorkflowTaskListScopeError", decoded, decoded)
 		}
-		if scopeErr.Kind != original.Kind || scopeErr.MissingScope == nil || *scopeErr.MissingScope != *original.MissingScope || !slices.Equal(scopeErr.WorkflowIDs, original.WorkflowIDs) {
+		if scopeErr.Reason != original.Reason || !textutil.EqualOptional(scopeErr.ProjectID, original.ProjectID) || !textutil.EqualOptional(scopeErr.WorkflowID, original.WorkflowID) {
 			t.Fatalf("decoded scope error = %+v, want %+v", scopeErr, original)
 		}
 		if scopeErr.RPCErrorCode() != protocol.ErrCodeWorkflowTaskListScope {
 			t.Fatalf("scope error code = %d, want %d", scopeErr.RPCErrorCode(), protocol.ErrCodeWorkflowTaskListScope)
 		}
 	}
+	if decoded := DecodeWorkflowTaskListScopeError(
+		json.RawMessage(`{"type":"workflow_task_list_scope_error","kind":"ambiguous","workflow_ids":["workflow-1","workflow-2"]}`),
+		"legacy scope error",
+	); decoded == nil || decoded.Error() != "legacy scope error" {
+		t.Fatalf("legacy ambiguity payload decoded as %#v, want fallback error", decoded)
+	}
+	for name, payload := range map[string]string{
+		"no links missing project":        `{"type":"workflow_task_list_scope_error","reason":"no_linked_workflows"}`,
+		"no links with workflow":          `{"type":"workflow_task_list_scope_error","reason":"no_linked_workflows","project_id":"project-1","workflow_id":"` + canonicalWorkflowID + `"}`,
+		"not linked missing workflow":     `{"type":"workflow_task_list_scope_error","reason":"workflow_not_linked","project_id":"project-1"}`,
+		"columns with workflow":           `{"type":"workflow_task_list_scope_error","reason":"workflow_required_for_columns","project_id":"project-1","workflow_id":"` + canonicalWorkflowID + `"}`,
+		"padded project":                  `{"type":"workflow_task_list_scope_error","reason":"no_linked_workflows","project_id":" project-1"}`,
+		"malformed persisted workflow id": `{"type":"workflow_task_list_scope_error","reason":"workflow_not_linked","project_id":"project-1","workflow_id":"workflow-1"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			decoded := DecodeWorkflowTaskListScopeError(json.RawMessage(payload), "fallback")
+			var scopeErr *WorkflowTaskListScopeError
+			if errors.As(decoded, &scopeErr) {
+				t.Fatalf("invalid payload decoded as typed scope error: %+v", scopeErr)
+			}
+		})
+	}
 }
 
-func workflowTaskListScopeDimensionPointer(value WorkflowTaskListScopeDimension) *WorkflowTaskListScopeDimension {
+func TestWorkflowTaskCreateSelectionErrorRoundTrip(t *testing.T) {
+	original := &WorkflowTaskCreateSelectionError{
+		Reason:    WorkflowTaskCreateSelectionReasonNoLinkedWorkflows,
+		ProjectID: "project-1",
+	}
+	decoded := DecodeWorkflowTaskCreateSelectionError(original.RPCErrorData(), original.Error())
+	var selectionErr *WorkflowTaskCreateSelectionError
+	if !errors.As(decoded, &selectionErr) {
+		t.Fatalf("decoded selection error = %T %v, want WorkflowTaskCreateSelectionError", decoded, decoded)
+	}
+	if selectionErr.Reason != original.Reason ||
+		selectionErr.ProjectID != original.ProjectID ||
+		selectionErr.WorkflowID != nil {
+		t.Fatalf("decoded selection error = %+v, want %+v", selectionErr, original)
+	}
+	if selectionErr.RPCErrorCode() != protocol.ErrCodeWorkflowTaskCreateSelection {
+		t.Fatalf("selection error code = %d, want %d", selectionErr.RPCErrorCode(), protocol.ErrCodeWorkflowTaskCreateSelection)
+	}
+}
+
+func TestWorkflowTaskCreateConflictErrorRoundTrip(t *testing.T) {
+	original := &WorkflowTaskCreateConflictError{
+		Reason: WorkflowTaskCreateConflictReasonSerialization,
+	}
+	decoded := DecodeWorkflowTaskCreateConflictError(original.RPCErrorData(), original.Error())
+	var conflictErr *WorkflowTaskCreateConflictError
+	if !errors.As(decoded, &conflictErr) {
+		t.Fatalf("decoded conflict error = %T %v, want WorkflowTaskCreateConflictError", decoded, decoded)
+	}
+	if conflictErr.Reason != original.Reason || conflictErr.RPCErrorCode() != protocol.ErrCodeWorkflowTaskCreateConflict {
+		t.Fatalf("decoded conflict error = %+v, want %+v", conflictErr, original)
+	}
+}
+
+func stringPointerForTest(value string) *string {
 	return &value
 }
 
@@ -788,6 +945,86 @@ func TestWorkflowProjectLinkRequestValidation(t *testing.T) {
 		{name: "list rejects malformed token", request: WorkflowListRequest{PageToken: " 10"}, field: "page_token", code: WorkflowRequestErrorInvalidMode},
 		{name: "set default requires project", request: WorkflowSetDefaultProjectLinkRequest{WorkflowID: "workflow-1"}, field: "project_id", code: WorkflowRequestErrorRequired},
 	})
+	projectID := "project-1"
+	workflowID := "workflow-1"
+	if err := (WorkflowListRequest{ProjectID: &projectID, WorkflowID: &workflowID}).Validate(); err != nil {
+		t.Fatalf("valid project workflow filters rejected: %v", err)
+	}
+	blank := " "
+	if err := (WorkflowListRequest{ProjectID: &blank}).Validate(); !isWorkflowFieldError(err, "project_id", WorkflowRequestErrorRequired) {
+		t.Fatalf("blank project filter error = %#v, want required on project_id", err)
+	}
+	if err := (WorkflowListRequest{WorkflowID: &blank}).Validate(); !isWorkflowFieldError(err, "workflow_id", WorkflowRequestErrorRequired) {
+		t.Fatalf("blank workflow filter error = %#v, want required on workflow_id", err)
+	}
+	if err := (WorkflowListRequest{WorkflowID: &workflowID}).Validate(); err != nil {
+		t.Fatalf("global exact workflow filter rejected: %v", err)
+	}
+	if err := (WorkflowSetDefaultProjectLinkRequest{ProjectID: "project-1", WorkflowID: "workflow-1"}).Validate(); err != nil {
+		t.Fatalf("valid set default request rejected: %v", err)
+	}
+	if err := (WorkflowSetDefaultProjectLinkRequest{ProjectID: "", WorkflowID: "workflow-1"}).Validate(); !isWorkflowFieldError(err, "project_id", WorkflowRequestErrorRequired) {
+		t.Fatalf("empty project id error = %#v, want required on project_id", err)
+	}
+}
+
+func TestWorkflowListProjectContextJSONIsOptionalAndTyped(t *testing.T) {
+	projectID := "project-1"
+	workflowID := "workflow-1"
+	request := WorkflowListRequest{ProjectID: &projectID, WorkflowID: &workflowID}
+	data, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal workflow list request: %v", err)
+	}
+	var requestShape map[string]any
+	if err := json.Unmarshal(data, &requestShape); err != nil {
+		t.Fatalf("decode workflow list request: %v", err)
+	}
+	if requestShape["project_id"] != projectID || requestShape["workflow_id"] != workflowID {
+		t.Fatalf("request JSON = %#v, want typed project/workflow filters", requestShape)
+	}
+
+	response := WorkflowListResponse{
+		ProjectID: &projectID,
+		Workflows: []WorkflowRecord{{
+			ID:          workflowID,
+			Name:        "Workflow",
+			ProjectLink: &WorkflowListProjectLink{Default: true},
+		}},
+	}
+	data, err = json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal workflow list response: %v", err)
+	}
+	var responseShape map[string]any
+	if err := json.Unmarshal(data, &responseShape); err != nil {
+		t.Fatalf("decode workflow list response: %v", err)
+	}
+	if responseShape["project_id"] != projectID {
+		t.Fatalf("response JSON = %#v, want project context", responseShape)
+	}
+	workflows := responseShape["workflows"].([]any)
+	record := workflows[0].(map[string]any)
+	link := record["project_link"].(map[string]any)
+	if link["default"] != true {
+		t.Fatalf("project link JSON = %#v, want default=true", link)
+	}
+
+	globalData, err := json.Marshal(WorkflowListResponse{Workflows: []WorkflowRecord{{ID: workflowID, Name: "Workflow"}}})
+	if err != nil {
+		t.Fatalf("marshal global response: %v", err)
+	}
+	var globalShape map[string]any
+	if err := json.Unmarshal(globalData, &globalShape); err != nil {
+		t.Fatalf("decode global response: %v", err)
+	}
+	if _, exists := globalShape["project_id"]; exists {
+		t.Fatalf("global response JSON = %#v, must omit project_id", globalShape)
+	}
+	globalRecords := globalShape["workflows"].([]any)
+	if _, exists := globalRecords[0].(map[string]any)["project_link"]; exists {
+		t.Fatalf("global response JSON = %#v, must omit project_link", globalShape)
+	}
 }
 
 func TestWorkflowTaskStatusKindNativeState(t *testing.T) {

--- a/shared/serverapi/workflow_test.go
+++ b/shared/serverapi/workflow_test.go
@@ -604,7 +604,7 @@ func TestWorkflowTaskListResponseJSONShape(t *testing.T) {
 			WorkflowID: stringPointerForTest("workflow-1"),
 		},
 		MatchingWorkflowCardinality: WorkflowTaskListMatchingWorkflowCardinalityOne,
-		NextPageToken:               "next",
+		NextPageToken:               stringPointerForTest("next"),
 		GeneratedAtUnixMs:           10,
 		Tasks: []WorkflowTaskListItem{{
 			TaskID:          "task-1",
@@ -632,6 +632,9 @@ func TestWorkflowTaskListResponseJSONShape(t *testing.T) {
 	}
 	if selectedShape["matching_workflow_cardinality"] != string(WorkflowTaskListMatchingWorkflowCardinalityOne) {
 		t.Fatalf("matching workflow cardinality = %#v", selectedShape["matching_workflow_cardinality"])
+	}
+	if selectedShape["next_page_token"] != "next" {
+		t.Fatalf("next page token = %#v, want present token", selectedShape["next_page_token"])
 	}
 	tasks, ok := selectedShape["tasks"].([]any)
 	if !ok || len(tasks) != 1 {
@@ -679,10 +682,13 @@ func TestWorkflowTaskListResponseJSONShape(t *testing.T) {
 	if _, ok := emptyScope["workflow_id"]; ok {
 		t.Fatalf("workflow_id present in project-only scope JSON: %s", raw)
 	}
+	if _, ok := emptyShape["next_page_token"]; ok {
+		t.Fatalf("next_page_token present without continuation: %s", raw)
+	}
 	projectWide := WorkflowTaskListResponse{
 		Scope:                       WorkflowTaskListScope{ProjectID: "project-1"},
 		MatchingWorkflowCardinality: WorkflowTaskListMatchingWorkflowCardinalityMultiple,
-		Tasks:                       []WorkflowTaskListItem{{TaskID: "task-1", WorkflowID: "workflow-1"}},
+		Tasks:                       []WorkflowTaskListItem{{TaskID: "task-1", WorkflowID: "workflow-1", WorkflowName: stringPointerForTest("Workflow")}},
 	}
 	raw, err = json.Marshal(projectWide)
 	if err != nil {
@@ -702,6 +708,9 @@ func TestWorkflowTaskListResponseJSONShape(t *testing.T) {
 	}
 	if _, ok := projectWideTask["column_keys"]; ok {
 		t.Fatalf("project-wide task unexpectedly contains column_keys: %s", raw)
+	}
+	if projectWideTask["workflow_name"] != "Workflow" {
+		t.Fatalf("project-wide task workflow_name = %#v, want present name", projectWideTask["workflow_name"])
 	}
 	emptyColumns := []string{}
 	narrowed := WorkflowTaskListResponse{
@@ -727,6 +736,21 @@ func TestWorkflowTaskListResponseJSONShape(t *testing.T) {
 	}
 	if columnKeys, present := narrowedTask["column_keys"]; !present || !equalJSONArrays(columnKeys.([]any), []any{}) {
 		t.Fatalf("narrowed empty column_keys = %#v, want present empty array", narrowedTask["column_keys"])
+	}
+	if _, present := narrowedTask["workflow_name"]; present {
+		t.Fatalf("narrowed task unexpectedly contains workflow_name: %s", raw)
+	}
+}
+
+func TestOptionalWorkflowIdentityJSONOmitsAbsentValues(t *testing.T) {
+	_, validationShape := marshalWorkflowJSON[map[string]any](t, WorkflowValidationError{Code: "invalid"})
+	if _, present := validationShape["workflow_id"]; present {
+		t.Fatalf("validation workflow_id present without identity: %#v", validationShape)
+	}
+
+	_, attentionShape := marshalWorkflowJSON[map[string]any](t, WorkflowAttentionItem{ID: "attention-1", Kind: "approval"})
+	if _, present := attentionShape["workflow_id"]; present {
+		t.Fatalf("attention workflow_id present without identity: %#v", attentionShape)
 	}
 }
 
@@ -865,6 +889,28 @@ func TestWorkflowTaskCreateSelectionErrorRoundTrip(t *testing.T) {
 	}
 	if selectionErr.RPCErrorCode() != protocol.ErrCodeWorkflowTaskCreateSelection {
 		t.Fatalf("selection error code = %d, want %d", selectionErr.RPCErrorCode(), protocol.ErrCodeWorkflowTaskCreateSelection)
+	}
+	canonicalWorkflowID := "workflow-7e8d24d2-8a98-4dcf-a197-6214db1cb3c0"
+	linked := &WorkflowTaskCreateSelectionError{
+		Reason:     WorkflowTaskCreateSelectionReasonWorkflowNotLinked,
+		ProjectID:  "project-1",
+		WorkflowID: &canonicalWorkflowID,
+	}
+	if decoded := DecodeWorkflowTaskCreateSelectionError(linked.RPCErrorData(), linked.Error()); !errors.As(decoded, &selectionErr) {
+		t.Fatalf("canonical workflow-not-linked error decoded as %T %v", decoded, decoded)
+	}
+	for name, payload := range map[string]string{
+		"padded project":     `{"type":"workflow_task_create_selection_error","reason":"no_linked_workflows","project_id":" project-1"}`,
+		"malformed workflow": `{"type":"workflow_task_create_selection_error","reason":"workflow_not_linked","project_id":"project-1","workflow_id":"workflow-1"}`,
+		"workflow forbidden": `{"type":"workflow_task_create_selection_error","reason":"no_linked_workflows","project_id":"project-1","workflow_id":"` + canonicalWorkflowID + `"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			decoded := DecodeWorkflowTaskCreateSelectionError(json.RawMessage(payload), "fallback")
+			var typed *WorkflowTaskCreateSelectionError
+			if errors.As(decoded, &typed) {
+				t.Fatalf("invalid payload decoded as typed selection error: %+v", typed)
+			}
+		})
 	}
 }
 

--- a/shared/textutil/optional.go
+++ b/shared/textutil/optional.go
@@ -15,7 +15,7 @@ func Int(value int) *int {
 	return &value
 }
 
-// EqualOptional compares optional values by presence and value.
+// EqualOptional compares optional comparable values by presence and value.
 func EqualOptional[T comparable](left *T, right *T) bool {
 	if left == nil || right == nil {
 		return left == right

--- a/shared/textutil/optional_test.go
+++ b/shared/textutil/optional_test.go
@@ -15,20 +15,23 @@ func TestPointerCopiesOptionalValue(t *testing.T) {
 }
 
 func TestEqualOptionalComparesPresenceAndValue(t *testing.T) {
-	one := 1
-	anotherOne := 1
-	two := 2
-	if !EqualOptional[int](nil, nil) {
-		t.Fatal("two absent values are not equal")
-	}
-	if EqualOptional(nil, &one) || EqualOptional(&one, nil) {
-		t.Fatal("present and absent values are equal")
-	}
-	if !EqualOptional(&one, &anotherOne) {
-		t.Fatal("distinct pointers with equal values are not equal")
-	}
-	if EqualOptional(&one, &two) {
-		t.Fatal("different values are equal")
+	one, anotherOne, two := 1, 1, 2
+	for name, testCase := range map[string]struct {
+		left  *int
+		right *int
+		want  bool
+	}{
+		"both absent":       {want: true},
+		"left absent":       {right: &one},
+		"right absent":      {left: &one},
+		"equal present":     {left: &one, right: &anotherOne, want: true},
+		"different present": {left: &one, right: &two},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := EqualOptional(testCase.left, testCase.right); got != testCase.want {
+				t.Fatalf("EqualOptional() = %t, want %t", got, testCase.want)
+			}
+		})
 	}
 }
 

--- a/shared/transcript/entry_compare.go
+++ b/shared/transcript/entry_compare.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"strings"
 
+	"core/shared/textutil"
 	patchformat "core/shared/transcript/patchformat"
 )
 
@@ -85,7 +86,7 @@ func ToolCallMetaEqual(left, right *ToolCallMeta) bool {
 		normalizedLeft.RawOutputRequested == normalizedRight.RawOutputRequested &&
 		normalizedLeft.OutputTruncated == normalizedRight.OutputTruncated &&
 		normalizedLeft.MovedToBackground == normalizedRight.MovedToBackground &&
-		optionalIntEqual(normalizedLeft.ShellExitCode, normalizedRight.ShellExitCode)
+		textutil.EqualOptional(normalizedLeft.ShellExitCode, normalizedRight.ShellExitCode)
 }
 
 func toolCallMetaEmpty(meta ToolCallMeta) bool {
@@ -110,13 +111,6 @@ func toolCallMetaEmpty(meta ToolCallMeta) bool {
 		!meta.OutputTruncated &&
 		!meta.MovedToBackground &&
 		meta.ShellExitCode == nil
-}
-
-func optionalIntEqual(left, right *int) bool {
-	if left == nil || right == nil {
-		return left == right
-	}
-	return *left == *right
 }
 
 func toolRenderHintsEqual(left, right *ToolRenderHint) bool {

--- a/tui-rs/crates/rpc-client/tests/websocket_factory.rs
+++ b/tui-rs/crates/rpc-client/tests/websocket_factory.rs
@@ -13,7 +13,7 @@ use tungstenite::Message;
 
 #[test]
 fn rust_protocol_version_matches_attachment_contract() {
-    assert_eq!(PROTOCOL_VERSION, "62");
+    assert_eq!(PROTOCOL_VERSION, "63");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Standardize every public workflow selector on a bare canonical UUIDv4 while preserving `workflow-...` IDs in persistence and server contracts.
- Make task listing project-scoped by default, with optional workflow narrowing, project-wide pagination/cardinality, conditional workflow display, and typed recovery for invalid scopes.
- Make task-create workflow selection transactional and typed across store, service, RPC, client, and CLI boundaries.
- Consolidate selector parsing, task recovery projection, optional-value equality, and workflow-command remote lifecycle behind single authoritative implementations.
- Preserve bounded SQL plans for workflow discovery/task cardinality and nullable continuation-token facts.
- Raise the bundled protocol contract from 62 to 63 and update Go, Desktop, and Rust client coverage.

## Verification

- `./scripts/test.sh server` — pass after an isolated rerun (an earlier parallel server/desktop invocation exceeded the suite wall-clock cap under resource contention; no package assertion failed).
- `./scripts/test.sh desktop` — pass.
- `./scripts/test.sh` — pass after rebasing onto `origin/main`.
- `./scripts/build.sh --output ./bin/kent` — pass.
- `sqlc generate` — hash-clean.
- `git diff --check` — pass.
- Focused CLI, metadata/sqlitegen, workflow store/view/service, transport/client, launch/workflow-runner, and shared contract suites — pass.
- Independent review/compliance reruns — PASS with no actionable findings.
- Post-rebase isolated rebuilt-binary smoke — created two linked workflows and one task in each, verified project-wide `multiple` cardinality at page size one, and traversed the second page using the continuation token.

## Completion evidence

- Acceptance criteria and detailed QA history: `.kent/plans/KENT-263.md` (local task evidence; ignored by the repository, so not attached to this PR).
- Operator documentation exercised during QA: `docs/src/content/docs/workflows.md`.
- Rebuilt CLI exercised against an owned isolated server: `./bin/kent` (build artifact is intentionally not committed or attached).

## Diff size

Calculated from `origin/main...KENT-263`, classifying `*_test.go`, test directories/files, and generated `server/metadata/sqlitegen/queries.sql.go` as test/generated:

| Category | Additions | Deletions | Gross LoC | Net LoC |
| --- | ---: | ---: | ---: | ---: |
| Production/docs/contracts | 2,481 | 807 | 3,288 | +1,674 |
| Tests/generated | 3,875 | 472 | 4,347 | +3,403 |
| **Total** | **6,356** | **1,279** | **7,635** | **+5,077** |

## Caveats and tradeoffs

- This is intentionally protocol-breaking: existing clients must update to protocol 63.
- Project-wide workflow-name visibility is frozen from first-page filtered cardinality, while task membership remains live; later pages can therefore retain a stale visibility choice during concurrent mutations by design.
- Column filters/sorts remain workflow-relative and require explicit narrowing; project-wide rows omit workflow-relative column fields.
- Workflow validity/Desktop validity mismatch remains out of scope and is owned by KENT-274.
- The immutable start-node policy remains unchanged.
- Rebase integration found duplicate CLI remote lifecycle paths; they were consolidated back onto latest main's single `runWorkflowCommandSession` authority before push.
- GitHub currently reports an existing moderate Dependabot alert on the default branch; this PR does not modify the affected dependency area.

## Tracking

- Kent task: **KENT-263 — Unify task workflow selectors**.
- No GitHub issue is linked; GitHub #263 is an unrelated historical pull request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `workflow list` with project filtering, pagination, and JSON output.
  * Added `workflow inspect --summary` for quick workflow metadata.
  * Workflow and task commands now accept canonical UUIDv4 workflow selectors.
  * Task creation can select linked or default workflows automatically.
  * Task listing now supports consistent project-wide and workflow-specific scopes.

* **Bug Fixes**
  * Improved task and workflow error messages with actionable recovery commands.
  * Added clearer handling for unlinked, ambiguous, or unavailable workflows.
  * Improved pagination, filtering, sorting, and JSON output consistency.

* **Documentation**
  * Updated CLI help and workflow/task guidance with the new selection and scoping rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->