### PR TITLE
fix: restore KENT-214 production readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,38 +148,20 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.9
-        with:
-          version: 11.11.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v6.4.0
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: apps/pnpm-lock.yaml
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.95.0
-        with:
-          components: clippy,rustfmt
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2.9.1
-        with:
-          workspaces: tui-rs
-
-      - name: Build mocked Windows release asset
+      - name: Build mocked Windows release assets
         env:
           VERSION: 0.0.0
         run: |
           mkdir -p dist staging
-          GOOS=windows GOARCH=amd64 KENT_VERSION="$VERSION" \
-            bash scripts/build.sh --output "staging/kent_${VERSION}_windows_amd64.exe"
-          powershell -NoProfile -Command "Compress-Archive -LiteralPath 'staging/kent_${VERSION}_windows_amd64.exe' -DestinationPath 'dist/kent_${VERSION}_windows_amd64.zip' -Force"
-          checksum=$(powershell -NoProfile -Command "(Get-FileHash -Algorithm SHA256 -LiteralPath 'dist/kent_${VERSION}_windows_amd64.zip').Hash.ToLowerInvariant()")
-          printf '%s  %s\n' "$checksum" "kent_${VERSION}_windows_amd64.zip" > dist/checksums.txt
+          : > dist/checksums.txt
+          for goarch in amd64 arm64; do
+            asset="kent_${VERSION}_windows_${goarch}"
+            GOOS=windows GOARCH="$goarch" KENT_VERSION="$VERSION" \
+              bash scripts/build.sh server --output "staging/${asset}.exe"
+            powershell -NoProfile -Command "Compress-Archive -LiteralPath 'staging/${asset}.exe' -DestinationPath 'dist/${asset}.zip' -Force"
+            checksum=$(powershell -NoProfile -Command "(Get-FileHash -Algorithm SHA256 -LiteralPath 'dist/${asset}.zip').Hash.ToLowerInvariant()")
+            printf '%s  %s\n' "$checksum" "${asset}.zip" >> dist/checksums.txt
+          done
 
       - name: Smoke test installer
         env:

--- a/cli/app/onboarding_imports.go
+++ b/cli/app/onboarding_imports.go
@@ -469,6 +469,6 @@ func commandImportSummary(state *onboardingFlowState) string {
 	case onboardingImportModeSymlinkSource:
 		return "from " + importProviderDisplayLabel(providerIDFromPtr(state.selections.commandImport.ChoiceRef.ImportProviderID), "external_provider")
 	default:
-		return ""
+		panic(fmt.Sprintf("invalid command import mode %q", state.selections.commandImport.Mode))
 	}
 }

--- a/cli/app/onboarding_render.go
+++ b/cli/app/onboarding_render.go
@@ -357,9 +357,7 @@ func (m *onboardingModel) renderReviewSummary(width int) []string {
 	if enabled, disabled := selectedSkillCounts(&m.state); enabled > 0 || disabled > 0 {
 		appendRow("Enabled skills", fmt.Sprintf("%d enabled, %d disabled", enabled, disabled), m.styles.valueNeutral)
 	}
-	if summary := commandImportSummary(&m.state); summary != "" {
-		appendRow("Slash commands import", summary, m.styles.valueNeutral)
-	}
+	appendRow("Slash commands import", commandImportSummary(&m.state), m.styles.valueNeutral)
 	return lines
 }
 

--- a/cli/app/onboarding_selection_invariants.go
+++ b/cli/app/onboarding_selection_invariants.go
@@ -100,6 +100,7 @@ func (selections onboardingSelections) invariantViolation() (onboardingInvariant
 		{"supervisor.thinking", string(selections.supervisor.thinking.kind), []string{"inherited", "overridden", "capability_disabled"}},
 		{"compaction", string(selections.compaction), []string{"local", "native", "manual_only"}},
 		{"skill_import", string(selections.skillImport.Mode), []string{"none", "symlink_source"}},
+		{"command_import", string(selections.commandImport.Mode), []string{"none", "symlink_source"}},
 		{"pending_primary_thinking", string(selections.pendingPrimaryThinking.kind), []string{"none", "pending", "revisiting"}},
 		{"pending_reviewer_thinking", string(selections.pendingReviewerThinking.kind), []string{"none", "pending", "revisiting"}},
 	}
@@ -130,23 +131,11 @@ func (selections onboardingSelections) invariantViolation() (onboardingInvariant
 			return violation, true
 		}
 	}
-	if selections.skillImport.Mode == onboardingImportModeSymlinkSource {
-		ref := selections.skillImport.ChoiceRef
-		if onboardingImportMode(ref.Mode) != onboardingImportModeSymlinkSource {
-			return onboardingInvariantViolation{VariantType: "skill_import.choice_ref.mode", VariantTag: ref.Mode}, true
-		}
-		if violation, ok := requiredStringReferenceViolation(
-			"skill_import.choice_ref.import_provider_id",
-			ref.ImportProviderID,
-		); ok {
-			return violation, true
-		}
-		if violation, ok := requiredStringReferenceViolation(
-			"skill_import.choice_ref.source_root_path",
-			ref.SourceRootPath,
-		); ok {
-			return violation, true
-		}
+	if violation, ok := importSelectionInvariantViolation("skill_import", selections.skillImport); ok {
+		return violation, true
+	}
+	if violation, ok := importSelectionInvariantViolation("command_import", selections.commandImport); ok {
+		return violation, true
 	}
 	if selections.preserved.providerOverride != nil && strings.TrimSpace(*selections.preserved.providerOverride) == "" {
 		return onboardingInvariantViolation{VariantType: "preserved.provider_override", VariantTag: *selections.preserved.providerOverride}, true
@@ -166,6 +155,29 @@ func (selections onboardingSelections) invariantViolation() (onboardingInvariant
 		}
 	}
 	return onboardingInvariantViolation{}, false
+}
+
+func importSelectionInvariantViolation(
+	variantPrefix string,
+	selection onboardingImportSelection,
+) (onboardingInvariantViolation, bool) {
+	if selection.Mode != onboardingImportModeSymlinkSource {
+		return onboardingInvariantViolation{}, false
+	}
+	ref := selection.ChoiceRef
+	if onboardingImportMode(ref.Mode) != onboardingImportModeSymlinkSource {
+		return onboardingInvariantViolation{VariantType: variantPrefix + ".choice_ref.mode", VariantTag: ref.Mode}, true
+	}
+	if violation, ok := requiredStringReferenceViolation(
+		variantPrefix+".choice_ref.import_provider_id",
+		ref.ImportProviderID,
+	); ok {
+		return violation, true
+	}
+	return requiredStringReferenceViolation(
+		variantPrefix+".choice_ref.source_root_path",
+		ref.SourceRootPath,
+	)
 }
 
 func requiredStringReferenceViolation(variantType string, value *string) (onboardingInvariantViolation, bool) {

--- a/cli/app/onboarding_selections_test.go
+++ b/cli/app/onboarding_selections_test.go
@@ -217,21 +217,41 @@ func TestOnboardingSelectionInvariantFailureReturnsTypedErrorInRelease(t *testin
 }
 
 func TestOnboardingSelectionInvariantDiagnosticReportsInvalidImportReferenceValue(t *testing.T) {
-	state, err := newOnboardingFlowState(onboardingSeedConfig(), testOnboardingCapabilityFacts())
-	if err != nil {
-		t.Fatalf("construct onboarding state: %v", err)
-	}
-	invalidProviderID := " \t"
-	state.selections.skillImport = testImportSelection(onboardingImportProviderCodex, "/tmp/skills")
-	state.selections.skillImport.ChoiceRef.ImportProviderID = &invalidProviderID
+	for _, test := range []struct {
+		name          string
+		variantPrefix string
+		selectImport  func(*onboardingSelections) *onboardingImportSelection
+	}{
+		{
+			name:          "skill import",
+			variantPrefix: "skill_import",
+			selectImport:  func(selections *onboardingSelections) *onboardingImportSelection { return &selections.skillImport },
+		},
+		{
+			name:          "command import",
+			variantPrefix: "command_import",
+			selectImport:  func(selections *onboardingSelections) *onboardingImportSelection { return &selections.commandImport },
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			state, err := newOnboardingFlowState(onboardingSeedConfig(), testOnboardingCapabilityFacts())
+			if err != nil {
+				t.Fatalf("construct onboarding state: %v", err)
+			}
+			invalidProviderID := " \t"
+			selection := test.selectImport(&state.selections)
+			*selection = testImportSelection(onboardingImportProviderCodex, "/tmp/import")
+			selection.ChoiceRef.ImportProviderID = &invalidProviderID
 
-	violation, ok := state.selections.invariantViolation()
-	if !ok {
-		t.Fatal("invalid import provider reference unexpectedly passed invariants")
-	}
-	if violation.VariantType != "skill_import.choice_ref.import_provider_id" ||
-		violation.VariantTag != invalidProviderID {
-		t.Fatalf("import provider diagnostic = %+v, want offending value", violation)
+			violation, ok := state.selections.invariantViolation()
+			if !ok {
+				t.Fatal("invalid import provider reference unexpectedly passed invariants")
+			}
+			if violation.VariantType != test.variantPrefix+".choice_ref.import_provider_id" ||
+				violation.VariantTag != invalidProviderID {
+				t.Fatalf("import provider diagnostic = %+v, want offending value", violation)
+			}
+		})
 	}
 }
 

--- a/cli/app/run_prompt_part2_test.go
+++ b/cli/app/run_prompt_part2_test.go
@@ -310,6 +310,9 @@ func TestRunPromptFastRoleUsesRoleLevelProviderSettingsForHeuristics(t *testing.
 		"",
 		"[subagents.fast]",
 		"provider_override = \"openai\"",
+		"",
+		"[subagents.fast.provider_capabilities]",
+		"provider_id = \"openai\"",
 	}, "\n")
 
 	requestBodies := make(chan map[string]any, 1)

--- a/docs/src/content/docs/slash-commands.md
+++ b/docs/src/content/docs/slash-commands.md
@@ -48,6 +48,6 @@ Discovery is non-recursive and includes non-blank `.md` files. The first valid f
 
 The picker shows a one-line preview made from the first 256 Unicode characters after collapsing whitespace. Markdown punctuation remains unchanged. Prompt bodies are resolved by the server when the command is invoked.
 
-If `$ARGUMENTS` appears in the body, Kent replaces every occurrence with trimmed trailing arguments. Otherwise, Kent appends non-empty trailing arguments after one blank line.
+If the exact `$ARGUMENTS` token appears in the body, Kent replaces every occurrence with trimmed trailing arguments. Otherwise, Kent appends non-empty trailing arguments after one blank line.
 
 First-time setup can import slash-command directories from supported providers. An unavailable or unknown `/prompt:` command reports an error and is never sent to the model as plain text. Other unknown slash commands retain their normal behavior.

--- a/internal/testharness/pty/blackbox/testdata/config.toml
+++ b/internal/testharness/pty/blackbox/testdata/config.toml
@@ -1,2 +1,7 @@
 model = "gpt-5"
 openai_base_url = "http://127.0.0.1:1/v1"
+
+[provider_capabilities]
+provider_id = "pty-responses-stub"
+supports_responses_api = true
+supports_prompt_cache_key = true

--- a/server/onboarding/finalizer_test.go
+++ b/server/onboarding/finalizer_test.go
@@ -60,7 +60,7 @@ func TestFinalizerProjectsModelContextThinkingVerbosityAskQuestionSupervisorAndC
 	trueValue := true
 	falseValue := false
 	providerOverride := "openai"
-	openAIBaseURL := "http://127.0.0.1:8080/v1"
+	openAIBaseURL := "https://api.openai.com/v1"
 	modelTimeout := 123
 	reviewerModel := "gpt-5.4"
 	reviewerThinking := "xhigh"

--- a/server/onboardingimports/imports.go
+++ b/server/onboardingimports/imports.go
@@ -13,6 +13,7 @@ import (
 
 	"core/server/skillcatalog"
 	brand "core/shared/config"
+	"core/shared/runtimeinput"
 	"core/shared/textutil"
 )
 
@@ -352,6 +353,9 @@ func discoverDirectCommands(providerID ProviderID, root string) ([]Item, error) 
 			continue
 		}
 		name := strings.TrimSuffix(target, filepath.Ext(target))
+		if _, err := runtimeinput.NormalizeIdentifier(name); err != nil {
+			continue
+		}
 		items = append(items, Item{Ref: ItemRef{ItemKind: ItemKindCommand, SourceKind: SourceKindExternalProvider, ProviderID: &providerID, SourceRoot: &sourceRoot, SourcePath: &sourcePath, TargetName: target, Name: &name}})
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].Ref.TargetName < items[j].Ref.TargetName })

--- a/server/onboardingimports/imports_test.go
+++ b/server/onboardingimports/imports_test.go
@@ -169,6 +169,9 @@ func TestDiscoverCommandsCountsFollowedRegularMarkdownFiles(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "blank.md"), []byte(" \n\t"), 0o644); err != nil {
 		t.Fatalf("write blank command: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(root, "---.md"), []byte("invalid command name"), 0o644); err != nil {
+		t.Fatalf("write invalid-name command: %v", err)
+	}
 	targetDir := filepath.Join(t.TempDir(), "command-directory")
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		t.Fatalf("mkdir command target directory: %v", err)
@@ -195,6 +198,9 @@ func TestDiscoverCommandsCountsFollowedRegularMarkdownFiles(t *testing.T) {
 	for _, item := range result.Commands.Items {
 		if item.Ref.TargetName == "directory.md" {
 			t.Fatalf("directory symlink counted as command: %+v", item)
+		}
+		if item.Ref.TargetName == "---.md" {
+			t.Fatalf("unnormalizable command filename counted as command: %+v", item)
 		}
 		foundBlank = foundBlank || item.Ref.TargetName == "blank.md"
 	}

--- a/server/runtime/request_cache_lineage_test.go
+++ b/server/runtime/request_cache_lineage_test.go
@@ -527,6 +527,12 @@ func TestOpenAITransport_UsesExpectedSessionHeadersAndPromptCacheKeysAcrossConve
 	transport := llm.NewHTTPTransport(transportStaticAuth{})
 	transport.BaseURL = server.URL + "/v1"
 	transport.Client = server.Client()
+	transport.ProviderCapabilitiesOverride = &llm.ProviderCapabilities{
+		ProviderID:             "openai",
+		SupportsResponsesAPI:   true,
+		SupportsPromptCacheKey: true,
+		IsOpenAIFirstParty:     true,
+	}
 	openAIClient := llm.NewOpenAIClient(transport)
 
 	store := mustCreateTestSession(t)


### PR DESCRIPTION
## Scope
- repair the four failed Go/PTY checks from merged PR #691 without expanding production architecture
- make the Windows installer smoke fixture produce both supported release archives
- close the three valid post-merge review findings for command discovery, import invariants, and `$ARGUMENTS` documentation

## Verification
- focused affected package tests passed
- server build passed
- actionlint and git diff checks passed
- full local server suite was blocked by an unrelated shared runtime-test admission holder in another worktree; CI runs without the local wall-clock cap and is authoritative

Follow-up to #691.