### PR TITLE
Add typed Desktop catalog client and queries

### DIFF
--- a/apps/desktop/src/api/apiService.ts
+++ b/apps/desktop/src/api/apiService.ts
@@ -34,6 +34,9 @@ import type {
   ProjectPage,
   ProjectWorkflowLink,
   ServerReadiness,
+  SessionCatalogPage,
+  SessionCategory,
+  SessionPagePosition,
   TaskAttention,
   TaskApproveResponse,
   TaskComment,
@@ -80,6 +83,11 @@ export interface ApiService {
 
   getReadiness(): Promise<ServerReadiness>;
   listProjects(pageToken: string): Promise<ProjectPage>;
+  listSessionPage(
+    projectID: string,
+    category: SessionCategory,
+    position: SessionPagePosition,
+  ): Promise<SessionCatalogPage>;
   listWorkspaces(projectID: string, pageToken?: string): Promise<WorkspaceList>;
   getProjectEdit(projectID: string, pageToken?: string): Promise<ProjectEdit>;
   planWorkspace(path: string): Promise<BindingPlan>;

--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -197,17 +197,20 @@ export class ApiClient implements ApiService {
     return response;
   }
 
-  async listWorkspaces(projectID: string, pageToken = ""): Promise<WorkspaceList> {
+  async listWorkspaces(projectID: string, pageToken?: string): Promise<WorkspaceList> {
     const validatedProjectID = parseCatalogInput("project.workspace.list project ID", canonicalProjectIDSchema, projectID);
-    const validatedPageToken = parseCatalogInput("project.workspace.list page token", workspacePageTokenSchema, pageToken);
+    const validatedPageToken =
+      pageToken === undefined
+        ? undefined
+        : parseCatalogInput("project.workspace.list page token", workspacePageTokenSchema, pageToken);
+    const request =
+      validatedPageToken === undefined
+        ? { project_id: validatedProjectID, page_size: 100 }
+        : { project_id: validatedProjectID, page_size: 100, page_token: validatedPageToken };
     const response = parseCatalogResponse(
       "project.workspace.list",
       workspaceListSchema,
-      await this.#transport.call("project.workspace.list", {
-        project_id: validatedProjectID,
-        page_size: 100,
-        page_token: validatedPageToken,
-      }),
+      await this.#transport.call("project.workspace.list", request),
     );
     requireCatalogProject("project.workspace.list", validatedProjectID, response.projectID);
     return response;

--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -1,3 +1,5 @@
+import type { z } from "zod";
+
 import type { AttentionNotificationEventHandler } from "./attentionNotifications";
 import { attentionNotificationRpcHandler } from "./attentionNotificationSubscription";
 import type { ApiConnectionSource, ApiService, ApiSubscription } from "./apiService";
@@ -48,6 +50,9 @@ import type {
   ProjectMutationResponse,
   ProjectPage,
   ServerReadiness,
+  SessionCatalogPage,
+  SessionCategory,
+  SessionPagePosition,
   TaskAttention,
   TaskComment,
   TaskDetail,
@@ -85,6 +90,14 @@ import {
   workspaceListSchema,
   workspaceUnlinkResponseSchema,
 } from "./schemas/project";
+import {
+  canonicalProjectIDSchema,
+  sessionCategorySchema,
+  sessionPagePositionSchema,
+  sessionPageResponseSchema,
+  workspacePageTokenSchema,
+} from "./schemas/catalog";
+import { CatalogContractError, ContractError } from "./errors";
 import { readinessSchema } from "./schemas/status";
 import { workflowIDSchema } from "./schemas/workflowID";
 import {
@@ -113,6 +126,25 @@ import { workflowProjectEventRpcHandler } from "./workflowProjectEvents";
 import * as workflowBoard from "./clientWorkflowBoard";
 import * as workflowLabels from "./clientWorkflowLabels";
 
+function parseCatalogInput<T>(operation: string, schema: z.ZodType<T>, value: unknown): T {
+  const result = schema.safeParse(value);
+  if (result.success) return result.data;
+  throw new ContractError(`${operation} did not match the catalog contract.`, result.error.issues.map((issue) => ({
+    code: issue.code,
+    path: issue.path.map(String),
+  })));
+}
+
+function parseCatalogResponse<T>(method: string, schema: z.ZodType<T>, value: unknown): T {
+  try { return parse(method, schema, value); } catch (error) {
+    throw error instanceof ContractError ? CatalogContractError.malformedResponse(method, error) : error;
+  }
+}
+
+function requireCatalogProject(method: string, expected: string, actual: string): void {
+  if (actual !== expected) throw CatalogContractError.projectMismatch(method, expected, actual);
+}
+
 export const guiTaskCommentAuthor = "user";
 
 export class ApiClient implements ApiService {
@@ -140,16 +172,45 @@ export class ApiClient implements ApiService {
     );
   }
 
+  async listSessionPage(
+    projectID: string,
+    category: SessionCategory,
+    position: SessionPagePosition,
+  ): Promise<SessionCatalogPage> {
+    const validatedProjectID = parseCatalogInput("session.page project ID", canonicalProjectIDSchema, projectID);
+    const validatedCategory = parseCatalogInput("session.page category", sessionCategorySchema, category);
+    const validatedPosition = parseCatalogInput("session.page position", sessionPagePositionSchema, position);
+    const response = parseCatalogResponse(
+      "session.page",
+      sessionPageResponseSchema,
+      await this.#transport.call("session.page", {
+        project_id: validatedProjectID,
+        category: validatedCategory,
+        page_size: 100,
+        position: validatedPosition,
+      }),
+    );
+    requireCatalogProject("session.page", validatedProjectID, response.projectID);
+    if (response.category !== validatedCategory) {
+      throw CatalogContractError.sessionCategoryMismatch(validatedCategory, response.category);
+    }
+    return response;
+  }
+
   async listWorkspaces(projectID: string, pageToken = ""): Promise<WorkspaceList> {
-    return parse(
+    const validatedProjectID = parseCatalogInput("project.workspace.list project ID", canonicalProjectIDSchema, projectID);
+    const validatedPageToken = parseCatalogInput("project.workspace.list page token", workspacePageTokenSchema, pageToken);
+    const response = parseCatalogResponse(
       "project.workspace.list",
       workspaceListSchema,
       await this.#transport.call("project.workspace.list", {
-        project_id: projectID,
+        project_id: validatedProjectID,
         page_size: 100,
-        page_token: pageToken,
+        page_token: validatedPageToken,
       }),
     );
+    requireCatalogProject("project.workspace.list", validatedProjectID, response.projectID);
+    return response;
   }
 
   async getProjectEdit(projectID: string, pageToken = ""): Promise<ProjectEdit> {

--- a/apps/desktop/src/api/clientCatalog.test.ts
+++ b/apps/desktop/src/api/clientCatalog.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import { FakeRpcTransport } from "@/test-support/api";
+import { ApiClient } from "./client";
+import { CatalogContractError, ContractError, RpcError } from "./index";
+const sessionResponse = {
+  project_id: "project-1",
+  category: "main",
+  sessions: [],
+} as const;
+const workspaceRow = {
+  workspace_id: "workspace-1",
+  display_name: "Kent",
+  root_path: "/workspace/kent",
+  availability: "available",
+  is_primary: true,
+  updated_at_unix_ms: 1,
+} as const;
+const workspaceResponse = {
+  project_id: "project-1",
+  workspaces: [workspaceRow],
+  default_workspace_id: "workspace-1",
+  next_page_token: "next-token",
+} as const;
+describe("ApiClient catalog boundary", () => {
+  it.each([
+    { category: "main" as const },
+    { category: "subagent" as const },
+  ])("requests a fixed 100-row newest Session page for $category", async ({ category }) => {
+    const transport = new FakeRpcTransport([
+      { method: "session.page", result: { ...sessionResponse, category } },
+    ]);
+    const client = new ApiClient(transport);
+
+    await expect(client.listSessionPage("project-1", category, { kind: "newest" })).resolves.toMatchObject({
+      projectID: "project-1",
+      category,
+    });
+    expect(transport.calls).toEqual([
+      {
+        method: "session.page",
+        params: {
+          project_id: "project-1",
+          category,
+          page_size: 100,
+          position: { kind: "newest" },
+        },
+      },
+    ]);
+  });
+  it.each([
+    { kind: "older" as const, token: "opaque-older" },
+    { kind: "newer" as const, token: "opaque-newer" },
+  ])("encodes opaque $kind Session positions", async (position) => {
+    const transport = new FakeRpcTransport([{ method: "session.page", result: sessionResponse }]);
+    await new ApiClient(transport).listSessionPage("project-1", "main", position);
+    expect(transport.calls[0]?.params).toMatchObject({ position });
+  });
+  it.each([
+    { kind: "older" as const, token: "" },
+    { kind: "older" as const, token: " token" },
+    { kind: "newer" as const, token: "token " },
+  ])("rejects malformed Session continuation $kind", async (position) => {
+    const transport = new FakeRpcTransport([]);
+    await expect(
+      new ApiClient(transport).listSessionPage("project-1", "main", position),
+    ).rejects.toBeInstanceOf(ContractError);
+    expect(transport.calls).toHaveLength(0);
+  });
+  it.each([" ", " next-token", "next-token "])("rejects invalid workspace page tokens %j", async (pageToken) => {
+    const transport = new FakeRpcTransport([]);
+    await expect(new ApiClient(transport).listWorkspaces("project-1", pageToken)).rejects.toBeInstanceOf(ContractError);
+    expect(transport.calls).toHaveLength(0);
+  });
+  it.each(["", " ", " project-1", "project-1 "])("rejects invalid catalog Project IDs %j", async (projectID) => {
+    const transport = new FakeRpcTransport([]);
+    const client = new ApiClient(transport);
+    await expect(client.listSessionPage(projectID, "main", { kind: "newest" })).rejects.toBeInstanceOf(ContractError);
+    await expect(client.listWorkspaces(projectID)).rejects.toBeInstanceOf(ContractError);
+    expect(transport.calls).toHaveLength(0);
+  });
+  it("validates Session page identity and preserves RPC failures", async () => {
+    const projectMismatch = new ApiClient(
+      new FakeRpcTransport([{ method: "session.page", result: { ...sessionResponse, project_id: "project-2" } }]),
+    );
+    await expect(projectMismatch.listSessionPage("project-1", "main", { kind: "newest" })).rejects.toMatchObject({
+      reason: "project_mismatch",
+      expectedProjectID: "project-1",
+      actualProjectID: "project-2",
+    });
+    const categoryMismatch = new ApiClient(
+      new FakeRpcTransport([{ method: "session.page", result: { ...sessionResponse, category: "subagent" } }]),
+    );
+    await expect(categoryMismatch.listSessionPage("project-1", "main", { kind: "newest" })).rejects.toMatchObject({
+      reason: "session_category_mismatch",
+      expectedCategory: "main",
+      actualCategory: "subagent",
+    });
+    const rpcError = new RpcError({ code: -32000, message: "unavailable", method: "session.page" });
+    const failed = new ApiClient(new FakeRpcTransport([{ method: "session.page", error: rpcError }]));
+    await expect(failed.listSessionPage("project-1", "main", { kind: "newest" })).rejects.toBe(rpcError);
+  });
+  it("validates the existing workspace page in place", async () => {
+    const transport = new FakeRpcTransport([{ method: "project.workspace.list", result: workspaceResponse }]);
+    const client = new ApiClient(transport);
+
+    await expect(client.listWorkspaces("project-1")).resolves.toMatchObject({
+      projectID: "project-1",
+      nextPageToken: "next-token",
+    });
+    expect(transport.calls).toEqual([
+      {
+        method: "project.workspace.list",
+        params: { project_id: "project-1", page_size: 100, page_token: "" },
+      },
+    ]);
+    await expect(
+      new ApiClient(
+        new FakeRpcTransport([
+          { method: "project.workspace.list", result: { ...workspaceResponse, project_id: "project-2" } },
+        ]),
+      ).listWorkspaces("project-1"),
+    ).rejects.toMatchObject({
+      reason: "project_mismatch",
+      expectedProjectID: "project-1",
+      actualProjectID: "project-2",
+    });
+  });
+  it("normalizes the existing workspace terminal continuation to null", async () => {
+    await expect(
+      new ApiClient(
+        new FakeRpcTransport([{ method: "project.workspace.list", result: { ...workspaceResponse } }]),
+      ).listWorkspaces("project-1"),
+    ).resolves.toMatchObject({ nextPageToken: "next-token" });
+    await expect(
+      new ApiClient(
+        new FakeRpcTransport([
+          {
+            method: "project.workspace.list",
+            result: { ...workspaceResponse, next_page_token: "" },
+          },
+        ]),
+      ).listWorkspaces("project-1"),
+    ).resolves.toMatchObject({ nextPageToken: null });
+    await expect(
+      new ApiClient(
+        new FakeRpcTransport([
+          {
+            method: "project.workspace.list",
+            result: { ...workspaceResponse, next_page_token: undefined },
+          },
+        ]),
+      ).listWorkspaces("project-1"),
+    ).resolves.toMatchObject({ nextPageToken: null });
+  });
+  it("reports malformed successful catalog payloads as typed errors", async () => {
+    const client = new ApiClient(
+      new FakeRpcTransport([
+        {
+          method: "session.page",
+          result: {
+            ...sessionResponse,
+            sessions: Array.from({ length: 101 }, (_, index) => ({
+              session_id: `session-${String(index)}`,
+              category: "main",
+              updated_at: "2026-08-09T10:00:00Z",
+            })),
+          },
+        },
+      ]),
+    );
+    const error = await catchError(client.listSessionPage("project-1", "main", { kind: "newest" }));
+    expect(error).toBeInstanceOf(CatalogContractError);
+    expect(error).toBeInstanceOf(ContractError);
+    expect(error).toMatchObject({ reason: "malformed_response" });
+  });
+});
+async function catchError(operation: Promise<unknown>): Promise<unknown> {
+  try {
+    await operation;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("operation did not fail");
+}

--- a/apps/desktop/src/api/clientCatalog.test.ts
+++ b/apps/desktop/src/api/clientCatalog.test.ts
@@ -173,6 +173,21 @@ describe("ApiClient catalog boundary", () => {
     expect(error).toBeInstanceOf(ContractError);
     expect(error).toMatchObject({ reason: "malformed_response" });
   });
+  it("preserves the complete diagnostic count when wrapping malformed responses", () => {
+    const source = new ContractError(
+      "source contract failure",
+      Array.from({ length: 12 }, (_, index) => ({
+        code: "invalid_type",
+        path: [`field-${String(index)}`],
+      })),
+    );
+
+    const error = CatalogContractError.malformedResponse("session.page", source);
+
+    expect(error.diagnostics).toHaveLength(8);
+    expect(error.totalDiagnosticCount).toBe(12);
+    expect(error.message).toContain("+4 more");
+  });
 });
 async function catchError(operation: Promise<unknown>): Promise<unknown> {
   try {

--- a/apps/desktop/src/api/clientCatalog.test.ts
+++ b/apps/desktop/src/api/clientCatalog.test.ts
@@ -66,7 +66,7 @@ describe("ApiClient catalog boundary", () => {
     ).rejects.toBeInstanceOf(ContractError);
     expect(transport.calls).toHaveLength(0);
   });
-  it.each([" ", " next-token", "next-token "])("rejects invalid workspace page tokens %j", async (pageToken) => {
+  it.each(["", " ", " next-token", "next-token "])("rejects invalid workspace page tokens %j", async (pageToken) => {
     const transport = new FakeRpcTransport([]);
     await expect(new ApiClient(transport).listWorkspaces("project-1", pageToken)).rejects.toBeInstanceOf(ContractError);
     expect(transport.calls).toHaveLength(0);
@@ -110,7 +110,7 @@ describe("ApiClient catalog boundary", () => {
     expect(transport.calls).toEqual([
       {
         method: "project.workspace.list",
-        params: { project_id: "project-1", page_size: 100, page_token: "" },
+        params: { project_id: "project-1", page_size: 100 },
       },
     ]);
     await expect(

--- a/apps/desktop/src/api/errors.ts
+++ b/apps/desktop/src/api/errors.ts
@@ -358,12 +358,17 @@ export class ContractError extends Error {
   readonly diagnostics: readonly ContractIssueDiagnostic[];
   readonly totalDiagnosticCount: number;
 
-  constructor(message: string, diagnostics: readonly ContractIssueDiagnostic[] = []) {
+  constructor(
+    message: string,
+    diagnostics: readonly ContractIssueDiagnostic[] = [],
+    totalDiagnosticCount = diagnostics.length,
+  ) {
     const retainedDiagnostics = diagnostics.slice(0, 8);
-    super(contractErrorMessage(message, retainedDiagnostics, diagnostics.length));
+    const completeDiagnosticCount = Math.max(totalDiagnosticCount, diagnostics.length);
+    super(contractErrorMessage(message, retainedDiagnostics, completeDiagnosticCount));
     this.name = "ContractError";
     this.diagnostics = retainedDiagnostics;
-    this.totalDiagnosticCount = diagnostics.length;
+    this.totalDiagnosticCount = completeDiagnosticCount;
   }
 }
 
@@ -382,9 +387,9 @@ export class CatalogContractError extends ContractError {
     reason: CatalogContractErrorReason,
     facts: Readonly<{ method?: string; expectedProjectID?: string; actualProjectID?: string;
       expectedCategory?: "main" | "subagent"; actualCategory?: "main" | "subagent";
-      diagnostics?: readonly ContractIssueDiagnostic[] }>,
+      diagnostics?: readonly ContractIssueDiagnostic[]; totalDiagnosticCount?: number }>,
   ) {
-    super(message, facts.diagnostics);
+    super(message, facts.diagnostics, facts.totalDiagnosticCount);
     this.name = "CatalogContractError"; this.reason = reason; this.method = facts.method ?? null;
     this.expectedProjectID = facts.expectedProjectID ?? null; this.actualProjectID = facts.actualProjectID ?? null;
     this.expectedCategory = facts.expectedCategory ?? null; this.actualCategory = facts.actualCategory ?? null;
@@ -392,7 +397,7 @@ export class CatalogContractError extends ContractError {
 
   static malformedResponse(method: string, error: ContractError): CatalogContractError {
     return new CatalogContractError(`${method} response did not match the catalog contract.`, "malformed_response", {
-      method, diagnostics: error.diagnostics,
+      method, diagnostics: error.diagnostics, totalDiagnosticCount: error.totalDiagnosticCount,
     });
   }
 

--- a/apps/desktop/src/api/errors.ts
+++ b/apps/desktop/src/api/errors.ts
@@ -367,6 +367,55 @@ export class ContractError extends Error {
   }
 }
 
+export type CatalogContractErrorReason =
+  | "malformed_response"
+  | "project_mismatch"
+  | "session_category_mismatch";
+
+export class CatalogContractError extends ContractError {
+  readonly reason: CatalogContractErrorReason;
+  readonly method: string | null; readonly expectedProjectID: string | null; readonly actualProjectID: string | null;
+  readonly expectedCategory: "main" | "subagent" | null; readonly actualCategory: "main" | "subagent" | null;
+
+  private constructor(
+    message: string,
+    reason: CatalogContractErrorReason,
+    facts: Readonly<{ method?: string; expectedProjectID?: string; actualProjectID?: string;
+      expectedCategory?: "main" | "subagent"; actualCategory?: "main" | "subagent";
+      diagnostics?: readonly ContractIssueDiagnostic[] }>,
+  ) {
+    super(message, facts.diagnostics);
+    this.name = "CatalogContractError"; this.reason = reason; this.method = facts.method ?? null;
+    this.expectedProjectID = facts.expectedProjectID ?? null; this.actualProjectID = facts.actualProjectID ?? null;
+    this.expectedCategory = facts.expectedCategory ?? null; this.actualCategory = facts.actualCategory ?? null;
+  }
+
+  static malformedResponse(method: string, error: ContractError): CatalogContractError {
+    return new CatalogContractError(`${method} response did not match the catalog contract.`, "malformed_response", {
+      method, diagnostics: error.diagnostics,
+    });
+  }
+
+  static projectMismatch(
+    method: string,
+    expectedProjectID: string,
+    actualProjectID: string,
+  ): CatalogContractError {
+    return new CatalogContractError(`${method} response Project identity did not match the request.`, "project_mismatch", {
+      method, expectedProjectID, actualProjectID,
+    });
+  }
+
+  static sessionCategoryMismatch(
+    expectedCategory: "main" | "subagent",
+    actualCategory: "main" | "subagent",
+  ): CatalogContractError {
+    return new CatalogContractError("session.page response category did not match the request.", "session_category_mismatch", {
+      method: "session.page", expectedCategory, actualCategory,
+    });
+  }
+}
+
 export class ProtocolMismatchError extends Error {
   constructor(message: string) {
     super(message);

--- a/apps/desktop/src/api/index.ts
+++ b/apps/desktop/src/api/index.ts
@@ -37,6 +37,7 @@ export {
 } from "./models";
 export { boardNodeCardsPageSize, defaultBoardNodeCardsSort } from "./boardNodeCardsSorting";
 export {
+  CatalogContractError,
   ContractError,
   ProtocolMismatchError,
   RpcError,
@@ -54,6 +55,7 @@ export {
   errorMessage,
 } from "./errors";
 export type { WorkflowLabelErrorReason } from "./errors";
+export type { CatalogContractErrorReason } from "./errors";
 export type { WorkflowTaskDependencyErrorReason } from "./errors";
 export type { TaskSearchErrorReason } from "./errors";
 export { guiTaskCommentAuthor } from "./client";
@@ -161,9 +163,16 @@ export type {
   WorkflowValidation,
   WorkflowValidationError,
   WorkspaceSummary,
+  WorkspaceList,
   WorkspaceAvailability,
   WorkspaceUnlinkBlocker,
   WorkspaceUnlinkResponse,
+} from "./models";
+export type {
+  SessionCatalogPage,
+  SessionCatalogSummary,
+  SessionCategory,
+  SessionPagePosition,
 } from "./models";
 export type {
   WorkflowEdgeSelectionMode,

--- a/apps/desktop/src/api/models.ts
+++ b/apps/desktop/src/api/models.ts
@@ -92,8 +92,16 @@ export type WorkspaceList = Readonly<{
   projectID: string;
   workspaces: readonly WorkspaceSummary[];
   defaultWorkspaceID: string;
-  nextPageToken: string;
+  nextPageToken: string | null;
 }>;
+
+export type SessionCategory = "main" | "subagent";
+
+export type SessionPagePosition = Readonly<{ kind: "newest" }>
+  | Readonly<{ kind: "older"; token: string }>
+  | Readonly<{ kind: "newer"; token: string }>;
+export type SessionCatalogSummary = Readonly<{ id: string; category: SessionCategory; name: string | null; firstPromptPreview: string | null; updatedAt: number }>;
+export type SessionCatalogPage = Readonly<{ projectID: string; category: SessionCategory; sessions: readonly SessionCatalogSummary[]; older: string | null; newer: string | null }>;
 
 export type ProjectEdit = Readonly<{
   projectID: string;

--- a/apps/desktop/src/api/schemas/catalog.test.ts
+++ b/apps/desktop/src/api/schemas/catalog.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import { sessionPageResponseSchema } from "./catalog";
+import { workspaceListSchema } from "./project";
+const session = {
+  session_id: "session-1",
+  category: "main",
+  first_prompt_preview: "Build the catalog",
+  updated_at: "2026-08-09T10:00:00Z",
+} as const;
+const workspace = {
+  workspace_id: "workspace-1",
+  display_name: "Kent",
+  root_path: "/workspace/kent",
+  availability: "available",
+  is_primary: true,
+  updated_at_unix_ms: 1,
+} as const;
+describe("Session catalog schema", () => {
+  it.each([
+    { name: undefined, expectedName: null },
+    { name: null, expectedName: null },
+    { name: "Catalog session", expectedName: "Catalog session" },
+  ])("maps Session name $name to its nullable domain form", ({ name, expectedName }) => {
+    const value = sessionPageResponseSchema.parse({
+      project_id: "project-1",
+      category: "main",
+      sessions: [{ ...session, ...(name === undefined ? {} : { name }) }],
+      older: "older-token",
+    });
+
+    expect(value.sessions[0]).toEqual({
+      id: "session-1",
+      category: "main",
+      name: expectedName,
+      firstPromptPreview: "Build the catalog",
+      updatedAt: Date.parse("2026-08-09T10:00:00Z"),
+    });
+  });
+  it("maps omitted prompt previews to null and preserves present previews", () => {
+    expect(
+      sessionPageResponseSchema.parse({
+        project_id: "project-1",
+        category: "main",
+        sessions: [{ ...session, first_prompt_preview: undefined }],
+      }).sessions[0]?.firstPromptPreview,
+    ).toBeNull();
+    expect(
+      sessionPageResponseSchema.parse({
+        project_id: "project-1",
+        category: "main",
+        sessions: [{ ...session, first_prompt_preview: "  preview  " }],
+      }).sessions[0]?.firstPromptPreview,
+    ).toBe("  preview  ");
+    expect(() =>
+      sessionPageResponseSchema.parse({
+        project_id: "project-1",
+        category: "main",
+        sessions: [{ ...session, first_prompt_preview: null }],
+      }),
+    ).toThrow();
+    expect(() =>
+      sessionPageResponseSchema.parse({
+        project_id: "project-1",
+        category: "main",
+        sessions: [],
+        older: null,
+      }),
+    ).toThrow();
+  });
+  it.each(["", " ", "\t"])("rejects invalid present Session names %j", (name) => {
+    expect(() =>
+      sessionPageResponseSchema.parse({
+        project_id: "project-1",
+        category: "main",
+        sessions: [{ ...session, name }],
+      }),
+    ).toThrow();
+  });
+  it.each(["", " project-1", "project-1 "])("rejects non-canonical Project IDs %j", (projectID) => {
+    expect(() =>
+      sessionPageResponseSchema.parse({
+        project_id: projectID,
+        category: "main",
+        sessions: [],
+      }),
+    ).toThrow();
+  });
+  it.each(["", " session-1", "session-1 "])("rejects non-canonical Session IDs %j", (sessionID) => {
+    expect(() =>
+      sessionPageResponseSchema.parse({
+        project_id: "project-1",
+        category: "main",
+        sessions: [{ ...session, session_id: sessionID }],
+      }),
+    ).toThrow();
+  });
+  it.each(["1970-01-01T00:00:00Z", "1969-12-31T23:59:59Z", "not-a-timestamp"])(
+    "rejects invalid Session recency %j",
+    (updatedAt) => {
+      expect(() =>
+        sessionPageResponseSchema.parse({
+          project_id: "project-1",
+          category: "main",
+          sessions: [{ ...session, updated_at: updatedAt }],
+        }),
+      ).toThrow();
+    },
+  );
+  it("rejects row categories that differ from the page category and pages above 100 rows", () => {
+    expect(() =>
+      sessionPageResponseSchema.parse({
+        project_id: "project-1",
+        category: "main",
+        sessions: [{ ...session, category: "subagent" }],
+      }),
+    ).toThrow();
+    expect(() =>
+      sessionPageResponseSchema.parse({
+        project_id: "project-1",
+        category: "main",
+        sessions: Array.from({ length: 101 }, (_, index) => ({
+          ...session,
+          session_id: `session-${String(index)}`,
+        })),
+      }),
+    ).toThrow();
+  });
+});
+describe("Workspace list schema", () => {
+  const page = {
+    project_id: "project-1",
+    workspaces: [workspace],
+    default_workspace_id: "workspace-1",
+  };
+  it("preserves an empty display name for a filesystem-root workspace", () => {
+    expect(
+      workspaceListSchema.parse({
+        ...page,
+        workspaces: [{ ...workspace, display_name: "", root_path: "/" }],
+        next_page_token: "",
+      }).workspaces[0],
+    ).toMatchObject({ id: "workspace-1", name: "", rootPath: "/" });
+  });
+  it.each([
+    ["project_id", ""],
+    ["project_id", " "],
+    ["project_id", " project-1"],
+    ["project_id", "project-1 "],
+    ["workspace_id", ""],
+    ["workspace_id", " "],
+    ["workspace_id", " workspace-1"],
+    ["workspace_id", "workspace-1 "],
+    ["default_workspace_id", ""],
+    ["default_workspace_id", " "],
+    ["default_workspace_id", " workspace-1"],
+    ["default_workspace_id", "workspace-1 "],
+  ])("rejects invalid required ID %s", (field, invalid) => {
+    const value = { ...page, workspaces: [workspace], [field]: invalid };
+    if (field === "workspace_id") {
+      expect(() =>
+        workspaceListSchema.parse({
+          ...page,
+          workspaces: [{ ...workspace, workspace_id: invalid }],
+        }),
+      ).toThrow();
+      return;
+    }
+    expect(() => workspaceListSchema.parse(value)).toThrow();
+  });
+  it("rejects empty required workspace roots", () => {
+    expect(() =>
+      workspaceListSchema.parse({
+        ...page,
+        workspaces: [{ ...workspace, root_path: "" }],
+      }),
+    ).toThrow();
+  });
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, "1"])(
+    "rejects invalid workspace recency %j",
+    (updatedAt) => {
+      expect(() =>
+        workspaceListSchema.parse({
+          ...page,
+          workspaces: [{ ...workspace, updated_at_unix_ms: updatedAt }],
+        }),
+      ).toThrow();
+    },
+  );
+  it("normalizes omitted and exact-empty terminal continuations", () => {
+    expect(workspaceListSchema.parse(page).nextPageToken).toBeNull();
+    expect(workspaceListSchema.parse({ ...page, next_page_token: "" }).nextPageToken).toBeNull();
+    expect(workspaceListSchema.parse({ ...page, next_page_token: "next-token" }).nextPageToken).toBe(
+      "next-token",
+    );
+  });
+
+  it.each([" ", "\tnext-token", "next-token "])("rejects malformed nonterminal continuation %j", (token) => {
+    expect(() => workspaceListSchema.parse({ ...page, next_page_token: token })).toThrow();
+  });
+
+  it("rejects workspace pages above 100 rows", () => {
+    expect(() =>
+      workspaceListSchema.parse({
+        ...page,
+        workspaces: Array.from({ length: 101 }, (_, index) => ({
+          ...workspace,
+          workspace_id: `workspace-${String(index)}`,
+        })),
+      }),
+    ).toThrow();
+  });
+});

--- a/apps/desktop/src/api/schemas/catalog.test.ts
+++ b/apps/desktop/src/api/schemas/catalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sessionPageResponseSchema } from "./catalog";
+import { sessionPageResponseSchema, workspacePageTokenSchema } from "./catalog";
 import { workspaceListSchema } from "./project";
 const session = {
   session_id: "session-1",
@@ -208,5 +208,9 @@ describe("Workspace list schema", () => {
         })),
       }),
     ).toThrow();
+  });
+  it("does not represent an absent initial cursor as an empty page token", () => {
+    expect(workspacePageTokenSchema.safeParse("").success).toBe(false);
+    expect(workspacePageTokenSchema.safeParse("next-token").success).toBe(true);
   });
 });

--- a/apps/desktop/src/api/schemas/catalog.ts
+++ b/apps/desktop/src/api/schemas/catalog.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+import type {
+  SessionCatalogPage,
+  SessionCatalogSummary,
+  SessionCategory,
+  SessionPagePosition,
+} from "../models";
+export const canonicalProjectIDSchema = z
+  .string()
+  .refine((value) => value.trim().length > 0 && value.trim() === value);
+const canonicalNonBlankString = canonicalProjectIDSchema;
+const opaqueTokenSchema = canonicalNonBlankString;
+export const workspacePageTokenSchema = z.string().refine(
+  (value) => value === "" || canonicalProjectIDSchema.safeParse(value).success,
+);
+export const sessionCategorySchema: z.ZodType<SessionCategory> = z.enum(["main", "subagent"]);
+export const sessionPagePositionSchema: z.ZodType<SessionPagePosition> = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("newest") }).strict(),
+  z.object({ kind: z.literal("older"), token: opaqueTokenSchema }).strict(),
+  z.object({ kind: z.literal("newer"), token: opaqueTokenSchema }).strict(),
+]);
+const sessionNameSchema = z
+  .string()
+  .refine((value) => value.trim().length > 0)
+  .nullable()
+  .optional()
+  .transform((value) => value ?? null);
+const promptPreviewSchema = z
+  .string()
+  .optional()
+  .transform((value) => value ?? null);
+const sessionRecencySchema = z
+  .iso.datetime({ offset: true })
+  .transform((value) => Date.parse(value))
+  .pipe(z.number().positive());
+const sessionCatalogSummarySchema: z.ZodType<SessionCatalogSummary> = z
+  .object({
+    session_id: canonicalNonBlankString,
+    category: sessionCategorySchema,
+    name: sessionNameSchema,
+    first_prompt_preview: promptPreviewSchema,
+    updated_at: sessionRecencySchema,
+  })
+  .strict()
+  .transform((value) => ({
+    id: value.session_id,
+    category: value.category,
+    name: value.name,
+    firstPromptPreview: value.first_prompt_preview,
+    updatedAt: value.updated_at,
+  }));
+const sessionContinuationSchema = opaqueTokenSchema.optional().transform((value) => value ?? null);
+export const sessionPageResponseSchema: z.ZodType<SessionCatalogPage> = z
+  .object({
+    project_id: canonicalNonBlankString,
+    category: sessionCategorySchema,
+    sessions: z.array(sessionCatalogSummarySchema).max(100),
+    older: sessionContinuationSchema,
+    newer: sessionContinuationSchema,
+  })
+  .strict()
+  .superRefine((value, context) => {
+    value.sessions.forEach((session, index) => {
+      if (session.category !== value.category) {
+        context.addIssue({
+          code: "custom",
+          path: ["sessions", index, "category"],
+          message: "Session category must match page category.",
+        });
+      }
+    });
+  })
+  .transform((value) => ({
+    projectID: value.project_id,
+    category: value.category,
+    sessions: value.sessions,
+    older: value.older,
+    newer: value.newer,
+  }));

--- a/apps/desktop/src/api/schemas/catalog.ts
+++ b/apps/desktop/src/api/schemas/catalog.ts
@@ -10,9 +10,8 @@ export const canonicalProjectIDSchema = z
   .refine((value) => value.trim().length > 0 && value.trim() === value);
 const canonicalNonBlankString = canonicalProjectIDSchema;
 const opaqueTokenSchema = canonicalNonBlankString;
-export const workspacePageTokenSchema = z.string().refine(
-  (value) => value === "" || canonicalProjectIDSchema.safeParse(value).success,
-);
+export const workspacePageTokenSchema = canonicalNonBlankString;
+export const workspaceContinuationWireSchema = z.union([z.literal(""), canonicalNonBlankString]);
 export const sessionCategorySchema: z.ZodType<SessionCategory> = z.enum(["main", "subagent"]);
 export const sessionPagePositionSchema: z.ZodType<SessionPagePosition> = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("newest") }).strict(),

--- a/apps/desktop/src/api/schemas/project.ts
+++ b/apps/desktop/src/api/schemas/project.ts
@@ -11,6 +11,23 @@ import type {
   WorkspaceUnlinkResponse,
 } from "../models";
 import { projectBindingSchema, workflowIDSchema, workspaceSummarySchema } from "./common";
+import { canonicalProjectIDSchema, workspacePageTokenSchema } from "./catalog";
+
+const workspaceListRowSchema = workspaceSummarySchema.superRefine((value, context) => {
+  if (!canonicalProjectIDSchema.safeParse(value.id).success) {
+    context.addIssue({ code: "custom", path: ["id"], message: "Workspace ID is not canonical." });
+  }
+  if (value.rootPath.length === 0) {
+    context.addIssue({ code: "custom", path: ["rootPath"], message: "Workspace root path is required." });
+  }
+  if (!Number.isFinite(value.updatedAt) || !Number.isInteger(value.updatedAt) || value.updatedAt <= 0) {
+    context.addIssue({ code: "custom", path: ["updatedAt"], message: "Workspace recency is invalid." });
+  }
+});
+
+export const workspaceContinuationSchema = workspacePageTokenSchema
+  .optional()
+  .transform((value) => (value === undefined || value === "" ? null : value));
 
 export const projectSummarySchema = z
   .object({
@@ -54,11 +71,12 @@ export const projectPageSchema: z.ZodType<ProjectPage> = z
 
 export const workspaceListSchema: z.ZodType<WorkspaceList> = z
   .object({
-    project_id: z.string(),
-    workspaces: z.array(workspaceSummarySchema),
-    default_workspace_id: z.string(),
-    next_page_token: z.string().optional().default(""),
+    project_id: canonicalProjectIDSchema,
+    workspaces: z.array(workspaceListRowSchema).max(100),
+    default_workspace_id: canonicalProjectIDSchema,
+    next_page_token: workspaceContinuationSchema,
   })
+  .strict()
   .transform((value) => ({
     projectID: value.project_id,
     workspaces: value.workspaces,

--- a/apps/desktop/src/api/schemas/project.ts
+++ b/apps/desktop/src/api/schemas/project.ts
@@ -11,7 +11,7 @@ import type {
   WorkspaceUnlinkResponse,
 } from "../models";
 import { projectBindingSchema, workflowIDSchema, workspaceSummarySchema } from "./common";
-import { canonicalProjectIDSchema, workspacePageTokenSchema } from "./catalog";
+import { canonicalProjectIDSchema, workspaceContinuationWireSchema } from "./catalog";
 
 const workspaceListRowSchema = workspaceSummarySchema.superRefine((value, context) => {
   if (!canonicalProjectIDSchema.safeParse(value.id).success) {
@@ -25,7 +25,7 @@ const workspaceListRowSchema = workspaceSummarySchema.superRefine((value, contex
   }
 });
 
-export const workspaceContinuationSchema = workspacePageTokenSchema
+export const workspaceContinuationSchema = workspaceContinuationWireSchema
   .optional()
   .transform((value) => (value === undefined || value === "" ? null : value));
 

--- a/apps/desktop/src/app-facade/index.ts
+++ b/apps/desktop/src/app-facade/index.ts
@@ -5,6 +5,7 @@ export * from "./nativeHooks";
 export * from "./navigation";
 export * from "./navigationTransitions";
 export * from "./projectDeletionEvents";
+export * from "./projectCatalogQueries";
 export * from "./projectRoutePersistence";
 export * from "./queryKeys";
 export * from "./services";

--- a/apps/desktop/src/app-facade/projectCatalogQueries.test.ts
+++ b/apps/desktop/src/app-facade/projectCatalogQueries.test.ts
@@ -1,0 +1,150 @@
+import { InfiniteQueryObserver, QueryClient } from "@tanstack/react-query";
+import { waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type {
+  ApiService,
+  SessionCatalogPage,
+  SessionCategory,
+  SessionPagePosition,
+  WorkspaceList,
+} from "@/api";
+import {
+  invalidateProjectSessionCatalogs,
+  mainSessionCatalogInfiniteQueryOptions,
+  subagentSessionCatalogInfiniteQueryOptions,
+  workspaceCatalogInfiniteQueryOptions,
+} from "./projectCatalogQueries";
+import { queryKeys } from "./queryKeys";
+describe("Project catalog query authority", () => {
+  it("uses independent Project/category keys and a distinct workspace infinite-query key", () => {
+    expect(queryKeys.projectSessionCatalog("project-1", "main")).not.toEqual(
+      queryKeys.projectSessionCatalog("project-1", "subagent"),
+    );
+    expect(queryKeys.projectSessionCatalog("project-1", "main")).not.toEqual(
+      queryKeys.projectSessionCatalog("project-2", "main"),
+    );
+    expect(queryKeys.projectWorkspaceCatalog("project-1")).not.toEqual(queryKeys.workspaces("project-1"));
+  });
+  it("retains five Session pages and traverses newest, older, and newer positions", async () => {
+    const requests: SessionPagePosition[] = [];
+    const pageByToken = new Map<string, number>();
+    const api: Pick<ApiService, "listSessionPage"> = {
+      listSessionPage: async (
+        projectID: string,
+        category: SessionCategory,
+        position: SessionPagePosition,
+      ): Promise<SessionCatalogPage> => {
+        expect(projectID).toBe("project-1");
+        expect(category).toBe("main");
+        requests.push(position);
+        const page = position.kind === "newest" ? 0 : pageByToken.get(position.token);
+        if (page === undefined) throw new Error("fixture received an unknown continuation.");
+        const older = `older-${String(page + 1)}`;
+        pageByToken.set(older, page + 1);
+        const newer = page > 0 ? `newer-${String(page - 1)}` : null;
+        if (newer !== null) pageByToken.set(newer, page - 1);
+        return {
+          projectID,
+          category,
+          sessions: [],
+          older,
+          newer,
+        };
+      },
+    };
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const observer = new InfiniteQueryObserver(
+      queryClient,
+      mainSessionCatalogInfiniteQueryOptions(api, "project-1"),
+    );
+    const unsubscribe = observer.subscribe(() => undefined);
+
+    await waitForSuccess(observer);
+    for (let index = 0; index < 5; index += 1) {
+      await observer.fetchNextPage();
+    }
+
+    expect(requests).toEqual([
+      { kind: "newest" },
+      { kind: "older", token: "older-1" },
+      { kind: "older", token: "older-2" },
+      { kind: "older", token: "older-3" },
+      { kind: "older", token: "older-4" },
+      { kind: "older", token: "older-5" },
+    ]);
+    expect(observer.getCurrentResult().data?.pages).toHaveLength(5);
+
+    await observer.fetchPreviousPage();
+    expect(requests.at(-1)).toEqual({ kind: "newer", token: "newer-0" });
+    unsubscribe();
+  });
+  it("keeps workspace traversal forward-only and retains five pages", async () => {
+    const requests: (string | undefined)[] = [];
+    const api: Pick<ApiService, "listWorkspaces"> = {
+      listWorkspaces: async (projectID: string, pageToken?: string): Promise<WorkspaceList> => {
+        expect(projectID).toBe("project-1");
+        requests.push(pageToken);
+        return {
+          projectID,
+          workspaces: [],
+          defaultWorkspaceID: "workspace-1",
+          nextPageToken: pageToken === undefined ? "next-1" : pageToken === "next-1" ? "next-2" : null,
+        };
+      },
+    };
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const observer = new InfiniteQueryObserver(
+      queryClient,
+      workspaceCatalogInfiniteQueryOptions(api, "project-1"),
+    );
+    const unsubscribe = observer.subscribe(() => undefined);
+
+    await waitForSuccess(observer);
+    await observer.fetchNextPage();
+    await observer.fetchNextPage();
+    expect(requests).toEqual([undefined, "next-1", "next-2"]);
+    expect(observer.getCurrentResult().data?.pages).toHaveLength(3);
+    expect(observer.getCurrentResult().hasPreviousPage).toBe(false);
+    unsubscribe();
+  });
+  it("invalidates both Session categories under one Project root", async () => {
+    const requests: SessionCategory[] = [];
+    const api: Pick<ApiService, "listSessionPage"> = {
+      listSessionPage: async (
+        projectID: string,
+        category: SessionCategory,
+      ): Promise<SessionCatalogPage> => {
+        requests.push(category);
+        return { projectID, category, sessions: [], older: null, newer: null };
+      },
+    };
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const main = new InfiniteQueryObserver(
+      queryClient,
+      mainSessionCatalogInfiniteQueryOptions(api, "project-1"),
+    );
+    const subagent = new InfiniteQueryObserver(
+      queryClient,
+      subagentSessionCatalogInfiniteQueryOptions(api, "project-1"),
+    );
+    const unsubscribeMain = main.subscribe(() => undefined);
+    const unsubscribeSubagent = subagent.subscribe(() => undefined);
+    await Promise.all([waitForSuccess(main), waitForSuccess(subagent)]);
+    requests.length = 0;
+
+    await invalidateProjectSessionCatalogs(queryClient, "project-1");
+
+    expect(requests).toEqual(["main", "subagent"]);
+    expect(queryClient.getQueryData(queryKeys.projectSessionCatalog("project-2", "main"))).toBeUndefined();
+    unsubscribeMain();
+    unsubscribeSubagent();
+  });
+});
+
+async function waitForSuccess(
+  observer: Readonly<{ getCurrentResult(): Readonly<{ isSuccess: boolean }> }>,
+): Promise<void> {
+  await waitFor(() => {
+    expect(observer.getCurrentResult().isSuccess).toBe(true);
+  });
+}

--- a/apps/desktop/src/app-facade/projectCatalogQueries.test.ts
+++ b/apps/desktop/src/app-facade/projectCatalogQueries.test.ts
@@ -78,17 +78,22 @@ describe("Project catalog query authority", () => {
     expect(requests.at(-1)).toEqual({ kind: "newer", token: "newer-0" });
     unsubscribe();
   });
-  it("keeps workspace traversal forward-only and retains five pages", async () => {
+  it("keeps workspace traversal forward-only and retains fewer than the full collection", async () => {
     const requests: (string | undefined)[] = [];
+    const pageByToken = new Map<string, number>();
     const api: Pick<ApiService, "listWorkspaces"> = {
       listWorkspaces: async (projectID: string, pageToken?: string): Promise<WorkspaceList> => {
         expect(projectID).toBe("project-1");
         requests.push(pageToken);
+        const page = pageToken === undefined ? 0 : pageByToken.get(pageToken);
+        if (page === undefined) throw new Error("fixture received an unknown continuation.");
+        const nextPageToken = `next-${String(page + 1)}`;
+        pageByToken.set(nextPageToken, page + 1);
         return {
           projectID,
           workspaces: [],
           defaultWorkspaceID: "workspace-1",
-          nextPageToken: pageToken === undefined ? "next-1" : pageToken === "next-1" ? "next-2" : null,
+          nextPageToken,
         };
       },
     };
@@ -100,10 +105,11 @@ describe("Project catalog query authority", () => {
     const unsubscribe = observer.subscribe(() => undefined);
 
     await waitForSuccess(observer);
-    await observer.fetchNextPage();
-    await observer.fetchNextPage();
-    expect(requests).toEqual([undefined, "next-1", "next-2"]);
-    expect(observer.getCurrentResult().data?.pages).toHaveLength(3);
+    for (let index = 0; index < 5; index += 1) {
+      await observer.fetchNextPage();
+    }
+    expect(requests).toEqual([undefined, "next-1", "next-2", "next-3", "next-4", "next-5"]);
+    expect(observer.getCurrentResult().data?.pages).toHaveLength(4);
     expect(observer.getCurrentResult().hasPreviousPage).toBe(false);
     unsubscribe();
   });

--- a/apps/desktop/src/app-facade/projectCatalogQueries.ts
+++ b/apps/desktop/src/app-facade/projectCatalogQueries.ts
@@ -8,7 +8,8 @@ import type {
 } from "@/api";
 import { queryKeys } from "./queryKeys";
 
-const catalogMaxPages = 5;
+const sessionCatalogMaxPages = 5;
+const workspaceCatalogMaxPages = 4;
 type SessionCatalogApi = Pick<ApiService, "listSessionPage">;
 type WorkspaceCatalogApi = Pick<ApiService, "listWorkspaces">;
 type WorkspaceCatalogQueryKey = ReturnType<typeof queryKeys.projectWorkspaceCatalog>;
@@ -43,7 +44,7 @@ export function workspaceCatalogInfiniteQueryOptions(
       pageParam === null ? api.listWorkspaces(projectID) : api.listWorkspaces(projectID, pageParam),
     initialPageParam: null,
     getNextPageParam: (lastPage: WorkspaceList) => lastPage.nextPageToken ?? undefined,
-    maxPages: catalogMaxPages,
+    maxPages: workspaceCatalogMaxPages,
   });
 }
 
@@ -70,6 +71,6 @@ function sessionCatalogInfiniteQueryOptions(
       lastPage.older === null ? undefined : { kind: "older", token: lastPage.older },
     getPreviousPageParam: (firstPage: SessionCatalogPage): SessionPagePosition | undefined =>
       firstPage.newer === null ? undefined : { kind: "newer", token: firstPage.newer },
-    maxPages: catalogMaxPages,
+    maxPages: sessionCatalogMaxPages,
   });
 }

--- a/apps/desktop/src/app-facade/projectCatalogQueries.ts
+++ b/apps/desktop/src/app-facade/projectCatalogQueries.ts
@@ -1,0 +1,75 @@
+import { infiniteQueryOptions, type InfiniteData, type QueryClient } from "@tanstack/react-query";
+import type {
+  ApiService,
+  SessionCatalogPage,
+  SessionCategory,
+  SessionPagePosition,
+  WorkspaceList,
+} from "@/api";
+import { queryKeys } from "./queryKeys";
+
+const catalogMaxPages = 5;
+type SessionCatalogApi = Pick<ApiService, "listSessionPage">;
+type WorkspaceCatalogApi = Pick<ApiService, "listWorkspaces">;
+type WorkspaceCatalogQueryKey = ReturnType<typeof queryKeys.projectWorkspaceCatalog>;
+
+export function mainSessionCatalogInfiniteQueryOptions(
+  api: SessionCatalogApi,
+  projectID: string,
+) {
+  return sessionCatalogInfiniteQueryOptions(api, projectID, "main");
+}
+
+export function subagentSessionCatalogInfiniteQueryOptions(
+  api: SessionCatalogApi,
+  projectID: string,
+) {
+  return sessionCatalogInfiniteQueryOptions(api, projectID, "subagent");
+}
+
+export function workspaceCatalogInfiniteQueryOptions(
+  api: WorkspaceCatalogApi,
+  projectID: string,
+) {
+  return infiniteQueryOptions<
+    WorkspaceList,
+    Error,
+    InfiniteData<WorkspaceList, string | null>,
+    WorkspaceCatalogQueryKey,
+    string | null
+  >({
+    queryKey: queryKeys.projectWorkspaceCatalog(projectID),
+    queryFn: async ({ pageParam }) =>
+      pageParam === null ? api.listWorkspaces(projectID) : api.listWorkspaces(projectID, pageParam),
+    initialPageParam: null,
+    getNextPageParam: (lastPage: WorkspaceList) => lastPage.nextPageToken ?? undefined,
+    maxPages: catalogMaxPages,
+  });
+}
+
+export async function invalidateProjectSessionCatalogs(
+  queryClient: QueryClient,
+  projectID: string,
+): Promise<void> {
+  await queryClient.invalidateQueries({
+    queryKey: queryKeys.projectSessionCatalogs(projectID),
+    refetchType: "active",
+  });
+}
+
+function sessionCatalogInfiniteQueryOptions(
+  api: SessionCatalogApi,
+  projectID: string,
+  category: SessionCategory,
+) {
+  return infiniteQueryOptions({
+    queryKey: queryKeys.projectSessionCatalog(projectID, category),
+    queryFn: async ({ pageParam }) => api.listSessionPage(projectID, category, pageParam),
+    initialPageParam: { kind: "newest" } satisfies SessionPagePosition,
+    getNextPageParam: (lastPage: SessionCatalogPage): SessionPagePosition | undefined =>
+      lastPage.older === null ? undefined : { kind: "older", token: lastPage.older },
+    getPreviousPageParam: (firstPage: SessionCatalogPage): SessionPagePosition | undefined =>
+      firstPage.newer === null ? undefined : { kind: "newer", token: firstPage.newer },
+    maxPages: catalogMaxPages,
+  });
+}

--- a/apps/desktop/src/app-facade/queryKeys.ts
+++ b/apps/desktop/src/app-facade/queryKeys.ts
@@ -3,6 +3,7 @@ import {
   defaultBoardNodeCardsSort,
   type BoardFilterInput,
   type BoardNodeCardsSort,
+  type SessionCategory,
 } from "@/api";
 
 const attentionKey = ["attention"] as const;
@@ -38,6 +39,16 @@ export const queryKeys = {
   projects: ["projects"],
   allProjectEdits: ["project-edit"],
   projectEdit: (projectID: string) => ["project-edit", projectID],
+  allProjectCatalogs: ["project-catalog"],
+  projectCatalog: (projectID: string) => ["project-catalog", projectID],
+  projectSessionCatalogs: (projectID: string) => ["project-catalog", projectID, "sessions"],
+  projectSessionCatalog: (projectID: string, category: SessionCategory) => [
+    "project-catalog",
+    projectID,
+    "sessions",
+    category,
+  ],
+  projectWorkspaceCatalog: (projectID: string) => ["project-catalog", projectID, "workspaces"],
   attention: attentionKey,
   allWorkspaces: ["workspaces"],
   workspaces: (projectID: string) => ["workspaces", projectID],


### PR DESCRIPTION
## Summary
- Add typed Desktop adapters for `session.page` and the existing `project.workspace.list` catalog contract.
- Add strict catalog schemas, structured contract errors, and category-aware project query options with bounded infinite pagination.
- Keep workspace cache retention below the server collection limit and omit the initial absent cursor from the request.
- Preserve complete diagnostic counts when catalog contract errors wrap truncated schema diagnostics.
- Add invalid-input, malformed-response, identity-mismatch, pagination, invalidation, and diagnostic-preservation coverage.

## Verification
- Focused Vitest after review fixes: 67 tests passed across catalog schemas, API client, and project catalog queries.
- Desktop TypeScript build passed.
- Targeted ESLint passed (boundary deprecation warning only).
- Full `pnpm --dir apps lint` and `pnpm --dir apps typecheck` passed before the review round.
- `./scripts/build.sh server --output ./bin/kent` and `./scripts/build.sh desktop` passed before the review round.
- `git diff --check` passed.

## Diff size
- Production code: **+327 net / 357 gross LoC** (+342 / -15).
- Test code: **+571 net / 571 gross LoC** (+571 / -0).
- Generated code: **0 net / 0 gross LoC**.
- Overall: **+898 net / 928 gross LoC** (+913 / -15).

## Caveats and follow-up
- The full `./scripts/test.sh server desktop` run was attempted before the final review fixes and hit the shared 300-second shard cap after many tests; it was not rerun. Focused Desktop coverage passed after the fixes.
- Workspace catalog retention is four 100-row pages (400 rows), intentionally below the server’s 500-row collection limit.
- The distinct workspace infinite-query key and existing finite `workspaces` key remain intentional until KENT-479 migrates existing consumers.
- Explicit-null Session-name acceptance remains an approved compatibility boundary until KENT-220.
- The existing omitted/exact-empty terminal `next_page_token` compatibility remains isolated at the workspace response adapter per the locked KENT-406 plan; KENT-479 owns the hard protocol cut.
- This slice excludes server/shared contract changes, UI consumers, workspace read-model migration, and retry/restart lifecycle machinery.
- GitHub issue: none linked.
- Kent task: KENT-406.