### PR TITLE
Add bounded sidebar task navigation stack

### DIFF
--- a/apps/desktop/src/app-facade/navigation.ts
+++ b/apps/desktop/src/app-facade/navigation.ts
@@ -43,11 +43,14 @@ export function useAppNavigation(): AppNavigation {
     [logger],
   );
   const runImmediateNavigation = useCallback(
-    async (action: () => Promise<void>): Promise<void> => {
+    async (action: () => Promise<void>, rethrow = false): Promise<void> => {
       try {
         await action();
       } catch (error) {
         await logger.append("warn", "Navigation failed", { error: errorMessage(error) });
+        if (rethrow) {
+          throw error;
+        }
       }
     },
     [logger],
@@ -116,13 +119,16 @@ export function useAppNavigation(): AppNavigation {
         });
       },
       async closeProjectTask(projectID, workflowID) {
-        await runImmediateNavigation(async () => {
-          await navigate({
-            to: "/projects/$projectId",
-            params: { projectId: projectID },
-            search: { workflowId: workflowID, taskId: "" },
-          });
-        });
+        await runImmediateNavigation(
+          async () => {
+            await navigate({
+              to: "/projects/$projectId",
+              params: { projectId: projectID },
+              search: { workflowId: workflowID, taskId: "" },
+            });
+          },
+          true,
+        );
       },
     }),
     [navigate, router.history, runImmediateNavigation, runNavigation],

--- a/apps/desktop/src/app-facade/navigation.ts
+++ b/apps/desktop/src/app-facade/navigation.ts
@@ -77,7 +77,7 @@ export function useAppNavigation(): AppNavigation {
           await navigate({
             to: "/projects/$projectId",
             params: { projectId: projectID },
-            search: { workflowId: workflowID, taskId: "" },
+            search: { workflowId: workflowID },
           });
         });
       },
@@ -124,7 +124,7 @@ export function useAppNavigation(): AppNavigation {
             await navigate({
               to: "/projects/$projectId",
               params: { projectId: projectID },
-              search: { workflowId: workflowID, taskId: "" },
+              search: { workflowId: workflowID },
             });
           },
           true,

--- a/apps/desktop/src/app-facade/projectDeletionEvents.ts
+++ b/apps/desktop/src/app-facade/projectDeletionEvents.ts
@@ -47,17 +47,25 @@ export async function completeProjectDeletion({
   projectID,
   pushDeletedToast,
   queryClient,
+  shouldCloseSidebar = () => true,
+  shouldNavigateHome = () => true,
 }: Readonly<{
   closeSidebar: SidebarController["closeSidebar"];
   navigateHome: () => Promise<void>;
   projectID: string;
   pushDeletedToast: () => void;
   queryClient: QueryClient;
+  shouldCloseSidebar?: () => boolean;
+  shouldNavigateHome?: () => boolean;
 }>): Promise<void> {
   await invalidateProjectDeleteQueries(queryClient, projectID);
   clearLastProjectRoute(projectID);
-  closeSidebar("closed");
-  await navigateHome();
+  if (shouldCloseSidebar()) {
+    closeSidebar("closed");
+  }
+  if (shouldNavigateHome()) {
+    await navigateHome();
+  }
   pushDeletedToast();
 }
 

--- a/apps/desktop/src/app-facade/sidebarContext.ts
+++ b/apps/desktop/src/app-facade/sidebarContext.ts
@@ -148,6 +148,8 @@ export type SidebarController = Readonly<{
   activeToken: SidebarEntryToken | null;
   backSidebar(): void;
   canGoBack: boolean;
+  sidebarExitBlocked: boolean;
+  setSidebarExitBlocked(token: SidebarEntryToken, blocked: boolean): void;
   closeSidebar(reason?: SidebarCancelReason): void;
   closeSidebarIfCurrent(token: SidebarEntryToken, reason?: SidebarCancelReason): void;
   openSidebar(destination: SidebarDestination): Promise<SidebarResult>;
@@ -188,7 +190,9 @@ export function sidebarRouteMatchesExpectation(
   location: SidebarRouteLocation,
   expectation: SidebarRouteChangeExpectation,
 ): boolean {
-  const search = new URLSearchParams(location.searchStr.startsWith("?") ? location.searchStr.slice(1) : location.searchStr);
+  const search = new URLSearchParams(
+    location.searchStr.startsWith("?") ? location.searchStr.slice(1) : location.searchStr,
+  );
   return (
     location.pathname === `/projects/${expectation.projectID}` &&
     search.get("taskId") === null &&

--- a/apps/desktop/src/app-facade/sidebarContext.ts
+++ b/apps/desktop/src/app-facade/sidebarContext.ts
@@ -141,6 +141,18 @@ export function sidebarDestinationMatchesTask(destination: SidebarDestination, t
   return destination.kind === "taskDetail" && destination.taskID === taskID;
 }
 
+export function sidebarDestinationIndexForTask(
+  destinations: readonly SidebarDestination[],
+  taskID: string,
+): number | undefined {
+  for (const [index, destination] of destinations.entries()) {
+    if (sidebarDestinationMatchesTask(destination, taskID)) {
+      return index;
+    }
+  }
+  return undefined;
+}
+
 export type SidebarController = Readonly<{
   activeDestination: SidebarDestination | null;
   activeActivationID: string | null;

--- a/apps/desktop/src/app-facade/sidebarContext.ts
+++ b/apps/desktop/src/app-facade/sidebarContext.ts
@@ -139,6 +139,7 @@ export type SidebarStateCapture = () => SidebarDestinationSnapshot | null;
 
 export type SidebarController = Readonly<{
   activeDestination: SidebarDestination | null;
+  activeActivationID: string | null;
   activeSnapshot: SidebarDestinationSnapshot | null;
   activeToken: SidebarEntryToken | null;
   backSidebar(): void;

--- a/apps/desktop/src/app-facade/sidebarContext.ts
+++ b/apps/desktop/src/app-facade/sidebarContext.ts
@@ -191,9 +191,7 @@ export function sidebarRouteMatchesExpectation(
   location: SidebarRouteLocation,
   expectation: SidebarRouteChangeExpectation,
 ): boolean {
-  const search = new URLSearchParams(
-    location.searchStr.startsWith("?") ? location.searchStr.slice(1) : location.searchStr,
-  );
+  const search = new URLSearchParams(location.searchStr);
   return (
     location.pathname === `/projects/${expectation.projectID}` &&
     search.get("taskId") === null &&

--- a/apps/desktop/src/app-facade/sidebarContext.ts
+++ b/apps/desktop/src/app-facade/sidebarContext.ts
@@ -152,6 +152,7 @@ export type SidebarController = Readonly<{
   setSidebarExitBlocked(token: SidebarEntryToken, blocked: boolean): void;
   closeSidebar(reason?: SidebarCancelReason): void;
   closeSidebarIfCurrent(token: SidebarEntryToken, reason?: SidebarCancelReason): void;
+  closeSidebarIfCurrentActivation(activationID: string, reason?: SidebarCancelReason): void;
   openSidebar(destination: SidebarDestination): Promise<SidebarResult>;
   pushSidebar(destination: SidebarDestination): void;
   preserveSidebarOnNextRouteChange(

--- a/apps/desktop/src/app-facade/sidebarContext.ts
+++ b/apps/desktop/src/app-facade/sidebarContext.ts
@@ -108,15 +108,50 @@ export type SidebarDestination =
       content: ReactNode;
     }>;
 
+export type SidebarEntryToken = Readonly<{
+  lifecycleID: string;
+  entryID: string;
+}>;
+
+export type SidebarTaskDetailSnapshot = Readonly<{
+  kind: "taskDetail";
+  scrollTop: number;
+  descriptionExpanded: boolean;
+  selectedTab: "comments" | "activity";
+  titleBodyDraft?: Readonly<{ title: string; body: string }> | undefined;
+  newCommentDraft?: string | undefined;
+  editedCommentDraft?: Readonly<{ commentID: string; body: string }> | undefined;
+}>;
+
+export type SidebarDestinationSnapshot = SidebarTaskDetailSnapshot;
+export type SidebarStateCapture = () => SidebarDestinationSnapshot | null;
+
 export type SidebarController = Readonly<{
   activeDestination: SidebarDestination | null;
+  activeSnapshot: SidebarDestinationSnapshot | null;
+  activeToken: SidebarEntryToken | null;
+  backSidebar(): void;
+  canGoBack: boolean;
   closeSidebar(reason?: SidebarCancelReason): void;
+  closeSidebarIfCurrent(token: SidebarEntryToken, reason?: SidebarCancelReason): void;
   openSidebar(destination: SidebarDestination): Promise<SidebarResult>;
+  pushSidebar(destination: SidebarDestination): void;
+  preserveSidebarOnNextRouteChange(): void;
+  consumeSidebarRouteChangePreservation(): boolean;
+  registerSidebarStateCapture(token: SidebarEntryToken, capture: SidebarStateCapture): () => void;
+  removeSidebarEntry(token: SidebarEntryToken): void;
   replaceSidebar(destination: SidebarDestination): void;
+  replaceSidebarIfCurrent(token: SidebarEntryToken, destination: SidebarDestination): void;
   phase: SidebarPhase;
   resolveSidebar(result: Exclude<SidebarResult, SidebarCanceledResult>): void;
+  resolveSidebarIfCurrent(
+    token: SidebarEntryToken,
+    result: Exclude<SidebarResult, SidebarCanceledResult>,
+  ): void;
   resizeSidebar(width: ResolvedSidebarWidth): void;
   sidebarWidthPx: number;
+  stackDestinations: readonly SidebarDestination[];
+  stackEntryTokens: readonly SidebarEntryToken[];
 }>;
 
 export const SidebarContext = createContext<SidebarController | null>(null);

--- a/apps/desktop/src/app-facade/sidebarContext.ts
+++ b/apps/desktop/src/app-facade/sidebarContext.ts
@@ -42,6 +42,11 @@ export type TaskDetailInitialFocus =
   | Readonly<{ kind: "interrupted_current_node" }>
   | Readonly<{ kind: "dependencies" }>;
 
+export type PendingTaskRelationship = Readonly<{
+  originTaskID: string;
+  newTaskRole: "blocker" | "blocked";
+}>;
+
 export type SidebarResult =
   SidebarCanceledResult | SidebarNewTaskResult | SidebarTaskDetailResult | SidebarWorkflowResult;
 
@@ -51,12 +56,7 @@ export type SidebarDestination =
       mode?: SidebarMode;
       boardQueryWorkflowID: string | undefined;
       initialSourceWorkspaceID?: string | undefined;
-      pendingRelationship?:
-        | Readonly<{
-            originTaskID: string;
-            newTaskRole: "blocker" | "blocked";
-          }>
-        | undefined;
+      pendingRelationship?: PendingTaskRelationship | undefined;
       projectID: string;
       workflowID: string;
     }>

--- a/apps/desktop/src/app-facade/sidebarContext.ts
+++ b/apps/desktop/src/app-facade/sidebarContext.ts
@@ -137,6 +137,10 @@ export type SidebarTaskDetailSnapshot = Readonly<{
 export type SidebarDestinationSnapshot = SidebarTaskDetailSnapshot;
 export type SidebarStateCapture = () => SidebarDestinationSnapshot | null;
 
+export function sidebarDestinationMatchesTask(destination: SidebarDestination, taskID: string): boolean {
+  return destination.kind === "taskDetail" && destination.taskID === taskID;
+}
+
 export type SidebarController = Readonly<{
   activeDestination: SidebarDestination | null;
   activeActivationID: string | null;

--- a/apps/desktop/src/app-facade/sidebarContext.ts
+++ b/apps/desktop/src/app-facade/sidebarContext.ts
@@ -187,7 +187,7 @@ export function sidebarRouteMatchesExpectation(
   const search = new URLSearchParams(location.searchStr.startsWith("?") ? location.searchStr.slice(1) : location.searchStr);
   return (
     location.pathname === `/projects/${expectation.projectID}` &&
-    search.get("taskId") === "" &&
+    search.get("taskId") === null &&
     (search.get("workflowId") ?? undefined) === expectation.workflowID
   );
 }

--- a/apps/desktop/src/app-facade/sidebarContext.ts
+++ b/apps/desktop/src/app-facade/sidebarContext.ts
@@ -113,6 +113,17 @@ export type SidebarEntryToken = Readonly<{
   entryID: string;
 }>;
 
+export type SidebarRouteLocation = Readonly<{
+  pathname: string;
+  searchStr: string;
+}>;
+
+export type SidebarRouteChangeExpectation = Readonly<{
+  kind: "projectTaskCleared";
+  projectID: string;
+  workflowID: string | undefined;
+}>;
+
 export type SidebarTaskDetailSnapshot = Readonly<{
   kind: "taskDetail";
   scrollTop: number;
@@ -136,8 +147,12 @@ export type SidebarController = Readonly<{
   closeSidebarIfCurrent(token: SidebarEntryToken, reason?: SidebarCancelReason): void;
   openSidebar(destination: SidebarDestination): Promise<SidebarResult>;
   pushSidebar(destination: SidebarDestination): void;
-  preserveSidebarOnNextRouteChange(): void;
-  consumeSidebarRouteChangePreservation(): boolean;
+  preserveSidebarOnNextRouteChange(
+    token: SidebarEntryToken,
+    expectation: SidebarRouteChangeExpectation,
+  ): void;
+  clearSidebarRouteChangePreservation(token: SidebarEntryToken): void;
+  consumeSidebarRouteChangePreservation(location: SidebarRouteLocation): boolean;
   registerSidebarStateCapture(token: SidebarEntryToken, capture: SidebarStateCapture): () => void;
   removeSidebarEntry(token: SidebarEntryToken): void;
   replaceSidebar(destination: SidebarDestination): void;
@@ -162,4 +177,16 @@ export function useSidebar(): SidebarController {
     throw new Error("SidebarProvider is required");
   }
   return value;
+}
+
+export function sidebarRouteMatchesExpectation(
+  location: SidebarRouteLocation,
+  expectation: SidebarRouteChangeExpectation,
+): boolean {
+  const search = new URLSearchParams(location.searchStr.startsWith("?") ? location.searchStr.slice(1) : location.searchStr);
+  return (
+    location.pathname === `/projects/${expectation.projectID}` &&
+    search.get("taskId") === "" &&
+    (search.get("workflowId") ?? undefined) === expectation.workflowID
+  );
 }

--- a/apps/desktop/src/app-facade/viewTransitions.ts
+++ b/apps/desktop/src/app-facade/viewTransitions.ts
@@ -1,4 +1,4 @@
-export type ViewTransitionScope = "route" | "board-card";
+export type ViewTransitionScope = "route" | "board-card" | "sidebar-push" | "sidebar-back";
 
 export type ViewTransitionOptions = Readonly<{
   scope: ViewTransitionScope;

--- a/apps/desktop/src/app/AppChrome.tsx
+++ b/apps/desktop/src/app/AppChrome.tsx
@@ -153,14 +153,14 @@ function ProjectDeletionEventHandler() {
   const queryClient = useQueryClient();
   const { nativeBridge } = useAppServices();
   const navigation = useAppNavigation();
-  const { activeDestination, closeSidebar } = useSidebar();
+  const { closeSidebar, stackDestinations } = useSidebar();
   const { push } = useStatusController();
   useProjectDeletedEvents(
     nativeBridge,
     useCallback(
       (event) => {
         const routeMatches = routeReferencesProject(location.pathname, event.projectID);
-        const sidebarMatches = sidebarReferencesProject(activeDestination, event.projectID);
+        const sidebarMatches = sidebarReferencesProject(stackDestinations, event.projectID);
         void completeProjectDeletion({
           closeSidebar: routeMatches || sidebarMatches ? closeSidebar : noopCloseSidebar,
           navigateHome: routeMatches ? navigation.openHome : noopNavigation,
@@ -175,7 +175,7 @@ function ProjectDeletionEventHandler() {
           queryClient,
         });
       },
-      [activeDestination, closeSidebar, location.pathname, navigation.openHome, push, queryClient, t],
+      [closeSidebar, location.pathname, navigation.openHome, push, queryClient, stackDestinations, t],
     ),
   );
   return null;
@@ -186,14 +186,16 @@ function routeReferencesProject(pathname: string, projectID: string): boolean {
   return segments[0] === "projects" && segments[1] === projectID;
 }
 
-function sidebarReferencesProject(destination: SidebarDestination | null, projectID: string): boolean {
-  if (destination === null) {
-    return false;
-  }
-  if ("projectID" in destination && destination.projectID === projectID) {
-    return true;
-  }
-  return destination.kind === "linkWorkflow" && destination.projectID === projectID;
+function sidebarReferencesProject(
+  destinations: readonly SidebarDestination[],
+  projectID: string,
+): boolean {
+  return destinations.some((destination) => {
+    if ("projectID" in destination && destination.projectID === projectID) {
+      return true;
+    }
+    return destination.kind === "linkWorkflow" && destination.projectID === projectID;
+  });
 }
 
 function noopCloseSidebar(): void {

--- a/apps/desktop/src/app/AppChrome.tsx
+++ b/apps/desktop/src/app/AppChrome.tsx
@@ -162,7 +162,11 @@ function ProjectDeletionEventHandler() {
   const navigation = useAppNavigation();
   const { closeSidebar, stackDestinations } = useSidebar();
   const { push } = useStatusController();
+  const pathnameRef = useRef(location.pathname);
   const stackDestinationsRef = useRef(stackDestinations);
+  useLayoutEffect(() => {
+    pathnameRef.current = location.pathname;
+  }, [location.pathname]);
   useLayoutEffect(() => {
     stackDestinationsRef.current = stackDestinations;
   }, [stackDestinations]);
@@ -170,11 +174,9 @@ function ProjectDeletionEventHandler() {
     nativeBridge,
     useCallback(
       (event) => {
-        const routeMatches = routeReferencesProject(location.pathname, event.projectID);
-        const sidebarMatches = sidebarReferencesProject(stackDestinationsRef.current, event.projectID);
         void completeProjectDeletion({
-          closeSidebar: routeMatches || sidebarMatches ? closeSidebar : noopCloseSidebar,
-          navigateHome: routeMatches ? navigation.openHome : noopNavigation,
+          closeSidebar,
+          navigateHome: navigation.openHome,
           projectID: event.projectID,
           pushDeletedToast: () => {
             push({
@@ -184,9 +186,11 @@ function ProjectDeletionEventHandler() {
             });
           },
           queryClient,
+          shouldCloseSidebar: () => sidebarReferencesProject(stackDestinationsRef.current, event.projectID),
+          shouldNavigateHome: () => routeReferencesProject(pathnameRef.current, event.projectID),
         });
       },
-      [closeSidebar, location.pathname, navigation.openHome, push, queryClient, t],
+      [closeSidebar, navigation.openHome, push, queryClient, t],
     ),
   );
   return null;
@@ -204,14 +208,6 @@ function sidebarReferencesProject(destinations: readonly SidebarDestination[], p
     }
     return destination.kind === "linkWorkflow" && destination.projectID === projectID;
   });
-}
-
-function noopCloseSidebar(): void {
-  return;
-}
-
-async function noopNavigation(): Promise<void> {
-  return;
 }
 
 function isPlainPrimaryClick(event: MouseEvent): boolean {

--- a/apps/desktop/src/app/AppChrome.tsx
+++ b/apps/desktop/src/app/AppChrome.tsx
@@ -1,7 +1,14 @@
 import { Link, useLocation } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight, Home, SunMoon } from "lucide-react";
-import { useCallback, type MouseEvent, type PointerEvent, type ReactNode } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  type MouseEvent,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
 import { useTranslation } from "react-i18next";
 
 import { WorkflowEditorDraftBridgeProvider } from "@/features/workflow-editor";
@@ -155,12 +162,16 @@ function ProjectDeletionEventHandler() {
   const navigation = useAppNavigation();
   const { closeSidebar, stackDestinations } = useSidebar();
   const { push } = useStatusController();
+  const stackDestinationsRef = useRef(stackDestinations);
+  useLayoutEffect(() => {
+    stackDestinationsRef.current = stackDestinations;
+  }, [stackDestinations]);
   useProjectDeletedEvents(
     nativeBridge,
     useCallback(
       (event) => {
         const routeMatches = routeReferencesProject(location.pathname, event.projectID);
-        const sidebarMatches = sidebarReferencesProject(stackDestinations, event.projectID);
+        const sidebarMatches = sidebarReferencesProject(stackDestinationsRef.current, event.projectID);
         void completeProjectDeletion({
           closeSidebar: routeMatches || sidebarMatches ? closeSidebar : noopCloseSidebar,
           navigateHome: routeMatches ? navigation.openHome : noopNavigation,
@@ -175,7 +186,7 @@ function ProjectDeletionEventHandler() {
           queryClient,
         });
       },
-      [closeSidebar, location.pathname, navigation.openHome, push, queryClient, stackDestinations, t],
+      [closeSidebar, location.pathname, navigation.openHome, push, queryClient, t],
     ),
   );
   return null;
@@ -186,10 +197,7 @@ function routeReferencesProject(pathname: string, projectID: string): boolean {
   return segments[0] === "projects" && segments[1] === projectID;
 }
 
-function sidebarReferencesProject(
-  destinations: readonly SidebarDestination[],
-  projectID: string,
-): boolean {
+function sidebarReferencesProject(destinations: readonly SidebarDestination[], projectID: string): boolean {
   return destinations.some((destination) => {
     if ("projectID" in destination && destination.projectID === projectID) {
       return true;

--- a/apps/desktop/src/app/projectRouteErrors.ts
+++ b/apps/desktop/src/app/projectRouteErrors.ts
@@ -1,12 +1,5 @@
-const legacyEmptyTaskSelectorMessage =
-  "This legacy project URL contains an empty task selector. Remove '?taskId=' from the URL and reload the project.";
-
 export class LegacyEmptyTaskSelectorError extends Error {
   readonly kind = "legacy_empty_task_selector";
-
-  constructor() {
-    super(legacyEmptyTaskSelectorMessage);
-  }
 }
 
 export function isLegacyEmptyTaskSelectorError(error: Error): error is LegacyEmptyTaskSelectorError {

--- a/apps/desktop/src/app/projectRouteErrors.ts
+++ b/apps/desktop/src/app/projectRouteErrors.ts
@@ -1,0 +1,14 @@
+const legacyEmptyTaskSelectorMessage =
+  "This legacy project URL contains an empty task selector. Remove '?taskId=' from the URL and reload the project.";
+
+export class LegacyEmptyTaskSelectorError extends Error {
+  readonly kind = "legacy_empty_task_selector";
+
+  constructor() {
+    super(legacyEmptyTaskSelectorMessage);
+  }
+}
+
+export function isLegacyEmptyTaskSelectorError(error: Error): error is LegacyEmptyTaskSelectorError {
+  return error instanceof LegacyEmptyTaskSelectorError;
+}

--- a/apps/desktop/src/app/routeComponents.tsx
+++ b/apps/desktop/src/app/routeComponents.tsx
@@ -8,6 +8,7 @@ import { StartupGate } from "@/features/startup";
 import { StandaloneTaskRoute } from "@/features/task-detail";
 import { ErrorState, LoadingState } from "@/ui";
 import { AppChrome } from "./AppChrome";
+import { isLegacyEmptyTaskSelectorError } from "./projectRouteErrors";
 import {
   readBrowserStorage,
   readLastProjectRoute,
@@ -119,7 +120,13 @@ export function ProjectRoute() {
 
 export function ProjectRouteError({ error }: { error: Error }) {
   const { t } = useTranslation();
-  return <ErrorState body={error.message} reveal={false} title={t("states.error")} />;
+  return (
+    <ErrorState
+      body={isLegacyEmptyTaskSelectorError(error) ? error.message : t("form.serverError")}
+      reveal={false}
+      title={t("states.error")}
+    />
+  );
 }
 
 export function HomeShellRoute() {

--- a/apps/desktop/src/app/routeComponents.tsx
+++ b/apps/desktop/src/app/routeComponents.tsx
@@ -122,7 +122,9 @@ export function ProjectRouteError({ error }: { error: Error }) {
   const { t } = useTranslation();
   return (
     <ErrorState
-      body={isLegacyEmptyTaskSelectorError(error) ? error.message : t("form.serverError")}
+      body={
+        isLegacyEmptyTaskSelectorError(error) ? t("routes.legacyEmptyTaskSelector") : t("form.serverError")
+      }
       reveal={false}
       title={t("states.error")}
     />

--- a/apps/desktop/src/app/routeComponents.tsx
+++ b/apps/desktop/src/app/routeComponents.tsx
@@ -76,7 +76,7 @@ function RoutePersistence() {
         void navigate({
           to: "/projects/$projectId",
           params: { projectId: restored.projectId },
-          search: { workflowId: restored.workflowId, taskId: "" },
+          search: { workflowId: restored.workflowId },
           replace: true,
         });
       }

--- a/apps/desktop/src/app/routeComponents.tsx
+++ b/apps/desktop/src/app/routeComponents.tsx
@@ -6,7 +6,7 @@ import { BoardRoute } from "@/features/board";
 import { HomeRoute } from "@/features/home";
 import { StartupGate } from "@/features/startup";
 import { StandaloneTaskRoute } from "@/features/task-detail";
-import { LoadingState } from "@/ui";
+import { ErrorState, LoadingState } from "@/ui";
 import { AppChrome } from "./AppChrome";
 import {
   readBrowserStorage,
@@ -115,6 +115,11 @@ export function ProjectRoute() {
   return (
     <BoardRoute projectId={params.projectId} selectedTaskId={search.taskId} workflowId={search.workflowId} />
   );
+}
+
+export function ProjectRouteError({ error }: { error: Error }) {
+  const { t } = useTranslation();
+  return <ErrorState body={error.message} reveal={false} title={t("states.error")} />;
 }
 
 export function HomeShellRoute() {

--- a/apps/desktop/src/app/routes.test.tsx
+++ b/apps/desktop/src/app/routes.test.tsx
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { LegacyEmptyTaskSelectorError } from "./projectRouteErrors";
 import { createAppRouter } from "./routes";
 
 it("rejects malformed present workflow selectors while preserving omission", () => {
@@ -11,8 +12,6 @@ it("rejects malformed present workflow selectors while preserving omission", () 
     taskId: undefined,
     workflowId: "7e8d24d2-8a98-4dcf-a197-6214db1cb3c0",
   });
-  expect(() => validate({ taskId: "" })).toThrow(
-    "This legacy project URL contains an empty task selector. Remove '?taskId=' from the URL and reload the project.",
-  );
+  expect(() => validate({ taskId: "" })).toThrow(LegacyEmptyTaskSelectorError);
   expect(() => validate({ workflowId: "workflow-1" })).toThrow();
 });

--- a/apps/desktop/src/app/routes.test.tsx
+++ b/apps/desktop/src/app/routes.test.tsx
@@ -6,10 +6,11 @@ it("rejects malformed present workflow selectors while preserving omission", () 
   if (!(validate instanceof Function)) {
     throw new Error("project route search validation is unavailable");
   }
-  expect(validate({})).toEqual({ taskId: "", workflowId: undefined });
+  expect(validate({})).toEqual({ taskId: undefined, workflowId: undefined });
   expect(validate({ workflowId: "7e8d24d2-8a98-4dcf-a197-6214db1cb3c0" })).toEqual({
-    taskId: "",
+    taskId: undefined,
     workflowId: "7e8d24d2-8a98-4dcf-a197-6214db1cb3c0",
   });
+  expect(() => validate({ taskId: "" })).toThrow();
   expect(() => validate({ workflowId: "workflow-1" })).toThrow();
 });

--- a/apps/desktop/src/app/routes.test.tsx
+++ b/apps/desktop/src/app/routes.test.tsx
@@ -11,6 +11,8 @@ it("rejects malformed present workflow selectors while preserving omission", () 
     taskId: undefined,
     workflowId: "7e8d24d2-8a98-4dcf-a197-6214db1cb3c0",
   });
-  expect(() => validate({ taskId: "" })).toThrow();
+  expect(() => validate({ taskId: "" })).toThrow(
+    "This legacy project URL contains an empty task selector. Remove '?taskId=' from the URL and reload the project.",
+  );
   expect(() => validate({ workflowId: "workflow-1" })).toThrow();
 });

--- a/apps/desktop/src/app/routes.tsx
+++ b/apps/desktop/src/app/routes.tsx
@@ -12,12 +12,10 @@ import {
   WorkflowEditorShellRoute,
   WorkflowLibraryShellRoute,
 } from "./routeComponents";
+import { LegacyEmptyTaskSelectorError } from "./projectRouteErrors";
 
 const optionalSearchString = z.string().catch("");
 const optionalWorkflowSelector = workflowIDSchema.optional();
-const legacyEmptyTaskSelectorMessage =
-  "This legacy project URL contains an empty task selector. Remove '?taskId=' from the URL and reload the project.";
-
 const projectSearchSchema = z.object({
   workflowId: optionalWorkflowSelector,
   taskId: z.string().min(1).optional(),
@@ -86,7 +84,7 @@ export function shouldSkipNativeDialogStartupGate(pathname: string): boolean {
 
 function validateProjectSearch(search: Record<string, unknown>) {
   if (search.taskId === "") {
-    throw new Error(legacyEmptyTaskSelectorMessage);
+    throw new LegacyEmptyTaskSelectorError();
   }
   return projectSearchSchema.parse(search);
 }

--- a/apps/desktop/src/app/routes.tsx
+++ b/apps/desktop/src/app/routes.tsx
@@ -17,7 +17,7 @@ const optionalWorkflowSelector = workflowIDSchema.optional();
 
 const projectSearchSchema = z.object({
   workflowId: optionalWorkflowSelector,
-  taskId: optionalSearchString,
+  taskId: z.string().min(1).optional(),
 });
 
 const workflowEditorSearchSchema = z.object({

--- a/apps/desktop/src/app/routes.tsx
+++ b/apps/desktop/src/app/routes.tsx
@@ -14,6 +14,8 @@ import {
 
 const optionalSearchString = z.string().catch("");
 const optionalWorkflowSelector = workflowIDSchema.optional();
+const legacyEmptyTaskSelectorMessage =
+  "This legacy project URL contains an empty task selector. Remove '?taskId=' from the URL and reload the project.";
 
 const projectSearchSchema = z.object({
   workflowId: optionalWorkflowSelector,
@@ -35,7 +37,7 @@ const homeRoute = createRoute({
 const projectRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/projects/$projectId",
-  validateSearch: (search: Record<string, unknown>) => projectSearchSchema.parse(search),
+  validateSearch: validateProjectSearch,
   component: ProjectRoute,
 });
 
@@ -78,6 +80,13 @@ export type AppRouter = ReturnType<typeof createAppRouter>;
 
 export function shouldSkipNativeDialogStartupGate(pathname: string): boolean {
   return pathname === workspaceUnlinkNativeDialogPath;
+}
+
+function validateProjectSearch(search: Record<string, unknown>) {
+  if (search.taskId === "") {
+    throw new Error(legacyEmptyTaskSelectorMessage);
+  }
+  return projectSearchSchema.parse(search);
 }
 
 declare module "@tanstack/react-router" {

--- a/apps/desktop/src/app/routes.tsx
+++ b/apps/desktop/src/app/routes.tsx
@@ -6,6 +6,7 @@ import { createNativeDialogRoutes, workspaceUnlinkNativeDialogPath } from "./nat
 import {
   HomeShellRoute,
   ProjectRoute,
+  ProjectRouteError,
   RootRoute,
   TaskRoute,
   WorkflowEditorShellRoute,
@@ -39,6 +40,7 @@ const projectRoute = createRoute({
   path: "/projects/$projectId",
   validateSearch: validateProjectSearch,
   component: ProjectRoute,
+  errorComponent: ProjectRouteError,
 });
 
 const workflowLibraryRoute = createRoute({

--- a/apps/desktop/src/app/sidebar.tsx
+++ b/apps/desktop/src/app/sidebar.tsx
@@ -1,6 +1,6 @@
 import { useLocation } from "@tanstack/react-router";
 import type { NativeDialogWindowOptions } from "@app/native-bridge";
-import { PictureInPicture, Plus, X } from "lucide-react";
+import { ChevronLeft, PictureInPicture, Plus, X } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -25,7 +25,7 @@ import { useStatusController } from "@/app-facade";
 import { SidebarHeaderActionProvider, SidebarHeaderActionSlot } from "@/app-facade";
 import { SidebarDestinationView } from "./sidebarDestinations";
 import { SidebarHeaderOffsetContext } from "@/app-facade";
-import { sidebarPopOutOptions } from "./sidebarPopOut";
+import { sidebarPopOutOptions, shouldCloseSidebarAfterPopOut } from "./sidebarPopOut";
 import { sidebarTitle } from "@/app-facade";
 import { sidebarSizePreference } from "@/app-facade";
 import { useSidebar, type SidebarDestination } from "@/app-facade";
@@ -40,25 +40,44 @@ import {
 
 export function SidebarRouteChangeCloser() {
   const location = useLocation();
-  const { activeDestination, closeSidebar } = useSidebar();
+  const {
+    closeSidebar,
+    consumeSidebarRouteChangePreservation,
+    stackDestinations,
+  } = useSidebar();
   const routeKey = `${location.pathname}?${location.searchStr}`;
   const previousRouteKeyRef = useRef(routeKey);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (previousRouteKeyRef.current !== routeKey) {
       previousRouteKeyRef.current = routeKey;
-      if (activeDestination !== null) {
+      if (stackDestinations.length > 0 && !consumeSidebarRouteChangePreservation()) {
         closeSidebar("route_change");
       }
     }
-  }, [activeDestination, closeSidebar, routeKey]);
+  }, [
+    closeSidebar,
+    consumeSidebarRouteChangePreservation,
+    routeKey,
+    stackDestinations.length,
+  ]);
 
   return null;
 }
 
 export function SidebarHost() {
   const { t } = useTranslation();
-  const { activeDestination, closeSidebar, phase, resizeSidebar, resolveSidebar, sidebarWidthPx } =
+  const {
+    activeDestination,
+    activeSnapshot,
+    backSidebar,
+    canGoBack,
+    closeSidebar,
+    phase,
+    resizeSidebar,
+    resolveSidebar,
+    sidebarWidthPx,
+  } =
     useSidebar();
   const sizePreference = useMemo(() => sidebarSizePreference(activeDestination), [activeDestination]);
   const titleId = useId();
@@ -275,6 +294,16 @@ export function SidebarHost() {
           >
             <X aria-hidden="true" size={18} strokeWidth={1.5} />
           </IconTooltipButton>
+          {canGoBack ? (
+            <IconTooltipButton
+              label={t("app.back")}
+              onClick={() => {
+                backSidebar();
+              }}
+            >
+              <ChevronLeft aria-hidden="true" size={18} strokeWidth={1.5} />
+            </IconTooltipButton>
+          ) : null}
           <h2 className="m-0 min-w-0 truncate text-[1.05rem] font-bold" id={titleId}>
             {title}
           </h2>
@@ -294,9 +323,11 @@ export function SidebarHost() {
                 ? "top-0 overflow-hidden"
                 : "top-0 overflow-y-auto px-[var(--space-4)] pb-[var(--space-4)] pt-[calc(var(--app-sidebar-header-height)+var(--space-4))]",
           )}
+          style={{ viewTransitionName: "sidebar-destination" }}
         >
           <SidebarHeaderOffsetContext.Provider value={headerOffsetPx}>
             <SidebarDestinationView
+              activeSnapshot={activeSnapshot}
               closeSidebar={closeSidebar}
               destination={activeDestination}
               resolveSidebar={resolveSidebar}
@@ -329,8 +360,12 @@ function SidebarPopOutSlot({
 function SidebarPopOutButton({ options }: Readonly<{ options: NativeDialogWindowOptions }>) {
   const { t } = useTranslation();
   const { nativeBridge } = useAppServices();
-  const { closeSidebar } = useSidebar();
+  const { activeToken, closeSidebarIfCurrent } = useSidebar();
   const { push } = useStatusController();
+  const activeTokenRef = useRef(activeToken);
+  useEffect(() => {
+    activeTokenRef.current = activeToken;
+  }, [activeToken]);
   if (!nativeBridge.capabilities.dialogWindows) {
     return null;
   }
@@ -338,10 +373,16 @@ function SidebarPopOutButton({ options }: Readonly<{ options: NativeDialogWindow
     <IconTooltipButton
       label={t("app.popOut")}
       onClick={() => {
+        const openedToken = activeToken;
+        if (openedToken === null) {
+          return;
+        }
         void nativeBridge.dialogs
           .openWindow(options)
           .then(() => {
-            closeSidebar("closed");
+            if (shouldCloseSidebarAfterPopOut(openedToken, activeTokenRef.current)) {
+              closeSidebarIfCurrent(openedToken, "closed");
+            }
           })
           .catch((error: unknown) => {
             push({

--- a/apps/desktop/src/app/sidebar.tsx
+++ b/apps/desktop/src/app/sidebar.tsx
@@ -40,11 +40,7 @@ import {
 
 export function SidebarRouteChangeCloser() {
   const location = useLocation();
-  const {
-    closeSidebar,
-    consumeSidebarRouteChangePreservation,
-    stackDestinations,
-  } = useSidebar();
+  const { closeSidebar, consumeSidebarRouteChangePreservation, stackDestinations } = useSidebar();
   const routeKey = `${location.pathname}?${location.searchStr}`;
   const previousRouteKeyRef = useRef(routeKey);
 
@@ -82,9 +78,9 @@ export function SidebarHost() {
     phase,
     resizeSidebar,
     resolveSidebar,
+    sidebarExitBlocked,
     sidebarWidthPx,
-  } =
-    useSidebar();
+  } = useSidebar();
   const sizePreference = useMemo(() => sidebarSizePreference(activeDestination), [activeDestination]);
   const titleId = useId();
   const sidebarRef = useRef<HTMLElement | null>(null);
@@ -294,6 +290,7 @@ export function SidebarHost() {
         >
           <div className="flex items-center gap-[var(--space-2)]">
             <IconTooltipButton
+              disabled={sidebarExitBlocked}
               label={t("app.close")}
               onClick={() => {
                 closeSidebar("closed");
@@ -303,6 +300,7 @@ export function SidebarHost() {
             </IconTooltipButton>
             {canGoBack ? (
               <IconTooltipButton
+                disabled={sidebarExitBlocked}
                 label={t("app.back")}
                 onClick={() => {
                   backSidebar();

--- a/apps/desktop/src/app/sidebar.tsx
+++ b/apps/desktop/src/app/sidebar.tsx
@@ -51,13 +51,19 @@ export function SidebarRouteChangeCloser() {
   useLayoutEffect(() => {
     if (previousRouteKeyRef.current !== routeKey) {
       previousRouteKeyRef.current = routeKey;
-      if (stackDestinations.length > 0 && !consumeSidebarRouteChangePreservation()) {
+      const preserved = consumeSidebarRouteChangePreservation({
+        pathname: location.pathname,
+        searchStr: location.searchStr,
+      });
+      if (stackDestinations.length > 0 && !preserved) {
         closeSidebar("route_change");
       }
     }
   }, [
     closeSidebar,
     consumeSidebarRouteChangePreservation,
+    location.pathname,
+    location.searchStr,
     routeKey,
     stackDestinations.length,
   ]);

--- a/apps/desktop/src/app/sidebar.tsx
+++ b/apps/desktop/src/app/sidebar.tsx
@@ -292,24 +292,26 @@ export function SidebarHost() {
           className="absolute top-0 right-0 left-0 z-10 grid grid-cols-[auto_minmax(0,auto)_minmax(min-content,1fr)] items-center gap-[var(--space-3)] border-b border-[var(--color-outline)] bg-[var(--color-island-0)] px-[var(--space-4)] py-[var(--space-3)] [backdrop-filter:blur(8px)]"
           ref={headerRef}
         >
-          <IconTooltipButton
-            label={t("app.close")}
-            onClick={() => {
-              closeSidebar("closed");
-            }}
-          >
-            <X aria-hidden="true" size={18} strokeWidth={1.5} />
-          </IconTooltipButton>
-          {canGoBack ? (
+          <div className="flex items-center gap-[var(--space-2)]">
             <IconTooltipButton
-              label={t("app.back")}
+              label={t("app.close")}
               onClick={() => {
-                backSidebar();
+                closeSidebar("closed");
               }}
             >
-              <ChevronLeft aria-hidden="true" size={18} strokeWidth={1.5} />
+              <X aria-hidden="true" size={18} strokeWidth={1.5} />
             </IconTooltipButton>
-          ) : null}
+            {canGoBack ? (
+              <IconTooltipButton
+                label={t("app.back")}
+                onClick={() => {
+                  backSidebar();
+                }}
+              >
+                <ChevronLeft aria-hidden="true" size={18} strokeWidth={1.5} />
+              </IconTooltipButton>
+            ) : null}
+          </div>
           <h2 className="m-0 min-w-0 truncate text-[1.05rem] font-bold" id={titleId}>
             {title}
           </h2>

--- a/apps/desktop/src/app/sidebar.tsx
+++ b/apps/desktop/src/app/sidebar.tsx
@@ -366,7 +366,7 @@ function SidebarPopOutSlot({
 function SidebarPopOutButton({ options }: Readonly<{ options: NativeDialogWindowOptions }>) {
   const { t } = useTranslation();
   const { nativeBridge } = useAppServices();
-  const { activeToken, closeSidebarIfCurrent } = useSidebar();
+  const { activeActivationID, closeSidebarIfCurrentActivation } = useSidebar();
   const { push } = useStatusController();
   if (!nativeBridge.capabilities.dialogWindows) {
     return null;
@@ -375,14 +375,14 @@ function SidebarPopOutButton({ options }: Readonly<{ options: NativeDialogWindow
     <IconTooltipButton
       label={t("app.popOut")}
       onClick={() => {
-        const openedToken = activeToken;
-        if (openedToken === null) {
+        const openedActivationID = activeActivationID;
+        if (openedActivationID === null) {
           return;
         }
         void nativeBridge.dialogs
           .openWindow(options)
           .then(() => {
-            closeSidebarIfCurrent(openedToken, "closed");
+            closeSidebarIfCurrentActivation(openedActivationID, "closed");
           })
           .catch((error: unknown) => {
             push({

--- a/apps/desktop/src/app/sidebar.tsx
+++ b/apps/desktop/src/app/sidebar.tsx
@@ -25,7 +25,7 @@ import { useStatusController } from "@/app-facade";
 import { SidebarHeaderActionProvider, SidebarHeaderActionSlot } from "@/app-facade";
 import { SidebarDestinationView } from "./sidebarDestinations";
 import { SidebarHeaderOffsetContext } from "@/app-facade";
-import { sidebarPopOutOptions, shouldCloseSidebarAfterPopOut } from "./sidebarPopOut";
+import { sidebarPopOutOptions } from "./sidebarPopOut";
 import { sidebarTitle } from "@/app-facade";
 import { sidebarSizePreference } from "@/app-facade";
 import { useSidebar, type SidebarDestination } from "@/app-facade";
@@ -368,10 +368,6 @@ function SidebarPopOutButton({ options }: Readonly<{ options: NativeDialogWindow
   const { nativeBridge } = useAppServices();
   const { activeToken, closeSidebarIfCurrent } = useSidebar();
   const { push } = useStatusController();
-  const activeTokenRef = useRef(activeToken);
-  useEffect(() => {
-    activeTokenRef.current = activeToken;
-  }, [activeToken]);
   if (!nativeBridge.capabilities.dialogWindows) {
     return null;
   }
@@ -386,9 +382,7 @@ function SidebarPopOutButton({ options }: Readonly<{ options: NativeDialogWindow
         void nativeBridge.dialogs
           .openWindow(options)
           .then(() => {
-            if (shouldCloseSidebarAfterPopOut(openedToken, activeTokenRef.current)) {
-              closeSidebarIfCurrent(openedToken, "closed");
-            }
+            closeSidebarIfCurrent(openedToken, "closed");
           })
           .catch((error: unknown) => {
             push({

--- a/apps/desktop/src/app/sidebarDestinations.tsx
+++ b/apps/desktop/src/app/sidebarDestinations.tsx
@@ -59,6 +59,7 @@ export function SidebarDestinationView({
   if (destination.kind === "taskDetail") {
     return (
       <TaskDetailSurface
+        key={activeActivationID ?? undefined}
         enabled
         initialFocus={destination.initialFocus}
         sidebarSnapshot={activeSnapshot?.kind === "taskDetail" ? activeSnapshot : undefined}

--- a/apps/desktop/src/app/sidebarDestinations.tsx
+++ b/apps/desktop/src/app/sidebarDestinations.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import { useCallback, type ReactElement } from "react";
 
 import { ProjectEditRoute } from "@/features/project-edit";
 import { TaskDetailSurface } from "@/features/task-detail";
@@ -25,7 +25,16 @@ export function SidebarDestinationView({
     removeSidebarEntry,
     replaceSidebarIfCurrent,
     resolveSidebarIfCurrent,
+    setSidebarExitBlocked,
   } = useSidebar();
+  const onSubmissionStateChange = useCallback(
+    (pending: boolean) => {
+      if (activeToken !== null) {
+        setSidebarExitBlocked(activeToken, pending);
+      }
+    },
+    [activeToken, setSidebarExitBlocked],
+  );
   if (destination.kind === "newTask") {
     const formToken = activeToken;
     return (
@@ -49,6 +58,7 @@ export function SidebarDestinationView({
             });
           }
         }}
+        onSubmissionStateChange={onSubmissionStateChange}
         projectID={destination.projectID}
         pendingRelationship={destination.pendingRelationship}
         workflowID={destination.workflowID}

--- a/apps/desktop/src/app/sidebarDestinations.tsx
+++ b/apps/desktop/src/app/sidebarDestinations.tsx
@@ -58,7 +58,10 @@ export function SidebarDestinationView({
             });
           }
         }}
-        onSubmissionStateChange={onSubmissionStateChange}
+        onSubmissionStateChange={pendingSubmissionStateChange(
+          destination.pendingRelationship,
+          onSubmissionStateChange,
+        )}
         projectID={destination.projectID}
         pendingRelationship={destination.pendingRelationship}
         workflowID={destination.workflowID}
@@ -121,6 +124,13 @@ export function SidebarDestinationView({
   }
 
   return <>{destination.content}</>;
+}
+
+function pendingSubmissionStateChange(
+  pendingRelationship: Extract<SidebarDestination, { kind: "newTask" }>["pendingRelationship"],
+  handler: (pending: boolean) => void,
+): ((pending: boolean) => void) | undefined {
+  return pendingRelationship === undefined ? undefined : handler;
 }
 
 function LinkWorkflowDestinationView({

--- a/apps/desktop/src/app/sidebarDestinations.tsx
+++ b/apps/desktop/src/app/sidebarDestinations.tsx
@@ -5,26 +5,48 @@ import { TaskDetailSurface } from "@/features/task-detail";
 import { NewTaskForm } from "@/features/tasks";
 import { WorkflowEditorRoute, WorkflowInspectorSidebar } from "@/features/workflow-editor";
 import { LinkWorkflowSidebar, WorkflowCreateForm } from "@/features/workflows";
-import { useAppNavigation } from "@/app-facade";
+import { useAppNavigation, useSidebar } from "@/app-facade";
 import type { SidebarController, SidebarDestination } from "@/app-facade";
 
 export function SidebarDestinationView({
+  activeSnapshot,
   closeSidebar,
   destination,
   resolveSidebar,
 }: Readonly<{
+  activeSnapshot: SidebarController["activeSnapshot"];
   closeSidebar: SidebarController["closeSidebar"];
   destination: SidebarDestination;
   resolveSidebar: SidebarController["resolveSidebar"];
 }>): ReactElement {
+  const {
+    activeToken,
+    removeSidebarEntry,
+    replaceSidebarIfCurrent,
+    resolveSidebarIfCurrent,
+  } = useSidebar();
   if (destination.kind === "newTask") {
+    const formToken = activeToken;
     return (
       <NewTaskForm
         boardQueryWorkflowID={destination.boardQueryWorkflowID}
         className="w-full"
         initialSourceWorkspaceID={destination.initialSourceWorkspaceID}
-        onSubmitted={() => {
-          resolveSidebar({ destination: "newTask", status: "submitted" });
+        onSubmitted={(taskID) => {
+          if (destination.pendingRelationship !== undefined && taskID !== undefined && formToken !== null) {
+            replaceSidebarIfCurrent(formToken, {
+              kind: "taskDetail",
+              taskID,
+              ...(destination.mode === undefined ? {} : { mode: destination.mode }),
+            });
+            return;
+          }
+          if (formToken !== null) {
+            resolveSidebarIfCurrent(formToken, {
+              destination: "newTask",
+              status: "submitted",
+            });
+          }
         }}
         projectID={destination.projectID}
         pendingRelationship={destination.pendingRelationship}
@@ -38,6 +60,12 @@ export function SidebarDestinationView({
       <TaskDetailSurface
         enabled
         initialFocus={destination.initialFocus}
+        sidebarSnapshot={activeSnapshot?.kind === "taskDetail" ? activeSnapshot : undefined}
+        onMissingTask={() => {
+          if (activeToken !== null) {
+            removeSidebarEntry(activeToken);
+          }
+        }}
         onMutated={destination.onMutated}
         taskId={destination.taskID}
       />

--- a/apps/desktop/src/app/sidebarDestinations.tsx
+++ b/apps/desktop/src/app/sidebarDestinations.tsx
@@ -21,6 +21,7 @@ export function SidebarDestinationView({
 }>): ReactElement {
   const {
     activeToken,
+    activeActivationID,
     removeSidebarEntry,
     replaceSidebarIfCurrent,
     resolveSidebarIfCurrent,
@@ -61,6 +62,7 @@ export function SidebarDestinationView({
         enabled
         initialFocus={destination.initialFocus}
         sidebarSnapshot={activeSnapshot?.kind === "taskDetail" ? activeSnapshot : undefined}
+        sidebarActivationID={activeActivationID}
         onMissingTask={() => {
           if (activeToken !== null) {
             removeSidebarEntry(activeToken);

--- a/apps/desktop/src/app/sidebarNavigation.integration.test.tsx
+++ b/apps/desktop/src/app/sidebarNavigation.integration.test.tsx
@@ -1,5 +1,10 @@
-import { createMemoryHistory, createRootRoute, createRouter, RouterContextProvider } from "@tanstack/react-router";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterContextProvider,
+} from "@tanstack/react-router";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useEffect, useState } from "react";
 import { z } from "zod";
@@ -47,38 +52,36 @@ describe("sidebar Task Detail navigation", () => {
 
     const user = userEvent.setup();
     await waitFor(() => {
-      expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue("Resolve blocker");
+      expect(getTaskTitleInput()).toHaveValue("Resolve blocker");
     });
-    await user.clear(screen.getByRole("textbox", { name: "Title" }));
-    await user.type(screen.getByRole("textbox", { name: "Title" }), "Drafted title");
-    await user.click(screen.getByRole("textbox", { name: "Description" }));
-    const description = screen.getByRole("textbox", { name: "Description" });
+    await user.clear(getTaskTitleInput());
+    await user.type(getTaskTitleInput(), "Drafted title");
+    await user.click(getTaskDescriptionInput());
+    const description = getTaskDescriptionInput();
     await user.clear(description);
     await user.type(description, "Drafted body");
-    await user.type(screen.getByRole("textbox", { name: "Add comment" }), "Drafted comment");
-    await user.click(screen.getByRole("tab", { name: "Activity" }));
+    await user.type(getTaskCommentInput(), "Drafted comment");
+    await user.click(getTaskTab("task-tab-activity"));
     const scrollStack = screen.getByTestId("task-detail-island-stack");
     scrollStack.scrollTop = 120;
     fireEvent.scroll(scrollStack);
     await user.click(await screen.findByTestId("dependency-row-task-2"));
-    await waitFor(() => {
-      expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue("Prepare");
-    });
+    await waitFor(() => expect(getTaskTitleInput()).toHaveValue("Prepare"));
 
-    await user.click(screen.getByRole("button", { name: "Back" }));
+    await user.click(screen.getByTestId("sidebar-back"));
     await waitFor(() => {
-      expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue("Drafted title");
-      expect(screen.getByRole("textbox", { name: "Description" })).toHaveTextContent("Drafted body");
+      expect(getTaskTitleInput()).toHaveValue("Drafted title");
+      expect(getTaskDescriptionInput()).toHaveTextContent("Drafted body");
     });
     const restoredStack = screen.getByTestId("task-detail-island-stack");
     expect(restoredStack).toHaveProperty("scrollTop", 120);
     restoredStack.scrollTop = 0;
     fireEvent.scroll(restoredStack);
     await waitFor(() => {
-      expect(screen.getByRole("tab", { name: "Activity" })).toHaveAttribute("aria-selected", "true");
+      expect(getTaskTab("task-tab-activity")).toHaveAttribute("aria-selected", "true");
     });
-    await user.click(screen.getByRole("tab", { name: /Comments/ }));
-    expect(screen.getByRole("textbox", { name: "Add comment" })).toHaveValue("Drafted comment");
+    await user.click(getTaskTab("task-tab-comments"));
+    expect(getTaskCommentInput()).toHaveValue("Drafted comment");
 
     const restoredScrollStack = screen.getByTestId("task-detail-island-stack");
     restoredScrollStack.scrollTop = 40;
@@ -142,12 +145,12 @@ describe("sidebar Task Detail navigation", () => {
 
     const user = userEvent.setup();
     await waitFor(() => {
-      expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue("task-0");
+      expect(getTaskTitleInput()).toHaveValue("task-0");
     });
     const initialActiveSubscriptionCount = services.transport.subscriptions.length;
     expect(initialActiveSubscriptionCount).toBeGreaterThan(0);
     for (let cycle = 0; cycle < 6; cycle += 1) {
-      await user.click(screen.getByRole("button", { name: "Cycle" }));
+      await user.click(screen.getByTestId("sidebar-cycle"));
       await waitFor(() => {
         expect(screen.getAllByTestId("task-detail-island-stack")).toHaveLength(1);
       });
@@ -159,14 +162,8 @@ describe("sidebar Task Detail navigation", () => {
 });
 
 function SidebarScenario() {
-  const {
-    activeDestination,
-    activeSnapshot,
-    backSidebar,
-    closeSidebar,
-    openSidebar,
-    resolveSidebar,
-  } = useSidebar();
+  const { activeDestination, activeSnapshot, backSidebar, closeSidebar, openSidebar, resolveSidebar } =
+    useSidebar();
   useEffect(() => {
     void openSidebar({ kind: "taskDetail", taskID: "task-1" });
   }, [openSidebar]);
@@ -175,7 +172,7 @@ function SidebarScenario() {
   }
   return (
     <>
-      <button onClick={backSidebar} type="button">
+      <button data-testid="sidebar-back" onClick={backSidebar} type="button">
         Back
       </button>
       <SidebarDestinationView
@@ -219,6 +216,7 @@ function SidebarTraversalScenario() {
           pushSidebar({ kind: "taskDetail", taskID });
         }}
         type="button"
+        data-testid="sidebar-cycle"
       >
         Cycle
       </button>
@@ -230,6 +228,22 @@ function SidebarTraversalScenario() {
       />
     </>
   );
+}
+
+function getTaskTitleInput() {
+  return within(screen.getByTestId("task-detail-title-island")).getByRole("textbox");
+}
+
+function getTaskDescriptionInput() {
+  return within(screen.getByTestId("task-description-input-frame")).getByRole("textbox");
+}
+
+function getTaskCommentInput() {
+  return within(screen.getByTestId("task-comment-input-frame")).getByRole("textbox");
+}
+
+function getTaskTab(testID: string) {
+  return within(screen.getByTestId(testID)).getByRole("tab");
 }
 
 function taskWithDependency(

--- a/apps/desktop/src/app/sidebarNavigation.integration.test.tsx
+++ b/apps/desktop/src/app/sidebarNavigation.integration.test.tsx
@@ -72,7 +72,7 @@ describe("sidebar Task Detail navigation", () => {
     });
     const restoredStack = screen.getByTestId("task-detail-island-stack");
     expect(restoredStack).toHaveProperty("scrollTop", 120);
-    expect(screen.getByRole("textbox", { name: "Description" })).toHaveClass("overflow-visible");
+    expect(screen.getByRole("textbox", { name: "Description" })).toHaveAttribute("aria-expanded", "true");
     restoredStack.scrollTop = 0;
     fireEvent.scroll(restoredStack);
     await waitFor(() => {
@@ -108,7 +108,7 @@ describe("sidebar Task Detail navigation", () => {
     await waitFor(() => {
       expect(screen.getByTestId("task-detail-island-stack")).toHaveProperty("scrollTop", 40);
     });
-  });
+  }, 15000);
 
   it("keeps one rendered Task Detail and one live project subscription across cycles", async () => {
     const services = createTestServices([

--- a/apps/desktop/src/app/sidebarNavigation.integration.test.tsx
+++ b/apps/desktop/src/app/sidebarNavigation.integration.test.tsx
@@ -72,7 +72,6 @@ describe("sidebar Task Detail navigation", () => {
     });
     const restoredStack = screen.getByTestId("task-detail-island-stack");
     expect(restoredStack).toHaveProperty("scrollTop", 120);
-    expect(screen.getByRole("textbox", { name: "Description" })).toHaveAttribute("aria-expanded", "true");
     restoredStack.scrollTop = 0;
     fireEvent.scroll(restoredStack);
     await waitFor(() => {
@@ -156,7 +155,7 @@ describe("sidebar Task Detail navigation", () => {
     await waitFor(() => {
       expect(services.transport.subscriptions).toHaveLength(initialActiveSubscriptionCount);
     });
-  });
+  }, 15_000);
 });
 
 function SidebarScenario() {
@@ -251,8 +250,8 @@ function taskWithDependency(
       : [
           {
             task_id: dependencyTaskID,
-            short_id: "T-2",
-            title: "Prepare",
+            short_id: `T-${dependencyTaskID}`,
+            title: `Dependency ${dependencyTaskID}`,
             workflow_id: base.workflow.workflow_id,
             status: {
               kind: "backlog",
@@ -269,7 +268,7 @@ function taskWithDependency(
       summary: {
         ...base.summary,
         id: taskID,
-        short_id: taskID === "task-1" ? "T-1" : "T-2",
+        short_id: `T-${taskID}`,
         title,
       },
       body,

--- a/apps/desktop/src/app/sidebarNavigation.integration.test.tsx
+++ b/apps/desktop/src/app/sidebarNavigation.integration.test.tsx
@@ -1,0 +1,157 @@
+import { createMemoryHistory, createRootRoute, createRouter, RouterContextProvider } from "@tanstack/react-router";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { z } from "zod";
+
+import { useSidebar } from "@/app-facade";
+import { TestAppProviders, createTestServices } from "@/test-support/app-services";
+import { activityResponse, emptyTaskAttentionResponse, taskDetailResponse } from "@/test-support/task-detail";
+import { SidebarDestinationView } from "./sidebarDestinations";
+import { SidebarProvider } from "./sidebarProvider";
+
+describe("sidebar Task Detail navigation", () => {
+  it("restores dirty title and body drafts after dependency Push and Back", async () => {
+    const taskOne = taskWithDependency("task-1", "Resolve blocker", "Need operator input", "task-2");
+    const taskTwo = taskWithDependency("task-2", "Prepare", "Preparation", undefined);
+    const services = createTestServices([
+      {
+        method: "workflow.project.label.list",
+        result: { catalog: { project_id: "project-1", labels: [] } },
+      },
+      {
+        method: "workflow.task.get",
+        handler: (params) => {
+          const taskID = z.object({ task_id: z.string() }).parse(params).task_id;
+          return taskID === "task-2" ? taskTwo : taskOne;
+        },
+      },
+      { method: "workflow.task.attention.list", result: emptyTaskAttentionResponse },
+      { method: "workflow.task.activity.list", result: activityResponse },
+      { method: "workflow.task.comment.list", result: { comments: [], next_offset: null } },
+    ]);
+    const router = createRouter({
+      history: createMemoryHistory({ initialEntries: ["/tasks/task-1"] }),
+      routeTree: createRootRoute(),
+    });
+
+    render(
+      <RouterContextProvider router={router}>
+        <TestAppProviders services={services}>
+          <SidebarProvider>
+            <SidebarScenario />
+          </SidebarProvider>
+        </TestAppProviders>
+      </RouterContextProvider>,
+    );
+
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue("Resolve blocker");
+    });
+    await user.clear(screen.getByRole("textbox", { name: "Title" }));
+    await user.type(screen.getByRole("textbox", { name: "Title" }), "Drafted title");
+    await user.click(screen.getByRole("textbox", { name: "Description" }));
+    const description = screen.getByRole("textbox", { name: "Description" });
+    await user.clear(description);
+    await user.type(description, "Drafted body");
+    await user.click(await screen.findByTestId("dependency-row-task-2"));
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue("Prepare");
+    });
+
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue("Drafted title");
+      expect(screen.getByRole("textbox", { name: "Description" })).toHaveTextContent("Drafted body");
+    });
+  });
+});
+
+function SidebarScenario() {
+  const {
+    activeDestination,
+    activeSnapshot,
+    backSidebar,
+    closeSidebar,
+    openSidebar,
+    resolveSidebar,
+  } = useSidebar();
+  useEffect(() => {
+    void openSidebar({ kind: "taskDetail", taskID: "task-1" });
+  }, [openSidebar]);
+  if (activeDestination === null) {
+    return null;
+  }
+  return (
+    <>
+      <button onClick={backSidebar} type="button">
+        Back
+      </button>
+      <SidebarDestinationView
+        activeSnapshot={activeSnapshot}
+        closeSidebar={closeSidebar}
+        destination={activeDestination}
+        resolveSidebar={resolveSidebar}
+      />
+    </>
+  );
+}
+
+function taskWithDependency(
+  taskID: string,
+  title: string,
+  body: string,
+  dependencyTaskID: string | undefined,
+) {
+  const base = taskDetailResponse.task;
+  const blockedBy = base.dependencies.directions[0];
+  const blocks = base.dependencies.directions[1];
+  if (blockedBy === undefined || blocks === undefined) {
+    throw new Error("Task fixture is missing dependency directions.");
+  }
+  const dependencyItems =
+    dependencyTaskID === undefined
+      ? []
+      : [
+          {
+            task_id: dependencyTaskID,
+            short_id: "T-2",
+            title: "Prepare",
+            workflow_id: base.workflow.workflow_id,
+            status: {
+              kind: "backlog",
+              native_state: "active",
+              node_ids: [],
+              attention_types: [],
+            },
+            satisfaction: "unsatisfied",
+          },
+        ];
+  return {
+    task: {
+      ...base,
+      summary: {
+        ...base.summary,
+        id: taskID,
+        short_id: taskID === "task-1" ? "T-1" : "T-2",
+        title,
+      },
+      body,
+      dependencies: {
+        ...base.dependencies,
+        blocker_count: dependencyTaskID === undefined ? 0 : 1,
+        unsatisfied_blocker_count: dependencyTaskID === undefined ? 0 : 1,
+        directions: [
+          {
+            ...blockedBy,
+            items: dependencyItems,
+            total_count: dependencyTaskID === undefined ? 0 : 1,
+            unsatisfied_count: dependencyTaskID === undefined ? 0 : 1,
+          },
+          blocks,
+        ],
+      },
+    },
+  };
+}

--- a/apps/desktop/src/app/sidebarNavigation.integration.test.tsx
+++ b/apps/desktop/src/app/sidebarNavigation.integration.test.tsx
@@ -1,7 +1,7 @@
 import { createMemoryHistory, createRootRoute, createRouter, RouterContextProvider } from "@tanstack/react-router";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { z } from "zod";
 
 import { useSidebar } from "@/app-facade";
@@ -55,6 +55,11 @@ describe("sidebar Task Detail navigation", () => {
     const description = screen.getByRole("textbox", { name: "Description" });
     await user.clear(description);
     await user.type(description, "Drafted body");
+    await user.type(screen.getByRole("textbox", { name: "Add comment" }), "Drafted comment");
+    await user.click(screen.getByRole("tab", { name: "Activity" }));
+    const scrollStack = screen.getByTestId("task-detail-island-stack");
+    scrollStack.scrollTop = 120;
+    fireEvent.scroll(scrollStack);
     await user.click(await screen.findByTestId("dependency-row-task-2"));
     await waitFor(() => {
       expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue("Prepare");
@@ -64,6 +69,92 @@ describe("sidebar Task Detail navigation", () => {
     await waitFor(() => {
       expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue("Drafted title");
       expect(screen.getByRole("textbox", { name: "Description" })).toHaveTextContent("Drafted body");
+    });
+    const restoredStack = screen.getByTestId("task-detail-island-stack");
+    expect(restoredStack).toHaveProperty("scrollTop", 120);
+    expect(screen.getByRole("textbox", { name: "Description" })).toHaveClass("overflow-visible");
+    restoredStack.scrollTop = 0;
+    fireEvent.scroll(restoredStack);
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Activity" })).toHaveAttribute("aria-selected", "true");
+    });
+    await user.click(screen.getByRole("tab", { name: /Comments/ }));
+    expect(screen.getByRole("textbox", { name: "Add comment" })).toHaveValue("Drafted comment");
+
+    const restoredScrollStack = screen.getByTestId("task-detail-island-stack");
+    restoredScrollStack.scrollTop = 40;
+    fireEvent.scroll(restoredScrollStack);
+    await waitFor(() => {
+      expect(services.transport.subscriptions).toContainEqual({
+        method: "workflow.subscribeProject",
+        params: { project_id: "project-1" },
+      });
+    });
+    services.transport.connection.set("disconnected", "offline");
+    await waitFor(() => {
+      expect(services.transport.subscriptions).not.toContainEqual({
+        method: "workflow.subscribeProject",
+        params: { project_id: "project-1" },
+      });
+    });
+    services.transport.connection.set("connected");
+    await waitFor(() => {
+      expect(services.transport.subscriptions).toContainEqual({
+        method: "workflow.subscribeProject",
+        params: { project_id: "project-1" },
+      });
+    });
+    services.transport.open("workflow.subscribeProject");
+    await waitFor(() => {
+      expect(screen.getByTestId("task-detail-island-stack")).toHaveProperty("scrollTop", 40);
+    });
+  });
+
+  it("keeps one rendered Task Detail and one live project subscription across cycles", async () => {
+    const services = createTestServices([
+      {
+        method: "workflow.project.label.list",
+        result: { catalog: { project_id: "project-1", labels: [] } },
+      },
+      {
+        method: "workflow.task.get",
+        handler: (params) => {
+          const taskID = z.object({ task_id: z.string() }).parse(params).task_id;
+          return taskWithDependency(taskID, taskID, "Body", undefined);
+        },
+      },
+      { method: "workflow.task.attention.list", result: emptyTaskAttentionResponse },
+      { method: "workflow.task.activity.list", result: activityResponse },
+      { method: "workflow.task.comment.list", result: { comments: [], next_offset: null } },
+    ]);
+    const router = createRouter({
+      history: createMemoryHistory({ initialEntries: ["/tasks/task-0"] }),
+      routeTree: createRootRoute(),
+    });
+    render(
+      <RouterContextProvider router={router}>
+        <TestAppProviders services={services}>
+          <SidebarProvider>
+            <SidebarTraversalScenario />
+          </SidebarProvider>
+        </TestAppProviders>
+      </RouterContextProvider>,
+    );
+
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "Title" })).toHaveValue("task-0");
+    });
+    const initialActiveSubscriptionCount = services.transport.subscriptions.length;
+    expect(initialActiveSubscriptionCount).toBeGreaterThan(0);
+    for (let cycle = 0; cycle < 6; cycle += 1) {
+      await user.click(screen.getByRole("button", { name: "Cycle" }));
+      await waitFor(() => {
+        expect(screen.getAllByTestId("task-detail-island-stack")).toHaveLength(1);
+      });
+    }
+    await waitFor(() => {
+      expect(services.transport.subscriptions).toHaveLength(initialActiveSubscriptionCount);
     });
   });
 });
@@ -87,6 +178,50 @@ function SidebarScenario() {
     <>
       <button onClick={backSidebar} type="button">
         Back
+      </button>
+      <SidebarDestinationView
+        activeSnapshot={activeSnapshot}
+        closeSidebar={closeSidebar}
+        destination={activeDestination}
+        resolveSidebar={resolveSidebar}
+      />
+    </>
+  );
+}
+
+function SidebarTraversalScenario() {
+  const {
+    activeDestination,
+    activeSnapshot,
+    backSidebar,
+    canGoBack,
+    closeSidebar,
+    openSidebar,
+    pushSidebar,
+    resolveSidebar,
+  } = useSidebar();
+  const [nextTaskNumber, setNextTaskNumber] = useState(1);
+  useEffect(() => {
+    void openSidebar({ kind: "taskDetail", taskID: "task-0" });
+  }, [openSidebar]);
+  if (activeDestination === null) {
+    return null;
+  }
+  return (
+    <>
+      <button
+        onClick={() => {
+          if (canGoBack) {
+            backSidebar();
+            return;
+          }
+          const taskID = `task-${nextTaskNumber.toString()}`;
+          setNextTaskNumber((current) => current + 1);
+          pushSidebar({ kind: "taskDetail", taskID });
+        }}
+        type="button"
+      >
+        Cycle
       </button>
       <SidebarDestinationView
         activeSnapshot={activeSnapshot}

--- a/apps/desktop/src/app/sidebarPopOut.test.ts
+++ b/apps/desktop/src/app/sidebarPopOut.test.ts
@@ -1,0 +1,33 @@
+import type { SidebarEntryToken } from "@/app-facade";
+import { sidebarPopOutOptions, shouldCloseSidebarAfterPopOut } from "./sidebarPopOut";
+
+const token = (lifecycleID: string, entryID: string): SidebarEntryToken => ({
+  lifecycleID,
+  entryID,
+});
+
+describe("sidebar pop-out completion", () => {
+  it("closes only when the captured entry is still current", () => {
+    const opened = token("lifecycle-1", "entry-1");
+
+    expect(shouldCloseSidebarAfterPopOut(opened, opened)).toBe(true);
+    expect(shouldCloseSidebarAfterPopOut(opened, token("lifecycle-1", "entry-2"))).toBe(false);
+    expect(shouldCloseSidebarAfterPopOut(opened, token("lifecycle-2", "entry-3"))).toBe(false);
+    expect(shouldCloseSidebarAfterPopOut(opened, null)).toBe(false);
+  });
+
+  it("keeps Task Detail pop-out options scoped to the current Task", () => {
+    expect(
+      sidebarPopOutOptions(
+        {
+          kind: "taskDetail",
+          taskID: "task-1",
+        },
+        "Task 1",
+      ),
+    ).toMatchObject({
+      params: { taskID: "task-1" },
+      title: "Task 1",
+    });
+  });
+});

--- a/apps/desktop/src/app/sidebarPopOut.test.ts
+++ b/apps/desktop/src/app/sidebarPopOut.test.ts
@@ -1,21 +1,6 @@
-import type { SidebarEntryToken } from "@/app-facade";
-import { sidebarPopOutOptions, shouldCloseSidebarAfterPopOut } from "./sidebarPopOut";
+import { sidebarPopOutOptions } from "./sidebarPopOut";
 
-const token = (lifecycleID: string, entryID: string): SidebarEntryToken => ({
-  lifecycleID,
-  entryID,
-});
-
-describe("sidebar pop-out completion", () => {
-  it("closes only when the captured entry is still current", () => {
-    const opened = token("lifecycle-1", "entry-1");
-
-    expect(shouldCloseSidebarAfterPopOut(opened, opened)).toBe(true);
-    expect(shouldCloseSidebarAfterPopOut(opened, token("lifecycle-1", "entry-2"))).toBe(false);
-    expect(shouldCloseSidebarAfterPopOut(opened, token("lifecycle-2", "entry-3"))).toBe(false);
-    expect(shouldCloseSidebarAfterPopOut(opened, null)).toBe(false);
-  });
-
+describe("sidebar pop-out options", () => {
   it("keeps Task Detail pop-out options scoped to the current Task", () => {
     expect(
       sidebarPopOutOptions(

--- a/apps/desktop/src/app/sidebarPopOut.ts
+++ b/apps/desktop/src/app/sidebarPopOut.ts
@@ -1,6 +1,6 @@
 import type { NativeDialogWindowOptions } from "@app/native-bridge";
 
-import type { SidebarDestination, SidebarEntryToken } from "@/app-facade";
+import type { SidebarDestination } from "@/app-facade";
 
 export const taskDetailNativeDialogPath = "/native-dialog/task-detail";
 
@@ -27,15 +27,4 @@ export function sidebarPopOutOptions(
     };
   }
   return null;
-}
-
-export function shouldCloseSidebarAfterPopOut(
-  openedToken: SidebarEntryToken,
-  currentToken: SidebarEntryToken | null,
-): boolean {
-  return (
-    currentToken !== null &&
-    openedToken.lifecycleID === currentToken.lifecycleID &&
-    openedToken.entryID === currentToken.entryID
-  );
 }

--- a/apps/desktop/src/app/sidebarPopOut.ts
+++ b/apps/desktop/src/app/sidebarPopOut.ts
@@ -1,6 +1,6 @@
 import type { NativeDialogWindowOptions } from "@app/native-bridge";
 
-import type { SidebarDestination } from "@/app-facade";
+import type { SidebarDestination, SidebarEntryToken } from "@/app-facade";
 
 export const taskDetailNativeDialogPath = "/native-dialog/task-detail";
 
@@ -27,4 +27,15 @@ export function sidebarPopOutOptions(
     };
   }
   return null;
+}
+
+export function shouldCloseSidebarAfterPopOut(
+  openedToken: SidebarEntryToken,
+  currentToken: SidebarEntryToken | null,
+): boolean {
+  return (
+    currentToken !== null &&
+    openedToken.lifecycleID === currentToken.lifecycleID &&
+    openedToken.entryID === currentToken.entryID
+  );
 }

--- a/apps/desktop/src/app/sidebarProvider.test.tsx
+++ b/apps/desktop/src/app/sidebarProvider.test.tsx
@@ -372,6 +372,27 @@ describe("SidebarProvider stack contract", () => {
     expect(result.current.stackDestinations).toEqual([{ kind: "taskDetail", taskID: "task-1" }]);
   });
 
+  it("preserves the exit block when replacement capture reports a pending save", () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+    const token = result.current.activeToken;
+    if (token === null) {
+      throw new Error("Sidebar token was not created.");
+    }
+    act(() => {
+      result.current.setSidebarExitBlocked(token, true);
+    });
+    result.current.registerSidebarStateCapture(token, () => null);
+
+    act(() => {
+      result.current.replaceSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+
+    expect(result.current.sidebarExitBlocked).toBe(true);
+  });
+
   it("blocks sidebar exits only for the current destination token", () => {
     const { result } = renderHook(() => useSidebar(), { wrapper });
     act(() => {

--- a/apps/desktop/src/app/sidebarProvider.test.tsx
+++ b/apps/desktop/src/app/sidebarProvider.test.tsx
@@ -69,6 +69,44 @@ describe("SidebarProvider replacement", () => {
     });
   });
 
+  it("captures drafts before refocusing the current Task Detail", () => {
+    const wrapper = ({ children }: Readonly<{ children: ReactNode }>) => (
+      <SidebarProvider>{children}</SidebarProvider>
+    );
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+    const token = result.current.activeToken;
+    if (token === null) {
+      throw new Error("Sidebar token was not created.");
+    }
+    const snapshot = {
+      kind: "taskDetail",
+      scrollTop: 180,
+      descriptionExpanded: true,
+      selectedTab: "comments",
+      titleBodyDraft: { title: "Draft title", body: "Draft body" },
+      newCommentDraft: "Draft comment",
+    } as const;
+    result.current.registerSidebarStateCapture(token, () => snapshot);
+
+    act(() => {
+      result.current.replaceSidebar({
+        kind: "taskDetail",
+        taskID: "task-1",
+        initialFocus: { kind: "dependencies" },
+      });
+    });
+
+    expect(result.current.activeDestination).toEqual({
+      kind: "taskDetail",
+      taskID: "task-1",
+      initialFocus: { kind: "dependencies" },
+    });
+    expect(result.current.activeSnapshot).toEqual(snapshot);
+  });
+
   it("keeps the active activation stable during the close animation", () => {
     const wrapper = ({ children }: Readonly<{ children: ReactNode }>) => (
       <SidebarProvider>{children}</SidebarProvider>

--- a/apps/desktop/src/app/sidebarProvider.test.tsx
+++ b/apps/desktop/src/app/sidebarProvider.test.tsx
@@ -68,6 +68,24 @@ describe("SidebarProvider replacement", () => {
       reason: "closed",
     });
   });
+
+  it("keeps the active activation stable during the close animation", () => {
+    const wrapper = ({ children }: Readonly<{ children: ReactNode }>) => (
+      <SidebarProvider>{children}</SidebarProvider>
+    );
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+    const activationID = result.current.activeActivationID;
+
+    act(() => {
+      result.current.closeSidebar();
+    });
+
+    expect(result.current.phase).toBe("closing");
+    expect(result.current.activeActivationID).toBe(activationID);
+  });
 });
 
 describe("SidebarProvider stack contract", () => {

--- a/apps/desktop/src/app/sidebarProvider.test.tsx
+++ b/apps/desktop/src/app/sidebarProvider.test.tsx
@@ -48,3 +48,276 @@ describe("SidebarProvider replacement", () => {
     });
   });
 });
+
+describe("SidebarProvider stack contract", () => {
+  const wrapper = ({ children }: Readonly<{ children: ReactNode }>) => (
+    <SidebarProvider>{children}</SidebarProvider>
+  );
+
+  it("keeps one lifecycle promise while exposing stack tokens and Back", async () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    let lifecycle: Promise<unknown> | undefined;
+
+    act(() => {
+      lifecycle = result.current.openSidebar({
+        kind: "taskDetail",
+        taskID: "task-1",
+      });
+    });
+    const rootToken = result.current.activeToken;
+
+    expect(rootToken).not.toBeNull();
+    expect(result.current.stackDestinations).toEqual([
+      { kind: "taskDetail", taskID: "task-1" },
+    ]);
+    expect(result.current.canGoBack).toBe(false);
+
+    act(() => {
+      result.current.pushSidebar({
+        kind: "taskDetail",
+        taskID: "task-2",
+      });
+    });
+
+    expect(result.current.stackDestinations).toEqual([
+      { kind: "taskDetail", taskID: "task-1" },
+      { kind: "taskDetail", taskID: "task-2" },
+    ]);
+    expect(result.current.activeDestination).toEqual({
+      kind: "taskDetail",
+      taskID: "task-2",
+    });
+    expect(result.current.canGoBack).toBe(true);
+
+    act(() => {
+      result.current.backSidebar();
+    });
+    expect(result.current.activeDestination).toEqual({
+      kind: "taskDetail",
+      taskID: "task-1",
+    });
+    expect(result.current.canGoBack).toBe(false);
+
+    act(() => {
+      result.current.closeSidebar();
+    });
+    if (lifecycle === undefined) {
+      throw new Error("Sidebar lifecycle was not created.");
+    }
+    await expect(lifecycle).resolves.toEqual({
+      status: "canceled",
+      reason: "closed",
+    });
+    expect(rootToken).not.toBeNull();
+  });
+
+  it("ignores stale token operations and only settles the matching lifecycle", async () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    let firstLifecycle: Promise<unknown> | undefined;
+    act(() => {
+      firstLifecycle = result.current.openSidebar({
+        kind: "taskDetail",
+        taskID: "task-1",
+      });
+    });
+    const staleToken = result.current.activeToken;
+    if (staleToken === null) {
+      throw new Error("Sidebar token was not created.");
+    }
+
+    act(() => {
+      result.current.replaceSidebar({
+        kind: "taskDetail",
+        taskID: "task-2",
+      });
+    });
+    const currentToken = result.current.activeToken;
+    expect(currentToken).not.toEqual(staleToken);
+    if (currentToken === null) {
+      throw new Error("Current sidebar token was not created.");
+    }
+
+    act(() => {
+      result.current.replaceSidebarIfCurrent(staleToken, {
+        kind: "taskDetail",
+        taskID: "stale",
+      });
+      result.current.closeSidebarIfCurrent(staleToken);
+      result.current.resolveSidebarIfCurrent(staleToken, {
+        status: "closed",
+        destination: "taskDetail",
+      });
+    });
+    expect(result.current.activeDestination).toEqual({
+      kind: "taskDetail",
+      taskID: "task-2",
+    });
+
+    act(() => {
+      result.current.resolveSidebarIfCurrent(currentToken, {
+        status: "closed",
+        destination: "taskDetail",
+      });
+    });
+    if (firstLifecycle === undefined) {
+      throw new Error("Sidebar lifecycle was not created.");
+    }
+    await expect(firstLifecycle).resolves.toEqual({
+      status: "closed",
+      destination: "taskDetail",
+    });
+  });
+
+  it("captures current state only for the matching token before Push", () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({
+        kind: "taskDetail",
+        taskID: "task-1",
+      });
+    });
+    const token = result.current.activeToken;
+    if (token === null) {
+      throw new Error("Sidebar token was not created.");
+    }
+    const capture = vi.fn(() => ({
+      kind: "taskDetail" as const,
+      scrollTop: 42,
+      descriptionExpanded: true,
+      selectedTab: "comments" as const,
+    }));
+    const cleanup = result.current.registerSidebarStateCapture(token, capture);
+
+    act(() => {
+      result.current.pushSidebar({
+        kind: "taskDetail",
+        taskID: "task-2",
+      });
+    });
+
+    expect(capture).toHaveBeenCalledOnce();
+    act(() => {
+      cleanup();
+      result.current.backSidebar();
+    });
+    expect(result.current.activeToken?.entryID).toBe(token.entryID);
+  });
+
+  it("restores retained Task Detail drafts and presentation state after Back", () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+    const token = result.current.activeToken;
+    if (token === null) {
+      throw new Error("Sidebar token was not created.");
+    }
+    result.current.registerSidebarStateCapture(token, () => ({
+      kind: "taskDetail",
+      scrollTop: 88,
+      descriptionExpanded: true,
+      selectedTab: "activity",
+      titleBodyDraft: { title: "draft title", body: "draft body" },
+      newCommentDraft: "draft comment",
+    }));
+
+    act(() => {
+      result.current.pushSidebar({ kind: "taskDetail", taskID: "task-2" });
+    });
+    act(() => {
+      result.current.backSidebar();
+    });
+
+    expect(result.current.activeSnapshot).toEqual({
+      kind: "taskDetail",
+      scrollTop: 88,
+      descriptionExpanded: true,
+      selectedTab: "activity",
+      titleBodyDraft: { title: "draft title", body: "draft body" },
+      newCommentDraft: "draft comment",
+    });
+  });
+
+  it("blocks Push when the active capture reports a pending save", () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+    const token = result.current.activeToken;
+    if (token === null) {
+      throw new Error("Sidebar token was not created.");
+    }
+    result.current.registerSidebarStateCapture(token, () => null);
+
+    act(() => {
+      result.current.pushSidebar({ kind: "taskDetail", taskID: "task-2" });
+    });
+
+    expect(result.current.stackDestinations).toEqual([{ kind: "taskDetail", taskID: "task-1" }]);
+  });
+
+  it("keeps traversal bounded while rendering one current destination", () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({ kind: "taskDetail", taskID: "task-0" });
+    });
+    for (let index = 1; index <= 60; index += 1) {
+      act(() => {
+        result.current.pushSidebar({ kind: "taskDetail", taskID: `task-${index.toString()}` });
+      });
+    }
+
+    expect(result.current.stackDestinations).toHaveLength(50);
+    expect(result.current.stackDestinations[0]).toEqual({
+      kind: "taskDetail",
+      taskID: "task-0",
+    });
+    expect(result.current.activeDestination).toEqual({
+      kind: "taskDetail",
+      taskID: "task-60",
+    });
+  });
+
+  it("removes a deleted non-current entry without closing surviving destinations", () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+    const rootToken = result.current.activeToken;
+    act(() => {
+      result.current.pushSidebar({ kind: "taskDetail", taskID: "task-2" });
+    });
+    if (rootToken === null) {
+      throw new Error("Root token was not created.");
+    }
+
+    act(() => {
+      result.current.removeSidebarEntry(rootToken);
+    });
+
+    expect(result.current.stackDestinations).toEqual([{ kind: "taskDetail", taskID: "task-2" }]);
+  });
+
+  it("preserves surviving entries when deletion clears the anchored route", () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+    const rootToken = result.current.activeToken;
+    if (rootToken === null) {
+      throw new Error("Root token was not created.");
+    }
+    act(() => {
+      result.current.pushSidebar({ kind: "taskDetail", taskID: "task-2" });
+    });
+
+    act(() => {
+      result.current.preserveSidebarOnNextRouteChange();
+      result.current.removeSidebarEntry(rootToken);
+    });
+
+    expect(result.current.stackDestinations).toEqual([{ kind: "taskDetail", taskID: "task-2" }]);
+    expect(result.current.consumeSidebarRouteChangePreservation()).toBe(true);
+    expect(result.current.consumeSidebarRouteChangePreservation()).toBe(false);
+  });
+});

--- a/apps/desktop/src/app/sidebarProvider.test.tsx
+++ b/apps/desktop/src/app/sidebarProvider.test.tsx
@@ -90,9 +90,7 @@ describe("SidebarProvider stack contract", () => {
 
     expect(rootToken).not.toBeNull();
     expect(rootActivationID).not.toBeNull();
-    expect(result.current.stackDestinations).toEqual([
-      { kind: "taskDetail", taskID: "task-1" },
-    ]);
+    expect(result.current.stackDestinations).toEqual([{ kind: "taskDetail", taskID: "task-1" }]);
     expect(result.current.canGoBack).toBe(false);
 
     act(() => {
@@ -280,6 +278,37 @@ describe("SidebarProvider stack contract", () => {
     });
 
     expect(result.current.stackDestinations).toEqual([{ kind: "taskDetail", taskID: "task-1" }]);
+  });
+
+  it("blocks sidebar exits only for the current destination token", () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({
+        kind: "newTask",
+        projectID: "project-1",
+        workflowID: "workflow-1",
+        boardQueryWorkflowID: undefined,
+      });
+    });
+    const staleToken = result.current.activeToken;
+    if (staleToken === null) {
+      throw new Error("Sidebar token was not created.");
+    }
+
+    act(() => {
+      result.current.setSidebarExitBlocked(staleToken, true);
+    });
+    expect(result.current.sidebarExitBlocked).toBe(true);
+
+    act(() => {
+      result.current.replaceSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+    expect(result.current.sidebarExitBlocked).toBe(false);
+
+    act(() => {
+      result.current.setSidebarExitBlocked(staleToken, true);
+    });
+    expect(result.current.sidebarExitBlocked).toBe(false);
   });
 
   it("keeps traversal bounded while rendering one current destination", () => {

--- a/apps/desktop/src/app/sidebarProvider.test.tsx
+++ b/apps/desktop/src/app/sidebarProvider.test.tsx
@@ -312,12 +312,99 @@ describe("SidebarProvider stack contract", () => {
     });
 
     act(() => {
-      result.current.preserveSidebarOnNextRouteChange();
+      result.current.preserveSidebarOnNextRouteChange(rootToken, {
+        kind: "projectTaskCleared",
+        projectID: "project-1",
+        workflowID: "workflow-1",
+      });
       result.current.removeSidebarEntry(rootToken);
     });
 
     expect(result.current.stackDestinations).toEqual([{ kind: "taskDetail", taskID: "task-2" }]);
-    expect(result.current.consumeSidebarRouteChangePreservation()).toBe(true);
-    expect(result.current.consumeSidebarRouteChangePreservation()).toBe(false);
+    expect(
+      result.current.consumeSidebarRouteChangePreservation({
+        pathname: "/projects/project-1",
+        searchStr: "workflowId=workflow-1&taskId=",
+      }),
+    ).toBe(true);
+    expect(
+      result.current.consumeSidebarRouteChangePreservation({
+        pathname: "/projects/project-1",
+        searchStr: "workflowId=workflow-1&taskId=",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not preserve a mismatched route and clears failed deletion intent", () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+    const token = result.current.activeToken;
+    if (token === null) {
+      throw new Error("Token was not created.");
+    }
+    act(() => {
+      result.current.preserveSidebarOnNextRouteChange(token, {
+        kind: "projectTaskCleared",
+        projectID: "project-1",
+        workflowID: "workflow-1",
+      });
+      result.current.clearSidebarRouteChangePreservation(token);
+    });
+
+    expect(
+      result.current.consumeSidebarRouteChangePreservation({
+        pathname: "/projects/project-1",
+        searchStr: "workflowId=workflow-1&taskId=",
+      }),
+    ).toBe(false);
+  });
+
+  it("clears route preservation when the final entry closes or a lifecycle is replaced", () => {
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+    const token = result.current.activeToken;
+    if (token === null) {
+      throw new Error("Token was not created.");
+    }
+    act(() => {
+      result.current.preserveSidebarOnNextRouteChange(token, {
+        kind: "projectTaskCleared",
+        projectID: "project-1",
+        workflowID: "workflow-1",
+      });
+      result.current.removeSidebarEntry(token);
+    });
+    expect(
+      result.current.consumeSidebarRouteChangePreservation({
+        pathname: "/projects/project-1",
+        searchStr: "workflowId=workflow-1&taskId=",
+      }),
+    ).toBe(false);
+
+    act(() => {
+      void result.current.openSidebar({ kind: "taskDetail", taskID: "task-2" });
+    });
+    const replacementToken = result.current.activeToken;
+    if (replacementToken === null) {
+      throw new Error("Replacement token was not created.");
+    }
+    act(() => {
+      result.current.preserveSidebarOnNextRouteChange(replacementToken, {
+        kind: "projectTaskCleared",
+        projectID: "project-1",
+        workflowID: "workflow-1",
+      });
+      result.current.replaceSidebar({ kind: "taskDetail", taskID: "task-3" });
+    });
+    expect(
+      result.current.consumeSidebarRouteChangePreservation({
+        pathname: "/projects/project-1",
+        searchStr: "workflowId=workflow-1&taskId=",
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/app/sidebarProvider.test.tsx
+++ b/apps/desktop/src/app/sidebarProvider.test.tsx
@@ -329,13 +329,13 @@ describe("SidebarProvider stack contract", () => {
     expect(
       result.current.consumeSidebarRouteChangePreservation({
         pathname: "/projects/project-1",
-        searchStr: "workflowId=workflow-1&taskId=",
+        searchStr: "workflowId=workflow-1",
       }),
     ).toBe(true);
     expect(
       result.current.consumeSidebarRouteChangePreservation({
         pathname: "/projects/project-1",
-        searchStr: "workflowId=workflow-1&taskId=",
+        searchStr: "workflowId=workflow-1",
       }),
     ).toBe(false);
   });
@@ -361,7 +361,7 @@ describe("SidebarProvider stack contract", () => {
     expect(
       result.current.consumeSidebarRouteChangePreservation({
         pathname: "/projects/project-1",
-        searchStr: "workflowId=workflow-1&taskId=",
+        searchStr: "workflowId=workflow-1",
       }),
     ).toBe(false);
   });
@@ -386,7 +386,7 @@ describe("SidebarProvider stack contract", () => {
     expect(
       result.current.consumeSidebarRouteChangePreservation({
         pathname: "/projects/project-1",
-        searchStr: "workflowId=workflow-1&taskId=",
+        searchStr: "workflowId=workflow-1",
       }),
     ).toBe(false);
 
@@ -408,7 +408,7 @@ describe("SidebarProvider stack contract", () => {
     expect(
       result.current.consumeSidebarRouteChangePreservation({
         pathname: "/projects/project-1",
-        searchStr: "workflowId=workflow-1&taskId=",
+        searchStr: "workflowId=workflow-1",
       }),
     ).toBe(false);
   });

--- a/apps/desktop/src/app/sidebarProvider.test.tsx
+++ b/apps/desktop/src/app/sidebarProvider.test.tsx
@@ -65,8 +65,10 @@ describe("SidebarProvider stack contract", () => {
       });
     });
     const rootToken = result.current.activeToken;
+    const rootActivationID = result.current.activeActivationID;
 
     expect(rootToken).not.toBeNull();
+    expect(rootActivationID).not.toBeNull();
     expect(result.current.stackDestinations).toEqual([
       { kind: "taskDetail", taskID: "task-1" },
     ]);
@@ -87,6 +89,8 @@ describe("SidebarProvider stack contract", () => {
       kind: "taskDetail",
       taskID: "task-2",
     });
+    const pushedActivationID = result.current.activeActivationID;
+    expect(pushedActivationID).not.toBe(rootActivationID);
     expect(result.current.canGoBack).toBe(true);
 
     act(() => {
@@ -96,6 +100,7 @@ describe("SidebarProvider stack contract", () => {
       kind: "taskDetail",
       taskID: "task-1",
     });
+    expect(result.current.activeActivationID).not.toBe(pushedActivationID);
     expect(result.current.canGoBack).toBe(false);
 
     act(() => {

--- a/apps/desktop/src/app/sidebarProvider.test.tsx
+++ b/apps/desktop/src/app/sidebarProvider.test.tsx
@@ -5,6 +5,27 @@ import { useSidebar } from "@/app-facade";
 import { SidebarProvider } from "./sidebarProvider";
 
 describe("SidebarProvider replacement", () => {
+  it("cancels the lifecycle promise when the provider unmounts", async () => {
+    const wrapper = ({ children }: Readonly<{ children: ReactNode }>) => (
+      <SidebarProvider>{children}</SidebarProvider>
+    );
+    const { result, unmount } = renderHook(() => useSidebar(), { wrapper });
+    let lifecycle: Promise<unknown> | undefined;
+
+    act(() => {
+      lifecycle = result.current.openSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+    unmount();
+
+    if (lifecycle === undefined) {
+      throw new Error("Sidebar lifecycle was not created.");
+    }
+    await expect(lifecycle).resolves.toEqual({
+      status: "canceled",
+      reason: "closed",
+    });
+  });
+
   it("preserves the original lifecycle promise until the replacement closes", async () => {
     const wrapper = ({ children }: Readonly<{ children: ReactNode }>) => (
       <SidebarProvider>{children}</SidebarProvider>

--- a/apps/desktop/src/app/sidebarProvider.test.tsx
+++ b/apps/desktop/src/app/sidebarProvider.test.tsx
@@ -552,7 +552,7 @@ describe("SidebarProvider stack contract", () => {
     ).toBe(false);
   });
 
-  it("clears route preservation when the final entry closes or a lifecycle is replaced", () => {
+  it("clears route preservation when the final entry closes and retains it across replacement", () => {
     const { result } = renderHook(() => useSidebar(), { wrapper });
     act(() => {
       void result.current.openSidebar({ kind: "taskDetail", taskID: "task-1" });
@@ -596,6 +596,6 @@ describe("SidebarProvider stack contract", () => {
         pathname: "/projects/project-1",
         searchStr: "workflowId=workflow-1",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/apps/desktop/src/app/sidebarProvider.test.tsx
+++ b/apps/desktop/src/app/sidebarProvider.test.tsx
@@ -86,6 +86,42 @@ describe("SidebarProvider replacement", () => {
     expect(result.current.phase).toBe("closing");
     expect(result.current.activeActivationID).toBe(activationID);
   });
+
+  it("ignores a pop-out completion from an activation superseded by Back", () => {
+    const wrapper = ({ children }: Readonly<{ children: ReactNode }>) => (
+      <SidebarProvider>{children}</SidebarProvider>
+    );
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+    const openedActivationID = result.current.activeActivationID;
+    if (openedActivationID === null) {
+      throw new Error("Sidebar activation was not created.");
+    }
+
+    act(() => {
+      result.current.pushSidebar({ kind: "taskDetail", taskID: "task-2" });
+    });
+    act(() => {
+      result.current.backSidebar();
+    });
+
+    expect(result.current.activeDestination).toEqual({
+      kind: "taskDetail",
+      taskID: "task-1",
+    });
+    expect(result.current.activeActivationID).not.toBe(openedActivationID);
+
+    act(() => {
+      result.current.closeSidebarIfCurrentActivation(openedActivationID);
+    });
+
+    expect(result.current.activeDestination).toEqual({
+      kind: "taskDetail",
+      taskID: "task-1",
+    });
+  });
 });
 
 describe("SidebarProvider stack contract", () => {

--- a/apps/desktop/src/app/sidebarProvider.test.tsx
+++ b/apps/desktop/src/app/sidebarProvider.test.tsx
@@ -125,6 +125,29 @@ describe("SidebarProvider replacement", () => {
     expect(result.current.activeActivationID).toBe(activationID);
   });
 
+  it("ignores replacement requests during the close animation", () => {
+    const wrapper = ({ children }: Readonly<{ children: ReactNode }>) => (
+      <SidebarProvider>{children}</SidebarProvider>
+    );
+    const { result } = renderHook(() => useSidebar(), { wrapper });
+    act(() => {
+      void result.current.openSidebar({ kind: "taskDetail", taskID: "task-1" });
+    });
+    act(() => {
+      result.current.closeSidebar();
+    });
+
+    act(() => {
+      result.current.replaceSidebar({ kind: "taskDetail", taskID: "task-2" });
+    });
+
+    expect(result.current.phase).toBe("closing");
+    expect(result.current.activeDestination).toEqual({
+      kind: "taskDetail",
+      taskID: "task-1",
+    });
+  });
+
   it("ignores a pop-out completion from an activation superseded by Back", () => {
     const wrapper = ({ children }: Readonly<{ children: ReactNode }>) => (
       <SidebarProvider>{children}</SidebarProvider>

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -305,6 +305,9 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       void runViewTransition({
         scope: "sidebar-push",
         update: () => {
+          if (pendingRef.current?.lifecycleID !== state.lifecycleID) {
+            return;
+          }
           dispatchStack({
             type: "push",
             activationID,
@@ -344,6 +347,9 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     void runViewTransition({
       scope: "sidebar-back",
       update: () => {
+        if (pendingRef.current?.lifecycleID !== state.lifecycleID) {
+          return;
+        }
         dispatchStack({
           type: "back",
           activationID,

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -309,8 +309,14 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
 
   const backSidebar = useCallback((): void => {
     const state = stackStateRef.current;
+    const pending = pendingRef.current;
     const activeEntry = state?.entries.at(-1);
-    if (state === null || state.entries.length <= 1 || activeEntry === undefined) {
+    if (
+      state === null ||
+      pending?.lifecycleID !== state.lifecycleID ||
+      state.entries.length <= 1 ||
+      activeEntry === undefined
+    ) {
       return;
     }
     clearCapture({ entryID: activeEntry.entryID, lifecycleID: state.lifecycleID });
@@ -437,6 +443,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
   useEffect(() => {
     return () => {
       clearCloseTimeout();
+      pendingRef.current?.resolve({ status: "canceled", reason: "closed" });
       pendingRef.current = null;
       clearAllCaptures();
     };

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -247,9 +247,6 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       if (state === null || pendingRef.current === null) {
         throw new Error("Sidebar replacement requires an active destination lifecycle.");
       }
-      clearCloseTimeout();
-      setExitBlockedToken(null);
-      preserveRouteChangeRef.current = null;
       const currentEntry = state.entries.at(-1);
       if (currentEntry === undefined) {
         throw new Error("Sidebar replacement requires an active destination.");
@@ -257,6 +254,9 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       if (findTaskDetailIndex([currentEntry], destination) === 0 && !captureCurrentState()) {
         return;
       }
+      clearCloseTimeout();
+      setExitBlockedToken(null);
+      preserveRouteChangeRef.current = null;
       clearCapture({ entryID: currentEntry.entryID, lifecycleID: state.lifecycleID });
       const nextProfile = sidebarWidthProfile(destination);
       setActiveWidthProfile(nextProfile);

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -260,7 +260,6 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       }
       clearCloseTimeout();
       setExitBlockedToken(null);
-      preserveRouteChangeRef.current = null;
       clearCapture(currentToken);
       const nextProfile = sidebarWidthProfile(destination);
       setActiveWidthProfile(nextProfile);

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -215,38 +215,6 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     [clearAllCaptures, clearCloseTimeout, dispatchStack, nextID],
   );
 
-  const replaceSidebar = useCallback(
-    (destination: SidebarDestination): void => {
-      const state = stackStateRef.current;
-      if (state === null || pendingRef.current === null) {
-        throw new Error("Sidebar replacement requires an active destination lifecycle.");
-      }
-      clearCloseTimeout();
-      setExitBlockedToken(null);
-      preserveRouteChangeRef.current = null;
-      const currentEntry = state.entries.at(-1);
-      if (currentEntry === undefined) {
-        throw new Error("Sidebar replacement requires an active destination.");
-      }
-      clearCapture({ entryID: currentEntry.entryID, lifecycleID: state.lifecycleID });
-      const nextProfile = sidebarWidthProfile(destination);
-      setActiveWidthProfile(nextProfile);
-      setSidebarWidths((current) =>
-        sidebarWidthForProfile(current, nextProfile) === undefined
-          ? [...current, { profile: nextProfile, widthPx: defaultSidebarWidth(destination) }]
-          : current,
-      );
-      setPhase("open");
-      dispatchStack({
-        type: "replace",
-        activationID: nextID("activation"),
-        entryID: nextID("entry"),
-        destination,
-      });
-    },
-    [clearCapture, clearCloseTimeout, dispatchStack, nextID],
-  );
-
   const captureCurrentState = useCallback((): boolean => {
     const state = stackStateRef.current;
     const pending = pendingRef.current;
@@ -272,6 +240,41 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     clearCapture(token);
     return true;
   }, [clearCapture, dispatchStack]);
+
+  const replaceSidebar = useCallback(
+    (destination: SidebarDestination): void => {
+      const state = stackStateRef.current;
+      if (state === null || pendingRef.current === null) {
+        throw new Error("Sidebar replacement requires an active destination lifecycle.");
+      }
+      clearCloseTimeout();
+      setExitBlockedToken(null);
+      preserveRouteChangeRef.current = null;
+      const currentEntry = state.entries.at(-1);
+      if (currentEntry === undefined) {
+        throw new Error("Sidebar replacement requires an active destination.");
+      }
+      if (findTaskDetailIndex([currentEntry], destination) === 0 && !captureCurrentState()) {
+        return;
+      }
+      clearCapture({ entryID: currentEntry.entryID, lifecycleID: state.lifecycleID });
+      const nextProfile = sidebarWidthProfile(destination);
+      setActiveWidthProfile(nextProfile);
+      setSidebarWidths((current) =>
+        sidebarWidthForProfile(current, nextProfile) === undefined
+          ? [...current, { profile: nextProfile, widthPx: defaultSidebarWidth(destination) }]
+          : current,
+      );
+      setPhase("open");
+      dispatchStack({
+        type: "replace",
+        activationID: nextID("activation"),
+        entryID: nextID("entry"),
+        destination,
+      });
+    },
+    [captureCurrentState, clearCapture, clearCloseTimeout, dispatchStack, nextID],
+  );
 
   const pushSidebar = useCallback(
     (destination: SidebarDestination): void => {

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -244,6 +244,9 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
   const replaceSidebar = useCallback(
     (destination: SidebarDestination): void => {
       const state = stackStateRef.current;
+      if (phase === "closing") {
+        return;
+      }
       if (state === null || pendingRef.current === null) {
         throw new Error("Sidebar replacement requires an active destination lifecycle.");
       }
@@ -251,13 +254,14 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       if (currentEntry === undefined) {
         throw new Error("Sidebar replacement requires an active destination.");
       }
+      const currentToken = sidebarEntryToken(state.lifecycleID, currentEntry.entryID);
       if (findTaskDetailIndex([currentEntry], destination) === 0 && !captureCurrentState()) {
         return;
       }
       clearCloseTimeout();
       setExitBlockedToken(null);
       preserveRouteChangeRef.current = null;
-      clearCapture({ entryID: currentEntry.entryID, lifecycleID: state.lifecycleID });
+      clearCapture(currentToken);
       const nextProfile = sidebarWidthProfile(destination);
       setActiveWidthProfile(nextProfile);
       setSidebarWidths((current) =>
@@ -273,7 +277,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
         destination,
       });
     },
-    [captureCurrentState, clearCapture, clearCloseTimeout, dispatchStack, nextID],
+    [captureCurrentState, clearCapture, clearCloseTimeout, dispatchStack, nextID, phase],
   );
 
   const pushSidebar = useCallback(
@@ -290,7 +294,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       const existingTaskIndex = findTaskDetailIndex(state.entries, destination);
       clearCloseTimeout();
       setExitBlockedToken(null);
-      clearCapture({ entryID: activeEntry.entryID, lifecycleID: state.lifecycleID });
+      clearCapture(sidebarEntryToken(state.lifecycleID, activeEntry.entryID));
       const nextDestination =
         existingTaskIndex === undefined
           ? destination
@@ -328,7 +332,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       return;
     }
     setExitBlockedToken(null);
-    clearCapture({ entryID: activeEntry.entryID, lifecycleID: state.lifecycleID });
+    clearCapture(sidebarEntryToken(state.lifecycleID, activeEntry.entryID));
     const previousEntry = state.entries.at(-2);
     if (previousEntry === undefined) {
       return;
@@ -403,9 +407,10 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
         closeSidebar("closed");
         return;
       }
+      const removesCurrentEntry = isCurrentToken(token);
       dispatchStack({
         type: "remove",
-        ...(state.entries.at(-1)?.entryID === token.entryID ? { activationID: nextID("activation") } : {}),
+        ...(removesCurrentEntry ? { activationID: nextID("activation") } : {}),
         lifecycleID: token.lifecycleID,
         entryID: token.entryID,
       });
@@ -415,6 +420,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       clearSidebarRouteChangePreservation,
       closeSidebar,
       dispatchStack,
+      isCurrentToken,
       isLiveEntryToken,
       nextID,
     ],

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -2,11 +2,15 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 
 import {
   SidebarContext,
+  runViewTransition,
   type SidebarCanceledResult,
   type SidebarCancelReason,
+  type SidebarController,
   type SidebarDestination,
+  type SidebarEntryToken,
   type SidebarPhase,
   type SidebarResult,
+  type SidebarStateCapture,
 } from "@/app-facade";
 import {
   sidebarSizePreference,
@@ -15,6 +19,11 @@ import {
   type SidebarWidthProfile,
 } from "@/app-facade";
 import { initialSidebarWidthForViewport, type ResolvedSidebarWidth } from "@/app-facade";
+import {
+  sidebarStackReducer,
+  type SidebarStackAction,
+  type SidebarStackState,
+} from "./sidebarStack";
 
 const sidebarExitAnimationMs = 140;
 type SidebarWidthEntry = Readonly<{
@@ -25,22 +34,29 @@ type SidebarWidths = readonly SidebarWidthEntry[];
 const defaultSidebarWidthProfile: SidebarWidthProfile = { kind: "custom", sizing: null };
 
 type PendingSidebar = Readonly<{
+  lifecycleID: string;
   resolve: (result: SidebarResult) => void;
 }>;
 
 export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>) {
-  const [activeDestination, setActiveDestination] = useState<SidebarDestination | null>(null);
+  const [stackState, setStackState] = useState<SidebarStackState | null>(null);
   const [activeWidthProfile, setActiveWidthProfile] =
     useState<SidebarWidthProfile>(defaultSidebarWidthProfile);
   const [phase, setPhase] = useState<SidebarPhase>("open");
   const [sidebarWidths, setSidebarWidths] = useState<SidebarWidths>(() => [
     { profile: defaultSidebarWidthProfile, widthPx: defaultSidebarWidth() },
   ]);
-  const sidebarWidthPx =
-    sidebarWidthForProfile(sidebarWidths, activeWidthProfile) ?? defaultSidebarWidth(activeDestination);
-  const activeDestinationRef = useRef<SidebarDestination | null>(activeDestination);
+  const stackStateRef = useRef<SidebarStackState | null>(stackState);
   const pendingRef = useRef<PendingSidebar | null>(null);
+  const captureRef = useRef(new Map<string, SidebarStateCapture>());
+  const preserveRouteChangeRef = useRef(false);
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const nextIDRef = useRef(0);
+
+  const nextID = useCallback((prefix: "lifecycle" | "entry"): string => {
+    nextIDRef.current += 1;
+    return `${prefix}-${nextIDRef.current.toString()}`;
+  }, []);
 
   const clearCloseTimeout = useCallback(() => {
     if (closeTimeoutRef.current !== null) {
@@ -49,31 +65,93 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     }
   }, []);
 
-  const animateClosed = useCallback(() => {
-    clearCloseTimeout();
-    setPhase("closing");
-    closeTimeoutRef.current = setTimeout(() => {
-      closeTimeoutRef.current = null;
-      setActiveDestination(null);
-      setPhase("open");
-    }, sidebarExitAnimationMs);
-  }, [clearCloseTimeout]);
+  const dispatchStack = useCallback((action: SidebarStackAction) => {
+    setStackState((current) => {
+      const next = sidebarStackReducer(current, action);
+      stackStateRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const clearCapture = useCallback((token: SidebarEntryToken) => {
+    captureRef.current.delete(tokenKey(token));
+  }, []);
+
+  const clearAllCaptures = useCallback(() => {
+    captureRef.current.clear();
+  }, []);
+
+  const isCurrentToken = useCallback((token: SidebarEntryToken): boolean => {
+    const state = stackStateRef.current;
+    const pending = pendingRef.current;
+    const activeEntry = state?.entries.at(-1);
+    return (
+      pending?.lifecycleID === token.lifecycleID &&
+      state?.lifecycleID === token.lifecycleID &&
+      activeEntry?.entryID === token.entryID
+    );
+  }, []);
+
+  const activeTokenForState = useCallback(
+    (state: SidebarStackState | null): SidebarEntryToken | null => {
+      const activeEntry = state?.entries.at(-1);
+      return activeEntry === undefined || state === null
+        ? null
+        : { entryID: activeEntry.entryID, lifecycleID: state.lifecycleID };
+    },
+    [],
+  );
+
+  const animateClosed = useCallback(
+    (lifecycleID: string) => {
+      clearCloseTimeout();
+      setPhase("closing");
+      closeTimeoutRef.current = setTimeout(() => {
+        closeTimeoutRef.current = null;
+        if (stackStateRef.current?.lifecycleID !== lifecycleID) {
+          return;
+        }
+        dispatchStack({ type: "close", lifecycleID });
+        setPhase("open");
+      }, sidebarExitAnimationMs);
+    },
+    [clearCloseTimeout, dispatchStack],
+  );
 
   const closeSidebar = useCallback(
     (reason: SidebarCancelReason = "closed") => {
+      const state = stackStateRef.current;
       const pending = pendingRef.current;
       pendingRef.current = null;
+      clearAllCaptures();
       pending?.resolve({ status: "canceled", reason });
-      if (activeDestinationRef.current !== null) {
-        animateClosed();
+      if (state !== null) {
+        animateClosed(state.lifecycleID);
       }
     },
-    [animateClosed],
+    [animateClosed, clearAllCaptures],
   );
+
+  const preserveSidebarOnNextRouteChange = useCallback(() => {
+    preserveRouteChangeRef.current = true;
+  }, []);
+
+  const consumeSidebarRouteChangePreservation = useCallback(() => {
+    const preserved = preserveRouteChangeRef.current;
+    preserveRouteChangeRef.current = false;
+    return preserved;
+  }, []);
 
   const openSidebar = useCallback(
     async (destination: SidebarDestination): Promise<SidebarResult> => {
       clearCloseTimeout();
+      const previousPending = pendingRef.current;
+      pendingRef.current = null;
+      clearAllCaptures();
+      previousPending?.resolve({ status: "canceled", reason: "replaced" });
+
+      const lifecycleID = nextID("lifecycle");
+      const entryID = nextID("entry");
       const nextProfile = sidebarWidthProfile(destination);
       setActiveWidthProfile(nextProfile);
       setSidebarWidths((current) => {
@@ -82,25 +160,32 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
         }
         return [...current, { profile: nextProfile, widthPx: defaultSidebarWidth(destination) }];
       });
-      const pending = pendingRef.current;
-      pendingRef.current = null;
-      pending?.resolve({ status: "canceled", reason: "replaced" });
       setPhase("open");
-      activeDestinationRef.current = destination;
-      setActiveDestination(destination);
+      dispatchStack({
+        type: "open",
+        lifecycleID,
+        entryID,
+        destination,
+      });
       return new Promise<SidebarResult>((resolve) => {
-        pendingRef.current = { resolve };
+        pendingRef.current = { lifecycleID, resolve };
       });
     },
-    [clearCloseTimeout],
+    [clearAllCaptures, clearCloseTimeout, dispatchStack, nextID],
   );
 
   const replaceSidebar = useCallback(
     (destination: SidebarDestination): void => {
-      if (activeDestinationRef.current === null || pendingRef.current === null) {
+      const state = stackStateRef.current;
+      if (state === null || pendingRef.current === null) {
         throw new Error("Sidebar replacement requires an active destination lifecycle.");
       }
       clearCloseTimeout();
+      const currentEntry = state.entries.at(-1);
+      if (currentEntry === undefined) {
+        throw new Error("Sidebar replacement requires an active destination.");
+      }
+      clearCapture({ entryID: currentEntry.entryID, lifecycleID: state.lifecycleID });
       const nextProfile = sidebarWidthProfile(destination);
       setActiveWidthProfile(nextProfile);
       setSidebarWidths((current) =>
@@ -109,22 +194,117 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
           : current,
       );
       setPhase("open");
-      activeDestinationRef.current = destination;
-      setActiveDestination(destination);
+      dispatchStack({
+        type: "replace",
+        entryID: nextID("entry"),
+        destination,
+      });
     },
-    [clearCloseTimeout],
+    [clearCapture, clearCloseTimeout, dispatchStack, nextID],
   );
+
+  const captureCurrentState = useCallback((): boolean => {
+    const state = stackStateRef.current;
+    const pending = pendingRef.current;
+    const activeEntry = state?.entries.at(-1);
+    if (state === null || pending === null || activeEntry === undefined) {
+      return false;
+    }
+    const token = { entryID: activeEntry.entryID, lifecycleID: state.lifecycleID };
+    const capture = captureRef.current.get(tokenKey(token));
+    if (capture === undefined) {
+      return true;
+    }
+    const snapshot = capture();
+    if (snapshot === null) {
+      return false;
+    }
+    dispatchStack({
+      type: "capture",
+      lifecycleID: token.lifecycleID,
+      entryID: token.entryID,
+      snapshot,
+    });
+    clearCapture(token);
+    return true;
+  }, [clearCapture, dispatchStack]);
+
+  const pushSidebar = useCallback(
+    (destination: SidebarDestination): void => {
+      const state = stackStateRef.current;
+      const pending = pendingRef.current;
+      if (state === null || pending === null || !captureCurrentState()) {
+        return;
+      }
+      const activeEntry = state.entries.at(-1);
+      if (activeEntry === undefined) {
+        return;
+      }
+      const existingTask = state.entries.find(
+        (entry) =>
+          destination.kind === "taskDetail" &&
+          entry.destination.kind === "taskDetail" &&
+          entry.destination.taskID === destination.taskID,
+      );
+      clearCloseTimeout();
+      clearCapture({ entryID: activeEntry.entryID, lifecycleID: state.lifecycleID });
+      const nextDestination = existingTask?.destination ?? destination;
+      setActiveWidthProfile(sidebarWidthProfile(nextDestination));
+      setPhase("open");
+      void runViewTransition({
+        scope: "sidebar-push",
+        update: () => {
+          dispatchStack({
+            type: "push",
+            lifecycleID: state.lifecycleID,
+            entryID: nextID("entry"),
+            sourceEntryID: activeEntry.entryID,
+            destination,
+          });
+        },
+      });
+    },
+    [captureCurrentState, clearCapture, clearCloseTimeout, dispatchStack, nextID],
+  );
+
+  const backSidebar = useCallback((): void => {
+    const state = stackStateRef.current;
+    const activeEntry = state?.entries.at(-1);
+    if (state === null || state.entries.length <= 1 || activeEntry === undefined) {
+      return;
+    }
+    clearCapture({ entryID: activeEntry.entryID, lifecycleID: state.lifecycleID });
+    const previousEntry = state.entries.at(-2);
+    if (previousEntry === undefined) {
+      return;
+    }
+    clearCloseTimeout();
+    setActiveWidthProfile(sidebarWidthProfile(previousEntry.destination));
+    setPhase("open");
+    void runViewTransition({
+      scope: "sidebar-back",
+      update: () => {
+        dispatchStack({
+          type: "back",
+          lifecycleID: state.lifecycleID,
+          entryID: activeEntry.entryID,
+        });
+      },
+    });
+  }, [clearCapture, clearCloseTimeout, dispatchStack]);
 
   const resolveSidebar = useCallback(
     (result: Exclude<SidebarResult, SidebarCanceledResult>) => {
+      const state = stackStateRef.current;
       const pending = pendingRef.current;
       pendingRef.current = null;
+      clearAllCaptures();
       pending?.resolve(result);
-      if (activeDestinationRef.current !== null) {
-        animateClosed();
+      if (state !== null) {
+        animateClosed(state.lifecycleID);
       }
     },
-    [animateClosed],
+    [animateClosed, clearAllCaptures],
   );
 
   const resizeSidebar = useCallback(
@@ -134,38 +314,159 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     [activeWidthProfile],
   );
 
-  useEffect(() => {
-    return clearCloseTimeout;
-  }, [clearCloseTimeout]);
+  const registerSidebarStateCapture = useCallback(
+    (token: SidebarEntryToken, capture: SidebarStateCapture): (() => void) => {
+      if (!isCurrentToken(token)) {
+        return () => {
+          return;
+        };
+      }
+      const key = tokenKey(token);
+      captureRef.current.set(key, capture);
+      return () => {
+        if (captureRef.current.get(key) === capture) {
+          captureRef.current.delete(key);
+        }
+      };
+    },
+    [isCurrentToken],
+  );
+
+  const removeSidebarEntry = useCallback(
+    (token: SidebarEntryToken): void => {
+      const state = stackStateRef.current;
+      if (
+        state === null ||
+        pendingRef.current?.lifecycleID !== token.lifecycleID ||
+        state.lifecycleID !== token.lifecycleID ||
+        !state.entries.some((entry) => entry.entryID === token.entryID)
+      ) {
+        return;
+      }
+      clearCapture(token);
+      if (state.entries.length === 1) {
+        closeSidebar("closed");
+        return;
+      }
+      dispatchStack({
+        type: "remove",
+        lifecycleID: token.lifecycleID,
+        entryID: token.entryID,
+      });
+    },
+    [clearCapture, closeSidebar, dispatchStack],
+  );
+
+  const closeSidebarIfCurrent = useCallback(
+    (token: SidebarEntryToken, reason: SidebarCancelReason = "closed"): void => {
+      if (isCurrentToken(token)) {
+        closeSidebar(reason);
+      }
+    },
+    [closeSidebar, isCurrentToken],
+  );
+
+  const replaceSidebarIfCurrent = useCallback(
+    (token: SidebarEntryToken, destination: SidebarDestination): void => {
+      if (isCurrentToken(token)) {
+        replaceSidebar(destination);
+      }
+    },
+    [isCurrentToken, replaceSidebar],
+  );
+
+  const resolveSidebarIfCurrent = useCallback(
+    (
+      token: SidebarEntryToken,
+      result: Exclude<SidebarResult, SidebarCanceledResult>,
+    ): void => {
+      if (isCurrentToken(token)) {
+        resolveSidebar(result);
+      }
+    },
+    [isCurrentToken, resolveSidebar],
+  );
 
   useEffect(() => {
-    activeDestinationRef.current = activeDestination;
-  }, [activeDestination]);
+    return () => {
+      clearCloseTimeout();
+      pendingRef.current = null;
+      clearAllCaptures();
+    };
+  }, [clearAllCaptures, clearCloseTimeout]);
 
-  const value = useMemo(
+  const activeDestination = stackState?.entries.at(-1)?.destination ?? null;
+  const activeSnapshot = stackState?.entries.at(-1)?.snapshot ?? null;
+  const activeToken = activeTokenForState(stackState);
+  const stackDestinations = useMemo(
+    () => stackState?.entries.map((entry) => entry.destination) ?? [],
+    [stackState],
+  );
+  const stackEntryTokens = useMemo(
+    () =>
+      stackState?.entries.map((entry) => ({ entryID: entry.entryID, lifecycleID: stackState.lifecycleID })) ??
+      [],
+    [stackState],
+  );
+  const sidebarWidthPx =
+    sidebarWidthForProfile(sidebarWidths, activeWidthProfile) ?? defaultSidebarWidth(activeDestination);
+
+  const value = useMemo<SidebarController>(
     () => ({
       activeDestination,
+      activeSnapshot,
+      activeToken,
+      backSidebar,
+      canGoBack: (stackState?.entries.length ?? 0) > 1,
       closeSidebar,
+      closeSidebarIfCurrent,
       openSidebar,
+      preserveSidebarOnNextRouteChange,
+      consumeSidebarRouteChangePreservation,
+      pushSidebar,
+      registerSidebarStateCapture,
+      removeSidebarEntry,
       replaceSidebar,
+      replaceSidebarIfCurrent,
       phase,
       resizeSidebar,
       resolveSidebar,
+      resolveSidebarIfCurrent,
       sidebarWidthPx,
+      stackDestinations,
+      stackEntryTokens,
     }),
     [
       activeDestination,
+      activeSnapshot,
+      activeToken,
+      backSidebar,
       closeSidebar,
+      closeSidebarIfCurrent,
       openSidebar,
+      preserveSidebarOnNextRouteChange,
+      consumeSidebarRouteChangePreservation,
       phase,
+      pushSidebar,
+      registerSidebarStateCapture,
+      removeSidebarEntry,
       replaceSidebar,
+      replaceSidebarIfCurrent,
       resizeSidebar,
       resolveSidebar,
+      resolveSidebarIfCurrent,
       sidebarWidthPx,
+      stackDestinations,
+      stackEntryTokens,
+      stackState?.entries.length,
     ],
   );
 
   return <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>;
+}
+
+function tokenKey(token: SidebarEntryToken): string {
+  return `${token.lifecycleID}:${token.entryID}`;
 }
 
 function defaultSidebarWidth(destination: SidebarDestination | null = null): number {

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -161,7 +161,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
 
   const clearSidebarRouteChangePreservation = useCallback((token: SidebarEntryToken) => {
     const pending = preserveRouteChangeRef.current;
-    if (pending?.token.lifecycleID === token.lifecycleID && pending.token.entryID === token.entryID) {
+    if (pending !== null && tokenKey(pending.token) === tokenKey(token)) {
       preserveRouteChangeRef.current = null;
     }
   }, []);

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -54,6 +54,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
   const [sidebarWidths, setSidebarWidths] = useState<SidebarWidths>(() => [
     { profile: defaultSidebarWidthProfile, widthPx: defaultSidebarWidth() },
   ]);
+  const [exitBlockedToken, setExitBlockedToken] = useState<SidebarEntryToken | null>(null);
   const stackStateRef = useRef<SidebarStackState | null>(stackState);
   const pendingRef = useRef<PendingSidebar | null>(null);
   const captureRef = useRef(new Map<string, SidebarStateCapture>());
@@ -89,26 +90,32 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     captureRef.current.clear();
   }, []);
 
-  const isCurrentToken = useCallback((token: SidebarEntryToken): boolean => {
+  const isLiveEntryToken = useCallback((token: SidebarEntryToken): boolean => {
     const state = stackStateRef.current;
-    const pending = pendingRef.current;
-    const activeEntry = state?.entries.at(-1);
     return (
-      pending?.lifecycleID === token.lifecycleID &&
-      state?.lifecycleID === token.lifecycleID &&
-      activeEntry?.entryID === token.entryID
+      state !== null &&
+      pendingRef.current?.lifecycleID === token.lifecycleID &&
+      state.lifecycleID === token.lifecycleID &&
+      state.entries.some((entry) => entry.entryID === token.entryID)
     );
   }, []);
 
-  const activeTokenForState = useCallback(
-    (state: SidebarStackState | null): SidebarEntryToken | null => {
-      const activeEntry = state?.entries.at(-1);
-      return activeEntry === undefined || state === null
-        ? null
-        : { entryID: activeEntry.entryID, lifecycleID: state.lifecycleID };
+  const isCurrentToken = useCallback(
+    (token: SidebarEntryToken): boolean => {
+      if (!isLiveEntryToken(token)) {
+        return false;
+      }
+      return stackStateRef.current?.entries.at(-1)?.entryID === token.entryID;
     },
-    [],
+    [isLiveEntryToken],
   );
+
+  const activeTokenForState = useCallback((state: SidebarStackState | null): SidebarEntryToken | null => {
+    const activeEntry = state?.entries.at(-1);
+    return activeEntry === undefined || state === null
+      ? null
+      : { entryID: activeEntry.entryID, lifecycleID: state.lifecycleID };
+  }, []);
 
   const animateClosed = useCallback(
     (lifecycleID: string) => {
@@ -130,6 +137,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     (reason: SidebarCancelReason = "closed") => {
       const state = stackStateRef.current;
       const pending = pendingRef.current;
+      setExitBlockedToken(null);
       pendingRef.current = null;
       preserveRouteChangeRef.current = null;
       clearAllCaptures();
@@ -143,18 +151,12 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
 
   const preserveSidebarOnNextRouteChange = useCallback(
     (token: SidebarEntryToken, expectation: SidebarRouteChangeExpectation) => {
-      const state = stackStateRef.current;
-      if (
-        state === null ||
-        pendingRef.current?.lifecycleID !== token.lifecycleID ||
-        state.lifecycleID !== token.lifecycleID ||
-        !state.entries.some((entry) => entry.entryID === token.entryID)
-      ) {
+      if (!isLiveEntryToken(token)) {
         return;
       }
       preserveRouteChangeRef.current = { expectation, token };
     },
-    [],
+    [isLiveEntryToken],
   );
 
   const clearSidebarRouteChangePreservation = useCallback((token: SidebarEntryToken) => {
@@ -180,6 +182,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
   const openSidebar = useCallback(
     async (destination: SidebarDestination): Promise<SidebarResult> => {
       clearCloseTimeout();
+      setExitBlockedToken(null);
       const previousPending = pendingRef.current;
       pendingRef.current = null;
       preserveRouteChangeRef.current = null;
@@ -219,6 +222,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
         throw new Error("Sidebar replacement requires an active destination lifecycle.");
       }
       clearCloseTimeout();
+      setExitBlockedToken(null);
       preserveRouteChangeRef.current = null;
       const currentEntry = state.entries.at(-1);
       if (currentEntry === undefined) {
@@ -282,6 +286,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       }
       const existingTaskIndex = findTaskDetailIndex(state.entries, destination);
       clearCloseTimeout();
+      setExitBlockedToken(null);
       clearCapture({ entryID: activeEntry.entryID, lifecycleID: state.lifecycleID });
       const nextDestination =
         existingTaskIndex === undefined
@@ -319,6 +324,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     ) {
       return;
     }
+    setExitBlockedToken(null);
     clearCapture({ entryID: activeEntry.entryID, lifecycleID: state.lifecycleID });
     const previousEntry = state.entries.at(-2);
     if (previousEntry === undefined) {
@@ -345,6 +351,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     (result: Exclude<SidebarResult, SidebarCanceledResult>) => {
       const state = stackStateRef.current;
       const pending = pendingRef.current;
+      setExitBlockedToken(null);
       pendingRef.current = null;
       preserveRouteChangeRef.current = null;
       clearAllCaptures();
@@ -384,12 +391,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
   const removeSidebarEntry = useCallback(
     (token: SidebarEntryToken): void => {
       const state = stackStateRef.current;
-      if (
-        state === null ||
-        pendingRef.current?.lifecycleID !== token.lifecycleID ||
-        state.lifecycleID !== token.lifecycleID ||
-        !state.entries.some((entry) => entry.entryID === token.entryID)
-      ) {
+      if (state === null || !isLiveEntryToken(token)) {
         clearSidebarRouteChangePreservation(token);
         return;
       }
@@ -400,14 +402,19 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       }
       dispatchStack({
         type: "remove",
-        ...(state.entries.at(-1)?.entryID === token.entryID
-          ? { activationID: nextID("activation") }
-          : {}),
+        ...(state.entries.at(-1)?.entryID === token.entryID ? { activationID: nextID("activation") } : {}),
         lifecycleID: token.lifecycleID,
         entryID: token.entryID,
       });
     },
-    [clearCapture, clearSidebarRouteChangePreservation, closeSidebar, dispatchStack, nextID],
+    [
+      clearCapture,
+      clearSidebarRouteChangePreservation,
+      closeSidebar,
+      dispatchStack,
+      isLiveEntryToken,
+      nextID,
+    ],
   );
 
   const closeSidebarIfCurrent = useCallback(
@@ -417,6 +424,21 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       }
     },
     [closeSidebar, isCurrentToken],
+  );
+
+  const setSidebarExitBlocked = useCallback(
+    (token: SidebarEntryToken, blocked: boolean): void => {
+      if (!isCurrentToken(token)) {
+        return;
+      }
+      setExitBlockedToken((current) => {
+        if (blocked) {
+          return current !== null && tokenKey(current) === tokenKey(token) ? current : token;
+        }
+        return current !== null && tokenKey(current) === tokenKey(token) ? null : current;
+      });
+    },
+    [isCurrentToken],
   );
 
   const replaceSidebarIfCurrent = useCallback(
@@ -429,10 +451,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
   );
 
   const resolveSidebarIfCurrent = useCallback(
-    (
-      token: SidebarEntryToken,
-      result: Exclude<SidebarResult, SidebarCanceledResult>,
-    ): void => {
+    (token: SidebarEntryToken, result: Exclude<SidebarResult, SidebarCanceledResult>): void => {
       if (isCurrentToken(token)) {
         resolveSidebar(result);
       }
@@ -452,7 +471,10 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
   const activeDestination = stackState?.entries.at(-1)?.destination ?? null;
   const activeActivationID = phase === "closing" ? null : (stackState?.activationID ?? null);
   const activeSnapshot = stackState?.entries.at(-1)?.snapshot ?? null;
-  const activeToken = activeTokenForState(stackState);
+  const activeToken = useMemo(
+    () => activeTokenForState(stackState),
+    [activeTokenForState, stackState],
+  );
   const stackDestinations = useMemo(
     () => stackState?.entries.map((entry) => entry.destination) ?? [],
     [stackState],
@@ -474,6 +496,11 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       activeToken,
       backSidebar,
       canGoBack: (stackState?.entries.length ?? 0) > 1,
+      sidebarExitBlocked:
+        activeToken !== null &&
+        exitBlockedToken !== null &&
+        tokenKey(activeToken) === tokenKey(exitBlockedToken),
+      setSidebarExitBlocked,
       closeSidebar,
       closeSidebarIfCurrent,
       openSidebar,
@@ -499,6 +526,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       activeSnapshot,
       activeToken,
       backSidebar,
+      exitBlockedToken,
       closeSidebar,
       closeSidebarIfCurrent,
       openSidebar,
@@ -514,6 +542,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       resizeSidebar,
       resolveSidebar,
       resolveSidebarIfCurrent,
+      setSidebarExitBlocked,
       sidebarWidthPx,
       stackDestinations,
       stackEntryTokens,

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -426,6 +426,15 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     [closeSidebar, isCurrentToken],
   );
 
+  const closeSidebarIfCurrentActivation = useCallback(
+    (activationID: string, reason: SidebarCancelReason = "closed"): void => {
+      if (stackStateRef.current?.activationID === activationID) {
+        closeSidebar(reason);
+      }
+    },
+    [closeSidebar],
+  );
+
   const setSidebarExitBlocked = useCallback(
     (token: SidebarEntryToken, blocked: boolean): void => {
       if (!isCurrentToken(token)) {
@@ -498,6 +507,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       setSidebarExitBlocked,
       closeSidebar,
       closeSidebarIfCurrent,
+      closeSidebarIfCurrentActivation,
       openSidebar,
       preserveSidebarOnNextRouteChange,
       clearSidebarRouteChangePreservation,
@@ -524,6 +534,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       exitBlockedToken,
       closeSidebar,
       closeSidebarIfCurrent,
+      closeSidebarIfCurrentActivation,
       openSidebar,
       preserveSidebarOnNextRouteChange,
       clearSidebarRouteChangePreservation,

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -47,6 +47,7 @@ type PendingSidebarRoutePreservation = Readonly<{
 
 export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>) {
   const [stackState, setStackState] = useState<SidebarStackState | null>(null);
+  const [activeActivationID, setActiveActivationID] = useState<string | null>(null);
   const [activeWidthProfile, setActiveWidthProfile] =
     useState<SidebarWidthProfile>(defaultSidebarWidthProfile);
   const [phase, setPhase] = useState<SidebarPhase>("open");
@@ -60,7 +61,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const nextIDRef = useRef(0);
 
-  const nextID = useCallback((prefix: "lifecycle" | "entry"): string => {
+  const nextID = useCallback((prefix: "activation" | "lifecycle" | "entry"): string => {
     nextIDRef.current += 1;
     return `${prefix}-${nextIDRef.current.toString()}`;
   }, []);
@@ -131,6 +132,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       const pending = pendingRef.current;
       pendingRef.current = null;
       preserveRouteChangeRef.current = null;
+      setActiveActivationID(null);
       clearAllCaptures();
       pending?.resolve({ status: "canceled", reason });
       if (state !== null) {
@@ -187,6 +189,8 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
 
       const lifecycleID = nextID("lifecycle");
       const entryID = nextID("entry");
+      const activationID = nextID("activation");
+      setActiveActivationID(activationID);
       const nextProfile = sidebarWidthProfile(destination);
       setActiveWidthProfile(nextProfile);
       setSidebarWidths((current) => {
@@ -223,6 +227,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       }
       clearCapture({ entryID: currentEntry.entryID, lifecycleID: state.lifecycleID });
       const nextProfile = sidebarWidthProfile(destination);
+      setActiveActivationID(nextID("activation"));
       setActiveWidthProfile(nextProfile);
       setSidebarWidths((current) =>
         sidebarWidthForProfile(current, nextProfile) === undefined
@@ -285,11 +290,13 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       clearCloseTimeout();
       clearCapture({ entryID: activeEntry.entryID, lifecycleID: state.lifecycleID });
       const nextDestination = existingTask?.destination ?? destination;
+      const activationID = nextID("activation");
       setActiveWidthProfile(sidebarWidthProfile(nextDestination));
       setPhase("open");
       void runViewTransition({
         scope: "sidebar-push",
         update: () => {
+          setActiveActivationID(activationID);
           dispatchStack({
             type: "push",
             lifecycleID: state.lifecycleID,
@@ -316,10 +323,12 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     }
     clearCloseTimeout();
     setActiveWidthProfile(sidebarWidthProfile(previousEntry.destination));
+    const activationID = nextID("activation");
     setPhase("open");
     void runViewTransition({
       scope: "sidebar-back",
       update: () => {
+        setActiveActivationID(activationID);
         dispatchStack({
           type: "back",
           lifecycleID: state.lifecycleID,
@@ -327,7 +336,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
         });
       },
     });
-  }, [clearCapture, clearCloseTimeout, dispatchStack]);
+  }, [clearCapture, clearCloseTimeout, dispatchStack, nextID]);
 
   const resolveSidebar = useCallback(
     (result: Exclude<SidebarResult, SidebarCanceledResult>) => {
@@ -335,6 +344,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       const pending = pendingRef.current;
       pendingRef.current = null;
       preserveRouteChangeRef.current = null;
+      setActiveActivationID(null);
       clearAllCaptures();
       pending?.resolve(result);
       if (state !== null) {
@@ -386,13 +396,16 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
         closeSidebar("closed");
         return;
       }
+      if (state.entries.at(-1)?.entryID === token.entryID) {
+        setActiveActivationID(nextID("activation"));
+      }
       dispatchStack({
         type: "remove",
         lifecycleID: token.lifecycleID,
         entryID: token.entryID,
       });
     },
-    [clearCapture, clearSidebarRouteChangePreservation, closeSidebar, dispatchStack],
+    [clearCapture, clearSidebarRouteChangePreservation, closeSidebar, dispatchStack, nextID],
   );
 
   const closeSidebarIfCurrent = useCallback(
@@ -452,6 +465,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
   const value = useMemo<SidebarController>(
     () => ({
       activeDestination,
+      activeActivationID,
       activeSnapshot,
       activeToken,
       backSidebar,
@@ -477,6 +491,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     }),
     [
       activeDestination,
+      activeActivationID,
       activeSnapshot,
       activeToken,
       backSidebar,

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -9,6 +9,9 @@ import {
   type SidebarDestination,
   type SidebarEntryToken,
   type SidebarPhase,
+  sidebarRouteMatchesExpectation,
+  type SidebarRouteChangeExpectation,
+  type SidebarRouteLocation,
   type SidebarResult,
   type SidebarStateCapture,
 } from "@/app-facade";
@@ -37,6 +40,10 @@ type PendingSidebar = Readonly<{
   lifecycleID: string;
   resolve: (result: SidebarResult) => void;
 }>;
+type PendingSidebarRoutePreservation = Readonly<{
+  expectation: SidebarRouteChangeExpectation;
+  token: SidebarEntryToken;
+}>;
 
 export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>) {
   const [stackState, setStackState] = useState<SidebarStackState | null>(null);
@@ -49,7 +56,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
   const stackStateRef = useRef<SidebarStackState | null>(stackState);
   const pendingRef = useRef<PendingSidebar | null>(null);
   const captureRef = useRef(new Map<string, SidebarStateCapture>());
-  const preserveRouteChangeRef = useRef(false);
+  const preserveRouteChangeRef = useRef<PendingSidebarRoutePreservation | null>(null);
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const nextIDRef = useRef(0);
 
@@ -123,6 +130,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       const state = stackStateRef.current;
       const pending = pendingRef.current;
       pendingRef.current = null;
+      preserveRouteChangeRef.current = null;
       clearAllCaptures();
       pending?.resolve({ status: "canceled", reason });
       if (state !== null) {
@@ -132,14 +140,40 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     [animateClosed, clearAllCaptures],
   );
 
-  const preserveSidebarOnNextRouteChange = useCallback(() => {
-    preserveRouteChangeRef.current = true;
+  const preserveSidebarOnNextRouteChange = useCallback(
+    (token: SidebarEntryToken, expectation: SidebarRouteChangeExpectation) => {
+      const state = stackStateRef.current;
+      if (
+        state === null ||
+        pendingRef.current?.lifecycleID !== token.lifecycleID ||
+        state.lifecycleID !== token.lifecycleID ||
+        !state.entries.some((entry) => entry.entryID === token.entryID)
+      ) {
+        return;
+      }
+      preserveRouteChangeRef.current = { expectation, token };
+    },
+    [],
+  );
+
+  const clearSidebarRouteChangePreservation = useCallback((token: SidebarEntryToken) => {
+    const pending = preserveRouteChangeRef.current;
+    if (pending?.token.lifecycleID === token.lifecycleID && pending.token.entryID === token.entryID) {
+      preserveRouteChangeRef.current = null;
+    }
   }, []);
 
-  const consumeSidebarRouteChangePreservation = useCallback(() => {
-    const preserved = preserveRouteChangeRef.current;
-    preserveRouteChangeRef.current = false;
-    return preserved;
+  const consumeSidebarRouteChangePreservation = useCallback((location: SidebarRouteLocation): boolean => {
+    const pending = preserveRouteChangeRef.current;
+    preserveRouteChangeRef.current = null;
+    const state = stackStateRef.current;
+    return (
+      pending !== null &&
+      state !== null &&
+      state.lifecycleID === pending.token.lifecycleID &&
+      state.entries.length > 0 &&
+      sidebarRouteMatchesExpectation(location, pending.expectation)
+    );
   }, []);
 
   const openSidebar = useCallback(
@@ -147,6 +181,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       clearCloseTimeout();
       const previousPending = pendingRef.current;
       pendingRef.current = null;
+      preserveRouteChangeRef.current = null;
       clearAllCaptures();
       previousPending?.resolve({ status: "canceled", reason: "replaced" });
 
@@ -181,6 +216,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
         throw new Error("Sidebar replacement requires an active destination lifecycle.");
       }
       clearCloseTimeout();
+      preserveRouteChangeRef.current = null;
       const currentEntry = state.entries.at(-1);
       if (currentEntry === undefined) {
         throw new Error("Sidebar replacement requires an active destination.");
@@ -298,6 +334,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       const state = stackStateRef.current;
       const pending = pendingRef.current;
       pendingRef.current = null;
+      preserveRouteChangeRef.current = null;
       clearAllCaptures();
       pending?.resolve(result);
       if (state !== null) {
@@ -341,6 +378,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
         state.lifecycleID !== token.lifecycleID ||
         !state.entries.some((entry) => entry.entryID === token.entryID)
       ) {
+        clearSidebarRouteChangePreservation(token);
         return;
       }
       clearCapture(token);
@@ -354,7 +392,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
         entryID: token.entryID,
       });
     },
-    [clearCapture, closeSidebar, dispatchStack],
+    [clearCapture, clearSidebarRouteChangePreservation, closeSidebar, dispatchStack],
   );
 
   const closeSidebarIfCurrent = useCallback(
@@ -422,6 +460,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       closeSidebarIfCurrent,
       openSidebar,
       preserveSidebarOnNextRouteChange,
+      clearSidebarRouteChangePreservation,
       consumeSidebarRouteChangePreservation,
       pushSidebar,
       registerSidebarStateCapture,
@@ -445,6 +484,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       closeSidebarIfCurrent,
       openSidebar,
       preserveSidebarOnNextRouteChange,
+      clearSidebarRouteChangePreservation,
       consumeSidebarRouteChangePreservation,
       phase,
       pushSidebar,

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -47,7 +47,6 @@ type PendingSidebarRoutePreservation = Readonly<{
 
 export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>) {
   const [stackState, setStackState] = useState<SidebarStackState | null>(null);
-  const [activeActivationID, setActiveActivationID] = useState<string | null>(null);
   const [activeWidthProfile, setActiveWidthProfile] =
     useState<SidebarWidthProfile>(defaultSidebarWidthProfile);
   const [phase, setPhase] = useState<SidebarPhase>("open");
@@ -132,7 +131,6 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       const pending = pendingRef.current;
       pendingRef.current = null;
       preserveRouteChangeRef.current = null;
-      setActiveActivationID(null);
       clearAllCaptures();
       pending?.resolve({ status: "canceled", reason });
       if (state !== null) {
@@ -190,7 +188,6 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       const lifecycleID = nextID("lifecycle");
       const entryID = nextID("entry");
       const activationID = nextID("activation");
-      setActiveActivationID(activationID);
       const nextProfile = sidebarWidthProfile(destination);
       setActiveWidthProfile(nextProfile);
       setSidebarWidths((current) => {
@@ -202,6 +199,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       setPhase("open");
       dispatchStack({
         type: "open",
+        activationID,
         lifecycleID,
         entryID,
         destination,
@@ -227,7 +225,6 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       }
       clearCapture({ entryID: currentEntry.entryID, lifecycleID: state.lifecycleID });
       const nextProfile = sidebarWidthProfile(destination);
-      setActiveActivationID(nextID("activation"));
       setActiveWidthProfile(nextProfile);
       setSidebarWidths((current) =>
         sidebarWidthForProfile(current, nextProfile) === undefined
@@ -237,6 +234,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       setPhase("open");
       dispatchStack({
         type: "replace",
+        activationID: nextID("activation"),
         entryID: nextID("entry"),
         destination,
       });
@@ -296,9 +294,9 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       void runViewTransition({
         scope: "sidebar-push",
         update: () => {
-          setActiveActivationID(activationID);
           dispatchStack({
             type: "push",
+            activationID,
             lifecycleID: state.lifecycleID,
             entryID: nextID("entry"),
             sourceEntryID: activeEntry.entryID,
@@ -328,9 +326,9 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     void runViewTransition({
       scope: "sidebar-back",
       update: () => {
-        setActiveActivationID(activationID);
         dispatchStack({
           type: "back",
+          activationID,
           lifecycleID: state.lifecycleID,
           entryID: activeEntry.entryID,
         });
@@ -344,7 +342,6 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       const pending = pendingRef.current;
       pendingRef.current = null;
       preserveRouteChangeRef.current = null;
-      setActiveActivationID(null);
       clearAllCaptures();
       pending?.resolve(result);
       if (state !== null) {
@@ -396,11 +393,11 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
         closeSidebar("closed");
         return;
       }
-      if (state.entries.at(-1)?.entryID === token.entryID) {
-        setActiveActivationID(nextID("activation"));
-      }
       dispatchStack({
         type: "remove",
+        ...(state.entries.at(-1)?.entryID === token.entryID
+          ? { activationID: nextID("activation") }
+          : {}),
         lifecycleID: token.lifecycleID,
         entryID: token.entryID,
       });
@@ -447,6 +444,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
   }, [clearAllCaptures, clearCloseTimeout]);
 
   const activeDestination = stackState?.entries.at(-1)?.destination ?? null;
+  const activeActivationID = phase === "closing" ? null : (stackState?.activationID ?? null);
   const activeSnapshot = stackState?.entries.at(-1)?.snapshot ?? null;
   const activeToken = activeTokenForState(stackState);
   const stackDestinations = useMemo(

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/app-facade";
 import { initialSidebarWidthForViewport, type ResolvedSidebarWidth } from "@/app-facade";
 import {
+  findTaskDetailIndex,
   sidebarStackReducer,
   type SidebarStackAction,
   type SidebarStackState,
@@ -279,15 +280,13 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
       if (activeEntry === undefined) {
         return;
       }
-      const existingTask = state.entries.find(
-        (entry) =>
-          destination.kind === "taskDetail" &&
-          entry.destination.kind === "taskDetail" &&
-          entry.destination.taskID === destination.taskID,
-      );
+      const existingTaskIndex = findTaskDetailIndex(state.entries, destination);
       clearCloseTimeout();
       clearCapture({ entryID: activeEntry.entryID, lifecycleID: state.lifecycleID });
-      const nextDestination = existingTask?.destination ?? destination;
+      const nextDestination =
+        existingTaskIndex === undefined
+          ? destination
+          : (state.entries[existingTaskIndex]?.destination ?? destination);
       const activationID = nextID("activation");
       setActiveWidthProfile(sidebarWidthProfile(nextDestination));
       setPhase("open");

--- a/apps/desktop/src/app/sidebarProvider.tsx
+++ b/apps/desktop/src/app/sidebarProvider.tsx
@@ -114,7 +114,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     const activeEntry = state?.entries.at(-1);
     return activeEntry === undefined || state === null
       ? null
-      : { entryID: activeEntry.entryID, lifecycleID: state.lifecycleID };
+      : sidebarEntryToken(state.lifecycleID, activeEntry.entryID);
   }, []);
 
   const animateClosed = useCallback(
@@ -254,7 +254,7 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
     if (state === null || pending === null || activeEntry === undefined) {
       return false;
     }
-    const token = { entryID: activeEntry.entryID, lifecycleID: state.lifecycleID };
+    const token = sidebarEntryToken(state.lifecycleID, activeEntry.entryID);
     const capture = captureRef.current.get(tokenKey(token));
     if (capture === undefined) {
       return true;
@@ -469,20 +469,15 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
   }, [clearAllCaptures, clearCloseTimeout]);
 
   const activeDestination = stackState?.entries.at(-1)?.destination ?? null;
-  const activeActivationID = phase === "closing" ? null : (stackState?.activationID ?? null);
+  const activeActivationID = stackState?.activationID ?? null;
   const activeSnapshot = stackState?.entries.at(-1)?.snapshot ?? null;
-  const activeToken = useMemo(
-    () => activeTokenForState(stackState),
-    [activeTokenForState, stackState],
-  );
+  const activeToken = useMemo(() => activeTokenForState(stackState), [activeTokenForState, stackState]);
   const stackDestinations = useMemo(
     () => stackState?.entries.map((entry) => entry.destination) ?? [],
     [stackState],
   );
   const stackEntryTokens = useMemo(
-    () =>
-      stackState?.entries.map((entry) => ({ entryID: entry.entryID, lifecycleID: stackState.lifecycleID })) ??
-      [],
+    () => stackState?.entries.map((entry) => sidebarEntryToken(stackState.lifecycleID, entry.entryID)) ?? [],
     [stackState],
   );
   const sidebarWidthPx =
@@ -555,6 +550,10 @@ export function SidebarProvider({ children }: Readonly<{ children: ReactNode }>)
 
 function tokenKey(token: SidebarEntryToken): string {
   return `${token.lifecycleID}:${token.entryID}`;
+}
+
+function sidebarEntryToken(lifecycleID: string, entryID: string): SidebarEntryToken {
+  return { entryID, lifecycleID };
 }
 
 function defaultSidebarWidth(destination: SidebarDestination | null = null): number {

--- a/apps/desktop/src/app/sidebarStack.test.ts
+++ b/apps/desktop/src/app/sidebarStack.test.ts
@@ -110,25 +110,23 @@ describe("sidebarStackReducer", () => {
       entryID: "entry-1",
       destination: task("task-1"),
     });
+    const focusedTask: SidebarDestination = {
+      kind: "taskDetail",
+      taskID: "task-1",
+      initialFocus: { kind: "dependencies" },
+    };
 
     const replaced = apply(opened, {
       type: "replace",
       activationID: "activation-2",
       entryID: "entry-2",
-      destination: {
-        ...task("task-1"),
-        initialFocus: { kind: "dependencies" },
-      },
+      destination: focusedTask,
     });
 
     expect(replaced?.entries).toEqual([
       {
         entryID: "entry-2",
-        destination: {
-          kind: "taskDetail",
-          taskID: "task-1",
-          initialFocus: { kind: "dependencies" },
-        },
+        destination: focusedTask,
       },
     ]);
     expect(replaced?.activationID).toBe("activation-2");

--- a/apps/desktop/src/app/sidebarStack.test.ts
+++ b/apps/desktop/src/app/sidebarStack.test.ts
@@ -35,6 +35,7 @@ describe("sidebarStackReducer", () => {
       null,
       {
         type: "open",
+        activationID: "activation-1",
         lifecycleID: "lifecycle-1",
         entryID: "entry-1",
         destination: task("task-1"),
@@ -42,6 +43,7 @@ describe("sidebarStackReducer", () => {
     );
 
     expect(state).toEqual({
+      activationID: "activation-1",
       lifecycleID: "lifecycle-1",
       entries: [
         {
@@ -103,12 +105,14 @@ describe("sidebarStackReducer", () => {
     });
     const replaced = apply(pushed, {
       type: "replace",
+      activationID: "activation-3",
       entryID: "entry-3",
       destination: task("task-3"),
     });
     expect(
       apply(replaced, {
         type: "back",
+        activationID: "activation-stale-back",
         lifecycleID: "lifecycle-1",
         entryID: "entry-2",
       }),
@@ -116,12 +120,14 @@ describe("sidebarStackReducer", () => {
     expect(
       apply(replaced, {
         type: "push",
+        activationID: "activation-stale-push",
         lifecycleID: "lifecycle-1",
         sourceEntryID: "entry-2",
         entryID: "entry-4",
         destination: task("task-4"),
       }),
     ).toBe(replaced);
+    expect(replaced?.activationID).toBe("activation-3");
   });
 
   it("pushes a destination and Back removes the current entry", () => {
@@ -131,6 +137,7 @@ describe("sidebarStackReducer", () => {
     });
     const pushed = apply(opened, {
       type: "push",
+      activationID: "activation-2",
       entryID: "entry-2",
       destination: task("task-2"),
     });
@@ -140,10 +147,12 @@ describe("sidebarStackReducer", () => {
 
     const backed = apply(pushed, {
       type: "back",
+      activationID: "activation-3",
       lifecycleID: "lifecycle-1",
       entryID: "entry-2",
     });
     expect(entryIDs(backed?.entries ?? [])).toEqual(["entry-1"]);
+    expect(backed?.activationID).toBe("activation-3");
   });
 
   it("truncates to an earlier Task Detail instead of creating a duplicate", () => {

--- a/apps/desktop/src/app/sidebarStack.test.ts
+++ b/apps/desktop/src/app/sidebarStack.test.ts
@@ -105,6 +105,35 @@ describe("sidebarStackReducer", () => {
     expect(replaced?.activationID).toBe("activation-3");
   });
 
+  it("replaces the current matching Task Detail to preserve the requested focus", () => {
+    const opened = createSidebarStack("lifecycle-1", {
+      entryID: "entry-1",
+      destination: task("task-1"),
+    });
+
+    const replaced = apply(opened, {
+      type: "replace",
+      activationID: "activation-2",
+      entryID: "entry-2",
+      destination: {
+        ...task("task-1"),
+        initialFocus: { kind: "dependencies" },
+      },
+    });
+
+    expect(replaced?.entries).toEqual([
+      {
+        entryID: "entry-2",
+        destination: {
+          kind: "taskDetail",
+          taskID: "task-1",
+          initialFocus: { kind: "dependencies" },
+        },
+      },
+    ]);
+    expect(replaced?.activationID).toBe("activation-2");
+  });
+
   it("ignores stale directional actions after the current token changes", () => {
     const state = createSidebarStack("lifecycle-1", {
       entryID: "entry-1",

--- a/apps/desktop/src/app/sidebarStack.test.ts
+++ b/apps/desktop/src/app/sidebarStack.test.ts
@@ -56,6 +56,7 @@ describe("sidebarStackReducer", () => {
 
     const replaced = apply(opened, {
       type: "replace",
+      activationID: "activation-2",
       entryID: "entry-2",
       destination: task("task-2"),
     });
@@ -71,6 +72,7 @@ describe("sidebarStackReducer", () => {
     });
     const pushed = apply(opened, {
       type: "push",
+      activationID: "activation-2",
       lifecycleID: "lifecycle-1",
       sourceEntryID: "entry-1",
       entryID: "entry-2",
@@ -78,6 +80,7 @@ describe("sidebarStackReducer", () => {
     });
     const replaced = apply(pushed, {
       type: "replace",
+      activationID: "activation-3",
       entryID: "entry-3",
       destination: task("task-3"),
     });
@@ -99,6 +102,7 @@ describe("sidebarStackReducer", () => {
     });
     const pushed = apply(opened, {
       type: "push",
+      activationID: "activation-2",
       lifecycleID: "lifecycle-1",
       sourceEntryID: "entry-1",
       entryID: "entry-2",
@@ -160,6 +164,7 @@ describe("sidebarStackReducer", () => {
     });
     const pushed = apply(state, {
       type: "push",
+      activationID: "activation-2",
       lifecycleID: "lifecycle-1",
       sourceEntryID: "entry-1",
       entryID: "entry-2",
@@ -226,6 +231,7 @@ describe("sidebarStackReducer", () => {
     });
     state = apply(state, {
       type: "push",
+      activationID: "activation-2",
       lifecycleID: "lifecycle-1",
       sourceEntryID: "entry-1",
       entryID: "entry-2",
@@ -233,6 +239,7 @@ describe("sidebarStackReducer", () => {
     });
     state = apply(state, {
       type: "push",
+      activationID: "activation-3",
       lifecycleID: "lifecycle-1",
       sourceEntryID: "entry-2",
       entryID: "entry-3",
@@ -241,6 +248,7 @@ describe("sidebarStackReducer", () => {
 
     const returned = apply(state, {
       type: "push",
+      activationID: "activation-4",
       lifecycleID: "lifecycle-1",
       sourceEntryID: "entry-3",
       entryID: "entry-4",
@@ -260,6 +268,7 @@ describe("sidebarStackReducer", () => {
     for (let index = 1; index < 50; index += 1) {
       state = apply(state, {
         type: "push",
+        activationID: `activation-${index.toString()}`,
         lifecycleID: "lifecycle-1",
         sourceEntryID: `entry-${(index - 1).toString()}`,
         entryID: `entry-${index.toString()}`,
@@ -273,6 +282,7 @@ describe("sidebarStackReducer", () => {
 
     const bounded = apply(state, {
       type: "push",
+      activationID: "activation-50",
       lifecycleID: "lifecycle-1",
       sourceEntryID: "entry-49",
       entryID: "entry-50",
@@ -292,6 +302,7 @@ describe("sidebarStackReducer", () => {
     });
     state = apply(state, {
       type: "push",
+      activationID: "activation-2",
       lifecycleID: "lifecycle-1",
       sourceEntryID: "entry-1",
       entryID: "entry-2",
@@ -340,6 +351,7 @@ describe("sidebarStackReducer", () => {
     expect(
       apply(state, {
         type: "push",
+        activationID: "activation-stale-lifecycle",
         sourceEntryID: "entry-1",
         entryID: "entry-2",
         destination: task("task-2"),

--- a/apps/desktop/src/app/sidebarStack.test.ts
+++ b/apps/desktop/src/app/sidebarStack.test.ts
@@ -71,6 +71,8 @@ describe("sidebarStackReducer", () => {
     });
     const pushed = apply(opened, {
       type: "push",
+      lifecycleID: "lifecycle-1",
+      sourceEntryID: "entry-1",
       entryID: "entry-2",
       destination: newTask,
     });
@@ -97,6 +99,8 @@ describe("sidebarStackReducer", () => {
     });
     const pushed = apply(opened, {
       type: "push",
+      lifecycleID: "lifecycle-1",
+      sourceEntryID: "entry-1",
       entryID: "entry-2",
       destination: task("task-2"),
     });
@@ -196,6 +200,8 @@ describe("sidebarStackReducer", () => {
     const pushed = apply(opened, {
       type: "push",
       activationID: "activation-2",
+      lifecycleID: "lifecycle-1",
+      sourceEntryID: "entry-1",
       entryID: "entry-2",
       destination: task("task-2"),
     });
@@ -220,17 +226,23 @@ describe("sidebarStackReducer", () => {
     });
     state = apply(state, {
       type: "push",
+      lifecycleID: "lifecycle-1",
+      sourceEntryID: "entry-1",
       entryID: "entry-2",
       destination: task("task-2"),
     });
     state = apply(state, {
       type: "push",
+      lifecycleID: "lifecycle-1",
+      sourceEntryID: "entry-2",
       entryID: "entry-3",
       destination: task("task-3"),
     });
 
     const returned = apply(state, {
       type: "push",
+      lifecycleID: "lifecycle-1",
+      sourceEntryID: "entry-3",
       entryID: "entry-4",
       destination: task("task-1"),
     });
@@ -248,6 +260,8 @@ describe("sidebarStackReducer", () => {
     for (let index = 1; index < 50; index += 1) {
       state = apply(state, {
         type: "push",
+        lifecycleID: "lifecycle-1",
+        sourceEntryID: `entry-${(index - 1).toString()}`,
         entryID: `entry-${index.toString()}`,
         destination: task(`task-${index.toString()}`),
       });
@@ -259,6 +273,8 @@ describe("sidebarStackReducer", () => {
 
     const bounded = apply(state, {
       type: "push",
+      lifecycleID: "lifecycle-1",
+      sourceEntryID: "entry-49",
       entryID: "entry-50",
       destination: task("task-50"),
     });
@@ -276,6 +292,8 @@ describe("sidebarStackReducer", () => {
     });
     state = apply(state, {
       type: "push",
+      lifecycleID: "lifecycle-1",
+      sourceEntryID: "entry-1",
       entryID: "entry-2",
       destination: newTask,
     });
@@ -322,6 +340,7 @@ describe("sidebarStackReducer", () => {
     expect(
       apply(state, {
         type: "push",
+        sourceEntryID: "entry-1",
         entryID: "entry-2",
         destination: task("task-2"),
         lifecycleID: "lifecycle-2",

--- a/apps/desktop/src/app/sidebarStack.test.ts
+++ b/apps/desktop/src/app/sidebarStack.test.ts
@@ -18,10 +18,7 @@ const newTask: SidebarDestination = {
   boardQueryWorkflowID: undefined,
 };
 
-function apply(
-  state: ReturnType<typeof createSidebarStack> | null,
-  action: SidebarStackAction,
-) {
+function apply(state: ReturnType<typeof createSidebarStack> | null, action: SidebarStackAction) {
   return sidebarStackReducer(state, action);
 }
 
@@ -31,16 +28,13 @@ function entryIDs(entries: readonly SidebarStackEntry[]) {
 
 describe("sidebarStackReducer", () => {
   it("creates a root entry with the supplied lifecycle and entry IDs", () => {
-    const state = apply(
-      null,
-      {
-        type: "open",
-        activationID: "activation-1",
-        lifecycleID: "lifecycle-1",
-        entryID: "entry-1",
-        destination: task("task-1"),
-      },
-    );
+    const state = apply(null, {
+      type: "open",
+      activationID: "activation-1",
+      lifecycleID: "lifecycle-1",
+      entryID: "entry-1",
+      destination: task("task-1"),
+    });
 
     expect(state).toEqual({
       activationID: "activation-1",
@@ -67,9 +61,7 @@ describe("sidebarStackReducer", () => {
     });
 
     expect(replaced?.lifecycleID).toBe("lifecycle-1");
-    expect(replaced?.entries).toEqual([
-      { entryID: "entry-2", destination: task("task-2") },
-    ]);
+    expect(replaced?.entries).toEqual([{ entryID: "entry-2", destination: task("task-2") }]);
   });
 
   it("preserves preceding entries when replacing the current destination", () => {
@@ -89,6 +81,28 @@ describe("sidebarStackReducer", () => {
     });
 
     expect(entryIDs(replaced?.entries ?? [])).toEqual(["entry-1", "entry-3"]);
+  });
+
+  it("returns to a retained Task Detail when replacement targets an earlier entry", () => {
+    const opened = createSidebarStack("lifecycle-1", {
+      entryID: "entry-1",
+      destination: task("task-1"),
+    });
+    const pushed = apply(opened, {
+      type: "push",
+      entryID: "entry-2",
+      destination: task("task-2"),
+    });
+    const replaced = apply(pushed, {
+      type: "replace",
+      activationID: "activation-3",
+      entryID: "entry-3",
+      destination: task("task-1"),
+    });
+
+    expect(entryIDs(replaced?.entries ?? [])).toEqual(["entry-1"]);
+    expect(replaced?.entries[0]?.entryID).toBe("entry-1");
+    expect(replaced?.activationID).toBe("activation-3");
   });
 
   it("ignores stale directional actions after the current token changes", () => {

--- a/apps/desktop/src/app/sidebarStack.test.ts
+++ b/apps/desktop/src/app/sidebarStack.test.ts
@@ -1,9 +1,9 @@
 import type { SidebarDestination } from "@/app-facade";
 import {
-  createSidebarStack,
   sidebarStackReducer,
   type SidebarStackAction,
   type SidebarStackEntry,
+  type SidebarStackState,
 } from "./sidebarStack";
 
 const task = (taskID: string): SidebarDestination => ({
@@ -20,6 +20,25 @@ const newTask: SidebarDestination = {
 
 function apply(state: ReturnType<typeof createSidebarStack> | null, action: SidebarStackAction) {
   return sidebarStackReducer(state, action);
+}
+
+function createSidebarStack(
+  lifecycleID: string,
+  root: SidebarStackEntry,
+  activationID = lifecycleID,
+): SidebarStackState {
+  const state = sidebarStackReducer(null, {
+    type: "open",
+    activationID,
+    lifecycleID,
+    entryID: root.entryID,
+    destination: root.destination,
+    ...(root.snapshot === undefined ? {} : { snapshot: root.snapshot }),
+  });
+  if (state === null) {
+    throw new Error("Sidebar stack did not open.");
+  }
+  return state;
 }
 
 function entryIDs(entries: readonly SidebarStackEntry[]) {

--- a/apps/desktop/src/app/sidebarStack.test.ts
+++ b/apps/desktop/src/app/sidebarStack.test.ts
@@ -1,0 +1,266 @@
+import type { SidebarDestination } from "@/app-facade";
+import {
+  createSidebarStack,
+  sidebarStackReducer,
+  type SidebarStackAction,
+  type SidebarStackEntry,
+} from "./sidebarStack";
+
+const task = (taskID: string): SidebarDestination => ({
+  kind: "taskDetail",
+  taskID,
+});
+
+const newTask: SidebarDestination = {
+  kind: "newTask",
+  projectID: "project-1",
+  workflowID: "workflow-1",
+  boardQueryWorkflowID: undefined,
+};
+
+function apply(
+  state: ReturnType<typeof createSidebarStack> | null,
+  action: SidebarStackAction,
+) {
+  return sidebarStackReducer(state, action);
+}
+
+function entryIDs(entries: readonly SidebarStackEntry[]) {
+  return entries.map((entry) => entry.entryID);
+}
+
+describe("sidebarStackReducer", () => {
+  it("creates a root entry with the supplied lifecycle and entry IDs", () => {
+    const state = apply(
+      null,
+      {
+        type: "open",
+        lifecycleID: "lifecycle-1",
+        entryID: "entry-1",
+        destination: task("task-1"),
+      },
+    );
+
+    expect(state).toEqual({
+      lifecycleID: "lifecycle-1",
+      entries: [
+        {
+          entryID: "entry-1",
+          destination: task("task-1"),
+        },
+      ],
+    });
+  });
+
+  it("replaces only the current entry with a new entry ID", () => {
+    const opened = createSidebarStack("lifecycle-1", {
+      entryID: "entry-1",
+      destination: task("task-1"),
+    });
+
+    const replaced = apply(opened, {
+      type: "replace",
+      entryID: "entry-2",
+      destination: task("task-2"),
+    });
+
+    expect(replaced?.lifecycleID).toBe("lifecycle-1");
+    expect(replaced?.entries).toEqual([
+      { entryID: "entry-2", destination: task("task-2") },
+    ]);
+  });
+
+  it("preserves preceding entries when replacing the current destination", () => {
+    const opened = createSidebarStack("lifecycle-1", {
+      entryID: "entry-1",
+      destination: task("task-1"),
+    });
+    const pushed = apply(opened, {
+      type: "push",
+      entryID: "entry-2",
+      destination: newTask,
+    });
+    const replaced = apply(pushed, {
+      type: "replace",
+      entryID: "entry-3",
+      destination: task("task-3"),
+    });
+
+    expect(entryIDs(replaced?.entries ?? [])).toEqual(["entry-1", "entry-3"]);
+  });
+
+  it("ignores stale directional actions after the current token changes", () => {
+    const state = createSidebarStack("lifecycle-1", {
+      entryID: "entry-1",
+      destination: task("task-1"),
+    });
+    const pushed = apply(state, {
+      type: "push",
+      lifecycleID: "lifecycle-1",
+      sourceEntryID: "entry-1",
+      entryID: "entry-2",
+      destination: task("task-2"),
+    });
+    const replaced = apply(pushed, {
+      type: "replace",
+      entryID: "entry-3",
+      destination: task("task-3"),
+    });
+    expect(
+      apply(replaced, {
+        type: "back",
+        lifecycleID: "lifecycle-1",
+        entryID: "entry-2",
+      }),
+    ).toBe(replaced);
+    expect(
+      apply(replaced, {
+        type: "push",
+        lifecycleID: "lifecycle-1",
+        sourceEntryID: "entry-2",
+        entryID: "entry-4",
+        destination: task("task-4"),
+      }),
+    ).toBe(replaced);
+  });
+
+  it("pushes a destination and Back removes the current entry", () => {
+    const opened = createSidebarStack("lifecycle-1", {
+      entryID: "entry-1",
+      destination: task("task-1"),
+    });
+    const pushed = apply(opened, {
+      type: "push",
+      entryID: "entry-2",
+      destination: task("task-2"),
+    });
+
+    expect(entryIDs(pushed?.entries ?? [])).toEqual(["entry-1", "entry-2"]);
+    expect(pushed?.entries.at(-1)?.destination).toEqual(task("task-2"));
+
+    const backed = apply(pushed, {
+      type: "back",
+      lifecycleID: "lifecycle-1",
+      entryID: "entry-2",
+    });
+    expect(entryIDs(backed?.entries ?? [])).toEqual(["entry-1"]);
+  });
+
+  it("truncates to an earlier Task Detail instead of creating a duplicate", () => {
+    let state: ReturnType<typeof createSidebarStack> | null = createSidebarStack("lifecycle-1", {
+      entryID: "entry-1",
+      destination: task("task-1"),
+    });
+    state = apply(state, {
+      type: "push",
+      entryID: "entry-2",
+      destination: task("task-2"),
+    });
+    state = apply(state, {
+      type: "push",
+      entryID: "entry-3",
+      destination: task("task-3"),
+    });
+
+    const returned = apply(state, {
+      type: "push",
+      entryID: "entry-4",
+      destination: task("task-1"),
+    });
+
+    expect(entryIDs(returned?.entries ?? [])).toEqual(["entry-1"]);
+    expect(returned?.entries[0]?.destination).toEqual(task("task-1"));
+  });
+
+  it("preserves the root and evicts the oldest non-root entry at capacity", () => {
+    let state: ReturnType<typeof createSidebarStack> | null = createSidebarStack("lifecycle-1", {
+      entryID: "entry-0",
+      destination: task("task-0"),
+    });
+
+    for (let index = 1; index < 50; index += 1) {
+      state = apply(state, {
+        type: "push",
+        entryID: `entry-${index.toString()}`,
+        destination: task(`task-${index.toString()}`),
+      });
+    }
+    if (state === null) {
+      throw new Error("Stack unexpectedly closed.");
+    }
+    expect(state.entries).toHaveLength(50);
+
+    const bounded = apply(state, {
+      type: "push",
+      entryID: "entry-50",
+      destination: task("task-50"),
+    });
+
+    expect(bounded?.entries).toHaveLength(50);
+    expect(bounded?.entries[0]).toEqual(state.entries[0]);
+    expect(bounded?.entries[1]?.destination).toEqual(task("task-2"));
+    expect(bounded?.entries.at(-1)?.destination).toEqual(task("task-50"));
+  });
+
+  it("removes exactly the matching entry and skips stale or unknown tokens", () => {
+    let state: ReturnType<typeof createSidebarStack> | null = createSidebarStack("lifecycle-1", {
+      entryID: "entry-1",
+      destination: task("task-1"),
+    });
+    state = apply(state, {
+      type: "push",
+      entryID: "entry-2",
+      destination: newTask,
+    });
+    if (state === null) {
+      throw new Error("Stack unexpectedly closed.");
+    }
+
+    expect(
+      apply(state, {
+        type: "remove",
+        lifecycleID: "lifecycle-2",
+        entryID: "entry-2",
+      }),
+    ).toBe(state);
+    expect(
+      apply(state, {
+        type: "remove",
+        lifecycleID: "lifecycle-1",
+        entryID: "entry-stale",
+      }),
+    ).toBe(state);
+
+    const removed = apply(state, {
+      type: "remove",
+      lifecycleID: "lifecycle-1",
+      entryID: "entry-2",
+    });
+    expect(entryIDs(removed?.entries ?? [])).toEqual(["entry-1"]);
+
+    const final = apply(removed, {
+      type: "remove",
+      lifecycleID: "lifecycle-1",
+      entryID: "entry-1",
+    });
+    expect(final).toBeNull();
+  });
+
+  it("ignores actions for a different lifecycle and closes the complete stack", () => {
+    const state = createSidebarStack("lifecycle-1", {
+      entryID: "entry-1",
+      destination: task("task-1"),
+    });
+
+    expect(
+      apply(state, {
+        type: "push",
+        entryID: "entry-2",
+        destination: task("task-2"),
+        lifecycleID: "lifecycle-2",
+      }),
+    ).toBe(state);
+    expect(apply(state, { type: "close", lifecycleID: "lifecycle-2" })).toBe(state);
+    expect(apply(state, { type: "close", lifecycleID: "lifecycle-1" })).toBeNull();
+  });
+});

--- a/apps/desktop/src/app/sidebarStack.test.ts
+++ b/apps/desktop/src/app/sidebarStack.test.ts
@@ -83,10 +83,17 @@ describe("sidebarStackReducer", () => {
     expect(entryIDs(replaced?.entries ?? [])).toEqual(["entry-1", "entry-3"]);
   });
 
-  it("returns to a retained Task Detail when replacement targets an earlier entry", () => {
+  it("applies requested focus while retaining an earlier Task Detail snapshot", () => {
+    const snapshot = {
+      kind: "taskDetail",
+      scrollTop: 240,
+      descriptionExpanded: true,
+      selectedTab: "comments",
+    } as const;
     const opened = createSidebarStack("lifecycle-1", {
       entryID: "entry-1",
       destination: task("task-1"),
+      snapshot,
     });
     const pushed = apply(opened, {
       type: "push",
@@ -97,11 +104,21 @@ describe("sidebarStackReducer", () => {
       type: "replace",
       activationID: "activation-3",
       entryID: "entry-3",
-      destination: task("task-1"),
+      destination: {
+        kind: "taskDetail",
+        taskID: "task-1",
+        initialFocus: { kind: "dependencies" },
+      },
     });
 
     expect(entryIDs(replaced?.entries ?? [])).toEqual(["entry-1"]);
     expect(replaced?.entries[0]?.entryID).toBe("entry-1");
+    expect(replaced?.entries[0]?.destination).toEqual({
+      kind: "taskDetail",
+      taskID: "task-1",
+      initialFocus: { kind: "dependencies" },
+    });
+    expect(replaced?.entries[0]?.snapshot).toEqual(snapshot);
     expect(replaced?.activationID).toBe("activation-3");
   });
 

--- a/apps/desktop/src/app/sidebarStack.ts
+++ b/apps/desktop/src/app/sidebarStack.ts
@@ -110,7 +110,7 @@ function reduceReplace(
     return state;
   }
   const existingTaskIndex = findTaskDetailIndex(state.entries, action.destination);
-  if (existingTaskIndex !== undefined) {
+  if (existingTaskIndex !== undefined && existingTaskIndex < state.entries.length - 1) {
     return {
       ...state,
       activationID: action.activationID ?? state.activationID,

--- a/apps/desktop/src/app/sidebarStack.ts
+++ b/apps/desktop/src/app/sidebarStack.ts
@@ -9,6 +9,7 @@ export type SidebarStackEntry = Readonly<{
 }>;
 
 export type SidebarStackState = Readonly<{
+  activationID: string;
   lifecycleID: string;
   entries: readonly SidebarStackEntry[];
 }>;
@@ -16,6 +17,7 @@ export type SidebarStackState = Readonly<{
 export type SidebarStackAction =
   | Readonly<{
       type: "open";
+      activationID?: string;
       lifecycleID: string;
       entryID: string;
       destination: SidebarDestination;
@@ -23,19 +25,22 @@ export type SidebarStackAction =
     }>
   | Readonly<{
       type: "replace";
+      activationID?: string;
       entryID: string;
       destination: SidebarDestination;
     }>
   | Readonly<{
       type: "push";
+      activationID?: string;
       entryID: string;
       lifecycleID?: string;
       sourceEntryID?: string;
       destination: SidebarDestination;
     }>
-  | Readonly<{ type: "back"; lifecycleID: string; entryID: string }>
+  | Readonly<{ type: "back"; activationID?: string; lifecycleID: string; entryID: string }>
   | Readonly<{
       type: "remove";
+      activationID?: string;
       lifecycleID: string;
       entryID: string;
     }>
@@ -50,8 +55,10 @@ export type SidebarStackAction =
 export function createSidebarStack(
   lifecycleID: string,
   root: SidebarStackEntry,
+  activationID = lifecycleID,
 ): SidebarStackState {
   return {
+    activationID,
     lifecycleID,
     entries: [root],
   };
@@ -78,7 +85,7 @@ function reduceOpen(action: Extract<SidebarStackAction, { type: "open" }>): Side
     entryID: action.entryID,
     destination: action.destination,
     ...(action.snapshot === undefined ? {} : { snapshot: action.snapshot }),
-  });
+  }, action.activationID);
 }
 
 function reduceReplace(
@@ -89,6 +96,7 @@ function reduceReplace(
     ? state
     : {
         ...state,
+        activationID: action.activationID ?? state.activationID,
         entries: [
           ...state.entries.slice(0, -1),
           { entryID: action.entryID, destination: action.destination },
@@ -107,12 +115,19 @@ function reducePush(
   )
     return state;
   const existingTaskIndex = findTaskDetailIndex(state.entries, action.destination);
-  if (existingTaskIndex !== undefined) return { ...state, entries: state.entries.slice(0, existingTaskIndex + 1) };
+  if (existingTaskIndex !== undefined) {
+    return {
+      ...state,
+      activationID: action.activationID ?? state.activationID,
+      entries: state.entries.slice(0, existingTaskIndex + 1),
+    };
+  }
   const root = state.entries[0];
   if (root === undefined) return state;
   const entries = state.entries.length >= sidebarStackCapacity ? [root, ...state.entries.slice(2)] : state.entries;
   return {
     ...state,
+    activationID: action.activationID ?? state.activationID,
     entries: [
       ...entries.map((entry, index) => (index === entries.length - 1 ? deactivateEntry(entry) : entry)),
       { entryID: action.entryID, destination: action.destination },
@@ -128,7 +143,11 @@ function reduceBack(
     state.entries.length <= 1 ||
     state.entries.at(-1)?.entryID !== action.entryID
     ? state
-    : { ...state, entries: state.entries.slice(0, -1) };
+    : {
+        ...state,
+        activationID: action.activationID ?? state.activationID,
+        entries: state.entries.slice(0, -1),
+      };
 }
 
 function reduceRemove(
@@ -137,7 +156,16 @@ function reduceRemove(
 ): SidebarStackState | null {
   if (state?.lifecycleID !== action.lifecycleID) return state;
   const index = state.entries.findIndex((entry) => entry.entryID === action.entryID);
-  return index < 0 ? state : state.entries.length === 1 ? null : { ...state, entries: state.entries.filter((_, i) => i !== index) };
+  return index < 0
+    ? state
+    : state.entries.length === 1
+      ? null
+      : {
+          ...state,
+          activationID:
+            index === state.entries.length - 1 ? action.activationID ?? state.activationID : state.activationID,
+          entries: state.entries.filter((_, i) => i !== index),
+        };
 }
 
 function reduceCapture(

--- a/apps/desktop/src/app/sidebarStack.ts
+++ b/apps/desktop/src/app/sidebarStack.ts
@@ -1,4 +1,8 @@
-import type { SidebarDestination, SidebarDestinationSnapshot } from "@/app-facade";
+import {
+  sidebarDestinationMatchesTask,
+  type SidebarDestination,
+  type SidebarDestinationSnapshot,
+} from "@/app-facade";
 
 export const sidebarStackCapacity = 50;
 
@@ -196,7 +200,7 @@ export function findTaskDetailIndex(
     return undefined;
   }
   const index = entries.findIndex(
-    (entry) => entry.destination.kind === "taskDetail" && entry.destination.taskID === destination.taskID,
+    (entry) => sidebarDestinationMatchesTask(entry.destination, destination.taskID),
   );
   return index === -1 ? undefined : index;
 }

--- a/apps/desktop/src/app/sidebarStack.ts
+++ b/apps/desktop/src/app/sidebarStack.ts
@@ -29,19 +29,19 @@ export type SidebarStackAction =
     }>
   | Readonly<{
       type: "replace";
-      activationID?: string;
+      activationID: string;
       entryID: string;
       destination: SidebarDestination;
     }>
   | Readonly<{
       type: "push";
-      activationID?: string;
+      activationID: string;
       entryID: string;
       lifecycleID: string;
       sourceEntryID: string;
       destination: SidebarDestination;
     }>
-  | Readonly<{ type: "back"; activationID?: string; lifecycleID: string; entryID: string }>
+  | Readonly<{ type: "back"; activationID: string; lifecycleID: string; entryID: string }>
   | Readonly<{
       type: "remove";
       activationID?: string;
@@ -118,7 +118,7 @@ function reduceReplace(
     const isCurrentEntry = existingTaskIndex === state.entries.length - 1;
     return {
       ...state,
-      activationID: action.activationID ?? state.activationID,
+      activationID: action.activationID,
       entries: [
         ...state.entries.slice(0, isCurrentEntry ? -1 : existingTaskIndex),
         {
@@ -131,7 +131,7 @@ function reduceReplace(
   }
   return {
     ...state,
-    activationID: action.activationID ?? state.activationID,
+    activationID: action.activationID,
     entries: [...state.entries.slice(0, -1), { entryID: action.entryID, destination: action.destination }],
   };
 }
@@ -148,7 +148,7 @@ function reducePush(
   if (existingTaskIndex !== undefined) {
     return {
       ...state,
-      activationID: action.activationID ?? state.activationID,
+      activationID: action.activationID,
       entries: state.entries.slice(0, existingTaskIndex + 1),
     };
   }
@@ -158,7 +158,7 @@ function reducePush(
     state.entries.length >= sidebarStackCapacity ? [root, ...state.entries.slice(2)] : state.entries;
   return {
     ...state,
-    activationID: action.activationID ?? state.activationID,
+    activationID: action.activationID,
     entries: [
       ...entries.map((entry, index) => (index === entries.length - 1 ? deactivateEntry(entry) : entry)),
       { entryID: action.entryID, destination: action.destination },
@@ -176,7 +176,7 @@ function reduceBack(
     ? state
     : {
         ...state,
-        activationID: action.activationID ?? state.activationID,
+        activationID: action.activationID,
         entries: state.entries.slice(0, -1),
       };
 }

--- a/apps/desktop/src/app/sidebarStack.ts
+++ b/apps/desktop/src/app/sidebarStack.ts
@@ -1,5 +1,5 @@
 import {
-  sidebarDestinationMatchesTask,
+  sidebarDestinationIndexForTask,
   type SidebarDestination,
   type SidebarDestinationSnapshot,
 } from "@/app-facade";
@@ -242,10 +242,8 @@ export function findTaskDetailIndex(
   if (destination.kind !== "taskDetail") {
     return undefined;
   }
-  for (const [index, entry] of entries.entries()) {
-    if (sidebarDestinationMatchesTask(entry.destination, destination.taskID)) {
-      return index;
-    }
-  }
-  return undefined;
+  return sidebarDestinationIndexForTask(
+    entries.map((entry) => entry.destination),
+    destination.taskID,
+  );
 }

--- a/apps/desktop/src/app/sidebarStack.ts
+++ b/apps/desktop/src/app/sidebarStack.ts
@@ -111,10 +111,17 @@ function reduceReplace(
   }
   const existingTaskIndex = findTaskDetailIndex(state.entries, action.destination);
   if (existingTaskIndex !== undefined && existingTaskIndex < state.entries.length - 1) {
+    const retainedEntry = state.entries[existingTaskIndex];
+    if (retainedEntry === undefined) {
+      return state;
+    }
     return {
       ...state,
       activationID: action.activationID ?? state.activationID,
-      entries: state.entries.slice(0, existingTaskIndex + 1),
+      entries: [
+        ...state.entries.slice(0, existingTaskIndex),
+        { ...retainedEntry, destination: action.destination },
+      ],
     };
   }
   return {

--- a/apps/desktop/src/app/sidebarStack.ts
+++ b/apps/desktop/src/app/sidebarStack.ts
@@ -56,7 +56,7 @@ export type SidebarStackAction =
     }>
   | Readonly<{ type: "close"; lifecycleID: string }>;
 
-export function createSidebarStack(
+function createSidebarStack(
   lifecycleID: string,
   root: SidebarStackEntry,
   activationID = lifecycleID,

--- a/apps/desktop/src/app/sidebarStack.ts
+++ b/apps/desktop/src/app/sidebarStack.ts
@@ -1,0 +1,174 @@
+import type { SidebarDestination, SidebarDestinationSnapshot } from "@/app-facade";
+
+export const sidebarStackCapacity = 50;
+
+export type SidebarStackEntry = Readonly<{
+  entryID: string;
+  destination: SidebarDestination;
+  snapshot?: SidebarDestinationSnapshot | undefined;
+}>;
+
+export type SidebarStackState = Readonly<{
+  lifecycleID: string;
+  entries: readonly SidebarStackEntry[];
+}>;
+
+export type SidebarStackAction =
+  | Readonly<{
+      type: "open";
+      lifecycleID: string;
+      entryID: string;
+      destination: SidebarDestination;
+      snapshot?: SidebarDestinationSnapshot | undefined;
+    }>
+  | Readonly<{
+      type: "replace";
+      entryID: string;
+      destination: SidebarDestination;
+    }>
+  | Readonly<{
+      type: "push";
+      entryID: string;
+      lifecycleID?: string;
+      sourceEntryID?: string;
+      destination: SidebarDestination;
+    }>
+  | Readonly<{ type: "back"; lifecycleID: string; entryID: string }>
+  | Readonly<{
+      type: "remove";
+      lifecycleID: string;
+      entryID: string;
+    }>
+  | Readonly<{
+      type: "capture";
+      lifecycleID: string;
+      entryID: string;
+      snapshot: SidebarDestinationSnapshot;
+    }>
+  | Readonly<{ type: "close"; lifecycleID: string }>;
+
+export function createSidebarStack(
+  lifecycleID: string,
+  root: SidebarStackEntry,
+): SidebarStackState {
+  return {
+    lifecycleID,
+    entries: [root],
+  };
+}
+
+export function sidebarStackReducer(
+  state: SidebarStackState | null,
+  action: SidebarStackAction,
+): SidebarStackState | null {
+  switch (action.type) {
+    case "open": return reduceOpen(action);
+    case "replace": return reduceReplace(state, action);
+    case "push": return reducePush(state, action);
+    case "back": return reduceBack(state, action);
+    case "remove": return reduceRemove(state, action);
+    case "capture": return reduceCapture(state, action);
+    case "close":
+      return state?.lifecycleID === action.lifecycleID ? null : state;
+  }
+}
+
+function reduceOpen(action: Extract<SidebarStackAction, { type: "open" }>): SidebarStackState {
+  return createSidebarStack(action.lifecycleID, {
+    entryID: action.entryID,
+    destination: action.destination,
+    ...(action.snapshot === undefined ? {} : { snapshot: action.snapshot }),
+  });
+}
+
+function reduceReplace(
+  state: SidebarStackState | null,
+  action: Extract<SidebarStackAction, { type: "replace" }>,
+): SidebarStackState | null {
+  return state === null || state.entries.length === 0
+    ? state
+    : {
+        ...state,
+        entries: [
+          ...state.entries.slice(0, -1),
+          { entryID: action.entryID, destination: action.destination },
+        ],
+      };
+}
+
+function reducePush(
+  state: SidebarStackState | null,
+  action: Extract<SidebarStackAction, { type: "push" }>,
+): SidebarStackState | null {
+  if (
+    state === null ||
+    (action.lifecycleID !== undefined && action.lifecycleID !== state.lifecycleID) ||
+    (action.sourceEntryID !== undefined && state.entries.at(-1)?.entryID !== action.sourceEntryID)
+  )
+    return state;
+  const existingTaskIndex = findTaskDetailIndex(state.entries, action.destination);
+  if (existingTaskIndex !== undefined) return { ...state, entries: state.entries.slice(0, existingTaskIndex + 1) };
+  const root = state.entries[0];
+  if (root === undefined) return state;
+  const entries = state.entries.length >= sidebarStackCapacity ? [root, ...state.entries.slice(2)] : state.entries;
+  return {
+    ...state,
+    entries: [
+      ...entries.map((entry, index) => (index === entries.length - 1 ? deactivateEntry(entry) : entry)),
+      { entryID: action.entryID, destination: action.destination },
+    ],
+  };
+}
+
+function reduceBack(
+  state: SidebarStackState | null,
+  action: Extract<SidebarStackAction, { type: "back" }>,
+): SidebarStackState | null {
+  return state?.lifecycleID !== action.lifecycleID ||
+    state.entries.length <= 1 ||
+    state.entries.at(-1)?.entryID !== action.entryID
+    ? state
+    : { ...state, entries: state.entries.slice(0, -1) };
+}
+
+function reduceRemove(
+  state: SidebarStackState | null,
+  action: Extract<SidebarStackAction, { type: "remove" }>,
+): SidebarStackState | null {
+  if (state?.lifecycleID !== action.lifecycleID) return state;
+  const index = state.entries.findIndex((entry) => entry.entryID === action.entryID);
+  return index < 0 ? state : state.entries.length === 1 ? null : { ...state, entries: state.entries.filter((_, i) => i !== index) };
+}
+
+function reduceCapture(
+  state: SidebarStackState | null,
+  action: Extract<SidebarStackAction, { type: "capture" }>,
+): SidebarStackState | null {
+  if (state?.lifecycleID !== action.lifecycleID) return state;
+  const index = state.entries.findIndex((entry) => entry.entryID === action.entryID);
+  return index < 0
+    ? state
+    : { ...state, entries: state.entries.map((entry, i) => (i === index ? { ...entry, snapshot: action.snapshot } : entry)) };
+}
+
+function deactivateEntry(entry: SidebarStackEntry): SidebarStackEntry {
+  if (entry.destination.kind !== "taskDetail") {
+    return entry;
+  }
+  const { initialFocus, ...destination } = entry.destination;
+  if (initialFocus === undefined) return entry;
+  return { ...entry, destination };
+}
+
+function findTaskDetailIndex(
+  entries: readonly SidebarStackEntry[],
+  destination: SidebarDestination,
+): number | undefined {
+  if (destination.kind !== "taskDetail") {
+    return undefined;
+  }
+  const index = entries.findIndex(
+    (entry) => entry.destination.kind === "taskDetail" && entry.destination.taskID === destination.taskID,
+  );
+  return index === -1 ? undefined : index;
+}

--- a/apps/desktop/src/app/sidebarStack.ts
+++ b/apps/desktop/src/app/sidebarStack.ts
@@ -188,7 +188,7 @@ function deactivateEntry(entry: SidebarStackEntry): SidebarStackEntry {
   return { ...entry, destination };
 }
 
-function findTaskDetailIndex(
+export function findTaskDetailIndex(
   entries: readonly SidebarStackEntry[],
   destination: SidebarDestination,
 ): number | undefined {

--- a/apps/desktop/src/app/sidebarStack.ts
+++ b/apps/desktop/src/app/sidebarStack.ts
@@ -110,17 +110,22 @@ function reduceReplace(
     return state;
   }
   const existingTaskIndex = findTaskDetailIndex(state.entries, action.destination);
-  if (existingTaskIndex !== undefined && existingTaskIndex < state.entries.length - 1) {
+  if (existingTaskIndex !== undefined) {
     const retainedEntry = state.entries[existingTaskIndex];
     if (retainedEntry === undefined) {
       return state;
     }
+    const isCurrentEntry = existingTaskIndex === state.entries.length - 1;
     return {
       ...state,
       activationID: action.activationID ?? state.activationID,
       entries: [
-        ...state.entries.slice(0, existingTaskIndex),
-        { ...retainedEntry, destination: action.destination },
+        ...state.entries.slice(0, isCurrentEntry ? -1 : existingTaskIndex),
+        {
+          ...retainedEntry,
+          ...(isCurrentEntry ? { entryID: action.entryID } : {}),
+          destination: action.destination,
+        },
       ],
     };
   }

--- a/apps/desktop/src/app/sidebarStack.ts
+++ b/apps/desktop/src/app/sidebarStack.ts
@@ -73,23 +73,33 @@ export function sidebarStackReducer(
   action: SidebarStackAction,
 ): SidebarStackState | null {
   switch (action.type) {
-    case "open": return reduceOpen(action);
-    case "replace": return reduceReplace(state, action);
-    case "push": return reducePush(state, action);
-    case "back": return reduceBack(state, action);
-    case "remove": return reduceRemove(state, action);
-    case "capture": return reduceCapture(state, action);
+    case "open":
+      return reduceOpen(action);
+    case "replace":
+      return reduceReplace(state, action);
+    case "push":
+      return reducePush(state, action);
+    case "back":
+      return reduceBack(state, action);
+    case "remove":
+      return reduceRemove(state, action);
+    case "capture":
+      return reduceCapture(state, action);
     case "close":
       return state?.lifecycleID === action.lifecycleID ? null : state;
   }
 }
 
 function reduceOpen(action: Extract<SidebarStackAction, { type: "open" }>): SidebarStackState {
-  return createSidebarStack(action.lifecycleID, {
-    entryID: action.entryID,
-    destination: action.destination,
-    ...(action.snapshot === undefined ? {} : { snapshot: action.snapshot }),
-  }, action.activationID);
+  return createSidebarStack(
+    action.lifecycleID,
+    {
+      entryID: action.entryID,
+      destination: action.destination,
+      ...(action.snapshot === undefined ? {} : { snapshot: action.snapshot }),
+    },
+    action.activationID,
+  );
 }
 
 function reduceReplace(
@@ -128,7 +138,8 @@ function reducePush(
   }
   const root = state.entries[0];
   if (root === undefined) return state;
-  const entries = state.entries.length >= sidebarStackCapacity ? [root, ...state.entries.slice(2)] : state.entries;
+  const entries =
+    state.entries.length >= sidebarStackCapacity ? [root, ...state.entries.slice(2)] : state.entries;
   return {
     ...state,
     activationID: action.activationID ?? state.activationID,
@@ -159,15 +170,17 @@ function reduceRemove(
   action: Extract<SidebarStackAction, { type: "remove" }>,
 ): SidebarStackState | null {
   if (state?.lifecycleID !== action.lifecycleID) return state;
-  const index = state.entries.findIndex((entry) => entry.entryID === action.entryID);
-  return index < 0
+  const index = sidebarEntryIndex(state.entries, action.entryID);
+  return index === undefined
     ? state
     : state.entries.length === 1
       ? null
       : {
           ...state,
           activationID:
-            index === state.entries.length - 1 ? action.activationID ?? state.activationID : state.activationID,
+            index === state.entries.length - 1
+              ? (action.activationID ?? state.activationID)
+              : state.activationID,
           entries: state.entries.filter((_, i) => i !== index),
         };
 }
@@ -177,10 +190,24 @@ function reduceCapture(
   action: Extract<SidebarStackAction, { type: "capture" }>,
 ): SidebarStackState | null {
   if (state?.lifecycleID !== action.lifecycleID) return state;
-  const index = state.entries.findIndex((entry) => entry.entryID === action.entryID);
-  return index < 0
+  const index = sidebarEntryIndex(state.entries, action.entryID);
+  return index === undefined
     ? state
-    : { ...state, entries: state.entries.map((entry, i) => (i === index ? { ...entry, snapshot: action.snapshot } : entry)) };
+    : {
+        ...state,
+        entries: state.entries.map((entry, i) =>
+          i === index ? { ...entry, snapshot: action.snapshot } : entry,
+        ),
+      };
+}
+
+function sidebarEntryIndex(entries: readonly SidebarStackEntry[], entryID: string): number | undefined {
+  for (const [index, entry] of entries.entries()) {
+    if (entry.entryID === entryID) {
+      return index;
+    }
+  }
+  return undefined;
 }
 
 function deactivateEntry(entry: SidebarStackEntry): SidebarStackEntry {
@@ -199,8 +226,8 @@ export function findTaskDetailIndex(
   if (destination.kind !== "taskDetail") {
     return undefined;
   }
-  const index = entries.findIndex(
-    (entry) => sidebarDestinationMatchesTask(entry.destination, destination.taskID),
+  const index = entries.findIndex((entry) =>
+    sidebarDestinationMatchesTask(entry.destination, destination.taskID),
   );
   return index === -1 ? undefined : index;
 }

--- a/apps/desktop/src/app/sidebarStack.ts
+++ b/apps/desktop/src/app/sidebarStack.ts
@@ -37,8 +37,8 @@ export type SidebarStackAction =
       type: "push";
       activationID?: string;
       entryID: string;
-      lifecycleID?: string;
-      sourceEntryID?: string;
+      lifecycleID: string;
+      sourceEntryID: string;
       destination: SidebarDestination;
     }>
   | Readonly<{ type: "back"; activationID?: string; lifecycleID: string; entryID: string }>
@@ -140,12 +140,10 @@ function reducePush(
   state: SidebarStackState | null,
   action: Extract<SidebarStackAction, { type: "push" }>,
 ): SidebarStackState | null {
-  if (
-    state === null ||
-    (action.lifecycleID !== undefined && action.lifecycleID !== state.lifecycleID) ||
-    (action.sourceEntryID !== undefined && state.entries.at(-1)?.entryID !== action.sourceEntryID)
-  )
+  if (state === null) return state;
+  if (action.lifecycleID !== state.lifecycleID || state.entries.at(-1)?.entryID !== action.sourceEntryID) {
     return state;
+  }
   const existingTaskIndex = findTaskDetailIndex(state.entries, action.destination);
   if (existingTaskIndex !== undefined) {
     return {
@@ -244,8 +242,10 @@ export function findTaskDetailIndex(
   if (destination.kind !== "taskDetail") {
     return undefined;
   }
-  const index = entries.findIndex((entry) =>
-    sidebarDestinationMatchesTask(entry.destination, destination.taskID),
-  );
-  return index === -1 ? undefined : index;
+  for (const [index, entry] of entries.entries()) {
+    if (sidebarDestinationMatchesTask(entry.destination, destination.taskID)) {
+      return index;
+    }
+  }
+  return undefined;
 }

--- a/apps/desktop/src/app/sidebarStack.ts
+++ b/apps/desktop/src/app/sidebarStack.ts
@@ -106,16 +106,22 @@ function reduceReplace(
   state: SidebarStackState | null,
   action: Extract<SidebarStackAction, { type: "replace" }>,
 ): SidebarStackState | null {
-  return state === null || state.entries.length === 0
-    ? state
-    : {
-        ...state,
-        activationID: action.activationID ?? state.activationID,
-        entries: [
-          ...state.entries.slice(0, -1),
-          { entryID: action.entryID, destination: action.destination },
-        ],
-      };
+  if (state === null || state.entries.length === 0) {
+    return state;
+  }
+  const existingTaskIndex = findTaskDetailIndex(state.entries, action.destination);
+  if (existingTaskIndex !== undefined) {
+    return {
+      ...state,
+      activationID: action.activationID ?? state.activationID,
+      entries: state.entries.slice(0, existingTaskIndex + 1),
+    };
+  }
+  return {
+    ...state,
+    activationID: action.activationID ?? state.activationID,
+    entries: [...state.entries.slice(0, -1), { entryID: action.entryID, destination: action.destination }],
+  };
 }
 
 function reducePush(

--- a/apps/desktop/src/app/startup/styles.css
+++ b/apps/desktop/src/app/startup/styles.css
@@ -376,6 +376,34 @@
   }
 }
 
+@keyframes sidebar-destination-push-old {
+  to {
+    opacity: 0;
+    transform: translateX(-10%);
+  }
+}
+
+@keyframes sidebar-destination-push-new {
+  from {
+    opacity: 0;
+    transform: translateX(10%);
+  }
+}
+
+@keyframes sidebar-destination-back-old {
+  to {
+    opacity: 0;
+    transform: translateX(10%);
+  }
+}
+
+@keyframes sidebar-destination-back-new {
+  from {
+    opacity: 0;
+    transform: translateX(-10%);
+  }
+}
+
 @layer base {
   * {
     box-sizing: border-box;
@@ -593,5 +621,21 @@
 
   .view-transition-route::view-transition-new(root) {
     animation: route-fade-scale var(--motion-fast) both;
+  }
+
+  .view-transition-sidebar-push::view-transition-old(sidebar-destination) {
+    animation: sidebar-destination-push-old var(--motion-fast) both;
+  }
+
+  .view-transition-sidebar-push::view-transition-new(sidebar-destination) {
+    animation: sidebar-destination-push-new var(--motion-fast) both;
+  }
+
+  .view-transition-sidebar-back::view-transition-old(sidebar-destination) {
+    animation: sidebar-destination-back-old var(--motion-fast) both;
+  }
+
+  .view-transition-sidebar-back::view-transition-new(sidebar-destination) {
+    animation: sidebar-destination-back-new var(--motion-fast) both;
   }
 }

--- a/apps/desktop/src/features/board/BoardRoute.tsx
+++ b/apps/desktop/src/features/board/BoardRoute.tsx
@@ -45,6 +45,7 @@ import { BoardLabelFilterChrome, BoardMembershipRefreshBinding } from "./BoardLa
 import { ignoreBoardMembershipRefresh, type BoardMembershipRefreshRef } from "./BoardMembershipRefresh";
 import { useBoard, useBoardTaskActions, useProjectBoardSubscription } from "./useBoardData";
 import { useBoardLoadErrorReporter } from "./useBoardLoadErrorReporter";
+import { useBoardSelectedTaskDeletion } from "./useBoardSelectedTaskDeletion";
 
 export type BoardRouteProps = Readonly<{
   projectId: string;
@@ -134,8 +135,6 @@ function BoardRouteData({
   }>) {
   const { t } = useTranslation();
   const { push } = useStatusController();
-  const navigation = useAppNavigation();
-  const { activeDestination, closeSidebar } = useSidebar();
   const reportBoardNavigationError = useCallback(
     (error: unknown) => {
       push({
@@ -151,23 +150,12 @@ function BoardRouteData({
   const boardQuery = useBoard(projectId, workflowId);
   const board = boardQuery.data;
   const selectedWorkflowID = board?.selectedWorkflow?.id;
-  const handleSelectedTaskDeleted = useCallback(() => {
-    // The task detail sidebar is opened independently of the route, so closing
-    // the route task alone would leave it mounted and refetching the now-deleted
-    // task into an error state. Close it too when it targets the deleted task.
-    if (activeDestination?.kind === "taskDetail" && activeDestination.taskID === selectedTaskId) {
-      closeSidebar();
-    }
-    void navigation.closeProjectTask(projectId, workflowId).catch(reportBoardNavigationError);
-  }, [
-    activeDestination,
-    closeSidebar,
-    navigation,
+  const handleSelectedTaskDeleted = useBoardSelectedTaskDeletion({
+    onNavigationError: reportBoardNavigationError,
     projectId,
-    reportBoardNavigationError,
     selectedTaskId,
     workflowId,
-  ]);
+  });
   useProjectBoardSubscription(projectId, workflowId, {
     onBackgroundError: reportBoardLoadError,
     onSelectedTaskDeleted: handleSelectedTaskDeleted,

--- a/apps/desktop/src/features/board/BoardRoute.tsx
+++ b/apps/desktop/src/features/board/BoardRoute.tsx
@@ -50,7 +50,7 @@ import { useBoardSelectedTaskDeletion } from "./useBoardSelectedTaskDeletion";
 export type BoardRouteProps = Readonly<{
   projectId: string;
   workflowId: string | undefined;
-  selectedTaskId: string;
+  selectedTaskId: string | undefined;
 }>;
 
 const emptyExpandedEmptyColumnIDs: ReadonlySet<string> = new Set();
@@ -159,7 +159,7 @@ function BoardRouteData({
   useProjectBoardSubscription(projectId, workflowId, {
     onBackgroundError: reportBoardLoadError,
     onSelectedTaskDeleted: handleSelectedTaskDeleted,
-    selectedTaskID: selectedTaskId,
+    ...(selectedTaskId === undefined ? {} : { selectedTaskID: selectedTaskId }),
     selectedWorkflowID,
   });
 
@@ -206,7 +206,7 @@ function BoardContent({
   boardQueryWorkflowID: string | undefined;
   boardRefreshError: Error | null;
   onBoardRefreshRetry(): void;
-  selectedTaskId: string;
+  selectedTaskId: string | undefined;
 }>) {
   const { t } = useTranslation();
   const [workflowIssuesCollapsed, setWorkflowIssuesCollapsed] = useState(false);
@@ -323,7 +323,7 @@ function BoardContent({
   );
 
   useEffect(() => {
-    if (selectedTaskId.length === 0) {
+    if (selectedTaskId === undefined) {
       return;
     }
     let active = true;

--- a/apps/desktop/src/features/board/BoardRoute.tsx
+++ b/apps/desktop/src/features/board/BoardRoute.tsx
@@ -2,11 +2,7 @@ import type { DragEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import {
-  hasSelectedWorkflow,
-  type BoardColumn,
-  type SelectedWorkflowBoard,
-} from "@/api";
+import { hasSelectedWorkflow, type BoardColumn, type SelectedWorkflowBoard } from "@/api";
 import { errorMessage } from "@/api";
 import { useAppNavigation } from "@/app-facade";
 import { useConnectionSnapshot } from "@/app-facade";
@@ -156,11 +152,12 @@ function BoardRouteData({
     selectedTaskId,
     workflowId,
   });
+  const handleSubscriptionSelectedTaskDeleted = useCallback(() => {
+    void handleSelectedTaskDeleted();
+  }, [handleSelectedTaskDeleted]);
   useProjectBoardSubscription(projectId, workflowId, {
     onBackgroundError: reportBoardLoadError,
-    onSelectedTaskDeleted: () => {
-      void handleSelectedTaskDeleted();
-    },
+    onSelectedTaskDeleted: handleSubscriptionSelectedTaskDeleted,
     ...(selectedTaskId === undefined ? {} : { selectedTaskID: selectedTaskId }),
     selectedWorkflowID,
   });
@@ -469,7 +466,6 @@ function BoardContent({
       return { ids: next, scope: columnExpansionScope };
     });
   }
-
 
   function handleTaskInitiatingDialogResult(result: TaskInitiatingActionDialogResult): void {
     if (result.kind === "view_dependencies") {

--- a/apps/desktop/src/features/board/BoardRoute.tsx
+++ b/apps/desktop/src/features/board/BoardRoute.tsx
@@ -158,7 +158,9 @@ function BoardRouteData({
   });
   useProjectBoardSubscription(projectId, workflowId, {
     onBackgroundError: reportBoardLoadError,
-    onSelectedTaskDeleted: handleSelectedTaskDeleted,
+    onSelectedTaskDeleted: () => {
+      void handleSelectedTaskDeleted();
+    },
     ...(selectedTaskId === undefined ? {} : { selectedTaskID: selectedTaskId }),
     selectedWorkflowID,
   });
@@ -190,6 +192,7 @@ function BoardRouteData({
       onBoardRefreshRetry={() => {
         void boardQuery.refetch().catch(reportBoardLoadError);
       }}
+      onSelectedTaskDeleted={handleSelectedTaskDeleted}
       selectedTaskId={selectedTaskId}
     />
   );
@@ -200,12 +203,14 @@ function BoardContent({
   boardQueryWorkflowID,
   boardRefreshError,
   onBoardRefreshRetry,
+  onSelectedTaskDeleted,
   selectedTaskId,
 }: Readonly<{
   board: SelectedWorkflowBoard;
   boardQueryWorkflowID: string | undefined;
   boardRefreshError: Error | null;
   onBoardRefreshRetry(): void;
+  onSelectedTaskDeleted(): Promise<void>;
   selectedTaskId: string | undefined;
 }>) {
   const { t } = useTranslation();
@@ -408,9 +413,7 @@ function BoardContent({
     try {
       await actions.delete.mutateAsync(target.taskID);
       if (target.taskID === selectedTaskId) {
-        await navigation
-          .closeProjectTask(board.projectID, board.selectedWorkflow.id)
-          .catch(reportNavigationError);
+        await onSelectedTaskDeleted();
       }
       close();
     } catch (error) {

--- a/apps/desktop/src/features/board/boardSidebarDeletion.ts
+++ b/apps/desktop/src/features/board/boardSidebarDeletion.ts
@@ -1,5 +1,5 @@
 import {
-  sidebarDestinationMatchesTask,
+  sidebarDestinationIndexForTask,
   type SidebarDestination,
   type SidebarEntryToken,
 } from "@/app-facade";
@@ -9,10 +9,9 @@ export function sidebarEntryTokenForDeletedTask(
   tokens: readonly SidebarEntryToken[],
   taskID: string,
 ): SidebarEntryToken | undefined {
-  for (const [index, destination] of destinations.entries()) {
-    if (sidebarDestinationMatchesTask(destination, taskID)) {
-      return tokens[index];
-    }
+  const index = sidebarDestinationIndexForTask(destinations, taskID);
+  if (index !== undefined) {
+    return tokens[index];
   }
   return undefined;
 }

--- a/apps/desktop/src/features/board/boardSidebarDeletion.ts
+++ b/apps/desktop/src/features/board/boardSidebarDeletion.ts
@@ -1,12 +1,16 @@
-import type { SidebarDestination, SidebarEntryToken } from "@/app-facade";
+import {
+  sidebarDestinationMatchesTask,
+  type SidebarDestination,
+  type SidebarEntryToken,
+} from "@/app-facade";
 
 export function sidebarEntryTokenForDeletedTask(
   destinations: readonly SidebarDestination[],
   tokens: readonly SidebarEntryToken[],
   taskID: string,
 ): SidebarEntryToken | undefined {
-  const index = destinations.findIndex(
-    (destination) => destination.kind === "taskDetail" && destination.taskID === taskID,
+  const index = destinations.findIndex((destination) =>
+    sidebarDestinationMatchesTask(destination, taskID),
   );
   return index < 0 ? undefined : tokens[index];
 }

--- a/apps/desktop/src/features/board/boardSidebarDeletion.ts
+++ b/apps/desktop/src/features/board/boardSidebarDeletion.ts
@@ -9,8 +9,10 @@ export function sidebarEntryTokenForDeletedTask(
   tokens: readonly SidebarEntryToken[],
   taskID: string,
 ): SidebarEntryToken | undefined {
-  const index = destinations.findIndex((destination) =>
-    sidebarDestinationMatchesTask(destination, taskID),
-  );
-  return index < 0 ? undefined : tokens[index];
+  for (const [index, destination] of destinations.entries()) {
+    if (sidebarDestinationMatchesTask(destination, taskID)) {
+      return tokens[index];
+    }
+  }
+  return undefined;
 }

--- a/apps/desktop/src/features/board/boardSidebarDeletion.ts
+++ b/apps/desktop/src/features/board/boardSidebarDeletion.ts
@@ -1,0 +1,12 @@
+import type { SidebarDestination, SidebarEntryToken } from "@/app-facade";
+
+export function sidebarEntryTokenForDeletedTask(
+  destinations: readonly SidebarDestination[],
+  tokens: readonly SidebarEntryToken[],
+  taskID: string,
+): SidebarEntryToken | undefined {
+  const index = destinations.findIndex(
+    (destination) => destination.kind === "taskDetail" && destination.taskID === taskID,
+  );
+  return index < 0 ? undefined : tokens[index];
+}

--- a/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.test.ts
+++ b/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.test.ts
@@ -23,7 +23,7 @@ const mocks = vi.hoisted(() => {
 });
 
 vi.mock("@/app-facade", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/app-facade")>();
+  const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
     useAppNavigation: () => mocks.navigation,

--- a/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.test.ts
+++ b/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.test.ts
@@ -6,10 +6,17 @@ const mocks = vi.hoisted(() => {
     lifecycleID: "lifecycle-1",
     entryID: "entry-task-b",
   };
+  const deletedToken = {
+    lifecycleID: "lifecycle-1",
+    entryID: "entry-task-a",
+  };
   return {
     activeToken,
+    deletedToken,
     navigation: {
-      closeProjectTask: vi.fn(async () => undefined),
+      closeProjectTask: vi.fn(async (): Promise<void> => {
+        await Promise.resolve();
+      }),
     },
     sidebar: {
       activeToken,
@@ -36,6 +43,10 @@ import { useBoardSelectedTaskDeletion } from "./useBoardSelectedTaskDeletion";
 describe("useBoardSelectedTaskDeletion", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.navigation.closeProjectTask.mockResolvedValue(undefined);
+    mocks.sidebar.activeToken = mocks.activeToken;
+    mocks.sidebar.stackDestinations = [{ kind: "taskDetail", taskID: "task-b" }];
+    mocks.sidebar.stackEntryTokens = [mocks.activeToken];
   });
 
   it("preserves an unrelated active sidebar stack during selected-task route cleanup", async () => {
@@ -64,5 +75,38 @@ describe("useBoardSelectedTaskDeletion", () => {
     expect(mocks.sidebar.removeSidebarEntry).not.toHaveBeenCalled();
     expect(mocks.navigation.closeProjectTask).toHaveBeenCalledWith("project-1", "workflow-1");
     expect(onNavigationError).not.toHaveBeenCalled();
+  });
+
+  it("coalesces concurrent cleanup for the same selected Task", async () => {
+    mocks.sidebar.activeToken = mocks.deletedToken;
+    mocks.sidebar.stackDestinations = [{ kind: "taskDetail", taskID: "task-a" }];
+    mocks.sidebar.stackEntryTokens = [mocks.deletedToken];
+    let resolveCloseProjectTask: (() => void) | undefined;
+    mocks.navigation.closeProjectTask.mockImplementation(async () => {
+      await new Promise<void>((resolve) => {
+        resolveCloseProjectTask = resolve;
+      });
+    });
+    const { result } = renderHook(() =>
+      useBoardSelectedTaskDeletion({
+        onNavigationError: vi.fn(),
+        projectId: "project-1",
+        selectedTaskId: "task-a",
+        workflowId: "workflow-1",
+      }),
+    );
+
+    const first = result.current();
+    const second = result.current();
+
+    expect(mocks.navigation.closeProjectTask).toHaveBeenCalledTimes(1);
+    expect(mocks.sidebar.preserveSidebarOnNextRouteChange).toHaveBeenCalledTimes(1);
+    expect(mocks.sidebar.removeSidebarEntry).toHaveBeenCalledTimes(1);
+
+    resolveCloseProjectTask?.();
+    await Promise.all([first, second]);
+    await result.current();
+    expect(mocks.navigation.closeProjectTask).toHaveBeenCalledTimes(1);
+    expect(mocks.sidebar.removeSidebarEntry).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.test.ts
+++ b/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.test.ts
@@ -1,0 +1,68 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const activeToken = {
+    lifecycleID: "lifecycle-1",
+    entryID: "entry-task-b",
+  };
+  return {
+    activeToken,
+    navigation: {
+      closeProjectTask: vi.fn(async () => undefined),
+    },
+    sidebar: {
+      activeToken,
+      clearSidebarRouteChangePreservation: vi.fn(),
+      preserveSidebarOnNextRouteChange: vi.fn(),
+      removeSidebarEntry: vi.fn(),
+      stackDestinations: [{ kind: "taskDetail", taskID: "task-b" }],
+      stackEntryTokens: [activeToken],
+    },
+  };
+});
+
+vi.mock("@/app-facade", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/app-facade")>();
+  return {
+    ...actual,
+    useAppNavigation: () => mocks.navigation,
+    useSidebar: () => mocks.sidebar,
+  };
+});
+
+import { useBoardSelectedTaskDeletion } from "./useBoardSelectedTaskDeletion";
+
+describe("useBoardSelectedTaskDeletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves an unrelated active sidebar stack during selected-task route cleanup", async () => {
+    const onNavigationError = vi.fn();
+    const { result } = renderHook(() =>
+      useBoardSelectedTaskDeletion({
+        onNavigationError,
+        projectId: "project-1",
+        selectedTaskId: "task-a",
+        workflowId: "workflow-1",
+      }),
+    );
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(mocks.sidebar.preserveSidebarOnNextRouteChange).toHaveBeenCalledWith(
+      mocks.activeToken,
+      {
+        kind: "projectTaskCleared",
+        projectID: "project-1",
+        workflowID: "workflow-1",
+      },
+    );
+    expect(mocks.sidebar.removeSidebarEntry).not.toHaveBeenCalled();
+    expect(mocks.navigation.closeProjectTask).toHaveBeenCalledWith("project-1", "workflow-1");
+    expect(onNavigationError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.ts
+++ b/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.ts
@@ -1,6 +1,10 @@
 import { useCallback } from "react";
 
-import { useAppNavigation, useSidebar } from "@/app-facade";
+import {
+  useAppNavigation,
+  useSidebar,
+  type SidebarRouteChangeExpectation,
+} from "@/app-facade";
 import { sidebarEntryTokenForDeletedTask } from "./boardSidebarDeletion";
 
 export function useBoardSelectedTaskDeletion({
@@ -15,8 +19,13 @@ export function useBoardSelectedTaskDeletion({
   workflowId: string | undefined;
 }>) {
   const navigation = useAppNavigation();
-  const { preserveSidebarOnNextRouteChange, removeSidebarEntry, stackDestinations, stackEntryTokens } =
-    useSidebar();
+  const {
+    clearSidebarRouteChangePreservation,
+    preserveSidebarOnNextRouteChange,
+    removeSidebarEntry,
+    stackDestinations,
+    stackEntryTokens,
+  } = useSidebar();
   return useCallback(() => {
     const deletedToken = sidebarEntryTokenForDeletedTask(
       stackDestinations,
@@ -24,11 +33,22 @@ export function useBoardSelectedTaskDeletion({
       selectedTaskId,
     );
     if (deletedToken !== undefined) {
-      preserveSidebarOnNextRouteChange();
+      const expectation: SidebarRouteChangeExpectation = {
+        kind: "projectTaskCleared",
+        projectID: projectId,
+        workflowID: workflowId,
+      };
+      preserveSidebarOnNextRouteChange(deletedToken, expectation);
       removeSidebarEntry(deletedToken);
     }
-    void navigation.closeProjectTask(projectId, workflowId).catch(onNavigationError);
+    void navigation.closeProjectTask(projectId, workflowId).catch((error: unknown) => {
+      if (deletedToken !== undefined) {
+        clearSidebarRouteChangePreservation(deletedToken);
+      }
+      onNavigationError(error);
+    });
   }, [
+    clearSidebarRouteChangePreservation,
     navigation,
     onNavigationError,
     preserveSidebarOnNextRouteChange,

--- a/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.ts
+++ b/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.ts
@@ -26,7 +26,7 @@ export function useBoardSelectedTaskDeletion({
     stackDestinations,
     stackEntryTokens,
   } = useSidebar();
-  return useCallback(() => {
+  return useCallback(async () => {
     const deletedToken =
       selectedTaskId === undefined
         ? undefined
@@ -40,12 +40,14 @@ export function useBoardSelectedTaskDeletion({
       preserveSidebarOnNextRouteChange(deletedToken, expectation);
       removeSidebarEntry(deletedToken);
     }
-    void navigation.closeProjectTask(projectId, workflowId).catch((error: unknown) => {
+    try {
+      await navigation.closeProjectTask(projectId, workflowId);
+    } catch (error: unknown) {
       if (deletedToken !== undefined) {
         clearSidebarRouteChangePreservation(deletedToken);
       }
       onNavigationError(error);
-    });
+    }
   }, [
     clearSidebarRouteChangePreservation,
     navigation,

--- a/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.ts
+++ b/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.ts
@@ -1,0 +1,42 @@
+import { useCallback } from "react";
+
+import { useAppNavigation, useSidebar } from "@/app-facade";
+import { sidebarEntryTokenForDeletedTask } from "./boardSidebarDeletion";
+
+export function useBoardSelectedTaskDeletion({
+  onNavigationError,
+  projectId,
+  selectedTaskId,
+  workflowId,
+}: Readonly<{
+  onNavigationError(error: unknown): void;
+  projectId: string;
+  selectedTaskId: string;
+  workflowId: string | undefined;
+}>) {
+  const navigation = useAppNavigation();
+  const { preserveSidebarOnNextRouteChange, removeSidebarEntry, stackDestinations, stackEntryTokens } =
+    useSidebar();
+  return useCallback(() => {
+    const deletedToken = sidebarEntryTokenForDeletedTask(
+      stackDestinations,
+      stackEntryTokens,
+      selectedTaskId,
+    );
+    if (deletedToken !== undefined) {
+      preserveSidebarOnNextRouteChange();
+      removeSidebarEntry(deletedToken);
+    }
+    void navigation.closeProjectTask(projectId, workflowId).catch(onNavigationError);
+  }, [
+    navigation,
+    onNavigationError,
+    preserveSidebarOnNextRouteChange,
+    projectId,
+    selectedTaskId,
+    stackDestinations,
+    stackEntryTokens,
+    removeSidebarEntry,
+    workflowId,
+  ]);
+}

--- a/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.ts
+++ b/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.ts
@@ -15,7 +15,7 @@ export function useBoardSelectedTaskDeletion({
 }: Readonly<{
   onNavigationError(error: unknown): void;
   projectId: string;
-  selectedTaskId: string;
+  selectedTaskId: string | undefined;
   workflowId: string | undefined;
 }>) {
   const navigation = useAppNavigation();
@@ -27,11 +27,10 @@ export function useBoardSelectedTaskDeletion({
     stackEntryTokens,
   } = useSidebar();
   return useCallback(() => {
-    const deletedToken = sidebarEntryTokenForDeletedTask(
-      stackDestinations,
-      stackEntryTokens,
-      selectedTaskId,
-    );
+    const deletedToken =
+      selectedTaskId === undefined
+        ? undefined
+        : sidebarEntryTokenForDeletedTask(stackDestinations, stackEntryTokens, selectedTaskId);
     if (deletedToken !== undefined) {
       const expectation: SidebarRouteChangeExpectation = {
         kind: "projectTaskCleared",

--- a/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.ts
+++ b/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.ts
@@ -20,6 +20,7 @@ export function useBoardSelectedTaskDeletion({
 }>) {
   const navigation = useAppNavigation();
   const {
+    activeToken,
     clearSidebarRouteChangePreservation,
     preserveSidebarOnNextRouteChange,
     removeSidebarEntry,
@@ -31,24 +32,28 @@ export function useBoardSelectedTaskDeletion({
       selectedTaskId === undefined
         ? undefined
         : sidebarEntryTokenForDeletedTask(stackDestinations, stackEntryTokens, selectedTaskId);
-    if (deletedToken !== undefined) {
+    const preservationToken = selectedTaskId === undefined ? null : (deletedToken ?? activeToken);
+    if (preservationToken !== null) {
       const expectation: SidebarRouteChangeExpectation = {
         kind: "projectTaskCleared",
         projectID: projectId,
         workflowID: workflowId,
       };
-      preserveSidebarOnNextRouteChange(deletedToken, expectation);
-      removeSidebarEntry(deletedToken);
+      preserveSidebarOnNextRouteChange(preservationToken, expectation);
+      if (deletedToken !== undefined) {
+        removeSidebarEntry(deletedToken);
+      }
     }
     try {
       await navigation.closeProjectTask(projectId, workflowId);
     } catch (error: unknown) {
-      if (deletedToken !== undefined) {
-        clearSidebarRouteChangePreservation(deletedToken);
+      if (preservationToken !== null) {
+        clearSidebarRouteChangePreservation(preservationToken);
       }
       onNavigationError(error);
     }
   }, [
+    activeToken,
     clearSidebarRouteChangePreservation,
     navigation,
     onNavigationError,

--- a/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.ts
+++ b/apps/desktop/src/features/board/useBoardSelectedTaskDeletion.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 
 import {
   useAppNavigation,
@@ -6,6 +6,13 @@ import {
   type SidebarRouteChangeExpectation,
 } from "@/app-facade";
 import { sidebarEntryTokenForDeletedTask } from "./boardSidebarDeletion";
+
+type SelectedTaskDeletionRun = Readonly<{
+  selectedTaskID: string | undefined;
+  runID: symbol;
+  promise: Promise<void>;
+}>;
+type SelectedTaskDeletionOutcome = "completed" | "failed";
 
 export function useBoardSelectedTaskDeletion({
   onNavigationError,
@@ -19,6 +26,7 @@ export function useBoardSelectedTaskDeletion({
   workflowId: string | undefined;
 }>) {
   const navigation = useAppNavigation();
+  const cleanupRef = useRef<SelectedTaskDeletionRun | null>(null);
   const {
     activeToken,
     clearSidebarRouteChangePreservation,
@@ -27,32 +35,59 @@ export function useBoardSelectedTaskDeletion({
     stackDestinations,
     stackEntryTokens,
   } = useSidebar();
-  return useCallback(async () => {
-    const deletedToken =
-      selectedTaskId === undefined
-        ? undefined
-        : sidebarEntryTokenForDeletedTask(stackDestinations, stackEntryTokens, selectedTaskId);
-    const preservationToken = selectedTaskId === undefined ? null : (deletedToken ?? activeToken);
-    if (preservationToken !== null) {
-      const expectation: SidebarRouteChangeExpectation = {
-        kind: "projectTaskCleared",
-        projectID: projectId,
-        workflowID: workflowId,
-      };
-      preserveSidebarOnNextRouteChange(preservationToken, expectation);
-      if (deletedToken !== undefined) {
-        removeSidebarEntry(deletedToken);
-      }
+  return useCallback(async (): Promise<void> => {
+    const existingRun = cleanupRef.current;
+    if (existingRun !== null && existingRun.selectedTaskID === selectedTaskId) {
+      return existingRun.promise;
     }
-    try {
-      await navigation.closeProjectTask(projectId, workflowId);
-    } catch (error: unknown) {
+    cleanupRef.current = null;
+    const runID = Symbol("selected-task-deletion");
+
+    const operation = (async (): Promise<SelectedTaskDeletionOutcome> => {
+      const deletedToken =
+        selectedTaskId === undefined
+          ? undefined
+          : sidebarEntryTokenForDeletedTask(stackDestinations, stackEntryTokens, selectedTaskId);
+      const preservationToken = selectedTaskId === undefined ? null : (deletedToken ?? activeToken);
       if (preservationToken !== null) {
-        clearSidebarRouteChangePreservation(preservationToken);
+        const expectation: SidebarRouteChangeExpectation = {
+          kind: "projectTaskCleared",
+          projectID: projectId,
+          workflowID: workflowId,
+        };
+        preserveSidebarOnNextRouteChange(preservationToken, expectation);
+        if (deletedToken !== undefined) {
+          removeSidebarEntry(deletedToken);
+        }
       }
-      onNavigationError(error);
-    }
+      try {
+        await navigation.closeProjectTask(projectId, workflowId);
+        return "completed";
+      } catch (error: unknown) {
+        if (preservationToken !== null) {
+          clearSidebarRouteChangePreservation(preservationToken);
+        }
+        onNavigationError(error);
+        return "failed";
+      }
+    })();
+    const completion = operation.then(
+      (outcome) => {
+        if (outcome === "failed" && cleanupRef.current?.runID === runID) {
+          cleanupRef.current = null;
+        }
+      },
+      (error: unknown) => {
+        if (cleanupRef.current?.runID === runID) {
+          cleanupRef.current = null;
+        }
+        throw error;
+      },
+    );
+    cleanupRef.current = { runID, selectedTaskID: selectedTaskId, promise: completion };
+    return completion;
   }, [
+    cleanupRef,
     activeToken,
     clearSidebarRouteChangePreservation,
     navigation,

--- a/apps/desktop/src/features/home/SidebarInboxNav.tsx
+++ b/apps/desktop/src/features/home/SidebarInboxNav.tsx
@@ -19,7 +19,7 @@ type TaskDetailDestination = Extract<SidebarDestination, { kind: "taskDetail" }>
  */
 export function SidebarInboxNav({ destination }: Readonly<{ destination: TaskDetailDestination }>) {
   const { t } = useTranslation();
-  const { openSidebar } = useSidebar();
+  const { replaceSidebar } = useSidebar();
   const attention = useSidebarGlobalAttentionPages();
   // Remembers the open task's last position so Next still works after it is
   // resolved and drops out of the live inbox; updated only while it is present.
@@ -48,7 +48,7 @@ export function SidebarInboxNav({ destination }: Readonly<{ destination: TaskDet
     if (taskID === null) {
       return;
     }
-    void openSidebar({
+    replaceSidebar({
       ...destination,
       initialFocus: taskDetailInitialFocusFromAttentionItem(
         attentionItems.find((candidate) => candidate.taskID === taskID),

--- a/apps/desktop/src/features/task-detail/TaskDependenciesArea.test.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDependenciesArea.test.tsx
@@ -74,6 +74,7 @@ describe("TaskDependenciesArea", () => {
         onAdd={vi.fn()}
         onRemove={vi.fn()}
         onSelectTask={vi.fn()}
+        removeDisabled={false}
         taskID="task-1"
       />,
     );
@@ -101,6 +102,7 @@ describe("TaskDependenciesArea", () => {
         onAdd={vi.fn()}
         onRemove={vi.fn()}
         onSelectTask={vi.fn()}
+        removeDisabled={false}
         taskID="task-1"
       />,
     );
@@ -118,6 +120,7 @@ describe("TaskDependenciesArea", () => {
         onAdd={vi.fn()}
         onRemove={vi.fn()}
         onSelectTask={vi.fn()}
+        removeDisabled
         taskID="task-1"
       />,
     );
@@ -139,6 +142,7 @@ describe("TaskDependenciesArea", () => {
         onAdd={onAdd}
         onRemove={onRemove}
         onSelectTask={onSelectTask}
+        removeDisabled={false}
         taskID="task-1"
       />,
     );
@@ -165,6 +169,34 @@ describe("TaskDependenciesArea", () => {
 
     expect(onSelectTask).toHaveBeenCalledWith("task-2");
     expect(onAdd).toHaveBeenCalledWith("blocked-by");
+    expect(onRemove).toHaveBeenCalledWith({
+      blockerTaskID: "task-2",
+      blockedTaskID: "task-1",
+    });
+  });
+
+  it("keeps relationship removal available while saves disable navigation and Add", async () => {
+    const onAdd = vi.fn();
+    const onRemove = vi.fn();
+    const onSelectTask = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <TaskDependenciesArea
+        dependencies={dependencies}
+        disabled
+        onAdd={onAdd}
+        onRemove={onRemove}
+        onSelectTask={onSelectTask}
+        removeDisabled={false}
+        taskID="task-1"
+      />,
+    );
+
+    expect(screen.getByTestId("dependency-add-blocked-by")).toBeDisabled();
+    expect(screen.getByTestId("dependency-remove-task-2")).toBeEnabled();
+
+    await user.click(screen.getByTestId("dependency-remove-task-2"));
     expect(onRemove).toHaveBeenCalledWith({
       blockerTaskID: "task-2",
       blockedTaskID: "task-1",

--- a/apps/desktop/src/features/task-detail/TaskDependenciesArea.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDependenciesArea.tsx
@@ -22,6 +22,7 @@ export function TaskDependenciesArea({
   onAdd,
   onRemove,
   onSelectTask,
+  removeDisabled,
   taskID,
 }: Readonly<{
   dependencies: TaskDependencies;
@@ -29,6 +30,7 @@ export function TaskDependenciesArea({
   onAdd(direction: TaskDependencyDirection): void;
   onRemove(pair: TaskDependencyPair): void;
   onSelectTask(taskID: string): void;
+  removeDisabled: boolean;
   taskID: string;
 }>) {
   const { t } = useTranslation();
@@ -53,6 +55,7 @@ export function TaskDependenciesArea({
         onAdd={onAdd}
         onRemove={onRemove}
         onSelectTask={onSelectTask}
+        removeDisabled={removeDisabled}
         taskID={taskID}
       />
       <div className="h-px bg-[var(--color-outline)]" />
@@ -62,6 +65,7 @@ export function TaskDependenciesArea({
         onAdd={onAdd}
         onRemove={onRemove}
         onSelectTask={onSelectTask}
+        removeDisabled={removeDisabled}
         taskID={taskID}
       />
     </Island>
@@ -74,6 +78,7 @@ function DependencyDirection({
   onAdd,
   onRemove,
   onSelectTask,
+  removeDisabled,
   taskID,
 }: Readonly<{
   direction: TaskDependencyDirectionProjection;
@@ -81,6 +86,7 @@ function DependencyDirection({
   onAdd(direction: TaskDependencyDirection): void;
   onRemove(pair: TaskDependencyPair): void;
   onSelectTask(taskID: string): void;
+  removeDisabled: boolean;
   taskID: string;
 }>) {
   const { t } = useTranslation();
@@ -124,6 +130,7 @@ function DependencyDirection({
             key={item.taskID}
             onRemove={onRemove}
             onSelectTask={onSelectTask}
+            removeDisabled={removeDisabled}
             taskID={taskID}
           />
         ))}
@@ -138,6 +145,7 @@ function DependencyRow({
   item,
   onRemove,
   onSelectTask,
+  removeDisabled,
   taskID,
 }: Readonly<{
   direction: TaskDependencyDirection;
@@ -145,6 +153,7 @@ function DependencyRow({
   item: TaskDependencyItem;
   onRemove(pair: TaskDependencyPair): void;
   onSelectTask(taskID: string): void;
+  removeDisabled: boolean;
   taskID: string;
 }>) {
   const { t } = useTranslation();
@@ -159,7 +168,7 @@ function DependencyRow({
           aria-label={t("task.dependenciesRemove")}
           className="grid size-7 place-items-center rounded-[var(--radius-s)] border-0 bg-transparent text-[var(--color-error)] outline-none focus-visible:ring-[3px] focus-visible:ring-[color-mix(in_srgb,var(--color-error)_35%,transparent)] disabled:cursor-not-allowed disabled:opacity-45"
           data-testid={`dependency-remove-${item.taskID}`}
-          disabled={disabled}
+          disabled={removeDisabled}
           onClick={() => {
             onRemove(pair);
           }}

--- a/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
@@ -408,9 +408,9 @@ export function TaskDetailContent({
       updatePending={update.isPending}
       initialScrollOffset={restoredSnapshot?.scrollTop}
       initialScrollOffsetRequestKey={
-        activeToken === null
+        activeToken === null || restoredSnapshot === undefined || !restoredDataReady
           ? undefined
-          : `${activeToken.entryID}:${restoredDataReady ? "ready" : "loading"}`
+          : `${activeToken.entryID}:${restoredSnapshot.scrollTop.toString()}`
       }
       onScrollElementChange={(element) => {
         scrollElementRef.current = element;

--- a/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
@@ -60,25 +60,33 @@ function relatedTaskDestination(
 function initialTaskDraftState(
   taskID: string,
   serverDraft: TaskDraft,
-  snapshot: SidebarTaskDetailSnapshot | undefined,
+  restoredState: RestoredTaskDetailState,
 ): TaskDraftState {
-  return { taskID, base: serverDraft, draft: snapshot?.titleBodyDraft ?? serverDraft };
+  return { taskID, base: serverDraft, draft: restoredState.titleBodyDraft ?? serverDraft };
 }
 
-function restoredEditingComment(
-  snapshot: SidebarTaskDetailSnapshot | undefined,
-): Readonly<{ id: string; body: string }> | null {
-  return snapshot?.editedCommentDraft === undefined
-    ? null
-    : { id: snapshot.editedCommentDraft.commentID, body: snapshot.editedCommentDraft.body };
-}
+type RestoredTaskDetailState = Readonly<{
+  titleBodyDraft: TaskDraft | undefined;
+  editingComment: Readonly<{ id: string; body: string }> | null;
+  newCommentBody: string;
+  descriptionPresentation: DescriptionPresentationState;
+  selectedTab: "comments" | "activity";
+}>;
 
-function restoredDescriptionPresentation(
-  snapshot: SidebarTaskDetailSnapshot | undefined,
-): DescriptionPresentationState {
-  return snapshot === undefined
-    ? initialDescriptionPresentationState
-    : { editing: false, expanded: snapshot.descriptionExpanded };
+function restoredTaskDetailState(snapshot: SidebarTaskDetailSnapshot | undefined): RestoredTaskDetailState {
+  return {
+    descriptionPresentation:
+      snapshot === undefined
+        ? initialDescriptionPresentationState
+        : { editing: false, expanded: snapshot.descriptionExpanded },
+    editingComment:
+      snapshot?.editedCommentDraft === undefined
+        ? null
+        : { id: snapshot.editedCommentDraft.commentID, body: snapshot.editedCommentDraft.body },
+    newCommentBody: snapshot?.newCommentDraft ?? "",
+    selectedTab: snapshot?.selectedTab ?? "comments",
+    titleBodyDraft: snapshot?.titleBodyDraft,
+  };
 }
 
 function useTaskDetailSidebarCapture({
@@ -173,18 +181,18 @@ function taskDetailRenderState({
   draftState,
   loadedTaskID,
   serverDraft,
-  snapshot,
+  restoredState,
 }: Readonly<{
   detail: TaskDetail;
   draftState: TaskDraftState;
   loadedTaskID: string;
   serverDraft: TaskDraft;
-  snapshot: SidebarTaskDetailSnapshot | undefined;
+  restoredState: RestoredTaskDetailState;
 }>): Readonly<{ changed: boolean; state: TaskDraftState }> {
   if (loadedTaskID !== detail.id) {
     return {
       changed: true,
-      state: initialTaskDraftState(detail.id, serverDraft, snapshot),
+      state: initialTaskDraftState(detail.id, serverDraft, restoredState),
     };
   }
   return {
@@ -198,19 +206,16 @@ function useTaskDetailLocalState(
   serverDraft: TaskDraft,
   snapshot: SidebarTaskDetailSnapshot | undefined,
 ) {
+  const restoredState = restoredTaskDetailState(snapshot);
   const [draftState, setDraftState] = useState<TaskDraftState>(() =>
-    initialTaskDraftState(detail.id, serverDraft, snapshot),
+    initialTaskDraftState(detail.id, serverDraft, restoredState),
   );
-  const [editingComment, setEditingComment] = useState<Readonly<{ id: string; body: string }> | null>(() =>
-    restoredEditingComment(snapshot),
+  const [editingComment, setEditingComment] = useState(restoredState.editingComment);
+  const [newCommentBody, setNewCommentBody] = useState(restoredState.newCommentBody);
+  const [descriptionPresentation, setDescriptionPresentation] = useState(
+    restoredState.descriptionPresentation,
   );
-  const [newCommentBody, setNewCommentBody] = useState(snapshot?.newCommentDraft ?? "");
-  const [descriptionPresentation, setDescriptionPresentation] = useState<DescriptionPresentationState>(() =>
-    restoredDescriptionPresentation(snapshot),
-  );
-  const [selectedTab, setSelectedTab] = useState<"comments" | "activity">(
-    snapshot?.selectedTab ?? "comments",
-  );
+  const [selectedTab, setSelectedTab] = useState(restoredState.selectedTab);
   const [questionSelections, setQuestionSelections] = useState<ReadonlyMap<string, QuestionSelectionState>>(
     () => new Map(),
   );
@@ -220,15 +225,15 @@ function useTaskDetailLocalState(
     draftState,
     loadedTaskID,
     serverDraft,
-    snapshot,
+    restoredState,
   });
   if (taskChanged) {
     setLoadedTaskID(detail.id);
-    setEditingComment(restoredEditingComment(snapshot));
-    setNewCommentBody(snapshot?.newCommentDraft ?? "");
-    setDescriptionPresentation(restoredDescriptionPresentation(snapshot));
+    setEditingComment(restoredState.editingComment);
+    setNewCommentBody(restoredState.newCommentBody);
+    setDescriptionPresentation(restoredState.descriptionPresentation);
     setDraftState(reconciled);
-    setSelectedTab(snapshot?.selectedTab ?? "comments");
+    setSelectedTab(restoredState.selectedTab);
     setQuestionSelections(new Map());
   }
   if (reconciled !== draftState) setDraftState(reconciled);
@@ -282,7 +287,8 @@ export function TaskDetailContent({
     registerSidebarStateCapture,
     openSidebar,
   } = useSidebar();
-  const isSidebarSurface = sidebarActivationID !== null && sidebarActivationID !== undefined;
+  const activeSidebarActivationID = sidebarActivationID ?? undefined;
+  const isSidebarSurface = activeSidebarActivationID !== undefined;
   const activeToken = isSidebarSurface ? sidebarActiveToken : null;
   const serverDraft = taskDraft(detail);
   const restoredSnapshot = sidebarSnapshot;
@@ -410,13 +416,13 @@ export function TaskDetailContent({
       updatePending={update.isPending}
       initialScrollOffset={restoredSnapshot?.scrollTop}
       initialScrollOffsetRequestKey={
+        !isSidebarSurface ||
         activeToken === null ||
-        sidebarActivationID === null ||
-        sidebarActivationID === undefined ||
+        initialFocus !== undefined ||
         restoredSnapshot === undefined ||
         !restoredDataReady
           ? undefined
-          : `${sidebarActivationID}:${detail.id}:${restoredSnapshot.scrollTop.toString()}`
+          : `${activeSidebarActivationID}:${detail.id}:${restoredSnapshot.scrollTop.toString()}`
       }
       onScrollElementChange={(element) => {
         scrollElementRef.current = element;

--- a/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
@@ -381,6 +381,7 @@ export function TaskDetailContent({
       detail={detail}
       disabled={connection.phase !== "connected"}
       dependencyDisabled={connection.phase !== "connected" || savePending}
+      dependencyRemoveDisabled={connection.phase !== "connected"}
       draft={draft}
       descriptionPresentation={descriptionPresentation}
       editingComment={editingComment}

--- a/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
@@ -261,6 +261,7 @@ export function TaskDetailContent({
   initialFocus,
   onMutated,
   openLink,
+  sidebarActivationID,
   restoredDataReady,
   sidebarSnapshot,
 }: Readonly<{
@@ -271,6 +272,7 @@ export function TaskDetailContent({
   initialFocus?: TaskDetailInitialFocus | undefined;
   onMutated?: (() => void) | undefined;
   openLink: (url: string) => void;
+  sidebarActivationID?: string | null | undefined;
   restoredDataReady: boolean;
   sidebarSnapshot?: SidebarTaskDetailSnapshot | undefined;
 }>) {
@@ -408,9 +410,13 @@ export function TaskDetailContent({
       updatePending={update.isPending}
       initialScrollOffset={restoredSnapshot?.scrollTop}
       initialScrollOffsetRequestKey={
-        activeToken === null || restoredSnapshot === undefined || !restoredDataReady
+        activeToken === null ||
+        sidebarActivationID === null ||
+        sidebarActivationID === undefined ||
+        restoredSnapshot === undefined ||
+        !restoredDataReady
           ? undefined
-          : `${activeToken.entryID}:${restoredSnapshot.scrollTop.toString()}`
+          : `${sidebarActivationID}:${detail.id}:${restoredSnapshot.scrollTop.toString()}`
       }
       onScrollElementChange={(element) => {
         scrollElementRef.current = element;

--- a/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { errorMessage, type TaskDetail } from "@/api";
-import type { TaskDetailInitialFocus } from "@/app-facade";
+import type { SidebarDestination, SidebarTaskDetailSnapshot, TaskDetailInitialFocus } from "@/app-facade";
 import { useAppNavigation, useConnectionSnapshot, useSidebar, useStatusController } from "@/app-facade";
 import { useUpdateTask } from "@/shared/task-mutations";
 import {
@@ -14,6 +14,7 @@ import type { QuestionSelectionState } from "./TaskDetailQuestionState";
 import type { TaskDraft } from "./TaskDetailRows";
 import { useTaskMutations, useTaskDetailLiveRefresh } from "./useTaskDetailData";
 import type { useTaskActivity, useTaskAttention, useTaskComments } from "./useTaskDetailData";
+import { taskDetailSavePending, taskDetailSnapshot } from "./taskDetailSidebarState";
 
 // TaskDraftState tracks the editable title/body draft alongside the server
 // snapshot (`base`) the draft last synced to. Comparing the draft to `base`
@@ -26,6 +27,232 @@ type TaskDraftState = Readonly<{
   draft: TaskDraft;
 }>;
 
+function taskDetailSidebarSnapshot(
+  snapshot: SidebarTaskDetailSnapshot | undefined,
+): SidebarTaskDetailSnapshot | undefined {
+  return snapshot?.kind === "taskDetail" ? snapshot : undefined;
+}
+
+function relatedNewTaskDestination(
+  detail: TaskDetail,
+  direction: "blocked-by" | "blocks",
+): Extract<SidebarDestination, { kind: "newTask" }> {
+  return {
+    boardQueryWorkflowID: detail.workflowID,
+    initialSourceWorkspaceID: detail.sourceWorkspace.id,
+    kind: "newTask",
+    mode: "overlay",
+    pendingRelationship: {
+      originTaskID: detail.id,
+      newTaskRole: direction === "blocked-by" ? "blocker" : "blocked",
+    },
+    projectID: detail.projectID,
+    workflowID: detail.workflowID,
+  };
+}
+
+function relatedTaskDestination(
+  current: Extract<SidebarDestination, { kind: "taskDetail" }>,
+  taskID: string,
+): Extract<SidebarDestination, { kind: "taskDetail" }> {
+  return {
+    kind: "taskDetail",
+    taskID,
+    ...(current.mode === undefined ? {} : { mode: current.mode }),
+    ...(current.onMutated === undefined ? {} : { onMutated: current.onMutated }),
+  };
+}
+
+function initialTaskDraftState(
+  taskID: string,
+  serverDraft: TaskDraft,
+  snapshot: SidebarTaskDetailSnapshot | undefined,
+): TaskDraftState {
+  return { taskID, base: serverDraft, draft: snapshot?.titleBodyDraft ?? serverDraft };
+}
+
+function restoredEditingComment(
+  snapshot: SidebarTaskDetailSnapshot | undefined,
+): Readonly<{ id: string; body: string }> | null {
+  return snapshot?.editedCommentDraft === undefined
+    ? null
+    : { id: snapshot.editedCommentDraft.commentID, body: snapshot.editedCommentDraft.body };
+}
+
+function restoredDescriptionPresentation(
+  snapshot: SidebarTaskDetailSnapshot | undefined,
+): DescriptionPresentationState {
+  return snapshot === undefined
+    ? initialDescriptionPresentationState
+    : { editing: false, expanded: snapshot.descriptionExpanded };
+}
+
+function useTaskDetailSidebarCapture({
+  activeToken,
+  descriptionExpanded,
+  editingComment,
+  newCommentBody,
+  registerSidebarStateCapture,
+  savePending,
+  scrollElementRef,
+  selectedTab,
+  titleBodyDraft,
+}: Readonly<{
+  activeToken: ReturnType<typeof useSidebar>["activeToken"];
+  descriptionExpanded: boolean;
+  editingComment: Readonly<{ id: string; body: string }> | null;
+  newCommentBody: string;
+  registerSidebarStateCapture: ReturnType<typeof useSidebar>["registerSidebarStateCapture"];
+  savePending: boolean;
+  scrollElementRef: Readonly<{ current: HTMLDivElement | null }>;
+  selectedTab: "comments" | "activity";
+  titleBodyDraft: TaskDraft | undefined;
+}>) {
+  useEffect(() => {
+    if (activeToken === null) return;
+    return registerSidebarStateCapture(activeToken, () =>
+      savePending
+        ? null
+        : taskDetailSnapshot({
+            descriptionExpanded,
+            editedCommentDraft:
+              editingComment === null
+                ? undefined
+                : { body: editingComment.body, commentID: editingComment.id },
+            newCommentDraft: newCommentBody,
+            scrollTop: scrollElementRef.current?.scrollTop ?? 0,
+            selectedTab,
+            titleBodyDraft,
+          }),
+    );
+  }, [
+    activeToken,
+    descriptionExpanded,
+    editingComment,
+    newCommentBody,
+    registerSidebarStateCapture,
+    savePending,
+    scrollElementRef,
+    selectedTab,
+    titleBodyDraft,
+  ]);
+}
+
+function useTaskDetailNavigation({
+  activeDestination,
+  detail,
+  navigation,
+  openSidebar,
+  pushSidebar,
+}: Readonly<{
+  activeDestination: SidebarDestination | null;
+  detail: TaskDetail;
+  navigation: ReturnType<typeof useAppNavigation>;
+  openSidebar: ReturnType<typeof useSidebar>["openSidebar"];
+  pushSidebar: ReturnType<typeof useSidebar>["pushSidebar"];
+}>) {
+  const addDependency = useCallback(
+    (direction: "blocked-by" | "blocks") => {
+      const destination = relatedNewTaskDestination(detail, direction);
+      if (activeDestination?.kind === "taskDetail") pushSidebar(destination);
+      else void openSidebar(destination);
+    },
+    [activeDestination, detail, openSidebar, pushSidebar],
+  );
+  const selectDependencyTask = useCallback(
+    (taskID: string) => {
+      if (activeDestination?.kind === "taskDetail") {
+        pushSidebar(relatedTaskDestination(activeDestination, taskID));
+        return;
+      }
+      void navigation.replaceTask(taskID);
+    },
+    [activeDestination, navigation, pushSidebar],
+  );
+  return { addDependency, selectDependencyTask };
+}
+
+function taskDetailRenderState({
+  detail,
+  draftState,
+  loadedTaskID,
+  serverDraft,
+  snapshot,
+}: Readonly<{
+  detail: TaskDetail;
+  draftState: TaskDraftState;
+  loadedTaskID: string;
+  serverDraft: TaskDraft;
+  snapshot: SidebarTaskDetailSnapshot | undefined;
+}>): Readonly<{ changed: boolean; state: TaskDraftState }> {
+  if (loadedTaskID !== detail.id) {
+    return {
+      changed: true,
+      state: initialTaskDraftState(detail.id, serverDraft, snapshot),
+    };
+  }
+  return {
+    changed: false,
+    state: reconcileDraftState(draftState, detail.id, serverDraft),
+  };
+}
+
+function useTaskDetailLocalState(
+  detail: TaskDetail,
+  serverDraft: TaskDraft,
+  snapshot: SidebarTaskDetailSnapshot | undefined,
+) {
+  const [draftState, setDraftState] = useState<TaskDraftState>(() =>
+    initialTaskDraftState(detail.id, serverDraft, snapshot),
+  );
+  const [editingComment, setEditingComment] = useState<Readonly<{ id: string; body: string }> | null>(
+    () => restoredEditingComment(snapshot),
+  );
+  const [newCommentBody, setNewCommentBody] = useState(snapshot?.newCommentDraft ?? "");
+  const [descriptionPresentation, setDescriptionPresentation] = useState<DescriptionPresentationState>(
+    () => restoredDescriptionPresentation(snapshot),
+  );
+  const [selectedTab, setSelectedTab] = useState<"comments" | "activity">(
+    snapshot?.selectedTab ?? "comments",
+  );
+  const [questionSelections, setQuestionSelections] = useState<ReadonlyMap<string, QuestionSelectionState>>(
+    () => new Map(),
+  );
+  const [loadedTaskID, setLoadedTaskID] = useState(detail.id);
+  const { changed: taskChanged, state: reconciled } = taskDetailRenderState({
+    detail,
+    draftState,
+    loadedTaskID,
+    serverDraft,
+    snapshot,
+  });
+  if (taskChanged) {
+    setLoadedTaskID(detail.id);
+    setEditingComment(restoredEditingComment(snapshot));
+    setNewCommentBody(snapshot?.newCommentDraft ?? "");
+    setDescriptionPresentation(restoredDescriptionPresentation(snapshot));
+    setDraftState(reconciled);
+    setSelectedTab(snapshot?.selectedTab ?? "comments");
+    setQuestionSelections(new Map());
+  }
+  if (reconciled !== draftState) setDraftState(reconciled);
+  return {
+    draft: reconciled.draft,
+    draftState: reconciled,
+    editingComment,
+    newCommentBody,
+    descriptionPresentation,
+    questionSelections,
+    selectedTab,
+    setDraftState,
+    setEditingComment,
+    setNewCommentBody,
+    setDescriptionPresentation,
+    setQuestionSelections,
+    setSelectedTab,
+  };
+}
+
 export function TaskDetailContent({
   activity,
   attention,
@@ -34,6 +261,8 @@ export function TaskDetailContent({
   initialFocus,
   onMutated,
   openLink,
+  restoredDataReady,
+  sidebarSnapshot,
 }: Readonly<{
   activity: ReturnType<typeof useTaskActivity>;
   attention: ReturnType<typeof useTaskAttention>;
@@ -42,39 +271,37 @@ export function TaskDetailContent({
   initialFocus?: TaskDetailInitialFocus | undefined;
   onMutated?: (() => void) | undefined;
   openLink: (url: string) => void;
+  restoredDataReady: boolean;
+  sidebarSnapshot?: SidebarTaskDetailSnapshot | undefined;
 }>) {
   const { t } = useTranslation();
   const { push } = useStatusController();
   const navigation = useAppNavigation();
-  const { activeDestination, openSidebar, replaceSidebar } = useSidebar();
+  const {
+    activeDestination,
+    activeToken,
+    pushSidebar,
+    registerSidebarStateCapture,
+    openSidebar,
+  } = useSidebar();
   const serverDraft = taskDraft(detail);
-  const [draftState, setDraftState] = useState<TaskDraftState>(() => ({
-    taskID: detail.id,
-    base: serverDraft,
-    draft: serverDraft,
-  }));
-  const [editingComment, setEditingComment] = useState<Readonly<{ id: string; body: string }> | null>(null);
-  const [newCommentBody, setNewCommentBody] = useState("");
-  const [descriptionPresentation, setDescriptionPresentation] = useState<DescriptionPresentationState>(
-    initialDescriptionPresentationState,
-  );
-  const [selectedTab, setSelectedTab] = useState<"comments" | "activity">("comments");
-  const [questionSelections, setQuestionSelections] = useState<ReadonlyMap<string, QuestionSelectionState>>(
-    () => new Map(),
-  );
-  // When the surface switches to a different task, drop the previous task's
-  // in-progress comment edit, new-comment draft, and question selections so they
-  // don't bleed into the newly loaded task. Reset during render (the React
-  // "adjust state on prop change" pattern) rather than in an effect. The
-  // title/body draft is reconciled separately below via reconcileDraftState.
-  const [loadedTaskID, setLoadedTaskID] = useState(detail.id);
-  if (loadedTaskID !== detail.id) {
-    setLoadedTaskID(detail.id);
-    setEditingComment(null);
-    setNewCommentBody("");
-    setDescriptionPresentation(initialDescriptionPresentationState);
-    setQuestionSelections(new Map());
-  }
+  const restoredSnapshot = taskDetailSidebarSnapshot(sidebarSnapshot);
+  const scrollElementRef = useRef<HTMLDivElement | null>(null);
+  const {
+    draft,
+    draftState,
+    editingComment,
+    newCommentBody,
+    descriptionPresentation,
+    questionSelections,
+    selectedTab,
+    setDraftState,
+    setEditingComment,
+    setNewCommentBody,
+    setDescriptionPresentation,
+    setQuestionSelections,
+    setSelectedTab,
+  } = useTaskDetailLocalState(detail, serverDraft, restoredSnapshot);
   const update = useUpdateTask(detail.id);
   const reportActionError = useCallback(
     (action: "dependency_remove" | "interrupt" | "resume", error: unknown) => {
@@ -100,6 +327,11 @@ export function TaskDetailContent({
     onActionError: reportActionError,
     onChanged: onMutated,
   });
+  const savePending = taskDetailSavePending({
+    addComment: mutations.addComment.isPending,
+    editComment: mutations.replaceComment.isPending,
+    task: update.isPending,
+  });
   const connection = useConnectionSnapshot();
   useTaskDetailLiveRefresh(detail, true);
 
@@ -109,11 +341,19 @@ export function TaskDetailContent({
   // unsaved edits keeps the user's draft so a background refresh never clobbers
   // in-progress work. A draft that has caught up to the server (e.g. after a
   // save) re-baselines so subsequent server changes are followed again.
-  const reconciled = reconcileDraftState(draftState, detail.id, serverDraft);
-  if (reconciled !== draftState) {
-    setDraftState(reconciled);
-  }
-  const draft = reconciled.draft;
+  const reconciled = draftState;
+
+  useTaskDetailSidebarCapture({
+    activeToken,
+    descriptionExpanded: descriptionPresentation.expanded,
+    editingComment,
+    newCommentBody,
+    registerSidebarStateCapture,
+    savePending,
+    scrollElementRef,
+    selectedTab,
+    titleBodyDraft: sameDraft(reconciled.draft, reconciled.base) ? undefined : reconciled.draft,
+  });
 
   async function saveDraft(nextDraft: TaskDraft = draft): Promise<void> {
     await update.mutateAsync({
@@ -123,6 +363,13 @@ export function TaskDetailContent({
     });
     onMutated?.();
   }
+  const { addDependency, selectDependencyTask } = useTaskDetailNavigation({
+    activeDestination,
+    detail,
+    navigation,
+    openSidebar,
+    pushSidebar,
+  });
 
   return (
     <TaskDetailList
@@ -131,6 +378,7 @@ export function TaskDetailContent({
       comments={comments}
       detail={detail}
       disabled={connection.phase !== "connected"}
+      dependencyDisabled={connection.phase !== "connected" || savePending}
       draft={draft}
       descriptionPresentation={descriptionPresentation}
       editingComment={editingComment}
@@ -141,40 +389,11 @@ export function TaskDetailContent({
         setDraftState({ taskID: detail.id, base: reconciled.base, draft: nextDraft });
       }}
       onDescriptionPresentationChange={setDescriptionPresentation}
-      onAddDependency={(direction) => {
-        const destination = {
-          boardQueryWorkflowID: detail.workflowID,
-          initialSourceWorkspaceID: detail.sourceWorkspace.id,
-          kind: "newTask" as const,
-          mode: "overlay" as const,
-          pendingRelationship: {
-            originTaskID: detail.id,
-            newTaskRole: direction === "blocked-by" ? ("blocker" as const) : ("blocked" as const),
-          },
-          projectID: detail.projectID,
-          workflowID: detail.workflowID,
-        };
-        if (activeDestination?.kind === "taskDetail") {
-          replaceSidebar(destination);
-        } else {
-          void openSidebar(destination);
-        }
-      }}
+      onAddDependency={addDependency}
       onRemoveDependency={(pair) => {
         mutations.removeDependency.mutate(pair);
       }}
-      onSelectDependencyTask={(taskID) => {
-        if (activeDestination?.kind === "taskDetail") {
-          replaceSidebar({
-            kind: "taskDetail",
-            taskID,
-            ...(activeDestination.mode === undefined ? {} : { mode: activeDestination.mode }),
-            ...(activeDestination.onMutated === undefined ? {} : { onMutated: activeDestination.onMutated }),
-          });
-          return;
-        }
-        void navigation.replaceTask(taskID);
-      }}
+      onSelectDependencyTask={selectDependencyTask}
       onNewCommentBodyChange={setNewCommentBody}
       onEditingCommentChange={setEditingComment}
       onQuestionSelectionChange={(askID, selection) => {
@@ -187,6 +406,15 @@ export function TaskDetailContent({
       setTab={setSelectedTab}
       updateError={update.error}
       updatePending={update.isPending}
+      initialScrollOffset={restoredSnapshot?.scrollTop}
+      initialScrollOffsetRequestKey={
+        activeToken === null
+          ? undefined
+          : `${activeToken.entryID}:${restoredDataReady ? "ready" : "loading"}`
+      }
+      onScrollElementChange={(element) => {
+        scrollElementRef.current = element;
+      }}
     />
   );
 }

--- a/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
@@ -14,7 +14,11 @@ import type { QuestionSelectionState } from "./TaskDetailQuestionState";
 import type { TaskDraft } from "./TaskDetailRows";
 import { useTaskMutations, useTaskDetailLiveRefresh } from "./useTaskDetailData";
 import type { useTaskActivity, useTaskAttention, useTaskComments } from "./useTaskDetailData";
-import { taskDetailSavePending, taskDetailSnapshot } from "./taskDetailSidebarState";
+import {
+  taskDetailSavePending,
+  taskDetailSnapshot,
+  type TaskDetailSidebarState,
+} from "./taskDetailSidebarState";
 
 // TaskDraftState tracks the editable title/body draft alongside the server
 // snapshot (`base`) the draft last synced to. Comparing the draft to `base`
@@ -95,6 +99,7 @@ function useTaskDetailSidebarCapture({
   editingComment,
   newCommentBody,
   registerSidebarStateCapture,
+  restoredDataReady,
   savePending,
   scrollElementRef,
   selectedTab,
@@ -105,13 +110,14 @@ function useTaskDetailSidebarCapture({
   editingComment: Readonly<{ id: string; body: string }> | null;
   newCommentBody: string;
   registerSidebarStateCapture: ReturnType<typeof useSidebar>["registerSidebarStateCapture"];
+  restoredDataReady: boolean;
   savePending: boolean;
   scrollElementRef: Readonly<{ current: HTMLDivElement | null }>;
   selectedTab: "comments" | "activity";
   titleBodyDraft: TaskDraft | undefined;
 }>) {
   useEffect(() => {
-    if (activeToken === null) return;
+    if (activeToken === null || !restoredDataReady) return;
     return registerSidebarStateCapture(activeToken, () =>
       savePending
         ? null
@@ -133,6 +139,7 @@ function useTaskDetailSidebarCapture({
     editingComment,
     newCommentBody,
     registerSidebarStateCapture,
+    restoredDataReady,
     savePending,
     scrollElementRef,
     selectedTab,
@@ -262,9 +269,8 @@ export function TaskDetailContent({
   initialFocus,
   onMutated,
   openLink,
-  sidebarActivationID,
+  sidebarState,
   restoredDataReady,
-  sidebarSnapshot,
 }: Readonly<{
   activity: ReturnType<typeof useTaskActivity>;
   attention: ReturnType<typeof useTaskAttention>;
@@ -273,9 +279,8 @@ export function TaskDetailContent({
   initialFocus?: TaskDetailInitialFocus | undefined;
   onMutated?: (() => void) | undefined;
   openLink: (url: string) => void;
-  sidebarActivationID?: string | null | undefined;
+  sidebarState?: TaskDetailSidebarState | undefined;
   restoredDataReady: boolean;
-  sidebarSnapshot?: SidebarTaskDetailSnapshot | undefined;
 }>) {
   const { t } = useTranslation();
   const { push } = useStatusController();
@@ -287,11 +292,10 @@ export function TaskDetailContent({
     registerSidebarStateCapture,
     openSidebar,
   } = useSidebar();
-  const activeSidebarActivationID = sidebarActivationID ?? undefined;
-  const isSidebarSurface = activeSidebarActivationID !== undefined;
+  const isSidebarSurface = sidebarState !== undefined;
   const activeToken = isSidebarSurface ? sidebarActiveToken : null;
   const serverDraft = taskDraft(detail);
-  const restoredSnapshot = sidebarSnapshot;
+  const restoredSnapshot = sidebarState?.snapshot;
   const scrollElementRef = useRef<HTMLDivElement | null>(null);
   const {
     draft,
@@ -355,6 +359,7 @@ export function TaskDetailContent({
     editingComment,
     newCommentBody,
     registerSidebarStateCapture,
+    restoredDataReady,
     savePending,
     scrollElementRef,
     selectedTab,
@@ -422,7 +427,7 @@ export function TaskDetailContent({
         restoredSnapshot === undefined ||
         !restoredDataReady
           ? undefined
-          : `${activeSidebarActivationID}:${detail.id}:${restoredSnapshot.scrollTop.toString()}`
+          : `${sidebarState.activationID}:${detail.id}:${restoredSnapshot.scrollTop.toString()}`
       }
       onScrollElementChange={(element) => {
         scrollElementRef.current = element;

--- a/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
@@ -27,12 +27,6 @@ type TaskDraftState = Readonly<{
   draft: TaskDraft;
 }>;
 
-function taskDetailSidebarSnapshot(
-  snapshot: SidebarTaskDetailSnapshot | undefined,
-): SidebarTaskDetailSnapshot | undefined {
-  return snapshot?.kind === "taskDetail" ? snapshot : undefined;
-}
-
 function relatedNewTaskDestination(
   detail: TaskDetail,
   direction: "blocked-by" | "blocks",
@@ -141,12 +135,14 @@ function useTaskDetailSidebarCapture({
 function useTaskDetailNavigation({
   activeDestination,
   detail,
+  isSidebarSurface,
   navigation,
   openSidebar,
   pushSidebar,
 }: Readonly<{
   activeDestination: SidebarDestination | null;
   detail: TaskDetail;
+  isSidebarSurface: boolean;
   navigation: ReturnType<typeof useAppNavigation>;
   openSidebar: ReturnType<typeof useSidebar>["openSidebar"];
   pushSidebar: ReturnType<typeof useSidebar>["pushSidebar"];
@@ -154,20 +150,20 @@ function useTaskDetailNavigation({
   const addDependency = useCallback(
     (direction: "blocked-by" | "blocks") => {
       const destination = relatedNewTaskDestination(detail, direction);
-      if (activeDestination?.kind === "taskDetail") pushSidebar(destination);
+      if (isSidebarSurface && activeDestination?.kind === "taskDetail") pushSidebar(destination);
       else void openSidebar(destination);
     },
-    [activeDestination, detail, openSidebar, pushSidebar],
+    [activeDestination, detail, isSidebarSurface, openSidebar, pushSidebar],
   );
   const selectDependencyTask = useCallback(
     (taskID: string) => {
-      if (activeDestination?.kind === "taskDetail") {
+      if (isSidebarSurface && activeDestination?.kind === "taskDetail") {
         pushSidebar(relatedTaskDestination(activeDestination, taskID));
         return;
       }
       void navigation.replaceTask(taskID);
     },
-    [activeDestination, navigation, pushSidebar],
+    [activeDestination, isSidebarSurface, navigation, pushSidebar],
   );
   return { addDependency, selectDependencyTask };
 }
@@ -205,12 +201,12 @@ function useTaskDetailLocalState(
   const [draftState, setDraftState] = useState<TaskDraftState>(() =>
     initialTaskDraftState(detail.id, serverDraft, snapshot),
   );
-  const [editingComment, setEditingComment] = useState<Readonly<{ id: string; body: string }> | null>(
-    () => restoredEditingComment(snapshot),
+  const [editingComment, setEditingComment] = useState<Readonly<{ id: string; body: string }> | null>(() =>
+    restoredEditingComment(snapshot),
   );
   const [newCommentBody, setNewCommentBody] = useState(snapshot?.newCommentDraft ?? "");
-  const [descriptionPresentation, setDescriptionPresentation] = useState<DescriptionPresentationState>(
-    () => restoredDescriptionPresentation(snapshot),
+  const [descriptionPresentation, setDescriptionPresentation] = useState<DescriptionPresentationState>(() =>
+    restoredDescriptionPresentation(snapshot),
   );
   const [selectedTab, setSelectedTab] = useState<"comments" | "activity">(
     snapshot?.selectedTab ?? "comments",
@@ -281,13 +277,15 @@ export function TaskDetailContent({
   const navigation = useAppNavigation();
   const {
     activeDestination,
-    activeToken,
+    activeToken: sidebarActiveToken,
     pushSidebar,
     registerSidebarStateCapture,
     openSidebar,
   } = useSidebar();
+  const isSidebarSurface = sidebarActivationID !== null && sidebarActivationID !== undefined;
+  const activeToken = isSidebarSurface ? sidebarActiveToken : null;
   const serverDraft = taskDraft(detail);
-  const restoredSnapshot = taskDetailSidebarSnapshot(sidebarSnapshot);
+  const restoredSnapshot = sidebarSnapshot;
   const scrollElementRef = useRef<HTMLDivElement | null>(null);
   const {
     draft,
@@ -368,6 +366,7 @@ export function TaskDetailContent({
   const { addDependency, selectDependencyTask } = useTaskDetailNavigation({
     activeDestination,
     detail,
+    isSidebarSurface,
     navigation,
     openSidebar,
     pushSidebar,

--- a/apps/desktop/src/features/task-detail/TaskDetailList.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailList.tsx
@@ -45,6 +45,7 @@ export function TaskDetailList({
   detail,
   disabled,
   dependencyDisabled,
+  dependencyRemoveDisabled,
   draft,
   descriptionPresentation,
   editingComment,
@@ -76,6 +77,7 @@ export function TaskDetailList({
   detail: TaskDetail;
   disabled: boolean;
   dependencyDisabled: boolean;
+  dependencyRemoveDisabled: boolean;
   draft: TaskDraft;
   descriptionPresentation: DescriptionPresentationState;
   editingComment: Readonly<{ id: string; body: string }> | null;
@@ -201,6 +203,7 @@ export function TaskDetailList({
           detail={detail}
           disabled={disabled}
           dependencyDisabled={dependencyDisabled}
+          dependencyRemoveDisabled={dependencyRemoveDisabled}
           draft={draft}
           descriptionPresentation={descriptionPresentation}
           editingComment={editingComment}
@@ -243,6 +246,7 @@ type TaskDetailListRowProps = Readonly<{
   detail: TaskDetail;
   disabled: boolean;
   dependencyDisabled: boolean;
+  dependencyRemoveDisabled: boolean;
   draft: TaskDraft;
   draftDirty: boolean;
   descriptionPresentation: DescriptionPresentationState;
@@ -358,6 +362,7 @@ function BodyRow({
 function DependenciesRow({
   detail,
   dependencyDisabled,
+  dependencyRemoveDisabled,
   onAddDependency,
   onRemoveDependency,
   onSelectDependencyTask,
@@ -369,6 +374,7 @@ function DependenciesRow({
       onAdd={onAddDependency}
       onRemove={onRemoveDependency}
       onSelectTask={onSelectDependencyTask}
+      removeDisabled={dependencyRemoveDisabled}
       taskID={detail.id}
     />
   );

--- a/apps/desktop/src/features/task-detail/TaskDetailList.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailList.tsx
@@ -44,6 +44,7 @@ export function TaskDetailList({
   comments,
   detail,
   disabled,
+  dependencyDisabled,
   draft,
   descriptionPresentation,
   editingComment,
@@ -65,12 +66,16 @@ export function TaskDetailList({
   setTab,
   updateError,
   updatePending,
+  initialScrollOffset,
+  initialScrollOffsetRequestKey,
+  onScrollElementChange,
 }: Readonly<{
   activity: ReturnType<typeof useTaskActivity>;
   attention: ReturnType<typeof useTaskAttention>;
   comments: ReturnType<typeof useTaskComments>;
   detail: TaskDetail;
   disabled: boolean;
+  dependencyDisabled: boolean;
   draft: TaskDraft;
   descriptionPresentation: DescriptionPresentationState;
   editingComment: Readonly<{ id: string; body: string }> | null;
@@ -92,6 +97,9 @@ export function TaskDetailList({
   setTab: (tab: DetailTab) => void;
   updateError: unknown;
   updatePending: boolean;
+  initialScrollOffset?: number | undefined;
+  initialScrollOffsetRequestKey?: string | undefined;
+  onScrollElementChange: (element: HTMLDivElement | null) => void;
 }>) {
   const { t } = useTranslation();
   const headerOffset = useSidebarHeaderOffset();
@@ -170,12 +178,15 @@ export function TaskDetailList({
       initialScrollRequestKey={
         initialFocus !== undefined ? taskDetailInitialFocusRequestKey(detail.id, initialFocus) : undefined
       }
+      initialScrollOffset={initialScrollOffset}
+      initialScrollOffsetRequestKey={initialScrollOffsetRequestKey}
       isFetchingNextPage={paging.isFetchingNextPage}
       items={listItems}
       loadingLabel={t("app.loadingMore")}
       loadMoreKey={paging.loadMoreKey}
       nonAdjustingResizeItemKey="body"
       onLoadMore={paging.loadMore}
+      onScrollElementChange={onScrollElementChange}
       paddingStart={headerOffset}
       pinnedItemKeys={pinnedItemKeys}
       rowSpacing="compact"
@@ -189,6 +200,7 @@ export function TaskDetailList({
           draftDirty={draftDirty}
           detail={detail}
           disabled={disabled}
+          dependencyDisabled={dependencyDisabled}
           draft={draft}
           descriptionPresentation={descriptionPresentation}
           editingComment={editingComment}
@@ -230,6 +242,7 @@ type TaskDetailListRowProps = Readonly<{
   commentCount: number;
   detail: TaskDetail;
   disabled: boolean;
+  dependencyDisabled: boolean;
   draft: TaskDraft;
   draftDirty: boolean;
   descriptionPresentation: DescriptionPresentationState;
@@ -344,7 +357,7 @@ function BodyRow({
 
 function DependenciesRow({
   detail,
-  disabled,
+  dependencyDisabled,
   onAddDependency,
   onRemoveDependency,
   onSelectDependencyTask,
@@ -352,7 +365,7 @@ function DependenciesRow({
   return (
     <TaskDependenciesArea
       dependencies={detail.dependencies}
-      disabled={disabled}
+      disabled={dependencyDisabled}
       onAdd={onAddDependency}
       onRemove={onRemoveDependency}
       onSelectTask={onSelectDependencyTask}

--- a/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
@@ -246,7 +246,6 @@ function DescriptionReadView({
     <div className="relative min-w-0">
       <div
         aria-label={t("task.description")}
-        aria-expanded={expanded}
         aria-readonly
         className={cx(
           fieldIslandInputClassName(1),
@@ -290,6 +289,7 @@ function DescriptionReadView({
             data-testid="task-description-fade"
           />
           <button
+            aria-expanded={expanded}
             aria-label={t("app.expand")}
             className={cx(
               "app-region-no-drag absolute inset-x-0 bottom-0 grid h-10 place-items-center text-[var(--color-on-island)] transition-opacity motion-reduce:transition-none",

--- a/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
@@ -246,6 +246,7 @@ function DescriptionReadView({
     <div className="relative min-w-0">
       <div
         aria-label={t("task.description")}
+        aria-expanded={expanded}
         aria-readonly
         className={cx(
           fieldIslandInputClassName(1),

--- a/apps/desktop/src/features/task-detail/TaskDetailSurface.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailSurface.tsx
@@ -8,6 +8,7 @@ import { useStatusController } from "@/app-facade";
 import { ProjectLabelsProvider, TaskLabelAssignmentProvider, useProjectLabelCatalog } from "@/shared/labels";
 import { ErrorState, LoadingState } from "@/ui";
 import { TaskDetailContent } from "./TaskDetailContent";
+import { taskDetailSidebarState } from "./taskDetailSidebarState";
 import { useTaskActivity, useTaskAttention, useTaskComments, useTaskDetail } from "./useTaskDetailData";
 
 export type TaskDetailSurfaceProps = Readonly<{
@@ -48,8 +49,8 @@ export function TaskDetailSurface({
   const activity = useTaskActivity(taskId, enabled);
   const comments = useTaskComments(taskId, enabled);
   const openLink = useOpenExternalLink();
-  const restoringSidebar =
-    sidebarSnapshot !== undefined && sidebarActivationID !== null && sidebarActivationID !== undefined;
+  const sidebarState = taskDetailSidebarState(sidebarActivationID, sidebarSnapshot);
+  const restoringSidebar = sidebarState?.snapshot !== undefined;
   const missingTask = detail.isError && isWorkflowTaskNotFound(detail.error);
   useEffect(() => {
     if (missingTask) {
@@ -74,12 +75,11 @@ export function TaskDetailSurface({
           initialFocus={initialFocus}
           onMutated={onMutated}
           openLink={openLink}
-          sidebarActivationID={sidebarActivationID}
+          sidebarState={sidebarState}
           restoredDataReady={
             !restoringSidebar ||
             (!detail.isFetching && !attention.isFetching && !activity.isFetching && !comments.isFetching)
           }
-          sidebarSnapshot={sidebarSnapshot}
         />
       </TaskDetailAssignmentScope>
     </ProjectLabelsProvider>

--- a/apps/desktop/src/features/task-detail/TaskDetailSurface.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailSurface.tsx
@@ -13,6 +13,7 @@ import { useTaskActivity, useTaskAttention, useTaskComments, useTaskDetail } fro
 export type TaskDetailSurfaceProps = Readonly<{
   taskId: string;
   enabled: boolean;
+  sidebarActivationID?: string | null | undefined;
   initialFocus?: TaskDetailInitialFocus | undefined;
   onMutated?: (() => void) | undefined;
   sidebarSnapshot?: SidebarTaskDetailSnapshot | undefined;
@@ -22,6 +23,7 @@ export type TaskDetailSurfaceProps = Readonly<{
 export function TaskDetailSurface({
   taskId,
   enabled,
+  sidebarActivationID,
   initialFocus,
   onMutated,
   sidebarSnapshot,
@@ -46,45 +48,17 @@ export function TaskDetailSurface({
   const activity = useTaskActivity(taskId, enabled);
   const comments = useTaskComments(taskId, enabled);
   const openLink = useOpenExternalLink();
-  const refetchDetail = detail.refetch;
-  const refetchAttention = attention.refetch;
-  const refetchActivity = activity.refetch;
-  const refetchComments = comments.refetch;
-  const restorationSnapshotKey =
-    sidebarSnapshot === undefined ? null : JSON.stringify(sidebarSnapshot);
-  const [completedRestorationSnapshotKey, setCompletedRestorationSnapshotKey] = useState<string | null>(null);
-  useEffect(() => {
-    if (restorationSnapshotKey === null) {
-      return;
-    }
-    let canceled = false;
-    void Promise.all([
-      refetchDetail(),
-      refetchAttention(),
-      refetchActivity(),
-      refetchComments(),
-    ]).then(
-      () => {
-        if (!canceled) {
-          setCompletedRestorationSnapshotKey(restorationSnapshotKey);
-        }
-      },
-      () => {
-        if (!canceled) {
-          setCompletedRestorationSnapshotKey(restorationSnapshotKey);
-        }
-      },
-    );
-    return () => {
-      canceled = true;
-    };
-  }, [
-    refetchActivity,
-    refetchAttention,
-    refetchComments,
-    refetchDetail,
-    restorationSnapshotKey,
-  ]);
+  const restorationActivationKey =
+    sidebarSnapshot === undefined || sidebarActivationID === null || sidebarActivationID === undefined
+      ? null
+      : `${sidebarActivationID}:${taskId}`;
+  const restoredDataRefreshComplete = useTaskDetailRestorationRefresh({
+    activationKey: restorationActivationKey,
+    refetchActivity: activity.refetch,
+    refetchAttention: attention.refetch,
+    refetchComments: comments.refetch,
+    refetchDetail: detail.refetch,
+  });
   const missingTask = detail.isError && isWorkflowTaskNotFound(detail.error);
   useEffect(() => {
     if (missingTask) {
@@ -109,9 +83,9 @@ export function TaskDetailSurface({
           initialFocus={initialFocus}
           onMutated={onMutated}
           openLink={openLink}
+          sidebarActivationID={sidebarActivationID}
           restoredDataReady={
-            (restorationSnapshotKey === null ||
-              completedRestorationSnapshotKey === restorationSnapshotKey) &&
+            restoredDataRefreshComplete &&
             !detail.isFetching &&
             !attention.isFetching &&
             !activity.isFetching &&
@@ -140,6 +114,46 @@ export function TaskDetailSurface({
       <div className="min-h-0">{content}</div>
     </div>
   );
+}
+
+type RestorationRefetch = () => Promise<unknown>;
+
+function useTaskDetailRestorationRefresh({
+  activationKey,
+  refetchActivity,
+  refetchAttention,
+  refetchComments,
+  refetchDetail,
+}: Readonly<{
+  activationKey: string | null;
+  refetchActivity: RestorationRefetch;
+  refetchAttention: RestorationRefetch;
+  refetchComments: RestorationRefetch;
+  refetchDetail: RestorationRefetch;
+}>): boolean {
+  const [completedActivationKey, setCompletedActivationKey] = useState<string | null>(null);
+  useEffect(() => {
+    if (activationKey === null) {
+      return;
+    }
+    let canceled = false;
+    void Promise.all([refetchDetail(), refetchAttention(), refetchActivity(), refetchComments()]).then(
+      () => {
+        if (!canceled) {
+          setCompletedActivationKey(activationKey);
+        }
+      },
+      () => {
+        if (!canceled) {
+          setCompletedActivationKey(activationKey);
+        }
+      },
+    );
+    return () => {
+      canceled = true;
+    };
+  }, [activationKey, refetchActivity, refetchAttention, refetchComments, refetchDetail]);
+  return activationKey === null || completedActivationKey === activationKey;
 }
 
 function isWorkflowTaskNotFound(error: unknown): boolean {

--- a/apps/desktop/src/features/task-detail/TaskDetailSurface.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailSurface.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import { errorMessage, rpcErrorCodes, RpcError, type TaskDetail, type TaskLabelAssignment } from "@/api";
@@ -46,6 +46,45 @@ export function TaskDetailSurface({
   const activity = useTaskActivity(taskId, enabled);
   const comments = useTaskComments(taskId, enabled);
   const openLink = useOpenExternalLink();
+  const refetchDetail = detail.refetch;
+  const refetchAttention = attention.refetch;
+  const refetchActivity = activity.refetch;
+  const refetchComments = comments.refetch;
+  const restorationSnapshotKey =
+    sidebarSnapshot === undefined ? null : JSON.stringify(sidebarSnapshot);
+  const [completedRestorationSnapshotKey, setCompletedRestorationSnapshotKey] = useState<string | null>(null);
+  useEffect(() => {
+    if (restorationSnapshotKey === null) {
+      return;
+    }
+    let canceled = false;
+    void Promise.all([
+      refetchDetail(),
+      refetchAttention(),
+      refetchActivity(),
+      refetchComments(),
+    ]).then(
+      () => {
+        if (!canceled) {
+          setCompletedRestorationSnapshotKey(restorationSnapshotKey);
+        }
+      },
+      () => {
+        if (!canceled) {
+          setCompletedRestorationSnapshotKey(restorationSnapshotKey);
+        }
+      },
+    );
+    return () => {
+      canceled = true;
+    };
+  }, [
+    refetchActivity,
+    refetchAttention,
+    refetchComments,
+    refetchDetail,
+    restorationSnapshotKey,
+  ]);
   const missingTask = detail.isError && isWorkflowTaskNotFound(detail.error);
   useEffect(() => {
     if (missingTask) {
@@ -71,6 +110,8 @@ export function TaskDetailSurface({
           onMutated={onMutated}
           openLink={openLink}
           restoredDataReady={
+            (restorationSnapshotKey === null ||
+              completedRestorationSnapshotKey === restorationSnapshotKey) &&
             !detail.isFetching &&
             !attention.isFetching &&
             !activity.isFetching &&

--- a/apps/desktop/src/features/task-detail/TaskDetailSurface.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailSurface.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import { errorMessage, rpcErrorCodes, RpcError, type TaskDetail, type TaskLabelAssignment } from "@/api";
@@ -48,17 +48,8 @@ export function TaskDetailSurface({
   const activity = useTaskActivity(taskId, enabled);
   const comments = useTaskComments(taskId, enabled);
   const openLink = useOpenExternalLink();
-  const restorationActivationKey =
-    sidebarSnapshot === undefined || sidebarActivationID === null || sidebarActivationID === undefined
-      ? null
-      : `${sidebarActivationID}:${taskId}`;
-  const restoredDataRefreshComplete = useTaskDetailRestorationRefresh({
-    activationKey: restorationActivationKey,
-    refetchActivity: activity.refetch,
-    refetchAttention: attention.refetch,
-    refetchComments: comments.refetch,
-    refetchDetail: detail.refetch,
-  });
+  const restoringSidebar =
+    sidebarSnapshot !== undefined && sidebarActivationID !== null && sidebarActivationID !== undefined;
   const missingTask = detail.isError && isWorkflowTaskNotFound(detail.error);
   useEffect(() => {
     if (missingTask) {
@@ -85,11 +76,8 @@ export function TaskDetailSurface({
           openLink={openLink}
           sidebarActivationID={sidebarActivationID}
           restoredDataReady={
-            restoredDataRefreshComplete &&
-            !detail.isFetching &&
-            !attention.isFetching &&
-            !activity.isFetching &&
-            !comments.isFetching
+            !restoringSidebar ||
+            (!detail.isFetching && !attention.isFetching && !activity.isFetching && !comments.isFetching)
           }
           sidebarSnapshot={sidebarSnapshot}
         />
@@ -114,46 +102,6 @@ export function TaskDetailSurface({
       <div className="min-h-0">{content}</div>
     </div>
   );
-}
-
-type RestorationRefetch = () => Promise<unknown>;
-
-function useTaskDetailRestorationRefresh({
-  activationKey,
-  refetchActivity,
-  refetchAttention,
-  refetchComments,
-  refetchDetail,
-}: Readonly<{
-  activationKey: string | null;
-  refetchActivity: RestorationRefetch;
-  refetchAttention: RestorationRefetch;
-  refetchComments: RestorationRefetch;
-  refetchDetail: RestorationRefetch;
-}>): boolean {
-  const [completedActivationKey, setCompletedActivationKey] = useState<string | null>(null);
-  useEffect(() => {
-    if (activationKey === null) {
-      return;
-    }
-    let canceled = false;
-    void Promise.all([refetchDetail(), refetchAttention(), refetchActivity(), refetchComments()]).then(
-      () => {
-        if (!canceled) {
-          setCompletedActivationKey(activationKey);
-        }
-      },
-      () => {
-        if (!canceled) {
-          setCompletedActivationKey(activationKey);
-        }
-      },
-    );
-    return () => {
-      canceled = true;
-    };
-  }, [activationKey, refetchActivity, refetchAttention, refetchComments, refetchDetail]);
-  return activationKey === null || completedActivationKey === activationKey;
 }
 
 function isWorkflowTaskNotFound(error: unknown): boolean {

--- a/apps/desktop/src/features/task-detail/TaskDetailSurface.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailSurface.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useMemo, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
-import { errorMessage, type TaskDetail, type TaskLabelAssignment } from "@/api";
+import { errorMessage, rpcErrorCodes, RpcError, type TaskDetail, type TaskLabelAssignment } from "@/api";
 import { useOpenExternalLink } from "@/app-facade";
-import type { TaskDetailInitialFocus } from "@/app-facade";
+import type { SidebarTaskDetailSnapshot, TaskDetailInitialFocus } from "@/app-facade";
 import { useStatusController } from "@/app-facade";
 import { ProjectLabelsProvider, TaskLabelAssignmentProvider, useProjectLabelCatalog } from "@/shared/labels";
 import { ErrorState, LoadingState } from "@/ui";
@@ -15,9 +15,18 @@ export type TaskDetailSurfaceProps = Readonly<{
   enabled: boolean;
   initialFocus?: TaskDetailInitialFocus | undefined;
   onMutated?: (() => void) | undefined;
+  sidebarSnapshot?: SidebarTaskDetailSnapshot | undefined;
+  onMissingTask?: (() => void) | undefined;
 }>;
 
-export function TaskDetailSurface({ taskId, enabled, initialFocus, onMutated }: TaskDetailSurfaceProps) {
+export function TaskDetailSurface({
+  taskId,
+  enabled,
+  initialFocus,
+  onMutated,
+  sidebarSnapshot,
+  onMissingTask,
+}: TaskDetailSurfaceProps) {
   const { t } = useTranslation();
   const { push } = useStatusController();
   const reportLabelError = useCallback(
@@ -37,6 +46,12 @@ export function TaskDetailSurface({ taskId, enabled, initialFocus, onMutated }: 
   const activity = useTaskActivity(taskId, enabled);
   const comments = useTaskComments(taskId, enabled);
   const openLink = useOpenExternalLink();
+  const missingTask = detail.isError && isWorkflowTaskNotFound(detail.error);
+  useEffect(() => {
+    if (missingTask) {
+      onMissingTask?.();
+    }
+  }, [missingTask, onMissingTask]);
 
   if (detail.isPending) {
     return <LoadingState appearanceDelayMs={0} fullPage={false} reveal={false} title={t("states.loading")} />;
@@ -55,6 +70,13 @@ export function TaskDetailSurface({ taskId, enabled, initialFocus, onMutated }: 
           initialFocus={initialFocus}
           onMutated={onMutated}
           openLink={openLink}
+          restoredDataReady={
+            !detail.isFetching &&
+            !attention.isFetching &&
+            !activity.isFetching &&
+            !comments.isFetching
+          }
+          sidebarSnapshot={sidebarSnapshot}
         />
       </TaskDetailAssignmentScope>
     </ProjectLabelsProvider>
@@ -77,6 +99,10 @@ export function TaskDetailSurface({ taskId, enabled, initialFocus, onMutated }: 
       <div className="min-h-0">{content}</div>
     </div>
   );
+}
+
+function isWorkflowTaskNotFound(error: unknown): boolean {
+  return error instanceof RpcError && error.code === rpcErrorCodes.workflowTaskNotFound;
 }
 
 function TaskDetailAssignmentScope({

--- a/apps/desktop/src/features/task-detail/TaskDetailTabs.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailTabs.tsx
@@ -22,8 +22,8 @@ export function TaskTabs({
         ariaLabel={t("task.title")}
         className="grid-cols-2"
         items={[
-          { label: t("task.comments"), meta: commentCount, value: "comments" },
-          { label: t("task.activity"), value: "activity" },
+          { label: t("task.comments"), meta: commentCount, testId: "task-tab-comments", value: "comments" },
+          { label: t("task.activity"), testId: "task-tab-activity", value: "activity" },
         ]}
         onValueChange={onSelect}
         value={selected}

--- a/apps/desktop/src/features/task-detail/taskDetailSidebarState.test.ts
+++ b/apps/desktop/src/features/task-detail/taskDetailSidebarState.test.ts
@@ -1,0 +1,55 @@
+import { taskDetailSavePending, taskDetailSnapshot } from "./taskDetailSidebarState";
+
+describe("task detail sidebar state", () => {
+  it("blocks state-retaining navigation while any approved save is pending", () => {
+    expect(
+      taskDetailSavePending({
+        task: true,
+        addComment: false,
+        editComment: false,
+      }),
+    ).toBe(true);
+    expect(
+      taskDetailSavePending({
+        task: false,
+        addComment: true,
+        editComment: false,
+      }),
+    ).toBe(true);
+    expect(
+      taskDetailSavePending({
+        task: false,
+        addComment: false,
+        editComment: true,
+      }),
+    ).toBe(true);
+    expect(
+      taskDetailSavePending({
+        task: false,
+        addComment: false,
+        editComment: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("retains only approved presentation and unsent draft state", () => {
+    expect(
+      taskDetailSnapshot({
+        scrollTop: 123,
+        descriptionExpanded: true,
+        selectedTab: "activity",
+        titleBodyDraft: { title: "Draft title", body: "Draft body" },
+        newCommentDraft: "Unsaved comment",
+        editedCommentDraft: { commentID: "comment-1", body: "Edited comment" },
+      }),
+    ).toEqual({
+      kind: "taskDetail",
+      scrollTop: 123,
+      descriptionExpanded: true,
+      selectedTab: "activity",
+      titleBodyDraft: { title: "Draft title", body: "Draft body" },
+      newCommentDraft: "Unsaved comment",
+      editedCommentDraft: { commentID: "comment-1", body: "Edited comment" },
+    });
+  });
+});

--- a/apps/desktop/src/features/task-detail/taskDetailSidebarState.test.ts
+++ b/apps/desktop/src/features/task-detail/taskDetailSidebarState.test.ts
@@ -1,4 +1,4 @@
-import { taskDetailSavePending, taskDetailSnapshot } from "./taskDetailSidebarState";
+import { taskDetailSavePending, taskDetailSidebarState, taskDetailSnapshot } from "./taskDetailSidebarState";
 
 describe("task detail sidebar state", () => {
   it("blocks state-retaining navigation while any approved save is pending", () => {
@@ -50,6 +50,24 @@ describe("task detail sidebar state", () => {
       titleBodyDraft: { title: "Draft title", body: "Draft body" },
       newCommentDraft: "Unsaved comment",
       editedCommentDraft: { commentID: "comment-1", body: "Edited comment" },
+    });
+  });
+
+  it("normalizes sidebar restoration presence around the activation ID", () => {
+    const snapshot = taskDetailSnapshot({
+      scrollTop: 32,
+      descriptionExpanded: false,
+      selectedTab: "comments",
+    });
+
+    expect(taskDetailSidebarState(undefined, snapshot)).toBeUndefined();
+    expect(taskDetailSidebarState(null, snapshot)).toBeUndefined();
+    expect(taskDetailSidebarState("activation-1", undefined)).toEqual({
+      activationID: "activation-1",
+    });
+    expect(taskDetailSidebarState("activation-1", snapshot)).toEqual({
+      activationID: "activation-1",
+      snapshot,
     });
   });
 });

--- a/apps/desktop/src/features/task-detail/taskDetailSidebarState.ts
+++ b/apps/desktop/src/features/task-detail/taskDetailSidebarState.ts
@@ -1,5 +1,20 @@
 import type { SidebarTaskDetailSnapshot } from "@/app-facade";
 
+export type TaskDetailSidebarState = Readonly<{
+  activationID: string;
+  snapshot?: SidebarTaskDetailSnapshot;
+}>;
+
+export function taskDetailSidebarState(
+  activationID: string | null | undefined,
+  snapshot: SidebarTaskDetailSnapshot | undefined,
+): TaskDetailSidebarState | undefined {
+  if (activationID === null || activationID === undefined) {
+    return undefined;
+  }
+  return snapshot === undefined ? { activationID } : { activationID, snapshot };
+}
+
 export type TaskDetailSavePendingState = Readonly<{
   task: boolean;
   addComment: boolean;

--- a/apps/desktop/src/features/task-detail/taskDetailSidebarState.ts
+++ b/apps/desktop/src/features/task-detail/taskDetailSidebarState.ts
@@ -6,14 +6,7 @@ export type TaskDetailSavePendingState = Readonly<{
   editComment: boolean;
 }>;
 
-export type TaskDetailSnapshotInput = Readonly<{
-  scrollTop: number;
-  descriptionExpanded: boolean;
-  selectedTab: "comments" | "activity";
-  titleBodyDraft?: Readonly<{ title: string; body: string }> | undefined;
-  newCommentDraft?: string | undefined;
-  editedCommentDraft?: Readonly<{ commentID: string; body: string }> | undefined;
-}>;
+export type TaskDetailSnapshotInput = Omit<SidebarTaskDetailSnapshot, "kind">;
 
 export function taskDetailSavePending(state: TaskDetailSavePendingState): boolean {
   return state.task || state.addComment || state.editComment;

--- a/apps/desktop/src/features/task-detail/taskDetailSidebarState.ts
+++ b/apps/desktop/src/features/task-detail/taskDetailSidebarState.ts
@@ -1,0 +1,34 @@
+import type { SidebarTaskDetailSnapshot } from "@/app-facade";
+
+export type TaskDetailSavePendingState = Readonly<{
+  task: boolean;
+  addComment: boolean;
+  editComment: boolean;
+}>;
+
+export type TaskDetailSnapshotInput = Readonly<{
+  scrollTop: number;
+  descriptionExpanded: boolean;
+  selectedTab: "comments" | "activity";
+  titleBodyDraft?: Readonly<{ title: string; body: string }> | undefined;
+  newCommentDraft?: string | undefined;
+  editedCommentDraft?: Readonly<{ commentID: string; body: string }> | undefined;
+}>;
+
+export function taskDetailSavePending(state: TaskDetailSavePendingState): boolean {
+  return state.task || state.addComment || state.editComment;
+}
+
+export function taskDetailSnapshot(input: TaskDetailSnapshotInput): SidebarTaskDetailSnapshot {
+  return {
+    kind: "taskDetail",
+    scrollTop: Math.max(0, input.scrollTop),
+    descriptionExpanded: input.descriptionExpanded,
+    selectedTab: input.selectedTab,
+    ...(input.titleBodyDraft === undefined ? {} : { titleBodyDraft: input.titleBodyDraft }),
+    ...(input.newCommentDraft === undefined || input.newCommentDraft.length === 0
+      ? {}
+      : { newCommentDraft: input.newCommentDraft }),
+    ...(input.editedCommentDraft === undefined ? {} : { editedCommentDraft: input.editedCommentDraft }),
+  };
+}

--- a/apps/desktop/src/features/tasks/NewTaskDialog.tsx
+++ b/apps/desktop/src/features/tasks/NewTaskDialog.tsx
@@ -97,6 +97,7 @@ export function NewTaskForm({
   boardQueryWorkflowID: string | undefined;
   className?: string;
   onSubmitted: (taskID?: string) => void;
+  onSubmissionStateChange?: ((pending: boolean) => void) | undefined;
   projectID: string;
   workflowID: string;
   initialSourceWorkspaceID?: string | undefined;
@@ -137,6 +138,7 @@ function NewTaskFormContent({
   boardQueryWorkflowID,
   className,
   onSubmitted,
+  onSubmissionStateChange,
   initialSourceWorkspaceID,
   pendingRelationship,
   projectID,
@@ -145,6 +147,7 @@ function NewTaskFormContent({
   boardQueryWorkflowID: string | undefined;
   className?: string;
   onSubmitted: (taskID?: string) => void;
+  onSubmissionStateChange?: ((pending: boolean) => void) | undefined;
   projectID: string;
   workflowID: string;
   initialSourceWorkspaceID?: string | undefined;
@@ -186,6 +189,10 @@ function NewTaskFormContent({
   });
   const canSubmit =
     connection.phase === "connected" && !createTask.isPending && initialWorkspaceID !== undefined;
+
+  useEffect(() => {
+    onSubmissionStateChange?.(createTask.isPending);
+  }, [createTask.isPending, onSubmissionStateChange]);
 
   useEffect(() => {
     if (!initializedRef.current && initialWorkspaceID !== undefined) {

--- a/apps/desktop/src/features/tasks/NewTaskDialog.tsx
+++ b/apps/desktop/src/features/tasks/NewTaskDialog.tsx
@@ -96,7 +96,7 @@ export function NewTaskForm({
 }: Readonly<{
   boardQueryWorkflowID: string | undefined;
   className?: string;
-  onSubmitted: () => void;
+  onSubmitted: (taskID?: string) => void;
   projectID: string;
   workflowID: string;
   initialSourceWorkspaceID?: string | undefined;
@@ -144,7 +144,7 @@ function NewTaskFormContent({
 }: Readonly<{
   boardQueryWorkflowID: string | undefined;
   className?: string;
-  onSubmitted: () => void;
+  onSubmitted: (taskID?: string) => void;
   projectID: string;
   workflowID: string;
   initialSourceWorkspaceID?: string | undefined;
@@ -200,7 +200,7 @@ function NewTaskFormContent({
     const sourceWorkspaceID = values.sourceWorkspaceID.trim() || initialWorkspaceID;
     const availableLabelIDs = new Set(catalog.data?.labels.map((label) => label.id) ?? []);
     try {
-      await createTask.mutateAsync({
+      const createdTaskID = await createTask.mutateAsync({
         projectID,
         workflowID,
         title: values.title,
@@ -215,7 +215,7 @@ function NewTaskFormContent({
                 newTaskRole: pendingRelationship.newTaskRole,
               },
       });
-      onSubmitted();
+      onSubmitted(createdTaskID);
     } catch {
       // The mutation state renders the persistent failure without clearing form input.
     }

--- a/apps/desktop/src/features/tasks/NewTaskDialog.tsx
+++ b/apps/desktop/src/features/tasks/NewTaskDialog.tsx
@@ -5,8 +5,12 @@ import { useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
-import { errorMessage, type TaskDependencyCreateIntent } from "@/api";
-import { useConnectionSnapshot, useTextFieldSubmitShortcut } from "@/app-facade";
+import { errorMessage } from "@/api";
+import {
+  useConnectionSnapshot,
+  useTextFieldSubmitShortcut,
+  type PendingTaskRelationship,
+} from "@/app-facade";
 import { useAppServices } from "@/app-facade";
 import { useStatusController } from "@/app-facade";
 import { LabelChooser, ProjectLabelsProvider, useProjectLabelCatalog } from "@/shared/labels";
@@ -101,12 +105,7 @@ export function NewTaskForm({
   projectID: string;
   workflowID: string;
   initialSourceWorkspaceID?: string | undefined;
-  pendingRelationship?:
-    | Readonly<{
-        originTaskID: string;
-        newTaskRole: TaskDependencyCreateIntent["newTaskRole"];
-      }>
-    | undefined;
+  pendingRelationship?: PendingTaskRelationship | undefined;
 }>) {
   const { t } = useTranslation();
   const { push } = useStatusController();
@@ -151,12 +150,7 @@ function NewTaskFormContent({
   projectID: string;
   workflowID: string;
   initialSourceWorkspaceID?: string | undefined;
-  pendingRelationship?:
-    | Readonly<{
-        originTaskID: string;
-        newTaskRole: TaskDependencyCreateIntent["newTaskRole"];
-      }>
-    | undefined;
+  pendingRelationship?: PendingTaskRelationship | undefined;
 }>) {
   const { t } = useTranslation();
   const connection = useConnectionSnapshot();

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -429,7 +429,7 @@ export const englishResources = {
     },
     routes: {
       legacyEmptyTaskSelector:
-        "This legacy project URL contains an empty task selector. Remove '?taskId=' from the URL and reload the project.",
+        "This legacy project URL contains an empty taskId query parameter. Remove that parameter and reload the project.",
     },
     form: {
       required: "Required",

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -427,6 +427,10 @@ export const englishResources = {
       empty: "Empty",
       error: "Error",
     },
+    routes: {
+      legacyEmptyTaskSelector:
+        "This legacy project URL contains an empty task selector. Remove '?taskId=' from the URL and reload the project.",
+    },
     form: {
       required: "Required",
       serverError: "Request failed",

--- a/apps/desktop/src/test-support/sidebar/index.ts
+++ b/apps/desktop/src/test-support/sidebar/index.ts
@@ -26,10 +26,17 @@ export function createTestSidebarController(
     pushSidebar(destination) {
       onOpen(destination);
     },
-    preserveSidebarOnNextRouteChange() {
+    preserveSidebarOnNextRouteChange(token, expectation) {
+      void token;
+      void expectation;
       return;
     },
-    consumeSidebarRouteChangePreservation() {
+    clearSidebarRouteChangePreservation(token) {
+      void token;
+      return;
+    },
+    consumeSidebarRouteChangePreservation(location) {
+      void location;
       return false;
     },
     registerSidebarStateCapture() {

--- a/apps/desktop/src/test-support/sidebar/index.ts
+++ b/apps/desktop/src/test-support/sidebar/index.ts
@@ -7,23 +7,57 @@ export function createTestSidebarController(
 ): SidebarController {
   return {
     activeDestination: null,
+    activeSnapshot: null,
+    activeToken: null,
+    backSidebar() {
+      return;
+    },
+    canGoBack: false,
     closeSidebar() {
+      return;
+    },
+    closeSidebarIfCurrent() {
       return;
     },
     async openSidebar(destination) {
       onOpen(destination);
       return { status: "canceled", reason: "closed" };
     },
+    pushSidebar(destination) {
+      onOpen(destination);
+    },
+    preserveSidebarOnNextRouteChange() {
+      return;
+    },
+    consumeSidebarRouteChangePreservation() {
+      return false;
+    },
+    registerSidebarStateCapture() {
+      return () => {
+        return;
+      };
+    },
+    removeSidebarEntry() {
+      return;
+    },
     replaceSidebar(destination) {
+      onOpen(destination);
+    },
+    replaceSidebarIfCurrent(_token, destination) {
       onOpen(destination);
     },
     phase: "open",
     resolveSidebar() {
       return;
     },
+    resolveSidebarIfCurrent() {
+      return;
+    },
     resizeSidebar() {
       return;
     },
     sidebarWidthPx: 320,
+    stackDestinations: [],
+    stackEntryTokens: [],
   };
 }

--- a/apps/desktop/src/test-support/sidebar/index.ts
+++ b/apps/desktop/src/test-support/sidebar/index.ts
@@ -24,6 +24,9 @@ export function createTestSidebarController(
     closeSidebarIfCurrent() {
       return;
     },
+    closeSidebarIfCurrentActivation() {
+      return;
+    },
     async openSidebar(destination) {
       onOpen(destination);
       return { status: "canceled", reason: "closed" };

--- a/apps/desktop/src/test-support/sidebar/index.ts
+++ b/apps/desktop/src/test-support/sidebar/index.ts
@@ -7,6 +7,7 @@ export function createTestSidebarController(
 ): SidebarController {
   return {
     activeDestination: null,
+    activeActivationID: null,
     activeSnapshot: null,
     activeToken: null,
     backSidebar() {

--- a/apps/desktop/src/test-support/sidebar/index.ts
+++ b/apps/desktop/src/test-support/sidebar/index.ts
@@ -14,6 +14,10 @@ export function createTestSidebarController(
       return;
     },
     canGoBack: false,
+    sidebarExitBlocked: false,
+    setSidebarExitBlocked() {
+      return;
+    },
     closeSidebar() {
       return;
     },

--- a/apps/desktop/src/ui/VirtualizedInfiniteList.tsx
+++ b/apps/desktop/src/ui/VirtualizedInfiniteList.tsx
@@ -4,7 +4,10 @@ import { type Range, type VirtualItem, useVirtualizer } from "@tanstack/react-vi
 import { cx } from "./classes";
 import { InfiniteListBoundary, type VirtualizedInfiniteListBoundaryState } from "./InfiniteListBoundary";
 import { Spinner } from "./Spinner";
-import { resolveVirtualizedInitialScroll } from "./virtualizedInfiniteListInitialScroll";
+import {
+  resolveVirtualizedInitialScroll,
+  shouldDeferVirtualizedInitialScrollOffset,
+} from "./virtualizedInfiniteListInitialScroll";
 import { resolveLoadMore } from "./virtualizedInfiniteListLoadMore";
 import { pinnedVirtualRangeExtractor } from "./virtualizedPinnedRange";
 import { shouldAdjustScrollForVirtualizedResize } from "./virtualizedResizePolicy";
@@ -166,6 +169,24 @@ export function VirtualizedInfiniteList<TItem>({
   const visibleIndexes = isFallbackRendering
     ? fallbackIndexes
     : virtualItems.map((virtualItem) => virtualItem.index);
+  const requestNextPageIfNeeded = useCallback(
+    (atBottom: boolean) => {
+      const decision = resolveLoadMore({
+        atBottom,
+        hasNextPage,
+        isFetchingNextPage,
+        lastLoadMoreKey: lastLoadMoreKeyRef.current,
+        loadMoreKey: loadMoreKey ?? items.length.toString(),
+        wasFetchingNextPage: wasFetchingNextPageRef.current,
+      });
+      wasFetchingNextPageRef.current = isFetchingNextPage;
+      lastLoadMoreKeyRef.current = decision.lastLoadMoreKey;
+      if (decision.shouldLoad) {
+        onLoadMore();
+      }
+    },
+    [hasNextPage, isFetchingNextPage, items.length, loadMoreKey, onLoadMore],
+  );
   const renderRow = (virtualIndex: number): ReactNode =>
     renderVirtualRow({
       empty,
@@ -248,11 +269,21 @@ export function VirtualizedInfiniteList<TItem>({
     if (element === null) {
       return;
     }
-    lastInitialScrollOffsetRequestKeyRef.current = initialScrollOffsetRequestKey;
     const offset = Math.max(0, initialScrollOffset);
+    if (
+      shouldDeferVirtualizedInitialScrollOffset({
+        hasNextPage,
+        maxScrollOffset: element.scrollHeight - element.clientHeight,
+        offset,
+      })
+    ) {
+      requestNextPageIfNeeded(true);
+      return;
+    }
+    lastInitialScrollOffsetRequestKeyRef.current = initialScrollOffsetRequestKey;
     element.scrollTop = offset;
     virtualizer.scrollToOffset(offset, { behavior: "auto" });
-  }, [initialScrollOffset, initialScrollOffsetRequestKey, virtualizer]);
+  }, [hasNextPage, initialScrollOffset, initialScrollOffsetRequestKey, requestNextPageIfNeeded, virtualizer]);
 
   useLayoutEffect(() => {
     const currentKeys = items.map(getItemKey);
@@ -319,28 +350,8 @@ export function VirtualizedInfiniteList<TItem>({
   useEffect(() => {
     const lastVisibleIndex = visibleIndexes.at(-1);
     const lastDataIndex = itemStartIndex + items.length - 1;
-    const decision = resolveLoadMore({
-      atBottom: lastVisibleIndex !== undefined && lastVisibleIndex >= lastDataIndex,
-      hasNextPage,
-      isFetchingNextPage,
-      lastLoadMoreKey: lastLoadMoreKeyRef.current,
-      loadMoreKey: loadMoreKey ?? items.length.toString(),
-      wasFetchingNextPage: wasFetchingNextPageRef.current,
-    });
-    wasFetchingNextPageRef.current = isFetchingNextPage;
-    lastLoadMoreKeyRef.current = decision.lastLoadMoreKey;
-    if (decision.shouldLoad) {
-      onLoadMore();
-    }
-  }, [
-    hasNextPage,
-    isFetchingNextPage,
-    itemStartIndex,
-    items.length,
-    loadMoreKey,
-    onLoadMore,
-    visibleIndexes,
-  ]);
+    requestNextPageIfNeeded(lastVisibleIndex !== undefined && lastVisibleIndex >= lastDataIndex);
+  }, [itemStartIndex, items.length, requestNextPageIfNeeded, visibleIndexes]);
 
   if (count > 0 && virtualItems.length === 0) {
     return (

--- a/apps/desktop/src/ui/VirtualizedInfiniteList.tsx
+++ b/apps/desktop/src/ui/VirtualizedInfiniteList.tsx
@@ -4,10 +4,7 @@ import { type Range, type VirtualItem, useVirtualizer } from "@tanstack/react-vi
 import { cx } from "./classes";
 import { InfiniteListBoundary, type VirtualizedInfiniteListBoundaryState } from "./InfiniteListBoundary";
 import { Spinner } from "./Spinner";
-import {
-  resolveVirtualizedInitialScroll,
-  shouldDeferVirtualizedInitialScrollOffset,
-} from "./virtualizedInfiniteListInitialScroll";
+import { resolveVirtualizedInitialScroll } from "./virtualizedInfiniteListInitialScroll";
 import { resolveLoadMore } from "./virtualizedInfiniteListLoadMore";
 import { pinnedVirtualRangeExtractor } from "./virtualizedPinnedRange";
 import { shouldAdjustScrollForVirtualizedResize } from "./virtualizedResizePolicy";
@@ -269,21 +266,14 @@ export function VirtualizedInfiniteList<TItem>({
     if (element === null) {
       return;
     }
+    // Restoration is deliberately one-shot. If evicted pages make the saved
+    // offset unreachable, the browser clamps to the currently available range;
+    // ordinary infinite-scroll loading remains user-driven.
     const offset = Math.max(0, initialScrollOffset);
-    if (
-      shouldDeferVirtualizedInitialScrollOffset({
-        hasNextPage,
-        maxScrollOffset: element.scrollHeight - element.clientHeight,
-        offset,
-      })
-    ) {
-      requestNextPageIfNeeded(true);
-      return;
-    }
     lastInitialScrollOffsetRequestKeyRef.current = initialScrollOffsetRequestKey;
     element.scrollTop = offset;
     virtualizer.scrollToOffset(offset, { behavior: "auto" });
-  }, [hasNextPage, initialScrollOffset, initialScrollOffsetRequestKey, requestNextPageIfNeeded, virtualizer]);
+  }, [initialScrollOffset, initialScrollOffsetRequestKey, virtualizer]);
 
   useLayoutEffect(() => {
     const currentKeys = items.map(getItemKey);

--- a/apps/desktop/src/ui/VirtualizedInfiniteList.tsx
+++ b/apps/desktop/src/ui/VirtualizedInfiniteList.tsx
@@ -28,6 +28,8 @@ export type VirtualizedInfiniteListProps<TItem> = Readonly<{
   testId?: string | undefined;
   initialScrollKey?: string | undefined;
   initialScrollRequestKey?: string | undefined;
+  initialScrollOffset?: number | undefined;
+  initialScrollOffsetRequestKey?: string | undefined;
   paddingEnd?: number | undefined;
   paddingStart?: number | undefined;
   className?: string | undefined;
@@ -59,6 +61,8 @@ export function VirtualizedInfiniteList<TItem>({
   testId,
   initialScrollKey,
   initialScrollRequestKey,
+  initialScrollOffset,
+  initialScrollOffsetRequestKey,
   paddingEnd = 0,
   paddingStart = 0,
   className,
@@ -81,6 +85,7 @@ export function VirtualizedInfiniteList<TItem>({
     [onScrollElementChange],
   );
   const lastInitialScrollKeyRef = useRef<string | null>(null);
+  const lastInitialScrollOffsetRequestKeyRef = useRef<string | null>(null);
   const lastLoadPreviousKeyRef = useRef<string | null>(null);
   const lastLoadMoreKeyRef = useRef<string | null>(null);
   const wasFetchingPreviousPageRef = useRef(false);
@@ -231,6 +236,23 @@ export function VirtualizedInfiniteList<TItem>({
     lastInitialScrollKeyRef.current = scroll.requestKey;
     virtualizer.scrollToIndex(scroll.scrollIndex, { align: "start", behavior: "auto" });
   }, [getItemKey, initialScrollKey, initialScrollRequestKey, itemStartIndex, items, virtualizer]);
+
+  useLayoutEffect(() => {
+    if (initialScrollOffset === undefined || initialScrollOffsetRequestKey === undefined) {
+      return;
+    }
+    if (lastInitialScrollOffsetRequestKeyRef.current === initialScrollOffsetRequestKey) {
+      return;
+    }
+    const element = scrollRef.current;
+    if (element === null) {
+      return;
+    }
+    lastInitialScrollOffsetRequestKeyRef.current = initialScrollOffsetRequestKey;
+    const offset = Math.max(0, initialScrollOffset);
+    element.scrollTop = offset;
+    virtualizer.scrollToOffset(offset, { behavior: "auto" });
+  }, [initialScrollOffset, initialScrollOffsetRequestKey, virtualizer]);
 
   useLayoutEffect(() => {
     const currentKeys = items.map(getItemKey);

--- a/apps/desktop/src/ui/virtualizedInfiniteListInitialScroll.test.ts
+++ b/apps/desktop/src/ui/virtualizedInfiniteListInitialScroll.test.ts
@@ -1,5 +1,6 @@
 import {
   resolveVirtualizedInitialScroll,
+  shouldDeferVirtualizedInitialScrollOffset,
   virtualizedInitialScrollIndex,
 } from "./virtualizedInfiniteListInitialScroll";
 
@@ -34,5 +35,29 @@ describe("virtualized initial scroll", () => {
         items: [{ key: "dependencies" }],
       }),
     ).toBe(0);
+  });
+
+  it("defers an offset that needs another loaded page", () => {
+    expect(
+      shouldDeferVirtualizedInitialScrollOffset({
+        hasNextPage: true,
+        maxScrollOffset: 400,
+        offset: 401,
+      }),
+    ).toBe(true);
+    expect(
+      shouldDeferVirtualizedInitialScrollOffset({
+        hasNextPage: true,
+        maxScrollOffset: 400,
+        offset: 400,
+      }),
+    ).toBe(false);
+    expect(
+      shouldDeferVirtualizedInitialScrollOffset({
+        hasNextPage: false,
+        maxScrollOffset: 400,
+        offset: 401,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/ui/virtualizedInfiniteListInitialScroll.test.ts
+++ b/apps/desktop/src/ui/virtualizedInfiniteListInitialScroll.test.ts
@@ -1,6 +1,5 @@
 import {
   resolveVirtualizedInitialScroll,
-  shouldDeferVirtualizedInitialScrollOffset,
   virtualizedInitialScrollIndex,
 } from "./virtualizedInfiniteListInitialScroll";
 
@@ -35,29 +34,5 @@ describe("virtualized initial scroll", () => {
         items: [{ key: "dependencies" }],
       }),
     ).toBe(0);
-  });
-
-  it("defers an offset that needs another loaded page", () => {
-    expect(
-      shouldDeferVirtualizedInitialScrollOffset({
-        hasNextPage: true,
-        maxScrollOffset: 400,
-        offset: 401,
-      }),
-    ).toBe(true);
-    expect(
-      shouldDeferVirtualizedInitialScrollOffset({
-        hasNextPage: true,
-        maxScrollOffset: 400,
-        offset: 400,
-      }),
-    ).toBe(false);
-    expect(
-      shouldDeferVirtualizedInitialScrollOffset({
-        hasNextPage: false,
-        maxScrollOffset: 400,
-        offset: 401,
-      }),
-    ).toBe(false);
   });
 });

--- a/apps/desktop/src/ui/virtualizedInfiniteListInitialScroll.ts
+++ b/apps/desktop/src/ui/virtualizedInfiniteListInitialScroll.ts
@@ -46,3 +46,15 @@ export function resolveVirtualizedInitialScroll<TItem>({
   });
   return scrollIndex === null ? null : { requestKey, scrollIndex };
 }
+
+export function shouldDeferVirtualizedInitialScrollOffset({
+  hasNextPage,
+  maxScrollOffset,
+  offset,
+}: Readonly<{
+  hasNextPage: boolean;
+  maxScrollOffset: number;
+  offset: number;
+}>): boolean {
+  return hasNextPage && Math.max(0, offset) > Math.max(0, maxScrollOffset);
+}

--- a/apps/desktop/src/ui/virtualizedInfiniteListInitialScroll.ts
+++ b/apps/desktop/src/ui/virtualizedInfiniteListInitialScroll.ts
@@ -46,15 +46,3 @@ export function resolveVirtualizedInitialScroll<TItem>({
   });
   return scrollIndex === null ? null : { requestKey, scrollIndex };
 }
-
-export function shouldDeferVirtualizedInitialScrollOffset({
-  hasNextPage,
-  maxScrollOffset,
-  offset,
-}: Readonly<{
-  hasNextPage: boolean;
-  maxScrollOffset: number;
-  offset: number;
-}>): boolean {
-  return hasNextPage && Math.max(0, offset) > Math.max(0, maxScrollOffset);
-}

--- a/docs/dev/specs/desktop-gui.md
+++ b/docs/dev/specs/desktop-gui.md
@@ -178,88 +178,47 @@
 - `queued` and `running` use a spinner.
 - `waiting_approval` and `interrupted` use a secondary-colored circle.
 - `waiting_question` uses a primary-colored circle.
-- Desktop must push a Task Detail onto the sidebar-local navigation stack when a related-Task row is selected.
-- Desktop must not change browser history for sidebar-local navigation.
-- Desktop must return to an earlier matching Task entry when the selected Task already appears earlier in the sidebar stack.
-- Desktop must remove every later destination when it returns to an earlier matching Task entry.
-- Desktop must silently discard unsent Task edits and comment drafts from every removed later destination.
-- Desktop must keep X before Back in the sidebar header.
-- Desktop must return to the preceding sidebar destination on Back.
-- Desktop must hide Back at the root sidebar destination.
-- Desktop must use the existing sidebar navigation icon-control presentation for Back.
-- Desktop must not provide Forward.
-- Desktop must close the complete sidebar stack on X.
-- Desktop must silently discard unsent Task edits and comment drafts in the stack on X.
-- Desktop must bound a sidebar stack to at most 50 destinations.
-- Desktop must keep only the current sidebar destination live.
-- Desktop must retain bounded interface state for earlier destinations without continuing to load or receive live updates.
-- Desktop must apply the 50-destination bound to sidebar entries and retained interface state.
-- Desktop must not keep inactive Task Detail data live or extend its normal
-  lifetime solely because sidebar history retains its interface state.
-- Desktop must preserve the root when the sidebar reaches its 50-destination bound.
-- Desktop must evict the oldest non-root destination when the sidebar reaches its 50-destination bound.
-- Desktop must evict that destination silently.
-- Desktop must discard evicted destination interface state, including unsent Task edits and comment drafts.
-- Desktop must keep the browser Task route anchored to the root Task that opened the sidebar stack.
-- Desktop must not update the browser Task route on sidebar push or Back.
-- Desktop must close the complete sidebar stack on an external browser route change.
-- Desktop must silently discard unsent Task edits and comment drafts on an external browser route change.
-- Desktop must preserve the complete sidebar stack and its saved interface state across disconnect and reconnect.
-- Desktop must refresh server-authoritative data when a retained destination is restored.
-- Desktop must use a quick horizontal transition for Push and Back.
-- Desktop must respect reduced-motion settings for Push and Back.
+
+Selecting a related-Task row pushes that Task Detail onto a sidebar-local stack
+while the browser Task route remains anchored to the root Task.
+
+The sidebar header keeps X before Back. Back returns to the preceding
+destination and is hidden at the root. X closes the complete stack.
+
+When a selected Task already appears in the stack, the sidebar returns to that
+Task and removes later destinations. The stack retains at most 50 destinations,
+keeps the root, and removes the oldest non-root destination at the limit.
+Earlier destinations retain bounded interface state while only the current
+destination remains live. Restoring a destination refreshes its
+server-authoritative data, and disconnect/reconnect preserves the stack and its
+saved interface state. An external browser route change closes the stack.
+
+The `Blocked by` and `Blocks` Add controls push the ordinary New Task form.
+Related-Task creation uses the open Task's Project, Workflow, and default source
+workspace, then atomically creates the Backlog Task and directed Task
+Dependency. Success replaces New Task with the created Task Detail and keeps
+the originating Task immediately behind it. Failure preserves ordinary New Task
+recovery, while leaving through Back or X creates neither record.
+
+While a Task title/body or add/edit-comment save is pending, related-Task
+selection and Dependency Add are unavailable. Back, X, route change, Pop out,
+and connected relationship Remove remain available. Successful or failed saves
+restore dependency navigation when the Task Detail remains current.
+
+Back restores the prior Task Detail's scroll position, description expansion,
+selected Comments or Activity tab, unsent Task edits, and unsent comment
+drafts, then refreshes server data. An unfinished Question response is not
+restored. Deleted Tasks are removed from the stack, and Back skips destinations
+that no longer exist.
+
+Pop out opens only the current Task in the separate window and closes the
+originating stack after the window opens. If the destination changes first, the
+window remains open and the current sidebar remains unchanged.
+
 - Each relationship row has an accessible trailing Remove action rendered as a
   minimal uncircled red `X`.
 - Remove acts immediately without confirmation.
 - Dependency actions use icon-only controls outside confirmation dialogs.
-- Desktop must push the ordinary New Task form for a new Blocker Task when `Blocked by` Add is selected.
-- Desktop must push the ordinary New Task form for a new Blocked Task when `Blocks` Add is selected.
-- Desktop must make related-Task selection unavailable while a Task title/body save or add/edit-comment save is pending.
-- Desktop must make Dependency Add unavailable while a Task title/body save or add/edit-comment save is pending.
-- Desktop must keep Back, X, route change, and Pop out available while those saves are pending.
-- Desktop must re-enable dependency navigation after a successful save when Task Detail remains current.
-- Desktop must not retain submitted input after a successful save.
-- Desktop must re-enable dependency navigation after a failed save when Task Detail remains current.
-- Desktop must preserve the failed draft after a failed save.
-- Desktop must use ordinary discard or close behavior when leaving through Back, X, route change, or Pop out while a save is pending.
-- Desktop must not restore or reopen a destination after a pending save settles.
-- Desktop must not offer an existing-Task search or chooser for Dependency Add.
-- Desktop must use the open Task's Project and Workflow for related-Task creation.
-- Desktop must default related-Task creation to the open Task's source workspace.
-- Desktop must keep the ordinary source-workspace selector available for related-Task creation.
-- Desktop must not show Dependencies in New Task.
-- Desktop must carry a related New Task's preconfigured originating relationship without showing it in the form.
-- Desktop must not show a Cancel button in New Task.
-- Desktop must discard an unsubmitted New Task form and return to the preceding Task Detail on Back.
-- Desktop must atomically create the Backlog Task and directed Task Dependency when related-Task creation is submitted.
-- Desktop must replace New Task with the newly created Task Detail after successful related-Task creation.
-- Desktop must keep the originating Task immediately behind the created Task in the sidebar stack.
-- Desktop must keep the created Task and relationship when related-Task creation succeeds after New Task is no longer current.
-- Desktop must leave the current sidebar unchanged when stale related-Task creation succeeds.
-- Desktop must create neither Task nor relationship when related-Task creation fails.
-- Desktop must preserve the ordinary New Task recovery path after related-Task creation fails.
-- Desktop must create neither Task nor relationship when related-Task creation is left through Back or X.
-- Desktop must open only the current Task in the separate window when a stacked Task Detail is popped out.
-- Desktop must close the complete originating sidebar stack after the separate window opens.
-- Desktop must leave the separate window open and the current sidebar unchanged when the window opens after that Task Detail is no longer current.
-- Desktop must not warn about unsent input in the sidebar stack during Pop out.
-- Desktop must discard unsent input in the originating stack when Pop out closes it.
-- Desktop must restore the prior Task Detail scroll position, description expansion, selected Comments or Activity tab, unsent Task edits, and unsent comment drafts on Back.
-- Desktop must reapply the captured pixel offset after ordinary server refresh during scroll restoration.
-- Desktop must use the nearest available position when refreshed content cannot provide the captured offset.
-- Desktop must not retain or replay Activity or Comments pages only to reconstruct an earlier viewport.
-- Desktop must apply a Task Detail initial-focus request only to its first activation.
-- Desktop must restore captured scroll position without replaying an earlier Dependencies, Question, Approval, or interrupted-node focus request.
-- Desktop must discard the current Task Detail's unsent Task edits and comment drafts without warning on Back.
-- Desktop must retain restored drafts only for their earlier retained destination.
-- Desktop must not preserve an unfinished Question response on Back.
-- Desktop must refetch current server data on Back.
-- Desktop must layer retained unsent Task and comment drafts over refetched server data on Back.
-- Desktop must remove a retained Task's sidebar destination when that Task is deleted.
-- Desktop must skip deleted destinations on Back.
-- Desktop must close the sidebar only when no destination survives after deleted destinations are skipped.
-- Desktop must close the originating Task Detail lifecycle as an ordinary close when the final destination is removed.
-- Desktop must clear an anchored browser Task route when the final destination is removed.
 - The Add control is unavailable with an accessible explanation when its
   relationship direction has reached the 50-Task limit.
 - Kent rechecks the limit when related-Task creation is submitted.
@@ -269,11 +228,9 @@
 ## Inbox, Questions, Approvals, And Notifications
 
 - Inbox lists the global infinite-scrolling attention feed. Task Detail owns Question and Approval actions through its bounded Task attention view.
-- Desktop must let Inbox-opened Task Detail move through the live Inbox order with Previous and Next.
-- Desktop must advance Next to the replacement item after resolution removes the open Task.
-- Desktop must replace the current Inbox Task for Previous and Next.
-- Desktop must not push sidebar history for Inbox Previous and Next.
-- Desktop must make Inbox Previous and Next unavailable outside Inbox.
+- Inbox-opened Task Detail can move through the live Inbox order with Previous
+  and Next. After resolution removes the open Task, Next advances to the
+  replacement item. These controls are unavailable outside Inbox.
 - The top Task Detail action opens or focuses the highest-priority unresolved attention. All unresolved items retain inline controls.
 - Home Inbox shows only task-scoped attention. It has no Workflow-validity badge or section.
 - Questions support suggestions, freeform commentary, recommendations, pointer or keyboard selection, and ordinary focus navigation. An option Question selects its valid recommended option by default and otherwise selects option 1; malformed recommendation metadata follows the same option-1 fallback. Live refresh preserves the user's selection and draft. Selection and recommendation remain distinct states. A Question with no suggestions has only freeform response and does not offer `Neither`.

--- a/docs/dev/specs/desktop-gui.md
+++ b/docs/dev/specs/desktop-gui.md
@@ -198,7 +198,10 @@ Related-Task creation uses the open Task's Project, Workflow, and default source
 workspace, then atomically creates the Backlog Task and directed Task
 Dependency. Success replaces New Task with the created Task Detail and keeps
 the originating Task immediately behind it. Failure preserves ordinary New Task
-recovery, while leaving through Back or X creates neither record.
+recovery. Before submission starts, leaving through Back or X creates neither
+record. Once submission starts, Back and X are unavailable until creation
+succeeds or fails, and a stale completion cannot change a newer sidebar
+destination.
 
 While a Task title/body or add/edit-comment save is pending, related-Task
 selection and Dependency Add are unavailable. Back, X, route change, Pop out,

--- a/docs/dev/specs/desktop-gui.md
+++ b/docs/dev/specs/desktop-gui.md
@@ -194,10 +194,8 @@
 - Desktop must keep only the current sidebar destination live.
 - Desktop must retain bounded interface state for earlier destinations without continuing to load or receive live updates.
 - Desktop must apply the 50-destination bound to sidebar entries and retained interface state.
-- Desktop must not apply the 50-destination bound to the app's ordinary query cache.
-- Desktop must leave inactive Task Detail queries on the app's ordinary time-based cache lifecycle.
-- Desktop must allow dependency traversal to temporarily increase inactive query cache until ordinary expiry.
-- Desktop must not pin, copy, extend, isolate, or explicitly evict Task Detail queries.
+- Desktop must not keep inactive Task Detail data live or extend its normal
+  lifetime solely because sidebar history retains its interface state.
 - Desktop must preserve the root when the sidebar reaches its 50-destination bound.
 - Desktop must evict the oldest non-root destination when the sidebar reaches its 50-destination bound.
 - Desktop must evict that destination silently.

--- a/docs/dev/specs/desktop-gui.md
+++ b/docs/dev/specs/desktop-gui.md
@@ -178,28 +178,90 @@
 - `queued` and `running` use a spinner.
 - `waiting_approval` and `interrupted` use a secondary-colored circle.
 - `waiting_question` uses a primary-colored circle.
-- Selecting a related-Task row replaces the current Task Detail with that Task
-  in the same sidebar or Task Detail presentation.
-- Dependency navigation has no sidebar-local Back or Forward action.
-- Closing Task Detail after dependency navigation closes the current Task Detail
-  as usual.
+- Desktop must push a Task Detail onto the sidebar-local navigation stack when a related-Task row is selected.
+- Desktop must not change browser history for sidebar-local navigation.
+- Desktop must return to an earlier matching Task entry when the selected Task already appears earlier in the sidebar stack.
+- Desktop must remove every later destination when it returns to an earlier matching Task entry.
+- Desktop must silently discard unsent Task edits and comment drafts from every removed later destination.
+- Desktop must keep X before Back in the sidebar header.
+- Desktop must return to the preceding sidebar destination on Back.
+- Desktop must hide Back at the root sidebar destination.
+- Desktop must use the existing sidebar navigation icon-control presentation for Back.
+- Desktop must not provide Forward.
+- Desktop must close the complete sidebar stack on X.
+- Desktop must silently discard unsent Task edits and comment drafts in the stack on X.
+- Desktop must bound a sidebar stack to at most 50 destinations.
+- Desktop must keep only the current sidebar destination live.
+- Desktop must retain bounded interface state for earlier destinations without continuing to load or receive live updates.
+- Desktop must apply the 50-destination bound to sidebar entries and retained interface state.
+- Desktop must not apply the 50-destination bound to the app's ordinary query cache.
+- Desktop must leave inactive Task Detail queries on the app's ordinary time-based cache lifecycle.
+- Desktop must allow dependency traversal to temporarily increase inactive query cache until ordinary expiry.
+- Desktop must not pin, copy, extend, isolate, or explicitly evict Task Detail queries.
+- Desktop must preserve the root when the sidebar reaches its 50-destination bound.
+- Desktop must evict the oldest non-root destination when the sidebar reaches its 50-destination bound.
+- Desktop must evict that destination silently.
+- Desktop must discard evicted destination interface state, including unsent Task edits and comment drafts.
+- Desktop must keep the browser Task route anchored to the root Task that opened the sidebar stack.
+- Desktop must not update the browser Task route on sidebar push or Back.
+- Desktop must close the complete sidebar stack on an external browser route change.
+- Desktop must silently discard unsent Task edits and comment drafts on an external browser route change.
+- Desktop must preserve the complete sidebar stack and its saved interface state across disconnect and reconnect.
+- Desktop must refresh server-authoritative data when a retained destination is restored.
+- Desktop must use a quick horizontal transition for Push and Back.
+- Desktop must respect reduced-motion settings for Push and Back.
 - Each relationship row has an accessible trailing Remove action rendered as a
   minimal uncircled red `X`.
 - Remove acts immediately without confirmation.
 - Dependency actions use icon-only controls outside confirmation dialogs.
-- `Blocked by` Add opens the ordinary New Task form for a new Blocker Task.
-- `Blocks` Add opens the ordinary New Task form for a new Blocked Task.
-- Related-Task creation uses the open Task's Project and Workflow.
-- Related-Task creation defaults source workspace to the open Task's source
-  workspace and keeps the ordinary source-workspace selector available.
-- The New Task form shows no dependency field, picker, relationship copy, or
-  other dependency-specific visible state.
-- Submitting related-Task creation atomically creates the Backlog Task and the
-  directed Task Dependency.
-- A related-Task creation failure creates neither Task nor relationship and
-  preserves the ordinary New Task recovery path.
-- Canceling related-Task creation creates neither Task nor relationship.
-- Desktop has no existing-Task dependency picker.
+- Desktop must push the ordinary New Task form for a new Blocker Task when `Blocked by` Add is selected.
+- Desktop must push the ordinary New Task form for a new Blocked Task when `Blocks` Add is selected.
+- Desktop must make related-Task selection unavailable while a Task title/body save or add/edit-comment save is pending.
+- Desktop must make Dependency Add unavailable while a Task title/body save or add/edit-comment save is pending.
+- Desktop must keep Back, X, route change, and Pop out available while those saves are pending.
+- Desktop must re-enable dependency navigation after a successful save when Task Detail remains current.
+- Desktop must not retain submitted input after a successful save.
+- Desktop must re-enable dependency navigation after a failed save when Task Detail remains current.
+- Desktop must preserve the failed draft after a failed save.
+- Desktop must use ordinary discard or close behavior when leaving through Back, X, route change, or Pop out while a save is pending.
+- Desktop must not restore or reopen a destination after a pending save settles.
+- Desktop must not offer an existing-Task search or chooser for Dependency Add.
+- Desktop must use the open Task's Project and Workflow for related-Task creation.
+- Desktop must default related-Task creation to the open Task's source workspace.
+- Desktop must keep the ordinary source-workspace selector available for related-Task creation.
+- Desktop must not show Dependencies in New Task.
+- Desktop must carry a related New Task's preconfigured originating relationship without showing it in the form.
+- Desktop must not show a Cancel button in New Task.
+- Desktop must discard an unsubmitted New Task form and return to the preceding Task Detail on Back.
+- Desktop must atomically create the Backlog Task and directed Task Dependency when related-Task creation is submitted.
+- Desktop must replace New Task with the newly created Task Detail after successful related-Task creation.
+- Desktop must keep the originating Task immediately behind the created Task in the sidebar stack.
+- Desktop must keep the created Task and relationship when related-Task creation succeeds after New Task is no longer current.
+- Desktop must leave the current sidebar unchanged when stale related-Task creation succeeds.
+- Desktop must create neither Task nor relationship when related-Task creation fails.
+- Desktop must preserve the ordinary New Task recovery path after related-Task creation fails.
+- Desktop must create neither Task nor relationship when related-Task creation is left through Back or X.
+- Desktop must open only the current Task in the separate window when a stacked Task Detail is popped out.
+- Desktop must close the complete originating sidebar stack after the separate window opens.
+- Desktop must leave the separate window open and the current sidebar unchanged when the window opens after that Task Detail is no longer current.
+- Desktop must not warn about unsent input in the sidebar stack during Pop out.
+- Desktop must discard unsent input in the originating stack when Pop out closes it.
+- Desktop must restore the prior Task Detail scroll position, description expansion, selected Comments or Activity tab, unsent Task edits, and unsent comment drafts on Back.
+- Desktop must reapply the captured pixel offset after ordinary server refresh during scroll restoration.
+- Desktop must use the nearest available position when refreshed content cannot provide the captured offset.
+- Desktop must not retain or replay Activity or Comments pages only to reconstruct an earlier viewport.
+- Desktop must apply a Task Detail initial-focus request only to its first activation.
+- Desktop must restore captured scroll position without replaying an earlier Dependencies, Question, Approval, or interrupted-node focus request.
+- Desktop must discard the current Task Detail's unsent Task edits and comment drafts without warning on Back.
+- Desktop must retain restored drafts only for their earlier retained destination.
+- Desktop must not preserve an unfinished Question response on Back.
+- Desktop must refetch current server data on Back.
+- Desktop must layer retained unsent Task and comment drafts over refetched server data on Back.
+- Desktop must remove a retained Task's sidebar destination when that Task is deleted.
+- Desktop must skip deleted destinations on Back.
+- Desktop must close the sidebar only when no destination survives after deleted destinations are skipped.
+- Desktop must close the originating Task Detail lifecycle as an ordinary close when the final destination is removed.
+- Desktop must clear an anchored browser Task route when the final destination is removed.
 - The Add control is unavailable with an accessible explanation when its
   relationship direction has reached the 50-Task limit.
 - Kent rechecks the limit when related-Task creation is submitted.
@@ -209,7 +271,11 @@
 ## Inbox, Questions, Approvals, And Notifications
 
 - Inbox lists the global infinite-scrolling attention feed. Task Detail owns Question and Approval actions through its bounded Task attention view.
-- Inbox-opened Task Detail can move through the live Inbox order with Previous and Next. After resolution removes the open Task, Next advances to the replacement item. These controls are unavailable outside Inbox.
+- Desktop must let Inbox-opened Task Detail move through the live Inbox order with Previous and Next.
+- Desktop must advance Next to the replacement item after resolution removes the open Task.
+- Desktop must replace the current Inbox Task for Previous and Next.
+- Desktop must not push sidebar history for Inbox Previous and Next.
+- Desktop must make Inbox Previous and Next unavailable outside Inbox.
 - The top Task Detail action opens or focuses the highest-priority unresolved attention. All unresolved items retain inline controls.
 - Home Inbox shows only task-scoped attention. It has no Workflow-validity badge or section.
 - Questions support suggestions, freeform commentary, recommendations, pointer or keyboard selection, and ordinary focus navigation. An option Question selects its valid recommended option by default and otherwise selects option 1; malformed recommendation metadata follows the same option-1 fallback. Live refresh preserves the user's selection and draft. Selection and recommendation remain distinct states. A Question with no suggestions has only freeform response and does not offer `Neither`.

--- a/server/workflowrunner/current_node_integration_test.go
+++ b/server/workflowrunner/current_node_integration_test.go
@@ -30,7 +30,10 @@ import (
 	"core/shared/toolspec"
 )
 
-const currentNodeRunnerWait = 5 * time.Second
+// Controller finalization crosses several runtime goroutines and can be
+// delayed by CI's concurrent package scheduling even after the scripted work
+// has completed.
+const currentNodeRunnerWait = 15 * time.Second
 
 type currentNodeRunnerFixture struct {
 	cfg          config.App

--- a/server/worktree/git.go
+++ b/server/worktree/git.go
@@ -12,6 +12,7 @@ import (
 
 	"core/shared/clientui"
 	"core/shared/config"
+	"core/shared/serverapi"
 )
 
 var errGitTargetNotFound = errors.New("git target not found")

--- a/server/worktree/git_test.go
+++ b/server/worktree/git_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"core/shared/clientui"
+	"core/shared/serverapi"
 )
 
 type canceledGitCommandRunner struct{}


### PR DESCRIPTION
## Summary

- Add a reusable typed sidebar navigation stack for Task Detail and New Task destinations with bounded retention, cycle deduplication, Back, whole-stack X close, route/reconnect handling, and current-destination pop-out behavior.
- Preserve Task Detail presentation and unsent drafts across Push/Back while keeping one mounted/live Task Detail. Activation IDs are reducer-owned, and TaskDetailSurface remounts per accepted activation so pending mutation state cannot leak across activations.
- Keep project-task route selection optional and non-empty: clearing navigation omits taskId, route preservation matches an absent parameter, and explicit taskId= is rejected.
- Scope sidebar navigation and snapshot capture to the rendered Task Detail surface activation, so a standalone /tasks surface cannot push or capture state in an unrelated sidebar stack.
- Keep the active Task Detail activation stable through the close animation; phase remains the shell animation state and the stack is removed only after the exit timeout.
- Use one shared sidebar Task identity matcher for provider presentation, stack truncation, and deleted-entry lookup. Live stack-token construction and validation plus reducer entry-index lookup are centralized, and retained snapshot input is derived from the shared snapshot contract.
- Prevent pending sidebar New Task mutations from being silently abandoned: the active form token blocks X and Back while creation is in flight, and stale callbacks cannot alter a replacement destination.
- Make initial pixel-offset restoration one-shot and bounded: the browser clamps to currently available content and restoration never fetches additional infinite-scroll pages or retains an unbounded history.
- Make Task Detail replacement return to a retained matching Task entry instead of creating A → A duplicates.
- Keep integration verification independent of English UI copy by using stable task-detail and tab behavior hooks.
- Express the sidebar contract in concise user-visible prose in the Desktop GUI spec.

## Verification

- Frozen dependency install: passed; no dependencies changed in the review rounds.
- Desktop lint: passed.
- TypeScript typecheck: passed.
- Full Desktop verification: 60 test files, 291 tests passed.
- Targeted final review verification: 25 tests passed; the final full run passed after the bounded-restoration fix.
- Desktop build: passed.
- Existing React act warnings were emitted by the integration test harness but did not fail tests.
- Evidence: apps/desktop/src/app/sidebarStack.test.ts; apps/desktop/src/app/sidebarProvider.test.tsx; apps/desktop/src/app/sidebarPopOut.test.ts; apps/desktop/src/features/task-detail/taskDetailSidebarState.test.ts; apps/desktop/src/features/task-detail/TaskDependenciesArea.test.tsx; apps/desktop/src/app/sidebarNavigation.integration.test.tsx; .kent/plans/KENT-356.md.

## Diff size

Compared with the current PR base commit:

- Production code: 24 files, +1,510/-207; gross 1,717 lines; net +1,303.
- Test/test-support code: 8 files, +1,181/-2; gross 1,183 lines; net +1,179. No generated files were identified; this bucket includes test-support code.
- Documentation: 1 file, +40/-19; gross 59 lines; net +21.
- Total: 33 files, +2,731/-228; gross 2,959 lines; net +2,503.

## Caveats and follow-up

- Browser/manual QA is intentionally excluded from this task by the direct human decision recorded on KENT-356; the authoritative task completion criteria now require automated verification and product-boundary tests instead.
- One earlier CI run exposed a pre-existing/flaky unrelated server workflowrunner test, TestCurrentNodeContinuationWithActiveTranscriptSubscriberDoesNotBlockLaterAutomaticScript. The failed job was rerun without code changes.
- Sidebar retention is bounded at 50 entries and deduplicates earlier Task Details during dependency cycles. KENT-369 owns the dependency picker, and KENT-372 owns unifying Task create/edit navigation destinations.

Kent task: KENT-356. No separate GitHub issue was supplied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stacked sidebar navigation for task details, including Back and close controls.
  * Preserves drafts, comments, selected tabs, and scroll position when navigating between dependencies.
  * Supports smooth transitions, pop-out behavior, and recovery after disconnection.
  * Creating a related task opens its details while preserving the originating task.

* **Bug Fixes**
  * Improved cleanup when tasks or projects are deleted.
  * Prevented invalid empty task identifiers in project routes.
  * Disabled navigation during saves while keeping dependency removal available.
  * Improved missing-task and navigation-error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->