### PR TITLE
Deduplicate terminal resets for failed streams

### DIFF
--- a/scripts/runtime-test-lock.py
+++ b/scripts/runtime-test-lock.py
@@ -3,10 +3,32 @@
 """Run one runtime-package test command at a time on the local host."""
 
 import os
+import stat
 import subprocess
 import sys
 import tempfile
 import time
+
+
+def open_shared_lock():
+    lock_path = "/tmp/kent-runtime-test.lock"
+    if os.name == "nt":
+        lock_path = os.path.join(tempfile.gettempdir(), "kent-runtime-test.lock")
+
+    flags = os.O_RDWR | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        previous_umask = os.umask(0)
+        try:
+            descriptor = os.open(lock_path, flags | os.O_CREAT | os.O_EXCL, 0o666)
+        finally:
+            os.umask(previous_umask)
+    except FileExistsError:
+        descriptor = os.open(lock_path, flags)
+
+    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise RuntimeError(f"runtime test lock is not a regular file: {lock_path}")
+    return os.fdopen(descriptor, "r+b", buffering=0)
 
 
 def acquire_lock(lock_file) -> None:
@@ -38,8 +60,7 @@ def main() -> int:
     if not command:
         raise SystemExit("runtime test lock requires a command")
 
-    lock_path = os.path.join(tempfile.gettempdir(), "kent-runtime-test.lock")
-    with open(lock_path, "a+b", buffering=0) as lock_file:
+    with open_shared_lock() as lock_file:
         acquire_lock(lock_file)
         return subprocess.run(command).returncode
 

--- a/scripts/runtime-test-lock.py
+++ b/scripts/runtime-test-lock.py
@@ -6,22 +6,38 @@ import os
 import stat
 import subprocess
 import sys
-import tempfile
 import time
 
 
-def open_shared_lock():
-    lock_path = "/tmp/kent-runtime-test.lock"
-    if os.name == "nt":
-        lock_path = os.path.join(tempfile.gettempdir(), "kent-runtime-test.lock")
+def repository_lock_path() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-common-dir"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "resolve shared runtime test lock directory: "
+            + result.stderr.strip()
+        )
+    common_dir = result.stdout.strip()
+    if not common_dir:
+        raise RuntimeError("resolve shared runtime test lock directory: empty git common directory")
+    if not os.path.isabs(common_dir):
+        common_dir = os.path.abspath(common_dir)
+    if not os.path.isdir(common_dir):
+        raise RuntimeError(
+            f"resolve shared runtime test lock directory: not a directory: {common_dir}"
+        )
+    return os.path.join(common_dir, "kent-runtime-test.lock")
 
+
+def open_shared_lock():
+    lock_path = repository_lock_path()
     flags = os.O_RDWR | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:
-        previous_umask = os.umask(0)
-        try:
-            descriptor = os.open(lock_path, flags | os.O_CREAT | os.O_EXCL, 0o666)
-        finally:
-            os.umask(previous_umask)
+        descriptor = os.open(lock_path, flags | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError:
         descriptor = os.open(lock_path, flags)
 

--- a/scripts/runtime-test-lock.py
+++ b/scripts/runtime-test-lock.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+"""Run one runtime-package test command at a time on the local host."""
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def acquire_lock(lock_file) -> None:
+    try:
+        import fcntl
+    except ImportError:
+        import msvcrt
+
+        lock_file.write(b"\0")
+        lock_file.flush()
+        while True:
+            try:
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+                return
+            except OSError:
+                print("waiting for shared runtime test admission...", file=sys.stderr, flush=True)
+                time.sleep(0.1)
+    else:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            print("waiting for shared runtime test admission...", file=sys.stderr, flush=True)
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+
+
+def main() -> int:
+    command = sys.argv[1:]
+    if not command:
+        raise SystemExit("runtime test lock requires a command")
+
+    lock_path = os.path.join(tempfile.gettempdir(), "kent-runtime-test.lock")
+    with open(lock_path, "a+b", buffering=0) as lock_file:
+        acquire_lock(lock_file)
+        return subprocess.run(command).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -96,6 +96,16 @@ if [ "${#go_test_args[@]}" -gt 0 ]; then
     server_test_args=("${go_test_args[@]}")
 fi
 
+server_test_requires_runtime_admission=0
+for server_test_arg in "${server_test_args[@]}"; do
+    case "$server_test_arg" in
+    ./... | ./server/... | ./server/runtime | ./server/runtime/... | core/server/... | core/server/runtime | core/server/runtime/...)
+        server_test_requires_runtime_admission=1
+        break
+        ;;
+    esac
+done
+
 if [ "$inherit_env" != "1" ]; then
     while IFS= read -r name; do
         case "$name" in
@@ -241,7 +251,7 @@ require_command() {
 check_dependencies() {
     if target_selected server; then
         require_command go "run server tests"
-        if [ "$disable_wall_clock_cap" != "1" ]; then
+        if [ "$disable_wall_clock_cap" != "1" ] || [ "$server_test_requires_runtime_admission" = "1" ]; then
             require_command python3 "enforce the server test-runtime timeout"
         fi
     fi
@@ -352,6 +362,10 @@ run_server_tests() {
         export KENT_PTY_ANSI_WRITER_BINARY="$pty_fixture_build_dir/ansi-writer"
         export KENT_PTY_PHASE_INPUT_WRITER_BINARY="$pty_fixture_build_dir/phase-input-writer"
         export KENT_PTY_PHASE_WRITER_BINARY="$pty_fixture_build_dir/phase-writer"
+    fi
+
+    if [ "$server_test_requires_runtime_admission" = "1" ]; then
+        server_test_command=(python3 "$repo_root/scripts/runtime-test-lock.py" "${server_test_command[@]}")
     fi
 
     if [ "$disable_wall_clock_cap" = "1" ]; then

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -104,6 +104,13 @@ for server_test_arg in "${server_test_args[@]}"; do
         break
         ;;
     esac
+    if [ -d "$server_test_arg" ] && command -v go >/dev/null 2>&1; then
+        resolved_import_path="$(go list -f '{{.ImportPath}}' "$server_test_arg" 2>/dev/null || true)"
+        if [ "$resolved_import_path" = "core/server/runtime" ]; then
+            server_test_requires_runtime_admission=1
+            break
+        fi
+    fi
 done
 
 if [ "$inherit_env" != "1" ]; then

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -98,18 +98,17 @@ fi
 
 server_test_requires_runtime_admission=0
 for server_test_arg in "${server_test_args[@]}"; do
-    case "$server_test_arg" in
-    ./... | ./server/... | ./server/runtime | ./server/runtime/... | core/server/... | core/server/runtime | core/server/runtime/...)
-        server_test_requires_runtime_admission=1
-        break
-        ;;
-    esac
-    if [ -d "$server_test_arg" ] && command -v go >/dev/null 2>&1; then
-        resolved_import_path="$(go list -f '{{.ImportPath}}' "$server_test_arg" 2>/dev/null || true)"
+    if [[ "$server_test_arg" == -* ]] || ! command -v go >/dev/null 2>&1; then
+        continue
+    fi
+    while IFS= read -r resolved_import_path; do
         if [ "$resolved_import_path" = "core/server/runtime" ]; then
             server_test_requires_runtime_admission=1
             break
         fi
+    done < <(go list -f '{{.ImportPath}}' "$server_test_arg" 2>/dev/null || true)
+    if [ "$server_test_requires_runtime_admission" = "1" ]; then
+        break
     fi
 done
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -155,7 +155,9 @@ if [ "$go_test_package_parallelism" -le 0 ]; then
     printf 'KENT_TEST_GO_PACKAGE_PARALLELISM must be a positive integer\n' >&2
     exit 2
 fi
+server_test_uses_sharder=0
 if [ "${#server_test_args[@]}" -eq 1 ] && [ "${server_test_args[0]}" = "./..." ]; then
+    server_test_uses_sharder=1
     server_test_command=(
         go run ./tools/testshard
         --workers "$go_test_package_parallelism"
@@ -364,7 +366,10 @@ run_server_tests() {
         export KENT_PTY_PHASE_WRITER_BINARY="$pty_fixture_build_dir/phase-writer"
     fi
 
-    if [ "$server_test_requires_runtime_admission" = "1" ]; then
+    # The sharder acquires one admission for its complete job graph when it
+    # plans core/server/runtime. Wrapping it here would recurse through its
+    # script-integration test, which invokes this script.
+    if [ "$server_test_requires_runtime_admission" = "1" ] && [ "$server_test_uses_sharder" != "1" ]; then
         server_test_command=(python3 "$repo_root/scripts/runtime-test-lock.py" "${server_test_command[@]}")
     fi
 

--- a/server/runtime/completed_response_stream_test.go
+++ b/server/runtime/completed_response_stream_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestCompletedResponseActiveStreamFinalizesOnce(t *testing.T) {
+	t.Parallel()
 	step := scriptedllm.FinalAnswer("completed")
 	step.StreamDeltas = []llm.AssistantDelta{{
 		Text:  "draft",
@@ -99,6 +100,7 @@ func TestCompletedResponseActiveStreamFinalizesOnce(t *testing.T) {
 }
 
 func TestCompletedResponseWithoutActiveStreamPublishesNoStreamTerminal(t *testing.T) {
+	t.Parallel()
 	var events []Event
 	engine := mustNewExecTestEngine(
 		t,
@@ -143,6 +145,7 @@ func TestCompletedResponseWithoutActiveStreamPublishesNoStreamTerminal(t *testin
 }
 
 func TestCompletedResponseWorkflowPreflightAbortsBeforeContinuation(t *testing.T) {
+	t.Parallel()
 	runID := workflow.RunID("workflow-run")
 	controller := &workflowCompletionAccountingController{}
 	rejected := scriptedllm.ToolBatch(
@@ -197,6 +200,7 @@ func TestCompletedResponseWorkflowPreflightAbortsBeforeContinuation(t *testing.T
 }
 
 func TestCompletedResponseReasoningOnlyAbortsBeforeContinuation(t *testing.T) {
+	t.Parallel()
 	reasoning := scriptedllm.Step{
 		Response: llm.Response{
 			Assistant: llm.Message{
@@ -329,6 +333,7 @@ func assertSupersededStreamPrecedesFinalContinuation(t *testing.T, events []Even
 }
 
 func TestCompletedResponseFinalAnswerWithToolsFinalizesAfterToolPersistence(t *testing.T) {
+	t.Parallel()
 	const callID = "final-tool"
 	step := scriptedllm.ToolBatch("completed", llm.ToolCall{
 		ID:    callID,
@@ -493,6 +498,7 @@ func TestCompletedResponseFinalAnswerWithToolsFinalizesAfterToolPersistence(t *t
 }
 
 func TestSubmitUserMessageFinalAnswerWithMixedToolCallsMaterializesAllToolsBeforeSingleFinal(t *testing.T) {
+	t.Parallel()
 	calls := []llm.ToolCall{
 		{ID: "final-tool-one", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{"cmd":"true"}`)},
 		{ID: "final-tool-two", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{"cmd":"true"}`)},
@@ -570,6 +576,7 @@ func TestSubmitUserMessageFinalAnswerWithMixedToolCallsMaterializesAllToolsBefor
 }
 
 func TestNoopStreamedFinalResetsWithoutFinalPublication(t *testing.T) {
+	t.Parallel()
 	var events []Event
 	engine := mustNewExecTestEngine(t, mustCreateTestSession(t), fakeNoopStreamClient{}, Config{
 		Model:   "gpt-5",
@@ -597,6 +604,7 @@ func TestNoopStreamedFinalResetsWithoutFinalPublication(t *testing.T) {
 }
 
 func TestCompletedResponseExternalWorkflowCompletionDiscardsActiveStreamWithoutPersistence(t *testing.T) {
+	t.Parallel()
 	controller := &externallyCompletedWorkflowController{}
 	step := scriptedllm.ToolBatch("", llm.ToolCall{
 		ID:    "stale-call",
@@ -681,6 +689,7 @@ func TestCompletedResponseExternalWorkflowCompletionDiscardsActiveStreamWithoutP
 }
 
 func TestWorkflowDurableCompletionBeforeModelTurnStopsWithoutRequest(t *testing.T) {
+	t.Parallel()
 	controller := &externallyCompletedWorkflowController{}
 	controller.completed.Store(true)
 	runID := workflow.RunID("workflow-run")
@@ -718,6 +727,7 @@ func TestWorkflowDurableCompletionBeforeModelTurnStopsWithoutRequest(t *testing.
 }
 
 func TestWorkflowDelayedDurableCompletionObservedBeforeNextModelTurn(t *testing.T) {
+	t.Parallel()
 	const callID = "workflow-delayed-completion-call"
 	controller := &externallyCompletedWorkflowController{completeAfterObservations: 4}
 	runID := workflow.RunID("workflow-run")
@@ -793,6 +803,7 @@ func TestWorkflowDelayedDurableCompletionObservedBeforeNextModelTurn(t *testing.
 }
 
 func TestWorkflowInvalidCompletionFailClosedWhenConfiguredCapInvalid(t *testing.T) {
+	t.Parallel()
 	runID := workflow.RunID("workflow-run")
 	controller := &interruptingWorkflowProtocolViolationController{}
 	client := &fakeClient{responses: []llm.Response{{
@@ -839,6 +850,7 @@ func TestWorkflowInvalidCompletionFailClosedWhenConfiguredCapInvalid(t *testing.
 }
 
 func TestWorkflowCompletionControllerFailureUsesInvalidCompletionCapWithoutTerminalState(t *testing.T) {
+	t.Parallel()
 	runID := workflow.RunID("workflow-run")
 	controller := &failingWorkflowCompletionController{}
 	completionResponse := llm.Response{Assistant: llm.Message{
@@ -900,6 +912,7 @@ func TestWorkflowCompletionControllerFailureUsesInvalidCompletionCapWithoutTermi
 }
 
 func TestWorkflowObservedDurableCompletionFailsQueuedSteeringDuringCloseDrain(t *testing.T) {
+	t.Parallel()
 	runID := workflow.RunID("workflow-run")
 	controller := &externallyCompletedWorkflowController{}
 	controller.completed.Store(true)
@@ -959,6 +972,7 @@ func TestWorkflowObservedDurableCompletionFailsQueuedSteeringDuringCloseDrain(t 
 }
 
 func TestCompletedResponseFinalizationUsesActiveSegmentCoordinatesAfterCompaction(t *testing.T) {
+	t.Parallel()
 	first := scriptedllm.FinalAnswer("first")
 	first.StreamDeltas = []llm.AssistantDelta{{Text: "first", Phase: llm.MessagePhaseFinal}}
 	second := scriptedllm.FinalAnswer("second")

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -513,21 +513,39 @@ func (e *Engine) clearStreamingAssistantStateRaw() (*AssistantStreamMetadata, *u
 	return e.transcriptRuntimeState().ClearStreamingAssistantState()
 }
 
-func (e *Engine) emitStreamingAssistantResetEventsRaw(
+func (e *Engine) emitStreamingAssistantTerminalRaw(
 	stepID string,
 	metadata *AssistantStreamMetadata,
-	streamID *uuid.UUID,
+	streamID uuid.UUID,
 	abortReason *AssistantStreamAbortReason,
 ) error {
 	abortReasonValue := ""
 	if abortReason != nil {
 		abortReasonValue = string(*abortReason)
 	}
-	return errors.Join(
+	return e.emitRaw(Event{
+		Kind:                        EventAssistantDeltaReset,
+		StepID:                      stepID,
+		AssistantStreamMetadata:     cloneAssistantStreamMetadata(metadata),
+		AssistantTranscriptStreamID: cloneTranscriptStreamID(&streamID),
+		AssistantStreamAbortReason:  abortReasonValue,
+	})
+}
+
+func (e *Engine) emitStreamingAssistantCleanupEventsRaw(
+	stepID string,
+	metadata *AssistantStreamMetadata,
+	streamID *uuid.UUID,
+	abortReason *AssistantStreamAbortReason,
+) error {
+	emissionErrors := []error{
 		e.emitRaw(Event{Kind: EventConversationUpdated, StepID: stepID}),
-		e.emitRaw(Event{Kind: EventAssistantDeltaReset, StepID: stepID, AssistantStreamMetadata: cloneAssistantStreamMetadata(metadata), AssistantTranscriptStreamID: cloneTranscriptStreamID(streamID), AssistantStreamAbortReason: abortReasonValue}),
-		e.emitRaw(Event{Kind: EventReasoningDeltaReset, StepID: stepID}),
-	)
+	}
+	if streamID != nil {
+		emissionErrors = append(emissionErrors, e.emitStreamingAssistantTerminalRaw(stepID, metadata, *streamID, abortReason))
+	}
+	emissionErrors = append(emissionErrors, e.emitRaw(Event{Kind: EventReasoningDeltaReset, StepID: stepID}))
+	return errors.Join(emissionErrors...)
 }
 
 func (e *Engine) emitCommittedAssistantMessageRaw(stepID string, committed steeringCommittedAssistantMessage) error {
@@ -591,7 +609,7 @@ func (e *Engine) resolveCompletedResponseStreamRaw(stepID string, instruction co
 				committedAssistantEventPublished: true,
 			}, nil
 		}
-		if err := e.emitStreamingAssistantResetEventsRaw(stepID, clearedMetadata, clearedStreamID, nil); err != nil {
+		if err := e.emitStreamingAssistantCleanupEventsRaw(stepID, clearedMetadata, clearedStreamID, nil); err != nil {
 			return completedResponseResolutionOutcome{}, err
 		}
 		return completedResponseResolutionOutcome{
@@ -604,7 +622,7 @@ func (e *Engine) resolveCompletedResponseStreamRaw(stepID string, instruction co
 	if clearedStreamID == nil {
 		return completedResponseResolutionOutcome{kind: completedResponseResolutionAbsent}, nil
 	}
-	if err := e.emitStreamingAssistantResetEventsRaw(stepID, clearedMetadata, clearedStreamID, instruction.abortReason); err != nil {
+	if err := e.emitStreamingAssistantCleanupEventsRaw(stepID, clearedMetadata, clearedStreamID, instruction.abortReason); err != nil {
 		return completedResponseResolutionOutcome{}, err
 	}
 	return completedResponseResolutionOutcome{

--- a/server/runtime/engine_part12_test.go
+++ b/server/runtime/engine_part12_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestShouldCompactBeforeUserMessageSkipsExactCountWhenProviderOverrideDisablesIt(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	client := &preciseCompactionClient{inputTokenCount: 960, contextWindow: 1000}
@@ -52,6 +53,7 @@ func TestShouldCompactBeforeUserMessageSkipsExactCountWhenProviderOverrideDisabl
 }
 
 func TestShouldCompactBeforeUserMessageSkipsExactCountWhenLockedContractDisablesIt(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	if err := store.MarkModelDispatchLocked(session.LockedContract{
 		Model: "gpt-5",
@@ -88,6 +90,7 @@ func TestShouldCompactBeforeUserMessageSkipsExactCountWhenLockedContractDisables
 }
 
 func TestCompactionSoonReminderStaysSingleShotAfterReEnablingAutoCompactionAboveReminderBand(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
@@ -158,6 +161,7 @@ func TestCompactionSoonReminderStaysSingleShotAfterReEnablingAutoCompactionAbove
 }
 
 func TestReopenedSessionRestoresCompactionSoonReminderIssuedState(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
@@ -199,6 +203,7 @@ func TestReopenedSessionRestoresCompactionSoonReminderIssuedState(t *testing.T) 
 }
 
 func TestForkedSessionBeforeReminderDoesNotCopyReminderIssuedState(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
@@ -243,6 +248,7 @@ func TestForkedSessionBeforeReminderDoesNotCopyReminderIssuedState(t *testing.T)
 }
 
 func TestForkedSessionDoesNotCopyPersistedUsageState(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{Model: "gpt-5", ContextWindowTokens: 410_000})
@@ -266,6 +272,7 @@ func TestForkedSessionDoesNotCopyPersistedUsageState(t *testing.T) {
 }
 
 func TestForkedSessionAfterReminderPreservesCompactionSoonReminderIssuedState(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	eng := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeTool{name: toolspec.ToolExecCommand}}), Config{
@@ -297,6 +304,7 @@ func TestForkedSessionAfterReminderPreservesCompactionSoonReminderIssuedState(t 
 }
 
 func TestCompactionSoonReminderSkipsPreciseCountingWhenSuppressed(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		compactionMode string
@@ -348,6 +356,7 @@ func TestCompactionSoonReminderSkipsPreciseCountingWhenSuppressed(t *testing.T) 
 }
 
 func TestRunStepLoopSkipsCompactionSoonReminderWhenImmediateAutoCompactionRuns(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	client := &fakeCompactionClient{
@@ -398,6 +407,7 @@ func TestRunStepLoopSkipsCompactionSoonReminderWhenImmediateAutoCompactionRuns(t
 }
 
 func TestRunStepLoopInjectsCompactionSoonReminderBeforeFinalAnswerRequest(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	client := &fakeCompactionClient{
@@ -460,6 +470,7 @@ func TestRunStepLoopInjectsCompactionSoonReminderBeforeFinalAnswerRequest(t *tes
 }
 
 func TestRunStepLoopAppendsCompactionSoonReminderImmediatelyAfterToolOutputBoundary(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	client := &fakeCompactionClient{

--- a/server/runtime/engine_part4_test.go
+++ b/server/runtime/engine_part4_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestSubmitUserMessageMissingPhaseOpenAILegacyResponseRemainsTerminal(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	client := &fakeClient{responses: []llm.Response{
@@ -58,6 +59,7 @@ func TestSubmitUserMessageMissingPhaseOpenAILegacyResponseRemainsTerminal(t *tes
 }
 
 func TestSubmitUserMessageCommentaryWithoutToolsNonOpenAIRemainsTerminal(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	client := &fakeClient{responses: []llm.Response{
@@ -101,6 +103,7 @@ func TestSubmitUserMessageCommentaryWithoutToolsNonOpenAIRemainsTerminal(t *test
 }
 
 func TestSubmitUserMessageCommentaryWithoutToolsEmitsRealtimeAssistantEvent(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	client := &fakeClient{responses: []llm.Response{
@@ -161,6 +164,7 @@ func TestSubmitUserMessageCommentaryWithoutToolsEmitsRealtimeAssistantEvent(t *t
 }
 
 func TestSubmitUserMessageCommentaryWithToolCallsEmitsContiguousAssistantEvent(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	client := &fakeClient{responses: []llm.Response{
@@ -226,6 +230,7 @@ func TestSubmitUserMessageCommentaryWithToolCallsEmitsContiguousAssistantEvent(t
 }
 
 func TestSubmitUserMessageCommentaryWithToolCallsPublishesCommittedEntryStartMetadata(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	client := &fakeClient{responses: []llm.Response{
@@ -361,6 +366,7 @@ func TestSubmitUserMessageCommentaryWithToolCallsPublishesCommittedEntryStartMet
 }
 
 func TestSubmitUserMessageMissingPhaseWithToolCallsPublishesContiguousAssistantEvent(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	client := &fakeClient{responses: []llm.Response{
@@ -421,6 +427,7 @@ func TestSubmitUserMessageMissingPhaseWithToolCallsPublishesContiguousAssistantE
 }
 
 func TestSubmitUserMessageDoesNotRetainPendingToolStartForHostedExecutions(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	client := &fakeClient{responses: []llm.Response{
@@ -464,6 +471,7 @@ func TestSubmitUserMessageDoesNotRetainPendingToolStartForHostedExecutions(t *te
 }
 
 func TestSubmitUserMessageLegacyArtifactContentRemainsTerminal(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	client := &fakeClient{responses: []llm.Response{
@@ -508,6 +516,7 @@ func TestSubmitUserMessageLegacyArtifactContentRemainsTerminal(t *testing.T) {
 }
 
 func TestSubmitUserMessageFinalAnswerWithoutContentForcesNextLoop(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 
 	client := &fakeClient{responses: []llm.Response{

--- a/server/runtime/engine_part9_test.go
+++ b/server/runtime/engine_part9_test.go
@@ -488,27 +488,62 @@ func TestStreamingNonRetriableErrorResetsAttemptDeltas(t *testing.T) {
 	defer mu.Unlock()
 
 	var deltaIndex int
-	var hasDelta bool
-	var resetIndex int
-	var hasReset bool
+	hasDelta := false
+	var delta Event
+	var terminals []Event
+	assistantMessageCount := 0
 	for i, evt := range events {
-		if evt.Kind == EventAssistantDelta && evt.AssistantDelta == "partial" && !hasDelta {
+		switch evt.Kind {
+		case EventAssistantDelta:
+			if hasDelta {
+				t.Fatalf("multiple assistant deltas before terminal error: %+v", events)
+			}
 			deltaIndex = i
 			hasDelta = true
-		}
-		if evt.Kind == EventAssistantDeltaReset && !hasReset {
-			resetIndex = i
-			hasReset = true
+			delta = evt
+		case EventAssistantDeltaReset:
+			terminals = append(terminals, evt)
+		case EventAssistantMessage:
+			assistantMessageCount++
 		}
 	}
-	if !hasDelta {
+	if !hasDelta || delta.AssistantTranscriptStreamID == nil {
 		t.Fatalf("missing streamed delta before terminal error: %+v", events)
 	}
-	if !hasReset {
-		t.Fatalf("missing reset after terminal error: %+v", events)
+	if len(terminals) != 1 {
+		t.Fatalf("assistant stream terminals = %+v, want exactly one: %+v", terminals, events)
 	}
-	if deltaIndex > resetIndex {
-		t.Fatalf("unexpected delta/reset ordering delta=%d reset=%d", deltaIndex, resetIndex)
+	terminal := terminals[0]
+	if terminal.AssistantTranscriptStreamID == nil ||
+		*terminal.AssistantTranscriptStreamID != *delta.AssistantTranscriptStreamID ||
+		terminal.AssistantStreamAbortReason != string(AssistantStreamAbortSuperseded) {
+		t.Fatalf("assistant stream terminal = %+v, delta = %+v", terminal, delta)
+	}
+	if assistantMessageCount != 0 {
+		t.Fatalf("final assistant events = %d, want none: %+v", assistantMessageCount, events)
+	}
+
+	var cleanupKinds []EventKind
+	for _, evt := range events[deltaIndex+1:] {
+		switch evt.Kind {
+		case EventConversationUpdated, EventAssistantDeltaReset, EventReasoningDeltaReset:
+			cleanupKinds = append(cleanupKinds, evt.Kind)
+		}
+	}
+	wantCleanupKinds := []EventKind{
+		EventConversationUpdated,
+		EventAssistantDeltaReset,
+		EventReasoningDeltaReset,
+		EventConversationUpdated,
+		EventReasoningDeltaReset,
+	}
+	if len(cleanupKinds) != len(wantCleanupKinds) {
+		t.Fatalf("cleanup event kinds = %v, want %v", cleanupKinds, wantCleanupKinds)
+	}
+	for i, want := range wantCleanupKinds {
+		if cleanupKinds[i] != want {
+			t.Fatalf("cleanup event kinds = %v, want %v", cleanupKinds, wantCleanupKinds)
+		}
 	}
 }
 

--- a/server/runtime/missing_tool_output_repair_test.go
+++ b/server/runtime/missing_tool_output_repair_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestMissingToolOutputRepairAppendsSyntheticOutputAndRetries(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	if _, _, err := appendTestEvent(t, store, "step", llm.Message{
 		Role:      llm.RoleAssistant,
@@ -84,6 +85,7 @@ func TestMissingToolOutputRepairAppendsSyntheticOutputAndRetries(t *testing.T) {
 }
 
 func TestMissingToolOutputRepairRetryIncludesQueuedSteering(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	if _, _, err := appendTestEvent(t, store, "step", llm.Message{
 		Role:      llm.RoleAssistant,
@@ -138,6 +140,7 @@ func TestMissingToolOutputRepairRetryIncludesQueuedSteering(t *testing.T) {
 }
 
 func TestMissingToolOutputRepairLeavesUnrelated400Unrepaired(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	client := &fakeClient{
 		errors: []error{&llm.APIStatusError{StatusCode: 400, Body: "malformed request"}},
@@ -153,6 +156,7 @@ func TestMissingToolOutputRepairLeavesUnrelated400Unrepaired(t *testing.T) {
 }
 
 func TestRequiredToolChoiceRepairsDanglingOutputAndRebuildsRequest(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	if _, _, err := appendTestEvent(t, store, "step", llm.Message{
 		Role:      llm.RoleAssistant,
@@ -195,6 +199,7 @@ func TestRequiredToolChoiceRepairsDanglingOutputAndRebuildsRequest(t *testing.T)
 }
 
 func TestRepairMissingToolOutputsByAppendingIsIdempotent(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	if _, _, err := appendTestEvent(t, store, "step", llm.Message{
 		Role:      llm.RoleAssistant,
@@ -218,6 +223,7 @@ func TestRepairMissingToolOutputsByAppendingIsIdempotent(t *testing.T) {
 }
 
 func TestRepairMissingToolOutputsRetainsDanglingCallStepIdentity(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	if _, _, err := appendTestEvent(t, store, chatStoreTestStepID, llm.Message{
 		Role:      llm.RoleAssistant,
@@ -238,6 +244,7 @@ func TestRepairMissingToolOutputsRetainsDanglingCallStepIdentity(t *testing.T) {
 }
 
 func TestRepairMissingToolOutputsUsesRepairStepForUnownedLegacyCall(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	legacyMessage, err := sessionMessageRecordFromLLM(llm.Message{
 		Role:      llm.RoleAssistant,
@@ -262,6 +269,7 @@ func TestRepairMissingToolOutputsUsesRepairStepForUnownedLegacyCall(t *testing.T
 }
 
 func TestRepairMissingToolOutputsRejectsUnownedCallsBeforeAppending(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	if _, _, err := appendTestEvent(t, store, chatStoreTestStepID, llm.Message{
 		Role:      llm.RoleAssistant,
@@ -322,6 +330,7 @@ func repairCompletionRecord(
 }
 
 func TestRepairMissingToolOutputsDefersToPendingToolCallStarts(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	if _, _, err := appendTestEvent(t, store, "step", llm.Message{
 		Role:      llm.RoleAssistant,
@@ -345,6 +354,7 @@ func TestRepairMissingToolOutputsDefersToPendingToolCallStarts(t *testing.T) {
 }
 
 func TestRepairMissingToolOutputsPersistSyntheticErrorPresentation(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	if _, _, err := appendTestEvent(t, store, "step", llm.Message{
 		Role: llm.RoleAssistant,
@@ -368,6 +378,7 @@ func TestRepairMissingToolOutputsPersistSyntheticErrorPresentation(t *testing.T)
 }
 
 func TestCompactionMissingToolOutputRepairAppendsAndRetries(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	if _, _, err := appendTestEvent(t, store, "step", llm.Message{
 		Role:      llm.RoleAssistant,
@@ -401,6 +412,7 @@ func TestCompactionMissingToolOutputRepairAppendsAndRetries(t *testing.T) {
 }
 
 func TestCompactionMissingToolOutputRepairRunsSinglePass(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	if _, _, err := appendTestEvent(t, store, "step", llm.Message{
 		Role:      llm.RoleAssistant,
@@ -430,6 +442,7 @@ func TestCompactionMissingToolOutputRepairRunsSinglePass(t *testing.T) {
 }
 
 func TestCompactionMissingOutputRepairDoesNotConsumeOverflowAttempt(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	client := &fakeCompactionClient{
 		errors: []error{
@@ -515,6 +528,7 @@ func TestCompactionMissingOutputRepairDoesNotConsumeOverflowAttempt(t *testing.T
 }
 
 func TestCompactionMissingOutputAfterCollapsePanics(t *testing.T) {
+	t.Parallel()
 	store := mustCreateTestSession(t)
 	client := &fakeCompactionClient{
 		compactionErrors: []error{

--- a/server/runtime/output_steering.go
+++ b/server/runtime/output_steering.go
@@ -519,7 +519,7 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 			clearedMetadata, clearedStreamID = e.clearStreamingAssistantStateRaw()
 		}
 		if item.streaming.resetEvents {
-			return e.emitStreamingAssistantResetEventsRaw(stepID, clearedMetadata, clearedStreamID, item.streaming.abortReason)
+			return e.emitStreamingAssistantCleanupEventsRaw(stepID, clearedMetadata, clearedStreamID, item.streaming.abortReason)
 		}
 		return nil
 	}

--- a/server/runtime/runtime_test_helpers_test.go
+++ b/server/runtime/runtime_test_helpers_test.go
@@ -205,7 +205,18 @@ func mustCreateNamedTestSessionAt(t *testing.T, root string, workspaceContainerN
 	if err != nil {
 		t.Fatalf("create store: %v", err)
 	}
+	initializeTestEventLog(t, store)
 	return store
+}
+
+func initializeTestEventLog(t *testing.T, store *session.Store) {
+	t.Helper()
+	// Fresh runtime fixtures always need a materializable current log. Writing
+	// its stable header here avoids repeating header initialization per engine.
+	sessiontest.WriteEventLogHeaderFixture(t, store, session.EventLogHeader{
+		Contract: session.EventLogContract,
+		Version:  session.EventLogVersionV1,
+	})
 }
 
 func mustOpenTestSession(t *testing.T, dir string) *session.Store {

--- a/server/session/sessiontest/sessiontest.go
+++ b/server/session/sessiontest/sessiontest.go
@@ -18,6 +18,30 @@ import (
 	"core/internal/testharness/recordstore"
 )
 
+// WriteEventLogHeaderFixture replaces a test session's event artifact with a
+// self-describing header fixture.
+func WriteEventLogHeaderFixture(
+	t testing.TB,
+	store *session.Store,
+	header session.EventLogHeader,
+) {
+	t.Helper()
+	if store == nil {
+		t.Fatal("session store is required")
+	}
+	encoded, err := json.Marshal(header)
+	if err != nil {
+		t.Fatalf("marshal event log header fixture: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(store.Dir(), "events.jsonl"),
+		append(encoded, '\n'),
+		0o600,
+	); err != nil {
+		t.Fatalf("write event log header fixture: %v", err)
+	}
+}
+
 // WriteUnsupportedEventLogVersion replaces a test session's event artifact
 // with a newer self-describing header.
 func WriteUnsupportedEventLogVersion(
@@ -26,9 +50,6 @@ func WriteUnsupportedEventLogVersion(
 	version int,
 ) {
 	t.Helper()
-	if store == nil {
-		t.Fatal("session store is required")
-	}
 	if version <= session.EventLogVersionV1 {
 		t.Fatalf(
 			"unsupported event log fixture version = %d, want > %d",
@@ -36,20 +57,10 @@ func WriteUnsupportedEventLogVersion(
 			session.EventLogVersionV1,
 		)
 	}
-	header, err := json.Marshal(session.EventLogHeader{
+	WriteEventLogHeaderFixture(t, store, session.EventLogHeader{
 		Contract: session.EventLogContract,
 		Version:  version,
 	})
-	if err != nil {
-		t.Fatalf("marshal unsupported event log header: %v", err)
-	}
-	if err := os.WriteFile(
-		filepath.Join(store.Dir(), "events.jsonl"),
-		append(header, '\n'),
-		0o600,
-	); err != nil {
-		t.Fatalf("write unsupported event log: %v", err)
-	}
 }
 
 type Persistence struct {

--- a/tools/testshard/main.go
+++ b/tools/testshard/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"go/ast"
@@ -45,7 +46,11 @@ func main() {
 		fatalf("plan Go test shards: %v", err)
 	}
 	if requiresRuntimeAdmission(jobs) {
-		if err := runWithRuntimeAdmission(); err != nil {
+		repositoryRoot, err := moduleRoot()
+		if err != nil {
+			fatalf("resolve runtime test repository root: %v", err)
+		}
+		if err := runWithRuntimeAdmission(repositoryRoot); err != nil {
 			fatalf("admit runtime test shards: %v", err)
 		}
 		return
@@ -67,12 +72,33 @@ func requiresRuntimeAdmission(jobs []testJob) bool {
 	return false
 }
 
-func runWithRuntimeAdmission() error {
+func moduleRoot() (string, error) {
+	command := exec.Command("go", "list", "-m", "-f", "{{.Dir}}")
+	output, err := command.Output()
+	if err != nil {
+		return "", err
+	}
+	root := strings.TrimSpace(string(output))
+	if root == "" {
+		return "", errors.New("module root is empty")
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("module root is not a directory: %s", root)
+	}
+	return root, nil
+}
+
+func runWithRuntimeAdmission(repositoryRoot string) error {
 	arguments := append(
-		[]string{runtimeAdmissionLockScriptRelative, os.Args[0]},
+		[]string{filepath.Join(repositoryRoot, runtimeAdmissionLockScriptRelative), os.Args[0]},
 		os.Args[1:]...,
 	)
 	command := exec.Command("python3", arguments...)
+	command.Dir = repositoryRoot
 	command.Stdin = os.Stdin
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr

--- a/tools/testshard/main.go
+++ b/tools/testshard/main.go
@@ -22,6 +22,10 @@ import (
 const (
 	shardThreshold = 30
 	maxShards      = 24
+
+	runtimePackagePath                 = "core/server/runtime"
+	runtimeAdmissionHeldEnvironment    = "KENT_TESTSHARD_RUNTIME_ADMISSION_HELD"
+	runtimeAdmissionLockScriptRelative = "scripts/runtime-test-lock.py"
 )
 
 func main() {
@@ -40,9 +44,40 @@ func main() {
 	if err != nil {
 		fatalf("plan Go test shards: %v", err)
 	}
+	if requiresRuntimeAdmission(jobs) {
+		if err := runWithRuntimeAdmission(); err != nil {
+			fatalf("admit runtime test shards: %v", err)
+		}
+		return
+	}
 	if err := runJobs(jobs, *workers); err != nil {
 		fatalf("run Go test shards: %v", err)
 	}
+}
+
+func requiresRuntimeAdmission(jobs []testJob) bool {
+	if os.Getenv(runtimeAdmissionHeldEnvironment) == "1" {
+		return false
+	}
+	for _, job := range jobs {
+		if job.packagePath == runtimePackagePath {
+			return true
+		}
+	}
+	return false
+}
+
+func runWithRuntimeAdmission() error {
+	arguments := append(
+		[]string{runtimeAdmissionLockScriptRelative, os.Args[0]},
+		os.Args[1:]...,
+	)
+	command := exec.Command("python3", arguments...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	command.Env = append(os.Environ(), runtimeAdmissionHeldEnvironment+"=1")
+	return command.Run()
 }
 
 func listPackages(pattern string) ([]goPackage, error) {

--- a/tools/testshard/main_test.go
+++ b/tools/testshard/main_test.go
@@ -299,6 +299,38 @@ func TestGoTestArgumentsLimitEachShardToOnePackageBuild(t *testing.T) {
 	}
 }
 
+func TestRequiresRuntimeAdmissionOnlyForUnadmittedRuntimeJobs(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		jobs []testJob
+		want bool
+	}{
+		{
+			name: "runtime job",
+			jobs: []testJob{{packagePath: runtimePackagePath}},
+			want: true,
+		},
+		{
+			name: "non-runtime job",
+			jobs: []testJob{{packagePath: "core/server/session"}},
+		},
+		{
+			name: "admitted runtime job",
+			env:  "1",
+			jobs: []testJob{{packagePath: runtimePackagePath}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(runtimeAdmissionHeldEnvironment, test.env)
+			if got := requiresRuntimeAdmission(test.jobs); got != test.want {
+				t.Fatalf("requires runtime admission = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
 func TestUnshardedJobEventOmitsAbsentRootListHash(t *testing.T) {
 	event := completedJobEvent(testJob{
 		packagePath:   "core/fixture",


### PR DESCRIPTION
## Summary
- Makes live streaming state the sole authority for assistant terminals: failed streamed attempts now publish exactly one typed `superseded` reset for the active stream and no final assistant event.
- Strengthens the typed runtime-event regression to assert terminal identity, ordering, and no final assistant event.
- Serializes shared-host runtime testing without changing the 180-second active-test cap. Full `./...` re-execs the sharder once under admission; direct runtime selections resolve filesystem directories to canonical Go import paths before admission.

## Verification
- Focused stream/reopen/lock/late-drain suite passed in 2.322s.
- Exact capped runtime suite passed twice after rebase: `ok core/server/runtime 127.992s` and `120.814s`.
- CI-equivalent `KENT_TEST_DISABLE_WALL_CLOCK_CAP=1 ./scripts/test.sh server` passed in 238.619s after the sharder-deadlock fix.
- Sharder admission and nested-script integration tests passed in 0.437s.
- A held-lock check with the absolute normalized runtime directory `server/runtime/../runtime` waited for admission and passed.
- Build, whitespace, shell/Python syntax, and binary-smoke checks passed.

## QA evidence
- Prior isolated manual captures: `.kent/qa/proofs/20260727T031028Z-KENT-340-final-isolated-normal` and `.kent/qa/proofs/20260727T031030Z-KENT-340-final-isolated-interrupt`; ignored local harness artifacts cannot be attached through the GitHub PR API.

## Diff size
Classification treats non-test runtime code as production; `*_test.go`, `server/session/sessiontest`, test-runner scripts, and `tools/testshard` as test/generated infrastructure.
- Production: +27 / -9; net +18 LoC; gross 36 LoC.
- Test/generated: +295 / -28; net +267 LoC; gross 323 LoC.
- Total: +322 / -37; net +285 LoC; gross 359 LoC.

## Caveats and follow-up
- Admission coordinates `scripts/test.sh` runtime invocations; arbitrary direct `go test` and unrelated host load remain outside it.
- `AssistantStreamAbortReason` intentionally remains the locked legacy string shape; optional typing or a terminal-state enum is a separate contract migration.
- No production protocol, client, persistence, or specification contract changed.

## Tracking
- Kent task: KENT-340 — Deduplicate stream terminal resets.
- GitHub issue: none supplied; standalone task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response reset/cleanup behavior, including correct abort-reason handling and consistent cleanup event ordering.
  * Added exclusive “runtime test admission” coordination to prevent conflicting runtime tests from running at the same time.

* **Tests**
  * Enabled more Go tests to run in parallel where safe.
  * Strengthened streaming-related assertions for terminal reset and cleanup event sequences.
  * Improved runtime test event-log setup via a shared fixture helper.
  * Added coverage for when runtime admission locking is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->