### PR TITLE
Separate Script Node concurrency from Agent scheduling

### DIFF
--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -38,6 +38,7 @@
 
 - `shell` is the only model-facing command-execution tool. It uses the user's login shell without a TTY, inherits the parent environment, adds non-interactive technical environment values, and combines stdout and stderr into one unlabelled stream.
 - Commands have no lifetime limit. `yield_time_ms` returns control and leaves the command running in the background. An output check with no requested wait may return available output immediately.
+- Kent does not limit concurrent command processes, including background processes visible through `/ps`.
 - A model output check requesting less than 15 seconds fails with `Avoid polling repeatedly for short intervals, prefer 3-15min polls depending on task. Pick a better interval and retry`. One requesting more than 24 hours fails with `This poll is too long. Consider using system cron jobs and \`kent run\` headless runs for tasks that require such long wait periods`. Sending input is not subject to those limits.
 - A non-zero command exit is recoverable and does not abort the model turn. Launch failures are not retried automatically. Interruption sends `SIGINT`, then `SIGKILL` after 10 seconds.
 - `[shell].postprocessing_mode` accepts only `none`, `builtin`, `user`, or `all`; omission selects the built-in default, while an empty or unknown value is an error. `[shell].postprocess_hook` is optional; absence is `null`, and a present empty or whitespace-only value is invalid.

--- a/docs/dev/specs/workflow-orchestration.md
+++ b/docs/dev/specs/workflow-orchestration.md
@@ -221,7 +221,9 @@
 - Script nodes are first-class executable workflow nodes. They can be Start targets, fan-out branches, join predecessors/successors, manual automation targets, and board columns anywhere agent nodes are accepted by graph semantics.
 - A Script Node can omit its script path in a Workflow Draft. A missing path, nonexistent path, directory, or non-executable file blocks execution, not draft editing.
 - Relative script paths resolve against the task execution root. Absolute paths resolve on the Kent server host.
-- Kent launches the resolved executable directly with the Execution Root as its working directory. It does not use a shell wrapper, retry the script, or impose a timeout.
+- Kent launches the resolved executable directly with the Execution Root as its working directory. It does not use a shell wrapper, retry the script, or impose a timeout, CPU quota, or memory quota.
+- Kent bounds captured stdout and stderr independently.
+- When interruption stops a Script Node process, Kent requests graceful termination and force-kills the process after a bounded grace period if it remains running.
 - Script input is one JSON object on standard input. Incoming Workflow Parameters are top-level properties. `_kent` is reserved for Task, Node, and parallel Transition Branch identity.
 - Script stdout is parsed as the workflow completion JSON using the same completion contract as agent nodes. Stderr is diagnostics only and is not mixed into completion parsing.
 - Invalid stdout, invalid script path, interruption, and execution errors leave the script's current Node interrupted with bounded structured details.
@@ -325,8 +327,10 @@
 
 - Workflow Execution is the single authority for Workflow lifecycle changes. It sequences conflicting operations and reports authoritative live state.
 - Requests to start eligible work automatically are temporary. Kent loses them on restart and does not reconstruct them from saved Task state.
-- Automatic starts use available capacity and prefer to continue related work on the same Task. `[workflow].concurrency` limits automatic starts only.
-- Explicit Start, Resume, approval, and executable manual move may exceed the automatic concurrency limit without preempting existing work.
+- Workflow automation starts Agent Nodes within available agent capacity and prefers to continue related work on the same Task. `[workflow].concurrency` limits these agent runs only.
+- Script Nodes do not wait for or consume agent-run capacity. Kent does not limit concurrent Script Node runs.
+- When Agent and Script Nodes are both eligible within their applicable capacity, Kent gives neither kind priority. The same-Task continuation preference applies across both kinds.
+- Explicit Start, Resume, approval, and executable manual move may exceed the agent concurrency limit without preempting existing work.
 - Resume returns after it durably requeues the interrupted Current Nodes and queues their explicit starts.
 - Resume does not wait for Execution Target restoration, Session setup, or agent or Script startup.
 - Only an actively executing Exact Execution Scope proves that an agent or Script is live and interruptible. Current Nodes, Automatic Intents, Session relations, waiting Questions, Task status, transcript entries, and Goals do not prove liveness.

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -64,7 +64,7 @@ postprocessing_mode = "all" # shell output token optimizations by Kent: none | b
 
 [workflow]
 completion_mode = "auto"
-concurrency = 5
+concurrency = 5 # Agent Node scheduling capacity; Script Nodes do not use it
 max_invalid_completion_attempts = 5
 use_required_tool_calls = true
 subagents = false # TOML-only; workflow agents cannot launch custom roles unless enabled
@@ -156,7 +156,7 @@ verbose_output = false # show supervisor suggestions in ongoing transcript
 | Key | Type | Default | Env | Description |
 | --- | --- | --- | --- | --- |
 | `workflow.completion_mode` | string | `auto` | `KENT_WORKFLOW_COMPLETION_MODE` | Default completion mode for workflow agent nodes that inherit the global default. Allowed: `auto`, `structured_output`, `tool`, `shell_command`, `unstructured_output`. |
-| `workflow.concurrency` | int | `5` | `KENT_WORKFLOW_CONCURRENCY` | Maximum number of workflow agent runs scheduled concurrently. Must be `> 0`. |
+| `workflow.concurrency` | int | `5` | `KENT_WORKFLOW_CONCURRENCY` | Agent Node scheduling capacity. Explicit workflow actions may exceed it. Script Nodes do not use it. Must be `> 0`. |
 | `workflow.max_invalid_completion_attempts` | int | `5` | `KENT_WORKFLOW_MAX_INVALID_COMPLETION_ATTEMPTS` | Number of invalid workflow completion attempts allowed before Kent interrupts the run. Must be `> 0`. |
 | `workflow.use_required_tool_calls` | bool | `true` |  | Uses provider-required tool selection for `tool` and `shell_command` workflow completion modes. Set to `false` to use automatic tool selection while preserving Kent's workflow completion validation. |
 | `workflow.subagents` | bool | `false` |  | Allows workflow agents to launch eligible custom roles. |

--- a/server/core/composition.go
+++ b/server/core/composition.go
@@ -289,9 +289,9 @@ func NewWithContextOptions(ctx context.Context, cfg config.App, authSupport serv
 		runtimeAuthority,
 		workflowMutationPermit,
 		workflowexecution.CurrentNodeControllerConfig{
-			AutomaticConcurrency: cfg.Settings.Workflow.Concurrency,
-			Attention:            workflowAttentionFinalizer,
-			AssignmentSteerer:    workflowRuntimeStarter,
+			AgentConcurrency:  cfg.Settings.Workflow.Concurrency,
+			Attention:         workflowAttentionFinalizer,
+			AssignmentSteerer: workflowRuntimeStarter,
 		},
 	)
 	if err != nil {

--- a/server/workflowexecution/current_node_admission.go
+++ b/server/workflowexecution/current_node_admission.go
@@ -46,218 +46,41 @@ func (p currentNodeAdmissionPolicy) nodeKind() workflow.NodeKind {
 	}
 }
 
+type currentNodeAgentCapacityOwner uint8
+
+const (
+	currentNodeAgentCapacityReservation currentNodeAgentCapacityOwner = iota
+	currentNodeAgentCapacityGate
+	currentNodeAgentCapacityLive
+	currentNodeAgentCapacityReleased
+)
+
+type currentNodeAgentCapacityLease struct {
+	owner currentNodeAgentCapacityOwner
+}
+
 type currentNodeQueuedStart struct {
 	reference          workflow.CurrentNodeReference
 	taskPromptDelivery workflowruntime.TaskPromptDelivery
 	assignmentSteer    CurrentNodeAssignmentSteer
 	policy             currentNodeAdmissionPolicy
 	done               chan struct{}
-}
-
-type currentNodeAutomaticQueue struct {
-	first       *currentNodeAutomaticQueueEntry
-	last        *currentNodeAutomaticQueueEntry
-	firstAgent  *currentNodeAutomaticQueueEntry
-	lastAgent   *currentNodeAutomaticQueueEntry
-	firstScript *currentNodeAutomaticQueueEntry
-	lastScript  *currentNodeAutomaticQueueEntry
-	tasks       map[workflow.TaskID]*currentNodeAutomaticTaskQueue
-	nextOrder   uint64
-	size        int
-}
-
-type currentNodeAutomaticTaskQueue struct {
-	firstAgent  *currentNodeAutomaticQueueEntry
-	lastAgent   *currentNodeAutomaticQueueEntry
-	firstScript *currentNodeAutomaticQueueEntry
-	lastScript  *currentNodeAutomaticQueueEntry
-}
-
-type currentNodeAutomaticQueueEntry struct {
-	start      currentNodeQueuedStart
-	order      uint64
-	globalPrev *currentNodeAutomaticQueueEntry
-	globalNext *currentNodeAutomaticQueueEntry
-	policyPrev *currentNodeAutomaticQueueEntry
-	policyNext *currentNodeAutomaticQueueEntry
-	taskPrev   *currentNodeAutomaticQueueEntry
-	taskNext   *currentNodeAutomaticQueueEntry
-}
-
-func (q *currentNodeAutomaticQueue) append(start currentNodeQueuedStart) {
-	if !start.policy.isAutomatic() {
-		panic(fmt.Sprintf("automatic queue received non-automatic policy %d", start.policy))
-	}
-	q.nextOrder++
-	if q.nextOrder == 0 {
-		panic("automatic queue order overflow")
-	}
-	entry := &currentNodeAutomaticQueueEntry{start: start, order: q.nextOrder, globalPrev: q.last}
-	if q.last == nil {
-		q.first = entry
-	} else {
-		q.last.globalNext = entry
-	}
-	q.last = entry
-	if q.tasks == nil {
-		q.tasks = make(map[workflow.TaskID]*currentNodeAutomaticTaskQueue)
-	}
-	taskQueue := q.tasks[start.reference.TaskID]
-	if taskQueue == nil {
-		taskQueue = &currentNodeAutomaticTaskQueue{}
-		q.tasks[start.reference.TaskID] = taskQueue
-	}
-	if start.policy == currentNodeAdmissionAutomaticAgent {
-		entry.policyPrev = q.lastAgent
-		entry.taskPrev = taskQueue.lastAgent
-		if q.lastAgent == nil {
-			q.firstAgent = entry
-		} else {
-			q.lastAgent.policyNext = entry
-		}
-		q.lastAgent = entry
-		if taskQueue.lastAgent == nil {
-			taskQueue.firstAgent = entry
-		} else {
-			taskQueue.lastAgent.taskNext = entry
-		}
-		taskQueue.lastAgent = entry
-	} else {
-		entry.policyPrev = q.lastScript
-		entry.taskPrev = taskQueue.lastScript
-		if q.lastScript == nil {
-			q.firstScript = entry
-		} else {
-			q.lastScript.policyNext = entry
-		}
-		q.lastScript = entry
-		if taskQueue.lastScript == nil {
-			taskQueue.firstScript = entry
-		} else {
-			taskQueue.lastScript.taskNext = entry
-		}
-		taskQueue.lastScript = entry
-	}
-	q.size++
-}
-
-func (q *currentNodeAutomaticQueue) remove(entry *currentNodeAutomaticQueueEntry) currentNodeQueuedStart {
-	if entry.globalPrev == nil {
-		q.first = entry.globalNext
-	} else {
-		entry.globalPrev.globalNext = entry.globalNext
-	}
-	if entry.globalNext == nil {
-		q.last = entry.globalPrev
-	} else {
-		entry.globalNext.globalPrev = entry.globalPrev
-	}
-	taskQueue := q.tasks[entry.start.reference.TaskID]
-	if taskQueue == nil {
-		panic("automatic queue task index lost an entry")
-	}
-	if entry.start.policy == currentNodeAdmissionAutomaticAgent {
-		if entry.policyPrev == nil {
-			q.firstAgent = entry.policyNext
-		} else {
-			entry.policyPrev.policyNext = entry.policyNext
-		}
-		if entry.policyNext == nil {
-			q.lastAgent = entry.policyPrev
-		} else {
-			entry.policyNext.policyPrev = entry.policyPrev
-		}
-		if entry.taskPrev == nil {
-			taskQueue.firstAgent = entry.taskNext
-		} else {
-			entry.taskPrev.taskNext = entry.taskNext
-		}
-		if entry.taskNext == nil {
-			taskQueue.lastAgent = entry.taskPrev
-		} else {
-			entry.taskNext.taskPrev = entry.taskPrev
-		}
-	} else {
-		if entry.policyPrev == nil {
-			q.firstScript = entry.policyNext
-		} else {
-			entry.policyPrev.policyNext = entry.policyNext
-		}
-		if entry.policyNext == nil {
-			q.lastScript = entry.policyPrev
-		} else {
-			entry.policyNext.policyPrev = entry.policyPrev
-		}
-		if entry.taskPrev == nil {
-			taskQueue.firstScript = entry.taskNext
-		} else {
-			entry.taskPrev.taskNext = entry.taskNext
-		}
-		if entry.taskNext == nil {
-			taskQueue.lastScript = entry.taskPrev
-		} else {
-			entry.taskNext.taskPrev = entry.taskPrev
-		}
-	}
-	if taskQueue.firstAgent == nil && taskQueue.firstScript == nil {
-		delete(q.tasks, entry.start.reference.TaskID)
-	}
-	q.size--
-	return entry.start
-}
-
-func (q *currentNodeAutomaticQueue) clear() {
-	q.first = nil
-	q.last = nil
-	q.firstAgent = nil
-	q.lastAgent = nil
-	q.firstScript = nil
-	q.lastScript = nil
-	q.tasks = nil
-	q.nextOrder = 0
-	q.size = 0
-}
-
-func (q *currentNodeAutomaticQueue) len() int {
-	return q.size
-}
-
-func (q *currentNodeAutomaticQueue) selectEntry(lastTask *workflow.TaskID, agentAvailable bool) (*currentNodeAutomaticQueueEntry, bool) {
-	if lastTask != nil {
-		if taskQueue := q.tasks[*lastTask]; taskQueue != nil {
-			candidate := taskQueue.firstScript
-			if agentAvailable && taskQueue.firstAgent != nil &&
-				(candidate == nil || taskQueue.firstAgent.order < candidate.order) {
-				candidate = taskQueue.firstAgent
-			}
-			if candidate != nil {
-				return candidate, true
-			}
-		}
-	}
-	if !agentAvailable {
-		return q.firstScript, q.firstScript != nil
-	}
-	if q.firstAgent == nil {
-		return q.firstScript, q.firstScript != nil
-	}
-	if q.firstScript == nil || q.firstAgent.order < q.firstScript.order {
-		return q.firstAgent, true
-	}
-	return q.firstScript, true
+	agentCapacityLease *currentNodeAgentCapacityLease
 }
 
 type currentNodeAdmissionGate struct {
-	reference workflow.CurrentNodeReference
-	lease     sessionruntime.WorkflowExecutionLease
-	policy    currentNodeAdmissionPolicy
-	done      <-chan struct{}
+	reference          workflow.CurrentNodeReference
+	lease              sessionruntime.WorkflowExecutionLease
+	policy             currentNodeAdmissionPolicy
+	done               <-chan struct{}
+	agentCapacityLease *currentNodeAgentCapacityLease
 }
 
 type currentNodeLiveScope struct {
-	reference workflow.CurrentNodeReference
-	lease     sessionruntime.WorkflowExecutionLease
-	policy    currentNodeAdmissionPolicy
+	reference          workflow.CurrentNodeReference
+	lease              sessionruntime.WorkflowExecutionLease
+	policy             currentNodeAdmissionPolicy
+	agentCapacityLease *currentNodeAgentCapacityLease
 }
 
 type currentNodeAdmissionError struct {
@@ -351,11 +174,11 @@ func (c *CurrentNodeController) admit(ctx context.Context, start currentNodeQueu
 	if err != nil {
 		return err
 	}
+	defer c.releaseReservation(key, start.policy, start.agentCapacityLease)
 	assignmentSteer, err := resolvedCurrentNodeAssignmentSteer(ctx, start.assignmentSteer)
 	if err != nil {
 		return err
 	}
-	defer c.releaseReservation(key, start.policy)
 	c.mu.Lock()
 	if c.closed {
 		c.mu.Unlock()
@@ -414,13 +237,19 @@ func (c *CurrentNodeController) admit(ctx context.Context, start currentNodeQueu
 			return sessionruntime.ErrExecutionNoLongerLive
 		}
 		c.deleteAdmissionReservationLocked(key, start.policy)
+		c.transitionAgentCapacityLocked(
+			start.agentCapacityLease,
+			currentNodeAgentCapacityReservation,
+			currentNodeAgentCapacityGate,
+		)
 		// The gate precedes the durable restart marker, so any conflicting
 		// lifecycle mutation sees admission before slow runner preparation.
 		c.gates[key] = currentNodeAdmissionGate{
-			reference: reference,
-			lease:     next,
-			policy:    start.policy,
-			done:      start.done,
+			reference:          reference,
+			lease:              next,
+			policy:             start.policy,
+			done:               start.done,
+			agentCapacityLease: start.agentCapacityLease,
 		}
 		c.mu.Unlock()
 
@@ -462,7 +291,17 @@ func (c *CurrentNodeController) admit(ctx context.Context, start currentNodeQueu
 			return sessionruntime.ErrExecutionNoLongerLive
 		}
 		delete(c.gates, key)
-		c.live[lease.ScopeID()] = currentNodeLiveScope{reference: reference, lease: lease, policy: gate.policy}
+		c.transitionAgentCapacityLocked(
+			gate.agentCapacityLease,
+			currentNodeAgentCapacityGate,
+			currentNodeAgentCapacityLive,
+		)
+		c.live[lease.ScopeID()] = currentNodeLiveScope{
+			reference:          reference,
+			lease:              lease,
+			policy:             gate.policy,
+			agentCapacityLease: gate.agentCapacityLease,
+		}
 		c.liveByNode[key] = lease.ScopeID()
 		lease.Release()
 		return nil
@@ -484,9 +323,7 @@ func (c *CurrentNodeController) removeGate(key workflow.CurrentNodeReferenceKey,
 	if gate, exists := c.gates[key]; exists && gate.lease.ScopeID() == scopeID {
 		delete(c.gates, key)
 		delete(c.stopping, scopeID)
-		if gate.policy.countsAgentCapacity() {
-			c.releaseAgentCapacityLocked()
-		}
+		c.releaseAgentCapacityLocked(gate.agentCapacityLease)
 		wake = true
 	}
 	c.mu.Unlock()
@@ -499,9 +336,7 @@ func (c *CurrentNodeController) discardAdmission(reference workflow.CurrentNodeR
 	c.removeGate(key, lease.ScopeID())
 	c.mu.Lock()
 	if live, exists := c.live[lease.ScopeID()]; exists {
-		if live.policy.countsAgentCapacity() {
-			c.releaseAgentCapacityLocked()
-		}
+		c.releaseAgentCapacityLocked(live.agentCapacityLease)
 		delete(c.live, lease.ScopeID())
 	}
 	if current, exists := c.liveByNode[key]; exists && current == lease.ScopeID() {
@@ -836,49 +671,44 @@ func (c *CurrentNodeController) takeAutomaticIntent() (currentNodeQueuedStart, b
 	delete(c.queued, key)
 	start.taskPromptDelivery = workflowruntime.TaskPromptDeliveryResume
 	start.done = make(chan struct{})
-	c.automaticReservations[key] = start
-	c.admissionWorkers[key] = start
 	if start.policy.countsAgentCapacity() {
+		start.agentCapacityLease = &currentNodeAgentCapacityLease{
+			owner: currentNodeAgentCapacityReservation,
+		}
 		c.agentCapacityActive++
 	}
+	c.automaticReservations[key] = start
+	c.admissionWorkers[key] = start
 	c.admissionWG.Add(1)
 	taskID := start.reference.TaskID
 	c.lastAutomaticTask = &taskID
 	return start, true
 }
 
-func automaticIntentAdmissible(intent CurrentNodeAutomaticIntent, agentAvailable bool) bool {
-	switch intent.NodeKind {
-	case workflow.NodeKindAgent:
-		return agentAvailable
-	case workflow.NodeKindScript:
-		return true
+func (c *CurrentNodeController) transitionAgentCapacityLocked(
+	lease *currentNodeAgentCapacityLease,
+	from currentNodeAgentCapacityOwner,
+	to currentNodeAgentCapacityOwner,
+) {
+	if lease == nil {
+		return
+	}
+	if lease.owner != from {
+		panic(fmt.Sprintf("automatic Agent capacity owner transition %d -> %d from %d", from, to, lease.owner))
+	}
+	lease.owner = to
+}
+
+func (c *CurrentNodeController) releaseAgentCapacityLocked(lease *currentNodeAgentCapacityLease) {
+	if lease == nil || lease.owner == currentNodeAgentCapacityReleased {
+		return
+	}
+	switch lease.owner {
+	case currentNodeAgentCapacityReservation, currentNodeAgentCapacityGate, currentNodeAgentCapacityLive:
+		lease.owner = currentNodeAgentCapacityReleased
 	default:
-		panic(fmt.Sprintf("automatic intent %v has non-executable node kind %q", intent.CurrentNode, intent.NodeKind))
+		panic(fmt.Sprintf("automatic Agent capacity has invalid owner %d", lease.owner))
 	}
-}
-
-func selectAutomaticIntentIndex(intents []CurrentNodeAutomaticIntent, lastTask *workflow.TaskID, agentAvailable bool) (int, bool) {
-	if lastTask != nil {
-		for index, intent := range intents {
-			if intent.CurrentNode.TaskID == *lastTask && automaticIntentAdmissible(intent, agentAvailable) {
-				return index, true
-			}
-		}
-	}
-	for index, intent := range intents {
-		if automaticIntentAdmissible(intent, agentAvailable) {
-			return index, true
-		}
-	}
-	return 0, false
-}
-
-func (c *CurrentNodeController) agentActiveLocked() int {
-	return c.agentCapacityActive
-}
-
-func (c *CurrentNodeController) releaseAgentCapacityLocked() {
 	if c.agentCapacityActive <= 0 {
 		panic("automatic Agent capacity released without an active reservation, gate, or live scope")
 	}
@@ -917,12 +747,16 @@ func (c *CurrentNodeController) deleteAdmissionReservationLocked(key workflow.Cu
 	delete(c.explicitReservations, key)
 }
 
-func (c *CurrentNodeController) releaseReservation(key workflow.CurrentNodeReferenceKey, policy currentNodeAdmissionPolicy) {
+func (c *CurrentNodeController) releaseReservation(
+	key workflow.CurrentNodeReferenceKey,
+	policy currentNodeAdmissionPolicy,
+	capacityLease *currentNodeAgentCapacityLease,
+) {
 	c.mu.Lock()
 	_, reserved := c.admissionReservationLocked(key, policy)
 	c.deleteAdmissionReservationLocked(key, policy)
-	if reserved && policy.countsAgentCapacity() {
-		c.releaseAgentCapacityLocked()
+	if capacityLease != nil && capacityLease.owner == currentNodeAgentCapacityReservation {
+		c.releaseAgentCapacityLocked(capacityLease)
 	}
 	closed := c.closed
 	c.mu.Unlock()

--- a/server/workflowexecution/current_node_admission.go
+++ b/server/workflowexecution/current_node_admission.go
@@ -10,6 +10,7 @@ import (
 	"core/server/sessionruntime"
 	"core/server/workflow"
 	"core/server/workflowruntime"
+	"core/server/workflowstore"
 	"core/shared/runtimeids"
 )
 
@@ -18,25 +19,245 @@ const (
 	reasonCurrentNodeRuntimeStartFailed workflow.CurrentNodeInterruptionReason = "workflow_runtime_start_failed"
 )
 
+type currentNodeAdmissionPolicy uint8
+
+const (
+	currentNodeAdmissionExplicitOverride currentNodeAdmissionPolicy = iota
+	currentNodeAdmissionAutomaticAgent
+	currentNodeAdmissionAutomaticScript
+)
+
+func (p currentNodeAdmissionPolicy) isAutomatic() bool {
+	return p == currentNodeAdmissionAutomaticAgent || p == currentNodeAdmissionAutomaticScript
+}
+
+func (p currentNodeAdmissionPolicy) countsAgentCapacity() bool {
+	return p == currentNodeAdmissionAutomaticAgent
+}
+
+func (p currentNodeAdmissionPolicy) nodeKind() workflow.NodeKind {
+	switch p {
+	case currentNodeAdmissionAutomaticAgent:
+		return workflow.NodeKindAgent
+	case currentNodeAdmissionAutomaticScript:
+		return workflow.NodeKindScript
+	default:
+		panic(fmt.Sprintf("admission policy %d has no executable Node kind", p))
+	}
+}
+
 type currentNodeQueuedStart struct {
 	reference          workflow.CurrentNodeReference
 	taskPromptDelivery workflowruntime.TaskPromptDelivery
 	assignmentSteer    CurrentNodeAssignmentSteer
-	automatic          bool
+	policy             currentNodeAdmissionPolicy
 	done               chan struct{}
+}
+
+type currentNodeAutomaticQueue struct {
+	first       *currentNodeAutomaticQueueEntry
+	last        *currentNodeAutomaticQueueEntry
+	firstAgent  *currentNodeAutomaticQueueEntry
+	lastAgent   *currentNodeAutomaticQueueEntry
+	firstScript *currentNodeAutomaticQueueEntry
+	lastScript  *currentNodeAutomaticQueueEntry
+	tasks       map[workflow.TaskID]*currentNodeAutomaticTaskQueue
+	nextOrder   uint64
+	size        int
+}
+
+type currentNodeAutomaticTaskQueue struct {
+	firstAgent  *currentNodeAutomaticQueueEntry
+	lastAgent   *currentNodeAutomaticQueueEntry
+	firstScript *currentNodeAutomaticQueueEntry
+	lastScript  *currentNodeAutomaticQueueEntry
+}
+
+type currentNodeAutomaticQueueEntry struct {
+	start      currentNodeQueuedStart
+	order      uint64
+	globalPrev *currentNodeAutomaticQueueEntry
+	globalNext *currentNodeAutomaticQueueEntry
+	policyPrev *currentNodeAutomaticQueueEntry
+	policyNext *currentNodeAutomaticQueueEntry
+	taskPrev   *currentNodeAutomaticQueueEntry
+	taskNext   *currentNodeAutomaticQueueEntry
+}
+
+func (q *currentNodeAutomaticQueue) append(start currentNodeQueuedStart) {
+	if !start.policy.isAutomatic() {
+		panic(fmt.Sprintf("automatic queue received non-automatic policy %d", start.policy))
+	}
+	q.nextOrder++
+	if q.nextOrder == 0 {
+		panic("automatic queue order overflow")
+	}
+	entry := &currentNodeAutomaticQueueEntry{start: start, order: q.nextOrder, globalPrev: q.last}
+	if q.last == nil {
+		q.first = entry
+	} else {
+		q.last.globalNext = entry
+	}
+	q.last = entry
+	if q.tasks == nil {
+		q.tasks = make(map[workflow.TaskID]*currentNodeAutomaticTaskQueue)
+	}
+	taskQueue := q.tasks[start.reference.TaskID]
+	if taskQueue == nil {
+		taskQueue = &currentNodeAutomaticTaskQueue{}
+		q.tasks[start.reference.TaskID] = taskQueue
+	}
+	if start.policy == currentNodeAdmissionAutomaticAgent {
+		entry.policyPrev = q.lastAgent
+		entry.taskPrev = taskQueue.lastAgent
+		if q.lastAgent == nil {
+			q.firstAgent = entry
+		} else {
+			q.lastAgent.policyNext = entry
+		}
+		q.lastAgent = entry
+		if taskQueue.lastAgent == nil {
+			taskQueue.firstAgent = entry
+		} else {
+			taskQueue.lastAgent.taskNext = entry
+		}
+		taskQueue.lastAgent = entry
+	} else {
+		entry.policyPrev = q.lastScript
+		entry.taskPrev = taskQueue.lastScript
+		if q.lastScript == nil {
+			q.firstScript = entry
+		} else {
+			q.lastScript.policyNext = entry
+		}
+		q.lastScript = entry
+		if taskQueue.lastScript == nil {
+			taskQueue.firstScript = entry
+		} else {
+			taskQueue.lastScript.taskNext = entry
+		}
+		taskQueue.lastScript = entry
+	}
+	q.size++
+}
+
+func (q *currentNodeAutomaticQueue) remove(entry *currentNodeAutomaticQueueEntry) currentNodeQueuedStart {
+	if entry.globalPrev == nil {
+		q.first = entry.globalNext
+	} else {
+		entry.globalPrev.globalNext = entry.globalNext
+	}
+	if entry.globalNext == nil {
+		q.last = entry.globalPrev
+	} else {
+		entry.globalNext.globalPrev = entry.globalPrev
+	}
+	taskQueue := q.tasks[entry.start.reference.TaskID]
+	if taskQueue == nil {
+		panic("automatic queue task index lost an entry")
+	}
+	if entry.start.policy == currentNodeAdmissionAutomaticAgent {
+		if entry.policyPrev == nil {
+			q.firstAgent = entry.policyNext
+		} else {
+			entry.policyPrev.policyNext = entry.policyNext
+		}
+		if entry.policyNext == nil {
+			q.lastAgent = entry.policyPrev
+		} else {
+			entry.policyNext.policyPrev = entry.policyPrev
+		}
+		if entry.taskPrev == nil {
+			taskQueue.firstAgent = entry.taskNext
+		} else {
+			entry.taskPrev.taskNext = entry.taskNext
+		}
+		if entry.taskNext == nil {
+			taskQueue.lastAgent = entry.taskPrev
+		} else {
+			entry.taskNext.taskPrev = entry.taskPrev
+		}
+	} else {
+		if entry.policyPrev == nil {
+			q.firstScript = entry.policyNext
+		} else {
+			entry.policyPrev.policyNext = entry.policyNext
+		}
+		if entry.policyNext == nil {
+			q.lastScript = entry.policyPrev
+		} else {
+			entry.policyNext.policyPrev = entry.policyPrev
+		}
+		if entry.taskPrev == nil {
+			taskQueue.firstScript = entry.taskNext
+		} else {
+			entry.taskPrev.taskNext = entry.taskNext
+		}
+		if entry.taskNext == nil {
+			taskQueue.lastScript = entry.taskPrev
+		} else {
+			entry.taskNext.taskPrev = entry.taskPrev
+		}
+	}
+	if taskQueue.firstAgent == nil && taskQueue.firstScript == nil {
+		delete(q.tasks, entry.start.reference.TaskID)
+	}
+	q.size--
+	return entry.start
+}
+
+func (q *currentNodeAutomaticQueue) clear() {
+	q.first = nil
+	q.last = nil
+	q.firstAgent = nil
+	q.lastAgent = nil
+	q.firstScript = nil
+	q.lastScript = nil
+	q.tasks = nil
+	q.nextOrder = 0
+	q.size = 0
+}
+
+func (q *currentNodeAutomaticQueue) len() int {
+	return q.size
+}
+
+func (q *currentNodeAutomaticQueue) selectEntry(lastTask *workflow.TaskID, agentAvailable bool) (*currentNodeAutomaticQueueEntry, bool) {
+	if lastTask != nil {
+		if taskQueue := q.tasks[*lastTask]; taskQueue != nil {
+			candidate := taskQueue.firstScript
+			if agentAvailable && taskQueue.firstAgent != nil &&
+				(candidate == nil || taskQueue.firstAgent.order < candidate.order) {
+				candidate = taskQueue.firstAgent
+			}
+			if candidate != nil {
+				return candidate, true
+			}
+		}
+	}
+	if !agentAvailable {
+		return q.firstScript, q.firstScript != nil
+	}
+	if q.firstAgent == nil {
+		return q.firstScript, q.firstScript != nil
+	}
+	if q.firstScript == nil || q.firstAgent.order < q.firstScript.order {
+		return q.firstAgent, true
+	}
+	return q.firstScript, true
 }
 
 type currentNodeAdmissionGate struct {
 	reference workflow.CurrentNodeReference
 	lease     sessionruntime.WorkflowExecutionLease
-	automatic bool
+	policy    currentNodeAdmissionPolicy
 	done      <-chan struct{}
 }
 
 type currentNodeLiveScope struct {
 	reference workflow.CurrentNodeReference
 	lease     sessionruntime.WorkflowExecutionLease
-	automatic bool
+	policy    currentNodeAdmissionPolicy
 }
 
 type currentNodeAdmissionError struct {
@@ -134,7 +355,7 @@ func (c *CurrentNodeController) admit(ctx context.Context, start currentNodeQueu
 	if err != nil {
 		return err
 	}
-	defer c.releaseReservation(key, start.automatic)
+	defer c.releaseReservation(key, start.policy)
 	c.mu.Lock()
 	if c.closed {
 		c.mu.Unlock()
@@ -149,7 +370,7 @@ func (c *CurrentNodeController) admit(ctx context.Context, start currentNodeQueu
 			c.mu.Unlock()
 			return err
 		}
-		reservation, reserved := c.admissionReservationLocked(key, start.automatic)
+		reservation, reserved := c.admissionReservationLocked(key, start.policy)
 		if !reserved || reservation.done != start.done {
 			c.mu.Unlock()
 			return sessionruntime.ErrExecutionNoLongerLive
@@ -186,19 +407,19 @@ func (c *CurrentNodeController) admit(ctx context.Context, start currentNodeQueu
 			next.Cancel()
 			return sessionruntime.ErrExecutionNoLongerLive
 		}
-		reservation, reserved = c.admissionReservationLocked(key, start.automatic)
+		reservation, reserved = c.admissionReservationLocked(key, start.policy)
 		if !reserved || reservation.done != start.done {
 			c.mu.Unlock()
 			next.Cancel()
 			return sessionruntime.ErrExecutionNoLongerLive
 		}
-		c.deleteAdmissionReservationLocked(key, start.automatic)
+		c.deleteAdmissionReservationLocked(key, start.policy)
 		// The gate precedes the durable restart marker, so any conflicting
 		// lifecycle mutation sees admission before slow runner preparation.
 		c.gates[key] = currentNodeAdmissionGate{
 			reference: reference,
 			lease:     next,
-			automatic: start.automatic,
+			policy:    start.policy,
 			done:      start.done,
 		}
 		c.mu.Unlock()
@@ -241,7 +462,7 @@ func (c *CurrentNodeController) admit(ctx context.Context, start currentNodeQueu
 			return sessionruntime.ErrExecutionNoLongerLive
 		}
 		delete(c.gates, key)
-		c.live[lease.ScopeID()] = currentNodeLiveScope{reference: reference, lease: lease, automatic: gate.automatic}
+		c.live[lease.ScopeID()] = currentNodeLiveScope{reference: reference, lease: lease, policy: gate.policy}
 		c.liveByNode[key] = lease.ScopeID()
 		lease.Release()
 		return nil
@@ -251,7 +472,7 @@ func (c *CurrentNodeController) admit(ctx context.Context, start currentNodeQueu
 			admitted: true,
 		}
 	}
-	if !start.automatic {
+	if !start.policy.isAutomatic() {
 		c.wakeAdmissionWorker()
 	}
 	return nil
@@ -263,6 +484,9 @@ func (c *CurrentNodeController) removeGate(key workflow.CurrentNodeReferenceKey,
 	if gate, exists := c.gates[key]; exists && gate.lease.ScopeID() == scopeID {
 		delete(c.gates, key)
 		delete(c.stopping, scopeID)
+		if gate.policy.countsAgentCapacity() {
+			c.releaseAgentCapacityLocked()
+		}
 		wake = true
 	}
 	c.mu.Unlock()
@@ -274,7 +498,12 @@ func (c *CurrentNodeController) removeGate(key workflow.CurrentNodeReferenceKey,
 func (c *CurrentNodeController) discardAdmission(reference workflow.CurrentNodeReference, key workflow.CurrentNodeReferenceKey, lease sessionruntime.WorkflowExecutionLease, cause error) error {
 	c.removeGate(key, lease.ScopeID())
 	c.mu.Lock()
-	delete(c.live, lease.ScopeID())
+	if live, exists := c.live[lease.ScopeID()]; exists {
+		if live.policy.countsAgentCapacity() {
+			c.releaseAgentCapacityLocked()
+		}
+		delete(c.live, lease.ScopeID())
+	}
 	if current, exists := c.liveByNode[key]; exists && current == lease.ScopeID() {
 		delete(c.liveByNode, key)
 	}
@@ -445,7 +674,7 @@ func (c *CurrentNodeController) enqueueStarts(starts []currentNodeQueuedStart) {
 	}
 	for _, start := range starts {
 		var err error
-		if start.automatic {
+		if start.policy.isAutomatic() {
 			err = c.queueAutomaticStartLocked(start)
 		} else {
 			err = c.queueExplicitStartLocked(start)
@@ -459,7 +688,7 @@ func (c *CurrentNodeController) enqueueStarts(starts []currentNodeQueuedStart) {
 }
 
 func (c *CurrentNodeController) queueExplicitStartLocked(start currentNodeQueuedStart) error {
-	if start.automatic {
+	if start.policy != currentNodeAdmissionExplicitOverride {
 		return errors.New("explicit current node start cannot be automatic")
 	}
 	key, err := start.reference.Key()
@@ -476,8 +705,8 @@ func (c *CurrentNodeController) queueExplicitStartLocked(start currentNodeQueued
 }
 
 func (c *CurrentNodeController) queueAutomaticStartLocked(start currentNodeQueuedStart) error {
-	if !start.automatic {
-		return errors.New("automatic current node start must be automatic")
+	if !start.policy.isAutomatic() {
+		return errors.New("automatic current node start requires an automatic admission policy")
 	}
 	key, err := start.reference.Key()
 	if err != nil {
@@ -486,7 +715,7 @@ func (c *CurrentNodeController) queueAutomaticStartLocked(start currentNodeQueue
 	if c.currentNodeOwnedLocked(key) {
 		return nil
 	}
-	c.automaticQueue = append(c.automaticQueue, start)
+	c.automaticQueue.append(start)
 	c.queued[key] = struct{}{}
 	c.wakeAdmissionWorker()
 	return nil
@@ -570,7 +799,7 @@ func (c *CurrentNodeController) runAdmission(start currentNodeQueuedStart) {
 func (c *CurrentNodeController) takeExplicitStart() (currentNodeQueuedStart, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.closed || c.inFlightAdmissionCountLocked(false) >= explicitAdmissionConcurrency || len(c.explicitQueue) == 0 {
+	if c.closed || c.inFlightAdmissionCountLocked(currentNodeAdmissionExplicitOverride) >= explicitAdmissionConcurrency || len(c.explicitQueue) == 0 {
 		return currentNodeQueuedStart{}, false
 	}
 	start := c.explicitQueue[0]
@@ -591,58 +820,88 @@ func (c *CurrentNodeController) takeExplicitStart() (currentNodeQueuedStart, boo
 func (c *CurrentNodeController) takeAutomaticIntent() (currentNodeQueuedStart, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.closed || c.automaticActiveLocked() >= c.automaticConcurrency || len(c.automaticQueue) == 0 {
+	if c.closed || c.automaticQueue.len() == 0 {
 		return currentNodeQueuedStart{}, false
 	}
-	index := 0
-	if c.lastAutomaticTask != nil {
-		for candidateIndex, candidate := range c.automaticQueue {
-			if candidate.reference.TaskID == *c.lastAutomaticTask {
-				index = candidateIndex
-				break
-			}
-		}
+	agentAvailable := c.agentCapacityActive < c.agentConcurrency
+	entry, ok := c.automaticQueue.selectEntry(c.lastAutomaticTask, agentAvailable)
+	if !ok {
+		return currentNodeQueuedStart{}, false
 	}
-	start := c.automaticQueue[index]
-	c.automaticQueue = append(c.automaticQueue[:index], c.automaticQueue[index+1:]...)
+	start := c.automaticQueue.remove(entry)
 	key, err := start.reference.Key()
 	if err != nil {
 		panic(fmt.Sprintf("take automatic current node intent: %v", err))
 	}
 	delete(c.queued, key)
 	start.taskPromptDelivery = workflowruntime.TaskPromptDeliveryResume
-	start.automatic = true
 	start.done = make(chan struct{})
 	c.automaticReservations[key] = start
 	c.admissionWorkers[key] = start
+	if start.policy.countsAgentCapacity() {
+		c.agentCapacityActive++
+	}
 	c.admissionWG.Add(1)
 	taskID := start.reference.TaskID
 	c.lastAutomaticTask = &taskID
 	return start, true
 }
 
-func (c *CurrentNodeController) automaticActiveLocked() int {
-	active := c.inFlightAdmissionCountLocked(true)
-	for _, live := range c.live {
-		if live.automatic {
-			active++
-		}
+func automaticIntentAdmissible(intent CurrentNodeAutomaticIntent, agentAvailable bool) bool {
+	switch intent.NodeKind {
+	case workflow.NodeKindAgent:
+		return agentAvailable
+	case workflow.NodeKindScript:
+		return true
+	default:
+		panic(fmt.Sprintf("automatic intent %v has non-executable node kind %q", intent.CurrentNode, intent.NodeKind))
 	}
-	return active
 }
 
-func (c *CurrentNodeController) inFlightAdmissionCountLocked(automatic bool) int {
+func selectAutomaticIntentIndex(intents []CurrentNodeAutomaticIntent, lastTask *workflow.TaskID, agentAvailable bool) (int, bool) {
+	if lastTask != nil {
+		for index, intent := range intents {
+			if intent.CurrentNode.TaskID == *lastTask && automaticIntentAdmissible(intent, agentAvailable) {
+				return index, true
+			}
+		}
+	}
+	for index, intent := range intents {
+		if automaticIntentAdmissible(intent, agentAvailable) {
+			return index, true
+		}
+	}
+	return 0, false
+}
+
+func (c *CurrentNodeController) agentActiveLocked() int {
+	return c.agentCapacityActive
+}
+
+func (c *CurrentNodeController) releaseAgentCapacityLocked() {
+	if c.agentCapacityActive <= 0 {
+		panic("automatic Agent capacity released without an active reservation, gate, or live scope")
+	}
+	c.agentCapacityActive--
+}
+
+func (c *CurrentNodeController) inFlightAdmissionCountLocked(policy currentNodeAdmissionPolicy) int {
 	count := 0
-	for _, start := range c.admissionWorkers {
-		if start.automatic == automatic {
+	for key, start := range c.admissionWorkers {
+		if start.policy == policy {
+			if policy.countsAgentCapacity() {
+				if _, live := c.liveByNode[key]; live {
+					continue
+				}
+			}
 			count++
 		}
 	}
 	return count
 }
 
-func (c *CurrentNodeController) admissionReservationLocked(key workflow.CurrentNodeReferenceKey, automatic bool) (currentNodeQueuedStart, bool) {
-	if automatic {
+func (c *CurrentNodeController) admissionReservationLocked(key workflow.CurrentNodeReferenceKey, policy currentNodeAdmissionPolicy) (currentNodeQueuedStart, bool) {
+	if policy.isAutomatic() {
 		start, exists := c.automaticReservations[key]
 		return start, exists
 	}
@@ -650,21 +909,24 @@ func (c *CurrentNodeController) admissionReservationLocked(key workflow.CurrentN
 	return start, exists
 }
 
-func (c *CurrentNodeController) deleteAdmissionReservationLocked(key workflow.CurrentNodeReferenceKey, automatic bool) {
-	if automatic {
+func (c *CurrentNodeController) deleteAdmissionReservationLocked(key workflow.CurrentNodeReferenceKey, policy currentNodeAdmissionPolicy) {
+	if policy.isAutomatic() {
 		delete(c.automaticReservations, key)
 		return
 	}
 	delete(c.explicitReservations, key)
 }
 
-func (c *CurrentNodeController) releaseReservation(key workflow.CurrentNodeReferenceKey, automatic bool) {
+func (c *CurrentNodeController) releaseReservation(key workflow.CurrentNodeReferenceKey, policy currentNodeAdmissionPolicy) {
 	c.mu.Lock()
-	_, reserved := c.admissionReservationLocked(key, automatic)
-	c.deleteAdmissionReservationLocked(key, automatic)
+	_, reserved := c.admissionReservationLocked(key, policy)
+	c.deleteAdmissionReservationLocked(key, policy)
+	if reserved && policy.countsAgentCapacity() {
+		c.releaseAgentCapacityLocked()
+	}
 	closed := c.closed
 	c.mu.Unlock()
-	if (reserved || automatic) && !closed {
+	if (reserved || policy.isAutomatic()) && !closed {
 		c.wakeAdmissionWorker()
 	}
 }
@@ -676,7 +938,7 @@ func (c *CurrentNodeController) finishAdmissionWorker(start currentNodeQueuedSta
 	}
 	c.mu.Lock()
 	current, exists := c.admissionWorkers[key]
-	if !exists || current.done != start.done || current.automatic != start.automatic {
+	if !exists || current.done != start.done || current.policy != start.policy {
 		c.mu.Unlock()
 		panic("current node admission worker ownership was replaced before completion")
 	}
@@ -755,19 +1017,22 @@ func (c *CurrentNodeController) interruptCurrentNodeStartFailures(
 	return err
 }
 
-func currentNodeAutomaticIntents(references []workflow.CurrentNodeReference) ([]CurrentNodeAutomaticIntent, error) {
-	intents := make([]CurrentNodeAutomaticIntent, 0, len(references))
-	seen := make(map[workflow.CurrentNodeReferenceKey]struct{}, len(references))
-	for index, reference := range references {
-		key, err := reference.Key()
+func currentNodeAutomaticIntents(source []workflowstore.CurrentNodeAutomaticIntent) ([]CurrentNodeAutomaticIntent, error) {
+	intents := make([]CurrentNodeAutomaticIntent, 0, len(source))
+	seen := make(map[workflow.CurrentNodeReferenceKey]struct{}, len(source))
+	for index, intent := range source {
+		key, err := intent.CurrentNode.Key()
 		if err != nil {
 			return nil, fmt.Errorf("automatic successor current node at index %d: %w", index, err)
 		}
 		if _, exists := seen[key]; exists {
 			return nil, fmt.Errorf("automatic successor current node at index %d is duplicated", index)
 		}
+		if intent.NodeKind != workflow.NodeKindAgent && intent.NodeKind != workflow.NodeKindScript {
+			return nil, fmt.Errorf("automatic successor current node at index %d has non-executable kind %q", index, intent.NodeKind)
+		}
 		seen[key] = struct{}{}
-		intents = append(intents, CurrentNodeAutomaticIntent{CurrentNode: reference})
+		intents = append(intents, intent)
 	}
 	return intents, nil
 }
@@ -775,9 +1040,13 @@ func currentNodeAutomaticIntents(references []workflow.CurrentNodeReference) ([]
 func automaticQueuedStarts(intents []CurrentNodeAutomaticIntent) []currentNodeQueuedStart {
 	starts := make([]currentNodeQueuedStart, 0, len(intents))
 	for _, intent := range intents {
+		policy := currentNodeAdmissionAutomaticAgent
+		if intent.NodeKind == workflow.NodeKindScript {
+			policy = currentNodeAdmissionAutomaticScript
+		}
 		starts = append(starts, currentNodeQueuedStart{
 			reference: intent.CurrentNode,
-			automatic: true,
+			policy:    policy,
 		})
 	}
 	return starts

--- a/server/workflowexecution/current_node_automatic_queue.go
+++ b/server/workflowexecution/current_node_automatic_queue.go
@@ -18,14 +18,16 @@ type currentNodeAutomaticQueueLaneState struct {
 	last  *currentNodeAutomaticQueueEntry
 }
 
+type currentNodeAutomaticQueueLanes [2]currentNodeAutomaticQueueLaneState
+
 type currentNodeAutomaticTaskQueue struct {
-	lanes [2]currentNodeAutomaticQueueLaneState
+	lanes currentNodeAutomaticQueueLanes
 }
 
 type currentNodeAutomaticQueue struct {
 	first     *currentNodeAutomaticQueueEntry
 	last      *currentNodeAutomaticQueueEntry
-	lanes     [2]currentNodeAutomaticQueueLaneState
+	lanes     currentNodeAutomaticQueueLanes
 	tasks     map[workflow.TaskID]*currentNodeAutomaticTaskQueue
 	nextOrder uint64
 	size      int
@@ -53,12 +55,8 @@ func currentNodeAutomaticQueueLaneForPolicy(policy currentNodeAdmissionPolicy) c
 	}
 }
 
-func (q *currentNodeAutomaticQueue) lane(policy currentNodeAdmissionPolicy) *currentNodeAutomaticQueueLaneState {
-	return &q.lanes[currentNodeAutomaticQueueLaneForPolicy(policy)]
-}
-
-func (q *currentNodeAutomaticTaskQueue) lane(policy currentNodeAdmissionPolicy) *currentNodeAutomaticQueueLaneState {
-	return &q.lanes[currentNodeAutomaticQueueLaneForPolicy(policy)]
+func (lanes *currentNodeAutomaticQueueLanes) lane(policy currentNodeAdmissionPolicy) *currentNodeAutomaticQueueLaneState {
+	return &lanes[currentNodeAutomaticQueueLaneForPolicy(policy)]
 }
 
 func (q *currentNodeAutomaticQueue) append(start currentNodeQueuedStart) {
@@ -86,8 +84,8 @@ func (q *currentNodeAutomaticQueue) append(start currentNodeQueuedStart) {
 		taskQueue = &currentNodeAutomaticTaskQueue{}
 		q.tasks[start.reference.TaskID] = taskQueue
 	}
-	policyLane := q.lane(start.policy)
-	taskLane := taskQueue.lane(start.policy)
+	policyLane := q.lanes.lane(start.policy)
+	taskLane := taskQueue.lanes.lane(start.policy)
 	entry.policyPrev = policyLane.last
 	entry.taskPrev = taskLane.last
 	if policyLane.last == nil {
@@ -121,8 +119,8 @@ func (q *currentNodeAutomaticQueue) remove(entry *currentNodeAutomaticQueueEntry
 	if taskQueue == nil {
 		panic("automatic queue task index lost an entry")
 	}
-	policyLane := q.lane(entry.start.policy)
-	taskLane := taskQueue.lane(entry.start.policy)
+	policyLane := q.lanes.lane(entry.start.policy)
+	taskLane := taskQueue.lanes.lane(entry.start.policy)
 	if entry.policyPrev == nil {
 		policyLane.first = entry.policyNext
 	} else {
@@ -154,7 +152,7 @@ func (q *currentNodeAutomaticQueue) remove(entry *currentNodeAutomaticQueueEntry
 func (q *currentNodeAutomaticQueue) clear() {
 	q.first = nil
 	q.last = nil
-	q.lanes = [2]currentNodeAutomaticQueueLaneState{}
+	q.lanes = currentNodeAutomaticQueueLanes{}
 	q.tasks = nil
 	q.nextOrder = 0
 	q.size = 0
@@ -167,10 +165,10 @@ func (q *currentNodeAutomaticQueue) len() int {
 func (q *currentNodeAutomaticQueue) selectEntry(lastTask *workflow.TaskID, agentAvailable bool) (*currentNodeAutomaticQueueEntry, bool) {
 	if lastTask != nil {
 		if taskQueue := q.tasks[*lastTask]; taskQueue != nil {
-			script := taskQueue.lane(currentNodeAdmissionAutomaticScript).first
+			script := taskQueue.lanes.lane(currentNodeAdmissionAutomaticScript).first
 			candidate := script
 			if agentAvailable {
-				agent := taskQueue.lane(currentNodeAdmissionAutomaticAgent).first
+				agent := taskQueue.lanes.lane(currentNodeAdmissionAutomaticAgent).first
 				if agent != nil && (candidate == nil || agent.order < candidate.order) {
 					candidate = agent
 				}
@@ -180,11 +178,11 @@ func (q *currentNodeAutomaticQueue) selectEntry(lastTask *workflow.TaskID, agent
 			}
 		}
 	}
-	script := q.lane(currentNodeAdmissionAutomaticScript).first
+	script := q.lanes.lane(currentNodeAdmissionAutomaticScript).first
 	if !agentAvailable {
 		return script, script != nil
 	}
-	agent := q.lane(currentNodeAdmissionAutomaticAgent).first
+	agent := q.lanes.lane(currentNodeAdmissionAutomaticAgent).first
 	if agent == nil {
 		return script, script != nil
 	}

--- a/server/workflowexecution/current_node_automatic_queue.go
+++ b/server/workflowexecution/current_node_automatic_queue.go
@@ -1,0 +1,195 @@
+package workflowexecution
+
+import (
+	"fmt"
+
+	"core/server/workflow"
+)
+
+type currentNodeAutomaticQueueLane uint8
+
+const (
+	currentNodeAutomaticAgentLane currentNodeAutomaticQueueLane = iota
+	currentNodeAutomaticScriptLane
+)
+
+type currentNodeAutomaticQueueLaneState struct {
+	first *currentNodeAutomaticQueueEntry
+	last  *currentNodeAutomaticQueueEntry
+}
+
+type currentNodeAutomaticTaskQueue struct {
+	lanes [2]currentNodeAutomaticQueueLaneState
+}
+
+type currentNodeAutomaticQueue struct {
+	first     *currentNodeAutomaticQueueEntry
+	last      *currentNodeAutomaticQueueEntry
+	lanes     [2]currentNodeAutomaticQueueLaneState
+	tasks     map[workflow.TaskID]*currentNodeAutomaticTaskQueue
+	nextOrder uint64
+	size      int
+}
+
+type currentNodeAutomaticQueueEntry struct {
+	start      currentNodeQueuedStart
+	order      uint64
+	globalPrev *currentNodeAutomaticQueueEntry
+	globalNext *currentNodeAutomaticQueueEntry
+	policyPrev *currentNodeAutomaticQueueEntry
+	policyNext *currentNodeAutomaticQueueEntry
+	taskPrev   *currentNodeAutomaticQueueEntry
+	taskNext   *currentNodeAutomaticQueueEntry
+}
+
+func currentNodeAutomaticQueueLaneForPolicy(policy currentNodeAdmissionPolicy) currentNodeAutomaticQueueLane {
+	switch policy {
+	case currentNodeAdmissionAutomaticAgent:
+		return currentNodeAutomaticAgentLane
+	case currentNodeAdmissionAutomaticScript:
+		return currentNodeAutomaticScriptLane
+	default:
+		panic(fmt.Sprintf("automatic queue received non-automatic policy %d", policy))
+	}
+}
+
+func (q *currentNodeAutomaticQueue) lane(policy currentNodeAdmissionPolicy) *currentNodeAutomaticQueueLaneState {
+	return &q.lanes[currentNodeAutomaticQueueLaneForPolicy(policy)]
+}
+
+func (q *currentNodeAutomaticTaskQueue) lane(policy currentNodeAdmissionPolicy) *currentNodeAutomaticQueueLaneState {
+	return &q.lanes[currentNodeAutomaticQueueLaneForPolicy(policy)]
+}
+
+func (q *currentNodeAutomaticQueue) append(start currentNodeQueuedStart) {
+	q.nextOrder++
+	if q.nextOrder == 0 {
+		panic("automatic queue order overflow")
+	}
+	entry := &currentNodeAutomaticQueueEntry{
+		start:      start,
+		order:      q.nextOrder,
+		globalPrev: q.last,
+	}
+	if q.last == nil {
+		q.first = entry
+	} else {
+		q.last.globalNext = entry
+	}
+	q.last = entry
+
+	if q.tasks == nil {
+		q.tasks = make(map[workflow.TaskID]*currentNodeAutomaticTaskQueue)
+	}
+	taskQueue := q.tasks[start.reference.TaskID]
+	if taskQueue == nil {
+		taskQueue = &currentNodeAutomaticTaskQueue{}
+		q.tasks[start.reference.TaskID] = taskQueue
+	}
+	policyLane := q.lane(start.policy)
+	taskLane := taskQueue.lane(start.policy)
+	entry.policyPrev = policyLane.last
+	entry.taskPrev = taskLane.last
+	if policyLane.last == nil {
+		policyLane.first = entry
+	} else {
+		policyLane.last.policyNext = entry
+	}
+	policyLane.last = entry
+	if taskLane.last == nil {
+		taskLane.first = entry
+	} else {
+		taskLane.last.taskNext = entry
+	}
+	taskLane.last = entry
+	q.size++
+}
+
+func (q *currentNodeAutomaticQueue) remove(entry *currentNodeAutomaticQueueEntry) currentNodeQueuedStart {
+	if entry.globalPrev == nil {
+		q.first = entry.globalNext
+	} else {
+		entry.globalPrev.globalNext = entry.globalNext
+	}
+	if entry.globalNext == nil {
+		q.last = entry.globalPrev
+	} else {
+		entry.globalNext.globalPrev = entry.globalPrev
+	}
+
+	taskQueue := q.tasks[entry.start.reference.TaskID]
+	if taskQueue == nil {
+		panic("automatic queue task index lost an entry")
+	}
+	policyLane := q.lane(entry.start.policy)
+	taskLane := taskQueue.lane(entry.start.policy)
+	if entry.policyPrev == nil {
+		policyLane.first = entry.policyNext
+	} else {
+		entry.policyPrev.policyNext = entry.policyNext
+	}
+	if entry.policyNext == nil {
+		policyLane.last = entry.policyPrev
+	} else {
+		entry.policyNext.policyPrev = entry.policyPrev
+	}
+	if entry.taskPrev == nil {
+		taskLane.first = entry.taskNext
+	} else {
+		entry.taskPrev.taskNext = entry.taskNext
+	}
+	if entry.taskNext == nil {
+		taskLane.last = entry.taskPrev
+	} else {
+		entry.taskNext.taskPrev = entry.taskPrev
+	}
+	if taskQueue.lanes[currentNodeAutomaticAgentLane].first == nil &&
+		taskQueue.lanes[currentNodeAutomaticScriptLane].first == nil {
+		delete(q.tasks, entry.start.reference.TaskID)
+	}
+	q.size--
+	return entry.start
+}
+
+func (q *currentNodeAutomaticQueue) clear() {
+	q.first = nil
+	q.last = nil
+	q.lanes = [2]currentNodeAutomaticQueueLaneState{}
+	q.tasks = nil
+	q.nextOrder = 0
+	q.size = 0
+}
+
+func (q *currentNodeAutomaticQueue) len() int {
+	return q.size
+}
+
+func (q *currentNodeAutomaticQueue) selectEntry(lastTask *workflow.TaskID, agentAvailable bool) (*currentNodeAutomaticQueueEntry, bool) {
+	if lastTask != nil {
+		if taskQueue := q.tasks[*lastTask]; taskQueue != nil {
+			script := taskQueue.lane(currentNodeAdmissionAutomaticScript).first
+			candidate := script
+			if agentAvailable {
+				agent := taskQueue.lane(currentNodeAdmissionAutomaticAgent).first
+				if agent != nil && (candidate == nil || agent.order < candidate.order) {
+					candidate = agent
+				}
+			}
+			if candidate != nil {
+				return candidate, true
+			}
+		}
+	}
+	script := q.lane(currentNodeAdmissionAutomaticScript).first
+	if !agentAvailable {
+		return script, script != nil
+	}
+	agent := q.lane(currentNodeAdmissionAutomaticAgent).first
+	if agent == nil {
+		return script, script != nil
+	}
+	if script == nil || agent.order < script.order {
+		return agent, true
+	}
+	return script, true
+}

--- a/server/workflowexecution/current_node_automatic_queue_test.go
+++ b/server/workflowexecution/current_node_automatic_queue_test.go
@@ -1,0 +1,96 @@
+package workflowexecution
+
+import (
+	"fmt"
+	"testing"
+
+	"core/server/workflow"
+)
+
+func TestCurrentNodeControllerLargeMixedKindQueueSelection(t *testing.T) {
+	queue := currentNodeAutomaticQueue{}
+	for index := 0; index < 4096; index++ {
+		policy := currentNodeAdmissionAutomaticScript
+		if index%2 == 0 {
+			policy = currentNodeAdmissionAutomaticAgent
+		}
+		queue.append(currentNodeQueuedStart{
+			reference: workflow.CurrentNodeReference{
+				TaskID: workflow.TaskID("task-large-mixed-kind-queue"),
+				NodeID: workflow.NodeID(fmt.Sprintf("node-%d", index)),
+			},
+			policy: policy,
+		})
+	}
+	agentAvailable := false
+	for queue.len() != 0 {
+		entry, ok := queue.selectEntry(nil, agentAvailable)
+		if !ok && !agentAvailable {
+			agentAvailable = true
+			continue
+		}
+		if !ok || entry.start.policy != currentNodeAdmissionAutomaticScript {
+			if !agentAvailable {
+				t.Fatalf("selected queue entry = %+v, want an admissible Script", entry)
+			}
+		}
+		queue.remove(entry)
+	}
+}
+
+func TestCurrentNodeAutomaticQueueSelectionPreservesTaskLocalityAndFIFO(t *testing.T) {
+	queue := currentNodeAutomaticQueue{}
+	taskOne := workflow.TaskID("task-automatic-queue-one")
+	taskTwo := workflow.TaskID("task-automatic-queue-two")
+	entries := []currentNodeQueuedStart{
+		{reference: workflow.CurrentNodeReference{TaskID: taskOne, NodeID: "agent-one"}, policy: currentNodeAdmissionAutomaticAgent},
+		{reference: workflow.CurrentNodeReference{TaskID: taskTwo, NodeID: "script-two"}, policy: currentNodeAdmissionAutomaticScript},
+		{reference: workflow.CurrentNodeReference{TaskID: taskOne, NodeID: "script-one"}, policy: currentNodeAdmissionAutomaticScript},
+		{reference: workflow.CurrentNodeReference{TaskID: taskTwo, NodeID: "agent-two"}, policy: currentNodeAdmissionAutomaticAgent},
+	}
+	for _, entry := range entries {
+		queue.append(entry)
+	}
+
+	lastTask := taskOne
+	entry, ok := queue.selectEntry(&lastTask, true)
+	if !ok || !entry.start.reference.Equal(entries[0].reference) {
+		t.Fatalf("same-Task Agent selection = %+v, want first Agent", entry)
+	}
+	queue.remove(entry)
+
+	lastTask = taskTwo
+	entry, ok = queue.selectEntry(&lastTask, true)
+	if !ok || !entry.start.reference.Equal(entries[1].reference) {
+		t.Fatalf("same-Task FIFO selection = %+v, want first Script", entry)
+	}
+	queue.remove(entry)
+
+	entry, ok = queue.selectEntry(nil, false)
+	if !ok || !entry.start.reference.Equal(entries[2].reference) {
+		t.Fatalf("Script selection at saturated Agent capacity = %+v, want Script", entry)
+	}
+}
+
+func TestCurrentNodeAutomaticQueueRemovalMaintainsEveryIndex(t *testing.T) {
+	queue := currentNodeAutomaticQueue{}
+	entries := []currentNodeQueuedStart{
+		{reference: workflow.CurrentNodeReference{TaskID: "task-a", NodeID: "agent-a"}, policy: currentNodeAdmissionAutomaticAgent},
+		{reference: workflow.CurrentNodeReference{TaskID: "task-a", NodeID: "script-a"}, policy: currentNodeAdmissionAutomaticScript},
+		{reference: workflow.CurrentNodeReference{TaskID: "task-b", NodeID: "agent-b"}, policy: currentNodeAdmissionAutomaticAgent},
+		{reference: workflow.CurrentNodeReference{TaskID: "task-b", NodeID: "script-b"}, policy: currentNodeAdmissionAutomaticScript},
+	}
+	for _, entry := range entries {
+		queue.append(entry)
+	}
+	for queue.len() != 0 {
+		entry, ok := queue.selectEntry(nil, true)
+		if !ok {
+			t.Fatal("queue lost an eligible entry")
+		}
+		queue.remove(entry)
+	}
+	if len(queue.tasks) != 0 || queue.first != nil || queue.last != nil {
+		t.Fatalf("queue indexes after drain = %+v, want empty", queue)
+	}
+}

--- a/server/workflowexecution/current_node_automatic_queue_test.go
+++ b/server/workflowexecution/current_node_automatic_queue_test.go
@@ -25,14 +25,15 @@ func TestCurrentNodeControllerLargeMixedKindQueueSelection(t *testing.T) {
 	agentAvailable := false
 	for queue.len() != 0 {
 		entry, ok := queue.selectEntry(nil, agentAvailable)
-		if !ok && !agentAvailable {
+		if !ok {
+			if agentAvailable {
+				t.Fatalf("queue lost an eligible entry with %d remaining", queue.len())
+			}
 			agentAvailable = true
 			continue
 		}
-		if !ok || entry.start.policy != currentNodeAdmissionAutomaticScript {
-			if !agentAvailable {
-				t.Fatalf("selected queue entry = %+v, want an admissible Script", entry)
-			}
+		if !agentAvailable && entry.start.policy != currentNodeAdmissionAutomaticScript {
+			t.Fatalf("selected queue entry = %+v, want an admissible Script", entry)
 		}
 		queue.remove(entry)
 	}

--- a/server/workflowexecution/current_node_controller.go
+++ b/server/workflowexecution/current_node_controller.go
@@ -650,6 +650,7 @@ func (c *CurrentNodeController) ExecutionFinalized(scope sessionruntime.Executio
 	starts := append([]currentNodeQueuedStart(nil), c.heldStarts[scope.ID()]...)
 	delete(c.heldStarts, scope.ID())
 	if gate, gated := c.gates[key]; gated && gate.lease.ScopeID() == scope.ID() {
+		c.releaseAgentCapacityLocked(gate.agentCapacityLease)
 		delete(c.gates, key)
 	}
 	interrupted := c.interrupts.scopeFenced(scope.ID())

--- a/server/workflowexecution/current_node_controller.go
+++ b/server/workflowexecution/current_node_controller.go
@@ -636,8 +636,8 @@ func (c *CurrentNodeController) ExecutionFinalized(scope sessionruntime.Executio
 	}
 	c.mu.Lock()
 	live, isLive := c.live[scope.ID()]
-	if isLive && live.policy.countsAgentCapacity() {
-		c.releaseAgentCapacityLocked()
+	if isLive {
+		c.releaseAgentCapacityLocked(live.agentCapacityLease)
 	}
 	delete(c.live, scope.ID())
 	if current, exists := c.liveByNode[key]; exists && current == scope.ID() {

--- a/server/workflowexecution/current_node_controller.go
+++ b/server/workflowexecution/current_node_controller.go
@@ -42,9 +42,9 @@ type CurrentNodeAssignmentSteer interface {
 }
 
 type CurrentNodeControllerConfig struct {
-	AutomaticConcurrency int
-	Attention            CurrentNodeAttentionLifecycle
-	AssignmentSteerer    CurrentNodeAssignmentSteerer
+	AgentConcurrency  int
+	Attention         CurrentNodeAttentionLifecycle
+	AssignmentSteerer CurrentNodeAssignmentSteerer
 }
 
 type CurrentNodeAttentionLifecycle interface {
@@ -54,9 +54,7 @@ type CurrentNodeAttentionLifecycle interface {
 
 // CurrentNodeAutomaticIntent is volatile automatic work. It has a Current Node
 // natural reference rather than a replacement execution identity.
-type CurrentNodeAutomaticIntent struct {
-	CurrentNode workflow.CurrentNodeReference
-}
+type CurrentNodeAutomaticIntent = workflowstore.CurrentNodeAutomaticIntent
 
 type CurrentNodeExplicitStart struct {
 	CurrentNode workflow.CurrentNodeReference
@@ -117,12 +115,12 @@ type CurrentNodeController struct {
 	permit    *MutationPermit
 	attention CurrentNodeAttentionLifecycle
 
-	automaticConcurrency int
-	workerContext        context.Context
-	workerCancel         context.CancelFunc
-	workerWake           chan struct{}
-	workerWG             sync.WaitGroup
-	admissionWG          sync.WaitGroup
+	agentConcurrency int
+	workerContext    context.Context
+	workerCancel     context.CancelFunc
+	workerWake       chan struct{}
+	workerWG         sync.WaitGroup
+	admissionWG      sync.WaitGroup
 
 	mu                    sync.Mutex
 	closed                bool
@@ -136,10 +134,11 @@ type CurrentNodeController struct {
 	explicitQueue         []currentNodeQueuedStart
 	explicitQueued        map[workflow.CurrentNodeReferenceKey]struct{}
 	explicitReservations  map[workflow.CurrentNodeReferenceKey]currentNodeQueuedStart
-	automaticQueue        []currentNodeQueuedStart
+	automaticQueue        currentNodeAutomaticQueue
 	queued                map[workflow.CurrentNodeReferenceKey]struct{}
 	automaticReservations map[workflow.CurrentNodeReferenceKey]currentNodeQueuedStart
 	admissionWorkers      map[workflow.CurrentNodeReferenceKey]currentNodeQueuedStart
+	agentCapacityActive   int
 	interrupts            currentNodeInterruptState
 	workerErr             error
 	lastAutomaticTask     *workflow.TaskID
@@ -182,8 +181,8 @@ func NewCurrentNodeController(
 	if permit == nil {
 		return nil, errors.New("workflow mutation permit is required")
 	}
-	if cfg.AutomaticConcurrency <= 0 {
-		return nil, errors.New("automatic workflow concurrency must be positive")
+	if cfg.AgentConcurrency <= 0 {
+		return nil, errors.New("workflow agent concurrency must be positive")
 	}
 	workerContext, workerCancel := context.WithCancel(context.Background())
 	controller := &CurrentNodeController{
@@ -193,7 +192,7 @@ func NewCurrentNodeController(
 		authority:             authority,
 		permit:                permit,
 		attention:             cfg.Attention,
-		automaticConcurrency:  cfg.AutomaticConcurrency,
+		agentConcurrency:      cfg.AgentConcurrency,
 		workerContext:         workerContext,
 		workerCancel:          workerCancel,
 		workerWake:            make(chan struct{}, 1),
@@ -637,6 +636,9 @@ func (c *CurrentNodeController) ExecutionFinalized(scope sessionruntime.Executio
 	}
 	c.mu.Lock()
 	live, isLive := c.live[scope.ID()]
+	if isLive && live.policy.countsAgentCapacity() {
+		c.releaseAgentCapacityLocked()
+	}
 	delete(c.live, scope.ID())
 	if current, exists := c.liveByNode[key]; exists && current == scope.ID() {
 		delete(c.liveByNode, key)
@@ -658,6 +660,9 @@ func (c *CurrentNodeController) ExecutionFinalized(scope sessionruntime.Executio
 		c.wakeAdmissionWorker()
 	}
 	if !isLive || !live.lease.Workflow().CurrentNode.Equal(ref.CurrentNode) || !completed || interrupted || closed {
+		if !closed {
+			c.wakeAdmissionWorker()
+		}
 		return
 	}
 	waitCtx, cancel := context.WithTimeout(context.Background(), interruptCleanupTimeout)
@@ -672,6 +677,9 @@ func (c *CurrentNodeController) ExecutionFinalized(scope sessionruntime.Executio
 		return
 	}
 	c.enqueueStarts(starts)
+	if len(starts) == 0 {
+		c.wakeAdmissionWorker()
+	}
 }
 
 func (c *CurrentNodeController) Snapshot() CurrentNodeExecutionSnapshot {
@@ -681,16 +689,23 @@ func (c *CurrentNodeController) Snapshot() CurrentNodeExecutionSnapshot {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	snapshot := CurrentNodeExecutionSnapshot{
-		AutomaticIntents: make([]CurrentNodeAutomaticIntent, 0, len(c.automaticQueue)+len(c.automaticReservations)),
+		AutomaticIntents: make([]CurrentNodeAutomaticIntent, 0, c.automaticQueue.len()+len(c.automaticReservations)),
 		ExplicitStarts:   make([]CurrentNodeExplicitStart, 0, len(c.explicitQueue)+len(c.explicitReservations)),
 		Gates:            make([]CurrentNodeAdmissionGateSnapshot, 0, len(c.gates)),
 		LiveScopes:       make([]CurrentNodeLiveScopeSnapshot, 0, len(c.live)),
 	}
-	for _, start := range c.automaticQueue {
-		snapshot.AutomaticIntents = append(snapshot.AutomaticIntents, CurrentNodeAutomaticIntent{CurrentNode: start.reference})
+	for entry := c.automaticQueue.first; entry != nil; entry = entry.globalNext {
+		start := entry.start
+		snapshot.AutomaticIntents = append(snapshot.AutomaticIntents, CurrentNodeAutomaticIntent{
+			CurrentNode: start.reference,
+			NodeKind:    start.policy.nodeKind(),
+		})
 	}
 	for _, start := range c.automaticReservations {
-		snapshot.AutomaticIntents = append(snapshot.AutomaticIntents, CurrentNodeAutomaticIntent{CurrentNode: start.reference})
+		snapshot.AutomaticIntents = append(snapshot.AutomaticIntents, CurrentNodeAutomaticIntent{
+			CurrentNode: start.reference,
+			NodeKind:    start.policy.nodeKind(),
+		})
 	}
 	for _, start := range c.explicitQueue {
 		snapshot.ExplicitStarts = append(snapshot.ExplicitStarts, CurrentNodeExplicitStart{CurrentNode: start.reference})
@@ -702,14 +717,14 @@ func (c *CurrentNodeController) Snapshot() CurrentNodeExecutionSnapshot {
 		snapshot.Gates = append(snapshot.Gates, CurrentNodeAdmissionGateSnapshot{
 			CurrentNode: gate.reference,
 			ScopeID:     gate.lease.ScopeID(),
-			Automatic:   gate.automatic,
+			Automatic:   gate.policy.isAutomatic(),
 		})
 	}
 	for scopeID, live := range c.live {
 		snapshot.LiveScopes = append(snapshot.LiveScopes, CurrentNodeLiveScopeSnapshot{
 			CurrentNode: live.reference,
 			ScopeID:     scopeID,
-			Automatic:   live.automatic,
+			Automatic:   live.policy.isAutomatic(),
 		})
 	}
 	for sourceScope, starts := range c.heldStarts {
@@ -717,7 +732,7 @@ func (c *CurrentNodeController) Snapshot() CurrentNodeExecutionSnapshot {
 			snapshot.HeldIntents = append(snapshot.HeldIntents, CurrentNodeHeldIntentSnapshot{
 				CurrentNode: start.reference,
 				SourceScope: sourceScope,
-				Automatic:   start.automatic,
+				Automatic:   start.policy.isAutomatic(),
 			})
 		}
 	}
@@ -737,7 +752,7 @@ func (c *CurrentNodeController) Close() error {
 	c.closed = true
 	c.explicitQueue = nil
 	c.explicitQueued = make(map[workflow.CurrentNodeReferenceKey]struct{})
-	c.automaticQueue = nil
+	c.automaticQueue.clear()
 	c.queued = make(map[workflow.CurrentNodeReferenceKey]struct{})
 	c.heldStarts = make(map[runtimeids.ExecutionScopeID][]currentNodeQueuedStart)
 	gates := make([]currentNodeAdmissionGate, 0, len(c.gates))
@@ -754,12 +769,19 @@ func (c *CurrentNodeController) Close() error {
 	for _, gate := range gates {
 		gate.lease.Cancel()
 	}
-	var stopErrs []error
+	handles := make([]sessionruntime.ExecutionHandle, 0, len(liveScopes))
 	for _, scopeID := range liveScopes {
 		handle, exists := c.authority.ExecutionByScope(scopeID)
-		if !exists {
-			continue
+		if exists {
+			handles = append(handles, handle)
 		}
+	}
+	for _, handle := range handles {
+		handle.RequestStop()
+	}
+	var stopErrs []error
+	for _, handle := range handles {
+		scopeID := handle.Scope().ID()
 		if err := handle.Stop(context.Background()); err != nil {
 			stopErrs = append(stopErrs, fmt.Errorf("stop workflow execution scope %s: %w", scopeID, err))
 		}

--- a/server/workflowexecution/current_node_controller_admission_test.go
+++ b/server/workflowexecution/current_node_controller_admission_test.go
@@ -3,6 +3,7 @@ package workflowexecution
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"sync"
@@ -341,8 +342,8 @@ func TestCurrentNodeControllerReservesAutomaticCapacityBeforeLaunchingAdmission(
 	})
 
 	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{
-		{CurrentNode: first},
-		{CurrentNode: second},
+		{CurrentNode: first, NodeKind: workflow.NodeKindAgent},
+		{CurrentNode: second, NodeKind: workflow.NodeKindAgent},
 	})
 	select {
 	case entered := <-runner.entered:
@@ -377,6 +378,233 @@ func TestCurrentNodeControllerReservesAutomaticCapacityBeforeLaunchingAdmission(
 	}
 }
 
+func TestCurrentNodeControllerStartsScriptsWhileAgentCapacityIsSaturated(t *testing.T) {
+	shellPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh executable unavailable: %v", err)
+	}
+	agent := currentNodeReferenceForControllerTest(t, "task-agent-running", "node-agent-running")
+	queuedAgent := currentNodeReferenceForControllerTest(t, "task-agent-queued", "node-agent-queued")
+	firstScript := currentNodeReferenceForControllerTest(t, "task-script-first", "node-script-first")
+	secondScript := currentNodeReferenceForControllerTest(t, "task-script-second", "node-script-second")
+	store := &currentNodeControllerStore{}
+	var controller *CurrentNodeController
+	authority := sessionruntime.NewAuthority(sessionruntime.AuthorityOptions{
+		ExecutionFinalized: sessionruntime.ExecutionFinalizedFunc(func(scope sessionruntime.ExecutionScope) {
+			controller.ExecutionFinalized(scope)
+		}),
+	})
+	runner := &recordingScriptRunner{
+		authority: authority,
+		command: sessionruntime.ScriptCommand{
+			Path: shellPath,
+			Args: []string{"-c", "trap 'exit 0' TERM; while :; do sleep 1; done"},
+		},
+		started: make(chan workflow.CurrentNodeReference, 4),
+	}
+	controller = newCurrentNodeControllerForTest(t, store, runner, authority, 1)
+	t.Cleanup(func() {
+		if err := controller.Close(); err != nil {
+			t.Errorf("close controller: %v", err)
+		}
+		if err := authority.Close(context.Background()); err != nil {
+			t.Errorf("close authority: %v", err)
+		}
+	})
+
+	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{{
+		CurrentNode: agent,
+		NodeKind:    workflow.NodeKindAgent,
+	}})
+	select {
+	case started := <-runner.started:
+		if !started.Equal(agent) {
+			t.Fatalf("first automatic start = %v, want %v", started, agent)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("first automatic Agent Node did not start")
+	}
+	waitForRunningCurrentNode(t, authority, agent)
+
+	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{
+		{CurrentNode: queuedAgent, NodeKind: workflow.NodeKindAgent},
+		{CurrentNode: firstScript, NodeKind: workflow.NodeKindScript},
+		{CurrentNode: secondScript, NodeKind: workflow.NodeKindScript},
+	})
+	seenScripts := map[workflow.CurrentNodeReference]bool{}
+	for len(seenScripts) < 2 {
+		select {
+		case started := <-runner.started:
+			switch {
+			case started.Equal(firstScript), started.Equal(secondScript):
+				seenScripts[started] = true
+			case started.Equal(queuedAgent):
+				t.Fatalf("queued automatic Agent Node started before the occupying Agent was released")
+			default:
+				t.Fatalf("unexpected automatic start %v", started)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatalf("Scripts did not start concurrently while Agent capacity was saturated: %v", seenScripts)
+		}
+	}
+	testsetup.RequireUntil(t, time.Now().Add(3*time.Second), 10*time.Millisecond, func() bool {
+		snapshot := controller.Snapshot()
+		return hasLiveCurrentNode(snapshot, firstScript) && hasLiveCurrentNode(snapshot, secondScript)
+	}, "both Script Nodes did not become live before Agent release")
+	if !hasAutomaticCurrentNodeIntent(controller.Snapshot(), queuedAgent) {
+		t.Fatalf("automatic queue = %+v, want queued Agent while scripts are live", controller.Snapshot().AutomaticIntents)
+	}
+
+	agentHandle, ok := authority.ExecutionByScope(singleLiveScope(t, controller, agent))
+	if !ok {
+		t.Fatal("occupying Agent has no exact execution")
+	}
+	if err := agentHandle.Stop(context.Background()); err != nil {
+		t.Fatalf("stop occupying Agent: %v", err)
+	}
+	select {
+	case started := <-runner.started:
+		if !started.Equal(queuedAgent) {
+			t.Fatalf("queued Agent start = %v, want %v", started, queuedAgent)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("queued Agent did not start after occupying Agent released")
+	}
+}
+
+func TestSelectAutomaticIntentIndexUsesAdmissibilityFIFOAndTaskLocality(t *testing.T) {
+	taskA := workflow.TaskID("task-selection-a")
+	taskB := workflow.TaskID("task-selection-b")
+	lastTask := taskB
+	reference := func(taskID workflow.TaskID, nodeID string) workflow.CurrentNodeReference {
+		return workflow.CurrentNodeReference{TaskID: taskID, NodeID: workflow.NodeID(nodeID)}
+	}
+	tests := []struct {
+		name          string
+		intents       []CurrentNodeAutomaticIntent
+		lastTask      *workflow.TaskID
+		agentCapacity bool
+		wantIndex     int
+	}{
+		{
+			name: "FIFO when no same Task matches",
+			intents: []CurrentNodeAutomaticIntent{
+				{CurrentNode: reference(taskA, "agent-first"), NodeKind: workflow.NodeKindAgent},
+				{CurrentNode: reference(taskB, "script-second"), NodeKind: workflow.NodeKindScript},
+			},
+			lastTask:      func() *workflow.TaskID { task := workflow.TaskID("task-other"); return &task }(),
+			agentCapacity: true,
+			wantIndex:     0,
+		},
+		{
+			name: "same Task prefers a later Agent",
+			intents: []CurrentNodeAutomaticIntent{
+				{CurrentNode: reference(taskA, "script-first"), NodeKind: workflow.NodeKindScript},
+				{CurrentNode: reference(taskB, "agent-second"), NodeKind: workflow.NodeKindAgent},
+			},
+			lastTask:      &lastTask,
+			agentCapacity: true,
+			wantIndex:     1,
+		},
+		{
+			name: "same Task prefers a later Script",
+			intents: []CurrentNodeAutomaticIntent{
+				{CurrentNode: reference(taskA, "agent-first"), NodeKind: workflow.NodeKindAgent},
+				{CurrentNode: reference(taskB, "script-second"), NodeKind: workflow.NodeKindScript},
+			},
+			lastTask:      &lastTask,
+			agentCapacity: true,
+			wantIndex:     1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			index, ok := selectAutomaticIntentIndex(test.intents, test.lastTask, test.agentCapacity)
+			if !ok || index != test.wantIndex {
+				t.Fatalf("selectAutomaticIntentIndex = (%d, %t), want (%d, true)", index, ok, test.wantIndex)
+			}
+		})
+	}
+}
+
+func TestCurrentNodeControllerCloseBroadcastsScriptStopsBeforeJoining(t *testing.T) {
+	shellPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh executable unavailable: %v", err)
+	}
+	const scriptCount = 3
+	grace := 250 * time.Millisecond
+	script := `trap '' TERM; while :; do sleep 1; done`
+	store := &currentNodeControllerStore{}
+	var controller *CurrentNodeController
+	authority := sessionruntime.NewAuthority(sessionruntime.AuthorityOptions{
+		ExecutionFinalized: sessionruntime.ExecutionFinalizedFunc(func(scope sessionruntime.ExecutionScope) {
+			controller.ExecutionFinalized(scope)
+		}),
+	})
+	runner := &recordingScriptRunner{
+		authority: authority,
+		command: sessionruntime.ScriptCommand{
+			Path:              shellPath,
+			Args:              []string{"-c", script},
+			CancellationGrace: &grace,
+		},
+		started: make(chan workflow.CurrentNodeReference, scriptCount),
+	}
+	controller = newCurrentNodeControllerForTest(t, store, runner, authority, 1)
+	t.Cleanup(func() {
+		if err := controller.Close(); err != nil {
+			t.Errorf("close controller: %v", err)
+		}
+		if err := authority.Close(context.Background()); err != nil {
+			t.Errorf("close authority: %v", err)
+		}
+	})
+	references := make([]workflow.CurrentNodeReference, 0, scriptCount)
+	intents := make([]CurrentNodeAutomaticIntent, 0, scriptCount)
+	for index := 0; index < scriptCount; index++ {
+		reference := currentNodeReferenceForControllerTest(t, fmt.Sprintf("task-close-script-%d", index), fmt.Sprintf("node-script-%d", index))
+		references = append(references, reference)
+		intents = append(intents, CurrentNodeAutomaticIntent{
+			CurrentNode: reference,
+			NodeKind:    workflow.NodeKindScript,
+		})
+	}
+	controller.enqueueAutomaticIntents(intents)
+	started := make(map[workflow.CurrentNodeReference]struct{}, scriptCount)
+	for len(started) < scriptCount {
+		select {
+		case reference := <-runner.started:
+			started[reference] = struct{}{}
+			if len(started) == scriptCount {
+				break
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatalf("Scripts did not start: %+v", started)
+		}
+	}
+	for _, reference := range references {
+		waitForRunningCurrentNode(t, authority, reference)
+	}
+	testsetup.RequireUntil(t, time.Now().Add(3*time.Second), 10*time.Millisecond, func() bool {
+		snapshot := controller.Snapshot()
+		for _, reference := range references {
+			if !hasLiveCurrentNode(snapshot, reference) {
+				return false
+			}
+		}
+		return true
+	}, "all Script Nodes did not enter controller live state")
+
+	closeStarted := time.Now()
+	if err := controller.Close(); err != nil {
+		t.Fatalf("controller Close: %v", err)
+	}
+	if elapsed := time.Since(closeStarted); elapsed >= 2*grace {
+		t.Fatalf("controller Close took %s for %d Script grace windows, want overlapping shutdown", elapsed, scriptCount)
+	}
+}
+
 func TestCurrentNodeControllerStartTaskPublishesAdmissionOwnershipBeforeDeleteCanObserveQuiescence(t *testing.T) {
 	taskID := workflow.TaskID("task-start-delete-linearization")
 	target := currentNodeReferenceForControllerTest(t, string(taskID), "node-target")
@@ -397,8 +625,8 @@ func TestCurrentNodeControllerStartTaskPublishesAdmissionOwnershipBeforeDeleteCa
 	}
 	permit := NewMutationPermit()
 	controller, err := NewCurrentNodeController(store, runner, authority, permit, CurrentNodeControllerConfig{
-		AutomaticConcurrency: 1,
-		AssignmentSteerer:    noOpCurrentNodeAssignmentSteerer{},
+		AgentConcurrency:  1,
+		AssignmentSteerer: noOpCurrentNodeAssignmentSteerer{},
 	})
 	if err != nil {
 		t.Fatalf("NewCurrentNodeController: %v", err)
@@ -484,7 +712,7 @@ func TestCurrentNodeControllerReservationBlocksTaskQuiescence(t *testing.T) {
 		t.Fatalf("reference key: %v", err)
 	}
 	controller.mu.Lock()
-	controller.automaticReservations[key] = currentNodeQueuedStart{reference: reference, automatic: true}
+	controller.automaticReservations[key] = currentNodeQueuedStart{reference: reference, policy: currentNodeAdmissionAutomaticAgent}
 	controller.mu.Unlock()
 
 	if err := controller.EnsureTaskQuiescent(reference.TaskID); !errors.Is(err, ErrTaskExecutionNotQuiescent) {
@@ -512,7 +740,10 @@ func TestCurrentNodeControllerTaskQuiescenceRejectsEveryControllerOwnedWorkState
 		{
 			name: "automatic queue",
 			apply: func(controller *CurrentNodeController) {
-				controller.automaticQueue = append(controller.automaticQueue, currentNodeQueuedStart{reference: reference, automatic: true})
+				controller.automaticQueue.append(currentNodeQueuedStart{
+					reference: reference,
+					policy:    currentNodeAdmissionAutomaticAgent,
+				})
 			},
 		},
 		{
@@ -522,13 +753,13 @@ func TestCurrentNodeControllerTaskQuiescenceRejectsEveryControllerOwnedWorkState
 				if err != nil {
 					t.Fatalf("reference key: %v", err)
 				}
-				controller.automaticReservations[key] = currentNodeQueuedStart{reference: reference, automatic: true}
+				controller.automaticReservations[key] = currentNodeQueuedStart{reference: reference, policy: currentNodeAdmissionAutomaticAgent}
 			},
 		},
 		{
 			name: "retirement held intent",
 			apply: func(controller *CurrentNodeController) {
-				controller.heldStarts[runtimeids.NewExecutionScopeID()] = []currentNodeQueuedStart{{reference: reference, automatic: true}}
+				controller.heldStarts[runtimeids.NewExecutionScopeID()] = []currentNodeQueuedStart{{reference: reference, policy: currentNodeAdmissionAutomaticAgent}}
 			},
 		},
 		{

--- a/server/workflowexecution/current_node_controller_admission_test.go
+++ b/server/workflowexecution/current_node_controller_admission_test.go
@@ -472,61 +472,6 @@ func TestCurrentNodeControllerStartsScriptsWhileAgentCapacityIsSaturated(t *test
 	}
 }
 
-func TestSelectAutomaticIntentIndexUsesAdmissibilityFIFOAndTaskLocality(t *testing.T) {
-	taskA := workflow.TaskID("task-selection-a")
-	taskB := workflow.TaskID("task-selection-b")
-	lastTask := taskB
-	reference := func(taskID workflow.TaskID, nodeID string) workflow.CurrentNodeReference {
-		return workflow.CurrentNodeReference{TaskID: taskID, NodeID: workflow.NodeID(nodeID)}
-	}
-	tests := []struct {
-		name          string
-		intents       []CurrentNodeAutomaticIntent
-		lastTask      *workflow.TaskID
-		agentCapacity bool
-		wantIndex     int
-	}{
-		{
-			name: "FIFO when no same Task matches",
-			intents: []CurrentNodeAutomaticIntent{
-				{CurrentNode: reference(taskA, "agent-first"), NodeKind: workflow.NodeKindAgent},
-				{CurrentNode: reference(taskB, "script-second"), NodeKind: workflow.NodeKindScript},
-			},
-			lastTask:      func() *workflow.TaskID { task := workflow.TaskID("task-other"); return &task }(),
-			agentCapacity: true,
-			wantIndex:     0,
-		},
-		{
-			name: "same Task prefers a later Agent",
-			intents: []CurrentNodeAutomaticIntent{
-				{CurrentNode: reference(taskA, "script-first"), NodeKind: workflow.NodeKindScript},
-				{CurrentNode: reference(taskB, "agent-second"), NodeKind: workflow.NodeKindAgent},
-			},
-			lastTask:      &lastTask,
-			agentCapacity: true,
-			wantIndex:     1,
-		},
-		{
-			name: "same Task prefers a later Script",
-			intents: []CurrentNodeAutomaticIntent{
-				{CurrentNode: reference(taskA, "agent-first"), NodeKind: workflow.NodeKindAgent},
-				{CurrentNode: reference(taskB, "script-second"), NodeKind: workflow.NodeKindScript},
-			},
-			lastTask:      &lastTask,
-			agentCapacity: true,
-			wantIndex:     1,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			index, ok := selectAutomaticIntentIndex(test.intents, test.lastTask, test.agentCapacity)
-			if !ok || index != test.wantIndex {
-				t.Fatalf("selectAutomaticIntentIndex = (%d, %t), want (%d, true)", index, ok, test.wantIndex)
-			}
-		})
-	}
-}
-
 func TestCurrentNodeControllerCloseBroadcastsScriptStopsBeforeJoining(t *testing.T) {
 	shellPath, err := exec.LookPath("sh")
 	if err != nil {

--- a/server/workflowexecution/current_node_controller_fixture_test.go
+++ b/server/workflowexecution/current_node_controller_fixture_test.go
@@ -42,9 +42,9 @@ func newCurrentNodeControllerWithAttentionForTest(
 ) *CurrentNodeController {
 	t.Helper()
 	controller, err := NewCurrentNodeController(store, runner, authority, NewMutationPermit(), CurrentNodeControllerConfig{
-		AutomaticConcurrency: concurrency,
-		Attention:            attention,
-		AssignmentSteerer:    noOpCurrentNodeAssignmentSteerer{},
+		AgentConcurrency:  concurrency,
+		Attention:         attention,
+		AssignmentSteerer: noOpCurrentNodeAssignmentSteerer{},
 	})
 	if err != nil {
 		t.Fatalf("new current node controller: %v", err)

--- a/server/workflowexecution/current_node_controller_interruption_test.go
+++ b/server/workflowexecution/current_node_controller_interruption_test.go
@@ -173,7 +173,7 @@ func TestCurrentNodeControllerTaskInterruptFencesFinalizingSiblingBeforeReturn(t
 			{Reference: finalizing, Scheduling: &workflow.CurrentNodeScheduling{State: workflow.CurrentNodeSchedulingInterrupted}},
 		},
 		completion: workflowstore.CurrentNodeCompletionResult{
-			AutomaticIntents: []workflow.CurrentNodeReference{successor},
+			AutomaticIntents: []workflowstore.CurrentNodeAutomaticIntent{{CurrentNode: successor, NodeKind: workflow.NodeKindAgent}},
 		},
 		interruptStarted: make(chan struct{}),
 		interruptRelease: make(chan struct{}),
@@ -498,7 +498,7 @@ func TestCurrentNodeControllerTaskInterruptDrainsReservationOnlyAlongsideLiveSco
 		t.Fatalf("reserved key: %v", err)
 	}
 	controller.mu.Lock()
-	controller.automaticReservations[reservedKey] = currentNodeQueuedStart{reference: reserved, automatic: true}
+	controller.automaticReservations[reservedKey] = currentNodeQueuedStart{reference: reserved, policy: currentNodeAdmissionAutomaticAgent}
 	controller.mu.Unlock()
 
 	if err := controller.Interrupt(context.Background(), InterruptSelector{TaskID: live.TaskID}); err != nil {
@@ -512,6 +512,95 @@ func TestCurrentNodeControllerTaskInterruptDrainsReservationOnlyAlongsideLiveSco
 	}
 	if hasAutomaticCurrentNodeIntent(controller.Snapshot(), reserved) {
 		t.Fatalf("drained reservation remains in snapshot: %+v", controller.Snapshot())
+	}
+}
+
+func TestCurrentNodeControllerInterruptingScriptDoesNotReleaseAgentCapacity(t *testing.T) {
+	shellPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh executable unavailable: %v", err)
+	}
+	occupyingAgent := currentNodeReferenceForControllerTest(t, "task-interrupted-script-agent", "node-occupying-agent")
+	script := currentNodeReferenceForControllerTest(t, "task-interrupted-script", "node-script")
+	queuedAgent := currentNodeReferenceForControllerTest(t, "task-interrupted-script-queued-agent", "node-queued-agent")
+	store := &currentNodeControllerStore{}
+	var controller *CurrentNodeController
+	authority := sessionruntime.NewAuthority(sessionruntime.AuthorityOptions{
+		ExecutionFinalized: sessionruntime.ExecutionFinalizedFunc(func(scope sessionruntime.ExecutionScope) {
+			controller.ExecutionFinalized(scope)
+		}),
+	})
+	runner := &recordingScriptRunner{
+		authority: authority,
+		command: sessionruntime.ScriptCommand{
+			Path: shellPath,
+			Args: []string{"-c", "trap 'exit 0' TERM; while :; do sleep 1; done"},
+		},
+		started: make(chan workflow.CurrentNodeReference, 3),
+	}
+	controller = newCurrentNodeControllerForTest(t, store, runner, authority, 1)
+	t.Cleanup(func() {
+		if err := controller.Close(); err != nil {
+			t.Errorf("close controller: %v", err)
+		}
+		if err := authority.Close(context.Background()); err != nil {
+			t.Errorf("close authority: %v", err)
+		}
+	})
+
+	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{{
+		CurrentNode: occupyingAgent,
+		NodeKind:    workflow.NodeKindAgent,
+	}})
+	select {
+	case started := <-runner.started:
+		if !started.Equal(occupyingAgent) {
+			t.Fatalf("occupying Agent start = %v, want %v", started, occupyingAgent)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("occupying Agent did not start")
+	}
+	waitForRunningCurrentNode(t, authority, occupyingAgent)
+	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{
+		{CurrentNode: script, NodeKind: workflow.NodeKindScript},
+		{CurrentNode: queuedAgent, NodeKind: workflow.NodeKindAgent},
+	})
+	select {
+	case started := <-runner.started:
+		if !started.Equal(script) {
+			t.Fatalf("Script start = %v, want %v", started, script)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Script did not start while Agent capacity was occupied")
+	}
+	waitForRunningCurrentNode(t, authority, script)
+	if !hasAutomaticCurrentNodeIntent(controller.Snapshot(), queuedAgent) {
+		t.Fatalf("queued Agent = %+v, want queued while occupying Agent is live", controller.Snapshot().AutomaticIntents)
+	}
+
+	if err := controller.Interrupt(context.Background(), InterruptSelector{TaskID: script.TaskID}); err != nil {
+		t.Fatalf("interrupt Script: %v", err)
+	}
+	if hasLiveCurrentNode(controller.Snapshot(), script) {
+		t.Fatalf("interrupted Script remains live: %+v", controller.Snapshot().LiveScopes)
+	}
+	if !hasAutomaticCurrentNodeIntent(controller.Snapshot(), queuedAgent) {
+		t.Fatalf("queued Agent = %+v, want queued after Script interruption", controller.Snapshot().AutomaticIntents)
+	}
+	occupyingHandle, live := authority.ExecutionByScope(singleLiveScope(t, controller, occupyingAgent))
+	if !live {
+		t.Fatal("occupying Agent is not live")
+	}
+	if err := occupyingHandle.Stop(context.Background()); err != nil {
+		t.Fatalf("stop occupying Agent: %v", err)
+	}
+	select {
+	case started := <-runner.started:
+		if !started.Equal(queuedAgent) {
+			t.Fatalf("queued Agent start = %v, want %v", started, queuedAgent)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("queued Agent did not start after occupying Agent stopped")
 	}
 }
 
@@ -633,7 +722,7 @@ func TestCurrentNodeControllerReservationDoesNotAuthorizeTaskInterrupt(t *testin
 		t.Fatalf("reference key: %v", err)
 	}
 	controller.mu.Lock()
-	controller.automaticReservations[key] = currentNodeQueuedStart{reference: reference, automatic: true}
+	controller.automaticReservations[key] = currentNodeQueuedStart{reference: reference, policy: currentNodeAdmissionAutomaticAgent}
 	controller.mu.Unlock()
 
 	if err := controller.Interrupt(context.Background(), InterruptSelector{TaskID: reference.TaskID}); !errors.Is(err, ErrNoInterruptibleExecution) {

--- a/server/workflowexecution/current_node_controller_interruption_test.go
+++ b/server/workflowexecution/current_node_controller_interruption_test.go
@@ -498,7 +498,14 @@ func TestCurrentNodeControllerTaskInterruptDrainsReservationOnlyAlongsideLiveSco
 		t.Fatalf("reserved key: %v", err)
 	}
 	controller.mu.Lock()
-	controller.automaticReservations[reservedKey] = currentNodeQueuedStart{reference: reserved, policy: currentNodeAdmissionAutomaticAgent}
+	controller.agentCapacityActive = 1
+	controller.automaticReservations[reservedKey] = currentNodeQueuedStart{
+		reference: reserved,
+		policy:    currentNodeAdmissionAutomaticAgent,
+		agentCapacityLease: &currentNodeAgentCapacityLease{
+			owner: currentNodeAgentCapacityReservation,
+		},
+	}
 	controller.mu.Unlock()
 
 	if err := controller.Interrupt(context.Background(), InterruptSelector{TaskID: live.TaskID}); err != nil {
@@ -513,6 +520,12 @@ func TestCurrentNodeControllerTaskInterruptDrainsReservationOnlyAlongsideLiveSco
 	if hasAutomaticCurrentNodeIntent(controller.Snapshot(), reserved) {
 		t.Fatalf("drained reservation remains in snapshot: %+v", controller.Snapshot())
 	}
+	controller.mu.Lock()
+	if controller.agentCapacityActive != 0 {
+		controller.mu.Unlock()
+		t.Fatalf("Agent capacity after draining reservation = %d, want 0", controller.agentCapacityActive)
+	}
+	controller.mu.Unlock()
 }
 
 func TestCurrentNodeControllerInterruptingScriptDoesNotReleaseAgentCapacity(t *testing.T) {

--- a/server/workflowexecution/current_node_controller_lifecycle_test.go
+++ b/server/workflowexecution/current_node_controller_lifecycle_test.go
@@ -161,8 +161,8 @@ func TestCurrentNodeControllerSteersApprovalTargetBeforeStartingIt(t *testing.T)
 	runner := &countingCurrentNodeRunner{}
 	steerer := &recordingCurrentNodeAssignmentSteerer{}
 	controller, err := NewCurrentNodeController(store, runner, authority, NewMutationPermit(), CurrentNodeControllerConfig{
-		AutomaticConcurrency: 1,
-		AssignmentSteerer:    steerer,
+		AgentConcurrency:  1,
+		AssignmentSteerer: steerer,
 	})
 	if err != nil {
 		t.Fatalf("new current node controller: %v", err)
@@ -207,8 +207,8 @@ func TestCurrentNodeControllerDoesNotMakeUnassignedApprovalTargetResumable(t *te
 	runner := &countingCurrentNodeRunner{}
 	cause := errors.New("assignment append failed")
 	controller, err := NewCurrentNodeController(store, runner, authority, NewMutationPermit(), CurrentNodeControllerConfig{
-		AutomaticConcurrency: 1,
-		AssignmentSteerer:    &recordingCurrentNodeAssignmentSteerer{err: cause},
+		AgentConcurrency:  1,
+		AssignmentSteerer: &recordingCurrentNodeAssignmentSteerer{err: cause},
 	})
 	if err != nil {
 		t.Fatalf("new current node controller: %v", err)
@@ -263,9 +263,9 @@ func TestCompleteIdleCurrentNodeRecoversSuccessorByAssignmentCommit(t *testing.T
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			source := currentNodeReferenceForControllerTest(t, "task-idle-completion-steer-failure", "node-source")
-			targets := []workflow.CurrentNodeReference{
-				currentNodeReferenceForControllerTest(t, "task-idle-completion-steer-failure", "node-target-a"),
-				currentNodeReferenceForControllerTest(t, "task-idle-completion-steer-failure", "node-target-b"),
+			targets := []workflowstore.CurrentNodeAutomaticIntent{
+				{CurrentNode: currentNodeReferenceForControllerTest(t, "task-idle-completion-steer-failure", "node-target-a"), NodeKind: workflow.NodeKindAgent},
+				{CurrentNode: currentNodeReferenceForControllerTest(t, "task-idle-completion-steer-failure", "node-target-b"), NodeKind: workflow.NodeKindAgent},
 			}
 			targets = targets[:len(tc.wantInterrupted)]
 			sourceNode := workflow.CurrentNode{
@@ -281,7 +281,7 @@ func TestCompleteIdleCurrentNodeRecoversSuccessorByAssignmentCommit(t *testing.T
 			authority := sessionruntime.NewAuthority(sessionruntime.AuthorityOptions{})
 			runner := &countingCurrentNodeRunner{}
 			controller, err := NewCurrentNodeController(store, runner, authority, NewMutationPermit(), CurrentNodeControllerConfig{
-				AutomaticConcurrency: 1,
+				AgentConcurrency: 1,
 				AssignmentSteerer: &recordingCurrentNodeAssignmentSteerer{
 					outcomes: tc.outcomes,
 				},
@@ -307,7 +307,8 @@ func TestCompleteIdleCurrentNodeRecoversSuccessorByAssignmentCommit(t *testing.T
 			if starts := runner.starts(); starts != 0 {
 				t.Fatalf("runner starts = %d, want none after assignment failure", starts)
 			}
-			for index, target := range targets {
+			for index, intent := range targets {
+				target := intent.CurrentNode
 				interruption, interrupted := store.interruption(target)
 				if interrupted != tc.wantInterrupted[index] {
 					t.Fatalf(
@@ -342,7 +343,7 @@ func TestCompleteIdleCurrentNodeRetainsLateAssignmentAfterCallerCancellation(t *
 	store := &currentNodeControllerStore{
 		idleResolved: &sourceNode,
 		completion: workflowstore.CurrentNodeCompletionResult{
-			AutomaticIntents: []workflow.CurrentNodeReference{target},
+			AutomaticIntents: []workflowstore.CurrentNodeAutomaticIntent{{CurrentNode: target, NodeKind: workflow.NodeKindAgent}},
 		},
 	}
 	release := make(chan struct{})
@@ -357,7 +358,7 @@ func TestCompleteIdleCurrentNodeRetainsLateAssignmentAfterCallerCancellation(t *
 		started: make(chan workflow.CurrentNodeReference, 1),
 	}
 	controller, err := NewCurrentNodeController(store, runner, authority, NewMutationPermit(), CurrentNodeControllerConfig{
-		AutomaticConcurrency: 1,
+		AgentConcurrency: 1,
 		AssignmentSteerer: lateCommitCurrentNodeAssignmentSteerer{
 			release: release,
 			started: waitStarted,
@@ -426,6 +427,7 @@ func TestCurrentNodeControllerHoldsApprovalTargetUntilCompletedSourceScopeRetire
 	}
 	source := currentNodeReferenceForControllerTest(t, "task-approval-retirement", "node-source")
 	target := currentNodeReferenceForControllerTest(t, "task-approval-retirement", "node-target")
+	queuedAgent := currentNodeReferenceForControllerTest(t, "task-approval-retirement", "node-queued-agent")
 	approval := workflow.PendingApproval{ID: workflow.NewApprovalID(), Source: source}
 	targetNode := workflow.CurrentNode{
 		Reference:  target,
@@ -463,11 +465,20 @@ func TestCurrentNodeControllerHoldsApprovalTargetUntilCompletedSourceScopeRetire
 		}
 	})
 
-	if err := startCurrentNodeForControllerTest(context.Background(), controller, store, source); err != nil {
-		t.Fatalf("start approval source: %v", err)
-	}
+	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{{
+		CurrentNode: source,
+		NodeKind:    workflow.NodeKindAgent,
+	}})
 	<-runner.started
 	waitForRunningCurrentNode(t, authority, source)
+	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{{
+		CurrentNode: queuedAgent,
+		NodeKind:    workflow.NodeKindAgent,
+	}})
+	testsetup.RequireUntil(t, time.Now().Add(3*time.Second), 10*time.Millisecond, func() bool {
+		snapshot := controller.Snapshot()
+		return hasLiveCurrentNode(snapshot, source) && hasAutomaticCurrentNodeIntent(snapshot, queuedAgent)
+	}, "approval source did not hold Agent capacity while queued Agent remained queued")
 	sourceScope := singleLiveScope(t, controller, source)
 	if _, err := controller.CompleteCurrentNode(context.Background(), workflowruntime.CompletionRequest{
 		ScopeID:      sourceScope,
@@ -484,6 +495,9 @@ func TestCurrentNodeControllerHoldsApprovalTargetUntilCompletedSourceScopeRetire
 		snapshot.HeldIntents[0].Automatic {
 		t.Fatalf("held approval starts = %+v, want explicit target held by source scope", snapshot.HeldIntents)
 	}
+	if !hasAutomaticCurrentNodeIntent(snapshot, queuedAgent) {
+		t.Fatalf("automatic agent queue = %+v, want queued agent while source occupies capacity", snapshot.AutomaticIntents)
+	}
 	select {
 	case started := <-runner.started:
 		t.Fatalf("approval target %v started before source retirement", started)
@@ -496,13 +510,32 @@ func TestCurrentNodeControllerHoldsApprovalTargetUntilCompletedSourceScopeRetire
 	if err := sourceHandle.Stop(context.Background()); err != nil {
 		t.Fatalf("stop approval source: %v", err)
 	}
-	select {
-	case started := <-runner.started:
-		if !started.Equal(target) {
-			t.Fatalf("started approval target = %v, want %v", started, target)
+	targetStarted := false
+	for !targetStarted {
+		select {
+		case started := <-runner.started:
+			switch {
+			case started.Equal(target):
+				targetStarted = true
+			case started.Equal(queuedAgent):
+				continue
+			default:
+				t.Fatalf("started approval successor = %v, want target or queued Agent", started)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("approval target did not start after source retirement")
 		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("approval target did not start after source retirement")
+	}
+	testsetup.RequireUntil(t, time.Now().Add(3*time.Second), 10*time.Millisecond, func() bool {
+		for _, live := range controller.Snapshot().LiveScopes {
+			if live.CurrentNode.Equal(target) {
+				return !live.Automatic
+			}
+		}
+		return false
+	}, "approval target did not enter an explicit live scope")
+	if !hasLiveCurrentNode(controller.Snapshot(), queuedAgent) {
+		t.Fatalf("queued Agent did not enter a live automatic scope: %+v", controller.Snapshot().LiveScopes)
 	}
 }
 
@@ -515,7 +548,7 @@ func TestCurrentNodeControllerHoldsSuccessorUntilSourceScopeRetires(t *testing.T
 	successor := currentNodeReferenceForControllerTest(t, "task-successor", "node-successor")
 	store := &currentNodeControllerStore{
 		completion: workflowstore.CurrentNodeCompletionResult{
-			AutomaticIntents: []workflow.CurrentNodeReference{successor},
+			AutomaticIntents: []workflowstore.CurrentNodeAutomaticIntent{{CurrentNode: successor, NodeKind: workflow.NodeKindAgent}},
 		},
 	}
 	var controller *CurrentNodeController
@@ -534,7 +567,7 @@ func TestCurrentNodeControllerHoldsSuccessorUntilSourceScopeRetires(t *testing.T
 	}
 	assignmentDeadline := make(chan time.Time, 1)
 	controller, err = NewCurrentNodeController(store, runner, authority, NewMutationPermit(), CurrentNodeControllerConfig{
-		AutomaticConcurrency: 1,
+		AgentConcurrency: 1,
 		AssignmentSteerer: deadlineRecordingCurrentNodeAssignmentSteerer{
 			reference: successor,
 			deadline:  assignmentDeadline,
@@ -558,6 +591,9 @@ func TestCurrentNodeControllerHoldsSuccessorUntilSourceScopeRetires(t *testing.T
 	if got := <-runner.started; !got.Equal(source) {
 		t.Fatalf("first started current node = %v, want source %v", got, source)
 	}
+	testsetup.RequireUntil(t, time.Now().Add(3*time.Second), 10*time.Millisecond, func() bool {
+		return hasLiveCurrentNode(controller.Snapshot(), source)
+	}, "source did not become live")
 	sourceScope := singleLiveScope(t, controller, source)
 	if _, err := controller.CompleteCurrentNode(context.Background(), workflowruntime.CompletionRequest{
 		ScopeID:      sourceScope,
@@ -601,84 +637,6 @@ func TestCurrentNodeControllerHoldsSuccessorUntilSourceScopeRetires(t *testing.T
 	}
 }
 
-func TestExecutionFinalizationDoesNotMakeUnassignedHeldSuccessorResumable(t *testing.T) {
-	shellPath, err := exec.LookPath("sh")
-	if err != nil {
-		t.Skipf("sh executable unavailable: %v", err)
-	}
-	source := currentNodeReferenceForControllerTest(t, "task-successor-steer-failure", "node-source")
-	successor := currentNodeReferenceForControllerTest(t, "task-successor-steer-failure", "node-successor")
-	store := &currentNodeControllerStore{
-		completion: workflowstore.CurrentNodeCompletionResult{
-			AutomaticIntents: []workflow.CurrentNodeReference{successor},
-		},
-	}
-	steerer := &recordingCurrentNodeAssignmentSteerer{}
-	var controller *CurrentNodeController
-	authority := sessionruntime.NewAuthority(sessionruntime.AuthorityOptions{
-		ExecutionFinalized: sessionruntime.ExecutionFinalizedFunc(func(scope sessionruntime.ExecutionScope) {
-			controller.ExecutionFinalized(scope)
-		}),
-	})
-	runner := &recordingScriptRunner{
-		authority: authority,
-		command: sessionruntime.ScriptCommand{
-			Path: shellPath,
-			Args: []string{"-c", "while :; do sleep 1; done"},
-		},
-		started: make(chan workflow.CurrentNodeReference, 2),
-	}
-	controller, err = NewCurrentNodeController(store, runner, authority, NewMutationPermit(), CurrentNodeControllerConfig{
-		AutomaticConcurrency: 1,
-		AssignmentSteerer:    steerer,
-	})
-	if err != nil {
-		t.Fatalf("new current node controller: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := controller.Close(); err != nil {
-			t.Errorf("close controller: %v", err)
-		}
-		if err := authority.Close(context.Background()); err != nil {
-			t.Errorf("close authority: %v", err)
-		}
-	})
-
-	if err := startCurrentNodeForControllerTest(context.Background(), controller, store, source); err != nil {
-		t.Fatalf("start source: %v", err)
-	}
-	<-runner.started
-	waitForRunningCurrentNode(t, authority, source)
-	sourceScope := singleLiveScope(t, controller, source)
-	cause := errors.New("assignment persistence failed")
-	steerer.setWaitError(cause)
-	if _, err := controller.CompleteCurrentNode(context.Background(), workflowruntime.CompletionRequest{
-		ScopeID:      sourceScope,
-		TransitionID: "next",
-	}); err != nil {
-		t.Fatalf("complete source: %v", err)
-	}
-	sourceHandle, live := authority.ExecutionByScope(sourceScope)
-	if !live {
-		t.Fatal("completed source scope retired before stop")
-	}
-	if err := sourceHandle.Stop(context.Background()); err != nil {
-		t.Fatalf("stop source: %v", err)
-	}
-
-	if interruption, interrupted := store.interruption(successor); interrupted {
-		t.Fatalf("unassigned held successor was made resumable: %+v", interruption)
-	}
-	if err := controller.EnsureTaskQuiescent(source.TaskID); err != nil {
-		t.Fatalf("uncommitted assignment failure latched controller failure: %v", err)
-	}
-	select {
-	case started := <-runner.started:
-		t.Fatalf("successor %v started after assignment failure", started)
-	case <-time.After(50 * time.Millisecond):
-	}
-}
-
 func TestCurrentNodeControllerCompletionAndTaskInterruptDoNotDeadlockOrReleaseSuccessor(t *testing.T) {
 	shellPath, err := exec.LookPath("sh")
 	if err != nil {
@@ -688,7 +646,7 @@ func TestCurrentNodeControllerCompletionAndTaskInterruptDoNotDeadlockOrReleaseSu
 	successor := currentNodeReferenceForControllerTest(t, "task-complete-interrupt", "node-successor")
 	store := &currentNodeControllerStore{
 		completion: workflowstore.CurrentNodeCompletionResult{
-			AutomaticIntents: []workflow.CurrentNodeReference{successor},
+			AutomaticIntents: []workflowstore.CurrentNodeAutomaticIntent{{CurrentNode: successor, NodeKind: workflow.NodeKindAgent}},
 		},
 		completionStarted: make(chan struct{}),
 		completionRelease: make(chan struct{}),
@@ -778,7 +736,7 @@ func TestCurrentNodeControllerCompletesSuccessfulScriptBeforeScopeRetirement(t *
 	successor := currentNodeReferenceForControllerTest(t, "task-script-complete", "node-successor")
 	store := &currentNodeControllerStore{
 		completion: workflowstore.CurrentNodeCompletionResult{
-			AutomaticIntents: []workflow.CurrentNodeReference{successor},
+			AutomaticIntents: []workflowstore.CurrentNodeAutomaticIntent{{CurrentNode: successor, NodeKind: workflow.NodeKindAgent}},
 		},
 	}
 	var controller *CurrentNodeController

--- a/server/workflowexecution/current_node_controller_lifecycle_test.go
+++ b/server/workflowexecution/current_node_controller_lifecycle_test.go
@@ -534,9 +534,9 @@ func TestCurrentNodeControllerHoldsApprovalTargetUntilCompletedSourceScopeRetire
 		}
 		return false
 	}, "approval target did not enter an explicit live scope")
-	if !hasLiveCurrentNode(controller.Snapshot(), queuedAgent) {
-		t.Fatalf("queued Agent did not enter a live automatic scope: %+v", controller.Snapshot().LiveScopes)
-	}
+	testsetup.RequireUntil(t, time.Now().Add(3*time.Second), 10*time.Millisecond, func() bool {
+		return hasLiveCurrentNode(controller.Snapshot(), queuedAgent)
+	}, "queued Agent did not enter a live automatic scope")
 }
 
 func TestCurrentNodeControllerHoldsSuccessorUntilSourceScopeRetires(t *testing.T) {

--- a/server/workflowexecution/current_node_controller_script_policy_test.go
+++ b/server/workflowexecution/current_node_controller_script_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"sync"
 	"testing"
 	"time"
 
@@ -297,6 +298,109 @@ func (r *selectiveScriptFailureRunner) StartCurrentNode(_ context.Context, refer
 		r.started <- reference
 	}
 	return err
+}
+
+type finalizingBeforeLiveRunner struct {
+	authority *sessionruntime.Authority
+	fast      workflow.CurrentNodeReference
+	shellPath string
+	finalized <-chan struct{}
+	started   chan workflow.CurrentNodeReference
+}
+
+func (r *finalizingBeforeLiveRunner) StartCurrentNode(
+	ctx context.Context,
+	reference workflow.CurrentNodeReference,
+	_ workflowruntime.TaskPromptDelivery,
+	_ CurrentNodeAssignmentSteer,
+	lease sessionruntime.WorkflowExecutionLease,
+	_ workflowruntime.Controller,
+) error {
+	command := sessionruntime.ScriptCommand{
+		Path: r.shellPath,
+		Args: []string{"-c", "while :; do sleep 1; done"},
+	}
+	if reference.Equal(r.fast) {
+		command.Args = []string{"-c", "exit 0"}
+		if _, err := r.authority.StartScriptExecution(context.Background(), sessionruntime.ScriptExecutionRequest{
+			Workflow: &lease,
+			Command:  command,
+		}); err != nil {
+			return err
+		}
+		lease.Release()
+		select {
+		case <-r.finalized:
+			return nil
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		}
+	}
+	_, err := r.authority.StartScriptExecution(context.Background(), sessionruntime.ScriptExecutionRequest{
+		Workflow: &lease,
+		Command:  command,
+	})
+	if err == nil {
+		r.started <- reference
+	}
+	return err
+}
+
+func TestCurrentNodeControllerFinalizedGateReleasesAgentCapacity(t *testing.T) {
+	shellPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh executable unavailable: %v", err)
+	}
+	fast := currentNodeReferenceForControllerTest(t, "task-finalized-gate", "node-fast")
+	next := currentNodeReferenceForControllerTest(t, "task-after-finalized-gate", "node-next")
+	store := &currentNodeControllerStore{}
+	var controller *CurrentNodeController
+	finalized := make(chan struct{})
+	var finalizedOnce sync.Once
+	authority := sessionruntime.NewAuthority(sessionruntime.AuthorityOptions{
+		ExecutionFinalized: sessionruntime.ExecutionFinalizedFunc(func(scope sessionruntime.ExecutionScope) {
+			controller.ExecutionFinalized(scope)
+			finalizedOnce.Do(func() { close(finalized) })
+		}),
+	})
+	runner := &finalizingBeforeLiveRunner{
+		authority: authority,
+		fast:      fast,
+		shellPath: shellPath,
+		finalized: finalized,
+		started:   make(chan workflow.CurrentNodeReference, 1),
+	}
+	controller = newCurrentNodeControllerForTest(t, store, runner, authority, 1)
+	t.Cleanup(func() {
+		if err := controller.Close(); err != nil {
+			t.Errorf("close controller: %v", err)
+		}
+		if err := authority.Close(context.Background()); err != nil {
+			t.Errorf("close authority: %v", err)
+		}
+	})
+
+	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{{
+		CurrentNode: fast,
+		NodeKind:    workflow.NodeKindAgent,
+	}})
+	testsetup.RequireUntil(t, time.Now().Add(3*time.Second), 10*time.Millisecond, func() bool {
+		_, interrupted := store.interruption(fast)
+		return interrupted
+	}, "fast-finalized gated Agent was not cleaned up")
+
+	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{{
+		CurrentNode: next,
+		NodeKind:    workflow.NodeKindAgent,
+	}})
+	select {
+	case started := <-runner.started:
+		if !started.Equal(next) {
+			t.Fatalf("queued Agent start = %v, want %v", started, next)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("queued Agent did not start after gated finalization released capacity")
+	}
 }
 
 func TestExecutionFinalizationDoesNotMakeUnassignedHeldSuccessorResumable(t *testing.T) {

--- a/server/workflowexecution/current_node_controller_script_policy_test.go
+++ b/server/workflowexecution/current_node_controller_script_policy_test.go
@@ -3,7 +3,6 @@ package workflowexecution
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os/exec"
 	"testing"
 	"time"
@@ -128,19 +127,16 @@ func TestCurrentNodeControllerScriptPolicyMatrixDoesNotUseAgentCapacity(t *testi
 			})
 			controller.queued[queuedKey] = struct{}{}
 			test.apply(controller, scriptKey)
-			if got := controller.agentActiveLocked(); got != 1 {
+			if got := controller.agentCapacityActive; got != 1 {
 				controller.mu.Unlock()
 				t.Fatalf("Agent capacity with %s Script = %d, want 1", test.name, got)
 			}
-			if _, ok := selectAutomaticIntentIndex([]CurrentNodeAutomaticIntent{{
-				CurrentNode: queuedAgent,
-				NodeKind:    workflow.NodeKindAgent,
-			}}, nil, false); ok {
+			if _, ok := controller.automaticQueue.selectEntry(nil, false); ok {
 				controller.mu.Unlock()
 				t.Fatalf("queued Agent became admissible while %s Script owned controller state", test.name)
 			}
 			test.clean(controller, scriptKey)
-			if got := controller.agentActiveLocked(); got != 1 {
+			if got := controller.agentCapacityActive; got != 1 {
 				controller.mu.Unlock()
 				t.Fatalf("Agent capacity after %s Script cleanup = %d, want 1", test.name, got)
 			}
@@ -224,6 +220,64 @@ func TestCurrentNodeControllerFailedScriptDoesNotReleaseAgentCapacity(t *testing
 	}
 }
 
+func TestCurrentNodeControllerFailedReservationReleasesAgentCapacity(t *testing.T) {
+	shellPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh executable unavailable: %v", err)
+	}
+	failed := currentNodeReferenceForControllerTest(t, "task-failed-reservation", "node-failed")
+	next := currentNodeReferenceForControllerTest(t, "task-next-after-failed-reservation", "node-next")
+	store := &currentNodeControllerStore{}
+	var controller *CurrentNodeController
+	authority := sessionruntime.NewAuthority(sessionruntime.AuthorityOptions{
+		ExecutionFinalized: sessionruntime.ExecutionFinalizedFunc(func(scope sessionruntime.ExecutionScope) {
+			controller.ExecutionFinalized(scope)
+		}),
+	})
+	runner := &recordingScriptRunner{
+		authority: authority,
+		command: sessionruntime.ScriptCommand{
+			Path: shellPath,
+			Args: []string{"-c", "while :; do sleep 1; done"},
+		},
+		started: make(chan workflow.CurrentNodeReference, 1),
+	}
+	controller = newCurrentNodeControllerForTest(t, store, runner, authority, 1)
+	t.Cleanup(func() {
+		if err := controller.Close(); err != nil {
+			t.Errorf("close controller: %v", err)
+		}
+		if err := authority.Close(context.Background()); err != nil {
+			t.Errorf("close authority: %v", err)
+		}
+	})
+
+	controller.enqueueStarts([]currentNodeQueuedStart{{
+		reference: failed,
+		policy:    currentNodeAdmissionAutomaticAgent,
+		assignmentSteer: completedCurrentNodeAssignmentSteer{
+			err: errors.New("assignment preparation failed"),
+		},
+	}})
+	testsetup.RequireUntil(t, time.Now().Add(3*time.Second), 10*time.Millisecond, func() bool {
+		_, interrupted := store.interruption(failed)
+		return interrupted
+	}, "failed reservation was not interrupted")
+
+	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{{
+		CurrentNode: next,
+		NodeKind:    workflow.NodeKindAgent,
+	}})
+	select {
+	case started := <-runner.started:
+		if !started.Equal(next) {
+			t.Fatalf("next Agent start = %v, want %v", started, next)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("next Agent did not start after failed reservation released capacity")
+	}
+}
+
 type selectiveScriptFailureRunner struct {
 	authority *sessionruntime.Authority
 	command   sessionruntime.ScriptCommand
@@ -243,71 +297,6 @@ func (r *selectiveScriptFailureRunner) StartCurrentNode(_ context.Context, refer
 		r.started <- reference
 	}
 	return err
-}
-
-func TestCurrentNodeControllerLargeMixedKindQueueSelection(t *testing.T) {
-	queue := currentNodeAutomaticQueue{}
-	for index := 0; index < 4096; index++ {
-		policy := currentNodeAdmissionAutomaticScript
-		if index%2 == 0 {
-			policy = currentNodeAdmissionAutomaticAgent
-		}
-		queue.append(currentNodeQueuedStart{
-			reference: workflow.CurrentNodeReference{
-				TaskID: workflow.TaskID("task-large-mixed-kind-queue"),
-				NodeID: workflow.NodeID(fmt.Sprintf("node-%d", index)),
-			},
-			policy: policy,
-		})
-	}
-	agentAvailable := false
-	for queue.len() != 0 {
-		entry, ok := queue.selectEntry(nil, agentAvailable)
-		if !ok && !agentAvailable {
-			agentAvailable = true
-			continue
-		}
-		if !ok || entry.start.policy != currentNodeAdmissionAutomaticScript {
-			if !agentAvailable {
-				t.Fatalf("selected queue entry = %+v, want an admissible Script", entry)
-			}
-		}
-		queue.remove(entry)
-	}
-}
-
-func TestCurrentNodeAutomaticQueueSelectionPreservesTaskLocalityAndFIFO(t *testing.T) {
-	queue := currentNodeAutomaticQueue{}
-	taskOne := workflow.TaskID("task-automatic-queue-one")
-	taskTwo := workflow.TaskID("task-automatic-queue-two")
-	entries := []currentNodeQueuedStart{
-		{reference: workflow.CurrentNodeReference{TaskID: taskOne, NodeID: "agent-one"}, policy: currentNodeAdmissionAutomaticAgent},
-		{reference: workflow.CurrentNodeReference{TaskID: taskTwo, NodeID: "script-two"}, policy: currentNodeAdmissionAutomaticScript},
-		{reference: workflow.CurrentNodeReference{TaskID: taskOne, NodeID: "script-one"}, policy: currentNodeAdmissionAutomaticScript},
-		{reference: workflow.CurrentNodeReference{TaskID: taskTwo, NodeID: "agent-two"}, policy: currentNodeAdmissionAutomaticAgent},
-	}
-	for _, entry := range entries {
-		queue.append(entry)
-	}
-
-	lastTask := taskOne
-	entry, ok := queue.selectEntry(&lastTask, true)
-	if !ok || !entry.start.reference.Equal(entries[0].reference) {
-		t.Fatalf("same-Task Agent selection = %+v, want first Agent", entry)
-	}
-	queue.remove(entry)
-
-	lastTask = taskTwo
-	entry, ok = queue.selectEntry(&lastTask, true)
-	if !ok || !entry.start.reference.Equal(entries[1].reference) {
-		t.Fatalf("same-Task FIFO selection = %+v, want first Script", entry)
-	}
-	queue.remove(entry)
-
-	entry, ok = queue.selectEntry(nil, false)
-	if !ok || !entry.start.reference.Equal(entries[2].reference) {
-		t.Fatalf("Script selection at saturated Agent capacity = %+v, want Script", entry)
-	}
 }
 
 func TestExecutionFinalizationDoesNotMakeUnassignedHeldSuccessorResumable(t *testing.T) {

--- a/server/workflowexecution/current_node_controller_script_policy_test.go
+++ b/server/workflowexecution/current_node_controller_script_policy_test.go
@@ -1,0 +1,411 @@
+package workflowexecution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"core/internal/testharness/testsetup"
+	"core/server/sessionruntime"
+	"core/server/workflow"
+	"core/server/workflowruntime"
+	"core/server/workflowstore"
+	"core/shared/runtimeids"
+)
+
+func TestCurrentNodeControllerScriptPolicyMatrixDoesNotUseAgentCapacity(t *testing.T) {
+	occupyingAgent := currentNodeReferenceForControllerTest(t, "task-policy-agent", "node-occupying-agent")
+	queuedAgent := currentNodeReferenceForControllerTest(t, "task-policy-queued", "node-queued-agent")
+	script := currentNodeReferenceForControllerTest(t, "task-policy-script", "node-script")
+	tests := []struct {
+		name  string
+		apply func(*CurrentNodeController, workflow.CurrentNodeReferenceKey)
+		clean func(*CurrentNodeController, workflow.CurrentNodeReferenceKey)
+	}{
+		{
+			name: "predecessor held",
+			apply: func(controller *CurrentNodeController, _ workflow.CurrentNodeReferenceKey) {
+				controller.heldStarts[runtimeids.NewExecutionScopeID()] = []currentNodeQueuedStart{{
+					reference: script,
+					policy:    currentNodeAdmissionAutomaticScript,
+				}}
+			},
+			clean: func(controller *CurrentNodeController, _ workflow.CurrentNodeReferenceKey) {
+				controller.heldStarts = make(map[runtimeids.ExecutionScopeID][]currentNodeQueuedStart)
+			},
+		},
+		{
+			name: "reserved",
+			apply: func(controller *CurrentNodeController, key workflow.CurrentNodeReferenceKey) {
+				controller.automaticReservations[key] = currentNodeQueuedStart{
+					reference: script,
+					policy:    currentNodeAdmissionAutomaticScript,
+				}
+			},
+			clean: func(controller *CurrentNodeController, key workflow.CurrentNodeReferenceKey) {
+				delete(controller.automaticReservations, key)
+			},
+		},
+		{
+			name: "gated",
+			apply: func(controller *CurrentNodeController, key workflow.CurrentNodeReferenceKey) {
+				controller.gates[key] = currentNodeAdmissionGate{
+					reference: script,
+					policy:    currentNodeAdmissionAutomaticScript,
+				}
+			},
+			clean: func(controller *CurrentNodeController, key workflow.CurrentNodeReferenceKey) {
+				delete(controller.gates, key)
+			},
+		},
+		{
+			name: "live",
+			apply: func(controller *CurrentNodeController, key workflow.CurrentNodeReferenceKey) {
+				scopeID := runtimeids.NewExecutionScopeID()
+				controller.live[scopeID] = currentNodeLiveScope{
+					reference: script,
+					policy:    currentNodeAdmissionAutomaticScript,
+				}
+				controller.liveByNode[key] = scopeID
+			},
+			clean: func(controller *CurrentNodeController, key workflow.CurrentNodeReferenceKey) {
+				scopeID := controller.liveByNode[key]
+				delete(controller.liveByNode, key)
+				delete(controller.live, scopeID)
+			},
+		},
+		{
+			name: "finalizing",
+			apply: func(controller *CurrentNodeController, key workflow.CurrentNodeReferenceKey) {
+				scopeID := runtimeids.NewExecutionScopeID()
+				controller.live[scopeID] = currentNodeLiveScope{
+					reference: script,
+					policy:    currentNodeAdmissionAutomaticScript,
+				}
+				controller.liveByNode[key] = scopeID
+				controller.stopping[scopeID] = struct{}{}
+			},
+			clean: func(controller *CurrentNodeController, key workflow.CurrentNodeReferenceKey) {
+				scopeID := controller.liveByNode[key]
+				delete(controller.liveByNode, key)
+				delete(controller.live, scopeID)
+				delete(controller.stopping, scopeID)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			authority := sessionruntime.NewAuthority(sessionruntime.AuthorityOptions{})
+			controller := newCurrentNodeControllerForTest(t, &currentNodeControllerStore{}, &countingCurrentNodeRunner{}, authority, 1)
+			t.Cleanup(func() {
+				if err := controller.Close(); err != nil {
+					t.Errorf("close controller: %v", err)
+				}
+				if err := authority.Close(context.Background()); err != nil {
+					t.Errorf("close authority: %v", err)
+				}
+			})
+			queuedKey, err := queuedAgent.Key()
+			if err != nil {
+				t.Fatalf("queued Agent key: %v", err)
+			}
+			scriptKey, err := script.Key()
+			if err != nil {
+				t.Fatalf("Script key: %v", err)
+			}
+			controller.mu.Lock()
+			controller.live[runtimeids.NewExecutionScopeID()] = currentNodeLiveScope{
+				reference: occupyingAgent,
+				policy:    currentNodeAdmissionAutomaticAgent,
+			}
+			controller.agentCapacityActive = 1
+			controller.automaticQueue.append(currentNodeQueuedStart{
+				reference: queuedAgent,
+				policy:    currentNodeAdmissionAutomaticAgent,
+			})
+			controller.queued[queuedKey] = struct{}{}
+			test.apply(controller, scriptKey)
+			if got := controller.agentActiveLocked(); got != 1 {
+				controller.mu.Unlock()
+				t.Fatalf("Agent capacity with %s Script = %d, want 1", test.name, got)
+			}
+			if _, ok := selectAutomaticIntentIndex([]CurrentNodeAutomaticIntent{{
+				CurrentNode: queuedAgent,
+				NodeKind:    workflow.NodeKindAgent,
+			}}, nil, false); ok {
+				controller.mu.Unlock()
+				t.Fatalf("queued Agent became admissible while %s Script owned controller state", test.name)
+			}
+			test.clean(controller, scriptKey)
+			if got := controller.agentActiveLocked(); got != 1 {
+				controller.mu.Unlock()
+				t.Fatalf("Agent capacity after %s Script cleanup = %d, want 1", test.name, got)
+			}
+			controller.mu.Unlock()
+		})
+	}
+}
+
+func TestCurrentNodeControllerFailedScriptDoesNotReleaseAgentCapacity(t *testing.T) {
+	shellPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh executable unavailable: %v", err)
+	}
+	occupyingAgent := currentNodeReferenceForControllerTest(t, "task-failed-script-agent", "node-occupying-agent")
+	failedScript := currentNodeReferenceForControllerTest(t, "task-failed-script", "node-failed-script")
+	queuedAgent := currentNodeReferenceForControllerTest(t, "task-failed-script-queued-agent", "node-queued-agent")
+	store := &currentNodeControllerStore{}
+	var controller *CurrentNodeController
+	authority := sessionruntime.NewAuthority(sessionruntime.AuthorityOptions{
+		ExecutionFinalized: sessionruntime.ExecutionFinalizedFunc(func(scope sessionruntime.ExecutionScope) {
+			controller.ExecutionFinalized(scope)
+		}),
+	})
+	runner := &selectiveScriptFailureRunner{
+		authority: authority,
+		failed:    failedScript,
+		command: sessionruntime.ScriptCommand{
+			Path: shellPath,
+			Args: []string{"-c", "trap 'exit 0' TERM; while :; do sleep 1; done"},
+		},
+		started: make(chan workflow.CurrentNodeReference, 2),
+	}
+	controller = newCurrentNodeControllerForTest(t, store, runner, authority, 1)
+	t.Cleanup(func() {
+		if err := controller.Close(); err != nil {
+			t.Errorf("close controller: %v", err)
+		}
+		if err := authority.Close(context.Background()); err != nil {
+			t.Errorf("close authority: %v", err)
+		}
+	})
+
+	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{{
+		CurrentNode: occupyingAgent,
+		NodeKind:    workflow.NodeKindAgent,
+	}})
+	select {
+	case started := <-runner.started:
+		if !started.Equal(occupyingAgent) {
+			t.Fatalf("occupying Agent start = %v, want %v", started, occupyingAgent)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("occupying Agent did not start")
+	}
+	waitForRunningCurrentNode(t, authority, occupyingAgent)
+	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{
+		{CurrentNode: failedScript, NodeKind: workflow.NodeKindScript},
+		{CurrentNode: queuedAgent, NodeKind: workflow.NodeKindAgent},
+	})
+	testsetup.RequireUntil(t, time.Now().Add(3*time.Second), 10*time.Millisecond, func() bool {
+		_, interrupted := store.interruption(failedScript)
+		return interrupted
+	}, "failed Script was not interrupted")
+	if !hasAutomaticCurrentNodeIntent(controller.Snapshot(), queuedAgent) {
+		t.Fatalf("queued Agent = %+v, want queued after failed Script cleanup", controller.Snapshot().AutomaticIntents)
+	}
+	occupyingHandle, live := authority.ExecutionByScope(singleLiveScope(t, controller, occupyingAgent))
+	if !live {
+		t.Fatal("occupying Agent is not live")
+	}
+	if err := occupyingHandle.Stop(context.Background()); err != nil {
+		t.Fatalf("stop occupying Agent: %v", err)
+	}
+	select {
+	case started := <-runner.started:
+		if !started.Equal(queuedAgent) {
+			t.Fatalf("queued Agent start = %v, want %v", started, queuedAgent)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("queued Agent did not start after occupying Agent stopped")
+	}
+}
+
+type selectiveScriptFailureRunner struct {
+	authority *sessionruntime.Authority
+	command   sessionruntime.ScriptCommand
+	failed    workflow.CurrentNodeReference
+	started   chan workflow.CurrentNodeReference
+}
+
+func (r *selectiveScriptFailureRunner) StartCurrentNode(_ context.Context, reference workflow.CurrentNodeReference, _ workflowruntime.TaskPromptDelivery, _ CurrentNodeAssignmentSteer, lease sessionruntime.WorkflowExecutionLease, _ workflowruntime.Controller) error {
+	if reference.Equal(r.failed) {
+		return errors.New("script start failed")
+	}
+	_, err := r.authority.StartScriptExecution(context.Background(), sessionruntime.ScriptExecutionRequest{
+		Workflow: &lease,
+		Command:  r.command,
+	})
+	if err == nil {
+		r.started <- reference
+	}
+	return err
+}
+
+func TestCurrentNodeControllerLargeMixedKindQueueSelection(t *testing.T) {
+	queue := currentNodeAutomaticQueue{}
+	for index := 0; index < 4096; index++ {
+		policy := currentNodeAdmissionAutomaticScript
+		if index%2 == 0 {
+			policy = currentNodeAdmissionAutomaticAgent
+		}
+		queue.append(currentNodeQueuedStart{
+			reference: workflow.CurrentNodeReference{
+				TaskID: workflow.TaskID("task-large-mixed-kind-queue"),
+				NodeID: workflow.NodeID(fmt.Sprintf("node-%d", index)),
+			},
+			policy: policy,
+		})
+	}
+	agentAvailable := false
+	for queue.len() != 0 {
+		entry, ok := queue.selectEntry(nil, agentAvailable)
+		if !ok && !agentAvailable {
+			agentAvailable = true
+			continue
+		}
+		if !ok || entry.start.policy != currentNodeAdmissionAutomaticScript {
+			if !agentAvailable {
+				t.Fatalf("selected queue entry = %+v, want an admissible Script", entry)
+			}
+		}
+		queue.remove(entry)
+	}
+}
+
+func TestCurrentNodeAutomaticQueueSelectionPreservesTaskLocalityAndFIFO(t *testing.T) {
+	queue := currentNodeAutomaticQueue{}
+	taskOne := workflow.TaskID("task-automatic-queue-one")
+	taskTwo := workflow.TaskID("task-automatic-queue-two")
+	entries := []currentNodeQueuedStart{
+		{reference: workflow.CurrentNodeReference{TaskID: taskOne, NodeID: "agent-one"}, policy: currentNodeAdmissionAutomaticAgent},
+		{reference: workflow.CurrentNodeReference{TaskID: taskTwo, NodeID: "script-two"}, policy: currentNodeAdmissionAutomaticScript},
+		{reference: workflow.CurrentNodeReference{TaskID: taskOne, NodeID: "script-one"}, policy: currentNodeAdmissionAutomaticScript},
+		{reference: workflow.CurrentNodeReference{TaskID: taskTwo, NodeID: "agent-two"}, policy: currentNodeAdmissionAutomaticAgent},
+	}
+	for _, entry := range entries {
+		queue.append(entry)
+	}
+
+	lastTask := taskOne
+	entry, ok := queue.selectEntry(&lastTask, true)
+	if !ok || !entry.start.reference.Equal(entries[0].reference) {
+		t.Fatalf("same-Task Agent selection = %+v, want first Agent", entry)
+	}
+	queue.remove(entry)
+
+	lastTask = taskTwo
+	entry, ok = queue.selectEntry(&lastTask, true)
+	if !ok || !entry.start.reference.Equal(entries[1].reference) {
+		t.Fatalf("same-Task FIFO selection = %+v, want first Script", entry)
+	}
+	queue.remove(entry)
+
+	entry, ok = queue.selectEntry(nil, false)
+	if !ok || !entry.start.reference.Equal(entries[2].reference) {
+		t.Fatalf("Script selection at saturated Agent capacity = %+v, want Script", entry)
+	}
+}
+
+func TestExecutionFinalizationDoesNotMakeUnassignedHeldSuccessorResumable(t *testing.T) {
+	shellPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("sh executable unavailable: %v", err)
+	}
+	source := currentNodeReferenceForControllerTest(t, "task-successor-steer-failure", "node-source")
+	successor := currentNodeReferenceForControllerTest(t, "task-successor-steer-failure", "node-successor")
+	queuedAgent := currentNodeReferenceForControllerTest(t, "task-unrelated-agent", "node-agent")
+	queuedScript := currentNodeReferenceForControllerTest(t, "task-unrelated-script", "node-script")
+	store := &currentNodeControllerStore{
+		completion: workflowstore.CurrentNodeCompletionResult{
+			AutomaticIntents: []workflowstore.CurrentNodeAutomaticIntent{{CurrentNode: successor, NodeKind: workflow.NodeKindAgent}},
+		},
+	}
+	steerer := &recordingCurrentNodeAssignmentSteerer{}
+	var controller *CurrentNodeController
+	authority := sessionruntime.NewAuthority(sessionruntime.AuthorityOptions{
+		ExecutionFinalized: sessionruntime.ExecutionFinalizedFunc(func(scope sessionruntime.ExecutionScope) {
+			controller.ExecutionFinalized(scope)
+		}),
+	})
+	runner := &recordingScriptRunner{
+		authority: authority,
+		command: sessionruntime.ScriptCommand{
+			Path: shellPath,
+			Args: []string{"-c", "while :; do sleep 1; done"},
+		},
+		started: make(chan workflow.CurrentNodeReference, 4),
+	}
+	controller, err = NewCurrentNodeController(store, runner, authority, NewMutationPermit(), CurrentNodeControllerConfig{
+		AgentConcurrency:  1,
+		AssignmentSteerer: steerer,
+	})
+	if err != nil {
+		t.Fatalf("new current node controller: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := controller.Close(); err != nil {
+			t.Errorf("close controller: %v", err)
+		}
+		if err := authority.Close(context.Background()); err != nil {
+			t.Errorf("close authority: %v", err)
+		}
+	})
+
+	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{{CurrentNode: source, NodeKind: workflow.NodeKindAgent}})
+	<-runner.started
+	waitForRunningCurrentNode(t, authority, source)
+	controller.enqueueAutomaticIntents([]CurrentNodeAutomaticIntent{
+		{CurrentNode: queuedAgent, NodeKind: workflow.NodeKindAgent},
+		{CurrentNode: queuedScript, NodeKind: workflow.NodeKindScript},
+	})
+	testsetup.RequireUntil(t, time.Now().Add(3*time.Second), 10*time.Millisecond, func() bool {
+		return hasAutomaticCurrentNodeIntent(controller.Snapshot(), queuedAgent)
+	}, "unrelated Agent did not remain queued while source occupied capacity")
+	sourceScope := singleLiveScope(t, controller, source)
+	cause := errors.New("assignment persistence failed")
+	steerer.setWaitError(cause)
+	if _, err := controller.CompleteCurrentNode(context.Background(), workflowruntime.CompletionRequest{
+		ScopeID:      sourceScope,
+		TransitionID: "next",
+	}); err != nil {
+		t.Fatalf("complete source: %v", err)
+	}
+	sourceHandle, live := authority.ExecutionByScope(sourceScope)
+	if !live {
+		t.Fatal("completed source scope retired before stop")
+	}
+	if err := sourceHandle.Stop(context.Background()); err != nil {
+		t.Fatalf("stop source: %v", err)
+	}
+
+	if interruption, interrupted := store.interruption(successor); interrupted {
+		t.Fatalf("unassigned held successor was made resumable: %+v", interruption)
+	}
+	if err := controller.EnsureTaskQuiescent(source.TaskID); err != nil {
+		t.Fatalf("uncommitted assignment failure latched controller failure: %v", err)
+	}
+	started := make(map[workflow.CurrentNodeReferenceKey]struct{}, 2)
+	deadline := time.After(3 * time.Second)
+	for len(started) < 2 {
+		select {
+		case currentNode := <-runner.started:
+			if currentNode.Equal(successor) {
+				t.Fatalf("unassigned held successor started after assignment failure")
+			}
+			if !currentNode.Equal(queuedAgent) && !currentNode.Equal(queuedScript) {
+				t.Fatalf("unexpected start after assignment failure: %v", currentNode)
+			}
+			currentNodeKey, err := currentNode.Key()
+			if err != nil {
+				t.Fatalf("started current node key: %v", err)
+			}
+			started[currentNodeKey] = struct{}{}
+		case <-deadline:
+			t.Fatalf("queued work did not start after source capacity was released: %+v", started)
+		}
+	}
+}

--- a/server/workflowexecution/current_node_interruption.go
+++ b/server/workflowexecution/current_node_interruption.go
@@ -168,6 +168,7 @@ func (c *CurrentNodeController) Interrupt(ctx context.Context, selector Interrup
 					continue
 				}
 				delete(c.automaticReservations, key)
+				c.releaseAgentCapacityLocked(start.agentCapacityLease)
 				c.interrupts.addCurrentNode(taskFence, key)
 				references = append(references, start.reference)
 				admissionWaits = appendAdmissionWait(admissionWaits, key, start.done)

--- a/server/workflowexecution/current_node_interruption.go
+++ b/server/workflowexecution/current_node_interruption.go
@@ -123,8 +123,9 @@ func (c *CurrentNodeController) Interrupt(ctx context.Context, selector Interrup
 			}
 			c.explicitQueue = explicitQueue
 
-			automaticQueue := c.automaticQueue[:0]
-			for _, start := range c.automaticQueue {
+			var automaticQueue currentNodeAutomaticQueue
+			for entry := c.automaticQueue.first; entry != nil; entry = entry.globalNext {
+				start := entry.start
 				if start.reference.TaskID == selector.TaskID {
 					key, keyErr := start.reference.Key()
 					if keyErr != nil {
@@ -134,7 +135,7 @@ func (c *CurrentNodeController) Interrupt(ctx context.Context, selector Interrup
 					references = append(references, start.reference)
 					continue
 				}
-				automaticQueue = append(automaticQueue, start)
+				automaticQueue.append(start)
 			}
 			c.automaticQueue = automaticQueue
 

--- a/server/workflowexecution/current_node_lifecycle.go
+++ b/server/workflowexecution/current_node_lifecycle.go
@@ -320,7 +320,8 @@ func (c *CurrentNodeController) taskExecutionQuiescentLocked(taskID workflow.Tas
 			return false
 		}
 	}
-	for _, start := range c.automaticQueue {
+	for entry := c.automaticQueue.first; entry != nil; entry = entry.globalNext {
+		start := entry.start
 		if start.reference.TaskID == taskID {
 			return false
 		}

--- a/server/workflowrunner/current_node_integration_test.go
+++ b/server/workflowrunner/current_node_integration_test.go
@@ -202,8 +202,8 @@ func newCurrentNodeRunnerFixture(t *testing.T, steps ...ScriptedRuntimeStep) *cu
 	fixture.starter = starter
 	fixture.dependencies = dependencies
 	controller, err = workflowexecution.NewCurrentNodeController(store, starter, fixture.authority, permit, workflowexecution.CurrentNodeControllerConfig{
-		AutomaticConcurrency: 1,
-		AssignmentSteerer:    starter,
+		AgentConcurrency:  1,
+		AssignmentSteerer: starter,
 	})
 	if err != nil {
 		t.Fatalf("new current node controller: %v", err)

--- a/server/workflowstore/current_node_completion.go
+++ b/server/workflowstore/current_node_completion.go
@@ -20,10 +20,18 @@ type CurrentNodeCompletionRequest struct {
 	Commentary   string
 }
 
+// CurrentNodeAutomaticIntent is a volatile successor start produced by a
+// committed completion. The executable Node kind is captured from the same
+// Workflow definition used to materialize the successor.
+type CurrentNodeAutomaticIntent struct {
+	CurrentNode workflow.CurrentNodeReference
+	NodeKind    workflow.NodeKind
+}
+
 type CurrentNodeCompletionResult struct {
 	Mutation         workflow.CurrentNodeMutationResult
 	Handoff          CompletionHandoff
-	AutomaticIntents []workflow.CurrentNodeReference
+	AutomaticIntents []CurrentNodeAutomaticIntent
 	PendingApproval  *workflow.PendingApproval
 }
 
@@ -272,7 +280,11 @@ func (s *Store) CompleteCurrentNode(ctx context.Context, req CurrentNodeCompleti
 		Handoff: handoff,
 	}
 	if executableNodeKind(target.Node.Kind()) {
-		result.AutomaticIntents = []workflow.CurrentNodeReference{targetCurrentNode.Reference}
+		intent, err := newCurrentNodeAutomaticIntent(targetCurrentNode.Reference, target.Node)
+		if err != nil {
+			return CurrentNodeCompletionResult{}, err
+		}
+		result.AutomaticIntents = []CurrentNodeAutomaticIntent{intent}
 	}
 	return result, nil
 }
@@ -316,6 +328,20 @@ func cloneCurrentNodeOutputValues(values map[string]string) map[string]string {
 		cloned[key] = value
 	}
 	return cloned
+}
+
+func newCurrentNodeAutomaticIntent(reference workflow.CurrentNodeReference, node workflow.Node) (CurrentNodeAutomaticIntent, error) {
+	if err := reference.Validate(); err != nil {
+		return CurrentNodeAutomaticIntent{}, err
+	}
+	if node == nil {
+		return CurrentNodeAutomaticIntent{}, errors.New("automatic intent target node is required")
+	}
+	kind := node.Kind()
+	if !executableNodeKind(kind) {
+		return CurrentNodeAutomaticIntent{}, fmt.Errorf("automatic intent target node %q has non-executable kind %q", reference.NodeID, kind)
+	}
+	return CurrentNodeAutomaticIntent{CurrentNode: reference, NodeKind: kind}, nil
 }
 
 func sortedStringKeys(values map[string]string) []string {

--- a/server/workflowstore/current_node_completion_test.go
+++ b/server/workflowstore/current_node_completion_test.go
@@ -79,8 +79,11 @@ func TestCompleteCurrentNodeAtomicallyReplacesAgentAndReturnsSuccessorIntent(t *
 	if completed.Handoff != (CompletionHandoff{SourceNodeDisplayName: "Plan", DestinationDisplayName: "Review"}) {
 		t.Fatalf("completion handoff = %+v, want Plan -> Review", completed.Handoff)
 	}
-	if len(completed.AutomaticIntents) != 1 || !completed.AutomaticIntents[0].Equal(target) {
+	if len(completed.AutomaticIntents) != 1 || !completed.AutomaticIntents[0].CurrentNode.Equal(target) {
 		t.Fatalf("completion automatic intents = %+v, want review current node", completed.AutomaticIntents)
+	}
+	if completed.AutomaticIntents[0].NodeKind != workflow.NodeKindAgent {
+		t.Fatalf("completion automatic intent kind = %q, want %q", completed.AutomaticIntents[0].NodeKind, workflow.NodeKindAgent)
 	}
 
 	currentNodes, err := store.ListCurrentNodes(ctx, task.ID)
@@ -137,6 +140,61 @@ func TestCompleteCurrentNodeInfersOnlyOutgoingFanoutTransition(t *testing.T) {
 	}
 	if !branches["split_a"] || !branches["split_b"] {
 		t.Fatalf("completion branches = %+v, want split_a and split_b", branches)
+	}
+	if len(completed.AutomaticIntents) != 2 {
+		t.Fatalf("completion automatic intents = %+v, want both fan-out branches", completed.AutomaticIntents)
+	}
+	for _, intent := range completed.AutomaticIntents {
+		if intent.NodeKind != workflow.NodeKindAgent {
+			t.Fatalf("fan-out automatic intent = %+v, want Agent Node kind", intent)
+		}
+	}
+}
+
+func TestCompleteCurrentNodeJoinContinuationReturnsTargetNodeKind(t *testing.T) {
+	ctx, store, binding := newTestStoreContext(t)
+	workflowID := createFanoutJoinWorkflow(t, ctx, store)
+	linkWorkflow(t, ctx, store, binding.ProjectID, workflowID, true)
+	task := createDefaultTask(t, ctx, store, binding.ProjectID)
+	source := startTask(t, ctx, store, task.ID).Mutation.Created[0]
+
+	split, err := store.CompleteCurrentNode(ctx, CurrentNodeCompletionRequest{
+		Source:       source.Reference,
+		OutputValues: map[string]string{"summary": "plan complete"},
+	})
+	if err != nil {
+		t.Fatalf("CompleteCurrentNode split: %v", err)
+	}
+	if len(split.Mutation.Created) != 2 {
+		t.Fatalf("split mutation = %+v, want two branches", split.Mutation)
+	}
+	for _, intent := range split.AutomaticIntents {
+		if intent.NodeKind != workflow.NodeKindAgent {
+			t.Fatalf("split automatic intent = %+v, want Agent Node kind", intent)
+		}
+	}
+
+	first, second := split.Mutation.Created[0], split.Mutation.Created[1]
+	if _, err := store.CompleteCurrentNode(ctx, CurrentNodeCompletionRequest{
+		Source:       first.Reference,
+		TransitionID: "join",
+		OutputValues: map[string]string{"joined": "branch complete"},
+	}); err != nil {
+		t.Fatalf("CompleteCurrentNode first join arrival: %v", err)
+	}
+	joined, err := store.CompleteCurrentNode(ctx, CurrentNodeCompletionRequest{
+		Source:       second.Reference,
+		TransitionID: "join",
+		OutputValues: map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("CompleteCurrentNode second join arrival: %v", err)
+	}
+	if len(joined.AutomaticIntents) != 1 {
+		t.Fatalf("join continuation automatic intents = %+v, want one synth successor", joined.AutomaticIntents)
+	}
+	if joined.AutomaticIntents[0].NodeKind != workflow.NodeKindAgent {
+		t.Fatalf("join continuation automatic intent = %+v, want Agent Node kind", joined.AutomaticIntents[0])
 	}
 }
 

--- a/server/workflowstore/current_node_fanout.go
+++ b/server/workflowstore/current_node_fanout.go
@@ -14,6 +14,7 @@ import (
 type currentNodeFanoutTarget struct {
 	BranchKey   workflow.TransitionBranchKey
 	CurrentNode workflow.CurrentNode
+	Node        workflow.Node
 }
 
 func completeCurrentNodeFanout(
@@ -56,6 +57,7 @@ func completeCurrentNodeFanout(
 		preparedTargets = append(preparedTargets, currentNodeFanoutTarget{
 			BranchKey:   branchKey,
 			CurrentNode: targetCurrentNode,
+			Node:        target.Node,
 		})
 		approvalBranches = append(approvalBranches, workflow.PendingApprovalBranch{
 			TransitionBranchKey: branchKey,
@@ -102,8 +104,12 @@ func completeCurrentNodeFanout(
 		},
 	}
 	for _, target := range preparedTargets {
-		if target.CurrentNode.Scheduling != nil {
-			result.AutomaticIntents = append(result.AutomaticIntents, target.CurrentNode.Reference)
+		if target.CurrentNode.Scheduling != nil && executableNodeKind(target.Node.Kind()) {
+			intent, err := newCurrentNodeAutomaticIntent(target.CurrentNode.Reference, target.Node)
+			if err != nil {
+				return CurrentNodeCompletionResult{}, err
+			}
+			result.AutomaticIntents = append(result.AutomaticIntents, intent)
 		}
 	}
 	return result, nil

--- a/server/workflowstore/current_node_join.go
+++ b/server/workflowstore/current_node_join.go
@@ -124,7 +124,11 @@ func completeCurrentNodeJoinArrival(
 		Handoff: handoff,
 	}
 	if executableNodeKind(target.Node.Kind()) {
-		result.AutomaticIntents = []workflow.CurrentNodeReference{targetCurrentNode.Reference}
+		intent, err := newCurrentNodeAutomaticIntent(targetCurrentNode.Reference, target.Node)
+		if err != nil {
+			return CurrentNodeCompletionResult{}, err
+		}
+		result.AutomaticIntents = []CurrentNodeAutomaticIntent{intent}
 	}
 	return result, nil
 }


### PR DESCRIPTION
## Summary

Kent task: **KENT-276 — Separate script concurrency pool**. No separate GitHub issue is associated with this task.

- Keeps `workflow.concurrency` as bounded Agent Node scheduling capacity.
- Removes Script Nodes from the Agent capacity pool; eligible Scripts can admit concurrently without a Script pool setting.
- Preserves explicit Approval/Resume override behavior, output bounds, cancellation, startup recovery, interruption, quiescence, and shutdown stop broadcast/join semantics.
- Adds typed Agent/Script completion intents and a single indexed Automatic Intent queue with same-Task locality and FIFO ordering across executable kinds.
- Adds release-once Agent capacity ownership across reservation, gate, live, finalization, failed-start, and interruption paths.

## Verification

- `./scripts/test.sh ./server/workflowexecution ./server/workflowstore ./server/workflowrunner ./server/sessionruntime ./shared/config`: passed in the pre-rebase verification and all changed workflowexecution/queue regressions passed after rebase.
- The post-rebase aggregate run exposed one unrelated flaky base test, `TestConcurrentTaskDependencyAddsSerializeTheFinalOutgoingAndIncomingSlots/outgoing`; its focused rerun passed.
- `./scripts/test.sh ./server/workflowstore -run ^TestConcurrentTaskDependencyAddsSerializeTheFinalOutgoingAndIncomingSlots`: passed.
- `./scripts/build.sh server --output ./bin/kent`: passed.
- `./bin/kent --version`: `2.4.0`.
- `git diff --check`: passed.
- The repository-wide server suite remains subject to the known 300-second shard cap, explicitly waived in the task comment; no assertion failure was observed in the prior attempt.

## QA evidence

Prior QA confirmed saturated-Agent Script concurrency, bounded Agent capacity, reservation-before-launch, mixed-kind selection, Script ownership lifecycle, failed and interrupted Script cleanup, shutdown broadcast-stop/join, Approval override, startup recovery, quiescence, Workflowrunner integration, and Sessionruntime edge cases. Supporting evidence is documented in `.kent/plans/KENT-276.md`; available logs include:

- `/tmp/kent-276-workflowexecution-focused.log`
- `/tmp/kent-276-workflowstore-focused.log`
- `/tmp/kent-276-workflowrunner-integration.log`
- `/tmp/kent-276-sessionruntime-edge.log`
- `/tmp/kent-276-focused-all.log`
- `/tmp/kent-276-build.log`

## Diff accounting

Against `origin/main` after rebase:

- Production Go: **+460 / -102**, net **+358**, gross **562** LoC.
- Test Go: **+1,013 / -119**, net **+894**, gross **1,132** LoC.
- Documentation/spec: **+10 / -5**, net **+5**, gross **15** LoC.
- Generated code: **0**.

## Caveats and follow-up

- Script admission is intentionally unlimited at the scheduler level; per-process output capture and terminate-then-kill cancellation containment remain bounded.
- The automatic queue uses typed global, per-kind, and per-Task indexes. Focused invariant tests cover lane removal, locality, FIFO, and large mixed-kind draining.
- The one post-rebase aggregate failure was a nondeterministic timestamp assertion in unrelated workflow dependency tests; the isolated test passed immediately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow automation now supports unrestricted concurrent Script Nodes, while Agent Nodes continue to respect configured capacity.
  * Scheduling favors continuing work within the same task while preserving fair ordering across Agent and Script Nodes.
  * Explicit workflow actions can exceed automatic Agent capacity limits.

* **Bug Fixes**
  * Interrupted scripts now limit captured output and terminate gracefully before forcing shutdown.
  * Agent capacity is released consistently after failed, canceled, or completed workflow activity.

* **Documentation**
  * Updated concurrency configuration and command execution guidance to clarify these behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->