### PR TITLE
Add Cmd+Enter submission for Desktop text fields

### DIFF
--- a/apps/desktop/src/app-facade/index.ts
+++ b/apps/desktop/src/app-facade/index.ts
@@ -19,6 +19,7 @@ export * from "./sidebarTitle";
 export * from "./statusContextValue";
 export * from "./statusStore";
 export * from "./taskDetailInitialFocus";
+export * from "./textFieldSubmitShortcut";
 export * from "./useAppServices";
 export * from "./useConnectionSnapshot";
 export * from "./useNativeDialogFallback";

--- a/apps/desktop/src/app-facade/textFieldSubmitShortcut.test.tsx
+++ b/apps/desktop/src/app-facade/textFieldSubmitShortcut.test.tsx
@@ -51,6 +51,10 @@ describe("text field submit shortcut", () => {
     ["macos", { key: "Enter", ctrlKey: true }],
     ["windows", { key: "Enter", metaKey: true }],
     ["macos", { key: "Enter", metaKey: true, isComposing: true }],
+    ["macos", { key: "Enter", metaKey: true, shiftKey: true }],
+    ["macos", { key: "Enter", metaKey: true, altKey: true }],
+    ["macos", { key: "Enter", metaKey: true, ctrlKey: true }],
+    ["windows", { key: "Enter", ctrlKey: true, metaKey: true }],
     ["browser", { key: "Enter", metaKey: true }],
     ["unknown", { key: "Enter", ctrlKey: true }],
   ] as const)("ignores unsupported shortcut %s", (platform, event) => {

--- a/apps/desktop/src/app-facade/textFieldSubmitShortcut.test.tsx
+++ b/apps/desktop/src/app-facade/textFieldSubmitShortcut.test.tsx
@@ -1,26 +1,30 @@
 import { createEvent, fireEvent, render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
+import type { NativePlatform } from "@app/native-bridge";
+import { createElement, type ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
-
 import { isTextFieldSubmitShortcut, useTextFieldSubmitShortcut } from "./textFieldSubmitShortcut";
-
-type Platform = "browser" | "linux" | "macos" | "unknown" | "windows";
-const nativePlatform = vi.hoisted((): { current: Platform } => ({ current: "macos" }));
+const nativePlatform = vi.hoisted((): { current: NativePlatform } => ({ current: "macos" }));
 vi.mock("./useAppServices", () => ({
   useAppServices: () => ({ nativeBridge: { capabilities: { platform: nativePlatform.current } } }),
 }));
 
-function DirectHarness({ action, available = true }: Readonly<{ action: (() => void) | null; available?: boolean }>) {
-  return <input aria-label="text" onKeyDown={useTextFieldSubmitShortcut({ action, available, kind: "direct" })} />;
+type DirectProps = Readonly<{ action: (() => void) | null; available?: boolean }>;
+function DirectHarness({ action, available = true }: DirectProps) {
+  const onKeyDown = useTextFieldSubmitShortcut({ action, available, kind: "direct" });
+  return <input aria-label="text" onKeyDown={onKeyDown} />;
 }
 function FormHarness({ children, id = "owner-form" }: Readonly<{ children: ReactNode; id?: string }>) {
-  return (
-    <form data-testid={id} id={id} onKeyDown={useTextFieldSubmitShortcut({ available: true, kind: "form" })} onSubmit={(event) => { event.preventDefault(); }}>
-      {children}
-    </form>
-  );
+  const onKeyDown = useTextFieldSubmitShortcut({ available: true, kind: "form" });
+  return createElement("form", { "data-testid": id, id, onKeyDown }, children);
 }
-
+function formSpy(id = "owner-form") {
+  const form = screen.getByTestId(id);
+  if (!(form instanceof HTMLFormElement)) throw new Error("Expected an owning form.");
+  return vi.spyOn(form, "requestSubmit").mockImplementation(() => undefined);
+}
+function press(name: string, options: KeyboardEventInit, role = "textbox") {
+  fireEvent.keyDown(screen.getByRole(role, { name }), { key: "Enter", ...options });
+}
 describe("text field submit shortcut", () => {
   it.each([
     ["macos", { metaKey: true }],
@@ -30,31 +34,36 @@ describe("text field submit shortcut", () => {
     nativePlatform.current = platform;
     const action = vi.fn();
     render(<DirectHarness action={action} />);
-    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter", ...modifier });
+    press("text", modifier);
     expect(action).toHaveBeenCalledOnce();
   });
-  it("recognizes only the platform shortcut and ignores composition", () => {
-    for (const [platform, event] of [
-      ["macos", new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true })],
-      ["windows", new KeyboardEvent("keydown", { key: "Enter", metaKey: true })],
-      ["macos", new KeyboardEvent("keydown", { key: "a", metaKey: true })],
-      ["macos", new KeyboardEvent("keydown", { key: "Enter", metaKey: true, isComposing: true })],
-      ["browser", new KeyboardEvent("keydown", { key: "Enter", metaKey: true })],
-      ["unknown", new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true })],
-    ] as const) {
-      expect(isTextFieldSubmitShortcut(event, platform)).toBe(false);
-    }
+  it.each([
+    ["macos", { key: "Enter", ctrlKey: true }],
+    ["windows", { key: "Enter", metaKey: true }],
+    ["macos", { key: "a", metaKey: true }],
+    ["macos", { key: "Enter", metaKey: true, isComposing: true }],
+    ["browser", { key: "Enter", metaKey: true }],
+    ["unknown", { key: "Enter", ctrlKey: true }],
+  ] as const)("ignores unsupported shortcut %s", (platform, event) => {
+    expect(isTextFieldSubmitShortcut(new KeyboardEvent("keydown", event), platform)).toBe(false);
   });
   it("consumes repeated and unavailable direct shortcuts", () => {
     nativePlatform.current = "macos";
     const action = vi.fn();
     const view = render(<DirectHarness action={action} />);
-    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter", metaKey: true });
-    const repeated = createEvent.keyDown(screen.getByRole("textbox"), { key: "Enter", metaKey: true, repeat: true });
-    fireEvent(screen.getByRole("textbox"), repeated);
+    press("text", { metaKey: true });
+    const repeated = createEvent.keyDown(screen.getByRole("textbox", { name: "text" }), {
+      key: "Enter",
+      metaKey: true,
+      repeat: true,
+    });
+    fireEvent(screen.getByRole("textbox", { name: "text" }), repeated);
     view.rerender(<DirectHarness action={action} available={false} />);
-    const unavailable = createEvent.keyDown(screen.getByRole("textbox"), { key: "Enter", metaKey: true });
-    fireEvent(screen.getByRole("textbox"), unavailable);
+    const unavailable = createEvent.keyDown(screen.getByRole("textbox", { name: "text" }), {
+      key: "Enter",
+      metaKey: true,
+    });
+    fireEvent(screen.getByRole("textbox", { name: "text" }), unavailable);
     expect(action).toHaveBeenCalledOnce();
     expect(repeated.defaultPrevented).toBe(true);
     expect(unavailable.defaultPrevented).toBe(true);
@@ -62,51 +71,43 @@ describe("text field submit shortcut", () => {
   it("requests only exact owning text targets", () => {
     nativePlatform.current = "macos";
     render(
-      <FormHarness>
-        <textarea aria-label="body" /><input aria-label="read-only" readOnly /><input aria-label="radio" type="radio" />
-        <input aria-label="unassociated" form="missing-form" />
-      </FormHarness>,
-    );
-    const form = screen.getByTestId("owner-form");
-    if (!(form instanceof HTMLFormElement)) throw new Error("Expected an owning form.");
-    const submitSpy = vi.spyOn(form, "requestSubmit");
-    for (const [role, name] of [["textbox", "body"], ["textbox", "read-only"], ["radio", "radio"], ["textbox", "unassociated"]] as const) {
-      fireEvent.keyDown(screen.getByRole(role, { name }), { key: "Enter", metaKey: true });
-    }
-    expect(submitSpy).toHaveBeenCalledTimes(2);
-  });
-  it("keeps an associated inner form responsible for its own target", () => {
-    nativePlatform.current = "macos";
-    render(
       <>
-        <FormHarness><input aria-label="inner-associated" form="inner-form" /></FormHarness>
-        <FormHarness id="inner-form"><input aria-label="inner-owned" /></FormHarness>
+        <FormHarness>
+          <textarea aria-label="body" />
+          <input aria-label="read-only" readOnly />
+          <input aria-label="radio" type="radio" />
+          <input aria-label="unassociated" form="missing-form" />
+          <input aria-label="inner-associated" form="inner-form" />
+          <input
+            aria-label="consumed"
+            onKeyDown={(event) => {
+              event.preventDefault();
+            }}
+          />
+          <input aria-label="repeat" />
+        </FormHarness>
+        <FormHarness id="inner-form">
+          <input aria-label="inner-owned" />
+        </FormHarness>
       </>,
     );
-    const outer = screen.getByTestId("owner-form");
-    const inner = screen.getByTestId("inner-form");
-    if (!(outer instanceof HTMLFormElement) || !(inner instanceof HTMLFormElement)) throw new Error("Expected owning forms.");
-    const outerSubmit = vi.spyOn(outer, "requestSubmit");
-    const innerSubmit = vi.spyOn(inner, "requestSubmit");
-    fireEvent.keyDown(screen.getByRole("textbox", { name: "inner-associated" }), { key: "Enter", metaKey: true });
-    fireEvent.keyDown(screen.getByRole("textbox", { name: "inner-owned" }), { key: "Enter", metaKey: true });
-    expect(outerSubmit).not.toHaveBeenCalled();
-    expect(innerSubmit).toHaveBeenCalledOnce();
-  });
-  it("skips consumed descendants and consumes form auto-repeat", () => {
-    nativePlatform.current = "windows";
-    render(
-      <FormHarness>
-        <input aria-label="consumed" onKeyDown={(event) => { event.preventDefault(); }} /><input aria-label="repeat" />
-      </FormHarness>,
-    );
-    const form = screen.getByTestId("owner-form");
-    if (!(form instanceof HTMLFormElement)) throw new Error("Expected an owning form.");
-    const submitSpy = vi.spyOn(form, "requestSubmit");
-    fireEvent.keyDown(screen.getByRole("textbox", { name: "consumed" }), { key: "Enter", ctrlKey: true });
-    const repeated = createEvent.keyDown(screen.getByRole("textbox", { name: "repeat" }), { key: "Enter", ctrlKey: true, repeat: true });
+    const submitSpy = formSpy();
+    press("body", { metaKey: true });
+    press("read-only", { metaKey: true });
+    press("unassociated", { metaKey: true });
+    press("radio", { metaKey: true }, "radio");
+    press("consumed", { metaKey: true });
+    const repeated = createEvent.keyDown(screen.getByRole("textbox", { name: "repeat" }), {
+      key: "Enter",
+      metaKey: true,
+      repeat: true,
+    });
     fireEvent(screen.getByRole("textbox", { name: "repeat" }), repeated);
-    expect(submitSpy).not.toHaveBeenCalled();
     expect(repeated.defaultPrevented).toBe(true);
+    const innerSubmit = formSpy("inner-form");
+    press("inner-associated", { metaKey: true });
+    press("inner-owned", { metaKey: true });
+    expect(innerSubmit).toHaveBeenCalledOnce();
+    expect(submitSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/desktop/src/app-facade/textFieldSubmitShortcut.test.tsx
+++ b/apps/desktop/src/app-facade/textFieldSubmitShortcut.test.tsx
@@ -1,26 +1,36 @@
 import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import type { NativePlatform } from "@app/native-bridge";
-import { createElement, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { isTextFieldSubmitShortcut, useTextFieldSubmitShortcut } from "./textFieldSubmitShortcut";
 const nativePlatform = vi.hoisted((): { current: NativePlatform } => ({ current: "macos" }));
 vi.mock("./useAppServices", () => ({
   useAppServices: () => ({ nativeBridge: { capabilities: { platform: nativePlatform.current } } }),
 }));
-
 type DirectProps = Readonly<{ action: (() => void) | null; available?: boolean }>;
 function DirectHarness({ action, available = true }: DirectProps) {
   const onKeyDown = useTextFieldSubmitShortcut({ action, available, kind: "direct" });
   return <input aria-label="text" onKeyDown={onKeyDown} />;
 }
-function FormHarness({ children, id = "owner-form" }: Readonly<{ children: ReactNode; id?: string }>) {
+function FormHarness({
+  children,
+  id = "owner-form",
+  onSubmitted,
+}: Readonly<{ children: ReactNode; id?: string; onSubmitted?: () => void }>) {
   const onKeyDown = useTextFieldSubmitShortcut({ available: true, kind: "form" });
-  return createElement("form", { "data-testid": id, id, onKeyDown }, children);
-}
-function formSpy(id = "owner-form") {
-  const form = screen.getByTestId(id);
-  if (!(form instanceof HTMLFormElement)) throw new Error("Expected an owning form.");
-  return vi.spyOn(form, "requestSubmit").mockImplementation(() => undefined);
+  return (
+    <form
+      data-testid={id}
+      id={id}
+      onKeyDown={onKeyDown}
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmitted?.();
+      }}
+    >
+      {children}
+    </form>
+  );
 }
 function press(name: string, options: KeyboardEventInit, role = "textbox") {
   fireEvent.keyDown(screen.getByRole(role, { name }), { key: "Enter", ...options });
@@ -40,7 +50,6 @@ describe("text field submit shortcut", () => {
   it.each([
     ["macos", { key: "Enter", ctrlKey: true }],
     ["windows", { key: "Enter", metaKey: true }],
-    ["macos", { key: "a", metaKey: true }],
     ["macos", { key: "Enter", metaKey: true, isComposing: true }],
     ["browser", { key: "Enter", metaKey: true }],
     ["unknown", { key: "Enter", ctrlKey: true }],
@@ -65,14 +74,14 @@ describe("text field submit shortcut", () => {
     });
     fireEvent(screen.getByRole("textbox", { name: "text" }), unavailable);
     expect(action).toHaveBeenCalledOnce();
-    expect(repeated.defaultPrevented).toBe(true);
-    expect(unavailable.defaultPrevented).toBe(true);
+    expect([repeated.defaultPrevented, unavailable.defaultPrevented]).toEqual([true, true]);
   });
   it("requests only exact owning text targets", () => {
     nativePlatform.current = "macos";
+    const submissions: string[] = [];
     render(
       <>
-        <FormHarness>
+        <FormHarness onSubmitted={() => submissions.push("outer")}>
           <textarea aria-label="body" />
           <input aria-label="read-only" readOnly />
           <input aria-label="radio" type="radio" />
@@ -86,28 +95,19 @@ describe("text field submit shortcut", () => {
           />
           <input aria-label="repeat" />
         </FormHarness>
-        <FormHarness id="inner-form">
+        <FormHarness id="inner-form" onSubmitted={() => submissions.push("inner")}>
           <input aria-label="inner-owned" />
         </FormHarness>
       </>,
     );
-    const submitSpy = formSpy();
     press("body", { metaKey: true });
     press("read-only", { metaKey: true });
     press("unassociated", { metaKey: true });
     press("radio", { metaKey: true }, "radio");
     press("consumed", { metaKey: true });
-    const repeated = createEvent.keyDown(screen.getByRole("textbox", { name: "repeat" }), {
-      key: "Enter",
-      metaKey: true,
-      repeat: true,
-    });
-    fireEvent(screen.getByRole("textbox", { name: "repeat" }), repeated);
-    expect(repeated.defaultPrevented).toBe(true);
-    const innerSubmit = formSpy("inner-form");
+    press("repeat", { metaKey: true, repeat: true });
     press("inner-associated", { metaKey: true });
     press("inner-owned", { metaKey: true });
-    expect(innerSubmit).toHaveBeenCalledOnce();
-    expect(submitSpy).toHaveBeenCalledTimes(2);
+    expect(submissions).toEqual(["outer", "outer", "inner"]);
   });
 });

--- a/apps/desktop/src/app-facade/textFieldSubmitShortcut.test.tsx
+++ b/apps/desktop/src/app-facade/textFieldSubmitShortcut.test.tsx
@@ -1,0 +1,112 @@
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { isTextFieldSubmitShortcut, useTextFieldSubmitShortcut } from "./textFieldSubmitShortcut";
+
+type Platform = "browser" | "linux" | "macos" | "unknown" | "windows";
+const nativePlatform = vi.hoisted((): { current: Platform } => ({ current: "macos" }));
+vi.mock("./useAppServices", () => ({
+  useAppServices: () => ({ nativeBridge: { capabilities: { platform: nativePlatform.current } } }),
+}));
+
+function DirectHarness({ action, available = true }: Readonly<{ action: (() => void) | null; available?: boolean }>) {
+  return <input aria-label="text" onKeyDown={useTextFieldSubmitShortcut({ action, available, kind: "direct" })} />;
+}
+function FormHarness({ children, id = "owner-form" }: Readonly<{ children: ReactNode; id?: string }>) {
+  return (
+    <form data-testid={id} id={id} onKeyDown={useTextFieldSubmitShortcut({ available: true, kind: "form" })} onSubmit={(event) => { event.preventDefault(); }}>
+      {children}
+    </form>
+  );
+}
+
+describe("text field submit shortcut", () => {
+  it.each([
+    ["macos", { metaKey: true }],
+    ["windows", { ctrlKey: true }],
+    ["linux", { ctrlKey: true }],
+  ] as const)("submits the direct action on %s", (platform, modifier) => {
+    nativePlatform.current = platform;
+    const action = vi.fn();
+    render(<DirectHarness action={action} />);
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter", ...modifier });
+    expect(action).toHaveBeenCalledOnce();
+  });
+  it("recognizes only the platform shortcut and ignores composition", () => {
+    for (const [platform, event] of [
+      ["macos", new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true })],
+      ["windows", new KeyboardEvent("keydown", { key: "Enter", metaKey: true })],
+      ["macos", new KeyboardEvent("keydown", { key: "a", metaKey: true })],
+      ["macos", new KeyboardEvent("keydown", { key: "Enter", metaKey: true, isComposing: true })],
+      ["browser", new KeyboardEvent("keydown", { key: "Enter", metaKey: true })],
+      ["unknown", new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true })],
+    ] as const) {
+      expect(isTextFieldSubmitShortcut(event, platform)).toBe(false);
+    }
+  });
+  it("consumes repeated and unavailable direct shortcuts", () => {
+    nativePlatform.current = "macos";
+    const action = vi.fn();
+    const view = render(<DirectHarness action={action} />);
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter", metaKey: true });
+    const repeated = createEvent.keyDown(screen.getByRole("textbox"), { key: "Enter", metaKey: true, repeat: true });
+    fireEvent(screen.getByRole("textbox"), repeated);
+    view.rerender(<DirectHarness action={action} available={false} />);
+    const unavailable = createEvent.keyDown(screen.getByRole("textbox"), { key: "Enter", metaKey: true });
+    fireEvent(screen.getByRole("textbox"), unavailable);
+    expect(action).toHaveBeenCalledOnce();
+    expect(repeated.defaultPrevented).toBe(true);
+    expect(unavailable.defaultPrevented).toBe(true);
+  });
+  it("requests only exact owning text targets", () => {
+    nativePlatform.current = "macos";
+    render(
+      <FormHarness>
+        <textarea aria-label="body" /><input aria-label="read-only" readOnly /><input aria-label="radio" type="radio" />
+        <input aria-label="unassociated" form="missing-form" />
+      </FormHarness>,
+    );
+    const form = screen.getByTestId("owner-form");
+    if (!(form instanceof HTMLFormElement)) throw new Error("Expected an owning form.");
+    const submitSpy = vi.spyOn(form, "requestSubmit");
+    for (const [role, name] of [["textbox", "body"], ["textbox", "read-only"], ["radio", "radio"], ["textbox", "unassociated"]] as const) {
+      fireEvent.keyDown(screen.getByRole(role, { name }), { key: "Enter", metaKey: true });
+    }
+    expect(submitSpy).toHaveBeenCalledTimes(2);
+  });
+  it("keeps an associated inner form responsible for its own target", () => {
+    nativePlatform.current = "macos";
+    render(
+      <>
+        <FormHarness><input aria-label="inner-associated" form="inner-form" /></FormHarness>
+        <FormHarness id="inner-form"><input aria-label="inner-owned" /></FormHarness>
+      </>,
+    );
+    const outer = screen.getByTestId("owner-form");
+    const inner = screen.getByTestId("inner-form");
+    if (!(outer instanceof HTMLFormElement) || !(inner instanceof HTMLFormElement)) throw new Error("Expected owning forms.");
+    const outerSubmit = vi.spyOn(outer, "requestSubmit");
+    const innerSubmit = vi.spyOn(inner, "requestSubmit");
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "inner-associated" }), { key: "Enter", metaKey: true });
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "inner-owned" }), { key: "Enter", metaKey: true });
+    expect(outerSubmit).not.toHaveBeenCalled();
+    expect(innerSubmit).toHaveBeenCalledOnce();
+  });
+  it("skips consumed descendants and consumes form auto-repeat", () => {
+    nativePlatform.current = "windows";
+    render(
+      <FormHarness>
+        <input aria-label="consumed" onKeyDown={(event) => { event.preventDefault(); }} /><input aria-label="repeat" />
+      </FormHarness>,
+    );
+    const form = screen.getByTestId("owner-form");
+    if (!(form instanceof HTMLFormElement)) throw new Error("Expected an owning form.");
+    const submitSpy = vi.spyOn(form, "requestSubmit");
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "consumed" }), { key: "Enter", ctrlKey: true });
+    const repeated = createEvent.keyDown(screen.getByRole("textbox", { name: "repeat" }), { key: "Enter", ctrlKey: true, repeat: true });
+    fireEvent(screen.getByRole("textbox", { name: "repeat" }), repeated);
+    expect(submitSpy).not.toHaveBeenCalled();
+    expect(repeated.defaultPrevented).toBe(true);
+  });
+});

--- a/apps/desktop/src/app-facade/textFieldSubmitShortcut.ts
+++ b/apps/desktop/src/app-facade/textFieldSubmitShortcut.ts
@@ -1,0 +1,95 @@
+import { useCallback, type KeyboardEvent as ReactKeyboardEvent, type KeyboardEventHandler } from "react";
+import type { NativePlatform } from "@app/native-bridge";
+import { useAppServices } from "./useAppServices";
+type TextFieldSubmitKeyEvent = Readonly<{
+  ctrlKey: boolean; defaultPrevented: boolean; isComposing?: boolean | undefined; key: string; metaKey: boolean;
+  nativeEvent?: Readonly<{ isComposing?: boolean | undefined }> | undefined; preventDefault(): void; repeat: boolean;
+  stopPropagation(): void;
+}>;
+type DirectShortcutOptions = Readonly<{ kind: "direct"; action: (() => void) | null; available: boolean }>;
+type FormShortcutOptions = Readonly<{ kind: "form"; available: boolean }>;
+export function useTextFieldSubmitShortcut(
+  options: DirectShortcutOptions,
+): KeyboardEventHandler<HTMLElement>;
+export function useTextFieldSubmitShortcut(options: FormShortcutOptions): KeyboardEventHandler<HTMLFormElement>;
+export function useTextFieldSubmitShortcut(
+  options: DirectShortcutOptions | FormShortcutOptions,
+): KeyboardEventHandler<HTMLElement | HTMLFormElement> {
+  const { nativeBridge } = useAppServices();
+  const platform = nativeBridge.capabilities.platform;
+  return useCallback(
+    (event) => {
+      if (options.kind === "direct") {
+        handleDirectTextFieldSubmit(event, platform, options.available, options.action);
+        return;
+      }
+      handleFormTextFieldSubmit(event, platform, options.available);
+    },
+    [options, platform],
+  );
+}
+
+export function isTextFieldSubmitShortcut(
+  event: Pick<TextFieldSubmitKeyEvent, "ctrlKey" | "isComposing" | "key" | "metaKey" | "nativeEvent" | "repeat">,
+  platform: NativePlatform,
+): boolean {
+  if (event.key !== "Enter" || event.isComposing === true || event.nativeEvent?.isComposing === true) {
+    return false;
+  }
+  if (platform === "macos") {
+    return event.metaKey;
+  }
+  if (platform === "linux" || platform === "windows") {
+    return event.ctrlKey;
+  }
+  return false;
+}
+
+function handleDirectTextFieldSubmit(
+  event: TextFieldSubmitKeyEvent,
+  platform: NativePlatform,
+  available: boolean,
+  action: (() => void) | null,
+): void {
+  if (!isTextFieldSubmitShortcut(event, platform)) {
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  if (!event.repeat && available) {
+    action?.();
+  }
+}
+
+function handleFormTextFieldSubmit(
+  event: ReactKeyboardEvent<HTMLElement | HTMLFormElement>,
+  platform: NativePlatform,
+  available: boolean,
+): void {
+  if (event.defaultPrevented || !isTextFieldSubmitShortcut(event, platform)) {
+    return;
+  }
+  const form = event.currentTarget;
+  if (!(form instanceof HTMLFormElement)) {
+    return;
+  }
+  const target = event.target;
+  if (!isTextualFormTarget(target) || target.form !== form) {
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  if (!event.repeat && available) {
+    form.requestSubmit();
+  }
+}
+
+function isTextualFormTarget(target: EventTarget | null): target is HTMLInputElement | HTMLTextAreaElement {
+  if (target instanceof HTMLTextAreaElement) {
+    return true;
+  }
+  if (!(target instanceof HTMLInputElement)) {
+    return false;
+  }
+  return ["email", "password", "search", "tel", "text", "url"].includes(target.type);
+}

--- a/apps/desktop/src/app-facade/textFieldSubmitShortcut.ts
+++ b/apps/desktop/src/app-facade/textFieldSubmitShortcut.ts
@@ -2,16 +2,22 @@ import { useCallback, type KeyboardEvent as ReactKeyboardEvent, type KeyboardEve
 import type { NativePlatform } from "@app/native-bridge";
 import { useAppServices } from "./useAppServices";
 type TextFieldSubmitKeyEvent = Readonly<{
-  ctrlKey: boolean; defaultPrevented: boolean; isComposing?: boolean | undefined; key: string; metaKey: boolean;
-  nativeEvent?: Readonly<{ isComposing?: boolean | undefined }> | undefined; preventDefault(): void; repeat: boolean;
+  ctrlKey: boolean;
+  defaultPrevented: boolean;
+  isComposing?: boolean | undefined;
+  key: string;
+  metaKey: boolean;
+  nativeEvent?: Readonly<{ isComposing?: boolean | undefined }> | undefined;
+  preventDefault(): void;
+  repeat: boolean;
   stopPropagation(): void;
 }>;
 type DirectShortcutOptions = Readonly<{ kind: "direct"; action: (() => void) | null; available: boolean }>;
 type FormShortcutOptions = Readonly<{ kind: "form"; available: boolean }>;
+export function useTextFieldSubmitShortcut(options: DirectShortcutOptions): KeyboardEventHandler<HTMLElement>;
 export function useTextFieldSubmitShortcut(
-  options: DirectShortcutOptions,
-): KeyboardEventHandler<HTMLElement>;
-export function useTextFieldSubmitShortcut(options: FormShortcutOptions): KeyboardEventHandler<HTMLFormElement>;
+  options: FormShortcutOptions,
+): KeyboardEventHandler<HTMLFormElement>;
 export function useTextFieldSubmitShortcut(
   options: DirectShortcutOptions | FormShortcutOptions,
 ): KeyboardEventHandler<HTMLElement | HTMLFormElement> {
@@ -30,7 +36,10 @@ export function useTextFieldSubmitShortcut(
 }
 
 export function isTextFieldSubmitShortcut(
-  event: Pick<TextFieldSubmitKeyEvent, "ctrlKey" | "isComposing" | "key" | "metaKey" | "nativeEvent" | "repeat">,
+  event: Pick<
+    TextFieldSubmitKeyEvent,
+    "ctrlKey" | "isComposing" | "key" | "metaKey" | "nativeEvent" | "repeat"
+  >,
   platform: NativePlatform,
 ): boolean {
   if (event.key !== "Enter" || event.isComposing === true || event.nativeEvent?.isComposing === true) {

--- a/apps/desktop/src/app-facade/textFieldSubmitShortcut.ts
+++ b/apps/desktop/src/app-facade/textFieldSubmitShortcut.ts
@@ -2,6 +2,7 @@ import { useCallback, type KeyboardEvent as ReactKeyboardEvent, type KeyboardEve
 import type { NativePlatform } from "@app/native-bridge";
 import { useAppServices } from "./useAppServices";
 type TextFieldSubmitKeyEvent = Readonly<{
+  altKey: boolean;
   ctrlKey: boolean;
   defaultPrevented: boolean;
   isComposing?: boolean | undefined;
@@ -10,6 +11,7 @@ type TextFieldSubmitKeyEvent = Readonly<{
   nativeEvent?: Readonly<{ isComposing?: boolean | undefined }> | undefined;
   preventDefault(): void;
   repeat: boolean;
+  shiftKey: boolean;
   stopPropagation(): void;
 }>;
 type DirectShortcutOptions = Readonly<{ kind: "direct"; action: (() => void) | null; available: boolean }>;
@@ -38,18 +40,31 @@ export function useTextFieldSubmitShortcut(
 export function isTextFieldSubmitShortcut(
   event: Pick<
     TextFieldSubmitKeyEvent,
-    "ctrlKey" | "isComposing" | "key" | "metaKey" | "nativeEvent" | "repeat"
+    | "altKey"
+    | "ctrlKey"
+    | "isComposing"
+    | "key"
+    | "metaKey"
+    | "nativeEvent"
+    | "repeat"
+    | "shiftKey"
   >,
   platform: NativePlatform,
 ): boolean {
-  if (event.key !== "Enter" || event.isComposing === true || event.nativeEvent?.isComposing === true) {
+  if (
+    event.key !== "Enter" ||
+    event.isComposing === true ||
+    event.nativeEvent?.isComposing === true ||
+    event.altKey ||
+    event.shiftKey
+  ) {
     return false;
   }
   if (platform === "macos") {
-    return event.metaKey;
+    return event.metaKey && !event.ctrlKey;
   }
   if (platform === "linux" || platform === "windows") {
-    return event.ctrlKey;
+    return event.ctrlKey && !event.metaKey;
   }
   return false;
 }

--- a/apps/desktop/src/features/board/ManualMoveDialog.test.tsx
+++ b/apps/desktop/src/features/board/ManualMoveDialog.test.tsx
@@ -1,9 +1,9 @@
-import { I18nextProvider } from "react-i18next";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import type { TaskMovePreviewResponse } from "@/api";
+import { TestAppProviders, createTestServices } from "@/test-support/app-services";
 import { appI18n, initializeI18n } from "@/i18n";
 import { ManualMoveDialog } from "./ManualMoveDialog";
 
@@ -11,11 +11,13 @@ beforeAll(async () => {
   await initializeI18n();
 });
 
+const appServices = createTestServices([], undefined, { platform: "macos" });
+
 function renderDialog(preview: TaskMovePreviewResponse, onSubmit = vi.fn(), onCancel = vi.fn()) {
   render(
-    <I18nextProvider i18n={appI18n}>
+    <TestAppProviders services={appServices}>
       <ManualMoveDialog onCancel={onCancel} onSubmit={onSubmit} preview={preview} />
-    </I18nextProvider>,
+    </TestAppProviders>,
   );
   return { onCancel, onSubmit };
 }
@@ -110,5 +112,40 @@ describe("ManualMoveDialog", () => {
 
     await user.click(screen.getByRole("button", { name: appI18n.t("app.cancel") }));
     expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("submits valid required values with the desktop text shortcut", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderDialog({
+      outcome: "transition",
+      transition: {
+        choices: [
+          {
+            transitionKey: "transition-0",
+            label: "Implement",
+            sourceNodeDisplayName: "Plan",
+            requiredValues: [
+              {
+                nodeKey: "plan",
+                outputName: "summary",
+                description: "The plan summary.",
+                resolvedValue: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const field = screen.getByLabelText("summary");
+    fireEvent.keyDown(field, { key: "Enter", metaKey: true });
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await user.type(field, "A plan");
+    fireEvent.keyDown(field, { key: "Enter", metaKey: true });
+    expect(onSubmit).toHaveBeenCalledWith({
+      transitionKey: "transition-0",
+      values: { plan: { summary: "A plan" } },
+    });
   });
 });

--- a/apps/desktop/src/features/board/ManualMoveDialog.test.tsx
+++ b/apps/desktop/src/features/board/ManualMoveDialog.test.tsx
@@ -67,9 +67,11 @@ describe("ManualMoveDialog", () => {
     const confirmButton = screen.getByRole("button", { name: appI18n.t("board.manualMoveConfirm") });
     expect(confirmButton).toBeDisabled();
 
+    fireEvent.keyDown(screen.getByLabelText("summary"), { key: "Enter", metaKey: true });
+    expect(onSubmit).not.toHaveBeenCalled();
     await user.type(screen.getByLabelText("summary"), "A plan");
     expect(confirmButton).toBeEnabled();
-    await user.click(confirmButton);
+    fireEvent.keyDown(screen.getByLabelText("summary"), { key: "Enter", metaKey: true });
 
     expect(onSubmit).toHaveBeenCalledWith({
       transitionKey: "transition-0",
@@ -114,38 +116,4 @@ describe("ManualMoveDialog", () => {
     expect(onCancel).toHaveBeenCalledOnce();
   });
 
-  it("submits valid required values with the desktop text shortcut", async () => {
-    const user = userEvent.setup();
-    const { onSubmit } = renderDialog({
-      outcome: "transition",
-      transition: {
-        choices: [
-          {
-            transitionKey: "transition-0",
-            label: "Implement",
-            sourceNodeDisplayName: "Plan",
-            requiredValues: [
-              {
-                nodeKey: "plan",
-                outputName: "summary",
-                description: "The plan summary.",
-                resolvedValue: null,
-              },
-            ],
-          },
-        ],
-      },
-    });
-
-    const field = screen.getByLabelText("summary");
-    fireEvent.keyDown(field, { key: "Enter", metaKey: true });
-    expect(onSubmit).not.toHaveBeenCalled();
-
-    await user.type(field, "A plan");
-    fireEvent.keyDown(field, { key: "Enter", metaKey: true });
-    expect(onSubmit).toHaveBeenCalledWith({
-      transitionKey: "transition-0",
-      values: { plan: { summary: "A plan" } },
-    });
-  });
 });

--- a/apps/desktop/src/features/board/ManualMoveDialog.tsx
+++ b/apps/desktop/src/features/board/ManualMoveDialog.tsx
@@ -2,6 +2,7 @@ import { useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { TaskMovePreviewChoice, TaskMovePreviewResponse } from "@/api";
+import { useTextFieldSubmitShortcut } from "@/app-facade";
 import {
   Button,
   Dialog,
@@ -112,8 +113,12 @@ function ManualMoveDialogContent({
   values: ManualMoveValues;
 }>) {
   const { t } = useTranslation();
-  const contentRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLFormElement | null>(null);
   const [contentHeight, setContentHeight] = useState<number | null>(null);
+  const formShortcut = useTextFieldSubmitShortcut({
+    available: phase === "details" && canSubmit,
+    kind: "form",
+  });
   useLayoutEffect(() => {
     if (contentRef.current !== null) {
       setContentHeight(contentRef.current.scrollHeight);
@@ -129,42 +134,52 @@ function ManualMoveDialogContent({
           : `max-height ${String(motionDurationFromCSSVar("--motion-morph", 220))}ms ease`,
       }}
     >
-      <div className="grid gap-[var(--space-4)]" ref={contentRef}>
-      <div className="manual-move-dialog-phase" key={phase}>
-      {phase === "choices" && choices.length > 1 ? (
-        <ManualMoveChoicePhase
-          choices={choices}
-          onSelect={onSelect}
-          selectedTransitionKey={selectedTransitionKey}
-        />
-      ) : (
-        <ManualMoveDetailsPhase
-          onValueChange={onValueChange}
-          requiredValues={requiredValues}
-          selectedChoice={selectedChoice}
-          values={values}
-        />
-      )}
-      </div>
-      <div className="flex justify-end gap-[var(--space-2)]">
-        <Button onClick={onCancel}>{t("app.cancel")}</Button>
-        {phase === "choices" ? (
-          <Button
-            disabled={!canAdvance}
-            onClick={() => {
-              setPhase("details");
-            }}
-            variant="primary"
-          >
-            {t("app.continue")}
-          </Button>
-        ) : (
-          <Button disabled={!canSubmit} onClick={onSubmit} variant="primary">
-            {t("board.manualMoveConfirm")}
-          </Button>
-        )}
-      </div>
-      </div>
+      <form
+        className="grid gap-[var(--space-4)]"
+        onKeyDown={formShortcut}
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (phase === "details" && canSubmit) {
+            onSubmit();
+          }
+        }}
+        ref={contentRef}
+      >
+        <div className="manual-move-dialog-phase" key={phase}>
+          {phase === "choices" && choices.length > 1 ? (
+            <ManualMoveChoicePhase
+              choices={choices}
+              onSelect={onSelect}
+              selectedTransitionKey={selectedTransitionKey}
+            />
+          ) : (
+            <ManualMoveDetailsPhase
+              onValueChange={onValueChange}
+              requiredValues={requiredValues}
+              selectedChoice={selectedChoice}
+              values={values}
+            />
+          )}
+        </div>
+        <div className="flex justify-end gap-[var(--space-2)]">
+          <Button onClick={onCancel}>{t("app.cancel")}</Button>
+          {phase === "choices" ? (
+            <Button
+              disabled={!canAdvance}
+              onClick={() => {
+                setPhase("details");
+              }}
+              variant="primary"
+            >
+              {t("app.continue")}
+            </Button>
+          ) : (
+            <Button disabled={!canSubmit} type="submit" variant="primary">
+              {t("board.manualMoveConfirm")}
+            </Button>
+          )}
+        </div>
+      </form>
     </div>
   );
 }

--- a/apps/desktop/src/features/home/ProjectCreateForm.tsx
+++ b/apps/desktop/src/features/home/ProjectCreateForm.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
 import { errorMessage } from "@/api";
-import { useAppNavigation } from "@/app-facade";
+import { useAppNavigation, useTextFieldSubmitShortcut } from "@/app-facade";
 import { useAppServices } from "@/app-facade";
 import { useStatusController } from "@/app-facade";
 import { NativeDialogWindow } from "@/shared/native-dialog";
@@ -132,10 +132,15 @@ function ProjectCreateForm({
   });
   const nameField = form.register("name", projectNameRules(t));
   const keyField = form.register("key", projectKeyRules(t));
+  const formShortcut = useTextFieldSubmitShortcut({
+    available: !isCreating,
+    kind: "form",
+  });
 
   return (
     <form
       className={cx("grid gap-[var(--space-3)]", className)}
+      onKeyDown={formShortcut}
       onSubmit={(event) => void form.handleSubmit(onSubmitDraft)(event)}
     >
       <TextInput

--- a/apps/desktop/src/features/project-edit/ProjectEditParts.tsx
+++ b/apps/desktop/src/features/project-edit/ProjectEditParts.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties } from "react";
+import { useState, type CSSProperties, type KeyboardEventHandler } from "react";
 import { useTranslation } from "react-i18next";
 import { Link2Off, Star, Unlink } from "lucide-react";
 
@@ -30,11 +30,13 @@ export function ProjectNameField({
   disabled,
   nameDraft,
   nameErrors,
+  onKeyDown,
   onNameChange,
 }: Readonly<{
   disabled: boolean;
   nameDraft: string;
   nameErrors: readonly string[];
+  onKeyDown: KeyboardEventHandler<HTMLInputElement>;
   onNameChange: (value: string) => void;
 }>) {
   const { t } = useTranslation();
@@ -52,6 +54,7 @@ export function ProjectNameField({
         onChange={(event) => {
           onNameChange(event.target.value);
         }}
+        onKeyDown={onKeyDown}
         value={nameDraft}
       />
       <span
@@ -76,11 +79,13 @@ export function ProjectKeyField({
   disabled,
   keyDraft,
   keyErrors,
+  onKeyDown,
   onKeyChange,
 }: Readonly<{
   disabled: boolean;
   keyDraft: string;
   keyErrors: readonly string[];
+  onKeyDown: KeyboardEventHandler<HTMLInputElement>;
   onKeyChange: (value: string) => void;
 }>) {
   const { t } = useTranslation();
@@ -99,6 +104,7 @@ export function ProjectKeyField({
         onChange={(event) => {
           onKeyChange(event.target.value.toUpperCase());
         }}
+        onKeyDown={onKeyDown}
         spellCheck={false}
         value={keyDraft}
       />

--- a/apps/desktop/src/features/project-edit/ProjectEditRoute.tsx
+++ b/apps/desktop/src/features/project-edit/ProjectEditRoute.tsx
@@ -10,6 +10,7 @@ import { useNativeDialogFallback } from "@/app-facade";
 import { usePublishSidebarHeaderAction } from "@/app-facade";
 import { useSidebarHeaderOffset } from "@/app-facade";
 import { useStatusController } from "@/app-facade";
+import { useTextFieldSubmitShortcut } from "@/app-facade";
 import { useWindowChromeTitle } from "@/app-facade";
 import { Button, ErrorState, HelpHint, LoadingState, VirtualizedInfiniteList } from "@/ui";
 import {
@@ -202,6 +203,13 @@ function ProjectEditContent({
   // Publish the save control into the shared sidebar header (left of delete). It only appears when a
   // draft (name or key) differs from the saved value, and is disabled while invalid or disconnected.
   const canSave = dirty && nameErrors.length === 0 && keyErrors.length === 0 && !mutating;
+  const projectSaveShortcut = useTextFieldSubmitShortcut({
+    action: () => {
+      void saveProject();
+    },
+    available: canSave,
+    kind: "direct",
+  });
   const headerSaveAction = useMemo<ReactNode>(() => {
     if (!dirty) {
       return null;
@@ -229,6 +237,7 @@ function ProjectEditContent({
       nameDraft={nameDraft}
       nameErrors={nameErrors}
       onAttach={() => void chooseWorkspace()}
+      onKeyDown={projectSaveShortcut}
       onKeyChange={setKeyDraft}
       onNameChange={setNameDraft}
     />
@@ -269,6 +278,7 @@ function ProjectEditListHeader({
   nameDraft,
   nameErrors,
   onAttach,
+  onKeyDown,
   onKeyChange,
   onNameChange,
 }: Readonly<{
@@ -278,6 +288,7 @@ function ProjectEditListHeader({
   nameDraft: string;
   nameErrors: readonly string[];
   onAttach: () => void;
+  onKeyDown: React.KeyboardEventHandler<HTMLInputElement>;
   onKeyChange: (value: string) => void;
   onNameChange: (value: string) => void;
 }>) {
@@ -289,12 +300,14 @@ function ProjectEditListHeader({
           disabled={disabled}
           nameDraft={nameDraft}
           nameErrors={nameErrors}
+          onKeyDown={onKeyDown}
           onNameChange={onNameChange}
         />
         <ProjectKeyField
           disabled={disabled}
           keyDraft={keyDraft}
           keyErrors={keyErrors}
+          onKeyDown={onKeyDown}
           onKeyChange={onKeyChange}
         />
       </div>

--- a/apps/desktop/src/features/task-detail/TaskDetailActivity.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailActivity.tsx
@@ -3,8 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import type { ActivityItem, TaskComment } from "@/api";
 import { errorMessage } from "@/api";
-import { formatRelativeTime } from "@/app-facade";
-import { useStatusController } from "@/app-facade";
+import { formatRelativeTime, useStatusController, useTextFieldSubmitShortcut } from "@/app-facade";
 import { Button, homeListCardMaxWidthClassName, IslandSurface, MarkdownText } from "@/ui";
 import { cx, fieldIslandInputClassName } from "@/ui";
 import type { useTaskMutations } from "./useTaskDetailData";
@@ -30,6 +29,7 @@ export function CommentComposer({
   const pending =
     mutations.addComment.isPending || mutations.replaceComment.isPending || mutations.deleteComment.isPending;
   const interactionDisabled = disabled || pending;
+  const canSubmit = !interactionDisabled && commentBody.trim().length > 0;
 
   async function submit(): Promise<void> {
     if (interactionDisabled || commentBody.trim().length === 0) {
@@ -52,6 +52,13 @@ export function CommentComposer({
       });
     }
   }
+  const submitShortcut = useTextFieldSubmitShortcut({
+    action: () => {
+      void submit();
+    },
+    available: canSubmit,
+    kind: "direct",
+  });
 
   return (
     <section className="grid gap-[var(--space-2)]">
@@ -74,6 +81,7 @@ export function CommentComposer({
             }
             onEditingChange({ id: editing.id, body: event.target.value });
           }}
+          onKeyDown={submitShortcut}
           placeholder={editing === null ? `${t("task.addComment")}...` : `${t("task.editComment")}...`}
           value={commentBody}
         />
@@ -81,7 +89,7 @@ export function CommentComposer({
           aria-label={editing === null ? t("task.submitComment") : t("task.saveComment")}
           className="relative z-10 col-start-1 row-start-1 self-end justify-self-end"
           data-testid="task-comment-save"
-          disabled={interactionDisabled || commentBody.trim().length === 0}
+          disabled={!canSubmit}
           onClick={() => void submit()}
           size="icon"
           style={{ marginBottom: "var(--space-2)", marginRight: "var(--space-2)" }}

--- a/apps/desktop/src/features/task-detail/TaskDetailActivity.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailActivity.tsx
@@ -197,9 +197,7 @@ function CommentAuthorIcon({ authorKind }: Readonly<{ authorKind: TaskComment["a
 }
 
 function AuthorText({ author }: Readonly<{ author: string }>) {
-  return (
-    <EllipsisText className="font-bold text-[var(--color-on-island)]" text={author} />
-  );
+  return <EllipsisText className="font-bold text-[var(--color-on-island)]" text={author} />;
 }
 
 function EllipsisText({ className, text }: Readonly<{ className?: string | undefined; text: string }>) {
@@ -210,9 +208,7 @@ function EllipsisText({ className, text }: Readonly<{ className?: string | undef
   );
 }
 
-export function ActivityRow({
-  item,
-}: Readonly<{ item: ActivityItem }>) {
+export function ActivityRow({ item }: Readonly<{ item: ActivityItem }>) {
   const { t } = useTranslation();
   const summary = item.type === "comment" ? item.comment.body : t("task.sessionStarted");
   return (

--- a/apps/desktop/src/features/task-detail/TaskDetailList.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailList.tsx
@@ -95,7 +95,11 @@ export function TaskDetailList({
 }>) {
   const { t } = useTranslation();
   const headerOffset = useSidebarHeaderOffset();
-  const canSaveDraft = !disabled && !updatePending && draft.title.trim().length > 0;
+  const canSaveDraft =
+    (draft.title !== detail.title || draft.body !== detail.body) &&
+    !disabled &&
+    !updatePending &&
+    draft.title.trim().length > 0;
   const activityItems = useMemo(
     () => activity.data?.pages.flatMap((page) => page.items) ?? [],
     [activity.data],

--- a/apps/desktop/src/features/task-detail/TaskDetailList.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailList.tsx
@@ -95,11 +95,8 @@ export function TaskDetailList({
 }>) {
   const { t } = useTranslation();
   const headerOffset = useSidebarHeaderOffset();
-  const canSaveDraft =
-    (draft.title !== detail.title || draft.body !== detail.body) &&
-    !disabled &&
-    !updatePending &&
-    draft.title.trim().length > 0;
+  const draftDirty = draft.title !== detail.title || draft.body !== detail.body;
+  const canSaveDraft = draftDirty && !disabled && !updatePending && draft.title.trim().length > 0;
   const activityItems = useMemo(
     () => activity.data?.pages.flatMap((page) => page.items) ?? [],
     [activity.data],
@@ -189,6 +186,7 @@ export function TaskDetailList({
           attentionPending={attention.isPending}
           commentCount={commentItems.length}
           canSaveDraft={canSaveDraft}
+          draftDirty={draftDirty}
           detail={detail}
           disabled={disabled}
           draft={draft}
@@ -233,6 +231,7 @@ type TaskDetailListRowProps = Readonly<{
   detail: TaskDetail;
   disabled: boolean;
   draft: TaskDraft;
+  draftDirty: boolean;
   descriptionPresentation: DescriptionPresentationState;
   editingComment: Readonly<{ id: string; body: string }> | null;
   errorTitle: string;
@@ -311,10 +310,10 @@ function HeaderRow({
 }
 
 function BodyRow({
-  canSaveDraft,
   detail,
   disabled,
   draft,
+  draftDirty,
   mutations,
   onDraftChange,
   onDescriptionPresentationChange,
@@ -329,9 +328,9 @@ function BodyRow({
       data-testid="task-detail-body-split"
     >
       <DescriptionIsland
-        canSaveDraft={canSaveDraft}
         disabled={disabled || updatePending}
         draft={draft}
+        draftDirty={draftDirty}
         error={updateError}
         onDraftChange={onDraftChange}
         onPresentationChange={onDescriptionPresentationChange}

--- a/apps/desktop/src/features/task-detail/TaskDetailList.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailList.tsx
@@ -95,6 +95,7 @@ export function TaskDetailList({
 }>) {
   const { t } = useTranslation();
   const headerOffset = useSidebarHeaderOffset();
+  const canSaveDraft = !disabled && !updatePending && draft.title.trim().length > 0;
   const activityItems = useMemo(
     () => activity.data?.pages.flatMap((page) => page.items) ?? [],
     [activity.data],
@@ -183,6 +184,7 @@ export function TaskDetailList({
           attentionItems={attentionItems}
           attentionPending={attention.isPending}
           commentCount={commentItems.length}
+          canSaveDraft={canSaveDraft}
           detail={detail}
           disabled={disabled}
           draft={draft}
@@ -222,6 +224,7 @@ type TaskDetailListRowProps = Readonly<{
   activityCount: number;
   attentionItems: readonly AttentionItem[];
   attentionPending: boolean;
+  canSaveDraft: boolean;
   commentCount: number;
   detail: TaskDetail;
   disabled: boolean;
@@ -283,6 +286,7 @@ function TaskDetailListRow(props: TaskDetailListRowProps): ReactNode {
 }
 
 function HeaderRow({
+  canSaveDraft,
   detail,
   disabled,
   draft,
@@ -292,6 +296,7 @@ function HeaderRow({
 }: TaskDetailListRowProps): ReactNode {
   return (
     <TaskHeaderIsland
+      canSaveDraft={canSaveDraft}
       detail={detail}
       disabled={disabled || updatePending}
       draft={draft}
@@ -302,12 +307,14 @@ function HeaderRow({
 }
 
 function BodyRow({
+  canSaveDraft,
   detail,
   disabled,
   draft,
   mutations,
   onDraftChange,
   onDescriptionPresentationChange,
+  onSaveDraft,
   descriptionPresentation,
   updateError,
   updatePending,
@@ -318,11 +325,13 @@ function BodyRow({
       data-testid="task-detail-body-split"
     >
       <DescriptionIsland
+        canSaveDraft={canSaveDraft}
         disabled={disabled || updatePending}
         draft={draft}
         error={updateError}
         onDraftChange={onDraftChange}
         onPresentationChange={onDescriptionPresentationChange}
+        onSave={onSaveDraft}
         presentation={descriptionPresentation}
       />
       <PropertiesIsland detail={detail} disabled={disabled} mutations={mutations} />

--- a/apps/desktop/src/features/task-detail/TaskDetailQuestionFormView.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailQuestionFormView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import { errorMessage, type ApprovalDecision, type QuestionAttentionItem } from "@/api";
 import type { QuestionAnswerInput } from "@/api";
+import { useTextFieldSubmitShortcut } from "@/app-facade";
 import { Button, MarkdownText, RadioGroup, RadioGroupItem, showStatusToast } from "@/ui";
 import { cx, fieldInputClassName } from "@/ui";
 import type { QuestionAnswerMutation } from "./TaskDetailQuestionAnswer";
@@ -303,9 +304,14 @@ function QuestionFormFrame({
 }>) {
   const { t } = useTranslation();
   const submitDisabled = interactionDisabled || !canSubmit;
+  const formShortcut = useTextFieldSubmitShortcut({
+    available: !submitDisabled,
+    kind: "form",
+  });
   return (
     <form
       className="grid gap-[var(--space-2)]"
+      onKeyDown={formShortcut}
       onSubmit={(event) => {
         event.preventDefault();
         if (canSubmit && !interactionDisabled) {

--- a/apps/desktop/src/features/task-detail/TaskDetailQuestionFormView.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailQuestionFormView.tsx
@@ -251,10 +251,7 @@ function ApprovalQuestionForm({
       }}
       onRadioValueChange={(value) => {
         onSelectionStateChange(
-          withApprovalQuestionDecision(
-            selection,
-            approvalDecisionForValue(approvalDecisions, value),
-          ),
+          withApprovalQuestionDecision(selection, approvalDecisionForValue(approvalDecisions, value)),
         );
       }}
       onSubmit={submit}

--- a/apps/desktop/src/features/task-detail/TaskDetailQuestionState.test.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailQuestionState.test.tsx
@@ -210,11 +210,8 @@ describe("questionPresentation", () => {
     expect(
       anchorQuestionSelection(
         emptyQuestionSelection("ask-1"),
-        questionPresentation(
-          approvalAttention(["deny", "allow_session", "allow_once"]),
-          undefined,
-          false,
-        ).defaultSelection,
+        questionPresentation(approvalAttention(["deny", "allow_session", "allow_once"]), undefined, false)
+          .defaultSelection,
       ),
     ).toMatchObject({
       approvalDecision: "allow_once",
@@ -223,8 +220,7 @@ describe("questionPresentation", () => {
     expect(
       anchorQuestionSelection(
         emptyQuestionSelection("ask-1"),
-        questionPresentation(approvalAttention(["allow_session", "deny"]), undefined, false)
-          .defaultSelection,
+        questionPresentation(approvalAttention(["allow_session", "deny"]), undefined, false).defaultSelection,
       ),
     ).toMatchObject({
       approvalDecision: "allow_session",
@@ -235,8 +231,7 @@ describe("questionPresentation", () => {
   it("does not rederive an anchored or explicit choice on refresh", () => {
     const ordinarySelection = anchorQuestionSelection(
       emptyQuestionSelection("ask-1"),
-      questionPresentation(ordinaryAttention(["one", "two", "three"], 2), undefined, false)
-        .defaultSelection,
+      questionPresentation(ordinaryAttention(["one", "two", "three"], 2), undefined, false).defaultSelection,
     );
     const refreshedOrdinary = questionPresentation(
       ordinaryAttention(["three", "one", "two"], 1),
@@ -245,10 +240,7 @@ describe("questionPresentation", () => {
     ).defaultSelection;
     expect(anchorQuestionSelection(ordinarySelection, refreshedOrdinary)).toBe(ordinarySelection);
     expect(
-      anchorQuestionSelection(
-        withOrdinaryQuestionOption(ordinarySelection, 3),
-        refreshedOrdinary,
-      ),
+      anchorQuestionSelection(withOrdinaryQuestionOption(ordinarySelection, 3), refreshedOrdinary),
     ).toMatchObject({
       provenance: "explicit",
       selectedOption: 3,
@@ -256,11 +248,8 @@ describe("questionPresentation", () => {
 
     const approvalSelection = anchorQuestionSelection(
       emptyQuestionSelection("ask-1"),
-      questionPresentation(
-        approvalAttention(["deny", "allow_session", "allow_once"]),
-        undefined,
-        false,
-      ).defaultSelection,
+      questionPresentation(approvalAttention(["deny", "allow_session", "allow_once"]), undefined, false)
+        .defaultSelection,
     );
     const refreshedApproval = questionPresentation(
       approvalAttention(["deny", "allow_once", "allow_session"]),
@@ -269,10 +258,7 @@ describe("questionPresentation", () => {
     ).defaultSelection;
     expect(anchorQuestionSelection(approvalSelection, refreshedApproval)).toBe(approvalSelection);
     expect(
-      anchorQuestionSelection(
-        withApprovalQuestionDecision(approvalSelection, "deny"),
-        refreshedApproval,
-      ),
+      anchorQuestionSelection(withApprovalQuestionDecision(approvalSelection, "deny"), refreshedApproval),
     ).toMatchObject({
       approvalDecision: "deny",
       provenance: "explicit",
@@ -599,9 +585,7 @@ function QuestionFormHarness({
   );
 }
 
-function recordingQuestionAnswerMutation(
-  inputs: QuestionAnswerInput[],
-): QuestionAnswerMutation {
+function recordingQuestionAnswerMutation(inputs: QuestionAnswerInput[]): QuestionAnswerMutation {
   return {
     isPending: false,
     async mutateAsync(input: QuestionAnswerInput): Promise<void> {

--- a/apps/desktop/src/features/task-detail/TaskDetailQuestionState.test.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailQuestionState.test.tsx
@@ -6,8 +6,9 @@ import { I18nextProvider } from "react-i18next";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import type { PendingAsk, QuestionAnswerInput, QuestionAttentionItem } from "@/api";
-import { queryKeys } from "@/app-facade";
+import { AppServicesProvider, queryKeys } from "@/app-facade";
 import { appI18n, initializeI18n } from "@/i18n";
+import { createTestServices } from "@/test-support/app-services";
 import { QuestionBox } from "./TaskDetailQuestionForm";
 import {
   anchorQuestionSelection,
@@ -24,19 +25,25 @@ type FixtureQuestionAttention = QuestionAttentionItem & Readonly<{ sessionID: st
 let questionAnswerMutation: QuestionAnswerMutation;
 let listPendingAsks: (sessionID: string) => Promise<readonly PendingAsk[]>;
 
-vi.mock("@/app-facade", () => ({
-  queryKeys: {
-    pendingAsks: (sessionID: string | null) => ["pending-asks", sessionID],
-  },
-  useAppServices: () => ({
-    api: { listPendingAsks },
-  }),
-  useOpenExternalLink: () => {
-    return () => {
-      return;
-    };
-  },
-}));
+vi.mock("@/app-facade", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    queryKeys: {
+      pendingAsks: (sessionID: string | null) => ["pending-asks", sessionID],
+    },
+    useAppServices: () => ({
+      api: { listPendingAsks },
+    }),
+    useOpenExternalLink: () => {
+      return () => {
+        return;
+      };
+    },
+  };
+});
+
+const shortcutServices = createTestServices([], undefined, { platform: "macos" });
 
 beforeAll(async () => {
   await initializeI18n();
@@ -640,12 +647,14 @@ function questionFormTree(
 ) {
   return (
     <I18nextProvider i18n={appI18n}>
-      <QuestionFormHarness
-        answerQuestion={answerQuestion}
-        attention={attention}
-        initialSelection={selection}
-        presentation={presentation}
-      />
+      <AppServicesProvider services={shortcutServices}>
+        <QuestionFormHarness
+          answerQuestion={answerQuestion}
+          attention={attention}
+          initialSelection={selection}
+          presentation={presentation}
+        />
+      </AppServicesProvider>
     </I18nextProvider>
   );
 }
@@ -658,7 +667,9 @@ function questionBoxTree(
   return (
     <I18nextProvider i18n={appI18n}>
       <QueryClientProvider client={queryClient}>
-        <QuestionBoxHarness attention={attention} onSelectionChange={onSelectionChange} />
+        <AppServicesProvider services={shortcutServices}>
+          <QuestionBoxHarness attention={attention} onSelectionChange={onSelectionChange} />
+        </AppServicesProvider>
       </QueryClientProvider>
     </I18nextProvider>
   );

--- a/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useId, useRef, useState, type RefObject } from "react";
+import { useEffect, useId, useRef, useState, type KeyboardEventHandler, type RefObject } from "react";
 import { ChevronDown, Save } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import type { TaskDetail } from "@/api";
 import { errorMessage } from "@/api";
-import { useAppServices } from "@/app-facade";
+import { useAppServices, useTextFieldSubmitShortcut } from "@/app-facade";
 import { useOpenExternalLink } from "@/app-facade";
 import { writeClipboardText } from "@/shared/native-clipboard";
 import {
@@ -30,12 +30,14 @@ export type TaskDraft = Readonly<{
 }>;
 
 export function TaskHeaderIsland({
+  canSaveDraft,
   detail,
   disabled,
   draft,
   onDraftChange,
   onSave,
 }: Readonly<{
+  canSaveDraft: boolean;
   detail: TaskDetail;
   disabled: boolean;
   draft: TaskDraft;
@@ -45,6 +47,10 @@ export function TaskHeaderIsland({
   const { t } = useTranslation();
   const title = draft.title;
   const dirty = draft.title !== detail.title || draft.body !== detail.body;
+  const formShortcut = useTextFieldSubmitShortcut({
+    available: canSaveDraft,
+    kind: "form",
+  });
 
   function nextTitle(value: string): TaskDraft {
     return { ...draft, title: value.replaceAll("\n", " ") };
@@ -54,9 +60,12 @@ export function TaskHeaderIsland({
     <form
       className="flex min-w-0 items-center gap-[var(--space-2)]"
       data-testid="task-detail-title-island"
+      onKeyDown={formShortcut}
       onSubmit={(event) => {
         event.preventDefault();
-        void onSave();
+        if (canSaveDraft) {
+          void onSave();
+        }
       }}
     >
       <input
@@ -70,7 +79,7 @@ export function TaskHeaderIsland({
           onDraftChange(nextTitle(event.target.value));
         }}
         onKeyDown={(event) => {
-          if (event.key === "Enter") {
+          if (event.key === "Enter" && !event.metaKey && !event.ctrlKey) {
             event.preventDefault();
             event.currentTarget.form?.requestSubmit();
           }
@@ -83,7 +92,7 @@ export function TaskHeaderIsland({
           aria-label={t("task.save")}
           className="shrink-0"
           data-testid="task-detail-save"
-          disabled={disabled || title.trim().length === 0}
+          disabled={!canSaveDraft}
           size="icon"
           type="submit"
           variant="primary"
@@ -96,23 +105,35 @@ export function TaskHeaderIsland({
 }
 
 export function DescriptionIsland({
+  canSaveDraft,
   disabled,
   draft,
   error,
   onDraftChange,
   onPresentationChange,
+  onSave,
   presentation,
 }: Readonly<{
+  canSaveDraft: boolean;
   disabled: boolean;
   draft: TaskDraft;
   error: unknown;
   onDraftChange: (draft: TaskDraft) => void;
   onPresentationChange: (presentation: DescriptionPresentationState) => void;
+  onSave: (draft?: TaskDraft) => Promise<void>;
   presentation: DescriptionPresentationState;
 }>) {
   const descriptionId = useId();
   const descriptionErrorId = `${descriptionId}-error`;
   const descriptionError = error == null ? "" : errorMessage(error);
+  const descriptionShortcut = useTextFieldSubmitShortcut({
+    action: () => {
+      onPresentationChange({ ...presentation, editing: false });
+      void onSave(draft);
+    },
+    available: canSaveDraft && presentation.editing,
+    kind: "direct",
+  });
 
   return (
     <div className="grid min-h-0 min-w-0 gap-[var(--space-2)]" data-testid="task-description-input-frame">
@@ -127,6 +148,7 @@ export function DescriptionIsland({
           onChange={(body) => {
             onDraftChange({ ...draft, body });
           }}
+          onKeyDown={descriptionShortcut}
           value={draft.body}
         />
       ) : (
@@ -160,6 +182,7 @@ function DescriptionEditor({
   id,
   onBlur,
   onChange,
+  onKeyDown,
   value,
 }: Readonly<{
   describedBy: string | undefined;
@@ -167,6 +190,7 @@ function DescriptionEditor({
   id: string;
   onBlur: () => void;
   onChange: (value: string) => void;
+  onKeyDown: KeyboardEventHandler<HTMLTextAreaElement>;
   value: string;
 }>) {
   const { t } = useTranslation();
@@ -185,6 +209,7 @@ function DescriptionEditor({
       onChange={(event) => {
         onChange(event.target.value);
       }}
+      onKeyDown={onKeyDown}
       placeholder={t("task.bodyPlaceholder")}
       value={value}
     />

--- a/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
@@ -105,18 +105,18 @@ export function TaskHeaderIsland({
 }
 
 export function DescriptionIsland({
-  canSaveDraft,
   disabled,
   draft,
+  draftDirty,
   error,
   onDraftChange,
   onPresentationChange,
   onSave,
   presentation,
 }: Readonly<{
-  canSaveDraft: boolean;
   disabled: boolean;
   draft: TaskDraft;
+  draftDirty: boolean;
   error: unknown;
   onDraftChange: (draft: TaskDraft) => void;
   onPresentationChange: (presentation: DescriptionPresentationState) => void;
@@ -128,11 +128,15 @@ export function DescriptionIsland({
   const descriptionError = error == null ? "" : errorMessage(error);
   const descriptionShortcut = useTextFieldSubmitShortcut({
     action: () => {
+      if (!draftDirty) {
+        onPresentationChange({ ...presentation, editing: false });
+        return;
+      }
       void onSave(draft).then(() => {
         onPresentationChange({ ...presentation, editing: false });
       });
     },
-    available: canSaveDraft && presentation.editing,
+    available: !disabled && draft.title.trim().length > 0 && presentation.editing,
     kind: "direct",
   });
 

--- a/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
@@ -128,8 +128,9 @@ export function DescriptionIsland({
   const descriptionError = error == null ? "" : errorMessage(error);
   const descriptionShortcut = useTextFieldSubmitShortcut({
     action: () => {
-      onPresentationChange({ ...presentation, editing: false });
-      void onSave(draft);
+      void onSave(draft).then(() => {
+        onPresentationChange({ ...presentation, editing: false });
+      });
     },
     available: canSaveDraft && presentation.editing,
     kind: "direct",

--- a/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
@@ -386,10 +386,7 @@ export function PropertiesIsland({
         <TaskExecutionTargetFacts detail={detail} />
         <TaskPropertyLine label={t("task.workflow")} value={detail.workflowName} />
         <SourceLine label={t("task.source")} onOpen={openExternalLink} value={detail.sourceURL} />
-        <TaskPropertyLine
-          label={t("task.sessions")}
-          value={detail.retainedSessionCount.toString()}
-        />
+        <TaskPropertyLine label={t("task.sessions")} value={detail.retainedSessionCount.toString()} />
       </dl>
       <TaskActionPanel detail={detail} disabled={disabled} mutations={mutations} />
     </Island>
@@ -491,9 +488,7 @@ function TaskOpenButtons({ detail, disabled }: Readonly<{ detail: TaskDetail; di
             </Button>
           ))
         : null}
-      {openError.length > 0 ? (
-        <p className="m-0 text-sm text-[var(--color-error)]">{openError}</p>
-      ) : null}
+      {openError.length > 0 ? <p className="m-0 text-sm text-[var(--color-error)]">{openError}</p> : null}
     </>
   );
 }

--- a/apps/desktop/src/features/tasks/NewTaskDialog.tsx
+++ b/apps/desktop/src/features/tasks/NewTaskDialog.tsx
@@ -168,7 +168,7 @@ function NewTaskFormContent({
     const availableLabelIDs = new Set(catalog.data.labels.map((label) => label.id));
     return selectedLabelIDs.filter((labelID) => availableLabelIDs.has(labelID));
   }, [catalog.data, selectedLabelIDs]);
-  const defaultWorkspaceID = workspaces.data?.defaultWorkspaceID ?? "";
+  const defaultWorkspaceID = workspaces.data?.defaultWorkspaceID;
   const workspaceItems = useMemo(() => workspaces.data?.workspaces ?? [], [workspaces.data?.workspaces]);
   const initialWorkspaceID = resolveInitialSourceWorkspaceID(
     initialSourceWorkspaceID,
@@ -181,14 +181,14 @@ function NewTaskFormContent({
     defaultValues: {
       title: "",
       body: "",
-      sourceWorkspaceID: initialWorkspaceID,
+      sourceWorkspaceID: initialWorkspaceID ?? "",
     },
   });
   const canSubmit =
-    connection.phase === "connected" && !createTask.isPending && initialWorkspaceID.length > 0;
+    connection.phase === "connected" && !createTask.isPending && initialWorkspaceID !== undefined;
 
   useEffect(() => {
-    if (!initializedRef.current && initialWorkspaceID.length > 0) {
+    if (!initializedRef.current && initialWorkspaceID !== undefined) {
       form.reset({ title: "", body: "", sourceWorkspaceID: initialWorkspaceID });
       initializedRef.current = true;
     }
@@ -198,9 +198,6 @@ function NewTaskFormContent({
       return;
     }
     const sourceWorkspaceID = values.sourceWorkspaceID.trim() || initialWorkspaceID;
-    if (sourceWorkspaceID.length === 0) {
-      return;
-    }
     const availableLabelIDs = new Set(catalog.data?.labels.map((label) => label.id) ?? []);
     try {
       await createTask.mutateAsync({
@@ -230,7 +227,7 @@ function NewTaskFormContent({
   );
   const selectedWorkspaceID = useWatch({ control: form.control, name: "sourceWorkspaceID" });
   const displayedWorkspaceID =
-    selectedWorkspaceID.trim().length > 0 ? selectedWorkspaceID : initialWorkspaceID;
+    selectedWorkspaceID.trim().length > 0 ? selectedWorkspaceID : (initialWorkspaceID ?? "");
   const formShortcut = useTextFieldSubmitShortcut({
     available: canSubmit,
     kind: "form",
@@ -360,17 +357,17 @@ function NewTaskLabels({
 
 function resolveInitialSourceWorkspaceID(
   requestedWorkspaceID: string | undefined,
-  defaultWorkspaceID: string,
+  defaultWorkspaceID: string | undefined,
   workspaceItems: readonly { id: string }[],
-): string {
+): string | undefined {
   if (
     requestedWorkspaceID !== undefined &&
     workspaceItems.some((workspace) => workspace.id === requestedWorkspaceID)
   ) {
     return requestedWorkspaceID;
   }
-  if (defaultWorkspaceID.length > 0) {
+  if (defaultWorkspaceID !== undefined) {
     return defaultWorkspaceID;
   }
-  return workspaceItems[0]?.id ?? "";
+  return workspaceItems[0]?.id;
 }

--- a/apps/desktop/src/features/tasks/NewTaskDialog.tsx
+++ b/apps/desktop/src/features/tasks/NewTaskDialog.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
 import { errorMessage, type TaskDependencyCreateIntent } from "@/api";
-import { useConnectionSnapshot } from "@/app-facade";
+import { useConnectionSnapshot, useTextFieldSubmitShortcut } from "@/app-facade";
 import { useAppServices } from "@/app-facade";
 import { useStatusController } from "@/app-facade";
 import { LabelChooser, ProjectLabelsProvider, useProjectLabelCatalog } from "@/shared/labels";
@@ -184,6 +184,8 @@ function NewTaskFormContent({
       sourceWorkspaceID: initialWorkspaceID,
     },
   });
+  const canSubmit =
+    connection.phase === "connected" && !createTask.isPending && initialWorkspaceID.length > 0;
 
   useEffect(() => {
     if (!initializedRef.current && initialWorkspaceID.length > 0) {
@@ -192,6 +194,9 @@ function NewTaskFormContent({
     }
   }, [form, initialWorkspaceID]);
   async function submit(values: NewTaskFormValues): Promise<void> {
+    if (!canSubmit) {
+      return;
+    }
     const sourceWorkspaceID = values.sourceWorkspaceID.trim() || initialWorkspaceID;
     if (sourceWorkspaceID.length === 0) {
       return;
@@ -226,12 +231,15 @@ function NewTaskFormContent({
   const selectedWorkspaceID = useWatch({ control: form.control, name: "sourceWorkspaceID" });
   const displayedWorkspaceID =
     selectedWorkspaceID.trim().length > 0 ? selectedWorkspaceID : initialWorkspaceID;
-  const disabled =
-    connection.phase !== "connected" || createTask.isPending || initialWorkspaceID.length === 0;
+  const formShortcut = useTextFieldSubmitShortcut({
+    available: canSubmit,
+    kind: "form",
+  });
 
   return (
     <form
       className={cx("grid gap-[var(--space-3)]", className)}
+      onKeyDown={formShortcut}
       onSubmit={(event) => void form.handleSubmit(submit)(event)}
     >
       <TextInput
@@ -288,7 +296,7 @@ function NewTaskFormContent({
       {createTask.error !== null ? (
         <p className="m-0 text-[var(--color-error)]">{errorMessage(createTask.error)}</p>
       ) : null}
-      <Button className="mx-auto w-full max-w-[400px]" disabled={disabled} type="submit" variant="primary">
+      <Button className="mx-auto w-full max-w-[400px]" disabled={!canSubmit} type="submit" variant="primary">
         {t("task.create")}
       </Button>
     </form>

--- a/apps/desktop/src/features/workflows/WorkflowCreateForm.tsx
+++ b/apps/desktop/src/features/workflows/WorkflowCreateForm.tsx
@@ -4,8 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import type { ProjectWorkflowLink, WorkflowRecord } from "@/api";
 import { errorMessage } from "@/api";
-import { queryKeys } from "@/app-facade";
-import { useAppServices } from "@/app-facade";
+import { queryKeys, useAppServices, useTextFieldSubmitShortcut } from "@/app-facade";
 import { Button, ErrorState, TextArea, TextInput } from "@/ui";
 
 export type WorkflowCreateResult = Readonly<{
@@ -43,17 +42,22 @@ export function WorkflowCreateForm({
       onCreated(result);
     },
   });
+  const canSubmit = name.trim().length > 0 && !create.isPending;
+  const formShortcut = useTextFieldSubmitShortcut({
+    available: canSubmit,
+    kind: "form",
+  });
 
   function submit(event: SyntheticEvent<HTMLFormElement>): void {
     event.preventDefault();
-    if (name.trim().length === 0 || create.isPending) {
+    if (!canSubmit) {
       return;
     }
     void create.mutateAsync();
   }
 
   return (
-    <form className="grid gap-[var(--space-4)]" onSubmit={submit}>
+    <form className="grid gap-[var(--space-4)]" onKeyDown={formShortcut} onSubmit={submit}>
       {create.isError ? (
         <ErrorState
           body={errorMessage(create.error)}
@@ -80,7 +84,7 @@ export function WorkflowCreateForm({
         value={description}
       />
       <div className="flex justify-end gap-[var(--space-2)]">
-        <Button disabled={name.trim().length === 0 || create.isPending} type="submit" variant="primary">
+        <Button disabled={!canSubmit} type="submit" variant="primary">
           {create.isPending ? t("workflowLibrary.creating") : t("workflowLibrary.createWorkflow")}
         </Button>
       </div>

--- a/apps/desktop/src/shared/execution-target/ExecutionTargetContinuationDialog.tsx
+++ b/apps/desktop/src/shared/execution-target/ExecutionTargetContinuationDialog.tsx
@@ -166,12 +166,7 @@ function ExecutionTargetForm({
       <ExecutionTargetChoices continuation={continuation} pending={pending} />
       <div className="flex justify-end gap-[var(--space-2)]">
         <Button onClick={continuation.close}>{t("app.cancel")}</Button>
-        <Button
-          data-testid="execution-target-submit"
-          disabled={!canSubmit}
-          type="submit"
-          variant="primary"
-        >
+        <Button data-testid="execution-target-submit" disabled={!canSubmit} type="submit" variant="primary">
           {t("executionTargetContinuation.continue")}
         </Button>
       </div>

--- a/apps/desktop/src/shared/execution-target/ExecutionTargetContinuationDialog.tsx
+++ b/apps/desktop/src/shared/execution-target/ExecutionTargetContinuationDialog.tsx
@@ -5,6 +5,7 @@ import type {
   WorkflowExecutionTargetSelectionMode,
   WorkflowExecutionTargetSelectionRequirement,
 } from "@/api";
+import { useTextFieldSubmitShortcut } from "@/app-facade";
 import { Button, compactDialogWidth, Dialog, RadioGroup, RadioGroupItem, TextInput } from "@/ui";
 import {
   executionTargetSelectionFromDraft,
@@ -140,12 +141,18 @@ function ExecutionTargetForm({
 }>) {
   const { t } = useTranslation();
   const selectedTarget = executionTargetSelectionFromDraft(pending.selection);
+  const canSubmit = selectedTarget !== null;
+  const formShortcut = useTextFieldSubmitShortcut({
+    available: canSubmit,
+    kind: "form",
+  });
   return (
     <form
       className="grid gap-[var(--space-4)]"
+      onKeyDown={formShortcut}
       onSubmit={(event) => {
         event.preventDefault();
-        if (selectedTarget === null) {
+        if (!canSubmit) {
           return;
         }
         onResult({
@@ -161,7 +168,7 @@ function ExecutionTargetForm({
         <Button onClick={continuation.close}>{t("app.cancel")}</Button>
         <Button
           data-testid="execution-target-submit"
-          disabled={selectedTarget === null}
+          disabled={!canSubmit}
           type="submit"
           variant="primary"
         >

--- a/apps/desktop/src/shared/execution-target/TaskInitiatingActionDialogs.test.tsx
+++ b/apps/desktop/src/shared/execution-target/TaskInitiatingActionDialogs.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
 import type { TaskStartResponse, WorkflowExecutionTargetSelection } from "@/api";
+import { TestAppProviders, createTestServices } from "@/test-support/app-services";
 import {
   startTaskInitiatingAction,
   TaskInitiatingActionDialogs,
@@ -17,6 +18,8 @@ type ExecuteStub = (
   selection?: WorkflowExecutionTargetSelection,
 ) => Promise<Readonly<{ kind: "start"; response: TaskStartResponse }>>;
 
+const appServices = createTestServices([], undefined, { platform: "macos" });
+
 describe("TaskInitiatingActionDialogs", () => {
   it("closes dependency confirmation and returns approval without executing it", async () => {
     const execute = vi.fn<ExecuteStub>().mockResolvedValue({
@@ -27,7 +30,11 @@ describe("TaskInitiatingActionDialogs", () => {
       },
     });
     const onResult = vi.fn<(result: TaskInitiatingActionDialogResult) => void>();
-    render(<Harness execute={execute} onResult={onResult} />);
+    render(
+      <TestAppProviders services={appServices}>
+        <Harness execute={execute} onResult={onResult} />
+      </TestAppProviders>,
+    );
     const user = userEvent.setup();
 
     await user.click(screen.getByTestId("initiate-action"));
@@ -49,16 +56,18 @@ describe("TaskInitiatingActionDialogs", () => {
   it("closes dependency confirmation and returns View dependencies", async () => {
     const onResult = vi.fn<(result: TaskInitiatingActionDialogResult) => void>();
     render(
-      <Harness
-        execute={vi.fn<ExecuteStub>().mockResolvedValue({
-          kind: "start",
-          response: {
-            outcome: "dependency_confirmation_required",
-            unsatisfiedDependencyCount: 1,
-          },
-        })}
-        onResult={onResult}
-      />,
+      <TestAppProviders services={appServices}>
+        <Harness
+          execute={vi.fn<ExecuteStub>().mockResolvedValue({
+            kind: "start",
+            response: {
+              outcome: "dependency_confirmation_required",
+              unsatisfiedDependencyCount: 1,
+            },
+          })}
+          onResult={onResult}
+        />
+      </TestAppProviders>,
     );
     const user = userEvent.setup();
 
@@ -78,7 +87,11 @@ describe("TaskInitiatingActionDialogs", () => {
       },
     });
     const onResult = vi.fn<(result: TaskInitiatingActionDialogResult) => void>();
-    render(<Harness execute={execute} onResult={onResult} />);
+    render(
+      <TestAppProviders services={appServices}>
+        <Harness execute={execute} onResult={onResult} />
+      </TestAppProviders>,
+    );
     const user = userEvent.setup();
 
     await user.click(screen.getByTestId("initiate-action"));

--- a/apps/desktop/src/shared/labels/LabelChooser.test.tsx
+++ b/apps/desktop/src/shared/labels/LabelChooser.test.tsx
@@ -4,6 +4,9 @@ import { vi } from "vitest";
 
 import { createLabelFilterState, type LabelFilterAction } from "./labelFilterState";
 import { LabelChooser } from "./LabelChooser";
+import { TestAppProviders, createTestServices } from "@/test-support/app-services";
+
+const appServices = createTestServices([], undefined, { platform: "macos" });
 
 const createdLabelID = "f74ce532-9e6e-4cf6-b3c1-d67d5a3eedcf";
 
@@ -49,16 +52,18 @@ describe("LabelChooser", () => {
     const user = userEvent.setup();
     const actions: LabelFilterAction[] = [];
     render(
-      <LabelChooser
-        invocation={{
-          kind: "filter",
-          onAction(action) {
-            actions.push(action);
-          },
-          state: createLabelFilterState(),
-        }}
-        trigger={<button type="button">Open label chooser</button>}
-      />,
+      <TestAppProviders services={appServices}>
+        <LabelChooser
+          invocation={{
+            kind: "filter",
+            onAction(action) {
+              actions.push(action);
+            },
+            state: createLabelFilterState(),
+          }}
+          trigger={<button type="button">Open label chooser</button>}
+        />
+      </TestAppProviders>,
     );
 
     await user.click(screen.getByRole("button", { name: "Open label chooser" }));

--- a/apps/desktop/src/shared/labels/LabelChooser.tsx
+++ b/apps/desktop/src/shared/labels/LabelChooser.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import { PlusIcon, SearchIcon } from "lucide-react";
 
 import { decodeWorkflowLabelError, errorMessage, workflowLabelMaxIDs, type ProjectLabel } from "@/api";
+import { isTextFieldSubmitShortcut, useAppServices, useTextFieldSubmitShortcut } from "@/app-facade";
 import {
   Button,
   IconTooltipButton,
@@ -57,6 +58,7 @@ type LabelChooserChoice = Readonly<{ kind: "unlabeled" }> | Readonly<{ kind: "la
 
 export function LabelChooser({ invocation, trigger }: LabelChooserProps) {
   const { t } = useTranslation();
+  const { nativeBridge } = useAppServices();
   const catalog = useProjectLabelCatalog();
   const mutations = useProjectLabelCatalogMutations();
   const [search, setSearch] = useState("");
@@ -135,8 +137,31 @@ export function LabelChooser({ invocation, trigger }: LabelChooserProps) {
     const selection = labelResultRowSelection(invocation, choice.label.id);
     selectLabel(invocation, choice.label.id, selection.kind === "binary" ? !selection.selected : true);
   };
+  const hasSearchAction =
+    choiceCount > 0 || (canCreate && !catalogAtLimit && !mutations.create.isPending);
+  const runSearchAction = () => {
+    if (choiceCount > 0) {
+      activateChoice(Math.min(keyboardHighlightedIndex ?? 0, choiceCount - 1));
+      return;
+    }
+    if (canCreate && !catalogAtLimit && !mutations.create.isPending) {
+      void createLabel();
+    }
+  };
+  const searchShortcut = useTextFieldSubmitShortcut({
+    action: runSearchAction,
+    available: hasSearchAction,
+    kind: "direct",
+  });
   const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (handleLabelChoiceNavigation(event, choiceCount, setKeyboardHighlightedIndex)) {
+      return;
+    }
+    if (isTextFieldSubmitShortcut(event, nativeBridge.capabilities.platform)) {
+      searchShortcut(event);
+      return;
+    }
+    if (event.metaKey || event.ctrlKey) {
       return;
     }
     if (event.key !== "Enter") {
@@ -144,12 +169,12 @@ export function LabelChooser({ invocation, trigger }: LabelChooserProps) {
     }
     if (choiceCount > 0) {
       event.preventDefault();
-      activateChoice(Math.min(keyboardHighlightedIndex ?? 0, choiceCount - 1));
+      runSearchAction();
       return;
     }
     if (canCreate && !catalogAtLimit && !mutations.create.isPending) {
       event.preventDefault();
-      void createLabel();
+      runSearchAction();
     }
   };
   const commitRename = async () => {

--- a/apps/desktop/src/shared/labels/LabelChooser.tsx
+++ b/apps/desktop/src/shared/labels/LabelChooser.tsx
@@ -137,8 +137,7 @@ export function LabelChooser({ invocation, trigger }: LabelChooserProps) {
     const selection = labelResultRowSelection(invocation, choice.label.id);
     selectLabel(invocation, choice.label.id, selection.kind === "binary" ? !selection.selected : true);
   };
-  const hasSearchAction =
-    choiceCount > 0 || (canCreate && !catalogAtLimit && !mutations.create.isPending);
+  const hasSearchAction = choiceCount > 0 || (canCreate && !catalogAtLimit && !mutations.create.isPending);
   const runSearchAction = () => {
     if (choiceCount > 0) {
       activateChoice(Math.min(keyboardHighlightedIndex ?? 0, choiceCount - 1));

--- a/apps/desktop/src/shared/labels/LabelChooserRows.tsx
+++ b/apps/desktop/src/shared/labels/LabelChooserRows.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 
 import type { ProjectLabel } from "@/api";
+import { useTextFieldSubmitShortcut } from "@/app-facade";
 import {
   ActionableListRow,
   Button,
@@ -58,12 +59,20 @@ export function LabelRenameEditor({
   rename: RenameState;
 }>) {
   const { t } = useTranslation();
+  const canSubmit = !rename.pending;
+  const formShortcut = useTextFieldSubmitShortcut({
+    available: canSubmit,
+    kind: "form",
+  });
   return (
     <form
       className="grid gap-[var(--space-1)] rounded-[var(--radius-s)] bg-[var(--color-island-1)] p-[var(--space-1)]"
+      onKeyDown={formShortcut}
       onSubmit={(event) => {
         event.preventDefault();
-        onCommit();
+        if (canSubmit) {
+          onCommit();
+        }
       }}
       role="listitem"
     >
@@ -72,14 +81,14 @@ export function LabelRenameEditor({
           aria-label={t("labels.renameField")}
           autoFocus
           className={`${fieldInputClassName} min-w-0 flex-1 py-[var(--space-1)]`}
-          disabled={rename.pending}
+          disabled={!canSubmit}
           onChange={(event) => {
             onChange(event.currentTarget.value);
           }}
           value={rename.draft}
         />
         <IconTooltipButton
-          disabled={rename.pending}
+          disabled={!canSubmit}
           label={t("labels.saveRename")}
           onClick={onCommit}
           size="icon-sm"

--- a/apps/desktop/src/test-support/app-services/index.ts
+++ b/apps/desktop/src/test-support/app-services/index.ts
@@ -1,4 +1,4 @@
-import { createBrowserNativeBridge } from "@app/native-bridge";
+import { createBrowserNativeBridge, type NativePlatform } from "@app/native-bridge";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, useMemo, type ReactNode } from "react";
 import { I18nextProvider } from "react-i18next";
@@ -39,6 +39,7 @@ export type TestAppServices = Omit<AppServices, "logger"> &
 export type CreateTestServicesOptions = Readonly<{
   debugThemeOverrideEnabled?: boolean | undefined;
   homePath?: string | undefined;
+  platform?: NativePlatform | undefined;
 }>;
 
 export function TestAppProviders({
@@ -76,17 +77,20 @@ export function TestAppProviders({
 
 export function createTestServices(
   routes: readonly FakeRoute[],
-  nativeBridge = createBrowserNativeBridge(),
+  nativeBridge?: ReturnType<typeof createBrowserNativeBridge>,
   options: CreateTestServicesOptions = {},
 ): TestAppServices {
   const transport = new FakeRpcTransport(routes);
+  const resolvedNativeBridge =
+    nativeBridge ??
+    createBrowserNativeBridge(options.platform === undefined ? {} : { platform: options.platform });
   return {
     api: new ApiClient(transport),
     debugThemeOverrideEnabled: options.debugThemeOverrideEnabled ?? false,
     endpoint: "ws://127.0.0.1:53082/rpc",
     homePath: options.homePath ?? "",
     logger: createTestLogger(),
-    nativeBridge,
+    nativeBridge: resolvedNativeBridge,
     protocolVersion,
     storageNamespace: {
       kind: "browser-endpoint",

--- a/docs/dev/specs/desktop-gui.md
+++ b/docs/dev/specs/desktop-gui.md
@@ -11,6 +11,9 @@
 - Keep unsent local drafts for new Tasks, comments, and editable Task or Project text while the window stays open. Do not queue or replay mutations. After reconnection, refresh server state and let the operator submit preserved drafts manually; a save overwrites remote changes.
 - Local capabilities such as clipboard, directory selection, separate windows, window controls, and notifications are distinct from server readiness. When unavailable, explain the unavailable action; cosmetic shell behavior may be absent in a browser presentation.
 - Text input is plain multiline Markdown. Raw HTML is unavailable. Links allow only safe protocols and open externally. Code is styled distinctly.
+- When focus is in a Desktop text field outside the Workflow editor, Command+Enter on macOS and Ctrl+Enter on Windows or Linux must invoke that field's existing submit, save, or selection action. The shortcut must follow the same validation, disabled state, and confirmation behavior as that action.
+- The shortcut must do nothing when the focused text field has no existing submission action.
+- The shortcut must not change the field's ordinary Enter behavior.
 - Desktop uses localized user-facing text, accessible controls, standard compact loading, error, and empty states, and motion that respects reduced-motion preference. macOS, Linux, and browser presentation use a contrast fade for readable top chrome; Windows uses progressive blur without a darkening fade.
 - Dialogs, popups, confirmation flows, and dropdowns only collect an operator
   result. They close before returning that result to their parent destination.
@@ -136,6 +139,8 @@
 - Long descriptions start collapsed only when they overflow, at roughly half the available height and never fewer than about five or more than about ten rendered lines, with an expand action. Expansion lasts until that Task Detail closes, keeps the description top anchored, grows downward, and occurs automatically for editing.
 - A Markdown task-list item uses one product-styled checkbox in place of its list bullet.
 - Selecting a checkbox in an editable Task description updates the local Markdown body Draft without saving it. The existing Task Save action persists the changed body.
+- From an editable Task description, the text-field submission shortcut must save the current Task title and body together.
+- From an editable Task description, the text-field submission shortcut must close description editing.
 - Task Detail begins with Inbox, which contains current blockers and answer, Approval, and Resume controls. Comments have composer, list, edit, delete, and count. There is no completed Workflow movement or execution-history view.
 - Task Detail shows Task Short ID, title, Markdown body, Project, Workflow, source workspace name and root, all Current Nodes and states, completion state, and available actions including Task Delete. When available, it also shows Execution Target, managed worktree, requested revision, resolved commit, branch, Agent role and execution state, Session identity, source URL, and assignee or column.
 - Source root and Execution Root are not separate facts. Unavailable expected facts are hidden; useful continuity facts may be empty or unassigned; unexpected meaningful absence is an unavailable or error state. Unavailable managed worktrees have no managed-worktree fact.


### PR DESCRIPTION
## Summary

- Adds a shared Desktop-only text-field submission shortcut: Command+Enter on macOS and Ctrl+Enter on Windows/Linux.
- Reuses each field's existing submit, save, or selection action and preserves ordinary Enter behavior, validation, disabled state, confirmation, composition, repeat-key, exact-modifier, and no-action semantics.
- Wires the shortcut through approvals, questions, comments, Task description editing, Task and Project creation/editing, Workflow creation, manual-move values, execution-target continuation, and Label search/rename flows.
- Keeps save shortcuts unavailable for clean Task drafts, while a valid clean description editor closes without a mutation; dirty descriptions close only after successful persistence.
- Represents an absent initial workspace explicitly and updates the Desktop GUI specification with the shortcut and Task description contracts.

## Verification

- `pnpm --dir apps/desktop test` — passed, 56 files / 262 tests.
- `pnpm --dir apps/desktop exec tsc -b --pretty false` — passed.
- ESLint on all review-touched files — passed.
- Shortcut coverage includes 14 exact/modified predicate cases and the Manual Move dialog's invalid/valid submission path.
- `./scripts/test.sh desktop` — passed earlier in this branch, 56 files / 258 tests; subsequent configured Desktop runs passed 262 tests.
- `./scripts/build.sh desktop` — passed before review-fix commits; review fixes were typechecked, linted, and covered by the full Desktop suite.
- `git diff --check` — clean.

## QA evidence and caveats

- Browser QA evidence from the isolated QA harness:
  - `/Users/nek/Dev/kent/.kent/qa/KENT-375-browser-nativeqa.png`
  - `/Users/nek/Dev/kent/.kent/qa/KENT-375-browser-nativeqa2.png`
- The browser platform intentionally takes the no-op path for the native shortcut; visible comment and Label flows and New Task draft preservation were checked.
- Native Desktop QA was not run per the operator instruction to avoid manual QA, and the fixed Vite port 1420 was occupied. Native-only behavior remains unverified; follow-up is to run native smoke cases when the runtime and port are available.
- No server, API, persistence, or protocol changes are included.
- An initial ad-hoc Vitest invocation omitted this repository's Vite config and failed before loading tests; configured Desktop commands passed.

## Diff size

- Production code: 15 files, 437 gross lines, +247 net lines.
- Test/generated code: 6 files, 291 gross lines, +139 net lines. No generated files were added; test-support is counted here.
- Documentation: 1 file, 5 gross lines, +5 net lines.
- Total: 22 files, 733 gross lines, +391 net lines.

## Tracking

- Kent task: `KENT-375`.
- GitHub issue: none specified in the task.
