### PR TITLE
Deduplicate Home Inbox fetch

### DIFF
--- a/apps/desktop/src/app/connectionRefresh.test.tsx
+++ b/apps/desktop/src/app/connectionRefresh.test.tsx
@@ -10,7 +10,7 @@ import {
   waitForMacrotask,
 } from "@/test-support/scheduling";
 import {
-  workflowAttentionCallCount,
+  workflowAttentionCalls,
   workflowAttentionRpcMethods,
 } from "@/test-support/workflow-attention";
 
@@ -33,7 +33,7 @@ describe("application reconnect attention refresh", () => {
     await flushQueuedWork();
 
     await waitFor(() => {
-      expect(workflowAttentionCallCount(services.transport)).toBe(1);
+      expect(workflowAttentionCalls(services.transport)).toHaveLength(1);
     });
     await waitFor(() => {
       expect(activeProjectSubscriptions(services)).toHaveLength(1);
@@ -47,7 +47,7 @@ describe("application reconnect attention refresh", () => {
       services.transport.open(workflowAttentionRpcMethods.subscribeProject);
       await waitForMacrotask();
     });
-    expect(workflowAttentionCallCount(services.transport)).toBe(1);
+    expect(workflowAttentionCalls(services.transport)).toHaveLength(1);
 
     await act(async () => {
       services.transport.connection.set("disconnected");
@@ -66,7 +66,7 @@ describe("application reconnect attention refresh", () => {
       expect(activeProjectSubscriptions(services)).toHaveLength(1);
     });
     await waitFor(() => {
-      expect(workflowAttentionCallCount(services.transport)).toBe(2);
+      expect(workflowAttentionCalls(services.transport)).toHaveLength(2);
     });
     await flushQueuedWork();
 
@@ -74,7 +74,7 @@ describe("application reconnect attention refresh", () => {
       services.transport.open(workflowAttentionRpcMethods.subscribeProject);
       await waitForMacrotask();
     });
-    expect(workflowAttentionCallCount(services.transport)).toBe(2);
+    expect(workflowAttentionCalls(services.transport)).toHaveLength(2);
   });
 });
 

--- a/apps/desktop/src/app/connectionRefresh.test.tsx
+++ b/apps/desktop/src/app/connectionRefresh.test.tsx
@@ -1,13 +1,18 @@
-import { act, render, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AppRoot } from "./AppRoot";
 import { removeBrowserStorage } from "@/app-facade";
 import { createTestServices, startupRoutes, type TestAppServices } from "@/test-support/app-services";
-import { flushQueuedWork, installAnimationFrameTestSupport } from "@/test-support/scheduling";
-
-const globalAttentionMethod = "workflow.attention.list";
-const globalSubscriptionMethod = "workflow.subscribeProject";
+import {
+  flushQueuedWork,
+  installAnimationFrameTestSupport,
+  waitForMacrotask,
+} from "@/test-support/scheduling";
+import {
+  workflowAttentionCallCount,
+  workflowAttentionRpcMethods,
+} from "@/test-support/workflow-attention";
 
 describe("application reconnect attention refresh", () => {
   beforeEach(() => {
@@ -25,51 +30,58 @@ describe("application reconnect attention refresh", () => {
   it("coordinates central reconnect refresh with replacement subscription readiness", async () => {
     const services = createTestServices(startupRoutes);
     render(<AppRoot services={services} />);
+    await flushQueuedWork();
 
     await waitFor(() => {
-      expect(attentionCalls(services)).toHaveLength(1);
+      expect(workflowAttentionCallCount(services.transport)).toBe(1);
     });
     await waitFor(() => {
       expect(activeProjectSubscriptions(services)).toHaveLength(1);
     });
-
-    act(() => {
-      services.transport.open(globalSubscriptionMethod);
+    await waitFor(() => {
+      expect(screen.getByTestId("home-route-root")).toBeInTheDocument();
     });
     await flushQueuedWork();
-    expect(attentionCalls(services)).toHaveLength(1);
 
-    act(() => {
+    await act(async () => {
+      services.transport.open(workflowAttentionRpcMethods.subscribeProject);
+      await waitForMacrotask();
+    });
+    expect(workflowAttentionCallCount(services.transport)).toBe(1);
+
+    await act(async () => {
       services.transport.connection.set("disconnected");
+      await waitForMacrotask();
     });
     await waitFor(() => {
       expect(activeProjectSubscriptions(services)).toHaveLength(0);
     });
+    await flushQueuedWork();
 
-    act(() => {
+    await act(async () => {
       services.transport.connection.set("connected");
+      await waitForMacrotask();
     });
     await waitFor(() => {
       expect(activeProjectSubscriptions(services)).toHaveLength(1);
     });
     await waitFor(() => {
-      expect(attentionCalls(services)).toHaveLength(2);
-    });
-
-    act(() => {
-      services.transport.open(globalSubscriptionMethod);
+      expect(workflowAttentionCallCount(services.transport)).toBe(2);
     });
     await flushQueuedWork();
-    expect(attentionCalls(services)).toHaveLength(2);
+
+    await act(async () => {
+      services.transport.open(workflowAttentionRpcMethods.subscribeProject);
+      await waitForMacrotask();
+    });
+    expect(workflowAttentionCallCount(services.transport)).toBe(2);
   });
 });
 
-function attentionCalls(services: TestAppServices) {
-  return services.transport.calls.filter((call) => call.method === globalAttentionMethod);
-}
-
 function activeProjectSubscriptions(services: TestAppServices) {
-  return services.transport.subscriptions.filter((subscription) => subscription.method === globalSubscriptionMethod);
+  return services.transport.subscriptions.filter(
+    (subscription) => subscription.method === workflowAttentionRpcMethods.subscribeProject,
+  );
 }
 
 function clearRoutePersistence(): void {

--- a/apps/desktop/src/app/connectionRefresh.test.tsx
+++ b/apps/desktop/src/app/connectionRefresh.test.tsx
@@ -1,0 +1,78 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AppRoot } from "./AppRoot";
+import { removeBrowserStorage } from "@/app-facade";
+import { createTestServices, startupRoutes, type TestAppServices } from "@/test-support/app-services";
+import { flushQueuedWork, installAnimationFrameTestSupport } from "@/test-support/scheduling";
+
+const globalAttentionMethod = "workflow.attention.list";
+const globalSubscriptionMethod = "workflow.subscribeProject";
+
+describe("application reconnect attention refresh", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+    clearRoutePersistence();
+    installAnimationFrameTestSupport();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    window.history.replaceState(null, "", "/");
+    clearRoutePersistence();
+  });
+
+  it("coordinates central reconnect refresh with replacement subscription readiness", async () => {
+    const services = createTestServices(startupRoutes);
+    render(<AppRoot services={services} />);
+
+    await waitFor(() => {
+      expect(attentionCalls(services)).toHaveLength(1);
+    });
+    await waitFor(() => {
+      expect(activeProjectSubscriptions(services)).toHaveLength(1);
+    });
+
+    act(() => {
+      services.transport.open(globalSubscriptionMethod);
+    });
+    await flushQueuedWork();
+    expect(attentionCalls(services)).toHaveLength(1);
+
+    act(() => {
+      services.transport.connection.set("disconnected");
+    });
+    await waitFor(() => {
+      expect(activeProjectSubscriptions(services)).toHaveLength(0);
+    });
+
+    act(() => {
+      services.transport.connection.set("connected");
+    });
+    await waitFor(() => {
+      expect(activeProjectSubscriptions(services)).toHaveLength(1);
+    });
+    await waitFor(() => {
+      expect(attentionCalls(services)).toHaveLength(2);
+    });
+
+    act(() => {
+      services.transport.open(globalSubscriptionMethod);
+    });
+    await flushQueuedWork();
+    expect(attentionCalls(services)).toHaveLength(2);
+  });
+});
+
+function attentionCalls(services: TestAppServices) {
+  return services.transport.calls.filter((call) => call.method === globalAttentionMethod);
+}
+
+function activeProjectSubscriptions(services: TestAppServices) {
+  return services.transport.subscriptions.filter((subscription) => subscription.method === globalSubscriptionMethod);
+}
+
+function clearRoutePersistence(): void {
+  removeBrowserStorage("local", "desktop.lastProjectRoute");
+  removeBrowserStorage("session", "desktop.routeRestoreChecked");
+}

--- a/apps/desktop/src/app/connectionRefresh.test.tsx
+++ b/apps/desktop/src/app/connectionRefresh.test.tsx
@@ -33,11 +33,9 @@ describe("application reconnect attention refresh", () => {
     await flushQueuedWork();
 
     await waitFor(() => {
-      expect(workflowAttentionCalls(services.transport)).toHaveLength(1);
-    });
-    await waitFor(() => {
       expect(activeProjectSubscriptions(services)).toHaveLength(1);
     });
+    expect(workflowAttentionCalls(services.transport)).toHaveLength(0);
     await waitFor(() => {
       expect(screen.getByTestId("home-route-root")).toBeInTheDocument();
     });
@@ -47,7 +45,9 @@ describe("application reconnect attention refresh", () => {
       services.transport.open(workflowAttentionRpcMethods.subscribeProject);
       await waitForMacrotask();
     });
-    expect(workflowAttentionCalls(services.transport)).toHaveLength(1);
+    await waitFor(() => {
+      expect(workflowAttentionCalls(services.transport)).toHaveLength(1);
+    });
 
     await act(async () => {
       services.transport.connection.set("disconnected");
@@ -65,16 +65,16 @@ describe("application reconnect attention refresh", () => {
     await waitFor(() => {
       expect(activeProjectSubscriptions(services)).toHaveLength(1);
     });
-    await waitFor(() => {
-      expect(workflowAttentionCalls(services.transport)).toHaveLength(2);
-    });
-    await flushQueuedWork();
+    expect(workflowAttentionCalls(services.transport)).toHaveLength(1);
 
     await act(async () => {
       services.transport.open(workflowAttentionRpcMethods.subscribeProject);
       await waitForMacrotask();
     });
-    expect(workflowAttentionCalls(services.transport)).toHaveLength(2);
+    await waitFor(() => {
+      expect(workflowAttentionCalls(services.transport)).toHaveLength(2);
+    });
+    await flushQueuedWork();
   });
 });
 

--- a/apps/desktop/src/features/home/HomeRoute.tsx
+++ b/apps/desktop/src/features/home/HomeRoute.tsx
@@ -42,8 +42,8 @@ export function HomeRoute() {
   const queryClient = useQueryClient();
   const creation = useProjectCreation();
   const projects = useProjectPages();
-  const attention = useGlobalAttentionPages();
-  useGlobalAttentionEvents();
+  const attentionSubscriptionReady = useGlobalAttentionEvents();
+  const attention = useGlobalAttentionPages(attentionSubscriptionReady);
   const [primaryTab, setPrimaryTab] = useState<HomePrimaryTab>("projects");
   const projectItems = projects.data?.pages.flatMap((page) => page.projects) ?? [];
   const attentionItems = attention.data?.pages.flatMap((page) => page.items) ?? [];

--- a/apps/desktop/src/features/home/SidebarInboxNav.tsx
+++ b/apps/desktop/src/features/home/SidebarInboxNav.tsx
@@ -7,7 +7,7 @@ import { useSidebar } from "@/app-facade";
 import { taskDetailInitialFocusFromAttentionItem } from "@/app-facade";
 import { IconTooltipButton } from "@/ui";
 import { inboxNavNeighbors, orderedInboxTaskIDs } from "./inboxNavNeighbors";
-import { useGlobalAttentionPages } from "./useHomeData";
+import { useSidebarGlobalAttentionPages } from "./useHomeData";
 
 type TaskDetailDestination = Extract<SidebarDestination, { kind: "taskDetail" }>;
 
@@ -20,7 +20,7 @@ type TaskDetailDestination = Extract<SidebarDestination, { kind: "taskDetail" }>
 export function SidebarInboxNav({ destination }: Readonly<{ destination: TaskDetailDestination }>) {
   const { t } = useTranslation();
   const { openSidebar } = useSidebar();
-  const attention = useGlobalAttentionPages();
+  const attention = useSidebarGlobalAttentionPages();
   // Remembers the open task's last position so Next still works after it is
   // resolved and drops out of the live inbox; updated only while it is present.
   const [anchorIndex, setAnchorIndex] = useState(0);

--- a/apps/desktop/src/features/home/useHomeData.test.tsx
+++ b/apps/desktop/src/features/home/useHomeData.test.tsx
@@ -24,11 +24,14 @@ describe("Home global attention data", () => {
     vi.unstubAllGlobals();
   });
 
-  it("loads once before opening the stream, refreshes for events, and reconciles after recovery", async () => {
+  it("opens the stream before the initial attention load, refreshes for events, and reconciles after recovery", async () => {
     const services = createAttentionServices();
     renderHome(services, <HomeAttentionEventsHarness />);
 
-    await expectAttentionCalls(services.transport, 1);
+    await waitFor(() => {
+      expect(services.transport.subscriptions).toHaveLength(1);
+    });
+    expect(workflowAttentionCalls(services.transport)).toHaveLength(0);
 
     act(() => {
       services.transport.open(workflowAttentionRpcMethods.subscribeProject);
@@ -57,7 +60,10 @@ describe("Home global attention data", () => {
     const services = createAttentionServices();
     renderHome(services, <HomeAttentionEventsHarness />);
 
-    await expectAttentionCalls(services.transport, 1);
+    await waitFor(() => {
+      expect(services.transport.subscriptions).toHaveLength(1);
+    });
+    expect(workflowAttentionCalls(services.transport)).toHaveLength(0);
 
     act(() => {
       services.transport.fail(
@@ -66,19 +72,21 @@ describe("Home global attention data", () => {
       );
     });
     await flushQueuedWork();
-    expect(attentionPageTokens(services.transport)).toEqual([""]);
+    expect(attentionPageTokens(services.transport)).toEqual([]);
 
     act(() => {
       services.transport.open(workflowAttentionRpcMethods.subscribeProject);
     });
-    await expectAttentionCalls(services.transport, 2);
+    await expectAttentionCalls(services.transport, 1);
   });
 
   it("reconciles after a decoder error while the Project stream remains open", async () => {
     const services = createAttentionServices();
     renderHome(services, <HomeAttentionEventsHarness />);
 
-    await expectAttentionCalls(services.transport, 1);
+    await waitFor(() => {
+      expect(services.transport.subscriptions).toHaveLength(1);
+    });
     act(() => {
       services.transport.open(workflowAttentionRpcMethods.subscribeProject);
     });
@@ -208,8 +216,8 @@ function renderHome(services: TestAppServices, children: ReactNode) {
 }
 
 function HomeAttentionEventsHarness() {
-  useGlobalAttentionPages();
-  useGlobalAttentionEvents();
+  const attentionSubscriptionReady = useGlobalAttentionEvents();
+  useGlobalAttentionPages(attentionSubscriptionReady);
   return null;
 }
 

--- a/apps/desktop/src/features/home/useHomeData.test.tsx
+++ b/apps/desktop/src/features/home/useHomeData.test.tsx
@@ -1,0 +1,351 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { useEffect, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import type { JsonValue } from "@/api";
+import { SidebarContext, type SidebarController, type SidebarDestination } from "@/app-facade";
+import { createTestServices, TestAppProviders, type TestAppServices } from "@/test-support/app-services";
+import type { FakeRpcTransport, FakeRoute } from "@/test-support/api";
+import { flushQueuedWork, installAnimationFrameTestSupport } from "@/test-support/scheduling";
+import { SidebarInboxNav } from "./SidebarInboxNav";
+import { useGlobalAttentionEvents, useGlobalAttentionPages } from "./useHomeData";
+
+const globalSubscriptionMethod = "workflow.subscribeProject";
+const globalEventMethod = "workflow.project";
+const globalAttentionMethod = "workflow.attention.list";
+
+describe("Home global attention data", () => {
+  beforeEach(() => {
+    installAnimationFrameTestSupport();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads once before opening the stream, refreshes for events, and reconciles after recovery", async () => {
+    const services = createAttentionServices();
+    renderHome(services, <HomeAttentionEventsHarness />);
+
+    await expectAttentionCalls(services.transport, 1);
+
+    act(() => {
+      services.transport.open(globalSubscriptionMethod);
+    });
+    await flushQueuedWork();
+    expect(attentionPageTokens(services.transport)).toEqual([""]);
+
+    act(() => {
+      services.transport.emit(globalEventMethod, attentionChangingProjectEvent);
+    });
+    await expectAttentionCalls(services.transport, 2);
+
+    act(() => {
+      services.transport.fail(globalSubscriptionMethod, new Error("stream failed"));
+    });
+    await flushQueuedWork();
+    expect(attentionPageTokens(services.transport)).toHaveLength(2);
+
+    act(() => {
+      services.transport.open(globalSubscriptionMethod);
+    });
+    await expectAttentionCalls(services.transport, 3);
+  });
+
+  it("reconciles a stream that fails before its first successful open", async () => {
+    const services = createAttentionServices();
+    renderHome(services, <HomeAttentionEventsHarness />);
+
+    await expectAttentionCalls(services.transport, 1);
+
+    act(() => {
+      services.transport.fail(globalSubscriptionMethod, new Error("stream failed before open"));
+    });
+    await flushQueuedWork();
+    expect(attentionPageTokens(services.transport)).toEqual([""]);
+
+    act(() => {
+      services.transport.open(globalSubscriptionMethod);
+    });
+    await expectAttentionCalls(services.transport, 2);
+  });
+
+  it("refreshes Inbox when a live subscription reports an invalid event payload", async () => {
+    const services = createAttentionServices();
+    renderHome(services, <HomeAttentionEventsHarness />);
+
+    await expectAttentionCalls(services.transport, 1);
+    act(() => {
+      services.transport.open(globalSubscriptionMethod);
+    });
+    await flushQueuedWork();
+
+    act(() => {
+      services.transport.emit(globalEventMethod, invalidProjectEvent);
+    });
+    await expectAttentionCalls(services.transport, 2);
+  });
+
+  it("does not refetch Sidebar navigation when Home already owns populated attention data", async () => {
+    const services = createAttentionServices();
+    const view = renderHome(services, <HomeAttentionQueryHarness />);
+
+    await expectAttentionCalls(services.transport, 1);
+
+    view.rerender(
+      <TestAppProviders services={services}>
+        <SidebarContext.Provider value={sidebarController}>
+          <HomeAttentionQueryHarness />
+          <SidebarInboxNav destination={taskDetailDestination} />
+        </SidebarContext.Provider>
+      </TestAppProviders>,
+    );
+    await flushQueuedWork();
+
+    expect(attentionPageTokens(services.transport)).toEqual([""]);
+  });
+
+  it("loads a cold cache when Sidebar is the only global attention observer", async () => {
+    const services = createAttentionServices();
+    renderHome(services, <SidebarInboxNav destination={taskDetailDestination} />);
+
+    await expectAttentionCalls(services.transport, 1);
+    expect(attentionPageTokens(services.transport)).toEqual([""]);
+  });
+
+  it("refreshes stale data for a sole Sidebar observer and renders the refreshed navigation", async () => {
+    const services = createAttentionServices((pageToken, callIndex) => {
+      if (pageToken !== "") {
+        return attentionResponse([]);
+      }
+      return attentionResponse(callIndex === 0 ? [attentionItem("task-1")] : [
+        attentionItem("task-1"),
+        attentionItem("task-2"),
+      ]);
+    });
+    const openedDestinations: SidebarDestination[] = [];
+    const controller = createSidebarController((destination) => {
+      openedDestinations.push(destination);
+    });
+    const view = renderHome(services, <HomeAttentionQueryHarness />);
+
+    await expectAttentionCalls(services.transport, 1);
+    view.rerender(
+      <TestAppProviders services={services}>
+        <SidebarContext.Provider value={sidebarController}>
+          <div />
+        </SidebarContext.Provider>
+      </TestAppProviders>,
+    );
+    view.rerender(
+      <TestAppProviders services={services}>
+        <SidebarContext.Provider value={controller}>
+          <SidebarInboxNav destination={taskDetailDestination} />
+        </SidebarContext.Provider>
+      </TestAppProviders>,
+    );
+
+    await expectAttentionCalls(services.transport, 2);
+    await waitFor(() => {
+      expect(screen.getAllByRole("button")).toHaveLength(1);
+    });
+    const nextButton = screen.getAllByRole("button")[0];
+    if (nextButton === undefined) {
+      throw new Error("Sidebar Inbox navigation did not render its available control.");
+    }
+    act(() => {
+      nextButton.click();
+    });
+    expect(openedDestinations).toHaveLength(1);
+    expect(openedDestinations[0]).toMatchObject({
+      inboxNav: true,
+      kind: "taskDetail",
+      taskID: "task-2",
+    });
+  });
+
+  it("forwards the production infinite-query next-page token exactly once", async () => {
+    let attentionQuery: ReturnType<typeof useGlobalAttentionPages> | undefined;
+    const services = createAttentionServices((pageToken) =>
+      pageToken === "" ? attentionResponse([], "page-2") : attentionResponse([]),
+    );
+    renderHome(
+      services,
+      <HomeAttentionQueryHarness
+        onQuery={(query) => {
+          attentionQuery = query;
+        }}
+      />,
+    );
+
+    await expectAttentionCalls(services.transport, 1);
+    await waitFor(() => {
+      expect(attentionQuery?.hasNextPage).toBe(true);
+    });
+    const query = attentionQuery;
+    if (query === undefined) {
+      throw new Error("Home attention query was not exposed by the rendered harness.");
+    }
+
+    await act(async () => {
+      await query.fetchNextPage();
+    });
+    await expectAttentionCalls(services.transport, 2);
+    expect(attentionPageTokens(services.transport)).toEqual(["", "page-2"]);
+  });
+});
+
+function renderHome(services: TestAppServices, children: ReactNode) {
+  return render(
+    <TestAppProviders services={services}>
+      <SidebarContext.Provider value={sidebarController}>{children}</SidebarContext.Provider>
+    </TestAppProviders>,
+  );
+}
+
+function HomeAttentionEventsHarness() {
+  useGlobalAttentionPages();
+  useGlobalAttentionEvents();
+  return null;
+}
+
+function HomeAttentionQueryHarness({
+  onQuery,
+}: Readonly<{
+  onQuery?: (query: ReturnType<typeof useGlobalAttentionPages>) => void;
+}>) {
+  const query = useGlobalAttentionPages();
+  useEffect(() => {
+    onQuery?.(query);
+  }, [onQuery, query]);
+  return null;
+}
+
+type AttentionPageFactory = (
+  pageToken: string,
+  callIndex: number,
+) => Readonly<Record<string, JsonValue>>;
+
+function createAttentionServices(page: AttentionPageFactory = () => attentionResponse([])): TestAppServices {
+  return createTestServices([attentionRoute(page)]);
+}
+
+function attentionRoute(
+  page: (pageToken: string, callIndex: number) => Readonly<Record<string, JsonValue>>,
+): FakeRoute {
+  return {
+    method: globalAttentionMethod,
+    handler(params, callIndex) {
+      const pageToken = attentionRequestParamsSchema.parse(params).page_token;
+      return page(pageToken, callIndex);
+    },
+  };
+}
+
+function attentionResponse(items: readonly Readonly<Record<string, JsonValue>>[], nextPageToken = "") {
+  return {
+    items,
+    next_page_token: nextPageToken,
+    generated_at_unix_ms: 1,
+  } satisfies Readonly<Record<string, JsonValue>>;
+}
+
+function attentionItem(taskID: string): Readonly<Record<string, JsonValue>> {
+  return {
+    id: `approval:${taskID}`,
+    kind: "approval",
+    project_id: "project-1",
+    workflow_id: "workflow-1",
+    task_id: taskID,
+    task_short_id: taskID,
+    task_title: taskID,
+    approval_id: `approval-${taskID}`,
+    message: "Approval required",
+    approval_snapshot: {
+      source_node_display_name: "Review",
+      targets: [{ display_name: "Done" }],
+      commentary: "",
+      output_values: {},
+      workflow_revision_seen: 1,
+    },
+    occurred_at_unix_ms: 1,
+  };
+}
+
+function attentionPageTokens(transport: FakeRpcTransport): string[] {
+  return transport.calls
+    .filter((call) => call.method === globalAttentionMethod)
+    .map((call) => {
+      return attentionRequestParamsSchema.parse(call.params).page_token;
+    });
+}
+
+async function expectAttentionCalls(transport: FakeRpcTransport, count: number): Promise<void> {
+  await waitFor(() => {
+    expect(transport.calls.filter((call) => call.method === globalAttentionMethod)).toHaveLength(count);
+  });
+}
+
+const taskDetailDestination = {
+  kind: "taskDetail",
+  inboxNav: true,
+  taskID: "task-1",
+} as const;
+
+const sidebarController = createSidebarController();
+
+function createSidebarController(
+  onOpen: (destination: SidebarDestination) => void = () => {
+    return;
+  },
+): SidebarController {
+  return {
+    activeDestination: null,
+    closeSidebar() {
+      return;
+    },
+    async openSidebar(destination) {
+      onOpen(destination);
+      return { status: "canceled", reason: "closed" };
+    },
+    phase: "open",
+    resolveSidebar() {
+      return;
+    },
+    resizeSidebar() {
+      return;
+    },
+    sidebarWidthPx: 320,
+  };
+}
+
+const attentionChangingProjectEvent = {
+  event: {
+    action: "updated",
+    occurred_at_unix_ms: 2,
+    primary_entity_id: "task-1",
+    project_id: "project-1",
+    related_ids: [],
+    resource: "task",
+    workflow_id: "workflow-1",
+  },
+} as const;
+
+const invalidProjectEvent = {
+  event: {
+    action: "updated",
+    occurred_at_unix_ms: 3,
+    primary_entity_id: "task-1",
+    project_id: "project-1",
+    related_ids: [],
+    resource: "task",
+  },
+} as const;
+
+const attentionRequestParamsSchema = z
+  .object({
+    page_size: z.number(),
+    page_token: z.string(),
+  })
+  .strict();

--- a/apps/desktop/src/features/home/useHomeData.test.tsx
+++ b/apps/desktop/src/features/home/useHomeData.test.tsx
@@ -8,12 +8,13 @@ import { SidebarContext, type SidebarController, type SidebarDestination } from 
 import { createTestServices, TestAppProviders, type TestAppServices } from "@/test-support/app-services";
 import type { FakeRpcTransport, FakeRoute } from "@/test-support/api";
 import { flushQueuedWork, installAnimationFrameTestSupport } from "@/test-support/scheduling";
+import {
+  workflowAttentionCallCount,
+  workflowAttentionCalls,
+  workflowAttentionRpcMethods,
+} from "@/test-support/workflow-attention";
 import { SidebarInboxNav } from "./SidebarInboxNav";
 import { useGlobalAttentionEvents, useGlobalAttentionPages } from "./useHomeData";
-
-const globalSubscriptionMethod = "workflow.subscribeProject";
-const globalEventMethod = "workflow.project";
-const globalAttentionMethod = "workflow.attention.list";
 
 describe("Home global attention data", () => {
   beforeEach(() => {
@@ -31,24 +32,24 @@ describe("Home global attention data", () => {
     await expectAttentionCalls(services.transport, 1);
 
     act(() => {
-      services.transport.open(globalSubscriptionMethod);
+      services.transport.open(workflowAttentionRpcMethods.subscribeProject);
     });
     await flushQueuedWork();
     expect(attentionPageTokens(services.transport)).toEqual([""]);
 
     act(() => {
-      services.transport.emit(globalEventMethod, attentionChangingProjectEvent);
+      services.transport.emit(workflowAttentionRpcMethods.projectEvent, attentionChangingProjectEvent);
     });
     await expectAttentionCalls(services.transport, 2);
 
     act(() => {
-      services.transport.fail(globalSubscriptionMethod, new Error("stream failed"));
+      services.transport.fail(workflowAttentionRpcMethods.subscribeProject, new Error("stream failed"));
     });
     await flushQueuedWork();
     expect(attentionPageTokens(services.transport)).toHaveLength(2);
 
     act(() => {
-      services.transport.open(globalSubscriptionMethod);
+      services.transport.open(workflowAttentionRpcMethods.subscribeProject);
     });
     await expectAttentionCalls(services.transport, 3);
   });
@@ -60,29 +61,16 @@ describe("Home global attention data", () => {
     await expectAttentionCalls(services.transport, 1);
 
     act(() => {
-      services.transport.fail(globalSubscriptionMethod, new Error("stream failed before open"));
+      services.transport.fail(
+        workflowAttentionRpcMethods.subscribeProject,
+        new Error("stream failed before open"),
+      );
     });
     await flushQueuedWork();
     expect(attentionPageTokens(services.transport)).toEqual([""]);
 
     act(() => {
-      services.transport.open(globalSubscriptionMethod);
-    });
-    await expectAttentionCalls(services.transport, 2);
-  });
-
-  it("refreshes Inbox when a live subscription reports an invalid event payload", async () => {
-    const services = createAttentionServices();
-    renderHome(services, <HomeAttentionEventsHarness />);
-
-    await expectAttentionCalls(services.transport, 1);
-    act(() => {
-      services.transport.open(globalSubscriptionMethod);
-    });
-    await flushQueuedWork();
-
-    act(() => {
-      services.transport.emit(globalEventMethod, invalidProjectEvent);
+      services.transport.open(workflowAttentionRpcMethods.subscribeProject);
     });
     await expectAttentionCalls(services.transport, 2);
   });
@@ -235,7 +223,7 @@ function attentionRoute(
   page: (pageToken: string, callIndex: number) => Readonly<Record<string, JsonValue>>,
 ): FakeRoute {
   return {
-    method: globalAttentionMethod,
+    method: workflowAttentionRpcMethods.list,
     handler(params, callIndex) {
       const pageToken = attentionRequestParamsSchema.parse(params).page_token;
       return page(pageToken, callIndex);
@@ -274,16 +262,12 @@ function attentionItem(taskID: string): Readonly<Record<string, JsonValue>> {
 }
 
 function attentionPageTokens(transport: FakeRpcTransport): string[] {
-  return transport.calls
-    .filter((call) => call.method === globalAttentionMethod)
-    .map((call) => {
-      return attentionRequestParamsSchema.parse(call.params).page_token;
-    });
+  return workflowAttentionCalls(transport).map((call) => attentionRequestParamsSchema.parse(call.params).page_token);
 }
 
 async function expectAttentionCalls(transport: FakeRpcTransport, count: number): Promise<void> {
   await waitFor(() => {
-    expect(transport.calls.filter((call) => call.method === globalAttentionMethod)).toHaveLength(count);
+    expect(workflowAttentionCallCount(transport)).toBe(count);
   });
 }
 
@@ -329,17 +313,6 @@ const attentionChangingProjectEvent = {
     related_ids: [],
     resource: "task",
     workflow_id: "workflow-1",
-  },
-} as const;
-
-const invalidProjectEvent = {
-  event: {
-    action: "updated",
-    occurred_at_unix_ms: 3,
-    primary_entity_id: "task-1",
-    project_id: "project-1",
-    related_ids: [],
-    resource: "task",
   },
 } as const;
 

--- a/apps/desktop/src/features/home/useHomeData.test.tsx
+++ b/apps/desktop/src/features/home/useHomeData.test.tsx
@@ -9,7 +9,6 @@ import { createTestServices, TestAppProviders, type TestAppServices } from "@/te
 import type { FakeRpcTransport, FakeRoute } from "@/test-support/api";
 import { flushQueuedWork, installAnimationFrameTestSupport } from "@/test-support/scheduling";
 import {
-  workflowAttentionCallCount,
   workflowAttentionCalls,
   workflowAttentionRpcMethods,
 } from "@/test-support/workflow-attention";
@@ -71,6 +70,22 @@ describe("Home global attention data", () => {
 
     act(() => {
       services.transport.open(workflowAttentionRpcMethods.subscribeProject);
+    });
+    await expectAttentionCalls(services.transport, 2);
+  });
+
+  it("reconciles after a decoder error while the Project stream remains open", async () => {
+    const services = createAttentionServices();
+    renderHome(services, <HomeAttentionEventsHarness />);
+
+    await expectAttentionCalls(services.transport, 1);
+    act(() => {
+      services.transport.open(workflowAttentionRpcMethods.subscribeProject);
+    });
+    await flushQueuedWork();
+
+    act(() => {
+      services.transport.emit(workflowAttentionRpcMethods.projectEvent, invalidProjectEvent);
     });
     await expectAttentionCalls(services.transport, 2);
   });
@@ -267,7 +282,7 @@ function attentionPageTokens(transport: FakeRpcTransport): string[] {
 
 async function expectAttentionCalls(transport: FakeRpcTransport, count: number): Promise<void> {
   await waitFor(() => {
-    expect(workflowAttentionCallCount(transport)).toBe(count);
+    expect(workflowAttentionCalls(transport)).toHaveLength(count);
   });
 }
 
@@ -313,6 +328,17 @@ const attentionChangingProjectEvent = {
     related_ids: [],
     resource: "task",
     workflow_id: "workflow-1",
+  },
+} as const;
+
+const invalidProjectEvent = {
+  event: {
+    action: "updated",
+    occurred_at_unix_ms: 3,
+    primary_entity_id: "task-1",
+    project_id: "project-1",
+    related_ids: [],
+    resource: "task",
   },
 } as const;
 

--- a/apps/desktop/src/features/home/useHomeData.ts
+++ b/apps/desktop/src/features/home/useHomeData.ts
@@ -7,7 +7,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 
-import { errorMessage } from "@/api";
+import { ContractError, errorMessage } from "@/api";
 import type { ProjectBinding, WorkflowProjectEvent } from "@/api";
 import type { AppServices } from "@/app-facade";
 import { queryKeys } from "@/app-facade";
@@ -84,6 +84,9 @@ export function useGlobalAttentionEvents() {
       void queryClient.invalidateQueries({ queryKey: queryKeys.activity(taskID), refetchType: "active" });
       void queryClient.invalidateQueries({ queryKey: queryKeys.allPendingAsks, refetchType: "active" });
     };
+    const logSubscriptionWarning = (message: string, error: Error) => {
+      void logger.append("warn", message, { error: errorMessage(error) });
+    };
     const subscription = api.subscribeProject("", {
       onOpen() {
         const shouldReconcile = subscriptionLifecycle !== "initial";
@@ -102,8 +105,13 @@ export function useGlobalAttentionEvents() {
         return;
       },
       onError(error) {
+        if (error instanceof ContractError) {
+          refreshAttention();
+          logSubscriptionWarning("Global attention event payload failed.", error);
+          return;
+        }
         subscriptionLifecycle = "recovery-pending";
-        void logger.append("warn", "Global attention subscription failed.", { error: errorMessage(error) });
+        logSubscriptionWarning("Global attention subscription failed.", error);
       },
     });
     return () => {

--- a/apps/desktop/src/features/home/useHomeData.ts
+++ b/apps/desktop/src/features/home/useHomeData.ts
@@ -1,8 +1,14 @@
 import { useEffect } from "react";
-import { keepPreviousData, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  infiniteQueryOptions,
+  keepPreviousData,
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 
+import { ContractError, errorMessage } from "@/api";
 import type { ProjectBinding, WorkflowProjectEvent } from "@/api";
-import { errorMessage } from "@/api";
 import type { AppServices } from "@/app-facade";
 import { queryKeys } from "@/app-facade";
 import { useAppServices } from "@/app-facade";
@@ -33,12 +39,15 @@ export function useProjectPages() {
 
 export function useGlobalAttentionPages() {
   const { api } = useAppServices();
+  return useInfiniteQuery(globalAttentionQueryOptions(api));
+}
+
+export function useSidebarGlobalAttentionPages() {
+  const { api } = useAppServices();
   return useInfiniteQuery({
-    queryKey: queryKeys.attention,
-    queryFn: async ({ pageParam }) => api.listAttention(pageParam),
-    initialPageParam: "",
-    getNextPageParam: (lastPage) => (lastPage.nextPageToken.length > 0 ? lastPage.nextPageToken : undefined),
-    placeholderData: keepPreviousData,
+    ...globalAttentionQueryOptions(api),
+    refetchOnMount: (query) =>
+      query.observers.filter((observer) => observer.getCurrentResult().isEnabled).length <= 1,
   });
 }
 
@@ -52,6 +61,7 @@ export function useGlobalAttentionEvents() {
       return;
     }
     let refreshFrame: number | null = null;
+    let subscriptionLifecycle: GlobalAttentionSubscriptionLifecycle = "initial";
     const refreshAttention = () => {
       if (refreshFrame !== null) {
         return;
@@ -74,9 +84,16 @@ export function useGlobalAttentionEvents() {
       void queryClient.invalidateQueries({ queryKey: queryKeys.activity(taskID), refetchType: "active" });
       void queryClient.invalidateQueries({ queryKey: queryKeys.allPendingAsks, refetchType: "active" });
     };
+    const logSubscriptionWarning = (message: string, error: Error) => {
+      void logger.append("warn", message, { error: errorMessage(error) });
+    };
     const subscription = api.subscribeProject("", {
       onOpen() {
-        refreshAttention();
+        const shouldReconcile = subscriptionLifecycle !== "initial";
+        subscriptionLifecycle = "open";
+        if (shouldReconcile) {
+          refreshAttention();
+        }
       },
       onEvent(event) {
         refreshQuestionTask(event);
@@ -88,8 +105,13 @@ export function useGlobalAttentionEvents() {
         return;
       },
       onError(error) {
-        refreshAttention();
-        void logger.append("warn", "Global attention subscription failed.", { error: errorMessage(error) });
+        if (error instanceof ContractError) {
+          refreshAttention();
+          logSubscriptionWarning("Global attention event payload failed.", error);
+          return;
+        }
+        subscriptionLifecycle = "recovery-pending";
+        logSubscriptionWarning("Global attention subscription failed.", error);
       },
     });
     return () => {
@@ -100,6 +122,8 @@ export function useGlobalAttentionEvents() {
     };
   }, [api, connection.generation, connection.phase, logger, queryClient]);
 }
+
+type GlobalAttentionSubscriptionLifecycle = "initial" | "open" | "recovery-pending";
 
 export function useProjectCreationEvents(onCreated: (binding: NativeProjectBinding) => void) {
   const { logger, nativeBridge } = useAppServices();
@@ -163,3 +187,13 @@ export type WorkspaceAttachInput = Readonly<{
   projectID: string;
   workspaceRoot: string;
 }>;
+
+function globalAttentionQueryOptions(api: AppServices["api"]) {
+  return infiniteQueryOptions({
+    queryKey: queryKeys.attention,
+    queryFn: async ({ pageParam }) => api.listAttention(pageParam),
+    initialPageParam: "",
+    getNextPageParam: (lastPage) => (lastPage.nextPageToken.length > 0 ? lastPage.nextPageToken : undefined),
+    placeholderData: keepPreviousData,
+  });
+}

--- a/apps/desktop/src/features/home/useHomeData.ts
+++ b/apps/desktop/src/features/home/useHomeData.ts
@@ -7,7 +7,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 
-import { ContractError, errorMessage } from "@/api";
+import { errorMessage } from "@/api";
 import type { ProjectBinding, WorkflowProjectEvent } from "@/api";
 import type { AppServices } from "@/app-facade";
 import { queryKeys } from "@/app-facade";
@@ -84,9 +84,6 @@ export function useGlobalAttentionEvents() {
       void queryClient.invalidateQueries({ queryKey: queryKeys.activity(taskID), refetchType: "active" });
       void queryClient.invalidateQueries({ queryKey: queryKeys.allPendingAsks, refetchType: "active" });
     };
-    const logSubscriptionWarning = (message: string, error: Error) => {
-      void logger.append("warn", message, { error: errorMessage(error) });
-    };
     const subscription = api.subscribeProject("", {
       onOpen() {
         const shouldReconcile = subscriptionLifecycle !== "initial";
@@ -105,13 +102,8 @@ export function useGlobalAttentionEvents() {
         return;
       },
       onError(error) {
-        if (error instanceof ContractError) {
-          refreshAttention();
-          logSubscriptionWarning("Global attention event payload failed.", error);
-          return;
-        }
         subscriptionLifecycle = "recovery-pending";
-        logSubscriptionWarning("Global attention subscription failed.", error);
+        void logger.append("warn", "Global attention subscription failed.", { error: errorMessage(error) });
       },
     });
     return () => {

--- a/apps/desktop/src/features/home/useHomeData.ts
+++ b/apps/desktop/src/features/home/useHomeData.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import {
   infiniteQueryOptions,
   keepPreviousData,
@@ -37,9 +37,12 @@ export function useProjectPages() {
   });
 }
 
-export function useGlobalAttentionPages() {
+export function useGlobalAttentionPages(enabled = true) {
   const { api } = useAppServices();
-  return useInfiniteQuery(globalAttentionQueryOptions(api));
+  return useInfiniteQuery({
+    ...globalAttentionQueryOptions(api),
+    enabled,
+  });
 }
 
 export function useSidebarGlobalAttentionPages() {
@@ -55,11 +58,13 @@ export function useGlobalAttentionEvents() {
   const { api, logger } = useAppServices();
   const connection = useConnectionSnapshot();
   const queryClient = useQueryClient();
+  const [openGeneration, setOpenGeneration] = useState<number | null>(null);
 
   useEffect(() => {
     if (connection.phase !== "connected") {
       return;
     }
+    const subscriptionGeneration = connection.generation;
     let refreshFrame: number | null = null;
     let subscriptionLifecycle: GlobalAttentionSubscriptionLifecycle = "initial";
     const refreshAttention = () => {
@@ -91,6 +96,7 @@ export function useGlobalAttentionEvents() {
       onOpen() {
         const shouldReconcile = subscriptionLifecycle !== "initial";
         subscriptionLifecycle = "open";
+        setOpenGeneration(subscriptionGeneration);
         if (shouldReconcile) {
           refreshAttention();
         }
@@ -121,6 +127,7 @@ export function useGlobalAttentionEvents() {
       subscription.close();
     };
   }, [api, connection.generation, connection.phase, logger, queryClient]);
+  return connection.phase === "connected" && openGeneration === connection.generation;
 }
 
 type GlobalAttentionSubscriptionLifecycle = "initial" | "open" | "recovery-pending";

--- a/apps/desktop/src/test-support/scheduling/index.ts
+++ b/apps/desktop/src/test-support/scheduling/index.ts
@@ -1,0 +1,21 @@
+import { act } from "@testing-library/react";
+import { vi } from "vitest";
+
+export function installAnimationFrameTestSupport(): void {
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    return window.setTimeout(() => {
+      callback(performance.now());
+    }, 0);
+  });
+  vi.stubGlobal("cancelAnimationFrame", (handle: number) => {
+    window.clearTimeout(handle);
+  });
+}
+
+export async function flushQueuedWork(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      window.setTimeout(resolve, 0);
+    });
+  });
+}

--- a/apps/desktop/src/test-support/scheduling/index.ts
+++ b/apps/desktop/src/test-support/scheduling/index.ts
@@ -12,10 +12,14 @@ export function installAnimationFrameTestSupport(): void {
   });
 }
 
+export async function waitForMacrotask(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    window.setTimeout(resolve, 0);
+  });
+}
+
 export async function flushQueuedWork(): Promise<void> {
   await act(async () => {
-    await new Promise<void>((resolve) => {
-      window.setTimeout(resolve, 0);
-    });
+    await waitForMacrotask();
   });
 }

--- a/apps/desktop/src/test-support/workflow-attention/index.ts
+++ b/apps/desktop/src/test-support/workflow-attention/index.ts
@@ -18,7 +18,3 @@ type RpcCallSource = Readonly<{
 export function workflowAttentionCalls(transport: RpcCallSource): readonly RpcCallLog[] {
   return transport.calls.filter((call) => call.method === workflowAttentionRpcMethods.list);
 }
-
-export function workflowAttentionCallCount(transport: RpcCallSource): number {
-  return workflowAttentionCalls(transport).length;
-}

--- a/apps/desktop/src/test-support/workflow-attention/index.ts
+++ b/apps/desktop/src/test-support/workflow-attention/index.ts
@@ -1,0 +1,24 @@
+import type { JsonValue } from "@/api";
+
+export const workflowAttentionRpcMethods = {
+  list: "workflow.attention.list",
+  projectEvent: "workflow.project",
+  subscribeProject: "workflow.subscribeProject",
+} as const;
+
+type RpcCallLog = Readonly<{
+  method: string;
+  params: JsonValue;
+}>;
+
+type RpcCallSource = Readonly<{
+  calls: readonly RpcCallLog[];
+}>;
+
+export function workflowAttentionCalls(transport: RpcCallSource): readonly RpcCallLog[] {
+  return transport.calls.filter((call) => call.method === workflowAttentionRpcMethods.list);
+}
+
+export function workflowAttentionCallCount(transport: RpcCallSource): number {
+  return workflowAttentionCalls(transport).length;
+}


### PR DESCRIPTION
## Summary

- Deduplicate the Home Inbox's initial global-attention fetch by registering the Project subscription before enabling the initial attention query.
- Keep Home as the active infinite-query owner while allowing Sidebar Inbox navigation to reuse the shared cache without redundant active-owner fetches.
- Preserve cold-cache and sole-owner stale-cache Sidebar behavior through a shared query-options definition and enabled-observer-aware mount refetching.
- Separate subscription-session recovery from live Project-event decoder failures: transport/session failures reconcile after a successful reopen, while `ContractError` payload failures reconcile immediately because the stream remains open.
- Remove the duplicated workflow-attention call-count helper and cover the decoder-error path through the production API wrapper.
- Close the initial and reconnect snapshot/subscription race without adding an API, wire, or server contract: the current-generation subscription opens first, then Home performs one initial or reconnect attention read.

Kent task: `KENT-359` — Deduplicate Home Inbox fetch.

No GitHub issue number is associated with the task metadata.

## Verification

- Focused regressions: `8/8` passed — 7 Home lifecycle/cache/pagination tests and 1 canonical app reconnect test.
- Desktop suite: `./scripts/test.sh desktop` — 37 files, 184 tests passed.
- `pnpm --dir apps lint` passed.
- `pnpm --dir apps/desktop typecheck` passed.
- `./scripts/build.sh desktop` passed.
- `git diff --check` passed.

## Completion evidence

Prior QA verified the isolated Home route, empty Inbox state, user-facing empty-state copy, and a successful isolated headless runtime. The available local evidence files are:

- `/tmp/kent-359-desktop-test.log`
- `/tmp/kent-359-apps-lint.log`
- `/tmp/kent-359-home-empty-inbox-dismissed.png`
- `/tmp/kent-359-home-after-route-reset.png`

The `gh` CLI does not provide a local `/tmp` attachment mechanism for PR creation, so these paths are listed for the originating workspace. Manual populated-Inbox/Sidebar navigation could not be exercised because creating an isolated workflow reached a blank indefinitely-loading Workflow Editor; the populated, pagination, reconnect, event, and cache-sharing paths are covered by the rendered production-boundary regressions above.

## Diff size

Gross means additions plus deletions; net means additions minus deletions.

| Area | Added | Removed | Net | Gross |
| --- | ---: | ---: | ---: | ---: |
| Production code | 57 | 16 | +41 | 73 |
| Test/support code | 493 | 0 | +493 | 493 |
| Total | 550 | 16 | +534 | 566 |

## Caveats and follow-up

- The canonical app-boundary regression still emits unsuppressed React `act(...)` warnings from TanStack Router transition components. The test passes; eliminating that warning noise should be a separate router-test-harness follow-up rather than a production suppression.
- An earlier parallel recursive test attempt encountered two unrelated Task Detail timeouts; the required `./scripts/test.sh desktop` rerun passed all 184 tests.
- Populated-Inbox manual acceptance evidence should be repeated once the isolated Workflow Editor can create a workflow successfully.
- No API, wire, protocol, persistence, product-specification, or visual-surface changes are included.
