### PR TITLE
Project transcript row metadata across delivery surfaces

### DIFF
--- a/cli/app/pty_checkpoint_model_behavior_test.go
+++ b/cli/app/pty_checkpoint_model_behavior_test.go
@@ -178,6 +178,7 @@ func TestPTYCheckpointModelEmitsScenarioFinalAppliedAfterTerminalTransaction(t *
 			Visibility: clientui.EntryVisibilityOngoing,
 			Integrity:  transcript.RowIntegrityValid,
 			Kind:       clientui.TranscriptRowAssistant,
+			Locator:    transcript.CommittedRowLocator{EventSequence: 1, RowOrdinal: 1},
 			Assistant: &clientui.TranscriptAssistantRow{
 				StepID:   ptyCheckpointStepID(),
 				StreamID: ptyCheckpointAssistantStreamID(),
@@ -376,6 +377,7 @@ func applyPTYCheckpointAssistantFinal(model *ptyCheckpointModel, sequence uint64
 			Visibility: clientui.EntryVisibilityOngoing,
 			Integrity:  transcript.RowIntegrityValid,
 			Kind:       clientui.TranscriptRowAssistant,
+			Locator:    transcript.CommittedRowLocator{EventSequence: int64(sequence), RowOrdinal: 1},
 			Assistant: &clientui.TranscriptAssistantRow{
 				StepID:   ptyCheckpointStepID(),
 				StreamID: ptyCheckpointAssistantStreamID(),

--- a/cli/app/session_transcript_controller_test.go
+++ b/cli/app/session_transcript_controller_test.go
@@ -168,6 +168,7 @@ func TestOngoingTranscriptControllerDrainsQueuedAssistantFinalizationAfterDetail
 		Visibility: transcript.EntryVisibilityOngoing,
 		Integrity:  transcript.RowIntegrityValid,
 		Kind:       clientui.TranscriptRowAssistant,
+		Locator:    transcript.CommittedRowLocator{EventSequence: 1, RowOrdinal: 1},
 		Assistant: &clientui.TranscriptAssistantRow{
 			StepID:   ongoingTestStepID(),
 			StreamID: &streamID,
@@ -481,6 +482,7 @@ func ongoingTranscriptMessage(sequence uint64, kind clientui.TranscriptMessageKi
 			Visibility: transcript.EntryVisibilityOngoing,
 			Integrity:  transcript.RowIntegrityValid,
 			Kind:       clientui.TranscriptRowUser,
+			Locator:    transcript.CommittedRowLocator{EventSequence: int64(sequence), RowOrdinal: 1},
 			User:       &clientui.TranscriptUserRow{StepID: ongoingTestStepID(), Text: "hello"},
 		})
 	case clientui.TranscriptMessageRuntimeReadModelUpdate:

--- a/cli/app/session_transcript_pending_tools_test.go
+++ b/cli/app/session_transcript_pending_tools_test.go
@@ -55,6 +55,7 @@ func TestCommittedToolRowAppendsImmediatelyAndRemovesPendingToolInSameEvent(t *t
 		Visibility: transcript.EntryVisibilityOngoing,
 		Integrity:  transcript.RowIntegrityValid,
 		Kind:       clientui.TranscriptRowTool,
+		Locator:    transcript.CommittedRowLocator{EventSequence: 1, RowOrdinal: 1},
 		Tool: &clientui.TranscriptToolRow{
 			StepID:     ongoingTestStepID(),
 			ToolCallID: "tool-1",
@@ -165,6 +166,7 @@ func TestPendingToolStartUsesPresentationMetadata(t *testing.T) {
 		Visibility: transcript.EntryVisibilityOngoing,
 		Integrity:  transcript.RowIntegrityValid,
 		Kind:       clientui.TranscriptRowTool,
+		Locator:    transcript.CommittedRowLocator{EventSequence: 1, RowOrdinal: 1},
 		Tool: &clientui.TranscriptToolRow{
 			StepID:       ongoingTestStepID(),
 			ToolCallID:   "77777777-7777-4777-8777-777777777777",

--- a/cli/app/ui_detail_test_ids_test.go
+++ b/cli/app/ui_detail_test_ids_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"hash/fnv"
 	"slices"
 
 	"core/cli/tui"
@@ -19,6 +20,7 @@ func detailTestUserRow(text string) clientui.TranscriptCommittedRow {
 		Visibility: clientui.EntryVisibilityDetail,
 		Integrity:  transcript.RowIntegrityValid,
 		Kind:       clientui.TranscriptRowUser,
+		Locator:    detailTestLocator("user:" + text),
 		User:       &clientui.TranscriptUserRow{Text: text},
 	}
 }
@@ -28,6 +30,7 @@ func detailTestAssistantRow(text string) clientui.TranscriptCommittedRow {
 		Visibility: clientui.EntryVisibilityDetail,
 		Integrity:  transcript.RowIntegrityValid,
 		Kind:       clientui.TranscriptRowAssistant,
+		Locator:    detailTestLocator("assistant:" + text),
 		Assistant:  &clientui.TranscriptAssistantRow{Text: text},
 	}
 }
@@ -37,8 +40,19 @@ func detailTestToolRow(tool clientui.TranscriptToolRow) clientui.TranscriptCommi
 		Visibility: clientui.EntryVisibilityDetail,
 		Integrity:  transcript.RowIntegrityValid,
 		Kind:       clientui.TranscriptRowTool,
+		Locator:    detailTestLocator("tool:" + string(tool.ToolCallID) + ":" + tool.Text),
 		Tool:       &tool,
 	}
+}
+
+func detailTestLocator(value string) transcript.CommittedRowLocator {
+	hash := fnv.New64a()
+	_, _ = hash.Write([]byte(value))
+	sequence := int64(hash.Sum64() & (uint64(1<<63) - 1))
+	if sequence == 0 {
+		sequence = 1
+	}
+	return transcript.CommittedRowLocator{EventSequence: sequence, RowOrdinal: 1}
 }
 
 func detailTestRowsEqual(left, right []clientui.TranscriptCommittedRow) bool {

--- a/cli/app/ui_detail_test_ids_test.go
+++ b/cli/app/ui_detail_test_ids_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"hash/fnv"
 	"slices"
+	"testing"
 
 	"core/cli/tui"
 	"core/shared/clientui"
@@ -57,4 +58,17 @@ func detailTestLocator(value string) transcript.CommittedRowLocator {
 
 func detailTestRowsEqual(left, right []clientui.TranscriptCommittedRow) bool {
 	return slices.EqualFunc(left, right, tui.TranscriptCommittedRowEqual)
+}
+
+func TestDetailTranscriptRowEqualityIncludesLocator(t *testing.T) {
+	left := detailTestUserRow("same content")
+	right := left
+	right.Locator.RowOrdinal++
+
+	if !tui.TranscriptCommittedRowEqual(left, left) {
+		t.Fatal("a transcript row was not equal to itself")
+	}
+	if tui.TranscriptCommittedRowEqual(left, right) {
+		t.Fatalf("rows with different locators were treated as equal: left=%+v right=%+v", left.Locator, right.Locator)
+	}
 }

--- a/cli/app/ui_detail_transcript_request_test.go
+++ b/cli/app/ui_detail_transcript_request_test.go
@@ -235,12 +235,14 @@ func TestDetailTranscriptMalformedToolRowsRemainLoadable(t *testing.T) {
 			Visibility: clientui.EntryVisibilityDetail,
 			Integrity:  transcript.RowIntegrityRecoverableMalformed,
 			Kind:       clientui.TranscriptRowTool,
+			Locator:    transcript.CommittedRowLocator{EventSequence: 1, RowOrdinal: 1},
 			Tool:       &clientui.TranscriptToolRow{},
 		},
 		{
 			Visibility: clientui.EntryVisibilityDetail,
 			Integrity:  transcript.RowIntegrityUnrecoverableMalformed,
 			Kind:       clientui.TranscriptRowTool,
+			Locator:    transcript.CommittedRowLocator{EventSequence: 1, RowOrdinal: 2},
 			Tool:       &clientui.TranscriptToolRow{},
 		},
 	}

--- a/cli/app/ui_ongoing_transcript_state.go
+++ b/cli/app/ui_ongoing_transcript_state.go
@@ -395,6 +395,14 @@ func (m *uiModel) applyTranscriptOperationalDiagnostic(diagnostic clientui.Trans
 			uiStatusNoticeReplace,
 			"",
 		)
+	case clientui.OperationalDiagnosticInFlightClearFailed:
+		return m.sendTransientStatusWithNoticeID(
+			"run cleanup failed: "+diagnostic.Detail,
+			uiStatusNoticeError,
+			transientStatusDuration,
+			uiStatusNoticeReplace,
+			"",
+		)
 	default:
 		panic(fmt.Sprintf("unsupported transcript operational diagnostic %q", diagnostic.Code))
 	}

--- a/cli/tui/transcript_row_equal.go
+++ b/cli/tui/transcript_row_equal.go
@@ -9,7 +9,8 @@ import (
 func TranscriptCommittedRowEqual(left, right clientui.TranscriptCommittedRow) bool {
 	if left.Visibility != right.Visibility ||
 		left.Integrity != right.Integrity ||
-		left.Kind != right.Kind {
+		left.Kind != right.Kind ||
+		left.Locator != right.Locator {
 		return false
 	}
 	return transcriptUserRowEqual(left.User, right.User) &&

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -13,6 +13,7 @@
 - Transcript delivery does not promise lossless continuity across subscription establishment, disconnection, process failure, or recovery. When a client detects discontinuity, it reopens the subscription and refreshes authoritative Session state instead of remaining silently stale.
 - A Session with no execution target hydrates without one. Failure to resolve an execution target fails Chat opening or reopening with a clear error; it never becomes an absent or stale target.
 - Clients receive transcript, session-activity, and prompt-activity updates in one ordered subscription.
+- A failure to clear PendingModelRecovery remains live operational feedback. TUI and Desktop surface it through their typed operational-diagnostic or status-notice owner; it is neither persisted nor projected as committed transcript history.
 - The server owns exact Session-resource admission, Runtime Command ordering, and dormant Goal commands. Transport keeps request identity and idempotency only; it never owns ordering, queueing, execution lifecycle, reconciliation, or persistence disposition.
 
 ## Skills And Generated Assets

--- a/docs/dev/specs/desktop-chat.md
+++ b/docs/dev/specs/desktop-chat.md
@@ -30,7 +30,7 @@
 ## Transcript
 
 - Chat has one infinite-scrolling transcript with a live assistant tail. It does not expose the TUI's Ongoing Mode and Detail Mode split. It shows every committed transcript item except items whose explicit hidden classification requires omission.
-- Each non-conversational item has a compact and full presentation. Expansion is local to the visible row and returns to that row type's default after the row leaves and re-enters the viewport. Expanded rows alone show their committed timestamp and actions; live rows never invent a timestamp.
+- Each non-conversational item has a compact and full presentation. Expansion is local to the visible row and returns to that row type's default after the row leaves and re-enters the viewport. Expanded rows alone show their actions.
 - Expanded flat rows use the transcript width without a nested island. They are borderless and neutral except for the semantic color of their leading status icon. Their header shows icon, localized type, compact summary, and available status or actions. The header toggles expansion without taking row-specific actions.
 - Context rows start collapsed: loaded instructions with their source label, skill guidance, environment facts, Subagent context, handoff context, mode instructions and restoration, Workflow execution instructions, active-goal continuation, Compaction-Preserved User Messages, compaction summaries, context-pressure reminders, Goal feedback, and worktree changes. Worktree entry shows branch and path; return to the main workspace shows its destination. Full expansion shows the original complete content.
 - Assistant commentary is a full assistant message without a phase label.
@@ -51,7 +51,7 @@
 - Thinking Status remains visible throughout the complete running active-work scope. For a main-agent Agent Step this includes assistant streaming and tool execution. As live or committed content arrives, it remains the final transient tail immediately before the composer.
 - Thinking Status disappears when its owning active work finishes or runtime activity leaves running. Its initial production exit combines a short downward slide with a fade; reduced motion removes the transition.
 - A later Agent Step starts fresh at `Working…`. Desktop does not morph Thinking Status into an assistant message.
-- Thinking Status is non-interactive. It has no disclosure, Copy action, timestamp, hover detail, or link to a Reasoning Trace.
+- Thinking Status is non-interactive. It has no disclosure, Copy action, hover detail, or link to a Reasoning Trace.
 - While the Reviewer model request is processing, the same transient presentation shows a spinner and `Reviewing…`. Reviewer completion removes it and creates no completed-review marker.
 - Main-agent Thinking Status takes precedence over Reviewer activity. If a main-agent follow-up starts while Reviewer activity is still represented, the fresh ordinary `Working…` and Thinking Status presentation replaces `Reviewing…`.
 - While a Question or Approval waits for the operator, Thinking Status is absent. The prompt picker alone owns the waiting state.
@@ -61,12 +61,15 @@
 - The first nonempty progressive Reasoning Trace update creates one provisional collapsed item. Later updates change that same item in place. The operator may expand it while it streams, and its complete visible text continues updating in place.
 - If the server resets a provider attempt, Desktop removes the discarded provisional Reasoning Trace but retains the current Thinking Status. A later trace update creates fresh provisional trace content.
 - A live Reasoning Trace does not auto-open or auto-close. A provider that supplies only a completed trace creates the collapsed item when that trace becomes available.
-- A live Reasoning Trace has no timestamp or actions. After it commits, its expanded presentation shows the authoritative timestamp and an icon-only Copy action for the complete plain text.
+- A live Reasoning Trace has no actions. After it commits, its expanded presentation shows an icon-only Copy action for the complete plain text.
 - The server's Reasoning Trace presentation projection removes only the provider's outer literal `**` delimiters. It preserves interior asterisks and all other content. Desktop and the TUI display and copy that projected text without repeating the cleanup. Persisted and model-facing content remains unchanged.
 - Desktop represents every Reasoning Trace supplied by the server in authoritative order. It never concatenates, groups, drops, or otherwise interprets separate traces.
 - Desktop shows no reasoning-duration copy until the server supplies an authoritative duration. It never estimates a duration from client observation. A future authoritative duration measures from the first nonempty update for that Reasoning Trace through its commit.
 - Malformed user, assistant, tool, or notice items are contract failures, not display variants: development builds fail immediately; production uses the transcript contract-failure recovery path. Chat never substitutes placeholder content or roles.
-- Each committed transcript row has one stable Kent-provided identity across pagination, hydration, and live updates. Desktop does not infer row identity from display text, role, position, or transport order.
+- Each committed transcript row has one stable Kent-provided identity across pagination, hydration, and live updates. The identity is a Session-scoped locator composed of the durable event sequence and a one-based ordinal among committed rows projected from that event, after filtering, in deterministic projection order.
+- Both locator components are positive and required on every committed row. Provisional and other non-committed row shapes omit the whole locator. Desktop does not infer row identity from display text, role, position, or transport order.
+- Duplicate locators are contract failures within one bounded page and within one continuous subscription generation after applying hydration and live committed rows. After hydration, live committed rows advance by durable event sequence; rows from one event are contiguous and use gapless one-based ordinals in deterministic projection order. Regression, repetition, an ordinal gap, or a live event sequence that is not newer than the greatest hydrated event sequence is a contract failure.
+- The locator-order contract applies only to committed rows in one subscription generation. The same locator may recur across independent reads, page responses, replacement hydration generations, reconnects, and separate clients or surfaces.
 - Opening, reopening, and transcript recovery hydrate mutable Session facts from their authoritative server owners. Cached feed-ordering state never replaces fresher Session identity, execution-target, runtime, or transcript facts.
 - Desktop does not require a globally atomic cross-owner snapshot-plus-live handoff or exactly-once delivery across that boundary. If event-sequence continuity cannot be established, Desktop discards transient live state and repeats authoritative hydration instead of remaining silently stale.
 
@@ -105,8 +108,7 @@
 - Thinking Status is the sole non-message exception that may imitate an assistant island. It remains transient and never becomes transcript history.
 - User messages longer than 10 rendered lines begin collapsed to 10 lines with a fade and accessible Expand action. Expansion is one-way until the row leaves the viewport. Assistant messages stay expanded.
 - Each committed message has an always-visible footer aligned and width-matched with the message. Footer actions are icon-only controls with accessible names and explanatory hover or focus text. Eligible user messages offer Copy and Edit; assistant messages offer Copy. Copy uses the original Markdown source. Edit is the only fork action.
-- A live assistant message has no footer. The committed message receives timestamp and Copy together when it resolves.
-- Committed-message time uses the server's durable timestamp: relative age for 24 hours, then localized compact date and time, including the year only when different from the current year. Full date, time, and time zone are available on focus or hover.
+- A live assistant message has no footer. The committed message receives Copy when it resolves.
 - Consecutive user or assistant messages use tighter spacing and a compact adjacent corner on their matching side. Messages remain separate islands.
 - Tools, diagnostics, context, and notices use flat transcript rows rather than message islands. Transcript content opens no duplicate detail surfaces; its full content is available through expansion.
 - Contextual destinations adapt between shifted and overlay presentation. Processes and Goal are the defined Chat destinations. Session settings use a non-modal popover under the composer, not a contextual destination.
@@ -114,7 +116,7 @@
 ## Edit And Fork
 
 - Desktop replaces the TUI rollback picker with the Edit action in an eligible committed user-message footer. It adds no global rollback picker, double-Escape shortcut, separate Fork action, or confirmation dialog.
-- A user message is eligible only when the server supplies its typed rollback target. Desktop never derives eligibility from role, text, position, timestamp, or another row.
+- A user message is eligible only when the server supplies its typed rollback target. Desktop never derives eligibility from role, text, position, or another row.
 - Edit follows the TUI admission boundary. It is unavailable while authoritative runtime input is blocked or while the ordinary composer draft is nonblank. The server enforces active-work admission; the client does not become the sole blocker.
 - Activating Edit immediately resolves the ordinary fork/rollback transition. It does not wait for the edited text to be submitted.
 - The server creates one durable main child Session whose copied history ends immediately before the selected user message. The selected message and all later parent history are absent from the child, and the parent Session remains unchanged.

--- a/server/registry/runtime_registry.go
+++ b/server/registry/runtime_registry.go
@@ -489,8 +489,8 @@ func (r *RuntimeRegistry) publishRuntimeEvent(entry *authorityRuntimeEntry, evt 
 	if !transcriptEventRequiresVisibleSubscriber(evt) || entry.sessionFeed.HasSubscribers() {
 		messages, err := runtimeview.TranscriptMessagesFromRuntimeEventChecked(evt)
 		if err != nil {
-			entry.sessionFeed.Publish([]clientui.TranscriptEvent{{}})
-			return fmt.Errorf("project runtime transcript event: %w", err)
+			contractErr := entry.sessionFeed.CloseContractViolation(fmt.Errorf("project runtime transcript event: %w", err))
+			return contractErr
 		}
 		entry.sessionFeed.Publish(messages)
 	}

--- a/server/registry/runtime_registry.go
+++ b/server/registry/runtime_registry.go
@@ -487,7 +487,12 @@ func (r *RuntimeRegistry) PublishAuthorityRuntimeEvent(ref runtimeids.SessionRes
 
 func (r *RuntimeRegistry) publishRuntimeEvent(entry *authorityRuntimeEntry, evt runtime.Event) error {
 	if !transcriptEventRequiresVisibleSubscriber(evt) || entry.sessionFeed.HasSubscribers() {
-		entry.sessionFeed.Publish(runtimeview.TranscriptMessagesFromRuntimeEvent(evt))
+		messages, err := runtimeview.TranscriptMessagesFromRuntimeEventChecked(evt)
+		if err != nil {
+			entry.sessionFeed.Publish([]clientui.TranscriptEvent{{}})
+			return fmt.Errorf("project runtime transcript event: %w", err)
+		}
+		entry.sessionFeed.Publish(messages)
 	}
 	if runtimeEventShouldPublishSessionStatus(evt) {
 		if err := entry.sessionFeed.PublishBuilt(func() ([]clientui.TranscriptEvent, error) {

--- a/server/registry/runtime_registry_test.go
+++ b/server/registry/runtime_registry_test.go
@@ -160,6 +160,39 @@ func TestPublishMalformedLiveLocatorClosesTranscriptFeedWithContractError(t *tes
 	if !ok || reason != serverapi.TranscriptCloseReasonContractViolation {
 		t.Fatalf("subscription close reason = %q ok=%t, want contract violation", reason, ok)
 	}
+
+	reconnected, err := registry.SubscribeSessionTranscript(context.Background(), serverapi.TranscriptSubscribeRequest{
+		SessionID: engine.SessionID(),
+	})
+	if err != nil {
+		t.Fatalf("reconnect transcript subscription: %v", err)
+	}
+	defer func() { _ = reconnected.Close() }()
+	if hydration := nextTranscriptMessage(t, reconnected); hydration.Kind() != clientui.TranscriptMessageHydration {
+		t.Fatalf("reconnected first message = %+v, want hydration", hydration)
+	}
+	err = registry.PublishAuthorityRuntimeEvent(
+		registryTestResourceRef(engine.SessionID()),
+		runtime.Event{
+			Kind:        runtime.EventUserMessageFlushed,
+			StepID:      registryTestStepID,
+			UserMessage: "valid after reconnect",
+			CommittedProvenance: &runtime.TranscriptCommittedRowProvenance{
+				EventSequence: 1,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("publish valid row after reconnect: %v", err)
+	}
+	message := nextTranscriptMessage(t, reconnected)
+	if message.Kind() != clientui.TranscriptMessageCommittedRow {
+		t.Fatalf("reconnected live message = %+v, want committed row", message)
+	}
+	row := transcriptPayload[clientui.TranscriptCommittedRow](t, message)
+	if row.Locator.EventSequence != 1 || row.Locator.RowOrdinal != 1 {
+		t.Fatalf("reconnected live locator = %+v, want {event=1 ordinal=1}", row.Locator)
+	}
 }
 
 func TestPublishMalformedLiveLocatorPanicsInContractMode(t *testing.T) {

--- a/server/registry/runtime_registry_test.go
+++ b/server/registry/runtime_registry_test.go
@@ -553,6 +553,7 @@ func TestAuthorityEventFeedProjectsExactResourceGeneration(t *testing.T) {
 		StepID:                     registryTestStepID,
 		Message:                    llm.Message{Role: llm.RoleAssistant, Phase: textutil.Value(llm.MessagePhaseFinal), Content: textutil.Value("authority event")},
 		CommittedTranscriptChanged: true,
+		CommittedProvenance:        &runtime.TranscriptCommittedRowProvenance{EventSequence: 1},
 	})
 	message := nextTranscriptMessage(t, sub)
 	if message.Kind() != clientui.TranscriptMessageCommittedRow {

--- a/server/registry/runtime_registry_test.go
+++ b/server/registry/runtime_registry_test.go
@@ -119,6 +119,80 @@ func TestSubscribeSessionTranscriptFailsExecutionTargetResolution(t *testing.T) 
 	}
 }
 
+func TestPublishMalformedLiveLocatorClosesTranscriptFeedWithContractError(t *testing.T) {
+	registry := NewRuntimeRegistry().WithTranscriptContractViolationPanic(false)
+	engine := newRegistryTestRuntime(t, nil)
+	registerReady(t, registry, engine.SessionID(), engine)
+	defer closeRuntime(registry, engine.SessionID(), engine)
+
+	subscription, err := registry.SubscribeSessionTranscript(context.Background(), serverapi.TranscriptSubscribeRequest{
+		SessionID: engine.SessionID(),
+	})
+	if err != nil {
+		t.Fatalf("subscribe transcript: %v", err)
+	}
+	defer func() { _ = subscription.Close() }()
+	if hydration := nextTranscriptMessage(t, subscription); hydration.Kind() != clientui.TranscriptMessageHydration {
+		t.Fatalf("first message = %+v, want hydration", hydration)
+	}
+
+	err = registry.PublishAuthorityRuntimeEvent(
+		registryTestResourceRef(engine.SessionID()),
+		runtime.Event{
+			Kind:                runtime.EventUserMessageFlushed,
+			StepID:              registryTestStepID,
+			UserMessage:         "malformed live row",
+			CommittedProvenance: &runtime.TranscriptCommittedRowProvenance{},
+		},
+	)
+	if err == nil {
+		t.Fatal("malformed live locator returned nil error")
+	}
+	reason, ok := serverapi.TranscriptCloseReasonOf(err)
+	if !ok || reason != serverapi.TranscriptCloseReasonContractViolation {
+		t.Fatalf("publish error close reason = %q ok=%t, want contract violation", reason, ok)
+	}
+	_, err = subscription.Next(context.Background())
+	if err == nil {
+		t.Fatal("subscription remained open after malformed live locator")
+	}
+	reason, ok = serverapi.TranscriptCloseReasonOf(err)
+	if !ok || reason != serverapi.TranscriptCloseReasonContractViolation {
+		t.Fatalf("subscription close reason = %q ok=%t, want contract violation", reason, ok)
+	}
+}
+
+func TestPublishMalformedLiveLocatorPanicsInContractMode(t *testing.T) {
+	registry := NewRuntimeRegistry().WithTranscriptContractViolationPanic(true)
+	engine := newRegistryTestRuntime(t, nil)
+	registerReady(t, registry, engine.SessionID(), engine)
+	defer closeRuntime(registry, engine.SessionID(), engine)
+
+	subscription, err := registry.SubscribeSessionTranscript(context.Background(), serverapi.TranscriptSubscribeRequest{
+		SessionID: engine.SessionID(),
+	})
+	if err != nil {
+		t.Fatalf("subscribe transcript: %v", err)
+	}
+	defer func() { _ = subscription.Close() }()
+	_ = nextTranscriptMessage(t, subscription)
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("malformed live locator did not panic in contract mode")
+		}
+	}()
+	_ = registry.PublishAuthorityRuntimeEvent(
+		registryTestResourceRef(engine.SessionID()),
+		runtime.Event{
+			Kind:                runtime.EventUserMessageFlushed,
+			StepID:              registryTestStepID,
+			UserMessage:         "malformed live row",
+			CommittedProvenance: &runtime.TranscriptCommittedRowProvenance{},
+		},
+	)
+}
+
 func TestSubscriptionAndPromptResolutionWithPendingPromptDoNotDeadlock(t *testing.T) {
 	registry := NewRuntimeRegistry()
 	engine := newRegistryTestRuntime(t, nil)

--- a/server/registry/runtime_registry_test.go
+++ b/server/registry/runtime_registry_test.go
@@ -120,7 +120,8 @@ func TestSubscribeSessionTranscriptFailsExecutionTargetResolution(t *testing.T) 
 }
 
 func TestPublishMalformedLiveLocatorClosesTranscriptFeedWithContractError(t *testing.T) {
-	registry := NewRuntimeRegistry().WithTranscriptContractViolationPanic(false)
+	defer withTranscriptContractViolationPanic(false)()
+	registry := NewRuntimeRegistry()
 	engine := newRegistryTestRuntime(t, nil)
 	registerReady(t, registry, engine.SessionID(), engine)
 	defer closeRuntime(registry, engine.SessionID(), engine)
@@ -196,7 +197,8 @@ func TestPublishMalformedLiveLocatorClosesTranscriptFeedWithContractError(t *tes
 }
 
 func TestPublishMalformedLiveLocatorPanicsInContractMode(t *testing.T) {
-	registry := NewRuntimeRegistry().WithTranscriptContractViolationPanic(true)
+	defer withTranscriptContractViolationPanic(true)()
+	registry := NewRuntimeRegistry()
 	engine := newRegistryTestRuntime(t, nil)
 	registerReady(t, registry, engine.SessionID(), engine)
 	defer closeRuntime(registry, engine.SessionID(), engine)

--- a/server/registry/session_feed_sequencer.go
+++ b/server/registry/session_feed_sequencer.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -10,6 +11,21 @@ import (
 type sessionFeedSequencer struct {
 	mu     sync.Mutex
 	broker *transcriptSubscriptionBroker
+}
+
+type transcriptHydrationProjectionError struct {
+	cause error
+}
+
+func (e transcriptHydrationProjectionError) Error() string {
+	if e.cause == nil {
+		return "transcript hydration projection failed"
+	}
+	return e.cause.Error()
+}
+
+func (e transcriptHydrationProjectionError) Unwrap() error {
+	return e.cause
 }
 
 func newSessionFeedSequencer(broker *transcriptSubscriptionBroker) *sessionFeedSequencer {
@@ -33,6 +49,10 @@ func (s *sessionFeedSequencer) Subscribe(
 	}
 	hydration, err := build()
 	if err != nil {
+		var projectionErr transcriptHydrationProjectionError
+		if errors.As(err, &projectionErr) {
+			return nil, transcriptProjectionContractError(projectionErr)
+		}
 		return nil, err
 	}
 	event := clientui.NewTranscriptEvent(hydration)
@@ -99,6 +119,20 @@ func (s *sessionFeedSequencer) Close(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.broker.Close(err)
+}
+
+func (s *sessionFeedSequencer) CloseContractViolation(err error) error {
+	if err == nil {
+		return nil
+	}
+	if s == nil {
+		return transcriptProjectionContractError(err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	contractErr := transcriptProjectionContractError(err)
+	s.broker.Close(contractErr)
+	return contractErr
 }
 
 func (s *sessionFeedSequencer) publishRuntimeReadModelLocked(update clientui.RuntimeReadModelUpdate) {

--- a/server/registry/session_feed_sequencer.go
+++ b/server/registry/session_feed_sequencer.go
@@ -131,7 +131,7 @@ func (s *sessionFeedSequencer) CloseContractViolation(err error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	contractErr := transcriptProjectionContractError(err)
-	s.broker.Close(contractErr)
+	s.broker.CloseSubscribers(contractErr)
 	return contractErr
 }
 

--- a/server/registry/transcript_hydration_composer.go
+++ b/server/registry/transcript_hydration_composer.go
@@ -17,7 +17,9 @@ func (r *RuntimeRegistry) composeTranscriptHydration(
 ) (clientui.TranscriptHydration, error) {
 	hydration, err := runtimeview.TranscriptHydrationFromSnapshotChecked(snapshot)
 	if err != nil {
-		return clientui.TranscriptHydration{}, fmt.Errorf("project transcript hydration: %w", err)
+		return clientui.TranscriptHydration{}, transcriptHydrationProjectionError{
+			cause: fmt.Errorf("project transcript hydration: %w", err),
+		}
 	}
 	readModel, err := r.runtimeReadModelFeedSnapshot(ctx, sessionID, nil)
 	if err != nil {
@@ -46,7 +48,9 @@ func (r *RuntimeRegistry) composeTranscriptHydration(
 		return clientui.TranscriptHydration{}, fmt.Errorf("build transcript background activities: %w", err)
 	}
 	if err := hydration.Validate(); err != nil {
-		return clientui.TranscriptHydration{}, fmt.Errorf("validate canonical transcript hydration: %w", err)
+		return clientui.TranscriptHydration{}, transcriptHydrationProjectionError{
+			cause: fmt.Errorf("validate canonical transcript hydration: %w", err),
+		}
 	}
 	return hydration, nil
 }

--- a/server/registry/transcript_hydration_composer.go
+++ b/server/registry/transcript_hydration_composer.go
@@ -15,7 +15,10 @@ func (r *RuntimeRegistry) composeTranscriptHydration(
 	entry *authorityRuntimeEntry,
 	snapshot runtime.TranscriptHydrationSnapshot,
 ) (clientui.TranscriptHydration, error) {
-	hydration := runtimeview.TranscriptHydrationFromSnapshot(snapshot)
+	hydration, err := runtimeview.TranscriptHydrationFromSnapshotChecked(snapshot)
+	if err != nil {
+		return clientui.TranscriptHydration{}, fmt.Errorf("project transcript hydration: %w", err)
+	}
 	readModel, err := r.runtimeReadModelFeedSnapshot(ctx, sessionID, nil)
 	if err != nil {
 		return clientui.TranscriptHydration{}, fmt.Errorf("build transcript runtime read model: %w", err)

--- a/server/registry/transcript_subscription_broker.go
+++ b/server/registry/transcript_subscription_broker.go
@@ -104,31 +104,25 @@ func (b *transcriptSubscriptionBroker) Publish(events []clientui.TranscriptEvent
 }
 
 func (b *transcriptSubscriptionBroker) Close(err error) {
-	if b == nil {
-		return
-	}
-	b.mu.Lock()
-	if b.closed {
-		b.mu.Unlock()
-		return
-	}
-	b.closed = true
-	subs := make([]*transcriptSubscription, 0, len(b.subscribers))
-	for id, sub := range b.subscribers {
-		subs = append(subs, sub)
-		delete(b.subscribers, id)
-	}
-	b.mu.Unlock()
-	for _, sub := range subs {
-		sub.closeWithError(err)
-	}
+	b.closeSubscribers(err, true)
 }
 
 func (b *transcriptSubscriptionBroker) CloseSubscribers(err error) {
+	b.closeSubscribers(err, false)
+}
+
+func (b *transcriptSubscriptionBroker) closeSubscribers(err error, terminal bool) {
 	if b == nil {
 		return
 	}
 	b.mu.Lock()
+	if terminal {
+		if b.closed {
+			b.mu.Unlock()
+			return
+		}
+		b.closed = true
+	}
 	subs := make([]*transcriptSubscription, 0, len(b.subscribers))
 	for id, sub := range b.subscribers {
 		subs = append(subs, sub)

--- a/server/registry/transcript_subscription_broker.go
+++ b/server/registry/transcript_subscription_broker.go
@@ -104,31 +104,44 @@ func (b *transcriptSubscriptionBroker) Publish(events []clientui.TranscriptEvent
 }
 
 func (b *transcriptSubscriptionBroker) Close(err error) {
-	b.closeSubscribers(err, true)
-}
-
-func (b *transcriptSubscriptionBroker) CloseSubscribers(err error) {
-	b.closeSubscribers(err, false)
-}
-
-func (b *transcriptSubscriptionBroker) closeSubscribers(err error, terminal bool) {
 	if b == nil {
 		return
 	}
 	b.mu.Lock()
-	if terminal {
-		if b.closed {
-			b.mu.Unlock()
-			return
-		}
-		b.closed = true
+	if b.closed {
+		b.mu.Unlock()
+		return
 	}
+	b.closed = true
+	subs := b.detachSubscribersLocked()
+	b.mu.Unlock()
+	closeTranscriptSubscribers(subs, err)
+}
+
+func (b *transcriptSubscriptionBroker) CloseSubscribers(err error) {
+	if b == nil {
+		return
+	}
+	subs := b.detachSubscribers()
+	closeTranscriptSubscribers(subs, err)
+}
+
+func (b *transcriptSubscriptionBroker) detachSubscribers() []*transcriptSubscription {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.detachSubscribersLocked()
+}
+
+func (b *transcriptSubscriptionBroker) detachSubscribersLocked() []*transcriptSubscription {
 	subs := make([]*transcriptSubscription, 0, len(b.subscribers))
 	for id, sub := range b.subscribers {
 		subs = append(subs, sub)
 		delete(b.subscribers, id)
 	}
-	b.mu.Unlock()
+	return subs
+}
+
+func closeTranscriptSubscribers(subs []*transcriptSubscription, err error) {
 	for _, sub := range subs {
 		sub.closeWithError(err)
 	}

--- a/server/registry/transcript_subscription_broker.go
+++ b/server/registry/transcript_subscription_broker.go
@@ -124,6 +124,22 @@ func (b *transcriptSubscriptionBroker) Close(err error) {
 	}
 }
 
+func (b *transcriptSubscriptionBroker) CloseSubscribers(err error) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	subs := make([]*transcriptSubscription, 0, len(b.subscribers))
+	for id, sub := range b.subscribers {
+		subs = append(subs, sub)
+		delete(b.subscribers, id)
+	}
+	b.mu.Unlock()
+	for _, sub := range subs {
+		sub.closeWithError(err)
+	}
+}
+
 func (s *transcriptSubscription) publish(event clientui.TranscriptEvent) error {
 	if s == nil {
 		return errTranscriptContractViolation("transcript subscription is nil")

--- a/server/registry/transcript_subscription_broker.go
+++ b/server/registry/transcript_subscription_broker.go
@@ -13,6 +13,7 @@ import (
 	"core/shared/invariant"
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
+	"core/shared/transcript"
 )
 
 const transcriptSubscriptionBufferSize = 256
@@ -179,9 +180,12 @@ func transcriptPublishError(err error) error {
 }
 
 type transcriptSubscriptionContract struct {
-	hydrated      bool
-	activeStream  *runtimeids.AssistantStreamID
-	inFlightTools map[clientui.ToolCallID]struct{}
+	hydrated                 bool
+	activeStream             *runtimeids.AssistantStreamID
+	inFlightTools            map[clientui.ToolCallID]struct{}
+	hydratedEventSequence    int64
+	hasHydratedEventSequence bool
+	liveLocator              *transcript.CommittedRowLocator
 }
 
 func (c *transcriptSubscriptionContract) Validate(message clientui.TranscriptMessage) error {
@@ -215,6 +219,10 @@ func (c *transcriptSubscriptionContract) validateHydration(hydration clientui.Tr
 		if err := validateCommittedRow(row); err != nil {
 			return err
 		}
+		if !c.hasHydratedEventSequence || row.Locator.EventSequence > c.hydratedEventSequence {
+			c.hydratedEventSequence = row.Locator.EventSequence
+			c.hasHydratedEventSequence = true
+		}
 	}
 	return nil
 }
@@ -240,6 +248,9 @@ func (c *transcriptSubscriptionContract) validateLiveMessage(message clientui.Tr
 		if err := validateCommittedRow(row); err != nil {
 			return err
 		}
+		if err := c.validateLiveLocator(row.Locator); err != nil {
+			return err
+		}
 		if row.Assistant != nil {
 			if row.Assistant.StreamID != nil {
 				if err := c.matchActiveStream(*row.Assistant.StreamID, message.Sequence, "committed assistant row"); err != nil {
@@ -254,6 +265,33 @@ func (c *transcriptSubscriptionContract) validateLiveMessage(message clientui.Tr
 			return c.trackToolTerminal(row.Tool.ToolCallID, fmt.Sprintf("committed tool row at seq=%d", message.Sequence))
 		}
 	}
+	return nil
+}
+
+func (c *transcriptSubscriptionContract) validateLiveLocator(locator transcript.CommittedRowLocator) error {
+	if c.liveLocator == nil {
+		if c.hasHydratedEventSequence && locator.EventSequence <= c.hydratedEventSequence {
+			return errTranscriptContractViolation(fmt.Sprintf("first live committed row event sequence %d is not newer than hydrated sequence %d", locator.EventSequence, c.hydratedEventSequence))
+		}
+		if locator.RowOrdinal != 1 {
+			return errTranscriptContractViolation(fmt.Sprintf("first live committed row for event %d has ordinal %d, want 1", locator.EventSequence, locator.RowOrdinal))
+		}
+		copyLocator := locator
+		c.liveLocator = &copyLocator
+		return nil
+	}
+	if locator.EventSequence < c.liveLocator.EventSequence {
+		return errTranscriptContractViolation(fmt.Sprintf("live committed row event sequence regressed from %d to %d", c.liveLocator.EventSequence, locator.EventSequence))
+	}
+	if locator.EventSequence == c.liveLocator.EventSequence {
+		if locator.RowOrdinal != c.liveLocator.RowOrdinal+1 {
+			return errTranscriptContractViolation(fmt.Sprintf("live committed row ordinal for event %d = %d, want %d", locator.EventSequence, locator.RowOrdinal, c.liveLocator.RowOrdinal+1))
+		}
+	} else if locator.RowOrdinal != 1 {
+		return errTranscriptContractViolation(fmt.Sprintf("live committed row for event %d starts at ordinal %d, want 1", locator.EventSequence, locator.RowOrdinal))
+	}
+	copyLocator := locator
+	c.liveLocator = &copyLocator
 	return nil
 }
 

--- a/server/registry/transcript_subscription_broker.go
+++ b/server/registry/transcript_subscription_broker.go
@@ -179,6 +179,13 @@ func transcriptPublishError(err error) error {
 	return serverapi.NewTranscriptStreamError(serverapi.TranscriptCloseReasonContractViolation, err)
 }
 
+func transcriptProjectionContractError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return transcriptPublishError(errTranscriptContractViolation(err.Error()))
+}
+
 type transcriptSubscriptionContract struct {
 	hydrated                 bool
 	activeStream             *runtimeids.AssistantStreamID

--- a/server/registry/transcript_subscription_test.go
+++ b/server/registry/transcript_subscription_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"core/server/runtime"
 	"core/shared/clientui"
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
@@ -216,6 +217,70 @@ func TestSessionFeedSequencerBuildsHydrationWithoutPriorRuntimeReadModel(t *test
 	if message := nextTranscriptMessage(t, sub); message.Sequence != 1 || message.Kind() != clientui.TranscriptMessageHydration {
 		t.Fatalf("first message = %+v, want sequence 1 hydration", message)
 	}
+}
+
+func TestSessionFeedSequencerHydrationProjectionUsesContractFailurePolicy(t *testing.T) {
+	t.Run("production returns contract error", func(t *testing.T) {
+		restore := withTranscriptContractViolationPanic(false)
+		defer restore()
+		_, err := newSessionFeedSequencer(newTranscriptSubscriptionBroker()).Subscribe(func() (clientui.TranscriptHydration, error) {
+			return clientui.TranscriptHydration{}, transcriptHydrationProjectionError{cause: errors.New("malformed hydration locator")}
+		})
+		if err == nil {
+			t.Fatal("malformed hydration projection returned nil error")
+		}
+		reason, ok := serverapi.TranscriptCloseReasonOf(err)
+		if !ok || reason != serverapi.TranscriptCloseReasonContractViolation {
+			t.Fatalf("hydration error close reason = %q ok=%t, want contract violation", reason, ok)
+		}
+	})
+	t.Run("development panics with contract diagnostic", func(t *testing.T) {
+		restore := withTranscriptContractViolationPanic(true)
+		defer restore()
+		defer func() {
+			if recover() == nil {
+				t.Fatal("malformed hydration projection did not panic")
+			}
+		}()
+		_, _ = newSessionFeedSequencer(newTranscriptSubscriptionBroker()).Subscribe(func() (clientui.TranscriptHydration, error) {
+			return clientui.TranscriptHydration{}, transcriptHydrationProjectionError{cause: errors.New("malformed hydration locator")}
+		})
+	})
+}
+
+func TestRegistryHydrationCompositionUsesContractFailurePolicy(t *testing.T) {
+	registry := NewRuntimeRegistry()
+	snapshot := runtime.TranscriptHydrationSnapshot{
+		CommittedRows: []runtime.TranscriptCommittedRowFact{{
+			Locator: transcript.CommittedRowLocator{},
+		}},
+	}
+	t.Run("production returns contract error", func(t *testing.T) {
+		restore := withTranscriptContractViolationPanic(false)
+		defer restore()
+		_, err := newSessionFeedSequencer(newTranscriptSubscriptionBroker()).Subscribe(func() (clientui.TranscriptHydration, error) {
+			return registry.composeTranscriptHydration(context.Background(), "", nil, snapshot)
+		})
+		if err == nil {
+			t.Fatal("malformed hydration composition returned nil error")
+		}
+		reason, ok := serverapi.TranscriptCloseReasonOf(err)
+		if !ok || reason != serverapi.TranscriptCloseReasonContractViolation {
+			t.Fatalf("hydration composition close reason = %q ok=%t, want contract violation", reason, ok)
+		}
+	})
+	t.Run("development panics with contract diagnostic", func(t *testing.T) {
+		restore := withTranscriptContractViolationPanic(true)
+		defer restore()
+		defer func() {
+			if recover() == nil {
+				t.Fatal("malformed hydration composition did not panic")
+			}
+		}()
+		_, _ = newSessionFeedSequencer(newTranscriptSubscriptionBroker()).Subscribe(func() (clientui.TranscriptHydration, error) {
+			return registry.composeTranscriptHydration(context.Background(), "", nil, snapshot)
+		})
+	})
 }
 
 func TestTranscriptBrokerRejectsUninitializedEventWithoutSequenceOrDelivery(t *testing.T) {

--- a/server/registry/transcript_subscription_test.go
+++ b/server/registry/transcript_subscription_test.go
@@ -269,6 +269,7 @@ func TestTranscriptSubscriptionBoundaryValidatesCommittedRowIntegrity(t *testing
 		Visibility: clientui.EntryVisibilityDetail,
 		Integrity:  transcript.RowIntegrityValid,
 		Kind:       clientui.TranscriptRowUser,
+		Locator:    transcript.CommittedRowLocator{EventSequence: 1, RowOrdinal: 1},
 		User:       &clientui.TranscriptUserRow{StepID: mustRegistryStepID(t), Text: "valid"},
 	}
 	if err := validateCommittedRow(valid); err != nil {
@@ -287,6 +288,113 @@ func TestTranscriptSubscriptionBoundaryValidatesCommittedRowIntegrity(t *testing
 		if !errors.As(err, &violation) {
 			t.Fatalf("broker validation error = %T, want transcript contract violation", err)
 		}
+	}
+}
+
+func TestTranscriptSubscriptionContractValidatesLiveLocatorProgression(t *testing.T) {
+	restore := withTranscriptContractViolationPanic(false)
+	defer restore()
+
+	tests := []struct {
+		name        string
+		hydrated    []transcript.CommittedRowLocator
+		live        []transcript.CommittedRowLocator
+		wantFailure bool
+	}{
+		{
+			name: "empty hydration starts at first live event",
+			live: []transcript.CommittedRowLocator{{EventSequence: 5, RowOrdinal: 1}},
+		},
+		{
+			name:     "hydrated watermark accepts newer event",
+			hydrated: []transcript.CommittedRowLocator{{EventSequence: 10, RowOrdinal: 1}},
+			live:     []transcript.CommittedRowLocator{{EventSequence: 11, RowOrdinal: 1}},
+		},
+		{
+			name:     "same event continues contiguously",
+			hydrated: []transcript.CommittedRowLocator{{EventSequence: 10, RowOrdinal: 1}},
+			live: []transcript.CommittedRowLocator{
+				{EventSequence: 11, RowOrdinal: 1},
+				{EventSequence: 11, RowOrdinal: 2},
+				{EventSequence: 12, RowOrdinal: 1},
+			},
+		},
+		{
+			name:        "duplicate ordinal fails",
+			hydrated:    []transcript.CommittedRowLocator{{EventSequence: 10, RowOrdinal: 1}},
+			live:        []transcript.CommittedRowLocator{{EventSequence: 11, RowOrdinal: 1}, {EventSequence: 11, RowOrdinal: 1}},
+			wantFailure: true,
+		},
+		{
+			name:        "regressed event fails",
+			hydrated:    []transcript.CommittedRowLocator{{EventSequence: 10, RowOrdinal: 1}},
+			live:        []transcript.CommittedRowLocator{{EventSequence: 11, RowOrdinal: 1}, {EventSequence: 10, RowOrdinal: 1}},
+			wantFailure: true,
+		},
+		{
+			name:        "skipped ordinal fails",
+			hydrated:    []transcript.CommittedRowLocator{{EventSequence: 10, RowOrdinal: 1}},
+			live:        []transcript.CommittedRowLocator{{EventSequence: 11, RowOrdinal: 1}, {EventSequence: 11, RowOrdinal: 3}},
+			wantFailure: true,
+		},
+		{
+			name:        "first live row must be newer than hydration",
+			hydrated:    []transcript.CommittedRowLocator{{EventSequence: 10, RowOrdinal: 1}},
+			live:        []transcript.CommittedRowLocator{{EventSequence: 10, RowOrdinal: 1}},
+			wantFailure: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			hydration := transcriptBrokerHydrationWithLocators(t, test.hydrated)
+			broker := newTranscriptSubscriptionBroker()
+			sub, err := broker.Subscribe(hydration)
+			if err != nil {
+				t.Fatalf("subscribe with test broker: %v", err)
+			}
+			defer func() { _ = sub.Close() }()
+			_ = nextTranscriptMessage(t, sub)
+			for _, locator := range test.live {
+				broker.Publish([]clientui.TranscriptEvent{clientui.NewTranscriptEvent(transcriptBrokerCommittedRow(t, locator))})
+			}
+			if !test.wantFailure {
+				for range test.live {
+					if _, err := nextTranscriptMessageTimeout(sub, time.Second); err != nil {
+						t.Fatalf("valid live locator was rejected: %v", err)
+					}
+				}
+				return
+			}
+			for range test.live[:len(test.live)-1] {
+				if _, err := nextTranscriptMessageTimeout(sub, time.Second); err != nil {
+					t.Fatalf("valid prefix before invalid locator was rejected: %v", err)
+				}
+			}
+			if _, err := sub.Next(context.Background()); err == nil {
+				t.Fatal("invalid live locator progression was delivered")
+			}
+		})
+	}
+}
+
+func transcriptBrokerHydrationWithLocators(t *testing.T, locators []transcript.CommittedRowLocator) clientui.TranscriptEvent {
+	t.Helper()
+	hydration := transcriptBrokerHydration(t).Payload().(clientui.TranscriptHydration)
+	for _, locator := range locators {
+		hydration.CommittedRows = append(hydration.CommittedRows, transcriptBrokerCommittedRow(t, locator))
+	}
+	return clientui.NewTranscriptEvent(hydration)
+}
+
+func transcriptBrokerCommittedRow(t *testing.T, locator transcript.CommittedRowLocator) clientui.TranscriptCommittedRow {
+	t.Helper()
+	return clientui.TranscriptCommittedRow{
+		Visibility: transcript.EntryVisibilityOngoing,
+		Integrity:  transcript.RowIntegrityValid,
+		Kind:       clientui.TranscriptRowUser,
+		Locator:    locator,
+		User:       &clientui.TranscriptUserRow{StepID: mustRegistryStepID(t), Text: "row"},
 	}
 }
 

--- a/server/runtime/background_test.go
+++ b/server/runtime/background_test.go
@@ -238,7 +238,7 @@ func TestBackgroundNoticeOwnershipFollowsWriteStdinCompletionCommitReceipt(t *te
 			}
 
 			presentation := transcript.NormalizeToolCallMeta(transcript.ToolCallMeta{ToolName: string(toolspec.ToolWriteStdin)})
-			receipt, err := engine.persistToolCompletionRaw("step", tools.Result{
+			receipt, _, err := engine.persistToolCompletionRaw("step", tools.Result{
 				CallID:       "write-stdin-call",
 				Name:         toolspec.ToolWriteStdin,
 				Output:       json.RawMessage(`{"background_session_id":42,"background_running":false,"backgrounded":true}`),

--- a/server/runtime/chat_store.go
+++ b/server/runtime/chat_store.go
@@ -37,6 +37,7 @@ type ChatEntry struct {
 	BackgroundProcessID  string
 	BackgroundExitCode   *int
 	ToolCall             *transcript.ToolCallMeta
+	CommittedProvenance  *TranscriptCommittedRowProvenance
 }
 
 type ChatSnapshot struct {
@@ -77,6 +78,7 @@ type chatStore struct {
 	local          []localChatEntry
 
 	toolCompletions                   map[string]tools.Result
+	toolCompletionProvenance          map[string]*TranscriptCommittedRowProvenance
 	toolCompletionProviderItems       map[string][]llm.ResponseItem
 	assistantToolCalls                map[string]struct{}
 	assistantToolCallStepIDs          map[string]string
@@ -98,6 +100,7 @@ type chatMessageRecord struct {
 	StepID        string
 	Message       llm.Message
 	ProviderItems []llm.ResponseItem
+	Provenance    *TranscriptCommittedRowProvenance
 }
 
 type localChatEntry struct {
@@ -106,6 +109,7 @@ type localChatEntry struct {
 	AfterToolCallID   *string
 	MarksBoundary     bool
 	Projected         bool
+	Provenance        *TranscriptCommittedRowProvenance
 }
 
 type assistantStreamingState struct {
@@ -127,6 +131,7 @@ func newChatStore() *chatStore {
 func newChatStoreWithCWD(cwd string) *chatStore {
 	return &chatStore{
 		toolCompletions:             make(map[string]tools.Result, 16),
+		toolCompletionProvenance:    make(map[string]*TranscriptCommittedRowProvenance, 16),
 		toolCompletionProviderItems: make(map[string][]llm.ResponseItem, 16),
 		assistantToolCalls:          make(map[string]struct{}, 16),
 		assistantToolCallStepIDs:    make(map[string]string, 16),
@@ -144,7 +149,11 @@ func (s *chatStore) validateMessage(stepID string, msg llm.Message) error {
 	return s.validateMessageLocked(stepID, msg)
 }
 
-func (s *chatStore) appendMessage(stepID string, msg llm.Message) error {
+func (s *chatStore) appendMessage(stepID string, msg llm.Message, provenances ...*TranscriptCommittedRowProvenance) error {
+	var provenance *TranscriptCommittedRowProvenance
+	if len(provenances) > 0 {
+		provenance = provenances[0]
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	msg = normalizeMessageForTranscript(msg, s.cwd)
@@ -155,6 +164,7 @@ func (s *chatStore) appendMessage(stepID string, msg llm.Message) error {
 		StepID:        strings.TrimSpace(stepID),
 		Message:       cloneChatStoreMessage(msg),
 		ProviderItems: llm.ItemsFromMessages([]llm.Message{msg}),
+		Provenance:    cloneTranscriptCommittedRowProvenance(provenance),
 	})
 	s.applyMessageStatsLocked(stepID, msg)
 	s.placeAttachedLocalEntriesAfterMaterializedToolLocked(msg)
@@ -215,6 +225,7 @@ func (s *chatStore) pruneAssistantStreamIDsBeforeLocked(activeSegmentEntryStart 
 
 func (s *chatStore) pruneToolCompletionsToWorkingSetLocked() {
 	if len(s.toolCompletions) == 0 &&
+		len(s.toolCompletionProvenance) == 0 &&
 		len(s.toolCompletionProviderItems) == 0 &&
 		len(s.assistantToolCalls) == 0 &&
 		len(s.assistantToolCallStepIDs) == 0 &&
@@ -232,6 +243,7 @@ func (s *chatStore) pruneToolCompletionsToWorkingSetLocked() {
 		}
 	}
 	pruneCallIDMapToReferenced(s.toolCompletions, referenced)
+	pruneCallIDMapToReferenced(s.toolCompletionProvenance, referenced)
 	pruneCallIDMapToReferenced(s.toolCompletionProviderItems, referenced)
 	pruneCallIDMapToReferenced(s.assistantToolCalls, referenced)
 	pruneCallIDMapToReferenced(s.assistantToolCallStepIDs, referenced)
@@ -311,7 +323,7 @@ func toolCallSnapshotFromItems(items []llm.ResponseItem, callID string) (llm.Too
 	return llm.ToolCall{}, false
 }
 
-func (s *chatStore) restoreToolCompletionRecord(record session.ToolCompletionRecord) error {
+func (s *chatStore) restoreToolCompletionRecord(record session.ToolCompletionRecord, provenances ...*TranscriptCommittedRowProvenance) error {
 	completion, err := storedToolCompletionFromSessionRecord(record)
 	if err != nil {
 		return fmt.Errorf("restore session tool completion record: %w", err)
@@ -324,11 +336,11 @@ func (s *chatStore) restoreToolCompletionRecord(record session.ToolCompletionRec
 		Summary:       completion.Summary,
 		CondensedText: completion.CondensedText,
 		Presentation:  completion.Presentation,
-	}, completion.ProviderItems)
+	}, completion.ProviderItems, provenances...)
 	return nil
 }
 
-func (s *chatStore) recordToolCompletionWithProviderItems(res tools.Result, providerItems []llm.ResponseItem) {
+func (s *chatStore) recordToolCompletionWithProviderItems(res tools.Result, providerItems []llm.ResponseItem, provenances ...*TranscriptCommittedRowProvenance) {
 	callID := strings.TrimSpace(res.CallID)
 	if callID == "" {
 		return
@@ -336,6 +348,9 @@ func (s *chatStore) recordToolCompletionWithProviderItems(res tools.Result, prov
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.toolCompletions[callID] = res
+	if len(provenances) > 0 {
+		s.toolCompletionProvenance[callID] = cloneTranscriptCommittedRowProvenance(provenances[0])
+	}
 	if len(providerItems) > 0 {
 		s.toolCompletionProviderItems[callID] = llm.CloneResponseItems(providerItems)
 	} else {
@@ -476,7 +491,7 @@ func cloneTranscriptStreamID(streamID *uuid.UUID) *uuid.UUID {
 	return &copied
 }
 
-func (s *chatStore) appendLocalEntryRecord(entry ChatEntry, afterToolCallID *string) {
+func (s *chatStore) appendLocalEntryRecord(entry ChatEntry, afterToolCallID *string, provenances ...*TranscriptCommittedRowProvenance) {
 	if strings.TrimSpace(entry.Text) == "" {
 		return
 	}
@@ -496,6 +511,12 @@ func (s *chatStore) appendLocalEntryRecord(entry ChatEntry, afterToolCallID *str
 		Entry:             entry,
 		AfterMessageCount: len(s.messageRecords),
 		AfterToolCallID:   afterToolCallID,
+		Provenance: func() *TranscriptCommittedRowProvenance {
+			if len(provenances) == 0 {
+				return cloneTranscriptCommittedRowProvenance(entry.CommittedProvenance)
+			}
+			return cloneTranscriptCommittedRowProvenance(provenances[0])
+		}(),
 	})
 	s.transcriptEntryCount++
 }
@@ -538,6 +559,7 @@ func (s *chatStore) appendProjectedEntryLocked(entry ChatEntry, marksBoundary bo
 		AfterMessageCount: 0,
 		MarksBoundary:     marksBoundary,
 		Projected:         true,
+		Provenance:        cloneTranscriptCommittedRowProvenance(entry.CommittedProvenance),
 	})
 	s.transcriptEntryCount++
 }
@@ -852,18 +874,19 @@ type transcriptDeliverySnapshot struct {
 }
 
 type transcriptDeliveryFactScan struct {
-	rows                  []TranscriptCommittedRowFact
-	toolCompletions       map[string]tools.Result
-	materializedToolCalls map[string]struct{}
-	streamIDsByEntry      map[int]uuid.UUID
-	currentEntryIndex     int
+	rows                     []TranscriptCommittedRowFact
+	toolCompletions          map[string]tools.Result
+	toolCompletionProvenance map[string]*TranscriptCommittedRowProvenance
+	materializedToolCalls    map[string]struct{}
+	streamIDsByEntry         map[int]uuid.UUID
+	currentEntryIndex        int
 }
 
-func newTranscriptDeliveryFactScan(completions map[string]tools.Result, materializedToolCalls map[string]struct{}, streamIDsByEntry map[int]uuid.UUID, currentEntryIndex int) *transcriptDeliveryFactScan {
-	return &transcriptDeliveryFactScan{toolCompletions: completions, materializedToolCalls: materializedToolCalls, streamIDsByEntry: streamIDsByEntry, currentEntryIndex: currentEntryIndex}
+func newTranscriptDeliveryFactScan(completions map[string]tools.Result, completionProvenance map[string]*TranscriptCommittedRowProvenance, materializedToolCalls map[string]struct{}, streamIDsByEntry map[int]uuid.UUID, currentEntryIndex int) *transcriptDeliveryFactScan {
+	return &transcriptDeliveryFactScan{toolCompletions: completions, toolCompletionProvenance: completionProvenance, materializedToolCalls: materializedToolCalls, streamIDsByEntry: streamIDsByEntry, currentEntryIndex: currentEntryIndex}
 }
 
-func (s *transcriptDeliveryFactScan) ApplyMessage(stepID string, msg llm.Message) {
+func (s *transcriptDeliveryFactScan) ApplyMessage(stepID string, msg llm.Message, provenance *TranscriptCommittedRowProvenance) {
 	if s == nil {
 		return
 	}
@@ -873,7 +896,16 @@ func (s *transcriptDeliveryFactScan) ApplyMessage(stepID string, msg llm.Message
 	}
 	facts := transcriptCommittedRowFactsForStep(
 		stepID,
-		transcriptCommittedRowFactsFromMessage(msg, streamID, s.toolCompletions, s.materializedToolCalls),
+		transcriptCommittedRowFactsFromMessage(
+			msg,
+			streamID,
+			s.toolCompletions,
+			s.materializedToolCalls,
+			transcriptMessageProjectionContext{
+				Provenance:           provenance,
+				CompletionProvenance: s.toolCompletionProvenance,
+			},
+		),
 	)
 	s.rows = append(s.rows, facts...)
 	s.currentEntryIndex += transcriptCommittedEntryCountFromMessage(msg, s.toolCompletions, s.materializedToolCalls)
@@ -908,11 +940,11 @@ func (s *transcriptDeliveryFactScan) Snapshot() []TranscriptCommittedRowFact {
 	}
 	out := make([]TranscriptCommittedRowFact, len(s.rows))
 	copy(out, s.rows)
-	return out
+	return locateTranscriptCommittedRowFacts(out)
 }
 
 func (s *chatStore) walkProjectionLocked(
-	applyMessage func(stepID string, msg llm.Message),
+	applyMessage func(chatMessageRecord),
 	applyLocalEntry func(localChatEntry),
 	markCompactionBoundary func(),
 ) {
@@ -933,7 +965,7 @@ func (s *chatStore) walkProjectionLocked(
 	}
 	appendLocalEntries(0)
 	for _, record := range s.messageRecords {
-		applyMessage(record.StepID, record.Message)
+		applyMessage(record)
 		messageIndex++
 		appendLocalEntries(messageIndex)
 	}
@@ -949,11 +981,15 @@ func (s *chatStore) deliverySnapshot() transcriptDeliverySnapshot {
 	for entryIndex, streamID := range s.assistantStreamIDsByEntry {
 		streamIDsByEntry[entryIndex] = streamID
 	}
-	scan := newTranscriptDeliveryFactScan(s.toolCompletions, materializedToolResults, streamIDsByEntry, s.activeSegmentEntryStart)
+	scan := newTranscriptDeliveryFactScan(s.toolCompletions, s.toolCompletionProvenance, materializedToolResults, streamIDsByEntry, s.activeSegmentEntryStart)
 	s.walkProjectionLocked(
-		scan.ApplyMessage,
+		func(record chatMessageRecord) {
+			scan.ApplyMessage(record.StepID, record.Message, record.Provenance)
+		},
 		func(local localChatEntry) {
-			scan.ApplyLocalEntry(local.Entry, local.Projected)
+			entry := local.Entry
+			entry.CommittedProvenance = cloneTranscriptCommittedRowProvenance(local.Provenance)
+			scan.ApplyLocalEntry(entry, local.Projected)
 		},
 		scan.MarkCompactionBoundary,
 	)

--- a/server/runtime/engine.go
+++ b/server/runtime/engine.go
@@ -681,11 +681,7 @@ func (e *Engine) submitUserMessage(ctx context.Context, text string, onActive fu
 			return err
 		}
 		userMessage := llm.Message{Role: llm.RoleUser, Content: textutil.Value(text)}
-		intents := []steeringIntent{steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventNone, true, []llm.Message{userMessage})}
-		if flushed := flushedUserMessageEvent(userMessage, stepID); flushed != nil {
-			intents = append(intents, steerEventIntent(*flushed))
-		}
-		if err := e.steer(stepID, intents...); err != nil {
+		if err := e.steer(stepID, steerUserMessageWithFlushIntent(userMessage)); err != nil {
 			return err
 		}
 		if onFlushed != nil {

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -78,30 +78,36 @@ func (e *Engine) persistFinalizedToolCompletionRaw(
 		[]session.EventRecordPayload{completionRecord, feedbackRecord},
 	)
 	var completionProvenance *TranscriptCommittedRowProvenance
-	if receipt.Committed {
-		value, provenanceErr := transcriptProvenanceFromRecord(records[0])
-		if provenanceErr != nil {
-			return receipt, nil, nil, errors.Join(err, provenanceErr)
-		}
-		feedbackProvenance, provenanceErr := transcriptProvenanceFromRecord(records[1])
-		if provenanceErr != nil {
-			return receipt, nil, nil, errors.Join(err, provenanceErr)
-		}
-		e.applyCommittedStoredToolCompletion(
-			payload,
-			backgroundSessionID,
-			hasBackgroundSession,
-			&value,
-		)
-		completionProvenance = &value
-		e.transcriptRuntimeState().AppendLocalEntryRecord(
-			*localEntryChatEntryForStep(feedback, stepID),
-			feedback.AfterToolCallID,
-			&feedbackProvenance,
-		)
-		return receipt, &value, &feedbackProvenance, err
+	if !receipt.Committed {
+		return receipt, nil, nil, err
 	}
-	return receipt, completionProvenance, nil, err
+	if len(records) < 2 {
+		return receipt, nil, nil, errors.Join(
+			err,
+			fmt.Errorf("persist finalized tool completion committed %d records, want at least 2", len(records)),
+		)
+	}
+	value, provenanceErr := transcriptProvenanceFromRecord(records[0])
+	if provenanceErr != nil {
+		return receipt, nil, nil, errors.Join(err, provenanceErr)
+	}
+	feedbackProvenance, provenanceErr := transcriptProvenanceFromRecord(records[1])
+	if provenanceErr != nil {
+		return receipt, nil, nil, errors.Join(err, provenanceErr)
+	}
+	e.applyCommittedStoredToolCompletion(
+		payload,
+		backgroundSessionID,
+		hasBackgroundSession,
+		&value,
+	)
+	completionProvenance = &value
+	e.transcriptRuntimeState().AppendLocalEntryRecord(
+		*localEntryChatEntryForStep(feedback, stepID),
+		feedback.AfterToolCallID,
+		&feedbackProvenance,
+	)
+	return receipt, completionProvenance, &feedbackProvenance, err
 }
 
 func (e *Engine) prepareStoredToolCompletion(

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -362,7 +362,9 @@ func (e *Engine) appendMessageRaw(
 		*provenanceDestination = cloneTranscriptCommittedRowProvenance(provenance)
 	}
 	currentCommittedCount := e.CommittedTranscriptEntryCount()
-	if eventPolicy != steeringMessageEventNone && currentCommittedCount > previousCommittedCount && shouldEmitCommittedMessageEvent(msg) {
+	if eventPolicy != steeringMessageEventNone &&
+		currentCommittedCount > previousCommittedCount &&
+		e.shouldEmitCommittedMessageEvent(msg) {
 		e.emitRaw(Event{
 			Kind:                       EventConversationUpdated,
 			StepID:                     stepID,
@@ -423,6 +425,21 @@ func (e *Engine) emitLiveToolAbortsRaw(stepID string, reason string) error {
 
 func shouldEmitCommittedMessageEvent(msg llm.Message) bool {
 	return len(VisibleChatEntriesFromMessage(msg)) > 0
+}
+
+func (e *Engine) shouldEmitCommittedMessageEvent(msg llm.Message) bool {
+	if !shouldEmitCommittedMessageEvent(msg) {
+		return false
+	}
+	if msg.Role != llm.RoleTool {
+		return true
+	}
+	callID, present := textutil.OptionalTrimmed(msg.ToolCallID)
+	if !present {
+		return true
+	}
+	_, completed := e.transcriptRuntimeState().ToolCompletionSnapshot(callID)
+	return !completed
 }
 
 func (e *Engine) appendQueuedUserMessageFlush(stepID string, text string, batch []string, queueItems []QueuedUserMessage) (session.CommitReceipt, error) {

--- a/server/runtime/engine_message_ops.go
+++ b/server/runtime/engine_message_ops.go
@@ -21,29 +21,37 @@ import (
 	"github.com/google/uuid"
 )
 
-func (e *Engine) persistToolCompletionRaw(stepID string, r tools.Result) (session.CommitReceipt, error) {
+func (e *Engine) persistToolCompletionRaw(stepID string, r tools.Result) (session.CommitReceipt, *TranscriptCommittedRowProvenance, error) {
 	payload, backgroundSessionID, hasBackgroundSession := e.prepareStoredToolCompletion(r)
 	record, adaptErr := sessionToolCompletionRecordFromStored(payload)
 	if adaptErr != nil {
-		return session.CommitReceipt{}, fmt.Errorf("adapt tool completion record: %w", adaptErr)
+		return session.CommitReceipt{}, nil, fmt.Errorf("adapt tool completion record: %w", adaptErr)
 	}
-	_, receipt, err := e.eventLog.AppendRecord(textutil.OptionalExactString(stepID), record)
+	appended, receipt, err := e.eventLog.AppendRecord(textutil.OptionalExactString(stepID), record)
+	var provenance *TranscriptCommittedRowProvenance
 	if receipt.Committed {
+		value, provenanceErr := transcriptProvenanceFromRecord(appended)
+		if provenanceErr != nil {
+			return receipt, nil, errors.Join(err, provenanceErr)
+		}
 		e.applyCommittedStoredToolCompletion(
 			payload,
 			backgroundSessionID,
 			hasBackgroundSession,
+			&value,
 		)
+		provenance = &value
 	}
-	return receipt, err
+	return receipt, provenance, err
 }
 
 func (e *Engine) persistFinalizedToolCompletionRaw(
 	stepID string,
 	completion finalizedToolCompletion,
-) (session.CommitReceipt, error) {
+) (session.CommitReceipt, *TranscriptCommittedRowProvenance, *TranscriptCommittedRowProvenance, error) {
 	if completion.OperatorFeedback == nil {
-		return e.persistToolCompletionRaw(stepID, completion.Result)
+		receipt, provenance, err := e.persistToolCompletionRaw(stepID, completion.Result)
+		return receipt, provenance, nil, err
 	}
 	payload, backgroundSessionID, hasBackgroundSession := e.prepareStoredToolCompletion(
 		completion.Result,
@@ -59,28 +67,41 @@ func (e *Engine) persistFinalizedToolCompletionRaw(
 	}
 	completionRecord, adaptErr := sessionToolCompletionRecordFromStored(payload)
 	if adaptErr != nil {
-		return session.CommitReceipt{}, fmt.Errorf("adapt tool completion record: %w", adaptErr)
+		return session.CommitReceipt{}, nil, nil, fmt.Errorf("adapt tool completion record: %w", adaptErr)
 	}
 	feedbackRecord, adaptErr := sessionLocalEntryRecordFromRuntime(feedback)
 	if adaptErr != nil {
-		return session.CommitReceipt{}, fmt.Errorf("adapt operator feedback record: %w", adaptErr)
+		return session.CommitReceipt{}, nil, nil, fmt.Errorf("adapt operator feedback record: %w", adaptErr)
 	}
-	_, receipt, err := e.eventLog.AppendRecordsAtomic(
+	records, receipt, err := e.eventLog.AppendRecordsAtomic(
 		textutil.OptionalExactString(stepID),
 		[]session.EventRecordPayload{completionRecord, feedbackRecord},
 	)
+	var completionProvenance *TranscriptCommittedRowProvenance
 	if receipt.Committed {
+		value, provenanceErr := transcriptProvenanceFromRecord(records[0])
+		if provenanceErr != nil {
+			return receipt, nil, nil, errors.Join(err, provenanceErr)
+		}
+		feedbackProvenance, provenanceErr := transcriptProvenanceFromRecord(records[1])
+		if provenanceErr != nil {
+			return receipt, nil, nil, errors.Join(err, provenanceErr)
+		}
 		e.applyCommittedStoredToolCompletion(
 			payload,
 			backgroundSessionID,
 			hasBackgroundSession,
+			&value,
 		)
+		completionProvenance = &value
 		e.transcriptRuntimeState().AppendLocalEntryRecord(
 			*localEntryChatEntryForStep(feedback, stepID),
 			feedback.AfterToolCallID,
+			&feedbackProvenance,
 		)
+		return receipt, &value, &feedbackProvenance, err
 	}
-	return receipt, err
+	return receipt, completionProvenance, nil, err
 }
 
 func (e *Engine) prepareStoredToolCompletion(
@@ -118,9 +139,10 @@ func (e *Engine) applyCommittedStoredToolCompletion(
 	payload storedToolCompletion,
 	backgroundSessionID string,
 	hasBackgroundSession bool,
+	provenance *TranscriptCommittedRowProvenance,
 ) {
 	e.markCurrentRequestShapeDirtyForSignificantMutation()
-	e.transcriptRuntimeState().RecordStoredToolCompletion(payload)
+	e.transcriptRuntimeState().RecordStoredToolCompletion(payload, provenance)
 	if hasBackgroundSession {
 		e.ensureOrchestrationCollaborators()
 		e.backgroundFlow.ConsumePendingBackgroundNotice(backgroundSessionID)
@@ -190,27 +212,34 @@ func (e *Engine) steerPersistedDiagnosticEntry(stepID, diagnosticKey, role, text
 	return nil
 }
 
-func (e *Engine) appendPersistedLocalEntryRecordRaw(stepID string, entry storedLocalEntry) (session.CommitReceipt, error) {
+func (e *Engine) appendPersistedLocalEntryRecordRaw(stepID string, entry storedLocalEntry) (session.CommitReceipt, *TranscriptCommittedRowProvenance, error) {
 	entry, err := normalizeStoredLocalEntry(entry)
 	if err != nil {
-		return session.CommitReceipt{}, fmt.Errorf("normalize local entry: %w", err)
+		return session.CommitReceipt{}, nil, fmt.Errorf("normalize local entry: %w", err)
 	}
 	record, adaptErr := sessionLocalEntryRecordFromRuntime(entry)
 	if adaptErr != nil {
-		return session.CommitReceipt{}, fmt.Errorf("adapt local entry record: %w", adaptErr)
+		return session.CommitReceipt{}, nil, fmt.Errorf("adapt local entry record: %w", adaptErr)
 	}
-	_, receipt, err := e.eventLog.AppendRecord(textutil.OptionalExactString(stepID), record)
+	appended, receipt, err := e.eventLog.AppendRecord(textutil.OptionalExactString(stepID), record)
+	var provenance *TranscriptCommittedRowProvenance
 	if receipt.Committed {
+		value, provenanceErr := transcriptProvenanceFromRecord(appended)
+		if provenanceErr != nil {
+			return receipt, nil, errors.Join(err, provenanceErr)
+		}
+		provenance = &value
 		projected := localEntryChatEntryForStep(entry, stepID)
-		e.transcriptRuntimeState().AppendLocalEntryRecord(*projected, entry.AfterToolCallID)
+		e.transcriptRuntimeState().AppendLocalEntryRecord(*projected, entry.AfterToolCallID, provenance)
 		e.emitRaw(Event{
 			Kind:                       EventLocalEntryAdded,
 			StepID:                     stepID,
 			LocalEntry:                 projected,
 			CommittedTranscriptChanged: true,
+			CommittedProvenance:        provenance,
 		})
 	}
-	return receipt, err
+	return receipt, provenance, err
 }
 
 func normalizeStoredLocalEntry(entry storedLocalEntry) (storedLocalEntry, error) {
@@ -280,7 +309,13 @@ func (e *Engine) diagnosticDedupeStore() *diagnosticDedupeStore {
 	return e.diagnostics
 }
 
-func (e *Engine) appendMessageRaw(stepID string, msg llm.Message, eventPolicy steeringMessageEventPolicy, persist bool) (session.CommitReceipt, error) {
+func (e *Engine) appendMessageRaw(
+	stepID string,
+	msg llm.Message,
+	eventPolicy steeringMessageEventPolicy,
+	persist bool,
+	provenanceDestination **TranscriptCommittedRowProvenance,
+) (session.CommitReceipt, error) {
 	msg = normalizeMessageForTranscript(msg, e.transcriptWorkingDir())
 	var err error
 	msg, err = normalizePersistedMessageWorktreeContext(msg)
@@ -295,6 +330,7 @@ func (e *Engine) appendMessageRaw(stepID string, msg llm.Message, eventPolicy st
 	previousCommittedCount := e.CommittedTranscriptEntryCount()
 	receipt := session.CommitReceipt{}
 	var appendErr error
+	var provenance *TranscriptCommittedRowProvenance
 	if persist {
 		appended, err := e.appendPersistedMessageEvent(stepID, msg)
 		receipt = appended.CommitReceipt
@@ -302,14 +338,22 @@ func (e *Engine) appendMessageRaw(stepID string, msg llm.Message, eventPolicy st
 		if !receipt.Committed {
 			return receipt, appendErr
 		}
+		value, provenanceErr := transcriptProvenanceFromRecord(appended.Record)
+		if provenanceErr != nil {
+			return receipt, errors.Join(appendErr, provenanceErr)
+		}
+		provenance = &value
 	}
 	if mutation := tokenUsageMutationForMessage(msg); mutation == tokenUsageMutationSignificant {
 		e.markCurrentRequestShapeDirtyForSignificantMutation()
 	} else {
 		e.markCurrentRequestShapeDirty()
 	}
-	if projectionErr := e.transcriptRuntimeState().AppendMessage(stepID, msg); projectionErr != nil {
+	if projectionErr := e.transcriptRuntimeState().AppendMessage(stepID, msg, provenance); projectionErr != nil {
 		return receipt, errors.Join(appendErr, fmt.Errorf("append message projection: %w", projectionErr))
+	}
+	if provenanceDestination != nil {
+		*provenanceDestination = cloneTranscriptCommittedRowProvenance(provenance)
 	}
 	currentCommittedCount := e.CommittedTranscriptEntryCount()
 	if eventPolicy != steeringMessageEventNone && currentCommittedCount > previousCommittedCount && shouldEmitCommittedMessageEvent(msg) {
@@ -318,6 +362,7 @@ func (e *Engine) appendMessageRaw(stepID string, msg llm.Message, eventPolicy st
 			StepID:                     stepID,
 			CommittedTranscriptChanged: true,
 			Message:                    msg,
+			CommittedProvenance:        cloneTranscriptCommittedRowProvenance(provenance),
 		})
 	}
 	return receipt, appendErr
@@ -390,7 +435,11 @@ func (e *Engine) appendQueuedUserMessageFlush(stepID string, text string, batch 
 	} else {
 		e.markCurrentRequestShapeDirty()
 	}
-	if projectionErr := e.transcriptRuntimeState().AppendMessage(stepID, msg); projectionErr != nil {
+	provenance, provenanceErr := transcriptProvenanceFromRecord(appended.Record)
+	if provenanceErr != nil {
+		return appended.CommitReceipt, errors.Join(appendErr, provenanceErr)
+	}
+	if projectionErr := e.transcriptRuntimeState().AppendMessage(stepID, msg, &provenance); projectionErr != nil {
 		return appended.CommitReceipt, errors.Join(appendErr, fmt.Errorf("append queued message projection: %w", projectionErr))
 	}
 	e.emitRaw(Event{
@@ -401,6 +450,7 @@ func (e *Engine) appendQueuedUserMessageFlush(stepID string, text string, batch 
 		UserMessageBatchQueueItemIDs: normalizedIDs,
 		UserMessageBatchQueuedItems:  queuedUserMessageIdentities(normalizedItems),
 		CommittedTranscriptChanged:   true,
+		CommittedProvenance:          &provenance,
 	})
 	for _, item := range normalizedItems {
 		e.unmarkQueuedUserInjectionForAutoDrain(item.ID)
@@ -560,6 +610,7 @@ func (e *Engine) emitCommittedAssistantMessageEventRaw(stepID string, committed 
 		Kind:                        EventAssistantMessage,
 		StepID:                      stepID,
 		Message:                     committed.message,
+		CommittedProvenance:         cloneTranscriptCommittedRowProvenance(committed.provenance),
 		AssistantStreamMetadata:     cloneAssistantStreamMetadata(streamMetadata),
 		AssistantTranscriptStreamID: cloneTranscriptStreamID(streamID),
 		CommittedTranscriptChanged:  true,
@@ -603,6 +654,7 @@ func (e *Engine) resolveCompletedResponseStreamRaw(stepID string, instruction co
 		if err := e.emitCommittedAssistantMessageEventRaw(stepID, steeringCommittedAssistantMessage{
 			message:    committed.message,
 			coordinate: cloneCommittedAssistantCoordinate(committed.coordinate),
+			provenance: cloneTranscriptCommittedRowProvenance(committed.provenance),
 		}, clearedMetadata, clearedStreamID); err != nil {
 			return completedResponseResolutionOutcome{}, err
 		}
@@ -634,7 +686,7 @@ func (e *Engine) resolveCompletedResponseStreamRaw(stepID string, instruction co
 	}, nil
 }
 
-func flushedUserMessageEvent(msg llm.Message, stepID string) *Event {
+func flushedUserMessageEvent(provenance *TranscriptCommittedRowProvenance, msg llm.Message, stepID string) *Event {
 	if msg.Role != llm.RoleUser {
 		return nil
 	}
@@ -645,7 +697,7 @@ func flushedUserMessageEvent(msg llm.Message, stepID string) *Event {
 	if msg.Content == nil || strings.TrimSpace(*msg.Content) == "" {
 		return nil
 	}
-	return &Event{Kind: EventUserMessageFlushed, StepID: stepID, UserMessage: *msg.Content, UserMessageBatch: []string{*msg.Content}, CommittedTranscriptChanged: true}
+	return &Event{Kind: EventUserMessageFlushed, StepID: stepID, UserMessage: *msg.Content, UserMessageBatch: []string{*msg.Content}, CommittedTranscriptChanged: true, CommittedProvenance: cloneTranscriptCommittedRowProvenance(provenance)}
 }
 
 func (e *Engine) flushPendingUserInjections(stepID string, selection userInjectionSelection) (userInjectionCommitResult, error) {

--- a/server/runtime/events.go
+++ b/server/runtime/events.go
@@ -103,6 +103,7 @@ type Event struct {
 	CommittedEntryCount          int
 	CommittedEntryStart          int
 	CommittedEntryStartSet       bool
+	CommittedProvenance          *TranscriptCommittedRowProvenance
 	Error                        string
 	AssistantDelta               string
 	AssistantDeltaPhase          llm.MessagePhase

--- a/server/runtime/history_replacement.go
+++ b/server/runtime/history_replacement.go
@@ -94,3 +94,22 @@ func syntheticCompactionSummaryEntry(compactionNumber *int) ChatEntry {
 		CompactionNumber: textutil.Pointer(compactionNumber),
 	}
 }
+
+func assignHistoryReplacementEntryProvenance(
+	entries []ChatEntry,
+	base *TranscriptCommittedRowProvenance,
+) []ChatEntry {
+	var ordinal int64
+	for index := range entries {
+		entries[index].CommittedProvenance = cloneTranscriptCommittedRowProvenance(base)
+		if _, projected := transcriptCommittedRowFactFromChatEntry(entries[index]); !projected {
+			continue
+		}
+		ordinal++
+		provenance := cloneTranscriptCommittedRowProvenance(base)
+		projectedOrdinal := ordinal
+		provenance.ProjectedOrdinal = &projectedOrdinal
+		entries[index].CommittedProvenance = provenance
+	}
+	return entries
+}

--- a/server/runtime/message_lifecycle.go
+++ b/server/runtime/message_lifecycle.go
@@ -64,7 +64,11 @@ func (m *defaultMessageLifecycle) RestoreMessages() error {
 			if err := rollbackLocator.ObserveMessage(record.Seq(), msg); err != nil {
 				return err
 			}
-			if err := e.transcriptRuntimeState().AppendMessage(stepID, msg); err != nil {
+			provenance, provenanceErr := transcriptProvenanceFromRecord(record)
+			if provenanceErr != nil {
+				return fmt.Errorf("restore session message provenance: %w", provenanceErr)
+			}
+			if err := e.transcriptRuntimeState().AppendMessage(stepID, msg, &provenance); err != nil {
 				return fmt.Errorf("restore session message projection: %w", err)
 			}
 			if msg.Role == llm.RoleAssistant && len(msg.ToolCalls) > 0 {
@@ -93,7 +97,11 @@ func (m *defaultMessageLifecycle) RestoreMessages() error {
 				reminderIssued = true
 			}
 		case session.ToolCompletionRecord:
-			if err := e.transcriptRuntimeState().RestoreToolCompletionRecord(payload); err != nil {
+			provenance, provenanceErr := transcriptProvenanceFromRecord(record)
+			if provenanceErr != nil {
+				return fmt.Errorf("restore session tool completion provenance: %w", provenanceErr)
+			}
+			if err := e.transcriptRuntimeState().RestoreToolCompletionRecord(payload, &provenance); err != nil {
 				return err
 			}
 			for _, generation := range generationsByStep[stepID] {
@@ -117,9 +125,17 @@ func (m *defaultMessageLifecycle) RestoreMessages() error {
 				e.diagnosticDedupeStore().RestoreLocal(*entry.DiagnosticKey)
 			}
 			restored := *localEntryChatEntryForStep(entry, stepID)
-			e.transcriptRuntimeState().AppendLocalEntryRecord(restored, entry.AfterToolCallID)
+			provenance, provenanceErr := transcriptProvenanceFromRecord(record)
+			if provenanceErr != nil {
+				return fmt.Errorf("restore session local entry provenance: %w", provenanceErr)
+			}
+			e.transcriptRuntimeState().AppendLocalEntryRecord(restored, entry.AfterToolCallID, &provenance)
 		case session.CacheWarningRecord:
-			applyPersistedCacheWarningToTranscript(e.transcriptRuntimeState(), payload, e.cfg.CacheWarningMode)
+			provenance, provenanceErr := transcriptProvenanceFromRecord(record)
+			if provenanceErr != nil {
+				return fmt.Errorf("restore session cache warning provenance: %w", provenanceErr)
+			}
+			applyPersistedCacheWarningToTranscript(e.transcriptRuntimeState(), payload, e.cfg.CacheWarningMode, &provenance)
 		case session.CacheRequestObservationRecord:
 			// Cache requests are observational. The following response record
 			// reconstructs the cache tracker state.
@@ -134,14 +150,23 @@ func (m *defaultMessageLifecycle) RestoreMessages() error {
 			}
 			e.resetLocalDiagnostics()
 			manualEligible = false
+			provenance, provenanceErr := transcriptProvenanceFromRecord(record)
+			if provenanceErr != nil {
+				return fmt.Errorf("restore session history replacement provenance: %w", provenanceErr)
+			}
+			projectedEntries := transcriptEntriesFromHistoryReplacement(
+				replacement.Items,
+				replacement.CompactionNumber,
+			)
+			for index := range projectedEntries {
+				projectedEntries[index].StepID = stepID
+			}
+			projectedEntries = assignHistoryReplacementEntryProvenance(projectedEntries, &provenance)
 			e.transcriptRuntimeState().ReplaceHistoryAtCommittedEntryStart(
 				stepID,
 				replacement.Items,
 				replacement.CommittedEntryStart,
-				transcriptEntriesFromHistoryReplacement(
-					replacement.Items,
-					replacement.CompactionNumber,
-				),
+				projectedEntries,
 			)
 			if replacement.LastCommittedAssistantFinalAnswer != nil {
 				e.transcriptRuntimeState().SeedLastCommittedAssistantFinalAnswerIfEmpty(

--- a/server/runtime/output_steering.go
+++ b/server/runtime/output_steering.go
@@ -812,7 +812,12 @@ func (e *Engine) emitProjectedHistoryReplacementEntriesRaw(
 		copyEntry := clonePersistedChatEntry(entry)
 		provenance := cloneTranscriptCommittedRowProvenance(entry.CommittedProvenance)
 		if _, projected := transcriptCommittedRowFactFromChatEntry(copyEntry); projected && (provenance == nil || provenance.ProjectedOrdinal == nil) {
-			panic(fmt.Sprintf("history replacement projected row %d lacks filtered ordinal: entry=%+v provenance=%+v", idx, copyEntry, provenance))
+			return fmt.Errorf(
+				"history replacement projected row %d lacks filtered ordinal (step_id=%q role=%q)",
+				idx,
+				copyEntry.StepID,
+				copyEntry.Role,
+			)
 		}
 		if err := e.emitRaw(Event{
 			Kind:                       EventLocalEntryAdded,

--- a/server/runtime/output_steering.go
+++ b/server/runtime/output_steering.go
@@ -33,6 +33,7 @@ type steeringIntent struct {
 
 type steeringItem struct {
 	message                     *steeringMessage
+	assistantCommit             *steeringAssistantCommit
 	goalNoticeAndStatus         *steeringGoalNoticeAndStatus
 	committedAssistant          *steeringCommittedAssistantMessage
 	completedResponseResolution *steeringCompletedResponseResolution
@@ -50,9 +51,23 @@ type steeringItem struct {
 }
 
 type steeringMessage struct {
-	message     llm.Message
-	eventPolicy steeringMessageEventPolicy
-	persist     bool
+	message               llm.Message
+	eventPolicy           steeringMessageEventPolicy
+	persist               bool
+	provenanceDestination **TranscriptCommittedRowProvenance
+	emitUserFlushEvent    bool
+}
+
+type steeringAssistantCommit struct {
+	message           llm.Message
+	executableCallIDs map[string]struct{}
+	result            *steeringAssistantCommitResult
+}
+
+type steeringAssistantCommitResult struct {
+	provenance *TranscriptCommittedRowProvenance
+	coordinate *committedAssistantCoordinate
+	resolution completedResponseResolutionOutcome
 }
 
 type steeringGoalNoticeAndStatus struct {
@@ -67,6 +82,7 @@ type steeringLocalEntry struct {
 type steeringCommittedAssistantMessage struct {
 	message    llm.Message
 	coordinate *committedAssistantCoordinate
+	provenance *TranscriptCommittedRowProvenance
 }
 
 type committedAssistantCoordinate struct {
@@ -169,6 +185,31 @@ func steerMessagesWithPersistenceIntent(priority steeringPriority, eventPolicy s
 	return steeringIntent{priority: priority, items: items}
 }
 
+func steerAssistantCommitIntent(
+	msg llm.Message,
+	executableCallIDs map[string]struct{},
+	result *steeringAssistantCommitResult,
+) steeringIntent {
+	return steeringIntent{
+		priority: steeringPriorityNormal,
+		items: []steeringItem{{
+			assistantCommit: &steeringAssistantCommit{
+				message:           msg,
+				executableCallIDs: executableCallIDs,
+				result:            result,
+			},
+		}},
+	}
+}
+
+func steerUserMessageWithFlushIntent(msg llm.Message) steeringIntent {
+	intent := steerMessagesWithPersistenceIntent(steeringPriorityUser, steeringMessageEventNone, true, []llm.Message{msg})
+	var provenance *TranscriptCommittedRowProvenance
+	intent.items[0].message.provenanceDestination = &provenance
+	intent.items[0].message.emitUserFlushEvent = true
+	return intent
+}
+
 func steerLocalEntryIntent(entry storedLocalEntry) steeringIntent {
 	copyEntry := entry
 	return steeringIntent{
@@ -251,24 +292,33 @@ func steerLiveToolAbortIntent(reason string) steeringIntent {
 	}
 }
 
-func steerCommittedAssistantMessageIntent(msg llm.Message, coordinate *committedAssistantCoordinate) steeringIntent {
+func steerCommittedAssistantMessageIntent(msg llm.Message, coordinate *committedAssistantCoordinate, provenances ...*TranscriptCommittedRowProvenance) steeringIntent {
 	return steeringIntent{
 		priority: steeringPriorityRuntimeEvent,
 		items: []steeringItem{{committedAssistant: &steeringCommittedAssistantMessage{
 			message:    msg,
 			coordinate: cloneCommittedAssistantCoordinate(coordinate),
+			provenance: firstTranscriptCommittedRowProvenance(provenances),
 		}}},
 	}
 }
 
-func completedResponseFinalizeInstruction(msg llm.Message, coordinate *committedAssistantCoordinate) completedResponseResolutionInstruction {
+func completedResponseFinalizeInstruction(msg llm.Message, coordinate *committedAssistantCoordinate, provenances ...*TranscriptCommittedRowProvenance) completedResponseResolutionInstruction {
 	return completedResponseResolutionInstruction{
 		kind: completedResponseResolutionInstructionFinalize,
 		committedAssistant: &steeringCommittedAssistantMessage{
 			message:    msg,
 			coordinate: cloneCommittedAssistantCoordinate(coordinate),
+			provenance: firstTranscriptCommittedRowProvenance(provenances),
 		},
 	}
+}
+
+func firstTranscriptCommittedRowProvenance(values []*TranscriptCommittedRowProvenance) *TranscriptCommittedRowProvenance {
+	if len(values) == 0 {
+		return nil
+	}
+	return cloneTranscriptCommittedRowProvenance(values[0])
 }
 
 func cloneCommittedAssistantCoordinate(coordinate *committedAssistantCoordinate) *committedAssistantCoordinate {
@@ -417,9 +467,65 @@ func (e *Engine) resolveCompletedResponseStream(stepID string, instruction compl
 }
 
 func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
-	if item.message != nil {
-		receipt, err := e.appendMessageRaw(stepID, item.message.message, item.message.eventPolicy, item.message.persist)
+	if item.assistantCommit != nil {
+		commit := item.assistantCommit
+		if commit.result == nil {
+			return errors.New("assistant commit steering item requires a result destination")
+		}
+		receipt, err := e.appendMessageRaw(stepID, commit.message, steeringMessageEventNone, true, &commit.result.provenance)
 		item.recordCommitReceipt(receipt)
+		if err != nil || !receipt.Committed {
+			return err
+		}
+		if len(VisibleChatEntriesFromMessage(commit.message)) == 0 {
+			outcome, resolveErr := e.resolveCompletedResponseStreamRaw(stepID, completedResponseDiscardInstruction())
+			commit.result.resolution = outcome
+			return resolveErr
+		}
+		coordinate, toolCallStarts := committedStartsForPersistedAssistantMessage(e, commit.message, commit.executableCallIDs)
+		commit.result.coordinate = coordinate
+		e.rememberPendingToolCallStarts(toolCallStarts)
+		if committedAssistantMessageFinalizesStreaming(commit.message) {
+			if coordinate == nil {
+				return errors.New("persisted assistant text row has no committed transcript coordinate")
+			}
+			instruction := completedResponseFinalizeInstruction(commit.message, coordinate, commit.result.provenance)
+			outcome, resolveErr := e.resolveCompletedResponseStreamRaw(stepID, instruction)
+			commit.result.resolution = outcome
+			return resolveErr
+		}
+		commit.result.resolution = completedResponseResolutionOutcome{
+			kind: completedResponseResolutionAbsent,
+		}
+		if err := e.emitCommittedAssistantMessageEventRaw(stepID, steeringCommittedAssistantMessage{
+			message:    commit.message,
+			coordinate: cloneCommittedAssistantCoordinate(coordinate),
+			provenance: cloneTranscriptCommittedRowProvenance(commit.result.provenance),
+		}, nil, nil); err != nil {
+			return err
+		}
+		outcome, resolveErr := e.resolveCompletedResponseStreamRaw(stepID, completedResponseDiscardInstruction())
+		commit.result.resolution = outcome
+		return resolveErr
+	}
+	if item.message != nil {
+		receipt, err := e.appendMessageRaw(
+			stepID,
+			item.message.message,
+			item.message.eventPolicy,
+			item.message.persist,
+			item.message.provenanceDestination,
+		)
+		item.recordCommitReceipt(receipt)
+		if err == nil && receipt.Committed && item.message.emitUserFlushEvent {
+			if flushed := flushedUserMessageEvent(
+				*item.message.provenanceDestination,
+				item.message.message,
+				stepID,
+			); flushed != nil {
+				err = errors.Join(err, e.emitRaw(*flushed))
+			}
+		}
 		return err
 	}
 	if item.goalNoticeAndStatus != nil {
@@ -429,6 +535,7 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 			notice.message,
 			steeringMessageEventDefault,
 			true,
+			nil,
 		)
 		item.recordCommitReceipt(receipt)
 		if !receipt.Committed {
@@ -457,7 +564,7 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 		return nil
 	}
 	if item.localEntry != nil {
-		receipt, err := e.appendPersistedLocalEntryRecordRaw(stepID, item.localEntry.entry)
+		receipt, _, err := e.appendPersistedLocalEntryRecordRaw(stepID, item.localEntry.entry)
 		item.recordCommitReceipt(receipt)
 		return err
 	}
@@ -468,12 +575,12 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 	}
 	if item.toolCompletion != nil {
 		completion := e.finalizeLiveToolCompletion(*item.toolCompletion)
-		receipt, err := e.persistFinalizedToolCompletionRaw(stepID, completion)
+		receipt, provenance, feedbackProvenance, err := e.persistFinalizedToolCompletionRaw(stepID, completion)
 		item.recordCommitReceipt(receipt)
 		if receipt.Committed {
 			result := cloneToolResult(completion.Result)
 			e.transcriptRuntimeState().CompleteLiveTool(result.CallID)
-			err = errors.Join(err, e.emitRaw(Event{Kind: EventToolCallCompleted, StepID: stepID, ToolResult: &result, CommittedTranscriptChanged: true}))
+			err = errors.Join(err, e.emitRaw(Event{Kind: EventToolCallCompleted, StepID: stepID, ToolResult: &result, CommittedTranscriptChanged: true, CommittedProvenance: cloneTranscriptCommittedRowProvenance(provenance)}))
 			if completion.OperatorFeedback != nil {
 				entry := localEntryChatEntryForStep(*completion.OperatorFeedback, stepID)
 				err = errors.Join(err, e.emitRaw(Event{
@@ -481,6 +588,7 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 					StepID:                     stepID,
 					LocalEntry:                 entry,
 					CommittedTranscriptChanged: true,
+					CommittedProvenance:        cloneTranscriptCommittedRowProvenance(feedbackProvenance),
 				}))
 			}
 		}
@@ -529,20 +637,24 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 		if adaptErr != nil {
 			return fmt.Errorf("adapt cache warning record: %w", adaptErr)
 		}
-		_, receipt, appendErr := e.eventLog.AppendRecord(textutil.OptionalExactString(stepID), record)
+		appended, receipt, appendErr := e.eventLog.AppendRecord(textutil.OptionalExactString(stepID), record)
 		item.recordCommitReceipt(receipt)
 		if appendErr != nil && !receipt.Committed {
 			return appendErr
 		}
-		e.transcriptRuntimeState().AppendCommittedEntryWithVisibility(cacheWarningTranscriptRole, transcript.CacheWarningText(warning), visibility)
+		provenance, provenanceErr := transcriptProvenanceFromRecord(appended)
+		if provenanceErr != nil {
+			return errors.Join(appendErr, provenanceErr)
+		}
+		e.transcriptRuntimeState().AppendCommittedEntryWithVisibility(cacheWarningTranscriptRole, transcript.CacheWarningText(warning), visibility, &provenance)
 		if item.cacheWarning.emit {
-			appendErr = errors.Join(appendErr, e.emitRaw(Event{Kind: EventCacheWarning, StepID: stepID, CacheWarning: copyCacheWarning(&warning), CacheWarningVisibility: visibility, CommittedTranscriptChanged: true}))
+			appendErr = errors.Join(appendErr, e.emitRaw(Event{Kind: EventCacheWarning, StepID: stepID, CacheWarning: copyCacheWarning(&warning), CacheWarningVisibility: visibility, CommittedTranscriptChanged: true, CommittedProvenance: &provenance}))
 		}
 		return appendErr
 	}
 	if item.cacheObservation != nil {
 		observation := item.cacheObservation
-		_, receipt, appendErr := e.eventLog.AppendRecordsAtomic(textutil.OptionalExactString(stepID), observation.records)
+		records, receipt, appendErr := e.eventLog.AppendRecordsAtomic(textutil.OptionalExactString(stepID), observation.records)
 		item.recordCommitReceipt(receipt)
 		if !receipt.Committed {
 			return appendErr
@@ -551,9 +663,27 @@ func (e *Engine) applySteeringItem(stepID string, item steeringItem) error {
 		if observation.hasWarning {
 			warning := observation.warning
 			visibility := normalizeRuntimeEntryVisibility(observation.visibility)
-			e.transcriptRuntimeState().AppendCommittedEntryWithVisibility(cacheWarningTranscriptRole, transcript.CacheWarningText(warning), visibility)
+			var warningProvenance *TranscriptCommittedRowProvenance
+			for _, record := range records {
+				payload, payloadErr := record.Payload()
+				if payloadErr != nil {
+					return errors.Join(appendErr, payloadErr)
+				}
+				if _, ok := payload.(session.CacheWarningRecord); ok {
+					provenance, provenanceErr := transcriptProvenanceFromRecord(record)
+					if provenanceErr != nil {
+						return errors.Join(appendErr, provenanceErr)
+					}
+					warningProvenance = &provenance
+					break
+				}
+			}
+			if warningProvenance == nil {
+				return errors.Join(appendErr, errors.New("cache warning append did not return its warning record"))
+			}
+			e.transcriptRuntimeState().AppendCommittedEntryWithVisibility(cacheWarningTranscriptRole, transcript.CacheWarningText(warning), visibility, warningProvenance)
 			if observation.emit {
-				appendErr = errors.Join(appendErr, e.emitRaw(Event{Kind: EventCacheWarning, StepID: stepID, CacheWarning: copyCacheWarning(&warning), CacheWarningVisibility: visibility, CommittedTranscriptChanged: true}))
+				appendErr = errors.Join(appendErr, e.emitRaw(Event{Kind: EventCacheWarning, StepID: stepID, CacheWarning: copyCacheWarning(&warning), CacheWarningVisibility: visibility, CommittedTranscriptChanged: true, CommittedProvenance: warningProvenance}))
 			}
 		}
 		return appendErr
@@ -608,13 +738,24 @@ func (e *Engine) replaceHistoryRaw(stepID string, replacement steeringHistoryRep
 	if adaptErr != nil {
 		return session.CommitReceipt{}, fmt.Errorf("adapt history replacement record: %w", adaptErr)
 	}
-	_, receipt, appendErr := e.eventLog.AppendCompactionHistoryReplacement(
+	appended, receipt, appendErr := e.eventLog.AppendCompactionHistoryReplacement(
 		textutil.OptionalExactString(stepID),
 		record,
 	)
 	if appendErr != nil && !receipt.Committed {
 		return receipt, appendErr
 	}
+	provenance, provenanceErr := transcriptProvenanceFromRecord(appended)
+	if provenanceErr != nil {
+		return receipt, errors.Join(appendErr, provenanceErr)
+	}
+	for index := range replacement.projectedEntries {
+		replacement.projectedEntries[index].StepID = strings.TrimSpace(stepID)
+	}
+	replacement.projectedEntries = assignHistoryReplacementEntryProvenance(
+		replacement.projectedEntries,
+		&provenance,
+	)
 	e.lockedContractState().MarkPromptFacingSnapshotsStale()
 	// Compaction reinjects canonical generation context, including base meta,
 	// into the same replacement payload. Mirror the restore-time length signal
@@ -669,6 +810,10 @@ func (e *Engine) emitProjectedHistoryReplacementEntriesRaw(
 	}
 	for idx, entry := range entries {
 		copyEntry := clonePersistedChatEntry(entry)
+		provenance := cloneTranscriptCommittedRowProvenance(entry.CommittedProvenance)
+		if _, projected := transcriptCommittedRowFactFromChatEntry(copyEntry); projected && (provenance == nil || provenance.ProjectedOrdinal == nil) {
+			panic(fmt.Sprintf("history replacement projected row %d lacks filtered ordinal: entry=%+v provenance=%+v", idx, copyEntry, provenance))
+		}
 		if err := e.emitRaw(Event{
 			Kind:                       EventLocalEntryAdded,
 			StepID:                     stepID,
@@ -678,6 +823,7 @@ func (e *Engine) emitProjectedHistoryReplacementEntriesRaw(
 			CommittedEntryStart:        start + idx,
 			CommittedEntryStartSet:     true,
 			CommittedEntryCount:        start + idx + 1,
+			CommittedProvenance:        provenance,
 		}); err != nil {
 			return err
 		}

--- a/server/runtime/persisted_transcript_scan.go
+++ b/server/runtime/persisted_transcript_scan.go
@@ -110,6 +110,7 @@ func clonePersistedChatEntry(entry ChatEntry) ChatEntry {
 	copyEntry.BackgroundExitCode = textutil.Pointer(entry.BackgroundExitCode)
 	copyEntry.WorktreeContext = session.CloneWorktreeContext(entry.WorktreeContext)
 	copyEntry.ToolCall = clonePersistedToolCallMeta(entry.ToolCall)
+	copyEntry.CommittedProvenance = cloneTranscriptCommittedRowProvenance(entry.CommittedProvenance)
 	return copyEntry
 }
 

--- a/server/runtime/step_executor.go
+++ b/server/runtime/step_executor.go
@@ -38,6 +38,9 @@ type preparedCompletedResponse struct {
 	response                     llm.Response
 	phaseTurn                    phaseProtocolTurn
 	assistant                    llm.Message
+	assistantProvenance          *TranscriptCommittedRowProvenance
+	resolutionOutcome            completedResponseResolutionOutcome
+	resolutionResolved           bool
 	localToolCalls               []llm.ToolCall
 	hostedToolExecutions         []hostedToolExecution
 	noopFinalAnswer              bool
@@ -115,9 +118,14 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 			executedToolCall = true
 		}
 		patchEditsApplied = patchEditsApplied || prepared.patchEditsApplied
-		resolution, err := e.resolveCompletedResponseStream(stepID, prepared.resolution)
-		if err != nil {
-			return stepLoopResult{}, err
+		var resolution completedResponseResolutionOutcome
+		if prepared.resolutionResolved {
+			resolution = prepared.resolutionOutcome
+		} else {
+			resolution, err = e.resolveCompletedResponseStream(stepID, prepared.resolution)
+			if err != nil {
+				return stepLoopResult{}, err
+			}
 		}
 		switch prepared.next {
 		case completedResponseNextExternalWorkflowTerminal:
@@ -150,6 +158,7 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 		hostedToolExecutions := prepared.hostedToolExecutions
 		noopFinalAnswer := prepared.noopFinalAnswer
 		assistantCommittedCoordinate := prepared.assistantCommittedCoordinate
+		assistantProvenance := cloneTranscriptCommittedRowProvenance(prepared.assistantProvenance)
 		assistantEventEmitted := resolution.committedAssistantEventPublished
 
 		if !noopFinalAnswer {
@@ -323,7 +332,7 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 					// The answer is already committed before supervisor entries are appended.
 					// Publish it first so live clients never see supervisor entries as a gap
 					// after an unannounced committed assistant message.
-					_ = s.publishCommittedAssistantMessage(stepID, resolved, resolvedCommittedCoordinate)
+					_ = s.publishCommittedAssistantMessage(stepID, resolved, resolvedCommittedCoordinate, assistantProvenance)
 					assistantEventEmitted = true
 				}
 				preReviewMessage := resolved
@@ -340,7 +349,7 @@ func (s *defaultStepExecutor) RunStepLoopWithOptions(ctx context.Context, stepID
 				}
 			}
 			if !assistantEventEmitted {
-				_ = s.publishCommittedAssistantMessage(stepID, resolved, resolvedCommittedCoordinate)
+				_ = s.publishCommittedAssistantMessage(stepID, resolved, resolvedCommittedCoordinate, assistantProvenance)
 			}
 			if reviewerCompletion != nil {
 				if err := e.steer(stepID, steerLocalEntryIntent(storedLocalEntry{Role: reviewerStatusEntryRole(*reviewerCompletion), Text: reviewerStatusText(*reviewerCompletion, nil)})); err != nil {
@@ -491,42 +500,33 @@ func (s *defaultStepExecutor) prepareCompletedResponse(ctx context.Context, step
 			return preparedCompletedResponse{}, err
 		}
 	}
-	if err := e.steer(stepID, steerMessagesWithPersistenceIntent(steeringPriorityNormal, steeringMessageEventNone, true, []llm.Message{assistantMsg})); err != nil {
+	executableCallIDs := make(map[string]struct{}, len(localToolCalls))
+	for _, call := range localToolCalls {
+		if callID := strings.TrimSpace(call.ID); callID != "" {
+			executableCallIDs[callID] = struct{}{}
+		}
+	}
+	assistantCommitResult := steeringAssistantCommitResult{}
+	if err := e.steer(
+		stepID,
+		steerAssistantCommitIntent(assistantMsg, executableCallIDs, &assistantCommitResult),
+	); err != nil {
 		return preparedCompletedResponse{}, err
 	}
-	var assistantCommittedCoordinate *committedAssistantCoordinate
-	if !noopFinalAnswer {
-		executableCallIDs := make(map[string]struct{}, len(localToolCalls))
-		for _, call := range localToolCalls {
-			if callID := strings.TrimSpace(call.ID); callID != "" {
-				executableCallIDs[callID] = struct{}{}
-			}
-		}
-		var toolCallStarts map[string]int
-		assistantCommittedCoordinate, toolCallStarts = committedStartsForPersistedAssistantMessage(e, assistantMsg, executableCallIDs)
-		e.rememberPendingToolCallStarts(toolCallStarts)
-	}
+	assistantCommittedCoordinate := assistantCommitResult.coordinate
+	assistantProvenance := assistantCommitResult.provenance
 	if len(localToolCalls) == 0 && len(hostedToolExecutions) == 0 {
 		e.compactionRuntimeState().SetManualCompactionEligible(true)
 	}
-	resolution := completedResponseDiscardInstruction()
-	if committedAssistantMessageFinalizesStreaming(assistantMsg) {
-		if assistantCommittedCoordinate == nil {
-			return preparedCompletedResponse{}, errors.New("persisted assistant text row has no committed transcript coordinate")
-		}
-		resolution = completedResponseFinalizeInstruction(assistantMsg, assistantCommittedCoordinate)
-	} else if len(VisibleChatEntriesFromMessage(assistantMsg)) > 0 {
-		if err := s.publishCommittedAssistantMessage(stepID, assistantMsg, assistantCommittedCoordinate); err != nil {
-			return preparedCompletedResponse{}, err
-		}
-	}
-
 	return preparedCompletedResponse{
 		next:                         completedResponseNextAccepted,
-		resolution:                   resolution,
+		resolution:                   completedResponseDiscardInstruction(),
+		resolutionOutcome:            assistantCommitResult.resolution,
+		resolutionResolved:           true,
 		response:                     resp,
 		phaseTurn:                    phaseTurn,
 		assistant:                    assistantMsg,
+		assistantProvenance:          cloneTranscriptCommittedRowProvenance(assistantProvenance),
 		localToolCalls:               localToolCalls,
 		hostedToolExecutions:         hostedToolExecutions,
 		noopFinalAnswer:              noopFinalAnswer,
@@ -827,8 +827,8 @@ func (s *defaultStepExecutor) prepareModelTurn(ctx context.Context, stepID strin
 	return newCompactionReminderCoordinator(e).maybeAppend(ctx, stepID)
 }
 
-func (s *defaultStepExecutor) publishCommittedAssistantMessage(stepID string, msg llm.Message, coordinate *committedAssistantCoordinate) error {
-	return s.engine.steer(stepID, steerCommittedAssistantMessageIntent(msg, coordinate))
+func (s *defaultStepExecutor) publishCommittedAssistantMessage(stepID string, msg llm.Message, coordinate *committedAssistantCoordinate, provenances ...*TranscriptCommittedRowProvenance) error {
+	return s.engine.steer(stepID, steerCommittedAssistantMessageIntent(msg, coordinate, provenances...))
 }
 
 func committedAssistantMessageFinalizesStreaming(msg llm.Message) bool {

--- a/server/runtime/streaming_transcript_scan.go
+++ b/server/runtime/streaming_transcript_scan.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"core/server/llm"
@@ -258,6 +259,34 @@ func (s *streamingTranscriptScan) closeTurn() {
 	if len(localEntryProvenance) != len(localEntries) {
 		panic(fmt.Sprintf("persisted transcript local-entry provenance count mismatch: local_entry_count=%d provenance_count=%d", len(localEntries), len(localEntryProvenance)))
 	}
+	orderedMaterialized := make([]struct {
+		message    llm.Message
+		provenance *TranscriptCommittedRowProvenance
+		stepID     string
+	}, len(materialized))
+	for index := range materialized {
+		provenance := materializedProvenance[index]
+		if callID, present := textutil.OptionalTrimmed(materialized[index].ToolCallID); present {
+			if owner := s.completionProvenance[callID]; owner != nil {
+				provenance = owner
+			}
+		}
+		orderedMaterialized[index] = struct {
+			message    llm.Message
+			provenance *TranscriptCommittedRowProvenance
+			stepID     string
+		}{
+			message:    materialized[index],
+			provenance: provenance,
+			stepID:     materializedSteps[index],
+		}
+	}
+	sort.SliceStable(orderedMaterialized, func(left, right int) bool {
+		return transcriptCommittedProvenanceBefore(
+			orderedMaterialized[left].provenance,
+			orderedMaterialized[right].provenance,
+		)
+	})
 	for _, rm := range materialized {
 		if callID, present := textutil.OptionalTrimmed(rm.ToolCallID); present {
 			s.materialized[callID] = struct{}{}
@@ -271,9 +300,9 @@ func (s *streamingTranscriptScan) closeTurn() {
 		}
 		s.appendLocalEntry(entry, localEntrySteps[index], localEntryProvenance[index])
 	}
-	for index, rm := range materialized {
-		s.applyMessage(rm, materializedProvenance[index], materializedSteps[index])
-		callID, _ := textutil.OptionalTrimmed(rm.ToolCallID)
+	for _, materializedEntry := range orderedMaterialized {
+		s.applyMessage(materializedEntry.message, materializedEntry.provenance, materializedEntry.stepID)
+		callID, _ := textutil.OptionalTrimmed(materializedEntry.message.ToolCallID)
 		for localIndex, entry := range localEntries {
 			if entry.AfterToolCallID == nil || strings.TrimSpace(*entry.AfterToolCallID) != callID {
 				continue

--- a/server/runtime/streaming_transcript_scan.go
+++ b/server/runtime/streaming_transcript_scan.go
@@ -28,10 +28,11 @@ import (
 // streamed in, so the assistant message is buffered until the turn closes (the
 // next non-tool event or end of stream) before its entries are emitted.
 type streamingTranscriptScan struct {
-	scan             *inMemoryTranscriptScan
-	completions      map[string]tools.Result
-	materialized     map[string]struct{}
-	cacheWarningMode config.CacheWarningMode
+	scan                 *inMemoryTranscriptScan
+	completions          map[string]tools.Result
+	completionProvenance map[string]*TranscriptCommittedRowProvenance
+	materialized         map[string]struct{}
+	cacheWarningMode     config.CacheWarningMode
 
 	turn turnBuffer
 
@@ -39,23 +40,27 @@ type streamingTranscriptScan struct {
 }
 
 type turnBuffer struct {
-	assistant         *llm.Message
-	assistantStepID   string
-	callIDs           []string
-	materialized      []llm.Message
-	materializedSteps []string
-	localEntries      []storedLocalEntry
-	localEntrySteps   []string
+	assistant              *llm.Message
+	assistantProvenance    *TranscriptCommittedRowProvenance
+	assistantStepID        string
+	callIDs                []string
+	materialized           []llm.Message
+	materializedProvenance []*TranscriptCommittedRowProvenance
+	materializedSteps      []string
+	localEntries           []storedLocalEntry
+	localEntryProvenance   []*TranscriptCommittedRowProvenance
+	localEntrySteps        []string
 }
 
 func newStreamingTranscriptScan(req inMemoryTranscriptScanRequest, cacheWarningMode config.CacheWarningMode) *streamingTranscriptScan {
 	completions := make(map[string]tools.Result)
 	materialized := make(map[string]struct{})
 	return &streamingTranscriptScan{
-		scan:             newInMemoryTranscriptScan(req, completions, materialized),
-		completions:      completions,
-		materialized:     materialized,
-		cacheWarningMode: cacheWarningMode,
+		scan:                 newInMemoryTranscriptScan(req, completions, materialized),
+		completions:          completions,
+		completionProvenance: make(map[string]*TranscriptCommittedRowProvenance),
+		materialized:         materialized,
+		cacheWarningMode:     cacheWarningMode,
 	}
 }
 
@@ -74,8 +79,12 @@ func (s *streamingTranscriptScan) ApplyPersistedEvent(record session.EventRecord
 		if err != nil {
 			return fmt.Errorf("restore session message record: %w", err)
 		}
+		provenance, provenanceErr := transcriptProvenanceFromRecord(record)
+		if provenanceErr != nil {
+			return provenanceErr
+		}
 		for _, reconstructed := range reconstructPersistedMessages(msg) {
-			s.applyReconstructedMessage(reconstructed, record.Seq(), stepID)
+			s.applyReconstructedMessage(reconstructed, &provenance, stepID)
 		}
 	case session.ToolCompletionRecord:
 		completion, err := storedToolCompletionFromSessionRecord(payload)
@@ -95,6 +104,11 @@ func (s *streamingTranscriptScan) ApplyPersistedEvent(record session.EventRecord
 			CondensedText: completion.CondensedText,
 			Presentation:  completion.Presentation,
 		}
+		provenance, provenanceErr := transcriptProvenanceFromRecord(record)
+		if provenanceErr != nil {
+			return provenanceErr
+		}
+		s.completionProvenance[callID] = cloneTranscriptCommittedRowProvenance(&provenance)
 	case session.LocalEntryRecord:
 		entry, err := storedLocalEntryFromSessionRecord(payload)
 		if err != nil {
@@ -111,20 +125,34 @@ func (s *streamingTranscriptScan) ApplyPersistedEvent(record session.EventRecord
 					callID,
 				)
 			}
+			provenance, provenanceErr := transcriptProvenanceFromRecord(record)
+			if provenanceErr != nil {
+				return provenanceErr
+			}
 			s.turn.localEntries = append(s.turn.localEntries, entry)
+			s.turn.localEntryProvenance = append(s.turn.localEntryProvenance, cloneTranscriptCommittedRowProvenance(&provenance))
 			s.turn.localEntrySteps = append(s.turn.localEntrySteps, stepID)
 			return nil
 		}
 		s.closeTurn()
-		s.appendLocalEntry(entry, stepID)
+		provenance, provenanceErr := transcriptProvenanceFromRecord(record)
+		if provenanceErr != nil {
+			return provenanceErr
+		}
+		s.appendLocalEntry(entry, stepID, &provenance)
 	case session.CacheWarningRecord:
 		s.closeTurn()
 		warning := cacheWarningFromSessionRecord(payload)
+		provenance, provenanceErr := transcriptProvenanceFromRecord(record)
+		if provenanceErr != nil {
+			return provenanceErr
+		}
 		s.scan.appendEntry(ChatEntry{
-			StepID:     stepID,
-			Visibility: cacheWarningEntryVisibility(s.cacheWarningMode),
-			Role:       cacheWarningTranscriptRole,
-			Text:       transcript.CacheWarningText(warning),
+			StepID:              stepID,
+			Visibility:          cacheWarningEntryVisibility(s.cacheWarningMode),
+			Role:                cacheWarningTranscriptRole,
+			Text:                transcript.CacheWarningText(warning),
+			CommittedProvenance: &provenance,
 		})
 	case session.HistoryReplacementRecord:
 		s.closeTurn()
@@ -133,11 +161,18 @@ func (s *streamingTranscriptScan) ApplyPersistedEvent(record session.EventRecord
 			return fmt.Errorf("restore session history replacement record: %w", err)
 		}
 		s.scan.MarkCompactionBoundary()
-		for _, entry := range transcriptEntriesFromHistoryReplacement(
+		provenance, provenanceErr := transcriptProvenanceFromRecord(record)
+		if provenanceErr != nil {
+			return provenanceErr
+		}
+		entries := transcriptEntriesFromHistoryReplacement(
 			llm.PrepareOpenAIInputItems(replacement.Items),
 			replacement.CompactionNumber,
-		) {
-			entry.StepID = stepID
+		)
+		for index := range entries {
+			entries[index].StepID = stepID
+		}
+		for _, entry := range assignHistoryReplacementEntryProvenance(entries, &provenance) {
 			s.scan.appendEntry(entry)
 		}
 		if replacement.LastCommittedAssistantFinalAnswer != nil {
@@ -149,11 +184,12 @@ func (s *streamingTranscriptScan) ApplyPersistedEvent(record session.EventRecord
 	return nil
 }
 
-func (s *streamingTranscriptScan) applyReconstructedMessage(msg llm.Message, seq int64, stepID string) {
+func (s *streamingTranscriptScan) applyReconstructedMessage(msg llm.Message, provenance *TranscriptCommittedRowProvenance, stepID string) {
 	if msg.Role == llm.RoleAssistant && len(msg.ToolCalls) > 0 {
 		s.closeTurn()
 		buffered := msg
 		s.turn.assistant = &buffered
+		s.turn.assistantProvenance = cloneTranscriptCommittedRowProvenance(provenance)
 		s.turn.assistantStepID = strings.TrimSpace(stepID)
 		s.turn.callIDs = s.turn.callIDs[:0]
 		for _, call := range msg.ToolCalls {
@@ -166,11 +202,12 @@ func (s *streamingTranscriptScan) applyReconstructedMessage(msg llm.Message, seq
 	toolCallID, _ := textutil.OptionalTrimmed(msg.ToolCallID)
 	if msg.Role == llm.RoleTool && s.turn.assistant != nil && s.turnOwnsCall(toolCallID) {
 		s.turn.materialized = append(s.turn.materialized, msg)
+		s.turn.materializedProvenance = append(s.turn.materializedProvenance, cloneTranscriptCommittedRowProvenance(provenance))
 		s.turn.materializedSteps = append(s.turn.materializedSteps, strings.TrimSpace(stepID))
 		return
 	}
 	s.closeTurn()
-	s.applyMessage(msg, seq, stepID)
+	s.applyMessage(msg, provenance, stepID)
 }
 
 func (s *streamingTranscriptScan) turnOwnsCall(callID string) bool {
@@ -185,8 +222,12 @@ func (s *streamingTranscriptScan) turnOwnsCall(callID string) bool {
 	return false
 }
 
-func (s *streamingTranscriptScan) applyMessage(msg llm.Message, seq int64, stepID string) {
-	s.scan.ApplyMessage(msg, seq, stepID)
+func (s *streamingTranscriptScan) applyMessage(msg llm.Message, provenance *TranscriptCommittedRowProvenance, stepID string) {
+	var seq int64
+	if provenance != nil {
+		seq = provenance.EventSequence
+	}
+	s.scan.ApplyMessage(msg, seq, stepID, s.completionProvenance)
 	s.lastCommittedAssistantFinalAnswer = applyLastCommittedAssistantFinalAnswer(s.lastCommittedAssistantFinalAnswer, msg)
 }
 
@@ -195,11 +236,14 @@ func (s *streamingTranscriptScan) closeTurn() {
 		return
 	}
 	assistant := *s.turn.assistant
+	assistantProvenance := s.turn.assistantProvenance
 	assistantStepID := s.turn.assistantStepID
 	materialized := s.turn.materialized
+	materializedProvenance := s.turn.materializedProvenance
 	materializedSteps := s.turn.materializedSteps
 	callIDs := s.turn.callIDs
 	localEntries := s.turn.localEntries
+	localEntryProvenance := s.turn.localEntryProvenance
 	localEntrySteps := s.turn.localEntrySteps
 
 	if len(materializedSteps) != len(materialized) {
@@ -208,45 +252,55 @@ func (s *streamingTranscriptScan) closeTurn() {
 	if len(localEntrySteps) != len(localEntries) {
 		panic(fmt.Sprintf("persisted transcript local-entry step identity count mismatch: local_entry_count=%d step_id_count=%d", len(localEntries), len(localEntrySteps)))
 	}
+	if len(materializedProvenance) != len(materialized) {
+		panic(fmt.Sprintf("persisted transcript tool-message provenance count mismatch: materialized_count=%d provenance_count=%d", len(materialized), len(materializedProvenance)))
+	}
+	if len(localEntryProvenance) != len(localEntries) {
+		panic(fmt.Sprintf("persisted transcript local-entry provenance count mismatch: local_entry_count=%d provenance_count=%d", len(localEntries), len(localEntryProvenance)))
+	}
 	for _, rm := range materialized {
 		if callID, present := textutil.OptionalTrimmed(rm.ToolCallID); present {
 			s.materialized[callID] = struct{}{}
 		}
 	}
-	s.applyMessage(assistant, 0, assistantStepID)
+	s.applyMessage(assistant, assistantProvenance, assistantStepID)
 	for index, entry := range localEntries {
 		callID := strings.TrimSpace(*entry.AfterToolCallID)
 		if _, materialized := s.materialized[callID]; materialized {
 			continue
 		}
-		s.appendLocalEntry(entry, localEntrySteps[index])
+		s.appendLocalEntry(entry, localEntrySteps[index], localEntryProvenance[index])
 	}
 	for index, rm := range materialized {
-		s.applyMessage(rm, 0, materializedSteps[index])
+		s.applyMessage(rm, materializedProvenance[index], materializedSteps[index])
 		callID, _ := textutil.OptionalTrimmed(rm.ToolCallID)
 		for localIndex, entry := range localEntries {
 			if entry.AfterToolCallID == nil || strings.TrimSpace(*entry.AfterToolCallID) != callID {
 				continue
 			}
-			s.appendLocalEntry(entry, localEntrySteps[localIndex])
+			s.appendLocalEntry(entry, localEntrySteps[localIndex], localEntryProvenance[localIndex])
 		}
 	}
 
 	for _, callID := range callIDs {
 		delete(s.completions, callID)
+		delete(s.completionProvenance, callID)
 		delete(s.materialized, callID)
 	}
 	s.turn = turnBuffer{
-		callIDs:           callIDs[:0],
-		materialized:      materialized[:0],
-		materializedSteps: materializedSteps[:0],
-		localEntries:      localEntries[:0],
-		localEntrySteps:   localEntrySteps[:0],
+		callIDs:                callIDs[:0],
+		materialized:           materialized[:0],
+		materializedProvenance: materializedProvenance[:0],
+		materializedSteps:      materializedSteps[:0],
+		localEntries:           localEntries[:0],
+		localEntryProvenance:   localEntryProvenance[:0],
+		localEntrySteps:        localEntrySteps[:0],
 	}
 }
 
-func (s *streamingTranscriptScan) appendLocalEntry(entry storedLocalEntry, stepID string) {
+func (s *streamingTranscriptScan) appendLocalEntry(entry storedLocalEntry, stepID string, provenance *TranscriptCommittedRowProvenance) {
 	projected := *localEntryChatEntryForStep(entry, stepID)
+	projected.CommittedProvenance = cloneTranscriptCommittedRowProvenance(provenance)
 	s.scan.appendEntry(projected)
 }
 

--- a/server/runtime/streaming_transcript_scan_test.go
+++ b/server/runtime/streaming_transcript_scan_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func streamScanTestEvent(t *testing.T, kind string, payload any) session.EventRecord {
+	return streamScanTestEventAtSequence(t, 1, kind, payload)
+}
+
+func streamScanTestEventAtSequence(t *testing.T, sequence int64, kind string, payload any) session.EventRecord {
 	t.Helper()
 	var record session.EventRecordPayload
 	switch kind {
@@ -91,7 +95,7 @@ func streamScanTestEvent(t *testing.T, kind string, payload any) session.EventRe
 	default:
 		t.Fatalf("unsupported persisted test event kind %q", kind)
 	}
-	event, err := session.NewEventRecord(1, nil, record)
+	event, err := session.NewEventRecord(sequence, nil, record)
 	if err != nil {
 		t.Fatalf("create %s record: %v", kind, err)
 	}
@@ -371,6 +375,96 @@ func TestStreamingTranscriptScanPagesAreWindowsOfFullProjection(t *testing.T) {
 		if len(got.Snapshot.Entries) != len(want) || (len(want) > 0 && !reflect.DeepEqual(got.Snapshot.Entries, want)) {
 			t.Fatalf("page(%d,%d) entries diverged from full-projection window: got %d want %d entries", req.offset, req.limit, len(got.Snapshot.Entries), len(want))
 		}
+	}
+}
+
+func TestStreamingTranscriptScanPagesOrderMaterializedToolsByCompletionProvenance(t *testing.T) {
+	t.Parallel()
+	events := []session.EventRecord{
+		streamScanTestEventAtSequence(t, 1, "message", llm.Message{
+			Role: llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{
+				{ID: "call-a", Name: string(toolspec.ToolExecCommand)},
+				{ID: "call-b", Name: string(toolspec.ToolExecCommand)},
+			},
+		}),
+		streamScanTestEventAtSequence(t, 2, "tool_completed", storedToolCompletion{
+			CallID: "call-b",
+			Name:   string(toolspec.ToolExecCommand),
+			Output: json.RawMessage(`{"output":"b"}`),
+		}),
+		streamScanTestEventAtSequence(t, 3, "tool_completed", storedToolCompletion{
+			CallID: "call-a",
+			Name:   string(toolspec.ToolExecCommand),
+			Output: json.RawMessage(`{"output":"a"}`),
+		}),
+		streamScanTestEventAtSequence(t, 4, "message", llm.Message{
+			Role:       llm.RoleTool,
+			ToolCallID: textutil.Value("call-a"),
+			Name:       textutil.Value(string(toolspec.ToolExecCommand)),
+			Content:    textutil.Value(`{"output":"a"}`),
+		}),
+		streamScanTestEventAtSequence(t, 5, "message", llm.Message{
+			Role:       llm.RoleTool,
+			ToolCallID: textutil.Value("call-b"),
+			Name:       textutil.Value(string(toolspec.ToolExecCommand)),
+			Content:    textutil.Value(`{"output":"b"}`),
+		}),
+		streamScanTestEventAtSequence(t, 6, "message", llm.Message{
+			Role:    llm.RoleAssistant,
+			Phase:   textutil.Value(llm.MessagePhaseFinal),
+			Content: textutil.Value("done"),
+		}),
+	}
+
+	for _, test := range []struct {
+		offset int
+		callID string
+		seq    int64
+	}{
+		{offset: 2, callID: "call-b", seq: 2},
+		{offset: 3, callID: "call-a", seq: 3},
+	} {
+		scan := newStreamingTranscriptScan(
+			inMemoryTranscriptScanRequest{Offset: test.offset, Limit: 1},
+			config.CacheWarningModeDefault,
+		)
+		applyEventsToStreaming(t, scan, events)
+		page := scan.PageSnapshot()
+		if page.TotalEntries != 5 {
+			t.Fatalf("page at offset %d total entries = %d, want 5", test.offset, page.TotalEntries)
+		}
+		if len(page.Snapshot.Entries) != 1 {
+			t.Fatalf("page at offset %d entries = %+v, want one row", test.offset, page.Snapshot.Entries)
+		}
+		entry := page.Snapshot.Entries[0]
+		if entry.Role != "tool_result_ok" || entry.ToolCallID != test.callID {
+			t.Fatalf("page at offset %d entry = %+v, want tool result for %s", test.offset, entry, test.callID)
+		}
+		if entry.CommittedProvenance == nil || entry.CommittedProvenance.EventSequence != test.seq {
+			t.Fatalf(
+				"page at offset %d entry provenance = %+v, want event sequence %d",
+				test.offset,
+				entry.CommittedProvenance,
+				test.seq,
+			)
+		}
+	}
+
+	tail := newStreamingTranscriptScan(
+		inMemoryTranscriptScanRequest{TrackRecentTail: true, TailLimit: 1},
+		config.CacheWarningModeDefault,
+	)
+	applyEventsToStreaming(t, tail, events[:5])
+	window := tail.RecentTailSnapshot()
+	if len(window.Snapshot.Entries) != 1 {
+		t.Fatalf("recent tail entries = %+v, want one row", window.Snapshot.Entries)
+	}
+	if entry := window.Snapshot.Entries[0]; entry.Role != "tool_result_ok" ||
+		entry.ToolCallID != "call-a" ||
+		entry.CommittedProvenance == nil ||
+		entry.CommittedProvenance.EventSequence != 3 {
+		t.Fatalf("recent tail entry = %+v, want latest completion for call-a", entry)
 	}
 }
 

--- a/server/runtime/tool_completion_locator_projection_test.go
+++ b/server/runtime/tool_completion_locator_projection_test.go
@@ -69,6 +69,9 @@ func TestToolCompletionLocatorOwnerSurvivesRoleToolMaterializationAndReopen(t *t
 
 	page := mustEngineNewestSegmentPage(t, engine)
 	pageFacts := TranscriptCommittedRowFactsFromSnapshot(page.Snapshot)
+	assertToolFactsFollowLocatorOrder(t, pageFacts, "page")
+	hydrationFacts := hydrationSnapshot(t, engine).CommittedRows
+	assertToolFactsFollowLocatorOrder(t, hydrationFacts, "hydration")
 	for _, callID := range []string{"call-1", "call-2"} {
 		pageFact := findToolFact(t, pageFacts, callID)
 		liveLocator, ok := liveLocators[callID]
@@ -88,10 +91,26 @@ func TestToolCompletionLocatorOwnerSurvivesRoleToolMaterializationAndReopen(t *t
 	}
 	reopened := mustNewTestEngine(t, mustOpenTestSession(t, store.Dir()), &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
 	reopenedFacts := TranscriptCommittedRowFactsFromSnapshot(mustEngineNewestSegmentPage(t, reopened).Snapshot)
+	assertToolFactsFollowLocatorOrder(t, reopenedFacts, "reopened page")
+	assertToolFactsFollowLocatorOrder(t, hydrationSnapshot(t, reopened).CommittedRows, "reopened hydration")
 	for _, callID := range []string{"call-1", "call-2"} {
 		if got := findToolFact(t, reopenedFacts, callID).Locator; got != liveLocators[callID] {
 			t.Fatalf("reopened tool %s locator = %+v, live locator = %+v", callID, got, liveLocators[callID])
 		}
+	}
+}
+
+func assertToolFactsFollowLocatorOrder(t *testing.T, facts []TranscriptCommittedRowFact, source string) {
+	t.Helper()
+	var previous *TranscriptCommittedRowFact
+	for index := range facts {
+		if facts[index].Tool == nil {
+			continue
+		}
+		if previous != nil && facts[index].Locator.EventSequence < previous.Locator.EventSequence {
+			t.Fatalf("%s tool facts regress by locator: previous=%+v current=%+v", source, previous.Locator, facts[index].Locator)
+		}
+		previous = &facts[index]
 	}
 }
 

--- a/server/runtime/tool_completion_locator_projection_test.go
+++ b/server/runtime/tool_completion_locator_projection_test.go
@@ -1,0 +1,107 @@
+package runtime
+
+import (
+	"encoding/json"
+	"testing"
+
+	"core/server/llm"
+	"core/server/tools"
+	"core/shared/textutil"
+	"core/shared/toolspec"
+	"core/shared/transcript"
+)
+
+func TestToolCompletionLocatorOwnerSurvivesRoleToolMaterializationAndReopen(t *testing.T) {
+	t.Parallel()
+	store := mustCreateTestSession(t)
+	events := make([]Event, 0, 16)
+	engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{
+		Model:   "gpt-5",
+		OnEvent: func(event Event) { events = append(events, event) },
+	})
+	calls := []llm.ToolCall{
+		{ID: "call-1", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{}`)},
+		{ID: "call-2", Name: string(toolspec.ToolExecCommand), Input: json.RawMessage(`{}`)},
+	}
+	if err := engine.steer("step-1", steerMessagesWithPersistenceIntent(
+		steeringPriorityNormal,
+		steeringMessageEventNone,
+		true,
+		[]llm.Message{{Role: llm.RoleAssistant, ToolCalls: calls}},
+	)); err != nil {
+		t.Fatalf("append assistant tool calls: %v", err)
+	}
+	results := []tools.Result{
+		{CallID: "call-2", Name: toolspec.ToolExecCommand, Output: json.RawMessage(`{"output":"two"}`)},
+		{CallID: "call-1", Name: toolspec.ToolExecCommand, Output: json.RawMessage(`{"output":"one"}`)},
+	}
+	liveLocators := make(map[string]transcript.CommittedRowLocator, len(results))
+	for _, result := range results {
+		before := len(events)
+		if err := engine.steer("step-1", steerToolCompletionIntent(result)); err != nil {
+			t.Fatalf("persist tool completion %s: %v", result.CallID, err)
+		}
+		for _, event := range events[before:] {
+			facts := TranscriptCommittedRowFactsFromEvent(event)
+			for _, fact := range facts {
+				if fact.Tool != nil && fact.Tool.ToolCallID == result.CallID {
+					liveLocators[result.CallID] = fact.Locator
+				}
+			}
+		}
+	}
+	for _, result := range results {
+		mirror := llm.Message{
+			Role:       llm.RoleTool,
+			ToolCallID: textutil.Value(result.CallID),
+			Name:       textutil.Value(string(result.Name)),
+			Content:    textutil.Value(string(result.Output)),
+		}
+		if err := engine.steer("step-1", steerMessagesWithPersistenceIntent(
+			steeringPriorityNormal,
+			steeringMessageEventDefault,
+			true,
+			[]llm.Message{mirror},
+		)); err != nil {
+			t.Fatalf("materialize tool mirror %s: %v", result.CallID, err)
+		}
+	}
+
+	page := mustEngineNewestSegmentPage(t, engine)
+	pageFacts := TranscriptCommittedRowFactsFromSnapshot(page.Snapshot)
+	for _, callID := range []string{"call-1", "call-2"} {
+		pageFact := findToolFact(t, pageFacts, callID)
+		liveLocator, ok := liveLocators[callID]
+		if !ok {
+			t.Fatalf("live locator for %s is absent", callID)
+		}
+		if err := liveLocator.Validate(); err != nil {
+			t.Fatalf("live locator for %s is invalid: %v", callID, err)
+		}
+		if pageFact.Locator != liveLocator {
+			t.Fatalf("tool %s page locator = %+v, live locator = %+v", callID, pageFact.Locator, liveLocator)
+		}
+	}
+
+	if err := engine.Close(); err != nil {
+		t.Fatalf("close engine: %v", err)
+	}
+	reopened := mustNewTestEngine(t, mustOpenTestSession(t, store.Dir()), &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
+	reopenedFacts := TranscriptCommittedRowFactsFromSnapshot(mustEngineNewestSegmentPage(t, reopened).Snapshot)
+	for _, callID := range []string{"call-1", "call-2"} {
+		if got := findToolFact(t, reopenedFacts, callID).Locator; got != liveLocators[callID] {
+			t.Fatalf("reopened tool %s locator = %+v, live locator = %+v", callID, got, liveLocators[callID])
+		}
+	}
+}
+
+func findToolFact(t *testing.T, facts []TranscriptCommittedRowFact, callID string) TranscriptCommittedRowFact {
+	t.Helper()
+	for _, fact := range facts {
+		if fact.Tool != nil && fact.Tool.ToolCallID == callID {
+			return fact
+		}
+	}
+	t.Fatalf("tool fact %s is absent: %+v", callID, facts)
+	return TranscriptCommittedRowFact{}
+}

--- a/server/runtime/tool_completion_locator_projection_test.go
+++ b/server/runtime/tool_completion_locator_projection_test.go
@@ -66,6 +66,19 @@ func TestToolCompletionLocatorOwnerSurvivesRoleToolMaterializationAndReopen(t *t
 			t.Fatalf("materialize tool mirror %s: %v", result.CallID, err)
 		}
 	}
+	liveToolRows := make(map[string]int, len(results))
+	for _, event := range events {
+		for _, fact := range TranscriptCommittedRowFactsFromEvent(event) {
+			if fact.Tool != nil {
+				liveToolRows[fact.Tool.ToolCallID]++
+			}
+		}
+	}
+	for _, result := range results {
+		if got, want := liveToolRows[result.CallID], 1; got != want {
+			t.Fatalf("live tool row count for %s = %d, want %d", result.CallID, got, want)
+		}
+	}
 
 	page := mustEngineNewestSegmentPage(t, engine)
 	pageFacts := TranscriptCommittedRowFactsFromSnapshot(page.Snapshot)

--- a/server/runtime/transcript_delivery_facts.go
+++ b/server/runtime/transcript_delivery_facts.go
@@ -26,6 +26,8 @@ type TranscriptCommittedRowFact struct {
 	Visibility transcript.EntryVisibility
 	Integrity  transcript.RowIntegrity
 	Kind       TranscriptCommittedRowFactKind
+	Locator    transcript.CommittedRowLocator
+	Provenance *TranscriptCommittedRowProvenance
 	User       *TranscriptUserRowFact
 	Assistant  *TranscriptAssistantRowFact
 	Tool       *TranscriptToolRowFact
@@ -90,7 +92,13 @@ func TranscriptCommittedRowFactsFromEvent(evt Event) []TranscriptCommittedRowFac
 	var facts []TranscriptCommittedRowFact
 	switch evt.Kind {
 	case EventConversationUpdated, EventAssistantMessage:
-		facts = transcriptCommittedRowFactsFromMessage(evt.Message, evt.AssistantTranscriptStreamID, nil, nil)
+		facts = transcriptCommittedRowFactsFromMessage(
+			evt.Message,
+			evt.AssistantTranscriptStreamID,
+			nil,
+			nil,
+			transcriptMessageProjectionContext{Provenance: evt.CommittedProvenance},
+		)
 	case EventUserMessageFlushed:
 		if strings.TrimSpace(evt.UserMessage) == "" {
 			return nil
@@ -123,16 +131,21 @@ func TranscriptCommittedRowFactsFromEvent(evt Event) []TranscriptCommittedRowFac
 		}
 		return nil
 	case EventInFlightClearFailed:
-		if strings.TrimSpace(evt.Error) == "" {
-			return nil
-		}
-		facts = []TranscriptCommittedRowFact{runtimeDiagnosticNoticeFact("in_flight_clear_failed", transcript.NoticeSeverityError, evt.Error)}
+		return nil
 	case EventBackgroundUpdated:
 		return nil
 	default:
 		return nil
 	}
-	return transcriptCommittedRowFactsForStep(evt.StepID, facts)
+	for index := range facts {
+		if evt.CommittedProvenance != nil {
+			facts[index].Provenance = cloneTranscriptCommittedRowProvenance(evt.CommittedProvenance)
+		} else if facts[index].Provenance == nil {
+			facts[index].Provenance = cloneTranscriptCommittedRowProvenance(evt.CommittedProvenance)
+		}
+	}
+	facts = transcriptCommittedRowFactsForStep(evt.StepID, facts)
+	return locateTranscriptCommittedRowFacts(facts)
 }
 
 func transcriptCommittedRowFactsForStep(stepID string, facts []TranscriptCommittedRowFact) []TranscriptCommittedRowFact {
@@ -149,6 +162,28 @@ func transcriptCommittedRowFactsForStep(stepID string, facts []TranscriptCommitt
 	return facts
 }
 
+func locateTranscriptCommittedRowFacts(facts []TranscriptCommittedRowFact) []TranscriptCommittedRowFact {
+	ordinals := make(map[int64]int64, len(facts))
+	for index := range facts {
+		provenance := facts[index].Provenance
+		if provenance == nil {
+			return facts
+		}
+		ordinal := ordinals[provenance.EventSequence] + 1
+		if provenance.ProjectedOrdinal != nil {
+			ordinal = *provenance.ProjectedOrdinal
+		}
+		ordinals[provenance.EventSequence] = ordinal
+		facts[index].Locator = transcript.CommittedRowLocator{
+			EventSequence: provenance.EventSequence,
+			RowOrdinal:    ordinal,
+		}
+		facts[index].Provenance = cloneTranscriptCommittedRowProvenance(provenance)
+		facts[index].Provenance.ProjectedOrdinal = nil
+	}
+	return facts
+}
+
 func TranscriptCommittedRowFactsFromSnapshot(snapshot ChatSnapshot) []TranscriptCommittedRowFact {
 	facts := make([]TranscriptCommittedRowFact, 0, len(snapshot.Entries))
 	for _, entry := range snapshot.Entries {
@@ -161,7 +196,7 @@ func TranscriptCommittedRowFactsFromSnapshot(snapshot ChatSnapshot) []Transcript
 			facts = append(facts, fact)
 		}
 	}
-	return facts
+	return locateTranscriptCommittedRowFacts(facts)
 }
 
 func TranscriptToolStartFactsFromEvent(evt Event) []TranscriptLiveToolStart {
@@ -180,7 +215,37 @@ func TranscriptToolStartFactsFromEvent(evt Event) []TranscriptLiveToolStart {
 	}
 }
 
-func transcriptCommittedRowFactsFromMessage(msg llm.Message, streamID *uuid.UUID, completions map[string]tools.Result, materializedToolCalls map[string]struct{}) []TranscriptCommittedRowFact {
+type transcriptMessageProjectionContext struct {
+	Provenance           *TranscriptCommittedRowProvenance
+	CompletionProvenance map[string]*TranscriptCommittedRowProvenance
+}
+
+func transcriptCommittedRowFactsFromMessage(
+	msg llm.Message,
+	streamID *uuid.UUID,
+	completions map[string]tools.Result,
+	materializedToolCalls map[string]struct{},
+	contexts ...transcriptMessageProjectionContext,
+) []TranscriptCommittedRowFact {
+	facts := transcriptCommittedRowFactsFromMessageUnlocated(msg, streamID, completions, materializedToolCalls)
+	var provenance *TranscriptCommittedRowProvenance
+	var completionProvenance map[string]*TranscriptCommittedRowProvenance
+	if len(contexts) > 0 {
+		provenance = contexts[0].Provenance
+		completionProvenance = contexts[0].CompletionProvenance
+	}
+	for index := range facts {
+		facts[index].Provenance = cloneTranscriptCommittedRowProvenance(provenance)
+		if facts[index].Tool != nil && completionProvenance != nil {
+			if owner := completionProvenance[facts[index].Tool.ToolCallID]; owner != nil {
+				facts[index].Provenance = cloneTranscriptCommittedRowProvenance(owner)
+			}
+		}
+	}
+	return facts
+}
+
+func transcriptCommittedRowFactsFromMessageUnlocated(msg llm.Message, streamID *uuid.UUID, completions map[string]tools.Result, materializedToolCalls map[string]struct{}) []TranscriptCommittedRowFact {
 	switch msg.Role {
 	case llm.RoleUser:
 		if msg.MessageType != nil &&
@@ -247,6 +312,14 @@ func transcriptCommittedEntryCountFromMessage(msg llm.Message, completions map[s
 }
 
 func transcriptCommittedRowFactFromChatEntry(entry ChatEntry) (TranscriptCommittedRowFact, bool) {
+	fact, ok := transcriptCommittedRowFactFromChatEntryUnlocated(entry)
+	if ok {
+		fact.Provenance = cloneTranscriptCommittedRowProvenance(entry.CommittedProvenance)
+	}
+	return fact, ok
+}
+
+func transcriptCommittedRowFactFromChatEntryUnlocated(entry ChatEntry) (TranscriptCommittedRowFact, bool) {
 	visibility := normalizeRuntimeEntryVisibility(entry.Visibility)
 	if visibility == transcript.EntryVisibilityHidden {
 		return TranscriptCommittedRowFact{}, false
@@ -322,6 +395,14 @@ func transcriptCommittedRowFactFromChatEntry(entry ChatEntry) (TranscriptCommitt
 }
 
 func transcriptNoticeRowFactFromChatEntry(entry ChatEntry) (TranscriptCommittedRowFact, bool) {
+	fact, ok := transcriptNoticeRowFactFromChatEntryUnlocated(entry)
+	if ok {
+		fact.Provenance = cloneTranscriptCommittedRowProvenance(entry.CommittedProvenance)
+	}
+	return fact, ok
+}
+
+func transcriptNoticeRowFactFromChatEntryUnlocated(entry ChatEntry) (TranscriptCommittedRowFact, bool) {
 	visibility := normalizeRuntimeEntryVisibility(entry.Visibility)
 	if visibility == transcript.EntryVisibilityHidden {
 		return TranscriptCommittedRowFact{}, false

--- a/server/runtime/transcript_delivery_facts.go
+++ b/server/runtime/transcript_delivery_facts.go
@@ -165,18 +165,10 @@ func transcriptCommittedRowFactsForStep(stepID string, facts []TranscriptCommitt
 
 func locateTranscriptCommittedRowFacts(facts []TranscriptCommittedRowFact) []TranscriptCommittedRowFact {
 	sort.SliceStable(facts, func(left, right int) bool {
-		leftProvenance := facts[left].Provenance
-		rightProvenance := facts[right].Provenance
-		if leftProvenance == nil || rightProvenance == nil {
-			return false
-		}
-		if leftProvenance.EventSequence != rightProvenance.EventSequence {
-			return leftProvenance.EventSequence < rightProvenance.EventSequence
-		}
-		if leftProvenance.ProjectedOrdinal != nil && rightProvenance.ProjectedOrdinal != nil {
-			return *leftProvenance.ProjectedOrdinal < *rightProvenance.ProjectedOrdinal
-		}
-		return false
+		return transcriptCommittedProvenanceBefore(
+			facts[left].Provenance,
+			facts[right].Provenance,
+		)
 	})
 	ordinals := make(map[int64]int64, len(facts))
 	for index := range facts {

--- a/server/runtime/transcript_delivery_facts.go
+++ b/server/runtime/transcript_delivery_facts.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"sort"
 	"strings"
 
 	"core/server/llm"
@@ -163,6 +164,20 @@ func transcriptCommittedRowFactsForStep(stepID string, facts []TranscriptCommitt
 }
 
 func locateTranscriptCommittedRowFacts(facts []TranscriptCommittedRowFact) []TranscriptCommittedRowFact {
+	sort.SliceStable(facts, func(left, right int) bool {
+		leftProvenance := facts[left].Provenance
+		rightProvenance := facts[right].Provenance
+		if leftProvenance == nil || rightProvenance == nil {
+			return false
+		}
+		if leftProvenance.EventSequence != rightProvenance.EventSequence {
+			return leftProvenance.EventSequence < rightProvenance.EventSequence
+		}
+		if leftProvenance.ProjectedOrdinal != nil && rightProvenance.ProjectedOrdinal != nil {
+			return *leftProvenance.ProjectedOrdinal < *rightProvenance.ProjectedOrdinal
+		}
+		return false
+	})
 	ordinals := make(map[int64]int64, len(facts))
 	for index := range facts {
 		provenance := facts[index].Provenance

--- a/server/runtime/transcript_event_entries.go
+++ b/server/runtime/transcript_event_entries.go
@@ -104,10 +104,7 @@ func TranscriptEntriesFromEvent(evt Event) []ChatEntry {
 	case EventCompactionFailed:
 		return nil
 	case EventInFlightClearFailed:
-		if strings.TrimSpace(evt.Error) == "" {
-			return nil
-		}
-		entries = []ChatEntry{{Role: "error", Text: fmt.Sprintf("Run cleanup warning: %s", evt.Error)}}
+		return nil
 	case EventCacheWarning:
 		if evt.CacheWarning == nil {
 			return nil

--- a/server/runtime/transcript_locator_restart_replacement_test.go
+++ b/server/runtime/transcript_locator_restart_replacement_test.go
@@ -1,0 +1,150 @@
+package runtime
+
+import (
+	"testing"
+
+	"core/server/llm"
+	"core/server/tools"
+	"core/shared/textutil"
+	"core/shared/transcript"
+)
+
+func TestHistoryReplacementLocatorsSurviveReopenAsOneBoundedBatch(t *testing.T) {
+	t.Parallel()
+	store := mustCreateTestSession(t)
+	events := make([]Event, 0, 16)
+	engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{
+		Model:   "gpt-5",
+		OnEvent: func(event Event) { events = append(events, event) },
+	})
+	items := llm.ItemsFromMessages([]llm.Message{
+		{Role: llm.RoleUser, MessageType: textutil.Value(llm.MessageTypeCompactionSummary), Content: textutil.Value("summary")},
+		{Role: llm.RoleUser, Content: textutil.Value("preserved")},
+		{Role: llm.RoleDeveloper, MessageType: textutil.Value(llm.MessageTypeEnvironment), Content: textutil.Value("environment")},
+	})
+	if err := engine.steer("compaction", steerHistoryReplacementIntent("local", compactionModeManual, 1, "", "", items)); err != nil {
+		t.Fatalf("persist history replacement: %v", err)
+	}
+
+	live := make([]TranscriptCommittedRowFact, 0, 3)
+	for _, event := range events {
+		if event.LocalEntryProjected {
+			live = append(live, TranscriptCommittedRowFactsFromEvent(event)...)
+		}
+	}
+	if len(live) != 3 {
+		t.Fatalf("live replacement facts = %+v, want three rows", live)
+	}
+	for index, fact := range live {
+		if fact.Locator.RowOrdinal != int64(index+1) {
+			t.Fatalf("live replacement fact %d locator = %+v, want ordinal %d", index, fact.Locator, index+1)
+		}
+		if fact.Locator.EventSequence <= 0 {
+			t.Fatalf("live replacement fact %d locator = %+v, want positive sequence", index, fact.Locator)
+		}
+	}
+
+	pageFacts := TranscriptCommittedRowFactsFromSnapshot(mustEngineNewestSegmentPage(t, engine).Snapshot)
+	if len(pageFacts) != len(live) {
+		t.Fatalf("active segment facts = %+v, live facts = %+v", pageFacts, live)
+	}
+	for index := range live {
+		if pageFacts[index].Locator != live[index].Locator {
+			t.Fatalf("active segment locator[%d] = %+v, live locator = %+v", index, pageFacts[index].Locator, live[index].Locator)
+		}
+	}
+	hydrationFacts := hydrationSnapshot(t, engine).CommittedRows
+	if len(hydrationFacts) != len(live) {
+		t.Fatalf("current hydration facts = %+v, live facts = %+v", hydrationFacts, live)
+	}
+	for index := range live {
+		if hydrationFacts[index].Locator != live[index].Locator {
+			t.Fatalf("current hydration locator[%d] = %+v, live locator = %+v", index, hydrationFacts[index].Locator, live[index].Locator)
+		}
+	}
+	if err := engine.Close(); err != nil {
+		t.Fatalf("close engine: %v", err)
+	}
+	reopened := mustNewTestEngine(t, mustOpenTestSession(t, store.Dir()), &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
+	reopenedFacts := TranscriptCommittedRowFactsFromSnapshot(mustEngineNewestSegmentPage(t, reopened).Snapshot)
+	if len(reopenedFacts) != len(live) {
+		t.Fatalf("reopened facts = %+v, live facts = %+v", reopenedFacts, live)
+	}
+	for index := range live {
+		if reopenedFacts[index].Locator != live[index].Locator {
+			t.Fatalf("reopened locator[%d] = %+v, live locator = %+v", index, reopenedFacts[index].Locator, live[index].Locator)
+		}
+	}
+	reopenedHydrationFacts := hydrationSnapshot(t, reopened).CommittedRows
+	if len(reopenedHydrationFacts) != len(live) {
+		t.Fatalf("reopened hydration facts = %+v, live facts = %+v", reopenedHydrationFacts, live)
+	}
+	for index := range live {
+		if reopenedHydrationFacts[index].Locator != live[index].Locator {
+			t.Fatalf("reopened hydration locator[%d] = %+v, live locator = %+v", index, reopenedHydrationFacts[index].Locator, live[index].Locator)
+		}
+	}
+
+	_ = transcript.EntryVisibilityOngoing
+}
+
+func TestHistoryReplacementLocatorsSkipFilteredToolCallEntries(t *testing.T) {
+	t.Parallel()
+	store := mustCreateTestSession(t)
+	events := make([]Event, 0, 16)
+	engine := mustNewTestEngine(t, store, &fakeClient{}, tools.NewRegistry(), Config{
+		Model:   "gpt-5",
+		OnEvent: func(event Event) { events = append(events, event) },
+	})
+	items := llm.ItemsFromMessages([]llm.Message{
+		{
+			Role:    llm.RoleAssistant,
+			Content: textutil.Value("visible assistant"),
+			ToolCalls: []llm.ToolCall{{
+				ID:    "call-filtered",
+				Name:  "shell",
+				Input: []byte(`{"command":"pwd"}`),
+			}},
+		},
+		{Role: llm.RoleUser, Content: textutil.Value("visible user")},
+	})
+	if err := engine.steer("compaction", steerHistoryReplacementIntent("local", compactionModeManual, 1, "", "", items)); err != nil {
+		t.Fatalf("persist history replacement: %v", err)
+	}
+
+	live := make([]TranscriptCommittedRowFact, 0, 3)
+	for _, event := range events {
+		if event.LocalEntryProjected {
+			live = append(live, TranscriptCommittedRowFactsFromEvent(event)...)
+		}
+	}
+	if len(live) != 3 {
+		t.Fatalf("live replacement facts = %+v, want three visible rows", live)
+	}
+	for index, fact := range live {
+		if got, want := fact.Locator.RowOrdinal, int64(index+1); got != want {
+			t.Fatalf("live fact %d locator = %+v, want ordinal %d", index, fact.Locator, want)
+		}
+	}
+	pageFacts := TranscriptCommittedRowFactsFromSnapshot(mustEngineNewestSegmentPage(t, engine).Snapshot)
+	hydrationFacts := hydrationSnapshot(t, engine).CommittedRows
+	assertReplacementLocatorsMatch(t, pageFacts, live, "page")
+	assertReplacementLocatorsMatch(t, hydrationFacts, live, "hydration")
+}
+
+func assertReplacementLocatorsMatch(
+	t *testing.T,
+	got []TranscriptCommittedRowFact,
+	want []TranscriptCommittedRowFact,
+	source string,
+) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s facts = %+v, want %+v", source, got, want)
+	}
+	for index := range want {
+		if got[index].Locator != want[index].Locator {
+			t.Fatalf("%s locator[%d] = %+v, want %+v", source, index, got[index].Locator, want[index].Locator)
+		}
+	}
+}

--- a/server/runtime/transcript_locator_restart_replacement_test.go
+++ b/server/runtime/transcript_locator_restart_replacement_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"strings"
 	"testing"
 
 	"core/server/llm"
@@ -130,6 +131,26 @@ func TestHistoryReplacementLocatorsSkipFilteredToolCallEntries(t *testing.T) {
 	hydrationFacts := hydrationSnapshot(t, engine).CommittedRows
 	assertReplacementLocatorsMatch(t, pageFacts, live, "page")
 	assertReplacementLocatorsMatch(t, hydrationFacts, live, "hydration")
+}
+
+func TestHistoryReplacementEmissionReturnsMissingOrdinalError(t *testing.T) {
+	engine := mustNewTestEngine(t, mustCreateTestSession(t), &fakeClient{}, tools.NewRegistry(), Config{Model: "gpt-5"})
+	err := engine.emitProjectedHistoryReplacementEntriesRaw(
+		"step-1",
+		0,
+		[]ChatEntry{{
+			StepID:     "step-1",
+			Role:       "user",
+			Text:       "private transcript text",
+			Visibility: transcript.EntryVisibilityOngoing,
+		}},
+	)
+	if err == nil {
+		t.Fatal("history replacement emission returned nil for missing ordinal")
+	}
+	if strings.Contains(err.Error(), "private transcript text") {
+		t.Fatalf("history replacement error exposed transcript text: %v", err)
+	}
 }
 
 func assertReplacementLocatorsMatch(

--- a/server/runtime/transcript_provenance.go
+++ b/server/runtime/transcript_provenance.go
@@ -1,0 +1,50 @@
+package runtime
+
+import (
+	"fmt"
+	"strings"
+
+	"core/server/session"
+)
+
+type TranscriptCommittedRowProvenance struct {
+	EventSequence    int64
+	ToolCallID       string
+	ProjectedOrdinal *int64
+}
+
+func transcriptProvenanceFromRecord(record session.EventRecord) (TranscriptCommittedRowProvenance, error) {
+	if record.Seq() <= 0 {
+		return TranscriptCommittedRowProvenance{}, fmt.Errorf("committed transcript provenance has invalid event sequence %d", record.Seq())
+	}
+	payload, err := record.Payload()
+	if err != nil {
+		return TranscriptCommittedRowProvenance{}, err
+	}
+	provenance := TranscriptCommittedRowProvenance{EventSequence: record.Seq()}
+	switch typed := payload.(type) {
+	case session.MessageRecord:
+		if typed.ToolCallID != nil {
+			provenance.ToolCallID = strings.TrimSpace(*typed.ToolCallID)
+		}
+	case session.ToolCompletionRecord:
+		provenance.ToolCallID = strings.TrimSpace(typed.CallID)
+	case session.LocalEntryRecord:
+		if typed.AfterToolCallID != nil {
+			provenance.ToolCallID = strings.TrimSpace(*typed.AfterToolCallID)
+		}
+	}
+	return provenance, nil
+}
+
+func cloneTranscriptCommittedRowProvenance(value *TranscriptCommittedRowProvenance) *TranscriptCommittedRowProvenance {
+	if value == nil {
+		return nil
+	}
+	copyValue := *value
+	if value.ProjectedOrdinal != nil {
+		ordinal := *value.ProjectedOrdinal
+		copyValue.ProjectedOrdinal = &ordinal
+	}
+	return &copyValue
+}

--- a/server/runtime/transcript_provenance.go
+++ b/server/runtime/transcript_provenance.go
@@ -13,6 +13,22 @@ type TranscriptCommittedRowProvenance struct {
 	ProjectedOrdinal *int64
 }
 
+func transcriptCommittedProvenanceBefore(
+	left *TranscriptCommittedRowProvenance,
+	right *TranscriptCommittedRowProvenance,
+) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	if left.EventSequence != right.EventSequence {
+		return left.EventSequence < right.EventSequence
+	}
+	if left.ProjectedOrdinal != nil && right.ProjectedOrdinal != nil {
+		return *left.ProjectedOrdinal < *right.ProjectedOrdinal
+	}
+	return false
+}
+
 func transcriptProvenanceFromRecord(record session.EventRecord) (TranscriptCommittedRowProvenance, error) {
 	if record.Seq() <= 0 {
 		return TranscriptCommittedRowProvenance{}, fmt.Errorf("committed transcript provenance has invalid event sequence %d", record.Seq())

--- a/server/runtime/transcript_runtime_state.go
+++ b/server/runtime/transcript_runtime_state.go
@@ -258,16 +258,16 @@ func (s *transcriptRuntimeState) ValidateMessage(stepID string, msg llm.Message)
 	return s.chatProjection().validateMessage(stepID, msg)
 }
 
-func (s *transcriptRuntimeState) AppendMessage(stepID string, msg llm.Message) error {
-	return s.chatProjection().appendMessage(stepID, msg)
+func (s *transcriptRuntimeState) AppendMessage(stepID string, msg llm.Message, provenances ...*TranscriptCommittedRowProvenance) error {
+	return s.chatProjection().appendMessage(stepID, msg, provenances...)
 }
 
-func (s *transcriptRuntimeState) AppendLocalEntryRecord(entry ChatEntry, afterToolCallID *string) {
-	s.chatProjection().appendLocalEntryRecord(entry, afterToolCallID)
+func (s *transcriptRuntimeState) AppendLocalEntryRecord(entry ChatEntry, afterToolCallID *string, provenances ...*TranscriptCommittedRowProvenance) {
+	s.chatProjection().appendLocalEntryRecord(entry, afterToolCallID, provenances...)
 }
 
-func (s *transcriptRuntimeState) AppendCommittedEntryWithVisibility(role, text string, visibility transcript.EntryVisibility) {
-	s.chatProjection().appendLocalEntryRecord(ChatEntry{Visibility: visibility, Role: role, Text: text}, nil)
+func (s *transcriptRuntimeState) AppendCommittedEntryWithVisibility(role, text string, visibility transcript.EntryVisibility, provenances ...*TranscriptCommittedRowProvenance) {
+	s.chatProjection().appendLocalEntryRecord(ChatEntry{Visibility: visibility, Role: role, Text: text}, nil, provenances...)
 }
 
 func (s *transcriptRuntimeState) AppendStreamingDelta(stepID string, baseRevision int64, baseCommittedEntryCount int, delta string, phase llm.MessagePhase) (*AssistantStreamMetadata, *uuid.UUID) {
@@ -278,7 +278,7 @@ func (s *transcriptRuntimeState) RecordAssistantStreamFinalization(committedEntr
 	s.chatProjection().recordAssistantStreamFinalization(committedEntryStart, streamID)
 }
 
-func (s *transcriptRuntimeState) RecordStoredToolCompletion(completion storedToolCompletion) {
+func (s *transcriptRuntimeState) RecordStoredToolCompletion(completion storedToolCompletion, provenance *TranscriptCommittedRowProvenance) {
 	s.chatProjection().recordToolCompletionWithProviderItems(tools.Result{
 		CallID:        completion.CallID,
 		Name:          toolspec.ID(completion.Name),
@@ -287,11 +287,11 @@ func (s *transcriptRuntimeState) RecordStoredToolCompletion(completion storedToo
 		Summary:       completion.Summary,
 		CondensedText: completion.CondensedText,
 		Presentation:  completion.Presentation,
-	}, completion.ProviderItems)
+	}, completion.ProviderItems, provenance)
 }
 
-func (s *transcriptRuntimeState) RestoreToolCompletionRecord(record session.ToolCompletionRecord) error {
-	return s.chatProjection().restoreToolCompletionRecord(record)
+func (s *transcriptRuntimeState) RestoreToolCompletionRecord(record session.ToolCompletionRecord, provenances ...*TranscriptCommittedRowProvenance) error {
+	return s.chatProjection().restoreToolCompletionRecord(record, provenances...)
 }
 
 func (s *transcriptRuntimeState) ReplaceHistoryAtCommittedEntryStart(
@@ -323,7 +323,7 @@ func (s *transcriptRuntimeState) ClearStreamingError() {
 	s.chatProjection().clearStreamingError()
 }
 
-func applyPersistedCacheWarningToTranscript(state *transcriptRuntimeState, record session.CacheWarningRecord, mode config.CacheWarningMode) {
+func applyPersistedCacheWarningToTranscript(state *transcriptRuntimeState, record session.CacheWarningRecord, mode config.CacheWarningMode, provenance ...*TranscriptCommittedRowProvenance) {
 	warning := cacheWarningFromSessionRecord(record)
-	state.AppendCommittedEntryWithVisibility(cacheWarningTranscriptRole, transcript.CacheWarningText(warning), cacheWarningEntryVisibility(mode))
+	state.AppendCommittedEntryWithVisibility(cacheWarningTranscriptRole, transcript.CacheWarningText(warning), cacheWarningEntryVisibility(mode), provenance...)
 }

--- a/server/runtime/transcript_scan.go
+++ b/server/runtime/transcript_scan.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 
 	"core/server/llm"
@@ -62,7 +63,9 @@ func (s *inMemoryTranscriptScan) ApplyMessage(msg llm.Message, seq int64, stepID
 	if s == nil {
 		return
 	}
-	for _, entry := range visibleChatEntriesFromMessage(msg, s.toolCompletions, s.materializedToolCalls) {
+	entries := visibleChatEntriesFromMessage(msg, s.toolCompletions, s.materializedToolCalls)
+	for index := range entries {
+		entry := &entries[index]
 		if strings.TrimSpace(entry.Role) == "user" && seq > 0 {
 			targetID := rollbacktarget.EncodeUserMessageSeq(seq)
 			entry.RollbackTargetID = &targetID
@@ -76,6 +79,14 @@ func (s *inMemoryTranscriptScan) ApplyMessage(msg llm.Message, seq int64, stepID
 				entry.CommittedProvenance = cloneTranscriptCommittedRowProvenance(owner)
 			}
 		}
+	}
+	sort.SliceStable(entries, func(left, right int) bool {
+		return transcriptCommittedProvenanceBefore(
+			entries[left].CommittedProvenance,
+			entries[right].CommittedProvenance,
+		)
+	})
+	for _, entry := range entries {
 		s.appendEntry(entry)
 	}
 }

--- a/server/runtime/transcript_scan.go
+++ b/server/runtime/transcript_scan.go
@@ -58,7 +58,7 @@ func newInMemoryTranscriptScan(req inMemoryTranscriptScanRequest, completions ma
 	}
 }
 
-func (s *inMemoryTranscriptScan) ApplyMessage(msg llm.Message, seq int64, stepID string) {
+func (s *inMemoryTranscriptScan) ApplyMessage(msg llm.Message, seq int64, stepID string, owners ...map[string]*TranscriptCommittedRowProvenance) {
 	if s == nil {
 		return
 	}
@@ -68,6 +68,14 @@ func (s *inMemoryTranscriptScan) ApplyMessage(msg llm.Message, seq int64, stepID
 			entry.RollbackTargetID = &targetID
 		}
 		entry.StepID = strings.TrimSpace(stepID)
+		if seq > 0 {
+			entry.CommittedProvenance = &TranscriptCommittedRowProvenance{EventSequence: seq}
+		}
+		if len(owners) > 0 && entry.ToolCallID != "" {
+			if owner := owners[0][entry.ToolCallID]; owner != nil {
+				entry.CommittedProvenance = cloneTranscriptCommittedRowProvenance(owner)
+			}
+		}
 		s.appendEntry(entry)
 	}
 }

--- a/server/runtimeview/transcript.go
+++ b/server/runtimeview/transcript.go
@@ -33,10 +33,14 @@ func TranscriptPageFromRuntime(engine *runtime.Engine, req clientui.TranscriptPa
 		engine.SessionName(),
 		ConversationFreshnessFromSession(freshness),
 		segment,
-	), nil
+	)
 }
 
-func TranscriptPageFromSegment(sessionID, sessionName string, freshness clientui.ConversationFreshness, page runtime.TranscriptSegmentPage) clientui.TranscriptPage {
+func TranscriptPageFromSegment(sessionID, sessionName string, freshness clientui.ConversationFreshness, page runtime.TranscriptSegmentPage) (clientui.TranscriptPage, error) {
+	entries, err := transcriptRowsFromFactsChecked(runtime.TranscriptCommittedRowFactsFromSnapshot(page.Snapshot))
+	if err != nil {
+		return clientui.TranscriptPage{}, err
+	}
 	return clientui.TranscriptPage{
 		SessionID:               sessionID,
 		SessionName:             sessionName,
@@ -46,8 +50,8 @@ func TranscriptPageFromSegment(sessionID, sessionName string, freshness clientui
 		NewerCursor:             transcriptCursor(page.HasMoreBelow, page.NewerCursor),
 		HasMoreBelow:            page.HasMoreBelow,
 		LatestRollbackCandidate: textutil.Pointer(page.LatestRollbackCandidate),
-		Entries:                 transcriptRowsFromFacts(runtime.TranscriptCommittedRowFactsFromSnapshot(page.Snapshot)),
-	}
+		Entries:                 entries,
+	}, nil
 }
 
 func transcriptCursor(hasMore bool, cursor int64) *int64 {

--- a/server/runtimeview/transcript_locator_projection_test.go
+++ b/server/runtimeview/transcript_locator_projection_test.go
@@ -1,0 +1,150 @@
+package runtimeview
+
+import (
+	"testing"
+
+	"core/server/llm"
+	"core/server/runtime"
+	"core/shared/clientui"
+	"core/shared/transcript"
+)
+
+func TestCommittedRowLocatorIsStableAcrossPageHydrationAndLiveProjection(t *testing.T) {
+	const (
+		sessionID = "12345678-1234-4234-8234-123456789012"
+		stepID    = "22222222-2222-4222-8222-222222222222"
+	)
+	provenance := &runtime.TranscriptCommittedRowProvenance{EventSequence: 17}
+	snapshot := runtime.ChatSnapshot{Entries: []runtime.ChatEntry{{
+		StepID:              stepID,
+		Visibility:          transcript.EntryVisibilityOngoing,
+		Role:                "user",
+		Text:                "hello",
+		CommittedProvenance: provenance,
+	}}}
+
+	page, err := TranscriptPageFromSegment(
+		sessionID,
+		"session",
+		clientui.ConversationFreshness(0),
+		runtime.TranscriptSegmentPage{Snapshot: snapshot},
+	)
+	if err != nil {
+		t.Fatalf("project page: %v", err)
+	}
+	hydration := TranscriptHydrationFromSnapshot(runtime.TranscriptHydrationSnapshot{
+		CommittedRows: runtime.TranscriptCommittedRowFactsFromSnapshot(snapshot),
+	})
+	live := TranscriptMessagesFromRuntimeEvent(runtime.Event{
+		Kind:                runtime.EventUserMessageFlushed,
+		StepID:              stepID,
+		UserMessage:         "hello",
+		CommittedProvenance: provenance,
+	})
+
+	if len(page.Entries) != 1 || len(hydration.CommittedRows) != 1 || len(live) != 1 {
+		t.Fatalf("projected rows: page=%d hydration=%d live=%d, want one each", len(page.Entries), len(hydration.CommittedRows), len(live))
+	}
+	liveRow := transcriptPayload[clientui.TranscriptCommittedRow](t, live[0])
+	if page.Entries[0].Locator != hydration.CommittedRows[0].Locator ||
+		page.Entries[0].Locator != liveRow.Locator {
+		t.Fatalf(
+			"locators disagree: page=%+v hydration=%+v live=%+v",
+			page.Entries[0].Locator,
+			hydration.CommittedRows[0].Locator,
+			liveRow.Locator,
+		)
+	}
+	if err := page.Entries[0].Locator.Validate(); err != nil {
+		t.Fatalf("projected locator is invalid: %v", err)
+	}
+}
+
+func TestCommittedRowLocatorNumbersProjectedRowsAfterFiltering(t *testing.T) {
+	const stepID = "22222222-2222-4222-8222-222222222222"
+	provenance := &runtime.TranscriptCommittedRowProvenance{EventSequence: 23}
+	facts := runtime.TranscriptCommittedRowFactsFromSnapshot(runtime.ChatSnapshot{
+		Entries: []runtime.ChatEntry{
+			{
+				StepID:              stepID,
+				Visibility:          transcript.EntryVisibilityHidden,
+				Role:                "assistant",
+				Text:                "internal",
+				CommittedProvenance: provenance,
+			},
+			{
+				StepID:              stepID,
+				Visibility:          transcript.EntryVisibilityOngoing,
+				Role:                "user",
+				Text:                "visible one",
+				CommittedProvenance: provenance,
+			},
+			{
+				StepID:              stepID,
+				Visibility:          transcript.EntryVisibilityDetail,
+				Role:                "assistant",
+				Text:                "visible two",
+				Phase:               llm.MessagePhaseCommentary,
+				CommittedProvenance: provenance,
+			},
+		},
+	})
+	if len(facts) != 2 {
+		t.Fatalf("projected facts = %d, want two visible rows", len(facts))
+	}
+	if got, want := facts[0].Locator.RowOrdinal, int64(1); got != want {
+		t.Fatalf("first projected ordinal = %d, want %d", got, want)
+	}
+	if got, want := facts[1].Locator.RowOrdinal, int64(2); got != want {
+		t.Fatalf("second projected ordinal = %d, want %d", got, want)
+	}
+	for index, fact := range facts {
+		if fact.Locator.EventSequence != 23 {
+			t.Fatalf("fact %d event sequence = %d, want 23", index, fact.Locator.EventSequence)
+		}
+	}
+}
+
+func TestCheckedTranscriptProjectionReturnsMalformedLocatorErrors(t *testing.T) {
+	const sessionID = "12345678-1234-4234-8234-123456789012"
+	const stepID = "22222222-2222-4222-8222-222222222222"
+	malformed := &runtime.TranscriptCommittedRowProvenance{}
+	snapshot := runtime.TranscriptHydrationSnapshot{
+		CommittedRows: []runtime.TranscriptCommittedRowFact{{
+			StepID:     stepID,
+			Kind:       runtime.TranscriptCommittedRowFactUser,
+			Locator:    transcript.CommittedRowLocator{},
+			Provenance: malformed,
+			User:       &runtime.TranscriptUserRowFact{Text: "malformed"},
+		}},
+	}
+	if _, err := TranscriptHydrationFromSnapshotChecked(snapshot); err == nil {
+		t.Fatal("checked hydration projection accepted malformed locator")
+	}
+
+	_, err := TranscriptPageFromSegment(
+		sessionID,
+		"session",
+		clientui.ConversationFreshness(0),
+		runtime.TranscriptSegmentPage{Snapshot: runtime.ChatSnapshot{Entries: []runtime.ChatEntry{{
+			StepID:              stepID,
+			Visibility:          transcript.EntryVisibilityOngoing,
+			Role:                "user",
+			Text:                "malformed",
+			CommittedProvenance: malformed,
+		}}}},
+	)
+	if err == nil {
+		t.Fatal("checked page projection accepted malformed locator")
+	}
+
+	_, err = TranscriptMessagesFromRuntimeEventChecked(runtime.Event{
+		Kind:                runtime.EventUserMessageFlushed,
+		StepID:              stepID,
+		UserMessage:         "malformed",
+		CommittedProvenance: malformed,
+	})
+	if err == nil {
+		t.Fatal("checked live projection accepted malformed locator")
+	}
+}

--- a/server/runtimeview/transcript_subscription.go
+++ b/server/runtimeview/transcript_subscription.go
@@ -17,8 +17,20 @@ import (
 )
 
 func TranscriptHydrationFromSnapshot(runtimeSnapshot runtime.TranscriptHydrationSnapshot) clientui.TranscriptHydration {
+	hydration, err := TranscriptHydrationFromSnapshotChecked(runtimeSnapshot)
+	if err != nil {
+		panic(err)
+	}
+	return hydration
+}
+
+func TranscriptHydrationFromSnapshotChecked(runtimeSnapshot runtime.TranscriptHydrationSnapshot) (clientui.TranscriptHydration, error) {
+	rows, err := transcriptRowsFromFactsChecked(runtimeSnapshot.CommittedRows)
+	if err != nil {
+		return clientui.TranscriptHydration{}, err
+	}
 	hydration := clientui.TranscriptHydration{
-		CommittedRows:   transcriptRowsFromFacts(runtimeSnapshot.CommittedRows),
+		CommittedRows:   rows,
 		ActiveAssistant: transcriptAssistantStream(runtimeSnapshot),
 	}
 	hydration.ActiveReasoning = transcriptReasoningStateFromRuntime(runtimeSnapshot.ActiveReasoning)
@@ -28,7 +40,7 @@ func TranscriptHydrationFromSnapshot(runtimeSnapshot runtime.TranscriptHydration
 	hydration.ActiveCompaction = transcriptCompactionStateFromRuntime(runtimeSnapshot.ActiveCompaction)
 	hydration.ContextUsage = transcriptContextUsageFromRuntime(runtimeSnapshot.ContextUsage)
 	hydration.GoalStatus = transcriptGoalStatusFromRuntime(runtimeSnapshot.Goal, runtimeSnapshot.GoalSuspended)
-	return hydration
+	return hydration, nil
 }
 
 func transcriptReasoningStateFromRuntime(state *runtime.TranscriptReasoningState) *clientui.TranscriptReasoningUpdate {
@@ -129,6 +141,19 @@ func transcriptToolStartsFromRuntime(starts []runtime.TranscriptLiveToolStart) [
 }
 
 func TranscriptMessagesFromRuntimeEvent(evt runtime.Event) []clientui.TranscriptEvent {
+	return transcriptMessagesFromRuntimeEvent(evt)
+}
+
+func TranscriptMessagesFromRuntimeEventChecked(evt runtime.Event) ([]clientui.TranscriptEvent, error) {
+	for index, fact := range runtime.TranscriptCommittedRowFactsFromEvent(evt) {
+		if err := fact.Locator.Validate(); err != nil {
+			return nil, fmt.Errorf("runtime committed row fact %d from event %q lacks valid provenance: %w", index, evt.Kind, err)
+		}
+	}
+	return transcriptMessagesFromRuntimeEvent(evt), nil
+}
+
+func transcriptMessagesFromRuntimeEvent(evt runtime.Event) []clientui.TranscriptEvent {
 	switch evt.Kind {
 	case runtime.EventAssistantDelta:
 		if evt.AssistantDelta == "" {
@@ -180,7 +205,7 @@ func TranscriptMessagesFromRuntimeEvent(evt runtime.Event) []clientui.Transcript
 		return transcriptLiveRunFinishedMessages(evt)
 	case runtime.EventReviewerStarted, runtime.EventReviewerCompleted:
 		return transcriptReviewerStateMessages(evt)
-	case runtime.EventSleepGuardFailed, runtime.EventPromptHistoryPersistFailed:
+	case runtime.EventSleepGuardFailed, runtime.EventPromptHistoryPersistFailed, runtime.EventInFlightClearFailed:
 		return transcriptOperationalDiagnosticMessages(evt)
 	case runtime.EventUserMessageFlushed:
 		messages := transcriptFeedStateMessages(evt)
@@ -403,6 +428,9 @@ func transcriptCommittedRowMessages(evt runtime.Event) []clientui.TranscriptEven
 	}
 	out := make([]clientui.TranscriptEvent, 0, len(rowFacts))
 	for _, fact := range rowFacts {
+		if err := fact.Locator.Validate(); err != nil {
+			panic(fmt.Sprintf("runtime committed row lacks valid provenance: event_kind=%q fact=%+v error=%v", evt.Kind, fact, err))
+		}
 		row := transcriptRowFromFact(fact)
 		out = append(out, clientui.NewTranscriptEvent(row))
 	}
@@ -410,14 +438,40 @@ func transcriptCommittedRowMessages(evt runtime.Event) []clientui.TranscriptEven
 }
 
 func transcriptRowsFromFacts(facts []runtime.TranscriptCommittedRowFact) []clientui.TranscriptCommittedRow {
-	if len(facts) == 0 {
-		return []clientui.TranscriptCommittedRow{}
-	}
-	rows := make([]clientui.TranscriptCommittedRow, 0, len(facts))
-	for _, fact := range facts {
-		rows = append(rows, transcriptRowFromFact(fact))
+	rows, err := transcriptRowsFromFactsChecked(facts)
+	if err != nil {
+		panic(err)
 	}
 	return rows
+}
+
+func transcriptRowsFromFactsChecked(facts []runtime.TranscriptCommittedRowFact) ([]clientui.TranscriptCommittedRow, error) {
+	if len(facts) == 0 {
+		return []clientui.TranscriptCommittedRow{}, nil
+	}
+	rows := make([]clientui.TranscriptCommittedRow, 0, len(facts))
+	for index, fact := range facts {
+		if err := fact.Locator.Validate(); err != nil {
+			return nil, fmt.Errorf(
+				"runtime hydrated committed row lacks valid provenance: fact_index=%d kind=%q step_id=%q provenance=%+v notice=%+v error=%v",
+				index,
+				fact.Kind,
+				fact.StepID,
+				fact.Provenance,
+				transcriptNoticeFactDiagnostic(fact.Notice),
+				err,
+			)
+		}
+		rows = append(rows, transcriptRowFromFact(fact))
+	}
+	return rows, nil
+}
+
+func transcriptNoticeFactDiagnostic(notice *runtime.TranscriptNoticeRowFact) any {
+	if notice == nil {
+		return nil
+	}
+	return *notice
 }
 
 func transcriptAssistantStream(snapshot runtime.TranscriptHydrationSnapshot) *clientui.TranscriptAssistantStream {
@@ -565,6 +619,8 @@ func transcriptOperationalDiagnosticMessages(evt runtime.Event) []clientui.Trans
 		diagnostic.Code = clientui.OperationalDiagnosticSleepGuardFailed
 	case runtime.EventPromptHistoryPersistFailed:
 		diagnostic.Code = clientui.OperationalDiagnosticPromptHistoryPersistFailed
+	case runtime.EventInFlightClearFailed:
+		diagnostic.Code = clientui.OperationalDiagnosticInFlightClearFailed
 	default:
 		panic(fmt.Sprintf("runtime event %q is not an operational diagnostic", evt.Kind))
 	}
@@ -575,6 +631,7 @@ func transcriptRowFromFact(fact runtime.TranscriptCommittedRowFact) clientui.Tra
 	row := clientui.TranscriptCommittedRow{
 		Visibility: fact.Visibility,
 		Integrity:  fact.Integrity,
+		Locator:    fact.Locator,
 	}
 	switch fact.Kind {
 	case runtime.TranscriptCommittedRowFactUser:

--- a/server/runtimeview/transcript_subscription_test.go
+++ b/server/runtimeview/transcript_subscription_test.go
@@ -132,6 +132,8 @@ func TestTranscriptHydrationPreservesDeletionDispositionPresence(t *testing.T) {
 					Visibility: transcript.EntryVisibilityOngoingCollapsed,
 					Integrity:  transcript.RowIntegrityValid,
 					Kind:       runtime.TranscriptCommittedRowFactTool,
+					Locator:    transcript.CommittedRowLocator{EventSequence: 1, RowOrdinal: 1},
+					Provenance: &runtime.TranscriptCommittedRowProvenance{EventSequence: 1},
 					Tool: &runtime.TranscriptToolRowFact{
 						ToolCallID: "call-delete",
 						ToolName:   "patch",
@@ -241,6 +243,9 @@ func TestTranscriptCommittedRowsPreserveRuntimeVisibility(t *testing.T) {
 			Visibility: transcript.EntryVisibilityDetail,
 			Role:       "user",
 			Text:       "detail-only row",
+			CommittedProvenance: &runtime.TranscriptCommittedRowProvenance{
+				EventSequence: 1,
+			},
 		},
 	})
 	if len(messages) != 1 {
@@ -256,7 +261,11 @@ func TestTranscriptCommittedRowsPreserveRuntimeVisibility(t *testing.T) {
 			StepID:     transcriptProjectionStepID,
 			Visibility: transcript.EntryVisibilityHidden,
 			Kind:       runtime.TranscriptCommittedRowFactUser,
+			Locator:    transcript.CommittedRowLocator{EventSequence: 2, RowOrdinal: 1},
 			User:       &runtime.TranscriptUserRowFact{Text: "hidden row"},
+			Provenance: &runtime.TranscriptCommittedRowProvenance{
+				EventSequence: 2,
+			},
 		}},
 	})
 	if len(hydration.CommittedRows) != 1 {
@@ -343,7 +352,7 @@ func TestTranscriptPagePreservesRollbackTargetIdentity(t *testing.T) {
 		UserMessageSeq:       91,
 		CandidatePageEndByte: 2048,
 	}
-	page := TranscriptPageFromSegment(
+	page, err := TranscriptPageFromSegment(
 		"58e121b5-30f7-4d0f-a1fa-fb3e6695e39c",
 		"name",
 		clientui.ConversationFreshnessEstablished,
@@ -354,9 +363,15 @@ func TestTranscriptPagePreservesRollbackTargetIdentity(t *testing.T) {
 				StepID:           transcriptProjectionStepID,
 				Text:             "persisted user prompt",
 				RollbackTargetID: &targetID,
+				CommittedProvenance: &runtime.TranscriptCommittedRowProvenance{
+					EventSequence: 5,
+				},
 			}}},
 		},
 	)
+	if err != nil {
+		t.Fatalf("project page: %v", err)
+	}
 
 	if len(page.Entries) != 1 || page.Entries[0].User == nil {
 		t.Fatalf("transcript page rows = %#v, want one user row", page.Entries)
@@ -372,8 +387,9 @@ func TestTranscriptPagePreservesRollbackTargetIdentity(t *testing.T) {
 func TestTranscriptProjectionCanonicalizesBlankPersistedAssistantPhase(t *testing.T) {
 	hydration := TranscriptHydrationFromSnapshot(runtime.TranscriptHydrationSnapshot{
 		CommittedRows: []runtime.TranscriptCommittedRowFact{{
-			StepID: transcriptProjectionStepID,
-			Kind:   runtime.TranscriptCommittedRowFactAssistant,
+			StepID:  transcriptProjectionStepID,
+			Kind:    runtime.TranscriptCommittedRowFactAssistant,
+			Locator: transcript.CommittedRowLocator{EventSequence: 3, RowOrdinal: 1},
 			Assistant: &runtime.TranscriptAssistantRowFact{
 				Text: "legacy final answer",
 			},
@@ -390,9 +406,9 @@ func TestTranscriptProjectionCanonicalizesBlankPersistedAssistantPhase(t *testin
 func TestTranscriptPageProjectsReviewerAndBackgroundMetadata(t *testing.T) {
 	exitCode := 9
 	activityID := uuid.New()
-	page := TranscriptPageFromSegment("58e121b5-30f7-4d0f-a1fa-fb3e6695e39c", "name", clientui.ConversationFreshnessEstablished, runtime.TranscriptSegmentPage{
+	page, err := TranscriptPageFromSegment("58e121b5-30f7-4d0f-a1fa-fb3e6695e39c", "name", clientui.ConversationFreshnessEstablished, runtime.TranscriptSegmentPage{
 		Snapshot: runtime.ChatSnapshot{Entries: []runtime.ChatEntry{
-			{Role: "reviewer_status", Text: "review complete"},
+			{Role: "reviewer_status", Text: "review complete", CommittedProvenance: &runtime.TranscriptCommittedRowProvenance{EventSequence: 6}},
 			{
 				Role:                 "system",
 				Text:                 "background failed",
@@ -400,9 +416,13 @@ func TestTranscriptPageProjectsReviewerAndBackgroundMetadata(t *testing.T) {
 				BackgroundActivityID: activityID.String(),
 				BackgroundProcessID:  "process-1",
 				BackgroundExitCode:   &exitCode,
+				CommittedProvenance:  &runtime.TranscriptCommittedRowProvenance{EventSequence: 7},
 			},
 		}},
 	})
+	if err != nil {
+		t.Fatalf("project page: %v", err)
+	}
 
 	if len(page.Entries) != 2 {
 		t.Fatalf("page entries = %+v", page.Entries)
@@ -538,6 +558,9 @@ func TestTranscriptBackgroundNoticeCarriesTypedExitCode(t *testing.T) {
 	messages := TranscriptMessagesFromRuntimeEvent(runtime.Event{
 		Kind:   runtime.EventConversationUpdated,
 		StepID: transcriptProjectionStepID,
+		CommittedProvenance: &runtime.TranscriptCommittedRowProvenance{
+			EventSequence: 1,
+		},
 		Message: llm.Message{
 			Role:                 llm.RoleDeveloper,
 			Name:                 textutil.Value("process-1"),
@@ -574,6 +597,9 @@ func TestTranscriptWorktreeNoticeCarriesTypedContextWithoutServerPresentation(t 
 	}
 	messages := TranscriptMessagesFromRuntimeEvent(runtime.Event{
 		Kind: runtime.EventConversationUpdated,
+		CommittedProvenance: &runtime.TranscriptCommittedRowProvenance{
+			EventSequence: 2,
+		},
 		Message: llm.Message{
 			Role:            llm.RoleDeveloper,
 			MessageType:     textutil.Value(llm.MessageTypeWorktreeMode),
@@ -616,6 +642,9 @@ func TestTranscriptWorktreeNoticeKeepsMissingBranchNullable(t *testing.T) {
 	}
 	messages := TranscriptMessagesFromRuntimeEvent(runtime.Event{
 		Kind: runtime.EventConversationUpdated,
+		CommittedProvenance: &runtime.TranscriptCommittedRowProvenance{
+			EventSequence: 3,
+		},
 		Message: llm.Message{
 			Role:            llm.RoleDeveloper,
 			MessageType:     textutil.Value(llm.MessageTypeWorktreeMode),
@@ -664,6 +693,9 @@ func TestAssistantTranscriptMessagesDoNotReemitLiveToolStarts(t *testing.T) {
 			messages := TranscriptMessagesFromRuntimeEvent(runtime.Event{
 				Kind:   kind,
 				StepID: transcriptProjectionStepID,
+				CommittedProvenance: &runtime.TranscriptCommittedRowProvenance{
+					EventSequence: 4,
+				},
 				Message: llm.Message{
 					Role:    llm.RoleAssistant,
 					Content: textutil.Value("checking the repo"),
@@ -685,5 +717,23 @@ func TestAssistantTranscriptMessagesDoNotReemitLiveToolStarts(t *testing.T) {
 				t.Fatalf("message = %+v, want assistant committed row", messages[0])
 			}
 		})
+	}
+}
+
+func TestInFlightClearFailureIsOperationalDiagnosticOnly(t *testing.T) {
+	event := runtime.Event{
+		Kind:   runtime.EventInFlightClearFailed,
+		StepID: transcriptProjectionStepID,
+	}
+	if facts := runtime.TranscriptCommittedRowFactsFromEvent(event); len(facts) != 0 {
+		t.Fatalf("in-flight clear failure committed facts = %+v, want none", facts)
+	}
+	messages := TranscriptMessagesFromRuntimeEvent(event)
+	if len(messages) != 1 || messages[0].Kind() != clientui.TranscriptMessageOperationalDiagnostic {
+		t.Fatalf("in-flight clear failure messages = %+v, want one operational diagnostic", messages)
+	}
+	diagnostic := transcriptPayload[clientui.TranscriptOperationalDiagnostic](t, messages[0])
+	if diagnostic.Code != clientui.OperationalDiagnosticInFlightClearFailed {
+		t.Fatalf("diagnostic code = %q, want %q", diagnostic.Code, clientui.OperationalDiagnosticInFlightClearFailed)
 	}
 }

--- a/server/sessionview/service.go
+++ b/server/sessionview/service.go
@@ -18,6 +18,7 @@ import (
 	servicecontract "core/shared/apicontract"
 	"core/shared/clientui"
 	"core/shared/config"
+	"core/shared/invariant"
 	"core/shared/serverapi"
 )
 
@@ -179,7 +180,27 @@ func (s *Service) GetSessionTranscriptPage(ctx context.Context, req serverapi.Se
 	if err != nil {
 		return serverapi.SessionTranscriptPageResponse{}, err
 	}
-	return serverapi.SessionTranscriptPageResponse{Transcript: page}, nil
+	response := serverapi.SessionTranscriptPageResponse{Transcript: page}
+	if err := validateSessionTranscriptPageResponse(response); err != nil {
+		return serverapi.SessionTranscriptPageResponse{}, err
+	}
+	return response, nil
+}
+
+func validateSessionTranscriptPageResponse(response serverapi.SessionTranscriptPageResponse) error {
+	if err := response.Validate(); err != nil {
+		invariant.NewPolicy().Check(false, invariant.ReadModelPublicationDiagnostic(
+			invariant.ReadModelPublicationDiagnosticInput{
+				Operation:        "session_view.transcript_page",
+				SessionID:        response.Transcript.SessionID,
+				PublicationCause: err.Error(),
+				OwnerSnapshots:   "canonical_transcript_page",
+				ResolverInputs:   "session_transcript_page",
+			},
+		))
+		return fmt.Errorf("validate session transcript page response: %w", err)
+	}
+	return nil
 }
 
 func (s *Service) GetLatestCommittedAssistantFinalAnswer(ctx context.Context, req serverapi.SessionLatestCommittedAssistantFinalAnswerRequest) (serverapi.SessionLatestCommittedAssistantFinalAnswerResponse, error) {

--- a/server/sessionview/service_test.go
+++ b/server/sessionview/service_test.go
@@ -16,6 +16,7 @@ import (
 	"core/shared/config"
 	"core/shared/runtimeids"
 	"core/shared/serverapi"
+	"core/shared/transcript"
 )
 
 type serviceFakeLLM struct {
@@ -43,6 +44,36 @@ type serviceBlockingLLM struct {
 
 type staticExecutionTargetResolver struct {
 	target clientui.SessionExecutionTarget
+}
+
+func TestValidateSessionTranscriptPageResponseUsesInvariantFailurePolicy(t *testing.T) {
+	response := serverapi.SessionTranscriptPageResponse{
+		Transcript: clientui.TranscriptPage{
+			SessionID: "12345678-1234-4234-8234-123456789012",
+			Entries: []clientui.TranscriptCommittedRow{{
+				Visibility: transcript.EntryVisibilityOngoing,
+				Kind:       clientui.TranscriptRowUser,
+				Locator:    transcript.CommittedRowLocator{EventSequence: 0, RowOrdinal: 1},
+				User:       &clientui.TranscriptUserRow{Text: "malformed"},
+			}},
+		},
+	}
+
+	t.Run("diagnostic mode returns contract error", func(t *testing.T) {
+		t.Setenv("KENT_INVARIANT_MODE", "diagnostic")
+		if err := validateSessionTranscriptPageResponse(response); err == nil {
+			t.Fatal("malformed transcript page returned nil error")
+		}
+	})
+	t.Run("panic mode fails fast with diagnostic", func(t *testing.T) {
+		t.Setenv("KENT_INVARIANT_MODE", "panic")
+		defer func() {
+			if recover() == nil {
+				t.Fatal("malformed transcript page did not panic in invariant panic mode")
+			}
+		}()
+		_ = validateSessionTranscriptPageResponse(response)
+	})
 }
 
 func (r staticExecutionTargetResolver) ResolveSessionExecutionTarget(context.Context, string) (clientui.SessionExecutionTarget, error) {

--- a/server/sessionview/snapshot.go
+++ b/server/sessionview/snapshot.go
@@ -324,5 +324,5 @@ func (s dormantSessionSnapshot) transcriptPage(segment runtime.TranscriptSegment
 		meta.Name,
 		runtimeview.ConversationFreshnessFromSession(freshness),
 		segment,
-	), nil
+	)
 }

--- a/shared/client/remote.go
+++ b/shared/client/remote.go
@@ -653,7 +653,13 @@ func (c *Remote) GetSessionMainView(ctx context.Context, req serverapi.SessionMa
 
 func (c *Remote) GetSessionTranscriptPage(ctx context.Context, req serverapi.SessionTranscriptPageRequest) (serverapi.SessionTranscriptPageResponse, error) {
 	var resp serverapi.SessionTranscriptPageResponse
-	return resp, c.call(ctx, protocol.MethodSessionGetTranscriptPage, req, &resp)
+	if err := c.call(ctx, protocol.MethodSessionGetTranscriptPage, req, &resp); err != nil {
+		return resp, err
+	}
+	if err := resp.Validate(); err != nil {
+		return serverapi.SessionTranscriptPageResponse{}, fmt.Errorf("validate session transcript page response: %w", err)
+	}
+	return resp, nil
 }
 
 func (c *Remote) GetLatestCommittedAssistantFinalAnswer(ctx context.Context, req serverapi.SessionLatestCommittedAssistantFinalAnswerRequest) (serverapi.SessionLatestCommittedAssistantFinalAnswerResponse, error) {

--- a/shared/client/remote_stream.go
+++ b/shared/client/remote_stream.go
@@ -99,8 +99,11 @@ func (c *Remote) SubscribeSessionTranscript(ctx context.Context, req serverapi.T
 	if err != nil {
 		return nil, err
 	}
-	return newRemoteSubscription(conn, route, func(params protocol.SessionTranscriptEventParams) clientui.TranscriptMessage {
-		return params.Message
+	return newRemoteSubscriptionWithError(conn, route, func(params protocol.SessionTranscriptEventParams) (clientui.TranscriptMessage, error) {
+		if err := params.Message.Validate(); err != nil {
+			return clientui.TranscriptMessage{}, err
+		}
+		return params.Message, nil
 	}), nil
 }
 

--- a/shared/client/transcript_locator_remote_contract_test.go
+++ b/shared/client/transcript_locator_remote_contract_test.go
@@ -1,0 +1,119 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"core/shared/clientui"
+	"core/shared/protocol"
+	"core/shared/runtimeids"
+	"core/shared/serverapi"
+
+	"golang.org/x/net/websocket"
+)
+
+func TestRemoteTranscriptPageRejectsMalformedLocatorPayload(t *testing.T) {
+	server := newRemoteTestServer(t, func(ws *websocket.Conn) {
+		acceptRemoteHandshake(t, ws)
+		var request protocol.Request
+		if err := websocket.JSON.Receive(ws, &request); err != nil {
+			t.Fatalf("receive transcript page request: %v", err)
+		}
+		if request.Method != protocol.MethodSessionGetTranscriptPage {
+			t.Fatalf("method = %q, want transcript page", request.Method)
+		}
+		response := serverapi.SessionTranscriptPageResponse{
+			Transcript: clientui.TranscriptPage{
+				SessionID: "12345678-1234-4234-8234-123456789012",
+				Entries: []clientui.TranscriptCommittedRow{{
+					Visibility: clientui.EntryVisibilityOngoing,
+					Kind:       clientui.TranscriptRowAssistant,
+					Assistant: &clientui.TranscriptAssistantRow{
+						StepID: transcriptRemoteTestStepID(t),
+						Text:   "done",
+						Phase:  "final_answer",
+					},
+				}},
+			},
+		}
+		if err := websocket.JSON.Send(ws, protocol.NewSuccessResponse(request.ID, response)); err != nil {
+			t.Fatalf("send transcript page response: %v", err)
+		}
+	})
+
+	remote, err := DialRemoteURL(context.Background(), "ws"+server.URL[len("http"):])
+	if err != nil {
+		t.Fatalf("dial remote: %v", err)
+	}
+	defer func() { _ = remote.Close() }()
+
+	if _, err := remote.GetSessionTranscriptPage(context.Background(), serverapi.SessionTranscriptPageRequest{
+		SessionID: "12345678-1234-4234-8234-123456789012",
+	}); err == nil {
+		t.Fatal("accepted transcript page with missing locator")
+	}
+}
+
+func TestRemoteTranscriptSubscriptionRejectsMalformedLocatorPayload(t *testing.T) {
+	server := newRemoteTestServer(t, func(ws *websocket.Conn) {
+		req := acceptRemoteHandshake(t, ws)
+		if err := websocket.JSON.Receive(ws, &req); err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			t.Fatalf("receive attach request: %v", err)
+		}
+		if err := websocket.JSON.Send(ws, protocol.NewSuccessResponse(req.ID, testSessionAttachResponse(t, "project-1", "workspace-1", "/workspace", "session-1"))); err != nil {
+			t.Fatalf("send attach response: %v", err)
+		}
+		if err := websocket.JSON.Receive(ws, &req); err != nil {
+			t.Fatalf("receive subscribe request: %v", err)
+		}
+		if err := websocket.JSON.Send(ws, protocol.NewSuccessResponse(req.ID, protocol.SubscribeResponse{})); err != nil {
+			t.Fatalf("send subscribe response: %v", err)
+		}
+		message := clientui.NewTranscriptMessage(2, clientui.NewTranscriptEvent(clientui.TranscriptCommittedRow{
+			Visibility: clientui.EntryVisibilityOngoing,
+			Kind:       clientui.TranscriptRowAssistant,
+			Assistant: &clientui.TranscriptAssistantRow{
+				StepID: transcriptRemoteTestStepID(t),
+				Text:   "done",
+				Phase:  "final_answer",
+			},
+		}))
+		params := protocol.SessionTranscriptEventParams{Message: message}
+		if err := websocket.JSON.Send(ws, protocol.Request{
+			JSONRPC: protocol.JSONRPCVersion,
+			Method:  protocol.MethodSessionTranscriptEvent,
+			Params:  mustJSON(t, params),
+		}); err != nil {
+			t.Fatalf("send transcript event: %v", err)
+		}
+	})
+
+	remote, err := DialRemoteURL(context.Background(), "ws"+server.URL[len("http"):])
+	if err != nil {
+		t.Fatalf("dial remote: %v", err)
+	}
+	defer func() { _ = remote.Close() }()
+	sub, err := remote.SubscribeSessionTranscript(context.Background(), serverapi.TranscriptSubscribeRequest{SessionID: "session-1"})
+	if err != nil {
+		t.Fatalf("subscribe transcript: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+
+	if _, err := sub.Next(context.Background()); err == nil || !errors.Is(err, serverapi.ErrStreamFailed) {
+		t.Fatalf("malformed transcript event error = %v, want stream failure", err)
+	}
+}
+
+func transcriptRemoteTestStepID(t *testing.T) runtimeids.StepID {
+	t.Helper()
+	id, err := runtimeids.ParseStepID("22222222-2222-4222-8222-222222222222")
+	if err != nil {
+		t.Fatalf("parse step id: %v", err)
+	}
+	return id
+}

--- a/shared/clientui/transcript_hydration_validation.go
+++ b/shared/clientui/transcript_hydration_validation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"core/shared/runtimeids"
+	"core/shared/transcript"
 )
 
 func (h TranscriptHydration) Validate() error {
@@ -19,10 +20,15 @@ func (h TranscriptHydration) Validate() error {
 	if h.CommittedRows == nil {
 		return fmt.Errorf("transcript hydration committed rows are required")
 	}
+	seenLocators := make(map[transcript.CommittedRowLocator]struct{}, len(h.CommittedRows))
 	for index, row := range h.CommittedRows {
 		if err := row.Validate(); err != nil {
 			return fmt.Errorf("validate transcript hydration committed row %d: %w", index, err)
 		}
+		if _, exists := seenLocators[row.Locator]; exists {
+			return fmt.Errorf("transcript hydration repeats committed row locator %+v", row.Locator)
+		}
+		seenLocators[row.Locator] = struct{}{}
 	}
 	if h.ActiveAssistant != nil {
 		if err := h.ActiveAssistant.Validate(); err != nil {

--- a/shared/clientui/transcript_locator_contract_test.go
+++ b/shared/clientui/transcript_locator_contract_test.go
@@ -1,0 +1,114 @@
+package clientui
+
+import (
+	"encoding/json"
+	"testing"
+
+	"core/shared/transcript"
+)
+
+func TestCommittedRowLocatorRequiresPositiveComparableComponents(t *testing.T) {
+	valid := transcript.CommittedRowLocator{
+		EventSequence: 12,
+		RowOrdinal:    3,
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("validate committed row locator: %v", err)
+	}
+	if valid != (transcript.CommittedRowLocator{EventSequence: 12, RowOrdinal: 3}) {
+		t.Fatalf("committed row locator is not comparable: %+v", valid)
+	}
+
+	for _, invalid := range []transcript.CommittedRowLocator{
+		{},
+		{EventSequence: 0, RowOrdinal: 1},
+		{EventSequence: 1, RowOrdinal: 0},
+		{EventSequence: -1, RowOrdinal: 1},
+		{EventSequence: 1, RowOrdinal: -1},
+	} {
+		if err := invalid.Validate(); err == nil {
+			t.Fatalf("accepted invalid committed row locator: %+v", invalid)
+		}
+	}
+}
+
+func TestCommittedRowRequiresLocatorAndPreservesItThroughJSON(t *testing.T) {
+	row := transcriptLocatorTestAssistantRow(t)
+	if err := row.Validate(); err != nil {
+		t.Fatalf("validate committed row: %v", err)
+	}
+
+	data, err := json.Marshal(NewTranscriptMessage(2, NewTranscriptEvent(row)))
+	if err != nil {
+		t.Fatalf("marshal committed row message: %v", err)
+	}
+	var decoded TranscriptMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal committed row message: %v", err)
+	}
+	if err := decoded.ValidatePayload(); err != nil {
+		t.Fatalf("validate decoded committed row message: %v", err)
+	}
+	got := decoded.Payload().(TranscriptCommittedRow)
+	if got.Locator != row.Locator {
+		t.Fatalf("decoded locator = %+v, want %+v", got.Locator, row.Locator)
+	}
+
+	row.Locator = transcript.CommittedRowLocator{}
+	if err := row.Validate(); err == nil {
+		t.Fatal("accepted committed row without a valid locator")
+	}
+}
+
+func TestTranscriptHydrationRequiresUniqueLocatorsAndPreservesThemThroughJSON(t *testing.T) {
+	row := transcriptLocatorTestAssistantRow(t)
+	hydration := TranscriptHydration{
+		SessionIdentity:        transcriptTestSessionIdentity(t),
+		SessionStatus:          transcriptTestSessionStatus(),
+		RuntimeReadModelUpdate: transcriptTestRuntimeReadModelUpdate(t),
+		CommittedRows:          []TranscriptCommittedRow{row},
+	}
+	if err := hydration.Validate(); err != nil {
+		t.Fatalf("validate hydration: %v", err)
+	}
+
+	data, err := json.Marshal(NewTranscriptMessage(1, NewTranscriptEvent(hydration)))
+	if err != nil {
+		t.Fatalf("marshal hydration: %v", err)
+	}
+	var decoded TranscriptMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal hydration: %v", err)
+	}
+	if err := decoded.ValidatePayload(); err != nil {
+		t.Fatalf("validate decoded hydration: %v", err)
+	}
+	got := decoded.Payload().(TranscriptHydration)
+	if got.CommittedRows[0].Locator != row.Locator {
+		t.Fatalf("hydration locator = %+v, want %+v", got.CommittedRows[0].Locator, row.Locator)
+	}
+
+	duplicate := hydration
+	duplicate.CommittedRows = []TranscriptCommittedRow{row, row}
+	if err := duplicate.Validate(); err == nil {
+		t.Fatal("accepted duplicate committed row locator in hydration")
+	}
+}
+
+func transcriptLocatorTestAssistantRow(t *testing.T) TranscriptCommittedRow {
+	t.Helper()
+	return TranscriptCommittedRow{
+		Visibility: transcript.EntryVisibilityOngoing,
+		Integrity:  transcript.RowIntegrityValid,
+		Kind:       TranscriptRowAssistant,
+		Locator: transcript.CommittedRowLocator{
+			EventSequence: 12,
+			RowOrdinal:    1,
+		},
+		Assistant: &TranscriptAssistantRow{
+			StepID: transcriptTestStepID(t),
+			Text:   "Done",
+			Phase:  transcript.AssistantPhaseFinal,
+		},
+	}
+}

--- a/shared/clientui/transcript_message_union_test.go
+++ b/shared/clientui/transcript_message_union_test.go
@@ -55,6 +55,7 @@ func TestTranscriptEventPayloadsUseOneTypedConstructionPath(t *testing.T) {
 			Visibility: transcript.EntryVisibilityOngoing,
 			Integrity:  transcript.RowIntegrityValid,
 			Kind:       TranscriptRowAssistant,
+			Locator:    transcript.CommittedRowLocator{EventSequence: 1, RowOrdinal: 1},
 			Assistant: &TranscriptAssistantRow{
 				StepID: transcriptTestStepID(t),
 				Text:   "Done",

--- a/shared/clientui/transcript_operation.go
+++ b/shared/clientui/transcript_operation.go
@@ -21,6 +21,7 @@ type OperationalDiagnosticCode string
 const (
 	OperationalDiagnosticSleepGuardFailed           OperationalDiagnosticCode = "sleep_guard_failed"
 	OperationalDiagnosticPromptHistoryPersistFailed OperationalDiagnosticCode = "prompt_history_persist_failed"
+	OperationalDiagnosticInFlightClearFailed        OperationalDiagnosticCode = "in_flight_clear_failed"
 )
 
 type TranscriptOperationalDiagnostic struct {
@@ -73,7 +74,8 @@ func (o TranscriptWorktreeTransitionOutcome) Validate() error {
 func (d TranscriptOperationalDiagnostic) Validate() error {
 	switch d.Code {
 	case OperationalDiagnosticSleepGuardFailed,
-		OperationalDiagnosticPromptHistoryPersistFailed:
+		OperationalDiagnosticPromptHistoryPersistFailed,
+		OperationalDiagnosticInFlightClearFailed:
 	default:
 		return fmt.Errorf("unknown operational diagnostic code %q", d.Code)
 	}

--- a/shared/clientui/transcript_row.go
+++ b/shared/clientui/transcript_row.go
@@ -21,6 +21,7 @@ type TranscriptCommittedRow struct {
 	Visibility transcript.EntryVisibility
 	Integrity  transcript.RowIntegrity
 	Kind       TranscriptRowKind
+	Locator    transcript.CommittedRowLocator
 	User       *TranscriptUserRow
 	Assistant  *TranscriptAssistantRow
 	Tool       *TranscriptToolRow
@@ -149,6 +150,9 @@ type TranscriptBackgroundNoticeIdentity struct {
 }
 
 func (r TranscriptCommittedRow) Validate() error {
+	if err := r.Locator.Validate(); err != nil {
+		return fmt.Errorf("transcript committed row locator: %w", err)
+	}
 	switch r.Visibility {
 	case transcript.EntryVisibilityOngoing,
 		transcript.EntryVisibilityOngoingCollapsed,

--- a/shared/clientui/transcript_row_test.go
+++ b/shared/clientui/transcript_row_test.go
@@ -12,6 +12,7 @@ func TestTranscriptCommittedAssistantRowCarriesStepAndOptionalStreamIdentity(t *
 		Visibility: transcript.EntryVisibilityOngoing,
 		Integrity:  transcript.RowIntegrityValid,
 		Kind:       TranscriptRowAssistant,
+		Locator:    transcript.CommittedRowLocator{EventSequence: 1, RowOrdinal: 1},
 		Assistant: &TranscriptAssistantRow{
 			StepID: transcriptTestStepID(t),
 			Text:   "Done",
@@ -28,6 +29,7 @@ func TestTranscriptCommittedRowRejectsImplicitVisibilityAndMismatchedPayload(t *
 		Visibility: transcript.EntryVisibilityOngoing,
 		Integrity:  transcript.RowIntegrityValid,
 		Kind:       TranscriptRowAssistant,
+		Locator:    transcript.CommittedRowLocator{EventSequence: 1, RowOrdinal: 1},
 		Assistant: &TranscriptAssistantRow{
 			StepID: transcriptTestStepID(t),
 			Text:   "Done",

--- a/shared/invariant/transcript.go
+++ b/shared/invariant/transcript.go
@@ -11,6 +11,9 @@ import (
 )
 
 func ValidateTranscriptCommittedRow(row clientui.TranscriptCommittedRow) error {
+	if err := row.Locator.Validate(); err != nil {
+		return fmt.Errorf("committed row locator: %w", err)
+	}
 	if !row.Integrity.Valid() {
 		return fmt.Errorf("committed row has invalid integrity %d", row.Integrity)
 	}
@@ -82,10 +85,15 @@ func ValidateTranscriptPage(page clientui.TranscriptPage) error {
 			return fmt.Errorf("transcript page latest rollback candidate: %w", err)
 		}
 	}
+	seenTranscriptLocators := make(map[transcript.CommittedRowLocator]struct{}, len(page.Entries))
 	for index, row := range page.Entries {
 		if err := ValidateTranscriptCommittedRow(row); err != nil {
 			return fmt.Errorf("transcript page entry %d: %w", index, err)
 		}
+		if _, exists := seenTranscriptLocators[row.Locator]; exists {
+			return fmt.Errorf("transcript page repeats committed row locator %+v", row.Locator)
+		}
+		seenTranscriptLocators[row.Locator] = struct{}{}
 	}
 	return nil
 }

--- a/shared/invariant/transcript_locator_contract_test.go
+++ b/shared/invariant/transcript_locator_contract_test.go
@@ -1,0 +1,44 @@
+package invariant
+
+import (
+	"testing"
+
+	"core/shared/clientui"
+	"core/shared/runtimeids"
+	"core/shared/transcript"
+)
+
+func TestValidateTranscriptPageRejectsDuplicateLocatorsButAllowsIndependentRecurrence(t *testing.T) {
+	stepID, err := runtimeids.ParseStepID("22222222-2222-4222-8222-222222222222")
+	if err != nil {
+		t.Fatalf("parse step id: %v", err)
+	}
+	row := clientui.TranscriptCommittedRow{
+		Visibility: transcript.EntryVisibilityOngoing,
+		Integrity:  transcript.RowIntegrityValid,
+		Kind:       clientui.TranscriptRowUser,
+		Locator: transcript.CommittedRowLocator{
+			EventSequence: 8,
+			RowOrdinal:    1,
+		},
+		User: &clientui.TranscriptUserRow{
+			StepID: stepID,
+			Text:   "hello",
+		},
+	}
+	page := clientui.TranscriptPage{
+		SessionID: "12345678-1234-4234-8234-123456789012",
+		Entries:   []clientui.TranscriptCommittedRow{row},
+	}
+	if err := ValidateTranscriptPage(page); err != nil {
+		t.Fatalf("validate page: %v", err)
+	}
+	if err := ValidateTranscriptPage(page); err != nil {
+		t.Fatalf("independent recurrence rejected: %v", err)
+	}
+
+	page.Entries = []clientui.TranscriptCommittedRow{row, row}
+	if err := ValidateTranscriptPage(page); err == nil {
+		t.Fatal("accepted duplicate committed row locator in one page")
+	}
+}

--- a/shared/invariant/transcript_test.go
+++ b/shared/invariant/transcript_test.go
@@ -22,16 +22,19 @@ func TestValidateTranscriptCommittedRow(t *testing.T) {
 		{
 			Visibility: clientui.EntryVisibilityOngoing,
 			Kind:       clientui.TranscriptRowUser,
+			Locator:    transcript.CommittedRowLocator{EventSequence: 1, RowOrdinal: 1},
 			User:       &clientui.TranscriptUserRow{StepID: stepID, Text: "user", RollbackTargetID: &rollbackTargetID},
 		},
 		{
 			Visibility: clientui.EntryVisibilityOngoingCollapsed,
 			Kind:       clientui.TranscriptRowAssistant,
+			Locator:    transcript.CommittedRowLocator{EventSequence: 2, RowOrdinal: 1},
 			Assistant:  &clientui.TranscriptAssistantRow{StepID: stepID, Text: "assistant", StreamID: &streamID},
 		},
 		{
 			Visibility: clientui.EntryVisibilityDetail,
 			Kind:       clientui.TranscriptRowTool,
+			Locator:    transcript.CommittedRowLocator{EventSequence: 3, RowOrdinal: 1},
 			Tool: &clientui.TranscriptToolRow{
 				StepID:     stepID,
 				ToolCallID: "tool-call",
@@ -41,6 +44,7 @@ func TestValidateTranscriptCommittedRow(t *testing.T) {
 		{
 			Visibility: clientui.EntryVisibilityHidden,
 			Kind:       clientui.TranscriptRowNotice,
+			Locator:    transcript.CommittedRowLocator{EventSequence: 4, RowOrdinal: 1},
 			Notice:     &clientui.TranscriptNoticeRow{},
 		},
 	}
@@ -75,12 +79,14 @@ func TestValidateTranscriptCommittedRow(t *testing.T) {
 			Visibility: clientui.EntryVisibilityDetail,
 			Integrity:  transcript.RowIntegrityRecoverableMalformed,
 			Kind:       clientui.TranscriptRowTool,
+			Locator:    transcript.CommittedRowLocator{EventSequence: 5, RowOrdinal: 1},
 			Tool:       &clientui.TranscriptToolRow{},
 		},
 		{
 			Visibility: clientui.EntryVisibilityDetail,
 			Integrity:  transcript.RowIntegrityUnrecoverableMalformed,
 			Kind:       clientui.TranscriptRowTool,
+			Locator:    transcript.CommittedRowLocator{EventSequence: 6, RowOrdinal: 1},
 			Tool:       &clientui.TranscriptToolRow{ToolCallID: " "},
 		},
 	}
@@ -105,18 +111,20 @@ func TestValidateTranscriptPage(t *testing.T) {
 			CandidatePageEndByte: 15,
 		},
 		Entries: []clientui.TranscriptCommittedRow{
-			{Visibility: clientui.EntryVisibilityOngoing, Kind: clientui.TranscriptRowUser, User: &clientui.TranscriptUserRow{Text: "valid"}},
-			{Visibility: clientui.EntryVisibilityHidden, Kind: clientui.TranscriptRowNotice, Notice: &clientui.TranscriptNoticeRow{}},
+			{Visibility: clientui.EntryVisibilityOngoing, Kind: clientui.TranscriptRowUser, Locator: transcript.CommittedRowLocator{EventSequence: 1, RowOrdinal: 1}, User: &clientui.TranscriptUserRow{Text: "valid"}},
+			{Visibility: clientui.EntryVisibilityHidden, Kind: clientui.TranscriptRowNotice, Locator: transcript.CommittedRowLocator{EventSequence: 2, RowOrdinal: 1}, Notice: &clientui.TranscriptNoticeRow{}},
 			{
 				Visibility: clientui.EntryVisibilityDetail,
 				Integrity:  transcript.RowIntegrityRecoverableMalformed,
 				Kind:       clientui.TranscriptRowTool,
+				Locator:    transcript.CommittedRowLocator{EventSequence: 3, RowOrdinal: 1},
 				Tool:       &clientui.TranscriptToolRow{},
 			},
 			{
 				Visibility: clientui.EntryVisibilityOngoingCollapsed,
 				Integrity:  transcript.RowIntegrityUnrecoverableMalformed,
 				Kind:       clientui.TranscriptRowTool,
+				Locator:    transcript.CommittedRowLocator{EventSequence: 4, RowOrdinal: 1},
 				Tool:       &clientui.TranscriptToolRow{},
 			},
 		},

--- a/shared/protocol/version.json
+++ b/shared/protocol/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "90"
+  "version": "91"
 }

--- a/shared/serverapi/session_view.go
+++ b/shared/serverapi/session_view.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"core/shared/clientui"
+	"core/shared/invariant"
 )
 
 // ErrLimitNegative is returned when a request supplies a negative limit.
@@ -28,6 +29,10 @@ type SessionTranscriptPageRequest struct {
 
 type SessionTranscriptPageResponse struct {
 	Transcript clientui.TranscriptPage `json:"transcript"`
+}
+
+func (r SessionTranscriptPageResponse) Validate() error {
+	return invariant.ValidateTranscriptPage(r.Transcript)
 }
 
 type SessionLatestCommittedAssistantFinalAnswerRequest struct {

--- a/shared/transcript/committed_row_locator.go
+++ b/shared/transcript/committed_row_locator.go
@@ -1,0 +1,21 @@
+package transcript
+
+import "fmt"
+
+// CommittedRowLocator identifies one committed transcript row within a Session.
+// EventSequence is the durable event-record sequence and RowOrdinal is the
+// one-based projection ordinal within that event.
+type CommittedRowLocator struct {
+	EventSequence int64 `json:"event_sequence"`
+	RowOrdinal    int64 `json:"row_ordinal"`
+}
+
+func (l CommittedRowLocator) Validate() error {
+	if l.EventSequence <= 0 {
+		return fmt.Errorf("committed row locator event sequence must be positive, got %d", l.EventSequence)
+	}
+	if l.RowOrdinal <= 0 {
+		return fmt.Errorf("committed row locator row ordinal must be positive, got %d", l.RowOrdinal)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Adds the approved Session-scoped committed-row locator: durable event sequence plus one-based projected-row ordinal.
- Preserves provenance through pages, hydration, live delivery, buffered assistant/tool turns, restart, and compaction replacement.
- Adds bounded validation, reconnect-safe subscription contract failures, typed operational diagnostics, and protocol/read-model contract coverage.

## Verification
- `go test ./server/registry ./server/runtimeview ./server/sessionview ./shared/client ./shared/clientui ./shared/invariant ./shared/serverapi ./shared/transcript -count=1 -timeout=180s`
- Targeted runtime locator/tool/completion tests passed.
- `./scripts/build.sh --output ./bin/kent` passed.
- `git diff --check` passed.
- A full sharded `./scripts/test.sh server` rerun reached the repository 300-second wall-clock cap without a reported test failure; focused suites and the build passed after the rebase.

## Diff accounting
Compared with `origin/main` at the rebase base:
- Production/shared/docs: **+925 / -197**, net **+728**, gross **1,122** lines.
- Test/generated: **+1,087 / -8**, net **+1,079**, gross **1,095** lines. No generated source files were added.
- Total: **+2,012 / -205**, net **+1,807**, gross **2,217** lines.

## Caveats and follow-up
- This is contract/read-model work only; it does not add Desktop Chat UI, deep links, read state, full-history traversal, UUID row IDs, side indexes, or persisted timestamps.
- The existing event-sequence authority remains the sole identity source. KENT-443 remains the separate future committed-timestamp design task.
- The protocol version was rebased onto the current main value (90), which already includes the required contract-version progression.

Kent task: KENT-374 — Project transcript row metadata.
GitHub issue: none associated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcript committed rows now retain stable locators and provenance, improving identity consistency across live updates, refreshes, reconnections, hydration, and history replacement.
  * Added stronger validation to detect malformed or duplicate transcript row data.

* **Bug Fixes**
  * Invalid transcript pages and subscription events are now rejected instead of being displayed.
  * In-flight clear failures now appear as temporary operational notifications rather than committed transcript entries.

* **Style**
  * Removed timestamps from non-conversational rows, thinking status, reasoning traces, and committed assistant messages; reasoning traces now show Copy only after commitment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->