### PR TITLE
fix: address KENT-455 post-merge review

### DIFF
--- a/apps/desktop/src/features/task-detail/TaskDetailActions.test.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailActions.test.tsx
@@ -38,7 +38,7 @@ it("orders Start, Open, and targeted Interrupt in one wrapping action flow", asy
 
   const flow = await screen.findByTestId("task-detail-action-flow");
   const start = within(flow).getByTestId("task-detail-start");
-  const openLabel = appI18n.t("task.openChat", { name: sessionName });
+  const openLabel = appI18n.t("task.openInCli", { name: sessionName });
   const interruptLabel = appI18n.t("task.interruptChat", { name: sessionName });
   const open = within(flow).getByRole("button", { name: openLabel });
   const interrupt = within(flow).getByRole("button", { name: interruptLabel });
@@ -66,10 +66,10 @@ it("falls back to the Agent Node display name and keeps Task-wide Interrupt gene
 
   const flow = await screen.findByTestId("task-detail-action-flow");
   const firstOpen = within(flow).getByRole("button", {
-    name: appI18n.t("task.openChat", { name: "Implementation" }),
+    name: appI18n.t("task.openInCli", { name: "Implementation" }),
   });
   const secondOpen = within(flow).getByRole("button", {
-    name: appI18n.t("task.openChat", { name: "Review" }),
+    name: appI18n.t("task.openInCli", { name: "Review" }),
   });
   const interrupt = within(flow).getByRole("button", { name: appI18n.t("board.interrupt") });
   expect(within(flow).getAllByRole("button")).toEqual([firstOpen, secondOpen, interrupt]);

--- a/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailContent.tsx
@@ -95,6 +95,7 @@ export function TaskDetailContent({
   const [selectedTab, setSelectedTab] = useState<"comments" | "activity">(
     restored?.selectedTab ?? "comments",
   );
+  const [localDependencyFocusRequest, setLocalDependencyFocusRequest] = useState<number | null>(null);
   const [questionSelections, setQuestionSelections] = useState<ReadonlyMap<string, QuestionSelectionState>>(
     () => new Map(),
   );
@@ -110,6 +111,7 @@ export function TaskDetailContent({
     setNewCommentBody("");
     setDescriptionPresentation(initialDescriptionPresentationState);
     setQuestionSelections(new Map());
+    setLocalDependencyFocusRequest(null);
   }
   const update = useUpdateTask(detail.id, detail.projectID);
   useTaskDetailRetainedCapture({
@@ -158,6 +160,11 @@ export function TaskDetailContent({
     setDraftState(reconciled);
   }
   const draft = reconciled.draft;
+  const focusPresentation = taskDetailFocusPresentation({
+    initialFocus,
+    localDependencyFocusRequest,
+    restored: restored !== undefined,
+  });
 
   async function saveDraft(nextDraft: TaskDraft = draft): Promise<void> {
     await update.mutateAsync({
@@ -173,15 +180,13 @@ export function TaskDetailContent({
       key={detail.id}
       onApplied={mutations.refresh}
       onViewDependencies={(taskID) => {
-        if (navigator !== undefined && sidebarDestination !== undefined) {
-          navigator.replace(
-            taskDetailSidebarDestination(sidebarDestination, taskID, { kind: "dependencies" }),
-          );
-          return;
-        }
-        openSidebar?.({
-          kind: "taskDetail",
-          initialFocus: { kind: "dependencies" },
+        presentTaskDependencies({
+          navigator,
+          openSidebar,
+          requestLocalFocus: () => {
+            setLocalDependencyFocusRequest((current) => (current === null ? 1 : current + 1));
+          },
+          sidebarDestination,
           taskID,
         });
       }}
@@ -197,7 +202,12 @@ export function TaskDetailContent({
           draft={draft}
           descriptionPresentation={descriptionPresentation}
           editingComment={editingComment}
-          initialFocus={restored === undefined ? initialFocus : undefined}
+          focusRequestKey={
+            localDependencyFocusRequest === null
+              ? undefined
+              : `${detail.id}:dependencies:${localDependencyFocusRequest.toString()}`
+          }
+          initialFocus={focusPresentation}
           mutations={mutations}
           newCommentBody={newCommentBody}
           relationshipNavigationAvailable={relationshipNavigationAvailable}
@@ -239,6 +249,49 @@ export function TaskDetailContent({
       </TaskDeleteProvider>
     </TaskInitiatingActionProvider>
   );
+}
+
+function taskDetailFocusPresentation({
+  initialFocus,
+  localDependencyFocusRequest,
+  restored,
+}: Readonly<{
+  initialFocus: TaskDetailInitialFocus | undefined;
+  localDependencyFocusRequest: number | null;
+  restored: boolean;
+}>): TaskDetailInitialFocus | undefined {
+  if (localDependencyFocusRequest !== null) {
+    return { kind: "dependencies" };
+  }
+  return restored ? undefined : initialFocus;
+}
+
+function presentTaskDependencies({
+  navigator,
+  openSidebar,
+  requestLocalFocus,
+  sidebarDestination,
+  taskID,
+}: Readonly<{
+  navigator: SidebarPageNavigator | undefined;
+  openSidebar: SidebarRootController["open"] | undefined;
+  requestLocalFocus(): void;
+  sidebarDestination: Extract<SidebarDestination, { kind: "taskDetail" }> | undefined;
+  taskID: string;
+}>): void {
+  if (navigator !== undefined && sidebarDestination !== undefined) {
+    navigator.replace(taskDetailSidebarDestination(sidebarDestination, taskID, { kind: "dependencies" }));
+    return;
+  }
+  if (openSidebar !== undefined) {
+    openSidebar({
+      kind: "taskDetail",
+      initialFocus: { kind: "dependencies" },
+      taskID,
+    });
+    return;
+  }
+  requestLocalFocus();
 }
 
 function dependencyDestination(

--- a/apps/desktop/src/features/task-detail/TaskDetailList.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailList.tsx
@@ -47,6 +47,7 @@ export function TaskDetailList({
   draft,
   descriptionPresentation,
   editingComment,
+  focusRequestKey,
   initialFocus,
   mutations,
   newCommentBody,
@@ -76,6 +77,7 @@ export function TaskDetailList({
   draft: TaskDraft;
   descriptionPresentation: DescriptionPresentationState;
   editingComment: Readonly<{ id: string; body: string }> | null;
+  focusRequestKey?: string | undefined;
   initialFocus?: TaskDetailInitialFocus | undefined;
   mutations: ReturnType<typeof useTaskMutations>;
   newCommentBody: string;
@@ -163,9 +165,7 @@ export function TaskDetailList({
       getItemKey={taskDetailListItemKey}
       hasNextPage={paging.hasNextPage}
       initialScrollKey={initialScrollKey}
-      initialScrollRequestKey={
-        initialFocus !== undefined ? taskDetailInitialFocusRequestKey(detail.id, initialFocus) : undefined
-      }
+      initialScrollRequestKey={resolveTaskDetailFocusRequestKey(detail.id, initialFocus, focusRequestKey)}
       isFetchingNextPage={paging.isFetchingNextPage}
       items={listItems}
       loadingLabel={t("app.loadingMore")}
@@ -222,6 +222,17 @@ export function TaskDetailList({
       testId="task-detail-island-stack"
     />
   );
+}
+
+function resolveTaskDetailFocusRequestKey(
+  taskID: string,
+  focus: TaskDetailInitialFocus | undefined,
+  requestKey: string | undefined,
+): string | undefined {
+  if (requestKey !== undefined) {
+    return requestKey;
+  }
+  return focus === undefined ? undefined : taskDetailInitialFocusRequestKey(taskID, focus);
 }
 
 type TaskDetailListRowProps = Readonly<{

--- a/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
@@ -504,7 +504,7 @@ function TaskOpenButtons({ detail, disabled }: Readonly<{ detail: TaskDetail; di
     <>
       {detail.liveSessions.map((session) => {
         const target = taskLiveSessionTarget(session);
-        const fullLabel = t("task.openChat", { name: target });
+        const fullLabel = t("task.openInCli", { name: target });
         return (
           <Button
             aria-label={fullLabel}
@@ -519,7 +519,7 @@ function TaskOpenButtons({ detail, disabled }: Readonly<{ detail: TaskDetail; di
             title={fullLabel}
             variant="secondary"
           >
-            {t("task.openChat", { name: ellipsizeActionTarget(target) })}
+            {t("task.openInCli", { name: ellipsizeActionTarget(target) })}
           </Button>
         );
       })}

--- a/apps/desktop/src/features/task-detail/TaskDetailStart.test.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailStart.test.tsx
@@ -65,3 +65,61 @@ it("starts the persisted Task without submitting a dirty title or description dr
     proceed_despite_dependencies: false,
   });
 });
+
+it("focuses Dependencies in-place for every View deps request without a sidebar host", async () => {
+  const scrollTo = vi.fn();
+  Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+    configurable: true,
+    value: scrollTo,
+  });
+  mountTaskDetailSurface(
+    {
+      task: {
+        ...taskDetailResponse.task,
+        current_nodes: [],
+        live_sessions: [],
+        status: {
+          kind: "backlog",
+          native_state: "backlog",
+          node_ids: [],
+          attention_types: [],
+        },
+        actions: {
+          ...taskDetailResponse.task.actions,
+          can_start: true,
+          can_interrupt: false,
+        },
+        attention_count: 0,
+      },
+    },
+    {
+      routes: [
+        {
+          method: "workflow.task.start",
+          result: {
+            outcome: "dependency_confirmation_required",
+            unsatisfied_dependency_count: 1,
+          },
+        },
+      ],
+    },
+  );
+  const user = userEvent.setup();
+  const start = await screen.findByTestId("task-detail-start");
+
+  await user.click(start);
+  const firstViewDependencies = await screen.findByTestId("dependency-confirmation-view");
+  const firstRequestBaseline = scrollTo.mock.calls.length;
+  await user.click(firstViewDependencies);
+  await waitFor(() => {
+    expect(scrollTo.mock.calls.length).toBeGreaterThan(firstRequestBaseline);
+  });
+
+  await user.click(start);
+  const secondViewDependencies = await screen.findByTestId("dependency-confirmation-view");
+  const secondRequestBaseline = scrollTo.mock.calls.length;
+  await user.click(secondViewDependencies);
+  await waitFor(() => {
+    expect(scrollTo.mock.calls.length).toBeGreaterThan(secondRequestBaseline);
+  });
+});

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -407,7 +407,7 @@ export const englishResources = {
       noActivityTitle: "No activity yet",
       noCommentsTitle: "No comments yet",
       sessions: "Sessions",
-      openChat: "Open {{name}} Chat",
+      openInCli: "Open {{name}} in CLI",
       interruptChat: "Interrupt {{name}} Chat",
       openScript: "Open script",
       cliCommandCopied: "Copied command to clipboard",

--- a/server/workflowview/current_node_task_detail_status_test.go
+++ b/server/workflowview/current_node_task_detail_status_test.go
@@ -506,24 +506,34 @@ func TestTaskDetailCurrentScriptOrderingIsNilAwareAndTotal(t *testing.T) {
 
 	sortTaskDetailCurrentScripts(scripts)
 
-	got := make([]string, 0, len(scripts))
-	for _, script := range scripts {
-		branch := "<none>"
-		if script.CurrentNode.TransitionBranchKey != nil {
-			branch = *script.CurrentNode.TransitionBranchKey
-		}
-		got = append(got, script.CurrentNode.NodeID+":"+branch+":"+script.Path)
+	want := []serverapi.WorkflowTaskCurrentScript{
+		{CurrentNode: serverapi.WorkflowTaskCurrentNode{NodeID: "node-a"}, Path: "a"},
+		{CurrentNode: serverapi.WorkflowTaskCurrentNode{NodeID: "node-a"}, Path: "z"},
+		{
+			CurrentNode: serverapi.WorkflowTaskCurrentNode{
+				NodeID:              "node-a",
+				TransitionBranchKey: &branchA,
+			},
+			Path: "a",
+		},
+		{
+			CurrentNode: serverapi.WorkflowTaskCurrentNode{
+				NodeID:              "node-a",
+				TransitionBranchKey: &branchA,
+			},
+			Path: "z",
+		},
+		{
+			CurrentNode: serverapi.WorkflowTaskCurrentNode{
+				NodeID:              "node-a",
+				TransitionBranchKey: &branchZ,
+			},
+			Path: "z",
+		},
+		{CurrentNode: serverapi.WorkflowTaskCurrentNode{NodeID: "node-b"}, Path: "b"},
 	}
-	want := []string{
-		"node-a:<none>:a",
-		"node-a:<none>:z",
-		"node-a:a:a",
-		"node-a:a:z",
-		"node-a:z:z",
-		"node-b:<none>:b",
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("Current Script order = %v, want %v", got, want)
+	if !reflect.DeepEqual(scripts, want) {
+		t.Fatalf("Current Script order = %+v, want %+v", scripts, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- assert Current Script ordering with structured nullable values
- keep Task Detail Session actions truthful as CLI actions until KENT-409 delivers the routed Desktop Chat shell
- focus Dependencies in-place for repeated View deps requests in standalone and native Task Detail hosts

## Verification
- `./scripts/test.sh server ./server/workflowview`
- `./scripts/test.sh desktop`
- `pnpm --dir apps/desktop typecheck`
- `pnpm --dir apps/desktop lint` (five existing Fast Refresh warnings)
- `./scripts/build.sh server desktop`
- `./scripts/build.sh --output ./bin/kent`

A full repository server run was also attempted with the wall-clock cap disabled; the unrelated `core/cli/app/internal/ptyfixture` package hit its existing 600-second package timeout. The changed server package passed directly, and PR #725 CI passed before this test-only server adjustment.