### PR TITLE
Make prompt hydration idempotent

### DIFF
--- a/cli/app/pty_checkpoint_model_behavior_test.go
+++ b/cli/app/pty_checkpoint_model_behavior_test.go
@@ -145,7 +145,8 @@ func TestPTYCheckpointModelEmitsScenarioFinalAppliedAfterTerminalTransaction(t *
 	scenario.markScenarioComplete()
 	wrapped := newPTYCheckpointModel(model, writer, scenario)
 	wrapped.Update(dispatchPTYCheckpointTranscriptEvent(ongoingTranscriptEvent{
-		Kind: ongoingTranscriptEventMessage,
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
 		Message: clientui.TranscriptMessage{
 			Sequence: 2,
 			Kind:     clientui.TranscriptMessageCommittedRow,
@@ -192,7 +193,8 @@ func TestPTYCheckpointModelEmitsToolStartedOnceAfterAcceptedToolStart(t *testing
 		newPTYCheckpointScenarioState(appfixture.ScriptFinalAssistantOrdinal(1)),
 	)
 	wrapped.Update(dispatchPTYCheckpointTranscriptEvent(ongoingTranscriptEvent{
-		Kind: ongoingTranscriptEventMessage,
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
 		Message: clientui.TranscriptMessage{
 			Sequence: 3,
 			Kind:     clientui.TranscriptMessageToolStart,
@@ -217,7 +219,8 @@ func TestPTYCheckpointModelEmitsToolStartedOnceAfterAcceptedToolStart(t *testing
 		newPTYCheckpointScenarioState(appfixture.ScriptFinalAssistantOrdinal(1)),
 	)
 	wrapped.Update(dispatchPTYCheckpointTranscriptEvent(ongoingTranscriptEvent{
-		Kind: ongoingTranscriptEventMessage,
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
 		Message: clientui.TranscriptMessage{
 			Sequence: 2,
 			Kind:     clientui.TranscriptMessageToolStart,
@@ -231,7 +234,8 @@ func TestPTYCheckpointModelEmitsToolStartedOnceAfterAcceptedToolStart(t *testing
 		},
 	}))
 	wrapped.Update(dispatchPTYCheckpointTranscriptEvent(ongoingTranscriptEvent{
-		Kind: ongoingTranscriptEventMessage,
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
 		Message: clientui.TranscriptMessage{
 			Sequence: 3,
 			Kind:     clientui.TranscriptMessageToolStart,
@@ -357,7 +361,8 @@ func ptyLastTerminalOperationEnd(analysis analyzer.Analysis) int64 {
 
 func applyPTYCheckpointAssistantFinal(model *ptyCheckpointModel, sequence uint64, text string) {
 	model.Update(dispatchPTYCheckpointTranscriptEvent(ongoingTranscriptEvent{
-		Kind: ongoingTranscriptEventMessage,
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
 		Message: clientui.TranscriptMessage{
 			Sequence: sequence,
 			Kind:     clientui.TranscriptMessageCommittedRow,

--- a/cli/app/pty_checkpoint_model_behavior_test.go
+++ b/cli/app/pty_checkpoint_model_behavior_test.go
@@ -337,8 +337,9 @@ func newPTYCheckpointOngoingModel(t *testing.T, writer *analyzer.Writer) *uiMode
 		model.ongoingFrameInput,
 		runtimeClient.admitTranscriptMessageState,
 		model.applyAdmittedTranscriptMessageState,
+		model,
 	)
-	if _, _, err := model.ongoingTranscript.Accept(ongoingHydrationMessage(1)); err != nil {
+	if _, _, err := model.ongoingTranscript.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept initial hydration: %v", err)
 	}
 	return model

--- a/cli/app/pty_checkpoint_model_test.go
+++ b/cli/app/pty_checkpoint_model_test.go
@@ -276,6 +276,9 @@ func ptyCheckpointTranscriptEvent(msg tea.Msg) (ongoingTranscriptEvent, bool) {
 }
 
 func dispatchPTYCheckpointTranscriptEvent(event ongoingTranscriptEvent) uiDispatchedEventMsg {
+	if event.SourceSessionID.IsZero() {
+		event.SourceSessionID = ongoingTestSessionID()
+	}
 	return uiDispatchedEventMsg{event: event}
 }
 

--- a/cli/app/runtime_attachment.go
+++ b/cli/app/runtime_attachment.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"core/cli/app/internal/runtimeattach"
 	"core/shared/apicontract"
+	"core/shared/runtimeids"
 	"core/shared/serverapi"
 )
 
@@ -36,6 +38,10 @@ type runtimeAttachmentClients struct {
 func prepareSharedRuntime(ctx context.Context, source runtimeAttachmentSource, plan sessionLaunchPlan, diagnosticWriter io.Writer, startLogLine string) (*runtimeLaunchPlan, error) {
 	if source == nil {
 		return nil, errors.New("server is required")
+	}
+	sourceSessionID, err := runtimeids.ParseSessionID(plan.SessionID)
+	if err != nil {
+		return nil, fmt.Errorf("validate runtime session id: %w", err)
 	}
 	clients := source.RuntimeAttachmentClients()
 	reactivator, ownerID, err := activateSharedRuntime(ctx, clients, plan)
@@ -67,6 +73,7 @@ func prepareSharedRuntime(ctx context.Context, source runtimeAttachmentSource, p
 		ctx,
 		clients,
 		plan,
+		sourceSessionID,
 		attentionSubscription,
 		reactivator,
 	)
@@ -109,6 +116,7 @@ func prepareSharedRuntimeWiring(
 	ctx context.Context,
 	clients runtimeAttachmentClients,
 	plan sessionLaunchPlan,
+	sourceSessionID runtimeids.SessionID,
 	attentionSubscription serverapi.AttentionNotificationSubscription,
 	reactivator *runtimeReactivator,
 ) (*runtimeWiring, func(), func()) {
@@ -119,7 +127,7 @@ func prepareSharedRuntimeWiring(
 	subscribeTranscript := func(ctx context.Context, req serverapi.TranscriptSubscribeRequest) (serverapi.TranscriptSubscription, error) {
 		return clients.SessionTranscript.SubscribeSessionTranscript(ctx, req)
 	}
-	transcriptStream := startSessionTranscriptEvents(ctx, plan.SessionID, subscribeTranscript)
+	transcriptStream := startSessionTranscriptEvents(ctx, sourceSessionID, subscribeTranscript)
 	transcriptEvents := transcriptStream.Events
 	requestTranscriptOpen := transcriptStream.RequestRehydration
 	stopTranscriptEvents := transcriptStream.Stop

--- a/cli/app/runtime_attachment_v60_test.go
+++ b/cli/app/runtime_attachment_v60_test.go
@@ -97,6 +97,29 @@ func TestRuntimeAttachmentRequiresTranscriptServiceAndReleasesRuntime(t *testing
 	}
 }
 
+func TestRuntimeAttachmentRejectsInvalidSessionIDBeforeActivation(t *testing.T) {
+	activateCalls := 0
+	server := runtimeAttachmentTestServer{
+		runtime: &recordingSessionRuntimeClient{
+			activate: func(context.Context, serverapi.SessionRuntimeActivateRequest) (serverapi.SessionRuntimeActivateResponse, error) {
+				activateCalls++
+				return serverapi.SessionRuntimeActivateResponse{}, nil
+			},
+		},
+	}
+
+	plan, err := prepareSharedRuntime(context.Background(), server, sessionLaunchPlan{SessionID: "../invalid"}, io.Discard, "test")
+	if err == nil {
+		t.Fatal("expected invalid session ID error")
+	}
+	if plan != nil {
+		t.Fatalf("plan = %+v, want nil", plan)
+	}
+	if activateCalls != 0 {
+		t.Fatalf("activation calls = %d, want zero before session ID validation", activateCalls)
+	}
+}
+
 func TestRuntimeAttachmentAttentionSubscribeFailureReleasesRuntime(t *testing.T) {
 	releaseCount := 0
 	subscribeErr := errors.New("attention stream unavailable")

--- a/cli/app/session_server_target_part2_test.go
+++ b/cli/app/session_server_target_part2_test.go
@@ -343,7 +343,7 @@ func TestStartSessionServerUsesConfiguredDaemonForPromptRoundTrip(t *testing.T) 
 		t.Fatalf("unexpected ask prompt: %+v", askPrompt)
 	}
 	answerRemoteTranscriptPrompt(t, runtimePlan.Wiring.promptAnswers, askPrompt, clientui.PromptAnswer{
-		PromptID:             string(askPrompt.PromptID),
+		PromptID:             &askPrompt.PromptID,
 		SelectedOptionNumber: textutil.Int(2),
 	})
 	select {
@@ -376,7 +376,7 @@ func TestStartSessionServerUsesConfiguredDaemonForPromptRoundTrip(t *testing.T) 
 		t.Fatalf("unexpected approval prompt: %+v", approvalPrompt)
 	}
 	answerRemoteTranscriptPrompt(t, runtimePlan.Wiring.promptAnswers, approvalPrompt, clientui.PromptAnswer{
-		PromptID: string(approvalPrompt.PromptID),
+		PromptID: &approvalPrompt.PromptID,
 		Approval: &clientui.ApprovalPromptAnswer{
 			Decision:   clientui.ApprovalDecisionAllowOnce,
 			Commentary: "trusted",

--- a/cli/app/session_server_target_part3_test.go
+++ b/cli/app/session_server_target_part3_test.go
@@ -51,12 +51,12 @@ func TestStartSessionServerListsPendingPromptSnapshotOverRemoteReads(t *testing.
 		switch prompt.PromptID {
 		case "ask-remote-1":
 			answerRemoteTranscriptPrompt(t, runtimePlan.Wiring.promptAnswers, prompt, clientui.PromptAnswer{
-				PromptID: string(prompt.PromptID),
+				PromptID: &prompt.PromptID,
 				Answer:   "done",
 			})
 		case "approval-remote-1":
 			answerRemoteTranscriptPrompt(t, runtimePlan.Wiring.promptAnswers, prompt, clientui.PromptAnswer{
-				PromptID: string(prompt.PromptID),
+				PromptID: &prompt.PromptID,
 				Approval: &clientui.ApprovalPromptAnswer{Decision: clientui.ApprovalDecisionAllowOnce},
 			})
 		default:

--- a/cli/app/session_transcript_channel.go
+++ b/cli/app/session_transcript_channel.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"core/shared/clientui"
 	"core/shared/runtimeids"
@@ -32,11 +31,15 @@ type ongoingTranscriptEventStream struct {
 
 type sessionTranscriptSubscriber func(context.Context, serverapi.TranscriptSubscribeRequest) (serverapi.TranscriptSubscription, error)
 
-func startSessionTranscriptEvents(ctx context.Context, sessionID string, subscribe sessionTranscriptSubscriber) ongoingTranscriptEventStream {
-	sourceSessionID, err := runtimeids.ParseSessionID(sessionID)
-	if err != nil {
-		panic(fmt.Sprintf("start session transcript events with invalid session id %q: %v", sessionID, err))
+func startSessionTranscriptEvents(
+	ctx context.Context,
+	sourceSessionID runtimeids.SessionID,
+	subscribe sessionTranscriptSubscriber,
+) ongoingTranscriptEventStream {
+	if sourceSessionID.IsZero() {
+		panic("start session transcript events requires source session authority")
 	}
+	sessionID := sourceSessionID.String()
 	out := make(chan ongoingTranscriptEvent, 64)
 	requests := make(chan struct{}, 1)
 	if subscribe == nil {

--- a/cli/app/session_transcript_channel.go
+++ b/cli/app/session_transcript_channel.go
@@ -3,8 +3,10 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"core/shared/clientui"
+	"core/shared/runtimeids"
 	"core/shared/serverapi"
 )
 
@@ -16,9 +18,10 @@ const (
 )
 
 type ongoingTranscriptEvent struct {
-	Kind    ongoingTranscriptEventKind
-	Message clientui.TranscriptMessage
-	Err     error
+	Kind            ongoingTranscriptEventKind
+	SourceSessionID runtimeids.SessionID
+	Message         clientui.TranscriptMessage
+	Err             error
 }
 
 type ongoingTranscriptEventStream struct {
@@ -30,6 +33,10 @@ type ongoingTranscriptEventStream struct {
 type sessionTranscriptSubscriber func(context.Context, serverapi.TranscriptSubscribeRequest) (serverapi.TranscriptSubscription, error)
 
 func startSessionTranscriptEvents(ctx context.Context, sessionID string, subscribe sessionTranscriptSubscriber) ongoingTranscriptEventStream {
+	sourceSessionID, err := runtimeids.ParseSessionID(sessionID)
+	if err != nil {
+		panic(fmt.Sprintf("start session transcript events with invalid session id %q: %v", sessionID, err))
+	}
 	out := make(chan ongoingTranscriptEvent, 64)
 	requests := make(chan struct{}, 1)
 	if subscribe == nil {
@@ -44,7 +51,7 @@ func startSessionTranscriptEvents(ctx context.Context, sessionID string, subscri
 			if err != nil {
 				return
 			}
-			reopen, stop := pumpSessionTranscriptSubscription(pollCtx, sub, out, requests)
+			reopen, stop := pumpSessionTranscriptSubscription(pollCtx, sourceSessionID, sub, out, requests)
 			if stop {
 				return
 			}
@@ -67,7 +74,7 @@ type transcriptNextResult struct {
 	err     error
 }
 
-func pumpSessionTranscriptSubscription(ctx context.Context, sub serverapi.TranscriptSubscription, out chan<- ongoingTranscriptEvent, requests <-chan struct{}) (reopen bool, stop bool) {
+func pumpSessionTranscriptSubscription(ctx context.Context, sourceSessionID runtimeids.SessionID, sub serverapi.TranscriptSubscription, out chan<- ongoingTranscriptEvent, requests <-chan struct{}) (reopen bool, stop bool) {
 	subClosed := false
 	closeSub := func() {
 		if subClosed {
@@ -98,13 +105,13 @@ func pumpSessionTranscriptSubscription(ctx context.Context, sub serverapi.Transc
 					return false, true
 				}
 				closeSub()
-				emitSessionTranscriptLoss(ctx, out, result.err)
+				emitSessionTranscriptLoss(ctx, sourceSessionID, out, result.err)
 				return waitForTranscriptRehydrationRequest(ctx, requests)
 			}
 			select {
 			case <-ctx.Done():
 				return false, true
-			case out <- ongoingTranscriptEvent{Kind: ongoingTranscriptEventMessage, Message: result.message}:
+			case out <- ongoingTranscriptEvent{Kind: ongoingTranscriptEventMessage, SourceSessionID: sourceSessionID, Message: result.message}:
 			}
 		}
 	}
@@ -135,9 +142,9 @@ func resubscribeSessionTranscript(ctx context.Context, sessionID string, subscri
 	}
 }
 
-func emitSessionTranscriptLoss(ctx context.Context, out chan<- ongoingTranscriptEvent, err error) {
+func emitSessionTranscriptLoss(ctx context.Context, sourceSessionID runtimeids.SessionID, out chan<- ongoingTranscriptEvent, err error) {
 	select {
 	case <-ctx.Done():
-	case out <- ongoingTranscriptEvent{Kind: ongoingTranscriptEventLoss, Err: err}:
+	case out <- ongoingTranscriptEvent{Kind: ongoingTranscriptEventLoss, SourceSessionID: sourceSessionID, Err: err}:
 	}
 }

--- a/cli/app/session_transcript_channel_test.go
+++ b/cli/app/session_transcript_channel_test.go
@@ -21,7 +21,8 @@ func TestStartSessionTranscriptEventsWaitsForExplicitRehydrationAfterLoss(t *tes
 			{messages: []clientui.TranscriptMessage{ongoingHydrationMessage(1)}},
 		},
 	}
-	stream := startSessionTranscriptEvents(context.Background(), "session-1", subscriber.SubscribeSessionTranscript)
+	sourceSessionID := ongoingTestSessionID()
+	stream := startSessionTranscriptEvents(context.Background(), sourceSessionID, subscriber.SubscribeSessionTranscript)
 	defer stream.Stop()
 
 	first := nextTranscriptEvent(t, stream.Events)
@@ -43,14 +44,14 @@ func TestStartSessionTranscriptEventsWaitsForExplicitRehydrationAfterLoss(t *tes
 	if second.Kind != ongoingTranscriptEventMessage || second.Message.Kind != clientui.TranscriptMessageHydration {
 		t.Fatalf("second event = %+v, want reopened hydration message", second)
 	}
-	if got, want := subscriber.sessionIDs, []string{"session-1", "session-1"}; !reflect.DeepEqual(got, want) {
+	if got, want := subscriber.sessionIDs, []string{sourceSessionID.String(), sourceSessionID.String()}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("subscribe session IDs = %v, want %v", got, want)
 	}
 }
 
 func TestStartSessionTranscriptEventsLocalCancelClosesChannel(t *testing.T) {
 	subscriber := &recordingTranscriptSubscriber{subs: []*scriptedTranscriptSubscription{{}}}
-	stream := startSessionTranscriptEvents(context.Background(), "session-1", subscriber.SubscribeSessionTranscript)
+	stream := startSessionTranscriptEvents(context.Background(), ongoingTestSessionID(), subscriber.SubscribeSessionTranscript)
 
 	stream.Stop()
 
@@ -71,7 +72,7 @@ func TestStartSessionTranscriptEventsReopensOnLocalRehydrationRequest(t *testing
 			{messages: []clientui.TranscriptMessage{ongoingHydrationMessage(1)}},
 		},
 	}
-	stream := startSessionTranscriptEvents(context.Background(), "session-1", subscriber.SubscribeSessionTranscript)
+	stream := startSessionTranscriptEvents(context.Background(), ongoingTestSessionID(), subscriber.SubscribeSessionTranscript)
 	defer stream.Stop()
 
 	first := nextTranscriptEvent(t, stream.Events)

--- a/cli/app/session_transcript_controller.go
+++ b/cli/app/session_transcript_controller.go
@@ -84,6 +84,9 @@ func newOngoingTranscriptController(
 
 func (c *ongoingTranscriptController) AcceptFrom(sourceSessionID runtimeids.SessionID, message clientui.TranscriptMessage) (ongoing.Result, tea.Cmd, error) {
 	c.validateSourceSession(sourceSessionID, message)
+	if result, ok := c.rejectDelivery(message); ok {
+		return result, nil, nil
+	}
 	var (
 		promptReconciliation    transcriptPromptReconciliation
 		hasPromptReconciliation bool
@@ -103,9 +106,6 @@ func (c *ongoingTranscriptController) AcceptFrom(sourceSessionID runtimeids.Sess
 	}
 	if err := message.Validate(); err != nil {
 		return ongoing.Result{}, nil, fmt.Errorf("validate ongoing transcript message: %w", err)
-	}
-	if result, ok := c.rejectDelivery(message); ok {
-		return result, nil, nil
 	}
 	admission, err := c.runtimeAdmission(message)
 	if err != nil {

--- a/cli/app/session_transcript_controller.go
+++ b/cli/app/session_transcript_controller.go
@@ -3,12 +3,15 @@ package app
 import (
 	"errors"
 	"fmt"
+	"log"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
 	"core/cli/tui/ongoing"
 	"core/cli/tui/transcriptrender"
 	"core/shared/clientui"
+	"core/shared/runtimeids"
 	"core/shared/transcript"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -40,6 +43,8 @@ type ongoingTranscriptController struct {
 	queueOverflowed  bool
 	renderPending    bool
 	liveReadModel    ongoingTranscriptReadModel
+	promptOwner      ongoingTranscriptPromptOwner
+	logger           uiLogger
 }
 
 func newOngoingTranscriptController(
@@ -47,6 +52,8 @@ func newOngoingTranscriptController(
 	frameProvider ongoingFrameProvider,
 	runtimeAdmission ongoingTranscriptRuntimeAdmission,
 	stateObserver ongoingTranscriptAdmittedStateObserver,
+	promptOwner ongoingTranscriptPromptOwner,
+	loggers ...uiLogger,
 ) *ongoingTranscriptController {
 	if frameProvider == nil {
 		panic("ongoing transcript controller requires frame provider")
@@ -55,33 +62,63 @@ func newOngoingTranscriptController(
 		panic("ongoing transcript controller requires runtime admission")
 	}
 	if stateObserver == nil {
-		panic("ongoing transcript controller requires state observer")
+		panic("ongoing transcript controller requires admitted state observer")
 	}
-	return &ongoingTranscriptController{
+	if promptOwner == nil {
+		panic("ongoing transcript controller requires prompt owner")
+	}
+	controller := &ongoingTranscriptController{
 		surface:          surface,
 		frameProvider:    frameProvider,
 		runtimeAdmission: runtimeAdmission,
 		stateObserver:    stateObserver,
 		normalOwned:      true,
 		liveReadModel:    newOngoingTranscriptReadModel(),
+		promptOwner:      promptOwner,
 	}
+	if len(loggers) > 0 {
+		controller.logger = loggers[0]
+	}
+	return controller
 }
 
-func (c *ongoingTranscriptController) Accept(message clientui.TranscriptMessage) (ongoing.Result, tea.Cmd, error) {
+func (c *ongoingTranscriptController) AcceptFrom(sourceSessionID runtimeids.SessionID, message clientui.TranscriptMessage) (ongoing.Result, tea.Cmd, error) {
+	c.validateSourceSession(sourceSessionID, message)
+	var (
+		promptReconciliation    transcriptPromptReconciliation
+		hasPromptReconciliation bool
+		promptStateChanged      bool
+		promptErr               error
+	)
+	if transcriptMessageCanPreparePromptReconciliation(message) {
+		ownership := c.snapshotTranscriptPromptOwnership()
+		promptReconciliation, hasPromptReconciliation, promptErr = prepareTranscriptPromptReconciliation(
+			ownership,
+			message,
+		)
+		promptStateChanged = len(ownership.events) > 0 || len(promptReconciliation.events) > 0
+		if promptErr != nil {
+			c.panicPromptReconciliationError(sourceSessionID, message, promptErr)
+		}
+	}
 	if err := message.Validate(); err != nil {
 		return ongoing.Result{}, nil, fmt.Errorf("validate ongoing transcript message: %w", err)
 	}
-	if result, ok := c.classifyDelivery(message); ok {
-		c.requestScratchRehydration()
+	if result, ok := c.rejectDelivery(message); ok {
 		return result, nil, nil
 	}
 	admission, err := c.runtimeAdmission(message)
 	if err != nil {
 		return ongoing.Result{}, nil, c.diagnoseRuntimeAdmissionError(message, err)
 	}
-	c.commitDelivery(message)
+	c.advanceDelivery(message)
 	stateChanged := c.applyState(message)
 	stateCmd := c.stateObserver(message, admission)
+	if hasPromptReconciliation {
+		c.liveReadModel.replacePendingPrompts(promptReconciliation.pendingPrompts())
+		c.promptOwner.commitTranscriptPromptReconciliation(promptReconciliation)
+		stateChanged = stateChanged || promptStateChanged
+	}
 	if !c.normalOwned {
 		if !isAppOwnedOngoingMessage(message.Kind) {
 			c.enqueue(message)
@@ -111,6 +148,225 @@ func (c *ongoingTranscriptController) diagnoseRuntimeAdmissionError(
 		conflict.Error(),
 		facts,
 	)
+}
+
+func transcriptMessageCanPreparePromptReconciliation(message clientui.TranscriptMessage) bool {
+	switch message.Kind {
+	case clientui.TranscriptMessageHydration:
+		return message.Payload.Hydration != nil
+	case clientui.TranscriptMessagePromptPending:
+		return message.Payload.PromptPending != nil
+	case clientui.TranscriptMessagePromptResolved:
+		return message.Payload.PromptResolved != nil
+	default:
+		return false
+	}
+}
+
+type ongoingTranscriptDeveloperError struct {
+	Operation         string
+	Geometry          ongoing.Size
+	Payload           string
+	SourceSessionID   runtimeids.SessionID
+	PayloadSessionID  runtimeids.SessionID
+	MessageKind       clientui.TranscriptMessageKind
+	Sequence          uint64
+	PromptID          *clientui.PromptID
+	OldPromptContract *transcriptPromptContract
+	NewPromptContract *transcriptPromptContract
+	Stack             string
+}
+
+func (e *ongoingTranscriptDeveloperError) Error() string {
+	var promptID any
+	if e.PromptID != nil {
+		promptID = *e.PromptID
+	}
+	return fmt.Sprintf(
+		"ongoing transcript developer error: operation=%s geometry=%dx%d source_session_id=%q payload_session_id=%q message_kind=%q sequence=%d prompt_id=%v payload=%s",
+		e.Operation,
+		e.Geometry.Width,
+		e.Geometry.Height,
+		e.SourceSessionID.String(),
+		e.PayloadSessionID.String(),
+		e.MessageKind,
+		e.Sequence,
+		promptID,
+		e.Payload,
+	)
+}
+
+func (c *ongoingTranscriptController) validateSourceSession(sourceSessionID runtimeids.SessionID, message clientui.TranscriptMessage) {
+	payloadSessionID, offendingPrompt := transcriptMessageForeignSession(sourceSessionID, message)
+	if !sourceSessionID.IsZero() && payloadSessionID.IsZero() {
+		return
+	}
+	diagnostic := c.newDeveloperError(sourceSessionID, message)
+	diagnostic.PayloadSessionID = payloadSessionID
+	if offendingPrompt != nil {
+		c.decorateDeveloperErrorPromptContractForPrompt(diagnostic, *offendingPrompt)
+	} else {
+		c.decorateDeveloperErrorPromptContract(diagnostic, message)
+	}
+	c.panicDeveloperError(diagnostic)
+}
+
+func transcriptMessageForeignSession(
+	sourceSessionID runtimeids.SessionID,
+	message clientui.TranscriptMessage,
+) (runtimeids.SessionID, *clientui.TranscriptPrompt) {
+	if sourceSessionID.IsZero() {
+		return transcriptMessagePayloadSessionID(message), transcriptMessagePrompt(message)
+	}
+	switch message.Kind {
+	case clientui.TranscriptMessageHydration:
+		if message.Payload.Hydration == nil {
+			return runtimeids.SessionID{}, nil
+		}
+		if identity := message.Payload.Hydration.SessionIdentity.SessionID; identity != sourceSessionID {
+			return identity, nil
+		}
+		for index := range message.Payload.Hydration.PendingPrompts {
+			prompt := &message.Payload.Hydration.PendingPrompts[index]
+			if prompt.SessionID != sourceSessionID {
+				return prompt.SessionID, prompt
+			}
+		}
+	case clientui.TranscriptMessagePromptPending:
+		if prompt := message.Payload.PromptPending; prompt != nil && prompt.SessionID != sourceSessionID {
+			return prompt.SessionID, prompt
+		}
+	case clientui.TranscriptMessagePromptResolved:
+		if prompt := message.Payload.PromptResolved; prompt != nil && prompt.SessionID != sourceSessionID {
+			return prompt.SessionID, prompt
+		}
+	case clientui.TranscriptMessageSessionIdentity:
+		if identity := message.Payload.SessionIdentity; identity != nil && identity.SessionID != sourceSessionID {
+			return identity.SessionID, nil
+		}
+	}
+	return runtimeids.SessionID{}, nil
+}
+
+func (c *ongoingTranscriptController) panicPromptReconciliationError(
+	sourceSessionID runtimeids.SessionID,
+	message clientui.TranscriptMessage,
+	err error,
+) {
+	mismatch, ok := err.(*transcriptPromptContractMismatch)
+	if !ok {
+		panic(err)
+	}
+	diagnostic := c.newDeveloperError(sourceSessionID, message)
+	diagnostic.Operation = "reconcile_transcript_prompt"
+	promptID := mismatch.PromptID
+	diagnostic.PromptID = &promptID
+	diagnostic.OldPromptContract = &mismatch.Old
+	diagnostic.NewPromptContract = &mismatch.New
+	c.panicDeveloperError(diagnostic)
+}
+
+func (c *ongoingTranscriptController) newDeveloperError(
+	sourceSessionID runtimeids.SessionID,
+	message clientui.TranscriptMessage,
+) *ongoingTranscriptDeveloperError {
+	return &ongoingTranscriptDeveloperError{
+		Operation:        "accept_transcript_delivery",
+		Geometry:         c.frameProvider().Size,
+		Payload:          fmt.Sprintf("%#v", message),
+		SourceSessionID:  sourceSessionID,
+		PayloadSessionID: transcriptMessagePayloadSessionID(message),
+		MessageKind:      message.Kind,
+		Sequence:         message.Sequence,
+		PromptID:         transcriptMessagePromptID(message),
+		Stack:            string(debug.Stack()),
+	}
+}
+
+func (c *ongoingTranscriptController) decorateDeveloperErrorPromptContract(
+	diagnostic *ongoingTranscriptDeveloperError,
+	message clientui.TranscriptMessage,
+) {
+	newPrompt := transcriptMessagePrompt(message)
+	if newPrompt == nil {
+		return
+	}
+	c.decorateDeveloperErrorPromptContractForPrompt(diagnostic, *newPrompt)
+}
+
+func (c *ongoingTranscriptController) decorateDeveloperErrorPromptContractForPrompt(
+	diagnostic *ongoingTranscriptDeveloperError,
+	newPrompt clientui.TranscriptPrompt,
+) {
+	promptID := newPrompt.PromptID
+	diagnostic.PromptID = &promptID
+	for _, event := range c.snapshotTranscriptPromptOwnership().events {
+		if event.prompt.PromptID != newPrompt.PromptID {
+			continue
+		}
+		oldContract := newTranscriptPromptContract(event.prompt)
+		newContract := newTranscriptPromptContract(newPrompt)
+		diagnostic.OldPromptContract = &oldContract
+		diagnostic.NewPromptContract = &newContract
+		return
+	}
+}
+
+func (c *ongoingTranscriptController) panicDeveloperError(diagnostic *ongoingTranscriptDeveloperError) {
+	if c.logger != nil {
+		c.logger.Logf("ongoing.transcript.developer_error diagnostic=%+v stack=%s", diagnostic, diagnostic.Stack)
+	} else {
+		log.Printf("ongoing.transcript.developer_error diagnostic=%+v stack=%s", diagnostic, diagnostic.Stack)
+	}
+	panic(diagnostic)
+}
+
+func transcriptMessagePayloadSessionID(message clientui.TranscriptMessage) runtimeids.SessionID {
+	switch message.Kind {
+	case clientui.TranscriptMessageHydration:
+		if message.Payload.Hydration != nil {
+			return message.Payload.Hydration.SessionIdentity.SessionID
+		}
+	case clientui.TranscriptMessagePromptPending:
+		if message.Payload.PromptPending != nil {
+			return message.Payload.PromptPending.SessionID
+		}
+	case clientui.TranscriptMessagePromptResolved:
+		if message.Payload.PromptResolved != nil {
+			return message.Payload.PromptResolved.SessionID
+		}
+	case clientui.TranscriptMessageSessionIdentity:
+		if message.Payload.SessionIdentity != nil {
+			return message.Payload.SessionIdentity.SessionID
+		}
+	}
+	return runtimeids.SessionID{}
+}
+
+func transcriptMessagePromptID(message clientui.TranscriptMessage) *clientui.PromptID {
+	if prompt := transcriptMessagePrompt(message); prompt != nil {
+		promptID := prompt.PromptID
+		return &promptID
+	}
+	return nil
+}
+
+func transcriptMessagePrompt(message clientui.TranscriptMessage) *clientui.TranscriptPrompt {
+	switch message.Kind {
+	case clientui.TranscriptMessagePromptPending:
+		if message.Payload.PromptPending != nil {
+			return message.Payload.PromptPending
+		}
+	case clientui.TranscriptMessagePromptResolved:
+		if message.Payload.PromptResolved != nil {
+			return message.Payload.PromptResolved
+		}
+	case clientui.TranscriptMessageHydration:
+		if message.Payload.Hydration != nil && len(message.Payload.Hydration.PendingPrompts) > 0 {
+			return &message.Payload.Hydration.PendingPrompts[0]
+		}
+	}
+	return nil
 }
 
 func (c *ongoingTranscriptController) SetNormalBufferOwned(owned bool) (ongoing.Result, error) {
@@ -158,26 +414,27 @@ func (c *ongoingTranscriptController) HandleSubscriptionLoss() ongoing.Result {
 	return ongoing.Result{Action: ongoing.ResultRequestScratchRehydration, Reason: ongoing.RehydrateReasonSequenceGap}
 }
 
-func (c *ongoingTranscriptController) classifyDelivery(message clientui.TranscriptMessage) (ongoing.Result, bool) {
+func (c *ongoingTranscriptController) rejectDelivery(message clientui.TranscriptMessage) (ongoing.Result, bool) {
 	if !c.hydrated {
 		if message.Sequence != 1 || message.Kind != clientui.TranscriptMessageHydration {
+			c.requestScratchRehydration()
 			return ongoing.Result{Action: ongoing.ResultRequestScratchRehydration, Reason: ongoing.RehydrateReasonSequenceGap}, true
 		}
 		return ongoing.Result{}, false
 	}
 	if message.Sequence != c.lastSequence+1 {
+		c.requestScratchRehydration()
 		return ongoing.Result{Action: ongoing.ResultRequestScratchRehydration, Reason: ongoing.RehydrateReasonSequenceGap}, true
 	}
 	if message.Kind == clientui.TranscriptMessageHydration {
+		c.requestScratchRehydration()
 		return ongoing.Result{Action: ongoing.ResultRequestScratchRehydration, Reason: ongoing.RehydrateReasonSequenceGap}, true
 	}
 	return ongoing.Result{}, false
 }
 
-func (c *ongoingTranscriptController) commitDelivery(message clientui.TranscriptMessage) {
-	if !c.hydrated {
-		c.hydrated = true
-	}
+func (c *ongoingTranscriptController) advanceDelivery(message clientui.TranscriptMessage) {
+	c.hydrated = true
 	c.lastSequence = message.Sequence
 }
 
@@ -185,6 +442,10 @@ func (c *ongoingTranscriptController) acceptedHydration(message clientui.Transcr
 	return message.Kind == clientui.TranscriptMessageHydration &&
 		c.hydrated &&
 		c.lastSequence == message.Sequence
+}
+
+func (c *ongoingTranscriptController) snapshotTranscriptPromptOwnership() transcriptPromptOwnershipSnapshot {
+	return c.promptOwner.snapshotTranscriptPromptOwnership()
 }
 
 func (c *ongoingTranscriptController) requestScratchRehydration() {
@@ -279,11 +540,9 @@ func (c *ongoingTranscriptController) applyAppOwnedMessage(message clientui.Tran
 	case clientui.TranscriptMessageCompactionStatus:
 		// Compaction status is already represented by the app status line.
 	case clientui.TranscriptMessagePromptPending:
-		c.liveReadModel.applyPendingPrompt(message.Payload.PromptPending)
-		return true
+		// Prompt ownership and projection commit through one prepared reconciliation.
 	case clientui.TranscriptMessagePromptResolved:
-		c.liveReadModel.applyPendingPrompt(message.Payload.PromptResolved)
-		return true
+		// Prompt ownership and projection commit through one prepared reconciliation.
 	case clientui.TranscriptMessageContextUsage:
 		// Context usage is already represented by the app status line.
 	case clientui.TranscriptMessageGoalStatus:
@@ -321,12 +580,6 @@ func (c *ongoingTranscriptController) applyHydrationAppOwnedFacts(hydration *cli
 	if len(hydration.QueuedMessages) > 0 {
 		for _, state := range hydration.QueuedMessages {
 			c.liveReadModel.applyQueuedOrSteered(&state)
-		}
-		changed = true
-	}
-	if len(hydration.PendingPrompts) > 0 {
-		for _, prompt := range hydration.PendingPrompts {
-			c.liveReadModel.applyPendingPrompt(&prompt)
 		}
 		changed = true
 	}

--- a/cli/app/session_transcript_controller_test.go
+++ b/cli/app/session_transcript_controller_test.go
@@ -116,19 +116,22 @@ func TestOngoingTranscriptControllerLeavesUserMessageFlushPresentationToStateObs
 	controller := newOngoingTranscriptController(
 		surface,
 		ongoingTestFrameProvider,
-		noopOngoingTranscriptRuntimeAdmission,
+		func(clientui.TranscriptMessage) (runtimeTupleMergeResult, error) {
+			return runtimeTupleMergeResult{}, nil
+		},
 		func(message clientui.TranscriptMessage, _ runtimeTupleMergeResult) tea.Cmd {
 			observed = append(observed, message.Kind)
 			return nil
 		},
+		newTestOngoingTranscriptPromptOwner(),
 	)
-	if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
 	surface.calls = nil
 	observed = nil
 
-	if _, command, err := controller.Accept(ongoingTranscriptMessage(2, clientui.TranscriptMessageUserMessageFlushed)); err != nil {
+	if _, command, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingTranscriptMessage(2, clientui.TranscriptMessageUserMessageFlushed)); err != nil {
 		t.Fatalf("accept user-message flush: %v", err)
 	} else if command != nil {
 		t.Fatal("user-message flush returned an unexpected state command")
@@ -345,19 +348,46 @@ func newNoopOngoingTranscriptController(surface ongoingTranscriptSurface, frameP
 	return newOngoingTranscriptController(
 		surface,
 		frameProvider,
-		noopOngoingTranscriptRuntimeAdmission,
+		func(clientui.TranscriptMessage) (runtimeTupleMergeResult, error) {
+			return runtimeTupleMergeResult{}, nil
+		},
 		func(clientui.TranscriptMessage, runtimeTupleMergeResult) tea.Cmd {
 			return nil
 		},
+		newTestOngoingTranscriptPromptOwner(),
 	)
 }
 
-func noopOngoingTranscriptRuntimeAdmission(clientui.TranscriptMessage) (runtimeTupleMergeResult, error) {
-	return runtimeTupleMergeResult{}, nil
+type testOngoingTranscriptPromptOwner struct {
+	snapshot transcriptPromptOwnershipSnapshot
+}
+
+func newTestOngoingTranscriptPromptOwner() *testOngoingTranscriptPromptOwner {
+	return &testOngoingTranscriptPromptOwner{}
+}
+
+func (o *testOngoingTranscriptPromptOwner) snapshotTranscriptPromptOwnership() transcriptPromptOwnershipSnapshot {
+	return o.snapshot
+}
+
+func (o *testOngoingTranscriptPromptOwner) commitTranscriptPromptReconciliation(
+	reconciliation transcriptPromptReconciliation,
+) {
+	events := make([]askEvent, 0, len(reconciliation.events))
+	for _, planned := range reconciliation.events {
+		event := planned.retained
+		event.prompt = cloneTranscriptPromptForAsk(planned.prompt)
+		events = append(events, event)
+	}
+	o.snapshot = transcriptPromptOwnershipSnapshot{events: events}
+	if len(events) > 0 {
+		currentPromptID := events[0].prompt.PromptID
+		o.snapshot.currentPromptID = &currentPromptID
+	}
 }
 
 func (c *testOngoingTranscriptController) Accept(message clientui.TranscriptMessage) (ongoing.Result, error) {
-	result, command, err := c.ongoingTranscriptController.Accept(message)
+	result, command, err := c.ongoingTranscriptController.AcceptFrom(ongoingTestSessionID(), message)
 	if command != nil {
 		panic("test ongoing transcript controller received an unexpected state command")
 	}

--- a/cli/app/session_transcript_prompt_reconciliation.go
+++ b/cli/app/session_transcript_prompt_reconciliation.go
@@ -255,7 +255,7 @@ func (m *uiModel) snapshotTranscriptPromptOwnership() transcriptPromptOwnershipS
 		switch {
 		case m.ask.answerPending || m.ask.activeDelivery != nil:
 			snapshot.retention = transcriptPromptRetentionAnswerPending
-		case strings.TrimSpace(m.ask.input) != "":
+		case strings.TrimSpace(m.ask.editor.Text()) != "":
 			snapshot.retention = transcriptPromptRetentionMeaningfulDraft
 		}
 		snapshot.events = append(snapshot.events, *m.ask.current)
@@ -320,7 +320,7 @@ func (m *uiModel) normalizeRetainedPromptInteraction(oldPrompt, newPrompt client
 	if slices.Equal(oldPrompt.Suggestions, newPrompt.Suggestions) {
 		return
 	}
-	if strings.TrimSpace(m.ask.input) != "" {
+	if strings.TrimSpace(m.ask.editor.Text()) != "" {
 		m.ask.cursor = len(newPrompt.Suggestions)
 		m.ask.freeform = true
 		m.ask.freeformMode = askFreeformModeGeneric

--- a/cli/app/session_transcript_prompt_reconciliation.go
+++ b/cli/app/session_transcript_prompt_reconciliation.go
@@ -277,7 +277,14 @@ func (m *uiModel) commitTranscriptPromptReconciliation(reconciliation transcript
 		event.prompt = cloneTranscriptPromptForAsk(planned.prompt)
 		events = append(events, event)
 	}
+	retainedPromptIDs := make(map[clientui.PromptID]struct{}, len(reconciliation.events))
+	for _, event := range reconciliation.events {
+		retainedPromptIDs[event.prompt.PromptID] = struct{}{}
+	}
 	for _, event := range reconciliation.canceled {
+		if _, retained := retainedPromptIDs[event.promptID()]; retained {
+			continue
+		}
 		m.clearApprovalCommentaryAnswer(event.promptID())
 		if m.ask.activeDelivery != nil && m.ask.activeDelivery.key.promptID == event.promptID() {
 			m.askController().cancelActiveDelivery()

--- a/cli/app/session_transcript_prompt_reconciliation.go
+++ b/cli/app/session_transcript_prompt_reconciliation.go
@@ -1,0 +1,368 @@
+package app
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"core/cli/tui"
+	"core/shared/clientui"
+)
+
+type ongoingTranscriptPromptOwner interface {
+	snapshotTranscriptPromptOwnership() transcriptPromptOwnershipSnapshot
+	commitTranscriptPromptReconciliation(transcriptPromptReconciliation)
+}
+
+type transcriptPromptOwnershipSnapshot struct {
+	currentPromptID *clientui.PromptID
+	retention       transcriptPromptInteractionRetention
+	events          []askEvent
+}
+
+type transcriptPromptInteractionRetention uint8
+
+const (
+	transcriptPromptRetentionNone transcriptPromptInteractionRetention = iota
+	transcriptPromptRetentionMeaningfulDraft
+	transcriptPromptRetentionAnswerPending
+)
+
+type transcriptPromptReconciliation struct {
+	events         []transcriptPromptReconciliationEvent
+	canceled       []askEvent
+	activeRetained bool
+	source         clientui.AttentionNotificationSource
+}
+
+type transcriptPromptReconciliationEvent struct {
+	prompt   clientui.TranscriptPrompt
+	retained askEvent
+	owned    bool
+	notify   bool
+}
+
+type transcriptPromptContract struct {
+	PromptID  clientui.PromptID
+	SessionID string
+	Kind      clientui.TranscriptPromptKind
+	StepID    string
+	CreatedAt time.Time
+	Tool      *clientui.ToolProvenance
+}
+
+type transcriptPromptContractMismatch struct {
+	PromptID clientui.PromptID
+	Old      transcriptPromptContract
+	New      transcriptPromptContract
+}
+
+func (e *transcriptPromptContractMismatch) Error() string {
+	return fmt.Sprintf("prompt %q immutable contract mismatch", e.PromptID)
+}
+
+func prepareTranscriptPromptReconciliation(
+	ownership transcriptPromptOwnershipSnapshot,
+	message clientui.TranscriptMessage,
+) (transcriptPromptReconciliation, bool, error) {
+	var (
+		incoming []clientui.TranscriptPrompt
+		source   clientui.AttentionNotificationSource
+		mode     clientui.TranscriptMessageKind
+	)
+	switch message.Kind {
+	case clientui.TranscriptMessageHydration:
+		incoming = message.Payload.Hydration.PendingPrompts
+		source = clientui.AttentionNotificationSourceSnapshot
+		mode = message.Kind
+	case clientui.TranscriptMessagePromptPending:
+		incoming = []clientui.TranscriptPrompt{*message.Payload.PromptPending}
+		source = clientui.AttentionNotificationSourceLive
+		mode = message.Kind
+	case clientui.TranscriptMessagePromptResolved:
+		incoming = []clientui.TranscriptPrompt{*message.Payload.PromptResolved}
+		source = clientui.AttentionNotificationSourceLive
+		mode = message.Kind
+	default:
+		return transcriptPromptReconciliation{}, false, nil
+	}
+
+	existingOrder := make([]clientui.PromptID, 0, len(ownership.events))
+	existing := make(map[clientui.PromptID]askEvent, len(ownership.events))
+	plan := transcriptPromptReconciliation{source: source}
+	for _, event := range ownership.events {
+		id := event.prompt.PromptID
+		if _, duplicate := existing[id]; duplicate {
+			plan.canceled = append(plan.canceled, event)
+			continue
+		}
+		existing[id] = event
+		existingOrder = append(existingOrder, id)
+	}
+
+	switch mode {
+	case clientui.TranscriptMessageHydration:
+		byID := make(map[clientui.PromptID]clientui.TranscriptPrompt, len(incoming))
+		for _, prompt := range incoming {
+			byID[prompt.PromptID] = prompt
+		}
+		for _, id := range existingOrder {
+			event := existing[id]
+			prompt, present := byID[id]
+			if !present {
+				plan.canceled = append(plan.canceled, event)
+				continue
+			}
+			if mismatch := compareTranscriptPromptContract(event.prompt, prompt); mismatch != nil {
+				return transcriptPromptReconciliation{}, true, mismatch
+			}
+		}
+		ordered := append([]clientui.TranscriptPrompt(nil), incoming...)
+		if len(ordered) > 1 &&
+			ownership.currentPromptID != nil &&
+			ordered[0].PromptID != *ownership.currentPromptID &&
+			ownership.retention != transcriptPromptRetentionNone {
+			for index, prompt := range ordered {
+				if prompt.PromptID != *ownership.currentPromptID {
+					continue
+				}
+				ordered = append([]clientui.TranscriptPrompt{prompt}, append(ordered[:index], ordered[index+1:]...)...)
+				break
+			}
+		}
+		for _, prompt := range ordered {
+			id := prompt.PromptID
+			if event, retained := existing[id]; retained {
+				plan.events = append(plan.events, retainedTranscriptPromptEvent(event, prompt))
+			} else {
+				plan.events = append(plan.events, newTranscriptPromptEvent(prompt))
+			}
+		}
+	case clientui.TranscriptMessagePromptPending:
+		prompt := incoming[0]
+		targetID := prompt.PromptID
+		found := false
+		for _, id := range existingOrder {
+			event := existing[id]
+			if id == targetID {
+				if mismatch := compareTranscriptPromptContract(event.prompt, prompt); mismatch != nil {
+					return transcriptPromptReconciliation{}, true, mismatch
+				}
+				plan.events = append(plan.events, retainedTranscriptPromptEvent(event, prompt))
+				found = true
+				continue
+			}
+			plan.events = append(plan.events, retainedTranscriptPromptEvent(event, event.prompt))
+		}
+		if !found {
+			plan.events = append(plan.events, newTranscriptPromptEvent(prompt))
+		}
+	case clientui.TranscriptMessagePromptResolved:
+		targetID := incoming[0].PromptID
+		for _, id := range existingOrder {
+			event := existing[id]
+			if id == targetID {
+				if mismatch := compareTranscriptPromptContract(event.prompt, incoming[0]); mismatch != nil {
+					return transcriptPromptReconciliation{}, true, mismatch
+				}
+				plan.canceled = append(plan.canceled, event)
+				continue
+			}
+			plan.events = append(plan.events, retainedTranscriptPromptEvent(event, event.prompt))
+		}
+	}
+
+	plan.activeRetained = len(plan.events) > 0 &&
+		plan.events[0].owned &&
+		ownership.currentPromptID != nil &&
+		plan.events[0].retained.prompt.PromptID == *ownership.currentPromptID
+	return plan, true, nil
+}
+
+func compareTranscriptPromptContract(oldPrompt, newPrompt clientui.TranscriptPrompt) *transcriptPromptContractMismatch {
+	oldContract := newTranscriptPromptContract(oldPrompt)
+	newContract := newTranscriptPromptContract(newPrompt)
+	if oldContract.SessionID == newContract.SessionID &&
+		oldContract.PromptID == newContract.PromptID &&
+		oldContract.Kind == newContract.Kind &&
+		oldContract.StepID == newContract.StepID &&
+		oldContract.CreatedAt.Equal(newContract.CreatedAt) &&
+		equalToolProvenance(oldContract.Tool, newContract.Tool) {
+		return nil
+	}
+	return &transcriptPromptContractMismatch{
+		PromptID: oldPrompt.PromptID,
+		Old:      oldContract,
+		New:      newContract,
+	}
+}
+
+func newTranscriptPromptContract(prompt clientui.TranscriptPrompt) transcriptPromptContract {
+	var tool *clientui.ToolProvenance
+	if prompt.Tool != nil {
+		cloned := *prompt.Tool
+		tool = &cloned
+	}
+	return transcriptPromptContract{
+		PromptID:  prompt.PromptID,
+		SessionID: prompt.SessionID.String(),
+		Kind:      prompt.Kind,
+		StepID:    prompt.StepID.String(),
+		CreatedAt: prompt.CreatedAt,
+		Tool:      tool,
+	}
+}
+
+func equalToolProvenance(left, right *clientui.ToolProvenance) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return left.ToolCallID == right.ToolCallID && left.ToolName == right.ToolName
+}
+
+func retainedTranscriptPromptEvent(event askEvent, prompt clientui.TranscriptPrompt) transcriptPromptReconciliationEvent {
+	return transcriptPromptReconciliationEvent{
+		prompt:   cloneTranscriptPromptForAsk(prompt),
+		retained: event,
+		owned:    true,
+	}
+}
+
+func newTranscriptPromptEvent(prompt clientui.TranscriptPrompt) transcriptPromptReconciliationEvent {
+	return transcriptPromptReconciliationEvent{
+		prompt: cloneTranscriptPromptForAsk(prompt),
+		notify: true,
+	}
+}
+
+func (r transcriptPromptReconciliation) pendingPrompts() []clientui.TranscriptPrompt {
+	prompts := make([]clientui.TranscriptPrompt, 0, len(r.events))
+	for _, event := range r.events {
+		prompts = append(prompts, cloneTranscriptPromptForAsk(event.prompt))
+	}
+	return prompts
+}
+
+func (m *uiModel) snapshotTranscriptPromptOwnership() transcriptPromptOwnershipSnapshot {
+	if m == nil {
+		return transcriptPromptOwnershipSnapshot{}
+	}
+	snapshot := transcriptPromptOwnershipSnapshot{}
+	if m.ask.hasCurrent() {
+		currentPromptID := m.ask.current.promptID()
+		snapshot.currentPromptID = &currentPromptID
+		switch {
+		case m.ask.answerPending || m.ask.activeDelivery != nil:
+			snapshot.retention = transcriptPromptRetentionAnswerPending
+		case strings.TrimSpace(m.ask.input) != "":
+			snapshot.retention = transcriptPromptRetentionMeaningfulDraft
+		}
+		snapshot.events = append(snapshot.events, *m.ask.current)
+	}
+	snapshot.events = append(snapshot.events, m.ask.queue...)
+	return snapshot
+}
+
+func (m *uiModel) commitTranscriptPromptReconciliation(reconciliation transcriptPromptReconciliation) {
+	if m == nil {
+		return
+	}
+	events := make([]askEvent, 0, len(reconciliation.events))
+	for _, planned := range reconciliation.events {
+		event := planned.retained
+		if !planned.owned {
+			event = m.transcriptPromptEvent(planned.prompt)
+		}
+		event.prompt = cloneTranscriptPromptForAsk(planned.prompt)
+		events = append(events, event)
+	}
+	for _, event := range reconciliation.canceled {
+		m.clearApprovalCommentaryAnswer(event.promptID())
+		if m.ask.activeDelivery != nil && m.ask.activeDelivery.key.promptID == event.promptID() {
+			m.askController().cancelActiveDelivery()
+		}
+	}
+	if reconciliation.activeRetained &&
+		len(reconciliation.events) > 0 &&
+		!m.ask.answerPending &&
+		m.ask.activeDelivery == nil {
+		m.normalizeRetainedPromptInteraction(
+			reconciliation.events[0].retained.prompt,
+			reconciliation.events[0].prompt,
+		)
+	}
+	m.askController().replaceTranscriptPromptEvents(events, reconciliation.activeRetained)
+	for _, planned := range reconciliation.events {
+		if planned.notify {
+			notifyTranscriptPromptFallback(m.promptAttention, planned.prompt, reconciliation.source)
+		}
+	}
+}
+
+func (m *uiModel) normalizeRetainedPromptInteraction(oldPrompt, newPrompt clientui.TranscriptPrompt) {
+	if transcriptPromptIsApproval(oldPrompt) {
+		decision, selected := selectedApprovalDecision(oldPrompt, m.ask.cursor)
+		if selected {
+			for index, candidate := range newPrompt.ApprovalOptions {
+				if candidate == decision {
+					m.ask.cursor = index
+					return
+				}
+			}
+		}
+		m.ask.cursor = 0
+		m.ask.freeform = false
+		m.ask.freeformMode = askFreeformModeGeneric
+		m.clearAskInput()
+		return
+	}
+	if slices.Equal(oldPrompt.Suggestions, newPrompt.Suggestions) {
+		return
+	}
+	if strings.TrimSpace(m.ask.input) != "" {
+		m.ask.cursor = len(newPrompt.Suggestions)
+		m.ask.freeform = true
+		m.ask.freeformMode = askFreeformModeGeneric
+		return
+	}
+	m.ask.cursor = 0
+	m.ask.freeform = len(newPrompt.Suggestions) == 0
+	m.ask.freeformMode = askFreeformModeGeneric
+	m.clearAskInput()
+}
+
+func (c uiAskController) replaceTranscriptPromptEvents(events []askEvent, preserveCurrentInteraction bool) {
+	m := c.model
+	if len(events) == 0 {
+		c.cancelActiveDelivery()
+		m.ask.current = nil
+		m.ask.currentToken = nextNonZeroToken(m.ask.currentToken)
+		m.ask.queue = nil
+		m.ask.cursor = 0
+		m.ask.answerPending = false
+		m.clearAskInput()
+		m.ask.freeform = false
+		m.ask.freeformMode = askFreeformModeGeneric
+		m.restorePrimaryInputMode()
+		if m.activity == uiActivityQuestion {
+			if m.isBusy() {
+				m.activity = uiActivityRunning
+			} else {
+				m.activity = uiActivityIdle
+			}
+		}
+		return
+	}
+
+	if preserveCurrentInteraction && m.ask.hasCurrent() {
+		m.ask.current.prompt = cloneTranscriptPromptForAsk(events[0].prompt)
+	} else {
+		c.setActiveAsk(events[0])
+	}
+	m.ask.queue = append(m.ask.queue[:0], events[1:]...)
+	m.activity = uiActivityQuestion
+	if m.inputMode() == uiInputModeMain && (m.view.Mode() == "" || m.view.Mode() == tui.ModeOngoing) {
+		m.setInputMode(uiInputModeAsk)
+	}
+}

--- a/cli/app/session_transcript_read_model.go
+++ b/cli/app/session_transcript_read_model.go
@@ -32,7 +32,7 @@ type keyedOngoingLiveItems[K comparable, T any] struct {
 
 type ongoingLiveItemID string
 
-type ongoingPromptID string
+type ongoingPromptID clientui.PromptID
 
 func newOngoingTranscriptReadModel() ongoingTranscriptReadModel {
 	return ongoingTranscriptReadModel{
@@ -171,6 +171,14 @@ func (m *ongoingTranscriptReadModel) applyPendingPrompt(prompt *clientui.Transcr
 	m.refreshPendingPromptSection(80)
 }
 
+func (m *ongoingTranscriptReadModel) replacePendingPrompts(prompts []clientui.TranscriptPrompt) {
+	m.pendingPrompts = newKeyedOngoingLiveItems[ongoingPromptID, clientui.TranscriptPrompt]()
+	for _, prompt := range prompts {
+		m.pendingPrompts.set(parseOngoingPromptID(prompt.PromptID), cloneTranscriptPromptForAsk(prompt))
+	}
+	m.refreshPendingPromptSection(80)
+}
+
 func (m *ongoingTranscriptReadModel) refreshPendingPromptSection(width int) {
 	m.setSection(ongoing.FrameSectionPendingPrompt, terminalSafeFrameLinesForWidth(pendingPromptListLines(m.pendingPrompts.values()), width))
 }
@@ -211,11 +219,10 @@ func (items keyedOngoingLiveItems[K, T]) values() []T {
 }
 
 func parseOngoingPromptID(raw clientui.PromptID) ongoingPromptID {
-	id := strings.TrimSpace(string(raw))
-	if id == "" {
-		panicOngoingTranscriptReadModelDeveloperError("pending_prompt_id", "missing id", nil)
+	if err := raw.Validate(); err != nil {
+		panicOngoingTranscriptReadModelDeveloperError("pending_prompt_id", err.Error(), map[string]any{"id": raw})
 	}
-	return ongoingPromptID(id)
+	return ongoingPromptID(raw)
 }
 
 func panicOngoingTranscriptReadModelDeveloperError(operation, reason string, facts map[string]any) {

--- a/cli/app/terminal_bell_test.go
+++ b/cli/app/terminal_bell_test.go
@@ -91,7 +91,8 @@ func TestUIAskLifecycleDoesNotDuplicateAttentionNotifications(t *testing.T) {
 	model = next.(*uiModel)
 	next, _ = model.Update(askEventMsg{event: askEvent{prompt: bellTestPrompt("ask-2", "Second?")}})
 	model = next.(*uiModel)
-	_, _ = model.Update(askEventMsg{event: askEvent{resolvedPromptID: "ask-1"}})
+	resolvedPromptID := clientui.PromptID("ask-1")
+	_, _ = model.Update(askEventMsg{event: askEvent{resolvedPromptID: &resolvedPromptID}})
 
 	if ringer.total() != 0 {
 		t.Fatalf("UI ask lifecycle emitted %d notification events", ringer.total())

--- a/cli/app/transcript_prompt_answers.go
+++ b/cli/app/transcript_prompt_answers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"core/shared/apicontract"
@@ -12,6 +11,7 @@ import (
 	"core/shared/rpcwire"
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
+	"core/shared/textutil"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -159,9 +159,8 @@ func newTranscriptPromptKey(prompt clientui.TranscriptPrompt) (transcriptPromptK
 	if prompt.SessionID.IsZero() {
 		return transcriptPromptKey{}, errors.New("prompt answer session id is required")
 	}
-	rawPromptID := string(prompt.PromptID)
-	if strings.TrimSpace(rawPromptID) == "" || strings.TrimSpace(rawPromptID) != rawPromptID {
-		return transcriptPromptKey{}, errors.New("prompt answer prompt id is required without surrounding whitespace")
+	if err := prompt.PromptID.Validate(); err != nil {
+		return transcriptPromptKey{}, fmt.Errorf("validate prompt answer prompt id: %w", err)
 	}
 	return transcriptPromptKey{sessionID: prompt.SessionID, promptID: prompt.PromptID}, nil
 }
@@ -171,8 +170,11 @@ func newActivePromptAnswerDelivery(
 	requestID runtimeids.RuntimeClientRequestID,
 	cancel context.CancelFunc,
 ) (*activePromptAnswerDelivery, error) {
-	if key.sessionID.IsZero() || strings.TrimSpace(string(key.promptID)) == "" {
+	if key.sessionID.IsZero() {
 		return nil, errors.New("prompt answer delivery key is required")
+	}
+	if err := key.promptID.Validate(); err != nil {
+		return nil, fmt.Errorf("validate prompt answer delivery prompt id: %w", err)
 	}
 	if requestID.IsZero() {
 		return nil, errors.New("prompt answer delivery request id is required")
@@ -230,6 +232,7 @@ func shouldRetryTranscriptPromptAnswer(err error) bool {
 }
 
 func clonePromptAnswer(answer clientui.PromptAnswer) clientui.PromptAnswer {
+	answer.PromptID = textutil.Pointer(answer.PromptID)
 	if answer.SelectedOptionNumber != nil {
 		selected := *answer.SelectedOptionNumber
 		answer.SelectedOptionNumber = &selected

--- a/cli/app/transcript_prompt_answers_ui_test.go
+++ b/cli/app/transcript_prompt_answers_ui_test.go
@@ -751,8 +751,9 @@ func TestStaleQueuedApprovalCommentaryDoesNotUnlockCurrentPrompt(t *testing.T) {
 	)})
 	model.ask.answerPending = true
 
+	stalePromptID := clientui.PromptID("approval-stale")
 	command := model.answerQueuedApprovalCommentary(clientui.PromptAnswer{
-		PromptID: "approval-stale",
+		PromptID: &stalePromptID,
 		Approval: &clientui.ApprovalPromptAnswer{
 			Decision:   clientui.ApprovalDecisionAllowOnce,
 			Commentary: "stale commentary",

--- a/cli/app/transcript_prompt_contract_test.go
+++ b/cli/app/transcript_prompt_contract_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"core/cli/tui/ongoing"
 	"core/shared/clientui"
 	"core/shared/runtimeids"
 
@@ -21,14 +22,6 @@ type promptInvariantLogger struct {
 func (l *promptInvariantLogger) Logf(_ string, args ...any) {
 	l.calls++
 	l.args = append([]any(nil), args...)
-}
-
-func captureTestPanic(run func()) (value any) {
-	defer func() {
-		value = recover()
-	}()
-	run()
-	return nil
 }
 
 func mustTestSessionID(raw string) runtimeids.SessionID {
@@ -212,7 +205,7 @@ func TestOngoingTranscriptForeignSessionPayloadPanics(t *testing.T) {
 				beforeTransition := model.Transition()
 				beforeReopens := reopens
 
-				panicValue := captureTestPanic(func() {
+				panicValue := capturePanic(func() {
 					_, _ = model.Update(ongoingTranscriptEvent{
 						Kind:            ongoingTranscriptEventMessage,
 						SourceSessionID: ongoingTestSessionID(),
@@ -261,6 +254,33 @@ func TestOngoingTranscriptPromptLiveContractMismatchPanics(t *testing.T) {
 
 func TestOngoingTranscriptPromptHydrationContractMismatchPanics(t *testing.T) {
 	runPromptContractMismatchCases(t, clientui.TranscriptMessageHydration)
+}
+
+func TestOngoingTranscriptStalePromptContractMismatchRequestsScratchBeforeReconciliation(t *testing.T) {
+	model := sizedTestUIModel(newProjectedStaticUIModel(), 80, 24)
+	model.ongoingTranscript = newPromptTestOngoingTranscriptController(model, &ongoingSurfaceSpy{})
+	prompt := testQuestionPrompt("stale-contract", "Choose", "one")
+	model = deliverPromptHydration(t, model, prompt)
+
+	stale := prompt
+	stale.StepID = mustTestStepID("dddddddd-dddd-4ddd-8ddd-dddddddddddd")
+	result, command, err := model.ongoingTranscript.AcceptFrom(
+		ongoingTestSessionID(),
+		clientui.TranscriptMessage{
+			Sequence: 3,
+			Kind:     clientui.TranscriptMessagePromptPending,
+			Payload:  clientui.TranscriptPayload{PromptPending: &stale},
+		},
+	)
+	if err != nil {
+		t.Fatalf("accept stale contract mismatch: %v", err)
+	}
+	if command != nil {
+		t.Fatal("stale contract mismatch returned a state command")
+	}
+	if result.Action != ongoing.ResultRequestScratchRehydration {
+		t.Fatalf("stale contract mismatch action = %q, want scratch rehydration", result.Action)
+	}
 }
 
 func TestOngoingTranscriptPromptResolvedContractMismatchPanics(t *testing.T) {
@@ -358,7 +378,7 @@ func runPromptContractMismatchCases(t *testing.T, messageKind clientui.Transcrip
 					}
 					surfaceCalls := len(surface.calls)
 					notifications := ringer.total()
-					panicValue := captureTestPanic(func() {
+					panicValue := capturePanic(func() {
 						_, _ = model.Update(ongoingTranscriptEvent{
 							Kind:            ongoingTranscriptEventMessage,
 							SourceSessionID: ongoingTestSessionID(),

--- a/cli/app/transcript_prompt_contract_test.go
+++ b/cli/app/transcript_prompt_contract_test.go
@@ -1,0 +1,388 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"core/shared/clientui"
+	"core/shared/runtimeids"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type promptInvariantLogger struct {
+	calls int
+	args  []any
+}
+
+func (l *promptInvariantLogger) Logf(_ string, args ...any) {
+	l.calls++
+	l.args = append([]any(nil), args...)
+}
+
+func captureTestPanic(run func()) (value any) {
+	defer func() {
+		value = recover()
+	}()
+	run()
+	return nil
+}
+
+func mustTestSessionID(raw string) runtimeids.SessionID {
+	id, err := runtimeids.ParseSessionID(raw)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
+func mustTestStepID(raw string) runtimeids.StepID {
+	id, err := runtimeids.ParseStepID(raw)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
+func TestOngoingTranscriptForeignSessionPayloadPanics(t *testing.T) {
+	foreignSessionID := mustTestSessionID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+	testCases := []struct {
+		name     string
+		baseline bool
+		scratch  bool
+		setup    func(*testing.T, *uiModel) *uiModel
+		message  func() clientui.TranscriptMessage
+	}{
+		{
+			name: "initial_hydration",
+			message: func() clientui.TranscriptMessage {
+				message := ongoingHydrationMessage(1)
+				message.Payload.Hydration.SessionIdentity.SessionID = foreignSessionID
+				return message
+			},
+		},
+		{
+			name: "initial_hydration_prompt",
+			message: func() clientui.TranscriptMessage {
+				message := ongoingHydrationMessage(1)
+				prompt := testQuestionPrompt("foreign-hydrated", "Choose", "one")
+				prompt.SessionID = foreignSessionID
+				message.Payload.Hydration.RuntimeReadModelUpdate.Activity = runningPromptTestActivity()
+				message.Payload.Hydration.PendingPrompts = []clientui.TranscriptPrompt{prompt}
+				return message
+			},
+		},
+		{
+			name:     "scratch_hydration",
+			baseline: true,
+			scratch:  true,
+			message: func() clientui.TranscriptMessage {
+				message := ongoingHydrationMessage(1)
+				message.Payload.Hydration.SessionIdentity.SessionID = foreignSessionID
+				return message
+			},
+		},
+		{
+			name:     "live_pending",
+			baseline: true,
+			message: func() clientui.TranscriptMessage {
+				prompt := testQuestionPrompt("foreign-pending", "Choose", "one")
+				prompt.SessionID = foreignSessionID
+				return clientui.TranscriptMessage{
+					Sequence: 2,
+					Kind:     clientui.TranscriptMessagePromptPending,
+					Payload:  clientui.TranscriptPayload{PromptPending: &prompt},
+				}
+			},
+		},
+		{
+			name:     "live_resolved",
+			baseline: true,
+			message: func() clientui.TranscriptMessage {
+				prompt := testQuestionPrompt("foreign-resolved", "Choose", "one")
+				prompt.SessionID = foreignSessionID
+				prompt.State = clientui.TranscriptPromptStateResolved
+				return clientui.TranscriptMessage{
+					Sequence: 2,
+					Kind:     clientui.TranscriptMessagePromptResolved,
+					Payload:  clientui.TranscriptPayload{PromptResolved: &prompt},
+				}
+			},
+		},
+		{
+			name:     "live_identity",
+			baseline: true,
+			message: func() clientui.TranscriptMessage {
+				message := ongoingTranscriptMessage(2, clientui.TranscriptMessageSessionIdentity)
+				message.Payload.SessionIdentity.SessionID = foreignSessionID
+				return message
+			},
+		},
+		{
+			name:     "pending_drain",
+			baseline: true,
+			scratch:  true,
+			setup: func(t *testing.T, model *uiModel) *uiModel {
+				running := ongoingTranscriptMessage(2, clientui.TranscriptMessageRuntimeReadModelUpdate)
+				running.Payload.RuntimeReadModelUpdate.Activity = clientui.RuntimeActivity{
+					State:          clientui.RuntimeActivityRunning,
+					QueueAccepting: true,
+					ActiveStep: &clientui.RuntimeActiveStep{
+						ActiveKind: clientui.RuntimeActivityActiveKindUserTurn,
+						RunID:      ongoingTestRunID(),
+						StepID:     ongoingTestStepID(),
+					},
+				}
+				model = updateUIModel(t, model, ongoingTranscriptEvent{
+					Kind:            ongoingTranscriptEventMessage,
+					SourceSessionID: ongoingTestSessionID(),
+					Message:         running,
+				})
+				model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("queued")})
+				model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+
+				approval := testApprovalPrompt(
+					"approval-pending-drain",
+					"Allow?",
+					clientui.ApprovalDecisionAllowOnce,
+					clientui.ApprovalDecisionDeny,
+				)
+				model = updateUIModel(t, model, ongoingTranscriptEvent{
+					Kind:            ongoingTranscriptEventMessage,
+					SourceSessionID: ongoingTestSessionID(),
+					Message: clientui.TranscriptMessage{
+						Sequence: 3,
+						Kind:     clientui.TranscriptMessagePromptPending,
+						Payload:  clientui.TranscriptPayload{PromptPending: &approval},
+					},
+				})
+				model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+				model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("commentary")})
+				return updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+			},
+			message: func() clientui.TranscriptMessage {
+				message := ongoingHydrationMessage(1)
+				message.Payload.Hydration.SessionIdentity.SessionID = foreignSessionID
+				return message
+			},
+		},
+	}
+
+	for _, debugMode := range []bool{false, true} {
+		for _, testCase := range testCases {
+			t.Run(testCase.name+"/debug="+boolName(debugMode), func(t *testing.T) {
+				logger := &promptInvariantLogger{}
+				ringer := &countRinger{}
+				hooks := newUnfocusedBellHooks(ringer)
+				surface := &ongoingSurfaceSpy{}
+				control := newBlockingPromptControl()
+				reopens := 0
+				runtimeClient := &runtimeControlFakeClient{}
+				model := sizedTestUIModel(newProjectedTestUIModel(runtimeClient,
+					WithUIDebug(debugMode),
+					WithUILogger(logger),
+					WithUITurnQueueHook(hooks),
+					WithUIOngoingTranscriptReopen(func() { reopens++ }),
+				), 80, 24)
+				model.promptAnswers = newTranscriptPromptAnswerer(context.Background(), control)
+				model.promptAttention = hooks
+				model.ongoingTranscript = newPromptTestOngoingTranscriptController(model, surface, logger)
+				if testCase.baseline {
+					model = updateUIModel(t, model, ongoingTranscriptEvent{
+						Kind:            ongoingTranscriptEventMessage,
+						SourceSessionID: ongoingTestSessionID(),
+						Message:         ongoingHydrationMessage(1),
+					})
+				}
+				if testCase.setup != nil {
+					model = testCase.setup(t, model)
+				}
+				if testCase.scratch {
+					model = updateUIModel(t, model, ongoingTranscriptEvent{
+						Kind:            ongoingTranscriptEventLoss,
+						SourceSessionID: ongoingTestSessionID(),
+						Err:             errors.New("scratch"),
+					})
+				}
+				surfaceCalls := len(surface.calls)
+				notifications := ringer.total()
+				beforeTransition := model.Transition()
+				beforeReopens := reopens
+
+				panicValue := captureTestPanic(func() {
+					_, _ = model.Update(ongoingTranscriptEvent{
+						Kind:            ongoingTranscriptEventMessage,
+						SourceSessionID: ongoingTestSessionID(),
+						Message:         testCase.message(),
+					})
+				})
+				diagnostic, ok := panicValue.(*ongoingTranscriptDeveloperError)
+				if !ok {
+					t.Fatalf("panic = %T, want *ongoingTranscriptDeveloperError", panicValue)
+				}
+				if diagnostic.SourceSessionID != ongoingTestSessionID() || diagnostic.PayloadSessionID != foreignSessionID {
+					t.Fatalf("diagnostic session IDs = source:%q payload:%q", diagnostic.SourceSessionID.String(), diagnostic.PayloadSessionID.String())
+				}
+				if diagnostic.Geometry.Width != 80 || diagnostic.Geometry.Height != 24 || diagnostic.Stack == "" {
+					t.Fatalf("diagnostic structure incomplete: %+v", diagnostic)
+				}
+				if len(surface.calls) != surfaceCalls || ringer.total() != notifications || reopens != beforeReopens {
+					t.Fatalf("rejected payload produced follow-up: surface=%d/%d notifications=%d/%d reopens=%d/%d",
+						len(surface.calls), surfaceCalls, ringer.total(), notifications, reopens, beforeReopens)
+				}
+				if got := model.Transition(); !reflect.DeepEqual(got, beforeTransition) {
+					t.Fatalf("transition changed after panic: got=%+v want=%+v", got, beforeTransition)
+				}
+				control.assertNoRequest(t)
+				if runtimeClient.queueUserMessageCalls != 0 ||
+					runtimeClient.hasQueuedUserWorkCalls != 0 ||
+					runtimeClient.submitQueuedCalls != 0 {
+					t.Fatalf(
+						"rejected payload dispatched queued work: create=%d check=%d submit=%d",
+						runtimeClient.queueUserMessageCalls,
+						runtimeClient.hasQueuedUserWorkCalls,
+						runtimeClient.submitQueuedCalls,
+					)
+				}
+				if logger.calls != 1 || len(logger.args) == 0 {
+					t.Fatalf("diagnostic logger calls=%d args=%d, want one structured call", logger.calls, len(logger.args))
+				}
+			})
+		}
+	}
+}
+
+func TestOngoingTranscriptPromptLiveContractMismatchPanics(t *testing.T) {
+	runPromptContractMismatchCases(t, clientui.TranscriptMessagePromptPending)
+}
+
+func TestOngoingTranscriptPromptHydrationContractMismatchPanics(t *testing.T) {
+	runPromptContractMismatchCases(t, clientui.TranscriptMessageHydration)
+}
+
+func TestOngoingTranscriptPromptResolvedContractMismatchPanics(t *testing.T) {
+	runPromptContractMismatchCases(t, clientui.TranscriptMessagePromptResolved)
+}
+
+func runPromptContractMismatchCases(t *testing.T, messageKind clientui.TranscriptMessageKind) {
+	t.Helper()
+	foreignSessionID := mustTestSessionID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+	foreignStepID := mustTestStepID("dddddddd-dddd-4ddd-8ddd-dddddddddddd")
+	mutations := map[string]func(*clientui.TranscriptPrompt){
+		"session": func(prompt *clientui.TranscriptPrompt) {
+			prompt.SessionID = foreignSessionID
+		},
+		"kind": func(prompt *clientui.TranscriptPrompt) {
+			prompt.Kind = clientui.TranscriptPromptKindApproval
+			prompt.Suggestions = nil
+			prompt.RecommendedOptionIndex = nil
+			prompt.ApprovalOptions = []clientui.ApprovalDecision{clientui.ApprovalDecisionAllowOnce}
+		},
+		"step": func(prompt *clientui.TranscriptPrompt) {
+			prompt.StepID = foreignStepID
+		},
+		"created_at": func(prompt *clientui.TranscriptPrompt) {
+			prompt.CreatedAt = prompt.CreatedAt.Add(time.Second)
+		},
+		"tool": func(prompt *clientui.TranscriptPrompt) {
+			prompt.Tool = &clientui.ToolProvenance{ToolCallID: "tool-mismatch", ToolName: "ask_question"}
+		},
+	}
+	for _, debugMode := range []bool{false, true} {
+		for _, queued := range []bool{false, true} {
+			for mutationName, mutate := range mutations {
+				t.Run(string(messageKind)+"/"+mutationName+"/queued="+boolName(queued)+"/debug="+boolName(debugMode), func(t *testing.T) {
+					logger := &promptInvariantLogger{}
+					ringer := &countRinger{}
+					hooks := newUnfocusedBellHooks(ringer)
+					surface := &ongoingSurfaceSpy{}
+					model := sizedTestUIModel(newProjectedStaticUIModel(
+						WithUIDebug(debugMode),
+						WithUILogger(logger),
+						WithUITurnQueueHook(hooks),
+					), 80, 24)
+					model.promptAttention = hooks
+					model.ongoingTranscript = newPromptTestOngoingTranscriptController(model, surface, logger)
+					active := testQuestionPrompt("contract-active", "Active", "one")
+					target := active
+					if queued {
+						target = testQuestionPrompt("contract-queued", "Queued", "one")
+						target.CreatedAt = active.CreatedAt.Add(time.Second)
+					}
+					hydration := ongoingHydrationMessage(1)
+					hydration.Payload.Hydration.RuntimeReadModelUpdate.Activity = runningPromptTestActivity()
+					hydration.Payload.Hydration.PendingPrompts = []clientui.TranscriptPrompt{active}
+					if queued {
+						hydration.Payload.Hydration.PendingPrompts = append(hydration.Payload.Hydration.PendingPrompts, target)
+					}
+					model = updateUIModel(t, model, ongoingTranscriptEvent{
+						Kind:            ongoingTranscriptEventMessage,
+						SourceSessionID: ongoingTestSessionID(),
+						Message:         hydration,
+					})
+
+					incoming := cloneTranscriptPromptForAsk(target)
+					mutate(&incoming)
+					var message clientui.TranscriptMessage
+					switch messageKind {
+					case clientui.TranscriptMessagePromptPending:
+						message = clientui.TranscriptMessage{
+							Sequence: 2,
+							Kind:     messageKind,
+							Payload:  clientui.TranscriptPayload{PromptPending: &incoming},
+						}
+					case clientui.TranscriptMessagePromptResolved:
+						incoming.State = clientui.TranscriptPromptStateResolved
+						message = clientui.TranscriptMessage{
+							Sequence: 2,
+							Kind:     messageKind,
+							Payload:  clientui.TranscriptPayload{PromptResolved: &incoming},
+						}
+					case clientui.TranscriptMessageHydration:
+						model = updateUIModel(t, model, ongoingTranscriptEvent{
+							Kind:            ongoingTranscriptEventLoss,
+							SourceSessionID: ongoingTestSessionID(),
+							Err:             errors.New("scratch"),
+						})
+						message = hydration
+						if queued {
+							message.Payload.Hydration.PendingPrompts[1] = incoming
+						} else {
+							message.Payload.Hydration.PendingPrompts[0] = incoming
+						}
+					default:
+						t.Fatalf("unsupported mismatch message kind %q", messageKind)
+					}
+					surfaceCalls := len(surface.calls)
+					notifications := ringer.total()
+					panicValue := captureTestPanic(func() {
+						_, _ = model.Update(ongoingTranscriptEvent{
+							Kind:            ongoingTranscriptEventMessage,
+							SourceSessionID: ongoingTestSessionID(),
+							Message:         message,
+						})
+					})
+					diagnostic, ok := panicValue.(*ongoingTranscriptDeveloperError)
+					if !ok {
+						t.Fatalf("panic = %T, want *ongoingTranscriptDeveloperError", panicValue)
+					}
+					if diagnostic.PromptID == nil || *diagnostic.PromptID != target.PromptID ||
+						diagnostic.OldPromptContract == nil ||
+						diagnostic.NewPromptContract == nil {
+						t.Fatalf("contract diagnostic incomplete: %+v", diagnostic)
+					}
+					if len(surface.calls) != surfaceCalls || ringer.total() != notifications {
+						t.Fatalf("contract mismatch partially committed: surface=%d/%d notifications=%d/%d",
+							len(surface.calls), surfaceCalls, ringer.total(), notifications)
+					}
+					if logger.calls != 1 || len(logger.args) == 0 {
+						t.Fatalf("diagnostic logger calls=%d args=%d", logger.calls, len(logger.args))
+					}
+				})
+			}
+		}
+	}
+}

--- a/cli/app/transcript_prompt_deferred_approval_test.go
+++ b/cli/app/transcript_prompt_deferred_approval_test.go
@@ -1,0 +1,164 @@
+package app
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"core/shared/clientui"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestTranscriptPromptDeferredApprovalCommentaryUsesSubmittedSnapshotOnce(t *testing.T) {
+	for _, queueErr := range []error{nil, errors.New("queue failed")} {
+		t.Run("failure="+boolName(queueErr != nil), func(t *testing.T) {
+			runtimeClient := &runtimeControlFakeClient{queueUserMessageErr: queueErr}
+			control := newRecordingPromptControl()
+			model := newDeferredApprovalTestModel(runtimeClient, control)
+			prompt := testApprovalPrompt(
+				"approval-deferred",
+				"Allow?",
+				clientui.ApprovalDecisionAllowOnce,
+				clientui.ApprovalDecisionDeny,
+			)
+			model = deliverPromptHydration(t, model, prompt)
+			model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+			model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("submitted")})
+			next, queueCmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			model = next.(*uiModel)
+			if queueCmd == nil {
+				t.Fatal("approval commentary did not start queue creation")
+			}
+
+			model = updateUIModel(t, model, ongoingTranscriptEvent{
+				Kind:            ongoingTranscriptEventLoss,
+				SourceSessionID: ongoingTestSessionID(),
+				Err:             errors.New("scratch"),
+			})
+			refresh := ongoingHydrationMessage(1)
+			refresh.Payload.Hydration.RuntimeReadModelUpdate.Activity = runningPromptTestActivity()
+			refreshedPrompt := prompt
+			refreshedPrompt.ApprovalOptions = []clientui.ApprovalDecision{
+				clientui.ApprovalDecisionDeny,
+				clientui.ApprovalDecisionAllowOnce,
+			}
+			refresh.Payload.Hydration.PendingPrompts = []clientui.TranscriptPrompt{refreshedPrompt}
+			model = updateUIModel(t, model, ongoingTranscriptEvent{
+				Kind:            ongoingTranscriptEventMessage,
+				SourceSessionID: ongoingTestSessionID(),
+				Message:         refresh,
+			})
+			model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+
+			done := queueCmd()
+			model = updatePromptUIModel(t, model, done)
+			answer := control.nextApproval(t)
+			if answer.ApprovalID != string(prompt.PromptID) ||
+				answer.Decision != clientui.ApprovalDecisionAllowOnce ||
+				answer.Commentary != "submitted" {
+				t.Fatalf("approval answer = %+v, want original typed snapshot", answer)
+			}
+			control.assertNoApproval(t)
+		})
+	}
+}
+
+func TestTranscriptPromptDeferredApprovalCommentarySubmitsEmptyDirectly(t *testing.T) {
+	runtimeClient := &runtimeControlFakeClient{}
+	control := newRecordingPromptControl()
+	model := newDeferredApprovalTestModel(runtimeClient, control)
+	prompt := testApprovalPrompt(
+		"approval-empty-commentary",
+		"Allow?",
+		clientui.ApprovalDecisionAllowOnce,
+		clientui.ApprovalDecisionDeny,
+	)
+	model = deliverPromptHydration(t, model, prompt)
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updatePromptUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+
+	answer := control.nextApproval(t)
+	if answer.ApprovalID != string(prompt.PromptID) ||
+		answer.Decision != clientui.ApprovalDecisionAllowOnce ||
+		answer.Commentary != "" {
+		t.Fatalf("empty-commentary approval answer = %+v", answer)
+	}
+	if runtimeClient.queueUserMessageCalls != 0 {
+		t.Fatalf("empty commentary queue calls = %d, want 0", runtimeClient.queueUserMessageCalls)
+	}
+
+	resolved := prompt
+	resolved.State = clientui.TranscriptPromptStateResolved
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message: clientui.TranscriptMessage{
+			Sequence: 2,
+			Kind:     clientui.TranscriptMessagePromptResolved,
+			Payload:  clientui.TranscriptPayload{PromptResolved: &resolved},
+		},
+	})
+	nextPrompt := testQuestionPrompt("after-empty-commentary", "Next?", "yes")
+	nextPrompt.CreatedAt = prompt.CreatedAt.Add(time.Second)
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message: clientui.TranscriptMessage{
+			Sequence: 3,
+			Kind:     clientui.TranscriptMessagePromptPending,
+			Payload:  clientui.TranscriptPayload{PromptPending: &nextPrompt},
+		},
+	})
+	model = updatePromptUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+	if got := control.nextAsk(t).AskID; got != string(nextPrompt.PromptID) {
+		t.Fatalf("next answered prompt = %q, want %q", got, nextPrompt.PromptID)
+	}
+}
+
+func TestTranscriptPromptDeferredApprovalCommentaryDiscardsResolvedSnapshot(t *testing.T) {
+	runtimeClient := &runtimeControlFakeClient{}
+	control := newRecordingPromptControl()
+	model := newDeferredApprovalTestModel(runtimeClient, control)
+	prompt := testApprovalPrompt(
+		"approval-stale",
+		"Allow?",
+		clientui.ApprovalDecisionAllowOnce,
+		clientui.ApprovalDecisionDeny,
+	)
+	model = deliverPromptHydration(t, model, prompt)
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("stale")})
+	next, queueCmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+
+	resolved := prompt
+	resolved.State = clientui.TranscriptPromptStateResolved
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message: clientui.TranscriptMessage{
+			Sequence: 2,
+			Kind:     clientui.TranscriptMessagePromptResolved,
+			Payload:  clientui.TranscriptPayload{PromptResolved: &resolved},
+		},
+	})
+	model = updateUIModel(t, model, queueCmd())
+	control.assertNoApproval(t)
+
+	nextPrompt := testQuestionPrompt("next-after-stale", "Next?", "yes")
+	nextPrompt.CreatedAt = prompt.CreatedAt.Add(time.Second)
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message: clientui.TranscriptMessage{
+			Sequence: 3,
+			Kind:     clientui.TranscriptMessagePromptPending,
+			Payload:  clientui.TranscriptPayload{PromptPending: &nextPrompt},
+		},
+	})
+	model = updatePromptUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+	if got := control.nextAsk(t).AskID; got != string(nextPrompt.PromptID) {
+		t.Fatalf("next answered prompt = %q, want %q", got, nextPrompt.PromptID)
+	}
+}

--- a/cli/app/transcript_prompt_hydration_test.go
+++ b/cli/app/transcript_prompt_hydration_test.go
@@ -1,0 +1,170 @@
+package app
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"core/shared/clientui"
+	"core/shared/serverapi"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func runningPromptTestActivity() clientui.RuntimeActivity {
+	return clientui.RuntimeActivity{
+		State:          clientui.RuntimeActivityRunning,
+		QueueAccepting: true,
+		ActiveStep: &clientui.RuntimeActiveStep{
+			ActiveKind: clientui.RuntimeActivityActiveKindUserTurn,
+			RunID:      ongoingTestRunID(),
+			StepID:     ongoingTestStepID(),
+		},
+	}
+}
+
+func newDeferredApprovalTestModel(runtimeClient clientui.RuntimeClient, control *recordingPromptControl) *uiModel {
+	model := sizedTestUIModel(newProjectedTestUIModel(runtimeClient), 80, 24)
+	model.promptAnswers = newTranscriptPromptAnswerer(context.Background(), control)
+	model.ongoingTranscript = newPromptTestOngoingTranscriptController(model, &ongoingSurfaceSpy{})
+	return model
+}
+
+func newPromptTestOngoingTranscriptController(
+	model *uiModel,
+	surface ongoingTranscriptSurface,
+	loggers ...uiLogger,
+) *ongoingTranscriptController {
+	return newOngoingTranscriptController(
+		surface,
+		model.ongoingFrameInput,
+		promptTestRuntimeAdmission,
+		model.applyAdmittedTranscriptMessageState,
+		model,
+		loggers...,
+	)
+}
+
+func promptTestRuntimeAdmission(message clientui.TranscriptMessage) (runtimeTupleMergeResult, error) {
+	var update clientui.RuntimeReadModelUpdate
+	switch message.Kind {
+	case clientui.TranscriptMessageHydration:
+		update = message.Payload.Hydration.RuntimeReadModelUpdate
+	case clientui.TranscriptMessageRuntimeReadModelUpdate:
+		update = *message.Payload.RuntimeReadModelUpdate
+	default:
+		return runtimeTupleMergeResult{}, nil
+	}
+	return runtimeTupleMergeResult{
+		decision: runtimeTupleApply,
+		view: clientui.RuntimeMainView{
+			Version:             update.Version,
+			Activity:            update.Activity,
+			InputReconciliation: update.InputReconciliation,
+		},
+		project: true,
+	}, nil
+}
+
+func deliverPromptHydration(t *testing.T, model *uiModel, prompt clientui.TranscriptPrompt) *uiModel {
+	t.Helper()
+	hydration := ongoingHydrationMessage(1)
+	hydration.Payload.Hydration.RuntimeReadModelUpdate.Activity = runningPromptTestActivity()
+	hydration.Payload.Hydration.PendingPrompts = []clientui.TranscriptPrompt{prompt}
+	return updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message:         hydration,
+	})
+}
+
+func updatePromptUIModel(t *testing.T, model *uiModel, message tea.Msg) *uiModel {
+	t.Helper()
+	next, command := model.Update(message)
+	updated, ok := next.(*uiModel)
+	if !ok {
+		t.Fatalf("unexpected model type %T", next)
+	}
+	if command == nil {
+		return updated
+	}
+	return runPromptTestCommand(t, updated, command)
+}
+
+func runPromptTestCommand(t *testing.T, model *uiModel, command tea.Cmd) *uiModel {
+	t.Helper()
+	if command == nil {
+		return model
+	}
+	harness := &promptTestCommandModel{model: model, command: command}
+	program := tea.NewProgram(
+		harness,
+		tea.WithoutRenderer(),
+		tea.WithoutSignals(),
+		tea.WithInput(nil),
+		tea.WithOutput(io.Discard),
+	)
+	final, err := program.Run()
+	if err != nil {
+		t.Fatalf("run prompt test command: %v", err)
+	}
+	return final.(*promptTestCommandModel).model
+}
+
+type promptTestCommandModel struct {
+	model   *uiModel
+	command tea.Cmd
+}
+
+func (m *promptTestCommandModel) Init() tea.Cmd {
+	return tea.Sequence(m.command, tea.Quit)
+}
+
+func (m *promptTestCommandModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
+	next, command := m.model.Update(message)
+	m.model = next.(*uiModel)
+	return m, command
+}
+
+func (m *promptTestCommandModel) View() string {
+	return ""
+}
+
+func (c *recordingPromptControl) nextApproval(t *testing.T) serverapi.ApprovalAnswerRequest {
+	t.Helper()
+	select {
+	case request := <-c.approvalRequests:
+		return request
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for approval answer")
+		return serverapi.ApprovalAnswerRequest{}
+	}
+}
+
+func (c *recordingPromptControl) assertNoApproval(t *testing.T) {
+	t.Helper()
+	select {
+	case request := <-c.approvalRequests:
+		t.Fatalf("unexpected approval answer: %+v", request)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func (c *recordingPromptControl) nextAsk(t *testing.T) serverapi.AskAnswerRequest {
+	t.Helper()
+	select {
+	case request := <-c.askRequests:
+		return request
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for ask answer")
+		return serverapi.AskAnswerRequest{}
+	}
+}
+
+func boolName(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}

--- a/cli/app/transcript_prompt_reconciliation_test.go
+++ b/cli/app/transcript_prompt_reconciliation_test.go
@@ -54,6 +54,42 @@ func TestOngoingTranscriptPromptHydrationPreservesFIFO(t *testing.T) {
 	}
 }
 
+func TestFallbackTranscriptPromptReconciliationRejectsDuplicateIDsAtomically(t *testing.T) {
+	model := newProjectedStaticUIModel()
+	prompt := testQuestionPrompt("duplicate-fallback", "Choose", "one")
+
+	recovered := capturePanic(func() {
+		model.reconcileTranscriptPrompts([]clientui.TranscriptPrompt{prompt, prompt})
+	})
+	if recovered == nil {
+		t.Fatal("duplicate fallback prompts did not panic")
+	}
+	if testActiveAsk(model) != nil || len(model.ask.queue) != 0 {
+		t.Fatalf("duplicate fallback prompts partially committed: active=%v queue=%d", testActiveAsk(model) != nil, len(model.ask.queue))
+	}
+}
+
+func TestFallbackTranscriptPromptReconciliationRemovesEveryOmittedQueuedPrompt(t *testing.T) {
+	model := newProjectedStaticUIModel()
+	active := testQuestionPrompt("fallback-active", "Active", "one")
+	firstOmitted := testQuestionPrompt("fallback-omitted-1", "First omitted", "one")
+	firstOmitted.CreatedAt = active.CreatedAt.Add(time.Second)
+	secondOmitted := testQuestionPrompt("fallback-omitted-2", "Second omitted", "one")
+	secondOmitted.CreatedAt = active.CreatedAt.Add(2 * time.Second)
+	for _, prompt := range []clientui.TranscriptPrompt{active, firstOmitted, secondOmitted} {
+		model.askController().acceptEvent(model.transcriptPromptEvent(prompt))
+	}
+
+	model.reconcileTranscriptPrompts([]clientui.TranscriptPrompt{active})
+
+	if current := testActiveAsk(model); current == nil || current.prompt.PromptID != active.PromptID {
+		t.Fatalf("fallback active prompt = %+v, want %q", current, active.PromptID)
+	}
+	if len(model.ask.queue) != 0 {
+		t.Fatalf("fallback reconciliation retained %d omitted queued prompts", len(model.ask.queue))
+	}
+}
+
 func TestOngoingTranscriptPromptExactIDsDoNotCollide(t *testing.T) {
 	control := newRecordingPromptControl()
 	model := newDeferredApprovalTestModel(&runtimeControlFakeClient{}, control)

--- a/cli/app/transcript_prompt_reconciliation_test.go
+++ b/cli/app/transcript_prompt_reconciliation_test.go
@@ -1,0 +1,290 @@
+package app
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"core/shared/clientui"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func scratchHydratePrompts(t *testing.T, model *uiModel, prompts []clientui.TranscriptPrompt) *uiModel {
+	t.Helper()
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventLoss,
+		SourceSessionID: ongoingTestSessionID(),
+		Err:             errors.New("scratch"),
+	})
+	hydration := ongoingHydrationMessage(1)
+	hydration.Payload.Hydration.RuntimeReadModelUpdate.Activity = runningPromptTestActivity()
+	hydration.Payload.Hydration.PendingPrompts = append([]clientui.TranscriptPrompt(nil), prompts...)
+	return updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message:         hydration,
+	})
+}
+
+func resolvePromptForTest(t *testing.T, model *uiModel, prompt clientui.TranscriptPrompt, sequence uint64) *uiModel {
+	t.Helper()
+	resolved := prompt
+	resolved.State = clientui.TranscriptPromptStateResolved
+	return updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message: clientui.TranscriptMessage{
+			Sequence: sequence,
+			Kind:     clientui.TranscriptMessagePromptResolved,
+			Payload:  clientui.TranscriptPayload{PromptResolved: &resolved},
+		},
+	})
+}
+
+func TestOngoingTranscriptPromptHydrationPreservesFIFO(t *testing.T) {
+	model, control, prompts := concurrentPromptOrderTestModel(t)
+	model = scratchHydratePrompts(t, model, prompts)
+	for index, prompt := range prompts {
+		model = updatePromptUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+		if got := control.nextAsk(t).AskID; got != string(prompt.PromptID) {
+			t.Fatalf("answer %d prompt = %q, want %q", index, got, prompt.PromptID)
+		}
+		model = resolvePromptForTest(t, model, prompt, uint64(index+2))
+	}
+}
+
+func TestOngoingTranscriptPromptExactIDsDoNotCollide(t *testing.T) {
+	control := newRecordingPromptControl()
+	model := newDeferredApprovalTestModel(&runtimeControlFakeClient{}, control)
+	first := testQuestionPrompt("exact-id", "First?", "yes")
+	second := testQuestionPrompt(" exact-id", "Second?", "yes")
+	second.CreatedAt = first.CreatedAt.Add(time.Second)
+	hydration := ongoingHydrationMessage(1)
+	hydration.Payload.Hydration.RuntimeReadModelUpdate.Activity = runningPromptTestActivity()
+	hydration.Payload.Hydration.PendingPrompts = []clientui.TranscriptPrompt{first, second}
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message:         hydration,
+	})
+
+	model = updatePromptUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+	if got := control.nextAsk(t).AskID; got != string(first.PromptID) {
+		t.Fatalf("first exact prompt id = %q, want %q", got, first.PromptID)
+	}
+	model = resolvePromptForTest(t, model, first, 2)
+	model = updatePromptUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+	if got := control.nextAsk(t).AskID; got != string(second.PromptID) {
+		t.Fatalf("second exact prompt id = %q, want %q", got, second.PromptID)
+	}
+	model = resolvePromptForTest(t, model, second, 3)
+}
+
+func TestOngoingTranscriptPromptHydrationRecoversConcurrentRegistrationWithConditionalStickiness(t *testing.T) {
+	model, control, prompts := concurrentPromptOrderTestModel(t)
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("draft")})
+	model = scratchHydratePrompts(t, model, prompts)
+
+	model = updatePromptUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+	first := control.nextAsk(t)
+	if first.AskID != string(prompts[1].PromptID) || first.FreeformAnswer != "draft" {
+		t.Fatalf("sticky answer = %+v, want prompt B with preserved draft", first)
+	}
+	model = resolvePromptForTest(t, model, prompts[1], 2)
+	for index, prompt := range []clientui.TranscriptPrompt{prompts[0], prompts[2]} {
+		model = updatePromptUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+		if got := control.nextAsk(t).AskID; got != string(prompt.PromptID) {
+			t.Fatalf("remainder answer %d prompt = %q, want %q", index, got, prompt.PromptID)
+		}
+		model = resolvePromptForTest(t, model, prompt, uint64(index+3))
+	}
+}
+
+func TestTranscriptPromptRefreshPreservesApprovalDecision(t *testing.T) {
+	control := newRecordingPromptControl()
+	model := newDeferredApprovalTestModel(&runtimeControlFakeClient{}, control)
+	prompt := testApprovalPrompt("approval-refresh", "Allow?",
+		clientui.ApprovalDecisionAllowOnce, clientui.ApprovalDecisionDeny)
+	model = deliverPromptHydration(t, model, prompt)
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyDown})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("reason")})
+	refreshed := prompt
+	refreshed.ApprovalOptions = []clientui.ApprovalDecision{
+		clientui.ApprovalDecisionDeny, clientui.ApprovalDecisionAllowOnce,
+	}
+	model = refreshSinglePrompt(t, model, refreshed)
+	next, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	model = updateUIModel(t, model, cmd())
+	answer := control.nextApproval(t)
+	if answer.Decision != clientui.ApprovalDecisionDeny || answer.Commentary != "reason" {
+		t.Fatalf("approval refresh answer = %+v", answer)
+	}
+}
+
+func TestTranscriptPromptRefreshResetsRemovedApprovalDecision(t *testing.T) {
+	control := newRecordingPromptControl()
+	model := newDeferredApprovalTestModel(&runtimeControlFakeClient{}, control)
+	prompt := testApprovalPrompt("approval-removed", "Allow?",
+		clientui.ApprovalDecisionAllowOnce, clientui.ApprovalDecisionDeny)
+	model = deliverPromptHydration(t, model, prompt)
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyDown})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("stale")})
+	refreshed := prompt
+	refreshed.ApprovalOptions = []clientui.ApprovalDecision{clientui.ApprovalDecisionAllowOnce}
+	model = refreshSinglePrompt(t, model, refreshed)
+	model = updatePromptUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+	answer := control.nextApproval(t)
+	if answer.Decision != clientui.ApprovalDecisionAllowOnce || answer.Commentary != "" {
+		t.Fatalf("removed approval decision answer = %+v", answer)
+	}
+}
+
+func TestTranscriptPromptRefreshResetsChangedQuestionChoices(t *testing.T) {
+	control := newRecordingPromptControl()
+	model := newDeferredApprovalTestModel(&runtimeControlFakeClient{}, control)
+	prompt := testQuestionPrompt("question-refresh", "Choose", "old-1", "old-2")
+	model = deliverPromptHydration(t, model, prompt)
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyDown})
+	refreshed := prompt
+	refreshed.Suggestions = []string{"new-1", "new-2"}
+	model = refreshSinglePrompt(t, model, refreshed)
+	model = updatePromptUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+	answer := control.nextAsk(t)
+	if answer.SelectedOptionNumber == nil || *answer.SelectedOptionNumber != 1 {
+		t.Fatalf("changed question choice answer = %+v", answer)
+	}
+}
+
+func TestTranscriptPromptRefreshPreservesGenericFreeformDraft(t *testing.T) {
+	control := newRecordingPromptControl()
+	model := newDeferredApprovalTestModel(&runtimeControlFakeClient{}, control)
+	prompt := testQuestionPrompt("question-freeform", "Choose", "duplicate", "duplicate")
+	model = deliverPromptHydration(t, model, prompt)
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyTab})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("custom")})
+	refreshed := prompt
+	refreshed.Suggestions = []string{"duplicate", "new"}
+	model = refreshSinglePrompt(t, model, refreshed)
+	model = updatePromptUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+	answer := control.nextAsk(t)
+	if answer.SelectedOptionNumber != nil || answer.FreeformAnswer != "custom" {
+		t.Fatalf("freeform refresh answer = %+v", answer)
+	}
+}
+
+func TestTranscriptPromptRefreshUpdatesQueuedPrompt(t *testing.T) {
+	control := newRecordingPromptControl()
+	model := newDeferredApprovalTestModel(&runtimeControlFakeClient{}, control)
+	active := testQuestionPrompt("active-refresh", "Active", "yes")
+	queued := testQuestionPrompt("queued-refresh", "Queued", "old")
+	queued.CreatedAt = active.CreatedAt.Add(time.Second)
+	hydration := ongoingHydrationMessage(1)
+	hydration.Payload.Hydration.RuntimeReadModelUpdate.Activity = runningPromptTestActivity()
+	hydration.Payload.Hydration.PendingPrompts = []clientui.TranscriptPrompt{active, queued}
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind: ongoingTranscriptEventMessage, SourceSessionID: ongoingTestSessionID(), Message: hydration,
+	})
+	refreshed := queued
+	refreshed.Suggestions = []string{"new"}
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind: ongoingTranscriptEventMessage, SourceSessionID: ongoingTestSessionID(),
+		Message: clientui.TranscriptMessage{Sequence: 2, Kind: clientui.TranscriptMessagePromptPending,
+			Payload: clientui.TranscriptPayload{PromptPending: &refreshed}},
+	})
+	model = resolvePromptForTest(t, model, active, 3)
+	model = updatePromptUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+	answer := control.nextAsk(t)
+	if answer.AskID != string(queued.PromptID) || answer.SelectedOptionNumber == nil || *answer.SelectedOptionNumber != 1 {
+		t.Fatalf("queued refresh answer = %+v", answer)
+	}
+}
+
+func refreshSinglePrompt(t *testing.T, model *uiModel, prompt clientui.TranscriptPrompt) *uiModel {
+	t.Helper()
+	return scratchHydratePrompts(t, model, []clientui.TranscriptPrompt{prompt})
+}
+
+func TestTranscriptPromptFallbackNotificationLifecycle(t *testing.T) {
+	testCases := []struct {
+		name   string
+		prompt clientui.TranscriptPrompt
+	}{
+		{name: "question", prompt: testQuestionPrompt("notify-question", "Choose", "one")},
+		{name: "approval", prompt: testApprovalPrompt("notify-approval", "Allow", clientui.ApprovalDecisionAllowOnce)},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ringer := &countRinger{}
+			hooks := newUnfocusedBellHooks(ringer)
+			model := sizedTestUIModel(newProjectedStaticUIModel(WithUITurnQueueHook(hooks)), 80, 24)
+			model.promptAttention = hooks
+			model.ongoingTranscript = newPromptTestOngoingTranscriptController(model, &ongoingSurfaceSpy{})
+			model = deliverPromptHydration(t, model, testCase.prompt)
+			if got := ringer.total(); got != 1 {
+				t.Fatalf("initial notification count = %d, want 1", got)
+			}
+			model = refreshSinglePrompt(t, model, testCase.prompt)
+			if got := ringer.total(); got != 1 {
+				t.Fatalf("repeated hydration notification count = %d, want 1", got)
+			}
+			refreshed := testCase.prompt
+			refreshed.Question += " refreshed"
+			model = updateUIModel(t, model, ongoingTranscriptEvent{
+				Kind: ongoingTranscriptEventMessage, SourceSessionID: ongoingTestSessionID(),
+				Message: clientui.TranscriptMessage{Sequence: 2, Kind: clientui.TranscriptMessagePromptPending,
+					Payload: clientui.TranscriptPayload{PromptPending: &refreshed}},
+			})
+			if got := ringer.total(); got != 1 {
+				t.Fatalf("live refresh notification count = %d, want 1", got)
+			}
+			model = resolvePromptForTest(t, model, refreshed, 3)
+			next := testCase.prompt
+			next.PromptID = clientui.PromptID(string(next.PromptID) + "-next")
+			next.CreatedAt = next.CreatedAt.Add(time.Second)
+			model = updateUIModel(t, model, ongoingTranscriptEvent{
+				Kind: ongoingTranscriptEventMessage, SourceSessionID: ongoingTestSessionID(),
+				Message: clientui.TranscriptMessage{Sequence: 4, Kind: clientui.TranscriptMessagePromptPending,
+					Payload: clientui.TranscriptPayload{PromptPending: &next}},
+			})
+			if got := ringer.total(); got != 2 {
+				t.Fatalf("later prompt notification count = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func concurrentPromptOrderTestModel(t *testing.T) (*uiModel, *recordingPromptControl, []clientui.TranscriptPrompt) {
+	t.Helper()
+	control := newRecordingPromptControl()
+	model := newDeferredApprovalTestModel(&runtimeControlFakeClient{}, control)
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message:         ongoingHydrationMessage(1),
+	})
+	base := time.Unix(10, 0).UTC()
+	a := testQuestionPrompt("prompt-a", "A?", "yes")
+	b := testQuestionPrompt("prompt-b", "B?", "yes")
+	c := testQuestionPrompt("prompt-c", "C?", "yes")
+	a.CreatedAt = base
+	b.CreatedAt = base.Add(time.Second)
+	c.CreatedAt = base.Add(2 * time.Second)
+	for index, prompt := range []clientui.TranscriptPrompt{b, a} {
+		copy := prompt
+		model = updateUIModel(t, model, ongoingTranscriptEvent{
+			Kind:            ongoingTranscriptEventMessage,
+			SourceSessionID: ongoingTestSessionID(),
+			Message: clientui.TranscriptMessage{
+				Sequence: uint64(index + 2),
+				Kind:     clientui.TranscriptMessagePromptPending,
+				Payload:  clientui.TranscriptPayload{PromptPending: &copy},
+			},
+		})
+	}
+	return model, control, []clientui.TranscriptPrompt{a, b, c}
+}

--- a/cli/app/transcript_prompt_worker_lifecycle_test.go
+++ b/cli/app/transcript_prompt_worker_lifecycle_test.go
@@ -166,6 +166,30 @@ func TestOngoingTranscriptPromptHydrationCancelsOmittedWorker(t *testing.T) {
 	_ = awaitPromptAnswerCommand(t, nextDelivery)
 }
 
+func TestOngoingTranscriptPromptHydrationKeepsRetainedDeliveryWhenDroppingDuplicateOwnership(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	control := newCancellationObservingPromptControl()
+	model := sizedTestUIModel(newProjectedStaticUIModel(), 80, 24)
+	model.promptAnswers = newTranscriptPromptAnswerer(ctx, control)
+	model.ongoingTranscript = newPromptTestOngoingTranscriptController(model, &ongoingSurfaceSpy{})
+
+	prompt := testQuestionPrompt("duplicate-owned-delivery", "Choose", "one")
+	model = deliverPromptHydration(t, model, prompt)
+	model, delivery := startPromptAnswerCommand(t, model)
+	if got := control.nextRequest(t).AskID; got != string(prompt.PromptID) {
+		t.Fatalf("blocked request prompt = %q, want %q", got, prompt.PromptID)
+	}
+	model.ask.queue = append(model.ask.queue, model.transcriptPromptEvent(prompt))
+
+	model = scratchHydratePrompts(t, model, []clientui.TranscriptPrompt{prompt})
+	control.assertNoCancellation(t)
+	control.assertNoRequest(t)
+
+	cancel()
+	_ = awaitPromptAnswerCommand(t, delivery)
+}
+
 func startPromptAnswerCommand(t *testing.T, model *uiModel) (*uiModel, <-chan tea.Msg) {
 	t.Helper()
 	next, command := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -257,6 +281,15 @@ func (c *cancellationObservingPromptControl) nextCancellation(t *testing.T) stri
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for prompt-control cancellation")
 		return ""
+	}
+}
+
+func (c *cancellationObservingPromptControl) assertNoCancellation(t *testing.T) {
+	t.Helper()
+	select {
+	case promptID := <-c.cancellations:
+		t.Fatalf("unexpected prompt-control cancellation for %q", promptID)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/cli/app/transcript_prompt_worker_lifecycle_test.go
+++ b/cli/app/transcript_prompt_worker_lifecycle_test.go
@@ -1,0 +1,321 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"core/cli/tui/ongoing"
+	"core/shared/clientui"
+	"core/shared/serverapi"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestOngoingTranscriptPromptHydrationIsIdempotentWhileAnswerBlocked(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	control := newBlockingPromptControl()
+	ringer := &countRinger{}
+	hooks := newUnfocusedBellHooks(ringer)
+	surface := &ongoingSurfaceSpy{}
+	model := sizedTestUIModel(newProjectedStaticUIModel(WithUITurnQueueHook(hooks)), 80, 24)
+	model.promptAnswers = newTranscriptPromptAnswerer(ctx, control)
+	model.promptAttention = hooks
+	model.ongoingTranscript = newPromptTestOngoingTranscriptController(model, surface)
+
+	first := testQuestionPrompt("ask-1", "Choose once", "first", "second")
+	hydration := ongoingHydrationMessage(1)
+	hydration.Payload.Hydration.RuntimeReadModelUpdate.Activity = clientui.RuntimeActivity{
+		State:          clientui.RuntimeActivityRunning,
+		QueueAccepting: true,
+		ActiveStep: &clientui.RuntimeActiveStep{
+			ActiveKind: clientui.RuntimeActivityActiveKindUserTurn,
+			RunID:      ongoingTestRunID(),
+			StepID:     ongoingTestStepID(),
+		},
+	}
+	hydration.Payload.Hydration.PendingPrompts = []clientui.TranscriptPrompt{first}
+	if err := hydration.Validate(); err != nil {
+		t.Fatalf("validate initial hydration: %v", err)
+	}
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message:         hydration,
+	})
+	if got := ringer.total(); got != 1 {
+		t.Fatalf("initial prompt notification count = %d, want 1", got)
+	}
+	model, firstDelivery := startPromptAnswerCommand(t, model)
+
+	firstRequest := control.nextRequest(t)
+	if got, want := firstRequest.AskID, string(first.PromptID); got != want {
+		t.Fatalf("first answered prompt = %q, want %q", got, want)
+	}
+	if firstRequest.SelectedOptionNumber == nil || *firstRequest.SelectedOptionNumber != 1 {
+		t.Fatalf("first selected option = %v, want 1", firstRequest.SelectedOptionNumber)
+	}
+
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventLoss,
+		SourceSessionID: ongoingTestSessionID(),
+		Err:             errors.New("test scratch hydration"),
+	})
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message:         hydration,
+	})
+	model = updateUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+
+	control.assertNoRequest(t)
+	if got := ringer.total(); got != 1 {
+		t.Fatalf("prompt notification count = %d, want 1", got)
+	}
+	if got := len(surface.lastFrameSectionLines(ongoing.FrameSectionPendingPrompt)); got != 1 {
+		t.Fatalf("pending prompt section cardinality = %d, want 1 before canonical resolution", got)
+	}
+
+	control.release()
+	control.waitForCompletion(t)
+	model = updateUIModel(t, model, awaitPromptAnswerCommand(t, firstDelivery))
+
+	resolved := first
+	resolved.State = clientui.TranscriptPromptStateResolved
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message: clientui.TranscriptMessage{
+			Sequence: 2,
+			Kind:     clientui.TranscriptMessagePromptResolved,
+			Payload:  clientui.TranscriptPayload{PromptResolved: &resolved},
+		},
+	})
+
+	second := testQuestionPrompt("ask-2", "Choose next", "next")
+	second.CreatedAt = first.CreatedAt.Add(time.Second)
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message: clientui.TranscriptMessage{
+			Sequence: 3,
+			Kind:     clientui.TranscriptMessagePromptPending,
+			Payload:  clientui.TranscriptPayload{PromptPending: &second},
+		},
+	})
+	model = updatePromptUIModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+
+	secondRequest := control.nextRequest(t)
+	if got, want := secondRequest.AskID, string(second.PromptID); got != want {
+		t.Fatalf("second answered prompt = %q, want %q", got, want)
+	}
+	control.assertNoRequest(t)
+}
+
+func TestOngoingTranscriptPromptHydrationCancelsOmittedWorker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	control := newCancellationObservingPromptControl()
+	model := sizedTestUIModel(newProjectedStaticUIModel(), 80, 24)
+	model.promptAnswers = newTranscriptPromptAnswerer(ctx, control)
+	model.ongoingTranscript = newPromptTestOngoingTranscriptController(model, &ongoingSurfaceSpy{})
+
+	omitted := testQuestionPrompt("omitted-worker", "Choose", "one")
+	model = deliverPromptHydration(t, model, omitted)
+	model, omittedDelivery := startPromptAnswerCommand(t, model)
+	if got := control.nextRequest(t).AskID; got != string(omitted.PromptID) {
+		t.Fatalf("blocked request prompt = %q, want %q", got, omitted.PromptID)
+	}
+
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventLoss,
+		SourceSessionID: ongoingTestSessionID(),
+		Err:             errors.New("scratch"),
+	})
+	emptyHydration := ongoingHydrationMessage(1)
+	emptyHydration.Payload.Hydration.RuntimeReadModelUpdate.Activity = runningPromptTestActivity()
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message:         emptyHydration,
+	})
+	if got := control.nextCancellation(t); got != string(omitted.PromptID) {
+		t.Fatalf("canceled prompt = %q, want %q", got, omitted.PromptID)
+	}
+	model = updateUIModel(t, model, awaitPromptAnswerCommand(t, omittedDelivery))
+	control.assertNoRequest(t)
+
+	nextPrompt := testQuestionPrompt("after-omission", "Next?", "yes")
+	nextPrompt.CreatedAt = omitted.CreatedAt.Add(time.Second)
+	model = updateUIModel(t, model, ongoingTranscriptEvent{
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message: clientui.TranscriptMessage{
+			Sequence: 2,
+			Kind:     clientui.TranscriptMessagePromptPending,
+			Payload:  clientui.TranscriptPayload{PromptPending: &nextPrompt},
+		},
+	})
+	model, nextDelivery := startPromptAnswerCommand(t, model)
+	if got := control.nextRequest(t).AskID; got != string(nextPrompt.PromptID) {
+		t.Fatalf("next request prompt = %q, want %q", got, nextPrompt.PromptID)
+	}
+	cancel()
+	_ = awaitPromptAnswerCommand(t, nextDelivery)
+}
+
+func startPromptAnswerCommand(t *testing.T, model *uiModel) (*uiModel, <-chan tea.Msg) {
+	t.Helper()
+	next, command := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated, ok := next.(*uiModel)
+	if !ok {
+		t.Fatalf("unexpected model type %T", next)
+	}
+	if command == nil {
+		t.Fatal("prompt answer did not return a delivery command")
+	}
+	completed := make(chan tea.Msg, 1)
+	go func() {
+		completed <- command()
+	}()
+	return updated, completed
+}
+
+func awaitPromptAnswerCommand(t *testing.T, completed <-chan tea.Msg) tea.Msg {
+	t.Helper()
+	select {
+	case message := <-completed:
+		return message
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for prompt answer delivery command")
+		return nil
+	}
+}
+
+type blockingPromptControl struct {
+	requests  chan serverapi.AskAnswerRequest
+	released  chan struct{}
+	completed chan struct{}
+}
+
+type cancellationObservingPromptControl struct {
+	requests      chan serverapi.AskAnswerRequest
+	cancellations chan string
+}
+
+func newCancellationObservingPromptControl() *cancellationObservingPromptControl {
+	return &cancellationObservingPromptControl{
+		requests:      make(chan serverapi.AskAnswerRequest, 4),
+		cancellations: make(chan string, 4),
+	}
+}
+
+func (c *cancellationObservingPromptControl) AnswerAsk(
+	ctx context.Context,
+	request serverapi.AskAnswerRequest,
+) error {
+	c.requests <- request
+	<-ctx.Done()
+	c.cancellations <- request.AskID
+	return ctx.Err()
+}
+
+func (c *cancellationObservingPromptControl) AnswerApproval(
+	context.Context,
+	serverapi.ApprovalAnswerRequest,
+) error {
+	return errors.New("unexpected approval answer")
+}
+
+func (c *cancellationObservingPromptControl) nextRequest(t *testing.T) serverapi.AskAnswerRequest {
+	t.Helper()
+	select {
+	case request := <-c.requests:
+		return request
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for prompt-control request")
+		return serverapi.AskAnswerRequest{}
+	}
+}
+
+func (c *cancellationObservingPromptControl) assertNoRequest(t *testing.T) {
+	t.Helper()
+	select {
+	case request := <-c.requests:
+		t.Fatalf("unexpected delayed prompt-control request: %+v", request)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func (c *cancellationObservingPromptControl) nextCancellation(t *testing.T) string {
+	t.Helper()
+	select {
+	case promptID := <-c.cancellations:
+		return promptID
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for prompt-control cancellation")
+		return ""
+	}
+}
+
+func newBlockingPromptControl() *blockingPromptControl {
+	return &blockingPromptControl{
+		requests:  make(chan serverapi.AskAnswerRequest, 4),
+		released:  make(chan struct{}),
+		completed: make(chan struct{}, 4),
+	}
+}
+
+func (c *blockingPromptControl) AnswerAsk(ctx context.Context, request serverapi.AskAnswerRequest) error {
+	select {
+	case c.requests <- request:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case <-c.released:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	c.completed <- struct{}{}
+	return nil
+}
+
+func (c *blockingPromptControl) AnswerApproval(context.Context, serverapi.ApprovalAnswerRequest) error {
+	return errors.New("unexpected approval answer")
+}
+
+func (c *blockingPromptControl) nextRequest(t *testing.T) serverapi.AskAnswerRequest {
+	t.Helper()
+	select {
+	case request := <-c.requests:
+		return request
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for prompt-control request")
+		return serverapi.AskAnswerRequest{}
+	}
+}
+
+func (c *blockingPromptControl) assertNoRequest(t *testing.T) {
+	t.Helper()
+	select {
+	case request := <-c.requests:
+		t.Fatalf("unexpected duplicate prompt-control request: %+v", request)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func (c *blockingPromptControl) release() {
+	close(c.released)
+}
+
+func (c *blockingPromptControl) waitForCompletion(t *testing.T) {
+	t.Helper()
+	select {
+	case <-c.completed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for prompt-control completion")
+	}
+}

--- a/cli/app/ui_animation_test.go
+++ b/cli/app/ui_animation_test.go
@@ -85,7 +85,7 @@ func TestTranscriptRuntimeProgressStartsAndRearmsSpinner(t *testing.T) {
 			ActiveKind: clientui.RuntimeActivityActiveKindUserTurn,
 		},
 	}
-	next, cmd := m.Update(ongoingTranscriptEvent{Kind: ongoingTranscriptEventMessage, Message: running})
+	next, cmd := m.Update(ongoingTranscriptEvent{Kind: ongoingTranscriptEventMessage, SourceSessionID: ongoingTestSessionID(), Message: running})
 	updated := next.(*uiModel)
 	if !updated.isBusy() || updated.spinnerTickToken == 0 || updated.spinnerTickDue.IsZero() || cmd == nil {
 		t.Fatalf(
@@ -101,8 +101,9 @@ func TestTranscriptRuntimeProgressStartsAndRearmsSpinner(t *testing.T) {
 	updated.spinnerTickDue = anchor.Add(spinnerTickInterval)
 	now = updated.spinnerTickDue.Add(spinnerTickRearmGrace + time.Millisecond)
 	next, cmd = updated.Update(ongoingTranscriptEvent{
-		Kind:    ongoingTranscriptEventMessage,
-		Message: animationAssistantDeltaMessage(3),
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message:         animationAssistantDeltaMessage(3),
 	})
 	updated = next.(*uiModel)
 	if updated.spinnerTickToken == 0 || updated.spinnerTickToken == previousToken {
@@ -127,7 +128,7 @@ func TestTranscriptReviewerLifecycleStartsAndStopsSpinner(t *testing.T) {
 			State:  clientui.ReviewerStateRunning,
 		}},
 	}
-	next, _ := m.Update(ongoingTranscriptEvent{Kind: ongoingTranscriptEventMessage, Message: startedMessage})
+	next, _ := m.Update(ongoingTranscriptEvent{Kind: ongoingTranscriptEventMessage, SourceSessionID: ongoingTestSessionID(), Message: startedMessage})
 	started := next.(*uiModel)
 	if !started.isReviewerRunning() || started.spinnerTickToken == 0 {
 		t.Fatalf("reviewer start did not start spinner: running=%t token=%d", started.isReviewerRunning(), started.spinnerTickToken)
@@ -139,7 +140,7 @@ func TestTranscriptReviewerLifecycleStartsAndStopsSpinner(t *testing.T) {
 		StepID: ongoingTestStepID(),
 		State:  clientui.ReviewerStateCompleted,
 	}
-	next, _ = started.Update(ongoingTranscriptEvent{Kind: ongoingTranscriptEventMessage, Message: completedMessage})
+	next, _ = started.Update(ongoingTranscriptEvent{Kind: ongoingTranscriptEventMessage, SourceSessionID: ongoingTestSessionID(), Message: completedMessage})
 	completed := next.(*uiModel)
 	if completed.isReviewerRunning() || completed.spinnerTickToken != 0 {
 		t.Fatalf("reviewer completion did not stop spinner: running=%t token=%d", completed.isReviewerRunning(), completed.spinnerTickToken)
@@ -156,10 +157,12 @@ func newAnimationTranscriptModel(t *testing.T) *uiModel {
 		m.ongoingFrameInput,
 		runtimeClient.admitTranscriptMessageState,
 		m.applyAdmittedTranscriptMessageState,
+		m,
 	)
 	next, _ := m.Update(ongoingTranscriptEvent{
-		Kind:    ongoingTranscriptEventMessage,
-		Message: ongoingHydrationMessage(1),
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message:         ongoingHydrationMessage(1),
 	})
 	return next.(*uiModel)
 }

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -19,6 +19,29 @@ type uiAskController struct {
 	model *uiModel
 }
 
+func (m *uiModel) reconcileTranscriptPrompts(prompts []clientui.TranscriptPrompt) {
+	if m == nil || m.ongoingTranscript != nil {
+		return
+	}
+	present := make(map[clientui.PromptID]struct{}, len(prompts))
+	for _, prompt := range prompts {
+		present[prompt.PromptID] = struct{}{}
+	}
+	if m.ask.hasCurrent() {
+		if _, ok := present[m.ask.current.prompt.PromptID]; !ok {
+			m.askController().resolvePrompt(m.ask.current.prompt.PromptID)
+		}
+	}
+	for _, queued := range m.ask.queue {
+		if _, ok := present[queued.prompt.PromptID]; !ok {
+			m.askController().resolvePrompt(queued.prompt.PromptID)
+		}
+	}
+	for _, prompt := range prompts {
+		m.askController().acceptEvent(askEvent{prompt: cloneTranscriptPromptForAsk(prompt)})
+	}
+}
+
 type askPromptLineKind int
 
 const (
@@ -55,8 +78,8 @@ func (c uiAskController) acceptEvent(evt askEvent) {
 		c.resolvePrompt(evt.promptID())
 		return
 	}
-	incomingPromptID := strings.TrimSpace(string(evt.prompt.PromptID))
-	if incomingPromptID != "" && m.ask.hasCurrent() && strings.TrimSpace(string(m.ask.current.prompt.PromptID)) == incomingPromptID {
+	incomingPromptID := evt.prompt.PromptID
+	if m.ask.hasCurrent() && m.ask.current.prompt.PromptID == incomingPromptID {
 		m.ask.current.prompt = evt.prompt
 		return
 	}
@@ -71,21 +94,17 @@ func (c uiAskController) acceptEvent(evt askEvent) {
 	m.ask.queue = append(m.ask.queue, evt)
 }
 
-func (c uiAskController) resolvePrompt(promptID string) {
+func (c uiAskController) resolvePrompt(promptID clientui.PromptID) {
 	m := c.model
-	targetID := strings.TrimSpace(promptID)
-	if targetID == "" {
-		return
-	}
 	filteredQueue := m.ask.queue[:0]
 	for _, queued := range m.ask.queue {
-		if strings.TrimSpace(string(queued.prompt.PromptID)) == targetID {
+		if queued.prompt.PromptID == promptID {
 			continue
 		}
 		filteredQueue = append(filteredQueue, queued)
 	}
 	m.ask.queue = filteredQueue
-	if !m.ask.hasCurrent() || strings.TrimSpace(string(m.ask.current.prompt.PromptID)) != targetID {
+	if !m.ask.hasCurrent() || m.ask.current.prompt.PromptID != promptID {
 		return
 	}
 	c.cancelActiveDelivery()
@@ -196,7 +215,10 @@ func (c uiAskController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 						return m, nil
 					}
 					resp = clientui.PromptAnswer{
-						PromptID: string(req.PromptID),
+						PromptID: func() *clientui.PromptID {
+							promptID := req.PromptID
+							return &promptID
+						}(),
 						Approval: &clientui.ApprovalPromptAnswer{Decision: decision, Commentary: commentary},
 					}
 					if decision != clientui.ApprovalDecisionDeny {
@@ -407,17 +429,14 @@ func (c uiAskController) answer(resp clientui.PromptAnswer, err error) (bool, bo
 	if !m.ask.hasCurrent() {
 		return false, false, nil
 	}
-	currentPromptID := strings.TrimSpace(string(m.ask.current.prompt.PromptID))
-	answerPromptID := strings.TrimSpace(resp.PromptID)
-	if answerPromptID != "" && answerPromptID != currentPromptID {
+	currentPromptID := m.ask.current.prompt.PromptID
+	if resp.PromptID != nil && *resp.PromptID != currentPromptID {
 		return false, false, nil
 	}
-	if answerPromptID == "" {
-		resp.PromptID = currentPromptID
-	} else {
-		resp.PromptID = answerPromptID
+	if resp.PromptID == nil {
+		resp.PromptID = &currentPromptID
 	}
-	if m.promptAnswers == nil || m.ask.current.prompt.SessionID.IsZero() || currentPromptID == "" {
+	if m.promptAnswers == nil || m.ask.current.prompt.SessionID.IsZero() {
 		return true, c.resolveAnsweredPromptOptimistically(), nil
 	}
 	active, cmd, deliveryErr := m.promptAnswers.delivery(m.ask.current.prompt, resp, err)

--- a/cli/app/ui_ask_controller.go
+++ b/cli/app/ui_ask_controller.go
@@ -25,6 +25,9 @@ func (m *uiModel) reconcileTranscriptPrompts(prompts []clientui.TranscriptPrompt
 	}
 	present := make(map[clientui.PromptID]struct{}, len(prompts))
 	for _, prompt := range prompts {
+		if _, duplicate := present[prompt.PromptID]; duplicate {
+			panic(fmt.Sprintf("reconcile transcript prompts with duplicate prompt id %q", prompt.PromptID))
+		}
 		present[prompt.PromptID] = struct{}{}
 	}
 	if m.ask.hasCurrent() {
@@ -32,7 +35,8 @@ func (m *uiModel) reconcileTranscriptPrompts(prompts []clientui.TranscriptPrompt
 			m.askController().resolvePrompt(m.ask.current.prompt.PromptID)
 		}
 	}
-	for _, queued := range m.ask.queue {
+	queuedPrompts := append([]askEvent(nil), m.ask.queue...)
+	for _, queued := range queuedPrompts {
 		if _, ok := present[queued.prompt.PromptID]; !ok {
 			m.askController().resolvePrompt(queued.prompt.PromptID)
 		}

--- a/cli/app/ui_general_support_test.go
+++ b/cli/app/ui_general_support_test.go
@@ -53,6 +53,10 @@ func (s stubSessionViewClient) GetSessionExecutionEnvironment(context.Context, s
 
 func updateUIModel(t *testing.T, m *uiModel, msg tea.Msg) *uiModel {
 	t.Helper()
+	if event, ok := msg.(ongoingTranscriptEvent); ok && event.SourceSessionID.IsZero() {
+		event.SourceSessionID = ongoingTestSessionID()
+		msg = event
+	}
 	next, _ := m.Update(msg)
 	updated, ok := next.(*uiModel)
 	if !ok {

--- a/cli/app/ui_general_support_test.go
+++ b/cli/app/ui_general_support_test.go
@@ -53,10 +53,6 @@ func (s stubSessionViewClient) GetSessionExecutionEnvironment(context.Context, s
 
 func updateUIModel(t *testing.T, m *uiModel, msg tea.Msg) *uiModel {
 	t.Helper()
-	if event, ok := msg.(ongoingTranscriptEvent); ok && event.SourceSessionID.IsZero() {
-		event.SourceSessionID = ongoingTestSessionID()
-		msg = event
-	}
 	next, _ := m.Update(msg)
 	updated, ok := next.(*uiModel)
 	if !ok {

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -7,6 +7,7 @@ import (
 	"core/cli/app/internal/runtimeattach"
 	"core/shared/clientui"
 	"core/shared/runtimeids"
+	"core/shared/textutil"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/google/uuid"
@@ -84,19 +85,21 @@ func (m *uiModel) enqueueInjectedInputWithApprovalAnswer(text string, answer *cl
 		return nil
 	}
 	localID := uuid.NewString()
+	approvalCommentaryAnswer := cloneOptionalPromptAnswer(answer)
 	if !m.hasRuntimeClient() {
 		item := clientui.QueuedUserMessage{ID: localID, Text: trimmed}
 		m.pendingInjected = append(m.pendingInjected, item)
-		m.injectedQueue = append(m.injectedQueue, injectedRuntimeQueueItem{LocalID: localID, ServerID: localID, Text: trimmed, State: injectedRuntimeQueueEnqueued})
+		m.injectedQueue = append(m.injectedQueue, injectedRuntimeQueueItem{
+			LocalID:                  localID,
+			ServerID:                 localID,
+			Text:                     trimmed,
+			State:                    injectedRuntimeQueueEnqueued,
+			ApprovalCommentaryAnswer: approvalCommentaryAnswer,
+		})
 		return nil
 	}
 	token := m.nextInjectedQueueToken()
 	clientRequestID := runtimeids.NewRuntimeClientRequestID()
-	var approvalCommentaryAnswer *clientui.PromptAnswer
-	if answer != nil {
-		snap := *answer
-		approvalCommentaryAnswer = &snap
-	}
 	m.pendingInjected = append(m.pendingInjected, clientui.QueuedUserMessage{ID: localID, Text: trimmed, ClientRequestID: clientRequestID.String()})
 	m.injectedQueue = append(m.injectedQueue, injectedRuntimeQueueItem{
 		LocalID:                  localID,
@@ -109,8 +112,21 @@ func (m *uiModel) enqueueInjectedInputWithApprovalAnswer(text string, answer *cl
 	client := m.runtimeClient()
 	return func() tea.Msg {
 		item, err := queueRuntimeUserMessage(client, trimmed, clientRequestID)
-		return injectedQueueCreateDoneMsg{token: token, localID: localID, item: item, approvalCommentaryAnswer: answer, err: err}
+		return injectedQueueCreateDoneMsg{token: token, localID: localID, item: item, err: err}
 	}
+}
+
+func cloneOptionalPromptAnswer(answer *clientui.PromptAnswer) *clientui.PromptAnswer {
+	if answer == nil {
+		return nil
+	}
+	cloned := *answer
+	cloned.PromptID = textutil.Pointer(answer.PromptID)
+	if answer.Approval != nil {
+		approval := *answer.Approval
+		cloned.Approval = &approval
+	}
+	return &cloned
 }
 
 func queueRuntimeUserMessage(client clientui.RuntimeClient, text string, clientRequestID runtimeids.RuntimeClientRequestID) (clientui.QueuedUserMessage, error) {
@@ -464,9 +480,7 @@ func (c uiInputController) handleInjectedQueueCreateDone(msg injectedQueueCreate
 		return m, nil
 	}
 	approvalCommentaryAnswer := item.ApprovalCommentaryAnswer
-	if approvalCommentaryAnswer == nil {
-		approvalCommentaryAnswer = msg.approvalCommentaryAnswer
-	}
+	item.ApprovalCommentaryAnswer = nil
 	m.observeRuntimeRequestResult(msg.err)
 	if msg.err != nil {
 		m.injectedQueue[index].State = injectedRuntimeQueueCreateFailed
@@ -498,7 +512,6 @@ func (c uiInputController) handleInjectedQueueCreateDone(msg injectedQueueCreate
 	item.ServerID = serverID
 	item.Text = serverText
 	item.ClientRequestID = strings.TrimSpace(msg.item.ClientRequestID)
-	item.ApprovalCommentaryAnswer = nil
 	switch item.State {
 	case injectedRuntimeQueuePendingCreate:
 		item.State = injectedRuntimeQueueEnqueued
@@ -521,6 +534,27 @@ func (c uiInputController) handleInjectedQueueCreateDone(msg injectedQueueCreate
 		m.injectedQueue[index] = item
 	}
 	return m, nil
+}
+
+func (m *uiModel) consumeApprovalCommentaryAnswer(promptID clientui.PromptID) *clientui.PromptAnswer {
+	for index := range m.injectedQueue {
+		answer := m.injectedQueue[index].ApprovalCommentaryAnswer
+		if answer == nil || answer.PromptID == nil || *answer.PromptID != promptID {
+			continue
+		}
+		m.injectedQueue[index].ApprovalCommentaryAnswer = nil
+		return answer
+	}
+	return nil
+}
+
+func (m *uiModel) clearApprovalCommentaryAnswer(promptID clientui.PromptID) {
+	for index := range m.injectedQueue {
+		answer := m.injectedQueue[index].ApprovalCommentaryAnswer
+		if answer != nil && answer.PromptID != nil && *answer.PromptID == promptID {
+			m.injectedQueue[index].ApprovalCommentaryAnswer = nil
+		}
+	}
 }
 
 func (c uiInputController) handleInjectedQueueDiscardDone(msg injectedQueueDiscardDoneMsg) (tea.Model, tea.Cmd) {

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -7,7 +7,6 @@ import (
 	"core/cli/app/internal/runtimeattach"
 	"core/shared/clientui"
 	"core/shared/runtimeids"
-	"core/shared/textutil"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/google/uuid"
@@ -120,12 +119,7 @@ func cloneOptionalPromptAnswer(answer *clientui.PromptAnswer) *clientui.PromptAn
 	if answer == nil {
 		return nil
 	}
-	cloned := *answer
-	cloned.PromptID = textutil.Pointer(answer.PromptID)
-	if answer.Approval != nil {
-		approval := *answer.Approval
-		cloned.Approval = &approval
-	}
+	cloned := clonePromptAnswer(*answer)
 	return &cloned
 }
 

--- a/cli/app/ui_loop.go
+++ b/cli/app/ui_loop.go
@@ -160,6 +160,8 @@ func composeUIProgram(request uiLoopRequest, output io.Writer) (*uiProgramCompos
 		model.ongoingFrameInput,
 		sessionClient.admitTranscriptMessageState,
 		model.applyAdmittedTranscriptMessageState,
+		model,
+		uiLogger,
 	)
 	return &uiProgramComposition{
 		model:   model,

--- a/cli/app/ui_messages.go
+++ b/cli/app/ui_messages.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"os/exec"
-	"strings"
 	"time"
 
 	"core/shared/clientui"
@@ -227,18 +226,18 @@ type clipboardTextCopyDoneMsg struct {
 
 type askEvent struct {
 	prompt           clientui.TranscriptPrompt
-	resolvedPromptID clientui.PromptID
+	resolvedPromptID *clientui.PromptID
 }
 
-func (e askEvent) promptID() string {
-	if strings.TrimSpace(string(e.resolvedPromptID)) != "" {
-		return strings.TrimSpace(string(e.resolvedPromptID))
+func (e askEvent) promptID() clientui.PromptID {
+	if e.resolvedPromptID != nil {
+		return *e.resolvedPromptID
 	}
-	return strings.TrimSpace(string(e.prompt.PromptID))
+	return e.prompt.PromptID
 }
 
 func (e askEvent) isResolution() bool {
-	return strings.TrimSpace(string(e.resolvedPromptID)) != ""
+	return e.resolvedPromptID != nil
 }
 
 type askEventMsg struct {

--- a/cli/app/ui_ongoing_ownership_test.go
+++ b/cli/app/ui_ongoing_ownership_test.go
@@ -15,7 +15,7 @@ import (
 func TestOngoingSurfaceTransitionQueuesTranscriptWhileDetailActive(t *testing.T) {
 	surface := &ongoingSurfaceSpy{}
 	controller := newNoopOngoingTranscriptController(surface, ongoingTestFrameProvider)
-	if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
 	surface.calls = nil
@@ -24,7 +24,7 @@ func TestOngoingSurfaceTransitionQueuesTranscriptWhileDetailActive(t *testing.T)
 	if cmd := m.activateSurface(uiSurfaceTranscriptDetail); cmd == nil {
 		t.Fatal("expected detail activation command")
 	}
-	if _, _, err := controller.Accept(ongoingTranscriptMessage(2, clientui.TranscriptMessageRuntimeReadModelUpdate)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingTranscriptMessage(2, clientui.TranscriptMessageRuntimeReadModelUpdate)); err != nil {
 		t.Fatalf("accept detail queued message: %v", err)
 	}
 	if len(surface.calls) != 0 {
@@ -50,7 +50,7 @@ func TestOngoingSurfaceTransitionQueuesTranscriptWhileDetailActive(t *testing.T)
 func TestTranscriptModeTransitionMarksOngoingUnowned(t *testing.T) {
 	surface := &ongoingSurfaceSpy{}
 	controller := newNoopOngoingTranscriptController(surface, ongoingTestFrameProvider)
-	if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
 	surface.calls = nil
@@ -60,7 +60,7 @@ func TestTranscriptModeTransitionMarksOngoingUnowned(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("transition to detail did not return alt-screen command")
 	}
-	if _, _, err := controller.Accept(ongoingTranscriptMessage(2, clientui.TranscriptMessageRuntimeReadModelUpdate)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingTranscriptMessage(2, clientui.TranscriptMessageRuntimeReadModelUpdate)); err != nil {
 		t.Fatalf("accept detail queued message: %v", err)
 	}
 
@@ -72,14 +72,14 @@ func TestTranscriptModeTransitionMarksOngoingUnowned(t *testing.T) {
 func TestTranscriptModeReturnDrainsOngoingOnlyAfterPostExitMessage(t *testing.T) {
 	surface := &ongoingSurfaceSpy{}
 	controller := newNoopOngoingTranscriptController(surface, ongoingTestFrameProvider)
-	if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
 	m := newProjectedStaticUIModel(withUIOngoingTranscriptController(controller))
 	if cmd := m.transitionTranscriptModeWithOptions(transcriptModeTransitionOptions{target: tui.ModeDetail}); cmd == nil {
 		t.Fatal("transition to detail did not return alt-screen command")
 	}
-	if _, _, err := controller.Accept(ongoingTranscriptMessage(2, clientui.TranscriptMessageRuntimeReadModelUpdate)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingTranscriptMessage(2, clientui.TranscriptMessageRuntimeReadModelUpdate)); err != nil {
 		t.Fatalf("accept queued message: %v", err)
 	}
 	surface.calls = nil
@@ -102,14 +102,14 @@ func TestTranscriptModeReturnDrainsOngoingOnlyAfterPostExitMessage(t *testing.T)
 func TestDetailReturnKeyDoesNotRenderOngoingBeforePostExitMessage(t *testing.T) {
 	surface := &ongoingSurfaceSpy{}
 	controller := newNoopOngoingTranscriptController(surface, ongoingTestFrameProvider)
-	if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
 	m := newProjectedStaticUIModel(withUIOngoingTranscriptController(controller))
 	if cmd := m.transitionTranscriptModeWithOptions(transcriptModeTransitionOptions{target: tui.ModeDetail}); cmd == nil {
 		t.Fatal("transition to detail did not return alt-screen command")
 	}
-	if _, _, err := controller.Accept(ongoingTranscriptMessage(2, clientui.TranscriptMessageRuntimeReadModelUpdate)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingTranscriptMessage(2, clientui.TranscriptMessageRuntimeReadModelUpdate)); err != nil {
 		t.Fatalf("accept queued message: %v", err)
 	}
 	surface.calls = nil
@@ -139,7 +139,7 @@ func TestScratchResetWhileDetailActiveDefersRawSurfaceWriteUntilOngoingOwnsTermi
 	}
 	raw.Reset()
 	controller := newNoopOngoingTranscriptController(&ongoingSurfaceSpy{}, ongoingTestFrameProvider)
-	if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
 	reopenCount := 0

--- a/cli/app/ui_ongoing_reducer.go
+++ b/cli/app/ui_ongoing_reducer.go
@@ -39,7 +39,7 @@ func (m *uiModel) handleOngoingTranscriptEvent(event ongoingTranscriptEvent) tea
 	switch event.Kind {
 	case ongoingTranscriptEventMessage:
 		var stateCmd tea.Cmd
-		result, stateCmd, err = m.ongoingTranscript.Accept(event.Message)
+		result, stateCmd, err = m.ongoingTranscript.AcceptFrom(event.SourceSessionID, event.Message)
 		if err != nil {
 			var developerErr ongoing.DeveloperError
 			if errors.As(err, &developerErr) {

--- a/cli/app/ui_ongoing_resize_test.go
+++ b/cli/app/ui_ongoing_resize_test.go
@@ -61,7 +61,7 @@ func TestWindowResizeWhileDetailOwnsTerminalRepaintsOnReturn(t *testing.T) {
 			), 80, 24)
 			controller := newNoopOngoingTranscriptController(surface, m.ongoingFrameInput)
 			m.ongoingTranscript = controller
-			if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+			if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil {
 				t.Fatalf("accept hydration: %v", err)
 			}
 
@@ -124,7 +124,7 @@ func TestAppleTerminalWidthResizeWhileDetailOwnsTerminalRehydratesOnReturn(t *te
 	raw.Reset()
 	surface := &ongoingSurfaceSpy{}
 	controller := newNoopOngoingTranscriptController(surface, ongoingTestFrameProvider)
-	if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
 	reopenCount := 0
@@ -178,10 +178,10 @@ func TestWindowResizeKeepsControllerLiveFrameSections(t *testing.T) {
 		WithUIOngoingSurface(nativeSurface),
 	), 40, 10)
 	m.ongoingTranscript = newNoopOngoingTranscriptController(surface, m.ongoingFrameInput)
-	if _, _, err := m.ongoingTranscript.Accept(ongoingHydrationMessage(1)); err != nil {
+	if _, _, err := m.ongoingTranscript.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
-	if _, _, err := m.ongoingTranscript.Accept(ongoingTranscriptMessage(2, clientui.TranscriptMessagePromptPending)); err != nil {
+	if _, _, err := m.ongoingTranscript.AcceptFrom(ongoingTestSessionID(), ongoingTranscriptMessage(2, clientui.TranscriptMessagePromptPending)); err != nil {
 		t.Fatalf("accept pending prompt: %v", err)
 	}
 	surface.calls = nil

--- a/cli/app/ui_ongoing_surface_test.go
+++ b/cli/app/ui_ongoing_surface_test.go
@@ -86,8 +86,9 @@ func TestNativeOngoingHydrationWaitsForWindowSize(t *testing.T) {
 
 	_ = m.Init()
 	_, _ = m.Update(ongoingTranscriptEvent{
-		Kind:    ongoingTranscriptEventMessage,
-		Message: ongoingHydrationMessage(1),
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message:         ongoingHydrationMessage(1),
 	})
 	if len(spySurface.calls) != 0 {
 		t.Fatalf("surface calls before window size = %v, want none", spySurface.callKinds())
@@ -116,8 +117,9 @@ func TestOngoingTranscriptEventReachesNativeSurface(t *testing.T) {
 	}
 	hydration.Payload.Hydration.CommittedRows[0].User.Text = "hydrated row"
 	_, cmd := m.Update(ongoingTranscriptEvent{
-		Kind:    ongoingTranscriptEventMessage,
-		Message: hydration,
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message:         hydration,
 	})
 
 	if cmd != nil {
@@ -138,7 +140,7 @@ func TestOngoingTranscriptDeliveryKeepsCursorAbsentForAskOptionPicker(t *testing
 	testSetMainInput(m, strings.Repeat("x", 91))
 	m.ongoingTranscript = newNoopOngoingTranscriptController(surface, m.ongoingFrameInput)
 
-	if _, _, err := m.ongoingTranscript.Accept(ongoingHydrationMessage(1)); err != nil {
+	if _, _, err := m.ongoingTranscript.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
 	next, _ := m.Update(askEventMsg{event: testQuestionAskEvent(
@@ -162,7 +164,7 @@ func TestOngoingTranscriptDeliveryKeepsCursorAbsentForAskOptionPicker(t *testing
 		t.Fatalf("ask option picker cursor = %+v, want absent", got)
 	}
 
-	if _, _, err := m.ongoingTranscript.Accept(clientui.TranscriptMessage{
+	if _, _, err := m.ongoingTranscript.AcceptFrom(ongoingTestSessionID(), clientui.TranscriptMessage{
 		Sequence: 2,
 		Kind:     clientui.TranscriptMessageAssistantDelta,
 		Payload: clientui.TranscriptPayload{
@@ -190,10 +192,10 @@ func TestNativeOngoingRepaintKeepsControllerLiveFrameSections(t *testing.T) {
 		WithUIOngoingSurface(nativeSurface),
 	), 40, 10)
 	m.ongoingTranscript = newNoopOngoingTranscriptController(spySurface, m.ongoingFrameInput)
-	if _, _, err := m.ongoingTranscript.Accept(ongoingHydrationMessage(1)); err != nil {
+	if _, _, err := m.ongoingTranscript.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
-	if _, _, err := m.ongoingTranscript.Accept(ongoingTranscriptMessage(2, clientui.TranscriptMessagePromptPending)); err != nil {
+	if _, _, err := m.ongoingTranscript.AcceptFrom(ongoingTestSessionID(), ongoingTranscriptMessage(2, clientui.TranscriptMessagePromptPending)); err != nil {
 		t.Fatalf("accept pending prompt: %v", err)
 	}
 	spySurface.calls = nil
@@ -319,7 +321,7 @@ func TestScratchRehydrationResultRequestsTranscriptReopen(t *testing.T) {
 	var out bytes.Buffer
 	surface := ongoing.NewSurface(&out)
 	controller := newNoopOngoingTranscriptController(surface, ongoingTestFrameProvider)
-	if _, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil {
 		t.Fatalf("accept hydration: %v", err)
 	}
 	reopened := false
@@ -340,7 +342,7 @@ func TestScratchRehydrationResultRequestsTranscriptReopen(t *testing.T) {
 	if !reopened {
 		t.Fatal("scratch rehydration did not request transcript subscription reopen")
 	}
-	if result, _, err := controller.Accept(ongoingHydrationMessage(1)); err != nil || result.Action != ongoing.ResultNoop {
+	if result, _, err := controller.AcceptFrom(ongoingTestSessionID(), ongoingHydrationMessage(1)); err != nil || result.Action != ongoing.ResultNoop {
 		t.Fatalf("post-reopen hydration result=%+v err=%v, want accepted hydration", result, err)
 	}
 }

--- a/cli/app/ui_ongoing_transcript_state.go
+++ b/cli/app/ui_ongoing_transcript_state.go
@@ -55,11 +55,9 @@ func (m *uiModel) applyAdmittedTranscriptMessageState(
 			return m.requestProcessListRefresh()
 		}
 	case clientui.TranscriptMessagePromptPending:
-		prompt := *message.Payload.PromptPending
-		m.askController().acceptEvent(m.transcriptPromptEvent(prompt))
-		notifyTranscriptPromptFallback(m.promptAttention, prompt, clientui.AttentionNotificationSourceLive)
+		// The ongoing transcript controller commits prepared prompt reconciliation.
 	case clientui.TranscriptMessagePromptResolved:
-		m.askController().resolvePrompt(string(message.Payload.PromptResolved.PromptID))
+		// The ongoing transcript controller commits prepared prompt reconciliation.
 	case clientui.TranscriptMessageWorktreeTransitionOutcome:
 		return m.reconcileTranscriptWorktreeTransitionOutcome(*message.Payload.WorktreeTransitionOutcome)
 	case clientui.TranscriptMessageOperationalDiagnostic:
@@ -94,7 +92,6 @@ func (m *uiModel) applyTranscriptHydration(
 	}
 
 	m.reconcileTranscriptQueuedMessages(hydration.QueuedMessages)
-	m.reconcileTranscriptPrompts(hydration.PendingPrompts)
 	for _, background := range hydration.BackgroundActivities {
 		m.applyTranscriptBackgroundActivity(background)
 	}
@@ -330,33 +327,6 @@ func (m *uiModel) transcriptPromptEvent(prompt clientui.TranscriptPrompt) askEve
 	}
 	return askEvent{
 		prompt: cloneTranscriptPromptForAsk(prompt),
-	}
-}
-
-func (m *uiModel) reconcileTranscriptPrompts(prompts []clientui.TranscriptPrompt) {
-	present := make(map[string]struct{}, len(prompts))
-	for _, prompt := range prompts {
-		present[string(prompt.PromptID)] = struct{}{}
-	}
-	var stale []string
-	if m.ask.hasCurrent() {
-		id := m.ask.current.promptID()
-		if _, exists := present[id]; !exists {
-			stale = append(stale, id)
-		}
-	}
-	for _, queued := range m.ask.queue {
-		id := queued.promptID()
-		if _, exists := present[id]; !exists {
-			stale = append(stale, id)
-		}
-	}
-	for _, id := range stale {
-		m.askController().resolvePrompt(id)
-	}
-	for _, prompt := range prompts {
-		m.askController().acceptEvent(m.transcriptPromptEvent(prompt))
-		notifyTranscriptPromptFallback(m.promptAttention, prompt, clientui.AttentionNotificationSourceSnapshot)
 	}
 }
 

--- a/cli/app/ui_runtime_tuple_hydration_test.go
+++ b/cli/app/ui_runtime_tuple_hydration_test.go
@@ -34,6 +34,7 @@ func TestStaleContentCompleteHydrationFailsBeforeAnySideEffect(t *testing.T) {
 		m.ongoingFrameInput,
 		runtimeClient.admitTranscriptMessageState,
 		m.applyAdmittedTranscriptMessageState,
+		m,
 	)
 	beforeView := runtimeClient.MainView()
 	beforeActivity := m.runtimeActivityProjection
@@ -43,7 +44,7 @@ func TestStaleContentCompleteHydrationFailsBeforeAnySideEffect(t *testing.T) {
 	beforeAsk := m.ask
 
 	hydration := runtimeTupleTestRichHydration(10)
-	_, cmd, err := controller.Accept(hydration)
+	_, cmd, err := controller.AcceptFrom(ongoingTestSessionID(), hydration)
 	assertRuntimeTupleHydrationError(t, err)
 	if cmd != nil {
 		t.Fatal("stale hydration returned a state command")
@@ -86,6 +87,7 @@ func TestStaleHydrationDeveloperErrorPanicsInEveryModeBeforeSideEffects(t *testi
 				m.ongoingFrameInput,
 				runtimeClient.admitTranscriptMessageState,
 				m.applyAdmittedTranscriptMessageState,
+				m,
 			)
 			beforeView := runtimeClient.MainView()
 			beforeQueue := append([]queuedInputItem(nil), m.queued...)
@@ -93,8 +95,9 @@ func TestStaleHydrationDeveloperErrorPanicsInEveryModeBeforeSideEffects(t *testi
 
 			recovered := capturePanic(func() {
 				_ = m.handleOngoingTranscriptEvent(ongoingTranscriptEvent{
-					Kind:    ongoingTranscriptEventMessage,
-					Message: hydration,
+					Kind:            ongoingTranscriptEventMessage,
+					SourceSessionID: ongoingTestSessionID(),
+					Message:         hydration,
 				})
 			})
 			developerErr, ok := recovered.(ongoing.DeveloperError)
@@ -152,10 +155,11 @@ func TestNonStaleContentCompleteHydrationAppliesWholeEvent(t *testing.T) {
 		m.ongoingFrameInput,
 		runtimeClient.admitTranscriptMessageState,
 		m.applyAdmittedTranscriptMessageState,
+		m,
 	)
 	hydration := runtimeTupleTestRichHydration(11)
 
-	if _, _, err := controller.Accept(hydration); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), hydration); err != nil {
 		t.Fatalf("accept current hydration: %v", err)
 	}
 
@@ -204,12 +208,14 @@ func TestAcceptedHydrationDoesNotAdvanceCacheWithUnaryRead(t *testing.T) {
 		m.ongoingFrameInput,
 		runtimeClient.admitTranscriptMessageState,
 		m.applyAdmittedTranscriptMessageState,
+		m,
 	)
 	hydration := runtimeTupleTestRichHydration(11)
 
 	cmd := m.handleOngoingTranscriptEvent(ongoingTranscriptEvent{
-		Kind:    ongoingTranscriptEventMessage,
-		Message: hydration,
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message:         hydration,
 	})
 
 	if got := reads.mainViewCount.Load(); got != 0 {
@@ -251,15 +257,17 @@ func TestRejectedDuplicateHydrationDoesNotStartUnaryRefresh(t *testing.T) {
 		m.ongoingFrameInput,
 		runtimeClient.admitTranscriptMessageState,
 		m.applyAdmittedTranscriptMessageState,
+		m,
 	)
 	hydration := runtimeTupleTestRichHydration(11)
-	if _, _, err := m.ongoingTranscript.Accept(hydration); err != nil {
+	if _, _, err := m.ongoingTranscript.AcceptFrom(ongoingTestSessionID(), hydration); err != nil {
 		t.Fatalf("accept initial hydration: %v", err)
 	}
 
 	cmd := m.handleOngoingTranscriptEvent(ongoingTranscriptEvent{
-		Kind:    ongoingTranscriptEventMessage,
-		Message: hydration,
+		Kind:            ongoingTranscriptEventMessage,
+		SourceSessionID: ongoingTestSessionID(),
+		Message:         hydration,
 	})
 	_ = collectCmdMessages(t, cmd)
 
@@ -296,11 +304,12 @@ func TestHydrationAdmissionSerializesUnaryAndInterruptTupleCommitsUntilWholeEven
 		m.ongoingFrameInput,
 		runtimeClient.admitTranscriptMessageState,
 		m.applyAdmittedTranscriptMessageState,
+		m,
 	)
 	hydration := runtimeTupleTestRichHydration(11)
 	acceptDone := make(chan error, 1)
 	go func() {
-		_, _, err := controller.Accept(hydration)
+		_, _, err := controller.AcceptFrom(ongoingTestSessionID(), hydration)
 		acceptDone <- err
 	}()
 	<-surface.started

--- a/cli/app/ui_runtime_tuple_regression_test.go
+++ b/cli/app/ui_runtime_tuple_regression_test.go
@@ -23,8 +23,9 @@ func TestDelayedTranscriptRuntimeTupleCannotRollBackNewerUnaryState(t *testing.T
 		m.ongoingFrameInput,
 		runtimeClient.admitTranscriptMessageState,
 		m.applyAdmittedTranscriptMessageState,
+		m,
 	)
-	if _, _, err := controller.Accept(runtimeTupleTestHydration(9, runtimeTupleTestIdleActivity(), v9.InputReconciliation)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), runtimeTupleTestHydration(9, runtimeTupleTestIdleActivity(), v9.InputReconciliation)); err != nil {
 		t.Fatalf("accept initial hydration: %v", err)
 	}
 
@@ -32,7 +33,7 @@ func TestDelayedTranscriptRuntimeTupleCannotRollBackNewerUnaryState(t *testing.T
 	canonical := runtimeClient.storeMainView(v11)
 	m.applyRuntimeMainViewState(canonical)
 	delayed := runtimeTupleTestUpdateMessage(2, 10, runtimeTupleTestRunningActivity(), runtimeTupleTestReconciliation(clientui.RuntimeInputReconciliationUnknown))
-	if _, cmd, err := controller.Accept(delayed); err != nil {
+	if _, cmd, err := controller.AcceptFrom(ongoingTestSessionID(), delayed); err != nil {
 		t.Fatalf("accept delayed runtime update: %v", err)
 	} else if cmd != nil {
 		t.Fatal("lower-sequence runtime update scheduled an unexpected refresh")
@@ -78,8 +79,9 @@ func TestRuntimeMainViewRefreshCommitsOnlyWhenReducerHandlesCandidate(t *testing
 		m.ongoingFrameInput,
 		runtimeClient.admitTranscriptMessageState,
 		m.applyAdmittedTranscriptMessageState,
+		m,
 	)
-	if _, _, err := controller.Accept(runtimeTupleTestHydration(9, v9.Activity, v9.InputReconciliation)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), runtimeTupleTestHydration(9, v9.Activity, v9.InputReconciliation)); err != nil {
 		t.Fatalf("accept initial hydration: %v", err)
 	}
 
@@ -97,7 +99,7 @@ func TestRuntimeMainViewRefreshCommitsOnlyWhenReducerHandlesCandidate(t *testing
 	}
 
 	v11 := runtimeTupleTestView(11, runtimeTupleTestIdleActivity(), runtimeTupleTestReconciliation(clientui.RuntimeInputReconciliationCommitted))
-	if _, _, err := controller.Accept(runtimeTupleTestUpdateMessage(2, 11, v11.Activity, v11.InputReconciliation)); err != nil {
+	if _, _, err := controller.AcceptFrom(ongoingTestSessionID(), runtimeTupleTestUpdateMessage(2, 11, v11.Activity, v11.InputReconciliation)); err != nil {
 		t.Fatalf("accept newer transcript update: %v", err)
 	}
 	m.handleRuntimeMainViewRefreshed(msg)

--- a/cli/app/ui_state_test_helpers_test.go
+++ b/cli/app/ui_state_test_helpers_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"cmp"
+	"slices"
 	"testing"
 
 	"core/shared/clientui"
@@ -134,7 +136,29 @@ func resolveAnsweredTestAskThroughTranscript(t *testing.T, m *uiModel) {
 	if err := message.Validate(); err != nil {
 		t.Fatalf("validate prompt resolution transcript message: %v", err)
 	}
-	if cmd := m.applyAdmittedTranscriptMessageState(message, runtimeTupleMergeResult{}); cmd != nil {
-		t.Fatal("prompt resolution transcript message unexpectedly returned a command")
+	if m.ongoingTranscript == nil {
+		m.ongoingTranscript = newPromptTestOngoingTranscriptController(m, &ongoingSurfaceSpy{})
+	}
+	hydration := ongoingHydrationMessage(1)
+	hydration.Payload.Hydration.RuntimeReadModelUpdate.Activity = runningPromptTestActivity()
+	ownership := m.snapshotTranscriptPromptOwnership()
+	hydration.Payload.Hydration.PendingPrompts = make([]clientui.TranscriptPrompt, 0, len(ownership.events))
+	for _, event := range ownership.events {
+		hydration.Payload.Hydration.PendingPrompts = append(
+			hydration.Payload.Hydration.PendingPrompts,
+			cloneTranscriptPromptForAsk(event.prompt),
+		)
+	}
+	slices.SortFunc(hydration.Payload.Hydration.PendingPrompts, func(left, right clientui.TranscriptPrompt) int {
+		if order := left.CreatedAt.Compare(right.CreatedAt); order != 0 {
+			return order
+		}
+		return cmp.Compare(left.PromptID, right.PromptID)
+	})
+	if _, _, err := m.ongoingTranscript.AcceptFrom(ongoingTestSessionID(), hydration); err != nil {
+		t.Fatalf("accept prompt hydration: %v", err)
+	}
+	if _, _, err := m.ongoingTranscript.AcceptFrom(ongoingTestSessionID(), message); err != nil {
+		t.Fatalf("accept prompt resolution: %v", err)
 	}
 }

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -119,6 +119,9 @@
 - Source origin is not labeled in UI.
 - Answers are persisted as explicit summary text including selected option number and commentary.
 - Ask queue semantics are strict FIFO and in-memory only. Each submission snapshots an immutable answer payload. During delivery, the visible editor may hold a separate editable retry draft; changes apply only to a future submission after delivery fails, and canonical prompt resolution discards the draft.
+- Prompt/tool-call IDs are unique for the full lifetime of a session; same-session ID reuse is unsupported.
+- A repeated prompt ID must preserve its immutable session, kind, step, creation time, and tool-provenance contract. A mismatch is a developer error.
+- This contract has no prompt-incarnation protocol or server-side session-lifetime seen-ID guard. The theoretical delayed-answer ABA risk from a contract-violating external/provider ID is accepted.
 - Optional post-answer action binding uses typed registry with stable ID, payload schema, and handler.
 
 ## Sessions And Persistence

--- a/server/worktree/service_part2_test.go
+++ b/server/worktree/service_part2_test.go
@@ -322,7 +322,8 @@ func TestNextAvailableWorktreeRootFailsAfterCollisionCap(t *testing.T) {
 
 func newServiceTestEnv(t *testing.T) *serviceTestEnv {
 	t.Helper()
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(worktreeTestContext)
+	t.Cleanup(cancel)
 	home := t.TempDir()
 	workspace := t.TempDir()
 	t.Setenv("HOME", home)

--- a/server/worktree/service_test.go
+++ b/server/worktree/service_test.go
@@ -327,9 +327,12 @@ func TestCreateWorktreeBlocksUntilSetupCompletesBeforeSessionSwitch(t *testing.T
 		resp serverapi.WorktreeCreateResponse
 		err  error
 	}
+	createCtx, cancelCreate := context.WithCancel(env.ctx)
 	resultCh := make(chan createResult, 1)
+	createDone := make(chan struct{})
 	go func() {
-		resp, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+		defer close(createDone)
+		resp, err := env.service.CreateWorktree(createCtx, serverapi.WorktreeCreateRequest{
 			SetupOperationID: setupID,
 			ClientRequestID:  "req-create-blocking",
 			SessionID:        env.session.Meta().SessionID,
@@ -339,6 +342,14 @@ func TestCreateWorktreeBlocksUntilSetupCompletesBeforeSessionSwitch(t *testing.T
 		})
 		resultCh <- createResult{resp: resp, err: err}
 	}()
+	t.Cleanup(func() {
+		cancelCreate()
+		select {
+		case <-createDone:
+		case <-time.After(5 * time.Second):
+			t.Error("timed out cleaning up blocked CreateWorktree")
+		}
+	})
 
 	started := waitForFileText(t, startedPath)
 	if started != "started" {

--- a/server/worktree/testmain_test.go
+++ b/server/worktree/testmain_test.go
@@ -1,0 +1,19 @@
+package worktree
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+)
+
+var worktreeTestContext = context.Background()
+
+func TestMain(m *testing.M) {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	worktreeTestContext = ctx
+	exitCode := m.Run()
+	stop()
+	os.Exit(exitCode)
+}

--- a/shared/clientui/prompt_answer.go
+++ b/shared/clientui/prompt_answer.go
@@ -1,7 +1,7 @@
 package clientui
 
 type PromptAnswer struct {
-	PromptID             string
+	PromptID             *PromptID
 	ErrorMessage         string
 	Answer               string
 	SelectedOptionNumber *int


### PR DESCRIPTION
## Summary

- Reconcile hydrated and live prompts by exact typed prompt identity before mutating UI ownership, preserving one worker and one in-flight answer per prompt.
- Keep authoritative FIFO hydration order while retaining meaningful drafts or active deliveries, cancel omitted/resolved workers, and deduplicate fallback notifications.
- Enforce source-session authority and the locked session-lifetime prompt/tool-call ID contract with structured developer diagnostics.
- Make worktree test subprocess ownership signal-aware so wall-clock timeout cleanup cancels and joins blocking setup work.
- Address PR review findings by preserving retained same-ID deliveries during duplicate recovery, validating runtime session IDs before activation, rejecting stale deliveries before reconciliation, and hardening fallback prompt reconciliation.

## Verification

- `./scripts/test.sh ./cli/app -count=1` — passed after the review fixes (15.3s); the pre-review branch also passed twice after its final rebase.
- `./scripts/test.sh ./cli/app -race -run 'Test(Ongoing)?TranscriptPrompt|TestFallbackTranscriptPromptReconciliation' -count=1` — passed.
- `./scripts/test.sh tui` — passed.
- `./scripts/test.sh ./server/worktree -count=1` — passed.
- `./scripts/build.sh --output ./bin/kent` — passed.
- Forced one-second timeout of `TestCreateWorktreeBlocksUntilSetupCompletesBeforeSessionSwitch` — timed out as intended; no `worktree.test` or `blocking-setup.sh` process remained after cleanup.
- `bash -n scripts/test.sh`, `gofmt`, and `git diff --check` — passed.

Review-specific regressions cover retained active delivery during duplicate ownership cleanup, stale contract-mismatch delivery rejection, invalid runtime session IDs before activation, duplicate fallback IDs without partial commit, and removal of every omitted queued fallback prompt.

## Completion evidence

- `.kent/plans/KENT-268-prompt-hydration-idempotent.md` contains the acceptance criteria and four completed review-remediation checklists. It is intentionally ignored local workflow evidence, so GitHub CLI cannot attach it directly.
- `docs/dev/specs/core-runtime-tools.md` records the approved session-unique prompt/tool-call-ID contract and accepted ABA tradeoff.
- Kent task comment `comment-b8786f0c-95be-4bc8-851d-49366bcab971` records the original 120-second timeout and leaked blocking-setup child; the final repeated and forced-timeout checks above verify that failure is resolved.

## LoC

Classified `_test.go`, testdata, and generated paths as test/generated. Documentation/spec changes are included with production/docs. No generated files changed.

- Production/docs: `+795 / -114`; net `+681`; gross `909`.
- Test/generated: `+1629 / -71`; net `+1558`; gross `1700`.
- Total: `+2424 / -185`; net `+2239`; gross `2609`.

## Caveats and tradeoffs

- Same-session prompt/tool-call ID reuse remains unsupported by product contract. Immutable contract mismatches fail fast; there is deliberately no incarnation protocol or server lifetime seen-ID ledger.
- The theoretical delayed-answer ABA case is accepted only for a contract-violating external/provider ID.
- Prompt reconciliation is intentionally client-side and in-memory; the server prompt store and wire protocol are unchanged.
- Delivery sequencing now rejects stale/out-of-order events before prompt reconciliation. Runtime admission remains after side-effect-free prompt planning because it mutates the runtime-view cache; moving it earlier would violate atomic mismatch handling.
- Structurally valid same-ID immutable-contract mismatches retain their required developer-error precedence. Invalid authoritative hydration still cannot commit duplicate prompt ownership because message validation runs before delivery/state/prompt commit.
- No GitHub issue was identified for this work. The addressed Kent task is `KENT-268`.

## Suggested follow-up

- If provider-generated prompt ID reuse is ever observed, treat it as a protocol/product decision and design an explicit incarnation contract rather than adding a client-side compatibility shim.