### PR TITLE
Consolidate terminal turn-completion notifications

### DIFF
--- a/cli/app/session_transcript_terminal_bell.go
+++ b/cli/app/session_transcript_terminal_bell.go
@@ -9,11 +9,19 @@ func (h *bellHooks) OnTranscriptMessage(message clientui.TranscriptMessage) {
 	switch message.Kind {
 	case clientui.TranscriptMessageAssistantDelta:
 		if delta := message.Payload.AssistantDelta; delta != nil && isNoopFinalText(delta.Delta) {
-			h.clearPendingTurnCompletionForSilentFinal(delta.StepID.String())
+			h.clearPendingTurnCompletionForSilentFinal(delta.StepID)
 		}
 	case clientui.TranscriptMessageToolStart:
 		if tool := message.Payload.ToolStart; tool != nil {
-			h.recordToolCall(tool.StepID.String())
+			h.recordToolCall(tool.StepID)
+		}
+	case clientui.TranscriptMessageReviewerState:
+		if reviewer := message.Payload.ReviewerState; reviewer != nil {
+			h.recordReviewerState(*reviewer)
+		}
+	case clientui.TranscriptMessageStepState:
+		if step := message.Payload.StepState; step != nil && step.Lifecycle == clientui.StepLifecycleFinished {
+			h.recordStepFinished(step.StepID)
 		}
 	case clientui.TranscriptMessageCommittedRow:
 		row := message.Payload.CommittedRow
@@ -22,7 +30,7 @@ func (h *bellHooks) OnTranscriptMessage(message clientui.TranscriptMessage) {
 		}
 		switch row.Assistant.Phase {
 		case transcript.AssistantPhaseFinal:
-			h.recordTurnCompletion(row.Assistant.StepID.String(), row.Assistant.Text)
+			h.recordTurnCompletion(row.Assistant.StepID, row.Assistant.Text)
 		}
 	}
 }

--- a/cli/app/terminal_bell.go
+++ b/cli/app/terminal_bell.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"sync"
 
+	"core/cli/tui/transcriptrender"
 	"core/shared/clientui"
+	"core/shared/runtimeids"
 )
 
 const terminalBell = "\a"
@@ -32,6 +34,21 @@ type belTerminalNotifier struct {
 type osc9TerminalNotifier struct {
 	mu  sync.Mutex
 	out io.Writer
+}
+
+type observedNotificationTurn struct {
+	stepID    runtimeids.StepID
+	toolCalls int
+}
+
+type turnCompletionPreview struct {
+	stepID runtimeids.StepID
+	body   string
+}
+
+type queuedTurnCompletion struct {
+	preview  turnCompletionPreview
+	eligible bool
 }
 
 func newBELTerminalNotifier(out io.Writer) *belTerminalNotifier {
@@ -91,31 +108,6 @@ func supportsOSC9(lookup func(string) (string, bool)) bool {
 	return false
 }
 
-func sanitizeTerminalNotificationMessage(message string) string {
-	message = strings.ReplaceAll(message, "\x1b", "")
-	message = strings.ReplaceAll(message, terminalBell, "")
-	return message
-}
-
-func formatAssistantPreview(content string, maxChars int) string {
-	normalized := strings.Join(strings.Fields(sanitizeTerminalNotificationMessage(content)), " ")
-	trimmed := strings.TrimSpace(normalized)
-	if trimmed == "" {
-		return ""
-	}
-	if maxChars <= 0 {
-		return trimmed
-	}
-	runes := []rune(trimmed)
-	if len(runes) <= maxChars {
-		return trimmed
-	}
-	if maxChars == 1 {
-		return "…"
-	}
-	return string(runes[:maxChars-1]) + "…"
-}
-
 func (r *belTerminalNotifier) Notify(_ string) {
 	r.Bell()
 }
@@ -137,7 +129,7 @@ func (r *osc9TerminalNotifier) Notify(message string) {
 	defer r.mu.Unlock()
 	// The first BEL terminates the OSC 9 sequence. Emit a second BEL so asks and
 	// turn-complete notifications still produce an audible bell on OSC-capable terminals.
-	_, _ = io.WriteString(r.out, osc9Prefix+sanitizeTerminalNotificationMessage(message)+terminalBell+terminalBell)
+	_, _ = io.WriteString(r.out, osc9Prefix+terminalNotificationSingleLine(message)+terminalBell+terminalBell)
 }
 
 func (r *osc9TerminalNotifier) Bell() {
@@ -154,11 +146,10 @@ type bellHooks struct {
 	notifier              terminalNotifier
 	title                 func() string
 	focused               func() bool
-	currentStep           string
-	toolCalls             int
-	pendingTurnCompletion bool
+	observedTurn          *observedNotificationTurn
+	pendingTurnCompletion *queuedTurnCompletion
 	pendingCompaction     bool
-	lastCompletionMessage string
+	reviewerStep          *runtimeids.StepID
 }
 
 func newBellHooks(notifier terminalNotifier, title func() string, focused ...func() bool) *bellHooks {
@@ -186,7 +177,10 @@ func (h *bellHooks) OnAttentionNotification(evt clientui.AttentionNotificationEv
 	if !tuiSupportsAttentionNotification(*notification) {
 		return
 	}
-	body := formatAssistantPreview(attentionNotificationBody(*notification), terminalNotificationPreviewLimit)
+	body := notificationMarkdownPreview(
+		attentionNotificationBody(*notification),
+		currentTerminalCapabilities().MarkdownLinks,
+	)
 	if body == "" {
 		body = attentionNotificationFallbackBody(*notification)
 	}
@@ -238,45 +232,67 @@ func attentionNotificationApprovalMessage(notification clientui.AttentionNotific
 	return notification.Approval.Message
 }
 
-func (h *bellHooks) recordToolCall(stepID string) {
-	stepID = strings.TrimSpace(stepID)
-	if stepID == "" {
-		return
-	}
+func (h *bellHooks) recordToolCall(stepID runtimeids.StepID) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if h.currentStep != stepID {
-		h.currentStep = stepID
-		h.toolCalls = 0
+	if h.observedTurn == nil || h.observedTurn.stepID != stepID {
+		h.observedTurn = &observedNotificationTurn{stepID: stepID}
 	}
-	h.toolCalls++
+	h.observedTurn.toolCalls++
 }
 
-func (h *bellHooks) recordTurnCompletion(stepID, assistantContent string) {
-	stepID = strings.TrimSpace(stepID)
+func (h *bellHooks) recordTurnCompletion(stepID runtimeids.StepID, assistantContent string) {
 	message := turnCompletionNotificationMessage(assistantContent)
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.lastCompletionMessage = message
-	if stepID == "" || h.currentStep != stepID {
+	if h.reviewerStep != nil && *h.reviewerStep == stepID {
 		return
 	}
-	if h.toolCalls >= 2 {
-		h.pendingTurnCompletion = true
+	eligible := false
+	if h.pendingTurnCompletion != nil {
+		eligible = h.pendingTurnCompletion.eligible
 	}
-	h.currentStep = ""
-	h.toolCalls = 0
+	h.pendingTurnCompletion = &queuedTurnCompletion{
+		preview:  turnCompletionPreview{stepID: stepID, body: message},
+		eligible: eligible,
+	}
 }
 
-func (h *bellHooks) clearPendingTurnCompletionForSilentFinal(stepID string) {
-	stepID = strings.TrimSpace(stepID)
+func (h *bellHooks) recordStepFinished(stepID runtimeids.StepID) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.pendingTurnCompletion = false
-	h.lastCompletionMessage = ""
-	if stepID != "" && h.currentStep == stepID {
-		h.currentStep = ""
-		h.toolCalls = 0
+	if h.observedTurn != nil && h.observedTurn.stepID == stepID {
+		if h.pendingTurnCompletion != nil && h.observedTurn.toolCalls >= 2 {
+			h.pendingTurnCompletion.eligible = true
+		}
+		h.observedTurn = nil
+	}
+	if h.reviewerStep != nil && *h.reviewerStep == stepID {
+		h.reviewerStep = nil
+	}
+}
+
+func (h *bellHooks) recordReviewerState(state clientui.TranscriptReviewerState) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	switch state.State {
+	case clientui.ReviewerStateRunning:
+		stepID := state.StepID
+		h.reviewerStep = &stepID
+	case clientui.ReviewerStateCompleted:
+		return
+	}
+}
+
+func (h *bellHooks) clearPendingTurnCompletionForSilentFinal(stepID runtimeids.StepID) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.reviewerStep != nil && *h.reviewerStep == stepID {
+		return
+	}
+	h.pendingTurnCompletion = nil
+	if h.observedTurn != nil && h.observedTurn.stepID == stepID {
+		h.observedTurn = nil
 	}
 }
 
@@ -287,19 +303,17 @@ func (h *bellHooks) OnTurnQueueDrained() {
 	h.mu.Lock()
 	if h.pendingCompaction {
 		h.pendingCompaction = false
-		h.pendingTurnCompletion = false
-		h.lastCompletionMessage = ""
+		h.pendingTurnCompletion = nil
 		h.mu.Unlock()
 		h.notifyIfUnfocused(compactionCompletionNotificationMessage)
 		return
 	}
-	if !h.pendingTurnCompletion {
+	if h.pendingTurnCompletion == nil || !h.pendingTurnCompletion.eligible {
 		h.mu.Unlock()
 		return
 	}
-	message := h.lastCompletionMessage
-	h.pendingTurnCompletion = false
-	h.lastCompletionMessage = ""
+	message := h.pendingTurnCompletion.preview.body
+	h.pendingTurnCompletion = nil
 	h.mu.Unlock()
 	h.notifyIfUnfocused(message)
 }
@@ -309,11 +323,10 @@ func (h *bellHooks) OnTurnQueueAborted() {
 		return
 	}
 	h.mu.Lock()
-	h.currentStep = ""
-	h.toolCalls = 0
-	h.pendingTurnCompletion = false
+	h.observedTurn = nil
+	h.pendingTurnCompletion = nil
 	h.pendingCompaction = false
-	h.lastCompletionMessage = ""
+	h.reviewerStep = nil
 	h.mu.Unlock()
 }
 
@@ -330,17 +343,38 @@ func (h *bellHooks) OnUserCompactionCompleted(queueDrained bool) {
 		return
 	}
 	h.pendingCompaction = false
-	h.pendingTurnCompletion = false
-	h.lastCompletionMessage = ""
+	h.pendingTurnCompletion = nil
 	h.mu.Unlock()
 	h.notifyIfUnfocused(compactionCompletionNotificationMessage)
 }
 
 func turnCompletionNotificationMessage(assistantContent string) string {
-	if preview := formatAssistantPreview(assistantContent, terminalNotificationPreviewLimit); preview != "" {
+	if preview := notificationMarkdownPreview(
+		assistantContent,
+		currentTerminalCapabilities().MarkdownLinks,
+	); preview != "" {
 		return preview
 	}
 	return "turn complete"
+}
+
+func notificationMarkdownPreview(
+	content string,
+	linkPresentation transcriptrender.MarkdownLinkPresentation,
+) string {
+	lines := transcriptrender.RenderMarkdownStableLinesWithLinkPresentation(
+		transcriptrender.StyleRoleAssistant,
+		content,
+		terminalNotificationPreviewLimit,
+		linkPresentation,
+	)
+	plain := strings.Join(transcriptrender.PlainLines(lines), " ")
+	normalized := terminalNotificationSingleLine(plain)
+	runes := []rune(normalized)
+	if len(runes) <= terminalNotificationPreviewLimit {
+		return normalized
+	}
+	return string(runes[:terminalNotificationPreviewLimit])
 }
 
 func (h *bellHooks) formatMessage(message string) string {
@@ -348,7 +382,23 @@ func (h *bellHooks) formatMessage(message string) string {
 	if h != nil && h.title != nil {
 		title = sessionTitle(h.title())
 	}
-	return title + ": " + sanitizeTerminalNotificationMessage(message)
+	return formatTerminalNotificationMessage(title, message)
+}
+
+func formatTerminalNotificationMessage(title, message string) string {
+	composed := terminalNotificationSingleLine(sessionTitle(title) + ": " + message)
+	runes := []rune(composed)
+	if len(runes) <= terminalNotificationPreviewLimit {
+		return composed
+	}
+	return string(runes[:terminalNotificationPreviewLimit-3]) + "..."
+}
+
+func terminalNotificationSingleLine(text string) string {
+	return strings.Join(
+		strings.Fields(transcriptrender.TerminalSafeSingleLine(text)),
+		" ",
+	)
 }
 
 func (h *bellHooks) notifyIfUnfocused(message string) {
@@ -366,10 +416,7 @@ func (h *bellHooks) focusedForAttention() bool {
 		return false
 	}
 	h.mu.Lock()
-	focused := false
-	if h.focused != nil {
-		focused = h.focused()
-	}
+	focusedProvider := h.focused
 	h.mu.Unlock()
-	return focused
+	return focusedProvider != nil && focusedProvider()
 }

--- a/cli/app/terminal_bell.go
+++ b/cli/app/terminal_bell.go
@@ -39,6 +39,7 @@ type osc9TerminalNotifier struct {
 type observedNotificationTurn struct {
 	stepID    runtimeids.StepID
 	toolCalls int
+	preview   *turnCompletionPreview
 }
 
 type turnCompletionPreview struct {
@@ -129,7 +130,7 @@ func (r *osc9TerminalNotifier) Notify(message string) {
 	defer r.mu.Unlock()
 	// The first BEL terminates the OSC 9 sequence. Emit a second BEL so asks and
 	// turn-complete notifications still produce an audible bell on OSC-capable terminals.
-	_, _ = io.WriteString(r.out, osc9Prefix+terminalNotificationSingleLine(message)+terminalBell+terminalBell)
+	_, _ = io.WriteString(r.out, osc9Prefix+message+terminalBell+terminalBell)
 }
 
 func (r *osc9TerminalNotifier) Bell() {
@@ -248,22 +249,28 @@ func (h *bellHooks) recordTurnCompletion(stepID runtimeids.StepID, assistantCont
 	if h.reviewerStep != nil && *h.reviewerStep == stepID {
 		return
 	}
-	eligible := false
-	if h.pendingTurnCompletion != nil {
-		eligible = h.pendingTurnCompletion.eligible
+	if h.observedTurn == nil {
+		h.observedTurn = &observedNotificationTurn{stepID: stepID}
 	}
-	h.pendingTurnCompletion = &queuedTurnCompletion{
-		preview:  turnCompletionPreview{stepID: stepID, body: message},
-		eligible: eligible,
+	if h.observedTurn.stepID != stepID {
+		return
 	}
+	h.observedTurn.preview = &turnCompletionPreview{stepID: stepID, body: message}
 }
 
 func (h *bellHooks) recordStepFinished(stepID runtimeids.StepID) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.observedTurn != nil && h.observedTurn.stepID == stepID {
-		if h.pendingTurnCompletion != nil && h.observedTurn.toolCalls >= 2 {
-			h.pendingTurnCompletion.eligible = true
+		if h.observedTurn.preview != nil {
+			eligible := h.observedTurn.toolCalls >= 2
+			if h.pendingTurnCompletion != nil {
+				eligible = eligible || h.pendingTurnCompletion.eligible
+			}
+			h.pendingTurnCompletion = &queuedTurnCompletion{
+				preview:  *h.observedTurn.preview,
+				eligible: eligible,
+			}
 		}
 		h.observedTurn = nil
 	}

--- a/cli/app/terminal_bell_test.go
+++ b/cli/app/terminal_bell_test.go
@@ -68,6 +68,19 @@ func TestTerminalNotifierProtocolOutput(t *testing.T) {
 	}
 }
 
+func TestOSC9NotifierEncodesFormattedMessageVerbatim(t *testing.T) {
+	var out bytes.Buffer
+	notifier := newOSC9TerminalNotifier(&out)
+	formatted := "dynamic  formatted notification"
+
+	notifier.Notify(formatted)
+
+	want := osc9Prefix + formatted + terminalBell + terminalBell
+	if got := out.String(); got != want {
+		t.Fatalf("OSC 9 output = %q, want opaque formatted payload %q", got, want)
+	}
+}
+
 func TestBellHooksAttentionNotificationPolicy(t *testing.T) {
 	unfocused := &countRinger{}
 	hooks := newUnfocusedBellHooks(unfocused)
@@ -107,11 +120,13 @@ func TestBellHooksAttentionNotificationsPropagateDynamicMarkdownPreview(t *testi
 	if ringer.notifications != 2 || len(ringer.messages) != 2 {
 		t.Fatalf("dynamic attention events = notifications %d, messages %d", ringer.notifications, len(ringer.messages))
 	}
-	if !strings.Contains(ringer.messages[0], questionPreview) {
-		t.Fatalf("question notification omitted dynamic preview: %q", ringer.messages[0])
+	questionFields := strings.Fields(ringer.messages[0])
+	if got := questionFields[len(questionFields)-1]; got != questionPreview {
+		t.Fatalf("question notification dynamic preview = %q, want %q", got, questionPreview)
 	}
-	if !strings.Contains(ringer.messages[1], approvalPreview) {
-		t.Fatalf("approval notification omitted dynamic preview: %q", ringer.messages[1])
+	approvalFields := strings.Fields(ringer.messages[1])
+	if got := approvalFields[len(approvalFields)-1]; got != approvalPreview {
+		t.Fatalf("approval notification dynamic preview = %q, want %q", got, approvalPreview)
 	}
 }
 
@@ -143,8 +158,8 @@ func TestBellHooksTextNotificationsHaveNonEmptyStructuralFallbacks(t *testing.T)
 		if strings.TrimSpace(message) == "" || message == title+":" || message == title+": " {
 			t.Fatalf("notification lacks structural fallback: %q", message)
 		}
-		if strings.ContainsAny(message, "\n\t") {
-			t.Fatalf("fallback notification is not single-line: %q", message)
+		if normalized := strings.Join(strings.Fields(message), " "); normalized != message {
+			t.Fatalf("fallback notification = %q, want normalized single line %q", message, normalized)
 		}
 	}
 }
@@ -167,8 +182,10 @@ func TestBellHooksCapsCompleteNotificationAtNotifierBoundary(t *testing.T) {
 	if got := len([]rune(message)); got != terminalNotificationPreviewLimit {
 		t.Fatalf("formatted notification length = %d, want %d", got, terminalNotificationPreviewLimit)
 	}
-	if !strings.HasSuffix(message, "...") || strings.Count(message, "...") != 1 || strings.Contains(message, "…") {
-		t.Fatalf("formatted notification has invalid terminal ellipsis: %q", message)
+	composed := terminalNotificationSingleLine(title + ": " + strings.Repeat("answer", 30))
+	want := string([]rune(composed)[:terminalNotificationPreviewLimit-3]) + "..."
+	if message != want {
+		t.Fatalf("formatted notification = %q, want one final truncation %q", message, want)
 	}
 }
 
@@ -184,16 +201,9 @@ func TestNotificationMarkdownPreviewUsesVisibleSingleLineText(t *testing.T) {
 		transcriptrender.MarkdownLinkLabelAndDestination,
 	)
 
-	for _, dynamic := range []string{first, label, destination, last} {
-		if !strings.Contains(preview, dynamic) {
-			t.Fatalf("Markdown preview %q omitted dynamic visible text %q", preview, dynamic)
-		}
-	}
-	if strings.ContainsAny(preview, "*[]()\n\t") {
-		t.Fatalf("Markdown preview retained source syntax or whitespace controls: %q", preview)
-	}
-	if got := strings.Join(strings.Fields(preview), " "); got != preview {
-		t.Fatalf("Markdown preview whitespace = %q, want collapsed single line", preview)
+	want := strings.Join([]string{first, label, destination, last}, " ")
+	if preview != want {
+		t.Fatalf("Markdown preview = %q, want visible single-line text %q", preview, want)
 	}
 }
 
@@ -205,14 +215,11 @@ func TestNotificationMarkdownPreviewAdaptsLinkPresentation(t *testing.T) {
 	labelOnly := notificationMarkdownPreview(source, transcriptrender.MarkdownLinkLabelOnly)
 	withDestination := notificationMarkdownPreview(source, transcriptrender.MarkdownLinkLabelAndDestination)
 
-	if !strings.Contains(labelOnly, label) || !strings.Contains(withDestination, label) {
-		t.Fatalf("link previews omitted dynamic label: label-only=%q fallback=%q", labelOnly, withDestination)
+	if labelOnly != label {
+		t.Fatalf("label-only preview = %q, want %q", labelOnly, label)
 	}
-	if strings.Contains(labelOnly, destination) {
-		t.Fatalf("label-only preview exposed dynamic destination: %q", labelOnly)
-	}
-	if !strings.Contains(withDestination, destination) {
-		t.Fatalf("fallback preview omitted dynamic destination: %q", withDestination)
+	if want := label + " " + destination; withDestination != want {
+		t.Fatalf("fallback preview = %q, want %q", withDestination, want)
 	}
 }
 
@@ -225,8 +232,9 @@ func TestNotificationMarkdownPreviewIsBoundedWithoutVisibleTruncation(t *testing
 	if got := len([]rune(preview)); got != terminalNotificationPreviewLimit {
 		t.Fatalf("retained preview length = %d, want %d", got, terminalNotificationPreviewLimit)
 	}
-	if strings.HasSuffix(preview, "...") || strings.HasSuffix(preview, "…") {
-		t.Fatalf("retained preview contains early visible truncation: %q", preview)
+	runes := []rune(preview)
+	if last := runes[len(runes)-1]; last == '.' || last == '…' {
+		t.Fatalf("retained preview ends with visible truncation rune %q: %q", last, preview)
 	}
 }
 
@@ -242,8 +250,9 @@ func TestTerminalNotificationFormattingSlicesUnicodeSafely(t *testing.T) {
 	if got := len([]rune(message)); got != terminalNotificationPreviewLimit {
 		t.Fatalf("formatted Unicode notification length = %d, want %d", got, terminalNotificationPreviewLimit)
 	}
-	if !strings.HasSuffix(message, "...") {
-		t.Fatalf("formatted Unicode notification lacks terminal ellipsis: %q", message)
+	runes := []rune(message)
+	if got := string(runes[len(runes)-3:]); got != "..." {
+		t.Fatalf("formatted Unicode notification suffix = %q, want terminal ellipsis", got)
 	}
 }
 
@@ -260,8 +269,9 @@ func TestBellHooksCompactionUsesCompleteMessageFormatter(t *testing.T) {
 	if got := len([]rune(ringer.messages[0])); got != terminalNotificationPreviewLimit {
 		t.Fatalf("compaction notification length = %d, want %d", got, terminalNotificationPreviewLimit)
 	}
-	if !strings.HasSuffix(ringer.messages[0], "...") {
-		t.Fatalf("compaction notification lacks terminal ellipsis: %q", ringer.messages[0])
+	runes := []rune(ringer.messages[0])
+	if got := string(runes[len(runes)-3:]); got != "..." {
+		t.Fatalf("compaction notification suffix = %q, want terminal ellipsis", got)
 	}
 }
 
@@ -499,6 +509,7 @@ func TestBellHooksCorrelateQueuedTurnSteps(t *testing.T) {
 		hooks.OnTranscriptMessage(bellToolStartMessage(1))
 		hooks.OnTranscriptMessage(bellToolStartMessage(1))
 		hooks.OnTranscriptMessage(bellAssistantFinalMessage(2))
+		hooks.OnTranscriptMessage(bellStepFinishedMessage(1))
 		hooks.OnTurnQueueDrained()
 		if ringer.total() != 0 {
 			t.Fatalf("mismatched final emitted %d events", ringer.total())

--- a/cli/app/terminal_bell_test.go
+++ b/cli/app/terminal_bell_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
+	"core/cli/tui/transcriptrender"
 	"core/shared/clientui"
 	"core/shared/runtimeids"
 	"core/shared/transcript"
@@ -13,10 +15,12 @@ import (
 type countRinger struct {
 	notifications int
 	bells         int
+	messages      []string
 }
 
-func (r *countRinger) Notify(string) {
+func (r *countRinger) Notify(message string) {
 	r.notifications++
+	r.messages = append(r.messages, message)
 }
 
 func (r *countRinger) Bell() {
@@ -80,6 +84,184 @@ func TestBellHooksAttentionNotificationPolicy(t *testing.T) {
 	)
 	if focused.notifications != 0 || focused.bells != 1 {
 		t.Fatalf("focused events = notifications %d, bells %d", focused.notifications, focused.bells)
+	}
+}
+
+func TestBellHooksAttentionNotificationsPropagateDynamicMarkdownPreview(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newUnfocusedBellHooks(ringer)
+	questionPreview := "dynamic-question-preview"
+	approvalPreview := "dynamic-approval-preview"
+
+	hooks.OnAttentionNotification(testAttentionPendingEvent(
+		"question-dynamic",
+		clientui.AttentionNotificationKindQuestion,
+		"**"+questionPreview+"**",
+	))
+	hooks.OnAttentionNotification(testAttentionPendingEvent(
+		"approval-dynamic",
+		clientui.AttentionNotificationKindApproval,
+		"`"+approvalPreview+"`",
+	))
+
+	if ringer.notifications != 2 || len(ringer.messages) != 2 {
+		t.Fatalf("dynamic attention events = notifications %d, messages %d", ringer.notifications, len(ringer.messages))
+	}
+	if !strings.Contains(ringer.messages[0], questionPreview) {
+		t.Fatalf("question notification omitted dynamic preview: %q", ringer.messages[0])
+	}
+	if !strings.Contains(ringer.messages[1], approvalPreview) {
+		t.Fatalf("approval notification omitted dynamic preview: %q", ringer.messages[1])
+	}
+}
+
+func TestBellHooksTextNotificationsHaveNonEmptyStructuralFallbacks(t *testing.T) {
+	ringer := &countRinger{}
+	title := "dynamic-session"
+	hooks := newBellHooks(ringer, func() string { return title }, func() bool { return false })
+
+	hooks.OnAttentionNotification(testAttentionPendingEvent(
+		"question-empty",
+		clientui.AttentionNotificationKindQuestion,
+		"",
+	))
+	hooks.OnAttentionNotification(testAttentionPendingEvent(
+		"approval-empty",
+		clientui.AttentionNotificationKindApproval,
+		"",
+	))
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+	hooks.OnTranscriptMessage(bellAssistantFinalMessageWithText(1, " \n\t "))
+	hooks.OnTranscriptMessage(bellStepFinishedMessage(1))
+	hooks.OnTurnQueueDrained()
+
+	if len(ringer.messages) != 3 {
+		t.Fatalf("fallback notification count = %d, want three", len(ringer.messages))
+	}
+	for _, message := range ringer.messages {
+		if strings.TrimSpace(message) == "" || message == title+":" || message == title+": " {
+			t.Fatalf("notification lacks structural fallback: %q", message)
+		}
+		if strings.ContainsAny(message, "\n\t") {
+			t.Fatalf("fallback notification is not single-line: %q", message)
+		}
+	}
+}
+
+func TestBellHooksCapsCompleteNotificationAtNotifierBoundary(t *testing.T) {
+	ringer := &countRinger{}
+	title := strings.Repeat("session-", 4)
+	hooks := newBellHooks(ringer, func() string { return title }, func() bool { return false })
+
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+	hooks.OnTranscriptMessage(bellAssistantFinalMessageWithText(1, strings.Repeat("answer", 30)))
+	hooks.OnTranscriptMessage(bellStepFinishedMessage(1))
+	hooks.OnTurnQueueDrained()
+
+	if len(ringer.messages) != 1 {
+		t.Fatalf("formatted notification count = %d, want one", len(ringer.messages))
+	}
+	message := ringer.messages[0]
+	if got := len([]rune(message)); got != terminalNotificationPreviewLimit {
+		t.Fatalf("formatted notification length = %d, want %d", got, terminalNotificationPreviewLimit)
+	}
+	if !strings.HasSuffix(message, "...") || strings.Count(message, "...") != 1 || strings.Contains(message, "…") {
+		t.Fatalf("formatted notification has invalid terminal ellipsis: %q", message)
+	}
+}
+
+func TestNotificationMarkdownPreviewUsesVisibleSingleLineText(t *testing.T) {
+	first := "dynamic-bold"
+	label := "dynamic-link"
+	destination := "https://example.invalid/dynamic-target"
+	last := "dynamic-tail"
+	source := "**" + first + "**\n\n[" + label + "](" + destination + ")\t" + last
+
+	preview := notificationMarkdownPreview(
+		source,
+		transcriptrender.MarkdownLinkLabelAndDestination,
+	)
+
+	for _, dynamic := range []string{first, label, destination, last} {
+		if !strings.Contains(preview, dynamic) {
+			t.Fatalf("Markdown preview %q omitted dynamic visible text %q", preview, dynamic)
+		}
+	}
+	if strings.ContainsAny(preview, "*[]()\n\t") {
+		t.Fatalf("Markdown preview retained source syntax or whitespace controls: %q", preview)
+	}
+	if got := strings.Join(strings.Fields(preview), " "); got != preview {
+		t.Fatalf("Markdown preview whitespace = %q, want collapsed single line", preview)
+	}
+}
+
+func TestNotificationMarkdownPreviewAdaptsLinkPresentation(t *testing.T) {
+	label := "dynamic-link-label"
+	destination := "https://example.invalid/dynamic-link-destination"
+	source := "[" + label + "](" + destination + ")"
+
+	labelOnly := notificationMarkdownPreview(source, transcriptrender.MarkdownLinkLabelOnly)
+	withDestination := notificationMarkdownPreview(source, transcriptrender.MarkdownLinkLabelAndDestination)
+
+	if !strings.Contains(labelOnly, label) || !strings.Contains(withDestination, label) {
+		t.Fatalf("link previews omitted dynamic label: label-only=%q fallback=%q", labelOnly, withDestination)
+	}
+	if strings.Contains(labelOnly, destination) {
+		t.Fatalf("label-only preview exposed dynamic destination: %q", labelOnly)
+	}
+	if !strings.Contains(withDestination, destination) {
+		t.Fatalf("fallback preview omitted dynamic destination: %q", withDestination)
+	}
+}
+
+func TestNotificationMarkdownPreviewIsBoundedWithoutVisibleTruncation(t *testing.T) {
+	preview := notificationMarkdownPreview(
+		strings.Repeat("dynamic-preview", terminalNotificationPreviewLimit),
+		transcriptrender.MarkdownLinkLabelOnly,
+	)
+
+	if got := len([]rune(preview)); got != terminalNotificationPreviewLimit {
+		t.Fatalf("retained preview length = %d, want %d", got, terminalNotificationPreviewLimit)
+	}
+	if strings.HasSuffix(preview, "...") || strings.HasSuffix(preview, "…") {
+		t.Fatalf("retained preview contains early visible truncation: %q", preview)
+	}
+}
+
+func TestTerminalNotificationFormattingSlicesUnicodeSafely(t *testing.T) {
+	title := strings.Repeat("界", 12)
+	body := strings.Repeat("λ", terminalNotificationPreviewLimit)
+
+	message := formatTerminalNotificationMessage(title, body)
+
+	if !utf8.ValidString(message) {
+		t.Fatalf("formatted notification is invalid UTF-8: %q", message)
+	}
+	if got := len([]rune(message)); got != terminalNotificationPreviewLimit {
+		t.Fatalf("formatted Unicode notification length = %d, want %d", got, terminalNotificationPreviewLimit)
+	}
+	if !strings.HasSuffix(message, "...") {
+		t.Fatalf("formatted Unicode notification lacks terminal ellipsis: %q", message)
+	}
+}
+
+func TestBellHooksCompactionUsesCompleteMessageFormatter(t *testing.T) {
+	ringer := &countRinger{}
+	title := strings.Repeat("dynamic-session-title", 6)
+	hooks := newBellHooks(ringer, func() string { return title }, func() bool { return false })
+
+	hooks.OnUserCompactionCompleted(true)
+
+	if len(ringer.messages) != 1 {
+		t.Fatalf("compaction notification count = %d, want one", len(ringer.messages))
+	}
+	if got := len([]rune(ringer.messages[0])); got != terminalNotificationPreviewLimit {
+		t.Fatalf("compaction notification length = %d, want %d", got, terminalNotificationPreviewLimit)
+	}
+	if !strings.HasSuffix(ringer.messages[0], "...") {
+		t.Fatalf("compaction notification lacks terminal ellipsis: %q", ringer.messages[0])
 	}
 }
 
@@ -152,6 +334,117 @@ func TestBellHooksToolHeavyTurnCompletion(t *testing.T) {
 	}
 }
 
+func TestBellHooksSupervisorTurnUsesPreFeedbackPreview(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newUnfocusedBellHooks(ringer)
+	preFeedback := "original answer before review"
+	followUp := "distinct answer after review"
+
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+	hooks.OnTranscriptMessage(bellAssistantFinalMessageWithText(1, preFeedback))
+	hooks.OnTranscriptMessage(bellReviewerStateMessage(1, clientui.ReviewerStateRunning))
+	hooks.OnTranscriptMessage(bellAssistantFinalMessageWithText(1, followUp))
+	hooks.OnTranscriptMessage(bellReviewerStateMessage(1, clientui.ReviewerStateCompleted))
+	hooks.OnTranscriptMessage(bellStepFinishedMessage(1))
+	hooks.OnTurnQueueDrained()
+
+	if ringer.notifications != 1 {
+		t.Fatalf("supervisor turn emitted %d notifications, want one", ringer.notifications)
+	}
+	if len(ringer.messages) != 1 {
+		t.Fatalf("supervisor turn retained %d messages, want one", len(ringer.messages))
+	}
+	if got := ringer.messages[0]; got != defaultSessionTitle+": "+preFeedback {
+		t.Fatalf("supervisor notification = %q, want pre-feedback preview", got)
+	}
+}
+
+func TestBellHooksSupervisorToolThresholdSpansReview(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newUnfocusedBellHooks(ringer)
+
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+	hooks.OnTranscriptMessage(bellAssistantFinalMessageWithText(1, "answer before review"))
+	hooks.OnTranscriptMessage(bellReviewerStateMessage(1, clientui.ReviewerStateRunning))
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+	hooks.OnTranscriptMessage(bellAssistantFinalMessageWithText(1, "answer after review"))
+	hooks.OnTranscriptMessage(bellReviewerStateMessage(1, clientui.ReviewerStateCompleted))
+	hooks.OnTurnQueueDrained()
+	if ringer.total() != 0 {
+		t.Fatalf("supervisor turn notified before step finish")
+	}
+
+	hooks.OnTranscriptMessage(bellStepFinishedMessage(1))
+	hooks.OnTurnQueueDrained()
+	if ringer.notifications != 1 {
+		t.Fatalf("split-threshold supervisor turn emitted %d notifications, want one", ringer.notifications)
+	}
+}
+
+func TestBellHooksSupervisorNoopFollowUpPreservesTurn(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newUnfocusedBellHooks(ringer)
+	preFeedback := "answer preserved across silent review"
+
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+	hooks.OnTranscriptMessage(bellAssistantFinalMessageWithText(1, preFeedback))
+	hooks.OnTranscriptMessage(bellReviewerStateMessage(1, clientui.ReviewerStateRunning))
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+	hooks.OnTranscriptMessage(bellAssistantDeltaMessage(1, uiNoopFinalToken))
+	hooks.OnTranscriptMessage(bellReviewerStateMessage(1, clientui.ReviewerStateCompleted))
+	hooks.OnTranscriptMessage(bellStepFinishedMessage(1))
+	hooks.OnTurnQueueDrained()
+
+	if ringer.notifications != 1 {
+		t.Fatalf("silent reviewer follow-up emitted %d notifications, want one", ringer.notifications)
+	}
+	if got := ringer.messages[0]; got != defaultSessionTitle+": "+preFeedback {
+		t.Fatalf("silent reviewer notification = %q, want preserved pre-feedback preview", got)
+	}
+}
+
+func TestBellHooksQueuedTurnsUseLatestPreviewAndEarlierEligibility(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newUnfocusedBellHooks(ringer)
+	latest := "latest observed queued answer"
+
+	recordToolHeavyBellTurn(hooks, 1)
+	hooks.OnTranscriptMessage(bellToolStartMessage(2))
+	hooks.OnTranscriptMessage(bellAssistantFinalMessageWithText(2, latest))
+	hooks.OnTranscriptMessage(bellStepFinishedMessage(2))
+	hooks.OnTurnQueueDrained()
+
+	if ringer.notifications != 1 {
+		t.Fatalf("queued turns emitted %d notifications, want one", ringer.notifications)
+	}
+	if got := ringer.messages[0]; got != defaultSessionTitle+": "+latest {
+		t.Fatalf("queued notification = %q, want latest observed preview", got)
+	}
+}
+
+func TestBellHooksDrainUsesOnlyObservedFacts(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newUnfocusedBellHooks(ringer)
+
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+	hooks.OnTranscriptMessage(bellAssistantFinalMessage(1))
+	hooks.OnTurnQueueDrained()
+	if ringer.total() != 0 {
+		t.Fatalf("drain emitted %d events before step finish was observed", ringer.total())
+	}
+
+	hooks.OnTranscriptMessage(bellStepFinishedMessage(1))
+	if ringer.total() != 0 {
+		t.Fatalf("late step finish scheduled %d delayed events", ringer.total())
+	}
+	hooks.OnTurnQueueDrained()
+	if ringer.notifications != 1 {
+		t.Fatalf("later ordinary drain emitted %d notifications, want one", ringer.notifications)
+	}
+}
+
 func TestBellHooksTurnCompletionFocusPolicy(t *testing.T) {
 	t.Run("focused suppresses", func(t *testing.T) {
 		ringer := &countRinger{}
@@ -197,25 +490,6 @@ func TestBellHooksNoopFinalizationScope(t *testing.T) {
 			t.Fatalf("unrelated active turn emitted %d notifications", ringer.notifications)
 		}
 	})
-}
-
-func TestFormatAssistantPreview(t *testing.T) {
-	long := strings.Repeat("a", terminalNotificationPreviewLimit+5)
-	for _, test := range []struct {
-		content string
-		limit   int
-		want    string
-	}{
-		{content: "\n  hello\tworld  ", limit: 80, want: "hello world"},
-		{content: "", limit: 80, want: ""},
-		{content: "abcdef", limit: 4, want: "abc…"},
-		{content: long, limit: terminalNotificationPreviewLimit, want: strings.Repeat("a", terminalNotificationPreviewLimit-1) + "…"},
-		{content: "ab\x1bcd\a ef", limit: 80, want: "abcd ef"},
-	} {
-		if got := formatAssistantPreview(test.content, test.limit); got != test.want {
-			t.Fatalf("formatAssistantPreview(%q, %d) = %q, want %q", test.content, test.limit, got, test.want)
-		}
-	}
 }
 
 func TestBellHooksCorrelateQueuedTurnSteps(t *testing.T) {
@@ -342,6 +616,10 @@ func bellToolStartMessage(step int) clientui.TranscriptMessage {
 }
 
 func bellAssistantFinalMessage(step int) clientui.TranscriptMessage {
+	return bellAssistantFinalMessageWithText(step, "turn complete")
+}
+
+func bellAssistantFinalMessageWithText(step int, text string) clientui.TranscriptMessage {
 	return clientui.TranscriptMessage{
 		Sequence: 2,
 		Kind:     clientui.TranscriptMessageCommittedRow,
@@ -350,8 +628,30 @@ func bellAssistantFinalMessage(step int) clientui.TranscriptMessage {
 			Integrity:  transcript.RowIntegrityValid,
 			Kind:       clientui.TranscriptRowAssistant,
 			Assistant: &clientui.TranscriptAssistantRow{
-				StepID: bellTestStepID(step), Text: "turn complete", Phase: transcript.AssistantPhaseFinal,
+				StepID: bellTestStepID(step), Text: text, Phase: transcript.AssistantPhaseFinal,
 			},
+		}},
+	}
+}
+
+func bellReviewerStateMessage(step int, state clientui.ReviewerState) clientui.TranscriptMessage {
+	return clientui.TranscriptMessage{
+		Sequence: 2,
+		Kind:     clientui.TranscriptMessageReviewerState,
+		Payload: clientui.TranscriptPayload{ReviewerState: &clientui.TranscriptReviewerState{
+			StepID: bellTestStepID(step),
+			State:  state,
+		}},
+	}
+}
+
+func bellStepFinishedMessage(step int) clientui.TranscriptMessage {
+	return clientui.TranscriptMessage{
+		Sequence: 2,
+		Kind:     clientui.TranscriptMessageStepState,
+		Payload: clientui.TranscriptPayload{StepState: &clientui.TranscriptStepState{
+			StepID:    bellTestStepID(step),
+			Lifecycle: clientui.StepLifecycleFinished,
 		}},
 	}
 }
@@ -370,4 +670,5 @@ func recordToolHeavyBellTurn(hooks *bellHooks, step int) {
 	hooks.OnTranscriptMessage(bellToolStartMessage(step))
 	hooks.OnTranscriptMessage(bellToolStartMessage(step))
 	hooks.OnTranscriptMessage(bellAssistantFinalMessage(step))
+	hooks.OnTranscriptMessage(bellStepFinishedMessage(step))
 }

--- a/cli/app/ui_input_submission_notification_test.go
+++ b/cli/app/ui_input_submission_notification_test.go
@@ -1,0 +1,72 @@
+package app
+
+import (
+	"testing"
+
+	"core/shared/clientui"
+)
+
+func TestSubmitDoneDispatchesQueuedTurnWithoutNotificationTranscriptFacts(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newUnfocusedBellHooks(ringer)
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+	hooks.OnTranscriptMessage(bellToolStartMessage(1))
+
+	model := newProjectedStaticUIModel(WithUITurnQueueHook(hooks))
+	model.activeSubmit = activeSubmitState{token: 1, text: "current turn"}
+	model.setRuntimeActivityBusyForTest(true)
+	model.queued = queuedInputsForTest("next queued turn")
+
+	next, cmd := model.Update(submitDoneMsg{token: 1, submittedText: "current turn", message: "done"})
+	updated := next.(*uiModel)
+
+	if cmd == nil {
+		t.Fatal("submit completion did not dispatch the next queued turn")
+	}
+	if got := updated.activeSubmit.text; got != "next queued turn" {
+		t.Fatalf("active submission = %q, want queued turn", got)
+	}
+	if len(updated.queued) != 0 {
+		t.Fatalf("queued turns after dispatch = %+v, want empty", updated.queued)
+	}
+	if ringer.total() != 0 {
+		t.Fatalf("queued dispatch emitted %d notifications without final transcript facts", ringer.total())
+	}
+}
+
+func TestTranscriptHydrationClearsNotificationStateWithoutReplayingRows(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newUnfocusedBellHooks(ringer)
+	recordToolHeavyBellTurn(hooks, 1)
+
+	model := newProjectedStaticUIModel(WithUITurnQueueHook(hooks))
+	hydration := ongoingHydrationMessage(1)
+	hydratedFinal := bellAssistantFinalMessageWithText(2, "hydrated historical answer")
+	hydration.Payload.Hydration.CommittedRows = []clientui.TranscriptCommittedRow{
+		*hydratedFinal.Payload.CommittedRow,
+	}
+	model.applyAdmittedTranscriptMessageState(hydration, runtimeTupleMergeResult{})
+	hooks.OnTurnQueueDrained()
+
+	if ringer.total() != 0 {
+		t.Fatalf("hydration emitted %d historical notification events", ringer.total())
+	}
+}
+
+func TestTranscriptSubscriptionLossClearsNotificationState(t *testing.T) {
+	ringer := &countRinger{}
+	hooks := newUnfocusedBellHooks(ringer)
+	recordToolHeavyBellTurn(hooks, 1)
+
+	model := newProjectedStaticUIModel(WithUITurnQueueHook(hooks))
+	model.ongoingTranscript = newNoopOngoingTranscriptController(
+		&ongoingSurfaceSpy{},
+		ongoingTestFrameProvider,
+	)
+	model.handleOngoingTranscriptEvent(ongoingTranscriptEvent{Kind: ongoingTranscriptEventLoss})
+	hooks.OnTurnQueueDrained()
+
+	if ringer.total() != 0 {
+		t.Fatalf("subscription loss retained %d notification events", ringer.total())
+	}
+}

--- a/cli/app/ui_ongoing_reducer.go
+++ b/cli/app/ui_ongoing_reducer.go
@@ -54,6 +54,9 @@ func (m *uiModel) handleOngoingTranscriptEvent(event ongoingTranscriptEvent) tea
 		m.layout().syncViewport()
 		return tea.Batch(stateCmd, m.handleOngoingResult(result), m.reconcileSpinnerTicking(true))
 	case ongoingTranscriptEventLoss:
+		if m.turnQueueHook != nil {
+			m.turnQueueHook.OnTurnQueueAborted()
+		}
 		result = m.ongoingTranscript.HandleSubscriptionLoss()
 	default:
 		if m.debugMode {

--- a/cli/app/ui_ongoing_transcript_state.go
+++ b/cli/app/ui_ongoing_transcript_state.go
@@ -17,8 +17,12 @@ func (m *uiModel) applyAdmittedTranscriptMessageState(
 	if m == nil {
 		return nil
 	}
-	if message.Kind != clientui.TranscriptMessageHydration && m.turnQueueHook != nil {
-		m.turnQueueHook.OnTranscriptMessage(message)
+	if m.turnQueueHook != nil {
+		if message.Kind == clientui.TranscriptMessageHydration {
+			m.turnQueueHook.OnTurnQueueAborted()
+		} else {
+			m.turnQueueHook.OnTranscriptMessage(message)
+		}
 	}
 	switch message.Kind {
 	case clientui.TranscriptMessageHydration:

--- a/docs/dev/specs/tui-transcript.md
+++ b/docs/dev/specs/tui-transcript.md
@@ -274,10 +274,16 @@
 ## Notifications
 
 - Ring terminal bell when a new `ask_question` is shown.
-- Ring on turn end only if the turn executed at least two tool calls.
-- Turn-end notification is deferred until queued prompt drain is fully idle.
+- Ring on turn end only if the TUI observed at least two tool calls for an eligible turn.
+- A supervisor-reviewed turn-end notification is requested only after the supervisor workflow completes, and every turn-end notification is requested only after the local queued prompt drain is fully idle.
+- Notification processing never delays queued model work. Submit completion and transcript delivery are independent, so transcript lag may omit a notification, delay it until a later drain, or select an earlier observed preview.
+- When the TUI observes a supervisor-reviewed turn boundary before notification, its preview uses the final answer produced before supervisor feedback is addressed.
+- A queued prompt drain emits at most one turn-end notification when any observed turn in the drain meets the two-tool threshold, using the last final answer observed by the TUI even when that turn has fewer than two tool calls.
 - Turn-end text includes assistant preview when available, else `<session title>: turn complete`.
 - Ask notifications include `<session title>: Question: <question>` or `<session title>: Action required: <question>`.
+- Every text-bearing terminal notification uses one formatting pipeline and is capped at 80 characters in total, including the session title and notification label. When the composed text exceeds the limit, Kent keeps its first 77 characters and appends `...` without word-boundary or component-specific truncation.
+- Markdown preview content uses the transcript's visible-text projection, including link destinations when that projection displays them, before the final notification is truncated.
+- Rendered preview whitespace and line breaks collapse to single spaces before composition.
 - `auto` notification method prefers OSC 9 on supported terminals and falls back to BEL.
 - OSC 9 notifications still emit a separate BEL.
 - OSC 9 is disabled when `WT_SESSION` is set.


### PR DESCRIPTION
## Summary

- correlate turn-completion previews with the matching finished step, preserving the pre-supervisor-feedback answer and preventing mismatched steps from inheriting tool eligibility
- preserve queued-turn throughput while selecting the latest completed preview and OR-ing earlier eligible turns
- consolidate assistant, question, approval, and compaction notification text through one Markdown-visible, terminal-safe formatter capped at 80 Unicode characters
- keep OSC 9 as an opaque transport for the already-formatted payload, with the existing separate audible BEL
- clear stale notification state on hydration/subscription loss and retain best-effort behavior under transcript lag

Closes #108. Kent task: `BUI-63`.

## Verification

- `./scripts/test.sh ./cli/app`
- focused notification/queue regressions repeated with `-count=20`
- `./scripts/test.sh server`
- `./scripts/build.sh --output ./bin/kent`
- `git diff --check`
- review and compliance gates passed after remediation

## QA evidence

Live isolated QA used the rebuilt binary with local omlx and covered:

- a completed two-tool turn
- two tool-heavy queued requests draining in order
- opening and answering an `ask_question` prompt

Retained proof directories:

```text
/Users/nek/Dev/kent/.kent/qa/instances/BUI-63-rereview/proofs/20260718T104352Z-BUI-63-rereview-two-tool
/Users/nek/Dev/kent/.kent/qa/instances/BUI-63-rereview/proofs/20260718T104421Z-BUI-63-rereview-queued
/Users/nek/Dev/kent/.kent/qa/instances/BUI-63-rereview/proofs/20260718T104435Z-BUI-63-rereview-question
```

The GitHub CLI does not provide a supported local-file attachment flow, so the retained text/ANSI captures are referenced rather than uploaded.

## LoC

| Category | Added | Deleted | Net | Gross |
| --- | ---: | ---: | ---: | ---: |
| Production code | 148 | 79 | +69 | 227 |
| Test/generated code | 405 | 21 | +384 | 426 |
| Documentation/spec | 8 | 2 | +6 | 10 |
| **Total** | **561** | **102** | **+459** | **663** |

Generated-code changes: none.

## Caveats and follow-ups

- Notification selection intentionally remains best-effort when submit RPC and transcript delivery race; authoritative bounded drain correlation remains tracked by `KENT-294`.
- Terminal notification write failures remain outside this change and are tracked by `KENT-293`.
- There is no server API, wire/protocol, persistence, database, migration, configuration, or installer impact.
- Two earlier full-server verification attempts exceeded the repository's 120-second wall-clock cap under high host load. All package chunks passed under the same cap, and the subsequent exact `./scripts/test.sh server` rerun passed.
