### PR TITLE
Make PTY scenario termination unconditional

### DIFF
--- a/internal/testharness/pty/blackbox/runner_test.go
+++ b/internal/testharness/pty/blackbox/runner_test.go
@@ -51,24 +51,11 @@ func TestRunnerExecutesDeclaredGoModelBoundaryScenario(t *testing.T) {
 }
 
 func TestCleanupForceKillsTERMAndHUPIgnoringClientAtGraceDeadline(t *testing.T) {
-	binary := filepath.Join(t.TempDir(), "ansi-writer")
-	if err := driver.BuildPackage(context.Background(), "core/internal/testharness/pty/testdata/cmd/ansi-writer", binary); err != nil {
-		t.Fatalf("build PTY helper: %v", err)
-	}
-	session, err := driver.StartSession(driver.SessionSpec{
-		Path:       binary,
-		Args:       []string{"ignore-term"},
-		Env:        []string{"TERM=xterm-256color", "LANG=C.UTF-8", "LC_ALL=C.UTF-8"},
-		Dimensions: pty.MustDimensions(2, 8),
-	})
-	if err != nil {
-		t.Fatalf("StartSession: %v", err)
-	}
+	session := startTermIgnoringSession(t)
 	t.Cleanup(func() {
 		_ = session.Close()
 		_ = session.ForceKill()
 	})
-	waitForVisibleCursor(t, session)
 
 	started := time.Now()
 	sessionOwner := session
@@ -92,6 +79,20 @@ func TestCleanupForceKillsTERMAndHUPIgnoringClientAtGraceDeadline(t *testing.T) 
 }
 
 func TestTerminateProcessActionForceKillsTermIgnoringClient(t *testing.T) {
+	session := startTermIgnoringSession(t)
+	t.Cleanup(func() { _ = session.ForceKill() })
+	if err := session.Enqueue(driver.SessionCommand{ID: uuid.New(), Kind: driver.SessionCommandTerminateProcess}); err != nil {
+		t.Fatalf("enqueue terminate: %v", err)
+	}
+	select {
+	case <-session.Done():
+	case <-time.After(time.Second):
+		t.Fatal("terminate_process did not end TERM-ignoring client")
+	}
+}
+
+func startTermIgnoringSession(t *testing.T) *driver.Session {
+	t.Helper()
 	binary := filepath.Join(t.TempDir(), "ansi-writer")
 	if err := driver.BuildPackage(context.Background(), "core/internal/testharness/pty/testdata/cmd/ansi-writer", binary); err != nil {
 		t.Fatalf("build PTY helper: %v", err)
@@ -104,16 +105,8 @@ func TestTerminateProcessActionForceKillsTermIgnoringClient(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartSession: %v", err)
 	}
-	t.Cleanup(func() { _ = session.ForceKill() })
 	waitForVisibleCursor(t, session)
-	if err := session.Enqueue(driver.SessionCommand{ID: uuid.New(), Kind: driver.SessionCommandTerminateProcess}); err != nil {
-		t.Fatalf("enqueue terminate: %v", err)
-	}
-	select {
-	case <-session.Done():
-	case <-time.After(time.Second):
-		t.Fatal("terminate_process did not end TERM-ignoring client")
-	}
+	return session
 }
 
 func TestFailureArtifactEvidenceTracksCaptureAvailabilityExplicitly(t *testing.T) {

--- a/internal/testharness/pty/blackbox/runner_test.go
+++ b/internal/testharness/pty/blackbox/runner_test.go
@@ -15,6 +15,8 @@ import (
 	"core/internal/testharness/pty"
 	"core/internal/testharness/pty/analyzer"
 	"core/internal/testharness/pty/driver"
+
+	"github.com/google/uuid"
 )
 
 const cleanupTeardownTestMargin = time.Second
@@ -86,6 +88,31 @@ func TestCleanupForceKillsTERMAndHUPIgnoringClientAtGraceDeadline(t *testing.T) 
 	case <-session.Done():
 	default:
 		t.Fatal("TERM-ignoring client remains live after cleanup")
+	}
+}
+
+func TestTerminateProcessActionForceKillsTermIgnoringClient(t *testing.T) {
+	binary := filepath.Join(t.TempDir(), "ansi-writer")
+	if err := driver.BuildPackage(context.Background(), "core/internal/testharness/pty/testdata/cmd/ansi-writer", binary); err != nil {
+		t.Fatalf("build PTY helper: %v", err)
+	}
+	session, err := driver.StartSession(driver.SessionSpec{
+		Path: binary, Args: []string{"ignore-term"},
+		Env:        []string{"TERM=xterm-256color", "LANG=C.UTF-8", "LC_ALL=C.UTF-8"},
+		Dimensions: pty.MustDimensions(2, 8),
+	})
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	t.Cleanup(func() { _ = session.ForceKill() })
+	waitForVisibleCursor(t, session)
+	if err := session.Enqueue(driver.SessionCommand{ID: uuid.New(), Kind: driver.SessionCommandTerminateProcess}); err != nil {
+		t.Fatalf("enqueue terminate: %v", err)
+	}
+	select {
+	case <-session.Done():
+	case <-time.After(time.Second):
+		t.Fatal("terminate_process did not end TERM-ignoring client")
 	}
 }
 

--- a/internal/testharness/pty/driver/session.go
+++ b/internal/testharness/pty/driver/session.go
@@ -295,10 +295,7 @@ func (s *Session) execute(command SessionCommand, assembler *analyzer.CaptureAss
 		}
 		return nil
 	case SessionCommandTerminateProcess:
-		if s.cmd.Process == nil {
-			return errors.New("PTY child process is unavailable")
-		}
-		return signalProcessGroup(s.cmd.Process.Pid, syscall.SIGTERM)
+		return s.ForceKill()
 	default:
 		return fmt.Errorf("unsupported session command kind %d", command.Kind)
 	}


### PR DESCRIPTION
## Summary
- Follow up on the CI-only PTY harness failure observed on #634.
- Make the test-harness `terminate_process` command delegate to its existing force-kill boundary instead of sending a best-effort SIGTERM.
- Add a TERM-ignoring child regression so the command must produce a terminal process exit, with shared PTY setup for the related cleanup coverage.

## Verification
- Red/green TDD: the TERM-ignoring-child regression failed with the prior SIGTERM-only implementation and passes with the repair.
- `./scripts/test.sh ./internal/testharness/pty/blackbox` — passed after extracting the shared setup.
- `./scripts/test.sh server --no-wall-clock-cap` — passed.
- `./scripts/build.sh --output ./bin/kent` — passed.

## Diff
- Production harness code: +1/-4, net -3, gross 5 LoC.
- Tests: +34/-14, net +20, gross 48 LoC.
- Total: +35/-18, net +17, gross 53 LoC.

## Caveats and follow-up
- #634 merged on July 23, 2026 before its failing CI check completed; this separate PR repairs that failure path.
- One local full-server attempt hit an unrelated existing runtime timing failure; its isolated test and the subsequent complete server rerun passed.
- The change is test-harness-only: no Kent product contract, protocol, persistence, or configuration behavior changes.

## Tracking
- Follow-up to #634.
- GitHub issue: none linked.
- Kent task: KENT-338.