### PR TITLE
Prevent service resurrection after fatal exit

### DIFF
--- a/cli/kent/service_backend_linux.go
+++ b/cli/kent/service_backend_linux.go
@@ -251,24 +251,12 @@ func systemdUnitPath() (string, error) {
 }
 
 func renderSystemdUnit(spec serviceSpec) string {
-	lines := []string{
-		"[Unit]",
-		"Description=" + brand.Product + " server background service",
-		"After=network-online.target",
-		"",
-		"[Service]",
-		"Type=simple",
-		"ExecStart=" + systemdCommand(serviceCommand(spec)),
-		"Restart=always",
-		"RestartSec=2",
-		"StandardOutput=append:" + systemdEscapeSpecifiers(spec.StdoutLogPath),
-		"StandardError=append:" + systemdEscapeSpecifiers(spec.StderrLogPath),
-		"",
-		"[Install]",
-		"WantedBy=default.target",
-		"",
-	}
-	return strings.Join(lines, "\n")
+	return renderSystemdUnitText(
+		brand.Product+" server background service",
+		systemdCommand(serviceCommand(spec)),
+		systemdEscapeSpecifiers(spec.StdoutLogPath),
+		systemdEscapeSpecifiers(spec.StderrLogPath),
+	)
 }
 
 func systemdCommand(args []string) string {

--- a/cli/kent/service_host_windows.go
+++ b/cli/kent/service_host_windows.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"time"
 
-	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 )
 
@@ -61,7 +60,7 @@ func (h *windowsServiceHandler) Execute(_ []string, r <-chan svc.ChangeRequest, 
 		select {
 		case <-done:
 			changes <- svc.Status{State: svc.Stopped}
-			return false, uint32(windows.ERROR_PROCESS_ABORTED)
+			return serviceCompletionStatus()
 		case request := <-r:
 			switch request.Cmd {
 			case svc.Interrogate:

--- a/cli/kent/service_recovery_test.go
+++ b/cli/kent/service_recovery_test.go
@@ -99,6 +99,7 @@ func assertDecision(t *testing.T, got managedChildSettlementDecision, replace, c
 }
 
 func assertCleanStop(t *testing.T, decision managedChildSettlementDecision) {
+	assertDecision(t, decision, false, true)
 	if specific, code := serviceCompletionStatus(); specific || code != 0 {
 		t.Fatalf("SCM completion = (%t, %d), want (false, 0)", specific, code)
 	}

--- a/cli/kent/service_recovery_test.go
+++ b/cli/kent/service_recovery_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+type managedChildFake struct {
+	observation       serviceTerminationObservation
+	releases, retains int
+	label, retained   string
+}
+
+func (f *managedChildFake) target() managedChildSettlementTarget {
+	return managedChildSettlementTarget{terminate: func() serviceTerminationObservation { return f.observation }, release: func() { f.releases++ }, retain: func() { f.retains++; f.retained = f.label }}
+}
+func TestServiceWakeRoutesManagedChildSettlement(t *testing.T) {
+	names := []string{"same session", "differing session", "no session"}
+	sessions := [][2]uint32{{7, 7}, {7, 8}, {7, 0}}
+	for i, name := range names {
+		t.Run(name, func(t *testing.T) {
+			fake := &managedChildFake{observation: observedStatus(2)}
+			calls := 0
+			got := routeManagedChildWake(sessions[i][0], sessions[i][1], func() managedChildSettlementDecision {
+				calls++
+				return settleManagedChild(fake.target(), fake.observation)
+			})
+			if calls != []int{0, 1, 1}[i] {
+				t.Fatalf("settlement calls = %d, want %d", calls, []int{0, 1, 1}[i])
+			}
+			if i == 0 {
+				assertOperations(t, fake, 0, 0)
+				return
+			}
+			assertDecision(t, got, false, true)
+			assertOperations(t, fake, 1, 0)
+			assertCleanStop(t, got)
+		})
+	}
+}
+
+func TestServiceManagedChildExitBeforeHandoff(t *testing.T) {
+	assertDecision(t, settleManagedChild((&managedChildFake{}).target(), observedStatus(2)), false, true)
+}
+
+func TestServiceManagedChildTerminationCases(t *testing.T) {
+	statusOne := uint32(1)
+	names := []string{"status 2", "non-2", "confirmed without status", "unconfirmed"}
+	observations := []serviceTerminationObservation{observedStatus(2), {TerminationConfirmed: true, ExitStatus: &statusOne}, {TerminationConfirmed: true}, {}}
+	releases, retains := []int{1, 1, 1, 0}, []int{0, 0, 0, 1}
+	for i, name := range names {
+		t.Run(name, func(t *testing.T) {
+			fake := &managedChildFake{observation: observations[i]}
+			got := settleManagedChild(fake.target(), observations[i])
+			assertDecision(t, got, i == 1, i == 0 || i == 2)
+			assertOperations(t, fake, releases[i], retains[i])
+		})
+	}
+}
+
+func TestServiceStaleLaunchedCandidateSettlement(t *testing.T) {
+	for i, name := range []string{"status 2", "unconfirmed"} {
+		t.Run(name, func(t *testing.T) {
+			observation := observedStatus(2)
+			if i == 1 {
+				observation = serviceTerminationObservation{}
+			}
+			fake := &managedChildFake{label: "candidate", observation: observation}
+			got := settleStaleLaunchedCandidate(fake.target())
+			assertDecision(t, got, false, i == 0)
+			if fake.retained != map[bool]string{true: "", false: "candidate"}[i == 0] || fake.releases != i^1 {
+				t.Fatalf("stale settlement operations = %#v", fake)
+			}
+			if i == 0 {
+				assertCleanStop(t, got)
+			}
+		})
+	}
+}
+
+func TestRenderedSystemdUnitRestartPolicy(t *testing.T) {
+	lines := strings.Split(renderSystemdUnitText("Kent server", "/bin/kent serve", "server.log", "server.err.log"), "\n")
+	for _, want := range []string{"Restart=always", "RestartPreventExitStatus=2", "RestartSec=2"} {
+		if !slices.Contains(lines, want) {
+			t.Fatalf("rendered unit missing %q", want)
+		}
+	}
+}
+
+func TestWindowsServiceNoResurrectCompletionIsCleanStop(t *testing.T) {
+	assertCleanStop(t, managedChildSettlementDecision{Complete: true})
+}
+
+func assertDecision(t *testing.T, got managedChildSettlementDecision, replace, complete bool) {
+	if got.Replace != replace || got.Complete != complete {
+		t.Fatalf("decision = %#v, want replace=%t complete=%t", got, replace, complete)
+	}
+}
+
+func assertCleanStop(t *testing.T, decision managedChildSettlementDecision) {
+	if specific, code := serviceCompletionStatus(); specific || code != 0 {
+		t.Fatalf("SCM completion = (%t, %d), want (false, 0)", specific, code)
+	}
+}
+
+func assertOperations(t *testing.T, fake *managedChildFake, releases, retains int) {
+	if fake.releases != releases || fake.retains != retains {
+		t.Fatalf("settlement operations = %#v", fake)
+	}
+}
+
+func observedStatus(status uint32) serviceTerminationObservation {
+	return serviceTerminationObservation{TerminationConfirmed: true, ExitStatus: &status}
+}

--- a/cli/kent/service_supervisor_windows.go
+++ b/cli/kent/service_supervisor_windows.go
@@ -74,7 +74,7 @@ func (s *serverSupervisor) run(ctx context.Context) {
 			}
 		}
 		s.mu.Lock()
-		needLaunch := s.child == nil || s.child.session != session
+		needLaunch := s.child == nil || (s.child.session != session && !s.child.retained)
 		s.mu.Unlock()
 		if needLaunch {
 			if s.stopChild().Complete {
@@ -112,6 +112,9 @@ func (s *serverSupervisor) run(ctx context.Context) {
 			s.stopChild()
 			return
 		case <-s.wake:
+			if child.retained {
+				continue
+			}
 			if routeManagedChildWake(child.session, s.wanted.Load(), func() managedChildSettlementDecision {
 				return settleManagedChild(s.settlementTarget(child), child.terminate(s.spec))
 			}).Complete {
@@ -155,7 +158,7 @@ func (s *serverSupervisor) stopChild() managedChildSettlementDecision {
 }
 
 func (s *serverSupervisor) settlementTarget(child *managedChild) managedChildSettlementTarget {
-	return managedChildSettlementTarget{func() serviceTerminationObservation { return child.terminate(s.spec) }, func() { child.release(); s.setChild(nil); s.clearPID() }, func() { s.setChild(child); s.writePID(child.pid); select {} }}
+	return managedChildSettlementTarget{func() serviceTerminationObservation { return child.terminate(s.spec) }, func() { child.release(); s.setChild(nil); s.clearPID() }, func() { child.retained = true; s.setChild(child); s.writePID(child.pid) }}
 }
 func (s *serverSupervisor) setChild(child *managedChild) { s.mu.Lock(); s.child = child; s.mu.Unlock() }
 func (s *serverSupervisor) writePID(pid uint32) {
@@ -258,6 +261,7 @@ type managedChild struct {
 	shutdown windows.Handle
 	job      windows.Handle
 	observed chan serviceTerminationObservation
+	retained bool
 	released sync.Once
 }
 

--- a/cli/kent/service_supervisor_windows.go
+++ b/cli/kent/service_supervisor_windows.go
@@ -23,7 +23,6 @@ import (
 const (
 	supervisorInitialBackoff = 1 * time.Second
 	supervisorMaxBackoff     = 30 * time.Second
-	stillActiveExitCode      = 259
 
 	supervisorStopGracePeriod = 15 * time.Second
 
@@ -64,7 +63,9 @@ func (s *serverSupervisor) run(ctx context.Context) {
 		}
 		session := s.wanted.Load()
 		if session == 0 {
-			s.stopChild()
+			if s.stopChild().Complete {
+				return
+			}
 			select {
 			case <-ctx.Done():
 				return
@@ -73,10 +74,15 @@ func (s *serverSupervisor) run(ctx context.Context) {
 			}
 		}
 		s.mu.Lock()
-		needLaunch := s.child == nil || s.child.session != session || !s.child.alive()
+		needLaunch := s.child == nil || s.child.session != session
 		s.mu.Unlock()
 		if needLaunch {
-			s.stopChild()
+			if s.stopChild().Complete {
+				return
+			}
+			if ctx.Err() != nil || s.wanted.Load() != session {
+				continue
+			}
 			child, err := launchServerAsUser(s.spec, session)
 			if err != nil {
 				s.logf("launch failed for session %d: %v", session, err)
@@ -84,6 +90,12 @@ func (s *serverSupervisor) run(ctx context.Context) {
 					return
 				}
 				backoff = growBackoff(backoff)
+				continue
+			}
+			if ctx.Err() != nil || s.wanted.Load() != session {
+				if settleStaleLaunchedCandidate(s.settlementTarget(child)).Complete {
+					return
+				}
 				continue
 			}
 			s.mu.Lock()
@@ -100,16 +112,14 @@ func (s *serverSupervisor) run(ctx context.Context) {
 			s.stopChild()
 			return
 		case <-s.wake:
-			continue
-		case <-child.exited:
-			child.release()
-			s.mu.Lock()
-			if s.child == child {
-				s.child = nil
+			if routeManagedChildWake(child.session, s.wanted.Load(), func() managedChildSettlementDecision {
+				return settleManagedChild(s.settlementTarget(child), child.terminate(s.spec))
+			}).Complete {
+				return
 			}
-			s.mu.Unlock()
-			s.clearPID()
-			if ctx.Err() != nil {
+			continue
+		case observation := <-child.observed:
+			if settleManagedChild(s.settlementTarget(child), observation).Complete {
 				return
 			}
 			if !s.sleep(ctx, backoff) {
@@ -133,17 +143,21 @@ func (s *serverSupervisor) sleep(ctx context.Context, d time.Duration) bool {
 	}
 }
 
-func (s *serverSupervisor) stopChild() {
+func (s *serverSupervisor) stopChild() managedChildSettlementDecision {
 	s.mu.Lock()
 	child := s.child
-	s.child = nil
 	s.mu.Unlock()
-	if child != nil {
-		child.terminate()
+	if child == nil {
+		s.clearPID()
+		return managedChildSettlementDecision{Replace: true}
 	}
-	s.clearPID()
+	return settleManagedChild(s.settlementTarget(child), child.terminate(s.spec))
 }
 
+func (s *serverSupervisor) settlementTarget(child *managedChild) managedChildSettlementTarget {
+	return managedChildSettlementTarget{func() serviceTerminationObservation { return child.terminate(s.spec) }, func() { child.release(); s.setChild(nil); s.clearPID() }, func() { s.setChild(child); s.writePID(child.pid); select {} }}
+}
+func (s *serverSupervisor) setChild(child *managedChild) { s.mu.Lock(); s.child = child; s.mu.Unlock() }
 func (s *serverSupervisor) writePID(pid uint32) {
 	_ = os.MkdirAll(windowsServiceDir(s.spec), 0o755)
 	_ = os.WriteFile(windowsServerPIDPath(s.spec), []byte(fmt.Sprintf("%d", pid)), 0o644)
@@ -243,38 +257,54 @@ type managedChild struct {
 	profile  windows.Handle
 	shutdown windows.Handle
 	job      windows.Handle
-	exited   chan struct{}
+	observed chan serviceTerminationObservation
 	released sync.Once
 }
 
-func (c *managedChild) watch() {
-	_, _ = windows.WaitForSingleObject(c.process, windows.INFINITE)
-	close(c.exited)
-}
-
-func (c *managedChild) alive() bool {
-	var code uint32
-	if err := windows.GetExitCodeProcess(c.process, &code); err != nil {
-		return false
+func (c *managedChild) watch(spec serviceSpec) {
+	result, waitErr := windows.WaitForSingleObject(c.process, windows.INFINITE)
+	observation := serviceTerminationObservation{TerminationConfirmed: waitErr == nil && result == windows.WAIT_OBJECT_0}
+	if waitErr != nil {
+		appendServiceLog(spec, "wait for server process failed: %v", waitErr)
+	} else if !observation.TerminationConfirmed {
+		appendServiceLog(spec, "wait for server process returned %d", result)
 	}
-	return code == stillActiveExitCode
-}
-
-func (c *managedChild) terminate() {
-	if c.shutdown != 0 && windows.SetEvent(c.shutdown) == nil {
-		select {
-		case <-c.exited:
-			c.release()
-			return
-		case <-time.After(supervisorStopGracePeriod):
+	if observation.TerminationConfirmed {
+		var status uint32
+		if err := windows.GetExitCodeProcess(c.process, &status); err != nil {
+			appendServiceLog(spec, "read server process exit status failed: %v", err)
+		} else {
+			observation.ExitStatus = &status
 		}
 	}
-	_ = windows.TerminateProcess(c.process, 1)
-	select {
-	case <-c.exited:
-	case <-time.After(5 * time.Second):
+	c.observed <- observation
+}
+
+func (c *managedChild) terminate(spec serviceSpec) serviceTerminationObservation {
+	if c.shutdown == 0 {
+		appendServiceLog(spec, "shutdown handle unavailable: pid %d", c.pid)
+	} else if err := windows.SetEvent(c.shutdown); err != nil {
+		appendServiceLog(spec, "shutdown signal failed: pid %d: %v", c.pid, err)
+	} else {
+		select {
+		case observation := <-c.observed:
+			if serviceTerminationConfirmed(observation) {
+				return observation
+			}
+		case <-time.After(supervisorStopGracePeriod):
+			appendServiceLog(spec, "shutdown timeout pid %d", c.pid)
+		}
 	}
-	c.release()
+	if err := windows.TerminateProcess(c.process, 1); err != nil {
+		appendServiceLog(spec, "terminate server process %d failed: %v", c.pid, err)
+	}
+	select {
+	case observation := <-c.observed:
+		return observation
+	case <-time.After(5 * time.Second):
+		appendServiceLog(spec, "termination wait timeout pid %d", c.pid)
+		return serviceTerminationObservation{}
+	}
 }
 
 func (c *managedChild) release() {
@@ -390,9 +420,9 @@ func launchServerAsUser(spec serviceSpec, session uint32) (child *managedChild, 
 		profile:  profile,
 		shutdown: shutdown,
 		job:      job,
-		exited:   make(chan struct{}),
+		observed: make(chan serviceTerminationObservation, 1),
 	}
-	go c.watch()
+	go c.watch(spec)
 	committed = true
 	return c, nil
 }

--- a/cli/kent/service_types.go
+++ b/cli/kent/service_types.go
@@ -25,6 +25,60 @@ const (
 	serviceStdoutLogName      = "server.log"
 	serviceStderrLogName      = "server.err.log"
 )
+const serviceNoRestartExitStatus uint32 = 2
+
+type serviceTerminationObservation struct {
+	TerminationConfirmed bool
+	ExitStatus           *uint32
+}
+type managedChildSettlementTarget struct {
+	terminate       func() serviceTerminationObservation
+	release, retain func()
+}
+type managedChildSettlementDecision struct{ Replace, Complete bool }
+
+func serviceTerminationConfirmed(o serviceTerminationObservation) bool { return o.TerminationConfirmed }
+func serviceRestartDecision(s *uint32) bool                            { return s != nil && *s != serviceNoRestartExitStatus }
+func settleManagedChild(target managedChildSettlementTarget, observation serviceTerminationObservation) managedChildSettlementDecision {
+	if !serviceTerminationConfirmed(observation) {
+		target.retain()
+		return managedChildSettlementDecision{}
+	}
+	target.release()
+	replace := serviceRestartDecision(observation.ExitStatus)
+	return managedChildSettlementDecision{Replace: replace, Complete: !replace}
+}
+func routeManagedChildWake(currentSession, wantedSession uint32, settle func() managedChildSettlementDecision) managedChildSettlementDecision {
+	if currentSession == wantedSession {
+		return managedChildSettlementDecision{}
+	}
+	return settle()
+}
+func settleStaleLaunchedCandidate(target managedChildSettlementTarget) managedChildSettlementDecision {
+	return settleManagedChild(target, target.terminate())
+}
+func serviceCompletionStatus() (bool, uint32) { return false, 0 }
+func renderSystemdUnitText(description, execStart, stdoutLogPath, stderrLogPath string) string {
+	lines := []string{
+		"[Unit]",
+		"Description=" + description,
+		"After=network-online.target",
+		"",
+		"[Service]",
+		"Type=simple",
+		"ExecStart=" + execStart,
+		"Restart=always",
+		fmt.Sprintf("RestartPreventExitStatus=%d", serviceNoRestartExitStatus),
+		"RestartSec=2",
+		"StandardOutput=append:" + stdoutLogPath,
+		"StandardError=append:" + stderrLogPath,
+		"",
+		"[Install]",
+		"WantedBy=default.target",
+		"",
+	}
+	return strings.Join(lines, "\n")
+}
 
 type serviceSpec struct {
 	Config        config.App

--- a/docs/dev/specs/cli-commands.md
+++ b/docs/dev/specs/cli-commands.md
@@ -134,6 +134,13 @@
 - Goal completion is explicit CLI state mutation, not natural-language inference.
 - Goal CLI never mutates Session storage directly. It submits Goal commands to the server.
 - Any `kent service` command that affects server state detects invocation by Kent itself and refuses to run because it is human-only.
+- On Linux and Windows, server exit status `2` must suppress automatic crash recovery for the current service-manager activation. A later independent service-manager activation may run the installed service again.
+- On Linux, every server exit other than status `2` must retain automatic restoration while the current service-manager activation expects Kent to run. On macOS, every server exit must retain automatic restoration while the current service-manager activation expects Kent to run.
+- On Windows, every observed numeric server exit status other than `2` must retain automatic restoration while the current service-manager activation expects Kent to run.
+- On Windows, status `2` must make the registered service report `Stopped` without Windows recovery. An unexpected registered-service failure must retain Windows recovery.
+- When Kent cannot confirm Windows server termination, Kent must retain ownership. Kent must not report `Stopped`. Kent must not start a replacement.
+- When Windows confirms termination without a numeric status, Kent must release the server. Kent must not start a replacement. Kent must report `Stopped` for the current activation.
+- A human start or restart must begin a new activation. An install that requests startup must begin a new activation. `kent service install --no-start` must not start the service.
 
 ## Headless Run And Shared Control
 

--- a/docs/src/content/docs/server.md
+++ b/docs/src/content/docs/server.md
@@ -29,6 +29,13 @@ kent service uninstall
 
 All service commands accept `--persistence-root` and honor `KENT_PERSISTENCE_ROOT`. The root you install with is remembered, so pass the same root on `status`/`start`/`stop`/`restart`/`uninstall` to target that instance.
 
+### Service recovery
+On Linux, status `2` suppresses automatic crash recovery for the active service-manager activation, while other exits continue restoration; macOS retains restoration after every server exit.
+On Windows, an observed numeric status `2` stops the service cleanly without recovery, and every other observed numeric status continues restoration; an unexpected service-host failure retains recovery.
+If Windows cannot confirm termination, the service retains ownership and neither reports `Stopped` nor launches a replacement.
+If Windows confirms termination without a numeric status, the service releases the server, launches no replacement, and stops cleanly.
+A human start or restart, or `kent service install` without `--no-start`, begins a new activation; `--no-start` installs without starting. A later independent operating-system, login, or service-manager activation may start the installed service again.
+
 ## Backends
 
 | OS | Service |


### PR DESCRIPTION
## Summary
- Prevent Linux and Windows service crash loops after server exit status `2`.
- Centralize Windows managed-child settlement across natural exits, handoffs, and stale launches with fail-closed ownership handling.
- Align Linux systemd rendering, Windows service completion, CLI specification, and public server documentation.

## Verification
- Focused service recovery tests passed on Darwin.
- Complete `./scripts/test.sh server` passed.
- Linux arm64 and Windows amd64 compile checks passed.
- `./scripts/build.sh --output ./bin/kent` passed.
- Documentation install, tests, and build passed.
- Formatting, whitespace, scope, root, and diff-cap checks passed.

## Diff size
Against `origin/main`:
- Net: +200 lines; gross: 318 lines.
- Production/documentation: +144 / -59, net +85, gross 203 lines.
- Tests: +115 / -0, net +115, gross 115 lines.
- Total implementation: +259 / -59, net +200, gross 318 lines across 7 files.

## Caveats and follow-up
- macOS automatic restart behavior remains unchanged because launchd cannot selectively suppress only status `2` without introducing a new supervisor.
- Windows termination remains fail-closed when termination cannot be confirmed; Kent retains ownership and starts no replacement.
- Backup ref and reconstruction patches are intentionally retained until merge per the task plan.

Addresses Kent task KENT-525. No separate GitHub issue was linked; the issue number `525` is an existing unrelated pull request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved service recovery after crashes and unexpected exits across Linux, macOS, and Windows.
  - Added safer handling for Windows service termination, including confirmation and fallback behavior.
  - System services now apply clearer restart policies, delays, logging, and startup settings.

- **Bug Fixes**
  - Prevented stale service sessions from being relaunched.
  - Improved handling of manual starts, restarts, installation, and `--no-start` behavior.

- **Documentation**
  - Added service recovery and lifecycle guidance to the CLI and server documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->