### PR TITLE
Transfer goals through session forks

### DIFF
--- a/docs/dev/specs/desktop-chat.md
+++ b/docs/dev/specs/desktop-chat.md
@@ -123,7 +123,7 @@
 - Edit follows the TUI admission boundary. It is unavailable while authoritative runtime input is blocked or while the ordinary composer draft is nonblank. The server enforces active-work admission; the client does not become the sole blocker.
 - Activating Edit immediately resolves the ordinary fork/rollback transition. It does not wait for the edited text to be submitted.
 - The server creates one durable main child Session whose copied history ends immediately before the selected user message. The selected message and all later parent history are absent from the child, and the parent Session remains unchanged.
-- The child inherits the TUI fork contract: execution context, locked contract, continuation context, worktree-reminder state, previous-Session lineage, and parent-agent ancestry.
+- The child inherits the TUI fork contract: execution context, locked contract, continuation context, worktree-reminder state, previous-Session lineage, parent-agent ancestry, and the parent Session's complete Goal unchanged, including its objective, state, identity, and original creation and update times.
 - The server owns the child name using its existing `<parent name or Session ID> → edit u<N>` convention. Desktop adds no naming field.
 - After creation, Chat navigates to the child Session at latest, places the selected original user-message text in its ordinary composer draft, and focuses the composer. Editing and submission then use the normal child-Session composer flow.
 - Fork failure leaves the operator in the unchanged parent Session and surfaces the authoritative diagnostic through Sonner. Desktop creates no optimistic child route or local fork state.

--- a/docs/dev/specs/desktop-chat.md
+++ b/docs/dev/specs/desktop-chat.md
@@ -123,7 +123,7 @@
 - Edit follows the TUI admission boundary. It is unavailable while authoritative runtime input is blocked or while the ordinary composer draft is nonblank. The server enforces active-work admission; the client does not become the sole blocker.
 - Activating Edit immediately resolves the ordinary fork/rollback transition. It does not wait for the edited text to be submitted.
 - The server creates one durable main child Session whose copied history ends immediately before the selected user message. The selected message and all later parent history are absent from the child, and the parent Session remains unchanged.
-- The child inherits the TUI fork contract: execution context, locked contract, continuation context, worktree-reminder state, previous-Session lineage, parent-agent ancestry, and the parent Session's complete Goal unchanged, including its objective, state, identity, and original creation and update times.
+- The child inherits the TUI fork contract: execution context, locked contract, continuation context, worktree-reminder state, previous-Session lineage, and parent-agent ancestry. Goal inheritance follows the Rollback Picker contract.
 - The server owns the child name using its existing `<parent name or Session ID> → edit u<N>` convention. Desktop adds no naming field.
 - After creation, Chat navigates to the child Session at latest, places the selected original user-message text in its ordinary composer draft, and focuses the composer. Editing and submission then use the normal child-Session composer flow.
 - Fork failure leaves the operator in the unchanged parent Session and surfaces the authoritative diagnostic through Sonner. Desktop creates no optimistic child route or local fork state.

--- a/docs/dev/specs/tui-slash-overlays.md
+++ b/docs/dev/specs/tui-slash-overlays.md
@@ -45,6 +45,7 @@
 - The selected candidate is highlighted and centered in the transcript. `Up`/`Down` move between candidates; at the window edge they page across transcript windows through bounded requests, re-anchoring the selection.
 - Candidate-free pages encountered during edge navigation are traversed automatically through sequential bounded reads while remaining transient. Each navigation attempt has a 20-second deadline; timeout stops pagination, keeps the current candidate selected, and surfaces an error in the status line.
 - `Enter` creates and opens a rollback fork at the selected message. The fork retains history before the selected user message and excludes that message.
+- The rollback fork inherits the parent Session's complete Goal unchanged, including its objective, state, identity, and original creation and update times.
 - The fork opens in Ongoing Mode with the selected user message text restored as unsent composer input.
 - `Esc` while selecting closes the picker and restores the prior Transcript Mode.
 - Rollback never changes the original Session transcript.

--- a/server/session/fork.go
+++ b/server/session/fork.go
@@ -123,7 +123,11 @@ func ForkAtUserMessage(parentLog MaterializedEventLog, userMessageSeq int64, for
 	if userMessageSeq <= 0 {
 		return nil, 0, fmt.Errorf("user message seq must be >= 1")
 	}
-	return streamChildFromParent(parentLog, forkName, category, userMessageSeq)
+	return streamChildFromParent(parentLog, forkName, category, ChildContextOptions{
+		InheritLockedContract: true,
+		InheritContinuation:   true,
+		InheritGoal:           true,
+	}, userMessageSeq)
 }
 
 // CloneSession creates a child session that replays the parent's entire
@@ -131,7 +135,10 @@ func ForkAtUserMessage(parentLog MaterializedEventLog, userMessageSeq int64, for
 // so each parallel continuation compacts its own isolated copy of the source
 // conversation instead of mutating the shared source session.
 func CloneSession(parentLog MaterializedEventLog, forkName string, category sessioncontract.SessionCategory) (*Store, error) {
-	child, _, err := streamChildFromParent(parentLog, forkName, category, 0)
+	child, _, err := streamChildFromParent(parentLog, forkName, category, ChildContextOptions{
+		InheritLockedContract: true,
+		InheritContinuation:   true,
+	}, 0)
 	return child, err
 }
 
@@ -140,7 +147,13 @@ func CloneSession(parentLog MaterializedEventLog, forkName string, category sess
 // visible user message persisted at that sequence (fork-at-message); targetSeq
 // == 0 clones everything. It returns the 1-based ordinal of the cut user
 // message among the parent's visible user messages (0 when cloning).
-func streamChildFromParent(parentLog MaterializedEventLog, forkName string, category sessioncontract.SessionCategory, targetSeq int64) (_ *Store, _ int, resultErr error) {
+func streamChildFromParent(
+	parentLog MaterializedEventLog,
+	forkName string,
+	category sessioncontract.SessionCategory,
+	contextOptions ChildContextOptions,
+	targetSeq int64,
+) (_ *Store, _ int, resultErr error) {
 	parent, err := materializedForkParent(parentLog)
 	if err != nil {
 		return nil, 0, err
@@ -157,10 +170,7 @@ func streamChildFromParent(parentLog MaterializedEventLog, forkName string, cate
 			resultErr = errors.Join(resultErr, child.RemoveDurable())
 		}
 	}()
-	if err := InitializeCreationContext(child, parent, SessionCreationSourcePreviousSession, ChildContextOptions{
-		InheritLockedContract: true,
-		InheritContinuation:   true,
-	}); err != nil {
+	if err := InitializeCreationContext(child, parent, SessionCreationSourcePreviousSession, contextOptions); err != nil {
 		return nil, 0, err
 	}
 
@@ -389,6 +399,9 @@ type ChildContextOptions struct {
 	// interactive children. Headless subagent launches leave this false so
 	// parent role/base URL state cannot override the selected subagent config.
 	InheritContinuation bool
+	// InheritGoal preserves the parent's current goal for user-facing
+	// Edit/Fork children. Complete-history workflow clones leave this false.
+	InheritGoal bool
 }
 
 type SessionCreationSourceKind uint8
@@ -443,6 +456,11 @@ func InitializeCreationContext(child *Store, source *Store, kind SessionCreation
 	child.meta.WorkspaceContainer = sourceMeta.WorkspaceContainer
 	child.meta.WorktreeReminder = CloneWorktreeReminderState(sourceMeta.WorktreeReminder)
 	child.meta.UsageState = nil
+	if opts.InheritGoal {
+		child.meta.Goal = cloneGoalState(sourceMeta.Goal)
+	} else {
+		child.meta.Goal = nil
+	}
 	sourceID, err := runtimeids.ParseSessionID(sourceMeta.SessionID)
 	if err != nil {
 		return fmt.Errorf("invalid creation source session id: %w", err)

--- a/server/session/fork_test.go
+++ b/server/session/fork_test.go
@@ -188,6 +188,25 @@ func TestCloneSessionStreamsLargeHistoryAcrossChunks(t *testing.T) {
 	}
 }
 
+func TestCloneSessionDoesNotInheritGoal(t *testing.T) {
+	parent := newSessionTestStore(t)
+	if _, _, err := parent.SetGoal("workflow source goal", GoalActorUser); err != nil {
+		t.Fatalf("SetGoal: %v", err)
+	}
+	parentLog := materializedForkEventLog(t, parent)
+	if _, _, err := parentLog.AppendRecord(forkStringPointer("step"), forkUserMessageRecord("source")); err != nil {
+		t.Fatalf("append source message: %v", err)
+	}
+
+	child, err := CloneSession(parentLog, "clone", testSessionCategory)
+	if err != nil {
+		t.Fatalf("CloneSession: %v", err)
+	}
+	if child.Meta().Goal != nil {
+		t.Fatalf("workflow clone goal = %+v, want nil", child.Meta().Goal)
+	}
+}
+
 func TestStreamedForkAndCloneRequireAndPersistCategory(t *testing.T) {
 	parent, err := Create(t.TempDir(), "workspace", "/tmp/work", sessioncontract.SessionCategoryMain, sessionTestPersistence.options()...)
 	if err != nil {

--- a/server/session/store_test.go
+++ b/server/session/store_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -813,6 +814,79 @@ func TestForkAtUserMessageCopiesPrefixBeforeSelectedMessage(t *testing.T) {
 	}
 	if meta.Locked.ReviewerPrompt != "parent reviewer prompt snapshot" || !meta.Locked.HasReviewerPrompt {
 		t.Fatalf("fork locked reviewer prompt = %+v, want replay fork to preserve parent reviewer prompt snapshot", meta.Locked)
+	}
+}
+
+func TestForkAtUserMessageCopiesGoalSnapshot(t *testing.T) {
+	cases := []struct {
+		name   string
+		status GoalStatus
+	}{
+		{name: "active", status: GoalStatusActive},
+		{name: "paused", status: GoalStatusPaused},
+		{name: "complete", status: GoalStatusComplete},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parent := newSessionTestStore(t)
+			appendSessionTestRecord(t, parent, "s1", sessionTestMessage(MessageRoleUser, "u1"))
+			appendSessionTestRecord(t, parent, "s1", sessionTestMessage(MessageRoleAssistant, "a1"))
+			appendSessionTestRecord(t, parent, "s2", sessionTestMessage(MessageRoleUser, "u2"))
+
+			if _, _, err := parent.SetGoal("ship the forked goal", GoalActorUser); err != nil {
+				t.Fatalf("SetGoal: %v", err)
+			}
+			if tc.status != GoalStatusActive {
+				if _, _, _, err := parent.SetGoalStatus(tc.status, GoalActorUser); err != nil {
+					t.Fatalf("SetGoalStatus(%s): %v", tc.status, err)
+				}
+			}
+			parentGoal := parent.Meta().Goal
+			if parentGoal == nil {
+				t.Fatal("parent goal is nil")
+			}
+			wantGoal := *parentGoal
+
+			parentLog := mustMaterializeSessionTestEventLog(t, parent)
+			parentEvents, err := collectEvents(parent)
+			if err != nil {
+				t.Fatalf("read parent events: %v", err)
+			}
+			forked, _, err := ForkAtUserMessage(
+				parentLog,
+				userMessageSeqAt(t, parent, 2),
+				"Parent → edit u2",
+				testSessionCategory,
+			)
+			if err != nil {
+				t.Fatalf("fork at user message: %v", err)
+			}
+			forkEvents, err := collectEvents(forked)
+			if err != nil {
+				t.Fatalf("read fork events: %v", err)
+			}
+			if !reflect.DeepEqual(forkEvents, parentEvents[:2]) {
+				t.Fatalf("fork history = %+v, want exact parent prefix %+v", forkEvents, parentEvents[:2])
+			}
+
+			forkGoal := forked.Meta().Goal
+			if forkGoal == nil {
+				t.Fatal("fork goal is nil")
+			}
+			if *forkGoal != wantGoal {
+				t.Fatalf("fork goal = %+v, want %+v", *forkGoal, wantGoal)
+			}
+
+			if _, _, err := forked.ClearGoal(GoalActorUser); err != nil {
+				t.Fatalf("ClearGoal on fork: %v", err)
+			}
+			if forked.Meta().Goal != nil {
+				t.Fatalf("fork goal after clear = %+v, want nil", forked.Meta().Goal)
+			}
+			if got := parent.Meta().Goal; got == nil || *got != wantGoal {
+				t.Fatalf("parent goal after clearing fork = %+v, want %+v", got, wantGoal)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Transfer the parent Session Goal snapshot through user-facing Edit/Fork creation, preserving objective, status, ID, and original timestamps.
- Keep complete-history workflow clones goal-free through an explicit child creation option.
- Define Goal inheritance in the Rollback Picker owner spec and keep the Desktop Edit/Fork spec contextual.
- Add regression coverage for active, paused, complete, and cleared goals.

## Verification

- `go test ./server/session -count=1` — passed after rebasing.
- Focused fork/clone tests — passed.
- `pnpm --dir apps lint` — passed with existing warnings only.
- `git diff --check` — passed.
- `./scripts/build.sh --output ./bin/kent` — passed before the rebase; the rebase changed only the base branch and resolved the already-landed GUI lint fix.
- `./scripts/test.sh server` was attempted locally, but the repository-wide sharder was blocked by the shared runtime-test admission lock and terminated without reporting a test failure.

## Diff size

- Production code: 25 additions, 7 deletions; gross 32 lines, net +18.
- Test code: 93 additions, 0 deletions; gross 93 lines, net +93.
- Generated code: 0 additions, 0 deletions; gross 0 lines, net 0.
- Specification documentation: 2 additions, 1 deletion; gross 3 lines, net +1.

## Caveats and follow-up

- Goal inheritance is intentionally limited to Edit/Fork; workflow clones remain unchanged.
- Goal metadata is copied silently before child durability, without goal mutation operations or transcript events.
- The prior GUI lint blocker landed on `main`; rebasing KENT-485 onto that commit resolved the PR conflict without duplicating the unrelated change in this PR.
- The review follow-up placed the shared Goal inheritance requirement in the Rollback Picker owner spec; Desktop now references that contract contextually.
- Kent task KENT-485 and GitHub issue KENT-485 are addressed.