### PR TITLE
Validate shell working directories before launch

### DIFF
--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -45,9 +45,10 @@
 ## Command Execution
 
 - `shell` is the only model-facing command-execution tool. It uses the user's login shell without a TTY, inherits the parent environment, adds non-interactive technical environment values, and combines stdout and stderr into one unlabelled stream.
-- Before launching a command, Kent must resolve the selected Working Directory to a normalized absolute path and verify that the path exists and is a directory.
-- If the selected Working Directory does not exist, Kent must not launch the command and must return `<normalized absolute path> does not exist, so the shell command was not executed. Please select an existing working directory`.
-- If the selected Working Directory exists but is not a directory, Kent must not launch the command and must return `<normalized absolute path> is not a directory, so the shell command was not executed. Please select an existing working directory`.
+- Before launching a command, Kent must resolve a non-empty selected Working Directory to a normalized absolute path and verify that the path exists and is a directory.
+- If a non-empty selected Working Directory does not exist, Kent must not launch the command and must return `<normalized absolute path> does not exist, so the shell command was not executed. Please select an existing working directory`.
+- If a non-empty selected Working Directory exists but is not a directory, Kent must not launch the command and must return `<normalized absolute path> is not a directory, so the shell command was not executed. Please select an existing working directory`.
+- An empty selected Working Directory retains the shell manager's existing validation behavior and never falls back to Kent's server process working directory.
 - A `shell` failure never adds the `exec_command failed:` prefix to its model-visible error.
 - Commands have no lifetime limit. `yield_time_ms` returns control and leaves the command running in the background. An output check with no requested wait may return available output immediately.
 - Kent does not limit concurrent command processes, including background processes visible through `/ps`.

--- a/docs/dev/specs/core-runtime-tools.md
+++ b/docs/dev/specs/core-runtime-tools.md
@@ -45,6 +45,10 @@
 ## Command Execution
 
 - `shell` is the only model-facing command-execution tool. It uses the user's login shell without a TTY, inherits the parent environment, adds non-interactive technical environment values, and combines stdout and stderr into one unlabelled stream.
+- Before launching a command, Kent must resolve the selected Working Directory to a normalized absolute path and verify that the path exists and is a directory.
+- If the selected Working Directory does not exist, Kent must not launch the command and must return `<normalized absolute path> does not exist, so the shell command was not executed. Please select an existing working directory`.
+- If the selected Working Directory exists but is not a directory, Kent must not launch the command and must return `<normalized absolute path> is not a directory, so the shell command was not executed. Please select an existing working directory`.
+- A `shell` failure never adds the `exec_command failed:` prefix to its model-visible error.
 - Commands have no lifetime limit. `yield_time_ms` returns control and leaves the command running in the background. An output check with no requested wait may return available output immediately.
 - Kent does not limit concurrent command processes, including background processes visible through `/ps`.
 - A model output check requesting less than 15 seconds fails with `Avoid polling repeatedly for short intervals, prefer 3-15min polls depending on task. Pick a better interval and retry`. One requesting more than 24 hours fails with `This poll is too long. Consider using system cron jobs and \`kent run\` headless runs for tasks that require such long wait periods`. Sending input is not subject to those limits.

--- a/server/tools/shell/exec_command_tool.go
+++ b/server/tools/shell/exec_command_tool.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"core/server/tools"
@@ -98,7 +99,7 @@ func (t *ExecCommandTool) Call(ctx context.Context, c tools.Call) (tools.Result,
 		workdir = normalizedWorkdir
 		info, err := os.Stat(workdir)
 		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
+			if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) {
 				return tools.ErrorResultWith(c, formatMissingWorkingDirectoryError(workdir), marshalNoHTMLEscape), nil
 			}
 			return tools.ErrorResultWith(c, err.Error(), marshalNoHTMLEscape), nil

--- a/server/tools/shell/exec_command_tool.go
+++ b/server/tools/shell/exec_command_tool.go
@@ -3,8 +3,10 @@ package shell
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -88,6 +90,23 @@ func (t *ExecCommandTool) Call(ctx context.Context, c tools.Call) (tools.Result,
 		return tools.ErrorResultWith(c, "cmd is required", marshalNoHTMLEscape), nil
 	}
 	workdir := ResolveWorkdir(t.workspaceRoot, in.Workdir)
+	if workdir != "" {
+		normalizedWorkdir, err := filepath.Abs(workdir)
+		if err != nil {
+			return tools.ErrorResultWith(c, err.Error(), marshalNoHTMLEscape), nil
+		}
+		workdir = normalizedWorkdir
+		info, err := os.Stat(workdir)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return tools.ErrorResultWith(c, formatMissingWorkingDirectoryError(workdir), marshalNoHTMLEscape), nil
+			}
+			return tools.ErrorResultWith(c, err.Error(), marshalNoHTMLEscape), nil
+		}
+		if !info.IsDir() {
+			return tools.ErrorResultWith(c, formatNonDirectoryWorkingDirectoryError(workdir), marshalNoHTMLEscape), nil
+		}
+	}
 	resolvedShell := strings.TrimSpace(in.Shell)
 	if resolvedShell == "" {
 		resolvedShell = t.defaultShell
@@ -125,7 +144,7 @@ func (t *ExecCommandTool) Call(ctx context.Context, c tools.Call) (tools.Result,
 		Postprocessor:        t.postprocessor,
 	})
 	if err != nil {
-		return tools.ErrorResultWith(c, formatToolCallError("exec_command", err), marshalNoHTMLEscape), nil
+		return tools.ErrorResultWith(c, formatToolCallErrorBase(err), marshalNoHTMLEscape), nil
 	}
 	if strings.TrimSpace(result.ToolError) != "" {
 		return tools.ErrorResultWith(c, formatToolError(result.Warning, result.ToolError), marshalNoHTMLEscape), nil

--- a/server/tools/shell/tool.go
+++ b/server/tools/shell/tool.go
@@ -14,6 +14,10 @@ const (
 	headTailSize                       = 1000
 	truncationBannerTemplate           = "\n\n...[Output is very large, omitted %d bytes. Consider using more targeted commands to reduce output size]...\n\n"
 	backgroundTruncationBannerTemplate = "\n\n...[Omitted %d bytes, read log file for details]...\n\n"
+	existingWorkingDirectoryHint       = "Please select an existing working directory"
+	missingWorkingDirectoryReason      = "does not exist, so the shell command was not executed."
+	nonDirectoryWorkingDirectoryReason = "is not a directory, so the shell command was not executed."
+	canceledByUserMessage              = "Canceled by user"
 )
 
 func marshalNoHTMLEscape(v any) (json.RawMessage, error) {
@@ -30,10 +34,26 @@ func formatToolCallError(toolName string, err error) string {
 	if err == nil {
 		return fmt.Sprintf("%s failed", toolName)
 	}
+	return formatToolCallErrorDecoration(toolName, formatToolCallErrorBase(err))
+}
+
+func formatToolCallErrorBase(err error) string {
 	if errors.Is(err, context.Canceled) {
-		return fmt.Sprintf("%s failed: %s", toolName, cancellationMessage(err))
+		return cancellationMessage(err)
 	}
-	return fmt.Sprintf("%s failed: %v", toolName, err)
+	return err.Error()
+}
+
+func formatToolCallErrorDecoration(toolName string, message string) string {
+	return fmt.Sprintf("%s failed: %s", toolName, message)
+}
+
+func formatMissingWorkingDirectoryError(path string) string {
+	return strings.Join([]string{path, missingWorkingDirectoryReason, existingWorkingDirectoryHint}, " ")
+}
+
+func formatNonDirectoryWorkingDirectoryError(path string) string {
+	return strings.Join([]string{path, nonDirectoryWorkingDirectoryReason, existingWorkingDirectoryHint}, " ")
 }
 
 func cancellationMessage(err error) string {
@@ -41,7 +61,7 @@ func cancellationMessage(err error) string {
 	if errors.As(err, &pollErr) {
 		return pollErr.Error()
 	}
-	return "Canceled by user"
+	return canceledByUserMessage
 }
 
 func truncateWithTemplate(s string, maxLen int, bannerTemplate string) (string, bool, int) {

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -136,6 +137,181 @@ func TestExecCommandSilentSuccessIsTerminalAndUnambiguous(t *testing.T) {
 	}
 	if result.PresentationDelta != nil && result.PresentationDelta.MovedToBackground {
 		t.Fatalf("silent foreground completion must not be marked backgrounded: %+v", result.PresentationDelta)
+	}
+	waitForManagerCount(t, manager, 0, time.Second)
+}
+
+func TestExecCommandEmptyDefaultWorkdirReturnsManagerErrorWithoutExecuting(t *testing.T) {
+	serverCWD := t.TempDir()
+	t.Chdir(serverCWD)
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool("", 16_000, manager, "")
+	call := tools.Call{
+		ID:   "empty-default-workdir",
+		Name: toolspec.ToolExecCommand,
+	}
+	input, err := json.Marshal(map[string]any{
+		"cmd":           "touch exec-command-empty-default-side-effect",
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 1_000,
+	})
+	if err != nil {
+		t.Fatalf("marshal exec_command input: %v", err)
+	}
+	call.Input = input
+
+	_, managerErr := manager.Start(context.Background(), ExecRequest{
+		Command: []string{"/bin/sh", "-c", "touch exec-command-empty-default-side-effect"},
+		Workdir: "",
+	})
+	if managerErr == nil {
+		t.Fatal("expected empty workdir manager error")
+	}
+	want := tools.ErrorResultWith(call, managerErr.Error(), marshalNoHTMLEscape)
+
+	got, err := execTool.Call(context.Background(), call)
+	if err != nil {
+		t.Fatalf("exec_command call returned transport error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("exec_command result = %#v, want %#v", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(serverCWD, "exec-command-empty-default-side-effect")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("empty default workdir command side effect = %v, want os.ErrNotExist", err)
+	}
+	waitForManagerCount(t, manager, 0, time.Second)
+}
+
+func TestExecCommandDeletedDefaultWorkdirReturnsExactValidationErrorWithoutExecuting(t *testing.T) {
+	workspace := t.TempDir()
+	resolvedWorkdir, err := filepath.Abs(ResolveWorkdir(workspace, ""))
+	if err != nil {
+		t.Fatalf("normalize default workdir: %v", err)
+	}
+	sideEffect := filepath.Join(t.TempDir(), "exec-command-deleted-default-side-effect")
+	if err := os.RemoveAll(workspace); err != nil {
+		t.Fatalf("remove default workdir: %v", err)
+	}
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+	call := tools.Call{
+		ID:   "deleted-default-workdir",
+		Name: toolspec.ToolExecCommand,
+	}
+	call.Input, err = json.Marshal(map[string]any{
+		"cmd":           "touch " + sideEffect,
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 1_000,
+	})
+	if err != nil {
+		t.Fatalf("marshal exec_command input: %v", err)
+	}
+	want := tools.ErrorResultWith(
+		call,
+		strings.Join([]string{resolvedWorkdir, missingWorkingDirectoryReason, existingWorkingDirectoryHint}, " "),
+		marshalNoHTMLEscape,
+	)
+
+	got, err := execTool.Call(context.Background(), call)
+	if err != nil {
+		t.Fatalf("exec_command call returned transport error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("exec_command result = %#v, want %#v", got, want)
+	}
+	if _, err := os.Stat(sideEffect); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("deleted default workdir command side effect = %v, want os.ErrNotExist", err)
+	}
+	waitForManagerCount(t, manager, 0, time.Second)
+}
+
+func TestExecCommandMissingRelativeWorkdirUsesCleanAbsolutePath(t *testing.T) {
+	workspace := t.TempDir()
+	requestedWorkdir := filepath.Join("nested", "..", "missing", ".", "child")
+	resolvedWorkdir, err := filepath.Abs(ResolveWorkdir(workspace, requestedWorkdir))
+	if err != nil {
+		t.Fatalf("normalize custom workdir: %v", err)
+	}
+	sideEffect := filepath.Join(t.TempDir(), "exec-command-missing-relative-side-effect")
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+	call := tools.Call{
+		ID:   "missing-relative-workdir",
+		Name: toolspec.ToolExecCommand,
+	}
+	call.Input, err = json.Marshal(map[string]any{
+		"cmd":           "touch " + sideEffect,
+		"workdir":       requestedWorkdir,
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 1_000,
+	})
+	if err != nil {
+		t.Fatalf("marshal exec_command input: %v", err)
+	}
+	want := tools.ErrorResultWith(
+		call,
+		strings.Join([]string{resolvedWorkdir, missingWorkingDirectoryReason, existingWorkingDirectoryHint}, " "),
+		marshalNoHTMLEscape,
+	)
+
+	got, err := execTool.Call(context.Background(), call)
+	if err != nil {
+		t.Fatalf("exec_command call returned transport error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("exec_command result = %#v, want %#v", got, want)
+	}
+	if _, err := os.Stat(sideEffect); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing relative workdir command side effect = %v, want os.ErrNotExist", err)
+	}
+	waitForManagerCount(t, manager, 0, time.Second)
+}
+
+func TestExecCommandFileWorkdirReturnsExactValidationErrorWithoutExecuting(t *testing.T) {
+	workspace := t.TempDir()
+	workdir := filepath.Join(workspace, "workdir-file")
+	if err := os.WriteFile(workdir, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write workdir file: %v", err)
+	}
+	resolvedWorkdir, err := filepath.Abs(workdir)
+	if err != nil {
+		t.Fatalf("normalize file workdir: %v", err)
+	}
+	sideEffect := filepath.Join(t.TempDir(), "exec-command-file-workdir-side-effect")
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+	call := tools.Call{
+		ID:   "file-workdir",
+		Name: toolspec.ToolExecCommand,
+	}
+	call.Input, err = json.Marshal(map[string]any{
+		"cmd":           "touch " + sideEffect,
+		"workdir":       filepath.Base(workdir),
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 1_000,
+	})
+	if err != nil {
+		t.Fatalf("marshal exec_command input: %v", err)
+	}
+	want := tools.ErrorResultWith(
+		call,
+		strings.Join([]string{resolvedWorkdir, nonDirectoryWorkingDirectoryReason, existingWorkingDirectoryHint}, " "),
+		marshalNoHTMLEscape,
+	)
+
+	got, err := execTool.Call(context.Background(), call)
+	if err != nil {
+		t.Fatalf("exec_command call returned transport error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("exec_command result = %#v, want %#v", got, want)
+	}
+	if _, err := os.Stat(sideEffect); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("file workdir command side effect = %v, want os.ErrNotExist", err)
 	}
 	waitForManagerCount(t, manager, 0, time.Second)
 }
@@ -589,18 +765,17 @@ func TestWriteStdinCancellationReportsActiveProcess(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	done := make(chan tools.Result, 1)
+	sessionID, err := strconv.Atoi(result.SessionID)
+	if err != nil {
+		t.Fatalf("parse session id: %v", err)
+	}
+	pollInput, _ := json.Marshal(map[string]any{
+		"session_id":    sessionID,
+		"yield_time_ms": 15_000,
+	})
+	pollCall := tools.Call{ID: "cancel-poll", Name: toolspec.ToolWriteStdin, Input: pollInput}
 	go func() {
-		sessionID, err := strconv.Atoi(result.SessionID)
-		if err != nil {
-			t.Errorf("parse session id: %v", err)
-			done <- tools.Result{}
-			return
-		}
-		pollInput, _ := json.Marshal(map[string]any{
-			"session_id":    sessionID,
-			"yield_time_ms": 15_000,
-		})
-		pollResult, err := pollTool.Call(ctx, tools.Call{ID: "cancel-poll", Name: toolspec.ToolWriteStdin, Input: pollInput})
+		pollResult, err := pollTool.Call(ctx, pollCall)
 		if err != nil {
 			t.Errorf("write_stdin call returned transport error: %v", err)
 		}
@@ -615,14 +790,107 @@ func TestWriteStdinCancellationReportsActiveProcess(t *testing.T) {
 		if !pollResult.IsError {
 			t.Fatalf("expected write_stdin error result, got %+v", pollResult)
 		}
-		if pollResult.Summary == nil || *pollResult.Summary == "" {
-			t.Fatal("expected cancellation summary")
+		pollErr := &PollingCanceledError{SessionID: result.SessionID, Active: true}
+		want := tools.ErrorResultWith(pollCall, formatToolCallErrorDecoration("write_stdin", pollErr.Error()), marshalNoHTMLEscape)
+		if !reflect.DeepEqual(pollResult, want) {
+			t.Fatalf("write_stdin result = %#v, want %#v", pollResult, want)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for canceled write_stdin")
 	}
 	if snapshot, err := manager.Snapshot(result.SessionID); err != nil || !snapshot.Running {
 		t.Fatalf("expected process to remain active after polling cancellation, snapshot=%+v err=%v", snapshot, err)
+	}
+}
+
+func TestExecCommandCancellationReturnsUndecoratedBaseError(t *testing.T) {
+	workspace := t.TempDir()
+	readyMarker := filepath.Join(workspace, "exec-command-cancellation-ready")
+	manager := newBackgroundTestManager(t)
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+	call := tools.Call{
+		ID:   "exec-command-cancellation",
+		Name: toolspec.ToolExecCommand,
+	}
+	var err error
+	call.Input, err = json.Marshal(map[string]any{
+		"cmd":           "touch " + readyMarker + "; while :; do :; done",
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 15_000,
+	})
+	if err != nil {
+		t.Fatalf("marshal exec_command input: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	type callResult struct {
+		result tools.Result
+		err    error
+	}
+	done := make(chan callResult, 1)
+	go func() {
+		result, err := execTool.Call(ctx, call)
+		done <- callResult{result: result, err: err}
+	}()
+
+	testsetup.RequireUntil(t, time.Now().Add(time.Second), time.Millisecond, func() bool {
+		_, err := os.Stat(readyMarker)
+		return err == nil
+	}, "timed out waiting for exec_command readiness marker")
+	cancel()
+
+	select {
+	case completed := <-done:
+		if completed.err != nil {
+			t.Fatalf("exec_command call returned transport error: %v", completed.err)
+		}
+		want := tools.ErrorResultWith(call, canceledByUserMessage, marshalNoHTMLEscape)
+		if !reflect.DeepEqual(completed.result, want) {
+			t.Fatalf("exec_command result = %#v, want %#v", completed.result, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for canceled exec_command")
+	}
+	waitForManagerCount(t, manager, 0, time.Second)
+}
+
+func TestExecCommandReturnsClosedManagerErrorUnchanged(t *testing.T) {
+	workspace := t.TempDir()
+	manager := newBackgroundTestManager(t)
+	if err := manager.Close(); err != nil {
+		t.Fatalf("close manager: %v", err)
+	}
+	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
+	call := tools.Call{
+		ID:   "closed-manager",
+		Name: toolspec.ToolExecCommand,
+	}
+	input, err := json.Marshal(map[string]any{
+		"cmd":           "true",
+		"shell":         "/bin/sh",
+		"login":         false,
+		"yield_time_ms": 1_000,
+	})
+	if err != nil {
+		t.Fatalf("marshal exec_command input: %v", err)
+	}
+	call.Input = input
+	_, managerErr := manager.Start(context.Background(), ExecRequest{
+		Command: []string{"/bin/sh", "-c", "true"},
+		Workdir: workspace,
+	})
+	if managerErr == nil {
+		t.Fatal("expected closed manager error")
+	}
+	want := tools.ErrorResultWith(call, managerErr.Error(), marshalNoHTMLEscape)
+
+	got, err := execTool.Call(context.Background(), call)
+	if err != nil {
+		t.Fatalf("exec_command call returned transport error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("exec_command result = %#v, want %#v", got, want)
 	}
 }
 

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -209,6 +209,15 @@ func TestExecCommandWorkdirValidationErrors(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "file ancestor", id: "file-ancestor-workdir",
+			workdir: filepath.Join("workdir-file", "child"), reason: missingWorkingDirectoryReason,
+			prepare: func(t *testing.T, workspace string) {
+				if err := os.WriteFile(filepath.Join(workspace, "workdir-file"), []byte("not a directory"), 0o600); err != nil {
+					t.Fatalf("write workdir file: %v", err)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -202,7 +202,7 @@ func TestExecCommandWorkdirValidationErrors(t *testing.T) {
 		},
 		{
 			name: "regular file", id: "file-workdir", workdir: "workdir-file",
-			reason: missingWorkingDirectoryReason,
+			reason: nonDirectoryWorkingDirectoryReason,
 			prepare: func(t *testing.T, workspace string) {
 				if err := os.WriteFile(filepath.Join(workspace, "workdir-file"), []byte("not a directory"), 0o600); err != nil {
 					t.Fatalf("write workdir file: %v", err)
@@ -210,7 +210,6 @@ func TestExecCommandWorkdirValidationErrors(t *testing.T) {
 			},
 		},
 	}
-	tests[2].reason = nonDirectoryWorkingDirectoryReason
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/server/tools/shell/tool_test.go
+++ b/server/tools/shell/tool_test.go
@@ -183,137 +183,73 @@ func TestExecCommandEmptyDefaultWorkdirReturnsManagerErrorWithoutExecuting(t *te
 	waitForManagerCount(t, manager, 0, time.Second)
 }
 
-func TestExecCommandDeletedDefaultWorkdirReturnsExactValidationErrorWithoutExecuting(t *testing.T) {
-	workspace := t.TempDir()
-	resolvedWorkdir, err := filepath.Abs(ResolveWorkdir(workspace, ""))
-	if err != nil {
-		t.Fatalf("normalize default workdir: %v", err)
+func TestExecCommandWorkdirValidationErrors(t *testing.T) {
+	tests := []struct {
+		name, id, workdir, reason string
+		prepare                   func(*testing.T, string)
+	}{
+		{
+			name: "deleted default", id: "deleted-default-workdir", reason: missingWorkingDirectoryReason,
+			prepare: func(t *testing.T, workspace string) {
+				if err := os.RemoveAll(workspace); err != nil {
+					t.Fatalf("remove default workdir: %v", err)
+				}
+			},
+		},
+		{
+			name: "missing relative", id: "missing-relative-workdir",
+			workdir: filepath.Join("nested", "..", "missing", ".", "child"), reason: missingWorkingDirectoryReason,
+		},
+		{
+			name: "regular file", id: "file-workdir", workdir: "workdir-file",
+			reason: missingWorkingDirectoryReason,
+			prepare: func(t *testing.T, workspace string) {
+				if err := os.WriteFile(filepath.Join(workspace, "workdir-file"), []byte("not a directory"), 0o600); err != nil {
+					t.Fatalf("write workdir file: %v", err)
+				}
+			},
+		},
 	}
-	sideEffect := filepath.Join(t.TempDir(), "exec-command-deleted-default-side-effect")
-	if err := os.RemoveAll(workspace); err != nil {
-		t.Fatalf("remove default workdir: %v", err)
-	}
-	manager := newBackgroundTestManager(t)
-	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
-	call := tools.Call{
-		ID:   "deleted-default-workdir",
-		Name: toolspec.ToolExecCommand,
-	}
-	call.Input, err = json.Marshal(map[string]any{
-		"cmd":           "touch " + sideEffect,
-		"shell":         "/bin/sh",
-		"login":         false,
-		"yield_time_ms": 1_000,
-	})
-	if err != nil {
-		t.Fatalf("marshal exec_command input: %v", err)
-	}
-	want := tools.ErrorResultWith(
-		call,
-		strings.Join([]string{resolvedWorkdir, missingWorkingDirectoryReason, existingWorkingDirectoryHint}, " "),
-		marshalNoHTMLEscape,
-	)
+	tests[2].reason = nonDirectoryWorkingDirectoryReason
 
-	got, err := execTool.Call(context.Background(), call)
-	if err != nil {
-		t.Fatalf("exec_command call returned transport error: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			resolved, err := filepath.Abs(ResolveWorkdir(workspace, tt.workdir))
+			if err != nil {
+				t.Fatalf("normalize workdir: %v", err)
+			}
+			if tt.prepare != nil {
+				tt.prepare(t, workspace)
+			}
+			sideEffect := filepath.Join(t.TempDir(), "side-effect")
+			input := map[string]any{
+				"cmd": "touch " + sideEffect, "shell": "/bin/sh", "login": false, "yield_time_ms": 1_000,
+			}
+			if tt.workdir != "" {
+				input["workdir"] = tt.workdir
+			}
+			rawInput, err := json.Marshal(input)
+			if err != nil {
+				t.Fatalf("marshal exec_command input: %v", err)
+			}
+			call := tools.Call{ID: tt.id, Name: toolspec.ToolExecCommand, Input: rawInput}
+			manager := newBackgroundTestManager(t)
+			got, err := NewExecCommandTool(workspace, 16_000, manager, "").Call(context.Background(), call)
+			if err != nil {
+				t.Fatalf("exec_command call returned transport error: %v", err)
+			}
+			wantMessage := strings.Join([]string{resolved, tt.reason, existingWorkingDirectoryHint}, " ")
+			want := tools.ErrorResultWith(call, wantMessage, marshalNoHTMLEscape)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("exec_command result = %#v, want %#v", got, want)
+			}
+			if _, err := os.Stat(sideEffect); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("command side effect = %v, want os.ErrNotExist", err)
+			}
+			waitForManagerCount(t, manager, 0, time.Second)
+		})
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("exec_command result = %#v, want %#v", got, want)
-	}
-	if _, err := os.Stat(sideEffect); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("deleted default workdir command side effect = %v, want os.ErrNotExist", err)
-	}
-	waitForManagerCount(t, manager, 0, time.Second)
-}
-
-func TestExecCommandMissingRelativeWorkdirUsesCleanAbsolutePath(t *testing.T) {
-	workspace := t.TempDir()
-	requestedWorkdir := filepath.Join("nested", "..", "missing", ".", "child")
-	resolvedWorkdir, err := filepath.Abs(ResolveWorkdir(workspace, requestedWorkdir))
-	if err != nil {
-		t.Fatalf("normalize custom workdir: %v", err)
-	}
-	sideEffect := filepath.Join(t.TempDir(), "exec-command-missing-relative-side-effect")
-	manager := newBackgroundTestManager(t)
-	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
-	call := tools.Call{
-		ID:   "missing-relative-workdir",
-		Name: toolspec.ToolExecCommand,
-	}
-	call.Input, err = json.Marshal(map[string]any{
-		"cmd":           "touch " + sideEffect,
-		"workdir":       requestedWorkdir,
-		"shell":         "/bin/sh",
-		"login":         false,
-		"yield_time_ms": 1_000,
-	})
-	if err != nil {
-		t.Fatalf("marshal exec_command input: %v", err)
-	}
-	want := tools.ErrorResultWith(
-		call,
-		strings.Join([]string{resolvedWorkdir, missingWorkingDirectoryReason, existingWorkingDirectoryHint}, " "),
-		marshalNoHTMLEscape,
-	)
-
-	got, err := execTool.Call(context.Background(), call)
-	if err != nil {
-		t.Fatalf("exec_command call returned transport error: %v", err)
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("exec_command result = %#v, want %#v", got, want)
-	}
-	if _, err := os.Stat(sideEffect); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("missing relative workdir command side effect = %v, want os.ErrNotExist", err)
-	}
-	waitForManagerCount(t, manager, 0, time.Second)
-}
-
-func TestExecCommandFileWorkdirReturnsExactValidationErrorWithoutExecuting(t *testing.T) {
-	workspace := t.TempDir()
-	workdir := filepath.Join(workspace, "workdir-file")
-	if err := os.WriteFile(workdir, []byte("not a directory"), 0o600); err != nil {
-		t.Fatalf("write workdir file: %v", err)
-	}
-	resolvedWorkdir, err := filepath.Abs(workdir)
-	if err != nil {
-		t.Fatalf("normalize file workdir: %v", err)
-	}
-	sideEffect := filepath.Join(t.TempDir(), "exec-command-file-workdir-side-effect")
-	manager := newBackgroundTestManager(t)
-	execTool := NewExecCommandTool(workspace, 16_000, manager, "")
-	call := tools.Call{
-		ID:   "file-workdir",
-		Name: toolspec.ToolExecCommand,
-	}
-	call.Input, err = json.Marshal(map[string]any{
-		"cmd":           "touch " + sideEffect,
-		"workdir":       filepath.Base(workdir),
-		"shell":         "/bin/sh",
-		"login":         false,
-		"yield_time_ms": 1_000,
-	})
-	if err != nil {
-		t.Fatalf("marshal exec_command input: %v", err)
-	}
-	want := tools.ErrorResultWith(
-		call,
-		strings.Join([]string{resolvedWorkdir, nonDirectoryWorkingDirectoryReason, existingWorkingDirectoryHint}, " "),
-		marshalNoHTMLEscape,
-	)
-
-	got, err := execTool.Call(context.Background(), call)
-	if err != nil {
-		t.Fatalf("exec_command call returned transport error: %v", err)
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("exec_command result = %#v, want %#v", got, want)
-	}
-	if _, err := os.Stat(sideEffect); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("file workdir command side effect = %v, want os.ErrNotExist", err)
-	}
-	waitForManagerCount(t, manager, 0, time.Second)
 }
 
 func envSliceToMap(t *testing.T, in []string) map[string]string {


### PR DESCRIPTION
## Summary
- Validate every non-empty shell Working Directory as a normalized absolute path before `Manager.Start`; reject missing paths and non-directories without executing the command.
- Preserve the existing empty-Working-Directory manager invariant and pass the validated absolute path to execution.
- Remove the `exec_command failed:` decoration while preserving decorated `write_stdin` cancellation errors through a shared base renderer.
- Update the Command Execution specification and add exact public-boundary regressions for all approved behavior slices.

## Verification
- `./scripts/test.sh ./server/tools/shell` — passed.
- `./scripts/test.sh server` — passed.
- `./scripts/build.sh --output ./bin/kent` — passed.
- `git diff --check` — passed.

## Diff accounting
- Production code: net +39 LOC; gross 47 changed LOC (43 additions, 4 deletions).
- Test code: net +203 LOC; gross 229 changed LOC (216 additions, 13 deletions).
- Generated code: net 0 LOC; gross 0 LOC.
- Specification: net +4 LOC; gross 4 changed LOC.
- Total: net +246 LOC; gross 280 changed LOC (263 additions, 17 deletions).

## Caveats and follow-up
- The implementation performs one metadata check before manager delegation; a directory removed after that check still surfaces the operating-system launch error, with no retries or coordination added.
- An empty resolved Working Directory remains delegated to the manager and never falls back to the Kent server process CWD.
- No protocol, schema, generated-code, runtime-wiring, locking, or retry changes are included.
- The cancellation regression uses a single-process shell loop to keep process cleanup deterministic. No follow-up work is required unless product requirements later define stronger guarantees for post-validation directory races.

Addresses Kent task KENT-537. No separate GitHub issue number is associated with this task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shell commands now validate the selected working directory before execution.
  * Missing, invalid, or non-directory paths return clear errors and prevent command execution.
  * Shell execution errors now use consistent, clearer messaging.
  * Cancellation results preserve the appropriate error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->