### PR TITLE
Add canonical Project deletion to the kent CLI

### DIFF
--- a/cli/kent/binding_commands.go
+++ b/cli/kent/binding_commands.go
@@ -36,6 +36,8 @@ func projectSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
 			return projectDefaultSubcommand(args[1:], stdout, stderr)
 		case "detach":
 			return detachSubcommand(args[1:], stdout, stderr)
+		case "delete":
+			return projectDeleteSubcommand(args[1:], stdout, stderr)
 		}
 	}
 	fs := newCommandFlagSet(config.Command+" project", stderr, projectUsage)

--- a/cli/kent/binding_mutation_commands.go
+++ b/cli/kent/binding_mutation_commands.go
@@ -125,7 +125,7 @@ func runBindingMutationCommand(
 	}
 	selector, err := bindingMutationSelector(cfg, arguments)
 	if err != nil {
-		return writeBindingMutationFailure(stdout, stderr, arguments.JSON, closeBindingMutationRemote(remote, err), arguments.ProjectID, defaultMutation)
+		return writeBindingMutationFailure(stdout, stderr, arguments.JSON, closeCommandRemote(remote, "binding mutation", err), arguments.ProjectID, defaultMutation)
 	}
 	rpcCtx, cancel := context.WithTimeout(context.Background(), bindingCommandRPCTimeout)
 	defer cancel()
@@ -135,12 +135,12 @@ func runBindingMutationCommand(
 			stdout,
 			stderr,
 			arguments.JSON,
-			closeBindingMutationRemote(remote, mutationErr),
+			closeCommandRemote(remote, "binding mutation", mutationErr),
 			arguments.ProjectID,
 			defaultMutation,
 		)
 	}
-	cleanupErr := closeBindingMutationRemote(remote, nil)
+	cleanupErr := closeCommandRemote(remote, "binding mutation", nil)
 	if cleanupErr != nil {
 		// The mutation has already committed. Preserve its authoritative result
 		// and surface connection cleanup as a non-fatal diagnostic.
@@ -156,18 +156,6 @@ func runBindingMutationCommand(
 		})
 	}
 	return writeBindingMutationPlainResult(stdout, stderr, result, defaultMutation)
-}
-
-func closeBindingMutationRemote(remote *client.Remote, cause error) error {
-	closeErr := remote.Close()
-	if closeErr == nil {
-		return cause
-	}
-	closeFailure := fmt.Errorf("close binding mutation remote: %w", closeErr)
-	if cause == nil {
-		return closeFailure
-	}
-	return errors.Join(cause, closeFailure)
 }
 
 func writeBindingMutationPlainResult(stdout io.Writer, stderr io.Writer, result bindingMutationResult, defaultMutation bool) int {

--- a/cli/kent/command_remote.go
+++ b/cli/kent/command_remote.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"core/shared/client"
+)
+
+func closeCommandRemote(remote *client.Remote, operation string, cause error) error {
+	closeErr := remote.Close()
+	if closeErr == nil {
+		return cause
+	}
+	closeFailure := fmt.Errorf("close %s remote: %w", operation, closeErr)
+	if cause == nil {
+		return closeFailure
+	}
+	return errors.Join(cause, closeFailure)
+}

--- a/cli/kent/help.go
+++ b/cli/kent/help.go
@@ -204,24 +204,14 @@ var (
 	detachUsage             = commandUsage{helpFile: "detach.txt", includeEmbeddedFlags: true}
 	projectListUsage        = commandUsage{helpFile: "project_list.txt"}
 	projectCreateUsage      = commandUsage{helpFile: "project_create.txt", includeEmbeddedFlags: true}
-	projectDeleteUsage      = leafCommandUsage(
-		config.Command+" project delete <project-id> [--confirm] [--json]",
-		"Delete a Project by canonical ID.",
-		"",
-		"Deletion is non-interactive and requires --confirm.",
-		"Selection accepts only the canonical Project ID; --json emits one stable result envelope.",
-		"Agent shells are denied only when the Project contains unfinished work, including Backlog Tasks.",
-		"Task state may change before deletion is processed; server blockers remain authoritative.",
-		"Workspace files are never deleted.",
-	)
-	attachUsage           = commandUsage{helpFile: "attach.txt", includeEmbeddedFlags: true}
-	rebindUsage           = commandUsage{helpFile: "rebind.txt"}
-	serveUsage            = commandUsage{helpFile: "serve.txt", includeEmbeddedFlags: true}
-	serviceUsage          = commandUsage{helpFile: "service.txt"}
-	serviceStatusUsage    = commandUsage{helpFile: "service_status.txt", includeEmbeddedFlags: true}
-	serviceInstallUsage   = commandUsage{helpFile: "service_install.txt", includeEmbeddedFlags: true}
-	serviceUninstallUsage = commandUsage{helpFile: "service_uninstall.txt", includeEmbeddedFlags: true}
-	serviceRestartUsage   = commandUsage{helpFile: "service_restart.txt", includeEmbeddedFlags: true}
+	attachUsage             = commandUsage{helpFile: "attach.txt", includeEmbeddedFlags: true}
+	rebindUsage             = commandUsage{helpFile: "rebind.txt"}
+	serveUsage              = commandUsage{helpFile: "serve.txt", includeEmbeddedFlags: true}
+	serviceUsage            = commandUsage{helpFile: "service.txt"}
+	serviceStatusUsage      = commandUsage{helpFile: "service_status.txt", includeEmbeddedFlags: true}
+	serviceInstallUsage     = commandUsage{helpFile: "service_install.txt", includeEmbeddedFlags: true}
+	serviceUninstallUsage   = commandUsage{helpFile: "service_uninstall.txt", includeEmbeddedFlags: true}
+	serviceRestartUsage     = commandUsage{helpFile: "service_restart.txt", includeEmbeddedFlags: true}
 )
 
 var (

--- a/cli/kent/help.go
+++ b/cli/kent/help.go
@@ -211,7 +211,7 @@ var (
 		"Deletion is non-interactive and requires --confirm.",
 		"Selection accepts only the canonical Project ID; --json emits one stable result envelope.",
 		"Agent shells are denied only when the Project contains unfinished work, including Backlog Tasks.",
-		"The unfinished-work check is a best-effort command-time snapshot; server blockers remain authoritative.",
+		"Task state may change before deletion is processed; server blockers remain authoritative.",
 		"Workspace files are never deleted.",
 	)
 	attachUsage           = commandUsage{helpFile: "attach.txt", includeEmbeddedFlags: true}

--- a/cli/kent/help.go
+++ b/cli/kent/help.go
@@ -204,14 +204,24 @@ var (
 	detachUsage             = commandUsage{helpFile: "detach.txt", includeEmbeddedFlags: true}
 	projectListUsage        = commandUsage{helpFile: "project_list.txt"}
 	projectCreateUsage      = commandUsage{helpFile: "project_create.txt", includeEmbeddedFlags: true}
-	attachUsage             = commandUsage{helpFile: "attach.txt", includeEmbeddedFlags: true}
-	rebindUsage             = commandUsage{helpFile: "rebind.txt"}
-	serveUsage              = commandUsage{helpFile: "serve.txt", includeEmbeddedFlags: true}
-	serviceUsage            = commandUsage{helpFile: "service.txt"}
-	serviceStatusUsage      = commandUsage{helpFile: "service_status.txt", includeEmbeddedFlags: true}
-	serviceInstallUsage     = commandUsage{helpFile: "service_install.txt", includeEmbeddedFlags: true}
-	serviceUninstallUsage   = commandUsage{helpFile: "service_uninstall.txt", includeEmbeddedFlags: true}
-	serviceRestartUsage     = commandUsage{helpFile: "service_restart.txt", includeEmbeddedFlags: true}
+	projectDeleteUsage      = leafCommandUsage(
+		config.Command+" project delete <project-id> [--confirm] [--json]",
+		"Delete a Project by canonical ID.",
+		"",
+		"Deletion is non-interactive and requires --confirm.",
+		"Selection accepts only the canonical Project ID; --json emits one stable result envelope.",
+		"Agent shells are denied only when the Project contains unfinished work, including Backlog Tasks.",
+		"Task state may change before deletion is processed; server blockers remain authoritative.",
+		"Workspace files are never deleted.",
+	)
+	attachUsage           = commandUsage{helpFile: "attach.txt", includeEmbeddedFlags: true}
+	rebindUsage           = commandUsage{helpFile: "rebind.txt"}
+	serveUsage            = commandUsage{helpFile: "serve.txt", includeEmbeddedFlags: true}
+	serviceUsage          = commandUsage{helpFile: "service.txt"}
+	serviceStatusUsage    = commandUsage{helpFile: "service_status.txt", includeEmbeddedFlags: true}
+	serviceInstallUsage   = commandUsage{helpFile: "service_install.txt", includeEmbeddedFlags: true}
+	serviceUninstallUsage = commandUsage{helpFile: "service_uninstall.txt", includeEmbeddedFlags: true}
+	serviceRestartUsage   = commandUsage{helpFile: "service_restart.txt", includeEmbeddedFlags: true}
 )
 
 var (

--- a/cli/kent/help.go
+++ b/cli/kent/help.go
@@ -204,14 +204,24 @@ var (
 	detachUsage             = commandUsage{helpFile: "detach.txt", includeEmbeddedFlags: true}
 	projectListUsage        = commandUsage{helpFile: "project_list.txt"}
 	projectCreateUsage      = commandUsage{helpFile: "project_create.txt", includeEmbeddedFlags: true}
-	attachUsage             = commandUsage{helpFile: "attach.txt", includeEmbeddedFlags: true}
-	rebindUsage             = commandUsage{helpFile: "rebind.txt"}
-	serveUsage              = commandUsage{helpFile: "serve.txt", includeEmbeddedFlags: true}
-	serviceUsage            = commandUsage{helpFile: "service.txt"}
-	serviceStatusUsage      = commandUsage{helpFile: "service_status.txt", includeEmbeddedFlags: true}
-	serviceInstallUsage     = commandUsage{helpFile: "service_install.txt", includeEmbeddedFlags: true}
-	serviceUninstallUsage   = commandUsage{helpFile: "service_uninstall.txt", includeEmbeddedFlags: true}
-	serviceRestartUsage     = commandUsage{helpFile: "service_restart.txt", includeEmbeddedFlags: true}
+	projectDeleteUsage      = leafCommandUsage(
+		config.Command+" project delete <project-id> [--confirm] [--json]",
+		"Delete a Project by canonical ID.",
+		"",
+		"Deletion is non-interactive and requires --confirm.",
+		"Selection accepts only the canonical Project ID; --json emits one stable result envelope.",
+		"Agent shells are denied only when the Project contains unfinished work, including Backlog Tasks.",
+		"The unfinished-work check is a best-effort command-time snapshot; server blockers remain authoritative.",
+		"Workspace files are never deleted.",
+	)
+	attachUsage           = commandUsage{helpFile: "attach.txt", includeEmbeddedFlags: true}
+	rebindUsage           = commandUsage{helpFile: "rebind.txt"}
+	serveUsage            = commandUsage{helpFile: "serve.txt", includeEmbeddedFlags: true}
+	serviceUsage          = commandUsage{helpFile: "service.txt"}
+	serviceStatusUsage    = commandUsage{helpFile: "service_status.txt", includeEmbeddedFlags: true}
+	serviceInstallUsage   = commandUsage{helpFile: "service_install.txt", includeEmbeddedFlags: true}
+	serviceUninstallUsage = commandUsage{helpFile: "service_uninstall.txt", includeEmbeddedFlags: true}
+	serviceRestartUsage   = commandUsage{helpFile: "service_restart.txt", includeEmbeddedFlags: true}
 )
 
 var (

--- a/cli/kent/help/project.txt
+++ b/cli/kent/help/project.txt
@@ -2,6 +2,7 @@ Usage of kent project:
   kent project [path]
   kent project list
   kent project create --path <server-path> --name <project-name>
+  kent project delete <project-id> [--confirm] [--json]
 
 Find or create projects and their workspace attachments.
 
@@ -22,6 +23,12 @@ Commands:
   kent project detach --project <project-id> [path]
   kent project detach --project <project-id> --workspace <workspace-id>
     Alias for `kent detach`.
+
+  kent project delete <project-id>
+    Delete a Project by canonical ID. Requires `--confirm`; workspace files are not deleted.
+    Selection accepts only the canonical Project ID. Use `--json` for one stable result envelope.
+    Agent shells are denied only when unfinished work exists, including Backlog Tasks.
+    The unfinished-work check is a best-effort command-time snapshot; server blockers remain authoritative.
 
 Examples:
   kent project

--- a/cli/kent/help/project.txt
+++ b/cli/kent/help/project.txt
@@ -2,7 +2,6 @@ Usage of kent project:
   kent project [path]
   kent project list
   kent project create --path <server-path> --name <project-name>
-  kent project delete <project-id> [--confirm] [--json]
 
 Find or create projects and their workspace attachments.
 
@@ -23,12 +22,6 @@ Commands:
   kent project detach --project <project-id> [path]
   kent project detach --project <project-id> --workspace <workspace-id>
     Alias for `kent detach`.
-
-  kent project delete <project-id>
-    Delete a Project by canonical ID. Requires `--confirm`; workspace files are not deleted.
-    Selection accepts only the canonical Project ID. Use `--json` for one stable result envelope.
-    Agent shells are denied only when unfinished work exists, including Backlog Tasks.
-    Task state may change before deletion is processed; server blockers remain authoritative.
 
 Examples:
   kent project

--- a/cli/kent/help/project.txt
+++ b/cli/kent/help/project.txt
@@ -2,6 +2,7 @@ Usage of kent project:
   kent project [path]
   kent project list
   kent project create --path <server-path> --name <project-name>
+  kent project delete <project-id> [--confirm] [--json]
 
 Find or create projects and their workspace attachments.
 
@@ -22,6 +23,9 @@ Commands:
   kent project detach --project <project-id> [path]
   kent project detach --project <project-id> --workspace <workspace-id>
     Alias for `kent detach`.
+
+  kent project delete <project-id> [--confirm] [--json]
+    Delete a Project by canonical ID. Requires `--confirm`; workspace files are not deleted.
 
 Examples:
   kent project

--- a/cli/kent/help/project.txt
+++ b/cli/kent/help/project.txt
@@ -28,7 +28,7 @@ Commands:
     Delete a Project by canonical ID. Requires `--confirm`; workspace files are not deleted.
     Selection accepts only the canonical Project ID. Use `--json` for one stable result envelope.
     Agent shells are denied only when unfinished work exists, including Backlog Tasks.
-    The unfinished-work check is a best-effort command-time snapshot; server blockers remain authoritative.
+    Task state may change before deletion is processed; server blockers remain authoritative.
 
 Examples:
   kent project

--- a/cli/kent/project_delete_command.go
+++ b/cli/kent/project_delete_command.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"core/shared/client"
 	"core/shared/config"
 	"core/shared/serverapi"
+	"core/shared/sessionenv"
 )
 
 type projectDeleteOperations interface {
@@ -53,7 +55,7 @@ type projectDeleteJSONEnvelope struct {
 }
 
 func projectDeleteSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
-	fs := newCommandFlagSet(config.Command+" project delete", stderr, projectDeleteUsage)
+	fs := newCommandFlagSet(config.Command+" project delete", stderr, projectUsage)
 	confirm := fs.Bool("confirm", false, "confirm project deletion")
 	jsonOut := fs.Bool("json", false, "write a stable JSON envelope")
 	positionals, ok, exitCode := parseInterspersedPositionals(fs, args)
@@ -78,7 +80,8 @@ func projectDeleteSubcommand(args []string, stdout io.Writer, stderr io.Writer) 
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
 	defer cancel()
-	outcome := runProjectDeleteUseCase(ctx, remote, projectID, *confirm, isAgentShell())
+	_, agent := sessionenv.LookupSessionID(os.LookupEnv)
+	outcome := runProjectDeleteUseCase(ctx, remote, projectID, *confirm, agent)
 	exitCode = writeProjectDeleteOutcome(stdout, stderr, outcome, *jsonOut)
 	if closeErr := closeCommandRemote(remote, "project deletion", nil); closeErr != nil {
 		fmt.Fprintln(stderr, closeErr)

--- a/cli/kent/project_delete_command.go
+++ b/cli/kent/project_delete_command.go
@@ -258,7 +258,12 @@ func writeProjectDeleteOutcome(stdout io.Writer, stderr io.Writer, outcome proje
 			return 1
 		}
 		for _, blocker := range outcome.Error.Blockers {
-			writeWorkflowBlockerLine(stderr, blocker.Code, blocker.Message, projectDeleteBlockerCount(blocker.Count))
+			count, err := projectDeleteBlockerCount(blocker.Count)
+			if err != nil {
+				fmt.Fprintln(stderr, err)
+				return 1
+			}
+			writeWorkflowBlockerLine(stderr, blocker.Code, blocker.Message, count)
 		}
 		fmt.Fprintln(stderr, outcome.Error.Message)
 		return 1
@@ -278,12 +283,15 @@ func writeProjectDeleteOutcome(stdout io.Writer, stderr io.Writer, outcome proje
 	return 0
 }
 
-func projectDeleteBlockerCount(count *int) *int64 {
-	if count == nil || *count <= 0 {
-		return nil
+func projectDeleteBlockerCount(count *int) (*int64, error) {
+	if count == nil {
+		return nil, nil
+	}
+	if *count <= 0 {
+		return nil, errors.New("project deletion blocker count must be positive when present")
 	}
 	value := int64(*count)
-	return &value
+	return &value, nil
 }
 
 func (outcome projectDeleteOutcome) validate() error {
@@ -295,6 +303,13 @@ func (outcome projectDeleteOutcome) validate() error {
 	}
 	if outcome.Error != nil && strings.TrimSpace(outcome.Error.ProjectID) == "" {
 		return errors.New("project deletion error requires a project id")
+	}
+	if outcome.Error != nil {
+		for _, blocker := range outcome.Error.Blockers {
+			if _, err := projectDeleteBlockerCount(blocker.Count); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/cli/kent/project_delete_command.go
+++ b/cli/kent/project_delete_command.go
@@ -279,7 +279,7 @@ func writeProjectDeleteOutcome(stdout io.Writer, stderr io.Writer, outcome proje
 }
 
 func projectDeleteBlockerCount(count *int) *int64 {
-	if count == nil {
+	if count == nil || *count <= 0 {
 		return nil
 	}
 	value := int64(*count)

--- a/cli/kent/project_delete_command.go
+++ b/cli/kent/project_delete_command.go
@@ -258,11 +258,7 @@ func writeProjectDeleteOutcome(stdout io.Writer, stderr io.Writer, outcome proje
 			return 1
 		}
 		for _, blocker := range outcome.Error.Blockers {
-			count := int64(0)
-			if blocker.Count != nil {
-				count = int64(*blocker.Count)
-			}
-			writeWorkflowBlockerLine(stderr, blocker.Code, blocker.Message, count)
+			writeWorkflowBlockerLine(stderr, blocker.Code, blocker.Message, projectDeleteBlockerCount(blocker.Count))
 		}
 		fmt.Fprintln(stderr, outcome.Error.Message)
 		return 1
@@ -280,6 +276,14 @@ func writeProjectDeleteOutcome(stdout io.Writer, stderr io.Writer, outcome proje
 	}
 	fmt.Fprintf(stdout, "Deleted project %s. Workspace files were not deleted.\n", outcome.Result.ProjectID)
 	return 0
+}
+
+func projectDeleteBlockerCount(count *int) *int64 {
+	if count == nil {
+		return nil
+	}
+	value := int64(*count)
+	return &value
 }
 
 func (outcome projectDeleteOutcome) validate() error {

--- a/cli/kent/project_delete_command.go
+++ b/cli/kent/project_delete_command.go
@@ -305,7 +305,19 @@ func (outcome projectDeleteOutcome) validate() error {
 		return errors.New("project deletion error requires a project id")
 	}
 	if outcome.Error != nil {
+		if strings.TrimSpace(outcome.Error.Code) == "" || strings.TrimSpace(outcome.Error.Message) == "" {
+			return errors.New("project deletion error requires code and message")
+		}
+		if outcome.Error.Code == "project_delete_blocked" && len(outcome.Error.Blockers) == 0 {
+			return errors.New("project deletion blocked outcome requires blockers")
+		}
+		if outcome.Error.Code != "project_delete_blocked" && len(outcome.Error.Blockers) != 0 {
+			return errors.New("project deletion non-blocked outcome must omit blockers")
+		}
 		for _, blocker := range outcome.Error.Blockers {
+			if strings.TrimSpace(blocker.Code) == "" || strings.TrimSpace(blocker.Message) == "" {
+				return errors.New("project deletion blocker requires code and message")
+			}
 			if _, err := projectDeleteBlockerCount(blocker.Count); err != nil {
 				return err
 			}
@@ -317,29 +329,12 @@ func (outcome projectDeleteOutcome) validate() error {
 func (envelope projectDeleteJSONEnvelope) validate() error {
 	switch envelope.Status {
 	case "ok":
-		if envelope.Result == nil || envelope.Error != nil || strings.TrimSpace(envelope.Result.ProjectID) == "" {
+		if envelope.Result == nil {
 			return errors.New("project deletion success envelope is invalid")
 		}
 	case "error":
-		if envelope.Error == nil || envelope.Result != nil ||
-			strings.TrimSpace(envelope.Error.Code) == "" ||
-			strings.TrimSpace(envelope.Error.Message) == "" ||
-			strings.TrimSpace(envelope.Error.ProjectID) == "" {
+		if envelope.Error == nil {
 			return errors.New("project deletion error envelope is invalid")
-		}
-		if envelope.Error.Code == "project_delete_blocked" && len(envelope.Error.Blockers) == 0 {
-			return errors.New("project deletion blocked envelope requires blockers")
-		}
-		if envelope.Error.Code != "project_delete_blocked" && len(envelope.Error.Blockers) != 0 {
-			return errors.New("project deletion non-blocked envelope must omit blockers")
-		}
-		for _, blocker := range envelope.Error.Blockers {
-			if strings.TrimSpace(blocker.Code) == "" || strings.TrimSpace(blocker.Message) == "" {
-				return errors.New("project deletion error envelope blocker is invalid")
-			}
-			if blocker.Count != nil && *blocker.Count <= 0 {
-				return errors.New("project deletion error envelope blocker count is invalid")
-			}
 		}
 	default:
 		return errors.New("project deletion envelope status is invalid")

--- a/cli/kent/project_delete_command.go
+++ b/cli/kent/project_delete_command.go
@@ -282,7 +282,12 @@ func writeProjectDeleteOutcome(stdout io.Writer, stderr io.Writer, outcome proje
 		}
 		return writeCommandJSON(stdout, stderr, envelope)
 	}
-	fmt.Fprintf(stdout, "Deleted project %s. Workspace files were not deleted.\n", outcome.Result.ProjectID)
+	if _, err := fmt.Fprintf(stdout, "Deleted project %s. Workspace files were not deleted.\n", outcome.Result.ProjectID); err != nil {
+		if _, stderrErr := fmt.Fprintf(stderr, "write project deletion result: %v\n", err); stderrErr != nil {
+			return 1
+		}
+		return 1
+	}
 	return 0
 }
 

--- a/cli/kent/project_delete_command.go
+++ b/cli/kent/project_delete_command.go
@@ -55,7 +55,7 @@ type projectDeleteJSONEnvelope struct {
 }
 
 func projectDeleteSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
-	fs := newCommandFlagSet(config.Command+" project delete", stderr, projectUsage)
+	fs := newCommandFlagSet(config.Command+" project delete", stderr, projectDeleteUsage)
 	confirm := fs.Bool("confirm", false, "confirm project deletion")
 	jsonOut := fs.Bool("json", false, "write a stable JSON envelope")
 	positionals, ok, exitCode := parseInterspersedPositionals(fs, args)

--- a/cli/kent/project_delete_command.go
+++ b/cli/kent/project_delete_command.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"core/shared/client"
+	"core/shared/config"
+	"core/shared/serverapi"
+)
+
+type projectDeleteOperations interface {
+	ListWorkflowTasks(context.Context, serverapi.WorkflowTaskListRequest) (serverapi.WorkflowTaskListResponse, error)
+	DeleteProject(context.Context, serverapi.ProjectDeleteRequest) (serverapi.ProjectDeleteResponse, error)
+}
+
+type projectDeleteError struct {
+	Code      string
+	Message   string
+	ProjectID string
+	Blockers  []projectDeleteBlocker
+}
+
+type projectDeleteBlocker struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Count   *int   `json:"count,omitempty"`
+}
+
+type projectDeleteOutcome struct {
+	Result *projectDeleteResult
+	Error  *projectDeleteError
+}
+
+type projectDeleteResult struct {
+	ProjectID string `json:"project_id"`
+}
+
+type projectDeleteJSONError struct {
+	Code      string                 `json:"code"`
+	Message   string                 `json:"message"`
+	ProjectID string                 `json:"project_id"`
+	Blockers  []projectDeleteBlocker `json:"blockers,omitempty"`
+}
+
+type projectDeleteJSONEnvelope struct {
+	Status string                  `json:"status"`
+	Result *projectDeleteResult    `json:"result,omitempty"`
+	Error  *projectDeleteJSONError `json:"error,omitempty"`
+}
+
+func projectDeleteSubcommand(args []string, stdout io.Writer, stderr io.Writer) int {
+	fs := newCommandFlagSet(config.Command+" project delete", stderr, projectDeleteUsage)
+	confirm := fs.Bool("confirm", false, "confirm project deletion")
+	jsonOut := fs.Bool("json", false, "write a stable JSON envelope")
+	positionals, ok, exitCode := parseInterspersedPositionals(fs, args)
+	if !ok {
+		return exitCode
+	}
+	if len(positionals) != 1 {
+		fmt.Fprintln(stderr, "project delete requires <project-id>")
+		return 2
+	}
+	projectID := strings.TrimSpace(positionals[0])
+	if projectID == "" {
+		fmt.Fprintln(stderr, "project id must not be blank")
+		return 2
+	}
+
+	_, remote, err := bindingCommandRemoteOpener(context.Background(), ".")
+	if err != nil {
+		return writeProjectDeleteOutcome(stdout, stderr, projectDeleteOutcome{
+			Error: &projectDeleteError{Code: "request_failed", Message: err.Error(), ProjectID: projectID},
+		}, *jsonOut)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), workflowCommandTimeout)
+	defer cancel()
+	outcome := runProjectDeleteUseCase(ctx, remote, projectID, *confirm, isAgentShell())
+	exitCode = writeProjectDeleteOutcome(stdout, stderr, outcome, *jsonOut)
+	if closeErr := closeCommandRemote(remote, "project deletion", nil); closeErr != nil {
+		fmt.Fprintln(stderr, closeErr)
+	}
+	return exitCode
+}
+
+func runProjectDeleteUseCase(
+	ctx context.Context,
+	operations projectDeleteOperations,
+	projectID string,
+	confirmed bool,
+	agent bool,
+) projectDeleteOutcome {
+	projectID = strings.TrimSpace(projectID)
+	if unfinished, err := projectDeleteHasUnfinishedWork(ctx, operations, projectID); err != nil {
+		return projectDeleteFailure(projectID, projectDeleteErrorCode(err), err)
+	} else if agent && unfinished {
+		return projectDeleteFailure(
+			projectID,
+			"human_only_unfinished_work",
+			fmt.Errorf("Project deletion is human-only because project %s contains unfinished work.", projectID),
+		)
+	}
+	if !confirmed {
+		return projectDeleteFailure(
+			projectID,
+			"confirmation_required",
+			fmt.Errorf("Project deletion was not confirmed. Rerun with --confirm to delete project %s.", projectID),
+		)
+	}
+	response, err := operations.DeleteProject(ctx, serverapi.ProjectDeleteRequest{ProjectID: projectID})
+	if err != nil {
+		return projectDeleteFailure(projectID, projectDeleteErrorCode(err), err)
+	}
+	if response.ProjectID != projectID {
+		return projectDeleteFailure(projectID, "request_failed", errors.New("project deletion returned a mismatched project identity"))
+	}
+	if response.Deleted {
+		if len(response.Blockers) != 0 {
+			return projectDeleteFailure(projectID, "request_failed", errors.New("project deletion returned blockers with deleted=true"))
+		}
+		return projectDeleteOutcome{Result: &projectDeleteResult{ProjectID: projectID}}
+	}
+	if len(response.Blockers) == 0 {
+		return projectDeleteFailure(projectID, "request_failed", errors.New("project deletion returned deleted=false without blockers"))
+	}
+	blockers, err := projectDeleteBlockersForCLI(response.Blockers)
+	if err != nil {
+		return projectDeleteFailure(projectID, "request_failed", err)
+	}
+	return projectDeleteOutcome{
+		Error: &projectDeleteError{
+			Code:      "project_delete_blocked",
+			Message:   "project deletion was blocked",
+			ProjectID: projectID,
+			Blockers:  blockers,
+		},
+	}
+}
+
+func projectDeleteHasUnfinishedWork(ctx context.Context, operations projectDeleteOperations, projectID string) (bool, error) {
+	projectID = strings.TrimSpace(projectID)
+	limit := 1
+	requestProjectID := projectID
+	response, err := operations.ListWorkflowTasks(ctx, serverapi.WorkflowTaskListRequest{
+		ProjectID:   &requestProjectID,
+		StatusKinds: projectDeleteUnfinishedTaskStatuses(),
+		LabelFilter: serverapi.WorkflowTaskLabelFilterNone(),
+		Limit:       &limit,
+	})
+	if err != nil {
+		var scopeErr *serverapi.WorkflowTaskListScopeError
+		if errors.As(err, &scopeErr) &&
+			scopeErr.Reason == serverapi.WorkflowTaskListScopeReasonNoLinkedWorkflows &&
+			scopeErr.ProjectID != nil &&
+			*scopeErr.ProjectID == projectID &&
+			scopeErr.WorkflowID == nil {
+			return false, nil
+		}
+		return false, err
+	}
+	if response.Scope.ProjectID != projectID || response.Scope.WorkflowID != nil {
+		return false, errors.New("project deletion task preflight returned an unexpected scope")
+	}
+	if len(response.Tasks) > 1 {
+		return false, errors.New("project deletion task preflight returned too many tasks")
+	}
+	if len(response.Tasks) == 0 {
+		return false, nil
+	}
+	task := response.Tasks[0]
+	expectedNativeState, valid := task.Status.Kind.NativeState()
+	if !valid || task.Status.Kind == serverapi.WorkflowTaskStatusKindDone ||
+		task.Status.NativeState == serverapi.WorkflowTaskNativeStateTerminal ||
+		task.Status.NativeState != expectedNativeState {
+		return false, errors.New("project deletion task preflight returned an invalid task status")
+	}
+	return true, nil
+}
+
+func projectDeleteUnfinishedTaskStatuses() []serverapi.WorkflowTaskStatusKind {
+	return []serverapi.WorkflowTaskStatusKind{
+		serverapi.WorkflowTaskStatusKindWaitingQuestion,
+		serverapi.WorkflowTaskStatusKindWaitingApproval,
+		serverapi.WorkflowTaskStatusKindInterrupted,
+		serverapi.WorkflowTaskStatusKindRunning,
+		serverapi.WorkflowTaskStatusKindQueued,
+		serverapi.WorkflowTaskStatusKindBacklog,
+		serverapi.WorkflowTaskStatusKindActive,
+	}
+}
+
+func projectDeleteFailure(projectID string, code string, err error) projectDeleteOutcome {
+	return projectDeleteOutcome{
+		Error: &projectDeleteError{
+			Code:      code,
+			Message:   err.Error(),
+			ProjectID: projectID,
+		},
+	}
+}
+
+func projectDeleteErrorCode(err error) string {
+	if errors.Is(err, serverapi.ErrProjectNotFound) {
+		return "project_not_found"
+	}
+	return "request_failed"
+}
+
+func projectDeleteBlockersForCLI(blockers []serverapi.ProjectDeleteBlocker) ([]projectDeleteBlocker, error) {
+	output := make([]projectDeleteBlocker, 0, len(blockers))
+	for _, blocker := range blockers {
+		if strings.TrimSpace(blocker.Code) == "" || strings.TrimSpace(blocker.Message) == "" {
+			return nil, errors.New("project deletion returned an incomplete blocker")
+		}
+		if blocker.Count < 0 {
+			return nil, errors.New("project deletion returned a negative blocker count")
+		}
+		var count *int
+		if blocker.Count > 0 {
+			value := blocker.Count
+			count = &value
+		}
+		output = append(output, projectDeleteBlocker{
+			Code:    blocker.Code,
+			Message: blocker.Message,
+			Count:   count,
+		})
+	}
+	return output, nil
+}
+
+func writeProjectDeleteOutcome(stdout io.Writer, stderr io.Writer, outcome projectDeleteOutcome, jsonOut bool) int {
+	if err := outcome.validate(); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if outcome.Error != nil {
+		if jsonOut {
+			envelope := projectDeleteJSONEnvelope{
+				Status: "error",
+				Error: &projectDeleteJSONError{
+					Code:      outcome.Error.Code,
+					Message:   outcome.Error.Message,
+					ProjectID: outcome.Error.ProjectID,
+					Blockers:  outcome.Error.Blockers,
+				},
+			}
+			if err := envelope.validate(); err != nil {
+				fmt.Fprintln(stderr, err)
+				return 1
+			}
+			if exitCode := writeCommandJSON(stdout, stderr, envelope); exitCode != 0 {
+				return exitCode
+			}
+			return 1
+		}
+		for _, blocker := range outcome.Error.Blockers {
+			count := int64(0)
+			if blocker.Count != nil {
+				count = int64(*blocker.Count)
+			}
+			writeWorkflowBlockerLine(stderr, blocker.Code, blocker.Message, count)
+		}
+		fmt.Fprintln(stderr, outcome.Error.Message)
+		return 1
+	}
+	if jsonOut {
+		envelope := projectDeleteJSONEnvelope{
+			Status: "ok",
+			Result: outcome.Result,
+		}
+		if err := envelope.validate(); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return writeCommandJSON(stdout, stderr, envelope)
+	}
+	fmt.Fprintf(stdout, "Deleted project %s. Workspace files were not deleted.\n", outcome.Result.ProjectID)
+	return 0
+}
+
+func (outcome projectDeleteOutcome) validate() error {
+	if (outcome.Result == nil) == (outcome.Error == nil) {
+		return errors.New("project deletion outcome must contain exactly one result or error")
+	}
+	if outcome.Result != nil && strings.TrimSpace(outcome.Result.ProjectID) == "" {
+		return errors.New("project deletion result requires a project id")
+	}
+	if outcome.Error != nil && strings.TrimSpace(outcome.Error.ProjectID) == "" {
+		return errors.New("project deletion error requires a project id")
+	}
+	return nil
+}
+
+func (envelope projectDeleteJSONEnvelope) validate() error {
+	switch envelope.Status {
+	case "ok":
+		if envelope.Result == nil || envelope.Error != nil || strings.TrimSpace(envelope.Result.ProjectID) == "" {
+			return errors.New("project deletion success envelope is invalid")
+		}
+	case "error":
+		if envelope.Error == nil || envelope.Result != nil ||
+			strings.TrimSpace(envelope.Error.Code) == "" ||
+			strings.TrimSpace(envelope.Error.Message) == "" ||
+			strings.TrimSpace(envelope.Error.ProjectID) == "" {
+			return errors.New("project deletion error envelope is invalid")
+		}
+		if envelope.Error.Code == "project_delete_blocked" && len(envelope.Error.Blockers) == 0 {
+			return errors.New("project deletion blocked envelope requires blockers")
+		}
+		if envelope.Error.Code != "project_delete_blocked" && len(envelope.Error.Blockers) != 0 {
+			return errors.New("project deletion non-blocked envelope must omit blockers")
+		}
+		for _, blocker := range envelope.Error.Blockers {
+			if strings.TrimSpace(blocker.Code) == "" || strings.TrimSpace(blocker.Message) == "" {
+				return errors.New("project deletion error envelope blocker is invalid")
+			}
+			if blocker.Count != nil && *blocker.Count <= 0 {
+				return errors.New("project deletion error envelope blocker count is invalid")
+			}
+		}
+	default:
+		return errors.New("project deletion envelope status is invalid")
+	}
+	return nil
+}
+
+var _ projectDeleteOperations = (*client.Remote)(nil)

--- a/cli/kent/project_delete_command_test.go
+++ b/cli/kent/project_delete_command_test.go
@@ -354,6 +354,24 @@ func TestProjectDeletePlainOutputUsesExpectedStreams(t *testing.T) {
 	}
 }
 
+func TestProjectDeletePlainBlockerRenderingPreservesOptionalCount(t *testing.T) {
+	var withoutCount bytes.Buffer
+	writeWorkflowBlockerLine(&withoutCount, "blocked", "message", projectDeleteBlockerCount(nil))
+
+	positive := 2
+	var withCount bytes.Buffer
+	writeWorkflowBlockerLine(&withCount, "blocked", "message", projectDeleteBlockerCount(&positive))
+
+	if withoutCount.Len() == 0 || withCount.Len() <= withoutCount.Len() || bytes.Equal(withoutCount.Bytes(), withCount.Bytes()) {
+		t.Fatalf("plain blocker outputs have unexpected count shapes: absent=%q positive=%q", withoutCount.String(), withCount.String())
+	}
+	for _, nonpositive := range []int{0, -1} {
+		if count := projectDeleteBlockerCount(&nonpositive); count != nil {
+			t.Fatalf("count %d projected as present: %v", nonpositive, *count)
+		}
+	}
+}
+
 func TestProjectDeleteRejectsNegativeServerBlockerCount(t *testing.T) {
 	const projectID = "project-123"
 	remote := &projectDeleteTestOperations{

--- a/cli/kent/project_delete_command_test.go
+++ b/cli/kent/project_delete_command_test.go
@@ -356,18 +356,47 @@ func TestProjectDeletePlainOutputUsesExpectedStreams(t *testing.T) {
 
 func TestProjectDeletePlainBlockerRenderingPreservesOptionalCount(t *testing.T) {
 	var withoutCount bytes.Buffer
-	writeWorkflowBlockerLine(&withoutCount, "blocked", "message", projectDeleteBlockerCount(nil))
+	absent, err := projectDeleteBlockerCount(nil)
+	if err != nil {
+		t.Fatalf("absent count rejected: %v", err)
+	}
+	writeWorkflowBlockerLine(&withoutCount, "blocked", "message", absent)
 
 	positive := 2
 	var withCount bytes.Buffer
-	writeWorkflowBlockerLine(&withCount, "blocked", "message", projectDeleteBlockerCount(&positive))
+	present, err := projectDeleteBlockerCount(&positive)
+	if err != nil {
+		t.Fatalf("positive count rejected: %v", err)
+	}
+	writeWorkflowBlockerLine(&withCount, "blocked", "message", present)
 
 	if withoutCount.Len() == 0 || withCount.Len() <= withoutCount.Len() || bytes.Equal(withoutCount.Bytes(), withCount.Bytes()) {
 		t.Fatalf("plain blocker outputs have unexpected count shapes: absent=%q positive=%q", withoutCount.String(), withCount.String())
 	}
+}
+
+func TestProjectDeletePlainOutputRejectsInvalidPresentBlockerCounts(t *testing.T) {
+	const projectID = "project-123"
 	for _, nonpositive := range []int{0, -1} {
-		if count := projectDeleteBlockerCount(&nonpositive); count != nil {
-			t.Fatalf("count %d projected as present: %v", nonpositive, *count)
+		outcome := projectDeleteOutcome{
+			Error: &projectDeleteError{
+				Code:      "project_delete_blocked",
+				Message:   "blocked",
+				ProjectID: projectID,
+				Blockers: []projectDeleteBlocker{{
+					Code:    "blocked",
+					Message: "message",
+					Count:   &nonpositive,
+				}},
+			},
+		}
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		if exitCode := writeProjectDeleteOutcome(&stdout, &stderr, outcome, false); exitCode != 1 {
+			t.Fatalf("count %d exit code = %d, want 1", nonpositive, exitCode)
+		}
+		if stdout.Len() != 0 || stderr.Len() == 0 {
+			t.Fatalf("count %d streams = stdout %q stderr %q, want diagnostic-only failure", nonpositive, stdout.String(), stderr.String())
 		}
 	}
 }

--- a/cli/kent/project_delete_command_test.go
+++ b/cli/kent/project_delete_command_test.go
@@ -1,0 +1,573 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"core/shared/config"
+	"core/shared/runtimeids"
+	"core/shared/serverapi"
+)
+
+type projectDeleteTestOperations struct {
+	listResponse   serverapi.WorkflowTaskListResponse
+	listErr        error
+	deleteResponse serverapi.ProjectDeleteResponse
+	deleteErr      error
+	listRequests   []serverapi.WorkflowTaskListRequest
+	deleteRequests []serverapi.ProjectDeleteRequest
+}
+
+func (r *projectDeleteTestOperations) ListWorkflowTasks(_ context.Context, req serverapi.WorkflowTaskListRequest) (serverapi.WorkflowTaskListResponse, error) {
+	r.listRequests = append(r.listRequests, req)
+	return r.listResponse, r.listErr
+}
+
+func (r *projectDeleteTestOperations) DeleteProject(_ context.Context, req serverapi.ProjectDeleteRequest) (serverapi.ProjectDeleteResponse, error) {
+	r.deleteRequests = append(r.deleteRequests, req)
+	return r.deleteResponse, r.deleteErr
+}
+
+func TestProjectDeleteWithoutConfirmPreflightsAndReturnsJSONError(t *testing.T) {
+	const projectID = "project-123"
+	remote := &projectDeleteTestOperations{
+		listResponse: serverapi.WorkflowTaskListResponse{
+			Scope: serverapi.WorkflowTaskListScope{ProjectID: projectID},
+			Tasks: []serverapi.WorkflowTaskListItem{},
+		},
+	}
+
+	outcome := runProjectDeleteUseCase(context.Background(), remote, projectID, false, false)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if exitCode := writeProjectDeleteOutcome(&stdout, &stderr, outcome, true); exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1; stderr=%q", exitCode, stderr.String())
+	}
+	if len(remote.listRequests) != 1 {
+		t.Fatalf("list requests = %d, want 1", len(remote.listRequests))
+	}
+	if len(remote.deleteRequests) != 0 {
+		t.Fatalf("delete requests = %d, want 0", len(remote.deleteRequests))
+	}
+	var envelope struct {
+		Status string `json:"status"`
+		Error  struct {
+			Code      string `json:"code"`
+			ProjectID string `json:"project_id"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode output: %v; output=%q", err, stdout.String())
+	}
+	if envelope.Status != "error" ||
+		envelope.Error.Code != "confirmation_required" ||
+		envelope.Error.ProjectID != projectID {
+		t.Fatalf("envelope = %+v, want confirmation error for %q", envelope, projectID)
+	}
+}
+
+func TestProjectDeleteHelpDispatchesExplicitly(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if exitCode := projectSubcommand([]string{"delete", "--help"}, &stdout, &stderr); exitCode != 0 {
+		t.Fatalf("exit code = %d; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() == 0 {
+		t.Fatal("help output is empty")
+	}
+}
+
+func TestProjectDeleteOutcomeRejectsAmbiguousSuccessState(t *testing.T) {
+	tests := []projectDeleteOutcome{
+		{},
+		{
+			Result: &projectDeleteResult{ProjectID: "project-123"},
+			Error:  &projectDeleteError{Code: "request_failed", Message: "failed", ProjectID: "project-123"},
+		},
+	}
+	for index, outcome := range tests {
+		t.Run(fmt.Sprintf("case-%d", index), func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			if exitCode := writeProjectDeleteOutcome(&stdout, &stderr, outcome, false); exitCode != 1 {
+				t.Fatalf("exit code = %d, want 1", exitCode)
+			}
+			if stdout.Len() != 0 || stderr.Len() == 0 {
+				t.Fatalf("streams = stdout %q stderr %q, want diagnostic-only failure", stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+func TestProjectDeleteAgentWithBacklogIsDeniedBeforeConfirmation(t *testing.T) {
+	const projectID = "project-123"
+	remote := &projectDeleteTestOperations{
+		listResponse: projectDeleteTaskListResponse(projectID, serverapi.WorkflowTaskStatus{
+			Kind:        serverapi.WorkflowTaskStatusKindBacklog,
+			NativeState: serverapi.WorkflowTaskNativeStateActive,
+		}),
+	}
+
+	outcome := runProjectDeleteUseCase(context.Background(), remote, projectID, false, true)
+
+	assertProjectDeleteFailure(t, outcome, "human_only_unfinished_work", projectID)
+	if len(remote.deleteRequests) != 0 {
+		t.Fatalf("delete requests = %d, want 0", len(remote.deleteRequests))
+	}
+	assertProjectDeletePreflightRequest(t, remote.listRequests)
+}
+
+func TestProjectDeleteHumanWithBacklogContinuesToConfirmation(t *testing.T) {
+	const projectID = "project-123"
+	remote := &projectDeleteTestOperations{
+		listResponse: projectDeleteTaskListResponse(projectID, serverapi.WorkflowTaskStatus{
+			Kind:        serverapi.WorkflowTaskStatusKindBacklog,
+			NativeState: serverapi.WorkflowTaskNativeStateActive,
+		}),
+	}
+
+	outcome := runProjectDeleteUseCase(context.Background(), remote, projectID, false, false)
+
+	assertProjectDeleteFailure(t, outcome, "confirmation_required", projectID)
+	if len(remote.deleteRequests) != 0 {
+		t.Fatalf("delete requests = %d, want 0", len(remote.deleteRequests))
+	}
+}
+
+func TestProjectDeleteAgentWithoutUnfinishedWorkContinuesToConfirmation(t *testing.T) {
+	const projectID = "project-123"
+	remote := &projectDeleteTestOperations{
+		listResponse: projectDeleteTaskListResponse(projectID),
+	}
+
+	outcome := runProjectDeleteUseCase(context.Background(), remote, projectID, false, true)
+
+	assertProjectDeleteFailure(t, outcome, "confirmation_required", projectID)
+}
+
+func TestProjectDeleteTreatsCorrectlyScopedNoLinkedWorkflowsAsEmpty(t *testing.T) {
+	const projectID = "project-123"
+	remote := &projectDeleteTestOperations{
+		listErr: &serverapi.WorkflowTaskListScopeError{
+			Reason:    serverapi.WorkflowTaskListScopeReasonNoLinkedWorkflows,
+			ProjectID: stringPointer(projectID),
+		},
+	}
+
+	outcome := runProjectDeleteUseCase(context.Background(), remote, projectID, false, true)
+
+	assertProjectDeleteFailure(t, outcome, "confirmation_required", projectID)
+}
+
+func TestProjectDeleteRejectsInvalidPreflightScopesAndStatuses(t *testing.T) {
+	const projectID = "project-123"
+	tests := []struct {
+		name     string
+		response serverapi.WorkflowTaskListResponse
+		err      error
+	}{
+		{
+			name: "mismatched project",
+			response: serverapi.WorkflowTaskListResponse{
+				Scope: serverapi.WorkflowTaskListScope{ProjectID: "other-project"},
+			},
+		},
+		{
+			name: "workflow scope",
+			response: serverapi.WorkflowTaskListResponse{
+				Scope: serverapi.WorkflowTaskListScope{
+					ProjectID:  projectID,
+					WorkflowID: workflowIDPointer(t),
+				},
+			},
+		},
+		{
+			name: "terminal task",
+			response: projectDeleteTaskListResponse(projectID, serverapi.WorkflowTaskStatus{
+				Kind:        serverapi.WorkflowTaskStatusKindDone,
+				NativeState: serverapi.WorkflowTaskNativeStateTerminal,
+			}),
+		},
+		{
+			name: "malformed status",
+			response: projectDeleteTaskListResponse(projectID, serverapi.WorkflowTaskStatus{
+				Kind:        "unknown",
+				NativeState: serverapi.WorkflowTaskNativeStateActive,
+			}),
+		},
+		{
+			name: "workflow scoped no links",
+			err: &serverapi.WorkflowTaskListScopeError{
+				Reason:     serverapi.WorkflowTaskListScopeReasonNoLinkedWorkflows,
+				ProjectID:  stringPointer(projectID),
+				WorkflowID: workflowIDPointer(t),
+			},
+		},
+		{
+			name: "transport failure",
+			err:  errors.New("preflight failed"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			remote := &projectDeleteTestOperations{listResponse: test.response, listErr: test.err}
+			outcome := runProjectDeleteUseCase(context.Background(), remote, projectID, true, false)
+			assertProjectDeleteFailure(t, outcome, "request_failed", projectID)
+			if len(remote.deleteRequests) != 0 {
+				t.Fatalf("delete requests = %d, want 0", len(remote.deleteRequests))
+			}
+		})
+	}
+}
+
+func TestProjectDeleteConfirmedSuccessCallsDeleteOnceAndProjectsJSON(t *testing.T) {
+	const projectID = "project-123"
+	remote := &projectDeleteTestOperations{
+		listResponse: projectDeleteTaskListResponse(projectID),
+		deleteResponse: serverapi.ProjectDeleteResponse{
+			ProjectID: projectID,
+			Deleted:   true,
+		},
+	}
+
+	outcome := runProjectDeleteUseCase(context.Background(), remote, projectID, true, false)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if exitCode := writeProjectDeleteOutcome(&stdout, &stderr, outcome, true); exitCode != 0 {
+		t.Fatalf("exit code = %d; stderr=%q", exitCode, stderr.String())
+	}
+	if len(remote.listRequests) != 1 || len(remote.deleteRequests) != 1 {
+		t.Fatalf("requests = list %d, delete %d; want one each", len(remote.listRequests), len(remote.deleteRequests))
+	}
+	if remote.deleteRequests[0].ProjectID != projectID {
+		t.Fatalf("delete project id = %q, want %q", remote.deleteRequests[0].ProjectID, projectID)
+	}
+	var envelope struct {
+		Status string `json:"status"`
+		Result struct {
+			ProjectID string `json:"project_id"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode output: %v; output=%q", err, stdout.String())
+	}
+	if envelope.Status != "ok" || envelope.Result.ProjectID != projectID {
+		t.Fatalf("envelope = %+v, want successful project result", envelope)
+	}
+}
+
+func TestProjectDeleteProjectsServerBlockersInOrderWithTypedCounts(t *testing.T) {
+	const projectID = "project-123"
+	remote := &projectDeleteTestOperations{
+		listResponse: projectDeleteTaskListResponse(projectID),
+		deleteResponse: serverapi.ProjectDeleteResponse{
+			ProjectID: projectID,
+			Blockers: []serverapi.ProjectDeleteBlocker{
+				{Code: "first", Message: "first blocker"},
+				{Code: "second", Message: "second blocker", Count: 3},
+			},
+		},
+	}
+
+	outcome := runProjectDeleteUseCase(context.Background(), remote, projectID, true, false)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if exitCode := writeProjectDeleteOutcome(&stdout, &stderr, outcome, true); exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1; stderr=%q", exitCode, stderr.String())
+	}
+	var envelope struct {
+		Status string `json:"status"`
+		Error  struct {
+			Code      string `json:"code"`
+			ProjectID string `json:"project_id"`
+			Blockers  []struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+				Count   *int   `json:"count,omitempty"`
+			} `json:"blockers"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode output: %v; output=%q", err, stdout.String())
+	}
+	if envelope.Status != "error" || envelope.Error.Code != "project_delete_blocked" ||
+		envelope.Error.ProjectID != projectID || len(envelope.Error.Blockers) != 2 {
+		t.Fatalf("envelope = %+v, want ordered blockers", envelope)
+	}
+	if envelope.Error.Blockers[0].Code != "first" || envelope.Error.Blockers[0].Count != nil ||
+		envelope.Error.Blockers[1].Code != "second" || envelope.Error.Blockers[1].Count == nil ||
+		*envelope.Error.Blockers[1].Count != 3 {
+		t.Fatalf("blockers = %+v, want absent zero and positive count", envelope.Error.Blockers)
+	}
+}
+
+func TestProjectDeletePlainOutputUsesExpectedStreams(t *testing.T) {
+	const projectID = "project-123"
+	success := runProjectDeleteUseCase(
+		context.Background(),
+		&projectDeleteTestOperations{
+			listResponse:   projectDeleteTaskListResponse(projectID),
+			deleteResponse: serverapi.ProjectDeleteResponse{ProjectID: projectID, Deleted: true},
+		},
+		projectID,
+		true,
+		false,
+	)
+	var successStdout bytes.Buffer
+	var successStderr bytes.Buffer
+	if exitCode := writeProjectDeleteOutcome(&successStdout, &successStderr, success, false); exitCode != 0 {
+		t.Fatalf("success exit code = %d; stderr=%q", exitCode, successStderr.String())
+	}
+	if successStdout.Len() == 0 || successStderr.Len() != 0 {
+		t.Fatalf("success streams = stdout %q stderr %q", successStdout.String(), successStderr.String())
+	}
+
+	blocked := runProjectDeleteUseCase(
+		context.Background(),
+		&projectDeleteTestOperations{
+			listResponse: projectDeleteTaskListResponse(projectID),
+			deleteResponse: serverapi.ProjectDeleteResponse{
+				ProjectID: projectID,
+				Blockers:  []serverapi.ProjectDeleteBlocker{{Code: "blocked", Message: "blocked", Count: 2}},
+			},
+		},
+		projectID,
+		true,
+		false,
+	)
+	var blockedStdout bytes.Buffer
+	var blockedStderr bytes.Buffer
+	if exitCode := writeProjectDeleteOutcome(&blockedStdout, &blockedStderr, blocked, false); exitCode != 1 {
+		t.Fatalf("blocked exit code = %d, want 1", exitCode)
+	}
+	if blockedStdout.Len() != 0 || blockedStderr.Len() == 0 {
+		t.Fatalf("blocked streams = stdout %q stderr %q", blockedStdout.String(), blockedStderr.String())
+	}
+}
+
+func TestProjectDeleteRejectsNegativeServerBlockerCount(t *testing.T) {
+	const projectID = "project-123"
+	remote := &projectDeleteTestOperations{
+		listResponse: projectDeleteTaskListResponse(projectID),
+		deleteResponse: serverapi.ProjectDeleteResponse{
+			ProjectID: projectID,
+			Blockers: []serverapi.ProjectDeleteBlocker{
+				{Code: "invalid", Message: "invalid blocker", Count: -1},
+			},
+		},
+	}
+
+	outcome := runProjectDeleteUseCase(context.Background(), remote, projectID, true, false)
+
+	assertProjectDeleteFailure(t, outcome, "request_failed", projectID)
+}
+
+func TestProjectDeleteMapsNotFoundAndDeleteFailures(t *testing.T) {
+	const projectID = "project-123"
+	tests := []struct {
+		name string
+		err  error
+		code string
+	}{
+		{name: "not found", err: serverapi.ErrProjectNotFound, code: "project_not_found"},
+		{name: "request failure", err: errors.New("delete failed"), code: "request_failed"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			remote := &projectDeleteTestOperations{
+				listResponse: projectDeleteTaskListResponse(projectID),
+				deleteErr:    test.err,
+			}
+			outcome := runProjectDeleteUseCase(context.Background(), remote, projectID, true, false)
+			assertProjectDeleteFailure(t, outcome, test.code, projectID)
+			if len(remote.listRequests) != 1 || len(remote.deleteRequests) != 1 {
+				t.Fatalf("requests = list %d, delete %d; want one each", len(remote.listRequests), len(remote.deleteRequests))
+			}
+		})
+	}
+}
+
+func TestProjectDeleteMapsPreflightNotFound(t *testing.T) {
+	const projectID = "project-123"
+	remote := &projectDeleteTestOperations{
+		listErr: serverapi.ErrProjectNotFound,
+	}
+
+	outcome := runProjectDeleteUseCase(context.Background(), remote, projectID, true, false)
+
+	assertProjectDeleteFailure(t, outcome, "project_not_found", projectID)
+	if len(remote.deleteRequests) != 0 {
+		t.Fatalf("delete requests = %d, want 0", len(remote.deleteRequests))
+	}
+}
+
+func TestProjectDeleteRejectsMalformedDeleteResponses(t *testing.T) {
+	const projectID = "project-123"
+	tests := []struct {
+		name     string
+		response serverapi.ProjectDeleteResponse
+	}{
+		{
+			name: "mismatched identity",
+			response: serverapi.ProjectDeleteResponse{
+				ProjectID: "other-project",
+				Deleted:   true,
+			},
+		},
+		{
+			name: "deleted with blockers",
+			response: serverapi.ProjectDeleteResponse{
+				ProjectID: projectID,
+				Deleted:   true,
+				Blockers: []serverapi.ProjectDeleteBlocker{
+					{Code: "blocker", Message: "blocker"},
+				},
+			},
+		},
+		{
+			name: "not deleted without blockers",
+			response: serverapi.ProjectDeleteResponse{
+				ProjectID: projectID,
+			},
+		},
+		{
+			name: "blank blocker code",
+			response: serverapi.ProjectDeleteResponse{
+				ProjectID: projectID,
+				Blockers: []serverapi.ProjectDeleteBlocker{
+					{Message: "blocker"},
+				},
+			},
+		},
+		{
+			name: "blank blocker message",
+			response: serverapi.ProjectDeleteResponse{
+				ProjectID: projectID,
+				Blockers: []serverapi.ProjectDeleteBlocker{
+					{Code: "blocker"},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			remote := &projectDeleteTestOperations{
+				listResponse:   projectDeleteTaskListResponse(projectID),
+				deleteResponse: test.response,
+			}
+			outcome := runProjectDeleteUseCase(context.Background(), remote, projectID, true, false)
+			assertProjectDeleteFailure(t, outcome, "request_failed", projectID)
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			if exitCode := writeProjectDeleteOutcome(&stdout, &stderr, outcome, true); exitCode != 1 {
+				t.Fatalf("exit code = %d, want 1", exitCode)
+			}
+			var envelope struct {
+				Status string `json:"status"`
+				Error  struct {
+					Code      string `json:"code"`
+					ProjectID string `json:"project_id"`
+					Blockers  []any  `json:"blockers"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+				t.Fatalf("decode output: %v; output=%q", err, stdout.String())
+			}
+			if envelope.Error.ProjectID != projectID || envelope.Error.Code != "request_failed" || envelope.Error.Blockers != nil {
+				t.Fatalf("envelope = %+v, want request_failed with project id and no blockers", envelope)
+			}
+		})
+	}
+}
+
+func TestProjectDeleteOpenerFailureUsesOperationalJSONEnvelope(t *testing.T) {
+	persistenceRoot := t.TempDir()
+	workspaceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(persistenceRoot, "config.toml"), []byte("server_host = \"127.0.0.1\"\nserver_port = 1\n"), 0o600); err != nil {
+		t.Fatalf("write isolated config: %v", err)
+	}
+	t.Setenv(config.PersistenceRootEnvName, persistenceRoot)
+	t.Chdir(workspaceRoot)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if exitCode := projectDeleteSubcommand([]string{"project-123", "--json"}, &stdout, &stderr); exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1; stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+	var envelope struct {
+		Status string `json:"status"`
+		Error  struct {
+			Code      string `json:"code"`
+			ProjectID string `json:"project_id"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode output: %v; output=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if envelope.Status != "error" || envelope.Error.Code != "request_failed" || envelope.Error.ProjectID != "project-123" {
+		t.Fatalf("envelope = %+v, want request_failed for requested project", envelope)
+	}
+}
+
+func projectDeleteTaskListResponse(projectID string, statuses ...serverapi.WorkflowTaskStatus) serverapi.WorkflowTaskListResponse {
+	response := serverapi.WorkflowTaskListResponse{
+		Scope: serverapi.WorkflowTaskListScope{ProjectID: projectID},
+	}
+	for _, status := range statuses {
+		response.Tasks = append(response.Tasks, serverapi.WorkflowTaskListItem{Status: status})
+	}
+	return response
+}
+
+func assertProjectDeleteFailure(t *testing.T, outcome projectDeleteOutcome, code string, projectID string) {
+	t.Helper()
+	if outcome.Result != nil || outcome.Error == nil {
+		t.Fatalf("outcome = %+v, want failure", outcome)
+	}
+	if outcome.Error.Code != code || outcome.Error.ProjectID != projectID {
+		t.Fatalf("error = %+v, want code %q and project %q", outcome.Error, code, projectID)
+	}
+}
+
+func assertProjectDeletePreflightRequest(t *testing.T, requests []serverapi.WorkflowTaskListRequest) {
+	t.Helper()
+	if len(requests) != 1 {
+		t.Fatalf("preflight requests = %d, want 1", len(requests))
+	}
+	request := requests[0]
+	if request.ProjectID == nil || *request.ProjectID != "project-123" {
+		t.Fatalf("project id = %v, want project-123", request.ProjectID)
+	}
+	limit := 1
+	if request.Limit == nil || *request.Limit != limit {
+		t.Fatalf("limit = %v, want %d", request.Limit, limit)
+	}
+	if request.WorkflowID != nil || len(request.ColumnKeys) != 0 || len(request.AttentionKinds) != 0 ||
+		len(request.Sort) != 0 || request.Offset != nil ||
+		request.LabelFilter.Kind != serverapi.WorkflowTaskLabelFilterKindNone ||
+		request.LabelFilter.Named != nil {
+		t.Fatalf("request filters = %+v, want project-wide unfiltered existence query", request)
+	}
+	if !slices.Equal(request.StatusKinds, projectDeleteUnfinishedTaskStatuses()) {
+		t.Fatalf("status kinds = %v, want %v", request.StatusKinds, projectDeleteUnfinishedTaskStatuses())
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+func workflowIDPointer(t *testing.T) *runtimeids.WorkflowID {
+	t.Helper()
+	value := runtimeids.NewWorkflowID()
+	return &value
+}

--- a/cli/kent/project_delete_command_test.go
+++ b/cli/kent/project_delete_command_test.go
@@ -354,6 +354,19 @@ func TestProjectDeletePlainOutputUsesExpectedStreams(t *testing.T) {
 	}
 }
 
+func TestProjectDeletePlainOutputFailureReturnsNonZero(t *testing.T) {
+	outcome := projectDeleteOutcome{
+		Result: &projectDeleteResult{ProjectID: "project-123"},
+	}
+	var stderr bytes.Buffer
+	if exitCode := writeProjectDeleteOutcome(bindingMutationFailingWriter{}, &stderr, outcome, false); exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1", exitCode)
+	}
+	if stderr.Len() == 0 {
+		t.Fatal("stderr is empty, want write diagnostic")
+	}
+}
+
 func TestProjectDeletePlainBlockerRenderingPreservesOptionalCount(t *testing.T) {
 	var withoutCount bytes.Buffer
 	absent, err := projectDeleteBlockerCount(nil)

--- a/cli/kent/task_policy.go
+++ b/cli/kent/task_policy.go
@@ -9,13 +9,8 @@ import (
 	"core/shared/sessionenv"
 )
 
-func isAgentShell() bool {
-	_, ok := sessionenv.LookupSessionID(os.LookupEnv)
-	return ok
-}
-
 func denyAgentHumanOnlyTaskAction(stderr io.Writer) bool {
-	if !isAgentShell() {
+	if _, ok := sessionenv.LookupSessionID(os.LookupEnv); !ok {
 		return false
 	}
 	fmt.Fprintln(stderr, prompts.WorkflowHumanOnlyTaskActionDeniedPrompt)

--- a/cli/kent/task_policy.go
+++ b/cli/kent/task_policy.go
@@ -9,8 +9,13 @@ import (
 	"core/shared/sessionenv"
 )
 
+func isAgentShell() bool {
+	_, ok := sessionenv.LookupSessionID(os.LookupEnv)
+	return ok
+}
+
 func denyAgentHumanOnlyTaskAction(stderr io.Writer) bool {
-	if _, ok := sessionenv.LookupSessionID(os.LookupEnv); !ok {
+	if !isAgentShell() {
 		return false
 	}
 	fmt.Fprintln(stderr, prompts.WorkflowHumanOnlyTaskActionDeniedPrompt)

--- a/cli/kent/workflow_command.go
+++ b/cli/kent/workflow_command.go
@@ -1416,19 +1416,27 @@ func writeWorkflowUnlinkBlockers(stderr io.Writer, blockers []serverapi.Workflow
 	}
 	fmt.Fprintln(stderr, "Cannot unlink; resolve these blockers first:")
 	for _, blocker := range blockers {
-		writeWorkflowBlockerLine(stderr, blocker.Code, blocker.Message, int64(blocker.Count))
+		writeWorkflowBlockerLine(stderr, blocker.Code, blocker.Message, workflowBlockerCount(blocker.Count))
 		for _, task := range blocker.Tasks {
 			fmt.Fprintf(stderr, "    %s: %s\n", task.ShortID, task.Title)
 		}
 	}
 }
 
-func writeWorkflowBlockerLine(w io.Writer, code string, message string, count int64) {
-	if count > 0 {
-		fmt.Fprintf(w, "- [%s] %s (%d)\n", code, message, count)
+func writeWorkflowBlockerLine(w io.Writer, code string, message string, count *int64) {
+	if count != nil {
+		fmt.Fprintf(w, "- [%s] %s (%d)\n", code, message, *count)
 		return
 	}
 	fmt.Fprintf(w, "- [%s] %s\n", code, message)
+}
+
+func workflowBlockerCount(count int) *int64 {
+	if count <= 0 {
+		return nil
+	}
+	value := int64(count)
+	return &value
 }
 
 func workflowDisplayNameFromKey(key string) string {

--- a/cli/kent/workflow_command.go
+++ b/cli/kent/workflow_command.go
@@ -1416,7 +1416,7 @@ func writeWorkflowUnlinkBlockers(stderr io.Writer, blockers []serverapi.Workflow
 	}
 	fmt.Fprintln(stderr, "Cannot unlink; resolve these blockers first:")
 	for _, blocker := range blockers {
-		writeWorkflowBlockerLine(stderr, blocker.Code, blocker.Message, workflowBlockerCount(blocker.Count))
+		writeWorkflowBlockerLine(stderr, blocker.Code, blocker.Message, workflowBlockerCount(int64(blocker.Count)))
 		for _, task := range blocker.Tasks {
 			fmt.Fprintf(stderr, "    %s: %s\n", task.ShortID, task.Title)
 		}
@@ -1431,12 +1431,11 @@ func writeWorkflowBlockerLine(w io.Writer, code string, message string, count *i
 	fmt.Fprintf(w, "- [%s] %s\n", code, message)
 }
 
-func workflowBlockerCount(count int) *int64 {
+func workflowBlockerCount(count int64) *int64 {
 	if count <= 0 {
 		return nil
 	}
-	value := int64(count)
-	return &value
+	return &count
 }
 
 func workflowDisplayNameFromKey(key string) string {

--- a/cli/kent/workflow_delete_command.go
+++ b/cli/kent/workflow_delete_command.go
@@ -87,7 +87,7 @@ func workflowDeleteSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 				writeWorkflowDeleteImpact(stdout, output.Impact)
 				fmt.Fprintln(stderr, "Workflow was not deleted; resolve these blockers first:")
 				for _, blocker := range output.Blockers {
-					writeWorkflowBlockerLine(stderr, blocker.Code, blocker.Message, blocker.Count)
+					writeWorkflowBlockerLine(stderr, blocker.Code, blocker.Message, workflowDeleteBlockerCount(blocker.Count))
 				}
 			}
 			return 1
@@ -97,6 +97,13 @@ func workflowDeleteSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 		}
 		return 0
 	})
+}
+
+func workflowDeleteBlockerCount(count int64) *int64 {
+	if count <= 0 {
+		return nil
+	}
+	return &count
 }
 
 func writeWorkflowDeleteImpact(w io.Writer, impact serverapi.WorkflowDeleteImpact) {

--- a/cli/kent/workflow_delete_command.go
+++ b/cli/kent/workflow_delete_command.go
@@ -87,7 +87,7 @@ func workflowDeleteSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 				writeWorkflowDeleteImpact(stdout, output.Impact)
 				fmt.Fprintln(stderr, "Workflow was not deleted; resolve these blockers first:")
 				for _, blocker := range output.Blockers {
-					writeWorkflowBlockerLine(stderr, blocker.Code, blocker.Message, workflowDeleteBlockerCount(blocker.Count))
+					writeWorkflowBlockerLine(stderr, blocker.Code, blocker.Message, workflowBlockerCount(blocker.Count))
 				}
 			}
 			return 1
@@ -97,13 +97,6 @@ func workflowDeleteSubcommand(args []string, stdout io.Writer, stderr io.Writer)
 		}
 		return 0
 	})
-}
-
-func workflowDeleteBlockerCount(count int64) *int64 {
-	if count <= 0 {
-		return nil
-	}
-	return &count
 }
 
 func writeWorkflowDeleteImpact(w io.Writer, impact serverapi.WorkflowDeleteImpact) {

--- a/docs/dev/specs/project-workspaces.md
+++ b/docs/dev/specs/project-workspaces.md
@@ -37,6 +37,34 @@
 - Mutation error objects contain only `code`, `message`, resolved Project/workspace IDs when resolution succeeded, bounded `blockers` when detach is blocked, and `retryable: true` for a concurrent detach conflict.
 - Canonical workspace roots are never included in mutation success or error JSON results.
 
+## CLI Project Deletion
+
+- `kent project delete <project-id>` selects a Project only by its canonical Project ID.
+- Project deletion never deletes or moves workspace files.
+- The server owns Project deletion and its blockers. The CLI never deletes Project data or workspace files directly.
+- Project deletion is non-interactive.
+- The CLI requires `--confirm` before it requests deletion.
+- Before checking confirmation, the CLI checks whether the Project contains any Task whose state is not terminal, including a Backlog Task.
+- If unfinished work exists and the command is running inside a Kent agent shell, the command is human-only and reports exactly `Project deletion is human-only because project <project-id> contains unfinished work.`
+- The unfinished-work check establishes only whether unfinished work exists. It does not count or list Tasks.
+- The unfinished-work check uses a command-time snapshot. A concurrent Task change can occur between that check and the deletion request.
+- If unfinished work appears after the snapshot, an agent's Project deletion may still complete. The CLI does not provide atomic human-only enforcement.
+- The server applies its authoritative deletion blockers when it processes the deletion request.
+- If confirmation is absent after the conditional human-only check permits the caller, the command makes no deletion request and reports exactly `Project deletion was not confirmed. Rerun with --confirm to delete project <project-id>.`
+- Successful plain output is exactly `Deleted project <project-id>. Workspace files were not deleted.`
+- Blocked plain output preserves every server blocker in server order with its code, message, and positive count when present. The CLI adds no blocker guidance.
+- A successful deletion exits with status 0.
+- Missing confirmation, conditional human-only denial, blocked deletion, Project lookup failure, and other operational failures exit with status 1.
+- Usage errors exit with status 2.
+- `--json` emits exactly one JSON object on stdout for every operational outcome after valid argument parsing.
+- Successful JSON uses `status: "ok"` and includes the canonical Project ID as `result.project_id`.
+- Failed JSON uses `status: "error"` and includes an `error` object with `code` and `message`.
+- Every failed JSON result after valid argument parsing includes the canonical requested Project ID as `error.project_id`.
+- A blocked JSON result includes every server blocker in server order at `error.blockers`.
+- Each JSON blocker preserves the server's `code` and `message`. It includes `count` only when the count is positive.
+- Non-blocked JSON errors omit `blockers`.
+- Stable Project deletion error codes are `confirmation_required`, `human_only_unfinished_work`, `project_not_found`, `project_delete_blocked`, and `request_failed`.
+
 ## CLI Detach
 
 - `kent detach` is the canonical detach command.

--- a/docs/dev/specs/project-workspaces.md
+++ b/docs/dev/specs/project-workspaces.md
@@ -37,34 +37,6 @@
 - Mutation error objects contain only `code`, `message`, resolved Project/workspace IDs when resolution succeeded, bounded `blockers` when detach is blocked, and `retryable: true` for a concurrent detach conflict.
 - Canonical workspace roots are never included in mutation success or error JSON results.
 
-## CLI Project Deletion
-
-- `kent project delete <project-id>` selects a Project only by its canonical Project ID.
-- Project deletion never deletes or moves workspace files.
-- The server owns Project deletion and its blockers. The CLI never deletes Project data or workspace files directly.
-- Project deletion is non-interactive.
-- The CLI requires `--confirm` before it requests deletion.
-- Before checking confirmation, the CLI checks whether the Project contains any Task whose state is not terminal, including a Backlog Task.
-- If unfinished work exists and the command is running inside a Kent agent shell, the command is human-only and reports exactly `Project deletion is human-only because project <project-id> contains unfinished work.`
-- The unfinished-work check establishes only whether unfinished work exists. It does not count or list Tasks.
-- The unfinished-work check uses a command-time snapshot. A concurrent Task change can occur between that check and the deletion request.
-- If unfinished work appears after the snapshot, an agent's Project deletion may still complete. The CLI does not provide atomic human-only enforcement.
-- The server applies its authoritative deletion blockers when it processes the deletion request.
-- If confirmation is absent after the conditional human-only check permits the caller, the command makes no deletion request and reports exactly `Project deletion was not confirmed. Rerun with --confirm to delete project <project-id>.`
-- Successful plain output is exactly `Deleted project <project-id>. Workspace files were not deleted.`
-- Blocked plain output preserves every server blocker in server order with its code, message, and positive count when present. The CLI adds no blocker guidance.
-- A successful deletion exits with status 0.
-- Missing confirmation, conditional human-only denial, blocked deletion, Project lookup failure, and other operational failures exit with status 1.
-- Usage errors exit with status 2.
-- `--json` emits exactly one JSON object on stdout for every operational outcome after valid argument parsing.
-- Successful JSON uses `status: "ok"` and includes the canonical Project ID as `result.project_id`.
-- Failed JSON uses `status: "error"` and includes an `error` object with `code` and `message`.
-- Every failed JSON result after valid argument parsing includes the canonical requested Project ID as `error.project_id`.
-- A blocked JSON result includes every server blocker in server order at `error.blockers`.
-- Each JSON blocker preserves the server's `code` and `message`. It includes `count` only when the count is positive.
-- Non-blocked JSON errors omit `blockers`.
-- Stable Project deletion error codes are `confirmation_required`, `human_only_unfinished_work`, `project_not_found`, `project_delete_blocked`, and `request_failed`.
-
 ## CLI Detach
 
 - `kent detach` is the canonical detach command.

--- a/docs/dev/specs/project-workspaces.md
+++ b/docs/dev/specs/project-workspaces.md
@@ -37,6 +37,30 @@
 - Mutation error objects contain only `code`, `message`, resolved Project/workspace IDs when resolution succeeded, bounded `blockers` when detach is blocked, and `retryable: true` for a concurrent detach conflict.
 - Canonical workspace roots are never included in mutation success or error JSON results.
 
+## CLI Project Deletion
+
+- `kent project delete <project-id>` selects a Project only by its canonical Project ID.
+- Project deletion never deletes or moves workspace files.
+- The server owns Project deletion and its blockers. The CLI never deletes Project data or workspace files directly.
+- Project deletion is non-interactive and requires `--confirm` before requesting deletion.
+- Before confirmation, the CLI checks whether the Project contains any Task whose state is not terminal, including a Backlog Task.
+- If unfinished work exists in a Kent agent shell, the command is human-only and reports exactly `Project deletion is human-only because project <project-id> contains unfinished work.`
+- Task state may change before deletion is processed; the server's deletion blockers remain authoritative.
+- If confirmation is absent after the conditional human-only check permits the caller, the command makes no deletion request and reports exactly `Project deletion was not confirmed. Rerun with --confirm to delete project <project-id>.`
+- Successful plain output is exactly `Deleted project <project-id>. Workspace files were not deleted.`
+- Blocked plain output preserves every server blocker in server order with its code, message, and positive count when present. The CLI adds no blocker guidance.
+- A successful deletion exits with status 0.
+- Missing confirmation, conditional human-only denial, blocked deletion, Project lookup failure, and other operational failures exit with status 1.
+- Usage errors exit with status 2.
+- `--json` emits exactly one JSON object on stdout for every operational outcome after valid argument parsing.
+- Successful JSON uses `status: "ok"` and includes the canonical Project ID as `result.project_id`.
+- Failed JSON uses `status: "error"` and includes an `error` object with `code` and `message`.
+- Every failed JSON result after valid argument parsing includes the canonical requested Project ID as `error.project_id`.
+- A blocked JSON result includes every server blocker in server order at `error.blockers`.
+- Each JSON blocker preserves the server's `code` and `message`. It includes `count` only when the count is positive.
+- Non-blocked JSON errors omit `blockers`.
+- Stable Project deletion error codes are `confirmation_required`, `human_only_unfinished_work`, `project_not_found`, `project_delete_blocked`, and `request_failed`.
+
 ## CLI Detach
 
 - `kent detach` is the canonical detach command.

--- a/docs/src/content/docs/headless.md
+++ b/docs/src/content/docs/headless.md
@@ -122,6 +122,22 @@ Detach blockers use these recovery actions:
 - `managed_owned_worktrees`: delete dependent worktrees or their quiescent owning Tasks, then retry.
 - `missing_history_snapshot`: re-save the editable Task's source workspace; keep the binding if its history cannot be edited.
 
+### Project deletion
+
+Delete a Project by its canonical Project ID:
+
+```bash
+kent project delete <project-id> --confirm
+```
+
+Project deletion is non-interactive and does not accept a path, name, default Project, or workspace binding as a selector. The command always checks for unfinished Tasks before checking `--confirm`. An agent-shell invocation is human-only when the Project contains any non-terminal Task, including a Backlog Task; the command reports the Project ID and does not request deletion. This policy check is a best-effort command-time snapshot, so a Task can change between the check and the server request. The server's deletion blockers remain authoritative.
+
+Without `--confirm`, the command makes no deletion request. Use `--json` for automation; it emits exactly one `status` envelope on `stdout`, with the canonical Project ID in `result.project_id` on success or `error.project_id` on operational failure. Blocked deletion preserves the server's blocker codes, messages, order, and positive counts. Blockers and other operational failures exit nonzero.
+
+Stable deletion error codes are `confirmation_required`, `human_only_unfinished_work`, `project_not_found`, `project_delete_blocked`, and `request_failed`.
+
+Project deletion is owned by the server and never deletes or moves workspace files. A successful human-readable result explicitly states that workspace files were not deleted.
+
 ## Output Modes
 
 By default, `kent run` writes each finalized assistant commentary or final response to `stdout` as it is committed. Use `--quiet` to suppress live output and print only the terminal result. For scripting, use JSON mode:

--- a/docs/src/content/docs/headless.md
+++ b/docs/src/content/docs/headless.md
@@ -122,22 +122,6 @@ Detach blockers use these recovery actions:
 - `managed_owned_worktrees`: delete dependent worktrees or their quiescent owning Tasks, then retry.
 - `missing_history_snapshot`: re-save the editable Task's source workspace; keep the binding if its history cannot be edited.
 
-### Project deletion
-
-Delete a Project by its canonical Project ID:
-
-```bash
-kent project delete <project-id> --confirm
-```
-
-Project deletion is non-interactive and does not accept a path, name, default Project, or workspace binding as a selector. The command always checks for unfinished Tasks before checking `--confirm`. An agent-shell invocation is human-only when the Project contains any non-terminal Task, including a Backlog Task; the command reports the Project ID and does not request deletion. Task state may change before deletion is processed, and the server's deletion blockers remain authoritative.
-
-Without `--confirm`, the command makes no deletion request. Use `--json` for automation; it emits exactly one `status` envelope on `stdout`, with the canonical Project ID in `result.project_id` on success or `error.project_id` on operational failure. Blocked deletion preserves the server's blocker codes, messages, order, and positive counts. Blockers and other operational failures exit nonzero.
-
-Stable deletion error codes are `confirmation_required`, `human_only_unfinished_work`, `project_not_found`, `project_delete_blocked`, and `request_failed`.
-
-Project deletion is owned by the server and never deletes or moves workspace files. A successful human-readable result explicitly states that workspace files were not deleted.
-
 ## Output Modes
 
 By default, `kent run` writes each finalized assistant commentary or final response to `stdout` as it is committed. Use `--quiet` to suppress live output and print only the terminal result. For scripting, use JSON mode:

--- a/docs/src/content/docs/headless.md
+++ b/docs/src/content/docs/headless.md
@@ -122,6 +122,22 @@ Detach blockers use these recovery actions:
 - `managed_owned_worktrees`: delete dependent worktrees or their quiescent owning Tasks, then retry.
 - `missing_history_snapshot`: re-save the editable Task's source workspace; keep the binding if its history cannot be edited.
 
+### Project deletion
+
+Delete a Project by its canonical Project ID:
+
+```bash
+kent project delete <project-id> --confirm
+```
+
+Project deletion is non-interactive and accepts only the canonical Project ID. The command checks for unfinished Tasks before checking `--confirm`. An agent-shell invocation is human-only when the Project contains any non-terminal Task, including a Backlog Task; it reports the Project ID and does not request deletion. Task state may change before deletion is processed, and the server's deletion blockers remain authoritative.
+
+Without `--confirm`, the command makes no deletion request. Use `--json` for automation; it emits one `status` envelope on `stdout`, with the canonical Project ID in `result.project_id` on success or `error.project_id` on operational failure. Blocked deletion preserves server blocker codes, messages, order, and positive counts. Blockers and other operational failures exit nonzero.
+
+Stable deletion error codes are `confirmation_required`, `human_only_unfinished_work`, `project_not_found`, `project_delete_blocked`, and `request_failed`.
+
+Project deletion never deletes or moves workspace files.
+
 ## Output Modes
 
 By default, `kent run` writes each finalized assistant commentary or final response to `stdout` as it is committed. Use `--quiet` to suppress live output and print only the terminal result. For scripting, use JSON mode:

--- a/docs/src/content/docs/headless.md
+++ b/docs/src/content/docs/headless.md
@@ -130,7 +130,7 @@ Delete a Project by its canonical Project ID:
 kent project delete <project-id> --confirm
 ```
 
-Project deletion is non-interactive and does not accept a path, name, default Project, or workspace binding as a selector. The command always checks for unfinished Tasks before checking `--confirm`. An agent-shell invocation is human-only when the Project contains any non-terminal Task, including a Backlog Task; the command reports the Project ID and does not request deletion. This policy check is a best-effort command-time snapshot, so a Task can change between the check and the server request. The server's deletion blockers remain authoritative.
+Project deletion is non-interactive and does not accept a path, name, default Project, or workspace binding as a selector. The command always checks for unfinished Tasks before checking `--confirm`. An agent-shell invocation is human-only when the Project contains any non-terminal Task, including a Backlog Task; the command reports the Project ID and does not request deletion. Task state may change before deletion is processed, and the server's deletion blockers remain authoritative.
 
 Without `--confirm`, the command makes no deletion request. Use `--json` for automation; it emits exactly one `status` envelope on `stdout`, with the canonical Project ID in `result.project_id` on success or `error.project_id` on operational failure. Blocked deletion preserves the server's blocker codes, messages, order, and positive counts. Blockers and other operational failures exit nonzero.
 


### PR DESCRIPTION
## Summary

Adds `kent project delete <project-id>` over the existing server-owned Project deletion contract. The command accepts canonical Project IDs, requires `--confirm` before requesting deletion, supports stable `--json` envelopes, preserves server blockers, never touches workspace files, and applies the conditional agent-shell policy for unfinished Tasks including Backlog. It adds explicit Project dispatch, dedicated leaf/group help, concise product/spec documentation, and shared concrete remote cleanup with workspace mutations.

Public help/docs describe the safety contract without command-time implementation details; the CLI remains non-interactive and confirmation-gated.

## Verification

- `env -u KENT_SESSION_ID go test ./cli/kent` passed after the latest output-error fix.
- `./scripts/test.sh` passed in the final full-suite run before review-only surface iterations; the isolated QA report notes one unrelated PTY flake that passed three isolated reruns before the final pass.
- `./scripts/build.sh --output ./bin/kent` passed after the latest adjustment.
- `gofmt` and `git diff --check` passed.
- Plain output write failures now return nonzero with a diagnostic; JSON writer failures retain existing behavior.
- QA evidence covered confirmation gating, JSON success/error envelopes, canonical-ID deletion, nonzero not-found failure, agent denial for unfinished Backlog work, agent allowance for empty Projects, and workspace preservation.

## QA evidence

- `.kent/qa/qa-harness.sh doctor` passed; isolated QA ran on `127.0.0.1:53090`; `down --wipe` stopped the QA server and removed QA state.
- Fresh manual results included `confirmation_required` for unconfirmed JSON deletion, exit 0 for confirmed JSON deletion, `project_not_found` on repeat deletion, and `human_only_unfinished_work` for an agent deleting a Project with unfinished Backlog work.

## Diff size

Compared with the PR base commit `5a25caea0`:

- Production Go: +408 / -28, net +380, gross 436 lines.
- Tests: +633 / -0, net +633, gross 633 lines.
- Generated code: 0 / 0.
- Help/docs/spec: +44 / -0, net +44, gross 44 lines.
- Overall: +1085 / -28, net +1057, gross 1113 changed lines.

## Caveats and follow-up

- Agent human-only enforcement is intentionally a best-effort command-time snapshot; the server remains authoritative for deletion blockers and no atomic preflight token was added.
- The approved two-operation preflight treats a correctly scoped `no_linked_workflows` result as an empty Task set; confirmed deletion remains the path that returns `project_not_found` from the server.
- The server/API blocker DTO remains unchanged by explicit scope decision; its existing zero-valued omitted count is converted to typed absence only at the CLI boundary, while invalid present command-local counts are rejected.
- QA encountered the existing server/task-create response issue `live_session_ids is required` after creating the disposable task; the task remained and the deletion policy flow was verified. This is outside the CLI deletion scope and should be tracked separately.
- No server, Desktop, wire protocol, storage, or generated implementation changes are included.
- Kent task: KENT-366. No separate GitHub issue was supplied.