### PR TITLE
Fix compact path allocation gaps

### DIFF
--- a/docs/src/content/docs/worktrees.md
+++ b/docs/src/content/docs/worktrees.md
@@ -55,7 +55,7 @@ base_dir = "~/.kent/worktrees"
 # setup_timeout_seconds = 60
 ```
 
-- `base_dir` sets the root directory for Kent-managed worktrees.
+- `base_dir` sets the root directory for Kent-managed worktrees. Automatic worktree paths must remain outside the source workspace.
 - `setup_script` runs after Kent creates a worktree and before the create command or a workflow run uses it. Relative paths resolve from the source workspace root.
 - `setup_timeout_seconds` sets the setup script timeout. The default is `60`; `0` or a negative value disables the timeout.
 

--- a/server/worktree/managed_root_allocator.go
+++ b/server/worktree/managed_root_allocator.go
@@ -16,6 +16,7 @@ import (
 const workspacePathKeyMaxBytes = 24
 
 var errManagedRootBaseInvalid = errors.New("managed worktree base is not a directory")
+var errManagedRootOverlapsSourceWorkspace = errors.New("automatic managed worktree root overlaps source workspace")
 
 type managedRootBase struct {
 	path string
@@ -148,6 +149,15 @@ func (a *managedRootAllocator) ensureWorkspaceParent(workspaceRoot string) (stri
 	if !sameOrDescendantPath(base, parent) {
 		return "", fmt.Errorf("managed workspace parent %q escapes base %q", parent, base)
 	}
+	if sameOrDescendantPath(canonicalWorkspaceRoot, parent) ||
+		sameOrDescendantPath(parent, canonicalWorkspaceRoot) {
+		return "", fmt.Errorf(
+			"managed workspace parent %q overlaps source workspace %q: %w",
+			parent,
+			canonicalWorkspaceRoot,
+			errManagedRootOverlapsSourceWorkspace,
+		)
+	}
 	if err := os.MkdirAll(parent, 0o755); err != nil {
 		return "", fmt.Errorf("create managed workspace parent %q: %w", parent, err)
 	}
@@ -269,6 +279,13 @@ func reserveManagedLeaf(parent string, leaf string) (string, bool, error) {
 		return "", false, fmt.Errorf("reserved managed worktree root %q is not a directory", root)
 	}
 	return root, false, nil
+}
+
+func removeEmptyManagedRootAfterAddFailure(root string) error {
+	if err := os.Remove(root); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove empty reserved managed worktree root %q after Git add failure: %w", root, err)
+	}
+	return nil
 }
 
 func (a *managedRootAllocator) randomDecimal(width int) (string, error) {

--- a/server/worktree/managed_root_allocator.go
+++ b/server/worktree/managed_root_allocator.go
@@ -149,8 +149,7 @@ func (a *managedRootAllocator) ensureWorkspaceParent(workspaceRoot string) (stri
 	if !sameOrDescendantPath(base, parent) {
 		return "", fmt.Errorf("managed workspace parent %q escapes base %q", parent, base)
 	}
-	if sameOrDescendantPath(canonicalWorkspaceRoot, parent) ||
-		sameOrDescendantPath(parent, canonicalWorkspaceRoot) {
+	if sameOrDescendantPath(canonicalWorkspaceRoot, parent) {
 		return "", fmt.Errorf(
 			"managed workspace parent %q overlaps source workspace %q: %w",
 			parent,

--- a/server/worktree/managed_root_allocator_test.go
+++ b/server/worktree/managed_root_allocator_test.go
@@ -93,6 +93,32 @@ func TestManagedRootAllocatorRejectsAutomaticParentOverlappingSourceWorkspace(t 
 	}
 }
 
+func TestManagedRootAllocatorAllowsParentContainingSourceWorkspace(t *testing.T) {
+	base := t.TempDir()
+	workspace := filepath.Join(base, "app", "app")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	allocator := newManagedRootAllocator(base, bytes.NewReader(bytes.Repeat([]byte{4}, 16)))
+	regularRoot, err := allocator.reserveRegularRoot(workspace)
+	if err != nil {
+		t.Fatalf("reserve regular root: %v", err)
+	}
+	taskRoot, err := allocator.reserveTaskRoot(workspace, "KENT-335")
+	if err != nil {
+		t.Fatalf("reserve Task root: %v", err)
+	}
+	wantParent := filepath.Join(allocator.base.path, "app")
+	for _, root := range []string{regularRoot, taskRoot} {
+		if filepath.Dir(root) != wantParent {
+			t.Fatalf("allocated root = %q, want parent %q", root, wantParent)
+		}
+		if sameOrDescendantPath(workspace, root) {
+			t.Fatalf("allocated root %q is inside source workspace %q", root, workspace)
+		}
+	}
+}
+
 func TestManagedRootAllocatorReservesRegularAndTaskLeaves(t *testing.T) {
 	base := filepath.Join(t.TempDir(), "worktrees")
 	workspace := filepath.Join(t.TempDir(), "Builder CLI")

--- a/server/worktree/managed_root_allocator_test.go
+++ b/server/worktree/managed_root_allocator_test.go
@@ -61,6 +61,38 @@ func TestManagedRootAllocatorUsesSharedNormalizedWorkspaceParent(t *testing.T) {
 	}
 }
 
+func TestManagedRootAllocatorRejectsAutomaticParentOverlappingSourceWorkspace(t *testing.T) {
+	tests := []struct {
+		name      string
+		base      func(root string) string
+		workspace func(root string) string
+	}{
+		{
+			name:      "parent equals source workspace",
+			base:      func(root string) string { return root },
+			workspace: func(root string) string { return filepath.Join(root, "app") },
+		},
+		{
+			name:      "parent is inside source workspace",
+			base:      func(root string) string { return filepath.Join(root, "app", "worktrees") },
+			workspace: func(root string) string { return filepath.Join(root, "app") },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			workspace := tt.workspace(root)
+			if err := os.MkdirAll(workspace, 0o755); err != nil {
+				t.Fatalf("create workspace: %v", err)
+			}
+			allocator := newManagedRootAllocator(tt.base(root), strings.NewReader("entropy"))
+			if _, err := allocator.reserveRegularRoot(workspace); !errors.Is(err, errManagedRootOverlapsSourceWorkspace) {
+				t.Fatalf("reserve overlapping automatic root error = %v, want overlap error", err)
+			}
+		})
+	}
+}
+
 func TestManagedRootAllocatorReservesRegularAndTaskLeaves(t *testing.T) {
 	base := filepath.Join(t.TempDir(), "worktrees")
 	workspace := filepath.Join(t.TempDir(), "Builder CLI")
@@ -81,6 +113,35 @@ func TestManagedRootAllocatorReservesRegularAndTaskLeaves(t *testing.T) {
 	}
 	if filepath.Base(task) != "KENT-335" {
 		t.Fatalf("Task root = %q, want KENT-335", task)
+	}
+}
+
+func TestRemoveEmptyManagedRootAfterAddFailure(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "reserved")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatalf("create reserved root: %v", err)
+	}
+	if err := removeEmptyManagedRootAfterAddFailure(root); err != nil {
+		t.Fatalf("remove empty reserved root: %v", err)
+	}
+	if _, err := os.Lstat(root); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("reserved root still exists: %v", err)
+	}
+	if err := removeEmptyManagedRootAfterAddFailure(root); err != nil {
+		t.Fatalf("repeat absent cleanup: %v", err)
+	}
+
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatalf("recreate reserved root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "partial"), nil, 0o600); err != nil {
+		t.Fatalf("write partial Git state: %v", err)
+	}
+	if err := removeEmptyManagedRootAfterAddFailure(root); err == nil {
+		t.Fatal("removed non-empty reserved root")
+	}
+	if _, err := os.Lstat(root); err != nil {
+		t.Fatalf("non-empty reserved root was removed: %v", err)
 	}
 }
 

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -106,6 +106,13 @@ type failedCreateCleanup struct {
 	createdBranch bool
 }
 
+type managedRootKind uint8
+
+const (
+	managedRootKindExplicit managedRootKind = iota + 1
+	managedRootKindAutomatic
+)
+
 type setupScriptPayload struct {
 	SourceWorkspaceRoot string  `json:"source_workspace_root"`
 	BranchName          string  `json:"branch_name"`
@@ -579,11 +586,13 @@ func (s *Service) createManagedTaskWorktree(ctx context.Context, req managedTask
 		return TaskWorktreeMaterialization{}, err
 	}
 	var worktreeRoot string
+	rootKind := managedRootKindExplicit
 	if req.RequestedRoot == nil {
 		worktreeRoot, err = s.managedRoots.reserveTaskRoot(req.Workspace.RootPath, req.Task.ShortID)
 		if err != nil {
 			return TaskWorktreeMaterialization{}, err
 		}
+		rootKind = managedRootKindAutomatic
 	} else {
 		requestedRoot := strings.TrimSpace(*req.RequestedRoot)
 		if requestedRoot == "" {
@@ -609,7 +618,7 @@ func (s *Service) createManagedTaskWorktree(ctx context.Context, req managedTask
 			err = errors.Join(err, cleanupErr)
 		}
 	}()
-	createdBranch, err := s.git.Add(ctx, req.Workspace.RootPath, worktreeRoot, createSpec)
+	createdBranch, err := s.addManagedWorktree(ctx, req.Workspace.RootPath, worktreeRoot, createSpec, rootKind)
 	if err != nil {
 		return TaskWorktreeMaterialization{}, err
 	}
@@ -1045,18 +1054,20 @@ func (s *Service) CreateWorktree(ctx context.Context, req serverapi.WorktreeCrea
 		}
 	}()
 	var worktreeRoot string
+	rootKind := managedRootKindExplicit
 	if strings.TrimSpace(req.RootPath) == "" {
 		worktreeRoot, err = s.managedRoots.reserveRegularRoot(workspaceCtx.workspaceRoot)
 		if err != nil {
 			return serverapi.WorktreeCreateResponse{}, err
 		}
+		rootKind = managedRootKindAutomatic
 	} else {
 		worktreeRoot, err = s.managedRoots.resolveExplicitRoot(req.RootPath)
 		if err != nil {
 			return serverapi.WorktreeCreateResponse{}, err
 		}
 	}
-	createdBranch, err := s.git.Add(ctx, workspaceCtx.workspaceRoot, worktreeRoot, createSpec)
+	createdBranch, err := s.addManagedWorktree(ctx, workspaceCtx.workspaceRoot, worktreeRoot, createSpec, rootKind)
 	if err != nil {
 		return serverapi.WorktreeCreateResponse{}, err
 	}
@@ -1121,6 +1132,23 @@ func (s *Service) CreateWorktree(ctx context.Context, req serverapi.WorktreeCrea
 		return serverapi.WorktreeCreateResponse{}, err
 	}
 	return serverapi.WorktreeCreateResponse{Target: workspaceCtx.target, Worktree: createdEntry}, nil
+}
+
+func (s *Service) addManagedWorktree(
+	ctx context.Context,
+	workspaceRoot string,
+	worktreeRoot string,
+	createSpec CreateSpec,
+	rootKind managedRootKind,
+) (bool, error) {
+	createdBranch, err := s.git.Add(ctx, workspaceRoot, worktreeRoot, createSpec)
+	if err == nil || rootKind != managedRootKindAutomatic {
+		return createdBranch, err
+	}
+	if cleanupErr := removeEmptyManagedRootAfterAddFailure(worktreeRoot); cleanupErr != nil {
+		return false, errors.Join(err, cleanupErr)
+	}
+	return false, err
 }
 
 func (s *Service) createdWorktreeListEntry(ctx context.Context, workspaceCtx sessionWorkspaceContext, worktreeID string) (serverapi.WorktreeListEntry, error) {


### PR DESCRIPTION
## Summary

- Reject automatically generated managed-worktree parents that equal or are inside the source workspace.
- Remove an automatic reserved leaf when Git creation fails and the leaf remains empty.
- Retain partial or non-empty Git state and join cleanup diagnostics with the creation error.
- Preserve the explicitly approved diagnostic panic after all bounded collision attempts are exhausted.

## Verification

- Focused source-overlap and pre-Git empty-leaf cleanup regressions passed.
- Complete `./scripts/test.sh` passed, including 240 desktop tests.
- `./scripts/build.sh --output ./bin/kent` passed; the binary reports `2.4.0`.
- `git diff --check` passed.

## Context

- Follow-up to #671 after its post-merge review.
- Fix commit: `e60d147c4`.
