### PR TITLE
Drain steered messages before each main-agent step

### DIFF
--- a/server/core/ownerless_runtime_control_test.go
+++ b/server/core/ownerless_runtime_control_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestSecondClientLiveControlsActiveRun(t *testing.T) {
 	t.Run("live steer", func(t *testing.T) {
-		runSecondClientLiveControlsActiveRun(t, func(t *testing.T, appCore *Core, sessionID string) {
+		runSecondClientLiveControlsActiveRun(t, "steered final answer", func(t *testing.T, appCore *Core, sessionID string) {
 			steerResp, err := appCore.RuntimeLiveControlClient().LiveSteer(context.Background(), serverapi.RuntimeLiveSteerRequest{
 				ClientRequestID: uuid.NewString(),
 				SessionID:       sessionID,
@@ -36,7 +36,7 @@ func TestSecondClientLiveControlsActiveRun(t *testing.T) {
 		})
 	})
 	t.Run("runtime control queue user message", func(t *testing.T) {
-		runSecondClientLiveControlsActiveRun(t, func(t *testing.T, appCore *Core, sessionID string) {
+		runSecondClientLiveControlsActiveRun(t, "first answer before steering", func(t *testing.T, appCore *Core, sessionID string) {
 			clientRequestID := uuid.NewString()
 			operationID, err := runtimeids.ParseRuntimeClientRequestID(clientRequestID)
 			if err != nil {
@@ -57,7 +57,7 @@ func TestSecondClientLiveControlsActiveRun(t *testing.T) {
 		})
 	})
 	t.Run("runtime control submit user turn", func(t *testing.T) {
-		runSecondClientLiveControlsActiveRun(t, func(t *testing.T, appCore *Core, sessionID string) {
+		runSecondClientLiveControlsActiveRun(t, "steered final answer", func(t *testing.T, appCore *Core, sessionID string) {
 			clientRequestID := uuid.NewString()
 			operationID, err := runtimeids.ParseRuntimeClientRequestID(clientRequestID)
 			if err != nil {
@@ -83,7 +83,7 @@ func TestSecondClientLiveControlsActiveRun(t *testing.T) {
 	})
 }
 
-func runSecondClientLiveControlsActiveRun(t *testing.T, steer func(*testing.T, *Core, string)) {
+func runSecondClientLiveControlsActiveRun(t *testing.T, wantCurrentResult string, steer func(*testing.T, *Core, string)) {
 	t.Helper()
 	home := t.TempDir()
 	workspace := t.TempDir()
@@ -91,7 +91,9 @@ func runSecondClientLiveControlsActiveRun(t *testing.T, steer func(*testing.T, *
 
 	release := make(chan struct{})
 	started := make(chan struct{})
+	secondStarted := make(chan struct{})
 	var startOnce sync.Once
+	var secondOnce sync.Once
 	var releaseOnce sync.Once
 	var requestMu sync.Mutex
 	requestIndex := 0
@@ -110,6 +112,9 @@ func runSecondClientLiveControlsActiveRun(t *testing.T, steer func(*testing.T, *
 		currentRequest := requestIndex
 		requestMu.Unlock()
 		startOnce.Do(func() { close(started) })
+		if currentRequest == 2 {
+			secondOnce.Do(func() { close(secondStarted) })
+		}
 		if currentRequest == 1 {
 			<-release
 			modelstub.WriteCompletedResponseStream(w, "first answer before steering", 1, 1)
@@ -214,8 +219,8 @@ func runSecondClientLiveControlsActiveRun(t *testing.T, steer func(*testing.T, *
 		t.Fatalf("timed out waiting for RunPrompt to finish after %d model requests", count)
 	}
 	resp := <-runResult
-	if resp.Result != "steered final answer" {
-		t.Fatalf("RunPrompt result = %q, want steered final answer", resp.Result)
+	if resp.Result != wantCurrentResult {
+		t.Fatalf("RunPrompt result = %q, want %q", resp.Result, wantCurrentResult)
 	}
 	select {
 	case waitErr := <-waitDone:
@@ -226,7 +231,12 @@ func runSecondClientLiveControlsActiveRun(t *testing.T, steer func(*testing.T, *
 		t.Fatal("timed out waiting for LiveWait to finish")
 	}
 	waitResp := <-waitResult
-	if waitResp.Result == nil || *waitResp.Result != "steered final answer" {
-		t.Fatalf("LiveWait result = %v, want steered final answer", waitResp.Result)
+	if waitResp.Result == nil || *waitResp.Result != wantCurrentResult {
+		t.Fatalf("LiveWait result = %v, want %q", waitResp.Result, wantCurrentResult)
+	}
+	select {
+	case <-secondStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for queued or steered follow-up request")
 	}
 }

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -184,15 +184,8 @@ type Engine struct {
 	activeStepGoalMutationsMu  sync.Mutex
 	activeStepGoalMutations    map[string][]activeStepGoalMutation
 	pendingGoalLoopStart       bool
-	// userInjectionScopeMu guards activeUserInjectionScope, the queued
-	// user-injection IDs the in-flight top-level step should flush. The engine
-	// owns this scope so the step executor derives it directly and reviewer
-	// follow-ups inherit it, instead of the supervisor threading injection IDs.
-	userInjectionScopeMu     sync.Mutex
-	activeUserInjectionScope map[string]struct{}
-
-	diagnostics    *diagnosticDedupeStore
-	toolCallStarts *pendingToolCallStartStore
+	diagnostics                *diagnosticDedupeStore
+	toolCallStarts             *pendingToolCallStartStore
 
 	usageState         *usageTrackingState
 	goalLoop           *goalLoopState
@@ -534,6 +527,11 @@ func (e *Engine) QueueUserMessageWithClientRequestID(text string, clientRequestI
 
 func (e *Engine) queueUserMessageWithClientRequestID(text string, clientRequestID string, forceAutoDrain bool) QueuedUserMessage {
 	e.ensureOrchestrationCollaborators()
+	if !forceAutoDrain {
+		item := e.messageFlow.QueueUserMessage(text, clientRequestID)
+		e.emitQueuedUserMessageStatus(item, QueuedUserMessageAccepted, "", false)
+		return item
+	}
 	liveItem := QueuedUserMessage{ID: runtimeids.NewQueueItemID().String(), Text: text, ClientRequestID: clientRequestID}
 	waitedForLiveRunStep := false
 	for {
@@ -562,10 +560,8 @@ func (e *Engine) queueUserMessageWithClientRequestID(text string, clientRequestI
 	}
 	item := e.messageFlow.QueueUserMessage(text, clientRequestID)
 	e.emitQueuedUserMessageStatus(item, QueuedUserMessageAccepted, "", false)
-	if forceAutoDrain || (!waitedForLiveRunStep && e.stepLifecycle != nil && e.stepLifecycle.IsBusy()) {
-		e.markQueuedUserInjectionForAutoDrain(item.ID)
-		e.scheduleQueuedUserInjectionsIfIdle()
-	}
+	e.markQueuedUserInjectionForAutoDrain(item.ID)
+	e.scheduleQueuedUserInjectionsIfIdle()
 	return item
 }
 
@@ -758,16 +754,10 @@ func (e *Engine) submitUserShellCommand(ctx context.Context, command string, onA
 }
 
 func (e *Engine) runStepLoop(ctx context.Context, stepID string) (llm.Message, error) {
-	return e.runStepLoopWithPendingUserInjectionIDs(ctx, stepID, nil)
+	return e.runStepLoopWithPendingUserInjectionObserver(ctx, stepID, nil)
 }
 
-func (e *Engine) runStepLoopWithPendingUserInjectionIDs(ctx context.Context, stepID string, queueItemIDs map[string]struct{}) (llm.Message, error) {
-	return e.runStepLoopWithPendingUserInjectionObserver(ctx, stepID, queueItemIDs, nil)
-}
-
-func (e *Engine) runStepLoopWithPendingUserInjectionObserver(ctx context.Context, stepID string, queueItemIDs map[string]struct{}, onQueuedUserFlushCommitted func(session.CommitReceipt)) (llm.Message, error) {
-	restore := e.pushActiveUserInjectionScope(queueItemIDs)
-	defer restore()
+func (e *Engine) runStepLoopWithPendingUserInjectionObserver(ctx context.Context, stepID string, onQueuedUserFlushCommitted func(session.CommitReceipt)) (llm.Message, error) {
 	reviewerFrequency := e.ReviewerFrequency()
 	reviewerClient := e.reviewerRuntimeState().Client()
 	result, err := e.runStepLoopWithQueuedUserFlushObserver(ctx, stepID, reviewerFrequency, reviewerClient, true, onQueuedUserFlushCommitted)

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -555,9 +555,9 @@ func flushedUserMessageEvent(msg llm.Message, stepID string) *Event {
 	return &Event{Kind: EventUserMessageFlushed, StepID: stepID, UserMessage: msg.Content, UserMessageBatch: []string{msg.Content}, CommittedTranscriptChanged: true}
 }
 
-func (e *Engine) flushPendingUserInjections(stepID string, queueItemIDs map[string]struct{}) (int, session.CommitReceipt, error) {
+func (e *Engine) flushPendingUserInjections(stepID string, selection userInjectionSelection) (int, session.CommitReceipt, error) {
 	e.ensureOrchestrationCollaborators()
-	return e.messageFlow.FlushPendingUserInjections(stepID, queueItemIDs)
+	return e.messageFlow.FlushPendingUserInjections(stepID, selection)
 }
 
 // resolveGlobalConfigDir returns the directory that owns model-visible global

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -555,7 +555,7 @@ func flushedUserMessageEvent(msg llm.Message, stepID string) *Event {
 	return &Event{Kind: EventUserMessageFlushed, StepID: stepID, UserMessage: msg.Content, UserMessageBatch: []string{msg.Content}, CommittedTranscriptChanged: true}
 }
 
-func (e *Engine) flushPendingUserInjections(stepID string, selection userInjectionSelection) (int, session.CommitReceipt, error) {
+func (e *Engine) flushPendingUserInjections(stepID string, selection userInjectionSelection) (userInjectionCommitResult, error) {
 	e.ensureOrchestrationCollaborators()
 	return e.messageFlow.FlushPendingUserInjections(stepID, selection)
 }

--- a/server/runtime/engine_part11_test.go
+++ b/server/runtime/engine_part11_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"core/server/llm"
 	"core/server/session/sessiontest"
@@ -12,65 +13,111 @@ import (
 	"core/shared/toolspec"
 )
 
-func TestQueuedUserMessageFlushesWhenAssistantReturnsWithoutTools(t *testing.T) {
-	client := &fakeClient{responses: []llm.Response{
-		{
-			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "first"},
+func encryptedReasoningOnlyResponse(id string) llm.Response {
+	reasoning := llm.ReasoningItem{ID: id, EncryptedContent: "encrypted-reasoning"}
+	return llm.Response{
+		Assistant:      llm.Message{Role: llm.RoleAssistant, ReasoningItems: []llm.ReasoningItem{reasoning}},
+		ReasoningItems: []llm.ReasoningItem{reasoning},
+		OutputItems: []llm.ResponseItem{{
+			Type:             llm.ResponseItemTypeReasoning,
+			ID:               reasoning.ID,
+			EncryptedContent: reasoning.EncryptedContent,
+		}},
+		Usage: llm.Usage{WindowTokens: 200000},
+	}
+}
+
+func newGatedHookClient(initial, next llm.Response) (*hookClient, <-chan struct{}, func()) {
+	started := make(chan struct{})
+	release := make(chan struct{}, 1)
+	client := &hookClient{response: initial}
+	client.beforeReturn = func() error {
+		close(started)
+		<-release
+		client.mu.Lock()
+		client.response = next
+		client.beforeReturn = nil
+		client.mu.Unlock()
+		return nil
+	}
+	return client, started, func() {
+		select {
+		case release <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func TestActiveSteerReachesRequestAfterReasoningOnlyResponseWhileQueueWaitsForNextTurn(t *testing.T) {
+	client, started, release := newGatedHookClient(
+		encryptedReasoningOnlyResponse("rs_1"),
+		llm.Response{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "turn done", Phase: llm.MessagePhaseFinal},
 			Usage:     llm.Usage{WindowTokens: 200000},
 		},
-		{
-			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "after flush"},
-			Usage:     llm.Usage{WindowTokens: 200000},
-		},
-	}}
+	)
+	eng := mustNewTestEngine(t, mustCreateTestSession(t), client, tools.NewRegistry(), Config{Model: "gpt-5"})
 
-	var seenFlushed bool
-	eng := mustNewTestEngine(t, mustCreateTestSession(t), client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
-		OnEvent: func(evt Event) {
-			if evt.Kind == EventUserMessageFlushed && evt.UserMessage == "steer now" {
-				seenFlushed = true
-			}
-		},
-	})
-
-	eng.QueueUserMessage("steer now")
-	msg, err := eng.SubmitUserMessage(context.Background(), "start")
-	if err != nil {
+	submitDone := make(chan error, 1)
+	go func() {
+		_, err := eng.SubmitUserMessage(context.Background(), "start")
+		submitDone <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for first request")
+	}
+	if _, accepted, err := eng.QueueUserMessageForActiveRun(context.Background(), "steer now", liveRunTestRequestID(t), nil); err != nil || !accepted {
+		t.Fatalf("QueueUserMessageForActiveRun accepted=%t err=%v", accepted, err)
+	}
+	eng.QueueUserMessage("queue next turn")
+	release()
+	if err := <-submitDone; err != nil {
 		t.Fatalf("submit: %v", err)
 	}
-	if msg.Content != "after flush" {
-		t.Fatalf("assistant content = %q, want after flush", msg.Content)
+
+	client.mu.Lock()
+	firstTurnRequests := append([]llm.Request(nil), client.calls...)
+	client.mu.Unlock()
+	if len(firstTurnRequests) != 2 {
+		t.Fatalf("first Agent Turn requests = %d, want 2", len(firstTurnRequests))
 	}
-	if !seenFlushed {
-		t.Fatal("expected user_message_flushed event")
-	}
-	if len(client.calls) < 2 {
-		t.Fatalf("expected at least 2 model calls, got %d", len(client.calls))
-	}
-	second := client.calls[1]
-	hasInjected := false
-	for _, m := range requestMessages(second) {
-		if m.Role == llm.RoleUser && m.Content == "steer now" {
-			hasInjected = true
+	assertRequestHasUserMessage(t, firstTurnRequests[1], "steer now", true)
+	assertRequestHasUserMessage(t, firstTurnRequests[1], "queue next turn", false)
+
+	waitEngineLifecycleTasks(t, eng)
+	client.mu.Lock()
+	nextTurnRequest := client.calls[2]
+	client.mu.Unlock()
+	assertRequestHasUserMessage(t, nextTurnRequest, "queue next turn", true)
+}
+
+func assertRequestHasUserMessage(t *testing.T, request llm.Request, content string, want bool) {
+	t.Helper()
+	found := false
+	for _, message := range requestMessages(request) {
+		if message.Role == llm.RoleUser && message.Content == content {
+			found = true
 			break
 		}
 	}
-	if !hasInjected {
-		t.Fatalf("expected flushed user message in second request, messages=%+v", requestMessages(second))
+	if found != want {
+		t.Fatalf("request user message %q present=%t, want %t; messages=%+v", content, found, want, requestMessages(request))
 	}
 }
 
 func TestQueuedUserMessageFlushAfterFinalAssistantPublishesCommittedAssistantFirst(t *testing.T) {
-	client := &fakeClient{responses: []llm.Response{
-		{
+	client, started, release := newGatedHookClient(
+		llm.Response{
 			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "first final", Phase: llm.MessagePhaseFinal},
 			Usage:     llm.Usage{WindowTokens: 200000},
 		},
-		{
+		llm.Response{
 			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "after flush", Phase: llm.MessagePhaseFinal},
 			Usage:     llm.Usage{WindowTokens: 200000},
 		},
-	}}
+	)
 
 	events := make([]Event, 0, 12)
 	eng := mustNewTestEngine(t, mustCreateTestSession(t), client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
@@ -79,11 +126,31 @@ func TestQueuedUserMessageFlushAfterFinalAssistantPublishesCommittedAssistantFir
 		},
 	})
 
-	eng.QueueUserMessage("steer now")
-	msg, err := eng.SubmitUserMessage(context.Background(), "start")
-	if err != nil {
-		t.Fatalf("submit: %v", err)
+	submitDone := make(chan struct {
+		message llm.Message
+		err     error
+	}, 1)
+	go func() {
+		message, err := eng.SubmitUserMessage(context.Background(), "start")
+		submitDone <- struct {
+			message llm.Message
+			err     error
+		}{message: message, err: err}
+	}()
+	select {
+	case <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for first final request")
 	}
+	if _, accepted, err := eng.QueueUserMessageForActiveRun(context.Background(), "steer now", liveRunTestRequestID(t), nil); err != nil || !accepted {
+		t.Fatalf("QueueUserMessageForActiveRun accepted=%t err=%v", accepted, err)
+	}
+	release()
+	result := <-submitDone
+	if result.err != nil {
+		t.Fatalf("submit: %v", result.err)
+	}
+	msg := result.message
 	if msg.Content != "after flush" {
 		t.Fatalf("assistant content = %q, want after flush", msg.Content)
 	}
@@ -117,106 +184,6 @@ func TestQueuedUserMessageFlushAfterFinalAssistantPublishesCommittedAssistantFir
 	wantFlushStart := assistant.CommittedEntryStart + len(assistantEntries)
 	if flushed.CommittedEntryStart != wantFlushStart {
 		t.Fatalf("queued user flush start = %d, want %d after assistant event; assistant=%+v flush=%+v", flushed.CommittedEntryStart, wantFlushStart, assistant, flushed)
-	}
-}
-
-func TestQueuedUserMessageFlushAfterFinalAssistantWithReasoningPublishesAssistantFirst(t *testing.T) {
-	client := &fakeClient{responses: []llm.Response{
-		{
-			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "first final", Phase: llm.MessagePhaseFinal},
-			Reasoning: []llm.ReasoningEntry{
-				{Role: "reasoning", Text: "Plan summary"},
-			},
-			Usage: llm.Usage{WindowTokens: 200000},
-		},
-		{
-			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "after flush", Phase: llm.MessagePhaseFinal},
-			Usage:     llm.Usage{WindowTokens: 200000},
-		},
-	}}
-
-	events := make([]Event, 0, 12)
-	eng := mustNewTestEngine(t, mustCreateTestSession(t), client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
-		OnEvent: func(evt Event) {
-			events = append(events, evt)
-		},
-	})
-
-	eng.QueueUserMessage("steer now")
-	if _, err := eng.SubmitUserMessage(context.Background(), "start"); err != nil {
-		t.Fatalf("submit: %v", err)
-	}
-
-	committedEvents := committedTranscriptEventsWithEntries(events)
-	if len(committedEvents) < 3 {
-		t.Fatalf("expected assistant, reasoning, and queued user committed events, got %+v", committedEvents)
-	}
-	userIdx := -1
-	for idx, evt := range committedEvents {
-		if evt.Kind == EventUserMessageFlushed && evt.UserMessage == "start" {
-			userIdx = idx
-			break
-		}
-	}
-	if userIdx < 0 {
-		t.Fatalf("expected initial user flush event, got %+v", committedEvents)
-	}
-	assistant := committedEvents[userIdx+1]
-	if assistant.Kind != EventAssistantMessage || assistant.Message.Content != "first final" {
-		t.Fatalf("committed event after initial user = %+v, want first final assistant before reasoning/queued rows; all=%+v", assistant, committedEvents)
-	}
-	assertRuntimeEventsAdvanceCommittedFrontierContiguously(t, committedEvents)
-}
-
-func TestDirectUserMessageWithQueuedInjectionPublishesUserBeforeToolEvents(t *testing.T) {
-	client := &fakeClient{responses: []llm.Response{
-		{
-			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "working", Phase: llm.MessagePhaseCommentary},
-			ToolCalls: []llm.ToolCall{{
-				ID:    "call_shell_1",
-				Name:  string(toolspec.ToolExecCommand),
-				Input: json.RawMessage(`{"command":"pwd"}`),
-			}},
-			Usage: llm.Usage{WindowTokens: 200000},
-		},
-		{
-			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done", Phase: llm.MessagePhaseFinal},
-			Usage:     llm.Usage{WindowTokens: 200000},
-		},
-	}}
-
-	events := make([]Event, 0, 16)
-	eng := mustNewTestEngine(t, mustCreateTestSession(t), client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
-		OnEvent: func(evt Event) {
-			events = append(events, evt)
-		},
-	})
-
-	eng.QueueUserMessage("queued steer")
-	if _, err := eng.SubmitUserMessage(context.Background(), "start"); err != nil {
-		t.Fatalf("submit: %v", err)
-	}
-
-	committedEvents := committedTranscriptEventsWithEntries(events)
-	assertRuntimeEventsAdvanceCommittedFrontierContiguously(t, committedEvents)
-	startIdx := -1
-	toolCompleteIdx := -1
-	for idx, evt := range committedEvents {
-		if evt.Kind == EventUserMessageFlushed && evt.UserMessage == "start" {
-			startIdx = idx
-		}
-		if evt.Kind == EventToolCallCompleted {
-			toolCompleteIdx = idx
-		}
-	}
-	if startIdx < 0 {
-		t.Fatalf("expected direct user message committed event, got %+v", committedEvents)
-	}
-	if toolCompleteIdx < 0 {
-		t.Fatalf("expected tool completion committed event, got %+v", committedEvents)
-	}
-	if startIdx > toolCompleteIdx {
-		t.Fatalf("direct user message must publish before tool completion, user_idx=%d tool_complete_idx=%d events=%+v", startIdx, toolCompleteIdx, committedEvents)
 	}
 }
 
@@ -289,45 +256,6 @@ func TestModelResponseEventCarriesContextUsage(t *testing.T) {
 	}
 }
 
-func TestQueuedUserMessageFlushDoesNotEmitConversationUpdatedForInjectedMessage(t *testing.T) {
-	client := &fakeClient{responses: []llm.Response{
-		{
-			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "first"},
-			Usage:     llm.Usage{WindowTokens: 200000},
-		},
-		{
-			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "after flush"},
-			Usage:     llm.Usage{WindowTokens: 200000},
-		},
-	}}
-
-	var (
-		events     []Event
-		eventIndex int
-		flushIndex = -1
-	)
-	eng := mustNewTestEngine(t, mustCreateTestSession(t), client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
-		OnEvent: func(evt Event) {
-			events = append(events, evt)
-			eventIndex++
-			if evt.Kind == EventUserMessageFlushed && evt.UserMessage == "steer now" && flushIndex < 0 {
-				flushIndex = eventIndex
-			}
-		},
-	})
-
-	eng.QueueUserMessage("steer now")
-	if _, err := eng.SubmitUserMessage(context.Background(), "start"); err != nil {
-		t.Fatalf("submit: %v", err)
-	}
-	if flushIndex < 0 {
-		t.Fatal("expected user_message_flushed event")
-	}
-	if got := committedConversationUpdatedCountAfterLastUserFlush(events); got != 0 {
-		t.Fatalf("committed conversation_updated count after injected user flush = %d, want 0; events=%+v", got, events)
-	}
-}
-
 func TestDirectUserMessageFlushDoesNotEmitConversationUpdated(t *testing.T) {
 	client := &fakeClient{responses: []llm.Response{{
 		Assistant: llm.Message{Role: llm.RoleAssistant, Content: "done"},
@@ -357,68 +285,6 @@ func TestDirectUserMessageFlushDoesNotEmitConversationUpdated(t *testing.T) {
 	}
 	if got := committedConversationUpdatedCountAfterLastUserFlush(events); got != 0 {
 		t.Fatalf("committed conversation_updated count after direct user flush = %d, want 0; events=%+v", got, events)
-	}
-}
-
-func TestQueuedUserMessagesCoalesceIntoSingleFlush(t *testing.T) {
-	client := &fakeClient{responses: []llm.Response{
-		{
-			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "first"},
-			Usage:     llm.Usage{WindowTokens: 200000},
-		},
-		{
-			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "after flush"},
-			Usage:     llm.Usage{WindowTokens: 200000},
-		},
-	}}
-
-	var (
-		queuedFlushCount int
-		flushed          Event
-	)
-	eng := mustNewTestEngine(t, mustCreateTestSession(t), client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
-		OnEvent: func(evt Event) {
-			if evt.Kind == EventUserMessageFlushed && len(evt.UserMessageBatch) == 2 {
-				queuedFlushCount++
-				flushed = evt
-			}
-		},
-	})
-
-	eng.QueueUserMessage("steer now")
-	eng.QueueUserMessage("and keep tests focused")
-	msg, err := eng.SubmitUserMessage(context.Background(), "start")
-	if err != nil {
-		t.Fatalf("submit: %v", err)
-	}
-	if msg.Content != "after flush" {
-		t.Fatalf("assistant content = %q, want after flush", msg.Content)
-	}
-	if flushed.UserMessage != "steer now\n\nand keep tests focused" {
-		t.Fatalf("unexpected flushed user message %q", flushed.UserMessage)
-	}
-	if len(flushed.UserMessageBatch) != 2 {
-		t.Fatalf("expected two flushed user messages in batch, got %+v", flushed.UserMessageBatch)
-	}
-	if queuedFlushCount != 1 {
-		t.Fatalf("expected one coalesced queued flush event, got %d", queuedFlushCount)
-	}
-	if len(client.calls) < 2 {
-		t.Fatalf("expected at least 2 model calls, got %d", len(client.calls))
-	}
-	second := client.calls[1]
-	userMessages := make([]llm.Message, 0, len(requestMessages(second)))
-	for _, m := range requestMessages(second) {
-		if m.Role == llm.RoleUser {
-			userMessages = append(userMessages, m)
-		}
-	}
-	if len(userMessages) < 2 {
-		t.Fatalf("expected initial and flushed user messages, got %+v", requestMessages(second))
-	}
-	last := userMessages[len(userMessages)-1]
-	if last.Content != "steer now\n\nand keep tests focused" {
-		t.Fatalf("expected coalesced flushed user message, got %+v", userMessages)
 	}
 }
 

--- a/server/runtime/engine_part7_test.go
+++ b/server/runtime/engine_part7_test.go
@@ -221,30 +221,23 @@ func TestDeferredFinalWithBackgroundNoticeStillRunsReviewerAndEmitsAssistantEven
 	}
 }
 
-func TestDeferredFinalWithQueuedUserInjectionStillRunsReviewerAndEmitsAssistantEvent(t *testing.T) {
-	dir := t.TempDir()
-	store := mustCreateTestSessionAt(t, dir)
-
+func TestSteerAcceptedDuringReviewerAppearsInMainAgentFollowUp(t *testing.T) {
 	mainClient := &fakeClient{responses: []llm.Response{
 		{
 			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "foreground done", Phase: llm.MessagePhaseFinal},
 			Usage:     llm.Usage{WindowTokens: 200000},
 		},
 		{
-			Assistant: llm.Message{Role: llm.RoleAssistant, Content: reviewerNoopToken, Phase: llm.MessagePhaseFinal},
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "reviewed done", Phase: llm.MessagePhaseFinal},
 			Usage:     llm.Usage{WindowTokens: 200000},
 		},
 	}}
-	reviewerClient := &fakeClient{responses: []llm.Response{{
-		Assistant: llm.Message{Role: llm.RoleAssistant, Content: `{"suggestions":[]}`},
+	reviewerResponse := llm.Response{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Content: `{"suggestions":["apply the requested correction"]}`},
 		Usage:     llm.Usage{WindowTokens: 200000},
-	}}}
-
-	var (
-		mu     sync.Mutex
-		events []Event
-	)
-	eng := mustNewTestEngine(t, store, mainClient, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
+	}
+	reviewerClient, reviewerStarted, releaseReviewer := newGatedHookClient(reviewerResponse, reviewerResponse)
+	eng := mustNewTestEngine(t, mustCreateTestSession(t), mainClient, tools.NewRegistry(), Config{
 		Model: "gpt-5",
 		Reviewer: ReviewerConfig{
 			Frequency:     "all",
@@ -252,65 +245,48 @@ func TestDeferredFinalWithQueuedUserInjectionStillRunsReviewerAndEmitsAssistantE
 			ThinkingLevel: "low",
 			Client:        reviewerClient,
 		},
-		OnEvent: func(evt Event) {
-			mu.Lock()
-			events = append(events, evt)
-			mu.Unlock()
-		},
+	})
+	eng.pauseQueuedUserAutoDrain()
+	t.Cleanup(func() {
+		eng.FailQueuedUserMessages(QueuedUserMessageFailureClosing)
+		eng.resumeQueuedUserAutoDrain()
+		waitEngineLifecycleTasks(t, eng)
 	})
 
-	eng.QueueUserMessage("steer now")
-	result, err := eng.SubmitUserMessage(context.Background(), "run task")
-	if err != nil {
-		t.Fatalf("submit: %v", err)
+	submitDone := make(chan struct {
+		message llm.Message
+		err     error
+	}, 1)
+	go func() {
+		message, err := eng.SubmitUserMessage(context.Background(), "run task")
+		submitDone <- struct {
+			message llm.Message
+			err     error
+		}{message: message, err: err}
+	}()
+	select {
+	case <-reviewerStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for reviewer request")
 	}
-	if result.Content != "foreground done" {
-		t.Fatalf("assistant content = %q, want foreground done", result.Content)
+	if _, accepted, err := eng.QueueUserMessageForActiveRun(context.Background(), "steer reviewer follow-up", liveRunTestRequestID(t), nil); err != nil || !accepted {
+		t.Fatalf("QueueUserMessageForActiveRun accepted=%t err=%v", accepted, err)
 	}
-	if len(reviewerClient.calls) != 1 {
-		t.Fatalf("expected reviewer to run once for deferred final, got %d", len(reviewerClient.calls))
+	releaseReviewer()
+	result := <-submitDone
+	if result.err != nil {
+		t.Fatalf("submit: %v", result.err)
 	}
-	if len(mainClient.calls) != 2 {
-		t.Fatalf("expected two main model calls for deferred final path, got %d", len(mainClient.calls))
+	if result.message.Content != "reviewed done" {
+		t.Fatalf("assistant content = %q, want reviewed done", result.message.Content)
 	}
-	snapshot := eng.ChatSnapshot()
-
-	mu.Lock()
-	defer mu.Unlock()
-	assistantMessages := 0
-	flushedQueuedUser := false
-	assistantCommittedStart := -1
-	assistantCommittedStartSet := false
-	for i, evt := range events {
-		_ = i
-		if evt.Kind == EventAssistantMessage {
-			assistantMessages++
-			if evt.Message.Content != "foreground done" {
-				t.Fatalf("assistant message content = %q, want foreground done", evt.Message.Content)
-			}
-			assistantCommittedStart = evt.CommittedEntryStart
-			assistantCommittedStartSet = evt.CommittedEntryStartSet
-		}
-		if evt.Kind == EventUserMessageFlushed && evt.UserMessage == "steer now" {
-			flushedQueuedUser = true
-		}
+	mainClient.mu.Lock()
+	requests := append([]llm.Request(nil), mainClient.calls...)
+	mainClient.mu.Unlock()
+	if len(requests) != 2 {
+		t.Fatalf("main-agent requests = %d, want initial and reviewer follow-up", len(requests))
 	}
-	if assistantMessages != 1 {
-		t.Fatalf("expected one assistant_message event for deferred final, got %d events=%+v", assistantMessages, events)
-	}
-	if !flushedQueuedUser {
-		t.Fatalf("expected queued user injection flush event, got %+v", events)
-	}
-	if !assistantCommittedStartSet {
-		t.Fatalf("expected deferred final assistant event committed start metadata, got %+v", events)
-	}
-	if assistantCommittedStart < 0 || assistantCommittedStart >= len(snapshot.Entries) {
-		t.Fatalf("deferred final assistant committed start = %d, snapshot=%+v", assistantCommittedStart, snapshot.Entries)
-	}
-	assistantEntry := snapshot.Entries[assistantCommittedStart]
-	if assistantEntry.Role != "assistant" || assistantEntry.Text != "foreground done" {
-		t.Fatalf("expected deferred final assistant event to point at committed assistant row, got %+v", assistantEntry)
-	}
+	assertRequestHasUserMessage(t, requests[1], "steer reviewer follow-up", true)
 }
 
 func TestFinalAssistantBeforeSameTurnBackgroundNoticeKeepsCommittedFrontierContiguous(t *testing.T) {
@@ -386,9 +362,6 @@ func TestFinalAssistantBeforeSameTurnBackgroundNoticeKeepsCommittedFrontierConti
 }
 
 func TestBackgroundShellNoticeSameTurnNoopAddsNoAssistantMessage(t *testing.T) {
-	dir := t.TempDir()
-	store := mustCreateTestSessionAt(t, dir)
-
 	client := &fakeClient{responses: []llm.Response{
 		{
 			Assistant: llm.Message{Role: llm.RoleAssistant, Content: "working", Phase: llm.MessagePhaseCommentary},
@@ -401,53 +374,27 @@ func TestBackgroundShellNoticeSameTurnNoopAddsNoAssistantMessage(t *testing.T) {
 		},
 	}}
 
-	started := make(chan struct{})
-	release := make(chan struct{})
-	var (
-		mu     sync.Mutex
-		events []Event
-	)
-	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: blockingTool{name: toolspec.ToolExecCommand, started: started, release: release}}), Config{
+	events := make([]Event, 0, 8)
+	eng := mustNewTestEngine(t, mustCreateTestSession(t), client, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
 		Model: "gpt-5",
 		OnEvent: func(evt Event) {
-			mu.Lock()
 			events = append(events, evt)
-			mu.Unlock()
 		},
 	})
 
-	submitDone := make(chan struct {
-		assistant llm.Message
-		err       error
-	}, 1)
-	go func() {
-		assistant, submitErr := eng.SubmitUserMessage(context.Background(), "run tools")
-		submitDone <- struct {
-			assistant llm.Message
-			err       error
-		}{assistant: assistant, err: submitErr}
-	}()
-
-	select {
-	case <-started:
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for tool call to start")
+	result, err := eng.SubmitUserMessageWithHooks(context.Background(), "run tools", func() {
+		eng.HandleBackgroundShellUpdate(BackgroundShellEvent{
+			Type:       BackgroundShellEventCompleted,
+			ID:         "1000",
+			State:      "completed",
+			NoticeText: "Background shell 1000 completed.\nExit code: 0\nOutput:\ndone",
+		}, true)
+	}, nil)
+	if err != nil {
+		t.Fatalf("submit: %v", err)
 	}
-
-	eng.HandleBackgroundShellUpdate(BackgroundShellEvent{
-		Type:       BackgroundShellEventCompleted,
-		ID:         "1000",
-		State:      "completed",
-		NoticeText: "Background shell 1000 completed.\nExit code: 0\nOutput:\ndone",
-	}, true)
-
-	close(release)
-	result := <-submitDone
-	if result.err != nil {
-		t.Fatalf("submit: %v", result.err)
-	}
-	if strings.TrimSpace(result.assistant.Content) != "" {
-		t.Fatalf("assistant content = %q, want empty", result.assistant.Content)
+	if strings.TrimSpace(result.Content) != "" {
+		t.Fatalf("assistant content = %q, want empty", result.Content)
 	}
 
 	client.mu.Lock()
@@ -465,6 +412,9 @@ func TestBackgroundShellNoticeSameTurnNoopAddsNoAssistantMessage(t *testing.T) {
 			}
 		}
 		return false
+	}
+	if containsNotice(requests[0]) {
+		t.Fatalf("background notice reached the first main-agent request: %+v", requestMessages(requests[0]))
 	}
 	if !containsNotice(requests[1]) {
 		t.Fatalf("expected background notice in same-turn follow-up, messages=%+v", requestMessages(requests[1]))
@@ -501,8 +451,6 @@ func TestBackgroundShellNoticeSameTurnNoopAddsNoAssistantMessage(t *testing.T) {
 		t.Fatalf("expected hidden persisted noop final assistant message, got %q", finalAssistantContents)
 	}
 
-	mu.Lock()
-	defer mu.Unlock()
 	assistantContents := make([]string, 0, 1)
 	for _, evt := range events {
 		if evt.Kind == EventAssistantMessage {

--- a/server/runtime/engine_queue_submission.go
+++ b/server/runtime/engine_queue_submission.go
@@ -52,18 +52,19 @@ func (e *Engine) SubmitQueuedUserMessages(ctx context.Context) (assistant llm.Me
 }
 
 func (e *Engine) SubmitQueuedUserMessagesWithActiveHook(ctx context.Context, onActive func()) (assistant llm.Message, receipt session.CommitReceipt, err error) {
-	return e.submitQueuedUserMessages(ctx, nil, onActive)
+	assistant, receipt, _, err = e.submitQueuedUserMessages(ctx, nil, onActive)
+	return
 }
 
-func (e *Engine) submitQueuedUserMessages(ctx context.Context, queueItemIDs map[string]struct{}, onActive func()) (assistant llm.Message, receipt session.CommitReceipt, err error) {
+func (e *Engine) submitQueuedUserMessages(ctx context.Context, queueItemIDs map[string]struct{}, onActive func()) (assistant llm.Message, receipt session.CommitReceipt, consumedQueueItemIDs map[string]struct{}, err error) {
 	e.ensureOrchestrationCollaborators()
 	for {
 		if e.failQueuedUserWorkIfTerminal() {
-			return llm.Message{}, receipt, nil
+			return llm.Message{}, receipt, consumedQueueItemIDs, nil
 		}
 		if len(queueItemIDs) > 0 {
 			if err := e.waitQueuedUserAutoDrainAllowed(ctx); err != nil {
-				return llm.Message{}, receipt, err
+				return llm.Message{}, receipt, consumedQueueItemIDs, err
 			}
 		}
 		err = e.stepLifecycle.Run(ctx, exclusiveStepOptions{EmitRunState: true, ActiveKind: ActiveKindUserTurn}, func(stepCtx context.Context, stepID string) error {
@@ -76,14 +77,15 @@ func (e *Engine) submitQueuedUserMessages(ctx context.Context, queueItemIDs map[
 			if err := e.ensureMetaContextForRequest(stepCtx, stepID); err != nil {
 				return err
 			}
-			flushed, flushReceipt, err := e.flushPendingUserInjections(stepID, allPendingUserInjectionSelection{})
-			if flushReceipt.Committed {
-				receipt = flushReceipt
+			flushResult, err := e.flushPendingUserInjections(stepID, allPendingUserInjectionSelection{})
+			if flushResult.receipt.Committed {
+				receipt = flushResult.receipt
 			}
 			if err != nil {
 				return err
 			}
-			if flushed == 0 {
+			consumedQueueItemIDs = flushResult.queueItemIDs
+			if flushResult.flushed == 0 {
 				return nil
 			}
 			msg, runErr := e.runStepLoopWithPendingUserInjectionObserver(stepCtx, stepID, func(flushReceipt session.CommitReceipt) {
@@ -93,12 +95,12 @@ func (e *Engine) submitQueuedUserMessages(ctx context.Context, queueItemIDs map[
 			return runErr
 		})
 		if receipt.Committed || !errors.Is(err, ErrAgentBusy) {
-			return assistant, receipt, err
+			return assistant, receipt, consumedQueueItemIDs, err
 		}
 
 		select {
 		case <-ctx.Done():
-			return llm.Message{}, receipt, ctx.Err()
+			return llm.Message{}, receipt, consumedQueueItemIDs, ctx.Err()
 		case <-time.After(queuedUserSubmissionBusyRetryDelay):
 		}
 	}
@@ -246,11 +248,12 @@ func (e *Engine) processQueuedUserWork(ctx context.Context) {
 		return
 	}
 	ids := e.queuedUserAutoDrainIDSnapshot()
-	if _, _, err := e.submitQueuedUserMessages(ctx, ids, nil); err != nil {
+	_, _, consumedQueueItemIDs, err := e.submitQueuedUserMessages(ctx, ids, nil)
+	if err != nil {
 		e.surfaceRunError(err)
 		return
 	}
-	e.completeLiveRunQueueItems(ids)
+	e.completeLiveRunQueueItems(consumedQueueItemIDs)
 	completed = true
 }
 
@@ -278,14 +281,7 @@ func (e *Engine) hasQueuedUserAutoDrainIDs() bool {
 func (e *Engine) queuedUserAutoDrainIDSnapshot() map[string]struct{} {
 	e.queuedUserWorkMu.Lock()
 	defer e.queuedUserWorkMu.Unlock()
-	if len(e.queuedUserWorkAutoDrainIDs) == 0 {
-		return nil
-	}
-	out := make(map[string]struct{}, len(e.queuedUserWorkAutoDrainIDs))
-	for id := range e.queuedUserWorkAutoDrainIDs {
-		out[id] = struct{}{}
-	}
-	return out
+	return cloneMapIfNonEmpty(e.queuedUserWorkAutoDrainIDs)
 }
 
 func cloneMapIfNonEmpty[M ~map[K]V, K comparable, V any](in M) M {

--- a/server/runtime/engine_queue_submission.go
+++ b/server/runtime/engine_queue_submission.go
@@ -76,7 +76,7 @@ func (e *Engine) submitQueuedUserMessages(ctx context.Context, queueItemIDs map[
 			if err := e.ensureMetaContextForRequest(stepCtx, stepID); err != nil {
 				return err
 			}
-			flushed, flushReceipt, err := e.flushPendingUserInjections(stepID, allPendingUserInjections())
+			flushed, flushReceipt, err := e.flushPendingUserInjections(stepID, allPendingUserInjectionSelection{})
 			if flushReceipt.Committed {
 				receipt = flushReceipt
 			}

--- a/server/runtime/engine_queue_submission.go
+++ b/server/runtime/engine_queue_submission.go
@@ -76,7 +76,7 @@ func (e *Engine) submitQueuedUserMessages(ctx context.Context, queueItemIDs map[
 			if err := e.ensureMetaContextForRequest(stepCtx, stepID); err != nil {
 				return err
 			}
-			flushed, flushReceipt, err := e.flushPendingUserInjections(stepID, queueItemIDs)
+			flushed, flushReceipt, err := e.flushPendingUserInjections(stepID, allPendingUserInjections())
 			if flushReceipt.Committed {
 				receipt = flushReceipt
 			}
@@ -86,7 +86,7 @@ func (e *Engine) submitQueuedUserMessages(ctx context.Context, queueItemIDs map[
 			if flushed == 0 {
 				return nil
 			}
-			msg, runErr := e.runStepLoopWithPendingUserInjectionObserver(stepCtx, stepID, queueItemIDs, func(flushReceipt session.CommitReceipt) {
+			msg, runErr := e.runStepLoopWithPendingUserInjectionObserver(stepCtx, stepID, func(flushReceipt session.CommitReceipt) {
 				receipt = flushReceipt
 			})
 			assistant = msg
@@ -220,10 +220,6 @@ func (e *Engine) scheduleQueuedUserInjectionsIfIdle() bool {
 		e.queuedUserWorkMu.Unlock()
 		return true
 	}
-	if len(e.queuedUserWorkAutoDrainIDs) == 0 {
-		e.queuedUserWorkMu.Unlock()
-		return false
-	}
 	e.queuedUserWorkScheduled = true
 	e.queuedUserWorkMu.Unlock()
 	if !e.launchLifecycleTask(e.processQueuedUserWork) {
@@ -241,14 +237,12 @@ func (e *Engine) processQueuedUserWork(ctx context.Context) {
 			return
 		}
 		e.ensureOrchestrationCollaborators()
-		if e.messageFlow.HasPendingUserInjections() && e.hasQueuedUserAutoDrainIDs() {
+		if e.messageFlow.HasPendingUserInjections() {
 			e.scheduleQueuedUserInjectionsIfIdle()
 		}
 	}()
-	if !e.hasQueuedUserAutoDrainIDs() {
-		if e.backgroundFlow != nil {
-			e.backgroundFlow.ScheduleIfIdle()
-		}
+	if err := e.waitQueuedUserAutoDrainAllowed(ctx); err != nil {
+		e.surfaceRunError(err)
 		return
 	}
 	ids := e.queuedUserAutoDrainIDSnapshot()
@@ -292,31 +286,6 @@ func (e *Engine) queuedUserAutoDrainIDSnapshot() map[string]struct{} {
 		out[id] = struct{}{}
 	}
 	return out
-}
-
-// pushActiveUserInjectionScope records the queued user-injection IDs the in-flight
-// step (and its nested reviewer follow-up) should flush, returning a restore func
-// that reinstates the prior scope. The step executor reads this scope so reviewer
-// follow-ups inherit it without the supervisor carrying injection IDs.
-func (e *Engine) pushActiveUserInjectionScope(ids map[string]struct{}) func() {
-	e.userInjectionScopeMu.Lock()
-	previous := e.activeUserInjectionScope
-	e.activeUserInjectionScope = cloneMapIfNonEmpty(ids)
-	e.userInjectionScopeMu.Unlock()
-	return func() {
-		e.userInjectionScopeMu.Lock()
-		e.activeUserInjectionScope = previous
-		e.userInjectionScopeMu.Unlock()
-	}
-}
-
-func (e *Engine) activeUserInjectionScopeSnapshot() map[string]struct{} {
-	if e == nil {
-		return nil
-	}
-	e.userInjectionScopeMu.Lock()
-	defer e.userInjectionScopeMu.Unlock()
-	return cloneMapIfNonEmpty(e.activeUserInjectionScope)
 }
 
 func cloneMapIfNonEmpty[M ~map[K]V, K comparable, V any](in M) M {

--- a/server/runtime/live_run_control_test.go
+++ b/server/runtime/live_run_control_test.go
@@ -542,10 +542,10 @@ func TestCapturedActiveRunResultWaitsForTaggedQueuedDrainResult(t *testing.T) {
 	}()
 	client.waitStarted(t)
 
-	queued := eng.QueueUserMessageWithClientRequestID("steer into drain", "req-queued")
+	queued, accepted, queueErr := eng.QueueUserMessageForActiveRun(context.Background(), "steer into drain", liveRunTestRequestID(t), nil)
 	handle, captureErr := eng.CaptureActiveRunResult(context.Background())
-	if queued.ID == "" || captureErr != nil {
-		t.Fatalf("queued=%+v capture error=%v", queued, captureErr)
+	if queued.ID == "" || !accepted || queueErr != nil || captureErr != nil {
+		t.Fatalf("queued=%+v accepted=%t queue error=%v capture error=%v", queued, accepted, queueErr, captureErr)
 	}
 	handle, err := eng.CaptureActiveRunResult(context.Background())
 	if err != nil {

--- a/server/runtime/live_run_control_test.go
+++ b/server/runtime/live_run_control_test.go
@@ -531,55 +531,63 @@ func TestWaitForActiveRunResultReturnsAssistantFinalAnswer(t *testing.T) {
 	}
 }
 
-func TestCapturedActiveRunResultWaitsForTaggedQueuedDrainResult(t *testing.T) {
-	store := mustCreateTestSession(t)
-	client := newBlockingThenBlockedQueuedClient()
-	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(), Config{Model: "gpt-5"})
+func TestCapturedActiveRunResultCompletesLateTaggedQueuedDrain(t *testing.T) {
+	client := &fakeClient{responses: []llm.Response{
+		{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "initial work handled", Phase: llm.MessagePhaseFinal}},
+		{Assistant: llm.Message{Role: llm.RoleAssistant, Content: "queued work handled", Phase: llm.MessagePhaseFinal}},
+	}}
+	transitions := make(chan StepLifecycleTransition)
+	releaseTransition := make(chan struct{})
+	sink := &callbackStepLifecycleSink{onTransition: func(transition StepLifecycleTransition) error {
+		transitions <- transition
+		<-releaseTransition
+		return nil
+	}}
+	eng := mustNewTestEngine(t, mustCreateTestSession(t), client, tools.NewRegistry(), Config{Model: "gpt-5", StepLifecycle: sink})
 	submitDone := make(chan error, 1)
 	go func() {
 		_, err := eng.SubmitUserMessage(context.Background(), "hello")
 		submitDone <- err
 	}()
-	client.waitStarted(t)
-
-	queued, accepted, queueErr := eng.QueueUserMessageForActiveRun(context.Background(), "steer into drain", liveRunTestRequestID(t), nil)
-	handle, captureErr := eng.CaptureActiveRunResult(context.Background())
-	if queued.ID == "" || !accepted || queueErr != nil || captureErr != nil {
-		t.Fatalf("queued=%+v accepted=%t queue error=%v capture error=%v", queued, accepted, queueErr, captureErr)
+	if got := <-transitions; got != StepLifecycleTransitionBegan {
+		t.Fatalf("first transition = %q, want began", got)
 	}
-	handle, err := eng.CaptureActiveRunResult(context.Background())
-	if err != nil {
-		t.Fatalf("CaptureActiveRunResult: %v", err)
+	releaseTransition <- struct{}{}
+	if got := <-transitions; got != StepLifecycleTransitionEnded {
+		t.Fatalf("second transition = %q, want ended", got)
 	}
-	waitDone := make(chan struct {
-		result LiveRunResult
-		err    error
-	}, 1)
-	go func() {
-		result, err := handle.Wait()
-		waitDone <- struct {
-			result LiveRunResult
-			err    error
-		}{result: result, err: err}
-	}()
-
-	client.release()
-	client.waitSecondStarted(t)
-	select {
-	case waited := <-waitDone:
-		t.Fatalf("wait completed before tagged queued drain model result: result=%+v err=%v", waited.result, waited.err)
-	default:
+	queued := eng.QueueUserMessageForAutoDrain("steer into drain", "initial-drain")
+	waitCtx, cancelWait := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelWait()
+	handle, err := eng.CaptureActiveRunResult(waitCtx)
+	if queued.ID == "" || err != nil {
+		t.Fatalf("queued=%+v capture error=%v", queued, err)
 	}
-	client.releaseSecond()
+	releaseTransition <- struct{}{}
 	if err := <-submitDone; err != nil {
 		t.Fatalf("SubmitUserMessage: %v", err)
 	}
-	waited := <-waitDone
-	if waited.err != nil {
-		t.Fatalf("captured live run result: %v", waited.err)
+	if got := <-transitions; got != StepLifecycleTransitionBegan {
+		t.Fatalf("queued transition = %q, want began", got)
 	}
-	if waited.result.AssistantMessage.Content != "queued work handled" {
-		t.Fatalf("wait result = %+v, want queued work handled", waited.result)
+	late, accepted, queueErr := eng.QueueUserMessageForActiveRun(context.Background(), "steer admitted after drain snapshot", liveRunTestRequestID(t), nil)
+	if late.ID == "" || !accepted || queueErr != nil {
+		t.Fatalf("late queued=%+v accepted=%t queue error=%v", late, accepted, queueErr)
+	}
+	releaseTransition <- struct{}{}
+	if got := <-transitions; got != StepLifecycleTransitionEnded {
+		t.Fatalf("final transition = %q, want ended", got)
+	}
+	releaseTransition <- struct{}{}
+	waited, err := handle.Wait()
+	if err != nil {
+		t.Fatalf("captured live run result: %v", err)
+	}
+	if waited.AssistantMessage.Content != "queued work handled" {
+		t.Fatalf("wait result = %+v, want queued work handled", waited)
+	}
+	if eng.HasActiveLiveRunGroup() {
+		t.Fatal("live-run group remained active after draining late tagged steering")
 	}
 }
 

--- a/server/runtime/message_lifecycle.go
+++ b/server/runtime/message_lifecycle.go
@@ -294,23 +294,22 @@ func queuedUserMessagesForFlush(messages []queuedUserSteeringIntent) []QueuedUse
 	return items
 }
 
-func (m *defaultMessageLifecycle) FlushPendingUserInjections(stepID string, selection userInjectionSelection) (int, session.CommitReceipt, error) {
+func (m *defaultMessageLifecycle) FlushPendingUserInjections(stepID string, selection userInjectionSelection) (userInjectionCommitResult, error) {
 	result, err := m.CommitPendingUserInjections(stepID, selection)
 	if err != nil || !result.continueCombinedFlush {
-		return result.flushed, result.receipt, err
+		return result, err
 	}
-	flushed := result.flushed
 	pendingNotices := []steeringIntent(nil)
 	if m.background != nil {
 		pendingNotices = m.background.DrainPendingNotices()
 	}
 	for _, notice := range pendingNotices {
 		if err := m.engine.steer(stepID, notice); err != nil {
-			return flushed, result.receipt, err
+			return result, err
 		}
-		flushed++
+		result.flushed++
 	}
-	return flushed, result.receipt, nil
+	return result, nil
 }
 
 func (m *defaultMessageLifecycle) CommitPendingUserInjections(stepID string, selection userInjectionSelection) (userInjectionCommitResult, error) {
@@ -325,7 +324,6 @@ func (m *defaultMessageLifecycle) CommitPendingUserInjections(stepID string, sel
 	default:
 		return userInjectionCommitResult{}, fmt.Errorf("unsupported user injection selection %T", selection)
 	}
-	pending = m.engine.dropStoppedLiveRunQueueItems(pending)
 	return m.commitPendingUserInjections(stepID, pending)
 }
 
@@ -333,19 +331,17 @@ func (m *defaultMessageLifecycle) commitPendingUserInjections(stepID string, pen
 	e := m.engine
 	result := userInjectionCommitResult{continueCombinedFlush: true}
 
+	// Recheck immediately before commit because a live-run stop can race the drain.
+	pending = e.dropStoppedLiveRunQueueItems(pending)
 	queuedMessages := normalizeQueuedUserMessages(pending)
 	if len(queuedMessages) > 0 {
-		pending = e.dropStoppedLiveRunQueueItems(pending)
-		queuedMessages = normalizeQueuedUserMessages(pending)
-		if len(queuedMessages) == 0 {
-			result.continueCombinedFlush = false
-			return result, nil
-		}
+		queueItems := queuedUserMessagesForFlush(pending)
+		result.queueItemIDs = queuedUserMessageIDSet(queueItems)
 		joined := strings.Join(queuedMessages, "\n\n")
 		publishAllowed, err := e.commitLiveRunQueueItemsUnlessStopped(pending, func() error {
 			receipt, persistErr := e.steerWithCommitReceipt(
 				stepID,
-				steerQueuedUserMessageFlushIntent(joined, queuedMessages, queuedUserMessagesForFlush(pending)),
+				steerQueuedUserMessageFlushIntent(joined, queuedMessages, queueItems),
 			)
 			result.receipt = receipt
 			return persistErr

--- a/server/runtime/message_lifecycle.go
+++ b/server/runtime/message_lifecycle.go
@@ -315,10 +315,15 @@ func (m *defaultMessageLifecycle) FlushPendingUserInjections(stepID string, sele
 
 func (m *defaultMessageLifecycle) CommitPendingUserInjections(stepID string, selection userInjectionSelection) (userInjectionCommitResult, error) {
 	var pending []queuedUserSteeringIntent
-	if selection.all {
+	switch selected := selection.(type) {
+	case allPendingUserInjectionSelection:
 		pending = m.queue.Drain()
-	} else if len(selection.queueItemIDs) > 0 {
-		pending = m.queue.DrainByID(selection.queueItemIDs)
+	case steerUserInjectionSelection:
+		if len(selected.queueItemIDs) > 0 {
+			pending = m.queue.DrainByID(selected.queueItemIDs)
+		}
+	default:
+		return userInjectionCommitResult{}, fmt.Errorf("unsupported user injection selection %T", selection)
 	}
 	pending = m.engine.dropStoppedLiveRunQueueItems(pending)
 	return m.commitPendingUserInjections(stepID, pending)

--- a/server/runtime/message_lifecycle.go
+++ b/server/runtime/message_lifecycle.go
@@ -294,31 +294,47 @@ func queuedUserMessagesForFlush(messages []queuedUserSteeringIntent) []QueuedUse
 	return items
 }
 
-// FlushPendingUserInjections flushes queued user injections for the step. An empty
-// queueItemIDs flushes every pending injection; a non-empty set flushes only those
-// IDs.
-func (m *defaultMessageLifecycle) FlushPendingUserInjections(stepID string, queueItemIDs map[string]struct{}) (int, session.CommitReceipt, error) {
-	var pending []queuedUserSteeringIntent
-	if len(queueItemIDs) == 0 {
-		pending = m.queue.Drain()
-	} else {
-		pending = m.queue.DrainByID(queueItemIDs)
+func (m *defaultMessageLifecycle) FlushPendingUserInjections(stepID string, selection userInjectionSelection) (int, session.CommitReceipt, error) {
+	result, err := m.CommitPendingUserInjections(stepID, selection)
+	if err != nil || !result.continueCombinedFlush {
+		return result.flushed, result.receipt, err
 	}
-	pending = m.engine.dropStoppedLiveRunQueueItems(pending)
-	return m.flushPendingUserInjections(stepID, pending)
+	flushed := result.flushed
+	pendingNotices := []steeringIntent(nil)
+	if m.background != nil {
+		pendingNotices = m.background.DrainPendingNotices()
+	}
+	for _, notice := range pendingNotices {
+		if err := m.engine.steer(stepID, notice); err != nil {
+			return flushed, result.receipt, err
+		}
+		flushed++
+	}
+	return flushed, result.receipt, nil
 }
 
-func (m *defaultMessageLifecycle) flushPendingUserInjections(stepID string, pending []queuedUserSteeringIntent) (int, session.CommitReceipt, error) {
+func (m *defaultMessageLifecycle) CommitPendingUserInjections(stepID string, selection userInjectionSelection) (userInjectionCommitResult, error) {
+	var pending []queuedUserSteeringIntent
+	if selection.all {
+		pending = m.queue.Drain()
+	} else if len(selection.queueItemIDs) > 0 {
+		pending = m.queue.DrainByID(selection.queueItemIDs)
+	}
+	pending = m.engine.dropStoppedLiveRunQueueItems(pending)
+	return m.commitPendingUserInjections(stepID, pending)
+}
+
+func (m *defaultMessageLifecycle) commitPendingUserInjections(stepID string, pending []queuedUserSteeringIntent) (userInjectionCommitResult, error) {
 	e := m.engine
-	flushed := 0
-	var flushReceipt session.CommitReceipt
+	result := userInjectionCommitResult{continueCombinedFlush: true}
 
 	queuedMessages := normalizeQueuedUserMessages(pending)
 	if len(queuedMessages) > 0 {
 		pending = e.dropStoppedLiveRunQueueItems(pending)
 		queuedMessages = normalizeQueuedUserMessages(pending)
 		if len(queuedMessages) == 0 {
-			return flushed, flushReceipt, nil
+			result.continueCombinedFlush = false
+			return result, nil
 		}
 		joined := strings.Join(queuedMessages, "\n\n")
 		publishAllowed, err := e.commitLiveRunQueueItemsUnlessStopped(pending, func() error {
@@ -326,38 +342,29 @@ func (m *defaultMessageLifecycle) flushPendingUserInjections(stepID string, pend
 				stepID,
 				steerQueuedUserMessageFlushIntent(joined, queuedMessages, queuedUserMessagesForFlush(pending)),
 			)
-			flushReceipt = receipt
+			result.receipt = receipt
 			return persistErr
 		})
 		if err != nil {
-			if !flushReceipt.Committed {
+			if !result.receipt.Committed {
 				m.queue.RestoreFront(pending)
 			}
-			return flushed, flushReceipt, err
+			return result, err
 		}
 		if !publishAllowed {
 			for _, item := range pending {
 				e.unmarkQueuedUserInjectionForAutoDrain(item.message.ID)
 				e.emitQueuedUserMessageStatus(item.message, QueuedUserMessageFailed, QueuedUserMessageFailureStopped, true)
 			}
-			return flushed, flushReceipt, nil
+			result.continueCombinedFlush = false
+			return result, nil
 		}
-		flushed++
+		result.flushed++
 	}
 	for _, item := range pending {
 		e.unmarkQueuedUserInjectionForAutoDrain(item.message.ID)
 	}
-	pendingNotices := []steeringIntent(nil)
-	if m.background != nil {
-		pendingNotices = m.background.DrainPendingNotices()
-	}
-	for _, notice := range pendingNotices {
-		if err := e.steer(stepID, notice); err != nil {
-			return flushed, flushReceipt, err
-		}
-		flushed++
-	}
-	return flushed, flushReceipt, nil
+	return result, nil
 }
 
 func (m *defaultMessageLifecycle) QueueUserMessage(text string, clientRequestID string) QueuedUserMessage {

--- a/server/runtime/missing_tool_output_repair_test.go
+++ b/server/runtime/missing_tool_output_repair_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"core/server/llm"
 	"core/server/session"
@@ -14,6 +15,28 @@ import (
 	"core/shared/toolspec"
 	"core/shared/transcript"
 )
+
+type gatedMissingToolRepairClient struct {
+	fakeClient
+	rejected chan struct{}
+	release  chan struct{}
+}
+
+func (c *gatedMissingToolRepairClient) Generate(_ context.Context, request llm.Request) (llm.Response, error) {
+	c.mu.Lock()
+	c.calls = append(c.calls, request)
+	call := len(c.calls)
+	c.mu.Unlock()
+	if call == 1 {
+		close(c.rejected)
+		<-c.release
+		return llm.Response{}, &llm.APIStatusError{StatusCode: 400, Body: "tool call without output"}
+	}
+	return llm.Response{
+		Assistant: llm.Message{Role: llm.RoleAssistant, Phase: llm.MessagePhaseFinal, Content: "repaired"},
+		Usage:     llm.Usage{InputTokens: 10, OutputTokens: 2, WindowTokens: 100},
+	}, nil
+}
 
 func appendRepairEvent(t *testing.T, store *session.Store, kind string, payload any) session.Event {
 	t.Helper()
@@ -107,6 +130,39 @@ func TestMissingToolOutputRepairAppendsSyntheticOutputAndRetries(t *testing.T) {
 	if got := countPersistedLocalEntries(readRepairEvents(t, store)); got != 1 {
 		t.Fatalf("persisted operator warnings = %d, want 1", got)
 	}
+}
+
+func TestMissingToolOutputRepairRebuildIncludesSteerAcceptedAfterRejectedRequest(t *testing.T) {
+	store := mustCreateTestSession(t)
+	appendRepairEvent(t, store, "message", llm.Message{
+		Role:      llm.RoleAssistant,
+		ToolCalls: []llm.ToolCall{{ID: "missing", Name: "exec", Input: json.RawMessage(`{}`)}},
+	})
+	client := &gatedMissingToolRepairClient{
+		rejected: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	eng := mustNewTestEngine(t, store, client, tools.NewRegistry(), Config{Model: "gpt-5"})
+
+	submitDone := make(chan error, 1)
+	go func() {
+		_, err := eng.SubmitUserMessage(context.Background(), "continue")
+		submitDone <- err
+	}()
+	select {
+	case <-client.rejected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for rejected request")
+	}
+	if _, accepted, err := eng.QueueUserMessageForActiveRun(context.Background(), "steer repaired request", liveRunTestRequestID(t), nil); err != nil || !accepted {
+		t.Fatalf("QueueUserMessageForActiveRun accepted=%t err=%v", accepted, err)
+	}
+	close(client.release)
+	if err := <-submitDone; err != nil {
+		t.Fatalf("submit user message: %v", err)
+	}
+
+	assertRequestHasUserMessage(t, client.calls[1], "steer repaired request", true)
 }
 
 // A 400 that is not caused by a missing tool output (nothing dangling) must

--- a/server/runtime/orchestration_collaborators.go
+++ b/server/runtime/orchestration_collaborators.go
@@ -54,9 +54,25 @@ type stepLoopOptions struct {
 	ReviewerFrequency              string
 	ReviewerClient                 llm.Client
 	RefreshReviewerConfigOnResolve bool
-	PendingUserInjectionIDs        map[string]struct{}
 	OnQueuedUserFlushCommitted     func(session.CommitReceipt)
 }
+
+type userInjectionSelection struct {
+	all          bool
+	queueItemIDs map[string]struct{}
+}
+
+type userInjectionCommitResult struct {
+	flushed               int
+	receipt               session.CommitReceipt
+	continueCombinedFlush bool
+}
+
+func steerUserInjections(queueItemIDs map[string]struct{}) userInjectionSelection {
+	return userInjectionSelection{queueItemIDs: queueItemIDs}
+}
+
+func allPendingUserInjections() userInjectionSelection { return userInjectionSelection{all: true} }
 
 type stepLoopResult struct {
 	Message                    llm.Message
@@ -80,7 +96,8 @@ type toolExecutor interface {
 
 type messageLifecycle interface {
 	RestoreMessages() error
-	FlushPendingUserInjections(stepID string, queueItemIDs map[string]struct{}) (int, session.CommitReceipt, error)
+	CommitPendingUserInjections(stepID string, selection userInjectionSelection) (userInjectionCommitResult, error)
+	FlushPendingUserInjections(stepID string, selection userInjectionSelection) (int, session.CommitReceipt, error)
 	DrainPendingUserInjections() []QueuedUserMessage
 	DrainPendingUserInjectionsByID(ids map[string]struct{}) []QueuedUserMessage
 	QueueUserMessage(text string, clientRequestID string) QueuedUserMessage

--- a/server/runtime/orchestration_collaborators.go
+++ b/server/runtime/orchestration_collaborators.go
@@ -57,10 +57,25 @@ type stepLoopOptions struct {
 	OnQueuedUserFlushCommitted     func(session.CommitReceipt)
 }
 
-type userInjectionSelection struct {
-	all          bool
+func observeQueuedUserFlushCommit(options stepLoopOptions, receipt session.CommitReceipt) {
+	if receipt.Committed && options.OnQueuedUserFlushCommitted != nil {
+		options.OnQueuedUserFlushCommitted(receipt)
+	}
+}
+
+type userInjectionSelection interface {
+	userInjectionSelection()
+}
+
+type steerUserInjectionSelection struct {
 	queueItemIDs map[string]struct{}
 }
+
+func (steerUserInjectionSelection) userInjectionSelection() {}
+
+type allPendingUserInjectionSelection struct{}
+
+func (allPendingUserInjectionSelection) userInjectionSelection() {}
 
 type userInjectionCommitResult struct {
 	flushed               int
@@ -69,10 +84,10 @@ type userInjectionCommitResult struct {
 }
 
 func steerUserInjections(queueItemIDs map[string]struct{}) userInjectionSelection {
-	return userInjectionSelection{queueItemIDs: queueItemIDs}
+	return steerUserInjectionSelection{queueItemIDs: queueItemIDs}
 }
 
-func allPendingUserInjections() userInjectionSelection { return userInjectionSelection{all: true} }
+func allPendingUserInjections() userInjectionSelection { return allPendingUserInjectionSelection{} }
 
 type stepLoopResult struct {
 	Message                    llm.Message

--- a/server/runtime/orchestration_collaborators.go
+++ b/server/runtime/orchestration_collaborators.go
@@ -80,6 +80,7 @@ func (allPendingUserInjectionSelection) userInjectionSelection() {}
 type userInjectionCommitResult struct {
 	flushed               int
 	receipt               session.CommitReceipt
+	queueItemIDs          map[string]struct{}
 	continueCombinedFlush bool
 }
 
@@ -110,7 +111,7 @@ type toolExecutor interface {
 type messageLifecycle interface {
 	RestoreMessages() error
 	CommitPendingUserInjections(stepID string, selection userInjectionSelection) (userInjectionCommitResult, error)
-	FlushPendingUserInjections(stepID string, selection userInjectionSelection) (int, session.CommitReceipt, error)
+	FlushPendingUserInjections(stepID string, selection userInjectionSelection) (userInjectionCommitResult, error)
 	DrainPendingUserInjections() []QueuedUserMessage
 	DrainPendingUserInjectionsByID(ids map[string]struct{}) []QueuedUserMessage
 	QueueUserMessage(text string, clientRequestID string) QueuedUserMessage

--- a/server/runtime/orchestration_collaborators.go
+++ b/server/runtime/orchestration_collaborators.go
@@ -87,8 +87,6 @@ func steerUserInjections(queueItemIDs map[string]struct{}) userInjectionSelectio
 	return steerUserInjectionSelection{queueItemIDs: queueItemIDs}
 }
 
-func allPendingUserInjections() userInjectionSelection { return allPendingUserInjectionSelection{} }
-
 type stepLoopResult struct {
 	Message                    llm.Message
 	ExecutedToolCall           bool

--- a/server/runtime/step_executor.go
+++ b/server/runtime/step_executor.go
@@ -346,9 +346,9 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 }
 
 func (s *defaultStepExecutor) flushPendingUserInjections(stepID string, options stepLoopOptions) (int, error) {
-	flushed, receipt, err := s.messages.FlushPendingUserInjections(stepID, steerUserInjections(s.engine.queuedUserAutoDrainIDSnapshot()))
-	observeQueuedUserFlushCommit(options, receipt)
-	return flushed, err
+	result, err := s.messages.FlushPendingUserInjections(stepID, steerUserInjections(s.engine.queuedUserAutoDrainIDSnapshot()))
+	observeQueuedUserFlushCommit(options, result.receipt)
+	return result.flushed, err
 }
 
 func (s *defaultStepExecutor) commitPendingUserSteer(stepID string, options stepLoopOptions) error {

--- a/server/runtime/step_executor.go
+++ b/server/runtime/step_executor.go
@@ -52,10 +52,6 @@ type completedResponsePreflightRejection struct {
 
 func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID string, options stepLoopOptions) (stepLoopResult, error) {
 	e := s.engine
-	// The engine owns the queued user-injection scope for the in-flight top-level
-	// step; derive it here so reviewer follow-ups inherit it without the supervisor
-	// threading injection IDs through stepLoopOptions.
-	options.PendingUserInjectionIDs = e.activeUserInjectionScopeSnapshot()
 	executedToolCall := false
 	patchEditsApplied := false
 	deferredFinal := llm.Message{}
@@ -83,6 +79,9 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 			ctx,
 			stepID,
 			func() (llm.Request, error) {
+				if err := s.commitPendingUserSteer(stepID, options); err != nil {
+					return llm.Request{}, err
+				}
 				requestPlan, buildErr := e.buildRequestPlanWithExtraItems(ctx, stepID, nil, true)
 				if buildErr != nil {
 					return llm.Request{}, buildErr
@@ -347,11 +346,19 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 }
 
 func (s *defaultStepExecutor) flushPendingUserInjections(stepID string, options stepLoopOptions) (int, error) {
-	flushed, receipt, err := s.messages.FlushPendingUserInjections(stepID, options.PendingUserInjectionIDs)
+	flushed, receipt, err := s.messages.FlushPendingUserInjections(stepID, steerUserInjections(s.engine.queuedUserAutoDrainIDSnapshot()))
 	if receipt.Committed && options.OnQueuedUserFlushCommitted != nil {
 		options.OnQueuedUserFlushCommitted(receipt)
 	}
 	return flushed, err
+}
+
+func (s *defaultStepExecutor) commitPendingUserSteer(stepID string, options stepLoopOptions) error {
+	result, err := s.messages.CommitPendingUserInjections(stepID, steerUserInjections(s.engine.queuedUserAutoDrainIDSnapshot()))
+	if result.receipt.Committed && options.OnQueuedUserFlushCommitted != nil {
+		options.OnQueuedUserFlushCommitted(result.receipt)
+	}
+	return err
 }
 
 func (s *defaultStepExecutor) prepareCompletedResponse(ctx context.Context, stepID string, resp llm.Response) (preparedCompletedResponse, error) {

--- a/server/runtime/step_executor.go
+++ b/server/runtime/step_executor.go
@@ -347,17 +347,13 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 
 func (s *defaultStepExecutor) flushPendingUserInjections(stepID string, options stepLoopOptions) (int, error) {
 	flushed, receipt, err := s.messages.FlushPendingUserInjections(stepID, steerUserInjections(s.engine.queuedUserAutoDrainIDSnapshot()))
-	if receipt.Committed && options.OnQueuedUserFlushCommitted != nil {
-		options.OnQueuedUserFlushCommitted(receipt)
-	}
+	observeQueuedUserFlushCommit(options, receipt)
 	return flushed, err
 }
 
 func (s *defaultStepExecutor) commitPendingUserSteer(stepID string, options stepLoopOptions) error {
 	result, err := s.messages.CommitPendingUserInjections(stepID, steerUserInjections(s.engine.queuedUserAutoDrainIDSnapshot()))
-	if result.receipt.Committed && options.OnQueuedUserFlushCommitted != nil {
-		options.OnQueuedUserFlushCommitted(result.receipt)
-	}
+	observeQueuedUserFlushCommit(options, result.receipt)
 	return err
 }
 

--- a/server/runtime/workflow_completion_test.go
+++ b/server/runtime/workflow_completion_test.go
@@ -121,11 +121,7 @@ func (c *workflowSteeringClient) Generate(_ context.Context, request llm.Request
 	if call == 1 {
 		close(c.started)
 		<-c.release
-		return commentaryResponse("working", llm.ToolCall{
-			ID:    "call-shell",
-			Name:  string(toolspec.ToolExecCommand),
-			Input: json.RawMessage(`{}`),
-		}), nil
+		return encryptedReasoningOnlyResponse("rs_workflow"), nil
 	}
 	return commentaryResponse("complete", completeNodeCall("call-complete", json.RawMessage(`{"commentary":"done","summary":"done"}`))), nil
 }


### PR DESCRIPTION
## Summary

- Drain current user **Steer** messages immediately before every covered main-agent request is built.
- Reuse the shared request rebuild so the behavior applies to normal and workflow continuations, missing-tool-output repair, and reviewer main-agent follow-up.
- Keep explicit **Queue** messages out of the current Agent Turn and submit them through the existing all-pending next-turn path.
- Split selected-user commit from the existing combined user/Background-notice flush, preserving notice timing, persistence receipts, restore/status behavior, and live-run ownership.
- Replace the prior fixed injection scope with a closed, typed Steer/all-pending selection and centralize queued-user commit-receipt observation.

## Verification

Passed:

- `./scripts/test.sh server ./server/runtime`
- `./scripts/test.sh server`
- `./scripts/build.sh server --output ./bin/kent`
- `git diff 640aefc58..HEAD --check`
- Acceptance-focused normal/workflow, final-answer deferral, Queue separation, missing-tool repair, reviewer follow-up, live-run/status, and Background-notice timing regressions
- Review verification additionally ran `go test ./server/runtime ./server/core`, `go test -race ./server/runtime`, and targeted regressions repeated 10 times

## Completion evidence

- Acceptance matrix and approved scope: `.kent/plans/KENT-319.md` (local workflow evidence; not committed)
- Isolated manual TUI proof: `.kent/qa/proofs/20260720T191812Z-KENT-319-post-review-steer/screen.txt`
- Final isolated capture: `.kent/qa/proofs/20260720T191812Z-KENT-319-post-review-steer/screen-current.txt`
- Manual QA showed an in-chat Steer entered during an active shell-driven turn becoming the next requested `git log -1 --oneline` action after the current shell command returned. The isolated QA harness was stopped and wiped; production server `:53082` was untouched.

The proof files are preserved in the local Kent workflow workspace; `gh pr create` does not support uploading local attachments directly.

## LoC budget

| Area | Additions | Deletions | Gross | Net |
|---|---:|---:|---:|---:|
| Production code | 101 | 97 | 198 | +4 |
| Tests/generated code | 250 | 374 | 624 | -124 |
| **Total** | **351** | **471** | **822** | **-120** |

The total change is net-negative and below the 1,000 gross-LoC ticket limit.

## Caveats and tradeoffs

- Steer and Queue remain intentionally distinct: Steer joins the next in-turn main-agent step; Queue waits for the automatically scheduled next Agent Turn.
- Two existing integration expectations used Queue APIs as shorthand for Steer. They were corrected under explicit operator authorization; public APIs and storage/protocol contracts are unchanged.
- No Background production logic, failed/interrupted scheduling policy, specifications, protocol, storage, migrations, or UI code changed.
- No follow-up work is required for this fix. A broader Queue/Steer naming cleanup would be a separate product/API decision and is intentionally out of scope.

## Tracking

- Kent task: `KENT-319` — Steered messages aren't actually drained in-between steps
- GitHub issue: no issue is currently linked to this Kent task


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of messages queued during active runs, including live steering/follow-ups and runtime control queued vs. steered behavior.
  * Ensured queued user messages are flushed/processed deterministically and reflected in the correct subsequent responses.
  * Fixed late queued steering/drain completion behavior for captured active-run results.
  * Improved recovery when a request is initially rejected due to missing tool output, preserving queued steering instructions.
  * Prevented background notices from appearing prematurely in responses.
* **Tests**
  * Expanded coverage for live controls, queued message flushing, reviewer follow-ups, workflow reasoning-only flow, and missing-tool-output repair scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->