### PR TITLE
Extract shared Markdown field for Task Description

### DIFF
--- a/apps/desktop/src/app-facade/textFieldSubmitShortcut.test.tsx
+++ b/apps/desktop/src/app-facade/textFieldSubmitShortcut.test.tsx
@@ -2,7 +2,11 @@ import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import type { NativePlatform } from "@app/native-bridge";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { isTextFieldSubmitShortcut, useTextFieldSubmitShortcut } from "./textFieldSubmitShortcut";
+import {
+  isTextFieldSubmitShortcut,
+  textFieldSubmitShortcutPolicyForPlatform,
+  useTextFieldSubmitShortcut,
+} from "./textFieldSubmitShortcut";
 const nativePlatform = vi.hoisted((): { current: NativePlatform } => ({ current: "macos" }));
 vi.mock("./useAppServices", () => ({
   useAppServices: () => ({ nativeBridge: { capabilities: { platform: nativePlatform.current } } }),
@@ -58,7 +62,21 @@ describe("text field submit shortcut", () => {
     ["browser", { key: "Enter", metaKey: true }],
     ["unknown", { key: "Enter", ctrlKey: true }],
   ] as const)("ignores unsupported shortcut %s", (platform, event) => {
-    expect(isTextFieldSubmitShortcut(new KeyboardEvent("keydown", event), platform)).toBe(false);
+    expect(
+      isTextFieldSubmitShortcut(
+        new KeyboardEvent("keydown", event),
+        textFieldSubmitShortcutPolicyForPlatform(platform),
+      ),
+    ).toBe(false);
+  });
+  it.each([
+    ["macos", "meta-enter"],
+    ["windows", "control-enter"],
+    ["linux", "control-enter"],
+    ["browser", "unavailable"],
+    ["unknown", "unavailable"],
+  ] as const)("maps %s to its closed UI policy", (platform, policy) => {
+    expect(textFieldSubmitShortcutPolicyForPlatform(platform)).toBe(policy);
   });
   it("consumes repeated and unavailable direct shortcuts", () => {
     nativePlatform.current = "macos";

--- a/apps/desktop/src/app-facade/textFieldSubmitShortcut.ts
+++ b/apps/desktop/src/app-facade/textFieldSubmitShortcut.ts
@@ -1,21 +1,16 @@
 import { useCallback, type KeyboardEvent as ReactKeyboardEvent, type KeyboardEventHandler } from "react";
 import type { NativePlatform } from "@app/native-bridge";
+
+import {
+  consumeTextFieldSubmitShortcut,
+  isTextFieldSubmitShortcut,
+  type TextFieldSubmitShortcutPolicy,
+} from "@/ui";
 import { useAppServices } from "./useAppServices";
-type TextFieldSubmitKeyEvent = Readonly<{
-  altKey: boolean;
-  ctrlKey: boolean;
-  defaultPrevented: boolean;
-  isComposing?: boolean | undefined;
-  key: string;
-  metaKey: boolean;
-  nativeEvent?: Readonly<{ isComposing?: boolean | undefined }> | undefined;
-  preventDefault(): void;
-  repeat: boolean;
-  shiftKey: boolean;
-  stopPropagation(): void;
-}>;
+
 type DirectShortcutOptions = Readonly<{ kind: "direct"; action: (() => void) | null; available: boolean }>;
 type FormShortcutOptions = Readonly<{ kind: "form"; available: boolean }>;
+
 export function useTextFieldSubmitShortcut(options: DirectShortcutOptions): KeyboardEventHandler<HTMLElement>;
 export function useTextFieldSubmitShortcut(
   options: FormShortcutOptions,
@@ -23,63 +18,48 @@ export function useTextFieldSubmitShortcut(
 export function useTextFieldSubmitShortcut(
   options: DirectShortcutOptions | FormShortcutOptions,
 ): KeyboardEventHandler<HTMLElement | HTMLFormElement> {
-  const { nativeBridge } = useAppServices();
-  const platform = nativeBridge.capabilities.platform;
+  const policy = useTextFieldSubmitShortcutPolicy();
   return useCallback(
     (event) => {
       if (options.kind === "direct") {
-        handleDirectTextFieldSubmit(event, platform, options.available, options.action);
+        handleDirectTextFieldSubmit(event, policy, options.available, options.action);
         return;
       }
-      handleFormTextFieldSubmit(event, platform, options.available);
+      handleFormTextFieldSubmit(event, policy, options.available);
     },
-    [options, platform],
+    [options, policy],
   );
 }
 
-export function isTextFieldSubmitShortcut(
-  event: Pick<
-    TextFieldSubmitKeyEvent,
-    | "altKey"
-    | "ctrlKey"
-    | "isComposing"
-    | "key"
-    | "metaKey"
-    | "nativeEvent"
-    | "repeat"
-    | "shiftKey"
-  >,
-  platform: NativePlatform,
-): boolean {
-  if (
-    event.key !== "Enter" ||
-    event.isComposing === true ||
-    event.nativeEvent?.isComposing === true ||
-    event.altKey ||
-    event.shiftKey
-  ) {
-    return false;
-  }
-  if (platform === "macos") {
-    return event.metaKey && !event.ctrlKey;
-  }
-  if (platform === "linux" || platform === "windows") {
-    return event.ctrlKey && !event.metaKey;
-  }
-  return false;
+export function useTextFieldSubmitShortcutPolicy(): TextFieldSubmitShortcutPolicy {
+  const { nativeBridge } = useAppServices();
+  return textFieldSubmitShortcutPolicyForPlatform(nativeBridge.capabilities.platform);
 }
 
-function handleDirectTextFieldSubmit(
-  event: TextFieldSubmitKeyEvent,
+export function textFieldSubmitShortcutPolicyForPlatform(
   platform: NativePlatform,
+): TextFieldSubmitShortcutPolicy {
+  if (platform === "macos") {
+    return "meta-enter";
+  }
+  if (platform === "linux" || platform === "windows") {
+    return "control-enter";
+  }
+  return "unavailable";
+}
+
+export { isTextFieldSubmitShortcut };
+export type { TextFieldSubmitShortcutPolicy };
+
+function handleDirectTextFieldSubmit(
+  event: ReactKeyboardEvent<HTMLElement>,
+  policy: TextFieldSubmitShortcutPolicy,
   available: boolean,
   action: (() => void) | null,
 ): void {
-  if (!isTextFieldSubmitShortcut(event, platform)) {
+  if (!consumeTextFieldSubmitShortcut(event, policy)) {
     return;
   }
-  event.preventDefault();
-  event.stopPropagation();
   if (!event.repeat && available) {
     action?.();
   }
@@ -87,10 +67,10 @@ function handleDirectTextFieldSubmit(
 
 function handleFormTextFieldSubmit(
   event: ReactKeyboardEvent<HTMLElement | HTMLFormElement>,
-  platform: NativePlatform,
+  policy: TextFieldSubmitShortcutPolicy,
   available: boolean,
 ): void {
-  if (event.defaultPrevented || !isTextFieldSubmitShortcut(event, platform)) {
+  if (event.defaultPrevented || !isTextFieldSubmitShortcut(event, policy)) {
     return;
   }
   const form = event.currentTarget;
@@ -101,8 +81,9 @@ function handleFormTextFieldSubmit(
   if (!isTextualFormTarget(target) || target.form !== form) {
     return;
   }
-  event.preventDefault();
-  event.stopPropagation();
+  if (!consumeTextFieldSubmitShortcut(event, policy)) {
+    return;
+  }
   if (!event.repeat && available) {
     form.requestSubmit();
   }

--- a/apps/desktop/src/app/startup/styles.css
+++ b/apps/desktop/src/app/startup/styles.css
@@ -565,8 +565,7 @@
   }
 
   .task-detail-description-island,
-  .task-detail-description-shell,
-  .task-detail-description-surface {
+  .task-detail-description-island > * {
     height: 100%;
   }
 }

--- a/apps/desktop/src/features/task-detail/TaskDescriptionChecklist.test.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDescriptionChecklist.test.tsx
@@ -146,6 +146,25 @@ describe("Task description checklist", () => {
     );
   });
 
+  it("returns to rendered Markdown when focus moves to the Task title", async () => {
+    mountTaskDetailSurface(taskDetailResponse);
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("textbox", { name: appI18n.t("task.description") }));
+    const editor = screen.getByRole("textbox", { name: appI18n.t("task.description") });
+
+    await user.clear(editor);
+    await user.type(editor, "Blur manual QA draft");
+    await user.click(screen.getByRole("textbox", { name: appI18n.t("task.name") }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Blur manual QA draft")).toBeInTheDocument();
+      expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).not.toBeInstanceOf(
+        HTMLTextAreaElement,
+      );
+    });
+    expect(screen.getByTestId("task-detail-save")).toBeInTheDocument();
+  });
+
   it("does not edit or toggle a disabled description", async () => {
     const services = mountTaskDetailSurface({
       task: {

--- a/apps/desktop/src/features/task-detail/TaskDescriptionChecklist.test.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDescriptionChecklist.test.tsx
@@ -1,11 +1,16 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import {
   getCallCount,
   mountTaskDetailSurface,
+  emptyTaskAttentionResponse,
   taskDetailResponse,
   taskUpdateResponse,
 } from "@/test-support/task-detail";
+import { appI18n } from "@/i18n";
+import { createBrowserNativeBridge } from "@/test-support/native-bridge";
+import { installResizeObserverGeometry } from "@/test-support/resize-observer";
 
 describe("Task description checklist", () => {
   it("edits the local description draft and waits for Save before updating the Task", async () => {
@@ -45,4 +50,358 @@ describe("Task description checklist", () => {
       },
     });
   });
+
+  it.each(["Enter", " "])("keeps keyboard focus in read mode until %s requests editing", async (key) => {
+    mountTaskDetailSurface(taskDetailResponse);
+    const description = await screen.findByRole("textbox", { name: appI18n.t("task.description") });
+
+    description.focus();
+
+    expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).not.toBeInstanceOf(
+      HTMLTextAreaElement,
+    );
+
+    fireEvent.keyDown(description, { key });
+
+    expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).toBeInstanceOf(
+      HTMLTextAreaElement,
+    );
+  });
+
+  it("enters editing from plain pointer activation", async () => {
+    mountTaskDetailSurface(taskDetailResponse);
+    const user = userEvent.setup();
+    const description = await screen.findByRole("textbox", { name: appI18n.t("task.description") });
+
+    await user.click(description);
+
+    expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).toBeInstanceOf(
+      HTMLTextAreaElement,
+    );
+  });
+
+  it("does not enter editing after a non-collapsed Markdown selection", async () => {
+    mountTaskDetailSurface(taskDetailResponse);
+    const description = await screen.findByRole("textbox", { name: appI18n.t("task.description") });
+    const selection = window.getSelection();
+    if (selection === null) throw new Error("Expected a browser selection.");
+
+    selection.selectAllChildren(description);
+    expect(selection.isCollapsed).toBe(false);
+
+    fireEvent.pointerUp(description);
+    fireEvent.click(description);
+
+    expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).not.toBeInstanceOf(
+      HTMLTextAreaElement,
+    );
+  });
+
+  it("keeps safe links in read mode", async () => {
+    mountTaskDetailSurface({
+      task: {
+        ...taskDetailResponse.task,
+        body: "[Safe link](https://example.com)",
+      },
+    });
+    const link = await screen.findByRole("button", { name: "Safe link" });
+
+    fireEvent.click(link);
+
+    expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).not.toBeInstanceOf(
+      HTMLTextAreaElement,
+    );
+  });
+
+  it("keeps task-list activation in read mode", async () => {
+    mountTaskDetailSurface({
+      task: {
+        ...taskDetailResponse.task,
+        body: "- [ ] Keep the Markdown source",
+      },
+    });
+    const checkbox = await screen.findByRole("checkbox");
+
+    fireEvent.click(checkbox);
+
+    expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).not.toBeInstanceOf(
+      HTMLTextAreaElement,
+    );
+  });
+
+  it("returns to rendered Markdown on blur without losing the Draft", async () => {
+    mountTaskDetailSurface(taskDetailResponse);
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("textbox", { name: appI18n.t("task.description") }));
+    const editor = screen.getByRole("textbox", { name: appI18n.t("task.description") });
+
+    await user.clear(editor);
+    await user.type(editor, "Unsaved body");
+    fireEvent.blur(editor);
+
+    expect(screen.getByText("Unsaved body")).toBeInTheDocument();
+    expect(screen.getByTestId("task-detail-save")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).not.toBeInstanceOf(
+      HTMLTextAreaElement,
+    );
+  });
+
+  it("does not edit or toggle a disabled description", async () => {
+    const services = mountTaskDetailSurface({
+      task: {
+        ...taskDetailResponse.task,
+        body: "- [ ] Keep the Markdown source",
+      },
+    });
+    act(() => {
+      services.transport.connection.set("disconnected", "offline");
+    });
+    const description = await screen.findByRole("textbox", { name: appI18n.t("task.description") });
+    const checkbox = await screen.findByRole("checkbox");
+
+    await waitFor(() => {
+      expect(checkbox).toBeDisabled();
+    });
+    fireEvent.focus(description);
+    fireEvent.keyDown(description, { key: "Enter" });
+    fireEvent.click(checkbox);
+
+    expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).not.toBeInstanceOf(
+      HTMLTextAreaElement,
+    );
+    expect(checkbox).not.toBeChecked();
+    expect(screen.queryByTestId("task-detail-save")).not.toBeInTheDocument();
+  });
+
+  it("closes clean editing from the native submit shortcut without updating the Task", async () => {
+    const services = mountTaskDetailSurface(taskDetailResponse, {
+      nativeBridge: createBrowserNativeBridge({ platform: "macos" }),
+    });
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("textbox", { name: appI18n.t("task.description") }));
+    const editor = screen.getByRole("textbox", { name: appI18n.t("task.description") });
+
+    fireEvent.keyDown(editor, { key: "Enter", metaKey: true });
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).not.toBeInstanceOf(
+        HTMLTextAreaElement,
+      );
+    });
+    expect(getCallCount(services.transport.calls, "workflow.task.update")).toBe(0);
+  });
+
+  it("keeps dirty editing active until a deferred native shortcut Save resolves", async () => {
+    const pending = deferred<typeof taskUpdateResponse>();
+    const services = mountTaskDetailSurface(taskDetailResponse, {
+      nativeBridge: createBrowserNativeBridge({ platform: "macos" }),
+      routes: [
+        {
+          method: "workflow.task.update",
+          handler: async () => pending.promise,
+        },
+      ],
+    });
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("textbox", { name: appI18n.t("task.description") }));
+    const editor = screen.getByRole("textbox", { name: appI18n.t("task.description") });
+    await user.clear(editor);
+    await user.type(editor, "Unsaved body");
+
+    fireEvent.keyDown(editor, { key: "Enter", metaKey: true });
+
+    await waitFor(() => {
+      expect(getCallCount(services.transport.calls, "workflow.task.update")).toBe(1);
+    });
+    expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).toBeInstanceOf(
+      HTMLTextAreaElement,
+    );
+
+    await act(async () => {
+      pending.resolve(taskUpdateResponse);
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).not.toBeInstanceOf(
+        HTMLTextAreaElement,
+      );
+    });
+  });
+
+  it("keeps the complete dirty Draft and editor active when a native shortcut Save rejects", async () => {
+    const pending = deferred<typeof taskUpdateResponse>();
+    const services = mountTaskDetailSurface(taskDetailResponse, {
+      nativeBridge: createBrowserNativeBridge({ platform: "macos" }),
+      routes: [
+        {
+          method: "workflow.task.update",
+          handler: async () => pending.promise,
+        },
+      ],
+    });
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("textbox", { name: appI18n.t("task.description") }));
+    const editor = screen.getByRole("textbox", { name: appI18n.t("task.description") });
+    await user.clear(editor);
+    await user.type(editor, "Unsaved body");
+
+    fireEvent.keyDown(editor, { key: "Enter", metaKey: true });
+    await waitFor(() => {
+      expect(getCallCount(services.transport.calls, "workflow.task.update")).toBe(1);
+    });
+    await act(async () => {
+      pending.reject(new Error("update failed"));
+    });
+
+    expect(await screen.findByText("update failed")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).toBeInstanceOf(
+      HTMLTextAreaElement,
+    );
+    expect(screen.getByRole("textbox", { name: appI18n.t("task.description") })).toHaveValue("Unsaved body");
+  });
+
+  it("does not offer Expand when the rendered content fits", async () => {
+    const geometry = installResizeObserverGeometry();
+    try {
+      mountTaskDetailSurface(
+        {
+          task: {
+            ...taskDetailResponse.task,
+            body: "Short description",
+          },
+        },
+        { attention: emptyTaskAttentionResponse },
+      );
+      const viewport = await screen.findByRole("textbox", { name: appI18n.t("task.description") });
+      geometry.setGeometry(viewport, { clientHeight: 100, scrollHeight: 100 });
+      act(() => {
+        geometry.notify();
+      });
+
+      expect(
+        screen.queryByRole("button", { name: appI18n.t("app.expand") }),
+      ).not.toBeInTheDocument();
+    } finally {
+      geometry.restore();
+    }
+  });
+
+  it("offers Expand after controlled remeasurement detects overflow", async () => {
+    const geometry = installResizeObserverGeometry();
+    try {
+      mountTaskDetailSurface(
+        {
+          task: {
+            ...taskDetailResponse.task,
+            body: "Long description",
+          },
+        },
+        { attention: emptyTaskAttentionResponse },
+      );
+      const viewport = await screen.findByRole("textbox", { name: appI18n.t("task.description") });
+      geometry.setGeometry(viewport, { clientHeight: 100, scrollHeight: 100 });
+      act(() => {
+        geometry.notify();
+      });
+      expect(
+        screen.queryByRole("button", { name: appI18n.t("app.expand") }),
+      ).not.toBeInTheDocument();
+
+      geometry.setGeometry(viewport, { clientHeight: 100, scrollHeight: 200 });
+      act(() => {
+        geometry.notify();
+      });
+
+      expect(
+        await screen.findByRole("button", { name: appI18n.t("app.expand") }),
+      ).toBeInTheDocument();
+    } finally {
+      geometry.restore();
+    }
+  });
+
+  it("expands the description and keeps it expanded through later geometry notifications", async () => {
+    const geometry = installResizeObserverGeometry();
+    try {
+      mountTaskDetailSurface(
+        {
+          task: {
+            ...taskDetailResponse.task,
+            body: "Long description",
+          },
+        },
+        { attention: emptyTaskAttentionResponse },
+      );
+      const viewport = await screen.findByRole("textbox", { name: appI18n.t("task.description") });
+      geometry.setGeometry(viewport, { clientHeight: 100, scrollHeight: 200 });
+      act(() => {
+        geometry.notify();
+      });
+      await screen.findByRole("button", { name: appI18n.t("app.expand") });
+
+      fireEvent.click(screen.getByRole("button", { name: appI18n.t("app.expand") }));
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: appI18n.t("app.expand") }),
+        ).not.toBeInTheDocument();
+      });
+
+      geometry.setGeometry(viewport, { clientHeight: 100, scrollHeight: 300 });
+      act(() => {
+        geometry.notify();
+      });
+
+      expect(
+        screen.queryByRole("button", { name: appI18n.t("app.expand") }),
+      ).not.toBeInTheDocument();
+    } finally {
+      geometry.restore();
+    }
+  });
+
+  it("restores retained expanded presentation without offering Expand", async () => {
+    const geometry = installResizeObserverGeometry();
+    try {
+      mountTaskDetailSurface(taskDetailResponse, {
+        attention: emptyTaskAttentionResponse,
+        retainedState: {
+          base: { body: taskDetailResponse.task.body, title: taskDetailResponse.task.summary.title },
+          descriptionPresentation: { editing: false, expanded: true },
+          draft: { body: taskDetailResponse.task.body, title: taskDetailResponse.task.summary.title },
+          editingComment: null,
+          newCommentBody: "",
+          scrollOffsetPx: 0,
+          selectedTab: "comments",
+        },
+      });
+      const viewport = await screen.findByRole("textbox", { name: appI18n.t("task.description") });
+      geometry.setGeometry(viewport, { clientHeight: 100, scrollHeight: 300 });
+      act(() => {
+        geometry.notify();
+      });
+
+      expect(
+        screen.queryByRole("button", { name: appI18n.t("app.expand") }),
+      ).not.toBeInTheDocument();
+    } finally {
+      geometry.restore();
+    }
+  });
 });
+
+function deferred<T>(): Readonly<{
+  promise: Promise<T>;
+  reject(error: unknown): void;
+  resolve(value: T): void;
+}> {
+  let resolvePromise!: (value: T) => void;
+  let rejectPromise!: (error: unknown) => void;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return {
+    promise,
+    reject: rejectPromise,
+    resolve: resolvePromise,
+  };
+}

--- a/apps/desktop/src/features/task-detail/TaskDetailList.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailList.tsx
@@ -341,7 +341,7 @@ function BodyRow({
       data-testid="task-detail-body-split"
     >
       <DescriptionIsland
-        disabled={disabled || updatePending}
+        disabled={disabled}
         draft={draft}
         draftDirty={draftDirty}
         error={updateError}
@@ -349,6 +349,7 @@ function BodyRow({
         onPresentationChange={onDescriptionPresentationChange}
         onSave={onSaveDraft}
         presentation={descriptionPresentation}
+        submitting={updatePending}
       />
       <PropertiesIsland detail={detail} disabled={disabled} mutations={mutations} />
     </div>

--- a/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
+++ b/apps/desktop/src/features/task-detail/TaskDetailRows.tsx
@@ -1,22 +1,26 @@
-import { useEffect, useId, useRef, useState, type KeyboardEventHandler, type RefObject } from "react";
-import { ChevronDown, Save } from "lucide-react";
+import { useState } from "react";
+import { Save } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import type { TaskCurrentNode, TaskDetail } from "@/api";
 import { errorMessage } from "@/api";
-import { useAppServices, useTextFieldSubmitShortcut } from "@/app-facade";
+import {
+  useAppServices,
+  useTextFieldSubmitShortcut,
+  useTextFieldSubmitShortcutPolicy,
+} from "@/app-facade";
 import { useOpenExternalLink } from "@/app-facade";
 import { writeClipboardText } from "@/shared/native-clipboard";
 import { taskStatusTone } from "@/shared/task-status";
 import {
   Button,
+  CollapsibleMarkdownField,
   Island,
-  StaticMarkdown,
   compactExternalUrlLabel,
   safeExternalUrl,
   showStatusToast,
 } from "@/ui";
-import { cx, fieldIslandInputClassName, useOpacityExit } from "@/ui";
+import { cx, fieldIslandInputClassName } from "@/ui";
 import type { DescriptionPresentationState } from "./TaskDetailDescriptionPresentation";
 import { ellipsizeActionTarget } from "./ellipsizeActionTarget";
 import { TaskExecutionTargetFacts } from "./TaskExecutionTargetFacts";
@@ -123,6 +127,7 @@ export function DescriptionIsland({
   onPresentationChange,
   onSave,
   presentation,
+  submitting,
 }: Readonly<{
   disabled: boolean;
   draft: TaskDraft;
@@ -132,237 +137,65 @@ export function DescriptionIsland({
   onPresentationChange: (presentation: DescriptionPresentationState) => void;
   onSave: (draft?: TaskDraft) => Promise<void>;
   presentation: DescriptionPresentationState;
+  submitting: boolean;
 }>) {
-  const descriptionId = useId();
-  const descriptionErrorId = `${descriptionId}-error`;
-  const descriptionError = error == null ? "" : errorMessage(error);
-  const descriptionShortcut = useTextFieldSubmitShortcut({
-    action: () => {
+  const { t } = useTranslation();
+  const descriptionError = error == null ? undefined : errorMessage(error);
+  const submitPolicy = useTextFieldSubmitShortcutPolicy();
+  const submitIntent = {
+    available: !disabled && !submitting && draft.title.trim().length > 0 && presentation.editing,
+    onSubmitIntent: () => {
       if (!draftDirty) {
         onPresentationChange({ ...presentation, editing: false });
         return;
       }
-      void onSave(draft).then(() => {
-        onPresentationChange({ ...presentation, editing: false });
-      });
+      void onSave(draft)
+        .then(() => {
+          onPresentationChange({ ...presentation, editing: false });
+        })
+        .catch(() => {
+          return;
+        });
     },
-    available: !disabled && draft.title.trim().length > 0 && presentation.editing,
-    kind: "direct",
-  });
+    policy: submitPolicy,
+  } as const;
 
   return (
     <div
-      className="task-detail-description-island grid min-h-0 min-w-0 gap-[var(--space-2)]"
+      className="task-detail-description-island grid h-full min-h-0 min-w-0 gap-[var(--space-2)]"
       data-testid="task-description-input-frame"
     >
-      {presentation.editing && !disabled ? (
-        <DescriptionEditor
-          describedBy={descriptionError.length > 0 ? descriptionErrorId : undefined}
-          error={descriptionError.length > 0}
-          id={descriptionId}
-          onBlur={() => {
-            onPresentationChange({ ...presentation, editing: false });
-          }}
-          onChange={(body) => {
-            onDraftChange({ ...draft, body });
-          }}
-          onKeyDown={descriptionShortcut}
-          value={draft.body}
-        />
-      ) : (
-        <DescriptionReadView
-          disabled={disabled}
-          expanded={presentation.expanded}
-          onChange={(body) => {
-            onDraftChange({ ...draft, body });
-          }}
-          onEdit={() => {
-            onPresentationChange({ editing: true, expanded: true });
-          }}
-          onExpand={() => {
-            onPresentationChange({ ...presentation, expanded: true });
-          }}
-          value={draft.body}
-        />
-      )}
-      {descriptionError.length > 0 ? (
-        <span className="text-[var(--color-error)]" id={descriptionErrorId}>
-          {descriptionError}
-        </span>
-      ) : null}
-    </div>
-  );
-}
-
-function DescriptionEditor({
-  describedBy,
-  error,
-  id,
-  onBlur,
-  onChange,
-  onKeyDown,
-  value,
-}: Readonly<{
-  describedBy: string | undefined;
-  error: boolean;
-  id: string;
-  onBlur: () => void;
-  onChange: (value: string) => void;
-  onKeyDown: KeyboardEventHandler<HTMLTextAreaElement>;
-  value: string;
-}>) {
-  const { t } = useTranslation();
-  return (
-    <textarea
-      aria-describedby={describedBy}
-      aria-invalid={error ? true : undefined}
-      aria-label={t("task.description")}
-      autoFocus
-      className={cx(
-        fieldIslandInputClassName(1),
-        "task-detail-description-surface block min-h-[220px] min-w-0 resize-none p-[var(--space-2)] font-mono",
-      )}
-      id={id}
-      onBlur={onBlur}
-      onChange={(event) => {
-        onChange(event.target.value);
-      }}
-      onKeyDown={onKeyDown}
-      placeholder={t("task.bodyPlaceholder")}
-      value={value}
-    />
-  );
-}
-
-function DescriptionReadView({
-  disabled,
-  expanded,
-  onChange,
-  onEdit,
-  onExpand,
-  value,
-}: Readonly<{
-  disabled: boolean;
-  expanded: boolean;
-  onChange: (value: string) => void;
-  onEdit: () => void;
-  onExpand: () => void;
-  value: string;
-}>) {
-  const { t } = useTranslation();
-  const viewportRef = useRef<HTMLDivElement | null>(null);
-  const contentRef = useRef<HTMLDivElement | null>(null);
-  const overflows = useDescriptionOverflow({ contentRef, enabled: !expanded, viewportRef });
-  const affordancePhase = useOpacityExit(!expanded && overflows);
-  return (
-    <div className="task-detail-description-shell relative min-w-0">
-      <div
-        aria-label={t("task.description")}
-        aria-readonly
-        className={cx(
-          fieldIslandInputClassName(1),
-          "task-detail-description-surface block min-w-0 p-[var(--space-2)]",
-          !disabled && "cursor-text",
-          expanded ? "overflow-visible" : "max-h-[clamp(5lh,50dvh,10lh)] overflow-hidden",
-        )}
-        onFocus={(event) => {
-          if (!disabled && event.target === event.currentTarget) {
-            onEdit();
-          }
+      <CollapsibleMarkdownField
+        collapsedHeightClamp={{ maximumLines: 10, minimumLines: 5, viewportPercent: 50 }}
+        disabled={disabled}
+        editorMinHeight={220}
+        error={descriptionError}
+        editing={presentation.editing}
+        expandLabel={t("app.expand")}
+        expanded={presentation.expanded}
+        label={t("task.description")}
+        onChange={(body) => {
+          onDraftChange({ ...draft, body });
         }}
-        ref={viewportRef}
-        role="textbox"
-        tabIndex={disabled ? -1 : 0}
-      >
-        <div ref={contentRef}>
-          {value.trim().length > 0 ? (
-            <StaticMarkdown
-              disabled={disabled}
-              onTaskListChange={onChange}
-              taskListItemToggleLabel={(checked) =>
-                checked ? t("markdown.markIncomplete") : t("markdown.markComplete")
-              }
-              value={value}
-            />
-          ) : (
-            <span className="text-[var(--color-muted)]">{t("task.bodyPlaceholder")}</span>
-          )}
-        </div>
-      </div>
-      {affordancePhase !== "hidden" ? (
-        <>
-          <div
-            aria-hidden="true"
-            className={cx(
-              "pointer-events-none absolute inset-x-[var(--space-2)] bottom-[var(--space-2)] h-12 bg-gradient-to-b from-transparent to-[var(--color-island-1)] transition-opacity motion-reduce:transition-none",
-              affordancePhase === "visible" ? "opacity-100" : "opacity-0",
-            )}
-            data-state={affordancePhase}
-            data-testid="task-description-fade"
-          />
-          <button
-            aria-label={t("app.expand")}
-            className={cx(
-              "app-region-no-drag absolute inset-x-0 bottom-0 grid h-10 place-items-center text-[var(--color-on-island)] transition-opacity motion-reduce:transition-none",
-              affordancePhase === "visible"
-                ? "pointer-events-auto opacity-100"
-                : "pointer-events-none opacity-0",
-            )}
-            data-state={affordancePhase}
-            data-testid="task-description-expand"
-            onClick={onExpand}
-            type="button"
-          >
-            <ChevronDown aria-hidden="true" size={20} strokeWidth={1.5} />
-          </button>
-        </>
-      ) : null}
+        onEdit={() => {
+          onPresentationChange({ editing: true, expanded: true });
+        }}
+        onEditingChange={(editing) => {
+          onPresentationChange({ ...presentation, editing });
+        }}
+        onExpand={() => {
+          onPresentationChange({ ...presentation, expanded: true });
+        }}
+        placeholder={t("task.bodyPlaceholder")}
+        submitIntent={submitIntent}
+        taskListInteraction={{
+          checkedLabel: t("markdown.markIncomplete"),
+          uncheckedLabel: t("markdown.markComplete"),
+        }}
+        value={draft.body}
+      />
     </div>
   );
-}
-
-function useDescriptionOverflow({
-  contentRef,
-  enabled,
-  viewportRef,
-}: Readonly<{
-  contentRef: RefObject<HTMLDivElement | null>;
-  enabled: boolean;
-  viewportRef: RefObject<HTMLDivElement | null>;
-}>): boolean {
-  const [overflows, setOverflows] = useState(false);
-  useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-    const measureOverflow = () => {
-      const viewport = viewportRef.current;
-      if (viewport !== null) {
-        setOverflows(viewport.scrollHeight > viewport.clientHeight);
-      }
-    };
-    const frame = window.requestAnimationFrame(measureOverflow);
-    window.addEventListener("resize", measureOverflow);
-    if (typeof ResizeObserver === "undefined") {
-      return () => {
-        window.cancelAnimationFrame(frame);
-        window.removeEventListener("resize", measureOverflow);
-      };
-    }
-    const observer = new ResizeObserver(measureOverflow);
-    if (viewportRef.current !== null) {
-      observer.observe(viewportRef.current);
-    }
-    if (contentRef.current !== null) {
-      observer.observe(contentRef.current);
-    }
-    return () => {
-      observer.disconnect();
-      window.cancelAnimationFrame(frame);
-      window.removeEventListener("resize", measureOverflow);
-    };
-  }, [contentRef, enabled, viewportRef]);
-  return enabled && overflows;
 }
 
 export function PropertiesIsland({

--- a/apps/desktop/src/shared/labels/LabelChooser.tsx
+++ b/apps/desktop/src/shared/labels/LabelChooser.tsx
@@ -14,7 +14,11 @@ import { useTranslation } from "react-i18next";
 
 import { ReorderableList, type ReorderableListItemRenderProps } from "@app/ui-kit";
 import { workflowLabelMaxIDs, type ProjectLabel } from "@/api";
-import { useAppServices, useStatusController } from "@/app-facade";
+import {
+  textFieldSubmitShortcutPolicyForPlatform,
+  useAppServices,
+  useStatusController,
+} from "@/app-facade";
 import {
   Button,
   IconTooltipButton,
@@ -277,7 +281,7 @@ export function LabelChooser({ invocation, trigger }: LabelChooserProps) {
               event,
               highlightedIndex: keyboardHighlightedIndex,
               invocation,
-              platform: nativeBridge.capabilities.platform,
+              policy: textFieldSubmitShortcutPolicyForPlatform(nativeBridge.capabilities.platform),
               choices,
               setHighlightedIndex: setKeyboardHighlightedIndex,
             });

--- a/apps/desktop/src/shared/labels/labelChooserActions.ts
+++ b/apps/desktop/src/shared/labels/labelChooserActions.ts
@@ -3,7 +3,10 @@ import { useCallback } from "react";
 import type { Dispatch, KeyboardEvent, SetStateAction } from "react";
 
 import { decodeWorkflowLabelError, errorMessage, type ProjectLabel } from "@/api";
-import { isTextFieldSubmitShortcut } from "@/app-facade";
+import {
+  isTextFieldSubmitShortcut,
+  type TextFieldSubmitShortcutPolicy,
+} from "@/app-facade";
 import type { LabelChooserInvocation } from "./LabelChooser";
 import type { DeleteState, LabelFilterCondition, LabelResultRowSelection, RenameState } from "./LabelChooserRows";
 import type { LabelFilterState } from "./labelFilterState";
@@ -42,7 +45,7 @@ export function handleLabelChooserSearchKeyDown({
   event,
   highlightedIndex,
   invocation,
-  platform,
+  policy,
   setHighlightedIndex,
 }: Readonly<{
   canCreate: boolean;
@@ -53,7 +56,7 @@ export function handleLabelChooserSearchKeyDown({
   event: KeyboardEvent<HTMLInputElement>;
   highlightedIndex: number | null;
   invocation: LabelChooserInvocation;
-  platform: Parameters<typeof isTextFieldSubmitShortcut>[1];
+  policy: TextFieldSubmitShortcutPolicy;
   setHighlightedIndex(update: (current: number | null) => number): void;
 }>): void {
   if (handleLabelChoiceNavigation(event, choices.length, setHighlightedIndex)) {
@@ -72,7 +75,7 @@ export function handleLabelChooserSearchKeyDown({
     void createLabel();
     return;
   }
-  if (isTextFieldSubmitShortcut(event, platform)) {
+  if (isTextFieldSubmitShortcut(event, policy)) {
     event.preventDefault();
     event.stopPropagation();
   }

--- a/apps/desktop/src/test-support/one-line-overflow/index.ts
+++ b/apps/desktop/src/test-support/one-line-overflow/index.ts
@@ -1,3 +1,5 @@
+import { installResizeObserverGeometry } from "../resize-observer";
+
 export type OneLineOverflowGeometryHarness = Readonly<{
   notify(): void;
   restore(): void;
@@ -12,19 +14,12 @@ export function installOneLineOverflowGeometry(
     overflowWidth: number;
   }>,
 ): OneLineOverflowGeometryHarness {
-  const originalResizeObserver = globalThis.ResizeObserver;
+  const resizeObserverGeometry = installResizeObserverGeometry();
   const originalGetBoundingClientRect = Object.getOwnPropertyDescriptor(
     HTMLElement.prototype,
     "getBoundingClientRect",
   );
-  const observers: ControlledResizeObserver[] = [];
   let availableWidth = input.availableWidth;
-  globalThis.ResizeObserver = class extends ControlledResizeObserver {
-    constructor(callback: ResizeObserverCallback) {
-      super(callback);
-      observers.push(this);
-    }
-  };
   Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
     configurable: true,
     value(this: HTMLElement): DOMRect {
@@ -49,17 +44,15 @@ export function installOneLineOverflowGeometry(
   });
   return {
     notify() {
-      for (const observer of observers) {
-        observer.notify();
-      }
+      resizeObserverGeometry.notify();
     },
     restore() {
-      globalThis.ResizeObserver = originalResizeObserver;
       if (originalGetBoundingClientRect === undefined) {
         Reflect.deleteProperty(HTMLElement.prototype, "getBoundingClientRect");
       } else {
         Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", originalGetBoundingClientRect);
       }
+      resizeObserverGeometry.restore();
     },
     setAvailableWidth(width) {
       availableWidth = width;
@@ -72,30 +65,6 @@ export function visibleOneLineOverflowText(row: HTMLElement): string {
     .filter((child) => child.getAttribute("aria-hidden") !== "true")
     .map((child) => child.textContent)
     .join("");
-}
-
-class ControlledResizeObserver implements ResizeObserver {
-  readonly #callback: ResizeObserverCallback;
-
-  constructor(callback: ResizeObserverCallback) {
-    this.#callback = callback;
-  }
-
-  disconnect(): void {
-    return;
-  }
-
-  observe(): void {
-    return;
-  }
-
-  unobserve(): void {
-    return;
-  }
-
-  notify(): void {
-    this.#callback([], this);
-  }
 }
 
 function rect(width: number, left = 0): DOMRect {

--- a/apps/desktop/src/test-support/resize-observer/index.ts
+++ b/apps/desktop/src/test-support/resize-observer/index.ts
@@ -1,0 +1,119 @@
+export type ResizeObserverGeometry = Readonly<{
+  clientHeight?: number | undefined;
+  rect?: DOMRect | undefined;
+  scrollHeight?: number | undefined;
+}>;
+
+export type ResizeObserverGeometryHarness = Readonly<{
+  notify(): void;
+  restore(): void;
+  setGeometry(element: HTMLElement, geometry: ResizeObserverGeometry): void;
+}>;
+
+export function installResizeObserverGeometry(): ResizeObserverGeometryHarness {
+  const originalResizeObserver = globalThis.ResizeObserver;
+  const originalClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientHeight");
+  const originalScrollHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollHeight");
+  const originalGetBoundingClientRect = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "getBoundingClientRect",
+  );
+  const geometries = new WeakMap<HTMLElement, ResizeObserverGeometry>();
+  const observers: ControlledResizeObserver[] = [];
+
+  globalThis.ResizeObserver = class extends ControlledResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      super(callback);
+      observers.push(this);
+    }
+  };
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get(this: HTMLElement) {
+      return geometries.get(this)?.clientHeight ?? 0;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get(this: HTMLElement) {
+      return geometries.get(this)?.scrollHeight ?? 0;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value(this: HTMLElement): DOMRect {
+      const geometry = geometries.get(this);
+      if (geometry?.rect !== undefined) {
+        return geometry.rect;
+      }
+      return emptyRect();
+    },
+  });
+
+  return {
+    notify() {
+      for (const observer of observers) {
+        observer.notify();
+      }
+    },
+    restore() {
+      globalThis.ResizeObserver = originalResizeObserver;
+      restoreDescriptor(HTMLElement.prototype, "clientHeight", originalClientHeight);
+      restoreDescriptor(HTMLElement.prototype, "scrollHeight", originalScrollHeight);
+      restoreDescriptor(HTMLElement.prototype, "getBoundingClientRect", originalGetBoundingClientRect);
+    },
+    setGeometry(element, geometry) {
+      geometries.set(element, geometry);
+    },
+  };
+}
+
+class ControlledResizeObserver implements ResizeObserver {
+  readonly #callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.#callback = callback;
+  }
+
+  disconnect(): void {
+    return;
+  }
+
+  observe(): void {
+    return;
+  }
+
+  unobserve(): void {
+    return;
+  }
+
+  notify(): void {
+    this.#callback([], this);
+  }
+}
+
+function restoreDescriptor(
+  prototype: typeof HTMLElement.prototype,
+  property: "clientHeight" | "getBoundingClientRect" | "scrollHeight",
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor === undefined) {
+    Reflect.deleteProperty(prototype, property);
+  } else {
+    Object.defineProperty(prototype, property, descriptor);
+  }
+}
+
+function emptyRect(): DOMRect {
+  return {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  };
+}

--- a/apps/desktop/src/ui/MarkdownField.tsx
+++ b/apps/desktop/src/ui/MarkdownField.tsx
@@ -194,6 +194,29 @@ function MarkdownFieldEditor({
   placeholder: string;
   value: string;
 }>) {
+  const editorRef = useRef<HTMLTextAreaElement | null>(null);
+  const onBlurRef = useRef(onBlur);
+
+  // Attach to the editor node so browser-native focus loss always returns the
+  // controlled field to its rendered Markdown presentation.
+  useEffect(() => {
+    onBlurRef.current = onBlur;
+  }, [onBlur]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (editor === null) {
+      return;
+    }
+    const handleBlur = () => {
+      onBlurRef.current();
+    };
+    editor.addEventListener("blur", handleBlur);
+    return () => {
+      editor.removeEventListener("blur", handleBlur);
+    };
+  }, []);
+
   return (
     <textarea
       aria-describedby={describedBy}
@@ -205,7 +228,7 @@ function MarkdownFieldEditor({
         "block h-full min-h-0 min-w-0 resize-none p-[var(--space-2)] font-mono",
       )}
       id={fieldID}
-      onBlur={onBlur}
+      ref={editorRef}
       onChange={(event) => {
         onChange(event.target.value);
       }}

--- a/apps/desktop/src/ui/MarkdownField.tsx
+++ b/apps/desktop/src/ui/MarkdownField.tsx
@@ -1,0 +1,427 @@
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
+
+import { ChevronDown } from "lucide-react";
+
+import { StaticMarkdown } from "./MarkdownText";
+import { cx } from "./classes";
+import { fieldIslandInputClassName } from "./fieldInputStyles";
+import { useOpacityExit } from "./motion";
+import {
+  consumeTextFieldSubmitShortcut,
+  type TextFieldSubmitShortcutPolicy,
+} from "./textFieldSubmitShortcut";
+
+export type MarkdownFieldTaskListInteraction = Readonly<{
+  checkedLabel: string;
+  uncheckedLabel: string;
+}>;
+
+export type MarkdownFieldSubmitIntent = Readonly<{
+  available: boolean;
+  onSubmitIntent: () => void;
+  policy: TextFieldSubmitShortcutPolicy;
+}>;
+
+export type MarkdownFieldHeightClamp = Readonly<{
+  maximumLines: number;
+  minimumLines: number;
+  viewportPercent: number;
+}>;
+
+type MarkdownFieldCommonProps = Readonly<{
+  disabled: boolean;
+  editorMinHeight: number;
+  error?: string | undefined;
+  label: string;
+  onChange: (value: string) => void;
+  onEdit: () => void;
+  onEditingChange: (editing: boolean) => void;
+  placeholder: string;
+  submitIntent?: MarkdownFieldSubmitIntent | undefined;
+  taskListInteraction?: MarkdownFieldTaskListInteraction | undefined;
+  value: string;
+  editing: boolean;
+}>;
+
+export type MarkdownFieldProps = MarkdownFieldCommonProps;
+
+export type CollapsibleMarkdownFieldProps = MarkdownFieldCommonProps &
+  Readonly<{
+    collapsedHeightClamp: MarkdownFieldHeightClamp;
+    expanded: boolean;
+    expandLabel: string;
+    onExpand: () => void;
+  }>;
+
+type MarkdownFieldReadPresentation =
+  | Readonly<{ kind: "plain" }>
+  | Readonly<{
+      collapsedHeightClamp: MarkdownFieldHeightClamp;
+      expanded: boolean;
+      expandLabel: string;
+      kind: "collapsible";
+      onExpand: () => void;
+    }>;
+
+type MarkdownFieldCoreProps = MarkdownFieldCommonProps &
+  Readonly<{
+    readPresentation: MarkdownFieldReadPresentation;
+  }>;
+
+export function MarkdownField(props: MarkdownFieldProps) {
+  return <MarkdownFieldCore {...props} readPresentation={{ kind: "plain" }} />;
+}
+
+export function CollapsibleMarkdownField({
+  collapsedHeightClamp,
+  expanded,
+  expandLabel,
+  onExpand,
+  ...props
+}: CollapsibleMarkdownFieldProps) {
+  return (
+    <MarkdownFieldCore
+      {...props}
+      readPresentation={{
+        collapsedHeightClamp,
+        expanded,
+        expandLabel,
+        kind: "collapsible",
+        onExpand,
+      }}
+    />
+  );
+}
+
+function MarkdownFieldCore({
+  disabled,
+  editorMinHeight,
+  error,
+  label,
+  onChange,
+  onEdit,
+  onEditingChange,
+  placeholder,
+  readPresentation,
+  submitIntent,
+  taskListInteraction,
+  value,
+  editing,
+}: MarkdownFieldCoreProps) {
+  const fieldID = useId();
+  const errorID = `${fieldID}-error`;
+  const errorText = error === undefined || error.length === 0 ? undefined : error;
+  const showEditor = editing && !disabled;
+
+  return (
+    <div className="grid h-full min-h-0 min-w-0 grid-rows-[minmax(0,1fr)_auto] gap-[var(--space-2)]">
+      <div className="min-h-0 min-w-0">
+        {showEditor ? (
+          <MarkdownFieldEditor
+            describedBy={errorText === undefined ? undefined : errorID}
+            editorMinHeight={editorMinHeight}
+            error={errorText !== undefined}
+            fieldID={fieldID}
+            label={label}
+            onBlur={() => {
+              onEditingChange(false);
+            }}
+            onChange={onChange}
+            onKeyDown={(event) => {
+              if (submitIntent === undefined) {
+                return;
+              }
+              const matched = consumeTextFieldSubmitShortcut(event, submitIntent.policy);
+              if (matched && !event.repeat && submitIntent.available) {
+                submitIntent.onSubmitIntent();
+              }
+            }}
+            placeholder={placeholder}
+            value={value}
+          />
+        ) : (
+          <MarkdownFieldReadViewport
+            disabled={disabled}
+            label={label}
+            onChange={onChange}
+            onEdit={onEdit}
+            onExpand={readPresentation.kind === "collapsible" ? readPresentation.onExpand : undefined}
+            placeholder={placeholder}
+            readPresentation={readPresentation}
+            taskListInteraction={taskListInteraction}
+            value={value}
+          />
+        )}
+      </div>
+      {errorText === undefined ? null : (
+        <span className="text-[var(--color-error)]" id={errorID}>
+          {errorText}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function MarkdownFieldEditor({
+  describedBy,
+  editorMinHeight,
+  error,
+  fieldID,
+  label,
+  onBlur,
+  onChange,
+  onKeyDown,
+  placeholder,
+  value,
+}: Readonly<{
+  describedBy?: string | undefined;
+  editorMinHeight: number;
+  error: boolean;
+  fieldID: string;
+  label: string;
+  onBlur: () => void;
+  onChange: (value: string) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  placeholder: string;
+  value: string;
+}>) {
+  return (
+    <textarea
+      aria-describedby={describedBy}
+      aria-invalid={error ? true : undefined}
+      aria-label={label}
+      autoFocus
+      className={cx(
+        fieldIslandInputClassName(1),
+        "block h-full min-h-0 min-w-0 resize-none p-[var(--space-2)] font-mono",
+      )}
+      id={fieldID}
+      onBlur={onBlur}
+      onChange={(event) => {
+        onChange(event.target.value);
+      }}
+      onKeyDown={onKeyDown}
+      placeholder={placeholder}
+      style={{ minHeight: `${editorMinHeight.toString()}px` }}
+      value={value}
+    />
+  );
+}
+
+function MarkdownFieldReadViewport({
+  disabled,
+  label,
+  onChange,
+  onEdit,
+  onExpand,
+  placeholder,
+  readPresentation,
+  taskListInteraction,
+  value,
+}: Readonly<{
+  disabled: boolean;
+  label: string;
+  onChange: (value: string) => void;
+  onEdit: () => void;
+  onExpand: (() => void) | undefined;
+  placeholder: string;
+  readPresentation: MarkdownFieldReadPresentation;
+  taskListInteraction: MarkdownFieldTaskListInteraction | undefined;
+  value: string;
+}>) {
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const collapsible = readPresentation.kind === "collapsible";
+  const collapsed = collapsible && !readPresentation.expanded;
+  const overflows = useMarkdownFieldOverflow({
+    contentRef,
+    enabled: collapsed,
+    viewportRef,
+  });
+  const affordancePhase = useOpacityExit(collapsible && !readPresentation.expanded && overflows);
+
+  const surfaceStyle: CSSProperties = collapsed
+    ? { maxHeight: heightClamp(readPresentation.collapsedHeightClamp) }
+    : {};
+  const taskListProps = markdownTaskListProps(disabled, taskListInteraction, onChange);
+  const expandLabel = readPresentation.kind === "collapsible" ? readPresentation.expandLabel : undefined;
+
+  return (
+    <div className="relative h-full min-h-0 min-w-0">
+      <div
+        aria-label={label}
+        aria-readonly
+        className={cx(
+          fieldIslandInputClassName(1),
+          "block h-full min-h-0 min-w-0 overflow-visible p-[var(--space-2)]",
+          !disabled && "cursor-text",
+          collapsed && "overflow-hidden",
+        )}
+        onKeyDown={(event) => {
+          activateFromKeyboard(event, disabled, onEdit);
+        }}
+        onPointerUp={(event) => {
+          activateFromPointer(event, disabled, onEdit);
+        }}
+        ref={viewportRef}
+        role="textbox"
+        style={surfaceStyle}
+        tabIndex={disabled ? -1 : 0}
+      >
+        <div ref={contentRef}>
+          {value.trim().length > 0 ? (
+            <StaticMarkdown disabled={disabled} {...(taskListProps ?? {})} value={value} />
+          ) : (
+            <span className="text-[var(--color-muted)]">{placeholder}</span>
+          )}
+        </div>
+      </div>
+      {renderMarkdownFieldAffordance(affordancePhase, expandLabel, onExpand)}
+    </div>
+  );
+}
+
+function useMarkdownFieldOverflow({
+  contentRef,
+  enabled,
+  viewportRef,
+}: Readonly<{
+  contentRef: Readonly<{ current: HTMLDivElement | null }>;
+  enabled: boolean;
+  viewportRef: Readonly<{ current: HTMLDivElement | null }>;
+}>): boolean {
+  const [overflows, setOverflows] = useState(false);
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const measureOverflow = () => {
+      const viewport = viewportRef.current;
+      if (viewport !== null) {
+        setOverflows(viewport.scrollHeight > viewport.clientHeight);
+      }
+    };
+    const frame = window.requestAnimationFrame(measureOverflow);
+    window.addEventListener("resize", measureOverflow);
+    if (typeof ResizeObserver === "undefined") {
+      return () => {
+        window.cancelAnimationFrame(frame);
+        window.removeEventListener("resize", measureOverflow);
+      };
+    }
+    const observer = new ResizeObserver(measureOverflow);
+    if (viewportRef.current !== null) {
+      observer.observe(viewportRef.current);
+    }
+    if (contentRef.current !== null) {
+      observer.observe(contentRef.current);
+    }
+    return () => {
+      observer.disconnect();
+      window.cancelAnimationFrame(frame);
+      window.removeEventListener("resize", measureOverflow);
+    };
+  }, [contentRef, enabled, viewportRef]);
+  return enabled && overflows;
+}
+
+function activateFromPointer(
+  event: PointerEvent<HTMLDivElement>,
+  disabled: boolean,
+  onEdit: () => void,
+): void {
+  if (disabled || !isPlainMarkdownActivation(event.target)) {
+    return;
+  }
+  const selection = window.getSelection();
+  if (selection !== null && !selection.isCollapsed) {
+    return;
+  }
+  onEdit();
+}
+
+function activateFromKeyboard(
+  event: KeyboardEvent<HTMLDivElement>,
+  disabled: boolean,
+  onEdit: () => void,
+): void {
+  if (disabled || event.target !== event.currentTarget) {
+    return;
+  }
+  if (event.key !== "Enter" && event.key !== " ") {
+    return;
+  }
+  event.preventDefault();
+  onEdit();
+}
+
+function isPlainMarkdownActivation(target: EventTarget | null): boolean {
+  return !(target instanceof Element && target.closest("a,button,input,[role='button']") !== null);
+}
+
+function markdownTaskListProps(
+  disabled: boolean,
+  interaction: MarkdownFieldTaskListInteraction | undefined,
+  onChange: (value: string) => void,
+): Readonly<{
+  onTaskListChange: (value: string) => void;
+  taskListItemToggleLabel: (checked: boolean) => string;
+}> | undefined {
+  if (disabled || interaction === undefined) {
+    return undefined;
+  }
+  return {
+    onTaskListChange: onChange,
+    taskListItemToggleLabel: (checked) =>
+      checked ? interaction.checkedLabel : interaction.uncheckedLabel,
+  };
+}
+
+function renderMarkdownFieldAffordance(
+  phase: ReturnType<typeof useOpacityExit>,
+  expandLabel: string | undefined,
+  onExpand: (() => void) | undefined,
+): ReactNode {
+  if (phase === "hidden" || onExpand === undefined || expandLabel === undefined) {
+    return null;
+  }
+  return (
+    <>
+      <div
+        aria-hidden="true"
+        className={cx(
+          "pointer-events-none absolute inset-x-[var(--space-2)] bottom-[var(--space-2)] h-12 bg-gradient-to-b from-transparent to-[var(--color-island-1)] transition-opacity motion-reduce:transition-none",
+          phase === "visible" ? "opacity-100" : "opacity-0",
+        )}
+        data-state={phase}
+      />
+      <button
+        aria-label={expandLabel}
+        className={cx(
+          "app-region-no-drag absolute inset-x-0 bottom-0 grid h-10 place-items-center text-[var(--color-on-island)] transition-opacity motion-reduce:transition-none",
+          phase === "visible"
+            ? "pointer-events-auto opacity-100"
+            : "pointer-events-none opacity-0",
+        )}
+        data-state={phase}
+        onClick={onExpand}
+        type="button"
+      >
+        <ChevronDown aria-hidden="true" size={20} strokeWidth={1.5} />
+      </button>
+    </>
+  );
+}
+
+function heightClamp(clamp: MarkdownFieldHeightClamp): string {
+  return `clamp(${clamp.minimumLines.toString()}lh,${clamp.viewportPercent.toString()}dvh,${clamp.maximumLines.toString()}lh)`;
+}

--- a/apps/desktop/src/ui/MarkdownField.tsx
+++ b/apps/desktop/src/ui/MarkdownField.tsx
@@ -429,6 +429,7 @@ function renderMarkdownFieldAffordance(
       />
       <button
         aria-label={expandLabel}
+        aria-hidden={phase === "visible" ? undefined : true}
         className={cx(
           "app-region-no-drag absolute inset-x-0 bottom-0 grid h-10 place-items-center text-[var(--color-on-island)] transition-opacity motion-reduce:transition-none",
           phase === "visible"
@@ -437,6 +438,7 @@ function renderMarkdownFieldAffordance(
         )}
         data-state={phase}
         onClick={onExpand}
+        tabIndex={phase === "visible" ? undefined : -1}
         type="button"
       >
         <ChevronDown aria-hidden="true" size={20} strokeWidth={1.5} />

--- a/apps/desktop/src/ui/index.ts
+++ b/apps/desktop/src/ui/index.ts
@@ -61,6 +61,20 @@ export { compactExternalUrlLabel, safeExternalUrl } from "./externalLinks";
 export { readEffectiveTheme, type AppTheme } from "./theme";
 export { cx } from "./classes";
 export { motionDurationFromCSSVar, prefersReducedMotion, useOpacityExit } from "./motion";
+export {
+  CollapsibleMarkdownField,
+  MarkdownField,
+  type CollapsibleMarkdownFieldProps,
+  type MarkdownFieldHeightClamp,
+  type MarkdownFieldProps,
+  type MarkdownFieldSubmitIntent,
+  type MarkdownFieldTaskListInteraction,
+} from "./MarkdownField";
+export {
+  consumeTextFieldSubmitShortcut,
+  isTextFieldSubmitShortcut,
+  type TextFieldSubmitShortcutPolicy,
+} from "./textFieldSubmitShortcut";
 export { Spinner } from "./Spinner";
 export type { SpinnerProps } from "./Spinner";
 export { Switch } from "./radix/switch";

--- a/apps/desktop/src/ui/textFieldSubmitShortcut.ts
+++ b/apps/desktop/src/ui/textFieldSubmitShortcut.ts
@@ -1,0 +1,56 @@
+export type TextFieldSubmitShortcutPolicy = "control-enter" | "meta-enter" | "unavailable";
+
+type TextFieldSubmitKeyEvent = Readonly<{
+  altKey: boolean;
+  ctrlKey: boolean;
+  isComposing?: boolean | undefined;
+  key: string;
+  metaKey: boolean;
+  nativeEvent?: Readonly<{ isComposing?: boolean | undefined }> | undefined;
+  repeat: boolean;
+  shiftKey: boolean;
+  preventDefault(): void;
+  stopPropagation(): void;
+}>;
+
+export function isTextFieldSubmitShortcut(
+  event: Pick<
+    TextFieldSubmitKeyEvent,
+    | "altKey"
+    | "ctrlKey"
+    | "isComposing"
+    | "key"
+    | "metaKey"
+    | "nativeEvent"
+    | "repeat"
+    | "shiftKey"
+  >,
+  policy: TextFieldSubmitShortcutPolicy,
+): boolean {
+  if (
+    policy === "unavailable" ||
+    event.key !== "Enter" ||
+    event.isComposing === true ||
+    event.nativeEvent?.isComposing === true ||
+    event.altKey ||
+    event.shiftKey
+  ) {
+    return false;
+  }
+  if (policy === "meta-enter") {
+    return event.metaKey && !event.ctrlKey;
+  }
+  return event.ctrlKey && !event.metaKey;
+}
+
+export function consumeTextFieldSubmitShortcut(
+  event: TextFieldSubmitKeyEvent,
+  policy: TextFieldSubmitShortcutPolicy,
+): boolean {
+  if (!isTextFieldSubmitShortcut(event, policy)) {
+    return false;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  return true;
+}

--- a/apps/desktop/tooling/vite.config.ts
+++ b/apps/desktop/tooling/vite.config.ts
@@ -44,6 +44,5 @@ export default defineConfig({
     globals: true,
     maxWorkers: 2,
     setupFiles: ["./test/setup.ts"],
-    testTimeout: 30_000,
   },
 });

--- a/apps/desktop/tooling/vite.config.ts
+++ b/apps/desktop/tooling/vite.config.ts
@@ -44,5 +44,6 @@ export default defineConfig({
     globals: true,
     maxWorkers: 2,
     setupFiles: ["./test/setup.ts"],
+    testTimeout: 30_000,
   },
 });

--- a/docs/dev/specs/desktop-chat.md
+++ b/docs/dev/specs/desktop-chat.md
@@ -213,7 +213,7 @@
 - Desktop has no `/goal` command. The visible Goal affordance and Goal sidebar are its only Goal entry path.
 - Goal uses the shared adaptive contextual-sidebar host.
 - The same Goal sidebar handles creation and management. It edits the complete objective as Markdown and has an explicit `Save` action.
-- Goal objective editing uses the same shared UI-kit editor as Task Description. Desktop does not maintain a Goal-specific large-text editor implementation.
+- Goal objective uses the shared collapsible large Markdown field defined for Desktop and used by Task Description.
 - An existing Goal opens as rendered Markdown. Activating the objective enters the shared editor. Goal creation opens the editor focused.
 - `Save` appears only while the objective draft differs from the authoritative Goal and contains non-whitespace text. A whitespace-only draft has no Save action. Saving an existing Goal replaces it directly without another confirmation. Success keeps the sidebar open and re-baselines the editor to the authoritative Goal.
 - Every successful Save uses set-or-replace semantics: the resulting Goal is active and Goal work starts or continues, including when the previous Goal was paused or complete.

--- a/docs/dev/specs/desktop-gui.md
+++ b/docs/dev/specs/desktop-gui.md
@@ -11,6 +11,15 @@
 - Keep unsent local drafts for new Tasks, comments, and editable Task or Project text while the window stays open. Do not queue or replay mutations. After reconnection, refresh server state and let the operator submit preserved drafts manually; a save overwrites remote changes.
 - Local capabilities such as clipboard, directory selection, separate windows, window controls, and notifications are distinct from server readiness. When unavailable, explain the unavailable action; cosmetic shell behavior may be absent in a browser presentation.
 - Text input is plain multiline Markdown. Rich Markdown preserves every source newline as a visible line break. Rich Markdown remains within its available surface width; only a code block may scroll horizontally inside its own block. Task Detail and Workflow Editor content use the approved rich Markdown presentation with sanitized raw-HTML and link behavior. Board previews are flattened text previews: they strip Markdown formatting and raw HTML without rendering rich structure or controls, preserve readable text labels, and remain bounded for dense boards. Completed supported code is syntax-highlighted and selectable in rich content; incomplete code remains selectable plain text.
+- Task Description and Goal objective use one shared large Markdown field. Desktop does not maintain feature-specific copies of its read or edit presentation.
+- The shared Markdown field has one base read-and-edit presentation and one optional collapsible presentation. The collapsible presentation adds overflow detection, a fade, and an accessible Expand action without creating another Markdown editor.
+- Each destination configures the editor's minimum height and the collapsible presentation's height clamp.
+- The destination owns the field's Markdown Draft, editing state, expanded state, dirty-Draft reconciliation, and server mutation. The field reports user editing, expansion, Draft-change, and submission intents without saving.
+- The destination supplies the field's accessible label, placeholder, disabled state, and mutation error. The field presents no built-in visible label, associates a supplied error with the editor, and contains no Task or Goal copy.
+- In enabled read mode, the field renders selectable rich Markdown. When the destination enables task-list interaction, selecting a Markdown task-list checkbox updates the destination-owned Draft without saving it.
+- A plain click or tap with no text selection enters editing. Dragging selects rendered Markdown without editing. Links and task-list checkboxes perform their own actions. Keyboard focus keeps the rendered presentation, and Enter or Space enters editing.
+- In disabled mode, the field renders read-only rich Markdown or its empty placeholder. It offers no editing focus or task-list interaction, and it does not change destination-owned presentation state.
+- Leaving the active editor returns the field to rendered Markdown without discarding its Draft.
 - When focus is in a Desktop text field outside the Workflow editor, Command+Enter on macOS and Ctrl+Enter on Windows or Linux must invoke that field's existing submit, save, or selection action. The shortcut must follow the same validation, disabled state, and confirmation behavior as that action.
 - The shortcut must do nothing when the focused text field has no existing submission action.
 - The shortcut must not change the field's ordinary Enter behavior.
@@ -232,11 +241,15 @@
 - Task creation and editing show server validation errors.
 - Task Detail can appear inline, in a separate window when supported, or as a standalone destination. Reopening an already separate Task Detail focuses it rather than duplicating it. Closing it after a mutation refreshes visible content.
 - On wide layouts that place Description and Metadata side by side, both islands have exactly the same height. Their shared height equals the larger intrinsic island height.
+- Task Description uses the shared collapsible large Markdown field.
 - Long descriptions start collapsed only when they overflow, at roughly half the available height and never fewer than about five or more than about ten rendered lines, with an expand action. Expansion lasts until that Task Detail closes, keeps the description top anchored, grows downward, and occurs automatically for editing.
 - A Markdown task-list item uses one product-styled checkbox in place of its list bullet.
 - Selecting a checkbox in an editable Task description updates the local Markdown body Draft without saving it. The existing Task Save action persists the changed body.
-- From an editable Task description, the text-field submission shortcut must save the current Task title and body together.
-- From an editable Task description, the text-field submission shortcut must close description editing.
+- From an editable Task description with a valid title and a dirty Draft, the text-field submission shortcut submits the current Task title and body together.
+- From an editable Task description with a clean Draft, the text-field submission shortcut closes description editing without a Task mutation.
+- While a dirty Task Description Save is pending, editing remains active and the Draft remains complete.
+- A successful dirty Task Description Save closes editing after the server operation completes.
+- A failed dirty Task Description Save keeps editing active, preserves the complete Draft, and presents the mutation error.
 - Task Detail begins with Inbox, which contains current blockers and answer, Approval, and Resume controls. Comments have composer, list, edit, delete, and count. There is no completed Workflow movement or execution-history view.
 - Task Detail shows Task Short ID, title, Markdown body, Project, Workflow, source workspace name and root, all Current Nodes and states, completion state, and available actions including Task Delete. When available, it also shows Execution Target, managed worktree, requested revision, resolved commit, branch, Agent role and execution state, Session identity, source URL, and assignee or column.
 - Source root and Execution Root are not separate facts. Unavailable expected facts are hidden; useful continuity facts may be empty or unassigned; unexpected meaningful absence is an unavailable or error state. Unavailable managed worktrees have no managed-worktree fact.

--- a/docs/dev/specs/desktop-gui.md
+++ b/docs/dev/specs/desktop-gui.md
@@ -245,11 +245,11 @@
 - Long descriptions start collapsed only when they overflow, at roughly half the available height and never fewer than about five or more than about ten rendered lines, with an expand action. Expansion lasts until that Task Detail closes, keeps the description top anchored, grows downward, and occurs automatically for editing.
 - A Markdown task-list item uses one product-styled checkbox in place of its list bullet.
 - Selecting a checkbox in an editable Task description updates the local Markdown body Draft without saving it. The existing Task Save action persists the changed body.
-- From an editable Task description with a valid title and a dirty Draft, the text-field submission shortcut submits the current Task title and body together.
-- From an editable Task description with a clean Draft, the text-field submission shortcut closes description editing without a Task mutation.
-- While a dirty Task Description Save is pending, editing remains active and the Draft remains complete.
-- A successful dirty Task Description Save closes editing after the server operation completes.
-- A failed dirty Task Description Save keeps editing active, preserves the complete Draft, and presents the mutation error.
+- From an editable Task description with a valid title and a dirty Draft, the text-field submission shortcut must submit the current Task title and body together.
+- From an editable Task description with a clean Draft, the text-field submission shortcut must close description editing without a Task mutation.
+- While a dirty Task Description Save is pending, editing must remain active and the Draft must remain complete.
+- A successful dirty Task Description Save must close editing after the server operation completes.
+- A failed dirty Task Description Save must keep editing active, preserve the complete Draft, and present the mutation error.
 - Task Detail begins with Inbox, which contains current blockers and answer, Approval, and Resume controls. Comments have composer, list, edit, delete, and count. There is no completed Workflow movement or execution-history view.
 - Task Detail shows Task Short ID, title, Markdown body, Project, Workflow, source workspace name and root, all Current Nodes and states, completion state, and available actions including Task Delete. When available, it also shows Execution Target, managed worktree, requested revision, resolved commit, branch, Agent role and execution state, Session identity, source URL, and assignee or column.
 - Source root and Execution Root are not separate facts. Unavailable expected facts are hidden; useful continuity facts may be empty or unassigned; unexpected meaningful absence is an unavailable or error state. Unavailable managed worktrees have no managed-worktree fact.


### PR DESCRIPTION
## Summary
- Extracted a controlled shared Markdown field and collapsible Markdown field facade under `apps/desktop/src/ui`.
- Migrated Task Description while keeping Draft, Save, mutation errors, retained presentation, task-list changes, and shortcut policy ownership in Task Detail.
- Added native textarea blur handling so real browser focus loss returns to rendered Markdown without losing the Draft.
- Kept the Expand fade visual transition while removing the exiting affordance from accessibility and keyboard focus.
- Updated the authoritative Desktop GUI/Chat specifications and focused Task product-boundary coverage.

## Verification
- Focused Task Description, shortcut, and overflow suites: 37/37 passed with an explicit CLI timeout.
- `pnpm --dir apps lint`: passed with 0 errors and five pre-existing Fast Refresh warnings.
- `pnpm --dir apps typecheck`: passed.
- `./scripts/build.sh desktop`: passed.
- `git diff --check`: passed.
- Full Desktop suite: a run passed 94 files / 498 tests while the temporary global timeout was present; that global timeout was removed after review. A fresh default-budget run exposed 9 suite-level timing failures (489/498) across unrelated Task/Sidebar tests, so this PR deliberately does not mask that pressure with a global timeout.

## Diff size
- Production code: 9 files, +626/-283; net +343, gross 909 lines.
- Tests and test support: 4 files, +523/-39; net +484, gross 562 lines.
- Documentation/specifications: 2 files, +16/-3; net +13, gross 19 lines.
- Total: 15 files, +1,165/-325; net +840, gross 1,490 lines. No generated files changed.

## Caveats and follow-up
- Manual browser QA remains a separate gate. Fresh QA confirmed read/rendered Markdown, safe links, checklist behavior, overflow/Expand, and blur Draft retention; true narrow CSS viewport and reduced-motion preference coverage remain unverified because of Firefox CLI limitations.
- No Goal consumer or controls were added; the shared seam is ready for the separately scoped Goal consumer.
- The default full-suite timing pressure should be followed up in the test harness/CI environment rather than hidden through a global timeout.

Kent task: KENT-382
GitHub issue: none associated.