### PR TITLE
fix: preserve repaired tool step identity

### DIFF
--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -136,10 +136,20 @@ func newChatStoreWithCWD(cwd string) *chatStore {
 	}
 }
 
-func (s *chatStore) appendMessage(stepID string, msg llm.Message) {
+func (s *chatStore) validateMessage(stepID string, msg llm.Message) error {
+	msg = normalizeMessageForTranscript(msg, s.cwd)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.validateMessageLocked(stepID, msg)
+}
+
+func (s *chatStore) appendMessage(stepID string, msg llm.Message) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	msg = normalizeMessageForTranscript(msg, s.cwd)
+	if err := s.validateMessageLocked(stepID, msg); err != nil {
+		return err
+	}
 	s.messageRecords = append(s.messageRecords, chatMessageRecord{
 		StepID:        strings.TrimSpace(stepID),
 		Message:       cloneChatStoreMessage(msg),
@@ -148,6 +158,7 @@ func (s *chatStore) appendMessage(stepID string, msg llm.Message) {
 	s.applyMessageStatsLocked(stepID, msg)
 	s.placeAttachedLocalEntriesAfterMaterializedToolLocked(msg)
 	s.providerTokenEstimateDirty = true
+	return nil
 }
 func (s *chatStore) replaceHistory(stepID string, items []llm.ResponseItem) {
 	s.replaceHistoryAtCommittedEntryStart(stepID, items, nil)
@@ -716,6 +727,31 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
+func (s *chatStore) validateMessageLocked(stepID string, msg llm.Message) error {
+	if msg.Role != llm.RoleAssistant {
+		return nil
+	}
+	stepID = strings.TrimSpace(stepID)
+	if stepID == "" {
+		return nil
+	}
+	for _, call := range msg.ToolCalls {
+		callID := strings.TrimSpace(call.ID)
+		if callID == "" {
+			continue
+		}
+		if existing, present := s.assistantToolCallStepIDs[callID]; present && existing != stepID {
+			return fmt.Errorf(
+				"assistant tool call %q changed step identity from %q to %q",
+				callID,
+				existing,
+				stepID,
+			)
+		}
+	}
+	return nil
+}
+
 func (s *chatStore) applyMessageStatsLocked(stepID string, msg llm.Message) {
 	s.applyLastCommittedAssistantFinalAnswerLocked(msg)
 	delta := len(VisibleChatEntriesFromMessage(msg))
@@ -728,9 +764,6 @@ func (s *chatStore) applyMessageStatsLocked(stepID string, msg llm.Message) {
 				continue
 			}
 			if stepID != "" {
-				if existing, present := s.assistantToolCallStepIDs[callID]; present && existing != stepID {
-					panic(fmt.Sprintf("assistant tool call %q changed step identity from %q to %q", callID, existing, stepID))
-				}
 				s.assistantToolCallStepIDs[callID] = stepID
 			}
 			s.assistantToolCalls[callID] = struct{}{}

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -638,8 +638,13 @@ func (s *chatStore) danglingToolCalls() []danglingToolCall {
 			continue
 		}
 		name, _ := textutil.OptionalTrimmed(item.Name)
+		stepID, hasStepID := s.assistantToolCallStepIDs[callID]
+		var ownedStepID *string
+		if hasStepID {
+			ownedStepID = textutil.Value(stepID)
+		}
 		seen[callID] = struct{}{}
-		out = append(out, danglingToolCall{callID: callID, name: name, stepID: s.assistantToolCallStepIDs[callID]})
+		out = append(out, danglingToolCall{callID: callID, name: name, stepID: ownedStepID})
 	}
 	return out
 }
@@ -723,7 +728,7 @@ func (s *chatStore) applyMessageStatsLocked(stepID string, msg llm.Message) {
 				continue
 			}
 			if stepID != "" {
-				if existing := s.assistantToolCallStepIDs[callID]; existing != "" && existing != stepID {
+				if existing, present := s.assistantToolCallStepIDs[callID]; present && existing != stepID {
 					panic(fmt.Sprintf("assistant tool call %q changed step identity from %q to %q", callID, existing, stepID))
 				}
 				s.assistantToolCallStepIDs[callID] = stepID
@@ -765,7 +770,10 @@ func (s *chatStore) recordReplacementToolCallStepIDsLocked(stepID string, items 
 			continue
 		}
 		callID, present := textutil.FirstOptionalTrimmed(item.CallID, item.ID)
-		if !present || s.assistantToolCallStepIDs[callID] != "" {
+		if !present {
+			continue
+		}
+		if _, owned := s.assistantToolCallStepIDs[callID]; owned {
 			continue
 		}
 		s.assistantToolCallStepIDs[callID] = stepID

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -773,9 +773,9 @@ func (s *chatStore) recordReplacementToolCallStepIDsLocked(stepID string, items 
 		if !present {
 			continue
 		}
-		if _, owned := s.assistantToolCallStepIDs[callID]; owned {
-			continue
-		}
+		// Replacement items are born at the compaction boundary, which is also
+		// the only ownership fact available when the active segment is restored.
+		// Rebase live ownership to the same Step so restart cannot change it.
 		s.assistantToolCallStepIDs[callID] = stepID
 	}
 }

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -78,6 +78,7 @@ type chatStore struct {
 	toolCompletions                   map[string]tools.Result
 	toolCompletionProviderItems       map[string][]llm.ResponseItem
 	assistantToolCalls                map[string]struct{}
+	assistantToolCallStepIDs          map[string]string
 	materializedToolResults           map[string]struct{}
 	synthesizedToolResults            map[string]struct{}
 	assistantStreamIDsByEntry         map[int]uuid.UUID
@@ -127,6 +128,7 @@ func newChatStoreWithCWD(cwd string) *chatStore {
 		toolCompletions:             make(map[string]tools.Result, 16),
 		toolCompletionProviderItems: make(map[string][]llm.ResponseItem, 16),
 		assistantToolCalls:          make(map[string]struct{}, 16),
+		assistantToolCallStepIDs:    make(map[string]string, 16),
 		materializedToolResults:     make(map[string]struct{}, 16),
 		synthesizedToolResults:      make(map[string]struct{}, 16),
 		cwd:                         strings.TrimSpace(cwd),
@@ -143,7 +145,7 @@ func (s *chatStore) appendMessage(stepID string, msg llm.Message) {
 		Message:       cloneChatStoreMessage(msg),
 		ProviderItems: llm.ItemsFromMessages([]llm.Message{msg}),
 	})
-	s.applyMessageStatsLocked(msg)
+	s.applyMessageStatsLocked(stepID, msg)
 	s.placeAttachedLocalEntriesAfterMaterializedToolLocked(msg)
 	s.providerTokenEstimateDirty = true
 }
@@ -162,6 +164,7 @@ func (s *chatStore) replaceHistoryAtCommittedEntryStart(stepID string, items []l
 		activeSegmentEntryStart = *committedEntryStart
 	}
 	preparedItems := llm.PrepareOpenAIInputItems(items)
+	s.recordReplacementToolCallStepIDsLocked(stepID, preparedItems)
 	// Non-reviewer compaction keeps user-visible transcript history append-only by
 	// materializing replacement items as synthetic local entries at the compaction
 	// boundary while provider/model history switches to the compacted checkpoint.
@@ -194,6 +197,7 @@ func (s *chatStore) pruneToolCompletionsToWorkingSetLocked() {
 	if len(s.toolCompletions) == 0 &&
 		len(s.toolCompletionProviderItems) == 0 &&
 		len(s.assistantToolCalls) == 0 &&
+		len(s.assistantToolCallStepIDs) == 0 &&
 		len(s.materializedToolResults) == 0 &&
 		len(s.synthesizedToolResults) == 0 {
 		return
@@ -210,6 +214,7 @@ func (s *chatStore) pruneToolCompletionsToWorkingSetLocked() {
 	pruneCallIDMapToReferenced(s.toolCompletions, referenced)
 	pruneCallIDMapToReferenced(s.toolCompletionProviderItems, referenced)
 	pruneCallIDMapToReferenced(s.assistantToolCalls, referenced)
+	pruneCallIDMapToReferenced(s.assistantToolCallStepIDs, referenced)
 	pruneCallIDMapToReferenced(s.materializedToolResults, referenced)
 	pruneCallIDMapToReferenced(s.synthesizedToolResults, referenced)
 }
@@ -634,7 +639,7 @@ func (s *chatStore) danglingToolCalls() []danglingToolCall {
 		}
 		name, _ := textutil.OptionalTrimmed(item.Name)
 		seen[callID] = struct{}{}
-		out = append(out, danglingToolCall{callID: callID, name: name})
+		out = append(out, danglingToolCall{callID: callID, name: name, stepID: s.assistantToolCallStepIDs[callID]})
 	}
 	return out
 }
@@ -706,15 +711,22 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func (s *chatStore) applyMessageStatsLocked(msg llm.Message) {
+func (s *chatStore) applyMessageStatsLocked(stepID string, msg llm.Message) {
 	s.applyLastCommittedAssistantFinalAnswerLocked(msg)
 	delta := len(VisibleChatEntriesFromMessage(msg))
 	switch msg.Role {
 	case llm.RoleAssistant:
+		stepID = strings.TrimSpace(stepID)
 		for _, call := range msg.ToolCalls {
 			callID := strings.TrimSpace(call.ID)
 			if callID == "" {
 				continue
+			}
+			if stepID != "" {
+				if existing := s.assistantToolCallStepIDs[callID]; existing != "" && existing != stepID {
+					panic(fmt.Sprintf("assistant tool call %q changed step identity from %q to %q", callID, existing, stepID))
+				}
+				s.assistantToolCallStepIDs[callID] = stepID
 			}
 			s.assistantToolCalls[callID] = struct{}{}
 			if _, materialized := s.materializedToolResults[callID]; materialized {
@@ -740,6 +752,23 @@ func (s *chatStore) applyMessageStatsLocked(msg llm.Message) {
 	s.transcriptEntryCount += delta
 	if s.transcriptEntryCount < 0 {
 		s.transcriptEntryCount = 0
+	}
+}
+
+func (s *chatStore) recordReplacementToolCallStepIDsLocked(stepID string, items []llm.ResponseItem) {
+	stepID = strings.TrimSpace(stepID)
+	if stepID == "" {
+		return
+	}
+	for _, item := range items {
+		if !isToolCallItem(item.Type) {
+			continue
+		}
+		callID, present := textutil.FirstOptionalTrimmed(item.CallID, item.ID)
+		if !present || s.assistantToolCallStepIDs[callID] != "" {
+			continue
+		}
+		s.assistantToolCallStepIDs[callID] = stepID
 	}
 }
 

--- a/server/runtime/chat_store_test.go
+++ b/server/runtime/chat_store_test.go
@@ -96,7 +96,9 @@ func TestHistoryReplacementRebasesDanglingToolCallStepOwnership(t *testing.T) {
 	items := llm.ItemsFromMessages([]llm.Message{message})
 
 	live := newChatStoreWithCWD(t.TempDir())
-	live.appendMessage(chatStoreTestStepID, message)
+	if err := live.appendMessage(chatStoreTestStepID, message); err != nil {
+		t.Fatalf("append live message: %v", err)
+	}
 	live.replaceHistory(replacementStepID, items)
 
 	reopened := newChatStoreWithCWD(t.TempDir())
@@ -116,6 +118,73 @@ func TestHistoryReplacementRebasesDanglingToolCallStepOwnership(t *testing.T) {
 			)
 		}
 	}
+}
+
+func TestConflictingAssistantToolCallStepReturnsError(t *testing.T) {
+	const conflictingStepID = "22222222-2222-4222-8222-222222222222"
+	message := llm.Message{
+		Role: llm.RoleAssistant,
+		ToolCalls: []llm.ToolCall{{
+			ID:    "call-conflict",
+			Name:  string(toolspec.ToolExecCommand),
+			Input: json.RawMessage(`{}`),
+		}},
+	}
+
+	t.Run("before persistence", func(t *testing.T) {
+		store := mustCreateTestSession(t)
+		engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
+		intent := steerMessagesWithPersistenceIntent(
+			steeringPriorityNormal,
+			steeringMessageEventDefault,
+			true,
+			[]llm.Message{message},
+		)
+		if err := engine.steer(chatStoreTestStepID, intent); err != nil {
+			t.Fatalf("append initial tool call: %v", err)
+		}
+		before, err := mustMaterializeTestEventLog(t, store).ReadRecentRecords(16)
+		if err != nil {
+			t.Fatalf("read records before conflict: %v", err)
+		}
+
+		if err := engine.steer(conflictingStepID, intent); err == nil {
+			t.Fatal("conflicting tool-call Step identity was accepted")
+		}
+		after, err := mustMaterializeTestEventLog(t, store).ReadRecentRecords(16)
+		if err != nil {
+			t.Fatalf("read records after conflict: %v", err)
+		}
+		if len(after.Records) != len(before.Records) {
+			t.Fatalf(
+				"conflicting tool call persisted records: before=%d after=%d",
+				len(before.Records),
+				len(after.Records),
+			)
+		}
+	})
+
+	t.Run("restore", func(t *testing.T) {
+		store := mustCreateTestSession(t)
+		for _, stepID := range []string{chatStoreTestStepID, conflictingStepID} {
+			if _, _, err := appendTestEvent(t, store, stepID, message); err != nil {
+				t.Fatalf("append conflicting persisted tool call: %v", err)
+			}
+		}
+		engine, err := New(
+			store,
+			mustMaterializeTestEventLog(t, store),
+			&fakeClient{},
+			tools.NewRegistry(),
+			Config{Model: "gpt-5"},
+		)
+		if err == nil {
+			if closeErr := engine.Close(); closeErr != nil {
+				t.Fatalf("close unexpectedly restored engine: %v", closeErr)
+			}
+			t.Fatal("restored conflicting tool-call Step identity")
+		}
+	})
 }
 
 func assertHistoryReplacementTail(t *testing.T, items []llm.ResponseItem) {

--- a/server/runtime/chat_store_test.go
+++ b/server/runtime/chat_store_test.go
@@ -83,6 +83,41 @@ func TestBuildRequestUsesLatestHistoryReplacementAndActiveTail(t *testing.T) {
 	}
 }
 
+func TestHistoryReplacementRebasesDanglingToolCallStepOwnership(t *testing.T) {
+	const replacementStepID = "22222222-2222-4222-8222-222222222222"
+	message := llm.Message{
+		Role: llm.RoleAssistant,
+		ToolCalls: []llm.ToolCall{{
+			ID:    "call-rebased",
+			Name:  string(toolspec.ToolExecCommand),
+			Input: json.RawMessage(`{}`),
+		}},
+	}
+	items := llm.ItemsFromMessages([]llm.Message{message})
+
+	live := newChatStoreWithCWD(t.TempDir())
+	live.appendMessage(chatStoreTestStepID, message)
+	live.replaceHistory(replacementStepID, items)
+
+	reopened := newChatStoreWithCWD(t.TempDir())
+	reopened.replaceHistory(replacementStepID, items)
+
+	for name, chat := range map[string]*chatStore{"live": live, "reopened": reopened} {
+		dangling := chat.danglingToolCalls()
+		if len(dangling) != 1 {
+			t.Fatalf("%s dangling calls = %+v, want one", name, dangling)
+		}
+		if dangling[0].stepID == nil || *dangling[0].stepID != replacementStepID {
+			t.Fatalf(
+				"%s dangling call step = %v, want replacement step %q",
+				name,
+				dangling[0].stepID,
+				replacementStepID,
+			)
+		}
+	}
+}
+
 func assertHistoryReplacementTail(t *testing.T, items []llm.ResponseItem) {
 	t.Helper()
 	if len(items) != 3 {

--- a/server/runtime/compaction.go
+++ b/server/runtime/compaction.go
@@ -636,10 +636,10 @@ func (e *Engine) compactNow(ctx context.Context, stepID string, mode compactionM
 	if enginePlan.engineKind == compactionEngineRemote {
 		result, err = e.compactRemote(ctx, stepID, input, providerID, instructions)
 		if err != nil && enginePlan.fallbackToLocalOnBadCheckpoint && errors.Is(err, errRemoteCompactionMissingCheckpoint) {
-			result, err = e.compactLocal(ctx, input, providerID, instructions, mode)
+			result, err = e.compactLocal(ctx, stepID, input, providerID, instructions, mode)
 		}
 	} else {
-		result, err = e.compactLocal(ctx, input, providerID, instructions, mode)
+		result, err = e.compactLocal(ctx, stepID, input, providerID, instructions, mode)
 	}
 	if err != nil {
 		statusErr := newCompactionPersistence(e).emitStatus(stepID, EventCompactionFailed, mode, result.engine, providerID, result.trimmedItemsCount, 0, err.Error())

--- a/server/runtime/compaction_executor.go
+++ b/server/runtime/compaction_executor.go
@@ -92,7 +92,7 @@ func (e *Engine) compactWithContextRepairRetry(
 		if !canRepair {
 			panic(missingToolOutputAfterCollapseInvariant)
 		}
-		repaired, repairErr := e.repairMissingToolOutputsByAppending(stepID)
+		repaired, repairErr := e.repairMissingToolOutputsByAppending(textutil.OptionalTrimmedString(stepID))
 		if repairErr != nil {
 			return resp, items, errors.Join(err, repairErr)
 		}
@@ -214,8 +214,14 @@ func (e *Engine) compactionCacheObservationRequest(ctx context.Context, request 
 	return req, true, nil
 }
 
-func (e *Engine) compactLocal(ctx context.Context, input []llm.ResponseItem, providerID string, instructions string, mode compactionMode) (compactionResult, error) {
-	summary, repairStats, err := e.localCompactionSummaryWithRepair(ctx, input, instructions, mode)
+func (e *Engine) compactLocal(ctx context.Context, stepID string, input []llm.ResponseItem, providerID string, instructions string, mode compactionMode) (compactionResult, error) {
+	summary, repairStats, err := e.localCompactionSummaryWithRepair(
+		ctx,
+		textutil.OptionalTrimmedString(stepID),
+		input,
+		instructions,
+		mode,
+	)
 	if err != nil {
 		return compactionResult{}, err
 	}
@@ -239,11 +245,11 @@ func (e *Engine) compactLocal(ctx context.Context, input []llm.ResponseItem, pro
 }
 
 func (e *Engine) localCompactionSummary(ctx context.Context, input []llm.ResponseItem, instructions string, mode compactionMode) (string, error) {
-	summary, _, err := e.localCompactionSummaryWithRepair(ctx, input, instructions, mode)
+	summary, _, err := e.localCompactionSummaryWithRepair(ctx, nil, input, instructions, mode)
 	return summary, err
 }
 
-func (e *Engine) localCompactionSummaryWithRepair(ctx context.Context, input []llm.ResponseItem, instructions string, mode compactionMode) (string, compactionOverflowRepairStats, error) {
+func (e *Engine) localCompactionSummaryWithRepair(ctx context.Context, repairStepID *string, input []llm.ResponseItem, instructions string, mode compactionMode) (string, compactionOverflowRepairStats, error) {
 	locked, err := e.ensureLocked()
 	if err != nil {
 		return "", compactionOverflowRepairStats{}, err
@@ -275,7 +281,7 @@ func (e *Engine) localCompactionSummaryWithRepair(ctx context.Context, input []l
 		if !canRepair {
 			panic(missingToolOutputAfterCollapseInvariant)
 		}
-		repaired, repairErr := e.repairMissingToolOutputsByAppending("")
+		repaired, repairErr := e.repairMissingToolOutputsByAppending(repairStepID)
 		if repairErr != nil {
 			return "", w, errors.Join(err, repairErr)
 		}

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -884,7 +884,7 @@ func (e *Engine) generateWithMissingToolOutputRepair(ctx context.Context, stepID
 		if emitted.Load() && onAttemptReset != nil {
 			onAttemptReset()
 		}
-		repaired, repairErr := e.repairMissingToolOutputsByAppending(stepID)
+		repaired, repairErr := e.repairMissingToolOutputsByAppending(textutil.OptionalTrimmedString(stepID))
 		if repairErr != nil {
 			return llm.Response{}, errors.Join(err, repairErr)
 		}

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -287,6 +287,11 @@ func (e *Engine) appendMessageRaw(stepID string, msg llm.Message, eventPolicy st
 	if err != nil {
 		return session.CommitReceipt{}, err
 	}
+	// Reject conflicting provider identity before durable append so one malformed
+	// response cannot poison the session or crash the server projection.
+	if err := e.transcriptRuntimeState().ValidateMessage(stepID, msg); err != nil {
+		return session.CommitReceipt{}, fmt.Errorf("validate message projection: %w", err)
+	}
 	previousCommittedCount := e.CommittedTranscriptEntryCount()
 	receipt := session.CommitReceipt{}
 	var appendErr error
@@ -303,7 +308,9 @@ func (e *Engine) appendMessageRaw(stepID string, msg llm.Message, eventPolicy st
 	} else {
 		e.markCurrentRequestShapeDirty()
 	}
-	e.transcriptRuntimeState().AppendMessage(stepID, msg)
+	if projectionErr := e.transcriptRuntimeState().AppendMessage(stepID, msg); projectionErr != nil {
+		return receipt, errors.Join(appendErr, fmt.Errorf("append message projection: %w", projectionErr))
+	}
 	currentCommittedCount := e.CommittedTranscriptEntryCount()
 	if eventPolicy != steeringMessageEventNone && currentCommittedCount > previousCommittedCount && shouldEmitCommittedMessageEvent(msg) {
 		e.emitRaw(Event{
@@ -372,6 +379,9 @@ func (e *Engine) appendQueuedUserMessageFlush(stepID string, text string, batch 
 	if msg.Content == nil || strings.TrimSpace(*msg.Content) == "" {
 		return session.CommitReceipt{}, nil
 	}
+	if err := e.transcriptRuntimeState().ValidateMessage(stepID, msg); err != nil {
+		return session.CommitReceipt{}, fmt.Errorf("validate queued message projection: %w", err)
+	}
 	normalizedItems := normalizedQueuedUserMessageStatusItems(queueItems)
 	normalizedIDs := queuedUserMessageStatusItemIDs(normalizedItems)
 	appended, appendErr := e.appendPersistedMessageEvent(stepID, msg)
@@ -383,7 +393,9 @@ func (e *Engine) appendQueuedUserMessageFlush(stepID string, text string, batch 
 	} else {
 		e.markCurrentRequestShapeDirty()
 	}
-	e.transcriptRuntimeState().AppendMessage(stepID, msg)
+	if projectionErr := e.transcriptRuntimeState().AppendMessage(stepID, msg); projectionErr != nil {
+		return appended.CommitReceipt, errors.Join(appendErr, fmt.Errorf("append queued message projection: %w", projectionErr))
+	}
 	e.emitRaw(Event{
 		Kind:                         EventUserMessageFlushed,
 		StepID:                       stepID,

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -379,9 +379,6 @@ func (e *Engine) appendQueuedUserMessageFlush(stepID string, text string, batch 
 	if msg.Content == nil || strings.TrimSpace(*msg.Content) == "" {
 		return session.CommitReceipt{}, nil
 	}
-	if err := e.transcriptRuntimeState().ValidateMessage(stepID, msg); err != nil {
-		return session.CommitReceipt{}, fmt.Errorf("validate queued message projection: %w", err)
-	}
 	normalizedItems := normalizedQueuedUserMessageStatusItems(queueItems)
 	normalizedIDs := queuedUserMessageStatusItemIDs(normalizedItems)
 	appended, appendErr := e.appendPersistedMessageEvent(stepID, msg)

--- a/server/runtime/message_lifecycle.go
+++ b/server/runtime/message_lifecycle.go
@@ -56,7 +56,9 @@ func (m *defaultMessageLifecycle) RestoreMessages() error {
 			if err := rollbackLocator.ObserveMessage(record.Seq(), msg); err != nil {
 				return err
 			}
-			e.transcriptRuntimeState().AppendMessage(stepID, msg)
+			if err := e.transcriptRuntimeState().AppendMessage(stepID, msg); err != nil {
+				return fmt.Errorf("restore session message projection: %w", err)
+			}
 			recoveredHandoff.ApplyMessage(msg)
 			if isCompactionSoonReminderMessage(msg) {
 				reminderIssued = true

--- a/server/runtime/missing_tool_output_repair.go
+++ b/server/runtime/missing_tool_output_repair.go
@@ -2,7 +2,9 @@ package runtime
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 
 	"core/server/llm"
 	"core/server/tools"
@@ -46,13 +48,23 @@ type danglingToolCall struct {
 // the prompt-cache prefix through each repaired call stays intact. The provider
 // output item materialized for each completion automatically matches the
 // original call kind (function vs custom) via the projection.
+// Each completion retains its call's original Step identity. An explicit repair
+// Step owns only legacy calls whose persisted message has no Step; without
+// either identity, validation fails before any completion is appended.
 //
 // It is a fallback for the resume path, which re-executes interrupted tool calls
 // to obtain real outputs; when there are still pending tool-call starts to
 // re-execute, this no-ops so it never pre-empts a real result.
-func (e *Engine) repairMissingToolOutputsByAppending(stepID string) (int, error) {
+func (e *Engine) repairMissingToolOutputsByAppending(repairStepID *string) (int, error) {
 	if e == nil || e.store == nil {
 		return 0, nil
+	}
+	if repairStepID != nil {
+		normalized := strings.TrimSpace(*repairStepID)
+		if normalized == "" {
+			return 0, errors.New("repair step id must be non-empty when present")
+		}
+		repairStepID = textutil.Value(normalized)
 	}
 	if e.pendingToolCallStartStore().Len() > 0 {
 		return 0, nil
@@ -65,9 +77,12 @@ func (e *Engine) repairMissingToolOutputsByAppending(stepID string) (int, error)
 	if len(dangling) == 0 {
 		return 0, nil
 	}
-	for _, call := range dangling {
-		if call.stepID == nil {
-			return 0, fmt.Errorf("repair dangling tool call %q: step id is required", call.callID)
+	for index := range dangling {
+		if dangling[index].stepID == nil {
+			dangling[index].stepID = textutil.Pointer(repairStepID)
+		}
+		if dangling[index].stepID == nil {
+			return 0, fmt.Errorf("repair dangling tool call %q: step id is required", dangling[index].callID)
 		}
 	}
 	repaired := 0
@@ -82,11 +97,18 @@ func (e *Engine) repairMissingToolOutputsByAppending(stepID string) (int, error)
 		}
 		repaired++
 	}
-	if err := e.steer(stepID, steerLocalEntryIntent(storedLocalEntry{
+	warning := steerLocalEntryIntent(storedLocalEntry{
 		Visibility: transcript.EntryVisibilityOngoing,
 		Role:       string(transcript.EntryRoleDeveloperErrorFeedback),
 		Text:       fmt.Sprintf(missingToolOutputRepairWarningTemplate, len(dangling)),
-	})); err != nil {
+	})
+	if repairStepID == nil {
+		if err := e.steer("", warning); err != nil {
+			return repaired, err
+		}
+		return repaired, nil
+	}
+	if err := e.steer(*repairStepID, warning); err != nil {
 		return repaired, err
 	}
 	return repaired, nil

--- a/server/runtime/missing_tool_output_repair.go
+++ b/server/runtime/missing_tool_output_repair.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"core/server/llm"
 	"core/server/tools"
@@ -33,6 +34,7 @@ var missingToolOutputInterruptedOutput = json.RawMessage(`{"error":"Tool executi
 type danglingToolCall struct {
 	callID string
 	name   string
+	stepID string
 }
 
 // repairMissingToolOutputsByAppending closes any tool calls in the live
@@ -64,24 +66,30 @@ func (e *Engine) repairMissingToolOutputsByAppending(stepID string) (int, error)
 	if len(dangling) == 0 {
 		return 0, nil
 	}
-	intents := make([]steeringIntent, 0, len(dangling)+1)
+	repaired := 0
 	for _, call := range dangling {
-		intents = append(intents, steerToolCompletionIntent(tools.Result{
+		callStepID := strings.TrimSpace(call.stepID)
+		if callStepID == "" {
+			return repaired, fmt.Errorf("repair dangling tool call %q: step id is required", call.callID)
+		}
+		if err := e.steer(callStepID, steerToolCompletionIntent(tools.Result{
 			CallID:  call.callID,
 			Name:    toolspec.ID(call.name),
 			IsError: true,
 			Output:  append(json.RawMessage(nil), missingToolOutputInterruptedOutput...),
-		}))
+		})); err != nil {
+			return repaired, err
+		}
+		repaired++
 	}
-	intents = append(intents, steerLocalEntryIntent(storedLocalEntry{
+	if err := e.steer(stepID, steerLocalEntryIntent(storedLocalEntry{
 		Visibility: transcript.EntryVisibilityOngoing,
 		Role:       string(transcript.EntryRoleDeveloperErrorFeedback),
 		Text:       fmt.Sprintf(missingToolOutputRepairWarningTemplate, len(dangling)),
-	}))
-	if err := e.steer(stepID, intents...); err != nil {
-		return 0, err
+	})); err != nil {
+		return repaired, err
 	}
-	return len(dangling), nil
+	return repaired, nil
 }
 
 // itemsHaveDanglingToolCalls reports whether a prepared request item sequence

--- a/server/runtime/missing_tool_output_repair.go
+++ b/server/runtime/missing_tool_output_repair.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"core/server/llm"
 	"core/server/tools"
@@ -34,7 +33,7 @@ var missingToolOutputInterruptedOutput = json.RawMessage(`{"error":"Tool executi
 type danglingToolCall struct {
 	callID string
 	name   string
-	stepID string
+	stepID *string
 }
 
 // repairMissingToolOutputsByAppending closes any tool calls in the live
@@ -66,13 +65,14 @@ func (e *Engine) repairMissingToolOutputsByAppending(stepID string) (int, error)
 	if len(dangling) == 0 {
 		return 0, nil
 	}
+	for _, call := range dangling {
+		if call.stepID == nil {
+			return 0, fmt.Errorf("repair dangling tool call %q: step id is required", call.callID)
+		}
+	}
 	repaired := 0
 	for _, call := range dangling {
-		callStepID := strings.TrimSpace(call.stepID)
-		if callStepID == "" {
-			return repaired, fmt.Errorf("repair dangling tool call %q: step id is required", call.callID)
-		}
-		if err := e.steer(callStepID, steerToolCompletionIntent(tools.Result{
+		if err := e.steer(*call.stepID, steerToolCompletionIntent(tools.Result{
 			CallID:  call.callID,
 			Name:    toolspec.ID(call.name),
 			IsError: true,

--- a/server/runtime/missing_tool_output_repair_test.go
+++ b/server/runtime/missing_tool_output_repair_test.go
@@ -254,6 +254,39 @@ func TestRepairMissingToolOutputsRetainsDanglingCallStepIdentity(t *testing.T) {
 	t.Fatal("missing synthetic completion")
 }
 
+func TestRepairMissingToolOutputsRejectsUnownedCallsBeforeAppending(t *testing.T) {
+	store := mustCreateTestSession(t)
+	if _, _, err := appendTestEvent(t, store, chatStoreTestStepID, llm.Message{
+		Role:      llm.RoleAssistant,
+		ToolCalls: []llm.ToolCall{{ID: "owned", Name: "exec_command", Input: json.RawMessage(`{}`)}},
+	}); err != nil {
+		t.Fatalf("append owned dangling tool call: %v", err)
+	}
+	legacyMessage, err := sessionMessageRecordFromLLM(llm.Message{
+		Role:      llm.RoleAssistant,
+		ToolCalls: []llm.ToolCall{{ID: "unowned", Name: "exec_command", Input: json.RawMessage(`{}`)}},
+	})
+	if err != nil {
+		t.Fatalf("adapt unowned dangling tool call: %v", err)
+	}
+	if _, _, err := mustMaterializeTestEventLog(t, store).AppendRecord(nil, legacyMessage); err != nil {
+		t.Fatalf("append unowned dangling tool call: %v", err)
+	}
+	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
+
+	repaired, err := eng.repairMissingToolOutputsByAppending(chatStoreTestStepID)
+	if err == nil {
+		t.Fatal("repair accepted a dangling tool call with no recoverable step identity")
+	}
+	if repaired != 0 {
+		t.Fatalf("repair count = %d, want no partial repair", repaired)
+	}
+	items := eng.transcriptRuntimeState().SnapshotItems()
+	if repairRequestHasToolOutput(items, "owned") || repairRequestHasToolOutput(items, "unowned") {
+		t.Fatal("repair appended output before validating every dangling call identity")
+	}
+}
+
 func TestRepairMissingToolOutputsDefersToPendingToolCallStarts(t *testing.T) {
 	store := mustCreateTestSession(t)
 	if _, _, err := appendTestEvent(t, store, "step", llm.Message{

--- a/server/runtime/missing_tool_output_repair_test.go
+++ b/server/runtime/missing_tool_output_repair_test.go
@@ -217,6 +217,43 @@ func TestRepairMissingToolOutputsByAppendingIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestRepairMissingToolOutputsRetainsDanglingCallStepIdentity(t *testing.T) {
+	store := mustCreateTestSession(t)
+	if _, _, err := appendTestEvent(t, store, chatStoreTestStepID, llm.Message{
+		Role:      llm.RoleAssistant,
+		ToolCalls: []llm.ToolCall{{ID: "missing", Name: "exec_command", Input: json.RawMessage(`{}`)}},
+	}); err != nil {
+		t.Fatalf("append dangling tool call: %v", err)
+	}
+	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
+
+	if _, err := eng.repairMissingToolOutputsByAppending(""); err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	window, err := mustMaterializeTestEventLog(t, store).ReadRecentRecords(16)
+	if err != nil {
+		t.Fatalf("read bounded repair records: %v", err)
+	}
+	for _, record := range window.Records {
+		completion, ok := mustSessionEventPayload(record).(session.ToolCompletionRecord)
+		if !ok {
+			continue
+		}
+		stored, err := storedToolCompletionFromSessionRecord(completion)
+		if err != nil {
+			t.Fatalf("restore completion: %v", err)
+		}
+		if stored.CallID != "missing" {
+			continue
+		}
+		if record.StepID() == nil || *record.StepID() != chatStoreTestStepID {
+			t.Fatalf("repair step id = %v, want original call step %q", record.StepID(), chatStoreTestStepID)
+		}
+		return
+	}
+	t.Fatal("missing synthetic completion")
+}
+
 func TestRepairMissingToolOutputsDefersToPendingToolCallStarts(t *testing.T) {
 	store := mustCreateTestSession(t)
 	if _, _, err := appendTestEvent(t, store, "step", llm.Message{

--- a/server/runtime/missing_tool_output_repair_test.go
+++ b/server/runtime/missing_tool_output_repair_test.go
@@ -230,7 +230,8 @@ func TestRepairMissingToolOutputsRetainsDanglingCallStepIdentity(t *testing.T) {
 	if _, err := eng.repairMissingToolOutputsByAppending(nil); err != nil {
 		t.Fatalf("repair: %v", err)
 	}
-	stepID := repairCompletionStepID(t, store, "missing")
+	record, _ := repairCompletionRecord(t, store, "missing")
+	stepID := record.StepID()
 	if stepID == nil || *stepID != chatStoreTestStepID {
 		t.Fatalf("repair step id = %v, want original call step %q", stepID, chatStoreTestStepID)
 	}
@@ -253,7 +254,8 @@ func TestRepairMissingToolOutputsUsesRepairStepForUnownedLegacyCall(t *testing.T
 	if _, err := eng.repairMissingToolOutputsByAppending(textutil.Value(chatStoreTestStepID)); err != nil {
 		t.Fatalf("repair: %v", err)
 	}
-	stepID := repairCompletionStepID(t, store, "unowned")
+	record, _ := repairCompletionRecord(t, store, "unowned")
+	stepID := record.StepID()
 	if stepID == nil || *stepID != chatStoreTestStepID {
 		t.Fatalf("repair step id = %v, want repair step %q", stepID, chatStoreTestStepID)
 	}
@@ -292,7 +294,11 @@ func TestRepairMissingToolOutputsRejectsUnownedCallsBeforeAppending(t *testing.T
 	}
 }
 
-func repairCompletionStepID(t *testing.T, store *session.Store, callID string) *string {
+func repairCompletionRecord(
+	t *testing.T,
+	store *session.Store,
+	callID string,
+) (session.EventRecord, storedToolCompletion) {
 	t.Helper()
 	window, err := mustMaterializeTestEventLog(t, store).ReadRecentRecords(16)
 	if err != nil {
@@ -308,11 +314,11 @@ func repairCompletionStepID(t *testing.T, store *session.Store, callID string) *
 			t.Fatalf("restore completion: %v", err)
 		}
 		if stored.CallID == callID {
-			return record.StepID()
+			return record, stored
 		}
 	}
 	t.Fatalf("missing synthetic completion for call %q", callID)
-	return nil
+	return session.EventRecord{}, storedToolCompletion{}
 }
 
 func TestRepairMissingToolOutputsDefersToPendingToolCallStarts(t *testing.T) {
@@ -355,28 +361,10 @@ func TestRepairMissingToolOutputsPersistSyntheticErrorPresentation(t *testing.T)
 	if _, err := eng.repairMissingToolOutputsByAppending(textutil.Value("step")); err != nil {
 		t.Fatalf("repair: %v", err)
 	}
-	window, err := mustMaterializeTestEventLog(t, store).ReadRecentRecords(16)
-	if err != nil {
-		t.Fatalf("read bounded repair records: %v", err)
+	_, completion := repairCompletionRecord(t, store, "missing")
+	if completion.Presentation == nil || !completion.Presentation.IsShell || completion.Presentation.Command == "" {
+		t.Fatalf("synthetic completion presentation = %+v, want typed shell presentation", completion.Presentation)
 	}
-	for _, record := range window.Records {
-		payload, ok := mustSessionEventPayload(record).(session.ToolCompletionRecord)
-		if !ok {
-			continue
-		}
-		completion, err := storedToolCompletionFromSessionRecord(payload)
-		if err != nil {
-			t.Fatalf("restore completion: %v", err)
-		}
-		if completion.CallID != "missing" {
-			continue
-		}
-		if completion.Presentation == nil || !completion.Presentation.IsShell || completion.Presentation.Command == "" {
-			t.Fatalf("synthetic completion presentation = %+v, want typed shell presentation", completion.Presentation)
-		}
-		return
-	}
-	t.Fatal("missing synthetic completion")
 }
 
 func TestCompactionMissingToolOutputRepairAppendsAndRetries(t *testing.T) {

--- a/server/runtime/missing_tool_output_repair_test.go
+++ b/server/runtime/missing_tool_output_repair_test.go
@@ -204,11 +204,11 @@ func TestRepairMissingToolOutputsByAppendingIsIdempotent(t *testing.T) {
 	}
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
 
-	first, err := eng.repairMissingToolOutputsByAppending("step")
+	first, err := eng.repairMissingToolOutputsByAppending(textutil.Value("step"))
 	if err != nil {
 		t.Fatalf("first repair: %v", err)
 	}
-	second, err := eng.repairMissingToolOutputsByAppending("step")
+	second, err := eng.repairMissingToolOutputsByAppending(textutil.Value("step"))
 	if err != nil {
 		t.Fatalf("second repair: %v", err)
 	}
@@ -227,31 +227,36 @@ func TestRepairMissingToolOutputsRetainsDanglingCallStepIdentity(t *testing.T) {
 	}
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
 
-	if _, err := eng.repairMissingToolOutputsByAppending(""); err != nil {
+	if _, err := eng.repairMissingToolOutputsByAppending(nil); err != nil {
 		t.Fatalf("repair: %v", err)
 	}
-	window, err := mustMaterializeTestEventLog(t, store).ReadRecentRecords(16)
+	stepID := repairCompletionStepID(t, store, "missing")
+	if stepID == nil || *stepID != chatStoreTestStepID {
+		t.Fatalf("repair step id = %v, want original call step %q", stepID, chatStoreTestStepID)
+	}
+}
+
+func TestRepairMissingToolOutputsUsesRepairStepForUnownedLegacyCall(t *testing.T) {
+	store := mustCreateTestSession(t)
+	legacyMessage, err := sessionMessageRecordFromLLM(llm.Message{
+		Role:      llm.RoleAssistant,
+		ToolCalls: []llm.ToolCall{{ID: "unowned", Name: "exec_command", Input: json.RawMessage(`{}`)}},
+	})
 	if err != nil {
-		t.Fatalf("read bounded repair records: %v", err)
+		t.Fatalf("adapt unowned dangling tool call: %v", err)
 	}
-	for _, record := range window.Records {
-		completion, ok := mustSessionEventPayload(record).(session.ToolCompletionRecord)
-		if !ok {
-			continue
-		}
-		stored, err := storedToolCompletionFromSessionRecord(completion)
-		if err != nil {
-			t.Fatalf("restore completion: %v", err)
-		}
-		if stored.CallID != "missing" {
-			continue
-		}
-		if record.StepID() == nil || *record.StepID() != chatStoreTestStepID {
-			t.Fatalf("repair step id = %v, want original call step %q", record.StepID(), chatStoreTestStepID)
-		}
-		return
+	if _, _, err := mustMaterializeTestEventLog(t, store).AppendRecord(nil, legacyMessage); err != nil {
+		t.Fatalf("append unowned dangling tool call: %v", err)
 	}
-	t.Fatal("missing synthetic completion")
+	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
+
+	if _, err := eng.repairMissingToolOutputsByAppending(textutil.Value(chatStoreTestStepID)); err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	stepID := repairCompletionStepID(t, store, "unowned")
+	if stepID == nil || *stepID != chatStoreTestStepID {
+		t.Fatalf("repair step id = %v, want repair step %q", stepID, chatStoreTestStepID)
+	}
 }
 
 func TestRepairMissingToolOutputsRejectsUnownedCallsBeforeAppending(t *testing.T) {
@@ -274,7 +279,7 @@ func TestRepairMissingToolOutputsRejectsUnownedCallsBeforeAppending(t *testing.T
 	}
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
 
-	repaired, err := eng.repairMissingToolOutputsByAppending(chatStoreTestStepID)
+	repaired, err := eng.repairMissingToolOutputsByAppending(nil)
 	if err == nil {
 		t.Fatal("repair accepted a dangling tool call with no recoverable step identity")
 	}
@@ -285,6 +290,29 @@ func TestRepairMissingToolOutputsRejectsUnownedCallsBeforeAppending(t *testing.T
 	if repairRequestHasToolOutput(items, "owned") || repairRequestHasToolOutput(items, "unowned") {
 		t.Fatal("repair appended output before validating every dangling call identity")
 	}
+}
+
+func repairCompletionStepID(t *testing.T, store *session.Store, callID string) *string {
+	t.Helper()
+	window, err := mustMaterializeTestEventLog(t, store).ReadRecentRecords(16)
+	if err != nil {
+		t.Fatalf("read bounded repair records: %v", err)
+	}
+	for _, record := range window.Records {
+		completion, ok := mustSessionEventPayload(record).(session.ToolCompletionRecord)
+		if !ok {
+			continue
+		}
+		stored, err := storedToolCompletionFromSessionRecord(completion)
+		if err != nil {
+			t.Fatalf("restore completion: %v", err)
+		}
+		if stored.CallID == callID {
+			return record.StepID()
+		}
+	}
+	t.Fatalf("missing synthetic completion for call %q", callID)
+	return nil
 }
 
 func TestRepairMissingToolOutputsDefersToPendingToolCallStarts(t *testing.T) {
@@ -298,7 +326,7 @@ func TestRepairMissingToolOutputsDefersToPendingToolCallStarts(t *testing.T) {
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
 	eng.rememberPendingToolCallStarts(map[string]int{"missing": 1})
 
-	repaired, err := eng.repairMissingToolOutputsByAppending("step")
+	repaired, err := eng.repairMissingToolOutputsByAppending(textutil.Value("step"))
 	if err != nil {
 		t.Fatalf("repair: %v", err)
 	}
@@ -324,7 +352,7 @@ func TestRepairMissingToolOutputsPersistSyntheticErrorPresentation(t *testing.T)
 	}
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
 
-	if _, err := eng.repairMissingToolOutputsByAppending("step"); err != nil {
+	if _, err := eng.repairMissingToolOutputsByAppending(textutil.Value("step")); err != nil {
 		t.Fatalf("repair: %v", err)
 	}
 	window, err := mustMaterializeTestEventLog(t, store).ReadRecentRecords(16)

--- a/server/runtime/transcript_runtime_state.go
+++ b/server/runtime/transcript_runtime_state.go
@@ -209,8 +209,12 @@ func (s *transcriptRuntimeState) ToolCompletionCount() int {
 	return 0
 }
 
-func (s *transcriptRuntimeState) AppendMessage(stepID string, msg llm.Message) {
-	s.chatProjection().appendMessage(stepID, msg)
+func (s *transcriptRuntimeState) ValidateMessage(stepID string, msg llm.Message) error {
+	return s.chatProjection().validateMessage(stepID, msg)
+}
+
+func (s *transcriptRuntimeState) AppendMessage(stepID string, msg llm.Message) error {
+	return s.chatProjection().appendMessage(stepID, msg)
 }
 
 func (s *transcriptRuntimeState) AppendLocalEntryRecord(entry ChatEntry, afterToolCallID *string) {


### PR DESCRIPTION
## Summary

- preserve the original Step identity for dangling tool calls in the active transcript
- rebase tool calls carried by a history replacement to the replacement boundary Step so live and reopened engines agree
- use the explicit repair Step only for legacy calls with no recoverable owner
- validate every repair owner before appending any synthetic completion
- reject conflicting provider tool-call ownership before persistence and surface persisted conflicts as an engine-open error instead of panicking the server

## Root cause

Pre-submit compaction repaired a dangling tool call using an empty current Step ID. The resulting persisted `tool_completed` event projected into an invalid committed tool row and crashed `runtimeview`.

## Verification

- focused repair, replacement-recovery, idempotency, conflict, and compaction regression tests
- focused race tests
- `./scripts/test.sh ./server/runtimeview ./server/core -count=1`
- `./scripts/build.sh --output ./bin/kent`
- all GitHub CI checks pass

The repository-wide local sweep still reaches the unchanged 180-second aggregate cap; GitHub CI runs the uncapped suite.