### PR TITLE
Tighten JSON observation error handling

### DIFF
--- a/cli/kent/main.go
+++ b/cli/kent/main.go
@@ -648,10 +648,7 @@ func runLiveWatchSubcommandWithCleanup(args []string, runWithCleanup liveWatchCl
 		return runObservationUsage(outputMode, err.Error())
 	}
 	if err := publishPersistenceRootEnv(*persistenceRoot); err != nil {
-		if outputMode == runOutputModeJSON {
-			return emitObservationError(os.Stdout, observationOperationRunWatch, observationTargetSession(sessionID.String()), context.Background(), err, nil, nil)
-		}
-		return runLiveFlagError(err)
+		return runObservationUsage(outputMode, err.Error())
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/cli/kent/observation_json.go
+++ b/cli/kent/observation_json.go
@@ -5,6 +5,7 @@ import (
 	"core/cli/app"
 	"core/shared/client"
 	"core/shared/serverapi"
+	"core/shared/textutil"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -160,8 +161,8 @@ func projectRunWatchJSON(targetSessionID string, response serverapi.RuntimeLiveW
 			observationJSONFinalAnswer{
 				observationJSONKind: observationJSONKind{Kind: "final_answer"},
 				Result:              response.Outcome.FinalAnswer.Result,
-				SessionName:         jsonStringPointer(response.Outcome.FinalAnswer.SessionName),
-				DurationMS:          jsonInt64Pointer(response.Outcome.FinalAnswer.DurationMillis),
+				SessionName:         textutil.Value(response.Outcome.FinalAnswer.SessionName),
+				DurationMS:          textutil.Value(response.Outcome.FinalAnswer.DurationMillis),
 			},
 		}}, 0, nil
 	case serverapi.RuntimeLiveWatchNoFinalResult:
@@ -198,8 +199,8 @@ func projectRunWaitJSON(targetSessionID string, result app.RunPromptResult, err 
 		Status: "success", Target: observationTargetSession(targetSessionID),
 		Outcomes: []observationJSONOutcome{observationJSONFinalAnswer{
 			observationJSONKind: observationJSONKind{Kind: "final_answer"},
-			Result:              jsonStringPointer(result.Result), SessionName: jsonStringPointer(result.SessionName),
-			DurationMS: jsonInt64Pointer(result.Duration.Milliseconds()), Warnings: append([]string(nil), result.Warnings...),
+			Result:              textutil.Value(result.Result), SessionName: textutil.Value(result.SessionName),
+			DurationMS: textutil.Value(result.Duration.Milliseconds()), Warnings: append([]string(nil), result.Warnings...),
 		}},
 	}, 0
 }
@@ -294,5 +295,3 @@ func emitObservationError(w io.Writer, operation observationOperation, target ob
 	envelope, code := projectObservationError(operation, target, caller, err)
 	return emitObservationJSONWithCleanup(w, envelope, code, warnings, closeFn)
 }
-func jsonStringPointer(value string) *string { return &value }
-func jsonInt64Pointer(value int64) *int64    { return &value }


### PR DESCRIPTION
## Summary
- Reuse the shared `textutil.Value` optional-value constructor for JSON final-answer metadata and remove duplicate CLI pointer helpers.
- Route Run watch persistence-root publication failures through the shared observation usage path so JSON mode emits the usage envelope with exit code 2, matching the CLI contract.

This is a follow-up to merged PR #735, created because the watcher reported these valid findings after #735 had already merged.

## Verification
- Focused Go tests passed across `cli/kent`, `shared/client`, `cli/app`, and `shared/runtimeids`.
- `./scripts/build.sh server --output ./bin/kent` passed.
- `git diff --check` passed.

## Diff accounting
Gross is additions plus deletions; net is additions minus deletions, measured with `git diff origin/main..HEAD`:

| Area | Additions | Deletions | Net | Gross |
| --- | ---: | ---: | ---: | ---: |
| Production/help | 6 | 10 | -4 | 16 |
| Test code | 0 | 0 | 0 | 0 |
| Generated code | 0 | 0 | 0 | 0 |
| Documentation/specs | 0 | 0 | 0 | 0 |
| Total | 6 | 10 | -4 | 16 |

## Caveats and follow-up
- The original feature and its prior review fixes are already merged in PR #735; this PR contains only the two post-merge remediation changes above.
- No GitHub issue number was linked. Kent task addressed: KENT-432.