### PR TITLE
feat: warn on cross-worktree edits

### DIFF
--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -47,7 +47,6 @@
 ## Patch And Image Tools
 
 - `patch` applies atomically: malformed or conflicting patches leave files unchanged. It supports add, update, move, and delete; resolves real paths before validating targets; has no timeout; and is not retried automatically.
-- After a successful `patch` or `edit`, Kent adds `[You reached into another Kent worktree. Prefer using \`kent worktree enter <selector>\` to edit in that worktree]` when an explicitly absolute target resolves under the configured managed-worktree base but outside the current managed worktree. Relative targets, current-worktree targets, targets outside that base, and failed edits do not add this warning.
 - Outside-workspace edits require approval unless `allow_non_cwd_edits=true`; the default is `false`. A denied edit returns an explicit error telling the model not to circumvent the decision and to request manual user edits when essential.
 - `view_image` resolves absolute canonical paths before checking access. Workspace checks happen after symlink resolution, so symlink escapes are blocked. Outside-workspace image reads use the same approval policy as edits.
 - Approved outside-workspace image reads appear in run logs with the requested and resolved paths.

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -47,6 +47,7 @@
 ## Patch And Image Tools
 
 - `patch` applies atomically: malformed or conflicting patches leave files unchanged. It supports add, update, move, and delete; resolves real paths before validating targets; has no timeout; and is not retried automatically.
+- After a successful `patch` or `edit`, Kent adds `[You reached into another Kent worktree. Prefer using \`kent worktree enter <selector>\` to edit in that worktree]` when an explicitly absolute target resolves under the configured managed-worktree base but outside the current managed worktree. Relative targets, current-worktree targets, targets outside that base, and failed edits do not add this warning.
 - Outside-workspace edits require approval unless `allow_non_cwd_edits=true`; the default is `false`. A denied edit returns an explicit error telling the model not to circumvent the decision and to request manual user edits when essential.
 - `view_image` resolves absolute canonical paths before checking access. Workspace checks happen after symlink resolution, so symlink escapes are blocked. Outside-workspace image reads use the same approval policy as edits.
 - Approved outside-workspace image reads appear in run logs with the requested and resolved paths.

--- a/server/runprompt/headless.go
+++ b/server/runprompt/headless.go
@@ -125,6 +125,18 @@ func (l *headlessPromptLauncher) prepareRuntime(ctx context.Context, plan launch
 	}
 	sessionID := plan.Descriptor.SessionID()
 	workdir := headlessRuntimeWorkdir(plan)
+	var currentWorktreeRoot *string
+	if plan.WorktreeReminder != nil && strings.TrimSpace(plan.WorktreeReminder.WorktreePath) != "" {
+		root := plan.WorktreeReminder.WorktreePath
+		currentWorktreeRoot = &root
+	}
+	var managedWorktreePathContext *askquestion.ManagedWorktreePathContext
+	if strings.TrimSpace(plan.ActiveSettings.Worktrees.BaseDir) != "" {
+		managedWorktreePathContext, err = askquestion.NewManagedWorktreePathContext(plan.ActiveSettings.Worktrees.BaseDir, currentWorktreeRoot)
+		if err != nil {
+			return nil, err
+		}
+	}
 	startLogLines := []string{
 		fmt.Sprintf("app.run_prompt.start session_id=%s workspace=%s workdir=%s model=%s", sessionID, plan.WorkspaceRoot, workdir, plan.ActiveSettings.Model),
 		fmt.Sprintf("config.settings path=%s created=%t", plan.Source.SettingsPath, plan.Source.CreatedDefaultConfig),
@@ -133,13 +145,14 @@ func (l *headlessPromptLauncher) prepareRuntime(ctx context.Context, plan launch
 		startLogLines = append(startLogLines, "config.source "+line)
 	}
 	runtimePlan, err := sessionruntime.NewAgentRuntimePlan(sessionruntime.AgentRuntimePlanOptions{
-		Settings:      plan.ActiveSettings,
-		EnabledTools:  plan.EnabledTools,
-		Workdir:       workdir,
-		Sources:       plan.Source.Sources,
-		Headless:      true,
-		FastMode:      l.boot.FastModeState,
-		StartLogLines: startLogLines,
+		Settings:                   plan.ActiveSettings,
+		EnabledTools:               plan.EnabledTools,
+		Workdir:                    workdir,
+		ManagedWorktreePathContext: managedWorktreePathContext,
+		Sources:                    plan.Source.Sources,
+		Headless:                   true,
+		FastMode:                   l.boot.FastModeState,
+		StartLogLines:              startLogLines,
 		OnLoggingFailure: func(message string) {
 			if progress != nil {
 				progress.PublishRunPromptProgress(serverapi.RunPromptProgress{

--- a/server/runprompt/headless.go
+++ b/server/runprompt/headless.go
@@ -132,10 +132,11 @@ func (l *headlessPromptLauncher) prepareRuntime(ctx context.Context, plan launch
 	}
 	var managedWorktreePathContext *askquestion.ManagedWorktreePathContext
 	if strings.TrimSpace(plan.ActiveSettings.Worktrees.BaseDir) != "" {
-		managedWorktreePathContext, err = askquestion.NewManagedWorktreePathContext(plan.ActiveSettings.Worktrees.BaseDir, currentWorktreeRoot)
-		if err != nil {
-			return nil, err
+		context, contextErr := askquestion.NewManagedWorktreePathContext(plan.ActiveSettings.Worktrees.BaseDir, currentWorktreeRoot)
+		if contextErr != nil {
+			return nil, contextErr
 		}
+		managedWorktreePathContext = context
 	}
 	startLogLines := []string{
 		fmt.Sprintf("app.run_prompt.start session_id=%s workspace=%s workdir=%s model=%s", sessionID, plan.WorkspaceRoot, workdir, plan.ActiveSettings.Model),

--- a/server/runprompt/headless.go
+++ b/server/runprompt/headless.go
@@ -12,6 +12,7 @@ import (
 	"core/server/requestmemo"
 	"core/server/runlog"
 	"core/server/runtime"
+	"core/server/session"
 	"core/server/sessionlaunch"
 	"core/server/sessionruntime"
 	askquestion "core/server/tools"
@@ -126,7 +127,9 @@ func (l *headlessPromptLauncher) prepareRuntime(ctx context.Context, plan launch
 	sessionID := plan.Descriptor.SessionID()
 	workdir := headlessRuntimeWorkdir(plan)
 	var currentWorktreeRoot *string
-	if plan.WorktreeReminder != nil && strings.TrimSpace(plan.WorktreeReminder.WorktreePath) != "" {
+	if plan.WorktreeReminder != nil &&
+		plan.WorktreeReminder.Mode == session.WorktreeReminderModeEnter &&
+		strings.TrimSpace(plan.WorktreeReminder.WorktreePath) != "" {
 		root := plan.WorktreeReminder.WorktreePath
 		currentWorktreeRoot = &root
 	}

--- a/server/runtime/committed_transcript_range_test.go
+++ b/server/runtime/committed_transcript_range_test.go
@@ -401,7 +401,7 @@ func TestTranscriptHydrationRetainsAdjacentRowsAroundProviderEmptyAssistant(t *t
 			message: llm.Message{Role: llm.RoleUser, Content: textutil.Value("before")},
 		},
 		{
-			stepID: emptyStepID,
+			stepID:  emptyStepID,
 			message: llm.Message{Role: llm.RoleAssistant, Phase: textutil.Value(llm.MessagePhaseFinal)},
 		},
 		{

--- a/server/runtime/tool_executor.go
+++ b/server/runtime/tool_executor.go
@@ -111,6 +111,7 @@ func (t *defaultToolExecutor) ExecuteToolCalls(ctx context.Context, stepID strin
 			}
 			res.CallID = tc.ID
 			res.Name = toolID
+			res = tools.MaterializeModelWarnings(res)
 			results[idx] = res
 			if err := e.steer(stepID, steerToolCompletionIntent(res)); err != nil {
 				persistErr := fmt.Errorf("%w (call_id=%s tool=%s): %w", errPersistToolCompletion, tc.ID, res.Name, err)

--- a/server/runtime/tool_executor_batch_test.go
+++ b/server/runtime/tool_executor_batch_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,6 +14,7 @@ import (
 	"core/server/session"
 	"core/server/session/sessiontest"
 	"core/server/tools"
+	patchtool "core/server/tools/patch"
 	"core/shared/toolspec"
 )
 
@@ -39,33 +42,36 @@ func TestExecuteToolCallsRejectsMissingProviderCallIDBeforeToolExecution(t *test
 	}
 }
 
-type warnedToolHandler struct{}
-
-func (warnedToolHandler) Call(_ context.Context, call tools.Call) (tools.Result, error) {
-	return tools.Result{
-		CallID: call.ID,
-		Name:   call.Name,
-		Output: json.RawMessage(`{"ok":true}`),
-		ModelWarnings: []tools.ModelWarning{
-			tools.ForeignManagedWorktreeEditWarning(),
-		},
-	}, nil
-}
-
 func TestExecuteToolCallsMaterializesSuccessfulModelWarningBeforePersistence(t *testing.T) {
 	store := mustCreateTestSession(t)
+	base := t.TempDir()
+	currentRoot := filepath.Join(base, "current")
+	foreignRoot := filepath.Join(base, "foreign")
+	for _, path := range []string{currentRoot, foreignRoot} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+	managedContext, err := tools.NewManagedWorktreePathContext(base, &currentRoot)
+	if err != nil {
+		t.Fatalf("new managed worktree path context: %v", err)
+	}
+	patchHandler, err := patchtool.New(currentRoot, true, patchtool.WithManagedWorktreePathContext(managedContext))
+	if err != nil {
+		t.Fatalf("new patch handler: %v", err)
+	}
 	engine := mustNewTestEngine(
 		t,
 		store,
 		&fakeClient{},
-		tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolPatch, Handler: warnedToolHandler{}}),
+		tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolPatch, Handler: patchHandler}),
 		Config{Model: "gpt-5"},
 	)
 
 	results, err := engine.executeToolCalls(context.Background(), "step", []llm.ToolCall{{
 		ID:    "warned-patch",
 		Name:  string(toolspec.ToolPatch),
-		Input: json.RawMessage(`{"patch":"*** Begin Patch\n*** Add File: a.txt\n+ok\n*** End Patch\n"}`),
+		Input: json.RawMessage(`{"patch":"*** Begin Patch\n*** Add File: ` + filepath.Join(foreignRoot, "a.txt") + `\n+ok\n*** End Patch\n"}`),
 	}})
 	if err != nil {
 		t.Fatalf("execute warned tool: %v", err)

--- a/server/runtime/tool_executor_batch_test.go
+++ b/server/runtime/tool_executor_batch_test.go
@@ -39,6 +39,70 @@ func TestExecuteToolCallsRejectsMissingProviderCallIDBeforeToolExecution(t *test
 	}
 }
 
+type warnedToolHandler struct{}
+
+func (warnedToolHandler) Call(_ context.Context, call tools.Call) (tools.Result, error) {
+	return tools.Result{
+		CallID: call.ID,
+		Name:   call.Name,
+		Output: json.RawMessage(`{"ok":true}`),
+		ModelWarnings: []tools.ModelWarning{
+			tools.ForeignManagedWorktreeEditWarning(),
+		},
+	}, nil
+}
+
+func TestExecuteToolCallsMaterializesSuccessfulModelWarningBeforePersistence(t *testing.T) {
+	store := mustCreateTestSession(t)
+	engine := mustNewTestEngine(
+		t,
+		store,
+		&fakeClient{},
+		tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolPatch, Handler: warnedToolHandler{}}),
+		Config{Model: "gpt-5"},
+	)
+
+	results, err := engine.executeToolCalls(context.Background(), "step", []llm.ToolCall{{
+		ID:    "warned-patch",
+		Name:  string(toolspec.ToolPatch),
+		Input: json.RawMessage(`{"patch":"*** Begin Patch\n*** Add File: a.txt\n+ok\n*** End Patch\n"}`),
+	}})
+	if err != nil {
+		t.Fatalf("execute warned tool: %v", err)
+	}
+	if len(results) != 1 || len(results[0].ModelWarnings) != 0 {
+		t.Fatalf("materialized result = %+v", results)
+	}
+	var output map[string]json.RawMessage
+	if err := json.Unmarshal(results[0].Output, &output); err != nil {
+		t.Fatalf("decode materialized output: %v", err)
+	}
+	if _, ok := output["ok"]; !ok {
+		t.Fatalf("materialized output lost success: %s", results[0].Output)
+	}
+	if _, ok := output["warning"]; !ok {
+		t.Fatalf("materialized output lost warning: %s", results[0].Output)
+	}
+	window, err := mustMaterializeTestEventLog(t, store).ReadRecentRecords(8)
+	if err != nil {
+		t.Fatalf("read persisted records: %v", err)
+	}
+	for _, record := range window.Records {
+		completion, ok := mustSessionEventPayload(record).(session.ToolCompletionRecord)
+		if !ok || completion.CallID != "warned-patch" {
+			continue
+		}
+		var persisted map[string]json.RawMessage
+		if err := json.Unmarshal(completion.Output, &persisted); err != nil {
+			t.Fatalf("decode persisted output: %v", err)
+		}
+		if _, ok := persisted["warning"]; ok {
+			return
+		}
+	}
+	t.Fatal("persisted completion omitted model warning")
+}
+
 func TestExecuteToolCallsRejectsInvalidWebSearchBeforeHandler(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/server/runtimewire/tool_registry.go
+++ b/server/runtimewire/tool_registry.go
@@ -147,7 +147,35 @@ func (b *LocalToolRegistryBinding) Rebind(workspaceRoot string) error {
 	return b.RebindExecutionTarget(workspaceRoot, nil)
 }
 
-func (b *LocalToolRegistryBinding) RebindExecutionTarget(workspaceRoot string, managedWorktreePathContext *tools.ManagedWorktreePathContext) error {
+func (b *LocalToolRegistryBinding) RebindExecutionTarget(workspaceRoot string, currentWorktreeRoot *string) error {
+	if b == nil {
+		return fmt.Errorf("local tool registry binding is required")
+	}
+	trimmedRoot := strings.TrimSpace(workspaceRoot)
+	if trimmedRoot == "" {
+		return errWorkspaceRootRequired
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	managedWorktreePathContext, err := b.ctx.ManagedWorktreePathContext.WithCurrentWorktreeRoot(currentWorktreeRoot)
+	if err != nil {
+		return err
+	}
+	b.ctx.WorkspaceRoot = trimmedRoot
+	b.ctx.ManagedWorktreePathContext = managedWorktreePathContext
+	return b.rebuildLocked()
+}
+
+func (b *LocalToolRegistryBinding) ManagedWorktreePathContext() *tools.ManagedWorktreePathContext {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.ctx.ManagedWorktreePathContext
+}
+
+func (b *LocalToolRegistryBinding) RebindWithManagedWorktreePathContext(workspaceRoot string, managedWorktreePathContext *tools.ManagedWorktreePathContext) error {
 	if b == nil {
 		return fmt.Errorf("local tool registry binding is required")
 	}

--- a/server/runtimewire/tool_registry.go
+++ b/server/runtimewire/tool_registry.go
@@ -34,6 +34,8 @@ var errWorkspaceRootRequired = errors.New("workspace root is required")
 
 type LocalToolRuntimeContext struct {
 	WorkspaceRoot                   string
+	ManagedWorktreeBaseDir          string
+	CurrentWorktreeRoot             string
 	OwnerSessionID                  string
 	ExecutionCorrelation            *runtimeids.ExecutionCorrelation
 	ShellOutputMaxChars             int
@@ -82,6 +84,7 @@ func BuildLocalRuntimeHandler(def tools.Definition, ctx LocalToolRuntimeContext)
 			patchtool.WithAllowOutsideWorkspace(ctx.AllowNonCwdEdits),
 			patchtool.WithOutsideWorkspaceApprover(ctx.OutsideWorkspaceEditApprover),
 			patchtool.WithPathDenyPolicy(ctx.EditPathDenyPolicy),
+			patchtool.WithManagedWorktreePathContext(ctx.ManagedWorktreeBaseDir, ctx.CurrentWorktreeRoot),
 		)
 	case tools.LocalRuntimeBuilderEdit:
 		if ctx.OutsideWorkspaceEditApprover == nil {
@@ -93,6 +96,7 @@ func BuildLocalRuntimeHandler(def tools.Definition, ctx LocalToolRuntimeContext)
 			edittool.WithAllowOutsideWorkspace(ctx.AllowNonCwdEdits),
 			edittool.WithOutsideWorkspaceApprover(ctx.OutsideWorkspaceEditApprover),
 			edittool.WithPathDenyPolicy(ctx.EditPathDenyPolicy),
+			edittool.WithManagedWorktreePathContext(ctx.ManagedWorktreeBaseDir, ctx.CurrentWorktreeRoot),
 		)
 	case tools.LocalRuntimeBuilderAskQuestion:
 		if ctx.AskQuestionBroker == nil {
@@ -141,6 +145,10 @@ func (b *LocalToolRegistryBinding) Registry() *tools.Registry {
 }
 
 func (b *LocalToolRegistryBinding) Rebind(workspaceRoot string) error {
+	return b.RebindExecutionTarget(workspaceRoot, "")
+}
+
+func (b *LocalToolRegistryBinding) RebindExecutionTarget(workspaceRoot string, currentWorktreeRoot string) error {
 	if b == nil {
 		return fmt.Errorf("local tool registry binding is required")
 	}
@@ -151,6 +159,7 @@ func (b *LocalToolRegistryBinding) Rebind(workspaceRoot string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.ctx.WorkspaceRoot = trimmedRoot
+	b.ctx.CurrentWorktreeRoot = strings.TrimSpace(currentWorktreeRoot)
 	return b.rebuildLocked()
 }
 
@@ -217,6 +226,8 @@ func (b *LocalToolRegistryBinding) rebuildLocked() error {
 
 type LocalToolRegistryOptions struct {
 	WorkspaceRoot            string
+	ManagedWorktreeBaseDir   string
+	CurrentWorktreeRoot      string
 	OwnerSessionID           string
 	ExecutionCorrelation     *runtimeids.ExecutionCorrelation
 	Enabled                  []toolspec.ID
@@ -265,6 +276,8 @@ func NewLocalToolRegistryBinding(opts LocalToolRegistryOptions) (*LocalToolRegis
 	registry := tools.NewRegistry()
 	ctx := LocalToolRuntimeContext{
 		WorkspaceRoot:                trimmedRoot,
+		ManagedWorktreeBaseDir:       strings.TrimSpace(opts.ManagedWorktreeBaseDir),
+		CurrentWorktreeRoot:          strings.TrimSpace(opts.CurrentWorktreeRoot),
 		OwnerSessionID:               opts.OwnerSessionID,
 		ExecutionCorrelation:         opts.ExecutionCorrelation,
 		ShellOutputMaxChars:          opts.ShellOutputMaxChars,

--- a/server/runtimewire/tool_registry.go
+++ b/server/runtimewire/tool_registry.go
@@ -34,8 +34,7 @@ var errWorkspaceRootRequired = errors.New("workspace root is required")
 
 type LocalToolRuntimeContext struct {
 	WorkspaceRoot                   string
-	ManagedWorktreeBaseDir          string
-	CurrentWorktreeRoot             string
+	ManagedWorktreePathContext      *tools.ManagedWorktreePathContext
 	OwnerSessionID                  string
 	ExecutionCorrelation            *runtimeids.ExecutionCorrelation
 	ShellOutputMaxChars             int
@@ -84,7 +83,7 @@ func BuildLocalRuntimeHandler(def tools.Definition, ctx LocalToolRuntimeContext)
 			patchtool.WithAllowOutsideWorkspace(ctx.AllowNonCwdEdits),
 			patchtool.WithOutsideWorkspaceApprover(ctx.OutsideWorkspaceEditApprover),
 			patchtool.WithPathDenyPolicy(ctx.EditPathDenyPolicy),
-			patchtool.WithManagedWorktreePathContext(ctx.ManagedWorktreeBaseDir, ctx.CurrentWorktreeRoot),
+			patchtool.WithManagedWorktreePathContext(ctx.ManagedWorktreePathContext),
 		)
 	case tools.LocalRuntimeBuilderEdit:
 		if ctx.OutsideWorkspaceEditApprover == nil {
@@ -96,7 +95,7 @@ func BuildLocalRuntimeHandler(def tools.Definition, ctx LocalToolRuntimeContext)
 			edittool.WithAllowOutsideWorkspace(ctx.AllowNonCwdEdits),
 			edittool.WithOutsideWorkspaceApprover(ctx.OutsideWorkspaceEditApprover),
 			edittool.WithPathDenyPolicy(ctx.EditPathDenyPolicy),
-			edittool.WithManagedWorktreePathContext(ctx.ManagedWorktreeBaseDir, ctx.CurrentWorktreeRoot),
+			edittool.WithManagedWorktreePathContext(ctx.ManagedWorktreePathContext),
 		)
 	case tools.LocalRuntimeBuilderAskQuestion:
 		if ctx.AskQuestionBroker == nil {
@@ -145,10 +144,10 @@ func (b *LocalToolRegistryBinding) Registry() *tools.Registry {
 }
 
 func (b *LocalToolRegistryBinding) Rebind(workspaceRoot string) error {
-	return b.RebindExecutionTarget(workspaceRoot, "")
+	return b.RebindExecutionTarget(workspaceRoot, nil)
 }
 
-func (b *LocalToolRegistryBinding) RebindExecutionTarget(workspaceRoot string, currentWorktreeRoot string) error {
+func (b *LocalToolRegistryBinding) RebindExecutionTarget(workspaceRoot string, managedWorktreePathContext *tools.ManagedWorktreePathContext) error {
 	if b == nil {
 		return fmt.Errorf("local tool registry binding is required")
 	}
@@ -159,7 +158,7 @@ func (b *LocalToolRegistryBinding) RebindExecutionTarget(workspaceRoot string, c
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.ctx.WorkspaceRoot = trimmedRoot
-	b.ctx.CurrentWorktreeRoot = strings.TrimSpace(currentWorktreeRoot)
+	b.ctx.ManagedWorktreePathContext = managedWorktreePathContext
 	return b.rebuildLocked()
 }
 
@@ -225,22 +224,21 @@ func (b *LocalToolRegistryBinding) rebuildLocked() error {
 }
 
 type LocalToolRegistryOptions struct {
-	WorkspaceRoot            string
-	ManagedWorktreeBaseDir   string
-	CurrentWorktreeRoot      string
-	OwnerSessionID           string
-	ExecutionCorrelation     *runtimeids.ExecutionCorrelation
-	Enabled                  []toolspec.ID
-	MinimumExecToBgTime      time.Duration
-	ShellOutputMaxChars      int
-	AllowNonCwdEdits         bool
-	SupportsVision           bool
-	Logger                   Logger
-	Background               *shelltool.Manager
-	ShellPostprocessor       *postprocess.Runner
-	TriggerHandoffController func() triggerhandofftool.TriggerHandoffController
-	QuestionsEnabledGetter   func() bool
-	GlobalConfigDir          string
+	WorkspaceRoot              string
+	ManagedWorktreePathContext *tools.ManagedWorktreePathContext
+	OwnerSessionID             string
+	ExecutionCorrelation       *runtimeids.ExecutionCorrelation
+	Enabled                    []toolspec.ID
+	MinimumExecToBgTime        time.Duration
+	ShellOutputMaxChars        int
+	AllowNonCwdEdits           bool
+	SupportsVision             bool
+	Logger                     Logger
+	Background                 *shelltool.Manager
+	ShellPostprocessor         *postprocess.Runner
+	TriggerHandoffController   func() triggerhandofftool.TriggerHandoffController
+	QuestionsEnabledGetter     func() bool
+	GlobalConfigDir            string
 }
 
 func NewLocalToolRegistryBinding(opts LocalToolRegistryOptions) (*LocalToolRegistryBinding, *askquestion.AskQuestionBroker, *shelltool.Manager, error) {
@@ -276,8 +274,7 @@ func NewLocalToolRegistryBinding(opts LocalToolRegistryOptions) (*LocalToolRegis
 	registry := tools.NewRegistry()
 	ctx := LocalToolRuntimeContext{
 		WorkspaceRoot:                trimmedRoot,
-		ManagedWorktreeBaseDir:       strings.TrimSpace(opts.ManagedWorktreeBaseDir),
-		CurrentWorktreeRoot:          strings.TrimSpace(opts.CurrentWorktreeRoot),
+		ManagedWorktreePathContext:   opts.ManagedWorktreePathContext,
 		OwnerSessionID:               opts.OwnerSessionID,
 		ExecutionCorrelation:         opts.ExecutionCorrelation,
 		ShellOutputMaxChars:          opts.ShellOutputMaxChars,

--- a/server/runtimewire/wiring.go
+++ b/server/runtimewire/wiring.go
@@ -11,6 +11,7 @@ import (
 	"core/server/llm"
 	"core/server/runtime"
 	"core/server/session"
+	"core/server/tools"
 	askquestion "core/server/tools"
 	triggerhandofftool "core/server/tools"
 	shelltool "core/server/tools/shell"
@@ -37,8 +38,7 @@ func (w *RuntimeWiring) Close() error {
 }
 
 type RuntimeWiringOptions struct {
-	ManagedWorktreeBaseDir              string
-	CurrentWorktreeRoot                 string
+	ManagedWorktreePathContext          *tools.ManagedWorktreePathContext
 	Context                             context.Context
 	OnEvent                             func(evt runtime.Event)
 	Headless                            bool
@@ -87,20 +87,19 @@ func NewRuntimeWiringWithBackground(
 	}
 	var eng *runtime.Engine
 	localTools, askBroker, background, err := NewLocalToolRegistryBinding(LocalToolRegistryOptions{
-		WorkspaceRoot:            workspaceRoot,
-		ManagedWorktreeBaseDir:   opts.ManagedWorktreeBaseDir,
-		CurrentWorktreeRoot:      opts.CurrentWorktreeRoot,
-		OwnerSessionID:           store.Meta().SessionID,
-		Enabled:                  enabledTools,
-		MinimumExecToBgTime:      time.Duration(active.MinimumExecToBgSeconds) * time.Second,
-		ShellOutputMaxChars:      active.ShellOutputMaxChars,
-		AllowNonCwdEdits:         active.AllowNonCwdEdits,
-		SupportsVision:           llm.LockedContractSupportsVisionInputs(store.Meta().Locked, active.Model),
-		Logger:                   logger,
-		Background:               background,
-		ShellPostprocessor:       shellPostprocessor,
-		GlobalConfigDir:          opts.GlobalConfigDir,
-		TriggerHandoffController: func() triggerhandofftool.TriggerHandoffController { return eng },
+		WorkspaceRoot:              workspaceRoot,
+		ManagedWorktreePathContext: opts.ManagedWorktreePathContext,
+		OwnerSessionID:             store.Meta().SessionID,
+		Enabled:                    enabledTools,
+		MinimumExecToBgTime:        time.Duration(active.MinimumExecToBgSeconds) * time.Second,
+		ShellOutputMaxChars:        active.ShellOutputMaxChars,
+		AllowNonCwdEdits:           active.AllowNonCwdEdits,
+		SupportsVision:             llm.LockedContractSupportsVisionInputs(store.Meta().Locked, active.Model),
+		Logger:                     logger,
+		Background:                 background,
+		ShellPostprocessor:         shellPostprocessor,
+		GlobalConfigDir:            opts.GlobalConfigDir,
+		TriggerHandoffController:   func() triggerhandofftool.TriggerHandoffController { return eng },
 		QuestionsEnabledGetter: func() bool {
 			if eng == nil {
 				return true

--- a/server/runtimewire/wiring.go
+++ b/server/runtimewire/wiring.go
@@ -37,6 +37,8 @@ func (w *RuntimeWiring) Close() error {
 }
 
 type RuntimeWiringOptions struct {
+	ManagedWorktreeBaseDir              string
+	CurrentWorktreeRoot                 string
 	Context                             context.Context
 	OnEvent                             func(evt runtime.Event)
 	Headless                            bool
@@ -86,6 +88,8 @@ func NewRuntimeWiringWithBackground(
 	var eng *runtime.Engine
 	localTools, askBroker, background, err := NewLocalToolRegistryBinding(LocalToolRegistryOptions{
 		WorkspaceRoot:            workspaceRoot,
+		ManagedWorktreeBaseDir:   opts.ManagedWorktreeBaseDir,
+		CurrentWorktreeRoot:      opts.CurrentWorktreeRoot,
 		OwnerSessionID:           store.Meta().SessionID,
 		Enabled:                  enabledTools,
 		MinimumExecToBgTime:      time.Duration(active.MinimumExecToBgSeconds) * time.Second,

--- a/server/sessionruntime/engine_adapter.go
+++ b/server/sessionruntime/engine_adapter.go
@@ -26,8 +26,7 @@ type AgentRuntimePlanOptions struct {
 	Settings                            config.Settings
 	EnabledTools                        []toolspec.ID
 	Workdir                             string
-	ManagedWorktreeBaseDir              string
-	CurrentWorktreeRoot                 string
+	ManagedWorktreePathContext          *tools.ManagedWorktreePathContext
 	Sources                             map[string]string
 	Headless                            bool
 	FastMode                            *runtime.FastModeState
@@ -215,8 +214,7 @@ func (a *Authority) newRuntimeWiringFromPlan(resource *agentResource, store *ses
 		ProviderCapabilitiesOverride:        options.ProviderCapabilitiesOverride,
 		SkipContinuationAgentRoleValidation: options.SkipContinuationAgentRoleValidation,
 		GlobalConfigDir:                     a.options.persistenceRoot,
-		ManagedWorktreeBaseDir:              options.ManagedWorktreeBaseDir,
-		CurrentWorktreeRoot:                 options.CurrentWorktreeRoot,
+		ManagedWorktreePathContext:          options.ManagedWorktreePathContext,
 		StepLifecycle:                       resource,
 		LifecycleTaskFinished: func() error {
 			return a.closeRetiringResource(context.Background(), resource)

--- a/server/sessionruntime/engine_adapter.go
+++ b/server/sessionruntime/engine_adapter.go
@@ -26,6 +26,8 @@ type AgentRuntimePlanOptions struct {
 	Settings                            config.Settings
 	EnabledTools                        []toolspec.ID
 	Workdir                             string
+	ManagedWorktreeBaseDir              string
+	CurrentWorktreeRoot                 string
 	Sources                             map[string]string
 	Headless                            bool
 	FastMode                            *runtime.FastModeState
@@ -213,6 +215,8 @@ func (a *Authority) newRuntimeWiringFromPlan(resource *agentResource, store *ses
 		ProviderCapabilitiesOverride:        options.ProviderCapabilitiesOverride,
 		SkipContinuationAgentRoleValidation: options.SkipContinuationAgentRoleValidation,
 		GlobalConfigDir:                     a.options.persistenceRoot,
+		ManagedWorktreeBaseDir:              options.ManagedWorktreeBaseDir,
+		CurrentWorktreeRoot:                 options.CurrentWorktreeRoot,
 		StepLifecycle:                       resource,
 		LifecycleTaskFinished: func() error {
 			return a.closeRetiringResource(context.Background(), resource)

--- a/server/sessionruntime/execution_target.go
+++ b/server/sessionruntime/execution_target.go
@@ -444,11 +444,7 @@ func rebindResourceExecutionTarget(resource *agentResource, engine *runtime.Engi
 		return errors.New("active runtime resource is required")
 	}
 	if resource.localTools != nil {
-		currentWorktreeRoot := ""
-		if target.Worktree != nil {
-			currentWorktreeRoot = target.Worktree.Root
-		}
-		if err := resource.localTools.RebindExecutionTarget(target.EffectiveWorkdir, currentWorktreeRoot); err != nil {
+		if err := resource.localTools.Rebind(target.EffectiveWorkdir); err != nil {
 			return err
 		}
 	}

--- a/server/sessionruntime/execution_target.go
+++ b/server/sessionruntime/execution_target.go
@@ -9,6 +9,7 @@ import (
 	"core/server/runtime"
 	"core/server/runtimeactivity"
 	"core/server/session"
+	"core/server/tools"
 	shelltool "core/server/tools/shell"
 	"core/shared/clientui"
 	"core/shared/runtimeids"
@@ -412,11 +413,15 @@ func normalizeTarget(target clientui.SessionExecutionTarget, reminder *session.W
 func syncResourceExecutionTarget(resource *agentResource, engine *runtime.Engine, target clientui.SessionExecutionTarget, reminder *session.WorktreeReminderState) (bool, error) {
 	previousWorkdir := strings.TrimSpace(engine.TranscriptWorkingDir())
 	previousReminder := engine.WorktreeReminderState()
+	var previousManagedWorktreePathContext *tools.ManagedWorktreePathContext
+	if resource.localTools != nil {
+		previousManagedWorktreePathContext = resource.localTools.ManagedWorktreePathContext()
+	}
 	if err := rebindResourceExecutionTarget(resource, engine, target); err != nil {
 		return false, err
 	}
 	if err := engine.SetWorktreeReminderState(reminder); err != nil {
-		rollbackErr := rollbackResourceExecutionTarget(resource, engine, previousWorkdir, previousReminder)
+		rollbackErr := rollbackResourceExecutionTarget(resource, engine, previousWorkdir, previousReminder, previousManagedWorktreePathContext)
 		if rollbackErr != nil {
 			engine.FailQueuedUserMessages(runtime.QueuedUserMessageFailureRuntimeUnavailable)
 			return true, errors.Join(err, rollbackErr)
@@ -444,7 +449,12 @@ func rebindResourceExecutionTarget(resource *agentResource, engine *runtime.Engi
 		return errors.New("active runtime resource is required")
 	}
 	if resource.localTools != nil {
-		if err := resource.localTools.Rebind(target.EffectiveWorkdir); err != nil {
+		var currentWorktreeRoot *string
+		if target.Worktree != nil {
+			root := target.Worktree.Root
+			currentWorktreeRoot = &root
+		}
+		if err := resource.localTools.RebindExecutionTarget(target.EffectiveWorkdir, currentWorktreeRoot); err != nil {
 			return err
 		}
 	}
@@ -452,12 +462,17 @@ func rebindResourceExecutionTarget(resource *agentResource, engine *runtime.Engi
 	return nil
 }
 
-func rollbackResourceExecutionTarget(resource *agentResource, engine *runtime.Engine, workdir string, reminder *session.WorktreeReminderState) error {
+func rollbackResourceExecutionTarget(resource *agentResource, engine *runtime.Engine, workdir string, reminder *session.WorktreeReminderState, managedWorktreePathContext *tools.ManagedWorktreePathContext) error {
 	var collected []error
 	if strings.TrimSpace(workdir) != "" {
-		if err := rebindResource(resource, engine, workdir); err != nil {
+		if resource.localTools != nil {
+			if err := resource.localTools.RebindWithManagedWorktreePathContext(workdir, managedWorktreePathContext); err != nil {
+				collected = append(collected, fmt.Errorf("rollback runtime workdir: %w", err))
+			}
+		} else if err := rebindResource(resource, engine, workdir); err != nil {
 			collected = append(collected, fmt.Errorf("rollback runtime workdir: %w", err))
 		}
+		engine.SetTranscriptWorkingDir(workdir)
 	}
 	if err := engine.SetWorktreeReminderState(reminder); err != nil {
 		collected = append(collected, fmt.Errorf("rollback worktree reminder: %w", err))

--- a/server/sessionruntime/execution_target.go
+++ b/server/sessionruntime/execution_target.go
@@ -25,7 +25,7 @@ func (a *Authority) SyncExecutionTarget(ctx context.Context, sessionID string, t
 	if err != nil {
 		return err
 	}
-	workdir, normalizedReminder, err := normalizeTarget(target, reminder)
+	normalizedTarget, normalizedReminder, err := normalizeTarget(target, reminder)
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func (a *Authority) SyncExecutionTarget(ctx context.Context, sessionID string, t
 		retire := false
 		err := engine.RunWhenIdleBeforeQueuedUserWork(runCtx, runtime.ActiveKindRuntimeMaintenance, func() error {
 			var syncErr error
-			retire, syncErr = syncResourceExecutionTarget(resource, engine, workdir, normalizedReminder)
+			retire, syncErr = syncResourceExecutionTarget(resource, engine, normalizedTarget, normalizedReminder)
 			return syncErr
 		})
 		return retire, err
@@ -87,12 +87,12 @@ func (a *Authority) RunWorktreeTransition(
 					if !active {
 						return errors.New("worktree transition target synchronizer is no longer active")
 					}
-					workdir, normalizedReminder, err := normalizeTarget(target, reminder)
+					normalizedTarget, normalizedReminder, err := normalizeTarget(target, reminder)
 					if err != nil {
 						return err
 					}
 					var syncErr error
-					retire, syncErr = syncResourceExecutionTarget(resource, engine, workdir, normalizedReminder)
+					retire, syncErr = syncResourceExecutionTarget(resource, engine, normalizedTarget, normalizedReminder)
 					return syncErr
 				})
 			})
@@ -118,12 +118,12 @@ func (a *Authority) RunWorktreeTransition(
 			if !active {
 				return runtime.ErrActiveStepInactive
 			}
-			workdir, normalizedReminder, err := normalizeTarget(target, reminder)
+			normalizedTarget, normalizedReminder, err := normalizeTarget(target, reminder)
 			if err != nil {
 				return err
 			}
 			var syncErr error
-			retire, syncErr = syncResourceExecutionTarget(resource, engine, workdir, normalizedReminder)
+			retire, syncErr = syncResourceExecutionTarget(resource, engine, normalizedTarget, normalizedReminder)
 			return syncErr
 		})
 		if err != nil {
@@ -394,25 +394,25 @@ func (a *Authority) retireExactResource(ctx context.Context, resource *agentReso
 	return resource.closeResource(ctx)
 }
 
-func normalizeTarget(target clientui.SessionExecutionTarget, reminder *session.WorktreeReminderState) (string, *session.WorktreeReminderState, error) {
-	workdir := strings.TrimSpace(target.EffectiveWorkdir)
-	if workdir == "" {
-		return "", nil, errors.New("execution target effective workdir is required")
+func normalizeTarget(target clientui.SessionExecutionTarget, reminder *session.WorktreeReminderState) (clientui.SessionExecutionTarget, *session.WorktreeReminderState, error) {
+	normalizedTarget := clientui.NormalizeSessionExecutionTarget(target)
+	if normalizedTarget.EffectiveWorkdir == "" {
+		return clientui.SessionExecutionTarget{}, nil, errors.New("execution target effective workdir is required")
 	}
 	if reminder == nil {
-		return workdir, nil, nil
+		return normalizedTarget, nil, nil
 	}
 	normalized, err := session.NormalizeWorktreeReminderState(*reminder)
 	if err != nil {
-		return "", nil, err
+		return clientui.SessionExecutionTarget{}, nil, err
 	}
-	return workdir, &normalized, nil
+	return normalizedTarget, &normalized, nil
 }
 
-func syncResourceExecutionTarget(resource *agentResource, engine *runtime.Engine, workdir string, reminder *session.WorktreeReminderState) (bool, error) {
+func syncResourceExecutionTarget(resource *agentResource, engine *runtime.Engine, target clientui.SessionExecutionTarget, reminder *session.WorktreeReminderState) (bool, error) {
 	previousWorkdir := strings.TrimSpace(engine.TranscriptWorkingDir())
 	previousReminder := engine.WorktreeReminderState()
-	if err := rebindResource(resource, engine, workdir); err != nil {
+	if err := rebindResourceExecutionTarget(resource, engine, target); err != nil {
 		return false, err
 	}
 	if err := engine.SetWorktreeReminderState(reminder); err != nil {
@@ -436,6 +436,23 @@ func rebindResource(resource *agentResource, engine *runtime.Engine, workdir str
 		}
 	}
 	engine.SetTranscriptWorkingDir(workdir)
+	return nil
+}
+
+func rebindResourceExecutionTarget(resource *agentResource, engine *runtime.Engine, target clientui.SessionExecutionTarget) error {
+	if resource == nil || engine == nil {
+		return errors.New("active runtime resource is required")
+	}
+	if resource.localTools != nil {
+		currentWorktreeRoot := ""
+		if target.Worktree != nil {
+			currentWorktreeRoot = target.Worktree.Root
+		}
+		if err := resource.localTools.RebindExecutionTarget(target.EffectiveWorkdir, currentWorktreeRoot); err != nil {
+			return err
+		}
+	}
+	engine.SetTranscriptWorkingDir(target.EffectiveWorkdir)
 	return nil
 }
 

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -11,6 +11,7 @@ import (
 	"core/server/runtime"
 	"core/server/runtimewire"
 	"core/server/session"
+	"core/server/tools"
 	servicecontract "core/shared/apicontract"
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
@@ -134,22 +135,25 @@ func (s *API) interactiveRuntimePlan(ctx context.Context, req serverapi.SessionR
 	for _, line := range runlog.FormatConfigSourceLines(req.Source.Sources) {
 		startLogLines = append(startLogLines, "config.source "+line)
 	}
+	var currentWorktreeRoot *string
+	if target.Worktree != nil {
+		root := target.Worktree.Root
+		currentWorktreeRoot = &root
+	}
+	managedWorktreePathContext, err := tools.NewManagedWorktreePathContext(req.ActiveSettings.Worktrees.BaseDir, currentWorktreeRoot)
+	if err != nil {
+		return AgentRuntimePlan{}, err
+	}
 	return NewAgentRuntimePlan(AgentRuntimePlanOptions{
-		Settings:               req.ActiveSettings,
-		EnabledTools:           enabledTools,
-		Workdir:                target.EffectiveWorkdir,
-		ManagedWorktreeBaseDir: req.ActiveSettings.Worktrees.BaseDir,
-		CurrentWorktreeRoot: func() string {
-			if target.Worktree == nil {
-				return ""
-			}
-			return target.Worktree.Root
-		}(),
-		Sources:                  req.Source.Sources,
-		FastMode:                 s.fastModeState,
-		ClientFactory:            s.runtimeClientFactory,
-		StartLogLines:            startLogLines,
-		RecoveredWarningProvider: s.recoveredWarningProvider,
+		Settings:                   req.ActiveSettings,
+		EnabledTools:               enabledTools,
+		Workdir:                    target.EffectiveWorkdir,
+		ManagedWorktreePathContext: managedWorktreePathContext,
+		Sources:                    req.Source.Sources,
+		FastMode:                   s.fastModeState,
+		ClientFactory:              s.runtimeClientFactory,
+		StartLogLines:              startLogLines,
+		RecoveredWarningProvider:   s.recoveredWarningProvider,
 	})
 }
 

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -135,9 +135,16 @@ func (s *API) interactiveRuntimePlan(ctx context.Context, req serverapi.SessionR
 		startLogLines = append(startLogLines, "config.source "+line)
 	}
 	return NewAgentRuntimePlan(AgentRuntimePlanOptions{
-		Settings:                 req.ActiveSettings,
-		EnabledTools:             enabledTools,
-		Workdir:                  target.EffectiveWorkdir,
+		Settings:               req.ActiveSettings,
+		EnabledTools:           enabledTools,
+		Workdir:                target.EffectiveWorkdir,
+		ManagedWorktreeBaseDir: req.ActiveSettings.Worktrees.BaseDir,
+		CurrentWorktreeRoot: func() string {
+			if target.Worktree == nil {
+				return ""
+			}
+			return target.Worktree.Root
+		}(),
 		Sources:                  req.Source.Sources,
 		FastMode:                 s.fastModeState,
 		ClientFactory:            s.runtimeClientFactory,

--- a/server/sessionruntime/service.go
+++ b/server/sessionruntime/service.go
@@ -140,9 +140,12 @@ func (s *API) interactiveRuntimePlan(ctx context.Context, req serverapi.SessionR
 		root := target.Worktree.Root
 		currentWorktreeRoot = &root
 	}
-	managedWorktreePathContext, err := tools.NewManagedWorktreePathContext(req.ActiveSettings.Worktrees.BaseDir, currentWorktreeRoot)
-	if err != nil {
-		return AgentRuntimePlan{}, err
+	var managedWorktreePathContext *tools.ManagedWorktreePathContext
+	if strings.TrimSpace(req.ActiveSettings.Worktrees.BaseDir) != "" {
+		managedWorktreePathContext, err = tools.NewManagedWorktreePathContext(req.ActiveSettings.Worktrees.BaseDir, currentWorktreeRoot)
+		if err != nil {
+			return AgentRuntimePlan{}, err
+		}
 	}
 	return NewAgentRuntimePlan(AgentRuntimePlanOptions{
 		Settings:                   req.ActiveSettings,

--- a/server/tools/edit/options.go
+++ b/server/tools/edit/options.go
@@ -1,10 +1,6 @@
 package edit
 
-import (
-	"strings"
-
-	"core/server/tools"
-)
+import "core/server/tools"
 
 type Option func(*Tool)
 
@@ -26,15 +22,8 @@ func WithPathDenyPolicy(policy tools.PathDenyPolicy) Option {
 	}
 }
 
-func WithManagedWorktreePathContext(baseDir string, currentWorktreeRoot string) Option {
+func WithManagedWorktreePathContext(context *tools.ManagedWorktreePathContext) Option {
 	return func(t *Tool) {
-		if strings.TrimSpace(baseDir) == "" {
-			return
-		}
-		context, err := tools.NewManagedWorktreePathContext(baseDir, currentWorktreeRoot)
-		if err != nil {
-			panic(err)
-		}
-		t.managedWorktreePathContext = &context
+		t.managedWorktreePathContext = context
 	}
 }

--- a/server/tools/edit/options.go
+++ b/server/tools/edit/options.go
@@ -1,6 +1,10 @@
 package edit
 
-import "core/server/tools"
+import (
+	"strings"
+
+	"core/server/tools"
+)
 
 type Option func(*Tool)
 
@@ -19,5 +23,18 @@ func WithOutsideWorkspaceApprover(approver tools.FSGuardApprover) Option {
 func WithPathDenyPolicy(policy tools.PathDenyPolicy) Option {
 	return func(t *Tool) {
 		t.pathDenyPolicy = policy
+	}
+}
+
+func WithManagedWorktreePathContext(baseDir string, currentWorktreeRoot string) Option {
+	return func(t *Tool) {
+		if strings.TrimSpace(baseDir) == "" {
+			return
+		}
+		context, err := tools.NewManagedWorktreePathContext(baseDir, currentWorktreeRoot)
+		if err != nil {
+			panic(err)
+		}
+		t.managedWorktreePathContext = &context
 	}
 }

--- a/server/tools/edit/tool.go
+++ b/server/tools/edit/tool.go
@@ -32,6 +32,7 @@ type Tool struct {
 	outsideWorkspaceSessionMu    sync.RWMutex
 	outsideWorkspaceSessionAllow bool
 	pathDenyPolicy               tools.PathDenyPolicy
+	managedWorktreePathContext   *tools.ManagedWorktreePathContext
 }
 
 type resolvedPath struct {
@@ -80,7 +81,11 @@ func (t *Tool) Call(ctx context.Context, c tools.Call) (tools.Result, error) {
 	if resolved.symlink {
 		message = "ok; warning: edited through symlink, real path is " + resolved.real + "; use that path directly next time"
 	}
-	return editSuccessResult(c, message), nil
+	result := editSuccessResult(c, message)
+	if t.managedWorktreePathContext != nil && t.managedWorktreePathContext.WarnsFor(in.Path, resolved.real) {
+		result.ModelWarnings = []tools.ModelWarning{tools.ForeignManagedWorktreeEditWarning()}
+	}
+	return result, nil
 }
 
 func (t *Tool) apply(ctx context.Context, path resolvedPath, in tools.EditInput) error {

--- a/server/tools/edit/tool_test.go
+++ b/server/tools/edit/tool_test.go
@@ -45,7 +45,11 @@ func TestSuccessfulAbsoluteForeignManagedWorktreeEditWarns(t *testing.T) {
 	}
 	foreignFile := filepath.Join(foreignRoot, "foreign.txt")
 	writeEditTestFile(t, foreignFile, "before\n", 0o644)
-	tool := newTestTool(t, filepath.Join(currentRoot, "nested"), WithManagedWorktreePathContext(base, currentRoot))
+	context, err := tools.NewManagedWorktreePathContext(base, &currentRoot)
+	if err != nil {
+		t.Fatalf("managed worktree path context: %v", err)
+	}
+	tool := newTestTool(t, filepath.Join(currentRoot, "nested"), WithManagedWorktreePathContext(context))
 
 	result := callEdit(t, tool, map[string]any{
 		"path":       foreignFile,
@@ -79,7 +83,11 @@ func TestEditManagedWorktreeWarningSkipsNonForeignOrFailedTargets(t *testing.T) 
 	writeEditTestFile(t, currentFile, "before\n", 0o644)
 	writeEditTestFile(t, foreignFile, "before\n", 0o644)
 	writeEditTestFile(t, outsideFile, "before\n", 0o644)
-	tool := newTestTool(t, filepath.Join(currentRoot, "nested"), WithManagedWorktreePathContext(base, currentRoot), WithAllowOutsideWorkspace(true))
+	context, err := tools.NewManagedWorktreePathContext(base, &currentRoot)
+	if err != nil {
+		t.Fatalf("managed worktree path context: %v", err)
+	}
+	tool := newTestTool(t, filepath.Join(currentRoot, "nested"), WithManagedWorktreePathContext(context), WithAllowOutsideWorkspace(true))
 
 	tests := []struct {
 		name    string

--- a/server/tools/edit/tool_test.go
+++ b/server/tools/edit/tool_test.go
@@ -31,6 +31,85 @@ func TestCreateMissingFileReturnsJSONString(t *testing.T) {
 	}
 }
 
+func TestSuccessfulAbsoluteForeignManagedWorktreeEditWarns(t *testing.T) {
+	base := t.TempDir()
+	currentRoot := filepath.Join(base, "current")
+	foreignRoot := filepath.Join(base, "foreign")
+	for _, dir := range []string{currentRoot, foreignRoot} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(currentRoot, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir nested workdir: %v", err)
+	}
+	foreignFile := filepath.Join(foreignRoot, "foreign.txt")
+	writeEditTestFile(t, foreignFile, "before\n", 0o644)
+	tool := newTestTool(t, filepath.Join(currentRoot, "nested"), WithManagedWorktreePathContext(base, currentRoot))
+
+	result := callEdit(t, tool, map[string]any{
+		"path":       foreignFile,
+		"old_string": "before",
+		"new_string": "after",
+	})
+
+	requireEditSuccess(t, result)
+	if len(result.ModelWarnings) != 1 || result.ModelWarnings[0].Kind != tools.ModelWarningForeignManagedWorktreeEdit {
+		t.Fatalf("managed worktree warning = %+v", result.ModelWarnings)
+	}
+	assertEditTestFileContent(t, foreignFile, "after\n")
+}
+
+func TestEditManagedWorktreeWarningSkipsNonForeignOrFailedTargets(t *testing.T) {
+	base := t.TempDir()
+	currentRoot := filepath.Join(base, "current")
+	foreignRoot := filepath.Join(base, "foreign")
+	outsideRoot := t.TempDir()
+	for _, dir := range []string{currentRoot, foreignRoot} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(currentRoot, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir nested workdir: %v", err)
+	}
+	currentFile := filepath.Join(currentRoot, "current.txt")
+	foreignFile := filepath.Join(foreignRoot, "foreign.txt")
+	outsideFile := filepath.Join(outsideRoot, "outside.txt")
+	writeEditTestFile(t, currentFile, "before\n", 0o644)
+	writeEditTestFile(t, foreignFile, "before\n", 0o644)
+	writeEditTestFile(t, outsideFile, "before\n", 0o644)
+	tool := newTestTool(t, filepath.Join(currentRoot, "nested"), WithManagedWorktreePathContext(base, currentRoot), WithAllowOutsideWorkspace(true))
+
+	tests := []struct {
+		name    string
+		path    string
+		old     string
+		new     string
+		isError bool
+	}{
+		{name: "relative current", path: filepath.Join("..", "current.txt"), old: "before", new: "after"},
+		{name: "absolute current", path: currentFile, old: "after", new: "again"},
+		{name: "absolute outside managed base", path: outsideFile, old: "before", new: "after"},
+		{name: "failed foreign", path: foreignFile, old: "missing", new: "after", isError: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := callEdit(t, tool, map[string]any{
+				"path":       tc.path,
+				"old_string": tc.old,
+				"new_string": tc.new,
+			})
+			if result.IsError != tc.isError {
+				t.Fatalf("error = %t, want %t; result=%q", result.IsError, tc.isError, toolResultText(t, result))
+			}
+			if len(result.ModelWarnings) != 0 {
+				t.Fatalf("unexpected managed worktree warning: %+v", result.ModelWarnings)
+			}
+		})
+	}
+}
+
 func TestExactReplaceAndReplaceAll(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "a.txt")

--- a/server/tools/managed_worktree_path.go
+++ b/server/tools/managed_worktree_path.go
@@ -40,6 +40,25 @@ func (c ManagedWorktreePathContext) WarnsFor(requestedPath string, resolvedPath 
 	return c.currentRoot == nil || !pathWithin(*c.currentRoot, resolvedPath)
 }
 
+func (c *ManagedWorktreePathContext) WithCurrentWorktreeRoot(currentWorktreeRoot *string) (*ManagedWorktreePathContext, error) {
+	if c == nil {
+		return nil, nil
+	}
+	next := &ManagedWorktreePathContext{baseRoot: c.baseRoot}
+	if currentWorktreeRoot == nil {
+		return next, nil
+	}
+	current, err := config.ResolveExistingPathRealPath(*currentWorktreeRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve current managed worktree root: %w", err)
+	}
+	if !pathWithin(c.baseRoot, current) {
+		return nil, fmt.Errorf("current managed worktree root %q is outside managed worktree base %q", current, c.baseRoot)
+	}
+	next.currentRoot = &current
+	return next, nil
+}
+
 func pathWithin(root string, path string) bool {
 	rootIdentity, err := config.CanonicalLexicalPathIdentity(root)
 	if err != nil {

--- a/server/tools/managed_worktree_path.go
+++ b/server/tools/managed_worktree_path.go
@@ -1,0 +1,54 @@
+package tools
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"core/shared/config"
+)
+
+type ManagedWorktreePathContext struct {
+	baseRoot    string
+	currentRoot string
+}
+
+func NewManagedWorktreePathContext(baseDir string, currentWorktreeRoot string) (ManagedWorktreePathContext, error) {
+	base, err := config.ResolveExistingPathRealPath(strings.TrimSpace(baseDir))
+	if err != nil {
+		return ManagedWorktreePathContext{}, fmt.Errorf("resolve managed worktree base: %w", err)
+	}
+	context := ManagedWorktreePathContext{baseRoot: base}
+	if strings.TrimSpace(currentWorktreeRoot) == "" {
+		return context, nil
+	}
+	current, err := config.ResolveExistingPathRealPath(currentWorktreeRoot)
+	if err != nil {
+		return ManagedWorktreePathContext{}, fmt.Errorf("resolve current managed worktree root: %w", err)
+	}
+	if !pathWithin(base, current) {
+		return ManagedWorktreePathContext{}, fmt.Errorf("current managed worktree root %q is outside managed worktree base %q", current, base)
+	}
+	context.currentRoot = current
+	return context, nil
+}
+
+func (c ManagedWorktreePathContext) WarnsFor(requestedPath string, resolvedPath string) bool {
+	if !filepath.IsAbs(requestedPath) || !pathWithin(c.baseRoot, resolvedPath) {
+		return false
+	}
+	return c.currentRoot == "" || !pathWithin(c.currentRoot, resolvedPath)
+}
+
+func pathWithin(root string, path string) bool {
+	rootIdentity, err := config.CanonicalLexicalPathIdentity(root)
+	if err != nil {
+		return false
+	}
+	pathIdentity, err := config.CanonicalLexicalPathIdentity(path)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(rootIdentity, pathIdentity)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}

--- a/server/tools/managed_worktree_path.go
+++ b/server/tools/managed_worktree_path.go
@@ -27,7 +27,7 @@ func NewManagedWorktreePathContext(baseDir string, currentWorktreeRoot *string) 
 		return nil, fmt.Errorf("resolve current managed worktree root: %w", err)
 	}
 	if !pathWithin(base, current) {
-		return nil, fmt.Errorf("current managed worktree root %q is outside managed worktree base %q", current, base)
+		return context, nil
 	}
 	context.currentRoot = &current
 	return context, nil
@@ -53,7 +53,7 @@ func (c *ManagedWorktreePathContext) WithCurrentWorktreeRoot(currentWorktreeRoot
 		return nil, fmt.Errorf("resolve current managed worktree root: %w", err)
 	}
 	if !pathWithin(c.baseRoot, current) {
-		return nil, fmt.Errorf("current managed worktree root %q is outside managed worktree base %q", current, c.baseRoot)
+		return next, nil
 	}
 	next.currentRoot = &current
 	return next, nil

--- a/server/tools/managed_worktree_path.go
+++ b/server/tools/managed_worktree_path.go
@@ -10,26 +10,26 @@ import (
 
 type ManagedWorktreePathContext struct {
 	baseRoot    string
-	currentRoot string
+	currentRoot *string
 }
 
-func NewManagedWorktreePathContext(baseDir string, currentWorktreeRoot string) (ManagedWorktreePathContext, error) {
+func NewManagedWorktreePathContext(baseDir string, currentWorktreeRoot *string) (*ManagedWorktreePathContext, error) {
 	base, err := config.ResolveExistingPathRealPath(strings.TrimSpace(baseDir))
 	if err != nil {
-		return ManagedWorktreePathContext{}, fmt.Errorf("resolve managed worktree base: %w", err)
+		return nil, fmt.Errorf("resolve managed worktree base: %w", err)
 	}
-	context := ManagedWorktreePathContext{baseRoot: base}
-	if strings.TrimSpace(currentWorktreeRoot) == "" {
+	context := &ManagedWorktreePathContext{baseRoot: base}
+	if currentWorktreeRoot == nil {
 		return context, nil
 	}
-	current, err := config.ResolveExistingPathRealPath(currentWorktreeRoot)
+	current, err := config.ResolveExistingPathRealPath(*currentWorktreeRoot)
 	if err != nil {
-		return ManagedWorktreePathContext{}, fmt.Errorf("resolve current managed worktree root: %w", err)
+		return nil, fmt.Errorf("resolve current managed worktree root: %w", err)
 	}
 	if !pathWithin(base, current) {
-		return ManagedWorktreePathContext{}, fmt.Errorf("current managed worktree root %q is outside managed worktree base %q", current, base)
+		return nil, fmt.Errorf("current managed worktree root %q is outside managed worktree base %q", current, base)
 	}
-	context.currentRoot = current
+	context.currentRoot = &current
 	return context, nil
 }
 
@@ -37,7 +37,7 @@ func (c ManagedWorktreePathContext) WarnsFor(requestedPath string, resolvedPath 
 	if !filepath.IsAbs(requestedPath) || !pathWithin(c.baseRoot, resolvedPath) {
 		return false
 	}
-	return c.currentRoot == "" || !pathWithin(c.currentRoot, resolvedPath)
+	return c.currentRoot == nil || !pathWithin(*c.currentRoot, resolvedPath)
 }
 
 func pathWithin(root string, path string) bool {

--- a/server/tools/model_warning.go
+++ b/server/tools/model_warning.go
@@ -1,0 +1,56 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type ModelWarningKind string
+
+const ModelWarningForeignManagedWorktreeEdit ModelWarningKind = "foreign_managed_worktree_edit"
+
+type ModelWarning struct {
+	Kind ModelWarningKind
+	Text string
+}
+
+const foreignManagedWorktreeEditWarning = "[You reached into another Kent worktree. Prefer using `kent worktree enter <selector>` to edit in that worktree]"
+
+func ForeignManagedWorktreeEditWarning() ModelWarning {
+	return ModelWarning{Kind: ModelWarningForeignManagedWorktreeEdit, Text: foreignManagedWorktreeEditWarning}
+}
+
+func MaterializeModelWarnings(result Result) Result {
+	if result.IsError || len(result.ModelWarnings) == 0 {
+		return result
+	}
+	lines := make([]string, 0, len(result.ModelWarnings))
+	for _, warning := range result.ModelWarnings {
+		if strings.TrimSpace(warning.Text) != "" {
+			lines = append(lines, warning.Text)
+		}
+	}
+	if len(lines) == 0 {
+		return result
+	}
+	warnings := strings.Join(lines, "\n")
+	var object map[string]json.RawMessage
+	if json.Unmarshal(result.Output, &object) == nil && object != nil {
+		object["warning"], _ = json.Marshal(warnings)
+		result.Output, _ = json.Marshal(object)
+	} else {
+		var text string
+		if json.Unmarshal(result.Output, &text) == nil {
+			result.Output, _ = json.Marshal(strings.TrimSpace(text) + "\n" + warnings)
+		} else {
+			result.Output, _ = json.Marshal(fmt.Sprintf("%s\n%s", strings.TrimSpace(string(result.Output)), warnings))
+		}
+	}
+	if result.Summary != nil {
+		summary := strings.TrimSpace(*result.Summary) + "\n" + warnings
+		result.Summary = &summary
+	}
+	result.ModelWarnings = nil
+	return result
+}

--- a/server/tools/model_warning_test.go
+++ b/server/tools/model_warning_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"core/shared/toolspec"
@@ -16,14 +17,17 @@ func TestMaterializeModelWarningsAppendsWarningToSuccessfulResult(t *testing.T) 
 			ForeignManagedWorktreeEditWarning(),
 		},
 	})
-	var output map[string]json.RawMessage
+	var output struct {
+		OK      bool   `json:"ok"`
+		Warning string `json:"warning"`
+	}
 	if err := json.Unmarshal(result.Output, &output); err != nil {
 		t.Fatalf("decode materialized result: %v", err)
 	}
-	if _, ok := output["ok"]; !ok {
+	if !output.OK {
 		t.Fatalf("original successful result was not preserved: %s", result.Output)
 	}
-	if _, ok := output["warning"]; !ok {
+	if strings.TrimSpace(output.Warning) == "" {
 		t.Fatalf("model warning was not materialized: %s", result.Output)
 	}
 	if len(result.ModelWarnings) != 0 {

--- a/server/tools/model_warning_test.go
+++ b/server/tools/model_warning_test.go
@@ -1,0 +1,32 @@
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+
+	"core/shared/toolspec"
+)
+
+func TestMaterializeModelWarningsAppendsWarningToSuccessfulResult(t *testing.T) {
+	result := MaterializeModelWarnings(Result{
+		CallID: "call",
+		Name:   toolspec.ToolPatch,
+		Output: json.RawMessage(`{"ok":true}`),
+		ModelWarnings: []ModelWarning{
+			ForeignManagedWorktreeEditWarning(),
+		},
+	})
+	var output map[string]json.RawMessage
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("decode materialized result: %v", err)
+	}
+	if _, ok := output["ok"]; !ok {
+		t.Fatalf("original successful result was not preserved: %s", result.Output)
+	}
+	if _, ok := output["warning"]; !ok {
+		t.Fatalf("model warning was not materialized: %s", result.Output)
+	}
+	if len(result.ModelWarnings) != 0 {
+		t.Fatalf("transient warnings remain after materialization: %+v", result.ModelWarnings)
+	}
+}

--- a/server/tools/patch/tool.go
+++ b/server/tools/patch/tool.go
@@ -28,6 +28,7 @@ type Tool struct {
 	outsideWorkspaceSessionMu    sync.RWMutex
 	outsideWorkspaceSessionAllow bool
 	pathDenyPolicy               tools.PathDenyPolicy
+	managedWorktreePathContext   *tools.ManagedWorktreePathContext
 }
 
 func New(workspaceRoot string, workspaceOnly bool, opts ...Option) (*Tool, error) {
@@ -74,6 +75,10 @@ func (t *Tool) Call(ctx context.Context, c tools.Call) (tools.Result, error) {
 			return json.Marshal(errorPayload(patchErr))
 		}), nil
 	}
+	warns, err := t.warnsForForeignManagedWorktree(doc)
+	if err != nil {
+		return tools.ErrorResult(c, err.Error()), nil
+	}
 	deletionFacts, err := t.apply(ctx, doc)
 	if err != nil {
 		return tools.ErrorResultWith(c, err.Error(), func(any) (json.RawMessage, error) {
@@ -86,12 +91,45 @@ func (t *Tool) Call(ctx context.Context, c tools.Call) (tools.Result, error) {
 		"operations": len(doc.Hunks),
 	})
 	result := tools.Result{CallID: c.ID, Name: c.Name, Output: body}
+	if warns {
+		result.ModelWarnings = []tools.ModelWarning{tools.ForeignManagedWorktreeEditWarning()}
+	}
 	if len(deletionFacts) > 0 {
 		result.PresentationDelta = &transcript.ToolResultPresentationDelta{
 			WholeFileDeletionFacts: deletionFacts,
 		}
 	}
 	return result, nil
+}
+
+func (t *Tool) warnsForForeignManagedWorktree(doc patchformat.Document) (bool, error) {
+	if t.managedWorktreePathContext == nil {
+		return false, nil
+	}
+	for _, hunk := range doc.Hunks {
+		paths := make([]string, 0, 2)
+		switch op := hunk.(type) {
+		case patchformat.AddFile:
+			paths = append(paths, op.Path)
+		case patchformat.DeleteFile:
+			paths = append(paths, op.Path)
+		case patchformat.UpdateFile:
+			paths = append(paths, op.Path)
+			if strings.TrimSpace(op.MoveTo) != "" {
+				paths = append(paths, op.MoveTo)
+			}
+		}
+		for _, path := range paths {
+			resolved, err := t.resolvePathTarget(path, false)
+			if err != nil {
+				return false, err
+			}
+			if t.managedWorktreePathContext.WarnsFor(path, resolved) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func (t *Tool) apply(

--- a/server/tools/patch/tool_paths.go
+++ b/server/tools/patch/tool_paths.go
@@ -42,16 +42,9 @@ func WithPathDenyPolicy(policy tools.PathDenyPolicy) Option {
 	}
 }
 
-func WithManagedWorktreePathContext(baseDir string, currentWorktreeRoot string) Option {
+func WithManagedWorktreePathContext(context *tools.ManagedWorktreePathContext) Option {
 	return func(t *Tool) {
-		if strings.TrimSpace(baseDir) == "" {
-			return
-		}
-		context, err := tools.NewManagedWorktreePathContext(baseDir, currentWorktreeRoot)
-		if err != nil {
-			panic(err)
-		}
-		t.managedWorktreePathContext = &context
+		t.managedWorktreePathContext = context
 	}
 }
 

--- a/server/tools/patch/tool_paths.go
+++ b/server/tools/patch/tool_paths.go
@@ -42,6 +42,19 @@ func WithPathDenyPolicy(policy tools.PathDenyPolicy) Option {
 	}
 }
 
+func WithManagedWorktreePathContext(baseDir string, currentWorktreeRoot string) Option {
+	return func(t *Tool) {
+		if strings.TrimSpace(baseDir) == "" {
+			return
+		}
+		context, err := tools.NewManagedWorktreePathContext(baseDir, currentWorktreeRoot)
+		if err != nil {
+			panic(err)
+		}
+		t.managedWorktreePathContext = &context
+	}
+}
+
 const outsideWorkspaceRejectionInstruction = "If it's essential to the task, ask the user to make the edit manually at the end of the task."
 
 func (t *Tool) resolvePath(ctx context.Context, path string, mustExist bool, approvedOutside map[string]bool) (string, error) {

--- a/server/tools/patch/tool_test.go
+++ b/server/tools/patch/tool_test.go
@@ -48,7 +48,11 @@ func TestSuccessfulAbsoluteForeignManagedWorktreePatchWarnsForMoveDestination(t 
 	if err := os.WriteFile(source, []byte("before\n"), 0o644); err != nil {
 		t.Fatalf("write source: %v", err)
 	}
-	tool := newPatchTestTool(t, filepath.Join(currentRoot, "nested"), WithManagedWorktreePathContext(base, currentRoot))
+	context, err := tools.NewManagedWorktreePathContext(base, &currentRoot)
+	if err != nil {
+		t.Fatalf("managed worktree path context: %v", err)
+	}
+	tool := newPatchTestTool(t, filepath.Join(currentRoot, "nested"), WithManagedWorktreePathContext(context))
 
 	result := callPatch(t, tool, "foreign-move", "*** Begin Patch\n*** Update File: "+source+"\n*** Move to: "+destination+"\n-before\n+after\n*** End Patch\n")
 
@@ -88,7 +92,11 @@ func TestPatchManagedWorktreeWarningSkipsRelativeCurrentOutsideAndFailures(t *te
 			t.Fatalf("write %s: %v", path, err)
 		}
 	}
-	tool := newPatchTestTool(t, filepath.Join(currentRoot, "nested"), WithManagedWorktreePathContext(base, currentRoot), WithAllowOutsideWorkspace(true))
+	context, err := tools.NewManagedWorktreePathContext(base, &currentRoot)
+	if err != nil {
+		t.Fatalf("managed worktree path context: %v", err)
+	}
+	tool := newPatchTestTool(t, filepath.Join(currentRoot, "nested"), WithManagedWorktreePathContext(context), WithAllowOutsideWorkspace(true))
 
 	tests := []struct {
 		name    string

--- a/server/tools/patch/tool_test.go
+++ b/server/tools/patch/tool_test.go
@@ -2,7 +2,9 @@ package patch
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -10,6 +12,7 @@ import (
 	"testing"
 
 	"core/internal/testharness/filemode"
+	"core/server/tools"
 )
 
 func TestNewMissingWorkspaceSuggestsRebind(t *testing.T) {
@@ -26,6 +29,99 @@ func TestNewMissingWorkspaceSuggestsRebind(t *testing.T) {
 	if got := err.Error(); got != want {
 		t.Fatalf("error = %q, want %q", got, want)
 	}
+}
+
+func TestSuccessfulAbsoluteForeignManagedWorktreePatchWarnsForMoveDestination(t *testing.T) {
+	base := t.TempDir()
+	currentRoot := filepath.Join(base, "current")
+	foreignRoot := filepath.Join(base, "foreign")
+	for _, dir := range []string{currentRoot, foreignRoot} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(currentRoot, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir nested workdir: %v", err)
+	}
+	source := filepath.Join(currentRoot, "source.txt")
+	destination := filepath.Join(foreignRoot, "destination.txt")
+	if err := os.WriteFile(source, []byte("before\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	tool := newPatchTestTool(t, filepath.Join(currentRoot, "nested"), WithManagedWorktreePathContext(base, currentRoot))
+
+	result := callPatch(t, tool, "foreign-move", "*** Begin Patch\n*** Update File: "+source+"\n*** Move to: "+destination+"\n-before\n+after\n*** End Patch\n")
+
+	if result.IsError {
+		t.Fatalf("expected success, got %s", string(result.Output))
+	}
+	if len(result.ModelWarnings) != 1 || result.ModelWarnings[0].Kind != tools.ModelWarningForeignManagedWorktreeEdit {
+		t.Fatalf("managed worktree warning = %+v", result.ModelWarnings)
+	}
+	data, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if string(data) != "after\n" {
+		t.Fatalf("destination = %q, want after", data)
+	}
+}
+
+func TestPatchManagedWorktreeWarningSkipsRelativeCurrentOutsideAndFailures(t *testing.T) {
+	base := t.TempDir()
+	currentRoot := filepath.Join(base, "current")
+	foreignRoot := filepath.Join(base, "foreign")
+	outsideRoot := t.TempDir()
+	for _, dir := range []string{currentRoot, foreignRoot} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(currentRoot, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir nested workdir: %v", err)
+	}
+	current := filepath.Join(currentRoot, "current.txt")
+	foreign := filepath.Join(foreignRoot, "foreign.txt")
+	outside := filepath.Join(outsideRoot, "outside.txt")
+	for _, path := range []string{current, foreign, outside} {
+		if err := os.WriteFile(path, []byte("before\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	tool := newPatchTestTool(t, filepath.Join(currentRoot, "nested"), WithManagedWorktreePathContext(base, currentRoot), WithAllowOutsideWorkspace(true))
+
+	tests := []struct {
+		name    string
+		path    string
+		old     string
+		new     string
+		isError bool
+	}{
+		{name: "relative current", path: "../current.txt", old: "before", new: "after"},
+		{name: "absolute current", path: current, old: "after", new: "again"},
+		{name: "absolute outside managed base", path: outside, old: "before", new: "after"},
+		{name: "failed foreign", path: foreign, old: "missing", new: "after", isError: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := callPatch(t, tool, "skip-"+tc.name, "*** Begin Patch\n*** Update File: "+tc.path+"\n-"+tc.old+"\n+"+tc.new+"\n*** End Patch\n")
+			if result.IsError != tc.isError {
+				t.Fatalf("error = %t, want %t; result=%q", result.IsError, tc.isError, patchResultText(t, result))
+			}
+			if len(result.ModelWarnings) != 0 {
+				t.Fatalf("unexpected managed worktree warning: %+v", result.ModelWarnings)
+			}
+		})
+	}
+}
+
+func patchResultText(t *testing.T, result tools.Result) string {
+	t.Helper()
+	var value any
+	if err := json.Unmarshal(result.Output, &value); err != nil {
+		t.Fatalf("decode patch result: %v", err)
+	}
+	return fmt.Sprint(value)
 }
 
 func TestDeleteParticipatesInAtomicPatchCommit(t *testing.T) {

--- a/server/tools/patch/tool_test.go
+++ b/server/tools/patch/tool_test.go
@@ -71,6 +71,47 @@ func TestSuccessfulAbsoluteForeignManagedWorktreePatchWarnsForMoveDestination(t 
 	}
 }
 
+func TestPatchWarnsForEveryForeignAbsoluteTargetKind(t *testing.T) {
+	base := t.TempDir()
+	currentRoot := filepath.Join(base, "current")
+	foreignRoot := filepath.Join(base, "foreign")
+	for _, dir := range []string{currentRoot, foreignRoot, filepath.Join(currentRoot, "nested")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	context, err := tools.NewManagedWorktreePathContext(base, &currentRoot)
+	if err != nil {
+		t.Fatalf("managed worktree path context: %v", err)
+	}
+	tool := newPatchTestTool(t, filepath.Join(currentRoot, "nested"), WithManagedWorktreePathContext(context))
+	update := filepath.Join(foreignRoot, "update.txt")
+	deletePath := filepath.Join(foreignRoot, "delete.txt")
+	moveSource := filepath.Join(foreignRoot, "move.txt")
+	for _, path := range []string{update, deletePath, moveSource} {
+		if err := os.WriteFile(path, []byte("before\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	tests := []struct {
+		name  string
+		patch string
+	}{
+		{name: "add", patch: "*** Begin Patch\n*** Add File: " + filepath.Join(foreignRoot, "added.txt") + "\n+after\n*** End Patch\n"},
+		{name: "update", patch: "*** Begin Patch\n*** Update File: " + update + "\n-before\n+after\n*** End Patch\n"},
+		{name: "delete", patch: "*** Begin Patch\n*** Delete File: " + deletePath + "\n*** End Patch\n"},
+		{name: "move source", patch: "*** Begin Patch\n*** Update File: " + moveSource + "\n*** Move to: " + filepath.Join(currentRoot, "moved.txt") + "\n-before\n+after\n*** End Patch\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := callPatch(t, tool, "foreign-"+test.name, test.patch)
+			if result.IsError || len(result.ModelWarnings) != 1 || result.ModelWarnings[0].Kind != tools.ModelWarningForeignManagedWorktreeEdit {
+				t.Fatalf("foreign %s result = %+v", test.name, result)
+			}
+		})
+	}
+}
+
 func TestPatchManagedWorktreeWarningSkipsRelativeCurrentOutsideAndFailures(t *testing.T) {
 	base := t.TempDir()
 	currentRoot := filepath.Join(base, "current")

--- a/server/tools/types.go
+++ b/server/tools/types.go
@@ -44,6 +44,7 @@ type Result struct {
 	Terminal      bool                     `json:"terminal,omitempty"`
 	Summary       *string                  `json:"summary,omitempty"`
 	CondensedText *string                  `json:"condensed_text,omitempty"`
+	ModelWarnings []ModelWarning           `json:"-"`
 	Presentation  *transcript.ToolCallMeta `json:"presentation,omitempty"`
 	// PresentationDelta is transient handler output. Runtime consumes it before
 	// persistence and materializes Presentation from authoritative call input.

--- a/server/workflowrunner/starter.go
+++ b/server/workflowrunner/starter.go
@@ -1123,9 +1123,16 @@ func (s *Starter) startAgentExecution(ctx context.Context, req workflowexecution
 		return err
 	}
 	runtimePlan, err := sessionruntime.NewAgentRuntimePlan(sessionruntime.AgentRuntimePlanOptions{
-		Settings:                            plan.ActiveSettings,
-		EnabledTools:                        workflowRuntimeEnabledTools(plan.EnabledTools),
-		Workdir:                             executionRoot.EffectiveRoot(),
+		Settings:               plan.ActiveSettings,
+		EnabledTools:           workflowRuntimeEnabledTools(plan.EnabledTools),
+		Workdir:                executionRoot.EffectiveRoot(),
+		ManagedWorktreeBaseDir: s.cfg.Settings.Worktrees.BaseDir,
+		CurrentWorktreeRoot: func() string {
+			if executionRoot.Managed == nil {
+				return ""
+			}
+			return executionRoot.Managed.Root
+		}(),
 		Sources:                             plan.Source.Sources,
 		Headless:                            true,
 		Client:                              client,

--- a/server/workflowrunner/starter.go
+++ b/server/workflowrunner/starter.go
@@ -1127,9 +1127,12 @@ func (s *Starter) startAgentExecution(ctx context.Context, req workflowexecution
 		root := executionRoot.Managed.Root
 		currentWorktreeRoot = &root
 	}
-	managedWorktreePathContext, err := askquestion.NewManagedWorktreePathContext(s.cfg.Settings.Worktrees.BaseDir, currentWorktreeRoot)
-	if err != nil {
-		return err
+	var managedWorktreePathContext *askquestion.ManagedWorktreePathContext
+	if strings.TrimSpace(s.cfg.Settings.Worktrees.BaseDir) != "" {
+		managedWorktreePathContext, err = askquestion.NewManagedWorktreePathContext(s.cfg.Settings.Worktrees.BaseDir, currentWorktreeRoot)
+		if err != nil {
+			return err
+		}
 	}
 	runtimePlan, err := sessionruntime.NewAgentRuntimePlan(sessionruntime.AgentRuntimePlanOptions{
 		Settings:                            plan.ActiveSettings,

--- a/server/workflowrunner/starter.go
+++ b/server/workflowrunner/starter.go
@@ -1122,17 +1122,20 @@ func (s *Starter) startAgentExecution(ctx context.Context, req workflowexecution
 	if err != nil {
 		return err
 	}
+	var currentWorktreeRoot *string
+	if executionRoot.Managed != nil {
+		root := executionRoot.Managed.Root
+		currentWorktreeRoot = &root
+	}
+	managedWorktreePathContext, err := askquestion.NewManagedWorktreePathContext(s.cfg.Settings.Worktrees.BaseDir, currentWorktreeRoot)
+	if err != nil {
+		return err
+	}
 	runtimePlan, err := sessionruntime.NewAgentRuntimePlan(sessionruntime.AgentRuntimePlanOptions{
-		Settings:               plan.ActiveSettings,
-		EnabledTools:           workflowRuntimeEnabledTools(plan.EnabledTools),
-		Workdir:                executionRoot.EffectiveRoot(),
-		ManagedWorktreeBaseDir: s.cfg.Settings.Worktrees.BaseDir,
-		CurrentWorktreeRoot: func() string {
-			if executionRoot.Managed == nil {
-				return ""
-			}
-			return executionRoot.Managed.Root
-		}(),
+		Settings:                            plan.ActiveSettings,
+		EnabledTools:                        workflowRuntimeEnabledTools(plan.EnabledTools),
+		Workdir:                             executionRoot.EffectiveRoot(),
+		ManagedWorktreePathContext:          managedWorktreePathContext,
 		Sources:                             plan.Source.Sources,
 		Headless:                            true,
 		Client:                              client,

--- a/server/workflowrunner/starter.go
+++ b/server/workflowrunner/starter.go
@@ -1128,8 +1128,8 @@ func (s *Starter) startAgentExecution(ctx context.Context, req workflowexecution
 		currentWorktreeRoot = &root
 	}
 	var managedWorktreePathContext *askquestion.ManagedWorktreePathContext
-	if strings.TrimSpace(s.cfg.Settings.Worktrees.BaseDir) != "" {
-		managedWorktreePathContext, err = askquestion.NewManagedWorktreePathContext(s.cfg.Settings.Worktrees.BaseDir, currentWorktreeRoot)
+	if strings.TrimSpace(plan.ActiveSettings.Worktrees.BaseDir) != "" {
+		managedWorktreePathContext, err = askquestion.NewManagedWorktreePathContext(plan.ActiveSettings.Worktrees.BaseDir, currentWorktreeRoot)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- warn after successful patch/edit operations that explicitly target another managed worktree
- classify paths from canonical facts and structured patch targets, including move destinations
- carry managed-worktree context through runtime setup and execution-target rebinds

## Verification
- `./scripts/test.sh ./server/tools/edit ./server/tools/patch`
- `go test ./server/sessionruntime ./server/runtimewire` is currently blocked after merging main: affected tests call config loading with the protected `/Users/nek/.kent` persistence root instead of an isolated test root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “foreign managed worktree” model warnings for both patch and edit operations, surfaced in tool results while edits/patches still complete successfully.
  * Worktree-aware warning behavior now follows execution-target changes and transition recovery.
* **Bug Fixes**
  * Improved managed worktree context setup, including validation of base/current worktree roots.
  * Enhanced rebind and rollback handling to preserve the correct managed worktree context when switching targets.
* **Tests**
  * Added unit/integration coverage for managed-worktree warning emission and warning materialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->