### PR TITLE
Limit model-visible shell output lines

### DIFF
--- a/docs/src/content/docs/command-postprocessing.md
+++ b/docs/src/content/docs/command-postprocessing.md
@@ -26,6 +26,7 @@ Allowed values:
 - `user`: run Kent's output cleanup, then your configured hook.
 - `all`: run Kent's output cleanup, built-in processing, then your configured hook.
 
+In `builtin`, `user`, and `all`, Kent's final model-visible command-output pass limits each line to 1,000 Unicode code points; oversized lines keep only their prefix and end with `… [N characters omitted]`, where `N` is exact. This runs after user-hook replacement; `none` bypasses the limit, and Kent operational warnings are not command-output lines.
 ## Protocol
 
 ### Input

--- a/server/tools/shell/background_notice_test.go
+++ b/server/tools/shell/background_notice_test.go
@@ -197,6 +197,35 @@ func TestBackgroundNoticeConciseFallbackRetainsVisibleCompletion(t *testing.T) {
 	}
 }
 
+func TestModelVisibleFallbackPreviewsLimitCommandOutputLines(t *testing.T) {
+	long := strings.Repeat("x", 1001)
+	want := strings.Repeat("x", 975) + "… [26 characters omitted]"
+	path := writeBackgroundNoticeLog(t, []byte(long))
+	exitCode := 0
+	snapshot := completedBackgroundSnapshot(path, &exitCode)
+	event, err := (&Manager{}).fallbackBackgroundEvent(EventCompleted, snapshot, nil)
+	if err != nil || fallbackPreview(t, event) != want {
+		t.Fatalf("fallback event = %v", err)
+	}
+	rawSnapshot := snapshot
+	rawSnapshot.RawOutput = true
+	rawEvent, _ := (&Manager{}).fallbackBackgroundEvent(EventCompleted, rawSnapshot, nil)
+	if got := fallbackPreview(t, rawEvent); got != long {
+		t.Fatalf("raw fallback preview = %q", got)
+	}
+	cache := &terminalEventCache{eventType: EventCompleted, snapshot: Snapshot{ID: "1000", RecentOutput: long}}
+	cached := cache.fallbackEvent(errors.New("cache unavailable"))
+	if got := fallbackPreview(t, cached); got != want {
+		t.Fatalf("cache fallback preview = %q", got)
+	}
+}
+
+func fallbackPreview(t *testing.T, event Event) string {
+	t.Helper()
+	summary, _ := SummarizeBackgroundEvent(event, BackgroundNoticeOptions{SuccessOutputMode: BackgroundOutputVerbose})
+	got, _ := summary.RuntimePreview()
+	return got
+}
 func TestInvariantFailureBackgroundNoticeUsesDistinctTypedProjection(t *testing.T) {
 	exitCode := 17
 	summary := InvariantFailureBackgroundNotice(Event{

--- a/server/tools/shell/manager.go
+++ b/server/tools/shell/manager.go
@@ -366,7 +366,7 @@ func (m *Manager) WriteStdin(ctx context.Context, req WriteRequest) (result Exec
 			var previewTruncated bool
 			preview, _, previewTruncated, previewErr := readBackgroundSummaryFromFile(snapshot.LogPath, maxOutputChars, BackgroundOutputDefault, !snapshot.RawOutput)
 			if previewErr == nil {
-				processed = postprocess.Result{Output: preview}
+				processed = postprocess.Result{Output: limitModelVisibleFallbackOutput(preview, snapshot.RawOutput)}
 				consumedCompletion = true
 				sourceTruncated = previewTruncated
 				warning, warningErr = mergeOperationalWarning(warning, fmt.Sprintf("full output log skipped: %v", readErr))

--- a/server/tools/shell/manager_notice.go
+++ b/server/tools/shell/manager_notice.go
@@ -250,7 +250,7 @@ func projectBackgroundNoticeOutput(evt Event, maxChars int, mode BackgroundOutpu
 				output.logLineCount = &lineCount
 			}
 			if completion.source == completionOutputFallback && mode != BackgroundOutputConcise {
-				output.visible.command = preview
+				output.visible.command = limitModelVisibleFallbackOutput(preview, evt.Snapshot.RawOutput)
 				output.truncated = output.truncated || truncated
 				if truncated && output.previewRemoved == 0 {
 					output.previewRemoved = 1

--- a/server/tools/shell/manager_postprocess.go
+++ b/server/tools/shell/manager_postprocess.go
@@ -35,6 +35,12 @@ func (m *Manager) applyPostprocessing(ctx context.Context, entry *processEntry, 
 	})
 }
 
+func limitModelVisibleFallbackOutput(output string, preservesRaw bool) string {
+	if preservesRaw {
+		return output
+	}
+	return postprocess.LimitOutputLines(output)
+}
 func mergeOperationalWarning(existing postprocess.Warning, message string) (postprocess.Warning, error) {
 	warning, err := postprocess.NewWarning(message)
 	if err != nil {

--- a/server/tools/shell/manager_runtime.go
+++ b/server/tools/shell/manager_runtime.go
@@ -212,6 +212,7 @@ func (m *Manager) fallbackBackgroundEvent(eventType EventType, snapshot Snapshot
 		}
 		preview = ""
 	}
+	preview = limitModelVisibleFallbackOutput(preview, snapshot.RawOutput)
 	removed := 0
 	if truncated {
 		removed = 1
@@ -358,7 +359,7 @@ func (c *terminalEventCache) fallbackEvent(cause error) Event {
 	return newFallbackBackgroundEvent(
 		c.eventType,
 		c.snapshot,
-		c.snapshot.RecentOutput,
+		limitModelVisibleFallbackOutput(c.snapshot.RecentOutput, c.snapshot.RawOutput),
 		warning,
 		1,
 		c.noticeSuppressed,

--- a/server/tools/shell/postprocess/runner.go
+++ b/server/tools/shell/postprocess/runner.go
@@ -41,6 +41,11 @@ type Result struct {
 	UnrecoverableError string
 }
 
+const (
+	commandOutputLineLimit = 1000
+	lineLimiterProcessorID = "builtin/limit-output-lines"
+)
+
 type warningMessage string
 
 // Warning is an opaque immutable aggregate of non-empty operational warnings.
@@ -544,7 +549,51 @@ func resultFromEnvelope(envelope Envelope, processed bool, processorID string, t
 	if terminal.Severity == FailureUnrecoverable {
 		result.UnrecoverableError = formatProcessorFailure(terminal)
 	}
+	if output, limited := limitCommandOutputLines(result.Output); limited {
+		result.Output = output
+		result.Processed = true
+		result.ProcessorID = lineLimiterProcessorID
+	}
 	return result
+}
+
+func limitCommandOutputLines(output string) (string, bool) {
+	if output == "" {
+		return output, false
+	}
+	lines := strings.Split(output, "\n")
+	limited := false
+	for index, line := range lines {
+		shortened, lineLimited := limitCommandOutputLine(line)
+		lines[index] = shortened
+		limited = limited || lineLimited
+	}
+	if !limited {
+		return output, false
+	}
+	return strings.Join(lines, "\n"), true
+}
+
+func LimitOutputLines(output string) string {
+	limited, _ := limitCommandOutputLines(output)
+	return limited
+}
+
+func limitCommandOutputLine(line string) (string, bool) {
+	runes := []rune(line)
+	if len(runes) <= commandOutputLineLimit {
+		return line, false
+	}
+	prefixLength := commandOutputLineLimit
+	for prefixLength >= 0 {
+		omitted := len(runes) - prefixLength
+		marker := fmt.Sprintf("… [%d characters omitted]", omitted)
+		if prefixLength+len([]rune(marker)) <= commandOutputLineLimit {
+			return string(runes[:prefixLength]) + marker, true
+		}
+		prefixLength--
+	}
+	return "", true
 }
 
 func formatProcessorFailure(failure ProcessorFailure) string {

--- a/server/tools/shell/postprocess/runner_test.go
+++ b/server/tools/shell/postprocess/runner_test.go
@@ -527,6 +527,78 @@ func TestRunnerAllModeAccumulatesWarnings(t *testing.T) {
 	}
 }
 
+func TestRunnerLimitsCommandOutputLinesAtFinalResultBoundary(t *testing.T) {
+	runner := mustNewRunner(t, Settings{Mode: config.ShellPostprocessingModeBuiltin})
+	tests := [][2]string{
+		{strings.Repeat("a", 712), strings.Repeat("a", 712)},
+		{strings.Repeat("a", 999), strings.Repeat("a", 999)},
+		{strings.Repeat("a", 1000), strings.Repeat("a", 1000)},
+		{strings.Repeat("a", 1001), strings.Repeat("a", 975) + "… [26 characters omitted]"},
+		{strings.Repeat("界", 1001), strings.Repeat("界", 975) + "… [26 characters omitted]"},
+		{strings.Repeat("a", 999) + "\n" + strings.Repeat("b", 1001) + "\nshort\n\n" + strings.Repeat("界", 1001) + "\n",
+			strings.Repeat("a", 999) + "\n" + strings.Repeat("b", 975) + "… [26 characters omitted]\nshort\n\n" + strings.Repeat("界", 975) + "… [26 characters omitted]\n"},
+	}
+	for _, tt := range tests {
+		result, _ := runner.Apply(context.Background(), Request{Output: tt[0]})
+		if result.Output != tt[1] {
+			t.Fatalf("result = %q; want %q", result.Output, tt[1])
+		}
+		if tt[0] != tt[1] && (!result.Processed || result.ProcessorID != lineLimiterProcessorID) {
+			t.Fatalf("limiter attribution = processed:%t processor:%q", result.Processed, result.ProcessorID)
+		}
+	}
+}
+func TestRunnerLineLimitRunsAfterHookReplacement(t *testing.T) {
+	runner := mustNewRunner(t, Settings{Mode: config.ShellPostprocessingModeUser})
+	runner.hookProcessor = testProcessor{id: "test/hook", fn: func(e Envelope) (Decision, error) {
+		return Continue(e.WithCurrent(strings.Repeat("x", 1200)), "test/hook"), nil
+	}}
+	result, _ := runner.Apply(context.Background(), Request{Output: "original"})
+	want := strings.Repeat("x", 974) + "… [226 characters omitted]"
+	if result.Output != want || result.ProcessorID != lineLimiterProcessorID {
+		t.Fatalf("result = %+v", result)
+	}
+}
+func TestRunnerLineLimitRunsForUnrecoverableResultsFromEachChain(t *testing.T) {
+	oversized := strings.Repeat("x", 1001)
+	for _, tt := range []struct {
+		name string
+		mode config.ShellPostprocessingMode
+		p    lineLimitFailureProcessor
+	}{{"global", config.ShellPostprocessingModeBuiltin, lineLimitFailureProcessor{"global-failure", "global warning", "global failure"}},
+		{"builtin", config.ShellPostprocessingModeBuiltin, lineLimitFailureProcessor{"builtin-failure", "builtin warning", "builtin failure"}},
+		{"user", config.ShellPostprocessingModeUser, lineLimitFailureProcessor{"user-failure", "user warning", "user failure"}}} {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := mustNewRunner(t, Settings{Mode: tt.mode})
+			switch tt.name {
+			case "global":
+				runner.globalProcessors = []Processor{tt.p}
+			case "builtin":
+				runner.processors = []Processor{tt.p}
+			case "user":
+				runner.hookProcessor = tt.p
+			}
+			result, _ := runner.Apply(context.Background(), Request{Output: oversized})
+			want := strings.Repeat("x", 975) + "… [26 characters omitted]"
+			if result.Output != want || result.Warning == nil || result.ProcessorID != lineLimiterProcessorID ||
+				result.UnrecoverableError != "Postprocess processor "+tt.name+"-failure failed: "+tt.name+" failure" {
+				t.Fatalf("result = %+v", result)
+			}
+		})
+	}
+}
+
+type lineLimitFailureProcessor struct {
+	id, warning, message string
+}
+
+func (p lineLimitFailureProcessor) ID() string { return p.id }
+
+func (p lineLimitFailureProcessor) Process(_ context.Context, envelope Envelope) (Decision, error) {
+	failure := ProcessorFailure{ProcessorID: p.id, Severity: FailureUnrecoverable, Message: p.message}
+	return Decision{Action: ActionHalt, Next: envelope, Warning: mustWarning(p.warning), Failure: &failure}, nil
+}
+
 type warningProcessor struct{}
 
 func (warningProcessor) ID() string { return "test/warning" }

--- a/server/tools/shell/tool_sanitization_test.go
+++ b/server/tools/shell/tool_sanitization_test.go
@@ -147,3 +147,39 @@ func TestRawBackgroundOutputPathsPreserveAnsi(t *testing.T) {
 		t.Fatalf("poll output lost ANSI: %q", text)
 	}
 }
+func TestShellCompletionPathsLimitCommandOutputLines(t *testing.T) {
+	const command = "printf '%1001s' '' | tr ' ' x"
+	want := strings.Repeat("x", 975) + "… [26 characters omitted]"
+	manager := newShellTestManager(t, 50*time.Millisecond)
+	completed := make(chan Event, 2)
+	manager.SetEventHandler(func(evt Event) bool {
+		if evt.Type == EventCompleted || evt.Type == EventKilled {
+			completed <- evt
+		}
+		return true
+	})
+	start := func(command string, yield time.Duration, stdin bool) (ExecResult, error) {
+		return manager.Start(context.Background(), ExecRequest{Command: []string{"/bin/sh", "-c", command}, Workdir: t.TempDir(), YieldTime: yield, MaxOutputChars: 16_000, KeepStdinOpen: stdin})
+	}
+	foreground, _ := start("sleep .1; "+command, 5*time.Second, false)
+	if foreground.Backgrounded || foreground.Output != want {
+		t.Fatalf("foreground = %+v", foreground)
+	}
+	background, _ := start(command+"; sleep .2", 50*time.Millisecond, false)
+	if !background.Backgrounded {
+		t.Fatalf("background = %+v", background)
+	}
+	event := <-completed
+	summary, _ := SummarizeBackgroundEvent(event, BackgroundNoticeOptions{})
+	if got, _ := summary.RuntimePreview(); got != want {
+		t.Fatalf("background preview = %q, want %q", got, want)
+	}
+	interactive, _ := start("read line; "+command, 50*time.Millisecond, true)
+	if !interactive.Backgrounded {
+		t.Fatalf("interactive = %+v", interactive)
+	}
+	finished, _ := manager.WriteStdin(context.Background(), WriteRequest{SessionID: interactive.SessionID, Input: "\n", YieldTime: 2 * time.Second, MaxOutputChars: 16_000})
+	if finished.Output != want {
+		t.Fatalf("write_stdin = %q; want %q", finished.Output, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Enforce a shared 1,000-Unicode-code-point limit for enabled shell postprocessing, including post-hook replacements.
- Apply the same prefix-only shortening to directly model-visible background fallback previews while preserving raw/none output and captured logs.
- Document the marker and scope in the command-postprocessing guide.

## Verification
- `./scripts/test.sh ./server/tools/shell/...` (pass)
- `./scripts/build.sh --output ./bin/kent` (pass)
- `git diff --check` (pass)
- Gross diff audit: 200 lines; 9 changed files.
- Prior QA evidence: `.kent/plans/KENT-367.md`, `server/tools/shell/postprocess/runner_test.go`, `server/tools/shell/background_notice_test.go`, `server/tools/shell/tool_sanitization_test.go`, `docs/src/content/docs/command-postprocessing.md`, `./bin/kent`.

## Diff accounting
- Production code: +56 net, 62 gross (+59/-3).
- Test code: +137 net, 137 gross (+137/-0).
- Documentation: +1 net, 1 gross.
- Generated code: 0 net, 0 gross.
- Overall: +194 net, 200 gross.

## Caveats and follow-up
- Shortening is prefix-only and uses `… [N characters omitted]`; the marker is included in the 1,000-code-point budget.
- `raw=true` and postprocessing mode `none` bypass the limit; whole-output truncation remains independent.
- Captured background log files, streaming/snapshot previews, operational warnings, configuration semantics, hook JSON, and product specs are unchanged.
- No GitHub issue number was supplied; this PR addresses Kent task KENT-367.