### PR TITLE
fix: generate auditable prebuilt brew formula

### DIFF
--- a/scripts/update-brew-tap.sh
+++ b/scripts/update-brew-tap.sh
@@ -211,7 +211,8 @@ cat >"$tmp_formula" <<EOF
 class ${formula_class} < Formula
   desc "Minimal terminal coding agent for professional engineering workflows"
   homepage "https://github.com/respawn-llc/kent"
-  version "$bare_version"
+  url "${release_base}/kent_${bare_version}_darwin_arm64.tar.gz"
+  sha256 "$darwin_arm64_sha256"
   license "AGPL-3.0-only"
 
   bottle do
@@ -222,9 +223,6 @@ class ${formula_class} < Formula
 
   on_macos do
     depends_on arch: :arm64
-
-    url "${release_base}/kent_${bare_version}_darwin_arm64.tar.gz"
-    sha256 "$darwin_arm64_sha256"
   end
 
   on_linux do

--- a/server/core/brew_formula_prebuilt_test.go
+++ b/server/core/brew_formula_prebuilt_test.go
@@ -32,8 +32,8 @@ func TestBrewTapGeneratorKeepsAppleSiliconPrebuiltInstall(t *testing.T) {
 		t.Fatalf("Apple Silicon Kent install must install exactly one prebuilt executable, got %v", result.Installed)
 	}
 	for source, destination := range result.Installed {
-		if source == "" {
-			t.Fatal("Apple Silicon Kent install must install a release archive executable")
+		if source != "kent_1.2.3_darwin_arm64" {
+			t.Fatalf("Apple Silicon Kent install source = %q, want versioned release archive executable", source)
 		}
 		if destination != "kent" {
 			t.Fatalf("Apple Silicon Kent install destination = %q, want kent", destination)
@@ -96,7 +96,8 @@ type formulaEvaluation struct {
 func evaluateFormulaOnMac(t *testing.T, formulaPath string, appleSilicon bool) formulaEvaluation {
 	t.Helper()
 	evaluateFormula := exec.Command("ruby", "-rjson", "-e", `
-apple_silicon = ARGV.fetch(1) == "arm"
+$apple_silicon = ARGV.fetch(1) == "arm"
+fixture_version = ARGV.fetch(2)
 
 module OS
   def self.mac?
@@ -128,12 +129,17 @@ class Formula
     def homepage(*); end
 
     def version(value)
+      if @inferred_version == value
+        raise "explicit version #{value} is redundant with the stable URL"
+      end
       @formula_version = value
     end
 
     def license(*); end
     def root_url(*); end
-    def sha256(*); end
+    def sha256(*)
+      raise "sha256 cannot be declared directly inside on_macos" if @platform_block == :macos
+    end
     def caveats(*); end
     def test(*); end
 
@@ -147,21 +153,35 @@ class Formula
     end
 
     def on_macos
+      previous_platform_block = @platform_block
+      @platform_block = :macos
       yield
+    ensure
+      @platform_block = previous_platform_block
     end
 
     def on_linux; end
 
     def on_arm
+      previous_platform_block = @platform_block
+      @platform_block = :arm
       yield if $apple_silicon
+    ensure
+      @platform_block = previous_platform_block
     end
 
     def on_intel
+      previous_platform_block = @platform_block
+      @platform_block = :intel
       yield unless $apple_silicon
+    ensure
+      @platform_block = previous_platform_block
     end
 
     def url(value)
+      raise "url cannot be declared directly inside on_macos" if @platform_block == :macos
       @formula_url = value
+      @inferred_version = $fixture_version if @platform_block.nil?
     end
   end
 
@@ -172,10 +192,11 @@ class Formula
   end
 
   def version
-    self.class.formula_version
+    self.class.formula_version || $fixture_version
   end
 end
 
+$fixture_version = fixture_version
 load ARGV.fetch(0)
 formula = Kent.new
 formula.install
@@ -184,10 +205,10 @@ puts JSON.generate(
   requires_arm64: Kent.dependencies.include?({ arch: :arm64 }),
   installed: formula.bin.installed,
 )
-`, formulaPath, map[bool]string{true: "arm", false: "intel"}[appleSilicon])
-	output, err := evaluateFormula.Output()
+`, formulaPath, map[bool]string{true: "arm", false: "intel"}[appleSilicon], "1.2.3")
+	output, err := evaluateFormula.CombinedOutput()
 	if err != nil {
-		t.Fatalf("evaluate generated formula on macOS: %v", err)
+		t.Fatalf("evaluate generated formula on macOS: %v\n%s", err, output)
 	}
 
 	var result formulaEvaluation


### PR DESCRIPTION
## Summary
- keep the macOS ARM archive as the stable top-level URL so Intel macOS can load the formula and fail through the existing ARM64 dependency
- keep Linux architecture-specific release archive overrides
- let Homebrew derive the release version from the stable URL
- correct the generator harness architecture authority and reject Homebrew-invalid URL/checksum/version declarations

## Verification
- `./scripts/test.sh ./server/core -run TestBrewTapGenerator -count=1`
- `bash -n scripts/update-brew-tap.sh`
- `shellcheck scripts/update-brew-tap.sh`
- `./scripts/build.sh --output ./bin/kent`
- Homebrew tap PR #43 test-bot and pr-pull workflows passed for 2.5.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated Homebrew formulas for Apple Silicon installations by using the correct versioned download source and checksum.
  * Preserved existing Linux installation sources and checksums.
  * Enhanced formula validation to catch incorrect platform-specific declarations and version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->