### PR TITLE
Load shared settings files only once

### DIFF
--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -200,6 +200,7 @@
 ## Configuration
 
 - User settings load from `~/.kent/config.toml` by default unless persistence root is overridden.
+- When global and workspace settings locations identify the same existing physical `config.toml`, Kent applies it once as global configuration, disables the workspace layer, and retains both location diagnostics.
 - Unknown config keys are errors.
 - Precedence is CLI overrides > environment > settings file > built-in defaults.
 - After first successful auth, missing `config.toml` triggers first-time setup before session selection.

--- a/shared/config/client_hooks_config_test.go
+++ b/shared/config/client_hooks_config_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -86,12 +88,72 @@ func TestLoadInteractiveClientLifecycleHookFromGlobalFilePreservesAndCopiesArgv(
 	}
 }
 
+func TestLoadInteractiveSharedSettingsFileIsGlobalOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		link func(string, string) error
+	}{
+		{"direct home path", nil},
+		{"workspace symlink", os.Symlink},
+		{"workspace hard link", os.Link},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home, workspace, homeSettingsPath := newConfigTestFile(t)
+			writeConfigTestFile(t, homeSettingsPath, "system_prompt_file = \"system.md\"\n\n[hooks.client]\nlifecycle = [\"notify\"]\n")
+			workspaceRoot := workspace
+			workspaceSettingsPath := filepath.Join(workspaceRoot, ConfigDirName, "config.toml")
+			if tc.link == nil {
+				workspaceRoot, workspaceSettingsPath = home, homeSettingsPath
+			} else {
+				ensureConfigTestDir(t, workspaceSettingsPath)
+				if err := tc.link(homeSettingsPath, workspaceSettingsPath); err != nil {
+					if errors.Is(err, errors.ErrUnsupported) {
+						t.Skipf("settings link unsupported: %v", err)
+					}
+					t.Fatalf("link workspace settings: %v", err)
+				}
+			}
+
+			app, client, err := LoadInteractive(workspaceRoot, LoadOptions{})
+			if err != nil {
+				t.Fatalf("load interactive config: %v", err)
+			}
+			if got := client.Hooks.LifecycleCommand(); !reflect.DeepEqual(got, []string{"notify"}) {
+				t.Fatalf("lifecycle command = %#v, want global command", got)
+			}
+			if got := app.Source.Sources["hooks.client.lifecycle"]; got != "file" {
+				t.Fatalf("lifecycle source = %q, want global file", got)
+			}
+			if got := app.Settings.SystemPromptFiles; !reflect.DeepEqual(got, []SystemPromptFile{{Path: filepath.Join(home, ConfigDirName, "system.md"), Scope: SystemPromptFileScopeHomeConfig}}) {
+				t.Fatalf("system prompt files = %#v, want one global prompt", got)
+			}
+			if app.Source.HomeSettingsPath != homeSettingsPath || app.Source.WorkspaceSettingsPath != workspaceSettingsPath ||
+				!app.Source.HomeSettingsFileExists || !app.Source.WorkspaceSettingsFileExists || app.Source.WorkspaceSettingsLayerEnabled ||
+				app.Source.SettingsPath != homeSettingsPath {
+				t.Fatalf("source report = %+v, want retained paths with global effective settings", app.Source)
+			}
+		})
+	}
+}
+
 func TestLoadInteractiveRejectsClientLifecycleHookInWorkspaceConfig(t *testing.T) {
-	_, workspace := newConfigTestEnv(t)
+	_, workspace, homeSettingsPath := newConfigTestFile(t)
+	writeConfigTestFile(t, homeSettingsPath, "model = \"global-model\"\n")
 	workspacePath := workspace + "/" + ConfigDirName + "/config.toml"
 	writeConfigTestFile(t, workspacePath, "[hooks.client]\nlifecycle = [\"notify\"]\n")
+	homeInfo, err := os.Stat(homeSettingsPath)
+	if err != nil {
+		t.Fatalf("stat global settings: %v", err)
+	}
+	workspaceInfo, err := os.Stat(workspacePath)
+	if err != nil {
+		t.Fatalf("stat workspace settings: %v", err)
+	}
+	if os.SameFile(homeInfo, workspaceInfo) {
+		t.Fatal("global and workspace settings files unexpectedly share one physical file")
+	}
 
-	_, _, err := LoadInteractive(workspace, LoadOptions{})
+	_, _, err = LoadInteractive(workspace, LoadOptions{})
 	if err == nil {
 		t.Fatal("workspace lifecycle hook succeeded")
 	}

--- a/shared/config/config_load.go
+++ b/shared/config/config_load.go
@@ -102,6 +102,7 @@ func loadAll(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions)
 	}
 	workspaceSettingsPath := ""
 	workspaceSettingsExists := false
+	workspaceSettingsLayerEnabled := includeWorkspaceLayer
 	workspaceFileConfig := settingsFile{}
 	if includeWorkspaceLayer {
 		workspaceSettingsPath, err = resolveWorkspaceSettingsFilePath(absWorkspace)
@@ -112,7 +113,18 @@ func loadAll(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions)
 		if err != nil {
 			return loadedConfig{}, err
 		}
-		if workspaceSettingsExists {
+		if homeSettingsExists && workspaceSettingsExists {
+			homeInfo, err := os.Stat(homeSettingsPath)
+			if err != nil {
+				return loadedConfig{}, err
+			}
+			workspaceInfo, err := os.Stat(workspaceSettingsPath)
+			if err != nil {
+				return loadedConfig{}, err
+			}
+			workspaceSettingsLayerEnabled = !os.SameFile(homeInfo, workspaceInfo)
+		}
+		if workspaceSettingsLayerEnabled && workspaceSettingsExists {
 			workspaceFileConfig, err = readSettingsFile(workspaceSettingsPath)
 			if err != nil {
 				return loadedConfig{}, err
@@ -134,7 +146,7 @@ func loadAll(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions)
 	if err := appendSystemPromptFileFromConfig(homeFileConfig, homeSettingsPath, SystemPromptFileScopeHomeConfig, &state); err != nil {
 		return loadedConfig{}, err
 	}
-	if includeWorkspaceLayer {
+	if workspaceSettingsLayerEnabled {
 		if err := configRegistry.applyFile(workspaceFileConfig, workspaceSettingsPath, settingsFileLayerWorkspace, &state, sources); err != nil {
 			return loadedConfig{}, err
 		}
@@ -169,7 +181,7 @@ func loadAll(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions)
 	state.Settings.Worktrees.BaseDir = absWorktreeBaseDir
 
 	settingsPath := homeSettingsPath
-	if workspaceSettingsExists {
+	if workspaceSettingsLayerEnabled && workspaceSettingsExists {
 		settingsPath = workspaceSettingsPath
 	}
 	settingsExists := homeSettingsExists || workspaceSettingsExists
@@ -187,7 +199,7 @@ func loadAll(workspaceRoot string, includeWorkspaceLayer bool, opts LoadOptions)
 				HomeSettingsFileExists:        homeSettingsExists,
 				WorkspaceSettingsPath:         workspaceSettingsPath,
 				WorkspaceSettingsFileExists:   workspaceSettingsExists,
-				WorkspaceSettingsLayerEnabled: includeWorkspaceLayer,
+				WorkspaceSettingsLayerEnabled: workspaceSettingsLayerEnabled,
 				Sources:                       sources,
 			},
 		},


### PR DESCRIPTION
## Summary
- Treat global and workspace settings locations that resolve to one existing physical `config.toml` as one global source.
- Skip the duplicate workspace read, layer validation, application, and workspace system-prompt inclusion while retaining both diagnostics.
- Cover direct home-directory, symlink, and hard-link identities; preserve the distinct-file workspace rejection.

## Verification
- `./scripts/test.sh ./shared/config` — passed after rebase.
- `./scripts/test.sh server --no-wall-clock-cap` — passed.
- `./scripts/build.sh --output ./bin/kent` — passed after rebase.

## Evidence
- Acceptance plan and coverage matrix: `.kent/plans/KENT-338.md`.
- Authoritative invariant: `docs/dev/specs/core-runtime-tools.md`.

## Diff
- Production code: +16/-4, net +12, gross 20 LoC.
- Tests: +64/-2, net +62, gross 66 LoC.
- Specification documentation: +1/-0, net +1, gross 1 LoC.
- Total: +81/-6, net +75, gross 87 LoC.

## Caveats and follow-up
- The standard 180-second server test cap stopped in an untouched `server/runtime` test. Per task-owner direction, the complete server suite was rerun without that cap and passed. Follow up on the runtime suite duration before relying on the cap as a completion gate.
- No exported/wire contracts or protocol version changed.

## Tracking
- GitHub issue: none linked.
- Kent task: KENT-338.