### PR TITLE
Sanitize accepted path references in the TUI

### DIFF
--- a/cli/app/ui_path_reference_integration_test.go
+++ b/cli/app/ui_path_reference_integration_test.go
@@ -86,22 +86,24 @@ func TestPathReferenceEnterDoesNotSubmitWhileQueryIsPending(t *testing.T) {
 	}
 }
 
-func TestPathReferenceAcceptanceKeyDoesNotSubmitUnusableProjectedPath(t *testing.T) {
+func TestPathReferenceAcceptanceSkipsUnsafeCandidate(t *testing.T) {
 	for _, key := range []tea.KeyType{tea.KeyTab, tea.KeyEnter} {
 		t.Run(key.String(), func(t *testing.T) {
 			m, _ := newPathReferenceTestModel("echo @ab")
-			m.pathReference.matches = []uiPathReferenceCandidate{{Path: "\x1b[31m\x1b[0m"}}
-			m.pathReference.pending = false
+			m = deliverPathReferenceTestMatches(t, m, 1, []uiPathReferenceCandidate{
+				{Path: "evil\x1b[31mred.go"},
+				{Path: "safe.go"},
+			})
 
 			updated := updateUIModel(t, m, tea.KeyMsg{Type: key})
-			if testMainInput(updated) != "echo @ab" {
-				t.Fatalf("input = %q, want unchanged draft", testMainInput(updated))
+			if testMainInput(updated) != "echo @safe.go" {
+				t.Fatalf("input = %q, want exact safe candidate", testMainInput(updated))
 			}
 			if updated.isBusy() {
-				t.Fatal("did not expect unusable completion to start submission")
+				t.Fatal("did not expect completion to start submission")
 			}
 			if len(updated.queued) != 0 || len(updated.pendingInjected) != 0 {
-				t.Fatalf("did not expect unusable completion to queue input: queued=%+v pending=%+v", updated.queued, updated.pendingInjected)
+				t.Fatalf("did not expect completion to queue input: queued=%+v pending=%+v", updated.queued, updated.pendingInjected)
 			}
 			if updated.transientStatus != "" {
 				t.Fatalf("unexpected status UI %q", updated.transientStatus)

--- a/cli/app/ui_path_reference_integration_test.go
+++ b/cli/app/ui_path_reference_integration_test.go
@@ -86,6 +86,30 @@ func TestPathReferenceEnterDoesNotSubmitWhileQueryIsPending(t *testing.T) {
 	}
 }
 
+func TestPathReferenceAcceptanceKeyDoesNotSubmitUnusableProjectedPath(t *testing.T) {
+	for _, key := range []tea.KeyType{tea.KeyTab, tea.KeyEnter} {
+		t.Run(key.String(), func(t *testing.T) {
+			m, _ := newPathReferenceTestModel("echo @ab")
+			m.pathReference.matches = []uiPathReferenceCandidate{{Path: "\x1b[31m\x1b[0m"}}
+			m.pathReference.pending = false
+
+			updated := updateUIModel(t, m, tea.KeyMsg{Type: key})
+			if testMainInput(updated) != "echo @ab" {
+				t.Fatalf("input = %q, want unchanged draft", testMainInput(updated))
+			}
+			if updated.isBusy() {
+				t.Fatal("did not expect unusable completion to start submission")
+			}
+			if len(updated.queued) != 0 || len(updated.pendingInjected) != 0 {
+				t.Fatalf("did not expect unusable completion to queue input: queued=%+v pending=%+v", updated.queued, updated.pendingInjected)
+			}
+			if updated.transientStatus != "" {
+				t.Fatalf("unexpected status UI %q", updated.transientStatus)
+			}
+		})
+	}
+}
+
 func TestPathReferenceUIRecoversAfterBuildFailureInSameWorkspace(t *testing.T) {
 	m, search := newPathReferenceTestModel("@ab")
 	initialRequests := len(search.requests)

--- a/cli/app/ui_path_reference_picker.go
+++ b/cli/app/ui_path_reference_picker.go
@@ -70,15 +70,14 @@ func isPathReferenceQueryRune(r rune) bool {
 }
 
 func applyPathReferenceCompletion(input string, cursor int, query uiPathReferenceQuery, candidate uiPathReferenceCandidate) (string, int, bool) {
-	safePath := terminalSafePathReferenceText(candidate.Path)
-	if !query.Active || query.End < query.Start || strings.TrimSpace(safePath) == "" {
+	if !query.Active || query.End < query.Start || !isTerminalSafePathReference(candidate.Path) {
 		return input, cursor, false
 	}
 	runes := []rune(input)
 	if query.Start < 0 || query.End > len(runes) || query.Start > len(runes) {
 		return input, cursor, false
 	}
-	completion := "@" + safePath
+	completion := "@" + candidate.Path
 	if candidate.Directory && !strings.HasSuffix(completion, "/") {
 		completion += "/"
 	}
@@ -203,7 +202,7 @@ func (m *uiModel) pathReferencePicker() uiPickerPresentation {
 	}
 	rows := make([]uiPickerRow, 0, len(m.pathReference.matches))
 	for _, match := range m.pathReference.matches {
-		rows = append(rows, uiPickerRow{primary: terminalSafePathReferenceText(match.Path), selectable: true})
+		rows = append(rows, uiPickerRow{primary: match.Path, selectable: true})
 	}
 	lineCount := len(m.pathReference.matches)
 	if lineCount > slashCommandPickerLines {
@@ -281,6 +280,20 @@ func terminalSafePathReferenceText(path string) string {
 		filtered = append(filtered, r)
 	}
 	return string(filtered)
+}
+
+func isTerminalSafePathReference(path string) bool {
+	return strings.TrimSpace(path) != "" && terminalSafePathReferenceText(path) == path
+}
+
+func terminalSafePathReferenceCandidates(candidates []uiPathReferenceCandidate) []uiPathReferenceCandidate {
+	filtered := make([]uiPathReferenceCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if isTerminalSafePathReference(candidate.Path) {
+			filtered = append(filtered, candidate)
+		}
+	}
+	return filtered
 }
 
 func skipTerminalEscapeSequence(runes []rune, start int) int {
@@ -377,7 +390,7 @@ func (m *uiModel) handlePathReferenceMatchResult(msg uiPathReferenceMatchResultM
 	m.pathReference.corpusGeneration = msg.CorpusGeneration
 	m.pathReference.pending = false
 	m.pathReference.loading = false
-	m.pathReference.matches = append([]uiPathReferenceCandidate(nil), msg.Matches...)
+	m.pathReference.matches = terminalSafePathReferenceCandidates(msg.Matches)
 	m.pathReference.selection = 0
 }
 

--- a/cli/app/ui_path_reference_picker.go
+++ b/cli/app/ui_path_reference_picker.go
@@ -70,14 +70,15 @@ func isPathReferenceQueryRune(r rune) bool {
 }
 
 func applyPathReferenceCompletion(input string, cursor int, query uiPathReferenceQuery, candidate uiPathReferenceCandidate) (string, int, bool) {
-	if !query.Active || query.End < query.Start || strings.TrimSpace(candidate.Path) == "" {
+	safePath := terminalSafePathReferenceText(candidate.Path)
+	if !query.Active || query.End < query.Start || strings.TrimSpace(safePath) == "" {
 		return input, cursor, false
 	}
 	runes := []rune(input)
 	if query.Start < 0 || query.End > len(runes) || query.Start > len(runes) {
 		return input, cursor, false
 	}
-	completion := "@" + candidate.Path
+	completion := "@" + safePath
 	if candidate.Directory && !strings.HasSuffix(completion, "/") {
 		completion += "/"
 	}
@@ -202,7 +203,7 @@ func (m *uiModel) pathReferencePicker() uiPickerPresentation {
 	}
 	rows := make([]uiPickerRow, 0, len(m.pathReference.matches))
 	for _, match := range m.pathReference.matches {
-		rows = append(rows, uiPickerRow{primary: sanitizePathReferenceDisplayText(match.Path), selectable: true})
+		rows = append(rows, uiPickerRow{primary: terminalSafePathReferenceText(match.Path), selectable: true})
 	}
 	lineCount := len(m.pathReference.matches)
 	if lineCount > slashCommandPickerLines {
@@ -241,7 +242,7 @@ func (m *uiModel) acceptPathReferenceSelection() bool {
 		m.pathReference.matches[selection],
 	)
 	if !ok {
-		return false
+		return true
 	}
 	m.replaceMainInput(updated, byteOffsetForRuneCursor(updated, nextCursor))
 	return true
@@ -262,7 +263,7 @@ func (m *uiModel) shouldBlockPathReferenceAcceptanceKey() bool {
 	return m.pathReference.pending || m.pathReference.loading
 }
 
-func sanitizePathReferenceDisplayText(path string) string {
+func terminalSafePathReferenceText(path string) string {
 	if path == "" {
 		return ""
 	}

--- a/cli/app/ui_path_reference_picker_test.go
+++ b/cli/app/ui_path_reference_picker_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"reflect"
 	"testing"
+	"unicode"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -45,17 +46,49 @@ func TestDetectPathReferenceQuery(t *testing.T) {
 }
 
 func TestApplyPathReferenceCompletionReplacesMiddleSpan(t *testing.T) {
-	input, cursor := testPathReferenceFixture("compare @cliap| with tests")
-	query := detectPathReferenceQuery(input, cursor)
-	updated, nextCursor, ok := applyPathReferenceCompletion(input, cursor, query, uiPathReferenceCandidate{Path: "cli/app/ui.go"})
-	if !ok {
-		t.Fatal("expected completion applied")
+	tests := []struct {
+		name          string
+		candidatePath string
+		safePath      string
+	}{
+		{name: "ordinary path", candidatePath: "cli/app/ui.go", safePath: "cli/app/ui.go"},
+		{name: "CSI", candidatePath: "cli/\x1b[31mapp\x1b[0m/ui.go", safePath: "cli/app/ui.go"},
+		{name: "OSC terminated by BEL", candidatePath: "cli/\x1b]8;;https://evil.test\x07app\x1b]8;;\x07/ui.go", safePath: "cli/app/ui.go"},
+		{name: "OSC terminated by ST", candidatePath: "cli/\x1b]0;owned\x1b\\app/ui.go", safePath: "cli/app/ui.go"},
+		{name: "C0 control", candidatePath: "cli/app/\x01ui.go", safePath: "cli/app/ui.go"},
+		{name: "printable Unicode and punctuation", candidatePath: "目录/[draft] #1?.txt", safePath: "目录/[draft] #1?.txt"},
+		{name: "empty projection", candidatePath: "\x1b[31m\x1b[0m"},
+		{name: "blank projection", candidatePath: "\x1b[31m \t\x1b[0m"},
 	}
-	if updated != "compare @cli/app/ui.go with tests" {
-		t.Fatalf("updated input = %q", updated)
-	}
-	if nextCursor != len([]rune("compare @cli/app/ui.go")) {
-		t.Fatalf("cursor = %d", nextCursor)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input, cursor := testPathReferenceFixture("compare @cliap| with tests")
+			query := detectPathReferenceQuery(input, cursor)
+			updated, nextCursor, ok := applyPathReferenceCompletion(input, cursor, query, uiPathReferenceCandidate{Path: tc.candidatePath})
+			if tc.safePath == "" {
+				if ok || updated != input || nextCursor != cursor {
+					t.Fatalf("unusable projection result = (%q, %d, %v), want original input and cursor with false", updated, nextCursor, ok)
+				}
+				return
+			}
+			if !ok {
+				t.Fatal("expected completion applied")
+			}
+			wantInput := "compare @" + tc.safePath + " with tests"
+			if updated != wantInput {
+				t.Fatalf("updated input = %q, want %q", updated, wantInput)
+			}
+			wantCursor := len([]rune("compare @" + tc.safePath))
+			if nextCursor != wantCursor {
+				t.Fatalf("cursor = %d, want %d", nextCursor, wantCursor)
+			}
+			for _, r := range updated {
+				if unicode.IsControl(r) {
+					t.Fatalf("updated input contains terminal control %U: %q", r, updated)
+				}
+			}
+		})
 	}
 }
 

--- a/cli/app/ui_path_reference_picker_test.go
+++ b/cli/app/ui_path_reference_picker_test.go
@@ -50,6 +50,7 @@ func TestApplyPathReferenceCompletionReplacesMiddleSpan(t *testing.T) {
 		name          string
 		candidatePath string
 		safePath      string
+		expectFailure bool
 	}{
 		{name: "ordinary path", candidatePath: "cli/app/ui.go", safePath: "cli/app/ui.go"},
 		{name: "CSI", candidatePath: "cli/\x1b[31mapp\x1b[0m/ui.go", safePath: "cli/app/ui.go"},
@@ -57,8 +58,8 @@ func TestApplyPathReferenceCompletionReplacesMiddleSpan(t *testing.T) {
 		{name: "OSC terminated by ST", candidatePath: "cli/\x1b]0;owned\x1b\\app/ui.go", safePath: "cli/app/ui.go"},
 		{name: "C0 control", candidatePath: "cli/app/\x01ui.go", safePath: "cli/app/ui.go"},
 		{name: "printable Unicode and punctuation", candidatePath: "目录/[draft] #1?.txt", safePath: "目录/[draft] #1?.txt"},
-		{name: "empty projection", candidatePath: "\x1b[31m\x1b[0m"},
-		{name: "blank projection", candidatePath: "\x1b[31m \t\x1b[0m"},
+		{name: "empty projection", candidatePath: "\x1b[31m\x1b[0m", expectFailure: true},
+		{name: "blank projection", candidatePath: "\x1b[31m \t\x1b[0m", expectFailure: true},
 	}
 
 	for _, tc := range tests {
@@ -66,7 +67,7 @@ func TestApplyPathReferenceCompletionReplacesMiddleSpan(t *testing.T) {
 			input, cursor := testPathReferenceFixture("compare @cliap| with tests")
 			query := detectPathReferenceQuery(input, cursor)
 			updated, nextCursor, ok := applyPathReferenceCompletion(input, cursor, query, uiPathReferenceCandidate{Path: tc.candidatePath})
-			if tc.safePath == "" {
+			if tc.expectFailure {
 				if ok || updated != input || nextCursor != cursor {
 					t.Fatalf("unusable projection result = (%q, %d, %v), want original input and cursor with false", updated, nextCursor, ok)
 				}

--- a/cli/app/ui_path_reference_picker_test.go
+++ b/cli/app/ui_path_reference_picker_test.go
@@ -53,10 +53,10 @@ func TestApplyPathReferenceCompletionReplacesMiddleSpan(t *testing.T) {
 		expectFailure bool
 	}{
 		{name: "ordinary path", candidatePath: "cli/app/ui.go", safePath: "cli/app/ui.go"},
-		{name: "CSI", candidatePath: "cli/\x1b[31mapp\x1b[0m/ui.go", safePath: "cli/app/ui.go"},
-		{name: "OSC terminated by BEL", candidatePath: "cli/\x1b]8;;https://evil.test\x07app\x1b]8;;\x07/ui.go", safePath: "cli/app/ui.go"},
-		{name: "OSC terminated by ST", candidatePath: "cli/\x1b]0;owned\x1b\\app/ui.go", safePath: "cli/app/ui.go"},
-		{name: "C0 control", candidatePath: "cli/app/\x01ui.go", safePath: "cli/app/ui.go"},
+		{name: "CSI", candidatePath: "cli/\x1b[31mapp\x1b[0m/ui.go", expectFailure: true},
+		{name: "OSC terminated by BEL", candidatePath: "cli/\x1b]8;;https://evil.test\x07app\x1b]8;;\x07/ui.go", expectFailure: true},
+		{name: "OSC terminated by ST", candidatePath: "cli/\x1b]0;owned\x1b\\app/ui.go", expectFailure: true},
+		{name: "C0 control", candidatePath: "cli/app/\x01ui.go", expectFailure: true},
 		{name: "printable Unicode and punctuation", candidatePath: "目录/[draft] #1?.txt", safePath: "目录/[draft] #1?.txt"},
 		{name: "empty projection", candidatePath: "\x1b[31m\x1b[0m", expectFailure: true},
 		{name: "blank projection", candidatePath: "\x1b[31m \t\x1b[0m", expectFailure: true},
@@ -292,21 +292,21 @@ func TestPathReferencePickerScrollsSelectionAndReservesBoundedHeight(t *testing.
 	}
 }
 
-func TestPathReferencePickerSanitizesControlCharactersForDisplay(t *testing.T) {
-	m := newProjectedStaticUIModel()
-	m.pathReference.tracked = detectPathReferenceQuery("@ab", 3)
+func TestPathReferencePickerFiltersControlBearingCandidates(t *testing.T) {
+	m, _ := newPathReferenceTestModel("@ab")
 	rawPath := "safe/\x1b]52;evil\x07name\x01.txt"
-	m.pathReference.matches = []uiPathReferenceCandidate{{Path: rawPath}}
+	safePath := "safe/name.txt"
+	m = deliverPathReferenceTestMatches(t, m, 1, []uiPathReferenceCandidate{{Path: rawPath}, {Path: safePath}})
 
 	state := m.pathReferencePicker()
 	if !state.visible || len(state.rows) != 1 {
 		t.Fatalf("unexpected picker state: %+v", state)
 	}
-	if state.rows[0].primary != "safe/name.txt" {
+	if state.rows[0].primary != safePath {
 		t.Fatalf("display path = %q", state.rows[0].primary)
 	}
-	if m.pathReference.matches[0].Path != rawPath {
-		t.Fatalf("expected underlying candidate path preserved, got %q", m.pathReference.matches[0].Path)
+	if len(m.pathReference.matches) != 1 || m.pathReference.matches[0].Path != safePath {
+		t.Fatalf("filtered matches = %+v, want only exact safe path", m.pathReference.matches)
 	}
 }
 

--- a/cli/app/ui_path_reference_picker_test.go
+++ b/cli/app/ui_path_reference_picker_test.go
@@ -308,21 +308,6 @@ func TestPathReferencePickerSanitizesControlCharactersForDisplay(t *testing.T) {
 	}
 }
 
-func TestPathReferenceAcceptanceUsesUnsanitizedCandidate(t *testing.T) {
-	m := newProjectedStaticUIModel()
-	testSetMainInput(m, "@ab")
-	m.pathReference.tracked = uiPathReferenceQuery{Active: true, Start: 0, End: 3, RawQuery: "ab", NormalizedQuery: "ab"}
-	rawPath := "safe/line\n\t" + string(rune(0x1b)) + "[31mname.txt"
-	m.pathReference.matches = []uiPathReferenceCandidate{{Path: rawPath}}
-
-	if !m.acceptPathReferenceSelection() {
-		t.Fatal("expected raw candidate acceptance")
-	}
-	if testMainInput(m) != "@"+rawPath {
-		t.Fatalf("accepted input = %q, want original candidate bytes", testMainInput(m))
-	}
-}
-
 func testPathReferenceFixture(fixture string) (string, int) {
 	runes := []rune(fixture)
 	idx := -1

--- a/cli/app/ui_path_reference_picker_test.go
+++ b/cli/app/ui_path_reference_picker_test.go
@@ -294,7 +294,8 @@ func TestPathReferencePickerScrollsSelectionAndReservesBoundedHeight(t *testing.
 func TestPathReferencePickerSanitizesControlCharactersForDisplay(t *testing.T) {
 	m := newProjectedStaticUIModel()
 	m.pathReference.tracked = detectPathReferenceQuery("@ab", 3)
-	m.pathReference.matches = []uiPathReferenceCandidate{{Path: "safe/]52;evilname.txt"}}
+	rawPath := "safe/\x1b]52;evil\x07name\x01.txt"
+	m.pathReference.matches = []uiPathReferenceCandidate{{Path: rawPath}}
 
 	state := m.pathReferencePicker()
 	if !state.visible || len(state.rows) != 1 {
@@ -303,7 +304,7 @@ func TestPathReferencePickerSanitizesControlCharactersForDisplay(t *testing.T) {
 	if state.rows[0].primary != "safe/name.txt" {
 		t.Fatalf("display path = %q", state.rows[0].primary)
 	}
-	if m.pathReference.matches[0].Path != "safe/]52;evilname.txt" {
+	if m.pathReference.matches[0].Path != rawPath {
 		t.Fatalf("expected underlying candidate path preserved, got %q", m.pathReference.matches[0].Path)
 	}
 }

--- a/cli/app/ui_path_reference_search.go
+++ b/cli/app/ui_path_reference_search.go
@@ -349,7 +349,7 @@ func (s *uiPathReferenceSearchService) loadCorpusSnapshot(ctx context.Context, w
 	sort.Slice(candidates, func(i, j int) bool {
 		return candidates[i].Path < candidates[j].Path
 	})
-	return uiPathReferenceCorpusSnapshot{Candidates: candidates}, nil
+	return uiPathReferenceCorpusSnapshot{Candidates: terminalSafePathReferenceCandidates(candidates)}, nil
 }
 
 func isEmptyRipgrepFilesResult(err error, output []byte) bool {

--- a/cli/app/ui_path_reference_search_test.go
+++ b/cli/app/ui_path_reference_search_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -47,7 +48,7 @@ func TestLoadCorpusSnapshotIncludesDerivedDirectoriesAndExcludesGit(t *testing.T
 	}
 }
 
-func TestLoadCorpusSnapshotPreservesFilenameNewlinesWithNullSeparatedOutput(t *testing.T) {
+func TestLoadCorpusSnapshotFiltersControlBearingFileAndKeepsSafeDirectory(t *testing.T) {
 	runner := &stubUIPathReferenceCommandRunner{output: nulJoinPathReferenceOutput("dir/line\nbreak.txt")}
 	service := &uiPathReferenceSearchService{runner: runner}
 
@@ -55,7 +56,7 @@ func TestLoadCorpusSnapshotPreservesFilenameNewlinesWithNullSeparatedOutput(t *t
 	if err != nil {
 		t.Fatalf("loadCorpusSnapshot() error = %v", err)
 	}
-	want := []uiPathReferenceCandidate{{Path: "dir", Directory: true}, {Path: "dir/line\nbreak.txt"}}
+	want := []uiPathReferenceCandidate{{Path: "dir", Directory: true}}
 	if !reflect.DeepEqual(snapshot.Candidates, want) {
 		t.Fatalf("snapshot candidates = %+v, want %+v", snapshot.Candidates, want)
 	}
@@ -89,6 +90,37 @@ func TestPathReferenceSearchServiceRunsOnlyOneMatcherAtATime(t *testing.T) {
 	second := waitForPathReferenceEventType[uiPathReferenceMatchResultMsg](t, service.Events())
 	if second.NormalizedQuery != "abc" {
 		t.Fatalf("second result query = %q, want abc", second.NormalizedQuery)
+	}
+}
+
+func TestPathReferenceSearchFiltersUnsafeCandidatesBeforeMatchLimit(t *testing.T) {
+	paths := make([]string, 0, slashCommandPickerLines+2)
+	for index := 0; index <= slashCommandPickerLines; index++ {
+		paths = append(paths, fmt.Sprintf("unsafe/match-%02d\x1b[31m.go", index))
+	}
+	const safePath = "safe/match.go"
+	paths = append(paths, safePath)
+
+	service := newTestUIPathReferenceSearchService(
+		&stubUIPathReferenceCommandRunner{output: nulJoinPathReferenceOutput(paths...)},
+		unsafeFirstUIPathReferenceMatcher{},
+	)
+	t.Cleanup(service.Stop)
+	service.Search(uiPathReferenceSearchRequest{WorkspaceRoot: "/tmp/workspace", DraftToken: 1, QueryToken: 1, NormalizedQuery: "match"})
+	waitForPathReferenceEventType[uiPathReferenceCorpusReadyMsg](t, service.Events())
+	result := waitForPathReferenceEventType[uiPathReferenceMatchResultMsg](t, service.Events())
+
+	foundSafePath := false
+	for _, candidate := range result.Matches {
+		if !isTerminalSafePathReference(candidate.Path) {
+			t.Fatalf("unsafe candidate reached limited matches: %q", candidate.Path)
+		}
+		if candidate.Path == safePath {
+			foundSafePath = true
+		}
+	}
+	if !foundSafePath {
+		t.Fatalf("safe path missing after unsafe higher-ranked candidates: %+v", result.Matches)
 	}
 }
 
@@ -303,6 +335,31 @@ type blockingUIPathReferenceMatcher struct {
 	started  chan string
 	release  chan struct{}
 	finished chan string
+}
+
+type unsafeFirstUIPathReferenceMatcher struct{}
+
+func (unsafeFirstUIPathReferenceMatcher) Match(_ string, candidates []uiPathReferenceCandidate, limit int) []uiPathReferenceCandidate {
+	results := make([]uiPathReferenceCandidate, 0, min(limit, len(candidates)))
+	for _, candidate := range candidates {
+		if isTerminalSafePathReference(candidate.Path) {
+			continue
+		}
+		results = append(results, candidate)
+		if len(results) == limit {
+			return results
+		}
+	}
+	for _, candidate := range candidates {
+		if !isTerminalSafePathReference(candidate.Path) {
+			continue
+		}
+		results = append(results, candidate)
+		if len(results) == limit {
+			break
+		}
+	}
+	return results
 }
 
 func newBlockingUIPathReferenceMatcher() *blockingUIPathReferenceMatcher {

--- a/docs/dev/specs/tui-chat-core.md
+++ b/docs/dev/specs/tui-chat-core.md
@@ -31,7 +31,7 @@ Bullets marked (owner: …) restate decisions owned by another spec for one-plac
 
 - Corpus and matching semantics: cached repo-relative corpus from `rg --files`, async prewarm, no per-keystroke shell-outs, cursor-local query charset, hidden-paths-in/`.git`-out, derived directories, retryable corpus failures. (owner: tui-transcript :: Path Autocomplete)
 - The picker is derived UI: it appears when the cursor sits in a parseable `@` query and disappears when the query no longer parses (cursor moved away, query deleted). No modal open/dismiss state exists.
-- `Up`/`Down` navigate candidates; `Tab` or `Enter` accepts the selection, replacing the query with the picker’s terminal-safe projection of the chosen repo-relative path; terminal controls are never inserted into the composer, and while the picker is visible these keys never submit or queue.
+- Candidates whose repo-relative path changes under terminal-safe projection are excluded from the picker. `Up`/`Down` navigate eligible candidates; `Tab` or `Enter` accepts the selection, replacing the query with the exact chosen repo-relative path; terminal controls are never inserted into the composer, and while the picker is visible these keys never submit or queue.
 - The picker renders between transcript and input, sized to available height; typing is never blocked by picker state or corpus readiness.
 
 ## Queueing And Steering

--- a/docs/dev/specs/tui-chat-core.md
+++ b/docs/dev/specs/tui-chat-core.md
@@ -31,7 +31,7 @@ Bullets marked (owner: …) restate decisions owned by another spec for one-plac
 
 - Corpus and matching semantics: cached repo-relative corpus from `rg --files`, async prewarm, no per-keystroke shell-outs, cursor-local query charset, hidden-paths-in/`.git`-out, derived directories, retryable corpus failures. (owner: tui-transcript :: Path Autocomplete)
 - The picker is derived UI: it appears when the cursor sits in a parseable `@` query and disappears when the query no longer parses (cursor moved away, query deleted). No modal open/dismiss state exists.
-- `Up`/`Down` navigate candidates; `Tab` or `Enter` accepts the selection, replacing the query with the chosen repo-relative path; while the picker is visible these keys never submit or queue.
+- `Up`/`Down` navigate candidates; `Tab` or `Enter` accepts the selection, replacing the query with the picker’s terminal-safe projection of the chosen repo-relative path; terminal controls are never inserted into the composer, and while the picker is visible these keys never submit or queue.
 - The picker renders between transcript and input, sized to available height; typing is never blocked by picker state or corpus readiness.
 
 ## Queueing And Steering

--- a/docs/dev/specs/tui-chat-core.md
+++ b/docs/dev/specs/tui-chat-core.md
@@ -31,7 +31,7 @@ Bullets marked (owner: …) restate decisions owned by another spec for one-plac
 
 - Corpus and matching semantics: cached repo-relative corpus from `rg --files`, async prewarm, no per-keystroke shell-outs, cursor-local query charset, hidden-paths-in/`.git`-out, derived directories, retryable corpus failures. (owner: tui-transcript :: Path Autocomplete)
 - The picker is derived UI: it appears when the cursor sits in a parseable `@` query and disappears when the query no longer parses (cursor moved away, query deleted). No modal open/dismiss state exists.
-- Candidates whose repo-relative path changes under terminal-safe projection are excluded from the picker. `Up`/`Down` navigate eligible candidates; `Tab` or `Enter` accepts the selection, replacing the query with the exact chosen repo-relative path; terminal controls are never inserted into the composer, and while the picker is visible these keys never submit or queue.
+- Candidates whose repo-relative path changes under terminal-safe projection are excluded before fuzzy matching and result limits. `Up`/`Down` navigate eligible candidates; `Tab` or `Enter` accepts the selection, replacing the query with the exact chosen repo-relative path; terminal controls are never inserted into the composer, and while the picker is visible these keys never submit or queue.
 - The picker renders between transcript and input, sized to available height; typing is never blocked by picker state or corpus readiness.
 
 ## Queueing And Steering

--- a/docs/dev/specs/tui-transcript.md
+++ b/docs/dev/specs/tui-transcript.md
@@ -198,6 +198,7 @@
 - Query tracking is cursor-local and accepts Unicode letters/digits plus `/`, `.`, `_`, and `-`.
 - Hidden paths are included, `.git` is excluded, and normal ignore-file handling remains enabled.
 - Non-empty directory candidates are derived from file paths; empty directories are intentionally excluded in v1.
+- Candidates whose repo-relative path changes under terminal-safe projection are excluded from the cached corpus before fuzzy matching and result limits; derived directories remain eligible when their own path is unchanged.
 - Corpus-build failures are retryable later in the same workspace and do not permanently disable path autocomplete.
 
 ## Startup And Session Selection


### PR DESCRIPTION
## Summary

- Exclude path-autocomplete candidates whose repo-relative path changes under terminal-safe projection while materializing the cached corpus, before fuzzy matching and result limits.
- Preserve eligible derived directories, revalidate search-result events, and revalidate the selected candidate at completion.
- Insert the exact original repo-relative path only when it is terminal-safe and usable; control-bearing filenames are never exposed as selectable aliases.
- Cover CSI, OSC (BEL and ST termination), independent C0 controls, printable Unicode/punctuation, exact cursor placement, mixed safe/unsafe results, pre-limit backfill, and `Tab`/`Enter` acceptance.
- Clarify both owner and client Path Autocomplete specifications with the filter-before-match and exact-acceptance contract.

## Verification

- `./scripts/test.sh ./cli/app` — pass after rebasing onto current `origin/main`.
- `./scripts/build.sh --output ./bin/kent` — pass.
- `git diff --check origin/main...HEAD` — pass.
- Focused completion, corpus filtering, picker filtering, mixed-result acceptance, and unsafe-first limit regressions — pass.
- GitHub CI before this review correction was fully green; the latest commit triggered a fresh run.

## QA evidence

The prior isolated TUI captures proved that raw CSI bytes could reach path matching, but they showed the now-superseded alias behavior (`evil<CSI>red.go` becoming `@evilred.go`). They are intentionally not presented as final-behavior evidence.

Final behavior is guarded by automated evidence:

- cached corpus materialization removes control-bearing files before matching while retaining an eligible parent directory;
- more than one picker page of higher-ranked unsafe hits cannot hide a lower-ranked safe hit;
- completion rejects CSI-, OSC-, and C0-bearing paths without mutating input or cursor;
- picker/event revalidation removes unsafe candidates while preserving exact safe candidates;
- with mixed unsafe/safe results, both `Tab` and `Enter` insert the exact safe repo path without submitting or queueing;
- printable Unicode and ordinary punctuation remain eligible.

The `gh` CLI does not support arbitrary PR file attachments. The earlier raw filename hex proof remains available locally for operator inspection, while the superseded screen captures are not attached.

## Diff size

- Production code: **+20 / -6** — gross 26 LoC, net +14 LoC.
- Tests/generated: **+137 / -34** — gross 171 LoC, net +103 LoC; generated code: 0 LoC.
- Product specification: **+2 / -1** — gross 3 LoC, net +1 LoC.
- Overall: **+159 / -41** — gross 200 LoC, net +118 LoC.

## Caveats and tradeoffs

- Raw `rg` output is normalized as before, but candidates changed by terminal-safe projection are not retained in the cached autocomplete corpus. Eligible derived directories remain available.
- Search-result events and completion repeat the eligibility check as defense at later boundaries.
- Control-bearing filenames cannot be selected through path autocomplete. If filtering removes every result, the picker is absent and existing no-match key behavior applies.
- This change does not sanitize manually typed or pasted composer text and does not alter the `rg` invocation or fuzzy-scoring algorithm.
- During review, a test fixture was found to contain literal terminal bytes in source, which could rewrite rendered review output. It now uses visible Go escape syntax while producing the same runtime bytes.
- No API, protocol, persistence, migration, or generated-code changes. Any broader policy for manually entered control-bearing paths should be designed separately.

Closes #112

Kent task: `BUI-61`
