### PR TITLE
Show the session agent role in TUI status

### DIFF
--- a/cli/app/internal/status/status.go
+++ b/cli/app/internal/status/status.go
@@ -51,6 +51,7 @@ type Request struct {
 	AuthStatePath         string
 	SessionName           string
 	SessionID             string
+	AgentRole             *string
 	ConfiguredModelName   string
 	ModelName             string
 	ThinkingLevel         string
@@ -69,6 +70,7 @@ type Snapshot struct {
 	Workdir                string
 	SessionName            string
 	SessionID              string
+	AgentRole              *string
 	PreviousSessionID      *runtimeids.SessionID
 	PreviousSessionName    string
 	ParentAgentSessionID   *runtimeids.SessionID

--- a/cli/app/internal/status/statuscollect_collect.go
+++ b/cli/app/internal/status/statuscollect_collect.go
@@ -10,6 +10,7 @@ import (
 	"core/server/runtime"
 	"core/shared/apicontract"
 	"core/shared/auth"
+	"core/shared/clientui"
 	"core/shared/config"
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
@@ -111,6 +112,14 @@ func (c Collector) CollectBase(req Request) Snapshot {
 }
 
 func (c Collector) EnrichBase(ctx context.Context, req Request, snapshot Snapshot) Snapshot {
+	if sessionID := strings.TrimSpace(snapshot.SessionID); sessionID != "" && req.SessionViews != nil {
+		currentSession, err := c.resolveSessionView(ctx, req.SessionViews, sessionID)
+		if err != nil {
+			snapshot.CollectorWarning = JoinWarnings(snapshot.CollectorWarning, "current session: "+err.Error())
+		} else {
+			snapshot.AgentRole = textutil.Pointer(currentSession.AgentRole)
+		}
+	}
 	if snapshot.PreviousSessionID != nil {
 		previousSessionName, err := c.ResolveSessionName(ctx, req.SessionViews, snapshot.PreviousSessionID.String())
 		if strings.TrimSpace(previousSessionName) != "" {
@@ -144,9 +153,17 @@ func JoinWarnings(existing string, warning string) string {
 }
 
 func (c Collector) ResolveSessionName(ctx context.Context, sessionViews apicontract.SessionViewService, sessionID string) (string, error) {
+	sessionView, err := c.resolveSessionView(ctx, sessionViews, sessionID)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(sessionView.SessionName), nil
+}
+
+func (c Collector) resolveSessionView(ctx context.Context, sessionViews apicontract.SessionViewService, sessionID string) (clientui.RuntimeSessionView, error) {
 	id := strings.TrimSpace(sessionID)
 	if sessionViews == nil || id == "" {
-		return "", nil
+		return clientui.RuntimeSessionView{}, nil
 	}
 	readTimeout := c.SessionNameReadTimeout
 	if readTimeout <= 0 {
@@ -159,9 +176,9 @@ func (c Collector) ResolveSessionName(ctx context.Context, sessionViews apicontr
 	defer cancel()
 	resp, err := sessionViews.GetSessionMainView(readCtx, serverapi.SessionMainViewRequest{SessionID: id})
 	if err != nil {
-		return "", err
+		return clientui.RuntimeSessionView{}, err
 	}
-	return strings.TrimSpace(resp.MainView.Session.SessionName), nil
+	return resp.MainView.Session, nil
 }
 
 func (c Collector) CollectAuth(ctx context.Context, req Request, _ Snapshot) AuthStageResult {

--- a/cli/app/internal/status/statuscollect_collect.go
+++ b/cli/app/internal/status/statuscollect_collect.go
@@ -13,6 +13,7 @@ import (
 	"core/shared/config"
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
+	"core/shared/textutil"
 )
 
 const DefaultUsageBaseURL = "https://chatgpt.com/backend-api"
@@ -91,6 +92,7 @@ func (c Collector) CollectBase(req Request) Snapshot {
 		Workdir:              filepath.ToSlash(strings.TrimSpace(workdir)),
 		SessionName:          strings.TrimSpace(req.SessionName),
 		SessionID:            strings.TrimSpace(req.SessionID),
+		AgentRole:            textutil.Pointer(req.AgentRole),
 		PreviousSessionID:    previousSessionID,
 		ParentAgentSessionID: parentAgentSessionID,
 		OwnsServer:           req.OwnsServer,

--- a/cli/app/internal/status/statuscollect_collector_test.go
+++ b/cli/app/internal/status/statuscollect_collector_test.go
@@ -3,13 +3,27 @@ package status
 import (
 	"context"
 	"core/server/auth"
+	"core/shared/apicontract"
+	"core/shared/clientui"
 	"core/shared/config"
+	"core/shared/serverapi"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+type statusSessionViewStub struct {
+	apicontract.SessionViewService
+	mainViewCalls int
+	view          clientui.RuntimeMainView
+}
+
+func (s *statusSessionViewStub) GetSessionMainView(_ context.Context, _ serverapi.SessionMainViewRequest) (serverapi.SessionMainViewResponse, error) {
+	s.mainViewCalls++
+	return serverapi.SessionMainViewResponse{MainView: s.view}, nil
+}
 
 func TestCollectEnvironmentDisabledSkillRemainsVisibleAndStillCollectsAgents(t *testing.T) {
 	workspace := t.TempDir()
@@ -198,6 +212,46 @@ func TestCollectBasePreservesOptionalAgentRole(t *testing.T) {
 			}
 			if snapshot.AgentRole == agentRole {
 				t.Fatal("snapshot agent role aliases request")
+			}
+		})
+	}
+}
+
+func TestEnrichBaseUsesCurrentSessionRoleAsAuthoritative(t *testing.T) {
+	cachedRole := "stale"
+	storedRole := "qa_tester"
+	for name, role := range map[string]*string{
+		"named agent":   &storedRole,
+		"default agent": nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			sessionViews := &statusSessionViewStub{
+				view: clientui.RuntimeMainView{
+					Session: clientui.RuntimeSessionView{SessionID: "session-1", AgentRole: role},
+				},
+			}
+			snapshot := (Collector{}).EnrichBase(context.Background(), Request{
+				SessionID:    "session-1",
+				SessionViews: sessionViews,
+			}, Snapshot{
+				SessionID: "session-1",
+				AgentRole: &cachedRole,
+			})
+
+			if sessionViews.mainViewCalls != 1 {
+				t.Fatalf("current session view calls = %d, want 1", sessionViews.mainViewCalls)
+			}
+			if role == nil {
+				if snapshot.AgentRole != nil {
+					t.Fatalf("snapshot agent role = %v, want nil", snapshot.AgentRole)
+				}
+				return
+			}
+			if snapshot.AgentRole == nil || *snapshot.AgentRole != *role {
+				t.Fatalf("snapshot agent role = %v, want %q", snapshot.AgentRole, *role)
+			}
+			if snapshot.AgentRole == role {
+				t.Fatal("snapshot agent role aliases current session view")
 			}
 		})
 	}

--- a/cli/app/internal/status/statuscollect_collector_test.go
+++ b/cli/app/internal/status/statuscollect_collector_test.go
@@ -178,3 +178,27 @@ func TestCollectorPreservesStoredAuthStateWhenRefreshFails(t *testing.T) {
 		t.Fatalf("collector warning = %q", snapshot.CollectorWarning)
 	}
 }
+
+func TestCollectBasePreservesOptionalAgentRole(t *testing.T) {
+	role := "worker"
+	for name, agentRole := range map[string]*string{
+		"named agent":   &role,
+		"default agent": nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			snapshot := (Collector{}).CollectBase(Request{AgentRole: agentRole})
+			if agentRole == nil {
+				if snapshot.AgentRole != nil {
+					t.Fatalf("snapshot agent role = %v, want nil", snapshot.AgentRole)
+				}
+				return
+			}
+			if snapshot.AgentRole == nil || *snapshot.AgentRole != *agentRole {
+				t.Fatalf("snapshot agent role = %v, want %q", snapshot.AgentRole, *agentRole)
+			}
+			if snapshot.AgentRole == agentRole {
+				t.Fatal("snapshot agent role aliases request")
+			}
+		})
+	}
+}

--- a/cli/app/ui_layout_rendering_status_overlay.go
+++ b/cli/app/ui_layout_rendering_status_overlay.go
@@ -115,6 +115,11 @@ func (l uiViewLayout) statusOverlayContentLines(width int) []string {
 	appendSectionTitle("Session")
 	appendWrapped("CWD: "+statusValueOrFallback(snapshot.Workdir, "<unknown>"), boldStyle)
 	appendANSI(l.renderStatusModelLine(width, snapshot.Model.Summary))
+	if snapshot.AgentRole != nil {
+		for _, line := range wrapANSIText("Agent role: "+boldStyle.Render(*snapshot.AgentRole), width) {
+			appendANSI(line)
+		}
+	}
 	for _, line := range statusOverlaySessionLines(snapshot) {
 		switch line.Style {
 		case statusOverlayLineStyleBold:

--- a/cli/app/ui_status.go
+++ b/cli/app/ui_status.go
@@ -10,6 +10,7 @@ import (
 	"core/shared/apicontract"
 	"core/shared/clientui"
 	"core/shared/config"
+	"core/shared/textutil"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -146,6 +147,7 @@ func (m *uiModel) newStatusRequest(now time.Time) uiStatusRequest {
 		AuthStatePath:         strings.TrimSpace(m.statusConfig.AuthStatePath),
 		SessionName:           strings.TrimSpace(m.sessionName),
 		SessionID:             strings.TrimSpace(m.sessionID),
+		AgentRole:             textutil.Pointer(m.cachedRuntimeMainView().Session.AgentRole),
 		ConfiguredModelName:   strings.TrimSpace(m.configuredModelName),
 		ModelName:             strings.TrimSpace(m.modelName),
 		ThinkingLevel:         strings.TrimSpace(m.thinkingLevel),

--- a/cli/app/ui_status_part2_test.go
+++ b/cli/app/ui_status_part2_test.go
@@ -13,6 +13,7 @@ import (
 	"core/server/sessionview"
 	"core/shared/clientui"
 	"core/shared/runtimeids"
+	"core/shared/serverapi"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -113,6 +114,44 @@ func TestStatusRequestCarriesCachedRuntimeAgentRole(t *testing.T) {
 	if request.AgentRole == nil || *request.AgentRole != role {
 		t.Fatalf("status request agent role = %v, want %q", request.AgentRole, role)
 	}
+}
+
+func TestStatusRefreshUsesCurrentSessionAgentRoleWhenRuntimeCacheIsCold(t *testing.T) {
+	role := "qa_tester"
+	sessionViews := stubSessionViewClient{
+		getSessionMainView: func(_ context.Context, request serverapi.SessionMainViewRequest) (serverapi.SessionMainViewResponse, error) {
+			if request.SessionID != "session-1" {
+				t.Fatalf("current session view request = %+v, want session-1", request)
+			}
+			return serverapi.SessionMainViewResponse{
+				MainView: clientui.RuntimeMainView{
+					Session: clientui.RuntimeSessionView{SessionID: "session-1", AgentRole: &role},
+				},
+			}, nil
+		},
+	}
+	runtimeClient := &sessionRuntimeClient{
+		sessionID: "session-1",
+		mainView:  clientui.RuntimeMainView{Session: clientui.RuntimeSessionView{SessionID: "session-1"}},
+	}
+	model := newProjectedTestUIModel(
+		runtimeClient,
+		WithUISessionID("session-1"),
+		WithUIStatusConfig(uiStatusConfig{WorkspaceRoot: t.TempDir(), SessionViews: sessionViews}),
+	)
+
+	messages := collectCmdMessages(t, model.statusRefreshCmd())
+	for _, message := range messages {
+		base, ok := message.(statusBaseRefreshDoneMsg)
+		if !ok {
+			continue
+		}
+		if base.snapshot.AgentRole == nil || *base.snapshot.AgentRole != role {
+			t.Fatalf("status agent role = %v, want %q", base.snapshot.AgentRole, role)
+		}
+		return
+	}
+	t.Fatal("status refresh did not emit a base snapshot")
 }
 
 func TestStatusSessionNameResolvesFromSessionViews(t *testing.T) {

--- a/cli/app/ui_status_part2_test.go
+++ b/cli/app/ui_status_part2_test.go
@@ -99,6 +99,22 @@ func TestTranscriptSessionIdentityUpdatesStatusExecutionTarget(t *testing.T) {
 	}
 }
 
+func TestStatusRequestCarriesCachedRuntimeAgentRole(t *testing.T) {
+	role := "worker"
+	runtimeClient := &runtimeControlFakeClient{
+		cachedMainView: clientui.RuntimeMainView{
+			Session: clientui.RuntimeSessionView{AgentRole: &role},
+		},
+		hasCachedMainView: true,
+	}
+	model := newProjectedTestUIModel(runtimeClient)
+
+	request := model.newStatusRequest(time.Now())
+	if request.AgentRole == nil || *request.AgentRole != role {
+		t.Fatalf("status request agent role = %v, want %q", request.AgentRole, role)
+	}
+}
+
 func TestStatusSessionNameResolvesFromSessionViews(t *testing.T) {
 	persistenceRoot := t.TempDir()
 	parentStore := createAuthoritativeAppSession(t, persistenceRoot, "/tmp/work-a")

--- a/server/runtime/engine_state.go
+++ b/server/runtime/engine_state.go
@@ -568,6 +568,13 @@ func (e *Engine) SessionID() string {
 	return strings.TrimSpace(e.store.Meta().SessionID)
 }
 
+func (e *Engine) ContinuationAgentRole() *string {
+	if e == nil || e.store == nil {
+		return nil
+	}
+	return session.ContinuationAgentRole(e.store.Meta())
+}
+
 func conversationPromptCacheKey(sessionID string, compactionCount int) string {
 	trimmed := strings.TrimSpace(sessionID)
 	if trimmed == "" {

--- a/server/runtimeview/projection.go
+++ b/server/runtimeview/projection.go
@@ -147,6 +147,7 @@ func SessionViewFromRuntime(engine *runtime.Engine) (clientui.RuntimeSessionView
 	return clientui.RuntimeSessionView{
 		SessionID:             engine.SessionID(),
 		SessionName:           engine.SessionName(),
+		AgentRole:             engine.ContinuationAgentRole(),
 		ConversationFreshness: ConversationFreshnessFromSession(freshness),
 	}, nil
 }

--- a/server/runtimeview/projection_test.go
+++ b/server/runtimeview/projection_test.go
@@ -170,6 +170,10 @@ func TestMainViewFromRuntimeBundlesStatusAndSession(t *testing.T) {
 	if err := store.SetName("Session Name"); err != nil {
 		t.Fatalf("set name: %v", err)
 	}
+	role := "worker"
+	if err := store.SetContinuationContext(session.ContinuationContext{AgentRole: &role}); err != nil {
+		t.Fatalf("set continuation context: %v", err)
+	}
 	eventLog, err := store.MaterializeEventLog()
 	if err != nil {
 		t.Fatalf("materialize event log: %v", err)
@@ -204,6 +208,9 @@ func TestMainViewFromRuntimeBundlesStatusAndSession(t *testing.T) {
 	if view.Session.SessionID != store.Meta().SessionID || view.Session.SessionName != "Session Name" {
 		t.Fatalf("unexpected session hydration: %+v", view.Session)
 	}
+	if view.Session.AgentRole == nil || *view.Session.AgentRole != role {
+		t.Fatalf("session agent role = %v, want %q", view.Session.AgentRole, role)
+	}
 	if view.Status.ParentAgentSessionID == nil || view.Status.ParentAgentSessionID.String() != parentSessionID ||
 		view.Status.NavigationTargetSessionID == nil || view.Status.NavigationTargetSessionID.String() != parentSessionID ||
 		view.Status.LastCommittedAssistantFinalAnswer != "final answer" {
@@ -217,6 +224,18 @@ func TestMainViewFromRuntimeBundlesStatusAndSession(t *testing.T) {
 	}
 	if view.Activity.ActiveForControl() {
 		t.Fatalf("expected idle activity in idle main view, got %+v", view.Activity)
+	}
+}
+
+func TestSessionViewFromRuntimeOmitsDefaultAgentRole(t *testing.T) {
+	eng := newRuntimeViewEngine(t, newRuntimeViewStore(t), projectionFastClient{})
+
+	view, err := SessionViewFromRuntime(eng)
+	if err != nil {
+		t.Fatalf("project runtime session: %v", err)
+	}
+	if view.AgentRole != nil {
+		t.Fatalf("session agent role = %v, want nil for default agent", view.AgentRole)
 	}
 }
 

--- a/server/session/continuation.go
+++ b/server/session/continuation.go
@@ -6,17 +6,17 @@ import (
 	"strings"
 
 	"core/shared/config"
+	"core/shared/textutil"
 )
 
 var ErrInvalidContinuationAgentRole = errors.New("invalid continuation agent role")
 
 // ContinuationAgentRole returns the persisted named role, if one was selected.
 func ContinuationAgentRole(meta Meta) *string {
-	if meta.Continuation == nil || meta.Continuation.AgentRole == nil {
+	if meta.Continuation == nil {
 		return nil
 	}
-	role := *meta.Continuation.AgentRole
-	return &role
+	return textutil.Pointer(meta.Continuation.AgentRole)
 }
 
 // NormalizeContinuationContext validates persisted continuation metadata at

--- a/server/session/continuation.go
+++ b/server/session/continuation.go
@@ -10,6 +10,15 @@ import (
 
 var ErrInvalidContinuationAgentRole = errors.New("invalid continuation agent role")
 
+// ContinuationAgentRole returns the persisted named role, if one was selected.
+func ContinuationAgentRole(meta Meta) *string {
+	if meta.Continuation == nil || meta.Continuation.AgentRole == nil {
+		return nil
+	}
+	role := *meta.Continuation.AgentRole
+	return &role
+}
+
 // NormalizeContinuationContext validates persisted continuation metadata at
 // every persistence boundary. An omitted or JSON-null role is the sole
 // default-agent encoding.

--- a/server/sessionview/service_test.go
+++ b/server/sessionview/service_test.go
@@ -123,6 +123,10 @@ func TestServiceGetSessionMainViewFallsBackToDurableSessionState(t *testing.T) {
 	if err := store.SetName("incident triage"); err != nil {
 		t.Fatalf("set name: %v", err)
 	}
+	role := "worker"
+	if err := store.SetContinuationContext(session.ContinuationContext{AgentRole: &role}); err != nil {
+		t.Fatalf("set continuation context: %v", err)
+	}
 	if _, err := store.SetGoal("ship dormant goal", session.GoalActorUser); err != nil {
 		t.Fatalf("set goal: %v", err)
 	}
@@ -135,6 +139,9 @@ func TestServiceGetSessionMainViewFallsBackToDurableSessionState(t *testing.T) {
 	}
 	if resp.MainView.Session.SessionID != store.Meta().SessionID || resp.MainView.Session.SessionName != "incident triage" {
 		t.Fatalf("unexpected dormant session view: %+v", resp.MainView.Session)
+	}
+	if resp.MainView.Session.AgentRole == nil || *resp.MainView.Session.AgentRole != role {
+		t.Fatalf("dormant session agent role = %v, want %q", resp.MainView.Session.AgentRole, role)
 	}
 	if resp.MainView.Status.ParentAgentSessionID == nil || resp.MainView.Status.ParentAgentSessionID.String() != parentSessionID ||
 		resp.MainView.Status.NavigationTargetSessionID == nil || resp.MainView.Status.NavigationTargetSessionID.String() != parentSessionID ||

--- a/server/sessionview/snapshot.go
+++ b/server/sessionview/snapshot.go
@@ -238,6 +238,7 @@ func (s dormantSessionSnapshot) MainView(ctx context.Context) (clientui.RuntimeM
 		clientui.RuntimeSessionView{
 			SessionID:             meta.SessionID,
 			SessionName:           meta.Name,
+			AgentRole:             session.ContinuationAgentRole(meta),
 			ConversationFreshness: freshness,
 		},
 	)

--- a/shared/clientui/runtime.go
+++ b/shared/clientui/runtime.go
@@ -166,6 +166,7 @@ func SessionExecutionTargetsEqual(a SessionExecutionTarget, b SessionExecutionTa
 type RuntimeSessionView struct {
 	SessionID             string
 	SessionName           string
+	AgentRole             *string
 	ConversationFreshness ConversationFreshness
 	ExecutionTarget       SessionExecutionTarget
 }


### PR DESCRIPTION
## Summary
- Adds the persisted optional session agent role to the runtime session read model for live and dormant sessions.
- Displays `Agent role: <role>` immediately below Model in `/status`, with only the role value bold and ANSI-aware wrapping.
- Refreshes the current session view during `/status` base enrichment so reopened and cold TUI clients show the durable role rather than depending on an empty local runtime cache.
- Reuses `textutil.Pointer` from the session-domain accessor to avoid a duplicate pointer-cloning implementation.

## Verification
- Focused changed-package suite passed for `server/runtimeview`, `server/sessionview`, `cli/app`, and `cli/app/internal/status`, including cold-cache named-role and default-role cases.
- `./scripts/build.sh --output ./bin/kent` passed.

## QA evidence
Prior isolated QA proof directories:
- `.kent/qa/proofs/20260722T110656Z-named-role-status-rerun`
- `.kent/qa/proofs/20260722T110720Z-named-role-after-model-rerun`
- `.kent/qa/proofs/20260722T110734Z-named-role-narrow-rerun`
- `.kent/qa/proofs/20260722T110747Z-default-role-status-rerun`
- `.kent/qa/proofs/20260722T110756Z-default-role-after-model-rerun`

## Diff
- Production code: +50 / -3, net +47, gross 53 lines.
- Tests/generated code: +159 / -0, net +159, gross 159 lines.

## Caveats and follow-up
- `/status` now performs one authoritative current-session view read during asynchronous base enrichment. This keeps role display correct after reopening while preserving the server as the source of truth.
- The pre-existing `./scripts/test.sh tui server` 120-second wall-clock cap failure in the unrelated `server/runtime` suite was explicitly deferred to a separate task; focused changed-package tests pass.
- Suggested follow-up: address the runtime-suite wall-clock cap independently.

## Tracking
- Kent task: `KENT-324`
- GitHub issue: none provided.