### PR TITLE
Prevent short write_stdin polling

### DIFF
--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -62,6 +62,9 @@
 - Execution inherits parent environment and adds non-interactive hints and other technical environment variables.
 - stdout/stderr merge into one stream without origin tags.
 - Command lifetime is unlimited. `yield_time_ms` controls when Kent returns control and backgrounds the process.
+- Model-originated output checks may return currently available output immediately when no wait is requested.
+- A model-originated output check that requests a wait shorter than 15 seconds fails with `Avoid polling repeatedly for short intervals, prefer 3-15min polls depending on task. Pick a better interval and retry`.
+- Sending input is not subject to the minimum output-check wait.
 - Non-zero exit is recoverable and does not auto-abort the turn.
 - Shell process-launch failures are not automatically retried.
 - Interrupt escalation is `SIGINT` then `SIGKILL` after 10 seconds.

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -64,7 +64,8 @@
 - Command lifetime is unlimited. `yield_time_ms` controls when Kent returns control and backgrounds the process.
 - Model-originated output checks may return currently available output immediately when no wait is requested.
 - A model-originated output check that requests a wait shorter than 15 seconds fails with `Avoid polling repeatedly for short intervals, prefer 3-15min polls depending on task. Pick a better interval and retry`.
-- Sending input is not subject to the minimum output-check wait.
+- A model-originated output check that requests a wait longer than 24 hours fails with ``This poll is too long. Consider using system cron jobs and `kent run` headless runs for tasks that require such long wait periods``.
+- Sending input is not subject to output-check wait limits.
 - Non-zero exit is recoverable and does not auto-abort the turn.
 - Shell process-launch failures are not automatically retried.
 - Interrupt escalation is `SIGINT` then `SIGKILL` after 10 seconds.

--- a/server/llm/openai_http_stream.go
+++ b/server/llm/openai_http_stream.go
@@ -741,7 +741,7 @@ func (a *toolCallAccumulator) UpsertFromOutput(item responses.ResponseOutputItem
 func (a *toolCallAccumulator) AppendArguments(itemID, delta string) {
 	key := textutil.FirstNonEmpty(strings.TrimSpace(a.itemToKey[itemID]), strings.TrimSpace(itemID))
 	state := a.ensure(key)
-	if state == nil || strings.TrimSpace(delta) == "" {
+	if state == nil || delta == "" {
 		return
 	}
 	state.Args.WriteString(delta)

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -346,6 +346,37 @@ func TestGenerateStream_EmitsAssistantDeltasAndToolCalls(t *testing.T) {
 }
 
 func TestGenerateStream_PreservesWhitespaceOnlyFunctionArgumentDelta(t *testing.T) {
+	const inputPrefix = `{"session_id":1000,"chars":"`
+	const inputSuffix = `","yield_time_ms":9223372036854775807}`
+	transport := newOpenAIStreamTestTransport(t,
+		`{"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","name":"write_stdin","call_id":"call_1","arguments":""}}`,
+		fmt.Sprintf(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":%q}`, inputPrefix),
+		fmt.Sprintf(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":%q}`, " "),
+		fmt.Sprintf(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":%q}`, inputSuffix),
+		`{"type":"response.completed","response":{"output":[]}}`,
+		`[DONE]`,
+	)
+
+	resp, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{ToolChoiceMode: ToolChoiceModeAutomatic, Model: "gpt-5"}, StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("GenerateStream failed: %v", err)
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("expected one tool call, got %+v", resp.ToolCalls)
+	}
+	var decodedInput struct {
+		Chars       string `json:"chars"`
+		YieldTimeMS int    `json:"yield_time_ms"`
+	}
+	if err := json.Unmarshal(resp.ToolCalls[0].Input, &decodedInput); err != nil {
+		t.Fatalf("decode streamed write_stdin input %q: %v", resp.ToolCalls[0].Input, err)
+	}
+	if decodedInput.Chars != " " || decodedInput.YieldTimeMS != math.MaxInt {
+		t.Fatalf("streamed write_stdin input = %+v", decodedInput)
+	}
+}
+
+func TestGenerateStream_PreservesNewlineInputAcrossCompletedSnapshots(t *testing.T) {
 	const input = `{"session_id":1000,"chars":"\n","yield_time_ms":9223372036854775807}`
 	transport := newOpenAIStreamTestTransport(t,
 		`{"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","name":"write_stdin","call_id":"call_1","arguments":""}}`,

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -376,36 +376,6 @@ func TestGenerateStream_PreservesWhitespaceOnlyFunctionArgumentDelta(t *testing.
 	}
 }
 
-func TestGenerateStream_PreservesNewlineInputAcrossCompletedSnapshots(t *testing.T) {
-	const input = `{"session_id":1000,"chars":"\n","yield_time_ms":9223372036854775807}`
-	transport := newOpenAIStreamTestTransport(t,
-		`{"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","name":"write_stdin","call_id":"call_1","arguments":""}}`,
-		fmt.Sprintf(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":%q}`, input),
-		fmt.Sprintf(`{"type":"response.function_call_arguments.done","item_id":"fc_1","arguments":%q}`, input),
-		fmt.Sprintf(`{"type":"response.output_item.done","item":{"id":"fc_1","type":"function_call","name":"write_stdin","call_id":"call_1","arguments":%q}}`, input),
-		fmt.Sprintf(`{"type":"response.completed","response":{"output":[{"id":"fc_1","type":"function_call","name":"write_stdin","call_id":"call_1","arguments":%q}]}}`, input),
-		`[DONE]`,
-	)
-
-	resp, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{ToolChoiceMode: ToolChoiceModeAutomatic, Model: "gpt-5"}, StreamCallbacks{})
-	if err != nil {
-		t.Fatalf("GenerateStream failed: %v", err)
-	}
-	if len(resp.ToolCalls) != 1 {
-		t.Fatalf("expected one tool call, got %+v", resp.ToolCalls)
-	}
-	var decodedInput struct {
-		Chars       string `json:"chars"`
-		YieldTimeMS int    `json:"yield_time_ms"`
-	}
-	if err := json.Unmarshal(resp.ToolCalls[0].Input, &decodedInput); err != nil {
-		t.Fatalf("decode streamed write_stdin input %q: %v", resp.ToolCalls[0].Input, err)
-	}
-	if decodedInput.Chars != "\n" || decodedInput.YieldTimeMS != math.MaxInt {
-		t.Fatalf("streamed write_stdin input = %+v", decodedInput)
-	}
-}
-
 func TestGenerateStream_EmitsUnknownPhaseWhenDeltaPrecedesAssistantItem(t *testing.T) {
 	transport := newOpenAIStreamTestTransport(t,
 		`{"type":"response.output_text.delta","output_index":0,"delta":"Hel"}`,

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -346,14 +346,13 @@ func TestGenerateStream_EmitsAssistantDeltasAndToolCalls(t *testing.T) {
 }
 
 func TestGenerateStream_PreservesWhitespaceOnlyFunctionArgumentDelta(t *testing.T) {
-	const inputPrefix = `{"session_id":1000,"chars":"`
-	const inputSuffix = `","yield_time_ms":9223372036854775807}`
+	const input = `{"session_id":1000,"chars":"\n","yield_time_ms":9223372036854775807}`
 	transport := newOpenAIStreamTestTransport(t,
 		`{"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","name":"write_stdin","call_id":"call_1","arguments":""}}`,
-		fmt.Sprintf(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":%q}`, inputPrefix),
-		fmt.Sprintf(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":%q}`, " "),
-		fmt.Sprintf(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":%q}`, inputSuffix),
-		`{"type":"response.completed","response":{"output":[]}}`,
+		fmt.Sprintf(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":%q}`, input),
+		fmt.Sprintf(`{"type":"response.function_call_arguments.done","item_id":"fc_1","arguments":%q}`, input),
+		fmt.Sprintf(`{"type":"response.output_item.done","item":{"id":"fc_1","type":"function_call","name":"write_stdin","call_id":"call_1","arguments":%q}}`, input),
+		fmt.Sprintf(`{"type":"response.completed","response":{"output":[{"id":"fc_1","type":"function_call","name":"write_stdin","call_id":"call_1","arguments":%q}]}}`, input),
 		`[DONE]`,
 	)
 
@@ -364,15 +363,15 @@ func TestGenerateStream_PreservesWhitespaceOnlyFunctionArgumentDelta(t *testing.
 	if len(resp.ToolCalls) != 1 {
 		t.Fatalf("expected one tool call, got %+v", resp.ToolCalls)
 	}
-	var input struct {
+	var decodedInput struct {
 		Chars       string `json:"chars"`
 		YieldTimeMS int    `json:"yield_time_ms"`
 	}
-	if err := json.Unmarshal(resp.ToolCalls[0].Input, &input); err != nil {
+	if err := json.Unmarshal(resp.ToolCalls[0].Input, &decodedInput); err != nil {
 		t.Fatalf("decode streamed write_stdin input %q: %v", resp.ToolCalls[0].Input, err)
 	}
-	if input.Chars != " " || input.YieldTimeMS != math.MaxInt {
-		t.Fatalf("streamed write_stdin input = %+v", input)
+	if decodedInput.Chars != "\n" || decodedInput.YieldTimeMS != math.MaxInt {
+		t.Fatalf("streamed write_stdin input = %+v", decodedInput)
 	}
 }
 

--- a/server/llm/openai_http_stream_test.go
+++ b/server/llm/openai_http_stream_test.go
@@ -2,14 +2,17 @@ package llm
 
 import (
 	"context"
-	"core/shared/textutil"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"core/shared/textutil"
 )
 
 type staticAuthHeader struct{}
@@ -339,6 +342,37 @@ func TestGenerateStream_EmitsAssistantDeltasAndToolCalls(t *testing.T) {
 	}
 	if len(reasoning) != 1 || reasoning[0].Key == "" || reasoning[0].Role != "reasoning" || reasoning[0].Text != "Plan" {
 		t.Fatalf("unexpected reasoning delta callbacks: %+v", reasoning)
+	}
+}
+
+func TestGenerateStream_PreservesWhitespaceOnlyFunctionArgumentDelta(t *testing.T) {
+	const inputPrefix = `{"session_id":1000,"chars":"`
+	const inputSuffix = `","yield_time_ms":9223372036854775807}`
+	transport := newOpenAIStreamTestTransport(t,
+		`{"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","name":"write_stdin","call_id":"call_1","arguments":""}}`,
+		fmt.Sprintf(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":%q}`, inputPrefix),
+		fmt.Sprintf(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":%q}`, " "),
+		fmt.Sprintf(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":%q}`, inputSuffix),
+		`{"type":"response.completed","response":{"output":[]}}`,
+		`[DONE]`,
+	)
+
+	resp, err := transport.GenerateStreamWithEvents(context.Background(), OpenAIRequest{ToolChoiceMode: ToolChoiceModeAutomatic, Model: "gpt-5"}, StreamCallbacks{})
+	if err != nil {
+		t.Fatalf("GenerateStream failed: %v", err)
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("expected one tool call, got %+v", resp.ToolCalls)
+	}
+	var input struct {
+		Chars       string `json:"chars"`
+		YieldTimeMS int    `json:"yield_time_ms"`
+	}
+	if err := json.Unmarshal(resp.ToolCalls[0].Input, &input); err != nil {
+		t.Fatalf("decode streamed write_stdin input %q: %v", resp.ToolCalls[0].Input, err)
+	}
+	if input.Chars != " " || input.YieldTimeMS != math.MaxInt {
+		t.Fatalf("streamed write_stdin input = %+v", input)
 	}
 }
 

--- a/server/runtime/engine_part8_test.go
+++ b/server/runtime/engine_part8_test.go
@@ -172,7 +172,7 @@ func TestWriteStdinCompletionDoesNotQueueDuplicateBackgroundNotice(t *testing.T)
 			ToolCalls: []llm.ToolCall{{
 				ID:    "call_poll_1",
 				Name:  string(toolspec.ToolWriteStdin),
-				Input: json.RawMessage(`{"session_id":1000,"yield_time_ms":800}`),
+				Input: json.RawMessage(`{"session_id":1000,"yield_time_ms":15000}`),
 			}},
 			Usage: llm.Usage{WindowTokens: 200000},
 		},

--- a/server/tools/shell/process_policy_capture_test.go
+++ b/server/tools/shell/process_policy_capture_test.go
@@ -166,7 +166,7 @@ func TestBackgroundProcessKeepsCapturedHookAcrossLaterStartsPollingAndCompletion
 
 	pollA := callWriteStdin(t, pollTool, "a-poll", map[string]any{
 		"session_id":    processA,
-		"yield_time_ms": 1_000,
+		"yield_time_ms": 15_000,
 	})
 	if pollA.IsError {
 		t.Fatalf("runtime A polling error: %s", string(pollA.Output))
@@ -253,7 +253,7 @@ func TestRawBypassesCapturedPolicyInForegroundBackgroundAndPolling(t *testing.T)
 	}
 	poll := callWriteStdin(t, pollTool, "raw-poll", map[string]any{
 		"session_id":    processID,
-		"yield_time_ms": 1_000,
+		"yield_time_ms": 15_000,
 	})
 	if poll.IsError {
 		t.Fatalf("raw polling error: %s", string(poll.Output))
@@ -313,8 +313,7 @@ func TestSharedManagerKeepsGlobalLifecycleAcrossCapturedPolicies(t *testing.T) {
 	}
 
 	pollA := callWriteStdin(t, pollTool, "cross-runtime-poll", map[string]any{
-		"session_id":    idByOwner["owner-a"],
-		"yield_time_ms": 250,
+		"session_id": idByOwner["owner-a"],
 	})
 	if pollA.IsError {
 		t.Fatalf("cross-runtime polling error: %s", string(pollA.Output))

--- a/server/tools/shell/tool_part2_test.go
+++ b/server/tools/shell/tool_part2_test.go
@@ -41,7 +41,7 @@ func runCompletionNoticeTest(t *testing.T, execID string, command string, pollID
 }
 
 func TestWriteStdinCompletionSuppressesBackgroundNoticeEvent(t *testing.T) {
-	manager, events := runCompletionNoticeTest(t, "bg-1", "sleep 0.15; echo done", "bg-2", 800)
+	manager, events := runCompletionNoticeTest(t, "bg-1", "sleep 0.15; echo done", "bg-2", 15_000)
 
 	select {
 	case evt := <-events:
@@ -60,7 +60,7 @@ func TestWriteStdinSuppressesFallbackCompletionNoticeEvent(t *testing.T) {
 		"bg-large-1",
 		"sleep 0.15; dd if=/dev/zero bs=1048576 count=3 2>/dev/null | tr '\\000' x",
 		"bg-large-2",
-		1_500,
+		15_000,
 	)
 
 	select {

--- a/server/tools/shell/tool_sanitization_test.go
+++ b/server/tools/shell/tool_sanitization_test.go
@@ -137,7 +137,7 @@ func TestRawBackgroundOutputPathsPreserveAnsi(t *testing.T) {
 
 	pollResult := callWriteStdin(t, stdinTool, "raw-bg-poll", map[string]any{
 		"session_id":    1000,
-		"yield_time_ms": 800,
+		"yield_time_ms": 15_000,
 	})
 	if pollResult.IsError {
 		t.Fatalf("unexpected write_stdin error: %s", string(pollResult.Output))

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -476,7 +476,7 @@ func TestWriteStdinPollingPreservesTerminalLifecycleForAllCompletionShapes(t *te
 
 			poll := callWriteStdin(t, pollTool, "poll-complete", map[string]any{
 				"session_id":    sessionID,
-				"yield_time_ms": 800,
+				"yield_time_ms": 15_000,
 			})
 			if poll.IsError {
 				t.Fatalf("unexpected write_stdin error: %s", string(poll.Output))
@@ -500,6 +500,56 @@ func TestWriteStdinPollingPreservesTerminalLifecycleForAllCompletionShapes(t *te
 			waitForManagerCount(t, manager, 0, time.Second)
 		})
 	}
+}
+
+func TestWriteStdinRejectsShortTimedOutputPolls(t *testing.T) {
+	workspace := t.TempDir()
+	manager := newShellTestManager(t, 50*time.Millisecond)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+	pollTool := NewWriteStdinTool(16_000, manager)
+
+	start := callExecCommand(t, execTool, "short-poll-start", map[string]any{
+		"cmd":           "sleep 0.15",
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 50,
+	})
+	if start.IsError {
+		t.Fatalf("unexpected exec_command error: %s", string(start.Output))
+	}
+
+	for _, yieldTimeMS := range []int{14_999, 0, -1} {
+		rejected := callWriteStdin(t, pollTool, "short-poll-rejected", map[string]any{
+			"session_id":    1000,
+			"yield_time_ms": yieldTimeMS,
+		})
+		if !rejected.IsError {
+			t.Fatalf("expected %dms timed output poll to fail, got %+v", yieldTimeMS, rejected)
+		}
+		var envelope struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(rejected.Output, &envelope); err != nil {
+			t.Fatalf("decode rejected write_stdin output: %v", err)
+		}
+		if envelope.Error == "" {
+			t.Fatal("expected rejected write_stdin error value")
+		}
+		if rejected.Summary == "" {
+			t.Fatal("expected rejected write_stdin summary")
+		}
+		if rejected.Summary != envelope.Error {
+			t.Fatalf("rejected summary = %q, want error value %q", rejected.Summary, envelope.Error)
+		}
+	}
+
+	accepted := callWriteStdin(t, pollTool, "short-poll-accepted", map[string]any{
+		"session_id": 1000,
+	})
+	if accepted.IsError {
+		t.Fatalf("expected process to remain usable after rejection: %s", string(accepted.Output))
+	}
+	waitForManagerCount(t, manager, 0, time.Second)
 }
 
 func TestWriteStdinCancellationReportsActiveProcess(t *testing.T) {
@@ -532,7 +582,7 @@ func TestWriteStdinCancellationReportsActiveProcess(t *testing.T) {
 		}
 		pollInput, _ := json.Marshal(map[string]any{
 			"session_id":    sessionID,
-			"yield_time_ms": 5_000,
+			"yield_time_ms": 15_000,
 		})
 		pollResult, err := pollTool.Call(ctx, tools.Call{ID: "cancel-poll", Name: toolspec.ToolWriteStdin, Input: pollInput})
 		if err != nil {
@@ -654,8 +704,7 @@ func TestWriteStdinWarnsAndRetriesWhenFullLogReadFails(t *testing.T) {
 	}
 
 	pollInput := map[string]any{
-		"session_id":    sessionID,
-		"yield_time_ms": 20,
+		"session_id": sessionID,
 	}
 	first := callWriteStdin(t, pollTool, "log-missing-1", pollInput)
 	if first.IsError {
@@ -735,9 +784,10 @@ func TestWriteStdinPollHonorsRequestedDuration(t *testing.T) {
 	pollTool := NewWriteStdinTool(16_000, manager)
 
 	result := callExecCommand(t, execTool, "poll-duration-exec", map[string]any{
-		"cmd":           "sleep 0.6",
+		"cmd":           "read line; sleep 0.6",
 		"shell":         "/bin/sh",
 		"login":         false,
+		"tty":           true,
 		"yield_time_ms": 50,
 	})
 	if result.IsError {
@@ -746,6 +796,7 @@ func TestWriteStdinPollHonorsRequestedDuration(t *testing.T) {
 
 	pollInput := map[string]any{
 		"session_id":        1000,
+		"chars":             "\n",
 		"yield_time_ms":     300,
 		"max_output_tokens": 32,
 	}

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -839,6 +840,59 @@ func TestWriteStdinPollHonorsRequestedDuration(t *testing.T) {
 		t.Fatalf("expected session to remain backgrounded, got %+v", payload)
 	}
 	waitForManagerCount(t, manager, 0, 2*time.Second)
+}
+
+func TestWriteStdinWhitespaceInputRemainsInputAtLongWaits(t *testing.T) {
+	tests := []struct {
+		name        string
+		yieldTimeMS int
+	}{
+		{name: "above output poll maximum", yieldTimeMS: 86_400_001},
+		{name: "maximum integer", yieldTimeMS: math.MaxInt},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			manager := newShellTestManager(t, 50*time.Millisecond)
+			execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+			stdinTool := NewWriteStdinTool(16_000, manager)
+
+			start := callExecCommand(t, execTool, "whitespace-input-start", map[string]any{
+				"cmd":           "read line; sleep 0.6",
+				"shell":         "/bin/sh",
+				"login":         false,
+				"tty":           true,
+				"yield_time_ms": 50,
+			})
+			if start.IsError {
+				t.Fatalf("unexpected exec_command error: %s", string(start.Output))
+			}
+
+			started := time.Now()
+			result := callWriteStdin(t, stdinTool, "whitespace-input", map[string]any{
+				"session_id":    1000,
+				"chars":         "\n",
+				"yield_time_ms": tt.yieldTimeMS,
+			})
+			elapsed := time.Since(started)
+			if result.IsError {
+				t.Fatalf("unexpected write_stdin error: %s", string(result.Output))
+			}
+			if elapsed < 500*time.Millisecond {
+				t.Fatalf("write_stdin returned before post-input delay: %s", elapsed)
+			}
+			if elapsed > 2*time.Second {
+				t.Fatalf("write_stdin took too long: %s", elapsed)
+			}
+			output := decodeWriteStdinToolOutput(t, result)
+			if output.BackgroundRunning || !output.Backgrounded ||
+				output.BackgroundExitCode == nil || *output.BackgroundExitCode != 0 {
+				t.Fatalf("completed whitespace input output = %+v", output)
+			}
+			waitForManagerCount(t, manager, 0, time.Second)
+		})
+	}
 }
 
 func TestExecCommandForegroundTruncationSetsPresentationMetadata(t *testing.T) {

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -440,11 +439,13 @@ func TestWriteStdinPollingPreservesTerminalLifecycleForAllCompletionShapes(t *te
 		name         string
 		command      string
 		wantExitCode int
+		yieldTimeMS  int
 	}{
-		{name: "zero silent", command: "sleep 0.15", wantExitCode: 0},
-		{name: "zero with output", command: "sleep 0.15; printf visible", wantExitCode: 0},
-		{name: "non-zero silent", command: "sleep 0.15; exit 7", wantExitCode: 7},
-		{name: "non-zero with output", command: "sleep 0.15; printf visible; exit 7", wantExitCode: 7},
+		{name: "zero silent", command: "sleep 0.15", wantExitCode: 0, yieldTimeMS: 15_000},
+		{name: "zero with output", command: "sleep 0.15; printf visible", wantExitCode: 0, yieldTimeMS: 15_000},
+		{name: "non-zero silent", command: "sleep 0.15; exit 7", wantExitCode: 7, yieldTimeMS: 15_000},
+		{name: "non-zero with output", command: "sleep 0.15; printf visible; exit 7", wantExitCode: 7, yieldTimeMS: 15_000},
+		{name: "maximum output poll wait", command: "sleep 0.15", wantExitCode: 0, yieldTimeMS: 86_400_000},
 	}
 
 	for _, tt := range tests {
@@ -477,7 +478,7 @@ func TestWriteStdinPollingPreservesTerminalLifecycleForAllCompletionShapes(t *te
 
 			poll := callWriteStdin(t, pollTool, "poll-complete", map[string]any{
 				"session_id":    sessionID,
-				"yield_time_ms": 15_000,
+				"yield_time_ms": tt.yieldTimeMS,
 			})
 			if poll.IsError {
 				t.Fatalf("unexpected write_stdin error: %s", string(poll.Output))
@@ -527,8 +528,7 @@ func TestWriteStdinRejectsShortTimedOutputPolls(t *testing.T) {
 		{name: "below minimum", yieldTimeMS: 14_999},
 		{name: "zero", yieldTimeMS: 0},
 		{name: "negative", yieldTimeMS: -1},
-		{name: "unrepresentable output poll", yieldTimeMS: math.MaxInt},
-		{name: "unrepresentable input", yieldTimeMS: math.MaxInt, chars: "x"},
+		{name: "above maximum", yieldTimeMS: 86_400_001},
 	} {
 		input := map[string]any{
 			"session_id":    1000,
@@ -939,7 +939,7 @@ func TestWriteStdinSendsInputToInteractiveProcess(t *testing.T) {
 	stdinResult := callWriteStdin(t, stdinTool, "tty-2", map[string]any{
 		"session_id":    1000,
 		"chars":         "hello app\n",
-		"yield_time_ms": 800,
+		"yield_time_ms": 86_400_001,
 	})
 	if stdinResult.IsError {
 		t.Fatalf("unexpected write_stdin error: %s", string(stdinResult.Output))

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -518,13 +519,27 @@ func TestWriteStdinRejectsShortTimedOutputPolls(t *testing.T) {
 		t.Fatalf("unexpected exec_command error: %s", string(start.Output))
 	}
 
-	for _, yieldTimeMS := range []int{14_999, 0, -1} {
-		rejected := callWriteStdin(t, pollTool, "short-poll-rejected", map[string]any{
+	for _, test := range []struct {
+		name        string
+		yieldTimeMS int
+		chars       string
+	}{
+		{name: "below minimum", yieldTimeMS: 14_999},
+		{name: "zero", yieldTimeMS: 0},
+		{name: "negative", yieldTimeMS: -1},
+		{name: "unrepresentable output poll", yieldTimeMS: math.MaxInt},
+		{name: "unrepresentable input", yieldTimeMS: math.MaxInt, chars: "x"},
+	} {
+		input := map[string]any{
 			"session_id":    1000,
-			"yield_time_ms": yieldTimeMS,
-		})
+			"yield_time_ms": test.yieldTimeMS,
+		}
+		if test.chars != "" {
+			input["chars"] = test.chars
+		}
+		rejected := callWriteStdin(t, pollTool, "short-poll-rejected", input)
 		if !rejected.IsError {
-			t.Fatalf("expected %dms timed output poll to fail, got %+v", yieldTimeMS, rejected)
+			t.Fatalf("expected %s request to fail, got %+v", test.name, rejected)
 		}
 		var envelope struct {
 			Error string `json:"error"`

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -551,11 +551,11 @@ func TestWriteStdinRejectsShortTimedOutputPolls(t *testing.T) {
 		if envelope.Error == "" {
 			t.Fatal("expected rejected write_stdin error value")
 		}
-		if rejected.Summary == "" {
+		if rejected.Summary == nil || *rejected.Summary == "" {
 			t.Fatal("expected rejected write_stdin summary")
 		}
-		if rejected.Summary != envelope.Error {
-			t.Fatalf("rejected summary = %q, want error value %q", rejected.Summary, envelope.Error)
+		if *rejected.Summary != envelope.Error {
+			t.Fatalf("rejected summary = %q, want error value %q", *rejected.Summary, envelope.Error)
 		}
 	}
 

--- a/server/tools/shell/write_stdin_tool.go
+++ b/server/tools/shell/write_stdin_tool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -65,7 +66,7 @@ func (t *WriteStdinTool) Call(ctx context.Context, c tools.Call) (tools.Result, 
 		if in.Chars == "" && *in.YieldTimeMS > maximumOutputPollWaitMS {
 			return tools.ErrorResultWith(c, longOutputPollError, marshalNoHTMLEscape), nil
 		}
-		yieldTime = time.Duration(*in.YieldTimeMS) * time.Millisecond
+		yieldTime = writeStdinYieldDuration(*in.YieldTimeMS)
 	}
 	maxChars := t.outputLimit
 	if in.MaxOutputTokens != nil && *in.MaxOutputTokens > 0 {
@@ -105,4 +106,15 @@ func (t *WriteStdinTool) Call(ctx context.Context, c tools.Call) (tools.Result, 
 		),
 	}
 	return toolResult, nil
+}
+
+func writeStdinYieldDuration(milliseconds int) time.Duration {
+	value := int64(milliseconds)
+	if value > math.MaxInt64/int64(time.Millisecond) {
+		return time.Duration(math.MaxInt64)
+	}
+	if value < math.MinInt64/int64(time.Millisecond) {
+		return time.Duration(math.MinInt64)
+	}
+	return time.Duration(value) * time.Millisecond
 }

--- a/server/tools/shell/write_stdin_tool.go
+++ b/server/tools/shell/write_stdin_tool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -20,8 +21,9 @@ type writeStdinInput struct {
 }
 
 const (
-	minimumOutputPollWaitMS = 15_000
-	shortOutputPollError    = "Avoid polling repeatedly for short intervals, prefer 3-15min polls depending on task. Pick a better interval and retry"
+	minimumOutputPollWaitMS      = 15_000
+	maximumWriteStdinYieldTimeMS = math.MaxInt64 / int64(time.Millisecond)
+	shortOutputPollError         = "Avoid polling repeatedly for short intervals, prefer 3-15min polls depending on task. Pick a better interval and retry"
 )
 
 type WriteStdinTool struct {
@@ -55,12 +57,14 @@ func (t *WriteStdinTool) Call(ctx context.Context, c tools.Call) (tools.Result, 
 	if in.SessionID <= 0 {
 		return tools.ErrorResultWith(c, "session_id is required", marshalNoHTMLEscape), nil
 	}
-	if in.Chars == "" && in.YieldTimeMS != nil && *in.YieldTimeMS < minimumOutputPollWaitMS {
-		return tools.ErrorResultWith(c, shortOutputPollError, marshalNoHTMLEscape), nil
-	}
 	yieldTime := defaultWriteYieldTime
 	if in.YieldTimeMS != nil {
-		yieldTime = time.Duration(*in.YieldTimeMS) * time.Millisecond
+		yieldTimeMS := int64(*in.YieldTimeMS)
+		if yieldTimeMS > maximumWriteStdinYieldTimeMS ||
+			(in.Chars == "" && yieldTimeMS < minimumOutputPollWaitMS) {
+			return tools.ErrorResultWith(c, shortOutputPollError, marshalNoHTMLEscape), nil
+		}
+		yieldTime = time.Duration(yieldTimeMS) * time.Millisecond
 	}
 	maxChars := t.outputLimit
 	if in.MaxOutputTokens != nil && *in.MaxOutputTokens > 0 {

--- a/server/tools/shell/write_stdin_tool.go
+++ b/server/tools/shell/write_stdin_tool.go
@@ -19,6 +19,11 @@ type writeStdinInput struct {
 	MaxOutputTokens *int   `json:"max_output_tokens,omitempty"`
 }
 
+const (
+	minimumOutputPollWaitMS = 15_000
+	shortOutputPollError    = "Avoid polling repeatedly for short intervals, prefer 3-15min polls depending on task. Pick a better interval and retry"
+)
+
 type WriteStdinTool struct {
 	outputLimit int
 	background  *Manager
@@ -49,6 +54,9 @@ func (t *WriteStdinTool) Call(ctx context.Context, c tools.Call) (tools.Result, 
 	}
 	if in.SessionID <= 0 {
 		return tools.ErrorResultWith(c, "session_id is required", marshalNoHTMLEscape), nil
+	}
+	if in.Chars == "" && in.YieldTimeMS != nil && *in.YieldTimeMS < minimumOutputPollWaitMS {
+		return tools.ErrorResultWith(c, shortOutputPollError, marshalNoHTMLEscape), nil
 	}
 	yieldTime := defaultWriteYieldTime
 	if in.YieldTimeMS != nil {

--- a/server/tools/shell/write_stdin_tool.go
+++ b/server/tools/shell/write_stdin_tool.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -21,9 +20,10 @@ type writeStdinInput struct {
 }
 
 const (
-	minimumOutputPollWaitMS      = 15_000
-	maximumWriteStdinYieldTimeMS = math.MaxInt64 / int64(time.Millisecond)
-	shortOutputPollError         = "Avoid polling repeatedly for short intervals, prefer 3-15min polls depending on task. Pick a better interval and retry"
+	minimumOutputPollWaitMS = 15_000
+	maximumOutputPollWaitMS = 24 * 60 * 60 * 1_000
+	shortOutputPollError    = "Avoid polling repeatedly for short intervals, prefer 3-15min polls depending on task. Pick a better interval and retry"
+	longOutputPollError     = "This poll is too long. Consider using system cron jobs and `kent run` headless runs for tasks that require such long wait periods"
 )
 
 type WriteStdinTool struct {
@@ -59,12 +59,13 @@ func (t *WriteStdinTool) Call(ctx context.Context, c tools.Call) (tools.Result, 
 	}
 	yieldTime := defaultWriteYieldTime
 	if in.YieldTimeMS != nil {
-		yieldTimeMS := int64(*in.YieldTimeMS)
-		if yieldTimeMS > maximumWriteStdinYieldTimeMS ||
-			(in.Chars == "" && yieldTimeMS < minimumOutputPollWaitMS) {
+		if in.Chars == "" && *in.YieldTimeMS < minimumOutputPollWaitMS {
 			return tools.ErrorResultWith(c, shortOutputPollError, marshalNoHTMLEscape), nil
 		}
-		yieldTime = time.Duration(yieldTimeMS) * time.Millisecond
+		if in.Chars == "" && *in.YieldTimeMS > maximumOutputPollWaitMS {
+			return tools.ErrorResultWith(c, longOutputPollError, marshalNoHTMLEscape), nil
+		}
+		yieldTime = time.Duration(*in.YieldTimeMS) * time.Millisecond
 	}
 	maxChars := t.outputLimit
 	if in.MaxOutputTokens != nil && *in.MaxOutputTokens > 0 {

--- a/server/tools/transcript_contracts.go
+++ b/server/tools/transcript_contracts.go
@@ -733,7 +733,7 @@ func formatToolInput(toolID toolspec.ID, raw json.RawMessage) (string, string) {
 	if toolID == toolspec.ToolWriteStdin {
 		sessionID, _ := asInt(obj["session_id"])
 		chars, _ := asString(obj["chars"])
-		if strings.TrimSpace(chars) == "" {
+		if chars == "" {
 			if yieldTimeMS, ok := asInt(obj["yield_time_ms"]); ok && yieldTimeMS > 0 {
 				pollDuration := time.Duration(yieldTimeMS) * time.Millisecond
 				pollDurationText := "0s"


### PR DESCRIPTION
## Summary
- Reject explicit output-only `write_stdin` waits below 15 seconds and above 24 hours while preserving checks that omit a wait.
- Preserve byte-bearing stdin calls, including whitespace/control bytes, and saturate oversized input waits instead of reclassifying them as polls.
- Preserve isolated non-empty whitespace function-argument stream deltas so provider-delivered tool JSON remains byte-exact.

## Verification
- `./scripts/test.sh ./server/llm`
- `./scripts/test.sh ./server/tools/shell`
- `./scripts/test.sh ./server/runtime -run "^TestWriteStdinCompletionDoesNotQueueDuplicateBackgroundNotice$"`
- `./scripts/test.sh ./server/workflowsvc`
- `./scripts/build.sh --output ./bin/kent`
- `git diff --check origin/main..HEAD`

## QA evidence
Prior user-authorized isolated oMLX QA exercised the rebuilt binary end-to-end: a model started a TTY process, sent one `write_stdin` call with an actual U+000A inside a byte-bearing payload and `yield_time_ms: 9223372036854775807`, received `done` with exit code 0 in 1.37 seconds, then returned `COMPLETE` in 24.2 seconds. The harness server and state were wiped afterward; production `:53082` was not touched.

## Diff size
- Production code: +28 / -3, 31 gross, +25 net.
- Tests/generated code: +172 / -19, 191 gross, +153 net. No generated files changed.
- Product specification: +4 / -0, 4 gross, +4 net.
- Total: +204 / -22, 226 gross, +182 net.

## Caveats and follow-up
- The local oMLX XML fallback cannot represent whitespace-only stdin input; this is an explicit KENT-318 user-accepted provider limitation. A future provider/input encoding redesign would need a separately scoped contract change.
- Input-bearing waits intentionally remain unrestricted. QA confirmed that literal backslash-plus-`n` bytes do not terminate a shell `read`; a real U+000A does.
- The full `./scripts/test.sh server` suite remains subject to the explicitly documented non-blocking 180-second cap outcome for this ticket; the focused affected suites and current build pass.

## Tracking
- Kent task: KENT-318
- GitHub issue: none provided.