### PR TITLE
Match desktop download transition to the documentation theme

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -107,6 +107,7 @@ export default defineConfig({
         MobileMenuFooter: './src/components/MobileMenuFooter.astro',
         Footer: './src/components/Footer.astro',
         PageTitle: './src/components/PageTitle.astro',
+        ThemeProvider: './src/components/ThemeProvider.astro',
         ThemeSelect: './src/components/ThemeSelect.astro',
       },
       expressiveCode: {

--- a/docs/scripts/smoke-built-docs.mjs
+++ b/docs/scripts/smoke-built-docs.mjs
@@ -201,20 +201,34 @@ async function assertRootRedirectPage() {
 async function assertDesktopRedirectPage() {
   const relativePath = 'desktop/index.html';
   const tree = fromHtml(await readFile(path.join(distRoot, relativePath), 'utf8'));
+  const htmlElements = collectElements(tree, (node) => node.tagName === 'html');
+  assert(
+    htmlElements.length === 1 && htmlElements[0].properties?.dataTheme === 'dark',
+    `${relativePath} should bootstrap with one deterministic initial theme`,
+  );
   assert(
     findMeta(tree, 'name', 'robots')?.properties?.content === 'noindex',
     `${relativePath} should keep noindex robots metadata`,
   );
   assert(
-    collectElements(tree, (node) => node.tagName === 'main').length === 1,
-    `${relativePath} should contain static fallback content`,
+    collectElements(tree, (node) => node.tagName === 'link' && relIncludes(node, 'stylesheet'))
+      .length > 0,
+    `${relativePath} should contain a generated stylesheet`,
+  );
+  const mainElements = collectElements(tree, (node) => node.tagName === 'main');
+  assert(
+    mainElements.length === 1 && mainElements[0].properties?.hidden === true,
+    `${relativePath} should contain one initially hidden confirmation surface`,
+  );
+  const releaseLinks = collectElements(
+    mainElements[0],
+    (node) =>
+      node.tagName === 'a' && node.properties?.href === `${docsConfig.repoUrl}/releases/latest`,
   );
   assert(
-    collectElements(
-      tree,
-      (node) =>
-        node.tagName === 'a' && node.properties?.href === `${docsConfig.repoUrl}/releases/latest`,
-    ).length === 1,
+    releaseLinks.length === 1 &&
+      (releaseLinks[0].properties?.target === undefined ||
+        releaseLinks[0].properties?.target === '_self'),
     `${relativePath} should link to the latest desktop release`,
   );
   assert(!hasScriptWithSource(tree, 'ClientRouter'), `${relativePath} should not include ClientRouter`);

--- a/docs/src/components/ThemeProvider.astro
+++ b/docs/src/components/ThemeProvider.astro
@@ -7,14 +7,21 @@
     const isTheme = (value) => value === lightTheme || value === darkTheme;
 
     const getStoredTheme = () => {
-      const value = typeof localStorage !== 'undefined' ? localStorage.getItem(storageKey) : null;
-      return isTheme(value) ? value : null;
+      try {
+        const value = typeof localStorage !== 'undefined' ? localStorage.getItem(storageKey) : null;
+        return isTheme(value) ? value : null;
+      } catch (error) {
+        console.warn('Kent docs could not read the saved theme; using the system theme.', error);
+        return null;
+      }
     };
 
     const getSystemTheme = () =>
       window.matchMedia('(prefers-color-scheme: light)').matches ? lightTheme : darkTheme;
 
-    const getEffectiveTheme = () => getStoredTheme() ?? getSystemTheme();
+    let activeTheme = darkTheme;
+
+    const getEffectiveTheme = () => activeTheme;
 
     const updatePickers = (theme = getStoredTheme() ?? 'auto') => {
       document.querySelectorAll('starlight-theme-select').forEach((picker) => {
@@ -26,18 +33,26 @@
     };
 
     const applyEffectiveTheme = () => {
-      const theme = getEffectiveTheme();
-      document.documentElement.dataset.theme = theme;
-      updatePickers();
-      return theme;
+      const storedTheme = getStoredTheme();
+      activeTheme = storedTheme ?? getSystemTheme();
+      document.documentElement.dataset.theme = activeTheme;
+      updatePickers(storedTheme ?? 'auto');
+      return activeTheme;
     };
 
     const toggleTheme = () => {
-      const theme = getEffectiveTheme() === darkTheme ? lightTheme : darkTheme;
-      localStorage.setItem(storageKey, theme);
-      document.documentElement.dataset.theme = theme;
-      updatePickers(theme);
-      return theme;
+      activeTheme = activeTheme === darkTheme ? lightTheme : darkTheme;
+      try {
+        localStorage.setItem(storageKey, activeTheme);
+      } catch (error) {
+        console.warn(
+          'Kent docs could not save the selected theme; applying it for this page only.',
+          error,
+        );
+      }
+      document.documentElement.dataset.theme = activeTheme;
+      updatePickers(activeTheme);
+      return activeTheme;
     };
 
     applyEffectiveTheme();

--- a/docs/src/components/ThemeProvider.astro
+++ b/docs/src/components/ThemeProvider.astro
@@ -1,0 +1,53 @@
+<script is:inline>
+  window.StarlightThemeProvider = (() => {
+    const storageKey = 'starlight-theme';
+    const lightTheme = 'light';
+    const darkTheme = 'dark';
+
+    const isTheme = (value) => value === lightTheme || value === darkTheme;
+
+    const getStoredTheme = () => {
+      const value = typeof localStorage !== 'undefined' ? localStorage.getItem(storageKey) : null;
+      return isTheme(value) ? value : null;
+    };
+
+    const getSystemTheme = () =>
+      window.matchMedia('(prefers-color-scheme: light)').matches ? lightTheme : darkTheme;
+
+    const getEffectiveTheme = () => getStoredTheme() ?? getSystemTheme();
+
+    const updatePickers = (theme = getStoredTheme() ?? 'auto') => {
+      document.querySelectorAll('starlight-theme-select').forEach((picker) => {
+        const select = picker.querySelector('select');
+        if (select) {
+          select.value = theme;
+        }
+      });
+    };
+
+    const applyEffectiveTheme = () => {
+      const theme = getEffectiveTheme();
+      document.documentElement.dataset.theme = theme;
+      updatePickers();
+      return theme;
+    };
+
+    const toggleTheme = () => {
+      const theme = getEffectiveTheme() === darkTheme ? lightTheme : darkTheme;
+      localStorage.setItem(storageKey, theme);
+      document.documentElement.dataset.theme = theme;
+      updatePickers(theme);
+      return theme;
+    };
+
+    applyEffectiveTheme();
+
+    return {
+      applyEffectiveTheme,
+      getEffectiveTheme,
+      getStoredTheme,
+      toggleTheme,
+      updatePickers,
+    };
+  })();
+</script>

--- a/docs/src/components/ThemeSelect.astro
+++ b/docs/src/components/ThemeSelect.astro
@@ -14,26 +14,16 @@ import { Icon } from '@astrojs/starlight/components';
 </kent-theme-toggle>
 
 <script>
-  const storageKey = 'starlight-theme';
-  const lightTheme = 'light';
-  const darkTheme = 'dark';
+  type Theme = 'light' | 'dark';
 
-  const getStoredTheme = () => {
-    const value = typeof localStorage !== 'undefined' ? localStorage.getItem(storageKey) : null;
-    return value === lightTheme || value === darkTheme ? value : null;
-  };
+  interface KentThemeProvider extends StarlightThemeProvider {
+    applyEffectiveTheme(): Theme;
+    getEffectiveTheme(): Theme;
+    getStoredTheme(): Theme | null;
+    toggleTheme(): Theme;
+  }
 
-  const getSystemTheme = () =>
-    window.matchMedia('(prefers-color-scheme: light)').matches ? lightTheme : darkTheme;
-
-  const getEffectiveTheme = () => getStoredTheme() ?? getSystemTheme();
-
-  const setTheme = (theme, persist) => {
-    document.documentElement.dataset.theme = theme;
-    if (persist) {
-      localStorage.setItem(storageKey, theme);
-    }
-  };
+  const themeProvider = window.StarlightThemeProvider as KentThemeProvider;
 
   const updateToggleUi = (root) => {
     const button = root.querySelector('button');
@@ -41,8 +31,8 @@ import { Icon } from '@astrojs/starlight/components';
       return;
     }
 
-    const currentTheme = getEffectiveTheme();
-    const nextTheme = currentTheme === darkTheme ? lightTheme : darkTheme;
+    const currentTheme = themeProvider.getEffectiveTheme();
+    const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
     button.dataset.currentTheme = currentTheme;
     button.setAttribute('aria-label', `Switch to ${nextTheme} theme`);
   };
@@ -56,14 +46,13 @@ import { Icon } from '@astrojs/starlight/components';
       super();
       this.mediaQuery = window.matchMedia('(prefers-color-scheme: light)');
       this.onSystemThemeChange = () => {
-        if (getStoredTheme() === null) {
-          setTheme(getSystemTheme(), false);
+        if (themeProvider.getStoredTheme() === null) {
+          themeProvider.applyEffectiveTheme();
           updateAllToggleUis();
         }
       };
       this.onToggleClick = () => {
-        const nextTheme = getEffectiveTheme() === darkTheme ? lightTheme : darkTheme;
-        setTheme(nextTheme, true);
+        themeProvider.toggleTheme();
         updateAllToggleUis();
       };
     }
@@ -74,7 +63,7 @@ import { Icon } from '@astrojs/starlight/components';
         return;
       }
 
-      setTheme(getEffectiveTheme(), false);
+      themeProvider.applyEffectiveTheme();
       updateAllToggleUis();
       button.addEventListener('click', this.onToggleClick);
 

--- a/docs/src/pages/desktop.astro
+++ b/docs/src/pages/desktop.astro
@@ -1,26 +1,27 @@
 ---
+import ThemeProvider from '@astrojs/starlight/components/ThemeProvider.astro';
+
+import '../styles/custom.css';
+
 const releasePageUrl = 'https://github.com/respawn-llc/kent/releases/latest';
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="robots" content="noindex" />
     <title>Downloading Kent Desktop | Kent</title>
+    <ThemeProvider />
   </head>
   <body>
-    <main>
-      <h1>Downloading Kent Desktop</h1>
-      <p id="status">Resolving the latest desktop download...</p>
-      <p>
-        If the download does not start, open the
-        <a href={releasePageUrl}>latest Kent release</a>.
-      </p>
+    <main id="download-confirmation" hidden>
+      <p>Your download has started. You can close this tab.</p>
+      <a href={releasePageUrl}>Open the latest release</a>
     </main>
     <script>
-      const statusElement = document.getElementById('status');
+      const confirmationElement = document.getElementById('download-confirmation');
       const releasePageUrl = 'https://github.com/respawn-llc/kent/releases/latest';
       const desktopAssets = [
         {
@@ -108,16 +109,70 @@ const releasePageUrl = 'https://github.com/respawn-llc/kent/releases/latest';
           throw new Error(`Latest Kent release does not contain ${assetRule.name}`);
         }
 
+        if (!(confirmationElement instanceof HTMLElement)) {
+          throw new Error('Kent Desktop download confirmation surface is unavailable');
+        }
+        confirmationElement.hidden = false;
         window.location.replace(asset.browser_download_url);
       }
 
       redirectToLatestDesktopDownload().catch((error) => {
         console.error(error);
-        if (statusElement) {
-          statusElement.textContent = 'Could not start the download automatically.';
-        }
-        window.location.assign(releasePageUrl);
+        window.location.replace(releasePageUrl);
       });
     </script>
   </body>
 </html>
+
+<style>
+  html,
+  body {
+    min-block-size: 100%;
+    background: var(--sl-color-bg);
+  }
+
+  body {
+    box-sizing: border-box;
+    min-block-size: 100vh;
+    min-block-size: 100svh;
+    margin: 0;
+    display: grid;
+    place-items: center;
+    color: var(--sl-color-text);
+    font-family: var(--sl-font);
+  }
+
+  main {
+    max-inline-size: var(--sl-content-width);
+    padding: var(--sl-text-2xl);
+    text-align: center;
+    animation: confirmation-in var(--kent-motion-fast) both;
+  }
+
+  main[hidden] {
+    display: none;
+  }
+
+  p {
+    margin: 0;
+    line-height: var(--sl-line-height);
+  }
+
+  a {
+    display: inline-block;
+    margin-block-start: var(--sl-text-base);
+    color: var(--sl-color-text-accent);
+    font-size: var(--sl-text-code-sm);
+    text-underline-offset: 0.2em;
+  }
+
+  @keyframes confirmation-in {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+</style>

--- a/docs/src/pages/desktop.astro
+++ b/docs/src/pages/desktop.astro
@@ -1,5 +1,5 @@
 ---
-import ThemeProvider from '@astrojs/starlight/components/ThemeProvider.astro';
+import ThemeProvider from '../components/ThemeProvider.astro';
 
 import '../styles/custom.css';
 


### PR DESCRIPTION
## Summary

- Makes `/desktop` an empty, theme-matched transition while the latest platform download resolves.
- Shows a centered post-download confirmation and quiet same-tab Releases fallback after handing the matching asset to the browser.
- Adds one Kent-owned pre-paint theme provider shared by normal documentation pages and `/desktop`.
- Validates saved theme values as exactly `light` or `dark`; absent, legacy `auto`, and malformed values follow the operating-system preference.
- Preserves the existing platform detection, release lookup, and asset matching behavior.

## Verification

- `pnpm --dir docs test` — 19/19 passed.
- `pnpm --dir docs build` — passed.
- `pnpm --dir docs smoke:built` — passed.
- `git diff --check` — passed.
- Browser QA covered saved light/dark, absent/`auto`/malformed preferences under both system themes, the successful attachment handoff, same-tab fallback navigation, reduced motion, JavaScript disabled, API/unsupported-platform fallback, narrow/wide layouts, and simulated `localStorage` read/write `SecurityError` failures.

### Completion evidence

Prior QA captured and reviewed screenshots for:

- the normal docs light-theme toggle state;
- the empty `/desktop` light resolving state;
- the empty `/desktop` dark resolving state.

The screenshots are not committed to the repository; the GitHub CLI PR flow does not support attaching local binary evidence.

## Diff size

- Production: **+151 / -38**, net **+113**, gross **189 LoC**.
- Tests: **+21 / -7**, net **+14**, gross **28 LoC**.
- Generated: **+0 / -0**, net **0**, gross **0 LoC**.
- Total: **+172 / -45**, net **+127**, gross **217 LoC**.

## Caveats and tradeoffs

- Browsers do not confirm that an attachment download has started, so the success message appears when the asset URL is handed to the browser.
- With JavaScript disabled, `/desktop` intentionally remains an empty themed page.
- Browsers that cannot prove a supported macOS architecture continue to fall back to the latest Releases page.
- Existing regex asset rules and substring-based platform detection are intentionally preserved for this ticket.
- If browser privacy settings make theme storage unavailable, the system theme is used initially and user toggles apply for the current page without persistence; the failure is reported in the browser console.

## Follow-up opportunities

- A first-party download-resolution endpoint or typed release manifest could eventually remove client-side GitHub API lookup and user-agent detection.

Addresses Kent task `KENT-254`. No GitHub issue is linked to this task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic theme support to documentation pages, including light/dark mode detection, persistence, and switching.
  * Updated the desktop download page with a streamlined confirmation message and automatic download redirection.
  * Added styling and animations for the download confirmation experience.

* **Bug Fixes**
  * Improved desktop download page validation and fallback behavior.
  * Ensured theme controls stay synchronized with the active theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
