### PR TITLE
Switch desktop CI builds to macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
         run: pnpm build
 
   gui-native:
-    runs-on: macos-15
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.0
@@ -341,10 +341,10 @@ jobs:
       - name: Install GUI dependencies
         run: pnpm --dir apps install --frozen-lockfile
 
-      - name: Build macOS 15 desktop bundle
+      - name: Build macOS desktop bundle
         run: bash scripts/build-desktop.sh --skip-install -- --bundles dmg
 
-      - name: Smoke test macOS 15 desktop bundle
+      - name: Smoke test macOS desktop bundle
         run: |
           shopt -s nullglob
           dmgs=(apps/desktop/src-tauri/target/release/bundle/dmg/*.dmg)
@@ -381,10 +381,10 @@ jobs:
           kill -TERM "$app_pid"
           wait "$app_pid" || true
 
-      - name: Upload macOS 15 desktop bundle
+      - name: Upload macOS desktop bundle
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: desktop-bundle-macos-15-arm64
+          name: desktop-bundle-macos-arm64
           path: apps/desktop/src-tauri/target/release/bundle/dmg/*.dmg
           if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,11 +283,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # macos-26 is Apple Silicon (arm64) with Xcode 26 — needed for the
-          # liquid-glass icon actool compile and aarch64-apple-darwin target.
-          # Pinned (not macos-latest) while GitHub migrates the latest label to
-          # macOS 26. Revisit ~2026-07-22: respawn-llc/kent#407.
-          - runs_on: macos-26
+          - runs_on: macos-latest
             platform: macos
           - runs_on: ubuntu-22.04
             platform: linux

--- a/docs/dev/specs/release-distribution.md
+++ b/docs/dev/specs/release-distribution.md
@@ -66,9 +66,10 @@
 - `desktop-checksums.txt` carries sha256s for the distributable bundles.
 - macOS bundles are Developer ID signed in CI (`APPLE_CERTIFICATE`); notarization is
   off for v1 (Apple-side blocked), so v1 ships signed + un-notarized. The macOS
-  build runner is pinned `macos-26` for the liquid-glass icon toolchain. Minimum
-  deployment target is macOS 15 (Sequoia); Liquid Glass UI falls back to
-  `NSVisualEffectView` on pre-26 macOS.
+  build uses GitHub's `macos-latest` Arm64 runner and its default Xcode; when Icon
+  Composer is unavailable, the bundle uses the PNG-derived icon. Minimum deployment
+  target is macOS 15 (Sequoia); Liquid Glass UI falls back to `NSVisualEffectView`
+  on pre-26 macOS.
 
 ## Desktop App Updates
 


### PR DESCRIPTION
## Summary
- Move the release `build_desktop` macOS matrix member to `macos-latest` and remove the temporary migration comment.
- Move the PR `gui-native` DMG build and smoke-test job to `macos-latest`, with version-independent step labels and artifact name.
- Align the release-distribution specification with the default-Xcode and Icon Composer fallback policy.

## Verification
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml` — passed.
- `git diff --check HEAD^ HEAD` — passed.
- GitHub Actions CI run `29933153696` completed `gui-native` successfully on the PR: the build, DMG smoke test, and artifact upload all passed, and the build log reports `Compiled liquid-glass app icon -> apps/desktop/src-tauri/icons/Assets.car`.
- The user had waived creating a dedicated hosted verification run on July 22, 2026; the merge PR CI nevertheless supplied this hosted evidence.

## Diff statistics
| Category | Added | Deleted | Net | Gross |
| --- | ---: | ---: | ---: | ---: |
| Production configuration and documentation (no source-code changes) | 10 | 13 | -3 | 23 |
| Tests/generated code | 0 | 0 | 0 | 0 |

## Caveats and follow-up
- `macos-latest` intentionally follows GitHub’s current GA macOS image rather than pinning a release image.
- The retained `LSMinimumSystemVersion == 15.0` assertion verifies deployment metadata, but PR CI no longer launches the app on a macOS 15 host.
- No Xcode-selection action was added: `scripts/build-desktop.sh` remains authoritative for Icon Composer detection and PNG-icon fallback.
- The PR’s `lint`, `gui`, and `test` checks are red due to pre-existing failures reproduced unchanged by the current `main` CI run `29932288640` at base commit `5e8327af530b6a5ef28d18d7e8a759b24e988d9f`; this PR changes none of the affected source files. The owning work should repair those main-branch regressions, then this branch can rebase.

Closes #407.

Kent task: BUI-165.