### PR TITLE
Remove desktop RPC head-of-line blocking at the Gateway

### DIFF
--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -14,8 +14,8 @@
 - A Session with no execution target hydrates without one. Failure to resolve an execution target fails Chat opening or reopening with a clear error; it never becomes an absent or stale target.
 - Clients receive transcript, session-activity, and prompt-activity updates in one ordered subscription.
 - A failure to clear PendingModelRecovery remains live operational feedback. TUI and Desktop surface it through their typed operational-diagnostic or status-notice owner; it is neither persisted nor projected as committed transcript history.
-- The server owns exact Session-resource admission, Runtime Command ordering, dormant Goal commands, domain-operation ordering, server work queues, execution lifecycle, reconciliation, and persistence disposition.
-- Transport owns request identity and idempotency. Transport may sequence connection setup, bound concurrent handling of requests on one client connection, apply socket backpressure, correlate and write responses, and cancel and drain connection-bound request handling when that connection closes. These connection mechanics never order domain operations, retain server work after request handling, or decide execution, reconciliation, or persistence outcomes.
+- The server owns exact Session-resource admission, Runtime Command ordering, dormant Goal commands, domain-operation ordering, idempotency, server work queues, execution lifecycle, reconciliation, and persistence disposition.
+- Transport preserves request identity for request/response correlation. Transport may sequence connection setup, bound concurrent handling of requests on one client connection, apply socket backpressure, correlate and write responses, and cancel and drain connection-bound request handling when that connection closes. These connection mechanics never order domain operations, retain server work after request handling, or decide idempotency, execution, reconciliation, or persistence outcomes.
 
 ## Skills And Generated Assets
 

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -14,7 +14,8 @@
 - A Session with no execution target hydrates without one. Failure to resolve an execution target fails Chat opening or reopening with a clear error; it never becomes an absent or stale target.
 - Clients receive transcript, session-activity, and prompt-activity updates in one ordered subscription.
 - A failure to clear PendingModelRecovery remains live operational feedback. TUI and Desktop surface it through their typed operational-diagnostic or status-notice owner; it is neither persisted nor projected as committed transcript history.
-- The server owns exact Session-resource admission, Runtime Command ordering, and dormant Goal commands. Transport keeps request identity and idempotency only; it never owns ordering, queueing, execution lifecycle, reconciliation, or persistence disposition.
+- The server owns exact Session-resource admission, Runtime Command ordering, dormant Goal commands, domain-operation ordering, server work queues, execution lifecycle, reconciliation, and persistence disposition.
+- Transport owns request identity and idempotency. Transport may sequence connection setup, bound concurrent handling of requests on one client connection, apply socket backpressure, correlate and write responses, and cancel and drain connection-bound request handling when that connection closes. These connection mechanics never order domain operations, retain server work after request handling, or decide execution, reconciliation, or persistence outcomes.
 
 ## Skills And Generated Assets
 

--- a/server/core/core.go
+++ b/server/core/core.go
@@ -328,6 +328,10 @@ func (s *Core) Config() config.App {
 	return s.safeBundles().Projects.cfg
 }
 
+func (s *Core) DebugEnabled() bool {
+	return s != nil && s.Config().Settings.Debug
+}
+
 func (s *Core) MetadataStore() *metadata.Store {
 	if s == nil {
 		return nil

--- a/server/startup/serve_server.go
+++ b/server/startup/serve_server.go
@@ -559,6 +559,10 @@ func (d *startupGatewayDependencies) snapshotConfig() config.App {
 	return d.cfg
 }
 
+func (d *startupGatewayDependencies) DebugEnabled() bool {
+	return d.snapshotConfig().Settings.Debug
+}
+
 type startupServerStatusService struct {
 	base      apicontract.ServerStatusService
 	readiness interface {

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -17,6 +17,7 @@ import (
 	"core/server/auth"
 	"core/server/metadata"
 	"core/shared/apicontract"
+	"core/shared/invariant"
 	"core/shared/llmerrors"
 	"core/shared/protocol"
 	"core/shared/rpcwire"
@@ -38,6 +39,7 @@ const canceledByClientMessage = "request canceled by client"
 type Gateway struct {
 	deps     GatewayDependencies
 	identity protocol.ServerIdentity
+	debug    bool
 }
 
 type GatewayDependencies interface {
@@ -232,7 +234,11 @@ func NewGateway(deps GatewayDependencies, identity protocol.ServerIdentity) (*Ga
 	if strings.TrimSpace(identity.ProtocolVersion) == "" {
 		return nil, errors.New("server identity is required")
 	}
-	return &Gateway{deps: deps, identity: identity}, nil
+	debugMode := invariant.NewPolicy().Mode() == invariant.ModePanic
+	if debugDeps, ok := deps.(interface{ DebugEnabled() bool }); ok {
+		debugMode = debugMode || debugDeps.DebugEnabled()
+	}
+	return &Gateway{deps: deps, identity: identity, debug: debugMode}, nil
 }
 
 func isNilGatewayDependencies(deps GatewayDependencies) bool {
@@ -355,14 +361,18 @@ func (g *Gateway) serveGatewayRequest(conn rpcwire.Conn, ctx context.Context, st
 func (g *Gateway) serveOrdinaryGatewayRequest(conn rpcwire.Conn, ctx context.Context, state *connectionState, req protocol.Request, schedule gatewayRequestSchedule, stop func()) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
+			stack := string(debug.Stack())
 			slog.Error(
 				"gateway request handler panicked",
 				"method", req.Method,
 				"request_id", req.ID,
 				"panic", recovered,
-				"stack", string(debug.Stack()),
+				"stack", stack,
 			)
 			stop()
+			if g.debug {
+				panic(recovered)
+			}
 		}
 	}()
 	if !g.serveGatewayRequest(conn, ctx, state, req, schedule) {

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -152,6 +152,27 @@ type gatewayRequestSchedule struct {
 	progressRoute apicontract.Route
 }
 
+const gatewayOrdinaryRequestOperation = "gateway.ordinary_request"
+
+type gatewayRequestPanicDiagnostic struct {
+	Operation string
+	Method    string
+	RequestID string
+	Cause     any
+	Stack     string
+}
+
+func (p gatewayRequestPanicDiagnostic) Error() string {
+	return fmt.Sprintf(
+		"gateway request panic operation=%q method=%q request_id=%q cause=%v\nstack:\n%s",
+		p.Operation,
+		p.Method,
+		p.RequestID,
+		p.Cause,
+		p.Stack,
+	)
+}
+
 var gatewayProgressHandlers = routeHandlersForKind(apicontract.KindProgress, gatewayProgressHandlerEntries)
 
 func RuntimeLiveControlRoutesExecutable() bool {
@@ -371,7 +392,13 @@ func (g *Gateway) serveOrdinaryGatewayRequest(conn rpcwire.Conn, ctx context.Con
 			)
 			stop()
 			if g.debug {
-				panic(recovered)
+				panic(gatewayRequestPanicDiagnostic{
+					Operation: gatewayOrdinaryRequestOperation,
+					Method:    req.Method,
+					RequestID: req.ID,
+					Cause:     recovered,
+					Stack:     stack,
+				})
 			}
 		}
 	}()

--- a/server/transport/gateway.go
+++ b/server/transport/gateway.go
@@ -6,9 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"reflect"
+	"runtime/debug"
 	"strings"
+	"sync"
 	"time"
 
 	"core/server/auth"
@@ -132,6 +135,21 @@ var gatewayProgressHandlerEntries = map[string]gatewayProgressHandler{
 
 type gatewayProgressHandler func(g *Gateway, conn rpcwire.Conn, ctx context.Context, state *connectionState, route apicontract.Route, req protocol.Request) bool
 
+type gatewayRequestScheduleKind uint8
+
+const (
+	gatewayRequestScheduleOrdinary gatewayRequestScheduleKind = iota
+	gatewayRequestScheduleExclusive
+	gatewayRequestScheduleProgress
+	gatewayRequestScheduleSubscription
+)
+
+type gatewayRequestSchedule struct {
+	kind          gatewayRequestScheduleKind
+	progress      gatewayProgressHandler
+	progressRoute apicontract.Route
+}
+
 var gatewayProgressHandlers = routeHandlersForKind(apicontract.KindProgress, gatewayProgressHandlerEntries)
 
 func RuntimeLiveControlRoutesExecutable() bool {
@@ -165,6 +183,7 @@ type connectionState struct {
 	attachedWorkspaceRoot string
 	attachedSession       *runtimeids.SessionID
 	runtimeOwnerID        string
+	ownedRuntimesMu       sync.Mutex
 	ownedRuntimes         map[serverapi.SessionRuntimeAttachment]struct{}
 }
 
@@ -234,38 +253,140 @@ func (g *Gateway) Handler() http.Handler {
 }
 
 func (g *Gateway) handleConn(ctx context.Context, conn rpcwire.Conn) {
-	defer func() { _ = conn.Close() }()
 	connCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	var stopOnce sync.Once
+	stop := func() {
+		stopOnce.Do(func() {
+			cancel()
+			_ = conn.Close()
+		})
+	}
 	go func() {
 		select {
 		case <-ctx.Done():
+			stop()
 		case <-conn.Closed():
+			stop()
 		}
-		cancel()
 	}()
 	state := &connectionState{runtimeOwnerID: uuid.NewString()}
-	defer g.cleanupConnectionRuntimes(state)
+	const ordinaryAdmissionLimit = 16
+	admission := make(chan struct{}, ordinaryAdmissionLimit)
+	var ordinary sync.WaitGroup
+	defer func() {
+		stop()
+		ordinary.Wait()
+		g.cleanupConnectionRuntimes(state)
+	}()
 	for {
-		req, err := receiveRequest(connCtx, conn)
-		if err != nil {
-			return
-		}
-		if handler, route, ok := gatewayProgressHandlerForMethod(req.Method); ok {
-			if !handler(g, conn, connCtx, state, route, req) {
+		if !state.handshakeDone {
+			req, err := receiveRequest(connCtx, conn)
+			if err != nil {
+				return
+			}
+			if !g.serveGatewayRequest(conn, connCtx, state, req, gatewayRequestScheduleFor(req)) {
 				return
 			}
 			continue
 		}
-		if _, ok := gatewaySubscriptionMethods[strings.TrimSpace(req.Method)]; ok {
-			g.serveSubscription(conn, connCtx, state, req)
+
+		select {
+		case admission <- struct{}{}:
+		case <-connCtx.Done():
 			return
 		}
-		resp := g.dispatch(connCtx, state, req)
-		if !sendResponse(connCtx, conn, resp) {
+
+		req, err := receiveRequest(connCtx, conn)
+		if err != nil {
+			<-admission
 			return
+		}
+		schedule := gatewayRequestScheduleFor(req)
+		if schedule.kind != gatewayRequestScheduleOrdinary {
+			<-admission
+			ordinary.Wait()
+			if !g.serveGatewayRequest(conn, connCtx, state, req, schedule) {
+				stop()
+				return
+			}
+			continue
+		}
+
+		ordinary.Add(1)
+		go func(req protocol.Request, schedule gatewayRequestSchedule) {
+			defer ordinary.Done()
+			defer func() { <-admission }()
+			g.serveOrdinaryGatewayRequest(conn, connCtx, state, req, schedule, stop)
+		}(req, schedule)
+	}
+}
+
+func gatewayRequestScheduleFor(req protocol.Request) gatewayRequestSchedule {
+	if handler, route, ok := gatewayProgressHandlerForMethod(req.Method); ok {
+		return gatewayRequestSchedule{
+			kind:          gatewayRequestScheduleProgress,
+			progress:      handler,
+			progressRoute: route,
 		}
 	}
+	if _, ok := gatewaySubscriptionMethods[strings.TrimSpace(req.Method)]; ok {
+		return gatewayRequestSchedule{kind: gatewayRequestScheduleSubscription}
+	}
+	if isGatewayExclusiveRequest(req) {
+		return gatewayRequestSchedule{kind: gatewayRequestScheduleExclusive}
+	}
+	return gatewayRequestSchedule{kind: gatewayRequestScheduleOrdinary}
+}
+
+func (g *Gateway) serveGatewayRequest(conn rpcwire.Conn, ctx context.Context, state *connectionState, req protocol.Request, schedule gatewayRequestSchedule) bool {
+	switch schedule.kind {
+	case gatewayRequestScheduleProgress:
+		return schedule.progress(g, conn, ctx, state, schedule.progressRoute, req)
+	case gatewayRequestScheduleSubscription:
+		g.serveSubscription(conn, ctx, state, req)
+		return false
+	case gatewayRequestScheduleOrdinary, gatewayRequestScheduleExclusive:
+		return sendResponse(ctx, conn, g.dispatch(ctx, state, req))
+	default:
+		panic(fmt.Sprintf("unknown Gateway request schedule kind %d", schedule.kind))
+	}
+}
+
+func (g *Gateway) serveOrdinaryGatewayRequest(conn rpcwire.Conn, ctx context.Context, state *connectionState, req protocol.Request, schedule gatewayRequestSchedule, stop func()) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			slog.Error(
+				"gateway request handler panicked",
+				"method", req.Method,
+				"request_id", req.ID,
+				"panic", recovered,
+				"stack", string(debug.Stack()),
+			)
+			stop()
+		}
+	}()
+	if !g.serveGatewayRequest(conn, ctx, state, req, schedule) {
+		stop()
+	}
+}
+
+func isGatewayExclusiveRequest(req protocol.Request) bool {
+	if req.Method == protocol.MethodHandshake {
+		return true
+	}
+	route, ok := apicontract.RouteByMethod(req.Method)
+	if !ok {
+		return false
+	}
+	switch route.Dependency {
+	case apicontract.DependencyAuthBootstrap, apicontract.DependencyAuthStatus:
+		return true
+	}
+	switch route.Scope {
+	case apicontract.ScopeAttachProject, apicontract.ScopeAttachSession:
+		return true
+	}
+	return false
 }
 
 const gatewayRuntimeCleanupTimeout = 3 * time.Second

--- a/server/transport/gateway_concurrency_test.go
+++ b/server/transport/gateway_concurrency_test.go
@@ -239,10 +239,11 @@ func TestGatewayOrdinaryHandlerPanicFailsFastInDebug(t *testing.T) {
 	appCore, _ := newGatewayTestCore(t, true, true)
 	defer func() { _ = appCore.Close() }()
 
+	panicCause := errors.New("gateway debug test panic")
 	workflow := &gatewayConcurrencyWorkflowService{
 		WorkflowService: appCore.WorkflowClient(),
 		getWorkflowTask: func(_ context.Context, _ serverapi.WorkflowTaskGetRequest) (serverapi.WorkflowTaskGetResponse, error) {
-			panic("gateway debug test panic")
+			panic(panicCause)
 		},
 	}
 	deps := &gatewayConcurrencyDependencies{
@@ -263,8 +264,26 @@ func TestGatewayOrdinaryHandlerPanicFailsFastInDebug(t *testing.T) {
 	state := &connectionState{handshakeDone: true}
 	stopped := false
 	defer func() {
-		if recovered := recover(); recovered == nil {
-			t.Fatal("debug panic was recovered instead of re-panicked")
+		recovered := recover()
+		diagnostic, ok := recovered.(gatewayRequestPanicDiagnostic)
+		if !ok {
+			t.Fatalf("recovered panic = %#v, want gatewayRequestPanicDiagnostic", recovered)
+		}
+		if diagnostic.Operation != gatewayOrdinaryRequestOperation {
+			t.Fatalf("diagnostic operation = %q, want %q", diagnostic.Operation, gatewayOrdinaryRequestOperation)
+		}
+		if diagnostic.Method != protocol.MethodWorkflowTaskGet {
+			t.Fatalf("diagnostic method = %q, want %q", diagnostic.Method, protocol.MethodWorkflowTaskGet)
+		}
+		if diagnostic.RequestID != "panic" {
+			t.Fatalf("diagnostic request id = %q, want panic", diagnostic.RequestID)
+		}
+		cause, ok := diagnostic.Cause.(error)
+		if !ok || !errors.Is(cause, panicCause) {
+			t.Fatalf("diagnostic cause = %#v, want original panic cause", diagnostic.Cause)
+		}
+		if diagnostic.Stack == "" {
+			t.Fatal("diagnostic stack is empty")
 		}
 		if !stopped {
 			t.Fatal("debug panic did not close the connection")

--- a/server/transport/gateway_concurrency_test.go
+++ b/server/transport/gateway_concurrency_test.go
@@ -1,0 +1,478 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"core/shared/apicontract"
+	"core/shared/protocol"
+	"core/shared/serverapi"
+
+	"golang.org/x/net/websocket"
+)
+
+type gatewayConcurrencyWorkflowService struct {
+	apicontract.WorkflowService
+	getWorkflowTask func(context.Context, serverapi.WorkflowTaskGetRequest) (serverapi.WorkflowTaskGetResponse, error)
+}
+
+func (s *gatewayConcurrencyWorkflowService) GetWorkflowTask(
+	ctx context.Context,
+	req serverapi.WorkflowTaskGetRequest,
+) (serverapi.WorkflowTaskGetResponse, error) {
+	return s.getWorkflowTask(ctx, req)
+}
+
+type gatewayConcurrencyDependencies struct {
+	GatewayDependencies
+	workflow apicontract.WorkflowService
+}
+
+func (d *gatewayConcurrencyDependencies) WorkflowClient() apicontract.WorkflowService {
+	return d.workflow
+}
+
+type gatewayCloseTracker struct {
+	active             atomic.Int32
+	entered            chan struct{}
+	canceled           chan string
+	exited             chan string
+	allowActivationEnd chan struct{}
+}
+
+type gatewayCloseWorkflowService struct {
+	apicontract.WorkflowService
+	tracker *gatewayCloseTracker
+}
+
+func (s *gatewayCloseWorkflowService) GetWorkflowTask(ctx context.Context, _ serverapi.WorkflowTaskGetRequest) (serverapi.WorkflowTaskGetResponse, error) {
+	s.tracker.active.Add(1)
+	s.tracker.entered <- struct{}{}
+	defer func() {
+		s.tracker.active.Add(-1)
+		s.tracker.exited <- "workflow"
+	}()
+	<-ctx.Done()
+	s.tracker.canceled <- "workflow"
+	return serverapi.WorkflowTaskGetResponse{}, ctx.Err()
+}
+
+type gatewayCloseRuntimeService struct {
+	apicontract.SessionRuntimeService
+	tracker        *gatewayCloseTracker
+	releaseStarted chan gatewayCloseRelease
+}
+
+type gatewayCloseRelease struct {
+	request serverapi.SessionRuntimeReleaseRequest
+	active  int32
+}
+
+func (s *gatewayCloseRuntimeService) ActivateSessionRuntime(ctx context.Context, req serverapi.SessionRuntimeActivateRequest) (serverapi.SessionRuntimeActivateResponse, error) {
+	s.tracker.active.Add(1)
+	s.tracker.entered <- struct{}{}
+	defer func() {
+		s.tracker.active.Add(-1)
+		s.tracker.exited <- "runtime"
+	}()
+	<-ctx.Done()
+	s.tracker.canceled <- "runtime"
+	<-s.tracker.allowActivationEnd
+	return serverapi.SessionRuntimeActivateResponse{
+		Attachment: serverapi.SessionRuntimeAttachment{SessionID: req.SessionID, Generation: 1},
+	}, nil
+}
+
+func (s *gatewayCloseRuntimeService) ReleaseSessionRuntime(_ context.Context, req serverapi.SessionRuntimeReleaseRequest) (serverapi.SessionRuntimeReleaseResponse, error) {
+	s.releaseStarted <- gatewayCloseRelease{request: req, active: s.tracker.active.Load()}
+	return serverapi.SessionRuntimeReleaseResponse{Released: true}, nil
+}
+
+type gatewayCloseDependencies struct {
+	GatewayDependencies
+	workflow apicontract.WorkflowService
+	runtime  apicontract.SessionRuntimeService
+}
+
+func (d *gatewayCloseDependencies) WorkflowClient() apicontract.WorkflowService {
+	return d.workflow
+}
+
+func (d *gatewayCloseDependencies) SessionRuntimeClient() apicontract.SessionRuntimeService {
+	return d.runtime
+}
+
+func TestGatewayConcurrentUnaryResponsesAreCorrelated(t *testing.T) {
+	appCore, _ := newGatewayTestCore(t, true, true)
+	defer func() { _ = appCore.Close() }()
+
+	blockedEntered := make(chan struct{})
+	releaseBlocked := make(chan struct{})
+	var releaseBlockedOnce sync.Once
+	release := func() {
+		releaseBlockedOnce.Do(func() { close(releaseBlocked) })
+	}
+	workflow := &gatewayConcurrencyWorkflowService{
+		WorkflowService: appCore.WorkflowClient(),
+		getWorkflowTask: func(ctx context.Context, req serverapi.WorkflowTaskGetRequest) (serverapi.WorkflowTaskGetResponse, error) {
+			if req.TaskID == "task-1" {
+				close(blockedEntered)
+				select {
+				case <-releaseBlocked:
+				case <-ctx.Done():
+					return serverapi.WorkflowTaskGetResponse{}, ctx.Err()
+				}
+			}
+			return serverapi.WorkflowTaskGetResponse{}, errors.New("blocked workflow task lookup")
+		},
+	}
+	deps := &gatewayConcurrencyDependencies{
+		GatewayDependencies: appCore,
+		workflow:            workflow,
+	}
+	gateway, err := NewGateway(deps, protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"})
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+	server := httptest.NewServer(gateway.Handler())
+	defer server.Close()
+
+	conn := dialGateway(t, server)
+	defer func() { _ = conn.Close() }()
+	handshakeGateway(t, conn)
+	t.Cleanup(release)
+
+	sendGatewayRequest(t, conn, "blocked", protocol.MethodWorkflowTaskGet, serverapi.WorkflowTaskGetRequest{TaskID: "task-1"})
+	select {
+	case <-blockedEntered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocked workflow task lookup")
+	}
+	sendGatewayRequest(t, conn, "fast", protocol.MethodWorkflowTaskGet, serverapi.WorkflowTaskGetRequest{TaskID: "task-2"})
+
+	if err := conn.SetReadDeadline(time.Now().Add(250 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	var response protocol.Response
+	if err := websocket.JSON.Receive(conn, &response); err != nil {
+		t.Fatalf("receive fast response: %v", err)
+	}
+	if response.ID != "fast" {
+		t.Fatalf("first response id = %q, want fast", response.ID)
+	}
+	if response.Error == nil {
+		t.Fatal("fast response unexpectedly succeeded")
+	}
+
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("clear read deadline: %v", err)
+	}
+	release()
+	if err := websocket.JSON.Receive(conn, &response); err != nil {
+		t.Fatalf("receive blocked response: %v", err)
+	}
+	if response.ID != "blocked" {
+		t.Fatalf("second response id = %q, want blocked", response.ID)
+	}
+}
+
+func TestGatewayOrdinaryHandlerPanicClosesOnlyItsConnection(t *testing.T) {
+	appCore, _ := newGatewayTestCore(t, true, true)
+	defer func() { _ = appCore.Close() }()
+
+	panicEntered := make(chan struct{})
+	workflow := &gatewayConcurrencyWorkflowService{
+		WorkflowService: appCore.WorkflowClient(),
+		getWorkflowTask: func(_ context.Context, req serverapi.WorkflowTaskGetRequest) (serverapi.WorkflowTaskGetResponse, error) {
+			if req.TaskID == "panic" {
+				close(panicEntered)
+				panic("gateway test panic")
+			}
+			return serverapi.WorkflowTaskGetResponse{}, errors.New("unexpected workflow task lookup")
+		},
+	}
+	deps := &gatewayConcurrencyDependencies{
+		GatewayDependencies: appCore,
+		workflow:            workflow,
+	}
+	gateway, err := NewGateway(deps, protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"})
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+	server := httptest.NewServer(gateway.Handler())
+	defer server.Close()
+
+	conn := dialGateway(t, server)
+	handshakeGateway(t, conn)
+	defer func() { _ = conn.Close() }()
+	sendGatewayRequest(t, conn, "panic", protocol.MethodWorkflowTaskGet, serverapi.WorkflowTaskGetRequest{TaskID: "panic"})
+	select {
+	case <-panicEntered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for panic route")
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	var response protocol.Response
+	if err := websocket.JSON.Receive(conn, &response); err == nil {
+		t.Fatal("panic request unexpectedly returned a response")
+	}
+
+	next := dialGateway(t, server)
+	defer func() { _ = next.Close() }()
+	handshakeGateway(t, next)
+}
+
+func TestGatewayCloseCancelsAndDrainsHandlersBeforeRuntimeCleanup(t *testing.T) {
+	appCore, _ := newGatewayTestCore(t, true, true)
+	defer func() { _ = appCore.Close() }()
+	store := createGatewayAuthoritativeSession(t, appCore)
+
+	tracker := &gatewayCloseTracker{
+		entered:            make(chan struct{}, 2),
+		canceled:           make(chan string, 2),
+		exited:             make(chan string, 2),
+		allowActivationEnd: make(chan struct{}),
+	}
+	var allowActivationEndOnce sync.Once
+	allowActivationEnd := func() {
+		allowActivationEndOnce.Do(func() { close(tracker.allowActivationEnd) })
+	}
+	runtime := &gatewayCloseRuntimeService{
+		SessionRuntimeService: appCore.SessionRuntimeClient(),
+		tracker:               tracker,
+		releaseStarted:        make(chan gatewayCloseRelease, 1),
+	}
+	workflow := &gatewayCloseWorkflowService{
+		WorkflowService: appCore.WorkflowClient(),
+		tracker:         tracker,
+	}
+	deps := &gatewayCloseDependencies{
+		GatewayDependencies: appCore,
+		workflow:            workflow,
+		runtime:             runtime,
+	}
+	gateway, err := NewGateway(deps, protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"})
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+	server := httptest.NewServer(gateway.Handler())
+	defer server.Close()
+
+	conn := dialGateway(t, server)
+	defer func() { _ = conn.Close() }()
+	handshakeGateway(t, conn)
+	t.Cleanup(allowActivationEnd)
+
+	sendGatewayRequest(t, conn, "workflow", protocol.MethodWorkflowTaskGet, serverapi.WorkflowTaskGetRequest{TaskID: "task-1"})
+	sendGatewayRequest(t, conn, "runtime", protocol.MethodSessionRuntimeActivate, gatewayRuntimeActivateRequest(appCore, store.Meta().SessionID, "runtime"))
+	for i := 0; i < 2; i++ {
+		select {
+		case <-tracker.entered:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for admitted handler %d", i+1)
+		}
+	}
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close gateway connection: %v", err)
+	}
+	canceled := make(map[string]struct{}, 2)
+	for len(canceled) < 2 {
+		select {
+		case name := <-tracker.canceled:
+			canceled[name] = struct{}{}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for canceled handlers")
+		}
+	}
+	if _, ok := canceled["workflow"]; !ok {
+		t.Fatal("workflow handler context was not canceled")
+	}
+	if _, ok := canceled["runtime"]; !ok {
+		t.Fatal("runtime handler context was not canceled")
+	}
+	waitForGatewayCloseEvent(t, tracker.exited, "workflow")
+	if got := tracker.active.Load(); got != 1 {
+		t.Fatalf("active handler count after cancellation = %d, want runtime handler still admitted", got)
+	}
+
+	allowActivationEnd()
+	waitForGatewayCloseEvent(t, tracker.exited, "runtime")
+	select {
+	case release := <-runtime.releaseStarted:
+		if release.request.Attachment.SessionID != store.Meta().SessionID || release.request.Attachment.Generation != 1 {
+			t.Fatalf("cleanup attachment = %+v, want session %q generation 1", release.request.Attachment, store.Meta().SessionID)
+		}
+		if !release.request.DropOwner || release.request.ClosePolicy != serverapi.SessionRuntimeReleaseClosePolicyCloseIfIdle {
+			t.Fatalf("cleanup release request = %+v, want owner drop close-if-idle", release.request)
+		}
+		if release.active != 0 {
+			t.Fatalf("cleanup started with %d active handler(s), want 0", release.active)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runtime cleanup")
+	}
+	if got := tracker.active.Load(); got != 0 {
+		t.Fatalf("active handler count after cleanup started = %d, want 0", got)
+	}
+}
+
+func waitForGatewayCloseEvent(t *testing.T, events <-chan string, want string) {
+	t.Helper()
+	for {
+		select {
+		case got := <-events:
+			if got == want {
+				return
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for %s handler exit", want)
+		}
+	}
+}
+
+func TestGatewayAdmissionCapsOrdinaryUnaryRequests(t *testing.T) {
+	appCore, _ := newGatewayTestCore(t, true, true)
+	defer func() { _ = appCore.Close() }()
+
+	entered := make(chan string, 17)
+	entered17BeforeRelease := make(chan struct{}, 1)
+	release := make(map[string]chan struct{}, 17)
+	for i := int32(1); i <= 17; i++ {
+		release["task-"+stringID(i)] = make(chan struct{}, 1)
+	}
+	var capacityReleased atomic.Bool
+	var calls atomic.Int32
+	workflow := &gatewayConcurrencyWorkflowService{
+		WorkflowService: appCore.WorkflowClient(),
+		getWorkflowTask: func(ctx context.Context, req serverapi.WorkflowTaskGetRequest) (serverapi.WorkflowTaskGetResponse, error) {
+			calls.Add(1)
+			if req.TaskID == "task-"+stringID(17) && !capacityReleased.Load() {
+				entered17BeforeRelease <- struct{}{}
+			}
+			entered <- req.TaskID
+			select {
+			case <-release[req.TaskID]:
+			case <-ctx.Done():
+				return serverapi.WorkflowTaskGetResponse{}, ctx.Err()
+			}
+			return serverapi.WorkflowTaskGetResponse{}, errors.New("blocked workflow task lookup")
+		},
+	}
+	deps := &gatewayConcurrencyDependencies{
+		GatewayDependencies: appCore,
+		workflow:            workflow,
+	}
+	gateway, err := NewGateway(deps, protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"})
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+	server := httptest.NewServer(gateway.Handler())
+	defer server.Close()
+
+	conn := dialGateway(t, server)
+	defer func() { _ = conn.Close() }()
+	handshakeGateway(t, conn)
+	releaseAll := func() {
+		for id := int32(1); id <= 17; id++ {
+			select {
+			case release["task-"+stringID(id)] <- struct{}{}:
+			default:
+			}
+		}
+	}
+	t.Cleanup(releaseAll)
+
+	for i := int32(1); i <= 17; i++ {
+		sendGatewayRequest(t, conn, stringID(i), protocol.MethodWorkflowTaskGet, serverapi.WorkflowTaskGetRequest{
+			TaskID: "task-" + stringID(i),
+		})
+	}
+
+	enteredIDs := make(map[string]struct{}, 16)
+	for len(enteredIDs) < 16 {
+		select {
+		case got := <-entered:
+			if got == "task-request-17" {
+				t.Fatal("17th request entered before an admission slot was released")
+			}
+			enteredIDs[got] = struct{}{}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for the first 16 service calls")
+		}
+	}
+	if got := calls.Load(); got != 16 {
+		t.Fatalf("service call count = %d, want 16", got)
+	}
+	for i := int32(1); i <= 16; i++ {
+		if _, ok := enteredIDs["task-"+stringID(i)]; !ok {
+			t.Fatalf("missing admitted request %q", stringID(i))
+		}
+	}
+	select {
+	case got := <-entered:
+		t.Fatalf("unexpected extra service call %q before capacity release", got)
+	default:
+	}
+
+	capacityReleased.Store(true)
+	release["task-"+stringID(1)] <- struct{}{}
+	select {
+	case got := <-entered:
+		if got != "task-request-17" {
+			t.Fatalf("service call after release = %q, want request-17", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the 17th request to enter")
+	}
+	select {
+	case <-entered17BeforeRelease:
+		t.Fatal("17th request entered before capacity release")
+	default:
+	}
+
+	for id := range enteredIDs {
+		release[id] <- struct{}{}
+	}
+	release["task-"+stringID(17)] <- struct{}{}
+	responses := make(map[string]struct{}, 17)
+	for i := 0; i < 17; i++ {
+		var response protocol.Response
+		if err := websocket.JSON.Receive(conn, &response); err != nil {
+			t.Fatalf("receive response %d: %v", i+1, err)
+		}
+		if response.Error == nil {
+			t.Fatalf("response %q unexpectedly succeeded", response.ID)
+		}
+		responses[response.ID] = struct{}{}
+	}
+	for i := int32(1); i <= 17; i++ {
+		if _, ok := responses[stringID(i)]; !ok {
+			t.Fatalf("missing response for request %q", stringID(i))
+		}
+	}
+}
+
+func stringID(id int32) string {
+	return "request-" + strconv.FormatInt(int64(id), 10)
+}
+
+func sendGatewayRequest(t *testing.T, conn *websocket.Conn, id, method string, params any) {
+	t.Helper()
+	if err := websocket.JSON.Send(conn, protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      id,
+		Method:  method,
+		Params:  mustJSON(t, params),
+	}); err != nil {
+		t.Fatalf("send %s: %v", id, err)
+	}
+}

--- a/server/transport/gateway_concurrency_test.go
+++ b/server/transport/gateway_concurrency_test.go
@@ -32,10 +32,15 @@ func (s *gatewayConcurrencyWorkflowService) GetWorkflowTask(
 type gatewayConcurrencyDependencies struct {
 	GatewayDependencies
 	workflow apicontract.WorkflowService
+	debug    bool
 }
 
 func (d *gatewayConcurrencyDependencies) WorkflowClient() apicontract.WorkflowService {
 	return d.workflow
+}
+
+func (d *gatewayConcurrencyDependencies) DebugEnabled() bool {
+	return d.debug
 }
 
 type gatewayCloseTracker struct {
@@ -228,6 +233,48 @@ func TestGatewayOrdinaryHandlerPanicClosesOnlyItsConnection(t *testing.T) {
 	next := dialGateway(t, server)
 	defer func() { _ = next.Close() }()
 	handshakeGateway(t, next)
+}
+
+func TestGatewayOrdinaryHandlerPanicFailsFastInDebug(t *testing.T) {
+	appCore, _ := newGatewayTestCore(t, true, true)
+	defer func() { _ = appCore.Close() }()
+
+	workflow := &gatewayConcurrencyWorkflowService{
+		WorkflowService: appCore.WorkflowClient(),
+		getWorkflowTask: func(_ context.Context, _ serverapi.WorkflowTaskGetRequest) (serverapi.WorkflowTaskGetResponse, error) {
+			panic("gateway debug test panic")
+		},
+	}
+	deps := &gatewayConcurrencyDependencies{
+		GatewayDependencies: appCore,
+		workflow:            workflow,
+		debug:               true,
+	}
+	gateway, err := NewGateway(deps, protocol.ServerIdentity{ProtocolVersion: protocol.Version, ServerID: "server-1"})
+	if err != nil {
+		t.Fatalf("NewGateway: %v", err)
+	}
+	req := protocol.Request{
+		JSONRPC: protocol.JSONRPCVersion,
+		ID:      "panic",
+		Method:  protocol.MethodWorkflowTaskGet,
+		Params:  mustJSON(t, serverapi.WorkflowTaskGetRequest{TaskID: "panic"}),
+	}
+	state := &connectionState{handshakeDone: true}
+	stopped := false
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("debug panic was recovered instead of re-panicked")
+		}
+		if !stopped {
+			t.Fatal("debug panic did not close the connection")
+		}
+	}()
+	gateway.serveOrdinaryGatewayRequest(nil, context.Background(), state, req, gatewayRequestSchedule{
+		kind: gatewayRequestScheduleOrdinary,
+	}, func() {
+		stopped = true
+	})
 }
 
 func TestGatewayCloseCancelsAndDrainsHandlersBeforeRuntimeCleanup(t *testing.T) {

--- a/server/transport/gateway_runtime_ownership.go
+++ b/server/transport/gateway_runtime_ownership.go
@@ -6,6 +6,8 @@ func (s *connectionState) recordOwnedRuntime(attachment serverapi.SessionRuntime
 	if s == nil || attachment.Validate() != nil {
 		return
 	}
+	s.ownedRuntimesMu.Lock()
+	defer s.ownedRuntimesMu.Unlock()
 	if s.ownedRuntimes == nil {
 		s.ownedRuntimes = make(map[serverapi.SessionRuntimeAttachment]struct{})
 	}
@@ -13,14 +15,24 @@ func (s *connectionState) recordOwnedRuntime(attachment serverapi.SessionRuntime
 }
 
 func (s *connectionState) removeOwnedRuntime(attachment serverapi.SessionRuntimeAttachment) {
-	if s == nil || len(s.ownedRuntimes) == 0 {
+	if s == nil {
+		return
+	}
+	s.ownedRuntimesMu.Lock()
+	defer s.ownedRuntimesMu.Unlock()
+	if len(s.ownedRuntimes) == 0 {
 		return
 	}
 	delete(s.ownedRuntimes, attachment)
 }
 
 func (s *connectionState) takeOwnedRuntimes() []serverapi.SessionRuntimeAttachment {
-	if s == nil || len(s.ownedRuntimes) == 0 {
+	if s == nil {
+		return nil
+	}
+	s.ownedRuntimesMu.Lock()
+	defer s.ownedRuntimesMu.Unlock()
+	if len(s.ownedRuntimes) == 0 {
 		return nil
 	}
 	owned := make([]serverapi.SessionRuntimeAttachment, 0, len(s.ownedRuntimes))


### PR DESCRIPTION
## Summary
- Addresses Kent task KENT-449 by removing shared-control RPC head-of-line blocking in the Go Gateway.
- Adds a fixed 16-request per-connection admission gate with out-of-order response handling, exclusive setup/auth/attachment scheduling, and existing synchronous progress/subscription paths.
- Cancels and drains connection-bound handlers before runtime ownership cleanup, with synchronized runtime ownership collection.
- Preserves production connection isolation for ordinary-handler panics and emits structured operation/method/request/cause/stack diagnostics before re-panicking in debug mode.
- Updates only the approved Core Runtime and Tools transport-boundary specification.

## Verification
- `go test -race ./server/transport -run ...` focused Gateway, panic, admission, close-drain, and runtime-ownership coverage passed.
- `./scripts/test.sh server` passed.
- `./scripts/build.sh server --output ./bin/kent` passed.
- `git diff --check` passed.

## Diff accounting
Compared with `origin/main`:
- Production Go: +193 / -15, net +178, gross 208 lines.
- Test Go: +544 / -0, net +544, gross 544 lines.
- Generated code: +0 / -0, net 0, gross 0 lines.
- Specification documentation: +2 / -1, net +1, gross 3 lines.
- Overall: +739 / -16, net +723, gross 755 lines.

## Caveats and follow-up
- Scope intentionally excludes Desktop transport workarounds, `shared/rpcwire` changes, protocol changes, route-interface changes, metrics, benchmarks, and application request queues.
- Domain-operation ordering, execution lifecycle, reconciliation, and persistence outcomes remain owned by existing server authorities.
- Progress and subscription routes remain connection-exclusive; ordinary unary requests have no arrival or completion ordering guarantee.
- No known technical-debt follow-up is required by this change; observability and benchmark work were explicitly out of scope.

GitHub issue: none identified.
Kent task: KENT-449.