### PR TITLE
Type Worktree Create failures

### DIFF
--- a/cli/app/internal/worktreeui/worktreecreate_create.go
+++ b/cli/app/internal/worktreeui/worktreecreate_create.go
@@ -7,13 +7,9 @@ import (
 	"core/shared/serverapi"
 )
 
-// ErrBranchTargetRequired and ErrBaseRefRequired guard worktree-create request
-// validation. Callers and tests match these with errors.Is rather than
-// comparing rendered message text.
-var (
-	ErrBranchTargetRequired = errors.New("Branch or ref is required")
-	ErrBaseRefRequired      = errors.New("Base ref is required")
-)
+// ErrBranchTargetRequired guards worktree-create target validation. Callers
+// and tests match it with errors.Is rather than comparing rendered text.
+var ErrBranchTargetRequired = errors.New("Branch or ref is required")
 
 func Request(branchTarget string, baseRef string, kind serverapi.WorktreeCreateTargetResolutionKind) (serverapi.WorktreeCreateRequest, error) {
 	if strings.TrimSpace(branchTarget) == "" {
@@ -24,8 +20,12 @@ func Request(branchTarget string, baseRef string, kind serverapi.WorktreeCreateT
 		return serverapi.WorktreeCreateRequest{BaseRef: target, CreateBranch: false}, nil
 	}
 	trimmedBaseRef := strings.TrimSpace(baseRef)
-	if trimmedBaseRef == "" {
-		return serverapi.WorktreeCreateRequest{}, ErrBaseRefRequired
+	if err := serverapi.ValidateWorktreeCreateSpec(trimmedBaseRef, true, target); err != nil {
+		return serverapi.WorktreeCreateRequest{}, serverapi.NewWorktreeCreateError(
+			serverapi.ProjectWorktreeCreateValidationOwner(err, true),
+			err.Error(),
+			err,
+		)
 	}
 	return serverapi.WorktreeCreateRequest{BaseRef: trimmedBaseRef, CreateBranch: true, BranchName: target}, nil
 }

--- a/cli/app/internal/worktreeui/worktreecreate_create_test.go
+++ b/cli/app/internal/worktreeui/worktreecreate_create_test.go
@@ -44,7 +44,9 @@ func TestRequestRejectsBlankTarget(t *testing.T) {
 }
 
 func TestRequestRejectsBlankBaseRefForNewBranch(t *testing.T) {
-	if _, err := Request("feature/a", " ", serverapi.WorktreeCreateTargetResolutionKindNewBranch); err == nil || !errors.Is(err, ErrBaseRefRequired) {
-		t.Fatalf("error = %v, want base ref required", err)
+	_, err := Request("feature/a", " ", serverapi.WorktreeCreateTargetResolutionKindNewBranch)
+	var typed *serverapi.WorktreeCreateError
+	if !errors.As(err, &typed) || typed.Owner != serverapi.WorktreeCreateErrorOwnerBaseRef {
+		t.Fatalf("error = %T %v, want Base-ref-owned create error", err, err)
 	}
 }

--- a/cli/app/ui_worktree_create_controller.go
+++ b/cli/app/ui_worktree_create_controller.go
@@ -71,6 +71,9 @@ func (d *uiWorktreeCreateDialogState) applyResolveState(state worktreeui.State) 
 	d.submitPending = state.SubmitPending
 	d.resolveToken = state.Token
 	d.resolution = state.Resolution
+	if d.resolution.Kind != serverapi.WorktreeCreateTargetResolutionKindNewBranch {
+		d.baseRefErrorText = ""
+	}
 	d.syncFocus()
 }
 
@@ -176,6 +179,7 @@ func (c uiInputController) handleWorktreeCreateDialogKey(msg tea.KeyMsg) (tea.Mo
 	}
 	if dialog.focus == uiWorktreeCreateFieldBaseRef {
 		dialog.errorText = ""
+		dialog.baseRefErrorText = ""
 	}
 	return m, cmd
 }

--- a/cli/app/ui_worktree_create_controller_test.go
+++ b/cli/app/ui_worktree_create_controller_test.go
@@ -1,9 +1,12 @@
 package app
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"core/cli/app/internal/worktreeui"
+	"core/shared/invariant"
 	"core/shared/serverapi"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -166,5 +169,140 @@ func TestWorktreeCreateCompletionSwitchesByStableWorktreeID(t *testing.T) {
 
 	if len(client.enterRequests) != 1 || client.enterRequests[0].Selector != "wt-created" {
 		t.Fatalf("enter requests = %+v, want created worktree ID", client.enterRequests)
+	}
+}
+
+func TestWorktreeCreateErrorOwnershipStopsSpinnerAndPreservesForm(t *testing.T) {
+	model := newWorktreeCreateControllerTestModel(t, nil)
+	model.worktrees.create.resolution = serverapi.WorktreeCreateTargetResolution{Kind: serverapi.WorktreeCreateTargetResolutionKindNewBranch}
+	model.worktrees.create.branchTarget.Replace(strings.NewReplacer("\r", "", "\n", "").Replace("feature/entered"))
+	model.worktrees.create.baseRef.Replace(strings.NewReplacer("\r", "", "\n", "").Replace("HEAD"))
+	model.worktrees.create.submitting = true
+	model.worktrees.mutationToken = 7
+	baseError := &serverapi.WorktreeCreateError{
+		Owner:      serverapi.WorktreeCreateErrorOwnerBaseRef,
+		Diagnostic: "base ref diagnostic",
+	}
+
+	updated := model.reduceWorktreeMessage(worktreeCreateDoneMsg{token: 7, err: baseError}).model
+
+	if updated.worktrees.create.submitting {
+		t.Fatal("create spinner remained active after failure")
+	}
+	if updated.worktrees.create.baseRefErrorText != baseError.Diagnostic {
+		t.Fatalf("base-ref error = %q, want %q", updated.worktrees.create.baseRefErrorText, baseError.Diagnostic)
+	}
+	if updated.worktrees.create.errorText != "" {
+		t.Fatalf("form error = %q, want empty for Base-ref-owned failure", updated.worktrees.create.errorText)
+	}
+	if updated.worktrees.create.branchTarget.Text() != "feature/entered" || updated.worktrees.create.baseRef.Text() != "HEAD" {
+		t.Fatalf("entered values changed: branch=%q base=%q", updated.worktrees.create.branchTarget.Text(), updated.worktrees.create.baseRef.Text())
+	}
+}
+
+func TestWorktreeCreateFormErrorsUseDialogErrorRegion(t *testing.T) {
+	model := newWorktreeCreateControllerTestModel(t, nil)
+	model.worktrees.create.submitting = true
+	model.worktrees.mutationToken = 7
+	formError := &serverapi.WorktreeCreateError{
+		Owner:      serverapi.WorktreeCreateErrorOwnerForm,
+		Diagnostic: "form diagnostic",
+	}
+
+	updated := model.reduceWorktreeMessage(worktreeCreateDoneMsg{token: 7, err: formError}).model
+
+	if updated.worktrees.create.submitting {
+		t.Fatal("create spinner remained active after failure")
+	}
+	if updated.worktrees.create.errorText != formError.Diagnostic {
+		t.Fatalf("form error = %q, want %q", updated.worktrees.create.errorText, formError.Diagnostic)
+	}
+	if updated.worktrees.create.baseRefErrorText != "" {
+		t.Fatalf("base-ref error = %q, want empty for form-owned failure", updated.worktrees.create.baseRefErrorText)
+	}
+}
+
+func TestWorktreeCreateNonTypedAndSetupRetainedErrorsUseFormRegion(t *testing.T) {
+	for _, source := range []error{
+		errors.New("transport failed"),
+		&serverapi.WorktreeSetupRetainedError{Diagnostic: "setup retained"},
+		&serverapi.WorktreeCreateContractError{Cause: errors.New("invalid contract")},
+	} {
+		model := newWorktreeCreateControllerTestModel(t, nil)
+		model.worktrees.create.submitting = true
+		model.worktrees.mutationToken = 7
+
+		updated := model.reduceWorktreeMessage(worktreeCreateDoneMsg{token: 7, err: source}).model
+
+		if updated.worktrees.create.submitting || updated.worktrees.create.errorText == "" || updated.worktrees.create.baseRefErrorText != "" {
+			t.Fatalf("source %T placed incorrectly: state=%+v", source, updated.worktrees.create)
+		}
+	}
+}
+
+func TestWorktreeCreateFieldErrorClearsWhenBaseRefIsEdited(t *testing.T) {
+	model := newWorktreeCreateControllerTestModel(t, nil)
+	model.worktrees.create.resolution = serverapi.WorktreeCreateTargetResolution{Kind: serverapi.WorktreeCreateTargetResolutionKindNewBranch}
+	model.worktrees.create.focus = uiWorktreeCreateFieldBaseRef
+	model.worktrees.create.baseRefErrorText = "old base ref error"
+
+	updated, _ := applyWorktreeCreateControllerKey(model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'H'}})
+
+	if updated.worktrees.create.baseRefErrorText != "" {
+		t.Fatalf("base-ref error = %q, want cleared after edit", updated.worktrees.create.baseRefErrorText)
+	}
+}
+
+func TestWorktreeCreateFieldErrorClearsWhenBaseRefBecomesHidden(t *testing.T) {
+	model := newWorktreeCreateControllerTestModel(t, nil)
+	model.worktrees.create.baseRefErrorText = "old base ref error"
+	model.worktrees.create.resolution = serverapi.WorktreeCreateTargetResolution{Kind: serverapi.WorktreeCreateTargetResolutionKindNewBranch}
+
+	model.worktrees.create.applyResolveState(worktreeui.State{
+		Resolution: serverapi.WorktreeCreateTargetResolution{Kind: serverapi.WorktreeCreateTargetResolutionKindExistingBranch},
+	})
+
+	if model.worktrees.create.baseRefErrorText != "" {
+		t.Fatalf("base-ref error = %q, want cleared when field is hidden", model.worktrees.create.baseRefErrorText)
+	}
+}
+
+func TestWorktreeCreateInvalidTypedErrorUsesContractPolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		invalid *serverapi.WorktreeCreateError
+	}{
+		{name: "invalid owner", invalid: &serverapi.WorktreeCreateError{Owner: "invalid", Diagnostic: "invalid owner"}},
+		{name: "blank diagnostic", invalid: &serverapi.WorktreeCreateError{Owner: serverapi.WorktreeCreateErrorOwnerForm, Diagnostic: ""}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			invalid := test.invalid
+			model := newWorktreeCreateControllerTestModel(t, nil)
+			model.worktrees.create.submitting = true
+			model.worktrees.create.baseRefErrorText = "stale"
+
+			model.debugMode = false
+			model.applyWorktreeCreateError(invalid)
+			if model.worktrees.create.errorText == "" || model.worktrees.create.baseRefErrorText != "" {
+				t.Fatalf("release invalid typed state = %+v, want form-level contract error", model.worktrees.create)
+			}
+
+			model.debugMode = true
+			defer func() {
+				recovered := recover()
+				diagnostic, ok := recovered.(invariant.Diagnostic)
+				if !ok {
+					t.Fatalf("panic payload = %T, want invariant.Diagnostic", recovered)
+				}
+				if diagnostic.Fields[invariant.FieldOperation] == "" ||
+					diagnostic.Fields[invariant.FieldRawOwner] == "" ||
+					diagnostic.Fields[invariant.FieldValidationCause] == "" ||
+					diagnostic.Stack == "" {
+					t.Fatalf("invariant diagnostic = %+v, want operation/raw owner/cause/stack", diagnostic)
+				}
+			}()
+			model.applyWorktreeCreateError(invalid)
+		})
 	}
 }

--- a/cli/app/ui_worktree_reducer.go
+++ b/cli/app/ui_worktree_reducer.go
@@ -289,8 +289,8 @@ func (m *uiModel) reduceWorktreeMessage(msg tea.Msg) uiFeatureUpdateResult {
 }
 
 type worktreeCreateErrorPlacement struct {
-	baseRef string
-	form    string
+	owner      serverapi.WorktreeCreateErrorOwner
+	diagnostic string
 }
 
 func (m *uiModel) applyWorktreeCreateError(err error) {
@@ -298,27 +298,56 @@ func (m *uiModel) applyWorktreeCreateError(err error) {
 		return
 	}
 	placement := classifyWorktreeCreateError(err, worktreeCreateInvariantPolicy(m.debugMode))
-	m.worktrees.create.baseRefErrorText = placement.baseRef
-	m.worktrees.create.errorText = placement.form
+	m.worktrees.create.baseRefErrorText = ""
+	m.worktrees.create.errorText = ""
+	if placement == nil {
+		return
+	}
+	switch placement.owner {
+	case serverapi.WorktreeCreateErrorOwnerBaseRef:
+		m.worktrees.create.baseRefErrorText = placement.diagnostic
+	case serverapi.WorktreeCreateErrorOwnerForm:
+		m.worktrees.create.errorText = placement.diagnostic
+	default:
+		m.worktrees.create.errorText = placement.diagnostic
+	}
 }
 
-func classifyWorktreeCreateError(err error, policy invariant.Policy) worktreeCreateErrorPlacement {
+func classifyWorktreeCreateError(err error, policy invariant.Policy) *worktreeCreateErrorPlacement {
 	if err == nil {
-		return worktreeCreateErrorPlacement{}
+		return nil
 	}
 	if contractErr := serverapi.ValidateWorktreeCreateErrorBoundary(err, "cli.worktree.create", policy); contractErr != nil {
-		return worktreeCreateErrorPlacement{form: runtimeattach.FormatSubmissionError(contractErr)}
+		return &worktreeCreateErrorPlacement{
+			owner:      serverapi.WorktreeCreateErrorOwnerForm,
+			diagnostic: runtimeattach.FormatSubmissionError(contractErr),
+		}
 	}
 	var typed *serverapi.WorktreeCreateError
 	if errors.As(err, &typed) {
+		if typed == nil {
+			return &worktreeCreateErrorPlacement{
+				owner:      serverapi.WorktreeCreateErrorOwnerForm,
+				diagnostic: runtimeattach.FormatSubmissionError(err),
+			}
+		}
 		switch typed.Owner {
 		case serverapi.WorktreeCreateErrorOwnerBaseRef:
-			return worktreeCreateErrorPlacement{baseRef: typed.Diagnostic}
+			return &worktreeCreateErrorPlacement{
+				owner:      serverapi.WorktreeCreateErrorOwnerBaseRef,
+				diagnostic: typed.Diagnostic,
+			}
 		case serverapi.WorktreeCreateErrorOwnerForm:
-			return worktreeCreateErrorPlacement{form: typed.Diagnostic}
+			return &worktreeCreateErrorPlacement{
+				owner:      serverapi.WorktreeCreateErrorOwnerForm,
+				diagnostic: typed.Diagnostic,
+			}
 		}
 	}
-	return worktreeCreateErrorPlacement{form: runtimeattach.FormatSubmissionError(err)}
+	return &worktreeCreateErrorPlacement{
+		owner:      serverapi.WorktreeCreateErrorOwnerForm,
+		diagnostic: runtimeattach.FormatSubmissionError(err),
+	}
 }
 
 func worktreeCreateInvariantPolicy(debugMode bool) invariant.Policy {

--- a/cli/app/ui_worktree_reducer.go
+++ b/cli/app/ui_worktree_reducer.go
@@ -7,6 +7,7 @@ import (
 	"core/cli/app/internal/runtimeattach"
 	"core/cli/app/internal/worktreeui"
 	"core/shared/clientui"
+	"core/shared/invariant"
 	"core/shared/serverapi"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -133,7 +134,7 @@ func (m *uiModel) reduceWorktreeMessage(msg tea.Msg) uiFeatureUpdateResult {
 				m.layout().syncViewport()
 				return handledUIFeatureUpdate(m, m.sendTransientStatusWithNoticeID(status, uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, ""))
 			}
-			m.worktrees.create.errorText = runtimeattach.FormatSubmissionError(msg.err)
+			m.applyWorktreeCreateError(msg.err)
 			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, m.reconcileSpinnerTicking(false))
 		}
@@ -167,7 +168,7 @@ func (m *uiModel) reduceWorktreeMessage(msg tea.Msg) uiFeatureUpdateResult {
 			return handledUIFeatureUpdate(m, nil)
 		}
 		if msg.err != nil {
-			m.worktrees.create.errorText = runtimeattach.FormatSubmissionError(msg.err)
+			m.applyWorktreeCreateError(msg.err)
 			m.layout().syncViewport()
 			return handledUIFeatureUpdate(m, m.reconcileSpinnerTicking(false))
 		}
@@ -275,7 +276,7 @@ func (m *uiModel) reduceWorktreeMessage(msg tea.Msg) uiFeatureUpdateResult {
 		if outcome.Submit {
 			req, err := worktreeui.Request(m.worktrees.create.branchTarget.Text(), m.worktrees.create.baseRef.Text(), outcome.SubmitKind)
 			if err != nil {
-				m.worktrees.create.errorText = err.Error()
+				m.applyWorktreeCreateError(err)
 				m.layout().syncViewport()
 				return handledUIFeatureUpdate(m, nil)
 			}
@@ -285,4 +286,45 @@ func (m *uiModel) reduceWorktreeMessage(msg tea.Msg) uiFeatureUpdateResult {
 		return handledUIFeatureUpdate(m, nil)
 	}
 	return uiFeatureUpdateResult{}
+}
+
+type worktreeCreateErrorPlacement struct {
+	baseRef string
+	form    string
+}
+
+func (m *uiModel) applyWorktreeCreateError(err error) {
+	if m == nil {
+		return
+	}
+	placement := classifyWorktreeCreateError(err, worktreeCreateInvariantPolicy(m.debugMode))
+	m.worktrees.create.baseRefErrorText = placement.baseRef
+	m.worktrees.create.errorText = placement.form
+}
+
+func classifyWorktreeCreateError(err error, policy invariant.Policy) worktreeCreateErrorPlacement {
+	if err == nil {
+		return worktreeCreateErrorPlacement{}
+	}
+	if contractErr := serverapi.ValidateWorktreeCreateErrorBoundary(err, "cli.worktree.create", policy); contractErr != nil {
+		return worktreeCreateErrorPlacement{form: runtimeattach.FormatSubmissionError(contractErr)}
+	}
+	var typed *serverapi.WorktreeCreateError
+	if errors.As(err, &typed) {
+		switch typed.Owner {
+		case serverapi.WorktreeCreateErrorOwnerBaseRef:
+			return worktreeCreateErrorPlacement{baseRef: typed.Diagnostic}
+		case serverapi.WorktreeCreateErrorOwnerForm:
+			return worktreeCreateErrorPlacement{form: typed.Diagnostic}
+		}
+	}
+	return worktreeCreateErrorPlacement{form: runtimeattach.FormatSubmissionError(err)}
+}
+
+func worktreeCreateInvariantPolicy(debugMode bool) invariant.Policy {
+	mode := invariant.ModeDiagnostic
+	if debugMode {
+		mode = invariant.ModePanic
+	}
+	return invariant.NewPolicy(invariant.WithMode(mode))
 }

--- a/cli/app/ui_worktree_render.go
+++ b/cli/app/ui_worktree_render.go
@@ -254,7 +254,7 @@ func (l uiViewLayout) renderWorktreeCreateDialog(width, height int, style uiStyl
 	})
 	addSection(uiWorktreeCreateFieldBranchTarget, true, l.renderWorktreeCreateTargetField(width, dialog))
 	usesBaseRef := dialog.resolution.Kind == serverapi.WorktreeCreateTargetResolutionKindNewBranch
-	addSection(uiWorktreeCreateFieldBaseRef, usesBaseRef, l.renderWorktreeCreateField(width, style, "Base ref", "Used when creating a new branch.", dialog.baseRef, dialog.focus == uiWorktreeCreateFieldBaseRef, usesBaseRef))
+	addSection(uiWorktreeCreateFieldBaseRef, usesBaseRef, l.renderWorktreeCreateField(width, style, "Base ref", "Used when creating a new branch.", dialog.baseRef, dialog.baseRefErrorText, dialog.focus == uiWorktreeCreateFieldBaseRef, usesBaseRef))
 	addSection(uiWorktreeCreateFieldActions, true, renderWorktreeCreateActionGroup(width, m.theme, dialog, dialog.focus == uiWorktreeCreateFieldActions))
 	footer := make([]string, 0, 3)
 	if dialog.submitting {
@@ -336,7 +336,7 @@ func (l uiViewLayout) renderWorktreeCreateTargetField(width int, dialog uiWorktr
 	return lines
 }
 
-func (l uiViewLayout) renderWorktreeCreateField(width int, style uiStyles, label string, helper string, input tuiinput.Editor, focused bool, enabled bool) []string {
+func (l uiViewLayout) renderWorktreeCreateField(width int, style uiStyles, label string, helper string, input tuiinput.Editor, errorText string, focused bool, enabled bool) []string {
 	p := uiPalette(l.model.theme)
 	rowStyle := lipgloss.NewStyle()
 	if focused {
@@ -361,6 +361,9 @@ func (l uiViewLayout) renderWorktreeCreateField(width int, style uiStyles, label
 		lines = append(lines, helperStyle.Render(padANSIRight(truncateQueuedMessageLine(helper, contentWidth), contentWidth)))
 	}
 	lines = append(lines, renderSingleLineEditorFramedSoftCursorLines(contentWidth, 1, input, "› ", focused && enabled && l.model.terminalCursor == nil, lineStyle, borderStyle, 0, "")...)
+	if strings.TrimSpace(errorText) != "" {
+		lines = append(lines, renderWorktreeErrorLines(errorText, contentWidth, lipgloss.NewStyle().Foreground(sharedtheme.DefaultPalette().Status.Error.Adaptive()).Bold(true), worktreeOverlayMaxErrorLines)...)
+	}
 	return lines
 }
 

--- a/cli/app/ui_worktrees.go
+++ b/cli/app/ui_worktrees.go
@@ -67,18 +67,19 @@ const (
 )
 
 type uiWorktreeCreateDialogState struct {
-	baseRef       tuiinput.Editor
-	branchTarget  tuiinput.Editor
-	focus         uiWorktreeCreateField
-	action        uiWorktreeCreateAction
-	errorText     string
-	submitting    bool
-	resolving     bool
-	submitPending bool
-	resolveToken  uint64
-	resolution    serverapi.WorktreeCreateTargetResolution
-	setupProgress *uiWorktreeSetupProgressState
-	setupEvent    *serverapi.WorktreeSetupEvent
+	baseRef          tuiinput.Editor
+	branchTarget     tuiinput.Editor
+	focus            uiWorktreeCreateField
+	action           uiWorktreeCreateAction
+	errorText        string
+	baseRefErrorText string
+	submitting       bool
+	resolving        bool
+	submitPending    bool
+	resolveToken     uint64
+	resolution       serverapi.WorktreeCreateTargetResolution
+	setupProgress    *uiWorktreeSetupProgressState
+	setupEvent       *serverapi.WorktreeSetupEvent
 }
 
 type uiWorktreeSetupProgressState struct {
@@ -466,6 +467,7 @@ func (m *uiModel) worktreeCreateCmd(req serverapi.WorktreeCreateRequest) tea.Cmd
 		req.SetupOperationID = serverapi.NewWorktreeSetupOperationID()
 	}
 	m.worktrees.create.errorText = ""
+	m.worktrees.create.baseRefErrorText = ""
 	m.worktrees.create.submitting = true
 	m.worktrees.create.setupEvent = nil
 	setupCtx, cancel := context.WithCancel(context.Background())

--- a/docs/dev/specs/desktop-chat.md
+++ b/docs/dev/specs/desktop-chat.md
@@ -270,10 +270,15 @@
 - Desktop never falls back to the current branch, `main`, or a generated generic Worktree name.
 - Desktop resolves `Branch or ref` asynchronously and presents the typed result as `New branch`, `Existing branch`, or `Detached ref`. It has no explicit new/existing target selector.
 - `Base ref` defaults to `HEAD` and is shown and enabled only when the target resolves as a new branch.
+- Before creating a new branch, the server must resolve `Base ref` once to an immutable commit. The server must use that commit for creation.
+- Blank, invalid, and unresolved Base refs must be owned by the `Base ref` field.
+- A failure after successful Base-ref resolution must be owned by the creation form, including a race in which the resolved commit disappears before creation.
+- Desktop must use typed ownership to place creation failures. Desktop must never inspect diagnostic text to choose between the `Base ref` field and the creation form.
 - The creation state has no custom filesystem-path field. Kent uses the configured worktree base directory.
 - The primary creation action is `Create`. Back returns to the Worktree list without creating anything.
 - While creation and optional setup run, the creation child state shows one simple spinner for the complete operation.
 - Desktop does not expose setup phases, phase labels, percentage progress, or a progress bar.
+- If creation fails before a worktree exists, Desktop must stop the spinner. Desktop must preserve every entered value. Desktop must show the authoritative diagnostic inline at its typed owner.
 - If optional setup fails, Desktop returns immediately to the refreshed Worktree list and shows the authoritative diagnostic through Sonner.
 - Setup failure preserves the created worktree and does not offer an inline Error state, Retry action, or automatic deletion.
 - Successful creation waits for optional setup to finish and then applies the ordinary Switch operation for the new worktree.

--- a/server/transport/gateway_part3_test.go
+++ b/server/transport/gateway_part3_test.go
@@ -555,6 +555,38 @@ func TestDecodeAndHandlePreservesWorktreeStructuredErrors(t *testing.T) {
 	}
 }
 
+func TestDecodeAndHandlePreservesWorktreeCreateOwnership(t *testing.T) {
+	source := &serverapi.WorktreeCreateError{
+		Owner:      serverapi.WorktreeCreateErrorOwnerBaseRef,
+		Diagnostic: errors.Join(
+			errors.New("base ref object disappeared"),
+			errors.New("cleanup removed no worktree"),
+		).Error(),
+	}
+	response := decodeAndHandle[serverapi.WorktreeCreateRequest, serverapi.WorktreeCreateResponse](
+		protocol.Request{
+			ID: "worktree-create-error",
+			Params: mustJSON(t, serverapi.WorktreeCreateRequest{
+				ClientRequestID:  "request-1",
+				SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+				SessionID:        "session",
+				BaseRef:          "HEAD",
+				CreateBranch:     true,
+				BranchName:       "feature",
+			}),
+		},
+		func(serverapi.WorktreeCreateRequest) (serverapi.WorktreeCreateResponse, error) {
+			return serverapi.WorktreeCreateResponse{}, source
+		},
+	)
+	if response.Error == nil || response.Error.Code != protocol.ErrCodeWorktreeCreate {
+		t.Fatalf("response error = %+v, want worktree create code", response.Error)
+	}
+	if !reflect.DeepEqual(response.Error.Data, source.RPCErrorData()) {
+		t.Fatalf("response data = %s, want %s", response.Error.Data, source.RPCErrorData())
+	}
+}
+
 func TestDecodeAndHandleRejectsInvalidWorkflowActionResponse(t *testing.T) {
 	response := decodeAndHandle[struct{}, serverapi.WorkflowTaskStartResponse](
 		protocol.Request{ID: "invalid-workflow-action-response", Params: mustJSON(t, struct{}{})},

--- a/server/transport/gateway_part3_test.go
+++ b/server/transport/gateway_part3_test.go
@@ -557,7 +557,7 @@ func TestDecodeAndHandlePreservesWorktreeStructuredErrors(t *testing.T) {
 
 func TestDecodeAndHandlePreservesWorktreeCreateOwnership(t *testing.T) {
 	source := &serverapi.WorktreeCreateError{
-		Owner:      serverapi.WorktreeCreateErrorOwnerBaseRef,
+		Owner: serverapi.WorktreeCreateErrorOwnerBaseRef,
 		Diagnostic: errors.Join(
 			errors.New("base ref object disappeared"),
 			errors.New("cleanup removed no worktree"),

--- a/server/worktree/create_error_test.go
+++ b/server/worktree/create_error_test.go
@@ -1,0 +1,300 @@
+package worktree
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"testing"
+
+	"core/shared/serverapi"
+)
+
+type recordingGitCommandRunner struct {
+	delegate            gitCommandRunner
+	calls               [][]string
+	failWorktreeAdd     error
+	failPostCreateList  error
+	failWorktreeRemove  error
+	succeedBranchDelete bool
+	worktreeAdded       bool
+	createdRoot         string
+}
+
+func (r *recordingGitCommandRunner) Run(ctx context.Context, dir string, args ...string) ([]byte, int, error) {
+	r.record(args)
+	if r.worktreeAdded && slices.Equal(args, []string{"worktree", "list", "--porcelain"}) && r.failPostCreateList != nil {
+		return nil, 1, r.failPostCreateList
+	}
+	return r.delegate.Run(ctx, dir, args...)
+}
+
+func (r *recordingGitCommandRunner) Output(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	r.record(args)
+	if len(args) >= 2 && args[0] == "worktree" && args[1] == "add" {
+		if r.failWorktreeAdd != nil {
+			return nil, r.failWorktreeAdd
+		}
+		output, err := r.delegate.Output(ctx, dir, args...)
+		if err == nil {
+			r.worktreeAdded = true
+			if len(args) >= 2 {
+				r.createdRoot = args[len(args)-2]
+			}
+		}
+		return output, err
+	}
+	if len(args) >= 2 && args[0] == "worktree" && args[1] == "remove" && r.failWorktreeRemove != nil {
+		return nil, r.failWorktreeRemove
+	}
+	if r.succeedBranchDelete && slices.Equal(args, []string{"branch", "-d", "feature/post-create-cleanup"}) {
+		return nil, nil
+	}
+	return r.delegate.Output(ctx, dir, args...)
+}
+
+func (r *recordingGitCommandRunner) record(args []string) {
+	r.calls = append(r.calls, append([]string(nil), args...))
+}
+
+func (r *recordingGitCommandRunner) resetCalls() {
+	r.calls = nil
+}
+
+func hasGitCall(calls [][]string, want []string) bool {
+	for _, call := range calls {
+		if slices.Equal(call, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCreateWorktreeRejectsBlankBaseRefBeforeGit(t *testing.T) {
+	env := newServiceTestEnv(t)
+	runner := &recordingGitCommandRunner{delegate: execGitCommandRunner{}}
+	env.service.git = NewGitInspector(runner)
+
+	_, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "blank-base-ref",
+		SessionID:        env.session.Meta().SessionID,
+		CreateBranch:     true,
+		BranchName:       "feature/blank-base-ref",
+	})
+	var typed *serverapi.WorktreeCreateError
+	if !errors.As(err, &typed) || typed.Owner != serverapi.WorktreeCreateErrorOwnerBaseRef {
+		t.Fatalf("CreateWorktree error = %T %v, want Base-ref-owned error", err, err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("Git calls = %v, want none", runner.calls)
+	}
+}
+
+func TestCreateWorktreeResolvesBaseRefOnceAndUsesCommitOIDForAdd(t *testing.T) {
+	env := newServiceTestEnv(t)
+	runner := &recordingGitCommandRunner{delegate: execGitCommandRunner{}}
+	env.service.git = NewGitInspector(runner)
+	commitOID := runGit(t, env.workspaceRoot, "rev-parse", "HEAD")
+
+	_, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "resolved-base-ref",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "HEAD",
+		CreateBranch:     true,
+		BranchName:       "feature/resolved-base-ref",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	if !hasGitCall(runner.calls, []string{"rev-parse", "--verify", "--quiet", "HEAD^{object}"}) ||
+		!hasGitCall(runner.calls, []string{"rev-parse", "--verify", "--quiet", "HEAD^{commit}"}) ||
+		!hasGitCall(runner.calls, []string{"rev-parse", "--symbolic-full-name", "--verify", "--quiet", "HEAD"}) {
+		t.Fatalf("Base-ref resolution calls = %v, want one authoritative resolution", runner.calls)
+	}
+	resolutionCount := 0
+	for _, call := range runner.calls {
+		if slices.Equal(call, []string{"rev-parse", "--verify", "--quiet", "HEAD^{object}"}) {
+			resolutionCount++
+		}
+	}
+	if resolutionCount != 1 {
+		t.Fatalf("object resolution count = %d, want one", resolutionCount)
+	}
+	var addCall []string
+	for _, call := range runner.calls {
+		if len(call) >= 2 && call[0] == "worktree" && call[1] == "add" {
+			addCall = call
+			break
+		}
+	}
+	if len(addCall) == 0 {
+		t.Fatalf("Git calls = %v, want worktree add", runner.calls)
+	}
+	if addCall[len(addCall)-1] != commitOID {
+		t.Fatalf("worktree add args = %v, want resolved commit oid %q", addCall, commitOID)
+	}
+	if slices.Contains(addCall, "HEAD") {
+		t.Fatalf("worktree add received moving Base ref: %v", addCall)
+	}
+}
+
+func TestCreateWorktreeBaseRefResolutionFailuresAreBaseRefOwned(t *testing.T) {
+	env := newServiceTestEnv(t)
+	runner := &recordingGitCommandRunner{delegate: execGitCommandRunner{}}
+	env.service.git = NewGitInspector(runner)
+	blobPath := t.TempDir() + "/blob"
+	writeFile(t, blobPath, "blob object")
+	blobOID := runGit(t, env.workspaceRoot, "hash-object", "-w", blobPath)
+	tests := []struct {
+		name    string
+		baseRef string
+	}{
+		{name: "invalid", baseRef: "HEAD^{not-a-revision}"},
+		{name: "unresolved", baseRef: "missing-revision"},
+		{name: "non-commit", baseRef: blobOID},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, expectedErr := env.service.git.ResolveRevision(env.ctx, env.workspaceRoot, test.baseRef)
+			var expectedResolutionErr *GitRevisionResolutionError
+			if !errors.As(expectedErr, &expectedResolutionErr) {
+				t.Fatalf("direct resolution error = %T %v, want GitRevisionResolutionError", expectedErr, expectedErr)
+			}
+			runner.resetCalls()
+			_, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+				SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+				ClientRequestID:  "resolve-" + test.name,
+				SessionID:        env.session.Meta().SessionID,
+				BaseRef:          test.baseRef,
+				CreateBranch:     true,
+				BranchName:       "feature/resolve-" + test.name,
+			})
+			var typed *serverapi.WorktreeCreateError
+			if !errors.As(err, &typed) || typed.Owner != serverapi.WorktreeCreateErrorOwnerBaseRef {
+				t.Fatalf("CreateWorktree error = %T %v, want Base-ref-owned error", err, err)
+			}
+			if typed.Diagnostic != expectedErr.Error() {
+				t.Fatalf("diagnostic = %q, want resolver diagnostic %q", typed.Diagnostic, expectedErr.Error())
+			}
+			var resolutionErr *GitRevisionResolutionError
+			if !errors.As(err, &resolutionErr) {
+				t.Fatalf("CreateWorktree error = %T %v, want resolver cause", err, err)
+			}
+		})
+	}
+}
+
+func TestCreateWorktreePostResolutionAddFailureIsFormOwned(t *testing.T) {
+	env := newServiceTestEnv(t)
+	addErr := errors.New("worktree add lost resolved object")
+	runner := &recordingGitCommandRunner{
+		delegate:        execGitCommandRunner{},
+		failWorktreeAdd: addErr,
+	}
+	env.service.git = NewGitInspector(runner)
+
+	_, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "post-resolution-add",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "HEAD",
+		CreateBranch:     true,
+		BranchName:       "feature/post-resolution-add",
+	})
+	var typed *serverapi.WorktreeCreateError
+	if !errors.As(err, &typed) || typed.Owner != serverapi.WorktreeCreateErrorOwnerForm {
+		t.Fatalf("CreateWorktree error = %T %v, want form-owned error", err, err)
+	}
+	if !errors.Is(err, addErr) {
+		t.Fatalf("CreateWorktree error = %v, want add cause %v", err, addErr)
+	}
+	if typed.Diagnostic != addErr.Error() {
+		t.Fatalf("diagnostic = %q, want add diagnostic %q", typed.Diagnostic, addErr.Error())
+	}
+}
+
+func TestCreateWorktreeExistingAndDetachedTargetsDoNotResolveBaseRefAgain(t *testing.T) {
+	env := newServiceTestEnv(t)
+	runGit(t, env.workspaceRoot, "branch", "feature/existing-create")
+	runner := &recordingGitCommandRunner{delegate: execGitCommandRunner{}}
+	env.service.git = NewGitInspector(runner)
+
+	_, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "existing-target",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "feature/existing-create",
+		BranchName:       "",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree existing branch: %v", err)
+	}
+	if hasGitCall(runner.calls, []string{"rev-parse", "--verify", "--quiet", "feature/existing-create^{commit}"}) {
+		t.Fatalf("existing branch creation resolved Base ref a second time: %v", runner.calls)
+	}
+
+	runner.resetCalls()
+	_, err = env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "detached-target",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "HEAD",
+	})
+	var typed *serverapi.WorktreeCreateError
+	if !errors.As(err, &typed) || typed.Owner != serverapi.WorktreeCreateErrorOwnerForm {
+		t.Fatalf("detached CreateWorktree error = %T %v, want form-owned error", err, err)
+	}
+	if hasGitCall(runner.calls, []string{"rev-parse", "--verify", "--quiet", "HEAD^{commit}"}) {
+		t.Fatalf("detached creation resolved Base ref a second time: %v", runner.calls)
+	}
+}
+
+func TestCreateWorktreeJoinsPostCreateAndCleanupCausesBeforeFormClassification(t *testing.T) {
+	env := newServiceTestEnv(t)
+	postCreateErr := errors.New("post-create inspection failed")
+	cleanupErr := errors.New("cleanup remove failed")
+	runner := &recordingGitCommandRunner{
+		delegate:            execGitCommandRunner{},
+		failPostCreateList:  postCreateErr,
+		failWorktreeRemove:  cleanupErr,
+		succeedBranchDelete: true,
+	}
+	env.service.git = NewGitInspector(runner)
+
+	_, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "post-create-cleanup",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "HEAD",
+		CreateBranch:     true,
+		BranchName:       "feature/post-create-cleanup",
+	})
+	var listErr *GitWorktreeListError
+	if !errors.As(err, &listErr) || !errors.Is(err, postCreateErr) || !errors.Is(err, cleanupErr) {
+		t.Fatalf("CreateWorktree error = %T %v, want joined list and cleanup causes", err, err)
+	}
+	var typed *serverapi.WorktreeCreateError
+	if !errors.As(err, &typed) || typed.Owner != serverapi.WorktreeCreateErrorOwnerForm {
+		t.Fatalf("CreateWorktree error = %T %v, want form-owned error", err, err)
+	}
+	expectedSource := errors.Join(
+		&GitWorktreeListError{
+			Kind:  GitWorktreeListErrorInspectionFailed,
+			Cause: fmt.Errorf("git worktree list --porcelain: %w", postCreateErr),
+		},
+		fmt.Errorf("remove failed worktree %q: %w", runner.createdRoot, cleanupErr),
+	)
+	if typed.Diagnostic != expectedSource.Error() {
+		t.Fatalf("diagnostic = %q, want joined source diagnostic %q", typed.Diagnostic, expectedSource.Error())
+	}
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %q: %v", path, err)
+	}
+}

--- a/server/worktree/create_error_test.go
+++ b/server/worktree/create_error_test.go
@@ -110,9 +110,11 @@ func TestCreateWorktreeResolvesBaseRefOnceAndUsesCommitOIDForAdd(t *testing.T) {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
 	if !hasGitCall(runner.calls, []string{"rev-parse", "--verify", "--quiet", "HEAD^{object}"}) ||
-		!hasGitCall(runner.calls, []string{"rev-parse", "--verify", "--quiet", "HEAD^{commit}"}) ||
-		!hasGitCall(runner.calls, []string{"rev-parse", "--symbolic-full-name", "--verify", "--quiet", "HEAD"}) {
+		!hasGitCall(runner.calls, []string{"rev-parse", "--verify", "--quiet", "HEAD^{commit}"}) {
 		t.Fatalf("Base-ref resolution calls = %v, want one authoritative resolution", runner.calls)
+	}
+	if hasGitCall(runner.calls, []string{"rev-parse", "--symbolic-full-name", "--verify", "--quiet", "HEAD"}) {
+		t.Fatalf("Base-ref resolution followed the moving ref after capturing its commit: %v", runner.calls)
 	}
 	resolutionCount := 0
 	for _, call := range runner.calls {
@@ -184,6 +186,39 @@ func TestCreateWorktreeBaseRefResolutionFailuresAreBaseRefOwned(t *testing.T) {
 				t.Fatalf("CreateWorktree error = %T %v, want resolver cause", err, err)
 			}
 		})
+	}
+}
+
+func TestCreateWorktreeGitBaseRefResolutionFailureIsFormOwned(t *testing.T) {
+	env := newServiceTestEnv(t)
+	resolveErr := errors.New("git object database is inaccessible")
+	runner := &recordingGitCommandRunner{
+		delegate: &stubGitCommandRunner{
+			results: map[string]stubGitCommandResult{
+				gitCommandKey("rev-parse", "--verify", "--quiet", "HEAD^{object}"): {
+					err:      resolveErr,
+					exitCode: 2,
+				},
+			},
+		},
+	}
+	env.service.git = NewGitInspector(runner)
+
+	_, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "resolve-git-failure",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "HEAD",
+		CreateBranch:     true,
+		BranchName:       "feature/resolve-git-failure",
+	})
+	var typed *serverapi.WorktreeCreateError
+	if !errors.As(err, &typed) || typed.Owner != serverapi.WorktreeCreateErrorOwnerForm {
+		t.Fatalf("CreateWorktree error = %T %v, want form-owned error", err, err)
+	}
+	var revisionErr *GitRevisionResolutionError
+	if !errors.As(err, &revisionErr) || revisionErr.Kind != GitRevisionResolutionErrorGitFailure {
+		t.Fatalf("CreateWorktree error = %T %v, want GitFailure resolution error", err, err)
 	}
 }
 

--- a/server/worktree/create_error_test.go
+++ b/server/worktree/create_error_test.go
@@ -222,6 +222,42 @@ func TestCreateWorktreeGitBaseRefResolutionFailureIsFormOwned(t *testing.T) {
 	}
 }
 
+func TestCreateWorktreeCommitResolutionInfrastructureFailureIsFormOwned(t *testing.T) {
+	env := newServiceTestEnv(t)
+	resolveErr := errors.New("git object database is inaccessible")
+	runner := &recordingGitCommandRunner{
+		delegate: &stubGitCommandRunner{
+			results: map[string]stubGitCommandResult{
+				gitCommandKey("rev-parse", "--verify", "--quiet", "HEAD^{object}"): {
+					output: []byte("object\n"),
+				},
+				gitCommandKey("rev-parse", "--verify", "--quiet", "HEAD^{commit}"): {
+					err:      resolveErr,
+					exitCode: 2,
+				},
+			},
+		},
+	}
+	env.service.git = NewGitInspector(runner)
+
+	_, err := env.service.CreateWorktree(env.ctx, serverapi.WorktreeCreateRequest{
+		SetupOperationID: serverapi.NewWorktreeSetupOperationID(),
+		ClientRequestID:  "resolve-commit-git-failure",
+		SessionID:        env.session.Meta().SessionID,
+		BaseRef:          "HEAD",
+		CreateBranch:     true,
+		BranchName:       "feature/resolve-commit-git-failure",
+	})
+	var typed *serverapi.WorktreeCreateError
+	if !errors.As(err, &typed) || typed.Owner != serverapi.WorktreeCreateErrorOwnerForm {
+		t.Fatalf("CreateWorktree error = %T %v, want form-owned error", err, err)
+	}
+	var revisionErr *GitRevisionResolutionError
+	if !errors.As(err, &revisionErr) || revisionErr.Kind != GitRevisionResolutionErrorGitFailure {
+		t.Fatalf("CreateWorktree error = %T %v, want GitFailure resolution error", err, err)
+	}
+}
+
 func TestCreateWorktreePostResolutionAddFailureIsFormOwned(t *testing.T) {
 	env := newServiceTestEnv(t)
 	addErr := errors.New("worktree add lost resolved object")

--- a/server/worktree/git.go
+++ b/server/worktree/git.go
@@ -14,10 +14,6 @@ import (
 	"core/shared/serverapi"
 )
 
-// ErrBaseRefRequired is returned when a create spec omits a required base ref.
-// Callers match it via errors.Is; the create_branch context is added with %w.
-var ErrBaseRefRequired = errors.New("base ref is required")
-
 var errGitTargetNotFound = errors.New("git target not found")
 
 // InvalidCreateTargetError reports that a requested create target is neither a
@@ -1109,22 +1105,10 @@ func (i *GitInspector) deleteBranch(ctx context.Context, workspaceRoot string, b
 func normalizeCreateSpec(spec CreateSpec) (CreateSpec, error) {
 	baseRef := strings.TrimSpace(spec.BaseRef)
 	branchName := strings.TrimSpace(spec.BranchName)
-	if spec.CreateBranch {
-		if branchName == "" {
-			return CreateSpec{}, fmt.Errorf("branch name is required when create_branch=true")
-		}
-		if baseRef == "" {
-			return CreateSpec{}, fmt.Errorf("%w when create_branch=true", ErrBaseRefRequired)
-		}
-		return CreateSpec{BaseRef: baseRef, CreateBranch: true, BranchName: branchName}, nil
+	if err := serverapi.ValidateWorktreeCreateSpec(baseRef, spec.CreateBranch, branchName); err != nil {
+		return CreateSpec{}, err
 	}
-	if baseRef == "" {
-		return CreateSpec{}, fmt.Errorf("%w when create_branch=false", ErrBaseRefRequired)
-	}
-	if branchName != "" {
-		return CreateSpec{}, fmt.Errorf("branch name must be empty when create_branch=false")
-	}
-	return CreateSpec{BaseRef: baseRef, CreateBranch: false}, nil
+	return CreateSpec{BaseRef: baseRef, CreateBranch: spec.CreateBranch, BranchName: branchName}, nil
 }
 
 type execGitCommandRunner struct{}

--- a/server/worktree/git.go
+++ b/server/worktree/git.go
@@ -349,6 +349,14 @@ func (i *GitInspector) ResolveHEAD(ctx context.Context, workspaceRoot string) (G
 }
 
 func (i *GitInspector) ResolveRevision(ctx context.Context, workspaceRoot string, revision string) (GitRevision, error) {
+	return i.resolveRevision(ctx, workspaceRoot, revision, true)
+}
+
+func (i *GitInspector) ResolveRevisionCommit(ctx context.Context, workspaceRoot string, revision string) (GitRevision, error) {
+	return i.resolveRevision(ctx, workspaceRoot, revision, false)
+}
+
+func (i *GitInspector) resolveRevision(ctx context.Context, workspaceRoot string, revision string, resolveCanonicalRef bool) (GitRevision, error) {
 	if i == nil {
 		return GitRevision{}, fmt.Errorf("git inspector is required")
 	}
@@ -406,6 +414,12 @@ func (i *GitInspector) ResolveRevision(ctx context.Context, workspaceRoot string
 			RequestedRef: requestedRef,
 			Cause:        fmt.Errorf("git %s returned no commit oid", strings.Join(commitArgs, " ")),
 		}
+	}
+	if !resolveCanonicalRef {
+		return GitRevision{
+			RequestedRef: requestedRef,
+			CommitOID:    commitOID,
+		}, nil
 	}
 
 	symbolicArgs := []string{"rev-parse", "--symbolic-full-name", "--verify", "--quiet", requestedRef}

--- a/server/worktree/git.go
+++ b/server/worktree/git.go
@@ -397,9 +397,9 @@ func (i *GitInspector) resolveRevision(ctx context.Context, workspaceRoot string
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return GitRevision{}, ctxErr
 		}
-		kind := GitRevisionResolutionErrorNonCommit
-		if exitCode < 0 {
-			kind = GitRevisionResolutionErrorGitFailure
+		kind := GitRevisionResolutionErrorGitFailure
+		if exitCode == 1 {
+			kind = GitRevisionResolutionErrorNonCommit
 		}
 		return GitRevision{}, &GitRevisionResolutionError{
 			Kind:         kind,

--- a/server/worktree/git_test.go
+++ b/server/worktree/git_test.go
@@ -254,8 +254,9 @@ func TestGitInspectorAddRejectsCreateBranchWithoutBaseRef(t *testing.T) {
 
 	_, err := inspector.Add(context.Background(), workspaceRoot, worktreeRoot, CreateSpec{CreateBranch: true, BranchName: "feature/new"})
 
-	if !errors.Is(err, ErrBaseRefRequired) {
-		t.Fatalf("error = %v, want base ref validation", err)
+	var validationErr *serverapi.WorktreeCreateValidationError
+	if !errors.As(err, &validationErr) || validationErr.Kind != serverapi.WorktreeCreateValidationBaseRefRequired {
+		t.Fatalf("error = %T %v, want neutral base ref validation", err, err)
 	}
 	if runner.args != nil {
 		t.Fatalf("expected no git command, got %v", runner.args)

--- a/server/worktree/git_test.go
+++ b/server/worktree/git_test.go
@@ -527,6 +527,26 @@ func TestGitInspectorResolveRevisionPeelsCommitAndReportsCanonicalRef(t *testing
 	}
 }
 
+func TestGitInspectorResolveRevisionCommitStopsAfterCommitOID(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	commitOID := "abc123"
+	runner := &stubGitCommandRunner{results: map[string]stubGitCommandResult{
+		gitCommandKey("rev-parse", "--verify", "--quiet", "HEAD^{object}"): {output: []byte("object\n")},
+		gitCommandKey("rev-parse", "--verify", "--quiet", "HEAD^{commit}"): {output: []byte(commitOID + "\n")},
+	}}
+
+	resolved, err := NewGitInspector(runner).ResolveRevisionCommit(context.Background(), workspaceRoot, "HEAD")
+	if err != nil {
+		t.Fatalf("ResolveRevisionCommit: %v", err)
+	}
+	if resolved.RequestedRef != "HEAD" || resolved.CommitOID != commitOID || resolved.CanonicalRef != nil {
+		t.Fatalf("resolved revision = %+v, want commit-only resolution", resolved)
+	}
+	if slices.Equal(runner.args, []string{"rev-parse", "--symbolic-full-name", "--verify", "--quiet", "HEAD"}) {
+		t.Fatalf("ResolveRevisionCommit followed moving ref after commit capture: %v", runner.args)
+	}
+}
+
 func TestGitInspectorResolveDefaultBranchUsesConfiguredRemoteHEAD(t *testing.T) {
 	newRepositoryWithRemoteHEAD := func(t *testing.T, remoteName string, branchName string) string {
 		t.Helper()

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -22,6 +22,7 @@ import (
 	"core/shared/boundedio"
 	"core/shared/clientui"
 	"core/shared/config"
+	"core/shared/invariant"
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
 	"github.com/google/uuid"
@@ -1028,6 +1029,27 @@ func (s *Service) ResolveWorktreeCreateTarget(ctx context.Context, req serverapi
 }
 
 func (s *Service) CreateWorktree(ctx context.Context, req serverapi.WorktreeCreateRequest) (resp serverapi.WorktreeCreateResponse, err error) {
+	defer func() {
+		if err == nil {
+			return
+		}
+		if contractErr := serverapi.ValidateWorktreeCreateErrorBoundary(err, "worktree.create", invariant.NewPolicy()); contractErr != nil {
+			err = contractErr
+			return
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
+		}
+		var retainedErr *serverapi.WorktreeSetupRetainedError
+		if errors.As(err, &retainedErr) {
+			return
+		}
+		var createErr *serverapi.WorktreeCreateError
+		if errors.As(err, &createErr) {
+			return
+		}
+		err = serverapi.NewWorktreeCreateError(serverapi.WorktreeCreateErrorOwnerForm, err.Error(), err)
+	}()
 	if err := req.Validate(); err != nil {
 		return serverapi.WorktreeCreateResponse{}, err
 	}
@@ -1053,6 +1075,20 @@ func (s *Service) CreateWorktree(ctx context.Context, req serverapi.WorktreeCrea
 			err = errors.Join(err, cleanupErr)
 		}
 	}()
+	if createSpec.CreateBranch {
+		resolved, resolveErr := s.git.ResolveRevision(ctx, workspaceCtx.workspaceRoot, createSpec.BaseRef)
+		if resolveErr != nil {
+			if errors.Is(resolveErr, context.Canceled) || errors.Is(resolveErr, context.DeadlineExceeded) {
+				return serverapi.WorktreeCreateResponse{}, resolveErr
+			}
+			return serverapi.WorktreeCreateResponse{}, serverapi.NewWorktreeCreateError(
+				serverapi.WorktreeCreateErrorOwnerBaseRef,
+				resolveErr.Error(),
+				resolveErr,
+			)
+		}
+		createSpec.BaseRef = resolved.CommitOID
+	}
 	var worktreeRoot string
 	rootKind := managedRootKindExplicit
 	if strings.TrimSpace(req.RootPath) == "" {

--- a/server/worktree/service.go
+++ b/server/worktree/service.go
@@ -1076,13 +1076,21 @@ func (s *Service) CreateWorktree(ctx context.Context, req serverapi.WorktreeCrea
 		}
 	}()
 	if createSpec.CreateBranch {
-		resolved, resolveErr := s.git.ResolveRevision(ctx, workspaceCtx.workspaceRoot, createSpec.BaseRef)
+		resolved, resolveErr := s.git.ResolveRevisionCommit(ctx, workspaceCtx.workspaceRoot, createSpec.BaseRef)
 		if resolveErr != nil {
 			if errors.Is(resolveErr, context.Canceled) || errors.Is(resolveErr, context.DeadlineExceeded) {
 				return serverapi.WorktreeCreateResponse{}, resolveErr
 			}
+			owner := serverapi.WorktreeCreateErrorOwnerForm
+			var revisionErr *GitRevisionResolutionError
+			if errors.As(resolveErr, &revisionErr) {
+				switch revisionErr.Kind {
+				case GitRevisionResolutionErrorInvalidRevision, GitRevisionResolutionErrorNonCommit:
+					owner = serverapi.WorktreeCreateErrorOwnerBaseRef
+				}
+			}
 			return serverapi.WorktreeCreateResponse{}, serverapi.NewWorktreeCreateError(
-				serverapi.WorktreeCreateErrorOwnerBaseRef,
+				owner,
 				resolveErr.Error(),
 				resolveErr,
 			)

--- a/shared/client/remote_rpc.go
+++ b/shared/client/remote_rpc.go
@@ -566,6 +566,9 @@ func protocolError(resp *protocol.ResponseError) error {
 		diagnostic := resp.Message
 		return worktreeBlockedError{diagnostic: &diagnostic}
 	}
+	if resp.Code == protocol.ErrCodeWorktreeCreate {
+		return serverapi.DecodeWorktreeCreateError(resp.Data, message)
+	}
 	switch resp.Code {
 	case protocol.ErrCodeWorktreeSelector,
 		protocol.ErrCodeWorktreeTransitionPending,

--- a/shared/client/remote_test.go
+++ b/shared/client/remote_test.go
@@ -48,6 +48,22 @@ func TestProtocolErrorDecodesWorktreeBlocked(t *testing.T) {
 	}
 }
 
+func TestProtocolErrorDecodesMalformedWorktreeCreateAsContractError(t *testing.T) {
+	err := protocolError(&protocol.ResponseError{
+		Code:    protocol.ErrCodeWorktreeCreate,
+		Message: "worktree creation failed",
+		Data:    json.RawMessage(`{"owner":"other","diagnostic":"bad owner"}`),
+	})
+	var contractErr *serverapi.WorktreeCreateContractError
+	if !errors.As(err, &contractErr) {
+		t.Fatalf("decoded error = %T %v, want WorktreeCreateContractError", err, err)
+	}
+	var typed *serverapi.WorktreeCreateError
+	if errors.As(err, &typed) {
+		t.Fatalf("malformed wire data decoded as typed create error: %+v", typed)
+	}
+}
+
 func TestProtocolErrorMapsBlankWorktreeBlockedSentinel(t *testing.T) {
 	err := protocolError(&protocol.ResponseError{Code: protocol.ErrCodeWorktreeBlocked})
 	if !errors.Is(err, serverapi.ErrWorktreeBlocked) {
@@ -1659,6 +1675,13 @@ func remoteTestWorktreeStructuredErrors(operationID serverapi.WorktreeOperationI
 				DirtyFileCount: remoteTestIntPointer(2),
 			},
 		},
+		&serverapi.WorktreeCreateError{
+			Owner:      serverapi.WorktreeCreateErrorOwnerForm,
+			Diagnostic: errors.Join(
+				errors.New("worktree path already exists"),
+				errors.New("cleanup failed"),
+			).Error(),
+		},
 	}
 }
 
@@ -1689,6 +1712,11 @@ func assertRemoteWorktreeStructuredError(t *testing.T, err error, source protoco
 		var decoded *serverapi.WorktreeDeletePreconditionError
 		if !errors.As(err, &decoded) || decoded.DirtyState.DirtyFileCount == nil || *decoded.DirtyState.DirtyFileCount != 2 {
 			t.Fatalf("decoded delete precondition = %+v (%v)", decoded, err)
+		}
+	case *serverapi.WorktreeCreateError:
+		var decoded *serverapi.WorktreeCreateError
+		if !errors.As(err, &decoded) || decoded.Owner != source.(*serverapi.WorktreeCreateError).Owner || decoded.Diagnostic != source.(*serverapi.WorktreeCreateError).Diagnostic {
+			t.Fatalf("decoded create error = %+v (%v)", decoded, err)
 		}
 	default:
 		t.Fatalf("unsupported structured worktree error %T", source)

--- a/shared/client/remote_test.go
+++ b/shared/client/remote_test.go
@@ -1676,7 +1676,7 @@ func remoteTestWorktreeStructuredErrors(operationID serverapi.WorktreeOperationI
 			},
 		},
 		&serverapi.WorktreeCreateError{
-			Owner:      serverapi.WorktreeCreateErrorOwnerForm,
+			Owner: serverapi.WorktreeCreateErrorOwnerForm,
 			Diagnostic: errors.Join(
 				errors.New("worktree path already exists"),
 				errors.New("cleanup failed"),

--- a/shared/invariant/diagnostic.go
+++ b/shared/invariant/diagnostic.go
@@ -13,6 +13,7 @@ const (
 	ScopeBackgroundEvent      Scope = "background_event"
 	ScopeSessionPersistence   Scope = "session_persistence"
 	ScopeWorkflowExecution    Scope = "workflow_execution"
+	ScopeWorktreeContract     Scope = "worktree_contract"
 )
 
 type Field string
@@ -48,6 +49,8 @@ const (
 	FieldProposedStepID           Field = "proposed_step_id"
 	FieldProcessID                Field = "process_id"
 	FieldBackgroundState          Field = "background_state"
+	FieldRawOwner                 Field = "raw_owner"
+	FieldValidationCause          Field = "validation_cause"
 )
 
 type Diagnostic struct {

--- a/shared/protocol/jsonrpc.go
+++ b/shared/protocol/jsonrpc.go
@@ -65,6 +65,7 @@ const (
 	ErrCodeManualCompactionDisabled          = -32055
 	ErrCodeManualCompactionActive            = -32056
 	ErrCodeWorkflowTaskMutationSelfTarget    = -32057
+	ErrCodeWorktreeCreate                    = -32058
 )
 
 type Request struct {

--- a/shared/protocol/version.json
+++ b/shared/protocol/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "83"
+  "version": "84"
 }

--- a/shared/serverapi/worktree.go
+++ b/shared/serverapi/worktree.go
@@ -598,28 +598,18 @@ func (r WorktreeCreateTargetResolveRequest) Validate() error {
 
 func (r WorktreeCreateRequest) Validate() error {
 	if err := validateClientRequestID(r.ClientRequestID); err != nil {
-		return err
+		return NewWorktreeCreateError(WorktreeCreateErrorOwnerForm, err.Error(), err)
 	}
 	if err := r.SetupOperationID.Validate(); err != nil {
-		return err
+		return NewWorktreeCreateError(WorktreeCreateErrorOwnerForm, err.Error(), err)
 	}
 	if err := validateRequiredSessionID(r.SessionID); err != nil {
-		return err
+		return NewWorktreeCreateError(WorktreeCreateErrorOwnerForm, err.Error(), err)
 	}
-	if r.CreateBranch {
-		if strings.TrimSpace(r.BaseRef) == "" {
-			return errors.New("base_ref is required when create_branch=true")
-		}
-		if strings.TrimSpace(r.BranchName) == "" {
-			return errors.New("branch_name is required when create_branch=true")
-		}
+	specErr := ValidateWorktreeCreateSpec(r.BaseRef, r.CreateBranch, r.BranchName)
+	if specErr == nil {
 		return nil
 	}
-	if strings.TrimSpace(r.BaseRef) == "" {
-		return errors.New("base_ref is required when create_branch=false")
-	}
-	if strings.TrimSpace(r.BranchName) != "" {
-		return errors.New("branch_name must be empty when create_branch=false")
-	}
-	return nil
+	owner := ProjectWorktreeCreateValidationOwner(specErr, r.CreateBranch)
+	return NewWorktreeCreateError(owner, specErr.Error(), specErr)
 }

--- a/shared/serverapi/worktree_create.go
+++ b/shared/serverapi/worktree_create.go
@@ -1,11 +1,9 @@
 package serverapi
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	"core/shared/invariant"
@@ -162,16 +160,7 @@ func DecodeWorktreeCreateError(data json.RawMessage, message string) error {
 		Owner      *WorktreeCreateErrorOwner `json:"owner"`
 		Diagnostic *string                   `json:"diagnostic"`
 	}
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&payload); err != nil {
-		return newWorktreeCreateContractError("worktree.create.remote.decode", nil, message, err)
-	}
-	var extra any
-	if err := decoder.Decode(&extra); err != io.EOF {
-		if err == nil {
-			return newWorktreeCreateContractError("worktree.create.remote.decode", nil, message, errors.New("multiple JSON values"))
-		}
+	if err := protocol.DecodeStrictJSON([]byte(data), &payload); err != nil {
 		return newWorktreeCreateContractError("worktree.create.remote.decode", nil, message, err)
 	}
 	if payload.Owner == nil || payload.Diagnostic == nil {

--- a/shared/serverapi/worktree_create.go
+++ b/shared/serverapi/worktree_create.go
@@ -143,12 +143,18 @@ func ValidateWorktreeCreateErrorBoundary(err error, operation string, policy inv
 		Scope: invariant.ScopeWorktreeContract,
 		Fields: map[invariant.Field]string{
 			invariant.FieldOperation:       strings.TrimSpace(operation),
-			invariant.FieldRawOwner:        string(typed.Owner),
 			invariant.FieldValidationCause: validationErr.Error(),
 		},
 	}
+	owner := (*WorktreeCreateErrorOwner)(nil)
+	validationDiagnostic := validationErr.Error()
+	if typed != nil {
+		diagnostic.Fields[invariant.FieldRawOwner] = string(typed.Owner)
+		owner = worktreeCreateErrorOwnerPointer(typed.Owner)
+		validationDiagnostic = typed.Diagnostic
+	}
 	policy.Check(false, diagnostic)
-	return newWorktreeCreateContractError(operation, worktreeCreateErrorOwnerPointer(typed.Owner), typed.Diagnostic, validationErr)
+	return newWorktreeCreateContractError(operation, owner, validationDiagnostic, validationErr)
 }
 
 func DecodeWorktreeCreateError(data json.RawMessage, message string) error {

--- a/shared/serverapi/worktree_create.go
+++ b/shared/serverapi/worktree_create.go
@@ -1,0 +1,234 @@
+package serverapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"core/shared/invariant"
+	"core/shared/protocol"
+)
+
+var ErrWorktreeCreateContract = errors.New("invalid worktree create error contract")
+
+type WorktreeCreateErrorOwner string
+
+const (
+	WorktreeCreateErrorOwnerBaseRef WorktreeCreateErrorOwner = "base_ref"
+	WorktreeCreateErrorOwnerForm    WorktreeCreateErrorOwner = "form"
+)
+
+type WorktreeCreateError struct {
+	Owner      WorktreeCreateErrorOwner `json:"owner"`
+	Diagnostic string                   `json:"diagnostic"`
+	cause      error
+}
+
+func NewWorktreeCreateError(owner WorktreeCreateErrorOwner, diagnostic string, cause error) error {
+	result := &WorktreeCreateError{Owner: owner, Diagnostic: diagnostic, cause: cause}
+	if err := result.Validate(); err != nil {
+		return newWorktreeCreateContractError("worktree.create.constructor", owner, diagnostic, err)
+	}
+	return result
+}
+
+func (e *WorktreeCreateError) Error() string {
+	if e == nil {
+		return "worktree creation failed"
+	}
+	diagnostic := strings.TrimSpace(e.Diagnostic)
+	if diagnostic == "" {
+		return "worktree creation failed"
+	}
+	return "worktree creation failed: " + diagnostic
+}
+
+func (e *WorktreeCreateError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *WorktreeCreateError) RPCErrorCode() int {
+	return protocol.ErrCodeWorktreeCreate
+}
+
+func (e *WorktreeCreateError) RPCErrorData() json.RawMessage {
+	if e == nil {
+		return nil
+	}
+	return marshalRPCErrorData(struct {
+		Owner      WorktreeCreateErrorOwner `json:"owner"`
+		Diagnostic string                   `json:"diagnostic"`
+	}{
+		Owner:      e.Owner,
+		Diagnostic: e.Diagnostic,
+	})
+}
+
+func (e *WorktreeCreateError) Validate() error {
+	if e == nil {
+		return errors.New("worktree create error is required")
+	}
+	switch e.Owner {
+	case WorktreeCreateErrorOwnerBaseRef, WorktreeCreateErrorOwnerForm:
+	default:
+		return errors.New("worktree create error owner is invalid")
+	}
+	if strings.TrimSpace(e.Diagnostic) == "" {
+		return errors.New("worktree create error diagnostic is required")
+	}
+	return nil
+}
+
+type WorktreeCreateContractError struct {
+	Operation  string
+	Owner      WorktreeCreateErrorOwner
+	Diagnostic string
+	Cause      error
+}
+
+func newWorktreeCreateContractError(operation string, owner WorktreeCreateErrorOwner, diagnostic string, cause error) *WorktreeCreateContractError {
+	return &WorktreeCreateContractError{
+		Operation:  strings.TrimSpace(operation),
+		Owner:      owner,
+		Diagnostic: diagnostic,
+		Cause:      cause,
+	}
+}
+
+func (e *WorktreeCreateContractError) Error() string {
+	if e == nil {
+		return ErrWorktreeCreateContract.Error()
+	}
+	if e.Cause == nil {
+		return fmt.Sprintf("%s: operation=%q owner=%q", ErrWorktreeCreateContract.Error(), e.Operation, e.Owner)
+	}
+	return fmt.Sprintf("%s: operation=%q owner=%q: %v", ErrWorktreeCreateContract.Error(), e.Operation, e.Owner, e.Cause)
+}
+
+func (e *WorktreeCreateContractError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+func (e *WorktreeCreateContractError) Is(target error) bool {
+	return target == ErrWorktreeCreateContract
+}
+
+func ValidateWorktreeCreateErrorBoundary(err error, operation string, policy invariant.Policy) error {
+	var typed *WorktreeCreateError
+	if !errors.As(err, &typed) {
+		return nil
+	}
+	validationErr := typed.Validate()
+	if validationErr == nil {
+		return nil
+	}
+	diagnostic := invariant.Diagnostic{
+		Scope: invariant.ScopeWorktreeContract,
+		Fields: map[invariant.Field]string{
+			invariant.FieldOperation:       strings.TrimSpace(operation),
+			invariant.FieldRawOwner:        string(typed.Owner),
+			invariant.FieldValidationCause: validationErr.Error(),
+		},
+	}
+	policy.Check(false, diagnostic)
+	return newWorktreeCreateContractError(operation, typed.Owner, typed.Diagnostic, validationErr)
+}
+
+func DecodeWorktreeCreateError(data json.RawMessage, message string) error {
+	var payload struct {
+		Owner      *WorktreeCreateErrorOwner `json:"owner"`
+		Diagnostic *string                   `json:"diagnostic"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&payload); err != nil {
+		return newWorktreeCreateContractError("worktree.create.remote.decode", "", message, err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return newWorktreeCreateContractError("worktree.create.remote.decode", "", message, errors.New("multiple JSON values"))
+		}
+		return newWorktreeCreateContractError("worktree.create.remote.decode", "", message, err)
+	}
+	if payload.Owner == nil || payload.Diagnostic == nil {
+		return newWorktreeCreateContractError("worktree.create.remote.decode", "", message, errors.New("owner and diagnostic are required"))
+	}
+	result := &WorktreeCreateError{Owner: *payload.Owner, Diagnostic: *payload.Diagnostic}
+	if err := result.Validate(); err != nil {
+		return newWorktreeCreateContractError("worktree.create.remote.decode", result.Owner, result.Diagnostic, err)
+	}
+	return result
+}
+
+type WorktreeCreateValidationKind string
+
+const (
+	WorktreeCreateValidationBaseRefRequired     WorktreeCreateValidationKind = "base_ref_required"
+	WorktreeCreateValidationBranchNameRequired  WorktreeCreateValidationKind = "branch_name_required"
+	WorktreeCreateValidationBranchNameForbidden WorktreeCreateValidationKind = "branch_name_forbidden"
+)
+
+type WorktreeCreateValidationError struct {
+	Kind       WorktreeCreateValidationKind
+	Diagnostic string
+}
+
+func (e *WorktreeCreateValidationError) Error() string {
+	if e == nil {
+		return "worktree create specification is invalid"
+	}
+	return e.Diagnostic
+}
+
+func ProjectWorktreeCreateValidationOwner(err error, baseRefEditable bool) WorktreeCreateErrorOwner {
+	var validationErr *WorktreeCreateValidationError
+	if errors.As(err, &validationErr) &&
+		validationErr.Kind == WorktreeCreateValidationBaseRefRequired &&
+		baseRefEditable {
+		return WorktreeCreateErrorOwnerBaseRef
+	}
+	return WorktreeCreateErrorOwnerForm
+}
+
+func ValidateWorktreeCreateSpec(baseRef string, createBranch bool, branchName string) error {
+	baseRef = strings.TrimSpace(baseRef)
+	branchName = strings.TrimSpace(branchName)
+	if createBranch {
+		if branchName == "" {
+			return &WorktreeCreateValidationError{
+				Kind:       WorktreeCreateValidationBranchNameRequired,
+				Diagnostic: "branch name is required when create_branch=true",
+			}
+		}
+		if baseRef == "" {
+			return &WorktreeCreateValidationError{
+				Kind:       WorktreeCreateValidationBaseRefRequired,
+				Diagnostic: "base ref is required when create_branch=true",
+			}
+		}
+		return nil
+	}
+	if baseRef == "" {
+		return &WorktreeCreateValidationError{
+			Kind:       WorktreeCreateValidationBaseRefRequired,
+			Diagnostic: "base ref is required when create_branch=false",
+		}
+	}
+	if branchName != "" {
+		return &WorktreeCreateValidationError{
+			Kind:       WorktreeCreateValidationBranchNameForbidden,
+			Diagnostic: "branch name must be empty when create_branch=false",
+		}
+	}
+	return nil
+}

--- a/shared/serverapi/worktree_create.go
+++ b/shared/serverapi/worktree_create.go
@@ -30,7 +30,7 @@ type WorktreeCreateError struct {
 func NewWorktreeCreateError(owner WorktreeCreateErrorOwner, diagnostic string, cause error) error {
 	result := &WorktreeCreateError{Owner: owner, Diagnostic: diagnostic, cause: cause}
 	if err := result.Validate(); err != nil {
-		return newWorktreeCreateContractError("worktree.create.constructor", owner, diagnostic, err)
+		return newWorktreeCreateContractError("worktree.create.constructor", worktreeCreateErrorOwnerPointer(owner), diagnostic, err)
 	}
 	return result
 }
@@ -87,12 +87,16 @@ func (e *WorktreeCreateError) Validate() error {
 
 type WorktreeCreateContractError struct {
 	Operation  string
-	Owner      WorktreeCreateErrorOwner
+	Owner      *WorktreeCreateErrorOwner
 	Diagnostic string
 	Cause      error
 }
 
-func newWorktreeCreateContractError(operation string, owner WorktreeCreateErrorOwner, diagnostic string, cause error) *WorktreeCreateContractError {
+func worktreeCreateErrorOwnerPointer(owner WorktreeCreateErrorOwner) *WorktreeCreateErrorOwner {
+	return &owner
+}
+
+func newWorktreeCreateContractError(operation string, owner *WorktreeCreateErrorOwner, diagnostic string, cause error) *WorktreeCreateContractError {
 	return &WorktreeCreateContractError{
 		Operation:  strings.TrimSpace(operation),
 		Owner:      owner,
@@ -105,10 +109,14 @@ func (e *WorktreeCreateContractError) Error() string {
 	if e == nil {
 		return ErrWorktreeCreateContract.Error()
 	}
-	if e.Cause == nil {
-		return fmt.Sprintf("%s: operation=%q owner=%q", ErrWorktreeCreateContract.Error(), e.Operation, e.Owner)
+	details := fmt.Sprintf("%s: operation=%q", ErrWorktreeCreateContract.Error(), e.Operation)
+	if e.Owner != nil {
+		details += fmt.Sprintf(" owner=%q", *e.Owner)
 	}
-	return fmt.Sprintf("%s: operation=%q owner=%q: %v", ErrWorktreeCreateContract.Error(), e.Operation, e.Owner, e.Cause)
+	if e.Cause == nil {
+		return details
+	}
+	return fmt.Sprintf("%s: %v", details, e.Cause)
 }
 
 func (e *WorktreeCreateContractError) Unwrap() error {
@@ -140,7 +148,7 @@ func ValidateWorktreeCreateErrorBoundary(err error, operation string, policy inv
 		},
 	}
 	policy.Check(false, diagnostic)
-	return newWorktreeCreateContractError(operation, typed.Owner, typed.Diagnostic, validationErr)
+	return newWorktreeCreateContractError(operation, worktreeCreateErrorOwnerPointer(typed.Owner), typed.Diagnostic, validationErr)
 }
 
 func DecodeWorktreeCreateError(data json.RawMessage, message string) error {
@@ -151,21 +159,21 @@ func DecodeWorktreeCreateError(data json.RawMessage, message string) error {
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&payload); err != nil {
-		return newWorktreeCreateContractError("worktree.create.remote.decode", "", message, err)
+		return newWorktreeCreateContractError("worktree.create.remote.decode", nil, message, err)
 	}
 	var extra any
 	if err := decoder.Decode(&extra); err != io.EOF {
 		if err == nil {
-			return newWorktreeCreateContractError("worktree.create.remote.decode", "", message, errors.New("multiple JSON values"))
+			return newWorktreeCreateContractError("worktree.create.remote.decode", nil, message, errors.New("multiple JSON values"))
 		}
-		return newWorktreeCreateContractError("worktree.create.remote.decode", "", message, err)
+		return newWorktreeCreateContractError("worktree.create.remote.decode", nil, message, err)
 	}
 	if payload.Owner == nil || payload.Diagnostic == nil {
-		return newWorktreeCreateContractError("worktree.create.remote.decode", "", message, errors.New("owner and diagnostic are required"))
+		return newWorktreeCreateContractError("worktree.create.remote.decode", payload.Owner, message, errors.New("owner and diagnostic are required"))
 	}
 	result := &WorktreeCreateError{Owner: *payload.Owner, Diagnostic: *payload.Diagnostic}
 	if err := result.Validate(); err != nil {
-		return newWorktreeCreateContractError("worktree.create.remote.decode", result.Owner, result.Diagnostic, err)
+		return newWorktreeCreateContractError("worktree.create.remote.decode", worktreeCreateErrorOwnerPointer(result.Owner), result.Diagnostic, err)
 	}
 	return result
 }

--- a/shared/serverapi/worktree_errors_test.go
+++ b/shared/serverapi/worktree_errors_test.go
@@ -233,6 +233,9 @@ func TestWorktreeCreateErrorRejectsMalformedWireDataAsContractError(t *testing.T
 			if !errors.As(decoded, &contractErr) {
 				t.Fatalf("decoded error = %T %v, want WorktreeCreateContractError", decoded, decoded)
 			}
+			if test.name == "missing owner" && contractErr.Owner != nil {
+				t.Fatalf("missing owner decoded as %q, want absent owner", *contractErr.Owner)
+			}
 			var typed *WorktreeCreateError
 			if errors.As(decoded, &typed) {
 				t.Fatalf("malformed wire data decoded as typed create error: %+v", typed)

--- a/shared/serverapi/worktree_errors_test.go
+++ b/shared/serverapi/worktree_errors_test.go
@@ -1,6 +1,7 @@
 package serverapi
 
 import (
+	"encoding/json"
 	"errors"
 	"strconv"
 	"strings"
@@ -161,6 +162,182 @@ func TestWorktreeStructuredErrorsRejectInvalidTypedData(t *testing.T) {
 		PendingOperationID: NewWorktreeOperationID(),
 	}).Validate(); err == nil {
 		t.Fatal("pending transition without session validated")
+	}
+}
+
+func TestWorktreeCreateErrorRoundTripsWithOwnershipOnlyWireData(t *testing.T) {
+	tests := []struct {
+		name  string
+		owner WorktreeCreateErrorOwner
+	}{
+		{name: "base ref", owner: WorktreeCreateErrorOwnerBaseRef},
+		{name: "form", owner: WorktreeCreateErrorOwnerForm},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := &WorktreeCreateError{
+				Owner:      test.owner,
+				Diagnostic: "git create diagnostic",
+			}
+			if err := source.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			if source.RPCErrorCode() != protocol.ErrCodeWorktreeCreate {
+				t.Fatalf("RPCErrorCode() = %d, want %d", source.RPCErrorCode(), protocol.ErrCodeWorktreeCreate)
+			}
+
+			var wire map[string]json.RawMessage
+			if err := json.Unmarshal(source.RPCErrorData(), &wire); err != nil {
+				t.Fatalf("unmarshal RPC data: %v", err)
+			}
+			if len(wire) != 2 {
+				t.Fatalf("RPC data fields = %v, want exactly owner and diagnostic", wire)
+			}
+			if _, ok := wire["owner"]; !ok {
+				t.Fatalf("RPC data omitted owner: %v", wire)
+			}
+			if _, ok := wire["diagnostic"]; !ok {
+				t.Fatalf("RPC data omitted diagnostic: %v", wire)
+			}
+			if _, ok := wire["type"]; ok {
+				t.Fatal("RPC data contains a duplicate type discriminator")
+			}
+
+			decoded := DecodeWorktreeCreateError(source.RPCErrorData(), source.Error())
+			var typed *WorktreeCreateError
+			if !errors.As(decoded, &typed) {
+				t.Fatalf("decoded error = %T %v, want WorktreeCreateError", decoded, decoded)
+			}
+			if typed.Owner != source.Owner || typed.Diagnostic != source.Diagnostic {
+				t.Fatalf("decoded error = %+v, want %+v", typed, source)
+			}
+		})
+	}
+}
+
+func TestWorktreeCreateErrorRejectsMalformedWireDataAsContractError(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{name: "invalid owner", data: `{"owner":"other","diagnostic":"diagnostic"}`},
+		{name: "blank diagnostic", data: `{"owner":"form","diagnostic":"  "}`},
+		{name: "missing owner", data: `{"diagnostic":"diagnostic"}`},
+		{name: "missing diagnostic", data: `{"owner":"form"}`},
+		{name: "unknown field", data: `{"owner":"form","diagnostic":"diagnostic","type":"worktree_create_error"}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decoded := DecodeWorktreeCreateError(json.RawMessage(test.data), "wire diagnostic")
+			var contractErr *WorktreeCreateContractError
+			if !errors.As(decoded, &contractErr) {
+				t.Fatalf("decoded error = %T %v, want WorktreeCreateContractError", decoded, decoded)
+			}
+			var typed *WorktreeCreateError
+			if errors.As(decoded, &typed) {
+				t.Fatalf("malformed wire data decoded as typed create error: %+v", typed)
+			}
+		})
+	}
+}
+
+func TestWorktreeCreateRequestValidationProjectsNeutralFailures(t *testing.T) {
+	base := WorktreeCreateRequest{
+		ClientRequestID:  "request-1",
+		SetupOperationID: NewWorktreeSetupOperationID(),
+		SessionID:        "session",
+		BranchName:       "feature",
+	}
+	tests := []struct {
+		name  string
+		patch func(*WorktreeCreateRequest)
+		owner WorktreeCreateErrorOwner
+	}{
+		{
+			name: "new branch blank base ref",
+			patch: func(request *WorktreeCreateRequest) {
+				request.CreateBranch = true
+			},
+			owner: WorktreeCreateErrorOwnerBaseRef,
+		},
+		{
+			name: "existing branch blank base ref",
+			patch: func(request *WorktreeCreateRequest) {
+				request.CreateBranch = false
+			},
+			owner: WorktreeCreateErrorOwnerForm,
+		},
+		{
+			name: "new branch blank branch name",
+			patch: func(request *WorktreeCreateRequest) {
+				request.CreateBranch = true
+				request.BaseRef = "HEAD"
+				request.BranchName = ""
+			},
+			owner: WorktreeCreateErrorOwnerForm,
+		},
+		{
+			name: "existing branch with branch name",
+			patch: func(request *WorktreeCreateRequest) {
+				request.CreateBranch = false
+				request.BaseRef = "feature"
+			},
+			owner: WorktreeCreateErrorOwnerForm,
+		},
+		{
+			name: "blank client request id",
+			patch: func(request *WorktreeCreateRequest) {
+				request.ClientRequestID = ""
+				request.CreateBranch = true
+				request.BaseRef = "HEAD"
+			},
+			owner: WorktreeCreateErrorOwnerForm,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := base
+			test.patch(&request)
+			err := request.Validate()
+			var typed *WorktreeCreateError
+			if !errors.As(err, &typed) {
+				t.Fatalf("Validate() = %T %v, want WorktreeCreateError", err, err)
+			}
+			if typed.Owner != test.owner {
+				t.Fatalf("owner = %q, want %q", typed.Owner, test.owner)
+			}
+			if strings.TrimSpace(typed.Diagnostic) == "" {
+				t.Fatal("validation error diagnostic is blank")
+			}
+		})
+	}
+}
+
+func TestWorktreeSetupRetainedErrorKeepsExistingWireIdentity(t *testing.T) {
+	source := &WorktreeSetupRetainedError{
+		Worktree: WorktreeTopologyEntry{
+			Variant: WorktreeTopologyVariantRegistered,
+			Registered: &WorktreeRegisteredFacts{
+				Git: WorktreeGitFacts{CanonicalRoot: "/repo/feature", HeadObject: "abc123", PathAvailable: true},
+				Kent: WorktreeKentFacts{
+					WorktreeID:    "c4aaf0cf-4c50-4560-b6a2-6c294d0b1495",
+					CanonicalRoot: "/repo/feature",
+					DisplayName:   "feature",
+				},
+			},
+		},
+		Diagnostic: "setup failed",
+	}
+	if source.RPCErrorCode() != protocol.ErrCodeWorktreeSetupRetained {
+		t.Fatalf("setup-retained RPC code = %d, want %d", source.RPCErrorCode(), protocol.ErrCodeWorktreeSetupRetained)
+	}
+	decoded := DecodeWorktreeRPCError(source.RPCErrorData(), source.Error())
+	var retained *WorktreeSetupRetainedError
+	if !errors.As(decoded, &retained) {
+		t.Fatalf("decoded error = %T %v, want WorktreeSetupRetainedError", decoded, decoded)
+	}
+	if !errors.Is(decoded, ErrWorktreeSetupRetained) {
+		t.Fatalf("decoded error does not preserve setup-retained identity: %v", decoded)
 	}
 }
 

--- a/shared/serverapi/worktree_errors_test.go
+++ b/shared/serverapi/worktree_errors_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"core/shared/invariant"
 	"core/shared/protocol"
 )
 
@@ -241,6 +242,23 @@ func TestWorktreeCreateErrorRejectsMalformedWireDataAsContractError(t *testing.T
 				t.Fatalf("malformed wire data decoded as typed create error: %+v", typed)
 			}
 		})
+	}
+}
+
+func TestWorktreeCreateErrorBoundaryHandlesTypedNil(t *testing.T) {
+	var source *WorktreeCreateError
+
+	err := ValidateWorktreeCreateErrorBoundary(source, "worktree.create.test", invariant.NewPolicy())
+
+	var contractErr *WorktreeCreateContractError
+	if !errors.As(err, &contractErr) {
+		t.Fatalf("boundary error = %T %v, want WorktreeCreateContractError", err, err)
+	}
+	if contractErr.Owner != nil {
+		t.Fatalf("typed-nil owner = %q, want absent owner", *contractErr.Owner)
+	}
+	if strings.TrimSpace(contractErr.Diagnostic) == "" {
+		t.Fatal("typed-nil contract diagnostic is blank")
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements KENT-391 so Worktree Create failures carry exhaustive typed ownership: `base_ref` for failures attributable to the editable Base ref and `form` for all other ordinary creation failures.

- Centralized neutral Worktree Create validation and its interactive ownership projection.
- Resolves new-branch Base refs once to immutable commit OIDs before mutation.
- Preserves Git diagnostics, cancellation, setup-retained identity, cleanup joins, and successful Create/setup behavior.
- Propagates the typed contract through loopback, gateway, Remote, strict RPC decoding, protocol version 84, and Go contract tests.
- Places Base-ref diagnostics beside the TUI field and form-owned diagnostics in the dialog error region.
- Updates the authoritative Desktop Worktree specification; Desktop TypeScript remains KENT-389 scope.

## Verification

- `./scripts/test.sh` passed after shared runtime-test admission load cleared (server, TUI checks, and desktop tests).
- Focused Worktree/API/protocol/Remote/TUI tests passed.
- `./scripts/build.sh --output ./bin/kent` passed; built Kent reports version 2.4.0.
- `git diff --check` passed.
- QA evidence was supplied from isolated runs covering immediate open, normal and narrow layouts, neutral/form/Base-ref states, long diagnostic wrapping, pending spinner, lower-section visibility, hidden-field cleanup, successful/form-error flows, and alt-screen scrollback restoration. Available evidence paths: `/Users/nek/Dev/kent/.kent/qa/instances/kent391-qa5/proofs`, `/Users/nek/Dev/kent/.kent/qa/instances/kent391-qa3/proofs`, `/Users/nek/Dev/kent/.kent/qa/instances/kent391-qa4/proofs`, and `/Users/nek/.kent/worktrees/kent/KENT-391/.kent/plans/KENT-391.md`.

## Diff size

Measured with `git diff origin/main...HEAD --numstat`:

- Production code: +364 / -62, net +302, gross 426 lines.
- Test code: +682 / -4, net +678, gross 686 lines.
- Generated protocol metadata: +1 / -1, net 0, gross 2 lines.
- Specification: +5 / -0, net +5, gross 5 lines.
- Overall: +1052 / -67, net +985, gross 1119 lines.

## Caveats and follow-up

- Protocol version 84 intentionally requires matching client/server builds through the existing strict handshake.
- Desktop client schemas, adapters, and UI consumption are intentionally deferred to KENT-389.
- BUI-91 remains the owner of the broad Worktree mutation module split.
- The repository-wide test run previously encountered the 300-second cap while local runtime admission was contended; the exact command passed once that load cleared.

GitHub issue: none linked.
Kent task: KENT-391.