### PR TITLE
fix: make compaction steerable

### DIFF
--- a/cli/app/ui_busy_commands_test.go
+++ b/cli/app/ui_busy_commands_test.go
@@ -5,6 +5,7 @@ import (
 
 	"core/cli/app/commands"
 	"core/shared/clientui"
+	"core/shared/runtimeinput"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -91,7 +92,7 @@ func TestBusyEnterOpensReadOverlays(t *testing.T) {
 }
 
 func TestBusyEnterBlocksIdleOnlyCommands(t *testing.T) {
-	for _, input := range []string{"/worktree list"} {
+	for _, input := range []string{"/worktree list", "/wt switch feature"} {
 		t.Run(input, func(t *testing.T) {
 			model := busyCommandTestModel()
 			testSetMainInput(model, input)
@@ -105,18 +106,74 @@ func TestBusyEnterBlocksIdleOnlyCommands(t *testing.T) {
 	}
 }
 
+func TestBusyEnterOpensBareWorktreePickerAliases(t *testing.T) {
+	for _, input := range []string{"/worktree", "/wt"} {
+		t.Run(input, func(t *testing.T) {
+			client := &worktreeCommandTestClient{listResp: testMainWorktreeListResponse()}
+			model := busyCommandTestModel()
+			model.worktreeClient = client
+			testSetMainInput(model, input)
+
+			next, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			updated := next.(*uiModel)
+			if cmd == nil || updated.inputMode() != uiInputModeWorktree {
+				t.Fatalf("bare picker result = cmd %v mode %v, want worktree overlay", cmd, updated.inputMode())
+			}
+			if len(client.enterRequests) != 0 || len(client.deleteRequests) != 0 || len(client.createRequests) != 0 {
+				t.Fatalf(
+					"bare picker performed a worktree mutation: enter=%+v delete=%+v create=%+v",
+					client.enterRequests,
+					client.deleteRequests,
+					client.createRequests,
+				)
+			}
+		})
+	}
+}
+
+func TestPromptCommandRemainsTypedRuntimeSubmission(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	model := newProjectedTestUIModel(
+		client,
+		WithUIConversationFreshness(clientui.ConversationFreshnessEstablished),
+		WithUIPromptCommandCatalogEntries([]commands.PromptCommandCatalogEntry{{
+			Name:    "prompt:inspect",
+			Preview: "Inspect the requested scope",
+		}}),
+	)
+	model.commandRegistry = commands.NewDefaultRegistryWithPromptCatalog(model.promptCatalogEntries)
+	submitted := "/prompt:inspect cli/app"
+	testSetMainInput(model, submitted)
+
+	next, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	for _, msg := range collectCmdMessages(t, cmd) {
+		model = updateUIModel(t, model, msg)
+	}
+
+	if client.submitCalls != 1 {
+		t.Fatalf("typed prompt steering calls = %d, want 1", client.submitCalls)
+	}
+	if client.submitInput.Kind != runtimeinput.KindPromptCommand ||
+		client.submitInput.PromptCommand == nil ||
+		client.submitInput.PromptCommand.Name != "prompt:inspect" ||
+		client.submitInput.PromptCommand.Arguments != "cli/app" {
+		t.Fatalf("typed prompt steering input = %+v", client.submitInput)
+	}
+}
+
 func TestBusyEnterDispatchesCompact(t *testing.T) {
 	model := busyCommandTestModel()
 	testSetMainInput(model, "/compact now")
 	next, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated := next.(*uiModel)
-	if cmd == nil || testMainInput(updated) != "" || len(updated.queued) != 0 || !updated.isCompacting() {
+	if cmd == nil || testMainInput(updated) != "" || len(updated.queued) != 0 || updated.isCompacting() {
 		t.Fatalf("compact dispatch = cmd %v, input %q, queued %+v, compacting %t", cmd, testMainInput(updated), updated.queued, updated.isCompacting())
 	}
 	testSetMainInput(updated, "/compact again")
 	next, repeatCmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
-	if repeatCmd != nil || !updated.isCompacting() || len(updated.queued) != 0 || len(updated.injectedQueue) != 0 {
+	if repeatCmd == nil || updated.isCompacting() || len(updated.queued) != 0 || len(updated.injectedQueue) != 0 {
 		t.Fatalf("repeat compact = cmd %v compacting %t queued %+v injected %+v", repeatCmd, updated.isCompacting(), updated.queued, updated.injectedQueue)
 	}
 }
@@ -196,20 +253,26 @@ func TestBusyQueuedCompactStartsCompactionAfterTurnDrains(t *testing.T) {
 
 	next, cmd := updated.Update(submitDoneMsg{message: "done"})
 	updated = next.(*uiModel)
-	if cmd == nil || !updated.isBusy() || !updated.isCompacting() || len(updated.queued) != 0 {
-		t.Fatalf("compact drain = cmd %v, busy %t, compacting %t, queued %+v", cmd, updated.isBusy(), updated.isCompacting(), updated.queued)
+	if cmd == nil || updated.isCompacting() || updated.postTurnCompactionsInFlight != 1 || len(updated.queued) != 0 {
+		t.Fatalf(
+			"compact drain = cmd %v, compacting %t, blockers %d, queued %+v",
+			cmd,
+			updated.isCompacting(),
+			updated.postTurnCompactionsInFlight,
+			updated.queued,
+		)
 	}
 }
 
-func TestCompactionKeepsInputEditableAndQueuesSteering(t *testing.T) {
-	client := &runtimeControlFakeClient{submitQueuedID: "server-queue-1"}
+func TestCompactionDispatchKeepsInputEditableWithoutLocalRuntimeBlocking(t *testing.T) {
+	client := &runtimeControlFakeClient{}
 	model := newProjectedTestUIModel(client)
 	model.startupCmds = nil
 
-	if cmd := model.inputController().startCompactionWithOrigin("", uiCompactionOriginManual); cmd == nil {
+	if cmd := model.inputController().startCompactionWithOrigin("/compact", "", uiCompactionOriginManual); cmd == nil {
 		t.Fatal("expected compaction command")
 	}
-	if !model.isCompacting() || !model.blocksRuntimeInput() || model.layout().mainInputPrefix() != "› " {
+	if model.isCompacting() || model.blocksRuntimeInput() || model.layout().mainInputPrefix() != "› " {
 		t.Fatalf("compaction state = compacting %t, blocked %t, prefix %q", model.isCompacting(), model.blocksRuntimeInput(), model.layout().mainInputPrefix())
 	}
 
@@ -217,8 +280,16 @@ func TestCompactionKeepsInputEditableAndQueuesSteering(t *testing.T) {
 	updated := next.(*uiModel)
 	next, queueCmd := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updated = next.(*uiModel)
-	if queueCmd == nil || testMainInput(updated) != "" || len(updated.injectedQueue) != 1 || updated.injectedQueue[0].Text != "steer during compaction" || !updated.isCompacting() {
-		t.Fatalf("queued steering = cmd %v, input %q, injected %+v, compacting %t", queueCmd, testMainInput(updated), updated.injectedQueue, updated.isCompacting())
+	if queueCmd == nil || testMainInput(updated) != "" || len(updated.injectedQueue) != 0 ||
+		updated.activeSubmit.text != "steer during compaction" || updated.isCompacting() {
+		t.Fatalf(
+			"submission = cmd %v, input %q, active %+v, injected %+v, compacting %t",
+			queueCmd,
+			testMainInput(updated),
+			updated.activeSubmit,
+			updated.injectedQueue,
+			updated.isCompacting(),
+		)
 	}
 }
 

--- a/cli/app/ui_compaction_request_test.go
+++ b/cli/app/ui_compaction_request_test.go
@@ -228,8 +228,7 @@ func TestCompactCommandInvokesCapturedClientAndReducesItsResult(t *testing.T) {
 	if !errors.Is(done.err, capturedErr) {
 		t.Fatalf("completion error = %v, want captured result %v", done.err, capturedErr)
 	}
-	if done.submittedText != submitted || done.guidance != "captured guidance" ||
-		done.origin != uiCompactionOriginManual || !done.invoked {
+	if done.submittedText != submitted || done.origin != uiCompactionOriginManual || !done.invoked {
 		t.Fatalf("request-owned completion = %+v", done)
 	}
 

--- a/cli/app/ui_compaction_request_test.go
+++ b/cli/app/ui_compaction_request_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"core/cli/app/internal/runtimeattach"
 	"core/shared/clientui"
 	"core/shared/serverapi"
 
@@ -39,6 +40,58 @@ func TestDirectCompactWithoutClientRestoresExactSubmittedText(t *testing.T) {
 	model = updateUIModel(t, model, done)
 	if got := testMainInput(model); got != submitted {
 		t.Fatalf("restored composer = %q, want exact %q", got, submitted)
+	}
+	if hook.aborted != 1 || hook.compactionCompleted != 0 {
+		t.Fatalf("queue hooks = aborted %d completed %d, want 1/0", hook.aborted, hook.compactionCompleted)
+	}
+}
+
+func TestCompactNotAcceptedUsesOnlyLocalCreationFailurePresentation(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	rejection := serverapi.NewRuntimeCommandNotAcceptedError(serverapi.ErrRuntimeUnavailable)
+	client := &runtimeControlFakeClient{compactErr: rejection}
+	hook := &compactionTurnQueueHook{}
+	model := newProjectedTestUIModel(client, WithUITurnQueueHook(hook))
+	model.activity = uiActivityRunning
+	model.injectedQueue = []injectedRuntimeQueueItem{{
+		LocalID:  "local-steer",
+		ServerID: "server-steer",
+		Text:     "existing accepted steer",
+		State:    injectedRuntimeQueueEnqueued,
+	}}
+	submitted := "/compact rejected"
+
+	done := compactDoneMessageFromCommand(
+		t,
+		model.inputController().startCompactionWithOrigin(submitted, "rejected", uiCompactionOriginManual),
+	)
+	next, _ := model.Update(done)
+	model = next.(*uiModel)
+
+	if model.activity != uiActivityRunning {
+		t.Fatalf("activity = %v, want unchanged running activity", model.activity)
+	}
+	if model.transientStatus != runtimeattach.FormatSubmissionError(rejection) ||
+		model.transientStatusKind != uiStatusNoticeError {
+		t.Fatalf(
+			"transient status = %q kind %v, want ordinary compact rejection detail",
+			model.transientStatus,
+			model.transientStatusKind,
+		)
+	}
+	if got := testMainInput(model); got != submitted {
+		t.Fatalf("restored composer = %q, want %q", got, submitted)
+	}
+	if len(model.injectedQueue) != 1 || model.injectedQueue[0].State != injectedRuntimeQueueEnqueued {
+		t.Fatalf("existing accepted steer was mutated: %+v", model.injectedQueue)
+	}
+	if client.compactCalls != 1 || client.appendCalls != 0 || client.discardQueuedCalls != 0 {
+		t.Fatalf(
+			"runtime calls = compact %d append %d discard %d, want 1/0/0",
+			client.compactCalls,
+			client.appendCalls,
+			client.discardQueuedCalls,
+		)
 	}
 	if hook.aborted != 1 || hook.compactionCompleted != 0 {
 		t.Fatalf("queue hooks = aborted %d completed %d, want 1/0", hook.aborted, hook.compactionCompleted)
@@ -80,6 +133,35 @@ func TestQueuedCompactWithoutClientRestoresExactTextAndAbortsDrain(t *testing.T)
 	}
 	if hook.aborted != 1 || hook.compactionCompleted != 0 {
 		t.Fatalf("queue hooks = aborted %d completed %d, want 1/0", hook.aborted, hook.compactionCompleted)
+	}
+}
+
+func TestQueuedCompactOwnsExactComposerTextBeforeNormalization(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	model := busyCommandTestModel()
+	submitted := "  /compact  queued\n guidance  "
+	testSetMainInput(model, submitted)
+
+	next, queueCmd := model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	model = next.(*uiModel)
+	if queueCmd != nil {
+		t.Fatal("busy Queue submission unexpectedly dispatched immediately")
+	}
+	if len(model.queued) != 1 || model.queued[0].Text != submitted {
+		t.Fatalf("queued compact text = %+v, want exact composer text %q", model.queued, submitted)
+	}
+
+	next, drainCmd := model.Update(submitDoneMsg{message: "turn complete"})
+	model = next.(*uiModel)
+	done := compactDoneMessageFromCommand(t, drainCmd)
+	if done.submittedText != submitted {
+		t.Fatalf("request-owned compact text = %q, want exact %q", done.submittedText, submitted)
+	}
+
+	next, _ = model.Update(done)
+	model = next.(*uiModel)
+	if got := testMainInput(model); got != submitted {
+		t.Fatalf("restored composer = %q, want exact %q", got, submitted)
 	}
 }
 

--- a/cli/app/ui_compaction_request_test.go
+++ b/cli/app/ui_compaction_request_test.go
@@ -41,8 +41,8 @@ func TestDirectCompactWithoutClientRestoresExactSubmittedText(t *testing.T) {
 	if got := testMainInput(model); got != submitted {
 		t.Fatalf("restored composer = %q, want exact %q", got, submitted)
 	}
-	if hook.aborted != 1 || hook.compactionCompleted != 0 {
-		t.Fatalf("queue hooks = aborted %d completed %d, want 1/0", hook.aborted, hook.compactionCompleted)
+	if hook.aborted != 0 || hook.compactionCompleted != 0 {
+		t.Fatalf("queue hooks = aborted %d completed %d, want 0/0", hook.aborted, hook.compactionCompleted)
 	}
 }
 
@@ -59,6 +59,7 @@ func TestCompactNotAcceptedUsesOnlyLocalCreationFailurePresentation(t *testing.T
 		Text:     "existing accepted steer",
 		State:    injectedRuntimeQueueEnqueued,
 	}}
+	model.queueInput("unrelated queued input")
 	submitted := "/compact rejected"
 
 	done := compactDoneMessageFromCommand(
@@ -85,6 +86,9 @@ func TestCompactNotAcceptedUsesOnlyLocalCreationFailurePresentation(t *testing.T
 	if len(model.injectedQueue) != 1 || model.injectedQueue[0].State != injectedRuntimeQueueEnqueued {
 		t.Fatalf("existing accepted steer was mutated: %+v", model.injectedQueue)
 	}
+	if len(model.queued) != 1 || model.queued[0].Text != "unrelated queued input" {
+		t.Fatalf("unrelated queued input was mutated: %+v", model.queued)
+	}
 	if client.compactCalls != 1 || client.appendCalls != 0 || client.discardQueuedCalls != 0 {
 		t.Fatalf(
 			"runtime calls = compact %d append %d discard %d, want 1/0/0",
@@ -93,8 +97,8 @@ func TestCompactNotAcceptedUsesOnlyLocalCreationFailurePresentation(t *testing.T
 			client.discardQueuedCalls,
 		)
 	}
-	if hook.aborted != 1 || hook.compactionCompleted != 0 {
-		t.Fatalf("queue hooks = aborted %d completed %d, want 1/0", hook.aborted, hook.compactionCompleted)
+	if hook.aborted != 0 || hook.compactionCompleted != 0 {
+		t.Fatalf("queue hooks = aborted %d completed %d, want 0/0", hook.aborted, hook.compactionCompleted)
 	}
 }
 

--- a/cli/app/ui_compaction_request_test.go
+++ b/cli/app/ui_compaction_request_test.go
@@ -165,6 +165,49 @@ func TestQueuedCompactOwnsExactComposerTextBeforeNormalization(t *testing.T) {
 	}
 }
 
+func TestIdleQueueKeyCompactRejectionRestoresExactComposerText(t *testing.T) {
+	disableTransientStatusClearForTest(t)
+	tests := []struct {
+		name string
+		key  tea.Msg
+	}{
+		{name: "Tab", key: tea.KeyMsg{Type: tea.KeyTab}},
+		{name: "CtrlEnter", key: customKeyMsg{Kind: customKeyCtrlEnter}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			model := newProjectedStaticUIModel()
+			submitted := "  /compact  idle\n guidance  "
+			testSetMainInput(model, submitted)
+
+			next, cmd := model.Update(test.key)
+			model = next.(*uiModel)
+			if cmd == nil {
+				t.Fatalf(
+					"idle Queue-key compact did not dispatch: input=%q queued=%+v blockers=%d busy=%t",
+					testMainInput(model),
+					model.queued,
+					model.postTurnCompactionsInFlight,
+					model.blocksRuntimeInput(),
+				)
+			}
+			done := compactDoneMessageFromCommand(t, cmd)
+			if !errors.Is(done.err, serverapi.ErrRuntimeCommandNotAccepted) {
+				t.Fatalf("compact error = %v, want runtime command not accepted", done.err)
+			}
+			if done.submittedText != submitted {
+				t.Fatalf("request-owned compact text = %q, want exact %q", done.submittedText, submitted)
+			}
+
+			next, _ = model.Update(done)
+			model = next.(*uiModel)
+			if got := testMainInput(model); got != submitted {
+				t.Fatalf("restored composer = %q, want exact %q", got, submitted)
+			}
+		})
+	}
+}
+
 func TestCompactCommandInvokesCapturedClientAndReducesItsResult(t *testing.T) {
 	capturedErr := serverapi.NewRuntimeCommandNotAcceptedError(errors.New("captured client rejected request"))
 	captured := &runtimeControlFakeClient{compactErr: capturedErr}

--- a/cli/app/ui_compaction_request_test.go
+++ b/cli/app/ui_compaction_request_test.go
@@ -25,8 +25,7 @@ func (h *compactionTurnQueueHook) OnUserCompactionCompleted(bool) {
 }
 
 func TestDirectCompactWithoutClientRestoresExactSubmittedText(t *testing.T) {
-	hook := &compactionTurnQueueHook{}
-	model := newProjectedStaticUIModel(WithUITurnQueueHook(hook))
+	model := newProjectedStaticUIModel()
 	submitted := "  /compact  preserve\n these instructions  "
 	testSetMainInput(model, submitted)
 
@@ -40,9 +39,6 @@ func TestDirectCompactWithoutClientRestoresExactSubmittedText(t *testing.T) {
 	model = updateUIModel(t, model, done)
 	if got := testMainInput(model); got != submitted {
 		t.Fatalf("restored composer = %q, want exact %q", got, submitted)
-	}
-	if hook.aborted != 0 || hook.compactionCompleted != 0 {
-		t.Fatalf("queue hooks = aborted %d completed %d, want 0/0", hook.aborted, hook.compactionCompleted)
 	}
 }
 

--- a/cli/app/ui_compaction_request_test.go
+++ b/cli/app/ui_compaction_request_test.go
@@ -1,0 +1,215 @@
+package app
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"core/shared/clientui"
+	"core/shared/serverapi"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type compactionTurnQueueHook struct {
+	aborted             int
+	compactionCompleted int
+}
+
+func (h *compactionTurnQueueHook) OnTranscriptMessage(clientui.TranscriptMessage) {}
+func (h *compactionTurnQueueHook) OnTurnQueueDrained()                            {}
+func (h *compactionTurnQueueHook) OnTurnQueueAborted()                            { h.aborted++ }
+func (h *compactionTurnQueueHook) OnUserCompactionCompleted(bool) {
+	h.compactionCompleted++
+}
+
+func TestDirectCompactWithoutClientRestoresExactSubmittedText(t *testing.T) {
+	hook := &compactionTurnQueueHook{}
+	model := newProjectedStaticUIModel(WithUITurnQueueHook(hook))
+	submitted := "  /compact  preserve\n these instructions  "
+	testSetMainInput(model, submitted)
+
+	next, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(*uiModel)
+	done := compactDoneMessageFromCommand(t, cmd)
+	if !errors.Is(done.err, serverapi.ErrRuntimeCommandNotAccepted) {
+		t.Fatalf("compact error = %v, want runtime command not accepted", done.err)
+	}
+
+	model = updateUIModel(t, model, done)
+	if got := testMainInput(model); got != submitted {
+		t.Fatalf("restored composer = %q, want exact %q", got, submitted)
+	}
+	if hook.aborted != 1 || hook.compactionCompleted != 0 {
+		t.Fatalf("queue hooks = aborted %d completed %d, want 1/0", hook.aborted, hook.compactionCompleted)
+	}
+}
+
+func compactDoneMessageFromCommand(t *testing.T, cmd tea.Cmd) compactDoneMsg {
+	t.Helper()
+	for _, msg := range collectCmdMessages(t, cmd) {
+		if done, ok := msg.(compactDoneMsg); ok {
+			return done
+		}
+	}
+	t.Fatal("compaction command returned no completion")
+	return compactDoneMsg{}
+}
+
+func TestQueuedCompactWithoutClientRestoresExactTextAndAbortsDrain(t *testing.T) {
+	hook := &compactionTurnQueueHook{}
+	model := newProjectedStaticUIModel(WithUITurnQueueHook(hook))
+	compactText := "  /compact  queued\n guidance  "
+	laterText := "later queued input"
+	model.queueInput(compactText)
+	model.queueInput(laterText)
+
+	_, cmd := model.inputController().flushQueuedInputs(queueDrainAuto)
+	done := compactDoneMessageFromCommand(t, cmd)
+	if !errors.Is(done.err, serverapi.ErrRuntimeCommandNotAccepted) {
+		t.Fatalf("compact error = %v, want runtime command not accepted", done.err)
+	}
+
+	model = updateUIModel(t, model, done)
+	want := strings.Join([]string{compactText, laterText}, "\n\n")
+	if got := testMainInput(model); got != want {
+		t.Fatalf("restored composer = %q, want %q", got, want)
+	}
+	if len(model.queued) != 0 {
+		t.Fatalf("queued inputs remained after abort: %+v", model.queued)
+	}
+	if hook.aborted != 1 || hook.compactionCompleted != 0 {
+		t.Fatalf("queue hooks = aborted %d completed %d, want 1/0", hook.aborted, hook.compactionCompleted)
+	}
+}
+
+func TestCompactCommandInvokesCapturedClientAndReducesItsResult(t *testing.T) {
+	capturedErr := serverapi.NewRuntimeCommandNotAcceptedError(errors.New("captured client rejected request"))
+	captured := &runtimeControlFakeClient{compactErr: capturedErr}
+	replacement := &runtimeControlFakeClient{}
+	model := newProjectedTestUIModel(captured)
+	submitted := "/compact captured guidance"
+
+	cmd := model.inputController().startCompactionWithOrigin(submitted, "captured guidance", uiCompactionOriginManual)
+	model.engine = replacement
+	done := compactDoneMessageFromCommand(t, cmd)
+
+	if captured.compactCalls != 1 || captured.compactArgs != "captured guidance" {
+		t.Fatalf("captured client calls = %d args %q, want 1 and parsed guidance", captured.compactCalls, captured.compactArgs)
+	}
+	if replacement.compactCalls != 0 {
+		t.Fatalf("replacement client calls = %d, want 0", replacement.compactCalls)
+	}
+	if !errors.Is(done.err, capturedErr) {
+		t.Fatalf("completion error = %v, want captured result %v", done.err, capturedErr)
+	}
+	if done.submittedText != submitted || done.guidance != "captured guidance" ||
+		done.origin != uiCompactionOriginManual || !done.invoked {
+		t.Fatalf("request-owned completion = %+v", done)
+	}
+
+	model = updateUIModel(t, model, done)
+	if got := testMainInput(model); got != submitted {
+		t.Fatalf("restored composer = %q, want request-owned text %q", got, submitted)
+	}
+}
+
+func TestConcurrentCompactRequestsRemainIndependentWhenCompletionsArriveOutOfOrder(t *testing.T) {
+	firstErr := serverapi.NewRuntimeCommandNotAcceptedError(errors.New("first request was not accepted"))
+	secondErr := errors.New("second request failed after acceptance")
+	firstClient := &runtimeControlFakeClient{compactErr: firstErr}
+	secondClient := &runtimeControlFakeClient{compactErr: secondErr}
+	model := newProjectedTestUIModel(firstClient)
+
+	firstText := " /compact first guidance "
+	firstCmd := model.inputController().startCompactionWithOrigin(firstText, "first guidance", uiCompactionOriginManual)
+	model.engine = secondClient
+	secondText := "/compact second guidance"
+	secondCmd := model.inputController().startCompactionWithOrigin(secondText, "second guidance", uiCompactionOriginManual)
+
+	if firstCmd == nil || secondCmd == nil {
+		t.Fatalf("compact commands = first %v second %v, want both dispatched", firstCmd, secondCmd)
+	}
+	if model.isCompacting() {
+		t.Fatal("compact dispatch mutated client-local compaction lifecycle")
+	}
+
+	firstDone := compactDoneMessageFromCommand(t, firstCmd)
+	secondDone := compactDoneMessageFromCommand(t, secondCmd)
+	if firstClient.compactCalls != 1 || firstClient.compactArgs != "first guidance" {
+		t.Fatalf("first client = calls %d args %q", firstClient.compactCalls, firstClient.compactArgs)
+	}
+	if secondClient.compactCalls != 1 || secondClient.compactArgs != "second guidance" {
+		t.Fatalf("second client = calls %d args %q", secondClient.compactCalls, secondClient.compactArgs)
+	}
+
+	model = updateUIModel(t, model, secondDone)
+	if got := testMainInput(model); got != "" {
+		t.Fatalf("accepted error restored composer = %q, want empty", got)
+	}
+	model = updateUIModel(t, model, firstDone)
+	if got := testMainInput(model); got != firstText {
+		t.Fatalf("not-accepted request restored %q, want only %q", got, firstText)
+	}
+}
+
+func TestAcceptedQueuedCompactErrorConsumesCommandAndAdvancesQueue(t *testing.T) {
+	acceptedErr := errors.New("compaction committed before finalization failed")
+	client := &runtimeControlFakeClient{compactErr: acceptedErr}
+	model := newProjectedTestUIModel(client)
+	compactText := "/compact queued guidance"
+	laterText := "later queued input"
+	model.queueInput(laterText)
+
+	cmd := model.inputController().startCompactionWithOrigin(compactText, "queued guidance", uiCompactionOriginQueued)
+	done := compactDoneMessageFromCommand(t, cmd)
+	next, completionCmd := model.Update(done)
+	model = next.(*uiModel)
+	for _, msg := range collectCmdMessages(t, completionCmd) {
+		model = updateUIModel(t, model, msg)
+	}
+
+	if got := testMainInput(model); got != "" {
+		t.Fatalf("accepted compact error restored composer = %q, want empty", got)
+	}
+	if client.submitCalls != 1 || client.submitText != laterText {
+		t.Fatalf("later Queue dispatch = calls %d text %q, want 1 and %q", client.submitCalls, client.submitText, laterText)
+	}
+}
+
+func TestQueuedCompactBlocksOnlyLaterPostTurnDispatchUntilCompletion(t *testing.T) {
+	client := &runtimeControlFakeClient{}
+	model := newProjectedTestUIModel(client)
+	compactText := "/compact queued guidance"
+	laterText := "later queued input"
+	model.queueInput(laterText)
+
+	cmd := model.inputController().startCompactionWithOrigin(compactText, "queued guidance", uiCompactionOriginQueued)
+	done := compactDoneMessageFromCommand(t, cmd)
+	_, blockedCmd := model.inputController().flushQueuedInputs(queueDrainAuto)
+	if blockedCmd != nil {
+		t.Fatal("later post-turn Queue input dispatched before compact completion")
+	}
+	if client.submitCalls != 0 || len(model.queued) != 1 || model.queued[0].Text != laterText {
+		t.Fatalf("pre-completion Queue state = submit calls %d queued %+v", client.submitCalls, model.queued)
+	}
+	if model.postTurnCompactionsInFlight != 1 {
+		t.Fatalf("post-turn compact blockers = %d, want 1", model.postTurnCompactionsInFlight)
+	}
+	if model.isCompacting() {
+		t.Fatal("queued compact dispatch mutated client-local compaction lifecycle")
+	}
+
+	next, completionCmd := model.Update(done)
+	model = next.(*uiModel)
+	for _, msg := range collectCmdMessages(t, completionCmd) {
+		model = updateUIModel(t, model, msg)
+	}
+
+	if model.postTurnCompactionsInFlight != 0 {
+		t.Fatalf("post-turn compact blockers = %d, want 0 after completion", model.postTurnCompactionsInFlight)
+	}
+	if client.submitCalls != 1 || client.submitText != laterText {
+		t.Fatalf("later Queue dispatch = calls %d text %q, want 1 and %q", client.submitCalls, client.submitText, laterText)
+	}
+}

--- a/cli/app/ui_input_controller_commands.go
+++ b/cli/app/ui_input_controller_commands.go
@@ -14,11 +14,20 @@ import (
 )
 
 func (c uiInputController) applyCommandResultWithPreSubmitQueuePosition(commandResult commands.Result, queuePosition preSubmitQueuePosition) (tea.Model, tea.Cmd) {
-	return c.applyCommandResultWithPreSubmitQueuePositionAndOrigin(commandResult, queuePosition, activeSubmitOriginDirect)
+	return c.applyCommandResultWithPreSubmitQueuePositionAndSubmittedText(commandResult, queuePosition, activeSubmitOriginDirect, "")
 }
 
 func (c uiInputController) applyCommandResultWithPreSubmitQueuePositionAndOrigin(commandResult commands.Result, queuePosition preSubmitQueuePosition, origin activeSubmitOrigin) (tea.Model, tea.Cmd) {
-	return c.applyCommandResultWithPreSubmitQueuePositionAndOriginAndOrder(commandResult, queuePosition, origin, nil)
+	return c.applyCommandResultWithPreSubmitQueuePositionAndSubmittedText(commandResult, queuePosition, origin, "")
+}
+
+func (c uiInputController) applyCommandResultWithPreSubmitQueuePositionAndSubmittedText(
+	commandResult commands.Result,
+	queuePosition preSubmitQueuePosition,
+	origin activeSubmitOrigin,
+	submittedText string,
+) (tea.Model, tea.Cmd) {
+	return c.applyCommandResultWithPreSubmitQueuePositionAndOriginAndOrder(commandResult, queuePosition, origin, nil, submittedText)
 }
 
 func (c uiInputController) applyCommandResultWithPreSubmitQueuePositionAndOriginAndOrder(
@@ -26,6 +35,7 @@ func (c uiInputController) applyCommandResultWithPreSubmitQueuePositionAndOrigin
 	queuePosition preSubmitQueuePosition,
 	origin activeSubmitOrigin,
 	submissionOrder *inputSubmissionOrder,
+	submittedText string,
 ) (tea.Model, tea.Cmd) {
 	m := c.model
 	if commandResult.PromptCommand != nil {
@@ -132,7 +142,10 @@ func (c uiInputController) applyCommandResultWithPreSubmitQueuePositionAndOrigin
 		next, cmd := c.handleQuestionsCommand(commandResult.QuestionsMode)
 		return next, sequenceCmds(prefixCmd, cmd)
 	case commands.ActionCompact:
-		return m, sequenceCmds(prefixCmd, c.startCompactionWithOrigin(commandResult.Args, uiCompactionOriginManual))
+		if strings.TrimSpace(submittedText) == "" {
+			panic("compact command is missing its exact submitted text")
+		}
+		return m, sequenceCmds(prefixCmd, c.startCompactionWithOrigin(submittedText, commandResult.Args, uiCompactionOriginManual))
 	case commands.ActionStatus:
 		return m, sequenceCmds(prefixCmd, c.startStatusFlowCmd())
 	case commands.ActionGoal:

--- a/cli/app/ui_input_controller_commands.go
+++ b/cli/app/ui_input_controller_commands.go
@@ -17,10 +17,6 @@ func (c uiInputController) applyCommandResultWithPreSubmitQueuePosition(commandR
 	return c.applyCommandResultWithPreSubmitQueuePositionAndSubmittedText(commandResult, queuePosition, activeSubmitOriginDirect, "")
 }
 
-func (c uiInputController) applyCommandResultWithPreSubmitQueuePositionAndOrigin(commandResult commands.Result, queuePosition preSubmitQueuePosition, origin activeSubmitOrigin) (tea.Model, tea.Cmd) {
-	return c.applyCommandResultWithPreSubmitQueuePositionAndSubmittedText(commandResult, queuePosition, origin, "")
-}
-
 func (c uiInputController) applyCommandResultWithPreSubmitQueuePositionAndSubmittedText(
 	commandResult commands.Result,
 	queuePosition preSubmitQueuePosition,

--- a/cli/app/ui_input_controller_keys.go
+++ b/cli/app/ui_input_controller_keys.go
@@ -159,7 +159,7 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, c.model.sendTransientStatusWithNoticeID(errText, uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, "")
 		}
 		if m.blocksRuntimeInput() {
-			if handled, next, cmd := c.handleEnteredSlashCommandInput(trimmedText); handled {
+			if handled, next, cmd := c.handleEnteredSlashCommandInput(submittedText); handled {
 				return next, cmd
 			}
 		}
@@ -183,14 +183,19 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.restoreCapturedPromptHistoryDraft(draft)
 			return c.flushQueuedInputs(queueDrainOne)
 		}
-		if handled, next, cmd := c.handleEnteredSlashCommandInput(trimmedText); handled {
+		if handled, next, cmd := c.handleEnteredSlashCommandInput(submittedText); handled {
 			return next, cmd
 		}
 		if commandResult := m.commandRegistry.Execute(trimmedText); commandResult.Handled {
 			command, _ := m.commandRegistry.Command(trimmedText)
 			recordCmd := m.recordPromptHistory(trimmedText)
 			m.clearCommandInput(command, draft)
-			next, cmd := c.applyCommandResultWithPreSubmitQueuePosition(commandResult, preSubmitQueueBack)
+			next, cmd := c.applyCommandResultWithPreSubmitQueuePositionAndSubmittedText(
+				commandResult,
+				preSubmitQueueBack,
+				activeSubmitOriginDirect,
+				submittedText,
+			)
 			return next, finalizeSlashCommandCmd(commandResult.Action, cmd, recordCmd)
 		}
 		m.clearInput()

--- a/cli/app/ui_input_controller_keys.go
+++ b/cli/app/ui_input_controller_keys.go
@@ -86,7 +86,7 @@ func (c uiInputController) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if errText, blocked := m.slashCommandInputBlocked(trimmedText); blocked {
 			return m, c.model.sendTransientStatusWithNoticeID(errText, uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, "")
 		}
-		if handled, next, cmd := c.handleQueuedSlashCommandInput(trimmedText); handled {
+		if handled, next, cmd := c.handleQueuedSlashCommandInput(submittedText); handled {
 			return next, cmd
 		}
 		return c.queueOrStartSubmission(submittedText)

--- a/cli/app/ui_input_queue.go
+++ b/cli/app/ui_input_queue.go
@@ -353,6 +353,9 @@ func (c uiInputController) flushQueuedInputs(mode queueDrainMode) (tea.Model, te
 	if len(m.queued) == 0 {
 		return m, nil
 	}
+	if m.postTurnCompactionsInFlight > 0 {
+		return m, nil
+	}
 	if blocked, disconnectCmd := c.blockDisconnectedQueuedSubmission(); blocked {
 		return m, disconnectCmd
 	}
@@ -374,7 +377,7 @@ func (c uiInputController) flushQueuedInputs(mode queueDrainMode) (tea.Model, te
 
 func (c uiInputController) resumeQueuedInputsAfterIdleRuntime() tea.Cmd {
 	m := c.model
-	if m == nil || m.blocksRuntimeInput() || m.ask.hasCurrent() ||
+	if m == nil || m.blocksRuntimeInput() || m.postTurnCompactionsInFlight > 0 || m.ask.hasCurrent() ||
 		m.processList.actionInFlight {
 		return nil
 	}
@@ -393,13 +396,14 @@ func (c uiInputController) dispatchQueuedInput(item queuedInputItem) tea.Cmd {
 		if _, knownCommand := m.commandRegistry.Command(text); knownCommand {
 			if commandResult := m.commandRegistry.Execute(text); commandResult.Handled {
 				if commandResult.Action == commands.ActionCompact {
-					return finalizeSlashCommandCmd(commandResult.Action, c.startCompactionWithOrigin(commandResult.Args, uiCompactionOriginQueued), m.recordPromptHistory(text))
+					return finalizeSlashCommandCmd(commandResult.Action, c.startCompactionWithOrigin(text, commandResult.Args, uiCompactionOriginQueued), m.recordPromptHistory(text))
 				}
 				_, cmd := c.applyCommandResultWithPreSubmitQueuePositionAndOriginAndOrder(
 					commandResult,
 					preSubmitQueueFront,
 					activeSubmitOriginQueued,
 					&item.submissionOrder,
+					text,
 				)
 				var recordCmd tea.Cmd
 				if commandResult.PromptCommand == nil {
@@ -423,7 +427,7 @@ func (c uiInputController) dispatchQueuedInput(item queuedInputItem) tea.Cmd {
 }
 
 func (m *uiModel) shouldContinueQueuedInputAutoDrain() bool {
-	if len(m.queued) == 0 || m.blocksRuntimeInput() ||
+	if len(m.queued) == 0 || m.postTurnCompactionsInFlight > 0 || m.blocksRuntimeInput() ||
 		m.exitAction != UIActionNone || m.ask.hasCurrent() || m.processList.actionInFlight {
 		return false
 	}

--- a/cli/app/ui_input_slash_commands.go
+++ b/cli/app/ui_input_slash_commands.go
@@ -27,7 +27,11 @@ func (c uiInputController) handleQueuedSlashCommandInput(text string) (bool, tea
 	if errText, blocked := m.blockedDeferredSlashCommand(selection.commandText()); blocked {
 		return true, m, sequenceCmds(c.model.appendLocalEntryWithNoticeID("error", errText, ""), c.model.sendTransientStatusWithNoticeID(errText, uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, ""))
 	}
-	next, cmd := c.queueOrStartSubmission(selection.commandText())
+	queuedText := selection.commandText()
+	if commandResult := m.commandRegistry.Execute(queuedText); m.isBusy() && isCompactCommandResult(commandResult) {
+		queuedText = text
+	}
+	next, cmd := c.queueOrStartSubmission(queuedText)
 	return true, next, cmd
 }
 
@@ -160,4 +164,8 @@ func isBusyLocalWorktreePicker(commandResult commands.Result) bool {
 	return commandResult.Handled &&
 		commandResult.Action == commands.ActionWorktree &&
 		strings.TrimSpace(commandResult.Args) == ""
+}
+
+func isCompactCommandResult(commandResult commands.Result) bool {
+	return commandResult.Handled && commandResult.Action == commands.ActionCompact
 }

--- a/cli/app/ui_input_slash_commands.go
+++ b/cli/app/ui_input_slash_commands.go
@@ -28,7 +28,7 @@ func (c uiInputController) handleQueuedSlashCommandInput(text string) (bool, tea
 		return true, m, sequenceCmds(c.model.appendLocalEntryWithNoticeID("error", errText, ""), c.model.sendTransientStatusWithNoticeID(errText, uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, ""))
 	}
 	queuedText := selection.commandText()
-	if commandResult := m.commandRegistry.Execute(queuedText); m.isBusy() && isCompactCommandResult(commandResult) {
+	if commandResult := m.commandRegistry.Execute(queuedText); isCompactCommandResult(commandResult) {
 		queuedText = text
 	}
 	next, cmd := c.queueOrStartSubmission(queuedText)

--- a/cli/app/ui_input_slash_commands.go
+++ b/cli/app/ui_input_slash_commands.go
@@ -45,7 +45,8 @@ func (c uiInputController) handleEnteredSlashCommandInput(text string) (bool, te
 		return false, m, nil
 	}
 	command := selection.command
-	if m.isBusy() {
+	commandResult := m.commandRegistry.Execute(commandText)
+	if m.isBusy() && !isBusyLocalWorktreePicker(commandResult) {
 		switch command.ActiveRunPolicy {
 		case commands.ActiveRunPolicyAllowed:
 		default:
@@ -53,7 +54,6 @@ func (c uiInputController) handleEnteredSlashCommandInput(text string) (bool, te
 			return true, m, c.model.sendTransientStatusWithNoticeID(fmt.Sprintf("cannot run /%s while model is working", command.Name), uiStatusNoticeError, transientStatusDuration, uiStatusNoticeReplace, "")
 		}
 	}
-	commandResult := m.commandRegistry.Execute(commandText)
 	if commandResult.Handled {
 		draft := m.capturePromptHistoryDraftForReuse()
 		var recordCmd tea.Cmd
@@ -61,7 +61,12 @@ func (c uiInputController) handleEnteredSlashCommandInput(text string) (bool, te
 			recordCmd = m.recordPromptHistory(commandText)
 		}
 		m.clearCommandInput(command, draft)
-		next, cmd := c.applyCommandResultWithPreSubmitQueuePosition(commandResult, preSubmitQueueBack)
+		next, cmd := c.applyCommandResultWithPreSubmitQueuePositionAndSubmittedText(
+			commandResult,
+			preSubmitQueueBack,
+			activeSubmitOriginDirect,
+			text,
+		)
 		return true, next, finalizeSlashCommandCmd(commandResult.Action, cmd, recordCmd)
 	}
 	return false, m, nil
@@ -141,7 +146,7 @@ func (m *uiModel) blockedDeferredSlashCommand(commandText string) (string, bool)
 			return "background process client is unavailable", true
 		}
 	case commands.ActionWorktree:
-		if m.isBusy() {
+		if m.isBusy() && !isBusyLocalWorktreePicker(commandResult) {
 			return "cannot run /worktree while model is working", true
 		}
 		if m.worktreeClient == nil {
@@ -149,4 +154,10 @@ func (m *uiModel) blockedDeferredSlashCommand(commandText string) (string, bool)
 		}
 	}
 	return "", false
+}
+
+func isBusyLocalWorktreePicker(commandResult commands.Result) bool {
+	return commandResult.Handled &&
+		commandResult.Action == commands.ActionWorktree &&
+		strings.TrimSpace(commandResult.Args) == ""
 }

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -402,11 +402,13 @@ func (c uiInputController) handleCompactDone(msg compactDoneMsg) (tea.Model, tea
 	}
 	if msg.err != nil {
 		if notAccepted {
-			if m.turnQueueHook != nil {
-				m.turnQueueHook.OnTurnQueueAborted()
-			}
 			c.restoreSubmittedTextIntoInput(msg.submittedText)
-			c.restoreQueuedMessagesIntoInput()
+			if compactionOrigin == uiCompactionOriginQueued {
+				if m.turnQueueHook != nil {
+					m.turnQueueHook.OnTurnQueueAborted()
+				}
+				c.restoreQueuedMessagesIntoInput()
+			}
 			detailErr := runtimeattach.FormatSubmissionError(msg.err)
 			m.logf("compaction.error err=%q", detailErr)
 			m.layout().syncViewport()

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -402,18 +402,21 @@ func (c uiInputController) handleCompactDone(msg compactDoneMsg) (tea.Model, tea
 	}
 	if msg.err != nil {
 		if notAccepted {
-			restoreInjectedCmd := c.restoreInjectedInputsIntoComposer()
 			if m.turnQueueHook != nil {
 				m.turnQueueHook.OnTurnQueueAborted()
 			}
 			c.restoreSubmittedTextIntoInput(msg.submittedText)
 			c.restoreQueuedMessagesIntoInput()
 			detailErr := runtimeattach.FormatSubmissionError(msg.err)
-			m.activity = uiActivityError
-			appendCmd := m.appendLocalEntryWithNoticeID(operatorErrorFeedbackRole, detailErr, "")
 			m.logf("compaction.error err=%q", detailErr)
 			m.layout().syncViewport()
-			return m, tea.Batch(restoreInjectedCmd, appendCmd)
+			return m, m.sendTransientStatusWithNoticeID(
+				detailErr,
+				uiStatusNoticeError,
+				transientStatusDuration,
+				uiStatusNoticeReplace,
+				"",
+			)
 		}
 		detailErr := runtimeattach.FormatSubmissionError(msg.err)
 		m.activity = uiActivityError

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -185,31 +185,46 @@ func (m *uiModel) beginSubmitAttempt(
 type uiCompactionOrigin uint8
 
 const (
-	uiCompactionOriginNone uiCompactionOrigin = iota
-	uiCompactionOriginManual
+	uiCompactionOriginManual uiCompactionOrigin = iota
 	uiCompactionOriginQueued
 )
 
-func (c uiInputController) startCompactionWithOrigin(args string, origin uiCompactionOrigin) tea.Cmd {
+func (c uiInputController) startCompactionWithOrigin(submittedText, args string, origin uiCompactionOrigin) tea.Cmd {
 	m := c.model
-	if m.isCompacting() {
-		return nil
+	switch origin {
+	case uiCompactionOriginManual:
+	case uiCompactionOriginQueued:
+		m.postTurnCompactionsInFlight++
+	default:
+		panic("compact request has invalid dispatch origin")
 	}
-	c.startRuntimeOperationAffordance(true)
-	m.compactionOrigin = origin
 	m.logf("compaction.start args_chars=%d", len(strings.TrimSpace(args)))
 	m.layout().syncViewport()
-	return tea.Batch(c.compactCmd(args), m.reconcileSpinnerTicking(false))
+	return c.compactCmd(submittedText, args, origin)
 }
 
-func (c uiInputController) compactCmd(args string) tea.Cmd {
+func (c uiInputController) compactCmd(submittedText, args string, origin uiCompactionOrigin) tea.Cmd {
 	m := c.model
 	client := m.runtimeClient()
 	return func() tea.Msg {
 		if client == nil {
-			return compactDoneMsg{err: errors.New("runtime engine is not configured")}
+			return compactDoneMsg{
+				submittedText: submittedText,
+				guidance:      args,
+				origin:        origin,
+				err: serverapi.NewRuntimeCommandNotAcceptedError(
+					errors.New("runtime engine is not configured"),
+				),
+			}
 		}
-		return compactDoneMsg{err: m.compactRuntimeInput(context.Background(), clientui.RuntimeCompactRequest{Args: args})}
+		err := client.CompactRuntime(context.Background(), clientui.RuntimeCompactRequest{Args: args})
+		return compactDoneMsg{
+			submittedText: submittedText,
+			guidance:      args,
+			origin:        origin,
+			invoked:       true,
+			err:           err,
+		}
 	}
 }
 
@@ -239,6 +254,7 @@ func (c uiInputController) notifyTurnQueueDrainedIfIdle() {
 	if m.turnQueueHook == nil ||
 		m.blocksRuntimeInput() ||
 		len(m.queued) > 0 ||
+		m.postTurnCompactionsInFlight > 0 ||
 		m.injectedQueueBlocksDrain() ||
 		m.hasEnqueuedInjectedRuntimeWork() ||
 		m.ask.hasCurrent() {
@@ -360,44 +376,75 @@ func (c uiInputController) handleSpinnerTick(msg spinnerTickMsg) (tea.Model, tea
 
 func (c uiInputController) handleCompactDone(msg compactDoneMsg) (tea.Model, tea.Cmd) {
 	m := c.model
-	serverActiveBeforeCompletion := m.runtimeActivityBusy()
-	compactionOrigin := m.compactionOrigin
-	m.compactionOrigin = uiCompactionOriginNone
-	m.observeRuntimeRequestResult(msg.err)
-	c.finishRuntimeOperationAffordance(true)
+	compactionOrigin := msg.origin
+	notAccepted := errors.Is(msg.err, serverapi.ErrRuntimeCommandNotAccepted)
+	if !msg.invoked && !notAccepted {
+		msg.err = serverapi.NewRuntimeCommandNotAcceptedError(
+			errors.New("compact request completed without dispatch"),
+		)
+		notAccepted = true
+	}
+	if compactionOrigin == uiCompactionOriginQueued {
+		if m.postTurnCompactionsInFlight == 0 {
+			if m.debugMode {
+				panic("compact completion has no matching post-turn request")
+			}
+			msg.err = serverapi.NewRuntimeCommandNotAcceptedError(
+				errors.New("compact completion has no matching post-turn request"),
+			)
+			notAccepted = true
+		} else {
+			m.postTurnCompactionsInFlight--
+		}
+	}
+	if msg.invoked {
+		m.observeRuntimeRequestResult(msg.err)
+	}
 	if msg.err != nil {
-		restoreInjectedCmd := c.restoreInjectedInputsIntoComposer()
-		c.restoreQueuedMessagesIntoInput()
-		if isRuntimeOperationInterrupted(msg.err) {
-			m.activity = uiActivityInterrupted
-			m.logf("step.interrupted")
+		if notAccepted {
+			restoreInjectedCmd := c.restoreInjectedInputsIntoComposer()
+			if m.turnQueueHook != nil {
+				m.turnQueueHook.OnTurnQueueAborted()
+			}
+			c.restoreSubmittedTextIntoInput(msg.submittedText)
+			c.restoreQueuedMessagesIntoInput()
+			detailErr := runtimeattach.FormatSubmissionError(msg.err)
+			m.activity = uiActivityError
+			appendCmd := m.appendLocalEntryWithNoticeID(operatorErrorFeedbackRole, detailErr, "")
+			m.logf("compaction.error err=%q", detailErr)
 			m.layout().syncViewport()
-			return m, tea.Batch(restoreInjectedCmd, m.interruptedStatusNoticeCmd())
+			return m, tea.Batch(restoreInjectedCmd, appendCmd)
 		}
 		detailErr := runtimeattach.FormatSubmissionError(msg.err)
 		m.activity = uiActivityError
 		appendCmd := m.appendLocalEntryWithNoticeID(operatorErrorFeedbackRole, detailErr, "")
 		m.logf("compaction.error err=%q", detailErr)
-		m.layout().syncViewport()
-		return m, tea.Batch(restoreInjectedCmd, appendCmd)
+		next, advanceCmd := c.advanceAfterAcceptedCompaction(compactionOrigin)
+		return next, tea.Batch(appendCmd, advanceCmd)
 	}
 
-	if !serverActiveBeforeCompletion {
-		m.activity = uiActivityIdle
-	}
 	m.logf("compaction.done")
+	return c.advanceAfterAcceptedCompaction(compactionOrigin)
+}
+
+func (c uiInputController) advanceAfterAcceptedCompaction(origin uiCompactionOrigin) (tea.Model, tea.Cmd) {
+	m := c.model
 	if len(m.queued) > 0 {
-		c.notifyUserCompactionCompleted(compactionOrigin, false)
+		c.notifyUserCompactionCompleted(origin, false)
+		if origin != uiCompactionOriginQueued {
+			m.layout().syncViewport()
+			return m, nil
+		}
 		next, cmd := c.flushQueuedInputs(queueDrainAuto)
 		c.notifyTurnQueueDrainedIfIdle()
 		return next, cmd
 	}
 	if m.injectedQueueBlocksDrain() || m.hasEnqueuedInjectedRuntimeWork() {
-		c.notifyUserCompactionCompleted(compactionOrigin, false)
+		c.notifyUserCompactionCompleted(origin, false)
 		m.layout().syncViewport()
 		return m, nil
 	}
-	c.notifyUserCompactionCompleted(compactionOrigin, true)
+	c.notifyUserCompactionCompleted(origin, true)
 	m.layout().syncViewport()
 	return m, nil
 }

--- a/cli/app/ui_input_submission.go
+++ b/cli/app/ui_input_submission.go
@@ -210,7 +210,6 @@ func (c uiInputController) compactCmd(submittedText, args string, origin uiCompa
 		if client == nil {
 			return compactDoneMsg{
 				submittedText: submittedText,
-				guidance:      args,
 				origin:        origin,
 				err: serverapi.NewRuntimeCommandNotAcceptedError(
 					errors.New("runtime engine is not configured"),
@@ -220,7 +219,6 @@ func (c uiInputController) compactCmd(submittedText, args string, origin uiCompa
 		err := client.CompactRuntime(context.Background(), clientui.RuntimeCompactRequest{Args: args})
 		return compactDoneMsg{
 			submittedText: submittedText,
-			guidance:      args,
 			origin:        origin,
 			invoked:       true,
 			err:           err,

--- a/cli/app/ui_messages.go
+++ b/cli/app/ui_messages.go
@@ -119,7 +119,11 @@ type injectedQueueDiscardDoneMsg struct {
 }
 
 type compactDoneMsg struct {
-	err error
+	submittedText string
+	guidance      string
+	origin        uiCompactionOrigin
+	invoked       bool
+	err           error
 }
 
 type activeSubmitOrigin uint8

--- a/cli/app/ui_messages.go
+++ b/cli/app/ui_messages.go
@@ -120,7 +120,6 @@ type injectedQueueDiscardDoneMsg struct {
 
 type compactDoneMsg struct {
 	submittedText string
-	guidance      string
 	origin        uiCompactionOrigin
 	invoked       bool
 	err           error

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -139,9 +139,6 @@ func runtimeControlCallNoResult(c *sessionRuntimeClient, call func(ctx context.C
 
 func retryRuntimeUnavailableCall[T any](ctx context.Context, recoverRuntimeConnection func(context.Context, error, bool) error, appendRecoveryWarning bool, call func() (T, error)) (T, error) {
 	value, err := call()
-	if errors.Is(err, serverapi.ErrRuntimeCommandNotAccepted) {
-		return value, err
-	}
 	if !errors.Is(err, serverapi.ErrRuntimeUnavailable) {
 		return value, err
 	}

--- a/cli/app/ui_runtime_client.go
+++ b/cli/app/ui_runtime_client.go
@@ -139,6 +139,9 @@ func runtimeControlCallNoResult(c *sessionRuntimeClient, call func(ctx context.C
 
 func retryRuntimeUnavailableCall[T any](ctx context.Context, recoverRuntimeConnection func(context.Context, error, bool) error, appendRecoveryWarning bool, call func() (T, error)) (T, error) {
 	value, err := call()
+	if errors.Is(err, serverapi.ErrRuntimeCommandNotAccepted) {
+		return value, err
+	}
 	if !errors.Is(err, serverapi.ErrRuntimeUnavailable) {
 		return value, err
 	}

--- a/cli/app/ui_runtime_client_control.go
+++ b/cli/app/ui_runtime_client_control.go
@@ -6,6 +6,8 @@ import (
 
 	"core/shared/clientui"
 	"core/shared/serverapi"
+
+	"github.com/google/uuid"
 )
 
 func (c *sessionRuntimeClient) sessionRuntimeBoundary() {}
@@ -240,9 +242,7 @@ func (c *sessionRuntimeClient) CompactRuntime(ctx context.Context, req clientui.
 	if err := req.Validate(); err != nil {
 		return err
 	}
-	return runtimeRequestCallNoResult(ctx, c, func(ctx context.Context, requestID string) error {
-		return c.controls.CompactContext(ctx, serverapi.RuntimeCompactContextRequest{ClientRequestID: requestID, SessionID: c.sessionID, Args: req.Args})
-	})
+	return c.controls.CompactContext(ctx, serverapi.RuntimeCompactContextRequest{ClientRequestID: uuid.NewString(), SessionID: c.sessionID, Args: req.Args})
 }
 
 func (c *sessionRuntimeClient) Interrupt() error {

--- a/cli/app/ui_runtime_client_part2_test.go
+++ b/cli/app/ui_runtime_client_part2_test.go
@@ -41,27 +41,29 @@ func TestRuntimeClientMainViewDoesNotRefreshCachedSnapshotBehindUIBack(t *testin
 }
 
 type reconnectRetryRuntimeControlClient struct {
-	mu               sync.Mutex
-	firstSubmitErr   error
-	firstRecordErr   error
-	appendErr        error
-	compactErr       error
-	compactCalls     int
-	showGoalErr      error
-	showGoalCalls    int
-	submitCalls      int
-	recordCalls      int
-	submitRequestID  []string
-	recordRequestID  []string
-	localEntries     []serverapi.RuntimeAppendCommittedEntryRequest
-	showGoalResp     serverapi.RuntimeGoalShowResponse
-	setGoalResp      serverapi.RuntimeGoalShowResponse
-	pauseGoalResp    serverapi.RuntimeGoalShowResponse
-	resumeGoalResp   serverapi.RuntimeGoalShowResponse
-	completeGoalResp serverapi.RuntimeGoalShowResponse
-	clearGoalResp    serverapi.RuntimeGoalShowResponse
-	interruptResp    serverapi.RuntimeInterruptResponse
-	interruptReq     serverapi.RuntimeInterruptRequest
+	mu                  sync.Mutex
+	firstSubmitErr      error
+	firstRecordErr      error
+	appendErr           error
+	compactErr          error
+	compactCalls        int
+	compactContextErr   error
+	compactContextCalls int
+	showGoalErr         error
+	showGoalCalls       int
+	submitCalls         int
+	recordCalls         int
+	submitRequestID     []string
+	recordRequestID     []string
+	localEntries        []serverapi.RuntimeAppendCommittedEntryRequest
+	showGoalResp        serverapi.RuntimeGoalShowResponse
+	setGoalResp         serverapi.RuntimeGoalShowResponse
+	pauseGoalResp       serverapi.RuntimeGoalShowResponse
+	resumeGoalResp      serverapi.RuntimeGoalShowResponse
+	completeGoalResp    serverapi.RuntimeGoalShowResponse
+	clearGoalResp       serverapi.RuntimeGoalShowResponse
+	interruptResp       serverapi.RuntimeInterruptResponse
+	interruptReq        serverapi.RuntimeInterruptRequest
 }
 
 func (c *reconnectRetryRuntimeControlClient) submitRequestIDs() []string {
@@ -139,7 +141,10 @@ func (c *reconnectRetryRuntimeControlClient) SubmitUserShellCommand(context.Cont
 }
 
 func (c *reconnectRetryRuntimeControlClient) CompactContext(context.Context, serverapi.RuntimeCompactContextRequest) error {
-	return nil
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.compactContextCalls++
+	return c.compactContextErr
 }
 
 func (c *reconnectRetryRuntimeControlClient) Interrupt(_ context.Context, req serverapi.RuntimeInterruptRequest) (serverapi.RuntimeInterruptResponse, error) {
@@ -457,6 +462,32 @@ func TestRuntimeClientSubmitUserMessageRecoversRuntimeUnavailableAndReusesReques
 	}
 	if got := controls.submitRequestIDs(); len(got) != 2 || got[0] == "" || got[0] != got[1] {
 		t.Fatalf("submit request ids = %+v, want same non-empty id across retry", got)
+	}
+}
+
+func TestRuntimeClientCompactNotAcceptedUnavailableDoesNotReactivateOrRetry(t *testing.T) {
+	joined := serverapi.NewRuntimeCommandNotAcceptedError(serverapi.ErrRuntimeUnavailable)
+	controls := &reconnectRetryRuntimeControlClient{compactContextErr: joined}
+	runtimeClient := newTestSessionRuntimeClientWithControls(controls)
+	reactivator := newRuntimeReactivator()
+	recoveryCalls := 0
+	reactivator.SetReactivateFunc(func(context.Context) error {
+		recoveryCalls++
+		return nil
+	})
+	runtimeClient.SetRuntimeReactivator(reactivator)
+
+	err := runtimeClient.CompactRuntime(context.Background(), clientui.RuntimeCompactRequest{})
+	if err != joined ||
+		!errors.Is(err, serverapi.ErrRuntimeCommandNotAccepted) ||
+		!errors.Is(err, serverapi.ErrRuntimeUnavailable) {
+		t.Fatalf("CompactRuntime error = %v, want unchanged joined not-accepted/unavailable error", err)
+	}
+	if controls.compactContextCalls != 1 {
+		t.Fatalf("compact control calls = %d, want 1", controls.compactContextCalls)
+	}
+	if recoveryCalls != 0 {
+		t.Fatalf("runtime reactivation calls = %d, want 0", recoveryCalls)
 	}
 }
 

--- a/cli/app/ui_runtime_client_part2_test.go
+++ b/cli/app/ui_runtime_client_part2_test.go
@@ -432,8 +432,8 @@ func assertRuntimeGoalConversionDropsAPITimestamps(t *testing.T, got *clientui.R
 	}
 }
 
-func TestRuntimeClientSubmitUserMessageRecoversRuntimeUnavailableAndReusesRequestID(t *testing.T) {
-	controls := &reconnectRetryRuntimeControlClient{firstSubmitErr: serverapi.ErrRuntimeUnavailable}
+func TestRuntimeClientSubmitUserMessageRecoversNotAcceptedRuntimeUnavailableAndReusesRequestID(t *testing.T) {
+	controls := &reconnectRetryRuntimeControlClient{firstSubmitErr: serverapi.NewRuntimeCommandNotAcceptedError(serverapi.ErrRuntimeUnavailable)}
 	runtimeClient := newTestSessionRuntimeClientWithControls(controls)
 	reactivator := newRuntimeReactivator()
 	recoveryCalls := 0
@@ -483,11 +483,8 @@ func TestRuntimeClientCompactNotAcceptedUnavailableDoesNotReactivateOrRetry(t *t
 		!errors.Is(err, serverapi.ErrRuntimeUnavailable) {
 		t.Fatalf("CompactRuntime error = %v, want unchanged joined not-accepted/unavailable error", err)
 	}
-	if controls.compactContextCalls != 1 {
-		t.Fatalf("compact control calls = %d, want 1", controls.compactContextCalls)
-	}
-	if recoveryCalls != 0 {
-		t.Fatalf("runtime reactivation calls = %d, want 0", recoveryCalls)
+	if controls.compactContextCalls != 1 || recoveryCalls != 0 {
+		t.Fatalf("compact calls = %d and reactivation calls = %d, want 1/0", controls.compactContextCalls, recoveryCalls)
 	}
 }
 

--- a/cli/app/ui_runtime_control.go
+++ b/cli/app/ui_runtime_control.go
@@ -157,20 +157,6 @@ func (m *uiModel) submitRuntimeShell(ctx context.Context, req clientui.RuntimeSh
 	return nil
 }
 
-func (m *uiModel) compactRuntimeContext(ctx context.Context, args string) error {
-	return m.compactRuntimeInput(ctx, clientui.RuntimeCompactRequest{Args: args})
-}
-
-func (m *uiModel) compactRuntimeInput(ctx context.Context, req clientui.RuntimeCompactRequest) error {
-	m.checkTUIBlockingOperation("runtime control mutation", "compact")
-	if client := m.runtimeClient(); client != nil {
-		err := client.CompactRuntime(ctx, req)
-		m.observeRuntimeRequestResult(err)
-		return err
-	}
-	return nil
-}
-
 func (m *uiModel) interruptRuntime() error {
 	m.checkTUIBlockingOperation("runtime control mutation", "interrupt")
 	candidate, err := executeRuntimeInterrupt(runtimeInterruptRequestFromModel(m))

--- a/cli/app/ui_runtime_control_test.go
+++ b/cli/app/ui_runtime_control_test.go
@@ -12,6 +12,7 @@ import (
 	"core/server/llm"
 	"core/shared/clientui"
 	"core/shared/runtimeids"
+	"core/shared/runtimeinput"
 	"core/shared/serverapi"
 	"core/shared/textutil"
 )
@@ -37,6 +38,7 @@ type runtimeControlFakeClient struct {
 	appendedRole          string
 	appendedText          string
 	submitText            string
+	submitInput           runtimeinput.Input
 	submitCalls           int
 	submitResult          string
 	interruptCalls        int
@@ -46,6 +48,9 @@ type runtimeControlFakeClient struct {
 	discardQueuedResult   bool
 	recordedPromptHistory string
 	refreshMainViewCalls  int
+	compactCalls          int
+	compactArgs           string
+	compactErr            error
 	err                   error
 	appendErr             error
 	submitErr             error
@@ -189,6 +194,7 @@ func (f *runtimeControlFakeClient) submitUserMessage(_ context.Context, text str
 }
 func (f *runtimeControlFakeClient) SubmitRuntimeInput(ctx context.Context, req clientui.RuntimeSubmitRequest) (clientui.UserTurnSubmission, error) {
 	f.submitCalls++
+	f.submitInput = req.Input
 	text := runtimeSubmitInputText(req)
 	submission, err := f.submitUserMessage(ctx, text)
 	if err == nil && strings.TrimSpace(f.submitQueuedID) != "" {
@@ -207,7 +213,11 @@ func (f *runtimeControlFakeClient) RunUserShell(ctx context.Context, req clientu
 	return f.submitUserShellCommand(ctx, req.Command)
 }
 func (f *runtimeControlFakeClient) compactContext(_ context.Context, args string) error {
-	_ = args
+	f.compactCalls++
+	f.compactArgs = args
+	if f.compactErr != nil {
+		return f.compactErr
+	}
 	return f.err
 }
 func (f *runtimeControlFakeClient) CompactRuntime(ctx context.Context, req clientui.RuntimeCompactRequest) error {

--- a/cli/app/ui_state.go
+++ b/cli/app/ui_state.go
@@ -68,10 +68,10 @@ type uiInputFeatureState struct {
 	// UI-side post-turn input queue. It may contain slash commands, shell
 	// commands, and other client-only actions; server queues only runtime
 	// injected user work.
-	queued           []queuedInputItem
-	compactionOrigin uiCompactionOrigin
-	submitToken      uint64
-	activeSubmit     activeSubmitState
+	queued                      []queuedInputItem
+	postTurnCompactionsInFlight uint
+	submitToken                 uint64
+	activeSubmit                activeSubmitState
 
 	injectedQueue               []injectedRuntimeQueueItem
 	injectedQueueToken          uint64

--- a/cli/tui/ongoing/error_notice_test.go
+++ b/cli/tui/ongoing/error_notice_test.go
@@ -1,0 +1,98 @@
+package ongoing
+
+import (
+	"strings"
+	"testing"
+
+	"core/cli/tui/transcriptrender"
+	"core/shared/clientui"
+	"core/shared/transcript"
+
+	xansi "github.com/charmbracelet/x/ansi"
+)
+
+func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
+	diagnosticDetail := "runtime diagnostic alpha beta gamma\nruntime diagnostic second line"
+	legacyText := "legacy error alpha beta gamma\nlegacy error second line"
+	misleadingCompact := "wrong compact source"
+	misleadingCondensed := "wrong condensed source"
+	messageType := clientui.TranscriptMessageErrorFeedback
+
+	tests := []struct {
+		name       string
+		visibility transcript.EntryVisibility
+		notice     *clientui.TranscriptNoticeRow
+		source     string
+		wantMode   transcriptrender.Mode
+	}{
+		{
+			name:       "runtime diagnostic ongoing",
+			visibility: transcript.EntryVisibilityOngoing,
+			notice: &clientui.TranscriptNoticeRow{
+				Reason:        clientui.TranscriptNoticeRuntimeDiagnostic,
+				Severity:      clientui.TranscriptNoticeError,
+				CompactLabel:  &misleadingCompact,
+				CondensedText: &misleadingCondensed,
+				Diagnostic: &clientui.TranscriptDiagnostic{
+					Code:   clientui.TranscriptDiagnosticCode(transcript.EntryRoleDeveloperErrorFeedback),
+					Detail: diagnosticDetail,
+				},
+			},
+			source:   diagnosticDetail,
+			wantMode: transcriptrender.ModeOngoing,
+		},
+		{
+			name:       "legacy error ongoing collapsed",
+			visibility: transcript.EntryVisibilityOngoingCollapsed,
+			notice: &clientui.TranscriptNoticeRow{
+				Reason:        clientui.TranscriptNoticeLegacyUntypedNotice,
+				Severity:      clientui.TranscriptNoticeError,
+				MessageType:   &messageType,
+				LegacyText:    &legacyText,
+				CompactLabel:  &misleadingCompact,
+				CondensedText: &misleadingCondensed,
+			},
+			source:   legacyText,
+			wantMode: transcriptrender.ModeOngoingCollapsed,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			row := clientui.TranscriptCommittedRow{
+				Visibility: test.visibility,
+				Integrity:  transcript.RowIntegrityValid,
+				Kind:       clientui.TranscriptRowNotice,
+				Notice:     test.notice,
+			}
+			if err := test.notice.Validate(); err != nil {
+				t.Fatalf("notice is invalid: %v", err)
+			}
+			if got := ongoingRenderMode(row); got != test.wantMode {
+				t.Fatalf("normal ongoing render mode = %d, want %d", got, test.wantMode)
+			}
+
+			rendered := NewSurface().renderCommittedRow(row, 26, "dark")
+			var visible strings.Builder
+			for _, line := range rendered {
+				plain := xansi.Strip(line)
+				if strings.Contains(plain, "…") {
+					t.Fatalf("ongoing error line was ellipsized: %q", plain)
+				}
+				if strings.HasPrefix(plain, "! ") {
+					plain = strings.TrimPrefix(plain, "! ")
+				} else {
+					plain = strings.TrimPrefix(
+						plain,
+						strings.Repeat(" ", transcriptrender.RolePrefixWidth(transcriptrender.StyleRoleError)),
+					)
+				}
+				visible.WriteString(plain)
+			}
+			want := strings.ReplaceAll(transcriptrender.TerminalSafePlainText(test.source), "\n", "")
+			if got := visible.String(); got != want {
+				t.Fatalf("ongoing error content = %q, want complete source %q", got, want)
+			}
+		})
+	}
+}

--- a/cli/tui/ongoing/error_notice_test.go
+++ b/cli/tui/ongoing/error_notice_test.go
@@ -10,10 +10,8 @@ import (
 )
 
 func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
-	diagnosticLines := []string{"runtime diagnostic alpha beta gamma", "runtime diagnostic second line"}
-	diagnosticDetail := diagnosticLines[0] + "\n" + diagnosticLines[1]
-	legacyLines := []string{"legacy error alpha beta gamma", "legacy error second line"}
-	legacyText := legacyLines[0] + "\n" + legacyLines[1]
+	diagnosticDetail := "runtime diagnostic \x1b[31mred\tgamma\nruntime diagnostic second \x00line"
+	legacyText := "legacy error alpha\tbeta\nlegacy error second \x07line"
 	misleadingCompact := "wrong compact source"
 	misleadingCondensed := "wrong condensed source"
 	messageType := clientui.TranscriptMessageErrorFeedback
@@ -22,7 +20,6 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 		name       string
 		visibility transcript.EntryVisibility
 		notice     *clientui.TranscriptNoticeRow
-		source     []string
 		wantMode   transcriptrender.Mode
 	}{
 		{
@@ -38,7 +35,6 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 					Detail: diagnosticDetail,
 				},
 			},
-			source:   []string{"! " + diagnosticLines[0], "  " + diagnosticLines[1]},
 			wantMode: transcriptrender.ModeOngoing,
 		},
 		{
@@ -52,7 +48,6 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 				CompactLabel:  &misleadingCompact,
 				CondensedText: &misleadingCondensed,
 			},
-			source:   []string{"! " + legacyLines[0], "  " + legacyLines[1]},
 			wantMode: transcriptrender.ModeOngoingCollapsed,
 		},
 	}
@@ -74,8 +69,8 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 
 			const width = 80
 			structured := transcriptrender.RenderCommittedRow(row, width, "dark", test.wantMode)
-			if got := transcriptrender.PlainLines(structured.Lines); !reflect.DeepEqual(got, test.source) {
-				t.Fatalf("structured ongoing error lines = %#v, want %#v", got, test.source)
+			if got := len(structured.Lines); got != 2 {
+				t.Fatalf("structured ongoing error lines = %d, want both authored lines", got)
 			}
 
 			wantEncoded := encodeTranscriptLines(structured.Lines, "dark")

--- a/cli/tui/ongoing/error_notice_test.go
+++ b/cli/tui/ongoing/error_notice_test.go
@@ -1,19 +1,19 @@
 package ongoing
 
 import (
-	"strings"
+	"reflect"
 	"testing"
 
 	"core/cli/tui/transcriptrender"
 	"core/shared/clientui"
 	"core/shared/transcript"
-
-	xansi "github.com/charmbracelet/x/ansi"
 )
 
 func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
-	diagnosticDetail := "runtime diagnostic alpha beta gamma\nruntime diagnostic second line"
-	legacyText := "legacy error alpha beta gamma\nlegacy error second line"
+	diagnosticLines := []string{"runtime diagnostic alpha beta gamma", "runtime diagnostic second line"}
+	diagnosticDetail := diagnosticLines[0] + "\n" + diagnosticLines[1]
+	legacyLines := []string{"legacy error alpha beta gamma", "legacy error second line"}
+	legacyText := legacyLines[0] + "\n" + legacyLines[1]
 	misleadingCompact := "wrong compact source"
 	misleadingCondensed := "wrong condensed source"
 	messageType := clientui.TranscriptMessageErrorFeedback
@@ -22,7 +22,7 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 		name       string
 		visibility transcript.EntryVisibility
 		notice     *clientui.TranscriptNoticeRow
-		source     string
+		source     []string
 		wantMode   transcriptrender.Mode
 	}{
 		{
@@ -38,7 +38,7 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 					Detail: diagnosticDetail,
 				},
 			},
-			source:   diagnosticDetail,
+			source:   diagnosticLines,
 			wantMode: transcriptrender.ModeOngoing,
 		},
 		{
@@ -52,7 +52,7 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 				CompactLabel:  &misleadingCompact,
 				CondensedText: &misleadingCondensed,
 			},
-			source:   legacyText,
+			source:   legacyLines,
 			wantMode: transcriptrender.ModeOngoingCollapsed,
 		},
 	}
@@ -72,27 +72,48 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 				t.Fatalf("normal ongoing render mode = %d, want %d", got, test.wantMode)
 			}
 
-			rendered := NewSurface().renderCommittedRow(row, 26, "dark")
-			var visible strings.Builder
-			for _, line := range rendered {
-				plain := xansi.Strip(line)
-				if strings.Contains(plain, "…") {
-					t.Fatalf("ongoing error line was ellipsized: %q", plain)
-				}
-				if strings.HasPrefix(plain, "! ") {
-					plain = strings.TrimPrefix(plain, "! ")
-				} else {
-					plain = strings.TrimPrefix(
-						plain,
-						strings.Repeat(" ", transcriptrender.RolePrefixWidth(transcriptrender.StyleRoleError)),
-					)
-				}
-				visible.WriteString(plain)
+			const width = 80
+			structured := transcriptrender.RenderCommittedRow(row, width, "dark", test.wantMode)
+			if len(structured.Lines) != len(test.source) {
+				t.Fatalf("structured ongoing rows = %d, want %d", len(structured.Lines), len(test.source))
 			}
-			want := strings.ReplaceAll(transcriptrender.TerminalSafePlainText(test.source), "\n", "")
-			if got := visible.String(); got != want {
-				t.Fatalf("ongoing error content = %q, want complete source %q", got, want)
+			for index, line := range structured.Lines {
+				if got := ongoingErrorLineContent(t, line, index); got != test.source[index] {
+					t.Fatalf("structured ongoing error line %d = %q, want %q", index, got, test.source[index])
+				}
+			}
+
+			wantEncoded := encodeTranscriptLines(structured.Lines, "dark")
+			if got := NewSurface().renderCommittedRow(row, width, "dark"); !reflect.DeepEqual(got, wantEncoded) {
+				t.Fatalf("ongoing surface changed structured renderer output: got=%q want=%q", got, wantEncoded)
 			}
 		})
 	}
+}
+
+func ongoingErrorLineContent(t *testing.T, line transcriptrender.Line, index int) string {
+	t.Helper()
+	start := 0
+	if line.LeadingSymbol != nil {
+		if index != 0 ||
+			line.LeadingSymbol.Style.Kind != transcriptrender.SpanStyleSemantic ||
+			line.LeadingSymbol.Style.SemanticRole != transcriptrender.StyleRoleError {
+			t.Fatalf("ongoing error line %d has invalid leading symbol: %+v", index, line.LeadingSymbol)
+		}
+		if len(line.Spans) == 0 ||
+			line.Spans[0].Style.Kind != transcriptrender.SpanStyleSemantic ||
+			line.Spans[0].Style.SemanticRole != transcriptrender.StyleRoleError ||
+			line.Spans[0].Text != " " {
+			t.Fatalf("ongoing error line %d has invalid structured symbol gap: %+v", index, line.Spans)
+		}
+		start = 1
+	}
+	content := ""
+	for _, span := range line.Spans[start:] {
+		if span.Style.Kind == transcriptrender.SpanStyleSemantic &&
+			span.Style.SemanticRole == transcriptrender.StyleRoleError {
+			content += span.Text
+		}
+	}
+	return content
 }

--- a/cli/tui/ongoing/error_notice_test.go
+++ b/cli/tui/ongoing/error_notice_test.go
@@ -38,7 +38,7 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 					Detail: diagnosticDetail,
 				},
 			},
-			source:   diagnosticLines,
+			source:   []string{"! " + diagnosticLines[0], "  " + diagnosticLines[1]},
 			wantMode: transcriptrender.ModeOngoing,
 		},
 		{
@@ -52,7 +52,7 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 				CompactLabel:  &misleadingCompact,
 				CondensedText: &misleadingCondensed,
 			},
-			source:   legacyLines,
+			source:   []string{"! " + legacyLines[0], "  " + legacyLines[1]},
 			wantMode: transcriptrender.ModeOngoingCollapsed,
 		},
 	}
@@ -74,13 +74,8 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 
 			const width = 80
 			structured := transcriptrender.RenderCommittedRow(row, width, "dark", test.wantMode)
-			if len(structured.Lines) != len(test.source) {
-				t.Fatalf("structured ongoing rows = %d, want %d", len(structured.Lines), len(test.source))
-			}
-			for index, line := range structured.Lines {
-				if got := ongoingErrorLineContent(t, line, index); got != test.source[index] {
-					t.Fatalf("structured ongoing error line %d = %q, want %q", index, got, test.source[index])
-				}
+			if got := transcriptrender.PlainLines(structured.Lines); !reflect.DeepEqual(got, test.source) {
+				t.Fatalf("structured ongoing error lines = %#v, want %#v", got, test.source)
 			}
 
 			wantEncoded := encodeTranscriptLines(structured.Lines, "dark")
@@ -89,31 +84,4 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 			}
 		})
 	}
-}
-
-func ongoingErrorLineContent(t *testing.T, line transcriptrender.Line, index int) string {
-	t.Helper()
-	start := 0
-	if line.LeadingSymbol != nil {
-		if index != 0 ||
-			line.LeadingSymbol.Style.Kind != transcriptrender.SpanStyleSemantic ||
-			line.LeadingSymbol.Style.SemanticRole != transcriptrender.StyleRoleError {
-			t.Fatalf("ongoing error line %d has invalid leading symbol: %+v", index, line.LeadingSymbol)
-		}
-		if len(line.Spans) == 0 ||
-			line.Spans[0].Style.Kind != transcriptrender.SpanStyleSemantic ||
-			line.Spans[0].Style.SemanticRole != transcriptrender.StyleRoleError ||
-			line.Spans[0].Text != " " {
-			t.Fatalf("ongoing error line %d has invalid structured symbol gap: %+v", index, line.Spans)
-		}
-		start = 1
-	}
-	content := ""
-	for _, span := range line.Spans[start:] {
-		if span.Style.Kind == transcriptrender.SpanStyleSemantic &&
-			span.Style.SemanticRole == transcriptrender.StyleRoleError {
-			content += span.Text
-		}
-	}
-	return content
 }

--- a/cli/tui/ongoing/error_notice_test.go
+++ b/cli/tui/ongoing/error_notice_test.go
@@ -2,6 +2,7 @@ package ongoing
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"core/cli/tui/transcriptrender"
@@ -10,17 +11,17 @@ import (
 )
 
 func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
-	diagnosticDetail := "runtime diagnostic \x1b[31mred\tgamma\nruntime diagnostic second \x00line"
-	legacyText := "legacy error alpha\tbeta\nlegacy error second \x07line"
+	diagnosticDetail := "runtime diagnostic first line\nruntime diagnostic second line"
+	legacyText := "legacy error first line\nlegacy error second line"
 	misleadingCompact := "wrong compact source"
 	misleadingCondensed := "wrong condensed source"
 	messageType := clientui.TranscriptMessageErrorFeedback
-
 	tests := []struct {
 		name       string
 		visibility transcript.EntryVisibility
 		notice     *clientui.TranscriptNoticeRow
 		wantMode   transcriptrender.Mode
+		wantText   string
 	}{
 		{
 			name:       "runtime diagnostic ongoing",
@@ -36,6 +37,7 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 				},
 			},
 			wantMode: transcriptrender.ModeOngoing,
+			wantText: diagnosticDetail,
 		},
 		{
 			name:       "legacy error ongoing collapsed",
@@ -49,33 +51,31 @@ func TestErrorNoticesRenderCompletelyThroughNormalOngoingModes(t *testing.T) {
 				CondensedText: &misleadingCondensed,
 			},
 			wantMode: transcriptrender.ModeOngoingCollapsed,
+			wantText: legacyText,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			row := clientui.TranscriptCommittedRow{
-				Visibility: test.visibility,
-				Integrity:  transcript.RowIntegrityValid,
-				Kind:       clientui.TranscriptRowNotice,
-				Notice:     test.notice,
-			}
-			if err := test.notice.Validate(); err != nil {
-				t.Fatalf("notice is invalid: %v", err)
-			}
+			row := clientui.TranscriptCommittedRow{Visibility: test.visibility, Kind: clientui.TranscriptRowNotice, Notice: test.notice}
 			if got := ongoingRenderMode(row); got != test.wantMode {
 				t.Fatalf("normal ongoing render mode = %d, want %d", got, test.wantMode)
 			}
-
-			const width = 80
-			structured := transcriptrender.RenderCommittedRow(row, width, "dark", test.wantMode)
-			if got := len(structured.Lines); got != 2 {
-				t.Fatalf("structured ongoing error lines = %d, want both authored lines", got)
+			structured := transcriptrender.RenderCommittedRow(row, 80, "dark", test.wantMode)
+			gotText := make([]string, len(structured.Lines))
+			for index, line := range structured.Lines {
+				for _, span := range line.Spans {
+					if role, ok := span.Style.Role(); ok && role == transcriptrender.StyleRoleError {
+						gotText[index] += span.Text
+					}
+				}
+				gotText[index] = strings.TrimSpace(gotText[index])
 			}
-
-			wantEncoded := encodeTranscriptLines(structured.Lines, "dark")
-			if got := NewSurface().renderCommittedRow(row, width, "dark"); !reflect.DeepEqual(got, wantEncoded) {
-				t.Fatalf("ongoing surface changed structured renderer output: got=%q want=%q", got, wantEncoded)
+			if want := strings.Split(test.wantText, "\n"); !reflect.DeepEqual(gotText, want) {
+				t.Fatalf("structured ongoing error payload = %#v, want %#v", gotText, want)
+			}
+			if got, want := NewSurface().renderCommittedRow(row, 80, "dark"), encodeTranscriptLines(structured.Lines, "dark"); !reflect.DeepEqual(got, want) {
+				t.Fatalf("ongoing surface changed structured renderer output: got=%q want=%q", got, want)
 			}
 		})
 	}

--- a/cli/tui/transcriptrender/error_notice_test.go
+++ b/cli/tui/transcriptrender/error_notice_test.go
@@ -204,9 +204,9 @@ func TestErrorNoticeReasonSelectsItsTypedContentSource(t *testing.T) {
 	}
 }
 
-func TestMetadataOnlyLegacyErrorUsesCompleteCondensedText(t *testing.T) {
+func TestMetadataOnlyLegacyErrorWithoutTypedFormatterFailsValidation(t *testing.T) {
 	messageType := clientui.TranscriptMessageErrorFeedback
-	condensed := "complete metadata error content"
+	condensed := "condensed preview is not error content"
 	compact := "compact label is not error content"
 	sourcePath := "/preview/source/path"
 	notice := &clientui.TranscriptNoticeRow{
@@ -217,11 +217,9 @@ func TestMetadataOnlyLegacyErrorUsesCompleteCondensedText(t *testing.T) {
 		CompactLabel:  &compact,
 		SourcePath:    &sourcePath,
 	}
-	if err := notice.Validate(); err != nil {
-		t.Fatalf("metadata-only legacy error is invalid: %v", err)
+	if err := notice.Validate(); err == nil {
+		t.Fatal("metadata-only legacy error without a typed formatter passed validation")
 	}
-	rendered := RenderCommittedRow(errorNoticeRow(notice), 120, "dark", ModeOngoingCollapsed)
-	assertCompleteErrorContent(t, rendered, []string{condensed})
 }
 
 func TestNonErrorNoticeAndToolRowsRetainCompactOneLineLayout(t *testing.T) {

--- a/cli/tui/transcriptrender/error_notice_test.go
+++ b/cli/tui/transcriptrender/error_notice_test.go
@@ -1,6 +1,7 @@
 package transcriptrender
 
 import (
+	"reflect"
 	"testing"
 
 	"core/shared/clientui"
@@ -22,7 +23,7 @@ func TestErrorNoticeClassifiesAsError(t *testing.T) {
 }
 
 func TestRuntimeDiagnosticErrorUsesCompleteTypedDetailInEveryMode(t *testing.T) {
-	detail := "diagnostic alpha beta gamma \x1b[31mred\nsecond diagnostic line remains complete"
+	detail := "diagnostic alpha beta gamma red\nsecond diagnostic line remains complete"
 	misleadingCompact := "wrong compact source"
 	misleadingCondensed := "wrong condensed source"
 	row := errorNoticeRow(&clientui.TranscriptNoticeRow{
@@ -41,8 +42,16 @@ func TestRuntimeDiagnosticErrorUsesCompleteTypedDetailInEveryMode(t *testing.T) 
 
 	for _, mode := range allTranscriptModes() {
 		t.Run(transcriptModeName(mode), func(t *testing.T) {
-			rendered := RenderCommittedRow(row, 24, "dark", mode)
-			assertCompleteErrorContent(t, rendered, detail, 24)
+			rendered := RenderCommittedRow(row, 120, "dark", mode)
+			assertCompleteErrorContent(
+				t,
+				rendered,
+				completeErrorLinesForMode(
+					mode,
+					"diagnostic alpha beta gamma red",
+					"second diagnostic line remains complete",
+				),
+			)
 		})
 	}
 }
@@ -66,8 +75,16 @@ func TestLegacyUntypedErrorUsesCompleteLegacyTextInEveryMode(t *testing.T) {
 
 	for _, mode := range allTranscriptModes() {
 		t.Run(transcriptModeName(mode), func(t *testing.T) {
-			rendered := RenderCommittedRow(row, 24, "dark", mode)
-			assertCompleteErrorContent(t, rendered, legacy, 24)
+			rendered := RenderCommittedRow(row, 120, "dark", mode)
+			assertCompleteErrorContent(
+				t,
+				rendered,
+				completeErrorLinesForMode(
+					mode,
+					"legacy alpha beta gamma",
+					"second legacy line remains complete",
+				),
+			)
 		})
 	}
 }
@@ -179,13 +196,13 @@ func TestErrorNoticeReasonSelectsItsTypedContentSource(t *testing.T) {
 			if err := test.notice.Validate(); err != nil {
 				t.Fatalf("notice is invalid: %v", err)
 			}
-			rendered := RenderCommittedRow(errorNoticeRow(test.notice), 32, "dark", ModeOngoingCollapsed)
-			assertCompleteErrorContent(t, rendered, test.want, 32)
+			rendered := RenderCommittedRow(errorNoticeRow(test.notice), 120, "dark", ModeOngoingCollapsed)
+			assertCompleteErrorContent(t, rendered, []string{"! " + test.want})
 		})
 	}
 }
 
-func TestMetadataOnlyLegacyErrorDoesNotUseCompactPreviewFields(t *testing.T) {
+func TestMetadataOnlyLegacyErrorWithoutTypedFormatterFailsFast(t *testing.T) {
 	messageType := clientui.TranscriptMessageErrorFeedback
 	condensed := "condensed preview is not error content"
 	compact := "compact label is not error content"
@@ -202,8 +219,12 @@ func TestMetadataOnlyLegacyErrorDoesNotUseCompactPreviewFields(t *testing.T) {
 		t.Fatalf("metadata-only legacy notice is invalid: %v", err)
 	}
 
-	rendered := RenderCommittedRow(errorNoticeRow(notice), 80, "dark", ModeOngoingCollapsed)
-	assertCompleteErrorContent(t, rendered, string(notice.Reason), 80)
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("metadata-only legacy error without a typed formatter did not fail fast")
+		}
+	}()
+	RenderCommittedRow(errorNoticeRow(notice), 80, "dark", ModeOngoingCollapsed)
 }
 
 func TestNonErrorNoticeAndToolRowsRetainCompactOneLineLayout(t *testing.T) {
@@ -271,36 +292,20 @@ func transcriptModeName(mode Mode) string {
 	}
 }
 
-func assertCompleteErrorContent(t *testing.T, rendered Row, source string, width int) {
+func assertCompleteErrorContent(t *testing.T, rendered Row, want []string) {
 	t.Helper()
-	want := wrapLines(TerminalSafePlainText(source), contentWidth(StyleRoleError, width))
-	if len(rendered.Lines) != len(want) {
-		t.Fatalf("rendered error lines = %d, want %d", len(rendered.Lines), len(want))
+	if got := PlainLines(rendered.Lines); !reflect.DeepEqual(got, want) {
+		t.Fatalf("rendered error lines = %#v, want %#v", got, want)
 	}
-	for index, line := range rendered.Lines {
-		start := 0
-		if line.LeadingSymbol != nil {
-			if index != 0 ||
-				line.LeadingSymbol.Style.Kind != SpanStyleSemantic ||
-				line.LeadingSymbol.Style.SemanticRole != StyleRoleError {
-				t.Fatalf("error line %d has invalid leading symbol: %+v", index, line.LeadingSymbol)
-			}
-			if len(line.Spans) == 0 ||
-				line.Spans[0].Style.Kind != SpanStyleSemantic ||
-				line.Spans[0].Style.SemanticRole != StyleRoleError ||
-				line.Spans[0].Text != " " {
-				t.Fatalf("error line %d has invalid structured symbol gap: %+v", index, line.Spans)
-			}
-			start = 1
-		}
-		content := ""
-		for _, span := range line.Spans[start:] {
-			if span.Style.Kind == SpanStyleSemantic && span.Style.SemanticRole == StyleRoleError {
-				content += span.Text
-			}
-		}
-		if content != want[index] {
-			t.Fatalf("rendered error line %d = %q, want %q", index, content, want[index])
-		}
+}
+
+func completeErrorLinesForMode(mode Mode, first, second string) []string {
+	switch mode {
+	case ModeOngoingStable:
+		return []string{"! " + first, second}
+	case ModeDetailCollapsed, ModeDetailExpanded:
+		return []string{"! " + first, "└ " + second}
+	default:
+		return []string{"! " + first, "  " + second}
 	}
 }

--- a/cli/tui/transcriptrender/error_notice_test.go
+++ b/cli/tui/transcriptrender/error_notice_test.go
@@ -1,6 +1,7 @@
 package transcriptrender
 
 import (
+	"strings"
 	"testing"
 
 	"core/shared/clientui"
@@ -18,5 +19,248 @@ func TestErrorNoticeClassifiesAsError(t *testing.T) {
 	}
 	if got := noticeStyleRole(row); got != StyleRoleError {
 		t.Fatalf("error notice role = %v, want %v", got, StyleRoleError)
+	}
+}
+
+func TestRuntimeDiagnosticErrorUsesCompleteTypedDetailInEveryMode(t *testing.T) {
+	detail := "diagnostic alpha beta gamma \x1b[31mred\nsecond diagnostic line remains complete"
+	misleadingCompact := "wrong compact source"
+	misleadingCondensed := "wrong condensed source"
+	row := errorNoticeRow(&clientui.TranscriptNoticeRow{
+		Reason:        clientui.TranscriptNoticeRuntimeDiagnostic,
+		Severity:      clientui.TranscriptNoticeError,
+		CompactLabel:  &misleadingCompact,
+		CondensedText: &misleadingCondensed,
+		Diagnostic: &clientui.TranscriptDiagnostic{
+			Code:   clientui.TranscriptDiagnosticCode(transcript.EntryRoleDeveloperErrorFeedback),
+			Detail: detail,
+		},
+	})
+	if err := row.Notice.Validate(); err != nil {
+		t.Fatalf("runtime diagnostic row is invalid: %v", err)
+	}
+
+	for _, mode := range allTranscriptModes() {
+		t.Run(transcriptModeName(mode), func(t *testing.T) {
+			rendered := RenderCommittedRow(row, 24, "dark", mode)
+			assertCompleteErrorContent(t, rendered, detail)
+		})
+	}
+}
+
+func TestLegacyUntypedErrorUsesCompleteLegacyTextInEveryMode(t *testing.T) {
+	legacy := "legacy alpha beta gamma\nsecond legacy line remains complete"
+	misleadingCompact := "wrong compact source"
+	misleadingCondensed := "wrong condensed source"
+	messageType := clientui.TranscriptMessageErrorFeedback
+	row := errorNoticeRow(&clientui.TranscriptNoticeRow{
+		Reason:        clientui.TranscriptNoticeLegacyUntypedNotice,
+		Severity:      clientui.TranscriptNoticeError,
+		MessageType:   &messageType,
+		LegacyText:    &legacy,
+		CompactLabel:  &misleadingCompact,
+		CondensedText: &misleadingCondensed,
+	})
+	if err := row.Notice.Validate(); err != nil {
+		t.Fatalf("legacy error row is invalid: %v", err)
+	}
+
+	for _, mode := range allTranscriptModes() {
+		t.Run(transcriptModeName(mode), func(t *testing.T) {
+			rendered := RenderCommittedRow(row, 24, "dark", mode)
+			assertCompleteErrorContent(t, rendered, legacy)
+		})
+	}
+}
+
+func TestErrorNoticeReasonSelectsItsTypedContentSource(t *testing.T) {
+	cacheWarning := &clientui.TranscriptCacheWarning{
+		Scope:      string(transcript.CacheWarningScopeConversation),
+		Reason:     string(transcript.CacheWarningReasonNonPostfix),
+		Visibility: transcript.EntryVisibilityOngoing,
+	}
+	compactionDetail := "typed compaction detail"
+	messageType := clientui.TranscriptMessageCompactionSummary
+	repair := &transcript.ToolOutputRepairNotice{
+		Kind:  transcript.ToolOutputRepairFreshResource,
+		Count: 2,
+	}
+	diagnosticDetail := "typed runtime diagnostic"
+	legacyText := "typed legacy text"
+	metadataText := "typed message metadata content"
+	metadataType := clientui.TranscriptMessageErrorFeedback
+
+	tests := []struct {
+		name   string
+		notice *clientui.TranscriptNoticeRow
+		want   string
+	}{
+		{
+			name: "cache warning",
+			notice: &clientui.TranscriptNoticeRow{
+				Reason:       clientui.TranscriptNoticeCacheWarning,
+				Severity:     clientui.TranscriptNoticeError,
+				CacheWarning: cacheWarning,
+			},
+			want: cacheWarningNoticeText(cacheWarning),
+		},
+		{
+			name: "compaction detail",
+			notice: &clientui.TranscriptNoticeRow{
+				Reason:      clientui.TranscriptNoticeCompaction,
+				Severity:    clientui.TranscriptNoticeError,
+				MessageType: &messageType,
+				Compaction:  &clientui.TranscriptCompactionNotice{Detail: &compactionDetail},
+			},
+			want: compactionDetail,
+		},
+		{
+			name: "compaction formatter",
+			notice: &clientui.TranscriptNoticeRow{
+				Reason:      clientui.TranscriptNoticeCompaction,
+				Severity:    clientui.TranscriptNoticeError,
+				MessageType: &messageType,
+				Compaction:  &clientui.TranscriptCompactionNotice{},
+			},
+			want: compactionNoticeText(nil),
+		},
+		{
+			name: "tool output repair",
+			notice: &clientui.TranscriptNoticeRow{
+				Reason:           clientui.TranscriptNoticeToolOutputRepair,
+				Severity:         clientui.TranscriptNoticeError,
+				ToolOutputRepair: repair,
+			},
+			want: toolOutputRepairNoticeText(repair),
+		},
+		{
+			name: "runtime diagnostic",
+			notice: &clientui.TranscriptNoticeRow{
+				Reason:   clientui.TranscriptNoticeRuntimeDiagnostic,
+				Severity: clientui.TranscriptNoticeError,
+				Diagnostic: &clientui.TranscriptDiagnostic{
+					Code:   clientui.TranscriptDiagnosticCode(transcript.EntryRoleDeveloperErrorFeedback),
+					Detail: diagnosticDetail,
+				},
+			},
+			want: diagnosticDetail,
+		},
+		{
+			name: "legacy text",
+			notice: &clientui.TranscriptNoticeRow{
+				Reason:     clientui.TranscriptNoticeLegacyUntypedNotice,
+				Severity:   clientui.TranscriptNoticeError,
+				LegacyText: &legacyText,
+			},
+			want: legacyText,
+		},
+		{
+			name: "typed message metadata",
+			notice: &clientui.TranscriptNoticeRow{
+				Reason:        clientui.TranscriptNoticeLegacyUntypedNotice,
+				Severity:      clientui.TranscriptNoticeError,
+				MessageType:   &metadataType,
+				CondensedText: &metadataText,
+			},
+			want: metadataText,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.notice.Validate(); err != nil {
+				t.Fatalf("notice is invalid: %v", err)
+			}
+			rendered := RenderCommittedRow(errorNoticeRow(test.notice), 32, "dark", ModeOngoingCollapsed)
+			assertCompleteErrorContent(t, rendered, test.want)
+		})
+	}
+}
+
+func TestNonErrorNoticeAndToolRowsRetainCompactOneLineLayout(t *testing.T) {
+	legacy := "ordinary notice first line\nordinary notice second line"
+	notice := &clientui.TranscriptNoticeRow{
+		Reason:     clientui.TranscriptNoticeLegacyUntypedNotice,
+		Severity:   clientui.TranscriptNoticeInfo,
+		LegacyText: &legacy,
+	}
+	rendered := RenderCommittedRow(errorNoticeRow(notice), 80, "dark", ModeOngoingCollapsed)
+	if got := len(rendered.Lines); got != 1 {
+		t.Fatalf("ordinary notice lines = %d, want compact single line", got)
+	}
+	if !strings.Contains(rendered.Lines[0].Plain(), "…") {
+		t.Fatal("ordinary multiline notice lost compact ellipsis")
+	}
+
+	tool := clientui.TranscriptCommittedRow{
+		Visibility: transcript.EntryVisibilityOngoingCollapsed,
+		Integrity:  transcript.RowIntegrityValid,
+		Kind:       clientui.TranscriptRowTool,
+		Tool: &clientui.TranscriptToolRow{
+			ToolName: "ordinary_tool",
+			Text:     "ordinary tool first line\nordinary tool second line",
+		},
+	}
+	rendered = RenderCommittedRow(tool, 80, "dark", ModeOngoingCollapsed)
+	if got := len(rendered.Lines); got != 1 {
+		t.Fatalf("ordinary tool lines = %d, want compact single line", got)
+	}
+}
+
+func errorNoticeRow(notice *clientui.TranscriptNoticeRow) clientui.TranscriptCommittedRow {
+	return clientui.TranscriptCommittedRow{
+		Visibility: transcript.EntryVisibilityOngoing,
+		Integrity:  transcript.RowIntegrityValid,
+		Kind:       clientui.TranscriptRowNotice,
+		Notice:     notice,
+	}
+}
+
+func allTranscriptModes() []Mode {
+	return []Mode{
+		ModeOngoing,
+		ModeOngoingCollapsed,
+		ModeDetailCollapsed,
+		ModeOngoingFull,
+		ModeOngoingStable,
+		ModeDetailExpanded,
+	}
+}
+
+func transcriptModeName(mode Mode) string {
+	switch mode {
+	case ModeOngoing:
+		return "ongoing"
+	case ModeOngoingCollapsed:
+		return "ongoing_collapsed"
+	case ModeOngoingFull:
+		return "ongoing_full"
+	case ModeOngoingStable:
+		return "ongoing_stable"
+	case ModeDetailCollapsed:
+		return "detail_collapsed"
+	case ModeDetailExpanded:
+		return "detail_expanded"
+	default:
+		return "unknown"
+	}
+}
+
+func assertCompleteErrorContent(t *testing.T, rendered Row, source string) {
+	t.Helper()
+	var content strings.Builder
+	for _, line := range rendered.Lines {
+		for _, span := range line.Spans {
+			if span.Style.Kind == SpanStyleSemantic && span.Style.SemanticRole == StyleRoleError {
+				content.WriteString(span.Text)
+			}
+		}
+		if strings.Contains(line.Plain(), "…") {
+			t.Fatalf("error line was ellipsized: %q", line.Plain())
+		}
+	}
+	want := strings.ReplaceAll(TerminalSafePlainText(source), "\n", "")
+	if got := strings.TrimSpace(content.String()); got != want {
+		t.Fatalf("rendered error content = %q, want complete terminal-safe source %q", got, want)
 	}
 }

--- a/cli/tui/transcriptrender/error_notice_test.go
+++ b/cli/tui/transcriptrender/error_notice_test.go
@@ -2,7 +2,9 @@ package transcriptrender
 
 import (
 	"reflect"
+	"strings"
 	"testing"
+	"unicode"
 
 	"core/shared/clientui"
 	"core/shared/transcript"
@@ -23,7 +25,11 @@ func TestErrorNoticeClassifiesAsError(t *testing.T) {
 }
 
 func TestRuntimeDiagnosticErrorUsesCompleteTypedDetailInEveryMode(t *testing.T) {
-	detail := "diagnostic alpha beta gamma red\nsecond diagnostic line remains complete"
+	detail := "diagnostic \x1b[31mred\tvalue\x00\nsecond diagnostic \x07line remains complete"
+	want := []string{
+		"diagnostic [31mred value",
+		"second diagnostic line remains complete",
+	}
 	misleadingCompact := "wrong compact source"
 	misleadingCondensed := "wrong condensed source"
 	row := errorNoticeRow(&clientui.TranscriptNoticeRow{
@@ -46,18 +52,18 @@ func TestRuntimeDiagnosticErrorUsesCompleteTypedDetailInEveryMode(t *testing.T) 
 			assertCompleteErrorContent(
 				t,
 				rendered,
-				completeErrorLinesForMode(
-					mode,
-					"diagnostic alpha beta gamma red",
-					"second diagnostic line remains complete",
-				),
+				want,
 			)
 		})
 	}
 }
 
 func TestLegacyUntypedErrorUsesCompleteLegacyTextInEveryMode(t *testing.T) {
-	legacy := "legacy alpha beta gamma\nsecond legacy line remains complete"
+	legacy := "legacy alpha\tbeta\x00\nsecond legacy \x07line remains complete"
+	want := []string{
+		"legacy alpha beta",
+		"second legacy line remains complete",
+	}
 	misleadingCompact := "wrong compact source"
 	misleadingCondensed := "wrong condensed source"
 	messageType := clientui.TranscriptMessageErrorFeedback
@@ -79,11 +85,7 @@ func TestLegacyUntypedErrorUsesCompleteLegacyTextInEveryMode(t *testing.T) {
 			assertCompleteErrorContent(
 				t,
 				rendered,
-				completeErrorLinesForMode(
-					mode,
-					"legacy alpha beta gamma",
-					"second legacy line remains complete",
-				),
+				want,
 			)
 		})
 	}
@@ -197,12 +199,12 @@ func TestErrorNoticeReasonSelectsItsTypedContentSource(t *testing.T) {
 				t.Fatalf("notice is invalid: %v", err)
 			}
 			rendered := RenderCommittedRow(errorNoticeRow(test.notice), 120, "dark", ModeOngoingCollapsed)
-			assertCompleteErrorContent(t, rendered, []string{"! " + test.want})
+			assertCompleteErrorContent(t, rendered, []string{test.want})
 		})
 	}
 }
 
-func TestMetadataOnlyLegacyErrorWithoutTypedFormatterFailsFast(t *testing.T) {
+func TestMetadataOnlyLegacyErrorWithoutTypedFormatterFailsValidation(t *testing.T) {
 	messageType := clientui.TranscriptMessageErrorFeedback
 	condensed := "condensed preview is not error content"
 	compact := "compact label is not error content"
@@ -215,16 +217,9 @@ func TestMetadataOnlyLegacyErrorWithoutTypedFormatterFailsFast(t *testing.T) {
 		CompactLabel:  &compact,
 		SourcePath:    &sourcePath,
 	}
-	if err := notice.Validate(); err != nil {
-		t.Fatalf("metadata-only legacy notice is invalid: %v", err)
+	if err := notice.Validate(); err == nil {
+		t.Fatal("metadata-only legacy error without a typed formatter passed validation")
 	}
-
-	defer func() {
-		if recovered := recover(); recovered == nil {
-			t.Fatal("metadata-only legacy error without a typed formatter did not fail fast")
-		}
-	}()
-	RenderCommittedRow(errorNoticeRow(notice), 80, "dark", ModeOngoingCollapsed)
 }
 
 func TestNonErrorNoticeAndToolRowsRetainCompactOneLineLayout(t *testing.T) {
@@ -294,18 +289,23 @@ func transcriptModeName(mode Mode) string {
 
 func assertCompleteErrorContent(t *testing.T, rendered Row, want []string) {
 	t.Helper()
-	if got := PlainLines(rendered.Lines); !reflect.DeepEqual(got, want) {
-		t.Fatalf("rendered error lines = %#v, want %#v", got, want)
+	got := make([]string, 0, len(rendered.Lines))
+	for _, line := range rendered.Lines {
+		var content strings.Builder
+		for _, span := range line.Spans {
+			if role, ok := span.Style.Role(); ok && role == StyleRoleError {
+				content.WriteString(span.Text)
+			}
+		}
+		projected := strings.TrimSpace(content.String())
+		for _, value := range projected {
+			if unicode.IsControl(value) {
+				t.Fatalf("rendered error payload contains terminal control %U", value)
+			}
+		}
+		got = append(got, projected)
 	}
-}
-
-func completeErrorLinesForMode(mode Mode, first, second string) []string {
-	switch mode {
-	case ModeOngoingStable:
-		return []string{"! " + first, second}
-	case ModeDetailCollapsed, ModeDetailExpanded:
-		return []string{"! " + first, "└ " + second}
-	default:
-		return []string{"! " + first, "  " + second}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("rendered semantic error payload = %#v, want %#v", got, want)
 	}
 }

--- a/cli/tui/transcriptrender/error_notice_test.go
+++ b/cli/tui/transcriptrender/error_notice_test.go
@@ -1,7 +1,6 @@
 package transcriptrender
 
 import (
-	"strings"
 	"testing"
 
 	"core/shared/clientui"
@@ -43,7 +42,7 @@ func TestRuntimeDiagnosticErrorUsesCompleteTypedDetailInEveryMode(t *testing.T) 
 	for _, mode := range allTranscriptModes() {
 		t.Run(transcriptModeName(mode), func(t *testing.T) {
 			rendered := RenderCommittedRow(row, 24, "dark", mode)
-			assertCompleteErrorContent(t, rendered, detail)
+			assertCompleteErrorContent(t, rendered, detail, 24)
 		})
 	}
 }
@@ -68,7 +67,7 @@ func TestLegacyUntypedErrorUsesCompleteLegacyTextInEveryMode(t *testing.T) {
 	for _, mode := range allTranscriptModes() {
 		t.Run(transcriptModeName(mode), func(t *testing.T) {
 			rendered := RenderCommittedRow(row, 24, "dark", mode)
-			assertCompleteErrorContent(t, rendered, legacy)
+			assertCompleteErrorContent(t, rendered, legacy, 24)
 		})
 	}
 }
@@ -87,8 +86,22 @@ func TestErrorNoticeReasonSelectsItsTypedContentSource(t *testing.T) {
 	}
 	diagnosticDetail := "typed runtime diagnostic"
 	legacyText := "typed legacy text"
-	metadataText := "typed message metadata content"
-	metadataType := clientui.TranscriptMessageErrorFeedback
+	metadataType := clientui.TranscriptMessageWorktreeMode
+	metadataNotice := &clientui.TranscriptNoticeRow{
+		Reason:      clientui.TranscriptNoticeLegacyUntypedNotice,
+		Severity:    clientui.TranscriptNoticeError,
+		MessageType: &metadataType,
+		Worktree: &clientui.TranscriptWorktreeContext{
+			Branch:        stringPtr("feature/error-source"),
+			WorktreePath:  "/workspace/feature",
+			WorkspaceRoot: "/workspace",
+			EffectiveCwd:  "/workspace/feature",
+		},
+	}
+	metadataText, metadataTextPresent := worktreeNoticeText(metadataNotice, ModeDetailExpanded)
+	if !metadataTextPresent {
+		t.Fatal("typed Worktree message metadata has no formatter")
+	}
 
 	tests := []struct {
 		name   string
@@ -155,14 +168,9 @@ func TestErrorNoticeReasonSelectsItsTypedContentSource(t *testing.T) {
 			want: legacyText,
 		},
 		{
-			name: "typed message metadata",
-			notice: &clientui.TranscriptNoticeRow{
-				Reason:        clientui.TranscriptNoticeLegacyUntypedNotice,
-				Severity:      clientui.TranscriptNoticeError,
-				MessageType:   &metadataType,
-				CondensedText: &metadataText,
-			},
-			want: metadataText,
+			name:   "typed message metadata",
+			notice: metadataNotice,
+			want:   metadataText,
 		},
 	}
 
@@ -172,9 +180,30 @@ func TestErrorNoticeReasonSelectsItsTypedContentSource(t *testing.T) {
 				t.Fatalf("notice is invalid: %v", err)
 			}
 			rendered := RenderCommittedRow(errorNoticeRow(test.notice), 32, "dark", ModeOngoingCollapsed)
-			assertCompleteErrorContent(t, rendered, test.want)
+			assertCompleteErrorContent(t, rendered, test.want, 32)
 		})
 	}
+}
+
+func TestMetadataOnlyLegacyErrorDoesNotUseCompactPreviewFields(t *testing.T) {
+	messageType := clientui.TranscriptMessageErrorFeedback
+	condensed := "condensed preview is not error content"
+	compact := "compact label is not error content"
+	sourcePath := "/preview/source/path"
+	notice := &clientui.TranscriptNoticeRow{
+		Reason:        clientui.TranscriptNoticeLegacyUntypedNotice,
+		Severity:      clientui.TranscriptNoticeError,
+		MessageType:   &messageType,
+		CondensedText: &condensed,
+		CompactLabel:  &compact,
+		SourcePath:    &sourcePath,
+	}
+	if err := notice.Validate(); err != nil {
+		t.Fatalf("metadata-only legacy notice is invalid: %v", err)
+	}
+
+	rendered := RenderCommittedRow(errorNoticeRow(notice), 80, "dark", ModeOngoingCollapsed)
+	assertCompleteErrorContent(t, rendered, string(notice.Reason), 80)
 }
 
 func TestNonErrorNoticeAndToolRowsRetainCompactOneLineLayout(t *testing.T) {
@@ -188,10 +217,6 @@ func TestNonErrorNoticeAndToolRowsRetainCompactOneLineLayout(t *testing.T) {
 	if got := len(rendered.Lines); got != 1 {
 		t.Fatalf("ordinary notice lines = %d, want compact single line", got)
 	}
-	if !strings.Contains(rendered.Lines[0].Plain(), "…") {
-		t.Fatal("ordinary multiline notice lost compact ellipsis")
-	}
-
 	tool := clientui.TranscriptCommittedRow{
 		Visibility: transcript.EntryVisibilityOngoingCollapsed,
 		Integrity:  transcript.RowIntegrityValid,
@@ -246,21 +271,36 @@ func transcriptModeName(mode Mode) string {
 	}
 }
 
-func assertCompleteErrorContent(t *testing.T, rendered Row, source string) {
+func assertCompleteErrorContent(t *testing.T, rendered Row, source string, width int) {
 	t.Helper()
-	var content strings.Builder
-	for _, line := range rendered.Lines {
-		for _, span := range line.Spans {
+	want := wrapLines(TerminalSafePlainText(source), contentWidth(StyleRoleError, width))
+	if len(rendered.Lines) != len(want) {
+		t.Fatalf("rendered error lines = %d, want %d", len(rendered.Lines), len(want))
+	}
+	for index, line := range rendered.Lines {
+		start := 0
+		if line.LeadingSymbol != nil {
+			if index != 0 ||
+				line.LeadingSymbol.Style.Kind != SpanStyleSemantic ||
+				line.LeadingSymbol.Style.SemanticRole != StyleRoleError {
+				t.Fatalf("error line %d has invalid leading symbol: %+v", index, line.LeadingSymbol)
+			}
+			if len(line.Spans) == 0 ||
+				line.Spans[0].Style.Kind != SpanStyleSemantic ||
+				line.Spans[0].Style.SemanticRole != StyleRoleError ||
+				line.Spans[0].Text != " " {
+				t.Fatalf("error line %d has invalid structured symbol gap: %+v", index, line.Spans)
+			}
+			start = 1
+		}
+		content := ""
+		for _, span := range line.Spans[start:] {
 			if span.Style.Kind == SpanStyleSemantic && span.Style.SemanticRole == StyleRoleError {
-				content.WriteString(span.Text)
+				content += span.Text
 			}
 		}
-		if strings.Contains(line.Plain(), "…") {
-			t.Fatalf("error line was ellipsized: %q", line.Plain())
+		if content != want[index] {
+			t.Fatalf("rendered error line %d = %q, want %q", index, content, want[index])
 		}
-	}
-	want := strings.ReplaceAll(TerminalSafePlainText(source), "\n", "")
-	if got := strings.TrimSpace(content.String()); got != want {
-		t.Fatalf("rendered error content = %q, want complete terminal-safe source %q", got, want)
 	}
 }

--- a/cli/tui/transcriptrender/error_notice_test.go
+++ b/cli/tui/transcriptrender/error_notice_test.go
@@ -204,9 +204,9 @@ func TestErrorNoticeReasonSelectsItsTypedContentSource(t *testing.T) {
 	}
 }
 
-func TestMetadataOnlyLegacyErrorWithoutTypedFormatterFailsValidation(t *testing.T) {
+func TestMetadataOnlyLegacyErrorUsesCompleteCondensedText(t *testing.T) {
 	messageType := clientui.TranscriptMessageErrorFeedback
-	condensed := "condensed preview is not error content"
+	condensed := "complete metadata error content"
 	compact := "compact label is not error content"
 	sourcePath := "/preview/source/path"
 	notice := &clientui.TranscriptNoticeRow{
@@ -217,9 +217,11 @@ func TestMetadataOnlyLegacyErrorWithoutTypedFormatterFailsValidation(t *testing.
 		CompactLabel:  &compact,
 		SourcePath:    &sourcePath,
 	}
-	if err := notice.Validate(); err == nil {
-		t.Fatal("metadata-only legacy error without a typed formatter passed validation")
+	if err := notice.Validate(); err != nil {
+		t.Fatalf("metadata-only legacy error is invalid: %v", err)
 	}
+	rendered := RenderCommittedRow(errorNoticeRow(notice), 120, "dark", ModeOngoingCollapsed)
+	assertCompleteErrorContent(t, rendered, []string{condensed})
 }
 
 func TestNonErrorNoticeAndToolRowsRetainCompactOneLineLayout(t *testing.T) {

--- a/cli/tui/transcriptrender/render.go
+++ b/cli/tui/transcriptrender/render.go
@@ -757,12 +757,7 @@ func errorNoticeText(row *clientui.TranscriptNoticeRow) string {
 		if text, ok := worktreeNoticeText(row, ModeDetailExpanded); ok {
 			return text
 		}
-		return firstNonBlankPreservingWhitespace(
-			optionalString(row.CondensedText),
-			optionalString(row.CompactLabel),
-			optionalString(row.SourcePath),
-			string(row.Reason),
-		)
+		return string(row.Reason)
 	default:
 		panic(fmt.Sprintf("render error notice with unsupported reason %q", row.Reason))
 	}

--- a/cli/tui/transcriptrender/render.go
+++ b/cli/tui/transcriptrender/render.go
@@ -741,9 +741,13 @@ func noticeRoleAndText(row *clientui.TranscriptNoticeRow, visibility clientui.En
 		case clientui.TranscriptNoticeRuntimeDiagnostic:
 			return role, row.Diagnostic.Detail
 		case clientui.TranscriptNoticeLegacyUntypedNotice:
+			messageType := "<nil>"
+			if row.MessageType != nil {
+				messageType = string(*row.MessageType)
+			}
 			panic(fmt.Sprintf(
 				"render legacy error notice with no content source: message_type=%q",
-				*row.MessageType,
+				messageType,
 			))
 		default:
 			panic(fmt.Sprintf("render error notice with unsupported reason %q", row.Reason))

--- a/cli/tui/transcriptrender/render.go
+++ b/cli/tui/transcriptrender/render.go
@@ -757,7 +757,10 @@ func errorNoticeText(row *clientui.TranscriptNoticeRow) string {
 		if text, ok := worktreeNoticeText(row, ModeDetailExpanded); ok {
 			return text
 		}
-		return optionalString(row.CondensedText)
+		panic(fmt.Sprintf(
+			"render legacy error notice with no content source: message_type=%q",
+			*row.MessageType,
+		))
 	default:
 		panic(fmt.Sprintf("render error notice with unsupported reason %q", row.Reason))
 	}

--- a/cli/tui/transcriptrender/render.go
+++ b/cli/tui/transcriptrender/render.go
@@ -111,6 +111,9 @@ func renderCommittedRow(
 			group = clientui.TranscriptRowTool
 		}
 		options := textBlockOptions{}
+		if row.Notice != nil && row.Notice.Severity == clientui.TranscriptNoticeError {
+			options.forceFull = true
+		}
 		if isReviewerNotice(row.Notice) {
 			options.compactEllipsis = compactEllipsisNever
 		}
@@ -251,6 +254,7 @@ func renderTextBlockWithInlineMeta(role StyleRole, text string, inlineMeta strin
 
 type textBlockOptions struct {
 	compactEllipsis compactEllipsisPolicy
+	forceFull       bool
 }
 
 type compactEllipsisPolicy uint8
@@ -325,7 +329,7 @@ func renderFormattedTextBlock(
 	if text == "" {
 		text = labelForRole(role)
 	}
-	if modeUsesCompactTextBlock(mode) {
+	if !options.forceFull && modeUsesCompactTextBlock(mode) {
 		first := firstDisplayLine(text)
 		return attachPrefixWithFirstLineMeta(
 			role,
@@ -692,6 +696,9 @@ func noticeRoleAndText(row *clientui.TranscriptNoticeRow, visibility clientui.En
 	if row == nil {
 		return StyleRoleNotice, "notice"
 	}
+	if row.Severity == clientui.TranscriptNoticeError {
+		return StyleRoleError, errorNoticeText(row)
+	}
 	if row.MessageType != nil && *row.MessageType == clientui.TranscriptMessageAgentSteer {
 		if mode != ModeDetailCollapsed && mode != ModeDetailExpanded && row.Diagnostic != nil {
 			return StyleRoleUser, row.Diagnostic.Detail
@@ -728,6 +735,37 @@ func noticeRoleAndText(row *clientui.TranscriptNoticeRow, visibility clientui.En
 		text = firstNonEmpty(row.Diagnostic.Detail, string(row.Diagnostic.Code), text)
 	}
 	return noticeStyleRoleForMode(row, mode), text
+}
+
+func errorNoticeText(row *clientui.TranscriptNoticeRow) string {
+	switch row.Reason {
+	case clientui.TranscriptNoticeCacheWarning:
+		return cacheWarningNoticeText(row.CacheWarning)
+	case clientui.TranscriptNoticeCompaction:
+		if row.Compaction.Detail != nil {
+			return *row.Compaction.Detail
+		}
+		return compactionNoticeText(row.Compaction.Count)
+	case clientui.TranscriptNoticeToolOutputRepair:
+		return toolOutputRepairNoticeText(row.ToolOutputRepair)
+	case clientui.TranscriptNoticeRuntimeDiagnostic:
+		return row.Diagnostic.Detail
+	case clientui.TranscriptNoticeLegacyUntypedNotice:
+		if row.LegacyText != nil {
+			return *row.LegacyText
+		}
+		if text, ok := worktreeNoticeText(row, ModeDetailExpanded); ok {
+			return text
+		}
+		return firstNonBlankPreservingWhitespace(
+			optionalString(row.CondensedText),
+			optionalString(row.CompactLabel),
+			optionalString(row.SourcePath),
+			string(row.Reason),
+		)
+	default:
+		panic(fmt.Sprintf("render error notice with unsupported reason %q", row.Reason))
+	}
 }
 
 func toolOutputRepairNoticeText(repair *transcript.ToolOutputRepairNotice) string {

--- a/cli/tui/transcriptrender/render.go
+++ b/cli/tui/transcriptrender/render.go
@@ -757,7 +757,10 @@ func errorNoticeText(row *clientui.TranscriptNoticeRow) string {
 		if text, ok := worktreeNoticeText(row, ModeDetailExpanded); ok {
 			return text
 		}
-		return string(row.Reason)
+		panic(fmt.Sprintf(
+			"render legacy error notice with no content source: message_type=%q",
+			*row.MessageType,
+		))
 	default:
 		panic(fmt.Sprintf("render error notice with unsupported reason %q", row.Reason))
 	}

--- a/cli/tui/transcriptrender/render.go
+++ b/cli/tui/transcriptrender/render.go
@@ -696,10 +696,12 @@ func noticeRoleAndText(row *clientui.TranscriptNoticeRow, visibility clientui.En
 	if row == nil {
 		return StyleRoleNotice, "notice"
 	}
-	if row.Severity == clientui.TranscriptNoticeError {
-		return StyleRoleError, errorNoticeText(row)
+	isError := row.Severity == clientui.TranscriptNoticeError
+	role := noticeStyleRoleForMode(row, mode)
+	if isError {
+		role = StyleRoleError
 	}
-	if row.MessageType != nil && *row.MessageType == clientui.TranscriptMessageAgentSteer {
+	if !isError && row.MessageType != nil && *row.MessageType == clientui.TranscriptMessageAgentSteer {
 		if mode != ModeDetailCollapsed && mode != ModeDetailExpanded && row.Diagnostic != nil {
 			return StyleRoleUser, row.Diagnostic.Detail
 		}
@@ -710,18 +712,43 @@ func noticeRoleAndText(row *clientui.TranscriptNoticeRow, visibility clientui.En
 	}
 	if row.Reason == clientui.TranscriptNoticeCompaction && row.Compaction != nil {
 		text := compactionNoticeText(row.Compaction.Count)
-		if mode == ModeDetailExpanded && row.Compaction.Detail != nil {
+		if row.Compaction.Detail != nil && (isError || mode == ModeDetailExpanded) {
 			text = *row.Compaction.Detail
 		}
-		return noticeStyleRoleForMode(row, mode), text
+		return role, text
 	}
 	if row.Reason == clientui.TranscriptNoticeToolOutputRepair && row.ToolOutputRepair != nil {
-		return StyleRoleWarning, toolOutputRepairNoticeText(row.ToolOutputRepair)
+		if !isError {
+			role = StyleRoleWarning
+		}
+		return role, toolOutputRepairNoticeText(row.ToolOutputRepair)
 	}
-	if text, ok := worktreeNoticeText(row, mode); ok {
-		return noticeStyleRole(row), text
+	if isError && row.Reason == clientui.TranscriptNoticeLegacyUntypedNotice && row.LegacyText != nil {
+		return role, *row.LegacyText
+	}
+	worktreeMode := mode
+	if isError {
+		worktreeMode = ModeDetailExpanded
+	}
+	if text, ok := worktreeNoticeText(row, worktreeMode); ok {
+		return role, text
 	}
 	cacheWarningText := cacheWarningNoticeText(row.CacheWarning)
+	if isError {
+		switch row.Reason {
+		case clientui.TranscriptNoticeCacheWarning:
+			return role, cacheWarningText
+		case clientui.TranscriptNoticeRuntimeDiagnostic:
+			return role, row.Diagnostic.Detail
+		case clientui.TranscriptNoticeLegacyUntypedNotice:
+			panic(fmt.Sprintf(
+				"render legacy error notice with no content source: message_type=%q",
+				*row.MessageType,
+			))
+		default:
+			panic(fmt.Sprintf("render error notice with unsupported reason %q", row.Reason))
+		}
+	}
 	typedCompactText := firstNonEmpty(optionalString(row.CompactLabel), optionalString(row.CondensedText), noticeLegacyText(row), cacheWarningText, optionalString(row.SourcePath))
 	compactText := firstNonEmpty(typedCompactText, string(row.Reason), "notice")
 	text := compactText
@@ -734,36 +761,7 @@ func noticeRoleAndText(row *clientui.TranscriptNoticeRow, visibility clientui.En
 	if row.Diagnostic != nil && (mode == ModeDetailExpanded || typedCompactText == "") {
 		text = firstNonEmpty(row.Diagnostic.Detail, string(row.Diagnostic.Code), text)
 	}
-	return noticeStyleRoleForMode(row, mode), text
-}
-
-func errorNoticeText(row *clientui.TranscriptNoticeRow) string {
-	switch row.Reason {
-	case clientui.TranscriptNoticeCacheWarning:
-		return cacheWarningNoticeText(row.CacheWarning)
-	case clientui.TranscriptNoticeCompaction:
-		if row.Compaction.Detail != nil {
-			return *row.Compaction.Detail
-		}
-		return compactionNoticeText(row.Compaction.Count)
-	case clientui.TranscriptNoticeToolOutputRepair:
-		return toolOutputRepairNoticeText(row.ToolOutputRepair)
-	case clientui.TranscriptNoticeRuntimeDiagnostic:
-		return row.Diagnostic.Detail
-	case clientui.TranscriptNoticeLegacyUntypedNotice:
-		if row.LegacyText != nil {
-			return *row.LegacyText
-		}
-		if text, ok := worktreeNoticeText(row, ModeDetailExpanded); ok {
-			return text
-		}
-		panic(fmt.Sprintf(
-			"render legacy error notice with no content source: message_type=%q",
-			*row.MessageType,
-		))
-	default:
-		panic(fmt.Sprintf("render error notice with unsupported reason %q", row.Reason))
-	}
+	return role, text
 }
 
 func toolOutputRepairNoticeText(repair *transcript.ToolOutputRepairNotice) string {

--- a/cli/tui/transcriptrender/render.go
+++ b/cli/tui/transcriptrender/render.go
@@ -757,10 +757,7 @@ func errorNoticeText(row *clientui.TranscriptNoticeRow) string {
 		if text, ok := worktreeNoticeText(row, ModeDetailExpanded); ok {
 			return text
 		}
-		panic(fmt.Sprintf(
-			"render legacy error notice with no content source: message_type=%q",
-			*row.MessageType,
-		))
+		return optionalString(row.CondensedText)
 	default:
 		panic(fmt.Sprintf("render error notice with unsupported reason %q", row.Reason))
 	}

--- a/docs/dev/specs/ongoing-scrollback-buffer.md
+++ b/docs/dev/specs/ongoing-scrollback-buffer.md
@@ -69,6 +69,8 @@
 - Separator placement uses only the most recently promoted group kind. A different incoming kind emits one blank line before the row. The same incoming kind appends without a separator.
 - Pending tool activity renders in the mutable band and repaints freely there until the server emits a committed tool row or abort for that call. A committed tool row appends to the immutable area immediately in server order and must not be retained for delayed group promotion, reordering, or batching.
 - Compact tool and notice rows remain one-line width-bound summaries and may ellipsize at emission. This compacting contract is separate from full user/assistant Markdown flow.
+- Error-severity notices are a renderer-owned exception to compact notice layout regardless of the selected Ongoing render mode. The renderer emits the complete typed reason payload, including complete runtime-diagnostic detail and complete legacy-untyped text, wrapped without ellipsis; cache-warning, compaction, and tool-output-repair errors use their complete typed reason text.
+- Every non-error tool and notice row retains its existing compact or full policy. Agent Steer notices and verbose Reviewer Suggestions retain their existing full Ongoing surface routing.
 - Assistant output groups promote progressively through stream promotion; the blank separator for the group is emitted before its first promoted row.
 
 ## Queueing While Not Owning The Normal Buffer

--- a/docs/dev/specs/tui-chat-core.md
+++ b/docs/dev/specs/tui-chat-core.md
@@ -47,6 +47,11 @@
 - If Kent cannot create the queued message or Steer, the failed message returns to the composer and requires an explicit user action to send again. The failed message does not remain pending or retry automatically.
 - The restored text is the exact message Kent attempted to submit. If the composer already contains a newer draft, Kent keeps that draft first, inserts one blank line, appends the failed message, and places the cursor at the end.
 - The failure appears as a transient status-line error using the ordinary submission failure detail. It does not change the activity indicator. The TUI does not create a transcript feedback row for this failure.
+- Each `/compact` submission retains its exact submitted text and whether it was sent directly or drained from the post-turn Queue until that request completes.
+- If Kent does not accept a `/compact` request, the TUI restores that request's exact text through the ordinary creation-failure behavior. A post-turn Queue drain stops at that rejected request.
+- If Kent accepts a `/compact` request, success or a later failure consumes the command without restoration. A post-turn Queue drain continues only after that request completes.
+- Repeated `/compact` submissions remain independent requests. The TUI does not reject a submission because another compaction request is pending or running.
+- Server-published compaction lifecycle is the TUI's only compaction-activity authority. Dispatch and request completion do not change compaction activity locally.
 - If the failed message is Allow commentary, Kent delivers the Approval answer independently while the transient notice is active. Successful Allow commentary creation still precedes the Approval answer.
 
 ## Interrupts And Exit

--- a/docs/dev/specs/tui-transcript.md
+++ b/docs/dev/specs/tui-transcript.md
@@ -172,9 +172,9 @@
 - Cache warnings and non-interrupting warnings use warning text. Compaction reminders use warning text in ongoing and collapsed Detail, and normal notice text when expanded.
 - Error rows use the Error color for both symbol and text, including interruption rows. Error rows may retain faintness when their presentation requires it.
 - One shared transcript renderer selects the complete content and layout for every error-severity notice from its typed reason.
-- A runtime-diagnostic error uses its complete diagnostic detail. A legacy-untyped error uses its complete legacy text when present and otherwise uses the content defined by its valid message metadata.
+- A runtime-diagnostic error uses its complete diagnostic detail. A legacy-untyped error uses its complete legacy text when present and otherwise uses an existing typed formatter for its valid message metadata, such as Worktree context. If that metadata defines no display content, the renderer uses the typed notice reason.
 - A cache-warning error uses its typed cache-warning text. A compaction error uses its typed detail when present and otherwise uses its typed compaction summary. A tool-output-repair error uses its typed repair text.
-- Error-severity notices ignore compact labels, condensed text, and other compact preview fields. They wrap to transcript width without ellipsis in every Ongoing and Detail render mode.
+- Error-severity notices ignore compact labels, condensed text, source paths, and other compact preview fields, including for metadata-only legacy errors. They wrap to transcript width without ellipsis in every Ongoing and Detail render mode.
 - Non-error rows retain their existing mode-specific compact or full content and layout rules.
 - Background shell completion notices use full-strength foreground text and remain separate transcript rows from shell tool calls/results, but join the tool-activity visual group so no blank separator appears between them.
 - Moving a shell to the background ends its mutable live-tool presentation. The backgrounded tool row remains in immutable ongoing scrollback, and completion is represented by a separate immutable notice.

--- a/docs/dev/specs/tui-transcript.md
+++ b/docs/dev/specs/tui-transcript.md
@@ -172,9 +172,9 @@
 - Cache warnings and non-interrupting warnings use warning text. Compaction reminders use warning text in ongoing and collapsed Detail, and normal notice text when expanded.
 - Error rows use the Error color for both symbol and text, including interruption rows. Error rows may retain faintness when their presentation requires it.
 - One shared transcript renderer selects the complete content and layout for every error-severity notice from its typed reason.
-- A runtime-diagnostic error uses its complete diagnostic detail. A legacy-untyped error uses its complete legacy text when present, then an existing typed formatter for its valid message metadata such as Worktree context, then its complete condensed text when no formatter exists.
+- A runtime-diagnostic error uses its complete diagnostic detail. A legacy-untyped error uses its complete legacy text when present and otherwise uses an existing typed formatter for its valid message metadata, such as Worktree context.
 - A cache-warning error uses its typed cache-warning text. A compaction error uses its typed detail when present and otherwise uses its typed compaction summary. A tool-output-repair error uses its typed repair text.
-- Error-severity notices ignore compact labels, source paths, and other compact preview fields. Condensed text is used only as the complete content source for a metadata-only legacy error with no typed formatter. Error notices wrap to transcript width without ellipsis in every Ongoing and Detail render mode.
+- Error-severity notices ignore compact labels, condensed text, source paths, and other compact preview fields, including for metadata-only legacy errors. They wrap to transcript width without ellipsis in every Ongoing and Detail render mode.
 - Non-error rows retain their existing mode-specific compact or full content and layout rules.
 - Background shell completion notices use full-strength foreground text and remain separate transcript rows from shell tool calls/results, but join the tool-activity visual group so no blank separator appears between them.
 - Moving a shell to the background ends its mutable live-tool presentation. The backgrounded tool row remains in immutable ongoing scrollback, and completion is represented by a separate immutable notice.

--- a/docs/dev/specs/tui-transcript.md
+++ b/docs/dev/specs/tui-transcript.md
@@ -172,7 +172,8 @@
 - Cache warnings and non-interrupting warnings use warning text. Compaction reminders use warning text in ongoing and collapsed Detail, and normal notice text when expanded.
 - Error rows use the Error color for both symbol and text, including interruption rows. Error rows may retain faintness when their presentation requires it.
 - One shared transcript renderer selects the complete content and layout for every error-severity notice from its typed reason.
-- A runtime-diagnostic error uses its complete diagnostic detail. A legacy-untyped error uses its complete legacy text when present and otherwise uses an existing typed formatter for its valid message metadata, such as Worktree context.
+- A runtime-diagnostic error uses its complete diagnostic detail. A legacy-untyped error uses its complete legacy text when present.
+- A legacy-untyped error without complete legacy text is valid only for a worktree-enter or worktree-exit message with typed Worktree context. Every other metadata-only legacy-untyped error is invalid.
 - A cache-warning error uses its typed cache-warning text. A compaction error uses its typed detail when present and otherwise uses its typed compaction summary. A tool-output-repair error uses its typed repair text.
 - Error-severity notices ignore compact labels, condensed text, source paths, and other compact preview fields, including for metadata-only legacy errors. They wrap to transcript width without ellipsis in every Ongoing and Detail render mode.
 - Non-error rows retain their existing mode-specific compact or full content and layout rules.

--- a/docs/dev/specs/tui-transcript.md
+++ b/docs/dev/specs/tui-transcript.md
@@ -172,7 +172,7 @@
 - Cache warnings and non-interrupting warnings use warning text. Compaction reminders use warning text in ongoing and collapsed Detail, and normal notice text when expanded.
 - Error rows use the Error color for both symbol and text, including interruption rows. Error rows may retain faintness when their presentation requires it.
 - One shared transcript renderer selects the complete content and layout for every error-severity notice from its typed reason.
-- A runtime-diagnostic error uses its complete diagnostic detail. A legacy-untyped error uses its complete legacy text when present and otherwise uses an existing typed formatter for its valid message metadata, such as Worktree context. If that metadata defines no display content, the renderer uses the typed notice reason.
+- A runtime-diagnostic error uses its complete diagnostic detail. A legacy-untyped error uses its complete legacy text when present and otherwise uses an existing typed formatter for its valid message metadata, such as Worktree context.
 - A cache-warning error uses its typed cache-warning text. A compaction error uses its typed detail when present and otherwise uses its typed compaction summary. A tool-output-repair error uses its typed repair text.
 - Error-severity notices ignore compact labels, condensed text, source paths, and other compact preview fields, including for metadata-only legacy errors. They wrap to transcript width without ellipsis in every Ongoing and Detail render mode.
 - Non-error rows retain their existing mode-specific compact or full content and layout rules.

--- a/docs/dev/specs/tui-transcript.md
+++ b/docs/dev/specs/tui-transcript.md
@@ -172,9 +172,9 @@
 - Cache warnings and non-interrupting warnings use warning text. Compaction reminders use warning text in ongoing and collapsed Detail, and normal notice text when expanded.
 - Error rows use the Error color for both symbol and text, including interruption rows. Error rows may retain faintness when their presentation requires it.
 - One shared transcript renderer selects the complete content and layout for every error-severity notice from its typed reason.
-- A runtime-diagnostic error uses its complete diagnostic detail. A legacy-untyped error uses its complete legacy text when present and otherwise uses an existing typed formatter for its valid message metadata, such as Worktree context.
+- A runtime-diagnostic error uses its complete diagnostic detail. A legacy-untyped error uses its complete legacy text when present, then an existing typed formatter for its valid message metadata such as Worktree context, then its complete condensed text when no formatter exists.
 - A cache-warning error uses its typed cache-warning text. A compaction error uses its typed detail when present and otherwise uses its typed compaction summary. A tool-output-repair error uses its typed repair text.
-- Error-severity notices ignore compact labels, condensed text, source paths, and other compact preview fields, including for metadata-only legacy errors. They wrap to transcript width without ellipsis in every Ongoing and Detail render mode.
+- Error-severity notices ignore compact labels, source paths, and other compact preview fields. Condensed text is used only as the complete content source for a metadata-only legacy error with no typed formatter. Error notices wrap to transcript width without ellipsis in every Ongoing and Detail render mode.
 - Non-error rows retain their existing mode-specific compact or full content and layout rules.
 - Background shell completion notices use full-strength foreground text and remain separate transcript rows from shell tool calls/results, but join the tool-activity visual group so no blank separator appears between them.
 - Moving a shell to the background ends its mutable live-tool presentation. The backgrounded tool row remains in immutable ongoing scrollback, and completion is represented by a separate immutable notice.

--- a/docs/dev/specs/tui-transcript.md
+++ b/docs/dev/specs/tui-transcript.md
@@ -171,6 +171,11 @@
 - Reviewer feedback rows use success text. Reviewer error rows use error text.
 - Cache warnings and non-interrupting warnings use warning text. Compaction reminders use warning text in ongoing and collapsed Detail, and normal notice text when expanded.
 - Error rows use the Error color for both symbol and text, including interruption rows. Error rows may retain faintness when their presentation requires it.
+- One shared transcript renderer selects the complete content and layout for every error-severity notice from its typed reason.
+- A runtime-diagnostic error uses its complete diagnostic detail. A legacy-untyped error uses its complete legacy text when present and otherwise uses the content defined by its valid message metadata.
+- A cache-warning error uses its typed cache-warning text. A compaction error uses its typed detail when present and otherwise uses its typed compaction summary. A tool-output-repair error uses its typed repair text.
+- Error-severity notices ignore compact labels, condensed text, and other compact preview fields. They wrap to transcript width without ellipsis in every Ongoing and Detail render mode.
+- Non-error rows retain their existing mode-specific compact or full content and layout rules.
 - Background shell completion notices use full-strength foreground text and remain separate transcript rows from shell tool calls/results, but join the tool-activity visual group so no blank separator appears between them.
 - Moving a shell to the background ends its mutable live-tool presentation. The backgrounded tool row remains in immutable ongoing scrollback, and completion is represented by a separate immutable notice.
 - The rendering matrix applies to ongoing and detail modes. Mode-specific compact/full rules may change which content is selected. Expanded compaction summary and reminder content uses the normal notice role; other selected content retains its semantic role.
@@ -217,7 +222,7 @@
 - Worktree-management product language uses `workspace`, not `repo`.
 - Changing worktrees keeps the Session identity stable. It changes only the workspace, optional worktree, and relative working directory used for execution.
 - `/worktree` has no separate teleport-root abstraction.
-- Bare `/worktree` opens the Worktree list.
+- Bare `/worktree` and `/wt` open the Worktree list, including during an active Agent Step.
 - `/worktree new` and `/worktree create` enter one smart-target create dialog. Raw `/worktree create <branch> [path]` bypass is unsupported.
 - Create dialog auto-suggests target name only from sanitized session name. It does not fall back to current branch, main, or generic placeholder.
 - Create dialog has no explicit new/existing selector. Kent resolves typed `Branch or ref` asynchronously and shows `new branch`, `existing branch`, or `detached ref`.
@@ -275,7 +280,7 @@
 - Built-ins: `/logout`, `/login`, `/exit`, `/new`, `/resume`, `/compact`, `/name`, `/thinking`, `/fast`, `/review`, `/init`, `/supervisor`, `/autocompaction`, `/questions`, `/status`, `/goal`, `/ps`, `/worktree` (alias `/wt`), `/copy`, `/back`.
 - Exact known slash commands use the normal queued-input drain path when queued; they are never sent as plain user prompts.
 - Run-safe commands execute immediately while busy. `/exit`, `/new`, `/resume`, `/back`, `/review`, and `/init` detach this TUI from the current Session without interrupting its Active Session Runtime.
-- Non-run-safe known commands while busy are rejected with transient status-line error.
+- Non-run-safe known commands while busy are rejected with transient status-line error. Bare `/worktree` and `/wt` are local-picker exceptions; Worktree commands with arguments remain non-run-safe.
 - `/resume` always enters the session picker, including when no other session exists. The originating attachment is released before the picker opens. A picker `Ctrl+C` leaves that run ownerless; it issues no second release and no interrupt.
 - `/copy` is always visible and reads the newest committed assistant final answer from the active transcript segment. It never uses client status or rendered terminal output as a fallback.
 - The durable final-answer read walks backward only within the active transcript segment and stops at the newest committed assistant final answer or a valid compaction boundary, whichever appears first. A valid boundary returns true absence and its carried pre-compaction answer is not reused.

--- a/server/runtimecontrol/service.go
+++ b/server/runtimecontrol/service.go
@@ -617,7 +617,7 @@ func (s *Service) CompactContext(ctx context.Context, req serverapi.RuntimeCompa
 	_, err := memoizedRuntimeCommand(ctx, strings.TrimSpace(req.ClientRequestID), memoReq, s.compactions, sameSessionStringMemoRequest, func(ctx context.Context) (struct{}, bool, error) {
 		attempt := newRuntimeCommandAttempt(ctx)
 		defer attempt.Finish()
-		commandErr := s.runAgentExecution(attempt.Context(), req.SessionID, func(runCtx context.Context, engine *runtime.Engine) error {
+		commandErr := s.withRuntime(attempt.Context(), req.SessionID, func(runCtx context.Context, engine *runtime.Engine) error {
 			_, compactErr := engine.CompactContextWithAcceptance(runCtx, req.Args, attempt.Accept)
 			return compactErr
 		})

--- a/server/runtimecontrol/service_compaction_test.go
+++ b/server/runtimecontrol/service_compaction_test.go
@@ -1,0 +1,267 @@
+package runtimecontrol
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"core/server/llm"
+	"core/server/runtime"
+	"core/server/sessionruntime"
+	"core/server/tools"
+	"core/shared/runtimeids"
+	"core/shared/serverapi"
+	"core/shared/textutil"
+	"core/shared/toolspec"
+)
+
+type boundaryCompactionRuntimeControlClient struct {
+	mu              sync.Mutex
+	generateCalls   int
+	compactionCalls int
+	activeStarted   chan struct{}
+	releaseActive   chan struct{}
+	compactionStart chan struct{}
+	nextStepStarted chan struct{}
+}
+
+type sequentialCompactionRuntimeControlClient struct {
+	runtimeControlFakeClient
+	compactionErrors []error
+}
+
+func (c *sequentialCompactionRuntimeControlClient) Compact(ctx context.Context, req llm.CompactionRequest) (llm.CompactionResponse, error) {
+	c.mu.Lock()
+	c.compactionCalls++
+	if len(c.compactionErrors) != 0 {
+		err := c.compactionErrors[0]
+		c.compactionErrors = c.compactionErrors[1:]
+		c.mu.Unlock()
+		return llm.CompactionResponse{}, err
+	}
+	if len(c.compactionResponses) == 0 {
+		c.mu.Unlock()
+		return llm.CompactionResponse{}, nil
+	}
+	resp := c.compactionResponses[0]
+	c.compactionResponses = c.compactionResponses[1:]
+	c.mu.Unlock()
+	return resp, nil
+}
+
+func newBoundaryCompactionRuntimeControlClient() *boundaryCompactionRuntimeControlClient {
+	return &boundaryCompactionRuntimeControlClient{
+		activeStarted:   make(chan struct{}),
+		releaseActive:   make(chan struct{}),
+		compactionStart: make(chan struct{}),
+		nextStepStarted: make(chan struct{}),
+	}
+}
+
+func (c *boundaryCompactionRuntimeControlClient) Generate(ctx context.Context, _ llm.Request) (llm.Response, error) {
+	c.mu.Lock()
+	c.generateCalls++
+	call := c.generateCalls
+	c.mu.Unlock()
+	switch call {
+	case 1:
+		return llm.Response{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: textutil.Value("seeded"), Phase: textutil.Value(llm.MessagePhaseFinal)},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		}, nil
+	case 2:
+		close(c.activeStarted)
+		select {
+		case <-c.releaseActive:
+		case <-ctx.Done():
+			return llm.Response{}, context.Cause(ctx)
+		}
+		return llm.Response{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: textutil.Value("working"), Phase: textutil.Value(llm.MessagePhaseCommentary)},
+			ToolCalls: []llm.ToolCall{{
+				ID:    "call-before-compaction",
+				Name:  string(toolspec.ToolExecCommand),
+				Input: json.RawMessage(`{"command":"true"}`),
+			}},
+			Usage: llm.Usage{WindowTokens: 200000},
+		}, nil
+	case 3:
+		close(c.nextStepStarted)
+		return llm.Response{
+			Assistant: llm.Message{Role: llm.RoleAssistant, Content: textutil.Value("done"), Phase: textutil.Value(llm.MessagePhaseFinal)},
+			Usage:     llm.Usage{WindowTokens: 200000},
+		}, nil
+	default:
+		return llm.Response{}, errors.New("unexpected model request")
+	}
+}
+
+func (c *boundaryCompactionRuntimeControlClient) Compact(context.Context, llm.CompactionRequest) (llm.CompactionResponse, error) {
+	c.mu.Lock()
+	c.compactionCalls++
+	c.mu.Unlock()
+	close(c.compactionStart)
+	trimmed := 1
+	return llm.CompactionResponse{
+		OutputItems: []llm.ResponseItem{
+			{Type: llm.ResponseItemTypeMessage, Role: textutil.Value(llm.RoleUser), MessageType: textutil.Value(llm.MessageTypeCompactionSummary), Content: textutil.Value("summary")},
+			{Type: llm.ResponseItemTypeCompaction, EncryptedContent: textutil.Value("checkpoint")},
+		},
+		Usage:             llm.Usage{WindowTokens: 200000},
+		TrimmedItemsCount: &trimmed,
+	}, nil
+}
+
+func (c *boundaryCompactionRuntimeControlClient) ProviderCapabilities(context.Context) (llm.ProviderCapabilities, error) {
+	return runtimeControlOpenAICapabilities, nil
+}
+
+func TestServiceCompactContextDuringAgentStepRunsBeforeNextStep(t *testing.T) {
+	client := newBoundaryCompactionRuntimeControlClient()
+	registry := tools.NewRegistry(tools.HandlerRegistration{ID: toolspec.ToolExecCommand, Handler: fakeShellHandler{}})
+	store, engine, service := newRuntimeControlTestService(t, client, registry, runtime.Config{
+		Model:                        "gpt-5",
+		ProviderCapabilitiesOverride: &runtimeControlOpenAICapabilities,
+	})
+	if _, err := engine.SubmitUserMessage(context.Background(), "seed compaction eligibility"); err != nil {
+		t.Fatalf("seed runtime transcript: %v", err)
+	}
+
+	turnDone := make(chan error, 1)
+	go func() {
+		_, err := service.SubmitUserTurn(context.Background(), runtimeControlUserTurnRequest(store, "active-before-compact", "run a tool"))
+		turnDone <- err
+	}()
+	select {
+	case <-client.activeStarted:
+	case err := <-turnDone:
+		t.Fatalf("Agent Turn ended before active step: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for active Agent Step")
+	}
+
+	compactDone := make(chan error, 1)
+	go func() {
+		compactDone <- service.CompactContext(context.Background(), serverapi.RuntimeCompactContextRequest{
+			ClientRequestID: runtimeids.NewRuntimeClientRequestID().String(),
+			SessionID:       store.Meta().SessionID,
+			Args:            "preserve the tool result",
+		})
+	}()
+	select {
+	case err := <-compactDone:
+		if errors.Is(err, serverapi.ErrSessionRunStarting) {
+			t.Fatalf("CompactContext returned active-run recreation error: %v", err)
+		}
+		t.Fatalf("CompactContext completed before the active step boundary: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(client.releaseActive)
+	select {
+	case <-client.compactionStart:
+	case <-client.nextStepStarted:
+		t.Fatal("next Agent Step started before reserved compaction")
+	case err := <-compactDone:
+		t.Fatalf("CompactContext ended before provider compaction: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for compaction at the Agent Step boundary")
+	}
+	if err := <-compactDone; err != nil {
+		t.Fatalf("CompactContext: %v", err)
+	}
+	select {
+	case <-client.nextStepStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("next Agent Step did not start after compaction")
+	}
+	if err := <-turnDone; err != nil {
+		t.Fatalf("SubmitUserTurn: %v", err)
+	}
+}
+
+func TestServiceCompactContextWithoutReadyRuntimeIsNotAcceptedAndUnavailable(t *testing.T) {
+	service := NewService(sessionruntime.NewAuthority(sessionruntime.AuthorityOptions{}))
+	err := service.CompactContext(context.Background(), serverapi.RuntimeCompactContextRequest{
+		ClientRequestID: runtimeids.NewRuntimeClientRequestID().String(),
+		SessionID:       "018fdd67-89ab-4cde-8123-456789abcdef",
+	})
+	if !errors.Is(err, serverapi.ErrRuntimeCommandNotAccepted) {
+		t.Fatalf("CompactContext error = %v, want runtime command not accepted", err)
+	}
+	if !errors.Is(err, serverapi.ErrRuntimeUnavailable) {
+		t.Fatalf("CompactContext error = %v, want runtime unavailable cause", err)
+	}
+}
+
+func TestServiceCompactContextRunsOnIdleReadyRuntime(t *testing.T) {
+	store, _, client, service := newRuntimeControlCompactionFixture(t)
+	err := service.CompactContext(context.Background(), serverapi.RuntimeCompactContextRequest{
+		ClientRequestID: runtimeids.NewRuntimeClientRequestID().String(),
+		SessionID:       store.Meta().SessionID,
+		Args:            "compact while idle",
+	})
+	if err != nil {
+		t.Fatalf("CompactContext: %v", err)
+	}
+	if client.compactionCalls != 1 {
+		t.Fatalf("compaction calls = %d, want 1", client.compactionCalls)
+	}
+	if got := countEventsByKind(t, store, "history_replaced"); got != 1 {
+		t.Fatalf("history replacement events = %d, want 1", got)
+	}
+}
+
+func TestServiceCompactContextRepeatedRequestsUseSeparateReservationsAfterPreCommitFailure(t *testing.T) {
+	providerErr := &llm.APIStatusError{StatusCode: 400, Body: "typed compaction policy failure"}
+	trimmed := 1
+	client := &sequentialCompactionRuntimeControlClient{
+		runtimeControlFakeClient: runtimeControlFakeClient{
+			responses: []llm.Response{{
+				Assistant: llm.Message{Role: llm.RoleAssistant, Content: textutil.Value("seeded"), Phase: textutil.Value(llm.MessagePhaseFinal)},
+				Usage:     llm.Usage{WindowTokens: 200000},
+			}},
+			compactionResponses: []llm.CompactionResponse{{
+				OutputItems: []llm.ResponseItem{
+					{Type: llm.ResponseItemTypeMessage, Role: textutil.Value(llm.RoleUser), MessageType: textutil.Value(llm.MessageTypeCompactionSummary), Content: textutil.Value("summary")},
+					{Type: llm.ResponseItemTypeCompaction, EncryptedContent: textutil.Value("checkpoint")},
+				},
+				Usage:             llm.Usage{WindowTokens: 200000},
+				TrimmedItemsCount: &trimmed,
+			}},
+		},
+		compactionErrors: []error{providerErr},
+	}
+	store, engine, service := newRuntimeControlTestService(t, client, nil, runtime.Config{
+		Model:                        "gpt-5",
+		ProviderCapabilitiesOverride: &runtimeControlOpenAICapabilities,
+	})
+	if _, err := engine.SubmitUserMessage(context.Background(), "seed compaction eligibility"); err != nil {
+		t.Fatalf("seed runtime transcript: %v", err)
+	}
+
+	firstErr := service.CompactContext(context.Background(), serverapi.RuntimeCompactContextRequest{
+		ClientRequestID: runtimeids.NewRuntimeClientRequestID().String(),
+		SessionID:       store.Meta().SessionID,
+		Args:            "first request",
+	})
+	if !errors.Is(firstErr, serverapi.ErrRuntimeCommandNotAccepted) || !errors.Is(firstErr, providerErr) {
+		t.Fatalf("first CompactContext error = %v, want not accepted typed provider cause", firstErr)
+	}
+	if err := service.CompactContext(context.Background(), serverapi.RuntimeCompactContextRequest{
+		ClientRequestID: runtimeids.NewRuntimeClientRequestID().String(),
+		SessionID:       store.Meta().SessionID,
+		Args:            "second request",
+	}); err != nil {
+		t.Fatalf("second CompactContext: %v", err)
+	}
+	if client.compactionCalls != 2 {
+		t.Fatalf("compaction calls = %d, want 2 separate requests", client.compactionCalls)
+	}
+	if got := countEventsByKind(t, store, "history_replaced"); got != 1 {
+		t.Fatalf("history replacement events = %d, want only the accepted request", got)
+	}
+}

--- a/server/runtimecontrol/service_idempotency_test.go
+++ b/server/runtimecontrol/service_idempotency_test.go
@@ -310,11 +310,11 @@ func TestServiceCompactionConsumesCommittedObserverError(t *testing.T) {
 		Args:            "compact now",
 	}
 	gate.FailNext(observerErr)
-	if err := service.CompactContext(context.Background(), request); !errors.Is(err, observerErr) {
-		t.Fatalf("first compaction error = %v, want observer error", err)
+	if err := service.CompactContext(context.Background(), request); !errors.Is(err, observerErr) || errors.Is(err, serverapi.ErrRuntimeCommandNotAccepted) {
+		t.Fatalf("first compaction error = %v, want accepted observer cause", err)
 	}
-	if err := service.CompactContext(context.Background(), request); !errors.Is(err, observerErr) {
-		t.Fatalf("replayed compaction error = %v, want cached observer error", err)
+	if err := service.CompactContext(context.Background(), request); !errors.Is(err, observerErr) || errors.Is(err, serverapi.ErrRuntimeCommandNotAccepted) {
+		t.Fatalf("replayed compaction error = %v, want cached accepted observer cause", err)
 	}
 	if client.compactionCalls != 1 {
 		t.Fatalf("compaction call count = %d, want 1", client.compactionCalls)

--- a/server/sessionruntime/authority_resource.go
+++ b/server/sessionruntime/authority_resource.go
@@ -438,6 +438,10 @@ func (r *agentResource) StepEnded(ctx context.Context, snapshot runtime.StepLife
 	}
 	completing := r.steps[len(r.steps)-1]
 	if completing.stepID != snapshot.StepID || completing.activeKind != snapshot.ActiveKind {
+		if r.rejectsNewStepLocked() && len(r.steps) == 1 && allowsBoundaryCompactionStep(completing.activeKind, snapshot.ActiveKind) {
+			r.mu.Unlock()
+			return nil
+		}
 		r.mu.Unlock()
 		panic(fmt.Sprintf(
 			"agent resource %s generation %d completed engine step out of order: active step %q kind %q, completion step %q kind %q",

--- a/server/sessionruntime/authority_resource.go
+++ b/server/sessionruntime/authority_resource.go
@@ -187,9 +187,14 @@ type agentResource struct {
 	current              *execution
 	pins                 int
 	callbacks            int
-	steps                int
+	steps                []agentResourceStep
 	lifecycleReady       bool
 	lifecycleDraining    bool
+}
+
+type agentResourceStep struct {
+	stepID     string
+	activeKind runtime.ActiveKind
 }
 
 func (r *agentResource) descriptorLocked() AgentResourceDescriptor {
@@ -366,7 +371,7 @@ func (r *agentResource) closeResource(ctx context.Context) error {
 		lifecycleErr = r.authority.options.resourceLifecycle.ResourceDraining(ctx, descriptor)
 	}
 	r.mu.Lock()
-	for r.pins != 0 || r.callbacks != 0 || r.steps != 0 || r.current != nil {
+	for r.pins != 0 || r.callbacks != 0 || len(r.steps) != 0 || r.current != nil {
 		changed := r.changed
 		r.mu.Unlock()
 		select {
@@ -396,11 +401,22 @@ func (r *agentResource) StepBegan(ctx context.Context, snapshot runtime.StepLife
 			fmt.Errorf("agent resource %s generation %d is retiring", r.ref.SessionID(), r.ref.Generation()),
 		)
 	}
-	if r.steps != 0 {
-		r.mu.Unlock()
-		panic(fmt.Sprintf("agent resource %s generation %d admitted overlapping engine steps", r.ref.SessionID(), r.ref.Generation()))
+	if len(r.steps) != 0 {
+		parent := r.steps[len(r.steps)-1]
+		if len(r.steps) != 1 || !allowsBoundaryCompactionStep(parent.activeKind, snapshot.ActiveKind) {
+			r.mu.Unlock()
+			panic(fmt.Sprintf(
+				"agent resource %s generation %d admitted overlapping engine steps: active step %q kind %q, incoming step %q kind %q",
+				r.ref.SessionID(),
+				r.ref.Generation(),
+				parent.stepID,
+				parent.activeKind,
+				snapshot.StepID,
+				snapshot.ActiveKind,
+			))
+		}
 	}
-	r.steps++
+	r.steps = append(r.steps, agentResourceStep{stepID: snapshot.StepID, activeKind: snapshot.ActiveKind})
 	r.signalLocked()
 	descriptor := r.descriptorLocked()
 	r.mu.Unlock()
@@ -412,13 +428,26 @@ func (r *agentResource) StepBegan(ctx context.Context, snapshot runtime.StepLife
 
 func (r *agentResource) StepEnded(ctx context.Context, snapshot runtime.StepLifecycleSnapshot) error {
 	r.mu.Lock()
-	if r.steps == 0 {
+	if len(r.steps) == 0 {
 		rejected := r.rejectsNewStepLocked()
 		r.mu.Unlock()
 		if rejected {
 			return nil
 		}
 		panic(fmt.Sprintf("agent resource %s generation %d engine step underflow", r.ref.SessionID(), r.ref.Generation()))
+	}
+	completing := r.steps[len(r.steps)-1]
+	if completing.stepID != snapshot.StepID || completing.activeKind != snapshot.ActiveKind {
+		r.mu.Unlock()
+		panic(fmt.Sprintf(
+			"agent resource %s generation %d completed engine step out of order: active step %q kind %q, completion step %q kind %q",
+			r.ref.SessionID(),
+			r.ref.Generation(),
+			completing.stepID,
+			completing.activeKind,
+			snapshot.StepID,
+			snapshot.ActiveKind,
+		))
 	}
 	descriptor := r.descriptorLocked()
 	r.mu.Unlock()
@@ -427,14 +456,28 @@ func (r *agentResource) StepEnded(ctx context.Context, snapshot runtime.StepLife
 		publishErr = r.authority.options.stepLifecycle.StepEnded(ctx, descriptor, snapshot)
 	}
 	r.mu.Lock()
-	if r.steps != 1 {
+	if len(r.steps) == 0 ||
+		r.steps[len(r.steps)-1].stepID != completing.stepID ||
+		r.steps[len(r.steps)-1].activeKind != completing.activeKind {
 		r.mu.Unlock()
-		panic(fmt.Sprintf("agent resource %s generation %d engine step count changed during completion", r.ref.SessionID(), r.ref.Generation()))
+		panic(fmt.Sprintf("agent resource %s generation %d engine step stack changed during completion", r.ref.SessionID(), r.ref.Generation()))
 	}
-	r.steps--
+	r.steps = r.steps[:len(r.steps)-1]
 	r.signalLocked()
 	r.mu.Unlock()
 	return publishErr
+}
+
+func allowsBoundaryCompactionStep(parent runtime.ActiveKind, nested runtime.ActiveKind) bool {
+	if nested != runtime.ActiveKindCompaction {
+		return false
+	}
+	switch parent {
+	case runtime.ActiveKindUserTurn, runtime.ActiveKindWorkflowTurn, runtime.ActiveKindGoalLoop:
+		return true
+	default:
+		return false
+	}
 }
 
 func (r *agentResource) rejectsNewUseLocked() bool {
@@ -543,7 +586,7 @@ func (a *Authority) ReleaseRuntime(ctx context.Context, request RuntimeReleaseRe
 		inFlight := resource.current != nil ||
 			resource.pins != 0 ||
 			resource.callbacks != 0 ||
-			resource.steps != 0
+			len(resource.steps) != 0
 		queued := resource.engine != nil && resource.engine.HasQueuedUserWork()
 		scheduled := resource.engine != nil && resource.engine.HasScheduledQueuedUserWork()
 		if inFlight || scheduled || (!request.DropOwner && queued) {
@@ -581,7 +624,7 @@ func (a *Authority) closeRetiringResource(ctx context.Context, resource *agentRe
 		resource.current != nil ||
 		resource.pins != 0 ||
 		resource.callbacks != 0 ||
-		resource.steps != 0 {
+		len(resource.steps) != 0 {
 		resource.mu.Unlock()
 		return nil
 	}
@@ -611,7 +654,7 @@ func (a *Authority) retireRuntimeAbortResource(ctx context.Context, resource *ag
 		return nil
 	}
 	if resource.state != AgentResourceReady ||
-		resource.steps != 0 {
+		len(resource.steps) != 0 {
 		descriptor := resource.descriptorLocked()
 		resource.mu.Unlock()
 		return fmt.Errorf(
@@ -1159,7 +1202,7 @@ func (a *Authority) retireResourceForReplacement(ctx context.Context, resource *
 			)
 		}
 
-		if resource.current != nil || resource.callbacks != 0 || resource.steps != 0 {
+		if resource.current != nil || resource.callbacks != 0 || len(resource.steps) != 0 {
 			changed := resource.changed
 			resource.mu.Unlock()
 			select {

--- a/server/sessionruntime/authority_resource_step_lifecycle_test.go
+++ b/server/sessionruntime/authority_resource_step_lifecycle_test.go
@@ -1,0 +1,87 @@
+package sessionruntime
+
+import (
+	"context"
+	"testing"
+
+	"core/server/runtime"
+	"core/shared/runtimeids"
+)
+
+func TestAgentResourceStepLifecycleAllowsBoundaryCompactionNesting(t *testing.T) {
+	sessionID, err := runtimeids.ParseSessionID("018fdd67-89ab-4cde-8123-456789abcdef")
+	if err != nil {
+		t.Fatalf("parse session id: %v", err)
+	}
+	ref, err := runtimeids.NewSessionResourceRef(sessionID, 1)
+	if err != nil {
+		t.Fatalf("new session resource ref: %v", err)
+	}
+	resource := &agentResource{
+		authority: &Authority{},
+		ref:       ref,
+		state:     AgentResourceReady,
+		changed:   make(chan struct{}),
+	}
+	outer := runtime.StepLifecycleSnapshot{
+		StepID:     "outer-agent-step",
+		ActiveKind: runtime.ActiveKindUserTurn,
+		Transition: runtime.StepLifecycleTransitionBegan,
+	}
+	nested := runtime.StepLifecycleSnapshot{
+		StepID:     "nested-compaction",
+		ActiveKind: runtime.ActiveKindCompaction,
+		Transition: runtime.StepLifecycleTransitionBegan,
+	}
+
+	if err := resource.StepBegan(context.Background(), outer); err != nil {
+		t.Fatalf("begin outer Agent Step: %v", err)
+	}
+	if err := resource.StepBegan(context.Background(), nested); err != nil {
+		t.Fatalf("begin boundary compaction: %v", err)
+	}
+	if err := resource.StepEnded(context.Background(), nested); err != nil {
+		t.Fatalf("end boundary compaction: %v", err)
+	}
+	if err := resource.StepEnded(context.Background(), outer); err != nil {
+		t.Fatalf("end outer Agent Step: %v", err)
+	}
+	if len(resource.steps) != 0 {
+		t.Fatalf("remaining resource step stack = %+v, want empty", resource.steps)
+	}
+}
+
+func TestAgentResourceStepLifecycleRejectsUnrelatedOverlap(t *testing.T) {
+	sessionID, err := runtimeids.ParseSessionID("018fdd67-89ab-4cde-8123-456789abcdef")
+	if err != nil {
+		t.Fatalf("parse session id: %v", err)
+	}
+	ref, err := runtimeids.NewSessionResourceRef(sessionID, 1)
+	if err != nil {
+		t.Fatalf("new session resource ref: %v", err)
+	}
+	resource := &agentResource{
+		authority: &Authority{},
+		ref:       ref,
+		state:     AgentResourceReady,
+		changed:   make(chan struct{}),
+	}
+	if err := resource.StepBegan(context.Background(), runtime.StepLifecycleSnapshot{
+		StepID:     "outer-agent-step",
+		ActiveKind: runtime.ActiveKindUserTurn,
+		Transition: runtime.StepLifecycleTransitionBegan,
+	}); err != nil {
+		t.Fatalf("begin outer Agent Step: %v", err)
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("unrelated overlapping step did not panic")
+		}
+	}()
+	_ = resource.StepBegan(context.Background(), runtime.StepLifecycleSnapshot{
+		StepID:     "overlapping-maintenance",
+		ActiveKind: runtime.ActiveKindRuntimeMaintenance,
+		Transition: runtime.StepLifecycleTransitionBegan,
+	})
+}

--- a/server/sessionruntime/authority_resource_step_lifecycle_test.go
+++ b/server/sessionruntime/authority_resource_step_lifecycle_test.go
@@ -9,20 +9,7 @@ import (
 )
 
 func TestAgentResourceStepLifecycleAllowsBoundaryCompactionNesting(t *testing.T) {
-	sessionID, err := runtimeids.ParseSessionID("018fdd67-89ab-4cde-8123-456789abcdef")
-	if err != nil {
-		t.Fatalf("parse session id: %v", err)
-	}
-	ref, err := runtimeids.NewSessionResourceRef(sessionID, 1)
-	if err != nil {
-		t.Fatalf("new session resource ref: %v", err)
-	}
-	resource := &agentResource{
-		authority: &Authority{},
-		ref:       ref,
-		state:     AgentResourceReady,
-		changed:   make(chan struct{}),
-	}
+	resource := newAgentResourceStepLifecycleTestResource(t)
 	outer := runtime.StepLifecycleSnapshot{
 		StepID:     "outer-agent-step",
 		ActiveKind: runtime.ActiveKindUserTurn,
@@ -43,6 +30,17 @@ func TestAgentResourceStepLifecycleAllowsBoundaryCompactionNesting(t *testing.T)
 	if err := resource.StepEnded(context.Background(), nested); err != nil {
 		t.Fatalf("end boundary compaction: %v", err)
 	}
+	resource.state = AgentResourceDraining
+	nested.StepID = "rejected-nested-compaction"
+	if err := resource.StepBegan(context.Background(), nested); err == nil {
+		t.Fatal("draining resource accepted nested compaction")
+	}
+	if err := resource.StepEnded(context.Background(), nested); err != nil {
+		t.Fatalf("clean up rejected boundary compaction: %v", err)
+	}
+	if len(resource.steps) != 1 || resource.steps[0].stepID != outer.StepID {
+		t.Fatalf("rejected nested cleanup changed outer step stack: %+v", resource.steps)
+	}
 	if err := resource.StepEnded(context.Background(), outer); err != nil {
 		t.Fatalf("end outer Agent Step: %v", err)
 	}
@@ -52,20 +50,7 @@ func TestAgentResourceStepLifecycleAllowsBoundaryCompactionNesting(t *testing.T)
 }
 
 func TestAgentResourceStepLifecycleRejectsUnrelatedOverlap(t *testing.T) {
-	sessionID, err := runtimeids.ParseSessionID("018fdd67-89ab-4cde-8123-456789abcdef")
-	if err != nil {
-		t.Fatalf("parse session id: %v", err)
-	}
-	ref, err := runtimeids.NewSessionResourceRef(sessionID, 1)
-	if err != nil {
-		t.Fatalf("new session resource ref: %v", err)
-	}
-	resource := &agentResource{
-		authority: &Authority{},
-		ref:       ref,
-		state:     AgentResourceReady,
-		changed:   make(chan struct{}),
-	}
+	resource := newAgentResourceStepLifecycleTestResource(t)
 	if err := resource.StepBegan(context.Background(), runtime.StepLifecycleSnapshot{
 		StepID:     "outer-agent-step",
 		ActiveKind: runtime.ActiveKindUserTurn,
@@ -84,4 +69,13 @@ func TestAgentResourceStepLifecycleRejectsUnrelatedOverlap(t *testing.T) {
 		ActiveKind: runtime.ActiveKindRuntimeMaintenance,
 		Transition: runtime.StepLifecycleTransitionBegan,
 	})
+}
+
+func newAgentResourceStepLifecycleTestResource(t *testing.T) *agentResource {
+	t.Helper()
+	ref, err := runtimeids.NewSessionResourceRef(runtimeids.NewSessionID(), 1)
+	if err != nil {
+		t.Fatalf("new session resource ref: %v", err)
+	}
+	return &agentResource{authority: &Authority{}, ref: ref, state: AgentResourceReady, changed: make(chan struct{})}
 }

--- a/server/sessionruntime/execution_target.go
+++ b/server/sessionruntime/execution_target.go
@@ -236,7 +236,7 @@ func (a *Authority) HasBlockingRuntimeActivity(ctx context.Context, sessionID st
 	resource.mu.Lock()
 	active := resource.state != AgentResourceReady ||
 		resource.current != nil ||
-		resource.steps != 0
+		len(resource.steps) != 0
 	engine := resource.engine
 	resource.mu.Unlock()
 	if !active && engine != nil {

--- a/server/transport/gateway_part3_test.go
+++ b/server/transport/gateway_part3_test.go
@@ -65,6 +65,58 @@ func TestGatewaySessionAttachEstablishesProjectForUnboundServer(t *testing.T) {
 	}
 }
 
+func TestCompactContextWithoutReadyRuntimePreservesJoinedErrorLoopbackAndRemote(t *testing.T) {
+	appCore, server := newGatewayTestServer(t)
+	defer func() { _ = appCore.Close() }()
+	defer server.Close()
+	store := createGatewayAuthoritativeSession(t, appCore)
+
+	request := serverapi.RuntimeCompactContextRequest{
+		ClientRequestID: runtimeids.NewRuntimeClientRequestID().String(),
+		SessionID:       store.Meta().SessionID,
+		Args:            "compact without a Ready runtime",
+	}
+	loopbackErr := appCore.RuntimeControlClient().CompactContext(context.Background(), request)
+	requireCompactRuntimeUnavailableNotAccepted(t, loopbackErr)
+	if err := appCore.RuntimeControlClient().SetSessionName(context.Background(), serverapi.RuntimeSetSessionNameRequest{
+		ClientRequestID: runtimeids.NewRuntimeClientRequestID().String(),
+		SessionID:       store.Meta().SessionID,
+		Name:            "must remain unavailable",
+	}); !errors.Is(err, serverapi.ErrRuntimeUnavailable) {
+		t.Fatalf("loopback compact created a runtime: SetSessionName error = %v", err)
+	}
+
+	remote, err := remoteclient.DialRemoteURLForSession(
+		context.Background(),
+		"ws"+server.URL[len("http"):],
+		store.Meta().SessionID,
+	)
+	if err != nil {
+		t.Fatalf("DialRemoteURLForSession: %v", err)
+	}
+	defer func() { _ = remote.Close() }()
+	request.ClientRequestID = runtimeids.NewRuntimeClientRequestID().String()
+	remoteErr := remote.CompactContext(context.Background(), request)
+	requireCompactRuntimeUnavailableNotAccepted(t, remoteErr)
+	if err := appCore.RuntimeControlClient().SetSessionName(context.Background(), serverapi.RuntimeSetSessionNameRequest{
+		ClientRequestID: runtimeids.NewRuntimeClientRequestID().String(),
+		SessionID:       store.Meta().SessionID,
+		Name:            "must still remain unavailable",
+	}); !errors.Is(err, serverapi.ErrRuntimeUnavailable) {
+		t.Fatalf("remote compact created a runtime: SetSessionName error = %v", err)
+	}
+}
+
+func requireCompactRuntimeUnavailableNotAccepted(t *testing.T, err error) {
+	t.Helper()
+	if !errors.Is(err, serverapi.ErrRuntimeCommandNotAccepted) {
+		t.Fatalf("CompactContext error = %v, want runtime command not accepted", err)
+	}
+	if !errors.Is(err, serverapi.ErrRuntimeUnavailable) {
+		t.Fatalf("CompactContext error = %v, want runtime unavailable", err)
+	}
+}
+
 func newGatewayTestServer(t *testing.T) (*core.Core, *httptest.Server) {
 	t.Helper()
 	appCore, server, _ := newGatewayTestServerWithAuth(t, true)

--- a/server/transport/gateway_test.go
+++ b/server/transport/gateway_test.go
@@ -170,6 +170,26 @@ func TestResponseForErrorPreservesRuntimeCommandNotAcceptedCause(t *testing.T) {
 	}
 }
 
+func TestResponseForErrorPreservesRuntimeCommandNotAcceptedUnavailableCause(t *testing.T) {
+	source := serverapi.NewRuntimeCommandNotAcceptedError(errors.Join(
+		serverapi.ErrRuntimeUnavailable,
+		errors.New("session has no Ready runtime"),
+	))
+	response := responseForError("runtime-command", source)
+	if response.Error == nil || response.Error.Code != protocol.ErrCodeRuntimeCommandNotAccepted {
+		t.Fatalf("runtime command response = %+v, want structured not-accepted error", response.Error)
+	}
+	var payload struct {
+		Cause protocol.ResponseError `json:"cause"`
+	}
+	if err := json.Unmarshal(response.Error.Data, &payload); err != nil {
+		t.Fatalf("decode nested cause: %v", err)
+	}
+	if payload.Cause.Code != protocol.ErrCodeRuntimeUnavailable {
+		t.Fatalf("nested cause code = %d, want %d", payload.Cause.Code, protocol.ErrCodeRuntimeUnavailable)
+	}
+}
+
 func TestResponseForErrorMapsProjectWorkspaceTypedFailures(t *testing.T) {
 	tests := []struct {
 		name string

--- a/shared/client/remote_test.go
+++ b/shared/client/remote_test.go
@@ -2200,6 +2200,11 @@ func TestProtocolErrorDecodesRuntimeCommandNotAcceptedCauses(t *testing.T) {
 				t.Fatalf("decoded cause = %v, want manual compaction active", err)
 			}
 		}},
+		{name: "runtime unavailable", cause: serverapi.ErrRuntimeUnavailable, check: func(t *testing.T, err error) {
+			if !errors.Is(err, serverapi.ErrRuntimeUnavailable) {
+				t.Fatalf("decoded cause = %v, want runtime unavailable", err)
+			}
+		}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			source := serverapi.NewRuntimeCommandNotAcceptedError(test.cause)

--- a/shared/clientui/transcript_row.go
+++ b/shared/clientui/transcript_row.go
@@ -515,19 +515,6 @@ func (r TranscriptNoticeRow) Validate() error {
 		if r.LegacyText == nil && r.MessageType == nil {
 			return fmt.Errorf("legacy notice requires text or typed message metadata")
 		}
-		if r.Severity == TranscriptNoticeError && r.LegacyText == nil {
-			if r.Worktree == nil {
-				return fmt.Errorf("legacy error without text requires typed Worktree metadata")
-			}
-			switch *r.MessageType {
-			case TranscriptMessageWorktreeMode, TranscriptMessageWorktreeModeExit:
-			default:
-				return fmt.Errorf(
-					"legacy error without text has unsupported typed message metadata %q",
-					*r.MessageType,
-				)
-			}
-		}
 		if r.CacheWarning != nil || r.Compaction != nil || r.ToolOutputRepair != nil || r.Diagnostic != nil || r.Background != nil {
 			return fmt.Errorf("legacy notice cannot carry a typed notice reason payload")
 		}

--- a/shared/clientui/transcript_row.go
+++ b/shared/clientui/transcript_row.go
@@ -515,6 +515,19 @@ func (r TranscriptNoticeRow) Validate() error {
 		if r.LegacyText == nil && r.MessageType == nil {
 			return fmt.Errorf("legacy notice requires text or typed message metadata")
 		}
+		if r.Severity == TranscriptNoticeError && r.LegacyText == nil {
+			if r.Worktree == nil {
+				return fmt.Errorf("legacy error without text requires typed Worktree metadata")
+			}
+			switch *r.MessageType {
+			case TranscriptMessageWorktreeMode, TranscriptMessageWorktreeModeExit:
+			default:
+				return fmt.Errorf(
+					"legacy error without text has unsupported typed message metadata %q",
+					*r.MessageType,
+				)
+			}
+		}
 		if r.CacheWarning != nil || r.Compaction != nil || r.ToolOutputRepair != nil || r.Diagnostic != nil || r.Background != nil {
 			return fmt.Errorf("legacy notice cannot carry a typed notice reason payload")
 		}

--- a/shared/clientui/transcript_row_test.go
+++ b/shared/clientui/transcript_row_test.go
@@ -162,6 +162,41 @@ func TestTranscriptCacheWarningAcceptsAbsentLossAndRejectsPresentZero(t *testing
 	}
 }
 
+func TestTranscriptNoticeRowRejectsPreviewOnlyLegacyError(t *testing.T) {
+	messageType := TranscriptMessageErrorFeedback
+	condensed := "preview"
+	compact := "compact"
+	sourcePath := "/preview"
+	notice := TranscriptNoticeRow{
+		Reason:        TranscriptNoticeLegacyUntypedNotice,
+		Severity:      TranscriptNoticeError,
+		MessageType:   &messageType,
+		CondensedText: &condensed,
+		CompactLabel:  &compact,
+		SourcePath:    &sourcePath,
+	}
+	if err := notice.Validate(); err == nil {
+		t.Fatal("accepted a legacy error with preview fields but no complete content source")
+	}
+}
+
+func TestTranscriptNoticeRowAcceptsMetadataOnlyWorktreeError(t *testing.T) {
+	messageType := TranscriptMessageWorktreeMode
+	notice := TranscriptNoticeRow{
+		Reason:      TranscriptNoticeLegacyUntypedNotice,
+		Severity:    TranscriptNoticeError,
+		MessageType: &messageType,
+		Worktree: &TranscriptWorktreeContext{
+			WorktreePath:  "/workspace/feature",
+			WorkspaceRoot: "/workspace",
+			EffectiveCwd:  "/workspace/feature",
+		},
+	}
+	if err := notice.Validate(); err != nil {
+		t.Fatalf("rejected metadata-only Worktree error: %v", err)
+	}
+}
+
 func TestTranscriptNoticeRowRejectsReasonPayloadMismatch(t *testing.T) {
 	legacyText := "legacy notice"
 	tests := []TranscriptNoticeRow{

--- a/shared/clientui/transcript_row_test.go
+++ b/shared/clientui/transcript_row_test.go
@@ -162,41 +162,6 @@ func TestTranscriptCacheWarningAcceptsAbsentLossAndRejectsPresentZero(t *testing
 	}
 }
 
-func TestTranscriptNoticeRowRejectsPreviewOnlyLegacyError(t *testing.T) {
-	messageType := TranscriptMessageErrorFeedback
-	condensed := "preview"
-	compact := "compact"
-	sourcePath := "/preview"
-	notice := TranscriptNoticeRow{
-		Reason:        TranscriptNoticeLegacyUntypedNotice,
-		Severity:      TranscriptNoticeError,
-		MessageType:   &messageType,
-		CondensedText: &condensed,
-		CompactLabel:  &compact,
-		SourcePath:    &sourcePath,
-	}
-	if err := notice.Validate(); err == nil {
-		t.Fatal("accepted a legacy error with preview fields but no complete content source")
-	}
-}
-
-func TestTranscriptNoticeRowAcceptsMetadataOnlyWorktreeError(t *testing.T) {
-	messageType := TranscriptMessageWorktreeMode
-	notice := TranscriptNoticeRow{
-		Reason:      TranscriptNoticeLegacyUntypedNotice,
-		Severity:    TranscriptNoticeError,
-		MessageType: &messageType,
-		Worktree: &TranscriptWorktreeContext{
-			WorktreePath:  "/workspace/feature",
-			WorkspaceRoot: "/workspace",
-			EffectiveCwd:  "/workspace/feature",
-		},
-	}
-	if err := notice.Validate(); err != nil {
-		t.Fatalf("rejected metadata-only Worktree error: %v", err)
-	}
-}
-
 func TestTranscriptNoticeRowRejectsReasonPayloadMismatch(t *testing.T) {
 	legacyText := "legacy notice"
 	tests := []TranscriptNoticeRow{

--- a/shared/serverapi/runtime_errors.go
+++ b/shared/serverapi/runtime_errors.go
@@ -50,6 +50,8 @@ func (e *RuntimeCommandNotAcceptedError) RPCErrorData() json.RawMessage {
 		var structured protocol.StructuredRPCError
 		if errors.Is(e.Cause, context.Canceled) {
 			cause.Code = protocol.ErrCodeRequestCanceled
+		} else if errors.Is(e.Cause, ErrRuntimeUnavailable) {
+			cause.Code = protocol.ErrCodeRuntimeUnavailable
 		} else if errors.As(e.Cause, &structured) {
 			cause.Code = structured.RPCErrorCode()
 			cause.Data = structured.RPCErrorData()


### PR DESCRIPTION
## Summary
- route compaction through the current ready runtime and preserve the existing engine reservation
- make queued compact requests independently own their exact text and rejection behavior
- allow boundary-safe command handling while busy, including local worktree picker commands
- render complete typed transcript errors without ellipsis in ongoing or detail modes

## Verification
- `go test ./shared/clientui ./shared/invariant ./cli/tui/transcriptrender ./cli/tui/ongoing -count=1`
- `./scripts/test.sh server --no-wall-clock-cap`
- `./scripts/build.sh --output ./bin/kent`
- `git diff --check`

Manual QA was intentionally left to the separate QA workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bare `/worktree` and `/wt` commands now open the Worktree picker while an agent is busy.
  * Compaction requests preserve submitted text and handle queued requests independently.

* **Bug Fixes**
  * Input remains editable and submits directly during compaction.
  * Queued commands pause safely until post-turn compaction completes.
  * Error notices now display complete diagnostic and legacy details without truncation.
  * Runtime-unavailable errors are reported accurately without unnecessary retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->