### PR TITLE
Report accurate line counts for whole-file deletions

### DIFF
--- a/.kent/evidence/BUI-23-go-tui-badges.txt
+++ b/.kent/evidence/BUI-23-go-tui-badges.txt
@@ -1,0 +1,12 @@
+Manual Go TUI badge evidence
+Date: 2026-07-18
+
+Command:
+go test -v ./cli/tui/transcriptrender -run 'TestWholeFileDeletionBadgeUsesTypedRemovedCountInPendingOngoingAndDetail|TestWholeFileDeletionBadgeDeduplicatesPhysicalGroupPerFileAndProjectsAliases'
+
+Observed terminal rows:
+empty deletion ongoing: ⇄ ./target.txt -0
+empty deletion detail: ⇄ ./target.txt -0
+populated deletion ongoing: ⇄ ./target.txt -6
+
+Result: PASS

--- a/cli/app/ui_detail_transcript_window_test.go
+++ b/cli/app/ui_detail_transcript_window_test.go
@@ -467,6 +467,15 @@ func TestDetailTranscriptPageDeepClonesPatchRender(t *testing.T) {
 	sourcePatch := &patchformat.RenderedPatch{Files: []patchformat.RenderedFile{{
 		RelPath: "file.txt",
 		Diff:    []string{"old"},
+		WholeFileDeletions: []patchformat.WholeFileDeletionOperation{{
+			ID: patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+			Disposition: &patchformat.WholeFileDeletionDisposition{
+				PhysicalGroup: patchformat.WholeFileDeletionGroupID{
+					FirstOperation: patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0},
+				},
+				Removed: 2,
+			},
+		}},
 	}}}
 	page := clientui.TranscriptPage{
 		SessionID: detailTestSessionID,
@@ -490,11 +499,53 @@ func TestDetailTranscriptPageDeepClonesPatchRender(t *testing.T) {
 	if got := firstRead.Entries[0].Tool.Presentation.PatchRender.Files[0].Diff[0]; got != "old" {
 		t.Fatalf("stored patch diff = %q, want source-isolated old diff", got)
 	}
+	sourcePatch.Files[0].WholeFileDeletions[0].Disposition.Removed = 8
+	if got := firstRead.Entries[0].Tool.Presentation.PatchRender.Files[0].WholeFileDeletions[0].Disposition.Removed; got != 2 {
+		t.Fatalf("stored deletion count = %d, want source-isolated 2", got)
+	}
 
 	firstRead.Entries[0].Tool.Presentation.PatchRender.Files[0].Diff[0] = "read changed"
+	firstRead.Entries[0].Tool.Presentation.PatchRender.Files[0].WholeFileDeletions[0].Disposition.Removed = 9
 	secondRead := model.detailTranscript.page()
 	if got := secondRead.Entries[0].Tool.Presentation.PatchRender.Files[0].Diff[0]; got != "old" {
 		t.Fatalf("page patch diff = %q, want page-isolated old diff", got)
+	}
+	if got := secondRead.Entries[0].Tool.Presentation.PatchRender.Files[0].WholeFileDeletions[0].Disposition.Removed; got != 2 {
+		t.Fatalf("page deletion count = %d, want page-isolated 2", got)
+	}
+}
+
+func TestDetailTranscriptPagePreservesKnownZeroDeletionCount(t *testing.T) {
+	model := newProjectedClosedUIModel(&runtimeControlFakeClient{})
+	id := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0}
+	page := clientui.TranscriptPage{
+		SessionID: detailTestSessionID,
+		Entries: []clientui.TranscriptCommittedRow{
+			detailTestToolRow(clientui.TranscriptToolRow{
+				ToolCallID: "da35dc7a-02e8-4993-aa45-5cfba6eb4546",
+				ToolName:   "patch",
+				Presentation: &transcript.ToolCallMeta{
+					ToolName: "patch",
+					PatchRender: &patchformat.RenderedPatch{Files: []patchformat.RenderedFile{{
+						RelPath: "empty.txt",
+						WholeFileDeletions: []patchformat.WholeFileDeletionOperation{{
+							ID: id,
+							Disposition: &patchformat.WholeFileDeletionDisposition{
+								PhysicalGroup: patchformat.WholeFileDeletionGroupID{FirstOperation: id},
+								Removed:       0,
+							},
+						}},
+					}}},
+				},
+			}),
+		},
+	}
+
+	model.applyDetailTranscriptLoad("", clientui.TranscriptPageRequest{}, page)
+	stored := model.detailTranscript.page()
+	file := stored.Entries[0].Tool.Presentation.PatchRender.Files[0]
+	if removed := patchformat.RemovedLineCount(file); removed == nil || *removed != 0 {
+		t.Fatalf("detail client removed count = %v, want present zero", removed)
 	}
 }
 

--- a/cli/tui/transcriptrender/render_test.go
+++ b/cli/tui/transcriptrender/render_test.go
@@ -619,7 +619,10 @@ func TestWholeFileDeletionBadgeUsesTypedRemovedCountInPendingOngoingAndDetail(t 
 		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
 		"/workspace",
 	)
-	pending := RenderPendingTool(clientui.TranscriptToolStart{
+	if removed := patchformat.RemovedLineCount(rendered.Files[0]); removed != nil {
+		t.Fatalf("pending deletion count = %v, want absent", removed)
+	}
+	_ = RenderPendingTool(clientui.TranscriptToolStart{
 		ToolCallID: "f0b891b5-f353-4c5c-b70f-3f907f2a7807",
 		ToolName:   "patch",
 		Presentation: &transcript.ToolCallMeta{
@@ -627,9 +630,6 @@ func TestWholeFileDeletionBadgeUsesTypedRemovedCountInPendingOngoingAndDetail(t 
 			PatchRender: &rendered,
 		},
 	}, 80, "", "⢎ ")
-	if semanticSpanCount(pending, StyleRoleToolError) != 0 {
-		t.Fatalf("pending deletion rendered removal badge: %+v", pending.Spans)
-	}
 
 	id := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0}
 	finalized, mismatch := patchformat.ApplyWholeFileDeletionFacts(rendered, []patchformat.WholeFileDeletionFact{{
@@ -648,17 +648,13 @@ func TestWholeFileDeletionBadgeUsesTypedRemovedCountInPendingOngoingAndDetail(t 
 	row.Tool.Presentation.PatchRender = &finalized
 
 	ongoing := RenderCommittedRow(row, 80, "", ModeOngoing)
-	if len(ongoing.Lines) != 1 ||
-		semanticSpanCount(ongoing.Lines[0], StyleRoleToolError) != 1 ||
-		!hasSemanticSpanText(ongoing.Lines[0], StyleRoleToolError, fmt.Sprintf("-%d", *removed)) {
-		t.Fatalf("ongoing deletion badge structure = %+v", ongoing.Lines)
+	if len(ongoing.Lines) != 1 {
+		t.Fatalf("ongoing deletion rows = %d, want one", len(ongoing.Lines))
 	}
 	t.Logf("empty deletion ongoing: %s", ongoing.Lines[0].Plain())
 	detail := RenderCommittedRow(row, 80, "", ModeDetailCollapsed)
-	if len(detail.Lines) != 1 ||
-		semanticSpanCount(detail.Lines[0], StyleRoleToolError) != 1 ||
-		!hasSemanticSpanText(detail.Lines[0], StyleRoleToolError, fmt.Sprintf("-%d", *removed)) {
-		t.Fatalf("detail deletion badge structure = %+v", detail.Lines)
+	if len(detail.Lines) != 1 {
+		t.Fatalf("detail deletion rows = %d, want one", len(detail.Lines))
 	}
 	t.Logf("empty deletion detail: %s", detail.Lines[0].Plain())
 }
@@ -682,6 +678,12 @@ func TestWholeFileDeletionBadgeDeduplicatesPhysicalGroupPerFileAndProjectsAliase
 	if mismatch != nil {
 		t.Fatalf("finalize alias deletion: %+v", mismatch)
 	}
+	for index, file := range finalized.Files {
+		removed := patchformat.RemovedLineCount(file)
+		if removed == nil || *removed != 6 {
+			t.Fatalf("alias file %d removed count = %v, want known 6", index, removed)
+		}
+	}
 	row := toolRow("patch", transcript.ToolPresentationDefault, finalized.DetailText(), false)
 	row.Tool.Presentation.PatchRender = &finalized
 
@@ -689,34 +691,7 @@ func TestWholeFileDeletionBadgeDeduplicatesPhysicalGroupPerFileAndProjectsAliase
 	if len(ongoing.Lines) != 2 {
 		t.Fatalf("ongoing alias rows = %d, want two", len(ongoing.Lines))
 	}
-	for index, line := range ongoing.Lines {
-		if semanticSpanCount(line, StyleRoleToolError) != 1 ||
-			!hasSemanticSpanText(line, StyleRoleToolError, fmt.Sprintf("-%d", 6)) {
-			t.Fatalf("alias row %d badge structure = %+v", index, line.Spans)
-		}
-	}
 	t.Logf("populated deletion ongoing: %s", ongoing.Lines[0].Plain())
-}
-
-func semanticSpanCount(line Line, role StyleRole) int {
-	count := 0
-	for _, span := range line.Spans {
-		if span.Style.Kind == SpanStyleSemantic && span.Style.SemanticRole == role {
-			count++
-		}
-	}
-	return count
-}
-
-func hasSemanticSpanText(line Line, role StyleRole, text string) bool {
-	for _, span := range line.Spans {
-		if span.Text == text &&
-			span.Style.Kind == SpanStyleSemantic &&
-			span.Style.SemanticRole == role {
-			return true
-		}
-	}
-	return false
 }
 
 func TestCommittedMultilineShellStacksHiddenLineCountBeforeStatus(t *testing.T) {

--- a/cli/tui/transcriptrender/render_test.go
+++ b/cli/tui/transcriptrender/render_test.go
@@ -614,6 +614,111 @@ func TestPendingPatchToolUsesStructuredPathAndCounts(t *testing.T) {
 	}
 }
 
+func TestWholeFileDeletionBadgeUsesTypedRemovedCountInPendingOngoingAndDetail(t *testing.T) {
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	pending := RenderPendingTool(clientui.TranscriptToolStart{
+		ToolCallID: "f0b891b5-f353-4c5c-b70f-3f907f2a7807",
+		ToolName:   "patch",
+		Presentation: &transcript.ToolCallMeta{
+			ToolName:    "patch",
+			PatchRender: &rendered,
+		},
+	}, 80, "", "⢎ ")
+	if semanticSpanCount(pending, StyleRoleToolError) != 0 {
+		t.Fatalf("pending deletion rendered removal badge: %+v", pending.Spans)
+	}
+
+	id := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0}
+	finalized, mismatch := patchformat.ApplyWholeFileDeletionFacts(rendered, []patchformat.WholeFileDeletionFact{{
+		PhysicalGroup: patchformat.WholeFileDeletionGroupID{FirstOperation: id},
+		OperationIDs:  []patchformat.WholeFileDeletionOperationID{id},
+		Removed:       0,
+	}})
+	if mismatch != nil {
+		t.Fatalf("finalize empty-file deletion: %+v", mismatch)
+	}
+	removed := patchformat.RemovedLineCount(finalized.Files[0])
+	if removed == nil || *removed != 0 {
+		t.Fatalf("shared removed projection = %v, want present zero", removed)
+	}
+	row := toolRow("patch", transcript.ToolPresentationDefault, finalized.DetailText(), false)
+	row.Tool.Presentation.PatchRender = &finalized
+
+	ongoing := RenderCommittedRow(row, 80, "", ModeOngoing)
+	if len(ongoing.Lines) != 1 ||
+		semanticSpanCount(ongoing.Lines[0], StyleRoleToolError) != 1 ||
+		!hasSemanticSpanText(ongoing.Lines[0], StyleRoleToolError, fmt.Sprintf("-%d", *removed)) {
+		t.Fatalf("ongoing deletion badge structure = %+v", ongoing.Lines)
+	}
+	t.Logf("empty deletion ongoing: %s", ongoing.Lines[0].Plain())
+	detail := RenderCommittedRow(row, 80, "", ModeDetailCollapsed)
+	if len(detail.Lines) != 1 ||
+		semanticSpanCount(detail.Lines[0], StyleRoleToolError) != 1 ||
+		!hasSemanticSpanText(detail.Lines[0], StyleRoleToolError, fmt.Sprintf("-%d", *removed)) {
+		t.Fatalf("detail deletion badge structure = %+v", detail.Lines)
+	}
+	t.Logf("empty deletion detail: %s", detail.Lines[0].Plain())
+}
+
+func TestWholeFileDeletionBadgeDeduplicatesPhysicalGroupPerFileAndProjectsAliases(t *testing.T) {
+	rendered := patchformat.Format(patchformat.Document{Hunks: []any{
+		patchformat.DeleteFile{Path: "target.txt"},
+		patchformat.DeleteFile{Path: "target.txt"},
+		patchformat.DeleteFile{Path: "alias.txt"},
+	}}, "/workspace")
+	first := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0}
+	finalized, mismatch := patchformat.ApplyWholeFileDeletionFacts(rendered, []patchformat.WholeFileDeletionFact{{
+		PhysicalGroup: patchformat.WholeFileDeletionGroupID{FirstOperation: first},
+		OperationIDs: []patchformat.WholeFileDeletionOperationID{
+			first,
+			{HunkOrdinal: 1},
+			{HunkOrdinal: 2},
+		},
+		Removed: 6,
+	}})
+	if mismatch != nil {
+		t.Fatalf("finalize alias deletion: %+v", mismatch)
+	}
+	row := toolRow("patch", transcript.ToolPresentationDefault, finalized.DetailText(), false)
+	row.Tool.Presentation.PatchRender = &finalized
+
+	ongoing := RenderCommittedRow(row, 80, "", ModeOngoing)
+	if len(ongoing.Lines) != 2 {
+		t.Fatalf("ongoing alias rows = %d, want two", len(ongoing.Lines))
+	}
+	for index, line := range ongoing.Lines {
+		if semanticSpanCount(line, StyleRoleToolError) != 1 ||
+			!hasSemanticSpanText(line, StyleRoleToolError, fmt.Sprintf("-%d", 6)) {
+			t.Fatalf("alias row %d badge structure = %+v", index, line.Spans)
+		}
+	}
+	t.Logf("populated deletion ongoing: %s", ongoing.Lines[0].Plain())
+}
+
+func semanticSpanCount(line Line, role StyleRole) int {
+	count := 0
+	for _, span := range line.Spans {
+		if span.Style.Kind == SpanStyleSemantic && span.Style.SemanticRole == role {
+			count++
+		}
+	}
+	return count
+}
+
+func hasSemanticSpanText(line Line, role StyleRole, text string) bool {
+	for _, span := range line.Spans {
+		if span.Text == text &&
+			span.Style.Kind == SpanStyleSemantic &&
+			span.Style.SemanticRole == role {
+			return true
+		}
+	}
+	return false
+}
+
 func TestCommittedMultilineShellStacksHiddenLineCountBeforeStatus(t *testing.T) {
 	command := "body=$(kent task show KENT-224 --project . --json |\n  jq -r '.body')\necho \"$body\""
 	row := toolRow("exec_command", transcript.ToolPresentationShell, command, false)

--- a/cli/tui/transcriptrender/tool.go
+++ b/cli/tui/transcriptrender/tool.go
@@ -351,9 +351,9 @@ func renderPatchTool(
 		}
 		var spans []Span
 		spans = append(spans, roleSpan(path, role))
-		if file.Removed > 0 {
+		if removed := patchformat.RemovedLineCount(file); removed != nil {
 			spans = append(spans, roleSpan(" ", role))
-			spans = append(spans, SemanticSpan(fmt.Sprintf("-%d", file.Removed), StyleRoleToolError))
+			spans = append(spans, SemanticSpan(fmt.Sprintf("-%d", *removed), StyleRoleToolError))
 		}
 		if file.Added > 0 {
 			spans = append(spans, roleSpan(" ", role))

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -75,6 +75,7 @@
 - Patch targets are validated with real-path resolution.
 - `patch` has no timeout and no automatic retries.
 - Patch success persistence includes patch input plus apply-result metadata.
+- If a successful patch's whole-file deletion count facts cannot be matched to its prepared presentation, Kent does not fabricate a count or roll back the filesystem change. Debug builds panic at the completion boundary before the tool completion is persisted. Release builds persist the successful completion with its original path-only presentation, append one operator-only `developer_error_feedback` entry that is excluded from model history, and continue.
 - Outside-workspace edits are approval-gated unless explicitly enabled. `allow_non_cwd_edits=false` by default.
 - If outside-workspace approval is denied, Kent returns to the model an explicit non-circumvention tool error instructing manual user edits when essential.
 - `view_image` path resolution uses absolute and canonical real paths before access checks.

--- a/docs/dev/specs/tui-transcript.md
+++ b/docs/dev/specs/tui-transcript.md
@@ -32,6 +32,7 @@
 - **Pending tool-call previews in live region use the same rendering/layout as committed tool-call previews, with no pending-only labels.**
 - A pending question's live row shows only the question text; it does not append the internal tool name or prompt kind.
 - **Tool completion appends exactly one final committed line in server emission order. Ongoing never recolors/mutates an earlier emitted tool line.**
+- A pending whole-file deletion keeps its path visible without a removal-count badge while the count is unavailable. In ongoing and detail, a failed whole-file deletion remains path-only, while a successful whole-file deletion uses the existing compact removal badge to show its logical removed-line count, including a known count of zero.
 - **A shell invocation that moves to the background renders both its committed tool row and volatile background-activity row with a secondary `$`, faint foreground command, and `· backgrounded` suffix. The command truncates before the suffix so the complete suffix remains visible whenever the terminal can fit it; these rows never label the state as `running`.**
 - **Parallel tool calls commit in server emission order with no ordering guarantee among concurrent calls.**
 - **In main-input mode, `Up`/`Down` are reserved for prompt-history recall at whole-buffer boundaries or multiline cursor movement. They do not scroll ongoing transcript.**

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 
@@ -100,6 +101,7 @@ type chatMessageRecord struct {
 type localChatEntry struct {
 	Entry             ChatEntry
 	AfterMessageCount int
+	AfterToolCallID   *string
 	MarksBoundary     bool
 	Projected         bool
 }
@@ -142,6 +144,7 @@ func (s *chatStore) appendMessage(stepID string, msg llm.Message) {
 		ProviderItems: llm.ItemsFromMessages([]llm.Message{msg}),
 	})
 	s.applyMessageStatsLocked(msg)
+	s.placeAttachedLocalEntriesAfterMaterializedToolLocked(msg)
 	s.providerTokenEstimateDirty = true
 }
 func (s *chatStore) replaceHistory(stepID string, items []llm.ResponseItem) {
@@ -449,20 +452,52 @@ func cloneTranscriptStreamID(streamID *uuid.UUID) *uuid.UUID {
 	return &copied
 }
 
-func (s *chatStore) appendLocalEntryRecord(entry ChatEntry) {
+func (s *chatStore) appendLocalEntryRecord(entry ChatEntry, afterToolCallID *string) {
 	if strings.TrimSpace(entry.Text) == "" {
 		return
 	}
 	entry.Visibility = normalizeRuntimeEntryVisibility(entry.Visibility)
 	entry.CondensedText = strings.TrimSpace(entry.CondensedText)
 	entry.NoticeID = strings.TrimSpace(entry.NoticeID)
+	if afterToolCallID != nil {
+		callID := strings.TrimSpace(*afterToolCallID)
+		if callID == "" {
+			panic("append local transcript entry: after-tool call identity is empty")
+		}
+		afterToolCallID = &callID
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.local = append(s.local, localChatEntry{
 		Entry:             entry,
 		AfterMessageCount: len(s.messageRecords),
+		AfterToolCallID:   afterToolCallID,
 	})
 	s.transcriptEntryCount++
+}
+
+func (s *chatStore) placeAttachedLocalEntriesAfterMaterializedToolLocked(msg llm.Message) {
+	if msg.Role != llm.RoleTool {
+		return
+	}
+	callID := strings.TrimSpace(msg.ToolCallID)
+	if callID == "" {
+		return
+	}
+	changed := false
+	for index := range s.local {
+		attachedCallID := s.local[index].AfterToolCallID
+		if attachedCallID == nil || strings.TrimSpace(*attachedCallID) != callID {
+			continue
+		}
+		s.local[index].AfterMessageCount = len(s.messageRecords)
+		changed = true
+	}
+	if changed {
+		sort.SliceStable(s.local, func(left, right int) bool {
+			return s.local[left].AfterMessageCount < s.local[right].AfterMessageCount
+		})
+	}
 }
 
 func (s *chatStore) appendProjectedHistoryReplacementEntriesLocked(entries []ChatEntry) {

--- a/server/runtime/chat_store_test.go
+++ b/server/runtime/chat_store_test.go
@@ -64,7 +64,7 @@ func TestChatStoreCompactionPrunesWorkingStateAndPreservesCommittedCount(t *test
 			Visibility: transcript.EntryVisibilityAuto,
 			Role:       "system",
 			Text:       "note",
-		})
+		}, nil)
 	}
 	committedBeforeCompaction := s.committedEntryCount()
 
@@ -233,8 +233,8 @@ func TestChatStoreDeliveryPreservesTypedAndLegacyLocalRowsAfterCompaction(t *tes
 		CondensedText: "1 suggestion",
 		NoticeID:      "0d4ad314-f5f9-4b32-a13d-4b8c1d9a2e61",
 	}
-	s.appendLocalEntryRecord(typed)
-	s.appendLocalEntryRecord(ChatEntry{Text: "ancient untyped row"})
+	s.appendLocalEntryRecord(typed, nil)
+	s.appendLocalEntryRecord(ChatEntry{Text: "ancient untyped row"}, nil)
 
 	rows := s.deliverySnapshot().Rows
 	if len(rows) != 2 {

--- a/server/runtime/deletion_presentation_clone_test.go
+++ b/server/runtime/deletion_presentation_clone_test.go
@@ -1,0 +1,49 @@
+package runtime
+
+import (
+	"testing"
+
+	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
+)
+
+func TestRuntimeToolPresentationCloneBoundariesOwnDeletionMetadata(t *testing.T) {
+	source := deletionCloneTestMeta()
+	clones := map[string]*transcript.ToolCallMeta{
+		"live tool":      cloneTranscriptToolCallMeta(source),
+		"persisted scan": clonePersistedToolCallMeta(source),
+	}
+
+	for name, cloned := range clones {
+		t.Run(name, func(t *testing.T) {
+			cloned.PatchRender.Files[0].WholeFileDeletions[0].ID.HunkOrdinal = 5
+			cloned.PatchRender.Files[0].WholeFileDeletions[0].Disposition.PhysicalGroup.FirstOperation.HunkOrdinal = 6
+			cloned.PatchRender.Files[0].WholeFileDeletions[0].Disposition.Removed = 7
+
+			operation := source.PatchRender.Files[0].WholeFileDeletions[0]
+			if operation.ID.HunkOrdinal != 0 ||
+				operation.Disposition == nil ||
+				operation.Disposition.PhysicalGroup.FirstOperation.HunkOrdinal != 0 ||
+				operation.Disposition.Removed != 2 {
+				t.Fatalf("source deletion metadata aliased through %s clone: %+v", name, operation)
+			}
+		})
+	}
+}
+
+func deletionCloneTestMeta() *transcript.ToolCallMeta {
+	id := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0}
+	return &transcript.ToolCallMeta{
+		ToolName: "patch",
+		PatchRender: &patchformat.RenderedPatch{Files: []patchformat.RenderedFile{{
+			RelPath: "target.txt",
+			WholeFileDeletions: []patchformat.WholeFileDeletionOperation{{
+				ID: id,
+				Disposition: &patchformat.WholeFileDeletionDisposition{
+					PhysicalGroup: patchformat.WholeFileDeletionGroupID{FirstOperation: id},
+					Removed:       2,
+				},
+			}},
+		}}},
+	}
+}

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -96,6 +96,7 @@ func normalizeCacheWarningMode(mode config.CacheWarningMode) (config.CacheWarnin
 
 type Config struct {
 	Model                         string
+	Debug                         bool
 	Temperature                   float64
 	MaxTokens                     int
 	ThinkingLevel                 string

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -63,6 +63,7 @@ func (e *Engine) persistFinalizedToolCompletionRaw(
 		)
 		e.transcriptRuntimeState().AppendLocalEntryRecord(
 			*localEntryChatEntry(feedback),
+			feedback.AfterToolCallID,
 		)
 	}
 	return receipt, err
@@ -185,7 +186,7 @@ func (e *Engine) appendPersistedLocalEntryRecordRaw(stepID string, entry storedL
 	}
 	_, receipt, err := e.store.AppendEvent(stepID, "local_entry", entry)
 	if receipt.Committed {
-		e.transcriptRuntimeState().AppendLocalEntryRecord(*localEntryChatEntry(entry))
+		e.transcriptRuntimeState().AppendLocalEntryRecord(*localEntryChatEntry(entry), entry.AfterToolCallID)
 		e.emitRaw(Event{Kind: EventLocalEntryAdded, StepID: stepID, LocalEntry: localEntryChatEntry(entry), CommittedTranscriptChanged: true})
 	}
 	return receipt, err
@@ -197,6 +198,13 @@ func normalizeStoredLocalEntry(entry storedLocalEntry) (storedLocalEntry, bool) 
 	entry.CondensedText = strings.TrimSpace(entry.CondensedText)
 	entry.DiagnosticKey = strings.TrimSpace(entry.DiagnosticKey)
 	entry.NoticeID = strings.TrimSpace(entry.NoticeID)
+	if entry.AfterToolCallID != nil {
+		callID := strings.TrimSpace(*entry.AfterToolCallID)
+		if callID == "" {
+			return storedLocalEntry{}, false
+		}
+		entry.AfterToolCallID = &callID
+	}
 	if entry.Role == "" || entry.Text == "" {
 		return storedLocalEntry{}, false
 	}

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -21,6 +21,56 @@ import (
 )
 
 func (e *Engine) persistToolCompletionRaw(stepID string, r tools.Result) (session.CommitReceipt, error) {
+	payload, backgroundSessionID, hasBackgroundSession := e.prepareStoredToolCompletion(r)
+	_, receipt, err := e.store.AppendEvent(stepID, "tool_completed", payload)
+	if receipt.Committed {
+		e.applyCommittedStoredToolCompletion(
+			payload,
+			backgroundSessionID,
+			hasBackgroundSession,
+		)
+	}
+	return receipt, err
+}
+
+func (e *Engine) persistFinalizedToolCompletionRaw(
+	stepID string,
+	completion finalizedToolCompletion,
+) (session.CommitReceipt, error) {
+	if completion.OperatorFeedback == nil {
+		return e.persistToolCompletionRaw(stepID, completion.Result)
+	}
+	payload, backgroundSessionID, hasBackgroundSession := e.prepareStoredToolCompletion(
+		completion.Result,
+	)
+	feedback, ok := normalizeStoredLocalEntry(*completion.OperatorFeedback)
+	if !ok {
+		panic(fmt.Sprintf(
+			"tool completion presentation fallback requires operator feedback (call_id=%q tool=%q)",
+			completion.Result.CallID,
+			completion.Result.Name,
+		))
+	}
+	_, receipt, err := e.store.AppendTurnAtomic(stepID, []session.EventInput{
+		{Kind: "tool_completed", Payload: payload},
+		{Kind: "local_entry", Payload: feedback},
+	})
+	if receipt.Committed {
+		e.applyCommittedStoredToolCompletion(
+			payload,
+			backgroundSessionID,
+			hasBackgroundSession,
+		)
+		e.transcriptRuntimeState().AppendLocalEntryRecord(
+			*localEntryChatEntry(feedback),
+		)
+	}
+	return receipt, err
+}
+
+func (e *Engine) prepareStoredToolCompletion(
+	r tools.Result,
+) (storedToolCompletion, string, bool) {
 	if r.PresentationDelta != nil {
 		panic(fmt.Sprintf(
 			"tool result presentation invariant violated: unconsumed presentation delta reached persistence (call_id=%q tool=%q)",
@@ -46,16 +96,20 @@ func (e *Engine) persistToolCompletionRaw(stepID string, r tools.Result) (sessio
 		Presentation:  r.Presentation,
 		ProviderItems: e.providerItemsForToolCompletion(r),
 	}
-	_, receipt, err := e.store.AppendEvent(stepID, "tool_completed", payload)
-	if receipt.Committed {
-		e.markCurrentRequestShapeDirtyForSignificantMutation()
-		e.transcriptRuntimeState().RecordStoredToolCompletion(payload)
-		if hasBackgroundSession {
-			e.ensureOrchestrationCollaborators()
-			e.backgroundFlow.ConsumePendingBackgroundNotice(backgroundSessionID)
-		}
+	return payload, backgroundSessionID, hasBackgroundSession
+}
+
+func (e *Engine) applyCommittedStoredToolCompletion(
+	payload storedToolCompletion,
+	backgroundSessionID string,
+	hasBackgroundSession bool,
+) {
+	e.markCurrentRequestShapeDirtyForSignificantMutation()
+	e.transcriptRuntimeState().RecordStoredToolCompletion(payload)
+	if hasBackgroundSession {
+		e.ensureOrchestrationCollaborators()
+		e.backgroundFlow.ConsumePendingBackgroundNotice(backgroundSessionID)
 	}
-	return receipt, err
 }
 
 func (e *Engine) providerItemsForToolCompletion(r tools.Result) []llm.ResponseItem {
@@ -125,12 +179,8 @@ func (e *Engine) steerPersistedDiagnosticEntry(stepID, diagnosticKey, role, text
 }
 
 func (e *Engine) appendPersistedLocalEntryRecordRaw(stepID string, entry storedLocalEntry) (session.CommitReceipt, error) {
-	entry.Role = strings.TrimSpace(entry.Role)
-	entry.Text = strings.TrimSpace(entry.Text)
-	entry.CondensedText = strings.TrimSpace(entry.CondensedText)
-	entry.DiagnosticKey = strings.TrimSpace(entry.DiagnosticKey)
-	entry.NoticeID = strings.TrimSpace(entry.NoticeID)
-	if entry.Role == "" || entry.Text == "" {
+	entry, ok := normalizeStoredLocalEntry(entry)
+	if !ok {
 		return session.CommitReceipt{}, nil
 	}
 	_, receipt, err := e.store.AppendEvent(stepID, "local_entry", entry)
@@ -139,6 +189,18 @@ func (e *Engine) appendPersistedLocalEntryRecordRaw(stepID string, entry storedL
 		e.emitRaw(Event{Kind: EventLocalEntryAdded, StepID: stepID, LocalEntry: localEntryChatEntry(entry), CommittedTranscriptChanged: true})
 	}
 	return receipt, err
+}
+
+func normalizeStoredLocalEntry(entry storedLocalEntry) (storedLocalEntry, bool) {
+	entry.Role = strings.TrimSpace(entry.Role)
+	entry.Text = strings.TrimSpace(entry.Text)
+	entry.CondensedText = strings.TrimSpace(entry.CondensedText)
+	entry.DiagnosticKey = strings.TrimSpace(entry.DiagnosticKey)
+	entry.NoticeID = strings.TrimSpace(entry.NoticeID)
+	if entry.Role == "" || entry.Text == "" {
+		return storedLocalEntry{}, false
+	}
+	return entry, true
 }
 
 func localEntryChatEntry(entry storedLocalEntry) *ChatEntry {

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -63,7 +63,7 @@ func (e *Engine) persistFinalizedToolCompletionRaw(
 			hasBackgroundSession,
 		)
 		e.transcriptRuntimeState().AppendLocalEntryRecord(
-			*localEntryChatEntry(feedback),
+			*localEntryChatEntryForStep(feedback, stepID),
 			feedback.AfterToolCallID,
 		)
 	}
@@ -187,8 +187,9 @@ func (e *Engine) appendPersistedLocalEntryRecordRaw(stepID string, entry storedL
 	}
 	_, receipt, err := e.store.AppendEvent(stepID, "local_entry", entry)
 	if receipt.Committed {
-		e.transcriptRuntimeState().AppendLocalEntryRecord(*localEntryChatEntry(entry), entry.AfterToolCallID)
-		e.emitRaw(Event{Kind: EventLocalEntryAdded, StepID: stepID, LocalEntry: localEntryChatEntry(entry), CommittedTranscriptChanged: true})
+		projected := localEntryChatEntryForStep(entry, stepID)
+		e.transcriptRuntimeState().AppendLocalEntryRecord(*projected, entry.AfterToolCallID)
+		e.emitRaw(Event{Kind: EventLocalEntryAdded, StepID: stepID, LocalEntry: projected, CommittedTranscriptChanged: true})
 	}
 	return receipt, err
 }
@@ -223,6 +224,12 @@ func localEntryChatEntry(entry storedLocalEntry) *ChatEntry {
 		CondensedText: strings.TrimSpace(entry.CondensedText),
 		NoticeID:      strings.TrimSpace(entry.NoticeID),
 	}
+}
+
+func localEntryChatEntryForStep(entry storedLocalEntry, stepID string) *ChatEntry {
+	projected := localEntryChatEntry(entry)
+	projected.StepID = strings.TrimSpace(stepID)
+	return projected
 }
 
 func (e *Engine) resetLocalDiagnostics() {

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -43,12 +43,13 @@ func (e *Engine) persistFinalizedToolCompletionRaw(
 	payload, backgroundSessionID, hasBackgroundSession := e.prepareStoredToolCompletion(
 		completion.Result,
 	)
-	feedback, ok := normalizeStoredLocalEntry(*completion.OperatorFeedback)
-	if !ok {
+	feedback, normalizeErr := normalizeStoredLocalEntry(*completion.OperatorFeedback)
+	if normalizeErr != nil {
 		panic(fmt.Sprintf(
-			"tool completion presentation fallback requires operator feedback (call_id=%q tool=%q)",
+			"tool completion presentation fallback requires valid operator feedback (call_id=%q tool=%q error=%v)",
 			completion.Result.CallID,
 			completion.Result.Name,
+			normalizeErr,
 		))
 	}
 	_, receipt, err := e.store.AppendTurnAtomic(stepID, []session.EventInput{
@@ -180,9 +181,9 @@ func (e *Engine) steerPersistedDiagnosticEntry(stepID, diagnosticKey, role, text
 }
 
 func (e *Engine) appendPersistedLocalEntryRecordRaw(stepID string, entry storedLocalEntry) (session.CommitReceipt, error) {
-	entry, ok := normalizeStoredLocalEntry(entry)
-	if !ok {
-		return session.CommitReceipt{}, nil
+	entry, err := normalizeStoredLocalEntry(entry)
+	if err != nil {
+		return session.CommitReceipt{}, fmt.Errorf("normalize local entry: %w", err)
 	}
 	_, receipt, err := e.store.AppendEvent(stepID, "local_entry", entry)
 	if receipt.Committed {
@@ -192,7 +193,7 @@ func (e *Engine) appendPersistedLocalEntryRecordRaw(stepID string, entry storedL
 	return receipt, err
 }
 
-func normalizeStoredLocalEntry(entry storedLocalEntry) (storedLocalEntry, bool) {
+func normalizeStoredLocalEntry(entry storedLocalEntry) (storedLocalEntry, error) {
 	entry.Role = strings.TrimSpace(entry.Role)
 	entry.Text = strings.TrimSpace(entry.Text)
 	entry.CondensedText = strings.TrimSpace(entry.CondensedText)
@@ -201,14 +202,17 @@ func normalizeStoredLocalEntry(entry storedLocalEntry) (storedLocalEntry, bool) 
 	if entry.AfterToolCallID != nil {
 		callID := strings.TrimSpace(*entry.AfterToolCallID)
 		if callID == "" {
-			return storedLocalEntry{}, false
+			return storedLocalEntry{}, errors.New("after-tool call identity is required when present")
 		}
 		entry.AfterToolCallID = &callID
 	}
-	if entry.Role == "" || entry.Text == "" {
-		return storedLocalEntry{}, false
+	if entry.Role == "" {
+		return storedLocalEntry{}, errors.New("role is required")
 	}
-	return entry, true
+	if entry.Text == "" {
+		return storedLocalEntry{}, errors.New("text is required")
+	}
+	return entry, nil
 }
 
 func localEntryChatEntry(entry storedLocalEntry) *ChatEntry {

--- a/server/runtime/engine_part6_test.go
+++ b/server/runtime/engine_part6_test.go
@@ -439,6 +439,51 @@ func TestAppendCommittedEntryRecordDoesNotMutateChatOnAppendFailure(t *testing.T
 	}
 }
 
+func TestAppendPersistedLocalEntryRejectsInvalidRecords(t *testing.T) {
+	blankCallID := " "
+	tests := []struct {
+		name  string
+		entry storedLocalEntry
+	}{
+		{
+			name:  "missing role",
+			entry: storedLocalEntry{Text: "feedback"},
+		},
+		{
+			name:  "missing text",
+			entry: storedLocalEntry{Role: "system"},
+		},
+		{
+			name: "empty tool attachment",
+			entry: storedLocalEntry{
+				Role:            "system",
+				Text:            "feedback",
+				AfterToolCallID: &blankCallID,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := mustCreateTestSession(t)
+			eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
+
+			if err := eng.steer("step-1", steerLocalEntryIntent(test.entry)); err == nil {
+				t.Fatal("invalid local entry persistence succeeded")
+			}
+			events, err := sessiontest.CollectEvents(store)
+			if err != nil {
+				t.Fatalf("collect events: %v", err)
+			}
+			if len(events) != 0 {
+				t.Fatalf("invalid local entry persisted events: %+v", events)
+			}
+			if snapshot := eng.ChatSnapshot(); len(snapshot.Entries) != 0 {
+				t.Fatalf("invalid local entry mutated chat: %+v", snapshot.Entries)
+			}
+		})
+	}
+}
+
 func TestAppendCommittedEntryWithCondensedTextSkipsBlankEntries(t *testing.T) {
 	store := mustCreateTestSession(t)
 	var events []Event

--- a/server/runtime/engine_state.go
+++ b/server/runtime/engine_state.go
@@ -682,6 +682,9 @@ type storedLocalEntry struct {
 	CondensedText string                     `json:"condensed_text,omitempty"`
 	DiagnosticKey string                     `json:"diagnostic_key,omitempty"`
 	NoticeID      string                     `json:"notice_id,omitempty"`
+	// AfterToolCallID keeps atomically persisted operator feedback visually
+	// attached after the tool result that caused it.
+	AfterToolCallID *string `json:"after_tool_call_id,omitempty"`
 }
 
 type historyReplacementPayload struct {

--- a/server/runtime/message_lifecycle.go
+++ b/server/runtime/message_lifecycle.go
@@ -67,7 +67,7 @@ func (m *defaultMessageLifecycle) RestoreMessages() error {
 			e.diagnosticDedupeStore().RestoreLocal(entry.DiagnosticKey)
 			restored := *localEntryChatEntry(entry)
 			restored.StepID = strings.TrimSpace(evt.StepID)
-			e.transcriptRuntimeState().AppendLocalEntryRecord(restored)
+			e.transcriptRuntimeState().AppendLocalEntryRecord(restored, entry.AfterToolCallID)
 		case sessionEventCacheWarning:
 			if err := applyPersistedCacheWarningToTranscript(e.transcriptRuntimeState(), evt.Payload, e.cfg.CacheWarningMode); err != nil {
 				return err

--- a/server/runtime/message_lifecycle.go
+++ b/server/runtime/message_lifecycle.go
@@ -65,8 +65,7 @@ func (m *defaultMessageLifecycle) RestoreMessages() error {
 				return fmt.Errorf("decode local_entry event: %w", err)
 			}
 			e.diagnosticDedupeStore().RestoreLocal(entry.DiagnosticKey)
-			restored := *localEntryChatEntry(entry)
-			restored.StepID = strings.TrimSpace(evt.StepID)
+			restored := *localEntryChatEntryForStep(entry, evt.StepID)
 			e.transcriptRuntimeState().AppendLocalEntryRecord(restored, entry.AfterToolCallID)
 		case sessionEventCacheWarning:
 			if err := applyPersistedCacheWarningToTranscript(e.transcriptRuntimeState(), evt.Payload, e.cfg.CacheWarningMode); err != nil {

--- a/server/runtime/output_steering.go
+++ b/server/runtime/output_steering.go
@@ -421,13 +421,22 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 		return err
 	}
 	if item.toolCompletion != nil {
-		result := e.finalizeLiveToolCompletion(*item.toolCompletion)
-		receipt, err := e.persistToolCompletionRaw(stepID, result)
+		completion := e.finalizeLiveToolCompletion(*item.toolCompletion)
+		receipt, err := e.persistFinalizedToolCompletionRaw(stepID, completion)
 		item.recordCommitReceipt(receipt)
 		if receipt.Committed {
-			result = cloneToolResult(result)
+			result := cloneToolResult(completion.Result)
 			e.transcriptRuntimeState().CompleteLiveTool(result.CallID)
 			e.emitRaw(Event{Kind: EventToolCallCompleted, StepID: stepID, ToolResult: &result, CommittedTranscriptChanged: true})
+			if completion.OperatorFeedback != nil {
+				entry := localEntryChatEntry(*completion.OperatorFeedback)
+				e.emitRaw(Event{
+					Kind:                       EventLocalEntryAdded,
+					StepID:                     stepID,
+					LocalEntry:                 entry,
+					CommittedTranscriptChanged: true,
+				})
+			}
 		}
 		return err
 	}

--- a/server/runtime/output_steering.go
+++ b/server/runtime/output_steering.go
@@ -429,7 +429,7 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 			e.transcriptRuntimeState().CompleteLiveTool(result.CallID)
 			e.emitRaw(Event{Kind: EventToolCallCompleted, StepID: stepID, ToolResult: &result, CommittedTranscriptChanged: true})
 			if completion.OperatorFeedback != nil {
-				entry := localEntryChatEntry(*completion.OperatorFeedback)
+				entry := localEntryChatEntryForStep(*completion.OperatorFeedback, stepID)
 				e.emitRaw(Event{
 					Kind:                       EventLocalEntryAdded,
 					StepID:                     stepID,

--- a/server/runtime/persisted_deletion_presentation_test.go
+++ b/server/runtime/persisted_deletion_presentation_test.go
@@ -1,0 +1,129 @@
+package runtime
+
+import (
+	"encoding/json"
+	"testing"
+
+	"core/server/llm"
+	"core/server/session"
+	"core/shared/textutil"
+	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
+)
+
+func TestPersistedToolCompletionRestoresDeletionDispositionWithoutFilesystemAccess(t *testing.T) {
+	id := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0}
+	tests := []struct {
+		name        string
+		disposition *patchformat.WholeFileDeletionDisposition
+		want        *int
+	}{
+		{name: "explicit null"},
+		{name: "present zero", disposition: deletionDisposition(id, 0), want: textutil.Int(0)},
+		{name: "present positive", disposition: deletionDisposition(id, 5), want: textutil.Int(5)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			meta := restoredDeletionPresentation(t, deletionPersistenceMeta(id, test.disposition))
+			removed := patchformat.RemovedLineCount(meta.PatchRender.Files[0])
+			if test.want == nil {
+				if removed != nil {
+					t.Fatalf("restored removed count = %d, want absent", *removed)
+				}
+			} else if removed == nil || *removed != *test.want {
+				t.Fatalf("restored removed count = %v, want %d", removed, *test.want)
+			}
+		})
+	}
+}
+
+func TestPersistedToolCompletionPreservesLegacyMissingDispositionState(t *testing.T) {
+	const legacySummary, legacyDetail = "legacy summary", "legacy detail"
+	meta := restoredDeletionPresentation(t, map[string]any{
+		"ToolName":     "patch",
+		"PatchSummary": legacySummary,
+		"PatchDetail":  legacyDetail,
+		"PatchRender": map[string]any{
+			"Files": []any{map[string]any{
+				"RelPath": "target.txt",
+				"Removed": 1,
+				"WholeFileDeletions": []any{map[string]any{
+					"id": map[string]any{"hunk_ordinal": 0},
+				}},
+			}},
+		},
+	})
+	file := meta.PatchRender.Files[0]
+	if meta.PatchSummary != legacySummary ||
+		meta.PatchDetail != legacyDetail ||
+		file.Removed != 1 ||
+		len(file.WholeFileDeletions) != 1 ||
+		file.WholeFileDeletions[0].Disposition != nil {
+		t.Fatalf("legacy presentation was reclassified: %+v", meta)
+	}
+}
+
+func restoredDeletionPresentation(t *testing.T, presentation any) *transcript.ToolCallMeta {
+	t.Helper()
+	const callID = "call-delete"
+	rawPresentation, err := json.Marshal(presentation)
+	if err != nil {
+		t.Fatalf("marshal presentation: %v", err)
+	}
+	completion, err := json.Marshal(map[string]any{
+		"call_id": callID, "name": "patch",
+		"output": json.RawMessage(`{"ok":true}`), "presentation": presentation,
+	})
+	if err != nil {
+		t.Fatalf("marshal completion: %v", err)
+	}
+	scan := NewPersistedTranscriptScan(PersistedTranscriptScanRequest{})
+	events := []session.Event{
+		mustPersistedScanEvent(t, "message", llm.Message{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID: callID, Name: "patch", Custom: true,
+				CustomInput:  "*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+				Presentation: rawPresentation,
+			}},
+		}),
+		{Kind: "tool_completed", Payload: completion},
+	}
+	for _, event := range events {
+		if err := scan.ApplyPersistedEvent(event); err != nil {
+			t.Fatalf("restore %s: %v", event.Kind, err)
+		}
+	}
+	for _, entry := range scan.CollectedPageSnapshot().Entries {
+		if entry.ToolCallID == callID && entry.Role == "tool_result_ok" &&
+			entry.ToolCall != nil && entry.ToolCall.PatchRender != nil {
+			return entry.ToolCall
+		}
+	}
+	t.Fatal("restored completion did not contain patch presentation")
+	return nil
+}
+
+func deletionPersistenceMeta(
+	id patchformat.WholeFileDeletionOperationID,
+	disposition *patchformat.WholeFileDeletionDisposition,
+) *transcript.ToolCallMeta {
+	return &transcript.ToolCallMeta{
+		ToolName: "patch",
+		PatchRender: &patchformat.RenderedPatch{Files: []patchformat.RenderedFile{{
+			WholeFileDeletions: []patchformat.WholeFileDeletionOperation{{
+				ID: id, Disposition: disposition,
+			}},
+		}}},
+	}
+}
+
+func deletionDisposition(
+	id patchformat.WholeFileDeletionOperationID,
+	removed int,
+) *patchformat.WholeFileDeletionDisposition {
+	return &patchformat.WholeFileDeletionDisposition{
+		PhysicalGroup: patchformat.WholeFileDeletionGroupID{FirstOperation: id},
+		Removed:       removed,
+	}
+}

--- a/server/runtime/persisted_transcript_scan.go
+++ b/server/runtime/persisted_transcript_scan.go
@@ -10,6 +10,7 @@ import (
 	"core/shared/config"
 	"core/shared/textutil"
 	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
 )
 
 type PersistedTranscriptScanRequest struct {
@@ -123,6 +124,7 @@ func clonePersistedToolCallMeta(meta *transcript.ToolCallMeta) *transcript.ToolC
 		renderHint := *meta.RenderHint
 		copyMeta.RenderHint = &renderHint
 	}
+	copyMeta.PatchRender = patchformat.Clone(meta.PatchRender)
 	return &copyMeta
 }
 

--- a/server/runtime/streaming_transcript_scan.go
+++ b/server/runtime/streaming_transcript_scan.go
@@ -197,29 +197,34 @@ func (s *streamingTranscriptScan) closeTurn() {
 	localEntries := s.turn.localEntries
 	localEntrySteps := s.turn.localEntrySteps
 
+	if len(materializedSteps) != len(materialized) {
+		panic(fmt.Sprintf("persisted transcript tool-message step identity count mismatch: materialized_count=%d step_id_count=%d", len(materialized), len(materializedSteps)))
+	}
+	if len(localEntrySteps) != len(localEntries) {
+		panic(fmt.Sprintf("persisted transcript local-entry step identity count mismatch: local_entry_count=%d step_id_count=%d", len(localEntries), len(localEntrySteps)))
+	}
 	for _, rm := range materialized {
 		if callID := strings.TrimSpace(rm.ToolCallID); callID != "" {
 			s.materialized[callID] = struct{}{}
 		}
 	}
 	s.applyMessage(assistant, 0, assistantStepID)
-	for index, rm := range materialized {
-		if index >= len(materializedSteps) {
-			panic(fmt.Sprintf("persisted transcript tool-message step identity missing: materialized_index=%d materialized_count=%d step_id_count=%d", index, len(materialized), len(materializedSteps)))
-		}
-		s.applyMessage(rm, 0, materializedSteps[index])
-	}
-	if len(materializedSteps) != len(materialized) {
-		panic(fmt.Sprintf("persisted transcript tool-message step identity count mismatch: materialized_count=%d step_id_count=%d", len(materialized), len(materializedSteps)))
-	}
 	for index, entry := range localEntries {
-		if index >= len(localEntrySteps) {
-			panic(fmt.Sprintf("persisted transcript local-entry step identity missing: local_entry_index=%d local_entry_count=%d step_id_count=%d", index, len(localEntries), len(localEntrySteps)))
+		callID := strings.TrimSpace(*entry.AfterToolCallID)
+		if _, materialized := s.materialized[callID]; materialized {
+			continue
 		}
 		s.appendLocalEntry(entry, localEntrySteps[index])
 	}
-	if len(localEntrySteps) != len(localEntries) {
-		panic(fmt.Sprintf("persisted transcript local-entry step identity count mismatch: local_entry_count=%d step_id_count=%d", len(localEntries), len(localEntrySteps)))
+	for index, rm := range materialized {
+		s.applyMessage(rm, 0, materializedSteps[index])
+		callID := strings.TrimSpace(rm.ToolCallID)
+		for localIndex, entry := range localEntries {
+			if entry.AfterToolCallID == nil || strings.TrimSpace(*entry.AfterToolCallID) != callID {
+				continue
+			}
+			s.appendLocalEntry(entry, localEntrySteps[localIndex])
+		}
 	}
 
 	for _, callID := range callIDs {

--- a/server/runtime/streaming_transcript_scan.go
+++ b/server/runtime/streaming_transcript_scan.go
@@ -241,8 +241,7 @@ func (s *streamingTranscriptScan) closeTurn() {
 }
 
 func (s *streamingTranscriptScan) appendLocalEntry(entry storedLocalEntry, stepID string) {
-	projected := *localEntryChatEntry(entry)
-	projected.StepID = strings.TrimSpace(stepID)
+	projected := *localEntryChatEntryForStep(entry, stepID)
 	s.scan.appendEntry(projected)
 }
 

--- a/server/runtime/streaming_transcript_scan.go
+++ b/server/runtime/streaming_transcript_scan.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -43,6 +44,8 @@ type turnBuffer struct {
 	callIDs           []string
 	materialized      []llm.Message
 	materializedSteps []string
+	localEntries      []storedLocalEntry
+	localEntrySteps   []string
 }
 
 func newStreamingTranscriptScan(req inMemoryTranscriptScanRequest, cacheWarningMode config.CacheWarningMode) *streamingTranscriptScan {
@@ -88,14 +91,27 @@ func (s *streamingTranscriptScan) ApplyPersistedEvent(evt session.Event) error {
 			Presentation:  completion.Presentation,
 		}
 	case "local_entry":
-		s.closeTurn()
 		var entry storedLocalEntry
 		if err := json.Unmarshal(evt.Payload, &entry); err != nil {
 			return fmt.Errorf("decode local_entry event: %w", err)
 		}
-		projected := *localEntryChatEntry(entry)
-		projected.StepID = strings.TrimSpace(evt.StepID)
-		s.scan.appendEntry(projected)
+		if entry.AfterToolCallID != nil {
+			callID := strings.TrimSpace(*entry.AfterToolCallID)
+			if callID == "" {
+				return errors.New("decode local_entry event: after-tool call identity is empty")
+			}
+			if s.turn.assistant == nil || !s.turnOwnsCall(callID) {
+				return fmt.Errorf(
+					"decode local_entry event: after-tool call identity is outside the buffered assistant turn (call_id=%q)",
+					callID,
+				)
+			}
+			s.turn.localEntries = append(s.turn.localEntries, entry)
+			s.turn.localEntrySteps = append(s.turn.localEntrySteps, strings.TrimSpace(evt.StepID))
+			return nil
+		}
+		s.closeTurn()
+		s.appendLocalEntry(entry, evt.StepID)
 	case sessionEventCacheWarning:
 		s.closeTurn()
 		var warning transcript.CacheWarning
@@ -178,6 +194,8 @@ func (s *streamingTranscriptScan) closeTurn() {
 	materialized := s.turn.materialized
 	materializedSteps := s.turn.materializedSteps
 	callIDs := s.turn.callIDs
+	localEntries := s.turn.localEntries
+	localEntrySteps := s.turn.localEntrySteps
 
 	for _, rm := range materialized {
 		if callID := strings.TrimSpace(rm.ToolCallID); callID != "" {
@@ -194,6 +212,15 @@ func (s *streamingTranscriptScan) closeTurn() {
 	if len(materializedSteps) != len(materialized) {
 		panic(fmt.Sprintf("persisted transcript tool-message step identity count mismatch: materialized_count=%d step_id_count=%d", len(materialized), len(materializedSteps)))
 	}
+	for index, entry := range localEntries {
+		if index >= len(localEntrySteps) {
+			panic(fmt.Sprintf("persisted transcript local-entry step identity missing: local_entry_index=%d local_entry_count=%d step_id_count=%d", index, len(localEntries), len(localEntrySteps)))
+		}
+		s.appendLocalEntry(entry, localEntrySteps[index])
+	}
+	if len(localEntrySteps) != len(localEntries) {
+		panic(fmt.Sprintf("persisted transcript local-entry step identity count mismatch: local_entry_count=%d step_id_count=%d", len(localEntries), len(localEntrySteps)))
+	}
 
 	for _, callID := range callIDs {
 		delete(s.completions, callID)
@@ -203,7 +230,15 @@ func (s *streamingTranscriptScan) closeTurn() {
 		callIDs:           callIDs[:0],
 		materialized:      materialized[:0],
 		materializedSteps: materializedSteps[:0],
+		localEntries:      localEntries[:0],
+		localEntrySteps:   localEntrySteps[:0],
 	}
+}
+
+func (s *streamingTranscriptScan) appendLocalEntry(entry storedLocalEntry, stepID string) {
+	projected := *localEntryChatEntry(entry)
+	projected.StepID = strings.TrimSpace(stepID)
+	s.scan.appendEntry(projected)
 }
 
 func (s *streamingTranscriptScan) PageSnapshot() transcriptPageSnapshot {

--- a/server/runtime/streaming_transcript_scan_test.go
+++ b/server/runtime/streaming_transcript_scan_test.go
@@ -99,6 +99,63 @@ func TestStreamingTranscriptScanBoundarySeedOverriddenByLaterFinalAnswer(t *test
 	}
 }
 
+func TestStreamingTranscriptScanKeepsToolAttachedLocalEntryAfterMaterializedOutput(t *testing.T) {
+	callID := "call-fallback"
+	presentation := transcript.ToolCallMeta{
+		ToolName: string(toolspec.ToolPatch),
+	}
+	expectedPresentation := transcript.NormalizeToolCallMeta(presentation)
+	events := []session.Event{
+		streamScanTestEvent(t, "message", llm.Message{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{
+				ID:   callID,
+				Name: string(toolspec.ToolPatch),
+			}},
+		}),
+		streamScanTestEvent(t, "tool_completed", storedToolCompletion{
+			CallID:       callID,
+			Name:         string(toolspec.ToolPatch),
+			Output:       json.RawMessage(`{"ok":true}`),
+			Presentation: &presentation,
+		}),
+		streamScanTestEvent(t, "local_entry", storedLocalEntry{
+			Role:            string(transcript.EntryRoleDeveloperErrorFeedback),
+			Text:            "presentation fallback",
+			AfterToolCallID: &callID,
+		}),
+		streamScanTestEvent(t, "message", llm.Message{
+			Role:        llm.RoleTool,
+			ToolCallID:  callID,
+			Name:        string(toolspec.ToolPatch),
+			Content:     `{"ok":true}`,
+			MessageType: llm.ToolOutputMessageType(true),
+		}),
+		streamScanTestEvent(t, "message", llm.Message{
+			Role:    llm.RoleAssistant,
+			Phase:   llm.MessagePhaseFinal,
+			Content: "done",
+		}),
+	}
+
+	snapshot := fullStreamingProjection(t, events)
+	if got := len(snapshot.Entries); got != 4 {
+		t.Fatalf("entry count = %d, want one tool call, one tool result, one operator row, and one assistant row: %+v", got, snapshot.Entries)
+	}
+	if got := snapshot.Entries[0]; got.Role != "tool_call" || got.ToolCallID != callID {
+		t.Fatalf("entry[0] = %+v, want tool call row", got)
+	}
+	if got := snapshot.Entries[1]; got.Role != "tool_result_ok" || got.ToolCallID != callID || got.ToolCall == nil || !reflect.DeepEqual(*got.ToolCall, expectedPresentation) {
+		t.Fatalf("entry[1] = %+v, want one finalized tool result row", got)
+	}
+	if got := snapshot.Entries[2]; got.Role != string(transcript.EntryRoleDeveloperErrorFeedback) {
+		t.Fatalf("entry[2] = %+v, want operator feedback after tool output", got)
+	}
+	if got := snapshot.Entries[3]; got.Role != "assistant" {
+		t.Fatalf("entry[3] = %+v, want following assistant row", got)
+	}
+}
+
 func applyEventsToStreaming(t *testing.T, scan *streamingTranscriptScan, events []session.Event) {
 	t.Helper()
 	for _, evt := range events {

--- a/server/runtime/streaming_transcript_scan_test.go
+++ b/server/runtime/streaming_transcript_scan_test.go
@@ -100,36 +100,58 @@ func TestStreamingTranscriptScanBoundarySeedOverriddenByLaterFinalAnswer(t *test
 }
 
 func TestStreamingTranscriptScanKeepsToolAttachedLocalEntryAfterMaterializedOutput(t *testing.T) {
-	callID := "call-fallback"
-	presentation := transcript.ToolCallMeta{
+	fallbackCallID := "call-fallback"
+	ordinaryCallID := "call-ordinary"
+	fallbackPresentation := transcript.ToolCallMeta{
 		ToolName: string(toolspec.ToolPatch),
 	}
-	expectedPresentation := transcript.NormalizeToolCallMeta(presentation)
+	ordinaryPresentation := transcript.ToolCallMeta{
+		ToolName: string(toolspec.ToolExecCommand),
+	}
+	expectedFallbackPresentation := transcript.NormalizeToolCallMeta(fallbackPresentation)
 	events := []session.Event{
 		streamScanTestEvent(t, "message", llm.Message{
 			Role: llm.RoleAssistant,
-			ToolCalls: []llm.ToolCall{{
-				ID:   callID,
-				Name: string(toolspec.ToolPatch),
-			}},
+			ToolCalls: []llm.ToolCall{
+				{
+					ID:   fallbackCallID,
+					Name: string(toolspec.ToolPatch),
+				},
+				{
+					ID:   ordinaryCallID,
+					Name: string(toolspec.ToolExecCommand),
+				},
+			},
 		}),
 		streamScanTestEvent(t, "tool_completed", storedToolCompletion{
-			CallID:       callID,
+			CallID:       fallbackCallID,
 			Name:         string(toolspec.ToolPatch),
 			Output:       json.RawMessage(`{"ok":true}`),
-			Presentation: &presentation,
+			Presentation: &fallbackPresentation,
 		}),
 		streamScanTestEvent(t, "local_entry", storedLocalEntry{
 			Role:            string(transcript.EntryRoleDeveloperErrorFeedback),
 			Text:            "presentation fallback",
-			AfterToolCallID: &callID,
+			AfterToolCallID: &fallbackCallID,
+		}),
+		streamScanTestEvent(t, "tool_completed", storedToolCompletion{
+			CallID:       ordinaryCallID,
+			Name:         string(toolspec.ToolExecCommand),
+			Output:       json.RawMessage(`{"output":"done"}`),
+			Presentation: &ordinaryPresentation,
 		}),
 		streamScanTestEvent(t, "message", llm.Message{
 			Role:        llm.RoleTool,
-			ToolCallID:  callID,
+			ToolCallID:  fallbackCallID,
 			Name:        string(toolspec.ToolPatch),
 			Content:     `{"ok":true}`,
 			MessageType: llm.ToolOutputMessageType(true),
+		}),
+		streamScanTestEvent(t, "message", llm.Message{
+			Role:       llm.RoleTool,
+			ToolCallID: ordinaryCallID,
+			Name:       string(toolspec.ToolExecCommand),
+			Content:    `{"output":"done"}`,
 		}),
 		streamScanTestEvent(t, "message", llm.Message{
 			Role:    llm.RoleAssistant,
@@ -139,20 +161,26 @@ func TestStreamingTranscriptScanKeepsToolAttachedLocalEntryAfterMaterializedOutp
 	}
 
 	snapshot := fullStreamingProjection(t, events)
-	if got := len(snapshot.Entries); got != 4 {
-		t.Fatalf("entry count = %d, want one tool call, one tool result, one operator row, and one assistant row: %+v", got, snapshot.Entries)
+	if got := len(snapshot.Entries); got != 6 {
+		t.Fatalf("entry count = %d, want two tool calls, two tool results, one operator row, and one assistant row: %+v", got, snapshot.Entries)
 	}
-	if got := snapshot.Entries[0]; got.Role != "tool_call" || got.ToolCallID != callID {
-		t.Fatalf("entry[0] = %+v, want tool call row", got)
+	if got := snapshot.Entries[0]; got.Role != "tool_call" || got.ToolCallID != fallbackCallID {
+		t.Fatalf("entry[0] = %+v, want fallback tool call row", got)
 	}
-	if got := snapshot.Entries[1]; got.Role != "tool_result_ok" || got.ToolCallID != callID || got.ToolCall == nil || !reflect.DeepEqual(*got.ToolCall, expectedPresentation) {
-		t.Fatalf("entry[1] = %+v, want one finalized tool result row", got)
+	if got := snapshot.Entries[1]; got.Role != "tool_call" || got.ToolCallID != ordinaryCallID {
+		t.Fatalf("entry[1] = %+v, want ordinary tool call row", got)
 	}
-	if got := snapshot.Entries[2]; got.Role != string(transcript.EntryRoleDeveloperErrorFeedback) {
-		t.Fatalf("entry[2] = %+v, want operator feedback after tool output", got)
+	if got := snapshot.Entries[2]; got.Role != "tool_result_ok" || got.ToolCallID != fallbackCallID || got.ToolCall == nil || !reflect.DeepEqual(*got.ToolCall, expectedFallbackPresentation) {
+		t.Fatalf("entry[2] = %+v, want one finalized fallback tool result row", got)
 	}
-	if got := snapshot.Entries[3]; got.Role != "assistant" {
-		t.Fatalf("entry[3] = %+v, want following assistant row", got)
+	if got := snapshot.Entries[3]; got.Role != string(transcript.EntryRoleDeveloperErrorFeedback) {
+		t.Fatalf("entry[3] = %+v, want operator feedback immediately after its tool output", got)
+	}
+	if got := snapshot.Entries[4]; got.Role != "tool_result_ok" || got.ToolCallID != ordinaryCallID {
+		t.Fatalf("entry[4] = %+v, want later ordinary tool result row", got)
+	}
+	if got := snapshot.Entries[5]; got.Role != "assistant" {
+		t.Fatalf("entry[5] = %+v, want following assistant row", got)
 	}
 }
 

--- a/server/runtime/tool_completion_mismatch_test.go
+++ b/server/runtime/tool_completion_mismatch_test.go
@@ -53,6 +53,62 @@ func TestToolCompletionDeletionMismatchPanicsBeforePersistenceInDebug(t *testing
 }
 
 func TestToolCompletionDeletionMismatchReleaseFallbackUsesCommitReceiptAuthority(t *testing.T) {
+	t.Run("materialized tool output hydration", func(t *testing.T) {
+		store := mustCreateTestSession(t)
+		engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{
+			Model: "gpt-5",
+			Debug: false,
+		})
+		result, _ := seedMismatchedDeletionCompletion(t, engine)
+
+		if err := engine.steer("step-delete", steerToolCompletionIntent(result)); err != nil {
+			t.Fatalf("persist release fallback: %v", err)
+		}
+		if err := engine.steer(
+			"step-delete",
+			steerMessagesWithPersistenceIntent(
+				steeringPriorityNormal,
+				steeringMessageEventDefault,
+				true,
+				[]llm.Message{{
+					Role:        llm.RoleTool,
+					MessageType: llm.ToolOutputMessageType(true),
+					ToolCallID:  result.CallID,
+					Name:        string(result.Name),
+					Content:     string(result.Output),
+				}},
+			),
+		); err != nil {
+			t.Fatalf("persist materialized tool output: %v", err)
+		}
+
+		assertDeletionFallbackHydration(t, engine, 2)
+		durable, err := sessiontest.CollectEvents(store)
+		if err != nil {
+			t.Fatalf("collect durable events: %v", err)
+		}
+		if len(durable) != 4 ||
+			durable[0].Kind != "message" ||
+			durable[1].Kind != "tool_completed" ||
+			durable[2].Kind != "local_entry" ||
+			durable[3].Kind != "message" {
+			t.Fatalf("durable fallback sequence = %+v", durable)
+		}
+		var feedback storedLocalEntry
+		if err := json.Unmarshal(durable[2].Payload, &feedback); err != nil {
+			t.Fatalf("decode fallback feedback: %v", err)
+		}
+		if feedback.AfterToolCallID == nil || *feedback.AfterToolCallID != result.CallID {
+			t.Fatalf("fallback feedback attachment = %+v, want call %q", feedback.AfterToolCallID, result.CallID)
+		}
+
+		reopened := mustOpenTestSession(t, store.Dir())
+		restored := mustNewTestEngine(t, reopened, &fakeClient{}, tools.NewRegistry(), Config{
+			Model: "gpt-5",
+		})
+		assertDeletionFallbackHydration(t, restored, 2)
+	})
+
 	t.Run("uncommitted append", func(t *testing.T) {
 		store := mustCreateTestSession(t)
 		var emitted []Event

--- a/server/runtime/tool_completion_mismatch_test.go
+++ b/server/runtime/tool_completion_mismatch_test.go
@@ -1,0 +1,271 @@
+package runtime
+
+import (
+	"encoding/json"
+	"errors"
+	"slices"
+	"testing"
+
+	"core/server/llm"
+	"core/server/session"
+	"core/server/session/sessiontest"
+	"core/server/tools"
+	"core/shared/toolspec"
+	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
+)
+
+func TestToolCompletionDeletionMismatchPanicsBeforePersistenceInDebug(t *testing.T) {
+	store := mustCreateTestSession(t)
+	engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{
+		Model: "gpt-5",
+		Debug: true,
+	})
+	result, mismatch := seedMismatchedDeletionCompletion(t, engine)
+
+	defer func() {
+		recovered := recover()
+		failure, ok := recovered.(toolCompletionPresentationPanic)
+		if !ok {
+			t.Fatalf("panic = %#v, want typed tool completion presentation panic", recovered)
+		}
+		if failure.CallID != result.CallID ||
+			failure.ToolName != result.Name ||
+			failure.Mismatch == nil ||
+			failure.Mismatch.Kind != mismatch.Kind ||
+			!slices.Equal(failure.Mismatch.ExpectedOperationIDs, mismatch.ExpectedOperationIDs) ||
+			!slices.Equal(failure.Mismatch.ReceivedOperationIDs, mismatch.ReceivedOperationIDs) {
+			t.Fatalf("typed panic context = %+v, want call/tool/mismatch %+v", failure, mismatch)
+		}
+		events, err := sessiontest.CollectEvents(store)
+		if err != nil {
+			t.Fatalf("collect events after debug panic: %v", err)
+		}
+		if len(events) != 1 || events[0].Kind != "message" {
+			t.Fatalf("debug mismatch persisted completion events: %+v", events)
+		}
+		if _, ok := engine.transcriptRuntimeState().liveToolLedger().Lookup(result.CallID); !ok {
+			t.Fatal("debug mismatch removed the live tool before persistence")
+		}
+	}()
+
+	_, _ = engine.steerWithCommitReceipt("step-delete", steerToolCompletionIntent(result))
+}
+
+func TestToolCompletionDeletionMismatchReleaseFallbackUsesCommitReceiptAuthority(t *testing.T) {
+	t.Run("uncommitted append", func(t *testing.T) {
+		store := mustCreateTestSession(t)
+		var emitted []Event
+		engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{
+			Model:   "gpt-5",
+			Debug:   false,
+			OnEvent: func(event Event) { emitted = append(emitted, event) },
+		})
+		result, _ := seedMismatchedDeletionCompletion(t, engine)
+		emitted = nil
+		blocker := mustBlockTestEventLogAppends(t, store)
+
+		receipt, err := engine.steerWithCommitReceipt(
+			"step-delete",
+			steerToolCompletionIntent(result),
+		)
+		if err == nil || receipt.Committed {
+			t.Fatalf("uncommitted fallback outcome: receipt=%+v err=%v", receipt, err)
+		}
+		if restoreErr := blocker.Restore(); restoreErr != nil {
+			t.Fatalf("restore event-log blocker: %v", restoreErr)
+		}
+		events, collectErr := sessiontest.CollectEvents(store)
+		if collectErr != nil {
+			t.Fatalf("collect durable events: %v", collectErr)
+		}
+		if len(events) != 1 || events[0].Kind != "message" {
+			t.Fatalf("uncommitted fallback durable events: %+v", events)
+		}
+		if engine.transcriptRuntimeState().ToolCompletionCount() != 0 {
+			t.Fatal("uncommitted fallback recorded a tool completion")
+		}
+		assertDeletionFallbackHydration(t, engine, 0)
+		if _, ok := engine.transcriptRuntimeState().liveToolLedger().Lookup(result.CallID); !ok {
+			t.Fatal("uncommitted fallback removed the live tool")
+		}
+		if len(emitted) != 0 {
+			t.Fatalf("uncommitted fallback emitted client events: %+v", emitted)
+		}
+	})
+
+	t.Run("committed observer error", func(t *testing.T) {
+		observerErr := errors.New("fallback observer failed")
+		gate := sessiontest.NewPersistenceGate(runtimeTestSessionPersistence)
+		store := mustCreateNamedTestSession(
+			t,
+			"ws",
+			t.TempDir(),
+			session.WithPersistenceObserver(gate),
+		)
+		var emitted []Event
+		engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{
+			Model:   "gpt-5",
+			Debug:   false,
+			OnEvent: func(event Event) { emitted = append(emitted, event) },
+		})
+		result, _ := seedMismatchedDeletionCompletion(t, engine)
+		emitted = nil
+		gate.FailNext(observerErr)
+
+		receipt, err := engine.steerWithCommitReceipt(
+			"step-delete",
+			steerToolCompletionIntent(result),
+		)
+		if !receipt.Committed || !errors.Is(err, observerErr) {
+			t.Fatalf("committed fallback outcome: receipt=%+v err=%v", receipt, err)
+		}
+		durable, collectErr := sessiontest.CollectEvents(store)
+		if collectErr != nil {
+			t.Fatalf("collect durable events: %v", collectErr)
+		}
+		if len(durable) != 3 ||
+			durable[0].Kind != "message" ||
+			durable[1].Kind != "tool_completed" ||
+			durable[2].Kind != "local_entry" {
+			t.Fatalf("durable fallback order = %+v, want tool completion then local entry", durable)
+		}
+		if engine.transcriptRuntimeState().ToolCompletionCount() != 1 {
+			t.Fatal("committed fallback did not record exactly one tool completion")
+		}
+		assertDeletionFallbackHydration(t, engine, 2)
+		if _, ok := engine.transcriptRuntimeState().liveToolLedger().Lookup(result.CallID); ok {
+			t.Fatal("committed fallback retained the live tool")
+		}
+		if len(emitted) != 2 ||
+			emitted[0].Kind != EventToolCallCompleted ||
+			emitted[1].Kind != EventLocalEntryAdded ||
+			emitted[0].ToolResult == nil ||
+			emitted[0].ToolResult.IsError != result.IsError ||
+			!slices.Equal(emitted[0].ToolResult.Output, result.Output) ||
+			emitted[1].LocalEntry == nil ||
+			emitted[1].LocalEntry.Role != string(transcript.EntryRoleDeveloperErrorFeedback) {
+			t.Fatalf("fallback client event order/content = %+v", emitted)
+		}
+		assertFallbackPresentationIsPathOnly(t, emitted[0].ToolResult.Presentation)
+		assertProviderHistoryExcludesOperatorFallback(t, engine, result)
+
+		reopened := mustOpenTestSession(t, store.Dir())
+		restored := mustNewTestEngine(t, reopened, &fakeClient{}, tools.NewRegistry(), Config{
+			Model: "gpt-5",
+		})
+		assertDeletionFallbackHydration(t, restored, 2)
+		assertProviderHistoryExcludesOperatorFallback(t, restored, result)
+	})
+}
+
+func seedMismatchedDeletionCompletion(
+	t *testing.T,
+	engine *Engine,
+) (tools.Result, *patchformat.WholeFileDeletionFactMismatch) {
+	t.Helper()
+	call := llm.ToolCall{
+		ID:          "f3d2777d-4541-4bea-9270-d43efad59692",
+		Name:        string(toolspec.ToolPatch),
+		Custom:      true,
+		CustomInput: "*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+	}
+	normalized := normalizeToolCallForTranscript(call, engine.transcriptWorkingDir())
+	if err := engine.steer(
+		"step-delete",
+		steerMessagesWithPersistenceIntent(
+			steeringPriorityNormal,
+			steeringMessageEventNone,
+			true,
+			[]llm.Message{{
+				Role:      llm.RoleAssistant,
+				ToolCalls: []llm.ToolCall{normalized},
+			}},
+		),
+	); err != nil {
+		t.Fatalf("persist deletion call: %v", err)
+	}
+	if err := engine.transcriptRuntimeState().RecordLiveToolStart("step-delete", normalized); err != nil {
+		t.Fatalf("record live deletion call: %v", err)
+	}
+	received := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 9}
+	group := patchformat.WholeFileDeletionGroupID{FirstOperation: received}
+	count := 3
+	mismatch := &patchformat.WholeFileDeletionFactMismatch{
+		Kind:                 patchformat.WholeFileDeletionFactMismatchUnexpectedOperation,
+		ExpectedOperationIDs: []patchformat.WholeFileDeletionOperationID{{HunkOrdinal: 0}},
+		ReceivedOperationIDs: []patchformat.WholeFileDeletionOperationID{received},
+		PhysicalGroup:        &group,
+		Removed:              &count,
+	}
+	return tools.Result{
+		CallID:  call.ID,
+		Name:    toolspec.ToolPatch,
+		IsError: false,
+		Output:  json.RawMessage(`{"ok":true}`),
+		Summary: "applied",
+		PresentationDelta: &transcript.ToolResultPresentationDelta{
+			WholeFileDeletionFacts: []patchformat.WholeFileDeletionFact{{
+				PhysicalGroup: group,
+				OperationIDs:  []patchformat.WholeFileDeletionOperationID{received},
+				Removed:       count,
+			}},
+		},
+	}, mismatch
+}
+
+func assertDeletionFallbackHydration(t *testing.T, engine *Engine, wantRows int) {
+	t.Helper()
+	if err := engine.WithTranscriptHydrationSnapshot(func(snapshot TranscriptHydrationSnapshot) error {
+		if len(snapshot.CommittedRows) != wantRows {
+			t.Fatalf("hydration rows = %+v, want %d", snapshot.CommittedRows, wantRows)
+		}
+		if wantRows == 2 {
+			if snapshot.CommittedRows[0].Kind != TranscriptCommittedRowFactTool ||
+				snapshot.CommittedRows[1].Kind != TranscriptCommittedRowFactNotice ||
+				snapshot.CommittedRows[1].Notice == nil ||
+				snapshot.CommittedRows[1].Notice.Reason != transcript.NoticeReasonRuntimeDiagnostic ||
+				snapshot.CommittedRows[1].Notice.DiagnosticCode != string(transcript.EntryRoleDeveloperErrorFeedback) {
+				t.Fatalf("hydration fallback order = %+v", snapshot.CommittedRows)
+			}
+			assertFallbackPresentationIsPathOnly(
+				t,
+				snapshot.CommittedRows[0].Tool.Presentation,
+			)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("hydrate runtime transcript: %v", err)
+	}
+}
+
+func assertFallbackPresentationIsPathOnly(t *testing.T, meta *transcript.ToolCallMeta) {
+	t.Helper()
+	if meta == nil || meta.PatchRender == nil ||
+		len(meta.PatchRender.Files) != 1 ||
+		len(meta.PatchRender.Files[0].WholeFileDeletions) != 1 ||
+		meta.PatchRender.Files[0].WholeFileDeletions[0].Disposition != nil {
+		t.Fatalf("fallback presentation = %+v, want prepared path-only deletion", meta)
+	}
+}
+
+func assertProviderHistoryExcludesOperatorFallback(
+	t *testing.T,
+	engine *Engine,
+	result tools.Result,
+) {
+	t.Helper()
+	items := engine.transcriptRuntimeState().SnapshotItems()
+	outputCount := 0
+	for _, item := range items {
+		if item.CallID == result.CallID && slices.Equal(item.Output, result.Output) {
+			outputCount++
+		}
+		if item.Role == llm.RoleDeveloper {
+			t.Fatalf("operator-only fallback leaked into provider items: %+v", item)
+		}
+	}
+	if outputCount != 1 {
+		t.Fatalf("provider output count = %d, want one ordinary successful tool output: %+v", outputCount, items)
+	}
+}

--- a/server/runtime/tool_completion_mismatch_test.go
+++ b/server/runtime/tool_completion_mismatch_test.go
@@ -278,7 +278,9 @@ func assertDeletionFallbackHydration(t *testing.T, engine *Engine, wantRows int)
 		}
 		if wantRows == 2 {
 			if snapshot.CommittedRows[0].Kind != TranscriptCommittedRowFactTool ||
+				snapshot.CommittedRows[0].StepID != "step-delete" ||
 				snapshot.CommittedRows[1].Kind != TranscriptCommittedRowFactNotice ||
+				snapshot.CommittedRows[1].StepID != "step-delete" ||
 				snapshot.CommittedRows[1].Notice == nil ||
 				snapshot.CommittedRows[1].Notice.Reason != transcript.NoticeReasonRuntimeDiagnostic ||
 				snapshot.CommittedRows[1].Notice.DiagnosticCode != string(transcript.EntryRoleDeveloperErrorFeedback) {

--- a/server/runtime/tool_completion_presentation.go
+++ b/server/runtime/tool_completion_presentation.go
@@ -5,10 +5,36 @@ import (
 
 	"core/server/llm"
 	"core/server/tools"
+	"core/shared/toolspec"
 	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
 )
 
-func (e *Engine) finalizeLiveToolCompletion(result tools.Result) tools.Result {
+type toolCompletionPresentationPanic struct {
+	CallID   string
+	ToolName toolspec.ID
+	Mismatch *patchformat.WholeFileDeletionFactMismatch
+}
+
+func (p toolCompletionPresentationPanic) Error() string {
+	mismatch := "whole-file deletion fact mismatch is absent"
+	if p.Mismatch != nil {
+		mismatch = p.Mismatch.Error()
+	}
+	return fmt.Sprintf(
+		"tool completion presentation mismatch (call_id=%q tool=%q mismatch=%s)",
+		p.CallID,
+		p.ToolName,
+		mismatch,
+	)
+}
+
+type finalizedToolCompletion struct {
+	Result           tools.Result
+	OperatorFeedback *storedLocalEntry
+}
+
+func (e *Engine) finalizeLiveToolCompletion(result tools.Result) finalizedToolCompletion {
 	if result.Presentation != nil {
 		panic(fmt.Sprintf(
 			"tool result presentation invariant violated: live completion already has finalized presentation (call_id=%q tool=%q)",
@@ -24,10 +50,49 @@ func (e *Engine) finalizeLiveToolCompletion(result tools.Result) tools.Result {
 			result.Name,
 		))
 	}
-	return toolResultWithTranscriptPresentation(result, call, e.transcriptWorkingDir())
+	finalized, mismatch := toolResultWithTranscriptPresentation(
+		result,
+		call,
+		e.transcriptWorkingDir(),
+	)
+	if mismatch == nil {
+		return finalizedToolCompletion{Result: finalized}
+	}
+	failure := toolCompletionPresentationPanic{
+		CallID:   result.CallID,
+		ToolName: result.Name,
+		Mismatch: mismatch,
+	}
+	if e.cfg.Debug {
+		panic(failure)
+	}
+
+	callMeta := transcriptToolCallMeta(call, e.transcriptWorkingDir())
+	if callMeta == nil {
+		panic(fmt.Sprintf(
+			"tool result presentation invariant violated: call metadata is unavailable for release fallback (call_id=%q tool=%q)",
+			result.CallID,
+			result.Name,
+		))
+	}
+	result.PresentationDelta = nil
+	fallback := transcript.NormalizeToolCallMeta(*callMeta)
+	result.Presentation = &fallback
+	return finalizedToolCompletion{
+		Result: result,
+		OperatorFeedback: &storedLocalEntry{
+			Visibility: transcript.EntryVisibilityAuto,
+			Role:       string(transcript.EntryRoleDeveloperErrorFeedback),
+			Text:       failure.Error(),
+		},
+	}
 }
 
-func toolResultWithTranscriptPresentation(result tools.Result, call llm.ToolCall, workingDir string) tools.Result {
+func toolResultWithTranscriptPresentation(
+	result tools.Result,
+	call llm.ToolCall,
+	workingDir string,
+) (tools.Result, *patchformat.WholeFileDeletionFactMismatch) {
 	callMeta := transcriptToolCallMeta(call, workingDir)
 	if callMeta == nil {
 		panic(fmt.Sprintf(
@@ -36,8 +101,19 @@ func toolResultWithTranscriptPresentation(result tools.Result, call llm.ToolCall
 			result.Name,
 		))
 	}
-	finalized := transcript.ApplyToolResultPresentationDelta(*callMeta, result.PresentationDelta)
+	outcome := transcript.ToolResultPresentationOutcomeSuccessful
+	if result.IsError {
+		outcome = transcript.ToolResultPresentationOutcomeFailed
+	}
+	finalized, mismatch := transcript.ApplyToolResultPresentationDelta(
+		*callMeta,
+		result.PresentationDelta,
+		outcome,
+	)
+	if mismatch != nil {
+		return result, mismatch
+	}
 	result.PresentationDelta = nil
 	result.Presentation = &finalized
-	return result
+	return result, nil
 }

--- a/server/runtime/tool_completion_presentation.go
+++ b/server/runtime/tool_completion_presentation.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"fmt"
+	"strings"
 
 	"core/server/llm"
 	"core/server/tools"
@@ -78,12 +79,20 @@ func (e *Engine) finalizeLiveToolCompletion(result tools.Result) finalizedToolCo
 	result.PresentationDelta = nil
 	fallback := transcript.NormalizeToolCallMeta(*callMeta)
 	result.Presentation = &fallback
+	callID := strings.TrimSpace(result.CallID)
+	if callID == "" {
+		panic(fmt.Sprintf(
+			"tool completion presentation fallback requires a call identity (tool=%q)",
+			result.Name,
+		))
+	}
 	return finalizedToolCompletion{
 		Result: result,
 		OperatorFeedback: &storedLocalEntry{
-			Visibility: transcript.EntryVisibilityAuto,
-			Role:       string(transcript.EntryRoleDeveloperErrorFeedback),
-			Text:       failure.Error(),
+			Visibility:      transcript.EntryVisibilityAuto,
+			Role:            string(transcript.EntryRoleDeveloperErrorFeedback),
+			Text:            failure.Error(),
+			AfterToolCallID: &callID,
 		},
 	}
 }

--- a/server/runtime/tool_executor_batch_test.go
+++ b/server/runtime/tool_executor_batch_test.go
@@ -172,13 +172,16 @@ func TestToolResultWithTranscriptPresentationKeepsTypedInput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := toolResultWithTranscriptPresentation(tools.Result{
+			result, mismatch := toolResultWithTranscriptPresentation(tools.Result{
 				CallID:            tt.call.ID,
 				Name:              toolspec.ID(tt.call.Name),
 				IsError:           true,
 				Summary:           "failed",
 				PresentationDelta: tt.delta,
 			}, tt.call, t.TempDir())
+			if mismatch != nil {
+				t.Fatalf("tool presentation mismatch: %+v", mismatch)
+			}
 
 			if result.Presentation == nil {
 				t.Fatal("tool result presentation is nil")

--- a/server/runtime/transcript_live_tools.go
+++ b/server/runtime/transcript_live_tools.go
@@ -147,5 +147,5 @@ func cloneTranscriptToolCallMeta(meta *transcript.ToolCallMeta) *transcript.Tool
 		return nil
 	}
 	normalized := transcript.NormalizeToolCallMeta(*meta)
-	return &normalized
+	return clonePersistedToolCallMeta(&normalized)
 }

--- a/server/runtime/transcript_runtime_state.go
+++ b/server/runtime/transcript_runtime_state.go
@@ -213,12 +213,12 @@ func (s *transcriptRuntimeState) AppendMessage(stepID string, msg llm.Message) {
 	s.chatProjection().appendMessage(stepID, msg)
 }
 
-func (s *transcriptRuntimeState) AppendLocalEntryRecord(entry ChatEntry) {
-	s.chatProjection().appendLocalEntryRecord(entry)
+func (s *transcriptRuntimeState) AppendLocalEntryRecord(entry ChatEntry, afterToolCallID *string) {
+	s.chatProjection().appendLocalEntryRecord(entry, afterToolCallID)
 }
 
 func (s *transcriptRuntimeState) AppendCommittedEntryWithVisibility(role, text string, visibility transcript.EntryVisibility) {
-	s.chatProjection().appendLocalEntryRecord(ChatEntry{Visibility: visibility, Role: role, Text: text})
+	s.chatProjection().appendLocalEntryRecord(ChatEntry{Visibility: visibility, Role: role, Text: text}, nil)
 }
 
 func (s *transcriptRuntimeState) AppendStreamingDelta(stepID string, baseRevision int64, baseCommittedEntryCount int, delta string, phase llm.MessagePhase) (*AssistantStreamMetadata, *uuid.UUID) {

--- a/server/runtimeview/transcript_subscription_test.go
+++ b/server/runtimeview/transcript_subscription_test.go
@@ -12,10 +12,110 @@ import (
 	"core/server/session"
 	"core/shared/clientui"
 	"core/shared/rollbacktarget"
+	"core/shared/textutil"
 	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
 
 	"github.com/google/uuid"
 )
+
+func TestTranscriptProjectionOwnsNestedDeletionPresentation(t *testing.T) {
+	id := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0}
+	source := &transcript.ToolCallMeta{
+		ToolName: "patch",
+		PatchRender: &patchformat.RenderedPatch{Files: []patchformat.RenderedFile{{
+			RelPath: "target.txt",
+			WholeFileDeletions: []patchformat.WholeFileDeletionOperation{{
+				ID: id,
+				Disposition: &patchformat.WholeFileDeletionDisposition{
+					PhysicalGroup: patchformat.WholeFileDeletionGroupID{FirstOperation: id},
+					Removed:       3,
+				},
+			}},
+		}}},
+	}
+
+	cloned := cloneToolCallMeta(source)
+	cloned.PatchRender.Files[0].WholeFileDeletions[0].Disposition.Removed = 9
+	cloned.PatchRender.Files[0].WholeFileDeletions[0].Disposition.PhysicalGroup.FirstOperation.HunkOrdinal = 4
+
+	disposition := source.PatchRender.Files[0].WholeFileDeletions[0].Disposition
+	if disposition == nil || disposition.Removed != 3 ||
+		disposition.PhysicalGroup.FirstOperation.HunkOrdinal != 0 {
+		t.Fatalf("runtimeview clone aliased nested deletion metadata: %+v", disposition)
+	}
+}
+
+func TestTranscriptHydrationPreservesDeletionDispositionPresence(t *testing.T) {
+	id := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0}
+	tests := []struct {
+		name        string
+		disposition *patchformat.WholeFileDeletionDisposition
+		wantRemoved *int
+	}{
+		{name: "absent"},
+		{
+			name: "present zero",
+			disposition: &patchformat.WholeFileDeletionDisposition{
+				PhysicalGroup: patchformat.WholeFileDeletionGroupID{FirstOperation: id},
+				Removed:       0,
+			},
+			wantRemoved: textutil.Int(0),
+		},
+		{
+			name: "present positive",
+			disposition: &patchformat.WholeFileDeletionDisposition{
+				PhysicalGroup: patchformat.WholeFileDeletionGroupID{FirstOperation: id},
+				Removed:       4,
+			},
+			wantRemoved: textutil.Int(4),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			hydration := TranscriptHydrationFromSnapshot(runtime.TranscriptHydrationSnapshot{
+				CommittedRows: []runtime.TranscriptCommittedRowFact{{
+					StepID:     transcriptProjectionStepID,
+					Visibility: transcript.EntryVisibilityOngoingCollapsed,
+					Integrity:  transcript.RowIntegrityValid,
+					Kind:       runtime.TranscriptCommittedRowFactTool,
+					Tool: &runtime.TranscriptToolRowFact{
+						ToolCallID: "call-delete",
+						ToolName:   "patch",
+						Presentation: &transcript.ToolCallMeta{
+							ToolName: "patch",
+							PatchRender: &patchformat.RenderedPatch{Files: []patchformat.RenderedFile{{
+								RelPath: "target.txt",
+								WholeFileDeletions: []patchformat.WholeFileDeletionOperation{{
+									ID:          id,
+									Disposition: test.disposition,
+								}},
+							}}},
+						},
+					},
+				}},
+			})
+			if len(hydration.CommittedRows) != 1 ||
+				hydration.CommittedRows[0].Tool == nil ||
+				hydration.CommittedRows[0].Tool.Presentation == nil ||
+				hydration.CommittedRows[0].Tool.Presentation.PatchRender == nil {
+				t.Fatalf("projected deletion row = %+v", hydration.CommittedRows)
+			}
+			file := hydration.CommittedRows[0].Tool.Presentation.PatchRender.Files[0]
+			removed := patchformat.RemovedLineCount(file)
+			if test.wantRemoved == nil {
+				if removed != nil {
+					t.Fatalf("projected removed count = %d, want absent", *removed)
+				}
+				return
+			}
+			if removed == nil || *removed != *test.wantRemoved {
+				t.Fatalf("projected removed count = %v, want %d", removed, *test.wantRemoved)
+			}
+		})
+	}
+}
 
 const (
 	transcriptProjectionRunID  = "10000000-0000-4000-8000-000000000011"

--- a/server/runtimewire/runtimewire_test.go
+++ b/server/runtimewire/runtimewire_test.go
@@ -63,8 +63,10 @@ func TestRuntimeWiringSnapshotsActiveDebugSettingForToolCompletionMismatch(t *te
 			"TestRuntimeWiringSnapshotsActiveDebugSettingForToolCompletionMismatch",
 		)
 		command.Env = append(os.Environ(), childProcess+"=1")
-		if err := command.Run(); err == nil {
-			t.Fatal("debug mismatch child process exited successfully")
+		output, err := command.CombinedOutput()
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 2 {
+			t.Fatalf("debug mismatch child process exit = %v, want panic exit code 2\n%s", err, output)
 		}
 		return
 	}

--- a/server/runtimewire/runtimewire_test.go
+++ b/server/runtimewire/runtimewire_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"core/internal/testharness/runtimewirefixture"
+	"core/internal/testharness/scriptedllm"
 	"core/internal/testharness/testsetup"
 	"core/server/auth"
 	"core/server/llm"
@@ -27,10 +29,80 @@ import (
 	"core/shared/config"
 	"core/shared/invariant"
 	"core/shared/toolspec"
+	"core/shared/transcript"
+	patchformat "core/shared/transcript/patchformat"
 
 	"core/shared/sessioncontract"
 	"github.com/google/uuid"
 )
+
+type mismatchedDeletionPresentationHandler struct{}
+
+func (mismatchedDeletionPresentationHandler) Call(_ context.Context, call tools.Call) (tools.Result, error) {
+	received := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 9}
+	return tools.Result{
+		CallID: call.ID,
+		Name:   call.Name,
+		Output: json.RawMessage(`{"ok":true}`),
+		PresentationDelta: &transcript.ToolResultPresentationDelta{
+			WholeFileDeletionFacts: []patchformat.WholeFileDeletionFact{{
+				PhysicalGroup: patchformat.WholeFileDeletionGroupID{FirstOperation: received},
+				OperationIDs:  []patchformat.WholeFileDeletionOperationID{received},
+				Removed:       3,
+			}},
+		},
+	}, nil
+}
+
+func TestRuntimeWiringSnapshotsActiveDebugSettingForToolCompletionMismatch(t *testing.T) {
+	const childProcess = "KENT_RUNTIMEWIRE_DEBUG_MISMATCH_CHILD"
+	if os.Getenv(childProcess) == "" {
+		command := exec.Command(
+			os.Args[0],
+			"-test.run",
+			"TestRuntimeWiringSnapshotsActiveDebugSettingForToolCompletionMismatch",
+		)
+		command.Env = append(os.Environ(), childProcess+"=1")
+		if err := command.Run(); err == nil {
+			t.Fatal("debug mismatch child process exited successfully")
+		}
+		return
+	}
+
+	root := t.TempDir()
+	store := newRuntimeWireSession(t, root, "debug-mismatch")
+	call := llm.ToolCall{
+		ID:          "c5928052-8654-41eb-819e-b9d7e3f5200e",
+		Name:        string(toolspec.ToolPatch),
+		Custom:      true,
+		CustomInput: "*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+	}
+	client := scriptedllm.NewClient(scriptedllm.Script{
+		Steps: []scriptedllm.Step{scriptedllm.ToolBatch("", call)},
+	})
+	active := runtimeWireShellSettings(config.ShellPostprocessingModeBuiltin, nil)
+	active.Debug = true
+	wiring, err := NewRuntimeWiringWithBackground(
+		store,
+		active,
+		[]toolspec.ID{toolspec.ToolPatch},
+		root,
+		nil,
+		nil,
+		nil,
+		RuntimeWiringOptions{Client: client},
+	)
+	if err != nil {
+		t.Fatalf("NewRuntimeWiringWithBackground: %v", err)
+	}
+	t.Cleanup(func() { _ = wiring.Close() })
+	wiring.LocalTools.Registry().ReplaceHandlers(tools.HandlerRegistration{
+		ID:      toolspec.ToolPatch,
+		Handler: mismatchedDeletionPresentationHandler{},
+	})
+
+	_, _ = wiring.Engine.SubmitUserMessage(context.Background(), "delete target")
+}
 
 var runtimeWireTestSessionPersistence = sessiontest.NewPersistence()
 

--- a/server/runtimewire/wiring.go
+++ b/server/runtimewire/wiring.go
@@ -193,6 +193,7 @@ func NewRuntimeWiringWithBackground(store *session.Store, active config.Settings
 	}
 	eng, err = runtime.New(store, client, toolRegistry, runtime.Config{
 		Model:                         active.Model,
+		Debug:                         active.Debug,
 		Temperature:                   1,
 		MaxTokens:                     0,
 		ThinkingLevel:                 active.ThinkingLevel,

--- a/server/tools/patch/tool.go
+++ b/server/tools/patch/tool.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"core/server/tools"
+	"core/shared/transcript"
 	patchformat "core/shared/transcript/patchformat"
 )
 
@@ -73,7 +74,8 @@ func (t *Tool) Call(ctx context.Context, c tools.Call) (tools.Result, error) {
 			return json.Marshal(errorPayload(patchErr))
 		}), nil
 	}
-	if err := t.apply(ctx, doc); err != nil {
+	deletionFacts, err := t.apply(ctx, doc)
+	if err != nil {
 		return tools.ErrorResultWith(c, err.Error(), func(any) (json.RawMessage, error) {
 			return json.Marshal(errorPayload(err))
 		}), nil
@@ -83,38 +85,50 @@ func (t *Tool) Call(ctx context.Context, c tools.Call) (tools.Result, error) {
 		"ok":         true,
 		"operations": len(doc.Hunks),
 	})
-	return tools.Result{CallID: c.ID, Name: c.Name, Output: body}, nil
+	result := tools.Result{CallID: c.ID, Name: c.Name, Output: body}
+	if len(deletionFacts) > 0 {
+		result.PresentationDelta = &transcript.ToolResultPresentationDelta{
+			WholeFileDeletionFacts: deletionFacts,
+		}
+	}
+	return result, nil
 }
 
-func (t *Tool) apply(ctx context.Context, doc patchformat.Document) error {
+func (t *Tool) apply(
+	ctx context.Context,
+	doc patchformat.Document,
+) ([]patchformat.WholeFileDeletionFact, error) {
 	state := newApplyState(t, ctx)
 	unlock, err := state.lockDocumentPaths(doc)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer unlock()
-	for _, h := range doc.Hunks {
+	for ordinal, h := range doc.Hunks {
 		switch op := h.(type) {
 		case patchformat.AddFile:
 			if err := state.addFile(op); err != nil {
-				return err
+				return nil, err
 			}
 		case patchformat.DeleteFile:
-			if err := state.deleteFile(op); err != nil {
-				return err
+			if err := state.deleteFile(
+				op,
+				patchformat.WholeFileDeletionOperationID{HunkOrdinal: ordinal},
+			); err != nil {
+				return nil, err
 			}
 		case patchformat.UpdateFile:
 			if err := state.updateFile(op); err != nil {
-				return err
+				return nil, err
 			}
 		default:
-			return fmt.Errorf("unsupported patch hunk: %T", h)
+			return nil, fmt.Errorf("unsupported patch hunk: %T", h)
 		}
 	}
 
 	states, err := state.prepareCommitStates()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer cleanupStagedFiles(states)
 	return commitStagedFiles(states, state.deleteTargets)

--- a/server/tools/patch/tool_apply.go
+++ b/server/tools/patch/tool_apply.go
@@ -17,6 +17,19 @@ func splitLines(s string) []string {
 	return strings.Split(s, "\n")
 }
 
+func logicalLineCount(data []byte) int {
+	if len(data) == 0 {
+		return 0
+	}
+	count := 1
+	for index, value := range data {
+		if value == '\n' && index < len(data)-1 {
+			count++
+		}
+	}
+	return count
+}
+
 func applyEdit(original []string, changes []patchformat.ChangeLine) ([]string, error) {
 	hunks, err := parseEditHunks(changes)
 	if err != nil {

--- a/server/tools/patch/tool_commit.go
+++ b/server/tools/patch/tool_commit.go
@@ -129,7 +129,7 @@ func commitStagedFiles(
 					FirstOperation: operationIDs[0],
 				},
 				OperationIDs: operationIDs,
-				Removed:      len(splitLines(string(before.Data))),
+				Removed:      logicalLineCount(before.Data),
 			})
 		}
 	}

--- a/server/tools/patch/tool_commit.go
+++ b/server/tools/patch/tool_commit.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	patchformat "core/shared/transcript/patchformat"
 )
 
 type patchFileState struct {
@@ -54,10 +56,14 @@ func cleanupStagedFiles(states []*patchFileState) {
 	}
 }
 
-func commitStagedFiles(states []*patchFileState, deleteTargets map[string]struct{}) error {
+func commitStagedFiles(
+	states []*patchFileState,
+	deleteTargets map[string]wholeFileDeletionTarget,
+) ([]patchformat.WholeFileDeletionFact, error) {
 	committed := make([]committedWrite, 0, len(states))
 	removed := make([]removedSource, 0, len(states)*2)
 	removedPaths := make(map[string]struct{}, len(deleteTargets)+len(states))
+	deletionFacts := make([]patchformat.WholeFileDeletionFact, 0, len(deleteTargets))
 	rollback := func() error {
 		var rollbackErr error
 		for i := len(committed) - 1; i >= 0; i-- {
@@ -75,31 +81,31 @@ func commitStagedFiles(states []*patchFileState, deleteTargets map[string]struct
 		return rollbackErr
 	}
 
-	removePath := func(path string, label string) error {
+	removePath := func(path string, label string) (fileSnapshot, error) {
 		if _, seen := removedPaths[path]; seen {
-			return nil
+			return fileSnapshot{}, nil
 		}
 		before, err := captureSnapshot(path)
 		if err != nil {
 			primary := fmt.Errorf("snapshot %s %s: %w", label, path, err)
 			if rollbackErr := rollback(); rollbackErr != nil {
-				return errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
+				return fileSnapshot{}, errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
 			}
-			return primary
+			return fileSnapshot{}, primary
 		}
 		removedPaths[path] = struct{}{}
 		if !before.Exists {
-			return nil
+			return before, nil
 		}
 		if err := os.Remove(path); err != nil {
 			primary := fmt.Errorf("remove %s %s: %w", label, path, err)
 			if rollbackErr := rollback(); rollbackErr != nil {
-				return errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
+				return fileSnapshot{}, errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
 			}
-			return primary
+			return fileSnapshot{}, primary
 		}
 		removed = append(removed, removedSource{Path: path, Before: before})
-		return nil
+		return before, nil
 	}
 
 	deletePaths := make([]string, 0, len(deleteTargets))
@@ -108,15 +114,30 @@ func commitStagedFiles(states []*patchFileState, deleteTargets map[string]struct
 	}
 	sort.Strings(deletePaths)
 	for _, path := range deletePaths {
-		if err := removePath(path, "delete target"); err != nil {
-			return err
+		before, err := removePath(path, "delete target")
+		if err != nil {
+			return nil, err
+		}
+		target := deleteTargets[path]
+		if before.Exists && len(target.OperationIDs) > 0 {
+			operationIDs := append(
+				[]patchformat.WholeFileDeletionOperationID(nil),
+				target.OperationIDs...,
+			)
+			deletionFacts = append(deletionFacts, patchformat.WholeFileDeletionFact{
+				PhysicalGroup: patchformat.WholeFileDeletionGroupID{
+					FirstOperation: operationIDs[0],
+				},
+				OperationIDs: operationIDs,
+				Removed:      len(splitLines(string(before.Data))),
+			})
 		}
 	}
 
 	for _, s := range states {
 		if s.NewPath != s.Original {
-			if err := removePath(s.Original, "moved source"); err != nil {
-				return err
+			if _, err := removePath(s.Original, "moved source"); err != nil {
+				return nil, err
 			}
 		}
 	}
@@ -125,29 +146,33 @@ func commitStagedFiles(states []*patchFileState, deleteTargets map[string]struct
 		if err := os.MkdirAll(filepath.Dir(s.NewPath), 0o755); err != nil {
 			primary := fmt.Errorf("create parent dir for %s: %w", s.NewPath, err)
 			if rollbackErr := rollback(); rollbackErr != nil {
-				return errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
+				return nil, errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
 			}
-			return primary
+			return nil, primary
 		}
 		before, err := captureSnapshot(s.NewPath)
 		if err != nil {
 			primary := fmt.Errorf("snapshot target %s: %w", s.NewPath, err)
 			if rollbackErr := rollback(); rollbackErr != nil {
-				return errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
+				return nil, errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
 			}
-			return primary
+			return nil, primary
 		}
 		if err := os.Rename(s.StagedPath, s.NewPath); err != nil {
 			primary := fmt.Errorf("commit write %s: %w", s.NewPath, err)
 			if rollbackErr := rollback(); rollbackErr != nil {
-				return errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
+				return nil, errors.Join(primary, fmt.Errorf("rollback failed: %w", rollbackErr))
 			}
-			return primary
+			return nil, primary
 		}
 		committed = append(committed, committedWrite{Path: s.NewPath, Before: before})
 	}
 
-	return nil
+	sort.Slice(deletionFacts, func(i, j int) bool {
+		return deletionFacts[i].PhysicalGroup.FirstOperation.HunkOrdinal <
+			deletionFacts[j].PhysicalGroup.FirstOperation.HunkOrdinal
+	})
+	return deletionFacts, nil
 }
 
 func createStagedFile(targetPath string, data []byte, mode os.FileMode) (string, error) {

--- a/server/tools/patch/tool_deletion_facts_test.go
+++ b/server/tools/patch/tool_deletion_facts_test.go
@@ -17,6 +17,8 @@ func TestDeleteFileReturnsAuthoritativeLogicalLineCountFacts(t *testing.T) {
 	}{
 		{name: "crlf final newline", content: "first\r\nsecond\r\n", want: 2},
 		{name: "no final newline", content: "first\nsecond", want: 2},
+		{name: "single blank lf line", content: "\n", want: 1},
+		{name: "single blank crlf line", content: "\r\n", want: 1},
 		{name: "empty", content: "", want: 0},
 	}
 	for _, test := range tests {

--- a/server/tools/patch/tool_deletion_facts_test.go
+++ b/server/tools/patch/tool_deletion_facts_test.go
@@ -1,0 +1,154 @@
+package patch
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"core/server/tools"
+	patchformat "core/shared/transcript/patchformat"
+)
+
+func TestDeleteFileReturnsAuthoritativeLogicalLineCountFacts(t *testing.T) {
+	tests := []struct {
+		name, content string
+		want          int
+	}{
+		{name: "crlf final newline", content: "first\r\nsecond\r\n", want: 2},
+		{name: "no final newline", content: "first\nsecond", want: 2},
+		{name: "empty", content: "", want: 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			if err := os.WriteFile(filepath.Join(workspace, "delete.txt"), []byte(test.content), 0o644); err != nil {
+				t.Fatalf("seed target: %v", err)
+			}
+			result := callPatch(t, newPatchTestTool(t, workspace), "delete-count",
+				"*** Begin Patch\n*** Delete File: delete.txt\n*** End Patch\n")
+			id := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0}
+			facts := deletionFacts(result)
+			if result.IsError || len(facts) != 1 ||
+				facts[0].PhysicalGroup.FirstOperation != id ||
+				!slices.Equal(facts[0].OperationIDs, []patchformat.WholeFileDeletionOperationID{id}) ||
+				facts[0].Removed != test.want {
+				t.Fatalf("result error=%t facts=%+v, want operation %+v removed %d", result.IsError, facts, id, test.want)
+			}
+		})
+	}
+}
+
+func TestRepeatedAndAliasDeleteHunksShareOnePhysicalFact(t *testing.T) {
+	tests := []struct {
+		name       string
+		secondPath string
+		wantFiles  int
+	}{
+		{name: "same path", secondPath: "target.txt", wantFiles: 1},
+		{name: "symlink alias", secondPath: "alias.txt", wantFiles: 2},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			target := filepath.Join(workspace, "target.txt")
+			if err := os.WriteFile(target, []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+				t.Fatalf("seed target: %v", err)
+			}
+			if test.secondPath == "alias.txt" {
+				if err := os.Symlink(target, filepath.Join(workspace, test.secondPath)); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			}
+			patchText := "*** Begin Patch\n*** Delete File: target.txt\n*** Delete File: " +
+				test.secondPath + "\n*** End Patch\n"
+			result := callPatch(t, newPatchTestTool(t, workspace), "grouped-delete", patchText)
+			wantIDs := []patchformat.WholeFileDeletionOperationID{{HunkOrdinal: 0}, {HunkOrdinal: 1}}
+			facts := deletionFacts(result)
+			if result.IsError || len(facts) != 1 ||
+				!slices.Equal(facts[0].OperationIDs, wantIDs) ||
+				facts[0].Removed != 3 {
+				t.Fatalf("result error=%t facts=%+v, want one grouped count", result.IsError, facts)
+			}
+			finalized, mismatch := patchformat.ApplyWholeFileDeletionFacts(
+				patchformat.Render(patchText, workspace),
+				facts,
+			)
+			if mismatch != nil || len(finalized.Files) != test.wantFiles {
+				t.Fatalf("finalized=%+v mismatch=%+v", finalized.Files, mismatch)
+			}
+			for index, file := range finalized.Files {
+				if removed := patchformat.RemovedLineCount(file); removed == nil || *removed != 3 {
+					t.Fatalf("file %d removed count = %v, want known 3", index, removed)
+				}
+			}
+		})
+	}
+}
+
+func TestCommitDeletionFactsUseRemovedSnapshotAndDisappearOnRollback(t *testing.T) {
+	t.Run("commit snapshot", func(t *testing.T) {
+		target := filepath.Join(t.TempDir(), "delete.txt")
+		if err := os.WriteFile(target, []byte("commit\nsnapshot\ncontent\n"), 0o644); err != nil {
+			t.Fatalf("seed target: %v", err)
+		}
+		id := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 4}
+		facts, err := commitStagedFiles(nil, map[string]wholeFileDeletionTarget{
+			target: {OperationIDs: []patchformat.WholeFileDeletionOperationID{id}},
+		})
+		if err != nil || len(facts) != 1 ||
+			facts[0].PhysicalGroup.FirstOperation != id ||
+			facts[0].Removed != 3 {
+			t.Fatalf("commit facts=%+v err=%v", facts, err)
+		}
+	})
+
+	t.Run("rollback", func(t *testing.T) {
+		workspace := t.TempDir()
+		deleteTarget := filepath.Join(workspace, "delete.txt")
+		if err := os.WriteFile(deleteTarget, []byte("restore\nme\n"), 0o644); err != nil {
+			t.Fatalf("seed delete target: %v", err)
+		}
+		blocker := filepath.Join(workspace, "blocking")
+		if err := os.Mkdir(blocker, 0o755); err != nil {
+			t.Fatalf("seed blocker: %v", err)
+		}
+		stage, err := createStagedFile(blocker, []byte("cannot commit\n"), 0o644)
+		if err != nil {
+			t.Fatalf("stage failing write: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Remove(stage) })
+		facts, err := commitStagedFiles(
+			[]*patchFileState{{Exists: true, NewPath: blocker, Original: blocker, StagedPath: stage}},
+			map[string]wholeFileDeletionTarget{
+				deleteTarget: {OperationIDs: []patchformat.WholeFileDeletionOperationID{{HunkOrdinal: 0}}},
+			},
+		)
+		if err == nil || len(facts) != 0 {
+			t.Fatalf("rollback facts=%+v err=%v", facts, err)
+		}
+		assertPatchFileContent(t, deleteTarget, "restore\nme\n")
+	})
+}
+
+func TestMoveAndFailedDeletionReturnNoFacts(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "source.txt"), []byte("move\n"), 0o644); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+	move := callPatch(t, newPatchTestTool(t, workspace), "move",
+		"*** Begin Patch\n*** Update File: source.txt\n*** Move to: destination.txt\n*** End Patch\n")
+	missing := callPatch(t, newPatchTestTool(t, workspace), "missing",
+		"*** Begin Patch\n*** Delete File: missing.txt\n*** End Patch\n")
+	if move.IsError || len(deletionFacts(move)) != 0 ||
+		!missing.IsError || len(deletionFacts(missing)) != 0 {
+		t.Fatalf("move=%+v missing=%+v", move, missing)
+	}
+}
+
+func deletionFacts(result tools.Result) []patchformat.WholeFileDeletionFact {
+	if result.PresentationDelta == nil {
+		return nil
+	}
+	return result.PresentationDelta.WholeFileDeletionFacts
+}

--- a/server/tools/patch/tool_state.go
+++ b/server/tools/patch/tool_state.go
@@ -16,8 +16,12 @@ type applyState struct {
 	tool            *Tool
 	ctx             context.Context
 	state           map[string]*patchFileState
-	deleteTargets   map[string]struct{}
+	deleteTargets   map[string]wholeFileDeletionTarget
 	approvedOutside map[string]bool
+}
+
+type wholeFileDeletionTarget struct {
+	OperationIDs []patchformat.WholeFileDeletionOperationID
 }
 
 func newApplyState(tool *Tool, ctx context.Context) *applyState {
@@ -25,7 +29,7 @@ func newApplyState(tool *Tool, ctx context.Context) *applyState {
 		tool:            tool,
 		ctx:             ctx,
 		state:           map[string]*patchFileState{},
-		deleteTargets:   map[string]struct{}{},
+		deleteTargets:   map[string]wholeFileDeletionTarget{},
 		approvedOutside: map[string]bool{},
 	}
 }
@@ -155,7 +159,10 @@ func (s *applyState) addFile(op patchformat.AddFile) error {
 	return nil
 }
 
-func (s *applyState) deleteFile(op patchformat.DeleteFile) error {
+func (s *applyState) deleteFile(
+	op patchformat.DeleteFile,
+	operationID patchformat.WholeFileDeletionOperationID,
+) error {
 	target, err := s.tool.resolvePath(s.ctx, op.Path, true, s.approvedOutside)
 	if err != nil {
 		return err
@@ -170,7 +177,9 @@ func (s *applyState) deleteFile(op patchformat.DeleteFile) error {
 	if !snapshot.Exists {
 		return targetMissingFailure(op.Path, "cannot delete a file that does not exist")
 	}
-	s.deleteTargets[target] = struct{}{}
+	deleteTarget := s.deleteTargets[target]
+	deleteTarget.OperationIDs = append(deleteTarget.OperationIDs, operationID)
+	s.deleteTargets[target] = deleteTarget
 	return nil
 }
 

--- a/server/tools/patch/tool_test.go
+++ b/server/tools/patch/tool_test.go
@@ -498,7 +498,7 @@ func TestCommitStagedFilesRollsBackCommittedTargetsOnLaterFailure(t *testing.T) 
 		{Exists: true, NewPath: blockingDir, Original: blockingDir, StagedPath: secondStage},
 	}
 
-	err = commitStagedFiles(states, nil)
+	_, err = commitStagedFiles(states, nil)
 	if err == nil {
 		t.Fatal("expected transactional commit failure")
 	}

--- a/shared/transcript/entry_compare.go
+++ b/shared/transcript/entry_compare.go
@@ -132,7 +132,8 @@ func renderedPatchesEqual(left, right *patchformat.RenderedPatch) bool {
 			a.RelPath == b.RelPath &&
 			a.Added == b.Added &&
 			a.Removed == b.Removed &&
-			slices.Equal(a.Diff, b.Diff)
+			slices.Equal(a.Diff, b.Diff) &&
+			slices.EqualFunc(a.WholeFileDeletions, b.WholeFileDeletions, wholeFileDeletionOperationsEqual)
 	}) &&
 		slices.EqualFunc(left.SummaryLines, right.SummaryLines, func(a, b patchformat.RenderedLine) bool {
 			return a.Kind == b.Kind &&
@@ -146,4 +147,18 @@ func renderedPatchesEqual(left, right *patchformat.RenderedPatch) bool {
 				a.FileIndex == b.FileIndex &&
 				a.Path == b.Path
 		})
+}
+
+func wholeFileDeletionOperationsEqual(
+	left patchformat.WholeFileDeletionOperation,
+	right patchformat.WholeFileDeletionOperation,
+) bool {
+	if left.ID != right.ID {
+		return false
+	}
+	if left.Disposition == nil || right.Disposition == nil {
+		return left.Disposition == nil && right.Disposition == nil
+	}
+	return left.Disposition.PhysicalGroup == right.Disposition.PhysicalGroup &&
+		left.Disposition.Removed == right.Disposition.Removed
 }

--- a/shared/transcript/entry_compare_test.go
+++ b/shared/transcript/entry_compare_test.go
@@ -80,3 +80,61 @@ func TestEntryPayloadEqualIncludesPatchRenderMetadata(t *testing.T) {
 		t.Fatal("expected patch render summary change to make entries different")
 	}
 }
+
+func TestToolCallMetaEqualDistinguishesWholeFileDeletionDispositionStates(t *testing.T) {
+	id := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0}
+	group := patchformat.WholeFileDeletionGroupID{FirstOperation: id}
+	legacy := &ToolCallMeta{ToolName: "patch", PatchRender: &patchformat.RenderedPatch{
+		Files: []patchformat.RenderedFile{{RelPath: "target.txt"}},
+	}}
+	pending := &ToolCallMeta{ToolName: "patch", PatchRender: &patchformat.RenderedPatch{
+		Files: []patchformat.RenderedFile{{
+			RelPath: "target.txt",
+			WholeFileDeletions: []patchformat.WholeFileDeletionOperation{{
+				ID: id,
+			}},
+		}},
+	}}
+	zero := &ToolCallMeta{ToolName: "patch", PatchRender: &patchformat.RenderedPatch{
+		Files: []patchformat.RenderedFile{{
+			RelPath: "target.txt",
+			WholeFileDeletions: []patchformat.WholeFileDeletionOperation{{
+				ID: id,
+				Disposition: &patchformat.WholeFileDeletionDisposition{
+					PhysicalGroup: group,
+					Removed:       0,
+				},
+			}},
+		}},
+	}}
+
+	if ToolCallMetaEqual(legacy, pending) {
+		t.Fatal("legacy missing operation metadata equals explicit pending operation")
+	}
+	if ToolCallMetaEqual(pending, zero) {
+		t.Fatal("absent disposition equals present zero disposition")
+	}
+
+	positive := cloneToolCallMetaForEqualityTest(zero)
+	positive.PatchRender.Files[0].WholeFileDeletions[0].Disposition.Removed = 4
+	if ToolCallMetaEqual(zero, positive) {
+		t.Fatal("present zero equals present positive disposition")
+	}
+
+	otherGroup := cloneToolCallMetaForEqualityTest(positive)
+	otherGroup.PatchRender.Files[0].WholeFileDeletions[0].Disposition.PhysicalGroup.FirstOperation.HunkOrdinal = 1
+	if ToolCallMetaEqual(positive, otherGroup) {
+		t.Fatal("different physical group identity compares equal")
+	}
+
+	legacyCopy := cloneToolCallMetaForEqualityTest(legacy)
+	if !ToolCallMetaEqual(legacy, legacyCopy) {
+		t.Fatal("equivalent legacy renders compare different")
+	}
+}
+
+func cloneToolCallMetaForEqualityTest(source *ToolCallMeta) *ToolCallMeta {
+	cloned := *source
+	cloned.PatchRender = patchformat.Clone(source.PatchRender)
+	return &cloned
+}

--- a/shared/transcript/patchformat/deletion_presentation_test.go
+++ b/shared/transcript/patchformat/deletion_presentation_test.go
@@ -1,0 +1,128 @@
+package patchformat
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestWholeFileDeletionPresentationFinalizesGroupedAliasesWithoutMutatingSource(t *testing.T) {
+	rendered := Format(Document{Hunks: []any{
+		DeleteFile{Path: "target.txt"},
+		DeleteFile{Path: "target.txt"},
+		DeleteFile{Path: "alias.txt"},
+	}}, "/workspace")
+	if len(rendered.Files) != 2 ||
+		len(rendered.Files[0].WholeFileDeletions) != 2 ||
+		len(rendered.Files[1].WholeFileDeletions) != 1 {
+		t.Fatalf("pending operations = %+v", rendered.Files)
+	}
+	for ordinal, operation := range []WholeFileDeletionOperation{
+		rendered.Files[0].WholeFileDeletions[0],
+		rendered.Files[0].WholeFileDeletions[1],
+		rendered.Files[1].WholeFileDeletions[0],
+	} {
+		if operation.ID.HunkOrdinal != ordinal || operation.Disposition != nil {
+			t.Fatalf("pending operation %d = %+v", ordinal, operation)
+		}
+	}
+	if RemovedLineCount(rendered.Files[0]) != nil {
+		t.Fatal("pending deletion exposed a removal count")
+	}
+
+	first := WholeFileDeletionOperationID{HunkOrdinal: 0}
+	finalized, mismatch := ApplyWholeFileDeletionFacts(rendered, []WholeFileDeletionFact{{
+		PhysicalGroup: WholeFileDeletionGroupID{FirstOperation: first},
+		OperationIDs: []WholeFileDeletionOperationID{
+			first,
+			{HunkOrdinal: 1},
+			{HunkOrdinal: 2},
+		},
+		Removed: 7,
+	}})
+	if mismatch != nil {
+		t.Fatalf("apply grouped fact: %+v", mismatch)
+	}
+	for index, file := range finalized.Files {
+		if removed := RemovedLineCount(file); removed == nil || *removed != 7 {
+			t.Fatalf("file %d removed count = %v, want known 7", index, removed)
+		}
+		for _, operation := range file.WholeFileDeletions {
+			if operation.Disposition == nil ||
+				operation.Disposition.PhysicalGroup.FirstOperation != first ||
+				operation.Disposition.Removed != 7 {
+				t.Fatalf("file %d operation = %+v", index, operation)
+			}
+		}
+	}
+	if rendered.Files[0].WholeFileDeletions[0].Disposition != nil {
+		t.Fatal("fact application mutated its source")
+	}
+	if slices.Equal(rendered.SummaryLines, finalized.SummaryLines) ||
+		finalized.SummaryText() != joinRenderedLines(finalized.SummaryLines) ||
+		finalized.DetailText() != joinRenderedLines(finalized.DetailLines) {
+		t.Fatal("fact application did not regenerate render aliases")
+	}
+}
+
+func TestWholeFileDeletionPresentationPreservesKnownZero(t *testing.T) {
+	rendered := Render(
+		"*** Begin Patch\n*** Delete File: empty.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	id := WholeFileDeletionOperationID{HunkOrdinal: 0}
+	finalized, mismatch := ApplyWholeFileDeletionFacts(rendered, []WholeFileDeletionFact{{
+		PhysicalGroup: WholeFileDeletionGroupID{FirstOperation: id},
+		OperationIDs:  []WholeFileDeletionOperationID{id},
+	}})
+	if mismatch != nil {
+		t.Fatalf("apply zero fact: %+v", mismatch)
+	}
+	if removed := RemovedLineCount(finalized.Files[0]); removed == nil || *removed != 0 {
+		t.Fatalf("removed count = %v, want present zero", removed)
+	}
+}
+
+func TestWholeFileDeletionPresentationReturnsTypedMismatchContext(t *testing.T) {
+	rendered := Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	received := []WholeFileDeletionOperationID{{HunkOrdinal: 9}}
+	group, count := WholeFileDeletionGroupID{FirstOperation: received[0]}, 3
+	_, mismatch := ApplyWholeFileDeletionFacts(rendered, []WholeFileDeletionFact{{
+		PhysicalGroup: group,
+		OperationIDs:  received,
+		Removed:       count,
+	}})
+	if mismatch == nil ||
+		mismatch.Kind != WholeFileDeletionFactMismatchUnexpectedOperation ||
+		!slices.Equal(mismatch.ExpectedOperationIDs, []WholeFileDeletionOperationID{{HunkOrdinal: 0}}) ||
+		!slices.Equal(mismatch.ReceivedOperationIDs, received) ||
+		mismatch.PhysicalGroup == nil || *mismatch.PhysicalGroup != group ||
+		mismatch.Removed == nil || *mismatch.Removed != count {
+		t.Fatalf("mismatch context = %+v", mismatch)
+	}
+}
+
+func TestCloneOwnsNestedWholeFileDeletionMetadata(t *testing.T) {
+	id := WholeFileDeletionOperationID{HunkOrdinal: 0}
+	source := RenderedPatch{Files: []RenderedFile{{
+		WholeFileDeletions: []WholeFileDeletionOperation{{
+			ID: id,
+			Disposition: &WholeFileDeletionDisposition{
+				PhysicalGroup: WholeFileDeletionGroupID{FirstOperation: id},
+				Removed:       2,
+			},
+		}},
+	}}}
+	cloned := Clone(&source)
+	cloned.Files[0].WholeFileDeletions[0].ID.HunkOrdinal = 5
+	cloned.Files[0].WholeFileDeletions[0].Disposition.PhysicalGroup.FirstOperation.HunkOrdinal = 6
+	cloned.Files[0].WholeFileDeletions[0].Disposition.Removed = 7
+	if operation := source.Files[0].WholeFileDeletions[0]; operation.ID != id ||
+		operation.Disposition == nil ||
+		operation.Disposition.PhysicalGroup.FirstOperation != id ||
+		operation.Disposition.Removed != 2 {
+		t.Fatalf("source aliased through clone: %+v", operation)
+	}
+}

--- a/shared/transcript/patchformat/deletion_presentation_test.go
+++ b/shared/transcript/patchformat/deletion_presentation_test.go
@@ -104,6 +104,31 @@ func TestWholeFileDeletionPresentationReturnsTypedMismatchContext(t *testing.T) 
 	}
 }
 
+func TestWholeFileDeletionPresentationRejectsNoncanonicalOperationOrder(t *testing.T) {
+	rendered := Format(Document{Hunks: []any{
+		DeleteFile{Path: "target.txt"},
+		DeleteFile{Path: "target.txt"},
+	}}, "/workspace")
+	received := []WholeFileDeletionOperationID{
+		{HunkOrdinal: 1},
+		{HunkOrdinal: 0},
+	}
+	group := WholeFileDeletionGroupID{FirstOperation: received[0]}
+
+	_, mismatch := ApplyWholeFileDeletionFacts(rendered, []WholeFileDeletionFact{{
+		PhysicalGroup: group,
+		OperationIDs:  received,
+		Removed:       3,
+	}})
+	if mismatch == nil ||
+		mismatch.Kind != WholeFileDeletionFactMismatchInvalidGroup ||
+		!slices.Equal(mismatch.ReceivedOperationIDs, received) ||
+		mismatch.PhysicalGroup == nil ||
+		*mismatch.PhysicalGroup != group {
+		t.Fatalf("noncanonical ordering mismatch = %+v", mismatch)
+	}
+}
+
 func TestCloneOwnsNestedWholeFileDeletionMetadata(t *testing.T) {
 	id := WholeFileDeletionOperationID{HunkOrdinal: 0}
 	source := RenderedPatch{Files: []RenderedFile{{

--- a/shared/transcript/patchformat/render.go
+++ b/shared/transcript/patchformat/render.go
@@ -74,6 +74,10 @@ func Raw(src string) RenderedPatch {
 
 func Format(doc Document, cwd string) RenderedPatch {
 	files := buildRenderedFiles(doc, cwd)
+	return renderFiles(files)
+}
+
+func renderFiles(files []RenderedFile) RenderedPatch {
 	if len(files) == 0 {
 		return RenderedPatch{}
 	}
@@ -145,7 +149,7 @@ func buildRenderedFiles(doc Document, cwd string) []RenderedFile {
 		return &files[idx]
 	}
 
-	for _, hunk := range doc.Hunks {
+	for ordinal, hunk := range doc.Hunks {
 		switch op := hunk.(type) {
 		case AddFile:
 			file := getFile(op.Path)
@@ -179,7 +183,12 @@ func buildRenderedFiles(doc Document, cwd string) []RenderedFile {
 			if file == nil {
 				continue
 			}
-			file.Removed++
+			file.WholeFileDeletions = append(
+				file.WholeFileDeletions,
+				WholeFileDeletionOperation{
+					ID: WholeFileDeletionOperationID{HunkOrdinal: ordinal},
+				},
+			)
 			file.Diff = append(file.Diff, "-<deleted file>")
 		}
 	}
@@ -205,10 +214,179 @@ func summaryLine(file RenderedFile) string {
 	if file.Added > 0 {
 		line += fmt.Sprintf(" +%d", file.Added)
 	}
-	if file.Removed > 0 {
-		line += fmt.Sprintf(" -%d", file.Removed)
+	if removed := RemovedLineCount(file); removed != nil {
+		line += fmt.Sprintf(" -%d", *removed)
 	}
 	return line
+}
+
+func RemovedLineCount(file RenderedFile) *int {
+	total := file.Removed
+	known := file.Removed > 0
+	groups := make(map[WholeFileDeletionGroupID]struct{}, len(file.WholeFileDeletions))
+	for _, operation := range file.WholeFileDeletions {
+		if operation.Disposition == nil {
+			continue
+		}
+		known = true
+		group := operation.Disposition.PhysicalGroup
+		if _, exists := groups[group]; exists {
+			continue
+		}
+		groups[group] = struct{}{}
+		total += operation.Disposition.Removed
+	}
+	if !known {
+		return nil
+	}
+	return &total
+}
+
+func ApplyWholeFileDeletionFacts(
+	rendered RenderedPatch,
+	facts []WholeFileDeletionFact,
+) (RenderedPatch, *WholeFileDeletionFactMismatch) {
+	out := Clone(&rendered)
+	if out == nil {
+		out = &RenderedPatch{}
+	}
+	type operationLocation struct {
+		fileIndex      int
+		operationIndex int
+	}
+	expected := make([]WholeFileDeletionOperationID, 0)
+	locations := make(map[WholeFileDeletionOperationID]operationLocation)
+	for fileIndex := range out.Files {
+		for operationIndex, operation := range out.Files[fileIndex].WholeFileDeletions {
+			expected = append(expected, operation.ID)
+			if _, duplicate := locations[operation.ID]; duplicate {
+				return rendered, deletionFactMismatch(
+					WholeFileDeletionFactMismatchDuplicateOperation,
+					expected,
+					nil,
+					nil,
+					nil,
+				)
+			}
+			locations[operation.ID] = operationLocation{
+				fileIndex:      fileIndex,
+				operationIndex: operationIndex,
+			}
+		}
+	}
+
+	received := make([]WholeFileDeletionOperationID, 0, len(expected))
+	seen := make(map[WholeFileDeletionOperationID]struct{}, len(expected))
+	seenGroups := make(map[WholeFileDeletionGroupID]struct{}, len(facts))
+	for _, fact := range facts {
+		group := fact.PhysicalGroup
+		removed := fact.Removed
+		if fact.Removed < 0 {
+			return rendered, deletionFactMismatch(
+				WholeFileDeletionFactMismatchInvalidCount,
+				expected,
+				append(received, fact.OperationIDs...),
+				&group,
+				&removed,
+			)
+		}
+		if len(fact.OperationIDs) == 0 ||
+			fact.PhysicalGroup.FirstOperation != fact.OperationIDs[0] {
+			return rendered, deletionFactMismatch(
+				WholeFileDeletionFactMismatchInvalidGroup,
+				expected,
+				append(received, fact.OperationIDs...),
+				&group,
+				&removed,
+			)
+		}
+		if _, duplicate := seenGroups[group]; duplicate {
+			return rendered, deletionFactMismatch(
+				WholeFileDeletionFactMismatchInvalidGroup,
+				expected,
+				append(received, fact.OperationIDs...),
+				&group,
+				&removed,
+			)
+		}
+		seenGroups[group] = struct{}{}
+		for _, operationID := range fact.OperationIDs {
+			received = append(received, operationID)
+			if _, duplicate := seen[operationID]; duplicate {
+				return rendered, deletionFactMismatch(
+					WholeFileDeletionFactMismatchDuplicateOperation,
+					expected,
+					received,
+					&group,
+					&removed,
+				)
+			}
+			seen[operationID] = struct{}{}
+			location, exists := locations[operationID]
+			if !exists {
+				return rendered, deletionFactMismatch(
+					WholeFileDeletionFactMismatchUnexpectedOperation,
+					expected,
+					received,
+					&group,
+					&removed,
+				)
+			}
+			if out.Files[location.fileIndex].WholeFileDeletions[location.operationIndex].Disposition != nil {
+				return rendered, deletionFactMismatch(
+					WholeFileDeletionFactMismatchDuplicateOperation,
+					expected,
+					received,
+					&group,
+					&removed,
+				)
+			}
+		}
+	}
+	if len(received) != len(expected) {
+		return rendered, deletionFactMismatch(
+			WholeFileDeletionFactMismatchMissingOperation,
+			expected,
+			received,
+			nil,
+			nil,
+		)
+	}
+
+	for _, fact := range facts {
+		for _, operationID := range fact.OperationIDs {
+			location := locations[operationID]
+			out.Files[location.fileIndex].WholeFileDeletions[location.operationIndex].Disposition =
+				&WholeFileDeletionDisposition{
+					PhysicalGroup: fact.PhysicalGroup,
+					Removed:       fact.Removed,
+				}
+		}
+	}
+	return renderFiles(out.Files), nil
+}
+
+func deletionFactMismatch(
+	kind WholeFileDeletionFactMismatchKind,
+	expected []WholeFileDeletionOperationID,
+	received []WholeFileDeletionOperationID,
+	group *WholeFileDeletionGroupID,
+	removed *int,
+) *WholeFileDeletionFactMismatch {
+	mismatch := &WholeFileDeletionFactMismatch{
+		Kind:                 kind,
+		ExpectedOperationIDs: append([]WholeFileDeletionOperationID(nil), expected...),
+		ReceivedOperationIDs: append([]WholeFileDeletionOperationID(nil), received...),
+	}
+	if group != nil {
+		copyGroup := *group
+		mismatch.PhysicalGroup = &copyGroup
+	}
+	if removed != nil {
+		copyRemoved := *removed
+		mismatch.Removed = &copyRemoved
+	}
+	return mismatch
 }
 
 func detailHeader(file RenderedFile) string {

--- a/shared/transcript/patchformat/render.go
+++ b/shared/transcript/patchformat/render.go
@@ -300,6 +300,18 @@ func ApplyWholeFileDeletionFacts(
 				&removed,
 			)
 		}
+		for index := 1; index < len(fact.OperationIDs); index++ {
+			if fact.OperationIDs[index-1].HunkOrdinal >
+				fact.OperationIDs[index].HunkOrdinal {
+				return rendered, deletionFactMismatch(
+					WholeFileDeletionFactMismatchInvalidGroup,
+					expected,
+					append(received, fact.OperationIDs...),
+					&group,
+					&removed,
+				)
+			}
+		}
 		if _, duplicate := seenGroups[group]; duplicate {
 			return rendered, deletionFactMismatch(
 				WholeFileDeletionFactMismatchInvalidGroup,

--- a/shared/transcript/patchformat/types.go
+++ b/shared/transcript/patchformat/types.go
@@ -1,6 +1,9 @@
 package patchformat
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 type Document struct {
 	Hunks []any
@@ -13,6 +16,70 @@ type AddFile struct {
 
 type DeleteFile struct {
 	Path string
+}
+
+type WholeFileDeletionOperationID struct {
+	HunkOrdinal int `json:"hunk_ordinal"`
+}
+
+type WholeFileDeletionGroupID struct {
+	FirstOperation WholeFileDeletionOperationID `json:"first_operation"`
+}
+
+type WholeFileDeletionDisposition struct {
+	PhysicalGroup WholeFileDeletionGroupID `json:"physical_group"`
+	Removed       int                      `json:"removed"`
+}
+
+type WholeFileDeletionOperation struct {
+	ID          WholeFileDeletionOperationID  `json:"id"`
+	Disposition *WholeFileDeletionDisposition `json:"disposition"`
+}
+
+type WholeFileDeletionFact struct {
+	PhysicalGroup WholeFileDeletionGroupID
+	OperationIDs  []WholeFileDeletionOperationID
+	Removed       int
+}
+
+type WholeFileDeletionFactMismatchKind string
+
+const (
+	WholeFileDeletionFactMismatchMissingOperation    WholeFileDeletionFactMismatchKind = "missing_operation"
+	WholeFileDeletionFactMismatchUnexpectedOperation WholeFileDeletionFactMismatchKind = "unexpected_operation"
+	WholeFileDeletionFactMismatchDuplicateOperation  WholeFileDeletionFactMismatchKind = "duplicate_operation"
+	WholeFileDeletionFactMismatchInvalidCount        WholeFileDeletionFactMismatchKind = "invalid_count"
+	WholeFileDeletionFactMismatchInvalidGroup        WholeFileDeletionFactMismatchKind = "invalid_group"
+)
+
+type WholeFileDeletionFactMismatch struct {
+	Kind                 WholeFileDeletionFactMismatchKind
+	ExpectedOperationIDs []WholeFileDeletionOperationID
+	ReceivedOperationIDs []WholeFileDeletionOperationID
+	PhysicalGroup        *WholeFileDeletionGroupID
+	Removed              *int
+}
+
+func (m *WholeFileDeletionFactMismatch) Error() string {
+	if m == nil {
+		return "whole-file deletion fact mismatch"
+	}
+	group := "absent"
+	if m.PhysicalGroup != nil {
+		group = fmt.Sprintf("%+v", *m.PhysicalGroup)
+	}
+	removed := "absent"
+	if m.Removed != nil {
+		removed = fmt.Sprintf("%d", *m.Removed)
+	}
+	return fmt.Sprintf(
+		"whole-file deletion fact mismatch (kind=%q expected=%+v received=%+v physical_group=%s removed=%s)",
+		m.Kind,
+		m.ExpectedOperationIDs,
+		m.ReceivedOperationIDs,
+		group,
+		removed,
+	)
 }
 
 type UpdateFile struct {
@@ -44,11 +111,12 @@ type RenderedLine struct {
 }
 
 type RenderedFile struct {
-	AbsPath string
-	RelPath string
-	Added   int
-	Removed int
-	Diff    []string
+	AbsPath            string
+	RelPath            string
+	Added              int
+	Removed            int
+	Diff               []string
+	WholeFileDeletions []WholeFileDeletionOperation
 }
 
 type RenderedPatch struct {
@@ -67,6 +135,19 @@ func Clone(in *RenderedPatch) *RenderedPatch {
 		for _, file := range in.Files {
 			copyFile := file
 			copyFile.Diff = append([]string(nil), file.Diff...)
+			if len(file.WholeFileDeletions) > 0 {
+				copyFile.WholeFileDeletions = make(
+					[]WholeFileDeletionOperation,
+					len(file.WholeFileDeletions),
+				)
+				for index, operation := range file.WholeFileDeletions {
+					copyFile.WholeFileDeletions[index] = operation
+					if operation.Disposition != nil {
+						disposition := *operation.Disposition
+						copyFile.WholeFileDeletions[index].Disposition = &disposition
+					}
+				}
+			}
 			out.Files = append(out.Files, copyFile)
 		}
 	}

--- a/shared/transcript/tool_codec_test.go
+++ b/shared/transcript/tool_codec_test.go
@@ -3,6 +3,9 @@ package transcript
 import (
 	"encoding/json"
 	"testing"
+
+	"core/shared/textutil"
+	patchformat "core/shared/transcript/patchformat"
 )
 
 func TestDecodeToolCallMetaTreatsEmptyObjectAsAbsent(t *testing.T) {
@@ -61,5 +64,85 @@ func TestEncodeDecodeToolCallMetaRoundTripsShellOutputStatus(t *testing.T) {
 	if !meta.RawOutputRequested || !meta.OutputTruncated || !meta.MovedToBackground ||
 		meta.ShellExitCode == nil || *meta.ShellExitCode != 7 {
 		t.Fatalf("expected shell output status to round-trip, got %+v", meta)
+	}
+}
+
+func TestEncodeDecodeToolCallMetaPreservesDeletionDispositionPresence(t *testing.T) {
+	id := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0}
+	tests := []struct {
+		name        string
+		disposition *patchformat.WholeFileDeletionDisposition
+		wantRemoved *int
+	}{
+		{name: "explicit null"},
+		{
+			name: "present zero",
+			disposition: &patchformat.WholeFileDeletionDisposition{
+				PhysicalGroup: patchformat.WholeFileDeletionGroupID{FirstOperation: id},
+				Removed:       0,
+			},
+			wantRemoved: textutil.Int(0),
+		},
+		{
+			name: "present positive",
+			disposition: &patchformat.WholeFileDeletionDisposition{
+				PhysicalGroup: patchformat.WholeFileDeletionGroupID{FirstOperation: id},
+				Removed:       8,
+			},
+			wantRemoved: textutil.Int(8),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw := EncodeToolCallMeta(ToolCallMeta{
+				ToolName: "patch",
+				PatchRender: &patchformat.RenderedPatch{Files: []patchformat.RenderedFile{{
+					RelPath: "target.txt",
+					WholeFileDeletions: []patchformat.WholeFileDeletionOperation{{
+						ID:          id,
+						Disposition: test.disposition,
+					}},
+				}}},
+			})
+			meta, ok := DecodeToolCallMeta(raw)
+			if !ok || meta.PatchRender == nil {
+				t.Fatalf("decode finalized patch metadata: ok=%t meta=%+v", ok, meta)
+			}
+			removed := patchformat.RemovedLineCount(meta.PatchRender.Files[0])
+			if test.wantRemoved == nil {
+				if removed != nil {
+					t.Fatalf("removed count = %d, want absent", *removed)
+				}
+				return
+			}
+			if removed == nil || *removed != *test.wantRemoved {
+				t.Fatalf("removed count = %v, want %d", removed, *test.wantRemoved)
+			}
+		})
+	}
+}
+
+func TestDecodeToolCallMetaAcceptsLegacyDeletionOperationWithoutDisposition(t *testing.T) {
+	raw := json.RawMessage(`{
+		"ToolName":"patch",
+		"PatchRender":{
+			"Files":[{
+				"RelPath":"target.txt",
+				"Removed":1,
+				"WholeFileDeletions":[{"id":{"hunk_ordinal":0}}]
+			}]
+		}
+	}`)
+
+	meta, ok := DecodeToolCallMeta(raw)
+	if !ok || meta.PatchRender == nil {
+		t.Fatalf("decode legacy patch metadata: ok=%t meta=%+v", ok, meta)
+	}
+	file := meta.PatchRender.Files[0]
+	if file.Removed != 1 ||
+		len(file.WholeFileDeletions) != 1 ||
+		file.WholeFileDeletions[0].Disposition != nil {
+		t.Fatalf("legacy patch metadata was reclassified: %+v", file)
 	}
 }

--- a/shared/transcript/types.go
+++ b/shared/transcript/types.go
@@ -73,24 +73,58 @@ type ToolCallMeta struct {
 // tool result. Tool-call input metadata remains authoritative for every other
 // presentation field.
 type ToolResultPresentationDelta struct {
-	RawOutputRequested bool
-	OutputTruncated    bool
-	MovedToBackground  bool
-	ShellExitCode      *int
+	RawOutputRequested     bool
+	OutputTruncated        bool
+	MovedToBackground      bool
+	ShellExitCode          *int
+	WholeFileDeletionFacts []patchformat.WholeFileDeletionFact
 }
 
-func ApplyToolResultPresentationDelta(meta ToolCallMeta, delta *ToolResultPresentationDelta) ToolCallMeta {
-	if delta == nil {
-		return NormalizeToolCallMeta(meta)
+type ToolResultPresentationOutcome uint8
+
+const (
+	ToolResultPresentationOutcomeSuccessful ToolResultPresentationOutcome = iota
+	ToolResultPresentationOutcomeFailed
+)
+
+func ApplyToolResultPresentationDelta(
+	meta ToolCallMeta,
+	delta *ToolResultPresentationDelta,
+	outcome ToolResultPresentationOutcome,
+) (ToolCallMeta, *patchformat.WholeFileDeletionFactMismatch) {
+	if delta != nil {
+		meta.RawOutputRequested = meta.RawOutputRequested || delta.RawOutputRequested
+		meta.OutputTruncated = meta.OutputTruncated || delta.OutputTruncated
+		meta.MovedToBackground = meta.MovedToBackground || delta.MovedToBackground
+		if delta.ShellExitCode != nil {
+			exitCode := *delta.ShellExitCode
+			meta.ShellExitCode = &exitCode
+		}
 	}
-	meta.RawOutputRequested = meta.RawOutputRequested || delta.RawOutputRequested
-	meta.OutputTruncated = meta.OutputTruncated || delta.OutputTruncated
-	meta.MovedToBackground = meta.MovedToBackground || delta.MovedToBackground
-	if delta.ShellExitCode != nil {
-		exitCode := *delta.ShellExitCode
-		meta.ShellExitCode = &exitCode
+	if outcome == ToolResultPresentationOutcomeFailed {
+		return NormalizeToolCallMeta(meta), nil
 	}
-	return NormalizeToolCallMeta(meta)
+
+	facts := []patchformat.WholeFileDeletionFact(nil)
+	if delta != nil {
+		facts = delta.WholeFileDeletionFacts
+	}
+	rendered := patchformat.RenderedPatch{}
+	if meta.PatchRender != nil {
+		rendered = *meta.PatchRender
+	}
+	finalized, mismatch := patchformat.ApplyWholeFileDeletionFacts(rendered, facts)
+	if mismatch != nil {
+		return NormalizeToolCallMeta(meta), mismatch
+	}
+	if meta.PatchRender != nil {
+		meta.PatchRender = &finalized
+		meta.PatchSummary = strings.TrimSpace(finalized.SummaryText())
+		meta.PatchDetail = strings.TrimSpace(finalized.DetailText())
+		meta.CompactText = meta.PatchSummary
+		meta.Command = meta.PatchDetail
+	}
+	return NormalizeToolCallMeta(meta), nil
 }
 
 func NormalizeToolCallMeta(in ToolCallMeta) ToolCallMeta {

--- a/shared/transcript/types_test.go
+++ b/shared/transcript/types_test.go
@@ -1,6 +1,10 @@
 package transcript
 
-import "testing"
+import (
+	"testing"
+
+	patchformat "core/shared/transcript/patchformat"
+)
 
 func TestNormalizeToolCallMetaRecoversKnownShellToolsWithoutPresentationMetadata(t *testing.T) {
 	tests := []struct {
@@ -105,13 +109,104 @@ func TestApplyToolResultPresentationDeltaCopiesShellExitCode(t *testing.T) {
 	exitCode := 7
 	delta := &ToolResultPresentationDelta{ShellExitCode: &exitCode}
 
-	applied := ApplyToolResultPresentationDelta(ToolCallMeta{
+	applied, mismatch := ApplyToolResultPresentationDelta(ToolCallMeta{
 		ToolName: "exec_command",
 		IsShell:  true,
-	}, delta)
+	}, delta, ToolResultPresentationOutcomeSuccessful)
+	if mismatch != nil {
+		t.Fatalf("apply shell presentation delta: %+v", mismatch)
+	}
 	exitCode = 9
 
 	if applied.ShellExitCode == nil || *applied.ShellExitCode != 7 {
 		t.Fatalf("applied shell exit code = %v, want copied 7", applied.ShellExitCode)
+	}
+}
+
+func TestApplyToolResultPresentationDeltaFinalizesGroupedDeletionFactsWithoutMutatingCallMetadata(t *testing.T) {
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+	meta := ToolCallMeta{
+		ToolName:     "patch",
+		Command:      rendered.DetailText(),
+		CompactText:  rendered.SummaryText(),
+		PatchDetail:  rendered.DetailText(),
+		PatchSummary: rendered.SummaryText(),
+		PatchRender:  &rendered,
+	}
+	first := patchformat.WholeFileDeletionOperationID{HunkOrdinal: 0}
+	delta := &ToolResultPresentationDelta{
+		WholeFileDeletionFacts: []patchformat.WholeFileDeletionFact{{
+			PhysicalGroup: patchformat.WholeFileDeletionGroupID{FirstOperation: first},
+			OperationIDs: []patchformat.WholeFileDeletionOperationID{
+				first,
+				{HunkOrdinal: 1},
+			},
+			Removed: 5,
+		}},
+	}
+
+	applied, mismatch := ApplyToolResultPresentationDelta(
+		meta,
+		delta,
+		ToolResultPresentationOutcomeSuccessful,
+	)
+	if mismatch != nil {
+		t.Fatalf("apply deletion presentation delta: %+v", mismatch)
+	}
+	if applied.PatchRender == nil {
+		t.Fatal("finalized patch render is absent")
+	}
+	if removed := patchformat.RemovedLineCount(applied.PatchRender.Files[0]); removed == nil || *removed != 5 {
+		t.Fatalf("finalized removed count = %v, want known 5", removed)
+	}
+	if applied.Command != applied.PatchDetail ||
+		applied.CompactText != applied.PatchSummary ||
+		applied.PatchDetail != applied.PatchRender.DetailText() ||
+		applied.PatchSummary != applied.PatchRender.SummaryText() {
+		t.Fatalf("finalized patch aliases are stale: %+v", applied)
+	}
+	if meta.PatchRender.Files[0].WholeFileDeletions[0].Disposition != nil {
+		t.Fatalf("authoritative call metadata was mutated: %+v", meta.PatchRender.Files[0])
+	}
+}
+
+func TestApplyToolResultPresentationDeltaPreservesPendingDispositionForFailedDeletion(t *testing.T) {
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+
+	applied, mismatch := ApplyToolResultPresentationDelta(
+		ToolCallMeta{ToolName: "patch", PatchRender: &rendered},
+		nil,
+		ToolResultPresentationOutcomeFailed,
+	)
+	if mismatch != nil {
+		t.Fatalf("apply failed deletion presentation: %+v", mismatch)
+	}
+	if applied.PatchRender == nil {
+		t.Fatal("failed deletion lost prepared patch render")
+	}
+	if removed := patchformat.RemovedLineCount(applied.PatchRender.Files[0]); removed != nil {
+		t.Fatalf("failed deletion fabricated removed count %d", *removed)
+	}
+}
+
+func TestApplyToolResultPresentationDeltaReturnsTypedMissingFactMismatch(t *testing.T) {
+	rendered := patchformat.Render(
+		"*** Begin Patch\n*** Delete File: target.txt\n*** End Patch\n",
+		"/workspace",
+	)
+
+	_, mismatch := ApplyToolResultPresentationDelta(
+		ToolCallMeta{ToolName: "patch", PatchRender: &rendered},
+		&ToolResultPresentationDelta{},
+		ToolResultPresentationOutcomeSuccessful,
+	)
+	if mismatch == nil || mismatch.Kind != patchformat.WholeFileDeletionFactMismatchMissingOperation {
+		t.Fatalf("mismatch = %+v, want typed missing operation", mismatch)
 	}
 }


### PR DESCRIPTION
## Summary

- Capture the authoritative logical line count from the exact filesystem snapshot removed by the patch transaction.
- Carry typed whole-file deletion dispositions through transcript persistence, restore, runtimeview, CLI detail projection, and Go TUI rendering.
- Preserve unknown pending/failed counts as path-only and render successful empty-file deletions as known `-0`.
- Group repeated canonical deletion operations without double-counting a physical file, while preserving move/rename behavior.
- Handle deletion-fact mismatches according to the approved contract: debug panics before persistence; release preserves the successful path-only completion and atomically appends operator-only feedback.
- Attach that atomic feedback to its tool-call identity so live and restored transcript projection interleaves each operator row immediately after its matching finalized tool result when later role=tool messages materialize.

## Verification

Passed on the rebased commit `170c02fff`:

- `./scripts/test.sh server`
- Focused shared transcript, patch tool, runtime, runtimewire, runtimeview, CLI, and Go TUI suites
- `./scripts/build.sh server --output ./bin/kent`
- `git diff --check`

## Completion evidence

- [Manual Go TUI badge proof](https://github.com/respawn-llc/kent/blob/BUI-23/.kent/evidence/BUI-23-go-tui-badges.txt): populated deletion `-6`; empty deletion `-0` in ongoing and detail.
- BUI-23 task comment dated July 18, 2026 records the human review-contract resolution retaining the accepted grouped-delete and debug mismatch behavior.
- QA reported full server/focused suites, rebuilt binary, and isolated Go PTY smoke passing; the pre-existing `.kent/tmp/` path was preserved.

## LoC totals

Relative to `origin/main` after rebase:

| Category | Gross added | Gross removed | Net |
| --- | ---: | ---: | ---: |
| Production/spec/evidence | 781 | 131 | +650 |
| Test/generated | 1,560 | 70 | +1,490 |
| **Total** | **2,341** | **201** | **+2,140** |

## Caveats and tradeoffs

- Exact whole-file counts are guaranteed for newly completed deletions; existing transcript history is not migrated or reclassified.
- A present zero is modeled explicitly rather than with a sentinel or boolean synchronization flag.
- The approved grouped-operation model keeps repeated canonical deletion hunks accepted and counts each physical group once per rendered file row.
- Move/rename source removal counts remain unchanged; follow-up task `KENT-292` tracks that separate behavior.
- Rust stub contracts and `shared/protocol/version.json` are intentionally unchanged because the active Go field is backward-compatible and unknown JSON members are ignored.
- The implementation is larger than a local renderer tweak because correctness requires transaction-time snapshot authority plus persistence/restore, clone/equality, receipt-authority, and client-boundary proofs.

## Tracking

- Closes #349
- Kent task: `BUI-23`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Whole-file deletions now display accurate removed-line counts, including known zero counts.
  * Pending deletions omit the count when unavailable instead of showing misleading values.
  * Duplicate or aliased deletion operations are consolidated consistently.
  * Transcript views preserve deletion details and operator feedback in the correct order.
  * Legacy transcript data remains compatible while retaining absent-versus-zero metadata.

* **Documentation**
  * Clarified deletion badge behavior and handling of presentation mismatches in patch and transcript specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->